### PR TITLE
fix(a1-harness): close the runs #4-7 live-soak tooling loci (deps + auditor + sentinel)

### DIFF
--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -191,8 +191,14 @@ def compose_env(*, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     # 1. Linux production overlay (pytest 180s, AST pool, Claude-disabled autarky).
     env.update(_parse_env_overlay(_LINUX_ENV_OVERLAY))
     # 2. Every derived cognitive flag ON.
-    for flag in derive_cognitive_flags():
+    flags = derive_cognitive_flags()
+    for flag in flags:
         env[flag] = "true"
+    # 2b. Hand the SAME derived flag set to the auditor via its override env var.
+    # The auditor's load_audit_flags() lacks the harness's AST-source fallback, so
+    # on a node where the heavy CADENCE_POLICY import fails (aiohttp path) it dies
+    # at flag_set_load (the run #7 wall) -- give it the already-derived list here.
+    env["JARVIS_A1_AUDIT_FLAGS"] = ",".join(flags)
     # 3. Orchestration-required flags (a strategic GOAL source + SSE + A1Trace).
     env["JARVIS_ROADMAP_ORCHESTRATOR_ENABLED"] = "1"
     env["JARVIS_IDE_STREAM_ENABLED"] = "1"

--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -1327,14 +1327,28 @@ def _remote_surgery_shell(args: argparse.Namespace) -> str:
         "python3 -m pip --version >/dev/null 2>&1 "
         "|| (sudo apt-get update -y -qq && sudo apt-get install -y -q python3-pip) >/dev/null 2>&1 "
         "|| (curl -fsSL https://bootstrap.pypa.io/get-pip.py | sudo python3) >/dev/null 2>&1 || true; "
-        # Filter the multi-GB ML libs the controlled harness never exercises +
-        # strip Ouroboros comment lines / drop the heavy set, keep aiohttp/fastapi/etc.
+        # Filter the multi-GB ML libs + the native-build packages a BARE Debian node
+        # cannot build (PyAudio needs portaudio; pyobjc is mac-only; webrtcvad/
+        # sounddevice need build libs) -- the A1 code-repair loop exercises NONE.
         "grep -ivE '^(#|torch|torchaudio|torchvision|tensorflow|transformers|vllm|"
         "llama|nvidia|triton|xformers|onnx|scipy|scikit|sentencepiece|accelerate|"
-        "bitsandbytes|fastembed|peft|trl|datasets)' requirements.txt > /tmp/req_light.txt 2>/dev/null "
-        "|| cp requirements.txt /tmp/req_light.txt; "
-        "sudo python3 -m pip install --break-system-packages -q -r /tmp/req_light.txt 2>&1 "
-        "| tail -4 || python3 -m pip install --user -q -r /tmp/req_light.txt 2>&1 | tail -4 || true; "
+        "bitsandbytes|fastembed|peft|trl|datasets|pyaudio|pyobjc|webrtcvad|"
+        "sounddevice|soundfile|pyttsx3|playsound)' requirements.txt "
+        # Strip INLINE comments (`pkg>=x  # note`) + trailing space so each line is a
+        # CLEAN pip spec -- else the per-package loop feeds pip `pkg # note` -> parse fail.
+        "| sed -E 's/[[:space:]]*#.*$//; s/[[:space:]]*$//' > /tmp/req_light.txt 2>/dev/null "
+        "|| sed -E 's/[[:space:]]*#.*$//; s/[[:space:]]*$//' requirements.txt > /tmp/req_light.txt; "
+        # PER-PACKAGE, continue-on-failure: a single unbuildable straggler must NOT
+        # abort the batch (the atomic `-r` did exactly that on PyAudio -> killed aiohttp).
+        "while IFS= read -r _pkg; do case \"$_pkg\" in ''|\\#*) continue;; esac; "
+        "sudo python3 -m pip install --break-system-packages -q \"$_pkg\" 2>/dev/null "
+        "|| echo \"[deps] skip unbuildable: $_pkg\"; done < /tmp/req_light.txt; "
+        # HARD-ENSURE the A1-critical core -- the loop is dead without these.
+        # pytest-asyncio is LOAD-BEARING: the repo's conftest has an autouse ASYNC
+        # fixture -- without the plugin EVERY test ERRORS at setup -> the chaos
+        # injector can never confirm a green test (the runs #4-6 wall).
+        "sudo python3 -m pip install --break-system-packages -q aiohttp httpx pydantic "
+        "pytest pytest-asyncio pyyaml requests anyio sniffio fastapi uvicorn orjson 2>&1 | tail -1; "
         "python3 -c 'import aiohttp; print(\"[deps] aiohttp ok\", aiohttp.__version__)' 2>&1 | tail -1",
     )
     # cd into the synced jarvis repo, install deps, run the surgery. The completion
@@ -1348,7 +1362,11 @@ def _remote_surgery_shell(args: argparse.Namespace) -> str:
         f"{dep_install}; "
         f"({args.surgery_cmd}) 2>&1 | tee /tmp/surgery.out; rc=${{PIPESTATUS[0]}}; "
         # verdict-conditional sentinel: only burn on a terminal verdict.
-        "if grep -qE 'VERDICT:|CROSS-REPO FRACTURE|ROLLBACK VERIFIED' /tmp/surgery.out; then "
+        # Drop the burn-sentinel ONLY on a SUCCESS verdict -- a FAILED A1 verdict
+        # ('STEP audit VERDICT: FAILED') must KEEP the node warm so the Black Box
+        # can be pulled + inspected before teardown (the dead-man + max-run-duration
+        # remain the no-orphan backstop). Run #7 burned on FAILED + lost the box.
+        "if grep -qE 'A1_DISPATCH_PROVEN|VERDICT: PASS|ROLLBACK VERIFIED' /tmp/surgery.out; then "
         f"sudo touch {sentinel_q2} 2>/dev/null || touch {sentinel_q2} 2>/dev/null || true; "
         "echo '[iac] verdict reached -- completion-sentinel dropped (dead-man will burn)'; "
         "else echo '[iac] no verdict (resumable) -- sentinel NOT dropped, node stays warm'; fi; "


### PR DESCRIPTION
Live-soak hardening from the 7-run A1 diagnostic loop. Every wall was tooling, never O+V:
- **Deps:** per-package continue-on-failure (atomic `-r` aborted on PyAudio -> killed aiohttp), filter native-build libs (pyaudio/pyobjc/webrtcvad/...), strip inline `# comments` from req lines, hard-ensure aiohttp + **pytest-asyncio** (the repo's autouse async fixture errors every test without it -> chaos injector could never confirm a green test).
- **Auditor:** harness now passes `JARVIS_A1_AUDIT_FLAGS` (its AST-derived flag set) so the auditor doesn't re-import CADENCE_POLICY and die at flag_set_load (the run #7 verdict-wall).
- **Sentinel:** drop the burn-sentinel only on a SUCCESS verdict; a FAILED A1 verdict keeps the node warm for the Black-Box pull (run #7 burned on FAILED + lost the box). Dead-man + max-run-duration remain the no-orphan backstop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the A1 live‑soak harness to avoid tooling-based aborts and prevent tearing down failed runs too early. Adds per‑package dependency installs, passes derived flags to the auditor, and only drops the burn sentinel on success.

- **Dependencies**
  - Install requirements per‑package with continue‑on‑failure.
  - Filter ML/native‑build libs on bare Debian (`pyaudio`, `pyobjc`, `webrtcvad`, etc.); strip inline `#` comments from `requirements.txt`.
  - Hard‑ensure core deps: `aiohttp`, `pytest-asyncio` (plus `pytest`, `httpx`, `fastapi`, `uvicorn`, etc.).

- **Bug Fixes**
  - Pass derived flags via `JARVIS_A1_AUDIT_FLAGS` so the auditor skips `CADENCE_POLICY` re‑import and loads reliably.
  - Drop the burn sentinel only on success (`A1_DISPATCH_PROVEN`, `VERDICT: PASS`, `ROLLBACK VERIFIED`); keep failed nodes warm for Black‑Box retrieval.

<sup>Written for commit a2a013eedfd5e327c4353bf456fa57cac86c6219. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69697?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

