### PR TITLE
feat(yield): Sovereign Async Yield Matrix — Layer 2 (graceful operator-yield, activated)

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -5126,6 +5126,22 @@ class SerpentREPL:
                     if not line:
                         continue
 
+                    # YM-T10 SEAM 3 — zero-latency operator-presence stamp.
+                    # Every non-empty human submission marks the operator as
+                    # present (a single time.monotonic() write). Lazy import +
+                    # fail-soft: this is the highest-signal human-input
+                    # boundary and must NEVER perturb REPL dispatch. No-op for
+                    # the yield feature when JARVIS_OPERATOR_YIELD_ENABLED off
+                    # (the stamp is harmless; only operator_present() reads it,
+                    # and operator_suspended() stays gated off).
+                    try:
+                        from backend.core.ouroboros.governance.operator_presence import (
+                            note_human_input,
+                        )
+                        note_human_input()
+                    except Exception:
+                        pass  # fail-soft — input dispatch is never blocked
+
                     # Gap #7 Slice 4 — @filepath mention extraction.
                     # Operators type ``@backend/auth.py do X`` and the
                     # path is auto-attached via the existing /attach

--- a/backend/core/ouroboros/governance/generate_park_wrapper.py
+++ b/backend/core/ouroboros/governance/generate_park_wrapper.py
@@ -217,6 +217,12 @@ async def maybe_park_or_resume(
     # via batch → detach. Over-parking is harmless (the continuation runs generate()
     # out-of-pool either way); under-parking re-wedges the worker. Fail-soft.
     _async_batch = _resolve_async_batch_payload(ctx, provider_route)
+    # Operator-Yield Bridge (spec §5.4, LR-B, Task 8). When the operator is
+    # active, the bridge's module suspend flag is set; we feed it into the park
+    # decision so the op parks at THIS safe checkpoint to free the worker.
+    # operator_suspended() is itself gated on JARVIS_OPERATOR_YIELD_ENABLED, so
+    # this resolves False (byte-identical) when the yield feature is off.
+    _op_suspended = _resolve_operator_suspended()
     if (
         master_on
         and pool is not None
@@ -226,8 +232,38 @@ async def maybe_park_or_resume(
             queue_pressure=queue_pressure,
             is_resumed=False,
             async_batch_payload=_async_batch,
+            operator_suspended=_op_suspended,
         )
     ):
+        # Drain-before-park (LR-B). If THIS park is happening because of the
+        # operator-yield suspend flag (and would NOT have parked otherwise),
+        # we MUST NOT park mid-mutation — await the mutation critical-section
+        # drain first. If it wedges past JARVIS_OPERATOR_YIELD_DRAIN_MAX_S,
+        # ABANDON the operator-yield park and let the op run normally (it will
+        # finish its mutation rather than be torn mid-apply). Gated; no-op when
+        # yield off (_op_suspended is False).
+        _park_is_operator_yield = (
+            _op_suspended
+            and not should_park_for_route(
+                provider_route,
+                queue_pressure=queue_pressure,
+                is_resumed=False,
+                async_batch_payload=_async_batch,
+                operator_suspended=False,
+            )
+        )
+        if _park_is_operator_yield:
+            _drained = await _drain_before_operator_park(ctx_op_id)
+            if not _drained:
+                logger.warning(
+                    "[OperatorYield] drain abandoned op=%s — not parking "
+                    "mid-mutation; op continues normally",
+                    ctx_op_id,
+                )
+                return await asyncio.wait_for(
+                    orch._generator.generate(ctx, deadline),
+                    timeout=gen_timeout + outer_grace_s,
+                )
         # Determine attempt_seq.  For the first GENERATE call this is
         # 1; GENERATE_RETRY would bump this.  We resolve via the BG
         # op's ``park_attempt_seq`` (which the worker bumps on each
@@ -291,6 +327,55 @@ async def maybe_park_or_resume(
 # ---------------------------------------------------------------------------
 # Internals — kept here so the seam logic is one file, easy to review
 # ---------------------------------------------------------------------------
+
+
+def _resolve_operator_suspended() -> bool:
+    """True iff the operator-yield bridge has its suspend flag set (and the
+    yield feature is enabled). Resolved fresh each call. NEVER raises — on any
+    failure returns False (byte-identical legacy behaviour)."""
+    try:
+        from backend.core.ouroboros.governance.operator_yield_bridge import (
+            operator_suspended,
+        )
+        return bool(operator_suspended())
+    except Exception:  # noqa: BLE001 — never raise from the park gate
+        return False
+
+
+def _operator_yield_drain_max_s() -> float:
+    """Resolved JARVIS_OPERATOR_YIELD_DRAIN_MAX_S (default 30s). Read at call
+    time; invalid values fall back to the default. Never raises."""
+    try:
+        raw = os.environ.get("JARVIS_OPERATOR_YIELD_DRAIN_MAX_S", "")
+        if not raw:
+            return 30.0
+        v = float(raw)
+        return v if v > 0 else 30.0
+    except (TypeError, ValueError):
+        return 30.0
+
+
+async def _drain_before_operator_park(ctx_op_id: str) -> bool:
+    """Await the mutation critical-section drain before an operator-yield park.
+
+    Returns True if the op has no in-flight mutation (safe to park) or drained
+    within the timeout; False if it wedged past JARVIS_OPERATOR_YIELD_DRAIN_MAX_S
+    (caller MUST abandon the park — never park mid-mutation). Fail-soft: any
+    bookkeeping error fails OPEN to True (drained) — the drain guard exists to
+    prevent tearing a mutation, and if its own machinery is unavailable we defer
+    to the existing park semantics rather than wedge the op."""
+    try:
+        from backend.core.ouroboros.governance.mutation_critical_section import (
+            drain,
+        )
+        return await drain(ctx_op_id, _operator_yield_drain_max_s())
+    except Exception:  # noqa: BLE001 — fail-open to "drained"
+        logger.debug(
+            "[OperatorYield] drain machinery unavailable for op=%s; "
+            "fail-open to drained",
+            ctx_op_id, exc_info=True,
+        )
+        return True
 
 
 def _resolve_async_batch_payload(ctx: Any, provider_route: str) -> bool:

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1122,6 +1122,12 @@ class GovernedLoopService:
         self._oracle_indexer_task: Optional[asyncio.Task] = None
         self._oracle: Optional[Any] = None
 
+        # YM-T10 SEAM 1 — Sovereign Daemon Injection Protocol (Layer 2).
+        # Strong ref to the operator-presence watcher daemon so it is not GC'd
+        # while running; cancelled in stop(). Spawn + attach are fail-soft and
+        # no-op when JARVIS_OPERATOR_YIELD_ENABLED is off (byte-identical).
+        self._operator_presence_task: Optional[asyncio.Task] = None
+
         # C+ autonomy infrastructure
         self._command_bus: Optional[CommandBus] = None
         self._event_emitter: Optional[EventEmitter] = None
@@ -1511,6 +1517,16 @@ class GovernedLoopService:
             # Master-flag-gated by each observer's own substrate flags;
             # fail-open per observer; never blocks the loop.
             await self._start_governance_observers()
+
+            # YM-T10 SEAM 1 — non-blocking daemon boot of the Layer-2
+            # operator-presence watcher + yield bridge. The pool (_bg_pool) is
+            # built in _build_components() earlier in start(); the bus self-
+            # resolves via get_event_bus_if_exists() (bus=None). Both the
+            # watcher .run() and bridge .attach() are already no-op when
+            # JARVIS_OPERATOR_YIELD_ENABLED is off, so this is byte-identical
+            # when the flag is off. Hard requirement: the watcher/attach must
+            # NEVER prevent or crash boot — the helper wraps both fail-soft.
+            await self._start_operator_yield_layer()
 
             # Wave 3 (6) Slice 5a — register parallel-dispatch env flags into
             # the FlagRegistry so `/help flags --search parallel_dispatch`
@@ -2084,6 +2100,21 @@ class GovernedLoopService:
             except asyncio.CancelledError:
                 pass
 
+        # YM-T10 SEAM 1 — cancel the operator-presence watcher daemon
+        # alongside the other background tasks. Fail-soft.
+        _op_pres_task = getattr(self, "_operator_presence_task", None)
+        if _op_pres_task is not None and not _op_pres_task.done():
+            _op_pres_task.cancel()
+            try:
+                await _op_pres_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001 — never block shutdown
+                logger.debug(
+                    "[GovernedLoop] operator-presence task cancel swallowed",
+                    exc_info=True,
+                )
+
         # Slice 5 Arc A — stop PostureObserver cleanly (no orphan tasks)
         observer = getattr(self, "_posture_observer", None)
         if observer is not None:
@@ -2179,6 +2210,74 @@ class GovernedLoopService:
         self._detach_from_stack()
         self._state = ServiceState.INACTIVE
         logger.info("[GovernedLoop] Stopped")
+
+    # ------------------------------------------------------------------
+    # YM-T10 SEAM 1 — Sovereign Daemon Injection Protocol (Layer 2)
+    # ------------------------------------------------------------------
+
+    async def _start_operator_yield_layer(self) -> None:
+        """Spawn the operator-presence watcher daemon + attach the yield bridge.
+
+        Layer-2 production activation (YM-T10 SEAM 1). Two independent,
+        fully fail-soft steps:
+
+          1. Spawn ``OperatorPresenceWatcher().run(bus=None)`` as a background
+             daemon task (mirrors the oracle/health-probe ``create_task``
+             pattern). A strong ref is stored on ``self`` so the task is not
+             GC'd; it is cancelled in ``stop()``.
+          2. ``await operator_yield_bridge.attach(bus=None, pool=self._bg_pool)``
+             once during boot, after the pool exists.
+
+        Both ``run()`` and ``attach()`` are already no-op when
+        ``JARVIS_OPERATOR_YIELD_ENABLED`` is off, and they self-resolve the
+        TrinityEventBus singleton when ``bus=None`` — so this method is
+        byte-identical to pre-YM-T10 when the flag is off.
+
+        HARD REQUIREMENT: nothing here may prevent or crash boot. Every step
+        is wrapped so a failure logs + degrades; the main loop runs regardless.
+        """
+        pool = getattr(self, "_bg_pool", None)
+
+        # Step 1 — spawn the watcher daemon (fail-soft).
+        try:
+            from backend.core.ouroboros.governance.operator_presence import (
+                OperatorPresenceWatcher,
+            )
+
+            watcher = OperatorPresenceWatcher()
+            self._operator_presence_task = asyncio.create_task(
+                watcher.run(bus=None),
+                name="operator_presence_watcher",
+            )
+            logger.info(
+                "[GovernedLoop] Operator-presence watcher daemon spawned "
+                "(YM-T10 SEAM 1; no-op when JARVIS_OPERATOR_YIELD_ENABLED off)",
+            )
+        except Exception:  # noqa: BLE001 — watcher must NEVER crash boot
+            logger.warning(
+                "[GovernedLoop] Operator-presence watcher spawn failed "
+                "(non-fatal; loop continues)",
+                exc_info=True,
+            )
+            self._operator_presence_task = None
+
+        # Step 2 — attach the yield bridge (fail-soft, independent of step 1).
+        try:
+            from backend.core.ouroboros.governance import (
+                operator_yield_bridge as _oyb,
+            )
+
+            await _oyb.attach(bus=None, pool=pool)
+            logger.info(
+                "[GovernedLoop] Operator-yield bridge attach() invoked "
+                "(YM-T10 SEAM 1; no-op when yield off)",
+            )
+        except Exception:  # noqa: BLE001 — attach must NEVER crash boot
+            logger.warning(
+                "[GovernedLoop] Operator-yield bridge attach failed "
+                "(non-fatal; loop continues)",
+                exc_info=True,
+            )
 
     # ------------------------------------------------------------------
     # Tier 0.5 batch 1 — governance observer boot/shutdown helpers

--- a/backend/core/ouroboros/governance/mutation_critical_section.py
+++ b/backend/core/ouroboros/governance/mutation_critical_section.py
@@ -1,0 +1,80 @@
+"""Mutation critical-section guard (spec 5.4 / LR-B).
+
+The operator-yield must never park an op while a critical state mutation
+(write_file/edit_file/ChangeEngine.execute/git commit) is in flight, or the FSM
+would rehydrate from a half-applied checkpoint. This is a per-op re-entrant
+async section + a drain() the yield path awaits before parking. Pure stdlib +
+asyncio. Never raises out of the public API.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from contextlib import asynccontextmanager
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+_counts: Dict[str, int] = {}
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def is_mutating(op_id: str) -> bool:
+    """True iff op_id is inside >=1 active mutation section. Never raises."""
+    try:
+        return _counts.get(str(op_id), 0) > 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
+@asynccontextmanager
+async def mutation_section(op_id: str):
+    """Re-entrant per-op critical section around a state mutation. Increments on
+    enter, decrements on exit (even on exception). Never swallows the body's
+    exception."""
+    key = str(op_id)
+    _counts[key] = _counts.get(key, 0) + 1
+    try:
+        yield
+    finally:
+        n = _counts.get(key, 0) - 1
+        if n <= 0:
+            _counts.pop(key, None)
+        else:
+            _counts[key] = n
+
+
+@asynccontextmanager
+async def maybe_mutation_section(op_id: str):
+    """Gated wrapper around mutation_section. When JARVIS_OPERATOR_YIELD_ENABLED
+    is on, enters a real mutation section; otherwise a cheap no-op so the
+    instrumented call site is byte-identical in behavior with the feature off."""
+    enabled = (os.environ.get("JARVIS_OPERATOR_YIELD_ENABLED", "false") or "").strip().lower() in _TRUTHY
+    if enabled:
+        async with mutation_section(op_id):
+            yield
+    else:
+        yield
+
+
+async def drain(op_id: str, timeout: float, poll_s: float = 0.02) -> bool:
+    """Wait until op_id has no active mutation section, up to `timeout` seconds.
+    Returns True if it drained (safe to park), False if it wedged past the
+    timeout (caller must ABANDON the yield — never park a half-applied op).
+    Never raises."""
+    key = str(op_id)
+    try:
+        loop = asyncio.get_event_loop()
+        deadline = loop.time() + max(0.0, float(timeout))
+        while is_mutating(key):
+            if loop.time() >= deadline:
+                logger.warning(
+                    "[MutationSection] drain abandoned op=%s (wedged > %.2fs)", key, timeout
+                )
+                return False
+            await asyncio.sleep(poll_s)
+        return True
+    except Exception:  # noqa: BLE001 — drain must not crash the yield path
+        return True  # fail-open to "drained" only if our own bookkeeping errors

--- a/backend/core/ouroboros/governance/op_park_store.py
+++ b/backend/core/ouroboros/governance/op_park_store.py
@@ -139,6 +139,15 @@ _DEFAULT_PARK_ROUTES = frozenset({"background", "complex"})
 # because the batch-strangle wedge proved 'standard' diff-codegen needs it too.
 _BATCH_CAPABLE_ROUTES = frozenset({"standard", "complex", "background"})
 
+# Routes the park/resume machinery actually supports — the union of the
+# throughput-park routes (background/complex) and the batch-capable routes
+# (standard/complex/background). Used by the operator-yield path: when the
+# operator becomes active the op parks on ANY of these (the resume
+# continuation + submit_for_resume can rehydrate them). IMMEDIATE/SPECULATIVE
+# are deliberately excluded — they have no resume continuation path, so
+# parking them would strand the op.
+_PARK_SUPPORTED_ROUTES = _DEFAULT_PARK_ROUTES | _BATCH_CAPABLE_ROUTES
+
 
 def _resolved_park_routes() -> frozenset:
     """Resolve the set of routes eligible for parking. Read at call time.
@@ -161,6 +170,7 @@ def should_park_for_route(
     queue_pressure: bool,
     is_resumed: bool = False,
     async_batch_payload: bool = False,
+    operator_suspended: bool = False,
 ) -> bool:
     """Single source of truth for "should this op park before its
     provider await?"  Pure function — no I/O, no side effects.
@@ -195,6 +205,17 @@ def should_park_for_route(
         ``True`` iff this dispatch is a resume-after-park.  Resumed
         dispatches MUST NOT re-park (would loop indefinitely); they
         materialize from the store and proceed.
+    operator_suspended:
+        ``True`` iff the operator-yield bridge (spec §5.4, LR-B) has
+        observed an ``operator.active`` edge and set its module suspend
+        flag.  When set, the op parks at its next SAFE checkpoint —
+        regardless of queue pressure — so the worker slot is freed for
+        the duration of operator activity.  Only routes the park/resume
+        machinery actually supports (``_PARK_SUPPORTED_ROUTES``) honour
+        this; IMMEDIATE/SPECULATIVE never park (no resume continuation).
+        ``is_resumed`` still wins (a resumed dispatch never re-parks).
+        Caller resolves this from ``operator_yield_bridge.operator_suspended()``
+        which is itself gated on ``JARVIS_OPERATOR_YIELD_ENABLED``.
 
     Returns
     -------
@@ -213,6 +234,20 @@ def should_park_for_route(
         return False
     if is_resumed:
         return False
+    # Operator-Yield Bridge (spec §5.4, LR-B). When the operator becomes
+    # active, the loop must gracefully PARK its op at the next SAFE checkpoint
+    # to free the worker for the human — regardless of queue pressure (no one
+    # need be waiting; the point is to yield the slot, not to optimize
+    # throughput). Honoured only on routes the park/resume machinery supports
+    # (the union of batch-capable + throughput-park routes); IMMEDIATE/
+    # SPECULATIVE have no resume continuation and so never park here. The
+    # drain-before-park (mutation_critical_section.drain) is enforced at the
+    # park-emit seam (generate_park_wrapper), NOT here — this remains a pure
+    # decision function. Caller gates `operator_suspended` on
+    # JARVIS_OPERATOR_YIELD_ENABLED, so this is byte-identical when the yield
+    # feature is off (the param defaults False).
+    if operator_suspended:
+        return (provider_route or "").strip().lower() in _PARK_SUPPORTED_ROUTES
     # Sovereign Transport Profiler Matrix (2026-06-20) — ACTIVE DETACHMENT.
     # An ASYNC_BATCH_PAYLOAD op MUST park regardless of queue pressure: its
     # provider call is a minutes-long async batch poll, so holding the worker slot

--- a/backend/core/ouroboros/governance/operator_presence.py
+++ b/backend/core/ouroboros/governance/operator_presence.py
@@ -1,0 +1,238 @@
+"""Deterministic operator-presence detector + edge-triggered event watcher (spec §5.3).
+
+Design constraints
+------------------
+* DETERMINISTIC only — no CAI/LLM call in the presence decision.
+* Edge-triggered publishing — emits operator.active / operator.idle only on state
+  transition; never repeats the same topic twice in a row (no level-spam).
+* Default-off — the long-running ``run()`` loop returns immediately unless
+  ``JARVIS_OPERATOR_YIELD_ENABLED`` is true.
+* Fail-soft throughout — a missing/unavailable bus never raises; a misbehaving
+  liveness probe is treated as absent (False).
+* Injected bus support — ``run_once`` and ``run`` accept an optional ``bus``
+  argument so callers (and tests) can supply a fake without touching globals.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Topic constants (public API)
+# ---------------------------------------------------------------------------
+
+EVENT_OPERATOR_ACTIVE: str = "operator.active"
+EVENT_OPERATOR_IDLE: str = "operator.idle"
+
+# ---------------------------------------------------------------------------
+# Module-level last-human-input timestamp (monotonic)
+# ---------------------------------------------------------------------------
+
+_last_input: float = 0.0  # never present by default until first note_human_input()
+
+
+def note_human_input() -> None:
+    """Stamp the current monotonic time as the most recent human-input moment.
+
+    Call this from the intake layer / REPL whenever the human sends a message.
+    Thread-safe via the GIL (float assignment is atomic in CPython).
+    """
+    global _last_input
+    _last_input = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Pure detection helpers
+# ---------------------------------------------------------------------------
+
+def _idle_threshold_s() -> float:
+    """Read JARVIS_OPERATOR_IDLE_S from env; default 45s."""
+    try:
+        return float(os.environ.get("JARVIS_OPERATOR_IDLE_S", "45"))
+    except (ValueError, TypeError):
+        return 45.0
+
+
+def _is_present(
+    last_input_monotonic: float,
+    now: float,
+    liveness: Optional[Callable[[], bool]] = None,
+) -> bool:
+    """Pure, deterministic presence test.
+
+    Returns True iff the operator is considered present.
+
+    Args:
+        last_input_monotonic: ``time.monotonic()`` value of the last human input.
+        now: Current ``time.monotonic()`` value.
+        liveness: Optional callable; if it returns truthy the operator is
+                  considered present regardless of the input timestamp.
+                  Exceptions from the probe are swallowed (fail-soft → False).
+    """
+    # Check liveness probe first — it can override a stale timestamp.
+    if liveness is not None:
+        try:
+            if liveness():
+                return True
+        except Exception:  # noqa: BLE001 — fail-soft
+            pass
+
+    elapsed = now - last_input_monotonic
+    return elapsed < _idle_threshold_s()
+
+
+def operator_present(liveness: Optional[Callable[[], bool]] = None) -> bool:
+    """Convenience wrapper using the module-level ``_last_input`` timestamp."""
+    return _is_present(
+        last_input_monotonic=_last_input,
+        now=time.monotonic(),
+        liveness=liveness,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Watcher class
+# ---------------------------------------------------------------------------
+
+_UNSET = object()  # sentinel for "no prior state"
+
+
+class OperatorPresenceWatcher:
+    """Edge-triggered operator-presence watcher.
+
+    Holds the last-emitted state and publishes ``operator.active`` /
+    ``operator.idle`` events on the TrinityEventBus only when the state
+    transitions.
+    """
+
+    def __init__(self) -> None:
+        self._last_state: object = _UNSET  # True | False | _UNSET
+
+    # ------------------------------------------------------------------
+    # Edge-trigger logic (pure, testable without async)
+    # ------------------------------------------------------------------
+
+    def _transition(self, present: bool) -> Optional[str]:
+        """Return the event topic string if the state changed, else None.
+
+        Args:
+            present: Current computed presence value.
+
+        Returns:
+            ``EVENT_OPERATOR_ACTIVE`` / ``EVENT_OPERATOR_IDLE`` on transition;
+            ``None`` when state is unchanged (no level-spam).
+        """
+        if self._last_state is _UNSET or self._last_state != present:
+            self._last_state = present
+            return EVENT_OPERATOR_ACTIVE if present else EVENT_OPERATOR_IDLE
+        return None
+
+    # ------------------------------------------------------------------
+    # Async publishing
+    # ------------------------------------------------------------------
+
+    async def run_once(
+        self,
+        bus: object = None,
+        liveness: Optional[Callable[[], bool]] = None,
+    ) -> None:
+        """Evaluate presence once; publish to *bus* if state changed.
+
+        Args:
+            bus: A TrinityEventBus instance (or a fake with an async
+                 ``publish(event, persist=...)`` method).  When None the
+                 real singleton is resolved via ``get_event_bus_if_exists()``.
+            liveness: Optional callable; forwarded to ``_is_present``.
+        """
+        present = _is_present(
+            last_input_monotonic=_last_input,
+            now=time.monotonic(),
+            liveness=liveness,
+        )
+        topic = self._transition(present)
+        if topic is None:
+            return  # no state change → nothing to publish
+
+        effective_bus = bus if bus is not None else _get_bus()
+        if effective_bus is None:
+            logger.debug("[OperatorPresence] No bus available; skipping publish of %s", topic)
+            return
+
+        try:
+            from backend.core.trinity_event_bus import (
+                EventPriority,
+                RepoType,
+                TrinityEvent,
+            )
+
+            event = TrinityEvent(
+                topic=topic,
+                source=RepoType.JARVIS,
+                priority=EventPriority.NORMAL,
+                payload={
+                    "present": present,
+                    "last_input_monotonic": _last_input,
+                    "source": "operator_presence_watcher",
+                },
+            )
+            await effective_bus.publish(event, persist=False)
+            logger.debug("[OperatorPresence] Published %s", topic)
+        except Exception:  # noqa: BLE001 — fail-soft
+            logger.debug("[OperatorPresence] publish failed (fail-soft)", exc_info=True)
+
+    async def run(
+        self,
+        bus: object = None,
+        liveness: Optional[Callable[[], bool]] = None,
+        interval_s: float = 5.0,
+    ) -> None:
+        """Polling loop — calls ``run_once`` on *interval_s* cadence.
+
+        Returns immediately (no-op) when ``JARVIS_OPERATOR_YIELD_ENABLED``
+        is not set to a truthy value.
+
+        Args:
+            bus: Bus instance to publish to (injected for tests).
+            liveness: Optional liveness probe forwarded to each ``run_once``.
+            interval_s: Seconds between presence checks.
+        """
+        if not _enabled():
+            logger.debug("[OperatorPresence] JARVIS_OPERATOR_YIELD_ENABLED=false; watcher inactive")
+            return
+
+        logger.info("[OperatorPresence] Starting presence watcher (interval=%.1fs)", interval_s)
+        try:
+            while True:
+                await self.run_once(bus=bus, liveness=liveness)
+                await asyncio.sleep(interval_s)
+        except asyncio.CancelledError:
+            logger.debug("[OperatorPresence] Watcher cancelled")
+            raise
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _enabled() -> bool:
+    """Return True when JARVIS_OPERATOR_YIELD_ENABLED is truthy."""
+    val = os.environ.get("JARVIS_OPERATOR_YIELD_ENABLED", "false").lower()
+    return val in ("true", "1", "yes", "on")
+
+
+def _get_bus() -> Optional[object]:
+    """Return the real bus singleton without creating one.
+
+    Uses ``get_event_bus_if_exists()`` which is non-async and side-effect-free.
+    Falls back to None when the bus is not yet initialised.
+    """
+    try:
+        from backend.core.trinity_event_bus import get_event_bus_if_exists
+        return get_event_bus_if_exists()
+    except Exception:  # noqa: BLE001
+        return None

--- a/backend/core/ouroboros/governance/operator_yield_bridge.py
+++ b/backend/core/ouroboros/governance/operator_yield_bridge.py
@@ -1,0 +1,262 @@
+"""Operator-Yield Bridge — spec §5.4, LR-B (Task 8).
+
+Wires operator-presence edges into the EXISTING cooperative park/resume
+machinery so the autonomous loop gracefully yields its worker to the human:
+
+* ``operator.active``  → set a module SUSPEND FLAG.  The op's next
+  park-decision point (``op_park_store.should_park_for_route(...,
+  operator_suspended=True)``) then parks at the next SAFE checkpoint —
+  never mid-mutation (the drain-before-park guard at the park-emit seam,
+  ``generate_park_wrapper``, awaits ``mutation_critical_section.drain`` first).
+  The governor hard-zero (Task 7) already blocks NEW ops, so the worker is
+  freed for the operator.
+* ``operator.idle``    → clear the flag + RESUME parked ops via
+  ``BackgroundAgentPool.submit_for_resume`` (enumerated from the pool's
+  ``status == "parked"`` ops).
+
+Architectural reality (READ + confirmed): the existing park is COOPERATIVE —
+there is NO safe way to preempt an arbitrary mid-op point.  An op parks only
+when it REACHES its park-decision point and the decision returns True.  So the
+only viable cross-op trigger is a shared SUSPEND FLAG that the decision point
+reads.  This module owns that flag.  This is the intended design, not a
+work-around (see spec §5.4).
+
+Discipline
+----------
+* Gated on ``JARVIS_OPERATOR_YIELD_ENABLED`` (default false) — byte-identical
+  no-op when off: ``operator_suspended()`` reports False and the event
+  handlers / ``attach`` short-circuit.
+* Fail-soft throughout — a missing bus/pool, a misbehaving handler, or a
+  ``submit_for_resume`` failure never raises out of the public API.
+* Imports only the substrate (``op_park_store`` indirectly via the decision
+  function param, the presence topic constants) + stdlib.  Does NOT import the
+  orchestrator or the BG pool class — the pool is duck-typed.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Optional
+
+from backend.core.ouroboros.governance.operator_presence import (
+    EVENT_OPERATOR_ACTIVE,
+    EVENT_OPERATOR_IDLE,
+)
+
+logger = logging.getLogger("Ouroboros.OperatorYieldBridge")
+
+_ENV_MASTER = "JARVIS_OPERATOR_YIELD_ENABLED"
+_TRUTHY = {"true", "1", "yes", "on"}
+
+# Module-level suspend flag. Set True on operator.active, cleared on
+# operator.idle. Read by `operator_suspended()` (which also gates on the
+# master flag). Plain bool assignment is atomic under the GIL.
+_suspended: bool = False
+
+
+# ---------------------------------------------------------------------------
+# Gating
+# ---------------------------------------------------------------------------
+
+
+def _enabled() -> bool:
+    """True iff JARVIS_OPERATOR_YIELD_ENABLED is truthy. Read at call time."""
+    return (os.environ.get(_ENV_MASTER, "false") or "").strip().lower() in _TRUTHY
+
+
+# ---------------------------------------------------------------------------
+# Flag surface
+# ---------------------------------------------------------------------------
+
+
+def operator_suspended() -> bool:
+    """Return True iff the loop should park ops to yield to the operator.
+
+    Gated on the master flag: when ``JARVIS_OPERATOR_YIELD_ENABLED`` is off
+    this ALWAYS returns False (byte-identical to pre-Task-8), regardless of the
+    raw flag value. Never raises.
+    """
+    try:
+        return _enabled() and _suspended
+    except Exception:  # noqa: BLE001 — fail-soft
+        return False
+
+
+def set_operator_active() -> None:
+    """Set the suspend flag (raw — not gated). Fail-soft."""
+    global _suspended
+    try:
+        _suspended = True
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def set_operator_idle() -> None:
+    """Clear the suspend flag (raw — not gated). Fail-soft."""
+    global _suspended
+    try:
+        _suspended = False
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Event handlers
+# ---------------------------------------------------------------------------
+
+
+async def on_operator_active(event: Any = None, *, pool: Any = None) -> None:
+    """Handle an ``operator.active`` edge.
+
+    Sets the suspend flag so the next park-decision point parks the in-flight
+    op at its next SAFE checkpoint (the actual safe-park + drain happen at the
+    park-emit seam). Does NOT itself touch any op — the cooperative checkpoint
+    model owns the park. No-op when the yield feature is disabled. Fail-soft.
+    """
+    if not _enabled():
+        return
+    try:
+        set_operator_active()
+        logger.info(
+            "[OperatorYield] operator.active — suspend flag SET; in-flight op "
+            "will park at next safe checkpoint (worker yields to operator)"
+        )
+    except Exception:  # noqa: BLE001 — fail-soft
+        logger.debug("[OperatorYield] on_operator_active failed (fail-soft)", exc_info=True)
+
+
+async def on_operator_idle(event: Any = None, *, pool: Any = None) -> None:
+    """Handle an ``operator.idle`` edge.
+
+    Clears the suspend flag, then resumes every currently-parked op by
+    re-submitting it via ``pool.submit_for_resume``. Ops already in a resume
+    dispatch are skipped (no double-resume). No-op when the yield feature is
+    disabled. Fail-soft — a single op's resume failure never aborts the rest.
+    """
+    if not _enabled():
+        return
+    try:
+        set_operator_idle()
+    except Exception:  # noqa: BLE001
+        pass
+    resumed = 0
+    try:
+        for ctx, attempt_seq in _enumerate_parked(pool):
+            try:
+                await pool.submit_for_resume(ctx, attempt_seq=attempt_seq)
+                resumed += 1
+            except Exception:  # noqa: BLE001 — one bad op never blocks the rest
+                logger.warning(
+                    "[OperatorYield] submit_for_resume failed for op=%s "
+                    "(continuing)",
+                    str(getattr(ctx, "op_id", "?")),
+                    exc_info=True,
+                )
+    except Exception:  # noqa: BLE001 — fail-soft
+        logger.debug("[OperatorYield] on_operator_idle enumerate failed (fail-soft)", exc_info=True)
+    logger.info(
+        "[OperatorYield] operator.idle — suspend flag CLEARED; resumed %d "
+        "parked op(s)",
+        resumed,
+    )
+
+
+def _enumerate_parked(pool: Any):
+    """Yield ``(ctx, attempt_seq)`` for each parked op the pool tracks.
+
+    Reads ``pool.list_all()`` and selects ops with ``status == "parked"`` whose
+    ctx is not already in a resume dispatch (``pool.is_resumed_dispatch``).
+    Never raises — a malformed pool yields nothing.
+    """
+    if pool is None:
+        return
+    try:
+        ops = pool.list_all()
+    except Exception:  # noqa: BLE001
+        return
+    for op in ops or ():
+        try:
+            if str(getattr(op, "status", "") or "") != "parked":
+                continue
+            ctx = getattr(op, "context", None)
+            if ctx is None:
+                continue
+            ctx_op_id = str(getattr(ctx, "op_id", "") or "")
+            if not ctx_op_id:
+                continue
+            try:
+                if pool.is_resumed_dispatch(ctx_op_id):
+                    continue  # already resuming — no double-dispatch
+            except Exception:  # noqa: BLE001
+                pass
+            attempt_seq = max(1, int(getattr(op, "park_attempt_seq", 1) or 1))
+            yield ctx, attempt_seq
+        except Exception:  # noqa: BLE001
+            continue
+
+
+# ---------------------------------------------------------------------------
+# Bus attach
+# ---------------------------------------------------------------------------
+
+
+async def attach(bus: Any = None, pool: Any = None) -> None:
+    """Subscribe the two handlers to the operator-presence topics.
+
+    No-op when the yield feature is disabled (nothing subscribed). Resolves the
+    real bus singleton via ``get_event_bus_if_exists()`` when ``bus`` is None.
+    Binds ``pool`` into each handler via a small closure so the handler signature
+    matches the bus's ``handler(event)`` contract. Fail-soft — any subscribe
+    failure is logged and swallowed (the loop still runs, just without yield).
+    """
+    if not _enabled():
+        logger.debug("[OperatorYield] JARVIS_OPERATOR_YIELD_ENABLED=false; bridge inactive")
+        return
+
+    effective_bus = bus if bus is not None else _get_bus()
+    if effective_bus is None:
+        logger.debug("[OperatorYield] No bus available; bridge not attached")
+        return
+
+    resolved_pool = pool if pool is not None else _get_pool()
+
+    async def _active_handler(event: Any = None) -> None:
+        await on_operator_active(event, pool=resolved_pool)
+
+    async def _idle_handler(event: Any = None) -> None:
+        await on_operator_idle(event, pool=resolved_pool)
+
+    try:
+        await effective_bus.subscribe(EVENT_OPERATOR_ACTIVE, _active_handler)
+        await effective_bus.subscribe(EVENT_OPERATOR_IDLE, _idle_handler)
+        logger.info(
+            "[OperatorYield] attached: subscribed to %s / %s",
+            EVENT_OPERATOR_ACTIVE, EVENT_OPERATOR_IDLE,
+        )
+    except Exception:  # noqa: BLE001 — fail-soft
+        logger.debug("[OperatorYield] attach failed (fail-soft)", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Singleton resolution helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_bus() -> Optional[Any]:
+    """Resolve the real TrinityEventBus without creating one. None on failure."""
+    try:
+        from backend.core.trinity_event_bus import get_event_bus_if_exists
+        return get_event_bus_if_exists()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _get_pool() -> Optional[Any]:
+    """Resolve the bound BG pool without creating one. None on failure."""
+    try:
+        from backend.core.ouroboros.governance._governance_state import (
+            get_bound_bg_pool,
+        )
+        return get_bound_bg_pool()
+    except Exception:  # noqa: BLE001
+        return None

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -65,6 +65,9 @@ from backend.core.ouroboros.governance.change_engine import (
     ChangeRequest,
     ChangeResult,
 )
+from backend.core.ouroboros.governance.mutation_critical_section import (
+    maybe_mutation_section,
+)
 from backend.core.ouroboros.governance.ledger import LedgerEntry, OperationState
 from backend.core.ouroboros.governance.learning_bridge import OperationOutcome
 from backend.core.ouroboros.governance.cost_governor import (
@@ -8968,9 +8971,13 @@ class GovernedOrchestrator:
             if len(_candidate_files) > 1:
                 _t_apply = time.monotonic()
                 try:
-                    change_result = await self._apply_multi_file_candidate(
-                        ctx, best_candidate, _candidate_files, snapshots,
-                    )
+                    # LR-B (spec 5.4): mark the on-disk multi-file apply as a
+                    # critical mutation so the operator-yield drains before it
+                    # can park the op mid-batch (no-op when the yield is off).
+                    async with maybe_mutation_section(ctx.op_id):
+                        change_result = await self._apply_multi_file_candidate(
+                            ctx, best_candidate, _candidate_files, snapshots,
+                        )
                 except Exception as exc:
                     logger.error(
                         "Multi-file change engine raised for %s: %s", ctx.op_id, exc
@@ -8993,7 +9000,11 @@ class GovernedOrchestrator:
                 change_request = self._build_change_request(ctx, best_candidate)
                 _t_apply = time.monotonic()
                 try:
-                    change_result = await self._stack.change_engine.execute(change_request)
+                    # LR-B (spec 5.4): mark the on-disk single-file apply as a
+                    # critical mutation so the operator-yield drains before it
+                    # can park the op mid-write (no-op when the yield is off).
+                    async with maybe_mutation_section(ctx.op_id):
+                        change_result = await self._stack.change_engine.execute(change_request)
                 except Exception as exc:
                     logger.error(
                         "Change engine raised for %s: %s", ctx.op_id, exc
@@ -9601,22 +9612,26 @@ class GovernedOrchestrator:
                     _in_tok = getattr(_gen, "total_input_tokens", 0) or 0
                     _out_tok = getattr(_gen, "total_output_tokens", 0) or 0
                     _cost = (_in_tok * 0.0000001 + _out_tok * 0.0000004)  # rough estimate
-                _commit_result = await asyncio.wait_for(
-                    _committer.commit(
-                        op_id=ctx.op_id,
-                        description=ctx.description,
-                        target_files=ctx.target_files,
-                        risk_tier=ctx.risk_tier,
-                        provider_name=_provider,
-                        generation_cost=_cost,
-                        # Mythos §7.4: originating signal + rationale for
-                        # zero-context reviewers.
-                        signal_source=getattr(ctx, "signal_source", ""),
-                        signal_urgency=getattr(ctx, "signal_urgency", ""),
-                        rationale=ctx.description,
-                    ),
-                    timeout=30.0,
-                )
+                # LR-B (spec 5.4): the git commit is a critical mutation —
+                # an in-progress commit must not be parked by the
+                # operator-yield (no-op when the yield is off).
+                async with maybe_mutation_section(ctx.op_id):
+                    _commit_result = await asyncio.wait_for(
+                        _committer.commit(
+                            op_id=ctx.op_id,
+                            description=ctx.description,
+                            target_files=ctx.target_files,
+                            risk_tier=ctx.risk_tier,
+                            provider_name=_provider,
+                            generation_cost=_cost,
+                            # Mythos §7.4: originating signal + rationale for
+                            # zero-context reviewers.
+                            signal_source=getattr(ctx, "signal_source", ""),
+                            signal_urgency=getattr(ctx, "signal_urgency", ""),
+                            rationale=ctx.description,
+                        ),
+                        timeout=30.0,
+                    )
                 if _commit_result.committed:
                     _committed_hash = _commit_result.commit_hash
                     try:

--- a/backend/core/ouroboros/governance/sensor_governor.py
+++ b/backend/core/ouroboros/governance/sensor_governor.py
@@ -1033,7 +1033,22 @@ def get_default_governor() -> SensorGovernor:
     global _default_governor
     with _singleton_lock:
         if _default_governor is None:
-            _default_governor = SensorGovernor()
+            # YM-T10 SEAM 2 — Governor DI (the hard-zero link).
+            # Wire the deterministic operator-presence probe into the governor
+            # so its hard-zero op gate can yield the worker to the operator.
+            # Lazy import inside the construction site avoids an import cycle
+            # (operator_presence imports trinity_event_bus, not sensor_governor).
+            # Byte-identical when yield off: operator_present() returns False
+            # (idle by default) and the governor's hard-zero is itself gated.
+            _operator_active_fn: Optional[Callable[[], bool]] = None
+            try:
+                from backend.core.ouroboros.governance.operator_presence import (
+                    operator_present,
+                )
+                _operator_active_fn = operator_present
+            except Exception:  # noqa: BLE001 — fail-soft; governor still works
+                _operator_active_fn = None
+            _default_governor = SensorGovernor(operator_active_fn=_operator_active_fn)
         return _default_governor
 
 

--- a/backend/core/ouroboros/governance/sensor_governor.py
+++ b/backend/core/ouroboros/governance/sensor_governor.py
@@ -185,6 +185,24 @@ def topology_backpressure_mult() -> float:
     return min(1.0, raw)
 
 
+def _operator_hard_zero(operator_active: bool) -> bool:
+    """True iff the operator-yield is enabled AND an operator is active.
+
+    When True the governor must admit NO new ops (hard-zero, distinct
+    from the soft 0.2× emergency brake). Pure. Never raises.
+
+    Spec §5.4 — byte-identical when ``JARVIS_OPERATOR_YIELD_ENABLED``
+    is off (default) or when ``operator_active`` is False.
+    """
+    try:
+        raw = os.environ.get("JARVIS_OPERATOR_YIELD_ENABLED", "false") or ""
+        if raw.strip().lower() not in ("1", "true", "yes", "on"):
+            return False
+        return bool(operator_active)
+    except Exception:  # noqa: BLE001
+        return False
+
+
 # ---------------------------------------------------------------------------
 # Vocabulary
 # ---------------------------------------------------------------------------
@@ -482,6 +500,7 @@ class SensorGovernor:
         topology_state_fn: Optional[
             Callable[[], Tuple[str, ...]]
         ] = None,
+        operator_active_fn: Optional[Callable[[], bool]] = None,
     ) -> None:
         self._specs: Dict[str, SensorBudgetSpec] = {}
         # Per-sensor deques of emission timestamps (monotonic seconds)
@@ -497,6 +516,13 @@ class SensorGovernor:
         self._topology_state_fn = (
             topology_state_fn or _default_topology_state_fn
         )
+        # Task 7 (spec §5.4) — operator-active hard-zero. When set and
+        # JARVIS_OPERATOR_YIELD_ENABLED is on, request_budget() returns
+        # allowed=False with reason_code='governor.operator_active_yield'
+        # for ALL sensors while the operator is present. Hard-zero —
+        # overrides even a fully-open per-sensor budget. Byte-identical
+        # when None (default) or yield flag is off.
+        self._operator_active_fn: Optional[Callable[[], bool]] = operator_active_fn
         self._lock = threading.Lock()
 
     # -- registration -------------------------------------------------------
@@ -696,6 +722,32 @@ class SensorGovernor:
 
             now = time.monotonic()
             self._evict_expired(now)
+
+            # Task 7 (spec §5.4) — operator-active hard-zero.
+            # Evaluated BEFORE cap math: when an operator is present
+            # the governor emits NO new ops regardless of remaining
+            # budget. Distinct from the soft 0.2× emergency brake.
+            # Fail-soft: callable exceptions → inactive (False).
+            if self._operator_active_fn is not None:
+                try:
+                    _op_active = bool(self._operator_active_fn())
+                except Exception:  # noqa: BLE001
+                    _op_active = False
+                if _operator_hard_zero(_op_active):
+                    _decision = BudgetDecision(
+                        allowed=False,
+                        sensor_name=sensor_name,
+                        urgency=urgency,
+                        posture=posture,
+                        weighted_cap=0,
+                        current_count=len(
+                            self._per_sensor.get(sensor_name, ())
+                        ),
+                        remaining=0,
+                        reason_code="governor.operator_active_yield",
+                    )
+                    self._decisions.append(_decision)
+                    return _decision
 
             brake = self._emergency_brake_active()
             topology_blocked = self._topology_blocking(urgency)

--- a/tests/governance/test_async_yield_integration.py
+++ b/tests/governance/test_async_yield_integration.py
@@ -1,0 +1,577 @@
+"""Layer-2 cross-component integration tests — Sovereign Async Yield Matrix (Task 9).
+
+Covers the full cross-component contract across:
+  - mutation_critical_section  (LR-B drain gate)
+  - operator_presence          (edge-trigger detection)
+  - operator_yield_bridge      (suspend flag + resume dispatch)
+  - op_park_store              (should_park_for_route)
+  - sensor_governor            (operator hard-zero)
+
+All tests are deterministic.  No real bus, no real event loop scheduling
+beyond the coroutines under test.  Fakes are local (or reused from the
+bridge test surface in _FakeCtx / _FakeBgOp / _FakePool).
+
+OFF byte-identical note (Test 5)
+---------------------------------
+When JARVIS_OPERATOR_YIELD_ENABLED is false (the default):
+  * operator_suspended() → always False, even after set_operator_active()
+  * _operator_hard_zero(True) → False
+  * should_park_for_route(..., operator_suspended=False) == legacy decision
+  * OperatorPresenceWatcher.run() returns immediately (no-op)
+
+Layer 1's deterministic mutation lock (mutation_section / maybe_mutation_section)
+is separate and stays active regardless of this env flag.  That path is fully
+tested in test_mutation_critical_section.py; we do not duplicate it here.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, List, Tuple
+
+import pytest
+
+import backend.core.ouroboros.governance.operator_yield_bridge as bridge
+import backend.core.ouroboros.governance.sensor_governor as sg
+from backend.core.ouroboros.governance.mutation_critical_section import (
+    drain,
+    is_mutating,
+    mutation_section,
+)
+from backend.core.ouroboros.governance.op_park_store import should_park_for_route
+from backend.core.ouroboros.governance.operator_presence import (
+    OperatorPresenceWatcher,
+    _is_present,
+)
+from backend.core.ouroboros.governance.sensor_governor import (
+    BudgetDecision,
+    SensorBudgetSpec,
+    SensorGovernor,
+    Urgency,
+    reset_default_governor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes (mirror test_operator_yield_bridge.py surface)
+# ---------------------------------------------------------------------------
+
+
+class _FakeCtx:
+    def __init__(self, op_id: str, route: str = "background") -> None:
+        self.op_id = op_id
+        self.provider_route = route
+
+
+class _FakeBgOp:
+    def __init__(self, op_id: str, status: str, context: Any) -> None:
+        self.op_id = op_id
+        self.status = status
+        self.context = context
+        self.park_attempt_seq = 1
+
+
+class _FakePool:
+    """Minimal stand-in exposing the surface the bridge needs."""
+
+    def __init__(self, parked: List[_FakeBgOp]) -> None:
+        self._parked = parked
+        self._resumed_ops: dict = {}
+        self.submitted: List[Tuple[str, int]] = []
+
+    def list_all(self):
+        return list(self._parked)
+
+    def is_resumed_dispatch(self, ctx_op_id: str) -> bool:
+        return ctx_op_id in self._resumed_ops
+
+    async def submit_for_resume(self, ctx, *, attempt_seq: int) -> str:
+        op_id = str(getattr(ctx, "op_id", "") or "")
+        self.submitted.append((op_id, attempt_seq))
+        self._resumed_ops[op_id] = attempt_seq
+        return f"pool-{op_id}"
+
+
+# ---------------------------------------------------------------------------
+# Module-level autouse — always reset the bridge suspend flag
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_bridge(monkeypatch):
+    """Clear the module suspend flag before and after each test."""
+    bridge.set_operator_idle()
+    yield
+    bridge.set_operator_idle()
+
+
+@pytest.fixture(autouse=True)
+def _reset_governor():
+    """Reset governor singleton so state doesn't leak between tests."""
+    reset_default_governor()
+    yield
+    reset_default_governor()
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Drain-gates-park (LR-B)
+# ---------------------------------------------------------------------------
+
+
+class TestDrainGatesPark:
+    """While an active mutation_section is held, drain() returns False
+    (would-abandon), which means the yield path must NOT park.  Once the
+    section exits, drain() returns True — safe to park."""
+
+    def test_drain_returns_false_while_mutating(self):
+        """drain() times out (returns False) when a mutation_section is active."""
+
+        async def _run():
+            op_id = "op-drain-test-001"
+            async with mutation_section(op_id):
+                # Confirm is_mutating reflects the active section
+                assert is_mutating(op_id) is True
+                # drain with a tiny timeout: should NOT wait long enough for
+                # the section to exit, so it returns False (wedged → abandon)
+                result = await drain(op_id, timeout=0.05, poll_s=0.01)
+                assert result is False, "drain must return False while section active"
+                # is_mutating still True inside the section
+                assert is_mutating(op_id) is True
+            return True
+
+        result = asyncio.run(_run())
+        assert result is True
+
+    def test_drain_returns_true_after_mutation_section_exits(self):
+        """drain() returns True immediately when no mutation_section is held."""
+
+        async def _run():
+            op_id = "op-drain-test-002"
+            async with mutation_section(op_id):
+                pass  # enter and immediately exit
+            # After the section exits is_mutating must be False
+            assert is_mutating(op_id) is False
+            result = await drain(op_id, timeout=0.5, poll_s=0.01)
+            assert result is True, "drain must return True when no section active"
+
+        asyncio.run(_run())
+
+    def test_drain_safe_to_park_after_section_exits(self):
+        """Once drain() returns True, should_park_for_route can proceed.
+
+        This composes the drain guard with the park decision: the yield
+        path first awaits drain(); only when it returns True is it safe
+        to evaluate should_park_for_route with operator_suspended=True.
+        """
+
+        async def _run():
+            op_id = "op-drain-test-003"
+            os.environ["JARVIS_BG_PARK_ENABLED"] = "true"
+            os.environ["JARVIS_OPERATOR_YIELD_ENABLED"] = "true"
+            try:
+                async with mutation_section(op_id):
+                    # Would-abandon path: drain inside section → False → don't park
+                    drained = await drain(op_id, timeout=0.05, poll_s=0.01)
+                    assert drained is False
+                # After section exits: drain → True → safe to evaluate park
+                drained = await drain(op_id, timeout=0.5, poll_s=0.01)
+                assert drained is True
+                # With operator suspended and a park-supported route, should park
+                decision = should_park_for_route(
+                    "background",
+                    queue_pressure=False,
+                    operator_suspended=True,
+                )
+                assert decision is True, (
+                    "should_park_for_route must return True on supported route "
+                    "when operator_suspended=True and park enabled"
+                )
+            finally:
+                os.environ.pop("JARVIS_BG_PARK_ENABLED", None)
+                os.environ.pop("JARVIS_OPERATOR_YIELD_ENABLED", None)
+
+        asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Presence → suspend → park decision
+# ---------------------------------------------------------------------------
+
+
+class TestPresenceSuspendPark:
+    """set_operator_active() (yield enabled) → operator_suspended() True
+    → should_park_for_route returns True even without queue pressure.
+    set_operator_idle() → operator_suspended() False → legacy decision."""
+
+    def test_active_suspends_and_parks(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+
+        bridge.set_operator_active()
+        assert bridge.operator_suspended() is True
+
+        # Park-supported route (background), no queue pressure — still parks
+        # because operator_suspended trumps queue pressure
+        result = should_park_for_route(
+            "background",
+            queue_pressure=False,
+            operator_suspended=bridge.operator_suspended(),
+        )
+        assert result is True, "must park on background route when operator active"
+
+    def test_active_parks_on_standard_route(self, monkeypatch):
+        """standard is in _PARK_SUPPORTED_ROUTES (batch-capable) so parks."""
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+
+        bridge.set_operator_active()
+        result = should_park_for_route(
+            "standard",
+            queue_pressure=False,
+            operator_suspended=bridge.operator_suspended(),
+        )
+        assert result is True
+
+    def test_idle_reverts_to_legacy_no_park_without_pressure(self, monkeypatch):
+        """After set_operator_idle() operator_suspended() → False.
+        Without queue pressure, should_park_for_route reverts to False (legacy)."""
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+
+        bridge.set_operator_active()
+        assert bridge.operator_suspended() is True
+
+        bridge.set_operator_idle()
+        assert bridge.operator_suspended() is False
+
+        result = should_park_for_route(
+            "background",
+            queue_pressure=False,
+            operator_suspended=bridge.operator_suspended(),
+        )
+        assert result is False, "must NOT park when operator idle + no queue pressure"
+
+    def test_immediate_route_never_parks_even_when_suspended(self, monkeypatch):
+        """IMMEDIATE is not in _PARK_SUPPORTED_ROUTES → never parks."""
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+
+        bridge.set_operator_active()
+        result = should_park_for_route(
+            "immediate",
+            queue_pressure=True,
+            operator_suspended=bridge.operator_suspended(),
+        )
+        assert result is False, "IMMEDIATE route must never park"
+
+    def test_presence_is_pure_deterministic(self):
+        """_is_present is a pure function: injected monotonic timestamps."""
+        # Operator present when elapsed < idle_threshold (default 45s)
+        assert _is_present(last_input_monotonic=100.0, now=140.0) is True
+        # Operator absent when elapsed >= idle_threshold
+        assert _is_present(last_input_monotonic=100.0, now=146.0) is False
+
+    def test_presence_liveness_overrides_stale_timestamp(self):
+        """A truthy liveness probe overrides a stale timestamp."""
+        # Elapsed 200s → would be absent, but liveness returns True
+        assert _is_present(
+            last_input_monotonic=100.0,
+            now=300.0,
+            liveness=lambda: True,
+        ) is True
+
+    def test_presence_liveness_exception_is_fail_soft(self):
+        """A crashing liveness probe is swallowed; falls through to timestamp."""
+        def _bad_liveness():
+            raise RuntimeError("boom")
+
+        # elapsed 200s → absent timestamp; probe raises → still absent
+        assert _is_present(
+            last_input_monotonic=100.0,
+            now=300.0,
+            liveness=_bad_liveness,
+        ) is False
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Governor hard-zero on active
+# ---------------------------------------------------------------------------
+
+
+class TestGovernorHardZeroOnActive:
+    """SensorGovernor(operator_active_fn=lambda: True) (yield enabled)
+    denies a budget request. With lambda: False it does not."""
+
+    def _make_governor(self, active_fn) -> SensorGovernor:
+        g = SensorGovernor(operator_active_fn=active_fn)
+        g.register(SensorBudgetSpec(sensor_name="TestSensor", base_cap_per_hour=100))
+        return g
+
+    def test_hard_zero_denies_when_active(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+
+        gov = self._make_governor(lambda: True)
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is False
+        assert decision.reason_code == "governor.operator_active_yield"
+
+    def test_hard_zero_not_triggered_when_inactive(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+
+        gov = self._make_governor(lambda: False)
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        # Operator inactive → hard-zero does not fire; budget should be allowed
+        assert decision.allowed is True
+
+    def test_hard_zero_not_triggered_when_yield_disabled(self, monkeypatch):
+        """Even with operator_active_fn returning True, if yield flag is off
+        the hard-zero never fires (byte-identical pre-Task-7 behavior)."""
+        monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+
+        gov = self._make_governor(lambda: True)
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is True, (
+            "hard-zero must not fire when JARVIS_OPERATOR_YIELD_ENABLED is off"
+        )
+
+    def test_hard_zero_pure_helper_on(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        assert sg._operator_hard_zero(True) is True
+
+    def test_hard_zero_pure_helper_off_by_flag(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+        assert sg._operator_hard_zero(True) is False
+
+    def test_hard_zero_pure_helper_inactive(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        assert sg._operator_hard_zero(False) is False
+
+    def test_hard_zero_no_fn_never_fires(self, monkeypatch):
+        """No operator_active_fn → hard-zero path not reached."""
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+
+        gov = SensorGovernor()  # no operator_active_fn
+        gov.register(SensorBudgetSpec(sensor_name="TestSensor", base_cap_per_hour=100))
+        decision = gov.request_budget("TestSensor")
+        assert decision.allowed is True
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Resume on idle
+# ---------------------------------------------------------------------------
+
+
+class TestResumeOnIdle:
+    """on_operator_idle with a fake pool (parked ops) calls submit_for_resume
+    for each parked op."""
+
+    def test_on_operator_idle_resumes_parked_ops(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        ctx_a = _FakeCtx("op-a")
+        ctx_b = _FakeCtx("op-b")
+        parked_ops = [
+            _FakeBgOp("op-a", "parked", ctx_a),
+            _FakeBgOp("op-b", "parked", ctx_b),
+        ]
+        pool = _FakePool(parked_ops)
+
+        async def _run():
+            await bridge.on_operator_idle(pool=pool)
+
+        asyncio.run(_run())
+
+        submitted_op_ids = {op_id for op_id, _ in pool.submitted}
+        assert "op-a" in submitted_op_ids
+        assert "op-b" in submitted_op_ids
+        assert len(pool.submitted) == 2
+
+    def test_on_operator_idle_skips_non_parked(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        ctx_a = _FakeCtx("op-running")
+        ctx_b = _FakeCtx("op-parked")
+        ops = [
+            _FakeBgOp("op-running", "running", ctx_a),
+            _FakeBgOp("op-parked", "parked", ctx_b),
+        ]
+        pool = _FakePool(ops)
+
+        async def _run():
+            await bridge.on_operator_idle(pool=pool)
+
+        asyncio.run(_run())
+
+        submitted_op_ids = {op_id for op_id, _ in pool.submitted}
+        assert "op-parked" in submitted_op_ids
+        assert "op-running" not in submitted_op_ids
+
+    def test_on_operator_idle_skips_already_resumed(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        ctx_a = _FakeCtx("op-already-resumed")
+        ops = [_FakeBgOp("op-already-resumed", "parked", ctx_a)]
+        pool = _FakePool(ops)
+        # Pre-mark as already in resume dispatch
+        pool._resumed_ops["op-already-resumed"] = 1
+
+        async def _run():
+            await bridge.on_operator_idle(pool=pool)
+
+        asyncio.run(_run())
+
+        assert len(pool.submitted) == 0, (
+            "should not double-dispatch an op already in resume"
+        )
+
+    def test_on_operator_idle_clears_suspend_flag(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        bridge.set_operator_active()
+        assert bridge.operator_suspended() is True
+
+        pool = _FakePool([])
+
+        async def _run():
+            await bridge.on_operator_idle(pool=pool)
+
+        asyncio.run(_run())
+        assert bridge.operator_suspended() is False
+
+    def test_on_operator_idle_noop_when_yield_disabled(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+
+        # Set raw flag but yield is off, so on_operator_idle is a no-op
+        bridge.set_operator_active()
+
+        ctx = _FakeCtx("op-x")
+        pool = _FakePool([_FakeBgOp("op-x", "parked", ctx)])
+
+        async def _run():
+            await bridge.on_operator_idle(pool=pool)
+
+        asyncio.run(_run())
+
+        # No submissions — bridge is inactive
+        assert len(pool.submitted) == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 5: OFF byte-identical (CRITICAL)
+# ---------------------------------------------------------------------------
+
+
+class TestOffByteIdentical:
+    """With JARVIS_OPERATOR_YIELD_ENABLED=false, all Layer-2 yield surfaces
+    are dormant: operator_suspended() is always False, _operator_hard_zero
+    never fires, should_park_for_route behaves as legacy, and
+    OperatorPresenceWatcher.run() is a no-op.
+
+    NOTE: Layer 1's deterministic mutation lock (mutation_section /
+    maybe_mutation_section) is separate and stays active regardless of this
+    flag — tested in test_mutation_critical_section.py.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _yield_disabled(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+
+    def test_operator_suspended_always_false_when_disabled(self):
+        # Even after set_operator_active(), operator_suspended() returns False
+        bridge.set_operator_active()
+        assert bridge.operator_suspended() is False, (
+            "operator_suspended() must return False when yield is disabled"
+        )
+
+    def test_set_operator_active_then_idle_both_safe_when_disabled(self):
+        # Should not raise; just no-op from the gate perspective
+        bridge.set_operator_active()
+        bridge.set_operator_idle()
+        assert bridge.operator_suspended() is False
+
+    def test_operator_hard_zero_false_when_disabled(self):
+        # _operator_hard_zero(True) → False when yield flag is off
+        assert sg._operator_hard_zero(True) is False
+
+    def test_should_park_for_route_legacy_when_disabled(self, monkeypatch):
+        """should_park_for_route with operator_suspended=False (the only value
+        possible when yield is off) falls through to legacy behavior.
+        Legacy with park disabled → always False."""
+        monkeypatch.delenv("JARVIS_BG_PARK_ENABLED", raising=False)
+        # operator_suspended() is False (feature off); pass that value
+        result = should_park_for_route(
+            "background",
+            queue_pressure=True,
+            operator_suspended=bridge.operator_suspended(),  # False
+        )
+        assert result is False, (
+            "should_park_for_route must respect legacy decision (park disabled)"
+        )
+
+    def test_should_park_for_route_legacy_with_park_enabled(self, monkeypatch):
+        """With park enabled but operator_suspended=False (yield off), park
+        returns True only when route is eligible AND queue_pressure is True."""
+        monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+        # operator_suspended is False (yield disabled)
+        result = should_park_for_route(
+            "background",
+            queue_pressure=True,
+            operator_suspended=False,
+        )
+        # background is in the default eligible routes — must park under pressure
+        assert result is True, (
+            "legacy path: eligible route + queue_pressure=True should park"
+        )
+        result_no_pressure = should_park_for_route(
+            "background",
+            queue_pressure=False,
+            operator_suspended=False,
+        )
+        assert result_no_pressure is False, (
+            "legacy path: no queue pressure → no park"
+        )
+
+    def test_presence_watcher_run_is_noop_when_disabled(self):
+        """OperatorPresenceWatcher.run() returns immediately when yield is off."""
+
+        async def _run():
+            watcher = OperatorPresenceWatcher()
+            # run() is gated on JARVIS_OPERATOR_YIELD_ENABLED; with it off,
+            # it should return without entering the while loop.
+            import asyncio
+            try:
+                await asyncio.wait_for(watcher.run(bus=None), timeout=0.2)
+            except asyncio.TimeoutError:
+                pytest.fail(
+                    "OperatorPresenceWatcher.run() should return immediately "
+                    "when JARVIS_OPERATOR_YIELD_ENABLED is false"
+                )
+
+        asyncio.run(_run())
+
+    def test_on_operator_active_noop_when_disabled(self):
+        """on_operator_active is a no-op when yield is disabled."""
+
+        async def _run():
+            await bridge.on_operator_active()
+
+        asyncio.run(_run())
+        # Suspend flag should remain False
+        assert bridge.operator_suspended() is False
+
+    def test_governor_hard_zero_not_fired_when_disabled(self, monkeypatch):
+        """SensorGovernor with operator_active_fn=lambda: True does NOT
+        deny budget when JARVIS_OPERATOR_YIELD_ENABLED is off."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+        # yield flag is delenv'd by the autouse fixture
+
+        gov = SensorGovernor(operator_active_fn=lambda: True)
+        gov.register(SensorBudgetSpec(sensor_name="TestSensor", base_cap_per_hour=100))
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is True, (
+            "governor must not hard-zero when JARVIS_OPERATOR_YIELD_ENABLED is off"
+        )

--- a/tests/governance/test_governor_operator_yield.py
+++ b/tests/governance/test_governor_operator_yield.py
@@ -1,0 +1,208 @@
+"""Task 7 — SensorGovernor operator-active hard-zero (spec §5.4).
+
+Tests the pure helper ``_operator_hard_zero`` and the behavioral
+path through ``SensorGovernor.request_budget`` when an
+``operator_active_fn`` is injected.
+
+Byte-identical invariant:
+  * When ``JARVIS_OPERATOR_YIELD_ENABLED`` is off → helper always False.
+  * When callable is None → no hard-zero regardless of env flag.
+  * When callable returns False → no hard-zero.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import backend.core.ouroboros.governance.sensor_governor as sg
+from backend.core.ouroboros.governance.sensor_governor import (
+    BudgetDecision,
+    SensorBudgetSpec,
+    SensorGovernor,
+    Urgency,
+    reset_default_governor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Wipe all governor env vars between tests."""
+    for key in list(os.environ):
+        if key.startswith("JARVIS_SENSOR_GOVERNOR") or key == "JARVIS_OPERATOR_YIELD_ENABLED":
+            monkeypatch.delenv(key, raising=False)
+    reset_default_governor()
+    yield
+    reset_default_governor()
+
+
+def _make_spec(name: str = "TestSensor", cap: int = 10) -> SensorBudgetSpec:
+    return SensorBudgetSpec(sensor_name=name, base_cap_per_hour=cap)
+
+
+# ---------------------------------------------------------------------------
+# Pure helper — _operator_hard_zero
+# ---------------------------------------------------------------------------
+
+
+class TestOperatorHardZeroHelper:
+
+    def test_hard_zero_true_when_yield_enabled_and_active(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        assert sg._operator_hard_zero(True) is True
+
+    def test_hard_zero_false_when_yield_enabled_but_inactive(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+        assert sg._operator_hard_zero(False) is False
+
+    def test_hard_zero_off_when_yield_disabled(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "false")
+        # Even with operator active, yield disabled → never hard-zero
+        assert sg._operator_hard_zero(True) is False
+
+    def test_hard_zero_off_when_yield_env_missing(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+        # Default is false → never hard-zero
+        assert sg._operator_hard_zero(True) is False
+
+    def test_accepts_1_yes_on_as_truthy_flag(self, monkeypatch):
+        for truthy in ("1", "yes", "on", "TRUE", "True"):
+            monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", truthy)
+            assert sg._operator_hard_zero(True) is True, f"failed for {truthy!r}"
+
+    def test_operator_false_with_1_flag(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "1")
+        assert sg._operator_hard_zero(False) is False
+
+
+# ---------------------------------------------------------------------------
+# Behavioral — SensorGovernor.request_budget with operator_active_fn
+# ---------------------------------------------------------------------------
+
+
+class TestGovernorOperatorYieldBehavioral:
+
+    def test_request_budget_denied_when_operator_active(self, monkeypatch):
+        """operator_active_fn=lambda: True + yield enabled → denied."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        gov = SensorGovernor(
+            posture_fn=lambda: None,
+            signal_bundle_fn=lambda: None,
+            operator_active_fn=lambda: True,
+        )
+        spec = _make_spec()
+        gov.register(spec)
+
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert isinstance(decision, BudgetDecision)
+        assert decision.allowed is False
+        assert decision.reason_code == "governor.operator_active_yield"
+
+    def test_request_budget_allowed_when_operator_inactive(self, monkeypatch):
+        """operator_active_fn=lambda: False → normal path (budget not exhausted)."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        gov = SensorGovernor(
+            posture_fn=lambda: None,
+            signal_bundle_fn=lambda: None,
+            operator_active_fn=lambda: False,
+        )
+        spec = _make_spec()
+        gov.register(spec)
+
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is True
+
+    def test_request_budget_allowed_when_callable_none(self, monkeypatch):
+        """No operator_active_fn → byte-identical to pre-feature (allowed)."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        gov = SensorGovernor(
+            posture_fn=lambda: None,
+            signal_bundle_fn=lambda: None,
+        )
+        spec = _make_spec()
+        gov.register(spec)
+
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is True
+
+    def test_request_budget_allowed_when_yield_disabled(self, monkeypatch):
+        """operator_active_fn raises True but yield flag is off → allowed."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "false")
+
+        gov = SensorGovernor(
+            posture_fn=lambda: None,
+            signal_bundle_fn=lambda: None,
+            operator_active_fn=lambda: True,
+        )
+        spec = _make_spec()
+        gov.register(spec)
+
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is True
+
+    def test_operator_yield_takes_priority_over_remaining_budget(self, monkeypatch):
+        """Hard-zero fires even when per-sensor budget still has headroom."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        gov = SensorGovernor(
+            posture_fn=lambda: None,
+            signal_bundle_fn=lambda: None,
+            operator_active_fn=lambda: True,
+        )
+        # Large budget so we wouldn't be denied for capacity reasons
+        spec = _make_spec(cap=10_000)
+        gov.register(spec)
+
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is False
+        assert decision.reason_code == "governor.operator_active_yield"
+
+    def test_operator_fn_exception_treated_as_inactive(self, monkeypatch):
+        """Fail-soft: if operator_active_fn raises, treat as inactive (allow)."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "true")
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        def _raising_fn() -> bool:
+            raise RuntimeError("broken callable")
+
+        gov = SensorGovernor(
+            posture_fn=lambda: None,
+            signal_bundle_fn=lambda: None,
+            operator_active_fn=_raising_fn,
+        )
+        spec = _make_spec()
+        gov.register(spec)
+
+        # Should NOT raise; should fall through to normal allowed path
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is True
+
+    def test_governor_disabled_bypasses_operator_yield(self, monkeypatch):
+        """Master governor flag off → always allowed, operator yield irrelevant."""
+        monkeypatch.setenv("JARVIS_SENSOR_GOVERNOR_ENABLED", "false")
+        monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+        gov = SensorGovernor(
+            posture_fn=lambda: None,
+            signal_bundle_fn=lambda: None,
+            operator_active_fn=lambda: True,
+        )
+        spec = _make_spec()
+        gov.register(spec)
+
+        decision = gov.request_budget("TestSensor", Urgency.STANDARD)
+        assert decision.allowed is True
+        assert decision.reason_code == "governor.disabled"

--- a/tests/governance/test_layer2_activation.py
+++ b/tests/governance/test_layer2_activation.py
@@ -1,0 +1,276 @@
+"""YM-T10 — Layer-2 production-activation wiring tests (Sovereign Daemon
+Injection Protocol).
+
+The cross-cutting review found Layer 2 correct but DORMANT. YM-T10 activates
+the four production seams:
+
+  * SEAM 1 — GovernedLoopService spawns the OperatorPresenceWatcher daemon +
+    awaits operator_yield_bridge.attach() during boot, both fail-soft.
+  * SEAM 2 — the default SensorGovernor singleton is constructed with
+    operator_active_fn=operator_present (the hard-zero DI link).
+  * SEAM 3 — the SerpentREPL input boundary calls note_human_input().
+
+These tests assert the WIRING is present + safe (structural + behavioral),
+without re-testing the underlying Layer-2 unit behaviour (covered by
+test_operator_presence.py / test_operator_yield_bridge.py / etc.).
+
+Everything is byte-identical when JARVIS_OPERATOR_YIELD_ENABLED is off — these
+tests therefore assert presence of the DI'd function / spawn / hook, plus
+fail-soft behaviour, rather than feature behaviour with the flag on.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import List
+
+import pytest
+
+
+# ===========================================================================
+# SEAM 2 — Governor DI (the hard-zero link). Highest value + easiest.
+# ===========================================================================
+
+
+def test_default_governor_has_operator_active_fn_injected(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """get_default_governor()/ensure_seeded() produce a governor whose
+    _operator_active_fn is wired (not None) — the DI link is live."""
+    import backend.core.ouroboros.governance.sensor_governor as sg
+
+    # Reset the singleton so we observe a fresh construction.
+    sg.reset_default_governor()
+    try:
+        gov = sg.get_default_governor()
+        assert gov._operator_active_fn is not None, (
+            "SEAM 2 regression: governor singleton built without "
+            "operator_active_fn — the hard-zero DI link is dormant"
+        )
+        # The DI'd fn must be the deterministic presence probe.
+        from backend.core.ouroboros.governance.operator_presence import (
+            operator_present,
+        )
+        assert gov._operator_active_fn is operator_present
+
+        # ensure_seeded() returns the SAME singleton (still DI'd).
+        seeded = sg.ensure_seeded()
+        assert seeded is gov
+        assert seeded._operator_active_fn is operator_present
+    finally:
+        sg.reset_default_governor()
+
+
+def test_governor_di_is_byte_identical_when_yield_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """With the master flag off, the DI'd fn reports the operator absent
+    (idle by default) so the governor behaves exactly as pre-YM-T10."""
+    monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+    import backend.core.ouroboros.governance.operator_presence as op
+
+    # No recent human input + flag off → operator_present() must be False
+    # regardless of the timestamp (the watcher/governor gating handles the
+    # flag; the bare probe just reports presence).
+    op._last_input = 0.0
+    # operator_present() is the probe the governor calls; under the
+    # default-idle module state it should report absent.
+    assert op.operator_present() is False
+
+
+def test_governor_di_fail_soft_when_import_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If the lazy operator_present import raises, the governor must STILL
+    be constructable (fail-soft → operator_active_fn=None), never crashing
+    the singleton accessor."""
+    import builtins
+
+    import backend.core.ouroboros.governance.sensor_governor as sg
+
+    sg.reset_default_governor()
+    real_import = builtins.__import__
+
+    def _boom(name, *args, **kwargs):
+        if name.endswith("operator_presence") or "operator_presence" in name:
+            raise ImportError("simulated import failure")
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", _boom)
+    try:
+        gov = sg.get_default_governor()  # must NOT raise
+        assert gov is not None
+        # fail-soft path → fn is None, governor still works.
+        assert gov._operator_active_fn is None
+    finally:
+        monkeypatch.setattr(builtins, "__import__", real_import)
+        sg.reset_default_governor()
+
+
+# ===========================================================================
+# SEAM 3 — zero-latency REPL/intake human-input hook.
+# ===========================================================================
+
+
+def test_note_human_input_updates_presence_timestamp(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """note_human_input() (the SEAM-3 hook) makes operator_present() True
+    within the idle window."""
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+    import backend.core.ouroboros.governance.operator_presence as op
+
+    op._last_input = 0.0
+    assert op.operator_present() is False  # stale → absent
+    op.note_human_input()  # the SEAM-3 call
+    assert op.operator_present() is True  # fresh → present
+
+
+def test_repl_input_loop_calls_note_human_input() -> None:
+    """The SerpentREPL input boundary is wired to note_human_input().
+
+    Structural assertion against the REPL source: the highest-signal human-
+    input boundary (_loop) must reference note_human_input so every human
+    submission stamps presence. Lazy-import + fail-soft so a missing module
+    never perturbs REPL dispatch.
+    """
+    from backend.core.ouroboros.battle_test import serpent_flow
+
+    src = inspect.getsource(serpent_flow)
+    assert "note_human_input" in src, (
+        "SEAM 3 regression: REPL input boundary no longer calls "
+        "note_human_input() — operator presence will never be stamped"
+    )
+    # The hook lives in the interactive input loop (_loop).
+    loop_src = inspect.getsource(serpent_flow.SerpentREPL._loop)
+    assert "note_human_input" in loop_src, (
+        "SEAM 3 regression: note_human_input() not in SerpentREPL._loop"
+    )
+
+
+# ===========================================================================
+# SEAM 1 — non-blocking daemon boot + attach (fail-soft).
+# ===========================================================================
+
+
+def test_attach_callable_and_subscribes_when_on_noop_when_off(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A fake-bus/fake-pool attach() subscribes both topics when yield on,
+    and subscribes nothing when off (the GLS SEAM-1 call passes bus=None +
+    pool=self._bg_pool; here we drive attach directly with fakes)."""
+    from backend.core.ouroboros.governance import operator_yield_bridge as oyb
+    from backend.core.ouroboros.governance.operator_presence import (
+        EVENT_OPERATOR_ACTIVE,
+        EVENT_OPERATOR_IDLE,
+    )
+
+    class _FakeBus:
+        def __init__(self) -> None:
+            self.subscribed: List[str] = []
+
+        async def subscribe(self, pattern, handler, **kw):
+            self.subscribed.append(pattern)
+            return f"sub-{len(self.subscribed)}"
+
+    class _FakePool:
+        def list_all(self):
+            return []
+
+    # OFF → no-op (nothing subscribed)
+    monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+    bus_off = _FakeBus()
+    asyncio.run(oyb.attach(bus=bus_off, pool=_FakePool()))
+    assert bus_off.subscribed == []
+
+    # ON → both topics subscribed
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    bus_on = _FakeBus()
+    asyncio.run(oyb.attach(bus=bus_on, pool=_FakePool()))
+    assert EVENT_OPERATOR_ACTIVE in bus_on.subscribed
+    assert EVENT_OPERATOR_IDLE in bus_on.subscribed
+
+
+def test_gls_has_operator_yield_layer_helper_and_task_ref() -> None:
+    """GLS exposes the SEAM-1 spawn helper + the strong task-ref attribute,
+    and stop() cancels the task. Structural — full GLS boot is too heavy to
+    instantiate in a unit test (see report)."""
+    from backend.core.ouroboros.governance.governed_loop_service import (
+        GovernedLoopService,
+    )
+
+    assert hasattr(GovernedLoopService, "_start_operator_yield_layer"), (
+        "SEAM 1 regression: GLS missing _start_operator_yield_layer helper"
+    )
+    assert asyncio.iscoroutinefunction(
+        GovernedLoopService._start_operator_yield_layer
+    )
+
+    # start() must invoke the helper; stop() must cancel the task ref.
+    start_src = inspect.getsource(GovernedLoopService.start)
+    assert "_start_operator_yield_layer" in start_src, (
+        "SEAM 1 regression: start() no longer invokes the yield-layer boot"
+    )
+    stop_src = inspect.getsource(GovernedLoopService.stop)
+    assert "_operator_presence_task" in stop_src, (
+        "SEAM 1 regression: stop() no longer cancels the watcher daemon"
+    )
+
+
+def test_start_operator_yield_layer_fail_soft_on_watcher_raise(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The SEAM-1 boot helper is fail-soft in ISOLATION: if the watcher
+    spawn raises (e.g. OperatorPresenceWatcher constructor blows up), the
+    helper must NOT propagate — boot proceeds. We drive the unbound coroutine
+    against a minimal stand-in self to avoid a full GLS boot.
+    """
+    import backend.core.ouroboros.governance.governed_loop_service as gls_mod
+    import backend.core.ouroboros.governance.operator_presence as op_mod
+
+    # Make the watcher constructor explode.
+    class _ExplodingWatcher:
+        def __init__(self, *a, **k):
+            raise RuntimeError("simulated watcher boom")
+
+    monkeypatch.setattr(op_mod, "OperatorPresenceWatcher", _ExplodingWatcher)
+
+    class _FakeSelf:
+        _bg_pool = None
+        _operator_presence_task = None
+
+    fake = _FakeSelf()
+    # Must NOT raise — fail-soft swallows the watcher error AND the
+    # attach (bus=None resolves to no real bus → graceful skip).
+    asyncio.run(
+        gls_mod.GovernedLoopService._start_operator_yield_layer(fake)
+    )
+    # Watcher spawn failed → task ref stays None (degraded, not crashed).
+    assert fake._operator_presence_task is None
+
+
+def test_start_operator_yield_layer_spawns_task_on_happy_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """On the happy path the helper spawns a strong-ref daemon task. With the
+    flag off the watcher.run() returns immediately (no-op), so the task
+    completes cleanly — proving the create_task wiring + ref storage."""
+    import backend.core.ouroboros.governance.governed_loop_service as gls_mod
+
+    monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+
+    class _FakeSelf:
+        _bg_pool = None
+        _operator_presence_task = None
+
+    fake = _FakeSelf()
+
+    async def _drive() -> None:
+        await gls_mod.GovernedLoopService._start_operator_yield_layer(fake)
+        # A task ref must have been stored.
+        assert fake._operator_presence_task is not None
+        # Flag off → watcher.run() returns immediately; let it settle.
+        await asyncio.sleep(0)
+        await asyncio.wait_for(fake._operator_presence_task, timeout=1.0)
+
+    asyncio.run(_drive())

--- a/tests/governance/test_mutation_critical_section.py
+++ b/tests/governance/test_mutation_critical_section.py
@@ -1,0 +1,76 @@
+from __future__ import annotations
+import asyncio
+from backend.core.ouroboros.governance import mutation_critical_section as mcs
+
+def test_section_marks_mutating():
+    async def go():
+        assert mcs.is_mutating("op1") is False
+        async with mcs.mutation_section("op1"):
+            assert mcs.is_mutating("op1") is True
+        assert mcs.is_mutating("op1") is False
+    asyncio.run(go())
+
+def test_drain_returns_true_when_idle():
+    async def go():
+        return await mcs.drain("opX", timeout=0.5)
+    assert asyncio.run(go()) is True
+
+def test_drain_waits_then_true():
+    async def go():
+        async def hold():
+            async with mcs.mutation_section("op2"):
+                await asyncio.sleep(0.2)
+        t = asyncio.create_task(hold()); await asyncio.sleep(0.01)
+        ok = await mcs.drain("op2", timeout=2.0); await t
+        return ok
+    assert asyncio.run(go()) is True
+
+def test_drain_abandons_on_wedge():
+    async def go():
+        async def wedge():
+            async with mcs.mutation_section("op3"):
+                await asyncio.sleep(5.0)
+        t = asyncio.create_task(wedge()); await asyncio.sleep(0.01)
+        ok = await mcs.drain("op3", timeout=0.2)
+        t.cancel()
+        try: await t
+        except asyncio.CancelledError: pass
+        return ok
+    assert asyncio.run(go()) is False
+
+def test_nested_reentrant_same_op():
+    async def go():
+        async with mcs.mutation_section("op4"):
+            async with mcs.mutation_section("op4"):
+                assert mcs.is_mutating("op4") is True
+            assert mcs.is_mutating("op4") is True   # still in outer section
+        assert mcs.is_mutating("op4") is False
+    asyncio.run(go())
+
+def test_exception_in_section_still_decrements():
+    async def go():
+        try:
+            async with mcs.mutation_section("op5"):
+                raise ValueError("boom")
+        except ValueError:
+            pass
+        assert mcs.is_mutating("op5") is False
+    asyncio.run(go())
+
+
+def test_maybe_section_noop_when_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "false")
+    async def go():
+        async with mcs.maybe_mutation_section("op6"):
+            assert mcs.is_mutating("op6") is False
+        assert mcs.is_mutating("op6") is False
+    asyncio.run(go())
+
+
+def test_maybe_section_active_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    async def go():
+        async with mcs.maybe_mutation_section("op7"):
+            assert mcs.is_mutating("op7") is True
+        assert mcs.is_mutating("op7") is False
+    asyncio.run(go())

--- a/tests/governance/test_operator_presence.py
+++ b/tests/governance/test_operator_presence.py
@@ -1,0 +1,237 @@
+"""Tests for deterministic operator-presence detector + edge-triggered event watcher (spec §5.3)."""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, List, Optional
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance import operator_presence as op
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+class _FakeBus:
+    """Minimal fake bus that captures published events without requiring a running loop."""
+
+    def __init__(self) -> None:
+        self.published: List[Any] = []
+        self.should_raise: bool = False
+
+    async def publish(self, event: Any, persist: bool = False) -> str:
+        if self.should_raise:
+            raise RuntimeError("bus unavailable")
+        self.published.append(event)
+        return getattr(event, "event_id", "fake-id")
+
+
+# ---------------------------------------------------------------------------
+# Pure detection logic
+# ---------------------------------------------------------------------------
+
+def test_present_when_recent_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+    # last input 5s ago → within threshold → present
+    assert op._is_present(last_input_monotonic=100.0, now=105.0) is True
+
+
+def test_idle_when_stale_input(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+    # last input 100s ago → beyond 45s threshold → idle
+    assert op._is_present(last_input_monotonic=100.0, now=200.0) is False
+
+
+def test_exactly_at_threshold_is_idle(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+    # gap == threshold → NOT strictly less-than → idle
+    assert op._is_present(last_input_monotonic=100.0, now=145.0) is False
+
+
+def test_just_under_threshold_is_present(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+    assert op._is_present(last_input_monotonic=100.0, now=144.9) is True
+
+
+def test_present_via_liveness_probe() -> None:
+    # Even if input is stale, an active liveness probe means present
+    assert op._is_present(last_input_monotonic=0.0, now=9999.0, liveness=lambda: True) is True
+
+
+def test_idle_when_liveness_probe_false(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+    assert op._is_present(last_input_monotonic=0.0, now=9999.0, liveness=lambda: False) is False
+
+
+def test_liveness_probe_exception_is_fail_soft(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+    # A probe that raises must not propagate — treat as absent
+    def _bad_probe() -> bool:
+        raise RuntimeError("probe broken")
+
+    result = op._is_present(last_input_monotonic=0.0, now=9999.0, liveness=_bad_probe)
+    assert result is False
+
+
+def test_default_idle_threshold_is_45s(monkeypatch: pytest.MonkeyPatch) -> None:
+    """No env var set → default of 45 seconds applies."""
+    monkeypatch.delenv("JARVIS_OPERATOR_IDLE_S", raising=False)
+    assert op._is_present(last_input_monotonic=100.0, now=144.0) is True
+    assert op._is_present(last_input_monotonic=100.0, now=146.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Edge-trigger logic
+# ---------------------------------------------------------------------------
+
+def test_edge_trigger_emits_only_on_transition() -> None:
+    """_transition() returns the topic string only on state change, else None."""
+    w = op.OperatorPresenceWatcher()
+    # Initially no state recorded — first call with present=True → transition to active
+    assert w._transition(present=True) == op.EVENT_OPERATOR_ACTIVE
+    # Same state again → no-op
+    assert w._transition(present=True) is None
+    # Flip to idle
+    assert w._transition(present=False) == op.EVENT_OPERATOR_IDLE
+    # Same idle state → no-op
+    assert w._transition(present=False) is None
+    # Flip back to active
+    assert w._transition(present=True) == op.EVENT_OPERATOR_ACTIVE
+
+
+def test_edge_trigger_starts_from_idle() -> None:
+    """A fresh watcher that first sees idle → emits operator.idle."""
+    w = op.OperatorPresenceWatcher()
+    assert w._transition(present=False) == op.EVENT_OPERATOR_IDLE
+    assert w._transition(present=False) is None
+
+
+# ---------------------------------------------------------------------------
+# module-level note_human_input + operator_present convenience
+# ---------------------------------------------------------------------------
+
+def test_note_human_input_stamps_module_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    """note_human_input() makes operator_present() return True immediately."""
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "30")
+    op.note_human_input()
+    assert op.operator_present() is True
+
+
+# ---------------------------------------------------------------------------
+# async run_once with injected fake bus
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_run_once_publishes_active_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "45")
+
+    bus = _FakeBus()
+    w = op.OperatorPresenceWatcher()
+
+    # Inject a present liveness probe
+    await w.run_once(bus=bus, liveness=lambda: True)
+
+    assert len(bus.published) == 1
+    assert bus.published[0].topic == op.EVENT_OPERATOR_ACTIVE
+
+
+@pytest.mark.asyncio
+async def test_run_once_publishes_idle_event(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OPERATOR_IDLE_S", "1")
+
+    bus = _FakeBus()
+    w = op.OperatorPresenceWatcher()
+
+    # Force stale: last_input far in the past, no liveness probe
+    op._last_input = 0.0
+    await w.run_once(bus=bus, liveness=lambda: False)
+
+    assert len(bus.published) == 1
+    assert bus.published[0].topic == op.EVENT_OPERATOR_IDLE
+
+
+@pytest.mark.asyncio
+async def test_run_once_no_spam_on_unchanged_state(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+    bus = _FakeBus()
+    w = op.OperatorPresenceWatcher()
+
+    liveness = lambda: True  # always present
+    await w.run_once(bus=bus, liveness=liveness)
+    await w.run_once(bus=bus, liveness=liveness)
+    await w.run_once(bus=bus, liveness=liveness)
+
+    # Only one event on the first call (idle→active), rest are no-ops
+    assert len(bus.published) == 1
+
+
+@pytest.mark.asyncio
+async def test_run_once_fail_soft_when_bus_raises(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+    bus = _FakeBus()
+    bus.should_raise = True
+    w = op.OperatorPresenceWatcher()
+
+    # Must not raise even if bus.publish() raises
+    await w.run_once(bus=bus, liveness=lambda: True)
+
+
+@pytest.mark.asyncio
+async def test_run_returns_immediately_when_disabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "false")
+
+    bus = _FakeBus()
+    w = op.OperatorPresenceWatcher()
+
+    # run() should return immediately (no loop) when master switch is off
+    await asyncio.wait_for(w.run(bus=bus, liveness=lambda: True, interval_s=0.01), timeout=1.0)
+
+    assert len(bus.published) == 0
+
+
+@pytest.mark.asyncio
+async def test_run_publishes_and_loops_when_enabled(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+    bus = _FakeBus()
+    w = op.OperatorPresenceWatcher()
+
+    # Run for just enough to fire a few iterations then cancel
+    task = asyncio.create_task(w.run(bus=bus, liveness=lambda: True, interval_s=0.01))
+    await asyncio.sleep(0.08)
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
+
+    # First call must have published exactly one event (idle→active);
+    # subsequent calls for unchanged state produce no extra events.
+    assert len(bus.published) == 1
+    assert bus.published[0].topic == op.EVENT_OPERATOR_ACTIVE
+
+
+# ---------------------------------------------------------------------------
+# Published event sanity (TrinityEvent fields)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_published_event_has_correct_fields(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+    bus = _FakeBus()
+    w = op.OperatorPresenceWatcher()
+    await w.run_once(bus=bus, liveness=lambda: True)
+
+    event = bus.published[0]
+    assert event.topic == op.EVENT_OPERATOR_ACTIVE
+    assert event.source is not None      # RepoType enum
+    assert event.payload is not None     # dict
+    assert isinstance(event.payload, dict)

--- a/tests/governance/test_operator_yield_bridge.py
+++ b/tests/governance/test_operator_yield_bridge.py
@@ -1,0 +1,288 @@
+"""Operator-yield bridge tests (spec §5.4, LR-B / Task 8).
+
+The bridge wires operator-presence events into the existing cooperative
+park/resume machinery:
+
+* ``operator.active``  → set a module suspend flag so the next park-decision
+  point (``should_park_for_route(operator_suspended=True)``) parks the op at
+  its next SAFE checkpoint, freeing the worker.
+* ``operator.idle``    → clear the flag + resume parked ops via
+  ``BackgroundAgentPool.submit_for_resume``.
+
+All tests use fakes — no real bus, no real event loop scheduling beyond the
+coroutines under test. Master flag ``JARVIS_OPERATOR_YIELD_ENABLED`` gates the
+whole surface; off → byte-identical no-op.
+"""
+from __future__ import annotations
+
+import asyncio
+from typing import Any, List, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance import op_park_store
+from backend.core.ouroboros.governance import operator_yield_bridge as bridge
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / fakes
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_flag():
+    """Ensure the module suspend flag starts cleared for every test."""
+    bridge.set_operator_idle()
+    yield
+    bridge.set_operator_idle()
+
+
+class _FakeCtx:
+    def __init__(self, op_id: str, route: str = "background") -> None:
+        self.op_id = op_id
+        self.provider_route = route
+
+
+class _FakeBgOp:
+    def __init__(self, op_id: str, status: str, context: Any) -> None:
+        self.op_id = op_id
+        self.status = status
+        self.context = context
+        self.park_attempt_seq = 1
+
+
+class _FakePool:
+    """Minimal stand-in exposing the surface the bridge needs."""
+
+    def __init__(self, parked: List[_FakeBgOp]) -> None:
+        self._parked = parked
+        self._resumed_ops: dict = {}
+        self.submitted: List[Tuple[str, int]] = []
+
+    def list_all(self):
+        return list(self._parked)
+
+    def is_resumed_dispatch(self, ctx_op_id: str) -> bool:
+        return ctx_op_id in self._resumed_ops
+
+    async def submit_for_resume(self, ctx, *, attempt_seq: int) -> str:
+        op_id = str(getattr(ctx, "op_id", "") or "")
+        self.submitted.append((op_id, attempt_seq))
+        self._resumed_ops[op_id] = attempt_seq
+        return f"pool-{op_id}"
+
+
+# ---------------------------------------------------------------------------
+# (a) should_park_for_route gains operator_suspended
+# ---------------------------------------------------------------------------
+
+
+def test_should_park_operator_suspended_true_parks_supported_route(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+    # background is in the park-supported set; operator_suspended forces park
+    # even with no queue pressure (the worker must be freed for the operator).
+    assert op_park_store.should_park_for_route(
+        "background", queue_pressure=False, operator_suspended=True
+    ) is True
+    assert op_park_store.should_park_for_route(
+        "complex", queue_pressure=False, operator_suspended=True
+    ) is True
+    assert op_park_store.should_park_for_route(
+        "standard", queue_pressure=False, operator_suspended=True
+    ) is True
+
+
+def test_should_park_operator_suspended_false_preserves_existing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+    # operator_suspended=False (default) → identical to pre-Task-8 behaviour:
+    # no queue pressure + no batch payload → no park.
+    assert op_park_store.should_park_for_route(
+        "background", queue_pressure=False, operator_suspended=False
+    ) is False
+    assert op_park_store.should_park_for_route(
+        "background", queue_pressure=False
+    ) is False  # default
+    # With queue pressure the existing route-eligibility still parks.
+    assert op_park_store.should_park_for_route(
+        "background", queue_pressure=True, operator_suspended=False
+    ) is True
+
+
+def test_should_park_operator_suspended_respects_master_flag_off(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("JARVIS_BG_PARK_ENABLED", raising=False)
+    # Master park flag off → no park even when operator_suspended.
+    assert op_park_store.should_park_for_route(
+        "background", queue_pressure=False, operator_suspended=True
+    ) is False
+
+
+def test_should_park_operator_suspended_unsupported_route_no_park(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+    # IMMEDIATE / SPECULATIVE are not park-supported routes — even under
+    # operator suspend they must not park (no resume continuation support).
+    assert op_park_store.should_park_for_route(
+        "immediate", queue_pressure=False, operator_suspended=True
+    ) is False
+    assert op_park_store.should_park_for_route(
+        "speculative", queue_pressure=False, operator_suspended=True
+    ) is False
+
+
+def test_should_park_resumed_dispatch_never_parks_even_when_suspended(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_BG_PARK_ENABLED", "true")
+    assert op_park_store.should_park_for_route(
+        "background",
+        queue_pressure=True,
+        is_resumed=True,
+        operator_suspended=True,
+    ) is False
+
+
+# ---------------------------------------------------------------------------
+# (b) bridge flag + handlers
+# ---------------------------------------------------------------------------
+
+
+def test_operator_suspended_false_when_yield_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+    bridge.set_operator_active()  # set the raw flag
+    # Flag is set, but yield disabled → operator_suspended() reports False.
+    assert bridge.operator_suspended() is False
+
+
+def test_operator_suspended_reflects_flag_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    assert bridge.operator_suspended() is False
+    bridge.set_operator_active()
+    assert bridge.operator_suspended() is True
+    bridge.set_operator_idle()
+    assert bridge.operator_suspended() is False
+
+
+def test_set_active_set_idle_toggle_the_flag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    bridge.set_operator_active()
+    assert bridge.operator_suspended() is True
+    bridge.set_operator_idle()
+    assert bridge.operator_suspended() is False
+
+
+def test_on_operator_active_sets_flag(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    asyncio.run(bridge.on_operator_active(None, pool=_FakePool([])))
+    assert bridge.operator_suspended() is True
+
+
+def test_on_operator_idle_clears_flag_and_resumes_parked_ops(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    bridge.set_operator_active()
+
+    parked = [
+        _FakeBgOp("op-a", "parked", _FakeCtx("op-a")),
+        _FakeBgOp("op-b", "running", _FakeCtx("op-b")),  # not parked → skip
+        _FakeBgOp("op-c", "parked", _FakeCtx("op-c")),
+    ]
+    pool = _FakePool(parked)
+
+    asyncio.run(bridge.on_operator_idle(None, pool=pool))
+
+    # Flag cleared
+    assert bridge.operator_suspended() is False
+    # Only the two parked ops were resumed
+    submitted_ids = sorted(op_id for op_id, _ in pool.submitted)
+    assert submitted_ids == ["op-a", "op-c"]
+
+
+def test_on_operator_idle_skips_already_resumed_ops(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    parked = [_FakeBgOp("op-a", "parked", _FakeCtx("op-a"))]
+    pool = _FakePool(parked)
+    pool._resumed_ops["op-a"] = 1  # already in a resume dispatch
+    asyncio.run(bridge.on_operator_idle(None, pool=pool))
+    assert pool.submitted == []  # no double-resume
+
+
+# ---------------------------------------------------------------------------
+# Master-flag-off → byte-identical no-op
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_handlers_noop_when_yield_disabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+    pool = _FakePool([_FakeBgOp("op-a", "parked", _FakeCtx("op-a"))])
+
+    asyncio.run(bridge.on_operator_active(None, pool=pool))
+    assert bridge.operator_suspended() is False  # disabled → reports False
+
+    asyncio.run(bridge.on_operator_idle(None, pool=pool))
+    assert pool.submitted == []  # no resume attempted when disabled
+
+
+def test_attach_noop_when_yield_disabled(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("JARVIS_OPERATOR_YIELD_ENABLED", raising=False)
+
+    class _FakeBus:
+        def __init__(self) -> None:
+            self.subscribed: List[str] = []
+
+        async def subscribe(self, pattern, handler, **kw):
+            self.subscribed.append(pattern)
+            return "sub-id"
+
+    bus = _FakeBus()
+    asyncio.run(bridge.attach(bus=bus, pool=_FakePool([])))
+    assert bus.subscribed == []  # nothing subscribed when disabled
+
+
+def test_attach_subscribes_both_topics_when_enabled(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+    from backend.core.ouroboros.governance.operator_presence import (
+        EVENT_OPERATOR_ACTIVE,
+        EVENT_OPERATOR_IDLE,
+    )
+
+    class _FakeBus:
+        def __init__(self) -> None:
+            self.subscribed: List[str] = []
+
+        async def subscribe(self, pattern, handler, **kw):
+            self.subscribed.append(pattern)
+            return f"sub-{len(self.subscribed)}"
+
+    bus = _FakeBus()
+    asyncio.run(bridge.attach(bus=bus, pool=_FakePool([])))
+    assert EVENT_OPERATOR_ACTIVE in bus.subscribed
+    assert EVENT_OPERATOR_IDLE in bus.subscribed
+
+
+def test_attach_fail_soft_on_bad_bus(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("JARVIS_OPERATOR_YIELD_ENABLED", "true")
+
+    class _BadBus:
+        async def subscribe(self, *a, **k):
+            raise RuntimeError("boom")
+
+    # Must not raise — fail-soft.
+    asyncio.run(bridge.attach(bus=_BadBus(), pool=_FakePool([])))


### PR DESCRIPTION
## Summary

**Layer 2** of the Sovereign Asynchronous Yield Matrix — graceful operator-yield, now **wired + active** (not dormant scaffolding). When an operator is working, the autonomous loop parks its in-flight op at the next *safe* checkpoint (never mid-mutation), frees the worker, and resumes when the operator goes idle. Builds on Layer 1 (deterministic isolation lock, merged in #69638).

Built via subagent-driven-development. A cross-cutting coherence review caught — and this PR fixes — a wired-vs-dormant gap (YM-T10).

## What's new (reuse-first — composes park/event-bus/governor)
- **Mutation critical-section guard (LR-B)** (`mutation_critical_section.py`) — `mutation_section(op_id)` wraps the 3 real apply/commit sites; `drain(op_id, timeout)` lets the yield wait for an in-flight mutation to finish. **We never park a half-written file/commit** — a wedged drain abandons the yield.
- **Deterministic operator-presence** (`operator_presence.py`) — last-input timestamp + liveness probe (NOT CAI/probabilistic); `OperatorPresenceWatcher` publishes edge-triggered `operator.active`/`operator.idle` on the TrinityEventBus.
- **SensorGovernor hard-zero** — when an operator is active, admit **no new ops** (distinct from the soft emergency brake).
- **Operator-yield bridge** (`operator_yield_bridge.py`) — `operator.active` → suspend flag → cooperative park at next checkpoint (drain-gated); `operator.idle` → resume parked ops via the existing `submit_for_resume`.
- **Production activation (YM-T10 / Daemon Injection):** GLS boot spawns the watcher as a **non-blocking daemon** (try/except — can never crash the loop) + calls `attach()`; the default `SensorGovernor` is **DI'd** with `operator_active_fn=operator_present`; the SerpentREPL stamps `note_human_input()` at the input boundary (zero-latency).

## Locked resolutions
- **LR-A** (Layer 1, shipped #69638) — deterministic lock force-arms both isolation + execution-boundary.
- **LR-B** (this PR) — atomic yield integrity: drain in-flight critical mutations (bounded `JARVIS_OPERATOR_YIELD_DRAIN_MAX_S=30s`) before parking; wedged → abandon, never park mid-mutation.

## Gating (all fail-soft; default-OFF → byte-identical)
- `JARVIS_OPERATOR_YIELD_ENABLED` (default **false** — advisory; graduate after soak).
- `JARVIS_OPERATOR_IDLE_S` (45), `JARVIS_OPERATOR_YIELD_DRAIN_MAX_S` (30).

## Design principle
Cooperative checkpoint-based park (never preemptive mid-op) + LR-B drain = safe. Layer 2 is advisory and sits *on top of* Layer 1's deterministic guarantee — it can never cause a primary-checkout write.

## Test plan
- [x] 30 cross-component integration tests + ~150 Layer-2 unit tests green (mutation-section, presence edge-trigger, governor hard-zero, drain-gates-park, resume-on-idle, activation DI).
- [x] OFF byte-identical proven (all Layer-2 surfaces dormant when the flag is off).
- [x] Zero real regressions across park / governor / event-bus / tool-loop (2 GLS-reentrancy failures verified pre-existing on base).
- [ ] Operator-run soak with `JARVIS_OPERATOR_YIELD_ENABLED=true`: confirm operator typing parks the loop and idle resumes it.

## Notes
- One follow-up refinement (out of scope): the parked op's out-of-pool continuation still progresses; the worker IS freed (the goal). Holding the continuation fully dormant until idle is a future enhancement.
- Spec/plan: `docs/superpowers/specs/2026-06-21-sovereign-async-yield-matrix-design.md`, `docs/superpowers/plans/2026-06-21-sovereign-async-yield-matrix-plan.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Activates Layer 2 of the Sovereign Async Yield Matrix: the loop yields to the human by parking at the next safe checkpoint when the operator is active, and resumes on idle. Adds a drain-before-park guard to avoid mid-mutation parks and a governor hard-zero to block new ops while the operator is present.

- New Features
  - Deterministic operator presence with edge-triggered `operator.active`/`operator.idle` events.
  - Operator-yield bridge: sets a suspend flag on active and resumes parked ops on idle; park decisions read `operator_suspended` and wait for a safe checkpoint.
  - Mutation critical-section guard: `mutation_section(op_id)` + `drain(op_id, timeout)` ensure no park during writes or commits.
  - Governor hard-zero: `SensorGovernor` (via DI `operator_active_fn`) admits no new ops while the operator is active.
  - Production activation: watcher daemon in `GovernedLoopService`, bridge `attach()` on boot, and REPL input hook `note_human_input()` for zero-latency presence.
  - Gating: `JARVIS_OPERATOR_YIELD_ENABLED=false` (default, byte-identical when off), `JARVIS_OPERATOR_IDLE_S=45`, `JARVIS_OPERATOR_YIELD_DRAIN_MAX_S=30`.

- Migration
  - To enable, set `JARVIS_OPERATOR_YIELD_ENABLED=true` and optionally tune `JARVIS_OPERATOR_IDLE_S` and `JARVIS_OPERATOR_YIELD_DRAIN_MAX_S`.

<sup>Written for commit f250e1e99b9a9bbafb372c067a898263ea174a2e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

