### PR TITLE
feat: IaC Hypervisor — checkpoint/streaming + 6 live-run root-cause fixes (LIVE cross-repo rollback PROVEN on 32GB GCP node)

### DIFF
--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -48,14 +48,16 @@ from __future__ import annotations
 
 import argparse
 import datetime as _dt
+import json
 import os
 import pathlib
 import re
 import shlex
 import subprocess
 import sys
+import tempfile
 import time
-from typing import Callable, List, Optional, Tuple
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 # --------------------------------------------------------------------------- #
 # Repo root (the jarvis repo == the cwd repo).
@@ -98,6 +100,19 @@ _DEFAULT_SURGERY_CMD = os.environ.get(
     "python3 scripts/cross_repo_first_surgery.py --run",
 )
 
+# The remote prebake command -- the WAN Docker image layer build that happens ON
+# the node (it has WAN) BEFORE the air-gapped compose. This is the step that hits
+# first-run friction (a PyPI timeout pulling wheels). Streaming the remote
+# `docker build` layer output line-by-line + checkpointing it as its own phase is
+# exactly why a resume can skip a completed sync + re-run only the prebake.
+# Empty == prebake is folded into the surgery command (legacy single-exec).
+_DEFAULT_PREBAKE_CMD = os.environ.get("JARVIS_IAC_PREBAKE_CMD", "")
+
+# The remote boot command -- the air-gapped compose bring-up that happens AFTER
+# the prebake and BEFORE the surgery. Streamed as the `booted` phase. Empty ==
+# the boot is folded into the surgery command (legacy single-exec).
+_DEFAULT_BOOT_CMD = os.environ.get("JARVIS_IAC_BOOT_CMD", "")
+
 # Completion-sentinel the surgery writes -- the node-side dead-man fires
 # IMMEDIATELY when it appears (don't wait the idle timeout).
 _COMPLETION_SENTINEL = os.environ.get(
@@ -106,6 +121,38 @@ _COMPLETION_SENTINEL = os.environ.get(
 
 # Local autopsy output dir.
 _AUTOPSY_DIR = os.environ.get("JARVIS_IAC_AUTOPSY_DIR", "autopsy_reports")
+
+# --------------------------------------------------------------------------- #
+# Checkpoint ledger (resume-don't-restart). A local JSON file records the live
+# node + per-phase completion so a 40-min multi-stage run that hits first-run
+# friction (PyPI timeout in the prebake, an SSH blip) can be RE-RUN to RESUME
+# from the first incomplete phase against the still-warm node, instead of
+# re-provisioning + re-syncing from zero. Env-overridable path -- no hardcoding.
+# --------------------------------------------------------------------------- #
+_DEFAULT_STATE_PATH = os.environ.get("JARVIS_IAC_STATE_PATH", ".hypervisor_state.json")
+
+# The node-side dead-man idle timeout the operator can tune so a warm node left
+# for resume is bounded (no infinite orphan) yet generous enough to re-run an
+# --execute resume. This is the env the spec calls out; it feeds the same
+# dead-man builder knob (_DEFAULT_DEADMAN_IDLE_TIMEOUT_S) when set.
+_DEFAULT_NODE_IDLE_TIMEOUT_S = int(
+    os.environ.get(
+        "JARVIS_IAC_NODE_IDLE_TIMEOUT_S",
+        os.environ.get("JARVIS_IAC_DEADMAN_IDLE_TIMEOUT_S", "3600"),
+    )
+)
+
+# The ordered pipeline phases recorded in the ledger. The orchestrator walks
+# these in order; a RESUME skips every phase already marked complete and starts
+# at the first incomplete one.
+_PHASE_ORDER: List[str] = [
+    "provisioned",
+    "docker_ready",
+    "synced",
+    "prebaked",
+    "booted",
+    "surgery_done",
+]
 
 # Readiness sentinel written by the node startup-script once Docker is up.
 _READY_SENTINEL = "/var/run/sovereign_iac_ready"
@@ -124,6 +171,129 @@ def _log(msg: str) -> None:
 
 def _abort(msg: str) -> None:
     print(f"[IAC ABORTED: {msg}]", flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# Checkpoint ledger -- the resume-don't-restart state file.
+# --------------------------------------------------------------------------- #
+class CheckpointLedger:
+    """A local `.hypervisor_state.json` ledger recording the live node + per-phase
+    completion so an --execute that hit a *resumable* mid-pipeline failure can be
+    RE-RUN to resume from the first incomplete phase against the still-warm node.
+
+    Schema (JSON):
+        {
+          "run_id": "<cli-passed or now-stamp>",
+          "node_name": "...", "zone": "...", "project": "...",
+          "external_ip": "<ip or ''>",   # connection info (best-effort)
+          "phases": { "<phase>": {"status": "complete", "ts": "<iso>"}, ... },
+          "updated": "<iso>"
+        }
+
+    Atomic writes (tmpfile + os.replace). Fail-soft: a corrupt/absent ledger
+    reads as empty; a write error logs and is swallowed (the run still works,
+    it just loses resumability for that step). NO authority -- it never decides
+    to spend money on its own; resume only happens when the node is verified
+    ALIVE by the orchestrator.
+    """
+
+    def __init__(self, path: str) -> None:
+        self.path = pathlib.Path(path)
+
+    # -- read -------------------------------------------------------------- #
+    def read(self) -> Dict[str, Any]:
+        try:
+            if not self.path.exists():
+                return {}
+            raw = self.path.read_text(encoding="utf-8")
+            data = json.loads(raw)
+            if isinstance(data, dict):
+                return data
+            return {}
+        except Exception as exc:  # noqa: BLE001 -- a corrupt ledger reads as empty
+            _log(f"checkpoint read failed ({exc!r}); treating as no checkpoint")
+            return {}
+
+    # -- write (atomic) ---------------------------------------------------- #
+    def write(self, data: Dict[str, Any]) -> None:
+        try:
+            data = dict(data)
+            data["updated"] = _iso_now()
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+            fd, tmp = tempfile.mkstemp(
+                prefix=self.path.name + ".", suffix=".tmp",
+                dir=str(self.path.parent),
+            )
+            try:
+                with os.fdopen(fd, "w", encoding="utf-8") as fh:
+                    json.dump(data, fh, indent=2, sort_keys=True)
+                os.replace(tmp, str(self.path))
+            finally:
+                try:
+                    if os.path.exists(tmp):
+                        os.unlink(tmp)
+                except OSError:
+                    pass
+        except Exception as exc:  # noqa: BLE001 -- a write error never crashes the run
+            _log(f"checkpoint write failed ({exc!r}); resumability degraded for this step")
+
+    # -- mutate ------------------------------------------------------------ #
+    def init_run(
+        self, *, run_id: str, node_name: str, zone: str, project: str,
+        external_ip: str = "",
+    ) -> Dict[str, Any]:
+        """Seed a fresh ledger for a brand-new node (clears any prior phases)."""
+        data: Dict[str, Any] = {
+            "run_id": run_id,
+            "node_name": node_name,
+            "zone": zone,
+            "project": project,
+            "external_ip": external_ip,
+            "phases": {},
+        }
+        self.write(data)
+        return data
+
+    def mark_phase(self, data: Dict[str, Any], phase: str, **info: Any) -> Dict[str, Any]:
+        """Stamp *phase* complete and persist atomically. `info` (e.g. external_ip)
+        is merged at the top level so connection info can be recorded as it lands."""
+        phases = dict(data.get("phases") or {})
+        phases[phase] = {"status": "complete", "ts": _iso_now()}
+        data["phases"] = phases
+        for k, v in info.items():
+            data[k] = v
+        self.write(data)
+        return data
+
+    def clear(self) -> None:
+        try:
+            if self.path.exists():
+                self.path.unlink()
+        except OSError as exc:
+            _log(f"checkpoint clear failed ({exc!r}); next run uses --fresh semantics anyway")
+
+    # -- queries ----------------------------------------------------------- #
+    @staticmethod
+    def phase_complete(data: Dict[str, Any], phase: str) -> bool:
+        rec = (data.get("phases") or {}).get(phase) or {}
+        return rec.get("status") == "complete"
+
+    @classmethod
+    def first_incomplete(cls, data: Dict[str, Any]) -> Optional[str]:
+        """First phase in _PHASE_ORDER not yet complete (None == all done)."""
+        for phase in _PHASE_ORDER:
+            if not cls.phase_complete(data, phase):
+                return phase
+        return None
+
+    @classmethod
+    def completed_phases(cls, data: Dict[str, Any]) -> List[str]:
+        return [p for p in _PHASE_ORDER if cls.phase_complete(data, p)]
+
+
+def _iso_now() -> str:
+    """ISO-8601 UTC timestamp for ledger records (stable, sortable)."""
+    return _dt.datetime.now(_dt.timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
 
 
 # --------------------------------------------------------------------------- #
@@ -171,7 +341,7 @@ def _run_streaming(
             stdout=subprocess.PIPE,
             stderr=subprocess.STDOUT,
             text=True,
-            bufsize=1,  # line-buffered
+            bufsize=1,  # line-buffered -- lines arrive + stream as the command runs
         )
         deadline = time.monotonic() + timeout_s
         assert proc.stdout is not None
@@ -192,6 +362,53 @@ def _run_streaming(
     except Exception as exc:  # noqa: BLE001 -- never crash the orchestrator
         captured.append(f"[IAC] streaming exec failed: {exc!r}\n")
         return 1, captured
+
+
+def _make_labeled_sink(label: str, log_path: Optional[pathlib.Path]) -> Callable[[str], None]:
+    """Build a sink that prefixes every streamed line with `[<label>] ` and TEES
+    it to *log_path* (the per-run autopsy log) so the full live stream is also
+    captured on disk for post-mortem -- the operator follows which stage is
+    talking in real-time, and nothing is lost if the terminal scrolls away.
+
+    Fail-soft on the file write (a tee failure never stops the live stream)."""
+    prefix = f"[{label}] "
+
+    def _sink(line: str) -> None:
+        # Normalize the raw line (it usually carries its own trailing newline)
+        # to exactly one prefixed line; stream LIVE to the local terminal.
+        out = prefix + line.rstrip("\n") + "\n"
+        sys.stdout.write(out)
+        sys.stdout.flush()
+        if log_path is not None:
+            try:
+                with open(log_path, "a", encoding="utf-8") as fh:
+                    fh.write(out)
+            except Exception:  # noqa: BLE001 -- a tee failure never blocks the stream
+                pass
+
+    return _sink
+
+
+def _run_streaming_labeled(
+    cmd: List[str], *, label: str, log_path: Optional[pathlib.Path] = None,
+    timeout_s: float = 3600.0,
+) -> Tuple[int, List[str]]:
+    """Convenience: stream *cmd* live with a phase `label` prefix + tee to log.
+    Used for the long phases (provision / sync / prebake / surgery)."""
+    return _run_streaming(cmd, timeout_s=timeout_s, sink=_make_labeled_sink(label, log_path))
+
+
+def _run_log_path(run_id: str) -> Optional[pathlib.Path]:
+    """The per-run tee log `autopsy_reports/iac_run_<run-id>.log` -- the full
+    streamed transcript for autopsy. Fail-soft (None if the dir can't be made)."""
+    try:
+        safe = re.sub(r"[^A-Za-z0-9_.-]", "_", run_id)[:80] or "run"
+        outdir = pathlib.Path(_AUTOPSY_DIR)
+        outdir.mkdir(parents=True, exist_ok=True)
+        return outdir / f"iac_run_{safe}.log"
+    except Exception as exc:  # noqa: BLE001
+        _log(f"run-log path setup failed ({exc!r}); streaming continues without tee")
+        return None
 
 
 # --------------------------------------------------------------------------- #
@@ -513,7 +730,9 @@ def _rsync_cmd(
         "--tunnel-through-iap --command"
     )
     return [
-        "rsync", "-az", "--delete",
+        # -v + --progress so the live stream carries per-file + progress-bar
+        # output the operator can watch line-by-line during the long sync.
+        "rsync", "-az", "--delete", "--progress", "-v",
         *exclude_flags,
         "-e", ssh_transport,
         local_dir.rstrip("/") + "/",
@@ -537,26 +756,55 @@ def _describe_node_cmd(args: argparse.Namespace, node: str) -> List[str]:
     ]
 
 
+def _describe_status_cmd(args: argparse.Namespace, node: str) -> List[str]:
+    """Describe the node's lifecycle status -- RUNNING means it is warm + alive
+    and a RESUME can reconnect to it (vs burned / preempted / terminated)."""
+    return [
+        "gcloud", "compute", "instances", "describe", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--format=value(status)",
+    ]
+
+
+def node_is_alive(args: argparse.Namespace, node: str) -> bool:
+    """Verify the node is still warm via `gcloud instances describe status`.
+
+    Returns True ONLY when describe succeeds AND status == RUNNING. A burned /
+    preempted / terminated node (describe rc != 0, or any non-RUNNING status)
+    returns False -> the orchestrator starts clean. Fail-soft: a describe error
+    is treated as 'not alive' (cannot confirm warm == start fresh, never resume
+    into a node we cannot prove is up)."""
+    rc, out = _run(_describe_status_cmd(args, node), timeout_s=60.0)
+    alive = rc == 0 and (out or "").strip().upper() == "RUNNING"
+    _log(f"resume-check: node {node} status={(out or '').strip() or '<none>'} -> {'ALIVE' if alive else 'not resumable'}")
+    return alive
+
+
 # --------------------------------------------------------------------------- #
 # Phase 1: Cloud Projector (provision).
 # --------------------------------------------------------------------------- #
 def provision_sandbox_node(
-    args: argparse.Namespace, node: str, startup_script: str
+    args: argparse.Namespace, node: str, startup_script: str,
+    log_path: Optional[pathlib.Path] = None,
 ) -> Tuple[bool, str]:
-    """Create the e2-standard-8 Spot node with the burn startup-script.
+    """Create the e2-standard-8 Spot node with the burn startup-script, STREAMING
+    the `gcloud compute instances create` output line-by-line to the local
+    terminal (prefixed `[provision] ...`) so the operator follows provisioning
+    live instead of waiting on a silent capture.
 
     Returns (ok, detail). Fail-soft.
     """
-    import tempfile
-
     fd, sp_path = tempfile.mkstemp(prefix="sovereign_iac_startup_", suffix=".sh")
     try:
         with os.fdopen(fd, "w") as fh:
             fh.write(startup_script)
         _log(f"provisioning {node} (e2-standard-8 SPOT, 32GB, DELETE-on-preempt)")
-        rc, out = _run(_create_node_cmd(args, node, sp_path), timeout_s=300.0)
+        rc, captured = _run_streaming_labeled(
+            _create_node_cmd(args, node, sp_path),
+            label="provision", log_path=log_path, timeout_s=300.0,
+        )
         if rc != 0:
-            return False, f"provision failed rc={rc}: {out.strip()[:400]}"
+            return False, f"provision failed rc={rc}: {''.join(captured).strip()[:400]}"
         return True, "provisioned"
     finally:
         try:
@@ -604,10 +852,13 @@ def _resolve_repo_paths(args: argparse.Namespace) -> List[Tuple[str, str]]:
 
 
 def sync_repos_to_node(
-    args: argparse.Namespace, node: str, excludes: List[str]
+    args: argparse.Namespace, node: str, excludes: List[str],
+    log_path: Optional[pathlib.Path] = None,
 ) -> Tuple[bool, str]:
-    """rsync/scp the 3 repos into /opt/trinity/{jarvis,prime,reactor}. Excludes
-    .git/__pycache__/node_modules/.venv/etc -- keep the beam lean. Bounded.
+    """rsync/scp the 3 repos into /opt/trinity/{jarvis,prime,reactor}, STREAMING
+    the transfer output (rsync --progress -v / scp progress) line-by-line to the
+    local terminal (prefixed `[sync] ...`). Excludes .git/__pycache__/etc -- keep
+    the beam lean. Bounded.
 
     Transport selected by JARVIS_IAC_SYNC_TRANSPORT (default scp -- robust over
     IAP). Returns (ok, detail). Fail-soft.
@@ -622,10 +873,12 @@ def sync_repos_to_node(
             cmd = _rsync_cmd(args, node, local, remote_dir, excludes)
         else:
             cmd = _scp_cmd(args, node, local, remote_dir, excludes)
-        _log(f"syncing {name}: {local} -> {node}:{remote_dir} (transport={transport})")
-        rc, out = _run(cmd, timeout_s=float(args.sync_timeout_s))
+        _log(f"syncing {name}: {local} -> {node}:{remote_dir} (transport={transport}, streamed)")
+        rc, captured = _run_streaming_labeled(
+            cmd, label="sync", log_path=log_path, timeout_s=float(args.sync_timeout_s),
+        )
         if rc != 0:
-            return False, f"sync of '{name}' failed rc={rc}: {out.strip()[:300]}"
+            return False, f"sync of '{name}' failed rc={rc}: {''.join(captured).strip()[:300]}"
     return True, "synced"
 
 
@@ -667,19 +920,96 @@ def parse_verdict(captured: List[str]) -> str:
     return "UNKNOWN"
 
 
+def _remote_prebake_shell(args: argparse.Namespace) -> str:
+    """The remote prebake shell: cd into the synced jarvis repo, set the trinity
+    env, run the WAN prebake command (the `docker build` layer pull). Does NOT
+    touch the completion-sentinel -- prebake is a mid-pipeline step the resume
+    can re-run; only the surgery's terminal verdict drops the sentinel."""
+    jr = f"{_REMOTE_TRINITY_ROOT}/jarvis"
+    pr = f"{_REMOTE_TRINITY_ROOT}/prime"
+    rr = f"{_REMOTE_TRINITY_ROOT}/reactor"
+    env = (
+        f"export JARVIS_PRIME_REPO_PATH={shlex.quote(pr)}; "
+        f"export JARVIS_REACTOR_REPO_PATH={shlex.quote(rr)}; "
+        "export JARVIS_TRINITY_PREBAKE_ENABLED=1; "
+    )
+    return f"cd {shlex.quote(jr)} && {env} {args.prebake_cmd}"
+
+
+def run_remote_prebake(
+    args: argparse.Namespace, node: str, log_path: Optional[pathlib.Path] = None,
+) -> Tuple[bool, str]:
+    """SSH-exec the WAN prebake (remote `docker build` layer build) remotely,
+    STREAMING the layer-build output line-by-line to the local terminal
+    (prefixed `[prebake] ...`). This is the first-run-friction step (PyPI
+    timeout); checkpointing it as its own phase lets a resume skip a completed
+    sync and re-run ONLY the prebake. Returns (ok, detail). Fail-soft.
+
+    When JARVIS_IAC_PREBAKE_CMD is empty the prebake is folded into the surgery
+    command (legacy single-exec) -- this returns ok with a 'skipped' detail."""
+    if not (args.prebake_cmd or "").strip():
+        return True, "prebake folded into surgery (no JARVIS_IAC_PREBAKE_CMD)"
+    remote = _remote_prebake_shell(args)
+    cmd = _ssh_cmd(args, node, remote)
+    _log("running remote prebake (WAN docker build, streaming to local terminal)...")
+    rc, captured = _run_streaming_labeled(
+        cmd, label="prebake", log_path=log_path, timeout_s=float(args.prebake_timeout_s),
+    )
+    if rc != 0:
+        return False, f"prebake failed rc={rc}: {''.join(captured).strip()[:400]}"
+    return True, "prebaked"
+
+
+def _remote_boot_shell(args: argparse.Namespace) -> str:
+    """The remote boot shell: cd into the synced jarvis repo, set the trinity env,
+    bring up the air-gapped compose (the `booted` phase). No completion-sentinel
+    -- boot is a mid-pipeline step a resume can re-run."""
+    jr = f"{_REMOTE_TRINITY_ROOT}/jarvis"
+    pr = f"{_REMOTE_TRINITY_ROOT}/prime"
+    rr = f"{_REMOTE_TRINITY_ROOT}/reactor"
+    env = (
+        f"export JARVIS_PRIME_REPO_PATH={shlex.quote(pr)}; "
+        f"export JARVIS_REACTOR_REPO_PATH={shlex.quote(rr)}; "
+    )
+    return f"cd {shlex.quote(jr)} && {env} {args.boot_cmd}"
+
+
+def run_remote_boot(
+    args: argparse.Namespace, node: str, log_path: Optional[pathlib.Path] = None,
+) -> Tuple[bool, str]:
+    """SSH-exec the air-gapped compose boot remotely, STREAMING line-by-line
+    (prefixed `[boot] ...`). Checkpointed as the `booted` phase. Returns
+    (ok, detail). Fail-soft. Empty JARVIS_IAC_BOOT_CMD == folded into surgery."""
+    if not (args.boot_cmd or "").strip():
+        return True, "boot folded into surgery (no JARVIS_IAC_BOOT_CMD)"
+    remote = _remote_boot_shell(args)
+    cmd = _ssh_cmd(args, node, remote)
+    _log("running remote boot (air-gap compose, streaming to local terminal)...")
+    rc, captured = _run_streaming_labeled(
+        cmd, label="boot", log_path=log_path, timeout_s=float(args.boot_timeout_s),
+    )
+    if rc != 0:
+        return False, f"boot failed rc={rc}: {''.join(captured).strip()[:400]}"
+    return True, "booted"
+
+
 def run_remote_surgery(
-    args: argparse.Namespace, node: str
+    args: argparse.Namespace, node: str, log_path: Optional[pathlib.Path] = None,
 ) -> Tuple[int, List[str], str]:
     """SSH-exec the Trinity surgery remotely, STREAMING stdout/stderr to the local
-    terminal in real-time. Returns (rc, captured_lines, verdict). Fail-soft.
+    terminal in real-time (prefixed `[surgery] ...`). Returns (rc, captured_lines,
+    verdict). Fail-soft.
 
     The WAN prebake happens ON the node before the air-gap compose -- the surgery
-    command drives the full prebake -> air-gap flow locally on the node.
+    command drives the full prebake -> air-gap flow locally on the node (when no
+    separate JARVIS_IAC_PREBAKE_CMD ran the prebake as its own checkpointed phase).
     """
     remote = _remote_surgery_shell(args)
     cmd = _ssh_cmd(args, node, remote)
     _log("running remote surgery (streaming to local terminal in real-time)...")
-    rc, captured = _run_streaming(cmd, timeout_s=float(args.surgery_timeout_s))
+    rc, captured = _run_streaming_labeled(
+        cmd, label="surgery", log_path=log_path, timeout_s=float(args.surgery_timeout_s),
+    )
     verdict = parse_verdict(captured)
     _log(f"remote surgery finished rc={rc} verdict={verdict}")
     return rc, captured, verdict
@@ -835,64 +1165,285 @@ def _print_plan(args: argparse.Namespace, node: str, startup_script: str, exclud
           "--i-understand-this-spends-money to run.")
 
 
+def _print_checkpoint_plan(args: argparse.Namespace, ledger: CheckpointLedger, run_id: str) -> None:
+    """Dry-run: surface the checkpoint/resume + streaming plan (spends nothing)."""
+    print("-" * 72)
+    print("CHECKPOINT / RESUME PLAN (resume-don't-restart):")
+    print(f"  state ledger     : {ledger.path}  (env JARVIS_IAC_STATE_PATH)")
+    print(f"  run-id           : {run_id}")
+    print(f"  phase order      : {' -> '.join(_PHASE_ORDER)}")
+    data = ledger.read()
+    if data.get("node_name"):
+        completed = CheckpointLedger.completed_phases(data)
+        resume_at = CheckpointLedger.first_incomplete(data)
+        print(f"  EXISTING checkpoint: node={data.get('node_name')} "
+              f"zone={data.get('zone')} completed={completed or '<none>'}")
+        if args.fresh:
+            print("  --fresh           : the checkpoint would be CLEARED -> brand-new node")
+        else:
+            print(f"  on --execute      : if node is RUNNING -> RESUME from '{resume_at}' "
+                  f"(skip {completed or '<none>'}); if GONE -> fresh node")
+    else:
+        print("  EXISTING checkpoint: <none>  -> --execute starts a fresh node")
+    print(f"  keep-warm-on-fail : {args.keep_warm_on_failure}  "
+          f"(resumable failure -> node LEFT WARM + checkpoint persisted + non-zero exit)")
+    print(f"  burn-on-failure   : {args.burn_on_failure}  (force-burn even on resumable failure)")
+    print("  NO-ORPHAN BACKSTOP: keep-warm is bounded -- node-side dead-man "
+          f"idle>{args.node_idle_timeout_s}s + max-run-duration={args.max_run_duration_s}s "
+          "+ Spot DELETE-on-preempt remain armed + independent of this process.")
+    print("-" * 72)
+    print("STREAMING PLAN (every long phase streams stdout/stderr LIVE, line-by-line):")
+    print("  [provision] gcloud compute instances create ... (provisioning)")
+    print("  [sync]      rsync --progress -v / scp ... (per-file + progress bars)")
+    print("  [prebake]   remote docker build ... (WAN image layer builds)")
+    print("  [boot]      remote air-gap compose bring-up ...")
+    print("  [surgery]   remote Trinity surgery + FRACTURE/PASS ...")
+    print(f"  tee log     : {_AUTOPSY_DIR}/iac_run_<run-id>.log (full transcript captured)")
+    print("-" * 72)
+
+
 # --------------------------------------------------------------------------- #
 # Execute pipeline.
 # --------------------------------------------------------------------------- #
-def _execute(args: argparse.Namespace, node: str, startup_script: str, excludes: List[str]) -> int:
-    node_exists = False
+def resolve_run_context(
+    args: argparse.Namespace, ledger: CheckpointLedger, default_node: str, run_id: str,
+) -> Tuple[str, Dict[str, Any], bool]:
+    """Decide RESUME vs FRESH from the ledger + the live node status.
+
+    Returns (node, ledger_data, resuming):
+      * RESUME  -- a node is recorded AND verified still RUNNING AND not --fresh:
+                   reconnect to the warm node, ledger_data carries the completed
+                   phases, resuming=True. The orchestrator skips completed phases.
+      * FRESH   -- no record / recorded node GONE (burned/preempted) / --fresh:
+                   the ledger is cleared + re-seeded for `default_node`,
+                   resuming=False.
+
+    No money is spent here -- a resume only reconnects to a node ALREADY proven
+    alive by `node_is_alive` (gcloud describe status == RUNNING)."""
+    prior = ledger.read()
+    recorded_node = (prior.get("node_name") or "").strip()
+
+    if args.fresh:
+        if recorded_node:
+            _log(f"--fresh: ignoring checkpoint for {recorded_node}, starting clean")
+        ledger.clear()
+        data = ledger.init_run(
+            run_id=run_id, node_name=default_node, zone=args.zone, project=args.project,
+        )
+        return default_node, data, False
+
+    if not recorded_node:
+        data = ledger.init_run(
+            run_id=run_id, node_name=default_node, zone=args.zone, project=args.project,
+        )
+        return default_node, data, False
+
+    # A node is recorded -- is it still warm? Reuse its zone/project from the
+    # ledger so the alive-check targets the SAME node that was provisioned.
+    probe_args = argparse.Namespace(**vars(args))
+    probe_args.zone = prior.get("zone") or args.zone
+    probe_args.project = prior.get("project") or args.project
+    if node_is_alive(probe_args, recorded_node):
+        completed = CheckpointLedger.completed_phases(prior)
+        resume_at = CheckpointLedger.first_incomplete(prior) or "surgery_done"
+        synced = CheckpointLedger.phase_complete(prior, "synced")
+        print(
+            f"[IAC RESUME] node {recorded_node} warm, files synced={synced}, "
+            f"resuming from phase {resume_at} (skipping {completed or '<none>'})",
+            flush=True,
+        )
+        # Inherit the recorded zone/project so we keep talking to the same node.
+        args.zone = probe_args.zone
+        args.project = probe_args.project
+        return recorded_node, prior, True
+
+    # Recorded node is GONE (burned / preempted / terminated) -> start clean.
+    _log(f"checkpoint node {recorded_node} is GONE (not RUNNING) -- starting fresh")
+    ledger.clear()
+    data = ledger.init_run(
+        run_id=run_id, node_name=default_node, zone=args.zone, project=args.project,
+    )
+    return default_node, data, False
+
+
+def _execute(
+    args: argparse.Namespace, node: str, startup_script: str, excludes: List[str],
+    ledger: Optional[CheckpointLedger] = None, ledger_data: Optional[Dict[str, Any]] = None,
+    resuming: bool = False, log_path: Optional[pathlib.Path] = None,
+) -> int:
+    """Run the checkpointed pipeline. Each phase, on success, stamps the ledger
+    (atomic) so a *resumable* mid-pipeline failure can be re-run to resume from
+    the first incomplete phase against the still-warm node.
+
+    BURN POLICY (the #1 invariant, refined for resumability):
+      * TERMINAL outcome (PASS / FRACTURE)  -> BURN ALWAYS. The surgery reached a
+        verdict; the node has served its purpose.
+      * UNRECOVERABLE error (raised exception / SSH-drop mid-finally) -> BURN. We
+        cannot prove the node is in a resumable state, so we do not leave it warm.
+      * --burn-on-failure -> BURN even on a resumable failure (operator cleanup).
+      * RESUMABLE mid-pipeline failure (e.g. prebake PyPI timeout) with
+        --keep-warm-on-failure (default TRUE) -> DO NOT burn: log the autopsy,
+        leave the node WARM, persist the checkpoint, EXIT non-zero so the operator
+        re-runs --execute to resume.
+
+    NO-ORPHAN BACKSTOP (the trade made explicit): keep-warm enables resume, but a
+    warm-left node can NEVER orphan forever -- the node-side dead-man (idle >
+    JARVIS_IAC_NODE_IDLE_TIMEOUT_S) + the GCP max_run_duration hard ceiling + the
+    Spot DELETE-on-preempt are still armed and independent of this process. The
+    idle timeout is generous enough to permit a resume yet bounded; the max-run
+    duration is the absolute ceiling. The local burn is one of FOUR teardowns;
+    skipping it for resume does not remove the other three.
+    """
+    if ledger is None:
+        ledger = CheckpointLedger(args.state_path)
+    data: Dict[str, Any] = ledger_data if ledger_data is not None else ledger.read()
+
+    node_exists = resuming or CheckpointLedger.phase_complete(data, "provisioned")
     verdict = "UNKNOWN"
     surgery_output: List[str] = []
     surgery_rc = 1
     abort_reason = ""
     succeeded = False
-    try:
-        # PHASE 1: PROVISION.
-        ok, detail = provision_sandbox_node(args, node, startup_script)
-        if not ok:
-            _abort(detail)
-            abort_reason = detail
-            return 4
-        node_exists = True
-        _log(f"node {node} created; startup-script installing Docker + burn watchdog")
+    resumable_failure = False  # set True when a phase fails recoverably
 
-        # PHASE 1b: POLL READY.
-        ready, reason = poll_node_ready(args, node)
-        if not ready:
-            _abort(f"readiness abort: {reason}")
-            abort_reason = reason
-            return 5
+    def _done(phase: str) -> bool:
+        return CheckpointLedger.phase_complete(data, phase)
+
+    try:
+        # PHASE 1: PROVISION. (skip if already provisioned on a warm resume)
+        if not _done("provisioned"):
+            ok, detail = provision_sandbox_node(args, node, startup_script, log_path=log_path)
+            if not ok:
+                _abort(detail)
+                abort_reason = detail
+                resumable_failure = True
+                return 4
+            node_exists = True
+            data = ledger.mark_phase(data, "provisioned")
+            _log(f"node {node} created; startup-script installing Docker + burn watchdog")
+        else:
+            _log("[resume] phase provisioned already complete -- skipping create")
+        node_exists = True
+
+        # PHASE 1b: DOCKER READY (poll for the ready sentinel).
+        if not _done("docker_ready"):
+            ready, reason = poll_node_ready(args, node)
+            if not ready:
+                _abort(f"readiness abort: {reason}")
+                abort_reason = reason
+                resumable_failure = True
+                return 5
+            data = ledger.mark_phase(data, "docker_ready")
+        else:
+            _log("[resume] phase docker_ready already complete -- skipping poll")
 
         # PHASE 2: SYNC BRIDGE.
-        ok, detail = sync_repos_to_node(args, node, excludes)
-        if not ok:
-            _abort(f"sync abort: {detail}")
-            abort_reason = detail
-            return 6
+        if not _done("synced"):
+            ok, detail = sync_repos_to_node(args, node, excludes, log_path=log_path)
+            if not ok:
+                _abort(f"sync abort: {detail}")
+                abort_reason = detail
+                resumable_failure = True
+                return 6
+            data = ledger.mark_phase(data, "synced")
+        else:
+            _log("[resume] phase synced already complete -- skipping sync")
 
-        # PHASE 3: REMOTE SURGERY (streamed).
-        surgery_rc, surgery_output, verdict = run_remote_surgery(args, node)
-        succeeded = True  # we reached the verdict; PASS or FRACTURE are both terminal
-        return 0 if verdict in ("PASS", "FRACTURE") else 7
+        # PHASE 2b: PREBAKE (WAN docker build -- the first-run-friction step).
+        if not _done("prebaked"):
+            ok, detail = run_remote_prebake(args, node, log_path=log_path)
+            if not ok:
+                _abort(f"prebake abort: {detail}")
+                abort_reason = detail
+                resumable_failure = True
+                return 8
+            data = ledger.mark_phase(data, "prebaked")
+        else:
+            _log("[resume] phase prebaked already complete -- skipping prebake")
+
+        # PHASE 2c: BOOT (air-gapped compose bring-up).
+        if not _done("booted"):
+            ok, detail = run_remote_boot(args, node, log_path=log_path)
+            if not ok:
+                _abort(f"boot abort: {detail}")
+                abort_reason = detail
+                resumable_failure = True
+                return 9
+            data = ledger.mark_phase(data, "booted")
+        else:
+            _log("[resume] phase booted already complete -- skipping boot")
+
+        # PHASE 3: REMOTE SURGERY (streamed). This is TERMINAL -- PASS/FRACTURE.
+        surgery_rc, surgery_output, verdict = run_remote_surgery(args, node, log_path=log_path)
+        if verdict in ("PASS", "FRACTURE"):
+            data = ledger.mark_phase(data, "surgery_done", verdict=verdict)
+            succeeded = True  # reached a terminal verdict
+            return 0
+        # No verdict -> the surgery did not converge; treat as resumable (the node
+        # is warm + synced + prebaked, a re-run resumes straight at surgery).
+        resumable_failure = True
+        return 7
     finally:
-        # PHASE 4: THE ULTIMATE BURN -- ALWAYS runs (PASS / FRACTURE / exception
-        # / SSH-drop). The burn is the #1 invariant: no orphaned 32GB node under
-        # ANY exit. Autopsy-before-burn on failure (NEVER blocks the burn).
-        if node_exists:
-            if not succeeded or verdict not in ("PASS", "FRACTURE"):
+        # PHASE 4: THE ULTIMATE BURN -- refined for resumability.
+        #
+        # keep_warm == True iff: a RESUMABLE failure happened AND
+        # --keep-warm-on-failure AND NOT --burn-on-failure AND we did NOT reach a
+        # terminal verdict. A raised exception bypasses the resumable_failure flag
+        # (it's set only on the recoverable return paths), so an exception / SSH
+        # drop ALWAYS burns -- we cannot prove a crashed run left a resumable node.
+        terminal = succeeded and verdict in ("PASS", "FRACTURE")
+        keep_warm = (
+            node_exists
+            and resumable_failure
+            and args.keep_warm_on_failure
+            and not args.burn_on_failure
+            and not terminal
+        )
+        if node_exists and keep_warm:
+            # Autopsy (never blocks), persist the checkpoint, leave the node WARM.
+            run_autopsy(args, node, abort_reason or f"verdict={verdict}", surgery_output)
+            ledger.write(data)
+            print(
+                f"[IAC KEEP-WARM] node {node} left RUNNING after resumable failure "
+                f"({abort_reason or 'no verdict'}); checkpoint persisted -> {ledger.path}. "
+                f"Re-run --execute to RESUME. NO-ORPHAN BACKSTOP armed: node-side "
+                f"dead-man idle>{args.node_idle_timeout_s}s + max-run-duration="
+                f"{args.max_run_duration_s}s + Spot DELETE-on-preempt.",
+                flush=True,
+            )
+        elif node_exists:
+            # Terminal verdict / exception / --burn-on-failure -> BURN ALWAYS.
+            if not terminal:
                 run_autopsy(args, node, abort_reason or f"verdict={verdict}", surgery_output)
             burn_node(args, node)
             verify_node_gone(args, node)
-        _report(args, node, verdict, surgery_rc, node_exists)
+            # Surgery reached a verdict -> the run is DONE, clear the checkpoint.
+            if terminal:
+                ledger.clear()
+        _report(args, node, verdict, surgery_rc, node_exists, keep_warm)
 
 
-def _report(args: argparse.Namespace, node: str, verdict: str, surgery_rc: int, node_existed: bool) -> None:
+def _report(
+    args: argparse.Namespace, node: str, verdict: str, surgery_rc: int,
+    node_existed: bool, kept_warm: bool = False,
+) -> None:
     print("=" * 72)
     print("[IAC] SESSION REPORT")
     print("=" * 72)
-    print(f"  node       : {node} ({'provisioned + burned' if node_existed else 'never provisioned'})")
+    if not node_existed:
+        node_state = "never provisioned"
+    elif kept_warm:
+        node_state = "LEFT WARM (resumable -- re-run --execute)"
+    else:
+        node_state = "provisioned + burned"
+    print(f"  node       : {node} ({node_state})")
     print(f"  verdict    : {verdict}")
     print(f"  surgery rc : {surgery_rc}")
-    print("  teardown   : quadruple (local-delete + remote-deadman + spot-DELETE + max-run-duration)")
+    if kept_warm:
+        print("  teardown   : DEFERRED (keep-warm) -- backstop: node-deadman + "
+              "spot-DELETE + max-run-duration (no infinite orphan)")
+    else:
+        print("  teardown   : quadruple (local-delete + remote-deadman + spot-DELETE + max-run-duration)")
     print("=" * 72)
 
 
@@ -948,6 +1499,38 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--node-name", default=None, help="node name (default sovereign-sandbox-<ts>)")
     p.add_argument("--i-understand-this-spends-money", action="store_true",
                    help="REAL-MONEY safety gate (required with --execute)")
+    # -- prebake / boot phases (streamed + checkpointed when their cmds are set) --
+    p.add_argument("--prebake-cmd", default=_DEFAULT_PREBAKE_CMD,
+                   help="remote WAN docker-build prebake (env JARVIS_IAC_PREBAKE_CMD; "
+                        "empty == folded into surgery)")
+    p.add_argument("--prebake-timeout-s", type=int,
+                   default=int(os.environ.get("JARVIS_IAC_PREBAKE_TIMEOUT_S", "1800")))
+    p.add_argument("--boot-cmd", default=_DEFAULT_BOOT_CMD,
+                   help="remote air-gap compose boot (env JARVIS_IAC_BOOT_CMD; empty == folded into surgery)")
+    p.add_argument("--boot-timeout-s", type=int,
+                   default=int(os.environ.get("JARVIS_IAC_BOOT_TIMEOUT_S", "600")))
+    # -- checkpoint / resume (resume-don't-restart) --
+    p.add_argument("--state-path", default=_DEFAULT_STATE_PATH,
+                   help="checkpoint ledger path (env JARVIS_IAC_STATE_PATH)")
+    p.add_argument("--run-id", default=None,
+                   help="run id stamped into the checkpoint (default: the node timestamp)")
+    p.add_argument("--node-idle-timeout-s", type=int, default=_DEFAULT_NODE_IDLE_TIMEOUT_S,
+                   help="node-side dead-man idle timeout, generous enough to allow a "
+                        "resume yet bounded (env JARVIS_IAC_NODE_IDLE_TIMEOUT_S)")
+    p.add_argument("--fresh", action="store_true",
+                   help="ignore + clear any checkpoint; provision a brand-new node")
+    p.add_argument("--keep-warm-on-failure", dest="keep_warm_on_failure",
+                   action="store_true", default=True,
+                   help="on a RESUMABLE mid-pipeline failure leave the node WARM + "
+                        "persist the checkpoint so --execute can resume (default TRUE; "
+                        "the dead-man + max-run-duration remain the no-orphan backstop)")
+    p.add_argument("--no-keep-warm-on-failure", dest="keep_warm_on_failure",
+                   action="store_false",
+                   help="burn the node even on a resumable failure (legacy always-burn)")
+    p.add_argument("--burn-on-failure", action="store_true",
+                   help="force a burn even on a resumable failure (overrides keep-warm)")
+    p.add_argument("--burn", action="store_true",
+                   help="force-burn the checkpointed node (cleanup) then exit")
     mode = p.add_mutually_exclusive_group()
     mode.add_argument("--dry-run", dest="dry_run", action="store_true",
                       help="print the plan + commands WITHOUT executing (default)")
@@ -957,18 +1540,50 @@ def build_parser() -> argparse.ArgumentParser:
     return p
 
 
+def _force_burn_checkpointed(args: argparse.Namespace, ledger: CheckpointLedger) -> int:
+    """`--burn`: force-burn the node recorded in the checkpoint (cleanup), then
+    clear the ledger. Reuses the same gcloud-delete + verify-gone path. If no
+    node is recorded, there is nothing to burn."""
+    data = ledger.read()
+    node = (data.get("node_name") or args.node_name or "").strip()
+    if not node:
+        _log("--burn: no checkpointed node to burn (clean ledger)")
+        return 0
+    # Talk to the node's recorded zone/project.
+    args.zone = data.get("zone") or args.zone
+    args.project = data.get("project") or args.project
+    _log(f"--burn: force-burning checkpointed node {node}")
+    burn_node(args, node)
+    verify_node_gone(args, node)
+    ledger.clear()
+    return 0
+
+
 def main(argv: Optional[List[str]] = None) -> int:
     args = build_parser().parse_args(argv)
     stamp = _now_stamp()
-    node = args.node_name or default_node_name(stamp)
+    run_id = args.run_id or stamp
+    default_node = args.node_name or default_node_name(stamp)
     excludes = parse_excludes(args.rsync_excludes)
-    startup_script = build_startup_script(completion_sentinel=args.completion_sentinel)
+    # The dead-man idle timeout the startup-script bakes in is the resume-aware
+    # JARVIS_IAC_NODE_IDLE_TIMEOUT_S -- generous enough to permit a re-run resume
+    # yet bounded so a warm-left node can never orphan forever (the max-run
+    # duration is the absolute ceiling regardless).
+    startup_script = build_startup_script(
+        completion_sentinel=args.completion_sentinel,
+        idle_timeout_s=args.node_idle_timeout_s,
+    )
+    ledger = CheckpointLedger(args.state_path)
 
     if args.dry_run:
         if not _master_enabled():
             _log(f"NOTE: master gate {_ENV_MASTER} is OFF (dry-run prints the plan anyway).")
-        _print_plan(args, node, startup_script, excludes)
+        _print_plan(args, default_node, startup_script, excludes)
+        _print_checkpoint_plan(args, ledger, run_id)
         return 0
+
+    if args.burn:
+        return _force_burn_checkpointed(args, ledger)
 
     ok, reason = check_triple_gate(args)
     if not ok:
@@ -977,7 +1592,13 @@ def main(argv: Optional[List[str]] = None) -> int:
         return 2
 
     _log("EXECUTE mode -- this WILL provision a 32GB GCP node and spend money")
-    return _execute(args, node, startup_script, excludes)
+    # RESUME vs FRESH: reconnect to a warm checkpointed node + skip done phases.
+    node, ledger_data, resuming = resolve_run_context(args, ledger, default_node, run_id)
+    log_path = _run_log_path(ledger_data.get("run_id") or run_id)
+    return _execute(
+        args, node, startup_script, excludes,
+        ledger=ledger, ledger_data=ledger_data, resuming=resuming, log_path=log_path,
+    )
 
 
 if __name__ == "__main__":

--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -527,12 +527,19 @@ if [ "${UPTIME_S}" -lt "${BOOT_GRACE_S}" ]; then
     echo "[sovereign-burn] BOOT GRACE active (uptime=${UPTIME_S}s < grace=${BOOT_GRACE_S}s) -- skip"
     exit 0
 fi
-if [ -f "${ACTIVITY_FILE}" ]; then
-    FILE_AGE_S=$(( $(date +%s) - $(stat -c %Y "${ACTIVITY_FILE}" 2>/dev/null || echo 0) ))
-    if [ "${FILE_AGE_S}" -lt "${IDLE_TIMEOUT_S}" ]; then
-        echo "[sovereign-burn] activity recent (age=${FILE_AGE_S}s < ${IDLE_TIMEOUT_S}s) -- no action"
-        exit 0
-    fi
+# FAIL-SAFE: if the activity file does NOT exist, we CANNOT determine idleness
+# (the IaC sandbox node has no Ollama bumping it) -- so DO NOT delete on a missing
+# file. The no-orphan guarantee then rests on max-run-duration (GCP hard ceiling)
+# + the completion-sentinel (verdict burn) + the local orchestrator delete. Only
+# an EXISTING activity file older than the timeout triggers an idle self-delete.
+if [ ! -f "${ACTIVITY_FILE}" ]; then
+    echo "[sovereign-burn] no activity file -- cannot assess idle; relying on max-run-duration + sentinel -- skip"
+    exit 0
+fi
+FILE_AGE_S=$(( $(date +%s) - $(stat -c %Y "${ACTIVITY_FILE}" 2>/dev/null || echo 0) ))
+if [ "${FILE_AGE_S}" -lt "${IDLE_TIMEOUT_S}" ]; then
+    echo "[sovereign-burn] activity recent (age=${FILE_AGE_S}s < ${IDLE_TIMEOUT_S}s) -- no action"
+    exit 0
 fi
 echo "[sovereign-burn] IDLE > ${IDLE_TIMEOUT_S}s and uptime > boot_grace -- initiating self-DELETE"
 _self_delete
@@ -595,6 +602,9 @@ def build_startup_script(
         "apt-get install -y docker.io docker-compose-plugin rsync || "
         "curl -fsSL https://get.docker.com | sh || true\n"
         "systemctl enable --now docker || service docker start || true\n"
+        "# Bootstrap python3-pip + build tools at BOOT (system pkgs, no repo needed)\n"
+        "# so the surgery harness deps install cleanly later (apt is fresh here).\n"
+        "apt-get install -y python3-pip python3-dev build-essential || true\n"
         "\n"
         "# 2. Open the minimal local firewall (sandbox is internal-network only).\n"
         "iptables -A INPUT -i lo -j ACCEPT 2>/dev/null || true\n"
@@ -670,8 +680,15 @@ def build_startup_script(
 def _create_node_cmd(
     args: argparse.Namespace, node: str, startup_script_path: str
 ) -> List[str]:
-    """e2-standard-8 (32GB) SPOT node, DELETE-on-preempt, max_run_duration,
-    cloud-platform scope (the dead-man needs it)."""
+    """e2-standard-8 (32GB) node, max_run_duration + DELETE (cost ceiling),
+    cloud-platform scope (the dead-man needs it). SPOT by default (cheapest);
+    --on-demand uses STANDARD for an UNINTERRUPTED window (no preemption) when a
+    multi-stage run needs to complete without a Spot reclaim mid-surgery."""
+    on_demand = bool(getattr(args, "on_demand", False))
+    sched = (
+        ["--provisioning-model=STANDARD"] if on_demand
+        else ["--provisioning-model=SPOT"]
+    )
     return [
         "gcloud", "compute", "instances", "create", node,
         f"--project={args.project}", f"--zone={args.zone}",
@@ -680,7 +697,7 @@ def _create_node_cmd(
         f"--image-project={args.source_image_project}",
         f"--boot-disk-size={args.boot_disk_size}",
         "--boot-disk-type=pd-balanced",
-        "--provisioning-model=SPOT",
+        *sched,
         "--instance-termination-action=DELETE",
         f"--max-run-duration={args.max_run_duration_s}s",
         "--scopes=cloud-platform",
@@ -695,6 +712,30 @@ def _ssh_cmd(args: argparse.Namespace, node: str, remote: str) -> List[str]:
         f"--project={args.project}", f"--zone={args.zone}",
         "--tunnel-through-iap", "--command", remote,
     ]
+
+
+def _tar_pipe_cmd(
+    args: argparse.Namespace, node: str, local: str, remote_dir: str,
+    excludes: List[str],
+) -> List[str]:
+    """Bulletproof remote sync: `tar czf - -C <local> <excludes> . | gcloud ssh
+    <node> --command 'tar xzf - -C <remote_dir>'`. Avoids the well-known
+    `gcloud compute scp --recurse` IAP flakiness ('stat remote: No such file or
+    directory') by streaming a tarball through the SSH tunnel and extracting it
+    into the pre-created remote dir. Returns a `bash -lc` command (a shell
+    pipeline) so the existing streaming runner can drive it. The tar progress
+    streams to the local terminal (prefixed [sync])."""
+    excl = " ".join(f"--exclude={shlex.quote(e)}" for e in excludes)
+    # remote side: gcloud ssh exec that pipes stdin into `tar xzf - -C <dir>`
+    remote_extract = (
+        f"gcloud compute ssh {shlex.quote(node)} "
+        f"--project={shlex.quote(args.project)} --zone={shlex.quote(args.zone)} "
+        f"--tunnel-through-iap --command {shlex.quote('tar xzf - -C ' + shlex.quote(remote_dir))}"
+    )
+    pipeline = (
+        f"tar czf - -C {shlex.quote(local)} {excl} . | {remote_extract}"
+    )
+    return ["bash", "-lc", pipeline]
 
 
 def _scp_cmd(
@@ -863,13 +904,35 @@ def sync_repos_to_node(
     Transport selected by JARVIS_IAC_SYNC_TRANSPORT (default scp -- robust over
     IAP). Returns (ok, detail). Fail-soft.
     """
-    transport = os.environ.get("JARVIS_IAC_SYNC_TRANSPORT", "scp").strip().lower()
+    transport = os.environ.get("JARVIS_IAC_SYNC_TRANSPORT", "tar").strip().lower()
     pairs = _resolve_repo_paths(args)
+    # PREP: the startup-script created _REMOTE_TRINITY_ROOT as ROOT, so the scp/ssh
+    # user cannot write into it ("stat remote: No such file or directory" / perm
+    # denied). Create the per-repo subdirs + chown the whole tree to the login
+    # user BEFORE the transfer. Reuses sudo (passwordless on the GCP image).
+    _root = shlex.quote(_REMOTE_TRINITY_ROOT)
+    # Create + chown the root AND the per-repo subdirs: the tar-pipe transport
+    # (default) extracts the repo CONTENTS into a pre-existing subdir (no nesting).
+    _subdirs = " ".join(shlex.quote(f"{_REMOTE_TRINITY_ROOT}/{n}") for n, _ in pairs)
+    _prep = (
+        f"sudo mkdir -p {_subdirs} && "
+        f'sudo chown -R "$(id -un)":"$(id -gn)" {_root} && '
+        f"echo workspace_ready {_root}"
+    )
+    _log(f"preparing remote workspace {_REMOTE_TRINITY_ROOT} (mkdir + chown to login user)")
+    _prc, _pcap = _run_streaming_labeled(
+        _ssh_cmd(args, node, _prep), label="sync", log_path=log_path,
+        timeout_s=float(args.sync_timeout_s),
+    )
+    if _prc != 0:
+        return False, f"remote workspace prep failed rc={_prc}: {''.join(_pcap).strip()[:300]}"
     for name, local in pairs:
         if not local:
             return False, f"repo path for '{name}' is unset (set JARVIS_{name.upper()}_REPO_PATH)"
         remote_dir = f"{_REMOTE_TRINITY_ROOT}/{name}"
-        if transport == "rsync":
+        if transport == "tar":
+            cmd = _tar_pipe_cmd(args, node, local, remote_dir, excludes)
+        elif transport == "rsync":
             cmd = _rsync_cmd(args, node, local, remote_dir, excludes)
         else:
             cmd = _scp_cmd(args, node, local, remote_dir, excludes)
@@ -900,12 +963,44 @@ def _remote_surgery_shell(args: argparse.Namespace) -> str:
         "export JARVIS_CROSS_REPO_MUTATION_ENABLED=1; "
         "export JARVIS_CHAOS_INJECTOR_ENABLED=1; "
     )
-    # cd into the synced jarvis repo, run the surgery, ALWAYS drop the sentinel.
+    # The surgery harness imports the full JARVIS ouroboros stack (oracle ->
+    # engine -> aiohttp + ...). Install jarvis's deps on the host python BEFORE
+    # the surgery -- but FILTER the multi-GB ML libs (torch/transformers/...) the
+    # controlled harness never exercises (no inference), so the install is fast.
+    # pip skips already-satisfied on a resume (cheap re-run). WAN-connected (the
+    # HOST node, not the air-gapped container). Override via JARVIS_IAC_SURGERY_DEP_INSTALL.
+    dep_install = os.environ.get(
+        "JARVIS_IAC_SURGERY_DEP_INSTALL",
+        "echo '[deps] installing jarvis host deps (pip from boot; ML libs filtered)'; "
+        # pip is installed at BOOT (startup-script). Fallback-bootstrap if missing.
+        "python3 -m pip --version >/dev/null 2>&1 "
+        "|| (sudo apt-get update -y -qq && sudo apt-get install -y -q python3-pip) >/dev/null 2>&1 "
+        "|| (curl -fsSL https://bootstrap.pypa.io/get-pip.py | sudo python3) >/dev/null 2>&1 || true; "
+        # Filter the multi-GB ML libs the controlled harness never exercises +
+        # strip Ouroboros comment lines / drop the heavy set, keep aiohttp/fastapi/etc.
+        "grep -ivE '^(#|torch|torchaudio|torchvision|tensorflow|transformers|vllm|"
+        "llama|nvidia|triton|xformers|onnx|scipy|scikit|sentencepiece|accelerate|"
+        "bitsandbytes|fastembed|peft|trl|datasets)' requirements.txt > /tmp/req_light.txt 2>/dev/null "
+        "|| cp requirements.txt /tmp/req_light.txt; "
+        "sudo python3 -m pip install --break-system-packages -q -r /tmp/req_light.txt 2>&1 "
+        "| tail -4 || python3 -m pip install --user -q -r /tmp/req_light.txt 2>&1 | tail -4 || true; "
+        "python3 -c 'import aiohttp; print(\"[deps] aiohttp ok\", aiohttp.__version__)' 2>&1 | tail -1",
+    )
+    # cd into the synced jarvis repo, install deps, run the surgery. The completion
+    # sentinel (which arms the node-side dead-man to burn IMMEDIATELY) is dropped
+    # ONLY when the surgery reached a real VERDICT (PASS/FRACTURE) -- NOT on a
+    # resumable failure (e.g. a missing dep), so keep-warm actually keeps the node
+    # alive for a resume instead of the dead-man burning it out from under us.
+    sentinel_q2 = shlex.quote(args.completion_sentinel)
     return (
         f"cd {shlex.quote(jr)} && {env} "
-        f"({args.surgery_cmd}); rc=$?; "
-        f"sudo touch {shlex.quote(args.completion_sentinel)} 2>/dev/null "
-        f"|| touch {shlex.quote(args.completion_sentinel)} 2>/dev/null || true; "
+        f"{dep_install}; "
+        f"({args.surgery_cmd}) 2>&1 | tee /tmp/surgery.out; rc=${{PIPESTATUS[0]}}; "
+        # verdict-conditional sentinel: only burn on a terminal verdict.
+        "if grep -qE 'VERDICT:|CROSS-REPO FRACTURE|ROLLBACK VERIFIED' /tmp/surgery.out; then "
+        f"sudo touch {sentinel_q2} 2>/dev/null || touch {sentinel_q2} 2>/dev/null || true; "
+        "echo '[iac] verdict reached -- completion-sentinel dropped (dead-man will burn)'; "
+        "else echo '[iac] no verdict (resumable) -- sentinel NOT dropped, node stays warm'; fi; "
         "exit $rc"
     )
 
@@ -1519,6 +1614,9 @@ def build_parser() -> argparse.ArgumentParser:
                         "resume yet bounded (env JARVIS_IAC_NODE_IDLE_TIMEOUT_S)")
     p.add_argument("--fresh", action="store_true",
                    help="ignore + clear any checkpoint; provision a brand-new node")
+    p.add_argument("--on-demand", dest="on_demand", action="store_true",
+                   help="provision STANDARD (on-demand, no Spot preemption) for an "
+                        "uninterrupted multi-stage run; keeps max-run-duration + DELETE")
     p.add_argument("--keep-warm-on-failure", dest="keep_warm_on_failure",
                    action="store_true", default=True,
                    help="on a RESUMABLE mid-pipeline failure leave the node WARM + "

--- a/tests/scripts/test_iac_checkpoint_streaming.py
+++ b/tests/scripts/test_iac_checkpoint_streaming.py
@@ -1,0 +1,527 @@
+# -*- coding: utf-8 -*-
+"""Checkpoint (resume-don't-restart) + synchronous-streaming tests for
+scripts/sovereign_iac_hypervisor.py.
+
+No real GCP/SSH/rsync. All gcloud/ssh/rsync funnel through the script's `_run`
+(capture) and `_run_streaming` / `_run_streaming_labeled` (stream) boundaries,
+which these tests monkeypatch with fakes that record call order. Asserts:
+
+  * the `.hypervisor_state.json` ledger round-trips (write/read phases),
+  * RESUME on a recorded RUNNING node skips completed phases (provision NOT
+    re-issued; resumes from the first incomplete phase),
+  * a recorded-but-GONE node -> fresh start (provision re-issued),
+  * --fresh ignores the ledger,
+  * a resumable mid-pipeline failure with --keep-warm-on-failure -> node NOT
+    burned + ledger persisted + non-zero exit (NO delete issued),
+  * a clean PASS/FRACTURE -> burn runs,
+  * `_run_streaming` iterates lines in real-time (incrementally, not all-at-end)
+    + tees to the per-run log,
+  * the streamed phases carry their `[<label>]` prefixes.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "sovereign_iac_hypervisor.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sovereign_iac_hypervisor", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def iac():
+    return _load_module()
+
+
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Isolate the ledger + autopsy dir inside a tmp cwd."""
+    monkeypatch.chdir(tmp_path)
+    return tmp_path
+
+
+@pytest.fixture()
+def args(iac):
+    return iac.build_parser().parse_args([])
+
+
+class _Recorder:
+    """Records every cmd through both subprocess boundaries, in order."""
+
+    def __init__(self, *, run_rc=0, run_out="", stream_rc=0, stream_lines=None):
+        self.calls = []
+        self.stream_labels = []
+        self.run_rc = run_rc
+        self.run_out = run_out
+        self.stream_rc = stream_rc
+        self.stream_lines = stream_lines or []
+
+    def run(self, cmd, *, timeout_s=120.0):
+        self.calls.append(cmd)
+        return self.run_rc, self.run_out
+
+    def stream(self, cmd, *, label="", log_path=None, timeout_s=3600.0):
+        self.calls.append(cmd)
+        self.stream_labels.append(label)
+        return self.stream_rc, list(self.stream_lines)
+
+    def patch(self, monkeypatch, iac):
+        monkeypatch.setattr(iac, "_run", self.run)
+        monkeypatch.setattr(iac, "_run_streaming_labeled", self.stream)
+
+
+def _delete_issued(rec):
+    return any("delete" in c and "instances" in c for c in rec.calls)
+
+
+def _create_issued(rec):
+    return any("create" in c and "instances" in c for c in rec.calls)
+
+
+# --------------------------------------------------------------------------- #
+# Ledger round-trip.
+# --------------------------------------------------------------------------- #
+def test_ledger_round_trips_phases(iac, tmp_path):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R1", node_name="node-a", zone="z1", project="p1")
+    assert iac.CheckpointLedger.completed_phases(data) == []
+    data = led.mark_phase(data, "provisioned")
+    data = led.mark_phase(data, "docker_ready", external_ip="1.2.3.4")
+    # Re-read from disk -- phases + connection info persisted.
+    fresh = iac.CheckpointLedger(str(tmp_path / "state.json")).read()
+    assert fresh["node_name"] == "node-a"
+    assert fresh["external_ip"] == "1.2.3.4"
+    assert iac.CheckpointLedger.phase_complete(fresh, "provisioned")
+    assert iac.CheckpointLedger.phase_complete(fresh, "docker_ready")
+    assert not iac.CheckpointLedger.phase_complete(fresh, "synced")
+    assert iac.CheckpointLedger.first_incomplete(fresh) == "synced"
+    # Each phase carries a timestamp.
+    assert fresh["phases"]["provisioned"]["ts"]
+
+
+def test_ledger_corrupt_reads_empty(iac, tmp_path):
+    p = tmp_path / "state.json"
+    p.write_text("{not valid json", encoding="utf-8")
+    assert iac.CheckpointLedger(str(p)).read() == {}
+
+
+def test_ledger_atomic_write_is_valid_json(iac, tmp_path):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    led.init_run(run_id="R", node_name="n", zone="z", project="pr")
+    raw = (tmp_path / "state.json").read_text(encoding="utf-8")
+    json.loads(raw)  # parses
+
+
+# --------------------------------------------------------------------------- #
+# RESUME vs FRESH context resolution.
+# --------------------------------------------------------------------------- #
+def _seed_ledger(iac, tmp_path, *, node, completed):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name=node, zone="us-central1-a", project="proj")
+    for ph in completed:
+        data = led.mark_phase(data, ph)
+    return led
+
+
+def test_resume_on_running_node_skips_completed_phases(iac, args, tmp_path, monkeypatch, capsys):
+    led = _seed_ledger(iac, tmp_path, node="warm-node",
+                       completed=["provisioned", "docker_ready", "synced"])
+    # Node is RUNNING.
+    monkeypatch.setattr(iac, "_run", lambda cmd, **k: (0, "RUNNING"))
+    node, data, resuming = iac.resolve_run_context(args, led, "fresh-node", "R")
+    assert resuming is True
+    assert node == "warm-node"
+    out = capsys.readouterr().out
+    assert "[IAC RESUME]" in out
+    assert "files synced=True" in out
+    assert "resuming from phase prebaked" in out
+
+
+def test_resume_runs_only_incomplete_phases_no_reprovision(iac, args, tmp_path, monkeypatch):
+    """Full _execute resume: provision/sync are complete -> NOT re-issued; the
+    incomplete phases (prebake/boot/surgery) run; provision NOT re-created."""
+    led = _seed_ledger(iac, tmp_path, node="warm-node",
+                       completed=["provisioned", "docker_ready", "synced"])
+    data = led.read()
+    rec = _Recorder(stream_lines=["VERDICT: PASS\n"])
+    rec.patch(monkeypatch, iac)
+    # poll/sync/prebake/boot succeed; surgery returns a verdict via the recorder.
+    prebake_called = {"n": 0}
+    boot_called = {"n": 0}
+    monkeypatch.setattr(iac, "run_remote_prebake",
+                        lambda *a, **k: (prebake_called.update(n=prebake_called["n"] + 1), (True, "ok"))[1])
+    monkeypatch.setattr(iac, "run_remote_boot",
+                        lambda *a, **k: (boot_called.update(n=boot_called["n"] + 1), (True, "ok"))[1])
+    monkeypatch.setattr(iac, "run_remote_surgery",
+                        lambda *a, **k: (0, ["VERDICT: PASS\n"], "PASS"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+
+    rc = iac._execute(args, "warm-node", iac.build_startup_script(), [],
+                      ledger=led, ledger_data=data, resuming=True)
+    assert rc == 0
+    # provision (create) was SKIPPED -- not re-issued.
+    assert not _create_issued(rec), "provision must NOT be re-issued on resume"
+    # the incomplete phases ran.
+    assert prebake_called["n"] == 1
+    assert boot_called["n"] == 1
+    # terminal verdict -> burn ran.
+    assert _delete_issued(rec)
+
+
+def test_gone_node_starts_fresh_reprovisions(iac, args, tmp_path, monkeypatch):
+    _seed_ledger(iac, tmp_path, node="dead-node", completed=["provisioned", "synced"])
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    # describe rc != 0 -> node GONE.
+    monkeypatch.setattr(iac, "_run", lambda cmd, **k: (1, "not found"))
+    node, data, resuming = iac.resolve_run_context(args, led, "new-node", "R2")
+    assert resuming is False
+    assert node == "new-node"
+    # ledger re-seeded clean (no completed phases).
+    assert iac.CheckpointLedger.completed_phases(data) == []
+
+
+def test_node_running_but_not_RUNNING_status_is_not_resumable(iac, args, tmp_path, monkeypatch):
+    _seed_ledger(iac, tmp_path, node="stopping-node", completed=["provisioned"])
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    monkeypatch.setattr(iac, "_run", lambda cmd, **k: (0, "TERMINATED"))
+    node, data, resuming = iac.resolve_run_context(args, led, "new-node", "R")
+    assert resuming is False
+    assert node == "new-node"
+
+
+def test_fresh_flag_ignores_and_clears_ledger(iac, args, tmp_path, monkeypatch):
+    _seed_ledger(iac, tmp_path, node="warm-node", completed=["provisioned", "synced"])
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    args.fresh = True
+    # alive-check must NOT even be consulted; but stub it to RUNNING to prove it.
+    monkeypatch.setattr(iac, "_run", lambda cmd, **k: (0, "RUNNING"))
+    node, data, resuming = iac.resolve_run_context(args, led, "brand-new", "R")
+    assert resuming is False
+    assert node == "brand-new"
+    assert iac.CheckpointLedger.completed_phases(data) == []
+
+
+def test_fresh_execute_reprovisions(iac, args, tmp_path, monkeypatch):
+    """With no checkpoint, _execute issues the create (provision)."""
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="n", zone="z", project="p")
+    rec = _Recorder(stream_lines=["VERDICT: PASS\n"])
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_boot", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_surgery", lambda *a, **k: (0, ["VERDICT: PASS\n"], "PASS"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+    rc = iac._execute(args, "n", iac.build_startup_script(), [],
+                      ledger=led, ledger_data=data, resuming=False)
+    assert rc == 0
+    assert _create_issued(rec), "fresh run must provision"
+
+
+# --------------------------------------------------------------------------- #
+# Keep-warm-on-failure: resumable failure -> NO burn, ledger persisted, non-zero.
+# --------------------------------------------------------------------------- #
+def test_resumable_failure_keeps_node_warm_no_burn(iac, args, tmp_path, monkeypatch, capsys):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="warm", zone="z", project="p")
+    rec = _Recorder()
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    # prebake FAILS (the PyPI-timeout class) -- resumable.
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (False, "PyPI timeout pulling wheels"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+
+    args.keep_warm_on_failure = True
+    args.burn_on_failure = False
+    rc = iac._execute(args, "warm", iac.build_startup_script(), [],
+                      ledger=led, ledger_data=data, resuming=False)
+    assert rc != 0  # non-zero so the operator re-runs --execute to resume
+    assert not _delete_issued(rec), "keep-warm must NOT burn the node"
+    # checkpoint persisted: provisioned/docker_ready/synced complete; prebaked NOT.
+    persisted = iac.CheckpointLedger(str(tmp_path / "state.json")).read()
+    assert iac.CheckpointLedger.phase_complete(persisted, "synced")
+    assert not iac.CheckpointLedger.phase_complete(persisted, "prebaked")
+    assert iac.CheckpointLedger.first_incomplete(persisted) == "prebaked"
+    out = capsys.readouterr().out
+    assert "[IAC KEEP-WARM]" in out
+    # the no-orphan backstop is stated.
+    assert "NO-ORPHAN BACKSTOP" in out
+    assert "max-run-duration" in out
+
+
+def test_burn_on_failure_overrides_keep_warm(iac, args, tmp_path, monkeypatch):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="warm", zone="z", project="p")
+    rec = _Recorder()
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (False, "boom"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+    args.keep_warm_on_failure = True
+    args.burn_on_failure = True  # operator forces burn
+    iac._execute(args, "warm", iac.build_startup_script(), [],
+                 ledger=led, ledger_data=data, resuming=False)
+    assert _delete_issued(rec), "--burn-on-failure must burn even on a resumable failure"
+
+
+def test_no_keep_warm_flag_burns_on_resumable_failure(iac, args, tmp_path, monkeypatch):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="warm", zone="z", project="p")
+    rec = _Recorder()
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (False, "boom"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+    args.keep_warm_on_failure = False  # legacy always-burn
+    iac._execute(args, "warm", iac.build_startup_script(), [],
+                 ledger=led, ledger_data=data, resuming=False)
+    assert _delete_issued(rec)
+
+
+# --------------------------------------------------------------------------- #
+# Clean PASS / FRACTURE -> burn runs (terminal); ledger cleared.
+# --------------------------------------------------------------------------- #
+def _wire_clean(iac, monkeypatch, rec, verdict_lines, verdict):
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_boot", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+    monkeypatch.setattr(iac, "run_remote_surgery", lambda *a, **k: (0, verdict_lines, verdict))
+
+
+def test_clean_pass_burns_and_clears_ledger(iac, args, tmp_path, monkeypatch):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="n", zone="z", project="p")
+    rec = _Recorder()
+    _wire_clean(iac, monkeypatch, rec, ["VERDICT: PASS\n"], "PASS")
+    rc = iac._execute(args, "n", iac.build_startup_script(), [],
+                      ledger=led, ledger_data=data, resuming=False)
+    assert rc == 0
+    assert _delete_issued(rec), "clean PASS must burn"
+    # terminal -> checkpoint cleared.
+    assert not (tmp_path / "state.json").exists()
+
+
+def test_clean_fracture_burns(iac, args, tmp_path, monkeypatch):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="n", zone="z", project="p")
+    rec = _Recorder()
+    _wire_clean(iac, monkeypatch, rec, ["[SOVEREIGN YIELD: CROSS-REPO FRACTURE]\n"], "FRACTURE")
+    rc = iac._execute(args, "n", iac.build_startup_script(), [],
+                      ledger=led, ledger_data=data, resuming=False)
+    assert rc == 0
+    assert _delete_issued(rec), "clean FRACTURE must burn"
+
+
+def test_exception_still_burns(iac, args, tmp_path, monkeypatch):
+    """An unrecoverable raised exception ALWAYS burns (cannot prove resumable)."""
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="n", zone="z", project="p")
+    rec = _Recorder()
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_boot", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+
+    def _boom(*a, **k):
+        raise RuntimeError("ssh dropped mid-surgery")
+
+    monkeypatch.setattr(iac, "run_remote_surgery", _boom)
+    args.keep_warm_on_failure = True  # even with keep-warm, an exception burns
+    with pytest.raises(RuntimeError):
+        iac._execute(args, "n", iac.build_startup_script(), [],
+                     ledger=led, ledger_data=data, resuming=False)
+    assert _delete_issued(rec), "a raised exception must still burn the node"
+
+
+# --------------------------------------------------------------------------- #
+# --burn force-cleanup.
+# --------------------------------------------------------------------------- #
+def test_force_burn_deletes_checkpointed_node(iac, args, tmp_path, monkeypatch):
+    led = _seed_ledger(iac, tmp_path, node="leftover", completed=["provisioned"])
+    rec = _Recorder()
+    monkeypatch.setattr(iac, "_run", rec.run)
+    led2 = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    rc = iac._force_burn_checkpointed(args, led2)
+    assert rc == 0
+    assert _delete_issued(rec)
+    assert not (tmp_path / "state.json").exists()  # ledger cleared after burn
+
+
+def test_force_burn_noop_when_no_checkpoint(iac, args, tmp_path):
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    assert iac._force_burn_checkpointed(args, led) == 0
+
+
+# --------------------------------------------------------------------------- #
+# Synchronous streaming: real-time line-by-line + tee + labels.
+# --------------------------------------------------------------------------- #
+def test_run_streaming_emits_lines_incrementally_not_all_at_end(iac, monkeypatch):
+    """Prove the stream emits EACH line as it is read, not buffered to the end:
+    the fake stdout records the emit timeline interleaved with iteration."""
+    timeline = []
+
+    class _FakeStdout:
+        def __init__(self, lines):
+            self._lines = lines
+            self._i = 0
+
+        def __iter__(self):
+            return self
+
+        def __next__(self):
+            if self._i >= len(self._lines):
+                raise StopIteration
+            line = self._lines[self._i]
+            self._i += 1
+            timeline.append(("yield", line))
+            return line
+
+    class _FakeProc:
+        def __init__(self, lines):
+            self.stdout = _FakeStdout(lines)
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    lines = ["a\n", "b\n", "c\n"]
+    monkeypatch.setattr(iac.subprocess, "Popen", lambda cmd, **k: _FakeProc(lines))
+
+    def _sink(line):
+        timeline.append(("emit", line))
+
+    rc, captured = iac._run_streaming(["x"], sink=_sink)
+    assert rc == 0
+    assert captured == lines
+    # Each yield is immediately followed by its emit -> incremental, interleaved.
+    assert timeline == [
+        ("yield", "a\n"), ("emit", "a\n"),
+        ("yield", "b\n"), ("emit", "b\n"),
+        ("yield", "c\n"), ("emit", "c\n"),
+    ]
+
+
+def test_labeled_sink_prefixes_and_tees_to_log(iac, tmp_path):
+    log = tmp_path / "run.log"
+    sink = iac._make_labeled_sink("prebake", log)
+    sink("Step 3/9 : RUN pip install\n")
+    sink("collecting wheels\n")
+    contents = log.read_text(encoding="utf-8")
+    assert "[prebake] Step 3/9 : RUN pip install" in contents
+    assert "[prebake] collecting wheels" in contents
+
+
+def test_run_streaming_labeled_carries_label_and_tees(iac, tmp_path, monkeypatch, capsys):
+    class _FakeProc:
+        def __init__(self, lines):
+            self.stdout = iter(lines)
+
+        def wait(self, timeout=None):
+            return 0
+
+        def kill(self):
+            pass
+
+    monkeypatch.setattr(iac.subprocess, "Popen",
+                        lambda cmd, **k: _FakeProc(["building layer\n"]))
+    log = tmp_path / "tee.log"
+    rc, captured = iac._run_streaming_labeled(["docker", "build"], label="prebake", log_path=log)
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "[prebake] building layer" in out
+    assert "[prebake] building layer" in log.read_text(encoding="utf-8")
+
+
+def test_each_long_phase_streams_with_its_label(iac, args, tmp_path, monkeypatch):
+    """provision/sync/prebake/boot/surgery each go through the streaming boundary
+    with their phase label."""
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="n", zone="z", project="p")
+    args.prime_repo_path = "/repos/prime"
+    args.reactor_repo_path = "/repos/reactor"
+    args.prebake_cmd = "docker build ."  # enable the prebake phase
+    args.boot_cmd = "docker compose up -d"  # enable the boot phase
+    rec = _Recorder(stream_lines=["VERDICT: PASS\n"])
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+    # surgery returns PASS via the stream lines (parse_verdict over stream_lines).
+    rc = iac._execute(args, "n", iac.build_startup_script(), [],
+                      ledger=led, ledger_data=data, resuming=False)
+    # The labels seen across all streamed calls, in order.
+    assert "provision" in rec.stream_labels
+    assert "sync" in rec.stream_labels
+    assert "prebake" in rec.stream_labels
+    assert "boot" in rec.stream_labels
+    assert "surgery" in rec.stream_labels
+    # provision before surgery (order preserved).
+    assert rec.stream_labels.index("provision") < rec.stream_labels.index("surgery")
+
+
+def test_prebake_and_boot_skipped_when_cmd_empty(iac, args, tmp_path, monkeypatch):
+    """With empty prebake/boot cmds they fold into surgery -- still checkpointed,
+    no separate streamed call issued for them."""
+    led = iac.CheckpointLedger(str(tmp_path / "state.json"))
+    data = led.init_run(run_id="R", node_name="n", zone="z", project="p")
+    args.prebake_cmd = ""
+    args.boot_cmd = ""
+    rec = _Recorder(stream_lines=["VERDICT: PASS\n"])
+    rec.patch(monkeypatch, iac)
+    monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
+    monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
+    rc = iac._execute(args, "n", iac.build_startup_script(), [],
+                      ledger=led, ledger_data=data, resuming=False)
+    assert rc == 0
+    assert "prebake" not in rec.stream_labels
+    assert "boot" not in rec.stream_labels
+    # but the phases are still marked complete (folded) -> ledger cleared on PASS.
+    assert not (tmp_path / "state.json").exists()
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run surfaces the checkpoint + streaming plan (spends nothing).
+# --------------------------------------------------------------------------- #
+def test_dry_run_shows_checkpoint_and_streaming_plan(iac, monkeypatch, capsys):
+    rec = _Recorder()
+    monkeypatch.setattr(iac, "_run", rec.run)
+    monkeypatch.setattr(iac, "_run_streaming_labeled", rec.stream)
+    rc = iac.main(["--dry-run", "--prime-repo-path", "/p", "--reactor-repo-path", "/r"])
+    assert rc == 0
+    assert rec.calls == []  # zero real commands
+    out = capsys.readouterr().out
+    assert "CHECKPOINT / RESUME PLAN" in out
+    assert "STREAMING PLAN" in out
+    assert "[provision]" in out
+    assert "[prebake]" in out
+    assert "NO-ORPHAN BACKSTOP" in out
+
+
+def test_node_idle_timeout_flows_into_startup_script(iac, monkeypatch, capsys):
+    """The resume-aware node idle timeout is baked into the dead-man watchdog."""
+    rc = iac.main(["--dry-run", "--node-idle-timeout-s", "3600",
+                   "--prime-repo-path", "/p", "--reactor-repo-path", "/r"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "IDLE_TIMEOUT_S=3600" in out

--- a/tests/scripts/test_sovereign_iac_hypervisor.py
+++ b/tests/scripts/test_sovereign_iac_hypervisor.py
@@ -36,6 +36,17 @@ def iac():
     return _load_module()
 
 
+@pytest.fixture(autouse=True)
+def _isolated_state(tmp_path, monkeypatch):
+    """Keep every test's checkpoint ledger + autopsy logs inside a tmp dir -- never
+    touch the repo's real `.hypervisor_state.json` / autopsy_reports/. The default
+    state path is relative (`.hypervisor_state.json`), so chdir'ing to a tmp dir
+    isolates it regardless of import-time env capture."""
+    monkeypatch.chdir(tmp_path)
+    monkeypatch.setenv("JARVIS_IAC_STATE_PATH", str(tmp_path / "state.json"))
+    return tmp_path
+
+
 @pytest.fixture()
 def args(iac):
     """Parse a default arg namespace (dry-run defaults) the tests can mutate."""
@@ -43,7 +54,12 @@ def args(iac):
 
 
 class _Recorder:
-    """Records every (cmd) passed to the faked _run / _run_streaming, in order."""
+    """Records every (cmd) passed to the faked _run / _run_streaming, in order.
+
+    The streaming long phases (provision / sync / prebake / boot / surgery) funnel
+    through `_run_streaming`; the non-streaming calls (poll, delete, describe)
+    funnel through `_run`. Both record into the SAME ordered `calls` list so the
+    burn-order assertions still see provision (create) before burn (delete)."""
 
     def __init__(self):
         self.calls = []
@@ -52,6 +68,16 @@ class _Recorder:
         self.calls.append(cmd)
         # Default: success + benign output. Specific tests override behavior.
         return 0, ""
+
+    def stream(self, cmd, *, label="", log_path=None, timeout_s=3600.0):
+        # Streaming variant -- mirrors _run_streaming_labeled's signature.
+        self.calls.append(cmd)
+        return 0, []
+
+    def patch(self, monkeypatch, iac):
+        """Patch BOTH subprocess boundaries onto this recorder."""
+        monkeypatch.setattr(iac, "_run", self.run)
+        monkeypatch.setattr(iac, "_run_streaming_labeled", self.stream)
 
     def joined(self):
         return [" ".join(c) for c in self.calls]
@@ -110,7 +136,7 @@ def test_provision_cmd_uses_e2_standard_8_spot_delete_maxrun_scope(iac, args):
 
 def test_provision_node_writes_startup_to_tmpfile_and_runs(iac, args, monkeypatch):
     rec = _Recorder()
-    monkeypatch.setattr(iac, "_run", rec.run)
+    rec.patch(monkeypatch, iac)  # provision streams -> patch both boundaries
     ok, detail = iac.provision_sandbox_node(args, "sovereign-sandbox-y", "SCRIPT BODY")
     assert ok
     assert len(rec.calls) == 1
@@ -123,7 +149,7 @@ def test_provision_node_writes_startup_to_tmpfile_and_runs(iac, args, monkeypatc
 # --------------------------------------------------------------------------- #
 def test_sync_issues_commands_with_excludes_for_three_repos(iac, args, monkeypatch):
     rec = _Recorder()
-    monkeypatch.setattr(iac, "_run", rec.run)
+    rec.patch(monkeypatch, iac)  # sync streams -> patch both boundaries
     monkeypatch.setenv("JARVIS_IAC_SYNC_TRANSPORT", "rsync")
     args.prime_repo_path = "/repos/prime"
     args.reactor_repo_path = "/repos/reactor"
@@ -143,7 +169,7 @@ def test_sync_issues_commands_with_excludes_for_three_repos(iac, args, monkeypat
 
 def test_sync_fails_soft_on_unset_repo_path(iac, args, monkeypatch):
     rec = _Recorder()
-    monkeypatch.setattr(iac, "_run", rec.run)
+    rec.patch(monkeypatch, iac)
     monkeypatch.delenv("JARVIS_PRIME_REPO_PATH", raising=False)
     monkeypatch.delenv("JARVIS_REACTOR_REPO_PATH", raising=False)
     args.prime_repo_path = None
@@ -277,10 +303,12 @@ def test_execute_refused_without_gate_issues_zero_commands(iac, monkeypatch):
 # --------------------------------------------------------------------------- #
 def _wire_execute_fakes(iac, monkeypatch, rec, *, surgery_behavior):
     """Wire provision/ready/sync to succeed; surgery_behavior drives phase 3."""
-    monkeypatch.setattr(iac, "_run", rec.run)
+    rec.patch(monkeypatch, iac)
     monkeypatch.setattr(iac, "provision_sandbox_node", lambda *a, **k: (True, "ok"))
     monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
     monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_boot", lambda *a, **k: (True, "ok"))
     monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
     monkeypatch.setattr(iac, "run_remote_surgery", surgery_behavior)
 
@@ -327,10 +355,13 @@ def test_burn_runs_on_exception(iac, args, monkeypatch):
 def test_burn_is_after_everything(iac, args, monkeypatch):
     """Assert the delete (burn) is the LAST instances-command issued."""
     rec = _Recorder()
-    # Don't stub _run for describe -- let provision/sync use real-ish recorder.
-    monkeypatch.setattr(iac, "_run", rec.run)
+    # Don't stub provision -- let it stream through the recorder so `create` is
+    # recorded; both boundaries funnel into the same ordered call list.
+    rec.patch(monkeypatch, iac)
     monkeypatch.setattr(iac, "poll_node_ready", lambda *a, **k: (True, ""))
     monkeypatch.setattr(iac, "sync_repos_to_node", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_prebake", lambda *a, **k: (True, "ok"))
+    monkeypatch.setattr(iac, "run_remote_boot", lambda *a, **k: (True, "ok"))
     monkeypatch.setattr(iac, "run_autopsy", lambda *a, **k: None)
     monkeypatch.setattr(
         iac, "run_remote_surgery",


### PR DESCRIPTION
Completes the Sovereign IaC Hypervisor with autonomous checkpointing + full streaming, and the six root-cause fixes found during the FIRST LIVE cloud surgery. **The live unsimulated cross-repo rollback is PROVEN on a real 32GB GCP node.**

**Checkpoint + streaming:** `.hypervisor_state.json` resume-don't-restart (skips completed phases on a warm node) + line-by-line streaming of every phase (provision/sync/prebake/boot/surgery) + keep-warm-on-resumable-failure (dead-man + max-run-duration backstop).

**Six live-run root-cause fixes:**
1. root-owned /opt/trinity → mkdir+chown prep
2. `gcloud scp --recurse` IAP flakiness → **tar-pipe transport**
3. Spot preemption breaking the window → **--on-demand STANDARD**
4. no pip on Debian slim → python3-pip bootstrapped at boot
5. sentinel touched on every exit (armed dead-man on resumable failure) → **verdict-conditional sentinel**
6. **dead-man deleted the node when the Ollama activity-file was missing** (the IaC node has no Ollama) → **fail-SAFE skip**; no-orphan now via max-run-duration + sentinel + local-delete

**LIVE PROOF (real 32GB GCP node sovereign-sandbox-...204114):** ARMING (armed=True) → BLAST-RADIUS (reactor::TelemetryAdapter.emit ← [jarvis] metrics_caller.py) → CHAOS (real SagaApplyStrategy.execute) → `[SOVEREIGN YIELD: CROSS-REPO FRACTURE]` → COMPENSATING ROLLBACK (reactor_restored + jarvis_restored) → **ROLLBACK VERIFIED, organism intact.** Node burned after. Total cost across all iterations ~$0.30, zero orphans.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds autonomous checkpointing with resume-don’t-restart and live, labeled streaming across all phases. Proves a real cross-repo rollback on a 32GB GCP node, with six live-run fixes that make the pipeline reliable end-to-end.

- New Features
  - Checkpoint ledger (`.hypervisor_state.json`) to skip completed phases; resume only if the node is verified RUNNING. Flags: `--fresh`, `--burn`, `--keep-warm-on-failure`, `--burn-on-failure`, `--state-path`, `--run-id`.
  - Live, line-by-line streaming for provision/sync/prebake/boot/surgery with `[phase]` prefixes and tee to `autopsy_reports/iac_run_<run-id>.log`.
  - Optional remote prebake and boot phases (`--prebake-cmd`, `--boot-cmd`) for faster resumes; surgery uses a verdict-conditional sentinel.
  - Safer teardown policy: terminal verdict always burns; resumable failures can keep the node warm for resume, with no-orphan backstops (node dead-man idle timeout, max-run-duration, Spot DELETE/preempt).
  - CLI `--on-demand` to provision STANDARD (no Spot preemption) when you need an uninterrupted window.
  - Comprehensive tests for checkpoint/resume and streaming; existing tests updated.

- Bug Fixes
  - Root-owned `/opt/trinity` blocked sync → add `mkdir + chown` prep on the node.
  - `gcloud scp --recurse` IAP flakiness → default to tar-pipe (`tar czf - | ssh 'tar xzf -'`).
  - Spot preemption killed long runs → add `--on-demand` (STANDARD) option.
  - Debian slim lacked pip → install `python3-pip` at boot.
  - Sentinel touched on every exit armed the dead-man → drop sentinel only on a real verdict.
  - Dead-man deleted node when activity file was missing → fail-safe skip on missing file; rely on max-run-duration + sentinel + local delete for no-orphan.

<sup>Written for commit 2d5073c358eda350eaa06a810ebaf453751c79c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69683?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

