### PR TITLE
feat(a1-harness): Hermetic Local Matrix Runner + WorkspaceResolver (fixes run-#12 path bug)

### DIFF
--- a/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
@@ -23,6 +23,7 @@ from typing import Any, Dict, List, Optional
 
 from backend.core.ouroboros.governance.intent.signals import IntentSignal
 from backend.core.ouroboros.governance.intent.test_watcher import TestFailure
+from backend.core.ouroboros.governance.workspace_resolver import resolve_repo_root
 from backend.core.ouroboros.governance.intake.intent_envelope import (
     IntentEnvelope,
     make_envelope,
@@ -742,17 +743,27 @@ class TestFailureSensor:
     # ------------------------------------------------------------------
 
     def _repo_root(self) -> Path:
-        """Best-effort repo root for the resolver / mirror-dir fallback.
+        """Authoritative repo root for the resolver / mirror-dir fallback.
 
-        Prefers the watcher's ``repo_path`` (set from ``JARVIS_REPO_PATH``),
-        falls back to the env var, then the cwd. Never raises.
+        Prefers the watcher's ``repo_path`` (which is itself now the
+        ``.git``-anchored :func:`resolve_repo_root` value, not bare ``"."``),
+        and falls back to the SAME canonical resolver — never to a raw ``"."``
+        / CWD that could disagree with where the changed-file paths anchor.
+        This single-source-of-truth is the run-#12 path-mismatch fix: the
+        boot-hydration ``git diff`` cwd, the ``TestRunner`` repo_root, and the
+        ``_normalize`` relative-to base are now one and the same anchor, so a
+        valid ``tests/...py`` is never rejected as "outside repo root" and the
+        scope never falls back to the 180s whole-suite sweep. Never raises.
         """
-        candidate = getattr(self._watcher, "repo_path", None) or os.environ.get(
-            "JARVIS_REPO_PATH", "."
-        )
+        candidate = getattr(self._watcher, "repo_path", None)
         try:
-            return Path(candidate).resolve()
-        except Exception:
+            if candidate:
+                return Path(candidate).resolve()
+        except Exception:  # noqa: BLE001 — fall through to the canonical resolver
+            pass
+        try:
+            return resolve_repo_root()
+        except Exception:  # noqa: BLE001 — defensive; resolver is fail-soft already
             return Path(".").resolve()
 
     async def _resolve_scoped_targets(

--- a/backend/core/ouroboros/governance/intent/test_watcher.py
+++ b/backend/core/ouroboros/governance/intent/test_watcher.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 
 from .signals import IntentSignal
+from backend.core.ouroboros.governance.workspace_resolver import resolve_repo_root
 
 logger = logging.getLogger(__name__)
 
@@ -111,7 +112,13 @@ class TestWatcher:
     ) -> None:
         self.repo = repo
         self.test_dir = os.environ.get("JARVIS_INTENT_TEST_DIR", test_dir)
-        self.repo_path = repo_path or os.environ.get("JARVIS_REPO_PATH", ".")
+        # Single authoritative repo root (run-#12 path-mismatch fix):
+        # an explicit *repo_path* wins, else the ``.git``-anchored resolver
+        # (which itself honors ``JARVIS_REPO_PATH`` then walks from ``__file__``
+        # then the CWD). NEVER defaults to bare ``"."`` — the CWD-vs-anchor
+        # disagreement was the live foil that fell the boot-hydration diff back
+        # to the 180s whole-suite sweep. ``str(...)`` keeps the public type.
+        self.repo_path = repo_path or str(resolve_repo_root())
         # Repair Context Bridge (Slice 1): injectable Oracle line->node resolver.
         # ``None`` → lazily resolved from the global Oracle backend at enrich time
         # (fail-soft). Tests inject a fake. Only consulted when the bridge is on.

--- a/backend/core/ouroboros/governance/workspace_resolver.py
+++ b/backend/core/ouroboros/governance/workspace_resolver.py
@@ -1,0 +1,198 @@
+"""WorkspaceResolver — the single authoritative ``.git``-anchored repo root.
+
+THE RUN-#12 BUG (A1 live soak, pinned)
+--------------------------------------
+``test_runner._normalize`` does ``resolved.relative_to(repo_root.resolve())``
+and raises ``BlockedPathError`` ("Path ... resolves outside repo root ...")
+whenever the ``repo_root`` it was handed does **not** match the directory the
+changed-file path anchors to. On the live node the repository lived at
+``/opt/trinity/jarvis`` but the boot-hydration path computed / passed a
+``repo_root`` that did not agree (the TestWatcher's ``repo_path`` defaulted to
+``"."`` — the process CWD — and the sensor's ``_repo_root`` inherited that
+default), so a perfectly valid ``tests/...py`` was rejected -> the resolver
+fell back to the whole ``pytest tests/`` suite -> 180s SIGKILL -> the injected
+chaos bug was **never detected**.
+
+ROOT CAUSE: the repo root was computed *inconsistently* across the pipeline —
+CWD here, ``__file__`` there, an env var somewhere else. There was no single
+source of truth, so local and node could (and did) disagree.
+
+THE FIX (this module)
+---------------------
+One deterministic, pure, fail-soft resolver: walk PARENTS from a start path
+(default: this module's own ``__file__``, then the CWD as a fallback) until a
+``.git`` directory **or** file is found, and return that directory fully
+``.resolve()``d. The TestWatcher boot-hydration AND ``TestRunner`` /
+``resolve_affected_tests`` both anchor to the **same** value from
+:func:`resolve_repo_root`, and the boot-hydration ``git diff --name-only HEAD``
+is run with ``cwd=repo_root`` so its output paths are repo-root-relative and
+``_normalize`` agrees.
+
+Design contract:
+
+* **Zero hardcoding** — the root comes from the real ``.git`` anchor. There is
+  no literal ``/opt/trinity`` or ``/Users/...`` anywhere; the only env override
+  is the operator-set ``JARVIS_REPO_PATH`` (honored first when it itself
+  resolves to a real directory, matching the existing pipeline convention).
+* **Linked-worktree aware** — ``git worktree add`` creates a ``.git`` *file*
+  (``gitdir: <path>``), not a directory. Both forms anchor a repo root, so the
+  walk accepts ``.git`` whether it is a file or a directory.
+* **Pure + deterministic** — same inputs, same output. No I/O beyond stat.
+* **Cached** — the default (no-``start``) resolution is memoized; the cache is
+  keyed by the resolved start path so an explicit ``start`` (e.g. a tmp fixture
+  repo in a hermetic test) is never poisoned by, nor poisons, the default.
+* **Fail-soft** — no ``.git`` anywhere up the tree -> return the CWD
+  (``.resolve()``d). Never raises, never returns ``None``.
+"""
+from __future__ import annotations
+
+import os
+import threading
+from pathlib import Path
+from typing import Dict, Optional
+
+__all__ = ["resolve_repo_root", "clear_cache"]
+
+# Operator override env var — the SAME one the existing TestWatcher /
+# TestFailureSensor already read, so this resolver is a drop-in single source
+# of truth rather than a competing convention.
+_ENV_REPO_PATH = "JARVIS_REPO_PATH"
+
+# Cache: resolved-start-path -> resolved repo root. Bounded by the number of
+# distinct start anchors (effectively 1-2 in production: the module path and
+# the CWD). Guarded so concurrent boot tasks can't race a half-written entry.
+_CACHE: Dict[str, Path] = {}
+_CACHE_LOCK = threading.Lock()
+
+
+def _has_git_anchor(directory: Path) -> bool:
+    """Return True iff *directory* holds a ``.git`` anchor (dir OR file).
+
+    A ``.git`` directory is the main repo root; a ``.git`` file
+    (``gitdir: <path>``) is a linked ``git worktree`` checkout. Both are
+    legitimate repo roots that anchor relative-path math. Fail-soft: any
+    OSError (permission, race, odd path) is treated as "no anchor here".
+    """
+    try:
+        return (directory / ".git").exists()
+    except OSError:
+        return False
+
+
+def _walk_to_git_root(start: Path) -> Optional[Path]:
+    """Walk *start* and its parents until a ``.git`` anchor is found.
+
+    Returns the anchoring directory (already ``.resolve()``d by the caller's
+    start) or ``None`` if no anchor exists anywhere up the tree. Never raises.
+    """
+    try:
+        # If *start* is a file, begin the walk at its containing directory;
+        # if it is a directory, include it as the first candidate.
+        first = start if start.is_dir() else start.parent
+    except OSError:
+        first = start.parent
+
+    for ancestor in (first, *first.parents):
+        if _has_git_anchor(ancestor):
+            return ancestor
+    return None
+
+
+def resolve_repo_root(start: Optional[Path] = None) -> Path:
+    """Return the authoritative ``.git``-anchored repository root.
+
+    Resolution order (first hit wins), all fully ``.resolve()``d:
+
+    1. **Explicit start** — when *start* is provided, walk its parents to the
+       ``.git`` anchor. This is the hermetic-test / multi-repo entry point
+       (e.g. a tmp fixture repo). No env override is consulted for an explicit
+       start so the caller's intent is honored exactly.
+    2. **Operator env override** — ``JARVIS_REPO_PATH`` when it itself resolves
+       to a real directory (matches the existing TestWatcher convention). The
+       value is still ``.resolve()``d so a relative override is anchored.
+    3. **This module's ``__file__``** — walk up to the ``.git`` anchor. This is
+       the production default and is robust to the process CWD (the run-#12
+       failure vector).
+    4. **CWD** — walk up from the current working directory.
+    5. **Fail-soft** — no anchor found anywhere -> the ``.resolve()``d CWD.
+
+    Pure + deterministic + cached. NEVER raises, NEVER returns ``None``.
+    """
+    if start is not None:
+        try:
+            anchored = start.resolve()
+        except OSError:
+            anchored = start
+        cache_key = f"start::{anchored}"
+        with _CACHE_LOCK:
+            cached = _CACHE.get(cache_key)
+        if cached is not None:
+            return cached
+        found = _walk_to_git_root(anchored)
+        result = found if found is not None else _safe_cwd()
+        with _CACHE_LOCK:
+            _CACHE[cache_key] = result
+        return result
+
+    # Default (no explicit start) — memoized under a stable key.
+    cache_key = "default"
+    with _CACHE_LOCK:
+        cached = _CACHE.get(cache_key)
+    if cached is not None:
+        return cached
+
+    result = _resolve_default()
+    with _CACHE_LOCK:
+        _CACHE[cache_key] = result
+    return result
+
+
+def _resolve_default() -> Path:
+    """Compute the production default root (env -> __file__ -> cwd -> cwd)."""
+    # 2. Operator env override, if it points at a real directory.
+    raw = os.environ.get(_ENV_REPO_PATH, "").strip()
+    if raw:
+        try:
+            candidate = Path(raw).expanduser().resolve()
+            if candidate.is_dir():
+                # Walk from the override too — it may point *into* the repo
+                # rather than exactly at the root; the ``.git`` anchor decides.
+                found = _walk_to_git_root(candidate)
+                if found is not None:
+                    return found
+                # Override is a real dir but not under any .git — honor it
+                # verbatim (operator intent), still resolved.
+                return candidate
+        except OSError:
+            pass
+
+    # 3. This module's own location — CWD-independent (the run-#12 fix).
+    try:
+        here = Path(__file__).resolve()
+        found = _walk_to_git_root(here)
+        if found is not None:
+            return found
+    except (OSError, NameError):
+        pass
+
+    # 4. CWD walk.
+    found = _walk_to_git_root(_safe_cwd())
+    if found is not None:
+        return found
+
+    # 5. Fail-soft.
+    return _safe_cwd()
+
+
+def _safe_cwd() -> Path:
+    """Return the resolved CWD, never raising."""
+    try:
+        return Path.cwd().resolve()
+    except OSError:
+        return Path(".")
+
+
+def clear_cache() -> None:
+    """Drop the memoized resolutions (test isolation / env-flip support)."""
+    with _CACHE_LOCK:
+        _CACHE.clear()

--- a/tests/governance/test_workspace_resolver.py
+++ b/tests/governance/test_workspace_resolver.py
@@ -1,0 +1,216 @@
+"""Regression suite for the WorkspaceResolver — the run-#12 path-bug fix.
+
+THE BUG (A1 live soak, run #12): ``test_runner._normalize`` rejected a valid
+``tests/...py`` as "outside repo root" because the ``repo_root`` it was handed
+(the CWD via a bare ``"."`` default) did NOT agree with the directory the
+changed-file path anchored to. These tests prove:
+
+1. :func:`resolve_repo_root` anchors to the real ``.git`` directory by walking
+   parents — with NO hardcoded ``/opt/trinity`` / ``/Users`` literals.
+2. The exact run-#12 mismatch is gone: a changed file under the fixture's real
+   ``.git`` root, fed through ``TestRunner.resolve_affected_tests`` /
+   ``_normalize`` with the resolver-derived root, is normalized + scoped to its
+   own test (no ``BlockedPathError``, no whole-suite fallback) even when the
+   process CWD is somewhere else entirely.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+from typing import Iterator
+
+import pytest
+
+from backend.core.ouroboros.governance.workspace_resolver import (
+    clear_cache,
+    resolve_repo_root,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _isolate_resolver_cache_and_env() -> Iterator[None]:
+    """Clear the resolver cache + scrub JARVIS_REPO_PATH around each test."""
+    saved = os.environ.pop("JARVIS_REPO_PATH", None)
+    clear_cache()
+    try:
+        yield
+    finally:
+        clear_cache()
+        if saved is not None:
+            os.environ["JARVIS_REPO_PATH"] = saved
+
+
+def _git_init(root: Path) -> None:
+    subprocess.run(
+        ["git", "init", "-q"], cwd=str(root), check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Anchor behavior — no hardcoding
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_to_git_dir_from_nested_start(tmp_path: Path) -> None:
+    root = tmp_path / "repo"
+    (root / "backend" / "core").mkdir(parents=True)
+    _git_init(root)
+    nested = root / "backend" / "core"
+
+    resolved = resolve_repo_root(start=nested)
+
+    assert resolved == root.resolve()
+
+
+def test_resolves_git_FILE_anchor_linked_worktree(tmp_path: Path) -> None:
+    """A ``.git`` *file* (linked worktree marker) also anchors a root."""
+    root = tmp_path / "linked"
+    (root / "pkg").mkdir(parents=True)
+    (root / ".git").write_text("gitdir: /somewhere/else/.git/worktrees/wt\n")
+
+    resolved = resolve_repo_root(start=root / "pkg")
+
+    assert resolved == root.resolve()
+
+
+def test_fail_soft_no_git_returns_cwd(tmp_path: Path, monkeypatch) -> None:
+    """No ``.git`` anywhere up the tree -> the resolved CWD, never raises."""
+    orphan = tmp_path / "no_git_here"
+    orphan.mkdir()
+    monkeypatch.chdir(orphan)
+
+    resolved = resolve_repo_root(start=orphan)
+
+    assert resolved == orphan.resolve()
+
+
+def test_no_hardcoded_absolute_paths_in_code() -> None:
+    """Structural guard: NO literal node/dev root appears in a CODE line.
+
+    Scans only the executable body (comments + the module docstring narrate
+    the run-#12 ``/opt/trinity`` story; that prose is not a hardcoded path).
+    The guard is that no STRING LITERAL anchors to an absolute machine path.
+    """
+    import ast
+
+    # Derive the source path via the real repo root (dogfood, no literal).
+    module_file = (
+        resolve_repo_root() / "backend" / "core" / "ouroboros" / "governance"
+        / "workspace_resolver.py"
+    )
+    tree = ast.parse(module_file.read_text())
+
+    # Collect the AST ids of every docstring node (module / class / function)
+    # so the narrative prose (which legitimately recounts the ``/opt/trinity``
+    # run-#12 story) is excluded — only EXECUTABLE string literals are scanned.
+    docstring_ids = set()
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                             ast.AsyncFunctionDef)):
+            body = getattr(node, "body", None)
+            if (body and isinstance(body[0], ast.Expr)
+                    and isinstance(body[0].value, ast.Constant)
+                    and isinstance(body[0].value.value, str)):
+                docstring_ids.add(id(body[0].value))
+
+    code_literals = [
+        node.value
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Constant)
+        and isinstance(node.value, str)
+        and id(node) not in docstring_ids
+    ]
+    for lit in code_literals:
+        for forbidden in ("/opt/trinity", "/Users/", "/home/"):
+            assert forbidden not in lit, (
+                f"hardcoded path {forbidden!r} leaked into a string literal"
+            )
+
+
+def test_default_resolution_is_cached_and_clearable() -> None:
+    first = resolve_repo_root()
+    second = resolve_repo_root()
+    assert first == second
+    # The live repo we are running in must itself be a .git root.
+    assert (first / ".git").exists()
+    clear_cache()
+    assert resolve_repo_root() == first
+
+
+# ---------------------------------------------------------------------------
+# The run-#12 reproduction — fixed
+# ---------------------------------------------------------------------------
+
+
+def test_run12_outside_repo_root_rejection_is_fixed(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """Reproduce run #12: a valid changed file under the REAL ``.git`` root is
+    normalized + scoped to its own test even though the process CWD points
+    somewhere else entirely.
+
+    Pre-fix: a bare ``"."`` default anchored ``repo_root`` at the (wrong) CWD,
+    so ``_normalize``'s ``relative_to`` raised BlockedPathError and scoping fell
+    back to the whole suite. Post-fix: ``resolve_repo_root(start=...)`` anchors
+    at the fixture's ``.git`` -> normalized cleanly -> scoped to ``test_foo.py``.
+    """
+    from backend.core.ouroboros.governance.test_runner import (
+        BlockedPathError,
+        TestRunner,
+        _normalize,
+    )
+
+    # Build a real fixture repo: src + its sibling tests/test_foo.py.
+    root = tmp_path / "trinity_fixture"
+    (root / "pkg").mkdir(parents=True)
+    (root / "pkg" / "tests").mkdir(parents=True)
+    src = root / "pkg" / "foo.py"
+    src.write_text("def add(a, b):\n    return a + b\n")
+    (root / "pkg" / "tests" / "test_foo.py").write_text(
+        "from pkg.foo import add\n\n\ndef test_add():\n    assert add(1, 2) == 3\n"
+    )
+    _git_init(root)
+
+    # Simulate the live node: the process CWD is NOT the repo root.
+    elsewhere = tmp_path / "elsewhere"
+    elsewhere.mkdir()
+    monkeypatch.chdir(elsewhere)
+
+    # The authoritative resolver anchors at the fixture's .git, not the CWD.
+    repo_root = resolve_repo_root(start=src)
+    assert repo_root == root.resolve()
+    assert repo_root != Path.cwd().resolve()
+
+    # _normalize agrees — no BlockedPathError (the run-#12 rejection).
+    normalized = _normalize(src, repo_root)
+    assert normalized == "pkg/foo.py"
+
+    # And the changed source scopes to its OWN test, not the whole suite.
+    runner = TestRunner(repo_root=repo_root)
+    resolved = asyncio.run(runner.resolve_affected_tests((src,)))
+    resolved_names = {p.name for p in resolved}
+    assert "test_foo.py" in resolved_names
+    # Must NOT degrade to the repo-level ``tests/`` directory (whole suite).
+    assert all(p.name == "test_foo.py" for p in resolved), (
+        f"scoping fell back to a directory / whole suite: {resolved}"
+    )
+
+    # Sanity: with the WRONG root the file no longer normalizes to its true
+    # repo-relative path — proving the resolver is what fixes it, not a no-op.
+    # (On a host whose tmp tree falls under a sandbox prefix, ``_normalize``
+    # degrades to ``path.name`` rather than raising; either way the result is
+    # NOT the correct ``pkg/foo.py`` the right root yields.)
+    wrong_root = elsewhere.resolve()
+    try:
+        wrong_norm = _normalize(src, wrong_root)
+        assert wrong_norm != "pkg/foo.py"
+    except BlockedPathError:
+        pass  # the strict (non-sandbox) rejection path — also correct

--- a/tests/integration/event_simulator.py
+++ b/tests/integration/event_simulator.py
@@ -1,0 +1,141 @@
+"""EventSimulator — hermetic in-memory ``fs.changed.*`` injection.
+
+Constructs the EXACT ``fs.changed.*`` event payload that the live
+``FileSystemEventBridge`` (``intake/fs_event_bridge.py::_on_file_event``)
+emits — same topic, same JSON fields — and publishes it DIRECTLY into a real
+:class:`TrinityEventBus` via the genuine ``publish_raw`` path (queue -> worker
+-> ``_deliver_event`` -> subscriber handler). No disk mutation is required: the
+system "believes" a file just changed and the real
+``TestFailureSensor._on_fs_event`` subscription fires exactly as it would on a
+live node.
+
+This is NOT a mock of the detection logic — it reuses the real bus and the real
+bridge payload schema. The only thing bypassed is the OS file-watch boundary
+(FileWatchGuard), which is the cloud/host edge, not the cognitive loop.
+
+The payload shape is kept in lockstep with the bridge by deriving every field
+the same way the bridge does:
+
+    topic            = f"fs.changed.{event_type}"            (default "modified")
+    payload["path"]            = absolute path string
+    payload["relative_path"]   = path relative to repo root (POSIX-ish, str())
+    payload["extension"]       = suffix (e.g. ".py")
+    payload["checksum"]        = content hash (sha256 hex, like FileWatchGuard)
+    payload["is_test_file"]    = tests/ prefix OR test_*/_test.py name
+    payload["is_config_file"]  = (.json/.yaml/.yml) AND ".jarvis" in rel
+    payload["is_directory"]    = False
+    payload["timestamp"]       = wall-clock float
+"""
+from __future__ import annotations
+
+import hashlib
+import time
+from pathlib import Path
+from typing import Any, Optional
+
+__all__ = ["build_fs_changed_payload", "EventSimulator"]
+
+
+def _compute_checksum(abs_path: Path) -> str:
+    """SHA-256 hex of the file's bytes, mirroring FileWatchGuard's verify hash.
+
+    Fail-soft: a missing / unreadable file yields a deterministic empty-hash so
+    the simulator can inject an event for a path even in pure-in-memory mode.
+    """
+    try:
+        return hashlib.sha256(abs_path.read_bytes()).hexdigest()
+    except OSError:
+        return hashlib.sha256(b"").hexdigest()
+
+
+def build_fs_changed_payload(
+    *,
+    abs_path: Path,
+    repo_root: Path,
+    event_type: str = "modified",
+    checksum: Optional[str] = None,
+    timestamp: Optional[float] = None,
+) -> "tuple[str, dict]":
+    """Return ``(topic, payload)`` matching the real bridge emission shape.
+
+    Field derivation is byte-for-byte aligned with
+    ``fs_event_bridge.FileSystemEventBridge._on_file_event`` so the consumer
+    cannot tell a simulated event from a live one.
+    """
+    abs_path = Path(abs_path)
+    repo_root = Path(repo_root)
+
+    topic = f"fs.changed.{event_type}"
+
+    try:
+        rel_path = str(abs_path.relative_to(repo_root))
+    except ValueError:
+        rel_path = str(abs_path)
+
+    extension = abs_path.suffix
+    is_test = (
+        rel_path.startswith("tests/")
+        or abs_path.name.startswith("test_")
+        or abs_path.name.endswith("_test.py")
+    )
+    is_config = (
+        extension in (".json", ".yaml", ".yml") and ".jarvis" in rel_path
+    )
+
+    payload = {
+        "path": str(abs_path),
+        "relative_path": rel_path,
+        "extension": extension,
+        "checksum": checksum if checksum is not None else _compute_checksum(abs_path),
+        "is_test_file": is_test,
+        "is_config_file": is_config,
+        "is_directory": False,
+        "timestamp": timestamp if timestamp is not None else time.time(),
+    }
+    return topic, payload
+
+
+class EventSimulator:
+    """Inject real-shape ``fs.changed.*`` events into a real TrinityEventBus.
+
+    Parameters
+    ----------
+    event_bus:
+        A live (``start()``-ed) :class:`TrinityEventBus` instance.
+    repo_root:
+        The authoritative repo root used to compute ``relative_path`` — must be
+        the SAME ``.git``-anchored root the consumer resolves to (otherwise the
+        run-#12 mismatch resurfaces). Pass ``resolve_repo_root(start=...)``.
+    """
+
+    def __init__(self, event_bus: Any, repo_root: Path) -> None:
+        self._bus = event_bus
+        self._repo_root = Path(repo_root)
+        self.injected: int = 0
+
+    async def inject_change(
+        self,
+        abs_path: Path,
+        *,
+        event_type: str = "modified",
+        checksum: Optional[str] = None,
+    ) -> str:
+        """Publish a single real-shape ``fs.changed.*`` event. Returns event id.
+
+        Routes through the genuine ``publish_raw`` -> priority-queue -> worker
+        -> ``_deliver_event`` path, so the real ``TestFailureSensor._on_fs_event``
+        handler runs. ``persist=False`` keeps it WAL-free (matches the bridge).
+        """
+        topic, payload = build_fs_changed_payload(
+            abs_path=Path(abs_path),
+            repo_root=self._repo_root,
+            event_type=event_type,
+            checksum=checksum,
+        )
+        event_id = await self._bus.publish_raw(
+            topic=topic,
+            data=payload,
+            persist=False,
+        )
+        self.injected += 1
+        return event_id

--- a/tests/integration/test_hermetic_a1_matrix.py
+++ b/tests/integration/test_hermetic_a1_matrix.py
@@ -1,0 +1,317 @@
+"""Hermetic Local Matrix Runner — the $0 in-memory A1 iteration harness.
+
+Drives the REAL Boot-Hydration -> Scoped-Pytest -> Chaos-Detect -> Dispatch
+pipeline locally, async, in milliseconds, with ZERO cloud calls (no GCP, no
+IAP, no soak, no manual file mutation of the live repo). It replaces the
+~50-min / ~$0.25 cloud run for harness-integration bugs.
+
+What is REAL here (not mocked):
+
+* A real ``git init`` fixture repo in a tmp dir, with a real pure-leaf source
+  function + its real GREEN pytest, committed.
+* A real chaos mutation (``a + b`` -> ``a - b``) that turns the fixture's test
+  RED — equivalent to ``chaos_injector_ast``'s pure-leaf bug, planted directly
+  for determinism against the tmp repo.
+* The real ``WorkspaceResolver`` anchoring repo_root at the fixture's ``.git``.
+* The real ``TestWatcher`` (``diff_working_tree`` / ``poll_once`` /
+  ``run_pytest``) + real ``TestFailureSensor`` (``hydrate_on_boot`` /
+  ``_resolve_scoped_targets`` / ``_on_fs_event``).
+* The real ``TestRunner.resolve_affected_tests`` deterministic scoping.
+* A real (``start()``-ed) ``TrinityEventBus`` + the real-shape ``fs.changed.*``
+  payload from the ``EventSimulator`` (Component 2).
+
+The ONLY bypassed boundary is the cloud / OS file-watch edge — never the
+detection logic.
+
+ACCEPTANCE BAR: this file GREEN == the chaos bug is detected via BOTH the
+boot-hydration path AND the simulated ``fs.changed.*`` event, SCOPED to the
+chaos file's own test (never the whole ``tests/`` suite, never "outside repo
+root"), with the resolver anchoring to the fixture's real ``.git`` root.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+from pathlib import Path
+from typing import Any, Iterator, List
+
+import pytest
+
+from backend.core.ouroboros.governance.workspace_resolver import (
+    clear_cache,
+    resolve_repo_root,
+)
+from backend.core.ouroboros.governance.intent.test_watcher import TestWatcher
+from backend.core.ouroboros.governance.intake.sensors.test_failure_sensor import (
+    TestFailureSensor,
+)
+from tests.integration.event_simulator import EventSimulator
+
+
+# ---------------------------------------------------------------------------
+# Fakes — only the router sink + the cloud boundary. Detection is REAL.
+# ---------------------------------------------------------------------------
+
+
+class _RecordingRouter:
+    """Real router contract: ``ingest(envelope) -> "enqueued"`` and records."""
+
+    def __init__(self) -> None:
+        self.ingested: List[Any] = []
+
+    async def ingest(self, envelope: Any) -> str:
+        self.ingested.append(envelope)
+        return "enqueued"
+
+
+# ---------------------------------------------------------------------------
+# Fixture repo — real git init, real green test, real chaos mutation
+# ---------------------------------------------------------------------------
+
+_SRC_GREEN = "def add(a, b):\n    return a + b\n"
+# Equivalent of a chaos_injector_ast pure-leaf mutation: + -> - turns the
+# green assertion RED while keeping the function pure (no imports/side effects).
+_SRC_CHAOS = "def add(a, b):\n    return a - b\n"
+_TEST_SRC = (
+    "from pkg.foo import add\n"
+    "\n"
+    "\n"
+    "def test_add():\n"
+    "    assert add(2, 3) == 5\n"
+)
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args], cwd=str(root), check=True,
+        stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+    )
+
+
+@pytest.fixture
+def chaos_fixture_repo(tmp_path: Path) -> Iterator[dict]:
+    """A real committed git repo whose test is GREEN, then chaos-mutated RED.
+
+    Yields a dict with ``root`` (repo root), ``src`` (the chaos source file),
+    ``rel`` (its repo-relative POSIX path), and ``test_rel`` (its test path).
+    """
+    root = tmp_path / "hermetic_fixture"
+    (root / "pkg" / "tests").mkdir(parents=True)
+    # ``conftest.py`` so ``from pkg.foo import add`` resolves with cwd=root.
+    (root / "conftest.py").write_text("")
+    (root / "pkg" / "__init__.py").write_text("")
+    src = root / "pkg" / "foo.py"
+    src.write_text(_SRC_GREEN)
+    test_file = root / "pkg" / "tests" / "test_foo.py"
+    test_file.write_text(_TEST_SRC)
+
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "hermetic@matrix.local")
+    _git(root, "config", "user.name", "Hermetic Matrix")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "green baseline")
+
+    # Plant the chaos mutation (uncommitted -> git diff HEAD sees it).
+    src.write_text(_SRC_CHAOS)
+
+    yield {
+        "root": root,
+        "src": src,
+        "rel": str(src.relative_to(root)).replace(os.sep, "/"),
+        "test_rel": str(test_file.relative_to(root)).replace(os.sep, "/"),
+    }
+
+
+@pytest.fixture(autouse=True)
+def _resolver_isolation() -> Iterator[None]:
+    saved = os.environ.pop("JARVIS_REPO_PATH", None)
+    clear_cache()
+    try:
+        yield
+    finally:
+        clear_cache()
+        if saved is not None:
+            os.environ["JARVIS_REPO_PATH"] = saved
+
+
+def _make_watcher_and_sensor(repo_root: Path) -> "tuple[TestWatcher, TestFailureSensor, _RecordingRouter]":
+    # Anchor explicitly at the fixture's .git root (the run-#12 fix in action).
+    watcher = TestWatcher(
+        repo="hermetic",
+        test_dir="pkg/tests",
+        repo_path=str(repo_root),
+        poll_interval_s=0.0,
+        pytest_timeout_s=30.0,
+    )
+    router = _RecordingRouter()
+    sensor = TestFailureSensor("hermetic", router, test_watcher=watcher)
+    return watcher, sensor, router
+
+
+# ---------------------------------------------------------------------------
+# (a) BOOT-HYDRATION PATH
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_boot_hydration_scopes_and_detects_chaos(chaos_fixture_repo: dict) -> None:
+    """git diff -> scoped test (NOT whole suite, NOT 'outside repo root') -> RED."""
+    root = chaos_fixture_repo["root"]
+    repo_root = resolve_repo_root(start=chaos_fixture_repo["src"])
+    assert repo_root == root.resolve(), "resolver must anchor at the fixture .git"
+
+    watcher, sensor, router = _make_watcher_and_sensor(repo_root)
+
+    # 1. diff_working_tree sees the chaos file (cwd=repo_root, repo-relative).
+    changed = await watcher.diff_working_tree()
+    assert chaos_fixture_repo["rel"] in changed, (
+        f"chaos file not seen by git diff: {changed}"
+    )
+
+    # 2. The changed source scopes to its OWN test — never the whole suite,
+    #    never a BlockedPathError. THIS is the run-#12 path-bug regression.
+    targets = await sensor._resolve_scoped_targets(chaos_fixture_repo["rel"])
+    assert targets, "scoped targets empty (would fall back to whole suite)"
+    target_names = {Path(t).name for t in targets}
+    assert "test_foo.py" in target_names
+    assert all(Path(t).name == "test_foo.py" for t in targets), (
+        f"scoping leaked beyond the chaos test (whole-suite risk): {targets}"
+    )
+
+    # 3. The scoped pytest run sees RED.
+    signals_first = await watcher.poll_once(target_paths=targets)
+    # First failure -> streak 1 (not yet stable). The chaos IS detected as a
+    # failure; stability needs a second consecutive RED (streak >= 2).
+    assert watcher._failure_streak, "no failure recorded — chaos went undetected"
+
+    # 4. hydrate_on_boot drives the SAME scoped path and, on this second
+    #    consecutive RED, emits the stable TestFailure IntentSignal -> dispatch.
+    ingested = await asyncio.wait_for(sensor.hydrate_on_boot(), timeout=30.0)
+    assert ingested >= 1, "boot hydration emitted no stable signal"
+    assert router.ingested, "TestFailure never dispatched to the router"
+    env = router.ingested[0]
+    # The dispatched envelope points at the chaos source file.
+    target_files = getattr(env, "target_files", ())
+    assert any("foo.py" in str(tf) for tf in target_files), (
+        f"dispatched envelope not scoped to the chaos file: {target_files}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# (b) EVENT PATH — real fs.changed.* through the real TrinityEventBus
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_event_path_scopes_and_detects_chaos(chaos_fixture_repo: dict) -> None:
+    """EventSimulator injects a real-shape fs.changed.* -> same scoped detect."""
+    from backend.core.trinity_event_bus import TrinityEventBus, RepoType
+
+    root = chaos_fixture_repo["root"]
+    repo_root = resolve_repo_root(start=chaos_fixture_repo["src"])
+    watcher, sensor, router = _make_watcher_and_sensor(repo_root)
+
+    # Prime one RED so the event-path run produces a STABLE (streak>=2) signal.
+    targets = await sensor._resolve_scoped_targets(chaos_fixture_repo["rel"])
+    await watcher.poll_once(target_paths=targets)
+
+    # Real, started, in-memory bus + real subscription.
+    os.environ["JARVIS_TEST_FAILURE_FS_EVENTS_ENABLED"] = "true"
+    bus = TrinityEventBus(local_repo=RepoType.JARVIS)
+    await bus.start()
+    try:
+        await sensor.subscribe_to_bus(bus)  # real handler wired to fs.changed.*
+
+        sim = EventSimulator(bus, repo_root=repo_root)
+        # Inject the EXACT real-shape fs.changed.* for the chaos file.
+        topic_payload_proof = await _assert_real_payload_shape(
+            sim, chaos_fixture_repo
+        )
+        assert topic_payload_proof  # payload shape validated below
+
+        await sim.inject_change(chaos_fixture_repo["src"])
+
+        # The real subscription debounces 2s then runs the scoped pytest.
+        # Poll the router (no sync sleep) until the dispatch lands.
+        await _wait_until(lambda: bool(router.ingested), timeout=20.0)
+    finally:
+        os.environ.pop("JARVIS_TEST_FAILURE_FS_EVENTS_ENABLED", None)
+        await bus.stop()
+
+    assert router.ingested, "event path did not dispatch the chaos TestFailure"
+    env = router.ingested[0]
+    target_files = getattr(env, "target_files", ())
+    assert any("foo.py" in str(tf) for tf in target_files)
+
+
+async def _assert_real_payload_shape(sim: EventSimulator, fx: dict) -> bool:
+    """Prove the simulator builds the bridge's exact field set + values."""
+    from tests.integration.event_simulator import build_fs_changed_payload
+
+    topic, payload = build_fs_changed_payload(
+        abs_path=fx["src"], repo_root=fx["root"].resolve(),
+    )
+    assert topic == "fs.changed.modified"
+    # Field set must match fs_event_bridge._on_file_event exactly.
+    assert set(payload) == {
+        "path", "relative_path", "extension", "checksum",
+        "is_test_file", "is_config_file", "is_directory", "timestamp",
+    }
+    assert payload["relative_path"] == fx["rel"]
+    assert payload["extension"] == ".py"
+    assert payload["is_test_file"] is False  # pkg/foo.py is a source file
+    assert payload["is_config_file"] is False
+    assert payload["is_directory"] is False
+    assert isinstance(payload["checksum"], str) and payload["checksum"]
+    return True
+
+
+# ---------------------------------------------------------------------------
+# Async helpers — no sync sleeps
+# ---------------------------------------------------------------------------
+
+
+async def _wait_until(pred, *, timeout: float, interval: float = 0.05) -> None:
+    """Await until *pred()* is truthy or *timeout* elapses (fully async)."""
+    async def _spin() -> None:
+        while not pred():
+            await asyncio.sleep(interval)
+    try:
+        await asyncio.wait_for(_spin(), timeout=timeout)
+    except asyncio.TimeoutError:
+        pass  # caller asserts on the predicate; surfaces a clear failure
+
+
+# ---------------------------------------------------------------------------
+# Speed + zero-cloud guard
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_resolver_anchors_no_cloud_no_hardcode(chaos_fixture_repo: dict) -> None:
+    """The whole matrix anchors at .git with no literal paths + no cloud SDK."""
+    repo_root = resolve_repo_root(start=chaos_fixture_repo["src"])
+    assert (repo_root / ".git").exists()
+
+    # Structural: none of the modules the matrix exercises import a cloud SDK.
+    import ast
+
+    for mod_rel in (
+        Path("backend/core/ouroboros/governance/workspace_resolver.py"),
+        Path("backend/core/ouroboros/governance/intent/test_watcher.py"),
+        Path("backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py"),
+        Path("tests/integration/event_simulator.py"),
+    ):
+        text = (resolve_repo_root() / mod_rel).read_text()
+        tree = ast.parse(text)
+        imported: List[str] = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                imported += [a.name for a in node.names]
+            elif isinstance(node, ast.ImportFrom) and node.module:
+                imported.append(node.module)
+        for name in imported:
+            assert not name.startswith("google"), (
+                f"{mod_rel} pulls in a cloud SDK ({name}) — not hermetic"
+            )


### PR DESCRIPTION
Dynamic .git-anchored WorkspaceResolver fixes the bare-'.' repo_root bug (the run-#12 'outside repo root' → full-suite SIGKILL). + in-memory EventSimulator (real fs.changed.* into TrinityEventBus) + async E2E fixture-repo test driving boot-hydration→scoped-pytest→chaos-detect→dispatch in ~3s, $0, zero cloud. The local iteration harness that replaces ~50-min/$0.25 cloud discovery runs. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a `.git`-anchored `WorkspaceResolver` and a hermetic local matrix runner with an in-memory `fs.changed.*` event simulator. Fixes the run-#12 path bug that rejected valid tests as “outside repo root” and prevented proper scoping, enabling fast, $0 local iteration.

- **New Features**
  - Added `backend/core/ouroboros/governance/workspace_resolver.py` with `resolve_repo_root()` (linked-worktree aware, cached, fail-soft).
  - `TestWatcher` and `TestFailureSensor` now use the resolver as the single repo root source.
  - Added `tests/integration/event_simulator.py` to publish real `fs.changed.*` payloads into `TrinityEventBus`.
  - Added `tests/integration/test_hermetic_a1_matrix.py` to drive boot hydration → scoped pytest → chaos detect → dispatch in a tmp repo (no cloud).
  - Added `tests/governance/test_workspace_resolver.py` for resolver behavior and regression coverage.

- **Bug Fixes**
  - Replaced bare `"."` repo defaults with the `.git`-anchored resolver, aligning `git diff`, normalization, and scoping.
  - Eliminates “outside repo root” errors and whole-suite fallbacks; valid changes now scope to their tests consistently.

<sup>Written for commit a3c2ec96f5594bb49c8aecbd7faa4c0e60b2030d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

