### PR TITLE
fix(chunking): wire chunking seam into the LIVE extracted CLASSIFY runner (C2 soak dormant-path fix)

### DIFF
--- a/backend/core/ouroboros/governance/phase_runners/classify_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/classify_runner.py
@@ -485,6 +485,12 @@ class CLASSIFYRunner(PhaseRunner):
                         ctx.op_id,
                         is_read_only=ctx.is_read_only,
                         repo_root=_adv_repo_root,
+                        # C1: feed intake evidence so the Advisor extracts
+                        # scoped_symbols (re-injected sub-goals) → call-graph
+                        # blast radius. Matches the orchestrator inline path.
+                        intake_evidence_json=getattr(
+                            ctx, "intake_evidence_json", ""
+                        ) or "",
                     )
 
             if _advisory.decision == AdvisoryDecision.BLOCK:
@@ -494,15 +500,23 @@ class CLASSIFYRunner(PhaseRunner):
                 )
                 if _serpent:
                     await _serpent.stop(success=False)
-                ctx = ctx.advance(
-                    OperationPhase.CANCELLED,
-                    terminal_reason_code="advisor_blocked",
+                # C2 live-path fix: this EXTRACTED CLASSIFY runner is the
+                # default-on path (JARVIS_PHASE_RUNNER_CLASSIFY_EXTRACTED=true),
+                # so the BLOCK must route through the SAME chunking seam as the
+                # orchestrator's legacy inline block — otherwise recursive
+                # chunking is dormant in production (soak 2026-06-22 caught this:
+                # 17 BLOCKs, 0 decomposed). Delegates to the shared method on the
+                # orchestrator; fail-soft to the exact legacy advisor_blocked.
+                ctx = await orch._decompose_block_or_legacy(ctx, _advisory)
+                _reason = (
+                    getattr(ctx, "terminal_reason_code", None)
+                    or "advisor_blocked"
                 )
                 return PhaseResult(
                     next_ctx=ctx,
                     next_phase=None,
                     status="fail",
-                    reason="advisor_blocked",
+                    reason=_reason,
                     artifacts={
                         "advisory": _advisory,
                         "consciousness_bridge": None,


### PR DESCRIPTION
**Soak-caught 3rd-level dormant wire.** The C2 convergence soak (node jarvis-ouroboros-soak-20260621-232249) showed 17 `Advisor BLOCKED` and **0 decomposed** despite all flags armed. Root cause: `JARVIS_PHASE_RUNNER_CLASSIFY_EXTRACTED` defaults TRUE, so the LIVE BLOCK is `classify_runner.py:490` (a verbatim transcription of the old inline block) — which terminated `advisor_blocked` and never called the chunking seam the fix wave added to the orchestrator's now-dead inline block.

Fix: the extracted runner's BLOCK now routes through the shared `orch._decompose_block_or_legacy(ctx, advisory)` (same path as the orchestrator inline block) + adds the C1 `intake_evidence_json` wire so scoped_symbols reach the call-graph Advisor. Fail-soft to the exact legacy `advisor_blocked`. Orchestrator-seam tests green (7/7).

Both reviews missed this because the tests monkeypatch the orchestrator method directly and neither exercised the default-on extracted runner as the live path. The soak is the ground truth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the live extracted CLASSIFY runner so Advisor BLOCKs go through the shared chunking seam and decompose instead of stopping at `advisor_blocked`. Also passes `intake_evidence_json` to the Advisor so scoped symbols reach the call-graph; legacy reason codes are preserved.

- **Bug Fixes**
  - Route BLOCK handling through `orch._decompose_block_or_legacy` (same path as the orchestrator’s inline block).
  - Include `intake_evidence_json` in the Advisor call to enable `scoped_symbols` extraction.
  - Fail-soft to legacy behavior by preserving `terminal_reason_code` and defaulting to `advisor_blocked`.

<sup>Written for commit ec16387815c5a5b6e916d3f069e0b36cc4cf89fb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69646?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

