### PR TITLE
feat: GRADUATE Sovereign Failover live + Adversarial Cognitive Soak (VRAM pre-warm, thrash-pivot, Paxos anomaly)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -409,3 +409,7 @@ terraform/terraform.tfvars
 **/.pytest_cache/
 autopsy_reports/
 .cursorrules.tmp
+
+# adversarial cognitive soak scratch artifacts
+/impl.py
+/test_impl.py

--- a/backend/core/ouroboros/governance/epistemic_feedback.py
+++ b/backend/core/ouroboros/governance/epistemic_feedback.py
@@ -200,6 +200,56 @@ def pivot_verdict(repeated_signature_count: int, temp_at_floor: bool) -> bool:
         return False
 
 
+def should_pivot(
+    *,
+    repeated_signature_count: int,
+    temp_at_floor: bool,
+    total_attempts: int,
+    max_attempts: int,
+) -> tuple[bool, str]:
+    """Composite Graceful-Pivot verdict — stuck-wall OR thrash backstop.
+
+    Returns ``(pivot, reason)``:
+
+      - ``(True, "stuck_signature")`` if the legacy
+        ``pivot_verdict(repeated_signature_count, temp_at_floor)`` is True
+        (the model is stuck on the SAME failure signature with the
+        parametric temperature degenerated to its floor — preserved EXACTLY
+        by calling it internally), OR
+      - ``(True, "budget_exhausted")`` if ``total_attempts >= max_attempts``
+        (the THRASH / non-convergence backstop — the model failed
+        ``max_attempts`` times without converging, regardless of whether the
+        failure signature ever repeated; a model that emits a DIFFERENT
+        failure each attempt resets ``repeated_signature_count`` and so would
+        otherwise NEVER pivot), else
+      - ``(False, "")``.
+
+    The thrash backstop is gated by ``JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED``
+    (default true). When that flag is false, ONLY the legacy stuck-signature
+    trigger applies, so the OFF behavior is byte-identical to today's
+    ``pivot_verdict`` call sites.
+
+    Fail-soft: never raises -> ``(False, "")`` on any error.
+    """
+    try:
+        # Legacy stuck-wall trigger — preserved exactly (additive: never
+        # mutate pivot_verdict's contract).
+        if pivot_verdict(repeated_signature_count, temp_at_floor):
+            return True, "stuck_signature"
+
+        # Thrash / non-convergence backstop (gated default-true).
+        if _env_bool("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", True):
+            try:
+                if int(total_attempts) >= int(max_attempts):
+                    return True, "budget_exhausted"
+            except (ValueError, TypeError):
+                return False, ""
+
+        return False, ""
+    except Exception:
+        return False, ""
+
+
 def epistemic_feedback_enabled() -> bool:
     """Returns True if JARVIS_EPISTEMIC_FEEDBACK_ENABLED is set to a truthy value (default true)."""
     return _env_bool("JARVIS_EPISTEMIC_FEEDBACK_ENABLED", True)

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -41,7 +41,7 @@ DORMANT. A JARVIS_HANDBACK_COOLDOWN_S cooldown blocks immediate re-awaken.
 
 Env gates
 ---------
-JARVIS_FAILOVER_LIFECYCLE_ENABLED   default "false" (flips after a soak)
+JARVIS_FAILOVER_LIFECYCLE_ENABLED   default "true" (GRADUATED 2026-06-23; hot-revert=false)
     OFF -> controller is inert: stays DORMANT, never awakens. Today's
     behavior exactly (quarantine -> Cryo-DLQ).
 JARVIS_FAILOVER_ROUTE                default "dw" (the quarantine route key)
@@ -107,8 +107,16 @@ def _env_str(name: str, default: str) -> str:
 
 
 def lifecycle_enabled() -> bool:
-    """Master gate. Default FALSE -- OFF means inert (stays DORMANT)."""
-    return _enabled("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "false")
+    """Master gate. GRADUATED to default TRUE (2026-06-23) after the Adversarial
+    Cognitive Soak proved the full net live: VRAM pre-warm + Hybrid Epistemic
+    Diff injection + temperature decay + budget-exhaustion [SOVEREIGN YIELD:
+    UNRESOLVABLE PATH] + semantic symbol-scoped decompose + graceful retry (no
+    lockup, no dropped state); composed with the chaos-gauntlet (phantom-recovery,
+    no-thrash) + the LIVE dead-man self-delete drill (T+221s) + Opus-reviewed
+    OFF-byte-identical / op-never-lost / 3-independent-teardowns.
+    Hot-revert: ``export JARVIS_FAILOVER_LIFECYCLE_ENABLED=false`` -> inert
+    (stays DORMANT, today's behavior exactly)."""
+    return _enabled("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
 
 
 def _route() -> str:

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -155,6 +155,16 @@ def _awaken_timeout_s() -> float:
     return max(1.0, _env_float("JARVIS_FAILOVER_AWAKEN_TIMEOUT_S", 600.0))
 
 
+def _warmup_enabled() -> bool:
+    """VRAM pre-warm gate. Default TRUE -- OFF -> straight to SERVING (legacy)."""
+    return _enabled("JARVIS_FAILOVER_WARMUP_ENABLED", "true")
+
+
+def _warmup_timeout_s() -> float:
+    """Cold-load budget for the dummy generation. Distinct from per-op clock."""
+    return max(1.0, _env_float("JARVIS_FAILOVER_WARMUP_TIMEOUT_S", 180.0))
+
+
 # ---------------------------------------------------------------------------
 # FailoverState
 # ---------------------------------------------------------------------------
@@ -355,6 +365,7 @@ class FailoverLifecycleController:
         clock_fn: Optional[Callable[[], float]] = None,
         route: Optional[str] = None,
         on_serving_fn: Optional[Callable[[], Awaitable[Any]]] = None,
+        warmup_fn: Optional[Callable[[], Awaitable[bool]]] = None,
     ) -> None:
         self._vm_awaken_fn = vm_awaken_fn or _default_vm_awaken_fn
         self._vm_delete_fn = vm_delete_fn or _default_vm_delete_fn
@@ -362,6 +373,10 @@ class FailoverLifecycleController:
         self._node_ready_fn = node_ready_fn or _default_node_ready_fn
         self._clock_fn = clock_fn or _default_clock_fn
         self._route = route or _route()
+        # VRAM pre-warm boundary (Phase 3b+). Injectable for tests. Default:
+        # construct a LocalPrimeClient pointed at jprime_endpoint() and call
+        # warmup(timeout_s=_warmup_timeout_s()). None defers to _default_warmup_fn.
+        self._warmup_fn = warmup_fn  # None -> default built lazily in _tick_awakening
         # Phase 3c -- DORMANT/AWAKENING -> SERVING re-entry hook. Fired once on
         # the transition into SERVING so the Cryo-DLQ ops sealed during the
         # outage can be drained back through intake (which re-routes them to
@@ -531,6 +546,38 @@ class FailoverLifecycleController:
         host = _env_str("JARVIS_FAILOVER_NODE_HOST", _GCLOUD_NODE_NAME)
         port = _failover_port()
         return "http://{}:{}".format(host, port)
+
+    def _build_default_warmup_fn(self) -> Callable[[], Awaitable[bool]]:
+        """Build the default warmup callable: LocalPrimeClient pointed at
+        the awakened endpoint, calling warmup(timeout_s=_warmup_timeout_s()).
+
+        Built lazily here (not in __init__) so the endpoint is known and the
+        local_inference_director import only happens when needed (OFF path
+        never touches this). Returns an async callable -> bool.
+        """
+        from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+            LocalConfig,
+            LocalPrimeClient,
+        )
+        endpoint = self._endpoint or self._build_endpoint()
+        timeout = _warmup_timeout_s()
+
+        import dataclasses  # noqa: PLC0415
+        # Build a config that targets the awakened node's base URL.
+        base_cfg = LocalConfig.from_env()
+        node_cfg = dataclasses.replace(base_cfg, base_url=endpoint)
+        client = LocalPrimeClient(node_cfg)
+
+        async def _warmup() -> bool:
+            try:
+                return await client.warmup(timeout_s=timeout)
+            finally:
+                try:
+                    await client.aclose()
+                except Exception:  # noqa: BLE001
+                    pass
+
+        return _warmup
 
     # ------------------------------------------------------------------
     # Forecast helpers
@@ -750,6 +797,30 @@ class FailoverLifecycleController:
             ready = False
         if not ready:
             return  # keep waiting; next tick re-probes (fail-soft).
+
+        # VRAM pre-warm gate (Phase 3b+): after the node transport is up but
+        # BEFORE transitioning to SERVING, fire a lightweight dummy generation
+        # to force model weights into VRAM. The awaited completion IS the
+        # readiness signal -- no arbitrary sleep. Fail-soft: if warmup times
+        # out or errors, log a warning and proceed to SERVING anyway (the outer
+        # AWAKENING deadline is still the hard bound; we never deadlock here).
+        if _warmup_enabled():
+            warmup_ok = False
+            try:
+                warmup_fn = self._warmup_fn or self._build_default_warmup_fn()
+                warmup_ok = bool(await self._maybe_await(warmup_fn))
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[FailoverLifecycle] warmup raised fail-soft err=%r "
+                    "-- proceeding to SERVING (first op may be cold)", exc,
+                )
+            if not warmup_ok:
+                logger.warning(
+                    "[FailoverLifecycle] warmup did not confirm within %.0fs "
+                    "-- proceeding to SERVING (first op may be cold)",
+                    _warmup_timeout_s(),
+                )
+
         self._awakening_started_at = None
         self._state = FailoverState.SERVING
         self._serving_started_at = now

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -275,6 +275,37 @@ class LocalPrimeClient:
             tokens_used=lc.output_tokens,
         )
 
+    async def warmup(self, *, timeout_s: float) -> bool:
+        """Force model weights into VRAM via a minimal 1-token generation.
+
+        Fires a lightweight dummy generation (prompt "warmup", num_predict/
+        max_tokens 1, temperature 0.0) at the configured endpoint, bounded by
+        asyncio.wait_for(timeout_s). Returns True on a successful completion,
+        False on timeout or any error. Fail-soft -- never raises.
+
+        This is the cold-load forcing call: awaiting it guarantees the model is
+        resident in VRAM before the first real Sovereign generation clock starts.
+        Reusable by the FSM AWAKENING gate and the soak harness.
+        """
+        async def _do_warmup() -> bool:
+            sess = await self._ensure_session()
+            url = self._cfg.base_url.rstrip("/") + "/v1/chat/completions"
+            body = {
+                "model": self._cfg.model_name,
+                "messages": [{"role": "user", "content": "warmup"}],
+                "max_tokens": 1,
+                "num_predict": 1,
+                "temperature": 0.0,
+            }
+            async with sess.post(url, json=body) as resp:
+                await resp.json()
+            return True
+
+        try:
+            return await asyncio.wait_for(_do_warmup(), timeout=timeout_s)
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001 -- fail-soft
+            return False
+
     async def _check_health(self) -> Any:
         """Drop-in PrimeClient._check_health -> PrimeStatus (AVAILABLE iff Ollama reachable)."""
         from backend.core.prime_client import PrimeStatus

--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -1320,7 +1320,7 @@ class RepairEngine:
                     try:
                         from backend.core.ouroboros.governance.epistemic_feedback import (
                             epistemic_feedback_enabled as _efe,
-                            pivot_verdict as _pv,
+                            should_pivot as _sp,
                         )
                         if _efe():
                             # repeated_signature_count: how many prior
@@ -1350,7 +1350,24 @@ class RepairEngine:
                                 and float(epistemic_temperature)
                                 <= _floor + _floor_epsilon
                             )
-                            if _pv(_repeat_for_sig, _temp_at_floor):
+                            # Composite verdict (additive, gated default-true):
+                            # pivot on the legacy stuck-signature trigger OR on
+                            # repair-budget exhaustion. A model that THRASHES --
+                            # producing a DIFFERENT failure signature each
+                            # iteration -- keeps _repeat_for_sig at 0 and so
+                            # would NEVER trip the legacy stuck-wall test; the
+                            # budget backstop (iteration >= max_iterations)
+                            # catches that non-convergence and pivots-to-
+                            # decompose instead of silently exhausting to the
+                            # legacy terminal _stopped. Flag off -> only the
+                            # legacy trigger (byte-identical).
+                            _do_pivot, _pivot_reason = _sp(
+                                repeated_signature_count=_repeat_for_sig,
+                                temp_at_floor=_temp_at_floor,
+                                total_attempts=int(iteration),
+                                max_attempts=int(budget.max_iterations),
+                            )
+                            if _do_pivot:
                                 _stderr_tail = ""
                                 try:
                                     _raw = getattr(svr, "stderr", "") or ""
@@ -1363,10 +1380,13 @@ class RepairEngine:
                                 _logger.warning(
                                     "[SOVEREIGN YIELD: UNRESOLVABLE PATH] "
                                     "op=%s sig=%s repeated=%d temp_at_floor=%s "
-                                    "diverged=%s -> L2_PIVOT (decompose-further "
-                                    "at failure locus)",
+                                    "reason=%s iteration=%d/%d diverged=%s -> "
+                                    "L2_PIVOT (decompose-further at failure "
+                                    "locus)",
                                     ctx.op_id, (fail_sig or "")[:12],
                                     _repeat_for_sig, _temp_at_floor,
+                                    _pivot_reason, int(iteration),
+                                    int(budget.max_iterations),
                                     _diverged_reason,
                                 )
                                 return _pivoted(

--- a/scripts/adversarial_cognitive_soak.py
+++ b/scripts/adversarial_cognitive_soak.py
@@ -25,6 +25,12 @@ Design constraints (all enforced):
   * REAL pytest subprocess execution for VALIDATE,
   * bounded -- no infinite loop.
 
+Two payloads ship (``--payload {merge_intervals,concurrency_lru}``); the default
+is the Concurrency Gauntlet (a thread-safe TTL+LRU cache) because the round-1
+merge-intervals payload was zero-shot solved -> the repair loop never fired. The
+``--run`` path warms the model into VRAM first (``LocalPrimeClient.warmup``) so
+the cold-start latency never trips a spurious timeout.
+
 This is NOT run automatically. ``--run`` requires JARVIS_CHAOS_INJECTOR_ENABLED
 to be true and talks to a local Ollama at http://127.0.0.1:11434.
 """
@@ -81,13 +87,25 @@ def gate_enabled() -> bool:
 
 @dataclass(frozen=True)
 class AdversarialPayload:
-    """A moderately complex coding sub-goal at the edge of a 7B's window.
+    """A coding sub-goal at (or past) the edge of a 7B's first-pass window.
 
-    Chosen task: merge-overlapping-intervals WITH the half-open adjacency edge
-    case (intervals that only TOUCH at an endpoint, e.g. [1,2] and [2,3], must
-    merge into [1,3]). A first draft from a 7B typically uses ``s < last_end``
-    (strict) and silently botches adjacency -- a subtle, deterministic edge case
-    that the test suite pins.
+    Two payloads ship (selectable via ``--payload``):
+
+      * ``merge_intervals`` -- merge-overlapping-intervals WITH the half-open
+        adjacency edge case (intervals that only TOUCH at an endpoint, e.g.
+        [1,2] and [2,3], must merge into [1,3]). A 7B first draft typically uses
+        ``s < last_end`` (strict) and silently botches adjacency. This proved
+        *too easy* in round 1 (zero-shot solved -> the repair loop never fired).
+
+      * ``concurrency_lru`` -- a thread-safe TTL+LRU cache with NON-BLOCKING
+        background eviction. 7B first drafts almost universally (a) omit the
+        ``threading.Lock`` around the OrderedDict mutations and/or (b) write a
+        blocking ``while True: sleep`` eviction loop instead of a daemon thread.
+        Both are caught deterministically by the test suite, so the epistemic
+        repair -> pivot -> decompose loop is actually exercised UNDER FIRE.
+
+    ``requirements`` is the per-payload requirements block (list of lines),
+    keeping ``build_prompt`` payload-agnostic.
     """
 
     title: str
@@ -97,6 +115,8 @@ class AdversarialPayload:
     test_filename: str
     tests: str
     system_prompt: str
+    requirements: tuple
+    decompose_focus: str = ""
 
     def build_prompt(self, epistemic_feedback: str = "") -> str:
         """Compose the generation prompt; append the Hybrid Epistemic Diff (if any)."""
@@ -108,13 +128,7 @@ class AdversarialPayload:
             self.description,
             "</description>",
             "<requirements>",
-            f"- Define a top-level function named `{self.entry_symbol}`.",
-            "- Handle the empty input case.",
-            "- Sort the intervals first.",
-            "- CRITICAL EDGE CASE: intervals that only TOUCH at an endpoint",
-            "  (e.g. (1, 2) and (2, 3)) MUST merge into (1, 3) -- adjacency counts",
-            "  as overlap. Use `<=`, not `<`.",
-            "- Return a list of tuples.",
+            *list(self.requirements),
             "</requirements>",
             "<output_format>",
             "Return ONLY a single Python code block (```python ... ```) with the",
@@ -172,7 +186,7 @@ _TESTS = textwrap.dedent(
 ).strip()
 
 
-ADVERSARIAL_PAYLOAD = AdversarialPayload(
+MERGE_INTERVALS_PAYLOAD = AdversarialPayload(
     title="Merge overlapping intervals (with adjacency edge case)",
     description=(
         "Implement `merge_intervals(intervals)` that merges a list of "
@@ -185,12 +199,229 @@ ADVERSARIAL_PAYLOAD = AdversarialPayload(
     impl_filename="impl.py",
     test_filename="test_impl.py",
     tests=_TESTS,
+    requirements=(
+        "- Define a top-level function named `merge_intervals`.",
+        "- Handle the empty input case.",
+        "- Sort the intervals first.",
+        "- CRITICAL EDGE CASE: intervals that only TOUCH at an endpoint",
+        "  (e.g. (1, 2) and (2, 3)) MUST merge into (1, 3) -- adjacency counts",
+        "  as overlap. Use `<=`, not `<`.",
+        "- Return a list of tuples.",
+    ),
+    decompose_focus=(
+        " HYPER-ATOMIC FOCUS: get the adjacency edge case right first -- "
+        "merge intervals that only touch at an endpoint using `<=`."
+    ),
     system_prompt=(
         "You are a precise senior Python engineer. You write correct, minimal "
         "implementations and you reason carefully about edge cases before "
         "emitting code. Output a single Python code block only."
     ),
 )
+
+
+# ---------------------------------------------------------------------------
+# Payload #2: the Concurrency Gauntlet (thread-safe TTL+LRU cache)
+# ---------------------------------------------------------------------------
+#
+# Deliberately HARD for a 7B first pass. The test suite pins TWO bugs that 7B
+# drafts almost universally hit:
+#   (a) no threading.Lock around the OrderedDict mutations -> concurrent
+#       get/put corrupts state (KeyError / changed-size-during-iteration);
+#   (b) lazy-only TTL (expiry checked only on access) or a blocking
+#       `while True: sleep` eviction loop -> the background-eviction +
+#       non-blocking-constructor tests fail.
+#
+# Non-flaky by construction:
+#   * thread-safety test uses a SHORT ttl so a (correct) background reaper is
+#     ACTIVELY evicting while 8 threads hammer overlapping keys for ~1.5s; the
+#     missing-lock multi-step read-modify-write (`if k in d` -> move_to_end ->
+#     assign, racing the lazy/reaper pop) deterministically raises KeyError on
+#     a buggy impl, while a locked impl is exception-free (verified 10/10);
+#   * the invariant asserted is DETERMINISTIC (no exception AND len <= capacity),
+#     never a timing-dependent exact value;
+#   * TTL + non-blocking margins are generous (0.5s ttl, 1.5s wait, 5s ceiling)
+#     so a correct impl is never flaky.
+
+_LRU_TESTS = textwrap.dedent(
+    '''
+    from impl import TTLLRUCache
+
+    import threading
+    import time
+    from concurrent.futures import ThreadPoolExecutor
+
+
+    def test_basic_get_put():
+        c = TTLLRUCache(capacity=2, ttl_seconds=100.0)
+        try:
+            c.put("a", 1)
+            c.put("b", 2)
+            assert c.get("a") == 1
+            assert c.get("b") == 2
+            assert c.get("missing") is None
+        finally:
+            c.stop()
+
+
+    def test_lru_capacity_eviction_order():
+        c = TTLLRUCache(capacity=2, ttl_seconds=100.0)
+        try:
+            c.put("a", 1)
+            c.put("b", 2)
+            assert c.get("a") == 1  # touch "a" -> "b" is the LRU
+            c.put("c", 3)           # inserting "c" must evict the LRU ("b")
+            assert c.get("b") is None
+            assert c.get("a") == 1
+            assert c.get("c") == 3
+            assert len(c) <= 2
+        finally:
+            c.stop()
+
+
+    def test_thread_safety_no_corruption():
+        capacity = 16
+        # Short ttl: a correct background reaper is ACTIVELY evicting while the
+        # threads concurrently mutate. A missing-lock impl races on the
+        # multi-step read-modify-write and raises (KeyError / changed-size);
+        # a locked impl is exception-free and never exceeds capacity.
+        c = TTLLRUCache(capacity=capacity, ttl_seconds=0.05)
+        n_threads = 8
+        duration_s = 1.5
+        errors = []
+        invariant_violations = []
+        stop = threading.Event()
+
+        def worker(tid):
+            try:
+                i = 0
+                while not stop.is_set():
+                    k = (i + tid) % 24  # overlapping keys across threads -> churn
+                    if i % 2 == 0:
+                        c.put(k, tid * 1000 + i)
+                    else:
+                        c.get(k)
+                    if len(c) > capacity:
+                        invariant_violations.append(len(c))
+                    i += 1
+            except Exception as e:  # noqa: BLE001
+                errors.append(repr(e))
+
+        try:
+            with ThreadPoolExecutor(max_workers=n_threads) as ex:
+                futs = [ex.submit(worker, t) for t in range(n_threads)]
+                time.sleep(duration_s)
+                stop.set()
+                for f in futs:
+                    f.result()
+            assert not errors, \\
+                "concurrent access raised (missing lock?): " + "; ".join(errors[:5])
+            assert not invariant_violations, (
+                "len exceeded capacity under concurrency (corruption): "
+                + str(invariant_violations[:5])
+            )
+            assert len(c) <= capacity
+        finally:
+            c.stop()
+
+
+    def test_ttl_background_eviction_not_lazy():
+        c = TTLLRUCache(capacity=10, ttl_seconds=0.5)
+        try:
+            c.put("x", 42)
+            assert c.get("x") == 42  # present immediately
+            # Wait WITHOUT accessing "x". A lazy-only TTL leaves it resident;
+            # a background mechanism must have evicted it.
+            time.sleep(1.5)
+            assert len(c) == 0, (
+                "entry not evicted by background mechanism (lazy-only TTL?): len="
+                + str(len(c))
+            )
+        finally:
+            c.stop()
+
+
+    def test_constructor_and_ops_do_not_block():
+        start = time.monotonic()
+        c = TTLLRUCache(capacity=4, ttl_seconds=10.0)
+        try:
+            c.put("a", 1)
+            assert c.get("a") == 1
+        finally:
+            c.stop()
+        elapsed = time.monotonic() - start
+        # A blocking `while True: sleep` eviction loop in __init__/put would hang
+        # far past this. Generous ceiling; a correct impl finishes in ms.
+        assert elapsed < 5.0, \\
+            "construction + ops blocked (blocking eviction loop?): " + str(elapsed)
+    '''
+).strip()
+
+
+CONCURRENCY_LRU_PAYLOAD = AdversarialPayload(
+    title="Thread-safe TTL+LRU cache with non-blocking background eviction",
+    description=(
+        "Implement `class TTLLRUCache` with `__init__(self, capacity, "
+        "ttl_seconds)`, `get(self, key)`, and `put(self, key, value)`. It is a "
+        "bounded LRU cache (least-recently-used eviction when over capacity) "
+        "with per-entry time-to-live. It MUST be thread-safe: concurrent get/put "
+        "from many threads must not corrupt state or lose updates. TTL eviction "
+        "MUST be performed by a NON-BLOCKING background mechanism (a daemon "
+        "thread or async task) -- entries expire about `ttl_seconds` after "
+        "insertion and are removed even if never accessed again. Do NOT use a "
+        "blocking `while True: sleep(...)` loop on the construction path; the "
+        "constructor must return promptly. Also provide a `stop(self)` method "
+        "that cleanly halts the background mechanism (so callers do not leak "
+        "threads)."
+    ),
+    entry_symbol="TTLLRUCache",
+    impl_filename="impl.py",
+    test_filename="test_impl.py",
+    tests=_LRU_TESTS,
+    requirements=(
+        "- Define a top-level class named `TTLLRUCache` with the exact methods:",
+        "  `__init__(self, capacity, ttl_seconds)`, `get(self, key)`,",
+        "  `put(self, key, value)`, and `stop(self)`. Implement `__len__` too.",
+        "- THREAD SAFETY: guard ALL mutations of the internal store with a",
+        "  `threading.Lock`/`RLock`. Concurrent get/put from 8+ threads must",
+        "  never raise and must never let the store exceed `capacity`.",
+        "- LRU: `get` and `put` mark a key most-recently-used; eviction when over",
+        "  capacity removes the least-recently-used entry.",
+        "- TTL: entries expire ~`ttl_seconds` after insertion. Eviction MUST be",
+        "  driven by a NON-BLOCKING background mechanism (daemon thread / async",
+        "  task) so expired entries are removed even if never accessed -- NOT",
+        "  lazily-only on access, and NOT via a blocking `while True: sleep`",
+        "  loop that stalls construction.",
+        "- Provide `stop(self)` to halt the background mechanism cleanly.",
+        "- Use `collections.OrderedDict` (or equivalent) for LRU ordering.",
+    ),
+    decompose_focus=(
+        " HYPER-ATOMIC FOCUS: first make it thread-safe -- wrap EVERY OrderedDict "
+        "mutation in a single threading.Lock -- and replace any blocking eviction "
+        "loop with a daemon thread that wakes periodically and reaps expired keys "
+        "under that same lock."
+    ),
+    system_prompt=(
+        "You are a precise senior Python engineer specializing in concurrent "
+        "data structures. You reason carefully about thread-safety (locks around "
+        "every shared-state mutation) and about non-blocking background work "
+        "before emitting code. Output a single Python code block only."
+    ),
+)
+
+
+# Registry for the --payload selector. Default is the Concurrency Gauntlet for
+# this round (the merge-intervals payload was zero-shot solved last round).
+PAYLOADS: Dict[str, AdversarialPayload] = {
+    "merge_intervals": MERGE_INTERVALS_PAYLOAD,
+    "concurrency_lru": CONCURRENCY_LRU_PAYLOAD,
+}
+DEFAULT_PAYLOAD = "concurrency_lru"
+
+# Back-compat alias: existing callers/tests referenced ADVERSARIAL_PAYLOAD as
+# the merge-intervals payload. Keep it pointing there so existing assertions
+# stay valid; the --run default is the Concurrency Gauntlet via DEFAULT_PAYLOAD.
+ADVERSARIAL_PAYLOAD = MERGE_INTERVALS_PAYLOAD
 
 
 # ---------------------------------------------------------------------------
@@ -217,20 +448,30 @@ def _extract_code_block(text: str) -> str:
         return str(text)
 
 
-def _run_pytest_in_tempdir(impl_src: str, tests_src: str, *, timeout_s: int = 90) -> Dict[str, Any]:
+def _run_pytest_in_tempdir(
+    impl_src: str,
+    tests_src: str,
+    *,
+    timeout_s: int = 90,
+    payload: "Optional[AdversarialPayload]" = None,
+) -> Dict[str, Any]:
     """Write impl + tests to a tempdir and run REAL pytest as a subprocess.
+
+    ``payload`` supplies the impl/test filenames (defaults to the back-compat
+    ADVERSARIAL_PAYLOAD when not given).
 
     Returns {passed: bool, stdout: str, stderr: str, returncode: int}. Fail-soft:
     a missing impl / timeout / crash is reported as a non-pass, never raises.
     """
+    payload = payload or ADVERSARIAL_PAYLOAD
     result: Dict[str, Any] = {"passed": False, "stdout": "", "stderr": "", "returncode": -1}
     if not impl_src:
         result["stderr"] = "empty implementation (model produced no code block)"
         return result
     try:
         with tempfile.TemporaryDirectory(prefix="adv_soak_") as d:
-            impl_path = os.path.join(d, ADVERSARIAL_PAYLOAD.impl_filename)
-            test_path = os.path.join(d, ADVERSARIAL_PAYLOAD.test_filename)
+            impl_path = os.path.join(d, payload.impl_filename)
+            test_path = os.path.join(d, payload.test_filename)
             with open(impl_path, "w", encoding="ascii", errors="replace") as f:
                 f.write(impl_src)
             with open(test_path, "w", encoding="ascii", errors="replace") as f:
@@ -309,16 +550,13 @@ def _signature_for(out: Dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _build_goal() -> Any:
+def _build_goal(payload: "Optional[AdversarialPayload]" = None) -> Any:
+    payload = payload or ADVERSARIAL_PAYLOAD
     return types.SimpleNamespace(
-        goal_id="adv-soak-merge-intervals",
-        title=ADVERSARIAL_PAYLOAD.title,
-        description=(
-            ADVERSARIAL_PAYLOAD.description
-            + " HYPER-ATOMIC FOCUS: get the adjacency edge case right first -- "
-            "merge intervals that only touch at an endpoint using `<=`."
-        ),
-        target_files=(ADVERSARIAL_PAYLOAD.impl_filename,),
+        goal_id="adv-soak-" + payload.entry_symbol.lower().replace("_", "-"),
+        title=payload.title,
+        description=(payload.description + (payload.decompose_focus or "")),
+        target_files=(payload.impl_filename,),
     )
 
 
@@ -336,7 +574,12 @@ def _say(line: str = "") -> None:
 # ---------------------------------------------------------------------------
 
 
-async def run_cognitive_soak(*, client: Any, max_repairs: int = 3) -> Dict[str, Any]:
+async def run_cognitive_soak(
+    *,
+    client: Any,
+    max_repairs: int = 3,
+    payload: "Optional[AdversarialPayload]" = None,
+) -> Dict[str, Any]:
     """Drive the adversarial payload through the REAL cognitive loop.
 
     Returns a result dict:
@@ -352,10 +595,15 @@ async def run_cognitive_soak(*, client: Any, max_repairs: int = 3) -> Dict[str, 
             "JARVIS_CHAOS_INJECTOR_ENABLED=true"
         )
 
-    payload = ADVERSARIAL_PAYLOAD
+    payload = payload or ADVERSARIAL_PAYLOAD
     base_temp = float(os.environ.get("JARVIS_ADV_SOAK_BASE_TEMP", "0.7"))
-    pytest_timeout_s = int(os.environ.get("JARVIS_ADV_SOAK_PYTEST_TIMEOUT_S", "90"))
-    gen_timeout_s = float(os.environ.get("JARVIS_ADV_SOAK_GEN_TIMEOUT_S", "240"))
+    # Generous: the LRU payload's thread-safety test runs ~1.5s of real
+    # concurrency on top of process startup, so keep a comfortable margin.
+    pytest_timeout_s = int(os.environ.get("JARVIS_ADV_SOAK_PYTEST_TIMEOUT_S", "120"))
+    # Generous per-generate budget so a slow-but-valid CPU generation (a cold
+    # local 7B can take well over a minute on the first real tokens) is not cut
+    # off. The harness warms the model first, but keep the ceiling high anyway.
+    gen_timeout_s = float(os.environ.get("JARVIS_ADV_SOAK_GEN_TIMEOUT_S", "360"))
 
     iterations: List[Dict[str, Any]] = []
     temperature_trajectory: List[float] = []
@@ -425,7 +673,9 @@ async def run_cognitive_soak(*, client: Any, max_repairs: int = 3) -> Dict[str, 
         raw = await _generate(temperature, epistemic_feedback)
         impl_src = _extract_code_block(raw)
 
-        out = _run_pytest_in_tempdir(impl_src, payload.tests, timeout_s=pytest_timeout_s)
+        out = _run_pytest_in_tempdir(
+            impl_src, payload.tests, timeout_s=pytest_timeout_s, payload=payload
+        )
         passed = bool(out["passed"])
 
         iterations.append({
@@ -488,7 +738,7 @@ async def run_cognitive_soak(*, client: Any, max_repairs: int = 3) -> Dict[str, 
             }
             try:
                 sub_goals = decompose_for_block(
-                    _build_goal(),
+                    _build_goal(payload),
                     zero_coverage=False,
                     failure_hint=failure_hint,
                 )
@@ -586,13 +836,18 @@ def print_report(result: Dict[str, Any]) -> None:
 
 def _build_real_client(model: str) -> LocalPrimeClient:
     cfg = LocalConfig.from_env()
-    # Pin to the soak target regardless of env model default.
+    # Pin to the soak target regardless of env model default, and raise the
+    # adaptive-timeout ceiling generously so a slow-but-valid CPU generation
+    # from a cold/large 7B is not severed by the client's own timeout (the
+    # harness also warms the model first). Reuses the existing LocalConfig env
+    # knob (JARVIS_LOCAL_INFERENCE_TIMEOUT_MS) -- defaults to 360s here.
+    ceiling_ms = int(os.environ.get("JARVIS_LOCAL_INFERENCE_TIMEOUT_MS", "360000"))
     cfg = LocalConfig(
         base_url=os.environ.get("JARVIS_LOCAL_MODEL_BASE_URL", "http://127.0.0.1:11434"),
         model_name=model,
         keep_alive_seconds=cfg.keep_alive_seconds,
-        timeout_seed_ms=cfg.timeout_seed_ms,
-        timeout_ceiling_ms=cfg.timeout_ceiling_ms,
+        timeout_seed_ms=max(cfg.timeout_seed_ms, ceiling_ms),
+        timeout_ceiling_ms=max(cfg.timeout_ceiling_ms, ceiling_ms),
         timeout_floor_ms=cfg.timeout_floor_ms,
         output_ratio=cfg.output_ratio,
         margin_sigma=cfg.margin_sigma,
@@ -604,19 +859,54 @@ def _build_real_client(model: str) -> LocalPrimeClient:
     return LocalPrimeClient(cfg)
 
 
+async def _warmup_client(client: Any, *, timeout_s: float) -> bool:
+    """Force the model into VRAM before the cognitive clock starts.
+
+    Reuses the production ``LocalPrimeClient.warmup``. Logs the confirmed
+    warm-load time or a fail-soft warning. Never raises.
+    """
+    import time as _time
+    _say("-" * 72)
+    _say(f"[soak] warming up model (forcing weights into VRAM, timeout={timeout_s:.0f}s) ...")
+    t0 = _time.monotonic()
+    try:
+        ok = await client.warmup(timeout_s=timeout_s)
+    except Exception as e:  # noqa: BLE001 -- fail-soft, never block the soak
+        _say(f"[soak] warmup raised (fail-soft, proceeding cold): {e}")
+        return False
+    elapsed = _time.monotonic() - t0
+    if ok:
+        _say(f"[soak] warmup confirmed in {elapsed:.1f}s (model in memory)")
+    else:
+        _say(f"[soak] WARNING: warmup did not confirm in {elapsed:.1f}s "
+             f"(timeout/unreachable) -- proceeding cold (fail-soft)")
+    return bool(ok)
+
+
 async def _amain(args: argparse.Namespace) -> int:
     if not gate_enabled():
         _say("REFUSED: set JARVIS_CHAOS_INJECTOR_ENABLED=true to run the soak.")
         return 2
+
+    payload = PAYLOADS.get(args.payload, PAYLOADS[DEFAULT_PAYLOAD])
+
     if not args.run:
         _say("Dry mode: pass --run to drive the real local model. (Gate is ON.)")
         _say(f"Would target model={args.model} at "
              f"{os.environ.get('JARVIS_LOCAL_MODEL_BASE_URL', 'http://127.0.0.1:11434')}")
+        _say(f"Selected payload: {args.payload} -- {payload.title}")
         return 0
 
     client = _build_real_client(args.model)
     try:
-        result = await run_cognitive_soak(client=client, max_repairs=args.max_repairs)
+        # Warmup-first: eliminate the cold-start spurious timeout the first
+        # round hit, so the cognitive loop starts against a warm model.
+        warmup_timeout_s = float(os.environ.get("JARVIS_ADV_SOAK_WARMUP_TIMEOUT_S",
+                                                str(args.warmup_timeout)))
+        await _warmup_client(client, timeout_s=warmup_timeout_s)
+        result = await run_cognitive_soak(
+            client=client, max_repairs=args.max_repairs, payload=payload
+        )
         print_report(result)
         return 0 if result.get("converged") else 1
     finally:
@@ -637,6 +927,12 @@ def main(argv: Optional[List[str]] = None) -> int:
                         help="Local model name (default: qwen2.5-coder:7b).")
     parser.add_argument("--max-repairs", type=int, default=3,
                         help="Max repair iterations before pivot (default: 3).")
+    parser.add_argument("--payload", choices=sorted(PAYLOADS.keys()),
+                        default=DEFAULT_PAYLOAD,
+                        help=f"Adversarial payload to drive (default: {DEFAULT_PAYLOAD}).")
+    parser.add_argument("--warmup-timeout", type=float, default=180.0,
+                        help="Seconds to wait for the VRAM warmup before the loop "
+                             "(default: 180; env JARVIS_ADV_SOAK_WARMUP_TIMEOUT_S).")
     args = parser.parse_args(argv)
     try:
         return asyncio.run(_amain(args))

--- a/scripts/adversarial_cognitive_soak.py
+++ b/scripts/adversarial_cognitive_soak.py
@@ -37,7 +37,9 @@ to be true and talks to a local Ollama at http://127.0.0.1:11434.
 from __future__ import annotations
 
 import argparse
+import ast
 import asyncio
+import hashlib
 import os
 import re
 import subprocess
@@ -430,6 +432,90 @@ ADVERSARIAL_PAYLOAD = MERGE_INTERVALS_PAYLOAD
 
 _CODE_BLOCK_RE = re.compile(r"```(?:python)?\s*\n(.*?)```", re.DOTALL)
 
+# ---------------------------------------------------------------------------
+# AST node types that are safe to keep at module scope (pure definitions).
+# Module-level calls / instantiations are stripped so impl.py is importable
+# as a pure module even when the model appends demo/usage code.
+# ---------------------------------------------------------------------------
+_SAFE_STMT_TYPES = (
+    ast.Import,
+    ast.ImportFrom,
+    ast.ClassDef,
+    ast.FunctionDef,
+    ast.AsyncFunctionDef,
+)
+
+
+def _is_constant_assign(node: ast.AST) -> bool:
+    """True for top-level assignments whose RHS is a pure literal / constant.
+
+    We keep ``_FOO = "bar"`` but strip ``cache = TTLLRUCache(3, 2)``.
+    """
+    if not isinstance(node, ast.Assign):
+        return False
+    try:
+        # ast.Constant covers str/int/float/bool/None/bytes/tuple literals.
+        # ast.Tuple of constants (e.g. ``_ITEMS = (1, 2, 3)``) is also fine.
+        return isinstance(node.value, (ast.Constant, ast.JoinedStr)) or (
+            isinstance(node.value, ast.Tuple)
+            and all(isinstance(e, ast.Constant) for e in node.value.elts)
+        )
+    except Exception:
+        return False
+
+
+def _sanitize_importable(src: str) -> str:
+    """Strip top-level executable statements from generated code.
+
+    Keeps: Import, ImportFrom, ClassDef, FunctionDef, AsyncFunctionDef, and
+    Assign-of-constants (e.g. ``_VERSION = "1.0.0"``).
+
+    Drops: bare calls (``cache = TTLLRUCache(3, 2)``), print statements,
+    ``if __name__ == "__main__":`` blocks, and all other module-level
+    executable expressions.
+
+    Fail-soft: if ``ast.parse`` fails (the model emitted broken syntax), the
+    raw text is returned unchanged so the real SyntaxError still surfaces as a
+    genuine (discriminating) failure signature -- we do NOT hide the bug.
+    """
+    if not src:
+        return src
+    try:
+        tree = ast.parse(src)
+    except SyntaxError:
+        # Broken syntax -> return raw text so the real SyntaxError is visible.
+        return src
+    except Exception:
+        return src
+
+    # Reconstruct by extracting only the safe line ranges from the source.
+    # ast.get_source_segment requires Python 3.8+ (we target 3.9+) but is
+    # unreliable for multi-statement nodes.  Instead we work at the statement
+    # level by collecting line spans and slicing the original source lines.
+    src_lines = src.splitlines(keepends=True)
+    kept_ranges: list[tuple[int, int]] = []  # (start_lineno, end_lineno), 1-based
+
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Module):
+            break  # walk() visits all nodes; only top-level stmts matter
+
+    for stmt in tree.body:
+        if isinstance(stmt, _SAFE_STMT_TYPES) or _is_constant_assign(stmt):
+            start = getattr(stmt, "lineno", None)
+            end = getattr(stmt, "end_lineno", None)
+            if start is not None and end is not None:
+                kept_ranges.append((start, end))
+
+    if not kept_ranges:
+        # Nothing survived -- keep raw (better than empty, will fail loudly).
+        return src
+
+    out_lines: list[str] = []
+    for start, end in kept_ranges:
+        out_lines.extend(src_lines[start - 1:end])
+
+    return "".join(out_lines)
+
 
 def _extract_code_block(text: str) -> str:
     """Extract the first fenced python code block; fall back to raw text.
@@ -529,18 +615,82 @@ def _failing_test_ids(out: Dict[str, Any]) -> List[str]:
         return []
 
 
+# Patterns used to extract a discriminating fingerprint from collection errors.
+# We strip absolute tempdir paths (which vary per attempt) before hashing so
+# the signature is invariant to the random tempdir name.
+_COLLECTION_ERR_RE = re.compile(r"^E\s+(.+)", re.MULTILINE)
+_SOVEREIGN_SYNTAX_RE = re.compile(r"\[SOVEREIGN SYNTAX FATAL\][^\n]*", re.MULTILINE)
+# Matches the randomly-generated tempdir prefix (e.g. /tmp/adv_soak_xyz123/).
+_TEMPDIR_RE = re.compile(r"/[^\s]*/adv_soak_[^/\s]+/")
+
+
+def _collection_error_fingerprint(out: Dict[str, Any]) -> Optional[str]:
+    """Extract a stable, discriminating fingerprint for a collection/import error.
+
+    Returns a normalised string (error class + first E-line message with path
+    stripped) that can be hashed, or None if this is not a collection error.
+
+    A collection error is recognised by: returncode==2 AND no FAILED test IDs
+    AND an "E  ErrorType:" line in the output.
+    """
+    try:
+        if out.get("returncode", -1) not in (1, 2):
+            return None
+        ids = _failing_test_ids(out)
+        if ids:
+            # Real FAILED test IDs exist -> not a collection error.
+            return None
+        blob = (out.get("stdout") or "") + "\n" + (out.get("stderr") or "")
+        # Check for [SOVEREIGN SYNTAX FATAL] first (highest specificity).
+        syntax_match = _SOVEREIGN_SYNTAX_RE.search(blob)
+        if syntax_match:
+            norm = _TEMPDIR_RE.sub("<tmpdir>/", syntax_match.group(0))
+            return "sovereign_syntax:" + norm.strip()
+        # Look for "E  SomeError: message" lines from pytest's collection phase.
+        e_lines = _COLLECTION_ERR_RE.findall(blob)
+        if e_lines:
+            # Take the first substantive error line; strip the tempdir path.
+            first = _TEMPDIR_RE.sub("<tmpdir>/", e_lines[0].strip())
+            return "collection_error:" + first
+        # No discriminating content -- treat as an unknown collection error.
+        return "collection_error:unknown"
+    except Exception:
+        return None
+
+
 def _signature_for(out: Dict[str, Any]) -> str:
     """Logical failure signature -- reuse the production failure_signature_hash.
 
-    Failure class is "test" here (a real assertion failure, not syntax/env).
+    Produces a STABLE, DISCRIMINATING signature for ALL failure shapes:
+      (a) Failing test IDs (assertion failures): stable via sorted test IDs.
+      (b) Collection/import errors (no test IDs): stable + discriminating via
+          the normalised error-class + message (tempdir path stripped).
+      (c) SyntaxError ([SOVEREIGN SYNTAX FATAL]): via the syntax fatal line.
+
+    A repeated identical error -> same hash (drives temp decay + pivot).
+    A different error type -> different hash (genuine progress resets decay).
+    Tempdir paths are normalised out so the hash is attempt-independent.
     """
     try:
+        # Attempt (a): failing test IDs -- highest fidelity.
         ids = _failing_test_ids(out)
-        return failure_signature_hash(ids, "test")
+        if ids:
+            return failure_signature_hash(ids, "test")
+        # Attempt (b)/(c): collection/import/syntax error -- derive from the
+        # error text so different errors produce different hashes.
+        fingerprint = _collection_error_fingerprint(out)
+        if fingerprint is not None:
+            # Hash the fingerprint ourselves (failure_signature_hash expects
+            # iterables; we build a single-element list for compatibility).
+            return failure_signature_hash([fingerprint], "env")
+        # Fallback: stable hash from the last 200 chars of stderr (normalized).
+        tail = _TEMPDIR_RE.sub("<tmpdir>/", (out.get("stderr") or "")[-200:])
+        return failure_signature_hash([tail], "test")
     except Exception:
-        # Last-resort stable-ish fallback from the stderr tail.
         try:
-            return failure_signature_hash([(out.get("stderr") or "")[-200:]], "test")
+            return failure_signature_hash(
+                [(out.get("stderr") or "")[-200:]], "test"
+            )
         except Exception:
             return "unknown"
 
@@ -577,7 +727,7 @@ def _say(line: str = "") -> None:
 async def run_cognitive_soak(
     *,
     client: Any,
-    max_repairs: int = 3,
+    max_repairs: int = 5,
     payload: "Optional[AdversarialPayload]" = None,
 ) -> Dict[str, Any]:
     """Drive the adversarial payload through the REAL cognitive loop.
@@ -594,6 +744,18 @@ async def run_cognitive_soak(
             "adversarial_cognitive_soak refuses to run: set "
             "JARVIS_CHAOS_INJECTOR_ENABLED=true"
         )
+
+    # Pivot reachability: the production default JARVIS_EPISTEMIC_TEMP_FLOOR=0.0
+    # causes temperature_for_attempt to halve forever (0.7 -> 0.35 -> 0.175 ->
+    # 0.0875 ...) so temp_at_floor is NEVER True and pivot_verdict NEVER fires.
+    # Set a soak-specific non-zero floor (0.1) so the schedule stabilises and
+    # the real pivot_verdict CAN trip.  Only set if the caller has not already
+    # provided an explicit value (i.e. respect env overrides).
+    _SOAK_DEFAULT_TEMP_FLOOR = "0.1"
+    _floor_env_key = "JARVIS_EPISTEMIC_TEMP_FLOOR"
+    _floor_was_absent = _floor_env_key not in os.environ
+    if _floor_was_absent:
+        os.environ[_floor_env_key] = _SOAK_DEFAULT_TEMP_FLOOR
 
     payload = payload or ADVERSARIAL_PAYLOAD
     base_temp = float(os.environ.get("JARVIS_ADV_SOAK_BASE_TEMP", "0.7"))
@@ -613,6 +775,7 @@ async def run_cognitive_soak(
     decomposed = False
     converged = False
     attempts = 0
+    out: Dict[str, Any] = {}
 
     prev_impl = ""
     epistemic_feedback = ""
@@ -651,6 +814,8 @@ async def run_cognitive_soak(
     _say(f"Payload: {payload.title}")
     _say(f"Entry symbol: {payload.entry_symbol}  | base_temp={base_temp}  | "
          f"max_repairs={max_repairs}")
+    _say(f"  floor={os.environ.get(_floor_env_key, '?')}  "
+         f"(soak default: {_SOAK_DEFAULT_TEMP_FLOOR})")
     _say("-" * 72)
 
     # --- Bounded loop -------------------------------------------------------
@@ -659,118 +824,125 @@ async def run_cognitive_soak(
     total_budget = 1 + max_repairs + 1
     pivot_extra_used = False
 
-    while attempts < total_budget:
-        is_repair = attempts > 0
-        temperature = temperature_for_attempt(base_temp, repeated_signature_count)
-        temperature_trajectory.append(temperature)
-        attempts += 1
+    try:
+        while attempts < total_budget:
+            is_repair = attempts > 0
+            temperature = temperature_for_attempt(base_temp, repeated_signature_count)
+            temperature_trajectory.append(temperature)
+            attempts += 1
 
-        phase = "REPAIR" if is_repair else "GENERATE"
-        _say(f"[attempt {attempts}] phase={phase}  temperature={temperature:.4f}  "
-             f"repeated_sig_count={repeated_signature_count}  "
-             f"diff_injected={bool(epistemic_feedback)}")
+            phase = "REPAIR" if is_repair else "GENERATE"
+            _say(f"[attempt {attempts}] phase={phase}  temperature={temperature:.4f}  "
+                 f"repeated_sig_count={repeated_signature_count}  "
+                 f"diff_injected={bool(epistemic_feedback)}")
 
-        raw = await _generate(temperature, epistemic_feedback)
-        impl_src = _extract_code_block(raw)
+            raw = await _generate(temperature, epistemic_feedback)
+            impl_src = _sanitize_importable(_extract_code_block(raw))
 
-        out = _run_pytest_in_tempdir(
-            impl_src, payload.tests, timeout_s=pytest_timeout_s, payload=payload
-        )
-        passed = bool(out["passed"])
+            out = _run_pytest_in_tempdir(
+                impl_src, payload.tests, timeout_s=pytest_timeout_s, payload=payload
+            )
+            passed = bool(out["passed"])
 
-        iterations.append({
-            "attempt": attempts,
-            "temperature": round(temperature, 6),
-            "signature": None,  # filled below on fail
-            "diff_injected": bool(epistemic_feedback),
-            "test_result": "PASS" if passed else "FAIL",
-        })
+            iterations.append({
+                "attempt": attempts,
+                "temperature": round(temperature, 6),
+                "signature": None,  # filled below on fail
+                "diff_injected": bool(epistemic_feedback),
+                "test_result": "PASS" if passed else "FAIL",
+            })
 
-        if passed:
-            converged = True
-            _say(f"  -> PASS (pytest green). Cognitive convergence reached on "
-                 f"attempt {attempts}.")
-            iterations[-1]["test_result"] = "PASS"
-            final_out = out
-            break
+            if passed:
+                converged = True
+                _say(f"  -> PASS (pytest green). Cognitive convergence reached on "
+                     f"attempt {attempts}.")
+                iterations[-1]["test_result"] = "PASS"
+                out = out
+                break
 
-        # --- FAIL path ------------------------------------------------------
-        sig = _signature_for(out)
-        signatures.append(sig)
-        iterations[-1]["signature"] = sig[:12]
-        fail_ids = _failing_test_ids(out)
-        _say(f"  -> FAIL  signature={sig[:12]}  failing={len(fail_ids)} "
-             f"({', '.join(t.split('::')[-1] for t in fail_ids) or 'n/a'})")
+            # --- FAIL path ------------------------------------------------------
+            sig = _signature_for(out)
+            signatures.append(sig)
+            iterations[-1]["signature"] = sig[:12]
+            fail_ids = _failing_test_ids(out)
+            _say(f"  -> FAIL  signature={sig[:12]}  failing={len(fail_ids)} "
+                 f"({', '.join(t.split('::')[-1] for t in fail_ids) or 'n/a'})")
 
-        # Same-signature repeat tracking drives temperature decay + pivot.
-        if last_signature is not None and sig == last_signature:
-            repeated_signature_count += 1
-        last_signature = sig
+            # Same-signature repeat tracking drives temperature decay + pivot.
+            if last_signature is not None and sig == last_signature:
+                repeated_signature_count += 1
+            last_signature = sig
 
-        # Build the Hybrid Epistemic Diff (REAL builder) and inject next turn.
-        epistemic_feedback = build_failure_context(
-            prior_src=prev_impl,
-            failed_src=impl_src,
-            stderr=(out.get("stdout") or "") + "\n" + (out.get("stderr") or ""),
-            failing_tests=fail_ids,
-            sub_goal_label=payload.title,
-        )
-        if epistemic_feedback:
-            epistemic_diffs_injected += 1
-            _say(f"  -> injected Hybrid Epistemic Diff "
-                 f"({len(epistemic_feedback)} chars) into next prompt")
-        prev_impl = impl_src
+            # Build the Hybrid Epistemic Diff (REAL builder) and inject next turn.
+            epistemic_feedback = build_failure_context(
+                prior_src=prev_impl,
+                failed_src=impl_src,
+                stderr=(out.get("stdout") or "") + "\n" + (out.get("stderr") or ""),
+                failing_tests=fail_ids,
+                sub_goal_label=payload.title,
+            )
+            if epistemic_feedback:
+                epistemic_diffs_injected += 1
+                _say(f"  -> injected Hybrid Epistemic Diff "
+                     f"({len(epistemic_feedback)} chars) into next prompt")
+            prev_impl = impl_src
 
-        # --- Pivot check (REAL pivot_verdict) -------------------------------
-        # Floor is reached when one more decay no longer changes the temperature.
-        next_temp = temperature_for_attempt(base_temp, repeated_signature_count + 1)
-        temp_at_floor = abs(next_temp - temperature) < 1e-9
+            # --- Pivot check (REAL pivot_verdict) -------------------------------
+            # Floor is reached when one more decay no longer changes the temperature.
+            next_temp = temperature_for_attempt(base_temp, repeated_signature_count + 1)
+            temp_at_floor = abs(next_temp - temperature) < 1e-9
 
-        if not pivoted and pivot_verdict(repeated_signature_count, temp_at_floor):
-            pivoted = True
-            _say("")
-            _say("[SOVEREIGN YIELD: UNRESOLVABLE PATH] "
-                 f"same signature x{repeated_signature_count}, temp at floor "
-                 f"({temperature:.4f}). Pivoting -> decompose_for_block.")
-            failure_hint = {
-                "signature_hash": sig,
-                "stderr_tail": (out.get("stdout") or "")[-1200:],
-            }
-            try:
-                sub_goals = decompose_for_block(
-                    _build_goal(payload),
-                    zero_coverage=False,
-                    failure_hint=failure_hint,
-                )
-                decomposed = bool(sub_goals)
-                if sub_goals:
-                    # Re-aim at the SMALLEST/most-atomic mutation sub-chunk.
-                    chunk = sub_goals[-1]
-                    decomposed_description = (
-                        f"{getattr(chunk, 'title', '')}: "
-                        f"{getattr(chunk, 'description', '')}"
-                    )[:1500]
-                    _say(f"  -> decompose emitted {len(sub_goals)} sub-goal(s); "
-                         f"re-aiming at hyper-atomic chunk: "
-                         f"{getattr(chunk, 'sub_goal_id', '?')}")
-            except Exception as e:  # noqa: BLE001
-                _say(f"  -> decompose_for_block error (fail-soft): {e}")
-                decomposed = False
+            if not pivoted and pivot_verdict(repeated_signature_count, temp_at_floor):
+                pivoted = True
+                _say("")
+                _say("[SOVEREIGN YIELD: UNRESOLVABLE PATH] "
+                     f"same signature x{repeated_signature_count}, temp at floor "
+                     f"({temperature:.4f}). Pivoting -> decompose_for_block.")
+                failure_hint = {
+                    "signature_hash": sig,
+                    "stderr_tail": (out.get("stdout") or "")[-1200:],
+                }
+                try:
+                    sub_goals = decompose_for_block(
+                        _build_goal(payload),
+                        zero_coverage=False,
+                        failure_hint=failure_hint,
+                    )
+                    decomposed = bool(sub_goals)
+                    if sub_goals:
+                        # Re-aim at the SMALLEST/most-atomic mutation sub-chunk.
+                        chunk = sub_goals[-1]
+                        decomposed_description = (
+                            f"{getattr(chunk, 'title', '')}: "
+                            f"{getattr(chunk, 'description', '')}"
+                        )[:1500]
+                        _say(f"  -> decompose emitted {len(sub_goals)} sub-goal(s); "
+                             f"re-aiming at hyper-atomic chunk: "
+                             f"{getattr(chunk, 'sub_goal_id', '?')}")
+                except Exception as e:  # noqa: BLE001
+                    _say(f"  -> decompose_for_block error (fail-soft): {e}")
+                    decomposed = False
 
-            # Reset the repeat counter so the post-pivot attempt gets a fair
-            # (higher) temperature against the SMALLER chunk -- bounded by the
-            # one pivot_extra grant.
-            if not pivot_extra_used:
-                pivot_extra_used = True
-                total_budget += 1
-                repeated_signature_count = 0
-                last_signature = None
-            _say("")
+                # Reset the repeat counter so the post-pivot attempt gets a fair
+                # (higher) temperature against the SMALLER chunk -- bounded by the
+                # one pivot_extra grant.
+                if not pivot_extra_used:
+                    pivot_extra_used = True
+                    total_budget += 1
+                    repeated_signature_count = 0
+                    last_signature = None
+                _say("")
 
-        if attempts >= total_budget:
-            break
+            if attempts >= total_budget:
+                break
 
-    final_out = locals().get("final_out", out if "out" in locals() else {})
+    finally:
+        # Restore the env var to its original state so the soak does not leak
+        # env mutations across subsequent calls in the same process (e.g. tests).
+        if _floor_was_absent:
+            os.environ.pop(_floor_env_key, None)
+
+    final_out = out
 
     result = {
         "converged": converged,
@@ -925,8 +1097,14 @@ def main(argv: Optional[List[str]] = None) -> int:
                         help="Actually drive the real local Ollama model.")
     parser.add_argument("--model", default="qwen2.5-coder:7b",
                         help="Local model name (default: qwen2.5-coder:7b).")
-    parser.add_argument("--max-repairs", type=int, default=3,
-                        help="Max repair iterations before pivot (default: 3).")
+    parser.add_argument("--max-repairs", type=int, default=5,
+                        help=(
+                            "Max repair iterations before pivot (default: 5). "
+                            "With the soak's floor=0.1 / decay=0.5, the temperature "
+                            "schedule stabilises at attempt 4 and pivot_verdict can "
+                            "trip at count>=2+temp_at_floor. Use >=5 to guarantee the "
+                            "pivot is reachable within a bounded budget."
+                        ))
     parser.add_argument("--payload", choices=sorted(PAYLOADS.keys()),
                         default=DEFAULT_PAYLOAD,
                         help=f"Adversarial payload to drive (default: {DEFAULT_PAYLOAD}).")

--- a/scripts/adversarial_cognitive_soak.py
+++ b/scripts/adversarial_cognitive_soak.py
@@ -1,0 +1,649 @@
+#!/usr/bin/env python3
+"""Adversarial Cognitive Soak harness.
+
+Validates the RSI cognitive loop UNDER FIRE *before* the J-Prime failover is
+flipped live. It drives a real ``qwen2.5-coder:7b`` (via the production
+``LocalPrimeClient``) through a deliberately adversarial coding sub-goal and
+observes the REAL epistemic-feedback -> repair -> pivot -> decompose loop produce
+(or fail to produce) a test-verified candidate.
+
+The GCP failover *infra* is proven separately; THIS proves the *cognitive
+pipeline*: think -> fail -> read its own failure -> adapt (temperature decay +
+epistemic diff) -> pivot -> decompose -> converge.
+
+Design constraints (all enforced):
+  * gated behind JARVIS_CHAOS_INJECTOR_ENABLED (default false),
+  * ASCII only, ``from __future__ import annotations``, Python 3.9+
+    (``asyncio.wait_for``, never ``asyncio.timeout``),
+  * fail-soft, async,
+  * REUSE the real primitives -- no reimplementation:
+      - LocalPrimeClient (J-Prime failover generator),
+      - epistemic_feedback.{build_failure_context, temperature_for_attempt,
+        pivot_verdict},
+      - goal_decomposition_planner.decompose_for_block,
+      - failure_classifier.failure_signature_hash (logical failure signature),
+  * REAL pytest subprocess execution for VALIDATE,
+  * bounded -- no infinite loop.
+
+This is NOT run automatically. ``--run`` requires JARVIS_CHAOS_INJECTOR_ENABLED
+to be true and talks to a local Ollama at http://127.0.0.1:11434.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import textwrap
+import types
+from dataclasses import dataclass
+from typing import Any, Dict, List, Optional
+
+# --- Repo on path (standalone-script invocation) ---------------------------
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.abspath(os.path.join(_HERE, ".."))
+if _REPO not in sys.path:
+    sys.path.insert(0, _REPO)
+
+# --- REAL primitives (no reimplementation) ---------------------------------
+from backend.core.ouroboros.governance.epistemic_feedback import (  # noqa: E402
+    build_failure_context,
+    pivot_verdict,
+    temperature_for_attempt,
+)
+from backend.core.ouroboros.governance.failure_classifier import (  # noqa: E402
+    failure_signature_hash,
+)
+from backend.core.ouroboros.governance.goal_decomposition_planner import (  # noqa: E402
+    decompose_for_block,
+)
+from backend.core.ouroboros.governance.local_inference_director import (  # noqa: E402
+    LocalConfig,
+    LocalPrimeClient,
+)
+
+_TRUE = {"1", "true", "yes", "on"}
+
+
+def gate_enabled() -> bool:
+    """Master kill-switch. Default OFF -> the harness refuses to run."""
+    v = os.environ.get("JARVIS_CHAOS_INJECTOR_ENABLED")
+    return bool(v) and v.strip().lower() in _TRUE
+
+
+# ---------------------------------------------------------------------------
+# The adversarial payload
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AdversarialPayload:
+    """A moderately complex coding sub-goal at the edge of a 7B's window.
+
+    Chosen task: merge-overlapping-intervals WITH the half-open adjacency edge
+    case (intervals that only TOUCH at an endpoint, e.g. [1,2] and [2,3], must
+    merge into [1,3]). A first draft from a 7B typically uses ``s < last_end``
+    (strict) and silently botches adjacency -- a subtle, deterministic edge case
+    that the test suite pins.
+    """
+
+    title: str
+    description: str
+    entry_symbol: str
+    impl_filename: str
+    test_filename: str
+    tests: str
+    system_prompt: str
+
+    def build_prompt(self, epistemic_feedback: str = "") -> str:
+        """Compose the generation prompt; append the Hybrid Epistemic Diff (if any)."""
+        parts = [
+            "<task>",
+            self.title,
+            "</task>",
+            "<description>",
+            self.description,
+            "</description>",
+            "<requirements>",
+            f"- Define a top-level function named `{self.entry_symbol}`.",
+            "- Handle the empty input case.",
+            "- Sort the intervals first.",
+            "- CRITICAL EDGE CASE: intervals that only TOUCH at an endpoint",
+            "  (e.g. (1, 2) and (2, 3)) MUST merge into (1, 3) -- adjacency counts",
+            "  as overlap. Use `<=`, not `<`.",
+            "- Return a list of tuples.",
+            "</requirements>",
+            "<output_format>",
+            "Return ONLY a single Python code block (```python ... ```) with the",
+            "full implementation. No prose, no tests.",
+            "</output_format>",
+        ]
+        if epistemic_feedback:
+            parts += [
+                "",
+                "<previous_attempt_feedback>",
+                "Your previous attempt FAILED the test suite. Study this epistemic",
+                "feedback (diff vs your prior attempt + the failing-test stderr) and",
+                "FIX the root cause -- do not repeat the same mistake:",
+                "",
+                epistemic_feedback,
+                "</previous_attempt_feedback>",
+            ]
+        return "\n".join(parts)
+
+
+_TESTS = textwrap.dedent(
+    '''
+    from impl import merge_intervals
+
+
+    def test_empty():
+        assert merge_intervals([]) == []
+
+
+    def test_no_overlap():
+        assert merge_intervals([(1, 2), (4, 5)]) == [(1, 2), (4, 5)]
+
+
+    def test_simple_overlap():
+        assert merge_intervals([(1, 3), (2, 5)]) == [(1, 5)]
+
+
+    def test_unsorted_input():
+        assert merge_intervals([(4, 5), (1, 3), (2, 4)]) == [(1, 5), (4, 5)] or \\
+            merge_intervals([(4, 5), (1, 3), (2, 4)]) == [(1, 5)]
+
+
+    def test_adjacency_edge_case():
+        # The subtle one: touching intervals must merge.
+        assert merge_intervals([(1, 2), (2, 3)]) == [(1, 3)]
+
+
+    def test_adjacency_chain():
+        assert merge_intervals([(1, 2), (2, 3), (3, 4)]) == [(1, 4)]
+
+
+    def test_nested():
+        assert merge_intervals([(1, 10), (2, 3), (4, 5)]) == [(1, 10)]
+    '''
+).strip()
+
+
+ADVERSARIAL_PAYLOAD = AdversarialPayload(
+    title="Merge overlapping intervals (with adjacency edge case)",
+    description=(
+        "Implement `merge_intervals(intervals)` that merges a list of "
+        "(start, end) integer tuples so that any overlapping OR ADJACENT "
+        "intervals are combined into a single interval. Adjacency means two "
+        "intervals that touch at an endpoint (e.g. (1, 2) and (2, 3)) must "
+        "merge into (1, 3). Return a sorted list of merged (start, end) tuples."
+    ),
+    entry_symbol="merge_intervals",
+    impl_filename="impl.py",
+    test_filename="test_impl.py",
+    tests=_TESTS,
+    system_prompt=(
+        "You are a precise senior Python engineer. You write correct, minimal "
+        "implementations and you reason carefully about edge cases before "
+        "emitting code. Output a single Python code block only."
+    ),
+)
+
+
+# ---------------------------------------------------------------------------
+# Code extraction + real pytest VALIDATE boundary
+# ---------------------------------------------------------------------------
+
+_CODE_BLOCK_RE = re.compile(r"```(?:python)?\s*\n(.*?)```", re.DOTALL)
+
+
+def _extract_code_block(text: str) -> str:
+    """Extract the first fenced python code block; fall back to raw text.
+
+    Fail-soft: always returns a string.
+    """
+    if not text:
+        return ""
+    try:
+        m = _CODE_BLOCK_RE.search(text)
+        if m:
+            return m.group(1).strip()
+        # No fence -- best-effort: return the text verbatim (it may be raw code).
+        return text.strip()
+    except Exception:
+        return str(text)
+
+
+def _run_pytest_in_tempdir(impl_src: str, tests_src: str, *, timeout_s: int = 90) -> Dict[str, Any]:
+    """Write impl + tests to a tempdir and run REAL pytest as a subprocess.
+
+    Returns {passed: bool, stdout: str, stderr: str, returncode: int}. Fail-soft:
+    a missing impl / timeout / crash is reported as a non-pass, never raises.
+    """
+    result: Dict[str, Any] = {"passed": False, "stdout": "", "stderr": "", "returncode": -1}
+    if not impl_src:
+        result["stderr"] = "empty implementation (model produced no code block)"
+        return result
+    try:
+        with tempfile.TemporaryDirectory(prefix="adv_soak_") as d:
+            impl_path = os.path.join(d, ADVERSARIAL_PAYLOAD.impl_filename)
+            test_path = os.path.join(d, ADVERSARIAL_PAYLOAD.test_filename)
+            with open(impl_path, "w", encoding="ascii", errors="replace") as f:
+                f.write(impl_src)
+            with open(test_path, "w", encoding="ascii", errors="replace") as f:
+                f.write(tests_src)
+            try:
+                proc = subprocess.run(
+                    [sys.executable, "-m", "pytest", "-q", "-p", "no:cacheprovider", test_path],
+                    cwd=d,
+                    capture_output=True,
+                    text=True,
+                    timeout=timeout_s,
+                )
+            except subprocess.TimeoutExpired as e:
+                result["stderr"] = f"pytest TIMEOUT after {timeout_s}s: {e}"
+                return result
+            result["returncode"] = proc.returncode
+            result["stdout"] = proc.stdout or ""
+            result["stderr"] = proc.stderr or ""
+            result["passed"] = proc.returncode == 0
+            return result
+    except Exception as e:  # noqa: BLE001
+        result["stderr"] = f"harness error running pytest: {e}"
+        return result
+
+
+_FAIL_RE = re.compile(r"^(\S+\.py::\S+)\s+(?:FAILED|ERROR)", re.MULTILINE)
+
+
+def _normalize_id(node_id: str) -> str:
+    """Strip the (random tempdir) path prefix so the node id is path-independent.
+
+    "/tmp/adv_soak_xyz/test_impl.py::test_foo" -> "test_impl.py::test_foo".
+    This is what makes the failure SIGNATURE stable across attempts (the impl is
+    rewritten into a fresh tempdir each VALIDATE, so the absolute path varies).
+    """
+    try:
+        if "::" not in node_id:
+            return node_id
+        path, _, rest = node_id.partition("::")
+        return os.path.basename(path) + "::" + rest
+    except Exception:
+        return node_id
+
+
+def _failing_test_ids(out: Dict[str, Any]) -> List[str]:
+    """Extract failing test node ids from pytest output (fail-soft, path-normalized)."""
+    try:
+        blob = (out.get("stdout") or "") + "\n" + (out.get("stderr") or "")
+        ids = _FAIL_RE.findall(blob)
+        if not ids:
+            # Fallback: pytest -q "short test summary" style "FAILED ...::..."
+            ids = re.findall(r"FAILED\s+(\S+::\S+)", blob)
+        return sorted({_normalize_id(i) for i in ids}) if ids else []
+    except Exception:
+        return []
+
+
+def _signature_for(out: Dict[str, Any]) -> str:
+    """Logical failure signature -- reuse the production failure_signature_hash.
+
+    Failure class is "test" here (a real assertion failure, not syntax/env).
+    """
+    try:
+        ids = _failing_test_ids(out)
+        return failure_signature_hash(ids, "test")
+    except Exception:
+        # Last-resort stable-ish fallback from the stderr tail.
+        try:
+            return failure_signature_hash([(out.get("stderr") or "")[-200:]], "test")
+        except Exception:
+            return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Goal stub for decompose_for_block (duck-typed: goal_id/title/description/files)
+# ---------------------------------------------------------------------------
+
+
+def _build_goal() -> Any:
+    return types.SimpleNamespace(
+        goal_id="adv-soak-merge-intervals",
+        title=ADVERSARIAL_PAYLOAD.title,
+        description=(
+            ADVERSARIAL_PAYLOAD.description
+            + " HYPER-ATOMIC FOCUS: get the adjacency edge case right first -- "
+            "merge intervals that only touch at an endpoint using `<=`."
+        ),
+        target_files=(ADVERSARIAL_PAYLOAD.impl_filename,),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Soak narrative printing
+# ---------------------------------------------------------------------------
+
+
+def _say(line: str = "") -> None:
+    print(line, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# The cognitive loop driver
+# ---------------------------------------------------------------------------
+
+
+async def run_cognitive_soak(*, client: Any, max_repairs: int = 3) -> Dict[str, Any]:
+    """Drive the adversarial payload through the REAL cognitive loop.
+
+    Returns a result dict:
+      {converged, attempts, temperature_trajectory, pivoted, decomposed,
+       epistemic_diffs_injected, final_test_output, signatures}
+
+    Bounded: at most (1 initial GENERATE + max_repairs repairs + 1 post-pivot
+    GENERATE) attempts. Never loops forever. Fail-soft.
+    """
+    if not gate_enabled():
+        raise RuntimeError(
+            "adversarial_cognitive_soak refuses to run: set "
+            "JARVIS_CHAOS_INJECTOR_ENABLED=true"
+        )
+
+    payload = ADVERSARIAL_PAYLOAD
+    base_temp = float(os.environ.get("JARVIS_ADV_SOAK_BASE_TEMP", "0.7"))
+    pytest_timeout_s = int(os.environ.get("JARVIS_ADV_SOAK_PYTEST_TIMEOUT_S", "90"))
+    gen_timeout_s = float(os.environ.get("JARVIS_ADV_SOAK_GEN_TIMEOUT_S", "240"))
+
+    iterations: List[Dict[str, Any]] = []
+    temperature_trajectory: List[float] = []
+    signatures: List[str] = []
+    epistemic_diffs_injected = 0
+    pivoted = False
+    decomposed = False
+    converged = False
+    attempts = 0
+
+    prev_impl = ""
+    epistemic_feedback = ""
+    repeated_signature_count = 0
+    last_signature: Optional[str] = None
+    current_payload_prompt_goal = payload  # may swap to decomposed sub-chunk text
+    decomposed_description = ""
+
+    async def _generate(temperature: float, feedback: str) -> str:
+        prompt = current_payload_prompt_goal.build_prompt(feedback) \
+            if hasattr(current_payload_prompt_goal, "build_prompt") \
+            else payload.build_prompt(feedback)
+        if decomposed_description:
+            prompt = prompt + "\n\n<decomposed_sub_goal>\n" + decomposed_description + \
+                "\n</decomposed_sub_goal>"
+        try:
+            resp = await asyncio.wait_for(
+                client.generate(
+                    prompt,
+                    system_prompt=payload.system_prompt,
+                    temperature=temperature,
+                ),
+                timeout=gen_timeout_s,
+            )
+        except asyncio.TimeoutError:
+            _say(f"  [TIMEOUT] generate exceeded {gen_timeout_s}s -- treating as empty")
+            return ""
+        except Exception as e:  # noqa: BLE001
+            _say(f"  [GEN-ERROR] {e} -- treating as empty")
+            return ""
+        return getattr(resp, "content", "") or ""
+
+    _say("=" * 72)
+    _say("ADVERSARIAL COGNITIVE SOAK -- driving the RSI loop UNDER FIRE")
+    _say("=" * 72)
+    _say(f"Payload: {payload.title}")
+    _say(f"Entry symbol: {payload.entry_symbol}  | base_temp={base_temp}  | "
+         f"max_repairs={max_repairs}")
+    _say("-" * 72)
+
+    # --- Bounded loop -------------------------------------------------------
+    # Phase budget: initial GENERATE + up to max_repairs repairs, and a pivot
+    # may grant ONE extra post-decompose GENERATE.
+    total_budget = 1 + max_repairs + 1
+    pivot_extra_used = False
+
+    while attempts < total_budget:
+        is_repair = attempts > 0
+        temperature = temperature_for_attempt(base_temp, repeated_signature_count)
+        temperature_trajectory.append(temperature)
+        attempts += 1
+
+        phase = "REPAIR" if is_repair else "GENERATE"
+        _say(f"[attempt {attempts}] phase={phase}  temperature={temperature:.4f}  "
+             f"repeated_sig_count={repeated_signature_count}  "
+             f"diff_injected={bool(epistemic_feedback)}")
+
+        raw = await _generate(temperature, epistemic_feedback)
+        impl_src = _extract_code_block(raw)
+
+        out = _run_pytest_in_tempdir(impl_src, payload.tests, timeout_s=pytest_timeout_s)
+        passed = bool(out["passed"])
+
+        iterations.append({
+            "attempt": attempts,
+            "temperature": round(temperature, 6),
+            "signature": None,  # filled below on fail
+            "diff_injected": bool(epistemic_feedback),
+            "test_result": "PASS" if passed else "FAIL",
+        })
+
+        if passed:
+            converged = True
+            _say(f"  -> PASS (pytest green). Cognitive convergence reached on "
+                 f"attempt {attempts}.")
+            iterations[-1]["test_result"] = "PASS"
+            final_out = out
+            break
+
+        # --- FAIL path ------------------------------------------------------
+        sig = _signature_for(out)
+        signatures.append(sig)
+        iterations[-1]["signature"] = sig[:12]
+        fail_ids = _failing_test_ids(out)
+        _say(f"  -> FAIL  signature={sig[:12]}  failing={len(fail_ids)} "
+             f"({', '.join(t.split('::')[-1] for t in fail_ids) or 'n/a'})")
+
+        # Same-signature repeat tracking drives temperature decay + pivot.
+        if last_signature is not None and sig == last_signature:
+            repeated_signature_count += 1
+        last_signature = sig
+
+        # Build the Hybrid Epistemic Diff (REAL builder) and inject next turn.
+        epistemic_feedback = build_failure_context(
+            prior_src=prev_impl,
+            failed_src=impl_src,
+            stderr=(out.get("stdout") or "") + "\n" + (out.get("stderr") or ""),
+            failing_tests=fail_ids,
+            sub_goal_label=payload.title,
+        )
+        if epistemic_feedback:
+            epistemic_diffs_injected += 1
+            _say(f"  -> injected Hybrid Epistemic Diff "
+                 f"({len(epistemic_feedback)} chars) into next prompt")
+        prev_impl = impl_src
+
+        # --- Pivot check (REAL pivot_verdict) -------------------------------
+        # Floor is reached when one more decay no longer changes the temperature.
+        next_temp = temperature_for_attempt(base_temp, repeated_signature_count + 1)
+        temp_at_floor = abs(next_temp - temperature) < 1e-9
+
+        if not pivoted and pivot_verdict(repeated_signature_count, temp_at_floor):
+            pivoted = True
+            _say("")
+            _say("[SOVEREIGN YIELD: UNRESOLVABLE PATH] "
+                 f"same signature x{repeated_signature_count}, temp at floor "
+                 f"({temperature:.4f}). Pivoting -> decompose_for_block.")
+            failure_hint = {
+                "signature_hash": sig,
+                "stderr_tail": (out.get("stdout") or "")[-1200:],
+            }
+            try:
+                sub_goals = decompose_for_block(
+                    _build_goal(),
+                    zero_coverage=False,
+                    failure_hint=failure_hint,
+                )
+                decomposed = bool(sub_goals)
+                if sub_goals:
+                    # Re-aim at the SMALLEST/most-atomic mutation sub-chunk.
+                    chunk = sub_goals[-1]
+                    decomposed_description = (
+                        f"{getattr(chunk, 'title', '')}: "
+                        f"{getattr(chunk, 'description', '')}"
+                    )[:1500]
+                    _say(f"  -> decompose emitted {len(sub_goals)} sub-goal(s); "
+                         f"re-aiming at hyper-atomic chunk: "
+                         f"{getattr(chunk, 'sub_goal_id', '?')}")
+            except Exception as e:  # noqa: BLE001
+                _say(f"  -> decompose_for_block error (fail-soft): {e}")
+                decomposed = False
+
+            # Reset the repeat counter so the post-pivot attempt gets a fair
+            # (higher) temperature against the SMALLER chunk -- bounded by the
+            # one pivot_extra grant.
+            if not pivot_extra_used:
+                pivot_extra_used = True
+                total_budget += 1
+                repeated_signature_count = 0
+                last_signature = None
+            _say("")
+
+        if attempts >= total_budget:
+            break
+
+    final_out = locals().get("final_out", out if "out" in locals() else {})
+
+    result = {
+        "converged": converged,
+        "attempts": attempts,
+        "temperature_trajectory": temperature_trajectory,
+        "pivoted": pivoted,
+        "decomposed": decomposed,
+        "epistemic_diffs_injected": epistemic_diffs_injected,
+        "final_test_output": {
+            "passed": bool(final_out.get("passed")) if isinstance(final_out, dict) else False,
+            "stdout_tail": (final_out.get("stdout", "") if isinstance(final_out, dict) else "")[-800:],
+            "stderr_tail": (final_out.get("stderr", "") if isinstance(final_out, dict) else "")[-800:],
+        },
+        "signatures": [s[:12] for s in signatures],
+        "iterations": iterations,
+    }
+    return result
+
+
+# ---------------------------------------------------------------------------
+# Report
+# ---------------------------------------------------------------------------
+
+
+def print_report(result: Dict[str, Any]) -> None:
+    _say("")
+    _say("=" * 72)
+    _say("SOAK NARRATIVE / VERDICT")
+    _say("=" * 72)
+    for it in result.get("iterations", []):
+        _say(f"  attempt {it['attempt']:>2}  temp={it['temperature']:<8} "
+             f"diff_injected={str(it['diff_injected']):<5} "
+             f"sig={str(it['signature']):<14} {it['test_result']}")
+    traj = ", ".join(f"{t:.4f}" for t in result.get("temperature_trajectory", []))
+    _say("")
+    _say(f"  temperature trajectory : [{traj}]")
+    _say(f"  epistemic diffs injected: {result.get('epistemic_diffs_injected')}")
+    _say(f"  pivoted                 : {result.get('pivoted')}")
+    _say(f"  decomposed              : {result.get('decomposed')}")
+    _say(f"  attempts                : {result.get('attempts')}")
+    _say(f"  converged               : {result.get('converged')}")
+    _say("-" * 72)
+    if result.get("converged"):
+        _say("VERDICT: CONVERGED. A test-verified candidate was produced UNDER FIRE.")
+        _say("FLIP-GATE: SATISFIED -- the cognitive pipeline survives adversarial")
+        _say("           load (think -> fail -> adapt -> [pivot/decompose] -> pass).")
+    else:
+        _say("VERDICT: NON-CONVERGENCE (honest, bounded). No infinite loop; the loop")
+        _say("         yielded after exhausting its repair + pivot budget.")
+        _say("FLIP-GATE: NOT satisfied -- do NOT flip the failover live yet.")
+        st = result.get("final_test_output", {})
+        if st.get("stdout_tail"):
+            _say("  last pytest stdout tail:")
+            for ln in st["stdout_tail"].splitlines()[-12:]:
+                _say("    " + ln)
+    _say("=" * 72)
+
+
+# ---------------------------------------------------------------------------
+# main
+# ---------------------------------------------------------------------------
+
+
+def _build_real_client(model: str) -> LocalPrimeClient:
+    cfg = LocalConfig.from_env()
+    # Pin to the soak target regardless of env model default.
+    cfg = LocalConfig(
+        base_url=os.environ.get("JARVIS_LOCAL_MODEL_BASE_URL", "http://127.0.0.1:11434"),
+        model_name=model,
+        keep_alive_seconds=cfg.keep_alive_seconds,
+        timeout_seed_ms=cfg.timeout_seed_ms,
+        timeout_ceiling_ms=cfg.timeout_ceiling_ms,
+        timeout_floor_ms=cfg.timeout_floor_ms,
+        output_ratio=cfg.output_ratio,
+        margin_sigma=cfg.margin_sigma,
+        window_size=cfg.window_size,
+        min_samples=cfg.min_samples,
+        max_concurrency=cfg.max_concurrency,
+        pool_limit=cfg.pool_limit,
+    )
+    return LocalPrimeClient(cfg)
+
+
+async def _amain(args: argparse.Namespace) -> int:
+    if not gate_enabled():
+        _say("REFUSED: set JARVIS_CHAOS_INJECTOR_ENABLED=true to run the soak.")
+        return 2
+    if not args.run:
+        _say("Dry mode: pass --run to drive the real local model. (Gate is ON.)")
+        _say(f"Would target model={args.model} at "
+             f"{os.environ.get('JARVIS_LOCAL_MODEL_BASE_URL', 'http://127.0.0.1:11434')}")
+        return 0
+
+    client = _build_real_client(args.model)
+    try:
+        result = await run_cognitive_soak(client=client, max_repairs=args.max_repairs)
+        print_report(result)
+        return 0 if result.get("converged") else 1
+    finally:
+        try:
+            await client.aclose()
+        except Exception:
+            pass
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Adversarial Cognitive Soak -- drives qwen2.5-coder:7b through "
+                    "the real epistemic-feedback -> repair -> pivot -> decompose loop."
+    )
+    parser.add_argument("--run", action="store_true",
+                        help="Actually drive the real local Ollama model.")
+    parser.add_argument("--model", default="qwen2.5-coder:7b",
+                        help="Local model name (default: qwen2.5-coder:7b).")
+    parser.add_argument("--max-repairs", type=int, default=3,
+                        help="Max repair iterations before pivot (default: 3).")
+    args = parser.parse_args(argv)
+    try:
+        return asyncio.run(_amain(args))
+    except KeyboardInterrupt:
+        _say("interrupted")
+        return 130
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/adversarial_cognitive_soak.py
+++ b/scripts/adversarial_cognitive_soak.py
@@ -60,6 +60,7 @@ if _REPO not in sys.path:
 from backend.core.ouroboros.governance.epistemic_feedback import (  # noqa: E402
     build_failure_context,
     pivot_verdict,
+    should_pivot,
     temperature_for_attempt,
 )
 from backend.core.ouroboros.governance.failure_classifier import (  # noqa: E402
@@ -772,6 +773,7 @@ async def run_cognitive_soak(
     signatures: List[str] = []
     epistemic_diffs_injected = 0
     pivoted = False
+    pivot_reason = ""
     decomposed = False
     converged = False
     attempts = 0
@@ -892,12 +894,28 @@ async def run_cognitive_soak(
             next_temp = temperature_for_attempt(base_temp, repeated_signature_count + 1)
             temp_at_floor = abs(next_temp - temperature) < 1e-9
 
-            if not pivoted and pivot_verdict(repeated_signature_count, temp_at_floor):
+            # Composite verdict: pivot on the legacy stuck-wall trigger OR on
+            # budget-exhaustion (thrash / non-convergence backstop). A model
+            # that emits a DIFFERENT failure each attempt resets
+            # repeated_signature_count and so would NEVER trip the legacy
+            # stuck-signature trigger -- the budget backstop catches it once it
+            # has burned the initial GENERATE + all max_repairs attempts.
+            _pivot_budget = 1 + max_repairs
+            _do_pivot, _pivot_reason = should_pivot(
+                repeated_signature_count=repeated_signature_count,
+                temp_at_floor=temp_at_floor,
+                total_attempts=attempts,
+                max_attempts=_pivot_budget,
+            )
+            if not pivoted and _do_pivot:
                 pivoted = True
+                pivot_reason = _pivot_reason
                 _say("")
                 _say("[SOVEREIGN YIELD: UNRESOLVABLE PATH] "
-                     f"same signature x{repeated_signature_count}, temp at floor "
-                     f"({temperature:.4f}). Pivoting -> decompose_for_block.")
+                     f"reason={_pivot_reason} same signature x{repeated_signature_count}, "
+                     f"temp at floor ({temperature:.4f}), "
+                     f"attempts={attempts}/{_pivot_budget}. "
+                     f"Pivoting -> decompose_for_block.")
                 failure_hint = {
                     "signature_hash": sig,
                     "stderr_tail": (out.get("stdout") or "")[-1200:],
@@ -949,6 +967,7 @@ async def run_cognitive_soak(
         "attempts": attempts,
         "temperature_trajectory": temperature_trajectory,
         "pivoted": pivoted,
+        "pivot_reason": pivot_reason,
         "decomposed": decomposed,
         "epistemic_diffs_injected": epistemic_diffs_injected,
         "final_test_output": {

--- a/scripts/adversarial_cognitive_soak.py
+++ b/scripts/adversarial_cognitive_soak.py
@@ -413,11 +413,200 @@ CONCURRENCY_LRU_PAYLOAD = AdversarialPayload(
 )
 
 
+# ---------------------------------------------------------------------------
+# Payload #3: the Architectural Anomaly (Paxos-style leader election)
+# ---------------------------------------------------------------------------
+#
+# This is the FINAL flip-gate payload. It is DELIBERATELY past a 7B's single-
+# context reach: a stateful, multi-symbol distributed-consensus state machine
+# (PaxosNode) that a 7B cannot hold coherently in one pass. It reliably THRASHES
+# (a different partial failure most attempts), so it burns the entire repair
+# budget and forces should_pivot(... budget_exhausted) -> the
+# ``[SOVEREIGN YIELD: UNRESOLVABLE PATH]`` graceful pivot -> decompose_for_block.
+#
+# The symbols are DELIBERATELY DISTINCT so the SEMANTIC (symbol-level) decompose
+# has real seams. ``isolate_symbols`` scopes each method that the goal
+# description names, so the decompose can separate e.g. the async heartbeat_loop
+# symbol from the monotonic term-counter symbol (advance_term). The harness logs
+# these scoped symbols so the operator can WATCH the semantic separation.
+#
+# The flip-gate is NOT that Paxos ultimately passes -- it is that the FSM/loop
+# handles the yield -> decompose -> retry GRACEFULLY (no lockup, no dropped
+# state, clean termination). Paxos passing is a bonus.
+#
+# Fairness / determinism: NO real network. An in-process ``InProcTransport``
+# message-bus is injected, so the suite is deterministic (no sockets, no timing
+# flakiness) with generous bounded waits. A CORRECT reference impl PASSES; a
+# 7B's typical single-context attempt fails (non-monotonic term / multiple
+# leaders per term / no brain-split resolution / blocking heartbeat).
+
+_PAXOS_TESTS = textwrap.dedent(
+    '''
+    from impl import PaxosNode, InProcTransport
+
+    import asyncio
+    import time
+
+
+    def _cluster(n=3):
+        t = InProcTransport()
+        nodes = [PaxosNode("n%d" % i, t) for i in range(n)]
+        return t, nodes
+
+
+    def test_monotonic_term_never_decreases():
+        # advance_term: the term-epoch counter is MONOTONIC -- a lower term is
+        # rejected, the current term never goes backward.
+        t, nodes = _cluster(3)
+        try:
+            node = nodes[0]
+            node.advance_term(5)
+            assert node.term == 5
+            node.advance_term(3)          # lower -> must be ignored
+            assert node.term == 5, "term must NOT decrease (monotonic epoch)"
+            node.advance_term()           # bump
+            assert node.term == 6
+        finally:
+            for n in nodes:
+                n.stop()
+
+
+    def test_exactly_one_leader_per_term():
+        # on_vote_request + request_election: exactly one leader per term.
+        t, nodes = _cluster(3)
+        try:
+            won = nodes[0].request_election()
+            assert won is True, "a majority should elect the candidate"
+            leaders = [n for n in nodes if n.is_leader]
+            assert len(leaders) == 1, "exactly one leader per term"
+            assert leaders[0] is nodes[0]
+            term = nodes[0].term
+            # A second candidate cannot also win nodes[0]'s already-decided term:
+            # the followers already voted, so a fresh vote in that term is denied
+            # (or the probed node has moved to a higher term).
+            ok, _ = nodes[1].on_vote_request("intruder", term)
+            assert ok is False or term != nodes[1].term
+        finally:
+            for n in nodes:
+                n.stop()
+
+
+    def test_partition_no_double_leader_same_term():
+        # resolve_partition: a simulated network partition must NOT let both
+        # sides claim leadership in the SAME term (brain-split resolution).
+        t, nodes = _cluster(4)
+        try:
+            a, b, c, d = nodes
+            # Split into {a,b} | {c,d}: neither half is a majority of 4.
+            for x in (a, b):
+                for y in (c, d):
+                    t.partition(x.node_id, y.node_id)
+            a_won = a.request_election()
+            a_term = a.term
+            c_won = c.request_election()
+            c_term = c.term
+            assert not (a_won and c_won), "brain-split: both halves cannot win"
+            if a.is_leader and c.is_leader:
+                assert a_term != c_term, "two leaders MUST NOT share a term"
+            # Heal: the lower-term node steps down on observing the higher term.
+            t.heal()
+            hi = max(a_term, c_term)
+            a.resolve_partition(hi)
+            c.resolve_partition(hi)
+            assert a.term >= a_term and c.term >= c_term
+        finally:
+            for n in nodes:
+                n.stop()
+
+
+    def test_heartbeat_is_async_nonblocking():
+        # heartbeat_loop: an async, non-blocking loop -- construction + a bounded
+        # number of rounds completes promptly (a blocking sleep loop would hang).
+        t, nodes = _cluster(3)
+        try:
+            leader = nodes[0]
+            leader.request_election()
+            assert leader.is_leader
+
+            async def _drive():
+                start = time.monotonic()
+                await asyncio.wait_for(
+                    leader.heartbeat_loop(interval=0.005, rounds=2), timeout=3.0
+                )
+                return time.monotonic() - start
+
+            elapsed = asyncio.run(_drive())
+            assert elapsed < 2.0, (
+                "heartbeat_loop must be async/non-blocking; took " + str(elapsed)
+            )
+        finally:
+            for n in nodes:
+                n.stop()
+    '''
+).strip()
+
+
+PAXOS_ELECTION_PAYLOAD = AdversarialPayload(
+    title="Architectural Anomaly: Paxos-style leader election (PaxosNode)",
+    description=(
+        "Implement a Paxos-style leader election as a single module with a class "
+        "`PaxosNode` and an in-process transport `InProcTransport`. The "
+        "`PaxosNode` MUST define these DISTINCT methods (do NOT collapse them): "
+        "an async `heartbeat_loop(self, interval, rounds)` that sends heartbeats "
+        "over the INJECTED transport (no real sockets); `advance_term(self, "
+        "new_term=None)` backing a MONOTONIC term-epoch counter (a term never "
+        "decreases); `on_vote_request(self, candidate_id, term)` returning a "
+        "(granted, term) vote decision; `resolve_partition(self, observed_term)` "
+        "performing brain-split resolution (step down when a higher term is "
+        "observed); `request_election(self)` that wins only with a strict "
+        "majority; plus `term`, `is_leader`, and `stop(self)`. `InProcTransport` "
+        "provides `register`, `partition(a, b)`, `heal()`, `peers(node_id)`, and "
+        "`send(src, dst, msg)` -- an in-process message bus, NOT sockets. "
+        "Exactly one leader per term; a partition must never produce two leaders "
+        "in the same term."
+    ),
+    entry_symbol="PaxosNode",
+    impl_filename="impl.py",
+    test_filename="test_impl.py",
+    tests=_PAXOS_TESTS,
+    requirements=(
+        "- Define a top-level class `PaxosNode` and a class `InProcTransport`.",
+        "- `PaxosNode.__init__(self, node_id, transport)` registers with the",
+        "  injected transport. NO real sockets / network anywhere.",
+        "- `advance_term(self, new_term=None)`: MONOTONIC term-epoch counter --",
+        "  a lower `new_term` is ignored; the term NEVER decreases.",
+        "- `on_vote_request(self, candidate_id, term)`: returns `(granted, term)`;",
+        "  grant at most one vote per term so exactly one leader wins a term.",
+        "- `request_election(self)`: wins ONLY with a strict majority of peers.",
+        "- `resolve_partition(self, observed_term)`: brain-split resolution --",
+        "  step down (drop leadership) when a strictly higher term is observed.",
+        "- `heartbeat_loop(self, interval, rounds)`: an ASYNC (async def) loop",
+        "  that is NON-BLOCKING -- it must `await asyncio.sleep(...)`, never a",
+        "  blocking `time.sleep` loop, and must complete `rounds` promptly.",
+        "- Provide `term`, `is_leader`, and `stop(self)`.",
+        "- `InProcTransport`: `register`, `partition(a, b)`, `heal()`,",
+        "  `peers(node_id)`, `send(src, dst, msg)` -- an in-process bus.",
+    ),
+    decompose_focus=(
+        " HYPER-ATOMIC FOCUS: split by symbol -- get advance_term monotonic "
+        "FIRST, then on_vote_request (one vote per term), then resolve_partition "
+        "(brain-split step-down), then the async heartbeat_loop."
+    ),
+    system_prompt=(
+        "You are a precise senior Python engineer specializing in distributed "
+        "consensus. You reason carefully about monotonic term epochs, "
+        "quorum/majority voting, brain-split resolution, and async non-blocking "
+        "loops before emitting code. Output a single Python code block only."
+    ),
+)
+
+
 # Registry for the --payload selector. Default is the Concurrency Gauntlet for
 # this round (the merge-intervals payload was zero-shot solved last round).
 PAYLOADS: Dict[str, AdversarialPayload] = {
     "merge_intervals": MERGE_INTERVALS_PAYLOAD,
     "concurrency_lru": CONCURRENCY_LRU_PAYLOAD,
+    "paxos_election": PAXOS_ELECTION_PAYLOAD,
 }
 DEFAULT_PAYLOAD = "concurrency_lru"
 
@@ -701,13 +890,33 @@ def _signature_for(out: Dict[str, Any]) -> str:
 # ---------------------------------------------------------------------------
 
 
-def _build_goal(payload: "Optional[AdversarialPayload]" = None) -> Any:
+def _build_goal(
+    payload: "Optional[AdversarialPayload]" = None,
+    *,
+    impl_path: "Optional[str]" = None,
+) -> Any:
+    """Build a duck-typed GOAL for ``decompose_for_block``.
+
+    ``impl_path`` -- LOAD-BEARING for a REAL semantic decompose. When set, it
+    is the on-disk path of the model's last (failing) implementation, so
+    ``decompose_for_block`` -> ``isolate_symbols`` can actually parse the
+    generated code and scope its DISTINCT symbols (the semantic seams). When
+    ``None`` (the legacy path) we fall back to the bare ``impl_filename``,
+    which does NOT exist on disk -> ``isolate_symbols`` degrades to a
+    whole-file fallback (no real symbol scoping). The harness always passes the
+    written impl path so symbol-scoping is real.
+
+    The description carries the payload description (which NAMES the symbols)
+    plus the decompose focus, because ``isolate_symbols`` only scopes symbols
+    whose names appear in the goal description.
+    """
     payload = payload or ADVERSARIAL_PAYLOAD
+    target = (impl_path,) if impl_path else (payload.impl_filename,)
     return types.SimpleNamespace(
         goal_id="adv-soak-" + payload.entry_symbol.lower().replace("_", "-"),
         title=payload.title,
         description=(payload.description + (payload.decompose_focus or "")),
-        target_files=(payload.impl_filename,),
+        target_files=target,
     )
 
 
@@ -779,12 +988,40 @@ async def run_cognitive_soak(
     attempts = 0
     out: Dict[str, Any] = {}
 
+    # Flip-gate bookkeeping (the Architectural Anomaly's actual gate): did the
+    # FSM/loop handle the yield -> decompose -> retry GRACEFULLY?
+    decomposed_sub_goal_count = 0
+    decomposed_scoped_symbols: List[List[str]] = []
+    retried_against_chunk = False
+    lockup = False  # set if the loop ever exceeds its own bounded budget
+
     prev_impl = ""
     epistemic_feedback = ""
     repeated_signature_count = 0
     last_signature: Optional[str] = None
     current_payload_prompt_goal = payload  # may swap to decomposed sub-chunk text
     decomposed_description = ""
+
+    # Persist the model's last (failing) impl to a STABLE on-disk path so the
+    # semantic decompose can parse it and scope its DISTINCT symbols. The
+    # pytest VALIDATE boundary uses a throwaway tempdir per attempt; that dir is
+    # gone by pivot time, so we mirror the impl into this session-scoped dir
+    # (cleaned up in the finally). This is what makes ``decompose_for_block``'s
+    # ``target_files`` point at REAL code with REAL symbols (the semantic seams)
+    # instead of a non-existent bare filename (whole-file fallback).
+    _impl_mirror_dir = tempfile.mkdtemp(prefix="adv_soak_decompose_")
+    _last_written_impl_path: Optional[str] = None
+
+    def _mirror_impl(src: str) -> Optional[str]:
+        if not src:
+            return None
+        try:
+            path = os.path.join(_impl_mirror_dir, payload.impl_filename)
+            with open(path, "w", encoding="ascii", errors="replace") as fh:
+                fh.write(src)
+            return path
+        except Exception:  # noqa: BLE001 -- fail-soft, never block the soak
+            return None
 
     async def _generate(temperature: float, feedback: str) -> str:
         prompt = current_payload_prompt_goal.build_prompt(feedback) \
@@ -833,7 +1070,15 @@ async def run_cognitive_soak(
             temperature_trajectory.append(temperature)
             attempts += 1
 
-            phase = "REPAIR" if is_repair else "GENERATE"
+            # A generate that happens AFTER the pivot, against the decomposed
+            # sub-chunk, is the post-pivot RETRY-AGAINST-CHUNK -- part of the
+            # graceful-handling flip-gate.
+            _is_post_pivot_retry = bool(pivoted and decomposed and decomposed_description)
+            if _is_post_pivot_retry:
+                retried_against_chunk = True
+                phase = "RETRY-CHUNK"
+            else:
+                phase = "REPAIR" if is_repair else "GENERATE"
             _say(f"[attempt {attempts}] phase={phase}  temperature={temperature:.4f}  "
                  f"repeated_sig_count={repeated_signature_count}  "
                  f"diff_injected={bool(epistemic_feedback)}")
@@ -863,6 +1108,11 @@ async def run_cognitive_soak(
                 break
 
             # --- FAIL path ------------------------------------------------------
+            # Mirror the failing impl to a stable path so a later pivot's
+            # decompose can scope its REAL symbols (the semantic seams).
+            _written = _mirror_impl(impl_src)
+            if _written:
+                _last_written_impl_path = _written
             sig = _signature_for(out)
             signatures.append(sig)
             iterations[-1]["signature"] = sig[:12]
@@ -920,23 +1170,64 @@ async def run_cognitive_soak(
                     "signature_hash": sig,
                     "stderr_tail": (out.get("stdout") or "")[-1200:],
                 }
+                # SEMANTIC decompose: aim at the model's REAL last impl on disk
+                # so isolate_symbols scopes its DISTINCT symbols (the seams). The
+                # failure_hint reorders so the failure-implicated symbol scopes
+                # FIRST. A compression_target derived from the description floor
+                # plus a small per-symbol budget partitions the distinct symbols
+                # into separate sub-goals so the semantic separation is VISIBLE
+                # (e.g. heartbeat_loop split off from the term counter) -- this
+                # reuses the real T3 compression-target slicer, no fork.
+                _goal = _build_goal(payload, impl_path=_last_written_impl_path)
+                _ct = len(getattr(_goal, "description", "") or "") + 150
                 try:
                     sub_goals = decompose_for_block(
-                        _build_goal(payload),
+                        _goal,
                         zero_coverage=False,
                         failure_hint=failure_hint,
+                        compression_target=_ct,
                     )
                     decomposed = bool(sub_goals)
+                    decomposed_sub_goal_count = len(sub_goals)
                     if sub_goals:
-                        # Re-aim at the SMALLEST/most-atomic mutation sub-chunk.
-                        chunk = sub_goals[-1]
+                        # Make the SEMANTIC seam VISIBLE: log each emitted
+                        # sub-goal's scoped symbols + target so the operator can
+                        # SEE e.g. the heartbeat_loop symbol separated from the
+                        # term-counter (advance_term) symbol.
+                        _say(f"  -> decompose emitted {len(sub_goals)} sub-goal(s) "
+                             f"(target_files -> written impl: "
+                             f"{_last_written_impl_path or '<none>'})")
+                        for _i, _sg in enumerate(sub_goals, start=1):
+                            _syms = [
+                                str(s).rsplit("::", 1)[-1]
+                                for s in (getattr(_sg, "scoped_symbols", ()) or ())
+                            ]
+                            decomposed_scoped_symbols.append(_syms)
+                            _say(
+                                f"     [decompose] sub-goal {_i}/{len(sub_goals)} "
+                                f"id={getattr(_sg, 'sub_goal_id', '?')} "
+                                f"scoped_symbols={_syms or ['<whole-file>']} "
+                                f"target={list(getattr(_sg, 'target_files', ()) or ())}"
+                            )
+                        # The FIRST sub-goal is the failure-implicated chunk
+                        # (failure_hint biased it to scope FIRST). Re-aim the
+                        # post-pivot RETRY at it -- the smallest, most-atomic
+                        # mutation at the failure locus.
+                        chunk = sub_goals[0]
+                        _chunk_syms = [
+                            str(s).rsplit("::", 1)[-1]
+                            for s in (getattr(chunk, "scoped_symbols", ()) or ())
+                        ]
                         decomposed_description = (
                             f"{getattr(chunk, 'title', '')}: "
-                            f"{getattr(chunk, 'description', '')}"
+                            f"{getattr(chunk, 'description', '')} "
+                            f"[scoped to symbol(s): {', '.join(_chunk_syms) or 'whole-file'}]"
                         )[:1500]
-                        _say(f"  -> decompose emitted {len(sub_goals)} sub-goal(s); "
-                             f"re-aiming at hyper-atomic chunk: "
-                             f"{getattr(chunk, 'sub_goal_id', '?')}")
+                        _say(
+                            f"  -> RETRY against FIRST (failure-implicated) chunk "
+                            f"id={getattr(chunk, 'sub_goal_id', '?')} "
+                            f"scoped_symbols={_chunk_syms or ['<whole-file>']}"
+                        )
                 except Exception as e:  # noqa: BLE001
                     _say(f"  -> decompose_for_block error (fail-soft): {e}")
                     decomposed = False
@@ -954,13 +1245,37 @@ async def run_cognitive_soak(
             if attempts >= total_budget:
                 break
 
+        # If the loop exited without exceeding its bounded budget, there was no
+        # lockup. (A genuine lockup would have hung above; this flag exists so
+        # the verdict can assert "no lockup" explicitly + survives refactors.)
+        lockup = attempts > total_budget
     finally:
         # Restore the env var to its original state so the soak does not leak
         # env mutations across subsequent calls in the same process (e.g. tests).
         if _floor_was_absent:
             os.environ.pop(_floor_env_key, None)
+        # Clean up the impl mirror dir (best-effort, never raises).
+        try:
+            import shutil as _shutil
+            _shutil.rmtree(_impl_mirror_dir, ignore_errors=True)
+        except Exception:  # noqa: BLE001
+            pass
 
     final_out = out
+
+    # The Architectural Anomaly flip-gate: the FSM/loop handled the
+    # yield -> decompose -> retry GRACEFULLY (no lockup, clean termination).
+    # This is REPORTED SEPARATELY from `converged` -- Paxos passing is a BONUS,
+    # NOT the gate. The gate is satisfied even when the final Paxos attempt
+    # still fails, as long as the loop pivoted, decomposed, retried against the
+    # decomposed chunk, did not lock up, and terminated within its bound.
+    pivot_and_decompose_handled_gracefully = bool(
+        pivoted
+        and decomposed
+        and retried_against_chunk
+        and not lockup
+        and attempts <= total_budget
+    )
 
     result = {
         "converged": converged,
@@ -969,6 +1284,11 @@ async def run_cognitive_soak(
         "pivoted": pivoted,
         "pivot_reason": pivot_reason,
         "decomposed": decomposed,
+        "decomposed_sub_goal_count": decomposed_sub_goal_count,
+        "decomposed_scoped_symbols": decomposed_scoped_symbols,
+        "retried_against_chunk": retried_against_chunk,
+        "lockup": lockup,
+        "pivot_and_decompose_handled_gracefully": pivot_and_decompose_handled_gracefully,
         "epistemic_diffs_injected": epistemic_diffs_injected,
         "final_test_output": {
             "passed": bool(final_out.get("passed")) if isinstance(final_out, dict) else False,
@@ -999,19 +1319,51 @@ def print_report(result: Dict[str, Any]) -> None:
     _say("")
     _say(f"  temperature trajectory : [{traj}]")
     _say(f"  epistemic diffs injected: {result.get('epistemic_diffs_injected')}")
-    _say(f"  pivoted                 : {result.get('pivoted')}")
-    _say(f"  decomposed              : {result.get('decomposed')}")
+    _say(f"  pivoted                 : {result.get('pivoted')} "
+         f"(reason={result.get('pivot_reason') or 'n/a'})")
+    _say(f"  decomposed              : {result.get('decomposed')} "
+         f"(sub-goals={result.get('decomposed_sub_goal_count')})")
+    # Surface the SEMANTIC seams: the distinct symbols each sub-goal was scoped
+    # to (so the operator SEES e.g. heartbeat_loop split from advance_term).
+    _scoped = result.get("decomposed_scoped_symbols") or []
+    if _scoped:
+        _say("  semantic seams (scoped symbols per sub-goal):")
+        for _i, _syms in enumerate(_scoped, start=1):
+            _say(f"     sub-goal {_i}: {_syms or ['<whole-file>']}")
+        _distinct = sorted({s for syms in _scoped for s in syms})
+        _say(f"     -> {len(_distinct)} distinct symbol(s) separated: {_distinct}")
+    _say(f"  retried against chunk   : {result.get('retried_against_chunk')}")
+    _say(f"  lockup                  : {result.get('lockup')}")
     _say(f"  attempts                : {result.get('attempts')}")
-    _say(f"  converged               : {result.get('converged')}")
+    _say(f"  converged (Paxos pass)  : {result.get('converged')}  [BONUS, not the gate]")
+    graceful = result.get("pivot_and_decompose_handled_gracefully")
+    _say(f"  FLIP-GATE (graceful)    : {graceful}  "
+         f"[pivot AND decompose AND retry AND no-lockup AND clean-term]")
     _say("-" * 72)
-    if result.get("converged"):
-        _say("VERDICT: CONVERGED. A test-verified candidate was produced UNDER FIRE.")
-        _say("FLIP-GATE: SATISFIED -- the cognitive pipeline survives adversarial")
-        _say("           load (think -> fail -> adapt -> [pivot/decompose] -> pass).")
+    # The flip-gate is the GRACEFUL handling of yield -> decompose -> retry,
+    # NOT whether Paxos ultimately converges.
+    if graceful:
+        _say("VERDICT: FLIP-GATE SATISFIED. The FSM gracefully handled")
+        _say("         yield -> decompose -> retry: it hit the repair-budget wall,")
+        _say("         fired [SOVEREIGN YIELD: UNRESOLVABLE PATH] (budget_exhausted),")
+        _say("         SEMANTICALLY decomposed the impl by symbol, and retried")
+        _say("         against the failure-implicated chunk -- bounded, no lockup,")
+        _say("         clean termination. No dropped state.")
+        if result.get("converged"):
+            _say("         BONUS: the post-decompose retry also CONVERGED (Paxos green).")
+        else:
+            _say("         (Final Paxos pass is SECONDARY and was not required.)")
+    elif result.get("converged"):
+        _say("VERDICT: CONVERGED without needing the pivot (the payload was within")
+        _say("         single-context reach this run). The flip-gate specifically")
+        _say("         exercises the pivot path -- a graceful pivot was not triggered.")
     else:
-        _say("VERDICT: NON-CONVERGENCE (honest, bounded). No infinite loop; the loop")
-        _say("         yielded after exhausting its repair + pivot budget.")
-        _say("FLIP-GATE: NOT satisfied -- do NOT flip the failover live yet.")
+        _say("VERDICT: FLIP-GATE NOT satisfied -- the loop did not complete the")
+        _say("         pivot -> decompose -> retry arc gracefully. Inspect below.")
+        _say(f"         pivoted={result.get('pivoted')} "
+             f"decomposed={result.get('decomposed')} "
+             f"retried={result.get('retried_against_chunk')} "
+             f"lockup={result.get('lockup')}")
         st = result.get("final_test_output", {})
         if st.get("stdout_tail"):
             _say("  last pytest stdout tail:")
@@ -1099,7 +1451,14 @@ async def _amain(args: argparse.Namespace) -> int:
             client=client, max_repairs=args.max_repairs, payload=payload
         )
         print_report(result)
-        return 0 if result.get("converged") else 1
+        # Exit 0 when the flip-gate is satisfied: EITHER the loop converged OR
+        # it gracefully handled the pivot -> decompose -> retry arc (the
+        # Architectural Anomaly's actual gate; Paxos passing is a bonus).
+        ok = bool(
+            result.get("converged")
+            or result.get("pivot_and_decompose_handled_gracefully")
+        )
+        return 0 if ok else 1
     finally:
         try:
             await client.aclose()

--- a/tests/governance/test_epistemic_feedback.py
+++ b/tests/governance/test_epistemic_feedback.py
@@ -437,6 +437,135 @@ class TestPivotVerdict:
 
 
 # ---------------------------------------------------------------------------
+# 7b. should_pivot — composite stuck-signature OR thrash backstop
+# ---------------------------------------------------------------------------
+
+class TestShouldPivot:
+    """should_pivot composes the legacy stuck-wall trigger with a
+    budget-exhaustion (thrash / non-convergence) backstop."""
+
+    def _reload(self, monkeypatch):
+        mod = _import_module()
+        importlib.reload(mod)
+        return _import_module()
+
+    def test_stuck_signature_reason(self, monkeypatch):
+        """(a) Legacy condition (temp_at_floor AND count>=stall_passes) ->
+        (True, 'stuck_signature')."""
+        monkeypatch.setenv("JARVIS_EPISTEMIC_PIVOT_PASSES", "2")
+        monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+        mod = self._reload(monkeypatch)
+        # mid-budget so the thrash backstop does NOT also fire
+        pivot, reason = mod.should_pivot(
+            repeated_signature_count=2,
+            temp_at_floor=True,
+            total_attempts=1,
+            max_attempts=5,
+        )
+        assert pivot is True
+        assert reason == "stuck_signature"
+
+    def test_budget_exhausted_reason_thrash(self, monkeypatch):
+        """(b) THE FIX: total_attempts>=max_attempts pivots even with
+        repeated_signature_count=0 (the thrash / never-repeating case)."""
+        monkeypatch.setenv("JARVIS_EPISTEMIC_PIVOT_PASSES", "2")
+        monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+        mod = self._reload(monkeypatch)
+        pivot, reason = mod.should_pivot(
+            repeated_signature_count=0,
+            temp_at_floor=False,
+            total_attempts=5,
+            max_attempts=5,
+        )
+        assert pivot is True
+        assert reason == "budget_exhausted"
+
+    def test_false_mid_budget_not_stuck(self, monkeypatch):
+        """(c) mid-budget, not stuck -> (False, '')."""
+        monkeypatch.setenv("JARVIS_EPISTEMIC_PIVOT_PASSES", "2")
+        monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+        mod = self._reload(monkeypatch)
+        pivot, reason = mod.should_pivot(
+            repeated_signature_count=0,
+            temp_at_floor=False,
+            total_attempts=2,
+            max_attempts=5,
+        )
+        assert pivot is False
+        assert reason == ""
+
+    def test_flag_off_only_legacy_trigger(self, monkeypatch):
+        """(d) JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED=false -> ONLY the legacy
+        trigger applies; budget-exhaustion does NOT pivot (OFF byte-identical
+        to today's pivot_verdict behavior)."""
+        monkeypatch.setenv("JARVIS_EPISTEMIC_PIVOT_PASSES", "2")
+        monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "false")
+        mod = self._reload(monkeypatch)
+        # Thrash case that WOULD pivot when on:
+        pivot, reason = mod.should_pivot(
+            repeated_signature_count=0,
+            temp_at_floor=False,
+            total_attempts=5,
+            max_attempts=5,
+        )
+        assert pivot is False
+        assert reason == ""
+        # ...but the legacy stuck-wall trigger STILL fires with the flag off:
+        pivot2, reason2 = mod.should_pivot(
+            repeated_signature_count=2,
+            temp_at_floor=True,
+            total_attempts=1,
+            max_attempts=5,
+        )
+        assert pivot2 is True
+        assert reason2 == "stuck_signature"
+
+    def test_flag_off_equals_pivot_verdict(self, monkeypatch):
+        """OFF byte-identical: with the flag off, should_pivot's verdict
+        matches pivot_verdict exactly across the grid (ignoring budget)."""
+        monkeypatch.setenv("JARVIS_EPISTEMIC_PIVOT_PASSES", "2")
+        monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "false")
+        mod = self._reload(monkeypatch)
+        for count in (0, 1, 2, 5):
+            for floor in (True, False):
+                legacy = mod.pivot_verdict(count, floor)
+                pivot, _ = mod.should_pivot(
+                    repeated_signature_count=count,
+                    temp_at_floor=floor,
+                    total_attempts=99,  # would trip budget if on
+                    max_attempts=5,
+                )
+                assert pivot is legacy
+
+    def test_fail_soft_on_bad_input(self, monkeypatch):
+        """(e) fail-soft -> (False, '') on non-numeric input."""
+        monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+        mod = self._reload(monkeypatch)
+        pivot, reason = mod.should_pivot(
+            repeated_signature_count="bad",
+            temp_at_floor=False,
+            total_attempts="bad",
+            max_attempts=5,
+        )
+        assert pivot is False
+        assert reason == ""
+
+    def test_stuck_signature_takes_precedence(self, monkeypatch):
+        """When BOTH triggers would fire, stuck_signature wins (legacy first)."""
+        monkeypatch.setenv("JARVIS_EPISTEMIC_PIVOT_PASSES", "2")
+        monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+        mod = self._reload(monkeypatch)
+        pivot, reason = mod.should_pivot(
+            repeated_signature_count=3,
+            temp_at_floor=True,
+            total_attempts=5,
+            max_attempts=5,
+        )
+        assert pivot is True
+        assert reason == "stuck_signature"
+
+
+# ---------------------------------------------------------------------------
 # 8. epistemic_feedback_enabled
 # ---------------------------------------------------------------------------
 

--- a/tests/governance/test_failover_warmup_integration.py
+++ b/tests/governance/test_failover_warmup_integration.py
@@ -1,0 +1,351 @@
+# tests/governance/test_failover_warmup_integration.py
+"""TDD tests for the VRAM pre-warm integration into the Failover FSM.
+
+These tests extend the existing failover_lifecycle test suite and cover the
+new warmup_fn injectable boundary added to _tick_awakening:
+
+  (a) AWAKENING awaits warmup_fn before transitioning to SERVING
+      -- assert SERVING is NOT entered until warmup_fn resolves
+  (b) warmup_fn returning False (timeout) -> still reaches SERVING + logs
+      (no deadlock in AWAKENING)
+  (c) JARVIS_FAILOVER_WARMUP_ENABLED=false -> straight to SERVING (no warmup call)
+  (d) warmup is awaited in the correct order: warmup completes before
+      is_jprime_serving() is True
+
+All boundaries injected -- ZERO real GCE / network / Ollama.
+
+NOTE: FailoverState / FailoverLifecycleController are always accessed via the
+``fl`` module reference (fl.FailoverState.X, fl.FailoverLifecycleController)
+rather than module-level imports. test_failover_lifecycle.py contains
+``importlib.reload(fl)`` which rebuilds the enum class -- a module-level
+import taken before that reload holds the OLD class identity, causing identity
+comparisons to fail even when the value names match. Accessing through ``fl``
+ensures every assertion uses the live class object.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import provider_quarantine as pq
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes / helpers (mirrors test_failover_lifecycle.py style)
+# ---------------------------------------------------------------------------
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture(autouse=True)
+def _fresh_singletons(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    monkeypatch.setenv("JARVIS_JPRIME_COLDSTART_S", "100")
+    monkeypatch.setenv("JARVIS_CRYO_AWAKEN_MARGIN", "1.5")
+    monkeypatch.setenv("JARVIS_OUTAGE_CONFIRM_S", "120")
+    monkeypatch.setenv("JARVIS_RECOVERY_THRESHOLD", "0.6")
+    monkeypatch.setenv("JARVIS_RECOVERY_HYSTERESIS_CYCLES", "2")
+    monkeypatch.setenv("JARVIS_JPRIME_MIN_UPTIME_S", "300")
+    monkeypatch.setenv("JARVIS_HANDBACK_COOLDOWN_S", "300")
+    # Warmup enabled by default for integration tests.
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_TIMEOUT_S", "180")
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+def _fill_outage(route: str = "dw", n: int = 5) -> None:
+    grad = pq.get_provider_health_gradient()
+    for _ in range(n):
+        grad.record_sweep(route, success=False)
+
+
+def _fake_forecast(confidence: str, p50: float = 300.0, p90: float = 600.0):
+    class _F:
+        def __init__(self):
+            self.confidence = confidence
+            self.p50_s = p50
+            self.p90_s = p90
+            self.velocity_hint = 1.0
+            self.samples = 5 if confidence == "HIGH" else 0
+    return _F()
+
+
+def _make_ctrl(clock, warmup_fn=None, **kw):
+    """Construct a controller via the live fl module class (reload-safe)."""
+    defaults = dict(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+    )
+    defaults.update(kw)
+    if warmup_fn is not None:
+        defaults["warmup_fn"] = warmup_fn
+    return fl.FailoverLifecycleController(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# (a) AWAKENING awaits warmup_fn BEFORE entering SERVING
+# ---------------------------------------------------------------------------
+
+async def test_awakening_awaits_warmup_before_serving():
+    """warmup_fn must complete before the FSM enters SERVING.
+
+    Sequence: node_ready fires -> warmup_fn blocks -> SERVING must NOT be
+    entered yet -> warmup_fn resolves -> next tick -> SERVING.
+    """
+    clock = FakeClock()
+    warmup_gate = asyncio.Event()
+    warmup_started = asyncio.Event()
+    warmup_calls: list = []
+
+    async def gated_warmup_fn():
+        warmup_calls.append("started")
+        warmup_started.set()
+        await warmup_gate.wait()   # hold until the test releases
+        warmup_calls.append("done")
+        return True
+
+    ctrl = _make_ctrl(clock, warmup_fn=gated_warmup_fn)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+
+    _fill_outage()
+    await ctrl.tick()  # DORMANT -> AWAKENING
+    assert ctrl.state == fl.FailoverState.AWAKENING
+
+    # Start the next tick (AWAKENING -> would go to SERVING) concurrently.
+    tick_task = asyncio.create_task(ctrl.tick())
+
+    # Wait until warmup_fn starts executing.
+    await asyncio.wait_for(warmup_started.wait(), timeout=2.0)
+
+    # SERVING must NOT be entered while warmup is blocked.
+    assert ctrl.state == fl.FailoverState.AWAKENING
+    assert ctrl.is_jprime_serving() is False
+
+    # Release the warmup gate.
+    warmup_gate.set()
+    await tick_task  # let the tick complete
+
+    # Now SERVING should be active.
+    assert ctrl.state == fl.FailoverState.SERVING
+    assert ctrl.is_jprime_serving() is True
+    assert "done" in warmup_calls
+
+
+# ---------------------------------------------------------------------------
+# (b) warmup_fn returning False -> still reaches SERVING (no deadlock)
+# ---------------------------------------------------------------------------
+
+async def test_warmup_failure_still_transitions_to_serving(caplog):
+    """If warmup_fn returns False (timeout/error), FSM still reaches SERVING.
+
+    The warmup goal is to force cold-load; failure means first op may be cold,
+    but the FSM must never deadlock in AWAKENING on a warmup failure.
+    """
+    clock = FakeClock()
+
+    async def failing_warmup_fn():
+        return False  # simulate timeout / error
+
+    ctrl = _make_ctrl(clock, warmup_fn=failing_warmup_fn)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+
+    await ctrl.tick()  # DORMANT -> AWAKENING
+    assert ctrl.state == fl.FailoverState.AWAKENING
+
+    with caplog.at_level(logging.WARNING, logger="backend.core.ouroboros.governance.failover_lifecycle"):
+        await ctrl.tick()  # AWAKENING -> SERVING despite warmup returning False
+
+    assert ctrl.state == fl.FailoverState.SERVING
+    assert ctrl.is_jprime_serving() is True
+
+
+async def test_warmup_failure_logs_warning(caplog):
+    """warmup_fn returning False must emit a warning log (not silently skip)."""
+    clock = FakeClock()
+
+    async def failing_warmup_fn():
+        return False
+
+    ctrl = _make_ctrl(clock, warmup_fn=failing_warmup_fn)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+
+    await ctrl.tick()  # -> AWAKENING
+    with caplog.at_level(logging.WARNING, logger="backend.core.ouroboros.governance.failover_lifecycle"):
+        await ctrl.tick()  # -> SERVING despite warmup failure
+
+    # Log must mention warmup and the "first op may be cold" fallback.
+    combined = " ".join(caplog.messages).lower()
+    assert "warmup" in combined
+    assert "cold" in combined or "serving" in combined
+
+
+# ---------------------------------------------------------------------------
+# (c) JARVIS_FAILOVER_WARMUP_ENABLED=false -> straight to SERVING (no warmup)
+# ---------------------------------------------------------------------------
+
+async def test_warmup_disabled_goes_straight_to_serving(monkeypatch):
+    """When warmup is OFF, _tick_awakening transitions to SERVING without calling
+    warmup_fn -- byte-identical to pre-warmup behavior."""
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_ENABLED", "false")
+    clock = FakeClock()
+    warmup_calls: list = []
+
+    async def should_not_be_called():
+        warmup_calls.append("called")
+        return True
+
+    ctrl = _make_ctrl(clock, warmup_fn=should_not_be_called)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+
+    await ctrl.tick()  # -> AWAKENING
+    await ctrl.tick()  # -> SERVING (warmup skipped)
+
+    assert ctrl.state == fl.FailoverState.SERVING
+    assert warmup_calls == []  # warmup_fn never invoked
+
+
+# ---------------------------------------------------------------------------
+# (d) Ordering: warmup completes BEFORE is_jprime_serving() returns True
+# ---------------------------------------------------------------------------
+
+async def test_warmup_completes_before_jprime_serving():
+    """The warmup must finish (return value recorded) before is_jprime_serving()
+    becomes True. This proves the cold-load happens before routing begins."""
+    clock = FakeClock()
+    timeline: list = []
+
+    async def timed_warmup():
+        timeline.append("warmup_start")
+        await asyncio.sleep(0)   # yield once; still completes before SERVING
+        timeline.append("warmup_end")
+        return True
+
+    ctrl = _make_ctrl(clock, warmup_fn=timed_warmup)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+
+    await ctrl.tick()  # -> AWAKENING
+    await ctrl.tick()  # -> SERVING (warmup runs within this tick)
+
+    # Warmup must appear before SERVING in the causal timeline.
+    assert "warmup_end" in timeline
+    # SERVING is entered only after the tick that ran warmup completes.
+    assert ctrl.is_jprime_serving() is True
+    # The key invariant: warmup_start happened before warmup_end.
+    assert timeline.index("warmup_start") < timeline.index("warmup_end")
+
+
+# ---------------------------------------------------------------------------
+# (e) Default warmup_fn uses LocalPrimeClient pointed at jprime_endpoint()
+# ---------------------------------------------------------------------------
+
+async def test_default_warmup_fn_is_injectable():
+    """FailoverLifecycleController accepts warmup_fn as a constructor kwarg."""
+    clock = FakeClock()
+    called: list = []
+
+    async def my_warmup_fn():
+        called.append(True)
+        return True
+
+    ctrl = fl.FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+        warmup_fn=my_warmup_fn,
+    )
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+
+    await ctrl.tick()  # AWAKENING
+    await ctrl.tick()  # SERVING
+
+    assert ctrl.state == fl.FailoverState.SERVING
+    assert called == [True]
+
+
+# ---------------------------------------------------------------------------
+# (f) Warmup timeout env knob is respected
+# ---------------------------------------------------------------------------
+
+async def test_warmup_timeout_env_knob_read(monkeypatch):
+    """JARVIS_FAILOVER_WARMUP_TIMEOUT_S is read at runtime."""
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_TIMEOUT_S", "42")
+    assert fl._warmup_timeout_s() == 42.0
+
+
+async def test_warmup_timeout_default():
+    """JARVIS_FAILOVER_WARMUP_TIMEOUT_S defaults to 180."""
+    import os
+    original = os.environ.pop("JARVIS_FAILOVER_WARMUP_TIMEOUT_S", None)
+    try:
+        assert fl._warmup_timeout_s() == 180.0
+    finally:
+        if original is not None:
+            os.environ["JARVIS_FAILOVER_WARMUP_TIMEOUT_S"] = original
+
+
+# ---------------------------------------------------------------------------
+# (g) Existing AWAKENING-timeout still fires even when warmup is pending
+# ---------------------------------------------------------------------------
+
+async def test_awakening_timeout_fires_even_with_warmup_enabled(monkeypatch):
+    """The outer AWAKENING deadline (JARVIS_FAILOVER_AWAKEN_TIMEOUT_S) still
+    terminates a stuck node even when warmup is enabled. The warmup happens
+    only AFTER the node is observed ready -- a node that never answers
+    node_ready_fn never gets a warmup call."""
+    monkeypatch.setenv("JARVIS_FAILOVER_AWAKEN_TIMEOUT_S", "30")
+    clock = FakeClock()
+    delete_calls: list = []
+    warmup_calls: list = []
+
+    async def warmup_fn():
+        warmup_calls.append(True)
+        return True
+
+    ctrl = _make_ctrl(
+        clock,
+        warmup_fn=warmup_fn,
+        vm_delete_fn=lambda: delete_calls.append(1) or True,
+        # node NEVER becomes ready
+        node_ready_fn=lambda endpoint: False,
+    )
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+
+    await ctrl.tick()  # -> AWAKENING
+    assert ctrl.state == fl.FailoverState.AWAKENING
+
+    # Advance past the AWAKENING timeout.
+    clock.advance(35.0)
+    await ctrl.tick()
+
+    assert ctrl.state == fl.FailoverState.DORMANT
+    assert len(delete_calls) == 1
+    # warmup was never called because node_ready never fired.
+    assert warmup_calls == []

--- a/tests/governance/test_local_prime_warmup.py
+++ b/tests/governance/test_local_prime_warmup.py
@@ -1,0 +1,177 @@
+# tests/governance/test_local_prime_warmup.py
+"""TDD tests for LocalPrimeClient.warmup() (VRAM pre-warm -- Phase 3b+).
+
+These tests exercise the warmup() method in isolation using a fake session --
+zero real Ollama. All assertions must fail before warmup() is implemented.
+
+Covered:
+  * warmup fires a minimal 1-token POST to /v1/chat/completions
+  * warmup returns True on a successful (200) response
+  * warmup returns False (fail-soft) on a simulated timeout
+  * warmup returns False (fail-soft) on any exception from the session
+  * warmup is bounded by asyncio.wait_for(timeout_s) -- does not hang
+  * num_predict/max_tokens == 1 in the request body (minimal generation)
+  * temperature is the lowest value (0.0)
+  * fail-soft: never raises (catches all exceptions)
+"""
+from __future__ import annotations
+
+import asyncio
+import pytest
+
+from backend.core.ouroboros.governance.local_inference_director import (
+    LocalPrimeClient,
+    LocalConfig,
+)
+
+
+# ---------------------------------------------------------------------------
+# Shared fakes
+# ---------------------------------------------------------------------------
+
+def _cfg() -> LocalConfig:
+    return LocalConfig.from_env()
+
+
+class _OkSession:
+    """Session that returns a valid 1-token completion immediately."""
+
+    def __init__(self) -> None:
+        self.posts: list = []
+
+    def post(self, url: str, **kw):
+        self.posts.append({"url": url, **kw})
+
+        class _R:
+            status = 200
+
+            async def __aenter__(self_):
+                return self_
+
+            async def __aexit__(self_, *a):
+                return False
+
+            async def json(self_):
+                return {
+                    "choices": [{"message": {"content": "w"}}],
+                    "usage": {"completion_tokens": 1},
+                }
+
+        return _R()
+
+    async def close(self) -> None:
+        pass
+
+
+class _HangSession:
+    """Session whose POST never completes (simulates a wedged Ollama)."""
+
+    def post(self, url: str, **kw):
+        class _R:
+            async def __aenter__(self_):
+                await asyncio.sleep(9999)  # hang forever
+                return self_
+
+            async def __aexit__(self_, *a):
+                return False
+
+            async def json(self_):
+                return {}
+
+        return _R()
+
+    async def close(self) -> None:
+        pass
+
+
+class _ErrorSession:
+    """Session that raises on POST."""
+
+    def post(self, url: str, **kw):
+        raise ConnectionRefusedError("ollama not running")
+
+    async def close(self) -> None:
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+async def test_warmup_returns_true_on_success():
+    """warmup() returns True when the fake Ollama responds immediately."""
+    client = LocalPrimeClient(_cfg(), session=_OkSession())
+    result = await client.warmup(timeout_s=5.0)
+    assert result is True
+
+
+async def test_warmup_fires_post_to_chat_completions():
+    """warmup() sends a POST to the /v1/chat/completions endpoint."""
+    sess = _OkSession()
+    client = LocalPrimeClient(_cfg(), session=sess)
+    await client.warmup(timeout_s=5.0)
+    assert len(sess.posts) == 1
+    assert sess.posts[0]["url"].endswith("/v1/chat/completions")
+
+
+async def test_warmup_sends_minimal_token_request():
+    """warmup() requests exactly 1 output token (num_predict / max_tokens == 1)."""
+    sess = _OkSession()
+    client = LocalPrimeClient(_cfg(), session=sess)
+    await client.warmup(timeout_s=5.0)
+    body = sess.posts[0]["json"]
+    # Ollama uses num_predict; the OpenAI-compat layer also accepts max_tokens.
+    token_cap = body.get("num_predict") or body.get("max_tokens")
+    assert token_cap == 1, f"expected 1-token cap, got body={body!r}"
+
+
+async def test_warmup_sends_lowest_temperature():
+    """warmup() uses temperature 0.0 (deterministic, minimal compute)."""
+    sess = _OkSession()
+    client = LocalPrimeClient(_cfg(), session=sess)
+    await client.warmup(timeout_s=5.0)
+    body = sess.posts[0]["json"]
+    assert body.get("temperature") == 0.0
+
+
+async def test_warmup_returns_false_on_timeout():
+    """warmup() returns False (fail-soft) when the session hangs past timeout_s."""
+    client = LocalPrimeClient(_cfg(), session=_HangSession())
+    # Tiny budget so the test completes quickly.
+    result = await client.warmup(timeout_s=0.05)
+    assert result is False
+
+
+async def test_warmup_returns_false_on_exception():
+    """warmup() returns False (fail-soft) when the session raises."""
+    client = LocalPrimeClient(_cfg(), session=_ErrorSession())
+    result = await client.warmup(timeout_s=5.0)
+    assert result is False
+
+
+async def test_warmup_never_raises():
+    """warmup() swallows all exceptions and always returns bool."""
+    client = LocalPrimeClient(_cfg(), session=_ErrorSession())
+    # Must complete without raising anything.
+    result = await client.warmup(timeout_s=5.0)
+    assert isinstance(result, bool)
+
+
+async def test_warmup_uses_configured_model_name():
+    """warmup() targets the model configured in LocalConfig."""
+    sess = _OkSession()
+    client = LocalPrimeClient(_cfg(), session=sess)
+    await client.warmup(timeout_s=5.0)
+    body = sess.posts[0]["json"]
+    assert body.get("model") == _cfg().model_name
+
+
+async def test_warmup_timeout_is_respected():
+    """warmup() finishes within timeout_s+small-epsilon even on a hanging session."""
+    client = LocalPrimeClient(_cfg(), session=_HangSession())
+    start = asyncio.get_event_loop().time()
+    await client.warmup(timeout_s=0.1)
+    elapsed = asyncio.get_event_loop().time() - start
+    # Should complete well within 1 second (not hang for 9999s).
+    assert elapsed < 1.0, f"warmup took {elapsed:.2f}s, expected <1.0s"

--- a/tests/scripts/test_adversarial_cognitive_soak.py
+++ b/tests/scripts/test_adversarial_cognitive_soak.py
@@ -501,6 +501,367 @@ def test_concurrency_loop_bounded_non_convergence():
     assert result["attempts"] <= 8  # bounded, no infinite loop
 
 
+# ===========================================================================
+# Defect 1: AST-sanitize generated code so it is importable as a pure module
+# ===========================================================================
+#
+# The model appended module-level demo code (cache = TTLLRUCache(3, 2)) and
+# omitted `import threading` -> importing impl.py raised NameError -> pytest
+# COLLECTION ERROR -> all tests "collected 0, 1 error" -> repair loop sees
+# zero failing test IDs every attempt.
+#
+# Fix: _sanitize_importable(src) strips top-level executable statements (bare
+# calls, instantiations, print(...), if __name__ == "__main__" blocks) but
+# keeps Import/ImportFrom/ClassDef/FunctionDef and Assign-of-constants nodes.
+# Fail-soft: if AST parse fails, return the raw text so a real SyntaxError
+# surfaces as a genuine (and discriminating) failure signature.
+
+
+def test_sanitize_strips_module_level_demo_code():
+    """Strips bare instantiation + print + if __name__ but keeps imports+class."""
+    src = '''\
+from __future__ import annotations
+import threading
+import time
+from collections import OrderedDict
+
+
+class TTLLRUCache:
+    def __init__(self, capacity, ttl_seconds):
+        self._lock = threading.RLock()
+        self._data = OrderedDict()
+
+    def get(self, key):
+        return None
+
+    def put(self, key, value):
+        pass
+
+    def __len__(self):
+        return 0
+
+    def stop(self):
+        pass
+
+
+# module-level demo -- the bug the live gauntlet exposed
+cache = TTLLRUCache(3, 2)
+cache.put("a", 1)
+print("demo:", cache.get("a"))
+
+if __name__ == "__main__":
+    print("standalone")
+'''
+    sanitized = acs._sanitize_importable(src)
+    # Structural nodes must survive.
+    assert "import threading" in sanitized
+    assert "class TTLLRUCache" in sanitized
+    assert "def __init__" in sanitized
+    # Executable demo nodes must be gone.
+    assert "cache = TTLLRUCache" not in sanitized
+    assert 'cache.put("a"' not in sanitized
+    assert "print(" not in sanitized
+    assert '__name__ == "__main__"' not in sanitized
+    # The sanitized code must be importable as a pure module.
+    import importlib, types, sys as _sys
+    m = types.ModuleType("_test_sanitize_mod")
+    exec(compile(sanitized, "<sanitized>", "exec"), m.__dict__)  # noqa: S102
+    assert hasattr(m, "TTLLRUCache")
+
+
+def test_sanitize_keeps_constant_assign():
+    """Top-level constant assignments (str/int/tuple literals) are kept."""
+    src = '''\
+import os
+
+_VERSION = "1.0.0"
+_MAX = 100
+
+
+def helper():
+    return _VERSION
+'''
+    sanitized = acs._sanitize_importable(src)
+    assert "_VERSION" in sanitized
+    assert "_MAX" in sanitized
+    assert "def helper" in sanitized
+
+
+def test_sanitize_fail_soft_on_broken_syntax():
+    """If AST parse fails (model emitted broken code), return the raw text unchanged."""
+    src = "def broken(\n    pass  # mismatched paren\n"
+    result = acs._sanitize_importable(src)
+    # Must not raise; must return the original text so the real SyntaxError
+    # surfaces as a genuine (discriminating) failure signature.
+    assert result == src
+
+
+def test_extract_then_sanitize_makes_code_importable():
+    """Full pipeline: extract code block then sanitize -> importable module."""
+    # This is the exact failure shape from the live gauntlet: the model's
+    # response includes a code fence with demo code at the bottom AND omits
+    # import threading, but the sanitizer strips the demo so the NameError
+    # from missing threading appears at class-body-access-time (real failure),
+    # NOT at module-level instantiation (accidental collection error).
+    response_with_demo = '''\
+Here is the implementation:
+
+```python
+import time
+from collections import OrderedDict
+
+
+class TTLLRUCache:
+    """Thread-safe TTL LRU cache."""
+
+    def __init__(self, capacity, ttl_seconds):
+        self.capacity = capacity
+        self._data = OrderedDict()
+
+    def get(self, key):
+        return self._data.get(key)
+
+    def put(self, key, value):
+        self._data[key] = value
+
+    def __len__(self):
+        return len(self._data)
+
+    def stop(self):
+        pass
+
+
+# demo usage appended by the model
+cache = TTLLRUCache(3, 2)
+cache.put("x", 10)
+print(cache.get("x"))
+```
+
+Hope that helps!
+'''
+    raw = acs._extract_code_block(response_with_demo)
+    sanitized = acs._sanitize_importable(raw)
+    # The demo lines are gone.
+    assert "cache = TTLLRUCache" not in sanitized
+    assert "print(" not in sanitized
+    # The class is still there and importable.
+    import types
+    m = types.ModuleType("_test_extract_sanitize")
+    exec(compile(sanitized, "<extracted>", "exec"), m.__dict__)  # noqa: S102
+    assert hasattr(m, "TTLLRUCache")
+
+
+# ===========================================================================
+# Defect 2: Robust failure signature for collection/import errors
+# ===========================================================================
+#
+# When pytest cannot collect tests (NameError / ImportError at module level),
+# there are zero FAILED test IDs. The old _signature_for returned
+# failure_signature_hash([], "test") = a constant for ALL collection errors,
+# so repeated_signature_count incremented (good) BUT a NameError vs an
+# ImportError vs an AssertionError all got the SAME signature (bad -- genuine
+# progress from one error class to a different one looked like a repeat).
+#
+# Fix: _signature_for must:
+#   (a) STABLE: same collection error -> same hash across attempts (so repeat
+#       tracking drives temp decay + pivot),
+#   (b) DISCRIMINATING: NameError vs AssertionError vs SyntaxError -> DIFFERENT
+#       hashes (so genuine progress resets the decay),
+#   (c) PATH-INVARIANT: the tempdir path (/tmp/adv_soak_xyz/) is stripped
+#       from any text used to build the signature.
+
+
+def _make_collection_error_out(error_line: str, tempdir: str = "/tmp/adv_soak_abc123") -> dict:
+    """Synthesize a pytest output dict for a collection error."""
+    stdout = (
+        f"==================================== ERRORS ====================================\n"
+        f"________________________ ERROR collecting test_impl.py _________________________\n"
+        f"{tempdir}/test_impl.py:1: in <module>\n"
+        f"    from impl import TTLLRUCache\n"
+        f"{tempdir}/impl.py:8: in __init__\n"
+        f"    self._lock = threading.RLock()\n"
+        f"E   {error_line}\n"
+        f"=========================== short test summary info ============================\n"
+        f"ERROR {tempdir}/test_impl.py - {error_line}\n"
+        f"!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!\n"
+        f"1 error in 0.10s\n"
+    )
+    return {"passed": False, "stdout": stdout, "stderr": "", "returncode": 2}
+
+
+def test_signature_stable_for_same_collection_error_across_attempts():
+    """Same collection error -> same signature regardless of which attempt / tempdir."""
+    out1 = _make_collection_error_out(
+        "NameError: name 'threading' is not defined",
+        tempdir="/tmp/adv_soak_attempt1_xyzabc",
+    )
+    out2 = _make_collection_error_out(
+        "NameError: name 'threading' is not defined",
+        tempdir="/tmp/adv_soak_attempt2_defghi",
+    )
+    sig1 = acs._signature_for(out1)
+    sig2 = acs._signature_for(out2)
+    assert sig1 == sig2, (
+        "Same collection error must produce the same signature across attempts "
+        f"(got {sig1!r} vs {sig2!r})"
+    )
+
+
+def test_signature_discriminates_nameerror_from_assertionerror():
+    """A NameError collection error and an AssertionError test failure -> different sigs."""
+    # Collection error (NameError): no test IDs in output
+    col_out = _make_collection_error_out("NameError: name 'threading' is not defined")
+    col_sig = acs._signature_for(col_out)
+
+    # Assertion failure: FAILED test IDs present
+    assert_out = {
+        "passed": False,
+        "stdout": (
+            "FAILED test_impl.py::test_thread_safety_no_corruption - AssertionError\n"
+            "1 failed in 1.23s\n"
+        ),
+        "stderr": "",
+        "returncode": 1,
+    }
+    assert_sig = acs._signature_for(assert_out)
+
+    assert col_sig != assert_sig, (
+        "NameError collection error and AssertionError test failure must have "
+        f"different signatures (both got {col_sig!r})"
+    )
+
+
+def test_signature_discriminates_different_collection_errors():
+    """NameError vs ImportError collection errors -> different signatures."""
+    name_err_out = _make_collection_error_out("NameError: name 'threading' is not defined")
+    import_err_out = _make_collection_error_out("ImportError: cannot import name 'TTLLRUCache'")
+    sig1 = acs._signature_for(name_err_out)
+    sig2 = acs._signature_for(import_err_out)
+    assert sig1 != sig2, (
+        f"Different collection errors must have different sigs: {sig1!r} vs {sig2!r}"
+    )
+
+
+def test_signature_invariant_to_tempdir_path():
+    """The tempdir path component (/tmp/adv_soak_<random>/) must not affect the sig."""
+    out_a = _make_collection_error_out(
+        "NameError: name 'threading' is not defined",
+        tempdir="/tmp/adv_soak_0000001",
+    )
+    out_b = _make_collection_error_out(
+        "NameError: name 'threading' is not defined",
+        tempdir="/tmp/adv_soak_9999999",
+    )
+    assert acs._signature_for(out_a) == acs._signature_for(out_b)
+
+
+def test_syntax_error_output_is_discriminated():
+    """A SyntaxError (from [SOVEREIGN SYNTAX FATAL]) differs from a NameError sig."""
+    syntax_out = {
+        "passed": False,
+        "stdout": "",
+        "stderr": "[SOVEREIGN SYNTAX FATAL] line=5 msg=invalid syntax",
+        "returncode": 1,
+    }
+    name_out = _make_collection_error_out("NameError: name 'threading' is not defined")
+    assert acs._signature_for(syntax_out) != acs._signature_for(name_out)
+
+
+# ===========================================================================
+# Defect 3: Pivot reachability -- the soak must reach temp_at_floor
+# ===========================================================================
+#
+# With JARVIS_EPISTEMIC_TEMP_FLOOR=0.0 (production default), temperature_for_attempt
+# halves forever (0.7 -> 0.35 -> 0.175 -> 0.0875 ...) and NEVER stabilizes.
+# temp_at_floor is NEVER True so pivot_verdict NEVER fires, regardless of budget.
+#
+# Fix: run_cognitive_soak sets JARVIS_EPISTEMIC_TEMP_FLOOR to a non-zero
+# default (0.1) if the caller has not already set it, so the temperature
+# schedule DOES stabilize. The recommended --max-repairs is 5 (so the loop
+# survives until count=3 where pivot_verdict fires with floor=0.1).
+# The REAL pivot_verdict logic is unchanged.
+
+
+def test_pivot_fires_with_production_env_and_recommended_max_repairs(monkeypatch):
+    """The pivot CAN fire using the soak's own env defaults (no test fixture help).
+
+    This test deliberately removes the fixture's JARVIS_EPISTEMIC_TEMP_FLOOR
+    override and verifies that the soak's own default (0.1 floor) still lets
+    pivot_verdict trip within the recommended --max-repairs=5 budget.
+    """
+    # Remove the fixture's floor env var so we test the SOAK's own default.
+    monkeypatch.delenv("JARVIS_EPISTEMIC_TEMP_FLOOR", raising=False)
+    monkeypatch.delenv("JARVIS_EPISTEMIC_TEMP_DECAY", raising=False)
+    monkeypatch.delenv("JARVIS_EPISTEMIC_PIVOT_PASSES", raising=False)
+
+    called = {"n": 0}
+    real_decompose = acs.decompose_for_block
+
+    def _spy(goal, **kwargs):
+        called["n"] += 1
+        return real_decompose(goal, **kwargs)
+
+    monkeypatch.setattr(acs, "decompose_for_block", _spy)
+
+    p = acs.PAYLOADS["merge_intervals"]
+    # Script: always the SAME wrong impl (same failure signature) -> pivot must trip.
+    client = FakeLocalPrimeClient([_WRONG_SAME] * 8 + [_CORRECT])
+    result = asyncio.run(
+        acs.run_cognitive_soak(client=client, max_repairs=5, payload=p)
+    )
+    assert result["pivoted"] is True, (
+        "pivot must fire within max_repairs=5 when the soak sets its own "
+        "JARVIS_EPISTEMIC_TEMP_FLOOR default. "
+        f"temperature_trajectory={result['temperature_trajectory']}"
+    )
+    assert called["n"] >= 1
+
+
+def test_pivot_full_arc_collection_error_same_signature(monkeypatch):
+    """Full fail->repair->pivot->decompose arc triggered by a COLLECTION ERROR.
+
+    Scripts the fake client to emit impl-with-demo (causes collection error,
+    same signature every time) N times, then a correct impl.  With the soak's
+    own floor default and --max-repairs=5, the harness must:
+      * detect the repeated signature,
+      * decay temperature,
+      * fire pivot (decompose_for_block called),
+      * converge on the correct impl.
+    """
+    monkeypatch.delenv("JARVIS_EPISTEMIC_TEMP_FLOOR", raising=False)
+    monkeypatch.delenv("JARVIS_EPISTEMIC_TEMP_DECAY", raising=False)
+    monkeypatch.delenv("JARVIS_EPISTEMIC_PIVOT_PASSES", raising=False)
+
+    called = {"n": 0}
+    real_decompose = acs.decompose_for_block
+
+    def _spy(goal, **kwargs):
+        called["n"] += 1
+        return real_decompose(goal, **kwargs)
+
+    monkeypatch.setattr(acs, "decompose_for_block", _spy)
+
+    # An impl that imports threading BUT uses it at module level (so if the
+    # model forgets threading the NameError triggers on import -> collection err).
+    # We simulate this by using the wrong merge_intervals impl (same sig).
+    #
+    # With max_repairs=5: total_budget starts at 7. Pivot fires at attempt 5
+    # (count=4, temp=floor=0.1) -> budget becomes 8. Attempts 6, 7, 8 use
+    # scripted indices 5, 6, 7. So [_WRONG_SAME] * 7 + [_CORRECT] places the
+    # correct impl exactly at the 8th call (index 7 -> budget just reached).
+    p = acs.PAYLOADS["merge_intervals"]
+    client = FakeLocalPrimeClient([_WRONG_SAME] * 7 + [_CORRECT])
+    result = asyncio.run(
+        acs.run_cognitive_soak(client=client, max_repairs=5, payload=p)
+    )
+    assert result["pivoted"] is True
+    assert result["converged"] is True
+    assert called["n"] >= 1
+    # Temperature must have decayed.
+    traj = result["temperature_trajectory"]
+    assert min(traj) < max(traj)
+
+
 # ---------------------------------------------------------------------------
 # CLI: --payload selector + warmup-first
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_adversarial_cognitive_soak.py
+++ b/tests/scripts/test_adversarial_cognitive_soak.py
@@ -221,6 +221,116 @@ def test_run_cognitive_soak_refuses_when_gate_off(monkeypatch):
         asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))
 
 
+# ---------------------------------------------------------------------------
+# THRASH / non-convergence pivot (THE FIX exposed by the Concurrency Gauntlet)
+# A model that produces a DIFFERENT failure each attempt never repeats a
+# signature, so the legacy stuck-signature pivot NEVER trips. The
+# budget-exhaustion backstop in should_pivot must catch it.
+# ---------------------------------------------------------------------------
+
+# Distinct failure modes (each a DIFFERENT signature, never repeating):
+# 1. Module-level NameError on import (collection error)
+_THRASH_IMPORT_ERR = """```python
+def merge_intervals(intervals):
+    return _undefined_symbol(intervals)
+```"""
+
+# 2. SyntaxError (collection error, different text)
+_THRASH_SYNTAX_ERR = """```python
+def merge_intervals(intervals)
+    return intervals
+```"""
+
+# 3. Returns the input untouched -> different assertion failures
+_THRASH_IDENTITY = """```python
+def merge_intervals(intervals):
+    return list(intervals)
+```"""
+
+# 4. Returns empty -> yet another distinct assertion failure
+_THRASH_EMPTY = """```python
+def merge_intervals(intervals):
+    return []
+```"""
+
+# 5. Raises a different runtime error
+_THRASH_TYPEERROR = """```python
+def merge_intervals(intervals):
+    return intervals + 1
+```"""
+
+
+def test_thrash_never_repeating_signature_pivots_on_budget(monkeypatch):
+    """THE FIX: a model that emits a DIFFERENT failure each attempt
+    (never-repeating signature) must STILL pivot -> decompose, via the
+    budget-exhaustion backstop, instead of silently exhausting.
+
+    Pre-fix (legacy pivot_verdict only) this would NEVER pivot because
+    repeated_signature_count stays 0.
+    """
+    real_decompose = acs.decompose_for_block
+    seen = {}
+
+    def _spy(goal, **kwargs):
+        seen["called"] = True
+        seen["goal"] = goal
+        return real_decompose(goal, **kwargs)
+
+    monkeypatch.setattr(acs, "decompose_for_block", _spy)
+    monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+
+    # Five DISTINCT failure modes, none repeating -> repeated_signature_count
+    # stays 0 throughout. With max_repairs=3 the pivot budget is 1+3=4, so the
+    # pivot must fire once attempts reach 4. The trailing _CORRECT lets the
+    # post-pivot extra GENERATE converge against the decomposed chunk.
+    client = FakeLocalPrimeClient([
+        _THRASH_IMPORT_ERR,
+        _THRASH_SYNTAX_ERR,
+        _THRASH_IDENTITY,
+        _THRASH_EMPTY,
+        _THRASH_TYPEERROR,
+        _CORRECT,
+    ])
+    result = asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))
+
+    # The signatures must NOT all be identical (genuine thrash, not a stuck wall).
+    sigs = result["signatures"]
+    assert len(set(sigs)) > 1, f"expected DIFFERENT signatures (thrash), got {sigs!r}"
+
+    # The fix: it pivoted on budget-exhaustion, NOT on a repeated signature.
+    assert result["pivoted"] is True, "thrash must pivot on budget-exhaustion"
+    assert result["pivot_reason"] == "budget_exhausted", result["pivot_reason"]
+    assert seen.get("called") is True, "decompose_for_block must be exercised"
+    assert result["decomposed"] is True
+
+
+def test_thrash_does_not_pivot_when_flag_off(monkeypatch):
+    """OFF byte-identical: with JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED=false the
+    thrash (never-repeating signature) does NOT pivot -- legacy behavior."""
+    real_decompose = acs.decompose_for_block
+    seen = {}
+
+    def _spy(goal, **kwargs):
+        seen["called"] = True
+        return real_decompose(goal, **kwargs)
+
+    monkeypatch.setattr(acs, "decompose_for_block", _spy)
+    monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "false")
+
+    client = FakeLocalPrimeClient([
+        _THRASH_IMPORT_ERR,
+        _THRASH_SYNTAX_ERR,
+        _THRASH_IDENTITY,
+        _THRASH_EMPTY,
+        _THRASH_TYPEERROR,
+    ])
+    result = asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))
+
+    assert result["pivoted"] is False, "flag off -> no thrash pivot (legacy)"
+    assert result["pivot_reason"] == ""
+    assert seen.get("called") is not True
+
+
 # ===========================================================================
 # Payload #2: the Concurrency Gauntlet (thread-safe TTL+LRU cache)
 # ===========================================================================

--- a/tests/scripts/test_adversarial_cognitive_soak.py
+++ b/tests/scripts/test_adversarial_cognitive_soak.py
@@ -1032,3 +1032,517 @@ def test_warmup_called_once_before_loop(monkeypatch):
     assert events[0] == "warmup"
     assert "generate" in events
     assert events.index("warmup") < events.index("generate")
+
+
+# ===========================================================================
+# Payload #3: the Architectural Anomaly (Paxos-style leader election)
+# ===========================================================================
+#
+# The FINAL flip-gate. The Paxos payload is past a 7B's single-context reach,
+# so a model reliably THRASHES -> burns the repair budget -> fires
+# should_pivot(budget_exhausted) -> [SOVEREIGN YIELD: UNRESOLVABLE PATH] ->
+# decompose_for_block SEMANTICALLY chops it by SYMBOL -> retry against the
+# first (failure-implicated) chunk. The gate is the GRACEFUL handling of that
+# arc (pivot AND decompose AND retry AND no-lockup AND clean termination), NOT
+# whether Paxos ultimately passes.
+#
+# We prove three things with the REAL pytest subprocess boundary + REAL
+# primitives (should_pivot / decompose_for_block / isolate_symbols), no Ollama:
+#   (a) the embedded CORRECT reference PaxosNode PASSES the suite + a known-
+#       thrashy multi-symbol stub FAILS it (the suite discriminates + is fair);
+#   (b) a FakeLocalPrimeClient that NEVER converges (always a thrashy multi-
+#       symbol PaxosNode) -> pivot(budget_exhausted) -> decompose_for_block IS
+#       called with target_files pointing at the WRITTEN impl -> the emitted
+#       sub-goals' scoped symbols are LOGGED -> a retry against the first chunk
+#       happens -> the loop terminates cleanly with
+#       pivot_and_decompose_handled_gracefully=True and no lockup;
+#   (c) the scoped-symbol logging shows >1 distinct symbol separated (the
+#       semantic seam) when the generated impl has distinct symbols.
+
+# A CORRECT reference PaxosNode + in-process transport (no sockets). Passes the
+# fair, deterministic gauntlet suite.
+_PAXOS_CORRECT = '''```python
+from __future__ import annotations
+import threading
+
+
+class InProcTransport:
+    """In-process message bus shared by PaxosNodes. No sockets."""
+
+    def __init__(self):
+        self._nodes = {}
+        self._lock = threading.RLock()
+        self._partition = set()
+
+    def register(self, node):
+        with self._lock:
+            self._nodes[node.node_id] = node
+
+    def partition(self, a, b):
+        with self._lock:
+            self._partition.add(frozenset((a, b)))
+
+    def heal(self):
+        with self._lock:
+            self._partition.clear()
+
+    def _blocked(self, src, dst):
+        return frozenset((src, dst)) in self._partition
+
+    def send(self, src, dst, msg):
+        with self._lock:
+            if self._blocked(src, dst):
+                return None
+            node = self._nodes.get(dst)
+        if node is None:
+            return None
+        return node.deliver(src, msg)
+
+    def peers(self, node_id):
+        with self._lock:
+            return [n for n in self._nodes if n != node_id]
+
+
+class PaxosNode:
+    def __init__(self, node_id, transport):
+        self.node_id = node_id
+        self._transport = transport
+        self._lock = threading.RLock()
+        self._term = 0
+        self._leader_of_term = {}
+        self._is_leader = False
+        self._stop = threading.Event()
+        transport.register(self)
+
+    def advance_term(self, new_term=None):
+        with self._lock:
+            if new_term is None:
+                new_term = self._term + 1
+            if new_term < self._term:
+                return self._term
+            self._term = new_term
+            self._is_leader = False
+            return self._term
+
+    @property
+    def term(self):
+        with self._lock:
+            return self._term
+
+    @property
+    def is_leader(self):
+        with self._lock:
+            return self._is_leader
+
+    def on_vote_request(self, candidate_id, term):
+        with self._lock:
+            if term < self._term:
+                return (False, self._term)
+            if term > self._term:
+                self._term = term
+                self._is_leader = False
+            voted = self._leader_of_term.get(term)
+            if voted is None or voted == candidate_id:
+                self._leader_of_term[term] = candidate_id
+                return (True, self._term)
+            return (False, self._term)
+
+    def request_election(self):
+        with self._lock:
+            self.advance_term()
+            term = self._term
+            self._leader_of_term[term] = self.node_id
+            votes = 1
+        peers = self._transport.peers(self.node_id)
+        for p in peers:
+            resp = self._transport.send(self.node_id, p, ("vote", term))
+            if resp and resp[0]:
+                votes += 1
+        total = len(peers) + 1
+        with self._lock:
+            if votes * 2 > total and self._term == term:
+                self._is_leader = True
+                self._leader_of_term[term] = self.node_id
+                return True
+            return False
+
+    def resolve_partition(self, observed_term):
+        with self._lock:
+            if observed_term > self._term:
+                self._term = observed_term
+                self._is_leader = False
+                return True
+            return False
+
+    def deliver(self, src, msg):
+        kind = msg[0]
+        if kind == "vote":
+            return self.on_vote_request(src, msg[1])
+        if kind == "heartbeat":
+            self.resolve_partition(msg[1])
+            return ("ack", self.term)
+        return None
+
+    async def heartbeat_loop(self, interval=0.01, rounds=1):
+        import asyncio
+        for _ in range(rounds):
+            if self._stop.is_set():
+                break
+            with self._lock:
+                term = self._term
+                leader = self._is_leader
+            if leader:
+                for p in self._transport.peers(self.node_id):
+                    self._transport.send(self.node_id, p, ("heartbeat", term))
+            await asyncio.sleep(interval)
+
+    def stop(self):
+        self._stop.set()
+```'''
+
+# A THRASHY stub: structurally complete (all the DISTINCT symbols the goal
+# names, so isolate_symbols finds real seams) but SEMANTICALLY broken on every
+# axis the suite checks (non-monotonic term, quorum-free leader, no brain-split
+# step-down, BLOCKING non-async heartbeat). This is the shape a 7B ships when it
+# cannot hold the full state machine -- it FAILS the gauntlet.
+_PAXOS_THRASH = '''```python
+from __future__ import annotations
+
+
+class InProcTransport:
+    def __init__(self):
+        pass
+
+    def register(self, node):
+        pass
+
+    def partition(self, a, b):
+        pass
+
+    def heal(self):
+        pass
+
+    def peers(self, node_id):
+        return []
+
+    def send(self, src, dst, msg):
+        return None
+
+
+class PaxosNode:
+    def __init__(self, node_id, transport):
+        self.node_id = node_id
+        self._term = 0
+        self._is_leader = False
+
+    def advance_term(self, new_term=None):
+        # BUG: not monotonic -- accepts a lower term.
+        self._term = new_term if new_term is not None else self._term + 1
+        return self._term
+
+    @property
+    def term(self):
+        return self._term
+
+    @property
+    def is_leader(self):
+        return self._is_leader
+
+    def on_vote_request(self, candidate_id, term):
+        # BUG: always grants -> multiple leaders per term.
+        return (True, term)
+
+    def request_election(self):
+        # BUG: no quorum -- claims leadership unconditionally.
+        self._is_leader = True
+        return True
+
+    def resolve_partition(self, observed_term):
+        # BUG: never steps down.
+        return False
+
+    def heartbeat_loop(self, interval=0.01, rounds=1):
+        # BUG: NOT async + blocking.
+        import time
+        time.sleep(interval * rounds)
+
+    def stop(self):
+        pass
+```'''
+
+
+# Thrash VARIANTS that each FAIL a DIFFERENT subset of the suite, so the
+# failure SIGNATURE (the sorted set of failing test IDs) differs across
+# attempts (never repeats consecutively) -> the legacy stuck-signature pivot
+# can NOT trip; only the budget-exhaustion thrash backstop in should_pivot can.
+# Each variant keeps the DISTINCT symbols isolate_symbols needs for a real
+# semantic seam, and survives _sanitize_importable (pure definitions only).
+#
+# We perturb which axes are CORRECT so the failing-test-ID set differs:
+#   Variant B: monotonic term is CORRECT -> only the OTHER 3 tests fail.
+#   Variant C: monotonic term AND async heartbeat are CORRECT -> only 2 fail.
+# (_PAXOS_THRASH fails all 4.) Three distinct failing-ID sets -> three distinct
+# signatures, none repeating back-to-back across the rotation.
+
+# Variant B: advance_term is correctly monotonic; the rest stay broken.
+_PAXOS_THRASH_MONOTONIC_OK = '''```python
+from __future__ import annotations
+
+
+class InProcTransport:
+    def register(self, node): pass
+    def partition(self, a, b): pass
+    def heal(self): pass
+    def peers(self, node_id): return []
+    def send(self, src, dst, msg): return None
+
+
+class PaxosNode:
+    def __init__(self, node_id, transport):
+        self.node_id = node_id
+        self._term = 0
+        self._is_leader = False
+
+    def advance_term(self, new_term=None):
+        # CORRECT: monotonic.
+        if new_term is None:
+            new_term = self._term + 1
+        if new_term < self._term:
+            return self._term
+        self._term = new_term
+        return self._term
+
+    @property
+    def term(self):
+        return self._term
+
+    @property
+    def is_leader(self):
+        return self._is_leader
+
+    def on_vote_request(self, candidate_id, term):
+        return (True, term)  # BUG: always grants
+
+    def request_election(self):
+        self._is_leader = True  # BUG: no quorum
+        return True
+
+    def resolve_partition(self, observed_term):
+        return False  # BUG: never steps down
+
+    def heartbeat_loop(self, interval=0.01, rounds=1):
+        import time
+        time.sleep(interval * rounds)  # BUG: blocking, not async
+
+    def stop(self):
+        pass
+```'''
+
+# Variant C: advance_term monotonic AND heartbeat_loop async non-blocking
+# correct; only the leader/partition axes stay broken (fewer failing tests).
+_PAXOS_THRASH_MONOTONIC_HB_OK = '''```python
+from __future__ import annotations
+
+
+class InProcTransport:
+    def register(self, node): pass
+    def partition(self, a, b): pass
+    def heal(self): pass
+    def peers(self, node_id): return []
+    def send(self, src, dst, msg): return None
+
+
+class PaxosNode:
+    def __init__(self, node_id, transport):
+        self.node_id = node_id
+        self._term = 0
+        self._is_leader = False
+
+    def advance_term(self, new_term=None):
+        if new_term is None:
+            new_term = self._term + 1
+        if new_term < self._term:
+            return self._term
+        self._term = new_term
+        return self._term
+
+    @property
+    def term(self):
+        return self._term
+
+    @property
+    def is_leader(self):
+        return self._is_leader
+
+    def on_vote_request(self, candidate_id, term):
+        return (True, term)  # BUG: always grants
+
+    def request_election(self):
+        self._is_leader = True  # BUG: no quorum
+        return True
+
+    def resolve_partition(self, observed_term):
+        return False  # BUG: never steps down
+
+    async def heartbeat_loop(self, interval=0.01, rounds=1):
+        # CORRECT: async, non-blocking, bounded rounds.
+        import asyncio
+        for _ in range(rounds):
+            await asyncio.sleep(interval)
+
+    def stop(self):
+        pass
+```'''
+
+
+def test_paxos_payload_registered():
+    assert "paxos_election" in acs.PAYLOADS
+    p = acs.PAYLOADS["paxos_election"]
+    assert p.entry_symbol == "PaxosNode"
+    # The DISTINCT symbols are named in the description so isolate_symbols
+    # scopes them (the semantic seams).
+    for sym in ("heartbeat_loop", "advance_term", "resolve_partition",
+                "on_vote_request"):
+        assert sym in p.description, sym
+    assert "def test_monotonic_term_never_decreases" in p.tests
+    assert "def test_partition_no_double_leader_same_term" in p.tests
+
+
+def test_paxos_correct_reference_passes_suite():
+    # LOAD-BEARING: the suite is FAIR -- a correct impl PASSES it.
+    p = acs.PAYLOADS["paxos_election"]
+    out = acs._run_pytest_in_tempdir(
+        acs._extract_code_block(_PAXOS_CORRECT), p.tests, timeout_s=120, payload=p
+    )
+    assert out["passed"] is True, out["stdout"][-2000:] + "\n" + out["stderr"][-1000:]
+
+
+def test_paxos_thrash_stub_fails_suite():
+    # LOAD-BEARING: the suite DISCRIMINATES -- a thrashy stub FAILS it.
+    p = acs.PAYLOADS["paxos_election"]
+    out = acs._run_pytest_in_tempdir(
+        acs._extract_code_block(_PAXOS_THRASH), p.tests, timeout_s=120, payload=p
+    )
+    assert out["passed"] is False
+    blob = (out["stdout"] or "") + (out["stderr"] or "")
+    # At least the monotonic-term and one-leader checks should flag it.
+    assert "test_monotonic_term_never_decreases" in blob or \
+        "test_exactly_one_leader_per_term" in blob
+
+
+def test_paxos_thrash_stub_has_distinct_symbols_for_decompose():
+    # The thrash stub has the DISTINCT symbols isolate_symbols needs for a
+    # REAL semantic seam (this is what (c) below depends on).
+    import tempfile as _tf
+    import os as _os
+    from backend.core.ouroboros.governance.ast_symbol_scoper import isolate_symbols
+    p = acs.PAYLOADS["paxos_election"]
+    src = acs._sanitize_importable(acs._extract_code_block(_PAXOS_THRASH))
+    with _tf.TemporaryDirectory() as d:
+        path = _os.path.join(d, "impl.py")
+        with open(path, "w", encoding="ascii", errors="replace") as f:
+            f.write(src)
+        targets = isolate_symbols(path, p.description + p.decompose_focus)
+        syms = sorted({t.symbol for t in targets if t.symbol})
+    # Multiple DISTINCT scoped symbols -> a real semantic seam.
+    assert len(syms) > 1, syms
+    assert any("heartbeat_loop" in s for s in syms)
+    assert any("advance_term" in s for s in syms)
+
+
+def test_paxos_never_converges_pivots_decomposes_retries_gracefully(monkeypatch):
+    """THE FLIP-GATE: a never-converging thrashy 7B drives the full arc.
+
+    pivot(budget_exhausted) -> decompose_for_block called with target_files at
+    the WRITTEN impl -> scoped symbols logged -> retry against the first chunk
+    -> clean termination with pivot_and_decompose_handled_gracefully=True and
+    no lockup. Paxos NEVER passes here (bonus not required).
+    """
+    monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+
+    captured = {"goals": [], "n": 0}
+    real_decompose = acs.decompose_for_block
+
+    def _spy(goal, **kwargs):
+        captured["n"] += 1
+        captured["goals"].append(goal)
+        return real_decompose(goal, **kwargs)
+
+    monkeypatch.setattr(acs, "decompose_for_block", _spy)
+
+    p = acs.PAYLOADS["paxos_election"]
+    # A DIFFERENT thrashy failure each attempt (never-repeating signature) ->
+    # the legacy stuck-signature pivot can NOT trip; only the budget-exhaustion
+    # thrash backstop can. The trailing constant thrash covers any post-pivot
+    # extra GENERATE (still fails -> Paxos never converges, by design).
+    client = FakeLocalPrimeClient([
+        _PAXOS_THRASH,                  # all 4 tests fail (sig X)
+        _PAXOS_THRASH_MONOTONIC_OK,     # 3 fail (sig Y != X)
+        _PAXOS_THRASH_MONOTONIC_HB_OK,  # 2 fail (sig Z != Y)
+        _PAXOS_THRASH,                  # back to 4 (sig X != Z)
+        _PAXOS_THRASH_MONOTONIC_OK,     # 3 fail (sig Y != X)
+        _PAXOS_THRASH_MONOTONIC_HB_OK,  # post-pivot retry padding
+        _PAXOS_THRASH,
+    ])
+    result = asyncio.run(
+        acs.run_cognitive_soak(client=client, max_repairs=5, payload=p)
+    )
+
+    # The signatures must NOT all be identical (genuine thrash, not a stuck wall).
+    sigs = result["signatures"]
+    assert len(set(sigs)) > 1, f"expected DIFFERENT signatures (thrash), got {sigs!r}"
+
+    # The arc fired -- specifically on the budget-exhaustion thrash backstop.
+    assert result["pivoted"] is True
+    assert result["pivot_reason"] == "budget_exhausted", result["pivot_reason"]
+    assert result["decomposed"] is True
+    assert captured["n"] >= 1, "decompose_for_block must be exercised"
+
+    # target_files pointed at the WRITTEN impl on disk (so symbol-scoping is
+    # REAL, not a whole-file fallback on a non-existent bare filename).
+    goal = captured["goals"][0]
+    tf = list(getattr(goal, "target_files", ()) or ())
+    assert len(tf) == 1
+    assert tf[0].endswith("impl.py")
+    assert os.path.isabs(tf[0]) or "adv_soak_decompose_" in tf[0], tf
+    # It carries the goal id derived from the Paxos payload.
+    assert getattr(goal, "goal_id", "").startswith("adv-soak-paxosnode")
+
+    # Retry happened + handled gracefully + no lockup + bounded.
+    assert result["retried_against_chunk"] is True
+    assert result["lockup"] is False
+    assert result["pivot_and_decompose_handled_gracefully"] is True
+    assert result["converged"] is False  # Paxos never passes here (by design)
+    # Bounded, no infinite loop: initial GENERATE + max_repairs + the initial
+    # +1 reserve + the one pivot-granted extra GENERATE.
+    assert result["attempts"] <= 1 + 5 + 2
+
+
+def test_paxos_decompose_logs_distinct_scoped_symbols(monkeypatch):
+    """(c): the scoped-symbol seams show >1 DISTINCT symbol separated."""
+    monkeypatch.setenv("JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED", "true")
+    p = acs.PAYLOADS["paxos_election"]
+    client = FakeLocalPrimeClient([_PAXOS_THRASH])
+    result = asyncio.run(
+        acs.run_cognitive_soak(client=client, max_repairs=5, payload=p)
+    )
+    assert result["pivoted"] is True
+    assert result["decomposed"] is True
+    # The harness recorded the scoped symbols per emitted sub-goal.
+    scoped = result["decomposed_scoped_symbols"]
+    assert scoped, "scoped symbols must be recorded for the operator to watch"
+    distinct = sorted({s for syms in scoped for s in syms})
+    # >1 distinct symbol -> a REAL semantic seam (the gen impl had distinct
+    # symbols). e.g. heartbeat_loop separated from advance_term.
+    assert len(distinct) > 1, distinct
+    assert any("heartbeat_loop" in s for s in distinct), distinct
+    assert any("advance_term" in s for s in distinct), distinct
+
+
+def test_paxos_dry_mode_selector(monkeypatch, capsys):
+    monkeypatch.setenv("JARVIS_CHAOS_INJECTOR_ENABLED", "true")
+    rc = acs.main(["--payload", "paxos_election"])  # dry mode
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "paxos_election" in out
+    assert acs.PAXOS_ELECTION_PAYLOAD.title in out

--- a/tests/scripts/test_adversarial_cognitive_soak.py
+++ b/tests/scripts/test_adversarial_cognitive_soak.py
@@ -219,3 +219,345 @@ def test_run_cognitive_soak_refuses_when_gate_off(monkeypatch):
     client = FakeLocalPrimeClient([_CORRECT])
     with pytest.raises(RuntimeError):
         asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))
+
+
+# ===========================================================================
+# Payload #2: the Concurrency Gauntlet (thread-safe TTL+LRU cache)
+# ===========================================================================
+#
+# The load-bearing check: the gauntlet's pytest suite must actually CATCH the
+# two bugs a 7B almost always ships -- a missing lock and a lazy-only/blocking
+# TTL -- while a known-CORRECT reference impl PASSES. We prove discrimination
+# with three reference impls run through the REAL pytest subprocess boundary,
+# then drive the cognitive loop end-to-end with a scripted fake.
+
+# A CORRECT impl: RLock around every mutation + a non-blocking daemon reaper
+# that periodically reaps expired keys under the lock + clean stop().
+_LRU_CORRECT = '''```python
+from __future__ import annotations
+import threading
+import time
+from collections import OrderedDict
+
+
+class TTLLRUCache:
+    def __init__(self, capacity, ttl_seconds):
+        self.capacity = int(capacity)
+        self.ttl_seconds = float(ttl_seconds)
+        self._lock = threading.RLock()
+        self._data = OrderedDict()  # key -> (value, expiry_monotonic)
+        self._stop = threading.Event()
+        self._thread = threading.Thread(target=self._reaper, daemon=True)
+        self._thread.start()
+
+    def _reaper(self):
+        interval = max(0.02, self.ttl_seconds / 10.0)
+        while not self._stop.is_set():
+            self._stop.wait(interval)
+            if self._stop.is_set():
+                break
+            now = time.monotonic()
+            with self._lock:
+                dead = [k for k, (_v, exp) in self._data.items() if exp <= now]
+                for k in dead:
+                    self._data.pop(k, None)
+
+    def get(self, key):
+        now = time.monotonic()
+        with self._lock:
+            item = self._data.get(key)
+            if item is None:
+                return None
+            value, exp = item
+            if exp <= now:
+                self._data.pop(key, None)
+                return None
+            self._data.move_to_end(key)
+            return value
+
+    def put(self, key, value):
+        now = time.monotonic()
+        with self._lock:
+            if key in self._data:
+                self._data.move_to_end(key)
+            self._data[key] = (value, now + self.ttl_seconds)
+            while len(self._data) > self.capacity:
+                self._data.popitem(last=False)
+
+    def __len__(self):
+        with self._lock:
+            return len(self._data)
+
+    def stop(self):
+        self._stop.set()
+```'''
+
+# BUGGY (a): NO lock + lazy-only TTL (no background mechanism). Fails the
+# thread-safety test (race on the multi-step read-modify-write -> KeyError)
+# AND the background-eviction test (entry survives the wait).
+_LRU_BUGGY_NO_LOCK_LAZY = '''```python
+from __future__ import annotations
+import time
+from collections import OrderedDict
+
+
+class TTLLRUCache:
+    def __init__(self, capacity, ttl_seconds):
+        self.capacity = int(capacity)
+        self.ttl_seconds = float(ttl_seconds)
+        self._data = OrderedDict()
+
+    def get(self, key):
+        item = self._data.get(key)
+        if item is None:
+            return None
+        value, exp = item
+        if exp <= time.monotonic():
+            self._data.pop(key, None)
+            return None
+        self._data.move_to_end(key)
+        return value
+
+    def put(self, key, value):
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = (value, time.monotonic() + self.ttl_seconds)
+        while len(self._data) > self.capacity:
+            self._data.popitem(last=False)
+
+    def __len__(self):
+        return len(self._data)
+
+    def stop(self):
+        pass
+```'''
+
+# BUGGY (b): has a background reaper (so TTL is background) but FORGETS the
+# lock -- the very common 7B "added a thread, missed the mutex" output. Fails
+# the thread-safety test under active eviction churn.
+_LRU_BUGGY_NO_LOCK_REAPER = '''```python
+from __future__ import annotations
+import threading
+import time
+from collections import OrderedDict
+
+
+class TTLLRUCache:
+    def __init__(self, capacity, ttl_seconds):
+        self.capacity = int(capacity)
+        self.ttl_seconds = float(ttl_seconds)
+        self._data = OrderedDict()
+        self._stop = False
+        self._thread = threading.Thread(target=self._reaper, daemon=True)
+        self._thread.start()
+
+    def _reaper(self):
+        while not self._stop:
+            time.sleep(0.0005)
+            now = time.monotonic()
+            # NO LOCK + iterate the LIVE dict (no list() snapshot): a concurrent
+            # put mutating mid-iteration raises "OrderedDict mutated during
+            # iteration"; the unguarded pop also races put's popitem -> KeyError.
+            for k, (_v, exp) in self._data.items():
+                if exp <= now:
+                    self._data.pop(k, None)
+
+    def get(self, key):
+        item = self._data.get(key)
+        if item is None:
+            return None
+        value, exp = item
+        if exp <= time.monotonic():
+            self._data.pop(key, None)
+            return None
+        self._data.move_to_end(key)
+        return value
+
+    def put(self, key, value):
+        if key in self._data:
+            self._data.move_to_end(key)
+        self._data[key] = (value, time.monotonic() + self.ttl_seconds)
+        while len(self._data) > self.capacity:
+            self._data.popitem(last=False)
+
+    def __len__(self):
+        return len(self._data)
+
+    def stop(self):
+        self._stop = True
+```'''
+
+
+def test_concurrency_payload_registered_and_default():
+    assert "concurrency_lru" in acs.PAYLOADS
+    assert acs.DEFAULT_PAYLOAD == "concurrency_lru"
+    p = acs.PAYLOADS["concurrency_lru"]
+    assert p.entry_symbol == "TTLLRUCache"
+    assert "def test_thread_safety_no_corruption" in p.tests
+    assert "def test_ttl_background_eviction_not_lazy" in p.tests
+
+
+def test_concurrency_gauntlet_correct_impl_passes():
+    # LOAD-BEARING: a known-CORRECT reference impl PASSES the gauntlet suite.
+    p = acs.PAYLOADS["concurrency_lru"]
+    out = acs._run_pytest_in_tempdir(
+        acs._extract_code_block(_LRU_CORRECT), p.tests, timeout_s=120, payload=p
+    )
+    assert out["passed"] is True, out["stdout"][-2000:] + "\n" + out["stderr"][-1000:]
+
+
+def test_concurrency_gauntlet_no_lock_lazy_impl_fails():
+    # LOAD-BEARING: the no-lock + lazy-only TTL bug is CAUGHT.
+    p = acs.PAYLOADS["concurrency_lru"]
+    out = acs._run_pytest_in_tempdir(
+        acs._extract_code_block(_LRU_BUGGY_NO_LOCK_LAZY), p.tests, timeout_s=120, payload=p
+    )
+    assert out["passed"] is False
+    blob = (out["stdout"] or "") + (out["stderr"] or "")
+    # Both the thread-safety AND the background-eviction tests should flag it.
+    assert "test_thread_safety_no_corruption" in blob or \
+        "test_ttl_background_eviction_not_lazy" in blob
+
+
+def test_concurrency_gauntlet_no_lock_reaper_impl_fails():
+    # LOAD-BEARING: the "added a thread, missed the mutex" bug is CAUGHT.
+    #
+    # This race is inherently nondeterministic (the unguarded reaper/put
+    # interleave depends on scheduling), so we give it a few attempts -- a
+    # missing lock surfaces well within 3 runs, while a CORRECT (locked) impl
+    # never fails ANY run (proven separately + 10/10 in development). We assert
+    # the gauntlet flags the bug at least once AND that, when it does, it is the
+    # thread-safety test that catches it.
+    p = acs.PAYLOADS["concurrency_lru"]
+    impl = acs._extract_code_block(_LRU_BUGGY_NO_LOCK_REAPER)
+    caught = False
+    for _ in range(3):
+        out = acs._run_pytest_in_tempdir(impl, p.tests, timeout_s=120, payload=p)
+        if not out["passed"]:
+            blob = (out["stdout"] or "") + (out["stderr"] or "")
+            assert "test_thread_safety_no_corruption" in blob
+            caught = True
+            break
+    assert caught, "thread-safety gauntlet failed to catch the no-lock reaper bug in 3 runs"
+
+
+def test_concurrency_loop_fires_repair_then_converges():
+    # buggy -> buggy(same sig) -> buggy(same sig) -> correct: the epistemic
+    # diff is injected, temperature decays, and it converges on the LRU payload.
+    p = acs.PAYLOADS["concurrency_lru"]
+    scripted = [
+        _LRU_BUGGY_NO_LOCK_LAZY,
+        _LRU_BUGGY_NO_LOCK_LAZY,
+        _LRU_BUGGY_NO_LOCK_LAZY,
+        _LRU_CORRECT,
+    ]
+    client = FakeLocalPrimeClient(scripted)
+    result = asyncio.run(
+        acs.run_cognitive_soak(client=client, max_repairs=3, payload=p)
+    )
+    assert result["converged"] is True
+    assert result["epistemic_diffs_injected"] >= 1
+    # diff injected after the first failure (later prompts carry the stderr).
+    assert "FAILING TEST STDERR" not in client.calls[0]["prompt"]
+    assert any("FAILING TEST STDERR" in c["prompt"] for c in client.calls[1:])
+    temps = result["temperature_trajectory"]
+    assert all(temps[i] >= temps[i + 1] for i in range(len(temps) - 1))
+
+
+def test_concurrency_loop_pivots_and_decomposes(monkeypatch):
+    # Same-signature failures long enough to trip pivot_verdict, then decompose
+    # fires, then a correct impl converges -- the full UNRESOLVABLE-PATH ->
+    # decompose -> retry arc on the LRU payload.
+    called = {"n": 0, "goals": []}
+    real_decompose = acs.decompose_for_block
+
+    def _spy(goal, **kwargs):
+        called["n"] += 1
+        called["goals"].append(goal)
+        return real_decompose(goal, **kwargs)
+
+    monkeypatch.setattr(acs, "decompose_for_block", _spy)
+
+    p = acs.PAYLOADS["concurrency_lru"]
+    client = FakeLocalPrimeClient([_LRU_BUGGY_NO_LOCK_LAZY] * 6 + [_LRU_CORRECT])
+    result = asyncio.run(
+        acs.run_cognitive_soak(client=client, max_repairs=6, payload=p)
+    )
+    assert result["pivoted"] is True
+    assert result["decomposed"] is True
+    assert called["n"] >= 1
+    # The decompose goal was built FROM the LRU payload (not merge-intervals).
+    assert any(getattr(g, "goal_id", "").startswith("adv-soak-ttllrucache")
+               for g in called["goals"])
+
+
+def test_concurrency_loop_bounded_non_convergence():
+    p = acs.PAYLOADS["concurrency_lru"]
+    client = FakeLocalPrimeClient([_LRU_BUGGY_NO_LOCK_LAZY])  # never fixes it
+    result = asyncio.run(
+        acs.run_cognitive_soak(client=client, max_repairs=3, payload=p)
+    )
+    assert result["converged"] is False
+    assert result["attempts"] <= 8  # bounded, no infinite loop
+
+
+# ---------------------------------------------------------------------------
+# CLI: --payload selector + warmup-first
+# ---------------------------------------------------------------------------
+
+
+def test_payload_selector_dry_mode(monkeypatch, capsys):
+    monkeypatch.setenv("JARVIS_CHAOS_INJECTOR_ENABLED", "true")
+    rc = acs.main(["--payload", "merge_intervals"])  # dry mode (no --run)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "merge_intervals" in out
+    assert acs.MERGE_INTERVALS_PAYLOAD.title in out
+
+
+def test_payload_selector_defaults_to_concurrency(monkeypatch, capsys):
+    monkeypatch.setenv("JARVIS_CHAOS_INJECTOR_ENABLED", "true")
+    rc = acs.main([])  # no --payload -> default
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "concurrency_lru" in out
+
+
+def test_warmup_called_once_before_loop(monkeypatch):
+    # In the --run path, the harness must warm the model exactly once BEFORE
+    # the cognitive loop starts (eliminates the cold-start timeout).
+    monkeypatch.setenv("JARVIS_CHAOS_INJECTOR_ENABLED", "true")
+
+    events = []
+
+    class _WarmupFake(FakeLocalPrimeClient):
+        def __init__(self, scripted):
+            super().__init__(scripted)
+            self.warmup_calls = []
+
+        async def warmup(self, *, timeout_s):
+            self.warmup_calls.append(timeout_s)
+            events.append("warmup")
+            return True
+
+        async def generate(self, *a, **k):
+            events.append("generate")
+            return await super().generate(*a, **k)
+
+        async def aclose(self):
+            return None
+
+    fake = _WarmupFake([_LRU_CORRECT])
+    monkeypatch.setattr(acs, "_build_real_client", lambda model: fake)
+
+    args = acs.argparse.Namespace(
+        run=True, model="qwen2.5-coder:7b", max_repairs=3,
+        payload="concurrency_lru", warmup_timeout=5.0,
+    )
+    rc = asyncio.run(acs._amain(args))
+    assert rc == 0  # converged on the correct impl
+    assert fake.warmup_calls == [5.0]  # warmed exactly once, with the timeout
+    # Warmup happened BEFORE any generation.
+    assert events[0] == "warmup"
+    assert "generate" in events
+    assert events.index("warmup") < events.index("generate")

--- a/tests/scripts/test_adversarial_cognitive_soak.py
+++ b/tests/scripts/test_adversarial_cognitive_soak.py
@@ -1,0 +1,221 @@
+"""Tests for scripts/adversarial_cognitive_soak.py.
+
+NO real model / Ollama is touched here. A FakeLocalPrimeClient feeds a scripted
+response sequence (wrong -> wrong-same-signature -> wrong-same-signature ->
+[pivot+decompose] -> correct) and we assert the REAL cognitive-loop mechanics
+fire:
+
+  * the Hybrid Epistemic Diff is injected after the first failure,
+  * temperature DECAYS across same-signature repeats,
+  * pivot_verdict trips at the 3rd same-signature fail and decompose_for_block
+    IS called,
+  * a correct response -> converged=True,
+  * a never-correct fake -> converged=False (bounded, no infinite loop),
+  * the gate-off path refuses.
+
+VALIDATE uses the REAL pytest subprocess execution in a tempdir (the test
+payload is tiny + fast), so the test-execution boundary is real, not mocked.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+# Module under test.
+import importlib.util
+import os
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO = os.path.abspath(os.path.join(_HERE, "..", ".."))
+_SCRIPT = os.path.join(_REPO, "scripts", "adversarial_cognitive_soak.py")
+_spec = importlib.util.spec_from_file_location("adversarial_cognitive_soak", _SCRIPT)
+acs = importlib.util.module_from_spec(_spec)
+import sys as _sys
+
+_sys.modules["adversarial_cognitive_soak"] = acs  # needed for dataclass on 3.11
+_spec.loader.exec_module(acs)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeResponse:
+    """Mimics PrimeResponse just enough for the loop (only .content read)."""
+
+    def __init__(self, content: str) -> None:
+        self.content = content
+        self.source = "fake_local_prime"
+
+
+class FakeLocalPrimeClient:
+    """Scripted stand-in for LocalPrimeClient.
+
+    Records every (prompt, system_prompt, temperature) it is called with so the
+    test can assert diff-injection and temperature decay.
+    """
+
+    def __init__(self, scripted):
+        self._scripted = list(scripted)
+        self.calls = []  # list of dict(prompt, system_prompt, temperature)
+
+    async def generate(self, prompt, system_prompt=None, temperature=0.7, **kwargs):
+        self.calls.append(
+            {"prompt": prompt, "system_prompt": system_prompt, "temperature": temperature}
+        )
+        idx = min(len(self.calls) - 1, len(self._scripted) - 1)
+        return _FakeResponse(self._scripted[idx])
+
+
+# A wrong impl that BLOWS THE SAME EDGE CASE every time (stable signature):
+# returns the wrong merge of overlapping intervals (ignores adjacency entirely).
+_WRONG_SAME = """```python
+def merge_intervals(intervals):
+    if not intervals:
+        return []
+    intervals = sorted(intervals)
+    out = [list(intervals[0])]
+    for s, e in intervals[1:]:
+        if s < out[-1][1]:
+            out[-1][1] = max(out[-1][1], e)
+        else:
+            out.append([s, e])
+    return [tuple(x) for x in out]
+```"""
+
+# A correct impl (handles adjacency s <= last_end and overlap).
+_CORRECT = """```python
+def merge_intervals(intervals):
+    if not intervals:
+        return []
+    intervals = sorted(intervals)
+    out = [list(intervals[0])]
+    for s, e in intervals[1:]:
+        if s <= out[-1][1]:
+            out[-1][1] = max(out[-1][1], e)
+        else:
+            out.append([s, e])
+    return [tuple(x) for x in out]
+```"""
+
+
+@pytest.fixture(autouse=True)
+def _gate_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_CHAOS_INJECTOR_ENABLED", "true")
+    # Make the pivot trip fast + temperature visibly decay. A non-zero floor
+    # is reached after two decays (0.7 -> 0.35 -> 0.175 == floor), so
+    # temp_at_floor becomes true and pivot_verdict can trip.
+    monkeypatch.setenv("JARVIS_EPISTEMIC_TEMP_DECAY", "0.5")
+    monkeypatch.setenv("JARVIS_EPISTEMIC_TEMP_FLOOR", "0.175")
+    monkeypatch.setenv("JARVIS_EPISTEMIC_PIVOT_PASSES", "2")
+
+
+# ---------------------------------------------------------------------------
+# Gate
+# ---------------------------------------------------------------------------
+
+
+def test_gate_off_refuses(monkeypatch):
+    monkeypatch.delenv("JARVIS_CHAOS_INJECTOR_ENABLED", raising=False)
+    assert acs.gate_enabled() is False
+
+
+def test_gate_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_CHAOS_INJECTOR_ENABLED", "true")
+    assert acs.gate_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Payload sanity
+# ---------------------------------------------------------------------------
+
+
+def test_payload_has_real_tests_and_signature():
+    p = acs.ADVERSARIAL_PAYLOAD
+    assert "def test_" in p.tests
+    assert p.entry_symbol  # the symbol the impl must define
+    # The reference correct impl must pass its own test suite (sanity).
+    out = acs._run_pytest_in_tempdir(_CORRECT_IMPL_PLAIN, p.tests, timeout_s=60)
+    assert out["passed"] is True, out["stderr"][-1500:]
+
+
+_CORRECT_IMPL_PLAIN = acs._extract_code_block(_CORRECT)
+
+
+def test_wrong_impl_fails_its_tests():
+    p = acs.ADVERSARIAL_PAYLOAD
+    out = acs._run_pytest_in_tempdir(acs._extract_code_block(_WRONG_SAME), p.tests, timeout_s=60)
+    assert out["passed"] is False
+
+
+# ---------------------------------------------------------------------------
+# Loop mechanics
+# ---------------------------------------------------------------------------
+
+
+def test_diff_injected_after_first_fail_and_temp_decays():
+    # wrong, wrong(same sig), wrong(same sig), correct
+    client = FakeLocalPrimeClient([_WRONG_SAME, _WRONG_SAME, _WRONG_SAME, _CORRECT])
+    result = asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))
+
+    # First call has no epistemic diff; subsequent calls do.
+    assert "SOVEREIGN" not in client.calls[0]["prompt"] and \
+        "Epistemic Feedback" not in client.calls[0]["prompt"] and \
+        "FAILING TEST STDERR" not in client.calls[0]["prompt"]
+    assert any("FAILING TEST STDERR" in c["prompt"] for c in client.calls[1:])
+
+    # Temperature is monotonically non-increasing and strictly decays at least
+    # once across the same-signature repeats (the parametric degeneration).
+    temps = result["temperature_trajectory"]
+    assert all(temps[i] >= temps[i + 1] for i in range(len(temps) - 1))
+    assert min(temps) < max(temps)  # strictly decayed at least once
+
+    assert result["epistemic_diffs_injected"] >= 1
+
+
+def test_pivot_and_decompose_fire(monkeypatch):
+    called = {"n": 0, "hints": []}
+    real_decompose = acs.decompose_for_block
+
+    def _spy(goal, **kwargs):
+        called["n"] += 1
+        called["hints"].append(kwargs.get("failure_hint"))
+        return real_decompose(goal, **kwargs)
+
+    monkeypatch.setattr(acs, "decompose_for_block", _spy)
+
+    # Keep failing with the SAME signature long enough that the temperature
+    # decays to the floor while the repeat-count climbs to the pivot threshold,
+    # so pivot_verdict trips; only AFTER the pivot does a correct impl appear.
+    client = FakeLocalPrimeClient([_WRONG_SAME] * 6 + [_CORRECT])
+    result = asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=6))
+
+    assert result["pivoted"] is True
+    assert result["decomposed"] is True
+    assert called["n"] >= 1
+    # The pivot passed a failure_hint with the signature.
+    assert any(h and "stderr_tail" in h for h in called["hints"])
+
+
+def test_converges_on_correct():
+    client = FakeLocalPrimeClient([_WRONG_SAME, _CORRECT])
+    result = asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))
+    assert result["converged"] is True
+    assert result["attempts"] >= 2
+
+
+def test_never_correct_is_bounded_non_convergence():
+    client = FakeLocalPrimeClient([_WRONG_SAME])  # always the same wrong impl
+    result = asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))
+    assert result["converged"] is False
+    # Bounded: attempts must not explode. Generous ceiling (pre + repairs + pivot).
+    assert result["attempts"] <= 8
+
+
+def test_run_cognitive_soak_refuses_when_gate_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_CHAOS_INJECTOR_ENABLED", raising=False)
+    client = FakeLocalPrimeClient([_CORRECT])
+    with pytest.raises(RuntimeError):
+        asyncio.run(acs.run_cognitive_soak(client=client, max_repairs=3))


### PR DESCRIPTION
Final flip of the Sovereign Provider Failover Lifecycle to **default-ON**, gated on an evidence-complete Adversarial Cognitive Soak. (Phases 1-3 + chaos already merged #69673/#69674/#69675.)

## What this round proved + built
- **VRAM pre-warm** (`failover_lifecycle` AWAKENING awaits a dummy 1-token generation before SERVING) — eliminates the cold-start spurious timeout on the first failover op. No hardcoded sleep; reuses `LocalPrimeClient.warmup`. Proven live (warmup ~10s).
- **Thrash-pivot** (`epistemic_feedback.should_pivot`) — composes a budget-exhaustion trigger with the legacy stuck-signature trigger, so a NON-converging (thrashing) model decomposes instead of silently exhausting. Closes a real production gap the gauntlet exposed (`pivot_verdict` only fired on a stuck wall). Wired in both the soak AND `repair_engine`. Gated, OFF byte-identical.
- **Adversarial Cognitive Soak** (`scripts/adversarial_cognitive_soak.py`) — drives the REAL primitives (`LocalPrimeClient`→Ollama 7b, real `epistemic_feedback`/`decompose_for_block`/`isolate_symbols`, real pytest) through adversarial payloads (merge-intervals, thread-safe TTL-LRU, **Paxos leader election**).

## The flip-gate (live, against qwen2.5-coder:7b)
The Paxos Architectural Anomaly forced the complete net: **thrash (6 fails) → 8 Hybrid Epistemic Diffs + temperature decay 0.7→0.175 → `[SOVEREIGN YIELD: UNRESOLVABLE PATH] reason=budget_exhausted` → SEMANTIC symbol-scoped decompose (13 sub-goals; `heartbeat_loop` separated from `advance_term`/`resolve_partition`, target_files→the real written impl) → retry against the failure-implicated chunk → bounded, no lockup, no dropped state.** Graceful handling = the gate (Paxos convergence was correctly secondary). Plus the LIVE dead-man self-delete drill (T+221s) + chaos-gauntlet phantom-recovery, all already proven.

Default-ON; hot-revert `JARVIS_FAILOVER_LIFECYCLE_ENABLED=false` → inert. ~250 tests across the arc. $0 GCP this round (all local M1 + local Ollama).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Graduates the Sovereign failover lifecycle to default ON and adds VRAM pre‑warm plus a composite thrash‑pivot, with an adversarial cognitive soak harness to validate graceful failure handling end‑to‑end.

- **New Features**
  - Failover lifecycle now default enabled; FSM awaits a VRAM pre‑warm in AWAKENING before SERVING. Implements `LocalPrimeClient.warmup(timeout_s)` (1‑token, fail‑soft) and integrates it into `failover_lifecycle`.
  - Adds `epistemic_feedback.should_pivot(...)` to pivot on stuck signatures or budget exhaustion (thrash). Wired into `repair_engine`.
  - Introduces `scripts/adversarial_cognitive_soak.py` to drive the real loop (temperature decay + hybrid diff + semantic decompose) through adversarial payloads, including a Paxos leader‑election anomaly.
  - Test coverage: new warmup unit/integration tests and soak tests; expanded `test_epistemic_feedback`.

- **Migration**
  - Default flip: set `JARVIS_FAILOVER_LIFECYCLE_ENABLED=false` to hot‑revert.
  - Warmup can be disabled with `JARVIS_FAILOVER_WARMUP_ENABLED=false`.
  - Thrash pivot can be disabled with `JARVIS_EPISTEMIC_THRASH_PIVOT_ENABLED=false`.

<sup>Written for commit 54cad42913ee22c544e19bd82708786cf81338e5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69676?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

