### PR TITLE
feat(a1): arm failover mesh + dynamic scoping in soak overlay

### DIFF
--- a/deploy/ouroboros_linux_prod.env
+++ b/deploy/ouroboros_linux_prod.env
@@ -48,3 +48,18 @@ export JARVIS_PROVIDER_CLAUDE_DISABLED=true
 export JARVIS_DW_PRIMARY_OVERRIDE=openai/gpt-oss-120b
 # export JARVIS_DW_PIN_FAIL_THRESHOLD=3
 # export JARVIS_DW_PIN_COOLDOWN_S=120
+
+# ---- Sovereign Failover Mesh ARMED (PRs #69700/#69701) — when DW collapses
+#      (the run-#10 live_transport failure mode), the preemptive heartbeat
+#      detects degradation, the native GCP Compute REST orchestrator awakens
+#      J-Prime from golden image jarvis-prime-coder-golden-20260623 (gcloud-free,
+#      IAM scope self-verified, dynamic zone/IP from metadata), and the Cryo-DLQ
+#      op routes to the awakened PrimeProvider. DW stays PRIMARY (JPRIME_PRIMACY
+#      false) — J-Prime is the FALLBACK, torn down on DW recovery. ----
+export JARVIS_FAILOVER_LIFECYCLE_ENABLED=true
+export JARVIS_DW_HEARTBEAT_ENABLED=true
+export JARVIS_FAILOVER_EARLY_PREWARM_ENABLED=true
+export JARVIS_JPRIME_PRIMACY=false
+# ---- Dynamic test scoping ARMED (#69699): fs.changed -> scoped pytest (kills the
+#      180s SIGKILL that hid the chaos bug in run #10). Default-on; explicit here. ----
+export JARVIS_TEST_DYNAMIC_SCOPING_ENABLED=true


### PR DESCRIPTION
Arms the two run-#10 fixes for the final A1 run. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable A1 soak failover: DW stays primary, and J‑Prime is auto‑booted via GCP Compute REST as fallback on degradation. Also enable dynamic test scoping to stabilize soak runs and expose the prior chaos bug.

- New Features
  - Turn on failover lifecycle, heartbeat, and early prewarm; keep J‑Prime non‑primary and tear down on DW recovery (boot from golden image).
  - Enable dynamic test scoping so only changed tests run, removing the 180s SIGKILL masking.

<sup>Written for commit 4a8c88d29626205740f91d7a339160f83a6c72b5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

