### PR TITLE
fix(orchestrator): Sovereign State-Propagation Bridge — gate BLOCK-decompose on forward-progress, not the lagging emitted_count aggregate

### DIFF
--- a/backend/core/ouroboros/governance/multi_step_orchestrator.py
+++ b/backend/core/ouroboros/governance/multi_step_orchestrator.py
@@ -1116,6 +1116,8 @@ def _publish_event(report: OrchestrationReport) -> None:
                 "blocked_count": report.blocked_count,
                 "ready_count": report.ready_count,
                 "emitted_count": report.emitted_count,
+                "emitted_this_tick": report.emitted_this_tick,
+                "made_forward_progress": report.made_forward_progress,
                 "done_count": report.done_count,
                 "failed_count": report.failed_count,
                 "completion_ratio": report.completion_ratio,

--- a/backend/core/ouroboros/governance/multi_step_orchestrator.py
+++ b/backend/core/ouroboros/governance/multi_step_orchestrator.py
@@ -323,7 +323,24 @@ class OrchestrationReport:
     run_records: Tuple[SubGoalRunRecord, ...]
     diagnostic: str
     elapsed_s: float
+    # Sovereign State-Propagation Bridge: the GROUND-TRUTH count of sub-goals
+    # actually dispatched to the router THIS tick (router.ingest succeeded).
+    # ``emitted_count`` aggregates run-state over the pre-emit completion_status
+    # ledger, so it STRUCTURALLY cannot reflect this tick's just-completed emit
+    # (it lags by a tick). The forward-progress gate must read THIS field, not
+    # the lagging aggregate, or a freshly-decomposed-and-dispatched GOAL is
+    # false-negatived as "emitted 0" and wrongly DLQ'd. Default 0 keeps the
+    # early-return construction sites (master-off / dedup) byte-identical.
+    emitted_this_tick: int = 0
     schema_version: str = MULTI_STEP_ORCHESTRATOR_SCHEMA_VERSION
+
+    @property
+    def made_forward_progress(self) -> bool:
+        """True iff this tick made real forward progress: a sub-goal was either
+        dispatched this tick (ground truth) OR is already in-flight per the
+        ledger. This is the correct success predicate for the BLOCK->decompose
+        re-inject gate -- NOT the lagging ``emitted_count`` alone."""
+        return self.emitted_count >= 1 or self.emitted_this_tick >= 1
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -335,6 +352,8 @@ class OrchestrationReport:
             "blocked_count": int(self.blocked_count),
             "ready_count": int(self.ready_count),
             "emitted_count": int(self.emitted_count),
+            "emitted_this_tick": int(self.emitted_this_tick),
+            "made_forward_progress": bool(self.made_forward_progress),
             "done_count": int(self.done_count),
             "failed_count": int(self.failed_count),
             "completion_ratio": float(self.completion_ratio),
@@ -958,6 +977,23 @@ async def advance_orchestration(
     ratio = (done - failed) / total if total > 0 else 0.0
 
     emitted_this_tick = sum(1 for o in emit_outcomes if o.emitted)
+
+    # Zero-Drop policy (Sovereign State-Propagation Bridge): a REAL silent drop
+    # is when we SELECTED ready sub-goals to emit (``to_emit`` non-empty) but
+    # NONE were actually dispatched (every router.ingest failed / envelope was
+    # None). That -- and only that -- is a propagation failure worth a loud
+    # signal; a successful dispatch (emitted_this_tick >= 1) is NOT a drop even
+    # though the lagging ``emitted`` aggregate reads 0 this tick.
+    if to_emit and emitted_this_tick == 0:
+        _errs = "; ".join(
+            f"{o.sub_goal_id}:{o.error}" for o in emit_outcomes if not o.emitted
+        )[:400]
+        logger.critical(
+            "[SovereignPropagation] REAL DROP: %d ready sub-goal(s) selected for "
+            "emit but 0 dispatched (parent=%s) -- failures: %s",
+            len(to_emit), parent_goal_id, _errs or "unknown",
+        )
+
     diagnostic = (
         f"verdict={verdict.value}; "
         f"total={total} blocked={blocked} ready={ready} "
@@ -981,6 +1017,7 @@ async def advance_orchestration(
         run_records=run_records,
         diagnostic=diagnostic,
         elapsed_s=max(0.0, time.time() - started),
+        emitted_this_tick=emitted_this_tick,
     )
     _persist_report(report)
     _publish_event(report)

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -2466,15 +2466,25 @@ class GovernedOrchestrator:
                             self._stack, "governed_loop_service", None,
                         )
                         router = getattr(_gls_ref, "_intake_router", None)
-                        # I1 -- capture the report and check emitted_count.
+                        # I1 -- capture the report and check FORWARD PROGRESS.
+                        # Sovereign State-Propagation Bridge: gate on
+                        # ``made_forward_progress`` (emitted_count >= 1 OR a
+                        # sub-goal dispatched THIS tick), NOT the lagging
+                        # ``emitted_count`` aggregate alone. ``emitted_count`` is
+                        # computed over the pre-emit completion_status ledger, so
+                        # it STRUCTURALLY reads 0 on a fresh decompose even when
+                        # router.ingest succeeded (emitted_this_tick >= 1) --
+                        # gating on it false-negatived every first emit and
+                        # wrongly DLQ'd a dispatched GOAL.
                         report = await advance_orchestration(plan, router=router)
-                        if report.emitted_count >= 1:
+                        if report.made_forward_progress:
                             ledger.mark(h)
                             logger.warning(
                                 "[Orchestrator] BLOCK decomposed into %d "
-                                "sub-goals (test_first=%s, emitted=%d) op=%s",
+                                "sub-goals (test_first=%s, emitted=%d "
+                                "dispatched_this_tick=%d) op=%s",
                                 len(subs), zero_cov, report.emitted_count,
-                                ctx.op_id,
+                                report.emitted_this_tick, ctx.op_id,
                             )
                             return ctx.advance(
                                 OperationPhase.CANCELLED,

--- a/tests/governance/test_block_decompose_reinject.py
+++ b/tests/governance/test_block_decompose_reinject.py
@@ -137,7 +137,7 @@ def test_enabled_decomposes_and_reinjects(monkeypatch):
         captured["router"] = router
         # I1: the seam returns "decomposed" only when >=1 sub-goal was emitted.
         from types import SimpleNamespace
-        return SimpleNamespace(emitted_count=1)
+        return SimpleNamespace(emitted_count=1, emitted_this_tick=1, made_forward_progress=True)
 
     monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
 
@@ -165,7 +165,7 @@ def test_enabled_marks_ledger_after_reinject(monkeypatch):
 
     async def _fake_advance(plan, *, router=None, **kw):
         from types import SimpleNamespace
-        return SimpleNamespace(emitted_count=1)  # I1: >=1 emit -> decomposed
+        return SimpleNamespace(emitted_count=1, emitted_this_tick=1, made_forward_progress=True)  # I1: forward progress -> decomposed
 
     monkeypatch.setattr(orch_mod, "advance_orchestration", _fake_advance)
     orch = _make_orch(router=_FakeRouter())

--- a/tests/governance/test_propagation_bridge.py
+++ b/tests/governance/test_propagation_bridge.py
@@ -1,0 +1,110 @@
+"""Sovereign State-Propagation Bridge — the forward-progress gate must read the
+GROUND-TRUTH dispatch count (emitted_this_tick), not the lagging emitted_count
+aggregate, so a freshly-decomposed-and-dispatched GOAL is never false-DLQ'd."""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from backend.core.ouroboros.governance import multi_step_orchestrator as mso
+from backend.core.ouroboros.governance.goal_decomposition_planner import (
+    SubGoal, SubGoalKind, DecomposedPlan,
+)
+
+
+def _sub(sid: str, deps=()):
+    return SubGoal(
+        sub_goal_id=sid, parent_goal_id="parent", title=sid, description="do " + sid,
+        kind=SubGoalKind.ATOMIC, target_files=("f.py",), depends_on_sub_ids=tuple(deps),
+        estimated_complexity="moderate", boundary_crossed=False, scoped_symbols=(),
+    )
+
+
+def _plan(*subs):
+    return DecomposedPlan(
+        parent_goal_id="parent", sub_goals=tuple(subs), dag_valid=True, dag_depth=1,
+        topological_order=tuple(s.sub_goal_id for s in subs),
+        diagnostic="test",
+    )
+
+
+class _OkRouter:
+    def __init__(self):
+        self.ingested = []
+
+    async def ingest(self, env):
+        self.ingested.append(env)
+        return "idem-key"
+
+
+class _FailRouter:
+    async def ingest(self, env):
+        raise RuntimeError("ingest exploded")
+
+
+# -- made_forward_progress predicate ---------------------------------------- #
+def _report(**over):
+    base = dict(
+        evaluated_at_unix=0.0, master_enabled=True,
+        verdict=mso.OrchestrationVerdict.PROGRESSING, parent_goal_id="p",
+        total_sub_goals=2, blocked_count=1, ready_count=1, emitted_count=0,
+        done_count=0, failed_count=0, completion_ratio=0.0,
+        emit_outcomes=(), run_records=(), diagnostic="", elapsed_s=0.0,
+    )
+    base.update(over)
+    return mso.OrchestrationReport(**base)
+
+
+def test_forward_progress_true_on_dispatch_this_tick():
+    # THE bug: aggregate emitted_count=0 (lagging ledger) but a sub-goal WAS
+    # dispatched this tick -> must read as forward progress.
+    assert _report(emitted_count=0, emitted_this_tick=1).made_forward_progress is True
+
+
+def test_forward_progress_true_on_inflight_aggregate():
+    assert _report(emitted_count=2, emitted_this_tick=0).made_forward_progress is True
+
+
+def test_forward_progress_false_when_nothing_moved():
+    assert _report(emitted_count=0, emitted_this_tick=0).made_forward_progress is False
+
+
+def test_report_to_dict_exposes_new_fields():
+    d = _report(emitted_count=0, emitted_this_tick=1).to_dict()
+    assert d["emitted_this_tick"] == 1 and d["made_forward_progress"] is True
+
+
+# -- advance_orchestration populates the ground truth (reproduces the bug) ---- #
+@pytest.mark.asyncio
+async def test_fresh_decompose_reports_dispatch_despite_zero_aggregate(monkeypatch):
+    monkeypatch.setattr(mso, "master_enabled", lambda: True)
+    monkeypatch.setattr(mso, "_make_envelope_for_sub_goal",
+                        lambda s: types.SimpleNamespace(idempotency_key="k"))
+    monkeypatch.setattr(mso, "_mark_emitted_via_goal_decomposition",
+                        lambda **kw: None)
+    router = _OkRouter()
+    # completion_status empty -> the just-emitted READY sub-goal cannot show as
+    # EMITTED in this tick's aggregate (the structural lag this fix addresses).
+    report = await mso.advance_orchestration(
+        _plan(_sub("s1")), router=router, completion_status_override={},
+    )
+    assert len(router.ingested) == 1           # actually dispatched
+    assert report.emitted_count == 0           # aggregate lags (the trap)
+    assert report.emitted_this_tick == 1       # ground truth
+    assert report.made_forward_progress is True  # -> gate passes, no false-DLQ
+
+
+@pytest.mark.asyncio
+async def test_real_drop_is_loud_not_silent(monkeypatch, caplog):
+    monkeypatch.setattr(mso, "master_enabled", lambda: True)
+    monkeypatch.setattr(mso, "_make_envelope_for_sub_goal",
+                        lambda s: types.SimpleNamespace(idempotency_key="k"))
+    import logging
+    with caplog.at_level(logging.CRITICAL):
+        report = await mso.advance_orchestration(
+            _plan(_sub("s1")), router=_FailRouter(), completion_status_override={},
+        )
+    assert report.emitted_this_tick == 0
+    assert report.made_forward_progress is False    # a genuine drop
+    assert any("[SovereignPropagation] REAL DROP" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
**The convergence blocker, root-caused.** Live soak: every strategic GOAL → Advisor BLOCK → `decompose emitted 0 sub-goals → DLQ → advisor_blocked` loop (`ready=1 emitted=0 this_tick_emitted=1`). The DAG was never severed and binding never broke — the orchestrator's success gate read the **wrong counter**.

**Root cause:** `advance_orchestration` loads `completion_status` BEFORE emitting; `emitted_count` is aggregated via `compute_run_state` over that pre-emit ledger, so it **structurally reads 0 on a fresh decompose** even when `router.ingest` succeeded (`emitted_this_tick=1`). The I1 gate (`report.emitted_count >= 1`) false-negatived every first emit → wrongly DLQ'd a dispatched GOAL.

**Fix (root-cause, no object-rebinding, no duplicated ledger):**
- `OrchestrationReport` exposes `emitted_this_tick` (ground-truth dispatch count, already computed) + `made_forward_progress` (`emitted_count>=1 OR emitted_this_tick>=1`).
- I1 gate reads `made_forward_progress` → terminate `decomposed` when a sub-goal actually dispatched.
- **Zero-Drop:** a real drop (`to_emit` non-empty but `emitted_this_tick==0` → all ingests failed) emits a loud `[SovereignPropagation] REAL DROP` — never a silent ready-drop.

Opus review APPROVE (no Critical/Important): diagnosis confirmed exactly; genuine structural repair, not a relabel. Caveat: this unblocks the false-DLQ; full convergence still needs `router.ingest` to succeed on the node — and the new `REAL DROP` vs `dispatched_this_tick=N` telemetry disambiguates. 6 bridge tests (incl. the exact `emitted_count=0/emitted_this_tick=1` trap) + 101 governance regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the propagation bridge convergence bug by gating BLOCK→decompose on real forward progress using `emitted_this_tick`, not the lagging `emitted_count`. This prevents false DLQs on first dispatch and adds clear telemetry for real drops.

- **Bug Fixes**
  - Added `emitted_this_tick` and `made_forward_progress` to `OrchestrationReport`, and publish them in events.
  - I1 gate now uses `made_forward_progress` so a decompose succeeds when a sub-goal dispatched this tick.
  - Emit CRITICAL `[SovereignPropagation] REAL DROP` when ready sub-goals were selected but none dispatched.
  - Added focused tests, including the `emitted_count=0`/`emitted_this_tick=1` case and real-drop logging.

<sup>Written for commit 7657bd957759f153278d407c30c32c72ee7c5c01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69662?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

