### PR TITLE
feat: Sovereign RSI Flywheel Phase 4a — Autonomous DPO Synthesizer + Epistemic Purity gate (+ costed Phase 4 spec)

### DIFF
--- a/backend/core/ouroboros/governance/dpo_synthesizer.py
+++ b/backend/core/ouroboros/governance/dpo_synthesizer.py
@@ -1,0 +1,716 @@
+"""dpo_synthesizer.py -- Phase 4a: Autonomous DPO Pair Synthesizer (Body, $0).
+
+Turns O+V's own epistemic-repair trajectories into token-dense DPO preference
+pairs and exports them async/fire-and-forget to reactor-core's ingestor. Pure
+Body-side logic -- no GPU, no network in the hot path.
+
+The flywheel
+------------
+EVERY converged L2 repair produces a ``(failed_candidate, stderr,
+repaired_candidate, resolved?)`` trajectory. The synthesizer turns each
+*failed->passing* transition into one DPO pair (REJECTED = the failed symbol
+body, CHOSEN = the repaired symbol body) and appends it to a bounded local
+JSONL ring (and, gated, a best-effort GCS/bus publish).
+
+The three load-bearing gates (purity over volume)
+--------------------------------------------------
+1. **Epistemic Purity** (``classify_rejection``): only train on OUR cognitive
+   failures (pytest AssertionError, SyntaxError, NameError/TypeError, Iron-Gate
+   logical severance). DROP anything caused by DoubleWord/Aegis/transport INFRA
+   (fsm_exhausted, 5xx, timeouts, lane-collapse). Reuses ``dw_fault_taxonomy``
+   + ``FailureSource`` names. Fail-safe: ambiguous -> infra -> DROP.
+2. **Golden ratio** (no half-pairs): require BOTH a failed candidate AND a
+   test-VERIFIED repaired candidate. A YIELDED trajectory (UNRESOLVABLE PATH /
+   pivot / no resolved chosen) -> drop the whole pair.
+3. **AST-node isolation**: extract ONLY the symbol that changed between failed
+   and repaired (REJECTED = failed symbol body, CHOSEN = repaired symbol body);
+   strip irrelevant imports/boilerplate/unrelated symbols. Density-cap each
+   side via ``estimate_body_chars`` <= ``JARVIS_DPO_PAIR_MAX_CHARS``. Isolation
+   failure / irreducible over-cap -> DROP (no raw dumps).
+
+Reuse-first
+-----------
+- ``dw_fault_taxonomy`` + ``topology_sentinel.FailureSource`` (the infra
+  classifiers; NOT forked).
+- ``ast_symbol_scoper.slice_is_valid`` (the AST integrity gate primitive).
+- ``dw_egress_interceptor.estimate_body_chars`` (the density estimate).
+- ``outage_ledger.emit_outage_event`` (the async fire-and-forget Trinity bridge
+  pattern; MIRRORED here, not imported).
+
+Env gates
+---------
+- ``JARVIS_DPO_SYNTHESIS_ENABLED``    default "true"  (OFF -> no-op)
+- ``JARVIS_DPO_PAIR_MAX_CHARS``       default 2048    (per-side density cap)
+- ``JARVIS_DPO_DATASET_PATH``         default ".jarvis/dpo_dataset.jsonl"
+- ``JARVIS_DPO_DATASET_MAX``          default 5000    (bounded ring)
+- ``JARVIS_DPO_GCS_EXPORT_ENABLED``   default "false" (best-effort GCS/bus pub)
+
+Fail-soft ABSOLUTE: NEVER raises into the repair loop or the O+V DAG.
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import re
+import tempfile
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+# Module-level strong refs for in-flight asyncio tasks (prevent GC reap) --
+# mirrors outage_ledger._INFLIGHT_TASKS.
+_INFLIGHT_TASKS: set = set()
+
+
+# ---------------------------------------------------------------------------
+# Env helpers
+# ---------------------------------------------------------------------------
+
+def _env_bool(name: str, default: str) -> bool:
+    return os.environ.get(name, default).strip().lower() not in {"0", "false", "no", "off"}
+
+
+def synthesis_enabled() -> bool:
+    return _env_bool("JARVIS_DPO_SYNTHESIS_ENABLED", "true")
+
+
+def gcs_export_enabled() -> bool:
+    return _env_bool("JARVIS_DPO_GCS_EXPORT_ENABLED", "false")
+
+
+def _max_chars() -> int:
+    try:
+        return int(os.environ.get("JARVIS_DPO_PAIR_MAX_CHARS", "2048"))
+    except (ValueError, TypeError):
+        return 2048
+
+
+def _dataset_path() -> str:
+    return os.environ.get(
+        "JARVIS_DPO_DATASET_PATH",
+        os.path.join(".jarvis", "dpo_dataset.jsonl"),
+    )
+
+
+def _dataset_max() -> int:
+    try:
+        return int(os.environ.get("JARVIS_DPO_DATASET_MAX", "5000"))
+    except (ValueError, TypeError):
+        return 5000
+
+
+# ---------------------------------------------------------------------------
+# Epistemic Purity gate (the load-bearing correctness gate)
+# ---------------------------------------------------------------------------
+
+# COGNITIVE markers -- OUR-side reasoning failures worth training away. These
+# are the failure shapes a better generator would have avoided. Matched on the
+# rejected payload's stderr/source.
+_COGNITIVE_MARKERS = (
+    "assertionerror",
+    "assert ",
+    "syntaxerror",
+    "indentationerror",
+    "nameerror",
+    "typeerror",
+    "attributeerror",
+    "keyerror",
+    "indexerror",
+    "valueerror",
+    "unboundlocalerror",
+    "importerror",
+    "modulenotfounderror",
+    "zerodivisionerror",
+    "recursionerror",
+    "notimplementederror",
+    "failed",            # pytest "1 failed", "test ... FAILED"
+    "iron gate",         # Iron-Gate logical severance
+    "exploration_insufficient",
+)
+
+# INFRA markers -- DoubleWord / Aegis / transport / our-budget faults. These are
+# NOT cognitive: a smarter model would not have fixed them. DROP. Mirrors the
+# FailureSource names + dw_fault_taxonomy message shapes.
+_INFRA_MARKERS = (
+    "fsm_exhausted",
+    "all_providers_exhausted",
+    "no_fallback_configured",
+    "fallback_skipped",
+    "generation_timeout",
+    "tool_loop_deadline",
+    "tool_loop_max_rounds",
+    "tool_loop_round_budget",
+    "tool_loop_starved",
+    "local_egress_overweight",
+    "live_transport",
+    "live_http_5xx",
+    "live_http_429",
+    "live_stream_stall",
+    "live_parse_error",
+    "lane collapse",
+    "lane_collapse",
+    "quarantine",
+    "upstream quarantine",
+    "timeouterror",
+    "timed out",
+    "timeout",
+    "clientconnectorerror",
+    "connection",
+    "aegis",
+    "503",
+    "502",
+    "504",
+    "service unavailable",
+    "bad gateway",
+    "gateway timeout",
+    "probe_fail",
+    "probe_timeout",
+)
+
+
+def _infra_failure_source(failure_source: Optional[str]) -> bool:
+    """True iff ``failure_source`` is one of the weight-0 / transport
+    FailureSource names. Reuses the canonical enum values when importable;
+    falls back to a literal-name match (this module stays import-light + the
+    classifier must work even if topology_sentinel can't be loaded)."""
+    if not failure_source:
+        return False
+    try:
+        fs = str(failure_source).strip().lower()
+    except Exception:  # noqa: BLE001
+        return False
+    if not fs:
+        return False
+    # Reuse the authoritative enum value set when available.
+    try:
+        from backend.core.ouroboros.governance.topology_sentinel import (  # noqa: PLC0415
+            FailureSource,
+        )
+        names = {m.value.lower() for m in FailureSource}
+        # COGNITIVE carve-out: nothing in FailureSource is cognitive (it is a
+        # *transport/probe* taxonomy), so any member match is infra.
+        if fs in names:
+            return True
+    except Exception:  # noqa: BLE001 -- import-light; fall through to literal match
+        pass
+    return any(m in fs for m in _INFRA_MARKERS)
+
+
+def classify_rejection(
+    *,
+    stderr: str,
+    failure_source: Optional[str],
+    fsm_state: Optional[str],
+) -> str:
+    """Classify the REJECTED payload as ``"cognitive"`` (KEEP) or ``"infra"``
+    (DROP). Fail-safe: if it cannot CONFIDENTLY classify as cognitive, returns
+    ``"infra"`` (purity over volume -- never pollute the dataset). NEVER raises.
+    """
+    try:
+        # 1. A transport/budget FailureSource or fsm_state is decisive -> infra.
+        if _infra_failure_source(failure_source):
+            return "infra"
+        if _infra_failure_source(fsm_state):
+            return "infra"
+
+        blob = str(stderr or "").lower()
+
+        # 2. Any infra marker in the stderr -> infra (drop -- DW's problem, not
+        #    a reasoning error). Checked BEFORE cognitive so a timeout that
+        #    happens to contain the word "failed" is still dropped.
+        if any(m in blob for m in _INFRA_MARKERS):
+            return "infra"
+
+        # 3. A clear cognitive marker -> keep.
+        if any(m in blob for m in _COGNITIVE_MARKERS):
+            return "cognitive"
+
+        # 4. Ambiguous / opaque -> fail-safe to infra (DROP).
+        return "infra"
+    except Exception:  # noqa: BLE001 -- the gate must never itself throw
+        return "infra"
+
+
+# ---------------------------------------------------------------------------
+# DPOPair (matches reactor-core dpo_pair_generator.DPOPair.to_dict shape)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class DPOPair:
+    """A single DPO preference pair -- schema-compatible with reactor-core's
+    ``training.dpo_pair_generator.DPOPair`` so Reactor ingests it natively
+    (no new schema on the Nerves side)."""
+
+    prompt: str
+    chosen: str
+    rejected: str
+    chosen_model: Optional[str] = None
+    rejected_model: Optional[str] = None
+    chosen_score: float = 1.0
+    rejected_score: float = 0.0
+    task_type: Optional[str] = None
+    generation_method: str = "outcome_diff"
+    metadata: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "prompt": self.prompt,
+            "chosen": self.chosen,
+            "rejected": self.rejected,
+            "chosen_model": self.chosen_model,
+            "rejected_model": self.rejected_model,
+            "chosen_score": round(self.chosen_score, 4),
+            "rejected_score": round(self.rejected_score, 4),
+            "task_type": self.task_type,
+            "generation_method": self.generation_method,
+            "metadata": self.metadata,
+        }
+
+    def content_hash(self) -> str:
+        """Stable content hash over (prompt, chosen, rejected) for dedup."""
+        try:
+            blob = (self.prompt + "\x00" + self.chosen + "\x00" + self.rejected).encode(
+                "utf-8", errors="replace"
+            )
+            return hashlib.sha256(blob).hexdigest()
+        except Exception:  # noqa: BLE001
+            return hashlib.sha256(repr(self).encode("utf-8", errors="replace")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# RepairTrajectory (the synthesizer input; decoupled for testability)
+# ---------------------------------------------------------------------------
+
+@dataclass
+class RepairTrajectory:
+    """The source trajectory for one DPO pair: a failed candidate and its
+    test-verified repaired counterpart. Decoupled from ctx/result objects so
+    it is trivially testable; use :meth:`from_repair` to extract from the live
+    orchestrator objects at the L2_CONVERGED seam."""
+
+    prompt: str
+    failed_candidate_src: str
+    repaired_candidate_src: Optional[str]
+    resolved: bool
+    stderr: str = ""
+    failure_source: Optional[str] = None
+    fsm_state: Optional[str] = None
+    failure_signature_hash: str = ""
+    task_type: Optional[str] = "l2_repair"
+    changed_symbol_hint: str = ""
+    provider: str = ""
+    file_path: str = ""
+
+    @classmethod
+    def from_repair(cls, ctx: Any, result: Any) -> Optional["RepairTrajectory"]:
+        """Extract a trajectory from the live ``(ctx, RepairResult)`` at the
+        orchestrator L2 seam. Returns ``None`` unless this is a genuine
+        L2_CONVERGED with both code states present. NEVER raises -> None."""
+        try:
+            if getattr(result, "terminal", "") != "L2_CONVERGED":
+                return None
+            chosen_cand = getattr(result, "candidate", None)
+            repaired_src = _candidate_src(chosen_cand)
+            if not repaired_src:
+                return None
+
+            failed_src = ""
+            gen = getattr(ctx, "generation", None)
+            cands = getattr(gen, "candidates", None) if gen is not None else None
+            if cands:
+                failed_src = _candidate_src(cands[0])
+            if not failed_src:
+                return None
+
+            file_path = ""
+            if isinstance(chosen_cand, dict):
+                file_path = str(chosen_cand.get("file_path", "") or "")
+
+            # Provider attribution: the converged iteration's provider_name.
+            provider = ""
+            try:
+                for rec in reversed(getattr(result, "iterations", ()) or ()):
+                    p = getattr(rec, "provider_name", "") or ""
+                    if p:
+                        provider = p
+                        break
+            except Exception:  # noqa: BLE001
+                provider = ""
+
+            # The prompt = the sub-goal / task description.
+            sig = getattr(ctx, "signal", None)
+            prompt = ""
+            if sig is not None:
+                prompt = str(getattr(sig, "description", "") or "")
+            if not prompt:
+                prompt = f"Repair the failing candidate for {file_path or 'the target'}."
+
+            return cls(
+                prompt=prompt,
+                failed_candidate_src=failed_src,
+                repaired_candidate_src=repaired_src,
+                resolved=True,
+                stderr=str(getattr(result, "stderr_tail", "") or ""),
+                failure_source=None,
+                fsm_state=None,
+                failure_signature_hash=str(getattr(result, "failure_signature_hash", "") or ""),
+                task_type="l2_repair",
+                provider=provider,
+                file_path=file_path,
+            )
+        except Exception:  # noqa: BLE001 -- extraction must never break the pipeline
+            return None
+
+
+def _candidate_src(candidate: Any) -> str:
+    """Best-effort full source of a candidate dict (full_content, else first
+    multi-file entry). Mirrors repair_trajectory_emitter._content."""
+    try:
+        if not isinstance(candidate, dict):
+            return ""
+        fc = candidate.get("full_content")
+        if isinstance(fc, str) and fc:
+            return fc
+        files = candidate.get("files")
+        if isinstance(files, list) and files and isinstance(files[0], dict):
+            return str(files[0].get("full_content", "") or "")
+        return ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# AST-node isolation
+# ---------------------------------------------------------------------------
+
+def _top_level_symbols(source: str) -> Dict[str, ast.AST]:
+    """Map top-level def/class name -> AST node. {} on parse failure."""
+    try:
+        tree = ast.parse(source)
+    except Exception:  # noqa: BLE001 -- syntax error / unparseable -> no symbols
+        return {}
+    out: Dict[str, ast.AST] = {}
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            out[node.name] = node
+    return out
+
+
+def _segment(source: str, node: ast.AST) -> str:
+    try:
+        seg = ast.get_source_segment(source, node)
+        return seg or ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _isolate_changed_symbol(
+    failed_src: str,
+    repaired_src: str,
+    hint: str = "",
+) -> Optional[tuple]:
+    """Return ``(rejected_body, chosen_body)`` for the ONE symbol that changed
+    between the failed and repaired source, with irrelevant imports/boilerplate/
+    unrelated symbols stripped (AST keep-list = the symbol itself).
+
+    Returns ``None`` if isolation fails (unparseable, no single changed symbol,
+    or either slice fails the integrity gate) -- never a raw dump.
+    """
+    try:
+        failed_syms = _top_level_symbols(failed_src)
+        repaired_syms = _top_level_symbols(repaired_src)
+        if not failed_syms or not repaired_syms:
+            return None
+
+        # Find symbols present in BOTH whose source segment differs.
+        changed: List[str] = []
+        for name, fnode in failed_syms.items():
+            rnode = repaired_syms.get(name)
+            if rnode is None:
+                continue
+            f_seg = _segment(failed_src, fnode)
+            r_seg = _segment(repaired_src, rnode)
+            if f_seg and r_seg and f_seg.strip() != r_seg.strip():
+                changed.append(name)
+
+        target: Optional[str] = None
+        if len(changed) == 1:
+            target = changed[0]
+        elif len(changed) > 1 and hint and hint in changed:
+            # Disambiguate via the changed-symbol hint when several differ.
+            target = hint
+        elif not changed:
+            # No common symbol differs -- maybe a symbol was added/removed.
+            # Fall back to the hint if it names a symbol in both.
+            if hint and hint in failed_syms and hint in repaired_syms:
+                target = hint
+            else:
+                return None
+        else:
+            return None
+
+        rejected = _segment(failed_src, failed_syms[target])
+        chosen = _segment(repaired_src, repaired_syms[target])
+        if not rejected or not chosen:
+            return None
+
+        # Integrity gate (reuse the ast_symbol_scoper primitive).
+        try:
+            from backend.core.ouroboros.governance.ast_symbol_scoper import (  # noqa: PLC0415
+                slice_is_valid,
+            )
+            if not slice_is_valid(rejected) or not slice_is_valid(chosen):
+                return None
+        except Exception:  # noqa: BLE001 -- fall back to a local parse check
+            for seg in (rejected, chosen):
+                try:
+                    ast.parse(textwrap.dedent(seg))
+                except Exception:  # noqa: BLE001
+                    return None
+
+        return (textwrap.dedent(rejected).strip("\n"), textwrap.dedent(chosen).strip("\n"))
+    except Exception:  # noqa: BLE001 -- isolation must never raise
+        return None
+
+
+def _within_cap(text: str, cap: int) -> bool:
+    """True iff ``text`` is within the density cap, measured via the egress
+    interceptor's estimate_body_chars (reused, not forked)."""
+    try:
+        from backend.core.ouroboros.governance.dw_egress_interceptor import (  # noqa: PLC0415
+            estimate_body_chars,
+        )
+        # Wrap as a single-message body so estimate_body_chars sums it.
+        size = estimate_body_chars({"messages": [{"content": text}]})
+    except Exception:  # noqa: BLE001 -- fall back to raw length
+        size = len(text or "")
+    return size <= cap
+
+
+# ---------------------------------------------------------------------------
+# synthesize_pair -- the gates
+# ---------------------------------------------------------------------------
+
+def synthesize_pair(trajectory: Any) -> Optional[DPOPair]:
+    """Turn a :class:`RepairTrajectory` into a :class:`DPOPair`, or ``None`` if
+    any gate fails (golden-ratio / epistemic-purity / AST-isolation / density).
+    NEVER raises -> None (fail-soft)."""
+    try:
+        traj = trajectory
+        # --- Golden ratio: both proven states required -------------------
+        failed_src = str(getattr(traj, "failed_candidate_src", "") or "")
+        repaired_src = getattr(traj, "repaired_candidate_src", None)
+        resolved = bool(getattr(traj, "resolved", False))
+        if not resolved or not repaired_src or not failed_src:
+            return None
+        repaired_src = str(repaired_src)
+        if failed_src.strip() == repaired_src.strip():
+            return None  # nothing changed -- nothing to learn
+
+        # --- Epistemic purity: drop infra-caused rejections --------------
+        verdict = classify_rejection(
+            stderr=str(getattr(traj, "stderr", "") or ""),
+            failure_source=getattr(traj, "failure_source", None),
+            fsm_state=getattr(traj, "fsm_state", None),
+        )
+        if verdict != "cognitive":
+            logger.debug("[DPOSynth] dropped pair: rejection classified infra")
+            return None
+
+        # --- AST-node isolation ------------------------------------------
+        hint = str(getattr(traj, "changed_symbol_hint", "") or "")
+        isolated = _isolate_changed_symbol(failed_src, repaired_src, hint)
+        if isolated is None:
+            logger.debug("[DPOSynth] dropped pair: AST isolation failed")
+            return None
+        rejected, chosen = isolated
+        if rejected.strip() == chosen.strip():
+            return None
+
+        # --- Density cap (per side) --------------------------------------
+        cap = _max_chars()
+        if not _within_cap(rejected, cap) or not _within_cap(chosen, cap):
+            logger.debug("[DPOSynth] dropped pair: density cap exceeded (irreducible)")
+            return None
+
+        provider = str(getattr(traj, "provider", "") or "") or None
+        return DPOPair(
+            prompt=str(getattr(traj, "prompt", "") or ""),
+            chosen=chosen,
+            rejected=rejected,
+            chosen_model=provider,
+            rejected_model=provider,
+            chosen_score=1.0,
+            rejected_score=0.0,
+            task_type=str(getattr(traj, "task_type", "") or "") or None,
+            generation_method="outcome_diff",
+            metadata={
+                "source": "ouroboros_epistemic_repair",
+                "signature": str(getattr(traj, "failure_signature_hash", "") or ""),
+                "task_type": str(getattr(traj, "task_type", "") or "") or None,
+                "file_path": str(getattr(traj, "file_path", "") or ""),
+            },
+        )
+    except Exception:  # noqa: BLE001 -- synthesis must never raise
+        logger.debug("[DPOSynth] synthesize_pair failed", exc_info=True)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Bounded JSONL ring (local dataset) + content-hash dedup
+# ---------------------------------------------------------------------------
+
+def _append_to_ring(pair: DPOPair) -> bool:
+    """Append ``pair`` to the bounded JSONL ring with content-hash dedup.
+    Returns True if a NEW record was written, False on dedup or any error.
+    NEVER raises."""
+    path = _dataset_path()
+    try:
+        h = pair.content_hash()
+        records: List[Dict[str, Any]] = []
+        seen: set = set()
+        try:
+            with open(path, encoding="utf-8") as fh:
+                for raw in fh:
+                    raw = raw.strip()
+                    if not raw:
+                        continue
+                    try:
+                        d = json.loads(raw)
+                    except Exception:  # noqa: BLE001 -- skip corrupt line
+                        continue
+                    records.append(d)
+                    ch = (d.get("metadata") or {}).get("_content_hash")
+                    if ch:
+                        seen.add(ch)
+        except FileNotFoundError:
+            pass
+
+        if h in seen:
+            return False  # dedup
+
+        rec = pair.to_dict()
+        rec.setdefault("metadata", {})
+        rec["metadata"]["_content_hash"] = h
+        records.append(rec)
+
+        # Bound the ring (trim oldest first).
+        trimmed = records[-_dataset_max():]
+
+        os.makedirs(os.path.dirname(os.path.abspath(path)), exist_ok=True)
+        dir_name = os.path.dirname(os.path.abspath(path))
+        fd, tmp_path = tempfile.mkstemp(dir=dir_name, suffix=".tmp")
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                for r in trimmed:
+                    fh.write(json.dumps(r, default=str) + "\n")
+            os.replace(tmp_path, path)
+        except Exception:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+            raise
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[DPOSynth] ring append failed path=%s err=%r", path, exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Async fire-and-forget export (MIRRORS outage_ledger.emit_outage_event)
+# ---------------------------------------------------------------------------
+
+async def _publish_pair(pair: DPOPair) -> None:
+    """Async coroutine: append to the local ring, then (gated) best-effort
+    GCS/Trinity-bus publish. NEVER raises."""
+    try:
+        wrote = _append_to_ring(pair)
+        if wrote:
+            logger.debug(
+                "[DPOSynth] pair appended sig=%s task=%s",
+                (pair.metadata or {}).get("signature"),
+                pair.task_type,
+            )
+        if not gcs_export_enabled():
+            return
+        # Best-effort bus publish (reuse the Trinity bus when running). Any
+        # failure is swallowed -- the local ring is the durable record.
+        try:
+            from backend.core.trinity_event_bus import (  # noqa: PLC0415
+                get_event_bus_if_exists,
+                TrinityEvent,
+                EventPriority,
+                RepoType,
+            )
+            bus = get_event_bus_if_exists()
+            if bus is not None and getattr(bus, "_running", False):
+                event = TrinityEvent(
+                    topic="rsi.dpo_pair",
+                    source=RepoType.JARVIS,
+                    priority=EventPriority.LOW,
+                    payload=pair.to_dict(),
+                )
+                await bus.publish(event, persist=True)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[DPOSynth] bus publish skipped err=%r", exc)
+    except Exception as exc:  # noqa: BLE001 -- the coroutine must never raise
+        logger.warning("[DPOSynth] _publish_pair failed err=%r", exc)
+
+
+def emit_dpo_pair(pair: DPOPair) -> None:
+    """Synchronous fire-and-forget export. Schedules ``_publish_pair`` as an
+    asyncio task; strong refs kept in ``_INFLIGHT_TASKS`` (GC cannot reap).
+    No-op (no exception) if there is no running event loop -- mirrors
+    ``outage_ledger.emit_outage_event``. NEVER blocks or raises into the DAG."""
+    if pair is None:
+        return
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return  # no running loop -- silence (batch / startup context)
+    try:
+        task = loop.create_task(_publish_pair(pair))
+        _INFLIGHT_TASKS.add(task)
+        task.add_done_callback(_INFLIGHT_TASKS.discard)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[DPOSynth] emit schedule failed err=%r", exc)
+
+
+# ---------------------------------------------------------------------------
+# Convenience: synthesize + emit (the wiring entry point)
+# ---------------------------------------------------------------------------
+
+def synthesize_and_emit(trajectory: Any) -> bool:
+    """Synthesize a pair from ``trajectory`` and emit it fire-and-forget.
+    Returns whether a pair was emitted. Gated by ``JARVIS_DPO_SYNTHESIS_ENABLED``
+    (OFF -> no-op, returns False). NEVER raises into the caller."""
+    try:
+        if not synthesis_enabled():
+            return False
+        pair = synthesize_pair(trajectory)
+        if pair is None:
+            return False
+        emit_dpo_pair(pair)
+        return True
+    except Exception:  # noqa: BLE001 -- absolute fail-soft into the repair loop
+        logger.debug("[DPOSynth] synthesize_and_emit failed", exc_info=True)
+        return False
+
+
+__all__ = [
+    "DPOPair",
+    "RepairTrajectory",
+    "classify_rejection",
+    "synthesize_pair",
+    "emit_dpo_pair",
+    "synthesize_and_emit",
+    "synthesis_enabled",
+    "gcs_export_enabled",
+]

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -11591,6 +11591,25 @@ class GovernedOrchestrator:
             except Exception:  # noqa: BLE001 — emission must never break the pipeline
                 logger.debug("[Orchestrator] repair-trajectory emit skipped", exc_info=True)
 
+            # Sovereign RSI Flywheel (Phase 4a): synthesize a token-dense DPO
+            # preference pair from this converged epistemic-repair trajectory and
+            # export it fire-and-forget to reactor-core's ingestor. Distinct from
+            # the emitter above: applies the Epistemic Purity gate (drops infra-
+            # caused rejections), the golden-ratio gate (both proven states), and
+            # AST-symbol isolation (token-dense, not raw full_content). Gated
+            # (JARVIS_DPO_SYNTHESIS_ENABLED, default ON), fail-soft — never
+            # affects repair/APPLY. Only runs on a resolved repair (chosen present);
+            # a yield/pivot has candidate is None and never reaches here.
+            try:
+                from backend.core.ouroboros.governance.dpo_synthesizer import (
+                    RepairTrajectory, synthesize_and_emit,
+                )
+                _dpo_traj = RepairTrajectory.from_repair(ctx, l2_result)
+                if _dpo_traj is not None:
+                    synthesize_and_emit(_dpo_traj)
+            except Exception:  # noqa: BLE001 — DPO synthesis must never break the pipeline
+                logger.debug("[Orchestrator] DPO pair synthesis skipped", exc_info=True)
+
             # Post-L2 canonical validation is architecturally broken for
             # Python candidates: test_runner.PythonAdapter.run hard-codes
             # sandbox_dir=None (see its docstring at run() line 228-237) so

--- a/docs/superpowers/specs/2026-06-23-sovereign-rsi-flywheel-phase4.md
+++ b/docs/superpowers/specs/2026-06-23-sovereign-rsi-flywheel-phase4.md
@@ -1,0 +1,99 @@
+# Sovereign RSI Flywheel — Phase 4 Design Spec (costed)
+
+> **Arc.** Close the Recursive Self-Improvement loop: O+V's own generation experience → fine-tune the self-hosted `Qwen2.5-Coder-7B` (the J-Prime failover Mind) → redeploy → a more capable last-resort generator. Built on the Trinity: Body (JARVIS/O+V, this repo) emits experience → Nerves (Reactor-Core, `~/Documents/repos/reactor-core`) trains → Mind (J-Prime, `~/Documents/repos/jarvis-prime`) serves the improved model.
+> **Date:** 2026-06-23. Branch `worktree-sovereign-rsi-flywheel`.
+> **PRIMARY CONSTRAINT (non-negotiable, operator-emphasized): the GCP bill must stay EXTREMELY LOW.** Every design choice below is subordinate to this. The cost model (§5) is the load-bearing section; if a feature can't be made near-free or hard-capped, it is cut or deferred.
+
+---
+
+## 0. Reality grounding (from the reactor-core deep dive)
+Reactor-Core is **~85% ready** — real, production-grade: `RawInteraction` ingestion + `is_trainable()`; SFT (HF `SFTTrainer`); a complete **DPO pair generator** (`training/dpo_pair_generator.py`); LoRA/QLoRA; **GGUF quantization** (Q4_K_M); a **DeploymentGate** (40+ tests); deploy-to-J-Prime (copy GGUF + `current.gguf` symlink + `model_ready` Trinity event). The `telemetry_ingestor` already tags DW→Claude escalations as DPO signal.
+**The three real gaps Phase 4 closes:** (4a) the Body emits no *code-generation-outcome* experience yet — only generic telemetry; (4b) reactor-core has **NO GPU-VM provisioning/lifecycle** — it assumes a node exists, so a training run left bare would bill an unmanaged GPU (the cost red-flag); (4c) the J-Prime hot-swap listener is unverified.
+**Reuse-first:** the epistemic-repair trajectory + `ast_symbol_scoper.isolate_symbols` + the egress interceptor's `estimate_body_chars`/compression (4a); `failover_deadman.py` + `gcp_vm_manager` Spot/STANDARD + the metadata-SA-token self-delete + `IntelligentGCPOptimizer` budget (4b); reactor-core's `_deploy_to_jprime` + Ollama's native model API (4c). NO duplication of training/quant/deploy — those are Reactor's.
+
+## 1. Goals / Non-Goals
+**Goals.** (G1) Collect O+V generation experience as **token-dense DPO pairs** at **$0** (4a). (G2) Run fine-tunes on an **ephemeral, Spot, self-deleting** GPU node — never an orphaned A100 (4b). (G3) **Zero-downtime** model reload into J-Prime (4c). (G4) **Hard, autonomous cost guardrails**: data-volume + demand trigger, Spot-first minimum-viable GPU, dead-man self-delete, monthly budget ceiling. (G5) Reuse-first, gated, fail-soft, OFF byte-identical, no hardcoding.
+**Non-Goals.** Not continuous/online training (cost). Not training a model bigger than 7B (cost + the failover host is CPU-class). Not rebuilding Reactor's trainer/quantizer/deployer. Not RLHF/world-models (Reactor's aspirational tier). The fine-tune targets the *failover* generator only; DW/Claude remain primary.
+
+## 2. The flywheel (data-flow)
+```
+EVERY O+V generation (DW primary OR J-Prime failover)
+   │  has an outcome: passed VALIDATE/Iron-Gate/VERIFY  OR  failed + epistemic-repair trajectory
+   ▼
+[4a] DPO Pair Synthesizer (Body, $0)  ── failed AST node = REJECTED, repaired AST node = CHOSEN,
+   │                                      imports/boilerplate stripped, token-dense
+   ▼  async fire-and-forget (the Phase-1 Trinity bridge) → GCS dataset (.jsonl, pennies)
+   ▼
+[4b] Ephemeral GPU Hypervisor (cost-gated)  ── trigger: enough NEW pairs AND model-underperforming
+   │     → bid minimum-viable Spot GPU (L4 first) → reactor-core SFT/DPO → GGUF Q4_K_M
+   │     → push weights to GCS → SELF-DELETE (dead-man) the instant quant completes
+   ▼
+[4c] Zero-Downtime Neural Reload (J-Prime)  ── Ollama hot-swap: load new, drain old, no dropped DAG req
+   ▼  improved Qwen2.5-Coder-7B serving on the next failover
+```
+The flywheel spins on **normal DW operation** (every op yields a pair), but the GPU **only spins on demand** — see §5.
+
+---
+
+## 3. Phase 4a — Autonomous DPO Pair Synthesizer (Body, $0, build FIRST)
+`backend/core/ouroboros/governance/dpo_synthesizer.py` (pure, fail-soft).
+- **Source = the epistemic-repair trajectory** (we already generate it): a `(failed_candidate, epistemic_diff, repaired_candidate, test_outcome)` sequence. The synthesizer turns each *failed→passing* transition into a DPO pair. Also consumes DW→Claude escalations (Reactor already tags these).
+- **AST-node isolation (the operator constraint — no raw payload dumps):** use `ast_symbol_scoper.isolate_symbols` to extract ONLY the symbol(s) that changed between rejected and chosen. `REJECTED` = the failed symbol body; `CHOSEN` = the repaired symbol body. Strip irrelevant global imports/boilerplate/unrelated symbols via an AST keep-list (the symbol + its directly-referenced names), reusing the egress interceptor's `estimate_body_chars` to keep each pair under a token-density cap (`JARVIS_DPO_PAIR_MAX_CHARS`, default ~2KB). A pair that can't be isolated cleanly is dropped (quality over quantity), logged — never a raw dump.
+- **`DPOPair` shape** matches reactor-core's `dpo_pair_generator` export (`prompt, chosen, rejected, metadata{signature, task_type, source}`) so Reactor ingests it natively — NO new schema on the Nerves side.
+- **Export:** async fire-and-forget on the existing Phase-1 Trinity bridge pattern (`emit_*` → `asyncio.create_task`, strong-ref, swallow-all) → append to a local bounded JSONL ring AND (gated) a GCS object. Body's live path NEVER blocks on it. Gated `JARVIS_DPO_SYNTHESIS_ENABLED` (default true; OFF → no-op).
+- **Dedup + density:** content-hash dedup (a recurring same fix isn't re-emitted); only `is_trainable`-quality pairs (real test-verified chosen). Bounded ring (`JARVIS_DPO_DATASET_MAX`, default 5000).
+- **Cost: $0** (in-process) + GCS storage: 5000 pairs × ~2KB ≈ 10MB ≈ **<$0.01/mo**.
+
+## 4. Phase 4b — Ephemeral GPU Hypervisor + Dead-Man's Switch (cost-gated; the bill guardrail)
+`backend/core/ouroboros/governance/rsi_training_hypervisor.py` — the cost-control wrapper Reactor lacks. Reuses the failover node's EXACT discipline.
+- **Demand-aware trigger (no wasteful runs):** train ONLY when BOTH (a) `new_pairs_since_last_train >= JARVIS_RSI_MIN_NEW_PAIRS` (default 2000 — amortize the GPU cost over enough data) AND (b) a **demand signal**: recent J-Prime failover generations underperformed (failure-rate over a window) OR `JARVIS_RSI_FORCE_TRAIN`. **Rationale: J-Prime is rarely active (failover-only), so a fine-tune that isn't needed is pure cost — don't train an idle, adequate model.** This is the single biggest cost lever.
+- **Minimum-viable Spot GPU bid:** a dynamic provisioner sizes the GPU to the dataset — `L4` (g2-standard-4, ~$0.20-0.30/hr Spot) for the default 7B-QLoRA on ≤ a few-thousand pairs; escalate to `A100` only if dataset/seq-len demands it (env thresholds, NOT hardcoded). **Spot-first** (`provisioning_model=SPOT`, `instance_termination_action=DELETE`) — reuse `gcp_vm_manager`'s Spot path. On-demand fallback only if Spot capacity is unavailable AND the budget allows.
+- **Aggressive Dead-Man's Switch (the no-orphaned-A100 guarantee):** the node's startup-script (reuse `failover_deadman.build_deadman_startup_script` pattern) runs the reactor-core training as its workload, then **the instant GGUF quantization completes + weights are pushed to GCS, the node executes a metadata-SA-token Compute REST `DELETE` on itself** — no idle GPU-seconds. PLUS an idle-timeout dead-man (training wedged/crashed → self-delete after `JARVIS_RSI_NODE_IDLE_TIMEOUT_S`) AND a hard `max_run_duration` cap (training overruns → GCP auto-deletes). Three independent teardowns, exactly like the failover node.
+- **Budget ceiling (hard):** reuse `IntelligentGCPOptimizer` `CostBudget` — a dedicated `JARVIS_RSI_MONTHLY_BUDGET_USD` (default **5.0** — i.e. ≤ $5/mo for ALL training) that BLOCKS a training launch if the month's RSI spend would exceed it. A launch is refused (logged, deferred) when the budget is exhausted — never silently overrun.
+- **Observed-gated, fail-soft:** a provision/train/push failure → self-delete + retry-next-trigger; the existing J-Prime model stays in place (no broken deploy). Gated `JARVIS_RSI_TRAINING_ENABLED` (default **FALSE** — the GPU tier stays OFF until the operator flips it after reviewing accumulated data + this cost model). OFF → no GPU ever provisions.
+
+## 5. COST MODEL (the load-bearing section)
+| Component | Billing | Frequency | ~Cost |
+|---|---|---|---|
+| 4a data collection | in-process, $0 | every op | **$0** |
+| 4a dataset storage (GCS) | ~10MB | continuous | **<$0.01/mo** |
+| 4b GPU training burst (L4 Spot, 7B QLoRA, ~2k pairs) | ~$0.25/hr × 1-3hr | **demand-gated** | **~$0.30-0.90/run** |
+| 4b (A100 Spot, only if escalated) | ~$1.20/hr × 2hr | rare | ~$2.40/run |
+| 4b weights→GCS + model storage | ~2GB GGUF | per run | **~$0.05/mo** |
+| 4c hot-swap | runs on existing J-Prime node | per deploy | **$0** |
+| **Hard ceiling** | `JARVIS_RSI_MONTHLY_BUDGET_USD` | — | **≤ $5/mo, enforced** |
+
+**Realistic steady-state: ~$0-2/mo.** Because (1) data collection is free; (2) the GPU is demand-gated — J-Prime is failover-only, so training is *infrequent* (maybe 0-2 runs/month, often zero if no failovers exercised the model); (3) L4-first + Spot + dead-man self-delete means each run is sub-dollar and leaves zero idle GPU; (4) the $5/mo hard cap is a backstop, not the expected spend. **Worst case is bounded at $5/mo by construction; expected is near-zero.** No persistent GPU, ever.
+
+**Cost kill-switches (all default-safe):** `JARVIS_RSI_TRAINING_ENABLED=false` (GPU tier fully off — the default) · `JARVIS_RSI_MONTHLY_BUDGET_USD` (hard cap) · `JARVIS_RSI_MIN_NEW_PAIRS` (amortization floor) · demand-gate (don't train an adequate model) · Spot-first + dead-man + max_run_duration (no orphan).
+
+## 6. Phase 4c — Zero-Downtime Neural Reload (J-Prime)
+Triggered by reactor-core's existing `model_ready` Trinity event after deploy.
+- **Ollama-native hot-swap (no hard reboot):** load the new GGUF as a new model tag, warm it (reuse the `LocalPrimeClient.warmup` 1-token gen — Phase-3 primitive), then atomically flip the `current` pointer the `LocalPrimeClient` resolves; the old model is unloaded from memory only AFTER in-flight requests drain. Incoming O+V DAG requests are served by old-or-new throughout — never dropped/erroring.
+- **Drain-before-unload + rollback:** a request-counter gate (no unload while requests in flight); if the new model fails its warmup/DeploymentGate inference check, **keep the old model** (no flip) and log — a bad fine-tune never degrades the failover. Reuse the existing DeploymentGate verdict.
+- **Spans the jarvis-prime repo** (the listener) — a cross-repo change; this spec defines the Body/Reactor contract + the J-Prime-side requirement.
+
+## 7. Cross-cutting / Invariants
+- **Bill-low-by-construction:** GPU tier default-OFF; demand+volume gated; Spot+dead-man+budget-cap; data/storage near-free. The expected bill is ~$0; the enforced ceiling is $5/mo.
+- **Fail-soft + OFF byte-identical:** every phase gated; OFF = today's behavior (no synthesis, no GPU, no hot-swap). Any error → the existing model/path stays; the live O+V DAG is never blocked or degraded.
+- **Reuse-first:** epistemic trajectory + isolate_symbols + egress compression (4a); failover_deadman + gcp_vm_manager + SA-self-delete + IntelligentGCPOptimizer (4b); reactor-core trainer/quant/deploy + Ollama API + warmup + DeploymentGate (4c). No duplication.
+- **No hardcoding:** GPU tier, budget, triggers, density caps all env. **Observed-gated:** train on demand+evidence, deploy on DeploymentGate-pass, never on a forecast alone.
+- **3-repo span (honest):** 4a = JARVIS (this repo); 4b = JARVIS provisioner wrapping reactor-core's training workload; 4c = jarvis-prime listener + the reactor-core deploy trigger. Build order isolates risk: 4a first ($0, self-contained here).
+
+## 8. Phasing / build order
+1. **4a (build FIRST, $0):** `dpo_synthesizer.py` + the bridge export + tests. Starts accumulating the dataset immediately from normal DW operation. NO GPU.
+2. **4b (build after 4a has data; GPU tier stays default-OFF):** `rsi_training_hypervisor.py` (demand+volume trigger, Spot-L4 bid, dead-man self-delete, budget cap) + the reactor-core training-workload wiring + tests. Operator flips `JARVIS_RSI_TRAINING_ENABLED` only after reviewing accumulated data + a dry-run cost estimate.
+3. **4c (build with/after 4b):** the J-Prime Ollama hot-swap listener (jarvis-prime repo) + drain/rollback + the Body-side reload trigger.
+4. **First real fine-tune burst:** operator-gated, budget-capped, on accumulated data — measured against the gauntlet (does the fine-tuned 7B thrash less on TTL-LRU/Paxos?).
+
+## 9. Tests (per phase)
+- **4a:** AST isolation maps failed-symbol→rejected + repaired-symbol→chosen; imports/boilerplate stripped; density cap enforced; pair shape matches reactor's DPO schema; dedup; fire-and-forget non-blocking + fail-soft; OFF → no-op; $0 (no network in the hot path).
+- **4b:** demand+volume trigger fires only when BOTH conditions met (not on data alone, not on an adequate model); L4 selected by default + A100 only above threshold; Spot-first + DELETE-on-preempt; dead-man self-delete script issues the SA-token REST DELETE on GGUF-complete; budget-cap BLOCKS launch when exhausted; max_run_duration set; OFF → no provision ever; fail-soft (provision/train fail → self-delete, existing model intact).
+- **4c:** hot-swap loads new + drains old with zero dropped requests (concurrent-request test); failed-warmup/gate → keep old (rollback); OFF → no swap.
+- **Cost guardrail (load-bearing):** a static test asserting the GPU tier cannot provision when `JARVIS_RSI_TRAINING_ENABLED=false`, cannot exceed the monthly budget, and every provision path sets Spot+DELETE+dead-man+max_run_duration (no un-capped launch reachable).
+
+## 10. Open decisions (for operator review of the cost model)
+1. **Monthly budget ceiling:** `JARVIS_RSI_MONTHLY_BUDGET_USD` default **5.0**. Lower? (Spec assumes $5/mo hard cap; expected spend ~$0-2.)
+2. **GPU tier default:** L4-first (cheapest viable) vs always-A100 (faster, ~4-8× cost). *Spec assumes L4-first, escalate-by-dataset.*
+3. **Train cadence trigger:** demand-gated (only when the failover model underperforms) vs pure-volume (every N pairs). *Spec assumes demand-AND-volume (cheapest — don't train an idle adequate model).*
+4. **GPU tier activation:** keep `JARVIS_RSI_TRAINING_ENABLED` default-OFF (operator flips after reviewing data) — recommended given the bill sensitivity. *Spec assumes default-OFF.*

--- a/tests/governance/test_dpo_synthesizer.py
+++ b/tests/governance/test_dpo_synthesizer.py
@@ -1,0 +1,430 @@
+"""tests/governance/test_dpo_synthesizer.py -- Phase 4a DPO Pair Synthesizer.
+
+Covers the Epistemic Purity gate (cognitive-vs-infra), the golden-ratio
+no-half-pairs gate, AST-symbol isolation + density cap, the reactor-core
+DPOPair schema match, and the fire-and-forget / fail-soft / dedup / bounded
+emit path. Uses fake trajectories (SimpleNamespace) -- NO real reactor-core,
+GCS, or network.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.dpo_synthesizer import (
+    DPOPair,
+    RepairTrajectory,
+    classify_rejection,
+    synthesize_pair,
+    emit_dpo_pair,
+    synthesize_and_emit,
+    _INFLIGHT_TASKS,
+)
+
+
+# ---------------------------------------------------------------------------
+# Source fixtures: a failed symbol and its repaired counterpart.
+# ---------------------------------------------------------------------------
+
+_FAILED_SRC = '''\
+import os
+import sys
+
+
+UNRELATED = 1
+
+
+def add(a, b):
+    return a - b
+
+
+def other_helper():
+    return 99
+'''
+
+_REPAIRED_SRC = '''\
+import os
+import sys
+
+
+UNRELATED = 1
+
+
+def add(a, b):
+    return a + b
+
+
+def other_helper():
+    return 99
+'''
+
+
+def _trajectory(
+    *,
+    resolved: bool = True,
+    failed_src: str = _FAILED_SRC,
+    repaired_src: str = _REPAIRED_SRC,
+    stderr: str = "E   assert 1 == 2\nE   AssertionError",
+    failure_source: str | None = None,
+    fsm_state: str | None = None,
+    prompt: str = "Fix the add function so it returns the sum",
+    changed_symbol_hint: str = "add",
+) -> RepairTrajectory:
+    return RepairTrajectory(
+        prompt=prompt,
+        failed_candidate_src=failed_src,
+        repaired_candidate_src=repaired_src if resolved else None,
+        resolved=resolved,
+        stderr=stderr,
+        failure_source=failure_source,
+        fsm_state=fsm_state,
+        failure_signature_hash="sig-abc123",
+        task_type="l2_repair",
+        changed_symbol_hint=changed_symbol_hint,
+        provider="doubleword",
+    )
+
+
+# ===========================================================================
+# (a) classify_rejection: cognitive KEEP vs infra DROP, unknown -> infra
+# ===========================================================================
+
+@pytest.mark.parametrize("stderr", [
+    "E   assert result == 3\nE   AssertionError",
+    "  File 'x.py', line 2\n    def add(\n          ^\nSyntaxError: invalid syntax",
+    "NameError: name 'foo' is not defined",
+    "TypeError: unsupported operand type(s)",
+    "ValueError: math domain error",
+])
+def test_classify_cognitive_keep(stderr):
+    assert classify_rejection(stderr=stderr, failure_source=None, fsm_state=None) == "cognitive"
+
+
+@pytest.mark.parametrize("failure_source", [
+    "fsm_exhausted",
+    "live_transport",
+    "live_http_5xx",
+    "generation_timeout",
+    "local_egress_overweight",
+])
+def test_classify_infra_by_failure_source(failure_source):
+    # Even with an assertion-shaped stderr, an infra failure_source must DROP.
+    assert classify_rejection(
+        stderr="E   AssertionError",
+        failure_source=failure_source,
+        fsm_state=None,
+    ) == "infra"
+
+
+@pytest.mark.parametrize("stderr", [
+    "aiohttp.ClientConnectorError: connection timeout to upstream",
+    "HTTP 503 Service Unavailable from provider",
+    "Aegis forward timeout after 60s",
+    "asyncio.TimeoutError",
+    "all_providers_exhausted:fallback_skipped",
+    "lane collapse: batch and realtime both timed out",
+])
+def test_classify_infra_by_stderr_shape(stderr):
+    assert classify_rejection(stderr=stderr, failure_source=None, fsm_state=None) == "infra"
+
+
+def test_classify_infra_by_fsm_state():
+    assert classify_rejection(
+        stderr="something ambiguous",
+        failure_source=None,
+        fsm_state="fsm_exhausted",
+    ) == "infra"
+
+
+def test_classify_unknown_drops_as_infra():
+    # Cannot confidently classify as cognitive -> fail-safe to infra (DROP).
+    assert classify_rejection(
+        stderr="totally opaque noise blah blah",
+        failure_source=None,
+        fsm_state=None,
+    ) == "infra"
+
+
+def test_classify_never_raises_on_garbage():
+    assert classify_rejection(stderr=None, failure_source=None, fsm_state=None) == "infra"  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# (b) golden-ratio: resolved -> pair; yielded (no chosen) -> None
+# ===========================================================================
+
+def test_resolved_trajectory_yields_pair():
+    pair = synthesize_pair(_trajectory(resolved=True))
+    assert pair is not None
+    assert isinstance(pair, DPOPair)
+
+
+def test_yielded_trajectory_returns_none():
+    # No repaired/chosen candidate (UNRESOLVABLE PATH / pivot) -> drop whole pair.
+    assert synthesize_pair(_trajectory(resolved=False, repaired_src=None)) is None
+
+
+def test_missing_failed_candidate_returns_none():
+    traj = _trajectory()
+    traj = RepairTrajectory(
+        prompt=traj.prompt,
+        failed_candidate_src="",
+        repaired_candidate_src=traj.repaired_candidate_src,
+        resolved=True,
+        stderr=traj.stderr,
+        failure_source=None,
+        fsm_state=None,
+    )
+    assert synthesize_pair(traj) is None
+
+
+def test_identical_candidates_returns_none():
+    # No actual change between rejected and chosen -> nothing to learn.
+    assert synthesize_pair(_trajectory(repaired_src=_FAILED_SRC)) is None
+
+
+# ===========================================================================
+# (c) purity: infra-caused rejection -> None even with a chosen present
+# ===========================================================================
+
+def test_infra_rejection_dropped_despite_chosen():
+    traj = _trajectory(resolved=True, failure_source="live_transport")
+    assert synthesize_pair(traj) is None
+
+
+def test_fsm_exhausted_rejection_dropped():
+    traj = _trajectory(resolved=True, stderr="all_providers_exhausted:no_fallback_configured")
+    assert synthesize_pair(traj) is None
+
+
+# ===========================================================================
+# (d) AST isolation: only the changed symbol, imports stripped, density cap
+# ===========================================================================
+
+def test_isolation_extracts_only_changed_symbol():
+    pair = synthesize_pair(_trajectory())
+    assert pair is not None
+    # The changed symbol is `add`. Its bodies must be present...
+    assert "def add" in pair.rejected
+    assert "def add" in pair.chosen
+    assert "return a - b" in pair.rejected
+    assert "return a + b" in pair.chosen
+    # ...and unrelated symbols / imports must be stripped.
+    assert "import os" not in pair.rejected
+    assert "import sys" not in pair.chosen
+    assert "other_helper" not in pair.rejected
+    assert "UNRELATED" not in pair.chosen
+
+
+def test_density_cap_drops_irreducible_oversize():
+    big_body = "    x = 'A' * 10\n" * 5000  # irreducibly huge symbol body
+    failed = f"def add(a, b):\n{big_body}    return a - b\n"
+    repaired = f"def add(a, b):\n{big_body}    return a + b\n"
+    traj = _trajectory(failed_src=failed, repaired_src=repaired)
+    os.environ["JARVIS_DPO_PAIR_MAX_CHARS"] = "2048"
+    try:
+        assert synthesize_pair(traj) is None
+    finally:
+        os.environ.pop("JARVIS_DPO_PAIR_MAX_CHARS", None)
+
+
+def test_isolation_failure_returns_none():
+    # Unparseable source -> cannot isolate -> drop (no raw dump).
+    traj = _trajectory(failed_src="def add( <<<broken", repaired_src="def add( <<<broken2")
+    assert synthesize_pair(traj) is None
+
+
+# ===========================================================================
+# (e) DPOPair shape matches reactor-core's schema
+# ===========================================================================
+
+def test_dpopair_shape_matches_reactor_schema():
+    pair = synthesize_pair(_trajectory())
+    assert pair is not None
+    d = pair.to_dict()
+    # reactor-core dpo_pair_generator.DPOPair.to_dict keys
+    for key in (
+        "prompt", "chosen", "rejected", "chosen_model", "rejected_model",
+        "chosen_score", "rejected_score", "task_type", "generation_method",
+        "metadata",
+    ):
+        assert key in d, f"missing key {key}"
+    assert d["metadata"]["source"] == "ouroboros_epistemic_repair"
+    assert d["metadata"]["signature"] == "sig-abc123"
+    assert d["task_type"] == "l2_repair"
+
+
+# ===========================================================================
+# (f) emit: fire-and-forget non-blocking, fail-soft, dedup, bounded, OFF no-op
+# ===========================================================================
+
+def _ring_path(tmp_path):
+    return str(tmp_path / "dpo_dataset.jsonl")
+
+
+def test_emit_appends_to_ring(tmp_path, monkeypatch):
+    path = _ring_path(tmp_path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", path)
+    pair = synthesize_pair(_trajectory())
+    assert pair is not None
+
+    async def _run():
+        emit_dpo_pair(pair)
+        await asyncio.gather(*list(_INFLIGHT_TASKS)) if _INFLIGHT_TASKS else None
+
+    asyncio.run(_run())
+    with open(path, encoding="utf-8") as fh:
+        lines = [ln for ln in fh if ln.strip()]
+    assert len(lines) == 1
+    rec = json.loads(lines[0])
+    assert rec["metadata"]["source"] == "ouroboros_epistemic_repair"
+
+
+def test_emit_dedup_content_hash(tmp_path, monkeypatch):
+    path = _ring_path(tmp_path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", path)
+    pair = synthesize_pair(_trajectory())
+
+    async def _run():
+        for _ in range(3):
+            emit_dpo_pair(pair)
+            if _INFLIGHT_TASKS:
+                await asyncio.gather(*list(_INFLIGHT_TASKS))
+
+    asyncio.run(_run())
+    with open(path, encoding="utf-8") as fh:
+        lines = [ln for ln in fh if ln.strip()]
+    assert len(lines) == 1  # dedup -> only one
+
+
+def test_emit_bounded_ring(tmp_path, monkeypatch):
+    path = _ring_path(tmp_path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_MAX", "3")
+
+    async def _run():
+        for i in range(6):
+            # Distinct prompts -> distinct content hashes (no dedup collapse).
+            pair = synthesize_pair(_trajectory(prompt=f"fix add variant {i}"))
+            assert pair is not None
+            emit_dpo_pair(pair)
+            if _INFLIGHT_TASKS:
+                await asyncio.gather(*list(_INFLIGHT_TASKS))
+
+    asyncio.run(_run())
+    with open(path, encoding="utf-8") as fh:
+        lines = [ln for ln in fh if ln.strip()]
+    assert len(lines) == 3  # bounded
+
+
+def test_emit_no_running_loop_is_noop(tmp_path, monkeypatch):
+    path = _ring_path(tmp_path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", path)
+    pair = synthesize_pair(_trajectory())
+    # No running loop -> no-op, never raises.
+    emit_dpo_pair(pair)
+    assert not os.path.exists(path)
+
+
+def test_emit_failsoft_on_bad_path(monkeypatch):
+    # An unwritable path must never raise into the caller.
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", "/proc/cannot/write/here.jsonl")
+    pair = synthesize_pair(_trajectory())
+
+    async def _run():
+        emit_dpo_pair(pair)  # must not raise
+        if _INFLIGHT_TASKS:
+            await asyncio.gather(*list(_INFLIGHT_TASKS))
+
+    asyncio.run(_run())  # no exception escapes
+
+
+def test_synthesis_disabled_off_noop(tmp_path, monkeypatch):
+    path = _ring_path(tmp_path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", path)
+    monkeypatch.setenv("JARVIS_DPO_SYNTHESIS_ENABLED", "false")
+
+    async def _run():
+        emitted = synthesize_and_emit(_trajectory())
+        if _INFLIGHT_TASKS:
+            await asyncio.gather(*list(_INFLIGHT_TASKS))
+        return emitted
+
+    emitted = asyncio.run(_run())
+    assert emitted is False
+    assert not os.path.exists(path)
+
+
+# ===========================================================================
+# (g) synthesize_and_emit only on resolved repairs, fail-soft
+# ===========================================================================
+
+def test_synthesize_and_emit_resolved_true(tmp_path, monkeypatch):
+    path = _ring_path(tmp_path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", path)
+
+    async def _run():
+        emitted = synthesize_and_emit(_trajectory(resolved=True))
+        if _INFLIGHT_TASKS:
+            await asyncio.gather(*list(_INFLIGHT_TASKS))
+        return emitted
+
+    assert asyncio.run(_run()) is True
+    assert os.path.exists(path)
+
+
+def test_synthesize_and_emit_yielded_false(tmp_path, monkeypatch):
+    path = _ring_path(tmp_path)
+    monkeypatch.setenv("JARVIS_DPO_DATASET_PATH", path)
+
+    async def _run():
+        emitted = synthesize_and_emit(_trajectory(resolved=False, repaired_src=None))
+        if _INFLIGHT_TASKS:
+            await asyncio.gather(*list(_INFLIGHT_TASKS))
+        return emitted
+
+    assert asyncio.run(_run()) is False
+    assert not os.path.exists(path)
+
+
+def test_synthesize_and_emit_never_raises():
+    # Pass garbage; must fail-soft to False, never raise.
+    assert synthesize_and_emit(SimpleNamespace()) is False  # type: ignore[arg-type]
+
+
+# ===========================================================================
+# from_repair adapter: extracts trajectory from live ctx/result objects
+# ===========================================================================
+
+def test_from_repair_extracts_resolved():
+    ctx = SimpleNamespace(
+        op_id="op-1",
+        generation=SimpleNamespace(candidates=[{"full_content": _FAILED_SRC, "file_path": "m.py"}]),
+        signal=SimpleNamespace(description="Fix add"),
+    )
+    result = SimpleNamespace(
+        terminal="L2_CONVERGED",
+        candidate={"full_content": _REPAIRED_SRC, "file_path": "m.py"},
+        iterations=(SimpleNamespace(failure_class="test", provider_name="doubleword"),),
+        summary={},
+        failure_signature_hash="sig-xyz",
+        stderr_tail="E   AssertionError",
+        stop_reason=None,
+    )
+    traj = RepairTrajectory.from_repair(ctx, result)
+    assert traj is not None
+    assert traj.resolved is True
+    assert traj.failed_candidate_src == _FAILED_SRC
+    assert traj.repaired_candidate_src == _REPAIRED_SRC
+    pair = synthesize_pair(traj)
+    assert pair is not None
+
+
+def test_from_repair_non_converged_returns_none():
+    ctx = SimpleNamespace(op_id="op-2", generation=None, signal=None)
+    result = SimpleNamespace(terminal="L2_PIVOT", candidate=None, iterations=(), summary={})
+    assert RepairTrajectory.from_repair(ctx, result) is None


### PR DESCRIPTION
Phase 4a of the Sovereign RSI Flywheel (spec: `docs/superpowers/specs/2026-06-23-sovereign-rsi-flywheel-phase4.md`, costed ~$0-2/mo, $5/mo hard cap). **$0 / no-GPU** — turns O+V's own epistemic-repair trajectories into token-dense DPO preference pairs for the (later, operator-gated) reactor-core fine-tune of the J-Prime failover coder.

**`dpo_synthesizer.py`** — converts each test-verified `failed→repaired` transition into a `DPOPair` (schema-matched to reactor-core's `dpo_pair_generator` — no new Nerves schema). Wired fail-soft at the repair-completion seam (`orchestrator._l2_hook`, L2_CONVERGED + candidate present).

**Epistemic Purity gate (the operator constraint):**
- **Cognitive-vs-infra isolation:** `classify_rejection` DROPs pairs whose REJECTED failed due to infra (Aegis/network timeout, `fsm_exhausted`, 503/5xx, transport, GENERATION_TIMEOUT — reusing `dw_fault_taxonomy` + `FailureSource`); KEEPs only true cognitive failures (pytest assertion, syntax, logical). **Fails SAFE: unknown → infra → DROP.** We never train on DoubleWord's infra problems.
- **Golden-ratio (no half-pairs):** requires BOTH a failed AND a test-verified repaired state; a trajectory that YIELDED (UNRESOLVABLE PATH, no chosen) → dropped entirely. Only complete, proven resolutions.
- **Token-dense:** AST-isolates only the changed symbol (rejected/chosen bodies), strips imports/boilerplate, density-capped (`JARVIS_DPO_PAIR_MAX_CHARS` 2048); no raw dumps.

Async fire-and-forget export mirrors the Phase-1 Trinity bridge (never blocks the DAG); bounded `.jarvis/dpo_dataset.jsonl` ring + sha256 dedup; GCS publish gated default-OFF. `JARVIS_DPO_SYNTHESIS_ENABLED` default-on, OFF byte-identical. 40 tests. GPU tier (4b) stays unbuilt/default-OFF per spec §8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autonomous DPO pair synthesizer that turns test-verified failed→repaired code trajectories into token‑dense preference pairs with an Epistemic Purity gate, wired into the L2 orchestrator seam. Pairs are written to a bounded local JSONL ring with sha256 dedup and optional Trinity/GCS publish; the path is fail‑soft and non‑blocking.

- **New Features**
  - `dpo_synthesizer.py`: builds `DPOPair` records (reactor-core schema) by AST‑isolating the changed symbol; per‑side cap via `JARVIS_DPO_PAIR_MAX_CHARS` (default 2048).
  - Epistemic Purity gate: drops infra-caused failures using `dw_fault_taxonomy`/stderr markers; “golden ratio” requires both failed and repaired states; ambiguous → drop.
  - Orchestrator hook: runs at `_l2_hook` after `L2_CONVERGED`; gated by `JARVIS_DPO_SYNTHESIS_ENABLED` (default true); never blocks or raises.
  - Async export: appends to `.jarvis/dpo_dataset.jsonl` with ring size `JARVIS_DPO_DATASET_MAX` (default 5000) and content-hash dedup; optional publish via `JARVIS_DPO_GCS_EXPORT_ENABLED` (default false). Added spec at `docs/superpowers/specs/...` and tests covering gates, isolation, density, and emit path.

- **Migration**
  - No action required; synthesis is on by default and is fail‑soft. GPU training (Phase 4b) remains off.
  - To publish externally, set `JARVIS_DPO_GCS_EXPORT_ENABLED=true`. Tune `JARVIS_DPO_DATASET_MAX` and `JARVIS_DPO_PAIR_MAX_CHARS` as needed.

<sup>Written for commit ffec62cef7d5125a57358a2ba5bbca1f84328bcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69677?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

