### PR TITLE
feat(watchdog): Autonomous Convergence Watchdog — trajectory stall-detect + Epistemic Weight-Shedder + Sovereign Ledger-Watchdog Composition

### DIFF
--- a/backend/core/ouroboros/governance/convergence_watchdog.py
+++ b/backend/core/ouroboros/governance/convergence_watchdog.py
@@ -16,8 +16,13 @@ stall_passes_threshold() -> int
 watchdog_enabled() -> bool
     JARVIS_CONVERGENCE_WATCHDOG_ENABLED (default true).
 
+max_self_heal_hops() -> int
+    JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS (default 3, clamp >=1). The real
+    termination bound on watchdog self-heal per invariant lineage.
+
 class ReductionTracker
     record_pass(lineage_id, parent_chars, max_child_chars) -> WatchdogVerdict
+    record_self_heal_hop(lineage_id) -> int  # bounded per-lineage hop counter
     reset(lineage_id)
 
 get_reduction_tracker() -> ReductionTracker
@@ -45,10 +50,12 @@ _ENV_STALL_RATIO = "JARVIS_WATCHDOG_STALL_RATIO"
 _ENV_STALL_PASSES = "JARVIS_WATCHDOG_STALL_PASSES"
 _ENV_ENABLED = "JARVIS_CONVERGENCE_WATCHDOG_ENABLED"
 _ENV_TRACKER_SIZE = "JARVIS_WATCHDOG_TRACKER_SIZE"
+_ENV_MAX_SELF_HEAL_HOPS = "JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS"
 
 _DEFAULT_STALL_RATIO = 0.95
 _DEFAULT_STALL_PASSES = 2
 _DEFAULT_TRACKER_SIZE = 256
+_DEFAULT_MAX_SELF_HEAL_HOPS = 3
 
 
 def stall_ratio_threshold() -> float:
@@ -71,6 +78,26 @@ def watchdog_enabled() -> bool:
     """Return True if JARVIS_CONVERGENCE_WATCHDOG_ENABLED is not 'false'/'0' (default true)."""
     val = os.environ.get(_ENV_ENABLED, "true").strip().lower()
     return val not in ("false", "0", "no", "off")
+
+
+def max_self_heal_hops() -> int:
+    """Return the max self-heal re-injections per invariant lineage.
+
+    Reads ``JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS`` (default 3). Clamped to >=1.
+    Fail-soft: any parse error returns the default (3).
+
+    This is the REAL mathematical termination bound on the watchdog self-heal:
+    because the lineage id is invariant across re-injection, a bounded
+    per-lineage counter caps the number of shed-and-continue hops at a small
+    constant REGARDLESS of the shed/envelope truncation dynamics (the
+    title-prefix window shift that defeated the fixpoint-only guard).
+    """
+    try:
+        return max(1, int(os.environ.get(
+            _ENV_MAX_SELF_HEAL_HOPS, _DEFAULT_MAX_SELF_HEAL_HOPS,
+        )))
+    except (ValueError, TypeError):
+        return _DEFAULT_MAX_SELF_HEAL_HOPS
 
 
 # ---------------------------------------------------------------------------
@@ -113,6 +140,10 @@ class ReductionTracker:
         self._max_lineages: int = max(1, max_lineages)
         # OrderedDict used for LRU eviction of oldest lineages.
         self._lineages: Dict[str, collections.deque] = collections.OrderedDict()
+        # Bounded per-lineage cumulative self-heal hop counter. SAME cap +
+        # LRU-eviction discipline as ``_lineages`` (no new unbounded store);
+        # this is the structural termination bound on watchdog self-heal.
+        self._self_heal_hops: Dict[str, int] = collections.OrderedDict()
 
     # ------------------------------------------------------------------
     def record_pass(
@@ -169,10 +200,43 @@ class ReductionTracker:
             logger.debug("[ConvergenceWatchdog] record_pass fail-soft", exc_info=True)
             return _SAFE_VERDICT
 
+    def record_self_heal_hop(self, lineage_id: str) -> int:
+        """Increment and return the cumulative self-heal count for *lineage_id*.
+
+        Bounded per-lineage counter mirroring the LRU-eviction discipline of
+        ``record_pass`` (same ``_max_lineages`` cap, oldest evicted). Because
+        the lineage id is INVARIANT across re-injection, this caps the number
+        of watchdog self-heal hops per lineage at a small constant regardless
+        of the shed/envelope truncation dynamics.
+
+        Fail-soft: any exception returns ``_DEFAULT_MAX_SELF_HEAL_HOPS + 1`` so
+        the caller treats it as over-budget and falls to advisor_blocked (the
+        de-dup final backstop) -- a failure NEVER grants an unbounded hop.
+        """
+        try:
+            if lineage_id in self._self_heal_hops:
+                self._self_heal_hops.move_to_end(lineage_id)
+                self._self_heal_hops[lineage_id] += 1
+            else:
+                if len(self._self_heal_hops) >= self._max_lineages:
+                    self._self_heal_hops.popitem(last=False)  # evict oldest
+                self._self_heal_hops[lineage_id] = 1
+            return self._self_heal_hops[lineage_id]
+        except Exception:  # pragma: no cover — fail-soft -> over-budget
+            logger.debug(
+                "[ConvergenceWatchdog] record_self_heal_hop fail-soft",
+                exc_info=True,
+            )
+            return _DEFAULT_MAX_SELF_HEAL_HOPS + 1
+
     def reset(self, lineage_id: str) -> None:
-        """Clear all recorded passes for *lineage_id*. Fail-soft."""
+        """Clear all recorded passes + self-heal hops for *lineage_id*. Fail-soft."""
         try:
             self._lineages.pop(lineage_id, None)
+        except Exception:  # pragma: no cover
+            pass
+        try:
+            self._self_heal_hops.pop(lineage_id, None)
         except Exception:  # pragma: no cover
             pass
 

--- a/backend/core/ouroboros/governance/convergence_watchdog.py
+++ b/backend/core/ouroboros/governance/convergence_watchdog.py
@@ -1,0 +1,250 @@
+"""convergence_watchdog.py — Reduction-trajectory stall detection + [SOVEREIGN YIELD] telemetry.
+
+Task T1 of the Autonomous Convergence Watchdog.
+
+Public API
+----------
+WatchdogVerdict
+    Frozen dataclass: stalled, ratio, consecutive_stalls, passes.
+
+stall_ratio_threshold() -> float
+    JARVIS_WATCHDOG_STALL_RATIO (default 0.95).
+
+stall_passes_threshold() -> int
+    JARVIS_WATCHDOG_STALL_PASSES (default 2).
+
+watchdog_enabled() -> bool
+    JARVIS_CONVERGENCE_WATCHDOG_ENABLED (default true).
+
+class ReductionTracker
+    record_pass(lineage_id, parent_chars, max_child_chars) -> WatchdogVerdict
+    reset(lineage_id)
+
+get_reduction_tracker() -> ReductionTracker
+    Process-global singleton.
+
+emit_sovereign_yield(op_id, *, lineage_id, ratio, consecutive_stalls,
+                     parent_chars, child_chars, tier) -> None
+    Emit WARNING + best-effort SSE event. Never raises.
+"""
+from __future__ import annotations
+
+import collections
+import logging
+import os
+from dataclasses import dataclass
+from typing import Dict
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Env-driven thresholds
+# ---------------------------------------------------------------------------
+
+_ENV_STALL_RATIO = "JARVIS_WATCHDOG_STALL_RATIO"
+_ENV_STALL_PASSES = "JARVIS_WATCHDOG_STALL_PASSES"
+_ENV_ENABLED = "JARVIS_CONVERGENCE_WATCHDOG_ENABLED"
+_ENV_TRACKER_SIZE = "JARVIS_WATCHDOG_TRACKER_SIZE"
+
+_DEFAULT_STALL_RATIO = 0.95
+_DEFAULT_STALL_PASSES = 2
+_DEFAULT_TRACKER_SIZE = 256
+
+
+def stall_ratio_threshold() -> float:
+    """Return the stall ratio threshold from env (default 0.95)."""
+    try:
+        return float(os.environ.get(_ENV_STALL_RATIO, _DEFAULT_STALL_RATIO))
+    except (ValueError, TypeError):
+        return _DEFAULT_STALL_RATIO
+
+
+def stall_passes_threshold() -> int:
+    """Return the consecutive stall passes threshold from env (default 2)."""
+    try:
+        return int(os.environ.get(_ENV_STALL_PASSES, _DEFAULT_STALL_PASSES))
+    except (ValueError, TypeError):
+        return _DEFAULT_STALL_PASSES
+
+
+def watchdog_enabled() -> bool:
+    """Return True if JARVIS_CONVERGENCE_WATCHDOG_ENABLED is not 'false'/'0' (default true)."""
+    val = os.environ.get(_ENV_ENABLED, "true").strip().lower()
+    return val not in ("false", "0", "no", "off")
+
+
+# ---------------------------------------------------------------------------
+# Verdict dataclass
+# ---------------------------------------------------------------------------
+
+@dataclass(frozen=True)
+class WatchdogVerdict:
+    """Immutable verdict from a single record_pass call."""
+
+    stalled: bool
+    ratio: float
+    consecutive_stalls: int
+    passes: int
+
+
+_SAFE_VERDICT = WatchdogVerdict(False, 0.0, 0, 0)
+
+
+# ---------------------------------------------------------------------------
+# ReductionTracker — bounded lineage map mirroring AttemptLedger pattern
+# ---------------------------------------------------------------------------
+
+def _lineage_deque_maxlen() -> int:
+    """Small per-lineage deque: passes_threshold + 3 to keep memory tiny."""
+    return stall_passes_threshold() + 3
+
+
+class ReductionTracker:
+    """Tracks reduction ratios per lineage and detects stall trajectories.
+
+    Mirrors the bounded-FIFO + shadow-set pattern from ``recursion_dedup.py``
+    (AttemptLedger).  The outer dict is bounded to ``JARVIS_WATCHDOG_TRACKER_SIZE``
+    lineages (oldest evicted via OrderedDict move-to-end discipline); each
+    lineage holds a small bounded deque of recent ratios.
+    """
+
+    def __init__(self) -> None:
+        max_lineages = int(os.environ.get(_ENV_TRACKER_SIZE, _DEFAULT_TRACKER_SIZE))
+        self._max_lineages: int = max(1, max_lineages)
+        # OrderedDict used for LRU eviction of oldest lineages.
+        self._lineages: Dict[str, collections.deque] = collections.OrderedDict()
+
+    # ------------------------------------------------------------------
+    def record_pass(
+        self,
+        lineage_id: str,
+        parent_chars: int,
+        max_child_chars: int,
+    ) -> WatchdogVerdict:
+        """Record one decompose pass for *lineage_id* and return a verdict.
+
+        ratio = max_child_chars / max(1, parent_chars).
+        consecutive_stalls = trailing run of ratios >= stall_ratio_threshold().
+        stalled = consecutive_stalls >= stall_passes_threshold().
+
+        Fail-soft: any exception returns WatchdogVerdict(False, 0.0, 0, 0).
+        """
+        try:
+            ratio = max_child_chars / max(1, parent_chars)
+            threshold = stall_ratio_threshold()
+            passes_needed = stall_passes_threshold()
+            deque_maxlen = passes_needed + 3
+
+            # Ensure lineage exists; evict oldest if over capacity.
+            if lineage_id not in self._lineages:
+                if len(self._lineages) >= self._max_lineages:
+                    self._lineages.popitem(last=False)  # evict oldest
+                self._lineages[lineage_id] = collections.deque(maxlen=deque_maxlen)
+            else:
+                # Move to end to mark as recently used.
+                self._lineages.move_to_end(lineage_id)
+
+            dq = self._lineages[lineage_id]
+            dq.append(ratio)
+
+            total_passes = len(dq)
+
+            # Count trailing run of stalls.
+            consecutive_stalls = 0
+            for r in reversed(dq):
+                if r >= threshold:
+                    consecutive_stalls += 1
+                else:
+                    break
+
+            stalled = consecutive_stalls >= passes_needed
+
+            return WatchdogVerdict(
+                stalled=stalled,
+                ratio=ratio,
+                consecutive_stalls=consecutive_stalls,
+                passes=total_passes,
+            )
+        except Exception:  # pragma: no cover — fail-soft
+            logger.debug("[ConvergenceWatchdog] record_pass fail-soft", exc_info=True)
+            return _SAFE_VERDICT
+
+    def reset(self, lineage_id: str) -> None:
+        """Clear all recorded passes for *lineage_id*. Fail-soft."""
+        try:
+            self._lineages.pop(lineage_id, None)
+        except Exception:  # pragma: no cover
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Process-global singleton (mirrors get_attempt_ledger pattern)
+# ---------------------------------------------------------------------------
+
+_REDUCTION_TRACKER_SINGLETON: ReductionTracker | None = None
+
+
+def get_reduction_tracker() -> ReductionTracker:
+    """Return the process-global ReductionTracker, creating it on first use."""
+    global _REDUCTION_TRACKER_SINGLETON
+    if _REDUCTION_TRACKER_SINGLETON is None:
+        _REDUCTION_TRACKER_SINGLETON = ReductionTracker()
+    return _REDUCTION_TRACKER_SINGLETON
+
+
+# ---------------------------------------------------------------------------
+# Sovereign yield telemetry
+# ---------------------------------------------------------------------------
+
+def emit_sovereign_yield(
+    op_id: str,
+    *,
+    lineage_id: str,
+    ratio: float,
+    consecutive_stalls: int,
+    parent_chars: int,
+    child_chars: int,
+    tier: str,
+) -> None:
+    """Emit a [SOVEREIGN YIELD] WARNING and best-effort SSE event. Never raises.
+
+    Log format:
+        [SOVEREIGN YIELD] op=<op_id> lineage=<lineage_id> stalled reduction
+        ratio=<ratio:.3f> passes=<consecutive_stalls> -> structural weight-shed
+        (tier=<tier>) parent=<parent_chars> child=<child_chars>
+    """
+    try:
+        logger.warning(
+            "[SOVEREIGN YIELD] op=%s lineage=%s stalled reduction ratio=%.3f"
+            " passes=%d -> structural weight-shed (tier=%s) parent=%d child=%d",
+            op_id,
+            lineage_id,
+            ratio,
+            consecutive_stalls,
+            tier,
+            parent_chars,
+            child_chars,
+        )
+    except Exception:  # pragma: no cover
+        pass
+
+    # Best-effort SSE event — lazy import so the module can be used without
+    # the full SSE broker stack loaded.
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: PLC0415
+            publish_task_event,
+        )
+        publish_task_event(
+            "sovereign_yield",
+            op_id,
+            {
+                "lineage_id": lineage_id,
+                "ratio": ratio,
+                "consecutive_stalls": consecutive_stalls,
+                "parent_chars": parent_chars,
+                "child_chars": child_chars,
+                "tier": tier,
+            },
+        )
+    except Exception:  # pragma: no cover — fail-soft, SSE stack optional
+        pass

--- a/backend/core/ouroboros/governance/epistemic_shedder.py
+++ b/backend/core/ouroboros/governance/epistemic_shedder.py
@@ -1,0 +1,227 @@
+"""epistemic_shedder.py — tiered pure-AST weight shedder.
+
+Reduces a Python source string to fit within a character budget using
+deterministic, model-free, pure-AST transformations applied in order
+of increasing aggression.  Never raises; always returns a string <=
+target_chars (or best-effort on Tier 3).
+
+Tiers
+-----
+none   – source already fits; return unchanged.
+tier1  – strip all docstrings (first Expr(Constant(str)) in each
+          Module/ClassDef/FunctionDef/AsyncFunctionDef body).
+          Comments are not in the AST so ast.unparse drops them for
+          free, reducing size further.
+tier2  – replace the body of every FunctionDef/AsyncFunctionDef/
+          ClassDef with a single "[SOVEREIGN YIELD: Implementation
+          Omitted]" Expr, heaviest-first, re-measuring after each
+          stub until source fits.  Operates on the Tier-1 output.
+tier3  – nuclear truncation: best_so_far[:target_chars] where
+          best_so_far is the smallest intermediate result from Tier
+          1/2 (or the original on parse error).
+
+Parse error at any AST tier → fall straight to Tier-3 truncation of
+the smallest available source (original on early parse failure).
+
+ABSOLUTE CONSTRAINT: pure AST only.
+  ast.parse / ast.unparse / ast.get_source_segment / ast.fix_missing_locations
+  NEVER exec / eval / compile(..., mode="exec").
+"""
+from __future__ import annotations
+
+import ast
+import logging
+
+log = logging.getLogger(__name__)
+
+_YIELD_STUB = "[SOVEREIGN YIELD: Implementation Omitted]"
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def shed_to_fit(source: str, target_chars: int) -> tuple[str, str]:
+    """Reduce *source* until ``len(result) <= target_chars``.
+
+    Parameters
+    ----------
+    source:
+        Raw Python source text.
+    target_chars:
+        Maximum character budget for the output.
+
+    Returns
+    -------
+    (shed_source, tier_reached)
+        *shed_source* is the (possibly reduced) source string.
+        *tier_reached* is one of ``{"none", "tier1", "tier2", "tier3"}``.
+    """
+    # Fast path — already fits.
+    if len(source) <= target_chars:
+        return source, "none"
+
+    # Track the best (smallest) intermediate result across tiers so that
+    # Tier-3 nuclear truncation cuts from the most-reduced form, not the raw
+    # original.  This preserves as much structure as possible even when
+    # truncating.
+    best: str = source
+
+    try:
+        # ----------------------------------------------------------------
+        # Tier 1 — strip docstrings.
+        # ----------------------------------------------------------------
+        t1 = _strip_docstrings(source)
+        if len(t1) < len(best):
+            best = t1
+        if len(t1) <= target_chars:
+            return t1, "tier1"
+
+        # ----------------------------------------------------------------
+        # Tier 2 — stub out heaviest function defs, one by one (on the
+        # Tier-1 output).  ClassDef bodies are intentionally excluded here
+        # so that nested function SIGNATURES remain visible in the output.
+        # The callback updates *best* with every intermediate result so
+        # that Tier-3 truncation slices the most-reduced form that still
+        # contains structural information (function signatures, stubs).
+        # ----------------------------------------------------------------
+        t2, t2_best = _stub_heavy_defs(t1, target_chars)
+        # t2_best is the smallest intermediate seen during Tier-2 stubs.
+        if len(t2_best) < len(best):
+            best = t2_best
+        if len(t2) < len(best):
+            best = t2
+        if len(t2) <= target_chars:
+            return t2, "tier2"
+
+    except Exception:  # noqa: BLE001  (fail-soft; any AST error → tier3)
+        log.debug(
+            "epistemic_shedder: AST processing failed; falling to tier3",
+            exc_info=True,
+        )
+
+    # ----------------------------------------------------------------
+    # Tier 3 — nuclear truncation of the best intermediate result.
+    # Truncates from the smallest intermediate so that any structure
+    # (function signatures, stub markers) that survived earlier tiers
+    # is preserved as much as possible within the budget.
+    # Falls here either because Tier 2 didn't fit OR on any parse error.
+    # ----------------------------------------------------------------
+    return best[:target_chars], "tier3"
+
+
+# ---------------------------------------------------------------------------
+# Tier 1 helpers
+# ---------------------------------------------------------------------------
+
+
+def _is_docstring_node(node: ast.stmt) -> bool:
+    """Return True when *node* is an ``Expr(Constant(str))`` docstring stmt."""
+    return (
+        isinstance(node, ast.Expr)
+        and isinstance(node.value, ast.Constant)
+        and isinstance(node.value.value, str)
+    )
+
+
+class _DocstringStripper(ast.NodeTransformer):
+    """Remove the leading docstring from each supported scope."""
+
+    def _strip_body(self, body: list[ast.stmt]) -> list[ast.stmt]:
+        if body and _is_docstring_node(body[0]):
+            return body[1:] or [ast.Pass()]
+        return body
+
+    def visit_Module(self, node: ast.Module) -> ast.Module:
+        node.body = self._strip_body(node.body)
+        self.generic_visit(node)
+        return node
+
+    def visit_ClassDef(self, node: ast.ClassDef) -> ast.ClassDef:
+        node.body = self._strip_body(node.body)
+        self.generic_visit(node)
+        return node
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> ast.FunctionDef:
+        node.body = self._strip_body(node.body)
+        self.generic_visit(node)
+        return node
+
+    def visit_AsyncFunctionDef(
+        self, node: ast.AsyncFunctionDef
+    ) -> ast.AsyncFunctionDef:
+        node.body = self._strip_body(node.body)
+        self.generic_visit(node)
+        return node
+
+
+def _strip_docstrings(source: str) -> str:
+    """Return *source* with all docstrings removed via AST round-trip."""
+    tree = ast.parse(source)
+    stripped = _DocstringStripper().visit(tree)
+    ast.fix_missing_locations(stripped)
+    return ast.unparse(stripped)
+
+
+# ---------------------------------------------------------------------------
+# Tier 2 helpers
+# ---------------------------------------------------------------------------
+
+_FUNC_STUBBABLE = (ast.FunctionDef, ast.AsyncFunctionDef)
+_CLASS_STUBBABLE = (ast.ClassDef,)
+_STUBBABLE = _FUNC_STUBBABLE + _CLASS_STUBBABLE
+
+
+def _yield_body() -> list[ast.stmt]:
+    """Return the single-statement stub body for a stubbable def."""
+    return [ast.Expr(value=ast.Constant(value=_YIELD_STUB))]
+
+
+def _collect_stubbable_defs(
+    tree: ast.AST,
+    source: str,
+    kinds: tuple[type, ...],
+) -> list[tuple[int, ast.AST]]:
+    """Collect stubbable nodes of *kinds* with source size, largest first."""
+    results: list[tuple[int, ast.AST]] = []
+    for node in ast.walk(tree):
+        if isinstance(node, kinds):
+            seg = ast.get_source_segment(source, node)
+            size = len(seg) if seg is not None else 0
+            results.append((size, node))
+    # Heaviest first (stable sort for determinism when sizes tie).
+    results.sort(key=lambda t: t[0], reverse=True)
+    return results
+
+
+def _stub_heavy_defs(source: str, target_chars: int) -> tuple[str, str]:
+    """Replace function/async-function def bodies one-by-one (heaviest first).
+
+    Only ``FunctionDef``/``AsyncFunctionDef`` bodies are replaced; ``ClassDef``
+    bodies are intentionally excluded so that nested function signatures remain
+    visible in the output.
+
+    Returns
+    -------
+    (final_result, best_intermediate)
+        *final_result* is the unparsed tree after all applicable stubs.
+        *best_intermediate* is the smallest string seen across all
+        intermediate steps (may differ from *final_result* when later stubs
+        grow the text, e.g. when a tiny function body is replaced by a stub
+        string that is longer).
+    """
+    tree = ast.parse(source)
+    current = ast.unparse(ast.fix_missing_locations(tree))
+    best_so_far = current
+
+    func_defs = _collect_stubbable_defs(tree, source, _FUNC_STUBBABLE)
+    for _size, node in func_defs:
+        if len(current) <= target_chars:
+            return current, best_so_far
+        node.body = _yield_body()  # type: ignore[attr-defined]
+        ast.fix_missing_locations(tree)
+        current = ast.unparse(tree)
+        if len(current) < len(best_so_far):
+            best_so_far = current
+
+    return current, best_so_far

--- a/backend/core/ouroboros/governance/goal_decomposition_planner.py
+++ b/backend/core/ouroboros/governance/goal_decomposition_planner.py
@@ -810,7 +810,15 @@ def shed_block_goal_to_fit(
         sub = SubGoal(
             sub_goal_id=f"{parent_goal_id}-shed",
             parent_goal_id=parent_goal_id,
-            title=str(description or "")[:80],
+            # EMPTY title (defense-in-depth, faster natural fixpoint): the
+            # multi-step ``_make_envelope`` builds the re-injected op
+            # description as ``f"{title}\n\n{description}"``. A non-empty
+            # ``description[:80]`` prefix shifts the tier3 truncation window by
+            # ~82 chars EACH hop, so the shed text keeps changing and the
+            # fixpoint guard isn't hit for ~compression_target/82 hops. An empty
+            # title makes the prefix a constant ``"\n\n"`` from hop 0, so the
+            # re-injected payload converges to a fixpoint immediately.
+            title="",
             description=shed,
             # Mutation/code sub-goal. SubGoalKind has no dedicated MUTATION
             # member; ATOMIC is the kind decompose_for_block emits for a

--- a/backend/core/ouroboros/governance/goal_decomposition_planner.py
+++ b/backend/core/ouroboros/governance/goal_decomposition_planner.py
@@ -769,6 +769,64 @@ def estimate_subgoal_payload_chars(
             return 0
 
 
+def shed_block_goal_to_fit(
+    target_files: Tuple[str, ...],
+    description: str,
+    target_chars: int,
+    parent_goal_id: str,
+    *,
+    source_reader: Callable[[str], str] | None = None,
+) -> Tuple["SubGoal | None", str]:
+    """Deep-payload structural shed (Sovereign Ledger-Watchdog Composition).
+
+    Reads the FULL target-file source, sheds it via the tiered epistemic
+    shedder, and returns ONE SubGoal carrying the shed source INLINE in
+    description with scoped_symbols CLEARED -- so estimate_subgoal_payload_chars
+    measures <= target_chars (the next egress check passes -> loop breaks).
+
+    The egress payload of a BLOCK GOAL is dominated by the scoped-symbol SOURCE
+    segments (the file content the model must read/edit), NOT the prose
+    description. Shedding the description alone is therefore useless: the ruler
+    keeps measuring the full file. This helper reads the real source, runs the
+    pure-AST tiered shedder over it, and inlines the shed result into the
+    description while CLEARING scoped_symbols -- so the next
+    ``estimate_subgoal_payload_chars`` pass measures only the (now-shed) inline
+    text and converges below the egress ceiling.
+
+    Returns ``(SubGoal | None, tier)``. Fail-soft -> ``(None, "none")``.
+    """
+    try:
+        from backend.core.ouroboros.governance.epistemic_shedder import (  # noqa: PLC0415
+            shed_to_fit,
+        )
+        reader = source_reader or _read_source_for_estimate
+        parts = [str(description or "")]
+        for fp in (target_files or ()):
+            src = reader(str(fp))
+            if src:
+                parts.append(src)
+        full = "\n".join(p for p in parts if p)
+        shed, tier = shed_to_fit(full, max(1, int(target_chars)))
+        sub = SubGoal(
+            sub_goal_id=f"{parent_goal_id}-shed",
+            parent_goal_id=parent_goal_id,
+            title=str(description or "")[:80],
+            description=shed,
+            # Mutation/code sub-goal. SubGoalKind has no dedicated MUTATION
+            # member; ATOMIC is the kind decompose_for_block emits for a
+            # single non-boundary mutation sub-goal (_fallback uses ATOMIC).
+            kind=SubGoalKind.ATOMIC,
+            target_files=tuple(target_files or ()),
+            depends_on_sub_ids=(),
+            estimated_complexity="moderate",
+            boundary_crossed=False,
+            scoped_symbols=(),  # CLEARED: shed source is inline in description
+        )
+        return sub, tier
+    except Exception:  # noqa: BLE001 — deep shed must never crash a dispatch
+        return None, "none"
+
+
 # A duck-typed alias for the scoper's ScopedTarget (avoids an import cycle /
 # hard dependency at module load — the planner already lazy-imports the scoper).
 ScopedTargetLike = Any

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -137,6 +137,7 @@ from backend.core.ouroboros.governance.convergence_watchdog import (
     get_reduction_tracker,
     watchdog_enabled,
     emit_sovereign_yield,
+    max_self_heal_hops,
 )
 from backend.core.ouroboros.governance.epistemic_shedder import shed_to_fit
 
@@ -2099,6 +2100,8 @@ class GovernedOrchestrator:
         path. ``None`` is returned when:
 
         - the lineage has NOT stalled yet (de-dup hard-fails as before), OR
+        - the lineage's cumulative self-heal hop count exceeds
+          ``max_self_heal_hops()`` (the structural bound, see TERMINATION), OR
         - the deep shed could not produce a sub-goal (fail-soft), OR
         - the shed result is a FIXPOINT (its hash is already a duplicate -> the
           shed can no longer reduce the payload, so the de-dup ledger is the
@@ -2106,10 +2109,24 @@ class GovernedOrchestrator:
         - the re-injection emitted zero sub-goals, OR
         - ANY exception (fail-soft -- NEVER crash a dispatch).
 
-        TERMINATION: at most ONE self-heal hop per lineage. The fixpoint check
-        (shed-hash duplicate) guarantees the loop cannot re-inject the same
-        irreducible shed forever -- the second arrival of an irreducible
-        lineage finds its shed-hash already marked and yields to advisor_blocked.
+        TERMINATION: self-heal is capped at ``max_self_heal_hops()`` (env
+        ``JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS``, default 3) re-injections per
+        INVARIANT lineage; the de-dup ledger remains the final backstop.
+
+        Why a hop counter and not the fixpoint guard alone: the multi-step
+        ``_make_envelope`` re-injects the sub-goal as
+        ``f"{title}\n\n{description}"``. Historically the shed sub-goal carried
+        a ``title=description[:80]`` prefix, so the tier3 truncation window
+        shifted ~82 chars EACH hop -- the shed text kept changing and the
+        fixpoint (shed-hash duplicate) guard was not hit until
+        ~``compression_target/82`` hops (~7,300 at the 600k ceiling), each a
+        real re-injection -> a multi-minute storm. The bounded hop counter caps
+        self-heals at a small constant REGARDLESS of the shed/envelope dynamics
+        because ``_lineage = subgoal_hash(target_files, ())`` is invariant
+        across re-injection. (Fix 2 additionally sets the shed ``title=""`` so
+        the prefix is a constant ``"\n\n"`` and the natural fixpoint converges
+        immediately -- defense in depth.) The fixpoint check still short-circuits
+        the common irreducible case before the budget is even consumed.
         """
         try:
             # INVARIANT LINEAGE: stable across re-injection (files do not change
@@ -2126,6 +2143,22 @@ class GovernedOrchestrator:
             if not _verdict.stalled:
                 # Not enough consecutive stalls yet -> de-dup hard-fails as
                 # before (the watchdog only intervenes on a proven stall).
+                return None
+
+            # BOUNDED SELF-HEAL (the REAL termination bound): cap the cumulative
+            # self-heal re-injections per INVARIANT lineage at a small env
+            # constant. Because ``_lineage`` is stable across re-injection, this
+            # holds REGARDLESS of the shed/envelope truncation dynamics (the
+            # _make_envelope title-prefix shifts the tier3 window each hop, so
+            # the fixpoint-only guard alone bounded at ~compression_target/82
+            # hops -- a multi-minute storm). Over budget -> fall to the de-dup
+            # final backstop (advisor_blocked).
+            if get_reduction_tracker().record_self_heal_hop(_lineage) > max_self_heal_hops():
+                logger.warning(
+                    "[SOVEREIGN YIELD] op=%s lineage=%s self-heal hop budget "
+                    "exhausted (max=%d) -> advisor_blocked backstop",
+                    ctx.op_id, _lineage, max_self_heal_hops(),
+                )
                 return None
 
             _sub, _tier = shed_block_goal_to_fit(

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -116,6 +116,7 @@ from backend.core.ouroboros.governance.goal_decomposition_planner import (
     chunking_enabled,
     decompose_for_block,
     estimate_subgoal_payload_chars,
+    shed_block_goal_to_fit,
 )
 from backend.core.ouroboros.governance.adaptive_recursion_governor import (
     recursion_budget,
@@ -2081,6 +2082,112 @@ class GovernedOrchestrator:
                 "[Orchestrator] Route cost heartbeat failed", exc_info=True,
             )
 
+    async def _watchdog_self_heal(
+        self,
+        ctx: OperationContext,
+        target_files: tuple,
+        description: str,
+        compression_target: int,
+        ledger: Any,
+    ) -> "OperationContext | None":
+        """Funnel-inversion self-heal: give the watchdog a shed-and-CONTINUE
+        chance on a DUPLICATE GOAL before the de-dup ledger hard-fails it to
+        advisor_blocked (Sovereign Ledger-Watchdog Composition).
+
+        Returns the advanced (terminal ``decomposed``) context on a successful
+        self-heal, or ``None`` to fall through to the legacy advisor_blocked
+        path. ``None`` is returned when:
+
+        - the lineage has NOT stalled yet (de-dup hard-fails as before), OR
+        - the deep shed could not produce a sub-goal (fail-soft), OR
+        - the shed result is a FIXPOINT (its hash is already a duplicate -> the
+          shed can no longer reduce the payload, so the de-dup ledger is the
+          final mathematical backstop -> advisor_blocked), OR
+        - the re-injection emitted zero sub-goals, OR
+        - ANY exception (fail-soft -- NEVER crash a dispatch).
+
+        TERMINATION: at most ONE self-heal hop per lineage. The fixpoint check
+        (shed-hash duplicate) guarantees the loop cannot re-inject the same
+        irreducible shed forever -- the second arrival of an irreducible
+        lineage finds its shed-hash already marked and yields to advisor_blocked.
+        """
+        try:
+            # INVARIANT LINEAGE: stable across re-injection (files do not change
+            # per re-injection; the op description does). This lets the tracker
+            # accumulate consecutive stalls across distinct op_ids.
+            _lineage = subgoal_hash(target_files, ())
+            # An exact repeat of an already-seen GOAL is a FULL stall: there was
+            # no reduction at all (ratio ~1.0). Feed parent==child so the
+            # tracker registers a stall pass.
+            _len = max(1, len(description))
+            _verdict = get_reduction_tracker().record_pass(
+                _lineage, _len, _len,
+            )
+            if not _verdict.stalled:
+                # Not enough consecutive stalls yet -> de-dup hard-fails as
+                # before (the watchdog only intervenes on a proven stall).
+                return None
+
+            _sub, _tier = shed_block_goal_to_fit(
+                target_files, description, compression_target, ctx.op_id,
+            )
+            if _sub is None:
+                return None
+
+            # FIXPOINT GUARD (termination keystone): if the shed result's hash
+            # is ALREADY a duplicate, the shed can no longer reduce the payload
+            # -> the de-dup ledger is the final backstop -> advisor_blocked.
+            _shed_h = subgoal_hash(_sub.target_files, _sub.description)
+            if is_duplicate(_shed_h, ledger, frozenset()):
+                return None
+
+            # Self-heal: emit the ONE shed sub-goal DIRECTLY. We do NOT re-run
+            # decompose_for_block -- it would re-read the full files and undo the
+            # shed. The shed sub-goal carries the shed source inline.
+            emit_sovereign_yield(
+                ctx.op_id,
+                lineage_id=_lineage,
+                ratio=_verdict.ratio,
+                consecutive_stalls=_verdict.consecutive_stalls,
+                parent_chars=len(description),
+                child_chars=len(_sub.description),
+                tier=_tier,
+            )
+            plan = DecomposedPlan(
+                parent_goal_id=ctx.op_id,
+                sub_goals=(_sub,),
+                dag_valid=True,
+                dag_depth=1,
+                topological_order=(_sub.sub_goal_id,),
+                diagnostic="watchdog_self_heal_reinject",
+            )
+            router = getattr(
+                getattr(self._stack, "governed_loop_service", None),
+                "_intake_router",
+                None,
+            )
+            report = await advance_orchestration(plan, router=router)
+            if getattr(report, "emitted_count", 0) >= 1:
+                # Mark the shed-hash so the next arrival of THIS irreducible
+                # lineage finds it duplicate at the fixpoint guard -> bounded.
+                ledger.mark(_shed_h)
+                logger.warning(
+                    "[SOVEREIGN YIELD] op=%s self-healed: shed-and-continue "
+                    "(tier=%s) -> 1 fitting sub-goal",
+                    ctx.op_id, _tier,
+                )
+                return ctx.advance(
+                    OperationPhase.CANCELLED,
+                    terminal_reason_code="decomposed",
+                )
+            return None
+        except Exception:  # noqa: BLE001 -- fail-soft -> legacy advisor_blocked
+            logger.debug(
+                "[Orchestrator] watchdog self-heal fail-soft -> legacy "
+                "advisor_blocked (op=%s)", ctx.op_id, exc_info=True,
+            )
+            return None
+
     async def _decompose_block_or_legacy(
         self,
         ctx: OperationContext,
@@ -2125,7 +2232,31 @@ class GovernedOrchestrator:
                 # B4 de-dup -- primary infinite-cycle guard.
                 h = subgoal_hash(target_files, description)
                 ledger = get_attempt_ledger()
-                if not is_duplicate(h, ledger, frozenset()):
+                # FUNNEL INVERSION (Sovereign Ledger-Watchdog Composition):
+                # the de-dup ledger previously HARD-FAILED a repeating GOAL to
+                # advisor_blocked BEFORE the watchdog could run, so the
+                # structural self-heal was inert live. Give the watchdog a
+                # shed-and-CONTINUE chance on the egress re-chunk path (compression
+                # _target set + watchdog enabled) before the legacy hard-fail. The
+                # de-dup ledger REMAINS the final mathematical backstop: a stalled
+                # lineage whose shed cannot reduce further (fixpoint) yields a
+                # duplicate shed-hash -> self-heal returns None -> advisor_blocked.
+                _dup = is_duplicate(h, ledger, frozenset())
+                if (
+                    _dup
+                    and compression_target is not None
+                    and watchdog_enabled()
+                ):
+                    _healed = await self._watchdog_self_heal(
+                        ctx,
+                        target_files,
+                        description,
+                        compression_target,
+                        ledger,
+                    )
+                    if _healed is not None:
+                        return _healed
+                if not _dup:
                     # Recursion depth from intake evidence (fail-soft to 0).
                     depth = 0
                     try:
@@ -2236,34 +2367,37 @@ class GovernedOrchestrator:
                                     (estimate_subgoal_payload_chars(s) for s in _all_subs),
                                     default=0,
                                 )
-                                # Use ctx.op_id as the stable lineage root id.
-                                # goal.goal_id == ctx.op_id (set at _BlockGoal
-                                # construction above), so either is equivalent;
-                                # ctx.op_id is explicit and never None.
-                                _lineage = ctx.op_id
+                                # INVARIANT LINEAGE (Ledger-Watchdog
+                                # Composition): the lineage id MUST be stable
+                                # across re-injections so the tracker can
+                                # accumulate consecutive stalls. ctx.op_id is
+                                # per-op (each re-injection is a NEW op_id) so
+                                # "2 consecutive stalls" was never reached --
+                                # the watchdog was inert live. subgoal_hash over
+                                # (target_files, ()) is invariant across the same
+                                # GOAL's re-injections (the op description
+                                # changes per re-injection but the files do not).
+                                _lineage = subgoal_hash(target_files, ())
                                 _verdict = get_reduction_tracker().record_pass(
                                     _lineage, _parent_chars, _max_child,
                                 )
                                 if _verdict.stalled:
-                                    # Stalled: structurally shed the heaviest
-                                    # sub-goal's description to fit the egress
-                                    # ceiling, emit [SOVEREIGN YIELD], and replace
-                                    # the non-shrinking slice with ONE fitting
-                                    # sub-goal so the next pass can make progress.
-                                    _heaviest = (
-                                        max(
-                                            _all_subs,
-                                            key=lambda s: estimate_subgoal_payload_chars(s),
-                                        )
-                                        if _all_subs
-                                        else None
+                                    # Stalled: deep-payload structural shed.
+                                    # Shedding the description alone is useless --
+                                    # the payload is dominated by the scoped-symbol
+                                    # SOURCE segments. shed_block_goal_to_fit reads
+                                    # the real file source, sheds it, and inlines
+                                    # the shed result with scoped_symbols CLEARED
+                                    # so the next egress estimate measures
+                                    # <= target. Replace the non-shrinking slice
+                                    # with that ONE fitting sub-goal so the next
+                                    # pass makes progress.
+                                    _shed_sub, _tier = shed_block_goal_to_fit(
+                                        target_files,
+                                        goal.description,
+                                        compression_target,
+                                        ctx.op_id,
                                     )
-                                    _src = (
-                                        getattr(_heaviest, "description", "") or ""
-                                    ) if _heaviest is not None else (
-                                        goal.description or ""
-                                    )
-                                    _shed, _tier = shed_to_fit(_src, compression_target)
                                     emit_sovereign_yield(
                                         ctx.op_id,
                                         lineage_id=_lineage,
@@ -2273,13 +2407,7 @@ class GovernedOrchestrator:
                                         child_chars=_max_child,
                                         tier=_tier,
                                     )
-                                    if _heaviest is not None:
-                                        # Replace the heaviest sub-goal with a
-                                        # shed copy.  SubGoal is a frozen
-                                        # dataclass so we use dataclasses.replace.
-                                        _shed_sub = dataclasses.replace(
-                                            _heaviest, description=_shed,
-                                        )
+                                    if _shed_sub is not None:
                                         _all_subs = (_shed_sub,)
                             except Exception:  # noqa: BLE001
                                 # Fail-soft: watchdog error -> legacy slice path.

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -115,6 +115,7 @@ from backend.core.ouroboros.governance.goal_decomposition_planner import (
     DecomposedPlan,
     chunking_enabled,
     decompose_for_block,
+    estimate_subgoal_payload_chars,
 )
 from backend.core.ouroboros.governance.adaptive_recursion_governor import (
     recursion_budget,
@@ -127,6 +128,16 @@ from backend.core.ouroboros.governance.recursion_dedup import (
 from backend.core.ouroboros.governance.multi_step_orchestrator import (
     advance_orchestration,
 )
+# T3 -- Convergence Watchdog wiring. Leaf modules (no orchestrator back-edge).
+# Bound at module level so the seam is monkeypatch-testable (same discipline
+# as decompose_for_block above).  estimate_subgoal_payload_chars already
+# imported from goal_decomposition_planner above.
+from backend.core.ouroboros.governance.convergence_watchdog import (
+    get_reduction_tracker,
+    watchdog_enabled,
+    emit_sovereign_yield,
+)
+from backend.core.ouroboros.governance.epistemic_shedder import shed_to_fit
 
 logger = logging.getLogger("Ouroboros.Orchestrator")
 
@@ -2210,6 +2221,69 @@ class GovernedOrchestrator:
                             goal, zero_coverage=zero_cov,
                             compression_target=compression_target,
                         )
+                        # T3 -- Convergence Watchdog: detect stalled reduction
+                        # trajectory on the egress re-chunk path and structurally
+                        # shed weight instead of looping forever.
+                        # Guard: only active when compression_target is set (i.e.
+                        # the egress-overweight re-chunk path) and the watchdog is
+                        # enabled.  Fail-soft: any exception falls through to the
+                        # legacy slice path unchanged; the de-dup ledger remains
+                        # the backstop against infinite cycles.
+                        if compression_target is not None and watchdog_enabled():
+                            try:
+                                _parent_chars = estimate_subgoal_payload_chars(goal)
+                                _max_child = max(
+                                    (estimate_subgoal_payload_chars(s) for s in _all_subs),
+                                    default=0,
+                                )
+                                # Use ctx.op_id as the stable lineage root id.
+                                # goal.goal_id == ctx.op_id (set at _BlockGoal
+                                # construction above), so either is equivalent;
+                                # ctx.op_id is explicit and never None.
+                                _lineage = ctx.op_id
+                                _verdict = get_reduction_tracker().record_pass(
+                                    _lineage, _parent_chars, _max_child,
+                                )
+                                if _verdict.stalled:
+                                    # Stalled: structurally shed the heaviest
+                                    # sub-goal's description to fit the egress
+                                    # ceiling, emit [SOVEREIGN YIELD], and replace
+                                    # the non-shrinking slice with ONE fitting
+                                    # sub-goal so the next pass can make progress.
+                                    _heaviest = (
+                                        max(
+                                            _all_subs,
+                                            key=lambda s: estimate_subgoal_payload_chars(s),
+                                        )
+                                        if _all_subs
+                                        else None
+                                    )
+                                    _src = (
+                                        getattr(_heaviest, "description", "") or ""
+                                    ) if _heaviest is not None else (
+                                        goal.description or ""
+                                    )
+                                    _shed, _tier = shed_to_fit(_src, compression_target)
+                                    emit_sovereign_yield(
+                                        ctx.op_id,
+                                        lineage_id=_lineage,
+                                        ratio=_verdict.ratio,
+                                        consecutive_stalls=_verdict.consecutive_stalls,
+                                        parent_chars=_parent_chars,
+                                        child_chars=_max_child,
+                                        tier=_tier,
+                                    )
+                                    if _heaviest is not None:
+                                        # Replace the heaviest sub-goal with a
+                                        # shed copy.  SubGoal is a frozen
+                                        # dataclass so we use dataclasses.replace.
+                                        _shed_sub = dataclasses.replace(
+                                            _heaviest, description=_shed,
+                                        )
+                                        _all_subs = (_shed_sub,)
+                            except Exception:  # noqa: BLE001
+                                # Fail-soft: watchdog error -> legacy slice path.
+                                pass
                         _prereq = [
                             s for s in _all_subs if not s.depends_on_sub_ids
                         ]

--- a/docs/superpowers/plans/2026-06-22-autonomous-convergence-watchdog-plan.md
+++ b/docs/superpowers/plans/2026-06-22-autonomous-convergence-watchdog-plan.md
@@ -1,0 +1,177 @@
+# Autonomous Convergence Watchdog — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: superpowers:subagent-driven-development. Steps use `- [ ]`.
+
+**Goal:** A trajectory-based, self-healing watchdog that detects a stalled recursive-decompose (a block that can't be sliced smaller but is still too heavy) and sheds weight structurally (tiered Epistemic Weight-Shedder) to fit — no infinite recursion, no hardcoded retry caps, no model call, no DW egress.
+
+**Architecture:** Two pure leaf modules (`convergence_watchdog.py` reduction-trajectory tracker + telemetry; `epistemic_shedder.py` tiered pure-AST weight shedder) wired into the single decompose funnel `orchestrator._decompose_block_or_legacy`. Reuse the existing weight ruler, the bounded-FIFO ledger pattern, and the SSE telemetry surface.
+
+**Tech Stack:** Python 3.9+ (`from __future__ import annotations`, stdlib `ast`), pytest. ASCII only.
+
+**Spec (binding):** `docs/superpowers/specs/2026-06-22-autonomous-convergence-watchdog.md`.
+
+## Global Constraints
+- **No hardcoding:** `JARVIS_WATCHDOG_STALL_RATIO` (0.95), `JARVIS_WATCHDOG_STALL_PASSES` (2), `JARVIS_WATCHDOG_TRACKER_SIZE` (256) from env. No magic-number retry cap anywhere.
+- **Pure AST shedder:** `ast.parse`/`ast.unparse`/`ast.get_source_segment` only — NEVER exec/eval/compile-exec.
+- **Zero watchdog egress:** the shedder is deterministic (no model call) — it can never produce a DW request.
+- **Fail-soft:** any watchdog/shedder error → the legacy slice path; never crashes a dispatch. Default-ON master `JARVIS_CONVERGENCE_WATCHDOG_ENABLED` (pure-safety, fires only on stall); OFF byte-identical.
+- **Reuse-first:** the SAME ruler (`estimate_subgoal_payload_chars`/`dw_egress_interceptor.estimate_body_chars`), the FIFO/singleton pattern from `recursion_dedup`, `publish_task_event` telemetry, the decompose funnel. NO parallel state store.
+- **Worktree:** verify via `git show`/`grep`; commits need `ledger_sovereignty.mark_owned` (stamped).
+
+---
+
+## Task T1: `convergence_watchdog.py` — reduction tracker + verdict + thresholds + telemetry
+**Files:** Create `backend/core/ouroboros/governance/convergence_watchdog.py`; Test `tests/governance/test_convergence_watchdog.py`.
+
+**Interfaces — Produces:**
+- `@dataclass(frozen=True) class WatchdogVerdict: stalled: bool; ratio: float; consecutive_stalls: int; passes: int`
+- `stall_ratio_threshold() -> float` (`JARVIS_WATCHDOG_STALL_RATIO` default 0.95); `stall_passes_threshold() -> int` (`JARVIS_WATCHDOG_STALL_PASSES` default 2); `watchdog_enabled() -> bool` (`JARVIS_CONVERGENCE_WATCHDOG_ENABLED` default true).
+- `class ReductionTracker`: bounded lineage map. `record_pass(self, lineage_id: str, parent_chars: int, max_child_chars: int) -> WatchdogVerdict` — `ratio = max_child_chars/max(1, parent_chars)`; append to the lineage's bounded deque; `consecutive_stalls` = trailing run of ratios ≥ `stall_ratio_threshold()`; `stalled = consecutive_stalls >= stall_passes_threshold()`. Fail-soft → `WatchdogVerdict(False, 0.0, 0, 0)`. `reset(lineage_id)` clears a lineage. `get_reduction_tracker() -> ReductionTracker` singleton.
+- `emit_sovereign_yield(op_id, *, lineage_id, ratio, consecutive_stalls, parent_chars, child_chars, tier) -> None` — stdout WARNING `[SOVEREIGN YIELD] op=… lineage=… stalled reduction ratio=… passes=… -> structural weight-shed (tier=…) parent=… child=…` + best-effort `publish_task_event("sovereign_yield", op_id, {…})`. Fail-soft.
+
+- [ ] **Step 1: Read first** — `recursion_dedup.py:57-130` (AttemptLedger bounded-deque + singleton pattern to MIRROR); `ide_observability_stream.py:2247` `publish_task_event` signature.
+- [ ] **Step 2: Failing tests** (`tests/governance/test_convergence_watchdog.py`):
+```python
+from __future__ import annotations
+import importlib, pytest
+from backend.core.ouroboros.governance import convergence_watchdog as cw
+
+def _fresh():
+    importlib.reload(cw); return cw.ReductionTracker()
+
+def test_thresholds_defaults(monkeypatch):
+    monkeypatch.delenv("JARVIS_WATCHDOG_STALL_RATIO", raising=False)
+    monkeypatch.delenv("JARVIS_WATCHDOG_STALL_PASSES", raising=False)
+    assert cw.stall_ratio_threshold() == 0.95 and cw.stall_passes_threshold() == 2
+    assert cw.watchdog_enabled() is True
+
+def test_good_reduction_no_stall():
+    t = _fresh()
+    v = t.record_pass("g1", parent_chars=1000, max_child_chars=400)  # ratio 0.4
+    assert v.stalled is False and v.ratio < 0.5 and v.consecutive_stalls == 0
+
+def test_two_consecutive_stalls_trips():
+    t = _fresh()
+    t.record_pass("g1", 1000, 980)            # 0.98 stall #1
+    v = t.record_pass("g1", 1000, 990)        # 0.99 stall #2 -> stalled
+    assert v.consecutive_stalls >= 2 and v.stalled is True
+
+def test_good_pass_resets_run():
+    t = _fresh()
+    t.record_pass("g1", 1000, 980)            # stall
+    v = t.record_pass("g1", 1000, 300)        # good -> resets
+    assert v.consecutive_stalls == 0 and v.stalled is False
+
+def test_lineages_independent():
+    t = _fresh()
+    t.record_pass("a", 1000, 990); t.record_pass("a", 1000, 990)
+    v = t.record_pass("b", 1000, 200)
+    assert v.stalled is False
+
+def test_failsoft_bad_input():
+    t = _fresh()
+    v = t.record_pass("g", parent_chars=0, max_child_chars=0)
+    assert isinstance(v.stalled, bool)
+
+def test_emit_sovereign_yield_warns(caplog):
+    import logging
+    with caplog.at_level(logging.WARNING):
+        cw.emit_sovereign_yield("op1", lineage_id="g1", ratio=0.97, consecutive_stalls=2,
+                                parent_chars=5000, child_chars=4850, tier="tier2")
+    assert any("[SOVEREIGN YIELD]" in r.getMessage() for r in caplog.records)
+```
+- [ ] **Step 3: Run → fail. Step 4: Implement** (bounded `dict[str, deque]` maxlen=tracker size lineages, each deque maxlen small e.g. passes_threshold+3; mirror recursion_dedup's singleton). `publish_task_event` lazy import + fail-soft. **Step 5: Run → pass.** Commit: `feat(watchdog): convergence_watchdog — reduction-trajectory stall detection + [SOVEREIGN YIELD] telemetry`.
+
+## Task T2: `epistemic_shedder.py` — tiered pure-AST weight shedder
+**Files:** Create `backend/core/ouroboros/governance/epistemic_shedder.py`; Test `tests/governance/test_epistemic_shedder.py`.
+
+**Interfaces — Produces:** `def shed_to_fit(source: str, target_chars: int) -> tuple[str, str]` → `(shed_source, tier_reached)` where tier ∈ {"none","tier1","tier2","tier3"}. Re-measures with `dw_egress_interceptor.estimate_body_chars({"messages":[{"role":"user","content":shed_source}]})` (or a thin char-len) after each tier; stops at first fit.
+
+- [ ] **Step 1: Read first** — `dw_egress_interceptor.estimate_body_chars` (the ruler); `ast` docs for unparse (3.9+: `ast.unparse` is 3.9+). For a char ruler over raw source, `len(source)` is acceptable + consistent.
+- [ ] **Step 2: Failing tests:**
+```python
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import epistemic_shedder as es
+
+SRC = '''
+"""Module docstring that is fairly long and counts as fluff padding padding."""
+import os
+class Big:
+    """Class doc."""
+    def build(self, x):
+        """Build doc."""
+        # a comment
+        total = 0
+        for i in range(1000):
+            total += i * i * i  # heavy body line padding padding padding
+        return total
+    def small(self):
+        return 1
+'''
+
+def test_tier1_strips_docstrings_still_parseable():
+    out, tier = es.shed_to_fit(SRC, target_chars=len(SRC) - 40)
+    import ast; ast.parse(out)                 # still valid
+    assert "Module docstring" not in out or tier in ("tier2", "tier3")
+
+def test_tier2_omits_bodies_keeps_signatures():
+    out, tier = es.shed_to_fit(SRC, target_chars=120)   # force deep shed
+    assert "[SOVEREIGN YIELD: Implementation Omitted]" in out or tier == "tier3"
+    assert "def build" in out                  # signature kept
+
+def test_tier3_truncates_to_fit():
+    out, tier = es.shed_to_fit(SRC, target_chars=40)
+    assert len(out) <= 60                       # truncated near target
+
+def test_parse_error_falls_to_truncation():
+    bad = "def (:\n  oops" * 50
+    out, tier = es.shed_to_fit(bad, target_chars=30)
+    assert len(out) <= 50 and tier == "tier3"
+
+def test_never_execs(monkeypatch):
+    import builtins
+    monkeypatch.setattr(builtins, "exec", lambda *a, **k: (_ for _ in ()).throw(AssertionError("exec")))
+    es.shed_to_fit(SRC, target_chars=50)
+
+def test_already_fits_returns_none_tier():
+    out, tier = es.shed_to_fit("x = 1\n", target_chars=10_000)
+    assert tier == "none"
+```
+- [ ] **Step 3: Run → fail. Step 4: Implement** the 3 tiers: Tier1 `ast.parse`→strip docstrings (first `Expr(Constant str)` in each `Module/ClassDef/FunctionDef/AsyncFunctionDef` body)→`ast.unparse` (drops comments); Tier2 for heaviest defs (by `len(ast.get_source_segment)`) replace `.body` with `[ast.Expr(ast.Constant("[SOVEREIGN YIELD: Implementation Omitted]"))]` keeping the signature, heaviest-first until fit; Tier3 `source[:target_chars]` (chronological truncation). Measure after each. Parse error → Tier3 of raw source. PURE AST, fail-soft. **Step 5: Run → pass.** Commit: `feat(watchdog): epistemic_shedder — tiered pure-AST weight shed (fluff -> signature-only -> truncation)`.
+
+## Task T3: Wire the watchdog into the decompose funnel
+**Files:** Modify `backend/core/ouroboros/governance/orchestrator.py` (`_decompose_block_or_legacy`); Test `tests/governance/test_watchdog_wiring.py`.
+**Consumes:** T1 `get_reduction_tracker`/`watchdog_enabled`/`emit_sovereign_yield`, T2 `shed_to_fit`, `estimate_subgoal_payload_chars`.
+- [ ] **Step 1: Read first** — `orchestrator.py:2073` `_decompose_block_or_legacy`, the `_all_subs = decompose_for_block(... compression_target=…)` site (~2209), how `compression_target` arrives, the `goal`/lineage id (root goal_id) + `ctx.op_id`.
+- [ ] **Step 2: Failing test** (fakes): with `compression_target` set and `watchdog_enabled()`, after a decompose pass whose largest child ≥95% of parent for 2 consecutive passes → the watchdog yields ONE fitting sub-goal (payload ≤ compression_target via `shed_to_fit`) AND `emit_sovereign_yield` fires; a reducible pass → normal `_all_subs`; disabled → byte-identical. Structural assertion that the funnel calls `record_pass` + (on stall) `shed_to_fit`+`emit_sovereign_yield` is acceptable for the deep site.
+- [ ] **Step 3: Implement** after `_all_subs = decompose_for_block(...)` (only when `compression_target is not None and watchdog_enabled()`):
+```python
+try:
+    _parent = estimate_subgoal_payload_chars(goal)
+    _maxchild = max((estimate_subgoal_payload_chars(s) for s in _all_subs), default=0)
+    _v = get_reduction_tracker().record_pass(<root_goal_id>, _parent, _maxchild)
+    if _v.stalled:
+        _src = <heaviest sub-goal's symbol source / goal source>
+        _shed, _tier = shed_to_fit(_src, compression_target)
+        emit_sovereign_yield(ctx.op_id, lineage_id=<root_goal_id>, ratio=_v.ratio,
+                             consecutive_stalls=_v.consecutive_stalls, parent_chars=_parent,
+                             child_chars=_maxchild, tier=_tier)
+        _all_subs = [<one SubGoal carrying _shed as its scoped context/description>]
+except Exception:
+    pass   # fail-soft: legacy slice path; de-dup ledger is the backstop
+```
+**Step 4: Run** + regression `-k "orchestrator or decomposition or watchdog or egress"`. **Step 5: Commit:** `feat(watchdog): wire convergence watchdog into _decompose_block_or_legacy — stall -> structural yield, fail-soft`.
+
+## Task T4: Integration + static validation (operator gate)
+**Files:** Test `tests/governance/test_watchdog_integration.py`.
+- [ ] End-to-end with fakes: (1) a synthetic irreducible-but-overweight lineage → 2 stalled passes → watchdog yields a ≤target sub-goal + `[SOVEREIGN YIELD]` (no infinite re-slice, no DW egress — fake session asserts zero post). (2) reducible lineage → no stall, normal slicing. (3) shedder Tier1→2→3 escalation fits. (4) parse-error → Tier3. (5) OFF byte-identical. (6) NEVER exec. Reused-subsystem regression sweep (orchestrator, decomposition, egress, recursion_dedup). Commit.
+
+## Done criteria
+- A stalled recursive-decompose YIELDS (sheds structurally to a fitting sub-goal) instead of looping — trajectory-triggered, no hardcoded cap, no DW egress, `[SOVEREIGN YIELD]` observable. Tiered pure-AST shedder (fluff → signature-only → truncation). Default-ON; OFF byte-identical. Fail-soft. Reuse-first. Zero real regressions. Final cross-cutting review (confirm the hook is on the LIVE funnel + the de-dup backstop intact).
+- **Static validation (operator gate):** a stalled lineage provably converges to ≤target locally (no loop, no egress) in a test, BEFORE the C2 soak.
+
+## Self-review
+- Spec coverage: §4.1→T1, §4.2→T2, §4.3→T1 (emit), §4.4→T3, §6→T4. Thresholds/env, tiered shedder, telemetry, funnel hook, fail-soft, OFF byte-identical all covered.
+- Interfaces consistent: `WatchdogVerdict`, `record_pass`, `get_reduction_tracker`, `watchdog_enabled`, `emit_sovereign_yield`, `shed_to_fit(source, target)->(src,tier)`.
+- Big-file task T3 ships read-first instructions — confirm the funnel site + lineage id against live code; the hook MUST be on the live `_decompose_block_or_legacy` path (the same funnel the egress re-chunk already uses).

--- a/docs/superpowers/specs/2026-06-22-autonomous-convergence-watchdog.md
+++ b/docs/superpowers/specs/2026-06-22-autonomous-convergence-watchdog.md
@@ -1,0 +1,63 @@
+# Autonomous Convergence Watchdog — Design Spec
+
+> **Arc:** with AST-slicing + the egress interceptor live, the primary risk shifted from *network spam* to *local infinite recursion* — an AST block that can't be sliced smaller but is still too heavy re-decomposes forever. A trajectory-based, self-healing watchdog catches the stall and sheds weight structurally. No manual babysitting, no hardcoded retry caps.
+> **Date:** 2026-06-22. **Branch:** `worktree-convergence-watchdog`. Feeds the recursive-chunking matrices ([[project_sovereign_resilience_chunking]]) + the egress interceptor ([[project_sovereign_egress_interceptor]]).
+
+---
+
+## 1. Diagnosis (reuse-first)
+- **Weight ruler exists:** `goal_decomposition_planner.estimate_subgoal_payload_chars` / `dw_egress_interceptor.estimate_body_chars` — the watchdog measures with the SAME ruler the interceptor uses, so "fits the target" means the same thing everywhere.
+- **Single funnel:** `orchestrator._decompose_block_or_legacy` (~2209) is the one place both the Advisor-BLOCK and the egress-overweight re-chunk call `decompose_for_block(compression_target=…)`. The watchdog hooks there.
+- **No reduction tracking today.** Recursion is bounded by `recursion_dedup.AttemptLedger` (exact-repeat de-dup) + `adaptive_recursion_governor` (depth/fan-out) + the "irreducible symbol emitted anyway" log — but a near-irreducible-but-overweight block can re-decompose without reducing.
+- **Telemetry:** `ide_observability_stream.publish_task_event(event_type, op_id, payload)` (SSE, best-effort) is the existing `[SOVEREIGN …]` event surface.
+
+## 2. Goals / Non-Goals
+**Goals.** (G1) Track per-pass **reduction trajectory** (largest child chars / parent chars) — NOT a retry count. (G2) Detect a **stall** = `ratio ≥ JARVIS_WATCHDOG_STALL_RATIO (0.95)` for `JARVIS_WATCHDOG_STALL_PASSES (2)` consecutive passes (env tunes the curve; no magic numbers). (G3) On stall, **shed weight structurally** (the Epistemic Weight-Shedder, tiered) to fit `compression_target` — never brute-force-chop, never re-spin, never crash. (G4) Emit a `[SOVEREIGN YIELD]` event (SSE + stdout WARNING) with the trajectory math + tier reached. (G5) Reuse the weight ruler, the bounded-FIFO ledger pattern, the telemetry surface, the decompose funnel — no parallel state.
+
+**Non-Goals.** No model call from the watchdog (it must not itself produce DW egress). No new dispatch queue/FSM. No change to the Advisor/cage. The de-dup ledger + governor remain the backstop.
+
+## 3. Reuse Inventory
+| Need | Existing asset | Anchor |
+|---|---|---|
+| Weight ruler | `estimate_subgoal_payload_chars` / `dw_egress_interceptor.estimate_body_chars` | `goal_decomposition_planner.py:733`, `dw_egress_interceptor.py` |
+| Decompose funnel (hook) | `orchestrator._decompose_block_or_legacy` after `decompose_for_block` | `orchestrator.py:~2209` |
+| Bounded-FIFO ledger pattern | `recursion_dedup.AttemptLedger` (deque maxlen + singleton) | `recursion_dedup.py:57,119` |
+| AST symbol extraction | `ast_symbol_scoper` (`ScopedTarget`, `isolate_symbols`) + stdlib `ast` | (merged) |
+| Telemetry event surface | `ide_observability_stream.publish_task_event` | `ide_observability_stream.py:2247` |
+| Sub-goal type | `goal_decomposition_planner.SubGoal` | `:331` |
+
+## 4. Component Specs
+
+### 4.1 `convergence_watchdog.py` (new pure leaf)
+- `@dataclass(frozen=True) class WatchdogVerdict: stalled: bool; ratio: float; consecutive_stalls: int; passes: int`.
+- `def stall_ratio_threshold() -> float` (`JARVIS_WATCHDOG_STALL_RATIO`, default 0.95) + `def stall_passes_threshold() -> int` (`JARVIS_WATCHDOG_STALL_PASSES`, default 2) + `def watchdog_enabled() -> bool` (`JARVIS_CONVERGENCE_WATCHDOG_ENABLED`, **default true** — pure-safety self-heal, only fires on a stall, fail-soft).
+- `class ReductionTracker`: bounded per-lineage map (lineage_id → bounded deque of recent ratios; reuses the FIFO/singleton pattern, `JARVIS_WATCHDOG_TRACKER_SIZE` default 256 lineages). `record_pass(lineage_id, parent_chars, max_child_chars) -> WatchdogVerdict`: `ratio = max_child_chars / max(1, parent_chars)`; append; `consecutive_stalls` = trailing run of ratios ≥ threshold; `stalled = consecutive_stalls >= passes_threshold`. Pure, fail-soft (bad input → `WatchdogVerdict(stalled=False, …)`, never raises). `get_reduction_tracker()` singleton. `lineage_id` = the root goal_id of the recursive chain (so the trajectory follows the lineage, not a single op).
+
+### 4.2 Epistemic Weight-Shedder (`epistemic_shedder.py`, pure AST + deterministic — NO model)
+`def shed_to_fit(source: str, target_chars: int) -> tuple[str, str]` returns `(shed_source, tier_reached)`. Applies tiers in order, re-measuring with `estimate_body_chars` after each; STOPS at the first tier that fits:
+- **Tier 1 — Fluff:** `ast.parse` → remove all docstrings (first `Expr(Constant(str))` in every module/class/func body) → `ast.unparse` (comments are not in the AST, so they drop automatically). Measure.
+- **Tier 2 — Deep Implementations:** if still over, for the HEAVIEST symbols (by `estimate_body_chars` of their source segment), replace each `FunctionDef`/`AsyncFunctionDef`/`ClassDef` body with a single placeholder `Constant("[SOVEREIGN YIELD: Implementation Omitted]")` (or `Pass`), KEEPING the signature (name, args, decorators, returns). Heaviest-first until it fits. Measure.
+- **Tier 3 — Nuclear truncation:** if STILL over, strict chronological truncation of the heaviest remaining source items until ≤ `target_chars`. Measure.
+- Pure AST/string only (NEVER exec/eval/compile-exec). Fail-soft: any parse error → fall straight to Tier-3 truncation of the raw source (always returns something ≤ target or the best effort). Returns the tier label for telemetry.
+
+### 4.3 `[SOVEREIGN YIELD]` telemetry
+`def emit_sovereign_yield(op_id, *, lineage_id, ratio, consecutive_stalls, parent_chars, child_chars, tier) -> None`: stdout `logger.warning("[SOVEREIGN YIELD] op=%s lineage=%s stalled reduction ratio=%.3f passes=%d -> structural weight-shed (tier=%s) parent=%d child=%d", …)` + best-effort `publish_task_event("sovereign_yield", op_id, {…})` (SSE). Fail-soft, never raises.
+
+### 4.4 Wiring into the decompose funnel
+In `orchestrator._decompose_block_or_legacy`, after `decompose_for_block(... compression_target=…)` produces `_all_subs` (and only when `watchdog_enabled()` AND a `compression_target` is set — i.e. the egress-overweight re-chunk path):
+1. `parent_chars = estimate_subgoal_payload_chars(goal)`; `max_child = max((estimate_subgoal_payload_chars(s) for s in _all_subs), default=0)`.
+2. `verdict = get_reduction_tracker().record_pass(lineage_id=<root goal id>, parent_chars, max_child)`.
+3. If `verdict.stalled`: for the over-target sub-goal(s), `shed_to_fit(<symbol source>, compression_target)` → emit ONE fitting sub-goal carrying the shed payload (in its description/evidence); `emit_sovereign_yield(...)`; use that in place of the non-shrinking slice. Else proceed with `_all_subs`.
+4. Fail-soft: any watchdog error → the legacy slice path (the de-dup ledger remains the backstop). OFF (`watchdog_enabled()` false) → byte-identical (legacy slice).
+
+## 5. Cross-cutting
+- **Invariants.** (I1) No infinite recursion: a stalled lineage YIELDS (sheds + emits a fitting sub-goal) rather than re-slicing — bounded by the trajectory, not a hardcoded count. (I2) Zero watchdog egress: the shedder is pure-deterministic (no model call) — it can never spam DW. (I3) Self-healing: stall → yield → fitting sub-goal, zero human action, `[SOVEREIGN YIELD]` observable. (I4) Fail-soft: any watchdog/shedder error → legacy path; never crashes a dispatch. (I5) Reuse-first — ruler, FIFO pattern, telemetry, decompose funnel; no parallel state. (I6) Pure AST in the shedder (no exec/eval).
+- **No hardcoding:** ratio (0.95) + passes (2) + tracker size from env. No magic-number retry cap anywhere.
+
+## 6. Test strategy
+- Unit: `ReductionTracker` (ratio math; stall after N consecutive ≥threshold; resets on a good pass; bounded; fail-soft). Shedder Tier 1 (docstrings/comments gone, still parseable), Tier 2 (heaviest bodies → placeholder, signatures kept, fits), Tier 3 (truncates to ≤ target), parse-error→Tier-3 fallback, NEVER exec, each tier re-measured. `emit_sovereign_yield` (stdout + SSE best-effort, fail-soft). Env thresholds.
+- Interaction: a synthetic irreducible-but-overweight lineage → 2 stalled passes → watchdog yields a fitting sub-goal + emits `[SOVEREIGN YIELD]` (no further re-slice). A genuinely-reducible lineage → no stall, normal slicing. OFF byte-identical.
+- **Static validation (operator gate):** a stalled lineage provably converges to a ≤target sub-goal locally (no infinite loop, no DW egress) BEFORE the C2 soak.
+
+## 7. Phasing
+1. `convergence_watchdog.py` (tracker + verdict + thresholds + telemetry) + tests. 2. `epistemic_shedder.py` (tiered, pure AST) + tests. 3. Wire into `_decompose_block_or_legacy` + interaction test. 4. Integration + static validation + final cross-cutting review (confirm the hook is on the LIVE funnel). Then the operator-authorized C2 soak.

--- a/tests/governance/test_convergence_watchdog.py
+++ b/tests/governance/test_convergence_watchdog.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import importlib, pytest
+from backend.core.ouroboros.governance import convergence_watchdog as cw
+
+def _fresh():
+    importlib.reload(cw); return cw.ReductionTracker()
+
+def test_thresholds_defaults(monkeypatch):
+    monkeypatch.delenv("JARVIS_WATCHDOG_STALL_RATIO", raising=False)
+    monkeypatch.delenv("JARVIS_WATCHDOG_STALL_PASSES", raising=False)
+    assert cw.stall_ratio_threshold() == 0.95 and cw.stall_passes_threshold() == 2
+    assert cw.watchdog_enabled() is True
+
+def test_good_reduction_no_stall():
+    t = _fresh()
+    v = t.record_pass("g1", parent_chars=1000, max_child_chars=400)  # ratio 0.4
+    assert v.stalled is False and v.ratio < 0.5 and v.consecutive_stalls == 0
+
+def test_two_consecutive_stalls_trips():
+    t = _fresh()
+    t.record_pass("g1", 1000, 980)            # 0.98 stall #1
+    v = t.record_pass("g1", 1000, 990)        # 0.99 stall #2 -> stalled
+    assert v.consecutive_stalls >= 2 and v.stalled is True
+
+def test_good_pass_resets_run():
+    t = _fresh()
+    t.record_pass("g1", 1000, 980)            # stall
+    v = t.record_pass("g1", 1000, 300)        # good -> resets
+    assert v.consecutive_stalls == 0 and v.stalled is False
+
+def test_lineages_independent():
+    t = _fresh()
+    t.record_pass("a", 1000, 990); t.record_pass("a", 1000, 990)
+    v = t.record_pass("b", 1000, 200)
+    assert v.stalled is False
+
+def test_failsoft_bad_input():
+    t = _fresh()
+    v = t.record_pass("g", parent_chars=0, max_child_chars=0)
+    assert isinstance(v.stalled, bool)
+
+def test_emit_sovereign_yield_warns(caplog):
+    import logging
+    with caplog.at_level(logging.WARNING):
+        cw.emit_sovereign_yield("op1", lineage_id="g1", ratio=0.97, consecutive_stalls=2,
+                                parent_chars=5000, child_chars=4850, tier="tier2")
+    assert any("[SOVEREIGN YIELD]" in r.getMessage() for r in caplog.records)

--- a/tests/governance/test_epistemic_shedder.py
+++ b/tests/governance/test_epistemic_shedder.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import epistemic_shedder as es
+
+SRC = '''
+"""Module docstring that is fairly long and counts as fluff padding padding."""
+import os
+class Big:
+    """Class doc."""
+    def build(self, x):
+        """Build doc."""
+        # a comment
+        total = 0
+        for i in range(1000):
+            total += i * i * i  # heavy body line padding padding padding
+        return total
+    def small(self):
+        return 1
+'''
+
+def test_tier1_strips_docstrings_still_parseable():
+    out, tier = es.shed_to_fit(SRC, target_chars=len(SRC) - 40)
+    import ast; ast.parse(out)                 # still valid
+    assert "Module docstring" not in out or tier in ("tier2", "tier3")
+
+def test_tier2_omits_bodies_keeps_signatures():
+    out, tier = es.shed_to_fit(SRC, target_chars=120)   # force deep shed
+    assert "[SOVEREIGN YIELD: Implementation Omitted]" in out or tier == "tier3"
+    assert "def build" in out                  # signature kept
+
+def test_tier3_truncates_to_fit():
+    out, tier = es.shed_to_fit(SRC, target_chars=40)
+    assert len(out) <= 60                       # truncated near target
+
+def test_parse_error_falls_to_truncation():
+    bad = "def (:\n  oops" * 50
+    out, tier = es.shed_to_fit(bad, target_chars=30)
+    assert len(out) <= 50 and tier == "tier3"
+
+def test_never_execs(monkeypatch):
+    import builtins
+    monkeypatch.setattr(builtins, "exec", lambda *a, **k: (_ for _ in ()).throw(AssertionError("exec")))
+    es.shed_to_fit(SRC, target_chars=50)
+
+def test_already_fits_returns_none_tier():
+    out, tier = es.shed_to_fit("x = 1\n", target_chars=10_000)
+    assert tier == "none"

--- a/tests/governance/test_watchdog_composition.py
+++ b/tests/governance/test_watchdog_composition.py
@@ -387,15 +387,14 @@ def test_reinjected_shed_reaches_fixpoint_and_terminates(
 ):
     """End-to-end boundedness via the REAL re-injection mechanism.
 
-    In the live loop the self-healed sub-goal carries the shed text AS its new
-    op description. So on the next stall the self-heal receives ``description ==
-    prior shed text``. shed(shed_text + source) truncated to target converges to
-    a FIXPOINT (once the shed text fills the budget, re-shedding it returns the
-    same bytes). At the fixpoint the shed-hash repeats -> already marked -> the
-    self-heal yields to advisor_blocked. This proves the chain TERMINATES: the
-    self-heal hops are bounded by the number of distinct shed payloads, which is
-    finite because each hop is a monotone non-growing AST reduction toward a
-    fixpoint. Here we drive that re-injection loop directly and assert it stops.
+    In the live loop the self-healed sub-goal is re-injected by the multi-step
+    ``_make_envelope`` as ``f"{title}\\n\\n{description}"`` -- NOT the raw shed
+    text. The OLD version of this test fed back the raw ``description`` only,
+    which masked the title-prefix window shift (the degenerate
+    ~compression_target/82-hop bound). Here we model the REAL envelope transform
+    and assert the chain terminates within ``max_self_heal_hops() + 1`` hops via
+    the bounded per-lineage self-heal counter -- the structural bound that holds
+    regardless of the shed/envelope truncation dynamics.
     """
     target_file = tmp_path / "irr.py"
     target_file.write_text(_HEAVY)
@@ -418,11 +417,15 @@ def test_reinjected_shed_reaches_fixpoint_and_terminates(
     ledger = dedup.get_attempt_ledger()
     orch = _make_orch(router=_FakeRouter())
 
-    # Drive the re-injection loop: each iteration feeds the PRIOR shed text back
-    # as the new op description (exactly what the multi-step emitter does live).
+    max_hops = cw_mod.max_self_heal_hops()
+
+    # Drive the re-injection loop modeling the REAL _make_envelope transform:
+    # each iteration feeds back ``f"{title}\n\n{description}"`` (what the
+    # multi-step emitter produces live), NOT the raw shed text.
     description = "irreducible heavy goal"
     terminated = False
-    for hop in range(25):  # hard cap: must terminate well before this
+    hops_taken = 0
+    for hop in range(max_hops + 5):  # hard cap: must terminate well before this
         ctx = _make_ctx(
             op_id=f"op-irr-{hop}",
             description=description,
@@ -440,12 +443,79 @@ def test_reinjected_shed_reaches_fixpoint_and_terminates(
             terminated = True
             break
         assert out.terminal_reason_code == "decomposed"
-        # Re-injection: the emitted sub-goal's description becomes the next op's
-        # description (the live multi-step emitter carries it forward).
-        plan = advance_calls[-1]
-        description = plan.sub_goals[0].description
+        hops_taken += 1
+        # REAL re-injection: the multi-step _make_envelope wraps the sub-goal as
+        # f"{title}\n\n{description}" -> THAT becomes the next op description.
+        sub = advance_calls[-1].sub_goals[0]
+        description = f"{sub.title}\n\n{sub.description}"
 
     assert terminated, (
-        "the re-injected shed chain MUST reach a fixpoint and terminate "
-        "advisor_blocked -- the loop cannot run forever"
+        "the re-injected shed chain MUST terminate advisor_blocked -- the loop "
+        "cannot run forever"
+    )
+    assert hops_taken <= max_hops, (
+        f"self-heal MUST be bounded by max_self_heal_hops() ({max_hops}); "
+        f"took {hops_taken} hops before terminating"
+    )
+
+
+# ===========================================================================
+# Test 8 -- HOP BUDGET: JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS=1 caps at 1 hop.
+# ===========================================================================
+
+def test_max_self_heal_hops_env_caps_self_heal(monkeypatch, tmp_path):
+    """JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS=1 -> at most ONE self-heal hop per
+    invariant lineage before the de-dup backstop (advisor_blocked) takes over.
+    Proves the bound is env-tunable and enforced by the hop counter, NOT the
+    shed/envelope dynamics.
+    """
+    monkeypatch.setenv("JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS", "1")
+    assert cw_mod.max_self_heal_hops() == 1
+
+    target_file = tmp_path / "cap.py"
+    target_file.write_text(_HEAVY)
+    target_files = (str(target_file),)
+    compression_target = 350
+
+    advance_calls: list = []
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        advance_calls.append(plan)
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    lineage = subgoal_hash(target_files, ())
+    cw_mod.get_reduction_tracker().record_pass(lineage, 1000, 1000)  # stall
+
+    ledger = dedup.get_attempt_ledger()
+    orch = _make_orch(router=_FakeRouter())
+
+    description = "heavy goal capped at one hop"
+    outcomes: list = []
+    for hop in range(5):
+        ctx = _make_ctx(
+            op_id=f"op-cap-{hop}",
+            description=description,
+            target_files=target_files,
+        )
+        ledger.mark(subgoal_hash(target_files, description))
+        out = _run(
+            orch._decompose_block_or_legacy(
+                ctx, _block_advisory(),
+                compression_target=compression_target,
+            )
+        )
+        outcomes.append(out.terminal_reason_code)
+        if out.terminal_reason_code == "advisor_blocked":
+            break
+        sub = advance_calls[-1].sub_goals[0]
+        description = f"{sub.title}\n\n{sub.description}"
+
+    # Exactly ONE 'decomposed' (the single allowed self-heal) then blocked.
+    assert outcomes.count("decomposed") <= 1, (
+        f"MAX_SELF_HEAL_HOPS=1 must allow at most one self-heal; got {outcomes}"
+    )
+    assert outcomes[-1] == "advisor_blocked", (
+        f"chain must terminate advisor_blocked; got {outcomes}"
     )

--- a/tests/governance/test_watchdog_composition.py
+++ b/tests/governance/test_watchdog_composition.py
@@ -1,0 +1,451 @@
+"""Sovereign Ledger-Watchdog Composition.
+
+Proves the Autonomous Convergence Watchdog actually ENGAGES on the live
+recursive chain instead of being pre-empted by the de-dup ledger. Three
+structural changes are validated here:
+
+  Part 1 -- deep-payload shed helper (shed_block_goal_to_fit): reads the FULL
+            target-file source, sheds it, and inlines the result with
+            scoped_symbols CLEARED so the egress ruler measures <= target.
+  Part 2 -- invariant lineage (subgoal_hash(target_files, ()) is stable across
+            re-injection -> the tracker accumulates stalls).
+  Part 3 -- FUNNEL INVERSION: a DUPLICATE GOAL on the egress path gives the
+            watchdog a shed-and-CONTINUE chance (decomposed) before the legacy
+            advisor_blocked hard-fail; a FIXPOINT (shed cannot reduce further)
+            yields to advisor_blocked -- the de-dup ledger is the final
+            mathematical backstop, so the loop is BOUNDED.
+
+TERMINATION PROOF: tests below prove (a) invariant lineage accumulates stalls,
+(b) one self-heal hop emits a sub-goal <= target, (c) a fixpoint lineage falls
+to advisor_blocked (at most one self-heal hop per lineage). Together: the loop
+cannot run forever.
+
+Fakes only: monkeypatched advance_orchestration, fake router/stack. No live
+advisor / network is touched.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, List, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance import orchestrator as orch_mod
+from backend.core.ouroboros.governance import convergence_watchdog as cw_mod
+from backend.core.ouroboros.governance import recursion_dedup as dedup
+from backend.core.ouroboros.governance.orchestrator import GovernedOrchestrator
+from backend.core.ouroboros.governance.op_context import (
+    OperationContext,
+    OperationPhase,
+)
+from backend.core.ouroboros.governance.goal_decomposition_planner import (
+    SubGoalKind,
+    estimate_subgoal_payload_chars,
+    shed_block_goal_to_fit,
+)
+from backend.core.ouroboros.governance.recursion_dedup import subgoal_hash
+from backend.core.ouroboros.governance.operation_advisor import (
+    Advisory,
+    AdvisoryDecision,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeStack:
+    governed_loop_service: Any = None
+
+
+@dataclass
+class _FakeGLS:
+    _intake_router: Any = None
+
+
+class _FakeRouter:
+    def __init__(self) -> None:
+        self.ingested: List[Any] = []
+
+
+def _make_orch(router: Any = None) -> GovernedOrchestrator:
+    o = object.__new__(GovernedOrchestrator)
+    o._stack = _FakeStack(governed_loop_service=_FakeGLS(_intake_router=router))
+    return o
+
+
+def _make_ctx(
+    *,
+    op_id: str = "op-comp-1",
+    description: str = "Implement the widget feature",
+    target_files: Tuple[str, ...] = ("backend/widget.py",),
+) -> OperationContext:
+    return OperationContext.create(
+        op_id=op_id,
+        target_files=target_files,
+        description=description,
+    )
+
+
+def _block_advisory(*, coverage: float = 1.0, reasons=None) -> Advisory:
+    return Advisory(
+        decision=AdvisoryDecision.BLOCK,
+        reasons=reasons if reasons is not None else ["blast_radius too high"],
+        blast_radius=99,
+        test_coverage=coverage,
+        chronic_entropy=0.0,
+        risk_score=0.9,
+    )
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# Heavy source the shedder must reduce (tier3 truncation for tight budgets).
+_HEAVY = (
+    '"""Module docstring padding padding padding padding padding."""\n'
+    "import os\n"
+    "def a(x):\n"
+    "    return x * 2 + sum(range(x)) + len(str(x)) + 1234567890\n"
+    "def b(y):\n"
+    "    return [i for i in range(y) if i % 2 == 0 and i > 3 and i < 99]\n"
+) * 40
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    """Reset both singletons + chunking/watchdog env per test."""
+    dedup._ATTEMPT_LEDGER_SINGLETON = None  # type: ignore[attr-defined]
+    cw_mod._REDUCTION_TRACKER_SINGLETON = None  # type: ignore[attr-defined]
+    monkeypatch.setenv("JARVIS_RECURSIVE_CHUNKING_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", raising=False)
+    yield
+    dedup._ATTEMPT_LEDGER_SINGLETON = None  # type: ignore[attr-defined]
+    cw_mod._REDUCTION_TRACKER_SINGLETON = None  # type: ignore[attr-defined]
+
+
+# ===========================================================================
+# Test 1 -- INVARIANT LINEAGE: stable across differing op descriptions.
+# ===========================================================================
+
+def test_invariant_lineage_is_stable_across_reinjection():
+    """subgoal_hash(target_files, ()) is the SAME for the same files even when
+    the per-op description changes -> the tracker accumulates stalls across
+    re-injections. The OLD lineage (ctx.op_id) was per-op and never tripped.
+    """
+    tf = ("backend/widget.py", "backend/other.py")
+    lin_a = subgoal_hash(tf, ())
+    lin_b = subgoal_hash(tf, ())  # different "op", same files
+    assert lin_a == lin_b, "lineage must be invariant across re-injection"
+    # And distinct files give a distinct lineage.
+    assert subgoal_hash(("x.py",), ()) != lin_a
+
+    # The tracker accumulates stalls under the invariant lineage.
+    tracker = cw_mod.get_reduction_tracker()
+    v1 = tracker.record_pass(lin_a, 1000, 990)
+    assert v1.consecutive_stalls == 1 and v1.stalled is False
+    v2 = tracker.record_pass(lin_b, 1000, 990)  # SAME lineage, "2nd op"
+    assert v2.consecutive_stalls == 2 and v2.stalled is True
+
+
+# ===========================================================================
+# Test 2 -- FUNNEL INVERSION: duplicate + stalled -> decomposed (NOT blocked).
+# ===========================================================================
+
+def test_funnel_inversion_duplicate_stalled_self_heals(monkeypatch, tmp_path):
+    """A DUPLICATE goal on the egress path (compression_target set, watchdog
+    enabled, lineage already stalled) -> _watchdog_self_heal returns a
+    `decomposed` ctx and emits ONE sub-goal whose estimated payload <= target.
+    """
+    # Write a real heavy target file so the deep shed measures real source.
+    target_file = tmp_path / "heavy.py"
+    target_file.write_text(_HEAVY)
+    target_files = (str(target_file),)
+    compression_target = 400
+
+    captured: dict = {}
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        captured["plan"] = plan
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    # Pre-stall the lineage so the very next self-heal call sees stalled=True
+    # (the funnel-inversion path needs an already-stalled lineage).
+    lineage = subgoal_hash(target_files, ())
+    tracker = cw_mod.get_reduction_tracker()
+    tracker.record_pass(lineage, 1000, 1000)  # stall #1 (full stall, ratio 1.0)
+
+    # Pre-mark the GOAL hash so it is a DUPLICATE -> funnel inversion fires.
+    ctx = _make_ctx(description="rechunk me", target_files=target_files)
+    h = subgoal_hash(target_files, ctx.description or "")
+    dedup.get_attempt_ledger().mark(h)
+
+    orch = _make_orch(router=_FakeRouter())
+    out = _run(
+        orch._decompose_block_or_legacy(
+            ctx, _block_advisory(), compression_target=compression_target,
+        )
+    )
+
+    assert out.phase == OperationPhase.CANCELLED
+    assert out.terminal_reason_code == "decomposed", (
+        "duplicate + stalled must self-heal (decomposed), NOT advisor_blocked"
+    )
+    plan = captured["plan"]
+    assert plan is not None
+    assert plan.diagnostic == "watchdog_self_heal_reinject"
+    subs = tuple(plan.sub_goals)
+    assert len(subs) == 1, "self-heal emits exactly ONE fitting sub-goal"
+    sub = subs[0]
+    # Deep-payload invariant: the shed sub-goal fits the egress ceiling.
+    assert estimate_subgoal_payload_chars(sub) <= compression_target, (
+        "self-healed sub-goal MUST fit compression_target so the loop breaks"
+    )
+
+
+# ===========================================================================
+# Test 3 -- FIXPOINT TERMINATION: unshrinkable shed -> advisor_blocked.
+# ===========================================================================
+
+def test_fixpoint_shed_already_marked_falls_to_advisor_blocked(
+    monkeypatch, tmp_path,
+):
+    """When the shed result's hash is ALREADY a duplicate (the shed cannot
+    reduce further -> fixpoint), _watchdog_self_heal returns None and the caller
+    falls to advisor_blocked. BOUNDED: at most one self-heal hop per lineage.
+    """
+    target_file = tmp_path / "small.py"
+    target_file.write_text("def f():\n    return 1\n")  # already tiny
+    target_files = (str(target_file),)
+    compression_target = 50_000  # huge -> shed is a no-op (tier 'none')
+
+    called: list = []
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        called.append(plan)
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    # Stall the lineage.
+    lineage = subgoal_hash(target_files, ())
+    cw_mod.get_reduction_tracker().record_pass(lineage, 100, 100)
+
+    ctx = _make_ctx(description="fixpoint goal", target_files=target_files)
+    ledger = dedup.get_attempt_ledger()
+    # Mark the GOAL hash (duplicate -> inversion fires).
+    ledger.mark(subgoal_hash(target_files, ctx.description or ""))
+    # Pre-mark the SHED hash so the fixpoint guard trips.
+    _sub, _ = shed_block_goal_to_fit(
+        target_files, ctx.description, compression_target, ctx.op_id,
+    )
+    assert _sub is not None
+    ledger.mark(subgoal_hash(_sub.target_files, _sub.description))
+
+    orch = _make_orch(router=_FakeRouter())
+    out = _run(
+        orch._decompose_block_or_legacy(
+            ctx, _block_advisory(), compression_target=compression_target,
+        )
+    )
+
+    assert out.terminal_reason_code == "advisor_blocked", (
+        "fixpoint (unshrinkable shed) MUST yield to the de-dup backstop"
+    )
+    assert called == [], "fixpoint must NOT re-inject -> loop terminates"
+
+
+# ===========================================================================
+# Test 4 -- PLAIN BLOCK path (compression_target=None) -> byte-identical.
+# ===========================================================================
+
+def test_plain_block_path_never_invokes_self_heal(monkeypatch):
+    """compression_target=None (plain BLOCK, not the egress re-chunk path) ->
+    the funnel inversion is NEVER entered; a duplicate falls straight through to
+    legacy advisor_blocked exactly as before.
+    """
+    self_heal_calls: list = []
+
+    async def _spy_self_heal(*a, **k):
+        self_heal_calls.append((a, k))
+        return None
+
+    monkeypatch.setattr(
+        GovernedOrchestrator, "_watchdog_self_heal", _spy_self_heal,
+    )
+
+    called: list = []
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        called.append(plan)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    ctx = _make_ctx()
+    # Duplicate goal so legacy path would otherwise short-circuit.
+    dedup.get_attempt_ledger().mark(
+        subgoal_hash(tuple(ctx.target_files), ctx.description or "")
+    )
+    orch = _make_orch(router=_FakeRouter())
+    out = _run(
+        orch._decompose_block_or_legacy(ctx, _block_advisory())  # no target
+    )
+
+    assert out.terminal_reason_code == "advisor_blocked"
+    assert self_heal_calls == [], (
+        "plain BLOCK (compression_target=None) must NOT invoke self-heal"
+    )
+
+
+# ===========================================================================
+# Test 5 -- MASTER OFF (watchdog disabled) -> byte-identical, no self-heal.
+# ===========================================================================
+
+def test_master_off_never_invokes_self_heal(monkeypatch):
+    """JARVIS_CONVERGENCE_WATCHDOG_ENABLED=false -> the funnel inversion guard
+    is False; a duplicate on the egress path falls straight to advisor_blocked.
+    """
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", "false")
+
+    self_heal_calls: list = []
+
+    async def _spy_self_heal(*a, **k):
+        self_heal_calls.append((a, k))
+        return None
+
+    monkeypatch.setattr(
+        GovernedOrchestrator, "_watchdog_self_heal", _spy_self_heal,
+    )
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    ctx = _make_ctx()
+    dedup.get_attempt_ledger().mark(
+        subgoal_hash(tuple(ctx.target_files), ctx.description or "")
+    )
+    orch = _make_orch(router=_FakeRouter())
+    out = _run(
+        orch._decompose_block_or_legacy(
+            ctx, _block_advisory(), compression_target=400,
+        )
+    )
+
+    assert out.terminal_reason_code == "advisor_blocked"
+    assert self_heal_calls == [], "master OFF must NOT invoke self-heal"
+
+
+# ===========================================================================
+# Test 6 -- DEEP-PAYLOAD shed: clears scoped_symbols + inlines source <= target.
+# ===========================================================================
+
+def test_deep_payload_shed_fits_target_and_clears_symbols(tmp_path):
+    """shed_block_goal_to_fit reads the FULL file source, sheds it, inlines it
+    into description, and CLEARS scoped_symbols -> estimate_subgoal_payload_chars
+    measures <= target for a large target file. Fail-soft on a missing file.
+    """
+    target_file = tmp_path / "big.py"
+    target_file.write_text(_HEAVY)
+    target_files = (str(target_file),)
+    compression_target = 300
+
+    sub, tier = shed_block_goal_to_fit(
+        target_files, "shed this goal", compression_target, "op-deep-1",
+    )
+    assert sub is not None
+    assert sub.scoped_symbols == (), "scoped_symbols MUST be cleared (inline shed)"
+    assert sub.kind == SubGoalKind.ATOMIC
+    assert sub.target_files == target_files
+    assert estimate_subgoal_payload_chars(sub) <= compression_target, (
+        f"deep shed must fit target; got {estimate_subgoal_payload_chars(sub)}"
+    )
+    assert tier in ("none", "tier1", "tier2", "tier3")
+
+    # Fail-soft: a non-existent file must NOT crash (reader returns "").
+    sub2, tier2 = shed_block_goal_to_fit(
+        ("/nonexistent/path/xyz.py",), "missing", 100, "op-deep-2",
+    )
+    # The reader yields "" for the missing file; the shed still returns a sub.
+    assert sub2 is not None
+    assert estimate_subgoal_payload_chars(sub2) <= 100
+
+
+# ===========================================================================
+# Test 7 -- BOUNDEDNESS: a second arrival of an irreducible lineage terminates.
+# ===========================================================================
+
+def test_reinjected_shed_reaches_fixpoint_and_terminates(
+    monkeypatch, tmp_path,
+):
+    """End-to-end boundedness via the REAL re-injection mechanism.
+
+    In the live loop the self-healed sub-goal carries the shed text AS its new
+    op description. So on the next stall the self-heal receives ``description ==
+    prior shed text``. shed(shed_text + source) truncated to target converges to
+    a FIXPOINT (once the shed text fills the budget, re-shedding it returns the
+    same bytes). At the fixpoint the shed-hash repeats -> already marked -> the
+    self-heal yields to advisor_blocked. This proves the chain TERMINATES: the
+    self-heal hops are bounded by the number of distinct shed payloads, which is
+    finite because each hop is a monotone non-growing AST reduction toward a
+    fixpoint. Here we drive that re-injection loop directly and assert it stops.
+    """
+    target_file = tmp_path / "irr.py"
+    target_file.write_text(_HEAVY)
+    target_files = (str(target_file),)
+    compression_target = 350
+
+    advance_calls: list = []
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        advance_calls.append(plan)
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    lineage = subgoal_hash(target_files, ())
+    tracker = cw_mod.get_reduction_tracker()
+    # Pre-stall the lineage so every arrival is treated as stalled.
+    tracker.record_pass(lineage, 1000, 1000)
+
+    ledger = dedup.get_attempt_ledger()
+    orch = _make_orch(router=_FakeRouter())
+
+    # Drive the re-injection loop: each iteration feeds the PRIOR shed text back
+    # as the new op description (exactly what the multi-step emitter does live).
+    description = "irreducible heavy goal"
+    terminated = False
+    for hop in range(25):  # hard cap: must terminate well before this
+        ctx = _make_ctx(
+            op_id=f"op-irr-{hop}",
+            description=description,
+            target_files=target_files,
+        )
+        # The arriving GOAL is a duplicate (it has been attempted) -> inversion.
+        ledger.mark(subgoal_hash(target_files, description))
+        out = _run(
+            orch._decompose_block_or_legacy(
+                ctx, _block_advisory(),
+                compression_target=compression_target,
+            )
+        )
+        if out.terminal_reason_code == "advisor_blocked":
+            terminated = True
+            break
+        assert out.terminal_reason_code == "decomposed"
+        # Re-injection: the emitted sub-goal's description becomes the next op's
+        # description (the live multi-step emitter carries it forward).
+        plan = advance_calls[-1]
+        description = plan.sub_goals[0].description
+
+    assert terminated, (
+        "the re-injected shed chain MUST reach a fixpoint and terminate "
+        "advisor_blocked -- the loop cannot run forever"
+    )

--- a/tests/governance/test_watchdog_integration.py
+++ b/tests/governance/test_watchdog_integration.py
@@ -1,0 +1,333 @@
+"""T4: Integration spine + static validation for the Autonomous Convergence Watchdog.
+
+Exercises the end-to-end flow (tracker -> verdict -> shedder) without
+instantiating the full governed stack.  These are "operator gate" tests:
+they prove locally -- before any C2 soak -- that:
+
+  (I1) A stalled irreducible lineage converges to <=target locally (no infinite
+       loop, no DW egress).
+  (I2) Zero watchdog egress: shedder is pure-deterministic, no model call.
+  (I3) Self-healing: stall -> shed -> fitting output observable via
+       [SOVEREIGN YIELD] WARNING.
+  (I4) Fail-soft: parse error -> tier3 truncation; never crashes.
+  (I5) OFF byte-identical: disabled flag -> watchdog_enabled() False.
+  (I6) Pure AST only in the shedder (no exec/eval).
+
+These tests are STATIC -- they do NOT run the live orchestrator FSM and do
+NOT touch the network.
+"""
+from __future__ import annotations
+
+import builtins
+import inspect
+import logging
+
+import pytest
+
+from backend.core.ouroboros.governance import convergence_watchdog as cw_mod
+from backend.core.ouroboros.governance.convergence_watchdog import (
+    WatchdogVerdict,
+    emit_sovereign_yield,
+    get_reduction_tracker,
+    watchdog_enabled,
+)
+from backend.core.ouroboros.governance.epistemic_shedder import shed_to_fit
+
+# ---------------------------------------------------------------------------
+# Source fixtures
+# ---------------------------------------------------------------------------
+
+_HEAVY_SOURCE = '''
+"""Module-level docstring that adds padding to the source text so the total
+character count significantly exceeds any reasonable target budget."""
+
+import os
+import sys
+
+
+def alpha(x, y, z):
+    """Alpha function docstring, also padding."""
+    result = 0
+    for i in range(x):
+        for j in range(y):
+            result += i * j * z
+    return result
+
+
+def beta(data):
+    """Beta function with a very heavy body."""
+    output = []
+    for item in data:
+        if item > 0:
+            output.append(item * 2)
+        elif item < 0:
+            output.append(item - 1)
+        else:
+            output.append(0)
+    return output
+
+
+class Worker:
+    """Worker class with multiple heavy methods."""
+
+    def __init__(self, config):
+        """Init docstring padding."""
+        self.config = config
+        self.state = {}
+
+    def run(self):
+        """Run method with a large body to inflate character count."""
+        for key, value in self.config.items():
+            if isinstance(value, list):
+                self.state[key] = [v * 2 for v in value]
+            else:
+                self.state[key] = value
+        return self.state
+
+    def cleanup(self):
+        """Cleanup method."""
+        self.state.clear()
+'''
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_tracker_singleton():
+    """Reset process-global ReductionTracker between tests to avoid pollution."""
+    cw_mod._REDUCTION_TRACKER_SINGLETON = None  # type: ignore[attr-defined]
+    yield
+    cw_mod._REDUCTION_TRACKER_SINGLETON = None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Test 1: Stall -> yield (operator gate)
+#   Drive IRREDUCIBLE-but-overweight lineage through 2 stalled passes.
+#   Prove loop TERMINATES: the shed output is <=target, not re-sliced again.
+# ---------------------------------------------------------------------------
+
+
+def test_stall_then_yield_converges_to_target():
+    """Two stalled passes cause WatchdogVerdict.stalled, then shed_to_fit
+    returns a payload whose len <= target. Loop terminates -- no infinite
+    re-decompose, no DW egress (shedder is synchronous + pure).
+    """
+    tracker = get_reduction_tracker()
+    lineage = "test-lineage-irred-01"
+    target = 200  # aggressive budget the heavy source cannot satisfy raw
+
+    # Pass 1: large parent (1000), large child (990) -> ratio 0.99, stall #1.
+    v1 = tracker.record_pass(lineage, parent_chars=1000, max_child_chars=990)
+    assert v1.stalled is False, "Single stall should NOT trip threshold (need 2)"
+    assert v1.consecutive_stalls == 1
+    assert v1.ratio == pytest.approx(0.99, abs=1e-6)
+
+    # Pass 2: same irreducible ratio -> stall #2 trips.
+    v2 = tracker.record_pass(lineage, parent_chars=1000, max_child_chars=990)
+    assert v2.stalled is True, "Two consecutive stalls must trip the watchdog"
+    assert v2.consecutive_stalls == 2
+
+    # Now shed the heavy source to fit the target.
+    shed, tier = shed_to_fit(_HEAVY_SOURCE, target_chars=target)
+
+    # CORE INVARIANT: result fits the target -> loop terminates.
+    assert len(shed) <= target, (
+        f"shed_to_fit must return <=target chars; got {len(shed)}, target={target}, tier={tier}"
+    )
+
+    # The tier label must be a known value.
+    assert tier in ("none", "tier1", "tier2", "tier3"), f"Unknown tier: {tier!r}"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: Reducible lineage -> no stall, normal slicing path.
+# ---------------------------------------------------------------------------
+
+
+def test_reducible_lineage_never_stalls():
+    """When the child is well below the parent on every pass, the tracker
+    never trips -- no stall verdict, no watchdog intervention needed.
+    """
+    tracker = get_reduction_tracker()
+    lineage = "test-lineage-good-01"
+
+    # Feed 5 passes where child is only 30% of parent (ratio 0.30).
+    for pass_num in range(5):
+        v = tracker.record_pass(lineage, parent_chars=1000, max_child_chars=300)
+        assert v.stalled is False, (
+            f"Pass {pass_num + 1}: ratio 0.30 should never stall; got {v}"
+        )
+        assert v.consecutive_stalls == 0
+
+
+# ---------------------------------------------------------------------------
+# Test 3: Tier escalation fits -- tier1 -> tier2 -> tier3 cascade.
+# ---------------------------------------------------------------------------
+
+
+def test_tier_escalation_fits_at_tier3():
+    """When source is too heavy for tier1 or tier2, shed_to_fit escalates
+    through the tiers and the final result is always <=target.
+    Each re-measurement after each tier is internal to shed_to_fit.
+    """
+    # Use a very tight target to force tier3.
+    target = 50
+    shed, tier = shed_to_fit(_HEAVY_SOURCE, target_chars=target)
+
+    assert len(shed) <= target, (
+        f"tier3 nuclear truncation must fit; got len={len(shed)}, target={target}"
+    )
+    # With a 50-char target against ~1KB source, tier3 should be hit.
+    assert tier == "tier3", f"Expected tier3 for tight budget; got {tier!r}"
+
+
+def test_tier1_fits_when_docstrings_are_the_excess():
+    """When the source is only slightly over-budget due to docstrings, tier1
+    should be enough -- the result has no module/function docstrings and fits.
+    """
+    # Build a source where the docstrings are the bulk of the excess.
+    minimal_core = "def f(x):\n    return x\n"
+    padded_docstrings = '"""' + ("X" * 300) + '"""\n' + minimal_core
+    # Core without docstrings is ~30 chars; add docstring padding to push it over.
+    target = len(minimal_core) + 10  # fits without the docstring
+
+    shed, tier = shed_to_fit(padded_docstrings, target_chars=target)
+    assert len(shed) <= target, (
+        f"tier1 doc-strip should fit; got len={len(shed)}, target={target}, tier={tier!r}"
+    )
+    # Tier 1 or better should have caught this.
+    assert tier in ("tier1", "tier2", "tier3")
+
+
+# ---------------------------------------------------------------------------
+# Test 4: Parse error -> tier3 (graceful degradation).
+# ---------------------------------------------------------------------------
+
+
+def test_parse_error_falls_to_tier3():
+    """Malformed Python source that cannot be ast.parsed falls straight to
+    tier3 truncation.  The result is always <=target, never raises.
+    """
+    malformed = "def (:\n  oops " * 30  # intentionally invalid Python
+    target = 40
+
+    shed, tier = shed_to_fit(malformed, target_chars=target)
+
+    assert tier == "tier3", f"Parse error must reach tier3; got {tier!r}"
+    assert len(shed) <= target, (
+        f"Tier3 truncation must fit budget; got len={len(shed)}, target={target}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: Zero watchdog egress -- shedder is synchronous + pure, no network.
+# ---------------------------------------------------------------------------
+
+
+def test_zero_watchdog_egress_shedder_is_synchronous():
+    """shed_to_fit is a pure synchronous function -- it cannot make a
+    network call or DW egress by construction.  This test asserts the return
+    type contract: a 2-tuple (str, str), which proves it completed
+    synchronously without awaiting anything.
+    """
+    result = shed_to_fit(_HEAVY_SOURCE, target_chars=100)
+
+    # Pure synchronous function must return a plain tuple, not a coroutine.
+    assert isinstance(result, tuple), "shed_to_fit must return a plain tuple"
+    assert len(result) == 2, "shed_to_fit must return (str, str)"
+    shed, tier = result
+    assert isinstance(shed, str), "First element must be str"
+    assert isinstance(tier, str), "Second element (tier) must be str"
+
+    # No coroutine object was returned (which would indicate an await was needed).
+    assert not inspect.iscoroutine(result), "shed_to_fit must not return a coroutine"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: NEVER exec -- shedder must not call exec under any circumstance.
+# ---------------------------------------------------------------------------
+
+
+def test_never_exec_called_by_shedder(monkeypatch):
+    """The epistemic shedder specification requires PURE AST only:
+    ast.parse / ast.unparse / ast.get_source_segment / ast.fix_missing_locations
+    NEVER exec / eval / compile(..., mode='exec').
+
+    Monkeypatch builtins.exec to raise; shed_to_fit must complete without
+    triggering it.
+    """
+    def _forbidden_exec(*args, **kwargs):
+        raise AssertionError("epistemic_shedder called exec -- FORBIDDEN by spec")
+
+    monkeypatch.setattr(builtins, "exec", _forbidden_exec)
+
+    # Must complete without raising AssertionError (exec was not called).
+    shed, tier = shed_to_fit(_HEAVY_SOURCE, target_chars=80)
+    assert isinstance(shed, str), "shed_to_fit must return a string even with exec blocked"
+
+
+# ---------------------------------------------------------------------------
+# Test 7: OFF byte-identical -- disabled flag means watchdog_enabled() False.
+# ---------------------------------------------------------------------------
+
+
+def test_watchdog_disabled_flag_returns_false(monkeypatch):
+    """JARVIS_CONVERGENCE_WATCHDOG_ENABLED=false must make watchdog_enabled()
+    return False.  This is the OFF byte-identical gate: the outer orchestrator
+    seam checks this flag before any watchdog logic runs.
+    """
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", "false")
+    assert watchdog_enabled() is False
+
+    # Also verify the '0' form.
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", "0")
+    assert watchdog_enabled() is False
+
+    # And verify it defaults to True when not set.
+    monkeypatch.delenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", raising=False)
+    assert watchdog_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Test 8: [SOVEREIGN YIELD] emitted -- emit_sovereign_yield logs WARNING.
+# ---------------------------------------------------------------------------
+
+
+def test_emit_sovereign_yield_logs_warning(caplog):
+    """emit_sovereign_yield must log a WARNING containing '[SOVEREIGN YIELD]'
+    and must be fail-soft without an SSE broker (the lazy import silently
+    swallows ImportError / AttributeError from the missing SSE stack).
+    """
+    with caplog.at_level(logging.WARNING, logger="backend.core.ouroboros.governance.convergence_watchdog"):
+        emit_sovereign_yield(
+            "op-t4-test-001",
+            lineage_id="lineage-t4-01",
+            ratio=0.97,
+            consecutive_stalls=2,
+            parent_chars=5000,
+            child_chars=4850,
+            tier="tier2",
+        )
+
+    # Must have emitted at least one WARNING with the sentinel.
+    yield_records = [
+        r for r in caplog.records if "[SOVEREIGN YIELD]" in r.getMessage()
+    ]
+    assert yield_records, (
+        "emit_sovereign_yield must emit a WARNING containing '[SOVEREIGN YIELD]'; "
+        f"records seen: {[r.getMessage() for r in caplog.records]}"
+    )
+
+    # The record must be at WARNING level.
+    assert any(r.levelno == logging.WARNING for r in yield_records), (
+        "The [SOVEREIGN YIELD] record must be at WARNING level"
+    )
+
+    # Key fields must appear in the log message.
+    msg = yield_records[0].getMessage()
+    assert "op-t4-test-001" in msg
+    assert "lineage-t4-01" in msg
+    assert "0.970" in msg or "0.97" in msg

--- a/tests/governance/test_watchdog_wiring.py
+++ b/tests/governance/test_watchdog_wiring.py
@@ -1,0 +1,445 @@
+"""T3: Convergence watchdog wired into _decompose_block_or_legacy funnel.
+
+Tests that after a stalled decompose lineage (2 consecutive passes where
+the largest child >= 95% of parent), the watchdog:
+  - replaces _all_subs with ONE fitting sub-goal (payload <= compression_target)
+  - fires emit_sovereign_yield
+
+Also tests the reducible-pass (no intervention) and the watchdog-disabled
+(byte-identical) paths.
+
+These are structural assertions against the LIVE _decompose_block_or_legacy
+funnel (orchestrator.py, defined at ~line 2073) -- the same funnel used
+by the egress-overweight re-chunk path and the Advisor-BLOCK path.  The
+funnel is exercised via monkeypatching orchestrator module seams so the
+test never instantiates the full governed stack.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance import orchestrator as orch_mod
+from backend.core.ouroboros.governance.orchestrator import GovernedOrchestrator
+from backend.core.ouroboros.governance.op_context import (
+    OperationContext,
+    OperationPhase,
+)
+from backend.core.ouroboros.governance import recursion_dedup as dedup
+from backend.core.ouroboros.governance.operation_advisor import (
+    Advisory,
+    AdvisoryDecision,
+)
+from backend.core.ouroboros.governance.goal_decomposition_planner import (
+    SubGoal,
+    SubGoalKind,
+)
+from backend.core.ouroboros.governance import convergence_watchdog as cw_mod
+
+
+# ---------------------------------------------------------------------------
+# Fakes / helpers
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeStack:
+    governed_loop_service: Any = None
+
+
+@dataclass
+class _FakeGLS:
+    _intake_router: Any = None
+
+
+def _make_orch() -> GovernedOrchestrator:
+    """Build a GovernedOrchestrator without running its heavy __init__."""
+    o = object.__new__(GovernedOrchestrator)
+    o._stack = _FakeStack(governed_loop_service=_FakeGLS(_intake_router=None))
+    return o
+
+
+def _make_ctx(
+    op_id: str = "op-watchdog-t3",
+    description: str = "Refactor the entire monolith",
+    target_files: Tuple[str, ...] = ("backend/core/ouroboros/governance/orchestrator.py",),
+) -> OperationContext:
+    return OperationContext.create(
+        op_id=op_id,
+        target_files=target_files,
+        description=description,
+    )
+
+
+def _block_advisory() -> Advisory:
+    return Advisory(
+        decision=AdvisoryDecision.BLOCK,
+        reasons=["blast_radius too high"],
+        blast_radius=99,
+        test_coverage=1.0,
+        chronic_entropy=0.0,
+        risk_score=0.9,
+    )
+
+
+def _make_sub(
+    sub_id: str,
+    parent_id: str,
+    description: str,
+    depends_on: Tuple[str, ...] = (),
+) -> SubGoal:
+    return SubGoal(
+        sub_goal_id=sub_id,
+        parent_goal_id=parent_id,
+        title=sub_id,
+        description=description,
+        kind=SubGoalKind.ATOMIC,
+        target_files=(),
+        depends_on_sub_ids=depends_on,
+        estimated_complexity="moderate",
+        boundary_crossed=False,
+        scoped_symbols=(),
+    )
+
+
+def _run_seam(
+    orch: GovernedOrchestrator,
+    ctx: OperationContext,
+    advisory: Advisory,
+    compression_target: Optional[int] = None,
+):
+    return asyncio.get_event_loop().run_until_complete(
+        orch._decompose_block_or_legacy(ctx, advisory, compression_target=compression_target)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture(autouse=True)
+def _reset_env_and_ledger(monkeypatch):
+    """Enable chunking + watchdog; reset process-global singletons per test."""
+    monkeypatch.setenv("JARVIS_RECURSIVE_CHUNKING_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", "true")
+    # Reset ledger singleton so no cross-test dedup contamination.
+    dedup._ATTEMPT_LEDGER_SINGLETON = None  # type: ignore[attr-defined]
+    # Reset watchdog tracker singleton so lineage history is clean.
+    cw_mod._REDUCTION_TRACKER_SINGLETON = None  # type: ignore[attr-defined]
+    yield
+    dedup._ATTEMPT_LEDGER_SINGLETON = None  # type: ignore[attr-defined]
+    cw_mod._REDUCTION_TRACKER_SINGLETON = None  # type: ignore[attr-defined]
+
+
+# ---------------------------------------------------------------------------
+# Helper: common fake advance_orchestration (returns emitted_count=1)
+# ---------------------------------------------------------------------------
+
+async def _fake_advance_emit_one(plan, *, router=None, **kw):
+    from types import SimpleNamespace
+    return SimpleNamespace(emitted_count=1)
+
+
+# ---------------------------------------------------------------------------
+# Test 1: stalled lineage -> ONE shed sub-goal + emit_sovereign_yield fires
+# ---------------------------------------------------------------------------
+
+def test_stalled_lineage_yields_one_shed_sub_goal_and_emits(monkeypatch):
+    """After 2 passes where largest child >= 95% of parent, watchdog intervenes:
+    _all_subs becomes exactly ONE sub-goal whose description length <=
+    compression_target, and emit_sovereign_yield is called.
+
+    Exercises the LIVE _decompose_block_or_legacy funnel in orchestrator.py.
+    """
+    compression_target = 500
+    parent_desc = "x" * 2000  # heavy parent description
+
+    ctx = _make_ctx(description=parent_desc)
+    op_id = ctx.op_id
+
+    # A heavy sub-goal: description is 1900 chars (95% of parent 2000 chars).
+    heavy_sub = _make_sub("sub-1", op_id, "y" * 1900)
+    stall_subs: List[SubGoal] = [heavy_sub]
+
+    emit_calls: List[dict] = []
+
+    # Monkeypatch decompose_for_block to return stall_subs every call.
+    monkeypatch.setattr(orch_mod, "decompose_for_block", lambda *a, **kw: tuple(stall_subs))
+
+    # Monkeypatch estimate_subgoal_payload_chars to return len(description).
+    monkeypatch.setattr(
+        orch_mod,
+        "estimate_subgoal_payload_chars",
+        lambda s: len(str(getattr(s, "description", "") or "")),
+    )
+
+    # Monkeypatch shed_to_fit to truncate to target_chars.
+    def _fake_shed(source: str, target_chars: int):
+        return source[:target_chars], "tier3"
+
+    monkeypatch.setattr(orch_mod, "shed_to_fit", _fake_shed)
+
+    # Monkeypatch emit_sovereign_yield to capture calls.
+    def _fake_emit(op_id, *, lineage_id, ratio, consecutive_stalls, parent_chars, child_chars, tier):
+        emit_calls.append(dict(
+            op_id=op_id, lineage_id=lineage_id, ratio=ratio,
+            consecutive_stalls=consecutive_stalls,
+            parent_chars=parent_chars, child_chars=child_chars, tier=tier,
+        ))
+
+    monkeypatch.setattr(orch_mod, "emit_sovereign_yield", _fake_emit)
+
+    # advance_orchestration always emits 1 so we get "decomposed" terminal.
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance_emit_one)
+
+    orch = _make_orch()
+
+    # Pass 1: stall #1 (ratio 0.95) -- watchdog records but threshold is 2.
+    _run_seam(orch, ctx, _block_advisory(), compression_target=compression_target)
+    # After pass 1 the tracker has 1 stall -- not yet tripped.
+    # emit_sovereign_yield must NOT have fired yet.
+    assert len(emit_calls) == 0, "emit should NOT fire on the first stall pass"
+
+    # Reset dedup ledger so the second call isn't treated as duplicate.
+    dedup._ATTEMPT_LEDGER_SINGLETON = None  # type: ignore[attr-defined]
+
+    # Pass 2: stall #2 (ratio still 0.95) -- watchdog NOW trips.
+    captured_subs: List[Tuple[SubGoal, ...]] = []
+
+    async def _fake_advance_capture(plan, *, router=None, **kw):
+        captured_subs.append(plan.sub_goals)
+        from types import SimpleNamespace
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance_capture)
+
+    _run_seam(orch, ctx, _block_advisory(), compression_target=compression_target)
+
+    # Watchdog MUST have fired emit_sovereign_yield.
+    assert len(emit_calls) == 1, f"emit_sovereign_yield must fire once on stall; got {emit_calls}"
+
+    # The emitted plan must carry exactly ONE sub-goal.
+    assert len(captured_subs) == 1, "advance_orchestration must be called once"
+    subs_on_stall = captured_subs[0]
+    assert len(subs_on_stall) == 1, (
+        f"stall -> ONE fitting sub-goal; got {len(subs_on_stall)}"
+    )
+
+    # That one sub-goal's description must fit within compression_target.
+    shed_desc = subs_on_stall[0].description
+    assert len(shed_desc) <= compression_target, (
+        f"shed description len {len(shed_desc)} must be <= compression_target {compression_target}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2: reducible pass -> _all_subs unchanged, no emit
+# ---------------------------------------------------------------------------
+
+def test_reducible_pass_does_not_intervene(monkeypatch):
+    """A decompose pass where largest child < 95% of parent should not trigger
+    the watchdog at all -- _all_subs passes through unchanged, no yield emitted.
+    """
+    compression_target = 500
+    parent_desc = "x" * 2000
+
+    ctx = _make_ctx(description=parent_desc)
+    op_id = ctx.op_id
+
+    # A SMALL sub-goal: description is only 400 chars (~20% of parent).
+    small_sub = _make_sub("sub-small", op_id, "z" * 400)
+
+    captured_subs: List[Tuple[SubGoal, ...]] = []
+    emit_calls: List[dict] = []
+
+    monkeypatch.setattr(orch_mod, "decompose_for_block", lambda *a, **kw: (small_sub,))
+    monkeypatch.setattr(
+        orch_mod,
+        "estimate_subgoal_payload_chars",
+        lambda s: len(str(getattr(s, "description", "") or "")),
+    )
+
+    def _fake_shed(source: str, target_chars: int):
+        return source[:target_chars], "tier2"  # should never be called
+
+    monkeypatch.setattr(orch_mod, "shed_to_fit", _fake_shed)
+
+    def _fake_emit(**kw):
+        emit_calls.append(kw)
+
+    monkeypatch.setattr(orch_mod, "emit_sovereign_yield", _fake_emit)
+
+    async def _fake_advance_capture(plan, *, router=None, **kw):
+        captured_subs.append(plan.sub_goals)
+        from types import SimpleNamespace
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance_capture)
+
+    _run_seam(_make_orch(), ctx, _block_advisory(), compression_target=compression_target)
+
+    # No yield should have been emitted.
+    assert emit_calls == [], f"emit_sovereign_yield must NOT fire on reducible pass; got {emit_calls}"
+
+    # The sub-goals passed to advance_orchestration should still include our sub.
+    assert len(captured_subs) == 1
+    assert any(s.sub_goal_id == "sub-small" for s in captured_subs[0]), (
+        "original sub-small sub-goal must pass through unchanged"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: watchdog_enabled() == False -> byte-identical (no watchdog logic)
+# ---------------------------------------------------------------------------
+
+def test_watchdog_disabled_is_byte_identical(monkeypatch):
+    """When JARVIS_CONVERGENCE_WATCHDOG_ENABLED=false, the seam must behave
+    exactly as before T3 -- _all_subs comes from decompose_for_block unchanged,
+    emit_sovereign_yield is never called, even after multiple stall passes.
+    """
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", "false")
+
+    compression_target = 500
+    parent_desc = "x" * 2000
+
+    ctx = _make_ctx(description=parent_desc)
+    op_id = ctx.op_id
+
+    heavy_sub1 = _make_sub("sub-h1", op_id, "y" * 1900)
+    heavy_sub2 = _make_sub("sub-h2", op_id, "y" * 1850)
+    stall_subs = (heavy_sub1, heavy_sub2)
+
+    emit_calls: List[dict] = []
+    captured_subs: List[Tuple[SubGoal, ...]] = []
+
+    monkeypatch.setattr(orch_mod, "decompose_for_block", lambda *a, **kw: stall_subs)
+    monkeypatch.setattr(
+        orch_mod,
+        "estimate_subgoal_payload_chars",
+        lambda s: len(str(getattr(s, "description", "") or "")),
+    )
+    monkeypatch.setattr(orch_mod, "shed_to_fit", lambda src, tgt: (src[:tgt], "tier3"))
+
+    def _fake_emit(**kw):
+        emit_calls.append(kw)
+
+    monkeypatch.setattr(orch_mod, "emit_sovereign_yield", _fake_emit)
+
+    async def _fake_advance_capture(plan, *, router=None, **kw):
+        captured_subs.append(plan.sub_goals)
+        from types import SimpleNamespace
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance_capture)
+
+    orch = _make_orch()
+
+    # Simulate two "stall" passes. Watchdog is OFF so nothing should change.
+    _run_seam(orch, ctx, _block_advisory(), compression_target=compression_target)
+    dedup._ATTEMPT_LEDGER_SINGLETON = None  # type: ignore[attr-defined]
+    _run_seam(orch, ctx, _block_advisory(), compression_target=compression_target)
+
+    # emit_sovereign_yield must NEVER fire when watchdog is disabled.
+    assert emit_calls == [], "emit_sovereign_yield must NOT fire when watchdog disabled"
+
+    # Both calls should have passed through all original sub-goals unchanged.
+    for subs in captured_subs:
+        assert len(subs) == len(stall_subs), (
+            f"sub-goal count must be unchanged when disabled; got {len(subs)}, want {len(stall_subs)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4: watchdog_enabled() False + no compression_target -> byte-identical
+# ---------------------------------------------------------------------------
+
+def test_no_compression_target_skips_watchdog(monkeypatch):
+    """compression_target=None means the egress re-chunk path is NOT active.
+    The watchdog guard requires compression_target is not None, so it must
+    be completely skipped (record_pass never called).
+    """
+    monkeypatch.setenv("JARVIS_CONVERGENCE_WATCHDOG_ENABLED", "true")
+
+    parent_desc = "x" * 2000
+    ctx = _make_ctx(description=parent_desc)
+    op_id = ctx.op_id
+
+    heavy_sub = _make_sub("sub-h", op_id, "y" * 1900)
+    emit_calls: List[dict] = []
+    record_pass_calls: List[Any] = []
+
+    monkeypatch.setattr(orch_mod, "decompose_for_block", lambda *a, **kw: (heavy_sub,))
+    monkeypatch.setattr(
+        orch_mod,
+        "estimate_subgoal_payload_chars",
+        lambda s: len(str(getattr(s, "description", "") or "")),
+    )
+    monkeypatch.setattr(orch_mod, "shed_to_fit", lambda src, tgt: (src[:tgt], "tier3"))
+
+    def _fake_emit(**kw):
+        emit_calls.append(kw)
+
+    monkeypatch.setattr(orch_mod, "emit_sovereign_yield", _fake_emit)
+
+    # Monkeypatch get_reduction_tracker to detect if record_pass is called.
+    class _SpyTracker:
+        def record_pass(self, lineage_id, parent_chars, max_child_chars):
+            record_pass_calls.append((lineage_id, parent_chars, max_child_chars))
+            # Return stalled=True to force intervention IF it were reached.
+            return cw_mod.WatchdogVerdict(stalled=True, ratio=0.99, consecutive_stalls=2, passes=2)
+
+    monkeypatch.setattr(orch_mod, "get_reduction_tracker", lambda: _SpyTracker())
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        from types import SimpleNamespace
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    # Call WITHOUT compression_target (None = legacy path).
+    _run_seam(_make_orch(), ctx, _block_advisory(), compression_target=None)
+
+    assert record_pass_calls == [], (
+        "record_pass must NOT be called when compression_target is None"
+    )
+    assert emit_calls == [], (
+        "emit_sovereign_yield must NOT fire when compression_target is None"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 5: fail-soft -- watchdog error -> legacy slice path (no crash)
+# ---------------------------------------------------------------------------
+
+def test_watchdog_error_is_failsoft(monkeypatch):
+    """An exception inside the watchdog block must be silently swallowed so
+    the outer chunking seam continues to its decomposed terminal.  The op
+    must NEVER be lost due to watchdog internals.
+    """
+    compression_target = 500
+    parent_desc = "x" * 2000
+    ctx = _make_ctx(description=parent_desc)
+
+    monkeypatch.setattr(orch_mod, "decompose_for_block", lambda *a, **kw: ())
+
+    # Make estimate_subgoal_payload_chars explode.
+    def _boom(s):
+        raise RuntimeError("intentional test bomb")
+
+    monkeypatch.setattr(orch_mod, "estimate_subgoal_payload_chars", _boom)
+    monkeypatch.setattr(orch_mod, "shed_to_fit", lambda src, tgt: (src[:tgt], "tier3"))
+    monkeypatch.setattr(orch_mod, "emit_sovereign_yield", lambda *a, **kw: None)
+
+    async def _fake_advance(plan, *, router=None, **kw):
+        from types import SimpleNamespace
+        return SimpleNamespace(emitted_count=1)
+
+    monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
+
+    # Must not raise -- fail-soft inside the try/except.
+    out = _run_seam(_make_orch(), ctx, _block_advisory(), compression_target=compression_target)
+    # Either decomposed or advisor_blocked -- but no exception.
+    assert out.phase == OperationPhase.CANCELLED


### PR DESCRIPTION
With AST-slicing + the egress interceptor live, the risk shifted from network-spam to **local infinite recursion** (an irreducible-but-overweight block re-decomposing forever). This watchdog detects a stalled reduction trajectory and sheds weight structurally — self-healing, no manual babysitting, no hardcoded retry caps for stall detection.

**Components**
- `convergence_watchdog.py`: reduction-trajectory tracker (`max(child)/parent` ratio, stall = ≥`JARVIS_WATCHDOG_STALL_RATIO` 0.95 for `JARVIS_WATCHDOG_STALL_PASSES` 2 consecutive, env-tuned) + `[SOVEREIGN YIELD]` telemetry (SSE + stdout). Default-ON.
- `epistemic_shedder.py`: tiered **pure-AST** weight shed — Tier1 strip docstrings/comments → Tier2 hollow heaviest bodies to signatures (`[SOVEREIGN YIELD: Implementation Omitted]`) → Tier3 truncate. NEVER exec/eval.
- **Sovereign Ledger-Watchdog Composition** (the keystone): invariant lineage key (`subgoal_hash(target_files, ())`, survives async re-injection) + **funnel inversion** (the de-dup ledger YIELDS to the watchdog for a shed-and-continue before hard-failing; de-dup retained as the final mathematical backstop) + **deep-payload shed** (reads full target-file source, sheds, inlines + clears `scoped_symbols` so the egress ruler measures ≤ target).

**Termination (two Opus reviews):** provably bounded. Self-heal capped at `JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS` (default **3**) re-injections per lineage — a small env-tunable constant (the first review caught a degenerate ~7,300-hop bound from the `_make_envelope` title-prefix shift; fixed). A stalled-and-unsheddable lineage still terminates `advisor_blocked` via the de-dup backstop. Fail-soft throughout; plain BLOCK path + master-OFF byte-identical. 61 arc tests + static stall→yield validation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autonomous convergence watchdog that detects stalled decomposition and auto-sheds payload with a pure-AST shedder to prevent local infinite recursion. Wired into `_decompose_block_or_legacy` with bounded self-heal (default 3) and `[SOVEREIGN YIELD]` telemetry; default ON and fail-soft.

- **New Features**
  - `convergence_watchdog.py`: tracks max-child/parent ratio; flags stall after `JARVIS_WATCHDOG_STALL_RATIO` (0.95) for `JARVIS_WATCHDOG_STALL_PASSES` (2).
  - `epistemic_shedder.py`: tiered shedder (strip docstrings → stub heavy bodies → truncate); pure AST, no model/eval.
  - Ledger–watchdog composition: invariant lineage ID; de-dup yields to shed-and-continue before the backstop.
  - Deep-payload shed for block goals: reads target files, sheds, inlines result, clears `scoped_symbols` so the egress ruler measures ≤ target.
  - Bounded self-heal per lineage via `JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS` (default 3). SSE/stdout `[SOVEREIGN YIELD]` on intervention.

- **Migration**
  - Enabled by default: set `JARVIS_CONVERGENCE_WATCHDOG_ENABLED=false` to disable.
  - Optional tuning: `JARVIS_WATCHDOG_STALL_RATIO`, `JARVIS_WATCHDOG_STALL_PASSES`, `JARVIS_WATCHDOG_MAX_SELF_HEAL_HOPS`.
  - No API or schema changes required.

<sup>Written for commit 599a726b352b46c8a74e8d6b01d1ee25870133ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

