### PR TITLE
feat: Sovereign Temporal Breaker (perpetual-in_progress batch trap) + on-demand ignition (Spot preemption fix)

### DIFF
--- a/backend/core/gcp_vm_manager.py
+++ b/backend/core/gcp_vm_manager.py
@@ -6326,18 +6326,29 @@ class GCPVMManager:
         # Configure as Spot VM with Hard Duration Limit
         # This is the "Dead Man's Switch": GCP kills the VM after max_run_duration seconds
         # even if the local script crashes or loses connectivity.
+        # Lifetime cap (auto-delete) applies to BOTH provisioning models so a node
+        # never runs unbounded. Valid range 60s..604800s.
+        max_duration_seconds = int(self.config.max_vm_lifetime_hours * 3600)
+        max_duration_seconds = max(60, min(max_duration_seconds, 604800))
         if self.config.use_spot:
-            # Calculate duration in seconds (default 3 hours = 10800s)
-            max_duration_seconds = int(self.config.max_vm_lifetime_hours * 3600)
-            
-            # Ensure duration is valid (must be between 60s and 604800s for Spot)
-            max_duration_seconds = max(60, min(max_duration_seconds, 604800))
-            
             instance.scheduling = compute_v1.Scheduling(
                 preemptible=True,
                 on_host_maintenance="TERMINATE",
                 automatic_restart=False,
                 provisioning_model="SPOT",
+                instance_termination_action="DELETE",
+                max_run_duration=compute_v1.Duration(seconds=max_duration_seconds)
+            )
+        else:
+            # ON-DEMAND (STANDARD): no preemption -> an UNINTERRUPTED window for a
+            # deep convergence FSM (Spot was preempted ~33min into a soak). Keep the
+            # max_run_duration auto-delete so the node is still cost-bounded; live-
+            # migrate on host maintenance instead of terminating.
+            instance.scheduling = compute_v1.Scheduling(
+                preemptible=False,
+                on_host_maintenance="MIGRATE",
+                automatic_restart=True,
+                provisioning_model="STANDARD",
                 instance_termination_action="DELETE",
                 max_run_duration=compute_v1.Duration(seconds=max_duration_seconds)
             )

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1143,6 +1143,73 @@ class DoublewordInfraError(Exception):
         return self.status_code == 0
 
 
+class SovereignBatchTimeoutError(DoublewordInfraError):
+    """Sovereign Temporal Breaker — our OWN temporal boundary on a wedged batch.
+
+    A DW batch can return ``200 OK`` with ``status="in_progress"`` FOREVER (DW
+    accepts the batch but never finalizes it). The existing lane escalation is
+    ERROR-BOUND: it only fires when a poll RAISES ``DoublewordInfraError("Batch
+    retrieval failed")``. A perpetual ``in_progress`` never raises -> the FSM
+    waits forever (the node stalls). This error is raised by
+    ``_adaptive_poll_batch`` when a batch stays ``in_progress`` past
+    ``JARVIS_DW_BATCH_TIMEOUT_S`` so the lane-escalation predicate
+    (``dw_fault_taxonomy.is_batch_lane_retrieval_timeout`` Shape 1) catches it
+    and rotates the op off the wedged batch lane onto realtime.
+
+    The message MUST contain "Batch retrieval failed" (Shape 1 marker) and the
+    class subclasses ``DoublewordInfraError`` so the predicate's class-ancestry
+    walk recognises it. ``status_code=0`` -> non-HTTP (our-side temporal trip,
+    never trips a vendor breaker).
+    """
+
+    def __init__(
+        self,
+        elapsed_s: float = 0.0,
+        deadline_s: float = 0.0,
+        *,
+        model_id: str = "",
+    ) -> None:
+        super().__init__(
+            "Batch retrieval failed: sovereign temporal breaker "
+            "(in_progress exceeded JARVIS_DW_BATCH_TIMEOUT_S; "
+            f"elapsed={elapsed_s:.1f}s deadline={deadline_s:.1f}s)",
+            status_code=0,
+            model_id=model_id,
+        )
+        self.elapsed_s = elapsed_s
+        self.deadline_s = deadline_s
+
+
+def _dw_temporal_breaker_enabled() -> bool:
+    """Sovereign Temporal Breaker master gate. Default TRUE.
+
+    OFF -> exact legacy behavior (poll to ``_DW_MAX_WAIT_S``, byte-identical;
+    a perpetual in_progress falls through to the legacy timeout -> None).
+    NEVER raises (fail-soft -> enabled).
+    """
+    try:
+        return os.environ.get(
+            "JARVIS_DW_TEMPORAL_BREAKER_ENABLED", "true",
+        ).strip().lower() not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001 — fail-soft: default enabled
+        return True
+
+
+def _batch_temporal_deadline_s() -> float:
+    """TIGHTER, error-emitting temporal bound for an in_progress batch.
+
+    Reads ``JARVIS_DW_BATCH_TIMEOUT_S`` (Slice 43, default 300s) — the SAME
+    env the candidate_generator's OUTER GENERATE deadline derives from, so the
+    two stay coherent. This is a tighter inner bound than ``_DW_MAX_WAIT_S``
+    (the outer poll ceiling, which remains the legacy backstop). A bad/missing
+    env -> default; NEVER raises (fail-soft -> legacy default).
+    """
+    try:
+        return float(os.environ.get("JARVIS_DW_BATCH_TIMEOUT_S", "300"))
+    except Exception:  # noqa: BLE001 — fail-soft: default
+        return 300.0
+
+
 @dataclass
 class DoublewordStats:
     """Cumulative stats for observability (Pillar 7)."""
@@ -4707,6 +4774,19 @@ class DoublewordProvider:
         """
         deadline = time.monotonic() + _DW_MAX_WAIT_S
         attempt = 0
+        # Sovereign Temporal Breaker — wall-clock of batch poll initiation.
+        # The TIGHTER inner bound (_batch_temporal_deadline_s, default 300s
+        # from JARVIS_DW_BATCH_TIMEOUT_S) emits a DISCRETE error so the lane
+        # escalation catches it; the outer _DW_MAX_WAIT_S deadline above is
+        # the legacy backstop and is NOT removed. Resolved fail-soft.
+        try:
+            _batch_started = time.monotonic()
+            _temporal_breaker_on = _dw_temporal_breaker_enabled()
+            _temporal_deadline_s = _batch_temporal_deadline_s()
+        except Exception:  # noqa: BLE001 — fail-soft: legacy behavior
+            _batch_started = time.monotonic()
+            _temporal_breaker_on = False
+            _temporal_deadline_s = 0.0
 
         while time.monotonic() < deadline:
             # Slice 37 Phase 2 — per-iteration cleanup discipline.
@@ -4767,8 +4847,43 @@ class DoublewordProvider:
                             batch_id, status,
                         )
                         return None
+                    # Still in_progress — Sovereign Temporal Breaker check
+                    # BEFORE the adaptive backoff. A perpetual in_progress
+                    # never raises on its own, so we enforce our OWN temporal
+                    # boundary: past JARVIS_DW_BATCH_TIMEOUT_S -> raise a
+                    # DISCRETE SovereignBatchTimeoutError. It is re-raised by
+                    # the dedicated guard below (NOT swallowed by the generic
+                    # ``except Exception`` that continues the loop) so it
+                    # propagates up through poll_and_retrieve ->
+                    # _generate_via_batch -> candidate_generator where the
+                    # lane-escalation predicate runs.
+                    if _temporal_breaker_on:
+                        try:
+                            _elapsed = time.monotonic() - _batch_started
+                            _over_deadline = _elapsed > _temporal_deadline_s
+                        except Exception:  # noqa: BLE001 — fail-soft: legacy
+                            _over_deadline = False
+                        if _over_deadline:
+                            logger.error(
+                                "[DoublewordProvider] Batch %s sovereign "
+                                "temporal breaker tripped: in_progress "
+                                "elapsed=%.1fs > deadline=%.1fs "
+                                "(JARVIS_DW_BATCH_TIMEOUT_S)",
+                                batch_id, _elapsed, _temporal_deadline_s,
+                            )
+                            raise SovereignBatchTimeoutError(
+                                elapsed_s=_elapsed,
+                                deadline_s=_temporal_deadline_s,
+                                model_id=getattr(self, "_model", "") or "",
+                            )
                     # Still in_progress — adaptive backoff
             except asyncio.CancelledError:
+                raise
+            except SovereignBatchTimeoutError:
+                # Sovereign Temporal Breaker — re-raise like CancelledError so
+                # the discrete temporal-trip error ESCAPES the swallowing
+                # ``except Exception`` below (which would otherwise continue the
+                # poll loop and re-establish the perpetual-in_progress stall).
                 raise
             except Exception as exc:
                 _is_network = "connect" in str(exc).lower() or "timeout" in str(exc).lower()

--- a/backend/core/ouroboros/governance/dw_fault_taxonomy.py
+++ b/backend/core/ouroboros/governance/dw_fault_taxonomy.py
@@ -149,8 +149,13 @@ def _carries_batch_retrieval_timeout(exc: BaseException) -> bool:
     """
     try:
         # Shape 1: the bare DoublewordInfraError (or any exc whose own message is
-        # the batch-retrieval marker).
-        if type(exc).__name__ == "DoublewordInfraError":
+        # the batch-retrieval marker). Subclasses count too -- the Sovereign
+        # Temporal Breaker raises ``SovereignBatchTimeoutError`` (a
+        # ``DoublewordInfraError`` subclass) for a perpetual in_progress batch;
+        # walk the MRO class names so the breaker's discrete error is recognised
+        # WITHOUT importing the provider (this taxonomy stays dependency-free).
+        _mro_names = {c.__name__ for c in type(exc).__mro__}
+        if "DoublewordInfraError" in _mro_names:
             if _BATCH_RETRIEVAL_TIMEOUT_MARKER in str(exc).lower():
                 return True
         # Shape 2: the wrapped all_providers_exhausted RuntimeError. The wrapper's

--- a/scripts/ignite_sovereign_cloud_node.py
+++ b/scripts/ignite_sovereign_cloud_node.py
@@ -76,7 +76,11 @@ async def _ignite(args: argparse.Namespace) -> int:
     cfg.zone = args.zone
     cfg.region = args.zone.rsplit("-", 1)[0]
     cfg.machine_type = args.machine
-    cfg.use_spot = True
+    # ON-DEMAND by default: Spot instances have no guaranteed lifetime and were
+    # preempted ~33min into a convergence soak (before the FSM could play out the
+    # batch-wait + lane escalation). A deep, long-running convergence FSM needs an
+    # UNINTERRUPTED window. ``--spot`` opts back into the cheaper preemptible node.
+    cfg.use_spot = bool(getattr(args, "spot", False))
     cfg.use_golden_image = False
     cfg.use_container = False
     cfg.boot_disk_size_gb = args.disk_gb
@@ -84,7 +88,8 @@ async def _ignite(args: argparse.Namespace) -> int:
     cfg.startup_script_path = str(_STARTUP_SCRIPT)
 
     print("🐍 Sovereign Cloud Ignition")
-    print(f"   project={cfg.project_id} zone={cfg.zone} machine={cfg.machine_type} (SPOT)")
+    print(f"   project={cfg.project_id} zone={cfg.zone} machine={cfg.machine_type} "
+          f"({'SPOT' if cfg.use_spot else 'ON-DEMAND'})")
     print(f"   disk={cfg.boot_disk_size_gb}GB max_lifetime={cfg.max_vm_lifetime_hours}h")
     print(f"   pin={args.pin}   DW key={_mask(dw_key)}")
     print(f"   startup_script={_STARTUP_SCRIPT.name}")
@@ -185,6 +190,9 @@ def main() -> int:
                    help="arm the autonomic Sovereign Cognitive Graduation Crucible cadence")
     p.add_argument("--no-sentinel", action="store_true",
                    help="do NOT auto-spawn the Sovereign Telemetry Sentinel daemon")
+    p.add_argument("--spot", action="store_true",
+                   help="use a preemptible SPOT node (cheaper, no guaranteed lifetime); "
+                        "default is ON-DEMAND for uninterrupted convergence soaks")
     args = p.parse_args()
     if str(_REPO_ROOT) not in sys.path:
         sys.path.insert(0, str(_REPO_ROOT))

--- a/tests/governance/test_sovereign_temporal_breaker.py
+++ b/tests/governance/test_sovereign_temporal_breaker.py
@@ -1,0 +1,236 @@
+"""Sovereign Temporal Breaker — tests.
+
+A DW batch can return ``200 OK`` with ``status="in_progress"`` FOREVER (DW
+accepts the batch but never finalizes it). The existing lane escalation is
+ERROR-BOUND: it only fires when a poll *raises* ``DoublewordInfraError("Batch
+retrieval failed")``. A perpetual ``in_progress`` never raises -> the FSM waits
+forever (the node stalls). The Sovereign Temporal Breaker enforces our OWN
+temporal boundary: if a batch stays ``in_progress`` past
+``JARVIS_DW_BATCH_TIMEOUT_S`` it forcefully raises ``SovereignBatchTimeoutError``
+(a ``DoublewordInfraError`` whose message carries "Batch retrieval failed") so
+the lane-escalation predicate catches it and rotates the op off the wedged batch
+lane.
+
+Coverage:
+  (a) ``SovereignBatchTimeoutError`` IS a ``DoublewordInfraError`` AND
+      ``is_batch_lane_retrieval_timeout(SovereignBatchTimeoutError(), lane=
+      "batch")`` is True (the escalation trigger fires).
+  (b) the in_progress-past-deadline path raises it AND the raise is RE-RAISED
+      (not swallowed by the loop's ``except Exception``).
+  (c) ``JARVIS_DW_TEMPORAL_BREAKER_ENABLED=false`` -> no raise (legacy).
+  (d) under the deadline -> no raise.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import os
+from typing import Any, Dict, List, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.doubleword_provider import (
+    DoublewordInfraError,
+    DoublewordProvider,
+    SovereignBatchTimeoutError,
+    _batch_temporal_deadline_s,
+    _dw_temporal_breaker_enabled,
+)
+from backend.core.ouroboros.governance import dw_fault_taxonomy
+
+
+# ---------------------------------------------------------------------------
+# (a) Identity + taxonomy predicate
+# ---------------------------------------------------------------------------
+def test_sovereign_batch_timeout_is_doubleword_infra_error():
+    err = SovereignBatchTimeoutError()
+    assert isinstance(err, DoublewordInfraError)
+    # Message MUST carry the Shape-1 marker so the predicate matches.
+    assert "batch retrieval failed" in str(err).lower()
+    # status_code 0 -> non-HTTP (our-side temporal breaker).
+    assert err.status_code == 0
+
+
+def test_sovereign_batch_timeout_satisfies_lane_escalation_predicate():
+    err = SovereignBatchTimeoutError()
+    assert dw_fault_taxonomy.is_batch_lane_retrieval_timeout(err, lane="batch") is True
+    # A realtime-lane attempt must NEVER feed a batch-lane trip.
+    assert dw_fault_taxonomy.is_batch_lane_retrieval_timeout(err, lane="realtime") is False
+
+
+# ---------------------------------------------------------------------------
+# (b) propagation: the raise is RE-RAISED, not swallowed
+# ---------------------------------------------------------------------------
+def test_propagation_reraise_clause_exists_in_source():
+    """Structural proof: an ``except SovereignBatchTimeoutError: raise`` guard
+    exists in ``_adaptive_poll_batch`` so the temporal-breaker raise escapes the
+    swallowing ``except Exception`` that continues the poll loop."""
+    src = inspect.getsource(DoublewordProvider._adaptive_poll_batch)
+    assert "except SovereignBatchTimeoutError:" in src
+    # The CancelledError re-raise must still be present and the new guard must
+    # sit alongside it (both re-raise rather than continue the loop).
+    assert "except asyncio.CancelledError:" in src
+    # The breaker raise itself.
+    assert "raise SovereignBatchTimeoutError" in src
+
+
+class _FakeResp:
+    def __init__(self, status: int, payload: Dict[str, Any]):
+        self.status = status
+        self._payload = payload
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def json(self):
+        return self._payload
+
+
+class _FakeSession:
+    """Always returns 200 + ``in_progress`` -> the perpetual-stall scenario."""
+
+    def __init__(self):
+        self.calls = 0
+
+    def get(self, *a, **k):
+        self.calls += 1
+        return _FakeResp(200, {"status": "in_progress"})
+
+
+def _make_provider() -> DoublewordProvider:
+    prov = DoublewordProvider.__new__(DoublewordProvider)
+    # Minimal attribute surface used by _adaptive_poll_batch.
+    prov._base_url = "https://example.invalid/v1"
+    prov._rate_limiter = None
+    fake = _FakeSession()
+    prov._fake_session = fake
+
+    async def _get_session():
+        return fake
+
+    prov._get_session = _get_session  # type: ignore[assignment]
+    prov._request_timeout = lambda: 1.0  # type: ignore[assignment]
+    prov._next_poll_interval = lambda attempt: 0.0  # type: ignore[assignment]
+    return prov
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def test_in_progress_past_deadline_raises_and_propagates(monkeypatch):
+    """Drive a fake poll that returns ``in_progress`` forever; with a mocked
+    clock past the temporal deadline, ``_adaptive_poll_batch`` MUST raise
+    ``SovereignBatchTimeoutError`` (propagates out, not swallowed)."""
+    monkeypatch.setenv("JARVIS_DW_TEMPORAL_BREAKER_ENABLED", "true")
+    # Deadline of 0s -> any positive elapsed in the in_progress branch trips the
+    # breaker on the FIRST in_progress poll. Real wall clock, no clock mocking
+    # (the outer _DW_MAX_WAIT_S stays at its 3600s default, untouched, so the
+    # ONLY exit is the breaker raise -> proves it propagates, not the legacy
+    # timeout fall-through).
+    monkeypatch.setenv("JARVIS_DW_BATCH_TIMEOUT_S", "0")
+
+    import backend.core.ouroboros.governance.doubleword_provider as dwp
+
+    async def _nosleep(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(dwp.asyncio, "sleep", _nosleep)
+
+    prov = _make_provider()
+    with pytest.raises(SovereignBatchTimeoutError):
+        _run(prov._adaptive_poll_batch("batch-perpetual"))
+
+
+# ---------------------------------------------------------------------------
+# (c) gate OFF -> legacy (no raise)
+# ---------------------------------------------------------------------------
+def test_disabled_no_raise_legacy(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_TEMPORAL_BREAKER_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_DW_BATCH_TIMEOUT_S", "5")
+    assert _dw_temporal_breaker_enabled() is False
+
+    import backend.core.ouroboros.governance.doubleword_provider as dwp
+
+    # Outer _DW_MAX_WAIT_S deadline shrunk so the legacy loop terminates with
+    # None quickly instead of spinning to 3600s. We patch the module constant.
+    monkeypatch.setattr(dwp, "_DW_MAX_WAIT_S", 0.05)
+
+    async def _nosleep(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(dwp.asyncio, "sleep", _nosleep)
+
+    prov = _make_provider()
+    # Legacy: polls to _DW_MAX_WAIT_S and returns None (NO raise).
+    result = _run(prov._adaptive_poll_batch("batch-legacy"))
+    assert result is None
+
+
+# ---------------------------------------------------------------------------
+# (d) under the deadline -> no raise
+# ---------------------------------------------------------------------------
+def test_under_deadline_completes_no_raise(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_TEMPORAL_BREAKER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_BATCH_TIMEOUT_S", "300")
+
+    import backend.core.ouroboros.governance.doubleword_provider as dwp
+
+    async def _nosleep(*_a, **_k):
+        return None
+
+    monkeypatch.setattr(dwp.asyncio, "sleep", _nosleep)
+
+    # A session that reports in_progress ONCE then completes — well under 300s.
+    class _CompletingSession:
+        def __init__(self):
+            self.calls = 0
+
+        def get(self, *a, **k):
+            self.calls += 1
+            if self.calls >= 2:
+                return _FakeResp(200, {"status": "completed", "output_file_id": "out-123"})
+            return _FakeResp(200, {"status": "in_progress"})
+
+    prov = DoublewordProvider.__new__(DoublewordProvider)
+    prov._base_url = "https://example.invalid/v1"
+    prov._rate_limiter = None
+    sess = _CompletingSession()
+
+    async def _get_session():
+        return sess
+
+    prov._get_session = _get_session  # type: ignore[assignment]
+    prov._request_timeout = lambda: 1.0  # type: ignore[assignment]
+    prov._next_poll_interval = lambda attempt: 0.0  # type: ignore[assignment]
+
+    result = _run(prov._adaptive_poll_batch("batch-under"))
+    assert result == "out-123"
+
+
+# ---------------------------------------------------------------------------
+# helpers: env resolution
+# ---------------------------------------------------------------------------
+def test_temporal_deadline_reads_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_BATCH_TIMEOUT_S", "123")
+    assert _batch_temporal_deadline_s() == pytest.approx(123.0)
+
+
+def test_temporal_deadline_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_BATCH_TIMEOUT_S", raising=False)
+    assert _batch_temporal_deadline_s() == pytest.approx(300.0)
+
+
+def test_temporal_breaker_enabled_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_TEMPORAL_BREAKER_ENABLED", raising=False)
+    assert _dw_temporal_breaker_enabled() is True
+
+
+def test_temporal_deadline_failsoft_on_bad_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_BATCH_TIMEOUT_S", "not-a-number")
+    # Fail-soft: a bad env -> default, never raises.
+    assert _batch_temporal_deadline_s() == pytest.approx(300.0)


### PR DESCRIPTION
Two fixes from the live-soak autopsy (a Spot-preempted node + the silent batch trap it would have hit).

**Part 1 — Sovereign Temporal Breaker.** The lane escalation (prior arc) is ERROR-bound, but a DW batch can return `200 OK status=in_progress` FOREVER (DW never finalizes it) and never *raises* — so the FSM silently waits. Now `_adaptive_poll_batch` enforces our OWN temporal boundary: in_progress past `JARVIS_DW_BATCH_TIMEOUT_S` (300s) raises a discrete `SovereignBatchTimeoutError` (subclass of `DoublewordInfraError`, message "Batch retrieval failed"). Re-raised via a dedicated `except SovereignBatchTimeoutError: raise` placed BEFORE the swallowing `except Exception` (verified ordering) so it propagates to candidate_generator, where `is_batch_lane_retrieval_timeout` (Shape-1 broadened to an MRO class-name walk so the subclass is caught) fires -> trips the breaker -> rotates to realtime -> `[SOVEREIGN YIELD: LANE COLLAPSE]`. Gated `JARVIS_DW_TEMPORAL_BREAKER_ENABLED` (default true); OFF byte-identical; `_DW_MAX_WAIT_S` retained as the outer backstop. 10 tests + end-to-end predicate proof.

**Part 2 — On-demand ignition.** A Spot node was preempted ~33min into a convergence soak (caught by the Autopsy's `instance not found`). `gcp_vm_manager` scheduling now honors `use_spot=False` with an explicit STANDARD/on-demand branch (preemptible=False, MIGRATE) that KEEPS the `max_run_duration` auto-delete lifetime cap (cost-bounded). `ignite_sovereign_cloud_node` defaults to ON-DEMAND (`--spot` opts back in) for an uninterrupted convergence window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents infinite waits on DW batch polling by enforcing a strict timeout that triggers lane rotation, and defaults cloud ignition to on-demand to avoid Spot preemption while keeping the lifetime auto-delete cap.

- New Features
  - Sovereign Temporal Breaker: `_adaptive_poll_batch` raises `SovereignBatchTimeoutError` when `status=in_progress` exceeds `JARVIS_DW_BATCH_TIMEOUT_S` (default 300s). Gated by `JARVIS_DW_TEMPORAL_BREAKER_ENABLED` (default true), propagates to lane escalation via taxonomy update. Legacy `_DW_MAX_WAIT_S` remains as the outer backstop. Tests added.
  - On-demand ignition: `backend/core/gcp_vm_manager.py` now applies STANDARD scheduling when `use_spot=False` (`preemptible=False`, `on_host_maintenance="MIGRATE"`, `max_run_duration` retained). `scripts/ignite_sovereign_cloud_node.py` defaults to ON-DEMAND; `--spot` opts back into Spot and prints the chosen mode.

<sup>Written for commit 7ecbe8621e292c752fbae5e7b317fdbf2bc78652. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69666?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

