### PR TITLE
fix(gcp): soak create path honors use_spot (preemption recurrence fix)

### DIFF
--- a/backend/core/gcp_vm_manager.py
+++ b/backend/core/gcp_vm_manager.py
@@ -10588,7 +10588,34 @@ fi
                 metadata_items.append(compute_v1.Items(key="startup-script", value=startup_script))
                 logger.info("   📜 Standard startup script attached (expected: ~10-15min)")
 
-            # Build instance with STOP termination (Invincible Node)
+            # Scheduling honors use_spot. SPOT = invincible (survive preemption via
+            # STOP). ON-DEMAND (use_spot=False) = STANDARD provisioning, NO preemption
+            # -> an UNINTERRUPTED window for a deep convergence FSM (a Spot node was
+            # `compute.instances.preempted` ~17min into a soak because THIS create path
+            # hardcoded SPOT regardless of use_spot). On-demand keeps a max_run_duration
+            # auto-delete so it stays cost-bounded.
+            if self.config.use_spot:
+                _soak_sched = compute_v1.Scheduling(
+                    preemptible=True,
+                    on_host_maintenance="TERMINATE",
+                    automatic_restart=False,
+                    provisioning_model="SPOT",
+                    instance_termination_action="STOP",  # INVINCIBLE: Survive preemption
+                )
+                _vm_class = "invincible"
+            else:
+                _ondemand_secs = max(60, min(int(self.config.max_vm_lifetime_hours * 3600), 604800))
+                _soak_sched = compute_v1.Scheduling(
+                    preemptible=False,
+                    on_host_maintenance="MIGRATE",
+                    automatic_restart=True,
+                    provisioning_model="STANDARD",
+                    instance_termination_action="DELETE",
+                    max_run_duration=compute_v1.Duration(seconds=_ondemand_secs),
+                )
+                _vm_class = "on-demand"
+
+            # Build instance (scheduling per use_spot)
             instance = compute_v1.Instance(
                 name=instance_name,
                 machine_type=machine_type_url,
@@ -10600,16 +10627,10 @@ fi
                 labels={
                     "created-by": "jarvis",
                     "type": "prime-node",
-                    "vm-class": "invincible",
+                    "vm-class": _vm_class,
                     "deployment-mode": deployment_mode.replace("-", "_"),
                 },
-                scheduling=compute_v1.Scheduling(
-                    preemptible=True,
-                    on_host_maintenance="TERMINATE",
-                    automatic_restart=False,
-                    provisioning_model="SPOT",
-                    instance_termination_action="STOP",  # INVINCIBLE: Survive preemption
-                ),
+                scheduling=_soak_sched,
             )
 
             # Create the VM


### PR DESCRIPTION
The on-demand fix only patched site 1; start_soak_vm uses a second create path that hardcoded SPOT -> the node was preempted ~17min in (GCP ops log: compute.instances.preempted by system). Both scheduling sites now branch on use_spot. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the soak VM create path to honor use_spot. On-demand soaks now run on STANDARD VMs (no preemption) with an auto-delete window to avoid mid-run interruptions.

- **Bug Fixes**
  - Updated the start_soak_vm create path to branch on use_spot instead of hardcoding SPOT.
  - ON-DEMAND: preemptible=False, MIGRATE, automatic_restart=True, provisioning_model=STANDARD, instance_termination_action=DELETE, max_run_duration from max_vm_lifetime_hours.
  - SPOT: unchanged “invincible” behavior (preemptible with STOP termination); vm-class label now reflects mode.

<sup>Written for commit 8377afe2f72e3507c0283f1324ebf7253160d175. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69669?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

