### PR TITLE
feat(egress): Sovereign Egress Interceptor Mesh — local pre-flight guard so DW never sees a malformed/oversized request

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4078,7 +4078,43 @@ class CandidateGenerator:
                     is_internal_fault as _s185_internal,
                     is_generation_timeout as _s241_gen_timeout,
                     is_fsm_exhaustion as _fsm_exhausted,
+                    is_local_egress_overweight as _egress_overweight,
                 )
+                # Sovereign Egress Interceptor Mesh (T3) — OUR-side egress
+                # interceptor blocked an over-ceiling body. DW never received the
+                # request (good API citizenship); no socket failed. Classify
+                # LOCAL_EGRESS_OVERWEIGHT (weight 0.0) so it NEVER trips the model/
+                # topology breaker or corrupts surface-health, THEN re-raise the
+                # ORIGINAL exception so its structured ``max_allowed_size`` survives
+                # to the orchestrator's generate-failure path, which routes it BACK
+                # to context-aware chunking (decompose_for_block(compression_target)).
+                # Re-raising immediately is correct: every sibling model would
+                # reject the SAME oversized body, so continuing the rotation only
+                # burns the loop and discards the compression math. Fail-soft:
+                # classification + report_failure are best-effort and never block
+                # the re-raise.
+                if _egress_overweight(exc):
+                    try:
+                        sentinel.report_failure(
+                            model_id,
+                            FailureSource.LOCAL_EGRESS_OVERWEIGHT,
+                            f"{type(exc).__name__}:{str(exc)[:120]}",
+                        )
+                    except Exception:  # noqa: BLE001 — telemetry, never block
+                        logger.debug(
+                            "[CandidateGenerator] egress-overweight report_failure raised",
+                            exc_info=True,
+                        )
+                    logger.warning(
+                        "[CandidateGenerator] LOCAL_EGRESS_OVERWEIGHT (weight 0.0, "
+                        "NOT a vendor rupture): our egress interceptor blocked an "
+                        "over-ceiling body for model=%s — re-raising with "
+                        "max_allowed_size=%s so the orchestrator re-chunks to fit "
+                        "(op=%s)",
+                        model_id, getattr(exc, "max_allowed_size", "?"),
+                        op_id_short,
+                    )
+                    raise exc
                 if _s185_internal(exc):
                     logger.error(
                         "[CandidateGenerator] INTERNAL_FAULT (%s) — NOT a vendor rupture; "

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -5208,6 +5208,20 @@ class DoublewordProvider:
         if response_format is not None:
             body["response_format"] = response_format
 
+        # Sovereign Egress Interceptor (review finding #1) — guard the heavy
+        # non-streaming lane too so I1 (DW never receives an oversized/malformed
+        # request) holds on EVERY generation egress, not just the two GENERATE
+        # chokepoints. Same fail-soft asymmetry: confirmed overweight blocks;
+        # any sanitize/estimate bug passes through.
+        if egress_interceptor_enabled():
+            try:
+                body = sanitize_egress_body(body, effective_model)
+                assert_egress_weight(body, effective_model)
+            except LocalEgressOverweightError:
+                raise
+            except Exception:  # noqa: BLE001 — never block a valid request
+                pass
+
         session = await self._get_session()
         t0 = time.monotonic()
 

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -54,6 +54,15 @@ from backend.core.ouroboros.governance.stream_rupture import (
 from backend.core.ouroboros.governance.control_plane_watchdog import (
     recent_lag_ms as _recent_lag_ms,
 )
+# T2 — Sovereign Egress Interceptor: sanitize + weight-check bodies before
+# they leave the process toward DoubleWord. Lazy provider-imports live inside
+# dw_egress_interceptor.py (not here) to avoid any circular-import cycle.
+from backend.core.ouroboros.governance.dw_egress_interceptor import (
+    LocalEgressOverweightError,
+    assert_egress_weight,
+    egress_interceptor_enabled,
+    sanitize_egress_body,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -1712,38 +1721,51 @@ class DoublewordProvider:
         # Slice 38 — canonical JSONL composition via single helper.
         # Replaces raw ``json.dumps(...)`` which omitted the trailing
         # ``\n`` and made DW reject the upload with HTTP 500.
+        # T2 — Batch egress chokepoint: build the inner body dict as a local
+        # variable so the egress interceptor can sanitize + weight-check it
+        # BEFORE it is serialized into JSONL. I2 asymmetry: only CONFIRMED
+        # overweight blocks; sanitize/estimate errors pass through unchanged.
+        _batch_body: dict = {
+            "model": _effective_model,
+            "messages": [
+                {"role": "system", "content": (
+                    "You are a code generation assistant. RESPOND WITH ONLY A SINGLE VALID JSON OBJECT. "
+                    "RULES: "
+                    "1. Start your response with { and end with }. "
+                    "2. No text before or after the JSON. No markdown fences. No explanations. "
+                    "3. All string values must use double quotes. Escape special characters: use \\n for newlines, \\t for tabs, \\\\ for backslashes. "
+                    "4. No trailing commas before } or ]. "
+                    "5. Use schema_version '2b.1' with full_content containing the COMPLETE file. "
+                    "6. NEVER return unified diffs, patches, or partial file content. "
+                    "7. CRITICAL: Every candidate MUST include a non-empty 'rationale' field "
+                    "(1 sentence, max 200 chars). Missing rationale will be rejected."
+                )},
+                {"role": "user", "content": prompt},
+            ],
+            "max_tokens": _retry_max_tokens,
+            "temperature": _DW_TEMPERATURE,
+            # Slice 54/55 — Qwen3.5 reasoning control. reasoning_effort
+            # (DW-honored; the old enable_thinking flag was ignored) is
+            # derived from task_complexity (Slice 55) — leaf work stays
+            # "none" (fast/cheap), high-impact core gets a CoT buffer.
+            **_reasoning_request_params(
+                complexity=getattr(ctx, "task_complexity", "") or "",
+                model=_effective_model,
+            ),
+        }
+        if egress_interceptor_enabled():
+            try:
+                _batch_body = sanitize_egress_body(_batch_body, _effective_model)
+                assert_egress_weight(_batch_body, _effective_model)
+            except LocalEgressOverweightError:
+                raise  # block egress; bubbles to candidate_generator (T3)
+            except Exception:  # noqa: BLE001
+                pass  # I2: sanitize/estimate bug never blocks valid request
         jsonl_line = self._compose_jsonl_batch_entry({
             "custom_id": operation_id,
             "method": "POST",
             "url": "/v1/chat/completions",
-            "body": {
-                "model": _effective_model,
-                "messages": [
-                    {"role": "system", "content": (
-                        "You are a code generation assistant. RESPOND WITH ONLY A SINGLE VALID JSON OBJECT. "
-                        "RULES: "
-                        "1. Start your response with { and end with }. "
-                        "2. No text before or after the JSON. No markdown fences. No explanations. "
-                        "3. All string values must use double quotes. Escape special characters: use \\n for newlines, \\t for tabs, \\\\ for backslashes. "
-                        "4. No trailing commas before } or ]. "
-                        "5. Use schema_version '2b.1' with full_content containing the COMPLETE file. "
-                        "6. NEVER return unified diffs, patches, or partial file content. "
-                        "7. CRITICAL: Every candidate MUST include a non-empty 'rationale' field "
-                        "(1 sentence, max 200 chars). Missing rationale will be rejected."
-                    )},
-                    {"role": "user", "content": prompt},
-                ],
-                "max_tokens": _retry_max_tokens,
-                "temperature": _DW_TEMPERATURE,
-                # Slice 54/55 — Qwen3.5 reasoning control. reasoning_effort
-                # (DW-honored; the old enable_thinking flag was ignored) is
-                # derived from task_complexity (Slice 55) — leaf work stays
-                # "none" (fast/cheap), high-impact core gets a CoT buffer.
-                **_reasoning_request_params(
-                    complexity=getattr(ctx, "task_complexity", "") or "",
-                    model=_effective_model,
-                ),
-            },
+            "body": _batch_body,
         })
 
         # Slice 35 Phase 2 — batch path stage profiler (composes
@@ -3141,6 +3163,19 @@ class DoublewordProvider:
                 # task_complexity (see _reasoning_request_params).
                 **_reasoning_request_params(complexity=_complexity or "", model=_effective_model),
             }
+
+            # T2 — Realtime egress chokepoint: sanitize + weight-check the
+            # assembled body BEFORE stream flag is set or session.post fires.
+            # I2 asymmetry (binding): only CONFIRMED overweight blocks;
+            # sanitize/estimate errors never block a valid request.
+            if egress_interceptor_enabled():
+                try:
+                    body = sanitize_egress_body(body, _effective_model)
+                    assert_egress_weight(body, _effective_model)
+                except LocalEgressOverweightError:
+                    raise  # block egress; bubbles to candidate_generator (T3)
+                except Exception:  # noqa: BLE001
+                    pass  # I2: sanitize/estimate bug never blocks valid request
 
             if _stream_callback is not None:
                 # Streaming path: SSE for token-by-token output.

--- a/backend/core/ouroboros/governance/dw_egress_interceptor.py
+++ b/backend/core/ouroboros/governance/dw_egress_interceptor.py
@@ -1,0 +1,308 @@
+"""dw_egress_interceptor.py -- Sovereign Egress Interceptor: local pre-flight guard.
+
+Sanitizes and weight-checks request bodies BEFORE they leave the process toward
+DoubleWord. Zero network I/O on the hot path. Fail-soft asymmetry (binding):
+  - sanitize/estimate ERROR -> pass-through (never blocks)
+  - CONFIRMED overweight     -> raise LocalEgressOverweightError
+
+Lazy imports of doubleword_provider/_dw_model_min_effort/_clamp_up_to_min and
+dw_catalog_client.ModelCard are done INSIDE functions (not at module top) to
+avoid a circular-import cycle: T2 will make doubleword_provider import this module.
+
+All public functions are wrapped fail-soft per the I2 asymmetry requirement.
+ASCII-only source. Python 3.9+.
+"""
+from __future__ import annotations
+
+import json
+import os
+from typing import Dict
+
+
+# ---------------------------------------------------------------------------
+# Error
+# ---------------------------------------------------------------------------
+
+
+class LocalEgressOverweightError(Exception):
+    """Raised when the estimated egress body size exceeds the local ceiling.
+
+    Carries enough math for the caller to decide on a remediation strategy
+    (e.g. trim messages, compress, or route to a larger context model).
+
+    ``required_compression_ratio`` is guaranted non-ZeroDivisionError:
+    when ``max_allowed_size==0`` we clamp to ``attempted_size`` (ratio >= 1.0).
+    """
+
+    def __init__(
+        self,
+        *,
+        attempted_size: int,
+        max_allowed_size: int,
+        model: str,
+    ) -> None:
+        self.attempted_size: int = attempted_size
+        self.max_allowed_size: int = max_allowed_size
+        self.model: str = model
+        # Guard /0: if ceiling is 0 treat it as 1 so ratio is always >= 1.
+        divisor = max(1, max_allowed_size)
+        self.required_compression_ratio: float = attempted_size / divisor
+        super().__init__(
+            f"Egress body too large for model={model!r}: "
+            f"{attempted_size} chars > ceiling {max_allowed_size} "
+            f"(need {self.required_compression_ratio:.2f}x compression)"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Master switch
+# ---------------------------------------------------------------------------
+
+
+def egress_interceptor_enabled() -> bool:
+    """Return True unless JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED is falsy.
+
+    Default TRUE (safe-by-default: guard is ON unless the operator opts out).
+    NEVER raises.
+    """
+    return os.environ.get(
+        "JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "true"
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+# ---------------------------------------------------------------------------
+# Estimation
+# ---------------------------------------------------------------------------
+
+
+def estimate_body_chars(body: dict) -> int:
+    """Estimate the character footprint of a request body.
+
+    Sums len(str(content)) for every message in body["messages"] and also
+    the top-level "prompt" key when present. Fail-soft: any error -> 0.
+    """
+    try:
+        total = 0
+        msgs = body.get("messages")
+        if isinstance(msgs, list):
+            for msg in msgs:
+                if isinstance(msg, dict):
+                    content = msg.get("content")
+                    if content is not None:
+                        total += len(str(content))
+        # Also count a top-level "prompt" key if present (some DW routes use it).
+        prompt = body.get("prompt")
+        if prompt is not None:
+            total += len(str(prompt))
+        return total
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+# ---------------------------------------------------------------------------
+# Ceiling
+# ---------------------------------------------------------------------------
+
+_DEFAULT_EGRESS_MAX_CHARS: int = 600_000
+_DEFAULT_CHARS_PER_TOKEN: int = 4
+
+
+def _model_card_char_budget(model: str) -> int | None:
+    """Return the char budget derived from the catalog ModelCard for ``model``.
+
+    Uses load_cached_snapshot (no network I/O) so this is fast and fail-soft.
+    Returns None when the card or context_window is unavailable.
+    """
+    try:
+        from backend.core.ouroboros.governance.dw_catalog_client import (  # noqa: PLC0415
+            load_cached_snapshot,
+        )
+        snapshot = load_cached_snapshot()
+        if snapshot is None:
+            return None
+        chars_per_token = int(
+            os.environ.get("JARVIS_DW_EGRESS_CHARS_PER_TOKEN", str(_DEFAULT_CHARS_PER_TOKEN))
+        )
+        mid_lower = model.strip().lower()
+        for card in snapshot.models:
+            if card.model_id.strip().lower() == mid_lower:
+                if isinstance(card.context_window, int) and card.context_window > 0:
+                    return card.context_window * chars_per_token
+                return None
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def egress_char_ceiling(model: str) -> int:
+    """Return the char ceiling for ``model``.
+
+    min(env JARVIS_DW_EGRESS_MAX_CHARS, ModelCard budget when available).
+    Fail-soft -> env cap.
+    """
+    try:
+        env_cap = int(
+            os.environ.get("JARVIS_DW_EGRESS_MAX_CHARS", str(_DEFAULT_EGRESS_MAX_CHARS))
+        )
+    except (ValueError, TypeError):
+        env_cap = _DEFAULT_EGRESS_MAX_CHARS
+    try:
+        card_budget = _model_card_char_budget(model)
+        if card_budget is not None:
+            return min(env_cap, card_budget)
+        return env_cap
+    except Exception:  # noqa: BLE001
+        return env_cap
+
+
+# ---------------------------------------------------------------------------
+# Sanitize registry
+# ---------------------------------------------------------------------------
+
+
+_BUILTIN_RULES: Dict[str, dict] = {
+    # gpt-oss family: cannot disable reasoning -> must floor effort UP.
+    "gpt-oss": {"floor_reasoning": True},
+}
+
+
+def _sanitize_rules() -> Dict[str, dict]:
+    """Return the merged sanitize-rule map: built-ins + env overrides.
+
+    Env format (JARVIS_DW_EGRESS_SANITIZE_RULES):
+        "substr={strip:p1|p2;floor_reasoning:true},..."
+
+    Example:
+        JARVIS_DW_EGRESS_SANITIZE_RULES="my-model={strip:top_p|temperature}"
+
+    Built-in rules are always included; env adds or overrides by substr key.
+    Unknown / malformed entries are skipped (fail-soft).
+    NEVER raises.
+    """
+    rules: Dict[str, dict] = dict(_BUILTIN_RULES)
+    raw = os.environ.get("JARVIS_DW_EGRESS_SANITIZE_RULES", "").strip()
+    if not raw:
+        return rules
+    try:
+        # Simple bespoke parser: key={directive;directive,...},...
+        # We consume token by token (no regex dep needed).
+        remaining = raw
+        while remaining:
+            remaining = remaining.strip()
+            if not remaining:
+                break
+            # Find '=' that precedes a '{'
+            eq_pos = remaining.find("={")
+            if eq_pos < 0:
+                break
+            substr_key = remaining[:eq_pos].strip().lower()
+            remaining = remaining[eq_pos + 1:]  # starts with '{'
+            # Find matching '}'
+            close = remaining.find("}")
+            if close < 0:
+                break
+            directive_str = remaining[1:close]  # inside the braces
+            remaining = remaining[close + 1:].lstrip(",")
+            # Parse directives: semicolon-separated key:value pairs
+            entry: dict = {}
+            for directive in directive_str.split(";"):
+                directive = directive.strip()
+                if not directive:
+                    continue
+                if directive.startswith("strip:"):
+                    params = [p.strip() for p in directive[6:].split("|") if p.strip()]
+                    entry["strip"] = params
+                elif directive.startswith("floor_reasoning:"):
+                    val = directive[16:].strip().lower()
+                    entry["floor_reasoning"] = val not in ("0", "false", "no", "off")
+            if substr_key and entry:
+                rules[substr_key] = entry
+    except Exception:  # noqa: BLE001
+        pass
+    return rules
+
+
+def _apply_rule(body: dict, rule: dict) -> dict:
+    """Apply a single sanitize rule to a copy of ``body``.
+
+    Handles two directives:
+      - strip: [param, ...] — removes listed top-level keys
+      - floor_reasoning: True — delegates to doubleword_provider reasoning floor
+
+    Lazy import of doubleword_provider to avoid circular import cycle.
+    NEVER raises (fail-soft -> return body unchanged on any error).
+    """
+    try:
+        out = dict(body)
+        # Strip unsupported params.
+        for param in rule.get("strip", []):
+            out.pop(param, None)
+        # Reasoning floor: delegate to the existing floor logic (no reimplementation).
+        if rule.get("floor_reasoning"):
+            try:
+                from backend.core.ouroboros.governance.doubleword_provider import (  # noqa: PLC0415
+                    _dw_model_min_effort,
+                    _clamp_up_to_min,
+                )
+                model = body.get("model", "")
+                current_effort = out.get("reasoning_effort", "none")
+                floor = _dw_model_min_effort(model)
+                floored = _clamp_up_to_min(str(current_effort), floor)
+                out["reasoning_effort"] = floored
+            except Exception:  # noqa: BLE001
+                pass  # fail-soft: leave reasoning_effort unchanged
+        return out
+    except Exception:  # noqa: BLE001
+        return body
+
+
+def sanitize_egress_body(body: dict, model: str) -> dict:
+    """Sanitize ``body`` for ``model`` using the extensible rule registry.
+
+    Applies rules whose substring key appears in ``model`` (case-insensitive).
+    Unknown model (no matching rule) -> returns ``body`` unchanged.
+    Fail-soft: any error -> return original ``body`` unchanged.
+    Data-driven: NO hardcoded model if/elif chains in the apply loop.
+    """
+    try:
+        rules = _sanitize_rules()
+        mid_lower = model.strip().lower()
+        out = body
+        matched = False
+        for substr, rule in rules.items():
+            if substr in mid_lower:
+                out = _apply_rule(out, rule)
+                matched = True
+        # Unknown model (no rule matched) -> pass-through.
+        if not matched:
+            return body
+        return out
+    except Exception:  # noqa: BLE001
+        return body
+
+
+# ---------------------------------------------------------------------------
+# Weight assertion
+# ---------------------------------------------------------------------------
+
+
+def assert_egress_weight(body: dict, model: str) -> None:
+    """Raise LocalEgressOverweightError if body exceeds the char ceiling.
+
+    Estimation errors -> no raise (fail-soft asymmetry: only CONFIRMED
+    overweight blocks; uncertainty never blocks).
+    """
+    try:
+        weight = estimate_body_chars(body)
+    except Exception:  # noqa: BLE001
+        return  # estimation failed -> fail-soft, no block
+    try:
+        ceiling = egress_char_ceiling(model)
+    except Exception:  # noqa: BLE001
+        return  # ceiling lookup failed -> fail-soft, no block
+    if weight > ceiling:
+        raise LocalEgressOverweightError(
+            attempted_size=weight,
+            max_allowed_size=ceiling,
+            model=model,
+        )

--- a/backend/core/ouroboros/governance/dw_egress_interceptor.py
+++ b/backend/core/ouroboros/governance/dw_egress_interceptor.py
@@ -226,8 +226,8 @@ def _apply_rule(body: dict, rule: dict) -> dict:
     """Apply a single sanitize rule to a copy of ``body``.
 
     Handles two directives:
-      - strip: [param, ...] — removes listed top-level keys
-      - floor_reasoning: True — delegates to doubleword_provider reasoning floor
+      - strip: [param, ...] - removes listed top-level keys
+      - floor_reasoning: True - delegates to doubleword_provider reasoning floor
 
     Lazy import of doubleword_provider to avoid circular import cycle.
     NEVER raises (fail-soft -> return body unchanged on any error).

--- a/backend/core/ouroboros/governance/dw_fault_taxonomy.py
+++ b/backend/core/ouroboros/governance/dw_fault_taxonomy.py
@@ -110,3 +110,23 @@ def is_fsm_exhaustion(exc: BaseException) -> bool:
         return any(m in msg for m in _FSM_EXHAUSTION_MARKERS)
     except Exception:  # noqa: BLE001 — the taxonomy must never itself throw
         return False
+
+
+def is_local_egress_overweight(exc: BaseException) -> bool:
+    """True iff ``exc`` is a ``LocalEgressOverweightError`` — OUR-side egress
+    interceptor refusing to dispatch a body bigger than the local ceiling
+    (Sovereign Egress Interceptor Mesh, T1). This is NOT a vendor rupture: no
+    socket failed, DoubleWord never even received the request — WE blocked it to
+    stay a good API citizen. Like FSM_EXHAUSTED it must classify weight-0.0
+    (``FailureSource.LOCAL_EGRESS_OVERWEIGHT``) so it NEVER trips the DW model /
+    topology breaker or corrupts surface-health; instead the orchestrator routes
+    it BACK to context-aware chunking. Type-matched (no fragile string match) via
+    an isolated lazy import so this taxonomy module stays import-light and
+    NEVER raises → False."""
+    try:
+        from backend.core.ouroboros.governance.dw_egress_interceptor import (  # noqa: PLC0415
+            LocalEgressOverweightError,
+        )
+        return isinstance(exc, LocalEgressOverweightError)
+    except Exception:  # noqa: BLE001 — the taxonomy must never itself throw
+        return False

--- a/backend/core/ouroboros/governance/goal_decomposition_planner.py
+++ b/backend/core/ouroboros/governance/goal_decomposition_planner.py
@@ -686,6 +686,95 @@ def heuristic_decompose(goal: Any) -> Tuple[SubGoal, ...]:
 
 
 # ---------------------------------------------------------------------------
+# Sovereign Egress Interceptor Mesh (T3) — compression-target estimation
+# ---------------------------------------------------------------------------
+
+
+def _read_source_for_estimate(file_path: str) -> str:
+    """Read ``file_path`` for payload estimation. Fail-soft -> "".
+
+    Kept as a tiny module-level seam so the compression-target estimator is
+    injectable in tests (monkeypatch this) without a real filesystem. NEVER
+    raises."""
+    try:
+        with open(file_path, encoding="utf-8", errors="replace") as fh:
+            return fh.read()
+    except Exception:  # noqa: BLE001 — estimation must never block decomposition
+        return ""
+
+
+def _symbol_segment_chars(
+    ref: str,
+    *,
+    scoped_targets_by_ref: Mapping[str, "ScopedTargetLike"],
+    source_reader: Callable[[str], str],
+) -> int:
+    """Estimate the source-segment char footprint of one ``"file::Symbol"``
+    ref using its scoper line range. Fail-soft -> a small constant. NEVER
+    raises."""
+    try:
+        tgt = scoped_targets_by_ref.get(ref)
+        if tgt is None:
+            return len(ref)
+        fp = str(getattr(tgt, "file_path", "") or "")
+        start = int(getattr(tgt, "lineno", 0) or 0)
+        end = int(getattr(tgt, "end_lineno", 0) or 0)
+        source = source_reader(fp)
+        if not source or start <= 0 or end < start:
+            return len(ref)
+        lines = source.splitlines(keepends=True)
+        # 1-indexed inclusive line range -> slice.
+        segment = "".join(lines[start - 1:end])
+        return len(segment) if segment else len(ref)
+    except Exception:  # noqa: BLE001
+        return len(ref)
+
+
+def estimate_subgoal_payload_chars(
+    sub_goal: "SubGoal",
+    *,
+    source_reader: Callable[[str], str] | None = None,
+    scoped_targets_by_ref: "Mapping[str, ScopedTargetLike] | None" = None,
+) -> int:
+    """Estimate the egress payload (chars) a sub-goal would carry.
+
+    Reuses T1's :func:`estimate_body_chars` (dw_egress_interceptor) over a
+    pseudo request body composed of the sub-goal's description PLUS the source
+    segments of its scoped symbols (the file content the model must read/edit
+    to satisfy the sub-goal). This is the same notion of "body weight" the
+    egress interceptor measures, so the chunker slices against the SAME ruler
+    that blocked the dispatch. Fail-soft -> len(description). NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.governance.dw_egress_interceptor import (  # noqa: PLC0415
+            estimate_body_chars as _estimate_body_chars,
+        )
+        reader = source_reader or _read_source_for_estimate
+        by_ref = scoped_targets_by_ref or {}
+        content = str(getattr(sub_goal, "description", "") or "")
+        for ref in (getattr(sub_goal, "scoped_symbols", ()) or ()):
+            content += _symbol_segment_chars(
+                # _symbol_segment_chars returns an int count; accumulate it
+                # as a synthetic block so estimate_body_chars sums correctly.
+                str(ref),
+                scoped_targets_by_ref=by_ref,
+                source_reader=reader,
+            ) * "x"
+        body = {"messages": [{"content": content}]}
+        return _estimate_body_chars(body)
+    except Exception:  # noqa: BLE001
+        try:
+            return len(str(getattr(sub_goal, "description", "") or ""))
+        except Exception:  # noqa: BLE001
+            return 0
+
+
+# A duck-typed alias for the scoper's ScopedTarget (avoids an import cycle /
+# hard dependency at module load — the planner already lazy-imports the scoper).
+ScopedTargetLike = Any
+
+
+# ---------------------------------------------------------------------------
 # B2: Test-first prerequisite injection (decompose_for_block)
 # ---------------------------------------------------------------------------
 
@@ -695,6 +784,7 @@ def decompose_for_block(
     *,
     zero_coverage: bool,
     scoper: Any = None,
+    compression_target: int | None = None,
 ) -> Tuple[SubGoal, ...]:
     """Decompose a GOAL for an OperationAdvisor BLOCK into topo-ordered SubGoals.
 
@@ -716,6 +806,15 @@ def decompose_for_block(
         zero_coverage: When True, prepend a test-gen sub-goal.
         scoper: Callable with the same signature as ``isolate_symbols``
                 (injectable for testing; defaults to B1 ``isolate_symbols``).
+        compression_target: Sovereign Egress Interceptor Mesh (T3). When set
+                (the interceptor's ``max_allowed_size``), the scoped symbols are
+                partitioned so each emitted mutation sub-goal's estimated payload
+                (via T1 ``estimate_body_chars``, reused by
+                ``estimate_subgoal_payload_chars``) is <= the target — a too-large
+                symbol SET is split into several sub-goals; a single irreducible
+                symbol is emitted alone with a WARNING (never silently exceeded).
+                ``None`` (default) is byte-identical to the legacy single
+                mutation sub-goal.
 
     Returns:
         Non-empty topo-ordered tuple of :class:`SubGoal` artifacts.
@@ -776,18 +875,22 @@ def decompose_for_block(
     # those (no symbol to scope to → Advisor stays file-level).
     def _scoped_files_for(
         files: Tuple[str, ...],
-    ) -> Tuple[Tuple[str, ...], Tuple[str, ...]]:
-        """Return ``(bearing_files, scoped_symbols)``.
+    ) -> Tuple[Tuple[str, ...], Tuple[str, ...], Dict[str, Any]]:
+        """Return ``(bearing_files, scoped_symbols, targets_by_ref)``.
 
         ``bearing_files`` is the set of files that are mutation targets
         (or all files if the scoper is unavailable / fails — fail-soft).
         ``scoped_symbols`` is the de-duplicated tuple of ``"file::Symbol"``
         refs the scoper matched (empty when the scoper is unavailable, no
-        symbol matched, or only whole-file fallbacks were produced)."""
+        symbol matched, or only whole-file fallbacks were produced).
+        ``targets_by_ref`` maps each ref to its ScopedTarget (carrying the
+        line range) so the T3 compression-target slicer can estimate each
+        symbol's source-segment footprint. Empty when no symbols matched."""
         if not files or scoper is None:
-            return files, ()
+            return files, (), {}
         bearing: list[str] = []
         symbols: list[str] = []
+        by_ref: Dict[str, Any] = {}
         seen: set[str] = set()
         for fp in files:
             try:
@@ -805,14 +908,93 @@ def decompose_for_block(
                     if ref not in seen:
                         seen.add(ref)
                         symbols.append(ref)
+                        by_ref[ref] = tgt
             except Exception:  # noqa: BLE001
                 bearing.append(fp)
         bearing_t = tuple(bearing) if bearing else files
-        return bearing_t, tuple(symbols)
+        return bearing_t, tuple(symbols), by_ref
 
-    symbol_files, scoped_symbols = _scoped_files_for(target_files)
+    symbol_files, scoped_symbols, _targets_by_ref = _scoped_files_for(target_files)
     if not symbol_files:
         symbol_files = target_files or ("",)
+
+    # --- T3 compression-target slicing -------------------------------------
+    # When a compression_target is supplied (the egress interceptor's
+    # max_allowed_size), partition the scoped symbols into ordered groups so
+    # each group's estimated payload (via T1's estimate_body_chars, reused by
+    # estimate_subgoal_payload_chars) is <= the target. A single symbol that
+    # alone exceeds the target is IRREDUCIBLE — it is emitted on its own with a
+    # clear WARNING (never silently exceeded, never dropped). Returns the
+    # ORIGINAL whole set as one group when chunking is unnecessary or unset, so
+    # the legacy behavior is byte-identical (compression_target=None / no
+    # symbols / fits-already). NEVER raises.
+    def _partition_for_target(
+        refs: Tuple[str, ...],
+    ) -> List[Tuple[str, ...]]:
+        if compression_target is None or compression_target <= 0:
+            return [refs] if refs else [()]
+        if not refs:
+            return [()]
+        try:
+            # Every sub-goal also carries the description in its payload (see
+            # estimate_subgoal_payload_chars), so reserve that floor from the
+            # symbol budget — keeps the FULL estimated payload <= target, not
+            # just the symbol segments. Clamp the effective budget to >=1 so a
+            # description already at/over the ceiling still makes forward
+            # progress (one symbol per group) rather than looping.
+            _desc_floor = len(description or "")
+            _budget = max(1, compression_target - _desc_floor)
+
+            # Per-symbol estimate via the shared T1 estimator (same ruler as
+            # the interceptor). A symbol is the source segment of its node.
+            def _ref_chars(ref: str) -> int:
+                seg = _symbol_segment_chars(
+                    ref,
+                    scoped_targets_by_ref=_targets_by_ref,
+                    source_reader=_read_source_for_estimate,
+                )
+                return int(seg)
+
+            groups: List[Tuple[str, ...]] = []
+            current: List[str] = []
+            current_chars = 0
+            for ref in refs:
+                rc = _ref_chars(ref)
+                if rc > _budget:
+                    # Irreducible: flush any pending group, emit this symbol
+                    # alone, and WARN — never silently exceed.
+                    if current:
+                        groups.append(tuple(current))
+                        current = []
+                        current_chars = 0
+                    logger.warning(
+                        "[Chunking] IRREDUCIBLE symbol %r estimated %d chars > "
+                        "compression_target %d — emitting it as a standalone "
+                        "sub-goal (cannot split a single symbol further); the "
+                        "egress interceptor may still block it, but it is NEVER "
+                        "silently dropped or under-reported",
+                        ref, rc, compression_target,
+                    )
+                    groups.append((ref,))
+                    continue
+                if current and (current_chars + rc) > _budget:
+                    groups.append(tuple(current))
+                    current = [ref]
+                    current_chars = rc
+                else:
+                    current.append(ref)
+                    current_chars += rc
+            if current:
+                groups.append(tuple(current))
+            return groups or [refs]
+        except Exception:  # noqa: BLE001 — fail-soft: one group = legacy
+            logger.debug(
+                "[Chunking] compression-target partition fail-soft -> single "
+                "group", exc_info=True,
+            )
+            return [refs]
+
+    _symbol_groups = _partition_for_target(scoped_symbols)
 
     boundary = _is_boundary_crossed(symbol_files)
 
@@ -849,38 +1031,44 @@ def decompose_for_block(
             boundary_crossed=boundary,
         ))
 
-        # step-01: mutation sub-goal that blocks on the test.
-        # Only the MUTATION sub-goal carries scoped_symbols — the test-gen
+        # step-01..: mutation sub-goal(s) that block on the test.
+        # Only the MUTATION sub-goals carry scoped_symbols — the test-gen
         # sub-goal above writes a new test file, it doesn't mutate the
-        # scoped symbols, so its blast stays file-level.
-        mutation_id = f"{parent_id}::step-01"
-        out.append(SubGoal(
-            sub_goal_id=mutation_id,
-            parent_goal_id=parent_id,
-            title=title,
-            description=description,
-            kind=SubGoalKind.SEQUENTIAL,
-            target_files=symbol_files,
-            depends_on_sub_ids=(test_id,),
-            estimated_complexity="moderate",
-            boundary_crossed=boundary,
-            scoped_symbols=scoped_symbols,
-        ))
+        # scoped symbols, so its blast stays file-level. When a
+        # compression_target split the symbols into >1 group, emit one
+        # mutation sub-goal per group (each <= target); otherwise byte-
+        # identical single step-01.
+        for _gi, _group in enumerate(_symbol_groups, start=1):
+            mutation_id = f"{parent_id}::step-{_gi:02d}"
+            out.append(SubGoal(
+                sub_goal_id=mutation_id,
+                parent_goal_id=parent_id,
+                title=title,
+                description=description,
+                kind=SubGoalKind.SEQUENTIAL,
+                target_files=symbol_files,
+                depends_on_sub_ids=(test_id,),
+                estimated_complexity="moderate",
+                boundary_crossed=boundary,
+                scoped_symbols=_group,
+            ))
     else:
-        # No test-gen sub-goal; just the (symbol-scoped) mutation sub-goal.
-        mutation_id = f"{parent_id}::step-00"
-        out.append(SubGoal(
-            sub_goal_id=mutation_id,
-            parent_goal_id=parent_id,
-            title=title,
-            description=description,
-            kind=SubGoalKind.SEQUENTIAL if boundary else SubGoalKind.ATOMIC,
-            target_files=symbol_files,
-            depends_on_sub_ids=(),
-            estimated_complexity="moderate",
-            boundary_crossed=boundary,
-            scoped_symbols=scoped_symbols,
-        ))
+        # No test-gen sub-goal; just the (symbol-scoped) mutation sub-goal(s).
+        # One sub-goal per compression-target group (legacy single when unset).
+        for _gi, _group in enumerate(_symbol_groups):
+            mutation_id = f"{parent_id}::step-{_gi:02d}"
+            out.append(SubGoal(
+                sub_goal_id=mutation_id,
+                parent_goal_id=parent_id,
+                title=title,
+                description=description,
+                kind=SubGoalKind.SEQUENTIAL if boundary else SubGoalKind.ATOMIC,
+                target_files=symbol_files,
+                depends_on_sub_ids=(),
+                estimated_complexity="moderate",
+                boundary_crossed=boundary,
+                scoped_symbols=_group,
+            ))
 
     return tuple(out)
 
@@ -1867,6 +2055,7 @@ __all__ = [
     "status_glyph",
     "heuristic_decompose",
     "decompose_for_block",
+    "estimate_subgoal_payload_chars",
     "decompose_goal",
     "emit_sub_goal_envelopes",
     "decompose_and_emit",

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -93,6 +93,36 @@ logger = logging.getLogger("Ouroboros.GovernedLoop")
 
 
 # ---------------------------------------------------------------------------
+# T4 — Sovereign Telemetry Boot-Guard
+# ---------------------------------------------------------------------------
+# Extracted helper so unit tests can verify the exact warning string without
+# booting the full GovernedLoopService. Default-ON means this fires ONLY when
+# an operator has explicitly set JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=false
+# (or 0/no/off). Never raises — boot must never crash due to this guard.
+
+
+def _warn_if_egress_guard_disabled(log: logging.Logger) -> bool:
+    """Emit a loud [SOVEREIGN WARNING] when the egress interceptor is OFF.
+
+    Returns True (warning emitted) when the guard is disabled, False otherwise.
+    NEVER raises — the check is always fail-soft.
+    """
+    try:
+        from backend.core.ouroboros.governance.dw_egress_interceptor import (
+            egress_interceptor_enabled,
+        )
+        if not egress_interceptor_enabled():
+            log.warning(
+                "[SOVEREIGN WARNING] API Citizenship Guard Disabled: Egress Interceptor "
+                "is OFF. Node is vulnerable to overweight payload dispatch."
+            )
+            return True
+    except Exception:  # noqa: BLE001
+        pass  # never let this guard crash boot
+    return False
+
+
+# ---------------------------------------------------------------------------
 # Slice 2B-ii.1 — Aegis-aware provider construction gate
 # ---------------------------------------------------------------------------
 # Closes the Catch-22 surfaced by Aegis Detonation soak bt-2026-05-24-222008:
@@ -1426,6 +1456,12 @@ class GovernedLoopService:
             self._seed_autonomy_policies()
             self._attach_to_stack()
             self._started_at = time.monotonic()
+
+            # T4 — Sovereign Telemetry Boot-Guard: emit a loud [SOVEREIGN WARNING]
+            # when the operator has explicitly disabled the egress interceptor.
+            # Default-ON (guard is active), so this fires only on an opt-out.
+            # Fail-soft — never raises, never blocks boot.
+            _warn_if_egress_guard_disabled(logger)
 
             # Wire curriculum and reactor event background tasks
             if self._config.curriculum_enabled:

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2074,8 +2074,16 @@ class GovernedOrchestrator:
         self,
         ctx: OperationContext,
         advisory: Any,
+        *,
+        compression_target: int | None = None,
     ) -> OperationContext:
         """B5 -- the BLOCK -> decompose -> re-inject seam.
+
+        Sovereign Egress Interceptor Mesh (T3): ``compression_target`` (the
+        egress interceptor's ``max_allowed_size``) is threaded into
+        ``decompose_for_block`` so each re-injected sub-goal's estimated
+        payload fits under the local egress ceiling. ``None`` (default) is
+        byte-identical to the legacy BLOCK-decompose behavior.
 
         At the OperationAdvisor BLOCK site, attempt to decompose the GOAL
         into AST-symbol-scoped + test-first sub-goals and re-inject them via
@@ -2200,6 +2208,7 @@ class GovernedOrchestrator:
                         # the test and silently drop the actual fix.)
                         _all_subs = decompose_for_block(
                             goal, zero_coverage=zero_cov,
+                            compression_target=compression_target,
                         )
                         _prereq = [
                             s for s in _all_subs if not s.depends_on_sub_ids

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -4742,8 +4742,9 @@ class GovernedOrchestrator:
                 return ctx
 
         # Wave 2 (5) Slice 5a/5b - GENERATERunner delegation gate.
-        # Flag JARVIS_PHASE_RUNNER_GENERATE_EXTRACTED (default false) routes
-        # the 1611-line GENERATE block through the extracted PhaseRunner.
+        # Flag JARVIS_PHASE_RUNNER_GENERATE_EXTRACTED (default TRUE) routes
+        # the 1611-line GENERATE block through the extracted PhaseRunner
+        # (the LIVE path — the inline block below is the legacy fallback).
         # Cross-phase artifacts (generation, _episodic_memory) threaded
         # via artifacts for VALIDATE consumption.
         if _phase_runner_generate_extracted():

--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -1576,6 +1576,79 @@ class GENERATERunner(PhaseRunner):
                 _err_msg = str(exc)
                 _route = getattr(ctx, "provider_route", "")
 
+                # ── Sovereign Egress Interceptor Mesh (T3) — route-back ──
+                # The LIVE generate-failure handler. When OUR egress interceptor
+                # blocked an over-ceiling DW body (LocalEgressOverweightError,
+                # re-raised from candidate_generator carrying max_allowed_size),
+                # this is NOT a vendor rupture and NOT a retryable generation
+                # failure — retrying the SAME oversized body would just block
+                # again. Instead route it BACK to context-aware chunking:
+                # decompose the GOAL with compression_target=max_allowed_size so
+                # each re-injected sub-goal fits under the ceiling, then terminate
+                # this op ``decomposed`` (the sub-goals carry the work forward) —
+                # exactly the BLOCK->decompose->re-inject seam. Chunking-eligible
+                # gate: only when at least one target_file is present (a symbol-
+                # scopable mutation). Fail-soft ABSOLUTE: any error falls through
+                # to the legacy generation-failure path below (op is never lost).
+                try:
+                    from backend.core.ouroboros.governance.dw_fault_taxonomy import (  # noqa: E501
+                        is_local_egress_overweight as _egress_overweight,
+                    )
+                    if _egress_overweight(exc):
+                        _max_allowed = getattr(exc, "max_allowed_size", None)
+                        _eligible = bool(
+                            getattr(ctx, "target_files", ()) or ()
+                        )
+                        from backend.core.ouroboros.governance.goal_decomposition_planner import (  # noqa: E501
+                            chunking_enabled as _chunking_enabled,
+                        )
+                        if (
+                            _eligible
+                            and _chunking_enabled()
+                            and isinstance(_max_allowed, int)
+                        ):
+                            logger.warning(
+                                "[Orchestrator] LOCAL_EGRESS_OVERWEIGHT op=%s — "
+                                "egress interceptor blocked an over-ceiling body "
+                                "(max_allowed=%d); routing BACK to context-aware "
+                                "chunking (compression_target=%d) instead of a "
+                                "doomed retry",
+                                ctx.op_id, _max_allowed, _max_allowed,
+                            )
+                            _re_ctx = await orch._decompose_block_or_legacy(
+                                ctx, None, compression_target=_max_allowed,
+                            )
+                            await orch._record_ledger(
+                                _re_ctx,
+                                OperationState.COMPLETED,
+                                {
+                                    "reason": "local_egress_overweight_rechunk",
+                                    "max_allowed_size": _max_allowed,
+                                    "terminal_reason_code": getattr(
+                                        _re_ctx, "terminal_reason_code", "",
+                                    ),
+                                },
+                            )
+                            return PhaseResult(
+                                next_ctx=_re_ctx,
+                                next_phase=None,
+                                status="fail",
+                                reason=(
+                                    getattr(_re_ctx, "terminal_reason_code", "")
+                                    or "local_egress_overweight_rechunk"
+                                ),
+                                artifacts={
+                                    "generation": generation,
+                                    "episodic_memory": _episodic_memory,
+                                },
+                            )
+                except Exception:  # noqa: BLE001 — fail-soft to legacy path
+                    logger.debug(
+                        "[Orchestrator] egress re-chunk seam fail-soft -> legacy "
+                        "generation-failure path (op=%s)",
+                        getattr(ctx, "op_id", "?"), exc_info=True,
+                    )
+
                 # ── Partial shadow log (widened) ──
                 # Fire the ExplorationLedger shadow pass for EVERY
                 # generation failure, regardless of route/cause. The

--- a/backend/core/ouroboros/governance/topology_sentinel.py
+++ b/backend/core/ouroboros/governance/topology_sentinel.py
@@ -449,6 +449,14 @@ class FailureSource(str, enum.Enum):
     # and (being != LIVE_TRANSPORT) the degrade/sever consumers ignore it — so one
     # op's no-candidate can NEVER sever the DW lane or corrupt vendor surface-health.
     FSM_EXHAUSTED = "fsm_exhausted"                # 0.0
+    # Sovereign Egress Interceptor Mesh (2026-06-22, T3) — OUR-side egress
+    # interceptor refused to dispatch an over-ceiling body (LocalEgressOverweight).
+    # DoubleWord never received the request; no socket failed — WE blocked it to
+    # stay a good API citizen. Weight 0.0: like FSM_EXHAUSTED it is telemetry-only
+    # and (being != LIVE_TRANSPORT) the degrade/sever/surface-health consumers
+    # ignore it — so an oversized payload can NEVER sever the DW lane. The
+    # orchestrator routes it BACK to context-aware chunking instead.
+    LOCAL_EGRESS_OVERWEIGHT = "local_egress_overweight"  # 0.0
 
 
 _DEFAULT_FAILURE_WEIGHTS: Dict[FailureSource, float] = {
@@ -462,6 +470,7 @@ _DEFAULT_FAILURE_WEIGHTS: Dict[FailureSource, float] = {
     FailureSource.LIGHT_PROBE_TIMEOUT: 1.0,
     FailureSource.GENERATION_TIMEOUT: 0.0,
     FailureSource.FSM_EXHAUSTED: 0.0,
+    FailureSource.LOCAL_EGRESS_OVERWEIGHT: 0.0,
 }
 
 

--- a/docs/superpowers/plans/2026-06-22-sovereign-egress-interceptor-mesh-plan.md
+++ b/docs/superpowers/plans/2026-06-22-sovereign-egress-interceptor-mesh-plan.md
@@ -1,0 +1,129 @@
+# Sovereign Egress Interceptor Mesh — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** A local pre-flight interceptor that GUARANTEES DoubleWord never receives a malformed or oversized request — schema sanitizer (extensible registry) + payload-weight governor (blocks oversized, raises a math-enriched error) + context-aware re-chunking + default-ON with a loud boot-guard.
+
+**Architecture:** A pure leaf `dw_egress_interceptor.py` invoked at both DW egress chokepoints. Oversized payloads raise `LocalEgressOverweightError` (carrying the compression math) → classified our-side (weight 0.0, no breaker trip) → orchestrator routes to `decompose_for_block(compression_target=…)` which AST-slices sub-goals that fit. Reuse-first: existing reasoning floor, `ModelCard`, `FailureSource`, the chunking matrix.
+
+**Tech Stack:** Python 3.9+ (`from __future__ import annotations`, `asyncio.wait_for`), pytest, stdlib only. ASCII only.
+
+**Spec (binding):** `docs/superpowers/specs/2026-06-22-sovereign-egress-interceptor-mesh.md`.
+
+## Global Constraints
+- **Default-ON:** `JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED` default `true`. OFF → boot-guard `[SOVEREIGN WARNING]`, never silent.
+- **Fail-soft ASYMMETRY (I2, critical):** a sanitize/estimate ERROR must NEVER wrongly block a valid request (→ pass-through); a CONFIRMED overweight MUST block. Never raise an unexpected exception into the dispatch path.
+- **Zero oversized/malformed egress (I1):** when enabled + confirmed overweight, the HTTP fire MUST NOT happen.
+- **`LOCAL_EGRESS_OVERWEIGHT` is weight 0.0** (our-side, like `FSM_EXHAUSTED`) — NEVER trips the vendor breaker/sentinel/surface-health.
+- **No hardcoding:** ceilings + sanitize rules env-driven (curve), refined by the live `ModelCard`. No literal model `if/else`.
+- **Reuse-first:** delegate reasoning to `_dw_model_min_effort`/`_reasoning_request_params`; reuse `ModelCard`, `FailureSource`, `decompose_for_block`, `ast_symbol_scoper`. NO parallel reasoning/capability/hash logic. A reviewer MUST reject a parallel capability store or a reimplemented reasoning floor.
+- **Worktree:** verify writes via `git show`/`grep`; commits need `ledger_sovereignty.mark_owned` (stamped).
+
+---
+
+## Task T1: `dw_egress_interceptor.py` core (sanitizer + governor + error)
+**Files:** Create `backend/core/ouroboros/governance/dw_egress_interceptor.py`; Test `tests/governance/test_dw_egress_interceptor.py`.
+
+**Interfaces — Produces:**
+- `class LocalEgressOverweightError(Exception)`: `__init__(self, *, attempted_size: int, max_allowed_size: int, model: str)`; computes `self.required_compression_ratio = attempted_size / max_allowed_size` (guard /0). Attrs: `attempted_size`, `max_allowed_size`, `required_compression_ratio`, `model`.
+- `def egress_interceptor_enabled() -> bool` (`JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED`, default **true**).
+- `def estimate_body_chars(body: dict) -> int` — sum of `len(str(content))` over `body["messages"][*]["content"]` (+ any top-level prompt). Fail-soft → 0.
+- `def egress_char_ceiling(model: str) -> int` — `min(env JARVIS_DW_EGRESS_MAX_CHARS default 600000, _model_card_char_budget(model))` where the model budget derives from `ModelCard.context_window` (chars≈4×tokens, env `JARVIS_DW_EGRESS_CHARS_PER_TOKEN` default 4) when available, else the env cap. Fail-soft → env cap.
+- `def sanitize_egress_body(body: dict, model: str) -> dict` — apply the extensible registry (4.1): returns a NEW dict with unsupported params stripped + floors applied. Reasoning rule delegates to the existing floor. Unknown model → unchanged. Fail-soft → return `body` unchanged.
+- `def assert_egress_weight(body: dict, model: str) -> None` — `w=estimate_body_chars(body); c=egress_char_ceiling(model); if w>c: raise LocalEgressOverweightError(attempted_size=w, max_allowed_size=c, model=model)`. Fail-soft on estimation error → return (no block).
+- registry: `def _sanitize_rules() -> dict` parsing `JARVIS_DW_EGRESS_SANITIZE_RULES` (format `substr={strip:p1|p2;floor:k:v}` — keep simple + documented) merged with built-ins (`{"gpt-oss": {"floor_reasoning": True}}`). NO literal model if/else in the apply loop.
+
+- [ ] **Step 1: Read first** — `doubleword_provider.py:192` `_dw_model_min_effort`, `:296` `_reasoning_request_params` (the reasoning floor to DELEGATE to); `dw_catalog_client.py:338-358` `ModelCard` (`context_window`) + how to fetch a card for a model id.
+- [ ] **Step 2: Failing tests** (`tests/governance/test_dw_egress_interceptor.py`):
+```python
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import dw_egress_interceptor as egi
+
+def _body(chars: int, model="m", reasoning="none"):
+    return {"model": model, "messages": [{"role": "user", "content": "x" * chars}], "reasoning_effort": reasoning}
+
+def test_enabled_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", raising=False)
+    assert egi.egress_interceptor_enabled() is True
+
+def test_estimate_chars():
+    assert egi.estimate_body_chars(_body(100)) >= 100
+
+def test_under_ceiling_passes(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "1000")
+    egi.assert_egress_weight(_body(500), "anymodel")  # no raise
+
+def test_over_ceiling_raises_with_math(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "1000")
+    with pytest.raises(egi.LocalEgressOverweightError) as ei:
+        egi.assert_egress_weight(_body(5000), "anymodel")
+    e = ei.value
+    assert e.max_allowed_size == 1000 and e.attempted_size >= 5000
+    assert e.required_compression_ratio >= 5.0 and e.model == "anymodel"
+
+def test_sanitize_unknown_model_passthrough():
+    b = _body(10, model="totally-unknown", reasoning="none")
+    assert egi.sanitize_egress_body(b, "totally-unknown") == b
+
+def test_sanitize_gpt_oss_floors_reasoning():
+    b = _body(10, model="openai/gpt-oss-120b", reasoning="none")
+    out = egi.sanitize_egress_body(b, "openai/gpt-oss-120b")
+    assert out["reasoning_effort"] != "none"  # floored via reused logic
+
+def test_failsoft_bad_body_never_raises_unexpected():
+    egi.assert_egress_weight({"messages": None}, "m")   # estimate→0→no block
+    assert egi.sanitize_egress_body({"messages": None}, "m") == {"messages": None}
+
+def test_overweight_error_ratio_zero_guard():
+    e = egi.LocalEgressOverweightError(attempted_size=100, max_allowed_size=0, model="m")
+    assert e.required_compression_ratio >= 1.0  # no ZeroDivisionError
+```
+- [ ] **Step 3: Run → fail** (`pytest tests/governance/test_dw_egress_interceptor.py -q`; ModuleNotFound).
+- [ ] **Step 4: Implement** `dw_egress_interceptor.py` per the interfaces. Reasoning floor delegates: `from backend.core.ouroboros.governance.doubleword_provider import _dw_model_min_effort, _clamp_up_to_min` (or `_reasoning_request_params`) — DO NOT reimplement. ModelCard fetch via `dw_catalog_client` (lazy import, fail-soft). Every public fn wrapped fail-soft per I2 asymmetry.
+- [ ] **Step 5: Run → pass.** Commit: `feat(egress): dw_egress_interceptor core — sanitizer (extensible registry) + weight governor + LocalEgressOverweightError(math)`.
+
+## Task T2: Wire the interceptor at both DW egress chokepoints
+**Files:** Modify `backend/core/ouroboros/governance/doubleword_provider.py` (realtime body site + batch JSONL site); Test `tests/governance/test_egress_chokepoint_wiring.py`.
+**Consumes:** T1 `sanitize_egress_body`, `assert_egress_weight`, `egress_interceptor_enabled`, `LocalEgressOverweightError`.
+
+- [ ] **Step 1: Read first** — `doubleword_provider.py:3132-3143` (realtime `body` assembly) + the `session.post` fire @~3272/3740; `:1715-1747` (batch JSONL `body`). Confirm exact var names.
+- [ ] **Step 2: Failing test** (`tests/governance/test_egress_chokepoint_wiring.py`): with a fake session that records calls, an oversized realtime body must NOT reach `session.post` (zero egress) and must raise `LocalEgressOverweightError`; a normal body passes through + IS sanitized. Use monkeypatch of the interceptor + a fake `_effective_model`. (Structural assertion that both chokepoints call `sanitize_egress_body` + `assert_egress_weight` under `egress_interceptor_enabled()` is acceptable for the deep batch site.)
+- [ ] **Step 3: Implement** at each chokepoint, immediately after the `body` dict is assembled (realtime ~3143; batch ~1747) and BEFORE the fire/JSONL-serialize:
+```python
+if egress_interceptor_enabled():
+    try:
+        body = sanitize_egress_body(body, <model_var>)
+        assert_egress_weight(body, <model_var>)
+    except LocalEgressOverweightError:
+        raise            # block egress; bubble to candidate_generator (T3)
+    except Exception:
+        pass             # I2: sanitize/estimate bug never blocks a valid request
+```
+(import the interceptor at module top, lazy if cycle risk.) **Step 4: Run** + regression `-k "doubleword or candidate_generator"`. **Step 5: Commit:** `feat(egress): wire interceptor at realtime + batch egress chokepoints — block oversized before session.post`.
+
+## Task T3: Route-back — FailureSource + orchestrator catch + compression target into decompose
+**Files:** Modify `topology_sentinel.py` (new FailureSource), `candidate_generator.py` (classify), `orchestrator.py` (catch→decompose), `goal_decomposition_planner.py` + `ast_symbol_scoper.py` (compression_target); Test `tests/governance/test_egress_rechunk.py`.
+
+- [ ] **Step 1: Read first** — `topology_sentinel.py:445-451` (`FailureSource.FSM_EXHAUSTED` weight 0.0 pattern); `candidate_generator.py` ~2256/5013 (DoublewordInfraError classify + re-raise); `orchestrator._decompose_block_or_legacy` + the generate-failure terminal path; `goal_decomposition_planner.decompose_for_block` signature; `ast_symbol_scoper.isolate_symbols`.
+- [ ] **Step 2: Failing tests:** (a) classifying a `LocalEgressOverweightError` → `FailureSource.LOCAL_EGRESS_OVERWEIGHT` with weight 0.0 (no breaker trip). (b) `decompose_for_block(goal, zero_coverage=False, compression_target=1000)` → every returned sub-goal's `estimate_body_chars`-equivalent payload ≤ 1000 (or a single irreducible symbol logged). (c) orchestrator catch: a generate that raises `LocalEgressOverweightError` for a chunking-eligible op routes to `decompose_for_block` with `compression_target=error.max_allowed_size`.
+- [ ] **Step 3: Implement** — add `LOCAL_EGRESS_OVERWEIGHT = "local_egress_overweight"` to `FailureSource` (weight 0.0, mirror FSM_EXHAUSTED's degrade/sever exclusion). `candidate_generator`: catch `LocalEgressOverweightError` in the dispatch try → classify `LOCAL_EGRESS_OVERWEIGHT`, attach `max_allowed_size` to the structured failure, re-raise as the wrapped RuntimeError carrying it. `orchestrator`: at the generate-failure site, if the failure is `LOCAL_EGRESS_OVERWEIGHT` + chunking-eligible → `await self._decompose_block_or_legacy(ctx, advisory, compression_target=<max_allowed>)` (extend the method with an optional `compression_target`). `decompose_for_block(..., compression_target: int | None = None)`: when set, the scoper slices so each sub-goal's estimated payload ≤ compression_target (split further; irreducible→emit+log). Reuse T1's `estimate_body_chars`/`egress_char_ceiling`. All fail-soft. **Step 4: Run** + regression `-k "topology or advisor or decomposition or candidate_generator or orchestrator"`. **Step 5: Commit:** `feat(egress): context-aware re-chunk — LOCAL_EGRESS_OVERWEIGHT (weight 0.0) -> decompose_for_block(compression_target)`.
+
+## Task T4: Sovereign Telemetry Boot-Guard
+**Files:** Modify `backend/core/ouroboros/governance/governed_loop_service.py` (boot sequence); Test `tests/governance/test_egress_boot_guard.py`.
+- [ ] **Step 1: Read first** — `GovernedLoopService.start()` boot sequence (where other boot warnings/telemetry fire).
+- [ ] **Step 2: Failing test:** when `JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=false`, boot emits the exact `[SOVEREIGN WARNING] API Citizenship Guard Disabled: Egress Interceptor is OFF. Node is vulnerable to overweight payload dispatch.` (caplog/telemetry); when default/true, no warning. Boot never crashes either way.
+- [ ] **Step 3: Implement** — in `start()`, `if not egress_interceptor_enabled(): logger.warning("[SOVEREIGN WARNING] API Citizenship Guard Disabled: ...")` (+ best-effort telemetry ledger note; async/non-blocking; fail-soft). **Step 4: Run.** **Step 5: Commit:** `feat(egress): Sovereign Telemetry Boot-Guard — loud [SOVEREIGN WARNING] when egress interceptor disabled`.
+
+## Task T5: Integration + static validation (the user's gate)
+**Files:** Test `tests/governance/test_egress_interceptor_integration.py`.
+- [ ] End-to-end with fakes: (1) an oversized request is provably BLOCKED locally — fake session asserts `session.post` was NEVER called; the op surfaces `LOCAL_EGRESS_OVERWEIGHT` (weight 0.0, no breaker trip) → `decompose_for_block(compression_target)` → all sub-goals fit. (2) a valid request passes through sanitized. (3) sanitize/estimate error → pass-through (never wrongly blocks). (4) boot-guard fires only when disabled. (5) OFF (interceptor disabled) → byte-identical egress path (minus the boot-guard warning). Reused-subsystem regression sweep (doubleword_provider, candidate_generator, topology_sentinel, orchestrator, decomposition). Commit.
+
+## Done criteria
+- DW provably never receives a malformed/oversized request when enabled (fake-session zero-egress proof). Oversized → math-enriched `LocalEgressOverweightError` → weight-0.0 classification (no breaker trip) → context-aware re-chunk to fitting sub-goals. Default-ON; OFF emits the boot-guard warning. Fail-soft asymmetry holds (errors never wrongly block). Reuse-first (no parallel reasoning/capability/hash). Zero real regressions. Final cross-cutting coherence review (mandatory — wire the interceptor at the LIVE egress, not a dead path; confirm both chokepoints + the orchestrator catch are reachable).
+- **Static validation (operator gate):** a >ceiling request blocked locally with zero egress, demonstrated in a test, BEFORE any C2 soak.
+
+## Self-review
+- Spec coverage: §4.1→T1, §4.2→T2, §4.3→T3, §4.4→T4, §6→T5. Default-ON + boot-guard + compression-target + extensible registry + weight-0.0 all covered.
+- Interfaces consistent: `LocalEgressOverweightError(attempted_size/max_allowed_size/required_compression_ratio/model)`, `sanitize_egress_body`, `assert_egress_weight`, `egress_interceptor_enabled`, `estimate_body_chars`, `egress_char_ceiling`, `FailureSource.LOCAL_EGRESS_OVERWEIGHT`, `decompose_for_block(..., compression_target)`.
+- Big-file tasks (T2/T3/T4) ship read-first instructions — confirm exact sites against live code; CRITICAL: T2 must wire the LIVE egress (both realtime + batch), and the final review must confirm reachability (the classify_runner-style dead-path miss must not recur).

--- a/docs/superpowers/specs/2026-06-22-sovereign-egress-interceptor-mesh.md
+++ b/docs/superpowers/specs/2026-06-22-sovereign-egress-interceptor-mesh.md
@@ -1,0 +1,59 @@
+# Sovereign Egress Interceptor Mesh — Design Spec
+
+> **Arc:** make it *structurally impossible* to send DoubleWord a malformed or oversized request — validated locally before any egress. Triggered by Meryem @ DW (co-founder) flagging `reasoning_effort=none` errors on gpt-oss-120b (2026-06-21, pre-fix). "Impeccable API citizen."
+> **Date:** 2026-06-22. **Branch:** `worktree-sovereign-egress-interceptor`. **Default-ON** (it's the citizenship guarantee).
+
+---
+
+## 1. Diagnosis (reuse-first — what already exists)
+- **reasoning_effort is ALREADY leak-proof** (verified): every egress site resolves it via `_reasoning_request_params(complexity, model=…)` → `_dw_model_min_effort(model)` 3-tier floor (catalog → learned `dw_reasoning_profile` → static `gpt-oss:low` seed, `doubleword_provider.py:169`). No path can send `none` to gpt-oss. Meryem's errors were pre-fix. So Component A is NOT a bug fix — it formalizes a single chokepoint + an extensible registry + belt-and-suspenders.
+- **Payload size:** batch upload has a 64 MiB byte gate (`doubleword_provider.py:4297-4306`); **realtime/streaming has NO size check** — this is the genuine gap.
+- **Egress chokepoint:** realtime body assembled at `doubleword_provider.py:3132-3143` (shared by SSE + non-stream, before `session.post` @3272/3740); batch body baked into JSONL at `1715-1747`. Body construction is DUPLICATED across the two paths.
+- **Failure→chunking:** `DoublewordInfraError` re-raised to candidate_generator → `RuntimeError` to orchestrator. No "payload too heavy → chunk" loop today.
+
+## 2. Goals / Non-Goals
+**Goals.** (G1) A single local pre-flight interceptor at both egress chokepoints that GUARANTEES DW never receives a malformed or oversized request. (G2) Schema sanitization via an EXTENSIBLE capability registry (no hardcoded if/else) — strips/maps unsupported params per the target model. (G3) A payload-weight governor that BLOCKS oversized egress locally, raising a math-enriched `LocalEgressOverweightError`. (G4) Context-aware re-chunking: the error carries the exact compression target, threaded into `decompose_for_block` so the AST decomposer slices sub-goals that fit. (G5) Default-ON + a loud boot-guard if disabled. (G6) Reuse `ModelCard`, the reasoning floor, `FailureSource`, `decompose_for_block`, `ast_symbol_scoper` — no parallel systems.
+
+**Non-Goals.** No new HTTP client. No change to the reasoning floor logic (reuse it). No weakening of the Advisor/cage. The interceptor is a SAFETY NET, not the primary chunker (the Advisor-BLOCK→chunking path remains upstream).
+
+## 3. Reuse Inventory
+| Need | Existing asset | Anchor |
+|---|---|---|
+| Egress chokepoint (realtime) | `_generate_raw` body @ 3132-3143, fires 3272/3740 | `doubleword_provider.py` |
+| Egress chokepoint (batch) | JSONL compose @ 1715-1747 | `doubleword_provider.py` |
+| Reasoning floor (reused, not duplicated) | `_reasoning_request_params` / `_dw_model_min_effort` | `doubleword_provider.py:296,192` |
+| Per-model capability metadata | `dw_catalog_client.ModelCard` (`context_window`, `param_count`, `supports_streaming`) | `dw_catalog_client.py:338-358` |
+| Failure taxonomy (weight 0.0 our-side) | `topology_sentinel.FailureSource` (FSM_EXHAUSTED pattern) | `topology_sentinel.py:445-451` |
+| Chunking matrix | `goal_decomposition_planner.decompose_for_block` + `ast_symbol_scoper` | (merged) |
+| Boot daemon (boot-guard) | `GovernedLoopService.start()` | `governed_loop_service.py` |
+
+## 4. Component Specs
+
+### 4.1 `dw_egress_interceptor.py` (new pure leaf module)
+- `class LocalEgressOverweightError(Exception)`: carries `attempted_size: int`, `max_allowed_size: int`, `required_compression_ratio: float` (`= attempted/max_allowed`), `model: str`. Math-enriched for the feedback loop.
+- **A. `sanitize_egress_body(body: dict, model: str) -> dict`**: consults an EXTENSIBLE registry. Rule shape (env `JARVIS_DW_EGRESS_SANITIZE_RULES`, parsed like the existing min-effort map): `model-substr → {"strip": [param,…], "floor": {param: value}}`. Built-in rules compose the EXISTING reasoning floor (delegates to `_dw_model_min_effort`/`_reasoning_request_params` — does NOT reimplement). Returns a NEW dict with unsupported params stripped/mapped; unknown models pass through unchanged. Pure, fail-soft (error → return body unchanged).
+- **B. `assert_egress_weight(body: dict, model: str) -> None`**: estimate payload weight = char-length of all `messages[].content` (+ system). Ceiling = `min(env JARVIS_DW_EGRESS_MAX_CHARS default e.g. 600_000, ModelCard.context_window-derived char budget when known)` — DYNAMIC, no literal cap (env tunes; registry refines). If `weight > ceiling` → raise `LocalEgressOverweightError(attempted=weight, max_allowed=ceiling, ratio=weight/ceiling, model=model)`. Else return. Pure, fail-soft (estimation error → do NOT block; never wrongly blocks a valid request).
+- `def egress_interceptor_enabled() -> bool`: `JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED` **default TRUE**.
+
+### 4.2 Wiring (both chokepoints)
+At realtime `_generate_raw` (after body @3143, before `session.post`) and batch JSONL compose (1715-1747), when `egress_interceptor_enabled()`: `body = sanitize_egress_body(body, model)` then `assert_egress_weight(body, model)`. The `assert` raising blocks the HTTP fire (DW never sees it). Fail-soft wrapper so an interceptor bug never blocks a valid request.
+
+### 4.3 Route-back to chunking (Context-Aware Compression Target)
+- `candidate_generator` catches `LocalEgressOverweightError` → classifies a NEW `FailureSource.LOCAL_EGRESS_OVERWEIGHT` (weight 0.0 — like FSM_EXHAUSTED: our-side, NEVER trips the vendor breaker/sentinel/surface-health). Attaches the compression math to the op context/failure.
+- The orchestrator's generate-failure path detects `LOCAL_EGRESS_OVERWEIGHT` + chunking-eligible → routes to `decompose_for_block(goal, …, compression_target=max_allowed_size)`.
+- `decompose_for_block` gains an optional `compression_target: int | None`; when set, the AST decomposer (`ast_symbol_scoper`) slices so **no resulting sub-goal's estimated payload exceeds `compression_target`** (split a too-large symbol set further; if a single symbol still exceeds, emit it with a clear "irreducible" log — never silently exceed). Reuses the existing decomposition + the weight estimator from 4.1.
+
+### 4.4 Sovereign Telemetry Boot-Guard
+In `GovernedLoopService.start()`: if `not egress_interceptor_enabled()`, emit (async, non-crashing) a high-visibility WARNING to stdout + the telemetry ledger: `[SOVEREIGN WARNING] API Citizenship Guard Disabled: Egress Interceptor is OFF. Node is vulnerable to overweight payload dispatch.` Default-ON means this only fires on an explicit operator override.
+
+## 5. Cross-cutting
+- **Invariants.** (I1) DW NEVER receives a request the interceptor would reject (the citizenship guarantee). (I2) Fail-soft asymmetry: an interceptor ERROR must NEVER wrongly block a valid request (estimation/sanitize error → pass-through), but a CONFIRMED overweight MUST block. (I3) `LOCAL_EGRESS_OVERWEIGHT` is weight-0.0 — never trips the vendor breaker (it's our mistake, not DW's). (I4) Default-ON; OFF emits the boot-guard warning, never silent. (I5) Reuse-first — no duplicated reasoning/jitter/hash logic, no parallel capability store.
+- **No hardcoding:** ceilings + sanitize rules are env-driven (curve), refined by the live `ModelCard` registry.
+
+## 6. Test strategy
+- Unit: `sanitize_egress_body` (strips registered param; floors reasoning via reuse; unknown model passthrough; fail-soft). `assert_egress_weight` (under→pass, over→raises with correct math; ModelCard ceiling; fail-soft estimation error→no block). `LocalEgressOverweightError` math. Registry parsing (env rules).
+- Interaction: oversized body at the chokepoint → blocked, no `session.post` (fake session asserts zero egress). `LOCAL_EGRESS_OVERWEIGHT` classified weight-0.0 (no breaker trip). `decompose_for_block(compression_target=N)` → every sub-goal ≤ N (or irreducible logged). Boot-guard fires only when disabled.
+- **Static validation (the user's gate):** a >ceiling request is provably blocked locally (no egress) BEFORE any soak. OFF byte-identical (minus the boot-guard warning).
+
+## 7. Phasing
+1. `dw_egress_interceptor.py` (sanitizer + governor + error) + tests. 2. Chokepoint wiring (both paths) + fake-session zero-egress test. 3. Route-back: FailureSource + orchestrator catch + `decompose_for_block(compression_target)` + AST slice bound. 4. Boot-guard. 5. Integration + final cross-cutting review. Then (operator-gated) the cost-capped C2 soak.

--- a/tests/governance/test_dw_egress_interceptor.py
+++ b/tests/governance/test_dw_egress_interceptor.py
@@ -1,0 +1,51 @@
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import dw_egress_interceptor as egi
+
+
+def _body(chars: int, model="m", reasoning="none"):
+    return {"model": model, "messages": [{"role": "user", "content": "x" * chars}], "reasoning_effort": reasoning}
+
+
+def test_enabled_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", raising=False)
+    assert egi.egress_interceptor_enabled() is True
+
+
+def test_estimate_chars():
+    assert egi.estimate_body_chars(_body(100)) >= 100
+
+
+def test_under_ceiling_passes(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "1000")
+    egi.assert_egress_weight(_body(500), "anymodel")  # no raise
+
+
+def test_over_ceiling_raises_with_math(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "1000")
+    with pytest.raises(egi.LocalEgressOverweightError) as ei:
+        egi.assert_egress_weight(_body(5000), "anymodel")
+    e = ei.value
+    assert e.max_allowed_size == 1000 and e.attempted_size >= 5000
+    assert e.required_compression_ratio >= 5.0 and e.model == "anymodel"
+
+
+def test_sanitize_unknown_model_passthrough():
+    b = _body(10, model="totally-unknown", reasoning="none")
+    assert egi.sanitize_egress_body(b, "totally-unknown") == b
+
+
+def test_sanitize_gpt_oss_floors_reasoning():
+    b = _body(10, model="openai/gpt-oss-120b", reasoning="none")
+    out = egi.sanitize_egress_body(b, "openai/gpt-oss-120b")
+    assert out["reasoning_effort"] != "none"  # floored via reused logic
+
+
+def test_failsoft_bad_body_never_raises_unexpected():
+    egi.assert_egress_weight({"messages": None}, "m")   # estimate->0->no block
+    assert egi.sanitize_egress_body({"messages": None}, "m") == {"messages": None}
+
+
+def test_overweight_error_ratio_zero_guard():
+    e = egi.LocalEgressOverweightError(attempted_size=100, max_allowed_size=0, model="m")
+    assert e.required_compression_ratio >= 1.0  # no ZeroDivisionError

--- a/tests/governance/test_egress_boot_guard.py
+++ b/tests/governance/test_egress_boot_guard.py
@@ -1,0 +1,128 @@
+"""T4 — Sovereign Telemetry Boot-Guard
+
+Unit tests for the _warn_if_egress_guard_disabled helper extracted
+from GovernedLoopService.start().
+
+Strategy: test the small helper directly (no async GLS boot needed).
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Import the helper under test
+# ---------------------------------------------------------------------------
+
+from backend.core.ouroboros.governance.governed_loop_service import (
+    _warn_if_egress_guard_disabled,
+)
+
+_SOVEREIGN_WARNING = (
+    "[SOVEREIGN WARNING] API Citizenship Guard Disabled: Egress Interceptor "
+    "is OFF. Node is vulnerable to overweight payload dispatch."
+)
+
+
+class TestWarnIfEgressGuardDisabled:
+    """Unit tests for _warn_if_egress_guard_disabled."""
+
+    def test_warns_when_explicitly_disabled(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=false the exact
+        [SOVEREIGN WARNING] string must be emitted at WARNING level."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "false")
+        logger = logging.getLogger("governed_loop_service_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is True, "helper must return True when guard is disabled"
+        assert any(
+            _SOVEREIGN_WARNING in record.message
+            for record in caplog.records
+        ), f"Expected warning not found in caplog. Records: {[r.message for r in caplog.records]}"
+
+    def test_no_warn_when_enabled_default(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When env var is absent (default=true) no warning should be emitted."""
+        monkeypatch.delenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", raising=False)
+        logger = logging.getLogger("governed_loop_service_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is False, "helper must return False when guard is enabled"
+        assert not any(
+            "SOVEREIGN WARNING" in record.message
+            for record in caplog.records
+        ), "No warning should be emitted when the guard is ON"
+
+    def test_no_warn_when_enabled_true(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=true no warning."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "true")
+        logger = logging.getLogger("governed_loop_service_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is False
+        assert not any("SOVEREIGN WARNING" in r.message for r in caplog.records)
+
+    def test_no_warn_when_enabled_1(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=1 no warning."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "1")
+        logger = logging.getLogger("governed_loop_service_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is False
+        assert not any("SOVEREIGN WARNING" in r.message for r in caplog.records)
+
+    def test_warns_when_disabled_zero(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=0 the warning fires."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "0")
+        logger = logging.getLogger("governed_loop_service_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is True
+        assert any(_SOVEREIGN_WARNING in r.message for r in caplog.records)
+
+    def test_warns_when_disabled_off(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """When JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=off the warning fires."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "off")
+        logger = logging.getLogger("governed_loop_service_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is True
+        assert any(_SOVEREIGN_WARNING in r.message for r in caplog.records)
+
+    def test_exact_warning_string(
+        self, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """The exact warning string must be present verbatim."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "false")
+        logger = logging.getLogger("governed_loop_service_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            _warn_if_egress_guard_disabled(logger)
+        messages = [r.message for r in caplog.records]
+        assert _SOVEREIGN_WARNING in messages, (
+            f"Exact string not matched. Got: {messages}"
+        )
+
+    def test_never_raises_on_import_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """Helper must be fail-soft — even a broken logger must not raise."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "false")
+        # Use a real logger — helper should never raise regardless
+        logger = logging.getLogger("governed_loop_service_test")
+        try:
+            _warn_if_egress_guard_disabled(logger)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"_warn_if_egress_guard_disabled raised unexpectedly: {exc}")

--- a/tests/governance/test_egress_chokepoint_wiring.py
+++ b/tests/governance/test_egress_chokepoint_wiring.py
@@ -1,0 +1,315 @@
+"""test_egress_chokepoint_wiring.py -- T2 tests.
+
+Verifies that the egress interceptor is wired at BOTH chokepoints in
+doubleword_provider.py:
+  1. Realtime body (~line 3171): interceptor fires BEFORE stream flag or
+     session.post is touched.  An oversized body raises
+     LocalEgressOverweightError and session.post is never called.
+  2. Batch body (~line 1756): interceptor fires BEFORE _compose_jsonl_batch_entry
+     is called.  An oversized batch body raises LocalEgressOverweightError.
+
+The tests use monkeypatching of the interceptor module's public functions
+(egress_interceptor_enabled, sanitize_egress_body, assert_egress_weight) rather
+than instantiating the full DoublewordProvider (which requires aiohttp sessions,
+live credentials, and other heavy machinery).  Each test verifies the guard
+snippet behaviour in isolation via a thin integration shim that calls the same
+conditional block the provider code runs.
+
+Three test classes:
+  TestGuardSnippetBehaviour  -- unit-level: the guard block itself
+  TestRealtimeChokepoint     -- structural: grep confirms the realtime site calls
+                                the interceptor API under egress_interceptor_enabled
+  TestBatchChokepoint        -- structural: grep confirms the batch site calls
+                                the interceptor API under egress_interceptor_enabled
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+import re
+import types
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_egress_interceptor import (
+    LocalEgressOverweightError,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_PROVIDER_SRC = pathlib.Path(
+    "backend/core/ouroboros/governance/doubleword_provider.py"
+)
+
+
+def _provider_source() -> str:
+    return _PROVIDER_SRC.read_text(encoding="ascii", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# 1. Unit-level guard snippet behaviour
+#    (the same conditional block that is embedded at each chokepoint)
+# ---------------------------------------------------------------------------
+
+
+class TestGuardSnippetBehaviour:
+    """Simulate the guard snippet to prove I2 asymmetry is correct."""
+
+    @staticmethod
+    def _run_guard(
+        body: dict,
+        model: str,
+        *,
+        interceptor_enabled: bool = True,
+        sanitize_raises: Exception | None = None,
+        weight_raises: Exception | None = None,
+        session_post_mock: MagicMock | None = None,
+    ) -> dict:
+        """Execute the guard snippet exactly as written in doubleword_provider.py.
+
+        Returns the (possibly sanitized) body.  Raises LocalEgressOverweightError
+        when weight assertion fails.  Never raises for other interceptor errors.
+        """
+        # Build fake interceptor callables.
+        def _enabled() -> bool:
+            return interceptor_enabled
+
+        def _sanitize(b: dict, m: str) -> dict:
+            if sanitize_raises is not None:
+                raise sanitize_raises
+            return dict(b, _sanitized=True)  # mark that sanitize ran
+
+        def _assert_weight(b: dict, m: str) -> None:
+            if weight_raises is not None:
+                raise weight_raises
+
+        # The guard snippet (verbatim from doubleword_provider.py).
+        if _enabled():
+            try:
+                body = _sanitize(body, model)
+                _assert_weight(body, model)
+            except LocalEgressOverweightError:
+                raise  # block egress
+            except Exception:  # noqa: BLE001
+                pass  # I2: never block on sanitize/estimate error
+
+        if session_post_mock is not None:
+            # Simulate reaching the fire point only if no exception was raised.
+            session_post_mock(body)
+
+        return body
+
+    def test_normal_body_is_sanitized_and_passes(self):
+        """Happy path: normal body goes through sanitize and weight check."""
+        post_mock = MagicMock()
+        body = {"messages": [{"role": "user", "content": "hello"}]}
+        result = self._run_guard(body, "test-model", session_post_mock=post_mock)
+        assert result.get("_sanitized") is True, "sanitize_egress_body was not called"
+        post_mock.assert_called_once()
+
+    def test_overweight_body_blocks_egress_and_post_never_called(self):
+        """Overweight body raises LocalEgressOverweightError; session.post not reached."""
+        post_mock = MagicMock()
+        body = {"messages": [{"role": "user", "content": "x" * 1_000}]}
+        with pytest.raises(LocalEgressOverweightError):
+            self._run_guard(
+                body,
+                "test-model",
+                weight_raises=LocalEgressOverweightError(
+                    attempted_size=1_000_000,
+                    max_allowed_size=100,
+                    model="test-model",
+                ),
+                session_post_mock=post_mock,
+            )
+        post_mock.assert_not_called()  # critical: zero egress
+
+    def test_sanitize_error_does_not_block_egress(self):
+        """I2: a sanitize bug (non-overweight exception) must not block egress."""
+        post_mock = MagicMock()
+        body = {"messages": [{"role": "user", "content": "hello"}]}
+        result = self._run_guard(
+            body,
+            "test-model",
+            sanitize_raises=RuntimeError("unexpected sanitize crash"),
+            session_post_mock=post_mock,
+        )
+        # post must still be called (request was not blocked)
+        post_mock.assert_called_once()
+        # body came back unchanged (sanitize did not run to completion)
+        assert "_sanitized" not in result
+
+    def test_weight_non_overweight_error_does_not_block(self):
+        """I2: a weight estimation crash (not LocalEgressOverweightError) passes through."""
+        post_mock = MagicMock()
+        body = {"messages": [{"role": "user", "content": "hello"}]}
+        # sanitize succeeds, but assert_egress_weight throws something unexpected
+        result = self._run_guard(
+            body,
+            "test-model",
+            weight_raises=ValueError("unexpected weight crash"),
+            session_post_mock=post_mock,
+        )
+        post_mock.assert_called_once()
+
+    def test_guard_disabled_skips_interceptor_entirely(self):
+        """When egress_interceptor_enabled() is False body is returned unchanged."""
+        post_mock = MagicMock()
+        body = {"messages": [{"role": "user", "content": "hello"}]}
+        result = self._run_guard(
+            body,
+            "test-model",
+            interceptor_enabled=False,
+            # Even if weight would have raised, it must not be called:
+            weight_raises=LocalEgressOverweightError(
+                attempted_size=999_999,
+                max_allowed_size=1,
+                model="test-model",
+            ),
+            session_post_mock=post_mock,
+        )
+        # body passes through unchanged; session.post is called
+        assert "_sanitized" not in result
+        post_mock.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 2. Structural assertion: realtime chokepoint
+# ---------------------------------------------------------------------------
+
+
+class TestRealtimeChokepoint:
+    """Verify that the realtime body (~line 3171) actually calls the interceptor."""
+
+    def test_interceptor_functions_called_at_realtime_site(self):
+        """The realtime body site must call sanitize + weight under the enabled guard."""
+        src = _provider_source()
+
+        # Find the realtime site: the guard block that follows the body-dict
+        # ending in ``**_reasoning_request_params(complexity=_complexity or``.
+        # The distinguishing signature is:
+        #   body = sanitize_egress_body(body, _effective_model)
+        #   assert_egress_weight(body, _effective_model)
+        # within the scope of ``if egress_interceptor_enabled():``.
+
+        assert "egress_interceptor_enabled" in src, (
+            "egress_interceptor_enabled not found in doubleword_provider.py"
+        )
+        assert "sanitize_egress_body(body, _effective_model)" in src, (
+            "sanitize_egress_body(body, _effective_model) not found in doubleword_provider.py"
+        )
+        assert "assert_egress_weight(body, _effective_model)" in src, (
+            "assert_egress_weight(body, _effective_model) not found in doubleword_provider.py"
+        )
+
+    def test_realtime_guard_precedes_stream_flag(self):
+        """The interceptor block must appear BEFORE body['stream'] = True."""
+        src = _provider_source()
+        interceptor_pos = src.find("sanitize_egress_body(body, _effective_model)")
+        stream_flag_pos = src.find("body[\"stream\"] = True")
+        assert interceptor_pos > 0, "sanitize_egress_body realtime call not found"
+        assert stream_flag_pos > 0, "body['stream'] = True not found"
+        assert interceptor_pos < stream_flag_pos, (
+            "Interceptor guard must appear BEFORE body['stream'] = True "
+            f"(interceptor_pos={interceptor_pos}, stream_flag_pos={stream_flag_pos})"
+        )
+
+    def test_overweight_error_re_raised_at_realtime_site(self):
+        """Source has ``except LocalEgressOverweightError: raise`` at the realtime site."""
+        src = _provider_source()
+        # Count occurrences of the re-raise pattern
+        pattern = r"except LocalEgressOverweightError:\s*\n\s*raise"
+        matches = re.findall(pattern, src)
+        assert len(matches) >= 2, (
+            "Expected >=2 ``except LocalEgressOverweightError: raise`` blocks "
+            f"(realtime + batch), found {len(matches)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. Structural assertion: batch chokepoint
+# ---------------------------------------------------------------------------
+
+
+class TestBatchChokepoint:
+    """Verify that the batch body (~line 1756) actually calls the interceptor."""
+
+    def test_interceptor_functions_called_at_batch_site(self):
+        """The batch body site must call sanitize + weight under the enabled guard."""
+        src = _provider_source()
+        # The batch site uses _batch_body as the local variable.
+        assert "sanitize_egress_body(_batch_body, _effective_model)" in src, (
+            "sanitize_egress_body(_batch_body, ...) not found — batch chokepoint not wired"
+        )
+        assert "assert_egress_weight(_batch_body, _effective_model)" in src, (
+            "assert_egress_weight(_batch_body, ...) not found — batch chokepoint not wired"
+        )
+
+    def test_batch_guard_precedes_compose_jsonl(self):
+        """_batch_body is intercepted BEFORE _compose_jsonl_batch_entry is called."""
+        src = _provider_source()
+        # The interceptor runs on _batch_body before it is passed to compose.
+        intercept_pos = src.find("sanitize_egress_body(_batch_body, _effective_model)")
+        compose_pos = src.find('self._compose_jsonl_batch_entry({')
+        assert intercept_pos > 0, "sanitize_egress_body(_batch_body) call not found"
+        assert compose_pos > 0, "_compose_jsonl_batch_entry not found"
+        assert intercept_pos < compose_pos, (
+            "Batch interceptor guard must appear BEFORE _compose_jsonl_batch_entry "
+            f"(intercept_pos={intercept_pos}, compose_pos={compose_pos})"
+        )
+
+    def test_batch_body_local_var_passed_to_compose(self):
+        """The compose call must receive _batch_body (not the raw inline dict)."""
+        src = _provider_source()
+        # After the interceptor, the compose call should reference _batch_body.
+        assert '"body": _batch_body,' in src, (
+            '"body": _batch_body, not found — _compose_jsonl_batch_entry '
+            "is not consuming the intercepted _batch_body"
+        )
+
+    def test_batch_guard_disabled_is_off_by_default_inverted(self):
+        """OFF path: when disabled the guard block is skipped (source inspection)."""
+        src = _provider_source()
+        # There must be exactly TWO egress_interceptor_enabled() call sites
+        # (one realtime, one batch).
+        count = src.count("egress_interceptor_enabled()")
+        assert count >= 2, (
+            f"Expected >=2 egress_interceptor_enabled() call sites, got {count}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Import cycle safety
+# ---------------------------------------------------------------------------
+
+
+class TestImportCycleSafety:
+    """Verify that importing doubleword_provider does NOT cause a circular import."""
+
+    def test_import_does_not_raise(self):
+        """Top-level import of doubleword_provider must succeed without ImportError."""
+        # If we get here the import already worked (test file imports from it
+        # transitively). This explicit re-import validates the module is
+        # importable without errors in a fresh module lookup.
+        import importlib
+        # Use importlib to force an explicit import resolution.
+        mod = importlib.import_module(
+            "backend.core.ouroboros.governance.doubleword_provider"
+        )
+        assert mod is not None
+
+    def test_interceptor_names_visible_on_provider_module(self):
+        """The four interceptor names must be importable from doubleword_provider."""
+        from backend.core.ouroboros.governance.doubleword_provider import (  # noqa: PLC0415
+            LocalEgressOverweightError as _LEE,
+            assert_egress_weight as _aw,
+            egress_interceptor_enabled as _ei,
+            sanitize_egress_body as _sb,
+        )
+        assert callable(_ei)
+        assert callable(_sb)
+        assert callable(_aw)
+        assert issubclass(_LEE, Exception)

--- a/tests/governance/test_egress_interceptor_integration.py
+++ b/tests/governance/test_egress_interceptor_integration.py
@@ -1,0 +1,706 @@
+"""test_egress_interceptor_integration.py -- T5 integration spine.
+
+Sovereign Egress Interceptor Mesh: end-to-end composition proof + citizenship
+guarantee tests.  Uses real module imports; fakes are limited to the network
+layer (aiohttp session) and the filesystem reader used inside the decomposition
+planner.
+
+Seven areas (matching the task-T5-brief spec section 6):
+
+  1. Zero-egress proof (THE operator gate): an oversized request is provably
+     BLOCKED locally; session.post is NEVER called.
+  2. Weight-0.0 classification: LOCAL_EGRESS_OVERWEIGHT -> FailureSource weight
+     0.0 -> does NOT trip the topology-sentinel breaker (mirror FSM_EXHAUSTED).
+  3. Compression-target re-chunk: decompose_for_block(compression_target=N) ->
+     every multi-symbol sub-goal payload <= N.
+  4. Sanitize: gpt-oss body with reasoning_effort=none -> floored to non-none;
+     unknown model -> unchanged.
+  5. Fail-soft asymmetry: malformed body (messages=None) -> assert_egress_weight
+     does NOT raise.
+  6. Boot-guard: disabled -> warning fires; enabled/default -> silent.
+  7. OFF byte-identical: egress_interceptor_enabled() false -> interceptor is a
+     no-op on the egress path (minus the boot-guard warning).
+
+ASCII-only source.  ``from __future__ import annotations`` per project mandate.
+Python 3.9+.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+import types
+from typing import Any, Dict, List
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Real module imports (not faked)
+# ---------------------------------------------------------------------------
+
+from backend.core.ouroboros.governance.dw_egress_interceptor import (
+    LocalEgressOverweightError,
+    assert_egress_weight,
+    egress_interceptor_enabled,
+    estimate_body_chars,
+    sanitize_egress_body,
+)
+from backend.core.ouroboros.governance import topology_sentinel as ts
+from backend.core.ouroboros.governance.dw_fault_taxonomy import (
+    is_local_egress_overweight,
+    is_fsm_exhaustion,
+)
+from backend.core.ouroboros.governance.goal_decomposition_planner import (
+    decompose_for_block,
+    estimate_subgoal_payload_chars,
+)
+from backend.core.ouroboros.governance import goal_decomposition_planner as gdp
+from backend.core.ouroboros.governance.governed_loop_service import (
+    _warn_if_egress_guard_disabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers shared across tests
+# ---------------------------------------------------------------------------
+
+def _make_body(chars: int, model: str = "test-model") -> Dict[str, Any]:
+    """Return a minimal request body with the given character footprint."""
+    return {
+        "model": model,
+        "messages": [{"role": "user", "content": "x" * chars}],
+        "reasoning_effort": "none",
+    }
+
+
+def _run_guard_snippet(
+    body: Dict[str, Any],
+    model: str,
+    *,
+    interceptor_enabled: bool = True,
+    session_post: MagicMock | None = None,
+) -> Dict[str, Any]:
+    """Execute the exact guard snippet that lives in doubleword_provider.py.
+
+    Uses the REAL sanitize_egress_body / assert_egress_weight from the module,
+    so this exercises the actual composed behaviour.  The only fake is
+    ``session_post`` (network I/O).
+    """
+    if interceptor_enabled:
+        try:
+            body = sanitize_egress_body(body, model)
+            assert_egress_weight(body, model)
+        except LocalEgressOverweightError:
+            raise  # block egress; session.post is never reached
+        except Exception:  # noqa: BLE001 -- I2 fail-soft
+            pass  # non-overweight error -> pass-through
+
+    if session_post is not None:
+        session_post(body)  # simulates the actual network fire
+
+    return body
+
+
+# ---------------------------------------------------------------------------
+# 1. Zero-egress proof -- THE operator gate
+# ---------------------------------------------------------------------------
+
+
+class TestZeroEgressProof:
+    """An oversized request is blocked LOCALLY; session.post is NEVER awaited."""
+
+    def test_oversized_body_raises_local_egress_overweight(self, monkeypatch):
+        """assert_egress_weight raises LocalEgressOverweightError on an oversized body."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "1000")
+        body = _make_body(chars=50_000)
+        with pytest.raises(LocalEgressOverweightError) as exc_info:
+            assert_egress_weight(body, "some-model")
+        err = exc_info.value
+        assert err.attempted_size >= 50_000
+        assert err.max_allowed_size == 1000
+        assert err.required_compression_ratio >= 50.0
+
+    def test_session_post_never_called_on_oversized_body(self, monkeypatch):
+        """session.post is NEVER called when the body is oversized — zero egress."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "500")
+        session_post = MagicMock()
+        body = _make_body(chars=5_000)
+
+        with pytest.raises(LocalEgressOverweightError):
+            _run_guard_snippet(body, "big-model", session_post=session_post)
+
+        session_post.assert_not_called()  # THE guarantee: zero network egress
+
+    def test_within_ceiling_reaches_session_post(self, monkeypatch):
+        """Happy path: a body within the ceiling does reach session.post."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "100_000")
+        session_post = MagicMock()
+        body = _make_body(chars=100)
+
+        _run_guard_snippet(body, "small-model", session_post=session_post)
+
+        session_post.assert_called_once()
+
+    def test_structural_guard_sequence_in_provider(self):
+        """Structural: the real doubleword_provider.py contains the correct guard
+        sequence (sanitize -> assert_weight -> re-raise) at BOTH chokepoints."""
+        import pathlib
+        src = pathlib.Path(
+            "backend/core/ouroboros/governance/doubleword_provider.py"
+        ).read_text(encoding="ascii", errors="replace")
+
+        # Both chokepoint variables are present.
+        assert "sanitize_egress_body(body, _effective_model)" in src
+        assert "assert_egress_weight(body, _effective_model)" in src
+        assert "sanitize_egress_body(_batch_body, _effective_model)" in src
+        assert "assert_egress_weight(_batch_body, _effective_model)" in src
+
+        # LocalEgressOverweightError is re-raised (not swallowed) at both sites.
+        import re
+        reraise_pattern = r"except LocalEgressOverweightError:\s*\n\s*raise"
+        matches = re.findall(reraise_pattern, src)
+        assert len(matches) >= 2, (
+            f"Expected >=2 re-raise blocks, found {len(matches)}"
+        )
+
+    def test_guard_precedes_stream_flag_structurally(self):
+        """Interceptor guard must appear BEFORE body['stream'] = True."""
+        import pathlib
+        src = pathlib.Path(
+            "backend/core/ouroboros/governance/doubleword_provider.py"
+        ).read_text(encoding="ascii", errors="replace")
+        intercept_pos = src.find("sanitize_egress_body(body, _effective_model)")
+        stream_pos = src.find('body["stream"] = True')
+        assert intercept_pos > 0
+        assert stream_pos > 0
+        assert intercept_pos < stream_pos, (
+            "Interceptor must fire BEFORE body['stream'] = True"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 2. Weight-0.0 classification -- does NOT trip the vendor breaker
+# ---------------------------------------------------------------------------
+
+
+class TestWeight0Classification:
+    """LOCAL_EGRESS_OVERWEIGHT -> FailureSource weight 0.0; breaker stays CLOSED."""
+
+    def test_failure_source_exists_with_correct_value(self):
+        assert hasattr(ts.FailureSource, "LOCAL_EGRESS_OVERWEIGHT")
+        assert ts.FailureSource.LOCAL_EGRESS_OVERWEIGHT.value == "local_egress_overweight"
+
+    def test_failure_weight_is_zero(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TOPOLOGY_WEIGHT_LOCAL_EGRESS_OVERWEIGHT", raising=False)
+        weight = ts.failure_weight(ts.FailureSource.LOCAL_EGRESS_OVERWEIGHT)
+        assert weight == 0.0
+
+    def test_mirrors_fsm_exhausted_weight(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_TOPOLOGY_WEIGHT_LOCAL_EGRESS_OVERWEIGHT", raising=False)
+        monkeypatch.delenv("JARVIS_TOPOLOGY_WEIGHT_FSM_EXHAUSTED", raising=False)
+        assert ts.failure_weight(ts.FailureSource.LOCAL_EGRESS_OVERWEIGHT) == (
+            ts.failure_weight(ts.FailureSource.FSM_EXHAUSTED)
+        )
+
+    def test_overweight_streak_never_trips_breaker(self, monkeypatch):
+        """Hammering LOCAL_EGRESS_OVERWEIGHT 50x must NOT open the topology breaker."""
+        monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+        monkeypatch.delenv("JARVIS_TOPOLOGY_FORCE_SEVERED", raising=False)
+        sentinel = ts.TopologySentinel()
+        model = "egress-integration-test-model"
+        sentinel.register_endpoint(model)
+
+        for _ in range(50):
+            sentinel.report_failure(
+                model, ts.FailureSource.LOCAL_EGRESS_OVERWEIGHT, "overweight"
+            )
+
+        snap = sentinel._snapshots.get(model)
+        assert snap is not None
+        assert snap.weighted_failure_streak == 0.0
+        assert sentinel.get_state(model) == "CLOSED"
+
+    def test_taxonomy_correctly_classifies_local_egress_overweight(self):
+        """is_local_egress_overweight correctly identifies the error type."""
+        err = LocalEgressOverweightError(
+            attempted_size=2_000_000,
+            max_allowed_size=600_000,
+            model="integration-test",
+        )
+        assert is_local_egress_overweight(err) is True
+        # Must NOT be mislabeled as FSM exhaustion.
+        assert is_fsm_exhaustion(err) is False
+
+    def test_taxonomy_does_not_misclassify_other_errors(self):
+        """Generic errors are not classified as local egress overweight."""
+        assert is_local_egress_overweight(RuntimeError("something")) is False
+        assert is_local_egress_overweight(ValueError("all_providers_exhausted")) is False
+
+    def test_taxonomy_is_fail_soft(self):
+        """is_local_egress_overweight never raises even on weird input."""
+        assert is_local_egress_overweight(None) is False  # type: ignore[arg-type]
+        assert is_local_egress_overweight(object()) is False  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 3. Compression-target re-chunk
+# ---------------------------------------------------------------------------
+
+
+class _GoalStub:
+    """Minimal duck-typed goal for decompose_for_block."""
+
+    def __init__(
+        self,
+        goal_id: str,
+        title: str,
+        description: str,
+        target_files: tuple,
+    ) -> None:
+        self.goal_id = goal_id
+        self.title = title
+        self.description = description
+        self.target_files = target_files
+
+
+def _make_scoper_with_sizes(symbol_sizes: Dict[str, int]):
+    """Return (scoper_fn, source_str) with per-symbol char sizes.
+
+    Each symbol occupies lines where len(line) ~= 50 chars.
+    The scoper returns ScopedTarget objects whose line ranges encompass the
+    synthetic content.
+    """
+    from backend.core.ouroboros.governance.ast_symbol_scoper import ScopedTarget
+
+    CHARS_PER_LINE = 50
+    lines: List[str] = []
+    targets: List[Any] = []
+    lineno = 1
+    for name, size in symbol_sizes.items():
+        n_lines = max(1, size // CHARS_PER_LINE)
+        start = lineno
+        for _ in range(n_lines):
+            lines.append("x" * (CHARS_PER_LINE - 1))
+            lineno += 1
+        end = lineno - 1
+        targets.append(ScopedTarget("f.py", name, start, end))
+    source = "\n".join(lines) + "\n"
+
+    def _scoper(file_path: str, description: str):  # noqa: ARG001
+        return tuple(targets)
+
+    return _scoper, source
+
+
+class TestCompressionTargetReChunk:
+    """decompose_for_block(compression_target=N) -> sub-goals fit in N chars."""
+
+    def test_compression_target_kwarg_exists_on_decompose(self):
+        sig = inspect.signature(decompose_for_block)
+        assert "compression_target" in sig.parameters
+        assert sig.parameters["compression_target"].default is None
+
+    def test_none_target_is_byte_identical_to_legacy(self):
+        """compression_target=None produces the same output as omitting the kwarg."""
+        scoper, _ = _make_scoper_with_sizes({"A": 100, "B": 100})
+        goal = _GoalStub("g1", "modify things", "touch A and B", ("f.py",))
+        legacy = decompose_for_block(goal, zero_coverage=False, scoper=scoper)
+        explicit_none = decompose_for_block(
+            goal, zero_coverage=False, scoper=scoper, compression_target=None
+        )
+        assert [s.to_dict() for s in legacy] == [s.to_dict() for s in explicit_none]
+
+    def test_multi_symbol_sub_goals_fit_within_target(self, monkeypatch):
+        """Every returned sub-goal with >1 symbol has payload <= compression_target."""
+        scoper, source = _make_scoper_with_sizes(
+            {"A": 200, "B": 200, "C": 200, "D": 200}
+        )
+        monkeypatch.setattr(
+            gdp, "_read_source_for_estimate", lambda fp: source, raising=False
+        )
+        goal = _GoalStub("g2", "refactor", "touch A B C D", ("f.py",))
+        subs = decompose_for_block(
+            goal, zero_coverage=False, scoper=scoper, compression_target=700
+        )
+        assert len(subs) >= 1
+        for sub in subs:
+            if len(sub.scoped_symbols) > 1:
+                payload = estimate_subgoal_payload_chars(
+                    sub, source_reader=lambda fp: source
+                )
+                assert payload <= 700, (
+                    f"sub {sub.sub_goal_id}: payload {payload} > 700 chars"
+                )
+
+    def test_single_oversized_symbol_is_not_dropped(self, monkeypatch):
+        """An irreducible symbol (> target alone) is emitted, never silently dropped."""
+        scoper, source = _make_scoper_with_sizes({"Huge": 5000})
+        monkeypatch.setattr(
+            gdp, "_read_source_for_estimate", lambda fp: source, raising=False
+        )
+        goal = _GoalStub("g3", "rewrite huge", "mutate Huge", ("f.py",))
+        subs = decompose_for_block(
+            goal, zero_coverage=False, scoper=scoper, compression_target=500
+        )
+        all_syms = [sym for sub in subs for sym in sub.scoped_symbols]
+        assert any("Huge" in sym for sym in all_syms), (
+            "Irreducible symbol 'Huge' was silently dropped"
+        )
+
+    def test_irreducible_symbol_emits_warning(self, monkeypatch, caplog):
+        """Irreducible symbol triggers a WARNING log (never silent)."""
+        scoper, source = _make_scoper_with_sizes({"BigFunc": 5000})
+        monkeypatch.setattr(
+            gdp, "_read_source_for_estimate", lambda fp: source, raising=False
+        )
+        goal = _GoalStub("g4", "big func", "mutate BigFunc", ("f.py",))
+        with caplog.at_level(logging.WARNING):
+            decompose_for_block(
+                goal, zero_coverage=False, scoper=scoper, compression_target=500
+            )
+        assert any(
+            "irreducible" in rec.message.lower() for rec in caplog.records
+        ), f"Expected irreducible warning, got: {[r.message for r in caplog.records]}"
+
+    def test_estimate_subgoal_payload_chars_uses_same_ruler(self):
+        """estimate_subgoal_payload_chars uses the same T1 estimator as the interceptor.
+
+        The composition proof: the same estimate_body_chars function that gates
+        dispatch is the ruler the chunker uses to partition sub-goals, so no
+        off-by-one drift is possible.
+        """
+        # Verify the planner imports from the interceptor module (not a fork).
+        src = inspect.getsource(estimate_subgoal_payload_chars)
+        assert "estimate_body_chars" in src or "dw_egress_interceptor" in src, (
+            "estimate_subgoal_payload_chars must reuse the interceptor's estimate_body_chars"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 4. Sanitize
+# ---------------------------------------------------------------------------
+
+
+class TestSanitize:
+    """sanitize_egress_body applies model-specific rules correctly."""
+
+    def test_gpt_oss_floors_reasoning_effort_from_none(self):
+        """gpt-oss body with reasoning_effort=none -> floored to a non-none value."""
+        body = {
+            "model": "openai/gpt-oss-120b",
+            "messages": [{"role": "user", "content": "hello"}],
+            "reasoning_effort": "none",
+        }
+        out = sanitize_egress_body(body, "openai/gpt-oss-120b")
+        assert out["reasoning_effort"] != "none", (
+            f"Expected floored reasoning_effort, got {out['reasoning_effort']!r}"
+        )
+
+    def test_unknown_model_is_unchanged(self):
+        """Body for an unknown model is returned completely unchanged."""
+        body = {
+            "model": "totally-unknown-xyz",
+            "messages": [{"role": "user", "content": "hi"}],
+            "reasoning_effort": "none",
+            "custom_field": "keep-me",
+        }
+        out = sanitize_egress_body(body, "totally-unknown-xyz")
+        assert out == body
+
+    def test_sanitize_never_raises_on_bad_input(self):
+        """sanitize_egress_body is fail-soft: bad inputs never raise."""
+        sanitize_egress_body({}, "")
+        sanitize_egress_body({"messages": None}, "gpt-oss-120b")
+        sanitize_egress_body(None, "gpt-oss")  # type: ignore[arg-type]
+
+
+# ---------------------------------------------------------------------------
+# 5. Fail-soft asymmetry
+# ---------------------------------------------------------------------------
+
+
+class TestFailSoftAsymmetry:
+    """I2 guarantee: estimation errors pass through; only confirmed overweight blocks."""
+
+    def test_messages_none_does_not_raise(self):
+        """A malformed body (messages=None) -> estimate=0 -> no block (pass-through)."""
+        body = {"messages": None, "model": "m"}
+        # Must NOT raise -- estimator is fail-soft, returns 0 on bad input.
+        assert_egress_weight(body, "m")  # no exception
+
+    def test_empty_dict_does_not_raise(self):
+        """Completely empty body -> estimate=0 -> no block."""
+        assert_egress_weight({}, "m")
+
+    def test_messages_wrong_type_does_not_raise(self):
+        """messages as a string (unexpected type) -> fail-soft, no block."""
+        assert_egress_weight({"messages": "not a list"}, "m")
+
+    def test_estimate_returns_zero_on_none_messages(self):
+        """estimate_body_chars returns 0 (not an error) for messages=None."""
+        result = estimate_body_chars({"messages": None})
+        assert result == 0
+
+    def test_guard_snippet_passes_through_on_sanitize_crash(self, monkeypatch):
+        """I2: if sanitize raises a non-overweight error, egress is NOT blocked."""
+        session_post = MagicMock()
+
+        # Patch sanitize_egress_body to raise an unexpected error.
+        monkeypatch.setattr(
+            "backend.core.ouroboros.governance.dw_egress_interceptor.sanitize_egress_body",
+            lambda body, model: (_ for _ in ()).throw(RuntimeError("sanitize crash")),
+        )
+
+        # Run the guard inline (mirrors the chokepoint logic exactly).
+        body = _make_body(chars=100)
+        # Since monkeypatch alters the module attribute, use the guarded inline
+        # logic directly (the same pattern as in test_egress_chokepoint_wiring.py).
+
+        import backend.core.ouroboros.governance.dw_egress_interceptor as egi_mod
+        original_sanitize = sanitize_egress_body
+        egi_mod.sanitize_egress_body = lambda b, m: (_ for _ in ()).throw(  # type: ignore[method-assign]
+            RuntimeError("sanitize crash")
+        )
+        try:
+            if egi_mod.egress_interceptor_enabled():
+                try:
+                    body = egi_mod.sanitize_egress_body(body, "m")
+                    egi_mod.assert_egress_weight(body, "m")
+                except LocalEgressOverweightError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    pass  # I2: non-overweight error -> pass-through
+            session_post(body)  # simulates reaching the fire point
+        finally:
+            egi_mod.sanitize_egress_body = original_sanitize  # type: ignore[method-assign]
+
+        session_post.assert_called_once()  # never blocked
+
+    def test_guard_snippet_passes_through_on_weight_estimation_crash(self):
+        """I2: if assert_egress_weight raises a non-overweight error, egress still fires."""
+        session_post = MagicMock()
+        body = _make_body(chars=100)
+
+        # Simulate the guard with a crashing weight check.
+        import backend.core.ouroboros.governance.dw_egress_interceptor as egi_mod
+        original_assert = egi_mod.assert_egress_weight
+        egi_mod.assert_egress_weight = lambda b, m: (_ for _ in ()).throw(  # type: ignore[method-assign]
+            ValueError("estimation internal crash")
+        )
+        try:
+            if egi_mod.egress_interceptor_enabled():
+                try:
+                    body = egi_mod.sanitize_egress_body(body, "m")
+                    egi_mod.assert_egress_weight(body, "m")
+                except LocalEgressOverweightError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    pass
+            session_post(body)
+        finally:
+            egi_mod.assert_egress_weight = original_assert  # type: ignore[method-assign]
+
+        session_post.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# 6. Boot-guard
+# ---------------------------------------------------------------------------
+
+
+class TestBootGuard:
+    """_warn_if_egress_guard_disabled fires exactly when the guard is OFF."""
+
+    _SOVEREIGN_WARNING = (
+        "[SOVEREIGN WARNING] API Citizenship Guard Disabled: Egress Interceptor "
+        "is OFF. Node is vulnerable to overweight payload dispatch."
+    )
+
+    def test_warns_when_disabled(self, monkeypatch, caplog):
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "false")
+        logger = logging.getLogger("boot_guard_integration_test")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is True
+        assert any(self._SOVEREIGN_WARNING in r.message for r in caplog.records)
+
+    def test_silent_when_enabled_default(self, monkeypatch, caplog):
+        monkeypatch.delenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", raising=False)
+        logger = logging.getLogger("boot_guard_integration_test2")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is False
+        assert not any("SOVEREIGN WARNING" in r.message for r in caplog.records)
+
+    def test_silent_when_enabled_explicit_true(self, monkeypatch, caplog):
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "true")
+        logger = logging.getLogger("boot_guard_integration_test3")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is False
+        assert not any("SOVEREIGN WARNING" in r.message for r in caplog.records)
+
+    def test_warns_when_disabled_zero(self, monkeypatch, caplog):
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "0")
+        logger = logging.getLogger("boot_guard_integration_test4")
+        with caplog.at_level(logging.WARNING, logger=logger.name):
+            result = _warn_if_egress_guard_disabled(logger)
+        assert result is True
+        assert any(self._SOVEREIGN_WARNING in r.message for r in caplog.records)
+
+    def test_never_raises(self, monkeypatch):
+        """_warn_if_egress_guard_disabled must never raise, even with a broken logger."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "off")
+        logger = logging.getLogger("boot_guard_never_raise")
+        try:
+            _warn_if_egress_guard_disabled(logger)
+        except Exception as exc:  # noqa: BLE001
+            pytest.fail(f"_warn_if_egress_guard_disabled raised: {exc}")
+
+
+# ---------------------------------------------------------------------------
+# 7. OFF byte-identical -- disabled -> interceptor is a no-op
+# ---------------------------------------------------------------------------
+
+
+class TestOffByteIdentical:
+    """egress_interceptor_enabled() == False -> guard is a pure pass-through."""
+
+    def test_disabled_guard_never_calls_sanitize_or_weight(self, monkeypatch):
+        """When the interceptor is disabled, sanitize + weight are never invoked."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "false")
+
+        sanitize_called = []
+        weight_called = []
+
+        import backend.core.ouroboros.governance.dw_egress_interceptor as egi_mod
+        original_sanitize = egi_mod.sanitize_egress_body
+        original_assert = egi_mod.assert_egress_weight
+
+        def _tracking_sanitize(b, m):
+            sanitize_called.append(True)
+            return original_sanitize(b, m)
+
+        def _tracking_assert(b, m):
+            weight_called.append(True)
+            return original_assert(b, m)
+
+        egi_mod.sanitize_egress_body = _tracking_sanitize  # type: ignore[method-assign]
+        egi_mod.assert_egress_weight = _tracking_assert  # type: ignore[method-assign]
+        try:
+            # Simulate the guard snippet with the real enabled() check.
+            session_post = MagicMock()
+            body = _make_body(chars=999_999)  # oversized: would be blocked if ON
+
+            if egi_mod.egress_interceptor_enabled():
+                try:
+                    body = egi_mod.sanitize_egress_body(body, "m")
+                    egi_mod.assert_egress_weight(body, "m")
+                except LocalEgressOverweightError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    pass
+            session_post(body)
+        finally:
+            egi_mod.sanitize_egress_body = original_sanitize  # type: ignore[method-assign]
+            egi_mod.assert_egress_weight = original_assert  # type: ignore[method-assign]
+
+        assert not sanitize_called, "sanitize_egress_body must NOT be called when OFF"
+        assert not weight_called, "assert_egress_weight must NOT be called when OFF"
+        session_post.assert_called_once()  # body passed through unchanged
+
+    def test_disabled_oversized_body_reaches_session_post(self, monkeypatch):
+        """When interceptor is OFF, even a hugely oversized body reaches session.post."""
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "false")
+        monkeypatch.setenv("JARVIS_DW_EGRESS_MAX_CHARS", "100")  # very low ceiling
+
+        session_post = MagicMock()
+        body = _make_body(chars=50_000)
+
+        result = _run_guard_snippet(
+            body, "some-model", interceptor_enabled=False, session_post=session_post
+        )
+        session_post.assert_called_once()  # body not blocked
+
+    def test_egress_interceptor_enabled_returns_false_on_env_false(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", "false")
+        assert egress_interceptor_enabled() is False
+
+    def test_egress_interceptor_enabled_returns_true_by_default(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED", raising=False)
+        assert egress_interceptor_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# 8. Composition integrity -- cross-module seam assertions
+# ---------------------------------------------------------------------------
+
+
+class TestCompositionIntegrity:
+    """Cross-module seam assertions: verify the mesh components are wired together."""
+
+    def test_generate_runner_references_egress_overweight(self):
+        """generate_runner.py must reference egress overweight handling."""
+        import backend.core.ouroboros.governance.phase_runners.generate_runner as gr
+        src = inspect.getsource(gr)
+        assert (
+            "is_local_egress_overweight" in src
+            or "LocalEgressOverweightError" in src
+        ), "generate_runner must handle LocalEgressOverweightError"
+
+    def test_generate_runner_references_compression_target(self):
+        """generate_runner.py must thread compression_target to the decompose seam."""
+        import backend.core.ouroboros.governance.phase_runners.generate_runner as gr
+        src = inspect.getsource(gr)
+        assert "compression_target" in src, (
+            "generate_runner must pass compression_target to the decompose seam"
+        )
+
+    def test_orchestrator_decompose_seam_accepts_compression_target(self):
+        """Orchestrator._decompose_block_or_legacy must accept compression_target kwarg."""
+        from backend.core.ouroboros.governance.orchestrator import Orchestrator
+        sig = inspect.signature(Orchestrator._decompose_block_or_legacy)
+        assert "compression_target" in sig.parameters
+        assert sig.parameters["compression_target"].default is None
+
+    def test_interceptor_names_importable_from_provider_module(self):
+        """The four interceptor public names are re-exported by doubleword_provider."""
+        from backend.core.ouroboros.governance.doubleword_provider import (  # noqa: PLC0415
+            LocalEgressOverweightError as _LEE,
+            assert_egress_weight as _aw,
+            egress_interceptor_enabled as _ei,
+            sanitize_egress_body as _sb,
+        )
+        assert callable(_ei)
+        assert callable(_sb)
+        assert callable(_aw)
+        assert issubclass(_LEE, Exception)
+
+    def test_taxonomy_module_imports_from_interceptor_not_forked(self):
+        """dw_fault_taxonomy.is_local_egress_overweight uses a lazy import — no fork."""
+        src = inspect.getsource(is_local_egress_overweight)
+        assert "LocalEgressOverweightError" in src, (
+            "is_local_egress_overweight must import from dw_egress_interceptor"
+        )
+
+    def test_planner_uses_estimate_body_chars_from_interceptor(self):
+        """estimate_subgoal_payload_chars reuses the interceptor's T1 estimate_body_chars."""
+        src = inspect.getsource(estimate_subgoal_payload_chars)
+        # The function must import or reference the shared estimator.
+        assert "estimate_body_chars" in src or "dw_egress_interceptor" in src, (
+            "estimate_subgoal_payload_chars must reuse the T1 estimate_body_chars ruler"
+        )
+
+    def test_full_mesh_import_cycle_is_safe(self):
+        """All mesh modules import cleanly without circular-import errors."""
+        import importlib
+        for mod_path in [
+            "backend.core.ouroboros.governance.dw_egress_interceptor",
+            "backend.core.ouroboros.governance.doubleword_provider",
+            "backend.core.ouroboros.governance.dw_fault_taxonomy",
+            "backend.core.ouroboros.governance.topology_sentinel",
+            "backend.core.ouroboros.governance.goal_decomposition_planner",
+            "backend.core.ouroboros.governance.governed_loop_service",
+        ]:
+            mod = importlib.import_module(mod_path)
+            assert mod is not None, f"Failed to import {mod_path}"

--- a/tests/governance/test_egress_rechunk.py
+++ b/tests/governance/test_egress_rechunk.py
@@ -1,0 +1,245 @@
+"""Sovereign Egress Interceptor Mesh — T3 route-back tests.
+
+Covers the three legs of T3 (spec 2026-06-22 §4.3):
+
+  (a) ``LocalEgressOverweightError`` classifies to
+      ``FailureSource.LOCAL_EGRESS_OVERWEIGHT`` at weight 0.0 — it is OUR
+      mistake, never a vendor rupture, so it MUST mirror FSM_EXHAUSTED and
+      never trip the topology breaker / surface-health.
+
+  (b) ``decompose_for_block(goal, zero_coverage=False, compression_target=N)``
+      slices so every returned sub-goal's estimated payload <= N chars, OR a
+      single irreducible symbol is emitted with a WARNING (never silently
+      exceeds).
+
+  (c) The LIVE generate-failure path (the extracted
+      ``phase_runners/generate_runner.py`` ``except`` block) routes a
+      ``LOCAL_EGRESS_OVERWEIGHT`` op to ``decompose_for_block`` with
+      ``compression_target=error.max_allowed_size``. We assert the structural
+      seam (``orchestrator._decompose_block_or_legacy`` accepts the kwarg and
+      threads it through) because the deep runner site is only reachable with a
+      full live stack.
+
+All behavior is fail-soft + OFF byte-identical (no behavior change when no
+overweight occurs). ASCII only.
+"""
+from __future__ import annotations
+
+import inspect
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_egress_interceptor import (
+    LocalEgressOverweightError,
+    estimate_body_chars,
+)
+from backend.core.ouroboros.governance import goal_decomposition_planner as gdp
+from backend.core.ouroboros.governance.goal_decomposition_planner import (
+    decompose_for_block,
+)
+from backend.core.ouroboros.governance import topology_sentinel as ts
+from backend.core.ouroboros.governance.dw_fault_taxonomy import (
+    is_local_egress_overweight,
+    is_fsm_exhaustion,
+)
+from backend.core.ouroboros.governance.ast_symbol_scoper import ScopedTarget
+
+
+# ---------------------------------------------------------------------------
+# Test goal stub + injectable scoper
+# ---------------------------------------------------------------------------
+
+
+class _Goal:
+    def __init__(self, goal_id, title, description, target_files):
+        self.goal_id = goal_id
+        self.title = title
+        self.description = description
+        self.target_files = target_files
+
+
+def _make_scoper(symbol_sizes):
+    """Return an injectable scoper + the source registry it reads.
+
+    ``symbol_sizes`` maps ``symbol_name -> approx_char_size``. The scoper
+    returns one ScopedTarget per symbol on file ``f.py`` with line ranges
+    chosen so the planner's source-segment estimator measures ~that many
+    chars. We register the synthetic source in the planner's reader hook.
+    """
+    # Build a synthetic source whose per-symbol line ranges sum to the sizes.
+    lines = []
+    targets = []
+    lineno = 1
+    CHARS_PER_LINE = 50
+    for name, size in symbol_sizes.items():
+        n_lines = max(1, size // CHARS_PER_LINE)
+        start = lineno
+        for _ in range(n_lines):
+            lines.append("x" * (CHARS_PER_LINE - 1))  # -1 for newline
+            lineno += 1
+        end = lineno - 1
+        targets.append(ScopedTarget("f.py", name, start, end))
+    source = "\n".join(lines) + "\n"
+
+    def _scoper(file_path, description):  # noqa: ARG001
+        return tuple(targets)
+
+    return _scoper, source
+
+
+# ---------------------------------------------------------------------------
+# (a) FailureSource.LOCAL_EGRESS_OVERWEIGHT — weight 0.0, mirror FSM_EXHAUSTED
+# ---------------------------------------------------------------------------
+
+
+def test_local_egress_overweight_failure_source_exists():
+    assert hasattr(ts.FailureSource, "LOCAL_EGRESS_OVERWEIGHT")
+    assert ts.FailureSource.LOCAL_EGRESS_OVERWEIGHT.value == "local_egress_overweight"
+
+
+def test_local_egress_overweight_weight_is_zero(monkeypatch):
+    # Clear any env override so we read the default map.
+    monkeypatch.delenv(
+        "JARVIS_TOPOLOGY_WEIGHT_LOCAL_EGRESS_OVERWEIGHT", raising=False
+    )
+    assert ts.failure_weight(ts.FailureSource.LOCAL_EGRESS_OVERWEIGHT) == 0.0
+    # Mirrors FSM_EXHAUSTED exactly.
+    assert ts.failure_weight(ts.FailureSource.FSM_EXHAUSTED) == 0.0
+
+
+def test_local_egress_overweight_never_trips_breaker(monkeypatch):
+    """A streak of LOCAL_EGRESS_OVERWEIGHT failures must NOT trip the
+    weighted-streak breaker (weight 0.0, mirroring FSM_EXHAUSTED)."""
+    # Sentinel must be live for the breaker path to engage at all.
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_TOPOLOGY_FORCE_SEVERED", raising=False)
+    sentinel = ts.TopologySentinel()
+    model = "egress-test-model"
+    sentinel.register_endpoint(model)
+    # Hammer the same model far past any reasonable threshold.
+    for _ in range(50):
+        sentinel.report_failure(
+            model, ts.FailureSource.LOCAL_EGRESS_OVERWEIGHT, "overweight"
+        )
+    # Weight 0.0 -> the weighted streak never accumulates -> breaker CLOSED.
+    snap = sentinel._snapshots.get(model)
+    assert snap is not None
+    assert snap.weighted_failure_streak == 0.0
+    assert sentinel.get_state(model) == "CLOSED"
+
+    # FSM_EXHAUSTED behaves IDENTICALLY (the pattern we mirror).
+    fsm_model = "fsm-test-model"
+    sentinel.register_endpoint(fsm_model)
+    for _ in range(50):
+        sentinel.report_failure(
+            fsm_model, ts.FailureSource.FSM_EXHAUSTED, "exhausted"
+        )
+    assert sentinel._snapshots[fsm_model].weighted_failure_streak == 0.0
+    assert sentinel.get_state(fsm_model) == "CLOSED"
+
+
+def test_taxonomy_classifies_local_egress_overweight():
+    err = LocalEgressOverweightError(
+        attempted_size=1_000_000, max_allowed_size=600_000, model="m"
+    )
+    assert is_local_egress_overweight(err) is True
+    # A genuine FSM exhaustion is NOT an egress-overweight.
+    assert is_local_egress_overweight(RuntimeError("all_providers_exhausted")) is False
+    # And vice-versa: an egress-overweight is NOT mislabeled FSM-exhausted.
+    assert is_fsm_exhaustion(err) is False
+
+
+def test_taxonomy_local_egress_overweight_never_raises():
+    # NEVER raises -> False on weird input.
+    assert is_local_egress_overweight(None) is False  # type: ignore[arg-type]
+    assert is_local_egress_overweight(RuntimeError("nothing")) is False
+
+
+# ---------------------------------------------------------------------------
+# (b) decompose_for_block(compression_target=N)
+# ---------------------------------------------------------------------------
+
+
+def test_decompose_compression_target_kwarg_exists():
+    sig = inspect.signature(decompose_for_block)
+    assert "compression_target" in sig.parameters
+    assert sig.parameters["compression_target"].default is None
+
+
+def test_decompose_without_target_is_byte_identical():
+    """OFF byte-identical: compression_target=None must equal the legacy call."""
+    scoper, _ = _make_scoper({"A": 100, "B": 100})
+    goal = _Goal("g1", "do the thing", "mutate A and B", ("f.py",))
+    legacy = decompose_for_block(goal, zero_coverage=False, scoper=scoper)
+    explicit_none = decompose_for_block(
+        goal, zero_coverage=False, scoper=scoper, compression_target=None
+    )
+    assert [s.to_dict() for s in legacy] == [s.to_dict() for s in explicit_none]
+
+
+def test_decompose_splits_to_fit_compression_target(monkeypatch):
+    """Every returned mutation sub-goal's estimated payload <= target."""
+    # 4 symbols ~300 chars each; target 1000 -> must split into >=2 groups.
+    scoper, source = _make_scoper({"A": 300, "B": 300, "C": 300, "D": 300})
+    monkeypatch.setattr(
+        gdp, "_read_source_for_estimate", lambda fp: source, raising=False
+    )
+    goal = _Goal("g2", "refactor many", "touch A B C D", ("f.py",))
+    subs = decompose_for_block(
+        goal, zero_coverage=False, scoper=scoper, compression_target=1000
+    )
+    assert len(subs) >= 1
+    for sub in subs:
+        payload = gdp.estimate_subgoal_payload_chars(sub, source_reader=lambda fp: source)
+        # Each sub-goal that carries >1 symbol must fit; irreducible singles
+        # may exceed but must be logged (asserted in the irreducible test).
+        if len(sub.scoped_symbols) > 1:
+            assert payload <= 1000, (
+                f"sub {sub.sub_goal_id} payload {payload} > 1000"
+            )
+
+
+def test_decompose_irreducible_symbol_logged(monkeypatch, caplog):
+    """A single symbol bigger than the target is emitted with a WARNING and
+    never silently dropped."""
+    scoper, source = _make_scoper({"Huge": 5000})
+    monkeypatch.setattr(
+        gdp, "_read_source_for_estimate", lambda fp: source, raising=False
+    )
+    goal = _Goal("g3", "mutate huge", "rewrite Huge", ("f.py",))
+    import logging
+    caplog.set_level(logging.WARNING)
+    subs = decompose_for_block(
+        goal, zero_coverage=False, scoper=scoper, compression_target=1000
+    )
+    # The symbol is NOT lost.
+    all_syms = [s for sub in subs for s in sub.scoped_symbols]
+    assert any("Huge" in s for s in all_syms)
+    # A clear irreducible WARNING was emitted.
+    assert any(
+        "irreducible" in rec.message.lower() for rec in caplog.records
+    ), [r.message for r in caplog.records]
+
+
+# ---------------------------------------------------------------------------
+# (c) LIVE generate-failure seam: orchestrator._decompose_block_or_legacy
+#     accepts compression_target and threads it to decompose_for_block.
+# ---------------------------------------------------------------------------
+
+
+def test_orchestrator_decompose_seam_accepts_compression_target():
+    from backend.core.ouroboros.governance.orchestrator import Orchestrator
+    sig = inspect.signature(Orchestrator._decompose_block_or_legacy)
+    assert "compression_target" in sig.parameters
+    assert sig.parameters["compression_target"].default is None
+
+
+def test_generate_runner_live_site_routes_overweight():
+    """Structural assertion: the LIVE generate-failure handler (extracted
+    runner) references LOCAL_EGRESS_OVERWEIGHT / egress-overweight detection
+    and routes to the compression-target decompose seam. The deep call is only
+    reachable with a full live stack, so we pin the wiring statically."""
+    import backend.core.ouroboros.governance.phase_runners.generate_runner as gr
+    src = inspect.getsource(gr)
+    assert "is_local_egress_overweight" in src or "LocalEgressOverweightError" in src
+    assert "compression_target" in src


### PR DESCRIPTION
**Impeccable API citizen** (triggered by Meryem @ DW's reasoning_effort report). A local pre-flight interceptor makes it structurally impossible to send DoubleWord a malformed or oversized request — validated locally before any egress.

**Components**
- `dw_egress_interceptor.py` (pure, default-ON): **schema sanitizer** (extensible env-driven registry; reasoning rule DELEGATES to the existing floor, not reimplemented) + **payload-weight governor** `assert_egress_weight` → raises `LocalEgressOverweightError(attempted/max_allowed/required_compression_ratio)`.
- Wired at **all three** DW generation egress chokepoints (realtime SSE+non-stream, batch JSONL, and the heavy `complete_sync` lane) — oversized blocked BEFORE `session.post` (zero egress).
- **Context-aware re-chunk:** `LocalEgressOverweightError` → `FailureSource.LOCAL_EGRESS_OVERWEIGHT` (weight 0.0, never trips the vendor breaker — it's our mistake) → the **LIVE** `generate_runner.py` catch routes to `decompose_for_block(compression_target=max_allowed)` → AST-slices sub-goals that fit (irreducible logged, never silently exceeded).
- **Default-ON + Sovereign Telemetry Boot-Guard:** `[SOVEREIGN WARNING] API Citizenship Guard Disabled...` if an operator overrides it OFF.

**Invariants (Opus final review, APPROVE / no Critical):** I1 zero-egress (traced end-to-end, no session.post on overweight); I2 fail-soft asymmetry (sanitize/estimate bug never wrongly blocks; confirmed overweight always blocks); I3 weight-0.0 mirrors FSM_EXHAUSTED everywhere (cannot sever the DW lane); compression_target genuinely bounds (no discard bug); reuse-first; live-path reachability confirmed (route-back in the extracted GENERATE runner, exception survives candidate_generator unwrapped). 84 egress tests + static zero-egress proof.

**Static validation gate (operator):** an oversized request is provably blocked locally before any DW soak. The C2 soak remains operator-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a local egress interceptor that sanitizes DoubleWord request bodies and blocks oversized payloads before any network call. Oversized requests are classified locally and automatically re-chunked to fit, avoiding breaker trips and keeping the DW lane healthy.

- **New Features**
  - New `dw_egress_interceptor.py`: schema sanitizer + payload-weight governor; raises `LocalEgressOverweightError` with max size and required compression details.
  - Guard applied at all DW egress chokepoints in `doubleword_provider.py` (realtime SSE/non-stream, batch JSONL, and `complete_sync`) before any `session.post`.
  - New failure source `LOCAL_EGRESS_OVERWEIGHT` (weight 0.0) with taxonomy helper; never degrades or severs the vendor lane.
  - Generate-failure path routes overweight errors to `decompose_for_block(compression_target=...)` for context-aware re-chunking.
  - Default-ON with a boot guard that logs a `[SOVEREIGN WARNING]` if disabled; added docs and a full test suite (wiring, rechunk, boot guard, zero-egress).

- **Migration**
  - No action needed for in-ceiling payloads.
  - To disable, set `JARVIS_DW_EGRESS_INTERCEPTOR_ENABLED=false`.
  - Optional cap via `JARVIS_DW_EGRESS_MAX_CHARS`; otherwise derived from the model card’s context window.

<sup>Written for commit 83164d3014cf411bbdb7815c47f5417272c45503. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

