### PR TITLE
feat(failover): Sovereign Failover Mesh gaps — preemptive DW heartbeat + Cryo-DLQ→PrimeProvider handoff

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3124,6 +3124,83 @@ class CandidateGenerator:
         except Exception:  # noqa: BLE001 — last-resort defensive
             return result
 
+    async def _honor_provider_override(
+        self,
+        context: OperationContext,
+        deadline: datetime,
+    ) -> Optional[GenerationResult]:
+        """Sovereign Failover Mesh Gap 3b — honor a Cryo-DLQ provider pin.
+
+        When ``context.provider_override == "gcp-jprime"`` (stamped at Cryo-DLQ
+        seal time on a DW global outage), route the op STRAIGHT to the awakened
+        J-Prime ``PrimeProvider`` -- NOT through the dead DW cascade.
+
+        Returns:
+          * a ``GenerationResult`` when J-Prime produced candidates (honored);
+          * ``None`` when there is no override (legacy dispatch continues);
+          * raises a terminal ``RuntimeError`` (fail-CLOSED) when the override
+            is set but J-Prime is unavailable / yielded nothing -- so the op
+            STAYS SEALED in the DLQ and is NEVER re-routed to dead DW.
+
+        Empty override -> None (byte-identical legacy). Fail-soft on the read
+        side: an unreadable override is treated as no override.
+        """
+        try:
+            override = (getattr(context, "provider_override", "") or "").strip()
+        except Exception:  # noqa: BLE001
+            override = ""
+        if not override:
+            return None  # legacy: no pin, normal cascade
+
+        op_id_short = (getattr(context, "op_id", "") or "?")[:16]
+
+        # Only "gcp-jprime" is a recognized pin today. An unknown override falls
+        # through to the legacy cascade (forward-compatible; never a hard error
+        # on an unrecognized value).
+        if override != "gcp-jprime":
+            logger.info(
+                "[CandidateGenerator] provider_override=%s unrecognized -- "
+                "falling through to legacy cascade [%s]",
+                override, op_id_short,
+            )
+            return None
+
+        # Fail-CLOSED gate: J-Prime must be wired AND advertising an endpoint.
+        if self._jprime is None or not getattr(
+            self._jprime, "provider_name", ""
+        ):
+            logger.warning(
+                "[CandidateGenerator] provider_override=gcp-jprime but no "
+                "PrimeProvider wired -- op STAYS SEALED in Cryo-DLQ (NOT routed "
+                "to dead DW) [%s]", op_id_short,
+            )
+            raise RuntimeError(
+                "provider_override_unavailable:gcp-jprime:no_prime_provider"
+            )
+
+        logger.info(
+            "[CandidateGenerator] Cryo-DLQ replay: provider_override=gcp-jprime "
+            "-> routing straight to awakened J-Prime (DW lane bypassed) [%s]",
+            op_id_short,
+        )
+        result = await self._try_jprime_primacy(
+            context, deadline, route_label="failover_override", force=True,
+        )
+        if result is not None:
+            return result
+
+        # J-Prime declined (sem saturated / timeout / error / no candidates).
+        # FAIL-CLOSED: do NOT cascade to the dead DW lane. Raise terminal so the
+        # op stays sealed in the DLQ for a later replay (the op is never lost).
+        logger.warning(
+            "[CandidateGenerator] provider_override=gcp-jprime but J-Prime "
+            "yielded no candidates -- op STAYS SEALED in Cryo-DLQ (NOT routed "
+            "to dead DW) [%s]", op_id_short,
+        )
+        raise RuntimeError(
+            "provider_override_unavailable:gcp-jprime:no_candidates"
+        )
+
     async def _generate_dispatch(
         self,
         context: OperationContext,
@@ -3135,6 +3212,19 @@ class CandidateGenerator:
         the hot path; the public ``generate()`` above wraps it only to
         observe exhaustion and success signals.
         """
+        # ── Sovereign Failover Mesh Gap 3b: provider_override honor-check ──
+        # When an op was sealed into the Cryo-DLQ on a DW global outage it
+        # carries provider_override="gcp-jprime" (the awakened J-Prime node).
+        # On replay we MUST route it straight to J-Prime, NOT re-cascade through
+        # the dead DW lane. Fail-CLOSED: if J-Prime is unavailable (no awakened
+        # endpoint), raise a terminal sentinel so the op STAYS SEALED in the DLQ
+        # (the orchestrator records a generation failure; the op is NOT lost and
+        # is NEVER sent to dead DW). Master gate inside the helper keeps OFF
+        # byte-identical (empty override -> no-op).
+        _override_result = await self._honor_provider_override(context, deadline)
+        if _override_result is not None:
+            return _override_result
+
         # ── Route-based dispatch (Manifesto §5 Tier 0: deterministic) ──
         _provider_route = getattr(context, "provider_route", "") or "standard"
 
@@ -5119,6 +5209,7 @@ class CandidateGenerator:
         deadline: datetime,
         *,
         route_label: str,
+        force: bool = False,
     ) -> Optional[GenerationResult]:
         """Phase 3 Scope α: try J-Prime first for BACKGROUND/SPECULATIVE.
 
@@ -5156,7 +5247,15 @@ class CandidateGenerator:
 
         # Quota Shield: prefer_local ops use the same local-first primacy path even
         # when jprime_primacy is otherwise off for this route.
-        if not (jprime_primacy_enabled() or getattr(context, "prefer_local", False)):
+        # Sovereign Failover Mesh Gap 3b: ``force=True`` (a Cryo-DLQ
+        # provider_override replay) bypasses the primacy-enabled guard entirely
+        # -- the op was explicitly pinned to J-Prime, so honor it regardless of
+        # the primacy flag for this route.
+        if not (
+            force
+            or jprime_primacy_enabled()
+            or getattr(context, "prefer_local", False)
+        ):
             return None
         if self._jprime is None or not getattr(
             self._jprime, "provider_name", ""

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -163,6 +163,18 @@ def _awaken_timeout_s() -> float:
     return max(1.0, _env_float("JARVIS_FAILOVER_AWAKEN_TIMEOUT_S", 600.0))
 
 
+def _early_prewarm_enabled() -> bool:
+    """Gap-2 sub-gate: degradation -> early pre-warm. Default FALSE.
+
+    Composes UNDER the master ``JARVIS_FAILOVER_LIFECYCLE_ENABLED`` gate. When
+    OFF (or when the master is off) the controller only awakens on the legacy
+    REACTIVE ``is_global_outage`` path -- byte-identical. When ON, a DEGRADED
+    (not-yet-outage) heartbeat reading plus a slow recovery forecast can awaken
+    J-Prime EARLY so the node is warm by the time DW formally collapses and the
+    op drops into the Cryo-DLQ. The operator arms this at soak time."""
+    return _enabled("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+
+
 def _warmup_enabled() -> bool:
     """VRAM pre-warm gate. Default TRUE -- OFF -> straight to SERVING (legacy)."""
     return _enabled("JARVIS_FAILOVER_WARMUP_ENABLED", "true")
@@ -352,6 +364,43 @@ def _default_node_ready_fn(endpoint: str) -> bool:
         return False
 
 
+def _resolve_node_ip() -> str:
+    """Resolve the awakened failover node's reachable IP via gcloud describe.
+
+    Gap 3a boundary -- the missing wire. After ``_default_vm_awaken_fn`` creates
+    the node and it answers on :PORT, we must tell PrimeClient WHERE the node
+    is. This resolves the external (or, if no external, the internal) IP via a
+    single ``gcloud compute instances describe`` with a format selector, so the
+    Body can publish ``JARVIS_PRIME_URL`` / ``JARVIS_PRIME_HOST``.
+
+    Returns the IP string, or "" if it cannot be resolved (fail-soft -- the
+    caller treats "" as "publish nothing" and PrimeProvider keeps its existing
+    configured target; the op is never lost). NEVER raises. Mockable in tests.
+    """
+    project = _env_str("GCP_PROJECT_ID", "") or _env_str("GOOGLE_CLOUD_PROJECT", "")
+    zone = _env_str("GCP_ZONE", "us-central1-a")
+    node = _env_str("JARVIS_FAILOVER_NODE_NAME", _GCLOUD_NODE_NAME)
+
+    # Prefer the external NAT IP; fall back to the internal IP if absent
+    # (e.g. an internal-only deployment where the Body shares the VPC).
+    fmt_external = (
+        "get(networkInterfaces[0].accessConfigs[0].natIP)"
+    )
+    fmt_internal = "get(networkInterfaces[0].networkIP)"
+    for fmt in (fmt_external, fmt_internal):
+        cmd = [
+            "gcloud", "compute", "instances", "describe", node,
+            "--zone={}".format(zone), "--format={}".format(fmt),
+        ]
+        if project:
+            cmd.append("--project={}".format(project))
+        rc, out = _gcloud_run(cmd, timeout_s=30.0)
+        ip = (out or "").strip().splitlines()[0].strip() if out else ""
+        if rc == 0 and ip:
+            return ip
+    return ""
+
+
 # ---------------------------------------------------------------------------
 # FailoverLifecycleController
 # ---------------------------------------------------------------------------
@@ -374,6 +423,8 @@ class FailoverLifecycleController:
         route: Optional[str] = None,
         on_serving_fn: Optional[Callable[[], Awaitable[Any]]] = None,
         warmup_fn: Optional[Callable[[], Awaitable[bool]]] = None,
+        is_degrading_fn: Optional[Callable[[], bool]] = None,
+        endpoint_publish_fn: Optional[Callable[[str], Any]] = None,
     ) -> None:
         self._vm_awaken_fn = vm_awaken_fn or _default_vm_awaken_fn
         self._vm_delete_fn = vm_delete_fn or _default_vm_delete_fn
@@ -381,6 +432,18 @@ class FailoverLifecycleController:
         self._node_ready_fn = node_ready_fn or _default_node_ready_fn
         self._clock_fn = clock_fn or _default_clock_fn
         self._route = route or _route()
+        # Gap 2 -- early-degradation signal source. Default: the DW heartbeat
+        # singleton's is_degrading() (resolved lazily so the heartbeat module
+        # only loads when the early-prewarm sub-gate is armed). Injectable for
+        # tests. Fail-soft: a missing/erroring source reads as "not degrading"
+        # (fail-CLOSED -> reactive path only, no false pre-warm).
+        self._is_degrading_fn = is_degrading_fn  # None -> lazy default
+        # Gap 3a -- endpoint publish boundary. Default: resolve the node IP and
+        # write JARVIS_PRIME_URL / JARVIS_PRIME_HOST (where PrimeClient reads
+        # its endpoint) + best-effort hot-swap a live PrimeClient. Injectable
+        # for tests. Fail-soft: a publish error never blocks the SERVING
+        # transition (the op is never lost).
+        self._endpoint_publish_fn = endpoint_publish_fn  # None -> default
         # VRAM pre-warm boundary (Phase 3b+). Injectable for tests. Default:
         # construct a LocalPrimeClient pointed at jprime_endpoint() and call
         # warmup(timeout_s=_warmup_timeout_s()). None defers to _default_warmup_fn.
@@ -555,6 +618,90 @@ class FailoverLifecycleController:
         port = _failover_port()
         return "http://{}:{}".format(host, port)
 
+    def _publish_endpoint(self) -> None:
+        """Gap 3a -- resolve the node IP + write it where PrimeClient reads it.
+
+        Steps (deterministic + logged; NEVER logs secrets):
+          1. Resolve the awakened node's reachable IP (gcloud describe boundary,
+             injectable). On "" -> publish nothing (PrimeProvider keeps its
+             configured target). This is the fail-soft no-op.
+          2. Compose ``http://<ip>:<port>`` and set it as ``self._endpoint``
+             (so jprime_endpoint() advertises the live URL).
+          3. Export ``JARVIS_PRIME_URL`` + ``JARVIS_PRIME_HOST`` (the two env
+             vars PrimeClient resolves its base_url from) so a fresh PrimeClient
+             picks the node up, and best-effort hot-swap any already-live
+             PrimeClient via its update_endpoint() (Gap 3a completion).
+
+        If a custom publish boundary was injected, defer to it entirely.
+        """
+        publish_fn = self._endpoint_publish_fn
+        if publish_fn is not None:
+            ip = self._resolve_ip()
+            if ip:
+                publish_fn(ip)
+            return
+
+        ip = self._resolve_ip()
+        if not ip:
+            logger.info(
+                "[FailoverLifecycle] endpoint publish: node IP unresolved "
+                "-- PrimeProvider keeps configured target (fail-soft no-op)"
+            )
+            return
+
+        port = _failover_port()
+        url = "http://{}:{}".format(ip, port)
+        self._endpoint = url
+        # Write the two env vars PrimeClient reads its endpoint from.
+        os.environ["JARVIS_PRIME_URL"] = url
+        os.environ["JARVIS_PRIME_HOST"] = ip
+        logger.info(
+            "[FailoverLifecycle] endpoint WIRED: JARVIS_PRIME_URL=%s "
+            "JARVIS_PRIME_HOST=%s (PrimeProvider now targets the live node)",
+            url, ip,
+        )
+        # Best-effort hot-swap a live PrimeClient (if the provider state already
+        # holds one). Fail-soft -- the env vars above are the durable wire.
+        self._hot_swap_prime_client(host=ip, port=port)
+
+    @staticmethod
+    def _resolve_ip() -> str:
+        """Call the module-level _resolve_node_ip boundary. Fail-soft -> ""."""
+        try:
+            return str(_resolve_node_ip() or "").strip()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[FailoverLifecycle] node IP resolve fail-soft err=%r", exc)
+            return ""
+
+    @staticmethod
+    def _hot_swap_prime_client(*, host: str, port: int) -> None:
+        """Best-effort: hot-swap a live PrimeClient to the awakened node.
+
+        Resolves the PrimeProviderState's injected client lazily (no import
+        cycle, no hard dependency in unit tests). If the client exposes an
+        async ``update_endpoint(host, port)`` we schedule it; otherwise this is
+        a no-op (the env-var wire above is the durable path). Fail-soft."""
+        try:
+            from backend.core.ouroboros.governance._governance_state import (  # noqa: PLC0415
+                get_prime_provider_state,
+            )
+            state = get_prime_provider_state()
+            client = getattr(state, "client", None)
+            update = getattr(client, "update_endpoint", None)
+            if not callable(update):
+                return
+            result = update(host, port)
+            if asyncio.iscoroutine(result):
+                # Schedule on the running loop without blocking the FSM tick.
+                try:
+                    asyncio.ensure_future(result)
+                except RuntimeError:
+                    # No running loop (sync context) -- close the coroutine to
+                    # avoid a "never awaited" warning. Env wire still applies.
+                    result.close()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FailoverLifecycle] prime client hot-swap fail-soft err=%r", exc)
+
     def _build_default_warmup_fn(self) -> Callable[[], Awaitable[bool]]:
         """Build the default warmup callable: LocalPrimeClient pointed at
         the awakened endpoint, calling warmup(timeout_s=_warmup_timeout_s()).
@@ -723,14 +870,93 @@ class FailoverLifecycleController:
             outage = grad.is_global_outage(self._route)
         except Exception:  # noqa: BLE001
             outage = False
-        if not outage:
+
+        if outage:
+            # Observed full outage. Apply the cryo-trigger cost gate (reactive).
+            if not self._should_awaken(now=now):
+                return
+            await self._enter_awakening(now=now)
             return
 
-        # Observed outage. Apply the cryo-trigger cost gate.
-        if not self._should_awaken(now=now):
+        # Gap 2 -- EARLY pre-warm path. NOT yet a full outage, but the heartbeat
+        # reports DEGRADATION. If the forecast also says recovery is slow
+        # (R > C*margin, HIGH confidence), pre-warm J-Prime NOW so the node is
+        # warm by the time DW formally collapses and the op drops into the
+        # Cryo-DLQ. Fail-CLOSED: not-degrading / low-confidence forecast / blip
+        # (R < C*margin) -> fall through (no behavior loss; the reactive path
+        # above remains the backstop on a later tick once the window fills).
+        if self._should_early_prewarm(now=now):
+            logger.info(
+                "[FailoverLifecycle] EARLY PRE-WARM: DW degrading + slow "
+                "forecast (R>C*margin) -> awakening J-Prime ahead of formal "
+                "outage (route=%s)", self._route,
+            )
+            await self._enter_awakening(now=now)
             return
 
-        # AWAKEN: build deadman startup-script, spin up the node.
+    def _should_early_prewarm(self, *, now: float) -> bool:
+        """Gap-2 decision: degradation + slow forecast -> pre-warm early?
+
+        Composes three independent gates (ALL must hold; fail-CLOSED on any):
+          1. The early-prewarm sub-gate is armed (env).
+          2. The heartbeat reports is_degrading() (DEGRADED, not yet outage).
+          3. The cost gate says it is worth paying the spin-up: HIGH-confidence
+             forecast with R(p50) > C*margin. LOW_CONFIDENCE -> decline (R is
+             unreliable; the reactive floor still applies once the window fills).
+        Pure-ish + fail-soft: any error -> False (decline -> reactive only).
+        """
+        if not _early_prewarm_enabled():
+            return False
+        try:
+            if not self._is_degrading():
+                return False
+        except Exception:  # noqa: BLE001
+            return False
+
+        try:
+            forecast = self._get_forecast()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FailoverLifecycle] early-prewarm forecast fail-soft err=%r", exc)
+            return False
+
+        confidence = getattr(forecast, "confidence", "LOW_CONFIDENCE")
+        if confidence != "HIGH":
+            # Fail-CLOSED: R unreliable -> do NOT speculatively pre-warm; the
+            # reactive is_global_outage path handles the real outage.
+            return False
+
+        r = float(getattr(forecast, "p50_s", 0.0))
+        threshold = _coldstart_s() * _awaken_margin()
+        decision = r > threshold
+        logger.info(
+            "[FailoverLifecycle] early-prewarm gate: degrading=True HIGH conf "
+            "R(p50)=%.1f threshold(C*margin)=%.1f -> %s",
+            r, threshold,
+            "PRE-WARM" if decision else "BLIP-SKIP (hold; reactive backstop)",
+        )
+        return decision
+
+    def _is_degrading(self) -> bool:
+        """Resolve the early-degradation signal. Default: the DW heartbeat
+        singleton's is_degrading(). Injectable + fail-soft (False on error)."""
+        fn = self._is_degrading_fn
+        if fn is None:
+            try:
+                from backend.core.ouroboros.governance.provider_heartbeat import (  # noqa: PLC0415
+                    get_dw_heartbeat,
+                )
+                fn = get_dw_heartbeat().is_degrading
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[FailoverLifecycle] heartbeat resolve fail-soft err=%r", exc)
+                return False
+        try:
+            return bool(fn())
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FailoverLifecycle] is_degrading fail-soft err=%r", exc)
+            return False
+
+    async def _enter_awakening(self, *, now: float) -> None:
+        """Shared DORMANT -> AWAKENING transition (reactive + early-prewarm)."""
         self._state = FailoverState.AWAKENING
         self._awakening_started_at = now
         self._recovered_streak = 0
@@ -828,6 +1054,20 @@ class FailoverLifecycleController:
                     "-- proceeding to SERVING (first op may be cold)",
                     _warmup_timeout_s(),
                 )
+
+        # Gap 3a -- WIRE the awakened node's reachable endpoint to PrimeClient
+        # BEFORE flipping to SERVING, so the moment the FSM advertises
+        # is_jprime_serving()/jprime_endpoint(), PrimeProvider already points at
+        # the live node. Fail-soft ABSOLUTE: a publish error never blocks (or
+        # reverts) the SERVING transition (the op is never lost -- PrimeProvider
+        # keeps its configured target on a publish miss).
+        try:
+            await self._maybe_await(self._publish_endpoint)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[FailoverLifecycle] endpoint publish fail-soft err=%r "
+                "-- SERVING proceeds (PrimeProvider keeps configured target)", exc,
+            )
 
         self._awakening_started_at = None
         self._state = FailoverState.SERVING

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1030,6 +1030,13 @@ class OperationContext:
     provider_route: str = ""   # "immediate" | "standard" | "complex" | "background" | "speculative"
     provider_route_reason: str = ""  # human-readable reason for telemetry
     prefer_local: bool = False    # Quota Shield: route this op to the local J-Prime tier
+    # Sovereign Failover Mesh (Gap 3b): an explicit provider pin stamped when an
+    # op is sealed into the Cryo-DLQ on a DW global outage. On replay,
+    # CandidateGenerator HONORS this override and routes the op straight to the
+    # named provider (e.g. "gcp-jprime", the awakened J-Prime node) instead of
+    # re-cascading through the dead DW lane. Fail-CLOSED: if the named provider
+    # is unavailable, the op stays sealed in the DLQ (never routed to dead DW).
+    provider_override: str = ""   # "" = no override (legacy cascade); "gcp-jprime" = pin to J-Prime
 
     # ---- Truncation-retry shape flags (Task 2, feat/jprime-truncation-retry-diff-shape) ----
     # Stamped by the orchestrator GENERATE_RETRY path when a truncation/elision

--- a/backend/core/ouroboros/governance/provider_heartbeat.py
+++ b/backend/core/ouroboros/governance/provider_heartbeat.py
@@ -1,0 +1,318 @@
+"""provider_heartbeat.py -- Gap 1 of the Sovereign Failover Mesh (2026-06-24).
+
+A lightweight ASYNC background loop that PROBES DoubleWord (DW) health
+PROACTIVELY -- a cheap, bounded-timeout health request to the DW endpoint on a
+fixed interval -- and records each verdict into the EXISTING
+:class:`SurfaceHealthLedger` (reuse; no new ledger). This gives the failover
+lifecycle an EARLY warning of degradation *before* an op formally times out
+(~53s) or the quarantine gradient declares a full ``is_global_outage`` (which
+needs a FULL window of 5 zero-success sweeps).
+
+Why a separate heartbeat instead of riding the op-driven gradient?
+------------------------------------------------------------------
+The quarantine ``ProviderHealthGradient`` only learns from *live op dispatches*.
+On a quiet system (or one whose ops are already wedged), it can take a long time
+to fill the window. The heartbeat is a CHEAP, INDEPENDENT, time-driven signal:
+it surfaces ``is_degrading()`` the moment ``consecutive_failures`` crosses the
+degrade streak (default 2 -- strictly LESS than the outage window of 5). The
+lifecycle can then PRE-WARM J-Prime so the node is warm by the time DW formally
+collapses and the op drops into the Cryo-DLQ.
+
+Degradation taxonomy (reuse SurfaceVerdict)
+-------------------------------------------
+  * probe OK              -> SurfaceVerdict.HEALTHY (streak resets to 0)
+  * probe failed / errored -> SurfaceVerdict.TRANSPORT_DEGRADED (streak +1)
+A probe *error* is itself a degrade signal -- the loop NEVER crashes on it.
+``is_degrading()`` == the recorded ``consecutive_failures`` for the
+DIRECT_STREAMING surface (DW's SSE generation lane) >= the degrade streak.
+
+Env gates
+---------
+JARVIS_DW_HEARTBEAT_ENABLED    default "false" (default-OFF byte-identical)
+    OFF -> beat()/run() are inert no-ops; is_degrading() is always False; no
+    background task; today's behavior exactly.
+JARVIS_DW_HEARTBEAT_INTERVAL_S default 10.0 (probe cadence in run())
+JARVIS_DW_DEGRADE_STREAK       default 2 (< the outage window of 5)
+JARVIS_DW_HEARTBEAT_PROBE_TIMEOUT_S default 3.0 (bounded per-probe deadline)
+DOUBLEWORD_BASE_URL            default https://api.doubleword.ai/v1 (probe target)
+
+Fail-soft / bounded throughout. Lazy-imports heavy deps so the module imports
+clean in tests. The default probe uses stdlib urllib so tests can inject a fake
+boundary with zero real network.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Awaitable, Callable, Optional
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+    SurfaceKind,
+    SurfaceVerdict,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Env helpers (fail-soft, never raise)
+# ---------------------------------------------------------------------------
+
+def _enabled(name: str, default: str) -> bool:
+    val = (os.environ.get(name, default) or "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (ValueError, TypeError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (ValueError, TypeError):
+        return default
+
+
+def heartbeat_enabled() -> bool:
+    """Master gate. DEFAULT-OFF (byte-identical legacy when unset).
+
+    The operator arms this at soak time via
+    ``export JARVIS_DW_HEARTBEAT_ENABLED=true`` alongside
+    ``JARVIS_FAILOVER_LIFECYCLE_ENABLED``.
+    """
+    return _enabled("JARVIS_DW_HEARTBEAT_ENABLED", "false")
+
+
+def _interval_s() -> float:
+    return max(0.001, _env_float("JARVIS_DW_HEARTBEAT_INTERVAL_S", 10.0))
+
+
+def _degrade_streak() -> int:
+    # Clamp to >= 1 and (defensively) below the quarantine outage window so the
+    # heartbeat is always the EARLIER signal. The outage window default is 5.
+    return max(1, _env_int("JARVIS_DW_DEGRADE_STREAK", 2))
+
+
+def _probe_timeout_s() -> float:
+    return max(0.1, _env_float("JARVIS_DW_HEARTBEAT_PROBE_TIMEOUT_S", 3.0))
+
+
+def _dw_base_url() -> str:
+    return (
+        os.environ.get("DOUBLEWORD_BASE_URL", "https://api.doubleword.ai/v1")
+        or "https://api.doubleword.ai/v1"
+    ).rstrip("/")
+
+
+# ---------------------------------------------------------------------------
+# Default probe boundary (stdlib urllib -- injectable for tests)
+# ---------------------------------------------------------------------------
+
+def _default_dw_probe() -> bool:
+    """Cheap DW reachability probe -- a bounded GET to ``{base}/models``.
+
+    Returns True iff the endpoint answers with a non-5xx status within the
+    bounded timeout. NEVER raises -- any error (timeout, refused, DNS) is a
+    failed probe (returns False), which the heartbeat treats as a degrade
+    signal. This is a *reachability* check, NOT a generation -- it is cheap
+    and side-effect-free.
+    """
+    url = _dw_base_url() + "/models"
+    try:
+        import urllib.request  # noqa: PLC0415
+
+        req = urllib.request.Request(url, method="GET")
+        with urllib.request.urlopen(  # noqa: S310
+            req, timeout=_probe_timeout_s()
+        ) as resp:
+            status = getattr(resp, "status", 200)
+            return 200 <= int(status) < 500
+    except Exception as exc:  # noqa: BLE001 -- a probe error IS a degrade signal
+        logger.debug("[DWHeartbeat] default probe fail-soft err=%r", exc)
+        return False
+
+
+# ---------------------------------------------------------------------------
+# DWHeartbeat
+# ---------------------------------------------------------------------------
+
+class DWHeartbeat:
+    """Preemptive DW health heartbeat. Records verdicts into the shared
+    SurfaceHealthLedger; exposes an EARLY ``is_degrading()`` signal.
+
+    All boundaries are injectable for testability -- a fake probe + an
+    in-process ledger mean NO real network is touched.
+    """
+
+    # The DW surface this heartbeat tracks: the SSE generation lane (the one
+    # that actually carries O+V's generation traffic).
+    _SURFACE = SurfaceKind.DIRECT_STREAMING
+
+    def __init__(
+        self,
+        *,
+        probe_fn: Optional[Callable[[], Any]] = None,
+        ledger: Optional[SurfaceHealthLedger] = None,
+    ) -> None:
+        self._probe_fn = probe_fn or _default_dw_probe
+        # Reuse the shared ledger by default (the same on-disk file the rest of
+        # the surface-health stack reads). Tests inject an in-memory ledger.
+        self._ledger = ledger if ledger is not None else SurfaceHealthLedger()
+        self._stopped = False
+        # Cache of the last recorded verdict for a cheap read surface (the
+        # ledger is the source of truth; this avoids a lock round-trip on the
+        # hot is_degrading() path).
+        self._last_verdict: Optional[SurfaceVerdict] = None
+        self._last_streak: int = 0
+
+    # ------------------------------------------------------------------
+    # Public read surface (consumed by the failover lifecycle pre-warm gate)
+    # ------------------------------------------------------------------
+
+    def is_degrading(self) -> bool:
+        """True iff DW is DEGRADED but NOT yet a full outage.
+
+        Reads the live ``consecutive_failures`` streak for the DIRECT_STREAMING
+        surface from the shared ledger and compares against the degrade streak
+        (default 2 < the outage window of 5). OFF -> always False (inert).
+        Fail-soft -> False on any error (conservative: no false pre-warm).
+        """
+        if not heartbeat_enabled():
+            return False
+        try:
+            rec = self._ledger.verdict_for(self._SURFACE)
+            if rec is None:
+                return False
+            return int(rec.consecutive_failures) >= _degrade_streak()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[DWHeartbeat] is_degrading fail-soft err=%r", exc)
+            return False
+
+    def latest_verdict(self) -> Optional[SurfaceVerdict]:
+        """The most recently recorded SurfaceVerdict, or None if no beat yet.
+        OFF -> None (inert)."""
+        if not heartbeat_enabled():
+            return None
+        try:
+            rec = self._ledger.verdict_for(self._SURFACE)
+            return rec.verdict if rec is not None else None
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[DWHeartbeat] latest_verdict fail-soft err=%r", exc)
+            return None
+
+    def consecutive_failures(self) -> int:
+        """Current degrade streak for the DW SSE surface (0 when healthy)."""
+        if not heartbeat_enabled():
+            return 0
+        try:
+            rec = self._ledger.verdict_for(self._SURFACE)
+            return int(rec.consecutive_failures) if rec is not None else 0
+        except Exception:  # noqa: BLE001
+            return 0
+
+    # ------------------------------------------------------------------
+    # One probe + record (the testable core)
+    # ------------------------------------------------------------------
+
+    async def beat(self) -> None:
+        """Fire one probe and record the verdict into the ledger. Fail-soft.
+
+        OFF -> inert no-op (no probe, no record): byte-identical legacy.
+        A probe error is itself a degrade signal -- the verdict recorded is
+        TRANSPORT_DEGRADED (never propagates the exception).
+        """
+        if not heartbeat_enabled():
+            return
+        ok = False
+        try:
+            result = self._probe_fn()
+            if asyncio.iscoroutine(result):
+                result = await result
+            ok = bool(result)
+        except Exception as exc:  # noqa: BLE001 -- a probe error IS a degrade
+            logger.debug("[DWHeartbeat] probe raised (degrade signal) err=%r", exc)
+            ok = False
+
+        verdict = SurfaceVerdict.HEALTHY if ok else SurfaceVerdict.TRANSPORT_DEGRADED
+        try:
+            rec = self._ledger.record(
+                self._SURFACE,
+                verdict,
+                diagnostic="dw_heartbeat",
+            )
+            self._last_verdict = rec.verdict
+            self._last_streak = int(rec.consecutive_failures)
+            if not ok and self._last_streak >= _degrade_streak():
+                logger.warning(
+                    "[DWHeartbeat] DW DEGRADING: streak=%d (>=%d) surface=%s "
+                    "-- EARLY pre-warm signal armed (outage window not yet full)",
+                    self._last_streak, _degrade_streak(), self._SURFACE.value,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[DWHeartbeat] record fail-soft err=%r", exc)
+
+    # ------------------------------------------------------------------
+    # Async run() driver (bounded, cancellable -- no event-loop starvation)
+    # ------------------------------------------------------------------
+
+    async def run(self) -> None:
+        """Beat on a fixed interval. Gated -- OFF returns immediately (inert).
+
+        Cadence = JARVIS_DW_HEARTBEAT_INTERVAL_S (asyncio.sleep, Python 3.9+
+        safe -- NOT asyncio.timeout). Fail-soft: a beat error never breaks the
+        loop. Cancellable via stop() or task cancellation.
+        """
+        if not heartbeat_enabled():
+            logger.debug("[DWHeartbeat] run(): disabled -- inert")
+            return
+        self._stopped = False
+        logger.info(
+            "[DWHeartbeat] run() loop started interval=%.1fs degrade_streak=%d",
+            _interval_s(), _degrade_streak(),
+        )
+        while not self._stopped:
+            try:
+                await self.beat()
+            except Exception as exc:  # noqa: BLE001 -- belt-and-braces
+                logger.warning("[DWHeartbeat] run beat fail-soft err=%r", exc)
+            try:
+                await asyncio.sleep(_interval_s())
+            except asyncio.CancelledError:
+                break
+
+    def stop(self) -> None:
+        self._stopped = True
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_singleton: Optional[DWHeartbeat] = None
+
+
+def get_dw_heartbeat() -> DWHeartbeat:
+    """Return (or lazily create) the process-wide DW heartbeat singleton."""
+    global _singleton  # noqa: PLW0603
+    if _singleton is None:
+        _singleton = DWHeartbeat()
+    return _singleton
+
+
+def _reset_singleton_for_tests() -> None:
+    """Test hook: drop the singleton so a fresh heartbeat is created."""
+    global _singleton  # noqa: PLW0603
+    _singleton = None
+
+
+__all__ = [
+    "DWHeartbeat",
+    "get_dw_heartbeat",
+    "heartbeat_enabled",
+]

--- a/backend/core/ouroboros/governance/provider_quarantine.py
+++ b/backend/core/ouroboros/governance/provider_quarantine.py
@@ -211,11 +211,53 @@ def _import_append_dlq() -> Callable:  # type: ignore[type-arg]
 # quarantine_op — terminal quarantine action
 # ---------------------------------------------------------------------------
 
+def _failover_provider_override() -> str:
+    """The provider to pin a Cryo-DLQ-sealed op to on a DW outage (Gap 3b).
+
+    Default ``"gcp-jprime"`` -- the awakened J-Prime failover node. Env-tunable
+    (``JARVIS_FAILOVER_PROVIDER_OVERRIDE``); empty string disables the stamp
+    (legacy: replay re-cascades through the normal path). NEVER raises.
+    """
+    return (
+        os.environ.get("JARVIS_FAILOVER_PROVIDER_OVERRIDE", "gcp-jprime") or ""
+    ).strip()
+
+
+def _stamp_provider_override(ctx: Any) -> Any:
+    """Stamp ``provider_override`` on *ctx* so the Cryo-DLQ seal carries the
+    Gap-3b J-Prime pin. Handles frozen dataclasses via ``dataclasses.replace``.
+
+    Returns the (possibly new) ctx to seal. Fail-soft: on any error returns the
+    original ctx unchanged (the seal still happens; the op is never lost -- it
+    just replays via the legacy path instead of the J-Prime pin).
+    """
+    override = _failover_provider_override()
+    if not override:
+        return ctx
+    try:
+        import dataclasses  # noqa: PLC0415
+
+        if dataclasses.is_dataclass(ctx) and any(
+            f.name == "provider_override" for f in dataclasses.fields(ctx)
+        ):
+            return dataclasses.replace(ctx, provider_override=override)
+        # Non-dataclass / mutable: best-effort attribute set.
+        setattr(ctx, "provider_override", override)
+        return ctx
+    except Exception:  # noqa: BLE001 -- never block the seal
+        logger.debug(
+            "[ProviderQuarantine] provider_override stamp fail-soft", exc_info=True
+        )
+        return ctx
+
+
 def quarantine_op(ctx: Any, *, route: str, telemetry: dict) -> bool:
     """Seal a context op into the Cryo-DLQ via [SOVEREIGN YIELD: UPSTREAM QUARANTINE].
 
     Steps:
       (a) emit_sovereign_yield — logs [SOVEREIGN YIELD: UPSTREAM QUARANTINE]
+      (a.5) stamp provider_override="gcp-jprime" (Gap 3b) so replay routes the
+            op straight to the awakened J-Prime node, NOT the dead DW lane
       (b) append_dlq — persists to intake_dlq.jsonl with reason
           "upstream_quarantine:dw_global_outage"
 
@@ -256,6 +298,11 @@ def quarantine_op(ctx: Any, *, route: str, telemetry: dict) -> bool:
                 ctx.dw_telemetry = telemetry
         except Exception:  # pragma: no cover
             pass
+
+        # (a.5) Stamp the J-Prime provider_override (Gap 3b) BEFORE sealing so
+        # the persisted envelope carries the pin and replay routes to the
+        # awakened node, NOT the dead DW lane.
+        ctx = _stamp_provider_override(ctx)
 
         # (b) Append to Cryo-DLQ.
         append_fn = _import_append_dlq()

--- a/tests/governance/test_failover_deadman_mesh.py
+++ b/tests/governance/test_failover_deadman_mesh.py
@@ -1,0 +1,56 @@
+"""Gap 3c confirmation -- the dead-man startup-script generator + self-delete.
+
+The failover FSM passes a ``startup_script`` to the awakened VM; the generator
+(``failover_deadman.build_deadman_startup_script``) emits an UNBREAKABLE
+node-side watchdog that self-deletes the VM via the metadata-SA-token Compute
+REST API once the Ollama endpoint has been idle past a TTL (env-tuned).
+
+This file is a Mesh-scoped confirmation that the generator exists, is wired into
+the lifecycle, is env-tuned, and emits the self-delete REST DELETE -- it does
+NOT duplicate the deadman's own unit suite.
+"""
+from __future__ import annotations
+
+import backend.core.ouroboros.governance.failover_deadman as dm
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+
+
+def test_deadman_script_generated_and_self_deletes():
+    script = dm.build_deadman_startup_script(port=11434)
+    # The watchdog self-deletes via the GCE Compute REST DELETE (decoupled,
+    # unbreakable -- no gcloud on the node; metadata SA token + curl only).
+    assert "jprime-deadman" in script
+    assert "-X DELETE" in script
+    assert "compute.googleapis.com" in script
+    assert "Metadata-Flavor: Google" in script
+    # Idle-driven: only self-deletes once idle > IDLE_TIMEOUT_S and uptime
+    # past boot grace.
+    assert "IDLE_TIMEOUT_S" in script
+    assert "BOOT_GRACE_S" in script
+
+
+def test_deadman_ttl_is_env_tuned(monkeypatch):
+    monkeypatch.setenv("JARVIS_DEADMAN_IDLE_TIMEOUT_S", "777")
+    script = dm.build_deadman_startup_script(port=11434)
+    assert "777" in script
+
+
+def test_lifecycle_wires_deadman_into_startup_script():
+    """The FSM's _build_startup_script delegates to the deadman generator -- so
+    the awakened node always carries the cost backstop."""
+    ctrl = fl.FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=lambda: 0.0,
+    )
+    script = ctrl._build_startup_script()
+    assert "jprime-deadman" in script
+    assert "-X DELETE" in script
+
+
+def test_deadman_script_is_ascii():
+    script = dm.build_deadman_startup_script(port=11434)
+    # ASCII-only invariant (the bash script must be 7-bit clean).
+    script.encode("ascii")

--- a/tests/governance/test_failover_lifecycle_mesh_gaps.py
+++ b/tests/governance/test_failover_lifecycle_mesh_gaps.py
@@ -1,0 +1,302 @@
+"""Tests for the Sovereign Failover Mesh gaps (2026-06-24).
+
+Gap 2 -- degradation -> early pre-warm trigger (wired into failover_lifecycle):
+  when the heartbeat reports is_degrading() (DEGRADED but NOT yet a full
+  is_global_outage) AND the forecast says recovery is slow (R > C*margin), the
+  lifecycle PRE-WARMS J-Prime EARLY (calls vm_awaken_fn) so the node is warm by
+  the time DW formally drops the op into the Cryo-DLQ. Fail-CLOSED: low forecast
+  confidence / not degrading -> fall back to the reactive is_global_outage path
+  (no behavior loss); a transient blip (streak below the degrade streak) does
+  NOT pre-warm.
+
+Gap 3a -- J-Prime endpoint wiring post-awaken: after awaken + node-ready, the
+  controller RESOLVES the node's reachable endpoint and PUBLISHES it where
+  PrimeClient/PrimeProvider reads it (JARVIS_PRIME_URL / JARVIS_PRIME_HOST env).
+
+OFF (all flags false) -> byte-identical: no early pre-warm, no endpoint publish.
+
+TDD with injected fakes -- ZERO real GCE / network.
+"""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import provider_quarantine as pq
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+def _reset_quarantine_singleton():
+    """Reset the gradient singleton on whatever provider_quarantine module is
+    currently live in sys.modules. A sibling test (test_provider_quarantine)
+    deletes + reimports the module via _fresh_module(); failover_lifecycle
+    resolves get_provider_health_gradient() lazily off sys.modules, so we must
+    clear the singleton on the CURRENT module object, not a stale reference."""
+    import importlib
+    import sys as _sys
+    mod = _sys.modules.get(
+        "backend.core.ouroboros.governance.provider_quarantine"
+    ) or importlib.import_module(
+        "backend.core.ouroboros.governance.provider_quarantine"
+    )
+    mod._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    return mod
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    global pq
+    pq = _reset_quarantine_singleton()
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    monkeypatch.setenv("JARVIS_JPRIME_COLDSTART_S", "100")
+    monkeypatch.setenv("JARVIS_CRYO_AWAKEN_MARGIN", "1.5")
+    monkeypatch.setenv("JARVIS_OUTAGE_CONFIRM_S", "120")
+    # Gap 2: early pre-warm armed by default in these tests (operator-gated in prod).
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "true")
+    # Keep VRAM warmup out of the way for endpoint-wiring assertions.
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_ENABLED", "false")
+    yield
+    _reset_quarantine_singleton()
+    fl._reset_singleton_for_tests()
+
+
+def _fake_forecast(confidence: str, p50: float = 0.0, p90: float = 0.0):
+    class _F:
+        def __init__(self):
+            self.confidence = confidence
+            self.p50_s = p50
+            self.p90_s = p90
+            self.velocity_hint = 1.0
+            self.samples = 5 if confidence == "HIGH" else 0
+    return _F()
+
+
+def _make_ctrl(clock, **kw) -> 'fl.FailoverLifecycleController':
+    defaults = dict(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+    )
+    defaults.update(kw)
+    return fl.FailoverLifecycleController(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Gap 2 -- degradation -> early pre-warm (BEFORE a full outage)
+# ---------------------------------------------------------------------------
+
+async def test_early_prewarm_on_degrading_plus_slow_forecast(monkeypatch):
+    """is_degrading() True + HIGH-confidence slow forecast (R > C*margin) ->
+    AWAKEN early, even though the quarantine window is NOT a full outage."""
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: True,  # heartbeat says DW degrading
+    )
+    # R=300 > C*margin=150 -> slow recovery -> worth pre-warming.
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    # NOTE: NO _fill_outage() -- the gradient is NOT a full outage. The ONLY
+    # trigger is the early degradation signal.
+    assert pq.get_provider_health_gradient().is_global_outage("dw") is False
+
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.AWAKENING
+    assert len(awaken_calls) == 1
+
+
+async def test_no_early_prewarm_on_transient_blip(monkeypatch):
+    """Degrading + FAST forecast (R < C*margin) -> blip-skip: do NOT pre-warm
+    (the Cryo-DLQ would hold the op; DW likely back before J-Prime boots)."""
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: True,
+    )
+    # R=40 < C*margin=150 -> blip -> no pre-warm.
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=40.0, p90=80.0))
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+async def test_no_early_prewarm_when_not_degrading(monkeypatch):
+    """Heartbeat NOT degrading + no full outage -> stays DORMANT (reactive path
+    only); the early gate never fires."""
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: False,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+async def test_early_prewarm_low_confidence_falls_back_to_reactive(monkeypatch):
+    """FAIL-CLOSED: degrading but LOW_CONFIDENCE forecast -> the early gate does
+    NOT fire (R is unreliable); the controller falls back to the reactive
+    is_global_outage path. With no full outage it stays DORMANT."""
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("LOW_CONFIDENCE"))
+    await ctrl.tick()
+    # Early gate declined (low confidence). No full outage -> DORMANT.
+    assert ctrl.state == fl.FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+async def test_reactive_outage_still_awakens_with_early_gate(monkeypatch):
+    """The reactive is_global_outage path is preserved: a full outage awakens
+    even when the heartbeat says NOT degrading (e.g. heartbeat disabled)."""
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: False,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    grad = pq.get_provider_health_gradient()
+    for _ in range(5):
+        grad.record_sweep("dw", success=False)
+    assert grad.is_global_outage("dw") is True
+
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.AWAKENING
+    assert len(awaken_calls) == 1
+
+
+async def test_early_prewarm_master_off_no_prewarm(monkeypatch):
+    """Gap-2 sub-gate OFF -> degradation never pre-warms (reactive only)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+async def test_lifecycle_off_no_early_prewarm(monkeypatch):
+    """Master lifecycle OFF -> inert: even with degrading + early gate on, the
+    controller never leaves DORMANT (byte-identical legacy)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "false")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+# ---------------------------------------------------------------------------
+# Gap 3a -- J-Prime endpoint wired post-awaken so PrimeProvider uses it.
+# ---------------------------------------------------------------------------
+
+async def test_endpoint_published_to_env_on_serving(monkeypatch):
+    """On SERVING, the resolved node endpoint is written to JARVIS_PRIME_URL /
+    JARVIS_PRIME_HOST (where PrimeClient reads it)."""
+    monkeypatch.delenv("JARVIS_PRIME_URL", raising=False)
+    monkeypatch.delenv("JARVIS_PRIME_HOST", raising=False)
+    # Resolve the node IP deterministically (mock the gcloud describe boundary).
+    monkeypatch.setattr(fl, "_resolve_node_ip", lambda: "203.0.113.7")
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0))
+    grad = pq.get_provider_health_gradient()
+    for _ in range(5):
+        grad.record_sweep("dw", success=False)
+
+    await ctrl.tick()  # DORMANT -> AWAKENING
+    await ctrl.tick()  # AWAKENING -> SERVING (node ready)
+    assert ctrl.state == fl.FailoverState.SERVING
+
+    url = os.environ.get("JARVIS_PRIME_URL", "")
+    host = os.environ.get("JARVIS_PRIME_HOST", "")
+    assert "203.0.113.7" in url
+    assert url.endswith(":11434")
+    assert host == "203.0.113.7"
+    # The exposed endpoint matches the published env target.
+    assert ctrl.jprime_endpoint() == url
+
+
+async def test_endpoint_publish_failsoft_still_serving(monkeypatch):
+    """If endpoint resolution fails, SERVING still proceeds (fail-soft) -- the
+    op is never lost; PrimeProvider falls back to its configured target."""
+    monkeypatch.setattr(
+        fl, "_resolve_node_ip",
+        lambda: (_ for _ in ()).throw(RuntimeError("describe failed")),
+    )
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0))
+    grad = pq.get_provider_health_gradient()
+    for _ in range(5):
+        grad.record_sweep("dw", success=False)
+    await ctrl.tick()
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.SERVING
+
+
+async def test_off_does_not_publish_endpoint(monkeypatch):
+    """OFF -> no endpoint publish (byte-identical legacy): the env stays clean."""
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_PRIME_URL", raising=False)
+    publishes = []
+    monkeypatch.setattr(
+        fl, "_resolve_node_ip", lambda: publishes.append(1) or "203.0.113.7"
+    )
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    await ctrl.tick()
+    assert ctrl.state == fl.FailoverState.DORMANT
+    assert os.environ.get("JARVIS_PRIME_URL", "") == ""
+    assert publishes == []

--- a/tests/governance/test_failover_provider_override.py
+++ b/tests/governance/test_failover_provider_override.py
@@ -1,0 +1,199 @@
+"""Tests for the Sovereign Failover Mesh Gap 3b -- Cryo-DLQ -> Prime routing.
+
+Two halves:
+
+  (1) provider_quarantine.quarantine_op STAMPS provider_override="gcp-jprime"
+      on the sealed envelope so the Cryo-DLQ entry carries the J-Prime pin.
+
+  (2) candidate_generator._honor_provider_override HONORS that pin on replay:
+        * routes a pinned op straight to the awakened PrimeProvider;
+        * FAIL-CLOSED -- when no Prime is wired (no awakened endpoint) it raises
+          a terminal sentinel so the op STAYS SEALED in the DLQ and is NEVER
+          re-routed to the dead DW lane;
+        * empty override -> None (legacy cascade, byte-identical).
+
+TDD with injected fakes -- ZERO real provider calls.
+"""
+from __future__ import annotations
+
+import dataclasses
+import importlib
+import sys
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest import mock
+
+import pytest
+
+
+def _fresh_quarantine():
+    for key in list(sys.modules.keys()):
+        if "provider_quarantine" in key:
+            del sys.modules[key]
+    return importlib.import_module(
+        "backend.core.ouroboros.governance.provider_quarantine"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (1) quarantine_op stamps provider_override onto the sealed envelope
+# ---------------------------------------------------------------------------
+
+def test_quarantine_op_stamps_override_on_mutable_ctx(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAILOVER_PROVIDER_OVERRIDE", raising=False)
+    mod = _fresh_quarantine()
+    ctx = SimpleNamespace(op_id="op-ov-1")
+    sealed = {}
+
+    def fake_emit(op_id, **kw):  # noqa: ANN001
+        pass
+
+    def fake_append(envelope, *, reason, path=None):
+        sealed["env"] = envelope
+        sealed["override"] = getattr(envelope, "provider_override", None)
+
+    with (
+        mock.patch.object(mod, "_import_emit_sovereign_yield", return_value=fake_emit),
+        mock.patch.object(mod, "_import_append_dlq", return_value=fake_append),
+    ):
+        ok = mod.quarantine_op(ctx, route="dw", telemetry={})
+
+    assert ok is True
+    assert sealed["override"] == "gcp-jprime"
+
+
+def test_quarantine_op_stamps_override_on_frozen_dataclass(monkeypatch):
+    """OperationContext is a frozen dataclass -- the stamp must use replace."""
+    monkeypatch.delenv("JARVIS_FAILOVER_PROVIDER_OVERRIDE", raising=False)
+    mod = _fresh_quarantine()
+    from backend.core.ouroboros.governance.op_context import OperationContext
+
+    ctx = OperationContext.create(target_files=("a.py",), description="x", op_id="op-ov-2")
+    assert ctx.provider_override == ""  # default
+    sealed = {}
+
+    def fake_append(envelope, *, reason, path=None):
+        sealed["override"] = getattr(envelope, "provider_override", None)
+
+    with (
+        mock.patch.object(mod, "_import_emit_sovereign_yield", return_value=lambda *a, **k: None),
+        mock.patch.object(mod, "_import_append_dlq", return_value=fake_append),
+    ):
+        ok = mod.quarantine_op(ctx, route="dw", telemetry={})
+
+    assert ok is True
+    assert sealed["override"] == "gcp-jprime"
+
+
+def test_quarantine_op_override_env_disable(monkeypatch):
+    """Empty JARVIS_FAILOVER_PROVIDER_OVERRIDE -> no stamp (legacy)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_PROVIDER_OVERRIDE", "")
+    mod = _fresh_quarantine()
+    ctx = SimpleNamespace(op_id="op-ov-3")
+    sealed = {}
+
+    def fake_append(envelope, *, reason, path=None):
+        sealed["override"] = getattr(envelope, "provider_override", None)
+
+    with (
+        mock.patch.object(mod, "_import_emit_sovereign_yield", return_value=lambda *a, **k: None),
+        mock.patch.object(mod, "_import_append_dlq", return_value=fake_append),
+    ):
+        mod.quarantine_op(ctx, route="dw", telemetry={})
+
+    assert sealed["override"] is None  # not stamped
+
+
+# ---------------------------------------------------------------------------
+# (2) _honor_provider_override at dispatch
+# ---------------------------------------------------------------------------
+
+def _deadline():
+    return datetime.now(timezone.utc) + timedelta(seconds=120)
+
+
+def _make_generator(jprime):
+    """Build a CandidateGenerator with a fake primary + injected jprime."""
+    from backend.core.ouroboros.governance.candidate_generator import (
+        CandidateGenerator,
+    )
+    fake_primary = SimpleNamespace(provider_name="claude")
+    return CandidateGenerator(primary=fake_primary, jprime=jprime)
+
+
+async def test_override_routes_to_jprime(monkeypatch):
+    """A pinned op routes straight to J-Prime and returns its result."""
+    sentinel_result = SimpleNamespace(candidates=("patch",), provider_name="gcp-jprime")
+    jprime = SimpleNamespace(provider_name="gcp-jprime")
+    gen = _make_generator(jprime)
+
+    called = {}
+
+    async def fake_primacy(context, deadline, *, route_label, force=False):
+        called["route_label"] = route_label
+        called["force"] = force
+        return sentinel_result
+
+    monkeypatch.setattr(gen, "_try_jprime_primacy", fake_primacy)
+
+    ctx = SimpleNamespace(op_id="op-r1", provider_override="gcp-jprime")
+    result = await gen._honor_provider_override(ctx, _deadline())
+    assert result is sentinel_result
+    assert called["route_label"] == "failover_override"
+    assert called["force"] is True
+
+
+async def test_no_override_returns_none(monkeypatch):
+    """Empty override -> None (legacy cascade continues)."""
+    gen = _make_generator(SimpleNamespace(provider_name="gcp-jprime"))
+    ctx = SimpleNamespace(op_id="op-r2", provider_override="")
+    result = await gen._honor_provider_override(ctx, _deadline())
+    assert result is None
+
+
+async def test_override_failclosed_no_prime_provider():
+    """Override set but NO Prime wired -> terminal raise (op stays sealed,
+    NEVER routed to dead DW)."""
+    gen = _make_generator(jprime=None)  # no Prime
+    ctx = SimpleNamespace(op_id="op-r3", provider_override="gcp-jprime")
+    with pytest.raises(RuntimeError) as exc:
+        await gen._honor_provider_override(ctx, _deadline())
+    assert "provider_override_unavailable:gcp-jprime" in str(exc.value)
+    assert "no_prime_provider" in str(exc.value)
+
+
+async def test_override_failclosed_jprime_no_candidates(monkeypatch):
+    """Override set, Prime wired, but J-Prime declines -> terminal raise (NOT
+    a DW cascade). Op stays sealed."""
+    jprime = SimpleNamespace(provider_name="gcp-jprime")
+    gen = _make_generator(jprime)
+
+    async def fake_primacy(context, deadline, *, route_label, force=False):
+        return None  # J-Prime declined
+
+    monkeypatch.setattr(gen, "_try_jprime_primacy", fake_primacy)
+    ctx = SimpleNamespace(op_id="op-r4", provider_override="gcp-jprime")
+    with pytest.raises(RuntimeError) as exc:
+        await gen._honor_provider_override(ctx, _deadline())
+    assert "provider_override_unavailable:gcp-jprime:no_candidates" in str(exc.value)
+
+
+async def test_unrecognized_override_falls_through(monkeypatch):
+    """An unknown override value -> None (forward-compatible legacy cascade)."""
+    gen = _make_generator(SimpleNamespace(provider_name="gcp-jprime"))
+    ctx = SimpleNamespace(op_id="op-r5", provider_override="some-future-provider")
+    result = await gen._honor_provider_override(ctx, _deadline())
+    assert result is None
+
+
+async def test_override_field_on_operation_context_roundtrips():
+    """The provider_override field is a real, replace-able field on the frozen
+    OperationContext (so the seal stamp is durable)."""
+    from backend.core.ouroboros.governance.op_context import OperationContext
+
+    ctx = OperationContext.create(target_files=("a.py",), description="x", op_id="op-r6")
+    assert ctx.provider_override == ""
+    pinned = dataclasses.replace(ctx, provider_override="gcp-jprime")
+    assert pinned.provider_override == "gcp-jprime"
+    # original unchanged (frozen).
+    assert ctx.provider_override == ""

--- a/tests/governance/test_provider_heartbeat.py
+++ b/tests/governance/test_provider_heartbeat.py
@@ -1,0 +1,229 @@
+"""Tests for provider_heartbeat.py -- Gap 1 of the Sovereign Failover Mesh.
+
+The preemptive DW heartbeat probes the DW endpoint proactively on an interval
+and records the verdict into the EXISTING SurfaceHealthLedger (reuse). It must
+detect DEGRADATION before total collapse: it surfaces ``is_degrading()`` once
+the ``consecutive_failures`` streak crosses ``JARVIS_DW_DEGRADE_STREAK``
+(default 2) -- strictly less than the quarantine outage window of 5, so the
+lifecycle gets an EARLY warning.
+
+TDD with injected fakes -- ZERO real network. The probe boundary is injectable;
+the ledger is a real in-process SurfaceHealthLedger pointed at a tmp path.
+
+Covered:
+  * OFF (master gate false) -> heartbeat is inert: no probe, no record, no task,
+    is_degrading() False (byte-identical legacy).
+  * a HEALTHY probe records SurfaceVerdict.HEALTHY + resets the streak.
+  * a failing probe records TRANSPORT_DEGRADED + bumps consecutive_failures.
+  * is_degrading() fires at the degrade streak (default 2) BEFORE the outage
+    window (5) -- the EARLY signal.
+  * a probe exception is itself a degrade signal (fail-soft), never crashes.
+  * latest_verdict() exposes the most recent record.
+  * the async run loop is bounded + cancellable (no event-loop starvation).
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+import backend.core.ouroboros.governance.provider_heartbeat as ph
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger,
+    SurfaceKind,
+    SurfaceVerdict,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch, tmp_path):
+    """Heartbeat ON by default for the active-path tests; ledger -> tmp file."""
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_INTERVAL_S", "10")
+    monkeypatch.setenv("JARVIS_DW_DEGRADE_STREAK", "2")
+    monkeypatch.setenv(
+        "JARVIS_DW_SURFACE_HEALTH_PATH", str(tmp_path / "surface_health.json")
+    )
+    ph._reset_singleton_for_tests()
+    yield
+    ph._reset_singleton_for_tests()
+
+
+def _ledger(tmp_path=None) -> SurfaceHealthLedger:
+    return SurfaceHealthLedger(autosave=False)
+
+
+# ---------------------------------------------------------------------------
+# OFF -> inert (byte-identical legacy)
+# ---------------------------------------------------------------------------
+
+async def test_off_is_inert(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_ENABLED", "false")
+    probe_calls = []
+    hb = ph.DWHeartbeat(
+        probe_fn=lambda: probe_calls.append(1) or True,
+        ledger=_ledger(),
+    )
+    # A single beat does nothing when OFF.
+    await hb.beat()
+    assert probe_calls == []
+    assert hb.is_degrading() is False
+    assert hb.latest_verdict() is None
+
+
+async def test_off_run_returns_immediately(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_ENABLED", "false")
+    hb = ph.DWHeartbeat(probe_fn=lambda: True, ledger=_ledger())
+    # run() exits at once -- no task left spinning.
+    await asyncio.wait_for(hb.run(), timeout=1.0)
+
+
+# ---------------------------------------------------------------------------
+# HEALTHY probe -> records HEALTHY + resets streak
+# ---------------------------------------------------------------------------
+
+async def test_healthy_probe_records_healthy():
+    led = _ledger()
+    hb = ph.DWHeartbeat(probe_fn=lambda: True, ledger=led)
+    await hb.beat()
+    rec = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    assert rec is not None
+    assert rec.verdict is SurfaceVerdict.HEALTHY
+    assert rec.consecutive_failures == 0
+    assert hb.is_degrading() is False
+
+
+# ---------------------------------------------------------------------------
+# Failing probe -> TRANSPORT_DEGRADED + streak bump
+# ---------------------------------------------------------------------------
+
+async def test_failing_probe_records_degraded():
+    led = _ledger()
+    hb = ph.DWHeartbeat(probe_fn=lambda: False, ledger=led)
+    await hb.beat()
+    rec = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    assert rec is not None
+    assert rec.verdict is SurfaceVerdict.TRANSPORT_DEGRADED
+    assert rec.consecutive_failures == 1
+
+
+# ---------------------------------------------------------------------------
+# is_degrading() fires at the degrade streak BEFORE the outage window.
+# ---------------------------------------------------------------------------
+
+async def test_is_degrading_fires_at_streak_before_outage(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_DEGRADE_STREAK", "2")
+    led = _ledger()
+    hb = ph.DWHeartbeat(probe_fn=lambda: False, ledger=led)
+
+    await hb.beat()  # streak 1 -> not yet degrading
+    assert hb.is_degrading() is False
+
+    await hb.beat()  # streak 2 -> DEGRADING (early signal, < outage window 5)
+    assert hb.is_degrading() is True
+    rec = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    assert rec.consecutive_failures == 2  # 2 < 5 (the outage window)
+
+
+async def test_healthy_probe_clears_degrading():
+    led = _ledger()
+    flips = {"ok": False}
+    hb = ph.DWHeartbeat(probe_fn=lambda: flips["ok"], ledger=led)
+    await hb.beat()
+    await hb.beat()
+    assert hb.is_degrading() is True
+    # DW recovers -> a healthy probe resets the streak -> not degrading.
+    flips["ok"] = True
+    await hb.beat()
+    assert hb.is_degrading() is False
+
+
+# ---------------------------------------------------------------------------
+# A probe exception is itself a degrade signal (fail-soft).
+# ---------------------------------------------------------------------------
+
+async def test_probe_exception_is_degrade_signal():
+    led = _ledger()
+
+    def boom():
+        raise RuntimeError("connection refused")
+
+    hb = ph.DWHeartbeat(probe_fn=boom, ledger=led)
+    # Must NOT raise -- fail-soft.
+    await hb.beat()
+    rec = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    assert rec is not None
+    assert rec.verdict is SurfaceVerdict.TRANSPORT_DEGRADED
+    assert rec.consecutive_failures == 1
+
+
+async def test_async_probe_supported():
+    led = _ledger()
+
+    async def aprobe():
+        return False
+
+    hb = ph.DWHeartbeat(probe_fn=aprobe, ledger=led)
+    await hb.beat()
+    rec = led.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    assert rec.verdict is SurfaceVerdict.TRANSPORT_DEGRADED
+
+
+# ---------------------------------------------------------------------------
+# latest_verdict() exposes the most recent record.
+# ---------------------------------------------------------------------------
+
+async def test_latest_verdict_exposed():
+    led = _ledger()
+    hb = ph.DWHeartbeat(probe_fn=lambda: False, ledger=led)
+    assert hb.latest_verdict() is None
+    await hb.beat()
+    v = hb.latest_verdict()
+    assert v is SurfaceVerdict.TRANSPORT_DEGRADED
+
+
+# ---------------------------------------------------------------------------
+# run() loop is bounded + cancellable (no event-loop starvation).
+# ---------------------------------------------------------------------------
+
+async def test_run_loop_is_cancellable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_INTERVAL_S", "0.01")
+    led = _ledger()
+    beats = {"n": 0}
+
+    def probe():
+        beats["n"] += 1
+        return True
+
+    hb = ph.DWHeartbeat(probe_fn=probe, ledger=led)
+    task = asyncio.create_task(hb.run())
+    await asyncio.sleep(0.05)
+    hb.stop()
+    await asyncio.wait_for(task, timeout=1.0)
+    assert beats["n"] >= 1  # the loop actually beat
+
+
+# ---------------------------------------------------------------------------
+# Singleton + default probe boundary import-clean.
+# ---------------------------------------------------------------------------
+
+def test_singleton_returns_same_instance():
+    a = ph.get_dw_heartbeat()
+    b = ph.get_dw_heartbeat()
+    assert a is b
+
+
+def test_default_probe_fn_importable_and_failsoft():
+    # The default probe must never raise even with no DW reachable.
+    v = ph._default_dw_probe()
+    assert isinstance(v, bool)
+
+
+def test_heartbeat_enabled_gate(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_ENABLED", "false")
+    assert ph.heartbeat_enabled() is False
+    monkeypatch.setenv("JARVIS_DW_HEARTBEAT_ENABLED", "true")
+    assert ph.heartbeat_enabled() is True
+    # Default (unset) -> OFF (default-OFF byte-identical).
+    monkeypatch.delenv("JARVIS_DW_HEARTBEAT_ENABLED", raising=False)
+    assert ph.heartbeat_enabled() is False


### PR DESCRIPTION
The 3 recon gaps (reuse-first): preemptive async DW heartbeat (degrade-before-collapse → early J-Prime pre-warm), Cryo-DLQ→PrimeProvider explicit handoff (endpoint wired post-awaken + provider_override routing, op-never-lost, fail-CLOSED), dead-man script. All gated default-OFF byte-identical. 78 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an early failover path: a DW health heartbeat triggers pre-warming J‑Prime before collapse, wires the awakened node’s endpoint automatically, and routes Cryo‑DLQ replays straight to Prime via a provider override. All changes are gated and default OFF; existing behavior is unchanged.

- **New Features**
  - Preemptive DW heartbeat that records into SurfaceHealthLedger and exposes is_degrading(); gated by JARVIS_DW_HEARTBEAT_ENABLED.
  - Early pre‑warm in failover_lifecycle when degrading + slow recovery forecast (HIGH confidence, R > C*margin); gated by JARVIS_FAILOVER_EARLY_PREWARM_ENABLED; fail‑closed on low confidence/blips.
  - Post‑awaken endpoint wiring: resolves node IP via gcloud describe and publishes JARVIS_PRIME_URL/JARVIS_PRIME_HOST; best‑effort PrimeClient hot‑swap; fail‑soft on errors.
  - Cryo‑DLQ handoff: quarantine stamps provider_override="gcp-jprime"; candidate generator honors it and forces J‑Prime; fail‑closed if Prime is unavailable so the op stays sealed (never routed back to dead DW).
  - Dead‑man startup script is confirmed wired via tests.
  - 78 new tests; gates default OFF keep byte‑identical behavior.

- **Migration**
  - Enable gates as needed: JARVIS_FAILOVER_LIFECYCLE_ENABLED=true, JARVIS_DW_HEARTBEAT_ENABLED=true, JARVIS_FAILOVER_EARLY_PREWARM_ENABLED=true.
  - Ensure gcloud is available and GCP project/zone/node settings are set for IP resolution (GCP_PROJECT_ID/GOOGLE_CLOUD_PROJECT, GCP_ZONE, JARVIS_FAILOVER_NODE_NAME).
  - Verify PrimeProvider reads JARVIS_PRIME_URL/JARVIS_PRIME_HOST; adjust JARVIS_FAILOVER_PROVIDER_OVERRIDE if not using the default "gcp-jprime".
  - Rollback by unsetting the above env flags (system reverts to current behavior).

<sup>Written for commit 1aa4be849b4d9485f7da53fc03ed18252b427761. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69700?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

