### PR TITLE
feat(testwatcher): dynamic test scoping (fs.changed → scoped pytest, kills the 180s SIGKILL)

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
@@ -101,6 +101,61 @@ def fs_events_enabled() -> bool:
     ).lower() in ("true", "1", "yes")
 
 
+# --- Dynamic test scoping (2026-06-24) ------------------------------------
+#
+# The FS-driven pytest run used to call ``poll_once()`` blind — pytest ran
+# the WHOLE ``tests/`` suite on every ``.py`` change. On a non-trivial repo
+# that sweep exceeds the 180s pytest ceiling and is SIGKILLed mid-run, so a
+# stable failure introduced by a single edit is NEVER detected. This is the
+# exact foil that blocked O+V's chaos self-detection in the A1 soak.
+#
+# Fix (reuse-first, no new mapper): the changed file's repo-relative path is
+# threaded to the EXISTING ``TestRunner.resolve_affected_tests`` — a 4-level
+# deterministic mapper (name-convention -> recursive search -> package
+# fallback -> repo fallback, capped at ``JARVIS_TEST_MAX_FILES``) — and the
+# bounded result is passed to ``poll_once(target_paths=...)``. A one-line
+# edit now runs ONLY that file's tests.
+#
+# Fail-safe ladder (never the whole ``tests/`` on a resolve failure):
+#   1. resolve_affected_tests -> bounded scoped targets (primary).
+#   2. resolver empty / errors -> nearest sibling ``tests/<mirror-dir>/``
+#      (bounded to a single directory, not the repo root).
+#   3. mirror dir unresolvable -> deep-background full-suite poll ONLY when
+#      ``JARVIS_TEST_FULL_SUITE_FALLBACK`` is explicitly true (default
+#      false); otherwise the run is skipped (a missed run is cheaper than a
+#      180s SIGKILL that detects nothing).
+#
+# Master gate ``JARVIS_TEST_DYNAMIC_SCOPING_ENABLED`` (default true). OFF ->
+# the FS path calls ``poll_once()`` with no target_paths == legacy
+# whole-suite behavior, byte-identical.
+
+
+def dynamic_scoping_enabled() -> bool:
+    """Re-read ``JARVIS_TEST_DYNAMIC_SCOPING_ENABLED`` at call-time (default true).
+
+    Not cached so tests can monkeypatch the env per-case (same pattern as
+    ``fs_events_enabled``). OFF restores byte-identical legacy whole-suite
+    behavior on the FS path.
+    """
+    return os.environ.get(
+        "JARVIS_TEST_DYNAMIC_SCOPING_ENABLED", "true",
+    ).lower() in ("true", "1", "yes")
+
+
+def full_suite_fallback_enabled() -> bool:
+    """Re-read ``JARVIS_TEST_FULL_SUITE_FALLBACK`` at call-time (default false).
+
+    The last-resort escape hatch: when scoping is on but NOTHING resolves
+    (no scoped targets, no mirror dir), only fall back to the whole-suite
+    poll if an operator has explicitly opted in. Default false means a
+    fully-unresolvable change skips the run rather than risking the 180s
+    SIGKILL that detects nothing.
+    """
+    return os.environ.get(
+        "JARVIS_TEST_FULL_SUITE_FALLBACK", "false",
+    ).lower() in ("true", "1", "yes")
+
+
 class TestFailureSensor:
     """Adapter that bridges TestWatcher → UnifiedIntakeRouter.
 
@@ -377,7 +432,7 @@ class TestFailureSensor:
         if self._debounce_task is not None and not self._debounce_task.done():
             self._debounce_task.cancel()
         self._debounce_task = asyncio.create_task(
-            self._debounced_pytest_run(),
+            self._debounced_pytest_run(changed_rel_path=rel_path),
             name="test_failure_debounced_run",
         )
 
@@ -445,8 +500,20 @@ class TestFailureSensor:
     # Phase 1 fallback: debounced subprocess pytest run
     # ------------------------------------------------------------------
 
-    async def _debounced_pytest_run(self) -> None:
-        """Wait 2s for edits to settle, then trigger a pytest run."""
+    async def _debounced_pytest_run(
+        self, changed_rel_path: str = ""
+    ) -> None:
+        """Wait 2s for edits to settle, then trigger a pytest run.
+
+        Dynamic test scoping (2026-06-24): *changed_rel_path* is the
+        FS-event's relative path. When scoping is enabled it is resolved
+        (via the existing :meth:`TestRunner.resolve_affected_tests`) to a
+        bounded set of scoped test targets and passed to
+        ``poll_once(target_paths=...)`` so ONLY that file's tests run — not
+        the whole ``tests/`` suite. Fail-safe: an unresolvable change skips
+        the run (or falls back to whole-suite only when
+        ``JARVIS_TEST_FULL_SUITE_FALLBACK`` is explicitly true).
+        """
         try:
             await asyncio.sleep(2.0)
             # Suppress if plugin results were consumed recently (Phase 2 active)
@@ -457,14 +524,155 @@ class TestFailureSensor:
                     time.monotonic() - self._last_plugin_ts,
                 )
                 return
-            if self._watcher is not None:
+            if self._watcher is None:
+                return
+
+            if not dynamic_scoping_enabled():
+                # OFF -> byte-identical legacy whole-suite behavior.
                 signals = await self._watcher.poll_once()
                 if signals:
                     await self.handle_signals(signals)
+                return
+
+            targets = await self._resolve_scoped_targets(changed_rel_path)
+            if targets is None:
+                # Nothing resolved (no scoped targets, no mirror dir).
+                if not full_suite_fallback_enabled():
+                    logger.debug(
+                        "TestFailureSensor: no scoped targets for %r and "
+                        "full-suite fallback disabled — skipping run",
+                        changed_rel_path,
+                    )
+                    return
+                logger.info(
+                    "TestFailureSensor: no scoped targets for %r — "
+                    "JARVIS_TEST_FULL_SUITE_FALLBACK on, running full suite",
+                    changed_rel_path,
+                )
+                signals = await self._watcher.poll_once()
+            else:
+                logger.info(
+                    "TestFailureSensor: scoped %d test target(s) for %r",
+                    len(targets), changed_rel_path,
+                )
+                signals = await self._watcher.poll_once(target_paths=targets)
+            if signals:
+                await self.handle_signals(signals)
         except asyncio.CancelledError:
             pass  # Newer edit arrived — debounce reset
         except Exception:
             logger.debug("TestFailureSensor: debounced run error", exc_info=True)
+
+    # ------------------------------------------------------------------
+    # Dynamic test scoping — changed file -> scoped test targets
+    # ------------------------------------------------------------------
+
+    def _repo_root(self) -> Path:
+        """Best-effort repo root for the resolver / mirror-dir fallback.
+
+        Prefers the watcher's ``repo_path`` (set from ``JARVIS_REPO_PATH``),
+        falls back to the env var, then the cwd. Never raises.
+        """
+        candidate = getattr(self._watcher, "repo_path", None) or os.environ.get(
+            "JARVIS_REPO_PATH", "."
+        )
+        try:
+            return Path(candidate).resolve()
+        except Exception:
+            return Path(".").resolve()
+
+    async def _resolve_scoped_targets(
+        self, changed_rel_path: str
+    ) -> Optional[List[str]]:
+        """Map *changed_rel_path* -> bounded scoped pytest targets.
+
+        Returns
+        -------
+        * A non-empty ``List[str]`` of scoped test paths when the existing
+          ``TestRunner.resolve_affected_tests`` (or the bounded mirror-dir
+          fallback) yields targets.
+        * ``None`` when nothing resolved — the caller then either skips the
+          run or (opt-in) falls back to the whole suite. **Never** returns
+          the whole ``tests/`` directory implicitly.
+
+        Fail-safe by construction: any error in the resolver degrades to the
+        mirror-dir fallback, and any error there degrades to ``None``.
+        """
+        if not changed_rel_path:
+            return None
+
+        repo_root = self._repo_root()
+        changed_abs = (repo_root / changed_rel_path).resolve()
+
+        # Primary: reuse the existing 4-level deterministic mapper.
+        try:
+            from backend.core.ouroboros.governance.test_runner import TestRunner
+
+            runner = TestRunner(repo_root)
+            resolved = await runner.resolve_affected_tests((changed_abs,))
+            targets = [
+                str(p) for p in resolved
+                if not self._is_repo_test_root(p, repo_root)
+            ]
+            if targets:
+                return targets
+        except Exception as exc:  # noqa: BLE001 — resolver is best-effort
+            logger.debug(
+                "TestFailureSensor: resolve_affected_tests failed for %r: %s",
+                changed_rel_path, exc,
+            )
+
+        # Fail-safe: nearest sibling mirror tests/ dir (bounded, single dir).
+        mirror = self._mirror_tests_dir(changed_abs, repo_root)
+        if mirror is not None:
+            return [str(mirror)]
+        return None
+
+    @staticmethod
+    def _is_repo_test_root(path: Path, repo_root: Path) -> bool:
+        """True if *path* is a top-level repo test dir (the whole-suite root).
+
+        The resolver's strategy-4/last-resort returns the repo-level
+        ``tests/`` dir, which is exactly the whole-suite sweep we are
+        avoiding. Treat it as "did not scope" so the caller can fall to the
+        bounded mirror-dir or skip — never run it implicitly.
+        """
+        try:
+            from backend.core.ouroboros.governance.test_runner import (
+                _TEST_DIR_NAMES,
+            )
+        except Exception:
+            _TEST_DIR_NAMES = frozenset({"tests", "test"})
+        try:
+            rp = path.resolve()
+        except Exception:
+            rp = path
+        return rp.parent == repo_root and rp.name in _TEST_DIR_NAMES
+
+    def _mirror_tests_dir(
+        self, changed_abs: Path, repo_root: Path
+    ) -> Optional[Path]:
+        """Nearest sibling ``tests/`` dir for *changed_abs*, NOT the repo root.
+
+        Bounded to a single directory so a resolve miss still runs a small,
+        local slice instead of the whole suite. Returns ``None`` when the
+        only sibling test dir IS the repo root (caller then skips / opts in).
+        """
+        try:
+            from backend.core.ouroboros.governance.test_runner import (
+                _find_sibling_tests_dir,
+            )
+        except Exception:
+            return None
+        try:
+            sibling = _find_sibling_tests_dir(changed_abs)
+        except Exception:
+            return None
+        if sibling is None:
+            return None
+        if self._is_repo_test_root(sibling, repo_root):
+            return None
+        return sibling
 
     # ------------------------------------------------------------------
     # Poll fallback (safety net when event spine is unavailable)

--- a/backend/core/ouroboros/governance/intent/test_watcher.py
+++ b/backend/core/ouroboros/governance/intent/test_watcher.py
@@ -28,7 +28,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass, field
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from .signals import IntentSignal
 
@@ -145,7 +145,9 @@ class TestWatcher:
     # Subprocess invocation
     # ------------------------------------------------------------------
 
-    async def run_pytest(self) -> Tuple[str, int]:
+    async def run_pytest(
+        self, target_paths: Optional[Sequence[str]] = None
+    ) -> Tuple[str, int]:
         """Run pytest via the Slice 9 canonical helper.
 
         Slice 9 (operator-bound, empirical from bt-2026-05-22-000838):
@@ -158,15 +160,30 @@ class TestWatcher:
         single source of pipe-discipline + provenance + process-
         group cleanup. AST pin in
         ``test_slice9_canonical_pytest_helper.py`` forbids any
-        other path."""
+        other path.
+
+        Dynamic test scoping (2026-06-24): when *target_paths* is a
+        non-empty sequence, the pytest argv targets those node ids /
+        file paths instead of the whole ``test_dir``. This is the
+        FS-driven hot path — a single changed source file resolves
+        (via ``TestRunner.resolve_affected_tests``) to a bounded set
+        of its own test files, so a one-line edit no longer triggers
+        the full ``tests/`` sweep that SIGKILLs at the 180s ceiling
+        (the foil that blocked O+V's chaos self-detection in the A1
+        soak). When *target_paths* is None / empty, the legacy
+        whole-``test_dir`` behavior is byte-identical (back-compat).
+        """
         from backend.core.ouroboros.governance.test_subprocess_helper import (  # noqa: E501
             run_pytest_subprocess,
         )
+        # Scoped targets (FS-driven primary) vs. legacy whole-suite.
+        scoped = [str(p) for p in (target_paths or []) if str(p).strip()]
+        pytest_targets = scoped if scoped else [str(self.test_dir)]
         argv = [
             "python3",
             "-m",
             "pytest",
-            str(self.test_dir),
+            *pytest_targets,
             "--tb=short",
             "-q",
             "--no-header",
@@ -369,18 +386,25 @@ class TestWatcher:
     # Poll loop
     # ------------------------------------------------------------------
 
-    async def poll_once(self) -> List[IntentSignal]:
+    async def poll_once(
+        self, target_paths: Optional[Sequence[str]] = None
+    ) -> List[IntentSignal]:
         """Run one poll cycle: invoke pytest, parse output, process failures.
 
         If pytest times out (exit_code == -1), the cycle is skipped and
         existing failure streaks are preserved -- a timeout does NOT mean
         tests are passing.
 
+        *target_paths* (dynamic test scoping, 2026-06-24): pass-through to
+        :meth:`run_pytest`. A non-empty sequence scopes the run to those
+        test paths; None / empty preserves the legacy whole-``test_dir``
+        sweep (back-compat).
+
         Returns
         -------
         List of :class:`IntentSignal` emitted for stable failures.
         """
-        output, exit_code = await self.run_pytest()
+        output, exit_code = await self.run_pytest(target_paths=target_paths)
         if exit_code == -1:
             return []  # timeout -- skip cycle, preserve streaks
         failures = self.parse_pytest_output(output, exit_code)

--- a/tests/governance/intake/sensors/test_test_failure_sensor_fs_events.py
+++ b/tests/governance/intake/sensors/test_test_failure_sensor_fs_events.py
@@ -200,9 +200,12 @@ async def test_on_fs_event_py_file_schedules_debounced_run(monkeypatch: Any) -> 
     assert sensor._fs_events_handled == 1
 
 
-async def _never_called() -> None:
+async def _never_called(*args: Any, **kwargs: Any) -> None:
     """Stand-in coroutine for _debounced_pytest_run; never actually runs
-    because the test cancels it before the 2s debounce completes."""
+    because the test cancels it before the 2s debounce completes.
+
+    Accepts ``*args/**kwargs`` so it tolerates the dynamic-scoping
+    ``changed_rel_path=`` kwarg threaded into the production call site."""
     await asyncio.sleep(10.0)
 
 

--- a/tests/governance/test_dynamic_test_scoping.py
+++ b/tests/governance/test_dynamic_test_scoping.py
@@ -1,0 +1,286 @@
+"""Dynamic test scoping — FS-changed file -> scoped pytest run.
+
+Validates the wiring that fixes the 180s SIGKILL which blocked O+V chaos
+self-detection in the A1 soak:
+
+* ``TestWatcher.run_pytest(target_paths=[...])`` builds an argv targeting the
+  SCOPED paths, not the whole ``tests/`` directory.
+* The sensor's FS path resolves a changed source file -> scoped test targets
+  (via the EXISTING ``TestRunner.resolve_affected_tests``) ->
+  ``poll_once(target_paths=...)``.
+* Resolver miss -> bounded mirror-dir fallback, NEVER the whole ``tests/``.
+* Master gate OFF -> byte-identical legacy whole-suite argv.
+* Back-compat: no ``target_paths`` -> legacy argv.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import List, Optional, Sequence, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.intent.test_watcher import TestWatcher
+from backend.core.ouroboros.governance.intake.sensors.test_failure_sensor import (
+    TestFailureSensor,
+    dynamic_scoping_enabled,
+    full_suite_fallback_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers: capture the argv handed to the canonical pytest subprocess helper
+# ---------------------------------------------------------------------------
+
+
+class _FakeResult:
+    def __init__(self) -> None:
+        self.timed_out = False
+        self.returncode = 0
+        self.stdout = ""
+
+
+def _patch_subprocess(monkeypatch) -> List[List[str]]:
+    """Patch run_pytest_subprocess; return a list captured argvs are appended to."""
+    captured: List[List[str]] = []
+
+    async def _fake(argv, *, cwd, timeout_s, caller):  # noqa: ANN001
+        captured.append(list(argv))
+        return _FakeResult()
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.test_subprocess_helper."
+        "run_pytest_subprocess",
+        _fake,
+    )
+    return captured
+
+
+# ---------------------------------------------------------------------------
+# 1. run_pytest(target_paths=[...]) -> scoped argv, NOT tests/
+# ---------------------------------------------------------------------------
+
+
+def test_run_pytest_scoped_argv_targets_paths(monkeypatch) -> None:
+    captured = _patch_subprocess(monkeypatch)
+    watcher = TestWatcher(repo="jarvis", test_dir="tests/")
+
+    out, rc = asyncio.run(
+        watcher.run_pytest(
+            target_paths=["tests/governance/test_foo.py", "tests/test_bar.py"]
+        )
+    )
+
+    assert rc == 0
+    argv = captured[0]
+    assert "tests/governance/test_foo.py" in argv
+    assert "tests/test_bar.py" in argv
+    # The whole-suite root must NOT be a bare argv token.
+    assert "tests/" not in argv
+    # Other flags preserved.
+    for flag in ("--tb=short", "-q", "--no-header", "--color=no"):
+        assert flag in argv
+
+
+def test_run_pytest_no_target_paths_legacy_argv(monkeypatch) -> None:
+    """Back-compat: no target_paths -> legacy whole-test_dir argv."""
+    captured = _patch_subprocess(monkeypatch)
+    watcher = TestWatcher(repo="jarvis", test_dir="tests/")
+
+    asyncio.run(watcher.run_pytest())
+
+    argv = captured[0]
+    assert "tests/" in argv
+
+
+def test_run_pytest_empty_target_paths_falls_back_to_legacy(monkeypatch) -> None:
+    captured = _patch_subprocess(monkeypatch)
+    watcher = TestWatcher(repo="jarvis", test_dir="tests/")
+
+    asyncio.run(watcher.run_pytest(target_paths=[]))
+
+    argv = captured[0]
+    assert "tests/" in argv
+
+
+def test_poll_once_passes_target_paths_through(monkeypatch) -> None:
+    captured = _patch_subprocess(monkeypatch)
+    watcher = TestWatcher(repo="jarvis", test_dir="tests/")
+
+    asyncio.run(watcher.poll_once(target_paths=["tests/test_scoped.py"]))
+
+    argv = captured[0]
+    assert "tests/test_scoped.py" in argv
+    assert "tests/" not in argv
+
+
+# ---------------------------------------------------------------------------
+# Sensor FS-path fixtures
+# ---------------------------------------------------------------------------
+
+
+class _SpyWatcher:
+    """Records poll_once(target_paths=...) calls; no subprocess."""
+
+    def __init__(self, repo_path: str) -> None:
+        self.repo_path = repo_path
+        self.poll_interval_s = 30.0
+        self.calls: List[Optional[Sequence[str]]] = []
+
+    async def poll_once(
+        self, target_paths: Optional[Sequence[str]] = None
+    ) -> list:
+        self.calls.append(target_paths)
+        return []
+
+    def stop(self) -> None:
+        pass
+
+
+class _Event:
+    def __init__(self, payload: dict) -> None:
+        self.payload = payload
+
+
+def _build_repo_tree(tmp_path: Path) -> Tuple[Path, Path, Path]:
+    """Create repo/pkg/foo.py + repo/pkg/tests/test_foo.py. Return (root, src, test)."""
+    pkg = tmp_path / "pkg"
+    tests_dir = pkg / "tests"
+    tests_dir.mkdir(parents=True)
+    src = pkg / "foo.py"
+    src.write_text("x = 1\n", encoding="utf-8")
+    test = tests_dir / "test_foo.py"
+    test.write_text("def test_foo():\n    assert True\n", encoding="utf-8")
+    return tmp_path, src, test
+
+
+# ---------------------------------------------------------------------------
+# 2. FS path: changed file -> scoped targets via resolve_affected_tests
+# ---------------------------------------------------------------------------
+
+
+def test_fs_path_resolves_scoped_targets(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TEST_DYNAMIC_SCOPING_ENABLED", "true")
+    root, src, test = _build_repo_tree(tmp_path)
+
+    watcher = _SpyWatcher(repo_path=str(root))
+    sensor = TestFailureSensor(repo="jarvis", router=object(), test_watcher=watcher)
+    sensor._last_plugin_ts = -1e9  # ensure no plugin-suppression
+    # Skip the 2s debounce sleep.
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    asyncio.run(sensor._debounced_pytest_run(changed_rel_path="pkg/foo.py"))
+
+    assert len(watcher.calls) == 1
+    targets = watcher.calls[0]
+    assert targets is not None
+    # Resolved to the file's own test (name convention), not the whole suite.
+    assert any(str(test) in t for t in targets)
+    # Never the whole tests/ root passed implicitly.
+    assert all(not t.endswith("/tests") and t != "tests" for t in targets)
+
+
+# ---------------------------------------------------------------------------
+# 3. Resolver miss -> bounded mirror-dir fallback, NEVER whole tests/
+# ---------------------------------------------------------------------------
+
+
+def test_resolver_miss_falls_back_to_mirror_dir(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TEST_DYNAMIC_SCOPING_ENABLED", "true")
+    # pkg/tests/ exists but has no matching test_*.py for bar.py and no
+    # recursive match -> strategy 1/2 miss; package fallback is empty;
+    # strategy 4 would be the repo root -> filtered out.
+    pkg = tmp_path / "pkg"
+    tests_dir = pkg / "tests"
+    tests_dir.mkdir(parents=True)
+    (pkg / "bar.py").write_text("y = 2\n", encoding="utf-8")
+
+    watcher = _SpyWatcher(repo_path=str(tmp_path))
+    sensor = TestFailureSensor(repo="jarvis", router=object(), test_watcher=watcher)
+    sensor._last_plugin_ts = -1e9
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    asyncio.run(sensor._debounced_pytest_run(changed_rel_path="pkg/bar.py"))
+
+    assert len(watcher.calls) == 1
+    targets = watcher.calls[0]
+    assert targets is not None
+    # Bounded to the single sibling mirror dir, not the repo-root tests/.
+    assert len(targets) == 1
+    assert targets[0] == str(tests_dir.resolve())
+    assert targets[0] != str((tmp_path / "tests").resolve())
+
+
+def test_unresolvable_change_skips_run_without_full_suite(tmp_path, monkeypatch) -> None:
+    """No mirror dir at all + full-suite fallback off -> NO poll (never full suite)."""
+    monkeypatch.setenv("JARVIS_TEST_DYNAMIC_SCOPING_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TEST_FULL_SUITE_FALLBACK", "false")
+    # A bare repo with no tests/ dir anywhere up the tree from the file.
+    src = tmp_path / "loose.py"
+    src.write_text("z = 3\n", encoding="utf-8")
+
+    watcher = _SpyWatcher(repo_path=str(tmp_path))
+    sensor = TestFailureSensor(repo="jarvis", router=object(), test_watcher=watcher)
+    sensor._last_plugin_ts = -1e9
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    asyncio.run(sensor._debounced_pytest_run(changed_rel_path="loose.py"))
+
+    # Resolver last-resort would be repo-root tests/ (which doesn't exist
+    # here) -> nothing -> skip. Crucially: poll_once was NOT called blind.
+    assert watcher.calls == []
+
+
+def test_unresolvable_change_full_suite_opt_in(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TEST_DYNAMIC_SCOPING_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TEST_FULL_SUITE_FALLBACK", "true")
+    src = tmp_path / "loose.py"
+    src.write_text("z = 3\n", encoding="utf-8")
+
+    watcher = _SpyWatcher(repo_path=str(tmp_path))
+    sensor = TestFailureSensor(repo="jarvis", router=object(), test_watcher=watcher)
+    sensor._last_plugin_ts = -1e9
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    asyncio.run(sensor._debounced_pytest_run(changed_rel_path="loose.py"))
+
+    # Opt-in -> exactly one whole-suite poll (target_paths is None).
+    assert len(watcher.calls) == 1
+    assert watcher.calls[0] is None
+
+
+# ---------------------------------------------------------------------------
+# 4. Master gate OFF -> byte-identical legacy whole-suite behavior
+# ---------------------------------------------------------------------------
+
+
+def test_scoping_off_is_legacy_whole_suite(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TEST_DYNAMIC_SCOPING_ENABLED", "false")
+    root, src, test = _build_repo_tree(tmp_path)
+
+    watcher = _SpyWatcher(repo_path=str(root))
+    sensor = TestFailureSensor(repo="jarvis", router=object(), test_watcher=watcher)
+    sensor._last_plugin_ts = -1e9
+    monkeypatch.setattr(asyncio, "sleep", _no_sleep)
+
+    asyncio.run(sensor._debounced_pytest_run(changed_rel_path="pkg/foo.py"))
+
+    # OFF -> poll_once() called with NO target_paths (legacy).
+    assert len(watcher.calls) == 1
+    assert watcher.calls[0] is None
+
+
+def test_gate_helpers_default(monkeypatch) -> None:
+    monkeypatch.delenv("JARVIS_TEST_DYNAMIC_SCOPING_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_TEST_FULL_SUITE_FALLBACK", raising=False)
+    assert dynamic_scoping_enabled() is True
+    assert full_suite_fallback_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# Shared: no-op sleep so debounce doesn't actually wait 2s
+# ---------------------------------------------------------------------------
+
+
+async def _no_sleep(_delay, *a, **k):  # noqa: ANN001
+    return None


### PR DESCRIPTION
Threads the changed file through the EXISTING resolve_affected_tests into a scoped run_pytest (never the full tests/ suite). Default-on, fail-safe. 107 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scope FS-driven pytest runs to only the tests affected by the changed file, preventing full-suite sweeps that hit the 180s timeout and miss failures. Default-on with opt-in fallback; addresses the SIGKILL issue in the test watcher path.

- **New Features**
  - Thread the changed path into `TestRunner.resolve_affected_tests`, then call `poll_once(target_paths=...)` with the scoped list.
  - Add `run_pytest(target_paths)` in `TestWatcher`; when empty/None, it runs the legacy whole `tests/` dir.
  - Fail-safes: scoped targets first; then nearest sibling `tests/` dir; full-suite only when `JARVIS_TEST_FULL_SUITE_FALLBACK=true` (default false). Never run the repo `tests/` root implicitly.
  - Gate `JARVIS_TEST_DYNAMIC_SCOPING_ENABLED` (default true) to toggle behavior.
  - Tests: new `tests/governance/test_dynamic_test_scoping.py`; minor updates to FS-event tests.

<sup>Written for commit fce1e5347b099a880ed51764dc92e20cc91854e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69699?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

