### PR TITLE
fix(a1-harness): uuid6 boot-dep + auditor subprocess env (runs #8 O+V-boot + auditor loci)

### DIFF
--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -413,7 +413,14 @@ class AuditorRunner:
             "--timeout", str(timeout_s), "--verdict-out", verdict_out,
             "--strict" if self.strict else "--lenient",
         ]
-        cp = subprocess.run(argv, capture_output=True, text=True, check=False)
+        # The auditor's load_audit_flags() lacks the harness's AST-source fallback,
+        # so on a node where the heavy CADENCE_POLICY import fails it dies at
+        # flag_set_load (runs #7/#8). subprocess.run() inherits os.environ, which does
+        # NOT carry the soak's composed JARVIS_A1_AUDIT_FLAGS -- so set it explicitly
+        # on the auditor's env from the already-derived flag set (no CADENCE import).
+        env = dict(os.environ)
+        env.setdefault("JARVIS_A1_AUDIT_FLAGS", ",".join(derive_cognitive_flags()))
+        cp = subprocess.run(argv, capture_output=True, text=True, check=False, env=env)
         if os.path.exists(verdict_out):
             try:
                 return json.loads(open(verdict_out, encoding="utf-8").read())

--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -886,7 +886,10 @@ def _git_clone_remote_shell(origin_url: str, commit_sha: str, remote_dir: str) -
         f"rm -rf {rd} && "
         f"git clone {url} {rd} && "
         f"git -C {rd} checkout {sha} && "
-        f"git -C {rd} rev-parse HEAD"
+        # Emit the node HEAD behind a UNIQUE MARKER so the parity probe extracts it
+        # reliably -- NOT 'the last streamed line' (a clone/checkout stderr advice
+        # line can land last -> empty -> false parity burn, the run #8 wall).
+        f"echo \"__NODE_HEAD__$(git -C {rd} rev-parse HEAD)\""
     )
 
 
@@ -913,18 +916,27 @@ def git_clone_on_node(
     )
     if rc != 0:
         return False, f"git clone of {origin_url} failed rc={rc}: {''.join(captured).strip()[:300]}"
-    # Parity probe: the LAST non-empty captured line is the node's `rev-parse HEAD`.
+    # Parity probe: extract the node HEAD from behind the unique marker (robust to
+    # interleaved clone/checkout stderr). Burn ONLY on a CONFIRMED real mismatch (a
+    # non-empty DIFFERENT sha). An UNREADABLE probe (empty) with clone rc==0 is a
+    # tooling read-failure, NOT a stale-commit soak -- warn + proceed (the exact-sha
+    # clone succeeded). Burning on an empty read falsely killed run #8.
     node_head = ""
-    for ln in reversed(captured):
+    for ln in captured:
         s = ln.strip()
-        if s:
-            node_head = s
+        if "__NODE_HEAD__" in s:
+            tail = s.split("__NODE_HEAD__", 1)[1].strip().split()
+            node_head = tail[0] if tail else ""
             break
-    if node_head != commit_sha:
+    if node_head and node_head != commit_sha:
         raise GitTransportError(
-            f"node {node} HEAD parity FAILED: node checked out {node_head[:12] or '<none>'} "
+            f"node {node} HEAD parity FAILED: node checked out {node_head[:12]} "
             f"but local soak commit is {commit_sha[:12]} -- mismatch, burn (no stale-commit soak)"
         )
+    if not node_head:
+        _log(f"[parity] WARN: node HEAD probe unreadable (clone rc=0) -- proceeding; "
+             f"the exact-sha clone @ {commit_sha[:12]} succeeded")
+        return True, f"cloned (parity-probe-unreadable, clone ok) @ {commit_sha[:12]}"
     return True, f"cloned + parity-verified @ {commit_sha[:12]}"
 
 
@@ -1347,8 +1359,11 @@ def _remote_surgery_shell(args: argparse.Namespace) -> str:
         # pytest-asyncio is LOAD-BEARING: the repo's conftest has an autouse ASYNC
         # fixture -- without the plugin EVERY test ERRORS at setup -> the chaos
         # injector can never confirm a green test (the runs #4-6 wall).
+        # uuid6 is UNDECLARED in requirements.txt but imported by core governance
+        # (operation_id.py) -- O+V crashes at boot without it (the run #8 wall: the
+        # soak never produced a debug.log, no A1Trace, because the import died).
         "sudo python3 -m pip install --break-system-packages -q aiohttp httpx pydantic "
-        "pytest pytest-asyncio pyyaml requests anyio sniffio fastapi uvicorn orjson 2>&1 | tail -1; "
+        "pytest pytest-asyncio pyyaml requests anyio sniffio fastapi uvicorn orjson uuid6 2>&1 | tail -1; "
         "python3 -c 'import aiohttp; print(\"[deps] aiohttp ok\", aiohttp.__version__)' 2>&1 | tail -1",
     )
     # cd into the synced jarvis repo, install deps, run the surgery. The completion
@@ -1361,6 +1376,15 @@ def _remote_surgery_shell(args: argparse.Namespace) -> str:
         f"cd {shlex.quote(jr)} && {env} "
         f"{dep_install}; "
         f"({args.surgery_cmd}) 2>&1 | tee /tmp/surgery.out; rc=${{PIPESTATUS[0]}}; "
+        # ---- SYNCHRONOUS TAIL (redundant telemetry) -- dump the raw verdict + the
+        # [A1Trace] hops + the FAILURE LOCUS straight to stdout BEFORE any teardown,
+        # so the trace physically reaches the local terminal even if the Black-Box
+        # scp fails or hangs. Runs on EVERY exit (success or FAILED), unconditionally.
+        "echo '===== SYNCHRONOUS TAIL (raw verdict + A1Trace -> stdout) ====='; "
+        "echo '--- a1_verdict.json ---'; cat a1_runs/*/a1_verdict.json 2>/dev/null | tail -40 || echo '(no verdict file)'; "
+        "echo '--- [A1Trace] hops (O+V debug.log) ---'; grep -hE '\\[A1Trace\\]' .ouroboros/sessions/*/debug.log 2>/dev/null | tail -20 || echo '(no A1Trace lines emitted)'; "
+        "echo '--- FAILURE LOCUS / final O+V state ---'; grep -hE 'FAILURE LOCUS|A1_DISPATCH_PROVEN|VERDICT:|state=applied|SOVEREIGN YIELD|Traceback' /tmp/surgery.out 2>/dev/null | tail -15; "
+        "echo '===== END SYNCHRONOUS TAIL ====='; "
         # verdict-conditional sentinel: only burn on a terminal verdict.
         # Drop the burn-sentinel ONLY on a SUCCESS verdict -- a FAILED A1 verdict
         # ('STEP audit VERDICT: FAILED') must KEEP the node warm so the Black Box


### PR DESCRIPTION
Run #8 reached O+V but it crashed at boot on `ModuleNotFoundError: uuid6` (undeclared in requirements.txt, imported by core governance `operation_id.py`) -> no debug.log, no A1Trace. And the auditor died at flag_set_load because `subprocess.run` inherited os.environ which lacked JARVIS_A1_AUDIT_FLAGS. Fixes: hard-ensure uuid6; set JARVIS_A1_AUDIT_FLAGS explicitly on the auditor subprocess env.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures O+V boots and the auditor runs by installing `uuid6` and passing `JARVIS_A1_AUDIT_FLAGS` to the auditor subprocess. Also hardens the node parity probe and guarantees terminal telemetry reaches stdout.

- **Bug Fixes**
  - Install `uuid6` during remote surgery to satisfy the undeclared import used by governance (`operation_id.py`) and prevent the O+V boot crash.
  - Pass `JARVIS_A1_AUDIT_FLAGS` into the auditor `subprocess.run()` env using derived flags to avoid `flag_set_load` failures when `CADENCE_POLICY` can’t import.

- **Reliability**
  - Make node HEAD parity probing robust: emit a unique marker, parse from it, only burn on confirmed mismatch, and warn/proceed on unreadable probes.
  - Print a synchronous tail of `a1_verdict.json`, `[A1Trace]` hops, and failure locus to stdout before teardown to preserve telemetry even if file collection fails.

<sup>Written for commit f9425630d34484f760733211705dd29914ddab91. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69698?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

