### PR TITLE
feat: Cross-Repo Mutator — Master Arming Switch + G1/G2 wiring + blast visualizer + first-surgery proof (master flag default-OFF)

### DIFF
--- a/backend/core/ouroboros/governance/cross_repo_master_flag.py
+++ b/backend/core/ouroboros/governance/cross_repo_master_flag.py
@@ -1,0 +1,491 @@
+"""cross_repo_master_flag -- Master Arming Switch for the Sovereign Cross-Repo Mutator.
+
+Consumer-facing gate for ``JARVIS_CROSS_REPO_MUTATION_ENABLED``. Default OFF --
+byte-identical to today. The flag only arms when an explicit-truthy token is set
+AND a startup handshake confirms the sandbox environment is ready (Docker alive +
+egress sinkhole configurable). Any uncertainty degrades gracefully to DISABLED
+(fail-CLOSED).
+
+Spec reference: docs/superpowers/specs/2026-06-23-sovereign-cross-repo-mutator.md
+section 6 (Cross-cutting / Invariants) -- ``master JARVIS_CROSS_REPO_MUTATION_ENABLED
+(default OFF) -- else Body-only (today)``.
+
+Design invariants (fail-CLOSED everywhere):
+  * **Garbage / falsy does NOT arm.** Only ``value.strip().lower() in
+    {"1","true","yes","on"}`` sets ``flag_set=True``. Unset / garbage / any other
+    value -> ``flag_set=False -> armed=False`` immediately.  This is the INVERSE of
+    ``critical_elevation.is_critical_elevation_enabled()`` which fails CLOSED to
+    ENABLED (jarvis hard-halt); here the master WRITE flag only arms on explicit
+    truthy (fail-CLOSED means: unrecognised garbage does NOT grant write permission).
+  * **Both Docker alive AND sinkhole configurable are required.** If either check
+    fails, ``armed=False`` + ``reason="degraded: <which check failed>"``.
+  * **Fail-soft on any handshake error.** Any exception -> ``armed=False``, never
+    propagates.  We log at WARNING so the operator sees the problem.
+  * **Caching is on by default.** The handshake runs once (at first call to
+    ``cross_repo_mutation_enabled()``) and the result is cached for the process
+    lifetime.  Set ``JARVIS_CROSS_REPO_HANDSHAKE_CACHE=0`` to re-evaluate on every
+    call (useful in tests).
+
+Env knobs:
+  * ``JARVIS_CROSS_REPO_MUTATION_ENABLED`` (default unset/OFF) -- master arm flag.
+  * ``JARVIS_CROSS_REPO_HANDSHAKE_CACHE`` (default 1) -- ``0`` disables caching.
+
+Injectable runner interface (``HandshakeRunner`` protocol):
+  * ``async docker_info() -> RunResult``
+  * ``async can_render_airgap() -> bool``
+Tests inject a ``_FakeRunner``; the real ``_DefaultRunner`` calls Docker.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, Optional, Protocol
+
+logger = logging.getLogger("Ouroboros.CrossRepoMasterFlag")
+
+# ---------------------------------------------------------------------------
+# Env knobs
+# ---------------------------------------------------------------------------
+_ENV_FLAG = "JARVIS_CROSS_REPO_MUTATION_ENABLED"
+_ENV_CACHE = "JARVIS_CROSS_REPO_HANDSHAKE_CACHE"
+
+# Only these tokens arm the master flag (explicit-truthy only).
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+# ---------------------------------------------------------------------------
+# Module-level cache (None = not yet evaluated)
+# ---------------------------------------------------------------------------
+_cached_handshake: Optional["ArmingHandshake"] = None
+
+
+# ---------------------------------------------------------------------------
+# Lightweight result type for runner calls
+# ---------------------------------------------------------------------------
+@dataclass
+class RunResult:
+    """Result of a single runner invocation (mirrors trinity_integration_gate)."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+# ---------------------------------------------------------------------------
+# Runner protocol -- all Docker/subprocess lives behind this boundary
+# ---------------------------------------------------------------------------
+class HandshakeRunner(Protocol):
+    """Injectable boundary around Docker/subprocess for the arming handshake.
+
+    Tests provide a fake implementation that records calls and returns scripted
+    results -- so the test-suite touches no real Docker.
+    """
+
+    async def docker_info(self) -> RunResult:
+        """Run ``docker info`` (or equivalent). ``returncode == 0`` => alive."""
+        ...
+
+    async def can_render_airgap(self) -> bool:
+        """Return True iff the egress-sinkhole compose overlay can be rendered
+        (pure logic from ``trinity_integration_gate.build_airgap_compose``).
+
+        The real implementation calls ``build_airgap_compose`` with a trivial
+        config and asserts the rendered YAML contains ``internal: true`` and the
+        egress-mock service.  On any error it returns False (fail-CLOSED).
+        """
+        ...
+
+
+class _DefaultRunner:
+    """Real runner: calls ``docker info`` via subprocess.
+
+    Lazy-import of subprocess so the module imports clean in
+    test/sandbox environments without Docker.
+    """
+
+    async def docker_info(self) -> RunResult:
+        def _call() -> RunResult:
+            import subprocess  # noqa: PLC0415 - lazy
+            try:
+                proc = subprocess.run(
+                    ["docker", "info"],
+                    capture_output=True,
+                    text=True,
+                    timeout=10.0,
+                )
+                return RunResult(proc.returncode, proc.stdout or "", proc.stderr or "")
+            except Exception as exc:
+                return RunResult(returncode=1, stdout="", stderr=str(exc))
+        return await asyncio.to_thread(_call)
+
+    async def can_render_airgap(self) -> bool:
+        """Attempt to render a trivial air-gap compose overlay and verify it is
+        internally-networked.  Pure logic -- no Docker calls, no disk I/O beyond
+        a temp file the gate already handles.  Returns True iff the rendered YAML
+        has ``internal: true`` AND the egress-mock service.
+        """
+        try:
+            from backend.core.ouroboros.governance.saga.trinity_integration_gate import (  # noqa: E501
+                _rendered_overlay_is_air_gapped,
+                _provider_url_overrides,
+                EGRESS_MOCK_SERVICE,
+            )
+            # Build a minimal overlay in memory (no real compose file needed).
+            # We exercise the pure render path directly.
+            try:
+                import yaml  # type: ignore
+            except ImportError:
+                # PyYAML absent -- cannot verify the overlay; degrade gracefully.
+                logger.debug(
+                    "[CrossRepoMasterFlag] PyYAML absent -- sinkhole check degraded"
+                )
+                return False
+
+            net = "trinity_sandbox_net"
+            port = 8099
+            overrides = _provider_url_overrides(mock_port=port)
+            base_svc = {
+                "jarvis": {"image": "python:3.11-slim", "environment": {}, "networks": [net]},
+            }
+            out_services: Dict[str, Any] = {}
+            for name, svc in base_svc.items():
+                svc = dict(svc)
+                env = dict(svc.get("environment") or {})
+                env.update(overrides)
+                svc["environment"] = env
+                svc["networks"] = [net]
+                out_services[name] = svc
+            # Add egress-mock service (mirrors build_airgap_compose).
+            out_services[EGRESS_MOCK_SERVICE] = {
+                "image": "python:3.11-slim",
+                "container_name": "trinity_sandbox_egress_mock",
+                "environment": {"TRINITY_SANDBOX_EGRESS_PORT": str(port)},
+                "networks": [net],
+            }
+            overlay: Dict[str, Any] = {
+                "services": out_services,
+                "networks": {net: {"internal": True, "driver": "bridge"}},
+            }
+            overlay_yaml = yaml.safe_dump(overlay, sort_keys=False, default_flow_style=False)
+            # Verify it is air-gapped (pure static check).
+            return _rendered_overlay_is_air_gapped(overlay_yaml, network=net)
+        except Exception as exc:  # noqa: BLE001 -- fail-CLOSED
+            logger.debug(
+                "[CrossRepoMasterFlag] can_render_airgap raised: %s", exc, exc_info=True
+            )
+            return False
+
+
+def _make_default_runner() -> _DefaultRunner:
+    """Factory for the default runner. Injectable point for tests."""
+    return _DefaultRunner()
+
+
+# ---------------------------------------------------------------------------
+# ArmingHandshake -- the verdict dataclass
+# ---------------------------------------------------------------------------
+@dataclass
+class ArmingHandshake:
+    """Verdict of the arming handshake.
+
+    armed:               True iff flag_set AND docker_alive AND sinkhole_configurable.
+    flag_set:            JARVIS_CROSS_REPO_MUTATION_ENABLED is explicitly truthy.
+    docker_alive:        docker info returned rc==0.
+    sinkhole_configurable: can_render_airgap() returned True.
+    reason:              Short human-readable verdict string.
+    """
+
+    armed: bool
+    flag_set: bool
+    docker_alive: bool
+    sinkhole_configurable: bool
+    reason: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "armed": self.armed,
+            "flag_set": self.flag_set,
+            "docker_alive": self.docker_alive,
+            "sinkhole_configurable": self.sinkhole_configurable,
+            "reason": self.reason,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Core handshake logic
+# ---------------------------------------------------------------------------
+def _flag_set() -> bool:
+    """Return True iff JARVIS_CROSS_REPO_MUTATION_ENABLED is explicitly truthy.
+
+    Only {"1","true","yes","on"} (case-insensitive) arm the gate.
+    Unset / garbage / falsy tokens ("0","false","no","off", and ANYTHING else
+    including whitespace) -> False (fail-CLOSED: garbage does NOT grant write
+    permission).
+    """
+    raw = os.environ.get(_ENV_FLAG)
+    if raw is None:
+        return False
+    return raw.strip().lower() in _TRUTHY
+
+
+def _cache_enabled() -> bool:
+    """Return True iff the handshake result should be cached (default True)."""
+    raw = os.environ.get(_ENV_CACHE, "1").strip().lower()
+    return raw in _TRUTHY or raw not in frozenset({"0", "false", "no", "off"})
+
+
+async def run_arming_handshake(
+    *,
+    runner: Optional[HandshakeRunner] = None,
+) -> ArmingHandshake:
+    """Execute the Master Arming Switch handshake.
+
+    Logic (fail-CLOSED throughout):
+      1. ``flag_set``: JARVIS_CROSS_REPO_MUTATION_ENABLED explicitly truthy.
+         Unset / garbage / falsy -> flag_set=False -> armed=False immediately.
+      2. If flag_set: ``docker_alive`` = docker info returns rc==0.
+      3. If docker_alive: ``sinkhole_configurable`` = can_render_airgap().
+      4. ``armed = flag_set AND docker_alive AND sinkhole_configurable``.
+         If flag_set but either check fails -> armed=False, reason="degraded: ...".
+      5. Any exception -> armed=False (fail-soft / fail-CLOSED).
+
+    Parameters
+    ----------
+    runner:
+        Injectable HandshakeRunner. Defaults to ``_DefaultRunner()`` (real Docker).
+        Tests inject a fake to avoid real Docker calls.
+
+    Returns an :class:`ArmingHandshake`. NEVER raises.
+    """
+    # Step 1: flag check (no runner needed).
+    fs = _flag_set()
+    if not fs:
+        return ArmingHandshake(
+            armed=False,
+            flag_set=False,
+            docker_alive=False,
+            sinkhole_configurable=False,
+            reason="flag_not_set",
+        )
+
+    # Steps 2-3: sandbox environment checks.
+    if runner is None:
+        runner = _make_default_runner()
+
+    docker_alive = False
+    sinkhole_ok = False
+    try:
+        docker_res = await runner.docker_info()
+        docker_alive = docker_res.ok
+    except Exception as exc:  # noqa: BLE001 -- fail-CLOSED
+        logger.warning(
+            "[CrossRepoMaster] docker_info raised -> NOT armed: %s", exc, exc_info=True
+        )
+        return ArmingHandshake(
+            armed=False,
+            flag_set=True,
+            docker_alive=False,
+            sinkhole_configurable=False,
+            reason="error:docker_info_raised:%s" % exc,
+        )
+
+    if not docker_alive:
+        reason = "degraded:docker_not_alive"
+        logger.warning(
+            "[CrossRepoMaster] armed flag set but sandbox env not ready (%s)"
+            " -- DEGRADING to disabled", reason,
+        )
+        return ArmingHandshake(
+            armed=False,
+            flag_set=True,
+            docker_alive=False,
+            sinkhole_configurable=False,
+            reason=reason,
+        )
+
+    try:
+        sinkhole_ok = await runner.can_render_airgap()
+    except Exception as exc:  # noqa: BLE001 -- fail-CLOSED
+        logger.warning(
+            "[CrossRepoMaster] can_render_airgap raised -> NOT armed: %s",
+            exc, exc_info=True,
+        )
+        return ArmingHandshake(
+            armed=False,
+            flag_set=True,
+            docker_alive=True,
+            sinkhole_configurable=False,
+            reason="error:can_render_airgap_raised:%s" % exc,
+        )
+
+    if not sinkhole_ok:
+        reason = "degraded:sinkhole_not_configurable"
+        logger.warning(
+            "[CrossRepoMaster] armed flag set but sandbox env not ready (%s)"
+            " -- DEGRADING to disabled", reason,
+        )
+        return ArmingHandshake(
+            armed=False,
+            flag_set=True,
+            docker_alive=True,
+            sinkhole_configurable=False,
+            reason=reason,
+        )
+
+    # All checks passed.
+    return ArmingHandshake(
+        armed=True,
+        flag_set=True,
+        docker_alive=True,
+        sinkhole_configurable=True,
+        reason="armed",
+    )
+
+
+# ---------------------------------------------------------------------------
+# Consumer-facing API
+# ---------------------------------------------------------------------------
+def cross_repo_mutation_enabled() -> bool:
+    """Consumer-facing gate: returns True iff the master arm switch is armed.
+
+    Caches the handshake result for the process lifetime by default.
+    Set ``JARVIS_CROSS_REPO_HANDSHAKE_CACHE=0`` to re-evaluate on each call
+    (useful in tests).
+
+    Default (flag unset) -> False, byte-identical to today (Body-only).
+    NEVER raises.
+    """
+    global _cached_handshake
+
+    if _cache_enabled() and _cached_handshake is not None:
+        return _cached_handshake.armed
+
+    # Run the handshake synchronously (blocking) from a sync call site.
+    # The handshake is only called at first use (or when cache is disabled),
+    # so blocking briefly here is acceptable.
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            # Already inside an event loop (e.g. during async boot) -- use
+            # a new loop in a thread rather than nest event loops.
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                hs = pool.submit(
+                    lambda: asyncio.run(
+                        run_arming_handshake(runner=_make_default_runner())
+                    )
+                ).result()
+        else:
+            hs = loop.run_until_complete(
+                run_arming_handshake(runner=_make_default_runner())
+            )
+    except Exception as exc:  # noqa: BLE001 -- fail-CLOSED
+        logger.warning(
+            "[CrossRepoMaster] cross_repo_mutation_enabled raised -> False: %s",
+            exc, exc_info=True,
+        )
+        return False
+
+    if _cache_enabled():
+        _cached_handshake = hs
+
+    return hs.armed
+
+
+def arming_status() -> ArmingHandshake:
+    """Return the current arming status (for observability / startup logging).
+
+    Respects the cache: if the handshake has already been run and caching is
+    enabled, returns the cached result.  Otherwise runs the handshake now.
+    NEVER raises.
+    """
+    global _cached_handshake
+
+    if _cache_enabled() and _cached_handshake is not None:
+        return _cached_handshake
+
+    # Trigger evaluation via cross_repo_mutation_enabled() which handles
+    # both sync and async call sites.
+    cross_repo_mutation_enabled()
+
+    if _cached_handshake is not None:
+        return _cached_handshake
+
+    # Fallback (cache disabled or error): run a fresh handshake synchronously.
+    try:
+        loop = asyncio.get_event_loop()
+        if loop.is_running():
+            import concurrent.futures
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                hs = pool.submit(
+                    lambda: asyncio.run(
+                        run_arming_handshake(runner=_make_default_runner())
+                    )
+                ).result()
+        else:
+            hs = loop.run_until_complete(
+                run_arming_handshake(runner=_make_default_runner())
+            )
+        return hs
+    except Exception as exc:  # noqa: BLE001 -- fail-CLOSED
+        logger.warning(
+            "[CrossRepoMaster] arming_status raised -> NOT armed: %s",
+            exc, exc_info=True,
+        )
+        return ArmingHandshake(
+            armed=False,
+            flag_set=False,
+            docker_alive=False,
+            sinkhole_configurable=False,
+            reason="error:arming_status_raised:%s" % exc,
+        )
+
+
+def log_arming_status_on_boot() -> None:
+    """Emit the handshake verdict at boot (for startup observability).
+
+    Call once during boot; subsequent calls are cheap (uses cache).
+    NEVER raises.
+    """
+    try:
+        status = arming_status()
+        if status.armed:
+            logger.info(
+                "[CrossRepoMaster] ARMED -- cross-repo mutation enabled "
+                "(docker_alive=%s sinkhole_configurable=%s reason=%s)",
+                status.docker_alive,
+                status.sinkhole_configurable,
+                status.reason,
+            )
+        else:
+            logger.info(
+                "[CrossRepoMaster] NOT ARMED (disabled) -- "
+                "JARVIS_CROSS_REPO_MUTATION_ENABLED not explicitly truthy OR "
+                "sandbox env not ready (flag_set=%s docker_alive=%s "
+                "sinkhole_configurable=%s reason=%s)",
+                status.flag_set,
+                status.docker_alive,
+                status.sinkhole_configurable,
+                status.reason,
+            )
+    except Exception:  # noqa: BLE001 -- log-on-boot must never raise
+        logger.debug(
+            "[CrossRepoMaster] log_arming_status_on_boot raised (fail-soft)",
+            exc_info=True,
+        )
+
+
+__all__ = [
+    "ArmingHandshake",
+    "RunResult",
+    "HandshakeRunner",
+    "arming_status",
+    "cross_repo_mutation_enabled",
+    "log_arming_status_on_boot",
+    "run_arming_handshake",
+]

--- a/backend/core/ouroboros/governance/multi_repo/blast_radius_visualizer.py
+++ b/backend/core/ouroboros/governance/multi_repo/blast_radius_visualizer.py
@@ -1,0 +1,151 @@
+"""blast_radius_visualizer -- human-readable cross-repo blast-radius TREE.
+
+Guardrail-1 companion: renders the Oracle-traced cross-repo dependents of a
+mutation target as a lightweight ASCII dependency tree so the OPERATOR can SEE
+which Body (jarvis) / Mind (prime) files map to a mutated Nerves (reactor) (or
+Mind) symbol BEFORE approving the cross-repo PR.
+
+    CROSS-REPO BLAST RADIUS  (mutating reactor::TelemetryAdapter.emit)
+    reactor/telemetry_adapter.py::TelemetryAdapter.emit
+    └─ depended on by:
+       ├─ [jarvis] backend/.../foo.py::caller_a
+       └─ [prime]  jarvis_prime/.../baz.py::caller_c
+    <N> Body/Mind files mapped to this Nerves mutation.
+
+Design invariants:
+  * **Pure render, authority-free.** This module imports NOTHING from the
+    orchestrator / policy / change_engine / risk_tier layers. It takes a
+    ``BlastRadiusContext`` and returns a string. A source-grep test enforces the
+    no-authority-imports invariant.
+  * **ASCII box-drawing only.** Uses only the lightweight tree glyphs
+    ``|- `- |  ` (rendered here as the box-drawing chars below) -- no Unicode
+    beyond the four standard box-drawing codepoints; everything else is ASCII.
+  * **Capped.** At most ``JARVIS_BLAST_TREE_MAX_NODES`` (default 40) dependents
+    are drawn; the remainder is summarised as ``... +M more ...`` (never silently
+    dropped). No hardcoded cap.
+  * **Fail-soft.** Any rendering error returns ``""`` -- the visualizer is an
+    operator convenience, never load-bearing for safety.
+"""
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING, List
+
+if TYPE_CHECKING:  # avoid a runtime import cycle; pure type hint only
+    from backend.core.ouroboros.governance.multi_repo.cross_repo_blast_context import (
+        BlastRadiusContext,
+    )
+
+# Env knob (NO hardcoded cap).
+_MAX_NODES_ENV = "JARVIS_BLAST_TREE_MAX_NODES"
+_DEFAULT_MAX_NODES = 40
+
+# Box-drawing glyphs (the only non-ASCII codepoints, by design).
+_TEE = "├─ "  # |-
+_ELBOW = "└─ "  # `-
+_ROOT_ELBOW = "└─ "  # `-
+_PIPE = "│  "  # |
+_BLANK = "   "
+
+# Repo -> Trinity role label.
+_REPO_ROLE = {
+    "prime": "Mind",
+    "reactor": "Nerves",
+    "jarvis": "Body",
+}
+
+
+def _max_nodes() -> int:
+    try:
+        raw = os.environ.get(_MAX_NODES_ENV, "").strip()
+        if not raw:
+            return _DEFAULT_MAX_NODES
+        return max(1, int(raw))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_NODES
+
+
+def _role(repo: str) -> str:
+    return _REPO_ROLE.get(repo, repo)
+
+
+def render_blast_tree(ctx: "BlastRadiusContext") -> str:
+    """Render the cross-repo blast radius as an ASCII dependency tree.
+
+    Dependents are grouped by repo (deterministic alpha order) and capped at
+    ``JARVIS_BLAST_TREE_MAX_NODES``; the overflow is summarised as ``+M more``.
+
+    Returns ``""`` when there are no cross-repo dependents (nothing to show) or
+    on any rendering error (fail-soft).
+    """
+    try:
+        deps = list(getattr(ctx, "dependents", ()) or ())
+        if not deps:
+            return ""
+
+        target_repo = getattr(ctx, "target_repo", "") or ""
+        target_symbol = getattr(ctx, "target_symbol", "") or ""
+
+        cap = _max_nodes()
+        total = len(deps)
+
+        # Group by repo (deterministic order), preserving nearest-first order
+        # within each repo (the trace already ordered them).
+        by_repo: dict = {}
+        for d in deps:
+            by_repo.setdefault(getattr(d, "repo", "") or "", []).append(d)
+        ordered_repos = sorted(by_repo.keys())
+
+        lines: List[str] = []
+        # Header.
+        lines.append(
+            "CROSS-REPO BLAST RADIUS  (mutating %s::%s)"
+            % (target_repo or "?", target_symbol or "?")
+        )
+        # The mutated root node line.
+        lines.append("%s::%s" % (target_repo or "?", target_symbol or "?"))
+        lines.append("%sdepended on by:" % _ROOT_ELBOW)
+
+        drawn = 0
+        capped = False
+        # Render repo groups. We flatten into a single list of (repo, dep) so the
+        # last drawn entry across all groups gets the elbow connector.
+        flat: List = []
+        for repo in ordered_repos:
+            for d in by_repo[repo]:
+                flat.append(d)
+
+        # Apply the cap.
+        if total > cap:
+            flat = flat[:cap]
+            capped = True
+
+        n = len(flat)
+        for idx, d in enumerate(flat):
+            is_last = (idx == n - 1) and not capped
+            connector = _ELBOW if is_last else _TEE
+            repo = getattr(d, "repo", "") or "?"
+            file = getattr(d, "file", "") or "?"
+            symbol = getattr(d, "symbol", "") or "?"
+            lines.append(
+                "   %s[%s] %s::%s" % (connector, repo, file, symbol)
+            )
+            drawn += 1
+
+        if capped:
+            more = total - drawn
+            lines.append("   %s... +%d more ..." % (_ELBOW, more))
+
+        # Footer: how many Body/Mind files map to this mutation.
+        role = _role(target_repo)
+        lines.append(
+            "%d Body/Mind files mapped to this %s mutation."
+            % (total, role)
+        )
+
+        return "\n".join(lines)
+    except Exception:  # noqa: BLE001 -- pure operator convenience; never raise
+        return ""
+
+
+__all__ = ["render_blast_tree"]

--- a/backend/core/ouroboros/governance/multi_repo/cross_repo_wiring.py
+++ b/backend/core/ouroboros/governance/multi_repo/cross_repo_wiring.py
@@ -1,0 +1,223 @@
+"""cross_repo_wiring -- thin orchestrator-facing wiring for G1 + G2.
+
+Keeps the orchestrator diff MINIMAL: all the resolve/trace/render/gate logic
+lives here, the orchestrator just calls two coroutines.
+
+  * ``build_blast_context_block(ctx, ...)`` -- GENERATE-time. Resolve the
+    mutation target's Oracle ``NodeID``, trace the cross-repo blast radius (G1),
+    emit the operator-visible ASCII tree visualizer, and return the rendered
+    prompt block to prepend into the generation context. Fail-soft -> ``""``
+    (safety unaffected: the promoter + G3 immutable-Orange floor already elevate
+    the risk tier, so an empty blast block degrades context, not safety).
+
+  * ``run_apply_sandbox_gate(ctx, ...)`` -- APPLY-time. Run the air-gapped
+    Trinity integration sandbox gate (G2) and return its ``SandboxVerdict``. The
+    caller routes ``verdict.fracture`` into the existing saga abort + compensating
+    rollback (the FRACTURE yield is emitted INSIDE the gate).
+
+BOTH are no-ops (return a disabled sentinel) when ``cross_repo_mutation_enabled()``
+is False -- so when the master arming switch is OFF the path is BYTE-IDENTICAL to
+today.
+
+Design invariants:
+  * Gated behind the master arming switch (``cross_repo_mutation_enabled()``).
+  * Fail-soft on the GENERATE side (empty block), fail-CLOSED on the APPLY side
+    (the gate itself returns a FRACTURE verdict on any uncertainty).
+  * Reuse-only: Oracle, RepoRegistry, G1 (cross_repo_blast_context), G2
+    (trinity_integration_gate), the visualizer. No reimplementation.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+logger = logging.getLogger("Ouroboros.CrossRepoWiring")
+
+
+# --------------------------------------------------------------------------- #
+# Disabled sentinel verdict for the APPLY gate (master OFF -> no-op pass).
+# --------------------------------------------------------------------------- #
+def _disabled_sandbox_verdict() -> Any:
+    """A no-op PASS verdict used when the master switch is OFF.
+
+    Mirrors ``SandboxVerdict`` fields so the caller can treat it uniformly. When
+    the master switch is OFF the surrounding cross-repo path is itself gated off
+    (a real cross-repo op is never created), so a no-op pass here cannot silently
+    pass a real cross-repo mutation.
+    """
+    from backend.core.ouroboros.governance.saga.trinity_integration_gate import (
+        SandboxVerdict,
+    )
+
+    return SandboxVerdict(
+        passed=True,
+        fracture=False,
+        reason="master_disabled",
+        air_gapped=False,
+        handshake_ok=False,
+        containers=(),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# G1 -- blast-radius context block (GENERATE)
+# --------------------------------------------------------------------------- #
+def _resolve_target_node(ctx: Any, oracle: Any) -> Optional[Any]:
+    """Resolve the mutation target's Oracle ``NodeID`` from ctx (best-effort).
+
+    Strategy (first hit wins, deterministic):
+      1. nodes in the primary target file that match the target symbol name;
+      2. any node in the primary target file (the enclosing symbol);
+      3. a global name lookup of the target symbol.
+    Returns ``None`` when nothing resolves (caller fail-soft -> empty block).
+    """
+    try:
+        target_files = tuple(getattr(ctx, "target_files", ()) or ())
+        target_symbol = (getattr(ctx, "target_symbol", "") or "").strip()
+        primary_file = target_files[0] if target_files else ""
+
+        # (1)/(2) file-scoped lookup.
+        if primary_file and hasattr(oracle, "find_nodes_in_file"):
+            nodes = oracle.find_nodes_in_file(primary_file) or []
+            if target_symbol:
+                leaf = target_symbol.split(".")[-1]
+                for n in nodes:
+                    nm = getattr(n, "name", "") or ""
+                    if nm == target_symbol or nm.split(".")[-1] == leaf:
+                        return n
+            if nodes:
+                return nodes[0]
+
+        # (3) global name lookup.
+        if target_symbol and hasattr(oracle, "find_nodes_by_name"):
+            by_name = oracle.find_nodes_by_name(target_symbol) or []
+            if by_name:
+                return by_name[0]
+    except Exception:  # noqa: BLE001 -- resolution is best-effort
+        logger.debug("[CrossRepoWiring] target node resolution failed", exc_info=True)
+    return None
+
+
+async def build_blast_context_block(
+    ctx: Any,
+    *,
+    oracle: Any = None,
+    registry: Any = None,
+) -> str:
+    """Build the G1 cross-repo blast-radius prompt block for a cross-repo op.
+
+    Resolves the target ``NodeID``, traces the cross-repo blast radius, emits the
+    operator-visible ASCII tree (logger.info), and returns the rendered prompt
+    block to prepend into the generation context.
+
+    Returns ``""`` (fail-soft) when the master switch is OFF, the op is not
+    cross-repo, the oracle/registry are unavailable, or anything errors. An empty
+    block does NOT relax safety -- the promoter + immutable-Orange floor already
+    elevate the risk tier (fail-CLOSED at the floor, not here).
+    """
+    from backend.core.ouroboros.governance.cross_repo_master_flag import (
+        cross_repo_mutation_enabled,
+    )
+
+    if not cross_repo_mutation_enabled():
+        return ""
+
+    if not getattr(ctx, "cross_repo", False):
+        return ""
+
+    try:
+        # The oracle is injected by the orchestrator (``self._stack.oracle``);
+        # there is no module-level singleton to fall back to. The registry can
+        # be resolved from env when not injected.
+        if registry is None:
+            try:
+                from backend.core.ouroboros.governance.multi_repo.registry import (
+                    RepoRegistry,
+                )
+
+                registry = RepoRegistry.from_env()
+            except Exception:  # noqa: BLE001
+                registry = None
+
+        if oracle is None or registry is None:
+            logger.debug(
+                "[CrossRepoWiring] oracle/registry unavailable -- empty blast block"
+            )
+            return ""
+
+        from backend.core.ouroboros.governance.multi_repo.cross_repo_blast_context import (
+            trace_cross_repo_blast,
+        )
+
+        node = _resolve_target_node(ctx, oracle)
+        if node is None:
+            logger.debug("[CrossRepoWiring] no target node resolved -- empty block")
+            return ""
+
+        blast = await trace_cross_repo_blast(
+            target_node_id=node,
+            oracle=oracle,
+            registry=registry,
+        )
+
+        # Emit the operator-visible ASCII tree BEFORE approval (fail-soft).
+        try:
+            from backend.core.ouroboros.governance.multi_repo.blast_radius_visualizer import (
+                render_blast_tree,
+            )
+
+            tree = render_blast_tree(blast)
+            if tree:
+                logger.info("\n%s", tree)
+        except Exception:  # noqa: BLE001 -- visualizer is operator convenience
+            logger.debug("[CrossRepoWiring] visualizer failed", exc_info=True)
+
+        return blast.rendered_prompt_block or ""
+    except Exception:  # noqa: BLE001 -- fail-soft -> empty (floor still elevates)
+        logger.warning(
+            "[CrossRepoWiring] build_blast_context_block failed -- empty block "
+            "(risk floor still elevated by promoter)",
+            exc_info=True,
+        )
+        return ""
+
+
+# --------------------------------------------------------------------------- #
+# G2 -- air-gapped Trinity sandbox gate (APPLY)
+# --------------------------------------------------------------------------- #
+async def run_apply_sandbox_gate(
+    ctx: Any,
+    *,
+    candidate_root: str,
+    op_id: str,
+    runner: Any = None,
+) -> Any:
+    """Run the G2 air-gapped Trinity integration sandbox gate at APPLY time.
+
+    Returns a ``SandboxVerdict``. The caller routes ``verdict.fracture`` into the
+    existing saga abort + compensating rollback. When the master switch is OFF
+    this returns a no-op PASS sentinel (the cross-repo path is itself gated off).
+
+    Fail-CLOSED: the gate itself never raises and returns a FRACTURE verdict on
+    any uncertainty (Docker absent, air-gap unverifiable, handshake failure,
+    timeout). We surface that verdict unchanged.
+    """
+    from backend.core.ouroboros.governance.cross_repo_master_flag import (
+        cross_repo_mutation_enabled,
+    )
+
+    if not cross_repo_mutation_enabled():
+        return _disabled_sandbox_verdict()
+
+    from backend.core.ouroboros.governance.saga.trinity_integration_gate import (
+        run_trinity_sandbox_gate,
+    )
+
+    return await run_trinity_sandbox_gate(
+        candidate_root=candidate_root,
+        op_id=op_id,
+        runner=runner,
+    )
+
+
+__all__ = ["build_blast_context_block", "run_apply_sandbox_gate"]

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -973,6 +973,10 @@ class OperationContext:
     strategic_memory_fact_ids: Tuple[str, ...] = ()
     strategic_memory_prompt: str = ""
     strategic_memory_digest: str = ""
+    # Sovereign Cross-Repo Mutator G1 (2026-06-23): the Oracle-traced cross-repo
+    # blast-radius prompt block, stamped at GENERATE when ctx.cross_repo and the
+    # master arming switch is ON. Empty (default) -> byte-identical legacy.
+    cross_repo_blast_prompt: str = ""
     terminal_reason_code: str = ""
     # Slice 160 — non-fatal infrastructure-hook warning (e.g. pip install failed under
     # fail-soft). Carried forward so the op reaches the governance floor / COMPLETE and

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -4113,6 +4113,31 @@ class GovernedOrchestrator:
                 except Exception:  # noqa: BLE001 — promoter is additive; never break the pipeline
                     logger.debug("[CrossRepoPromoter] hook skipped", exc_info=True)
 
+                # ---- Cross-Repo Mutator G1: blast-radius context (GENERATE) ----
+                # If the promoter elevated the op to cross-repo AND the master
+                # arming switch is ON, trace the Oracle cross-repo dependents,
+                # emit the operator-visible ASCII blast tree, and inject the
+                # rendered prompt block into the generation context. Gated +
+                # fail-soft → "" when off / on any error (byte-identical; the
+                # promoter + immutable-Orange floor already elevate the tier).
+                try:
+                    from backend.core.ouroboros.governance.cross_repo_master_flag import (
+                        cross_repo_mutation_enabled,
+                    )
+                    if cross_repo_mutation_enabled() and ctx.cross_repo:
+                        from backend.core.ouroboros.governance.multi_repo.cross_repo_wiring import (
+                            build_blast_context_block,
+                        )
+                        _blast_block = await build_blast_context_block(
+                            ctx, oracle=getattr(self._stack, "oracle", None),
+                        )
+                        if _blast_block:
+                            ctx = dataclasses.replace(
+                                ctx, cross_repo_blast_prompt=_blast_block
+                            )
+                except Exception:  # noqa: BLE001 — additive; never break the pipeline
+                    logger.debug("[CrossRepoBlast] G1 hook skipped", exc_info=True)
+
                 # ---- Phase 2b: CONTEXT_EXPANSION ----
                 try:
                     expansion_deadline = datetime.now(tz=timezone.utc) + timedelta(
@@ -12693,6 +12718,67 @@ class GovernedOrchestrator:
                 self._record_canary_for_ctx(ctx, False, time.monotonic() - _t_saga)
                 await self._publish_outcome(ctx, OperationState.FAILED, verify_result.reason_code)
                 return ctx
+
+            # ---- Cross-Repo Mutator G2: air-gapped Trinity sandbox gate ----
+            # AFTER the existing CrossRepoVerifier (structure/compilation/
+            # integration) passes and BEFORE promoting the ephemeral branches,
+            # run the air-gapped Trinity integration sandbox. A FRACTURE (broken
+            # Body<->Mind<->Nerves handshake; the FRACTURE yield is emitted
+            # inside the gate) routes into the SAME compensating rollback the
+            # verify-failure path uses — the op is sealed/terminal, never
+            # half-applied across repos. Gated + fail-CLOSED (gate returns a
+            # FRACTURE on any uncertainty); no-op PASS when the master switch is
+            # OFF (byte-identical legacy).
+            try:
+                from backend.core.ouroboros.governance.cross_repo_master_flag import (
+                    cross_repo_mutation_enabled,
+                )
+                _g2_armed = cross_repo_mutation_enabled()
+            except Exception:  # noqa: BLE001
+                _g2_armed = False
+            if _g2_armed:
+                from backend.core.ouroboros.governance.multi_repo.cross_repo_wiring import (
+                    run_apply_sandbox_gate,
+                )
+                _sandbox_root = str(
+                    (repo_roots.get(ctx.primary_repo) if isinstance(repo_roots, dict) else None)
+                    or self._config.project_root
+                )
+                _verdict = await run_apply_sandbox_gate(
+                    ctx, candidate_root=_sandbox_root, op_id=ctx.op_id,
+                )
+                if getattr(_verdict, "fracture", False):
+                    logger.warning(
+                        "[Orchestrator] Cross-repo Trinity sandbox FRACTURE "
+                        "op=%s reason=%s — routing to compensating rollback",
+                        ctx.op_id, getattr(_verdict, "reason", "?"),
+                    )
+                    comp_ok = await strategy.compensate_after_verify_failure(
+                        saga_result=apply_result,
+                        patch_map=patch_map,
+                        op_id=ctx.op_id,
+                        reason_code="cross_repo_fracture",
+                    )
+                    ctx = ctx.advance(
+                        OperationPhase.POSTMORTEM,
+                        terminal_reason_code="cross_repo_fracture",
+                        rollback_occurred=comp_ok,
+                    )
+                    await self._record_ledger(
+                        ctx,
+                        OperationState.FAILED,
+                        {
+                            "reason": "cross_repo_fracture",
+                            "saga_id": apply_result.saga_id,
+                            "compensated": comp_ok,
+                            "sandbox_reason": getattr(_verdict, "reason", ""),
+                        },
+                    )
+                    self._record_canary_for_ctx(ctx, False, time.monotonic() - _t_saga)
+                    await self._publish_outcome(
+                        ctx, OperationState.FAILED, "cross_repo_fracture"
+                    )
+                    return ctx
 
             # B+ mode: promote ephemeral branches before declaring success
             promote_state, promoted_shas = await strategy.promote_all(

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -2806,6 +2806,14 @@ Rules:
     # an attention-mechanism interference problem, not an injection
     # problem. Moving the block to the tail + wrapping in the override
     # XML is the compensating response.
+    # Sovereign Cross-Repo Mutator G1: force the Oracle-traced cross-repo blast
+    # radius into the generation context so the model SEES every downstream
+    # symbol in a DIFFERENT repo that depends on what it is about to mutate.
+    # Empty (default / master OFF) -> byte-identical legacy.
+    _cross_repo_blast = getattr(ctx, "cross_repo_blast_prompt", "")
+    if isinstance(_cross_repo_blast, str) and _cross_repo_blast.strip():
+        parts.append(_cross_repo_blast.strip())
+
     _strategic_memory = getattr(ctx, "strategic_memory_prompt", "")
     if isinstance(_strategic_memory, str) and _strategic_memory.strip():
         parts.append(_strategic_memory.strip())

--- a/scripts/cross_repo_first_surgery.py
+++ b/scripts/cross_repo_first_surgery.py
@@ -1,0 +1,608 @@
+"""cross_repo_first_surgery.py -- "First Cross-Repo Surgery" chaos demonstration.
+
+A CONTROLLED-SCENARIO harness (NOT the full autonomous GLS loop) that drives the
+REAL Sovereign Cross-Repo Mutator machinery through a chaos-injected mutation to
+prove the FRACTURE -> rollback path. It exercises the real components on a temp
+two-repo fixture (jarvis + reactor) so an operator can WATCH the organism heal:
+
+    arming handshake  (real cross_repo_master_flag.run_arming_handshake -- Docker)
+        |
+    blast-radius trace + visualizer  (real cross_repo_blast_context.trace_cross_repo_blast
+        |                              + blast_radius_visualizer.render_blast_tree)
+        |
+    chaos candidate applied across both repos  (real SagaApplyStrategy.execute -- writes
+        |                                        the broken reactor file, preimage captured)
+        |
+    air-gapped sandbox gate -> FRACTURE  (real trinity_integration_gate.run_trinity_sandbox_gate
+        |                                  with an injected runner whose handshake FAILS)
+        |
+    compensating rollback  (real SagaApplyStrategy.compensate_after_verify_failure ->
+        |                    restores BOTH repos from preimage)
+        |
+    VERIFY: both files byte-identical to the pre-surgery snapshots.
+
+WHAT IS REAL vs SIMULATED (be honest -- see also the report artifact):
+  * REAL: SagaApplyStrategy multi-repo apply + compensating rollback (the actual
+    preimage-restore + git-add/restore logic, on real git repos in the temp dir).
+  * REAL: trinity_integration_gate.run_trinity_sandbox_gate decision logic, the
+    air-gap assertion, the FRACTURE verdict, and the
+    `[SOVEREIGN YIELD: CROSS-REPO FRACTURE]` emission.
+  * REAL: cross_repo_blast_context.trace_cross_repo_blast + render_blast_tree --
+    the Body file is genuinely traced as the dependent of the Nerves symbol.
+  * REAL: cross_repo_master_flag.run_arming_handshake (real `docker info` probe).
+  * SIMULATED (honestly, by necessity -- no real 3-repo docker-compose exists on
+    this host): the air-gapped Docker network + the broken-handshake detection are
+    provided by an injected ``_FractureRunner`` whose `health_handshake` returns a
+    non-zero rc -- EXACTLY as a real broken cross-repo contract would. The runner is
+    the injection seam the gate is DESIGNED for (DockerRunner protocol).
+  * SIMULATED: the Oracle blast graph is a small controlled fixture
+    (``_FixtureOracle``) returning a REAL ``BlastRadius`` whose dependent is the
+    real jarvis ``metrics_caller`` of the reactor symbol. The graph data is
+    fixture; the trace/visualizer machinery consuming it is real.
+
+Gated: does NOTHING unless ``JARVIS_CHAOS_INJECTOR_ENABLED`` is explicitly truthy.
+Fail-soft: any error is caught, reported, and the temp dir is always torn down.
+
+Run:  JARVIS_CHAOS_INJECTOR_ENABLED=1 python3 scripts/cross_repo_first_surgery.py --run
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import shutil
+import subprocess
+import sys
+import tempfile
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, List, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Repo import bootstrap (standalone script -> ensure repo root on sys.path)
+# --------------------------------------------------------------------------- #
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from backend.core.ouroboros.oracle import BlastRadius, NodeID, NodeType  # noqa: E402
+from backend.core.ouroboros.governance.multi_repo.registry import (  # noqa: E402
+    RepoConfig,
+    RepoRegistry,
+)
+from backend.core.ouroboros.governance.multi_repo.cross_repo_blast_context import (  # noqa: E402
+    trace_cross_repo_blast,
+)
+from backend.core.ouroboros.governance.multi_repo.blast_radius_visualizer import (  # noqa: E402
+    render_blast_tree,
+)
+from backend.core.ouroboros.governance.cross_repo_master_flag import (  # noqa: E402
+    ArmingHandshake,
+    run_arming_handshake,
+)
+from backend.core.ouroboros.governance.op_context import OperationContext  # noqa: E402
+from backend.core.ouroboros.governance.saga.saga_apply_strategy import (  # noqa: E402
+    SagaApplyStrategy,
+)
+from backend.core.ouroboros.governance.saga.saga_types import (  # noqa: E402
+    FileOp,
+    PatchedFile,
+    RepoPatch,
+    SagaTerminalState,
+)
+from backend.core.ouroboros.governance.saga.trinity_integration_gate import (  # noqa: E402
+    RunResult,
+    SandboxVerdict,
+    run_trinity_sandbox_gate,
+)
+
+
+_ENV_CHAOS = "JARVIS_CHAOS_INJECTOR_ENABLED"
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# The cross-repo dependency the surgery exercises:
+#   reactor/telemetry_adapter.py :: TelemetryAdapter.emit  (the mutated Nerves symbol)
+#       <- jarvis/metrics_caller.py :: record_metric        (the Body dependent)
+_REACTOR_FILE = "telemetry_adapter.py"
+_JARVIS_FILE = "metrics_caller.py"
+_TARGET_SYMBOL = "emit"
+_TARGET_CLASS = "TelemetryAdapter"
+
+# --------------------------------------------------------------------------- #
+# The fixture source -- a utility-grade telemetry adapter + a real Body caller.
+# --------------------------------------------------------------------------- #
+_REACTOR_ORIGINAL = '''"""reactor/telemetry_adapter.py -- utility-grade telemetry adapter (Nerves)."""
+from __future__ import annotations
+
+
+class TelemetryAdapter:
+    """Emits a single metric reading as a structured record."""
+
+    def emit(self, metric: str, value: float) -> dict:
+        """Return a structured telemetry record for `metric` = `value`."""
+        return {"metric": metric, "value": float(value), "unit": "raw"}
+'''
+
+# CHAOS: the method is renamed AND its signature drops `value`. The file still
+# COMPILES (ast.parse OK), so the earlier compilation gate passes -- but the
+# jarvis caller's `.emit("x", 1.0)` would now break the cross-repo handshake.
+# This is the right chaos to exercise the SANDBOX HANDSHAKE (a pure syntax error
+# would trip the compilation gate, never reaching G2).
+_REACTOR_CHAOS = '''"""reactor/telemetry_adapter.py -- CHAOS MUTATION (contract-breaking)."""
+from __future__ import annotations
+
+
+class TelemetryAdapter:
+    """Emits a single metric reading as a structured record."""
+
+    def emit_metric(self, metric: str) -> dict:
+        """CHAOS: renamed emit->emit_metric and dropped the `value` parameter.
+
+        Compiles fine, but breaks the Body caller's `emit("x", 1.0)` contract --
+        the cross-repo handshake fractures.
+        """
+        return {"metric": metric, "unit": "raw"}
+'''
+
+_JARVIS_ORIGINAL = '''"""jarvis/metrics_caller.py -- Body code that calls the Nerves telemetry adapter."""
+from __future__ import annotations
+
+from telemetry_adapter import TelemetryAdapter
+
+
+def record_metric() -> dict:
+    """Record one metric via the reactor TelemetryAdapter (Body->Nerves call)."""
+    adapter = TelemetryAdapter()
+    return adapter.emit("x", 1.0)
+'''
+
+
+# --------------------------------------------------------------------------- #
+# Controlled Oracle fixture -- returns a REAL BlastRadius whose dependent is the
+# real jarvis caller of the reactor symbol. The graph DATA is fixture; the
+# trace/visualizer machinery that consumes it is the real production code.
+# --------------------------------------------------------------------------- #
+class _FixtureOracle:
+    """Minimal Oracle stand-in exposing the real ``compute_blast_radius`` shape.
+
+    Returns a real :class:`BlastRadius` (oracle.py) so the production
+    ``trace_cross_repo_blast`` consumes a genuine report -- not a mock.
+    """
+
+    def __init__(self, dependent: NodeID) -> None:
+        self._dependent = dependent
+
+    def compute_blast_radius(self, node_id: NodeID, max_depth: int = 3) -> BlastRadius:
+        return BlastRadius(
+            source_node=node_id,
+            directly_affected={self._dependent},
+            transitively_affected=set(),
+            broken_imports=[],
+            broken_calls=[],
+            risk_level="high",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Injected sandbox runner -- simulates the air-gapped 3-repo Docker network and
+# detects the broken cross-repo handshake. This is the seam the gate is DESIGNED
+# for (DockerRunner protocol). The handshake FAILS for the chaos candidate,
+# exactly as a real broken-handshake would -> the gate returns fracture=True.
+# --------------------------------------------------------------------------- #
+class _FractureRunner:
+    """Fake DockerRunner: air-gap asserts cleanly, handshake FRACTURES.
+
+    * ``compose_up`` / ``compose_down`` -> rc 0 (containers "spin"/"teardown").
+    * ``inspect_network`` -> "true" (network is internal: air-gap holds).
+    * ``probe_provider_host`` -> rc 7 (UNREACHABLE: the required air-gap outcome).
+    * ``health_handshake`` -> rc 11 (the Body<->Nerves handshake is BROKEN by the
+      contract-breaking chaos mutation) -> FRACTURE.
+    """
+
+    def __init__(self) -> None:
+        self.compose_down_calls = 0
+
+    async def compose_up(self, compose_path: str) -> RunResult:
+        return RunResult(0, stdout="Created 4 containers", stderr="")
+
+    async def compose_down(self, compose_path: str) -> RunResult:
+        self.compose_down_calls += 1
+        return RunResult(0, stdout="Removed", stderr="")
+
+    async def inspect_network(self, network: str) -> RunResult:
+        return RunResult(0, stdout="true\n", stderr="")
+
+    async def probe_provider_host(self, service: str, host: str) -> RunResult:
+        # Non-zero rc == host UNREACHABLE == air-gap holds (the required outcome).
+        return RunResult(7, stdout="", stderr="connection refused (air-gapped)")
+
+    async def health_handshake(self, service: str) -> RunResult:
+        # rc != 0 -> all_green is False -> the Trinity handshake FRACTURED.
+        return RunResult(
+            11,
+            stdout="",
+            stderr="trinity handshake failed: jarvis.metrics_caller.record_metric "
+            "called TelemetryAdapter.emit('x', 1.0) but reactor now exposes "
+            "emit_metric(metric) -- contract broken",
+        )
+
+
+# --------------------------------------------------------------------------- #
+# Fixture construction
+# --------------------------------------------------------------------------- #
+@dataclass
+class _Fixture:
+    root: Path
+    jarvis_root: Path
+    reactor_root: Path
+    jarvis_original: bytes
+    reactor_original: bytes
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(cwd),
+        check=True,
+        capture_output=True,
+        env={
+            **os.environ,
+            "GIT_AUTHOR_NAME": "surgery",
+            "GIT_AUTHOR_EMAIL": "surgery@jarvis.local",
+            "GIT_COMMITTER_NAME": "surgery",
+            "GIT_COMMITTER_EMAIL": "surgery@jarvis.local",
+        },
+    )
+
+
+def _init_repo(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+    _git(path, "init", "-q")
+    _git(path, "add", "-A")
+    _git(path, "commit", "-q", "-m", "fixture: initial", "--allow-empty")
+
+
+def build_fixture(base: Optional[Path] = None) -> _Fixture:
+    """Create the temp two-repo fixture (jarvis + reactor) with the real graph."""
+    root = base or Path(tempfile.mkdtemp(prefix="cross_repo_surgery_"))
+    jarvis_root = root / "jarvis"
+    reactor_root = root / "reactor"
+    jarvis_root.mkdir(parents=True, exist_ok=True)
+    reactor_root.mkdir(parents=True, exist_ok=True)
+
+    reactor_original = _REACTOR_ORIGINAL.encode("utf-8")
+    jarvis_original = _JARVIS_ORIGINAL.encode("utf-8")
+    (reactor_root / _REACTOR_FILE).write_bytes(reactor_original)
+    (jarvis_root / _JARVIS_FILE).write_bytes(jarvis_original)
+
+    _init_repo(jarvis_root)
+    _init_repo(reactor_root)
+
+    return _Fixture(
+        root=root,
+        jarvis_root=jarvis_root,
+        reactor_root=reactor_root,
+        jarvis_original=jarvis_original,
+        reactor_original=reactor_original,
+    )
+
+
+def make_fixture_oracle() -> _FixtureOracle:
+    """Build the controlled Oracle whose dependent is the real jarvis caller."""
+    dependent = NodeID(
+        repo="jarvis",
+        file_path=_JARVIS_FILE,
+        name="record_metric",
+        node_type=NodeType.FUNCTION,
+    )
+    return _FixtureOracle(dependent)
+
+
+def make_target_node() -> NodeID:
+    """The mutated Nerves symbol: reactor::TelemetryAdapter.emit."""
+    return NodeID(
+        repo="reactor",
+        file_path=_REACTOR_FILE,
+        name=f"{_TARGET_CLASS}.{_TARGET_SYMBOL}",
+        node_type=NodeType.METHOD,
+    )
+
+
+def make_registry(fixture: _Fixture) -> RepoRegistry:
+    """RepoRegistry pointed at the fixture's two repos."""
+    return RepoRegistry(
+        configs=(
+            RepoConfig(name="jarvis", local_path=fixture.jarvis_root, canary_slices=("tests/",)),
+            RepoConfig(name="reactor", local_path=fixture.reactor_root, canary_slices=("tests/",)),
+        )
+    )
+
+
+def make_chaos_patch_map(fixture: _Fixture) -> Dict[str, RepoPatch]:
+    """The cross-repo patch: a contract-breaking MODIFY of the reactor file.
+
+    Preimage = the original reactor bytes (so the REAL compensating rollback can
+    restore it). The jarvis file is unchanged by the chaos mutation -- the break
+    is that jarvis's caller now references a contract the mutated reactor dropped.
+    """
+    reactor_patch = RepoPatch(
+        repo="reactor",
+        files=(
+            PatchedFile(
+                path=_REACTOR_FILE,
+                op=FileOp.MODIFY,
+                preimage=fixture.reactor_original,
+            ),
+        ),
+        new_content=((_REACTOR_FILE, _REACTOR_CHAOS.encode("utf-8")),),
+    )
+    return {"reactor": reactor_patch}
+
+
+def make_cross_repo_ctx(fixture: _Fixture) -> OperationContext:
+    """A real cross-repo OperationContext (repo_scope spans jarvis + reactor)."""
+    return OperationContext.create(
+        target_files=(f"reactor/{_REACTOR_FILE}",),
+        description="first cross-repo surgery: chaos mutation of TelemetryAdapter.emit",
+        op_id="surgery-001",
+        primary_repo="reactor",
+        repo_scope=("jarvis", "reactor"),
+        # reactor must apply before jarvis would (dependency edge: jarvis depends on reactor)
+        dependency_edges=(("jarvis", "reactor"),),
+    )
+
+
+def render_blast_tree_if_available(blast) -> str:
+    """Thin pass-through to the real visualizer (kept for test ergonomics)."""
+    return render_blast_tree(blast)
+
+
+def make_saga_strategy(fixture: _Fixture) -> SagaApplyStrategy:
+    """The REAL SagaApplyStrategy pointed at the fixture repo roots.
+
+    branch_isolation=False -> legacy direct-to-HEAD apply with preimage
+    compensation (the path whose rollback we verify byte-for-byte). ledger=None
+    -> sub-event emits are skipped (best-effort, fail-soft by design).
+    """
+    return SagaApplyStrategy(
+        repo_roots={"jarvis": fixture.jarvis_root, "reactor": fixture.reactor_root},
+        ledger=None,
+        branch_isolation=False,
+    )
+
+
+# --------------------------------------------------------------------------- #
+# The surgery (async driver)
+# --------------------------------------------------------------------------- #
+@dataclass
+class SurgeryResult:
+    handshake: ArmingHandshake
+    blast_tree: str
+    blast_dependent_count: int
+    chaos_applied: bool
+    sandbox_verdict: SandboxVerdict
+    rollback_verified: bool
+    reactor_restored: bool
+    jarvis_restored: bool
+    narrative: List[str]
+
+
+def _say(narrative: List[str], line: str) -> None:
+    narrative.append(line)
+    print(line, flush=True)
+
+
+async def run_surgery(*, base: Optional[Path] = None) -> SurgeryResult:
+    """Drive the full controlled cross-repo surgery scenario.
+
+    Builds the fixture, runs the real components, and VERIFIES the rollback
+    restored both repos byte-for-byte. Tears down the temp dir in `finally`.
+    """
+    narrative: List[str] = []
+    fixture = build_fixture(base)
+    runner = _FractureRunner()
+    try:
+        _say(narrative, "=" * 72)
+        _say(narrative, "  FIRST CROSS-REPO SURGERY -- chaos -> FRACTURE -> rollback")
+        _say(narrative, "=" * 72)
+        _say(narrative, f"fixture: {fixture.root}")
+        _say(narrative, f"  reactor (Nerves): {_REACTOR_FILE} :: {_TARGET_CLASS}.{_TARGET_SYMBOL}")
+        _say(narrative, f"  jarvis  (Body):   {_JARVIS_FILE} :: record_metric -> emit('x', 1.0)")
+        _say(narrative, "")
+
+        # --- 1. ARMING HANDSHAKE (real Docker probe) -----------------------
+        _say(narrative, "[1] ARMING HANDSHAKE (real cross_repo_master_flag.run_arming_handshake)")
+        # Force the flag truthy for the demo regardless of the master flag's
+        # process state (we still run the REAL docker probe underneath).
+        prev_flag = os.environ.get("JARVIS_CROSS_REPO_MUTATION_ENABLED")
+        os.environ["JARVIS_CROSS_REPO_MUTATION_ENABLED"] = "1"
+        try:
+            handshake = await run_arming_handshake()
+        finally:
+            if prev_flag is None:
+                os.environ.pop("JARVIS_CROSS_REPO_MUTATION_ENABLED", None)
+            else:
+                os.environ["JARVIS_CROSS_REPO_MUTATION_ENABLED"] = prev_flag
+        _say(narrative, f"    armed={handshake.armed} docker_alive={handshake.docker_alive} "
+                        f"sinkhole_configurable={handshake.sinkhole_configurable}")
+        _say(narrative, f"    reason: {handshake.reason}")
+        if not handshake.armed:
+            _say(narrative, "    -> handshake degraded; proceeding in FORCED-DEMO mode "
+                            "(scenario still exercises the real apply/gate/rollback).")
+        _say(narrative, "")
+
+        # --- 2. BLAST-RADIUS TRACE + VISUALIZER (real) ---------------------
+        _say(narrative, "[2] BLAST-RADIUS TRACE (real trace_cross_repo_blast + render_blast_tree)")
+        oracle = make_fixture_oracle()
+        registry = make_registry(fixture)
+        target = make_target_node()
+        blast = await trace_cross_repo_blast(
+            target_node_id=target, oracle=oracle, registry=registry
+        )
+        blast_tree = render_blast_tree(blast)
+        _say(narrative, "")
+        for line in blast_tree.splitlines():
+            _say(narrative, "    " + line)
+        _say(narrative, "")
+        _say(narrative, f"    -> {blast.total_dependents} Body dependent(s) traced for the "
+                        "Nerves mutation.")
+        _say(narrative, "")
+
+        # --- 3. CHAOS CANDIDATE applied across repos (real SagaApplyStrategy) -
+        _say(narrative, "[3] CHAOS CANDIDATE (real SagaApplyStrategy.execute)")
+        _say(narrative, "    Mutation: TelemetryAdapter.emit(metric, value) -> "
+                        "emit_metric(metric)")
+        _say(narrative, "    (compiles -- ast.parse OK -- but BREAKS the Body caller's contract;")
+        _say(narrative, "     a pure syntax error would trip the compilation gate, never reaching G2)")
+        ctx = make_cross_repo_ctx(fixture)
+        strategy = make_saga_strategy(fixture)
+        patch_map = make_chaos_patch_map(fixture)
+        apply_result = await strategy.execute(ctx, patch_map)
+        reactor_on_disk = (fixture.reactor_root / _REACTOR_FILE).read_bytes()
+        chaos_applied = (
+            apply_result.terminal_state == SagaTerminalState.SAGA_APPLY_COMPLETED
+            and b"emit_metric" in reactor_on_disk
+        )
+        _say(narrative, f"    saga terminal_state={apply_result.terminal_state.value} "
+                        f"chaos_on_disk={b'emit_metric' in reactor_on_disk}")
+        _say(narrative, "")
+
+        # --- 4. AIR-GAPPED SANDBOX GATE -> FRACTURE (real gate) -------------
+        _say(narrative, "[4] AIR-GAPPED SANDBOX GATE (real run_trinity_sandbox_gate)")
+        _say(narrative, "    injected runner: air-gap holds, Trinity handshake BROKEN by the chaos")
+        prev_gate = os.environ.get("JARVIS_TRINITY_SANDBOX_GATE_ENABLED")
+        os.environ["JARVIS_TRINITY_SANDBOX_GATE_ENABLED"] = "true"
+        try:
+            sandbox_verdict = await run_trinity_sandbox_gate(
+                candidate_root=str(fixture.root),
+                op_id=ctx.op_id,
+                runner=runner,
+                # Build the air-gap overlay from a tiny in-fixture base compose so
+                # the real render path runs (no real 3-repo compose on this host).
+                base_compose_path=_write_base_compose(fixture.root),
+                services=("jarvis", "reactor"),
+            )
+        finally:
+            if prev_gate is None:
+                os.environ.pop("JARVIS_TRINITY_SANDBOX_GATE_ENABLED", None)
+            else:
+                os.environ["JARVIS_TRINITY_SANDBOX_GATE_ENABLED"] = prev_gate
+        _say(narrative, f"    verdict: passed={sandbox_verdict.passed} "
+                        f"fracture={sandbox_verdict.fracture} "
+                        f"air_gapped={sandbox_verdict.air_gapped} "
+                        f"handshake_ok={sandbox_verdict.handshake_ok}")
+        _say(narrative, f"    reason: {sandbox_verdict.reason}")
+        if sandbox_verdict.fracture:
+            _say(narrative, "    [SOVEREIGN YIELD: CROSS-REPO FRACTURE] emitted "
+                            "(see WARNING log) -> abort + rollback")
+        _say(narrative, "")
+
+        # --- 5. COMPENSATING ROLLBACK (real saga rollback) -----------------
+        _say(narrative, "[5] COMPENSATING ROLLBACK (real SagaApplyStrategy.compensate_after_verify_failure)")
+        reactor_restored = False
+        jarvis_restored = False
+        rollback_verified = False
+        if sandbox_verdict.fracture and chaos_applied:
+            all_ok = await strategy.compensate_after_verify_failure(
+                saga_result=apply_result,
+                patch_map=patch_map,
+                op_id=ctx.op_id,
+                reason_code="cross_repo_fracture",
+            )
+            reactor_now = (fixture.reactor_root / _REACTOR_FILE).read_bytes()
+            jarvis_now = (fixture.jarvis_root / _JARVIS_FILE).read_bytes()
+            reactor_restored = reactor_now == fixture.reactor_original
+            jarvis_restored = jarvis_now == fixture.jarvis_original
+            rollback_verified = bool(all_ok) and reactor_restored and jarvis_restored
+        _say(narrative, f"    compensation reactor_restored={reactor_restored} "
+                        f"jarvis_restored={jarvis_restored}")
+        _say(narrative, "")
+
+        # --- 6. VERDICT ----------------------------------------------------
+        _say(narrative, "=" * 72)
+        if rollback_verified:
+            _say(narrative, "  ROLLBACK VERIFIED: reactor + jarvis restored to pre-surgery "
+                            "state, organism intact.")
+            _say(narrative, "  VERDICT: PASS")
+        else:
+            _say(narrative, "  ROLLBACK FAILED: organism NOT fully restored.")
+            _say(narrative, "  VERDICT: FAIL")
+        _say(narrative, "=" * 72)
+
+        return SurgeryResult(
+            handshake=handshake,
+            blast_tree=blast_tree,
+            blast_dependent_count=blast.total_dependents,
+            chaos_applied=chaos_applied,
+            sandbox_verdict=sandbox_verdict,
+            rollback_verified=rollback_verified,
+            reactor_restored=reactor_restored,
+            jarvis_restored=jarvis_restored,
+            narrative=narrative,
+        )
+    finally:
+        try:
+            shutil.rmtree(fixture.root, ignore_errors=True)
+        except Exception:
+            pass
+
+
+def _write_base_compose(root: Path) -> str:
+    """Write a tiny base docker-compose so the gate's real overlay render runs.
+
+    The gate derives an air-gapped overlay from a base compose; on this host
+    there is no real 3-repo compose, so we provide a minimal one to drive the
+    REAL render path. The injected runner never actually spins these.
+    """
+    path = root / "docker-compose.soak.yml"
+    path.write_text(
+        "services:\n"
+        "  jarvis:\n"
+        "    image: python:3.11-slim\n"
+        "  reactor:\n"
+        "    image: python:3.11-slim\n",
+        encoding="utf-8",
+    )
+    return str(path)
+
+
+# --------------------------------------------------------------------------- #
+# CLI
+# --------------------------------------------------------------------------- #
+def _chaos_enabled() -> bool:
+    raw = os.environ.get(_ENV_CHAOS, "").strip().lower()
+    return raw in _TRUTHY
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run",
+        action="store_true",
+        help="Execute the surgery scenario (requires JARVIS_CHAOS_INJECTOR_ENABLED).",
+    )
+    args = parser.parse_args(argv)
+
+    if not _chaos_enabled():
+        print(
+            f"[cross_repo_first_surgery] REFUSING: {_ENV_CHAOS} is not enabled. "
+            f"Set {_ENV_CHAOS}=1 to run the chaos surgery.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if not args.run:
+        print("[cross_repo_first_surgery] pass --run to execute the surgery.", file=sys.stderr)
+        return 2
+
+    try:
+        result = asyncio.run(run_surgery())
+    except Exception as exc:  # noqa: BLE001 -- fail-soft top-level
+        print(f"[cross_repo_first_surgery] surgery raised: {exc}", file=sys.stderr)
+        return 1
+
+    return 0 if result.rollback_verified else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/governance/test_blast_radius_visualizer.py
+++ b/tests/governance/test_blast_radius_visualizer.py
@@ -1,0 +1,114 @@
+"""Tests for blast_radius_visualizer.render_blast_tree.
+
+Covers: tree grouped-by-repo, cap + "+M more", ASCII-only codepoints, footer
+count, empty -> "", and the authority-free invariant (source-grep: no policy /
+orchestrator / change_engine imports).
+"""
+from __future__ import annotations
+
+import os
+import pathlib
+import re
+
+import pytest
+
+from backend.core.ouroboros.governance.multi_repo.blast_radius_visualizer import (
+    render_blast_tree,
+)
+from backend.core.ouroboros.governance.multi_repo.cross_repo_blast_context import (
+    BlastRadiusContext,
+    DependentRef,
+)
+
+
+def _ctx(deps, *, target_repo="reactor", target_symbol="TelemetryAdapter.emit"):
+    return BlastRadiusContext(
+        target_repo=target_repo,
+        target_symbol=target_symbol,
+        dependents=tuple(deps),
+        rendered_prompt_block="",
+        truncated=False,
+        total_dependents=len(deps),
+    )
+
+
+def _dep(repo, file, symbol):
+    return DependentRef(repo=repo, file=file, symbol=symbol, relevance="...")
+
+
+def test_empty_dependents_returns_empty_string():
+    assert render_blast_tree(_ctx([])) == ""
+
+
+def test_tree_grouped_by_repo_and_has_header_and_footer():
+    deps = [
+        _dep("jarvis", "backend/a/foo.py", "caller_a"),
+        _dep("prime", "jarvis_prime/b/baz.py", "caller_c"),
+        _dep("jarvis", "backend/a/bar.py", "caller_b"),
+    ]
+    out = render_blast_tree(_ctx(deps))
+    assert "CROSS-REPO BLAST RADIUS" in out
+    assert "mutating reactor::TelemetryAdapter.emit" in out
+    assert "depended on by:" in out
+    # Grouped by repo: both jarvis entries appear before the prime entry
+    # (alpha repo order: jarvis < prime).
+    jarvis_a = out.index("backend/a/foo.py")
+    jarvis_b = out.index("backend/a/bar.py")
+    prime_c = out.index("jarvis_prime/b/baz.py")
+    assert jarvis_a < prime_c
+    assert jarvis_b < prime_c
+    # Repo tags rendered.
+    assert "[jarvis]" in out
+    assert "[prime]" in out
+    # Footer count == total dependents.
+    assert "3 Body/Mind files mapped to this Nerves mutation." in out
+
+
+def test_cap_and_plus_m_more(monkeypatch):
+    monkeypatch.setenv("JARVIS_BLAST_TREE_MAX_NODES", "2")
+    deps = [_dep("jarvis", "f%d.py" % i, "sym%d" % i) for i in range(5)]
+    out = render_blast_tree(_ctx(deps))
+    # Only 2 drawn, "+3 more" summarised.
+    assert "... +3 more ..." in out
+    # Footer still reports the true total (5), never the capped count.
+    assert "5 Body/Mind files mapped" in out
+
+
+def test_no_cap_when_under_limit(monkeypatch):
+    monkeypatch.setenv("JARVIS_BLAST_TREE_MAX_NODES", "40")
+    deps = [_dep("jarvis", "f%d.py" % i, "sym%d" % i) for i in range(3)]
+    out = render_blast_tree(_ctx(deps))
+    assert "more ..." not in out
+
+
+def test_output_is_ascii_plus_only_box_drawing():
+    deps = [
+        _dep("jarvis", "backend/a/foo.py", "caller_a"),
+        _dep("prime", "jarvis_prime/b/baz.py", "caller_c"),
+    ]
+    out = render_blast_tree(_ctx(deps))
+    allowed_nonascii = set("├─└│")
+    for ch in out:
+        if ord(ch) > 127:
+            assert ch in allowed_nonascii, "unexpected non-ASCII codepoint %r" % ch
+
+
+def test_render_never_raises_on_garbage():
+    class _Bad:
+        @property
+        def dependents(self):
+            raise RuntimeError("boom")
+    # Should fail-soft to "" rather than raise.
+    assert render_blast_tree(_Bad()) == ""
+
+
+def test_visualizer_is_authority_free_source_grep():
+    """Pure render: must NOT import orchestrator / policy / change_engine / risk."""
+    src = pathlib.Path(
+        "backend/core/ouroboros/governance/multi_repo/blast_radius_visualizer.py"
+    ).read_text(encoding="utf-8")
+    forbidden = ("orchestrator", "policy", "change_engine", "risk_tier", "risk_engine")
+    for needle in forbidden:
+        assert (
+            not re.search(r"^\s*(import|from).*%s" % re.escape(needle), src, re.MULTILINE)
+        ), "authority leak: visualizer imports %s" % needle

--- a/tests/governance/test_cross_repo_master_flag.py
+++ b/tests/governance/test_cross_repo_master_flag.py
@@ -1,0 +1,281 @@
+"""Master Arming Switch tests (cross_repo_master_flag).
+
+Tests the JARVIS_CROSS_REPO_MUTATION_ENABLED handshake gate:
+  * flag unset / falsy / garbage -> NOT armed (byte-identical default)
+  * flag=true + docker-alive + sinkhole-ok -> armed=True
+  * flag=true + docker-DEAD -> armed=False, reason mentions docker
+  * flag=true + sinkhole-not-configurable -> armed=False (degrade)
+  * handshake exception -> armed=False (fail-soft/fail-CLOSED)
+  * cross_repo_mutation_enabled() reflects armed
+  * caching works + re-eval flag (JARVIS_CROSS_REPO_HANDSHAKE_CACHE)
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Fake injectable runner (no real Docker in tests)
+# ---------------------------------------------------------------------------
+class _FakeRunner:
+    """Injectable fake runner for unit tests -- never calls Docker."""
+
+    def __init__(
+        self,
+        *,
+        docker_alive: bool = True,
+        sinkhole_ok: bool = True,
+    ) -> None:
+        self.docker_alive = docker_alive
+        self.sinkhole_ok = sinkhole_ok
+        self.calls: list = []
+
+    async def docker_info(self):
+        self.calls.append("docker_info")
+        from backend.core.ouroboros.governance.cross_repo_master_flag import RunResult
+        return RunResult(
+            returncode=0 if self.docker_alive else 1,
+            stdout="Docker info" if self.docker_alive else "",
+            stderr="" if self.docker_alive else "Cannot connect to Docker",
+        )
+
+    async def can_render_airgap(self) -> bool:
+        self.calls.append("can_render_airgap")
+        return self.sinkhole_ok
+
+
+class _ExplodingRunner:
+    """Runner that always raises -- simulates catastrophic failure."""
+
+    async def docker_info(self):
+        raise RuntimeError("simulated docker crash")
+
+    async def can_render_airgap(self) -> bool:
+        raise RuntimeError("simulated sinkhole crash")
+
+
+# ---------------------------------------------------------------------------
+# Autouse fixture: bust the module-level handshake cache between tests
+# ---------------------------------------------------------------------------
+@pytest.fixture(autouse=True)
+def _reset_cache(monkeypatch):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setattr(mod, "_cached_handshake", None, raising=False)
+    yield
+    monkeypatch.setattr(mod, "_cached_handshake", None, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Helper
+# ---------------------------------------------------------------------------
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _handshake(runner, *, flag_value, monkeypatch):
+    """Set env and run_arming_handshake with given flag value and runner."""
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    if flag_value is None:
+        monkeypatch.delenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", raising=False)
+    else:
+        monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", flag_value)
+    return _run(mod.run_arming_handshake(runner=runner))
+
+
+# ===========================================================================
+# 1. flag unset -> NOT armed (byte-identical default)
+# ===========================================================================
+def test_flag_unset_not_armed(monkeypatch):
+    monkeypatch.delenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", raising=False)
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    result = _handshake(runner, flag_value=None, monkeypatch=monkeypatch)
+    assert result.armed is False
+    assert result.flag_set is False
+
+
+# ===========================================================================
+# 2. flag=garbage/"maybe"/"2" -> NOT armed (fail-CLOSED)
+#    also verifies falsy values (false/0/no/off) do NOT arm
+# ===========================================================================
+@pytest.mark.parametrize("bad_val", [
+    "garbage", "maybe", "2", "TRUE1", "FALSE", "0", "off", "no", "false",
+    "  ", "1.5", "GARBAGE",
+])
+def test_garbage_and_falsy_not_armed(monkeypatch, bad_val):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setattr(mod, "_cached_handshake", None, raising=False)
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    result = _handshake(runner, flag_value=bad_val, monkeypatch=monkeypatch)
+    assert result.armed is False, f"Expected NOT armed for flag={bad_val!r}"
+    assert result.flag_set is False, f"Expected flag_set=False for flag={bad_val!r}"
+
+
+# ===========================================================================
+# 3. flag=true + docker-alive + sinkhole-ok -> armed=True
+# ===========================================================================
+def test_flag_true_docker_alive_sinkhole_ok_armed(monkeypatch):
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    result = _handshake(runner, flag_value="true", monkeypatch=monkeypatch)
+    assert result.armed is True
+    assert result.flag_set is True
+    assert result.docker_alive is True
+    assert result.sinkhole_configurable is True
+
+
+@pytest.mark.parametrize("truthy_val", ["1", "true", "yes", "on", "TRUE", "YES", "ON", "True"])
+def test_all_truthy_values_arm(monkeypatch, truthy_val):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setattr(mod, "_cached_handshake", None, raising=False)
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    result = _handshake(runner, flag_value=truthy_val, monkeypatch=monkeypatch)
+    assert result.armed is True, f"Expected armed for flag={truthy_val!r}"
+    assert result.flag_set is True
+
+
+# ===========================================================================
+# 4. flag=true + docker-DEAD -> armed=False, reason mentions "docker"
+# ===========================================================================
+def test_flag_true_docker_dead_not_armed(monkeypatch):
+    runner = _FakeRunner(docker_alive=False, sinkhole_ok=True)
+    result = _handshake(runner, flag_value="true", monkeypatch=monkeypatch)
+    assert result.armed is False
+    assert result.flag_set is True
+    assert result.docker_alive is False
+    assert "docker" in result.reason.lower()
+
+
+# ===========================================================================
+# 5. flag=true + sinkhole-not-configurable -> armed=False (degrade)
+# ===========================================================================
+def test_flag_true_sinkhole_not_configurable_not_armed(monkeypatch):
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=False)
+    result = _handshake(runner, flag_value="true", monkeypatch=monkeypatch)
+    assert result.armed is False
+    assert result.flag_set is True
+    assert result.docker_alive is True
+    assert result.sinkhole_configurable is False
+    assert result.reason
+
+
+# ===========================================================================
+# 6. handshake exception -> armed=False (fail-soft / fail-CLOSED)
+# ===========================================================================
+def test_handshake_exception_not_armed(monkeypatch):
+    monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", "true")
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    result = _run(mod.run_arming_handshake(runner=_ExplodingRunner()))
+    assert result.armed is False
+    assert "error" in result.reason.lower() or result.reason
+
+
+# ===========================================================================
+# 7. cross_repo_mutation_enabled() reflects armed
+# ===========================================================================
+def test_mutation_enabled_reflects_armed_true(monkeypatch):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", "0")
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    with patch.object(mod, "_make_default_runner", return_value=runner):
+        enabled = mod.cross_repo_mutation_enabled()
+    assert enabled is True
+
+
+def test_mutation_enabled_reflects_armed_false(monkeypatch):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.delenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", "0")
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    with patch.object(mod, "_make_default_runner", return_value=runner):
+        enabled = mod.cross_repo_mutation_enabled()
+    assert enabled is False
+
+
+# ===========================================================================
+# 8. caching works + re-eval flag (JARVIS_CROSS_REPO_HANDSHAKE_CACHE)
+# ===========================================================================
+def test_caching_returns_same_result(monkeypatch):
+    """With caching enabled (default), handshake runs once and is reused."""
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", raising=False)
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    with patch.object(mod, "_make_default_runner", return_value=runner):
+        r1 = mod.cross_repo_mutation_enabled()
+        # Poison the runner -- re-run would give different result
+        runner.docker_alive = False
+        r2 = mod.cross_repo_mutation_enabled()
+    assert r1 is True
+    assert r2 is True  # cache held, not re-evaluated
+
+
+def test_cache_disabled_re_evals(monkeypatch):
+    """With JARVIS_CROSS_REPO_HANDSHAKE_CACHE=0, each call re-evaluates."""
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", "0")
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    with patch.object(mod, "_make_default_runner", return_value=runner):
+        r1 = mod.cross_repo_mutation_enabled()
+        assert r1 is True
+        runner.docker_alive = False
+        r2 = mod.cross_repo_mutation_enabled()
+    assert r2 is False  # re-evaluated, docker now dead
+
+
+# ===========================================================================
+# 9. ArmingHandshake.to_dict() method coverage
+# ===========================================================================
+def test_arming_handshake_to_dict(monkeypatch):
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    result = _handshake(runner, flag_value="true", monkeypatch=monkeypatch)
+    d = result.to_dict()
+    assert isinstance(d, dict)
+    assert "armed" in d
+    assert "flag_set" in d
+    assert "docker_alive" in d
+    assert "sinkhole_configurable" in d
+    assert "reason" in d
+    assert d["armed"] is True
+
+
+# ===========================================================================
+# 10. arming_status() returns an ArmingHandshake
+# ===========================================================================
+def test_arming_status_returns_handshake(monkeypatch):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", "0")
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    with patch.object(mod, "_make_default_runner", return_value=runner):
+        status = mod.arming_status()
+    assert hasattr(status, "armed")
+    assert hasattr(status, "flag_set")
+    assert hasattr(status, "docker_alive")
+    assert hasattr(status, "sinkhole_configurable")
+    assert hasattr(status, "reason")
+    assert status.armed is True
+
+
+# ===========================================================================
+# 11. log_arming_status_on_boot() does not raise
+# ===========================================================================
+def test_log_arming_status_on_boot_does_not_raise(monkeypatch):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", "0")
+    runner = _FakeRunner(docker_alive=True, sinkhole_ok=True)
+    with patch.object(mod, "_make_default_runner", return_value=runner):
+        mod.log_arming_status_on_boot()
+
+
+def test_log_arming_status_on_boot_does_not_raise_degraded(monkeypatch):
+    import backend.core.ouroboros.governance.cross_repo_master_flag as mod
+    monkeypatch.setenv("JARVIS_CROSS_REPO_MUTATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", "0")
+    runner = _FakeRunner(docker_alive=False, sinkhole_ok=False)
+    with patch.object(mod, "_make_default_runner", return_value=runner):
+        mod.log_arming_status_on_boot()

--- a/tests/governance/test_cross_repo_wiring.py
+++ b/tests/governance/test_cross_repo_wiring.py
@@ -1,0 +1,200 @@
+"""Tests for cross_repo_wiring (G1 GENERATE block + G2 APPLY sandbox gate).
+
+Covers:
+  * build_blast_context_block returns the rendered block + fires the visualizer
+    on a cross-repo ctx (fake oracle/registry);
+  * build_blast_context_block returns "" when master-disabled (byte-identical);
+  * build_blast_context_block returns "" when ctx is not cross-repo;
+  * run_apply_sandbox_gate returns a fracture verdict on a fracture (fake gate);
+  * run_apply_sandbox_gate is a no-op PASS sentinel when master-disabled.
+"""
+from __future__ import annotations
+
+import asyncio
+import types
+
+import pytest
+
+import backend.core.ouroboros.governance.cross_repo_master_flag as master_flag
+import backend.core.ouroboros.governance.multi_repo.cross_repo_wiring as wiring
+import backend.core.ouroboros.governance.saga.trinity_integration_gate as gate_mod
+from backend.core.ouroboros.governance.saga.trinity_integration_gate import SandboxVerdict
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+class _FakeNode:
+    def __init__(self, repo, file_path, name):
+        self.repo = repo
+        self.file_path = file_path
+        self.name = name
+
+
+class _FakeReport:
+    def __init__(self, direct, trans=()):
+        self.directly_affected = set(direct)
+        self.transitively_affected = set(trans)
+
+
+class _FakeOracle:
+    def __init__(self, target_node, report):
+        self._target = target_node
+        self._report = report
+        self.compute_calls = 0
+
+    def find_nodes_in_file(self, path):
+        return [self._target]
+
+    def find_nodes_by_name(self, name):
+        return [self._target]
+
+    def compute_blast_radius(self, node_id, max_depth=None):
+        self.compute_calls += 1
+        return self._report
+
+
+class _FakeRegistry:
+    def __init__(self, sources):
+        # sources: {(repo, file): "src"}
+        self._sources = sources
+
+    async def read_file(self, repo, path):
+        return self._sources.get((repo, path), "def caller_a():\n    return 1\n")
+
+
+class _Ctx:
+    def __init__(self, *, cross_repo, target_files=("reactor/telemetry.py",),
+                 target_symbol="TelemetryAdapter.emit"):
+        self.cross_repo = cross_repo
+        self.target_files = target_files
+        self.target_symbol = target_symbol
+
+
+def _arm(monkeypatch, armed: bool):
+    """Force cross_repo_mutation_enabled() to a fixed value in BOTH the source
+    module and the wiring module (imports are lazy from the source module)."""
+    monkeypatch.setattr(master_flag, "cross_repo_mutation_enabled", lambda: armed)
+
+
+# --------------------------------------------------------------------------- #
+# G1 -- build_blast_context_block
+# --------------------------------------------------------------------------- #
+def test_blast_block_returns_block_and_fires_visualizer(monkeypatch, caplog):
+    _arm(monkeypatch, True)
+    target = _FakeNode("reactor", "reactor/telemetry.py", "TelemetryAdapter.emit")
+    dependent = _FakeNode("jarvis", "backend/a/foo.py", "caller_a")
+    oracle = _FakeOracle(target, _FakeReport(direct=[dependent]))
+    registry = _FakeRegistry({})
+
+    import logging
+    caplog.set_level(logging.INFO, logger="Ouroboros.CrossRepoWiring")
+
+    ctx = _Ctx(cross_repo=True)
+    block = asyncio.run(
+        wiring.build_blast_context_block(ctx, oracle=oracle, registry=registry)
+    )
+    # Rendered prompt block present, names the cross-repo dependent.
+    assert "CROSS-REPO BLAST RADIUS" in block
+    assert "caller_a" in block
+    # The oracle blast-radius graph was consulted.
+    assert oracle.compute_calls == 1
+    # The visualizer fired to the operator surface (logger.info).
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "CROSS-REPO BLAST RADIUS" in joined
+    assert "depended on by:" in joined
+
+
+def test_blast_block_empty_when_master_disabled(monkeypatch):
+    _arm(monkeypatch, False)
+    target = _FakeNode("reactor", "reactor/telemetry.py", "TelemetryAdapter.emit")
+    dependent = _FakeNode("jarvis", "backend/a/foo.py", "caller_a")
+    oracle = _FakeOracle(target, _FakeReport(direct=[dependent]))
+    ctx = _Ctx(cross_repo=True)
+    block = asyncio.run(
+        wiring.build_blast_context_block(ctx, oracle=oracle, registry=_FakeRegistry({}))
+    )
+    assert block == ""
+    # Master OFF -> the oracle was never even consulted (byte-identical).
+    assert oracle.compute_calls == 0
+
+
+def test_blast_block_empty_when_not_cross_repo(monkeypatch):
+    _arm(monkeypatch, True)
+    target = _FakeNode("reactor", "reactor/telemetry.py", "TelemetryAdapter.emit")
+    oracle = _FakeOracle(target, _FakeReport(direct=[]))
+    ctx = _Ctx(cross_repo=False)
+    block = asyncio.run(
+        wiring.build_blast_context_block(ctx, oracle=oracle, registry=_FakeRegistry({}))
+    )
+    assert block == ""
+    assert oracle.compute_calls == 0
+
+
+# --------------------------------------------------------------------------- #
+# G2 -- run_apply_sandbox_gate
+# --------------------------------------------------------------------------- #
+def test_sandbox_gate_returns_fracture_on_fracture(monkeypatch):
+    _arm(monkeypatch, True)
+
+    async def _fake_gate(*, candidate_root, op_id, runner=None):
+        return SandboxVerdict(
+            passed=False,
+            fracture=True,
+            reason="handshake_failed",
+            air_gapped=True,
+            handshake_ok=False,
+            containers=("jarvis",),
+        )
+
+    monkeypatch.setattr(gate_mod, "run_trinity_sandbox_gate", _fake_gate)
+
+    verdict = asyncio.run(
+        wiring.run_apply_sandbox_gate(
+            _Ctx(cross_repo=True), candidate_root="/tmp/cand", op_id="op-1"
+        )
+    )
+    assert verdict.fracture is True
+    assert verdict.passed is False
+    assert verdict.reason == "handshake_failed"
+
+
+def test_sandbox_gate_passes_through_pass_verdict(monkeypatch):
+    _arm(monkeypatch, True)
+
+    async def _fake_gate(*, candidate_root, op_id, runner=None):
+        return SandboxVerdict(
+            passed=True, fracture=False, reason="handshake_ok_air_gapped",
+            air_gapped=True, handshake_ok=True, containers=("jarvis",),
+        )
+
+    monkeypatch.setattr(gate_mod, "run_trinity_sandbox_gate", _fake_gate)
+    verdict = asyncio.run(
+        wiring.run_apply_sandbox_gate(
+            _Ctx(cross_repo=True), candidate_root="/tmp/cand", op_id="op-2"
+        )
+    )
+    assert verdict.fracture is False
+    assert verdict.passed is True
+
+
+def test_sandbox_gate_noop_when_master_disabled(monkeypatch):
+    _arm(monkeypatch, False)
+
+    called = {"n": 0}
+
+    async def _fake_gate(*, candidate_root, op_id, runner=None):
+        called["n"] += 1
+        return SandboxVerdict(False, True, "should-not-run", False, False, ())
+
+    monkeypatch.setattr(gate_mod, "run_trinity_sandbox_gate", _fake_gate)
+    verdict = asyncio.run(
+        wiring.run_apply_sandbox_gate(
+            _Ctx(cross_repo=True), candidate_root="/tmp/cand", op_id="op-3"
+        )
+    )
+    # No-op PASS sentinel, the real gate was never invoked (byte-identical).
+    assert verdict.passed is True
+    assert verdict.fracture is False
+    assert verdict.reason == "master_disabled"
+    assert called["n"] == 0

--- a/tests/scripts/test_cross_repo_first_surgery.py
+++ b/tests/scripts/test_cross_repo_first_surgery.py
@@ -1,0 +1,208 @@
+"""Tests for scripts/cross_repo_first_surgery.py -- the first-surgery chaos harness.
+
+Asserts the REAL machinery is driven:
+  * the fixture builds (two git repos with the real Body->Nerves dependency);
+  * the chaos candidate COMPILES (ast.parse OK) but CHANGES the contract
+    (symbol/signature differs);
+  * the harness drives apply -> FRACTURE -> rollback and BOTH files are restored
+    to their original snapshots (the rollback verification -- the REAL
+    SagaApplyStrategy compensating rollback, not a fake copy);
+  * the blast-radius visualizer is rendered (Body file mapped to Nerves mutation);
+  * gate-off (JARVIS_CHAOS_INJECTOR_ENABLED unset) refuses to run.
+"""
+from __future__ import annotations
+
+import ast
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from scripts import cross_repo_first_surgery as surgery  # noqa: E402
+from backend.core.ouroboros.governance.saga.saga_types import (  # noqa: E402
+    FileOp,
+    SagaTerminalState,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fixture builds + the real dependency graph
+# --------------------------------------------------------------------------- #
+def test_fixture_builds_two_repos(tmp_path):
+    fx = surgery.build_fixture(tmp_path / "fx")
+    try:
+        assert (fx.reactor_root / surgery._REACTOR_FILE).exists()
+        assert (fx.jarvis_root / surgery._JARVIS_FILE).exists()
+        # The Body file genuinely imports + calls the Nerves adapter.
+        jarvis_src = (fx.jarvis_root / surgery._JARVIS_FILE).read_text()
+        assert "from telemetry_adapter import TelemetryAdapter" in jarvis_src
+        assert 'adapter.emit("x", 1.0)' in jarvis_src
+        # Both are real git repos (HEAD resolvable).
+        for root in (fx.reactor_root, fx.jarvis_root):
+            rc = subprocess.run(
+                ["git", "rev-parse", "HEAD"], cwd=str(root), capture_output=True
+            ).returncode
+            assert rc == 0
+    finally:
+        import shutil
+
+        shutil.rmtree(fx.root, ignore_errors=True)
+
+
+def test_chaos_candidate_compiles_but_breaks_contract():
+    """The chaos candidate is ast.parse-OK yet changes the symbol + signature."""
+    # Original: a class with method `emit(self, metric, value)`.
+    orig_tree = ast.parse(surgery._REACTOR_ORIGINAL)
+    chaos_tree = ast.parse(surgery._REACTOR_CHAOS)  # must NOT raise -> compiles
+
+    def _methods(tree):
+        out = {}
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                out[node.name] = [a.arg for a in node.args.args]
+        return out
+
+    orig_m = _methods(orig_tree)
+    chaos_m = _methods(chaos_tree)
+
+    assert "emit" in orig_m and "value" in orig_m["emit"]
+    # CHAOS: the method name changed AND the value param is gone.
+    assert "emit" not in chaos_m, "chaos must rename/remove the original symbol"
+    assert "emit_metric" in chaos_m
+    assert "value" not in chaos_m["emit_metric"], "chaos must drop the value param"
+    # The contract genuinely differs (this is what fractures the handshake).
+    assert orig_m != chaos_m
+
+
+def test_chaos_patch_preimage_is_original(tmp_path):
+    fx = surgery.build_fixture(tmp_path / "fx")
+    try:
+        patch_map = surgery.make_chaos_patch_map(fx)
+        reactor_patch = patch_map["reactor"]
+        pf = reactor_patch.files[0]
+        assert pf.op == FileOp.MODIFY
+        # Preimage MUST be the original (so the real rollback can restore it).
+        assert pf.preimage == fx.reactor_original
+        # new_content carries the chaos.
+        new = dict(reactor_patch.new_content)[surgery._REACTOR_FILE]
+        assert b"emit_metric" in new
+    finally:
+        import shutil
+
+        shutil.rmtree(fx.root, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# The blast-radius trace + visualizer (real machinery, fixture graph)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_blast_trace_finds_jarvis_dependent(tmp_path):
+    fx = surgery.build_fixture(tmp_path / "fx")
+    try:
+        from backend.core.ouroboros.governance.multi_repo.cross_repo_blast_context import (
+            trace_cross_repo_blast,
+        )
+
+        oracle = surgery.make_fixture_oracle()
+        registry = surgery.make_registry(fx)
+        target = surgery.make_target_node()
+        blast = await trace_cross_repo_blast(
+            target_node_id=target, oracle=oracle, registry=registry
+        )
+        # The cross-repo dependent (jarvis) is genuinely traced.
+        assert blast.total_dependents == 1
+        dep = blast.dependents[0]
+        assert dep.repo == "jarvis"
+        assert dep.symbol == "record_metric"
+        # The rendered visualizer tree maps the Body file to the Nerves mutation.
+        tree = surgery.render_blast_tree_if_available(blast)
+        assert "CROSS-REPO BLAST RADIUS" in tree
+        assert "[jarvis]" in tree
+        assert surgery._JARVIS_FILE in tree
+    finally:
+        import shutil
+
+        shutil.rmtree(fx.root, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# The full apply -> FRACTURE -> rollback drive (the headline assertion)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_full_surgery_fractures_then_rolls_back(tmp_path, monkeypatch):
+    # Cache off so the arming handshake re-evaluates against this process state.
+    monkeypatch.setenv("JARVIS_CROSS_REPO_HANDSHAKE_CACHE", "0")
+    result = await surgery.run_surgery(base=tmp_path / "surgery")
+
+    # Chaos was genuinely applied across the repo scope via the real saga.
+    assert result.chaos_applied is True
+    # The air-gapped sandbox gate FRACTURED (the broken handshake was detected).
+    assert result.sandbox_verdict.fracture is True
+    assert result.sandbox_verdict.passed is False
+    assert result.sandbox_verdict.air_gapped is True  # air-gap held; handshake broke
+    assert result.sandbox_verdict.handshake_ok is False
+    assert "handshake_failed" in result.sandbox_verdict.reason
+
+    # The REAL compensating rollback restored BOTH repos byte-for-byte.
+    assert result.reactor_restored is True
+    assert result.jarvis_restored is True
+    assert result.rollback_verified is True
+
+    # The visualizer was printed in the narrative.
+    joined = "\n".join(result.narrative)
+    assert "CROSS-REPO BLAST RADIUS" in joined
+    assert "ROLLBACK VERIFIED" in joined
+
+
+@pytest.mark.asyncio
+async def test_apply_writes_chaos_then_rollback_restores(tmp_path):
+    """Lower-level proof: the saga writes the chaos to disk, rollback undoes it."""
+    fx = surgery.build_fixture(tmp_path / "fx")
+    try:
+        ctx = surgery.make_cross_repo_ctx(fx)
+        strategy = surgery.make_saga_strategy(fx)
+        patch_map = surgery.make_chaos_patch_map(fx)
+
+        # Apply: the chaos lands on disk.
+        apply_result = await strategy.execute(ctx, patch_map)
+        assert apply_result.terminal_state == SagaTerminalState.SAGA_APPLY_COMPLETED
+        on_disk = (fx.reactor_root / surgery._REACTOR_FILE).read_bytes()
+        assert b"emit_metric" in on_disk
+        assert on_disk != fx.reactor_original
+
+        # Compensate (REAL): restore from preimage.
+        all_ok = await strategy.compensate_after_verify_failure(
+            saga_result=apply_result,
+            patch_map=patch_map,
+            op_id=ctx.op_id,
+            reason_code="cross_repo_fracture",
+        )
+        assert all_ok is True
+        restored = (fx.reactor_root / surgery._REACTOR_FILE).read_bytes()
+        assert restored == fx.reactor_original  # byte-identical to pre-surgery
+        # jarvis was never touched -> still original.
+        assert (fx.jarvis_root / surgery._JARVIS_FILE).read_bytes() == fx.jarvis_original
+    finally:
+        import shutil
+
+        shutil.rmtree(fx.root, ignore_errors=True)
+
+
+# --------------------------------------------------------------------------- #
+# Gate-off: the CLI refuses to run without the chaos flag
+# --------------------------------------------------------------------------- #
+def test_cli_refuses_without_chaos_flag(monkeypatch):
+    monkeypatch.delenv("JARVIS_CHAOS_INJECTOR_ENABLED", raising=False)
+    rc = surgery.main(["--run"])
+    assert rc == 2  # refused
+
+
+def test_cli_refuses_without_run_flag(monkeypatch):
+    monkeypatch.setenv("JARVIS_CHAOS_INJECTOR_ENABLED", "1")
+    rc = surgery.main([])  # no --run
+    assert rc == 2


### PR DESCRIPTION
The activation layer for the Sovereign Cross-Repo Mutator (guardrails G1/G2/G3 merged #69678). **Master write flag default-OFF → byte-identical to today** (verified: `cross_repo_mutation_enabled()` returns False unset, the orchestrator wiring is fully inert).

**Master Arming Switch** (`cross_repo_master_flag.py`): `JARVIS_CROSS_REPO_MUTATION_ENABLED` is NOT a naive boolean — it requires a startup handshake (explicit-truthy flag AND `docker info` alive AND egress-sinkhole configurable). Any garbage value / dead Docker / unconfigurable sinkhole → graceful-degrade to FALSE. **Fail-CLOSED: only a deliberate arm + a ready air-gapped sandbox env arms it.**

**G1/G2 orchestrator wiring** (gated behind the master switch): G1 blast-radius context injected at GENERATE (`orchestrator.py:4116-4136` via a new `cross_repo_blast_prompt` field) — the model is forced to see cross-repo dependents; G2 air-gapped sandbox gate at APPLY (`:12722-12764`) — `verdict.fracture` routes into the existing compensating-rollback → terminal (never half-applied).

**Blast-Radius Visualizer** (`blast_radius_visualizer.py`): prints an ASCII Body→Nerves dependency tree to the operator surface before any cross-repo PR, so the human SEES which Body files map to the mutated Mind/Nerves. Authority-free.

**First-surgery proof** (`scripts/cross_repo_first_surgery.py`): a chaos harness driving the REAL machinery (SagaApplyStrategy execute + compensating rollback on real git repos, the G2 gate + FRACTURE yield, the blast trace + visualizer, the real docker-info handshake). **Live run PASSED:** a contract-breaking mutation to a reactor telemetry adapter → air-gapped sandbox caught the broken handshake → `[SOVEREIGN YIELD: CROSS-REPO FRACTURE]` → SagaApplyStrategy rolled back BOTH repos → ROLLBACK VERIFIED (organism intact). Honest caveat: the air-gapped Docker broken-handshake is injected via the gate's own runner seam (no 3-repo compose on the dev host); the rollback is genuine.

54 activation tests + the live surgery PASS. $0. Master flag stays OFF until operator-armed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a fail-closed Master Arming Switch for the cross-repo mutator and wires G1 (blast-radius prompt + visualizer) and G2 (air-gapped apply gate with rollback). The master flag defaults OFF, so behavior is unchanged until explicitly armed.

- **New Features**
  - Master switch via `JARVIS_CROSS_REPO_MUTATION_ENABLED` with a startup handshake (Docker reachable + egress sinkhole configurable). Any failure or garbage value disables it.
  - G1 (GENERATE): injects an Oracle-traced blast-radius block into the prompt via `cross_repo_blast_prompt` and prints an ASCII dependency tree for operator visibility.
  - G2 (APPLY): runs an air-gapped integration sandbox. A FRACTURE verdict triggers the existing saga abort and compensating rollback across repos.
  - First-surgery harness (`scripts/cross_repo_first_surgery.py`) proves FRACTURE → rollback on a contract-breaking change.

- **Migration**
  - No change by default (flag OFF).
  - To enable in a sandbox: set `JARVIS_CROSS_REPO_MUTATION_ENABLED=true`, ensure Docker is running, and configure the egress sinkhole; the handshake must pass.
  - Optional: run `scripts/cross_repo_first_surgery.py` to validate FRACTURE → rollback end-to-end.

<sup>Written for commit 21bbc4cbb2b0b52bd106a925d4ed129d2b6d5556. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69679?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

