### PR TITLE
feat(a1): boot-time hydration + chaos readiness handshake + failover trigger-signal fix

### DIFF
--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -45,6 +45,15 @@ JARVIS_FAILOVER_LIFECYCLE_ENABLED   default "true" (GRADUATED 2026-06-23; hot-re
     OFF -> controller is inert: stays DORMANT, never awakens. Today's
     behavior exactly (quarantine -> Cryo-DLQ).
 JARVIS_FAILOVER_ROUTE                default "dw" (the quarantine route key)
+JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED default "false" (sub-gate). When ARMED
+    the reactive awaken fires on ANY tracked generation route reaching the SAME
+    full-window rate==0 ``is_global_outage`` -- the AUTHORITATIVE real-generation
+    -failure signal -- not only the single ``JARVIS_FAILOVER_ROUTE`` key. Closes
+    the run-#11 blindspot (DW's cheap probe passed while the BACKGROUND route
+    collapsed). OFF -> byte-identical single-route check.
+JARVIS_FAILOVER_OUTAGE_ROUTES        default "" (comma-separated explicit extra
+    routes to fold into the any-route check; the gradient's tracked routes are
+    authoritative -- this is an operator escape hatch only).
 JARVIS_JPRIME_COLDSTART_S           default 180.0
 JARVIS_CRYO_AWAKEN_MARGIN           default 1.5
 JARVIS_OUTAGE_CONFIRM_S             default 120.0 (reactive-floor confirm window)
@@ -173,6 +182,37 @@ def _early_prewarm_enabled() -> bool:
     J-Prime EARLY so the node is warm by the time DW formally collapses and the
     op drops into the Cryo-DLQ. The operator arms this at soak time."""
     return _enabled("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+
+
+def _any_route_outage_enabled() -> bool:
+    """Authoritative-signal sub-gate: awaken on ANY route's real-generation
+    ``is_global_outage`` (the record_sweep-driven gradient), not only the single
+    configured ``JARVIS_FAILOVER_ROUTE`` key. Default FALSE -> byte-identical.
+
+    Run-#11 blindspot: DW's cheap HeavyProbe passed (partial single-token OK)
+    while the BACKGROUND *generation* route collapsed to rate==0 over a full
+    window (``dw_severed_queued``). The reactive awaken checked only
+    ``is_global_outage("dw")`` -- a key that is NEVER the urgency-routing key
+    ``candidate_generator.record_sweep`` populates -- so it stayed False and
+    J-Prime never awoke. When ARMED, the FSM reacts to ANY tracked route hitting
+    the SAME full-window rate==0 outage threshold (fail-CLOSED: a transient
+    blip / not-yet-full window does NOT trip it -- identical threshold to the
+    quarantine seal). Composes UNDER the master gate; OFF -> reactive path is
+    byte-identical (single ``self._route`` check)."""
+    return _enabled("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "false")
+
+
+def _outage_extra_routes() -> List[str]:
+    """Operator-pinnable explicit extra routes to fold into the any-route outage
+    check (comma-separated ``JARVIS_FAILOVER_OUTAGE_ROUTES``). Default empty ->
+    only the dynamically-tracked routes (plus ``self._route``) are considered.
+    No hardcoded route table -- the gradient's tracked routes are authoritative;
+    this is just an operator escape hatch for a route that hasn't recorded a
+    sweep yet. NEVER raises."""
+    raw = (os.environ.get("JARVIS_FAILOVER_OUTAGE_ROUTES", "") or "").strip()
+    if not raw:
+        return []
+    return [r.strip() for r in raw.split(",") if r.strip()]
 
 
 def _gcloud_fallback_enabled() -> bool:
@@ -999,11 +1039,7 @@ class FailoverLifecycleController:
             if (now - self._last_handback_at) < _handback_cooldown_s():
                 return
 
-        grad = self._gradient()
-        try:
-            outage = grad.is_global_outage(self._route)
-        except Exception:  # noqa: BLE001
-            outage = False
+        outage = self._real_outage()
 
         if outage:
             # Observed full outage. Apply the cryo-trigger cost gate (reactive).
@@ -1027,6 +1063,46 @@ class FailoverLifecycleController:
             )
             await self._enter_awakening(now=now)
             return
+
+    def _real_outage(self) -> bool:
+        """The AUTHORITATIVE real-generation-failure awaken signal.
+
+        Default (sub-gate OFF): the legacy single-route check --
+        ``is_global_outage(self._route)`` -- byte-identical to before.
+
+        When ``JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED`` is ARMED: ANY tracked
+        generation route (plus the configured ``self._route`` + any explicit
+        ``JARVIS_FAILOVER_OUTAGE_ROUTES``) reaching the SAME full-window rate==0
+        ``is_global_outage`` trips the awaken. This closes the run-#11 blindspot
+        where the BACKGROUND route collapsed (rate==0) while the FSM watched only
+        ``"dw"`` -- a key the live record_sweep path never populates. Same
+        threshold as the quarantine Cryo-DLQ seal (fail-CLOSED: a transient blip
+        or not-yet-full window never trips it). Fail-soft -> False (stay
+        reactive; no spurious awaken)."""
+        try:
+            grad = self._gradient()
+        except Exception:  # noqa: BLE001
+            return False
+        if not _any_route_outage_enabled():
+            try:
+                return bool(grad.is_global_outage(self._route))
+            except Exception:  # noqa: BLE001
+                return False
+        # Authoritative any-route path. Fold in the configured route + any
+        # operator-pinned extras so a route that hasn't recorded a sweep yet is
+        # still considered (harmless -- an empty/not-full window reads not-outage).
+        extra = [self._route] + _outage_extra_routes()
+        try:
+            any_fn = getattr(grad, "any_route_in_outage", None)
+            if callable(any_fn):
+                return bool(any_fn(extra_routes=extra))
+            # Fail-CLOSED fallback if the gradient predates the helper: union of
+            # the configured route + extras (no dynamic enumeration available).
+            return any(
+                bool(grad.is_global_outage(r)) for r in extra if r
+            )
+        except Exception:  # noqa: BLE001
+            return False
 
     def _should_early_prewarm(self, *, now: float) -> bool:
         """Gap-2 decision: degradation + slow forecast -> pre-warm early?

--- a/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
@@ -156,6 +156,47 @@ def full_suite_fallback_enabled() -> bool:
     ).lower() in ("true", "1", "yes")
 
 
+# --- Boot-Time Differential Hydration (offline-state blindspot fix) --------
+#
+# An event-driven watcher that boots AFTER a state mutation loses the
+# ``fs.changed`` event forever. The A1 live soak proved this: the chaos bug is
+# mutated BEFORE O+V boots, so no FS event ever fires and the only fallback
+# (the full-suite poll) SIGKILLs at 180s without detecting it. The same hole
+# opens on ANY crash/restart in prod.
+#
+# On boot the sensor reconstructs the missed change set from GROUND TRUTH (the
+# working tree, via ``git diff --name-only HEAD``), resolves each changed file
+# to its tests through the SAME ``resolve_affected_tests`` mapper the live FS
+# path uses, and runs the localized SCOPED pytest immediately. De-dupe tracking
+# (``_hydrated_keys``) suppresses a redundant live ``fs.changed`` run for a file
+# that was just hydrated.
+#
+# Gated ``JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED`` (default true). OFF ->
+# the sensor never hydrates == legacy byte-identical behavior.
+# ``JARVIS_TESTWATCHER_HYDRATION_DEDUP_TTL_S`` (default 120s) bounds the de-dupe
+# window so a genuinely-recurring later edit still re-runs.
+
+
+def boot_hydration_enabled() -> bool:
+    """Re-read ``JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED`` (default true).
+
+    Not cached so tests can monkeypatch per-case (same pattern as
+    ``fs_events_enabled``). OFF restores byte-identical legacy boot behavior.
+    """
+    return os.environ.get(
+        "JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED", "true",
+    ).lower() in ("true", "1", "yes")
+
+
+_HYDRATION_DEDUP_TTL_S: float = float(
+    os.environ.get("JARVIS_TESTWATCHER_HYDRATION_DEDUP_TTL_S", "120")
+)
+
+# Boot-marker the Chaos Readiness Handshake (and operators) grep for to know
+# the TestWatcher subscription is LIVE. Emitted once subscribe_to_bus succeeds.
+TESTWATCHER_READY_MARKER = "[TestWatcher] READY subscribed=fs.changed.*"
+
+
 class TestFailureSensor:
     """Adapter that bridges TestWatcher → UnifiedIntakeRouter.
 
@@ -192,6 +233,11 @@ class TestFailureSensor:
         # convergence tracking during the graduation arc).
         self._fs_events_handled: int = 0
         self._fs_events_ignored: int = 0
+        # Boot hydration de-dupe: changed_rel_path -> monotonic hydrated_at.
+        # A file hydrated on boot is suppressed from a redundant live
+        # fs.changed run for ``_HYDRATION_DEDUP_TTL_S``.
+        self._hydrated_keys: Dict[str, float] = {}
+        self._boot_hydrated: bool = False
 
     def _prune_stale_pending(self) -> None:
         """Drop pending target entries that have exceeded their TTL.
@@ -357,6 +403,99 @@ class TestFailureSensor:
             pass
 
     # ------------------------------------------------------------------
+    # Boot-Time Differential Hydration (offline-state blindspot fix)
+    # ------------------------------------------------------------------
+
+    def _is_recently_hydrated(self, changed_rel_path: str) -> bool:
+        """True if *changed_rel_path* was hydrated within the de-dupe TTL.
+
+        Lets a live ``fs.changed`` for a just-hydrated file be suppressed so
+        the same edit is not double-run (boot hydration + live event). A
+        different file (or one whose TTL expired) is not suppressed.
+        """
+        if _HYDRATION_DEDUP_TTL_S <= 0 or not changed_rel_path:
+            return False
+        ts = self._hydrated_keys.get(changed_rel_path)
+        if ts is None:
+            return False
+        if time.monotonic() - ts > _HYDRATION_DEDUP_TTL_S:
+            # Expired -> drop the entry and allow a fresh run.
+            self._hydrated_keys.pop(changed_rel_path, None)
+            return False
+        return True
+
+    async def hydrate_on_boot(self) -> int:
+        """Reconstruct + scope-run tests for pre-boot working-tree changes.
+
+        Ground-truth recovery of the offline-state blindspot: enumerate
+        uncommitted ``.py`` changes via ``TestWatcher.diff_working_tree``
+        (async ``git diff --name-only HEAD``), resolve each through the SAME
+        ``resolve_affected_tests`` mapper the live FS path uses, run the
+        localized SCOPED pytest (NEVER the whole ``tests/`` suite), and ingest
+        any resulting stable signals. Each hydrated file is recorded so a
+        later live ``fs.changed`` for it is de-duped.
+
+        Returns the number of stable signals ingested. Gated
+        ``JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED`` (default true); OFF /
+        no watcher / clean tree -> returns 0 with no side effects. Fail-soft:
+        any error logs at DEBUG and returns the count so far -- boot is never
+        crashed.
+        """
+        if not boot_hydration_enabled() or self._watcher is None:
+            return 0
+        try:
+            changed = await self._watcher.diff_working_tree()
+        except Exception:
+            logger.debug("[BootHydration] diff_working_tree failed", exc_info=True)
+            return 0
+        if not changed:
+            logger.debug("[BootHydration] clean working tree -- nothing to hydrate")
+            self._boot_hydrated = True
+            return 0
+
+        ingested = 0
+        now = time.monotonic()
+        for rel in changed:
+            try:
+                targets = await self._resolve_scoped_targets(rel)
+            except Exception:
+                logger.debug(
+                    "[BootHydration] resolve failed for %r", rel, exc_info=True
+                )
+                continue
+            if not targets:
+                # No scoped targets -> skip (never the 180s whole-suite sweep).
+                logger.debug(
+                    "[BootHydration] no scoped targets for %r -- skipping", rel
+                )
+                continue
+            # Record BEFORE running so a concurrent live event is de-duped.
+            self._hydrated_keys[rel] = now
+            try:
+                signals = await self._watcher.poll_once(target_paths=targets)
+            except Exception:
+                logger.debug(
+                    "[BootHydration] scoped poll failed for %r", rel, exc_info=True
+                )
+                continue
+            if signals:
+                results = await self.handle_signals(signals)
+                ingested += sum(1 for r in results if r is not None)
+                logger.info(
+                    "[BootHydration] %r -> %d scoped target(s), %d stable "
+                    "signal(s) ingested (NO fs.changed event needed)",
+                    rel, len(targets), len(signals),
+                )
+        self._boot_hydrated = True
+        if ingested:
+            logger.info(
+                "[BootHydration] boot hydration complete: %d stable failure(s) "
+                "recovered from working tree (%d changed .py file(s))",
+                ingested, len(changed),
+            )
+        return ingested
+
+    # ------------------------------------------------------------------
     # Event-driven path (Manifesto §3: zero polling, pure reflex)
     # ------------------------------------------------------------------
 
@@ -413,6 +552,29 @@ class TestFailureSensor:
             "FS events now PRIMARY (poll demoted to %ds fallback)",
             int(_TEST_FAILURE_FALLBACK_INTERVAL_S),
         )
+
+        # Boot-marker -- the subscription is now LIVE. The Chaos Readiness
+        # Handshake (and operators) grep this exact line to know the bus +
+        # TestWatcher are listening before any mutation. Emitted to stdout
+        # (flushed) so it lands in the soak log the external probe tails, and
+        # mirrored to the INFO log. Fail-soft: a print failure never breaks boot.
+        try:
+            import sys as _sys
+
+            print(TESTWATCHER_READY_MARKER, file=_sys.stdout, flush=True)
+        except Exception:  # noqa: BLE001 -- marker is best-effort
+            pass
+        logger.info("%s", TESTWATCHER_READY_MARKER)
+
+        # Boot-Time Differential Hydration -- reconstruct any pre-boot working-
+        # tree mutation from ground truth NOW that the subscription is live (so
+        # a file later touched live is de-duped). Gated + fail-soft inside
+        # ``hydrate_on_boot``; a missed FS event (chaos injected before boot,
+        # crash/restart) is no longer lost.
+        try:
+            await self.hydrate_on_boot()
+        except Exception:  # noqa: BLE001 -- hydration must never break intake boot
+            logger.debug("TestFailureSensor: boot hydration error", exc_info=True)
 
     async def _on_fs_event(self, event: Any) -> None:
         """Route events: test_results.json → instant consume; .py → debounced pytest."""
@@ -525,6 +687,18 @@ class TestFailureSensor:
                 )
                 return
             if self._watcher is None:
+                return
+
+            # Boot-hydration de-dupe: a file just reconstructed from the
+            # working tree on boot must not be re-run by the live event that
+            # the same edit also triggers. The TTL window expires so a genuine
+            # later edit still re-runs.
+            if changed_rel_path and self._is_recently_hydrated(changed_rel_path):
+                logger.debug(
+                    "TestFailureSensor: suppressing live run for %r -- "
+                    "hydrated on boot within de-dupe window",
+                    changed_rel_path,
+                )
                 return
 
             if not dynamic_scoping_enabled():

--- a/backend/core/ouroboros/governance/intent/test_watcher.py
+++ b/backend/core/ouroboros/governance/intent/test_watcher.py
@@ -206,6 +206,85 @@ class TestWatcher:
         return result.stdout, result.returncode
 
     # ------------------------------------------------------------------
+    # Boot-Time Differential Hydration (offline-state blindspot fix)
+    # ------------------------------------------------------------------
+
+    async def diff_working_tree(self) -> List[str]:
+        """Enumerate uncommitted working-tree ``.py`` changes from ground truth.
+
+        Runs ``git diff --name-only HEAD`` (tracked, uncommitted) plus
+        ``git ls-files --others --exclude-standard`` (untracked) via
+        ``asyncio.create_subprocess_exec`` so the event loop is NEVER blocked.
+        Only ``.py`` paths are returned (the watcher's mutation surface).
+
+        This is the ground-truth half of Boot-Time Differential Hydration:
+        an event-driven watcher that boots AFTER a state mutation (chaos
+        injection BEFORE O+V boots, or any crash/restart in prod) loses the
+        ``fs.changed`` event forever. Reconstructing the change set from the
+        working tree is robust to that whole failure class.
+
+        Fail-soft by construction: a git error / missing binary / non-zero
+        return code logs at DEBUG and returns ``[]`` -- hydration is skipped,
+        boot is never crashed. Bounded by ``JARVIS_TESTWATCHER_HYDRATION_GIT_TIMEOUT_S``
+        (default 15s) so a wedged git cannot stall the boot path.
+        """
+        try:
+            timeout_s = float(
+                os.environ.get(
+                    "JARVIS_TESTWATCHER_HYDRATION_GIT_TIMEOUT_S", "15"
+                )
+            )
+        except (TypeError, ValueError):
+            timeout_s = 15.0
+
+        async def _git(*args: str) -> List[str]:
+            try:
+                proc = await asyncio.create_subprocess_exec(
+                    "git", *args,
+                    cwd=str(self.repo_path),
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                )
+            except (OSError, Exception) as exc:  # noqa: BLE001 -- git is best-effort
+                logger.debug("[BootHydration] git %s spawn failed: %s", args, exc)
+                return []
+            try:
+                stdout, _stderr = await asyncio.wait_for(
+                    proc.communicate(), timeout=timeout_s
+                )
+            except asyncio.TimeoutError:
+                logger.debug("[BootHydration] git %s timed out (%.1fs)", args, timeout_s)
+                try:
+                    proc.kill()
+                except Exception:  # noqa: BLE001
+                    pass
+                return []
+            except Exception as exc:  # noqa: BLE001 -- never crash boot
+                logger.debug("[BootHydration] git %s communicate failed: %s", args, exc)
+                return []
+            if proc.returncode not in (0, None):
+                logger.debug(
+                    "[BootHydration] git %s rc=%s -- skipping", args, proc.returncode
+                )
+                return []
+            text = (stdout or b"").decode("utf-8", errors="replace")
+            return [ln.strip() for ln in text.splitlines() if ln.strip()]
+
+        changed: List[str] = []
+        seen: Set[str] = set()
+        # Tracked, uncommitted changes (the chaos mutation lands here).
+        for path in await _git("diff", "--name-only", "HEAD"):
+            if path.endswith(".py") and path not in seen:
+                seen.add(path)
+                changed.append(path)
+        # Untracked .py files (new modules a crash left behind).
+        for path in await _git("ls-files", "--others", "--exclude-standard"):
+            if path.endswith(".py") and path not in seen:
+                seen.add(path)
+                changed.append(path)
+        return changed
+
+    # ------------------------------------------------------------------
     # Output parsing
     # ------------------------------------------------------------------
 

--- a/backend/core/ouroboros/governance/provider_quarantine.py
+++ b/backend/core/ouroboros/governance/provider_quarantine.py
@@ -163,6 +163,59 @@ class ProviderHealthGradient:
             )
             return False
 
+    def tracked_routes(self) -> list:
+        """Return the list of routes that currently have a rolling window.
+
+        These are the routes the gradient has actually observed sweeps for
+        (e.g. ``"background"``, ``"standard"``, ``"complex"`` -- the live
+        urgency-routing keys ``candidate_generator.record_sweep`` populates).
+        Public so consumers (e.g. the Failover FSM) can react to ANY route's
+        outage rather than a single hardcoded key -- the run-#11 blindspot was
+        the FSM watching only ``"dw"`` while the BACKGROUND route's window hit
+        rate==0. Fail-soft: any error returns an empty list (conservative).
+        """
+        try:
+            return list(self._windows.keys())
+        except Exception:  # pragma: no cover
+            logger.debug("[ProviderQuarantine] tracked_routes fail-soft", exc_info=True)
+            return []
+
+    def any_route_in_outage(self, *, extra_routes: Any = None) -> bool:
+        """Return True iff ANY tracked route (plus any *extra_routes*) is in a
+        full ``is_global_outage`` (window FULL and success_rate == 0.0).
+
+        This is the AUTHORITATIVE real-generation-failure signal: a probe-based
+        heartbeat can pass (HeavyProbe partial-OK) while a specific *generation*
+        route (BACKGROUND in run #11) collapses to rate==0 across a full window.
+        Reuses ``is_global_outage`` per-route verbatim -- same threshold, no new
+        machinery, no relaxation (fail-CLOSED: a transient blip / not-yet-full
+        window never trips it). Fail-soft: any error returns False (stay
+        reactive -- no spurious awaken).
+
+        *extra_routes* lets the caller fold in a configured route key (e.g. the
+        FSM's ``JARVIS_FAILOVER_ROUTE``) even before that key has recorded a
+        sweep -- harmless because an empty / not-full window reads not-outage.
+        """
+        try:
+            routes = set(self.tracked_routes())
+            if extra_routes:
+                if isinstance(extra_routes, str):
+                    routes.add(extra_routes)
+                else:
+                    try:
+                        routes.update(str(r) for r in extra_routes if r)
+                    except TypeError:
+                        routes.add(str(extra_routes))
+            for route in routes:
+                if self.is_global_outage(route):
+                    return True
+            return False
+        except Exception:  # pragma: no cover
+            logger.debug(
+                "[ProviderQuarantine] any_route_in_outage fail-soft", exc_info=True
+            )
+            return False
+
     def reset(self, route: str) -> None:
         """Clear the window for *route*. Fail-soft."""
         try:

--- a/scripts/chaos_injector_ast.py
+++ b/scripts/chaos_injector_ast.py
@@ -41,12 +41,13 @@ from __future__ import annotations
 
 import argparse
 import ast
+import asyncio
 import json
 import os
 import subprocess
 import sys
 from dataclasses import dataclass, field
-from typing import List, Optional, Sequence, Tuple
+from typing import Awaitable, Callable, List, Optional, Sequence, Tuple
 
 # Standalone-invocation bootstrap: ensure the repo root (parent of scripts/) is
 # on sys.path. We DELIBERATELY do not import anything from backend/* -- this is
@@ -915,6 +916,11 @@ class InjectConfig:
     test_timeout_s: float = 60.0
     verify_green: bool = True   # run the test pre-injection to confirm green
     max_attempts: int = 25
+    # Chaos Readiness Handshake: optional readiness surface to probe BEFORE
+    # mutating. Empty -> handshake skipped (standalone / dry-run / unit-test
+    # usage). Env fallbacks: JARVIS_CHAOS_READINESS_URL / _LOG.
+    readiness_url: str = ""
+    readiness_log: str = ""
 
 
 def _select_function_node(src: str, func_name: str, lineno: int) -> Optional[ast.FunctionDef]:
@@ -962,6 +968,22 @@ def do_inject(cfg: InjectConfig) -> int:
         # green-pre check for any candidate touching that file).
         _log("--force: reverting prior active mutation before re-injecting.")
         do_revert(cfg)
+
+    # CHAOS READINESS HANDSHAKE -- never mutate into a dead bus. If a readiness
+    # surface is configured (and the probe is enabled), wait for O+V's bus +
+    # TestWatcher to be listening before touching a single byte. A graceful
+    # timeout aborts the inject with a clear locus instead of mutating blind.
+    check = _build_readiness_check(cfg)
+    if check is not None and readiness_probe_enabled():
+        _log("readiness handshake: probing O+V bus/TestWatcher before mutating...")
+        ready, locus = asyncio.run(await_chaos_readiness(check))
+        if not ready:
+            _log(
+                f"readiness ABORT [{locus}]: O+V not ready; no mutation performed."
+            )
+            print(json.dumps({"status": "aborted", "failure_locus": locus}, indent=2))
+            return 7
+        _log("readiness OK: O+V bus/TestWatcher live -- proceeding to mutate.")
 
     candidates = acquire_candidates(cfg)
     if not candidates:
@@ -1236,6 +1258,212 @@ def do_list_candidates(cfg: InjectConfig) -> int:
 
 
 # --------------------------------------------------------------------------- #
+# Chaos Readiness Handshake -- never mutate into a dead bus.
+# --------------------------------------------------------------------------- #
+#
+# THE BUG (A1 live soak): the injector mutated a file BEFORE O+V's
+# TrinityEventBus + TestWatcher were initialized and listening, so the live
+# ``fs.changed`` event fired into a void and the mutation was lost. Boot
+# hydration recovers the offline case from ground truth; this handshake covers
+# the live case by REFUSING to mutate until the bus + TestWatcher are
+# demonstrably ready.
+#
+# The probe is ASYNC + bounded-deadline + exponential-backoff. It consults a
+# readiness surface that O+V already exposes -- preferred: an HTTP health
+# endpoint (``/channel/health`` / ``/observability/health``) carrying a
+# ``testwatcher_ready`` field; alternative: the stdout/log BOOT-MARKER
+# ``[TestWatcher] READY subscribed=fs.changed.*`` the TestFailureSensor emits
+# once its fs.changed subscription is live. On timeout it returns a graceful
+# (False, "CHAOS_READINESS_TIMEOUT") -- a clear locus, never a blind mutate.
+#
+# Gated ``JARVIS_CHAOS_READINESS_PROBE_ENABLED`` (default true). OFF -> the
+# probe is a no-op that reports ready (legacy blind-inject), preserving the
+# pre-handshake behavior byte-for-byte. NO ``time.sleep``: the synchronization
+# is ``asyncio.sleep`` with env-tuned bounded deadlines.
+
+TESTWATCHER_READY_MARKER = "[TestWatcher] READY subscribed=fs.changed.*"
+
+ReadinessCheck = Callable[[], Awaitable[bool]]
+
+
+def readiness_probe_enabled() -> bool:
+    """Re-read ``JARVIS_CHAOS_READINESS_PROBE_ENABLED`` (default true)."""
+    return os.environ.get(
+        "JARVIS_CHAOS_READINESS_PROBE_ENABLED", "true",
+    ).strip().lower() in ("true", "1", "yes")
+
+
+def _readiness_deadline_s() -> float:
+    """Bounded overall probe deadline (env ``JARVIS_CHAOS_READINESS_DEADLINE_S``)."""
+    try:
+        val = float(os.environ.get("JARVIS_CHAOS_READINESS_DEADLINE_S", "120"))
+        return val if val > 0 else 120.0
+    except (TypeError, ValueError):
+        return 120.0
+
+
+def _readiness_initial_backoff_s() -> float:
+    """Initial backoff between polls (env ``JARVIS_CHAOS_READINESS_BACKOFF_S``)."""
+    try:
+        val = float(os.environ.get("JARVIS_CHAOS_READINESS_BACKOFF_S", "0.5"))
+        return val if val > 0 else 0.5
+    except (TypeError, ValueError):
+        return 0.5
+
+
+def _readiness_backoff_max_s() -> float:
+    """Backoff ceiling (env ``JARVIS_CHAOS_READINESS_BACKOFF_MAX_S``)."""
+    try:
+        val = float(os.environ.get("JARVIS_CHAOS_READINESS_BACKOFF_MAX_S", "5"))
+        return val if val > 0 else 5.0
+    except (TypeError, ValueError):
+        return 5.0
+
+
+async def _fetch_health_json(url: str, timeout_s: float) -> Optional[dict]:
+    """Fetch + parse a JSON health surface off-loop. Returns None on any error.
+
+    Uses stdlib ``urllib`` in a worker thread so the probe stays non-blocking
+    and the injector keeps its zero-backend-import discipline (no aiohttp dep).
+    """
+    def _blocking() -> Optional[dict]:
+        import urllib.request
+
+        try:
+            with urllib.request.urlopen(url, timeout=timeout_s) as resp:
+                raw = resp.read().decode("utf-8", errors="replace")
+            return json.loads(raw)
+        except Exception:  # noqa: BLE001 -- surface may not be up yet
+            return None
+
+    try:
+        return await asyncio.to_thread(_blocking)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def make_http_readiness_check(url: str, *, timeout_s: float = 2.0) -> ReadinessCheck:
+    """Build an async readiness check that polls an HTTP health surface.
+
+    Ready iff the JSON carries a truthy ``testwatcher_ready`` (or
+    ``testwatcher_subscribed``) field. An unreachable / non-JSON surface is
+    treated as not-ready (the probe keeps backing off), never an error.
+    """
+    async def _check() -> bool:
+        data = await _fetch_health_json(url, timeout_s)
+        if not isinstance(data, dict):
+            return False
+        return bool(
+            data.get("testwatcher_ready") or data.get("testwatcher_subscribed")
+        )
+
+    return _check
+
+
+def make_log_marker_readiness_check(
+    log_path: str, *, marker: str = TESTWATCHER_READY_MARKER,
+) -> ReadinessCheck:
+    """Build an async readiness check that scans a log/stdout file for *marker*.
+
+    Ready iff the boot-marker line is present. A missing / unreadable file is
+    not-ready, never an error. The read is off-loop (worker thread).
+    """
+    async def _check() -> bool:
+        def _blocking() -> bool:
+            try:
+                with open(log_path, "r", encoding="utf-8", errors="replace") as fh:
+                    return marker in fh.read()
+            except OSError:
+                return False
+
+        try:
+            return await asyncio.to_thread(_blocking)
+        except Exception:  # noqa: BLE001
+            return False
+
+    return _check
+
+
+async def await_chaos_readiness(
+    check: ReadinessCheck,
+    *,
+    deadline_s: Optional[float] = None,
+    initial_backoff_s: Optional[float] = None,
+    backoff_factor: float = 2.0,
+    backoff_max_s: Optional[float] = None,
+) -> Tuple[bool, str]:
+    """Async, bounded, exponential-backoff wait for O+V to be inject-ready.
+
+    Repeatedly awaits *check* (an async predicate over a readiness surface)
+    until it returns True or the overall *deadline_s* elapses. Between polls it
+    ``asyncio.sleep``s a backoff that grows by *backoff_factor* up to
+    *backoff_max_s* -- NO fixed wait constant, no blocking synchronous sleep.
+    A *check* that raises is swallowed (the surface may be transiently
+    unreachable) and the probe keeps backing off.
+
+    Returns
+    -------
+    ``(True, "")`` once ready, or ``(False, "CHAOS_READINESS_TIMEOUT")`` when
+    the deadline elapses without readiness -- a graceful failure locus the
+    caller surfaces instead of mutating into a dead bus.
+
+    Gated ``JARVIS_CHAOS_READINESS_PROBE_ENABLED`` (default true). OFF returns
+    ``(True, "")`` immediately WITHOUT consulting *check* (legacy blind inject).
+    """
+    if not readiness_probe_enabled():
+        return (True, "")
+
+    deadline = deadline_s if deadline_s is not None else _readiness_deadline_s()
+    backoff = (
+        initial_backoff_s
+        if initial_backoff_s is not None
+        else _readiness_initial_backoff_s()
+    )
+    backoff_ceiling = (
+        backoff_max_s if backoff_max_s is not None else _readiness_backoff_max_s()
+    )
+
+    loop = asyncio.get_event_loop()
+    start = loop.time()
+    while True:
+        try:
+            if await check():
+                return (True, "")
+        except Exception as exc:  # noqa: BLE001 -- surface errors must not crash the probe
+            _log("readiness check raised (treating as not-ready): %r" % (exc,))
+        # Deadline check BEFORE sleeping so we don't oversleep past it.
+        elapsed = loop.time() - start
+        if elapsed >= deadline:
+            _log(
+                "CHAOS_READINESS_TIMEOUT after %.1fs -- O+V bus/TestWatcher not "
+                "ready; refusing to mutate into a dead bus." % (elapsed,)
+            )
+            return (False, "CHAOS_READINESS_TIMEOUT")
+        # Bound the sleep so we never overshoot the deadline.
+        remaining = max(0.0, deadline - elapsed)
+        await asyncio.sleep(min(backoff, backoff_ceiling, remaining) or backoff_ceiling)
+        backoff = min(backoff * backoff_factor, backoff_ceiling)
+
+
+def _build_readiness_check(cfg: "InjectConfig") -> Optional[ReadinessCheck]:
+    """Pick the readiness surface from config / env. Returns None if none set.
+
+    Preference: explicit HTTP URL -> explicit log-marker path. When neither is
+    configured the handshake is skipped (the caller treats it as ready) so the
+    injector stays usable standalone (dry-run, unit tests) without a live O+V.
+    """
+    url = (cfg.readiness_url or os.environ.get("JARVIS_CHAOS_READINESS_URL", "")).strip()
+    if url:
+        return make_http_readiness_check(url)
+    log_path = (
+        cfg.readiness_log or os.environ.get("JARVIS_CHAOS_READINESS_LOG", "")
+    ).strip()
+    if log_path:
+        return make_log_marker_readiness_check(log_path)
+    return None
+
+
+# --------------------------------------------------------------------------- #
 # CLI.
 # --------------------------------------------------------------------------- #
 
@@ -1270,6 +1498,14 @@ def build_arg_parser() -> argparse.ArgumentParser:
                    help="Per-test pytest timeout (seconds).")
     p.add_argument("--no-verify", action="store_true",
                    help="Skip pre/post pytest verification (NOT recommended).")
+    p.add_argument("--readiness-url", default="",
+                   help="HTTP health surface to probe for 'testwatcher_ready' "
+                        "before mutating (Chaos Readiness Handshake). Env: "
+                        "JARVIS_CHAOS_READINESS_URL.")
+    p.add_argument("--readiness-log", default="",
+                   help="Log/stdout file to scan for the TestWatcher READY "
+                        "boot-marker before mutating. Env: "
+                        "JARVIS_CHAOS_READINESS_LOG.")
     return p
 
 
@@ -1284,6 +1520,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         force=bool(args.force),
         test_timeout_s=float(args.test_timeout),
         verify_green=not bool(args.no_verify),
+        readiness_url=str(args.readiness_url or ""),
+        readiness_log=str(args.readiness_log or ""),
     )
 
     if args.inject:

--- a/tests/governance/intent/test_boot_hydration.py
+++ b/tests/governance/intent/test_boot_hydration.py
@@ -1,0 +1,301 @@
+"""Tests for Boot-Time Differential Hydration (TestWatcher offline-state fix).
+
+THE BUG (A1 live soak): the TestWatcher relies on live ``fs.changed`` events,
+but the chaos bug is mutated BEFORE O+V boots -> no event fires -> the full-suite
+poll SIGKILLs at 180s -> the bug is never detected. Architecturally, an
+event-driven watcher that boots AFTER a state mutation loses it forever (also
+true on any crash/restart in prod).
+
+The fix reconstructs missed mutations from ground truth (the working tree) on
+every boot:
+
+1. ``TestWatcher.diff_working_tree()`` runs an async ``git diff --name-only
+   HEAD`` (+ untracked ``.py`` via ``git ls-files --others``) to enumerate
+   uncommitted changes -- non-blocking subprocess, fail-soft.
+2. ``TestFailureSensor.hydrate_on_boot()`` resolves each changed source file
+   to its tests via the EXISTING ``resolve_affected_tests`` and runs the
+   localized SCOPED pytest (NOT ``tests/``), de-duping against later live
+   ``fs.changed`` events for the same file.
+
+Both gated ``JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED`` (default true);
+OFF == legacy byte-identical.
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.intent.test_watcher import (
+    TestFailure,
+    TestWatcher,
+)
+from backend.core.ouroboros.governance.intake.sensors.test_failure_sensor import (
+    TestFailureSensor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeRouter:
+    def __init__(self) -> None:
+        self.ingested: List[Any] = []
+
+    async def ingest(self, envelope: Any) -> str:
+        self.ingested.append(envelope)
+        return "enqueued"
+
+
+class _RecordingWatcher:
+    """A TestWatcher stand-in that records the target_paths it was asked to run.
+
+    ``poll_once`` returns one stable IntentSignal so we can prove the hydration
+    path reaches ``handle_signals`` -> ``router.ingest``.
+    """
+
+    def __init__(self, repo_path: str, *, diff_files: Sequence[str]) -> None:
+        self.repo_path = repo_path
+        self.poll_interval_s = 30.0
+        self._diff_files = list(diff_files)
+        self.poll_calls: List[Optional[Sequence[str]]] = []
+
+    async def diff_working_tree(self) -> List[str]:
+        return list(self._diff_files)
+
+    async def poll_once(
+        self, target_paths: Optional[Sequence[str]] = None
+    ) -> List[Any]:
+        self.poll_calls.append(
+            list(target_paths) if target_paths is not None else None
+        )
+        # Emit a stable signal targeting the resolved test file so the
+        # sensor's ingest path is exercised.
+        from backend.core.ouroboros.governance.intent.signals import IntentSignal
+
+        target = (target_paths[0] if target_paths else "tests/unknown.py")
+        return [
+            IntentSignal(
+                source="intent:test_failure",
+                target_files=(target,),
+                repo="jarvis",
+                description="hydrated stable failure",
+                evidence={"signature": "x"},
+                confidence=0.9,
+                stable=True,
+            )
+        ]
+
+
+def _make_sensor(
+    repo_path: str, diff_files: Sequence[str]
+) -> Tuple[TestFailureSensor, _RecordingWatcher, _FakeRouter]:
+    watcher = _RecordingWatcher(repo_path, diff_files=diff_files)
+    router = _FakeRouter()
+    sensor = TestFailureSensor(repo="jarvis", router=router, test_watcher=watcher)
+    return sensor, watcher, router
+
+
+# ---------------------------------------------------------------------------
+# 1. Watcher.diff_working_tree runs git diff --name-only HEAD (async, non-block)
+# ---------------------------------------------------------------------------
+
+
+class TestDiffWorkingTree:
+    def test_runs_git_diff_name_only_head(self, monkeypatch: Any) -> None:
+        captured: Dict[str, Any] = {}
+
+        async def _fake_exec(*argv: str, **kwargs: Any) -> Any:
+            captured.setdefault("argvs", []).append(list(argv))
+
+            class _Proc:
+                returncode = 0
+
+                async def communicate(self) -> Tuple[bytes, bytes]:
+                    if "diff" in argv:
+                        return (b"backend/core/utils/calc.py\n", b"")
+                    # ls-files --others
+                    return (b"", b"")
+
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        watcher = TestWatcher(repo="jarvis", repo_path="/repo")
+        out = asyncio.run(watcher.diff_working_tree())
+
+        # Assert the git diff --name-only HEAD command was issued.
+        diff_argv = next(a for a in captured["argvs"] if "diff" in a)
+        assert "git" in diff_argv[0] or diff_argv[0] == "git"
+        assert "diff" in diff_argv
+        assert "--name-only" in diff_argv
+        assert "HEAD" in diff_argv
+        assert "backend/core/utils/calc.py" in out
+
+    def test_includes_untracked_py(self, monkeypatch: Any) -> None:
+        async def _fake_exec(*argv: str, **kwargs: Any) -> Any:
+            class _Proc:
+                returncode = 0
+
+                async def communicate(self) -> Tuple[bytes, bytes]:
+                    if "diff" in argv:
+                        return (b"", b"")
+                    if "ls-files" in argv:
+                        return (b"backend/new_mod.py\nREADME.md\n", b"")
+                    return (b"", b"")
+
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        watcher = TestWatcher(repo="jarvis", repo_path="/repo")
+        out = asyncio.run(watcher.diff_working_tree())
+        assert "backend/new_mod.py" in out
+        # Non-.py untracked files are filtered out.
+        assert "README.md" not in out
+
+    def test_git_error_returns_empty_no_raise(self, monkeypatch: Any) -> None:
+        async def _boom(*argv: str, **kwargs: Any) -> Any:
+            raise OSError("git not found")
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _boom)
+        watcher = TestWatcher(repo="jarvis", repo_path="/repo")
+        # Must NOT raise -- graceful skip.
+        out = asyncio.run(watcher.diff_working_tree())
+        assert out == []
+
+    def test_nonzero_returncode_returns_empty(self, monkeypatch: Any) -> None:
+        async def _fake_exec(*argv: str, **kwargs: Any) -> Any:
+            class _Proc:
+                returncode = 128
+
+                async def communicate(self) -> Tuple[bytes, bytes]:
+                    return (b"", b"fatal: not a git repository")
+
+            return _Proc()
+
+        monkeypatch.setattr(asyncio, "create_subprocess_exec", _fake_exec)
+        watcher = TestWatcher(repo="jarvis", repo_path="/repo")
+        out = asyncio.run(watcher.diff_working_tree())
+        assert out == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Core fix: a pre-boot-mutated file is detected on boot with NO fs.changed
+# ---------------------------------------------------------------------------
+
+
+class TestPreBootMutationDetected:
+    def test_pre_boot_mutation_detected_via_git_diff(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        """The whole point: a file mutated BEFORE boot (no fs.changed event)
+        is reconstructed from `git diff` and its tests run scoped."""
+        # The changed source file the chaos injector mutated pre-boot.
+        changed = "backend/core/utils/calc.py"
+        sensor, watcher, router = _make_sensor(str(tmp_path), [changed])
+
+        # Resolver maps calc.py -> tests/test_calc.py (scoped, NOT tests/).
+        async def _fake_resolve(self_sensor: Any, rel: str) -> Optional[List[str]]:
+            assert rel == changed
+            return ["tests/utils/test_calc.py"]
+
+        monkeypatch.setattr(
+            TestFailureSensor, "_resolve_scoped_targets", _fake_resolve
+        )
+
+        n = asyncio.run(sensor.hydrate_on_boot())
+
+        # A scoped pytest ran with the resolved test target (NOT the whole suite).
+        assert watcher.poll_calls, "hydration must run at least one scoped poll"
+        ran = watcher.poll_calls[0]
+        assert ran == ["tests/utils/test_calc.py"]
+        assert ran != ["tests/"] and "tests/" not in (ran or [])
+        # The stable signal was ingested -> bug detected with NO fs.changed.
+        assert n >= 1
+        assert router.ingested, "the pre-boot bug must reach the router"
+
+    def test_scoped_not_full_suite(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        sensor, watcher, _router = _make_sensor(
+            str(tmp_path), ["backend/a.py"]
+        )
+
+        async def _fake_resolve(self_sensor: Any, rel: str) -> Optional[List[str]]:
+            return ["tests/test_a.py"]
+
+        monkeypatch.setattr(
+            TestFailureSensor, "_resolve_scoped_targets", _fake_resolve
+        )
+        asyncio.run(sensor.hydrate_on_boot())
+        for call in watcher.poll_calls:
+            assert call is not None  # never the whole-suite (None) sweep
+            assert "tests/" not in call
+
+
+# ---------------------------------------------------------------------------
+# 3. De-dupe: a hydrated file later touched live is not double-run
+# ---------------------------------------------------------------------------
+
+
+class TestDeDupeVsLiveEvent:
+    def test_hydrated_file_not_rerun_by_later_fs_event(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        changed = "backend/core/utils/calc.py"
+        sensor, watcher, _router = _make_sensor(str(tmp_path), [changed])
+
+        async def _fake_resolve(self_sensor: Any, rel: str) -> Optional[List[str]]:
+            return ["tests/utils/test_calc.py"]
+
+        monkeypatch.setattr(
+            TestFailureSensor, "_resolve_scoped_targets", _fake_resolve
+        )
+
+        # Boot hydration records the file as freshly hydrated.
+        asyncio.run(sensor.hydrate_on_boot())
+        calls_after_boot = len(watcher.poll_calls)
+
+        # A live fs.changed for the SAME file arriving immediately after boot
+        # must be suppressed by the hydration de-dupe window.
+        assert sensor._is_recently_hydrated(changed) is True
+
+        # A DIFFERENT file is not suppressed.
+        assert sensor._is_recently_hydrated("backend/core/other.py") is False
+        assert len(watcher.poll_calls) == calls_after_boot
+
+
+# ---------------------------------------------------------------------------
+# 4. OFF flag -> legacy behavior byte-identical (no hydration runs)
+# ---------------------------------------------------------------------------
+
+
+class TestGatedOff:
+    def test_off_flag_skips_hydration(
+        self, monkeypatch: Any, tmp_path: Path
+    ) -> None:
+        monkeypatch.setenv("JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED", "false")
+        sensor, watcher, router = _make_sensor(
+            str(tmp_path), ["backend/a.py"]
+        )
+
+        async def _fake_resolve(self_sensor: Any, rel: str) -> Optional[List[str]]:
+            return ["tests/test_a.py"]
+
+        monkeypatch.setattr(
+            TestFailureSensor, "_resolve_scoped_targets", _fake_resolve
+        )
+        n = asyncio.run(sensor.hydrate_on_boot())
+        assert n == 0
+        assert watcher.poll_calls == []
+        assert router.ingested == []
+
+    def test_no_diff_no_runs(self, monkeypatch: Any, tmp_path: Path) -> None:
+        # Clean working tree -> nothing to hydrate.
+        sensor, watcher, _router = _make_sensor(str(tmp_path), [])
+        n = asyncio.run(sensor.hydrate_on_boot())
+        assert n == 0
+        assert watcher.poll_calls == []

--- a/tests/governance/test_failover_trigger_signal.py
+++ b/tests/governance/test_failover_trigger_signal.py
@@ -1,0 +1,359 @@
+"""Tests for the AUTHORITATIVE real-generation-failure awaken trigger.
+
+Run-#11 blindspot (2026-06-24)
+------------------------------
+DW's cheap ``dw_heavy_probe`` HeavyProbe showed PARTIAL success (single-token
+pings OK) so the probe-based heartbeat ``is_degrading()`` was False -- yet the
+ACTUAL BACKGROUND *generation* collapsed (``dw_severed_queued`` ->
+``fallback_tolerance=queue``), driving the per-route ProviderHealthGradient for
+the ``"background"`` route to rate==0 across a FULL window
+(``is_global_outage("background") == True``). The Failover FSM watched ONLY the
+single configured ``JARVIS_FAILOVER_ROUTE`` key (default ``"dw"``) -- a key the
+live ``candidate_generator.record_sweep`` path NEVER populates -- so the awaken
+stayed False and J-Prime never awoke (0 awaken / 0 instances.insert).
+
+The fix wires the FSM's reactive awaken to the AUTHORITATIVE any-route
+``is_global_outage`` signal (the record_sweep-driven gradient), gated behind
+``JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED`` (default-OFF byte-identical).
+
+ZERO real GCE / network -- every boundary is a fake. The gradient is the real
+in-process singleton (reset per test).
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance.failover_lifecycle import (
+    FailoverState,
+    FailoverLifecycleController,
+)
+from backend.core.ouroboros.governance import provider_quarantine as pq
+
+
+# ---------------------------------------------------------------------------
+# Fakes / fixtures
+# ---------------------------------------------------------------------------
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, dt: float) -> None:
+        self.t += dt
+
+
+@pytest.fixture(autouse=True)
+def _fresh_singletons(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    monkeypatch.setenv("JARVIS_JPRIME_COLDSTART_S", "100")
+    monkeypatch.setenv("JARVIS_CRYO_AWAKEN_MARGIN", "1.5")
+    monkeypatch.setenv("JARVIS_OUTAGE_CONFIRM_S", "120")
+    # The early pre-warm sub-gate stays OFF in these tests unless a test arms it
+    # (we are exercising the REACTIVE authoritative path, not the pre-warm).
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+def _fill_outage(route: str, n: int = 5) -> None:
+    """Push n failed sweeps so is_global_outage(route) -> True (FULL, rate 0)."""
+    grad = pq.get_provider_health_gradient()
+    for _ in range(n):
+        grad.record_sweep(route, success=False)
+
+
+def _fake_forecast(confidence: str, p50: float = 0.0, p90: float = 0.0):
+    class _F:
+        def __init__(self):
+            self.confidence = confidence
+            self.p50_s = p50
+            self.p90_s = p90
+            self.velocity_hint = 1.0
+            self.samples = 5 if confidence == "HIGH" else 0
+    return _F()
+
+
+def _make_ctrl(clock, **kw) -> FailoverLifecycleController:
+    defaults = dict(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+        # is_degrading() == False: the HeavyProbe-passed run-#11 mode. The
+        # probe-based heartbeat sees NOTHING wrong; only real generation died.
+        is_degrading_fn=lambda: False,
+    )
+    defaults.update(kw)
+    return FailoverLifecycleController(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# (a) Run-#11 mode: probe OK but a real generation route collapsed -> AWAKEN
+# ---------------------------------------------------------------------------
+
+async def test_run11_probe_ok_but_background_route_outage_awakens(monkeypatch):
+    """The regression we fix: HeavyProbe passes (is_degrading False) but the
+    BACKGROUND generation route hit rate==0 -> the FSM NOW awakens J-Prime."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+    )
+    # HIGH-confidence slow forecast so the cost gate says AWAKEN (R>C*margin).
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+
+    # The probe-based heartbeat sees nothing wrong.
+    assert ctrl._is_degrading() is False
+    # But the BACKGROUND *generation* route collapsed (rate==0, full window).
+    _fill_outage("background")
+    # And the configured "dw" route never recorded a sweep (the blindspot).
+    assert pq.get_provider_health_gradient().is_global_outage("dw") is False
+
+    await ctrl.tick()
+    assert ctrl.state == FailoverState.AWAKENING
+    assert awaken_calls == [1]
+
+
+async def test_run11_blindspot_persists_when_subgate_off(monkeypatch):
+    """OFF (sub-gate not armed) -> byte-identical: the BACKGROUND outage on a
+    non-'dw' route does NOT awaken (the exact pre-fix run-#11 behavior)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "false")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    _fill_outage("background")
+
+    await ctrl.tick()
+    # Legacy single-route ("dw") check -> no outage -> stays DORMANT.
+    assert ctrl.state == FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (b) BACKGROUND route specifically triggers it (not just realtime / dw)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("route", ["background", "realtime", "standard", "complex"])
+async def test_any_generation_route_triggers_awaken(monkeypatch, route):
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(route) or True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    _fill_outage(route)
+
+    await ctrl.tick()
+    assert ctrl.state == FailoverState.AWAKENING
+    assert awaken_calls == [route]
+
+
+# ---------------------------------------------------------------------------
+# (c) No spurious awaken on a transient blip (window not full / rate > 0)
+# ---------------------------------------------------------------------------
+
+async def test_transient_blip_partial_window_no_awaken(monkeypatch):
+    """Window not FULL (only 3 of 5 failures) -> NOT an outage -> no awaken."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    _fill_outage("background", n=3)  # window size 5 -> not full
+
+    await ctrl.tick()
+    assert ctrl.state == FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+async def test_full_window_but_one_success_no_awaken(monkeypatch):
+    """Full window but rate > 0 (one success) -> NOT an outage -> no awaken.
+    Fail-CLOSED: identical threshold to the quarantine seal."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    grad = pq.get_provider_health_gradient()
+    for _ in range(4):
+        grad.record_sweep("background", success=False)
+    grad.record_sweep("background", success=True)  # one success -> rate > 0
+
+    await ctrl.tick()
+    assert ctrl.state == FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (d) The quarantine_op Cryo-DLQ seal connects to the awaken path
+# ---------------------------------------------------------------------------
+
+async def test_quarantine_seal_route_outage_drives_awaken(monkeypatch, tmp_path):
+    """A quarantine_op seal only fires when is_global_outage(route) is True; that
+    SAME gradient state is what the FSM reads. Prove: after a seal on the
+    BACKGROUND route, the FSM awakens (the seal and the awaken share the
+    gradient -- no new event bus needed)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_PROVIDER_QUARANTINE_ENABLED", "true")
+    # Keep the DLQ append off-tree: stub append_dlq so the seal never touches
+    # the repo .jarvis/ dir (the seal still returns True -- the gradient state
+    # is what matters for the awaken wiring).
+    import backend.core.ouroboros.governance.intake_dlq as _dlq
+    monkeypatch.setattr(_dlq, "append_dlq", lambda *a, **k: None)
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+
+    # Drive the BACKGROUND route into outage (what candidate_generator does on
+    # the dw_severed_queued exhaustion), then perform the quarantine seal.
+    _fill_outage("background")
+
+    class _Ctx:
+        op_id = "op-run11"
+        dw_telemetry = None
+        provider_override = ""
+
+    assert pq.get_provider_health_gradient().is_global_outage("background") is True
+    sealed = pq.quarantine_op(_Ctx(), route="background", telemetry={"x": 1})
+    assert sealed is True  # the seal fired on the same gradient state
+
+    # The FSM, reading that same gradient, now awakens.
+    await ctrl.tick()
+    assert ctrl.state == FailoverState.AWAKENING
+    assert awaken_calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# (e) The probe-based EARLY pre-warm still works (independent path retained)
+# ---------------------------------------------------------------------------
+
+async def test_probe_early_prewarm_still_works(monkeypatch):
+    """The authoritative any-route signal does NOT replace the heartbeat early
+    pre-warm: a DEGRADED probe (is_degrading True) + slow forecast still
+    pre-warms even with NO route yet at full outage."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "true")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        is_degrading_fn=lambda: True,  # heartbeat says DEGRADED
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    # NO route at full outage -- the early pre-warm must carry the awaken.
+    assert pq.get_provider_health_gradient().any_route_in_outage() is False
+
+    await ctrl.tick()
+    assert ctrl.state == FailoverState.AWAKENING
+    assert awaken_calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# (f) OFF (master) -> byte-identical: never awakens regardless of route outage
+# ---------------------------------------------------------------------------
+
+async def test_master_off_no_awaken_even_with_route_outage(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    _fill_outage("background")
+
+    state = await ctrl.tick()
+    assert state == FailoverState.DORMANT
+    assert awaken_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (g) Explicit operator-pinned extra route folds in even pre-sweep
+# ---------------------------------------------------------------------------
+
+async def test_explicit_extra_route_folds_in(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_OUTAGE_ROUTES", "speculative")
+    clock = FakeClock()
+    awaken_calls = []
+    ctrl = _make_ctrl(
+        clock,
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+    )
+    monkeypatch.setattr(ctrl, "_get_forecast",
+                        lambda: _fake_forecast("HIGH", p50=300.0, p90=600.0))
+    _fill_outage("speculative")
+
+    await ctrl.tick()
+    assert ctrl.state == FailoverState.AWAKENING
+    assert awaken_calls == [1]
+
+
+# ---------------------------------------------------------------------------
+# Gradient unit tests: tracked_routes + any_route_in_outage
+# ---------------------------------------------------------------------------
+
+def test_gradient_tracked_routes_enumerates_seen_routes():
+    grad = pq.ProviderHealthGradient()
+    grad.record_sweep("background", success=False)
+    grad.record_sweep("standard", success=True)
+    assert set(grad.tracked_routes()) == {"background", "standard"}
+
+
+def test_gradient_any_route_in_outage_true_only_on_full_zero_window(monkeypatch):
+    monkeypatch.setenv("JARVIS_QUARANTINE_WINDOW", "5")
+    grad = pq.ProviderHealthGradient()
+    # Partial window -> not outage.
+    for _ in range(3):
+        grad.record_sweep("background", success=False)
+    assert grad.any_route_in_outage() is False
+    # Fill it -> outage on that route -> any_route True.
+    for _ in range(2):
+        grad.record_sweep("background", success=False)
+    assert grad.any_route_in_outage() is True
+
+
+def test_gradient_any_route_in_outage_extra_routes_pre_sweep_noop():
+    grad = pq.ProviderHealthGradient()
+    # extra_routes for an unseen route reads not-outage (empty window).
+    assert grad.any_route_in_outage(extra_routes=["dw", "background"]) is False
+    assert grad.any_route_in_outage(extra_routes="dw") is False

--- a/tests/test_chaos_readiness_handshake.py
+++ b/tests/test_chaos_readiness_handshake.py
@@ -1,0 +1,237 @@
+"""Tests for the Chaos Readiness Handshake (chaos_injector_ast).
+
+THE BUG (A1 live soak): the ChaosInjector mutated a file BEFORE O+V's
+TrinityEventBus + TestWatcher were initialized and listening -> the live
+``fs.changed`` event fired into a dead bus (or fired before any subscriber
+existed) and the mutation was lost. Boot hydration covers the offline case
+from ground truth; the readiness handshake covers the live case by REFUSING to
+mutate until the bus + TestWatcher are demonstrably ready.
+
+``await_chaos_readiness`` is an ASYNC, bounded-deadline, exponential-backoff
+probe of a readiness surface:
+
+* HTTP readiness surface (``/channel/health`` / ``/observability/health``)
+  parsed for a ``testwatcher_ready`` truthy field, OR
+* a stdout/log BOOT-MARKER (``[TestWatcher] READY subscribed=fs.changed.*``)
+
+On timeout it returns ``(False, "CHAOS_READINESS_TIMEOUT")`` -- a graceful
+inject failure with a clear locus, never a blind mutate-into-a-dead-bus.
+
+Gated ``JARVIS_CHAOS_READINESS_PROBE_ENABLED`` (default true). NO ``time.sleep``,
+NO fixed wait constant as the sync mechanism (env-tuned bounded deadlines only).
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, List, Optional, Tuple
+
+import pytest
+
+import scripts.chaos_injector_ast as ci
+
+
+# ---------------------------------------------------------------------------
+# 1. Probe waits for the ready signal then returns True
+# ---------------------------------------------------------------------------
+
+
+class TestProbeBecomesReady:
+    def test_returns_true_when_marker_appears(self, monkeypatch: Any) -> None:
+        # The readiness check flips ready on the 3rd poll -> proves the probe
+        # waits (does not assume ready) and converges.
+        calls: List[int] = []
+
+        async def _check() -> bool:
+            calls.append(1)
+            return len(calls) >= 3
+
+        ok, locus = asyncio.run(
+            ci.await_chaos_readiness(
+                check=_check, deadline_s=5.0, initial_backoff_s=0.001,
+            )
+        )
+        assert ok is True
+        assert locus == ""
+        assert len(calls) >= 3
+
+    def test_returns_true_immediately_if_ready(self) -> None:
+        async def _check() -> bool:
+            return True
+
+        ok, locus = asyncio.run(
+            ci.await_chaos_readiness(
+                check=_check, deadline_s=5.0, initial_backoff_s=0.001,
+            )
+        )
+        assert ok is True
+        assert locus == ""
+
+
+# ---------------------------------------------------------------------------
+# 2. Times out gracefully with CHAOS_READINESS_TIMEOUT when never ready
+# ---------------------------------------------------------------------------
+
+
+class TestProbeTimesOut:
+    def test_never_ready_times_out_gracefully(self) -> None:
+        async def _check() -> bool:
+            return False  # never ready
+
+        ok, locus = asyncio.run(
+            ci.await_chaos_readiness(
+                check=_check, deadline_s=0.05, initial_backoff_s=0.001,
+            )
+        )
+        assert ok is False
+        assert locus == "CHAOS_READINESS_TIMEOUT"
+
+    def test_check_errors_are_swallowed_then_timeout(self) -> None:
+        async def _check() -> bool:
+            raise RuntimeError("surface unreachable")
+
+        # A failing surface must NOT crash the probe -- it degrades to timeout.
+        ok, locus = asyncio.run(
+            ci.await_chaos_readiness(
+                check=_check, deadline_s=0.05, initial_backoff_s=0.001,
+            )
+        )
+        assert ok is False
+        assert locus == "CHAOS_READINESS_TIMEOUT"
+
+
+# ---------------------------------------------------------------------------
+# 3. Backoff (not fixed sleep): it polls multiple times + uses asyncio.sleep
+# ---------------------------------------------------------------------------
+
+
+class TestBackoffNotFixedSleep:
+    def test_uses_asyncio_sleep_with_growing_backoff(
+        self, monkeypatch: Any
+    ) -> None:
+        sleeps: List[float] = []
+
+        real_sleep = asyncio.sleep
+
+        async def _spy_sleep(delay: float, *a: Any, **k: Any) -> None:
+            sleeps.append(delay)
+            await real_sleep(0)  # yield, but don't actually wait
+
+        monkeypatch.setattr(asyncio, "sleep", _spy_sleep)
+
+        attempts: List[int] = []
+
+        async def _check() -> bool:
+            attempts.append(1)
+            return len(attempts) >= 4
+
+        ok, _ = asyncio.run(
+            ci.await_chaos_readiness(
+                check=_check, deadline_s=10.0,
+                initial_backoff_s=0.01, backoff_factor=2.0,
+            )
+        )
+        assert ok is True
+        # Polled more than once (it waited) and used asyncio.sleep between polls.
+        assert len(sleeps) >= 2
+        # Exponential growth: a later backoff is strictly larger than the first.
+        assert sleeps[-1] > sleeps[0]
+
+    def test_source_has_no_time_sleep(self) -> None:
+        # Structural guard: the probe must not use the blocking time.sleep as
+        # its synchronization mechanism.
+        src = inspect.getsource(ci.await_chaos_readiness)
+        assert "time.sleep" not in src
+        assert "asyncio.sleep" in src
+
+
+# ---------------------------------------------------------------------------
+# 4. HTTP readiness check parses testwatcher_ready
+# ---------------------------------------------------------------------------
+
+
+class TestHttpReadinessCheck:
+    def test_http_check_ready_true(self, monkeypatch: Any) -> None:
+        # A fake HTTP fetch returns a health JSON with testwatcher_ready=true.
+        async def _fake_fetch(url: str, timeout_s: float) -> Optional[dict]:
+            return {"testwatcher_ready": True, "enabled": True}
+
+        monkeypatch.setattr(ci, "_fetch_health_json", _fake_fetch)
+        check = ci.make_http_readiness_check("http://127.0.0.1:8123/channel/health")
+        assert asyncio.run(check()) is True
+
+    def test_http_check_not_ready(self, monkeypatch: Any) -> None:
+        async def _fake_fetch(url: str, timeout_s: float) -> Optional[dict]:
+            return {"testwatcher_ready": False}
+
+        monkeypatch.setattr(ci, "_fetch_health_json", _fake_fetch)
+        check = ci.make_http_readiness_check("http://127.0.0.1:8123/channel/health")
+        assert asyncio.run(check()) is False
+
+    def test_http_check_unreachable_returns_false(
+        self, monkeypatch: Any
+    ) -> None:
+        async def _fake_fetch(url: str, timeout_s: float) -> Optional[dict]:
+            return None  # connection refused / not up yet
+
+        monkeypatch.setattr(ci, "_fetch_health_json", _fake_fetch)
+        check = ci.make_http_readiness_check("http://127.0.0.1:8123/channel/health")
+        assert asyncio.run(check()) is False
+
+
+# ---------------------------------------------------------------------------
+# 5. Log boot-marker readiness check
+# ---------------------------------------------------------------------------
+
+
+class TestLogMarkerReadinessCheck:
+    def test_marker_present(self, tmp_path: Any) -> None:
+        log = tmp_path / "soak_stdout.log"
+        log.write_text(
+            "boot...\n[TestWatcher] READY subscribed=fs.changed.*\nmore\n",
+            encoding="utf-8",
+        )
+        check = ci.make_log_marker_readiness_check(str(log))
+        assert asyncio.run(check()) is True
+
+    def test_marker_absent(self, tmp_path: Any) -> None:
+        log = tmp_path / "soak_stdout.log"
+        log.write_text("boot...\nstill warming up\n", encoding="utf-8")
+        check = ci.make_log_marker_readiness_check(str(log))
+        assert asyncio.run(check()) is False
+
+    def test_missing_log_is_not_ready(self, tmp_path: Any) -> None:
+        check = ci.make_log_marker_readiness_check(str(tmp_path / "nope.log"))
+        assert asyncio.run(check()) is False
+
+
+# ---------------------------------------------------------------------------
+# 6. Gated OFF -> probe is a no-op that reports ready (legacy blind inject)
+# ---------------------------------------------------------------------------
+
+
+class TestGatedOff:
+    def test_probe_disabled_returns_ready_immediately(
+        self, monkeypatch: Any
+    ) -> None:
+        monkeypatch.setenv("JARVIS_CHAOS_READINESS_PROBE_ENABLED", "false")
+
+        calls: List[int] = []
+
+        async def _check() -> bool:
+            calls.append(1)
+            return False
+
+        ok, locus = asyncio.run(
+            ci.await_chaos_readiness(
+                check=_check, deadline_s=5.0, initial_backoff_s=0.001,
+            )
+        )
+        # OFF == legacy: do not block, do not consult the surface.
+        assert ok is True
+        assert locus == ""
+        assert calls == []
+
+    def test_probe_enabled_default_true(self, monkeypatch: Any) -> None:
+        monkeypatch.delenv("JARVIS_CHAOS_READINESS_PROBE_ENABLED", raising=False)
+        assert ci.readiness_probe_enabled() is True


### PR DESCRIPTION
Two run-#11 blockers: (1) boot-time differential hydration (git diff HEAD -> scoped pytest on pre-boot mutations, crash/restart-robust) + chaos readiness handshake; (2) failover awakens on any-route is_global_outage (the real generation-failure signal), fixing the route-namespace blindspot where the FSM read is_global_outage('dw') but record_sweep writes 'background'/'standard'/'complex'. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds boot-time differential hydration to run scoped tests for pre-boot file changes and a Chaos Readiness Handshake to avoid blind chaos mutations. Updates failover to awaken on the authoritative any-route outage signal, closing the run-#11 blindspot.

- **New Features**
  - Boot-time differential hydration in the TestWatcher: async `git diff` + scoped pytest for changed files; de-dupes immediate `fs.changed`; gated by `JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED` (default true).
  - Chaos Readiness Handshake in `scripts/chaos_injector_ast.py`: async, bounded probe of an HTTP health surface or a log boot-marker before mutating; gated by `JARVIS_CHAOS_READINESS_PROBE_ENABLED` (default true); new CLI flags `--readiness-url` and `--readiness-log`.
  - Provider quarantine helpers: `tracked_routes()` and `any_route_in_outage(extra_routes=...)` for authoritative outage checks.
  - TestWatcher emits a READY boot-marker to stdout/logs for external probes.

- **Bug Fixes**
  - Failover awakens on any-route `is_global_outage` (authoritative, full-window rate==0), not just a single route; controlled by `JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED` (default false) and optional `JARVIS_FAILOVER_OUTAGE_ROUTES`.
  - Prevents double runs after hydration via a short TTL de-dupe window.

<sup>Written for commit b73abe8bc3ffa3c0e7d5af477937ee63e2d3977b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

