### PR TITLE
feat(a1): arm run-#11 fixes for run #12

### DIFF
--- a/deploy/ouroboros_linux_prod.env
+++ b/deploy/ouroboros_linux_prod.env
@@ -60,6 +60,14 @@ export JARVIS_FAILOVER_LIFECYCLE_ENABLED=true
 export JARVIS_DW_HEARTBEAT_ENABLED=true
 export JARVIS_FAILOVER_EARLY_PREWARM_ENABLED=true
 export JARVIS_JPRIME_PRIMACY=false
+# run-#11 fix: awaken on ANY route's real is_global_outage (record_sweep writes
+# background/standard/complex, NOT "dw") — the FSM was structurally blind to the
+# real BACKGROUND collapse. Sub-gate defaults OFF; ARM it so the real signal triggers.
+export JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED=true
+# run-#11 fix: boot-time git-diff hydration (detect pre-soak chaos mutation on boot)
+# + chaos readiness handshake (inject only after TestWatcher/bus are listening).
+export JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED=true
+export JARVIS_CHAOS_READINESS_PROBE_ENABLED=true
 # ---- Dynamic test scoping ARMED (#69699): fs.changed -> scoped pytest (kills the
 #      180s SIGKILL that hid the chaos bug in run #10). Default-on; explicit here. ----
 export JARVIS_TEST_DYNAMIC_SCOPING_ENABLED=true


### PR DESCRIPTION
Arms any-route failover outage + boot-hydration + readiness handshake. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enables three production flags to fix run #11 issues ahead of run #12: any-route global-outage failover trigger, boot-time TestWatcher hydration, and a chaos readiness handshake. This improves failover accuracy and prevents early chaos injection during startup.

- **New Features**
  - Enable failover on any route’s global-outage signal (covers background/standard/complex, not only “dw”).
  - Boot-time TestWatcher git-diff hydration to catch pre-soak changes.
  - Chaos readiness probe to start injections only after TestWatcher and the bus are ready.

<sup>Written for commit ea1d93e335678ba649b25d33b583625616cc0305. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

