### PR TITLE
fix(sentinel): harden boot handling — ignore boot noise + fatal-kill only a LIVE organism (incidents #1+#2)

### DIFF
--- a/scripts/sovereign_sentinel.py
+++ b/scripts/sovereign_sentinel.py
@@ -130,10 +130,61 @@ _DEFAULT_RULES: Tuple[Tuple[str, str, str, bool, bool, bool], ...] = (
     ("CONVERGENCE",     "=", r"ouroboros/review|orange PR|\bPR #\d+|Pull request.*creat|"
                              r"\[SOVEREIGN GRADUATION\]|gh pr create|state=APPROVE|APPROVED",
                                                                                           True,  False, True),
-    ("FATAL",           "X", r"Traceback \(most recent call last\)|FATAL|"
-                             r"session_outcome=incomplete_kill|Fatal Python error|"
-                             r"CRITICAL.*unhandled|panic:",                               False, True,  False),
+    # FATAL = genuine PROCESS/NODE death only. A bare ``Traceback`` or the word
+    # ``FATAL`` appears routinely in HEALTHY boots (retried imports, optional-dep
+    # probes, handled exceptions) -- matching them auto-killed a healthy booting
+    # node (incident #2). Require strong, unambiguous death markers; the loud
+    # ``[SovereignPropagation]``/``REAL DROP`` app signals are governance events,
+    # not node-fatals, so they are NOT here.
+    ("FATAL",           "X", r"Fatal Python error|session_outcome=incomplete_kill|"
+                             r"panic:|Segmentation fault|OOMKilled|Out of memory: Kill|"
+                             r"container .*(exited|died)|exited with code [1-9]|"
+                             r"systemd.*Failed with result",                             False, True,  False),
 )
+
+
+# Boot / transport NOISE -- ssh, docker-not-yet-installed, gcloud chatter. These
+# lines are NOT organism output: they must never arm "node live", be classified,
+# or trigger a kill. (incident #1: ``sudo: docker: command not found`` was read
+# as a "log line" and armed a false stall clock.)
+_BOOT_NOISE: Pattern[str] = re.compile(
+    r"command not found|Connection (refused|timed out|closed|reset)|"
+    r"Permission denied|Could not resolve|No route to host|Permanently added|"
+    r"Pseudo-terminal|Updating project ssh|Waiting for .*propagate|"
+    r"Cannot connect to the Docker daemon|Is the docker daemon running|"
+    r"No such container|kex_exchange|banner exchange|^ssh:|Warning: Permanently|"
+    r"WARNING: The|gnome-keyring|/usr/bin/python|Pulling from|Pull complete|"
+    r"Downloaded newer image|docker:|Unable to find image",
+    re.IGNORECASE,
+)
+# A REAL organism log line: the app logs ``LEVEL [Module] ...`` or a known FSM
+# marker. Only such a line confirms the node is genuinely live (and arms the
+# stall clock + enables fatal-kill). Anything before that is still booting.
+_ORGANISM_LINE: Pattern[str] = re.compile(
+    # The app logs ``LEVEL [Module] ...`` (bracketed module) -- require the ``[``
+    # so ssh's ``Warning: Permanently added ...`` (colon) is NOT mistaken for an
+    # organism WARNING. Plus the explicit FSM/subsystem markers.
+    r"^\s*(CRITICAL|ERROR|WARNING|INFO|DEBUG)\s+\[|\[A1Trace\]|\[Orchestrator\]|"
+    r"\[Chunking\]|\[SOVEREIGN|\[IntakeDLQ\]|Advisor BLOCK|GovernedLoop|"
+    r"Ouroboros|IntakeLayer|intake.router",
+    re.IGNORECASE,
+)
+
+
+def is_boot_noise(line: str) -> bool:
+    """True for ssh/docker/gcloud boot chatter that must be ignored entirely."""
+    try:
+        return bool(_BOOT_NOISE.search(line)) and not _ORGANISM_LINE.search(line)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def looks_live(line: str) -> bool:
+    """True iff the line is genuine organism output (node is actually up)."""
+    try:
+        return bool(_ORGANISM_LINE.search(line))
+    except Exception:  # noqa: BLE001
+        return False
 
 
 class EventMatcher:
@@ -408,10 +459,20 @@ class Sentinel:
                 line = await q.get()
                 if line is None:
                     break
+                # (1) Drop ssh/docker/gcloud boot chatter entirely -- it is not
+                #     organism output and must never arm clocks or trigger a kill.
+                if is_boot_noise(line):
+                    continue
                 now = time.monotonic()
+                # (2) Arm "node live" + the stall clock ONLY on a real organism
+                #     log line. Until then the node is still booting -- a stray
+                #     boot traceback must NOT be treated as a fatal (incident #2).
                 if self._first_line_at is None:
+                    if not looks_live(line):
+                        continue
                     self._first_line_at = now
-                    _log("first log line received -- node is live; stall clock armed.")
+                    _log("organism log line received -- node is LIVE; "
+                         "stall clock armed, fatal-detection enabled.")
                 ev = self._matcher.classify(line)
                 if ev is not None:
                     self.note(ev, now)
@@ -420,6 +481,9 @@ class Sentinel:
                         self.verdict = "converged"
                         _log("=== CONVERGENCE DETECTED (orange PR / graduation). "
                              "Leaving the node up for inspection; auto-kill stood down. ===")
+                    # Fatal-kill is reachable only AFTER the organism is live (the
+                    # gate above ``continue``s on boot lines), so a boot-phase
+                    # traceback can never trigger it.
                     if ev.is_fatal and self._cfg.kill_on_fatal and not self._converged:
                         await self._teardown_and_stop(f"fatal:{ev.kind}")
                         break

--- a/tests/governance/test_sovereign_sentinel.py
+++ b/tests/governance/test_sovereign_sentinel.py
@@ -44,12 +44,47 @@ def _cfg(**over):
     ("raised LocalEgressOverweightError attempted=900000", "EGRESS_BLOCK", False, False),
     ("[SOVEREIGN YIELD] op=x lineage=y stalled reduction", "SOVEREIGN_YIELD", False, False),
     ("created Pull request #69661 ouroboros/review/op-1", "CONVERGENCE", True, False),
-    ("Traceback (most recent call last):", "FATAL", False, True),
+    ("Fatal Python error: Segmentation fault", "FATAL", False, True),
 ])
 def test_classify(line, kind, success, fatal):
     ev = ss.EventMatcher().classify(line)
     assert ev is not None and ev.kind == kind
     assert ev.is_success is success and ev.is_fatal is fatal
+
+
+# -- Boot-handling hardening (incidents #1 sudo + #2 boot-traceback) --------- #
+def test_bare_traceback_is_not_fatal():
+    # A bare boot traceback must NOT classify as FATAL (it auto-killed a healthy
+    # booting node). Only strong death markers are fatal.
+    assert ss.EventMatcher().classify("Traceback (most recent call last):") is None
+    assert ss.EventMatcher().classify("some FATAL-sounding banner text") is None
+
+
+@pytest.mark.parametrize("line", [
+    "sudo: docker: command not found",
+    "ssh: connect to host 1.2.3.4 port 22: Connection refused",
+    "Cannot connect to the Docker daemon at unix:///var/run/docker.sock",
+    "Warning: Permanently added 'compute.123' to the list of known hosts.",
+])
+def test_boot_noise_is_ignored(line):
+    assert ss.is_boot_noise(line) is True
+    assert ss.looks_live(line) is False
+
+
+@pytest.mark.parametrize("line", [
+    "WARNING [A1Trace] accept op=op-1",
+    "CRITICAL [Chunking] decompose emitted 0 sub-goals",
+    "INFO [Orchestrator] Advisor BLOCKED",
+])
+def test_organism_lines_are_live_and_not_noise(line):
+    assert ss.looks_live(line) is True
+    assert ss.is_boot_noise(line) is False
+
+
+def test_strong_fatal_markers_still_fire():
+    for s in ("Fatal Python error: bus error", "container abc exited",
+              "OOMKilled", "exited with code 137"):
+        assert ss.EventMatcher().classify(s).is_fatal is True
 
 
 def test_classify_noise_returns_none():


### PR DESCRIPTION
The Sentinel false-killed TWO healthy *booting* nodes by trusting boot-phase noise as real signal — caught and proven false-positive by the Autopsy black box.

- **#1 (sudo):** bare `docker logs` returned `sudo: docker: command not found`; the watcher armed it as a 'live' log line → false 900s stall-kill. (sudo fix already landed.)
- **#2 (boot-traceback):** the FATAL regex matched a bare boot `Traceback (most recent call last):` (healthy boots log tracebacks routinely) → instant false fatal-kill.

**Hardening:** `_BOOT_NOISE` denylist drops ssh/docker/gcloud chatter; `_ORGANISM_LINE` gate arms 'node LIVE' + the stall clock ONLY on a real organism log line (`LEVEL [Module]` or an FSM marker); fatal-kill is reachable ONLY after the organism is live, and the FATAL regex is tightened to genuine death markers (Fatal Python error / OOMKilled / container exited / exit code [1-9] / segfault) — bare `Traceback`/`FATAL` dropped. Boot failures are caught by `boot_timeout`, not log-lines. 28 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardened Sentinel boot handling to ignore ssh/docker/gcloud boot noise and only enable stall/fatal logic after a real organism log line. Tightened fatal detection to genuine death signals to prevent false-kills of healthy booting nodes.

- **Bug Fixes**
  - Added `_BOOT_NOISE` filter to drop boot chatter (e.g., “command not found”, SSH warnings, docker daemon not running) so it never arms clocks or triggers kills.
  - Added `_ORGANISM_LINE` gate; node becomes “LIVE” only on real app logs (LEVEL [Module] or FSM markers). Stall clock and fatal-kill start only then.
  - Restricted `FATAL` matching to strong death markers (e.g., “Fatal Python error”, OOMKilled, container exited/died, non‑zero exit codes, segfault). Dropped bare “Traceback”/“FATAL”. Boot failures are handled by `boot_timeout`.
  - Tests cover ignored noise, live gating, bare-traceback not fatal, and strong fatal markers.

<sup>Written for commit 35529553be341106552b300e74f4179d2317daec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69663?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

