### PR TITLE
feat: Autonomous Pre-Flight Cache Manager — dep-hash bake cache + WAN/air-gap phase separation (closes the unsimulated-surgery gap, default-OFF)

### DIFF
--- a/backend/core/ouroboros/governance/saga/trinity_compose_generator.py
+++ b/backend/core/ouroboros/governance/saga/trinity_compose_generator.py
@@ -43,7 +43,7 @@ Env knobs (no hardcoding of the tunables):
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 try:  # PyYAML available across soak/prod images.
     import yaml  # type: ignore
@@ -181,20 +181,43 @@ def _service(
     overrides: Dict[str, str],
     network: str,
     with_healthcheck: bool,
+    prebaked_image: str = "",
 ) -> Dict[str, Any]:
-    """One Trinity service: base image + repo bind-mount (ro) + server + env."""
-    svc: Dict[str, Any] = {
-        "image": base_image,
-        # Bind-mount the repo READ-ONLY -> the sandbox can never mutate the
-        # sibling repo's working tree (no cross-repo write through the sandbox).
-        "volumes": ["%s:/app:ro" % repo_root],
-        "working_dir": "/app",
-        "command": ["bash", "-lc", _install_and_start(server_cmd)],
-        # Every provider base URL points at the in-network sinkhole.
-        "environment": dict(overrides),
-        "networks": [network],
-        "expose": [str(port)],
-    }
+    """One Trinity service: base image + repo bind-mount (ro) + server + env.
+
+    When ``prebaked_image`` is supplied (the Pre-Flight Cache Manager baked a
+    hash-tagged image with the repo's deps already pip-installed in a WAN phase),
+    use that image directly and run the repo's OWN server command -- NO bind
+    mount, NO ``apt-get``/``pip`` at boot. This is what lets the air-gapped
+    (``internal: true``) boot succeed even though PyPI is unreachable: the deps
+    are already inside the image, baked WAN-connected before the air-gap is
+    entered. The legacy base-image + bind-mount + pip-at-boot path is preserved
+    byte-identical when ``prebaked_image`` is empty (prebake disabled / inert).
+    """
+    if prebaked_image:
+        # Deps already baked into the image (WAN phase). The repo is COPYed into
+        # /app at bake time, so just exec its server -- no mount, no pip.
+        svc: Dict[str, Any] = {
+            "image": prebaked_image,
+            "working_dir": "/app",
+            "command": ["bash", "-lc", "exec %s" % server_cmd],
+            "environment": dict(overrides),
+            "networks": [network],
+            "expose": [str(port)],
+        }
+    else:
+        svc = {
+            "image": base_image,
+            # Bind-mount the repo READ-ONLY -> the sandbox can never mutate the
+            # sibling repo's working tree (no cross-repo write through sandbox).
+            "volumes": ["%s:/app:ro" % repo_root],
+            "working_dir": "/app",
+            "command": ["bash", "-lc", _install_and_start(server_cmd)],
+            # Every provider base URL points at the in-network sinkhole.
+            "environment": dict(overrides),
+            "networks": [network],
+            "expose": [str(port)],
+        }
     if with_healthcheck:
         svc["healthcheck"] = _healthcheck(port=port)
     return svc
@@ -208,6 +231,7 @@ def generate_trinity_compose(
     mock_port: int = _DEFAULT_MOCK_PORT,
     base_image: str = _DEFAULT_BASE_IMAGE,
     egress_mock_script: str = "/app/scripts/trinity_sandbox_egress_mock.py",
+    images: Optional[Dict[str, str]] = None,
 ) -> Dict[str, Any]:
     """Generate the REAL air-gapped 3-repo Trinity compose dict.
 
@@ -220,11 +244,22 @@ def generate_trinity_compose(
 
     Cryptographic sinkhole: one ``internal: true`` network; every service's
     provider URLs overridden to the in-network ``egress-mock``.
+
+    Pre-baked images (Pre-Flight Cache Manager): ``images`` maps a repo key
+    (``"jarvis"`` / ``"prime"`` / ``"reactor"``) to a hash-tagged image that the
+    bake phase produced WAN-connected (deps already pip-installed + repo COPYed
+    in). When present for a service, that service runs from the cached image with
+    NO bind-mount and NO pip-at-boot -- which is what makes the air-gapped boot
+    succeed (PyPI is unreachable on the ``internal: true`` net). When ``images``
+    is None / a key is absent, the legacy base-image + bind-mount + pip-at-boot
+    path is used byte-identical (prebake disabled / inert).
     """
     # Env may override the passed defaults so an operator can tune without
     # touching the call site; explicit non-default args still win.
     if base_image == _DEFAULT_BASE_IMAGE:
         base_image = _base_image()
+
+    image_map: Dict[str, str] = dict(images or {})
 
     overrides = _provider_url_overrides(mock_port=mock_port)
     net = TRINITY_NETWORK
@@ -240,6 +275,7 @@ def generate_trinity_compose(
         overrides=overrides,
         network=net,
         with_healthcheck=True,
+        prebaked_image=image_map.get("prime", ""),
     )
     services["reactor"] = _service(
         repo_root=reactor_root,
@@ -249,6 +285,7 @@ def generate_trinity_compose(
         overrides=overrides,
         network=net,
         with_healthcheck=True,
+        prebaked_image=image_map.get("reactor", ""),
     )
 
     # Body (jarvis): the integration driver / in-network vantage. Health-GATED
@@ -265,6 +302,7 @@ def generate_trinity_compose(
         overrides=overrides,
         network=net,
         with_healthcheck=False,
+        prebaked_image=image_map.get("jarvis", ""),
     )
     jarvis_svc["depends_on"] = {
         "prime": {"condition": "service_healthy"},

--- a/backend/core/ouroboros/governance/saga/trinity_docker_runner.py
+++ b/backend/core/ouroboros/governance/saga/trinity_docker_runner.py
@@ -34,6 +34,10 @@ from backend.core.ouroboros.governance.saga.trinity_compose_generator import (
     serialize_compose,
     assert_sinkhole,
 )
+from backend.core.ouroboros.governance.saga.trinity_prebake_manager import (
+    PrebakeResult,
+    prebake_if_needed,
+)
 from backend.core.ouroboros.governance.saga.trinity_handshake_suite import (
     HandshakeHttpRunner,
     HandshakeResult,
@@ -133,6 +137,7 @@ class TrinityDockerRunner:
         jarvis_url: str = "http://jarvis:8091",
         prime_url: str = "http://prime:8000",
         reactor_url: str = "http://reactor:8090",
+        dockerfile_dir: str = "deploy/sandbox",
     ) -> None:
         self._jarvis_root = jarvis_root
         self._prime_root = prime_root
@@ -145,6 +150,7 @@ class TrinityDockerRunner:
         self._jarvis_url = jarvis_url
         self._prime_url = prime_url
         self._reactor_url = reactor_url
+        self._dockerfile_dir = dockerfile_dir
 
     # ------------------------------------------------------------------ #
     # Compose lifecycle (each behind the injectable cmd boundary)
@@ -187,16 +193,52 @@ class TrinityDockerRunner:
         mutated_endpoints: Sequence[MutatedEndpoint],
         overlay_writer: Optional[Callable[[str], str]] = None,
     ) -> TrinityBootVerdict:
-        """Generate -> sinkhole-assert -> up -> health-gate -> handshake -> down.
+        """Pre-flight bake -> generate -> sinkhole-assert -> up -> health-gate ->
+        handshake -> down.
+
+        The Pre-Flight Cache Manager runs FIRST (BEFORE generate + up): in a
+        WAN-connected phase it ensures a hash-tagged image exists per repo
+        (deps already baked in), so the air-gapped (``internal: true``) boot can
+        run the cached images with NO pip-at-boot. WAN-bake and air-gap-run are
+        strictly separated: baking is done here, the air-gapped network is only
+        entered at ``up``.
+
+        Fail-CLOSED: if prebake is enabled but a bake FAILS, we abort to FRACTURE
+        and NEVER ``up`` the air-gapped compose with a missing image. If prebake
+        is disabled, the generator uses its existing base-image path (existing
+        behavior, byte-identical).
 
         NEVER raises (fail-CLOSED). ``down -v`` ALWAYS runs in ``finally``.
         """
+        # 0. PRE-FLIGHT BAKE (WAN-connected, BEFORE the air-gap).
+        prebake: PrebakeResult = await prebake_if_needed(
+            jarvis_root=self._jarvis_root,
+            prime_root=self._prime_root,
+            reactor_root=self._reactor_root,
+            runner=self._cmd_runner,
+            dockerfile_dir=self._dockerfile_dir,
+        )
+        if not prebake.ok:
+            # Bake failed -> fail-CLOSED: do NOT enter the air-gapped boot with a
+            # missing image. FRACTURE.
+            return TrinityBootVerdict(
+                passed=False,
+                fracture=True,
+                reason="prebake_failed:%s" % prebake.reason,
+                sinkhole_ok=False,
+            )
+        # Skipped (disabled) -> images empty -> generator uses its base-image
+        # path (existing behavior). Otherwise the cached image map is passed so
+        # the air-gapped boot uses the pre-baked images (no pip-at-boot).
+        images = None if prebake.skipped else dict(prebake.images)
+
         compose = generate_trinity_compose(
             jarvis_root=self._jarvis_root,
             prime_root=self._prime_root,
             reactor_root=self._reactor_root,
             mock_port=self._mock_port,
             base_image=self._base_image,
+            images=images,
         )
 
         # Static sinkhole guarantee BEFORE any boot (fail-CLOSED).

--- a/backend/core/ouroboros/governance/saga/trinity_prebake_manager.py
+++ b/backend/core/ouroboros/governance/saga/trinity_prebake_manager.py
@@ -1,0 +1,363 @@
+"""trinity_prebake_manager -- the Autonomous Pre-Flight Cache Manager.
+
+The Trinity air-gapped sandbox (``trinity_compose_generator`` /
+``trinity_docker_runner``) is REAL: the integration network is declared
+``internal: true``, so Docker blackholes all WAN egress -- which means PyPI is
+unreachable and a ``pip install`` AT BOOT cannot resolve. This manager closes
+that operational gap by separating the build into TWO strictly-ordered phases:
+
+  1. **BAKE phase (WAN-connected).** Before the air-gap is ever entered, build a
+     per-repo, hash-tagged image from a JARVIS-side ``Dockerfile.<repo>.sandbox``
+     template using the SIBLING repo as the build context
+     (``docker build -f deploy/sandbox/Dockerfile.<repo>.sandbox <repo-root>``).
+     The Dockerfile ``pip install``s the repo's deps HERE, where PyPI is
+     reachable. (Templates live in JARVIS, never in the sibling repos -- putting
+     a Dockerfile in jarvis-prime/reactor-core would be a cross-repo *write*.)
+
+  2. **AIR-GAPPED RUN phase.** Only AFTER baking does the integration boot enter
+     the ``internal: true`` network, running the CACHED images (deps already
+     inside) -- no pip-at-boot, no WAN.
+
+The cache key is a **dependency content hash** (``dep_hash``): a mutated
+dependency file -> a new hash -> a new image tag -> a cache MISS -> a re-bake.
+An unchanged dep set -> a cache HIT -> the fast path (no build).
+
+Discipline:
+  * **Default-OFF.** ``JARVIS_TRINITY_PREBAKE_ENABLED`` (default false) -> the
+    manager is inert (``skipped=True``) and the compose generator falls back to
+    its existing base-image + bind-mount path byte-identical.
+  * **Fail-CLOSED.** A missing/uninspectable image -> treated as needs-bake (we
+    fail toward RE-BAKING, never toward a stale/missing image). A bake FAILURE ->
+    a result flagging the failure so the caller must NOT proceed to the
+    air-gapped boot with a missing image (it must FRACTURE instead).
+  * **WAN-vs-air-gap separation is structural.** The bake runs ``docker build``
+    (WAN). The air-gapped boot is a SEPARATE step (the runner's ``up``). This
+    manager NEVER enters the air-gapped network and NEVER pip-installs in it.
+  * **Injectable runner.** All ``docker`` invocations live behind an injectable
+    async callable so tests drive the full flow with NO real Docker / build.
+  * **No hardcoding.** Image prefix, bake timeout, and Dockerfile dir are env /
+    arg tunable.
+
+Env knobs:
+  * ``JARVIS_TRINITY_PREBAKE_ENABLED`` (default false) -- master switch.
+  * ``JARVIS_TRINITY_IMAGE_PREFIX`` (default ``jarvis-trinity-sandbox``).
+  * ``JARVIS_TRINITY_BAKE_TIMEOUT_S`` (default 1800) -- per-build bound.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Dict, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.TrinityPrebake")
+
+# --------------------------------------------------------------------------- #
+# Env knobs (no hardcoding of the tunables)
+# --------------------------------------------------------------------------- #
+_ENV_PREBAKE_ENABLED = "JARVIS_TRINITY_PREBAKE_ENABLED"
+_ENV_IMAGE_PREFIX = "JARVIS_TRINITY_IMAGE_PREFIX"
+_ENV_BAKE_TIMEOUT_S = "JARVIS_TRINITY_BAKE_TIMEOUT_S"
+
+_DEFAULT_IMAGE_PREFIX = "jarvis-trinity-sandbox"
+_DEFAULT_BAKE_TIMEOUT_S = 1800.0
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# The dep files that compose the cache key, in a stable order. A repo may have
+# either, both, or neither; a missing file contributes an empty section.
+_DEP_FILES: Tuple[str, ...] = ("requirements.txt", "pyproject.toml")
+
+
+# --------------------------------------------------------------------------- #
+# Injectable command boundary (reuses the runner shape from trinity_docker_runner)
+# --------------------------------------------------------------------------- #
+@dataclass
+class CmdResult:
+    """Result of a single shell command invocation (docker)."""
+
+    returncode: int
+    stdout: str = ""
+    stderr: str = ""
+
+    @property
+    def ok(self) -> bool:
+        return self.returncode == 0
+
+
+# (argv) -> CmdResult. Injectable so tests touch no real Docker.
+CmdRunner = Callable[[Sequence[str]], Awaitable[CmdResult]]
+
+
+async def _default_cmd_runner(argv: Sequence[str]) -> CmdResult:  # pragma: no cover - real subprocess, operator-gated
+    import subprocess  # noqa: PLC0415 - lazy, behind the boundary
+
+    def _call() -> CmdResult:
+        proc = subprocess.run(  # noqa: S603 - argv constructed, never shell
+            list(argv), capture_output=True, text=True, timeout=_bake_timeout_s()
+        )
+        return CmdResult(proc.returncode, proc.stdout or "", proc.stderr or "")
+
+    return await asyncio.to_thread(_call)
+
+
+# --------------------------------------------------------------------------- #
+# Env helpers
+# --------------------------------------------------------------------------- #
+def prebake_enabled() -> bool:
+    """``JARVIS_TRINITY_PREBAKE_ENABLED`` (default false)."""
+    raw = os.environ.get(_ENV_PREBAKE_ENABLED, "false").strip().lower()
+    return raw in _TRUTHY
+
+
+def _image_prefix() -> str:
+    return (os.environ.get(_ENV_IMAGE_PREFIX) or "").strip() or _DEFAULT_IMAGE_PREFIX
+
+
+def _bake_timeout_s() -> float:
+    try:
+        return max(1.0, float(os.environ.get(_ENV_BAKE_TIMEOUT_S, _DEFAULT_BAKE_TIMEOUT_S)))
+    except (TypeError, ValueError):
+        return _DEFAULT_BAKE_TIMEOUT_S
+
+
+# --------------------------------------------------------------------------- #
+# The cache key: a deterministic dependency content hash
+# --------------------------------------------------------------------------- #
+def dep_hash(repo_root: str) -> str:
+    """Deterministic sha256 over the CONTENT of ``requirements.txt`` +
+    ``pyproject.toml`` in ``repo_root``.
+
+    Pure + stable: same dep content -> same hash; a mutated dependency file ->
+    a different hash -> a cache miss -> a re-bake. Missing file -> empty section
+    (the hash still changes if a file is later added). Returns ASCII hex[:16].
+
+    The hash is computed over a canonical, labelled concatenation so that two
+    repos with the same combined bytes but different file split still differ.
+    """
+    h = hashlib.sha256()
+    for name in _DEP_FILES:  # stable, sorted-by-definition order
+        h.update(b"\x00")
+        h.update(name.encode("ascii"))
+        h.update(b"\x00")
+        try:
+            with open(os.path.join(repo_root, name), "rb") as fh:
+                h.update(fh.read())
+        except (FileNotFoundError, NotADirectoryError, IsADirectoryError, PermissionError):
+            # Missing / unreadable -> empty section (deterministic).
+            pass
+        except OSError:
+            pass
+    return h.hexdigest()[:16]
+
+
+def sandbox_image_tag(repo: str, dhash: str) -> str:
+    """``<prefix>-<repo>:<dhash>`` (prefix env-overridable).
+
+    e.g. ``jarvis-trinity-sandbox-prime:1a2b3c4d5e6f7a8b``.
+    """
+    return "%s-%s:%s" % (_image_prefix(), repo, dhash)
+
+
+# --------------------------------------------------------------------------- #
+# Cache probe (fail-CLOSED toward re-baking)
+# --------------------------------------------------------------------------- #
+async def is_image_cached(repo: str, dhash: str, *, runner: CmdRunner) -> bool:
+    """True iff ``docker image inspect <tag>`` reports the image present.
+
+    Fail-soft -> False: any error (Docker absent, inspect raised, non-zero rc)
+    is treated as NOT cached, i.e. needs-bake. This is fail-CLOSED in the safe
+    direction: we never assume a stale/missing image is present (which would let
+    the air-gapped boot proceed with no image).
+    """
+    tag = sandbox_image_tag(repo, dhash)
+    try:
+        res = await runner(["docker", "image", "inspect", tag])
+        return bool(res.ok)
+    except Exception:
+        logger.debug(
+            "[TrinityPrebake] image inspect raised for %s -> treat as needs-bake",
+            tag,
+            exc_info=True,
+        )
+        return False
+
+
+# --------------------------------------------------------------------------- #
+# Result
+# --------------------------------------------------------------------------- #
+@dataclass
+class PrebakeResult:
+    """Outcome of the Pre-Flight Cache Manager."""
+
+    images: Dict[str, str] = field(default_factory=dict)
+    baked: Tuple[str, ...] = ()
+    cached: Tuple[str, ...] = ()
+    skipped: bool = False
+    reason: str = ""
+
+    @property
+    def ok(self) -> bool:
+        """True iff the caller may proceed to the air-gapped boot.
+
+        Either prebake was skipped (disabled -> generator uses its base-image
+        path), or every required image is present (cached or freshly baked).
+        A bake FAILURE -> ``ok=False`` -> the caller must FRACTURE, never boot
+        air-gapped with a missing image.
+        """
+        return self.skipped or self.reason in ("all_cached", "baked")
+
+    def to_dict(self) -> dict:
+        return {
+            "images": dict(self.images),
+            "baked": list(self.baked),
+            "cached": list(self.cached),
+            "skipped": self.skipped,
+            "reason": self.reason,
+            "ok": self.ok,
+        }
+
+
+# The repo key -> (repo_root accessor key, dockerfile name) wiring. The repo
+# roots themselves are caller-supplied (no hardcoded paths).
+_REPO_KEYS: Tuple[str, ...] = ("jarvis", "prime", "reactor")
+
+
+def _dockerfile_path(dockerfile_dir: str, repo: str) -> str:
+    return os.path.join(dockerfile_dir, "Dockerfile.%s.sandbox" % repo)
+
+
+# --------------------------------------------------------------------------- #
+# The Pre-Flight Cache Manager
+# --------------------------------------------------------------------------- #
+async def prebake_if_needed(
+    *,
+    jarvis_root: str,
+    prime_root: str,
+    reactor_root: str,
+    runner: CmdRunner,
+    dockerfile_dir: str = "deploy/sandbox",
+) -> PrebakeResult:
+    """Ensure a hash-tagged sandbox image exists for each repo, baking the
+    missing ones in a WAN-connected phase BEFORE any air-gapped boot.
+
+    Flow:
+      1. ``not prebake_enabled()`` -> ``PrebakeResult(skipped=True,
+         reason="prebake_disabled")`` (inert; the generator falls back to its
+         base-image + bind-mount path).
+      2. For each repo: compute ``dep_hash`` -> image tag; probe ``is_image_cached``.
+      3. **Fast path:** all cached -> return the image map, NO build.
+         **Bake path:** for each MISSING image, run the WAN-connected
+         ``docker build -f <dockerfile_dir>/Dockerfile.<repo>.sandbox -t <tag>
+         <repo_root>`` (this phase is WAN -- NOT the air-gapped net). A build
+         FAILURE -> fail-CLOSED: return a result flagging the failure; the
+         caller must NOT proceed to the air-gapped boot.
+      4. Return ``images={repo: tag}`` for ``generate_trinity_compose(images=...)``.
+
+    NEVER raises (fail-CLOSED: any error -> a failure result, never a silent
+    proceed-with-missing-image).
+    """
+    if not prebake_enabled():
+        return PrebakeResult(skipped=True, reason="prebake_disabled")
+
+    roots: Dict[str, str] = {
+        "jarvis": jarvis_root,
+        "prime": prime_root,
+        "reactor": reactor_root,
+    }
+
+    # Resolve every repo's dep hash + tag, then probe the cache.
+    images: Dict[str, str] = {}
+    hashes: Dict[str, str] = {}
+    cached: list = []
+    missing: list = []
+    for repo in _REPO_KEYS:
+        dhash = dep_hash(roots[repo])
+        hashes[repo] = dhash
+        tag = sandbox_image_tag(repo, dhash)
+        images[repo] = tag
+        if await is_image_cached(repo, dhash, runner=runner):
+            cached.append(repo)
+        else:
+            missing.append(repo)
+
+    # Fast path: nothing to bake.
+    if not missing:
+        return PrebakeResult(
+            images=images,
+            baked=(),
+            cached=tuple(cached),
+            skipped=False,
+            reason="all_cached",
+        )
+
+    # Bake path (WAN-connected). Build each missing image from the JARVIS-side
+    # Dockerfile with the SIBLING repo as the build context. Fail-CLOSED on the
+    # FIRST build failure -> the caller must FRACTURE.
+    baked: list = []
+    for repo in missing:
+        tag = images[repo]
+        dockerfile = _dockerfile_path(dockerfile_dir, repo)
+        argv = [
+            "docker",
+            "build",
+            "-f",
+            dockerfile,
+            "-t",
+            tag,
+            roots[repo],
+        ]
+        try:
+            res = await runner(argv)
+        except Exception as exc:  # build raised -> fail-CLOSED
+            logger.warning(
+                "[TrinityPrebake] bake raised for %s (%s) -> fail-CLOSED: %s",
+                repo,
+                tag,
+                exc,
+            )
+            return PrebakeResult(
+                images=images,
+                baked=tuple(baked),
+                cached=tuple(cached),
+                skipped=False,
+                reason="bake_failed:%s:exception:%s" % (repo, exc),
+            )
+        if not res.ok:
+            logger.warning(
+                "[TrinityPrebake] bake FAILED for %s (%s, rc=%s) -> fail-CLOSED: %s",
+                repo,
+                tag,
+                res.returncode,
+                (res.stderr or res.stdout or "")[:200],
+            )
+            return PrebakeResult(
+                images=images,
+                baked=tuple(baked),
+                cached=tuple(cached),
+                skipped=False,
+                reason="bake_failed:%s:rc=%s" % (repo, res.returncode),
+            )
+        baked.append(repo)
+
+    return PrebakeResult(
+        images=images,
+        baked=tuple(baked),
+        cached=tuple(cached),
+        skipped=False,
+        reason="baked",
+    )
+
+
+__all__ = [
+    "CmdResult",
+    "CmdRunner",
+    "PrebakeResult",
+    "dep_hash",
+    "sandbox_image_tag",
+    "is_image_cached",
+    "prebake_if_needed",
+    "prebake_enabled",
+]

--- a/deploy/sandbox/Dockerfile.jarvis.sandbox
+++ b/deploy/sandbox/Dockerfile.jarvis.sandbox
@@ -1,0 +1,45 @@
+# Dockerfile.jarvis.sandbox -- JARVIS (Body) pre-baked Trinity sandbox image.
+#
+# TEMPLATE for the Pre-Flight Cache Manager's WAN-connected BAKE phase.
+# Built via:  docker build -f deploy/sandbox/Dockerfile.jarvis.sandbox -t <tag> <jarvis-root>
+# so the build CONTEXT is the JARVIS repo while the Dockerfile lives JARVIS-side
+# (never a cross-repo write into a sibling).
+#
+# The deps are pip-installed HERE, WAN-connected (PyPI reachable), BEFORE the
+# air-gapped (internal: true) integration network is ever entered. The resulting
+# hash-tagged image carries everything the air-gapped boot needs -- so no
+# pip-at-boot on the sinkholed net.
+#
+# The Body service in the sandbox is the in-network integration driver; it runs
+# a minimal stdlib /health server (the compose generator injects that command),
+# so the image only needs the repo + its deps present. Port 8091.
+FROM python:3.11-slim
+
+# curl is required by the compose healthcheck (curl -f .../health).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Build context = the JARVIS repo root.
+COPY . /app
+
+# Install the repo's deps in the WAN bake phase. Prefer requirements.txt; fall
+# back to `pip install .` when only pyproject.toml is present. Fail-CLOSED: a
+# failed install must fail the BUILD (no `|| true`) so a broken image is never
+# tagged + cached for the air-gapped run.
+RUN if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    elif [ -f pyproject.toml ]; then \
+        pip install --no-cache-dir .; \
+    fi
+
+# The Body health port inside the sandbox.
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 \
+    CMD curl -f http://localhost:8091/health || exit 1
+
+# Default: the lightweight stdlib health surface. The compose generator
+# overrides `command:` with its inline health server; this CMD is the standalone
+# fallback when the image is run directly.
+CMD ["python3", "-c", "import json\nfrom http.server import BaseHTTPRequestHandler,ThreadingHTTPServer\nclass H(BaseHTTPRequestHandler):\n def do_GET(self):\n  b=json.dumps({'status':'ok','service':'jarvis'}).encode();self.send_response(200);self.send_header('Content-Type','application/json');self.send_header('Content-Length',str(len(b)));self.end_headers();self.wfile.write(b)\n def log_message(self,*a):pass\nThreadingHTTPServer(('0.0.0.0',8091),H).serve_forever()"]

--- a/deploy/sandbox/Dockerfile.prime.sandbox
+++ b/deploy/sandbox/Dockerfile.prime.sandbox
@@ -1,0 +1,36 @@
+# Dockerfile.prime.sandbox -- J-Prime (Mind) pre-baked Trinity sandbox image.
+#
+# TEMPLATE for the Pre-Flight Cache Manager's WAN-connected BAKE phase.
+# Built via:  docker build -f deploy/sandbox/Dockerfile.prime.sandbox -t <tag> <prime-root>
+# Build CONTEXT = the J-Prime repo root (JARVIS_PRIME_REPO_PATH); the Dockerfile
+# stays JARVIS-side (never a cross-repo write into the sibling).
+#
+# Deps pip-installed HERE, WAN-connected, BEFORE the air-gapped network is
+# entered. The hash-tagged image carries them -- no pip-at-boot on the sinkhole.
+FROM python:3.11-slim
+
+# curl is required by the compose healthcheck (curl -f .../health).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Build context = the J-Prime repo root.
+COPY . /app
+
+# Install the repo's deps in the WAN bake phase. requirements.txt preferred;
+# fall back to `pip install .` for a pyproject-only repo. Fail-CLOSED: install
+# failure fails the BUILD (no `|| true`) so a broken image is never cached.
+RUN if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    elif [ -f pyproject.toml ]; then \
+        pip install --no-cache-dir .; \
+    fi
+
+# J-Prime exposes /health on :8000.
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 \
+    CMD curl -f http://localhost:8000/health || exit 1
+
+# J-Prime's own server. The compose generator runs the same command in-network.
+CMD ["python", "run_server.py"]

--- a/deploy/sandbox/Dockerfile.reactor.sandbox
+++ b/deploy/sandbox/Dockerfile.reactor.sandbox
@@ -1,0 +1,37 @@
+# Dockerfile.reactor.sandbox -- Reactor Core (Nerves) pre-baked sandbox image.
+#
+# TEMPLATE for the Pre-Flight Cache Manager's WAN-connected BAKE phase.
+# Built via:  docker build -f deploy/sandbox/Dockerfile.reactor.sandbox -t <tag> <reactor-root>
+# Build CONTEXT = the Reactor-Core repo root (JARVIS_REACTOR_REPO_PATH); the
+# Dockerfile stays JARVIS-side (never a cross-repo write into the sibling).
+#
+# Deps pip-installed HERE, WAN-connected, BEFORE the air-gapped network is
+# entered. The hash-tagged image carries them -- no pip-at-boot on the sinkhole.
+FROM python:3.11-slim
+
+# curl is required by the compose healthcheck (curl -f .../health).
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl \
+    && rm -rf /var/lib/apt/lists/*
+
+WORKDIR /app
+
+# Build context = the Reactor-Core repo root. Reactor commonly ships only a
+# pyproject.toml (no requirements.txt) -- handled by the fallback below.
+COPY . /app
+
+# Install the repo's deps in the WAN bake phase. requirements.txt preferred;
+# fall back to `pip install .` for a pyproject-only repo. Fail-CLOSED: install
+# failure fails the BUILD (no `|| true`) so a broken image is never cached.
+RUN if [ -f requirements.txt ]; then \
+        pip install --no-cache-dir -r requirements.txt; \
+    elif [ -f pyproject.toml ]; then \
+        pip install --no-cache-dir .; \
+    fi
+
+# Reactor Core exposes /health on :8090.
+HEALTHCHECK --interval=5s --timeout=3s --retries=20 \
+    CMD curl -f http://localhost:8090/health || exit 1
+
+# Reactor's own server. The compose generator runs the same command in-network.
+CMD ["python", "run_reactor.py"]

--- a/tests/governance/test_trinity_prebake_manager.py
+++ b/tests/governance/test_trinity_prebake_manager.py
@@ -1,0 +1,319 @@
+"""Tests for the Autonomous Pre-Flight Cache Manager (trinity_prebake_manager).
+
+NO real Docker / build. The docker command boundary is an injectable fake that
+records argv and returns scripted results. Proves:
+  * dep_hash is deterministic + changes when a dep file's CONTENT changes;
+  * sandbox_image_tag format (+ env prefix);
+  * is_image_cached True/False via fake `docker image inspect` rc;
+  * prebake_if_needed: disabled (skipped, inert) / fast-path (all cached, NO
+    build) / bake-path (only the missing built, WAN docker build issued) /
+    bake-failure (fail-CLOSED, caller must not proceed);
+  * the 3 Dockerfile.sandbox templates exist + carry FROM/pip-install/HEALTHCHECK/CMD.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.core.ouroboros.governance.saga import trinity_prebake_manager as pbm
+from backend.core.ouroboros.governance.saga.trinity_prebake_manager import (
+    CmdResult,
+    PrebakeResult,
+    dep_hash,
+    is_image_cached,
+    prebake_if_needed,
+    prebake_enabled,
+    sandbox_image_tag,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fake docker command boundary
+# --------------------------------------------------------------------------- #
+class FakeRunner:
+    """Records argv; returns scripted results.
+
+    ``inspect_present`` -> the set of repo keys whose `image inspect` returns rc0
+    (cached). ``build_fail`` -> the set of repo keys whose `docker build` fails.
+    """
+
+    def __init__(self, *, inspect_present=(), build_fail=()):
+        self.calls = []
+        self._present = set(inspect_present)
+        self._build_fail = set(build_fail)
+
+    async def __call__(self, argv):
+        self.calls.append(list(argv))
+        if argv[:3] == ["docker", "image", "inspect"]:
+            tag = argv[3]
+            # tag = <prefix>-<repo>:<hash>; extract repo between last '-' and ':'.
+            repo = tag.rsplit(":", 1)[0].rsplit("-", 1)[-1]
+            return CmdResult(0 if repo in self._present else 1)
+        if argv[:2] == ["docker", "build"]:
+            # -t <tag> is at a known offset; find repo from the tag.
+            tag = argv[argv.index("-t") + 1]
+            repo = tag.rsplit(":", 1)[0].rsplit("-", 1)[-1]
+            return CmdResult(1 if repo in self._build_fail else 0)
+        return CmdResult(0)
+
+    @property
+    def build_calls(self):
+        return [c for c in self.calls if c[:2] == ["docker", "build"]]
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in (
+        "JARVIS_TRINITY_PREBAKE_ENABLED",
+        "JARVIS_TRINITY_IMAGE_PREFIX",
+        "JARVIS_TRINITY_BAKE_TIMEOUT_S",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def _mk_repo(tmp_path, name, *, req=None, pyproj=None):
+    root = tmp_path / name
+    root.mkdir()
+    if req is not None:
+        (root / "requirements.txt").write_text(req, encoding="utf-8")
+    if pyproj is not None:
+        (root / "pyproject.toml").write_text(pyproj, encoding="utf-8")
+    return str(root)
+
+
+# --------------------------------------------------------------------------- #
+# dep_hash
+# --------------------------------------------------------------------------- #
+def test_dep_hash_deterministic(tmp_path):
+    root = _mk_repo(tmp_path, "r", req="flask==1.0\n", pyproj="[tool]\n")
+    assert dep_hash(root) == dep_hash(root)
+    assert len(dep_hash(root)) == 16
+    # ASCII hex.
+    int(dep_hash(root), 16)
+
+
+def test_dep_hash_changes_when_requirements_content_changes(tmp_path):
+    a = _mk_repo(tmp_path, "a", req="flask==1.0\n")
+    b = _mk_repo(tmp_path, "b", req="flask==2.0\n")
+    assert dep_hash(a) != dep_hash(b)
+
+
+def test_dep_hash_changes_when_pyproject_content_changes(tmp_path):
+    a = _mk_repo(tmp_path, "a", pyproj="[a]\nx=1\n")
+    b = _mk_repo(tmp_path, "b", pyproj="[a]\nx=2\n")
+    assert dep_hash(a) != dep_hash(b)
+
+
+def test_dep_hash_missing_files_is_stable_and_distinct(tmp_path):
+    empty = _mk_repo(tmp_path, "empty")  # no dep files
+    withreq = _mk_repo(tmp_path, "withreq", req="x\n")
+    # Two empty repos hash identically (deterministic empty sections).
+    empty2 = _mk_repo(tmp_path, "empty2")
+    assert dep_hash(empty) == dep_hash(empty2)
+    # Adding a dep file changes the hash (cache miss -> re-bake).
+    assert dep_hash(empty) != dep_hash(withreq)
+
+
+def test_dep_hash_split_matters(tmp_path):
+    # Same combined bytes but in different files must NOT collide (labelled).
+    a = _mk_repo(tmp_path, "a", req="abc", pyproj="")
+    b = _mk_repo(tmp_path, "b", req="", pyproj="abc")
+    assert dep_hash(a) != dep_hash(b)
+
+
+# --------------------------------------------------------------------------- #
+# sandbox_image_tag
+# --------------------------------------------------------------------------- #
+def test_sandbox_image_tag_format():
+    assert sandbox_image_tag("prime", "deadbeefcafe0001") == (
+        "jarvis-trinity-sandbox-prime:deadbeefcafe0001"
+    )
+
+
+def test_sandbox_image_tag_env_prefix(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRINITY_IMAGE_PREFIX", "custom-pfx")
+    assert sandbox_image_tag("reactor", "abcd").startswith("custom-pfx-reactor:")
+
+
+# --------------------------------------------------------------------------- #
+# is_image_cached
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_is_image_cached_true_false():
+    runner = FakeRunner(inspect_present={"prime"})
+    assert await is_image_cached("prime", "abcd", runner=runner) is True
+    assert await is_image_cached("reactor", "abcd", runner=runner) is False
+
+
+@pytest.mark.asyncio
+async def test_is_image_cached_failsoft_to_false():
+    async def raising(argv):
+        raise RuntimeError("docker absent")
+
+    # Any error -> treat as needs-bake (fail-CLOSED toward re-baking).
+    assert await is_image_cached("jarvis", "abcd", runner=raising) is False
+
+
+# --------------------------------------------------------------------------- #
+# prebake_enabled
+# --------------------------------------------------------------------------- #
+def test_prebake_disabled_by_default():
+    assert prebake_enabled() is False
+
+
+def test_prebake_enabled_truthy(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRINITY_PREBAKE_ENABLED", "true")
+    assert prebake_enabled() is True
+
+
+# --------------------------------------------------------------------------- #
+# prebake_if_needed -- disabled / inert
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_prebake_disabled_is_inert_no_commands(tmp_path):
+    j = _mk_repo(tmp_path, "j", req="x\n")
+    p = _mk_repo(tmp_path, "p", req="x\n")
+    r = _mk_repo(tmp_path, "r", pyproj="[a]\n")
+    runner = FakeRunner()
+    res = await prebake_if_needed(
+        jarvis_root=j, prime_root=p, reactor_root=r, runner=runner
+    )
+    assert res.skipped is True
+    assert res.reason == "prebake_disabled"
+    assert res.ok is True  # caller proceeds with the base-image path
+    assert runner.calls == []  # NO docker commands at all
+
+
+# --------------------------------------------------------------------------- #
+# prebake_if_needed -- fast path (all cached -> NO build)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_prebake_fast_path_all_cached_no_build(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TRINITY_PREBAKE_ENABLED", "1")
+    j = _mk_repo(tmp_path, "j", req="x\n")
+    p = _mk_repo(tmp_path, "p", req="y\n")
+    r = _mk_repo(tmp_path, "r", pyproj="[a]\n")
+    runner = FakeRunner(inspect_present={"jarvis", "prime", "reactor"})
+    res = await prebake_if_needed(
+        jarvis_root=j, prime_root=p, reactor_root=r, runner=runner
+    )
+    assert res.skipped is False
+    assert res.reason == "all_cached"
+    assert res.ok is True
+    assert set(res.cached) == {"jarvis", "prime", "reactor"}
+    assert res.baked == ()
+    assert set(res.images) == {"jarvis", "prime", "reactor"}
+    # NO build commands -- only inspects.
+    assert runner.build_calls == []
+
+
+# --------------------------------------------------------------------------- #
+# prebake_if_needed -- bake path (only missing built, WAN docker build)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_prebake_bakes_only_missing_wan_build(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TRINITY_PREBAKE_ENABLED", "yes")
+    j = _mk_repo(tmp_path, "j", req="x\n")
+    p = _mk_repo(tmp_path, "p", req="y\n")
+    r = _mk_repo(tmp_path, "r", pyproj="[a]\n")
+    # prime already cached; jarvis + reactor missing -> build only those 2.
+    runner = FakeRunner(inspect_present={"prime"})
+    res = await prebake_if_needed(
+        jarvis_root=j,
+        prime_root=p,
+        reactor_root=r,
+        runner=runner,
+        dockerfile_dir="deploy/sandbox",
+    )
+    assert res.reason == "baked"
+    assert res.ok is True
+    assert set(res.cached) == {"prime"}
+    assert set(res.baked) == {"jarvis", "reactor"}
+    builds = runner.build_calls
+    assert len(builds) == 2
+    built_repos = set()
+    for cmd in builds:
+        # docker build -f deploy/sandbox/Dockerfile.<repo>.sandbox -t <tag> <root>
+        assert cmd[:3] == ["docker", "build", "-f"]
+        dfile = cmd[3]
+        assert dfile.startswith("deploy/sandbox/Dockerfile.")
+        assert dfile.endswith(".sandbox")
+        repo = dfile.split("Dockerfile.")[1].rsplit(".sandbox", 1)[0]
+        built_repos.add(repo)
+        # build context = the repo root (last arg), NOT the dockerfile.
+        ctx = cmd[-1]
+        assert ctx in (j, p, r)
+    assert built_repos == {"jarvis", "reactor"}
+
+
+# --------------------------------------------------------------------------- #
+# prebake_if_needed -- bake FAILURE -> fail-CLOSED
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_prebake_bake_failure_is_fail_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TRINITY_PREBAKE_ENABLED", "true")
+    j = _mk_repo(tmp_path, "j", req="x\n")
+    p = _mk_repo(tmp_path, "p", req="y\n")
+    r = _mk_repo(tmp_path, "r", pyproj="[a]\n")
+    # reactor build fails.
+    runner = FakeRunner(inspect_present=(), build_fail={"reactor"})
+    res = await prebake_if_needed(
+        jarvis_root=j, prime_root=p, reactor_root=r, runner=runner
+    )
+    assert res.skipped is False
+    assert res.reason.startswith("bake_failed:reactor")
+    # The caller MUST NOT proceed.
+    assert res.ok is False
+
+
+@pytest.mark.asyncio
+async def test_prebake_bake_exception_is_fail_closed(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TRINITY_PREBAKE_ENABLED", "true")
+    j = _mk_repo(tmp_path, "j", req="x\n")
+    p = _mk_repo(tmp_path, "p", req="y\n")
+    r = _mk_repo(tmp_path, "r", pyproj="[a]\n")
+
+    class Boom:
+        def __init__(self):
+            self.calls = 0
+
+        async def __call__(self, argv):
+            if argv[:2] == ["docker", "build"]:
+                raise RuntimeError("daemon down")
+            return CmdResult(1)  # nothing cached -> everything needs bake
+
+    res = await prebake_if_needed(
+        jarvis_root=j, prime_root=p, reactor_root=r, runner=Boom()
+    )
+    assert res.ok is False
+    assert "bake_failed" in res.reason
+
+
+# --------------------------------------------------------------------------- #
+# The 3 Dockerfile.sandbox templates
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize(
+    "repo,port,cmd_token",
+    [
+        ("jarvis", "8091", "8091"),
+        ("prime", "8000", "run_server.py"),
+        ("reactor", "8090", "run_reactor.py"),
+    ],
+)
+def test_dockerfile_templates_exist_and_contain_required_directives(repo, port, cmd_token):
+    here = os.path.dirname(__file__)
+    repo_root = os.path.abspath(os.path.join(here, "..", ".."))
+    path = os.path.join(repo_root, "deploy", "sandbox", "Dockerfile.%s.sandbox" % repo)
+    assert os.path.isfile(path), path
+    text = open(path, "r", encoding="utf-8").read()
+    assert "FROM python:3.11-slim" in text
+    assert "pip install" in text
+    assert "HEALTHCHECK" in text
+    assert "/health" in text
+    assert port in text
+    assert "CMD" in text
+    assert cmd_token in text
+    # ASCII only.
+    text.encode("ascii")

--- a/tests/governance/test_trinity_prebake_wiring.py
+++ b/tests/governance/test_trinity_prebake_wiring.py
@@ -1,0 +1,171 @@
+"""Tests that the Pre-Flight Cache Manager is wired into TrinityDockerRunner.
+
+NO real Docker. Proves:
+  * the runner runs prebake BEFORE `up`, and passes the resulting image map into
+    generate_trinity_compose (so the air-gapped boot uses cached images);
+  * prebake disabled (default) -> existing path (images=None, no extra commands);
+  * a bake FAILURE -> FRACTURE, and the air-gapped `up` is NEVER reached
+    (fail-CLOSED: never boot air-gapped with a missing image).
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.saga.trinity_docker_runner as runner_mod
+from backend.core.ouroboros.governance.saga.trinity_docker_runner import (
+    CmdResult,
+    TrinityDockerRunner,
+)
+from backend.core.ouroboros.governance.saga.trinity_prebake_manager import PrebakeResult
+from backend.core.ouroboros.governance.saga.trinity_handshake_suite import (
+    HttpResponse,
+    MutatedEndpoint,
+)
+
+pytest.importorskip("yaml")
+
+_EPS = [MutatedEndpoint("reactor", "GET", "/metrics", ("count",))]
+
+
+class FakeCmd:
+    """Records argv in order. up/down rc scriptable."""
+
+    def __init__(self, up_rc=0, down_rc=0):
+        self.up_rc = up_rc
+        self.down_rc = down_rc
+        self.argvs = []
+        self.up_called = False
+        self.down_called = False
+
+    async def __call__(self, argv):
+        argv = list(argv)
+        self.argvs.append(argv)
+        if "up" in argv:
+            self.up_called = True
+            return CmdResult(self.up_rc)
+        if "down" in argv:
+            self.down_called = True
+            return CmdResult(self.down_rc)
+        return CmdResult(0)
+
+
+class FakeHttp:
+    async def call(self, method, url, *, timeout):
+        return HttpResponse(200, {"count": 1})
+
+
+def _runner(cmd):
+    async def health_checker():
+        return True
+
+    return TrinityDockerRunner(
+        jarvis_root="/repos/jarvis",
+        prime_root="/repos/prime",
+        reactor_root="/repos/reactor",
+        http_runner=FakeHttp(),
+        cmd_runner=cmd,
+        health_checker=health_checker,
+    )
+
+
+async def _run(runner):
+    return await runner.run(
+        mutated_endpoints=_EPS,
+        overlay_writer=lambda y: "/tmp/trinity_wire_test.yml",
+    )
+
+
+@pytest.mark.asyncio
+async def test_prebake_runs_before_up_and_images_passed_to_generator(monkeypatch):
+    images = {
+        "jarvis": "pfx-jarvis:aaaa",
+        "prime": "pfx-prime:bbbb",
+        "reactor": "pfx-reactor:cccc",
+    }
+    order = []
+
+    async def fake_prebake(**kwargs):
+        order.append("prebake")
+        return PrebakeResult(
+            images=dict(images), baked=("jarvis",), cached=("prime", "reactor"),
+            skipped=False, reason="baked",
+        )
+
+    seen = {}
+    real_generate = runner_mod.generate_trinity_compose
+
+    def spy_generate(**kwargs):
+        order.append("generate")
+        seen["images"] = kwargs.get("images")
+        return real_generate(**kwargs)
+
+    monkeypatch.setattr(runner_mod, "prebake_if_needed", fake_prebake)
+    monkeypatch.setattr(runner_mod, "generate_trinity_compose", spy_generate)
+
+    cmd = FakeCmd()
+    verdict = await _run(_runner(cmd))
+
+    # prebake ran, then generate, then up.
+    assert order[0] == "prebake"
+    assert order.index("prebake") < order.index("generate")
+    # The cached image map reached the generator.
+    assert seen["images"] == images
+    assert verdict.passed
+    assert cmd.up_called
+
+
+@pytest.mark.asyncio
+async def test_prebake_disabled_uses_existing_path_images_none(monkeypatch):
+    async def fake_prebake(**kwargs):
+        return PrebakeResult(skipped=True, reason="prebake_disabled")
+
+    seen = {}
+    real_generate = runner_mod.generate_trinity_compose
+
+    def spy_generate(**kwargs):
+        seen["images"] = kwargs.get("images")
+        return real_generate(**kwargs)
+
+    monkeypatch.setattr(runner_mod, "prebake_if_needed", fake_prebake)
+    monkeypatch.setattr(runner_mod, "generate_trinity_compose", spy_generate)
+
+    cmd = FakeCmd()
+    verdict = await _run(_runner(cmd))
+
+    # Disabled -> images=None -> generator falls back to its base-image path.
+    assert seen["images"] is None
+    assert verdict.passed
+    assert cmd.up_called
+
+
+@pytest.mark.asyncio
+async def test_bake_failure_fractures_and_never_ups(monkeypatch):
+    async def fake_prebake(**kwargs):
+        return PrebakeResult(
+            images={"jarvis": "pfx-jarvis:aaaa"},
+            baked=(), cached=(), skipped=False,
+            reason="bake_failed:reactor:rc=1",
+        )
+
+    monkeypatch.setattr(runner_mod, "prebake_if_needed", fake_prebake)
+
+    cmd = FakeCmd()
+    verdict = await _run(_runner(cmd))
+
+    assert verdict.fracture is True
+    assert not verdict.passed
+    assert verdict.reason.startswith("prebake_failed:bake_failed")
+    # Fail-CLOSED: the air-gapped `up` was NEVER reached.
+    assert cmd.up_called is False
+
+
+@pytest.mark.asyncio
+async def test_default_runner_unwired_still_works_prebake_disabled():
+    # No monkeypatch: real prebake_if_needed, default-OFF env -> skipped -> the
+    # legacy base-image path is used and the boot passes (proves OFF byte-ident).
+    cmd = FakeCmd()
+    verdict = await _run(_runner(cmd))
+    assert verdict.passed
+    # Only up + down + (health is injected) -> no docker build/inspect issued.
+    flat = [" ".join(a) for a in cmd.argvs]
+    assert not any("build" in f or "image inspect" in f for f in flat)


### PR DESCRIPTION
Closes the operational gap the Trinity sandbox boot exposed (#69680): the air-gap correctly blocks pip-at-boot, so deps must be PRE-BAKED. This is the autonomous cache+bake layer.

**`trinity_prebake_manager.py`** — the Pre-Flight Cache Manager:
- **Hash check:** `dep_hash(repo)` = sha256 over `requirements.txt` + `pyproject.toml` content → the cache key. A mutated dependency → new hash → cache miss → re-bake.
- **Fast path:** all 3 images cached (`docker image inspect <repo>:<hash>`) → proceed straight to the air-gapped sandbox using cached images (no build).
- **Autonomous pre-bake:** any image missing → a **WAN-connected** `docker build -f deploy/sandbox/Dockerfile.<repo>.sandbox <repo-root>` phase (PyPI reachable) bakes deps into the hash-tagged image — **strictly separated from + completed BEFORE** the `internal:true` air-gapped network is ever entered. Never pip in the air-gap.
- **Fail-CLOSED:** missing/uninspectable image → needs-bake; any bake failure → the runner FRACTUREs (never boots air-gapped with a missing image).

**`deploy/sandbox/Dockerfile.{jarvis,prime,reactor}.sandbox`** — the sandbox image templates live in JARVIS (used via `docker build -f` against the sibling-repo context) — **NOT in the sibling repos** (that would be a cross-repo write). Each: FROM python:3.11-slim + pip install + HEALTHCHECK /health + CMD server.

Wired into `TrinityDockerRunner` BEFORE `up` (bake-if-needed → generate with cached images → air-gapped boot). **Default-OFF** (`JARVIS_TRINITY_PREBAKE_ENABLED`): verified inert — `skipped=True`, zero docker calls, generator byte-identical (falls back to base-image path). Structurally complete + GCP-ready. 23 + 55 tests. $0 on the Mac.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autonomous pre-flight cache manager that pre-bakes hash-tagged images for Jarvis/Prime/Reactor in a WAN phase so the air-gapped boot runs without pip-at-boot. Default-off and fail-closed on bake errors to prevent booting the air-gap with missing images.

- **New Features**
  - Pre-bake manager: builds per-repo images using a dependency hash from `requirements.txt` + `pyproject.toml`, probes cache via `docker image inspect`, and bakes only missing images with `docker build -f deploy/sandbox/Dockerfile.<repo>.sandbox <repo-root>` (WAN-connected, never in the air-gap).
  - Compose generator now accepts an `images` map to run prebaked images directly (no bind-mount, no boot-time installs).
  - Runner runs prebake before `up`; on bake failure it fractures and never enters the air-gapped network.
  - Default-off via `JARVIS_TRINITY_PREBAKE_ENABLED`; when disabled, behavior is unchanged.
  - Adds sandbox Dockerfiles for `jarvis`, `prime`, `reactor` with healthchecks and repo COPY.

- **Migration**
  - Enable with `JARVIS_TRINITY_PREBAKE_ENABLED=true`.
  - Optional tuning: `JARVIS_TRINITY_IMAGE_PREFIX`, `JARVIS_TRINITY_BAKE_TIMEOUT_S`.
  - Ensure `docker` is available and WAN access is allowed during the bake phase; air-gapped runtime remains unchanged.

<sup>Written for commit 6c7daf0246e4101ff8acacf35ebcbf14110a7d50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69681?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

