### PR TITLE
fix(gcp): stop start_soak_vm forcing use_spot=True (preemption root cause)

### DIFF
--- a/backend/core/gcp_vm_manager.py
+++ b/backend/core/gcp_vm_manager.py
@@ -4681,7 +4681,11 @@ class GCPVMManager:
         # Soak runs the script, never a golden image / container offload server.
         self.config.use_golden_image = False
         self.config.use_container = False
-        self.config.use_spot = True
+        # NOTE: do NOT force use_spot here -- it was overriding the caller's intent
+        # (the ignition sets use_spot=False for an uninterrupted ON-DEMAND soak), which
+        # is why "ON-DEMAND"-labelled nodes were still created preemptible and got
+        # compute.instances.preempted mid-soak. Honor the config; the field's
+        # default_factory (GCP_USE_SPOT_VMS, default true) preserves the legacy default.
 
         name = vm_name or f"jarvis-ouroboros-soak-{datetime.now().strftime('%Y%m%d-%H%M%S')}"
         try:


### PR DESCRIPTION
Line 4684 force-reset use_spot=True regardless of the ignition's ON-DEMAND intent, downstream-overriding both scheduling fixes. Removed it. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the forced `use_spot=True` in `start_soak_vm` so the caller’s `use_spot` setting is honored; ON-DEMAND soaks now launch as non-preemptible as intended. Fixes unexpected mid-soak preemptions on ON-DEMAND nodes.

<sup>Written for commit 2c18075d62b368772908ba3362e8de7b6e05411c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69670?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

