### PR TITLE
feat: Sovereign Provider Failover — Phase 1 (golden-image bake + outage ledger)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4230,6 +4230,25 @@ class CandidateGenerator:
                     )
                 except Exception:  # noqa: BLE001 -- gradient is advisory, never blocks
                     pass
+                # Phase 1 Outage Ledger -- record DW recovery for the forecaster
+                # + async Trinity export. Only runs if an outage was open (fail-soft).
+                try:
+                    from backend.core.ouroboros.governance.outage_ledger import (  # noqa: PLC0415
+                        get_outage_ledger as _ol_get,
+                        emit_outage_event as _ol_emit,
+                    )
+                    _ol_ledger = _ol_get()
+                    if _ol_ledger.has_open_outage():
+                        _ol_recent = _ol_ledger.recent(1)
+                        if _ol_recent:
+                            _ol_open = _ol_recent[-1]
+                            if _ol_open.ended_ts is None:
+                                _ol_ledger.close_outage(_ol_open.outage_id)
+                                _ol_closed = _ol_ledger.recent(1)
+                                if _ol_closed:
+                                    _ol_emit("DW_OUTAGE_RECOVERED", _ol_closed[-1])
+                except Exception:  # noqa: BLE001 -- outage ledger never blocks the op
+                    pass
                 return _attempt_result
 
             if _attempt_exc is not None:
@@ -4810,6 +4829,29 @@ class CandidateGenerator:
                     if quarantine_op(
                         context, route=provider_route, telemetry=_q_telemetry,
                     ):
+                        # Phase 1 Outage Ledger -- record DW global outage for the
+                        # recovery forecaster + async Trinity export (fail-soft).
+                        try:
+                            from backend.core.ouroboros.governance.outage_ledger import (  # noqa: PLC0415
+                                get_outage_ledger,
+                                emit_outage_event,
+                            )
+                            _ol_rec_id = get_outage_ledger().open_outage(
+                                failure_mode=_q_telemetry.get("failure_mode", "TIMEOUT"),
+                                error_codes=[str(_q_telemetry.get("last_failure", ""))],
+                                lane=str(_q_telemetry.get("lanes", "batch+realtime")),
+                                model_ids=[
+                                    m for m in [
+                                        getattr(context, "model_id", None),
+                                    ] if m
+                                ],
+                                dilation_hops=int(_q_hops) if _q_hops != -1 else 0,
+                            )
+                            _ol_rec = get_outage_ledger().recent(1)
+                            if _ol_rec:
+                                emit_outage_event("DW_OUTAGE_DETECTED", _ol_rec[-1])
+                        except Exception:  # noqa: BLE001 -- outage ledger never blocks the op
+                            pass
                         # Global outage DEDUCED -> terminal Cryo-DLQ seal. Do NOT
                         # immortal re-queue. The op is sealed (replayable), not lost.
                         logger.warning(

--- a/backend/core/ouroboros/governance/outage_ledger.py
+++ b/backend/core/ouroboros/governance/outage_ledger.py
@@ -1,0 +1,409 @@
+"""outage_ledger.py -- Durable DW outage->recovery record + async TrinityEventBus export.
+
+Design
+------
+- Append-only bounded JSONL ring at ``.jarvis/outage_ledger.jsonl``.
+- ``OutageRecord`` carries the outage lifecycle: open (started_ts only) ->
+  close (ended_ts + duration_s stamped, optionally served_by_jprime).
+- ``OutageLedger`` is the durable store: open/close/recent/has_open_outage.
+- ``emit_outage_event`` is a synchronous fire-and-forget entry point that
+  schedules an async coroutine via ``asyncio.create_task``. Strong refs are
+  kept in ``_INFLIGHT_TASKS`` so GC cannot reap in-flight tasks. No-op when
+  no running loop exists.
+- All methods fail-soft: NEVER raise into the FSM.
+
+Env gates
+---------
+- ``JARVIS_OUTAGE_LEDGER_ENABLED``      default "true"
+- ``JARVIS_OUTAGE_LEDGER_PATH``         default ".jarvis/outage_ledger.jsonl"
+- ``JARVIS_OUTAGE_LEDGER_MAX``          default 200 (bounded ring size)
+- ``JARVIS_TRINITY_OUTAGE_EXPORT_ENABLED`` default "true"
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import tempfile
+import time
+import uuid
+from typing import Any, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Module-level strong refs for in-flight asyncio tasks (prevent GC reap)
+# ---------------------------------------------------------------------------
+_INFLIGHT_TASKS: set = set()
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+def _env_bool(name: str, default: str = "true") -> bool:
+    val = os.environ.get(name, default).strip().lower()
+    return val not in {"0", "false", "no", "off"}
+
+
+def _ledger_enabled() -> bool:
+    return _env_bool("JARVIS_OUTAGE_LEDGER_ENABLED", "true")
+
+
+def _export_enabled() -> bool:
+    return _env_bool("JARVIS_TRINITY_OUTAGE_EXPORT_ENABLED", "true")
+
+
+def _default_path() -> str:
+    return os.environ.get(
+        "JARVIS_OUTAGE_LEDGER_PATH",
+        os.path.join(".jarvis", "outage_ledger.jsonl"),
+    )
+
+
+def _max_records() -> int:
+    try:
+        return int(os.environ.get("JARVIS_OUTAGE_LEDGER_MAX", "200"))
+    except (ValueError, TypeError):
+        return 200
+
+
+# ---------------------------------------------------------------------------
+# OutageRecord
+# ---------------------------------------------------------------------------
+
+class OutageRecord:
+    """Lightweight value object representing one DW outage lifecycle event.
+
+    Uses ``__slots__`` to keep memory overhead minimal (many may be live
+    in the bounded ring simultaneously).
+    """
+
+    __slots__ = (
+        "outage_id",
+        "started_ts",
+        "ended_ts",
+        "duration_s",
+        "failure_mode",
+        "error_codes",
+        "lane",
+        "model_ids",
+        "dilation_hops",
+        "served_by_jprime",
+        "jprime_uptime_s",
+    )
+
+    def __init__(
+        self,
+        outage_id: str,
+        started_ts: float,
+        ended_ts: Optional[float] = None,
+        duration_s: Optional[float] = None,
+        failure_mode: str = "TIMEOUT",
+        error_codes: Optional[List[str]] = None,
+        lane: str = "batch+realtime",
+        model_ids: Optional[List[str]] = None,
+        dilation_hops: int = 0,
+        served_by_jprime: bool = False,
+        jprime_uptime_s: Optional[float] = None,
+    ) -> None:
+        self.outage_id = outage_id
+        self.started_ts = started_ts
+        self.ended_ts = ended_ts
+        self.duration_s = duration_s
+        self.failure_mode = failure_mode
+        self.error_codes: List[str] = error_codes if error_codes is not None else []
+        self.lane = lane
+        self.model_ids: List[str] = model_ids if model_ids is not None else []
+        self.dilation_hops = dilation_hops
+        self.served_by_jprime = served_by_jprime
+        self.jprime_uptime_s = jprime_uptime_s
+
+    # ------------------------------------------------------------------
+    # Serialisation
+    # ------------------------------------------------------------------
+
+    def to_dict(self) -> dict:
+        return {
+            "outage_id": self.outage_id,
+            "started_ts": self.started_ts,
+            "ended_ts": self.ended_ts,
+            "duration_s": self.duration_s,
+            "failure_mode": self.failure_mode,
+            "error_codes": list(self.error_codes),
+            "lane": self.lane,
+            "model_ids": list(self.model_ids),
+            "dilation_hops": self.dilation_hops,
+            "served_by_jprime": self.served_by_jprime,
+            "jprime_uptime_s": self.jprime_uptime_s,
+        }
+
+    @classmethod
+    def from_dict(cls, d: dict) -> "OutageRecord":
+        return cls(
+            outage_id=str(d.get("outage_id", "")),
+            started_ts=float(d.get("started_ts", 0.0)),
+            ended_ts=float(d["ended_ts"]) if d.get("ended_ts") is not None else None,
+            duration_s=float(d["duration_s"]) if d.get("duration_s") is not None else None,
+            failure_mode=str(d.get("failure_mode", "TIMEOUT")),
+            error_codes=list(d.get("error_codes") or []),
+            lane=str(d.get("lane", "batch+realtime")),
+            model_ids=list(d.get("model_ids") or []),
+            dilation_hops=int(d.get("dilation_hops", 0)),
+            served_by_jprime=bool(d.get("served_by_jprime", False)),
+            jprime_uptime_s=float(d["jprime_uptime_s"]) if d.get("jprime_uptime_s") is not None else None,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"OutageRecord(id={self.outage_id!r}, lane={self.lane!r}, "
+            f"started={self.started_ts}, ended={self.ended_ts}, "
+            f"failure_mode={self.failure_mode!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# OutageLedger
+# ---------------------------------------------------------------------------
+
+class OutageLedger:
+    """Durable bounded JSONL ring for DW outage records.
+
+    Parameters
+    ----------
+    path:
+        File path for the JSONL ledger. Defaults to the env-configured path.
+    max_records:
+        Maximum records to retain. Older records are trimmed on persist.
+    """
+
+    def __init__(
+        self,
+        path: Optional[str] = None,
+        max_records: Optional[int] = None,
+    ) -> None:
+        self._path = path if path is not None else _default_path()
+        self._max = max_records if max_records is not None else _max_records()
+
+    # ------------------------------------------------------------------
+    # Internal persistence
+    # ------------------------------------------------------------------
+
+    def _load(self) -> List[OutageRecord]:
+        """Load all records from the JSONL file. Returns [] on any error."""
+        records: List[OutageRecord] = []
+        try:
+            with open(self._path, "r", encoding="utf-8") as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        d = json.loads(raw)
+                        records.append(OutageRecord.from_dict(d))
+                    except Exception:  # noqa: BLE001 -- skip corrupt lines
+                        pass
+        except FileNotFoundError:
+            pass
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[OutageLedger] load failed path=%s err=%r", self._path, exc)
+        return records
+
+    def _persist(self, records: List[OutageRecord]) -> None:
+        """Atomically rewrite the ledger, trimmed to newest ``_max`` records."""
+        # Keep the newest _max records (trim oldest first)
+        trimmed = records[-self._max :]
+        try:
+            os.makedirs(os.path.dirname(os.path.abspath(self._path)), exist_ok=True)
+            dir_name = os.path.dirname(os.path.abspath(self._path))
+            fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    for rec in trimmed:
+                        fh.write(json.dumps(rec.to_dict(), default=str) + "\n")
+                os.replace(tmp_path, self._path)
+            except Exception:
+                # Clean up temp file on failure
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+                raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[OutageLedger] persist failed path=%s err=%r", self._path, exc)
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def open_outage(
+        self,
+        *,
+        failure_mode: str = "TIMEOUT",
+        error_codes: Optional[List[str]] = None,
+        lane: str = "batch+realtime",
+        model_ids: Optional[List[str]] = None,
+        dilation_hops: int = 0,
+    ) -> str:
+        """Record the start of a DW outage. Returns the outage_id.
+
+        Dedup: if an outage with the same ``lane`` and ``ended_ts is None``
+        already exists, returns its id without creating a duplicate.
+        """
+        if not _ledger_enabled():
+            return ""
+        try:
+            records = self._load()
+            # Dedup: return existing open outage for same lane
+            for rec in reversed(records):
+                if rec.lane == lane and rec.ended_ts is None:
+                    return rec.outage_id
+            outage_id = str(uuid.uuid4())
+            rec = OutageRecord(
+                outage_id=outage_id,
+                started_ts=time.time(),
+                failure_mode=failure_mode,
+                error_codes=error_codes,
+                lane=lane,
+                model_ids=model_ids,
+                dilation_hops=dilation_hops,
+            )
+            records.append(rec)
+            self._persist(records)
+            logger.info(
+                "[OutageLedger] outage OPENED id=%s lane=%s failure_mode=%s hops=%s",
+                outage_id, lane, failure_mode, dilation_hops,
+            )
+            return outage_id
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[OutageLedger] open_outage failed err=%r", exc)
+            return ""
+
+    def close_outage(
+        self,
+        outage_id: str,
+        *,
+        served_by_jprime: bool = False,
+        jprime_uptime_s: Optional[float] = None,
+    ) -> None:
+        """Stamp ``ended_ts`` and ``duration_s`` on the matching open outage."""
+        if not _ledger_enabled():
+            return
+        try:
+            records = self._load()
+            now = time.time()
+            for rec in records:
+                if rec.outage_id == outage_id and rec.ended_ts is None:
+                    rec.ended_ts = now
+                    rec.duration_s = now - rec.started_ts
+                    rec.served_by_jprime = served_by_jprime
+                    rec.jprime_uptime_s = jprime_uptime_s
+                    self._persist(records)
+                    logger.info(
+                        "[OutageLedger] outage CLOSED id=%s duration_s=%.1f jprime=%s",
+                        outage_id, rec.duration_s, served_by_jprime,
+                    )
+                    return
+            logger.debug(
+                "[OutageLedger] close_outage: id=%s not found or already closed",
+                outage_id,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[OutageLedger] close_outage failed err=%r", exc)
+
+    def recent(self, n: int = 50) -> List[OutageRecord]:
+        """Return the most recent *n* records (newest last).
+
+        Returns [] on any error.
+        """
+        if not _ledger_enabled():
+            return []
+        try:
+            records = self._load()
+            return records[-n:] if n > 0 else []
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[OutageLedger] recent failed err=%r", exc)
+            return []
+
+    def has_open_outage(self) -> bool:
+        """Return True if any outage record has ``ended_ts is None``."""
+        if not _ledger_enabled():
+            return False
+        try:
+            records = self._load()
+            return any(rec.ended_ts is None for rec in records)
+        except Exception:  # noqa: BLE001
+            return False
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_singleton: Optional[OutageLedger] = None
+
+
+def get_outage_ledger() -> OutageLedger:
+    """Return (or lazily create) the process-wide OutageLedger singleton."""
+    global _singleton  # noqa: PLW0603
+    if _singleton is None:
+        _singleton = OutageLedger()
+    return _singleton
+
+
+# ---------------------------------------------------------------------------
+# Async TrinityEventBus export (fire-and-forget)
+# ---------------------------------------------------------------------------
+
+async def _publish_outage_event(kind: str, record: OutageRecord) -> None:
+    """Async coroutine: lazy-import TrinityEventBus and publish.
+
+    Never raises -- any error is caught and logged at WARNING.
+    """
+    if not _export_enabled():
+        return
+    try:
+        from backend.core.trinity_event_bus import (  # noqa: PLC0415
+            get_event_bus_if_exists,
+            TrinityEvent,
+            EventPriority,
+            RepoType,
+        )
+        bus = get_event_bus_if_exists()
+        if bus is None or not getattr(bus, "_running", False):
+            return
+        event = TrinityEvent(
+            topic=kind,
+            source=RepoType.JARVIS,
+            priority=EventPriority.HIGH,
+            payload=record.to_dict(),
+        )
+        await bus.publish(event, persist=True)
+        logger.debug("[OutageLedger] exported event kind=%s id=%s", kind, record.outage_id)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[OutageLedger] event export failed kind=%s err=%r", kind, exc)
+
+
+def emit_outage_event(kind: str, record: OutageRecord) -> None:
+    """Synchronous fire-and-forget entry point for Trinity event export.
+
+    Schedules ``_publish_outage_event`` as an asyncio task. Strong refs are
+    kept in ``_INFLIGHT_TASKS`` so GC cannot reap the task before it
+    completes. Task completion removes the ref automatically.
+
+    No-op (no exception) if there is no running event loop.
+    """
+    if not _export_enabled():
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        # No running loop -- silence (batch or startup context)
+        return
+    try:
+        task = loop.create_task(_publish_outage_event(kind, record))
+        _INFLIGHT_TASKS.add(task)
+        task.add_done_callback(_INFLIGHT_TASKS.discard)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[OutageLedger] emit_outage_event schedule failed err=%r", exc)

--- a/docs/superpowers/specs/2026-06-23-sovereign-provider-failover-lifecycle.md
+++ b/docs/superpowers/specs/2026-06-23-sovereign-provider-failover-lifecycle.md
@@ -1,0 +1,223 @@
+# Sovereign Provider Failover Lifecycle + Recovery Forecaster — Design Spec
+
+> **Arc.** The live soak proved the full resilience stack fires and localized the wall to DW throughput collapse. The Provider Quarantine Matrix (#69671) now seals ops into a Cryo-DLQ instead of hammering a dead upstream. This arc adds the **other half**: when DW collapses (and Claude is depleted), **GCP J-Prime — the self-hosted Mind — awakens from its golden-image snapshot, carries generation through the outage, and tears itself back down the instant DW is sustainably healthy again.** Cost is bounded to the outage window. A *recovery forecaster* (EWMA + live velocity gradient — NOT heavy ML on sparse data) makes the awaken/probe/handback timing intelligent.
+>
+> **Date:** 2026-06-23. Branch `worktree-sovereign-failover-lifecycle`.
+> **Trinity context.** Body (JARVIS / O+V) = this repo. Mind (J-Prime, `jarvis_prime`) = 11 self-hosted GGUF specialists on an `e2-highmem-4` CPU node; **code → `Qwen2.5-Coder-7B` (70.4% HumanEval)**. Nerves (Reactor-Core) = training / experience-collection / model-deployment (later phase).
+
+---
+
+## 1. Goals / Non-Goals
+
+**Goals.**
+- **G1 — Sovereign failover.** When the Quarantine Matrix deduces a global DW outage (and Claude is unavailable), awaken J-Prime as the Tier-2 generation provider and route generation to it — so O+V is *never* hard-blocked by vendor collapse.
+- **G2 — Cost-bounded to the outage.** J-Prime dormant cost ≈ **$0.50/mo** (golden-image snapshot only; VM + disk deleted). Active cost = outage-hours × cheap CPU rate. Hard ceiling = the existing `IntelligentGCPOptimizer` **$5/day** budget.
+- **G3 — Intelligent, observed-gated handback.** Detect DW recovery via a cheap probe; hand back to DW (primary) and tear J-Prime down on **sustained** recovery (hysteresis, anti-thrash). The forecast *paces* this; an **observed** probe *decides* it.
+- **G4 — Recovery forecaster.** EWMA-MTTR + percentile bands + a live within-outage recovery-velocity gradient, robust on sparse outage data. Drives the three advanced layers below.
+- **G5 — Experience capture (RSI substrate).** Every outage→recovery is recorded locally AND exported asynchronously to Reactor-Core via TrinityEventBus — the dataset the make-the-model-better flywheel later trains on.
+- **G6 — Reuse-first, fail-soft, OFF byte-identical, gated.** Compose the existing quarantine gradient, transport-breaker HALF-OPEN probe, `dw_surface_health`, `gcp_vm_manager` idle-stop/golden-image, TrinityEventBus, `telemetry_ingestor`. No parallel machinery.
+
+**Non-Goals.**
+- Not Reactor-Core *training* (that's the later, budgeted flywheel phase — this spec only *feeds* it).
+- Not the per-sub-goal cognitive-complexity bounding / `LOCAL COGNITIVE OVERLOAD` decompose (a companion concern; a 7B coder is far above the 3B ceiling that motivated it — referenced in §9, not core here).
+- Not changing DW primacy: J-Prime is **last-resort**, never primary. DW recovers → DW resumes.
+- No heavy ML (LSTM/transformer) for forecasting — sparse outage data makes it overfit; explicitly rejected.
+
+---
+
+## 2. Architecture — the Lifecycle FSM + the Forecaster
+
+The controller is a small FSM over the *provider-fleet health state*, driven by the quarantine gradient + the forecaster:
+
+```
+        ┌────────────────────────────────────────────────────────────────┐
+        │ DORMANT  (DW healthy primary; J-Prime = golden-image snapshot)   │
+        └──────────────┬─────────────────────────────────────────────────┘
+   quarantine.is_global_outage(DW)==True  AND  Claude unavailable
+                       │   (Cryo-Trigger §5: forecast says R_remaining > cold-start cost)
+                       ▼
+        ┌──────────────────────────────────────────────────────────────┐
+        │ AWAKENING  (create VM from snapshot/golden image, ~boot+load)  │
+        └──────────────┬───────────────────────────────────────────────┘
+              ensure_static_vm_ready() healthy
+                       ▼
+        ┌──────────────────────────────────────────────────────────────┐
+        │ SERVING  (route generation → J-Prime Tier-2; DW recovery probe │
+        │           loop paced by Adaptive Polling §3)                   │
+        └──────────────┬───────────────────────────────────────────────┘
+        DW sustainably healthy (gradient recovered ≥ window + hysteresis + cooldown)
+                       ▼
+        ┌──────────────────────────────────────────────────────────────┐
+        │ HANDBACK  ([SOVEREIGN YIELD: UPSTREAM RECOVERED] → route DW →   │
+        │            delete-to-snapshot J-Prime)                         │
+        └──────────────┬───────────────────────────────────────────────┘
+                       ▼ back to DORMANT
+```
+
+**The reactive floor (correctness baseline, forecast-INDEPENDENT).** With zero forecasting the FSM is still correct: AWAKEN after a fixed confirm window once outage is deduced; PROBE at a fixed interval; HANDBACK on sustained observed recovery. The forecaster is a *pure optimization layer* on top — it can be wrong and the system stays correct (it only mis-paces). This is the load-bearing invariant: **observed probes are authoritative; the forecast is advisory.**
+
+---
+
+## 3. Layer 1 — Dynamic Polling Backoff (The Throttle)
+
+The DW-recovery probe interval is a function of the forecast, never static.
+
+**Inputs.** `t` = current outage elapsed (monotonic); `p50`, `p90` = forecaster recovery-time bands (§6); `I_min`, `I_max` = probe interval clamps (env).
+
+**The throttle function** `probe_interval(t, p50, p90)`:
+- **Far below p50** (`t < p50`, large `Δ = p50 − t`): probe *sparsely* — recovery is statistically unlikely yet. Interval scales with `Δ` toward `I_max` (don't waste probes or load a recovering DW early).
+- **Approaching p50** (`Δ → 0`): probe interval **accelerates toward `I_min`** — recovery is statistically imminent; we want to catch it fast (minimize handback latency = minimize J-Prime cost).
+- **Overshoot past p90** (`t > p90`): the forecast was wrong / the outage is anomalous → **exponential backoff** of the interval (toward `I_max`) to preserve local compute + network and avoid pestering a deeply-degraded DW. Reuse the existing `circuit_breaker.full_jitter_delay` exponential+jitter primitive (do NOT reimplement backoff).
+
+```
+probe_interval(t) =
+    t < p50 :  clamp(I_min, I_max, I_min + k_pre * (p50 - t))      # decelerate-to-sparse far out
+    p50≤t≤p90: I_min                                               # dense probing in the likely window
+    t > p90 :  clamp(I_min, I_max, full_jitter_delay(attempt=n_overshoot))  # exponential back-off
+```
+
+**Authority.** The interval is *pacing only*. A probe firing does not hand back — a probe **succeeding (sustained, §4)** does. A wrong forecast changes only *when we look*, never *what we conclude*. Cheap probe = a tiny health ping / minimal completion, **never** a full generation (good-citizen: no hammering a recovering DW).
+
+**Component.** `recovery_throttle.py` (pure): `probe_interval(t, p50, p90, *, cfg) -> float`. Gated `JARVIS_RECOVERY_THROTTLE_ENABLED` (default true); OFF → fixed `I_default`.
+
+---
+
+## 4. The Recovery Confirmation + Anti-Thrash (the HANDBACK gate)
+
+Reuse the quarantine `ProviderHealthGradient` (the rolling success-rate window) as the recovery signal — it already *recovers* when DW sweeps succeed. Add a symmetric **recovered** predicate:
+- `is_recovered(route)` = window FULL **and** `success_rate(route) >= JARVIS_RECOVERY_THRESHOLD` (default e.g. 0.6 — sustained, not a single flicker).
+- **Hysteresis:** require `is_recovered` to hold across `N` consecutive probe cycles (`JARVIS_RECOVERY_HYSTERESIS_CYCLES`, default 2) **+** a `JARVIS_JPRIME_MIN_UPTIME_S` floor (don't tear J-Prime down seconds after awakening) **+** a `JARVIS_HANDBACK_COOLDOWN_S` before a *re-awaken* is allowed (kills the awaken↔handback churn cycle).
+
+Reuse `dw_surface_health` (HEALTHY = "last probe completed without error") for the per-probe verdict feeding the gradient. Recovery probes use the transport-breaker **HALF-OPEN async probe** machinery already built (`transport_circuit_breaker` self-heals via HALF-OPEN; `dw_transport_recovery` owns the jitter window) — we consume its verdict rather than reimplement probing.
+
+On confirmed recovery → emit `[SOVEREIGN YIELD: UPSTREAM RECOVERED]` (reuse `emit_sovereign_yield(reason=...)`) → route generation back to DW → trigger HANDBACK teardown (§5).
+
+---
+
+## 5. Layer 3 — Cryo-Trigger Integration (forecast → awaken-from-snapshot threshold)
+
+Synthesizes the forecaster with the **Delete-to-Snapshot** dormancy strategy. Two decision points, both forecast-shaped, both cost-safe:
+
+**5a. AWAKEN threshold (when to pay the spin-up).** Spinning up J-Prime costs a cold-start `C` (boot + model load; ~87s from a stopped VM, ~2–5 min from a deleted-to-snapshot recreate) + the active compute. The math:
+
+```
+Let R = forecast remaining recovery time (p50, or a chosen percentile).
+Let C = J-Prime cold-start cost (env JARVIS_JPRIME_COLDSTART_S, measured).
+AWAKEN  iff  quarantine.is_global_outage(DW)  AND  Claude_unavailable
+             AND  R > C * JARVIS_CRYO_AWAKEN_MARGIN   (default 1.5)
+```
+
+- If `R > C·margin`: by the time J-Prime is ready, DW will *still* be down and J-Prime will serve a meaningful window → the spin-up pays off. Awaken.
+- If `R < C` (DW likely back before J-Prime even finishes booting — a blip): **do NOT awaken.** The quarantine Cryo-DLQ holds the op briefly; DW recovers; no money spent waking J-Prime for a flicker. *This is the core cost-saver of the cryo-trigger.*
+- **Cold-start confidence gate:** if the forecaster lacks history (cold-start, <`JARVIS_FORECAST_MIN_SAMPLES`), `R` is unknown → fall back to the reactive floor (awaken after a fixed `JARVIS_OUTAGE_CONFIRM_S` window). Never block awakening on an absent forecast.
+
+**5b. SLEEP (delete-to-snapshot on handback).** On confirmed recovery (§4): route to DW, then **delete-to-snapshot** — tear down the J-Prime VM + disk, preserving only the golden-image snapshot (~$0.50/mo dormant). Reuse `gcp_vm_manager`'s golden-image create path (`source_image`, `ensure_static_vm_ready`) for awaken and its delete/stop lifecycle for sleep.
+
+**Authority.** The cryo-trigger decides *when to pay* the spin-up (a cost optimization); routing to J-Prime only happens once it's *observed* ready AND DW is *observed* still down; handback is *observed*-gated (§4). A wrong forecast = a slightly early/late spin-up (a bounded cost wobble) — never a correctness break or a lost op.
+
+**Component.** `failover_lifecycle.py` — the FSM controller. Consumes: quarantine gradient, forecaster, throttle, `gcp_vm_manager`. Gated `JARVIS_FAILOVER_LIFECYCLE_ENABLED` (default **false** until the golden image exists + a soak validates — flip after Phase 3). OFF → today's behavior (quarantine → Cryo-DLQ, no J-Prime).
+
+---
+
+## 6. The Recovery Forecaster (EWMA + velocity gradient — robust on sparse data)
+
+`recovery_forecaster.py` (pure, stdlib + math). Reads the OutageLedger (§7).
+
+- **v1 — EWMA-MTTR + percentile bands.** Maintain an EWMA of historical outage durations + a simple percentile estimate (p50/p90) from the bounded recent-outage window. Works with 3–5 samples; interpretable; cannot overfit. `forecast(now) -> RecoveryForecast{p50_s, p90_s, samples, confidence}`.
+- **v1.5 — within-outage recovery-velocity gradient.** During the *live* outage, track the probe trajectory (latency trend + first intermittent successes). A turning trajectory (latencies dropping / sporadic 200s) is the strongest *leading* indicator — bias `R` downward when the gradient turns positive. This is "this outage," not history — the highest-signal input.
+- **v2 (optional, later) — conditioning** on time-of-day / failure-mode (a 5xx storm ≠ a batch backlog). Still a simple conditioned estimator.
+- `confidence` low (cold-start) → consumers fall back to reactive-floor constants. Fail-soft → returns a conservative default forecast, never raises.
+
+Gated `JARVIS_RECOVERY_FORECAST_ENABLED` (default true; OFF → consumers use fixed constants = the reactive floor).
+
+---
+
+## 7. Layer 2 — Trinity Telemetry Bridge + the Outage Ledger (async, non-blocking)
+
+**Two stores, deliberately separate:**
+
+**7a. Local OutageLedger** (`outage_ledger.py`, in-process, append-only, bounded). Records each outage lifecycle: `{outage_id, started_ts, ended_ts, duration_s, failure_mode, error_codes, lane, model_ids, dilation_hops, served_by_jprime, jprime_uptime_s, recovery_probe_trajectory}`. **The forecaster reads THIS** — in-process, zero cross-repo dependency. Durable at `.jarvis/outage_ledger.jsonl` (small, bounded ring). The forecast must work even if Reactor-Core is entirely offline.
+
+**7b. Trinity export (async, fire-and-forget).** On outage-detected and outage-recovered, publish a TrinityEventBus event carrying the DW-collapse metadata (timestamps, failure modes, error codes, lane, model_ids). **Strictly non-blocking** — it rides the existing async publish pattern (the v244 command-lifecycle / unlock-telemetry path):
+- `asyncio.create_task(...)` fire-and-forget with a strong task-ref (no GC), wrapped fail-soft — a dead bus / offline Reactor-Core **never** blocks or breaks the O+V operational DAG.
+- Add event types `DW_OUTAGE_DETECTED` / `DW_OUTAGE_RECOVERED` to the Body→Nerves telemetry contract (mirroring the `VOICE_UNLOCK_*` precedent).
+- Reactor-Core's `reactor_core/ingestion/telemetry_ingestor.py` maps them into the training dataset (the RSI substrate) — *that* side is a Reactor-Core change, scoped to Phase 4, but the **Body emission contract is defined here** so the bridge is ready.
+
+**Invariant.** The Body's live forecast/lifecycle depend ONLY on the local ledger (7a). The Trinity bridge (7b) is additive export for training — its failure is invisible to O+V. Gated `JARVIS_TRINITY_OUTAGE_EXPORT_ENABLED` (default true; fail-soft).
+
+---
+
+## 8. Cost Model (the whole point)
+
+| State | Billing | ~Cost |
+|---|---|---|
+| DORMANT (≈99% of time) | golden-image snapshot only (VM+disk deleted) | **~$0.50/mo** |
+| AWAKENING/SERVING | `e2-highmem-2` (16GB, code-only) Spot ~$0.015/hr or on-demand ~$0.067/hr × outage hours | **cents–$ per outage** |
+| Cryo-trigger blip-skip | `R < C` → never awaken for a flicker | **$0** |
+| Hard ceiling | `IntelligentGCPOptimizer` daily budget | **$5/day cap** |
+
+Realistic all-in: **~$1–3/month** vs ~$98–110 always-on. Spot-first / on-demand-fallback for the active burst is a minor (~$0.50/mo) bonus; the dominant levers are delete-to-snapshot dormancy + the cryo-trigger blip-skip.
+
+---
+
+## 9. Reuse Map (no parallel machinery)
+
+| Need | Reuse |
+|---|---|
+| Outage detection | `ProviderHealthGradient.is_global_outage` (quarantine arc) |
+| Recovery probe | `transport_circuit_breaker` HALF-OPEN async probe + `dw_transport_recovery` jitter window |
+| Per-probe verdict | `dw_surface_health` (HEALTHY/degraded) |
+| Recovery confirm | `ProviderHealthGradient.success_rate` + new `is_recovered` |
+| Backoff/jitter primitive | `circuit_breaker.full_jitter_delay` |
+| Yield surface | `emit_sovereign_yield(reason="UPSTREAM RECOVERED")` |
+| VM awaken/sleep | `gcp_vm_manager` golden-image `source_image` create + `ensure_static_vm_ready` + delete/snapshot + `jprime_idle_stop` lifecycle |
+| Budget cap | `IntelligentGCPOptimizer` `CostBudget` ($5/day) |
+| Trinity export | `TrinityEventBus` + `telemetry/events.py` + `reactor_core/ingestion/telemetry_ingestor.py` |
+| Tier-2 generation | `jarvis_prime_client` / the `PrimeProvider` seat (OpenAI-compatible `/v1/chat/completions`) |
+
+*Companion (out of scope here, referenced):* per-sub-goal cognitive-complexity bounding (`LOCAL COGNITIVE OVERLOAD` → `decompose_for_block`) — useful if a smaller local model is ever used; a 7B coder largely obviates it. Tracked separately.
+
+---
+
+## 10. Error Handling / Invariants
+
+- **Fail-soft absolute.** Any forecaster/throttle/bridge/VM error → fall back to the reactive floor (fixed intervals, conservative awaken) → the op is never lost (quarantine Cryo-DLQ remains the backstop).
+- **OFF byte-identical.** `JARVIS_FAILOVER_LIFECYCLE_ENABLED=false` → today's behavior exactly (quarantine → Cryo-DLQ; no J-Prime).
+- **Observed-gated authority** (load-bearing): the forecast only paces/optimizes; awaken-readiness and handback are observed-gated. A wrong forecast is a bounded cost wobble, never a correctness or op-loss event.
+- **Good-citizen probing:** recovery probes are tiny health pings, never full generations; throttle backs off past p90 so a deeply-degraded DW is not pestered.
+- **No cross-repo hard dependency:** the live forecast depends only on the local ledger; Reactor-Core may be entirely offline.
+
+---
+
+## 11. Phasing (precisely sequenced)
+
+**Phase 1 — Golden Image Bake + The Telemetry Ledger (execute first, per operator).**
+1. Bake a **code-only** golden image: provision a node, `download_recommended_models.py` for `Qwen2.5-Coder-7B` only, install `jarvis_prime`, snapshot → a small (~10–15GB) GCP image. One-time, a few dollars.
+2. `outage_ledger.py` (7a) + the Trinity export contract (7b) wired to the quarantine outage-detect/recover points (fire-and-forget). The ledger starts accumulating immediately (even before J-Prime is wired) so the forecaster has data.
+
+**Phase 2 — Forecaster + Adaptive Polling.** `recovery_forecaster.py` (§6) + `recovery_throttle.py` (§3), consuming the ledger. Pure, testable, no infra.
+
+**Phase 3 — Cryo-Trigger + Lifecycle FSM + Tier-2 wiring.** `failover_lifecycle.py` (§5) + `is_recovered`/hysteresis (§4) + `PrimeProvider` Tier-2 routing + the awaken/handback VM lifecycle. Flip `JARVIS_FAILOVER_LIFECYCLE_ENABLED` after a soak validates an awaken→serve→handback→teardown cycle.
+
+**Phase 4 — Reactor-Core training flywheel (later, budgeted).** `telemetry_ingestor` ingests the exported outage + generation-outcome dataset; DPO/curriculum fine-tunes the coder model; redeploy to J-Prime. Heavier GPU cost → budgeted bursts, only once experience justifies it.
+
+---
+
+## 12. Tests (per phase)
+
+- **OutageLedger:** append/bounded-ring/durable round-trip; failure-mode + trajectory captured; fail-soft on corrupt file.
+- **Trinity export:** fire-and-forget non-blocking (the publish never awaits / never raises into the DAG); dead-bus/offline-Reactor → no-op, O+V unaffected; event schema matches the contract.
+- **Forecaster:** EWMA/percentile correct on 3–5 samples; velocity-gradient biases R down on a turning trajectory; cold-start → low confidence → conservative default; never raises.
+- **Throttle:** `probe_interval` decelerates far below p50, hits `I_min` in the window, exponentially backs off past p90; OFF → fixed interval.
+- **Recovery confirm:** `is_recovered` requires full window + threshold; hysteresis blocks single-flicker handback; cooldown blocks re-awaken churn.
+- **Cryo-trigger:** `R > C·margin` → awaken; `R < C` (blip) → no awaken; cold-start → reactive-floor awaken; never awakens without `is_global_outage`.
+- **Lifecycle FSM:** dormant→awaken→serve→handback→dormant happy path; OFF byte-identical; fail-soft at each transition → reactive floor → op never lost.
+- **Static/integration:** observed-gated authority holds (a forced-wrong forecast never causes premature handback or op loss); cost-path (delete-to-snapshot) reachable.
+
+---
+
+## 13. Open Decisions (for operator review)
+
+1. **Node size / model set for the bake:** code-only `Qwen2.5-Coder-7B` on `e2-highmem-2` (16GB, recommended cheapest) vs the full 11-model fleet on `e2-highmem-4` (32GB). *Spec assumes code-only.*
+2. **Dormancy:** delete-to-snapshot (~$0.50/mo, ~2–5 min recreate) vs stop-when-idle (~$3–14/mo disk, ~87s start). *Spec assumes delete-to-snapshot* for max savings; the cryo-trigger's `C` accounts for the slower recreate.
+3. **Active provisioning:** Spot-first/on-demand-fallback vs plain on-demand. *Spec assumes Spot-first/on-demand-fallback* (minor saving, reuses the `use_spot` paths).

--- a/scripts/bake_jprime_golden_image.py
+++ b/scripts/bake_jprime_golden_image.py
@@ -46,6 +46,7 @@ import argparse
 import datetime as _dt
 import json
 import os
+import pathlib
 import re
 import shlex
 import subprocess
@@ -314,12 +315,135 @@ def _cleanup_node(args: argparse.Namespace, node: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Abort-autopsy (captures bake-node diagnostics BEFORE teardown so the
+# operator can diagnose why a readiness / validation / early-failure abort
+# happened -- same principle as sovereign_sentinel.py autopsy).
+# Bounded + fail-soft: NEVER raises, NEVER blocks teardown.
+# --------------------------------------------------------------------------- #
+_AUTOPSY_DIR = os.environ.get("JPRIME_BAKE_AUTOPSY_DIR", "autopsy_reports")
+
+# Commands to capture from the remote node (label, remote shell cmd).
+_AUTOPSY_CMDS: List[Tuple[str, str]] = [
+    ("jprime_bake.log",          "sudo cat /var/log/jprime_bake.log 2>/dev/null || echo '(absent)'"),
+    ("ollama_serve.log",         "sudo cat /var/log/ollama_serve.log 2>/dev/null || echo '(absent)'"),
+    ("ollama_list.txt",          "ollama list 2>&1 || echo '(ollama list failed)'"),
+    ("systemctl_ollama.txt",     "systemctl status ollama --no-pager 2>&1 || echo '(systemd unavailable)'"),
+    ("journalctl_ollama.txt",    "journalctl -u ollama --no-pager 2>/dev/null | tail -50 || echo '(journalctl unavailable)'"),
+    ("df_h.txt",                 "df -h / 2>&1"),
+    ("ollama_api_tags.json",     "curl -s localhost:11434/api/tags 2>&1 || echo '(curl failed)'"),
+]
+
+# Hard per-command SSH timeout for autopsy capture (seconds).
+_AUTOPSY_CMD_TIMEOUT_S: float = float(os.environ.get("JPRIME_BAKE_AUTOPSY_CMD_TIMEOUT_S", "30"))
+
+
+def _run_autopsy(args: argparse.Namespace, node: str, reason: str) -> Optional[pathlib.Path]:
+    """Capture diagnostic artifacts from the bake node into a local file.
+
+    Must be called BEFORE _cleanup_node (node must still exist).
+    Bounded + fail-soft: any failure is logged and silently skipped so
+    teardown is NEVER blocked. Returns the path written, or None on failure.
+    """
+    try:
+        stamp = _dt.datetime.now().strftime("%Y%m%d-%H%M%S")
+        safe_node = re.sub(r"[^A-Za-z0-9_.-]", "_", node)[:60]
+        outdir = pathlib.Path(_AUTOPSY_DIR)
+        outdir.mkdir(parents=True, exist_ok=True)
+        report_path = outdir / f"bake_{safe_node}_{stamp}.log"
+
+        lines: List[str] = [
+            f"# JARVIS J-Prime bake autopsy",
+            f"# node    : {node}",
+            f"# reason  : {reason}",
+            f"# captured: {stamp}",
+            f"# zone    : {args.zone}",
+            f"# project : {args.project}",
+            "",
+        ]
+
+        for label, remote_cmd in _AUTOPSY_CMDS:
+            lines.append(f"{'=' * 60}")
+            lines.append(f"# {label}")
+            lines.append(f"{'=' * 60}")
+            try:
+                rc, out = _run(
+                    _ssh_cmd(args, node, remote_cmd),
+                    timeout_s=_AUTOPSY_CMD_TIMEOUT_S,
+                )
+                body = out.strip() if out else "(empty output)"
+                lines.append(f"[rc={rc}]")
+                lines.append(body)
+            except Exception as exc:  # noqa: BLE001
+                lines.append(f"[capture failed: {exc!r}]")
+            lines.append("")
+
+        report_path.write_text("\n".join(lines), encoding="utf-8")
+        _log(f"autopsy written -> {report_path}")
+        return report_path
+    except Exception as exc:  # noqa: BLE001 -- autopsy NEVER blocks teardown
+        _log(f"autopsy FAILED (proceeding to teardown): {exc!r}")
+        return None
+
+
+# --------------------------------------------------------------------------- #
 # Poll loop.
 # --------------------------------------------------------------------------- #
-def _poll_readiness(args: argparse.Namespace, node: str) -> bool:
+
+# Patterns in the bake log that signal an unrecoverable failure so we can
+# abort early instead of burning the full timeout.
+_EARLY_FAIL_PATTERNS: List[re.Pattern] = [
+    re.compile(r"\bERROR\b", re.IGNORECASE),
+    re.compile(r"ollama pull failed", re.IGNORECASE),
+    re.compile(r"startup-script.*exit.*[1-9]", re.IGNORECASE),
+    re.compile(r"\bjprime-bake\].*ERROR", re.IGNORECASE),
+    re.compile(r"curl.*failed", re.IGNORECASE),
+    re.compile(r"^[^#]*exit [1-9]", re.IGNORECASE),
+]
+
+
+def _check_bake_log(args: argparse.Namespace, node: str
+                    ) -> Tuple[Optional[str], Optional[str]]:
+    """SSH-fetch the last 5 lines of the bake log; return (last_line, fail_reason).
+
+    last_line  -- the most recent log line for live-progress display (or None).
+    fail_reason -- non-None if an early-failure marker was found in the tail.
+
+    Fail-soft: any SSH/parse error returns (None, None).
+    """
+    remote = "sudo tail -n 5 /var/log/jprime_bake.log 2>/dev/null || true"
+    try:
+        rc, out = _run(_ssh_cmd(args, node, remote), timeout_s=30.0)
+        if rc != 0 or not out:
+            return None, None
+        text = out.strip()
+        lines = [l for l in text.splitlines() if l.strip()]
+        last_line = lines[-1] if lines else None
+        for line in lines:
+            for pat in _EARLY_FAIL_PATTERNS:
+                if pat.search(line):
+                    return last_line, f"early-failure marker in log: {line.strip()[:200]}"
+        return last_line, None
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def _poll_readiness(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
     """Poll the node (via SSH) for the sentinel + `ollama list` model presence.
 
-    Exponential-ish backoff, bounded by --bake-timeout-s. Returns True on ready.
+    Exponential-ish backoff, bounded by --bake-timeout-s.
+
+    Returns (ready, abort_reason):
+      (True, "")            -- node is ready.
+      (False, "<reason>")   -- timed-out or early-failure detected.
+
+    Three behaviours added vs the original:
+      1. Live progress: every poll attempt also SSH-fetches the last bake-log
+         line and prints it so the operator sees install/pull progress.
+      2. Early-failure detection: if the bake log contains an unambiguous
+         failure marker (ERROR / ollama pull failed / etc.) we abort
+         immediately rather than burning the full bake_timeout_s.
+      3. Return is now a 2-tuple (ready, reason) so callers can distinguish
+         timeout from early-fail for the autopsy manifest.
     """
     deadline = time.monotonic() + float(args.bake_timeout_s)
     delay = 15.0
@@ -334,7 +458,17 @@ def _poll_readiness(args: argparse.Namespace, node: str) -> bool:
         rc, out = _run(_ssh_cmd(args, node, check), timeout_s=90.0)
         if rc == 0 and "JPRIME_READY" in out:
             _log(f"readiness: node ready (attempt {attempt})")
-            return True
+            return True, ""
+
+        # Live progress: fetch last bake-log lines (every attempt; bounded 30s).
+        # Also checks for early-failure markers -- bail out immediately if found.
+        last_line, fail_reason = _check_bake_log(args, node)
+        if last_line:
+            _log(f"node progress: {last_line}")
+        if fail_reason:
+            _log(f"readiness: EARLY ABORT -- {fail_reason}")
+            return False, f"early_failure: {fail_reason}"
+
         remaining = int(deadline - time.monotonic())
         _log(
             f"readiness: not ready (attempt {attempt}, rc={rc}); "
@@ -345,7 +479,7 @@ def _poll_readiness(args: argparse.Namespace, node: str) -> bool:
         time.sleep(delay)
         delay = min(delay * 1.5, 120.0)
     _log(f"readiness: TIMEOUT after {args.bake_timeout_s}s")
-    return False
+    return False, "readiness_timeout"
 
 
 # --------------------------------------------------------------------------- #
@@ -443,6 +577,8 @@ def _execute_bake(args: argparse.Namespace, node: str, startup_script: str) -> i
     import tempfile
     fd, sp_path = tempfile.mkstemp(prefix="jprime_startup_", suffix=".sh")
     node_exists = False
+    bake_succeeded = False          # tracks whether we reached SUCCESS (skip autopsy)
+    abort_reason: str = ""          # reason passed to autopsy manifest
     try:
         with os.fdopen(fd, "w") as fh:
             fh.write(startup_script)
@@ -452,19 +588,23 @@ def _execute_bake(args: argparse.Namespace, node: str, startup_script: str) -> i
         rc, out = _run(_create_node_cmd(args, node, sp_path), timeout_s=300.0)
         if rc != 0:
             _abort(f"provision failed rc={rc}: {out.strip()[:400]}")
+            abort_reason = f"provision_failed rc={rc}"
             return 4
         node_exists = True
         _log(f"node {node} created; startup-script installing Ollama + pulling model")
 
-        # 2. POLL READINESS.
-        if not _poll_readiness(args, node):
-            _abort("readiness timeout -- model never finished pulling")
+        # 2. POLL READINESS (includes live progress + early-fail detection).
+        ready, poll_abort_reason = _poll_readiness(args, node)
+        if not ready:
+            _abort(f"readiness abort: {poll_abort_reason}")
+            abort_reason = poll_abort_reason
             return 5
 
         # 3. VALIDATION LOCK -- never snapshot a broken image.
         passed, sample = _validate_generation(args, node)
         if not passed:
             _abort(f"validation failed: {sample}")
+            abort_reason = f"validation_failed: {sample[:200]}"
             return 6
         _log("validation: PASS -- node generated plausible Python (loaded in RAM)")
         _log(f"validation sample: {sample[:300]!r}")
@@ -477,6 +617,7 @@ def _execute_bake(args: argparse.Namespace, node: str, startup_script: str) -> i
         ], timeout_s=300.0)
         if rc != 0:
             _abort(f"instance stop failed rc={rc}: {out.strip()[:300]}")
+            abort_reason = f"instance_stop_failed rc={rc}"
             return 7
 
         # If --force replacing an existing image, delete the old one first.
@@ -496,10 +637,12 @@ def _execute_bake(args: argparse.Namespace, node: str, startup_script: str) -> i
         ], timeout_s=900.0)
         if rc != 0:
             _abort(f"image create failed rc={rc}: {out.strip()[:400]}")
+            abort_reason = f"image_create_failed rc={rc}"
             return 8
         _log(f"golden image created: {args.image_name}")
 
         # 6. DELETE-TO-SNAPSHOT happens in the finally cleanup.
+        bake_succeeded = True
         _report_success(args, node, sample)
         return 0
     finally:
@@ -508,6 +651,13 @@ def _execute_bake(args: argparse.Namespace, node: str, startup_script: str) -> i
         except OSError:
             pass
         if node_exists:
+            # ABORT-AUTOPSY: on any non-success path (readiness timeout,
+            # early-failure, validation-fail, image-create-fail) -- capture
+            # node diagnostics BEFORE teardown so the operator can diagnose
+            # why the bake failed. Bounded + fail-soft: autopsy NEVER blocks
+            # teardown. A successful bake does NOT autopsy.
+            if not bake_succeeded:
+                _run_autopsy(args, node, abort_reason or "unknown_abort")
             # ALWAYS tear the node + disk down -- success or failure. The image
             # (if created) is the durable artifact; the VM must never linger.
             _cleanup_node(args, node)

--- a/scripts/bake_jprime_golden_image.py
+++ b/scripts/bake_jprime_golden_image.py
@@ -1,0 +1,591 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Sovereign J-Prime Golden-Image Bake -- one-time autonomous code-only image bake.
+
+Phase 1 of the Sovereign Provider Failover Lifecycle
+(spec: docs/superpowers/specs/2026-06-23-sovereign-provider-failover-lifecycle.md
+SS5/SS8/SS11). J-Prime is the last-resort code generator that AWAKENS when
+DoubleWord collapses (global outage) AND Claude is unavailable. To make the
+awaken path cheap, J-Prime lives DORMANT as a reusable GCP golden image
+(VM + disk deleted; image-only ~$0.50/mo) and is recreated on demand.
+
+This tool performs the ONE-TIME bake:
+
+    provision a cheap CPU node (ON-DEMAND for bake reliability)
+      -> install the Ollama serving runtime
+      -> pull the code model (qwen2.5-coder:7b) into RAM-backed serving
+      -> VALIDATE it actually generates Python code (the load-bearing lock)
+      -> snapshot the boot disk to a reusable GCP golden image
+      -> delete the bake VM + disk (the image is the durable artifact)
+
+VALIDATION LOCK: we NEVER snapshot a broken image. Before any image is created
+we run a real generation against the node's Ollama endpoint and require HTTP 200
++ a non-empty body containing plausible Python ('def '). On failure we ABORT,
+delete the node, and exit non-zero -- no image is created.
+
+NOTE: e2-highmem-2 is a CPU-only machine. The model is loaded in RAM and
+generates on CPU. There is NO GPU / NO VRAM here -- messages say
+"loaded in RAM + generating", never "VRAM".
+
+Standalone by design -- imports NOTHING from the JARVIS core. Pure
+subprocess(gcloud / gcloud-ssh) + stdlib. Fully parameterized (argparse with
+env-var defaults; zero hardcoding). Every gcloud call is fail-soft; after the
+node exists, the cleanup path ALWAYS attempts node + disk teardown so a failed
+bake never leaks billing.
+
+Usage:
+    # default DRY-RUN: print the full plan + every gcloud command, spend nothing
+    python3 scripts/bake_jprime_golden_image.py --dry-run
+
+    # actually bake (operator-monitored step, after review):
+    python3 scripts/bake_jprime_golden_image.py --execute
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import json
+import os
+import re
+import shlex
+import subprocess
+import sys
+import time
+from typing import List, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Defaults (every value is overridable via argparse; argparse defaults read env).
+# --------------------------------------------------------------------------- #
+_DEFAULT_PROJECT = os.environ.get("GCP_PROJECT", "jarvis-473803")
+_DEFAULT_ZONE = os.environ.get("GCP_ZONE", "us-central1-a")
+_DEFAULT_MACHINE = os.environ.get("JPRIME_BAKE_MACHINE", "e2-highmem-2")
+_DEFAULT_MODEL = os.environ.get("JPRIME_BAKE_MODEL", "qwen2.5-coder:7b")
+_DEFAULT_IMAGE_FAMILY = os.environ.get("JPRIME_IMAGE_FAMILY", "jarvis-prime-coder")
+_DEFAULT_BOOT_DISK = os.environ.get("JPRIME_BAKE_BOOT_DISK_SIZE", "30GB")
+_DEFAULT_BAKE_TIMEOUT_S = int(os.environ.get("JPRIME_BAKE_TIMEOUT_S", "1800"))
+_DEFAULT_DEBIAN_IMAGE_FAMILY = os.environ.get(
+    "JPRIME_BAKE_SOURCE_IMAGE_FAMILY", "debian-12"
+)
+_DEFAULT_DEBIAN_IMAGE_PROJECT = os.environ.get(
+    "JPRIME_BAKE_SOURCE_IMAGE_PROJECT", "debian-cloud"
+)
+
+# Readiness sentinel written by the startup-script ONLY after the model pull
+# completes -- the poll loop keys on this.
+_SENTINEL_PATH = "/var/run/jprime_bake_ready"
+_OLLAMA_PORT = 11434
+_VALIDATION_PROMPT = (
+    "Write a Python function is_even(n) that returns True if n is even."
+)
+
+
+def _now_stamp() -> str:
+    return _dt.datetime.now().strftime("%Y%m%d")
+
+
+def _default_image_name() -> str:
+    return os.environ.get(
+        "JPRIME_IMAGE_NAME", f"jarvis-prime-coder-golden-{_now_stamp()}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Logging.
+# --------------------------------------------------------------------------- #
+def _log(msg: str) -> None:
+    print(f"[BAKE] {msg}", flush=True)
+
+
+def _abort(msg: str) -> None:
+    print(f"[BAKE ABORTED: {msg}]", flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# THE single subprocess boundary. ALL gcloud / ssh funnel through here so tests
+# can intercept it with a monkeypatch and assert dry-run never executes.
+# --------------------------------------------------------------------------- #
+def _run(cmd: List[str], *, timeout_s: float = 120.0) -> Tuple[int, str]:
+    """Run a command fail-soft. Returns (returncode, combined_output).
+
+    Never raises -- a non-zero rc or an exception both surface as a failure
+    the caller inspects. This is the ONLY place the script touches subprocess.
+    """
+    try:
+        p = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout_s,
+        )
+        return p.returncode, (p.stdout or "") + (p.stderr or "")
+    except Exception as exc:  # noqa: BLE001 -- the bake never crashes on a call
+        return 1, f"[run failed: {exc!r}]"
+
+
+# --------------------------------------------------------------------------- #
+# Startup-script generator (installs Ollama, serves, pulls model, sentinels).
+# --------------------------------------------------------------------------- #
+def build_startup_script(model: str, *, sentinel_path: str = _SENTINEL_PATH) -> str:
+    """Return the metadata startup-script that bakes the node.
+
+    Installs Ollama, runs `ollama serve` (systemd if available, nohup fallback),
+    `ollama pull <model>`, and writes the readiness sentinel ONLY after the pull
+    completes. Pure string assembly -- no I/O, no subprocess. ASCII only.
+    """
+    model_q = shlex.quote(model)
+    sentinel_q = shlex.quote(sentinel_path)
+    return f"""#!/usr/bin/env bash
+# JARVIS J-Prime golden-image bake startup-script (auto-generated).
+# Installs the Ollama serving runtime, pulls the code model into RAM-backed
+# serving, and writes the readiness sentinel ONLY after the pull completes.
+set -uo pipefail
+
+LOG=/var/log/jprime_bake.log
+exec > >(tee -a "$LOG") 2>&1
+echo "[jprime-bake] startup-script begin $(date -u +%FT%TZ)"
+
+# Never leave a stale sentinel from a re-run.
+rm -f {sentinel_q} || true
+
+# 1. Install the Ollama serving runtime.
+echo "[jprime-bake] installing Ollama serving runtime"
+curl -fsSL https://ollama.com/install.sh | sh
+
+# 2. Serve. Prefer the systemd unit the installer ships; fall back to nohup.
+if systemctl list-unit-files 2>/dev/null | grep -q '^ollama.service'; then
+    echo "[jprime-bake] starting ollama via systemd"
+    systemctl enable ollama || true
+    systemctl restart ollama || true
+else
+    echo "[jprime-bake] systemd unit absent -- starting ollama via nohup"
+    nohup ollama serve > /var/log/ollama_serve.log 2>&1 &
+fi
+
+# 3. Wait for the Ollama HTTP endpoint to answer before pulling.
+echo "[jprime-bake] waiting for ollama endpoint on :{_OLLAMA_PORT}"
+for i in $(seq 1 60); do
+    if curl -fsS "http://localhost:{_OLLAMA_PORT}/api/tags" >/dev/null 2>&1; then
+        echo "[jprime-bake] ollama endpoint is up"
+        break
+    fi
+    sleep 5
+done
+
+# 4. Pull the code model (loaded in RAM + generating on CPU -- no GPU here).
+echo "[jprime-bake] pulling model {model_q}"
+if ollama pull {model_q}; then
+    echo "[jprime-bake] model pull complete -- writing readiness sentinel"
+    # Sentinel written ONLY after a successful pull.
+    echo "ready model={model} ts=$(date -u +%FT%TZ)" > {sentinel_q}
+    echo "[jprime-bake] startup-script done $(date -u +%FT%TZ)"
+else
+    echo "[jprime-bake] ERROR: ollama pull failed -- NOT writing sentinel"
+    exit 1
+fi
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Validation-verdict parser (the load-bearing lock).
+# --------------------------------------------------------------------------- #
+def parse_validation_verdict(
+    rc: int, body: str
+) -> Tuple[bool, str]:
+    """Decide PASS/ABORT from an SSH-curl generation result.
+
+    PASS iff the call succeeded (rc == 0), the body is non-empty, and it
+    contains plausible Python ('def '). Otherwise FAIL -- the caller ABORTS
+    and never snapshots.
+
+    The SSH transport returns rc==0 on a clean curl with HTTP 200 (we use
+    `curl --fail` upstream so a non-200 sets rc != 0). The body is the raw
+    Ollama JSON; we extract the generated text (`response` or chat `content`)
+    and look for `def `.
+
+    Returns (passed, reason). `reason` doubles as the sample/diagnostic.
+    """
+    if rc != 0:
+        return False, f"transport/HTTP failure (rc={rc})"
+    text = (body or "").strip()
+    if not text:
+        return False, "empty response body"
+
+    generated = _extract_generated_text(text)
+    if not generated:
+        return False, "no generated text in response body"
+    if "def " not in generated:
+        return False, f"no plausible Python ('def ' absent) in: {generated[:200]!r}"
+    return True, generated.strip()
+
+
+def _extract_generated_text(body: str) -> str:
+    """Pull the generated text out of an Ollama JSON body, fail-soft.
+
+    Handles /api/generate ({"response": "..."}) and the OpenAI-compat
+    /v1/chat/completions ({"choices":[{"message":{"content":"..."}}]}).
+    Falls back to the raw body if it isn't JSON (so a literal `def ` in plain
+    text still counts as a generation).
+    """
+    try:
+        obj = json.loads(body)
+    except Exception:  # noqa: BLE001
+        return body  # non-JSON: treat the raw text as the generation
+    if isinstance(obj, dict):
+        if isinstance(obj.get("response"), str):
+            return obj["response"]
+        choices = obj.get("choices")
+        if isinstance(choices, list) and choices:
+            msg = choices[0].get("message") if isinstance(choices[0], dict) else None
+            if isinstance(msg, dict) and isinstance(msg.get("content"), str):
+                return msg["content"]
+            # legacy completion shape
+            if isinstance(choices[0], dict) and isinstance(
+                choices[0].get("text"), str
+            ):
+                return choices[0]["text"]
+    return body
+
+
+# --------------------------------------------------------------------------- #
+# Awaken one-liner (what the lifecycle controller runs later to recreate).
+# --------------------------------------------------------------------------- #
+def build_awaken_one_liner(args: argparse.Namespace) -> str:
+    """The exact `gcloud compute instances create --image-family=...` the
+    failover lifecycle controller will run to AWAKEN J-Prime from this image."""
+    return (
+        "gcloud compute instances create jarvis-prime-failover "
+        f"--project={args.project} --zone={args.zone} "
+        f"--machine-type={args.machine_type} "
+        f"--image-family={args.image_family} "
+        f"--image-project={args.project} "
+        "--provisioning-model=SPOT "
+        "--instance-termination-action=DELETE"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# gcloud command builders (pure -- so dry-run can print them; _run executes).
+# --------------------------------------------------------------------------- #
+def _ssh_cmd(args: argparse.Namespace, node: str, remote: str) -> List[str]:
+    return [
+        "gcloud", "compute", "ssh", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--tunnel-through-iap", "--command", remote,
+    ]
+
+
+def _create_node_cmd(
+    args: argparse.Namespace, node: str, startup_script_path: str
+) -> List[str]:
+    # ON-DEMAND (no --provisioning-model=SPOT) for bake reliability: Spot is for
+    # the active failover burst, not the one-time bake.
+    return [
+        "gcloud", "compute", "instances", "create", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        f"--machine-type={args.machine_type}",
+        f"--image-family={args.source_image_family}",
+        f"--image-project={args.source_image_project}",
+        f"--boot-disk-size={args.boot_disk_size}",
+        "--boot-disk-type=pd-balanced",
+        f"--metadata-from-file=startup-script={startup_script_path}",
+    ]
+
+
+def _image_exists(args: argparse.Namespace) -> bool:
+    rc, _ = _run([
+        "gcloud", "compute", "images", "describe", args.image_name,
+        f"--project={args.project}", "--format=value(name)",
+    ])
+    return rc == 0
+
+
+# --------------------------------------------------------------------------- #
+# Cleanup (ALWAYS attempted once the node exists -- no orphaned billing).
+# --------------------------------------------------------------------------- #
+def _cleanup_node(args: argparse.Namespace, node: str) -> None:
+    """Delete the bake VM + its boot disk. Fail-soft, best-effort."""
+    _log(f"cleanup: deleting bake node {node} + disk (no orphaned billing)")
+    rc, out = _run([
+        "gcloud", "compute", "instances", "delete", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--delete-disks=all", "--quiet",
+    ], timeout_s=300.0)
+    if rc == 0:
+        _log(f"cleanup: node {node} + disk deleted")
+    else:
+        _log(f"cleanup: WARNING node delete rc={rc}: {out.strip()[:300]}")
+
+
+# --------------------------------------------------------------------------- #
+# Poll loop.
+# --------------------------------------------------------------------------- #
+def _poll_readiness(args: argparse.Namespace, node: str) -> bool:
+    """Poll the node (via SSH) for the sentinel + `ollama list` model presence.
+
+    Exponential-ish backoff, bounded by --bake-timeout-s. Returns True on ready.
+    """
+    deadline = time.monotonic() + float(args.bake_timeout_s)
+    delay = 15.0
+    attempt = 0
+    check = (
+        f"test -f {shlex.quote(_SENTINEL_PATH)} "
+        f"&& ollama list 2>/dev/null | grep -q {shlex.quote(args.model.split(':')[0])}"
+        " && echo JPRIME_READY || echo JPRIME_NOT_READY"
+    )
+    while time.monotonic() < deadline:
+        attempt += 1
+        rc, out = _run(_ssh_cmd(args, node, check), timeout_s=90.0)
+        if rc == 0 and "JPRIME_READY" in out:
+            _log(f"readiness: node ready (attempt {attempt})")
+            return True
+        remaining = int(deadline - time.monotonic())
+        _log(
+            f"readiness: not ready (attempt {attempt}, rc={rc}); "
+            f"{remaining}s left, sleeping {int(delay)}s"
+        )
+        if time.monotonic() + delay >= deadline:
+            break
+        time.sleep(delay)
+        delay = min(delay * 1.5, 120.0)
+    _log(f"readiness: TIMEOUT after {args.bake_timeout_s}s")
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# Validation (the load-bearing lock -- run a real generation before snapshot).
+# --------------------------------------------------------------------------- #
+def _validate_generation(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
+    """SSH-curl a real code-generation against the node's Ollama endpoint.
+
+    Uses `curl --fail` so a non-200 sets rc != 0. Returns (passed, sample).
+    """
+    payload = json.dumps({
+        "model": args.model,
+        "prompt": _VALIDATION_PROMPT,
+        "stream": False,
+    })
+    # Single-quote the JSON for the remote shell; curl --fail-with-body so we
+    # see a body even on a 4xx/5xx (and rc reflects the HTTP status).
+    remote = (
+        f"curl -fsS --max-time 300 "
+        f"http://localhost:{_OLLAMA_PORT}/api/generate "
+        f"-H 'Content-Type: application/json' "
+        f"-d {shlex.quote(payload)}"
+    )
+    _log("validation: running real generation against node Ollama endpoint")
+    rc, out = _run(_ssh_cmd(args, node, remote), timeout_s=360.0)
+    return parse_validation_verdict(rc, out)
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run plan printer.
+# --------------------------------------------------------------------------- #
+def _print_plan(args: argparse.Namespace, node: str, startup_script: str) -> None:
+    print("=" * 72)
+    print("J-PRIME GOLDEN-IMAGE BAKE -- PLAN (dry-run, spends nothing)")
+    print("=" * 72)
+    print(f"  project        : {args.project}")
+    print(f"  zone           : {args.zone}")
+    print(f"  machine-type   : {args.machine_type}  (CPU-only; model in RAM)")
+    print(f"  model          : {args.model}")
+    print(f"  bake node      : {node}  (ON-DEMAND for bake reliability)")
+    print(f"  source image   : {args.source_image_family}/{args.source_image_project}")
+    print(f"  boot disk      : {args.boot_disk_size}")
+    print(f"  bake timeout   : {args.bake_timeout_s}s")
+    print(f"  -> image name  : {args.image_name}")
+    print(f"  -> image family: {args.image_family}")
+    print("-" * 72)
+    print("STARTUP-SCRIPT (metadata startup-script):")
+    print(startup_script)
+    print("-" * 72)
+    print("GCLOUD COMMANDS THAT WOULD RUN (in order):")
+    print("  1. PROVISION:")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _create_node_cmd(args, node, "<startup-script-tmpfile>")))
+    print("  2. POLL READINESS (repeated, bounded):")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _ssh_cmd(args, node, "test -f " + _SENTINEL_PATH + " ...")))
+    print("  3. VALIDATION LOCK (real generation; NO snapshot unless PASS):")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _ssh_cmd(args, node,
+                                       f"curl ... localhost:{_OLLAMA_PORT}/api/generate")))
+    print("  4. STOP instance (consistent image):")
+    print(f"     gcloud compute instances stop {node} "
+          f"--project={args.project} --zone={args.zone} --quiet")
+    print("  5. CREATE GOLDEN IMAGE:")
+    print(f"     gcloud compute images create {args.image_name} "
+          f"--project={args.project} --source-disk={node} "
+          f"--source-disk-zone={args.zone} --family={args.image_family}")
+    print("  6. DELETE-TO-SNAPSHOT (node + disk; image is the durable artifact):")
+    print(f"     gcloud compute instances delete {node} "
+          f"--project={args.project} --zone={args.zone} --delete-disks=all --quiet")
+    print("-" * 72)
+    print("DORMANT FOOTPRINT: image-only (VM + disk deleted) ~ $0.50/mo")
+    print("AWAKEN ONE-LINER (used later by the failover lifecycle controller):")
+    print("  " + build_awaken_one_liner(args))
+    print("=" * 72)
+    print("[BAKE] --dry-run: nothing executed, no money spent. Use --execute to bake.")
+
+
+# --------------------------------------------------------------------------- #
+# Execute pipeline.
+# --------------------------------------------------------------------------- #
+def _execute_bake(args: argparse.Namespace, node: str, startup_script: str) -> int:
+    # Idempotency guard: refuse to clobber an existing image unless --force.
+    if _image_exists(args):
+        if not args.force:
+            _abort(
+                f"image '{args.image_name}' already exists -- "
+                "rerun with --force to replace, or pass a new --image-name"
+            )
+            return 3
+        _log(f"WARNING: image '{args.image_name}' exists -- --force given, "
+             "will delete + recreate after a clean bake")
+
+    # Write the startup-script to a tmpfile for --metadata-from-file.
+    import tempfile
+    fd, sp_path = tempfile.mkstemp(prefix="jprime_startup_", suffix=".sh")
+    node_exists = False
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(startup_script)
+
+        # 1. PROVISION (ON-DEMAND).
+        _log(f"provisioning bake node {node} (ON-DEMAND, {args.machine_type})")
+        rc, out = _run(_create_node_cmd(args, node, sp_path), timeout_s=300.0)
+        if rc != 0:
+            _abort(f"provision failed rc={rc}: {out.strip()[:400]}")
+            return 4
+        node_exists = True
+        _log(f"node {node} created; startup-script installing Ollama + pulling model")
+
+        # 2. POLL READINESS.
+        if not _poll_readiness(args, node):
+            _abort("readiness timeout -- model never finished pulling")
+            return 5
+
+        # 3. VALIDATION LOCK -- never snapshot a broken image.
+        passed, sample = _validate_generation(args, node)
+        if not passed:
+            _abort(f"validation failed: {sample}")
+            return 6
+        _log("validation: PASS -- node generated plausible Python (loaded in RAM)")
+        _log(f"validation sample: {sample[:300]!r}")
+
+        # 4. STOP for a consistent image.
+        _log(f"stopping {node} for a consistent image snapshot")
+        rc, out = _run([
+            "gcloud", "compute", "instances", "stop", node,
+            f"--project={args.project}", f"--zone={args.zone}", "--quiet",
+        ], timeout_s=300.0)
+        if rc != 0:
+            _abort(f"instance stop failed rc={rc}: {out.strip()[:300]}")
+            return 7
+
+        # If --force replacing an existing image, delete the old one first.
+        if args.force and _image_exists(args):
+            _log(f"--force: deleting existing image {args.image_name}")
+            _run([
+                "gcloud", "compute", "images", "delete", args.image_name,
+                f"--project={args.project}", "--quiet",
+            ], timeout_s=300.0)
+
+        # 5. CREATE GOLDEN IMAGE.
+        _log(f"creating golden image {args.image_name} (family={args.image_family})")
+        rc, out = _run([
+            "gcloud", "compute", "images", "create", args.image_name,
+            f"--project={args.project}", f"--source-disk={node}",
+            f"--source-disk-zone={args.zone}", f"--family={args.image_family}",
+        ], timeout_s=900.0)
+        if rc != 0:
+            _abort(f"image create failed rc={rc}: {out.strip()[:400]}")
+            return 8
+        _log(f"golden image created: {args.image_name}")
+
+        # 6. DELETE-TO-SNAPSHOT happens in the finally cleanup.
+        _report_success(args, node, sample)
+        return 0
+    finally:
+        try:
+            os.unlink(sp_path)
+        except OSError:
+            pass
+        if node_exists:
+            # ALWAYS tear the node + disk down -- success or failure. The image
+            # (if created) is the durable artifact; the VM must never linger.
+            _cleanup_node(args, node)
+
+
+def _report_success(args: argparse.Namespace, node: str, sample: str) -> None:
+    print("=" * 72)
+    print("[BAKE] SUCCESS -- golden image baked + validated")
+    print("=" * 72)
+    print(f"  image name   : {args.image_name}")
+    print(f"  image family : {args.image_family}")
+    print(f"  model        : {args.model} (loaded in RAM + generating on CPU)")
+    print("  validation   : PASS (real generation produced plausible Python)")
+    print(f"  sample       : {sample[:200]!r}")
+    print("  dormant cost : image-only (VM + disk deleted) ~ $0.50/mo")
+    print("-" * 72)
+    print("  AWAKEN later (failover lifecycle controller):")
+    print("    " + build_awaken_one_liner(args))
+    print("=" * 72)
+
+
+# --------------------------------------------------------------------------- #
+# CLI.
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "One-time autonomous bake of the J-Prime code-only golden image "
+            "(provision -> install Ollama -> pull model -> VALIDATE -> "
+            "snapshot -> delete-to-snapshot). Default is --dry-run."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--project", default=_DEFAULT_PROJECT,
+                   help="GCP project (env GCP_PROJECT)")
+    p.add_argument("--zone", default=_DEFAULT_ZONE,
+                   help="GCP zone (env GCP_ZONE)")
+    p.add_argument("--machine-type", default=_DEFAULT_MACHINE,
+                   help="bake machine type (CPU-only; model in RAM)")
+    p.add_argument("--model", default=_DEFAULT_MODEL,
+                   help="Ollama code model to pull")
+    p.add_argument("--image-name", default=_default_image_name(),
+                   help="golden image name (env JPRIME_IMAGE_NAME)")
+    p.add_argument("--image-family", default=_DEFAULT_IMAGE_FAMILY,
+                   help="golden image family (env JPRIME_IMAGE_FAMILY)")
+    p.add_argument("--boot-disk-size", default=_DEFAULT_BOOT_DISK,
+                   help="bake node boot disk size")
+    p.add_argument("--bake-timeout-s", type=int, default=_DEFAULT_BAKE_TIMEOUT_S,
+                   help="readiness poll timeout (seconds)")
+    p.add_argument("--source-image-family", default=_DEFAULT_DEBIAN_IMAGE_FAMILY,
+                   help="base OS image family (Debian)")
+    p.add_argument("--source-image-project", default=_DEFAULT_DEBIAN_IMAGE_PROJECT,
+                   help="base OS image project")
+    p.add_argument("--node-name", default=None,
+                   help="bake node name (default jarvis-prime-bake-<stamp>)")
+    p.add_argument("--force", action="store_true",
+                   help="replace an existing image of the same name")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="dry_run", action="store_true",
+                      help="print the plan + commands WITHOUT executing (default)")
+    mode.add_argument("--execute", dest="dry_run", action="store_false",
+                      help="actually run the bake (spends money)")
+    p.set_defaults(dry_run=True)
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    node = args.node_name or f"jarvis-prime-bake-{_now_stamp()}-{int(time.time()) % 100000}"
+    startup_script = build_startup_script(args.model)
+
+    if args.dry_run:
+        _print_plan(args, node, startup_script)
+        return 0
+
+    _log("EXECUTE mode -- this WILL provision a GCP node and spend money")
+    return _execute_bake(args, node, startup_script)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/bake_jprime_golden_image.py
+++ b/scripts/bake_jprime_golden_image.py
@@ -138,9 +138,16 @@ def build_startup_script(model: str, *, sentinel_path: str = _SENTINEL_PATH) -> 
 # serving, and writes the readiness sentinel ONLY after the pull completes.
 set -uo pipefail
 
+# ROOT-CAUSE FIX (v1 bake abort): Ollama (Go) calls envconfig.Models() at CLI
+# AND server startup and PANICS with "$HOME is not defined". GCP metadata
+# startup-scripts run as root with HOME unset, so both `ollama serve` (nohup)
+# and the `ollama pull` CLI died instantly. Export HOME before ANY ollama call.
+export HOME=/root
+export OLLAMA_HOST=127.0.0.1:{_OLLAMA_PORT}
+
 LOG=/var/log/jprime_bake.log
 exec > >(tee -a "$LOG") 2>&1
-echo "[jprime-bake] startup-script begin $(date -u +%FT%TZ)"
+echo "[jprime-bake] startup-script begin $(date -u +%FT%TZ) (HOME=$HOME)"
 
 # Never leave a stale sentinel from a re-run.
 rm -f {sentinel_q} || true
@@ -149,13 +156,16 @@ rm -f {sentinel_q} || true
 echo "[jprime-bake] installing Ollama serving runtime"
 curl -fsSL https://ollama.com/install.sh | sh
 
-# 2. Serve. Prefer the systemd unit the installer ships; fall back to nohup.
-if systemctl list-unit-files 2>/dev/null | grep -q '^ollama.service'; then
+# 2. Serve. Prefer the systemd unit the installer ships (it runs ollama with a
+#    correct per-service HOME); fall back to nohup (HOME exported above) only if
+#    systemd is not the init. Detect via /run/systemd/system -- NOT a brittle
+#    unit-name grep, which raced the installer and wrongly chose nohup in v1.
+if [ -d /run/systemd/system ]; then
     echo "[jprime-bake] starting ollama via systemd"
-    systemctl enable ollama || true
-    systemctl restart ollama || true
+    systemctl daemon-reload || true
+    systemctl enable --now ollama || systemctl restart ollama || true
 else
-    echo "[jprime-bake] systemd unit absent -- starting ollama via nohup"
+    echo "[jprime-bake] systemd not init -- starting ollama via nohup (HOME=$HOME)"
     nohup ollama serve > /var/log/ollama_serve.log 2>&1 &
 fi
 

--- a/tests/governance/test_outage_ledger.py
+++ b/tests/governance/test_outage_ledger.py
@@ -1,0 +1,256 @@
+"""tests/governance/test_outage_ledger.py -- Unit tests for OutageLedger.
+
+All tests use tmp_path and a direct OutageLedger(path=..., max_records=...)
+instantiation to avoid touching the global singleton or any real .jarvis dir.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.outage_ledger import (
+    OutageLedger,
+    OutageRecord,
+    _INFLIGHT_TASKS,
+    emit_outage_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ledger(tmp_path, max_records: int = 50) -> OutageLedger:
+    return OutageLedger(
+        path=str(tmp_path / "test_ledger.jsonl"),
+        max_records=max_records,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 1: open/close round-trip
+# ---------------------------------------------------------------------------
+
+def test_open_close_round_trip(tmp_path):
+    ledger = _make_ledger(tmp_path)
+    oid = ledger.open_outage(
+        failure_mode="TIMEOUT",
+        error_codes=["err-1"],
+        lane="batch",
+        model_ids=["model-a"],
+        dilation_hops=3,
+    )
+    assert oid, "open_outage should return a non-empty id"
+
+    records_before = ledger.recent(10)
+    assert len(records_before) == 1
+    assert records_before[0].ended_ts is None
+    assert records_before[0].duration_s is None
+
+    ledger.close_outage(oid, served_by_jprime=True, jprime_uptime_s=42.5)
+
+    records_after = ledger.recent(10)
+    assert len(records_after) == 1
+    rec = records_after[0]
+    assert rec.ended_ts is not None, "ended_ts should be stamped after close"
+    assert rec.duration_s is not None, "duration_s should be stamped after close"
+    assert rec.duration_s >= 0.0
+    assert rec.served_by_jprime is True
+    assert rec.jprime_uptime_s == pytest.approx(42.5)
+
+
+# ---------------------------------------------------------------------------
+# Test 2: bounded ring
+# ---------------------------------------------------------------------------
+
+def test_bounded_ring(tmp_path):
+    max_n = 5
+    ledger = _make_ledger(tmp_path, max_records=max_n)
+    # Open and close max_n + 5 outages
+    for i in range(max_n + 5):
+        oid = ledger.open_outage(lane=f"lane-{i}")
+        ledger.close_outage(oid)
+
+    records = ledger.recent(100)
+    assert len(records) <= max_n, (
+        f"ring should be bounded to {max_n}, got {len(records)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 3: recent(n) limit
+# ---------------------------------------------------------------------------
+
+def test_recent_n(tmp_path):
+    ledger = _make_ledger(tmp_path, max_records=50)
+    for i in range(10):
+        oid = ledger.open_outage(lane=f"lane-{i}")
+        ledger.close_outage(oid)
+
+    result = ledger.recent(3)
+    assert len(result) == 3
+
+
+# ---------------------------------------------------------------------------
+# Test 4: has_open_outage true and false
+# ---------------------------------------------------------------------------
+
+def test_has_open_outage_true_and_false(tmp_path):
+    ledger = _make_ledger(tmp_path)
+    assert not ledger.has_open_outage(), "should be False when empty"
+
+    oid = ledger.open_outage(lane="realtime")
+    assert ledger.has_open_outage(), "should be True after open"
+
+    ledger.close_outage(oid)
+    assert not ledger.has_open_outage(), "should be False after close"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: dedup -- double open returns same id
+# ---------------------------------------------------------------------------
+
+def test_dedup_double_open(tmp_path):
+    ledger = _make_ledger(tmp_path)
+    id1 = ledger.open_outage(lane="batch+realtime", failure_mode="TIMEOUT")
+    id2 = ledger.open_outage(lane="batch+realtime", failure_mode="TIMEOUT")
+    assert id1 == id2, "second open on same lane should return the existing id"
+
+    # Only one record should exist
+    records = ledger.recent(50)
+    assert len(records) == 1
+
+
+# ---------------------------------------------------------------------------
+# Test 6: fail-soft on corrupt file
+# ---------------------------------------------------------------------------
+
+def test_fail_soft_corrupt_file(tmp_path):
+    p = tmp_path / "test_ledger.jsonl"
+    p.write_text("NOT-JSON-AT-ALL\n{{{broken}}}\n", encoding="utf-8")
+    ledger = OutageLedger(path=str(p), max_records=50)
+    result = ledger.recent(10)
+    assert result == [], "corrupt file should return empty list, not raise"
+    assert not ledger.has_open_outage()
+
+
+# ---------------------------------------------------------------------------
+# Test 7: emit with no running loop -- no raise
+# ---------------------------------------------------------------------------
+
+def test_emit_no_running_loop_no_raise(tmp_path):
+    # Make sure we are outside an event loop
+    ledger = _make_ledger(tmp_path)
+    oid = ledger.open_outage(lane="batch")
+    records = ledger.recent(1)
+    assert records
+    rec = records[0]
+    # Should not raise even with no running loop
+    emit_outage_event("DW_OUTAGE_DETECTED", rec)
+
+
+# ---------------------------------------------------------------------------
+# Test 8: emit fire-and-forget with fake bus
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_emit_fire_and_forget_with_fake_bus(tmp_path, monkeypatch):
+    publish_calls = []
+
+    class FakeBus:
+        _running = True
+
+        async def publish(self, event, persist=True):  # noqa: ARG002
+            publish_calls.append(event)
+            return "fake-event-id"
+
+    import backend.core.ouroboros.governance.outage_ledger as _mod
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.outage_ledger._export_enabled",
+        lambda: True,
+    )
+
+    async def fake_get_bus_if_exists():
+        return FakeBus()
+
+    # Patch _publish_outage_event to use the fake bus directly
+    async def _fake_publish(kind: str, record: OutageRecord) -> None:
+        bus = FakeBus()
+        from backend.core.trinity_event_bus import TrinityEvent, EventPriority, RepoType
+        event = TrinityEvent(
+            topic=kind,
+            source=RepoType.JARVIS,
+            priority=EventPriority.HIGH,
+            payload=record.to_dict(),
+        )
+        await bus.publish(event, persist=True)
+
+    monkeypatch.setattr(_mod, "_publish_outage_event", _fake_publish)
+
+    ledger = _make_ledger(tmp_path)
+    oid = ledger.open_outage(lane="batch")
+    records = ledger.recent(1)
+    assert records
+    rec = records[0]
+
+    emit_outage_event("DW_OUTAGE_DETECTED", rec)
+    # Let the task run
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert len(publish_calls) == 1, f"expected 1 publish call, got {len(publish_calls)}"
+    assert publish_calls[0].topic == "DW_OUTAGE_DETECTED"
+
+
+# ---------------------------------------------------------------------------
+# Test 9: export disabled gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_export_disabled_gate(tmp_path, monkeypatch):
+    publish_calls = []
+
+    monkeypatch.setenv("JARVIS_TRINITY_OUTAGE_EXPORT_ENABLED", "false")
+
+    import backend.core.ouroboros.governance.outage_ledger as _mod
+
+    async def _fake_publish(kind: str, record: OutageRecord) -> None:
+        publish_calls.append(kind)
+
+    monkeypatch.setattr(_mod, "_publish_outage_event", _fake_publish)
+
+    ledger = _make_ledger(tmp_path)
+    oid = ledger.open_outage(lane="batch")
+    records = ledger.recent(1)
+    assert records
+    rec = records[0]
+
+    emit_outage_event("DW_OUTAGE_DETECTED", rec)
+    await asyncio.sleep(0)
+    await asyncio.sleep(0)
+
+    assert len(publish_calls) == 0, "publish should NOT be called when export is disabled"
+
+
+# ---------------------------------------------------------------------------
+# Test 10: master off -- all noop
+# ---------------------------------------------------------------------------
+
+def test_master_off_all_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_OUTAGE_LEDGER_ENABLED", "false")
+    p = tmp_path / "test_ledger.jsonl"
+    ledger = OutageLedger(path=str(p), max_records=50)
+
+    oid = ledger.open_outage(lane="batch")
+    assert oid == "", "open_outage should return '' when disabled"
+    ledger.close_outage(oid)
+    result = ledger.recent(10)
+    assert result == []
+    assert not ledger.has_open_outage()
+    # No file should be written
+    assert not p.exists(), "no file should be written when master is off"

--- a/tests/scripts/test_bake_jprime_golden_image.py
+++ b/tests/scripts/test_bake_jprime_golden_image.py
@@ -42,6 +42,12 @@ def test_startup_script_installs_ollama_pulls_model_and_sentinels(bake):
     assert "ollama.com/install.sh" in script  # installs Ollama
     assert "ollama pull qwen2.5-coder:7b" in script  # pulls the model
     assert "ollama serve" in script  # serves
+    # ROOT-CAUSE REGRESSION GUARD (v1 bake abort): HOME must be exported before
+    # any ollama call, else the Go CLI/server panics "$HOME is not defined".
+    assert "export HOME=" in script
+    # before the actual pull COMMAND (use the full command, not the bare words
+    # which also appear in the explanatory comment).
+    assert script.index("export HOME=") < script.index("ollama pull qwen2.5-coder:7b")
     # sentinel written ONLY after the pull (inside the success branch)
     assert "/var/run/jprime_bake_ready" in script
     assert script.startswith("#!")

--- a/tests/scripts/test_bake_jprime_golden_image.py
+++ b/tests/scripts/test_bake_jprime_golden_image.py
@@ -29,6 +29,11 @@ def bake():
     return _load_module()
 
 
+def _noop_autopsy_dir(bake, monkeypatch, tmp_path):
+    """Redirect autopsy output to tmp_path so tests don't litter the working dir."""
+    monkeypatch.setattr(bake, "_AUTOPSY_DIR", str(tmp_path / "autopsy_reports"))
+
+
 # --------------------------------------------------------------------------- #
 # Startup-script generator.
 # --------------------------------------------------------------------------- #
@@ -140,8 +145,9 @@ def test_dry_run_does_not_invoke_run(bake, monkeypatch, capsys):
     assert "nothing executed" in out.lower()
 
 
-def test_execute_invokes_run_and_validates(bake, monkeypatch):
+def test_execute_invokes_run_and_validates(bake, monkeypatch, tmp_path):
     calls = []
+    _noop_autopsy_dir(bake, monkeypatch, tmp_path)
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
@@ -170,8 +176,9 @@ def test_execute_invokes_run_and_validates(bake, monkeypatch):
     assert any("instances delete bake-node" in f for f in flat)
 
 
-def test_execute_aborts_and_does_not_snapshot_on_validation_fail(bake, monkeypatch):
+def test_execute_aborts_and_does_not_snapshot_on_validation_fail(bake, monkeypatch, tmp_path):
     calls = []
+    _noop_autopsy_dir(bake, monkeypatch, tmp_path)
 
     def fake_run(cmd, **kwargs):
         calls.append(cmd)
@@ -211,3 +218,180 @@ def test_execute_aborts_when_image_exists_without_force(bake, monkeypatch):
     flat = [" ".join(c) for c in calls]
     # never provisioned a node.
     assert not any("instances create" in f for f in flat)
+
+
+# --------------------------------------------------------------------------- #
+# NEW: Autopsy fires before teardown on all abort paths (capability 3).
+# --------------------------------------------------------------------------- #
+
+def test_autopsy_fires_before_teardown_on_readiness_timeout(bake, monkeypatch, tmp_path):
+    """Autopsy SSH commands must precede the instances-delete call on timeout."""
+    call_log: list = []
+    _noop_autopsy_dir(bake, monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        call_log.append(list(cmd))
+        joined = " ".join(cmd)
+        if "images" in cmd and "describe" in cmd:
+            return 1, "NOT_FOUND"
+        # Sentinel check: always NOT_READY so timeout is hit.
+        if "ssh" in cmd and "JPRIME_READY" in joined:
+            return 0, "JPRIME_NOT_READY\n"
+        # Bake log tail (progress + early-fail check): no error markers.
+        if "ssh" in cmd and "tail" in joined and "jprime_bake.log" in joined:
+            return 0, "[jprime-bake] pulling model qwen2.5-coder:7b\n"
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    # Use a very short timeout so the test is not slow.
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node", "--bake-timeout-s", "1"])
+    assert rc == 5  # readiness-timeout exit code
+
+    flat = [" ".join(c) for c in call_log]
+    # Autopsy SSH commands (cat jprime_bake.log, ollama list, etc.) must appear.
+    autopsy_calls = [f for f in flat if "ssh" in f and (
+        "jprime_bake.log" in f or "ollama list" in f or "systemctl" in f
+        or "journalctl" in f or "df -h" in f or "api/tags" in f
+        or "ollama_serve.log" in f
+    )]
+    delete_calls = [f for f in flat if "instances delete" in f]
+    assert autopsy_calls, "expected autopsy SSH calls to be issued before teardown"
+    assert delete_calls, "expected teardown (instances delete) to still run"
+
+    # Assert ordering: ALL autopsy calls precede the first delete call.
+    # Find the index of the first delete call.
+    delete_idx = next(i for i, f in enumerate(flat) if "instances delete" in f)
+    # Every autopsy SSH call must come before the delete call.
+    for ac in autopsy_calls:
+        ac_idx = next(i for i, f in enumerate(flat) if f == ac)
+        assert ac_idx < delete_idx, (
+            f"autopsy call '{ac}' appeared AFTER instances delete (idx {ac_idx} >= {delete_idx})"
+        )
+
+
+def test_autopsy_fires_before_teardown_on_validation_fail(bake, monkeypatch, tmp_path):
+    """Autopsy must also precede teardown when validation fails (abort rc=6)."""
+    call_log: list = []
+    _noop_autopsy_dir(bake, monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        call_log.append(list(cmd))
+        joined = " ".join(cmd)
+        if "images" in cmd and "describe" in cmd:
+            return 1, "NOT_FOUND"
+        if "ssh" in cmd and "JPRIME_READY" in joined:
+            return 0, "JPRIME_READY\n"
+        if "ssh" in cmd and "api/generate" in joined:
+            return 0, '{"response": "I refuse."}'  # validation FAIL
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node"])
+    assert rc == 6  # validation-fail exit code
+
+    flat = [" ".join(c) for c in call_log]
+    autopsy_calls = [f for f in flat if "ssh" in f and (
+        "jprime_bake.log" in f or "ollama list" in f or "systemctl" in f
+        or "df -h" in f or "api/tags" in f
+    )]
+    delete_calls = [f for f in flat if "instances delete" in f]
+    assert autopsy_calls, "autopsy SSH calls must fire on validation-fail abort"
+    assert delete_calls, "teardown must still run after autopsy"
+
+    delete_idx = next(i for i, f in enumerate(flat) if "instances delete" in f)
+    for ac in autopsy_calls:
+        ac_idx = next(i for i, f in enumerate(flat) if f == ac)
+        assert ac_idx < delete_idx, (
+            f"autopsy call appeared AFTER teardown (idx {ac_idx} >= {delete_idx})"
+        )
+
+
+def test_early_failure_detection_aborts_without_full_timeout(bake, monkeypatch, tmp_path):
+    """When the bake log contains an ERROR marker, abort immediately (rc=5)."""
+    call_log: list = []
+    _noop_autopsy_dir(bake, monkeypatch, tmp_path)
+
+    sentinel_attempts = [0]
+
+    def fake_run(cmd, **kwargs):
+        call_log.append(list(cmd))
+        joined = " ".join(cmd)
+        if "images" in cmd and "describe" in cmd:
+            return 1, "NOT_FOUND"
+        # Sentinel check: NOT_READY.
+        if "ssh" in cmd and "JPRIME_READY" in joined:
+            sentinel_attempts[0] += 1
+            return 0, "JPRIME_NOT_READY\n"
+        # Bake log tail: returns an ERROR marker immediately.
+        if "ssh" in cmd and "tail" in joined and "jprime_bake.log" in joined:
+            return 0, "[jprime-bake] ERROR: ollama pull failed\n"
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    # Long timeout -- the test must NOT take 300s; the early-fail must cut it.
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node", "--bake-timeout-s", "300"])
+    assert rc == 5  # early-fail + readiness abort share exit code 5
+
+    # Should have short-circuited after at most 1-2 sentinel checks.
+    assert sentinel_attempts[0] <= 2, (
+        f"expected early abort after <=2 sentinel checks, got {sentinel_attempts[0]}"
+    )
+
+
+def test_live_progress_poll_issues_log_tail_ssh(bake, monkeypatch, tmp_path):
+    """Each readiness poll that gets NOT_READY must also issue a tail SSH."""
+    tail_calls: list = []
+    _noop_autopsy_dir(bake, monkeypatch, tmp_path)
+
+    ready_calls = [0]
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "images" in cmd and "describe" in cmd:
+            return 1, "NOT_FOUND"
+        if "ssh" in cmd and "JPRIME_READY" in joined:
+            ready_calls[0] += 1
+            if ready_calls[0] >= 2:
+                return 0, "JPRIME_READY\n"   # ready on 2nd attempt
+            return 0, "JPRIME_NOT_READY\n"   # 1st attempt: not ready
+        if "ssh" in cmd and "tail" in joined and "jprime_bake.log" in joined:
+            tail_calls.append(cmd)
+            return 0, "[jprime-bake] pulling model\n"
+        if "ssh" in cmd and "api/generate" in joined:
+            return 0, '{"response": "def is_even(n): return n % 2 == 0"}'
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node"])
+    assert rc == 0
+    # At least one tail call was issued (for the NOT_READY attempt).
+    assert tail_calls, "expected at least one tail-log SSH call during the NOT_READY poll"
+
+
+def test_successful_bake_does_not_write_autopsy(bake, monkeypatch, tmp_path):
+    """A successful bake must NOT produce any autopsy file."""
+    autopsy_dir = tmp_path / "autopsy_reports"
+    _noop_autopsy_dir(bake, monkeypatch, tmp_path)
+
+    def fake_run(cmd, **kwargs):
+        joined = " ".join(cmd)
+        if "images" in cmd and "describe" in cmd:
+            return 1, "NOT_FOUND"
+        if "ssh" in cmd and "JPRIME_READY" in joined:
+            return 0, "JPRIME_READY\n"
+        if "ssh" in cmd and "api/generate" in joined:
+            return 0, '{"response": "def is_even(n): return n % 2 == 0"}'
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node"])
+    assert rc == 0
+    # autopsy dir must either not exist or be empty.
+    if autopsy_dir.exists():
+        reports = list(autopsy_dir.glob("*.log"))
+        assert reports == [], f"unexpected autopsy files on success: {reports}"

--- a/tests/scripts/test_bake_jprime_golden_image.py
+++ b/tests/scripts/test_bake_jprime_golden_image.py
@@ -1,0 +1,213 @@
+# -*- coding: utf-8 -*-
+"""Pure-logic tests for scripts/bake_jprime_golden_image.py.
+
+No real gcloud. ALL subprocess goes through the script's single `_run` boundary,
+which these tests monkeypatch to assert dry-run never executes and execute does.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "bake_jprime_golden_image.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bake_jprime_golden_image", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def bake():
+    return _load_module()
+
+
+# --------------------------------------------------------------------------- #
+# Startup-script generator.
+# --------------------------------------------------------------------------- #
+def test_startup_script_installs_ollama_pulls_model_and_sentinels(bake):
+    script = bake.build_startup_script("qwen2.5-coder:7b")
+    assert "ollama.com/install.sh" in script  # installs Ollama
+    assert "ollama pull qwen2.5-coder:7b" in script  # pulls the model
+    assert "ollama serve" in script  # serves
+    # sentinel written ONLY after the pull (inside the success branch)
+    assert "/var/run/jprime_bake_ready" in script
+    assert script.startswith("#!")
+    # ASCII only.
+    script.encode("ascii")
+
+
+def test_startup_script_sentinel_uses_custom_model(bake):
+    script = bake.build_startup_script("codellama:13b")
+    assert "ollama pull codellama:13b" in script
+
+
+# --------------------------------------------------------------------------- #
+# Validation-verdict parser (the load-bearing lock).
+# --------------------------------------------------------------------------- #
+def test_validation_pass_on_200_with_def(bake):
+    body = '{"response": "def is_even(n):\\n    return n % 2 == 0"}'
+    passed, reason = bake.parse_validation_verdict(0, body)
+    assert passed is True
+    assert "def " in reason
+
+
+def test_validation_pass_on_openai_chat_shape(bake):
+    body = (
+        '{"choices":[{"message":{"content":"Here:\\ndef is_even(n): return n%2==0"}}]}'
+    )
+    passed, reason = bake.parse_validation_verdict(0, body)
+    assert passed is True
+
+
+def test_validation_fail_on_empty_body(bake):
+    passed, reason = bake.parse_validation_verdict(0, "")
+    assert passed is False
+    assert "empty" in reason.lower()
+
+
+def test_validation_fail_on_non_200(bake):
+    # curl --fail sets rc != 0 on a non-200; the parser must ABORT.
+    passed, reason = bake.parse_validation_verdict(22, '{"response": "def x(): pass"}')
+    assert passed is False
+    assert "rc=" in reason
+
+
+def test_validation_fail_on_no_def(bake):
+    body = '{"response": "I cannot help with that."}'
+    passed, reason = bake.parse_validation_verdict(0, body)
+    assert passed is False
+    assert "def " in reason  # reason explains 'def ' is absent
+
+
+def test_validation_handles_non_json_raw_text(bake):
+    passed, reason = bake.parse_validation_verdict(0, "def is_even(n): return True")
+    assert passed is True
+
+
+# --------------------------------------------------------------------------- #
+# Awaken one-liner.
+# --------------------------------------------------------------------------- #
+def test_awaken_one_liner_references_image_family(bake):
+    args = bake.build_parser().parse_args(
+        ["--image-family", "jarvis-prime-coder", "--project", "p", "--zone", "z"]
+    )
+    line = bake.build_awaken_one_liner(args)
+    assert "--image-family=jarvis-prime-coder" in line
+    assert "gcloud compute instances create" in line
+
+
+# --------------------------------------------------------------------------- #
+# argparse defaults honor env vars.
+# --------------------------------------------------------------------------- #
+def test_argparse_defaults_honor_env(monkeypatch):
+    monkeypatch.setenv("GCP_PROJECT", "env-project-xyz")
+    monkeypatch.setenv("JPRIME_BAKE_MODEL", "env-model:1b")
+    monkeypatch.setenv("JPRIME_IMAGE_FAMILY", "env-family")
+    mod = _load_module()  # re-load so module-level env defaults re-read
+    args = mod.build_parser().parse_args([])
+    assert args.project == "env-project-xyz"
+    assert args.model == "env-model:1b"
+    assert args.image_family == "env-family"
+
+
+def test_argparse_default_is_dry_run(bake):
+    args = bake.build_parser().parse_args([])
+    assert args.dry_run is True
+    args2 = bake.build_parser().parse_args(["--execute"])
+    assert args2.dry_run is False
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run never executes; execute does (monkeypatched _run boundary).
+# --------------------------------------------------------------------------- #
+def test_dry_run_does_not_invoke_run(bake, monkeypatch, capsys):
+    calls = []
+    monkeypatch.setattr(bake, "_run", lambda *a, **k: calls.append(a) or (0, ""))
+    rc = bake.main(["--dry-run", "--project", "p", "--zone", "z"])
+    assert rc == 0
+    assert calls == []  # NOT called in dry-run
+    out = capsys.readouterr().out
+    assert "PLAN" in out
+    assert "AWAKEN ONE-LINER" in out
+    assert "nothing executed" in out.lower()
+
+
+def test_execute_invokes_run_and_validates(bake, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        joined = " ".join(cmd)
+        # image describe -> not found (so the idempotency guard passes)
+        if "images" in cmd and "describe" in cmd:
+            return 1, "NOT_FOUND"
+        # readiness poll SSH -> ready
+        if "ssh" in cmd and "JPRIME_READY" in joined:
+            return 0, "JPRIME_READY\n"
+        # validation SSH curl -> a valid generation
+        if "ssh" in cmd and "api/generate" in joined:
+            return 0, '{"response": "def is_even(n): return n % 2 == 0"}'
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node"])
+    assert rc == 0
+    # _run WAS called in execute mode.
+    assert calls, "expected _run to be invoked in --execute"
+    # provision + image create + cleanup delete all happened.
+    flat = [" ".join(c) for c in calls]
+    assert any("instances create bake-node" in f for f in flat)
+    assert any("images create" in f for f in flat)
+    assert any("instances delete bake-node" in f for f in flat)
+
+
+def test_execute_aborts_and_does_not_snapshot_on_validation_fail(bake, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        joined = " ".join(cmd)
+        if "images" in cmd and "describe" in cmd:
+            return 1, "NOT_FOUND"
+        if "ssh" in cmd and "JPRIME_READY" in joined:
+            return 0, "JPRIME_READY\n"
+        if "ssh" in cmd and "api/generate" in joined:
+            return 0, '{"response": "I refuse."}'  # no 'def ' -> FAIL
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node"])
+    assert rc == 6  # validation-fail exit code
+    flat = [" ".join(c) for c in calls]
+    # NEVER snapshotted a broken image.
+    assert not any("images create" in f for f in flat)
+    # BUT the node was still cleaned up (no orphaned billing).
+    assert any("instances delete bake-node" in f for f in flat)
+
+
+def test_execute_aborts_when_image_exists_without_force(bake, monkeypatch):
+    calls = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if "images" in cmd and "describe" in cmd:
+            return 0, "existing-image"  # image EXISTS
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    rc = bake.main(["--execute", "--project", "p", "--zone", "z",
+                    "--node-name", "bake-node"])
+    assert rc == 3  # image-exists guard
+    flat = [" ".join(c) for c in calls]
+    # never provisioned a node.
+    assert not any("instances create" in f for f in flat)


### PR DESCRIPTION
**Phase 1 of the Sovereign Provider Failover Lifecycle** (spec: `docs/superpowers/specs/2026-06-23-sovereign-provider-failover-lifecycle.md`). J-Prime is the last-resort code generator that awakens when DW collapses; this phase bakes its golden image + starts the outage data substrate.

**Golden image SECURED + VALIDATED:** `jarvis-prime-coder-golden-20260623` (family `jarvis-prime-coder`, READY). The bake's **validation lock** ran a real generation — `qwen2.5-coder:7b` produced a correct `is_even(n)` — *before* snapshot. Dormant footprint: image-only (~$0.50/mo), no VM, no disk, zero compute.

- `scripts/bake_jprime_golden_image.py` — autonomous code-only bake, validation lock (never snapshot a broken image), `finally` teardown (no orphan billing), **abort-autopsy + early-fail + live-progress** (added after run 1 aborted blind). 20 tests.
- `outage_ledger.py` — durable `.jarvis/outage_ledger.jsonl` ring + async fire-and-forget TrinityEventBus export (`persist=False`, 5s-bounded, swallows all errors). Wired to the quarantine seams **after** the op is sealed, `try/except`-wrapped — cannot touch the op-never-lost guarantee. OFF byte-identical. 10 tests.

**Diagnosis win:** run 1 aborted blind → hardened with an autopsy → run 2's autopsy caught the real root cause (`panic: $HOME is not defined` — GCP startup-scripts run as root with HOME unset) → fixed (`export HOME=/root`, regression-guarded) → run 3 succeeded.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Phase 1 of Sovereign Provider Failover: bakes the J‑Prime golden image and adds a durable outage ledger with async, fail‑soft Trinity export wired into the quarantine flow. This sets up cost‑bounded failover and starts collecting recovery data for the forecaster (spec: docs/superpowers/specs/2026-06-23-sovereign-provider-failover-lifecycle.md).

- **New Features**
  - `outage_ledger.py`: append-only JSONL ring at `.jarvis/outage_ledger.jsonl` with `open_outage/close_outage/recent/has_open_outage`, plus `emit_outage_event` fire‑and‑forget via `TrinityEventBus` (`JARVIS_OUTAGE_LEDGER_ENABLED`, `JARVIS_TRINITY_OUTAGE_EXPORT_ENABLED` gates; fail‑soft).
  - Quarantine wiring in `candidate_generator.py`: open a DW outage on global deduce and close on sustained recovery; emits `DW_OUTAGE_DETECTED`/`DW_OUTAGE_RECOVERED`; never blocks the op.
  - `scripts/bake_jprime_golden_image.py`: autonomous, code‑only golden‑image bake for `qwen2.5-coder:7b` with a validation lock (real generation must pass before snapshot) and guaranteed teardown; prints the AWAKEN one‑liner for later use.
  - Added the lifecycle spec and unit tests for the ledger and bake script.

- **Bug Fixes**
  - Bake startup-script now exports `HOME=/root` and prefers systemd to prevent the "$HOME is not defined" panic; regression‑guarded.
  - Bake hardening: live progress tailing, early‑fail detection, and pre‑teardown autopsy capture; ensures diagnostics while avoiding orphaned billing.

<sup>Written for commit 2c69ad126247758406f9568ac2ae3013dc0b25b3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69673?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

