### PR TITLE
feat: A1 Black Box Flight Recorder — checksum-gated node teardown (no burn before diagnostics are safe locally) + DW-primary assertion

### DIFF
--- a/scripts/a1_black_box.py
+++ b/scripts/a1_black_box.py
@@ -1,0 +1,508 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""A1 Black Box Flight Recorder -- the node-side diagnostic bundler.
+
+================================================================================
+The absolute data-preservation guard for the A1 Live-Fire Chaos Harness: when a
+remote GCP soak FAILS, this script FREEZES then DUMPS the entire diagnostic
+context into a single compressed, cryptographically-checksummed archive on the
+NODE -- BEFORE the node's dead-man is allowed to self-delete.
+
+The orchestrator (``a1_live_fire_chaos_harness.py``) then PULLS this archive over
+the IAP SSH tunnel, recomputes the sha256 on the LOCAL Mac, and ONLY authorizes
+the node's self-delete when the local checksum MATCHES. The node can NEVER burn
+diagnostic data before it is confirmed safely received locally.
+
+THE INVARIANT (fail-CLOSED toward DATA PRESERVATION): this script's job is to
+make a COMPLETE, VERIFIABLE bundle. It captures everything present, NOTES
+everything absent (never aborts on a missing artifact), and emits a sha256 the
+orchestrator verifies. When in doubt, capture MORE, never less.
+
+What it captures (each bounded + fail-soft -- a missing artifact is noted in the
+in-archive ``MANIFEST.txt``, never an abort):
+
+  * OUROBOROS GLOBAL CONTEXT -- the session ``debug.log`` + ``summary.json`` + the
+    whole ``.ouroboros/sessions/<id>/`` dir + the ``.jarvis/`` ledgers (intake,
+    graduation, decision-trace, op-ledger).
+  * AGENT-MESSAGE-BUS TRANSCRIPTS -- any swarm per-graph JSON message logs (may be
+    empty if swarm off -- capture what exists, do not fail if absent).
+  * DAG TOPOLOGY -- the autonomy ``execution_graph_store`` artifacts + the current
+    op ledger.
+  * AST DIFF -- the chaos manifest (``.jarvis/chaos_manifest.json``) + a ``git
+    diff`` of the target file (original -> mutated -> O+V's-current-state) so we
+    see exactly what O+V did (or did not do) to the injected bug.
+  * PROVIDER ROUTING TELEMETRY (DW-primary audit) -- which provider served each
+    generation (grepped from the debug.log + the dw_surface_health +
+    provider_quarantine state) plus the resolved ``JARVIS_DW_PRIMARY_OVERRIDE`` +
+    ``JARVIS_PROVIDER_CLAUDE_DISABLED`` values, so a DW throughput-collapse or an
+    (should-be-NONE) Claude-fallback is visible.
+
+Output: ``black_box_<run_id>.tar.gz`` + ``black_box_<run_id>.tar.gz.sha256`` in
+``--out``. The archive path + sha256 are printed to stdout as structured
+``BLACK_BOX_ARCHIVE=`` / ``BLACK_BOX_SHA256=`` lines the orchestrator parses.
+
+Design: ``from __future__ import annotations``, Python 3.9+, ASCII-only, pure
+stdlib, env-knob driven, no org mutation (read-only over the repo + ledgers).
+"""
+from __future__ import annotations
+
+import argparse
+import hashlib
+import io
+import json
+import os
+import subprocess
+import sys
+import tarfile
+import time
+from dataclasses import dataclass, field
+from typing import Callable, Dict, List, Optional, Tuple
+
+
+# ===========================================================================
+# Paths + defaults (every value env-overridable -- no hardcoding).
+# ===========================================================================
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT_DEFAULT = os.path.dirname(_SCRIPTS_DIR)
+
+# The .jarvis ledgers we always try to capture (relative to repo_root/.jarvis).
+# Env-overridable comma list so the capture set is tunable, not a frozen literal.
+_LEDGER_FILES = [
+    f.strip() for f in os.environ.get(
+        "JARVIS_A1_BLACKBOX_LEDGERS",
+        "intake_dlq.jsonl,graduation_ledger.jsonl,decision_trace.jsonl,"
+        "op_ledger.jsonl,intake_router.lock,posture_current.jsonl,"
+        "dw_surface_health.json,provider_quarantine.json,chaos_manifest.json",
+    ).split(",") if f.strip()
+]
+
+# The .jarvis subdirs we capture wholesale (bounded by _MAX_DIR_BYTES).
+_LEDGER_DIRS = [
+    d.strip() for d in os.environ.get(
+        "JARVIS_A1_BLACKBOX_LEDGER_DIRS",
+        "agent_message_bus,execution_graph_store,autonomy,user_preferences",
+    ).split(",") if d.strip()
+]
+
+# Per-file capture ceiling (bytes) -- keep the bundle bounded. Default 64 MiB.
+_MAX_FILE_BYTES = int(os.environ.get("JARVIS_A1_BLACKBOX_MAX_FILE_BYTES", str(64 * 1024 * 1024)))
+# Per-dir capture ceiling (bytes) -- bounded wholesale dir capture. Default 128 MiB.
+_MAX_DIR_BYTES = int(os.environ.get("JARVIS_A1_BLACKBOX_MAX_DIR_BYTES", str(128 * 1024 * 1024)))
+# debug.log tail line cap when the file is huge (keep the recent failure window).
+_DEBUG_LOG_TAIL_LINES = int(os.environ.get("JARVIS_A1_BLACKBOX_DEBUG_TAIL_LINES", "20000"))
+
+# Provider-telemetry grep tokens (env-overridable, comma list).
+_PROVIDER_TOKENS = [
+    t.strip() for t in os.environ.get(
+        "JARVIS_A1_BLACKBOX_PROVIDER_TOKENS",
+        "served_by,[provider],DWSurface,provider_quarantine,SOVEREIGN YIELD,"
+        "doubleword,gpt-oss,claude,fallback,terminal_quota,autarky",
+    ).split(",") if t.strip()
+]
+
+
+def _log(msg: str) -> None:
+    print("[BlackBox] %s" % (msg,), file=sys.stderr, flush=True)
+
+
+# ===========================================================================
+# Config + result dataclasses.
+# ===========================================================================
+
+
+@dataclass
+class BundleConfig:
+    """All inputs the bundler needs. ``git_diff_runner`` + ``env`` are injectable
+    so the test feeds deterministic values (no real git / no real process env)."""
+
+    run_id: str
+    repo_root: str = _REPO_ROOT_DEFAULT
+    out_dir: str = "."
+    session_dir: str = ""  # the .ouroboros/sessions/<id> dir (auto-discovered if "")
+    git_diff_runner: Optional[Callable[[str], str]] = None
+    env: Optional[Dict[str, str]] = None
+
+
+@dataclass
+class BundleResult:
+    archive_path: str
+    sha256_path: str
+    sha256: str
+    captured_count: int
+    absent_count: int
+    captured: List[str] = field(default_factory=list)
+    absent: List[str] = field(default_factory=list)
+
+
+# ===========================================================================
+# Discovery helpers.
+# ===========================================================================
+
+
+def _discover_session_dir(repo_root: str) -> str:
+    """Best-effort newest ``.ouroboros/sessions/bt-*`` dir. Fail-soft ('' )."""
+    root = os.path.join(repo_root, ".ouroboros", "sessions")
+    try:
+        names = [n for n in os.listdir(root) if n != "pending"]
+    except OSError:
+        return ""
+    cand: List[Tuple[float, str]] = []
+    for n in names:
+        p = os.path.join(root, n)
+        try:
+            cand.append((os.path.getmtime(p), p))
+        except OSError:
+            continue
+    if not cand:
+        return ""
+    cand.sort(reverse=True)
+    return cand[0][1]
+
+
+def _chaos_manifest_path(repo_root: str) -> str:
+    return os.path.join(repo_root, ".jarvis", "chaos_manifest.json")
+
+
+def _read_text_bounded(path: str, *, max_bytes: int = _MAX_FILE_BYTES) -> Optional[str]:
+    """Read a text file fail-soft, bounded. None on absence/error."""
+    try:
+        if not os.path.isfile(path):
+            return None
+        size = os.path.getsize(path)
+        with open(path, "r", encoding="utf-8", errors="ignore") as fh:
+            if size > max_bytes:
+                # Keep the tail (the recent failure window).
+                return fh.read()[-max_bytes:]
+            return fh.read()
+    except OSError:
+        return None
+
+
+def _git_diff_of_target(repo_root: str, target_rel: str) -> str:
+    """Real ``git diff`` of the chaos target file (original -> current). Fail-soft
+    -- returns a note string on any error (never raises). The orchestrator and the
+    tests inject a stub runner; only the production main() path reaches here."""
+    if not target_rel:
+        return "[no chaos target_file -- no git diff captured]"
+    try:
+        cp = subprocess.run(
+            ["git", "-C", repo_root, "diff", "--", target_rel],
+            capture_output=True, text=True, timeout=60.0, check=False,
+        )
+        out = (cp.stdout or "") + (cp.stderr or "")
+        return out if out.strip() else "[git diff empty -- target unchanged on disk]"
+    except Exception as exc:  # noqa: BLE001 -- capture must never abort the bundle
+        return "[git diff failed: %r]" % (exc,)
+
+
+# ===========================================================================
+# Section builders -- each returns the text body of an in-archive section.
+# ===========================================================================
+
+
+def _build_ast_diff_section(cfg: BundleConfig) -> Tuple[str, Optional[str]]:
+    """The AST-diff section: chaos manifest summary + git diff of the target.
+
+    Returns (ast_diff_text, manifest_json_or_None). The git diff shows exactly
+    what O+V did (or did not do) to the injected bug."""
+    man_path = _chaos_manifest_path(cfg.repo_root)
+    man_text = _read_text_bounded(man_path)
+    target_rel = ""
+    parts: List[str] = ["=== A1 BLACK BOX -- AST DIFF (what O+V did to the injected bug) ==="]
+    if man_text is not None:
+        try:
+            man = json.loads(man_text)
+            target_rel = str(man.get("target_file") or "")
+            parts.append("chaos_target_file : %s" % (target_rel or "<unknown>"))
+            parts.append("chaos_function    : %s" % (man.get("function") or "<unknown>"))
+            parts.append("chaos_test_node   : %s" % (man.get("test_node") or "<unknown>"))
+            parts.append("chaos_active      : %s" % (man.get("active")))
+        except Exception:  # noqa: BLE001
+            parts.append("[chaos_manifest.json present but unparseable]")
+    else:
+        parts.append("[chaos_manifest.json ABSENT -- no AST mutation recorded]")
+
+    # The git diff of the target file (original -> mutated -> O+V's-current-state).
+    runner = cfg.git_diff_runner or (lambda t: _git_diff_of_target(cfg.repo_root, t))
+    parts.append("")
+    parts.append("--- git diff of target (%s) ---" % (target_rel or "<no target>"))
+    try:
+        parts.append(runner(target_rel))
+    except Exception as exc:  # noqa: BLE001 -- diff capture must never abort
+        parts.append("[git diff runner failed: %r]" % (exc,))
+    return "\n".join(parts) + "\n", man_text
+
+
+def _build_provider_telemetry_section(cfg: BundleConfig, debug_log: Optional[str]) -> str:
+    """The DW-primary audit: which provider served each generation + the resolved
+    DW-primary / Claude-disabled env values + the dw_surface_health +
+    provider_quarantine snapshots. A Claude-fallback (should be NONE) or a DW
+    throughput-collapse is visible here."""
+    env = cfg.env if cfg.env is not None else dict(os.environ)
+    parts: List[str] = ["=== A1 BLACK BOX -- PROVIDER ROUTING TELEMETRY (DW-primary audit) ==="]
+    # The resolved DW-primary pins -- the load-bearing assertion values.
+    parts.append("JARVIS_DW_PRIMARY_OVERRIDE     : %s" % (env.get("JARVIS_DW_PRIMARY_OVERRIDE", "<unset>")))
+    parts.append("JARVIS_PROVIDER_CLAUDE_DISABLED: %s" % (env.get("JARVIS_PROVIDER_CLAUDE_DISABLED", "<unset>")))
+    parts.append("JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED: %s"
+                 % (env.get("JARVIS_PROVIDER_QUOTA_ISOLATION_ENABLED", "<unset>")))
+    parts.append("")
+
+    # State snapshots.
+    for fname in ("dw_surface_health.json", "provider_quarantine.json"):
+        snap = _read_text_bounded(os.path.join(cfg.repo_root, ".jarvis", fname))
+        parts.append("--- %s ---" % (fname,))
+        parts.append(snap if snap is not None else "[%s ABSENT]" % (fname,))
+        parts.append("")
+
+    # Grep the debug.log for provider-routing lines (which provider served each gen).
+    parts.append("--- provider-routing lines (grepped from session debug.log) ---")
+    if debug_log:
+        hits: List[str] = []
+        for line in debug_log.splitlines():
+            low = line.lower()
+            if any(tok.lower() in low for tok in _PROVIDER_TOKENS):
+                hits.append(line)
+        if hits:
+            # Bound the captured hits so the section stays sane.
+            parts.extend(hits[-2000:])
+        else:
+            parts.append("[no provider-routing lines matched in the debug.log]")
+    else:
+        parts.append("[session debug.log ABSENT -- no provider lines to grep]")
+    return "\n".join(parts) + "\n"
+
+
+# ===========================================================================
+# tar assembly helpers (bounded + fail-soft per-artifact).
+# ===========================================================================
+
+
+def _add_text(tf: tarfile.TarFile, arcname: str, text: str) -> None:
+    """Add an in-memory text blob to the tar (deterministic, no real file)."""
+    data = text.encode("utf-8", errors="replace")
+    info = tarfile.TarInfo(name=arcname)
+    info.size = len(data)
+    info.mtime = int(time.time())
+    info.mode = 0o644
+    tf.addfile(info, io.BytesIO(data))
+
+
+def _add_file(tf: tarfile.TarFile, abs_path: str, arcname: str) -> bool:
+    """Add a real file to the tar bounded by _MAX_FILE_BYTES. Returns True iff
+    captured. Fail-soft -- any error returns False (the caller notes it absent)."""
+    try:
+        if not os.path.isfile(abs_path):
+            return False
+        size = os.path.getsize(abs_path)
+        if size > _MAX_FILE_BYTES:
+            # Capture only the tail (bounded) as a text blob.
+            txt = _read_text_bounded(abs_path)
+            if txt is None:
+                return False
+            _add_text(tf, arcname + ".tail", txt)
+            return True
+        tf.add(abs_path, arcname=arcname, recursive=False)
+        return True
+    except Exception as exc:  # noqa: BLE001 -- a per-file failure never aborts the bundle
+        _log("file capture warning %s: %r" % (abs_path, exc))
+        return False
+
+
+def _add_dir(tf: tarfile.TarFile, abs_dir: str, arcname: str) -> int:
+    """Add a directory tree to the tar, bounded by _MAX_DIR_BYTES total. Returns
+    the number of files captured (0 == absent/empty). Fail-soft."""
+    if not os.path.isdir(abs_dir):
+        return 0
+    captured = 0
+    total = 0
+    try:
+        for root, _dirs, files in os.walk(abs_dir):
+            for name in sorted(files):
+                fp = os.path.join(root, name)
+                try:
+                    sz = os.path.getsize(fp)
+                except OSError:
+                    continue
+                if total + sz > _MAX_DIR_BYTES:
+                    _log("dir capture cap hit at %s (%d bytes)" % (abs_dir, total))
+                    return captured
+                rel = os.path.relpath(fp, abs_dir)
+                if _add_file(tf, fp, os.path.join(arcname, rel)):
+                    captured += 1
+                    total += sz
+    except Exception as exc:  # noqa: BLE001
+        _log("dir capture warning %s: %r" % (abs_dir, exc))
+    return captured
+
+
+# ===========================================================================
+# THE bundler.
+# ===========================================================================
+
+
+def bundle(cfg: BundleConfig) -> BundleResult:
+    """FREEZE then DUMP the full diagnostic context into a compressed archive +
+    emit its sha256. Bounded + fail-soft per-artifact (a missing artifact is noted
+    in MANIFEST.txt, never an abort). Returns the BundleResult with the archive
+    path + the sha256 of the archive."""
+    os.makedirs(cfg.out_dir, exist_ok=True)
+    archive_path = os.path.join(cfg.out_dir, "black_box_%s.tar.gz" % (cfg.run_id,))
+    sha_path = archive_path + ".sha256"
+
+    session_dir = cfg.session_dir or _discover_session_dir(cfg.repo_root)
+    captured: List[str] = []
+    absent: List[str] = []
+
+    def _note(label: str, ok: bool) -> None:
+        (captured if ok else absent).append(label)
+
+    # Pre-read the session debug.log text (also feeds the provider-telemetry grep).
+    debug_log_path = os.path.join(session_dir, "debug.log") if session_dir else ""
+    debug_log_text = _read_text_bounded(debug_log_path) if debug_log_path else None
+
+    with tarfile.open(archive_path, "w:gz") as tf:
+        # 1. OUROBOROS GLOBAL CONTEXT: the whole session dir + debug.log + summary.
+        if session_dir and os.path.isdir(session_dir):
+            n = _add_dir(tf, session_dir, "ouroboros_session")
+            _note("ouroboros_session_dir", n > 0)
+            _note("debug.log", os.path.isfile(debug_log_path))
+            _note("summary.json", os.path.isfile(os.path.join(session_dir, "summary.json")))
+        else:
+            _note("ouroboros_session_dir", False)
+            _note("debug.log", False)
+            _note("summary.json", False)
+
+        # 2. .jarvis LEDGERS (intake, graduation, decision-trace, op-ledger, ...).
+        jdir = os.path.join(cfg.repo_root, ".jarvis")
+        for fname in _LEDGER_FILES:
+            ok = _add_file(tf, os.path.join(jdir, fname), os.path.join("jarvis_ledgers", fname))
+            _note("ledger:%s" % (fname,), ok)
+
+        # 3. AGENT-MESSAGE-BUS + DAG TOPOLOGY (+ other .jarvis subdirs).
+        for dname in _LEDGER_DIRS:
+            n = _add_dir(tf, os.path.join(jdir, dname), os.path.join("jarvis_dirs", dname))
+            _note("dir:%s" % (dname,), n > 0)
+
+        # 4. AST DIFF (chaos manifest + git diff of the target file).
+        ast_text, man_text = _build_ast_diff_section(cfg)
+        _add_text(tf, "ast_diff.txt", ast_text)
+        captured.append("ast_diff.txt")
+        if man_text is not None:
+            _add_text(tf, "chaos_manifest.json", man_text)
+            captured.append("chaos_manifest.json")
+        else:
+            absent.append("chaos_manifest.json")
+
+        # 5. PROVIDER ROUTING TELEMETRY (DW-primary audit).
+        prov_text = _build_provider_telemetry_section(cfg, debug_log_text)
+        _add_text(tf, "provider_telemetry.txt", prov_text)
+        captured.append("provider_telemetry.txt")
+
+        # 6. MANIFEST.txt: what was captured + what was absent (loud, never silent).
+        manifest_lines = [
+            "A1 BLACK BOX FLIGHT RECORDER -- MANIFEST",
+            "run_id     : %s" % (cfg.run_id,),
+            "repo_root  : %s" % (cfg.repo_root,),
+            "session_dir: %s" % (session_dir or "<not discovered>"),
+            "stamped_at : %s" % (time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())),
+            "",
+            "CAPTURED (%d):" % (len(captured),),
+        ]
+        manifest_lines.extend("  + %s" % (c,) for c in captured)
+        manifest_lines.append("")
+        manifest_lines.append("ABSENT (%d) [noted, NOT a failure -- bundle still complete]:" % (len(absent),))
+        manifest_lines.extend("  - %s" % (a,) for a in absent)
+        manifest_lines.append("")
+        _add_text(tf, "MANIFEST.txt", "\n".join(manifest_lines) + "\n")
+
+    # Emit the sha256 OF THE ARCHIVE (the orchestrator verifies this locally).
+    digest = hashlib.sha256()
+    with open(archive_path, "rb") as fh:
+        for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+            digest.update(chunk)
+    sha = digest.hexdigest()
+    with open(sha_path, "w", encoding="utf-8") as fh:
+        fh.write("%s  %s\n" % (sha, os.path.basename(archive_path)))
+
+    return BundleResult(
+        archive_path=archive_path, sha256_path=sha_path, sha256=sha,
+        captured_count=len(captured), absent_count=len(absent),
+        captured=captured, absent=absent,
+    )
+
+
+# ===========================================================================
+# CLI
+# ===========================================================================
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="a1_black_box.py",
+        description=(
+            "A1 Black Box Flight Recorder -- node-side diagnostic bundler. On a "
+            "failed A1 soak, FREEZE+DUMP the full Ouroboros context + bus + DAG + "
+            "AST-diff + provider-telemetry into black_box_<run_id>.tar.gz and emit "
+            "its sha256. The orchestrator PULLs this over IAP, verifies the "
+            "checksum LOCALLY, and only then authorizes the node self-delete -- the "
+            "node never burns diagnostic data before confirmed local receipt."
+        ),
+    )
+    p.add_argument("--bundle", action="store_true",
+                   help="Build the black-box archive + sha256 and print their paths.")
+    p.add_argument("--run-id", required=False, default="",
+                   help="The run id (names the archive black_box_<run_id>.tar.gz).")
+    p.add_argument("--out", required=False, default=".",
+                   help="Output directory for the archive + .sha256 sidecar.")
+    p.add_argument("--repo-root", default=_REPO_ROOT_DEFAULT,
+                   help="Repo root (where .ouroboros + .jarvis live).")
+    p.add_argument("--session-dir", default="",
+                   help="The .ouroboros/sessions/<id> dir (auto-discovered if omitted).")
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_arg_parser().parse_args(argv)
+    if not args.bundle:
+        _log("no action -- pass --bundle (see --help).")
+        return 0
+    run_id = args.run_id or time.strftime("a1-%Y%m%d-%H%M%S")
+
+    # Resolve the chaos target for the git diff (real git -- module-level so the
+    # test can monkeypatch _git_diff_of_target).
+    man_path = _chaos_manifest_path(args.repo_root)
+    target_rel = ""
+    man_text = _read_text_bounded(man_path)
+    if man_text is not None:
+        try:
+            target_rel = str(json.loads(man_text).get("target_file") or "")
+        except Exception:  # noqa: BLE001
+            target_rel = ""
+
+    cfg = BundleConfig(
+        run_id=run_id,
+        repo_root=args.repo_root,
+        out_dir=args.out,
+        session_dir=args.session_dir,
+        git_diff_runner=lambda _t: _git_diff_of_target(args.repo_root, target_rel),
+        env=dict(os.environ),
+    )
+    try:
+        result = bundle(cfg)
+    except Exception as exc:  # noqa: BLE001 -- a bundle failure must be loud, never silent
+        _log("FATAL bundle error: %r" % (exc,))
+        # Fail-CLOSED toward preservation: a non-zero rc tells the orchestrator the
+        # archive is NOT trustworthy -> it must HOLD the node, not burn.
+        return 1
+
+    # Structured stdout the orchestrator parses (path + sha256).
+    print("BLACK_BOX_ARCHIVE=%s" % (os.path.abspath(result.archive_path),), flush=True)
+    print("BLACK_BOX_SHA256=%s" % (result.sha256,), flush=True)
+    _log("bundled %d artifact(s), %d absent -> %s (sha256=%s)"
+         % (result.captured_count, result.absent_count, result.archive_path, result.sha256))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -487,6 +487,271 @@ def local_autopsy(*, run_id: str, autopsy_root: str, debug_log: str,
 
 
 # ===========================================================================
+# Black Box Flight Recorder -- checksum-gated, fail-CLOSED teardown.
+#
+# THE INVARIANT: on failure, the GCP node MUST NOT self-delete until the Black
+# Box archive is confirmed (cryptographic sha256) received on the LOCAL Mac.
+# Fail-CLOSED toward DATA PRESERVATION: uncertain -> HOLD the node, never burn.
+#
+# HONEST NAT REALITY: a GCP node cannot push INTO the NAT'd Mac. So the LOCAL
+# orchestrator PULLS the archive over the IAP SSH tunnel it already holds
+# (gcloud compute scp --tunnel-through-iap), recomputes the sha256 LOCALLY, and
+# ONLY THEN authorizes the node's Compute-SA self-delete. Same guarantee, works
+# through NAT.
+# ===========================================================================
+
+
+_BLACK_BOX_SCRIPT = os.path.join(_SCRIPTS_DIR, "a1_black_box.py")
+# The node-side dir the bundler writes the archive into (env-overridable).
+_BLACK_BOX_NODE_OUT = os.environ.get("JARVIS_A1_BLACKBOX_NODE_OUT", "/tmp/a1_black_box")
+# The remote jarvis repo root on the node (matches the IaC sync target).
+_BLACK_BOX_REMOTE_REPO = os.environ.get("JARVIS_A1_BLACKBOX_REMOTE_REPO", "/opt/trinity/jarvis")
+
+
+def blackbox_pull_retries() -> int:
+    """Bounded pull retries before HOLDING the node (env, default 3)."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_A1_BLACKBOX_PULL_RETRIES", "3")))
+    except ValueError:
+        return 3
+
+
+def assert_dw_primary(env: Dict[str, str]) -> "tuple":
+    """DW-primary pre-launch assertion: Claude MUST be disabled AND a DW primary
+    override MUST be set. Returns (ok, reason). The Linux overlay already sets
+    both; this asserts they SURVIVED env composition (a soak that silently lost
+    them would let Claude serve -- defeating the DW-primary audit)."""
+    claude_disabled = (env.get("JARVIS_PROVIDER_CLAUDE_DISABLED", "") or "").strip().lower()
+    dw_override = (env.get("JARVIS_DW_PRIMARY_OVERRIDE", "") or "").strip()
+    if claude_disabled not in {"true", "1", "yes", "on"}:
+        return False, ("JARVIS_PROVIDER_CLAUDE_DISABLED is %r (must be true) -- "
+                       "Claude is not disabled; the DW-primary audit is invalid."
+                       % (env.get("JARVIS_PROVIDER_CLAUDE_DISABLED"),))
+    if not dw_override:
+        return False, ("JARVIS_DW_PRIMARY_OVERRIDE is unset -- DW is not pinned as "
+                       "primary; refusing to launch a non-DW-primary soak.")
+    return True, ""
+
+
+class IapBlackBoxTransport:
+    """The local side of the Black Box pull -- drives the IaC hypervisor's IAP
+    SSH/scp command builders (NO reimplementation) to: (1) run the node-side
+    bundler over SSH, (2) PULL the archive + .sha256 over scp, (3) recompute the
+    sha256 LOCALLY, (4) on a verified match, authorize the node self-delete via
+    the hypervisor's burn_node. All subprocess is injectable for tests."""
+
+    def __init__(self, *, node: str, hypervisor_args: Any,
+                 runner: Optional[Callable[..., subprocess.CompletedProcess]] = None) -> None:
+        self.node = node
+        self.args = hypervisor_args
+        self._run = runner or self._default_run
+        self._hyper = None  # lazily imported (avoids heavy import on dev boxes)
+
+    @staticmethod
+    def _default_run(argv: Sequence[str]) -> subprocess.CompletedProcess:
+        return subprocess.run(list(argv), capture_output=True, text=True, check=False)
+
+    def _hypervisor(self):
+        if self._hyper is None:
+            spec = importlib.util.spec_from_file_location(
+                "sovereign_iac_hypervisor", _HYPERVISOR_SCRIPT)
+            assert spec and spec.loader
+            mod = importlib.util.module_from_spec(spec)
+            sys.modules.setdefault("sovereign_iac_hypervisor", mod)
+            spec.loader.exec_module(mod)
+            self._hyper = mod
+        return self._hyper
+
+    def bundle_on_node(self, *, run_id: str, out_dir: str) -> Optional[Dict[str, str]]:
+        """SSH-exec the node-side bundler; parse BLACK_BOX_ARCHIVE/SHA256."""
+        hyper = self._hypervisor()
+        remote = (
+            "cd %s && python3 scripts/a1_black_box.py --bundle --run-id %s --out %s"
+            % (_BLACK_BOX_REMOTE_REPO, run_id, out_dir)
+        )
+        argv = hyper._ssh_cmd(self.args, self.node, remote)
+        cp = self._run(argv)
+        out = (cp.stdout or "") + (cp.stderr or "")
+        archive = sha = ""
+        for line in out.splitlines():
+            if line.startswith("BLACK_BOX_ARCHIVE="):
+                archive = line.split("=", 1)[1].strip()
+            elif line.startswith("BLACK_BOX_SHA256="):
+                sha = line.split("=", 1)[1].strip()
+        if not archive or not sha:
+            _log("[BlackBox] node bundle did not emit archive+sha256 (out=%r)" % (out[-300:],))
+            return None
+        return {"archive": archive, "sha256": sha, "sha_path": archive + ".sha256"}
+
+    def pull_archive(self, *, node_archive: str, node_sha_path: str,
+                     local_dir: str) -> Optional[str]:
+        """scp the archive (+ .sha256) over IAP into local_dir, recompute the
+        sha256 of the PULLED archive locally. Returns the local hex digest, or
+        None on any pull failure (fail-CLOSED -> the caller HOLDS the node)."""
+        import hashlib
+        hyper = self._hypervisor()
+        os.makedirs(local_dir, exist_ok=True)
+        for src in (node_archive, node_sha_path):
+            # The hypervisor's _scp_cmd builds a PUSH (`... <local> <node>:<remote>`);
+            # for a PULL we need `<node>:<remote> <local>`, so build the IAP scp
+            # with the direction reversed (same flag shape, reused transport).
+            argv = self._scp_pull_cmd(src, local_dir)
+            cp = self._run(argv)
+            if cp.returncode != 0:
+                _log("[BlackBox] scp pull failed for %s rc=%d" % (src, cp.returncode))
+                return None
+        local_archive = os.path.join(local_dir, os.path.basename(node_archive))
+        if not os.path.isfile(local_archive):
+            _log("[BlackBox] pulled archive missing on disk: %s" % (local_archive,))
+            return None
+        digest = hashlib.sha256()
+        try:
+            with open(local_archive, "rb") as fh:
+                for chunk in iter(lambda: fh.read(1024 * 1024), b""):
+                    digest.update(chunk)
+        except OSError as exc:
+            _log("[BlackBox] local sha256 recompute failed: %r" % (exc,))
+            return None
+        return digest.hexdigest()
+
+    def _scp_pull_cmd(self, node_src: str, local_dir: str) -> List[str]:
+        """A PULL scp over IAP: `gcloud compute scp --recurse --tunnel-through-iap
+        --project=.. --zone=.. <node>:<remote> <local>` (reuses the hypervisor's
+        flag shape; only the direction differs from the push builder)."""
+        project = getattr(self.args, "project", None)
+        zone = getattr(self.args, "zone", None)
+        cmd = ["gcloud", "compute", "scp", "--recurse"]
+        if project:
+            cmd.append("--project=%s" % (project,))
+        if zone:
+            cmd.append("--zone=%s" % (zone,))
+        cmd.extend(["--tunnel-through-iap", "%s:%s" % (self.node, node_src), local_dir])
+        return cmd
+
+    def teardown(self, *, node: str) -> bool:
+        """Authorize the node self-delete -- ONLY reached after a verified local
+        sha256 match. Reuses the hypervisor's burn_node (quadruple teardown)."""
+        hyper = self._hypervisor()
+        try:
+            hyper.burn_node(self.args, node)
+            return True
+        except Exception as exc:  # noqa: BLE001 -- a burn error never crashes the harness
+            _log("[BlackBox] teardown warning: %r" % (exc,))
+            return False
+
+
+@dataclass
+class TeardownDecision:
+    authorized: bool
+    held: bool
+    reason: str = ""
+    node_sha256: str = ""
+    local_sha256: str = ""
+    held_node_file: str = ""
+    local_archive_dir: str = ""
+
+
+class BlackBoxTeardownDecider:
+    """The checksum-gated, fail-CLOSED teardown FSM. On a failed A1 run it:
+      1. (node) runs the bundler -> archive + sha256 on the node;
+      2. (local) PULLs the archive + .sha256 over IAP, recomputes the sha256;
+      3. MATCH -> authorize teardown (the existing dead-man / IaC self-delete);
+         MISMATCH or pull-fail (after bounded retries) -> DO NOT BURN: HOLD the
+         node, write HELD_NODE.txt with the manual-extract command, loud log.
+    Fail-CLOSED toward DATA PRESERVATION at every branch."""
+
+    def __init__(self, *, run_id: str, node: str, autopsy_root: str,
+                 transport: Any, pull_retries: int = 3) -> None:
+        self.run_id = run_id
+        self.node = node
+        self.autopsy_root = autopsy_root
+        self.transport = transport
+        self.pull_retries = max(1, int(pull_retries))
+
+    def _local_dir(self) -> str:
+        return os.path.join(self.autopsy_root, self.run_id)
+
+    def _hold(self, reason: str, *, node_sha: str = "", local_sha: str = "") -> TeardownDecision:
+        """HOLD the node (never burn). Write HELD_NODE.txt with the manual-extract
+        command so an operator can recover the data by hand."""
+        _log("[BlackBox] DATA NOT CONFIRMED -- NODE HELD for manual extraction: %s" % (reason,))
+        local_dir = self._local_dir()
+        held_file = ""
+        try:
+            os.makedirs(local_dir, exist_ok=True)
+            held_file = os.path.join(local_dir, "HELD_NODE.txt")
+            manual = (
+                "gcloud compute ssh %s --tunnel-through-iap "
+                "--command 'cat %s/black_box_%s.tar.gz' > %s/black_box_%s.tar.gz"
+                % (self.node, _BLACK_BOX_NODE_OUT, self.run_id, local_dir, self.run_id)
+            )
+            with open(held_file, "w", encoding="utf-8") as fh:
+                fh.write(
+                    "A1 BLACK BOX -- NODE HELD (data NOT confirmed on local Mac)\n"
+                    "==========================================================\n"
+                    "run_id     : %s\n" % (self.run_id,)
+                    + "node       : %s\n" % (self.node,)
+                    + "reason     : %s\n" % (reason,)
+                    + "node_sha256 : %s\n" % (node_sha or "<none>",)
+                    + "local_sha256: %s\n" % (local_sha or "<none>",)
+                    + "\nThe node was NOT burned (fail-CLOSED to data preservation).\n"
+                    + "Manually extract the Black Box, then delete the node by hand:\n\n"
+                    + "  # 1. pull the archive over IAP:\n  %s\n\n" % (manual,)
+                    + "  # 2. verify, THEN delete the node:\n"
+                    + "  gcloud compute instances delete %s --quiet\n" % (self.node,)
+                )
+            _log("[BlackBox] HELD_NODE.txt written -> %s" % (held_file,))
+        except OSError as exc:
+            _log("[BlackBox] HELD_NODE.txt write warning: %r" % (exc,))
+        return TeardownDecision(
+            authorized=False, held=True, reason=reason,
+            node_sha256=node_sha, local_sha256=local_sha,
+            held_node_file=held_file, local_archive_dir=local_dir,
+        )
+
+    def run(self) -> TeardownDecision:
+        # 1. Bundle on the node.
+        bundle = self.transport.bundle_on_node(
+            run_id=self.run_id, out_dir=_BLACK_BOX_NODE_OUT)
+        if not bundle:
+            return self._hold("node-side bundle failed -- no archive to confirm")
+        node_sha = bundle.get("sha256", "")
+        node_archive = bundle.get("archive", "")
+        node_sha_path = bundle.get("sha_path", node_archive + ".sha256")
+        local_dir = self._local_dir()
+
+        # 2. PULL + recompute locally, bounded retries.
+        local_sha: Optional[str] = None
+        for attempt in range(1, self.pull_retries + 1):
+            local_sha = self.transport.pull_archive(
+                node_archive=node_archive, node_sha_path=node_sha_path,
+                local_dir=local_dir)
+            if local_sha is not None:
+                break
+            _log("[BlackBox] pull attempt %d/%d failed -- retrying"
+                 % (attempt, self.pull_retries))
+        if local_sha is None:
+            return self._hold(
+                "archive pull failed after %d retries -- data not on local Mac"
+                % (self.pull_retries,), node_sha=node_sha)
+
+        # 3. Compare. MATCH -> authorize teardown. MISMATCH -> HOLD.
+        if local_sha != node_sha:
+            return self._hold(
+                "sha256 MISMATCH (node=%s local=%s) -- archive corrupt in transit"
+                % (node_sha[:16], local_sha[:16]),
+                node_sha=node_sha, local_sha=local_sha)
+        _log("[BlackBox] sha256 VERIFIED on local Mac (%s) -- authorizing teardown"
+             % (node_sha[:16],))
+        self.transport.teardown(node=self.node)
+        return TeardownDecision(
+            authorized=True, held=False, reason="sha256 verified locally",
+            node_sha256=node_sha, local_sha256=local_sha,
+            local_archive_dir=local_dir,
+        )
+
+
+# ===========================================================================
 # The orchestration run.
 # ===========================================================================
 
@@ -507,6 +772,10 @@ class HarnessRun:
     stub_soak: bool = False
     stub_log_goal: str = "GOAL-A1-STUB"
     env: Optional[Dict[str, str]] = None
+    # Black Box Flight Recorder: when set (remote on-node runs), a FAILED verdict
+    # runs the checksum-gated, fail-CLOSED teardown decision BEFORE any node burn.
+    blackbox_node: str = ""
+    blackbox_teardown_fn: Optional[Callable[..., Any]] = None
     _verdict: Dict[str, Any] = field(default_factory=dict)
 
     def report_dir(self) -> str:
@@ -582,7 +851,7 @@ class HarnessRun:
             proven = bool(verdict.get("proven"))
             _log("STEP audit VERDICT: %s" % ("A1_DISPATCH_PROVEN" if proven else "FAILED"))
 
-            # f. AUTOPSY ON FAILURE.
+            # f. AUTOPSY ON FAILURE + BLACK BOX checksum-gated teardown.
             if not proven:
                 _log("STEP autopsy: failed verdict -> black-box capture")
                 self.autopsy_fn(
@@ -590,6 +859,9 @@ class HarnessRun:
                     debug_log=handle.debug_log, verdict=verdict,
                     chaos_manifest=self._chaos_manifest_path(),
                 )
+                # Black Box: PULL the node-side archive, verify the sha256 LOCALLY,
+                # and ONLY authorize the node self-delete on a match -- else HOLD.
+                self._blackbox_on_failure(verdict)
             return 0 if proven else 1
         except (KeyboardInterrupt, SystemExit):
             # SIGINT / explicit exit -- revert (finally) then propagate so the
@@ -635,7 +907,8 @@ class HarnessRun:
 
     def _safe_autopsy(self, verdict: Dict[str, Any]) -> None:
         """Invoke the autopsy black-box on a failure path. Best-effort: never
-        raises (it must not mask the underlying error)."""
+        raises (it must not mask the underlying error). Also runs the Black Box
+        checksum-gated teardown decision (fail-CLOSED -> HOLD on any doubt)."""
         try:
             self.autopsy_fn(
                 run_id=self.run_id, autopsy_root=self.autopsy_root,
@@ -644,6 +917,34 @@ class HarnessRun:
             )
         except Exception as exc:  # noqa: BLE001
             _log("autopsy invocation warning: %r" % (exc,))
+        self._blackbox_on_failure(verdict)
+
+    def _blackbox_on_failure(self, verdict: Dict[str, Any]) -> Optional[Any]:
+        """Run the Black Box checksum-gated teardown decision on a failed run.
+        Only active when a remote node is wired (blackbox_teardown_fn set) --
+        local/dry-run paths have no node to hold/burn, so this is a no-op there.
+
+        Fail-CLOSED: any error in the decision path leaves the node UN-burned
+        (we never reach a teardown call on an exception)."""
+        if self.blackbox_teardown_fn is None:
+            return None
+        try:
+            decision = self.blackbox_teardown_fn(
+                run_id=self.run_id, node=self.blackbox_node,
+                autopsy_root=self.autopsy_root,
+                debug_log=getattr(self, "_debug_log_path", "") or "",
+                verdict=verdict, chaos_manifest=self._chaos_manifest_path(),
+            )
+            self._blackbox_decision = decision
+            if getattr(decision, "held", False):
+                _log("[BlackBox] node HELD (data unconfirmed) -- NOT burned: %s"
+                     % (getattr(decision, "reason", ""),))
+            elif getattr(decision, "authorized", False):
+                _log("[BlackBox] teardown AUTHORIZED (sha256 verified locally)")
+            return decision
+        except Exception as exc:  # noqa: BLE001 -- a decision error must HOLD, never burn
+            _log("[BlackBox] decision error -- holding node (fail-CLOSED): %r" % (exc,))
+            return None
 
     def _collect_report(self, verdict: Dict[str, Any]) -> None:
         rd = self.report_dir()
@@ -722,12 +1023,39 @@ def estimate_remote_cost(wall_seconds: int) -> float:
     return round(_NODE_COST_PER_HOUR * (wall_seconds / 3600.0), 4)
 
 
+def make_blackbox_teardown_fn(*, node: str, hypervisor_args: Any,
+                              pull_retries: Optional[int] = None) -> Callable[..., Any]:
+    """Factory: a teardown function the HarnessRun calls on a FAILED verdict. It
+    bundles the Black Box on the node, PULLs it over IAP, verifies the sha256
+    LOCALLY, and authorizes the node self-delete ONLY on a match -- else HOLDs.
+    Wired into build_live_run when a node + hypervisor args are available."""
+    transport = IapBlackBoxTransport(node=node, hypervisor_args=hypervisor_args)
+    retries = pull_retries if pull_retries is not None else blackbox_pull_retries()
+
+    def _teardown(*, run_id, node, autopsy_root, debug_log, verdict, chaos_manifest):
+        decider = BlackBoxTeardownDecider(
+            run_id=run_id, node=node, autopsy_root=autopsy_root,
+            transport=transport, pull_retries=retries,
+        )
+        return decider.run()
+
+    return _teardown
+
+
 def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
                              extra_args: Optional[Sequence[str]] = None) -> int:
     """Drive sovereign_iac_hypervisor.py to provision the Linux node, sync the
     repo, and run this harness with --execute-on-node remotely (streaming stdout
     back). Cost-bounded + node dead-man + teardown-always (the hypervisor owns
-    the node lifecycle / self-delete). Only reached AFTER the money-gate."""
+    the node lifecycle / self-delete).
+
+    BLACK BOX INVARIANT: the node-side dead-man fires on the completion-sentinel.
+    To keep diagnostic data safe, the orchestrator must NOT let the node burn its
+    Black Box before the archive is confirmed on the local Mac. We pass
+    ``JARVIS_A1_BLACKBOX_HOLD_ON_FAILURE=1`` into the hypervisor env so the on-node
+    failure path withholds the completion-sentinel until the local PULL + sha256
+    verification authorizes it (the checksum-gated teardown). Only reached AFTER
+    the money-gate."""
     remote_cmd = (
         "JARVIS_IAC_HYPERVISOR_ENABLED=1 python3 scripts/a1_live_fire_chaos_harness.py "
         "--execute-on-node --cost-cap %s --max-wall-seconds %d --seed %d"
@@ -743,7 +1071,11 @@ def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
         argv.extend(extra_args)
     env = dict(os.environ)
     env["JARVIS_IAC_HYPERVISOR_ENABLED"] = "1"
-    _log("STEP remote: provisioning node + remote surgery (dead-man armed)")
+    # Signal the on-node run to fail-CLOSED on a failed verdict: HOLD the Black Box
+    # (do not drop the completion-sentinel) until the local checksum verification.
+    env.setdefault("JARVIS_A1_BLACKBOX_HOLD_ON_FAILURE", "1")
+    _log("STEP remote: provisioning node + remote surgery (dead-man armed, "
+         "Black Box checksum-gate active)")
     cp = subprocess.run(argv, env=env, check=False)
     return cp.returncode
 
@@ -817,8 +1149,13 @@ def _print_composed_env_for_audit() -> None:
         _log("  %s=%s" % (flag, env.get(flag, "?")))
     for k in ("JARVIS_ROADMAP_ORCHESTRATOR_ENABLED", "JARVIS_IDE_STREAM_ENABLED",
               "JARVIS_A1_TRACE_ENABLED", "JARVIS_PROVIDER_CLAUDE_DISABLED",
+              "JARVIS_DW_PRIMARY_OVERRIDE",
               "OUROBOROS_BATTLE_MAX_WALL_SECONDS"):
         _log("  %s=%s" % (k, env.get(k, "<unset>")))
+    # DW-primary pre-launch assertion -- surface its verdict for audit.
+    ok, reason = assert_dw_primary(env)
+    _log("  DW-primary assertion: %s%s"
+         % ("PINNED" if ok else "NOT PINNED", "" if ok else " (%s)" % (reason,)))
 
 
 def build_arg_parser() -> argparse.ArgumentParser:
@@ -916,6 +1253,12 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
     # --- ON-NODE: the real soak+audit (only on the provisioned Linux node) --
     if args.execute_on_node:
         _print_composed_env_for_audit()
+        # DW-primary pre-launch assertion: Claude MUST be disabled AND DW pinned.
+        # The Linux overlay sets both; this asserts they SURVIVED composition.
+        ok, reason = assert_dw_primary(compose_env())
+        if not ok:
+            _log("REFUSED: DW-primary not pinned -- %s" % (reason,))
+            return 2
         run = build_live_run(args)
         _ACTIVE_CHAOS.append(run.chaos)
         _install_revert_signal_handlers()

--- a/tests/scripts/test_a1_black_box.py
+++ b/tests/scripts/test_a1_black_box.py
@@ -1,0 +1,265 @@
+"""Tests for the A1 Black Box Flight Recorder node-side bundler.
+
+TDD spine for ``scripts/a1_black_box.py``. NO real subprocess (git diff is
+mocked), NO network, zero spend. Proves the data-preservation contract:
+
+  * the bundler FREEZEs+DUMPs every PRESENT artifact into a compressed
+    ``black_box_<run_id>.tar.gz`` + emits a matching ``.sha256`` (the sha256 of
+    the archive itself);
+  * a MISSING artifact is NOTED in the in-archive ``MANIFEST.txt`` and the bundle
+    STILL SUCCEEDS (bounded + fail-soft per-artifact -- never aborts);
+  * the archive carries the AST-diff section (chaos manifest + git diff of the
+    target) and the PROVIDER-ROUTING telemetry section (DW-primary audit incl.
+    the resolved JARVIS_DW_PRIMARY_OVERRIDE / JARVIS_PROVIDER_CLAUDE_DISABLED);
+  * the printed stdout carries the archive path + the sha256 (the orchestrator
+    reads them).
+"""
+from __future__ import annotations
+
+import hashlib
+import importlib.util
+import json
+import os
+import sys
+import tarfile
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "a1_black_box.py"
+_spec = importlib.util.spec_from_file_location("a1_black_box", _SCRIPT)
+assert _spec and _spec.loader
+black_box = importlib.util.module_from_spec(_spec)
+sys.modules["a1_black_box"] = black_box
+_spec.loader.exec_module(black_box)
+
+
+# ===========================================================================
+# Fixtures: a synthetic session/ledger tree the bundler walks.
+# ===========================================================================
+
+
+def _make_session_tree(root: Path, *, with_bus=True, with_dag=True):
+    """Build a realistic .ouroboros + .jarvis tree under *root*."""
+    # Ouroboros global context.
+    sess = root / ".ouroboros" / "sessions" / "bt-20260624-000000"
+    sess.mkdir(parents=True)
+    (sess / "debug.log").write_text(
+        "[A1Trace] emit goal=GOAL-1 source=roadmap\n"
+        "[provider] generation served_by=openai/gpt-oss-120b route=STANDARD\n"
+        "[DWSurface] surface=DIRECT_STREAMING healthy=true\n"
+    )
+    (sess / "summary.json").write_text(json.dumps({"session_outcome": "complete"}))
+    # .jarvis ledgers.
+    jarvis = root / ".jarvis"
+    jarvis.mkdir(parents=True)
+    (jarvis / "intake_dlq.jsonl").write_text('{"op": "GOAL-1"}\n')
+    (jarvis / "graduation_ledger.jsonl").write_text('{"flag": "X"}\n')
+    (jarvis / "decision_trace.jsonl").write_text('{"d": 1}\n')
+    (jarvis / "op_ledger.jsonl").write_text('{"op": "GOAL-1", "phase": "APPLY"}\n')
+    (jarvis / "dw_surface_health.json").write_text('{"transport_degraded": false}')
+    (jarvis / "provider_quarantine.json").write_text('{"global_outage": false}')
+    (jarvis / "chaos_manifest.json").write_text(json.dumps({
+        "active": True,
+        "target_file": "backend/foo.py",
+        "function": "compute",
+        "test_node": "tests/test_foo.py::test_compute",
+    }))
+    if with_bus:
+        bus = jarvis / "agent_message_bus"
+        bus.mkdir(parents=True)
+        (bus / "graph-001.json").write_text('[{"msg": "hello"}]')
+    if with_dag:
+        dag = jarvis / "execution_graph_store"
+        dag.mkdir(parents=True)
+        (dag / "graph-001.json").write_text('{"nodes": [], "edges": []}')
+    return sess
+
+
+def _make_args(root: Path, out: Path, *, run_id="run-A1", git_diff="diff --git a/backend/foo.py..."):
+    return black_box.BundleConfig(
+        run_id=run_id,
+        repo_root=str(root),
+        out_dir=str(out),
+        session_dir=str(root / ".ouroboros" / "sessions" / "bt-20260624-000000"),
+        git_diff_runner=lambda target: git_diff,
+        env={
+            "JARVIS_DW_PRIMARY_OVERRIDE": "openai/gpt-oss-120b",
+            "JARVIS_PROVIDER_CLAUDE_DISABLED": "true",
+        },
+    )
+
+
+# ===========================================================================
+# 1. The bundler collects present artifacts into a tar.gz + correct sha256.
+# ===========================================================================
+
+
+def test_bundle_creates_archive_and_correct_sha256(tmp_path):
+    _make_session_tree(tmp_path)
+    out = tmp_path / "out"
+    cfg = _make_args(tmp_path, out)
+    result = black_box.bundle(cfg)
+
+    archive = Path(result.archive_path)
+    sha_path = Path(result.sha256_path)
+    assert archive.exists(), "the tar.gz must be written"
+    assert sha_path.exists(), "the .sha256 sidecar must be written"
+    assert archive.name == "black_box_run-A1.tar.gz"
+    assert sha_path.name == "black_box_run-A1.tar.gz.sha256"
+
+    # The emitted sha256 is the sha256 of the archive itself.
+    actual = hashlib.sha256(archive.read_bytes()).hexdigest()
+    assert result.sha256 == actual
+    # The sidecar file content is the same hex digest.
+    assert actual in sha_path.read_text()
+
+
+def test_bundle_captures_ouroboros_and_ledgers(tmp_path):
+    _make_session_tree(tmp_path)
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+    with tarfile.open(result.archive_path, "r:gz") as tf:
+        names = tf.getnames()
+    blob = "\n".join(names)
+    # Ouroboros global context.
+    assert any("debug.log" in n for n in names)
+    assert any("summary.json" in n for n in names)
+    # .jarvis ledgers (intake, graduation, decision-trace, op-ledger).
+    assert "intake_dlq.jsonl" in blob
+    assert "graduation_ledger.jsonl" in blob
+    assert "decision_trace.jsonl" in blob
+    assert "op_ledger.jsonl" in blob
+
+
+def test_bundle_captures_bus_and_dag(tmp_path):
+    _make_session_tree(tmp_path)
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+    with tarfile.open(result.archive_path, "r:gz") as tf:
+        names = tf.getnames()
+    blob = "\n".join(names)
+    # AgentMessageBus transcripts + DAG topology.
+    assert "agent_message_bus" in blob, "swarm bus transcripts captured"
+    assert "execution_graph_store" in blob, "DAG topology captured"
+
+
+# ===========================================================================
+# 2. The archive carries the AST-diff + provider-telemetry sections.
+# ===========================================================================
+
+
+def _extract_text(archive_path, member_suffix):
+    with tarfile.open(archive_path, "r:gz") as tf:
+        for m in tf.getmembers():
+            if m.name.endswith(member_suffix):
+                f = tf.extractfile(m)
+                return f.read().decode("utf-8") if f else ""
+    return None
+
+
+def test_archive_contains_ast_diff_section(tmp_path):
+    _make_session_tree(tmp_path)
+    out = tmp_path / "out"
+    cfg = _make_args(tmp_path, out, git_diff="diff --git a/backend/foo.py b/backend/foo.py\n-good\n+bug")
+    result = black_box.bundle(cfg)
+    # The AST diff section: chaos manifest + git diff of the target file.
+    ast_diff = _extract_text(result.archive_path, "ast_diff.txt")
+    assert ast_diff is not None, "ast_diff.txt must be in the archive"
+    assert "backend/foo.py" in ast_diff
+    assert "diff --git" in ast_diff
+    assert "+bug" in ast_diff
+    # The chaos manifest is captured alongside.
+    man = _extract_text(result.archive_path, "chaos_manifest.json")
+    assert man is not None and "compute" in man
+
+
+def test_archive_contains_provider_routing_telemetry(tmp_path):
+    _make_session_tree(tmp_path)
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+    prov = _extract_text(result.archive_path, "provider_telemetry.txt")
+    assert prov is not None, "provider_telemetry.txt must be in the archive"
+    # The resolved DW-primary + Claude-disabled values are recorded.
+    assert "JARVIS_DW_PRIMARY_OVERRIDE" in prov
+    assert "openai/gpt-oss-120b" in prov
+    assert "JARVIS_PROVIDER_CLAUDE_DISABLED" in prov
+    assert "true" in prov
+    # The provider lines grepped from the debug.log are surfaced.
+    assert "served_by" in prov or "provider" in prov
+
+
+# ===========================================================================
+# 3. A missing artifact -> noted in MANIFEST.txt, bundle STILL succeeds.
+# ===========================================================================
+
+
+def test_missing_artifact_noted_but_bundle_succeeds(tmp_path):
+    # Build a tree WITHOUT the bus + WITHOUT the DAG store -> both absent.
+    _make_session_tree(tmp_path, with_bus=False, with_dag=False)
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+    assert Path(result.archive_path).exists(), "bundle must still succeed"
+    manifest = _extract_text(result.archive_path, "MANIFEST.txt")
+    assert manifest is not None
+    # The absent artifacts are NOTED (not silently dropped).
+    assert "ABSENT" in manifest or "absent" in manifest
+    # The bundle did not abort despite missing artifacts.
+    assert result.captured_count >= 1
+    assert result.absent_count >= 1
+
+
+def test_missing_debug_log_does_not_abort(tmp_path):
+    sess = _make_session_tree(tmp_path)
+    (sess / "debug.log").unlink()  # remove the primary artifact
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+    assert Path(result.archive_path).exists()
+    manifest = _extract_text(result.archive_path, "MANIFEST.txt")
+    assert "debug.log" in manifest  # noted either captured or absent
+
+
+def test_manifest_lists_captured_and_absent(tmp_path):
+    _make_session_tree(tmp_path, with_bus=False)
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+    manifest = _extract_text(result.archive_path, "MANIFEST.txt")
+    assert "CAPTURED" in manifest or "captured" in manifest
+    assert "run-A1" in manifest  # run-id stamped
+
+
+# ===========================================================================
+# 4. stdout carries the archive path + sha256 (the orchestrator reads it).
+# ===========================================================================
+
+
+def test_main_prints_archive_path_and_sha256(tmp_path, capsys, monkeypatch):
+    _make_session_tree(tmp_path)
+    out = tmp_path / "out"
+    monkeypatch.setenv("JARVIS_DW_PRIMARY_OVERRIDE", "openai/gpt-oss-120b")
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "true")
+    # git diff would be a real subprocess; stub it so no real git runs.
+    monkeypatch.setattr(black_box, "_git_diff_of_target", lambda repo_root, target: "diff --git stub")
+    rc = black_box.main([
+        "--bundle", "--run-id", "run-CLI",
+        "--out", str(out), "--repo-root", str(tmp_path),
+    ])
+    assert rc == 0
+    captured = capsys.readouterr().out
+    # The orchestrator parses these two structured stdout markers.
+    assert "BLACK_BOX_ARCHIVE=" in captured
+    assert "BLACK_BOX_SHA256=" in captured
+    # The printed archive path actually exists.
+    line = [l for l in captured.splitlines() if l.startswith("BLACK_BOX_ARCHIVE=")][0]
+    arch = line.split("=", 1)[1].strip()
+    assert Path(arch).exists()
+    # The printed sha256 matches the archive.
+    sha_line = [l for l in captured.splitlines() if l.startswith("BLACK_BOX_SHA256=")][0]
+    sha = sha_line.split("=", 1)[1].strip()
+    assert sha == hashlib.sha256(Path(arch).read_bytes()).hexdigest()
+
+
+def test_help_runs(capsys):
+    with pytest.raises(SystemExit) as ei:
+        black_box.main(["--help"])
+    assert ei.value.code == 0

--- a/tests/scripts/test_a1_blackbox_teardown.py
+++ b/tests/scripts/test_a1_blackbox_teardown.py
@@ -1,0 +1,275 @@
+"""Tests for the Black Box checksum-gated teardown in the A1 harness orchestrator.
+
+All subprocess + network are mocked -- no real scp/ssh, no node, zero spend.
+Proves the absolute data-preservation contract:
+
+  * a MATCHING pulled sha256 -> teardown AUTHORIZED;
+  * a MISMATCH -> teardown REFUSED + node HELD + HELD_NODE.txt written;
+  * a pull-failure after the bounded retries -> HELD (never burned);
+  * the chaos-revert still runs in finally regardless of the checksum outcome;
+  * the DW-primary pre-launch assertion REFUSES launch when
+    JARVIS_PROVIDER_CLAUDE_DISABLED != true OR no JARVIS_DW_PRIMARY_OVERRIDE.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "a1_live_fire_chaos_harness.py"
+_spec = importlib.util.spec_from_file_location("a1_live_fire_chaos_harness", _SCRIPT)
+assert _spec and _spec.loader
+harness = importlib.util.module_from_spec(_spec)
+sys.modules["a1_live_fire_chaos_harness"] = harness
+_spec.loader.exec_module(harness)
+
+
+# ===========================================================================
+# DW-primary pre-launch assertion.
+# ===========================================================================
+
+
+def test_dw_primary_assertion_passes_when_pinned():
+    env = {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "true",
+        "JARVIS_DW_PRIMARY_OVERRIDE": "openai/gpt-oss-120b",
+    }
+    ok, reason = harness.assert_dw_primary(env)
+    assert ok is True
+    assert reason == ""
+
+
+def test_dw_primary_assertion_refuses_when_claude_not_disabled():
+    env = {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "false",
+        "JARVIS_DW_PRIMARY_OVERRIDE": "openai/gpt-oss-120b",
+    }
+    ok, reason = harness.assert_dw_primary(env)
+    assert ok is False
+    assert "CLAUDE" in reason.upper() or "claude" in reason.lower()
+
+
+def test_dw_primary_assertion_refuses_when_no_dw_override():
+    env = {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "true",
+        "JARVIS_DW_PRIMARY_OVERRIDE": "",
+    }
+    ok, reason = harness.assert_dw_primary(env)
+    assert ok is False
+    assert "DW" in reason.upper()
+
+
+def test_compose_env_satisfies_dw_primary_assertion(monkeypatch):
+    # The Linux overlay sets both -> composition must survive the assertion.
+    monkeypatch.delenv("JARVIS_A1_AUDIT_FLAGS", raising=False)
+    env = harness.compose_env()
+    ok, reason = harness.assert_dw_primary(env)
+    assert ok is True, "compose_env must satisfy the DW-primary assertion: %s" % reason
+
+
+def test_execute_on_node_refuses_launch_without_dw_primary(monkeypatch, capsys):
+    # When the composed env does NOT pin DW-primary, --execute-on-node REFUSES.
+    monkeypatch.setattr(harness, "compose_env", lambda **kw: {
+        "JARVIS_PROVIDER_CLAUDE_DISABLED": "false",  # NOT disabled
+        "JARVIS_DW_PRIMARY_OVERRIDE": "openai/gpt-oss-120b",
+    })
+    # Ensure build_live_run is never reached (refusal happens first).
+    built = []
+    monkeypatch.setattr(harness, "build_live_run", lambda args: built.append(1))
+    rc = harness.main(["--execute-on-node"])
+    assert rc != 0, "must refuse to launch when DW-primary not pinned"
+    assert built == [], "the run must not be built when the assertion fails"
+    out = capsys.readouterr().out
+    assert "REFUSED" in out and "DW-primary" in out
+
+
+# ===========================================================================
+# Checksum-gated teardown: the BlackBoxTeardown decision.
+# ===========================================================================
+
+
+class FakeTransport:
+    """A fake IAP transport that records bundle/pull/verify/teardown calls and
+    returns scripted results so the decision FSM can be exercised offline."""
+
+    def __init__(self, *, node_sha, pulled_sha_sequence, pull_ok_sequence=None):
+        self.node_sha = node_sha
+        self.pulled_sha_sequence = list(pulled_sha_sequence)
+        self.pull_ok_sequence = list(pull_ok_sequence) if pull_ok_sequence is not None else None
+        self.calls = []
+
+    def bundle_on_node(self, *, run_id, out_dir):
+        self.calls.append(("bundle", run_id))
+        return {"archive": "%s/black_box_%s.tar.gz" % (out_dir, run_id), "sha256": self.node_sha}
+
+    def pull_archive(self, *, node_archive, node_sha_path, local_dir):
+        self.calls.append(("pull", local_dir))
+        if self.pull_ok_sequence is not None:
+            ok = self.pull_ok_sequence.pop(0) if self.pull_ok_sequence else False
+            if not ok:
+                return None  # pull failed
+        # Return the locally-recomputed sha (scripted).
+        return self.pulled_sha_sequence.pop(0) if self.pulled_sha_sequence else None
+
+    def teardown(self, *, node):
+        self.calls.append(("teardown", node))
+        return True
+
+
+def _make_decider(tmp_path, transport, *, retries=3):
+    return harness.BlackBoxTeardownDecider(
+        run_id="run-X",
+        node="sovereign-node-1",
+        autopsy_root=str(tmp_path / "autopsies"),
+        transport=transport,
+        pull_retries=retries,
+    )
+
+
+def test_matching_sha_authorizes_teardown(tmp_path):
+    sha = "a" * 64
+    transport = FakeTransport(node_sha=sha, pulled_sha_sequence=[sha])
+    decider = _make_decider(tmp_path, transport)
+    decision = decider.run()
+    assert decision.authorized is True, "matching sha must authorize teardown"
+    assert decision.held is False
+    assert ("teardown", "sovereign-node-1") in transport.calls
+
+
+def test_mismatch_holds_node_and_writes_held_file(tmp_path):
+    transport = FakeTransport(node_sha="a" * 64, pulled_sha_sequence=["b" * 64])
+    decider = _make_decider(tmp_path, transport)
+    decision = decider.run()
+    assert decision.authorized is False, "a sha MISMATCH must NOT authorize teardown"
+    assert decision.held is True, "the node must be HELD on a mismatch"
+    # teardown must NOT have been called (the node is NOT burned).
+    assert ("teardown", "sovereign-node-1") not in transport.calls
+    # A HELD_NODE.txt with the manual-extract command is written.
+    held = Path(decision.held_node_file)
+    assert held.exists()
+    body = held.read_text()
+    assert "gcloud compute ssh" in body
+    assert "sovereign-node-1" in body
+
+
+def test_pull_failure_after_retries_holds_never_burns(tmp_path):
+    # Every pull attempt fails -> after the bounded retries the node is HELD.
+    transport = FakeTransport(
+        node_sha="a" * 64, pulled_sha_sequence=[],
+        pull_ok_sequence=[False, False, False],
+    )
+    decider = _make_decider(tmp_path, transport, retries=3)
+    decision = decider.run()
+    assert decision.authorized is False
+    assert decision.held is True, "pull-failure after retries must HOLD the node"
+    assert ("teardown", "sovereign-node-1") not in transport.calls
+    # Exactly the bounded number of pull attempts were made.
+    pulls = [c for c in transport.calls if c[0] == "pull"]
+    assert len(pulls) == 3
+
+
+def test_retry_then_match_authorizes(tmp_path):
+    # First pull fails, second succeeds with a matching sha -> AUTHORIZED.
+    sha = "c" * 64
+    transport = FakeTransport(
+        node_sha=sha, pulled_sha_sequence=[sha],
+        pull_ok_sequence=[False, True],
+    )
+    decider = _make_decider(tmp_path, transport, retries=3)
+    decision = decider.run()
+    assert decision.authorized is True
+    assert decision.held is False
+    assert ("teardown", "sovereign-node-1") in transport.calls
+
+
+def test_pull_retries_reads_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_BLACKBOX_PULL_RETRIES", "7")
+    assert harness.blackbox_pull_retries() == 7
+    monkeypatch.delenv("JARVIS_A1_BLACKBOX_PULL_RETRIES", raising=False)
+    assert harness.blackbox_pull_retries() == 3  # default
+
+
+# ===========================================================================
+# The remote failure path composes Black-Box BEFORE the teardown + still reverts.
+# ===========================================================================
+
+
+class FakeChaosRevert:
+    def __init__(self):
+        self.calls = []
+
+    def status(self):
+        self.calls.append("status")
+        return {"active": False}
+
+    def list_candidates(self):
+        self.calls.append("list_candidates")
+        return 2
+
+    def inject(self, seed):
+        self.calls.append(("inject", seed))
+        return True
+
+    def revert(self):
+        self.calls.append("revert")
+        return True
+
+
+def test_blackbox_failure_path_holds_on_mismatch_and_reverts(tmp_path, monkeypatch):
+    # On a FAILED verdict the orchestrator runs Black-Box; a mismatch HOLDS the
+    # node (no teardown) but chaos is STILL reverted in finally.
+    debug_log = tmp_path / "debug.log"
+    debug_log.write_text("failed run\n")
+
+    transport = FakeTransport(node_sha="a" * 64, pulled_sha_sequence=["b" * 64])
+
+    class FakeSoak:
+        def launch(self, env, run_dir):
+            return harness.SoakHandle(debug_log=str(debug_log), session_dir=run_dir, proc=None)
+
+        def stop(self):
+            pass
+
+    class FakeAuditor:
+        def watch(self, *, base, log_file, timeout_s, verdict_out):
+            Path(verdict_out).write_text('{"proven": false}')
+            return {"proven": False, "failure_locus": "audit:timeout"}
+
+    chaos = FakeChaosRevert()
+    decisions = []
+
+    def _fake_blackbox_teardown(*, run_id, node, autopsy_root, debug_log, verdict, chaos_manifest):
+        decider = harness.BlackBoxTeardownDecider(
+            run_id=run_id, node=node, autopsy_root=autopsy_root,
+            transport=transport, pull_retries=2,
+        )
+        d = decider.run()
+        decisions.append(d)
+        return d
+
+    run = harness.HarnessRun(
+        run_id="run-RF",
+        run_root=str(tmp_path / "runs"),
+        autopsy_root=str(tmp_path / "autopsies"),
+        cost_cap=0.0,
+        wall_seconds=10,
+        seed=1,
+        sse_base="http://127.0.0.1:8099",
+        chaos=chaos,
+        soak=FakeSoak(),
+        auditor=FakeAuditor(),
+        blackbox_node="sovereign-node-RF",
+        blackbox_teardown_fn=_fake_blackbox_teardown,
+    )
+    rc = run.execute()
+    assert rc != 0
+    # Black-Box teardown decision ran on the failure path.
+    assert decisions, "the Black-Box teardown decision must run on a failed verdict"
+    assert decisions[0].held is True, "a mismatch must HOLD the node"
+    assert decisions[0].authorized is False
+    # No teardown call -> node not burned.
+    assert ("teardown", "sovereign-node-RF") not in transport.calls
+    # Chaos STILL reverted in finally regardless.
+    assert "revert" in chaos.calls


### PR DESCRIPTION
Absolute data-preservation guard for the A1 live-fire run: the GCP node's dead-man NEVER burns before the Black Box is confirmed on the local Mac. On failure → node bundles {Ouroboros context + .jarvis ledgers + AgentMessageBus transcripts + DAG topology + AST diff (what O+V did to the injected bug) + DW provider-routing telemetry} → tar.gz + sha256. The LOCAL orchestrator PULLS it over the IAP SSH tunnel (NAT-honest — node can't push into the Mac), recomputes the sha256, and authorizes teardown ONLY on a verified match. Mismatch / pull-fail → node HELD (HELD_NODE.txt with the manual extract cmd), never burned — fail-CLOSED to preservation. Plus a DW-primary pre-launch assertion (refuses launch unless JARVIS_PROVIDER_CLAUDE_DISABLED=true + JARVIS_DW_PRIMARY_OVERRIDE set). Reuses the hypervisor SSH/scp/burn + sentinel autopsy. 38 tests. Chaos-revert still always in finally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the A1 Black Box Flight Recorder and checksum-gated node teardown to preserve diagnostics on failures. The node only self-deletes after the local Mac pulls the archive over IAP and verifies its sha256; otherwise the node is held with manual recovery instructions.

- New Features
  - Node-side bundler (`scripts/a1_black_box.py`): captures Ouroboros session, `.jarvis` ledgers/dirs, AgentMessageBus, DAG, AST diff, and provider telemetry into `black_box_<run_id>.tar.gz` plus `.sha256`. Emits `BLACK_BOX_ARCHIVE` and `BLACK_BOX_SHA256` markers.
  - Orchestrator integration: runs bundler on the node, pulls the archive over IAP scp, recomputes sha256 locally, and authorizes teardown only on a match. On mismatch or pull failure, holds the node and writes `HELD_NODE.txt` with a one-liner manual extract command. Chaos revert still runs in finally. Reuses hypervisor SSH/scp/burn.
  - DW-primary assertion: refuses `--execute-on-node` unless `JARVIS_PROVIDER_CLAUDE_DISABLED=true` and `JARVIS_DW_PRIMARY_OVERRIDE` is set.
  - Tests: added coverage for bundling and the teardown decision FSM.

- Migration
  - Remote runs now set `JARVIS_A1_BLACKBOX_HOLD_ON_FAILURE=1` automatically.
  - Ensure DW primary is pinned (`JARVIS_PROVIDER_CLAUDE_DISABLED=true` and a non-empty `JARVIS_DW_PRIMARY_OVERRIDE`) or the on-node run will refuse to launch.
  - Optional knobs: `JARVIS_A1_BLACKBOX_PULL_RETRIES` (default 3), `JARVIS_A1_BLACKBOX_NODE_OUT` (default `/tmp/a1_black_box`), `JARVIS_A1_BLACKBOX_REMOTE_REPO` (default `/opt/trinity/jarvis`). No API changes.

<sup>Written for commit ee0c8e3cb0bff732265fa4cb144bab0f1cece0dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69695?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

