### PR TITLE
feat(epistemic): Sovereign Epistemological Context Matrix — Phase 1 (cure heavy-GOAL tool_loop_deadline via memory prefetch + Information-Gain Governor)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -68,6 +68,23 @@ from backend.core.ouroboros.governance.dw_latency_tracker import (
     DwLatencyTracker,
 )
 
+# LR3 terminal sentinel: the Information-Gain Governor's deadlock-override
+# failure (raised inside the Venom tool loop). It MUST propagate through every
+# broad-catch failback site below UNRECLASSIFIED so the orchestrator's
+# ``except GovernanceDeadlockError`` terminal catch can stamp
+# terminal_reason_code="deadlock_override_failed". Top-level import is
+# cycle-safe (verified: tool_executor does not import candidate_generator); a
+# fallback class keeps every ``except GovernanceDeadlockError`` clause
+# evaluable even if the import is severed under an unusual load order
+# (mirrors orchestrator.py's defensive fallback class).
+try:
+    from backend.core.ouroboros.governance.tool_executor import (
+        GovernanceDeadlockError,
+    )
+except Exception:  # noqa: BLE001 -- defensive; keep except-clauses evaluable
+    class GovernanceDeadlockError(RuntimeError):  # type: ignore[no-redef]
+        """Fallback shim -- real class lives in tool_executor."""
+
 logger = logging.getLogger(__name__)
 
 # ---------------------------------------------------------------------------
@@ -3007,6 +3024,8 @@ class CandidateGenerator:
                     )
                     try:
                         return await self._call_fallback(context, deadline)
+                    except GovernanceDeadlockError:
+                        raise  # LR3 terminal -- never wrap as fallback_failed
                     except Exception as exc:
                         raise RuntimeError(
                             f"background_fallback_failed:"
@@ -3850,6 +3869,16 @@ class CandidateGenerator:
                     _attempt_result = await self._try_primary_then_fallback(
                         context, deadline, model_id=model_id,
                     )
+            except GovernanceDeadlockError:
+                # LR3 terminal: the Information-Gain Governor's deadlock-override
+                # failure (raised inside the Venom tool loop) MUST reach the
+                # orchestrator's ``except GovernanceDeadlockError`` terminal catch
+                # so it stamps terminal_reason_code="deadlock_override_failed".
+                # If stored in _attempt_exc it gets reclassified by the per-model
+                # rotation taxonomy (not internal_fault, not generation_timeout,
+                # not fsm_exhausted) and re-driven as a transport failure /
+                # all_providers_exhausted; the deadlock would never surface.
+                raise
             except Exception as exc:
                 _attempt_exc = exc
             finally:
@@ -4715,6 +4744,8 @@ class CandidateGenerator:
             )
             try:
                 return await self._call_fallback(context, deadline)
+            except GovernanceDeadlockError:
+                raise  # LR3 terminal -- never wrap as fallback_failed
             except Exception as exc:
                 raise RuntimeError(
                     f"background_fallback_failed:forced:"
@@ -4751,6 +4782,8 @@ class CandidateGenerator:
                 )
                 try:
                     return await self._call_fallback(context, deadline)
+                except GovernanceDeadlockError:
+                    raise  # LR3 terminal -- never wrap as fallback_failed
                 except Exception as exc:
                     raise RuntimeError(
                         f"background_fallback_failed:dw_unavailable:"
@@ -4860,6 +4893,8 @@ class CandidateGenerator:
             )
             try:
                 return await self._call_fallback(context, deadline)
+            except GovernanceDeadlockError:
+                raise  # LR3 terminal -- never wrap as fallback_failed
             except Exception as exc:
                 raise RuntimeError(
                     f"background_fallback_failed:dw={_dw_error[:80]}:"
@@ -5337,6 +5372,11 @@ class CandidateGenerator:
             if self.fsm._consecutive_failures > 0:
                 self.fsm.record_primary_success()
             return result
+        except GovernanceDeadlockError:
+            # LR3 terminal: do NOT cascade a deadlock-override failure into the
+            # Claude fallback (that would reclassify it as a transient primary
+            # failure). Propagate to the orchestrator's terminal catch.
+            raise
         except (Exception, asyncio.CancelledError) as exc:
             mode = FailbackStateMachine.classify_exception(exc)
             # Phase 3.1 observability: surface local-tier degradations (memory /
@@ -6742,6 +6782,12 @@ class CandidateGenerator:
                         # W3(7) cooperative cancel — operator/watchdog/signal.
                         # NEVER retry; honor the cancel immediately.
                         raise
+                    except GovernanceDeadlockError:
+                        # LR3 terminal: the fallback (Claude) tool loop hit the
+                        # Information-Gain Governor deadlock-override failure.
+                        # NEVER retry / reclassify; propagate to the orchestrator's
+                        # terminal catch so it stamps deadlock_override_failed.
+                        raise
                     except (Exception, asyncio.CancelledError) as inner_exc:
                         # Slice 3C — harvest tool-records from the failed
                         # attempt BEFORE any other handling. Best-effort:
@@ -7011,6 +7057,12 @@ class CandidateGenerator:
                         await asyncio.sleep(_backoff)
                         continue
                 # Unreachable — loop either returns or raises.
+        except GovernanceDeadlockError:
+            # LR3 terminal: defense-in-depth. The inner-retry handler already
+            # re-raises this, but guard the outer catch too so a deadlock can
+            # never be folded into the all_providers_exhausted taxonomy. Must
+            # reach the orchestrator's deadlock_override_failed terminal catch.
+            raise
         except (Exception, asyncio.CancelledError) as exc:
             # Cooperative cancel via W3(7) cancel-token — propagate
             # immediately (NEVER treat as exhaustion). The inner loop

--- a/backend/core/ouroboros/governance/context_governor.py
+++ b/backend/core/ouroboros/governance/context_governor.py
@@ -177,3 +177,91 @@ class InformationGainGovernor:
         return GovernorVerdict(ACTION_DEADLOCK_BREAK, gain, scale,
                                missing_categories=missing,
                                directive=self._directive(missing))
+
+
+# ── Sovereign Epistemological Context Matrix — Task 6a: GENERATE-path wiring ──
+# Bridge exploration_engine's Iron Gate floor evaluation into the governor's
+# is_satisfied/missing_categories shape (no re-implementation of scoring), and
+# a fail-soft factory that builds a FRESH governor per generation attempt from
+# the op's prefetch manifest + the SAME Iron Gate floors the post-GENERATE gate
+# uses. exploration_engine is imported LAZILY inside every method/function so a
+# context_governor → exploration_engine edge can never create an import cycle
+# (verified: exploration_engine does NOT import context_governor).
+
+
+class _IronGateFloorAdapter:
+    """Bridges exploration_engine's floor evaluation into the governor's
+    is_satisfied/missing_categories shape. Reuses ExplorationFloors +
+    evaluate_exploration — no re-implementation of scoring. Exception-safe."""
+
+    def __init__(self, floors) -> None:
+        self._floors = floors
+
+    def is_satisfied(self, ledger) -> bool:
+        if ledger is None or self._floors is None:
+            return True
+        try:
+            from backend.core.ouroboros.governance.exploration_engine import (
+                evaluate_exploration,
+            )
+            return bool(evaluate_exploration(ledger, self._floors).sufficient)
+        except Exception:  # noqa: BLE001
+            return True
+
+    def missing_categories(self, ledger):
+        if ledger is None or self._floors is None:
+            return ()
+        try:
+            from backend.core.ouroboros.governance.exploration_engine import (
+                evaluate_exploration,
+            )
+            verdict = evaluate_exploration(ledger, self._floors)
+            return tuple(c.name for c in verdict.missing_categories)
+        except Exception:  # noqa: BLE001
+            return ()
+
+
+def governor_enabled() -> bool:
+    return (os.environ.get("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true") or "").strip().lower() in (
+        "1", "true", "yes", "on")
+
+
+def _resolve_complexity(context) -> str:
+    """Derive the Iron Gate complexity string from the op context.
+
+    Matches generate_runner / orchestrator EXACTLY: both derive the string fed
+    to ``ExplorationFloors.from_env_with_adapted`` via
+    ``getattr(ctx, "task_complexity", "") or ""`` (orchestrator.py:5009,
+    generate_runner.py:1089). We mirror that so the governor's floor tier ==
+    the real post-GENERATE Iron Gate's tier. Empty string is preserved (the
+    floors helper handles it); we never invent a tier."""
+    return str(getattr(context, "task_complexity", "") or "")
+
+
+def build_governor_for(context):
+    """Construct a FRESH InformationGainGovernor per generation attempt from the
+    op's prefetch manifest + Iron Gate floors. Returns None when disabled or
+    when there's nothing to govern. Fail-soft: never raises."""
+    try:
+        if not governor_enabled():
+            return None
+        manifest = tuple(getattr(context, "prefetch_manifest", ()) or ())
+        excerpts = [e.content_excerpt for e in manifest if getattr(e, "content_excerpt", "")]
+        # Iron Gate floors for this op's complexity (reuse the same source as the
+        # post-GENERATE Iron Gate so the governor's floor == the real gate).
+        complexity = _resolve_complexity(context)
+        floors = None
+        try:
+            from backend.core.ouroboros.governance.exploration_engine import (
+                ExplorationFloors,
+            )
+            floors = ExplorationFloors.from_env_with_adapted(complexity)
+        except Exception:  # noqa: BLE001
+            floors = None
+        return InformationGainGovernor(
+            prefetch_excerpts=excerpts,
+            floors=_IronGateFloorAdapter(floors),
+            enabled=True,
+        )
+    except Exception:  # noqa: BLE001 — governor is advisory; never block generation
+        return None

--- a/backend/core/ouroboros/governance/context_governor.py
+++ b/backend/core/ouroboros/governance/context_governor.py
@@ -131,8 +131,14 @@ class InformationGainGovernor:
         if floor_met:
             return GovernorVerdict("converge", gain, scale)
 
-        if self._deadlock_consumed:
-            # LR3: one-shot already spent and floor STILL unmet -> fatal.
+        if self._deadlock_consumed or self._deadlock_pending:
+            # LR3 (iron-clad): the one-shot directive was already issued —
+            # either explicitly consumed by the coordinator, OR still pending
+            # from a prior deadlock_break the coordinator failed to mark. Either
+            # way the floor is STILL unmet after the shot, so escalate to fatal.
+            # The governor self-defends against a coordinator that forgets to
+            # call mark_deadlock_round_consumed(); we never emit a second
+            # deadlock_break (no looping at the safety gate).
             return GovernorVerdict("deadlock_failed", gain, scale,
                                    missing_categories=missing)
         self._deadlock_pending = True

--- a/backend/core/ouroboros/governance/context_governor.py
+++ b/backend/core/ouroboros/governance/context_governor.py
@@ -241,10 +241,24 @@ def _resolve_complexity(context) -> str:
 def build_governor_for(context):
     """Construct a FRESH InformationGainGovernor per generation attempt from the
     op's prefetch manifest + Iron Gate floors. Returns None when disabled or
-    when there's nothing to govern. Fail-soft: never raises."""
+    when the op is not a heavy GOAL (light ops stay byte-identical). A heavy op
+    with an empty manifest still yields a cold governor. Fail-soft: never raises."""
     try:
         if not governor_enabled():
             return None
+        # Scope the governor to heavy GOALs (the arc's target). Light ops are
+        # left byte-identical. A heavy op with an EMPTY manifest (cold oracle)
+        # STILL gets a governor — that's the worst wandering case and exactly
+        # where info-gain convergence matters most.
+        try:
+            from backend.core.ouroboros.governance.epistemic_prefetch import is_heavy_goal
+            if not is_heavy_goal(
+                getattr(context, "target_files", ()) or (),
+                int(getattr(context, "blast_radius", 0) or 0),
+            ):
+                return None
+        except Exception:  # noqa: BLE001
+            pass
         manifest = tuple(getattr(context, "prefetch_manifest", ()) or ())
         excerpts = [e.content_excerpt for e in manifest if getattr(e, "content_excerpt", "")]
         # Iron Gate floors for this op's complexity (reuse the same source as the

--- a/backend/core/ouroboros/governance/context_governor.py
+++ b/backend/core/ouroboros/governance/context_governor.py
@@ -4,7 +4,7 @@
 Decides, after each Venom round, whether continued exploration yields enough
 NEW information to justify the budget — and forces a mathematically safe
 handoff when it does not. Synchronous + sub-millisecond on the hot path
-(TF-IDF/cosine over hashed tokens; NO model call). Deep embeds, if any, are the
+(TF-cosine over hashed tokens; NO model call). Deep embeds, if any, are the
 coordinator's async concern — the governor never awaits.
 
 LR1: the delta corpus is seeded with the prefetch excerpts as the round-0
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 import math
+import os
 import re
 from collections import Counter
 from dataclasses import dataclass, field
@@ -35,6 +36,22 @@ _CATEGORY_TOOLS = {
 }
 
 _TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,}")
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = (os.environ.get(name, "") or "").strip()
+    try:
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+# Elastic budget multipliers applied to Venom's convergence threshold.
+# Warm = prefetch supplied a baseline (compress exploration); cold = no prefetch
+# (allow more exploration, but only while info-gain stays high — the decay path
+# is what actually stops a cold loop). Tunable; reflect prefetch richness at
+# construction, not runtime corpus growth.
+_WARM_BUDGET_SCALE = _env_float("JARVIS_GOVERNOR_WARM_BUDGET_SCALE", 0.6)
+_COLD_BUDGET_SCALE = _env_float("JARVIS_GOVERNOR_COLD_BUDGET_SCALE", 1.4)
 
 
 def _tokens(text: str) -> Counter:
@@ -82,8 +99,9 @@ class InformationGainGovernor:
         self._warm = bool(self._corpus)
 
     def _budget_scale(self) -> float:
-        # warm cache -> compress; cold -> expand.
-        return 0.6 if self._warm else 1.4
+        # Determined at construction; reflects prefetch richness, not runtime
+        # corpus growth. Warm -> compress; cold -> expand (decay still stops it).
+        return _WARM_BUDGET_SCALE if self._warm else _COLD_BUDGET_SCALE
 
     def _directive(self, missing: Tuple[str, ...]) -> str:
         lines = ["STOP broad exploration. To satisfy the mandatory safety "
@@ -100,6 +118,8 @@ class InformationGainGovernor:
         self._deadlock_consumed = True
         self._deadlock_pending = False
 
+    # round_index: coordinator-facing interface parameter; reserved for future
+    # per-round decay curves (e.g. tighter threshold on later rounds).
     def observe_round(self, round_index: int, round_tool_results: List[str],
                       ledger: Any) -> GovernorVerdict:
         if not self.enabled:
@@ -139,9 +159,13 @@ class InformationGainGovernor:
             # The governor self-defends against a coordinator that forgets to
             # call mark_deadlock_round_consumed(); we never emit a second
             # deadlock_break (no looping at the safety gate).
+            logger.debug("[ContextGovernor] deadlock_failed gain=%.3f missing=%s",
+                         gain, missing)
             return GovernorVerdict("deadlock_failed", gain, scale,
                                    missing_categories=missing)
         self._deadlock_pending = True
+        logger.debug("[ContextGovernor] deadlock_break gain=%.3f missing=%s",
+                     gain, missing)
         return GovernorVerdict("deadlock_break", gain, scale,
                                missing_categories=missing,
                                directive=self._directive(missing))

--- a/backend/core/ouroboros/governance/context_governor.py
+++ b/backend/core/ouroboros/governance/context_governor.py
@@ -1,0 +1,141 @@
+# backend/core/ouroboros/governance/context_governor.py
+"""Information-Gain Governor (spec section 5.2, LR1, LR3).
+
+Decides, after each Venom round, whether continued exploration yields enough
+NEW information to justify the budget — and forces a mathematically safe
+handoff when it does not. Synchronous + sub-millisecond on the hot path
+(TF-IDF/cosine over hashed tokens; NO model call). Deep embeds, if any, are the
+coordinator's async concern — the governor never awaits.
+
+LR1: the delta corpus is seeded with the prefetch excerpts as the round-0
+     baseline; round-1 gain is measured against what memory already supplied.
+LR3: the deadlock breaker is one-shot; a second decay after it is consumed
+     yields action="deadlock_failed" (the coordinator turns that into the fatal
+     terminal deadlock_override_failed).
+"""
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, List, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Iron Gate category -> canonical tool(s) for the deadlock-break directive.
+# Mirrors exploration_engine._TOOL_CATEGORY.
+_CATEGORY_TOOLS = {
+    "COMPREHENSION": ["read_file"],
+    "DISCOVERY": ["search_code"],
+    "CALL_GRAPH": ["get_callers"],
+    "STRUCTURE": ["list_symbols"],
+    "HISTORY": ["git_blame", "git_log"],
+}
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,}")
+
+
+def _tokens(text: str) -> Counter:
+    return Counter(t.lower() for t in _TOKEN_RE.findall(text or ""))
+
+
+def _cosine(a: Counter, b: Counter) -> float:
+    if not a or not b:
+        return 0.0
+    common = set(a) & set(b)
+    num = sum(a[t] * b[t] for t in common)
+    da = math.sqrt(sum(v * v for v in a.values()))
+    db = math.sqrt(sum(v * v for v in b.values()))
+    if da == 0 or db == 0:
+        return 0.0
+    return num / (da * db)
+
+
+@dataclass(frozen=True)
+class GovernorVerdict:
+    action: str            # continue | converge | deadlock_break | deadlock_failed
+    info_gain: float
+    budget_scale: float
+    missing_categories: Tuple[str, ...] = ()
+    directive: str = ""
+
+
+@dataclass
+class InformationGainGovernor:
+    prefetch_excerpts: Sequence[str]
+    floors: Any
+    enabled: bool = True
+    min_gain: float = 0.15
+    decay_rounds: int = 2
+    _corpus: Counter = field(default_factory=Counter)
+    _low_streak: int = 0
+    _warm: bool = False
+    _deadlock_consumed: bool = False
+    _deadlock_pending: bool = False
+
+    def __post_init__(self) -> None:
+        # LR1: round-0 baseline IS the prefetch.
+        joined = "\n".join(self.prefetch_excerpts or [])
+        self._corpus = _tokens(joined)
+        self._warm = bool(self._corpus)
+
+    def _budget_scale(self) -> float:
+        # warm cache -> compress; cold -> expand.
+        return 0.6 if self._warm else 1.4
+
+    def _directive(self, missing: Tuple[str, ...]) -> str:
+        lines = ["STOP broad exploration. To satisfy the mandatory safety "
+                 "floor you MUST now call ONLY these tools, nothing else:"]
+        for cat in missing:
+            tools = _CATEGORY_TOOLS.get(cat, ["read_file"])
+            lines.append(f"  - {cat}: call {' or '.join(tools)} "
+                         f"on the most relevant target file.")
+        lines.append("Then immediately emit your patch.")
+        return "\n".join(lines)
+
+    def mark_deadlock_round_consumed(self) -> None:
+        """Coordinator calls this after appending the deadlock directive (LR3)."""
+        self._deadlock_consumed = True
+        self._deadlock_pending = False
+
+    def observe_round(self, round_index: int, round_tool_results: List[str],
+                      ledger: Any) -> GovernorVerdict:
+        if not self.enabled:
+            return GovernorVerdict("continue", 1.0, 1.0)
+        scale = self._budget_scale()
+        new = _tokens("\n".join(round_tool_results or []))
+        sim = _cosine(new, self._corpus)
+        gain = max(0.0, 1.0 - sim) if new else 0.0
+        self._corpus.update(new)
+
+        if gain < self.min_gain:
+            self._low_streak += 1
+        else:
+            self._low_streak = 0
+
+        decayed = self._low_streak >= self.decay_rounds
+        if not decayed:
+            return GovernorVerdict("continue", gain, scale)
+
+        floor_met = True
+        missing: Tuple[str, ...] = ()
+        try:
+            floor_met = bool(self.floors.is_satisfied(ledger))
+            if not floor_met:
+                missing = tuple(self.floors.missing_categories(ledger))
+        except Exception:  # noqa: BLE001 — floor probe must not crash governor
+            floor_met = True
+
+        if floor_met:
+            return GovernorVerdict("converge", gain, scale)
+
+        if self._deadlock_consumed:
+            # LR3: one-shot already spent and floor STILL unmet -> fatal.
+            return GovernorVerdict("deadlock_failed", gain, scale,
+                                   missing_categories=missing)
+        self._deadlock_pending = True
+        return GovernorVerdict("deadlock_break", gain, scale,
+                               missing_categories=missing,
+                               directive=self._directive(missing))

--- a/backend/core/ouroboros/governance/context_governor.py
+++ b/backend/core/ouroboros/governance/context_governor.py
@@ -37,6 +37,14 @@ _CATEGORY_TOOLS = {
 
 _TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,}")
 
+# Verdict action vocabulary — the single source of truth shared with the Venom
+# coordinator's dispatch (tool_executor.py) so a rename can never silently break
+# the safety-critical deadlock_failed branch.
+ACTION_CONTINUE = "continue"
+ACTION_CONVERGE = "converge"
+ACTION_DEADLOCK_BREAK = "deadlock_break"
+ACTION_DEADLOCK_FAILED = "deadlock_failed"
+
 
 def _env_float(name: str, default: float) -> float:
     raw = (os.environ.get(name, "") or "").strip()
@@ -123,7 +131,7 @@ class InformationGainGovernor:
     def observe_round(self, round_index: int, round_tool_results: List[str],
                       ledger: Any) -> GovernorVerdict:
         if not self.enabled:
-            return GovernorVerdict("continue", 1.0, 1.0)
+            return GovernorVerdict(ACTION_CONTINUE, 1.0, 1.0)
         scale = self._budget_scale()
         new = _tokens("\n".join(round_tool_results or []))
         sim = _cosine(new, self._corpus)
@@ -137,7 +145,7 @@ class InformationGainGovernor:
 
         decayed = self._low_streak >= self.decay_rounds
         if not decayed:
-            return GovernorVerdict("continue", gain, scale)
+            return GovernorVerdict(ACTION_CONTINUE, gain, scale)
 
         floor_met = True
         missing: Tuple[str, ...] = ()
@@ -149,7 +157,7 @@ class InformationGainGovernor:
             floor_met = True
 
         if floor_met:
-            return GovernorVerdict("converge", gain, scale)
+            return GovernorVerdict(ACTION_CONVERGE, gain, scale)
 
         if self._deadlock_consumed or self._deadlock_pending:
             # LR3 (iron-clad): the one-shot directive was already issued —
@@ -161,11 +169,11 @@ class InformationGainGovernor:
             # deadlock_break (no looping at the safety gate).
             logger.debug("[ContextGovernor] deadlock_failed gain=%.3f missing=%s",
                          gain, missing)
-            return GovernorVerdict("deadlock_failed", gain, scale,
+            return GovernorVerdict(ACTION_DEADLOCK_FAILED, gain, scale,
                                    missing_categories=missing)
         self._deadlock_pending = True
         logger.debug("[ContextGovernor] deadlock_break gain=%.3f missing=%s",
                      gain, missing)
-        return GovernorVerdict("deadlock_break", gain, scale,
+        return GovernorVerdict(ACTION_DEADLOCK_BREAK, gain, scale,
                                missing_categories=missing,
                                directive=self._directive(missing))

--- a/backend/core/ouroboros/governance/epistemic_prefetch.py
+++ b/backend/core/ouroboros/governance/epistemic_prefetch.py
@@ -37,6 +37,19 @@ def prefetch_enabled() -> bool:
         "1", "true", "yes", "on")
 
 
+def is_heavy_goal(target_files, blast_radius: int = 0) -> bool:
+    """A heavy GOAL = multi-file OR high blast radius. The arc's target scope
+    for both prefetch and the Information-Gain Governor. Never raises."""
+    try:
+        thresh = int((os.environ.get("OUROBOROS_BLAST_RADIUS_THRESHOLD", "") or "5").strip())
+    except (TypeError, ValueError):
+        thresh = 5
+    try:
+        return (len(target_files or ()) > 1) or (int(blast_radius or 0) > thresh)
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _topk() -> int:
     try:
         return max(1, int((os.environ.get(_ENV_TOPK, "") or "8").strip()))

--- a/backend/core/ouroboros/governance/epistemic_prefetch.py
+++ b/backend/core/ouroboros/governance/epistemic_prefetch.py
@@ -181,3 +181,38 @@ async def build_prefetch_manifest(
     except Exception:  # noqa: BLE001 — never block GENERATE on prefetch
         logger.debug("[EpistemicPrefetch] build swallowed", exc_info=True)
         return ()
+
+
+def revalidate_manifest(manifest, root: str, ledger=None):
+    """Cryptographic Truth Guard (spec 5.3.1, LR2) at CONSUMPTION time.
+
+    Re-hash each manifest entry against live disk; keep entries whose live hash
+    still matches the stored sha256, DROP entries that are stale or unreadable
+    (so Venom reads them fresh instead of ingesting stale content). When a
+    ``ledger`` is given, stale entries are quarantined (session-scoped) so
+    sibling workers + the teardown reconcile see them. Returns the filtered
+    tuple. Never raises."""
+    try:
+        if not manifest:
+            return ()
+        import os as _os
+        kept = []
+        for e in manifest:
+            rel = getattr(e, "rel_path", "")
+            stored = getattr(e, "sha256", "")
+            if not rel or not stored:
+                continue
+            _data, live = atomic_read_and_hash(_os.path.join(root, rel))
+            if live and live == stored:
+                kept.append(e)
+            else:
+                # stale or unreadable -> drop from seed; quarantine if possible
+                if ledger is not None:
+                    try:
+                        ledger.quarantine(rel, reason="stale_at_consume",
+                                          root=root, expected_sha=stored)
+                    except Exception:  # noqa: BLE001
+                        pass
+        return tuple(kept)
+    except Exception:  # noqa: BLE001 — Truth Guard must never block generation
+        return tuple(manifest or ())  # fail-open to the unvalidated manifest

--- a/backend/core/ouroboros/governance/epistemic_prefetch.py
+++ b/backend/core/ouroboros/governance/epistemic_prefetch.py
@@ -207,6 +207,8 @@ def revalidate_manifest(manifest, root: str, ledger=None):
                 kept.append(e)
             else:
                 # stale or unreadable -> drop from seed; quarantine if possible
+                logger.debug("[TruthGuard] stale rel=%s expected=%s live=%s quarantined=%s",
+                             rel, (stored or "")[:12], (live or "")[:12], ledger is not None)
                 if ledger is not None:
                     try:
                         ledger.quarantine(rel, reason="stale_at_consume",

--- a/backend/core/ouroboros/governance/epistemic_prefetch.py
+++ b/backend/core/ouroboros/governance/epistemic_prefetch.py
@@ -1,0 +1,117 @@
+# backend/core/ouroboros/governance/epistemic_prefetch.py
+"""DAG Router — directed pre-fetch for heavy GOALs (spec section 5.1).
+
+On a heavy multi-file GOAL, ask the (already-booted) Oracle for a fused
+structural+semantic neighborhood, rank + bound it, snapshot each candidate's
+sha256 (Truth Guard), and return an immutable manifest that seeds Venom so it
+starts DIRECTED instead of blind. Gated, fail-soft, no-op unless heavy + oracle
+ready. Never blocks GENERATE on the oracle.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+from backend.core.ouroboros.governance.epistemic_quarantine import atomic_read_and_hash
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_EPISTEMIC_PREFETCH_ENABLED"
+_ENV_TOPK = "JARVIS_EPISTEMIC_PREFETCH_TOPK"
+_ENV_SEED_BYTES = "JARVIS_EPISTEMIC_PREFETCH_SEED_BYTES"
+
+
+@dataclass(frozen=True)
+class PrefetchEntry:
+    rel_path: str
+    sha256: str
+    relevance: float
+    category_hint: str
+    content_excerpt: str
+
+
+def prefetch_enabled() -> bool:
+    return (os.environ.get(_ENV_ENABLED, "true") or "").strip().lower() in (
+        "1", "true", "yes", "on")
+
+
+def _topk() -> int:
+    try:
+        return max(1, int((os.environ.get(_ENV_TOPK, "") or "8").strip()))
+    except (TypeError, ValueError):
+        return 8
+
+
+def _seed_bytes() -> int:
+    try:
+        return max(0, int((os.environ.get(_ENV_SEED_BYTES, "") or "24000").strip()))
+    except (TypeError, ValueError):
+        return 24000
+
+
+def _field(item: Any, key: str, default):
+    if isinstance(item, dict):
+        return item.get(key, default)
+    return getattr(item, key, default)
+
+
+async def build_prefetch_manifest(
+    *,
+    target_files: Tuple[str, ...],
+    root: str,
+    oracle: Optional[Any],
+    goal_text: str,
+    is_heavy: bool,
+) -> Tuple[PrefetchEntry, ...]:
+    """Return a bounded, ranked, hash-validated candidate manifest. () when
+    disabled / not heavy / oracle cold / on any error (fail-soft)."""
+    try:
+        if not prefetch_enabled() or not is_heavy or oracle is None:
+            return ()
+        if not bool(oracle.is_semantic_ready()):
+            return ()
+        topk = _topk()
+        neighborhood = await oracle.get_fused_neighborhood(
+            list(target_files), goal_text, k_semantic=topk)
+        if not neighborhood:
+            return ()
+        ranked = sorted(
+            neighborhood,
+            key=lambda it: float(_field(it, "score", 0.0) or 0.0),
+            reverse=True,
+        )[:topk]
+
+        budget = _seed_bytes()
+        spent = 0
+        entries = []
+        targets = set(target_files)
+        for it in ranked:
+            rel = str(_field(it, "rel_path", "") or "")
+            if not rel or rel in targets:
+                continue
+            data, digest = atomic_read_and_hash(os.path.join(root, rel))
+            if not digest:
+                continue
+            excerpt = ""
+            text = data.decode("utf-8", errors="replace")
+            tlen = len(text.encode("utf-8"))
+            if spent + tlen <= budget:
+                excerpt = text
+                spent += tlen
+            entries.append(PrefetchEntry(
+                rel_path=rel,
+                sha256=digest,
+                relevance=float(_field(it, "score", 0.0) or 0.0),
+                category_hint=str(_field(it, "category_hint", "COMPREHENSION")
+                                  or "COMPREHENSION"),
+                content_excerpt=excerpt,
+            ))
+        logger.info(
+            "[EpistemicPrefetch] candidates=%d seeded=%d bytes=%d",
+            len(entries), sum(1 for e in entries if e.content_excerpt), spent)
+        return tuple(entries)
+    except Exception:  # noqa: BLE001 — never block GENERATE on prefetch
+        logger.debug("[EpistemicPrefetch] build swallowed", exc_info=True)
+        return ()

--- a/backend/core/ouroboros/governance/epistemic_prefetch.py
+++ b/backend/core/ouroboros/governance/epistemic_prefetch.py
@@ -57,6 +57,56 @@ def _field(item: Any, key: str, default):
     return getattr(item, key, default)
 
 
+# FileNeighborhood category list -> (Iron Gate category, base relevance).
+# Leverage-ordered: callers (get_callers, exploration weight 2.5) rank highest;
+# semantic_support (seed-origin, graph_proximity 0.5 per oracle fusion) lowest.
+_NEIGHBORHOOD_CATEGORIES = (
+    ("callers", "CALL_GRAPH", 1.0),
+    ("callees", "CALL_GRAPH", 0.9),
+    ("test_counterparts", "COMPREHENSION", 0.8),
+    ("imports", "DISCOVERY", 0.7),
+    ("importers", "DISCOVERY", 0.7),
+    ("inheritors", "STRUCTURE", 0.6),
+    ("base_classes", "STRUCTURE", 0.6),
+    ("semantic_support", "COMPREHENSION", 0.5),
+)
+
+
+def _strip_repo(key: str) -> str:
+    """'repo:rel/path.py' -> 'rel/path.py'. Tolerates a missing 'repo:' prefix."""
+    return key.split(":", 1)[1] if ":" in key else key
+
+
+def _normalize_neighborhood(nbh: Any) -> list:
+    """Coerce oracle's return into a uniform list of
+    {rel_path, score, category_hint} dicts.
+
+    - Falsy -> [].
+    - list/tuple (test shape + future item-shaped callers) -> passthrough.
+    - FileNeighborhood dataclass -> flatten its category lists, mapping each to
+      its Iron Gate category + leverage relevance; dedupe by rel_path keeping
+      the HIGHEST-leverage category (a file that is both a caller and an import
+      is credited as CALL_GRAPH). target_files are intentionally excluded.
+    """
+    if not nbh:
+        return []
+    if isinstance(nbh, (list, tuple)):
+        return list(nbh)
+    best = {}  # rel_path -> (relevance, category_hint)
+    for attr, cat, rel_score in _NEIGHBORHOOD_CATEGORIES:
+        for key in (getattr(nbh, attr, None) or []):
+            rel = _strip_repo(str(key))
+            if not rel:
+                continue
+            prev = best.get(rel)
+            if prev is None or rel_score > prev[0]:
+                best[rel] = (rel_score, cat)
+    return [
+        {"rel_path": rel, "score": sc, "category_hint": cat}
+        for rel, (sc, cat) in best.items()
+    ]
+
+
 async def build_prefetch_manifest(
     *,
     target_files: Tuple[str, ...],
@@ -75,10 +125,11 @@ async def build_prefetch_manifest(
         topk = _topk()
         neighborhood = await oracle.get_fused_neighborhood(
             list(target_files), goal_text, k_semantic=topk)
-        if not neighborhood:
+        items = _normalize_neighborhood(neighborhood)
+        if not items:
             return ()
         ranked = sorted(
-            neighborhood,
+            items,
             key=lambda it: float(_field(it, "score", 0.0) or 0.0),
             reverse=True,
         )[:topk]

--- a/backend/core/ouroboros/governance/epistemic_prefetch.py
+++ b/backend/core/ouroboros/governance/epistemic_prefetch.py
@@ -86,7 +86,9 @@ def _normalize_neighborhood(nbh: Any) -> list:
     - FileNeighborhood dataclass -> flatten its category lists, mapping each to
       its Iron Gate category + leverage relevance; dedupe by rel_path keeping
       the HIGHEST-leverage category (a file that is both a caller and an import
-      is credited as CALL_GRAPH). target_files are intentionally excluded.
+      is credited as CALL_GRAPH). Note: target_files exclusion is applied by
+      build_prefetch_manifest (the caller), not here — this normalizer emits
+      every category file.
     """
     if not nbh:
         return []

--- a/backend/core/ouroboros/governance/epistemic_quarantine.py
+++ b/backend/core/ouroboros/governance/epistemic_quarantine.py
@@ -57,7 +57,12 @@ class QuarantineLedger:
 
     def quarantine(self, rel_path: str, *, reason: str = "",
                    root: str = "", expected_sha: str = "") -> None:
-        """Append a quarantine record for the CURRENT session. Never raises."""
+        """Append a quarantine record for the CURRENT session. Never raises.
+
+        Footgun: a record appended without an explicit ``expected_sha`` will
+        always be classified as ``dropped`` by ``reconcile()`` because the
+        empty string cannot match any live file hash, so the node can never be
+        proven revalidated."""
         rec = {
             "session_id": self._session_id,
             "rel_path": rel_path,

--- a/backend/core/ouroboros/governance/epistemic_quarantine.py
+++ b/backend/core/ouroboros/governance/epistemic_quarantine.py
@@ -1,0 +1,125 @@
+# backend/core/ouroboros/governance/epistemic_quarantine.py
+"""Session-bound cross-process quarantine ledger + atomic Truth-Guard hash.
+
+Sovereign Epistemological Context Matrix (2026-06-21), spec section 5.3.1, LR2.
+
+The quarantine ledger is the load-bearing CROSS-PROCESS barrier that stops a
+sibling ProcessPoolExecutor worker from ingesting a memory node a peer just
+found stale. An in-memory set cannot cross process boundaries; an append-only
+on-disk JSONL (atomic temp+rename) consulted by every worker can.
+
+Discipline: pure stdlib, fail-open-to-fresh-read (a ledger error must NEVER
+block a legitimate live read), session_id-scoped (no infinite TTL).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from typing import Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def sha256_of_file(path: str) -> str:
+    """Full sha256 hex of a file's bytes, or "" if unreadable. Never raises.
+    Matches the convention in state_drift.py so memory + drift agree."""
+    try:
+        with open(path, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except (OSError, IOError):
+        return ""
+
+
+def atomic_read_and_hash(path: str) -> Tuple[bytes, str]:
+    """Read a file's bytes ONCE and hash exactly those bytes (no read->stat->
+    re-read tear window). Returns (b"", "") if unreadable. Never raises.
+
+    Atomicity guarantee: a concurrent writer either lands fully before or fully
+    after this single read of the open fd; the returned digest always
+    describes one coherent snapshot."""
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+        return data, hashlib.sha256(data).hexdigest()
+    except (OSError, IOError):
+        return b"", ""
+
+
+class QuarantineLedger:
+    """Append-only, session-scoped, fail-open quarantine of stale memory nodes."""
+
+    def __init__(self, path: str, session_id: str) -> None:
+        self._path = path
+        self._session_id = session_id or "unknown"
+
+    def quarantine(self, rel_path: str, *, reason: str = "",
+                   root: str = "", expected_sha: str = "") -> None:
+        """Append a quarantine record for the CURRENT session. Never raises."""
+        rec = {
+            "session_id": self._session_id,
+            "rel_path": rel_path,
+            "reason": reason,
+            "expected_sha": expected_sha,
+            "root": root,
+            "ts": time.time(),
+        }
+        try:
+            os.makedirs(os.path.dirname(self._path) or ".", exist_ok=True)
+            with open(self._path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(rec) + "\n")
+        except Exception:  # noqa: BLE001 — quarantine is best-effort
+            logger.debug("[Quarantine] append swallowed", exc_info=True)
+
+    def _records(self) -> List[Dict]:
+        """All parseable records (any session). Fail-open: returns [] on error."""
+        out: List[Dict] = []
+        try:
+            if not os.path.exists(self._path):
+                return out
+            with open(self._path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        out.append(json.loads(line))
+                    except (ValueError, TypeError):
+                        continue
+        except Exception:  # noqa: BLE001
+            return []
+        return out
+
+    def is_quarantined(self, rel_path: str) -> bool:
+        """True iff rel_path is quarantined IN THE CURRENT SESSION (LR2). A
+        prior soak's quarantine is ignored. Fail-open (False) on any error."""
+        for rec in self._records():
+            if rec.get("session_id") == self._session_id \
+                    and rec.get("rel_path") == rel_path:
+                return True
+        return False
+
+    def reconcile(self, root: str) -> Dict[str, List[str]]:
+        """On session terminate: re-hash each current-session quarantined node
+        vs live disk. revalidated = hash now matches expected_sha (node is
+        clean again); dropped = still drifted. Fail-soft. Returns the summary;
+        the caller (FSM) refreshes the oracle for revalidated nodes."""
+        revalidated: List[str] = []
+        dropped: List[str] = []
+        seen: set = set()
+        for rec in self._records():
+            if rec.get("session_id") != self._session_id:
+                continue
+            rel = rec.get("rel_path", "")
+            if not rel or rel in seen:
+                continue
+            seen.add(rel)
+            expected = rec.get("expected_sha", "")
+            live = sha256_of_file(os.path.join(root, rel))
+            if expected and live == expected:
+                revalidated.append(rel)
+            else:
+                dropped.append(rel)
+        return {"revalidated": revalidated, "dropped": dropped}

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1961,6 +1961,31 @@ class GovernedLoopService:
 
         self._state = ServiceState.STOPPING
 
+        # Sovereign Epistemic Context Matrix LR2: reconcile this session's memory
+        # quarantine vs live disk on teardown; refresh oracle for revalidated
+        # nodes. Fail-soft — never blocks shutdown.
+        try:
+            from pathlib import Path as _Path
+            from backend.core.ouroboros.governance.epistemic_quarantine import QuarantineLedger
+            _sess_dir = getattr(self, "_session_dir", None)
+            # derive repo root the same way the loop does elsewhere:
+            _cfg = getattr(self, "_config", None)
+            _root = str(getattr(_cfg, "project_root", "") or "") or "."
+            _sid = _Path(str(_sess_dir)).name if _sess_dir else ""
+            if _sid:
+                _led = QuarantineLedger(
+                    str(_Path(_root) / ".jarvis" / "epistemic_quarantine.jsonl"),
+                    _sid,
+                )
+                _rec = _led.reconcile(root=_root)
+                _oracle = getattr(self, "_oracle", None)
+                if _rec.get("revalidated") and _oracle is not None:
+                    _upd = getattr(_oracle, "incremental_update", None)
+                    if _upd is not None:
+                        await _upd()
+        except Exception:  # noqa: BLE001 — never block shutdown
+            pass
+
         # GracefulTeardownMatrix (2026-06-20) — cancel the DW discovery/heavy-probe
         # background loops FIRST. Left pending they leak ("Task was destroyed but
         # it is pending!") and wedge teardown for minutes on their aiohttp

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1967,11 +1967,26 @@ class GovernedLoopService:
         try:
             from pathlib import Path as _Path
             from backend.core.ouroboros.governance.epistemic_quarantine import QuarantineLedger
-            _sess_dir = getattr(self, "_session_dir", None)
             # derive repo root the same way the loop does elsewhere:
             _cfg = getattr(self, "_config", None)
             _root = str(getattr(_cfg, "project_root", "") or "") or "."
-            _sid = _Path(str(_sess_dir)).name if _sess_dir else ""
+            # LR2 reader/writer agreement: resolve the session id the SAME way
+            # the 6c WRITER (orchestrator._resolve_session_id) does -- via the
+            # canonical get_active_session_id() -- with a pid-<getpid()> fallback.
+            # The previous _session_dir-derived id was always "" on the service
+            # (self._session_dir is only ever set on the harness), so the
+            # ``if _sid:`` guard never fired and reconcile never ran. Worse, the
+            # writer keys by get_active_session_id() while this read keyed by
+            # _session_dir.name -- a latent mismatch. Now they agree.
+            _sid = ""
+            try:
+                from backend.core.ouroboros.governance.strategic_direction import get_active_session_id
+                _sid = str(get_active_session_id() or "")
+            except Exception:  # noqa: BLE001
+                _sid = ""
+            if not _sid:
+                import os as _os
+                _sid = f"pid-{_os.getpid()}"
             if _sid:
                 _led = QuarantineLedger(
                     str(_Path(_root) / ".jarvis" / "epistemic_quarantine.jsonl"),

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -43,6 +43,7 @@ from typing import TYPE_CHECKING, Any, Dict, Optional, Set, Tuple
 
 if TYPE_CHECKING:
     from backend.core.ouroboros.governance.patch_benchmarker import BenchmarkResult
+    from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
 
 from backend.core.ouroboros.governance.operation_id import generate_operation_id
 from backend.core.ouroboros.governance.risk_engine import RiskTier
@@ -1115,6 +1116,11 @@ class OperationContext:
     # skips redundant re-exploration. Authority-free (observation block).
     # Default None — non-handoff ops are byte-identical to today.
     exploration_manifest: Optional["ExplorationManifest"] = None  # Slice 89
+
+    # ---- Sovereign Epistemological Context Matrix (spec 5.1): bounded, hash- ----
+    # validated candidate DAG from the DAG Router; seeds Venom + the Governor's
+    # round-0 baseline. Empty tuple = no prefetch (light op / oracle cold / off).
+    prefetch_manifest: Tuple["PrefetchEntry", ...] = field(default_factory=tuple)
 
     # ------------------------------------------------------------------
     # Post-init

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -1388,6 +1388,35 @@ class GovernedOrchestrator:
     # the list identity held inside ``self._state``, not on a local
     # copy — so the existing call sites keep working unchanged.
 
+    def _resolve_session_id(self) -> str:
+        """Best-available session id for session-scoped memory quarantine (LR2).
+        Falls back to a stable per-process token so a NEW process (a NEW soak) is
+        a NEW session scope even if no explicit session id is plumbed. Never raises."""
+        try:
+            # Canonical session source used elsewhere in the orchestrator.
+            from backend.core.ouroboros.governance.strategic_direction import (
+                get_active_session_id,
+            )
+            _v = get_active_session_id()
+            if _v:
+                return str(_v)
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            for attr in ("_session_id", "session_id"):
+                v = getattr(self, attr, None)
+                if v:
+                    return str(v)
+            _sd = getattr(self, "_session_dir", None)
+            if _sd:
+                from pathlib import Path as _P
+                return _P(str(_sd)).name
+        except Exception:  # noqa: BLE001
+            pass
+        # stable per-process fallback (a process == a session for the daemon)
+        import os as _os
+        return f"pid-{_os.getpid()}"
+
     @property
     def _subagent_scheduler(self) -> Any:
         """Alias to ``_config.execution_graph_scheduler``.
@@ -3987,6 +4016,26 @@ class GovernedOrchestrator:
                                 ctx.op_id, _plan_decision.approver,
                             )
             ctx = ctx.advance(OperationPhase.GENERATE)
+
+            # Cryptographic Truth Guard (spec 5.3.1 / LR2): re-validate the prefetch
+            # manifest against live disk right before it is consumed. Stale entries
+            # are dropped from the seed (Venom reads them fresh) and quarantined
+            # (session-scoped) for sibling workers + teardown reconcile. Fail-soft.
+            if getattr(ctx, "prefetch_manifest", ()):
+                try:
+                    from backend.core.ouroboros.governance.epistemic_prefetch import revalidate_manifest
+                    from backend.core.ouroboros.governance.epistemic_quarantine import QuarantineLedger
+                    _root = str(self._config.project_root)
+                    _sid = self._resolve_session_id()
+                    _led = QuarantineLedger(
+                        path=os.path.join(_root, ".jarvis", "epistemic_quarantine.jsonl"),
+                        session_id=_sid,
+                    )
+                    _validated = revalidate_manifest(ctx.prefetch_manifest, _root, ledger=_led)
+                    if _validated != ctx.prefetch_manifest:
+                        ctx = dataclasses.replace(ctx, prefetch_manifest=_validated)
+                except Exception:  # noqa: BLE001 — never block GENERATE
+                    pass
 
             # ── Option C: DW topology early-detection circuit breaker ──
             # Pre-GENERATE check: if route=BACKGROUND AND topology says

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -394,7 +394,10 @@ _FAILFAST_CIRCUIT_OPEN_REASON = "all_providers_exhausted_circuit_open"
 # (and is unit-testable). It is *descriptive* of the already-non-retryable
 # sites plus the new ``deadlock_override_failed`` terminal (raised when LR3's
 # one-shot governance-deadlock breaker fails mid-Venom): retrying a wedged
-# governance deadlock just re-wedges, so it terminates non-retryably.
+# governance deadlock just re-wedges, so it terminates non-retryably. This is
+# the AUTHORITATIVE source of truth for the non-retry decision — the
+# ``except GovernanceDeadlockError`` terminal path consults it via
+# ``_is_nonretryable_terminal`` rather than deciding implicitly.
 _NONRETRYABLE_TERMINAL_REASONS: "frozenset[str]" = frozenset({
     "deadlock_override_failed",      # LR3 governance deadlock breaker failed
     "advisor_blocked",               # OperationAdvisor pre-gen veto
@@ -413,6 +416,12 @@ _NONRETRYABLE_TERMINAL_REASONS: "frozenset[str]" = frozenset({
 
 def _is_nonretryable_terminal(reason_code: str) -> bool:
     """Return True iff ``reason_code`` is a non-retryable terminal reason.
+
+    This is the AUTHORITATIVE registry of terminal reason codes that must never
+    be retried. It is consulted by the ``GovernanceDeadlockError`` terminal path
+    (``except GovernanceDeadlockError`` in ``run``) as the single source of
+    truth for the non-retry decision, and is available to future terminal sites
+    that need the same classification.
 
     Pure, side-effect-free classifier over ``_NONRETRYABLE_TERMINAL_REASONS``.
     Always returns a ``bool`` and never raises (coerces non-str input to str).
@@ -5735,20 +5744,23 @@ class GovernedOrchestrator:
                         "for %s: %s — terminating (non-retryable)",
                         ctx.op_id, _dl_exc,
                     )
-                    ctx = ctx.advance(
-                        OperationPhase.CANCELLED,
-                        terminal_reason_code="deadlock_override_failed",
-                    )
-                    await self._record_ledger(
-                        ctx,
-                        OperationState.FAILED,
-                        {
-                            "reason": "deadlock_override_failed",
-                            "error": str(_dl_exc)[:200],
-                            "nonretryable": True,
-                        },
-                    )
-                    return ctx
+                    _reason = "deadlock_override_failed"
+                    # Authoritative non-retry registry (single source of truth).
+                    if _is_nonretryable_terminal(_reason):
+                        ctx = ctx.advance(
+                            OperationPhase.CANCELLED,
+                            terminal_reason_code=_reason,
+                        )
+                        await self._record_ledger(
+                            ctx,
+                            OperationState.FAILED,
+                            {
+                                "reason": _reason,
+                                "error": str(_dl_exc)[:200],
+                                "nonretryable": True,
+                            },
+                        )
+                        return ctx
 
                 except Exception as exc:
                     _err_msg = str(exc)

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -381,6 +381,48 @@ _TRUTHY = frozenset({"1", "true", "yes", "on"})
 _FAILFAST_CIRCUIT_OPEN_REASON = "all_providers_exhausted_circuit_open"
 
 
+# ──────────────────────────────────────────────────────────────────────────
+# Sovereign Epistemic Context Matrix — non-retryable terminal reason codes
+# ──────────────────────────────────────────────────────────────────────────
+#
+# Terminal reason codes that MUST NOT be re-driven through GENERATE_RETRY.
+# Historically the orchestrator decided retryability imperatively at each
+# terminal site (infra-class escalates immediately, exhaustion parks the op,
+# advisor/plan-rejection short-circuits, etc.) — there was no single
+# grep-discoverable set. This frozenset gathers the codes whose terminal
+# state is genuinely unrecoverable within the same op so a classifier exists
+# (and is unit-testable). It is *descriptive* of the already-non-retryable
+# sites plus the new ``deadlock_override_failed`` terminal (raised when LR3's
+# one-shot governance-deadlock breaker fails mid-Venom): retrying a wedged
+# governance deadlock just re-wedges, so it terminates non-retryably.
+_NONRETRYABLE_TERMINAL_REASONS: "frozenset[str]" = frozenset({
+    "deadlock_override_failed",      # LR3 governance deadlock breaker failed
+    "advisor_blocked",               # OperationAdvisor pre-gen veto
+    "plan_rejected",                 # human/plan-review rejected the plan
+    "plan_required_unavailable",     # plan mandatory but generator unavailable
+    "plan_review_unavailable",       # plan-review mandatory but unavailable
+    "plan_approval_expired",         # approval window elapsed
+    "swebp_repo_root_rejected",      # repo-root boundary rejection
+    "validation_infra_failure",      # infra-class VALIDATE failure (non-retry)
+    "validation_budget_exhausted",   # VALIDATE budget gone
+    "op_cost_cap_exceeded",          # per-op cost cap blown
+    "user_cancelled",                # cooperative cancellation
+    _FAILFAST_CIRCUIT_OPEN_REASON,   # fail-fast exhaustion breaker open
+})
+
+
+def _is_nonretryable_terminal(reason_code: str) -> bool:
+    """Return True iff ``reason_code`` is a non-retryable terminal reason.
+
+    Pure, side-effect-free classifier over ``_NONRETRYABLE_TERMINAL_REASONS``.
+    Always returns a ``bool`` and never raises (coerces non-str input to str).
+    """
+    try:
+        return str(reason_code) in _NONRETRYABLE_TERMINAL_REASONS
+    except Exception:  # noqa: BLE001 — classifier must never raise
+        return False
+
+
 def _failfast_cb_enabled() -> bool:
     """Fail-Fast Exhaustion Circuit Breaker master switch.
 
@@ -3418,6 +3460,35 @@ class GovernedOrchestrator:
                                 )
                         except Exception as _dep_exc:
                             logger.debug("[Orchestrator] Dependency summary skipped: %s", _dep_exc)
+
+                    # Sovereign Epistemic Context Matrix (spec 5.1): on a heavy GOAL, build a
+                    # bounded, hash-validated candidate DAG from the oracle to seed Venom +
+                    # the Information-Gain Governor. Fail-soft; never blocks GENERATE.
+                    try:
+                        from backend.core.ouroboros.governance.epistemic_prefetch import (
+                            build_prefetch_manifest, is_heavy_goal,
+                        )
+                        if is_heavy_goal(ctx.target_files, int(getattr(ctx, "blast_radius", 0) or 0)):
+                            _pf_oracle = _oracle_ref if _oracle_ref is not None else getattr(self._stack, "oracle", None)
+                            _pf_timeout = float(os.environ.get("JARVIS_EPISTEMIC_PREFETCH_TIMEOUT_S", "8") or "8")
+                            _manifest = await asyncio.wait_for(
+                                build_prefetch_manifest(
+                                    target_files=tuple(ctx.target_files or ()),
+                                    root=str(self._config.project_root),
+                                    oracle=_pf_oracle,
+                                    goal_text=str(getattr(ctx, "goal", "") or getattr(ctx, "description", "") or ""),
+                                    is_heavy=True,
+                                ),
+                                timeout=_pf_timeout,
+                            )
+                            if _manifest:
+                                ctx = dataclasses.replace(ctx, prefetch_manifest=_manifest)
+                                logger.info(
+                                    "[Orchestrator] Epistemic prefetch manifest: %d entries [%s]",
+                                    len(_manifest), ctx.op_id,
+                                )
+                    except (asyncio.TimeoutError, Exception):  # noqa: BLE001 — never block GENERATE
+                        pass
                 except Exception as exc:
                     logger.warning(
                         "[Orchestrator] Context expansion failed for op=%s: %s; "
@@ -4478,6 +4549,19 @@ class GovernedOrchestrator:
             # the union of every tool call the model has made for this op, then
             # dedup-by-(tool, arguments_hash) happens inside diversity_score().
             _op_explore_records: List[Any] = []
+
+            # Sovereign Epistemic Context Matrix (LR3): bind the governance
+            # deadlock exception so the generation retry loop's dedicated catch
+            # can resolve it. Lazy import (no module-level coupling to
+            # tool_executor); fail-soft to a sentinel that can never be raised
+            # so the generic Exception handler still covers everything.
+            try:
+                from backend.core.ouroboros.governance.tool_executor import (
+                    GovernanceDeadlockError,
+                )
+            except Exception:  # noqa: BLE001 — never block GENERATE on import
+                class GovernanceDeadlockError(RuntimeError):  # type: ignore[no-redef]
+                    """Unreachable sentinel — import failed; never raised."""
 
             for attempt in range(1 + self._config.max_generate_retries):
                 # ── Per-op cost cap check (Manifesto §5/§7) ──
@@ -5589,6 +5673,33 @@ class GovernedOrchestrator:
 
                     # Success -- break out of retry loop
                     break
+
+                except GovernanceDeadlockError as _dl_exc:
+                    # Sovereign Epistemic Context Matrix (LR3): the one-shot
+                    # governance-deadlock breaker raised mid-Venom and could
+                    # not recover. This is a NON-RETRYABLE terminal — retrying
+                    # a wedged governance deadlock just re-wedges. Terminate
+                    # the op with deadlock_override_failed; do NOT fall through
+                    # to the generic retry/demotion path below.
+                    logger.warning(
+                        "[Orchestrator] Governance deadlock override failed "
+                        "for %s: %s — terminating (non-retryable)",
+                        ctx.op_id, _dl_exc,
+                    )
+                    ctx = ctx.advance(
+                        OperationPhase.CANCELLED,
+                        terminal_reason_code="deadlock_override_failed",
+                    )
+                    await self._record_ledger(
+                        ctx,
+                        OperationState.FAILED,
+                        {
+                            "reason": "deadlock_override_failed",
+                            "error": str(_dl_exc)[:200],
+                            "nonretryable": True,
+                        },
+                    )
+                    return ctx
 
                 except Exception as exc:
                     _err_msg = str(exc)

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -5422,6 +5422,13 @@ class PrimeProvider:
                 )
             except Exception:  # noqa: BLE001 — never block the tool loop
                 _op_weight_lines = None
+            # Task 6a — Information-Gain Governor for this generation attempt.
+            # build_governor_for returns None when disabled/empty → byte-identical.
+            try:
+                from backend.core.ouroboros.governance.context_governor import build_governor_for
+                _epi_governor = build_governor_for(context)
+            except Exception:  # noqa: BLE001
+                _epi_governor = None
             try:
                 raw, tool_records_list = await self._tool_loop.run(
                     prompt=prompt,
@@ -5435,6 +5442,8 @@ class PrimeProvider:
                     per_round_observer=_eb_observer,
                     repo_root_override=_evidence_override,
                     op_weight_lines=_op_weight_lines,
+                    prefetched_candidates=getattr(context, "prefetch_manifest", None),
+                    governor=_epi_governor,
                 )
             finally:
                 # Idempotent close — no-op when master flag off.
@@ -9423,6 +9432,13 @@ class ClaudeProvider:
                 )
             except Exception:  # noqa: BLE001 — never block the tool loop
                 _op_weight_lines = None
+            # Task 6a — Information-Gain Governor for this generation attempt.
+            # build_governor_for returns None when disabled/empty → byte-identical.
+            try:
+                from backend.core.ouroboros.governance.context_governor import build_governor_for
+                _epi_governor = build_governor_for(context)
+            except Exception:  # noqa: BLE001
+                _epi_governor = None
             raw, tool_records_list = await self._tool_loop.run(
                 prompt=prompt_text,
                 generate_fn=_generate_raw,
@@ -9434,6 +9450,8 @@ class ClaudeProvider:
                 is_read_only=bool(getattr(context, "is_read_only", False)),
                 repo_root_override=_evidence_override,
                 op_weight_lines=_op_weight_lines,
+                prefetched_candidates=getattr(context, "prefetch_manifest", None),
+                governor=_epi_governor,
             )
             tool_records = tuple(tool_records_list)
             tool_rounds = len(tool_records_list)

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -5423,7 +5423,7 @@ class PrimeProvider:
             except Exception:  # noqa: BLE001 — never block the tool loop
                 _op_weight_lines = None
             # Task 6a — Information-Gain Governor for this generation attempt.
-            # build_governor_for returns None when disabled/empty → byte-identical.
+            # build_governor_for returns None for non-heavy ops (light ops byte-identical).
             try:
                 from backend.core.ouroboros.governance.context_governor import build_governor_for
                 _epi_governor = build_governor_for(context)
@@ -9433,7 +9433,7 @@ class ClaudeProvider:
             except Exception:  # noqa: BLE001 — never block the tool loop
                 _op_weight_lines = None
             # Task 6a — Information-Gain Governor for this generation attempt.
-            # build_governor_for returns None when disabled/empty → byte-identical.
+            # build_governor_for returns None for non-heavy ops (light ops byte-identical).
             try:
                 from backend.core.ouroboros.governance.context_governor import build_governor_for
                 _epi_governor = build_governor_for(context)

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -34,7 +34,7 @@ import time
 logger = logging.getLogger(__name__)
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Awaitable, Callable, Dict, FrozenSet, List, Mapping, Optional, Protocol, Set, Tuple, runtime_checkable
+from typing import Any, Awaitable, Callable, Dict, FrozenSet, List, Mapping, Optional, Protocol, Sequence, Set, Tuple, runtime_checkable
 
 from backend.core.ouroboros.governance.test_runner import BlockedPathError
 
@@ -282,6 +282,46 @@ def _attach_tool_records(
     except Exception:  # noqa: BLE001 — never break a re-raise
         pass
     return exc
+
+
+# ---------------------------------------------------------------------------
+# Sovereign Epistemological Context Matrix (spec §5.2, LR3) — terminal
+# governance deadlock exception.
+# ---------------------------------------------------------------------------
+
+
+class GovernanceDeadlockError(RuntimeError):
+    """Raised when the InformationGainGovernor's one-shot deadlock breaker
+    fails to re-align exploration with the mandatory safety floor (LR3).
+
+    Terminal by contract: the governor already issued (and the coordinator
+    already consumed) the ``deadlock_break`` directive, yet the next decay
+    still found the Iron Gate floor unmet. The loop MUST NOT retry — a second
+    pass would loop at the safety gate. The orchestrator maps this to
+    ``terminal_reason_code = deadlock_override_failed``.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Sovereign Epistemological Context Matrix (spec §5.1) — prefetch seed.
+# ---------------------------------------------------------------------------
+
+
+def _build_prefetch_seed_prefix(entries) -> str:
+    """Render the validated prefetch manifest as an opening context block for
+    Venom (spec 5.1). Bounded by construction (entries already seed-budgeted).
+    Labelled as memory-supplied so the model treats it as a HINT, not as having
+    satisfied the Iron Gate (which still requires live reads)."""
+    if not entries:
+        return ""
+    parts = ["# Pre-fetched context (memory-supplied hints - VERIFY against "
+             "live files before patching):"]
+    for e in entries:
+        if not getattr(e, "content_excerpt", ""):
+            continue
+        parts.append(f"\n## {e.rel_path}  (relevance={e.relevance:.2f}, "
+                     f"satisfies={e.category_hint})\n{e.content_excerpt}")
+    return "\n".join(parts) + "\n\n" if len(parts) > 1 else ""
 
 
 # ---------------------------------------------------------------------------
@@ -4595,6 +4635,22 @@ _READONLY_EXPLORATION_TOOLS: frozenset = frozenset({
 })
 
 
+def _final_write_nudge_text() -> str:
+    """The imperative final-write nudge appended when convergence is forced
+    (Slice 3E time/round/context axes — and the Sovereign Epistemic Governor's
+    ``converge`` verdict, which reuses this exact wording so the model receives
+    a single, consistent convergence signal regardless of which trigger fired).
+    """
+    return (
+        "\n\n[SYSTEM] FINAL ROUND — exploration budget exhausted. "
+        "You MUST emit your final patch JSON now. Any further "
+        "tool calls will be IGNORED and the operation will fail. "
+        "Synthesize what you have learned from your tool calls "
+        "so far and produce the patch in the required JSON "
+        "format.\n"
+    )
+
+
 def _convergence_explore_call_threshold() -> int:
     """Slice 85 — cumulative read-only-call count that forces convergence.
 
@@ -5616,6 +5672,20 @@ class ToolLoopCoordinator:
         # latency blows the deadline. ``None`` / light ops → byte-identical (the
         # static Slice-85 threshold). The caller computes it via the existing
         # ``providers._max_target_line_count``; no parallel weight calc here.
+        prefetched_candidates: Optional[Sequence[Any]] = None,
+        # Sovereign Epistemological Context Matrix (spec §5.1) — memory-supplied
+        # PrefetchEntry sequence. When present, a bounded, clearly-labelled
+        # "memory-supplied hints" block is PREPENDED to the opening prompt so
+        # Venom starts directed, not blind. Memory is a HINT — it does NOT
+        # satisfy the Iron Gate (live reads still required). ``None`` →
+        # byte-identical legacy behavior (orchestrator pre-Task-6 passes nothing).
+        governor: Optional[Any] = None,
+        # Sovereign Epistemological Context Matrix (spec §5.2) — an
+        # InformationGainGovernor. When present, its per-round verdict is
+        # consulted at the per_round_observer seat and honored (converge /
+        # deadlock_break / deadlock_failed). Advisory: any governor exception
+        # other than GovernanceDeadlockError is swallowed. ``None`` →
+        # byte-identical legacy behavior.
     ) -> Tuple[str, List[ToolExecutionRecord]]:
         """Multi-turn tool loop with parallel execution support.
 
@@ -5672,6 +5742,18 @@ class ToolLoopCoordinator:
         records: List[ToolExecutionRecord] = []
         # Slice 89 — parallel salient-arg list; populated at dispatch alongside records
         salient_args: List[Tuple[str, str]] = []
+        # ── Sovereign Epistemological Context Matrix (spec §5.1) — prefetch seed ──
+        # Prepend the memory-supplied hint block to the OPENING prompt so Venom
+        # starts directed. Folded into ``prompt`` itself (the compaction base) so
+        # the seed is treated as stable context and never compacted/truncated as
+        # if it were a tool-result appendix. Bounded + clearly labelled as a HINT
+        # (does NOT satisfy the Iron Gate — live reads still required). ``None`` /
+        # empty entries → byte-identical: ``_build_prefetch_seed_prefix`` returns
+        # "" and the concatenation is a no-op.
+        if prefetched_candidates:
+            _seed_prefix = _build_prefetch_seed_prefix(prefetched_candidates)
+            if _seed_prefix:
+                prompt = _seed_prefix + prompt
         current_prompt = prompt
         repo_root = self._policy.repo_root_for(repo)
         # ── Slice 3G — envelope-override for per-op worktrees ──
@@ -5985,14 +6067,7 @@ class ToolLoopCoordinator:
                     else "round_cap" if _trigger_rounds
                     else "context_horizon"
                 )
-                current_prompt += (
-                    "\n\n[SYSTEM] FINAL ROUND — exploration budget exhausted. "
-                    "You MUST emit your final patch JSON now. Any further "
-                    "tool calls will be IGNORED and the operation will fail. "
-                    "Synthesize what you have learned from your tool calls "
-                    "so far and produce the patch in the required JSON "
-                    "format.\n"
-                )
+                current_prompt += _final_write_nudge_text()
                 _final_nudge_issued = True
                 if _BUDGET_TELEMETRY_ENABLED:
                     logger.info(
@@ -6564,6 +6639,75 @@ class ToolLoopCoordinator:
                     logger.debug(
                         "[ToolLoop] per_round_observer raised at "
                         "op=%s round=%d (swallowed)",
+                        op_id[:12] if op_id else "?", round_index,
+                        exc_info=True,
+                    )
+
+            # ── Sovereign Epistemological Context Matrix (spec §5.2) ──
+            # Information-Gain Governor: consult AFTER the pure observer, at the
+            # same round boundary, and HONOR the verdict. The governor measures
+            # this round's NEW information against the running corpus (seeded at
+            # round-0 by the prefetch) and, when gain decays, forces a safe
+            # handoff. Advisory by contract — any governor exception other than
+            # GovernanceDeadlockError is swallowed so it can never destabilize
+            # the loop. GovernanceDeadlockError (LR3 terminal) propagates.
+            #
+            # ``round_tool_results`` = this round's read-only EXPLORATION tool
+            # output texts (the gain signal — only looking-around counts; a
+            # progress tool is excluded, mirroring _READONLY_EXPLORATION_TOOLS).
+            # ``ledger=None``: no ExplorationLedger is held at this seat; the
+            # governor's floor probe is exception-safe and treats an
+            # unavailable floor as satisfied (Task 6 will wire the real ledger).
+            if governor is not None:
+                try:
+                    _round_readonly_results = [
+                        (tr.output or "")
+                        for tc, tr, *_ in (exec_results or [])
+                        if tc.name in _READONLY_EXPLORATION_TOOLS
+                    ]
+                    _verdict = governor.observe_round(
+                        round_index, _round_readonly_results, None,
+                    )
+                    _action = getattr(_verdict, "action", "continue")
+                    if _action == "converge":
+                        if not _final_nudge_issued:
+                            current_prompt += _final_write_nudge_text()
+                            _final_nudge_issued = True
+                            logger.info(
+                                "[ToolLoop] op=%s governor verdict=converge "
+                                "(gain=%.3f) — final-write nudge issued",
+                                op_id[:12] if op_id else "?",
+                                getattr(_verdict, "info_gain", -1.0),
+                            )
+                    elif _action == "deadlock_break":
+                        current_prompt += "\n\n" + getattr(
+                            _verdict, "directive", "",
+                        )
+                        governor.mark_deadlock_round_consumed()
+                        logger.warning(
+                            "[ToolLoop] op=%s governor verdict=deadlock_break "
+                            "(missing=%s) — directive injected, one-shot consumed",
+                            op_id[:12] if op_id else "?",
+                            getattr(_verdict, "missing_categories", ()),
+                        )
+                    elif _action == "deadlock_failed":
+                        # LR3 terminal — MUST propagate (never retry).
+                        self._last_records = list(records)
+                        self._last_salient_args = list(salient_args)
+                        self._finalize_run(op_id)
+                        raise _attach_tool_records(
+                            GovernanceDeadlockError(
+                                "deadlock_override_failed"
+                            ),
+                            records,
+                        )
+                    # "continue" → no action.
+                except GovernanceDeadlockError:
+                    raise  # terminal — do not swallow
+                except Exception:  # noqa: BLE001 — governor is advisory
+                    logger.debug(
+                        "[ToolLoop] governor raised at op=%s round=%d "
+                        "(swallowed)",
                         op_id[:12] if op_id else "?", round_index,
                         exc_info=True,
                     )

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -6668,8 +6668,11 @@ class ToolLoopCoordinator:
                     _verdict = governor.observe_round(
                         round_index, _round_readonly_results, None,
                     )
+                    from backend.core.ouroboros.governance.context_governor import (
+                        ACTION_CONVERGE, ACTION_DEADLOCK_BREAK, ACTION_DEADLOCK_FAILED,
+                    )
                     _action = getattr(_verdict, "action", "continue")
-                    if _action == "converge":
+                    if _action == ACTION_CONVERGE:
                         if not _final_nudge_issued:
                             current_prompt += _final_write_nudge_text()
                             _final_nudge_issued = True
@@ -6679,7 +6682,7 @@ class ToolLoopCoordinator:
                                 op_id[:12] if op_id else "?",
                                 getattr(_verdict, "info_gain", -1.0),
                             )
-                    elif _action == "deadlock_break":
+                    elif _action == ACTION_DEADLOCK_BREAK:
                         current_prompt += "\n\n" + getattr(
                             _verdict, "directive", "",
                         )
@@ -6690,7 +6693,7 @@ class ToolLoopCoordinator:
                             op_id[:12] if op_id else "?",
                             getattr(_verdict, "missing_categories", ()),
                         )
-                    elif _action == "deadlock_failed":
+                    elif _action == ACTION_DEADLOCK_FAILED:
                         # LR3 terminal — MUST propagate (never retry).
                         self._last_records = list(records)
                         self._last_salient_args = list(salient_args)

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -6683,6 +6683,11 @@ class ToolLoopCoordinator:
                         ACTION_CONVERGE, ACTION_DEADLOCK_BREAK, ACTION_DEADLOCK_FAILED,
                     )
                     _action = getattr(_verdict, "action", "continue")
+                    logger.debug("[ContextGovernor] op=%s round=%d gain=%.3f action=%s scale=%.2f",
+                                 op_id[:12] if op_id else "?", round_index,
+                                 getattr(_verdict, "info_gain", -1.0),
+                                 getattr(_verdict, "action", "?"),
+                                 getattr(_verdict, "budget_scale", 1.0))
                     if _action == ACTION_CONVERGE:
                         if not _final_nudge_issued:
                             current_prompt += _final_write_nudge_text()

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -6655,9 +6655,12 @@ class ToolLoopCoordinator:
             # ``round_tool_results`` = this round's read-only EXPLORATION tool
             # output texts (the gain signal — only looking-around counts; a
             # progress tool is excluded, mirroring _READONLY_EXPLORATION_TOOLS).
-            # ``ledger=None``: no ExplorationLedger is held at this seat; the
-            # governor's floor probe is exception-safe and treats an
-            # unavailable floor as satisfied (Task 6 will wire the real ledger).
+            # Task 6a: the real ExplorationLedger is now built LIVE from the
+            # accumulated ToolExecutionRecords and handed to the governor so its
+            # floor probe (the Iron Gate floor adapter) reflects what the model
+            # has actually explored this op. Fail-soft: any ledger-build failure
+            # yields None, which the governor's exception-safe floor probe treats
+            # as satisfied — byte-identical to the pre-6a ``ledger=None`` path.
             if governor is not None:
                 try:
                     _round_readonly_results = [
@@ -6665,8 +6668,16 @@ class ToolLoopCoordinator:
                         for tc, tr, *_ in (exec_results or [])
                         if tc.name in _READONLY_EXPLORATION_TOOLS
                     ]
+                    _live_ledger = None
+                    try:
+                        from backend.core.ouroboros.governance.exploration_engine import (
+                            ExplorationLedger,
+                        )
+                        _live_ledger = ExplorationLedger.from_records(records)
+                    except Exception:  # noqa: BLE001 — ledger advisory; governor handles None
+                        _live_ledger = None
                     _verdict = governor.observe_round(
-                        round_index, _round_readonly_results, None,
+                        round_index, _round_readonly_results, ledger=_live_ledger,
                     )
                     from backend.core.ouroboros.governance.context_governor import (
                         ACTION_CONVERGE, ACTION_DEADLOCK_BREAK, ACTION_DEADLOCK_FAILED,

--- a/docs/superpowers/plans/2026-06-21-sovereign-epistemic-context-matrix-phase1.md
+++ b/docs/superpowers/plans/2026-06-21-sovereign-epistemic-context-matrix-phase1.md
@@ -1,0 +1,1162 @@
+# Sovereign Epistemological Context Matrix — Phase 1 Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Cure heavy multi-file GOAL `tool_loop_deadline_exceeded` by feeding Venom a directed, hash-validated pre-fetch DAG and governing exploration with an Information-Gain Governor that converges on Δ-decay (never on wall-clock), actively bridging the Iron Gate floor with a one-shot deadlock breaker.
+
+**Architecture:** Two new pure modules (`epistemic_prefetch.py`, `context_governor.py`) + a session-bound cross-process quarantine ledger, composed with existing assets (`oracle.get_fused_neighborhood`, `state_drift` sha256, Venom's `per_round_observer` + budget machinery). One new frozen `OperationContext` field and one new `tool_executor.run()` parameter. All flags fail-soft; OFF = byte-identical legacy.
+
+**Tech Stack:** Python 3.9+ (`from __future__ import annotations`), asyncio, numpy, stdlib hashlib/json. pytest. No new third-party deps.
+
+**Spec:** `docs/superpowers/specs/2026-06-21-sovereign-epistemic-context-matrix-design.md` (binding; LR1–LR3 are absolute).
+
+**Binding resolutions (implement verbatim):**
+- **LR1** Prefetch-DAG excerpts seed the Δ corpus as round-0 baseline.
+- **LR2** Quarantine ledger is `session_id`-bound (consult-time filter ignores foreign sessions); reconciled to oracle on session terminate.
+- **LR3** Deadlock-breaker = exactly ONE dedicated round → else fatal `deadlock_override_failed` (no loop, no GENERATE_RETRY fallthrough).
+
+---
+
+## File Structure
+
+| File | Responsibility | New/Modify |
+|---|---|---|
+| `backend/core/ouroboros/governance/epistemic_prefetch.py` | DAG Router: heavy-GOAL gate → oracle fused neighborhood → bounded ranked + hash-validated `PrefetchEntry` tuple | **Create** |
+| `backend/core/ouroboros/governance/epistemic_quarantine.py` | Session-bound cross-process quarantine ledger + atomic read-then-hash Truth-Guard primitive | **Create** |
+| `backend/core/ouroboros/governance/context_governor.py` | Information-Gain Governor: lightweight Δ (round-0 = prefetch), elastic budget, verdict, deadlock-breaker directive synthesis | **Create** |
+| `backend/core/ouroboros/governance/op_context.py` | Add frozen field `prefetch_manifest: Tuple[PrefetchEntry, ...] = ()` | Modify |
+| `backend/core/ouroboros/governance/tool_executor.py` | `run(prefetched_candidates=…)` seed + governor verdict honoring in `per_round_observer` seat | Modify |
+| `backend/core/ouroboros/governance/orchestrator.py` | Trigger prefetch post-CONTEXT_EXPANSION; construct + pass governor; handle `deadlock_override_failed`; session-terminal quarantine reconcile | Modify |
+| `tests/governance/test_epistemic_prefetch.py` | Prefetch unit tests | **Create** |
+| `tests/governance/test_epistemic_quarantine.py` | Quarantine + atomic-hash unit tests | **Create** |
+| `tests/governance/test_context_governor.py` | Governor Δ / elastic-budget / deadlock-breaker tests | **Create** |
+| `tests/governance/test_epistemic_matrix_integration.py` | Cross-component + OFF byte-identical | **Create** |
+
+**Ordering rationale:** pure leaf modules first (quarantine → prefetch → governor), then the frozen-field foundation, then the two large-file integrations last (they depend on all leaves). Each task is independently committable.
+
+---
+
+## Task 1: Session-bound quarantine ledger + atomic hash primitive
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/epistemic_quarantine.py`
+- Test: `tests/governance/test_epistemic_quarantine.py`
+
+This is the cross-process Truth-Guard barrier (spec §5.3.1, LR2). Pure, no oracle/Venom deps. Reuses the sha256 convention from `state_drift.py`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_epistemic_quarantine.py
+from __future__ import annotations
+import json
+from pathlib import Path
+import pytest
+from backend.core.ouroboros.governance import epistemic_quarantine as eq
+
+
+def _write(p: Path, text: str) -> str:
+    p.write_text(text, encoding="utf-8")
+    return eq.sha256_of_file(str(p))
+
+
+def test_atomic_hash_matches_hashlib(tmp_path):
+    p = tmp_path / "f.py"
+    h = _write(p, "x = 1\n")
+    # atomic_read_and_hash returns (bytes, hexdigest) from a SINGLE read
+    data, digest = eq.atomic_read_and_hash(str(p))
+    assert data == b"x = 1\n"
+    assert digest == h
+
+
+def test_atomic_hash_missing_file_returns_empty(tmp_path):
+    data, digest = eq.atomic_read_and_hash(str(tmp_path / "nope.py"))
+    assert data == b""
+    assert digest == ""
+
+
+def test_quarantine_is_session_scoped(tmp_path):
+    ledger = tmp_path / "q.jsonl"
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    led.quarantine("a.py", reason="stale")
+    assert led.is_quarantined("a.py") is True
+    # a NEW session must NOT see S1's quarantine (LR2: no infinite TTL)
+    led2 = eq.QuarantineLedger(path=str(ledger), session_id="S2")
+    assert led2.is_quarantined("a.py") is False
+
+
+def test_quarantine_consult_failopen_on_bad_ledger(tmp_path):
+    ledger = tmp_path / "q.jsonl"
+    ledger.write_text("{not json\n", encoding="utf-8")
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    # corrupt ledger must fail-open (treat as not quarantined), never raise
+    assert led.is_quarantined("a.py") is False
+
+
+def test_reconcile_revalidates_and_drops(tmp_path):
+    f = tmp_path / "a.py"
+    h = _write(f, "v = 1\n")
+    ledger = tmp_path / "q.jsonl"
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    led.quarantine("a.py", reason="stale", root=str(tmp_path), expected_sha=h)
+    # file is UNCHANGED vs expected_sha -> reconcile re-validates (revalidated)
+    result = led.reconcile(root=str(tmp_path))
+    assert result["revalidated"] == ["a.py"]
+    assert result["dropped"] == []
+
+
+def test_reconcile_drops_when_still_drifted(tmp_path):
+    f = tmp_path / "a.py"
+    _write(f, "v = 1\n")
+    ledger = tmp_path / "q.jsonl"
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    led.quarantine("a.py", reason="stale", root=str(tmp_path), expected_sha="deadbeef")
+    result = led.reconcile(root=str(tmp_path))
+    assert result["dropped"] == ["a.py"]
+    assert result["revalidated"] == []
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_quarantine.py -x -q`
+Expected: FAIL — module `epistemic_quarantine` not found.
+
+- [ ] **Step 3: Implement the module**
+
+```python
+# backend/core/ouroboros/governance/epistemic_quarantine.py
+"""Session-bound cross-process quarantine ledger + atomic Truth-Guard hash.
+
+Sovereign Epistemological Context Matrix (2026-06-21), spec §5.3.1, LR2.
+
+The quarantine ledger is the load-bearing CROSS-PROCESS barrier that stops a
+sibling ProcessPoolExecutor worker from ingesting a memory node a peer just
+found stale. An in-memory set cannot cross process boundaries; an append-only
+on-disk JSONL (atomic temp+rename) consulted by every worker can.
+
+Discipline: pure stdlib, fail-open-to-fresh-read (a ledger error must NEVER
+block a legitimate live read), session_id-scoped (no infinite TTL).
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import time
+from typing import Dict, List, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def sha256_of_file(path: str) -> str:
+    """Full sha256 hex of a file's bytes, or "" if unreadable. Never raises.
+    Matches the convention in state_drift.py so memory + drift agree."""
+    try:
+        with open(path, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except (OSError, IOError):
+        return ""
+
+
+def atomic_read_and_hash(path: str) -> Tuple[bytes, str]:
+    """Read a file's bytes ONCE and hash exactly those bytes (no read->stat->
+    re-read tear window). Returns (b"", "") if unreadable. Never raises.
+
+    Atomicity guarantee: a concurrent writer either lands fully before or fully
+    after this single os.read of the open fd; the returned digest always
+    describes one coherent snapshot."""
+    try:
+        with open(path, "rb") as fh:
+            data = fh.read()
+        return data, hashlib.sha256(data).hexdigest()
+    except (OSError, IOError):
+        return b"", ""
+
+
+class QuarantineLedger:
+    """Append-only, session-scoped, fail-open quarantine of stale memory nodes."""
+
+    def __init__(self, path: str, session_id: str) -> None:
+        self._path = path
+        self._session_id = session_id or "unknown"
+
+    def quarantine(self, rel_path: str, *, reason: str = "",
+                   root: str = "", expected_sha: str = "") -> None:
+        """Append a quarantine record for the CURRENT session. Never raises."""
+        rec = {
+            "session_id": self._session_id,
+            "rel_path": rel_path,
+            "reason": reason,
+            "expected_sha": expected_sha,
+            "root": root,
+            "ts": time.time(),
+        }
+        try:
+            os.makedirs(os.path.dirname(self._path) or ".", exist_ok=True)
+            # append is atomic enough for single-line JSONL on POSIX; for full
+            # safety we temp+rename the whole file would lose concurrency, so we
+            # use line-append (workers only ever APPEND; consult tolerates dups).
+            with open(self._path, "a", encoding="utf-8") as fh:
+                fh.write(json.dumps(rec) + "\n")
+        except Exception:  # noqa: BLE001 — quarantine is best-effort
+            logger.debug("[Quarantine] append swallowed", exc_info=True)
+
+    def _records(self) -> List[Dict]:
+        """All parseable records (any session). Fail-open: returns [] on error."""
+        out: List[Dict] = []
+        try:
+            if not os.path.exists(self._path):
+                return out
+            with open(self._path, "r", encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        out.append(json.loads(line))
+                    except (ValueError, TypeError):
+                        continue  # skip corrupt line, keep going
+        except Exception:  # noqa: BLE001
+            return []
+        return out
+
+    def is_quarantined(self, rel_path: str) -> bool:
+        """True iff rel_path is quarantined IN THE CURRENT SESSION (LR2). A
+        prior soak's quarantine is ignored. Fail-open (False) on any error."""
+        for rec in self._records():
+            if rec.get("session_id") == self._session_id \
+                    and rec.get("rel_path") == rel_path:
+                return True
+        return False
+
+    def reconcile(self, root: str) -> Dict[str, List[str]]:
+        """On session terminate: re-hash each current-session quarantined node
+        vs live disk. revalidated = hash now matches expected_sha (node is
+        clean again); dropped = still drifted. Fail-soft. Returns the summary;
+        the caller (FSM) refreshes the oracle for revalidated nodes."""
+        revalidated: List[str] = []
+        dropped: List[str] = []
+        seen: set = set()
+        for rec in self._records():
+            if rec.get("session_id") != self._session_id:
+                continue
+            rel = rec.get("rel_path", "")
+            if not rel or rel in seen:
+                continue
+            seen.add(rel)
+            expected = rec.get("expected_sha", "")
+            live = sha256_of_file(os.path.join(root, rel))
+            if expected and live == expected:
+                revalidated.append(rel)
+            else:
+                dropped.append(rel)
+        return {"revalidated": revalidated, "dropped": dropped}
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_quarantine.py -x -q`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/epistemic_quarantine.py tests/governance/test_epistemic_quarantine.py
+git commit -m "feat(epistemic): session-bound quarantine ledger + atomic truth-guard hash (LR2)"
+```
+
+---
+
+## Task 2: DAG Router (`epistemic_prefetch.py`)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/epistemic_prefetch.py`
+- Test: `tests/governance/test_epistemic_prefetch.py`
+
+Spec §5.1. Pure aside from the injected `oracle` (always injected/mocked in tests).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_epistemic_prefetch.py
+from __future__ import annotations
+import asyncio
+import pytest
+from backend.core.ouroboros.governance import epistemic_prefetch as ep
+
+
+class _FakeOracle:
+    def __init__(self, ready=True, neighborhood=None, raises=False):
+        self._ready = ready
+        self._n = neighborhood or []
+        self._raises = raises
+    def is_semantic_ready(self):
+        return self._ready
+    async def get_fused_neighborhood(self, files, query, k_semantic=8):
+        if self._raises:
+            raise RuntimeError("oracle boom")
+        return self._n
+
+
+def _entries(monkeypatch, tmp_path, **kw):
+    # all candidate files live under tmp_path
+    return ep
+
+
+def test_disabled_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "false")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(), goal_text="g", is_heavy=True))
+    assert out == ()
+
+
+def test_not_heavy_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py",), root=str(tmp_path),
+        oracle=_FakeOracle(), goal_text="g", is_heavy=False))
+    assert out == ()
+
+
+def test_oracle_cold_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(ready=False), goal_text="g", is_heavy=True))
+    assert out == ()
+
+
+def test_oracle_exception_failsoft_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(raises=True), goal_text="g", is_heavy=True))
+    assert out == ()
+
+
+def test_builds_ranked_hashed_entries(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    (tmp_path / "dep.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    nbh = [{"rel_path": "dep.py", "score": 0.9, "category_hint": "CALL_GRAPH"}]
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(neighborhood=nbh), goal_text="g", is_heavy=True))
+    assert len(out) == 1
+    e = out[0]
+    assert e.rel_path == "dep.py"
+    assert e.sha256 != ""                 # hashed
+    assert e.relevance == 0.9
+    assert "helper" in e.content_excerpt  # seeded
+
+
+def test_seed_byte_budget_truncates_excerpt(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_SEED_BYTES", "10")
+    big = "x = 1  # " + ("padding " * 50) + "\n"
+    (tmp_path / "dep.py").write_text(big, encoding="utf-8")
+    nbh = [{"rel_path": "dep.py", "score": 0.5, "category_hint": "COMPREHENSION"}]
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(neighborhood=nbh), goal_text="g", is_heavy=True))
+    # over seed budget -> excerpt empty but still hashed + ranked
+    assert out[0].content_excerpt == ""
+    assert out[0].sha256 != ""
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_prefetch.py -x -q`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+> NOTE TO IMPLEMENTER: the live `oracle.get_fused_neighborhood` return shape (`oracle.py:4163-4279`) may be objects, not dicts. Read that method first and normalize defensively: support both `dict` (`.get`) and attribute access (`getattr`) for `rel_path`/`score`/`category_hint`, defaulting `category_hint` to `"COMPREHENSION"` when oracle doesn't supply one.
+
+```python
+# backend/core/ouroboros/governance/epistemic_prefetch.py
+"""DAG Router — directed pre-fetch for heavy GOALs (spec §5.1).
+
+On a heavy multi-file GOAL, ask the (already-booted) Oracle for a fused
+structural+semantic neighborhood, rank + bound it, snapshot each candidate's
+sha256 (Truth Guard), and return an immutable manifest that seeds Venom so it
+starts DIRECTED instead of blind. Gated, fail-soft, no-op unless heavy + oracle
+ready. Never blocks GENERATE on the oracle.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Optional, Tuple
+
+from backend.core.ouroboros.governance.epistemic_quarantine import atomic_read_and_hash
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_EPISTEMIC_PREFETCH_ENABLED"
+_ENV_TOPK = "JARVIS_EPISTEMIC_PREFETCH_TOPK"
+_ENV_SEED_BYTES = "JARVIS_EPISTEMIC_PREFETCH_SEED_BYTES"
+
+
+@dataclass(frozen=True)
+class PrefetchEntry:
+    rel_path: str
+    sha256: str
+    relevance: float
+    category_hint: str
+    content_excerpt: str
+
+
+def prefetch_enabled() -> bool:
+    return (os.environ.get(_ENV_ENABLED, "true") or "").strip().lower() in (
+        "1", "true", "yes", "on")
+
+
+def _topk() -> int:
+    try:
+        return max(1, int((os.environ.get(_ENV_TOPK, "") or "8").strip()))
+    except (TypeError, ValueError):
+        return 8
+
+
+def _seed_bytes() -> int:
+    try:
+        return max(0, int((os.environ.get(_ENV_SEED_BYTES, "") or "24000").strip()))
+    except (TypeError, ValueError):
+        return 24000
+
+
+def _field(item: Any, key: str, default):
+    if isinstance(item, dict):
+        return item.get(key, default)
+    return getattr(item, key, default)
+
+
+async def build_prefetch_manifest(
+    *,
+    target_files: Tuple[str, ...],
+    root: str,
+    oracle: Optional[Any],
+    goal_text: str,
+    is_heavy: bool,
+) -> Tuple[PrefetchEntry, ...]:
+    """Return a bounded, ranked, hash-validated candidate manifest. () when
+    disabled / not heavy / oracle cold / on any error (fail-soft)."""
+    try:
+        if not prefetch_enabled() or not is_heavy or oracle is None:
+            return ()
+        if not bool(oracle.is_semantic_ready()):
+            return ()
+        topk = _topk()
+        neighborhood = await oracle.get_fused_neighborhood(
+            list(target_files), goal_text, k_semantic=topk)
+        if not neighborhood:
+            return ()
+        ranked = sorted(
+            neighborhood,
+            key=lambda it: float(_field(it, "score", 0.0) or 0.0),
+            reverse=True,
+        )[:topk]
+
+        budget = _seed_bytes()
+        spent = 0
+        entries = []
+        targets = set(target_files)
+        for it in ranked:
+            rel = str(_field(it, "rel_path", "") or "")
+            if not rel or rel in targets:
+                continue  # never seed a target file (Venom edits those directly)
+            data, digest = atomic_read_and_hash(os.path.join(root, rel))
+            if not digest:
+                continue  # unreadable — skip
+            excerpt = ""
+            text = data.decode("utf-8", errors="replace")
+            tlen = len(text.encode("utf-8"))
+            if spent + tlen <= budget:
+                excerpt = text
+                spent += tlen
+            entries.append(PrefetchEntry(
+                rel_path=rel,
+                sha256=digest,
+                relevance=float(_field(it, "score", 0.0) or 0.0),
+                category_hint=str(_field(it, "category_hint", "COMPREHENSION")
+                                  or "COMPREHENSION"),
+                content_excerpt=excerpt,
+            ))
+        logger.info(
+            "[EpistemicPrefetch] candidates=%d seeded=%d bytes=%d",
+            len(entries), sum(1 for e in entries if e.content_excerpt), spent)
+        return tuple(entries)
+    except Exception:  # noqa: BLE001 — never block GENERATE on prefetch
+        logger.debug("[EpistemicPrefetch] build swallowed", exc_info=True)
+        return ()
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_prefetch.py -x -q`
+Expected: PASS (6 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/epistemic_prefetch.py tests/governance/test_epistemic_prefetch.py
+git commit -m "feat(epistemic): DAG Router — bounded hash-validated prefetch manifest from oracle (spec 5.1)"
+```
+
+---
+
+## Task 3: Information-Gain Governor (`context_governor.py`)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/context_governor.py`
+- Test: `tests/governance/test_context_governor.py`
+
+Spec §5.2 + LR1 + LR3. Pure + synchronous on the hot path (no model calls).
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_context_governor.py
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import context_governor as cg
+
+
+class _Floors:
+    """Minimal Iron Gate floor stand-in."""
+    def __init__(self, met, missing=()):
+        self._met = met
+        self._missing = tuple(missing)
+    def is_satisfied(self, ledger):
+        return self._met
+    def missing_categories(self, ledger):
+        return self._missing
+
+
+def _gov(**kw):
+    return cg.InformationGainGovernor(
+        prefetch_excerpts=kw.get("prefetch", ["def helper(): return 1"]),
+        floors=kw.get("floors", _Floors(met=True)),
+        enabled=kw.get("enabled", True),
+        min_gain=kw.get("min_gain", 0.15),
+        decay_rounds=kw.get("decay_rounds", 2),
+    )
+
+
+def test_disabled_always_continues():
+    g = _gov(enabled=False)
+    v = g.observe_round(0, ["totally new content xyz"], ledger=None)
+    assert v.action == "continue"
+
+
+def test_high_gain_continues():
+    g = _gov()
+    v = g.observe_round(0, ["completely unrelated brand new tokens alpha beta"],
+                        ledger=None)
+    assert v.action == "continue"
+    assert v.info_gain > 0.15
+
+
+def test_round0_baseline_is_prefetch_not_empty():
+    # content identical to the prefetch excerpt -> near-zero gain on round 0
+    # (LR1: baseline is the prefetch, so re-reading what memory gave is NOT new)
+    g = _gov(prefetch=["def helper(): return 1"])
+    v = g.observe_round(0, ["def helper(): return 1"], ledger=None)
+    assert v.info_gain < 0.15
+
+
+def test_decay_triggers_converge_when_floor_met():
+    g = _gov(floors=_Floors(met=True), decay_rounds=2,
+             prefetch=["aaa bbb ccc"])
+    g.observe_round(0, ["aaa bbb ccc"], ledger=None)         # low gain 1
+    v = g.observe_round(1, ["aaa bbb ccc"], ledger=None)     # low gain 2 -> decay
+    assert v.action == "converge"
+
+
+def test_decay_with_floor_unmet_emits_deadlock_break():
+    g = _gov(floors=_Floors(met=False, missing=("CALL_GRAPH", "HISTORY")),
+             decay_rounds=2, prefetch=["aaa bbb"])
+    g.observe_round(0, ["aaa bbb"], ledger=None)
+    v = g.observe_round(1, ["aaa bbb"], ledger=None)
+    assert v.action == "deadlock_break"
+    assert set(v.missing_categories) == {"CALL_GRAPH", "HISTORY"}
+    assert "get_callers" in v.directive   # CALL_GRAPH -> get_callers
+    assert "git_" in v.directive          # HISTORY -> git_blame/git_log
+
+
+def test_elastic_budget_warm_compresses_cold_expands():
+    warm = _gov(prefetch=["seed content present"])
+    cold = _gov(prefetch=[])
+    vw = warm.observe_round(0, ["new alpha"], ledger=None)
+    vc = cold.observe_round(0, ["new alpha"], ledger=None)
+    assert vw.budget_scale < 1.0     # warm cache -> compress
+    assert vc.budget_scale >= 1.0    # cold cache -> expand
+
+
+def test_deadlock_breaker_is_one_shot(monkeypatch):
+    # after a deadlock_break verdict is consumed, a second decay must NOT
+    # re-issue deadlock_break (LR3: exactly one round). The coordinator calls
+    # mark_deadlock_round_consumed() once it has appended the directive.
+    g = _gov(floors=_Floors(met=False, missing=("CALL_GRAPH",)),
+             decay_rounds=1, prefetch=["aaa"])
+    v1 = g.observe_round(0, ["aaa"], ledger=None)
+    assert v1.action == "deadlock_break"
+    g.mark_deadlock_round_consumed()
+    v2 = g.observe_round(1, ["aaa"], ledger=None)
+    assert v2.action == "deadlock_failed"   # one-shot exhausted -> fatal signal
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/governance/test_context_governor.py -x -q`
+Expected: FAIL — module not found.
+
+- [ ] **Step 3: Implement the module**
+
+```python
+# backend/core/ouroboros/governance/context_governor.py
+"""Information-Gain Governor (spec §5.2, LR1, LR3).
+
+Decides, after each Venom round, whether continued exploration yields enough
+NEW information to justify the budget — and forces a mathematically safe
+handoff when it does not. Synchronous + sub-millisecond on the hot path
+(TF-IDF/cosine over hashed tokens; NO model call). Deep embeds, if any, are the
+coordinator's async concern — the governor never awaits.
+
+LR1: the Δ corpus is seeded with the prefetch excerpts as the round-0 baseline.
+LR3: the deadlock breaker is one-shot; a second decay after it is consumed
+     yields action="deadlock_failed" (the coordinator turns that into the fatal
+     terminal `deadlock_override_failed`).
+"""
+from __future__ import annotations
+
+import logging
+import math
+import re
+from collections import Counter
+from dataclasses import dataclass, field
+from typing import Any, List, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+# Iron Gate category -> canonical tool(s) for the deadlock-break directive.
+# Mirrors exploration_engine._TOOL_CATEGORY (spec §3).
+_CATEGORY_TOOLS = {
+    "COMPREHENSION": ["read_file"],
+    "DISCOVERY": ["search_code"],
+    "CALL_GRAPH": ["get_callers"],
+    "STRUCTURE": ["list_symbols"],
+    "HISTORY": ["git_blame", "git_log"],
+}
+
+_TOKEN_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]{1,}")
+
+
+def _tokens(text: str) -> Counter:
+    return Counter(t.lower() for t in _TOKEN_RE.findall(text or ""))
+
+
+def _cosine(a: Counter, b: Counter) -> float:
+    if not a or not b:
+        return 0.0
+    common = set(a) & set(b)
+    num = sum(a[t] * b[t] for t in common)
+    da = math.sqrt(sum(v * v for v in a.values()))
+    db = math.sqrt(sum(v * v for v in b.values()))
+    if da == 0 or db == 0:
+        return 0.0
+    return num / (da * db)
+
+
+@dataclass(frozen=True)
+class GovernorVerdict:
+    action: str            # continue | converge | deadlock_break | deadlock_failed
+    info_gain: float
+    budget_scale: float
+    missing_categories: Tuple[str, ...] = ()
+    directive: str = ""
+
+
+@dataclass
+class InformationGainGovernor:
+    prefetch_excerpts: Sequence[str]
+    floors: Any
+    enabled: bool = True
+    min_gain: float = 0.15
+    decay_rounds: int = 2
+    _corpus: Counter = field(default_factory=Counter)
+    _low_streak: int = 0
+    _warm: bool = False
+    _deadlock_consumed: bool = False
+    _deadlock_pending: bool = False
+
+    def __post_init__(self) -> None:
+        # LR1: round-0 baseline IS the prefetch.
+        joined = "\n".join(self.prefetch_excerpts or [])
+        self._corpus = _tokens(joined)
+        self._warm = bool(self._corpus)
+
+    def _budget_scale(self) -> float:
+        # warm + still-informative -> compress; cold -> expand.
+        return 0.6 if self._warm else 1.4
+
+    def _directive(self, missing: Tuple[str, ...]) -> str:
+        lines = ["STOP broad exploration. To satisfy the mandatory safety "
+                 "floor you MUST now call ONLY these tools, nothing else:"]
+        for cat in missing:
+            tools = _CATEGORY_TOOLS.get(cat, ["read_file"])
+            lines.append(f"  - {cat}: call {' or '.join(tools)} "
+                         f"on the most relevant target file.")
+        lines.append("Then immediately emit your patch.")
+        return "\n".join(lines)
+
+    def mark_deadlock_round_consumed(self) -> None:
+        """Coordinator calls this after appending the deadlock directive (LR3)."""
+        self._deadlock_consumed = True
+        self._deadlock_pending = False
+
+    def observe_round(self, round_index: int, round_tool_results: List[str],
+                      ledger: Any) -> GovernorVerdict:
+        if not self.enabled:
+            return GovernorVerdict("continue", 1.0, 1.0)
+        scale = self._budget_scale()
+        new = _tokens("\n".join(round_tool_results or []))
+        # info gain = 1 - similarity-to-known; novel content -> high gain.
+        sim = _cosine(new, self._corpus)
+        gain = max(0.0, 1.0 - sim) if new else 0.0
+        self._corpus.update(new)
+
+        if gain < self.min_gain:
+            self._low_streak += 1
+        else:
+            self._low_streak = 0
+            self._warm = self._warm  # unchanged; still informative
+
+        decayed = self._low_streak >= self.decay_rounds
+        if not decayed:
+            return GovernorVerdict("continue", gain, scale)
+
+        # Δ decayed. Consult the floor.
+        floor_met = True
+        missing: Tuple[str, ...] = ()
+        try:
+            floor_met = bool(self.floors.is_satisfied(ledger))
+            if not floor_met:
+                missing = tuple(self.floors.missing_categories(ledger))
+        except Exception:  # noqa: BLE001 — floor probe must not crash governor
+            floor_met = True
+
+        if floor_met:
+            return GovernorVerdict("converge", gain, scale)
+
+        # Floor unmet.
+        if self._deadlock_consumed:
+            # LR3: one-shot already spent and floor STILL unmet -> fatal.
+            return GovernorVerdict("deadlock_failed", gain, scale,
+                                   missing_categories=missing)
+        self._deadlock_pending = True
+        return GovernorVerdict("deadlock_break", gain, scale,
+                               missing_categories=missing,
+                               directive=self._directive(missing))
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/governance/test_context_governor.py -x -q`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/context_governor.py tests/governance/test_context_governor.py
+git commit -m "feat(epistemic): Information-Gain Governor — round-0 baseline + one-shot deadlock breaker (LR1/LR3)"
+```
+
+---
+
+## Task 4: `OperationContext.prefetch_manifest` field
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/op_context.py` (near the `generate_file_hashes` field, ~line 1057)
+- Test: `tests/governance/test_op_context_prefetch_field.py` (Create)
+
+- [ ] **Step 1: Read the field block first**
+
+Run: `python3 -c "import re,sys; s=open('backend/core/ouroboros/governance/op_context.py').read(); i=s.find('generate_file_hashes'); print(s[i-200:i+300])"`
+Note the exact dataclass + default-factory style used so the new field matches.
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/governance/test_op_context_prefetch_field.py
+from __future__ import annotations
+from backend.core.ouroboros.governance.op_context import OperationContext
+
+def test_prefetch_manifest_defaults_empty_and_is_frozen_replaceable():
+    import dataclasses
+    # build a minimal context via the project's standard constructor/factory;
+    # IMPLEMENTER: use the same construction the other op_context tests use.
+    ctx = OperationContext.__dataclass_fields__
+    assert "prefetch_manifest" in ctx
+    assert ctx["prefetch_manifest"].default_factory is tuple
+```
+
+- [ ] **Step 3: Run to verify failure**
+
+Run: `python3 -m pytest tests/governance/test_op_context_prefetch_field.py -x -q`
+Expected: FAIL — `prefetch_manifest` not in fields.
+
+- [ ] **Step 4: Add the field**
+
+Add alongside `generate_file_hashes` (keep the frozen dataclass style; use `field(default_factory=tuple)`):
+
+```python
+    # Sovereign Epistemological Context Matrix (spec §5.1): bounded, hash-
+    # validated candidate DAG from the DAG Router; seeds Venom + the Governor's
+    # round-0 baseline. Empty tuple = no prefetch (light op / oracle cold / off).
+    prefetch_manifest: Tuple["PrefetchEntry", ...] = field(default_factory=tuple)
+```
+
+> IMPLEMENTER: import `PrefetchEntry` under `TYPE_CHECKING` only (avoid a runtime import cycle: op_context must not hard-import epistemic_prefetch). Use a string annotation as shown.
+
+- [ ] **Step 5: Run to verify pass + no regression**
+
+Run: `python3 -m pytest tests/governance/test_op_context_prefetch_field.py -x -q && python3 -m pytest tests/governance/ -k op_context -q`
+Expected: PASS; existing op_context tests still green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/op_context.py tests/governance/test_op_context_prefetch_field.py
+git commit -m "feat(epistemic): add OperationContext.prefetch_manifest frozen field"
+```
+
+---
+
+## Task 5: Venom seed + governor verdict honoring (`tool_executor.py`)
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/tool_executor.py` (`ToolLoopCoordinator.run` signature ~5586/5658; loop start ~5675; `per_round_observer` seat ~6554-6569)
+- Test: `tests/governance/test_epistemic_venom_wire.py` (Create)
+
+This is the most delicate integration. **Read the loop (`5728-6570`), the `run` signature, and the `per_round_observer` call site before editing.**
+
+- [ ] **Step 1: Write the failing test (focused on the new seam, not the whole loop)**
+
+```python
+# tests/governance/test_epistemic_venom_wire.py
+from __future__ import annotations
+import inspect
+from backend.core.ouroboros.governance import tool_executor
+
+
+def test_run_accepts_prefetched_candidates_kwarg():
+    sig = inspect.signature(tool_executor.ToolLoopCoordinator.run)
+    assert "prefetched_candidates" in sig.parameters
+    assert "governor" in sig.parameters
+
+
+def test_seed_prefix_builder_is_bounded():
+    # the helper that turns prefetch entries into the seed prompt prefix must
+    # be a pure function and must label content as memory-supplied context.
+    from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
+    entries = (PrefetchEntry("dep.py", "abc", 0.9, "CALL_GRAPH", "def f(): pass"),)
+    prefix = tool_executor._build_prefetch_seed_prefix(entries)
+    assert "dep.py" in prefix
+    assert "def f(): pass" in prefix
+    assert "memory" in prefix.lower() or "pre-fetched" in prefix.lower()
+
+
+def test_seed_prefix_empty_for_no_entries():
+    assert tool_executor._build_prefetch_seed_prefix(()) == ""
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_venom_wire.py -x -q`
+Expected: FAIL — kwargs/helper absent.
+
+- [ ] **Step 3: Implement the seam**
+
+(a) Add the pure helper near the other `_format_*` helpers:
+
+```python
+def _build_prefetch_seed_prefix(entries) -> str:
+    """Render the validated prefetch manifest as an opening context block for
+    Venom (spec §5.1). Bounded by construction (entries already seed-budgeted).
+    Labelled as memory-supplied so the model treats it as a HINT, not as having
+    satisfied the Iron Gate (which still requires live reads)."""
+    if not entries:
+        return ""
+    parts = ["# Pre-fetched context (memory-supplied hints — VERIFY against "
+             "live files before patching):"]
+    for e in entries:
+        if not getattr(e, "content_excerpt", ""):
+            continue
+        parts.append(f"\n## {e.rel_path}  (relevance={e.relevance:.2f}, "
+                     f"satisfies={e.category_hint})\n{e.content_excerpt}")
+    return "\n".join(parts) + "\n\n" if len(parts) > 1 else ""
+```
+
+(b) Add `prefetched_candidates=None` and `governor=None` to `run(...)` (keyword-only, defaulted — preserves all existing callers).
+
+(c) At loop start (~5675, after `current_prompt = prompt`):
+
+```python
+        if prefetched_candidates:
+            _seed = _build_prefetch_seed_prefix(prefetched_candidates)
+            if _seed:
+                current_prompt = _seed + current_prompt
+```
+
+(d) In the `per_round_observer` seat (~6554-6569), after the existing observer fires, consult the governor and honor the verdict. The governor needs this round's read-only tool-result texts and the live exploration ledger (already tracked via `_cumulative_explore_calls` / the ledger object if `JARVIS_EXPLORATION_LEDGER_ENABLED`). Honor verdict:
+
+```python
+        if governor is not None:
+            try:
+                _round_texts = [r.result_text for r in records
+                                if getattr(r, "round_index", None) == round_index
+                                and getattr(r, "name", "") in self._READONLY_EXPLORATION_TOOLS]
+                verdict = governor.observe_round(round_index, _round_texts,
+                                                 ledger=self._exploration_ledger)
+                if verdict.action == "converge":
+                    # reuse the EXISTING final-write nudge path
+                    current_prompt += self._final_write_nudge_text()
+                    self._final_nudge_issued = True
+                elif verdict.action == "deadlock_break":
+                    current_prompt += "\n\n" + verdict.directive + "\n"
+                    governor.mark_deadlock_round_consumed()
+                elif verdict.action == "deadlock_failed":
+                    raise GovernanceDeadlockError("deadlock_override_failed")
+            except GovernanceDeadlockError:
+                raise
+            except Exception:  # noqa: BLE001 — governor advisory must not crash loop
+                logger.debug("[ContextGovernor] observe swallowed", exc_info=True)
+```
+
+> IMPLEMENTER: (1) `self._final_write_nudge_text()` — extract the existing nudge string (currently inline ~5940-6011) into a small helper if it isn't already callable; reuse, do not duplicate the wording. (2) `record.result_text` / `record.round_index` — confirm the actual `ToolExecutionRecord` field names and adapt. (3) `self._exploration_ledger` — confirm how the ledger is held on the coordinator; if it lives elsewhere, thread it in. (4) Define `GovernanceDeadlockError` (Step 3e).
+
+(e) Define the exception near the other tool-loop exceptions:
+
+```python
+class GovernanceDeadlockError(RuntimeError):
+    """LR3: deadlock breaker's one shot failed to satisfy the Iron Gate floor.
+    Terminal — the orchestrator maps this to terminal_reason_code
+    `deadlock_override_failed`; it must NOT be retried."""
+```
+
+- [ ] **Step 4: Run to verify pass + loop regression**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_venom_wire.py -x -q && python3 -m pytest tests/governance/ -k "tool_loop or tool_executor" -q`
+Expected: new tests PASS; existing tool-loop suite green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/tool_executor.py tests/governance/test_epistemic_venom_wire.py
+git commit -m "feat(epistemic): Venom prefetch seed + governor verdict honoring (converge/deadlock/fatal)"
+```
+
+---
+
+## Task 6: Orchestrator wiring (trigger, pass-through, terminal, reconcile)
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/orchestrator.py` (prefetch after CONTEXT_EXPANSION ~3294; governor construct + pass to Venom in GENERATE ~3918/4455; terminal mapping; session-terminate reconcile)
+- Test: `tests/governance/test_epistemic_orchestrator_wire.py` (Create)
+
+> Heaviest-judgment task — read the CONTEXT_EXPANSION→GENERATE region, the existing oracle handle (`self._oracle`), the heavy-op signal, and the terminal-reason plumbing before editing.
+
+- [ ] **Step 1: Write the failing tests (seam-level, mock the heavy machinery)**
+
+```python
+# tests/governance/test_epistemic_orchestrator_wire.py
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import orchestrator as orch
+
+
+def test_is_heavy_goal_helper():
+    # pure helper: multi-file OR high blast radius -> heavy
+    assert orch._is_heavy_goal(target_files=("a.py", "b.py"), blast_radius=0) is True
+    assert orch._is_heavy_goal(target_files=("a.py",), blast_radius=99) is True
+    assert orch._is_heavy_goal(target_files=("a.py",), blast_radius=0) is False
+
+
+def test_deadlock_override_failed_is_terminal_nonretry():
+    # the terminal reason must be classified non-retryable
+    assert orch._is_nonretryable_terminal("deadlock_override_failed") is True
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_orchestrator_wire.py -x -q`
+Expected: FAIL — helpers absent.
+
+- [ ] **Step 3: Implement**
+
+(a) Pure helpers (module level):
+
+```python
+def _is_heavy_goal(target_files, blast_radius: int) -> bool:
+    import os
+    try:
+        thresh = int(os.environ.get("OUROBOROS_BLAST_RADIUS_THRESHOLD", "5"))
+    except (TypeError, ValueError):
+        thresh = 5
+    return (len(target_files or ()) > 1) or (int(blast_radius or 0) > thresh)
+```
+
+For `_is_nonretryable_terminal`, locate the existing terminal-reason classification (search `terminal_reason_code` / non-retry set) and ADD `"deadlock_override_failed"` to the non-retryable set rather than creating a parallel function if one exists. If none exists, add the helper.
+
+(b) After CONTEXT_EXPANSION advance (~3294), trigger the prefetch (overlap PLAN, bounded-await before GENERATE):
+
+```python
+        if _is_heavy_goal(ctx.target_files, getattr(ctx, "blast_radius", 0)):
+            from backend.core.ouroboros.governance.epistemic_prefetch import build_prefetch_manifest
+            try:
+                _manifest = await asyncio.wait_for(
+                    build_prefetch_manifest(
+                        target_files=tuple(ctx.target_files),
+                        root=str(self._config.project_root),
+                        oracle=getattr(self, "_oracle", None),
+                        goal_text=ctx.goal or "",
+                        is_heavy=True),
+                    timeout=float(os.environ.get("JARVIS_EPISTEMIC_PREFETCH_TIMEOUT_S", "8")))
+                ctx = dataclasses.replace(ctx, prefetch_manifest=_manifest)
+            except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+                pass  # fail-soft — Venom runs blind exactly as today
+```
+
+(c) Where Venom is invoked in GENERATE (the `tool_executor`/`ToolLoopCoordinator.run` call), construct the governor and pass both:
+
+```python
+        _governor = None
+        try:
+            if (os.environ.get("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true") or "").lower() in ("1","true","yes","on"):
+                from backend.core.ouroboros.governance.context_governor import InformationGainGovernor
+                _governor = InformationGainGovernor(
+                    prefetch_excerpts=[e.content_excerpt for e in ctx.prefetch_manifest if e.content_excerpt],
+                    floors=self._iron_gate_floor_adapter(ctx),   # IMPLEMENTER: adapt exploration_engine floors to the .is_satisfied/.missing_categories shape
+                    enabled=True)
+        except Exception:  # noqa: BLE001
+            _governor = None
+        # ... existing run(...) call gains:
+        #     prefetched_candidates=ctx.prefetch_manifest, governor=_governor
+```
+
+> IMPLEMENTER: build a thin `_iron_gate_floor_adapter(ctx)` that wraps the existing `exploration_engine` floor evaluation (`evaluate_exploration` / `ExplorationFloors`) into the two-method shape the governor expects (`is_satisfied(ledger)`, `missing_categories(ledger)`), computing missing = required − covered from the live ledger. Reuse `exploration_engine`; do not re-implement scoring.
+
+(d) Map the new error to a terminal: where `tool_executor` exceptions are caught in GENERATE, catch `GovernanceDeadlockError` → set `terminal_reason_code="deadlock_override_failed"`, mark non-retryable, route to terminal (NOT GENERATE_RETRY).
+
+(e) Session-terminate reconcile (LR2): in the FSM's session-teardown/`_slice12q_record_terminal` or the session-stop path, call the quarantine reconcile and refresh oracle for revalidated nodes:
+
+```python
+        try:
+            from backend.core.ouroboros.governance.epistemic_quarantine import QuarantineLedger
+            _led = QuarantineLedger(
+                path=os.path.join(str(self._config.project_root), ".jarvis", "epistemic_quarantine.jsonl"),
+                session_id=str(getattr(self, "_session_id", "") or ""))
+            _rec = _led.reconcile(root=str(self._config.project_root))
+            # best-effort: ask oracle to re-index revalidated files
+            if _rec["revalidated"] and getattr(self, "_oracle", None) is not None:
+                await self._oracle.incremental_update()  # IMPLEMENTER: confirm method name
+        except Exception:  # noqa: BLE001
+            pass
+```
+
+- [ ] **Step 4: Run to verify pass + orchestrator regression**
+
+Run: `python3 -m pytest tests/governance/test_epistemic_orchestrator_wire.py -x -q && python3 -m pytest tests/governance/ -k "orchestrator or exploration or state_drift" -q`
+Expected: new tests PASS; exploration-gate + state_drift + orchestrator suites green.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/orchestrator.py tests/governance/test_epistemic_orchestrator_wire.py
+git commit -m "feat(epistemic): orchestrator wiring — heavy-goal prefetch trigger, governor pass, deadlock terminal, session reconcile (LR2)"
+```
+
+---
+
+## Task 7: Integration + OFF byte-identical proof
+
+**Files:**
+- Test: `tests/governance/test_epistemic_matrix_integration.py` (Create)
+
+- [ ] **Step 1: Write the integration tests**
+
+```python
+# tests/governance/test_epistemic_matrix_integration.py
+from __future__ import annotations
+import asyncio
+from backend.core.ouroboros.governance import epistemic_prefetch as ep
+from backend.core.ouroboros.governance import context_governor as cg
+
+
+def test_prefetch_feeds_governor_round0_baseline(monkeypatch, tmp_path):
+    # end-to-end: a prefetched excerpt becomes the governor's round-0 baseline,
+    # so re-reading that same file yields LOW gain (memory worked).
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    (tmp_path / "dep.py").write_text("def shared(): return 42\n", encoding="utf-8")
+
+    class _O:
+        def is_semantic_ready(self): return True
+        async def get_fused_neighborhood(self, f, q, k_semantic=8):
+            return [{"rel_path": "dep.py", "score": 0.8, "category_hint": "COMPREHENSION"}]
+
+    manifest = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_O(), goal_text="touch shared", is_heavy=True))
+    gov = cg.InformationGainGovernor(
+        prefetch_excerpts=[e.content_excerpt for e in manifest if e.content_excerpt],
+        floors=type("F", (), {"is_satisfied": lambda s, l: True,
+                              "missing_categories": lambda s, l: ()})(),
+        enabled=True)
+    v = gov.observe_round(0, ["def shared(): return 42"], ledger=None)
+    assert v.info_gain < 0.15   # already known from prefetch -> low gain
+
+
+def test_all_flags_off_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "false")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=None, goal_text="g", is_heavy=True))
+    assert out == ()
+    gov = cg.InformationGainGovernor(prefetch_excerpts=[], floors=None, enabled=False)
+    assert gov.observe_round(0, ["anything"], ledger=None).action == "continue"
+```
+
+- [ ] **Step 2: Run + full Phase-1 sweep**
+
+Run:
+```bash
+python3 -m pytest tests/governance/test_epistemic_matrix_integration.py -x -q
+python3 -m pytest tests/governance/ -k "epistemic or context_governor or quarantine or prefetch" -q
+python3 -m pytest tests/governance/ -k "exploration or state_drift or tool_loop" -q
+```
+Expected: all PASS; no regressions in the reused subsystems.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/governance/test_epistemic_matrix_integration.py
+git commit -m "test(epistemic): cross-component integration + OFF byte-identical proof"
+```
+
+---
+
+## Done criteria (Phase 1)
+- New modules + tests green; reused subsystem suites (exploration, state_drift, tool_loop) green.
+- All masters OFF → byte-identical legacy behavior (proved by Task 7).
+- Governor converges on Δ-decay; deadlock breaker is one-shot → `deadlock_override_failed` fatal (LR3); quarantine session-bound + reconciled (LR2); prefetch is the Δ round-0 baseline (LR1).
+- **Live validation (separate, on GCP Spot 8-CPU):** heavy multi-file GOAL soak → assert `state=applied` and `tool_loop_deadline_exceeded`=0. (Not a unit task — operator-run soak.)
+
+## Self-Review notes
+- Spec coverage: §5.1 (Task 2), §5.2/LR1/LR3 (Task 3,5), §5.3.1/LR2 (Task 1,6), §5.4 is **Phase 2 — out of scope here**.
+- Type consistency: `PrefetchEntry` shape identical across prefetch/op_context/tool_executor; `GovernorVerdict.action` strings identical across governor/tool_executor.
+- The large-file tasks (5,6) deliberately ship as *seam tests + read-first edit instructions* because exact field names in `tool_executor.py` (ToolExecutionRecord) and `orchestrator.py` (ledger handle, terminal plumbing) must be confirmed against live code by the implementer — the plan flags every such confirmation inline.

--- a/docs/superpowers/specs/2026-06-21-sovereign-epistemic-context-matrix-design.md
+++ b/docs/superpowers/specs/2026-06-21-sovereign-epistemic-context-matrix-design.md
@@ -178,7 +178,7 @@ class GovernorVerdict:
 
 #### 5.2.1 Lightweight Semantic Δ (Constraint 2 — Zero-Latency Governor)
 Deep embedding every round is forbidden on the synchronous path.
-- **Primary (sync, in-observer):** TF-IDF / hashed-token cosine over the round's new tool-result text vs the accumulated exploration corpus. Pure stdlib + numpy, sub-millisecond, no model call.
+- **Primary (sync, in-observer):** TF-IDF / hashed-token cosine over the round's new tool-result text vs the accumulated exploration corpus. Pure stdlib + numpy, sub-millisecond, no model call. **The corpus is initialized to the prefetch-DAG excerpts as the round-0 baseline** (LR1) — Round-1 Δ is therefore measured against what memory already supplied, never against an empty cache, so the Governor cannot artificially inflate Information Gain on the first real read.
 - **Refinement (async, off-path):** an `asyncio.create_task` deep-embed via `EmbeddingService` *batched* across rounds; its result, when ready, recalibrates the lightweight estimator's threshold for *subsequent* rounds. The observer **never awaits** it.
 - `info_gain` ∈ [0,1]. Decay = `info_gain < JARVIS_GOVERNOR_MIN_GAIN` (default 0.15) for `JARVIS_GOVERNOR_DECAY_ROUNDS` (default 2) consecutive rounds.
 
@@ -195,9 +195,11 @@ On Δ-decay the governor consults the live `exploration_ledger`:
   1. Computes `missing = required_floor_categories − covered_categories` and the score gap.
   2. Maps each missing category → its canonical tool via `_TOOL_CATEGORY` (CALL_GRAPH→`get_callers`, HISTORY→`git_blame`/`git_log`, STRUCTURE→`list_symbols`, DISCOVERY→`search_code`, COMPREHENSION→`read_file`), targeting the highest-relevance prefetch-manifest paths.
   3. Emits a **strict zero-shot directive** (`directive`) instructing Venom to call exactly those tools on exactly those targets — nothing else — to satisfy the floor immediately.
-  4. The coordinator appends the directive (one bounded round, reusing the enforcement-round cap at `tool_executor.py:4781-4795` so the breaker itself can't loop). After that round the floor is met → graceful handoff.
+  4. The coordinator appends the directive for **exactly ONE dedicated bounded round** (its own counter, distinct from the enforcement-round cap — LR3). After that single round the ledger is re-evaluated:
+     - **Floor now satisfied** → graceful handoff (the intended path).
+     - **Floor STILL unsatisfied** (Venom hallucinated, refused, or failed to fetch the missing categories) → the Governor **MUST NOT loop and MUST NOT fall through to GENERATE_RETRY**. It forcefully fails the operation with terminal `deadlock_override_failed` (a `fatal_governance_error`). This is a hard circuit breaker: we do not tolerate infinite looping at the safety gate.
 
-This *actively bridges* the floor gap rather than passively avoiding it — the loop terminates **mathematically safe** (Iron Gate satisfied) and **never** on `tool_loop_deadline_exceeded`.
+This *actively bridges* the floor gap rather than passively avoiding it — the loop terminates **mathematically safe** (Iron Gate satisfied) and **never** on `tool_loop_deadline_exceeded`. The only non-success exit is the explicit one-shot circuit-breaker fatal.
 
 #### 5.2.4 Handoff invariant
 The governor never raises. The only terminal outcomes it produces are `converge` and `deadlock_break→converge`. The pre-existing wall-clock deadline remains an independent backstop owned by the coordinator (untouched), but in the happy path the governor converges before it can fire.
@@ -216,6 +218,7 @@ The governor never raises. The only terminal outcomes it produces are `converge`
 Heavy GOALs may run under `ProcessPoolExecutor` (parallel dispatch / L3 worktrees), so a file can be mutated by a sibling unit mid-verify.
 - **Atomic read-then-hash:** read the file's bytes **once** and hash *those exact bytes* (no read→stat→re-read window). The hash describes a single atomic snapshot; a concurrent writer either lands before or after, never tears the hash.
 - **Cross-process quarantine ledger:** on a detected mismatch, the node is quarantined in a **process-shared invalidation set** so no sibling worker ingests the stale node. Mechanism (honest tradeoff): a small on-disk quarantine ledger at `.jarvis/epistemic_quarantine.jsonl` (append-only, atomic temp+rename, mirrors the `op_context`/`state_drift` `.jarvis` convention) that all workers consult before consuming a memory node. An in-memory `set` is insufficient — it would not cross process boundaries; the on-disk ledger (or a `multiprocessing.Manager` dict when a shared manager is already in scope) is the load-bearing cross-process barrier. Reads are best-effort + fail-open-to-fresh-read (a quarantine-ledger error must never block a legitimate live read).
+- **Session-bound TTL + terminal reconciliation (LR2):** every quarantine record is stamped with the current `session_id`; consult-time filtering ignores any record whose `session_id != current` — so **stale memory from a previous soak can never permanently cripple the oracle** (no infinite TTL). On session termination the FSM **flushes/reconciles** the session's quarantine back to the primary oracle store: each quarantined node is re-hashed against live disk and either (a) re-validated + the oracle node refreshed to ground-truth, or (b) dropped. Reconciliation is fail-soft (a flush error leaves the append-only ledger intact for the next boot to filter out by session_id) and reuses the existing `.jarvis` GCS-vault flush path so the reconciliation survives Spot preemption.
 - **Invariant:** quarantine only ever *removes trust* from memory; it can never cause a patch to apply against stale content (that path is still guarded independently by `state_drift.should_block_apply()` at APPLY).
 
 ---
@@ -251,7 +254,7 @@ Every component returns control unchanged when its flag is off — the loop beha
 - **Oracle cold / absent:** prefetch returns `()`; Venom runs exactly as today. Never block GENERATE on oracle.
 - **Governor exception:** swallowed in the observer (already exception-safe per `tool_executor.py:6554-6569`); loop falls back to existing budget behavior.
 - **Quarantine-ledger I/O error:** fail-open to a fresh live read.
-- **Deadlock-breaker can't satisfy floor in its bounded round:** falls through to the *existing* `ExplorationInsufficientError` → GENERATE_RETRY path (no regression vs today).
+- **Deadlock-breaker can't satisfy floor in its one dedicated round:** terminal `deadlock_override_failed` (`fatal_governance_error`). Hard circuit breaker — no loop, no GENERATE_RETRY fallthrough (LR3). The op fails cleanly and auditably rather than spinning at the safety gate.
 
 ### 6.3 Performance / latency
 - Per-round governor cost: sub-ms (TF-IDF/cosine on cached vectors). No synchronous model calls — Constraint 2.
@@ -294,8 +297,11 @@ Every component returns control unchanged when its flag is off — the loop beha
 
 ---
 
-## 10. Open Questions (resolve during planning)
-- **OQ1.** Exact TF-IDF corpus scope for Δ — per-op accumulated tool-results only, or include the prefetch excerpts as the round-0 baseline? (Leaning: prefetch = round-0 baseline so the first real read's Δ is measured against what memory already supplied.)
-- **OQ2.** Quarantine ledger TTL / compaction — bound size like other `.jarvis` ledgers (reuse an existing ring pattern).
-- **OQ3.** Whether the deadlock-breaker's bounded round should consume an enforcement-round slot or a dedicated counter (leaning: dedicated, so it never starves legitimate enforcement re-prompts).
+## 10. Locked Resolutions (operator-ratified 2026-06-21 — absolute, not open)
+
+- **LR1 — Prefetch is the Δ round-0 baseline.** The TF-IDF/cosine corpus is seeded with the prefetch-DAG excerpts before Round 1. The Governor measures Round-1 Information Gain against what memory already supplied, never against an empty cache. Rationale: an empty baseline artificially inflates Δ on the first real read and defeats the Governor. Implemented in §5.2.1.
+- **LR2 — Quarantine TTL is strictly session-bound, with terminal reconciliation.** Every `.jarvis/epistemic_quarantine.jsonl` record carries the current `session_id`; consult-time filtering ignores foreign-session records (no infinite TTL — stale memory from a prior soak can never permanently cripple the oracle). On session termination the FSM flushes/reconciles the session's quarantine back into the primary oracle store (re-hash → re-validate-and-refresh or drop), fail-soft, over the existing `.jarvis` GCS-vault flush path. Implemented in §5.3.1.
+- **LR3 — Deadlock-breaker is a one-shot circuit breaker.** The Active Iron Gate routing gets EXACTLY ONE dedicated bounded round (its own counter, never the enforcement-round cap). If the floor is still unmet after that round (Venom hallucinated / refused / failed), the Governor forcefully terminates the op with `deadlock_override_failed` (`fatal_governance_error`) — it MUST NOT loop and MUST NOT fall through to GENERATE_RETRY. We do not tolerate infinite loops at the safety gate. Implemented in §5.2.3 and §6.2.
+
+These resolutions are binding inputs to the implementation plan; sub-agents implement them verbatim, not by interpretation.
 ```

--- a/docs/superpowers/specs/2026-06-21-sovereign-epistemic-context-matrix-design.md
+++ b/docs/superpowers/specs/2026-06-21-sovereign-epistemic-context-matrix-design.md
@@ -1,0 +1,301 @@
+# Sovereign Epistemological Context Matrix — Design Specification
+
+> **Arc codename:** Sovereign Epistemological Context Matrix (the Sovereign Memory Engine)
+> **Date:** 2026-06-21
+> **Author:** Derek J. Russell + O+V architect
+> **Branch:** `fleet/sovereign-epistemic-context-matrix`
+> **PRD anchor:** OUROBOROS_VENOM_PRD — Execution Frontier (heavy multi-file GOAL execution + long-term memory). M11 ActionOutcomeMemory arc, fused with the Venom tool-loop seventh-layer fix.
+
+---
+
+## 1. Problem Statement
+
+O+V's autonomous loop reliably reaches `state=applied` on light/single-file ops, but a clean **heavy multi-file GOAL** `state=applied` has never been achieved end-to-end. The blocking failure is the "seventh layer": **`tool_loop_deadline_exceeded`** — Venom (the multi-turn tool loop) burns its generation deadline re-discovering the codebase from scratch (`read_file`/`search_code`/`get_callers` rounds) *every op*, then cascades to a dead Claude fallback and dies `deadline_exhausted`.
+
+This is **partly compute** (now mitigated: GCP Spot `e2-custom-8-16384` replaces the starved 2-CPU M1) and **partly architectural** (unbounded, memory-less exploration). GCP is necessary, not sufficient. The architectural fix is to **collapse exploration time-complexity from O(N) brute-force search to directed semantic retrieval**, backed by durable long-term memory, while never weakening the governance cage.
+
+### The core insight
+The long-term-memory arc and the heavy-GOAL-execution arc are **the same arc**. Memory that lets Venom recall codebase structure and prior action outcomes — instead of re-exploring — *is* the mechanism that makes a heavy GOAL fit inside the deadline. We attack the deadline first (feed Venom), then enrich generation.
+
+---
+
+## 2. Goals / Non-Goals
+
+### Goals
+- **G1.** Heavy multi-file GOALs reach `state=applied` without `tool_loop_deadline_exceeded` by reducing exploration cost via directed pre-fetch.
+- **G2.** Replace unbounded exploration with an **Information-Gain Governor**: terminate exploration on semantic information-gain decay, not just wall-clock — with a controlled, native handoff to GENERATE.
+- **G3.** Never weaken the Iron Gate. Memory *seeds* exploration; it never *bypasses* mandatory verification reads of live file state.
+- **G4.** Wire the dormant `ActionOutcomeMemory` primitive into the GENERATE prompt (Phase 2).
+- **G5.** Zero duplication: compose `oracle.py`, `state_drift.py`, the existing Venom budget machinery, and `EmbeddingService`. Build only the genuinely-new seams.
+
+### Non-Goals
+- **NG1.** M9 (CuriosityGradient) / M10 (ArchitectureProposer) — sequenced *after* this arc proves heavy-GOAL execution.
+- **NG2.** New embedding backends or vector stores — reuse oracle's `EmbeddingService` / ChromaDB.
+- **NG3.** Replacing the deadline. The wall-clock cap remains as a hard backstop; the Governor's job is to converge *before* it fires.
+- **NG4.** Any change to risk-tier gating, OCA boundary, or merge authority. Cage-preserving throughout.
+
+---
+
+## 3. Reuse Inventory (zero-duplication baseline)
+
+| Capability | Existing asset | Anchor | Use |
+|---|---|---|---|
+| DAG pre-fetch (structural + semantic fusion) | `oracle.get_fused_neighborhood(file_paths, query, k_semantic)` | `oracle.py:4163` | Pre-fetch candidate DAG |
+| Semantic file ranking | `oracle.get_relevant_files_for_query(query, limit)` / `query_relevant_nodes` | `oracle.py:4281`, `3903` | Candidate ranking |
+| Dependency DAG | `get_dependencies`/`get_dependents`/`get_blast_radius`/`_file_index` | `oracle.py:3758-3783`, `869` | DAG edges |
+| Oracle readiness gate | `is_semantic_ready()` / `wait_until_ready(scope)` | `oracle.py:2240-2266` | Graceful degrade |
+| Embedder (no new dep) | `EmbeddingService` singleton | `oracle.py:1719`, `backend/core/embedding_service.py` | Δ approximation + async deep embed |
+| **Truth Guard precedent** | `state_drift.detect_drift()` / `should_block_apply()` | `state_drift.py:57-109` | sha256 live-vs-stored compare |
+| Hash snapshot shape | `op_context.generate_file_hashes: Tuple[(relpath, sha256hex)]` | `op_context.py:1057` | Manifest shape to mirror |
+| Venom main loop + deadline | `ToolLoopCoordinator.run()`; deadline raise | `tool_executor.py:5728`, `5646` | Governor seat |
+| Per-round observer hook | `per_round_observer(round_index)` | `tool_executor.py:6554-6569` | Governor invocation point |
+| Existing exploration budgets | `_cumulative_explore_calls`, `_convergence_call_threshold` (14), `scale_convergence_threshold` (Slice 237), `_explore_only_rounds` | `tool_executor.py:5699-5710`, `6387-6403` | Elastic budget substrate |
+| Graceful "stop exploring" nudge | final-write nudge path | `tool_executor.py:5940-6011` | Controlled handoff |
+| Live context compaction | `_compact_prompt()` (Gap #8) | `tool_executor.py:6430` | Seed-budget guard |
+| Iron Gate floors (score-based) | `_DEFAULT_FLOORS` per complexity | `exploration_engine.py:374-431` | Deadlock-breaker target |
+| Category→tool map | `_TOOL_CATEGORY` | `exploration_engine.py:59-78` | Deadlock-breaker directive synthesis |
+| ActionOutcomeMemory primitive (dormant) | M11 Slice 1 primitive | (defined, not wired) | Phase 2 retrieval |
+| GENERATE prompt builder (volatile tail) | `_build_lean_codegen_prompt()`; episodic inject at `~2624` | `providers.py:2525-2850` | Phase 2 injection site |
+| Heavy-GOAL signal | `len(ctx.target_files) > 1` OR `blast_radius > OUROBOROS_BLAST_RADIUS_THRESHOLD` (default 5) | `unified_intake_router.py:399`, `risk_engine.py:104-145` | Pre-fetch trigger |
+
+**Net new code:** two new modules (`epistemic_prefetch.py`, `context_governor.py`), one new `OperationContext` field (`prefetch_manifest`), one new `tool_executor.run()` parameter (`prefetched_candidates`), and the Phase-2 ActionOutcomeMemory retrieval wire. Everything else is composition.
+
+---
+
+## 4. Architecture
+
+```
+Heavy GOAL ingested
+        │
+        ▼
+ CONTEXT_EXPANSION ──(ctx.target_files + expanded_files finalized)
+        │
+        ▼
+ ┌─────────────────────────────────────────────────────────┐
+ │ epistemic_prefetch.py  — THE DAG ROUTER (async)          │
+ │  • gate: heavy GOAL + oracle.is_semantic_ready()         │
+ │  • oracle.get_fused_neighborhood(target_files, goal)     │
+ │  • rank → bounded top-K candidate DAG                    │
+ │  • Truth Guard: sha256 each candidate (atomic read)      │
+ │  • write ctx.prefetch_manifest (immutable tuple)         │
+ └─────────────────────────────────────────────────────────┘
+        │  prefetched_candidates (validated, bounded)
+        ▼
+ GENERATE → Venom ToolLoopCoordinator.run(prefetched_candidates=…)
+        │
+        │  (each round)
+        ▼
+ ┌─────────────────────────────────────────────────────────┐
+ │ context_governor.py — INFORMATION-GAIN GOVERNOR          │
+ │  (wired into per_round_observer)                         │
+ │  • lightweight Δ (TF-IDF / cached-cosine; deep embed     │
+ │    async, never blocks the observer)                     │
+ │  • elastic budget: warm cache → compress; cold → expand  │
+ │    only while Δ stays high                               │
+ │  • on Δ-decay:                                           │
+ │      ├─ Iron Gate floor MET → fire graceful nudge        │
+ │      └─ floor NOT met → ACTIVE DEADLOCK BREAKER:         │
+ │           parse missing categories, inject zero-shot     │
+ │           directive to fetch exactly those, THEN nudge   │
+ │  • NEVER raises tool_loop_deadline_exceeded              │
+ └─────────────────────────────────────────────────────────┘
+        │  controlled handoff
+        ▼
+ patch emitted → VALIDATE → GATE → APPLY (state_drift verify) → VERIFY → COMPLETE
+```
+
+Phase 2 (after Phase 1 cures the deadline): dormant `ActionOutcomeMemory` retrieval injected into `_build_lean_codegen_prompt` volatile tail.
+
+---
+
+## 5. Component Specifications
+
+### 5.1 `epistemic_prefetch.py` (NEW) — The DAG Router
+
+**Responsibility:** On a heavy GOAL, asynchronously build a bounded, validated candidate-file DAG from oracle so Venom starts *directed*, not blind.
+
+**Public interface:**
+```python
+async def build_prefetch_manifest(
+    ctx: OperationContext,
+    oracle,                      # injected; the booted TheOracle (or None)
+    *,
+    goal_text: str,
+    top_k: int,                  # bounded seed size (env JARVIS_EPISTEMIC_PREFETCH_TOPK, default 8)
+) -> tuple[PrefetchEntry, ...]:  # immutable; () when disabled / oracle cold / not heavy
+    ...
+
+@dataclass(frozen=True)
+class PrefetchEntry:
+    rel_path: str
+    sha256: str                  # "" if unreadable at snapshot time
+    relevance: float             # oracle fused score
+    category_hint: str           # which Iron Gate category this read would satisfy
+    content_excerpt: str         # bounded; for seeding (empty if seed-budget exhausted)
+```
+
+**Algorithm:**
+1. **Gate:** return `()` unless `JARVIS_EPISTEMIC_PREFETCH_ENABLED` (default true) AND heavy GOAL (`len(target_files) > 1` OR `blast_radius > threshold`) AND `oracle is not None and oracle.is_semantic_ready()`.
+2. `neighborhood = await oracle.get_fused_neighborhood(ctx.target_files, goal_text, k_semantic=top_k)`.
+3. Rank by fused score; truncate to `top_k`.
+4. For each candidate: **atomic snapshot** (§6.3) → `(rel_path, sha256, excerpt)`.
+5. Stamp `category_hint` from `_TOOL_CATEGORY` so prefetch *credits* Iron Gate categories.
+6. Return immutable tuple. **Fail-soft:** any exception → log + return `()`.
+
+**Wiring:** invoked after CONTEXT_EXPANSION advance (`orchestrator.py:~3294`) via `asyncio.create_task` so it overlaps PLAN; awaited (with a short bounded timeout) before GENERATE dispatch. Result stored on `ctx` via `dataclasses.replace` (ctx is frozen) into the new field `prefetch_manifest: Tuple[PrefetchEntry, ...] = ()` on `OperationContext`.
+
+**Seed budget:** total excerpt bytes bounded by `JARVIS_EPISTEMIC_PREFETCH_SEED_BYTES` (default 24_000) so seeding never trips Venom compaction at `tool_executor.py:6430`. Over-budget candidates carry `content_excerpt=""` (still ranked + hashed for the Truth Guard, just not seeded).
+
+---
+
+### 5.2 `context_governor.py` (NEW) — The Information-Gain Governor
+
+**Responsibility:** Decide, after each Venom round, whether continued exploration yields enough new information to justify the budget — and force a *mathematically safe* handoff when it does not.
+
+**Public interface:**
+```python
+class InformationGainGovernor:
+    def __init__(self, *, embed_service, iron_gate_floors, prefetch_manifest, enabled: bool): ...
+
+    def observe_round(
+        self,
+        round_index: int,
+        round_tool_results: list,        # this round's tool outputs
+        exploration_ledger,              # current category coverage + score
+    ) -> GovernorVerdict:
+        """Pure, fast, synchronous. NEVER blocks on a deep embed."""
+
+@dataclass(frozen=True)
+class GovernorVerdict:
+    action: str          # "continue" | "converge" | "deadlock_break"
+    info_gain: float     # lightweight Δ, [0,1]
+    budget_scale: float  # multiplier applied to convergence threshold
+    missing_categories: tuple[str, ...]   # populated only for "deadlock_break"
+    directive: str       # zero-shot fetch directive for deadlock_break; "" otherwise
+```
+
+**Wiring:** constructed per-op in the orchestrator, passed into `tool_executor.run()`, invoked from the existing `per_round_observer` (`tool_executor.py:6554`). The observer is **pure observer** today (return discarded); we extend the coordinator to honor a returned verdict by (a) appending the existing final-write nudge, or (b) appending the deadlock-break directive. The coordinator still owns the loop; the governor only advises + supplies directive text.
+
+#### 5.2.1 Lightweight Semantic Δ (Constraint 2 — Zero-Latency Governor)
+Deep embedding every round is forbidden on the synchronous path.
+- **Primary (sync, in-observer):** TF-IDF / hashed-token cosine over the round's new tool-result text vs the accumulated exploration corpus. Pure stdlib + numpy, sub-millisecond, no model call.
+- **Refinement (async, off-path):** an `asyncio.create_task` deep-embed via `EmbeddingService` *batched* across rounds; its result, when ready, recalibrates the lightweight estimator's threshold for *subsequent* rounds. The observer **never awaits** it.
+- `info_gain` ∈ [0,1]. Decay = `info_gain < JARVIS_GOVERNOR_MIN_GAIN` (default 0.15) for `JARVIS_GOVERNOR_DECAY_ROUNDS` (default 2) consecutive rounds.
+
+#### 5.2.2 Cache-Linked Elastic Budget
+Wired to the **existing** `_convergence_call_threshold` (14) via a multiplier (we do not replace the threshold):
+- **Warm + Truth-Guard-validated prefetch** (manifest non-empty, hashes valid): `budget_scale < 1.0` → compress; converge fast.
+- **Cold cache:** `budget_scale > 1.0` → expand, **but only while `info_gain` stays high**. The moment Δ decays, elasticity stops regardless of remaining budget — preventing unbounded wandering on a cold cache.
+- Composes with `scale_convergence_threshold` (Slice 237, heavy-op down-scaling): governor multiplier applies *on top of* the heavy-op scale; the effective threshold is `floor(base * heavy_scale * governor_scale)`.
+
+#### 5.2.3 Active Iron Gate Routing (Constraint 1 — The Deadlock Breaker)
+On Δ-decay the governor consults the live `exploration_ledger`:
+- **Floor satisfied** (`score ≥ min_score` AND `categories ≥ min_categories` AND required-categories covered): verdict `converge` → coordinator fires the existing graceful final-write nudge.
+- **Floor NOT satisfied:** verdict `deadlock_break`. The governor:
+  1. Computes `missing = required_floor_categories − covered_categories` and the score gap.
+  2. Maps each missing category → its canonical tool via `_TOOL_CATEGORY` (CALL_GRAPH→`get_callers`, HISTORY→`git_blame`/`git_log`, STRUCTURE→`list_symbols`, DISCOVERY→`search_code`, COMPREHENSION→`read_file`), targeting the highest-relevance prefetch-manifest paths.
+  3. Emits a **strict zero-shot directive** (`directive`) instructing Venom to call exactly those tools on exactly those targets — nothing else — to satisfy the floor immediately.
+  4. The coordinator appends the directive (one bounded round, reusing the enforcement-round cap at `tool_executor.py:4781-4795` so the breaker itself can't loop). After that round the floor is met → graceful handoff.
+
+This *actively bridges* the floor gap rather than passively avoiding it — the loop terminates **mathematically safe** (Iron Gate satisfied) and **never** on `tool_loop_deadline_exceeded`.
+
+#### 5.2.4 Handoff invariant
+The governor never raises. The only terminal outcomes it produces are `converge` and `deadlock_break→converge`. The pre-existing wall-clock deadline remains an independent backstop owned by the coordinator (untouched), but in the happy path the governor converges before it can fire.
+
+---
+
+### 5.3 Cryptographic Truth Guard (extends `state_drift.py`)
+
+**Responsibility:** Guarantee no seeded/recalled memory is ever stale relative to live disk.
+
+- **Reuse:** `state_drift`'s sha256 hasher and the `(rel_path, sha256hex)` shape. We do **not** fork a second hasher.
+- **At prefetch:** snapshot each candidate's hash into `PrefetchEntry.sha256`.
+- **At seed-consumption (Venom loop start) and at any memory-recall use:** re-hash the live file; if it mismatches the stored hash, the entry is **STALE** → discard the seed/recall for that file, force a fresh live `read_file`, and asynchronously refresh the memory node. Memory thus *accelerates which files to read*, never *replaces reading them* — preserving the Iron Gate.
+
+#### 5.3.1 Atomic Hash Verification (Constraint 3 — Race Condition Guard)
+Heavy GOALs may run under `ProcessPoolExecutor` (parallel dispatch / L3 worktrees), so a file can be mutated by a sibling unit mid-verify.
+- **Atomic read-then-hash:** read the file's bytes **once** and hash *those exact bytes* (no read→stat→re-read window). The hash describes a single atomic snapshot; a concurrent writer either lands before or after, never tears the hash.
+- **Cross-process quarantine ledger:** on a detected mismatch, the node is quarantined in a **process-shared invalidation set** so no sibling worker ingests the stale node. Mechanism (honest tradeoff): a small on-disk quarantine ledger at `.jarvis/epistemic_quarantine.jsonl` (append-only, atomic temp+rename, mirrors the `op_context`/`state_drift` `.jarvis` convention) that all workers consult before consuming a memory node. An in-memory `set` is insufficient — it would not cross process boundaries; the on-disk ledger (or a `multiprocessing.Manager` dict when a shared manager is already in scope) is the load-bearing cross-process barrier. Reads are best-effort + fail-open-to-fresh-read (a quarantine-ledger error must never block a legitimate live read).
+- **Invariant:** quarantine only ever *removes trust* from memory; it can never cause a patch to apply against stale content (that path is still guarded independently by `state_drift.should_block_apply()` at APPLY).
+
+---
+
+### 5.4 Phase 2 — ActionOutcomeMemory → GENERATE
+
+**Responsibility:** Inject "what broke the tests last time I touched this file" into the GENERATE prompt.
+
+- Wire the **dormant** M11 primitive's retrieval: `render_action_outcomes_for_region(ctx.target_files)`.
+- **Injection site:** `providers.py:_build_lean_codegen_prompt()`, volatile tail, immediately after the episodic block (`~2624`), before the oracle dependency summary (`~2629`). **Volatile tail only** — never `stable_prefix_out` (P2a-safe; outcomes change per op).
+- **Gating:** `JARVIS_ACTION_OUTCOME_MEMORY_ENABLED` (default false initially; graduates via the standard cadence).
+- **Truth Guard applies:** recalled outcomes for a file whose hash has drifted are suppressed (stale).
+
+---
+
+## 6. Cross-Cutting Concerns
+
+### 6.1 Gating & flags (all fail-soft, default byte-identical when off)
+| Flag | Default | Effect |
+|---|---|---|
+| `JARVIS_EPISTEMIC_PREFETCH_ENABLED` | `true` | DAG Router on (no-op unless heavy GOAL + oracle ready) |
+| `JARVIS_EPISTEMIC_PREFETCH_TOPK` | `8` | Candidate DAG size |
+| `JARVIS_EPISTEMIC_PREFETCH_SEED_BYTES` | `24000` | Seed budget (compaction guard) |
+| `JARVIS_CONTEXT_GOVERNOR_ENABLED` | `true` | Info-Gain Governor on (advisory until proven) |
+| `JARVIS_GOVERNOR_MIN_GAIN` | `0.15` | Δ-decay threshold |
+| `JARVIS_GOVERNOR_DECAY_ROUNDS` | `2` | Consecutive low-Δ rounds → converge |
+| `JARVIS_GOVERNOR_DEADLOCK_BREAKER_ENABLED` | `true` | Active Iron Gate routing on |
+| `JARVIS_ACTION_OUTCOME_MEMORY_ENABLED` | `false` | Phase 2 GENERATE injection |
+
+Every component returns control unchanged when its flag is off — the loop behaves exactly as today (verified by byte-identical OFF tests).
+
+### 6.2 Error handling
+- **Oracle cold / absent:** prefetch returns `()`; Venom runs exactly as today. Never block GENERATE on oracle.
+- **Governor exception:** swallowed in the observer (already exception-safe per `tool_executor.py:6554-6569`); loop falls back to existing budget behavior.
+- **Quarantine-ledger I/O error:** fail-open to a fresh live read.
+- **Deadlock-breaker can't satisfy floor in its bounded round:** falls through to the *existing* `ExplorationInsufficientError` → GENERATE_RETRY path (no regression vs today).
+
+### 6.3 Performance / latency
+- Per-round governor cost: sub-ms (TF-IDF/cosine on cached vectors). No synchronous model calls — Constraint 2.
+- Prefetch overlaps PLAN (async task), bounded-timeout awaited before GENERATE.
+- Deep embeds: batched, off the critical path.
+
+### 6.4 Cage / safety invariants (must hold)
+- **I1.** Memory seeds exploration; the Iron Gate floor is always satisfied before handoff (actively, via the deadlock breaker).
+- **I2.** No patch applies against stale content (Truth Guard at seed-time + `state_drift` at APPLY — defense in depth).
+- **I3.** Governor never raises `tool_loop_deadline_exceeded`; wall-clock backstop untouched.
+- **I4.** No change to risk tiers, OCA boundary, or merge authority.
+- **I5.** All flags fail-soft; OFF = byte-identical legacy behavior.
+
+---
+
+## 7. Phasing
+
+- **Phase 1 (the deadline cure):** `epistemic_prefetch.py` + `context_governor.py` + Truth Guard extension + Venom seed wire + deadlock breaker. Target: heavy GOAL `state=applied`, zero `tool_loop_deadline_exceeded`.
+- **Phase 2 (generative enrichment):** ActionOutcomeMemory → GENERATE prompt.
+- **After this arc:** M9 / M10 (only once heavy-GOAL execution is reliable).
+
+---
+
+## 8. Test Strategy
+
+- **Unit (pure, fast):** prefetch ranking + bounding; governor Δ math + elastic-budget scaling + decay detection; deadlock-breaker category→tool mapping + directive synthesis; atomic read-then-hash; quarantine ledger append/consult.
+- **Interaction:** governor + Iron Gate floor (deadlock breaker satisfies floor → converge, never deadlock GENERATE_RETRY); seed budget vs compaction threshold; warm-vs-cold elastic budget.
+- **OFF byte-identical:** each flag off → loop output identical to pre-arc (golden comparison on a recorded heavy-op trace).
+- **Fail-soft:** oracle cold, governor raises, quarantine I/O error — all degrade to legacy.
+- **Regression spine:** existing exploration-gate, state_drift (Slice 247/248), and tool-loop budget suites stay green.
+- **Live validation:** heavy multi-file GOAL soak on GCP Spot (8-CPU) — assert `state=applied`, `tool_loop_deadline_exceeded`=0, governor convergence telemetry present.
+
+---
+
+## 9. Telemetry (Manifesto §7 — absolute observability)
+- `[EpistemicPrefetch] op=… heavy=… oracle_ready=… candidates=N seeded=M bytes=B`
+- `[ContextGovernor] op=… round=R gain=… scale=… action=continue|converge|deadlock_break missing=[…]`
+- `[TruthGuard] op=… file=… verdict=valid|stale quarantined=bool`
+- SSE event types added additively (no breaking change to the stream schema).
+
+---
+
+## 10. Open Questions (resolve during planning)
+- **OQ1.** Exact TF-IDF corpus scope for Δ — per-op accumulated tool-results only, or include the prefetch excerpts as the round-0 baseline? (Leaning: prefetch = round-0 baseline so the first real read's Δ is measured against what memory already supplied.)
+- **OQ2.** Quarantine ledger TTL / compaction — bound size like other `.jarvis` ledgers (reuse an existing ring pattern).
+- **OQ3.** Whether the deadlock-breaker's bounded round should consume an enforcement-round slot or a dedicated counter (leaning: dedicated, so it never starves legitimate enforcement re-prompts).
+```

--- a/tests/governance/test_context_governor.py
+++ b/tests/governance/test_context_governor.py
@@ -78,3 +78,16 @@ def test_deadlock_breaker_is_one_shot():
     g.mark_deadlock_round_consumed()
     v2 = g.observe_round(1, ["aaa"], ledger=None)
     assert v2.action == "deadlock_failed"
+
+
+def test_deadlock_breaker_one_shot_even_if_coordinator_forgets_to_mark():
+    # LR3 self-defense: if the coordinator never calls
+    # mark_deadlock_round_consumed(), a SECOND decay with floor still unmet must
+    # STILL escalate to deadlock_failed -- never a second deadlock_break.
+    g = _gov(floors=_Floors(met=False, missing=("CALL_GRAPH",)),
+             decay_rounds=1, prefetch=["aaa"])
+    v1 = g.observe_round(0, ["aaa"], ledger=None)
+    assert v1.action == "deadlock_break"
+    # coordinator does NOT call mark_deadlock_round_consumed()
+    v2 = g.observe_round(1, ["aaa"], ledger=None)
+    assert v2.action == "deadlock_failed"

--- a/tests/governance/test_context_governor.py
+++ b/tests/governance/test_context_governor.py
@@ -91,3 +91,21 @@ def test_deadlock_breaker_one_shot_even_if_coordinator_forgets_to_mark():
     # coordinator does NOT call mark_deadlock_round_consumed()
     v2 = g.observe_round(1, ["aaa"], ledger=None)
     assert v2.action == "deadlock_failed"
+
+
+def test_floor_probe_exception_fails_open_to_converge():
+    class _Boom:
+        def is_satisfied(self, ledger):
+            raise RuntimeError("floor exploded")
+        def missing_categories(self, ledger):
+            return ()
+    g = _gov(floors=_Boom(), decay_rounds=1, prefetch=["aaa"])
+    v = g.observe_round(0, ["aaa"], ledger=None)
+    assert v.action == "converge"   # exception -> floor_met=True -> safe converge
+
+
+def test_empty_round_results_zero_gain():
+    g = _gov(floors=_Floors(met=True), decay_rounds=1, prefetch=["aaa"])
+    v = g.observe_round(0, [], ledger=None)
+    assert v.info_gain == 0.0
+    assert v.action == "converge"   # zero gain -> decay (1 round) -> floor met

--- a/tests/governance/test_context_governor.py
+++ b/tests/governance/test_context_governor.py
@@ -1,0 +1,80 @@
+# tests/governance/test_context_governor.py
+from __future__ import annotations
+from backend.core.ouroboros.governance import context_governor as cg
+
+
+class _Floors:
+    def __init__(self, met, missing=()):
+        self._met = met
+        self._missing = tuple(missing)
+    def is_satisfied(self, ledger):
+        return self._met
+    def missing_categories(self, ledger):
+        return self._missing
+
+
+def _gov(**kw):
+    return cg.InformationGainGovernor(
+        prefetch_excerpts=kw.get("prefetch", ["def helper(): return 1"]),
+        floors=kw.get("floors", _Floors(met=True)),
+        enabled=kw.get("enabled", True),
+        min_gain=kw.get("min_gain", 0.15),
+        decay_rounds=kw.get("decay_rounds", 2),
+    )
+
+
+def test_disabled_always_continues():
+    g = _gov(enabled=False)
+    v = g.observe_round(0, ["totally new content xyz"], ledger=None)
+    assert v.action == "continue"
+
+
+def test_high_gain_continues():
+    g = _gov()
+    v = g.observe_round(0, ["completely unrelated brand new tokens alpha beta"],
+                        ledger=None)
+    assert v.action == "continue"
+    assert v.info_gain > 0.15
+
+
+def test_round0_baseline_is_prefetch_not_empty():
+    g = _gov(prefetch=["def helper(): return 1"])
+    v = g.observe_round(0, ["def helper(): return 1"], ledger=None)
+    assert v.info_gain < 0.15
+
+
+def test_decay_triggers_converge_when_floor_met():
+    g = _gov(floors=_Floors(met=True), decay_rounds=2, prefetch=["aaa bbb ccc"])
+    g.observe_round(0, ["aaa bbb ccc"], ledger=None)
+    v = g.observe_round(1, ["aaa bbb ccc"], ledger=None)
+    assert v.action == "converge"
+
+
+def test_decay_with_floor_unmet_emits_deadlock_break():
+    g = _gov(floors=_Floors(met=False, missing=("CALL_GRAPH", "HISTORY")),
+             decay_rounds=2, prefetch=["aaa bbb"])
+    g.observe_round(0, ["aaa bbb"], ledger=None)
+    v = g.observe_round(1, ["aaa bbb"], ledger=None)
+    assert v.action == "deadlock_break"
+    assert set(v.missing_categories) == {"CALL_GRAPH", "HISTORY"}
+    assert "get_callers" in v.directive
+    assert "git_" in v.directive
+
+
+def test_elastic_budget_warm_compresses_cold_expands():
+    warm = _gov(prefetch=["seed content present"])
+    cold = _gov(prefetch=[])
+    vw = warm.observe_round(0, ["new alpha"], ledger=None)
+    vc = cold.observe_round(0, ["new alpha"], ledger=None)
+    assert vw.budget_scale < 1.0
+    assert vc.budget_scale >= 1.0
+
+
+def test_deadlock_breaker_is_one_shot():
+    g = _gov(floors=_Floors(met=False, missing=("CALL_GRAPH",)),
+             decay_rounds=1, prefetch=["aaa"])
+    v1 = g.observe_round(0, ["aaa"], ledger=None)
+    assert v1.action == "deadlock_break"
+    g.mark_deadlock_round_consumed()
+    v2 = g.observe_round(1, ["aaa"], ledger=None)
+    assert v2.action == "deadlock_failed"

--- a/tests/governance/test_epistemic_deadlock_propagation.py
+++ b/tests/governance/test_epistemic_deadlock_propagation.py
@@ -1,0 +1,167 @@
+"""Sovereign Epistemic Context Matrix — FIX 1 regression guard.
+
+The Information-Gain Governor's LR3 deadlock-override failure
+(``GovernanceDeadlockError``, raised inside the Venom tool loop) MUST
+reach the orchestrator's ``except GovernanceDeadlockError`` terminal catch
+so it stamps ``terminal_reason_code="deadlock_override_failed"``.
+
+Before this fix, every broad-catch failback site in ``candidate_generator``
+swallowed it:
+
+  * ``_try_primary_then_fallback`` reclassified the primary failure and
+    cascaded into the Claude fallback.
+  * ``_call_fallback`` (inner retry + outer catch) folded it into the
+    ``all_providers_exhausted`` taxonomy.
+  * ``_dispatch_via_sentinel``'s per-model rotation loop stored it in
+    ``_attempt_exc`` and re-drove the cascade (the deadlock never carried an
+    ``exhaustion_report`` so the "re-raise if instrumented" branch missed it,
+    and its message matched none of the GENERATION_TIMEOUT / FSM_EXHAUSTED /
+    INTERNAL_FAULT markers).
+
+These tests pin that a ``GovernanceDeadlockError`` PROPAGATES UNCONVERTED
+through the failback machinery rather than being reclassified.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance import candidate_generator as cgmod
+from backend.core.ouroboros.governance.candidate_generator import (
+    CandidateGenerator,
+    FailbackState,
+)
+from backend.core.ouroboros.governance.op_context import OperationContext
+from backend.core.ouroboros.governance.tool_executor import GovernanceDeadlockError
+
+
+def _make_generator(fallback_generate=None):
+    primary = MagicMock()
+    primary.health_probe = AsyncMock(return_value=False)
+    primary.generate = AsyncMock(side_effect=RuntimeError("primary down"))
+    fallback = MagicMock()
+    fallback.generate = fallback_generate or AsyncMock(
+        side_effect=RuntimeError("fallback should not be reached"),
+    )
+    gen = CandidateGenerator(
+        primary=primary,
+        fallback=fallback,
+        primary_concurrency=1,
+        fallback_concurrency=3,
+    )
+    gen.fsm._state = FailbackState.FALLBACK_ACTIVE
+    return gen
+
+
+def _make_context(op_id: str = "op-deadlock-test", route: str = "standard"):
+    return OperationContext.create(
+        target_files=("x.py",),
+        description="test goal",
+        op_id=op_id,
+        provider_route=route,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavioral: the symbol is shared (same class object) so the orchestrator's
+# except-clause WILL catch what candidate_generator re-raises.
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_generator_uses_real_deadlock_class():
+    """candidate_generator's GovernanceDeadlockError must BE the tool_executor
+    class (not the fallback shim) so the orchestrator's except clause catches
+    instances re-raised here."""
+    assert cgmod.GovernanceDeadlockError is GovernanceDeadlockError
+    assert issubclass(cgmod.GovernanceDeadlockError, RuntimeError)
+
+
+# ---------------------------------------------------------------------------
+# Behavioral Site B — _try_primary_then_fallback must NOT cascade a deadlock
+# into the Claude fallback.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_try_primary_then_fallback_propagates_deadlock(monkeypatch):
+    gen = _make_generator()
+    ctx = _make_context()
+    deadline = datetime.now(tz=timezone.utc) + timedelta(seconds=120)
+
+    async def _primary_raises(context, deadline, *, model_id=""):
+        raise GovernanceDeadlockError("deadlock_override_failed")
+
+    fallback_called = {"n": 0}
+
+    async def _fallback_sentinel(context, deadline):
+        fallback_called["n"] += 1
+        from backend.core.ouroboros.governance.candidate_generator import (
+            GenerationResult,
+        )
+        return GenerationResult(
+            candidates=(), provider_name="claude-api", generation_duration_s=0.0,
+        )
+
+    monkeypatch.setattr(gen, "_call_primary", _primary_raises)
+    monkeypatch.setattr(gen, "_call_fallback", _fallback_sentinel)
+
+    with pytest.raises(GovernanceDeadlockError):
+        await gen._try_primary_then_fallback(ctx, deadline)
+    # The cascade to fallback MUST NOT have fired — a deadlock is terminal.
+    assert fallback_called["n"] == 0
+
+
+# ---------------------------------------------------------------------------
+# Behavioral Site C/D — _call_fallback must NOT convert a deadlock into the
+# all_providers_exhausted taxonomy.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_call_fallback_propagates_deadlock():
+    async def _fb_gen(ctx, deadline):
+        raise GovernanceDeadlockError("deadlock_override_failed")
+
+    gen = _make_generator(AsyncMock(side_effect=_fb_gen))
+    ctx = _make_context()
+    deadline = datetime.now(tz=timezone.utc) + timedelta(seconds=120)
+
+    with pytest.raises(GovernanceDeadlockError):
+        await gen._call_fallback(ctx, deadline)
+
+
+# ---------------------------------------------------------------------------
+# Structural — every named broad-catch site has the re-raise guard, and the
+# specific clause precedes the broad clause.
+# ---------------------------------------------------------------------------
+
+
+def test_candidate_generator_reraises_governance_deadlock_structural():
+    src = inspect.getsource(cgmod)
+    assert "GovernanceDeadlockError" in src
+    assert "except GovernanceDeadlockError" in src
+    # At least the 6 reachable failback sites (rotation, primary cascade,
+    # fallback inner + outer, + 3 background wraps + topology). Count >= 6.
+    assert src.count("except GovernanceDeadlockError") >= 6
+
+
+def test_deadlock_guard_precedes_broad_catch_in_try_primary():
+    """In _try_primary_then_fallback the specific clause must come BEFORE the
+    broad ``except (Exception, asyncio.CancelledError)`` (Python evaluates
+    clauses in order)."""
+    src = inspect.getsource(cgmod.CandidateGenerator._try_primary_then_fallback)
+    i_specific = src.find("except GovernanceDeadlockError")
+    i_broad = src.find("except (Exception, asyncio.CancelledError)")
+    assert i_specific != -1, "missing deadlock guard in _try_primary_then_fallback"
+    assert i_broad != -1, "missing broad catch in _try_primary_then_fallback"
+    assert i_specific < i_broad, "deadlock guard must precede the broad catch"
+
+
+def test_deadlock_guard_precedes_broad_catch_in_call_fallback():
+    src = inspect.getsource(cgmod.CandidateGenerator._call_fallback)
+    # inner retry guard + outer guard both present
+    assert src.count("except GovernanceDeadlockError") >= 2

--- a/tests/governance/test_epistemic_gls_reconcile_session_id.py
+++ b/tests/governance/test_epistemic_gls_reconcile_session_id.py
@@ -1,0 +1,52 @@
+"""Sovereign Epistemic Context Matrix — FIX 2 regression guard.
+
+GovernedLoopService.stop()'s LR2 reconcile block previously derived the
+session id from ``self._session_dir`` — but the service never assigns
+``_session_dir`` (only the harness does), so ``_sid`` was always "" and the
+``if _sid:`` guard never fired → reconcile never ran. Worse, the 6c WRITER
+keys the QuarantineLedger by ``get_active_session_id()`` while this READER
+keyed by ``_session_dir.name`` — a latent reader/writer mismatch.
+
+The fix resolves the session id the SAME way the writer does
+(``strategic_direction.get_active_session_id()``) with a ``pid-<getpid()>``
+fail-soft fallback — mirroring ``orchestrator._resolve_session_id``. The
+``if _sid:`` guard is now always true → reconcile actually runs, and reader
+and writer agree on the key.
+"""
+from __future__ import annotations
+
+import inspect
+
+from backend.core.ouroboros.governance import governed_loop_service as glsmod
+
+
+def test_stop_reconcile_uses_get_active_session_id():
+    src = inspect.getsource(glsmod.GovernedLoopService.stop)
+    # The canonical session source, not the (always-empty) _session_dir.name.
+    assert "get_active_session_id" in src
+    # pid fallback mirrors orchestrator._resolve_session_id.
+    assert "pid-" in src or "getpid" in src
+
+
+def test_stop_reconcile_no_longer_keys_on_session_dir_name():
+    src = inspect.getsource(glsmod.GovernedLoopService.stop)
+    # The old reader pattern (_Path(str(_sess_dir)).name) is gone from the
+    # session-id resolution — the writer never used it.
+    assert "_session_dir\").name" not in src
+    assert "_sess_dir)).name" not in src
+
+
+def test_get_active_session_id_is_importable():
+    from backend.core.ouroboros.governance.strategic_direction import (
+        get_active_session_id,
+    )
+    # Returns None or a str; never raises.
+    v = get_active_session_id()
+    assert v is None or isinstance(v, str)
+
+
+def test_reconcile_block_still_targets_epistemic_quarantine_ledger():
+    src = inspect.getsource(glsmod.GovernedLoopService.stop)
+    assert "epistemic_quarantine.jsonl" in src
+    assert "QuarantineLedger" in src
+    assert "incremental_update" in src

--- a/tests/governance/test_epistemic_governor_factory.py
+++ b/tests/governance/test_epistemic_governor_factory.py
@@ -13,7 +13,8 @@ def test_build_governor_disabled_returns_none(monkeypatch):
 def test_build_governor_returns_governor_with_prefetch_excerpts(monkeypatch):
     monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true")
     manifest = (PrefetchEntry("a.py", "h", 0.9, "CALL_GRAPH", "def a(): pass"),)
-    ctx = types.SimpleNamespace(prefetch_manifest=manifest, task_complexity="moderate")
+    ctx = types.SimpleNamespace(prefetch_manifest=manifest, task_complexity="moderate",
+                                target_files=("a.py", "b.py"), blast_radius=0)
     gov = cg.build_governor_for(ctx)
     assert gov is not None
     # round-0 baseline seeded from the excerpt -> re-reading it = low gain
@@ -32,3 +33,20 @@ def test_build_governor_failsoft_on_bad_context(monkeypatch):
     # a context missing prefetch_manifest entirely must not raise
     gov = cg.build_governor_for(object())
     assert gov is None or gov is not None  # just must not raise
+
+
+def test_build_governor_none_for_light_op(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true")
+    manifest = (PrefetchEntry("a.py", "h", 0.9, "CALL_GRAPH", "def a(): pass"),)
+    # single target file, no blast radius -> NOT heavy -> None (light op untouched)
+    ctx = types.SimpleNamespace(prefetch_manifest=manifest, task_complexity="simple",
+                                target_files=("a.py",), blast_radius=0)
+    assert cg.build_governor_for(ctx) is None
+
+
+def test_build_governor_heavy_empty_manifest_still_returns_governor(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true")
+    # heavy (2 files) but EMPTY manifest (cold oracle) -> still a governor
+    ctx = types.SimpleNamespace(prefetch_manifest=(), task_complexity="moderate",
+                                target_files=("a.py", "b.py"), blast_radius=0)
+    assert cg.build_governor_for(ctx) is not None

--- a/tests/governance/test_epistemic_governor_factory.py
+++ b/tests/governance/test_epistemic_governor_factory.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import types
+from backend.core.ouroboros.governance import context_governor as cg
+from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
+
+
+def test_build_governor_disabled_returns_none(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "false")
+    ctx = types.SimpleNamespace(prefetch_manifest=(), task_complexity="moderate")
+    assert cg.build_governor_for(ctx) is None
+
+
+def test_build_governor_returns_governor_with_prefetch_excerpts(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true")
+    manifest = (PrefetchEntry("a.py", "h", 0.9, "CALL_GRAPH", "def a(): pass"),)
+    ctx = types.SimpleNamespace(prefetch_manifest=manifest, task_complexity="moderate")
+    gov = cg.build_governor_for(ctx)
+    assert gov is not None
+    # round-0 baseline seeded from the excerpt -> re-reading it = low gain
+    v = gov.observe_round(0, ["def a(): pass"], ledger=None)
+    assert v.info_gain < 0.15
+
+
+def test_floor_adapter_none_ledger_is_satisfied():
+    ad = cg._IronGateFloorAdapter(floors=None)
+    assert ad.is_satisfied(None) is True
+    assert ad.missing_categories(None) == ()
+
+
+def test_build_governor_failsoft_on_bad_context(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true")
+    # a context missing prefetch_manifest entirely must not raise
+    gov = cg.build_governor_for(object())
+    assert gov is None or gov is not None  # just must not raise

--- a/tests/governance/test_epistemic_matrix_integration.py
+++ b/tests/governance/test_epistemic_matrix_integration.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+import asyncio
+from backend.core.ouroboros.governance import epistemic_prefetch as ep
+from backend.core.ouroboros.governance import context_governor as cg
+from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
+
+
+class _FakeOracleObj:
+    def __init__(self, nbh):
+        self._nbh = nbh
+    def is_semantic_ready(self):
+        return True
+    async def get_fused_neighborhood(self, files, query, k_semantic=8):
+        return self._nbh
+
+
+class _FakeNeighborhood:
+    def __init__(self, **lists):
+        for k in ("target_files", "imports", "importers", "callers", "callees",
+                  "inheritors", "base_classes", "test_counterparts",
+                  "semantic_support"):
+            setattr(self, k, lists.get(k, []))
+
+
+def test_prefetch_feeds_governor_round0_baseline(monkeypatch, tmp_path):
+    # End-to-end: a prefetched excerpt becomes the governor's round-0 baseline,
+    # so re-reading that same file yields LOW gain (memory worked, no inflation).
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "true")
+    (tmp_path / "dep.py").write_text("def shared(): return 42\n", encoding="utf-8")
+    nb = _FakeNeighborhood(callers=["jarvis:dep.py"])
+    manifest = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracleObj(nb), goal_text="touch shared", is_heavy=True))
+    assert manifest and manifest[0].rel_path == "dep.py"
+    import types
+    ctx = types.SimpleNamespace(prefetch_manifest=manifest, task_complexity="moderate",
+                               target_files=("a.py", "b.py"), blast_radius=0)
+    gov = cg.build_governor_for(ctx)
+    assert gov is not None
+    v = gov.observe_round(0, ["def shared(): return 42"], ledger=None)
+    assert v.info_gain < 0.15   # already known from prefetch -> low gain
+
+
+def test_truth_guard_drops_stale_between_build_and_consume(monkeypatch, tmp_path):
+    # Build a manifest, then MUTATE the file on disk, then revalidate -> dropped.
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    f = tmp_path / "dep.py"
+    f.write_text("def shared(): return 42\n", encoding="utf-8")
+    nb = _FakeNeighborhood(callers=["jarvis:dep.py"])
+    manifest = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracleObj(nb), goal_text="g", is_heavy=True))
+    assert manifest
+    # file changes after prefetch hashed it
+    f.write_text("def shared(): return 999  # changed\n", encoding="utf-8")
+    validated = ep.revalidate_manifest(manifest, str(tmp_path), ledger=None)
+    assert all(e.rel_path != "dep.py" for e in validated)  # stale dropped
+
+
+def test_all_flags_off_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "false")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracleObj(_FakeNeighborhood(callers=["jarvis:x.py"])),
+        goal_text="g", is_heavy=True))
+    assert out == ()
+    import types
+    ctx = types.SimpleNamespace(prefetch_manifest=(), task_complexity="moderate",
+                               target_files=("a.py", "b.py"), blast_radius=0)
+    assert cg.build_governor_for(ctx) is None   # governor off -> None
+
+
+def test_governor_off_but_prefetch_on_still_safe(monkeypatch, tmp_path):
+    # prefetch builds, but governor disabled -> build_governor_for None, no crash
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CONTEXT_GOVERNOR_ENABLED", "false")
+    (tmp_path / "dep.py").write_text("x = 1\n", encoding="utf-8")
+    nb = _FakeNeighborhood(callers=["jarvis:dep.py"])
+    manifest = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracleObj(nb), goal_text="g", is_heavy=True))
+    assert manifest  # prefetch still works
+    import types
+    ctx = types.SimpleNamespace(prefetch_manifest=manifest, task_complexity="moderate",
+                               target_files=("a.py", "b.py"), blast_radius=0)
+    assert cg.build_governor_for(ctx) is None

--- a/tests/governance/test_epistemic_orchestrator_wire.py
+++ b/tests/governance/test_epistemic_orchestrator_wire.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from backend.core.ouroboros.governance import orchestrator as orch
+
+
+def test_deadlock_override_failed_is_nonretryable():
+    assert orch._is_nonretryable_terminal("deadlock_override_failed") is True
+
+
+def test_known_retryable_is_not_flagged_nonretryable():
+    # a clearly transient/normal code should NOT be classified terminal-nonretry
+    assert orch._is_nonretryable_terminal("generation_timeout") in (False, True)
+    # (assert it doesn't crash + returns a bool)
+    assert isinstance(orch._is_nonretryable_terminal("something_random"), bool)
+
+
+def test_nonretryable_set_includes_deadlock():
+    assert "deadlock_override_failed" in orch._NONRETRYABLE_TERMINAL_REASONS
+
+
+def test_classifier_never_raises_on_non_str():
+    # coerces non-str input and returns a bool rather than raising
+    assert isinstance(orch._is_nonretryable_terminal(None), bool)  # type: ignore[arg-type]
+    assert isinstance(orch._is_nonretryable_terminal(123), bool)  # type: ignore[arg-type]

--- a/tests/governance/test_epistemic_prefetch.py
+++ b/tests/governance/test_epistemic_prefetch.py
@@ -75,3 +75,60 @@ def test_seed_byte_budget_truncates_excerpt(monkeypatch, tmp_path):
         oracle=_FakeOracle(neighborhood=nbh), goal_text="g", is_heavy=True))
     assert out[0].content_excerpt == ""
     assert out[0].sha256 != ""
+
+
+class _FakeNeighborhood:
+    def __init__(self, **lists):
+        for k in ("target_files", "imports", "importers", "callers", "callees",
+                  "inheritors", "base_classes", "test_counterparts",
+                  "semantic_support"):
+            setattr(self, k, lists.get(k, []))
+
+
+class _FakeOracleObj:
+    def __init__(self, nbh):
+        self._nbh = nbh
+    def is_semantic_ready(self):
+        return True
+    async def get_fused_neighborhood(self, files, query, k_semantic=8):
+        return self._nbh
+
+
+def test_normalize_passthrough_for_list():
+    items = ep._normalize_neighborhood([{"rel_path": "a.py", "score": 0.5}])
+    assert items == [{"rel_path": "a.py", "score": 0.5}]
+
+
+def test_normalize_dedupes_keeping_highest_leverage():
+    nb = _FakeNeighborhood(callers=["r:x.py"], imports=["r:x.py"])
+    items = ep._normalize_neighborhood(nb)
+    assert len(items) == 1
+    assert items[0]["category_hint"] == "CALL_GRAPH"  # caller(1.0) beats import(0.7)
+
+
+def test_normalizes_real_fileneighborhood(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    (tmp_path / "caller.py").write_text("import dep\n", encoding="utf-8")
+    (tmp_path / "sem.py").write_text("x = 1\n", encoding="utf-8")
+    import asyncio as _aio
+    nb = _FakeNeighborhood(callers=["jarvis:caller.py"],
+                           semantic_support=["jarvis:sem.py"])
+    out = _aio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracleObj(nb), goal_text="g", is_heavy=True))
+    paths = {e.rel_path: e for e in out}
+    assert paths["caller.py"].category_hint == "CALL_GRAPH"
+    assert paths["sem.py"].category_hint == "COMPREHENSION"
+    assert paths["caller.py"].relevance > paths["sem.py"].relevance
+
+
+def test_target_files_excluded_from_normalized(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
+    import asyncio as _aio
+    # 'a.py' is BOTH a target and shows up as a caller -> must be excluded
+    nb = _FakeNeighborhood(callers=["jarvis:a.py"])
+    out = _aio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracleObj(nb), goal_text="g", is_heavy=True))
+    assert all(e.rel_path != "a.py" for e in out)

--- a/tests/governance/test_epistemic_prefetch.py
+++ b/tests/governance/test_epistemic_prefetch.py
@@ -110,10 +110,9 @@ def test_normalizes_real_fileneighborhood(monkeypatch, tmp_path):
     monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
     (tmp_path / "caller.py").write_text("import dep\n", encoding="utf-8")
     (tmp_path / "sem.py").write_text("x = 1\n", encoding="utf-8")
-    import asyncio as _aio
     nb = _FakeNeighborhood(callers=["jarvis:caller.py"],
                            semantic_support=["jarvis:sem.py"])
-    out = _aio.run(ep.build_prefetch_manifest(
+    out = asyncio.run(ep.build_prefetch_manifest(
         target_files=("a.py", "b.py"), root=str(tmp_path),
         oracle=_FakeOracleObj(nb), goal_text="g", is_heavy=True))
     paths = {e.rel_path: e for e in out}
@@ -125,10 +124,9 @@ def test_normalizes_real_fileneighborhood(monkeypatch, tmp_path):
 def test_target_files_excluded_from_normalized(monkeypatch, tmp_path):
     monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
     (tmp_path / "a.py").write_text("x = 1\n", encoding="utf-8")
-    import asyncio as _aio
     # 'a.py' is BOTH a target and shows up as a caller -> must be excluded
     nb = _FakeNeighborhood(callers=["jarvis:a.py"])
-    out = _aio.run(ep.build_prefetch_manifest(
+    out = asyncio.run(ep.build_prefetch_manifest(
         target_files=("a.py", "b.py"), root=str(tmp_path),
         oracle=_FakeOracleObj(nb), goal_text="g", is_heavy=True))
     assert all(e.rel_path != "a.py" for e in out)

--- a/tests/governance/test_epistemic_prefetch.py
+++ b/tests/governance/test_epistemic_prefetch.py
@@ -1,0 +1,77 @@
+# tests/governance/test_epistemic_prefetch.py
+from __future__ import annotations
+import asyncio
+from backend.core.ouroboros.governance import epistemic_prefetch as ep
+
+
+class _FakeOracle:
+    def __init__(self, ready=True, neighborhood=None, raises=False):
+        self._ready = ready
+        self._n = neighborhood or []
+        self._raises = raises
+    def is_semantic_ready(self):
+        return self._ready
+    async def get_fused_neighborhood(self, files, query, k_semantic=8):
+        if self._raises:
+            raise RuntimeError("oracle boom")
+        return self._n
+
+
+def test_disabled_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "false")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(), goal_text="g", is_heavy=True))
+    assert out == ()
+
+
+def test_not_heavy_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py",), root=str(tmp_path),
+        oracle=_FakeOracle(), goal_text="g", is_heavy=False))
+    assert out == ()
+
+
+def test_oracle_cold_returns_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(ready=False), goal_text="g", is_heavy=True))
+    assert out == ()
+
+
+def test_oracle_exception_failsoft_empty(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(raises=True), goal_text="g", is_heavy=True))
+    assert out == ()
+
+
+def test_builds_ranked_hashed_entries(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    (tmp_path / "dep.py").write_text("def helper():\n    return 1\n", encoding="utf-8")
+    nbh = [{"rel_path": "dep.py", "score": 0.9, "category_hint": "CALL_GRAPH"}]
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(neighborhood=nbh), goal_text="g", is_heavy=True))
+    assert len(out) == 1
+    e = out[0]
+    assert e.rel_path == "dep.py"
+    assert e.sha256 != ""
+    assert e.relevance == 0.9
+    assert "helper" in e.content_excerpt
+
+
+def test_seed_byte_budget_truncates_excerpt(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PREFETCH_SEED_BYTES", "10")
+    big = "x = 1  # " + ("padding " * 50) + "\n"
+    (tmp_path / "dep.py").write_text(big, encoding="utf-8")
+    nbh = [{"rel_path": "dep.py", "score": 0.5, "category_hint": "COMPREHENSION"}]
+    out = asyncio.run(ep.build_prefetch_manifest(
+        target_files=("a.py", "b.py"), root=str(tmp_path),
+        oracle=_FakeOracle(neighborhood=nbh), goal_text="g", is_heavy=True))
+    assert out[0].content_excerpt == ""
+    assert out[0].sha256 != ""

--- a/tests/governance/test_epistemic_prefetch.py
+++ b/tests/governance/test_epistemic_prefetch.py
@@ -130,3 +130,15 @@ def test_target_files_excluded_from_normalized(monkeypatch, tmp_path):
         target_files=("a.py", "b.py"), root=str(tmp_path),
         oracle=_FakeOracleObj(nb), goal_text="g", is_heavy=True))
     assert all(e.rel_path != "a.py" for e in out)
+
+
+def test_is_heavy_goal_multifile():
+    assert ep.is_heavy_goal(("a.py", "b.py"), 0) is True
+
+
+def test_is_heavy_goal_high_blast():
+    assert ep.is_heavy_goal(("a.py",), 99) is True
+
+
+def test_is_heavy_goal_light():
+    assert ep.is_heavy_goal(("a.py",), 0) is False

--- a/tests/governance/test_epistemic_quarantine.py
+++ b/tests/governance/test_epistemic_quarantine.py
@@ -1,0 +1,63 @@
+# tests/governance/test_epistemic_quarantine.py
+from __future__ import annotations
+import json
+from pathlib import Path
+import pytest
+from backend.core.ouroboros.governance import epistemic_quarantine as eq
+
+
+def _write(p: Path, text: str) -> str:
+    p.write_text(text, encoding="utf-8")
+    return eq.sha256_of_file(str(p))
+
+
+def test_atomic_hash_matches_hashlib(tmp_path):
+    p = tmp_path / "f.py"
+    h = _write(p, "x = 1\n")
+    data, digest = eq.atomic_read_and_hash(str(p))
+    assert data == b"x = 1\n"
+    assert digest == h
+
+
+def test_atomic_hash_missing_file_returns_empty(tmp_path):
+    data, digest = eq.atomic_read_and_hash(str(tmp_path / "nope.py"))
+    assert data == b""
+    assert digest == ""
+
+
+def test_quarantine_is_session_scoped(tmp_path):
+    ledger = tmp_path / "q.jsonl"
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    led.quarantine("a.py", reason="stale")
+    assert led.is_quarantined("a.py") is True
+    led2 = eq.QuarantineLedger(path=str(ledger), session_id="S2")
+    assert led2.is_quarantined("a.py") is False
+
+
+def test_quarantine_consult_failopen_on_bad_ledger(tmp_path):
+    ledger = tmp_path / "q.jsonl"
+    ledger.write_text("{not json\n", encoding="utf-8")
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    assert led.is_quarantined("a.py") is False
+
+
+def test_reconcile_revalidates_and_drops(tmp_path):
+    f = tmp_path / "a.py"
+    h = _write(f, "v = 1\n")
+    ledger = tmp_path / "q.jsonl"
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    led.quarantine("a.py", reason="stale", root=str(tmp_path), expected_sha=h)
+    result = led.reconcile(root=str(tmp_path))
+    assert result["revalidated"] == ["a.py"]
+    assert result["dropped"] == []
+
+
+def test_reconcile_drops_when_still_drifted(tmp_path):
+    f = tmp_path / "a.py"
+    _write(f, "v = 1\n")
+    ledger = tmp_path / "q.jsonl"
+    led = eq.QuarantineLedger(path=str(ledger), session_id="S1")
+    led.quarantine("a.py", reason="stale", root=str(tmp_path), expected_sha="deadbeef")
+    result = led.reconcile(root=str(tmp_path))
+    assert result["dropped"] == ["a.py"]
+    assert result["revalidated"] == []

--- a/tests/governance/test_epistemic_quarantine.py
+++ b/tests/governance/test_epistemic_quarantine.py
@@ -1,8 +1,6 @@
 # tests/governance/test_epistemic_quarantine.py
 from __future__ import annotations
-import json
 from pathlib import Path
-import pytest
 from backend.core.ouroboros.governance import epistemic_quarantine as eq
 
 

--- a/tests/governance/test_epistemic_truth_guard.py
+++ b/tests/governance/test_epistemic_truth_guard.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+from backend.core.ouroboros.governance import epistemic_prefetch as ep
+from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
+from backend.core.ouroboros.governance.epistemic_quarantine import (
+    QuarantineLedger, sha256_of_file,
+)
+
+
+def test_revalidate_keeps_fresh_drops_stale(tmp_path):
+    f = tmp_path / "fresh.py"
+    f.write_text("x = 1\n", encoding="utf-8")
+    fresh_h = sha256_of_file(str(f))
+    s = tmp_path / "stale.py"
+    s.write_text("y = 2\n", encoding="utf-8")  # on disk now
+    manifest = (
+        PrefetchEntry("fresh.py", fresh_h, 0.9, "CALL_GRAPH", "x = 1"),
+        PrefetchEntry("stale.py", "deadbeef_wrong_hash", 0.5, "COMPREHENSION", "old"),
+        PrefetchEntry("gone.py", "anyhash", 0.4, "COMPREHENSION", "missing"),  # not on disk
+    )
+    out = ep.revalidate_manifest(manifest, str(tmp_path), ledger=None)
+    rels = {e.rel_path for e in out}
+    assert rels == {"fresh.py"}   # stale + missing dropped, fresh kept
+
+
+def test_revalidate_quarantines_stale(tmp_path):
+    s = tmp_path / "stale.py"
+    s.write_text("y = 2\n", encoding="utf-8")
+    led = QuarantineLedger(path=str(tmp_path / "q.jsonl"), session_id="S1")
+    manifest = (PrefetchEntry("stale.py", "wrong_hash", 0.5, "COMPREHENSION", "old"),)
+    ep.revalidate_manifest(manifest, str(tmp_path), ledger=led)
+    assert led.is_quarantined("stale.py") is True
+
+
+def test_revalidate_empty_is_empty():
+    assert ep.revalidate_manifest((), "/tmp", ledger=None) == ()

--- a/tests/governance/test_epistemic_venom_wire.py
+++ b/tests/governance/test_epistemic_venom_wire.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+import inspect
+from backend.core.ouroboros.governance import tool_executor
+
+
+def test_run_accepts_prefetched_candidates_and_governor_kwargs():
+    sig = inspect.signature(tool_executor.ToolLoopCoordinator.run)
+    assert "prefetched_candidates" in sig.parameters
+    assert "governor" in sig.parameters
+
+
+def test_seed_prefix_builder_is_bounded_and_labelled():
+    from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
+    entries = (PrefetchEntry("dep.py", "abc", 0.9, "CALL_GRAPH", "def f(): pass"),)
+    prefix = tool_executor._build_prefetch_seed_prefix(entries)
+    assert "dep.py" in prefix
+    assert "def f(): pass" in prefix
+    assert ("memory" in prefix.lower()) or ("pre-fetched" in prefix.lower())
+
+
+def test_seed_prefix_empty_for_no_entries():
+    assert tool_executor._build_prefetch_seed_prefix(()) == ""
+
+
+def test_seed_prefix_skips_entries_without_excerpt():
+    from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
+    entries = (PrefetchEntry("dep.py", "abc", 0.9, "CALL_GRAPH", ""),)  # no excerpt
+    prefix = tool_executor._build_prefetch_seed_prefix(entries)
+    # an entry with empty excerpt contributes no body; with only such entries the
+    # builder returns "" (nothing to seed)
+    assert prefix == "" or "dep.py" not in prefix
+
+
+def test_governance_deadlock_error_exists():
+    assert issubclass(tool_executor.GovernanceDeadlockError, Exception)

--- a/tests/governance/test_epistemic_venom_wire.py
+++ b/tests/governance/test_epistemic_venom_wire.py
@@ -25,11 +25,26 @@ def test_seed_prefix_empty_for_no_entries():
 def test_seed_prefix_skips_entries_without_excerpt():
     from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
     entries = (PrefetchEntry("dep.py", "abc", 0.9, "CALL_GRAPH", ""),)  # no excerpt
-    prefix = tool_executor._build_prefetch_seed_prefix(entries)
-    # an entry with empty excerpt contributes no body; with only such entries the
-    # builder returns "" (nothing to seed)
-    assert prefix == "" or "dep.py" not in prefix
+    # every entry lacks a body -> nothing to seed -> exactly empty string
+    assert tool_executor._build_prefetch_seed_prefix(entries) == ""
 
 
 def test_governance_deadlock_error_exists():
     assert issubclass(tool_executor.GovernanceDeadlockError, Exception)
+
+
+def test_seed_prefix_multi_entry_includes_all():
+    from backend.core.ouroboros.governance.epistemic_prefetch import PrefetchEntry
+    entries = (
+        PrefetchEntry("a.py", "h1", 0.9, "CALL_GRAPH", "def a(): pass"),
+        PrefetchEntry("b.py", "h2", 0.5, "COMPREHENSION", "def b(): pass"),
+    )
+    prefix = tool_executor._build_prefetch_seed_prefix(entries)
+    assert "a.py" in prefix and "b.py" in prefix
+    assert "def a(): pass" in prefix and "def b(): pass" in prefix
+
+
+def test_final_write_nudge_text_sentinel():
+    # the governor's converge verdict reuses this exact wording; pin the sentinel
+    txt = tool_executor._final_write_nudge_text()
+    assert "FINAL ROUND" in txt

--- a/tests/governance/test_op_context_prefetch_field.py
+++ b/tests/governance/test_op_context_prefetch_field.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+from backend.core.ouroboros.governance.op_context import OperationContext
+
+
+def test_prefetch_manifest_field_exists_with_tuple_default():
+    fields = OperationContext.__dataclass_fields__
+    assert "prefetch_manifest" in fields
+    assert fields["prefetch_manifest"].default_factory is tuple
+
+
+def test_prefetch_manifest_default_is_empty_tuple():
+    """Freshly constructed context has prefetch_manifest == ()."""
+    ctx = OperationContext.create(
+        target_files=("backend/x.py",),
+        description="test prefetch manifest default",
+    )
+    assert ctx.prefetch_manifest == ()


### PR DESCRIPTION
## Summary

**Phase 1** of the Sovereign Epistemological Context Matrix — cures the "seventh layer" heavy multi-file GOAL `tool_loop_deadline_exceeded` (Venom re-explores the codebase from scratch every op, blows the generation deadline, cascades to dead Claude → `deadline_exhausted`). The fix collapses exploration from O(N) blind search to **directed semantic retrieval backed by long-term memory**, without weakening the governance cage.

Built via subagent-driven-development (implementer + spec-compliance + code-quality review per task, plus a cross-cutting integration review). **Reuse-first:** ~70% already existed — `oracle.get_fused_neighborhood` (DAG prefetch), `state_drift` sha256 (Truth Guard precedent), Venom budgets + `per_round_observer`, the dormant ActionOutcomeMemory primitive (Phase 2).

## What's new (3 leaf modules + wiring)

- **DAG Router** (`epistemic_prefetch.py`) — on a heavy GOAL, `oracle.get_fused_neighborhood` → bounded, hash-validated `PrefetchEntry` manifest that seeds Venom so it starts *directed*. Normalizes the real `FileNeighborhood` dataclass (category lists → ranked entries, leverage-ordered).
- **Information-Gain Governor** (`context_governor.py`) — converges exploration on TF-cosine Δ-decay (sub-ms, **no model call** on the hot path), prefetch as round-0 baseline, elastic budget (env-tunable), and a one-shot Iron-Gate **deadlock breaker** that injects a directive for exactly the missing Iron-Gate categories, then fails terminal.
- **Cryptographic Truth Guard** (`epistemic_quarantine.py` + `revalidate_manifest`) — atomic read-then-hash; re-validate the manifest vs live disk at consume; drop + session-scoped quarantine stale entries; reconcile on session teardown.

## Operator-ratified resolutions (binding)
- **LR1** — prefetch excerpts seed the Δ corpus as the round-0 baseline (no Information-Gain inflation).
- **LR2** — quarantine ledger is strictly `session_id`-bound (no infinite TTL) + terminal reconciliation to the oracle.
- **LR3** — deadlock breaker = exactly one round → fatal `deadlock_override_failed` (no loop, no GENERATE_RETRY); the governor self-defends even if the coordinator skips the consume-mark.

## Cage / safety invariants preserved
- Memory **seeds** exploration; it never bypasses the Iron Gate (seed is labelled a HINT; live reads still required; `state_drift` still blocks APPLY on drift — defense in depth).
- Heavy-gated: light single-file ops are **byte-identical** regardless of flags. All flags fail-soft; OFF = byte-identical legacy.
- No change to risk tiers, OCA boundary, or merge authority.

## Gating (all default-on except Phase 2, all fail-soft)
`JARVIS_EPISTEMIC_PREFETCH_ENABLED`, `JARVIS_CONTEXT_GOVERNOR_ENABLED`, `JARVIS_GOVERNOR_DEADLOCK_BREAKER_ENABLED`, `JARVIS_ACTION_OUTCOME_MEMORY_ENABLED` (false — Phase 2).

## Test plan
- [x] 65 arc unit/integration tests green (prefetch, quarantine, governor, truth-guard, deadlock-propagation, GLS reconcile, venom-wire, orchestrator-wire, OFF byte-identical).
- [x] 141 reused-subsystem regression-spine tests green (exploration / state_drift / tool_loop / op_context).
- [x] Zero real regressions (the 2 failing nodes — an `epistemic_budget` AST-pin substring collision and a `dw_discovery` quarantine test — proven pre-existing on the base commit).
- [ ] **Operator-run live soak (GCP Spot 8-CPU):** heavy multi-file GOAL reaches `state=applied` with `tool_loop_deadline_exceeded`=0. Unit tests prove the machinery; the deadline-cure *outcome* requires a real soak on adequate hardware (cannot be proven nested).

## Notes for the reviewer
- The prefetch trigger lives inside the `context_expansion_enabled` branch — prefetch is skipped when CONTEXT_EXPANSION is disabled (acceptable: heavy GOALs normally run with expansion on; the governor still builds cold and provides info-gain convergence).
- `_NONRETRYABLE_TERMINAL_REASONS` / `_is_nonretryable_terminal()` is the authoritative registry of non-retryable terminal reason codes, now consulted by the `deadlock_override_failed` terminal path.
- Spec: `docs/superpowers/specs/2026-06-21-sovereign-epistemic-context-matrix-design.md`; plan: `docs/superpowers/plans/2026-06-21-sovereign-epistemic-context-matrix-phase1.md`.
- Phase 2 (ActionOutcomeMemory → GENERATE prompt) and the M9/M10 cognitive arcs are deferred until heavy-GOAL execution is proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds directed memory prefetch and an information‑gain governor to guide heavy multi‑file GOAL exploration, preventing `tool_loop_deadline_exceeded` without weakening safety gates. Light ops are unchanged; new logic is fail‑soft behind env flags.

- **New Features**
  - Directed DAG prefetch (`epistemic_prefetch.py`) builds a bounded, hash‑validated `PrefetchEntry` manifest with excerpts from the oracle to seed the tool loop.
  - Information‑Gain Governor (`context_governor.py`) measures round‑to‑round delta (no model calls), seeds round‑0 from prefetch, and provides a one‑shot deadlock breaker for missing safety categories.
  - Cryptographic Truth Guard and session‑scoped quarantine (`epistemic_quarantine.py`): atomic read+hash, cross‑process JSONL ledger, and reconcile on service stop; stale entries are dropped and quarantined.
  - Wiring: orchestrator triggers prefetch for heavy goals, providers build the governor for heavy ops, and the tool loop accepts `prefetched_candidates` and honors governor verdicts. Flags: `JARVIS_EPISTEMIC_PREFETCH_ENABLED`, `JARVIS_CONTEXT_GOVERNOR_ENABLED`, `JARVIS_GOVERNOR_DEADLOCK_BREAKER_ENABLED`.

- **Bug Fixes**
  - `GovernanceDeadlockError` now propagates to the orchestrator and is stamped as non‑retryable `deadlock_override_failed` instead of being swallowed by fallbacks.
  - Fixed session‑id resolution in `GovernedLoopService.stop()` to match writer logic (`get_active_session_id()`), so quarantine reconcile actually runs.

<sup>Written for commit 0c7a0a554e7e1affce120da1de24efc1ac00204d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69637?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

