### PR TITLE
feat: Sovereign Command Node — Phase 1 read-only dashboard (live DAG + FSM ribbon + interactive blast-radius graph)

### DIFF
--- a/backend/core/ouroboros/governance/convergence_watchdog.py
+++ b/backend/core/ouroboros/governance/convergence_watchdog.py
@@ -471,26 +471,16 @@ def emit_sovereign_yield(
     except Exception:  # pragma: no cover
         pass
 
-    # Best-effort SSE event — lazy import so the module can be used without
+    # Best-effort SSE event -- lazy import so the module can be used without
     # the full SSE broker stack loaded.
+    # Command Node Phase 1 (2026-06-23): upgraded to use the dedicated
+    # publish_sovereign_yield helper (EVENT_TYPE_SOVEREIGN_YIELD is now in
+    # _VALID_EVENT_TYPES so the event is no longer silently dropped).
+    _yield_reason = reason or tier
     try:
         from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: PLC0415
-            publish_task_event,
+            publish_sovereign_yield as _pub_yield,
         )
-        _payload = {
-            "lineage_id": lineage_id,
-            "ratio": ratio,
-            "consecutive_stalls": consecutive_stalls,
-            "parent_chars": parent_chars,
-            "child_chars": child_chars,
-            "tier": tier,
-        }
-        if reason:
-            _payload["reason"] = reason
-        publish_task_event(
-            "sovereign_yield",
-            op_id,
-            _payload,
-        )
-    except Exception:  # pragma: no cover — fail-soft, SSE stack optional
+        _pub_yield(op_id, _yield_reason)
+    except Exception:  # pragma: no cover -- fail-soft, SSE stack optional
         pass

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -487,6 +487,14 @@ class IDEObservabilityRouter:
             "/observability/repair-tree/branch/{ref}",
             self._handle_repair_tree_by_ref,
         )
+        # Sovereign Command Node Phase 1 (2026-06-23) -- read-only blast-radius
+        # projection for a given op_id via oracle.get_blast_radius.
+        # Authority-free: lazy-imports oracle only; no orchestrator/policy/
+        # change_engine imports anywhere in this module.
+        app.router.add_get(
+            "/observability/blast-radius/{op_id}",
+            self._handle_blast_radius,
+        )
 
     # --- request-path helpers ---------------------------------------------
 
@@ -4317,6 +4325,77 @@ class IDEObservabilityRouter:
             scheduler=self._scheduler,
             git_worktree_paths=paths,
         )
+
+
+    async def _handle_blast_radius(self, request: "web.Request") -> Any:
+        """GET /observability/blast-radius/{op_id} -- read-only blast-radius
+        projection for a given op_id.
+
+        Authority-free: lazy-imports only ``backend.core.ouroboros.oracle``
+        (read-only call-graph oracle). No orchestrator / policy / change_engine
+        imports. Follows identical security posture to all other GET endpoints:
+        ide_observability_enabled() gate + rate-limit + CORS + no-store.
+
+        Response shape::
+
+            {
+              "schema_version": "1.0",
+              "op_id": "op-abc123",
+              "source": "jarvis:backend/core/.../foo.py",
+              "directly_affected": ["jarvis:...", ...],
+              "transitively_affected": ["jarvis:...", ...],
+              "broken_imports": [["jarvis:...", "import_name"], ...],
+              "broken_calls": [["jarvis:...", "call_name"], ...],
+              "total_affected": 7,
+              "risk_level": "low" | "medium" | "high" | "critical" | "unknown"
+            }
+
+        Returns 404 (with empty lists) when the op_id is not found in the
+        oracle graph -- the oracle returns an empty BlastRadius with
+        risk_level="unknown" for unknown identifiers.
+        """
+        if not ide_observability_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(
+                request, 429, "ide_observability.rate_limited",
+            )
+        op_id = request.match_info.get("op_id", "")
+        if not op_id or not _OP_ID_RE.match(op_id):
+            return self._error_response(
+                request, 400, "blast_radius.invalid_op_id",
+            )
+        try:
+            # Lazy import avoids heavy oracle startup at module-load time.
+            # Authority-invariant: oracle is read-only; it never triggers
+            # orchestrator / policy / change_engine actions.
+            from backend.core.ouroboros import oracle as _oracle_mod  # noqa: PLC0415
+            _oracle = _oracle_mod.get_oracle()
+            report = _oracle.get_blast_radius(op_id)
+            payload = report.to_dict()
+            found = payload.get("risk_level", "unknown") != "unknown"
+        except Exception:  # noqa: BLE001 -- empty rather than 500
+            logger.debug(
+                "[IDEObservability] blast_radius projection failed op=%s",
+                op_id,
+                exc_info=True,
+            )
+            payload = {
+                "source": "",
+                "directly_affected": [],
+                "transitively_affected": [],
+                "broken_imports": [],
+                "broken_calls": [],
+                "total_affected": 0,
+                "risk_level": "unknown",
+            }
+            found = False
+        payload["op_id"] = op_id
+        status = 200 if found else 404
+        return self._json_response(request, status, payload)
+
 
 
 

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -1371,6 +1371,33 @@ EVENT_TYPE_EVALUATOR_TRACE_FRAME = "evaluator_trace_frame"
 # object the dashboard renders as a prior distribution + confidence band.
 EVENT_TYPE_COGNITIVE_WHY_SNAPSHOT = "cognitive_why_snapshot"
 
+# Sovereign Command Node Phase 1 (2026-06-23) -- four additive event types
+# exposing FSM phase transitions, cross-repo elevation gates, sovereign yield
+# telemetry, and DAG node state updates to IDE consumers. All are best-effort
+# (fail-soft publish helpers) and authority-free (read-only projection only).
+EVENT_TYPE_FSM_PHASE_CHANGED = "fsm_phase_changed"
+"""Emitted at every Ouroboros FSM phase transition. Payload: op_id + phase
++ route + risk_tier + schema_version. Best-effort hook in orchestrator;
+broker exception NEVER raises into the phase runner."""
+
+EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING = "cross_repo_elevation_pending"
+"""Emitted when a cross-repo elevation request becomes pending (Orange/
+APPROVAL_REQUIRED with a cross-repo target recorded in critical_elevation).
+Payload: pr_id + target_repo + blast_radius_summary + schema_version.
+Authority-free; broker exception NEVER raises into the elevation path."""
+
+EVENT_TYPE_SOVEREIGN_YIELD = "sovereign_yield"
+"""Emitted by convergence_watchdog.emit_sovereign_yield when the reduction
+trajectory stalls or on graceful semantic-pivot yields (UNRESOLVABLE_PATH).
+Payload: op_id + reason + schema_version. The existing WARNING log is
+authoritative; this SSE event is a best-effort observability beacon."""
+
+EVENT_TYPE_DAG_NODE_UPDATED = "dag_node_updated"
+"""Emitted when a sub-goal DAG node transitions state (PENDING / DISPATCHED
+/ COMPLETE / FAILED / DLQ). Payload: op_id + node_id + state + schema_version.
+Composes sovereign_state_propagation_bridge -- no parallel state. Broker
+exception NEVER raises into the DAG runner."""
+
 _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_COGNITIVE_WHY_SNAPSHOT,
     EVENT_TYPE_TASK_CREATED,
@@ -1554,6 +1581,10 @@ _VALID_EVENT_TYPES = frozenset({
                                                   # per-model quality calibration result)
     EVENT_TYPE_FLEET_GRADUATED,                   # Sovereign Fleet Evaluator (2026-06-19 —
                                                   # quality-aware routing flipped authoritative)
+    EVENT_TYPE_FSM_PHASE_CHANGED,                # Command Node Phase 1 (2026-06-23 -- FSM phase transition)
+    EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING,     # Command Node Phase 1 (2026-06-23 -- cross-repo elevation pending)
+    EVENT_TYPE_SOVEREIGN_YIELD,                  # Command Node Phase 1 (2026-06-23 -- convergence stall yield)
+    EVENT_TYPE_DAG_NODE_UPDATED,                 # Command Node Phase 1 (2026-06-23 -- DAG node state update)
 })
 
 
@@ -4518,3 +4549,116 @@ def register_flags(registry: Any) -> int:
                 exc_info=True,
             )
     return count
+
+
+# ---------------------------------------------------------------------------
+# Sovereign Command Node Phase 1 -- publish helpers (2026-06-23)
+# All helpers are fail-soft: a broker exception or missing broker NEVER
+# propagates to the caller. All are authority-free (read-only telemetry).
+# ---------------------------------------------------------------------------
+
+
+def publish_fsm_phase(op_id: str, phase: str, route: str, risk_tier: str) -> None:
+    """Publish FSM phase transition event. Best-effort, fail-soft.
+
+    Call sites: orchestrator._run_pipeline phase-transition seams.
+    Wrapped in try/except at the call site so this helper NEVER
+    disrupts the pipeline. Payload keyed by the command node spec.
+    """
+    try:
+        broker = get_default_broker()
+        if broker is None:
+            return
+        broker.publish(
+            EVENT_TYPE_FSM_PHASE_CHANGED,
+            op_id,
+            {
+                "op_id": op_id,
+                "phase": phase,
+                "route": route,
+                "risk_tier": risk_tier,
+                "schema_version": STREAM_SCHEMA_VERSION,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def publish_elevation_pending(
+    pr_id: str,
+    target_repo: str,
+    blast_radius_summary: dict,
+) -> None:
+    """Publish cross-repo elevation pending event. Best-effort, fail-soft.
+
+    Call sites: critical_elevation layer when elevation becomes pending.
+    Wrapped in try/except at the call site. Payload keyed by command
+    node spec -- blast_radius_summary is a bounded dict projection, NOT
+    the full BlastRadius object (avoids large payloads on the SSE channel).
+    """
+    try:
+        broker = get_default_broker()
+        if broker is None:
+            return
+        broker.publish(
+            EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING,
+            pr_id,
+            {
+                "pr_id": pr_id,
+                "target_repo": target_repo,
+                "blast_radius_summary": blast_radius_summary,
+                "schema_version": STREAM_SCHEMA_VERSION,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def publish_sovereign_yield(op_id: str, reason: str) -> None:
+    """Publish sovereign yield event. Best-effort, fail-soft.
+
+    Replaces (or composes alongside) the existing publish_task_event
+    call in convergence_watchdog.emit_sovereign_yield. Carries a
+    dedicated SSE event type so IDE consumers can subscribe with a
+    type filter rather than inspecting task payloads.
+    """
+    try:
+        broker = get_default_broker()
+        if broker is None:
+            return
+        broker.publish(
+            EVENT_TYPE_SOVEREIGN_YIELD,
+            op_id,
+            {
+                "op_id": op_id,
+                "reason": reason,
+                "schema_version": STREAM_SCHEMA_VERSION,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def publish_dag_node(op_id: str, node_id: str, state: str) -> None:
+    """Publish DAG node state update event. Best-effort, fail-soft.
+
+    Call sites: sovereign_state_propagation_bridge or any site that
+    transitions a sub-goal DAG node through PENDING / DISPATCHED /
+    COMPLETE / FAILED / DLQ. Wrapped in try/except at the call site.
+    """
+    try:
+        broker = get_default_broker()
+        if broker is None:
+            return
+        broker.publish(
+            EVENT_TYPE_DAG_NODE_UPDATED,
+            op_id,
+            {
+                "op_id": op_id,
+                "node_id": node_id,
+                "state": state,
+                "schema_version": STREAM_SCHEMA_VERSION,
+            },
+        )
+    except Exception:  # noqa: BLE001
+        pass

--- a/extensions/command-node/.env.example
+++ b/extensions/command-node/.env.example
@@ -1,0 +1,20 @@
+# Sovereign Command Node -- environment (copy to .env.local).
+# NO hardcoded localhost in source; everything operational is here.
+
+# Backend EventChannelServer base URL.
+NEXT_PUBLIC_OBSERVABILITY_BASE=http://127.0.0.1:8765
+
+# Used only to build the default base when BASE is unset.
+NEXT_PUBLIC_OBSERVABILITY_PORT=8765
+
+# In-memory SSE ring-buffer cap.
+NEXT_PUBLIC_EVENT_BUFFER_CAP=500
+
+# Reconnect backoff ceiling (ms).
+NEXT_PUBLIC_RECONNECT_MAX_BACKOFF_MS=15000
+
+# Poll-fallback interval (ms) once SSE is deemed unreliable.
+NEXT_PUBLIC_POLL_INTERVAL_MS=5000
+
+# Consecutive SSE failures before degrading to poll fallback.
+NEXT_PUBLIC_MAX_FAILURES_BEFORE_POLL=5

--- a/extensions/command-node/.gitignore
+++ b/extensions/command-node/.gitignore
@@ -1,0 +1,9 @@
+node_modules/
+.next/
+out/
+dist/
+*.tsbuildinfo
+next-env.d.ts.timestamp
+.env*.local
+coverage/
+.DS_Store

--- a/extensions/command-node/README.md
+++ b/extensions/command-node/README.md
@@ -1,0 +1,118 @@
+# JARVIS Sovereign Command Node (Phase 1 -- read-only)
+
+A dynamic mission-control dashboard for the JARVIS Ouroboros governance
+loop. **Phase 1 is READ-ONLY visualization** -- it consumes the existing
+`/observability` SSE + GET surface and renders it. There is **no
+write-path and no biometric** in this phase (the elevation "Authorize"
+button is a disabled placeholder for Phase 2).
+
+Stack: Next.js (App Router) + React + TypeScript + React Flow, with a
+native-`fetch` SSE client mirrored from the `vscode-jarvis` extension's
+proven parser + reconnect logic.
+
+## What it shows
+
+- **FSM ribbon** -- the 11-phase Ouroboros pipeline
+  (`CLASSIFY -> ROUTE -> ... -> COMPLETE`), one live ribbon per active op,
+  highlighting the current phase with provider / route / risk-tier
+  badges (from `fsm_phase_changed`).
+- **DAG canvas** -- the live execution graph, nodes colored by state
+  (pending / running / applied / fractured / complete), fed by
+  `dag_node_updated` + `task_*` events.
+- **Blast-radius graph** -- the operator constraint, made visible. An
+  interactive React Flow graph of
+  `GET /observability/blast-radius/{op_id}`: the mutated symbol at the
+  center, edges to every directly- and transitively-affected dependent,
+  color-coded by repo (**Body/jarvis = blue, Mind/prime = amber,
+  Nerves/reactor = violet**) so a cross-boundary blast is obvious. Click
+  a node for a repo / file / symbol detail panel.
+- **Elevation queue** -- read-only list of pending `CRITICAL_ELEVATION`
+  PRs (from `cross_repo_elevation_pending`), each with a "view blast
+  radius" action and a clearly-disabled "Authorize (Phase 2: biometric)"
+  affordance.
+- **Connection status + yield toasts** -- live SSE state and transient
+  `sovereign_yield` alerts (FRACTURE / QUARANTINE / RECOVERED).
+
+## Run
+
+```bash
+cd extensions/command-node
+npm install
+npm run dev          # http://localhost:3000
+```
+
+Point it at your running JARVIS observability backend (the
+`EventChannelServer`) via env -- **there is no hardcoded localhost in
+source**:
+
+```bash
+# .env.local
+NEXT_PUBLIC_OBSERVABILITY_BASE=http://127.0.0.1:8765
+```
+
+If unset, the base defaults to
+`http://127.0.0.1:${NEXT_PUBLIC_OBSERVABILITY_PORT:-8765}`.
+
+### Tunables (all env, all optional)
+
+| Env var | Default | Meaning |
+| --- | --- | --- |
+| `NEXT_PUBLIC_OBSERVABILITY_BASE` | `http://127.0.0.1:8765` | Backend base URL |
+| `NEXT_PUBLIC_OBSERVABILITY_PORT` | `8765` | Used only to build the default base |
+| `NEXT_PUBLIC_EVENT_BUFFER_CAP` | `500` | In-memory SSE ring-buffer size |
+| `NEXT_PUBLIC_RECONNECT_MAX_BACKOFF_MS` | `15000` | Reconnect backoff ceiling |
+| `NEXT_PUBLIC_POLL_INTERVAL_MS` | `5000` | Poll-fallback interval |
+| `NEXT_PUBLIC_MAX_FAILURES_BEFORE_POLL` | `5` | Consecutive SSE failures before poll fallback |
+
+## Test / typecheck
+
+```bash
+npm run test        # vitest (jsdom)
+npm run typecheck   # tsc --noEmit (strict)
+```
+
+## Resilience
+
+The SSE client (`hooks/useSovereignStream.ts` + `lib/stream.ts`) uses a
+native-`fetch` `ReadableStream` reader (not the bare `EventSource`), so
+it can send the `Last-Event-ID` header for server-side ring-buffer
+replay on reconnect, with exponential backoff + full jitter. After
+`MAX_FAILURES_BEFORE_POLL` consecutive failures it **degrades to a poll
+fallback** (`GET /observability/tasks`) and automatically returns to SSE
+when the stream recovers. The event buffer is bounded.
+
+## Architecture / component tree
+
+```
+app/
+  layout.tsx          # html shell + global CSS
+  page.tsx            # 3-region mission-control layout, wires the hook
+  globals.css
+hooks/
+  useSovereignStream.ts   # React SSE client (bounded buffer + poll fallback)
+lib/
+  stream.ts           # framework-agnostic SSE parser + reconnect (mirror of vscode)
+  api.ts              # typed GET client (health/tasks/blast-radius)
+  types.ts            # SSE discriminated union + GET response shapes
+  config.ts           # env-driven config (no hardcoded localhost)
+  projection.ts       # pure event-stream -> view-model transforms
+  blastGraph.ts       # pure React Flow graph builder for the blast radius
+  theme.ts            # repo color map (Body/Mind/Nerves) + DAG state colors
+components/
+  FSMStateStream.tsx  # 11-phase ribbons
+  DAGCanvas.tsx       # live execution DAG (React Flow)
+  BlastRadiusGraph.tsx# interactive blast-radius graph + detail panel
+  ElevationQueue.tsx  # read-only elevation list (disabled authorize)
+  ConnectionStatus.tsx
+  YieldToasts.tsx
+test/
+  useSovereignStream.test.ts  # SSE parse + reconnect + Last-Event-ID + bounded buffer
+  blastRadiusGraph.test.tsx   # repo-colored nodes + click -> detail
+  projection.test.ts
+```
+
+## Scope (Phase 1)
+
+Read-only. No POST/auth/biometric code anywhere. The dashboard is a pure
+consumer of the observability surface; all governance authority stays in
+the backend.

--- a/extensions/command-node/app/globals.css
+++ b/extensions/command-node/app/globals.css
@@ -1,0 +1,357 @@
+:root {
+  --bg: #0b0f17;
+  --panel: #131926;
+  --panel-2: #0e131d;
+  --border: #1f2937;
+  --text: #e5e7eb;
+  --muted: #9ca3af;
+  --accent: #3b82f6;
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  margin: 0;
+  padding: 0;
+  height: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto,
+    Helvetica, Arial, sans-serif;
+  font-size: 14px;
+}
+
+.mono {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
+}
+
+.muted {
+  color: var(--muted);
+}
+
+.badge {
+  display: inline-block;
+  padding: 1px 6px;
+  border-radius: 6px;
+  font-size: 11px;
+  color: #fff;
+  background: #374151;
+}
+
+.badge-provider {
+  background: #1d4ed8;
+}
+.badge-route {
+  background: #4b5563;
+}
+.badge-cross,
+.badge-repo {
+  background: #b91c1c;
+}
+
+/* --- Mission-control 3-region layout --- */
+.command-node {
+  display: grid;
+  grid-template-rows: auto auto 1fr;
+  grid-template-columns: 1fr 360px;
+  grid-template-areas:
+    'topbar topbar'
+    'fsm    fsm'
+    'dag    side';
+  height: 100vh;
+  gap: 8px;
+  padding: 8px;
+}
+
+.cn-topbar {
+  grid-area: topbar;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 6px 12px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+}
+
+.cn-fsm {
+  grid-area: fsm;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  overflow-x: auto;
+  max-height: 220px;
+}
+
+.cn-dag {
+  grid-area: dag;
+  background: var(--panel-2);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  overflow: hidden;
+  position: relative;
+}
+
+.cn-side {
+  grid-area: side;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  overflow-y: auto;
+}
+
+.cn-side > .blast-graph,
+.cn-side > .elevation-queue {
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+}
+
+/* --- FSM ribbon --- */
+.op-ribbon {
+  margin-bottom: 10px;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 8px;
+}
+.op-ribbon-head {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  margin-bottom: 6px;
+}
+.op-id {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.phase-track {
+  display: flex;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  gap: 2px;
+}
+.phase {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  min-width: 70px;
+  font-size: 9px;
+  text-align: center;
+}
+.phase-dot {
+  width: 12px;
+  height: 12px;
+  border-radius: 50%;
+  background: #374151;
+  margin-bottom: 3px;
+}
+.phase-done .phase-dot {
+  background: #16a34a;
+}
+.phase-active .phase-dot {
+  background: var(--accent);
+  box-shadow: 0 0 0 3px rgba(59, 130, 246, 0.35);
+}
+.phase-active .phase-label {
+  color: var(--accent);
+  font-weight: 600;
+}
+.phase-future .phase-label {
+  color: var(--muted);
+}
+
+/* --- DAG --- */
+.dag-canvas,
+.blast-flow {
+  width: 100%;
+  height: 100%;
+}
+.cn-dag .dag-canvas {
+  position: absolute;
+  inset: 0;
+}
+.dag-empty,
+.blast-graph .muted {
+  padding: 16px;
+}
+
+/* --- Blast radius --- */
+.blast-flow {
+  height: 320px;
+}
+.blast-summary {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-bottom: 6px;
+  font-size: 12px;
+}
+.blast-legend {
+  display: flex;
+  gap: 10px;
+  margin-bottom: 6px;
+  font-size: 11px;
+}
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+.legend-swatch {
+  display: inline-block;
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+  border: 1px solid;
+}
+.blast-detail {
+  margin-top: 8px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  padding: 8px;
+  background: var(--panel-2);
+}
+.blast-detail-head {
+  display: flex;
+  justify-content: space-between;
+  border-bottom: 1px solid;
+  padding-bottom: 4px;
+  margin-bottom: 6px;
+}
+.blast-detail dl {
+  display: grid;
+  grid-template-columns: 70px 1fr;
+  gap: 2px 8px;
+  margin: 0;
+  font-size: 12px;
+}
+.blast-detail dt {
+  color: var(--muted);
+}
+.blast-detail dd {
+  margin: 0;
+}
+
+/* --- Elevation queue --- */
+.elevation-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+}
+.elevation-head h2 {
+  font-size: 14px;
+  margin: 0 0 4px 0;
+}
+.elevation-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.elevation-item {
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  border-radius: 6px;
+  padding: 8px;
+  background: var(--panel-2);
+}
+.elevation-item.focused {
+  outline: 1px solid var(--accent);
+}
+.elevation-row {
+  display: flex;
+  justify-content: space-between;
+  gap: 8px;
+  align-items: center;
+}
+.elevation-summary {
+  margin: 6px 0;
+  font-size: 12px;
+  color: var(--muted);
+}
+.elevation-actions {
+  display: flex;
+  gap: 6px;
+}
+.btn {
+  font-size: 12px;
+  padding: 4px 8px;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: #1f2937;
+  color: var(--text);
+  cursor: pointer;
+}
+.btn-view:hover {
+  background: #374151;
+}
+.btn-authorize[disabled] {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+/* --- Connection status --- */
+.conn-status {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+}
+.conn-dot {
+  width: 10px;
+  height: 10px;
+  border-radius: 50%;
+}
+.conn-eid {
+  color: var(--muted);
+  max-width: 160px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* --- Yield toasts --- */
+.yield-toasts {
+  position: fixed;
+  right: 16px;
+  bottom: 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  z-index: 50;
+}
+.yield-toast {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  background: var(--panel);
+  border: 1px solid var(--border);
+  border-left: 4px solid #6b7280;
+  border-radius: 8px;
+  padding: 8px 12px;
+  box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+}
+.yield-badge {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 6px;
+  color: #fff;
+}
+.link {
+  background: none;
+  border: none;
+  color: var(--muted);
+  cursor: pointer;
+}

--- a/extensions/command-node/app/layout.tsx
+++ b/extensions/command-node/app/layout.tsx
@@ -1,0 +1,21 @@
+import type { Metadata } from 'next';
+import type { ReactNode } from 'react';
+import './globals.css';
+
+export const metadata: Metadata = {
+  title: 'JARVIS Sovereign Command Node',
+  description:
+    'Read-only mission-control dashboard for the JARVIS Ouroboros loop (Phase 1).',
+};
+
+export default function RootLayout({
+  children,
+}: {
+  readonly children: ReactNode;
+}): JSX.Element {
+  return (
+    <html lang="en">
+      <body>{children}</body>
+    </html>
+  );
+}

--- a/extensions/command-node/app/page.tsx
+++ b/extensions/command-node/app/page.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * The Sovereign Command Node mission-control page (Phase 1, read-only).
+ *
+ * 3-region layout:
+ *   - top:  FSM ribbon (one per active op)
+ *   - main: live execution DAG canvas
+ *   - side: blast-radius graph + critical-elevation queue
+ * plus a connection-status indicator and sovereign_yield toasts.
+ *
+ * Blast radius loads on demand: when a cross_repo_elevation_pending
+ * event arrives (newest first) we auto-focus its op, and the operator
+ * can re-focus any pending elevation via "view blast radius".
+ */
+
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useSovereignStream } from '../hooks/useSovereignStream';
+import { resolveConfig } from '../lib/config';
+import { ObservabilityClient } from '../lib/api';
+import { BlastRadiusResponse } from '../lib/types';
+import {
+  projectDagNodes,
+  projectElevationQueue,
+  projectFsmStates,
+  projectYieldAlerts,
+} from '../lib/projection';
+import FSMStateStream from '../components/FSMStateStream';
+import DAGCanvas from '../components/DAGCanvas';
+import BlastRadiusGraph from '../components/BlastRadiusGraph';
+import ElevationQueue from '../components/ElevationQueue';
+import ConnectionStatus from '../components/ConnectionStatus';
+import YieldToasts from '../components/YieldToasts';
+
+export default function Page(): JSX.Element {
+  const cfg = useMemo(() => resolveConfig(), []);
+  const { events, connectionState, lastEventId } = useSovereignStream();
+
+  const fsmOps = useMemo(() => projectFsmStates(events), [events]);
+  const dagNodes = useMemo(() => projectDagNodes(events), [events]);
+  const elevations = useMemo(() => projectElevationQueue(events), [events]);
+  const yieldAlerts = useMemo(() => projectYieldAlerts(events), [events]);
+
+  const [focusedOpId, setFocusedOpId] = useState<string | null>(null);
+  const [report, setReport] = useState<BlastRadiusResponse | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const clientRef = useRef<ObservabilityClient | null>(null);
+  if (clientRef.current === null) {
+    clientRef.current = new ObservabilityClient({
+      endpoint: cfg.observabilityBase,
+    });
+  }
+
+  const loadBlastRadius = useCallback(async (opId: string): Promise<void> => {
+    setFocusedOpId(opId);
+    setLoading(true);
+    setError(null);
+    try {
+      const r = await clientRef.current!.blastRadius(opId);
+      setReport(r);
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+      setReport(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  // Auto-focus the newest pending elevation that we haven't loaded yet.
+  const newestOpId = elevations.length > 0 ? elevations[0]!.opId : null;
+  useEffect(() => {
+    if (newestOpId !== null && newestOpId !== focusedOpId) {
+      void loadBlastRadius(newestOpId);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newestOpId]);
+
+  return (
+    <main className="command-node">
+      <div className="cn-topbar">
+        <strong>JARVIS Sovereign Command Node</strong>
+        <ConnectionStatus state={connectionState} lastEventId={lastEventId} />
+      </div>
+
+      <div className="cn-fsm">
+        <FSMStateStream ops={fsmOps} />
+      </div>
+
+      <div className="cn-dag">
+        <DAGCanvas nodes={dagNodes} />
+      </div>
+
+      <div className="cn-side">
+        <BlastRadiusGraph report={report} loading={loading} error={error} />
+        <ElevationQueue
+          entries={elevations}
+          onViewBlastRadius={(opId) => void loadBlastRadius(opId)}
+          focusedOpId={focusedOpId}
+        />
+      </div>
+
+      <YieldToasts alerts={yieldAlerts} />
+    </main>
+  );
+}

--- a/extensions/command-node/components/BlastRadiusGraph.tsx
+++ b/extensions/command-node/components/BlastRadiusGraph.tsx
@@ -1,0 +1,181 @@
+'use client';
+
+/**
+ * BlastRadiusGraph -- the operator constraint, made visible.
+ *
+ * An interactive React Flow graph of GET /observability/blast-radius/
+ * {op_id}: the mutated symbol at the center, edges to every directly-
+ * and transitively-affected dependent. Nodes are color-coded by repo
+ * (Body/jarvis=blue, Mind/prime=amber, Nerves/reactor=violet) so a
+ * cross-boundary blast is visually obvious. Click a node -> detail
+ * panel (repo / file / symbol / type). Read-only.
+ */
+
+import { useEffect, useMemo, useState } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  Node,
+  NodeMouseHandler,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { AffectedNode, BlastRadiusResponse, TrinityRepo } from '../lib/types';
+import { buildBlastGraph, distinctRepos } from '../lib/blastGraph';
+import { repoStyle } from '../lib/theme';
+
+export interface BlastRadiusGraphProps {
+  /** The loaded report, or null while idle / loading. */
+  readonly report: BlastRadiusResponse | null;
+  readonly loading?: boolean;
+  readonly error?: string | null;
+}
+
+function RepoLegend(): JSX.Element {
+  const repos: TrinityRepo[] = ['jarvis', 'prime', 'reactor'];
+  return (
+    <div className="blast-legend" data-testid="blast-legend">
+      {repos.map((r) => {
+        const s = repoStyle(r);
+        return (
+          <span className="legend-item" key={r}>
+            <span
+              className="legend-swatch"
+              style={{ backgroundColor: s.color, borderColor: s.border }}
+            />
+            {s.label} ({r})
+          </span>
+        );
+      })}
+    </div>
+  );
+}
+
+function DetailPanel({
+  node,
+  onClose,
+}: {
+  readonly node: AffectedNode;
+  readonly onClose: () => void;
+}): JSX.Element {
+  const s = repoStyle(node.repo);
+  return (
+    <aside className="blast-detail" data-testid="blast-detail" role="dialog"
+      aria-label="affected node detail">
+      <div className="blast-detail-head" style={{ borderColor: s.border }}>
+        <strong>{node.name}</strong>
+        <button className="link" onClick={onClose} aria-label="close detail">
+          x
+        </button>
+      </div>
+      <dl>
+        <dt>Repo</dt>
+        <dd>
+          <span
+            className="legend-swatch"
+            style={{ backgroundColor: s.color, borderColor: s.border }}
+          />
+          {s.label} ({node.repo})
+        </dd>
+        <dt>File</dt>
+        <dd className="mono">{node.file}</dd>
+        <dt>Symbol</dt>
+        <dd className="mono">{node.name}</dd>
+        <dt>Type</dt>
+        <dd>{node.type}</dd>
+      </dl>
+    </aside>
+  );
+}
+
+export function BlastRadiusGraph({
+  report,
+  loading = false,
+  error = null,
+}: BlastRadiusGraphProps): JSX.Element {
+  const [selected, setSelected] = useState<AffectedNode | null>(null);
+
+  // Reset the selected detail whenever the report changes.
+  useEffect(() => {
+    setSelected(null);
+  }, [report?.op_id]);
+
+  const graph = useMemo(
+    () => (report ? buildBlastGraph(report) : { nodes: [], edges: [] }),
+    [report],
+  );
+
+  const repos = useMemo(
+    () => (report ? distinctRepos(report) : []),
+    [report],
+  );
+  const crossBoundary = repos.length > 1;
+
+  const onNodeClick: NodeMouseHandler = (_evt, node: Node) => {
+    const affected = (node.data as { affected?: AffectedNode } | undefined)
+      ?.affected;
+    if (affected) {
+      setSelected(affected);
+    }
+  };
+
+  if (error) {
+    return (
+      <div className="blast-graph blast-error" data-testid="blast-error">
+        <span className="muted">Blast radius unavailable: {error}</span>
+      </div>
+    );
+  }
+  if (loading) {
+    return (
+      <div className="blast-graph" data-testid="blast-loading">
+        <span className="muted">Loading blast radius...</span>
+      </div>
+    );
+  }
+  if (!report) {
+    return (
+      <div className="blast-graph blast-idle" data-testid="blast-idle">
+        <span className="muted">
+          Select an elevation to view its blast radius.
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <div className="blast-graph" data-testid="blast-graph">
+      <div className="blast-summary">
+        <span>
+          op <span className="mono">{report.op_id}</span>
+        </span>
+        <span>total affected: {report.total_affected}</span>
+        <span>risk: {report.risk_level}</span>
+        {crossBoundary ? (
+          <span className="badge badge-cross" data-testid="cross-boundary">
+            CROSS-BOUNDARY ({repos.join(', ')})
+          </span>
+        ) : null}
+      </div>
+      <RepoLegend />
+      <div className="blast-flow">
+        <ReactFlow
+          nodes={graph.nodes}
+          edges={graph.edges}
+          fitView
+          proOptions={{ hideAttribution: true }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          onNodeClick={onNodeClick}
+        >
+          <Background />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      </div>
+      {selected ? (
+        <DetailPanel node={selected} onClose={() => setSelected(null)} />
+      ) : null}
+    </div>
+  );
+}
+
+export default BlastRadiusGraph;

--- a/extensions/command-node/components/ConnectionStatus.tsx
+++ b/extensions/command-node/components/ConnectionStatus.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+/**
+ * ConnectionStatus -- a small live indicator of the SSE connection
+ * state (connecting / connected / reconnecting / error / polling /
+ * closed), plus the current Last-Event-ID for operator visibility.
+ */
+
+import { ConnectionState } from '../hooks/useSovereignStream';
+
+const STATE_COLOR: Record<ConnectionState, string> = {
+  disconnected: '#6b7280',
+  connecting: '#ca8a04',
+  connected: '#16a34a',
+  reconnecting: '#ea580c',
+  error: '#dc2626',
+  closed: '#6b7280',
+  polling: '#0891b2',
+};
+
+const STATE_LABEL: Record<ConnectionState, string> = {
+  disconnected: 'Disconnected',
+  connecting: 'Connecting',
+  connected: 'Live',
+  reconnecting: 'Reconnecting',
+  error: 'Error',
+  closed: 'Closed',
+  polling: 'Poll fallback',
+};
+
+export interface ConnectionStatusProps {
+  readonly state: ConnectionState;
+  readonly lastEventId: string | null;
+}
+
+export function ConnectionStatus({
+  state,
+  lastEventId,
+}: ConnectionStatusProps): JSX.Element {
+  return (
+    <div className="conn-status" data-testid="conn-status" data-state={state}>
+      <span
+        className="conn-dot"
+        style={{ backgroundColor: STATE_COLOR[state] }}
+        aria-hidden="true"
+      />
+      <span className="conn-label">{STATE_LABEL[state]}</span>
+      {lastEventId ? (
+        <span className="conn-eid mono" title="Last-Event-ID">
+          {lastEventId}
+        </span>
+      ) : null}
+    </div>
+  );
+}
+
+export default ConnectionStatus;

--- a/extensions/command-node/components/DAGCanvas.tsx
+++ b/extensions/command-node/components/DAGCanvas.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * DAGCanvas -- the live execution DAG.
+ *
+ * Renders nodes from the projected DAG view (dag_node_updated + task_*
+ * events), colored by state (pending/running/applied/fractured/
+ * complete). Uses React Flow for layout + pan/zoom. Read-only.
+ *
+ * Phase 1 has no edge stream from the backend yet; nodes are laid out
+ * in a simple grid keyed by op so the operator sees concurrent ops at a
+ * glance. When edge events land in a later phase, wire them here.
+ */
+
+import { useMemo } from 'react';
+import ReactFlow, {
+  Background,
+  Controls,
+  Edge,
+  Node,
+} from 'reactflow';
+import 'reactflow/dist/style.css';
+import { DagNodeView } from '../lib/projection';
+import { dagStateColor } from '../lib/theme';
+
+export interface DAGCanvasProps {
+  readonly nodes: readonly DagNodeView[];
+}
+
+const COLS = 4;
+const CELL_W = 200;
+const CELL_H = 120;
+
+export function buildFlowNodes(views: readonly DagNodeView[]): Node[] {
+  return views.map((v, i) => ({
+    id: v.nodeId,
+    position: {
+      x: (i % COLS) * CELL_W,
+      y: Math.floor(i / COLS) * CELL_H,
+    },
+    data: { label: `${v.nodeId}\n${v.state}` },
+    style: {
+      background: dagStateColor(v.state),
+      color: '#ffffff',
+      border: '1px solid rgba(255,255,255,0.25)',
+      borderRadius: 8,
+      fontSize: 11,
+      width: CELL_W - 40,
+      whiteSpace: 'pre-line' as const,
+    },
+  }));
+}
+
+export function DAGCanvas({ nodes }: DAGCanvasProps): JSX.Element {
+  const flowNodes = useMemo(() => buildFlowNodes(nodes), [nodes]);
+  const flowEdges = useMemo<Edge[]>(() => [], []);
+
+  return (
+    <div className="dag-canvas" data-testid="dag-canvas">
+      {nodes.length === 0 ? (
+        <div className="dag-empty muted">No DAG nodes yet.</div>
+      ) : (
+        <ReactFlow
+          nodes={flowNodes}
+          edges={flowEdges}
+          fitView
+          proOptions={{ hideAttribution: true }}
+          nodesDraggable={false}
+          nodesConnectable={false}
+          elementsSelectable={false}
+        >
+          <Background />
+          <Controls showInteractive={false} />
+        </ReactFlow>
+      )}
+    </div>
+  );
+}
+
+export default DAGCanvas;

--- a/extensions/command-node/components/ElevationQueue.tsx
+++ b/extensions/command-node/components/ElevationQueue.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+/**
+ * ElevationQueue -- read-only list of pending CRITICAL_ELEVATION PRs
+ * from cross_repo_elevation_pending events.
+ *
+ * Phase 1 is VIEW ONLY. The "Authorize" affordance is a DISABLED
+ * placeholder clearly marked as Phase 2 (biometric) -- there is no
+ * write/auth code anywhere in this component. The only active action is
+ * "view blast radius", which asks the parent to focus the graph on the
+ * op.
+ */
+
+import { ElevationEntry } from '../lib/projection';
+import { repoStyle } from '../lib/theme';
+
+export interface ElevationQueueProps {
+  readonly entries: readonly ElevationEntry[];
+  /** Ask the parent to load + focus the blast radius for this op. */
+  readonly onViewBlastRadius: (opId: string) => void;
+  /** The op currently focused in the blast graph (for highlighting). */
+  readonly focusedOpId?: string | null;
+}
+
+export function ElevationQueue({
+  entries,
+  onViewBlastRadius,
+  focusedOpId = null,
+}: ElevationQueueProps): JSX.Element {
+  return (
+    <section className="elevation-queue" data-testid="elevation-queue"
+      aria-label="pending critical elevations">
+      <header className="elevation-head">
+        <h2>Critical Elevations</h2>
+        <span className="muted">{entries.length} pending</span>
+      </header>
+      {entries.length === 0 ? (
+        <p className="muted" data-testid="elevation-empty">
+          No pending elevations.
+        </p>
+      ) : (
+        <ul className="elevation-list">
+          {entries.map((e) => {
+            const s = repoStyle(e.target_repo);
+            const focused = focusedOpId === e.opId;
+            return (
+              <li
+                key={e.pr_id}
+                className={`elevation-item${focused ? ' focused' : ''}`}
+                data-pr-id={e.pr_id}
+                style={{ borderLeftColor: s.border }}
+              >
+                <div className="elevation-row">
+                  <span className="elevation-pr mono">{e.pr_id}</span>
+                  <span
+                    className="badge badge-repo"
+                    style={{ backgroundColor: s.color }}
+                  >
+                    {s.label} ({e.target_repo})
+                  </span>
+                </div>
+                <p className="elevation-summary">{e.blast_radius_summary}</p>
+                <div className="elevation-actions">
+                  <button
+                    className="btn btn-view"
+                    onClick={() => onViewBlastRadius(e.opId)}
+                  >
+                    View blast radius
+                  </button>
+                  <button
+                    className="btn btn-authorize"
+                    disabled
+                    title="Disabled in Phase 1 -- biometric authorization arrives in Phase 2"
+                    aria-disabled="true"
+                  >
+                    Authorize (Phase 2: biometric)
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </section>
+  );
+}
+
+export default ElevationQueue;

--- a/extensions/command-node/components/FSMStateStream.tsx
+++ b/extensions/command-node/components/FSMStateStream.tsx
@@ -1,0 +1,107 @@
+'use client';
+
+/**
+ * FSMStateStream -- the 11-phase Ouroboros ribbon.
+ *
+ * One ribbon per active op (multiple concurrent ops = multiple
+ * ribbons), live-highlighting the current phase from fsm_phase_changed,
+ * with provider / route / risk-tier badges. Read-only.
+ */
+
+import { OUROBOROS_PHASES } from '../lib/types';
+import { OpFsmState } from '../lib/projection';
+
+export interface FSMStateStreamProps {
+  readonly ops: readonly OpFsmState[];
+}
+
+function phaseIndex(phase: string): number {
+  const idx = (OUROBOROS_PHASES as readonly string[]).indexOf(phase);
+  return idx;
+}
+
+function riskBadgeColor(tier: string | undefined): string {
+  switch (tier) {
+    case 'safe_auto':
+      return '#16a34a';
+    case 'notify_apply':
+      return '#ca8a04';
+    case 'approval_required':
+      return '#ea580c';
+    case 'critical_elevation':
+      return '#dc2626';
+    case 'blocked':
+      return '#991b1b';
+    default:
+      return '#6b7280';
+  }
+}
+
+export function OpRibbon({ op }: { readonly op: OpFsmState }): JSX.Element {
+  const current = phaseIndex(op.phase);
+  return (
+    <div className="op-ribbon" data-op-id={op.opId} role="group"
+      aria-label={`op ${op.opId} phase ${op.phase}`}>
+      <div className="op-ribbon-head">
+        <span className="op-id" title={op.opId}>{op.opId}</span>
+        {op.provider ? (
+          <span className="badge badge-provider">{op.provider}</span>
+        ) : null}
+        {op.route ? (
+          <span className="badge badge-route">{op.route}</span>
+        ) : null}
+        {op.riskTier ? (
+          <span
+            className="badge badge-risk"
+            style={{ backgroundColor: riskBadgeColor(op.riskTier) }}
+          >
+            {op.riskTier}
+          </span>
+        ) : null}
+      </div>
+      <ol className="phase-track">
+        {OUROBOROS_PHASES.map((phase, i) => {
+          const state =
+            current < 0
+              ? 'idle'
+              : i < current
+                ? 'done'
+                : i === current
+                  ? 'active'
+                  : 'future';
+          return (
+            <li
+              key={phase}
+              className={`phase phase-${state}`}
+              data-phase={phase}
+              data-state={state}
+              title={phase}
+            >
+              <span className="phase-dot" aria-hidden="true" />
+              <span className="phase-label">{phase}</span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+export function FSMStateStream({ ops }: FSMStateStreamProps): JSX.Element {
+  if (ops.length === 0) {
+    return (
+      <div className="fsm-stream fsm-empty" data-testid="fsm-empty">
+        <span className="muted">No active operations.</span>
+      </div>
+    );
+  }
+  return (
+    <div className="fsm-stream" data-testid="fsm-stream">
+      {ops.map((op) => (
+        <OpRibbon key={op.opId} op={op} />
+      ))}
+    </div>
+  );
+}
+
+export default FSMStateStream;

--- a/extensions/command-node/components/YieldToasts.tsx
+++ b/extensions/command-node/components/YieldToasts.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+/**
+ * YieldToasts -- transient alerts for sovereign_yield events
+ * (FRACTURE / QUARANTINE / RECOVERED). Read-only surfacing; no action.
+ */
+
+import { YieldAlert } from '../lib/projection';
+
+const REASON_COLOR: Record<string, string> = {
+  FRACTURE: '#dc2626',
+  QUARANTINE: '#ea580c',
+  RECOVERED: '#16a34a',
+};
+
+export interface YieldToastsProps {
+  readonly alerts: readonly YieldAlert[];
+}
+
+export function YieldToasts({ alerts }: YieldToastsProps): JSX.Element | null {
+  if (alerts.length === 0) {
+    return null;
+  }
+  return (
+    <div className="yield-toasts" data-testid="yield-toasts"
+      role="status" aria-live="polite">
+      {alerts.map((a) => (
+        <div
+          key={a.key}
+          className="yield-toast"
+          data-reason={a.reason}
+          style={{ borderLeftColor: REASON_COLOR[a.reason] ?? '#6b7280' }}
+        >
+          <span
+            className="yield-badge"
+            style={{ backgroundColor: REASON_COLOR[a.reason] ?? '#6b7280' }}
+          >
+            {a.reason}
+          </span>
+          <span className="yield-op mono">{a.opId}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export default YieldToasts;

--- a/extensions/command-node/hooks/useSovereignStream.ts
+++ b/extensions/command-node/hooks/useSovereignStream.ts
@@ -1,0 +1,177 @@
+'use client';
+
+/**
+ * useSovereignStream -- the React SSE client for the Command Node.
+ *
+ * Wraps the framework-agnostic `StreamConsumer` (lib/stream.ts, mirror
+ * of the vscode parser) into React state:
+ *   - a bounded in-memory ring buffer of typed event frames (cap from
+ *     config; default 500)
+ *   - a typed connection state
+ *   - the current Last-Event-ID (for operator visibility / debugging)
+ *
+ * Resilience: if the stream fails `maxFailuresBeforePoll` times in a
+ * row, the hook degrades to a poll fallback that periodically GETs
+ * /observability/tasks and synthesizes a `task_updated`-shaped frame so
+ * the UI keeps refreshing even when SSE is unreachable. When the stream
+ * recovers, polling stops.
+ *
+ * Read-only: this hook never POSTs and exposes no write surface.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { resolveConfig } from '../lib/config';
+import { ObservabilityClient } from '../lib/api';
+import { StreamConsumer, StreamState } from '../lib/stream';
+import { StreamEventFrame } from '../lib/types';
+
+export type ConnectionState = StreamState | 'polling';
+
+export interface UseSovereignStreamResult {
+  readonly events: readonly StreamEventFrame[];
+  readonly connectionState: ConnectionState;
+  readonly lastEventId: string | null;
+  /** Manually clear the in-memory event buffer (operator action). */
+  readonly clear: () => void;
+}
+
+export interface UseSovereignStreamOptions {
+  /** Optional op_id filter passed to the stream endpoint. */
+  readonly opIdFilter?: string;
+  /** Test injection -- defaults to the global fetch. */
+  readonly fetchFn?: typeof fetch;
+  /** Test injection -- defaults to resolveConfig(). */
+  readonly config?: ReturnType<typeof resolveConfig>;
+}
+
+/** Append a frame to a ring buffer of at most `cap` entries. Pure. */
+export function pushBounded(
+  buf: readonly StreamEventFrame[],
+  frame: StreamEventFrame,
+  cap: number,
+): StreamEventFrame[] {
+  const next = buf.length >= cap ? buf.slice(buf.length - cap + 1) : buf.slice();
+  next.push(frame);
+  return next;
+}
+
+export function useSovereignStream(
+  options: UseSovereignStreamOptions = {},
+): UseSovereignStreamResult {
+  const cfg = options.config ?? resolveConfig();
+  const fetchFn = options.fetchFn;
+
+  const [events, setEvents] = useState<readonly StreamEventFrame[]>([]);
+  const [connectionState, setConnectionState] =
+    useState<ConnectionState>('disconnected');
+  const [lastEventId, setLastEventId] = useState<string | null>(null);
+
+  const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const pollSeqRef = useRef(0);
+
+  const clear = useCallback(() => setEvents([]), []);
+
+  const ingest = useCallback(
+    (frame: StreamEventFrame) => {
+      setEvents((prev) => pushBounded(prev, frame, cfg.eventBufferCap));
+      setLastEventId(frame.event_id);
+    },
+    [cfg.eventBufferCap],
+  );
+
+  useEffect(() => {
+    let disposed = false;
+
+    const client = new ObservabilityClient({
+      endpoint: cfg.observabilityBase,
+      ...(fetchFn ? { fetchFn } : {}),
+    });
+
+    const stopPolling = (): void => {
+      if (pollTimerRef.current !== null) {
+        clearInterval(pollTimerRef.current);
+        pollTimerRef.current = null;
+      }
+    };
+
+    const startPolling = (): void => {
+      if (pollTimerRef.current !== null || disposed) {
+        return;
+      }
+      setConnectionState('polling');
+      const tick = async (): Promise<void> => {
+        try {
+          const list = await client.taskList();
+          if (disposed) {
+            return;
+          }
+          pollSeqRef.current += 1;
+          // Synthesize a poll-fallback frame so consumers keep updating.
+          ingest({
+            schema_version: '1.0',
+            event_id: `poll-${pollSeqRef.current}`,
+            event_type: 'task_updated',
+            op_id: '__poll__',
+            timestamp: new Date().toISOString(),
+            payload: { op_ids: list.op_ids, count: list.count, poll: true },
+          });
+        } catch {
+          // Keep polling; the next tick may succeed.
+        }
+      };
+      void tick();
+      pollTimerRef.current = setInterval(() => void tick(), cfg.pollIntervalMs);
+    };
+
+    const consumer = new StreamConsumer({
+      endpoint: cfg.observabilityBase,
+      autoReconnect: true,
+      reconnectMaxBackoffMs: cfg.reconnectMaxBackoffMs,
+      ...(fetchFn ? { fetchFn } : {}),
+      ...(options.opIdFilter ? { opIdFilter: options.opIdFilter } : {}),
+    });
+
+    consumer.onEvent((frame) => {
+      // Any live frame means SSE is healthy again -- drop the poll.
+      stopPolling();
+      ingest(frame);
+    });
+
+    consumer.onState((state) => {
+      if (disposed) {
+        return;
+      }
+      setConnectionState(state);
+      setLastEventId(consumer.getLastEventId());
+      if (state === 'connected') {
+        stopPolling();
+      }
+      // Degrade to polling once we've failed enough times in a row.
+      if (
+        (state === 'error' || state === 'reconnecting') &&
+        consumer.getConsecutiveFailures() >= cfg.maxFailuresBeforePoll
+      ) {
+        startPolling();
+      }
+    });
+
+    consumer.start();
+
+    return () => {
+      disposed = true;
+      stopPolling();
+      void consumer.stop();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [
+    cfg.observabilityBase,
+    cfg.reconnectMaxBackoffMs,
+    cfg.pollIntervalMs,
+    cfg.maxFailuresBeforePoll,
+    options.opIdFilter,
+    fetchFn,
+    ingest,
+  ]);
+
+  return { events, connectionState, lastEventId, clear };
+}

--- a/extensions/command-node/lib/api.ts
+++ b/extensions/command-node/lib/api.ts
@@ -1,0 +1,166 @@
+/**
+ * HTTP client for the JARVIS observability GET surface, used by the
+ * Command Node for initial state, reconnect resync, the poll fallback,
+ * and on-demand blast-radius loads.
+ *
+ * Thin wrapper around the browser's native fetch. Mirrors
+ * `extensions/vscode-jarvis/src/api/client.ts` -- read-only, never
+ * POSTs. Schema-version mismatches throw SchemaMismatchError.
+ */
+
+import {
+  BlastRadiusResponse,
+  HealthResponse,
+  SUPPORTED_SCHEMA_VERSION,
+  TaskDetailResponse,
+  TaskListResponse,
+  isSupportedSchema,
+} from './types';
+
+export class ObservabilityError extends Error {
+  public readonly status: number;
+  public readonly reasonCode: string;
+  public constructor(message: string, status: number, reasonCode = '') {
+    super(message);
+    this.name = 'ObservabilityError';
+    this.status = status;
+    this.reasonCode = reasonCode;
+  }
+}
+
+export class SchemaMismatchError extends Error {
+  public readonly expected: string;
+  public readonly received: string;
+  public constructor(received: string) {
+    super(
+      `schema_version mismatch: expected ${SUPPORTED_SCHEMA_VERSION}, got ${received}`,
+    );
+    this.name = 'SchemaMismatchError';
+    this.expected = SUPPORTED_SCHEMA_VERSION;
+    this.received = received;
+  }
+}
+
+const OP_ID_RE = /^[A-Za-z0-9_\-:.]{1,128}$/;
+
+export interface ClientOptions {
+  /** Base URL of the EventChannelServer, e.g. http://127.0.0.1:8765 */
+  readonly endpoint: string;
+  /** Optional fetch override (tests inject a stub). */
+  readonly fetchFn?: typeof fetch;
+  /** Abort signal for request cancellation. */
+  readonly signal?: AbortSignal;
+}
+
+type AnyEnvelope = { schema_version?: string };
+
+export class ObservabilityClient {
+  private readonly endpoint: string;
+  private readonly fetchFn: typeof fetch;
+  private readonly signal?: AbortSignal;
+
+  public constructor(opts: ClientOptions) {
+    this.endpoint = trimTrailingSlash(opts.endpoint);
+    this.fetchFn = opts.fetchFn ?? fetch;
+    this.signal = opts.signal;
+  }
+
+  public url(path: string): string {
+    return `${this.endpoint}${path.startsWith('/') ? path : `/${path}`}`;
+  }
+
+  public async health(): Promise<HealthResponse> {
+    return this.get<HealthResponse>('/observability/health');
+  }
+
+  public async taskList(): Promise<TaskListResponse> {
+    return this.get<TaskListResponse>('/observability/tasks');
+  }
+
+  public async taskDetail(opId: string): Promise<TaskDetailResponse> {
+    if (!OP_ID_RE.test(opId)) {
+      throw new ObservabilityError(
+        `malformed op_id: ${opId}`,
+        400,
+        'client.malformed_op_id',
+      );
+    }
+    return this.get<TaskDetailResponse>(
+      `/observability/tasks/${encodeURIComponent(opId)}`,
+    );
+  }
+
+  public async blastRadius(opId: string): Promise<BlastRadiusResponse> {
+    if (!OP_ID_RE.test(opId)) {
+      throw new ObservabilityError(
+        `malformed op_id: ${opId}`,
+        400,
+        'client.malformed_op_id',
+      );
+    }
+    return this.get<BlastRadiusResponse>(
+      `/observability/blast-radius/${encodeURIComponent(opId)}`,
+    );
+  }
+
+  private async get<T extends AnyEnvelope>(path: string): Promise<T> {
+    const url = this.url(path);
+    let response: Response;
+    try {
+      response = await this.fetchFn(url, {
+        method: 'GET',
+        headers: { Accept: 'application/json' },
+        signal: this.signal,
+        cache: 'no-store',
+      });
+    } catch (exc) {
+      const msg = exc instanceof Error ? exc.message : String(exc);
+      throw new ObservabilityError(
+        `fetch failed: ${msg}`,
+        -1,
+        'client.network_error',
+      );
+    }
+
+    if (!response.ok) {
+      const code = await extractReasonCode(response);
+      throw new ObservabilityError(
+        `${path} returned ${response.status}`,
+        response.status,
+        code,
+      );
+    }
+
+    let body: unknown;
+    try {
+      body = await response.json();
+    } catch {
+      throw new ObservabilityError(
+        `JSON parse failed for ${path}`,
+        response.status,
+        'client.invalid_json',
+      );
+    }
+
+    if (!isSupportedSchema(body as AnyEnvelope)) {
+      throw new SchemaMismatchError(
+        (body as AnyEnvelope)?.schema_version ?? '(missing)',
+      );
+    }
+
+    return body as T;
+  }
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+async function extractReasonCode(response: Response): Promise<string> {
+  try {
+    const body = (await response.json()) as { reason_code?: string };
+    return body.reason_code ?? '';
+  } catch {
+    return '';
+  }
+}

--- a/extensions/command-node/lib/blastGraph.ts
+++ b/extensions/command-node/lib/blastGraph.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure graph-building for the blast-radius visualization. Separated
+ * from the React component so the node/edge construction + repo color
+ * coding is unit-testable without rendering React Flow.
+ */
+
+import type { Edge, Node } from 'reactflow';
+import { AffectedNode, BlastRadiusResponse } from './types';
+import { repoStyle } from './theme';
+
+export const CENTER_NODE_ID = '__center__';
+
+/** Stable id for an affected node (repo + file + name are unique). */
+export function affectedNodeId(n: AffectedNode): string {
+  return `${n.repo}::${n.file}::${n.name}`;
+}
+
+export interface BlastFlowGraph {
+  readonly nodes: Node[];
+  readonly edges: Edge[];
+}
+
+interface BuildOptions {
+  /** Radius of the dependent ring(s) in px. */
+  readonly directRadius?: number;
+  readonly transitiveRadius?: number;
+}
+
+/**
+ * Build a radial graph: the mutated symbol at the center, a ring of
+ * directly-affected dependents, and an outer ring of transitively-
+ * affected dependents. Each node is colored by its repo so a cross-
+ * boundary blast (e.g. a reactor mutation with prime/jarvis dependents)
+ * is visually obvious.
+ */
+export function buildBlastGraph(
+  report: BlastRadiusResponse,
+  opts: BuildOptions = {},
+): BlastFlowGraph {
+  const directRadius = opts.directRadius ?? 220;
+  const transitiveRadius = opts.transitiveRadius ?? 420;
+
+  const nodes: Node[] = [];
+  const edges: Edge[] = [];
+
+  // Center: the mutated op/symbol.
+  nodes.push({
+    id: CENTER_NODE_ID,
+    position: { x: 0, y: 0 },
+    data: {
+      label: `${report.op_id}\n(mutated)`,
+      kind: 'center',
+    },
+    style: {
+      background: '#111827',
+      color: '#ffffff',
+      border: '2px solid #f9fafb',
+      borderRadius: 10,
+      fontSize: 12,
+      width: 150,
+      whiteSpace: 'pre-line' as const,
+    },
+  });
+
+  const place = (
+    list: readonly AffectedNode[],
+    radius: number,
+    edgeStyle: 'direct' | 'transitive',
+  ): void => {
+    const n = list.length;
+    list.forEach((node, i) => {
+      const angle = (2 * Math.PI * i) / Math.max(n, 1);
+      const id = affectedNodeId(node);
+      const style = repoStyle(node.repo);
+      nodes.push({
+        id,
+        position: {
+          x: Math.cos(angle) * radius,
+          y: Math.sin(angle) * radius,
+        },
+        data: {
+          label: `${node.name}\n${node.repo}/${node.file}`,
+          affected: node,
+          kind: edgeStyle,
+        },
+        style: {
+          background: style.color,
+          color: '#ffffff',
+          border: `2px solid ${style.border}`,
+          borderRadius: 8,
+          fontSize: 10,
+          width: 140,
+          whiteSpace: 'pre-line' as const,
+        },
+      });
+      edges.push({
+        id: `e-${edgeStyle}-${id}`,
+        source: CENTER_NODE_ID,
+        target: id,
+        animated: edgeStyle === 'direct',
+        style: {
+          stroke: style.border,
+          strokeDasharray: edgeStyle === 'transitive' ? '4 3' : undefined,
+        },
+      });
+    });
+  };
+
+  place(report.directly_affected, directRadius, 'direct');
+  place(report.transitively_affected, transitiveRadius, 'transitive');
+
+  return { nodes, edges };
+}
+
+/** Count distinct repos present in a blast report (cross-boundary
+ * detection: >1 means the blast crosses a Trinity boundary). */
+export function distinctRepos(report: BlastRadiusResponse): string[] {
+  const set = new Set<string>();
+  for (const n of [
+    ...report.directly_affected,
+    ...report.transitively_affected,
+  ]) {
+    set.add(n.repo);
+  }
+  return Array.from(set);
+}

--- a/extensions/command-node/lib/config.ts
+++ b/extensions/command-node/lib/config.ts
@@ -1,0 +1,59 @@
+/**
+ * Runtime config resolution for the Command Node.
+ *
+ * NO hardcoded localhost in source: the backend base URL comes from
+ * NEXT_PUBLIC_OBSERVABILITY_BASE. We fall back to a loopback default
+ * built from NEXT_PUBLIC_OBSERVABILITY_PORT (also env-driven) only so a
+ * fresh `npm run dev` works out of the box -- but both are overridable.
+ *
+ * All caps (event buffer size, reconnect backoff ceiling, poll
+ * interval, max consecutive failures before poll fallback) are
+ * env-tunable via NEXT_PUBLIC_* so nothing operational is baked in.
+ */
+
+const DEFAULT_PORT = '8765';
+
+function envStr(key: string, fallback: string): string {
+  const raw = process.env[key];
+  return raw !== undefined && raw !== '' ? raw : fallback;
+}
+
+function envInt(key: string, fallback: number): number {
+  const raw = process.env[key];
+  if (raw === undefined || raw === '') {
+    return fallback;
+  }
+  const n = Number.parseInt(raw, 10);
+  return Number.isFinite(n) && n > 0 ? n : fallback;
+}
+
+export interface CommandNodeConfig {
+  /** Base URL of the EventChannelServer, e.g. http://127.0.0.1:8765 */
+  readonly observabilityBase: string;
+  /** Max in-memory SSE event frames to retain (ring buffer). */
+  readonly eventBufferCap: number;
+  /** Ceiling for the exponential reconnect backoff (ms). */
+  readonly reconnectMaxBackoffMs: number;
+  /** Poll fallback interval (ms) once SSE is deemed unreliable. */
+  readonly pollIntervalMs: number;
+  /** Consecutive SSE failures before degrading to poll fallback. */
+  readonly maxFailuresBeforePoll: number;
+}
+
+export function resolveConfig(): CommandNodeConfig {
+  const port = envStr('NEXT_PUBLIC_OBSERVABILITY_PORT', DEFAULT_PORT);
+  const base = envStr(
+    'NEXT_PUBLIC_OBSERVABILITY_BASE',
+    `http://127.0.0.1:${port}`,
+  );
+  return {
+    observabilityBase: base.endsWith('/') ? base.slice(0, -1) : base,
+    eventBufferCap: envInt('NEXT_PUBLIC_EVENT_BUFFER_CAP', 500),
+    reconnectMaxBackoffMs: envInt(
+      'NEXT_PUBLIC_RECONNECT_MAX_BACKOFF_MS',
+      15000,
+    ),
+    pollIntervalMs: envInt('NEXT_PUBLIC_POLL_INTERVAL_MS', 5000),
+    maxFailuresBeforePoll: envInt('NEXT_PUBLIC_MAX_FAILURES_BEFORE_POLL', 5),
+  };
+}

--- a/extensions/command-node/lib/projection.ts
+++ b/extensions/command-node/lib/projection.ts
@@ -1,0 +1,152 @@
+/**
+ * Pure projections from the raw SSE event buffer into the view models
+ * the dashboard components render. Kept pure (no React) so they are
+ * trivially testable and reusable.
+ */
+
+import {
+  CrossRepoElevationPayload,
+  DagNodeState,
+  DagNodeUpdatedPayload,
+  FsmPhaseChangedPayload,
+  OuroborosPhase,
+  RiskTier,
+  StreamEventFrame,
+  SovereignYieldPayload,
+  isCrossRepoElevationEvent,
+  isDagNodeUpdatedEvent,
+  isFsmPhaseEvent,
+  isSovereignYieldEvent,
+  isTaskEvent,
+} from './types';
+
+export interface OpFsmState {
+  readonly opId: string;
+  readonly phase: OuroborosPhase;
+  readonly route?: string;
+  readonly riskTier?: RiskTier;
+  readonly provider?: string;
+  readonly updatedAt: string;
+}
+
+export interface DagNodeView {
+  readonly nodeId: string;
+  readonly opId: string;
+  readonly state: DagNodeState;
+}
+
+export interface ElevationEntry extends CrossRepoElevationPayload {
+  readonly opId: string;
+  readonly receivedAt: string;
+}
+
+export interface YieldAlert {
+  readonly opId: string;
+  readonly reason: SovereignYieldPayload['reason'];
+  readonly at: string;
+  readonly key: string;
+}
+
+/** Latest FSM phase per active op, ordered by most-recent update. */
+export function projectFsmStates(
+  events: readonly StreamEventFrame[],
+): OpFsmState[] {
+  const byOp = new Map<string, OpFsmState>();
+  for (const frame of events) {
+    if (isFsmPhaseEvent(frame)) {
+      const p = frame.payload as FsmPhaseChangedPayload;
+      byOp.set(frame.op_id, {
+        opId: frame.op_id,
+        phase: p.phase,
+        ...(p.route ? { route: p.route } : {}),
+        ...(p.risk_tier ? { riskTier: p.risk_tier } : {}),
+        ...(p.provider ? { provider: p.provider } : {}),
+        updatedAt: frame.timestamp,
+      });
+    } else if (isTaskEvent(frame) && frame.event_type === 'task_completed') {
+      // Completed ops drop off the live ribbon list.
+      byOp.delete(frame.op_id);
+    }
+  }
+  return Array.from(byOp.values());
+}
+
+/** Latest state per DAG node, fed by dag_node_updated + task_* events. */
+export function projectDagNodes(
+  events: readonly StreamEventFrame[],
+): DagNodeView[] {
+  const byNode = new Map<string, DagNodeView>();
+  for (const frame of events) {
+    if (isDagNodeUpdatedEvent(frame)) {
+      const p = frame.payload as DagNodeUpdatedPayload;
+      byNode.set(p.node_id, {
+        nodeId: p.node_id,
+        opId: frame.op_id,
+        state: p.state,
+      });
+    } else if (isTaskEvent(frame)) {
+      // Fall back to the op_id as a coarse node when no DAG event has
+      // been seen for it yet, so the canvas isn't empty pre-DAG.
+      const key = `op:${frame.op_id}`;
+      const state = taskEventToState(frame.event_type);
+      if (state !== null && !byNode.has(frame.op_id)) {
+        byNode.set(key, { nodeId: key, opId: frame.op_id, state });
+      }
+    }
+  }
+  return Array.from(byNode.values());
+}
+
+function taskEventToState(eventType: string): DagNodeState | null {
+  switch (eventType) {
+    case 'task_created':
+      return 'pending';
+    case 'task_started':
+    case 'task_updated':
+      return 'running';
+    case 'task_completed':
+      return 'complete';
+    case 'task_cancelled':
+      return 'fractured';
+    default:
+      return null;
+  }
+}
+
+/** Pending cross-repo elevations, newest first, de-duped by pr_id. */
+export function projectElevationQueue(
+  events: readonly StreamEventFrame[],
+): ElevationEntry[] {
+  const byPr = new Map<string, ElevationEntry>();
+  for (const frame of events) {
+    if (isCrossRepoElevationEvent(frame)) {
+      const p = frame.payload as CrossRepoElevationPayload;
+      byPr.set(p.pr_id, {
+        ...p,
+        opId: frame.op_id,
+        receivedAt: frame.timestamp,
+      });
+    }
+  }
+  return Array.from(byPr.values()).reverse();
+}
+
+/** The most recent sovereign_yield events, newest first (capped). */
+export function projectYieldAlerts(
+  events: readonly StreamEventFrame[],
+  cap = 5,
+): YieldAlert[] {
+  const out: YieldAlert[] = [];
+  for (const frame of events) {
+    if (isSovereignYieldEvent(frame)) {
+      const p = frame.payload as SovereignYieldPayload;
+      out.push({
+        opId: frame.op_id,
+        reason: p.reason,
+        at: frame.timestamp,
+        key: frame.event_id,
+      });
+    }
+  }
+  return out.reverse().slice(0, cap);
+}

--- a/extensions/command-node/lib/stream.ts
+++ b/extensions/command-node/lib/stream.ts
@@ -1,0 +1,345 @@
+/**
+ * SSE parser + reconnect loop for the /observability/stream endpoint.
+ *
+ * Mirrors `extensions/vscode-jarvis/src/api/stream.ts` -- the same
+ * proven native-fetch ReadableStream parser + exponential-backoff +
+ * full-jitter reconnect + Last-Event-ID replay. We deliberately do NOT
+ * use the bare browser EventSource: it can't set the Last-Event-ID
+ * header for server-side ring-buffer replay, can't carry custom
+ * headers, and gives weaker reconnect control.
+ *
+ * Wire format (one frame, blank-line terminated):
+ *     id: <event_id>
+ *     event: <event_type>
+ *     data: <json>
+ *     <blank line>
+ */
+
+import { StreamEventFrame, isSupportedSchema } from './types';
+
+export interface StreamOptions {
+  readonly endpoint: string;
+  readonly opIdFilter?: string;
+  readonly autoReconnect: boolean;
+  readonly reconnectMaxBackoffMs: number;
+  readonly fetchFn?: typeof fetch;
+  readonly logger?: (msg: string) => void;
+  /** Jitter [0..1) -- inject in tests for determinism. */
+  readonly jitterFn?: () => number;
+  /** Sleep override for tests. Takes ms, returns promise. */
+  readonly sleepFn?: (ms: number, signal: AbortSignal) => Promise<void>;
+}
+
+export type StreamListener = (frame: StreamEventFrame) => void | Promise<void>;
+export type StreamStateListener = (state: StreamState) => void;
+
+export type StreamState =
+  | 'disconnected'
+  | 'connecting'
+  | 'connected'
+  | 'reconnecting'
+  | 'closed'
+  | 'error';
+
+const BASE_BACKOFF_MS = 500;
+
+export class StreamConsumer {
+  private readonly opts: StreamOptions;
+  private readonly listeners: Set<StreamListener> = new Set();
+  private readonly stateListeners: Set<StreamStateListener> = new Set();
+  private controller: AbortController | null = null;
+  private runningLoop: Promise<void> | null = null;
+  private lastEventId: string | null = null;
+  private state: StreamState = 'disconnected';
+  private consecutiveFailures = 0;
+  /** Public for test-only introspection -- do NOT rely on this. */
+  public _testInternal_lastBackoff = 0;
+
+  public constructor(opts: StreamOptions) {
+    this.opts = opts;
+  }
+
+  public onEvent(listener: StreamListener): () => void {
+    this.listeners.add(listener);
+    return () => this.listeners.delete(listener);
+  }
+
+  public onState(listener: StreamStateListener): () => void {
+    this.stateListeners.add(listener);
+    return () => this.stateListeners.delete(listener);
+  }
+
+  public getState(): StreamState {
+    return this.state;
+  }
+
+  public getConsecutiveFailures(): number {
+    return this.consecutiveFailures;
+  }
+
+  public getLastEventId(): string | null {
+    return this.lastEventId;
+  }
+
+  public isRunning(): boolean {
+    return this.runningLoop !== null;
+  }
+
+  public start(): void {
+    if (this.runningLoop !== null) {
+      return;
+    }
+    this.controller = new AbortController();
+    this.runningLoop = this.runLoop(this.controller.signal).finally(() => {
+      this.runningLoop = null;
+      this.transition(this.state === 'closed' ? 'closed' : 'disconnected');
+    });
+  }
+
+  public async stop(): Promise<void> {
+    this.transition('closed');
+    if (this.controller !== null) {
+      this.controller.abort();
+      this.controller = null;
+    }
+    if (this.runningLoop !== null) {
+      try {
+        await this.runningLoop;
+      } catch {
+        // swallowed -- loop-exits are expected.
+      }
+    }
+  }
+
+  private transition(next: StreamState): void {
+    if (this.state === next) {
+      return;
+    }
+    this.state = next;
+    for (const l of this.stateListeners) {
+      try {
+        l(next);
+      } catch (exc) {
+        this.log(
+          `[stream] state-listener threw: ${
+            exc instanceof Error ? exc.message : String(exc)
+          }`,
+        );
+      }
+    }
+  }
+
+  private log(msg: string): void {
+    if (this.opts.logger !== undefined) {
+      this.opts.logger(msg);
+    }
+  }
+
+  private async runLoop(signal: AbortSignal): Promise<void> {
+    while (!signal.aborted) {
+      try {
+        this.transition(
+          this.consecutiveFailures === 0 ? 'connecting' : 'reconnecting',
+        );
+        await this.connectAndStream(signal);
+        this.consecutiveFailures = 0;
+      } catch (exc) {
+        if (signal.aborted) {
+          return;
+        }
+        this.consecutiveFailures += 1;
+        const msg = exc instanceof Error ? exc.message : String(exc);
+        this.log(
+          `[stream] connection dropped: ${msg} (failures=${this.consecutiveFailures})`,
+        );
+        this.transition('error');
+        if (!this.opts.autoReconnect) {
+          return;
+        }
+      }
+      if (!this.opts.autoReconnect || signal.aborted) {
+        return;
+      }
+      const backoff = this.computeBackoff();
+      this._testInternal_lastBackoff = backoff;
+      await (this.opts.sleepFn ?? defaultSleep)(backoff, signal);
+    }
+  }
+
+  private computeBackoff(): number {
+    const raw = BASE_BACKOFF_MS * 2 ** (this.consecutiveFailures - 1);
+    const capped = Math.min(raw, this.opts.reconnectMaxBackoffMs);
+    const jitter = (this.opts.jitterFn ?? Math.random)();
+    // full-jitter: [0, capped)
+    return Math.floor(capped * jitter);
+  }
+
+  private async connectAndStream(signal: AbortSignal): Promise<void> {
+    const url = `${trimTrailingSlash(this.opts.endpoint)}/observability/stream${
+      this.opts.opIdFilter !== undefined && this.opts.opIdFilter !== ''
+        ? `?op_id=${encodeURIComponent(this.opts.opIdFilter)}`
+        : ''
+    }`;
+    const headers: Record<string, string> = {
+      Accept: 'text/event-stream',
+      'Cache-Control': 'no-store',
+    };
+    if (this.lastEventId !== null) {
+      headers['Last-Event-ID'] = this.lastEventId;
+    }
+    const fetchFn = this.opts.fetchFn ?? fetch;
+    const response = await fetchFn(url, {
+      method: 'GET',
+      headers,
+      signal,
+    });
+    if (!response.ok) {
+      await safeDiscardBody(response);
+      throw new Error(`stream returned ${response.status}`);
+    }
+    if (response.body === null) {
+      throw new Error('stream response has no body');
+    }
+    this.transition('connected');
+    await this.consumeBody(response.body, signal);
+  }
+
+  private async consumeBody(
+    body: ReadableStream<Uint8Array>,
+    signal: AbortSignal,
+  ): Promise<void> {
+    const reader = body.getReader();
+    const decoder = new TextDecoder('utf-8');
+    let buffer = '';
+    const onAbort = (): void => {
+      reader.cancel().catch(() => {
+        /* cancel may race with natural close -- swallow */
+      });
+    };
+    if (signal.aborted) {
+      onAbort();
+    } else {
+      signal.addEventListener('abort', onAbort, { once: true });
+    }
+    try {
+      for (;;) {
+        if (signal.aborted) {
+          return;
+        }
+        const { value, done } = await reader.read();
+        if (done) {
+          return;
+        }
+        buffer += decoder.decode(value, { stream: true });
+        let eventEnd = buffer.indexOf('\n\n');
+        while (eventEnd !== -1) {
+          const rawEvent = buffer.slice(0, eventEnd);
+          buffer = buffer.slice(eventEnd + 2);
+          await this.parseAndDispatch(rawEvent);
+          eventEnd = buffer.indexOf('\n\n');
+        }
+      }
+    } finally {
+      signal.removeEventListener('abort', onAbort);
+      try {
+        reader.releaseLock();
+      } catch {
+        // releaseLock throws when the reader is already closed -- OK.
+      }
+    }
+  }
+
+  private async parseAndDispatch(rawEvent: string): Promise<void> {
+    // Comment lines start with ":" and are ignored.
+    const lines = rawEvent
+      .split('\n')
+      .filter((l) => l !== '' && !l.startsWith(':'));
+    if (lines.length === 0) {
+      return;
+    }
+    let id: string | null = null;
+    let eventType: string | null = null;
+    const dataParts: string[] = [];
+    for (const line of lines) {
+      const colonIdx = line.indexOf(':');
+      if (colonIdx === -1) {
+        continue;
+      }
+      const field = line.slice(0, colonIdx).trim();
+      // Strip exactly one leading space after the colon per spec.
+      const value = line.slice(colonIdx + 1).replace(/^ /, '');
+      if (field === 'id') {
+        id = value;
+      } else if (field === 'event') {
+        eventType = value;
+      } else if (field === 'data') {
+        dataParts.push(value);
+      }
+    }
+    if (id === null || eventType === null || dataParts.length === 0) {
+      this.log('[stream] incomplete frame, dropping');
+      return;
+    }
+    const dataText = dataParts.join('\n');
+    let parsed: StreamEventFrame;
+    try {
+      parsed = JSON.parse(dataText) as StreamEventFrame;
+    } catch {
+      this.log(`[stream] invalid JSON payload for event ${id}`);
+      return;
+    }
+    if (!isSupportedSchema(parsed)) {
+      this.log(
+        `[stream] schema mismatch -- expected 1.0, got ${parsed.schema_version}`,
+      );
+      return;
+    }
+    // Persist the last event_id BEFORE dispatch so a listener exception
+    // doesn't lose the ack point for replay.
+    this.lastEventId = id;
+    for (const l of this.listeners) {
+      try {
+        await l(parsed);
+      } catch (exc) {
+        this.log(
+          `[stream] listener threw for ${parsed.event_type}: ${
+            exc instanceof Error ? exc.message : String(exc)
+          }`,
+        );
+      }
+    }
+  }
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.endsWith('/') ? url.slice(0, -1) : url;
+}
+
+async function safeDiscardBody(response: Response): Promise<void> {
+  try {
+    if (response.body !== null) {
+      await response.body.cancel();
+    }
+  } catch {
+    /* already closed or not cancelable -- fine */
+  }
+}
+
+function defaultSleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal.aborted) {
+      resolve();
+      return;
+    }
+    const timer = setTimeout(() => {
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    }, ms);
+    const onAbort = (): void => {
+      clearTimeout(timer);
+      signal.removeEventListener('abort', onAbort);
+      resolve();
+    };
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}

--- a/extensions/command-node/lib/theme.ts
+++ b/extensions/command-node/lib/theme.ts
@@ -1,0 +1,44 @@
+/**
+ * Visual theming constants shared across components.
+ *
+ * The repo color map is load-bearing for the blast-radius graph: a
+ * cross-boundary blast must be visually obvious. Body/jarvis=blue,
+ * Mind/prime=amber, Nerves/reactor=violet. Unknown repos render
+ * neutral gray (open vocabulary -- never crash on a new repo).
+ */
+
+import { DagNodeState, TrinityRepo } from './types';
+
+export interface RepoStyle {
+  readonly label: string;
+  readonly color: string;
+  readonly border: string;
+}
+
+const REPO_STYLES: Record<string, RepoStyle> = {
+  jarvis: { label: 'Body', color: '#2563eb', border: '#3b82f6' },
+  prime: { label: 'Mind', color: '#d97706', border: '#f59e0b' },
+  reactor: { label: 'Nerves', color: '#7c3aed', border: '#8b5cf6' },
+};
+
+const NEUTRAL: RepoStyle = {
+  label: 'Unknown',
+  color: '#6b7280',
+  border: '#9ca3af',
+};
+
+export function repoStyle(repo: TrinityRepo): RepoStyle {
+  return REPO_STYLES[repo] ?? NEUTRAL;
+}
+
+export const DAG_STATE_COLORS: Record<string, string> = {
+  pending: '#6b7280',
+  running: '#2563eb',
+  applied: '#0891b2',
+  fractured: '#dc2626',
+  complete: '#16a34a',
+};
+
+export function dagStateColor(state: DagNodeState): string {
+  return DAG_STATE_COLORS[state] ?? '#6b7280';
+}

--- a/extensions/command-node/lib/types.ts
+++ b/extensions/command-node/lib/types.ts
@@ -1,0 +1,274 @@
+/**
+ * Wire types for the Sovereign Command Node (Phase 1, read-only).
+ *
+ * These shapes mirror the Python server's schema_version "1.0"
+ * payloads in `backend/core/ouroboros/governance/ide_observability.py`
+ * (Slice 1 GETs) and `ide_observability_stream.py` (Slice 2 SSE),
+ * extended with the Command-Node-specific Task A event types
+ * (fsm_phase_changed / cross_repo_elevation_pending / sovereign_yield /
+ * dag_node_updated) and the blast-radius GET.
+ *
+ * Authority invariant: these are READ-ONLY shapes. The dashboard never
+ * constructs a payload and POSTs it back. Phase 1 is a consumer only.
+ *
+ * Mirrors `extensions/vscode-jarvis/src/api/types.ts` -- kept in sync
+ * by hand (the two extensions consume the same backend surface).
+ */
+
+export const SUPPORTED_SCHEMA_VERSION = '1.0';
+
+/** Shared envelope for every JSON response from the server. */
+export interface Envelope {
+  readonly schema_version: string;
+}
+
+// --- GET responses --------------------------------------------------------
+
+export interface HealthResponse extends Envelope {
+  readonly enabled: boolean;
+  readonly api_version: string;
+  readonly surface: string;
+  readonly now_mono: number;
+}
+
+export interface TaskListResponse extends Envelope {
+  readonly op_ids: readonly string[];
+  readonly count: number;
+}
+
+export type TaskState =
+  | 'pending'
+  | 'in_progress'
+  | 'completed'
+  | 'cancelled';
+
+export interface TaskProjection {
+  readonly task_id: string;
+  readonly state: TaskState;
+  readonly title: string;
+  readonly body: string;
+  readonly sequence: number;
+  readonly cancel_reason: string;
+}
+
+export interface TaskDetailResponse extends Envelope {
+  readonly op_id: string;
+  readonly closed: boolean;
+  readonly active_task_id: string | null;
+  readonly tasks: readonly TaskProjection[];
+  readonly board_size: number;
+}
+
+export interface ErrorResponse extends Envelope {
+  readonly error: true;
+  readonly reason_code: string;
+}
+
+// --- Blast radius (GET /observability/blast-radius/{op_id}) ---------------
+
+/** One of the three Trinity repos. Open vocabulary: render unknowns
+ * with a neutral color rather than crashing. */
+export type TrinityRepo = 'jarvis' | 'prime' | 'reactor' | string;
+
+export interface AffectedNode {
+  readonly repo: TrinityRepo;
+  readonly file: string;
+  readonly name: string;
+  readonly type: string;
+}
+
+export type BlastRiskLevel =
+  | 'low'
+  | 'moderate'
+  | 'high'
+  | 'critical'
+  | string;
+
+export interface BlastRadiusResponse extends Envelope {
+  readonly op_id: string;
+  readonly directly_affected: readonly AffectedNode[];
+  readonly transitively_affected: readonly AffectedNode[];
+  readonly total_affected: number;
+  readonly risk_level: BlastRiskLevel;
+}
+
+// --- SSE event frames -----------------------------------------------------
+
+export type TaskEventType =
+  | 'task_created'
+  | 'task_started'
+  | 'task_updated'
+  | 'task_completed'
+  | 'task_cancelled'
+  | 'board_closed';
+
+export type ControlEventType =
+  | 'heartbeat'
+  | 'stream_lag'
+  | 'replay_start'
+  | 'replay_end'
+  | 'posture_changed';
+
+// Task A command-node event types.
+export type SovereignEventType =
+  | 'fsm_phase_changed'
+  | 'cross_repo_elevation_pending'
+  | 'sovereign_yield'
+  | 'dag_node_updated';
+
+export type StreamEventType =
+  | TaskEventType
+  | ControlEventType
+  | SovereignEventType;
+
+/** The 11-phase Ouroboros governance pipeline. */
+export const OUROBOROS_PHASES = [
+  'CLASSIFY',
+  'ROUTE',
+  'CONTEXT_EXPANSION',
+  'PLAN',
+  'GENERATE',
+  'VALIDATE',
+  'GATE',
+  'APPROVE',
+  'APPLY',
+  'VERIFY',
+  'COMPLETE',
+] as const;
+
+export type OuroborosPhase = (typeof OUROBOROS_PHASES)[number] | string;
+
+export type RiskTier =
+  | 'safe_auto'
+  | 'notify_apply'
+  | 'approval_required'
+  | 'critical_elevation'
+  | 'blocked'
+  | string;
+
+export interface FsmPhaseChangedPayload {
+  readonly phase: OuroborosPhase;
+  readonly route?: string;
+  readonly risk_tier?: RiskTier;
+  readonly provider?: string;
+}
+
+export interface CrossRepoElevationPayload {
+  readonly pr_id: string;
+  readonly target_repo: TrinityRepo;
+  readonly blast_radius_summary: string;
+}
+
+export type SovereignYieldReason =
+  | 'FRACTURE'
+  | 'QUARANTINE'
+  | 'RECOVERED'
+  | string;
+
+export interface SovereignYieldPayload {
+  readonly reason: SovereignYieldReason;
+}
+
+export type DagNodeState =
+  | 'pending'
+  | 'running'
+  | 'applied'
+  | 'fractured'
+  | 'complete'
+  | string;
+
+export interface DagNodeUpdatedPayload {
+  readonly node_id: string;
+  readonly state: DagNodeState;
+}
+
+/** Discriminated-union frame matching the server's StreamEvent shape. */
+export interface StreamEventFrame extends Envelope {
+  readonly event_id: string;
+  readonly event_type: StreamEventType;
+  readonly op_id: string;
+  readonly timestamp: string;
+  readonly payload: Record<string, unknown>;
+}
+
+// --- Helpers --------------------------------------------------------------
+
+/**
+ * Narrow the envelope's schema_version against the supported version.
+ * Returns false for payloads we cannot safely render -- consumers
+ * should fall back to a conservative display.
+ */
+export function isSupportedSchema(
+  env: { schema_version?: string } | null | undefined,
+): boolean {
+  return (
+    env !== null &&
+    env !== undefined &&
+    env.schema_version === SUPPORTED_SCHEMA_VERSION
+  );
+}
+
+const TASK_EVENT_TYPES: ReadonlySet<TaskEventType> = new Set([
+  'task_created',
+  'task_started',
+  'task_updated',
+  'task_completed',
+  'task_cancelled',
+  'board_closed',
+]);
+
+export function isTaskEvent(
+  frame: StreamEventFrame,
+): frame is StreamEventFrame & { event_type: TaskEventType } {
+  return TASK_EVENT_TYPES.has(frame.event_type as TaskEventType);
+}
+
+const CONTROL_EVENT_TYPES: ReadonlySet<ControlEventType> = new Set([
+  'heartbeat',
+  'stream_lag',
+  'replay_start',
+  'replay_end',
+  'posture_changed',
+]);
+
+export function isControlEvent(
+  frame: StreamEventFrame,
+): frame is StreamEventFrame & { event_type: ControlEventType } {
+  return CONTROL_EVENT_TYPES.has(frame.event_type as ControlEventType);
+}
+
+export function isFsmPhaseEvent(
+  frame: StreamEventFrame,
+): frame is StreamEventFrame & {
+  event_type: 'fsm_phase_changed';
+  payload: FsmPhaseChangedPayload;
+} {
+  return frame.event_type === 'fsm_phase_changed';
+}
+
+export function isCrossRepoElevationEvent(
+  frame: StreamEventFrame,
+): frame is StreamEventFrame & {
+  event_type: 'cross_repo_elevation_pending';
+  payload: CrossRepoElevationPayload;
+} {
+  return frame.event_type === 'cross_repo_elevation_pending';
+}
+
+export function isSovereignYieldEvent(
+  frame: StreamEventFrame,
+): frame is StreamEventFrame & {
+  event_type: 'sovereign_yield';
+  payload: SovereignYieldPayload;
+} {
+  return frame.event_type === 'sovereign_yield';
+}
+
+export function isDagNodeUpdatedEvent(
+  frame: StreamEventFrame,
+): frame is StreamEventFrame & {
+  event_type: 'dag_node_updated';
+  payload: DagNodeUpdatedPayload;
+} {
+  return frame.event_type === 'dag_node_updated';
+}

--- a/extensions/command-node/next-env.d.ts
+++ b/extensions/command-node/next-env.d.ts
@@ -1,0 +1,5 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+
+// NOTE: This file should not be edited.
+// See https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/extensions/command-node/next.config.js
+++ b/extensions/command-node/next.config.js
@@ -1,0 +1,20 @@
+/**
+ * Next.js config for the Sovereign Command Node (Phase 1, read-only).
+ *
+ * The dashboard is a pure client-side consumer of the existing JARVIS
+ * /observability surface. No server-side data fetching, no API routes
+ * here -- the backend URL is resolved at runtime from the
+ * NEXT_PUBLIC_OBSERVABILITY_BASE env var (see lib/config.ts). There is
+ * NO hardcoded localhost in source.
+ *
+ * @type {import('next').NextConfig}
+ */
+const nextConfig = {
+  reactStrictMode: true,
+  // The observability backend is a separate process; we never proxy or
+  // rewrite to it from Next -- the browser talks to it directly via the
+  // env-configured base URL. CORS on the backend (loopback allowlist)
+  // governs access.
+};
+
+module.exports = nextConfig;

--- a/extensions/command-node/package-lock.json
+++ b/extensions/command-node/package-lock.json
@@ -1,0 +1,4088 @@
+{
+  "name": "jarvis-command-node",
+  "version": "0.1.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "jarvis-command-node",
+      "version": "0.1.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "next": "^14.2.5",
+        "react": "^18.3.1",
+        "react-dom": "^18.3.1",
+        "reactflow": "^11.11.4"
+      },
+      "devDependencies": {
+        "@testing-library/jest-dom": "^6.4.8",
+        "@testing-library/react": "^16.0.0",
+        "@types/node": "^20.14.12",
+        "@types/react": "^18.3.3",
+        "@types/react-dom": "^18.3.0",
+        "@vitejs/plugin-react": "^4.3.1",
+        "jsdom": "^24.1.1",
+        "typescript": "^5.5.4",
+        "vitest": "^2.0.5"
+      },
+      "engines": {
+        "node": ">=18.0.0"
+      }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/@babel/code-frame": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "js-tokens": "^4.0.0",
+        "picocolors": "^1.1.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/compat-data": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/core": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/remapping": "^2.3.5",
+        "convert-source-map": "^2.0.0",
+        "debug": "^4.1.0",
+        "gensync": "^1.0.0-beta.2",
+        "json5": "^2.2.3",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/babel"
+      }
+    },
+    "node_modules/@babel/generator": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "@jridgewell/gen-mapping": "^0.3.12",
+        "@jridgewell/trace-mapping": "^0.3.28",
+        "jsesc": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-compilation-targets": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
+        "browserslist": "^4.24.0",
+        "lru-cache": "^5.1.1",
+        "semver": "^6.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-globals": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-imports": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-module-transforms": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0"
+      }
+    },
+    "node_modules/@babel/helper-plugin-utils": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.29.7.tgz",
+      "integrity": "sha512-G7sHYigPY17oO5SYWnfD/0MTBwVR781S/JI643e/JhUYgVgWE/61SoW3NH9KWUKyKq5LVh3npif99Wkt6j86Jw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-option": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helpers": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-self": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-self/-/plugin-transform-react-jsx-self-7.29.7.tgz",
+      "integrity": "sha512-TL0hMc9xzy86VD31nUiwzd5otRAcyEPcsegCxolO0PvcXuH1v0kECe/UIznYFihpkvU5wg/jk4v0TTEFfm53fw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/plugin-transform-react-jsx-source": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx-source/-/plugin-transform-react-jsx-source-7.29.7.tgz",
+      "integrity": "sha512-06IyK09H3wi4cGbhDBwp5gUGo0IKtnYa8tyTiephirPCK6fbobVGiXMMI5zLQ4aKEYP3wZ3ArU44o+8KMrSG/Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-plugin-utils": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      },
+      "peerDependencies": {
+        "@babel/core": "^7.0.0-0"
+      }
+    },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/template": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/traverse": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
+        "debug": "^4.3.1"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@next/env": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/@next/env/-/env-14.2.35.tgz",
+      "integrity": "sha512-DuhvCtj4t9Gwrx80dmz2F4t/zKQ4ktN8WrMwOuVzkJfBilwAwGr6v16M5eI8yCuZ63H9TTuEU09Iu2HqkzFPVQ==",
+      "license": "MIT"
+    },
+    "node_modules/@next/swc-darwin-arm64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-arm64/-/swc-darwin-arm64-14.2.33.tgz",
+      "integrity": "sha512-HqYnb6pxlsshoSTubdXKu15g3iivcbsMXg4bYpjL2iS/V6aQot+iyF4BUc2qA/J/n55YtvE4PHMKWBKGCF/+wA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-darwin-x64": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-darwin-x64/-/swc-darwin-x64-14.2.33.tgz",
+      "integrity": "sha512-8HGBeAE5rX3jzKvF593XTTFg3gxeU4f+UWnswa6JPhzaR6+zblO5+fjltJWIZc4aUalqTclvN2QtTC37LxvZAA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-gnu/-/swc-linux-arm64-gnu-14.2.33.tgz",
+      "integrity": "sha512-JXMBka6lNNmqbkvcTtaX8Gu5by9547bukHQvPoLe9VRBx1gHwzf5tdt4AaezW85HAB3pikcvyqBToRTDA4DeLw==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-arm64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-arm64-musl/-/swc-linux-arm64-musl-14.2.33.tgz",
+      "integrity": "sha512-Bm+QulsAItD/x6Ih8wGIMfRJy4G73tu1HJsrccPW6AfqdZd0Sfm5Imhgkgq2+kly065rYMnCOxTBvmvFY1BKfg==",
+      "cpu": [
+        "arm64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-gnu": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-gnu/-/swc-linux-x64-gnu-14.2.33.tgz",
+      "integrity": "sha512-FnFn+ZBgsVMbGDsTqo8zsnRzydvsGV8vfiWwUo1LD8FTmPTdV+otGSWKc4LJec0oSexFnCYVO4hX8P8qQKaSlg==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-linux-x64-musl": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-linux-x64-musl/-/swc-linux-x64-musl-14.2.33.tgz",
+      "integrity": "sha512-345tsIWMzoXaQndUTDv1qypDRiebFxGYx9pYkhwY4hBRaOLt8UGfiWKr9FSSHs25dFIf8ZqIFaPdy5MljdoawA==",
+      "cpu": [
+        "x64"
+      ],
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-arm64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-arm64-msvc/-/swc-win32-arm64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nscpt0G6UCTkrT2ppnJnFsYbPDQwmum4GNXYTeoTIdsmMydSKFz9Iny2jpaRupTb+Wl298+Rh82WKzt9LCcqSQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-ia32-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-ia32-msvc/-/swc-win32-ia32-msvc-14.2.33.tgz",
+      "integrity": "sha512-pc9LpGNKhJ0dXQhZ5QMmYxtARwwmWLpeocFmVG5Z0DzWq5Uf0izcI8tLc+qOpqxO1PWqZ5A7J1blrUIKrIFc7Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@next/swc-win32-x64-msvc": {
+      "version": "14.2.33",
+      "resolved": "https://registry.npmjs.org/@next/swc-win32-x64-msvc/-/swc-win32-x64-msvc-14.2.33.tgz",
+      "integrity": "sha512-nOjfZMy8B94MdisuzZo9/57xuFVLHJaDj5e/xrduJp9CV2/HrfxTRH2fbyLe+K9QT41WBLUd4iXX3R7jBp0EUg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@reactflow/background": {
+      "version": "11.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/background/-/background-11.3.14.tgz",
+      "integrity": "sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/controls": {
+      "version": "11.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/controls/-/controls-11.2.14.tgz",
+      "integrity": "sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/core": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/@reactflow/core/-/core-11.11.4.tgz",
+      "integrity": "sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3": "^7.4.0",
+        "@types/d3-drag": "^3.0.1",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/minimap": {
+      "version": "11.7.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/minimap/-/minimap-11.7.14.tgz",
+      "integrity": "sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "@types/d3-selection": "^3.0.3",
+        "@types/d3-zoom": "^3.0.1",
+        "classcat": "^5.0.3",
+        "d3-selection": "^3.0.0",
+        "d3-zoom": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-resizer": {
+      "version": "2.2.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-resizer/-/node-resizer-2.2.14.tgz",
+      "integrity": "sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.4",
+        "d3-drag": "^3.0.0",
+        "d3-selection": "^3.0.0",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@reactflow/node-toolbar": {
+      "version": "1.3.14",
+      "resolved": "https://registry.npmjs.org/@reactflow/node-toolbar/-/node-toolbar-1.3.14.tgz",
+      "integrity": "sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/core": "11.11.4",
+        "classcat": "^5.0.3",
+        "zustand": "^4.4.1"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0-beta.27",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-beta.27.tgz",
+      "integrity": "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.62.2.tgz",
+      "integrity": "sha512-6o7ZLZK+BeenkZCFNDXqpbjw9bD6nuWonvS/lwQJp7NoVVxm6p3qE7qQ5jGuBjiFsgvqjD8mZAU5oWxTmbOeOg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.62.2.tgz",
+      "integrity": "sha512-BaH7BllCACHoH1LguOU56UItGfUWjujlO65kS9LAodViaN4bwIKd7oeW/ZHJ/4ljr/7MIiENnNy3HJ0zXv8Zkw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.62.2.tgz",
+      "integrity": "sha512-v39RCCvj4He82I9sFmk+M1VZ0PLM9sfsLVikjfx2hYBNALhrrOR2D3JjQA6AhlaSOgcR+RzrKY7e1+bT6SUO/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.62.2.tgz",
+      "integrity": "sha512-yl0y2vq3S3lHeuXhEdss6TWfKW8vkujImO12tn4ZkG/4oghr09LvdYm2RElVjokTQiUvDUGXLGsYeLqUMCKpGA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.62.2.tgz",
+      "integrity": "sha512-tT4pvt4qXD+vEoezupCWi+a1F0vvDiksiHc+PxRlYTOH1I6/X4id9jPxTP+Fg+545euaFT1jJVs4CEdHZAU1vw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.62.2.tgz",
+      "integrity": "sha512-6nU5F2wCW+qvCBhTn1pdIU3bzsIoF7EUwsCDRxilWGprQR6yd508YnH9+OKFCwpfS8pjZqDUmnCAr7exax0XCg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.62.2.tgz",
+      "integrity": "sha512-n1GJHPOvpIfhi3TmrCeh6S6URt9BFCt0KQE3qvexyGCTAKpR4Lg+eWvNZEqu7epxwus/8ElT3hacYEucm49SZg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.62.2.tgz",
+      "integrity": "sha512-JqgflS8wEB+UXV/vS1RpRbifGBeN4D5lz8D8oOFbFZw4vedvdOgCFAjfBmIMdW3yL10XpQQ0Ambepw6MXrhOnA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.62.2.tgz",
+      "integrity": "sha512-wnFJkogWvN4jm/hQRF2UBaeUmk20j5+DmHvoyWii2b8HJDyvz1MF2OU/6ynXt2KR63rbZLWkFpoytpdc/yBuSA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.62.2.tgz",
+      "integrity": "sha512-HVu2bp0zhvJ8xHEV9+UUs7S90VadmBSY3LcIMvozbPo4AuMGDWlz3ymHLHZPX4hR67TKTt8Qp5PJ5RBg/i+RMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.62.2.tgz",
+      "integrity": "sha512-mQqqAV8QaoSgr9I2fKDLY2BAVvmKjWoGiu/cSYQonsLvtqwEn1E4QYfnCOcp5zoEqNhsDYin1s6jx/VJmrxlZg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.62.2.tgz",
+      "integrity": "sha512-IxKLoxCQ2IWi6bT2akyDUBGsOImDKB+sPp4EsTmwFQ/fMwpCKm8uLSSgP/Kx/QYUgKis6SEZ5/Nlhup0DIA0PQ==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.62.2.tgz",
+      "integrity": "sha512-Mk5ha2RQSgyFfmYYLkBpPnUk8D8FriBxesO1u9O75X0mHgXL1UQcH5Itl2lurWL2tj0RxV9b9tJgipac0hRY9A==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.62.2.tgz",
+      "integrity": "sha512-CjvEnqJL/0/TQ3TXX3OPIJ/kmBellrWd4heXUmHeJlTnmwjKpSJzoehLaL6Xk0ZnMHBu9dZuFADNOrtjF4v+2w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.62.2.tgz",
+      "integrity": "sha512-1SiZbzwdkaDURsew/tSOrooKiYy7EQGT6m8ufavAi9NEyQb/6VuIxFXAL1fqa4iZe3g4NbNk4P7J32z2tw5Mgg==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.62.2.tgz",
+      "integrity": "sha512-nQts12zJ3NQRoE6uYljOH89v7szzLDvG2JD/vsX+vGXU8w/At1GowTZ5/7qeFQ8m7L55rpR8Okugnuo5bgjy2Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.62.2.tgz",
+      "integrity": "sha512-E9/ll019jhPIJgpzfZoIkBGhcz+kKNgVWYRY0zr9srBdPPFVpvOKW8VaJKUbeK+eZXyQF9ltME+Kk6affeaPgg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-5BqxR/pshjey51iliyzTD5Xi3EN0aLmQ2lZ3lvefVV9c82BvrLo2/6OT55iifpWBufs6kdwWbuOKS841DrmK9A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "glibc"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.62.2.tgz",
+      "integrity": "sha512-uNN83XxQrRAh/w0/pmAfibcwyb6YWt4gP+dpnQKPVJshAloQ785ii8CT8ZCIxkGg9opVsvAlGhFitSm6D1Jjpg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "libc": [
+        "musl"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.62.2.tgz",
+      "integrity": "sha512-srjEIxSH3LRnJN6THczDHWQplqEMFiAJrTab0msUryh9kwNpkICf3Ea6q6MN/2cZwRFUNx5w+h6Hpi4QuHS6Zg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.62.2.tgz",
+      "integrity": "sha512-8hOJnxgbyObnCm5AlRA3A931xX19xq80RjVTKgJOvEKWqJruP/Uf12IbAOaDjjEXYRewwHLfmF0YRIdK3OwKWA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.62.2.tgz",
+      "integrity": "sha512-mmF4AY1i0hG/bLWUctUq59gtmgaSIRa3cu/A3JFRp/sCNEme2bgDEiDS22P9FbnJB8NJNF4jPJiSP5RHQpUTDg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.62.2.tgz",
+      "integrity": "sha512-DZgkknc6jhHrk46V25vbAM0zZkyP0nSDkJB8/dRkLTxv470dOmWDqGoEJl/9A0dFfS7yE3REOwNDxpHwSLSt0Q==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.62.2.tgz",
+      "integrity": "sha512-T6xr6ucWSFto+VGajA8YH26LdpHRuP4YLHEKAtCWvJDOlnmWcDZVCI2Jmjr+IFHDlt2zRaTAKE4tfjTaWLgJBg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.62.2.tgz",
+      "integrity": "sha512-BfzEnDJOt9T8M989/lA37EcJgat01wLRnoi5dQf3QzOH7jzpqTAzdDbVfRljVr5r+jzKqpbHeyOfAaXxAd0PAA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@swc/counter": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/@swc/counter/-/counter-0.1.3.tgz",
+      "integrity": "sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.5.tgz",
+      "integrity": "sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/counter": "^0.1.3",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@types/babel__core": {
+      "version": "7.20.5",
+      "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
+      "integrity": "sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.20.7",
+        "@babel/types": "^7.20.7",
+        "@types/babel__generator": "*",
+        "@types/babel__template": "*",
+        "@types/babel__traverse": "*"
+      }
+    },
+    "node_modules/@types/babel__generator": {
+      "version": "7.27.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.27.0.tgz",
+      "integrity": "sha512-ufFd2Xi92OAVPYsy+P4n7/U7e68fex0+Ee8gSG9KX7eo084CWiQ4sdxktvdl0bOPupXtVJPY19zk6EwWqUQ8lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__template": {
+      "version": "7.4.4",
+      "resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.4.tgz",
+      "integrity": "sha512-h/NUaSyG5EyxBIp8YRxo4RMe2/qQgvyowRwVMzhYhBCONbW8PUsg4lkFMrhgZhUe5z3L3MiLDuvyJ/CaPa2A8A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.1.0",
+        "@babel/types": "^7.0.0"
+      }
+    },
+    "node_modules/@types/babel__traverse": {
+      "version": "7.28.0",
+      "resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.28.0.tgz",
+      "integrity": "sha512-8PvcXf70gTDZBgt9ptxJ8elBeBjcLOAcOtoO/mPJjtji1+CdGbHgm77om1GrsPxsiE+uXIpNSK64UYaIwQXd4Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.28.2"
+      }
+    },
+    "node_modules/@types/d3": {
+      "version": "7.4.3",
+      "resolved": "https://registry.npmjs.org/@types/d3/-/d3-7.4.3.tgz",
+      "integrity": "sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/d3-axis": "*",
+        "@types/d3-brush": "*",
+        "@types/d3-chord": "*",
+        "@types/d3-color": "*",
+        "@types/d3-contour": "*",
+        "@types/d3-delaunay": "*",
+        "@types/d3-dispatch": "*",
+        "@types/d3-drag": "*",
+        "@types/d3-dsv": "*",
+        "@types/d3-ease": "*",
+        "@types/d3-fetch": "*",
+        "@types/d3-force": "*",
+        "@types/d3-format": "*",
+        "@types/d3-geo": "*",
+        "@types/d3-hierarchy": "*",
+        "@types/d3-interpolate": "*",
+        "@types/d3-path": "*",
+        "@types/d3-polygon": "*",
+        "@types/d3-quadtree": "*",
+        "@types/d3-random": "*",
+        "@types/d3-scale": "*",
+        "@types/d3-scale-chromatic": "*",
+        "@types/d3-selection": "*",
+        "@types/d3-shape": "*",
+        "@types/d3-time": "*",
+        "@types/d3-time-format": "*",
+        "@types/d3-timer": "*",
+        "@types/d3-transition": "*",
+        "@types/d3-zoom": "*"
+      }
+    },
+    "node_modules/@types/d3-array": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-array/-/d3-array-3.2.2.tgz",
+      "integrity": "sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-axis": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-axis/-/d3-axis-3.0.6.tgz",
+      "integrity": "sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-brush": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-brush/-/d3-brush-3.0.6.tgz",
+      "integrity": "sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-chord": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-chord/-/d3-chord-3.0.6.tgz",
+      "integrity": "sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-color": {
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-color/-/d3-color-3.1.3.tgz",
+      "integrity": "sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-contour": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-contour/-/d3-contour-3.0.6.tgz",
+      "integrity": "sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-array": "*",
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-delaunay": {
+      "version": "6.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-delaunay/-/d3-delaunay-6.0.4.tgz",
+      "integrity": "sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-dispatch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dispatch/-/d3-dispatch-3.0.7.tgz",
+      "integrity": "sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-drag": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-drag/-/d3-drag-3.0.7.tgz",
+      "integrity": "sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-dsv": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-dsv/-/d3-dsv-3.0.7.tgz",
+      "integrity": "sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-ease": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-ease/-/d3-ease-3.0.2.tgz",
+      "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-fetch": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-fetch/-/d3-fetch-3.0.7.tgz",
+      "integrity": "sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-dsv": "*"
+      }
+    },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-format": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-format/-/d3-format-3.0.4.tgz",
+      "integrity": "sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-geo": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-geo/-/d3-geo-3.1.0.tgz",
+      "integrity": "sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/geojson": "*"
+      }
+    },
+    "node_modules/@types/d3-hierarchy": {
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/@types/d3-hierarchy/-/d3-hierarchy-3.1.7.tgz",
+      "integrity": "sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-interpolate": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
+      "integrity": "sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-color": "*"
+      }
+    },
+    "node_modules/@types/d3-path": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/@types/d3-path/-/d3-path-3.1.1.tgz",
+      "integrity": "sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-polygon": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-polygon/-/d3-polygon-3.0.2.tgz",
+      "integrity": "sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-quadtree": {
+      "version": "3.0.6",
+      "resolved": "https://registry.npmjs.org/@types/d3-quadtree/-/d3-quadtree-3.0.6.tgz",
+      "integrity": "sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-random": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-random/-/d3-random-3.0.3.tgz",
+      "integrity": "sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-scale": {
+      "version": "4.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale/-/d3-scale-4.0.9.tgz",
+      "integrity": "sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-time": "*"
+      }
+    },
+    "node_modules/@types/d3-scale-chromatic": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@types/d3-scale-chromatic/-/d3-scale-chromatic-3.1.0.tgz",
+      "integrity": "sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-shape": {
+      "version": "3.1.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-shape/-/d3-shape-3.1.8.tgz",
+      "integrity": "sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-path": "*"
+      }
+    },
+    "node_modules/@types/d3-time": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/d3-time/-/d3-time-3.0.4.tgz",
+      "integrity": "sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-time-format": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/@types/d3-time-format/-/d3-time-format-4.0.3.tgz",
+      "integrity": "sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-timer": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/d3-timer/-/d3-timer-3.0.2.tgz",
+      "integrity": "sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/d3-transition": {
+      "version": "3.0.9",
+      "resolved": "https://registry.npmjs.org/@types/d3-transition/-/d3-transition-3.0.9.tgz",
+      "integrity": "sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/d3-zoom": {
+      "version": "3.0.8",
+      "resolved": "https://registry.npmjs.org/@types/d3-zoom/-/d3-zoom-3.0.8.tgz",
+      "integrity": "sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/d3-interpolate": "*",
+        "@types/d3-selection": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/geojson": {
+      "version": "7946.0.16",
+      "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
+      "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/prop-types": {
+      "version": "15.7.15",
+      "resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.15.tgz",
+      "integrity": "sha512-F6bEyamV9jKGAFBEmlQnesRPGOQqS2+Uwi0Em15xenOxHaf2hv6L8YCVn3rPdPJOiJfPiCnLIRyvwVaqMY3MIw==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/react": {
+      "version": "18.3.31",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-18.3.31.tgz",
+      "integrity": "sha512-vfEqpXTvwT91yhmwdfouStN2hSKwTvyRs8qpLfADyrq/kxDw0hZM7Wk9Ug1FELj8hIby+S/+kQCSRFF32nv2Qw==",
+      "devOptional": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/prop-types": "*",
+        "csstype": "^3.2.2"
+      }
+    },
+    "node_modules/@types/react-dom": {
+      "version": "18.3.7",
+      "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-18.3.7.tgz",
+      "integrity": "sha512-MEe3UeoENYVFXzoXEWsvcpg6ZvlrFNlOQ7EOsvhI3CfAXwzPfO8Qwuxd40nepsYKqyyVQnTdEfv68q91yLcKrQ==",
+      "dev": true,
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "^18.0.0"
+      }
+    },
+    "node_modules/@vitejs/plugin-react": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-4.7.0.tgz",
+      "integrity": "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/core": "^7.28.0",
+        "@babel/plugin-transform-react-jsx-self": "^7.27.1",
+        "@babel/plugin-transform-react-jsx-source": "^7.27.1",
+        "@rolldown/pluginutils": "1.0.0-beta.27",
+        "@types/babel__core": "^7.20.5",
+        "react-refresh": "^0.17.0"
+      },
+      "engines": {
+        "node": "^14.18.0 || >=16.0.0"
+      },
+      "peerDependencies": {
+        "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.38",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.38.tgz",
+      "integrity": "sha512-31/02mVB4yuQU6adKk5SlY6m+mxDwUq5KZkyYgnLrrKl7TEm1+3PyDtDBz2kOv/wxZz41GHsvV1A/u6RmiyBvw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/classcat": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/classcat/-/classcat-5.0.5.tgz",
+      "integrity": "sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==",
+      "license": "MIT"
+    },
+    "node_modules/client-only": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/client-only/-/client-only-0.0.1.tgz",
+      "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
+      "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "devOptional": true,
+      "license": "MIT"
+    },
+    "node_modules/d3-color": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/d3-color/-/d3-color-3.1.0.tgz",
+      "integrity": "sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-dispatch": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-3.0.1.tgz",
+      "integrity": "sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-drag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-drag/-/d3-drag-3.0.0.tgz",
+      "integrity": "sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-selection": "3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-ease": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-ease/-/d3-ease-3.0.1.tgz",
+      "integrity": "sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-interpolate": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-interpolate/-/d3-interpolate-3.0.1.tgz",
+      "integrity": "sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-selection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-timer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-3.0.1.tgz",
+      "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==",
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/d3-transition": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/d3-transition/-/d3-transition-3.0.1.tgz",
+      "integrity": "sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-color": "1 - 3",
+        "d3-dispatch": "1 - 3",
+        "d3-ease": "1 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-timer": "1 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "peerDependencies": {
+        "d3-selection": "2 - 3"
+      }
+    },
+    "node_modules/d3-zoom": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/d3-zoom/-/d3-zoom-3.0.0.tgz",
+      "integrity": "sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==",
+      "license": "ISC",
+      "dependencies": {
+        "d3-dispatch": "1 - 3",
+        "d3-drag": "2 - 3",
+        "d3-interpolate": "1 - 3",
+        "d3-selection": "2 - 3",
+        "d3-transition": "2 - 3"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.378",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.378.tgz",
+      "integrity": "sha512-VinvOAuuPmdD1guEgGv5f2Qp7/vlfqOrUOMYNnOD4wj3pit8kRsQHzfIf6teyUGWo15Tg5+bOJaRunvyltpVWQ==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gensync": {
+      "version": "1.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+      "integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "license": "MIT"
+    },
+    "node_modules/jsdom": {
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-24.1.3.tgz",
+      "integrity": "sha512-MyL55p3Ut3cXbeBEG7Hcv0mVM8pp8PBNWxRqchZnSfAiES1v1mRnMeFfaHWIPULpwsYfvO+ZmMZz5tGCnjzDUQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.0.1",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^4.1.4",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/jsesc": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
+      "integrity": "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "jsesc": "bin/jsesc"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/json5": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
+      "integrity": "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "json5": "lib/cli.js"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/lru-cache": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+      "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/next": {
+      "version": "14.2.35",
+      "resolved": "https://registry.npmjs.org/next/-/next-14.2.35.tgz",
+      "integrity": "sha512-KhYd2Hjt/O1/1aZVX3dCwGXM1QmOV4eNM2UTacK5gipDdPN/oHHK/4oVGy7X8GMfPMsUTUEmGlsy0EY1YGAkig==",
+      "license": "MIT",
+      "dependencies": {
+        "@next/env": "14.2.35",
+        "@swc/helpers": "0.5.5",
+        "busboy": "1.6.0",
+        "caniuse-lite": "^1.0.30001579",
+        "graceful-fs": "^4.2.11",
+        "postcss": "8.4.31",
+        "styled-jsx": "5.1.1"
+      },
+      "bin": {
+        "next": "dist/bin/next"
+      },
+      "engines": {
+        "node": ">=18.17.0"
+      },
+      "optionalDependencies": {
+        "@next/swc-darwin-arm64": "14.2.33",
+        "@next/swc-darwin-x64": "14.2.33",
+        "@next/swc-linux-arm64-gnu": "14.2.33",
+        "@next/swc-linux-arm64-musl": "14.2.33",
+        "@next/swc-linux-x64-gnu": "14.2.33",
+        "@next/swc-linux-x64-musl": "14.2.33",
+        "@next/swc-win32-arm64-msvc": "14.2.33",
+        "@next/swc-win32-ia32-msvc": "14.2.33",
+        "@next/swc-win32-x64-msvc": "14.2.33"
+      },
+      "peerDependencies": {
+        "@opentelemetry/api": "^1.1.0",
+        "@playwright/test": "^1.41.2",
+        "react": "^18.2.0",
+        "react-dom": "^18.2.0",
+        "sass": "^1.3.0"
+      },
+      "peerDependenciesMeta": {
+        "@opentelemetry/api": {
+          "optional": true
+        },
+        "@playwright/test": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.49",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.49.tgz",
+      "integrity": "sha512-f06bl1D+8ZDkn2oOQQKAh5/otFWqVnM1Q5oerA8Pex7UfT66Tx4IPHIqVVFKqFT3FUtaDstdgkM7yT7JWhqxfw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.4.31",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
+      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.6",
+        "picocolors": "^1.0.0",
+        "source-map-js": "^1.0.2"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/psl": {
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
+      "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/lupomontero"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/querystringify": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+      "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/react": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react/-/react-18.3.1.tgz",
+      "integrity": "sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-dom": {
+      "version": "18.3.1",
+      "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
+      "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0",
+        "scheduler": "^0.23.2"
+      },
+      "peerDependencies": {
+        "react": "^18.3.1"
+      }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/react-refresh": {
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.17.0.tgz",
+      "integrity": "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/reactflow": {
+      "version": "11.11.4",
+      "resolved": "https://registry.npmjs.org/reactflow/-/reactflow-11.11.4.tgz",
+      "integrity": "sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==",
+      "license": "MIT",
+      "dependencies": {
+        "@reactflow/background": "11.3.14",
+        "@reactflow/controls": "11.2.14",
+        "@reactflow/core": "11.11.4",
+        "@reactflow/minimap": "11.7.14",
+        "@reactflow/node-resizer": "2.2.14",
+        "@reactflow/node-toolbar": "1.3.14"
+      },
+      "peerDependencies": {
+        "react": ">=17",
+        "react-dom": ">=17"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/requires-port": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/requires-port/-/requires-port-1.0.0.tgz",
+      "integrity": "sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rollup": {
+      "version": "4.62.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.62.2.tgz",
+      "integrity": "sha512-RFnrW4lhXA3s3eqHDZvN654g8OTjzRfqpIRJYczCGB6HzphckVAi/Qh4tbPUbRuDi7s1Llv8g/NspLkttY3gTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.9"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.62.2",
+        "@rollup/rollup-android-arm64": "4.62.2",
+        "@rollup/rollup-darwin-arm64": "4.62.2",
+        "@rollup/rollup-darwin-x64": "4.62.2",
+        "@rollup/rollup-freebsd-arm64": "4.62.2",
+        "@rollup/rollup-freebsd-x64": "4.62.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.62.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.62.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.62.2",
+        "@rollup/rollup-linux-arm64-musl": "4.62.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.62.2",
+        "@rollup/rollup-linux-loong64-musl": "4.62.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.62.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.62.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.62.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.62.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-gnu": "4.62.2",
+        "@rollup/rollup-linux-x64-musl": "4.62.2",
+        "@rollup/rollup-openbsd-x64": "4.62.2",
+        "@rollup/rollup-openharmony-arm64": "4.62.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.62.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.62.2",
+        "@rollup/rollup-win32-x64-gnu": "4.62.2",
+        "@rollup/rollup-win32-x64-msvc": "4.62.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/scheduler": {
+      "version": "0.23.2",
+      "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
+      "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.1.0"
+      }
+    },
+    "node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "dev": true,
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/styled-jsx": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/styled-jsx/-/styled-jsx-5.1.1.tgz",
+      "integrity": "sha512-pW7uC1l4mBZ8ugbiZrcIsiIvVx1UmTfw7UkC3Um2tmfUq9Bhk8IiyEIPl6F8agHgjzku6j0xQEZbfA5uSgSaCw==",
+      "license": "MIT",
+      "dependencies": {
+        "client-only": "0.0.1"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "peerDependencies": {
+        "react": ">= 16.8.0 || 17.x.x || ^18.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@babel/core": {
+          "optional": true
+        },
+        "babel-plugin-macros": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tough-cookie": {
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+      "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "psl": "^1.1.33",
+        "punycode": "^2.1.1",
+        "universalify": "^0.2.0",
+        "url-parse": "^1.5.3"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/universalify": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+      "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4.0.0"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/url-parse": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+      "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "querystringify": "^2.1.1",
+        "requires-port": "^1.0.0"
+      }
+    },
+    "node_modules/use-sync-external-store": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/use-sync-external-store/-/use-sync-external-store-1.6.0.tgz",
+      "integrity": "sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vite/node_modules/postcss": {
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/yallist": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.1.1.tgz",
+      "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "4.5.7",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-4.5.7.tgz",
+      "integrity": "sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==",
+      "license": "MIT",
+      "dependencies": {
+        "use-sync-external-store": "^1.2.2"
+      },
+      "engines": {
+        "node": ">=12.7.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=16.8",
+        "immer": ">=9.0.6",
+        "react": ">=16.8"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/extensions/command-node/package.json
+++ b/extensions/command-node/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "jarvis-command-node",
+  "version": "0.1.0",
+  "private": true,
+  "description": "Sovereign Command Node -- Phase 1 read-only mission-control dashboard for the JARVIS Ouroboros loop. Consumes the existing /observability SSE + GET surface. No write-path, no biometric -- visualization only.",
+  "license": "UNLICENSED",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start",
+    "lint": "next lint",
+    "typecheck": "tsc --noEmit",
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "next": "^14.2.5",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
+    "reactflow": "^11.11.4"
+  },
+  "devDependencies": {
+    "@testing-library/jest-dom": "^6.4.8",
+    "@testing-library/react": "^16.0.0",
+    "@types/node": "^20.14.12",
+    "@types/react": "^18.3.3",
+    "@types/react-dom": "^18.3.0",
+    "@vitejs/plugin-react": "^4.3.1",
+    "jsdom": "^24.1.1",
+    "typescript": "^5.5.4",
+    "vitest": "^2.0.5"
+  },
+  "engines": {
+    "node": ">=18.0.0"
+  }
+}

--- a/extensions/command-node/test/blastRadiusGraph.test.tsx
+++ b/extensions/command-node/test/blastRadiusGraph.test.tsx
@@ -1,0 +1,113 @@
+/**
+ * BlastRadiusGraph tests.
+ *
+ *   - the pure buildBlastGraph: center + repo-color-coded nodes/edges
+ *   - cross-boundary detection (distinctRepos > 1)
+ *   - the component renders nodes from a fixture report and a click on
+ *     a node opens the detail panel with repo / file / symbol.
+ *
+ * React Flow renders nodes as DOM; we drive a click via the node label.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import BlastRadiusGraph from '../components/BlastRadiusGraph';
+import {
+  buildBlastGraph,
+  distinctRepos,
+  CENTER_NODE_ID,
+  affectedNodeId,
+} from '../lib/blastGraph';
+import { repoStyle } from '../lib/theme';
+import { BlastRadiusResponse } from '../lib/types';
+
+const FIXTURE: BlastRadiusResponse = {
+  schema_version: '1.0',
+  op_id: 'op-cross-1',
+  directly_affected: [
+    { repo: 'reactor', file: 'core/train.py', name: 'train_step', type: 'function' },
+    { repo: 'prime', file: 'mind/router.py', name: 'route', type: 'function' },
+  ],
+  transitively_affected: [
+    { repo: 'jarvis', file: 'backend/loop.py', name: 'GovernedLoop', type: 'class' },
+  ],
+  total_affected: 3,
+  risk_level: 'critical',
+};
+
+describe('buildBlastGraph (pure)', () => {
+  test('center node + one node per affected, colored by repo', () => {
+    const { nodes, edges } = buildBlastGraph(FIXTURE);
+    // 1 center + 2 direct + 1 transitive = 4 nodes; 3 edges from center.
+    expect(nodes).toHaveLength(4);
+    expect(edges).toHaveLength(3);
+    expect(nodes[0]?.id).toBe(CENTER_NODE_ID);
+
+    const reactorNode = nodes.find(
+      (n) => n.id === affectedNodeId(FIXTURE.directly_affected[0]!),
+    );
+    const primeNode = nodes.find(
+      (n) => n.id === affectedNodeId(FIXTURE.directly_affected[1]!),
+    );
+    const jarvisNode = nodes.find(
+      (n) => n.id === affectedNodeId(FIXTURE.transitively_affected[0]!),
+    );
+    expect(reactorNode?.style?.background).toBe(repoStyle('reactor').color);
+    expect(primeNode?.style?.background).toBe(repoStyle('prime').color);
+    expect(jarvisNode?.style?.background).toBe(repoStyle('jarvis').color);
+
+    // Every edge originates at the center (radial graph).
+    expect(edges.every((e) => e.source === CENTER_NODE_ID)).toBe(true);
+  });
+
+  test('distinctRepos detects a cross-boundary blast', () => {
+    expect(distinctRepos(FIXTURE).sort()).toEqual([
+      'jarvis',
+      'prime',
+      'reactor',
+    ]);
+    const singleRepo: BlastRadiusResponse = {
+      ...FIXTURE,
+      directly_affected: [
+        { repo: 'jarvis', file: 'a.py', name: 'x', type: 'function' },
+      ],
+      transitively_affected: [],
+    };
+    expect(distinctRepos(singleRepo)).toEqual(['jarvis']);
+  });
+});
+
+describe('BlastRadiusGraph component', () => {
+  test('renders the summary, the cross-boundary badge, and affected nodes', () => {
+    render(<BlastRadiusGraph report={FIXTURE} />);
+    expect(screen.getByTestId('blast-graph')).toBeInTheDocument();
+    expect(screen.getByTestId('cross-boundary')).toHaveTextContent(
+      'CROSS-BOUNDARY',
+    );
+    // Affected node labels are present (React Flow renders them).
+    expect(screen.getByText(/train_step/)).toBeInTheDocument();
+    expect(screen.getByText(/route/)).toBeInTheDocument();
+  });
+
+  test('clicking an affected node opens the detail panel', () => {
+    render(<BlastRadiusGraph report={FIXTURE} />);
+    // No detail until a node is clicked.
+    expect(screen.queryByTestId('blast-detail')).toBeNull();
+
+    fireEvent.click(screen.getByText(/train_step/));
+    const detail = screen.getByTestId('blast-detail');
+    expect(detail).toBeInTheDocument();
+    expect(within(detail).getByText('core/train.py')).toBeInTheDocument();
+    expect(within(detail).getByText(/Nerves \(reactor\)/)).toBeInTheDocument();
+  });
+
+  test('idle state when no report', () => {
+    render(<BlastRadiusGraph report={null} />);
+    expect(screen.getByTestId('blast-idle')).toBeInTheDocument();
+  });
+
+  test('error state surfaces the message', () => {
+    render(<BlastRadiusGraph report={null} error="boom" />);
+    expect(screen.getByTestId('blast-error')).toHaveTextContent('boom');
+  });
+});

--- a/extensions/command-node/test/projection.test.ts
+++ b/extensions/command-node/test/projection.test.ts
@@ -1,0 +1,87 @@
+/**
+ * Projection tests -- the pure event-stream -> view-model transforms.
+ */
+
+import { describe, expect, test } from 'vitest';
+import {
+  projectDagNodes,
+  projectElevationQueue,
+  projectFsmStates,
+  projectYieldAlerts,
+} from '../lib/projection';
+import { StreamEventFrame } from '../lib/types';
+
+function frame(
+  eventType: string,
+  payload: Record<string, unknown>,
+  opId = 'op-1',
+  id = `e-${Math.random()}`,
+): StreamEventFrame {
+  return {
+    schema_version: '1.0',
+    event_id: id,
+    event_type: eventType as StreamEventFrame['event_type'],
+    op_id: opId,
+    timestamp: 't',
+    payload,
+  };
+}
+
+describe('projectFsmStates', () => {
+  test('keeps the latest phase per op and drops completed ops', () => {
+    const events = [
+      frame('fsm_phase_changed', { phase: 'CLASSIFY' }, 'op-1'),
+      frame('fsm_phase_changed', { phase: 'GENERATE', route: 'STANDARD', risk_tier: 'notify_apply' }, 'op-1'),
+      frame('fsm_phase_changed', { phase: 'PLAN' }, 'op-2'),
+      frame('task_completed', {}, 'op-2'),
+    ];
+    const states = projectFsmStates(events);
+    expect(states).toHaveLength(1);
+    expect(states[0]?.opId).toBe('op-1');
+    expect(states[0]?.phase).toBe('GENERATE');
+    expect(states[0]?.route).toBe('STANDARD');
+    expect(states[0]?.riskTier).toBe('notify_apply');
+  });
+});
+
+describe('projectDagNodes', () => {
+  test('dag_node_updated wins; task events seed coarse nodes', () => {
+    const events = [
+      frame('task_created', {}, 'op-7'),
+      frame('dag_node_updated', { node_id: 'n9', state: 'fractured' }, 'op-7'),
+    ];
+    const nodes = projectDagNodes(events);
+    const n9 = nodes.find((n) => n.nodeId === 'n9');
+    expect(n9?.state).toBe('fractured');
+  });
+});
+
+describe('projectElevationQueue', () => {
+  test('de-dupes by pr_id, newest first', () => {
+    const events = [
+      frame('cross_repo_elevation_pending', { pr_id: 'pr-1', target_repo: 'prime', blast_radius_summary: 'a' }, 'op-a'),
+      frame('cross_repo_elevation_pending', { pr_id: 'pr-2', target_repo: 'reactor', blast_radius_summary: 'b' }, 'op-b'),
+      frame('cross_repo_elevation_pending', { pr_id: 'pr-1', target_repo: 'prime', blast_radius_summary: 'a2' }, 'op-a'),
+    ];
+    const q = projectElevationQueue(events);
+    // De-duped to 2 entries. Order is by first-seen, reversed, so the
+    // most-recently-first-seen pr (pr-2) leads; pr-1 retains its
+    // original slot but its summary is updated in place to 'a2'.
+    expect(q).toHaveLength(2);
+    expect(q.map((e) => e.pr_id)).toEqual(['pr-2', 'pr-1']);
+    const pr1 = q.find((e) => e.pr_id === 'pr-1');
+    expect(pr1?.blast_radius_summary).toBe('a2');
+  });
+});
+
+describe('projectYieldAlerts', () => {
+  test('returns newest first, capped', () => {
+    const events = [
+      frame('sovereign_yield', { reason: 'FRACTURE' }, 'op-1', 'y1'),
+      frame('sovereign_yield', { reason: 'RECOVERED' }, 'op-1', 'y2'),
+    ];
+    const alerts = projectYieldAlerts(events, 1);
+    expect(alerts).toHaveLength(1);
+    expect(alerts[0]?.reason).toBe('RECOVERED');
+  });
+});

--- a/extensions/command-node/test/setup.ts
+++ b/extensions/command-node/test/setup.ts
@@ -1,0 +1,26 @@
+import '@testing-library/jest-dom/vitest';
+
+// React Flow measures the DOM with ResizeObserver, which jsdom does not
+// implement. Provide a no-op stub so components mount in tests.
+class ResizeObserverStub {
+  observe(): void {}
+  unobserve(): void {}
+  disconnect(): void {}
+}
+
+if (typeof globalThis.ResizeObserver === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).ResizeObserver = ResizeObserverStub;
+}
+
+// jsdom lacks DOMMatrixReadOnly / matchMedia used by React Flow.
+if (typeof (globalThis as unknown as { matchMedia?: unknown }).matchMedia === 'undefined') {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (globalThis as any).matchMedia = () => ({
+    matches: false,
+    addListener: () => {},
+    removeListener: () => {},
+    addEventListener: () => {},
+    removeEventListener: () => {},
+  });
+}

--- a/extensions/command-node/test/useSovereignStream.test.ts
+++ b/extensions/command-node/test/useSovereignStream.test.ts
@@ -1,0 +1,281 @@
+/**
+ * SSE client tests for the Command Node.
+ *
+ * Mirrors the vscode-jarvis stream.parser + stream.reconnect tests:
+ *   - multi-event stream parsing (single chunk, split chunks, comments)
+ *   - schema-mismatch drop
+ *   - reconnect with Last-Event-ID replay header
+ *   - exponential backoff + jitter
+ * plus the Command-Node-specific:
+ *   - pushBounded ring-buffer cap (the hook's bounded buffer)
+ *   - poll-fallback frame shape (synthesized from /observability/tasks)
+ *
+ * Uses vitest with a mocked fetch returning a ReadableStream Response.
+ */
+
+import { describe, expect, test } from 'vitest';
+import { StreamConsumer } from '../lib/stream';
+import { StreamEventFrame } from '../lib/types';
+import { pushBounded } from '../hooks/useSovereignStream';
+
+function frameBytes(
+  id: string,
+  event: string,
+  payload: Record<string, unknown> = {},
+  opId = 'op-x',
+): Uint8Array {
+  const body = {
+    schema_version: '1.0',
+    event_id: id,
+    event_type: event,
+    op_id: opId,
+    timestamp: 't',
+    payload,
+  };
+  const txt = `id: ${id}\nevent: ${event}\ndata: ${JSON.stringify(body)}\n\n`;
+  return new TextEncoder().encode(txt);
+}
+
+function mkStreamResponse(
+  chunks: Uint8Array[],
+  opts: { never?: boolean; status?: number } = {},
+): Response {
+  if (opts.never === true) {
+    return new Response(
+      new ReadableStream<Uint8Array>({ start() {} }),
+      { status: 200, headers: { 'Content-Type': 'text/event-stream' } },
+    );
+  }
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const c of chunks) controller.enqueue(c);
+      controller.close();
+    },
+  });
+  return new Response(body, {
+    status: opts.status ?? 200,
+    headers: { 'Content-Type': 'text/event-stream' },
+  });
+}
+
+async function waitForState(
+  consumer: StreamConsumer,
+  target: string,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (consumer.getState() !== target) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error(`timeout waiting for state=${target}`);
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+async function waitUntil(
+  cond: () => boolean,
+  timeoutMs = 2000,
+): Promise<void> {
+  const start = Date.now();
+  while (!cond()) {
+    if (Date.now() - start > timeoutMs) {
+      throw new Error('timeout waiting for condition');
+    }
+    await new Promise((r) => setTimeout(r, 5));
+  }
+}
+
+function extractHeaders(h: HeadersInit | undefined): Record<string, string> {
+  if (h === undefined) return {};
+  if (h instanceof Headers) {
+    const out: Record<string, string> = {};
+    h.forEach((v, k) => {
+      out[k] = v;
+    });
+    return out;
+  }
+  if (Array.isArray(h)) return Object.fromEntries(h);
+  return { ...(h as Record<string, string>) };
+}
+
+describe('StreamConsumer SSE parsing', () => {
+  test('parses a multi-event stream (single chunk)', async () => {
+    const chunk = new Uint8Array([
+      ...frameBytes('e1', 'task_created'),
+      ...frameBytes('e2', 'fsm_phase_changed', { phase: 'GENERATE' }),
+      ...frameBytes('e3', 'task_completed'),
+    ]);
+    const consumer = new StreamConsumer({
+      endpoint: 'http://127.0.0.1:1234',
+      autoReconnect: false,
+      reconnectMaxBackoffMs: 100,
+      fetchFn: (async () => mkStreamResponse([chunk])) as unknown as typeof fetch,
+    });
+    const received: StreamEventFrame[] = [];
+    consumer.onEvent((f) => {
+      received.push(f);
+    });
+    consumer.start();
+    await waitForState(consumer, 'disconnected');
+    expect(received.map((f) => f.event_type)).toEqual([
+      'task_created',
+      'fsm_phase_changed',
+      'task_completed',
+    ]);
+    expect(received[1]?.payload).toEqual({ phase: 'GENERATE' });
+  });
+
+  test('parses a frame split across chunks', async () => {
+    const full = frameBytes('e1', 'dag_node_updated', {
+      node_id: 'n1',
+      state: 'running',
+    });
+    const mid = Math.floor(full.length / 2);
+    const consumer = new StreamConsumer({
+      endpoint: 'http://127.0.0.1:1234',
+      autoReconnect: false,
+      reconnectMaxBackoffMs: 100,
+      fetchFn: (async () =>
+        mkStreamResponse([full.slice(0, mid), full.slice(mid)])) as unknown as typeof fetch,
+    });
+    const received: StreamEventFrame[] = [];
+    consumer.onEvent((f) => {
+      received.push(f);
+    });
+    consumer.start();
+    await waitForState(consumer, 'disconnected');
+    expect(received).toHaveLength(1);
+    expect(received[0]?.event_type).toBe('dag_node_updated');
+  });
+
+  test('ignores SSE comment keepalive lines', async () => {
+    const comment = new TextEncoder().encode(': keepalive\n\n');
+    const consumer = new StreamConsumer({
+      endpoint: 'http://127.0.0.1:1234',
+      autoReconnect: false,
+      reconnectMaxBackoffMs: 100,
+      fetchFn: (async () =>
+        mkStreamResponse([comment, frameBytes('e1', 'task_created')])) as unknown as typeof fetch,
+    });
+    const received: StreamEventFrame[] = [];
+    consumer.onEvent((f) => {
+      received.push(f);
+    });
+    consumer.start();
+    await waitForState(consumer, 'disconnected');
+    expect(received).toHaveLength(1);
+  });
+
+  test('drops schema-mismatched frames', async () => {
+    const wrong = new TextEncoder().encode(
+      `id: e1\nevent: task_created\ndata: ${JSON.stringify({
+        schema_version: '9.9',
+        event_id: 'e1',
+        event_type: 'task_created',
+        op_id: 'op-x',
+        timestamp: 't',
+        payload: {},
+      })}\n\n`,
+    );
+    const consumer = new StreamConsumer({
+      endpoint: 'http://127.0.0.1:1234',
+      autoReconnect: false,
+      reconnectMaxBackoffMs: 100,
+      fetchFn: (async () => mkStreamResponse([wrong])) as unknown as typeof fetch,
+    });
+    const received: StreamEventFrame[] = [];
+    consumer.onEvent((f) => {
+      received.push(f);
+    });
+    consumer.start();
+    await waitForState(consumer, 'disconnected');
+    expect(received).toHaveLength(0);
+  });
+});
+
+describe('StreamConsumer reconnect', () => {
+  test('sends Last-Event-ID header on reconnect after a frame', async () => {
+    let calls = 0;
+    const headersSeen: Record<string, string>[] = [];
+    const consumer = new StreamConsumer({
+      endpoint: 'http://127.0.0.1:1234',
+      autoReconnect: true,
+      reconnectMaxBackoffMs: 50,
+      jitterFn: () => 0,
+      sleepFn: async () => {
+        await new Promise<void>((r) => setImmediate(r));
+      },
+      fetchFn: (async (_url: string, init?: RequestInit) => {
+        calls += 1;
+        headersSeen.push(extractHeaders(init?.headers));
+        if (calls === 1) {
+          // First connection yields one frame then closes -> reconnect.
+          return mkStreamResponse([frameBytes('evt-42', 'task_started')]);
+        }
+        // Second connection: open forever so we can inspect its headers.
+        return mkStreamResponse([], { never: true });
+      }) as unknown as typeof fetch,
+    });
+    consumer.start();
+    await waitUntil(() => calls >= 2);
+    await consumer.stop();
+    // First request: no Last-Event-ID. Second: replays from evt-42.
+    expect(headersSeen[0]?.['Last-Event-ID']).toBeUndefined();
+    expect(headersSeen[1]?.['Last-Event-ID']).toBe('evt-42');
+  });
+
+  test('backoff uses jitter and respects the max cap', async () => {
+    let calls = 0;
+    const sleeps: number[] = [];
+    const consumer = new StreamConsumer({
+      endpoint: 'http://127.0.0.1:1234',
+      autoReconnect: true,
+      reconnectMaxBackoffMs: 1000,
+      jitterFn: () => 0.5,
+      fetchFn: (async () => {
+        calls += 1;
+        if (calls > 3) throw new Error('give_up');
+        return new Response('x', { status: 503 });
+      }) as unknown as typeof fetch,
+      sleepFn: async (ms) => {
+        sleeps.push(ms);
+        await new Promise<void>((r) => setImmediate(r));
+      },
+    });
+    consumer.start();
+    await waitUntil(() => sleeps.length >= 2);
+    await consumer.stop();
+    // full-jitter with 0.5: floor(500*0.5)=250, floor(1000*0.5)=500...
+    expect(sleeps[0]).toBe(250);
+    expect(sleeps.every((s) => s <= 1000)).toBe(true);
+  });
+});
+
+describe('bounded event buffer (pushBounded)', () => {
+  function mkFrame(id: string): StreamEventFrame {
+    return {
+      schema_version: '1.0',
+      event_id: id,
+      event_type: 'heartbeat',
+      op_id: 'op',
+      timestamp: 't',
+      payload: {},
+    };
+  }
+
+  test('caps the buffer and drops oldest', () => {
+    let buf: StreamEventFrame[] = [];
+    for (let i = 0; i < 10; i += 1) {
+      buf = pushBounded(buf, mkFrame(`e${i}`), 3);
+    }
+    expect(buf).toHaveLength(3);
+    expect(buf.map((f) => f.event_id)).toEqual(['e7', 'e8', 'e9']);
+  });
+
+  test('does not mutate the input array', () => {
+    const original = [mkFrame('a')];
+    const next = pushBounded(original, mkFrame('b'), 5);
+    expect(original).toHaveLength(1);
+    expect(next).toHaveLength(2);
+  });
+});

--- a/extensions/command-node/tsconfig.json
+++ b/extensions/command-node/tsconfig.json
@@ -1,0 +1,33 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "lib": ["dom", "dom.iterable", "ES2021"],
+    "allowJs": false,
+    "skipLibCheck": true,
+    "strict": true,
+    "noImplicitAny": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "exactOptionalPropertyTypes": false,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "esnext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "preserve",
+    "incremental": true,
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"],
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [{ "name": "next" }]
+  },
+  "include": [
+    "next-env.d.ts",
+    "**/*.ts",
+    "**/*.tsx",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": ["node_modules"]
+}

--- a/extensions/command-node/vitest.config.ts
+++ b/extensions/command-node/vitest.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vitest/config';
+import react from '@vitejs/plugin-react';
+import path from 'node:path';
+
+export default defineConfig({
+  plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, '.'),
+    },
+  },
+  test: {
+    globals: true,
+    environment: 'jsdom',
+    include: ['test/**/*.test.ts', 'test/**/*.test.tsx'],
+    setupFiles: ['./test/setup.ts'],
+  },
+});

--- a/tests/governance/test_command_node_events.py
+++ b/tests/governance/test_command_node_events.py
@@ -1,0 +1,458 @@
+"""Tests for Sovereign Command Node Phase 1: additive SSE event types + blast-radius endpoint.
+
+Covers:
+  - New EVENT_TYPE_* constants exist + correct string values
+  - publish_fsm_phase / publish_elevation_pending / publish_sovereign_yield /
+    publish_dag_node -- correct event shape
+  - All publish helpers are fail-soft (broker exception never propagates)
+  - All publish helpers are no-op when broker is None
+  - blast-radius endpoint (_handle_blast_radius) -- correct response shape
+  - blast-radius endpoint -- authority-free (no forbidden imports in module)
+  - New event types are additive (existing EVENT_TYPE_* still exist)
+  - New event types are registered in _VALID_EVENT_TYPES (publish not dropped)
+"""
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Test 1: New event type constants exist with correct string values
+# ---------------------------------------------------------------------------
+
+
+def test_new_event_type_constants_exist():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_FSM_PHASE_CHANGED,
+        EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING,
+        EVENT_TYPE_SOVEREIGN_YIELD,
+        EVENT_TYPE_DAG_NODE_UPDATED,
+    )
+    assert EVENT_TYPE_FSM_PHASE_CHANGED == "fsm_phase_changed"
+    assert EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING == "cross_repo_elevation_pending"
+    assert EVENT_TYPE_SOVEREIGN_YIELD == "sovereign_yield"
+    assert EVENT_TYPE_DAG_NODE_UPDATED == "dag_node_updated"
+
+
+# ---------------------------------------------------------------------------
+# Test 2: publish_fsm_phase publishes correct event shape
+# ---------------------------------------------------------------------------
+
+
+def test_publish_fsm_phase_publishes_correct_event():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_fsm_phase,
+    )
+    mock_broker = MagicMock()
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        publish_fsm_phase("op-123", "GENERATE", "STANDARD", "NOTIFY_APPLY")
+    mock_broker.publish.assert_called_once()
+    call_args = mock_broker.publish.call_args
+    event_type = call_args[0][0]
+    op_id_arg = call_args[0][1]
+    payload = call_args[0][2]
+    assert event_type == "fsm_phase_changed"
+    assert op_id_arg == "op-123"
+    assert payload["op_id"] == "op-123"
+    assert payload["phase"] == "GENERATE"
+    assert payload["route"] == "STANDARD"
+    assert payload["risk_tier"] == "NOTIFY_APPLY"
+    assert payload["schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Test 3: publish_elevation_pending publishes correct event shape
+# ---------------------------------------------------------------------------
+
+
+def test_publish_elevation_pending_publishes_correct_event():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_elevation_pending,
+    )
+    mock_broker = MagicMock()
+    blast = {"directly_affected": 2, "transitively_affected": 5}
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        publish_elevation_pending("pr-456", "jarvis-prime", blast)
+    mock_broker.publish.assert_called_once()
+    call_args = mock_broker.publish.call_args
+    event_type = call_args[0][0]
+    op_id_arg = call_args[0][1]
+    payload = call_args[0][2]
+    assert event_type == "cross_repo_elevation_pending"
+    assert op_id_arg == "pr-456"
+    assert payload["pr_id"] == "pr-456"
+    assert payload["target_repo"] == "jarvis-prime"
+    assert payload["blast_radius_summary"] == blast
+    assert payload["schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Test 4: publish_sovereign_yield publishes correct event shape
+# ---------------------------------------------------------------------------
+
+
+def test_publish_sovereign_yield_publishes_correct_event():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_sovereign_yield,
+    )
+    mock_broker = MagicMock()
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        publish_sovereign_yield("op-789", "upstream_quarantine")
+    mock_broker.publish.assert_called_once()
+    call_args = mock_broker.publish.call_args
+    event_type = call_args[0][0]
+    op_id_arg = call_args[0][1]
+    payload = call_args[0][2]
+    assert event_type == "sovereign_yield"
+    assert op_id_arg == "op-789"
+    assert payload["op_id"] == "op-789"
+    assert payload["reason"] == "upstream_quarantine"
+    assert payload["schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Test 5: publish_dag_node publishes correct event shape
+# ---------------------------------------------------------------------------
+
+
+def test_publish_dag_node_publishes_correct_event():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_dag_node,
+    )
+    mock_broker = MagicMock()
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        publish_dag_node("op-001", "node-abc", "COMPLETE")
+    mock_broker.publish.assert_called_once()
+    call_args = mock_broker.publish.call_args
+    event_type = call_args[0][0]
+    op_id_arg = call_args[0][1]
+    payload = call_args[0][2]
+    assert event_type == "dag_node_updated"
+    assert op_id_arg == "op-001"
+    assert payload["op_id"] == "op-001"
+    assert payload["node_id"] == "node-abc"
+    assert payload["state"] == "COMPLETE"
+    assert payload["schema_version"] == "1.0"
+
+
+# ---------------------------------------------------------------------------
+# Test 6: All publish helpers are fail-soft (broker exception never propagates)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_fsm_phase_fail_soft():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_fsm_phase,
+    )
+    mock_broker = MagicMock()
+    mock_broker.publish.side_effect = RuntimeError("broker exploded")
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        # Must NOT raise
+        publish_fsm_phase("op-x", "VALIDATE", "IMMEDIATE", "SAFE_AUTO")
+
+
+def test_publish_elevation_pending_fail_soft():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_elevation_pending,
+    )
+    mock_broker = MagicMock()
+    mock_broker.publish.side_effect = RuntimeError("broker exploded")
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        publish_elevation_pending("pr-x", "some-repo", {})
+
+
+def test_publish_sovereign_yield_fail_soft():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_sovereign_yield,
+    )
+    mock_broker = MagicMock()
+    mock_broker.publish.side_effect = RuntimeError("broker exploded")
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        publish_sovereign_yield("op-x", "some_reason")
+
+
+def test_publish_dag_node_fail_soft():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_dag_node,
+    )
+    mock_broker = MagicMock()
+    mock_broker.publish.side_effect = RuntimeError("broker exploded")
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability_stream.get_default_broker",
+        return_value=mock_broker,
+    ):
+        publish_dag_node("op-x", "node-x", "FAILED")
+
+
+# ---------------------------------------------------------------------------
+# Test 7: All publish helpers are no-op when broker is None
+# ---------------------------------------------------------------------------
+
+
+def test_publish_helpers_noop_when_no_broker():
+    from backend.core.ouroboros.governance import ide_observability_stream as m
+    with patch.object(m, "get_default_broker", return_value=None):
+        m.publish_fsm_phase("op-1", "APPLY", "STANDARD", "NOTIFY_APPLY")
+        m.publish_elevation_pending("pr-1", "repo-x", {})
+        m.publish_sovereign_yield("op-1", "reason")
+        m.publish_dag_node("op-1", "node-1", "PENDING")
+
+
+# ---------------------------------------------------------------------------
+# Test 8: New event types are registered in _VALID_EVENT_TYPES (not dropped)
+# ---------------------------------------------------------------------------
+
+
+def test_new_event_types_in_valid_set():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        _VALID_EVENT_TYPES,
+        EVENT_TYPE_FSM_PHASE_CHANGED,
+        EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING,
+        EVENT_TYPE_SOVEREIGN_YIELD,
+        EVENT_TYPE_DAG_NODE_UPDATED,
+    )
+    assert EVENT_TYPE_FSM_PHASE_CHANGED in _VALID_EVENT_TYPES
+    assert EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING in _VALID_EVENT_TYPES
+    assert EVENT_TYPE_SOVEREIGN_YIELD in _VALID_EVENT_TYPES
+    assert EVENT_TYPE_DAG_NODE_UPDATED in _VALID_EVENT_TYPES
+
+
+# ---------------------------------------------------------------------------
+# Test 9: publish helpers do not drop when broker validates event type
+# ---------------------------------------------------------------------------
+
+
+def test_publish_sovereign_yield_not_dropped_by_broker():
+    """Uses the real broker to confirm publish() returns a non-None event_id."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+        EVENT_TYPE_SOVEREIGN_YIELD,
+    )
+    broker = StreamEventBroker()
+    event_id = broker.publish(EVENT_TYPE_SOVEREIGN_YIELD, "op-test", {"reason": "stall"})
+    assert event_id is not None, "EVENT_TYPE_SOVEREIGN_YIELD was rejected by the broker"
+
+
+def test_publish_fsm_phase_not_dropped_by_broker():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+        EVENT_TYPE_FSM_PHASE_CHANGED,
+    )
+    broker = StreamEventBroker()
+    event_id = broker.publish(
+        EVENT_TYPE_FSM_PHASE_CHANGED,
+        "op-test",
+        {"phase": "GENERATE", "route": "STANDARD", "risk_tier": "NOTIFY_APPLY"},
+    )
+    assert event_id is not None, "EVENT_TYPE_FSM_PHASE_CHANGED was rejected by the broker"
+
+
+def test_publish_dag_node_not_dropped_by_broker():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+        EVENT_TYPE_DAG_NODE_UPDATED,
+    )
+    broker = StreamEventBroker()
+    event_id = broker.publish(
+        EVENT_TYPE_DAG_NODE_UPDATED,
+        "op-test",
+        {"node_id": "n-001", "state": "COMPLETE"},
+    )
+    assert event_id is not None, "EVENT_TYPE_DAG_NODE_UPDATED was rejected by the broker"
+
+
+def test_publish_elevation_pending_not_dropped_by_broker():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+        EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING,
+    )
+    broker = StreamEventBroker()
+    event_id = broker.publish(
+        EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING,
+        "pr-test",
+        {"target_repo": "jarvis-prime", "blast_radius_summary": {}},
+    )
+    assert event_id is not None, "EVENT_TYPE_CROSS_REPO_ELEVATION_PENDING was rejected by the broker"
+
+
+# ---------------------------------------------------------------------------
+# Test 10: blast-radius endpoint is authority-free (no forbidden imports)
+# ---------------------------------------------------------------------------
+
+
+def test_blast_radius_endpoint_authority_free():
+    """Confirms ide_observability.py does not import top-level gate modules.
+
+    Uses AST-based import analysis to avoid false positives from sub-packages
+    that contain the banned name as a substring (e.g. closure_loop_orchestrator
+    is allowed, governance.orchestrator is banned).
+    """
+    import ast
+    obs_path = (
+        "/Users/djrussell23/Documents/repos/JARVIS-AI-Agent/"
+        ".claude/worktrees/command-node-phase1/backend/core/"
+        "ouroboros/governance/ide_observability.py"
+    )
+    with open(obs_path) as f:
+        source = f.read()
+    # Exact governance module base-names banned by the authority invariant.
+    # "orchestrator" as the LAST segment (governance.orchestrator) is banned;
+    # sub-packages like closure_loop_orchestrator are allowed.
+    forbidden_bases = {
+        "orchestrator",
+        "change_engine",
+        "candidate_generator",
+        "repair_engine",
+        "iron_gate",
+        "risk_tier_floor",
+        "semantic_guardian",
+    }
+    tree = ast.parse(source)
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                last_segment = alias.name.rsplit(".", 1)[-1]
+                assert last_segment not in forbidden_bases, (
+                    "ide_observability.py must not import "
+                    + repr(alias.name) + " (authority-invariant)"
+                )
+        elif isinstance(node, ast.ImportFrom):
+            module = node.module or ""
+            last_segment = module.rsplit(".", 1)[-1]
+            assert last_segment not in forbidden_bases, (
+                "ide_observability.py must not import from "
+                + repr(module) + " (authority-invariant)"
+            )
+
+
+# ---------------------------------------------------------------------------
+# Test 11: New event types are additive (existing types unchanged)
+# ---------------------------------------------------------------------------
+
+
+def test_new_event_types_are_additive():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        EVENT_TYPE_TASK_STARTED,
+        EVENT_TYPE_TASK_COMPLETED,
+        EVENT_TYPE_HEARTBEAT,
+        EVENT_TYPE_FSM_PHASE_CHANGED,
+        EVENT_TYPE_SOVEREIGN_YIELD,
+    )
+    # Old types still exist unchanged
+    assert EVENT_TYPE_TASK_STARTED == "task_started"
+    assert EVENT_TYPE_TASK_COMPLETED == "task_completed"
+    assert EVENT_TYPE_HEARTBEAT == "heartbeat"
+    # New types also exist
+    assert EVENT_TYPE_FSM_PHASE_CHANGED == "fsm_phase_changed"
+    assert EVENT_TYPE_SOVEREIGN_YIELD == "sovereign_yield"
+
+
+# ---------------------------------------------------------------------------
+# Test 12: blast-radius endpoint route is registered in IDEObservabilityRouter
+# ---------------------------------------------------------------------------
+
+
+def test_blast_radius_route_registered():
+    """Confirms the route /observability/blast-radius/{op_id} is registered."""
+    path = (
+        "/Users/djrussell23/Documents/repos/JARVIS-AI-Agent/"
+        ".claude/worktrees/command-node-phase1/backend/core/"
+        "ouroboros/governance/ide_observability.py"
+    )
+    with open(path) as f:
+        source = f.read()
+    assert "/observability/blast-radius/{op_id}" in source, (
+        "blast-radius route not found in register_routes"
+    )
+    assert "_handle_blast_radius" in source, (
+        "_handle_blast_radius handler not found"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 13: blast-radius handler returns 403 when ide_observability disabled
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_blast_radius_handler_returns_403_when_disabled():
+    import os
+    from backend.core.ouroboros.governance.ide_observability import (
+        IDEObservabilityRouter,
+    )
+    router = IDEObservabilityRouter.__new__(IDEObservabilityRouter)
+    router._rate_tracker = {}
+
+    mock_request = MagicMock()
+    mock_request.remote = "127.0.0.1"
+    mock_request.headers = {}
+    mock_request.match_info = {"op_id": "op-test-123"}
+
+    with patch(
+        "backend.core.ouroboros.governance.ide_observability.ide_observability_enabled",
+        return_value=False,
+    ):
+        resp = await router._handle_blast_radius(mock_request)
+    # Should return 403
+    assert resp.status == 403
+
+
+# ---------------------------------------------------------------------------
+# Test 14: publish helpers are all importable (sanity import check)
+# ---------------------------------------------------------------------------
+
+
+def test_publish_helpers_importable():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        publish_fsm_phase,
+        publish_elevation_pending,
+        publish_sovereign_yield,
+        publish_dag_node,
+    )
+    assert callable(publish_fsm_phase)
+    assert callable(publish_elevation_pending)
+    assert callable(publish_sovereign_yield)
+    assert callable(publish_dag_node)
+
+
+# ---------------------------------------------------------------------------
+# Test 15: convergence_watchdog uses publish_sovereign_yield (not publish_task_event)
+# ---------------------------------------------------------------------------
+
+
+def test_convergence_watchdog_uses_publish_sovereign_yield():
+    """Confirms the upgrade in convergence_watchdog.emit_sovereign_yield."""
+    path = (
+        "/Users/djrussell23/Documents/repos/JARVIS-AI-Agent/"
+        ".claude/worktrees/command-node-phase1/backend/core/"
+        "ouroboros/governance/convergence_watchdog.py"
+    )
+    with open(path) as f:
+        source = f.read()
+    assert "publish_sovereign_yield" in source, (
+        "convergence_watchdog should import publish_sovereign_yield "
+        "(Command Node Phase 1 wire)"
+    )


### PR DESCRIPTION
Phase 1 of the Sovereign Command Node (spec: `docs/superpowers/specs/2026-06-23-sovereign-command-node.md`). **READ-ONLY, additive, no new authority** — the biometric write-path is Phase 2 (separate, security-reviewed). Reuse-first.

**Backend** (`d35c7f25`, 111 tests): additive SSE event types (`fsm_phase_changed`/`cross_repo_elevation_pending`/`sovereign_yield`/`dag_node_updated`) on the EXISTING StreamEventBroker + a read-only `GET /observability/blast-radius/{op_id}` (returns `BlastRadiusReport.to_dict()`, loopback + rate-limited + **authority-free** — no orchestrator/policy imports). Caught + fixed a pre-existing bug: `sovereign_yield` events were silently dropped (not in the valid-types set). All fail-soft, OFF-safe, backward-compatible.

**Frontend** (`ef19ae30`, **18 vitest tests + tsc strict clean, 243 pkgs installed for real**): `extensions/command-node/` Next.js mission control — `useSovereignStream` (native-fetch SSE client MIRRORED from the vscode-jarvis parser: exp-backoff+jitter reconnect, Last-Event-ID replay, bounded buffer, poll fallback — not bare EventSource) + the 11-phase FSM ribbon + live DAG canvas + the **interactive Body(blue)/Mind(amber)/Nerves(violet) blast-radius graph** (React Flow, center=mutated symbol→dependents, click→detail, cross-boundary badge) + view-only elevation queue (disabled Phase-2-biometric authorize placeholder) + connection status + sovereign_yield toasts. Env-driven config, no hardcoded localhost.

The operator can now watch the organism — DAG, FSM state, and the cross-repo blast radius — visually in the browser instead of through stdout + JSON. Phase 2 (the ECAPA voice-biometric write-path) is next, behind its own security review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Phase 1 of the Sovereign Command Node: a read-only web dashboard with a live DAG, FSM ribbon, and an interactive blast-radius graph. It’s additive and authority-free; no write path or new permissions.

- **New Features**
  - Backend: added 4 SSE events — `fsm_phase_changed`, `cross_repo_elevation_pending`, `sovereign_yield`, `dag_node_updated` — and `GET /observability/blast-radius/{op_id}`. All fail-soft and backward-compatible.
  - Dashboard: new `extensions/command-node` Next.js app showing the FSM ribbon, live DAG, Body/Mind/Nerves blast-radius graph (`reactflow`), a view-only elevation queue, connection status, and yield alerts. Env-driven config, no hardcoded localhost.
  - Streaming: resilient `useSovereignStream` using native `fetch` SSE with backoff + jitter, Last-Event-ID replay, bounded buffer, and poll fallback. Tests added across backend and frontend; TypeScript strict clean.

- **Bug Fixes**
  - Fixed `sovereign_yield` being dropped by the broker (missing from valid-types). `convergence_watchdog.emit_sovereign_yield` now uses the new publish helper.

<sup>Written for commit ef19ae30bdeb1445671c131d983eba40d6173aac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69686?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

