### PR TITLE
feat(iac): Sovereign git-clone transport — node clones the EXACT local commit over WAN (replaces the <1MB/s IAP tar-pipe that killed 3 A1 runs)

### DIFF
--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -1067,10 +1067,20 @@ def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
         "--surgery-cmd", remote_cmd,
         "--surgery-timeout-s", str(wall_seconds + 600),
     ]
+    # --on-demand pass-through (env-gated): provision a STANDARD (no Spot
+    # preemption) node for an uninterrupted multi-stage run when the operator
+    # opts in. JARVIS_IAC_ON_DEMAND in {1,true,yes} -> append --on-demand.
+    if os.environ.get("JARVIS_IAC_ON_DEMAND", "").strip().lower() in {"1", "true", "yes"}:
+        argv.append("--on-demand")
     if extra_args:
         argv.extend(extra_args)
     env = dict(os.environ)
     env["JARVIS_IAC_HYPERVISOR_ENABLED"] = "1"
+    # GIT TRANSPORT: drive Run #4 over the fast-WAN git-clone transport (the node
+    # clones origin at the EXACT local HEAD), replacing the <1MB/s IAP tar-pipe
+    # that killed 3 A1 soak runs. Env-gated / default-ON for the A1 remote path
+    # (the operator can pin tar via JARVIS_IAC_SYNC_TRANSPORT=tar before --remote).
+    env.setdefault("JARVIS_IAC_SYNC_TRANSPORT", "git")
     # Signal the on-node run to fail-CLOSED on a failed verdict: HOLD the Black Box
     # (do not drop the completion-sentinel) until the local checksum verification.
     env.setdefault("JARVIS_A1_BLACKBOX_HOLD_ON_FAILURE", "1")

--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -88,6 +88,43 @@ _DEFAULT_DEADMAN_BOOT_GRACE_S = int(os.environ.get("JARVIS_IAC_DEADMAN_BOOT_GRAC
 # The remote root the 3 repos sync into.
 _REMOTE_TRINITY_ROOT = os.environ.get("JARVIS_IAC_REMOTE_ROOT", "/opt/trinity")
 
+# --------------------------------------------------------------------------- #
+# Git-clone transport (JARVIS_IAC_SYNC_TRANSPORT=git) -- the node clones origin
+# at the EXACT local HEAD commit over FAST WAN, replacing the <1MB/s IAP tar-pipe
+# (which runs over the SSH tunnel and killed 3 A1 soak runs). 581MB over WAN is
+# ~1-2min vs ~10min+ over the tar-pipe. Parity-guaranteed: local HEAD must be on
+# origin (pushed) and the node's resulting HEAD must == the local sha. PUBLIC
+# repo -> ANONYMOUS clone, NO token.
+#
+# Bounded clone timeout (581MB over WAN ~1-2min; 300s == ample margin).
+_DEFAULT_GIT_CLONE_TIMEOUT_S = int(
+    os.environ.get("JARVIS_IAC_GIT_CLONE_TIMEOUT_S", "300")
+)
+# Strict secret-injection timeout. A node without .env is USELESS -> fail-CLOSED
+# fast (do NOT keep a secretless node warm). 30s == strict.
+_DEFAULT_SECRET_TIMEOUT_S = int(os.environ.get("JARVIS_IAC_SECRET_TIMEOUT_S", "30"))
+# The secret/untracked files git clone CANNOT bring (gitignored). Comma-separated.
+# `.env` always required; operator may add untracked sqlite / `.jarvis/*.jsonl`
+# ledgers the test needs. NEVER log the CONTENTS of these (paths ok).
+_DEFAULT_SECRET_FILES = os.environ.get("JARVIS_IAC_SECRET_FILES", ".env")
+# Overlap the deps install (reads requirements.txt -- needs NO secret) with the
+# secret injection -> faster boot. Env-gated; default ON.
+_DEFAULT_CONCURRENT_DEPS = os.environ.get("JARVIS_IAC_CONCURRENT_DEPS", "true")
+# The node-side deps install command (empty == skip gracefully). Uses a node pip
+# cache dir if cheap (PIP_CACHE_DIR) -- the main win is the concurrency overlap.
+_DEFAULT_DEPS_CMD = os.environ.get("JARVIS_IAC_DEPS_CMD", "")
+
+# Marker stamped into a sync-failure detail to classify it as a BURN failure (a
+# secret transfer failed -> the node is useless, do NOT keep-warm).
+SYNC_FAILURE_BURN = "SECRET_FAILURE_BURN"
+
+
+class GitTransportError(RuntimeError):
+    """Raised on a fail-CLOSED git-transport parity violation (HEAD not on
+    origin, or the node's checked-out HEAD != the local sha). The caller maps
+    this to a transport failure (clone/parity -> resumable keep-warm; secret ->
+    burn). NEVER carries secret file contents."""
+
 # Default rsync excludes -- keep the beam lean (env-overridable, comma-separated).
 _DEFAULT_RSYNC_EXCLUDES = os.environ.get(
     "JARVIS_IAC_RSYNC_EXCLUDES",
@@ -781,6 +818,299 @@ def _rsync_cmd(
     ]
 
 
+# --------------------------------------------------------------------------- #
+# Git-clone transport: resolve -> clone (parity) -> (concurrent: deps || secrets).
+#
+# The node clones origin at the EXACT local HEAD over fast WAN. NO hardcoded
+# `main` -- the EXACT commit being soaked + its branch are read from the local
+# repo (parity local-dev <-> remote-soak). PUBLIC repo -> anonymous clone.
+# --------------------------------------------------------------------------- #
+def _git_cmd(local_root: str, *git_args: str) -> List[str]:
+    """A local `git -C <root> <args...>` command (routed through `_run`)."""
+    return ["git", "-C", local_root, *git_args]
+
+
+def resolve_local_git_target(local_root: str) -> Tuple[str, str, str]:
+    """Resolve `(origin_url, commit_sha, branch)` for the EXACT local HEAD being
+    soaked -- and VERIFY HEAD is reachable on origin (pushed). NO hardcoded
+    branch: the commit + branch + origin url are read live from the local repo.
+
+    Parity guarantee: the node can only clone PUSHED commits, so if local HEAD is
+    NOT on origin we fail-CLOSED here (before spending a cent on a node that would
+    clone a STALE commit). Raises GitTransportError on any resolution failure or
+    when HEAD is unpushed.
+    """
+    rc, out = _run(_git_cmd(local_root, "rev-parse", "HEAD"), timeout_s=30.0)
+    if rc != 0 or not (out or "").strip():
+        raise GitTransportError(f"git rev-parse HEAD failed in {local_root}: {out.strip()[:200]}")
+    sha = out.strip().splitlines()[0].strip()
+
+    rc, out = _run(_git_cmd(local_root, "rev-parse", "--abbrev-ref", "HEAD"), timeout_s=30.0)
+    if rc != 0 or not (out or "").strip():
+        raise GitTransportError(f"git rev-parse --abbrev-ref HEAD failed in {local_root}: {out.strip()[:200]}")
+    branch = out.strip().splitlines()[0].strip()
+
+    rc, out = _run(_git_cmd(local_root, "remote", "get-url", "origin"), timeout_s=30.0)
+    if rc != 0 or not (out or "").strip():
+        raise GitTransportError(f"git remote get-url origin failed in {local_root}: {out.strip()[:200]}")
+    origin_url = out.strip().splitlines()[0].strip()
+
+    # Parity gate: HEAD MUST be on origin (the node can only clone pushed commits).
+    # Primary check: `git branch -r --contains <sha>` lists the remote branches
+    # that contain the sha; if any origin/* contains it -> pushed.
+    rc, out = _run(_git_cmd(local_root, "branch", "-r", "--contains", sha), timeout_s=30.0)
+    pushed = rc == 0 and any(
+        ln.strip().startswith("origin/") for ln in (out or "").splitlines()
+    )
+    if not pushed:
+        # Fallback: ask the remote directly via ls-remote (the sha may sit on a
+        # remote branch our local refs haven't fetched).
+        rc2, out2 = _run(_git_cmd(local_root, "ls-remote", "origin"), timeout_s=60.0)
+        pushed = rc2 == 0 and sha in (out2 or "")
+    if not pushed:
+        raise GitTransportError(
+            f"HEAD {sha} not on origin/{branch} -- push before soak "
+            f"(the node can only clone pushed commits)"
+        )
+    return origin_url, sha, branch
+
+
+def _git_clone_remote_shell(origin_url: str, commit_sha: str, remote_dir: str) -> str:
+    """The node-side shell: rm the dir, anonymous clone, checkout the EXACT sha,
+    then echo the resulting HEAD (the parity probe reads the LAST line). The repo
+    is PUBLIC -> anonymous clone, NO token. Quoted for safe SSH transport."""
+    rd = shlex.quote(remote_dir)
+    url = shlex.quote(origin_url)
+    sha = shlex.quote(commit_sha)
+    return (
+        f"rm -rf {rd} && "
+        f"git clone {url} {rd} && "
+        f"git -C {rd} checkout {sha} && "
+        f"git -C {rd} rev-parse HEAD"
+    )
+
+
+def git_clone_on_node(
+    args: argparse.Namespace, node: str, origin_url: str, commit_sha: str,
+    branch: str, remote_dir: str, log_path: Optional[pathlib.Path] = None,
+) -> Tuple[bool, str]:
+    """SSH the node to anonymously clone *origin_url*, checkout the EXACT
+    *commit_sha*, and PARITY-ASSERT the node's resulting HEAD == *commit_sha*.
+
+    Streams the clone progress as the `synced` phase (resume-aware checkpointing
+    happens in the caller on success). Bounded by JARVIS_IAC_GIT_CLONE_TIMEOUT_S.
+    On a clone rc!=0 -> returns (False, detail) (resumable). On a PARITY mismatch
+    (node HEAD != sha) -> raises GitTransportError (the caller burns -- a node on
+    the WRONG commit defeats the entire parity invariant)."""
+    timeout_s = float(getattr(
+        args, "git_clone_timeout_s", _DEFAULT_GIT_CLONE_TIMEOUT_S))
+    remote = _git_clone_remote_shell(origin_url, commit_sha, remote_dir)
+    cmd = _ssh_cmd(args, node, remote)
+    _log(f"git-clone on {node}: {origin_url}@{commit_sha[:12]} (branch {branch}) "
+         f"-> {remote_dir} (anonymous, streamed, timeout={int(timeout_s)}s)")
+    rc, captured = _run_streaming_labeled(
+        cmd, label="synced", log_path=log_path, timeout_s=timeout_s,
+    )
+    if rc != 0:
+        return False, f"git clone of {origin_url} failed rc={rc}: {''.join(captured).strip()[:300]}"
+    # Parity probe: the LAST non-empty captured line is the node's `rev-parse HEAD`.
+    node_head = ""
+    for ln in reversed(captured):
+        s = ln.strip()
+        if s:
+            node_head = s
+            break
+    if node_head != commit_sha:
+        raise GitTransportError(
+            f"node {node} HEAD parity FAILED: node checked out {node_head[:12] or '<none>'} "
+            f"but local soak commit is {commit_sha[:12]} -- mismatch, burn (no stale-commit soak)"
+        )
+    return True, f"cloned + parity-verified @ {commit_sha[:12]}"
+
+
+def _secret_files() -> List[str]:
+    """The configured secret/untracked files git clone can't bring. `.env` always
+    included even if absent from the env list (the parity-incomplete tree needs
+    it)."""
+    raw = os.environ.get("JARVIS_IAC_SECRET_FILES", _DEFAULT_SECRET_FILES)
+    files = [p.strip() for p in (raw or "").split(",") if p.strip()]
+    if ".env" not in files:
+        files.insert(0, ".env")
+    # de-dup, preserve order
+    seen: set = set()
+    out: List[str] = []
+    for f in files:
+        if f not in seen:
+            seen.add(f)
+            out.append(f)
+    return out
+
+
+def _scp_secret_push_cmd(
+    args: argparse.Namespace, node: str, local_path: str, remote_path: str,
+) -> List[str]:
+    """`gcloud compute scp` over IAP pushing a SINGLE secret file. Carries PATHS
+    only -- NEVER the file CONTENTS (no contents ever touch the argv or the log)."""
+    return [
+        "gcloud", "compute", "scp",
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--tunnel-through-iap",
+        local_path, f"{node}:{remote_path}",
+    ]
+
+
+def inject_secrets_to_node(
+    args: argparse.Namespace, node: str, remote_dir: str,
+    local_root: Optional[str] = None,
+) -> Tuple[bool, str]:
+    """Asynchronously inject the secret/untracked files the git clone CANNOT
+    bring (.env + any operator-configured untracked ledgers) into *remote_dir*.
+
+    STRICT timeout (JARVIS_IAC_SECRET_TIMEOUT_S, default 30s). FAIL-CLOSED: if ANY
+    REQUIRED secret fails to transfer (timeout / error) -> returns (False, ...) so
+    the transport FAILS and the node BURNS (a node without .env is useless -- do
+    NOT keep-warm). NEVER logs secret file CONTENTS (paths only).
+
+    `.env` is REQUIRED -- if it's missing locally the injection fails-CLOSED.
+    Operator-added extra files that are absent locally are skipped with a notice
+    (only `.env` is hard-required)."""
+    root = local_root or str(_REPO_ROOT)
+    timeout_s = float(getattr(args, "secret_timeout_s", _DEFAULT_SECRET_TIMEOUT_S))
+    for rel in _secret_files():
+        local_path = os.path.join(root, rel)
+        required = (rel == ".env")
+        if not os.path.isfile(local_path):
+            if required:
+                return False, f"required secret '{rel}' missing locally -- cannot inject (burn)"
+            _log(f"secret '{rel}' absent locally -- skipping (not required)")
+            continue
+        remote_path = remote_dir.rstrip("/") + "/" + rel
+        # Ensure the parent dir exists on the node for nested ledgers (.jarvis/..).
+        parent = os.path.dirname(rel)
+        if parent:
+            mkdir = f"mkdir -p {shlex.quote(remote_dir.rstrip('/') + '/' + parent)}"
+            _run(_ssh_cmd(args, node, mkdir), timeout_s=timeout_s)
+        _log(f"injecting secret '{rel}' -> {node}:{remote_path} (strict {int(timeout_s)}s, contents NOT logged)")
+        rc, out = _run(
+            _scp_secret_push_cmd(args, node, local_path, remote_path),
+            timeout_s=timeout_s,
+        )
+        if rc != 0:
+            # Do NOT echo `out` verbatim if it could carry contents -- scp errors
+            # are path/transport messages, but stay conservative: report rel only.
+            return False, f"secret '{rel}' transfer FAILED rc={rc} -- fail-CLOSED, burn"
+    return True, "secrets injected"
+
+
+def run_node_deps_install(
+    args: argparse.Namespace, node: str, remote_dir: str,
+    log_path: Optional[pathlib.Path] = None,
+) -> Tuple[bool, str]:
+    """Run the node-side deps install (reads requirements.txt -- needs NO secret).
+    Designed to overlap inject_secrets_to_node for a faster boot. Uses a node pip
+    cache dir (PIP_CACHE_DIR) if cheap. Empty/not-configured deps cmd -> skip
+    gracefully. Bounded by the sync timeout. Returns (ok, detail). Fail-soft."""
+    deps_cmd = os.environ.get("JARVIS_IAC_DEPS_CMD", _DEFAULT_DEPS_CMD).strip()
+    if not deps_cmd:
+        return True, "deps install skipped (no JARVIS_IAC_DEPS_CMD)"
+    cache = "export PIP_CACHE_DIR=/opt/trinity/.pip_cache; mkdir -p /opt/trinity/.pip_cache; "
+    remote = f"cd {shlex.quote(remote_dir)} && {cache}{deps_cmd}"
+    cmd = _ssh_cmd(args, node, remote)
+    _log(f"deps install on {node} (concurrent with secret injection, streamed)")
+    rc, captured = _run_streaming_labeled(
+        cmd, label="synced", log_path=log_path, timeout_s=float(args.sync_timeout_s),
+    )
+    if rc != 0:
+        return False, f"deps install failed rc={rc}: {''.join(captured).strip()[:300]}"
+    return True, "deps installed"
+
+
+def is_secret_failure(detail: str) -> bool:
+    """Classify a sync-failure *detail* as a SECRET failure (-> BURN, the node is
+    useless without .env) vs a clone/parity failure (-> resumable keep-warm). The
+    secret path stamps SYNC_FAILURE_BURN / the word 'secret' into its detail."""
+    d = (detail or "").lower()
+    return SYNC_FAILURE_BURN.lower() in d or "secret" in d
+
+
+def _git_transport_sync(
+    args: argparse.Namespace, node: str,
+    log_path: Optional[pathlib.Path] = None,
+) -> Tuple[bool, str]:
+    """Run the git-clone transport for the jarvis repo: resolve the local target
+    (parity gate) -> clone+checkout on the node (parity-assert) -> overlap the
+    deps install with the secret injection -> join.
+
+    Returns (ok, detail). Clone/parity failures are RESUMABLE (keep-warm); a
+    SECRET failure is stamped SYNC_FAILURE_BURN so the orchestrator BURNS (a node
+    without .env is useless). NEVER logs secret CONTENTS."""
+    pairs = _resolve_repo_paths(args)
+    # The git transport clones the jarvis repo (the cwd repo == origin). prime /
+    # reactor (if configured + are their own remotes) still ride the tar-pipe;
+    # the A1 soak only needs jarvis. Resolve jarvis's local root.
+    jarvis_root = ""
+    for name, local in pairs:
+        if name == "jarvis":
+            jarvis_root = local
+            break
+    if not jarvis_root:
+        return False, "jarvis repo path unset -- cannot run git transport"
+
+    remote_dir = f"{_REMOTE_TRINITY_ROOT}/jarvis"
+
+    # 1) Resolve local target + parity gate (HEAD must be pushed). fail-CLOSED.
+    try:
+        origin_url, commit_sha, branch = resolve_local_git_target(jarvis_root)
+    except GitTransportError as exc:
+        return False, f"git target resolution failed (fail-CLOSED): {exc}"
+
+    # 2) Clone + checkout on the node, parity-assert (mismatch -> burn).
+    try:
+        ok, detail = git_clone_on_node(
+            args, node, origin_url, commit_sha, branch, remote_dir, log_path=log_path,
+        )
+    except GitTransportError as exc:
+        # Parity violation == wrong-commit soak -> BURN (defeats the invariant).
+        return False, f"{SYNC_FAILURE_BURN}: parity violation -- {exc}"
+    if not ok:
+        return False, detail  # clone rc!=0 -> resumable keep-warm.
+
+    # 3) Concurrency: launch deps install ALONGSIDE the secret injection, join.
+    concurrent = os.environ.get(
+        "JARVIS_IAC_CONCURRENT_DEPS", _DEFAULT_CONCURRENT_DEPS
+    ).strip().lower() in {"1", "true", "yes", "on"}
+    deps_result: Dict[str, Tuple[bool, str]] = {}
+    secret_result: Dict[str, Tuple[bool, str]] = {}
+
+    def _deps() -> None:
+        deps_result["r"] = run_node_deps_install(args, node, remote_dir, log_path=log_path)
+
+    def _secrets() -> None:
+        secret_result["r"] = inject_secrets_to_node(
+            args, node, remote_dir, local_root=jarvis_root)
+
+    if concurrent:
+        import threading
+        t_deps = threading.Thread(target=_deps, name="iac-deps", daemon=True)
+        t_deps.start()                       # deps launched FIRST (overlaps secrets)
+        _secrets()                           # secrets run on this thread
+        t_deps.join(timeout=float(args.sync_timeout_s) + 30.0)
+    else:
+        _secrets()
+        _deps()
+
+    secret_ok, secret_detail = secret_result.get("r", (False, "secret injection did not run"))
+    deps_ok, deps_detail = deps_result.get("r", (True, "deps skipped"))
+
+    # SECRET failure -> fail-CLOSED -> BURN (the node is useless without .env).
+    if not secret_ok:
+        return False, f"{SYNC_FAILURE_BURN}: {secret_detail}"
+    # Deps failure is resumable (a re-run re-installs); do NOT burn for deps.
+    if not deps_ok:
+        return False, f"deps install failed (resumable): {deps_detail}"
+    return True, "synced"
+
+
 def _delete_node_cmd(args: argparse.Namespace, node: str) -> List[str]:
     return [
         "gcloud", "compute", "instances", "delete", node,
@@ -906,6 +1236,27 @@ def sync_repos_to_node(
     """
     transport = os.environ.get("JARVIS_IAC_SYNC_TRANSPORT", "tar").strip().lower()
     pairs = _resolve_repo_paths(args)
+    # GIT TRANSPORT: the node clones origin at the EXACT local HEAD over FAST WAN
+    # (replacing the <1MB/s IAP tar-pipe). resolve -> clone (parity) -> (concurrent
+    # deps || secret injection) -> join. Clone/parity failure = resumable keep-warm;
+    # SECRET failure = burn (a node without .env is useless). Done BEFORE the
+    # tar-pipe workspace-prep (the clone's `rm -rf && git clone` owns the dir).
+    if transport == "git":
+        # Ensure the remote root is writable by the login user (the startup-script
+        # created it as ROOT). The clone then `rm -rf`s + recreates the jarvis dir.
+        _root = shlex.quote(_REMOTE_TRINITY_ROOT)
+        _prep = (
+            f"sudo mkdir -p {_root} && "
+            f'sudo chown -R "$(id -un)":"$(id -gn)" {_root} && '
+            f"echo workspace_ready {_root}"
+        )
+        _prc, _pcap = _run_streaming_labeled(
+            _ssh_cmd(args, node, _prep), label="synced", log_path=log_path,
+            timeout_s=float(args.sync_timeout_s),
+        )
+        if _prc != 0:
+            return False, f"remote workspace prep failed rc={_prc}: {''.join(_pcap).strip()[:300]}"
+        return _git_transport_sync(args, node, log_path=log_path)
     # PREP: the startup-script created _REMOTE_TRINITY_ROOT as ROOT, so the scp/ssh
     # user cannot write into it ("stat remote: No such file or directory" / perm
     # denied). Create the per-repo subdirs + chown the whole tree to the login
@@ -1438,7 +1789,15 @@ def _execute(
             if not ok:
                 _abort(f"sync abort: {detail}")
                 abort_reason = detail
-                resumable_failure = True
+                # A SECRET failure (git transport: .env couldn't be injected, or a
+                # parity violation) is NOT resumable -- a node without .env / on the
+                # WRONG commit is useless. Leave resumable_failure False so the
+                # finally-block BURNS it (do NOT keep-warm a secretless node).
+                if is_secret_failure(detail):
+                    _log("sync failure classified SECRET/PARITY -> BURN (node useless, no keep-warm)")
+                    resumable_failure = False
+                else:
+                    resumable_failure = True
                 return 6
             data = ledger.mark_phase(data, "synced")
         else:
@@ -1604,6 +1963,15 @@ def build_parser() -> argparse.ArgumentParser:
                    help="remote air-gap compose boot (env JARVIS_IAC_BOOT_CMD; empty == folded into surgery)")
     p.add_argument("--boot-timeout-s", type=int,
                    default=int(os.environ.get("JARVIS_IAC_BOOT_TIMEOUT_S", "600")))
+    # -- git-clone transport (JARVIS_IAC_SYNC_TRANSPORT=git) --
+    p.add_argument("--git-clone-timeout-s", dest="git_clone_timeout_s", type=int,
+                   default=_DEFAULT_GIT_CLONE_TIMEOUT_S,
+                   help="bound the node-side anonymous git clone of origin@HEAD "
+                        "(env JARVIS_IAC_GIT_CLONE_TIMEOUT_S; 581MB over WAN ~1-2min)")
+    p.add_argument("--secret-timeout-s", dest="secret_timeout_s", type=int,
+                   default=_DEFAULT_SECRET_TIMEOUT_S,
+                   help="STRICT per-secret scp timeout for the .env injection "
+                        "(env JARVIS_IAC_SECRET_TIMEOUT_S; fail-CLOSED -> burn)")
     # -- checkpoint / resume (resume-don't-restart) --
     p.add_argument("--state-path", default=_DEFAULT_STATE_PATH,
                    help="checkpoint ledger path (env JARVIS_IAC_STATE_PATH)")

--- a/tests/scripts/test_a1_live_fire_harness.py
+++ b/tests/scripts/test_a1_live_fire_harness.py
@@ -325,6 +325,81 @@ def test_remote_with_money_gate_calls_hypervisor(monkeypatch):
 
 
 # ===========================================================================
+# 5b. provision_and_run_remote wires transport=git + --on-demand passthrough.
+# ===========================================================================
+
+
+def test_provision_remote_sets_transport_git(monkeypatch):
+    captured = {}
+
+    def fake_run(argv, env=None, check=False):
+        captured["argv"] = list(argv)
+        captured["env"] = dict(env or {})
+
+        class _CP:
+            returncode = 0
+        return _CP()
+
+    monkeypatch.setattr(harness.subprocess, "run", fake_run)
+    monkeypatch.delenv("JARVIS_IAC_SYNC_TRANSPORT", raising=False)
+    rc = harness.provision_and_run_remote(cost_cap=10.0, wall_seconds=3600, seed=0)
+    assert rc == 0
+    assert captured["env"].get("JARVIS_IAC_SYNC_TRANSPORT") == "git", \
+        "the A1 remote path must drive the fast-WAN git transport"
+
+
+def test_provision_remote_on_demand_passthrough_present(monkeypatch):
+    captured = {}
+
+    def fake_run(argv, env=None, check=False):
+        captured["argv"] = list(argv)
+
+        class _CP:
+            returncode = 0
+        return _CP()
+
+    monkeypatch.setattr(harness.subprocess, "run", fake_run)
+    monkeypatch.setenv("JARVIS_IAC_ON_DEMAND", "1")
+    harness.provision_and_run_remote(cost_cap=10.0, wall_seconds=3600, seed=0)
+    assert "--on-demand" in captured["argv"], \
+        "JARVIS_IAC_ON_DEMAND=1 must append --on-demand to the hypervisor argv"
+
+
+def test_provision_remote_on_demand_absent_by_default(monkeypatch):
+    captured = {}
+
+    def fake_run(argv, env=None, check=False):
+        captured["argv"] = list(argv)
+
+        class _CP:
+            returncode = 0
+        return _CP()
+
+    monkeypatch.setattr(harness.subprocess, "run", fake_run)
+    monkeypatch.delenv("JARVIS_IAC_ON_DEMAND", raising=False)
+    harness.provision_and_run_remote(cost_cap=10.0, wall_seconds=3600, seed=0)
+    assert "--on-demand" not in captured["argv"], \
+        "without JARVIS_IAC_ON_DEMAND the node stays Spot (no --on-demand)"
+
+
+def test_provision_remote_respects_operator_tar_pin(monkeypatch):
+    captured = {}
+
+    def fake_run(argv, env=None, check=False):
+        captured["env"] = dict(env or {})
+
+        class _CP:
+            returncode = 0
+        return _CP()
+
+    monkeypatch.setattr(harness.subprocess, "run", fake_run)
+    monkeypatch.setenv("JARVIS_IAC_SYNC_TRANSPORT", "tar")
+    harness.provision_and_run_remote(cost_cap=10.0, wall_seconds=3600, seed=0)
+    assert captured["env"].get("JARVIS_IAC_SYNC_TRANSPORT") == "tar", \
+        "an explicit operator tar pin must be respected (setdefault, not override)"
+
+
+# ===========================================================================
 # 6. --dry-run-local --stub-soak: A1_DISPATCH_PROVEN end-to-end (real wiring).
 # ===========================================================================
 

--- a/tests/scripts/test_iac_git_transport.py
+++ b/tests/scripts/test_iac_git_transport.py
@@ -1,0 +1,320 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Tests for the Sovereign IaC Hypervisor git-clone transport (parity-verified
+node clone over fast WAN, replacing the <1MB/s IAP tar-pipe).
+
+ALL subprocess / SSH / scp / git calls are MOCKED -- NO real network, NO real
+nodes, NO real git remotes. We assert:
+
+  * resolve_local_git_target() -> (url, sha, branch) when HEAD is pushed.
+  * HEAD-not-on-origin -> fail-CLOSED (raises).
+  * node clone+checkout asserts parity: node HEAD == sha -> ok; mismatch -> raise.
+  * secret injection success -> ok; secret timeout/failure -> transport FAILS and
+    burn_node is CALLED (node NOT kept warm -- a node without .env is useless).
+  * concurrent deps launched ALONGSIDE secrets (both invoked, deps not serialized
+    after secrets).
+  * transport=tar path unchanged (back-compat regression).
+  * secret file CONTENTS are NEVER logged (paths ok).
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import pathlib
+import sys
+import types
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_HYPERVISOR = _REPO_ROOT / "scripts" / "sovereign_iac_hypervisor.py"
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "sovereign_iac_hypervisor_under_test", str(_HYPERVISOR)
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def hyper():
+    return _load_module()
+
+
+def _args(**over):
+    base = dict(
+        project="proj-x", zone="zone-y", sync_timeout_s=300.0,
+    )
+    base.update(over)
+    return argparse.Namespace(**base)
+
+
+# --------------------------------------------------------------------------- #
+# 1. resolve_local_git_target -- (url, sha, branch) when HEAD is pushed.
+# --------------------------------------------------------------------------- #
+def test_resolve_local_git_target_returns_url_sha_branch(hyper, monkeypatch):
+    sha = "a" * 40
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        joined = " ".join(cmd)
+        if "rev-parse" in cmd and "HEAD" in cmd and "--abbrev-ref" not in cmd:
+            return 0, sha + "\n"
+        if "--abbrev-ref" in cmd:
+            return 0, "feature/foo\n"
+        if "get-url" in cmd:
+            return 0, "https://github.com/drussell23/JARVIS.git\n"
+        if "branch" in cmd and "-r" in cmd:  # contains-check: HEAD on origin
+            return 0, "  origin/feature/foo\n"
+        return 1, "[unexpected " + joined + "]"
+
+    monkeypatch.setattr(hyper, "_run", fake_run)
+    url, got_sha, branch = hyper.resolve_local_git_target(str(_REPO_ROOT))
+    assert url == "https://github.com/drussell23/JARVIS.git"
+    assert got_sha == sha
+    assert branch == "feature/foo"
+
+
+# --------------------------------------------------------------------------- #
+# 2. HEAD-not-on-origin -> fail-CLOSED.
+# --------------------------------------------------------------------------- #
+def test_resolve_fails_closed_when_head_not_on_origin(hyper, monkeypatch):
+    sha = "b" * 40
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        if "rev-parse" in cmd and "HEAD" in cmd and "--abbrev-ref" not in cmd:
+            return 0, sha + "\n"
+        if "--abbrev-ref" in cmd:
+            return 0, "feature/unpushed\n"
+        if "get-url" in cmd:
+            return 0, "https://github.com/drussell23/JARVIS.git\n"
+        # contains-check returns NOTHING -> sha not on any remote branch.
+        if "branch" in cmd and "-r" in cmd:
+            return 0, "\n"
+        if "ls-remote" in cmd:
+            return 0, "deadbeef\trefs/heads/main\n"  # sha absent
+        return 1, "[unexpected]"
+
+    monkeypatch.setattr(hyper, "_run", fake_run)
+    with pytest.raises(hyper.GitTransportError) as ei:
+        hyper.resolve_local_git_target(str(_REPO_ROOT))
+    msg = str(ei.value)
+    assert sha in msg
+    assert "not on origin" in msg.lower()
+    assert "push" in msg.lower()
+
+
+# --------------------------------------------------------------------------- #
+# 3. node clone+checkout asserts parity.
+# --------------------------------------------------------------------------- #
+def test_git_clone_on_node_parity_ok(hyper, monkeypatch):
+    sha = "c" * 40
+    captured = {}
+
+    def fake_run_streaming_labeled(cmd, *, label, log_path=None, timeout_s=3600.0):
+        captured["clone_cmd"] = cmd
+        captured["label"] = label
+        # node's resulting HEAD == sha (parity holds).
+        return 0, [sha + "\n"]
+
+    monkeypatch.setattr(hyper, "_run_streaming_labeled", fake_run_streaming_labeled)
+    ok, detail = hyper.git_clone_on_node(
+        _args(), "node-1", "https://github.com/drussell23/JARVIS.git", sha,
+        "feature/foo", "/opt/trinity/jarvis",
+    )
+    assert ok, detail
+    # The clone command is an SSH exec carrying git clone + checkout + rev-parse.
+    joined = " ".join(captured["clone_cmd"])
+    assert "git clone" in joined
+    assert "checkout " + sha in joined or sha in joined
+    assert captured["label"] == "synced"
+
+
+def test_git_clone_on_node_parity_mismatch_raises(hyper, monkeypatch):
+    sha = "c" * 40
+    wrong = "d" * 40
+
+    def fake_run_streaming_labeled(cmd, *, label, log_path=None, timeout_s=3600.0):
+        return 0, [wrong + "\n"]  # node ended up on a DIFFERENT commit.
+
+    monkeypatch.setattr(hyper, "_run_streaming_labeled", fake_run_streaming_labeled)
+    with pytest.raises(hyper.GitTransportError) as ei:
+        hyper.git_clone_on_node(
+            _args(), "node-1", "https://github.com/drussell23/JARVIS.git", sha,
+            "feature/foo", "/opt/trinity/jarvis",
+        )
+    assert "parity" in str(ei.value).lower() or "mismatch" in str(ei.value).lower()
+
+
+# --------------------------------------------------------------------------- #
+# 4. secret injection -- success, and timeout/failure -> burn.
+# --------------------------------------------------------------------------- #
+def test_inject_secrets_success(hyper, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_SECRET_FILES", ".env")
+    calls = []
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        calls.append((cmd, timeout_s))
+        return 0, "transferred\n"
+
+    monkeypatch.setattr(hyper, "_run", fake_run)
+    # Pretend the local .env exists.
+    monkeypatch.setattr(hyper.os.path, "isfile", lambda p: p.endswith(".env"))
+    ok, detail = hyper.inject_secrets_to_node(
+        _args(), "node-1", "/opt/trinity/jarvis", local_root=str(_REPO_ROOT),
+    )
+    assert ok, detail
+    assert calls, "scp must be invoked for the secret transfer"
+    # Strict 30s timeout used.
+    assert all(t <= 30.0 for _, t in calls), "secret transfer must use the strict timeout"
+
+
+def test_inject_secrets_timeout_fails_closed(hyper, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_SECRET_FILES", ".env")
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        return 1, "[run failed: TimeoutExpired]"  # transfer failed / timed out.
+
+    monkeypatch.setattr(hyper, "_run", fake_run)
+    monkeypatch.setattr(hyper.os.path, "isfile", lambda p: p.endswith(".env"))
+    ok, detail = hyper.inject_secrets_to_node(
+        _args(), "node-1", "/opt/trinity/jarvis", local_root=str(_REPO_ROOT),
+    )
+    assert not ok, "a failed secret transfer must fail-CLOSED"
+
+
+def test_git_transport_secret_failure_burns_node(hyper, monkeypatch):
+    """End-to-end: when the secret injection fails, sync_repos_to_node returns a
+    FAILURE classified as SECRET (burn), NOT a resumable keep-warm failure."""
+    sha = "e" * 40
+    monkeypatch.setenv("JARVIS_IAC_SYNC_TRANSPORT", "git")
+    monkeypatch.setenv("JARVIS_IAC_SECRET_FILES", ".env")
+    monkeypatch.setenv("JARVIS_IAC_CONCURRENT_DEPS", "false")
+
+    monkeypatch.setattr(
+        hyper, "resolve_local_git_target",
+        lambda root: ("https://github.com/drussell23/JARVIS.git", sha, "main"),
+    )
+    monkeypatch.setattr(
+        hyper, "git_clone_on_node",
+        lambda *a, **k: (True, "cloned"),
+    )
+    # The remote-prep ssh succeeds; only the secret transfer fails.
+    monkeypatch.setattr(
+        hyper, "_run_streaming_labeled",
+        lambda *a, **k: (0, ["workspace_ready\n"]),
+    )
+    monkeypatch.setattr(
+        hyper, "inject_secrets_to_node",
+        lambda *a, **k: (False, "secret .env transfer timed out"),
+    )
+    monkeypatch.setattr(hyper, "_resolve_repo_paths",
+                        lambda args: [("jarvis", str(_REPO_ROOT))])
+
+    ok, detail = hyper.sync_repos_to_node(_args(), "node-1", [".git"])
+    assert not ok, "secret failure must fail the transport"
+    assert getattr(hyper, "SYNC_FAILURE_BURN", "burn") in (detail or "") or "burn" in detail.lower() \
+        or "secret" in detail.lower()
+
+
+def test_sync_failure_secret_class_triggers_burn_not_keepwarm(hyper, monkeypatch):
+    """The orchestrator's keep-warm vs burn decision: a SECRET-class sync failure
+    must BURN (node without .env is useless), not keep-warm-for-resume."""
+    # The classifier helper -- a secret failure is NOT resumable.
+    assert hyper.is_secret_failure("secret .env transfer FAILED -- BURN") is True
+    assert hyper.is_secret_failure("clone failed rc=1 (resumable)") is False
+
+
+# --------------------------------------------------------------------------- #
+# 5. concurrent deps run ALONGSIDE secrets (not serialized after).
+# --------------------------------------------------------------------------- #
+def test_concurrent_deps_launched_alongside_secrets(hyper, monkeypatch):
+    sha = "f" * 40
+    monkeypatch.setenv("JARVIS_IAC_SYNC_TRANSPORT", "git")
+    monkeypatch.setenv("JARVIS_IAC_CONCURRENT_DEPS", "true")
+    monkeypatch.setenv("JARVIS_IAC_SECRET_FILES", ".env")
+    monkeypatch.setenv("JARVIS_IAC_DEPS_CMD", "python3 -m pip install -r requirements.txt")
+
+    order = []
+
+    monkeypatch.setattr(
+        hyper, "resolve_local_git_target",
+        lambda root: ("https://github.com/drussell23/JARVIS.git", sha, "main"),
+    )
+    monkeypatch.setattr(hyper, "git_clone_on_node", lambda *a, **k: (True, "cloned"))
+    monkeypatch.setattr(
+        hyper, "_run_streaming_labeled",
+        lambda *a, **k: (0, ["workspace_ready\n"]),
+    )
+    monkeypatch.setattr(hyper, "_resolve_repo_paths",
+                        lambda args: [("jarvis", str(_REPO_ROOT))])
+
+    def fake_inject(*a, **k):
+        order.append("secrets")
+        return True, "secrets ok"
+
+    def fake_deps(*a, **k):
+        order.append("deps")
+        return True, "deps ok"
+
+    monkeypatch.setattr(hyper, "inject_secrets_to_node", fake_inject)
+    monkeypatch.setattr(hyper, "run_node_deps_install", fake_deps)
+
+    ok, detail = hyper.sync_repos_to_node(_args(), "node-1", [".git"])
+    assert ok, detail
+    assert "secrets" in order and "deps" in order, "both deps + secrets must run"
+
+
+# --------------------------------------------------------------------------- #
+# 6. transport=tar unchanged (back-compat regression).
+# --------------------------------------------------------------------------- #
+def test_tar_transport_back_compat_unchanged(hyper, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_SYNC_TRANSPORT", "tar")
+    seen = {"tar_pipe": 0, "git_clone": 0}
+
+    monkeypatch.setattr(hyper, "_resolve_repo_paths",
+                        lambda args: [("jarvis", str(_REPO_ROOT))])
+
+    def fake_run_streaming_labeled(cmd, *, label, log_path=None, timeout_s=3600.0):
+        joined = " ".join(cmd)
+        if "tar czf" in joined:
+            seen["tar_pipe"] += 1
+        return 0, ["ok\n"]
+
+    monkeypatch.setattr(hyper, "_run_streaming_labeled", fake_run_streaming_labeled)
+
+    def fake_clone(*a, **k):
+        seen["git_clone"] += 1
+        return True, "cloned"
+
+    monkeypatch.setattr(hyper, "git_clone_on_node", fake_clone)
+
+    ok, detail = hyper.sync_repos_to_node(_args(), "node-1", [".git"])
+    assert ok, detail
+    assert seen["git_clone"] == 0, "tar transport must NOT call the git clone"
+    assert seen["tar_pipe"] >= 1, "tar transport must drive the tar-pipe"
+
+
+# --------------------------------------------------------------------------- #
+# 7. secret CONTENTS never logged.
+# --------------------------------------------------------------------------- #
+def test_secret_contents_never_logged(hyper, monkeypatch, capsys):
+    monkeypatch.setenv("JARVIS_IAC_SECRET_FILES", ".env")
+    secret_value = "SUPER_SECRET_API_KEY=sk-deadbeefcafe123456"
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        # The scp command carries PATHS only -- never the file contents.
+        assert secret_value not in " ".join(cmd), "secret CONTENTS leaked into the scp argv"
+        return 0, "transferred\n"
+
+    monkeypatch.setattr(hyper, "_run", fake_run)
+    monkeypatch.setattr(hyper.os.path, "isfile", lambda p: p.endswith(".env"))
+    hyper.inject_secrets_to_node(
+        _args(), "node-1", "/opt/trinity/jarvis", local_root=str(_REPO_ROOT),
+    )
+    out = capsys.readouterr().out
+    assert secret_value not in out, "secret CONTENTS must never be logged"


### PR DESCRIPTION
Replaces the IAP tar-pipe (proven <1 MB/s — 2.5 GB took 58 min and still timed out) with a node-side `git clone` over fast WAN. Public repo → anonymous clone, no token. 32 tests.

- **Dynamic commit parity:** resolves live local HEAD + branch (no hardcoded `main`); fail-CLOSED if HEAD isn't pushed to origin (node can only clone pushed commits). Node clones + `checkout <exact-sha>` + **asserts node HEAD == local HEAD** (parity-verified; mismatch → burn).
- **Async secret injection:** after clone, scp `.env` (+ env-configurable untracked ledgers) under a **strict 30s timeout, fail-CLOSED → BURN** (a node without secrets is useless — never kept warm). Secret contents never logged.
- **Concurrent deps:** node-side deps install runs on a background thread overlapping the secret scp (fast boot).
- **Back-compat:** tar/rsync paths untouched; `transport=git` is a new branch (env `JARVIS_IAC_SYNC_TRANSPORT`). Harness wires `transport=git` + the `--on-demand` passthrough for the A1 remote path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the slow IAP tar/rsync path with a parity-verified `git` transport: the node clones origin over WAN, checks out the exact local HEAD, then injects `.env` (and optional files) with strict timeouts. The A1 remote path now defaults to `transport=git` and passes `--on-demand` when `JARVIS_IAC_ON_DEMAND` is set.

- **New Features**
  - Parity-verified clone: resolves origin URL/branch/HEAD, requires HEAD is pushed, clones anonymously, checks out the exact SHA, and asserts the node HEAD matches.
  - Secret injection with a strict 30s timeout: scp `.env` (required) and optional files from `JARVIS_IAC_SECRET_FILES`; failure burns the node; secret contents are never logged.
  - Optional concurrent deps install: run `JARVIS_IAC_DEPS_CMD` in parallel with secrets; failure is resumable.
  - Failure policy: clone/deps failures are resumable; secret or parity violations burn (classified via `SYNC_FAILURE_BURN`).
  - Back-compat and harness wiring: tar/rsync paths unchanged; select via `JARVIS_IAC_SYNC_TRANSPORT` (`git` default in A1); operator `tar` pin respected; `--on-demand` passthrough when `JARVIS_IAC_ON_DEMAND` is set.

- **Migration**
  - Push your local HEAD before running remote; unpushed HEAD fails closed.
  - Ensure a local `.env` exists; add extra paths via `JARVIS_IAC_SECRET_FILES`.
  - To force the old path, set `JARVIS_IAC_SYNC_TRANSPORT=tar`; to use on-demand nodes, set `JARVIS_IAC_ON_DEMAND=1`.
  - Optionally set `JARVIS_IAC_DEPS_CMD` and toggle concurrency with `JARVIS_IAC_CONCURRENT_DEPS`.

<sup>Written for commit a3555cbc49bd26ab644cd2239307242aff8bf313. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69696?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

