### PR TITLE
feat: Autonomous Provider Quarantine Matrix — gradient-deduced DW outage -> Cryo-DLQ (kills the immortal hops=77 spin)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -67,6 +67,16 @@ from backend.core.ouroboros.governance.op_context import (
 from backend.core.ouroboros.governance.dw_latency_tracker import (
     DwLatencyTracker,
 )
+# Task T2 -- Autonomous Provider Quarantine Matrix. Top import is cycle-safe:
+# provider_quarantine top-level imports only stdlib and lazy-imports its
+# downstream deps (convergence_watchdog, intake_dlq), so it never re-enters
+# candidate_generator at module-import time. Verified via
+# `python3 -c "import ...candidate_generator"`.
+from backend.core.ouroboros.governance.provider_quarantine import (
+    get_provider_health_gradient,
+    quarantine_enabled,
+    quarantine_op,
+)
 
 # LR3 terminal sentinel: the Information-Gain Governor's deadlock-override
 # failure (raised inside the Venom tool loop). It MUST propagate through every
@@ -4208,6 +4218,18 @@ class CandidateGenerator:
                 # Lane: "batch" if force-batch was armed (_s182_fb_token set), else "realtime".
                 _a3_success_lane = "batch" if _s182_fb_token is not None else "realtime"
                 _breaker_record_outcome(_a3_success_lane, ok=True, failure_mode=None)
+                # Task T2 -- provider health gradient RECOVERY. A real DW
+                # candidate returned, so the per-route success window records a
+                # success: this autonomously CLEARS a previously-deduced global
+                # outage (is_global_outage flips False once one True lands in a
+                # full all-False window). Fail-soft: gradient errors never
+                # perturb the success return.
+                try:
+                    get_provider_health_gradient().record_sweep(
+                        provider_route, success=True,
+                    )
+                except Exception:  # noqa: BLE001 -- gradient is advisory, never blocks
+                    pass
                 return _attempt_result
 
             if _attempt_exc is not None:
@@ -4572,6 +4594,18 @@ class CandidateGenerator:
             ", ".join(attempts),
             fallback_tolerance, op_id_short, last_failure or "none",
         )
+        # Task T2 -- provider health gradient FAILURE record. Every ranked DW
+        # model failed for this route: that is ONE failed dispatch sweep. The
+        # gradient DEDUCES a global outage from the RATE of these sweeps over a
+        # bounded rolling window (NOT a hops count) -- a full all-False window
+        # trips is_global_outage, consumed at the immortal re-queue intercept
+        # below. Fail-soft: gradient errors never perturb the dispatch path.
+        try:
+            get_provider_health_gradient().record_sweep(
+                provider_route, success=False,
+            )
+        except Exception:  # noqa: BLE001 -- gradient is advisory, never blocks
+            pass
         if fallback_tolerance == "queue":
             # Defect #5 fix (2026-05-03) — Read-only cascade reflex.
             # Soak v5 (bt-2026-05-03-060330) had 17/19 BG ops terminal-
@@ -4736,6 +4770,72 @@ class CandidateGenerator:
             # a capped attempt count. A transient TOTAL DW outage is survived (the warm-boot
             # + intra-DW failover route the recovered attempt to batch); a permanently-dead
             # DW still fails — but only after exhausting the queue budget, never instantly.
+            # Task T2 -- UPSTREAM QUARANTINE intercept (the keystone). BEFORE the
+            # immortal re-queue: if the provider health gradient has DEDUCED a
+            # global DW outage (full rolling window of all-failed sweeps for this
+            # route -- a RATE, never a hops count), the immortal queue would
+            # otherwise re-queue this op forever (observed dilation hops=77,
+            # hammering a degraded upstream). Instead, terminally seal the op in
+            # the Cryo-DLQ via [SOVEREIGN YIELD: UPSTREAM QUARANTINE] and raise a
+            # terminal error -- the op is NOT lost (it is replayable from the DLQ).
+            # A TRANSIENT failure (window not yet all-False) leaves is_global_outage
+            # False, so the EXISTING immortal retry below runs unchanged.
+            #
+            # Fail-soft ABSOLUTE: any gradient/quarantine error -> fall through to
+            # the legacy immortal path (the I1 op-never-lost guarantee holds). When
+            # quarantine_enabled() is false the whole block is skipped -> the legacy
+            # immortal loop is byte-identical.
+            try:
+                if quarantine_enabled() and get_provider_health_gradient().is_global_outage(
+                    provider_route
+                ):
+                    try:
+                        from backend.core.ouroboros.governance.convergence_watchdog import (  # noqa: PLC0415
+                            get_lane_dilation_tracker as _q_get_dt,
+                        )
+                        _q_hops = _q_get_dt().hops(
+                            getattr(context, "op_id", "") or "",
+                        )
+                    except Exception:  # noqa: BLE001 -- telemetry best-effort
+                        _q_hops = -1
+                    _q_telemetry = {
+                        "route": provider_route,
+                        "fleet_exhausted": True,
+                        "fleet_size": len(ranked_models),
+                        "lanes": "batch+realtime",
+                        "failure_mode": "TIMEOUT",
+                        "dilation_hops": _q_hops,
+                        "last_failure": (last_failure or "all_models_open")[:120],
+                    }
+                    if quarantine_op(
+                        context, route=provider_route, telemetry=_q_telemetry,
+                    ):
+                        # Global outage DEDUCED -> terminal Cryo-DLQ seal. Do NOT
+                        # immortal re-queue. The op is sealed (replayable), not lost.
+                        logger.warning(
+                            "[CandidateGenerator] UPSTREAM QUARANTINE: route=%s "
+                            "global DW outage deduced (full-window all-failure) -- "
+                            "op sealed in Cryo-DLQ, immortal re-queue SKIPPED "
+                            "(op=%s, hops=%s)",
+                            provider_route, op_id_short, _q_hops,
+                        )
+                        raise RuntimeError(
+                            "upstream_quarantine:dw_global_outage"
+                        )
+                    # quarantine_op returned False (DLQ seal failed) -> fall through
+                    # to the legacy immortal path so the op is never lost.
+            except RuntimeError as _q_terminal:
+                # The terminal quarantine signal must propagate (it is the op's
+                # terminal outcome -- sealed in the DLQ, handled by the caller as a
+                # generation failure, NOT a silent drop). Only re-raise OUR
+                # sentinel; any other RuntimeError is unexpected and falls through.
+                if str(_q_terminal).startswith("upstream_quarantine:"):
+                    raise
+            except Exception:  # noqa: BLE001 -- quarantine must never itself break the op
+                logger.debug(
+                    "[CandidateGenerator] UPSTREAM QUARANTINE intercept fail-soft "
+                    "-> legacy immortal path", exc_info=True,
+                )
             try:
                 from backend.core.ouroboros.governance.dw_immortal import (
                     immortal_should_retry as _imm_should_retry,

--- a/backend/core/ouroboros/governance/provider_quarantine.py
+++ b/backend/core/ouroboros/governance/provider_quarantine.py
@@ -1,0 +1,252 @@
+"""provider_quarantine.py — Rolling success-rate gradient + UPSTREAM QUARANTINE action.
+
+Task T1 of the Autonomous Provider Quarantine Matrix.
+
+When the DW provider enters a GLOBAL outage (every model timing out, both
+transport lanes collapsed), the immortal queue would otherwise re-queue the op
+forever (observed: dilation hops=77, hammering a degraded upstream).
+
+This module supplies the pure ``degradation gradient``: it DEDUCES a global
+outage from the FAILURE RATE over a rolling bounded window — NOT a hardcoded
+retry count — and seals the op via [SOVEREIGN YIELD: UPSTREAM QUARANTINE] +
+Cryo-DLQ.
+
+Public API
+----------
+JARVIS_QUARANTINE_WINDOW (env, default 5)
+    Size of the per-route rolling window.  Mirrors JARVIS_WATCHDOG_TRACKER_SIZE
+    / JARVIS_RECURSION_LEDGER_SIZE discipline: env-tunable, never hardcoded.
+
+JARVIS_PROVIDER_QUARANTINE_ENABLED (env, default "true")
+    Master kill-switch.  When false, quarantine_op is a no-op that returns
+    False so the caller falls back to legacy immortal-queue behaviour.
+
+class ProviderHealthGradient
+    Per-route bounded deque of boolean sweep outcomes.  Mirrors the
+    AttemptLedger (recursion_dedup.py) + ReductionTracker (convergence_watchdog.py)
+    bounded-deque/singleton pattern; no novel persistent store.
+
+    record_sweep(route, *, success) -> None
+    success_rate(route) -> float
+    is_global_outage(route) -> bool
+    reset(route) -> None
+
+get_provider_health_gradient() -> ProviderHealthGradient
+    Process-global singleton.
+
+quarantine_enabled() -> bool
+
+quarantine_op(ctx, *, route, telemetry) -> bool
+    Terminal quarantine action.  Fail-soft: returns True if sealed, False on
+    any error (caller falls back to legacy immortal queue).
+    Lazy-imports convergence_watchdog and intake_dlq to avoid import cycles.
+"""
+from __future__ import annotations
+
+import collections
+import logging
+import os
+from typing import Any, Callable, Dict
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Env-driven configuration
+# ---------------------------------------------------------------------------
+
+_ENV_WINDOW = "JARVIS_QUARANTINE_WINDOW"
+_ENV_ENABLED = "JARVIS_PROVIDER_QUARANTINE_ENABLED"
+
+_DEFAULT_WINDOW = 5
+
+
+def _window_size() -> int:
+    """Return the rolling window size from env (default 5). Clamped to >= 1."""
+    try:
+        return max(1, int(os.environ.get(_ENV_WINDOW, _DEFAULT_WINDOW)))
+    except (ValueError, TypeError):
+        return _DEFAULT_WINDOW
+
+
+def quarantine_enabled() -> bool:
+    """Return True unless JARVIS_PROVIDER_QUARANTINE_ENABLED is explicitly falsy."""
+    val = os.environ.get(_ENV_ENABLED, "true").strip().lower()
+    return val not in ("false", "0", "no", "off")
+
+
+# ---------------------------------------------------------------------------
+# ProviderHealthGradient — bounded per-route rolling success window
+# ---------------------------------------------------------------------------
+
+class ProviderHealthGradient:
+    """Tracks per-route dispatch sweep outcomes in a bounded deque.
+
+    The outage trigger is a RATE (velocity/gradient) over a rolling window —
+    never a hardcoded retry count.  An outage is declared only when:
+      1. The window is FULL (>= maxlen samples), AND
+      2. success_rate == 0.0 (absolute zero across a full programmatic sweep).
+
+    The maxlen is read from JARVIS_QUARANTINE_WINDOW at instantiation time
+    (mirrors recursion_dedup.AttemptLedger and convergence_watchdog.ReductionTracker).
+    """
+
+    def __init__(self) -> None:
+        # Dict[route, deque[bool]] — each deque is bounded to _window_size().
+        # Window size is read lazily per-route on first record so env changes
+        # made between module import and first use are honoured (mirrors the
+        # pattern where env-driven configuration is not baked in at import time).
+        self._windows: Dict[str, collections.deque] = {}
+
+    def _get_window(self, route: str) -> collections.deque:
+        """Return (creating if needed) the bounded deque for *route*.
+
+        The maxlen is resolved from the env at first-use time for the route
+        so that JARVIS_QUARANTINE_WINDOW set after module import is honoured.
+        """
+        if route not in self._windows:
+            self._windows[route] = collections.deque(maxlen=_window_size())
+        return self._windows[route]
+
+    def record_sweep(self, route: str, *, success: bool) -> None:
+        """Push one sweep outcome into the route window. Fail-soft."""
+        try:
+            self._get_window(route).append(bool(success))
+        except Exception:  # pragma: no cover
+            logger.debug("[ProviderQuarantine] record_sweep fail-soft", exc_info=True)
+
+    def success_rate(self, route: str) -> float:
+        """Return the fraction of True entries in the window (0.0..1.0).
+
+        Empty window -> 1.0 (assume healthy until proven otherwise).
+        Fail-soft: any exception returns 1.0.
+        """
+        try:
+            dq = self._get_window(route)
+            if not dq:
+                return 1.0
+            return sum(1 for v in dq if v) / len(dq)
+        except Exception:  # pragma: no cover
+            logger.debug("[ProviderQuarantine] success_rate fail-soft", exc_info=True)
+            return 1.0
+
+    def is_global_outage(self, route: str) -> bool:
+        """Return True iff the window is FULL AND success_rate == 0.0.
+
+        This is the velocity/gradient gate — NOT a hardcoded retry-N.
+        Fail-soft: any exception returns False.
+        """
+        try:
+            dq = self._get_window(route)
+            maxlen = dq.maxlen  # set at deque creation via _window_size()
+            if maxlen is None or len(dq) < maxlen:
+                # Window not yet full; not enough evidence to declare outage.
+                return False
+            return self.success_rate(route) == 0.0
+        except Exception:  # pragma: no cover
+            logger.debug(
+                "[ProviderQuarantine] is_global_outage fail-soft", exc_info=True
+            )
+            return False
+
+    def reset(self, route: str) -> None:
+        """Clear the window for *route*. Fail-soft."""
+        try:
+            if route in self._windows:
+                self._windows[route].clear()
+        except Exception:  # pragma: no cover
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Process-global singleton (mirrors get_reduction_tracker pattern)
+# ---------------------------------------------------------------------------
+
+_PROVIDER_HEALTH_GRADIENT_SINGLETON: ProviderHealthGradient | None = None
+
+
+def get_provider_health_gradient() -> ProviderHealthGradient:
+    """Return the process-global ProviderHealthGradient, creating on first use."""
+    global _PROVIDER_HEALTH_GRADIENT_SINGLETON
+    if _PROVIDER_HEALTH_GRADIENT_SINGLETON is None:
+        _PROVIDER_HEALTH_GRADIENT_SINGLETON = ProviderHealthGradient()
+    return _PROVIDER_HEALTH_GRADIENT_SINGLETON
+
+
+# ---------------------------------------------------------------------------
+# Lazy import helpers — avoid circular import cycles
+# ---------------------------------------------------------------------------
+
+def _import_emit_sovereign_yield() -> Callable:  # type: ignore[type-arg]
+    """Lazy import of emit_sovereign_yield from convergence_watchdog."""
+    from backend.core.ouroboros.governance.convergence_watchdog import (  # noqa: PLC0415
+        emit_sovereign_yield,
+    )
+    return emit_sovereign_yield
+
+
+def _import_append_dlq() -> Callable:  # type: ignore[type-arg]
+    """Lazy import of append_dlq from intake_dlq."""
+    from backend.core.ouroboros.governance.intake_dlq import (  # noqa: PLC0415
+        append_dlq,
+    )
+    return append_dlq
+
+
+# ---------------------------------------------------------------------------
+# quarantine_op — terminal quarantine action
+# ---------------------------------------------------------------------------
+
+def quarantine_op(ctx: Any, *, route: str, telemetry: dict) -> bool:
+    """Seal a context op into the Cryo-DLQ via [SOVEREIGN YIELD: UPSTREAM QUARANTINE].
+
+    Steps:
+      (a) emit_sovereign_yield — logs [SOVEREIGN YIELD: UPSTREAM QUARANTINE]
+      (b) append_dlq — persists to intake_dlq.jsonl with reason
+          "upstream_quarantine:dw_global_outage"
+
+    Returns True if both steps succeed, False on any error (never raises).
+    The caller falls back to legacy immortal-queue behaviour on False.
+
+    Lazy imports both callees to avoid import cycles.  All errors are caught
+    and logged at DEBUG; the function is fully fail-soft.
+    """
+    try:
+        op_id: str = getattr(ctx, "op_id", "") or ""
+
+        # (a) Emit sovereign yield telemetry.
+        try:
+            emit_fn = _import_emit_sovereign_yield()
+            emit_fn(
+                op_id,
+                lineage_id=op_id,
+                ratio=0.0,
+                consecutive_stalls=0,
+                parent_chars=0,
+                child_chars=0,
+                tier="provider",
+                reason="UPSTREAM_QUARANTINE",
+            )
+        except Exception:
+            logger.debug(
+                "[ProviderQuarantine] emit_sovereign_yield fail-soft", exc_info=True
+            )
+            # Non-fatal: continue to DLQ step.
+
+        # Attach telemetry to ctx best-effort so the DLQ envelope carries it.
+        try:
+            if hasattr(ctx, "dw_telemetry"):
+                ctx.dw_telemetry = telemetry
+        except Exception:  # pragma: no cover
+            pass
+
+        # (b) Append to Cryo-DLQ.
+        append_fn = _import_append_dlq()
+        append_fn(ctx, reason="upstream_quarantine:dw_global_outage")
+
+        return True
+
+    except Exception:
+        logger.debug(
+            "[ProviderQuarantine] quarantine_op fail-soft", exc_info=True
+        )
+        return False

--- a/backend/core/ouroboros/governance/provider_quarantine.py
+++ b/backend/core/ouroboros/governance/provider_quarantine.py
@@ -224,7 +224,10 @@ def quarantine_op(ctx: Any, *, route: str, telemetry: dict) -> bool:
                 parent_chars=0,
                 child_chars=0,
                 tier="provider",
-                reason="UPSTREAM_QUARANTINE",
+                # Space form so the emitted marker matches the documented/grepped
+                # [SOVEREIGN YIELD: UPSTREAM QUARANTINE] (parity with LANE COLLAPSE /
+                # UNRESOLVABLE PATH and the Sentinel/watcher patterns).
+                reason="UPSTREAM QUARANTINE",
             )
         except Exception:
             logger.debug(

--- a/docs/superpowers/specs/2026-06-22-autonomous-provider-quarantine.md
+++ b/docs/superpowers/specs/2026-06-22-autonomous-provider-quarantine.md
@@ -1,0 +1,48 @@
+# Autonomous Provider Quarantine Matrix — Design Spec
+
+> **Arc:** the live soak proved the full resilience stack fires, then localized the wall to DW throughput collapse — and exposed a pathological immortal-retry loop (`dilation hops=77`, hammering a degraded upstream). When a GLOBAL provider outage is deduced from the FAILURE-RATE GRADIENT (NOT a hardcoded retry count), the op must terminally quarantine into cold storage instead of spinning forever — a good DW citizen, and resumable when DW recovers.
+> **Date:** 2026-06-22. Branch `worktree-provider-quarantine`. Built into the existing immortal backstop seam.
+
+## 1. Diagnosis (reuse-first)
+- **Immortal re-queue seam:** `candidate_generator.py:~4750` — `if immortal_should_retry(...)` then recursive `_dispatch_via_sentinel(_immortal_attempt+1)` (the loop that spun to `hops=77`). The quarantine intercepts HERE, before the re-queue.
+- **Full-fleet-sweep signal:** `candidate_generator.py:~4563` ("exhausted all N DW models", `fallback_tolerance=="queue"`) = a single dispatch where every ranked model failed (success rate 0.0 across the fleet).
+- **Lane collapse:** `convergence_watchdog.LaneDilationTracker` (the `[SOVEREIGN YIELD: LANE COLLAPSE]` site) = both batch+realtime lanes TIMEOUT.
+- **Why a NEW rate signal is needed:** `topology_sentinel` weights `FSM_EXHAUSTED`/`GENERATION_TIMEOUT` at **0.0** (our-side faults) so DW timeouts never trip its breaker → models never go OPEN on this failure mode → its state cannot deduce this outage. So the gradient must track the DW-timeout-sweep outcomes directly.
+- **Cryo-DLQ:** `intake_dlq.append_dlq(envelope, reason=)` + `replay_dlq(path, ingest_fn)` (resume on recovery). Envelope serialized via `to_dict()`/dict.
+- **Yield:** `convergence_watchdog.emit_sovereign_yield(op_id, *, reason="UPSTREAM_QUARANTINE", ...)` (the `reason` kwarg already exists).
+
+## 2. Goals / Non-Goals
+**Goals.** (G1) Deduce a GLOBAL DW outage from the **failure-rate gradient** — NO hardcoded retry-count N. (G2) On a deduced outage, at the immortal re-queue seam, do NOT re-queue: emit terminal `[SOVEREIGN YIELD: UPSTREAM QUARANTINE]` + seal the op in the Cryo-DLQ with the DW timeout/latency telemetry. (G3) Resumable: the Cryo-DLQ replays flawlessly when DW recovers. (G4) Reuse the immortal seam, intake_dlq, emit_sovereign_yield — no parallel queue. (G5) Default-on, fail-soft, OFF byte-identical (legacy immortal loop).
+
+**Non-Goals.** No change to the per-op generation deadline / the lane escalation / the temporal breaker (all working). No new provider rotation. Not a hardcoded `hops > N` cap (explicitly rejected).
+
+## 3. Components
+### 3.1 `provider_quarantine.py` (new pure leaf — the degradation gradient)
+- `class ProviderHealthGradient`: a per-route **rolling success-rate window** (bounded deque of recent full-fleet-sweep outcomes, env `JARVIS_QUARANTINE_WINDOW` default 5; reuse the ReductionTracker/LaneDilationTracker bounded-deque+singleton pattern — justified: the existing trackers ignore weight-0.0 timeouts). `record_sweep(route, *, success: bool) -> None`; `success_rate(route) -> float`; `is_global_outage(route) -> bool` = window is FULL **and** `success_rate == 0.0` (absolute 0.0 across a full programmatic sweep — the user's threshold; the window is the velocity/gradient, NOT a retry count). Fail-soft.
+- `quarantine_enabled() -> bool` (`JARVIS_PROVIDER_QUARANTINE_ENABLED`, default **true**).
+- `get_provider_health_gradient()` singleton.
+- The gradient also RECOVERS: a single successful sweep pushes `success_rate > 0.0` → outage clears → new ops dispatch normally (autonomous un-quarantine; no manual reset).
+
+### 3.2 Quarantine action (`provider_quarantine.quarantine_op` or inline)
+`quarantine_op(ctx, *, route, telemetry: dict) -> None`: (a) `emit_sovereign_yield(op_id, reason="UPSTREAM_QUARANTINE", ...)` → logs `[SOVEREIGN YIELD: UPSTREAM QUARANTINE]` + SSE; (b) `append_dlq(ctx, reason="upstream_quarantine:dw_global_outage")` with the DW telemetry (fleet swept, lanes collapsed, last timeout mode, dilation hops) attached to the envelope for flawless resume. Fail-soft (any error → fall back to the legacy immortal path; the op is NEVER lost).
+
+### 3.3 Wiring into the immortal seam (`candidate_generator` ~4750)
+At the immortal re-queue decision: `record_sweep(route, success=False)` on a full-fleet exhaustion; then `if quarantine_enabled() and get_provider_health_gradient().is_global_outage(route): quarantine_op(ctx, route, telemetry); raise <terminal quarantine error>` (do NOT recurse into the immortal re-queue). Else → the existing immortal retry (unchanged). On a successful dispatch elsewhere, `record_sweep(route, success=True)` so the gradient recovers. Gated; OFF → exact legacy immortal loop.
+
+### 3.4 Resume on recovery
+The Cryo-DLQ is the existing `intake_dlq` (reason `upstream_quarantine`). `replay_dlq` re-ingests quarantined ops; trigger it on the next boot (existing DLQ-replay-on-boot) AND/OR when the gradient recovers (`success_rate > 0.0`). Reuse — no new store.
+
+## 4. Cross-cutting
+- **No hardcoded retry-N:** the trigger is `success_rate == 0.0 over a rolling window` (a rate/gradient), window size env-tunable; NOT a `hops > N` count. The dilation cap stays as-is (orthogonal).
+- **Fail-soft + OFF byte-identical:** any quarantine error → legacy immortal path; op never lost (the I1 guarantee). Default-on; OFF → unchanged.
+- **Good-citizen:** a quarantined op stops hammering DW (no immortal re-queue on a deduced outage) and is cold-stored for resume — exactly the DW-citizenship principle.
+- **Reuse-first:** immortal seam, intake_dlq, emit_sovereign_yield, the bounded-deque pattern. No parallel queue/loop.
+
+## 5. Tests
+- `ProviderHealthGradient`: window fills; `success_rate==0.0` over a full window → `is_global_outage` True; one success → rate>0 → outage clears (recovery); fail-soft. No hardcoded N (window env-tunable).
+- `quarantine_op`: emits `[SOVEREIGN YIELD: UPSTREAM QUARANTINE]` + appends to DLQ with telemetry; fail-soft.
+- Intercept: a deduced outage at the immortal seam → quarantine + terminal (NOT immortal re-queue); a transient (window not all-failed) → normal immortal retry; OFF byte-identical. Cryo-DLQ envelope is replay-shaped.
+- Static: a full-outage op terminally quarantines (no infinite immortal loop) + is resumable; OFF unchanged.
+
+## 6. Phasing
+1. `provider_quarantine.py` (gradient + quarantine action) + tests. 2. Wire into the immortal seam + the recovery record_sweep + tests. 3. Integration + final review (confirm: no immortal loop on outage; legacy byte-identical when off; the intercept is on the LIVE immortal path). Then (operator) a future soak when DW has recovered.

--- a/tests/governance/test_provider_quarantine.py
+++ b/tests/governance/test_provider_quarantine.py
@@ -228,7 +228,7 @@ def test_quarantine_op_calls_both_sides_and_returns_true():
     op_arg, tier_arg, reason_arg = emit_calls[0]
     assert op_arg == "op-test-001"
     assert tier_arg == "provider"
-    assert reason_arg == "UPSTREAM_QUARANTINE"
+    assert reason_arg == "UPSTREAM QUARANTINE"
     assert len(dlq_calls) == 1
     _, dlq_reason = dlq_calls[0]
     assert dlq_reason == "upstream_quarantine:dw_global_outage"

--- a/tests/governance/test_provider_quarantine.py
+++ b/tests/governance/test_provider_quarantine.py
@@ -1,0 +1,300 @@
+"""Tests for provider_quarantine.py — rolling success-rate gradient.
+
+All tests written FIRST (TDD RED phase) before any implementation exists.
+
+Covers:
+- Window fills, all False -> is_global_outage True
+- Window all False but not yet full -> False (need full window)
+- One True in window -> success_rate > 0 -> is_global_outage False (recovery)
+- Empty window -> rate 1.0, outage False
+- JARVIS_QUARANTINE_WINDOW=3 env-tunable (not hardcoded)
+- quarantine_enabled default true
+- quarantine_op with fake ctx + monkeypatched callees -> True + both called
+- quarantine_op fail-soft (raising append_dlq -> returns False, never raises)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers to ensure a clean singleton between tests
+# ---------------------------------------------------------------------------
+
+def _fresh_module() -> object:
+    """Import (or re-import) provider_quarantine with current env."""
+    # Remove cached module so env changes are picked up between tests.
+    for key in list(sys.modules.keys()):
+        if "provider_quarantine" in key:
+            del sys.modules[key]
+
+    import importlib
+    return importlib.import_module(
+        "backend.core.ouroboros.governance.provider_quarantine"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Empty window -> success_rate 1.0, is_global_outage False
+# ---------------------------------------------------------------------------
+
+def test_empty_window_rate_is_one_and_no_outage(monkeypatch):
+    """Empty window: assume healthy (rate=1.0, outage=False)."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    mod = _fresh_module()
+    g = mod.ProviderHealthGradient()
+    assert g.success_rate("STANDARD") == 1.0
+    assert g.is_global_outage("STANDARD") is False
+
+
+# ---------------------------------------------------------------------------
+# 2. Window all-False but not yet full -> is_global_outage False
+# ---------------------------------------------------------------------------
+
+def test_partial_window_all_failures_not_outage(monkeypatch):
+    """A partial window (< maxlen) of all failures is NOT yet an outage."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    mod = _fresh_module()
+    g = mod.ProviderHealthGradient()
+    route = "IMMEDIATE"
+    # Push 4 failures (one short of window=5)
+    for _ in range(4):
+        g.record_sweep(route, success=False)
+    assert g.success_rate(route) == 0.0
+    # Not an outage yet — window not full
+    assert g.is_global_outage(route) is False
+
+
+# ---------------------------------------------------------------------------
+# 3. Window fills then all-False -> is_global_outage True
+# ---------------------------------------------------------------------------
+
+def test_full_window_all_failures_is_outage(monkeypatch):
+    """Once the window is full and every entry is False, declare outage."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    mod = _fresh_module()
+    g = mod.ProviderHealthGradient()
+    route = "STANDARD"
+    for _ in range(5):
+        g.record_sweep(route, success=False)
+    assert g.success_rate(route) == 0.0
+    assert g.is_global_outage(route) is True
+
+
+# ---------------------------------------------------------------------------
+# 4. One True in full window -> success_rate > 0 -> is_global_outage False
+# ---------------------------------------------------------------------------
+
+def test_one_success_in_full_window_clears_outage(monkeypatch):
+    """A single success inside the window keeps success_rate > 0 -> no outage."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    mod = _fresh_module()
+    g = mod.ProviderHealthGradient()
+    route = "COMPLEX"
+    # 4 failures then one success
+    for _ in range(4):
+        g.record_sweep(route, success=False)
+    g.record_sweep(route, success=True)
+    assert g.success_rate(route) > 0.0
+    assert g.is_global_outage(route) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. JARVIS_QUARANTINE_WINDOW=3 is honoured (env-tunable)
+# ---------------------------------------------------------------------------
+
+def test_env_window_size_3_honoured(monkeypatch):
+    """JARVIS_QUARANTINE_WINDOW=3 -> outage after exactly 3 failures, not 5."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "3")
+    mod = _fresh_module()
+    g = mod.ProviderHealthGradient()
+    route = "BACKGROUND"
+    # 2 failures: not yet full (window=3)
+    g.record_sweep(route, success=False)
+    g.record_sweep(route, success=False)
+    assert g.is_global_outage(route) is False, "2/3 failures should not be outage"
+    # 3rd failure: window full + all false -> outage
+    g.record_sweep(route, success=False)
+    assert g.is_global_outage(route) is True
+
+
+# ---------------------------------------------------------------------------
+# 6. reset() clears the window
+# ---------------------------------------------------------------------------
+
+def test_reset_clears_window(monkeypatch):
+    """reset() must wipe the recorded window so the route starts fresh."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "3")
+    mod = _fresh_module()
+    g = mod.ProviderHealthGradient()
+    route = "STANDARD"
+    for _ in range(3):
+        g.record_sweep(route, success=False)
+    assert g.is_global_outage(route) is True
+    g.reset(route)
+    # After reset: empty window -> rate 1.0, no outage
+    assert g.success_rate(route) == 1.0
+    assert g.is_global_outage(route) is False
+
+
+# ---------------------------------------------------------------------------
+# 7. success_rate is accurate fraction
+# ---------------------------------------------------------------------------
+
+def test_success_rate_fraction(monkeypatch):
+    """success_rate returns the fraction of True values in the window."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "4")
+    mod = _fresh_module()
+    g = mod.ProviderHealthGradient()
+    route = "STANDARD"
+    g.record_sweep(route, success=True)
+    g.record_sweep(route, success=False)
+    g.record_sweep(route, success=True)
+    g.record_sweep(route, success=False)
+    # 2 out of 4 successes
+    assert g.success_rate(route) == pytest.approx(0.5)
+
+
+# ---------------------------------------------------------------------------
+# 8. quarantine_enabled default true
+# ---------------------------------------------------------------------------
+
+def test_quarantine_enabled_default_true(monkeypatch):
+    """JARVIS_PROVIDER_QUARANTINE_ENABLED defaults to true."""
+    monkeypatch.delenv("JARVIS_PROVIDER_QUARANTINE_ENABLED", raising=False)
+    mod = _fresh_module()
+    assert mod.quarantine_enabled() is True
+
+
+def test_quarantine_enabled_respects_false(monkeypatch):
+    """JARVIS_PROVIDER_QUARANTINE_ENABLED=false -> False."""
+    monkeypatch.setenv("JARVIS_PROVIDER_QUARANTINE_ENABLED", "false")
+    mod = _fresh_module()
+    assert mod.quarantine_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# 9. get_provider_health_gradient returns singleton
+# ---------------------------------------------------------------------------
+
+def test_get_provider_health_gradient_singleton():
+    """get_provider_health_gradient() must return the same object each call."""
+    mod = _fresh_module()
+    a = mod.get_provider_health_gradient()
+    b = mod.get_provider_health_gradient()
+    assert a is b
+
+
+# ---------------------------------------------------------------------------
+# 10. quarantine_op: returns True + calls emit_sovereign_yield + append_dlq
+# ---------------------------------------------------------------------------
+
+def test_quarantine_op_calls_both_sides_and_returns_true():
+    """quarantine_op must call emit_sovereign_yield and append_dlq, then return True."""
+    mod = _fresh_module()
+    ctx = SimpleNamespace(op_id="op-test-001")
+
+    emit_calls = []
+    dlq_calls = []
+
+    def fake_emit(op_id, *, lineage_id, ratio, consecutive_stalls,
+                  parent_chars, child_chars, tier, reason):
+        emit_calls.append((op_id, tier, reason))
+
+    def fake_append_dlq(envelope, *, reason, path=None):
+        dlq_calls.append((envelope, reason))
+
+    with (
+        mock.patch(
+            "backend.core.ouroboros.governance.provider_quarantine"
+            "._import_emit_sovereign_yield",
+            return_value=fake_emit,
+        ),
+        mock.patch(
+            "backend.core.ouroboros.governance.provider_quarantine"
+            "._import_append_dlq",
+            return_value=fake_append_dlq,
+        ),
+    ):
+        result = mod.quarantine_op(ctx, route="STANDARD", telemetry={"lane": "batch"})
+
+    assert result is True
+    assert len(emit_calls) == 1
+    op_arg, tier_arg, reason_arg = emit_calls[0]
+    assert op_arg == "op-test-001"
+    assert tier_arg == "provider"
+    assert reason_arg == "UPSTREAM_QUARANTINE"
+    assert len(dlq_calls) == 1
+    _, dlq_reason = dlq_calls[0]
+    assert dlq_reason == "upstream_quarantine:dw_global_outage"
+
+
+# ---------------------------------------------------------------------------
+# 11. quarantine_op fail-soft: raising append_dlq -> returns False, never raises
+# ---------------------------------------------------------------------------
+
+def test_quarantine_op_fail_soft_on_append_dlq_error():
+    """If append_dlq raises, quarantine_op must return False without raising."""
+    mod = _fresh_module()
+    ctx = SimpleNamespace(op_id="op-fail-002")
+
+    def fake_emit(op_id, *, lineage_id, ratio, consecutive_stalls,
+                  parent_chars, child_chars, tier, reason):
+        pass  # succeeds
+
+    def bad_append_dlq(envelope, *, reason, path=None):
+        raise RuntimeError("disk full")
+
+    with (
+        mock.patch(
+            "backend.core.ouroboros.governance.provider_quarantine"
+            "._import_emit_sovereign_yield",
+            return_value=fake_emit,
+        ),
+        mock.patch(
+            "backend.core.ouroboros.governance.provider_quarantine"
+            "._import_append_dlq",
+            return_value=bad_append_dlq,
+        ),
+    ):
+        result = mod.quarantine_op(ctx, route="STANDARD", telemetry={})
+
+    assert result is False
+
+
+# ---------------------------------------------------------------------------
+# 12. quarantine_op: ctx without op_id doesn't crash (fail-soft)
+# ---------------------------------------------------------------------------
+
+def test_quarantine_op_no_op_id_attr():
+    """quarantine_op is fail-soft even when ctx has no op_id."""
+    mod = _fresh_module()
+    ctx = SimpleNamespace()  # no op_id
+
+    def fake_emit(op_id, *, lineage_id, ratio, consecutive_stalls,
+                  parent_chars, child_chars, tier, reason):
+        pass
+
+    def fake_append_dlq(envelope, *, reason, path=None):
+        pass
+
+    with (
+        mock.patch(
+            "backend.core.ouroboros.governance.provider_quarantine"
+            "._import_emit_sovereign_yield",
+            return_value=fake_emit,
+        ),
+        mock.patch(
+            "backend.core.ouroboros.governance.provider_quarantine"
+            "._import_append_dlq",
+            return_value=fake_append_dlq,
+        ),
+    ):
+        result = mod.quarantine_op(ctx, route="BACKGROUND", telemetry={})
+
+    assert result is True

--- a/tests/governance/test_quarantine_wiring.py
+++ b/tests/governance/test_quarantine_wiring.py
@@ -1,0 +1,244 @@
+"""Task T2 -- UPSTREAM QUARANTINE wiring into the immortal re-queue seam.
+
+These tests prove the keystone: at the LIVE immortal re-queue decision in
+``candidate_generator._dispatch_via_sentinel``, a DEDUCED global DW outage
+(full rolling window of all-failed sweeps for a route) seals the op into the
+Cryo-DLQ and raises a TERMINAL ``upstream_quarantine:...`` error INSTEAD of
+recursing into the immortal queue forever (the observed dilation hops=77
+pathology). A transient failure (window not yet all-False) takes the EXISTING
+immortal retry unchanged. ``quarantine_enabled()`` false -> byte-identical legacy
+path. ``record_sweep(success=True)`` clears the deduced outage.
+
+The deep async dispatcher is hard to drive end-to-end, so the keystone-intercept
+test exercises the SAME decision logic the LIVE seam runs (the real gradient +
+real quarantine_op gate), and a structural test pins the intercept's placement
+relative to the live ``_dispatch_via_sentinel`` immortal recursion + the success/
+failure ``record_sweep`` sites.
+"""
+from __future__ import annotations
+
+import importlib
+import importlib.util
+import sys
+from types import SimpleNamespace
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _fresh_quarantine_module(monkeypatch):
+    """Re-import provider_quarantine with a clean singleton + current env."""
+    for key in list(sys.modules.keys()):
+        if "provider_quarantine" in key:
+            del sys.modules[key]
+    return importlib.import_module(
+        "backend.core.ouroboros.governance.provider_quarantine"
+    )
+
+
+def _seed_full_outage(gradient, route, window):
+    """Drive the gradient to a FULL all-failure window for *route*."""
+    for _ in range(window):
+        gradient.record_sweep(route, success=False)
+
+
+# ---------------------------------------------------------------------------
+# 1. LIVE-seam decision: full all-False window -> quarantine fires (terminal)
+# ---------------------------------------------------------------------------
+
+def test_full_window_outage_quarantines_terminal_no_recurse(monkeypatch):
+    """The intercept condition the live seam runs: with the REAL gradient seeded
+    to a full all-failure window, quarantine_enabled() True + is_global_outage
+    True -> quarantine_op is called and the seam raises the terminal
+    ``upstream_quarantine:`` error (it does NOT proceed to the immortal recurse).
+    """
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    monkeypatch.setenv("JARVIS_PROVIDER_QUARANTINE_ENABLED", "true")
+    mod = _fresh_quarantine_module(monkeypatch)
+
+    gradient = mod.get_provider_health_gradient()
+    gradient.reset("standard")
+    _seed_full_outage(gradient, "standard", 5)
+    assert gradient.is_global_outage("standard") is True
+
+    # Spy on quarantine_op so we don't touch the real DLQ file.
+    called = {"n": 0, "route": None, "telemetry": None}
+
+    def _fake_quarantine_op(ctx, *, route, telemetry):
+        called["n"] += 1
+        called["route"] = route
+        called["telemetry"] = telemetry
+        return True  # sealed in Cryo-DLQ
+
+    monkeypatch.setattr(mod, "quarantine_op", _fake_quarantine_op)
+
+    ctx = SimpleNamespace(op_id="op-deadbeef0001")
+
+    # Replicate the LIVE seam's intercept decision (candidate_generator
+    # _dispatch_via_sentinel, just before the immortal _imm_should_retry recurse).
+    recursed = {"n": 0}
+
+    def _run_seam():
+        if mod.quarantine_enabled() and gradient.is_global_outage("standard"):
+            _telemetry = {
+                "route": "standard", "fleet_exhausted": True,
+                "lanes": "batch+realtime", "failure_mode": "TIMEOUT",
+                "dilation_hops": -1,
+            }
+            if mod.quarantine_op(ctx, route="standard", telemetry=_telemetry):
+                raise RuntimeError("upstream_quarantine:dw_global_outage")
+        # legacy immortal path would recurse here
+        recursed["n"] += 1
+
+    with pytest.raises(RuntimeError) as exc:
+        _run_seam()
+
+    assert str(exc.value).startswith("upstream_quarantine:")
+    assert called["n"] == 1
+    assert called["route"] == "standard"
+    assert recursed["n"] == 0  # immortal recurse SKIPPED -- terminal, not re-queued
+
+
+# ---------------------------------------------------------------------------
+# 2. Transient (window not yet all-False) -> NO quarantine -> legacy retry
+# ---------------------------------------------------------------------------
+
+def test_transient_failure_no_quarantine_legacy_retry(monkeypatch):
+    """A transient failure (a full window that contains ANY success, or a
+    not-yet-full window) leaves is_global_outage False -> quarantine_op is NEVER
+    called and the legacy immortal retry path runs unchanged."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    monkeypatch.setenv("JARVIS_PROVIDER_QUARANTINE_ENABLED", "true")
+    mod = _fresh_quarantine_module(monkeypatch)
+
+    gradient = mod.get_provider_health_gradient()
+    gradient.reset("standard")
+    # 4 failures + 1 success in a window of 5 -> not all-False -> not an outage.
+    for _ in range(4):
+        gradient.record_sweep("standard", success=False)
+    gradient.record_sweep("standard", success=True)
+    assert gradient.is_global_outage("standard") is False
+
+    called = {"n": 0}
+    monkeypatch.setattr(
+        mod, "quarantine_op",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or True,
+    )
+
+    recursed = {"n": 0}
+
+    def _run_seam():
+        if mod.quarantine_enabled() and gradient.is_global_outage("standard"):
+            if mod.quarantine_op(SimpleNamespace(op_id="x"), route="standard",
+                                 telemetry={}):
+                raise RuntimeError("upstream_quarantine:dw_global_outage")
+        recursed["n"] += 1  # legacy immortal recurse
+
+    _run_seam()
+    assert called["n"] == 0      # quarantine never consulted/fired
+    assert recursed["n"] == 1    # legacy immortal path ran unchanged
+
+
+# ---------------------------------------------------------------------------
+# 3. quarantine_enabled() false -> byte-identical legacy path (no quarantine)
+# ---------------------------------------------------------------------------
+
+def test_disabled_is_byte_identical_legacy(monkeypatch):
+    """Master switch false -> the intercept is fully skipped even under a deduced
+    outage: the legacy immortal path runs and quarantine_op is never reached."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    monkeypatch.setenv("JARVIS_PROVIDER_QUARANTINE_ENABLED", "false")
+    mod = _fresh_quarantine_module(monkeypatch)
+
+    assert mod.quarantine_enabled() is False
+
+    gradient = mod.get_provider_health_gradient()
+    gradient.reset("standard")
+    _seed_full_outage(gradient, "standard", 5)
+    assert gradient.is_global_outage("standard") is True  # outage IS deduced...
+
+    called = {"n": 0}
+    monkeypatch.setattr(
+        mod, "quarantine_op",
+        lambda *a, **k: called.__setitem__("n", called["n"] + 1) or True,
+    )
+
+    recursed = {"n": 0}
+
+    def _run_seam():
+        # quarantine_enabled() short-circuits FIRST -> outage never consulted.
+        if mod.quarantine_enabled() and gradient.is_global_outage("standard"):
+            if mod.quarantine_op(SimpleNamespace(op_id="x"), route="standard",
+                                 telemetry={}):
+                raise RuntimeError("upstream_quarantine:dw_global_outage")
+        recursed["n"] += 1
+
+    _run_seam()
+    assert called["n"] == 0    # ...but quarantine NEVER fires (master off)
+    assert recursed["n"] == 1  # legacy immortal path ran -- byte-identical
+
+
+# ---------------------------------------------------------------------------
+# 4. record_sweep(success=True) clears a previously-deduced outage (recovery)
+# ---------------------------------------------------------------------------
+
+def test_success_sweep_clears_outage(monkeypatch):
+    """A recovery sweep (DW comes back) records success and flips
+    is_global_outage False -- the gradient recovers autonomously, so the NEXT
+    failed sweep starts a fresh window rather than re-triggering instantly."""
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    mod = _fresh_quarantine_module(monkeypatch)
+
+    gradient = mod.get_provider_health_gradient()
+    gradient.reset("complex")
+    _seed_full_outage(gradient, "complex", 5)
+    assert gradient.is_global_outage("complex") is True
+
+    # The success-return site records a success -> one True lands in the window.
+    gradient.record_sweep("complex", success=True)
+    assert gradient.is_global_outage("complex") is False
+
+
+# ---------------------------------------------------------------------------
+# 5. STRUCTURAL: the live seam wires the intercept BEFORE the immortal recurse
+#    + the success/failure record_sweep sites are present in the right order.
+# ---------------------------------------------------------------------------
+
+def test_live_seam_structurally_wired():
+    """Pin the LIVE seam in candidate_generator: the UPSTREAM QUARANTINE
+    intercept (is_global_outage + quarantine_op + the terminal raise) must
+    PRECEDE the immortal ``_dispatch_via_sentinel`` re-queue recursion, and the
+    failure ``record_sweep`` (full-fleet exhaustion) + success ``record_sweep``
+    sites must both exist."""
+    spec = importlib.util.find_spec(
+        "backend.core.ouroboros.governance.candidate_generator"
+    )
+    with open(spec.origin) as fh:
+        src = fh.read()
+
+    # The intercept symbols are present.
+    assert "is_global_outage(" in src
+    assert "quarantine_op(" in src
+    assert "quarantine_enabled()" in src
+    assert "upstream_quarantine:dw_global_outage" in src
+    assert "record_sweep(" in src
+
+    # The terminal raise precedes the immortal recursion.
+    i_raise = src.find('raise RuntimeError(\n                            "upstream_quarantine:dw_global_outage"')
+    if i_raise == -1:
+        i_raise = src.find("upstream_quarantine:dw_global_outage")
+    i_recurse = src.find("_immortal_attempt=_immortal_attempt + 1")
+    assert 0 < i_raise < i_recurse, (
+        "UPSTREAM QUARANTINE intercept must precede the immortal re-queue recurse"
+    )
+
+    # Both record_sweep outcome sites are wired.
+    assert "record_sweep(\n                provider_route, success=False" in src
+    assert "record_sweep(\n                        provider_route, success=True" in src
+
+
+if __name__ == "__main__":
+    raise SystemExit(pytest.main([__file__, "-v"]))


### PR DESCRIPTION
The live soak proved the full resilience stack fires, then localized the wall to DW throughput collapse — and exposed a pathological immortal-retry loop (`dilation hops=77`, hammering a degraded upstream forever).

**ProviderHealthGradient** (`provider_quarantine.py`): a per-route rolling success-rate window (env `JARVIS_QUARANTINE_WINDOW`, default 5 — a RATE/gradient, NOT a hardcoded retry-N). `is_global_outage` = window FULL **and** success_rate==0.0. Recovers autonomously: one successful sweep clears it.

**Quarantine action**: at the LIVE immortal re-queue seam (`_dispatch_via_sentinel`), a deduced global outage emits `[SOVEREIGN YIELD: UPSTREAM QUARANTINE]`, seals the op in the Cryo-DLQ (`intake_dlq`, with DW timeout telemetry, resumable via `replay_dlq`), and raises a terminal error **instead of** re-queuing — structurally killing the `hops=77` spin. `record_sweep(success=True/False)` at the dispatch success/full-exhaustion sites drive the gradient.

**Opus final review: CLEAN, no Critical.** Verified op-never-lost (every path → sealed+terminal OR legacy re-queue; sealed BEFORE the raise; the raise escapes the immortal `except` → orchestrator terminal), the loop is structurally broken, recovery route-key is consistent, no hardcoded N, OFF byte-identical, fail-soft. 18 tests. Good-citizen: a quarantined op stops hammering DW and cold-stores for resume when DW recovers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autonomous provider quarantine that detects DW global outages from a rolling per-route success-rate gradient and moves ops to Cryo-DLQ instead of re-queuing. This stops the immortal retry loop and keeps ops replayable when DW recovers.

- **New Features**
  - Introduced `ProviderHealthGradient` (singleton via `get_provider_health_gradient`) with `JARVIS_QUARANTINE_WINDOW` (default 5); outage when window is full and success rate is 0%.
  - Wired intercept in `candidate_generator._dispatch_via_sentinel`: when `quarantine_enabled()` and outage, call `quarantine_op` to emit `[SOVEREIGN YIELD: UPSTREAM QUARANTINE]`, seal to DLQ, and raise a terminal error instead of re-queueing.
  - Added `record_sweep(success=True|False)` at success and full-fleet-exhaustion sites so the gradient both detects outages and clears on recovery; transient failures keep the existing retry.
  - Config: `JARVIS_PROVIDER_QUARANTINE_ENABLED` toggles the feature; fail-soft fallback preserves legacy behavior if anything goes wrong.
  - Added docs and tests for the gradient, quarantine action, and wiring.

<sup>Written for commit f17b5ace64c34b52bb95622b13adfd93f563e7cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

