### PR TITLE
feat(c2): arm convergence matrices on the GCP soak node (breaker + chunking + call-graph)

### DIFF
--- a/docker-compose.gcp.yml
+++ b/docker-compose.gcp.yml
@@ -106,4 +106,22 @@ services:
       # A1 observability — breadcrumbs + DLQ default-true; pinned for soak audit.
       JARVIS_A1_TRACE_ENABLED: "1"
       JARVIS_INTAKE_DLQ_ENABLED: "1"
+      # ── C2 CONVERGENCE MATRICES (2026-06-22, PR #69644) ──────────────────────
+      # Arm the full convergence path so a BLOCKed strategic GOAL (GOAL-001) can
+      # decompose into a test-first + symbol-scoped plan that clears the Advisor,
+      # and DW generation rotates off a dead transport lane. All default-OFF in
+      # code; enabled HERE for the C2 soak. Each is fail-soft + gated.
+      #   Matrix A — self-healing transport circuit breaker (batch TIMEOUT trips
+      #   OPEN -> rotate to healthy realtime lane -> jittered HALF-OPEN probe).
+      JARVIS_TRANSPORT_BREAKER_ENABLED: "1"
+      #   Matrix B — adaptive recursive chunking on Advisor BLOCK (AST-symbol +
+      #   test-first sub-goals, adaptive governor, semantic de-dup). The op is
+      #   never lost (decomposed only when >=1 sub-goal emits, else legacy).
+      JARVIS_RECURSIVE_CHUNKING_ENABLED: "1"
+      #   C1 — call-graph blast radius (oracle.get_callers, not the file import
+      #   graph) for symbol-scoped sub-goals. Needs the oracle-blast prerequisite
+      #   (a live oracle). Fail-soft to file-level when the oracle is unavailable,
+      #   so chunking's test-first path still clears the zero-coverage veto half.
+      JARVIS_ADVISOR_ORACLE_BLAST_ENABLED: "1"
+      JARVIS_ADVISOR_CALLGRAPH_BLAST_ENABLED: "1"
 


### PR DESCRIPTION
Enables the 4 default-OFF convergence masters in docker-compose.gcp.yml so the C2 soak proves the full path end-to-end: A1 dispatch -> GOAL-001 BLOCK -> adaptive recursive chunking (test-first + AST-symbol-scoped) -> call-graph-aware Advisor clears it -> DW generation rotates off the dead batch lane onto realtime (self-healing breaker) -> orange PR.

Flags armed: JARVIS_TRANSPORT_BREAKER_ENABLED, JARVIS_RECURSIVE_CHUNKING_ENABLED, JARVIS_ADVISOR_ORACLE_BLAST_ENABLED, JARVIS_ADVISOR_CALLGRAPH_BLAST_ENABLED. All fail-soft; call-graph degrades to file-level when the oracle is unavailable (chunking's test-first path still clears the zero-coverage veto half). Builds on #69642/#69643 (A1) + #69644 (the matrices).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enabled `JARVIS_TRANSPORT_BREAKER_ENABLED`, `JARVIS_RECURSIVE_CHUNKING_ENABLED`, `JARVIS_ADVISOR_ORACLE_BLAST_ENABLED`, and `JARVIS_ADVISOR_CALLGRAPH_BLAST_ENABLED` in `docker-compose.gcp.yml` on the GCP soak node. This lets soak runs prove the full C2 path (blocked goal → test-first, symbol-scoped chunks → Advisor clearance → self-healing transport), with fail-soft fallback to file-level when the oracle is down.

<sup>Written for commit 411168ea1f0f602aebd07a64a9ee769bb60c5788. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69645?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

