### PR TITLE
feat(a1-cloud): arm strategic-GOAL roadmap chain on the GCP Spot soak node (file-00 ignition)

### DIFF
--- a/deploy/gcp_ouroboros_startup.sh
+++ b/deploy/gcp_ouroboros_startup.sh
@@ -67,18 +67,46 @@ PIN="$(meta jarvis-dw-primary-override)"
 GH_TOK="$(gcloud secrets versions access latest --secret=github-token \
   --project="${GCP_PROJECT:-jarvis-473803}" 2>/dev/null || true)"
 [ -z "$GH_TOK" ] && GH_TOK="$(meta jarvis-gh-token)"
+# A1: the HMAC secret that validates the SIGNED roadmap.yaml. The reader's
+# REQUIRE_SIGNATURE defaults TRUE, so without this the hydrated roadmap fails
+# verification → zero goals → silent no-op. Travels as instance metadata
+# (project-scoped; same channel as the DW key), never in git/the image.
+HMAC_SECRET="$(meta jarvis-roadmap-hmac-secret)"
 {
   [ -n "$DW_KEY" ] && echo "DOUBLEWORD_API_KEY=$DW_KEY"
   [ -n "$PIN" ] && echo "JARVIS_DW_PRIMARY_OVERRIDE=$PIN"
   # JIT GitHub auth — gh CLI + git both read GH_TOKEN; never logged (len only).
   [ -n "$GH_TOK" ] && echo "GH_TOKEN=$GH_TOK"
   [ -n "$GH_TOK" ] && echo "GITHUB_TOKEN=$GH_TOK"
+  # A1 roadmap signature secret — read by roadmap_reader (env_file → container).
+  [ -n "$HMAC_SECRET" ] && echo "JARVIS_ROADMAP_READER_HMAC_SECRET=$HMAC_SECRET"
 } > "$APP_DIR/.env"
 chmod 600 "$APP_DIR/.env"
-echo "[ignition] .env written (DW key len=${#DW_KEY}, pin=${PIN:-<default>}, gh_token len=${#GH_TOK})"
+echo "[ignition] .env written (DW key len=${#DW_KEY}, pin=${PIN:-<default>}, gh_token len=${#GH_TOK}, hmac len=${#HMAC_SECRET})"
 [ -z "$DW_KEY" ] && echo "[ignition] WARNING: no jarvis-dw-api-key metadata — DW calls will 401"
 [ -z "$GH_TOK" ] && echo "[ignition] WARNING: no github-token secret / jarvis-gh-token metadata — graduation PRs cannot be pushed"
+[ -z "$HMAC_SECRET" ] && echo "[ignition] WARNING: no jarvis-roadmap-hmac-secret metadata — signed roadmap will FAIL verification (no file-00 will emit)"
 mkdir -p "$APP_DIR/.jarvis"
+
+# ---- 3c. A1 Strategic Ignition — hydrate the SIGNED roadmap from the GCS Vault.
+# The Vault (gs://<project>-deployments/crucible-state/.jarvis) is the source of
+# truth where the operator-signed roadmap + graduation ledgers live. Pull
+# roadmap.yaml from it so roadmap_reader has GOAL-001 (the first file-00) to
+# decompose + emit. Uses the same host gcloud already relied on above (gcloud
+# secrets, line ~67). On any miss, fall back to the committed UNSIGNED draft
+# (reader needs REQUIRE_SIGNATURE=false to parse that) so the node still has *a*
+# roadmap rather than silently emitting nothing.
+ROADMAP_VAULT="gs://${GCP_PROJECT:-jarvis-473803}-deployments/crucible-state/.jarvis/roadmap.yaml"
+echo "[ignition] hydrating signed roadmap <- $ROADMAP_VAULT"
+if command -v gcloud >/dev/null 2>&1 && \
+   gcloud storage cp "$ROADMAP_VAULT" "$APP_DIR/.jarvis/roadmap.yaml" 2>/dev/null; then
+  echo "[ignition] roadmap.yaml hydrated from GCS Vault (signed source of truth)"
+elif [ -f "$APP_DIR/.jarvis/roadmap.draft.yaml" ]; then
+  cp "$APP_DIR/.jarvis/roadmap.draft.yaml" "$APP_DIR/.jarvis/roadmap.yaml"
+  echo "[ignition] WARNING: Vault miss — using committed roadmap.draft.yaml (UNSIGNED; set JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE=false to parse it)"
+else
+  echo "[ignition] ERROR: no roadmap source (Vault miss + no committed draft) — roadmap reader will be a NO_ROADMAP no-op"
+fi
 
 # ---- 3b. Amnesia-proofing: RESTORE handled NATIVELY inside the container ----
 # Preemption-resume (pulling the prior .jarvis ledger from GCS) is done by the

--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -81,4 +81,29 @@ services:
       # collection errors from running the whole deps-incomplete tests/ tree.
       JARVIS_INTENT_TEST_DIR: "tests/seed"
       JARVIS_INTENT_TEST_INTERVAL_S: "60"
+      # ── A1 STRATEGIC IGNITION CHAIN (2026-06-22) ─────────────────────────────
+      # Arm the strategic-GOAL source so this cloud node emits its first file-00
+      # (the signed roadmap's GOAL-001) end-to-end and the [A1Trace] breadcrumbs
+      # fire. Ported verbatim from the proven A1 venue
+      # (docker-compose.dw-cortex-soak.yml). Without these the node soaks but the
+      # roadmap daemon never spawns → no strategic GOAL is ever emitted (the exact
+      # silent-no-op A1 exists to kill). The signed roadmap.yaml is hydrated from
+      # the GCS Vault by deploy/gcp_ouroboros_startup.sh; the HMAC secret that
+      # validates it travels via .env (startup writes it from instance metadata),
+      # NEVER committed here.
+      JARVIS_ROADMAP_READER_ENABLED: "1"          # parse signed roadmap → envelopes
+      JARVIS_ROADMAP_ORCHESTRATOR_ENABLED: "1"    # the daemon that emits GOALs into intake
+      JARVIS_GOAL_DECOMPOSITION_ENABLED: "1"      # GOAL → sub-goals
+      JARVIS_MULTI_STEP_ORCHESTRATION_ENABLED: "1"  # sub-goals → emitted pipeline work
+      JARVIS_M10_CADENCE_ENABLED: "1"             # ProposalSynthesizer cadence
+      JARVIS_SUBGOAL_COMPLETION_WRITEBACK_ENABLED: "1"  # close PROPOSED→COMPLETED loop
+      JARVIS_PROGRESS_LEDGER_ENABLED: "1"         # done_count / next_targets tracking
+      # Autonomous-PR path: GOAL-001 edits governance files → boundary gate routes
+      # it to APPROVAL_REQUIRED → ouroboros/review PR (the A1 milestone artifact,
+      # human-reviewed, never auto-merged). Needs GH_TOKEN (startup writes it from
+      # Secret Manager `github-token`).
+      JARVIS_ORANGE_PR_ENABLED: "1"
+      # A1 observability — breadcrumbs + DLQ default-true; pinned for soak audit.
+      JARVIS_A1_TRACE_ENABLED: "1"
+      JARVIS_INTAKE_DLQ_ENABLED: "1"
 

--- a/scripts/ignite_sovereign_cloud_node.py
+++ b/scripts/ignite_sovereign_cloud_node.py
@@ -31,20 +31,25 @@ _REPO_ROOT = Path(__file__).resolve().parent.parent
 _STARTUP_SCRIPT = _REPO_ROOT / "deploy" / "gcp_ouroboros_startup.sh"
 
 
-def _read_dw_key() -> str:
-    """Read DOUBLEWORD_API_KEY from the process env or the repo ``.env``."""
-    k = os.environ.get("DOUBLEWORD_API_KEY", "").strip()
-    if k:
-        return k
+def _read_env_var(name: str) -> str:
+    """Read *name* from the process env or the repo ``.env`` (never printed)."""
+    v = os.environ.get(name, "").strip()
+    if v:
+        return v
     env_path = _REPO_ROOT / ".env"
     if env_path.is_file():
         m = re.search(
-            r'^\s*(?:export\s+)?DOUBLEWORD_API_KEY\s*=\s*["\']?([^"\'\n]+)',
+            rf'^\s*(?:export\s+)?{re.escape(name)}\s*=\s*["\']?([^"\'\n]+)',
             env_path.read_text(), re.M,
         )
         if m:
             return m.group(1).strip()
     return ""
+
+
+def _read_dw_key() -> str:
+    """Read DOUBLEWORD_API_KEY from the process env or the repo ``.env``."""
+    return _read_env_var("DOUBLEWORD_API_KEY")
 
 
 def _mask(key: str) -> str:
@@ -91,6 +96,16 @@ async def _ignite(args: argparse.Namespace) -> int:
         "jarvis-dw-api-key": dw_key,
         "jarvis-dw-primary-override": args.pin,
     }
+    # A1: ship the roadmap HMAC secret so the node can VERIFY the signed
+    # roadmap.yaml it hydrates from the GCS Vault (reader REQUIRE_SIGNATURE
+    # defaults TRUE). Without it the strategic GOAL never emits — no file-00.
+    hmac_secret = _read_env_var("JARVIS_ROADMAP_READER_HMAC_SECRET")
+    if hmac_secret:
+        md["jarvis-roadmap-hmac-secret"] = hmac_secret
+        print(f"   roadmap HMAC via metadata: {_mask(hmac_secret)}")
+    else:
+        print("   WARNING: no JARVIS_ROADMAP_READER_HMAC_SECRET in env/.env — "
+              "signed roadmap will fail verification (no file-00 will emit)")
     if args.crucible:
         # Arm the autonomic graduation cadence (crucible overlay on the node).
         md["jarvis-crucible-mode"] = "true"


### PR DESCRIPTION
Wires the GCP cloud ignition path to actually emit the first **file-00** (signed roadmap GOAL-001) so the A1 `[A1Trace]` proof can fire in the wild.

**Gap fixed:** the cloud path (`docker-compose.prod.yml + gcp.yml`) was configured for the 2026-06-20 DW-autarky/aegis soak and only exercised dispatch via a calibration seed test-failure — it had **none** of the roadmap-ignition chain, so the node would soak but never emit a strategic GOAL (the silent no-op A1 exists to kill).

**Changes**
- `docker-compose.gcp.yml`: arm the 8-flag chain (ROADMAP_READER + ROADMAP_ORCHESTRATOR + GOAL_DECOMPOSITION + MULTI_STEP_ORCHESTRATION + M10_CADENCE + SUBGOAL_COMPLETION_WRITEBACK + PROGRESS_LEDGER + ORANGE_PR) + pin A1_TRACE/DLQ. Ported from the proven A1 venue (`dw-cortex-soak.yml`).
- `gcp_ouroboros_startup.sh`: hydrate the **signed** `roadmap.yaml` from the GCS Vault (`gs://<proj>-deployments/crucible-state/.jarvis`), fallback to the committed unsigned draft; write the roadmap HMAC secret to `.env` from instance metadata (reader `REQUIRE_SIGNATURE` defaults TRUE).
- `ignite_sovereign_cloud_node.py`: ship `JARVIS_ROADMAP_READER_HMAC_SECRET` via metadata (masked); generalize the .env reader.

**Safety:** GOAL-001 edits governance files → boundary gate routes it to `APPROVAL_REQUIRED` → `ouroboros/review` PR (human-reviewed, never auto-merged). Calibration greenlight is NOT broadened to governance files.

**Verified:** `bash -n` startup OK; ignite `py_compile` OK + `--dry-run` config valid; `docker compose config` merges with all flags; HMAC+DW secrets read from .env (masked).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the A1 strategic roadmap chain on the GCP spot soak node so it emits the first signed goal (file-00/GOAL-001) and opens an approval-required review PR.

- **New Features**
  - Enabled the full roadmap pipeline in `docker-compose.gcp.yml` (reader, orchestrator, goal decomposition, multi-step orchestration, cadence, writeback, progress ledger, `ORANGE_PR`) and pinned `A1_TRACE`/DLQ.
  - `gcp_ouroboros_startup.sh`: hydrate signed `roadmap.yaml` from the GCS Vault and fall back to the committed draft; write `JARVIS_ROADMAP_READER_HMAC_SECRET` to `.env` from instance metadata; improved warnings.
  - `ignite_sovereign_cloud_node.py`: ship the roadmap HMAC via instance metadata and add a generalized `.env` reader with masked output.

- **Migration**
  - Ensure the signed roadmap exists at `gs://<project>-deployments/crucible-state/.jarvis/roadmap.yaml`.
  - Set instance metadata `jarvis-roadmap-hmac-secret`; ensure Secret Manager `github-token` is present.
  - If using the unsigned draft, set `JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE=false`.

<sup>Written for commit f24441630068350e0e724695e1bc99ed329de7d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

