### PR TITLE
feat(l3): MAS fan-out hardening — Collision Matrix + DecomposableChaosInjector + per-subagent telemetry

### DIFF
--- a/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
+++ b/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import dataclasses
 import logging
+import os
 import tempfile
 import time
 from datetime import datetime, timedelta, timezone
@@ -45,6 +47,78 @@ _TERMINAL_GRAPH_PHASES = {
 }
 
 
+# --- L3 per-subagent telemetry (gated, fail-soft) --------------------------
+# Surfaces each parallel subagent's resource + cost footprint live:
+#   - worktree lifespan (create()->reap, monotonic seconds)
+#   - DoubleWord inference cost (from the provider's reported cost_usd)
+# Gated by JARVIS_L3_TELEMETRY_ENABLED (default true). OFF -> no [L3Telemetry]
+# lines and the execution path is byte-identical (telemetry never mutates
+# control flow). Every emit is wrapped fail-soft: a telemetry error is
+# swallowed and never affects the work-unit result.
+
+def _l3_telemetry_enabled() -> bool:
+    return os.environ.get("JARVIS_L3_TELEMETRY_ENABLED", "true").strip().lower() not in (
+        "0",
+        "false",
+        "no",
+        "off",
+    )
+
+
+def _fmt_opt_float(value: Optional[float]) -> str:
+    """Render an optional float honestly: None -> 'None', else a plain float."""
+    if value is None:
+        return "None"
+    return repr(float(value))
+
+
+def _emit_unit_telemetry(result: "WorkUnitResult", branch: str) -> None:
+    """Emit the per-unit [L3Telemetry] breadcrumb. Fail-soft + gated."""
+    if not _l3_telemetry_enabled():
+        return
+    try:
+        logger.info(
+            "[L3Telemetry] unit=%s worktree=%s lifespan_s=%s dw_cost_usd=%s status=%s",
+            result.unit_id,
+            branch or "-",
+            _fmt_opt_float(result.worktree_lifespan_s),
+            _fmt_opt_float(result.dw_cost_usd),
+            getattr(result.status, "value", result.status),
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break execution
+        logger.debug("[L3Telemetry] per-unit emit failed (non-fatal)", exc_info=True)
+
+
+def _emit_graph_telemetry(
+    graph_id: str, results: Dict[str, "WorkUnitResult"]
+) -> None:
+    """Emit the graph-aggregate [L3Telemetry] line. Fail-soft + gated.
+
+    Honest sums: a None lifespan/cost contributes nothing (it is not a 0.0
+    measurement, it is the absence of one). total_* therefore aggregate only
+    the units that actually reported a value.
+    """
+    if not _l3_telemetry_enabled():
+        return
+    try:
+        total_lifespan = 0.0
+        total_cost = 0.0
+        for res in results.values():
+            if res.worktree_lifespan_s is not None:
+                total_lifespan += float(res.worktree_lifespan_s)
+            if res.dw_cost_usd is not None:
+                total_cost += float(res.dw_cost_usd)
+        logger.info(
+            "[L3Telemetry] graph=%s units=%d total_lifespan_s=%s total_dw_cost_usd=%s",
+            graph_id,
+            len(results),
+            repr(round(total_lifespan, 6)),
+            repr(round(total_cost, 6)),
+        )
+    except Exception:  # noqa: BLE001 — telemetry must never break execution
+        logger.debug("[L3Telemetry] graph-aggregate emit failed (non-fatal)", exc_info=True)
+
+
 class GenerationSubagentExecutor:
     """Default work-unit executor backed by the existing governed generator."""
 
@@ -82,6 +156,12 @@ class GenerationSubagentExecutor:
         causal_parent_id = graph.causal_trace_id
         _worktree_path: Optional[Path] = None
         _sandbox: Optional[Any] = self._build_sandbox_for_unit(unit)
+        # --- L3 telemetry locals (fail-soft; never affect control flow) ---
+        _worktree_create_mono: Optional[float] = None
+        _worktree_lifespan_s: Optional[float] = None
+        _dw_cost_usd: Optional[float] = None
+        _branch_label: str = ""
+        _result: Optional[WorkUnitResult] = None
         try:
             if len(unit.target_files) != 1:
                 raise RuntimeError(
@@ -99,9 +179,17 @@ class GenerationSubagentExecutor:
             # main working copy while the contract still promises isolation.
             if self._worktree_manager is not None:
                 _branch = f"unit-{unit.unit_id}-{graph.graph_id}"
+                _branch_label = _branch
                 try:
                     _created = await self._worktree_manager.create(_branch)
                     _worktree_path = _created
+                    # Telemetry: monotonic stamp at create() success. Reap
+                    # stamp is taken in the finally block -> lifespan. Wrapped
+                    # so a clock hiccup never affects the unit.
+                    try:
+                        _worktree_create_mono = time.monotonic()
+                    except Exception:  # noqa: BLE001
+                        _worktree_create_mono = None
                     logger.info(
                         "[SubagentExecutor] Worktree created: %s -> %s",
                         _branch, _created,
@@ -114,7 +202,7 @@ class GenerationSubagentExecutor:
                         "— unit fails (isolation promised, not obtained)",
                         _branch, wt_exc,
                     )
-                    return WorkUnitResult(
+                    _result = WorkUnitResult(
                         unit_id=unit.unit_id,
                         repo=unit.repo,
                         status=WorkUnitState.FAILED,
@@ -132,6 +220,7 @@ class GenerationSubagentExecutor:
                         error=f"worktree_create_failed:{type(wt_exc).__name__}:{wt_exc}",
                         causal_parent_id=causal_parent_id,
                     )
+                    return _result
 
             op_id = f"{graph.op_id}:{unit.unit_id}"
             subctx = OperationContext.create(
@@ -145,8 +234,16 @@ class GenerationSubagentExecutor:
             subctx = subctx.with_pipeline_deadline(deadline)
 
             generation = await self._generator.generate(subctx, deadline)
+            # Telemetry: thread the provider's reported DW cost. Honest-null —
+            # a missing cost_usd attribute means the result carries no cost, so
+            # we report None rather than fabricating a 0.0 measurement.
+            try:
+                _gen_cost = getattr(generation, "cost_usd", None)
+                _dw_cost_usd = None if _gen_cost is None else float(_gen_cost)
+            except Exception:  # noqa: BLE001
+                _dw_cost_usd = None
             if generation.is_noop:
-                return WorkUnitResult(
+                _result = WorkUnitResult(
                     unit_id=unit.unit_id,
                     repo=unit.repo,
                     status=WorkUnitState.COMPLETED,
@@ -156,6 +253,7 @@ class GenerationSubagentExecutor:
                     finished_at_ns=time.monotonic_ns(),
                     causal_parent_id=causal_parent_id,
                 )
+                return _result
 
             best_candidate: Optional[Dict[str, Any]] = None
             best_failure_class = ""
@@ -177,7 +275,7 @@ class GenerationSubagentExecutor:
                 best_error = error
 
             if best_candidate is None:
-                return WorkUnitResult(
+                _result = WorkUnitResult(
                     unit_id=unit.unit_id,
                     repo=unit.repo,
                     status=WorkUnitState.FAILED,
@@ -189,9 +287,10 @@ class GenerationSubagentExecutor:
                     error=best_error or "no_valid_candidate",
                     causal_parent_id=causal_parent_id,
                 )
+                return _result
 
             patch = self._candidate_to_patch(unit.repo, repo_root, best_candidate)
-            return WorkUnitResult(
+            _result = WorkUnitResult(
                 unit_id=unit.unit_id,
                 repo=unit.repo,
                 status=WorkUnitState.COMPLETED,
@@ -201,8 +300,9 @@ class GenerationSubagentExecutor:
                 finished_at_ns=time.monotonic_ns(),
                 causal_parent_id=causal_parent_id,
             )
+            return _result
         except Exception as exc:
-            return WorkUnitResult(
+            _result = WorkUnitResult(
                 unit_id=unit.unit_id,
                 repo=unit.repo,
                 status=WorkUnitState.FAILED,
@@ -224,6 +324,40 @@ class GenerationSubagentExecutor:
                     logger.warning(
                         "[SubagentExecutor] Worktree cleanup failed: %s", cleanup_exc
                     )
+            # --- L3 telemetry: worktree lifespan (create()->reap) ----------
+            # The reap stamp is taken here (post-cleanup) so the lifespan
+            # spans the full isolated-worktree lifetime. Entirely fail-soft:
+            # any timing error leaves lifespan None and never disturbs the
+            # unit result or the teardown that follows.
+            if _worktree_create_mono is not None:
+                try:
+                    _worktree_lifespan_s = time.monotonic() - _worktree_create_mono
+                except Exception:  # noqa: BLE001
+                    _worktree_lifespan_s = None
+            # Attach telemetry fields to the (already-built) result and emit
+            # the per-unit breadcrumb. dataclasses.replace keeps WorkUnitResult
+            # frozen + back-compat. Gated: OFF -> result is byte-identical (no
+            # enrichment, no line). If anything here raises, the original
+            # _result is returned unchanged (fail-soft).
+            if _result is not None and _l3_telemetry_enabled():
+                try:
+                    _result = dataclasses.replace(
+                        _result,
+                        worktree_lifespan_s=_worktree_lifespan_s,
+                        dw_cost_usd=_dw_cost_usd,
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "[L3Telemetry] result enrichment failed (non-fatal)",
+                        exc_info=True,
+                    )
+                try:
+                    _emit_unit_telemetry(_result, _branch_label)
+                except Exception:  # noqa: BLE001 — telemetry never breaks the unit
+                    logger.debug(
+                        "[L3Telemetry] per-unit emit raised (non-fatal)",
+                        exc_info=True,
+                    )
             # --- Swarm Phase 1b — deterministic sandbox vaporization. -------
             # finally-guaranteed (success / failure / cancellation); composes
             # with the worktree cleanup above + WorktreeManager.reap_orphans()
@@ -239,6 +373,13 @@ class GenerationSubagentExecutor:
                 # swarm_node_vaporized telemetry edge (fail-soft; never
                 # disturbs the finally-guaranteed teardown).
                 vaporize_quietly(_sandbox, graph_id=getattr(graph, "graph_id", ""))
+            # Return the (telemetry-enriched) result from the finally block so
+            # the lifespan + cost fields — only fully known after reap — ride
+            # back on the WorkUnitResult. When _result is None (unreachable in
+            # practice: every try path assigns it) we fall through and the
+            # original return value stands.
+            if _result is not None:
+                return _result
 
     @staticmethod
     def _build_sandbox_for_unit(unit: WorkUnitSpec) -> Optional[Any]:
@@ -1006,6 +1147,16 @@ class SubagentScheduler:
             future.set_result(state)
 
     def _finish_graph(self, graph_id: str, state: GraphExecutionState) -> None:
+        # L3 telemetry: graph-aggregate footprint at terminal phase (COMPLETED
+        # / FAILED / CANCELLED). Fail-soft + gated inside the helper; wrapped
+        # again here so a broken emit can never abort graph finalization.
+        try:
+            _emit_graph_telemetry(graph_id, state.results)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[L3Telemetry] graph-aggregate emit raised (non-fatal)",
+                exc_info=True,
+            )
         self._set_graph_future_result(graph_id, state)
         self._graph_tasks.pop(graph_id, None)
         if self._running and self._recovery_queue:

--- a/backend/core/ouroboros/governance/autonomy/subagent_types.py
+++ b/backend/core/ouroboros/governance/autonomy/subagent_types.py
@@ -228,6 +228,14 @@ class WorkUnitResult:
     failure_class: str = ""
     error: str = ""
     causal_parent_id: str = ""
+    # --- L3 per-subagent telemetry (optional, back-compat default None) ---
+    # Worktree lifespan in seconds measured create()->reap (monotonic). None
+    # when no worktree manager was active for this unit (nothing to report).
+    worktree_lifespan_s: Optional[float] = None
+    # DoubleWord inference cost in USD summed across this unit's generation
+    # calls, threaded from the provider's reported ``cost_usd``. Honest-null
+    # (None) when the generation result carried no cost — never fabricated.
+    dw_cost_usd: Optional[float] = None
 
     def __post_init__(self) -> None:
         if self.finished_at_ns < self.started_at_ns:
@@ -354,6 +362,9 @@ def work_unit_result_to_dict(result: WorkUnitResult) -> Dict[str, Any]:
         "failure_class": result.failure_class,
         "error": result.error,
         "causal_parent_id": result.causal_parent_id,
+        # L3 telemetry — additive; absent/None for legacy persisted results.
+        "worktree_lifespan_s": result.worktree_lifespan_s,
+        "dw_cost_usd": result.dw_cost_usd,
     }
 
 
@@ -372,6 +383,14 @@ def work_unit_result_from_dict(data: Dict[str, Any]) -> WorkUnitResult:
         failure_class=str(data.get("failure_class", "")),
         error=str(data.get("error", "")),
         causal_parent_id=str(data.get("causal_parent_id", "")),
+        worktree_lifespan_s=(
+            None
+            if data.get("worktree_lifespan_s") is None
+            else float(data["worktree_lifespan_s"])
+        ),
+        dw_cost_usd=(
+            None if data.get("dw_cost_usd") is None else float(data["dw_cost_usd"])
+        ),
     )
 
 

--- a/backend/core/ouroboros/governance/collision_matrix.py
+++ b/backend/core/ouroboros/governance/collision_matrix.py
@@ -1,0 +1,583 @@
+"""Wave 3 (6) -- Proactive zero-trust AST Collision Matrix for L3 fan-out.
+
+This module is the *proactive, pre-submit* complement to the scheduler's
+*reactive* runtime guard
+(:meth:`~backend.core.ouroboros.governance.autonomy.subagent_scheduler.SubagentScheduler._select_ready_batch`,
+which defers a ready unit when its ``effective_owned_paths`` overlap a
+unit already running). The reactive guard catches collisions silently at
+execution time; this matrix catches them *before* the
+:class:`ExecutionGraph` is even built, so a forced-serial decision is
+observable and fail-fast instead of an invisible runtime serialization.
+
+It does NOT remove or duplicate the reactive guard -- it shares the same
+path-overlap notion (units own ``target_files``) but evaluates eligibility
+pre-submit and additionally forbids parallelism across *import-coupled*
+files (interface <-> implementation) using the real Oracle import/call
+graph.
+
+Zero-trust default-DENY mandate
+-------------------------------
+Two units are allowed to fan out in parallel ONLY when their coupling can
+be *proven disjoint*. Any of the following yields ``COLLIDE`` (force
+sequential), never optimistic parallel:
+
+1. Direct ``target_files`` set-overlap (same file).
+2. Import-coupling via the Oracle graph (A imports B, B imports A, or a
+   shared interface<->impl edge in either direction).
+3. **Indeterminate coupling** -- Oracle is ``None``, the Oracle raises, or
+   the Oracle genuinely has no indexed data for one of the files. Unknown
+   coupling is treated as a collision; we never optimistically parallelize
+   an unknown.
+
+Reuse-first
+-----------
+- No new import parser. Coupling is read from the existing Oracle graph
+  (``find_nodes_in_file`` / ``get_dependencies`` / ``get_dependents``,
+  which back the IMPORTS / IMPORTS_FROM / CALLS edges).
+- No new unit type. Units are :class:`WorkUnitSpec`; coupling is keyed on
+  the existing ``target_files`` tuple.
+- The eligibility entry point reuses :func:`is_fanout_eligible` from
+  :mod:`parallel_dispatch` for the master-flag / posture / memory chain,
+  and emits the already-defined
+  :data:`~parallel_dispatch.ReasonCode.COLLISION_FORCED_SEQUENTIAL`.
+
+Determinism
+-----------
+:func:`partition_parallel_safe` uses a deterministic greedy
+maximal-pairwise-disjoint partition over units sorted by ``unit_id``
+(documented inline). Same inputs -> same split.
+
+Master-flag gating
+------------------
+The matrix only matters when fan-out is on. When the WAVE3 master flag is
+off, :func:`is_fanout_eligible_collision_aware` short-circuits to the
+underlying :func:`is_fanout_eligible` (``MASTER_OFF``) WITHOUT building the
+collision matrix -- production is byte-identical to the pre-matrix path.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    WorkUnitSpec,
+)
+from backend.core.ouroboros.governance.parallel_dispatch import (
+    FanoutEligibility,
+    ReasonCode,
+    is_fanout_eligible,
+    parallel_dispatch_enabled,
+)
+
+logger = logging.getLogger("Ouroboros.CollisionMatrix")
+
+
+# ---------------------------------------------------------------------------
+# Verdict vocabulary
+# ---------------------------------------------------------------------------
+
+
+class CollisionVerdict(str, enum.Enum):
+    """Pairwise verdict between two work units.
+
+    ``COLLIDE`` -- the two units MUST NOT run in parallel (same file,
+    import-coupled, or indeterminate coupling under zero-trust).
+
+    ``DISJOINT`` -- the two units were *proven* to touch neither the same
+    file nor any import-coupled file; they are safe to fan out together.
+
+    There is intentionally no ``UNKNOWN`` value: under the zero-trust
+    mandate, anything not provably disjoint is a ``COLLIDE``.
+    """
+
+    COLLIDE = "collide"
+    DISJOINT = "disjoint"
+
+
+# ---------------------------------------------------------------------------
+# Oracle coupling probe (reuse-first: reads the existing import/call graph)
+# ---------------------------------------------------------------------------
+
+
+def _files_of(unit: WorkUnitSpec) -> Tuple[str, ...]:
+    """Files a unit owns -- the existing ``target_files`` tuple.
+
+    Mirrors the reactive guard's path notion (units own their target
+    files). We deliberately key on ``target_files`` rather than
+    ``effective_owned_paths`` because coupling is computed from the files
+    the model will actually edit; an empty tuple is impossible
+    (``WorkUnitSpec.__post_init__`` rejects it).
+    """
+    return tuple(unit.target_files)
+
+
+def _node_file(node: Any) -> Optional[str]:
+    """Extract a ``file_path`` from an Oracle node-ish object, defensively."""
+    fp = getattr(node, "file_path", None)
+    if isinstance(fp, str) and fp:
+        return fp
+    return None
+
+
+def _coupled_files(oracle: Any, file_path: str) -> Optional[set]:
+    """Return the set of files import/call-coupled to ``file_path``.
+
+    Reuses the Oracle graph exclusively -- no new parser:
+
+    - ``find_nodes_in_file(file_path)`` -> the nodes Oracle has indexed for
+      this file. An EMPTY list means the Oracle genuinely has no data for
+      the file (unindexed) -> indeterminate.
+    - For each such node, ``get_dependencies`` (outgoing IMPORTS/CALLS) and
+      ``get_dependents`` (incoming) give the coupled nodes; their
+      ``file_path`` attributes are the coupled files.
+
+    Returns
+    -------
+    Optional[set]
+        The set of coupled file paths (excluding ``file_path`` itself) on
+        success. ``None`` on INDETERMINATE -- Oracle is missing, raised, or
+        has no indexed nodes for this file. ``None`` is the zero-trust
+        signal: callers MUST treat it as a collision.
+    """
+    if oracle is None:
+        return None
+    try:
+        nodes = oracle.find_nodes_in_file(file_path)
+    except Exception:  # noqa: BLE001 -- broken/unavailable graph -> indeterminate
+        logger.debug(
+            "[CollisionMatrix] find_nodes_in_file raised for %s -> indeterminate",
+            file_path,
+            exc_info=True,
+        )
+        return None
+    if not nodes:
+        # Oracle has no data for this file -> cannot prove disjoint.
+        return None
+
+    coupled: set = set()
+    for node in nodes:
+        for probe in ("get_dependencies", "get_dependents"):
+            fn = getattr(oracle, probe, None)
+            if fn is None:
+                continue
+            try:
+                neighbours = fn(node)
+            except Exception:  # noqa: BLE001 -- partial graph -> indeterminate
+                logger.debug(
+                    "[CollisionMatrix] %s raised for %s -> indeterminate",
+                    probe,
+                    file_path,
+                    exc_info=True,
+                )
+                return None
+            for nb in neighbours or ():
+                nf = _node_file(nb)
+                if nf and nf != file_path:
+                    coupled.add(nf)
+    return coupled
+
+
+# ---------------------------------------------------------------------------
+# Pairwise verdict
+# ---------------------------------------------------------------------------
+
+
+def _pair_verdict(
+    files_a: Sequence[str],
+    files_b: Sequence[str],
+    oracle: Any,
+    cache: Dict[str, Optional[set]],
+) -> CollisionVerdict:
+    """Decide COLLIDE / DISJOINT for two units' file sets (zero-trust).
+
+    Order of evaluation (first trip wins -> COLLIDE):
+
+    (a) Direct same-file overlap of ``target_files``.
+    (b) Import-coupling: for any file in A, is any file in B in A's coupled
+        set (or vice versa)? Probed in BOTH directions because the Oracle
+        graph is directional.
+    (c) Indeterminate: if coupling for ANY file on either side could not be
+        resolved (``_coupled_files`` returned ``None``), default-DENY.
+
+    Returns ``DISJOINT`` only when every probe resolved AND no overlap or
+    coupling edge was found.
+    """
+    set_a = set(files_a)
+    set_b = set(files_b)
+
+    # (a) Direct file overlap -- same path notion as the reactive guard.
+    if set_a & set_b:
+        return CollisionVerdict.COLLIDE
+
+    # (b)+(c) Import-coupling with zero-trust on indeterminate resolution.
+    # Resolve coupled sets for every involved file once (cached).
+    for fp in set_a | set_b:
+        if fp not in cache:
+            cache[fp] = _coupled_files(oracle, fp)
+
+    indeterminate = False
+    for fp in set_a:
+        coupled = cache[fp]
+        if coupled is None:
+            indeterminate = True
+            continue
+        if coupled & set_b:
+            return CollisionVerdict.COLLIDE
+    for fp in set_b:
+        coupled = cache[fp]
+        if coupled is None:
+            indeterminate = True
+            continue
+        if coupled & set_a:
+            return CollisionVerdict.COLLIDE
+
+    # (c) Zero-trust: any unresolved coupling -> COLLIDE, never optimistic.
+    if indeterminate:
+        return CollisionVerdict.COLLIDE
+
+    return CollisionVerdict.DISJOINT
+
+
+# ---------------------------------------------------------------------------
+# CollisionMatrix
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CollisionMatrix:
+    """Immutable pairwise verdict table over a set of work units.
+
+    Built once via :func:`build_collision_matrix`; queried with
+    :meth:`verdict` / :meth:`collides`. Symmetric: ``verdict(a, b) ==
+    verdict(b, a)``. A unit never collides with itself in the pairwise
+    sense (``collides(x, x) is False``).
+    """
+
+    unit_ids: Tuple[str, ...]
+    _verdicts: Dict[Tuple[str, str], CollisionVerdict] = field(
+        default_factory=dict
+    )
+
+    @staticmethod
+    def _key(a: str, b: str) -> Tuple[str, str]:
+        return (a, b) if a <= b else (b, a)
+
+    def verdict(self, a: str, b: str) -> CollisionVerdict:
+        """Symmetric pairwise verdict. A unit vs. itself is DISJOINT."""
+        if a == b:
+            return CollisionVerdict.DISJOINT
+        return self._verdicts.get(self._key(a, b), CollisionVerdict.COLLIDE)
+
+    def collides(self, a: str, b: str) -> bool:
+        """``True`` iff the pair must not run in parallel (and ``a != b``)."""
+        if a == b:
+            return False
+        return self.verdict(a, b) is CollisionVerdict.COLLIDE
+
+
+def build_collision_matrix(
+    units: Sequence[WorkUnitSpec],
+    *,
+    oracle: Any = None,
+) -> CollisionMatrix:
+    """Build the pairwise collision matrix for ``units`` (zero-trust).
+
+    Parameters
+    ----------
+    units:
+        The candidate work units. Each carries ``target_files``.
+    oracle:
+        The Oracle import/call graph (dependency-injected for tests). When
+        ``None``, the default global Oracle is used; if THAT cannot be
+        obtained, every cross-file coupling is INDETERMINATE -> COLLIDE.
+
+    Returns
+    -------
+    CollisionMatrix
+        Pairwise verdicts for every distinct unit pair. Bounded:
+        ``O(U^2)`` pairs over ``O(F)`` distinct files; per-file coupling is
+        resolved once and cached.
+    """
+    resolved_oracle = oracle
+    if resolved_oracle is None:
+        resolved_oracle = _maybe_default_oracle()
+
+    unit_ids = tuple(u.unit_id for u in units)
+    verdicts: Dict[Tuple[str, str], CollisionVerdict] = {}
+    # Per-build coupling cache: file_path -> coupled set (or None).
+    cache: Dict[str, Optional[set]] = {}
+
+    files = {u.unit_id: _files_of(u) for u in units}
+    for i in range(len(units)):
+        for j in range(i + 1, len(units)):
+            a = units[i].unit_id
+            b = units[j].unit_id
+            v = _pair_verdict(files[a], files[b], resolved_oracle, cache)
+            verdicts[CollisionMatrix._key(a, b)] = v
+
+    return CollisionMatrix(unit_ids=unit_ids, _verdicts=verdicts)
+
+
+def _maybe_default_oracle() -> Any:
+    """Best-effort fetch of the global Oracle; ``None`` on any failure.
+
+    A ``None`` oracle drives the zero-trust path (every cross-file pair
+    INDETERMINATE -> COLLIDE), which is the correct fail-closed behaviour.
+    """
+    try:
+        from backend.core.ouroboros.oracle import get_oracle
+
+        return get_oracle()
+    except Exception:  # noqa: BLE001 -- Oracle absent -> zero-trust deny
+        logger.debug(
+            "[CollisionMatrix] default Oracle unavailable -> zero-trust deny",
+            exc_info=True,
+        )
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Deterministic maximal-pairwise-disjoint partition
+# ---------------------------------------------------------------------------
+
+
+def partition_parallel_safe(
+    units: Sequence[WorkUnitSpec],
+    *,
+    oracle: Any = None,
+    matrix: Optional[CollisionMatrix] = None,
+) -> Tuple[List[List[WorkUnitSpec]], List[WorkUnitSpec]]:
+    """Partition units into parallel-safe groups + a sequential remainder.
+
+    Algorithm (deterministic greedy clique packing)
+    -----------------------------------------------
+    1. Sort units by ``unit_id`` (stable, deterministic).
+    2. For the first unsplaced unit, open a new parallel group seeded with
+       it, then greedily admit each later unit that is ``DISJOINT`` with
+       EVERY unit already in the group (a clique in the disjoint graph).
+    3. Repeat over the remaining unplaced units until all are placed.
+    4. Any group of size >= 2 is a real fan-out group; any singleton group
+       is serial-equivalent and is moved to the ``sequential_forced`` list
+       (a fan-out of 1 is meaningless overhead and would otherwise hide a
+       forced-serial unit).
+
+    This greedy clique packing is a heuristic for maximum disjoint
+    partitioning (the exact problem is graph-colouring-hard); it is
+    deterministic, fail-closed (a unit only joins a group when *proven*
+    disjoint from all members), and never co-groups a colliding pair.
+
+    Returns
+    -------
+    (parallel_groups, sequential_forced)
+        ``parallel_groups`` -- list of groups, each a list of >= 2 units
+        that are pairwise DISJOINT and may fan out together.
+        ``sequential_forced`` -- units that could not join any >= 2 group;
+        they run one at a time on the serial path.
+    """
+    ordered = sorted(units, key=lambda u: u.unit_id)
+    if matrix is None:
+        matrix = build_collision_matrix(ordered, oracle=oracle)
+
+    placed: set = set()
+    groups: List[List[WorkUnitSpec]] = []
+
+    for seed in ordered:
+        if seed.unit_id in placed:
+            continue
+        group = [seed]
+        placed.add(seed.unit_id)
+        for cand in ordered:
+            if cand.unit_id in placed:
+                continue
+            # Admit only when DISJOINT with every current group member.
+            if all(
+                matrix.verdict(member.unit_id, cand.unit_id)
+                is CollisionVerdict.DISJOINT
+                for member in group
+            ):
+                group.append(cand)
+                placed.add(cand.unit_id)
+        groups.append(group)
+
+    parallel_groups: List[List[WorkUnitSpec]] = []
+    sequential_forced: List[WorkUnitSpec] = []
+    for group in groups:
+        if len(group) >= 2:
+            parallel_groups.append(group)
+        else:
+            sequential_forced.extend(group)
+
+    return parallel_groups, sequential_forced
+
+
+# ---------------------------------------------------------------------------
+# Collision-aware eligibility decision (the seam wired pre-submit)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CollisionAwareEligibility:
+    """Eligibility decision augmented with the collision partition.
+
+    Wraps the underlying :class:`FanoutEligibility` (master-flag / posture
+    / memory chain) and adds the proactive collision partition.
+
+    Attributes
+    ----------
+    allowed:
+        ``True`` iff a >= 2-unit pairwise-disjoint fan-out group survives
+        both the collision partition AND the underlying eligibility chain.
+    reason_code:
+        ``COLLISION_FORCED_SEQUENTIAL`` when the collision matrix collapses
+        fan-out below 2 units; otherwise the underlying chain's reason.
+    parallel_units:
+        The flat list of units offered for parallel fan-out (the largest
+        disjoint group, capped by the underlying ``n_allowed``). ``<= 1``
+        unit means serial-equivalent.
+    sequential_units:
+        Units forced onto the serial path -- colliders plus any units
+        trimmed by the underlying fan-out cap.
+    base_eligibility:
+        The underlying :class:`FanoutEligibility` record, for telemetry.
+    """
+
+    allowed: bool
+    reason_code: ReasonCode
+    parallel_units: Tuple[WorkUnitSpec, ...]
+    sequential_units: Tuple[WorkUnitSpec, ...]
+    base_eligibility: Optional[FanoutEligibility] = None
+
+
+def is_fanout_eligible_collision_aware(
+    *,
+    op_id: str,
+    units: Sequence[WorkUnitSpec],
+    oracle: Any = None,
+    gate: Any = None,
+    posture_fn: Any = None,
+    emit_log: bool = True,
+) -> CollisionAwareEligibility:
+    """Proactive, pre-submit collision-aware fan-out eligibility.
+
+    This is the seam intended to run BEFORE ``build_execution_graph`` /
+    ``scheduler.submit`` (e.g. from ``phase_dispatcher`` where
+    ``enforce_evaluate_fanout`` is called). It:
+
+    1. Short-circuits to the underlying :func:`is_fanout_eligible` when the
+       WAVE3 master flag is off -> ``MASTER_OFF``, collision matrix NOT
+       built (production byte-identical to the pre-matrix path).
+    2. Builds the zero-trust :class:`CollisionMatrix` and partitions the
+       candidate units into pairwise-disjoint fan-out groups + a forced
+       sequential remainder.
+    3. Picks the largest disjoint group as the fan-out set, then runs the
+       underlying eligibility chain (posture / memory / max_units) on that
+       group's size to compute the effective fan-out degree.
+    4. If fewer than 2 units survive (nothing provably parallelizes, or the
+       chain clamps to 1), returns ``allowed=False`` with
+       ``COLLISION_FORCED_SEQUENTIAL`` -- the previously-dormant reason
+       code now has its first producer.
+
+    The remainder (colliders + any units trimmed by the underlying cap)
+    falls onto the serial path, complementing -- not duplicating -- the
+    scheduler's reactive ``owned_paths`` deferral.
+    """
+    unit_list = list(units)
+
+    # 1. Master flag off -> byte-identical passthrough, no matrix built.
+    if not parallel_dispatch_enabled():
+        base = is_fanout_eligible(
+            op_id=op_id,
+            n_candidate_files=len(unit_list),
+            gate=gate,
+            posture_fn=posture_fn,
+            emit_log=emit_log,
+        )
+        return CollisionAwareEligibility(
+            allowed=False,
+            reason_code=base.reason_code,
+            parallel_units=(),
+            sequential_units=tuple(unit_list),
+            base_eligibility=base,
+        )
+
+    # 2. Build the zero-trust collision matrix + partition.
+    matrix = build_collision_matrix(unit_list, oracle=oracle)
+    parallel_groups, sequential_forced = partition_parallel_safe(
+        unit_list, oracle=oracle, matrix=matrix
+    )
+
+    # 3. Pick the largest disjoint group (deterministic tie-break: the
+    #    group whose sorted unit_ids come first).
+    best_group: List[WorkUnitSpec] = []
+    for group in parallel_groups:
+        if len(group) > len(best_group) or (
+            len(group) == len(best_group)
+            and _group_sig(group) < _group_sig(best_group)
+        ):
+            best_group = group
+
+    # Run the underlying chain on the disjoint group's degree.
+    base = is_fanout_eligible(
+        op_id=op_id,
+        n_candidate_files=len(best_group),
+        gate=gate,
+        posture_fn=posture_fn,
+        emit_log=emit_log,
+    )
+
+    # 4. Compose the final split. The underlying chain may clamp below the
+    #    disjoint group size (posture / memory / max_units) -- trim the
+    #    fan-out set and push the trimmed units to sequential.
+    n_allowed = max(0, int(base.n_allowed))
+    # Deterministic order within the chosen group.
+    chosen_sorted = sorted(best_group, key=lambda u: u.unit_id)
+    if base.allowed and n_allowed >= 2:
+        parallel_units = tuple(chosen_sorted[:n_allowed])
+        trimmed = tuple(chosen_sorted[n_allowed:])
+    else:
+        # Nothing parallelizes -- whole group drops to serial.
+        parallel_units = ()
+        trimmed = tuple(chosen_sorted)
+
+    sequential_units = tuple(
+        sorted(
+            list(sequential_forced) + list(trimmed),
+            key=lambda u: u.unit_id,
+        )
+    )
+
+    if len(parallel_units) >= 2:
+        allowed = True
+        reason_code = base.reason_code
+    else:
+        # Collision matrix (or the chain on the disjoint subset) collapsed
+        # fan-out below 2 -> the dormant reason code fires here.
+        allowed = False
+        reason_code = ReasonCode.COLLISION_FORCED_SEQUENTIAL
+
+    if emit_log:
+        logger.info(
+            "[CollisionMatrix] op=%s units=%d parallel=%d sequential=%d "
+            "groups=%d reason=%s",
+            op_id[:16],
+            len(unit_list),
+            len(parallel_units),
+            len(sequential_units),
+            len(parallel_groups),
+            reason_code.value,
+        )
+
+    return CollisionAwareEligibility(
+        allowed=allowed,
+        reason_code=reason_code,
+        parallel_units=parallel_units,
+        sequential_units=sequential_units,
+        base_eligibility=base,
+    )
+
+
+def _group_sig(group: Sequence[WorkUnitSpec]) -> Tuple[str, ...]:
+    """Deterministic signature of a group (sorted unit_ids)."""
+    return tuple(sorted(u.unit_id for u in group))

--- a/backend/core/ouroboros/governance/parallel_dispatch.py
+++ b/backend/core/ouroboros/governance/parallel_dispatch.py
@@ -185,6 +185,11 @@ class ReasonCode(str, enum.Enum):
     MEMORY_CLAMP = "memory_clamp"
     POSTURE_CLAMP = "posture_clamp"
     MAX_UNITS_CLAMP = "max_units_clamp"
+    # Zero-trust AST Collision Matrix (L3) — candidate units could not be
+    # partitioned into a >=2-unit pairwise-disjoint fan-out group because
+    # every parallelizable subset collided on the same file or an
+    # import-coupled file (or coupling was INDETERMINATE -> fail-closed).
+    COLLISION_FORCED_SEQUENTIAL = "collision_forced_sequential"
 
 
 @dataclass(frozen=True)

--- a/scripts/chaos_injector_ast.py
+++ b/scripts/chaos_injector_ast.py
@@ -1148,6 +1148,39 @@ def do_revert(cfg: InjectConfig) -> int:
     if not manifest:
         _log("no active chaos manifest; nothing to revert.")
         return 0
+
+    # schema_version 2 (decomposable): restore EVERY target in the list,
+    # byte-identically. The manifest is cleared only if ALL restores succeed, so
+    # a partial revert failure stays auditable (manifest retained).
+    if manifest.get("schema_version") == DECOMPOSABLE_SCHEMA_VERSION:
+        entries = manifest.get("targets") or []
+        if not entries:
+            _log("decomposable manifest has no targets; clearing.")
+            _delete_manifest(cfg.repo_root)
+            return 0
+        all_ok = True
+        for entry in entries:
+            abs_path = entry.get("target_file_abs") or os.path.join(
+                cfg.repo_root, entry.get("target_file", ""),
+            )
+            original = entry.get("original_source")
+            if original is None:
+                _log("decomposable revert: entry missing original_source for "
+                     "%s; skipping (cannot restore safely)." % (abs_path,))
+                all_ok = False
+                continue
+            if not _restore_target(abs_path, original):
+                all_ok = False
+        if not all_ok:
+            _log("decomposable revert: one or more targets FAILED to restore; "
+                 "retaining manifest for audit.")
+            return 6
+        _delete_manifest(cfg.repo_root)
+        _log("REVERTED %d decomposable target(s) to byte-identical originals. "
+             "Manifest cleared." % (len(entries),))
+        return 0
+
+    # schema_version 1 (legacy single-target) -- unchanged behavior.
     abs_path = manifest.get("target_file_abs") or os.path.join(
         cfg.repo_root, manifest.get("target_file", ""),
     )
@@ -1155,12 +1188,7 @@ def do_revert(cfg: InjectConfig) -> int:
     if original is None:
         _log("manifest missing original_source; cannot revert safely. Aborting.")
         return 6
-    try:
-        with open(abs_path, "w", encoding="utf-8") as fh:
-            fh.write(original)
-        _bump_mtime(abs_path)
-    except OSError as exc:
-        _log(f"revert FAILED writing {abs_path}: {exc}")
+    if not _restore_target(abs_path, original):
         return 6
     _delete_manifest(cfg.repo_root)
     _log(
@@ -1464,6 +1492,430 @@ def _build_readiness_check(cfg: "InjectConfig") -> Optional[ReadinessCheck]:
 
 
 # --------------------------------------------------------------------------- #
+# DecomposableChaosInjector -- N MUTUALLY-ISOLATED pure-leaf targets.
+# --------------------------------------------------------------------------- #
+#
+# THE POINT: O+V's L3 AST Collision Matrix fans a set of work units out into
+# parallel subagents ONLY when their target files are pairwise import-disjoint
+# (no two files import each other / share an interface<->impl coupling). A
+# single-target chaos op can never exercise that fan-out. This mode acquires N
+# pure-leaf functions in N DIFFERENT files, PROVES pairwise import isolation via
+# a bounded AST import scan (the same shape oracle.py uses), mutates each so its
+# OWN test goes red, and records ALL N in one manifest (schema_version 2).
+#
+# Zero-trust: if N mutually-isolated, green-tested leaves cannot be found we
+# return FEWER and log honestly -- never fabricate a target. Any one target that
+# fails to go red is reverted + dropped (shrink); the inject NEVER leaves a
+# half-mutated tree (partial-failure cleanup reverts every already-applied
+# target). REVERT iterates the manifest list and restores ALL N byte-identically.
+#
+# Reuse-first: purity (_PurityVisitor / _analyze_function), candidate scan
+# (acquire_candidates), mutation planning (_iter_mutations), green/red
+# verification (_run_pytest_node), manifest IO (_write/_read/_delete_manifest)
+# and the byte-identical revert primitive are ALL reused unchanged. This mode
+# only adds the import-isolation predicate + the N-target orchestration.
+
+DECOMPOSABLE_SCHEMA_VERSION = 2
+
+
+@dataclass
+class ChaosTarget:
+    """One acquired, mutation-ready isolated target within a decomposable set."""
+    target_file: str               # absolute path (alias of candidate.target_file)
+    function: str
+    lineno: int
+    end_lineno: int
+    test_node: str                 # the green test node confirmed pre-injection
+    test_nodes: List[str] = field(default_factory=list)
+    dotted_name: str = ""          # module dotted name (for the import graph)
+
+
+def _module_dotted_name(repo_root: str, abs_file: str) -> str:
+    """Map an absolute .py path to its dotted module name relative to the repo
+    root (e.g. <repo>/backend/utils/calc0.py -> backend.utils.calc0). Mirrors the
+    package-path math oracle.py uses for its import graph. ``__init__.py`` maps
+    to the package dotted name. Returns "" for paths outside the repo."""
+    try:
+        rel = os.path.relpath(os.path.abspath(abs_file), os.path.abspath(repo_root))
+    except ValueError:
+        return ""
+    if rel.startswith(".."):
+        return ""
+    rel = rel[:-3] if rel.endswith(".py") else rel
+    parts = [p for p in rel.split(os.sep) if p and p != "."]
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _file_import_targets(abs_file: str) -> set:
+    """Return the set of dotted import targets a file references, via a bounded
+    AST scan (NO import execution). Covers both ``import a.b.c`` and
+    ``from a.b import name`` (the module is ``a.b``; relative imports keep their
+    leading-dot prefix so a sibling resolve can match). Best-effort: an
+    unparseable / unreadable file yields an empty set (treated as importing
+    nothing -- conservative for the *coupling* test, which only adds edges)."""
+    out: set = set()
+    try:
+        with open(abs_file, "r", encoding="utf-8") as fh:
+            src = fh.read()
+    except (OSError, UnicodeDecodeError):
+        return out
+    try:
+        tree = ast.parse(src, filename=abs_file)
+    except SyntaxError:
+        return out
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                if alias.name:
+                    out.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            if node.level and node.level > 0:
+                # Relative import: preserve dots so the caller can resolve it
+                # against the importer's own package.
+                out.add("." * node.level + mod)
+            elif mod:
+                out.add(mod)
+                # ``from a.b import c`` may name a submodule a.b.c -- record both
+                # the package and each fully-qualified candidate so a direct
+                # sibling-module import is detected.
+                for alias in node.names:
+                    if alias.name:
+                        out.add(mod + "." + alias.name)
+    return out
+
+
+def _resolve_relative(importer_dotted: str, rel_target: str) -> str:
+    """Resolve a relative import token (leading dots + module) against the
+    importer's dotted module name. ``importer=backend.utils.coupled_b`` +
+    ``rel=.coupled_a`` -> ``backend.utils.coupled_a``."""
+    level = len(rel_target) - len(rel_target.lstrip("."))
+    suffix = rel_target.lstrip(".")
+    base_parts = importer_dotted.split(".") if importer_dotted else []
+    # ``from . import x`` (level=1) is relative to the importer's package, so we
+    # drop the module's own name (one component) per extra level beyond the pkg.
+    drop = level
+    anchor = base_parts[: max(0, len(base_parts) - drop)]
+    if suffix:
+        anchor = anchor + suffix.split(".")
+    return ".".join(anchor)
+
+
+def _files_are_import_coupled(repo_root: str, file_a: str, file_b: str) -> bool:
+    """SYMMETRIC predicate: do these two files import-couple (does either import
+    the other's module)? Bounded AST scan against the real dotted-name graph --
+    no import execution, no hardcoding. The Collision Matrix marks a pair
+    DISJOINT iff this returns False.
+
+    Coupling exists iff A imports B's module (or a submodule under it), or vice
+    versa. Resolves both absolute (``backend.utils.x``) and relative
+    (``.x`` / ``..pkg.x``) import forms."""
+    a_abs, b_abs = os.path.abspath(file_a), os.path.abspath(file_b)
+    if a_abs == b_abs:
+        return True  # same file -> can never be two parallel units
+    a_dotted = _module_dotted_name(repo_root, a_abs)
+    b_dotted = _module_dotted_name(repo_root, b_abs)
+
+    def _imports_other(importer_abs: str, importer_dotted: str, other_dotted: str) -> bool:
+        if not other_dotted:
+            return False
+        for tok in _file_import_targets(importer_abs):
+            resolved = (
+                _resolve_relative(importer_dotted, tok)
+                if tok.startswith(".")
+                else tok
+            )
+            if not resolved:
+                continue
+            # Exact module hit, or other_dotted is a package prefix of the import
+            # (importer pulls a submodule of other), or other pulls a submodule
+            # under the import token.
+            if (
+                resolved == other_dotted
+                or resolved.startswith(other_dotted + ".")
+                or other_dotted.startswith(resolved + ".")
+            ):
+                return True
+        return False
+
+    return (
+        _imports_other(a_abs, a_dotted, b_dotted)
+        or _imports_other(b_abs, b_dotted, a_dotted)
+    )
+
+
+def _candidate_to_target(repo_root: str, cand: Candidate) -> ChaosTarget:
+    return ChaosTarget(
+        target_file=cand.target_file,
+        function=cand.function,
+        lineno=cand.lineno,
+        end_lineno=cand.end_lineno,
+        test_node=cand.test_node,
+        test_nodes=list(cand.test_nodes or [cand.test_node]),
+        dotted_name=_module_dotted_name(repo_root, cand.target_file),
+    )
+
+
+def _confirm_green(cfg: InjectConfig, cand: Candidate) -> Optional[str]:
+    """Return the FIRST plausible test node confirmed GREEN pre-injection, or
+    None. Reuses _run_pytest_node. When verify_green is off, trusts the primary
+    node (mirrors do_inject's --no-verify path)."""
+    if not cfg.verify_green:
+        return cand.test_node
+    for tn in (cand.test_nodes or [cand.test_node]):
+        if _run_pytest_node(cfg.repo_root, tn, cfg.test_timeout_s) is True:
+            return tn
+    return None
+
+
+def acquire_isolated_targets(cfg: InjectConfig, n: int = 3) -> List[ChaosTarget]:
+    """Acquire up to ``n`` pure-leaf targets, each in a DIFFERENT file, such that
+    every pair is import-DISJOINT (verified via the real AST import graph) AND
+    each independently has a GREEN test.
+
+    Greedy maximal-independent-set: scan candidates (one per file, deterministic
+    order), and add a candidate to the chosen set iff its file is pairwise
+    uncoupled with every file already chosen. Stops at ``n``. Zero-trust: if
+    fewer than ``n`` mutually-isolated green leaves exist, returns FEWER -- never
+    fabricates. Reuses acquire_candidates + the green-test confirmation."""
+    if n <= 0:
+        return []
+    candidates = acquire_candidates(cfg)
+    # Collapse to one candidate per file (the Collision Matrix is file-grained;
+    # two functions in one file can never fan out as two parallel units).
+    by_file: List[Candidate] = []
+    seen_files = set()
+    for cand in _seed_order(candidates, cfg.seed):
+        if cand.target_file in seen_files:
+            continue
+        seen_files.add(cand.target_file)
+        by_file.append(cand)
+
+    chosen: List[ChaosTarget] = []
+    chosen_files: List[str] = []
+    for cand in by_file:
+        if len(chosen) >= n:
+            break
+        # Pairwise import-isolation against every already-chosen file.
+        if any(
+            _files_are_import_coupled(cfg.repo_root, cand.target_file, picked)
+            for picked in chosen_files
+        ):
+            continue
+        # Independently green-tested (reuse the existing confirmation).
+        green = _confirm_green(cfg, cand)
+        if green is None:
+            continue
+        cand.test_node = green
+        chosen.append(_candidate_to_target(cfg.repo_root, cand))
+        chosen_files.append(cand.target_file)
+
+    if len(chosen) < n:
+        _log(
+            "acquire_isolated_targets: requested %d but only %d mutually-isolated "
+            "green-tested pure-leaf target(s) available (honest: fewer, NOT "
+            "fabricated)." % (n, len(chosen))
+        )
+    return chosen
+
+
+def _mutate_one_target_red(
+    cfg: InjectConfig, tgt: ChaosTarget,
+) -> Optional[Tuple[dict, str]]:
+    """Apply the existing single-mutation logic to ONE target and confirm its OWN
+    test goes red. On success returns ``(entry, original_src)`` where ``entry`` is
+    the per-target manifest dict; the file is left MUTATED on disk. On failure
+    (no viable site / nothing turns red) the file is restored byte-identically
+    and None is returned. Reuses _iter_mutations + _apply_mutation +
+    _run_pytest_node entirely."""
+    try:
+        with open(tgt.target_file, "r", encoding="utf-8") as fh:
+            src = fh.read()
+    except (OSError, UnicodeDecodeError):
+        return None
+    func = _select_function_node(src, tgt.function, tgt.lineno)
+    if func is None:
+        return None
+    muts = _iter_mutations(src, func)
+    if not muts:
+        _log("decomposable: %s has no viable mutation site." % (tgt.function,))
+        return None
+
+    for mut in muts:
+        try:
+            mutated_src = _apply_mutation(src, mut)
+        except ValueError as exc:
+            _log("  decomposable site skip (%s L%d): %s" % (tgt.function, mut.lineno, exc))
+            continue
+        try:
+            with open(tgt.target_file, "w", encoding="utf-8") as fh:
+                fh.write(mutated_src)
+            _bump_mtime(tgt.target_file)
+        except OSError as exc:
+            _log("decomposable write failed for %s: %s" % (tgt.target_file, exc))
+            return None
+
+        if cfg.verify_green:
+            post = _run_pytest_node(cfg.repo_root, tgt.test_node, cfg.test_timeout_s)
+            went_red = post is False
+        else:
+            went_red = True  # trust (no verification requested)
+
+        if went_red:
+            entry = {
+                "target_file": os.path.relpath(tgt.target_file, cfg.repo_root),
+                "target_file_abs": tgt.target_file,
+                "function": tgt.function,
+                "line": mut.lineno,
+                "dotted_name": tgt.dotted_name,
+                "original_source": src,
+                "mutated_source": mutated_src,
+                "mutation_kind": mut.kind,
+                "mutation_detail": {
+                    "lineno": mut.lineno,
+                    "col_offset": mut.col_offset,
+                    "end_col_offset": mut.end_col_offset,
+                    "original_segment": mut.original_segment,
+                    "mutated_segment": mut.mutated_segment,
+                },
+                "test_node": tgt.test_node,
+                "test_was_green_pre": bool(cfg.verify_green),
+                "test_red_post": bool(cfg.verify_green) or None,
+            }
+            return entry, src
+
+        # Inert site -> restore + try next site.
+        try:
+            with open(tgt.target_file, "w", encoding="utf-8") as fh:
+                fh.write(src)
+            _bump_mtime(tgt.target_file)
+        except OSError:
+            _log("WARNING: decomposable site-revert write failed for %s" % (tgt.target_file,))
+
+    return None
+
+
+def _restore_target(target_file_abs: str, original_source: str) -> bool:
+    """Byte-identical restore of one target (reused by partial-failure cleanup
+    and do_revert). Returns True on success."""
+    try:
+        with open(target_file_abs, "w", encoding="utf-8") as fh:
+            fh.write(original_source)
+        _bump_mtime(target_file_abs)
+        return True
+    except OSError as exc:
+        _log("restore FAILED for %s: %s" % (target_file_abs, exc))
+        return False
+
+
+def do_inject_decomposable(
+    cfg: InjectConfig, n: int = 3, *, require_exact: bool = False,
+) -> int:
+    """Acquire + mutate up to ``n`` MUTUALLY-ISOLATED pure-leaf targets so each
+    turns its OWN test red, then write ONE schema_version-2 manifest carrying the
+    full target list.
+
+    ``require_exact=True`` -> refuse (no mutation) unless exactly ``n`` isolated
+    green targets both exist AND go red. Default (False) -> inject as many as can
+    be turned red and report honestly (zero-trust: fewer over fabricate).
+
+    PARTIAL-FAILURE CLEANUP: any target that cannot be turned red is dropped and
+    every already-mutated target is restored if the final set is unacceptable, so
+    the tree is NEVER left half-injected.
+
+    Returns 0 on success (>=1 target red, or exactly n when require_exact), non-0
+    otherwise (with the tree restored byte-identically)."""
+    existing = _read_manifest(cfg.repo_root)
+    if existing and not cfg.force:
+        _log(
+            "REFUSING: an active chaos manifest already exists. Use --revert "
+            "first, or --force to override."
+        )
+        return 3
+    if existing and cfg.force:
+        _log("--force: reverting prior active mutation before decomposable inject.")
+        do_revert(cfg)
+
+    targets = acquire_isolated_targets(cfg, n=n)
+    if require_exact and len(targets) < n:
+        _log(
+            "require_exact: only %d/%d isolated targets acquired -- refusing to "
+            "inject a partial set. No mutation performed." % (len(targets), n)
+        )
+        return 4
+    if not targets:
+        _log("decomposable: no isolated pure-leaf targets acquired. Nothing to do.")
+        return 4
+
+    applied: List[dict] = []  # successfully-reddened per-target manifest entries
+
+    def _rollback_all() -> None:
+        for entry in applied:
+            _restore_target(entry["target_file_abs"], entry["original_source"])
+        applied.clear()
+
+    for tgt in targets:
+        result = _mutate_one_target_red(cfg, tgt)
+        if result is None:
+            _log(
+                "decomposable: target %s::%s could not be turned red; dropping it "
+                "(no half-state)." % (tgt.dotted_name or tgt.target_file, tgt.function)
+            )
+            continue
+        entry, _orig = result
+        applied.append(entry)
+
+    # Acceptance check.
+    if require_exact and len(applied) < n:
+        _log(
+            "require_exact: only %d/%d targets turned red -- rolling back ALL "
+            "(no half-injected tree)." % (len(applied), n)
+        )
+        _rollback_all()
+        return 5
+    if not applied:
+        _log("decomposable: NO target turned red -- nothing injected (tree clean).")
+        _rollback_all()  # no-op; defensive
+        return 5
+
+    manifest = {
+        "schema_version": DECOMPOSABLE_SCHEMA_VERSION,
+        "injector_version": INJECTOR_VERSION,
+        "mode": "decomposable",
+        "requested_n": n,
+        "targets": applied,
+        "injected_at_iso": cfg.now_iso,
+        "seed": cfg.seed,
+    }
+    _write_manifest(cfg.repo_root, manifest)
+    _log(
+        "INJECTED decomposable chaos: %d MUTUALLY-ISOLATED target(s) red in %d "
+        "distinct file(s). Manifest (schema 2) written." % (
+            len(applied), len({e["target_file_abs"] for e in applied}),
+        )
+    )
+    print(json.dumps({
+        "status": "injected_decomposable",
+        "count": len(applied),
+        "requested_n": n,
+        "targets": [
+            {
+                "target_file": e["target_file"],
+                "function": e["function"],
+                "line": e["line"],
+                "mutation_kind": e["mutation_kind"],
+                "test_node": e["test_node"],
+                "test_red_post": e["test_red_post"],
+            }
+            for e in applied
+        ],
+    }, indent=2))
+    return 0
+
+
+# --------------------------------------------------------------------------- #
 # CLI.
 # --------------------------------------------------------------------------- #
 
@@ -1477,6 +1929,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     mode = p.add_mutually_exclusive_group(required=True)
     mode.add_argument("--inject", action="store_true",
                       help="Acquire a target, mutate, verify the test goes red, write manifest.")
+    mode.add_argument("--inject-decomposable", action="store_true",
+                      help="Acquire + mutate N MUTUALLY-ISOLATED pure-leaf functions "
+                           "(N different files, import-disjoint via the AST graph) so "
+                           "they fan out into N parallel L3 subagents. N-entry manifest, "
+                           "revert-ALL byte-identical.")
     mode.add_argument("--revert", action="store_true",
                       help="Restore the original source from the active manifest.")
     mode.add_argument("--status", action="store_true",
@@ -1486,6 +1943,11 @@ def build_arg_parser() -> argparse.ArgumentParser:
     mode.add_argument("--list-candidates", action="store_true",
                       help="List all viable pure-leaf + green-test targets found.")
 
+    p.add_argument("-n", "--num-targets", type=int, default=3,
+                   help="Number of mutually-isolated targets for --inject-decomposable.")
+    p.add_argument("--require-exact", action="store_true",
+                   help="--inject-decomposable: refuse (no mutation) unless exactly N "
+                        "isolated targets are acquired AND turn red.")
     p.add_argument("--seed", type=int, default=0,
                    help="Deterministic candidate selection rotation (NOT random).")
     p.add_argument("--now", dest="now_iso", default="",
@@ -1526,6 +1988,10 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if args.inject:
         return do_inject(cfg)
+    if args.inject_decomposable:
+        return do_inject_decomposable(
+            cfg, n=int(args.num_targets), require_exact=bool(args.require_exact),
+        )
     if args.revert:
         return do_revert(cfg)
     if args.status:

--- a/tests/governance/autonomy/test_l3_telemetry.py
+++ b/tests/governance/autonomy/test_l3_telemetry.py
@@ -1,0 +1,303 @@
+"""Per-subagent L3 telemetry contract.
+
+Covers the L3 fan-out resource/cost footprint visibility:
+  1. WorkUnitResult carries ``worktree_lifespan_s`` measured create->reap
+     (mocked monotonic) when a worktree manager is present.
+  2. WorkUnitResult carries ``dw_cost_usd`` threaded from the generation
+     result's ``cost_usd`` (honest-null when the result reports no cost).
+  3. Per-unit ``[L3Telemetry] unit=... lifespan_s=... dw_cost_usd=...`` and
+     graph-aggregate ``[L3Telemetry] graph=... total_lifespan_s=...
+     total_dw_cost_usd=...`` lines emit the right values.
+  4. A telemetry exception is swallowed (the unit result is unaffected) ->
+     fail-soft.
+  5. ``JARVIS_L3_TELEMETRY_ENABLED=false`` -> no L3Telemetry lines, the
+     returned result is byte-identical (no telemetry fields populated by
+     the telemetry layer itself beyond what the data path provides).
+"""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy.subagent_scheduler import (
+    GenerationSubagentExecutor,
+)
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    WorkUnitResult,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+
+
+# ---------------------------------------------------------------------------
+# Stubs
+# ---------------------------------------------------------------------------
+class _Generation:
+    """Minimal generation result mirroring GenerationResult's relevant shape."""
+
+    def __init__(
+        self,
+        *,
+        candidates: tuple,
+        cost_usd: Optional[float] = None,
+        is_noop: bool = False,
+    ) -> None:
+        self.is_noop = is_noop
+        self.candidates = candidates
+        if cost_usd is not None:
+            self.cost_usd = cost_usd
+
+
+class _Generator:
+    def __init__(self, generation: Any) -> None:
+        self._generation = generation
+
+    async def generate(self, ctx: Any, deadline: Any) -> Any:
+        return self._generation
+
+
+class _OkWorktreeManager:
+    """Worktree manager whose create()/cleanup() always succeed."""
+
+    def __init__(self, path: Path) -> None:
+        self._path = path
+        self.create_calls = 0
+        self.cleanup_calls = 0
+
+    async def create(self, branch_name: str) -> Path:
+        self.create_calls += 1
+        self._path.mkdir(parents=True, exist_ok=True)
+        return self._path
+
+    async def cleanup(self, worktree_path: Path) -> None:
+        self.cleanup_calls += 1
+
+
+def _candidate() -> dict:
+    return {"file_path": "jarvis/a.py", "full_content": "x = 1\n"}
+
+
+def _make_unit_graph() -> tuple[ExecutionGraph, WorkUnitSpec]:
+    unit = WorkUnitSpec(
+        unit_id="u1",
+        repo="jarvis",
+        goal="update a",
+        target_files=("jarvis/a.py",),
+        owned_paths=("jarvis/a.py",),
+    )
+    graph = ExecutionGraph(
+        graph_id="graph-l3-tel",
+        op_id="op-l3-tel",
+        planner_id="planner-test",
+        schema_version="2d.1",
+        concurrency_limit=1,
+        units=(unit,),
+    )
+    return graph, unit
+
+
+def _executor(
+    tmp_path: Path,
+    *,
+    cost_usd: Optional[float],
+    worktree: bool,
+) -> tuple[GenerationSubagentExecutor, Optional[_OkWorktreeManager]]:
+    repo_root = tmp_path / "repo"
+    repo_root.mkdir(exist_ok=True)
+    (repo_root / "jarvis").mkdir(exist_ok=True)
+    gen = _Generation(candidates=(_candidate(),), cost_usd=cost_usd)
+    mgr = _OkWorktreeManager(tmp_path / "wt") if worktree else None
+    ex = GenerationSubagentExecutor(
+        generator=_Generator(gen),
+        validation_runner=None,
+        repo_roots={"jarvis": repo_root},
+        worktree_manager=mgr,
+    )
+    return ex, mgr
+
+
+# ---------------------------------------------------------------------------
+# 1. Worktree lifespan create->reap
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_worktree_lifespan_measured_create_to_reap(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "true")
+
+    # Drive time.monotonic deterministically: create stamp = 100.0,
+    # reap stamp = 103.5 -> lifespan 3.5s.
+    import backend.core.ouroboros.governance.autonomy.subagent_scheduler as mod
+
+    seq = iter([100.0, 103.5])
+    fixed = [100.0]
+
+    def fake_monotonic() -> float:
+        try:
+            fixed[0] = next(seq)
+        except StopIteration:
+            pass
+        return fixed[0]
+
+    monkeypatch.setattr(mod.time, "monotonic", fake_monotonic)
+
+    ex, mgr = _executor(tmp_path, cost_usd=0.42, worktree=True)
+    graph, unit = _make_unit_graph()
+    result = await ex.execute(graph, unit)
+
+    assert result.status is WorkUnitState.COMPLETED
+    assert mgr is not None and mgr.create_calls == 1 and mgr.cleanup_calls == 1
+    assert result.worktree_lifespan_s is not None
+    assert abs(result.worktree_lifespan_s - 3.5) < 1e-6
+
+
+@pytest.mark.asyncio
+async def test_no_worktree_lifespan_is_none(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """No worktree manager -> no lifespan to honestly report."""
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "true")
+    ex, _ = _executor(tmp_path, cost_usd=0.10, worktree=False)
+    graph, unit = _make_unit_graph()
+    result = await ex.execute(graph, unit)
+    assert result.status is WorkUnitState.COMPLETED
+    assert result.worktree_lifespan_s is None
+
+
+# ---------------------------------------------------------------------------
+# 2. DW cost threaded from generation result (honest-null absent)
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_dw_cost_threaded_from_generation(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "true")
+    ex, _ = _executor(tmp_path, cost_usd=0.42, worktree=False)
+    graph, unit = _make_unit_graph()
+    result = await ex.execute(graph, unit)
+    assert result.dw_cost_usd is not None
+    assert abs(result.dw_cost_usd - 0.42) < 1e-9
+
+
+@pytest.mark.asyncio
+async def test_dw_cost_honest_null_when_absent(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Generation result with no cost_usd attribute -> honest None (no fabrication)."""
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "true")
+    ex, _ = _executor(tmp_path, cost_usd=None, worktree=False)
+    graph, unit = _make_unit_graph()
+    result = await ex.execute(graph, unit)
+    assert result.status is WorkUnitState.COMPLETED
+    assert result.dw_cost_usd is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Per-unit telemetry line emits the right values
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_per_unit_line_emitted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "true")
+    ex, _ = _executor(tmp_path, cost_usd=0.42, worktree=False)
+    graph, unit = _make_unit_graph()
+    with caplog.at_level(logging.INFO, logger="Ouroboros.SubagentScheduler"):
+        await ex.execute(graph, unit)
+    lines = [r.message for r in caplog.records if "[L3Telemetry]" in r.message]
+    assert any("unit=u1" in m for m in lines), lines
+    line = next(m for m in lines if "unit=u1" in m)
+    assert "dw_cost_usd=0.42" in line
+    assert "status=" in line
+
+
+@pytest.mark.asyncio
+async def test_off_emits_no_lines_byte_identical_result(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture
+) -> None:
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "false")
+    ex, _ = _executor(tmp_path, cost_usd=0.42, worktree=False)
+    graph, unit = _make_unit_graph()
+    with caplog.at_level(logging.INFO, logger="Ouroboros.SubagentScheduler"):
+        result = await ex.execute(graph, unit)
+    lines = [r.message for r in caplog.records if "[L3Telemetry]" in r.message]
+    assert lines == []
+    # OFF -> telemetry fields untouched by the telemetry layer.
+    assert result.worktree_lifespan_s is None
+    assert result.dw_cost_usd is None
+    assert result.status is WorkUnitState.COMPLETED
+
+
+# ---------------------------------------------------------------------------
+# 4. Fail-soft: a telemetry exception never affects the unit result
+# ---------------------------------------------------------------------------
+@pytest.mark.asyncio
+async def test_telemetry_exception_swallowed(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "true")
+    import backend.core.ouroboros.governance.autonomy.subagent_scheduler as mod
+
+    # Make the per-unit telemetry emit raise; the unit result must survive.
+    def boom(*_a: Any, **_k: Any) -> None:
+        raise RuntimeError("telemetry blew up")
+
+    monkeypatch.setattr(mod, "_emit_unit_telemetry", boom, raising=True)
+
+    ex, _ = _executor(tmp_path, cost_usd=0.42, worktree=False)
+    graph, unit = _make_unit_graph()
+    result = await ex.execute(graph, unit)
+    assert result.status is WorkUnitState.COMPLETED
+    assert result.patch is not None
+
+
+# ---------------------------------------------------------------------------
+# 5. Graph-aggregate line
+# ---------------------------------------------------------------------------
+def test_graph_aggregate_line(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "true")
+    from backend.core.ouroboros.governance.autonomy.subagent_scheduler import (
+        _emit_graph_telemetry,
+    )
+
+    results = {
+        "u1": WorkUnitResult(
+            unit_id="u1",
+            repo="jarvis",
+            status=WorkUnitState.COMPLETED,
+            patch=None,
+            attempt_count=1,
+            started_at_ns=0,
+            finished_at_ns=1,
+            worktree_lifespan_s=3.5,
+            dw_cost_usd=0.42,
+        ),
+        "u2": WorkUnitResult(
+            unit_id="u2",
+            repo="jarvis",
+            status=WorkUnitState.COMPLETED,
+            patch=None,
+            attempt_count=1,
+            started_at_ns=0,
+            finished_at_ns=1,
+            worktree_lifespan_s=1.5,
+            dw_cost_usd=None,  # honest-null contributes 0 to the sum
+        ),
+    }
+    with caplog.at_level(logging.INFO, logger="Ouroboros.SubagentScheduler"):
+        _emit_graph_telemetry("graph-x", results)
+    lines = [r.message for r in caplog.records if "[L3Telemetry]" in r.message]
+    assert any("graph=graph-x" in m for m in lines), lines
+    line = next(m for m in lines if "graph=graph-x" in m)
+    assert "units=2" in line
+    assert "total_lifespan_s=5.0" in line
+    assert "total_dw_cost_usd=0.42" in line
+
+
+def test_graph_aggregate_off_no_line(monkeypatch: pytest.MonkeyPatch, caplog: pytest.LogCaptureFixture) -> None:
+    monkeypatch.setenv("JARVIS_L3_TELEMETRY_ENABLED", "false")
+    from backend.core.ouroboros.governance.autonomy.subagent_scheduler import (
+        _emit_graph_telemetry,
+    )
+
+    with caplog.at_level(logging.INFO, logger="Ouroboros.SubagentScheduler"):
+        _emit_graph_telemetry("graph-x", {})
+    assert [r.message for r in caplog.records if "[L3Telemetry]" in r.message] == []

--- a/tests/governance/test_collision_matrix.py
+++ b/tests/governance/test_collision_matrix.py
@@ -1,0 +1,352 @@
+"""Zero-trust AST Collision Matrix — regression spine.
+
+Proves the mathematical guarantee that two L3 subagents NEVER fan out in
+parallel when their tasks touch the same file OR import-coupled files
+(interface <-> implementation). Colliding units are forced sequential;
+only provably-disjoint units fan out.
+
+Invariants pinned here:
+
+1. Same-file targets COLLIDE -> forced sequential.
+2. Import-coupled targets (via the Oracle import graph) COLLIDE.
+3. Disjoint, import-isolated targets are pairwise-safe -> fan out.
+4. INDETERMINATE coupling (Oracle unavailable / unknown) -> COLLIDE
+   (zero-trust default-DENY, NEVER optimistic parallel).
+5. partition_parallel_safe returns the correct (parallel, sequential)
+   split for a mixed set, deterministically.
+6. The eligibility path returns COLLISION_FORCED_SEQUENTIAL when nothing
+   can safely parallelize.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import WorkUnitSpec
+from backend.core.ouroboros.governance.collision_matrix import (
+    CollisionMatrix,
+    CollisionVerdict,
+    build_collision_matrix,
+    is_fanout_eligible_collision_aware,
+    partition_parallel_safe,
+)
+from backend.core.ouroboros.governance.parallel_dispatch import ReasonCode
+
+
+# ---------------------------------------------------------------------------
+# Test doubles — a minimal Oracle import-graph stub.
+# ---------------------------------------------------------------------------
+
+
+class _StubNodeID:
+    """Minimal NodeID-like object with a .file_path attribute."""
+
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+
+
+class _StubOracle:
+    """Deterministic in-memory import-graph stub.
+
+    ``couples`` maps a file_path -> set(file_paths it is coupled to) via
+    the import/call graph. Symmetric coupling is NOT assumed — the matrix
+    must probe both directions.
+
+    ``known_files`` is the set of files the Oracle has indexed. A file not
+    in ``known_files`` yields an *empty* node list from
+    ``find_nodes_in_file`` (the Oracle genuinely has no data for it) —
+    which the matrix must treat as INDETERMINATE (zero-trust deny).
+    """
+
+    def __init__(self, couples: dict, known_files: set) -> None:
+        self._couples = couples
+        self._known = known_files
+
+    def find_nodes_in_file(self, file_path: str):
+        if file_path not in self._known:
+            return []
+        # One synthetic node per known file.
+        return [_StubNodeID(file_path)]
+
+    def get_dependencies(self, node_id):
+        fp = node_id.file_path
+        return [_StubNodeID(d) for d in self._couples.get(fp, set())]
+
+    def get_dependents(self, node_id):
+        # Incoming coupling: anyone who lists fp in their dependencies.
+        fp = node_id.file_path
+        out = []
+        for src, deps in self._couples.items():
+            if fp in deps:
+                out.append(_StubNodeID(src))
+        return out
+
+
+class _RaisingOracle:
+    """Oracle whose probes raise — simulates an unavailable/broken graph."""
+
+    def find_nodes_in_file(self, file_path: str):
+        raise RuntimeError("oracle graph unavailable")
+
+    def get_dependencies(self, node_id):
+        raise RuntimeError("oracle graph unavailable")
+
+    def get_dependents(self, node_id):
+        raise RuntimeError("oracle graph unavailable")
+
+
+def _unit(unit_id: str, *files: str) -> WorkUnitSpec:
+    return WorkUnitSpec(
+        unit_id=unit_id,
+        repo="jarvis",
+        goal=f"edit {files[0]}",
+        target_files=tuple(files),
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Same-file units COLLIDE -> forced sequential.
+# ---------------------------------------------------------------------------
+
+
+def test_same_file_units_collide():
+    oracle = _StubOracle(couples={}, known_files={"a.py"})
+    u1 = _unit("u1", "a.py")
+    u2 = _unit("u2", "a.py")
+    matrix = build_collision_matrix([u1, u2], oracle=oracle)
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.COLLIDE
+    assert matrix.collides("u1", "u2") is True
+
+
+def test_same_file_partition_forces_sequential():
+    oracle = _StubOracle(couples={}, known_files={"a.py"})
+    units = [_unit("u1", "a.py"), _unit("u2", "a.py")]
+    parallel, sequential = partition_parallel_safe(units, oracle=oracle)
+    # No two can run together -> at most one parallel group with a single
+    # unit; the other drops to sequential-forced.
+    parallel_ids = {u.unit_id for grp in parallel for u in grp}
+    sequential_ids = {u.unit_id for u in sequential}
+    assert parallel_ids | sequential_ids == {"u1", "u2"}
+    # They must never be in the SAME parallel group.
+    for grp in parallel:
+        assert not ({"u1", "u2"} <= {u.unit_id for u in grp})
+
+
+# ---------------------------------------------------------------------------
+# (b) Import-coupled units COLLIDE (via the Oracle graph).
+# ---------------------------------------------------------------------------
+
+
+def test_import_coupled_units_collide():
+    # iface.py is imported by impl.py -> coupled.
+    oracle = _StubOracle(
+        couples={"impl.py": {"iface.py"}},
+        known_files={"iface.py", "impl.py"},
+    )
+    u1 = _unit("u1", "iface.py")
+    u2 = _unit("u2", "impl.py")
+    matrix = build_collision_matrix([u1, u2], oracle=oracle)
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.COLLIDE
+
+
+def test_reverse_import_coupling_also_collides():
+    # Coupling probed in the OTHER direction (A imports B).
+    oracle = _StubOracle(
+        couples={"a.py": {"b.py"}},
+        known_files={"a.py", "b.py"},
+    )
+    matrix = build_collision_matrix(
+        [_unit("u1", "b.py"), _unit("u2", "a.py")], oracle=oracle
+    )
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.COLLIDE
+
+
+# ---------------------------------------------------------------------------
+# (c) Disjoint, import-isolated units fan out (happy path).
+# ---------------------------------------------------------------------------
+
+
+def test_disjoint_isolated_units_all_parallel_safe():
+    oracle = _StubOracle(
+        couples={},  # no coupling at all
+        known_files={"a.py", "b.py", "c.py"},
+    )
+    units = [_unit("u1", "a.py"), _unit("u2", "b.py"), _unit("u3", "c.py")]
+    matrix = build_collision_matrix(units, oracle=oracle)
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.DISJOINT
+    assert matrix.verdict("u1", "u3") is CollisionVerdict.DISJOINT
+    assert matrix.verdict("u2", "u3") is CollisionVerdict.DISJOINT
+
+    parallel, sequential = partition_parallel_safe(units, oracle=oracle)
+    assert sequential == []
+    # All three in a single pairwise-disjoint group.
+    assert len(parallel) == 1
+    assert {u.unit_id for u in parallel[0]} == {"u1", "u2", "u3"}
+
+
+# ---------------------------------------------------------------------------
+# (d) INDETERMINATE coupling -> COLLIDE (zero-trust fail-CLOSED).
+# ---------------------------------------------------------------------------
+
+
+def test_oracle_unavailable_pair_is_collide_not_parallel():
+    # Oracle is None -> coupling cannot be proven disjoint -> deny.
+    units = [_unit("u1", "a.py"), _unit("u2", "b.py")]
+    matrix = build_collision_matrix(units, oracle=None)
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.COLLIDE
+    parallel, sequential = partition_parallel_safe(units, oracle=None)
+    # Fail-closed: must NOT fan them out together.
+    for grp in parallel:
+        assert not ({"u1", "u2"} <= {u.unit_id for u in grp})
+
+
+def test_oracle_raises_pair_is_collide_not_parallel():
+    units = [_unit("u1", "a.py"), _unit("u2", "b.py")]
+    matrix = build_collision_matrix(units, oracle=_RaisingOracle())
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.COLLIDE
+
+
+def test_unindexed_file_is_indeterminate_collide():
+    # b.py is NOT in known_files -> Oracle has no data -> indeterminate.
+    oracle = _StubOracle(couples={}, known_files={"a.py"})
+    units = [_unit("u1", "a.py"), _unit("u2", "b.py")]
+    matrix = build_collision_matrix(units, oracle=oracle)
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.COLLIDE
+
+
+# ---------------------------------------------------------------------------
+# (e) Mixed set -> correct (parallel, sequential) split, deterministic.
+# ---------------------------------------------------------------------------
+
+
+def test_mixed_set_partition_split():
+    # u1(a.py) + u2(b.py) disjoint; u3(impl.py) coupled to a.py; u4(d.py)
+    # disjoint from everything.
+    oracle = _StubOracle(
+        couples={"impl.py": {"a.py"}},
+        known_files={"a.py", "b.py", "impl.py", "d.py"},
+    )
+    units = [
+        _unit("u1", "a.py"),
+        _unit("u2", "b.py"),
+        _unit("u3", "impl.py"),
+        _unit("u4", "d.py"),
+    ]
+    parallel, sequential = partition_parallel_safe(units, oracle=oracle)
+
+    placed = {u.unit_id for grp in parallel for u in grp} | {
+        u.unit_id for u in sequential
+    }
+    assert placed == {"u1", "u2", "u3", "u4"}
+
+    # u1 and u3 collide (a.py <-> impl.py) -> never in the same group.
+    for grp in parallel:
+        ids = {u.unit_id for u in grp}
+        assert not ({"u1", "u3"} <= ids)
+
+    # Determinism: same inputs -> same split.
+    parallel2, sequential2 = partition_parallel_safe(units, oracle=oracle)
+    sig = lambda p, s: (  # noqa: E731
+        [[u.unit_id for u in g] for g in p],
+        [u.unit_id for u in s],
+    )
+    assert sig(parallel, sequential) == sig(parallel2, sequential2)
+
+
+def test_partition_keeps_disjoint_pair_together():
+    oracle = _StubOracle(
+        couples={"impl.py": {"a.py"}},
+        known_files={"a.py", "b.py", "impl.py"},
+    )
+    # b.py is disjoint from both a.py and impl.py; a.py<->impl.py collide.
+    units = [_unit("u1", "a.py"), _unit("u2", "impl.py"), _unit("u3", "b.py")]
+    parallel, sequential = partition_parallel_safe(units, oracle=oracle)
+    # Greedy disjoint: u1 + u3 can run together; u2 forced sequential.
+    parallel_ids = {u.unit_id for grp in parallel for u in grp if len(grp) > 1}
+    # b.py (u3) should join whichever disjoint group it can.
+    placed = {u.unit_id for grp in parallel for u in grp} | {
+        u.unit_id for u in sequential
+    }
+    assert placed == {"u1", "u2", "u3"}
+    # u1 and u2 must never be co-grouped.
+    for grp in parallel:
+        assert not ({"u1", "u2"} <= {u.unit_id for u in grp})
+
+
+# ---------------------------------------------------------------------------
+# (f) Eligibility path returns COLLISION_FORCED_SEQUENTIAL when nothing's
+#     disjoint.
+# ---------------------------------------------------------------------------
+
+
+def test_eligibility_collision_forced_sequential(monkeypatch):
+    monkeypatch.setenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", "true")
+    # Two units on the SAME file -> nothing disjoint.
+    units = [_unit("u1", "a.py"), _unit("u2", "a.py")]
+    oracle = _StubOracle(couples={}, known_files={"a.py"})
+    result = is_fanout_eligible_collision_aware(
+        op_id="op-collide",
+        units=units,
+        oracle=oracle,
+        posture_fn=lambda: (None, None),
+        emit_log=False,
+    )
+    assert result.allowed is False
+    assert result.reason_code is ReasonCode.COLLISION_FORCED_SEQUENTIAL
+    # The disjoint subset offered for fan-out is at most 1 unit (serial-eq).
+    assert len(result.parallel_units) <= 1
+
+
+def test_eligibility_reduces_to_disjoint_subset(monkeypatch):
+    monkeypatch.setenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", "true")
+    # u1(a.py) collides with u2(impl.py); u3(c.py) + u4(d.py) disjoint.
+    oracle = _StubOracle(
+        couples={"impl.py": {"a.py"}},
+        known_files={"a.py", "impl.py", "c.py", "d.py"},
+    )
+    units = [
+        _unit("u1", "a.py"),
+        _unit("u2", "impl.py"),
+        _unit("u3", "c.py"),
+        _unit("u4", "d.py"),
+    ]
+    result = is_fanout_eligible_collision_aware(
+        op_id="op-mixed",
+        units=units,
+        oracle=oracle,
+        posture_fn=lambda: (None, None),
+        emit_log=False,
+    )
+    # At least the disjoint pair fans out.
+    parallel_ids = {u.unit_id for u in result.parallel_units}
+    assert len(parallel_ids) >= 2
+    # The colliding pair is NOT both in the fan-out set.
+    assert not ({"u1", "u2"} <= parallel_ids)
+    # The forced-sequential remainder accounts for the rest.
+    seq_ids = {u.unit_id for u in result.sequential_units}
+    assert parallel_ids.isdisjoint(seq_ids)
+    assert parallel_ids | seq_ids == {"u1", "u2", "u3", "u4"}
+
+
+def test_master_off_is_byte_identical_passthrough(monkeypatch):
+    # Master off -> collision check is dead code; MASTER_OFF returned, no
+    # collision matrix consulted.
+    monkeypatch.setenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", "false")
+    units = [_unit("u1", "a.py"), _unit("u2", "a.py")]
+    result = is_fanout_eligible_collision_aware(
+        op_id="op-off",
+        units=units,
+        oracle=_StubOracle(couples={}, known_files={"a.py"}),
+        posture_fn=lambda: (None, None),
+        emit_log=False,
+    )
+    assert result.allowed is False
+    assert result.reason_code is ReasonCode.MASTER_OFF
+
+
+def test_matrix_is_symmetric_and_self_disjoint():
+    oracle = _StubOracle(couples={}, known_files={"a.py", "b.py"})
+    units = [_unit("u1", "a.py"), _unit("u2", "b.py")]
+    matrix = build_collision_matrix(units, oracle=oracle)
+    assert matrix.verdict("u1", "u2") is matrix.verdict("u2", "u1")
+    # A unit never collides with itself in the pairwise sense.
+    assert matrix.collides("u1", "u1") is False

--- a/tests/governance/test_parallel_dispatch_eligibility.py
+++ b/tests/governance/test_parallel_dispatch_eligibility.py
@@ -572,6 +572,7 @@ def test_reason_code_values_stable():
         "memory_clamp",
         "posture_clamp",
         "max_units_clamp",
+        "collision_forced_sequential",
     }
     actual = {c.value for c in ReasonCode}
     assert actual == expected

--- a/tests/scripts/test_decomposable_chaos.py
+++ b/tests/scripts/test_decomposable_chaos.py
@@ -1,0 +1,384 @@
+"""Tests for the DecomposableChaosInjector extension of chaos_injector_ast.py.
+
+The DecomposableChaosInjector acquires + mutates N=3 MUTUALLY-ISOLATED pure-leaf
+functions, each in a DIFFERENT source file, such that NO two of their files are
+import-coupled. This guarantees the L3 AST Collision Matrix marks them pairwise
+disjoint -> a clean 3-way parallel subagent fan-out.
+
+Strategy mirrors test_chaos_injector_ast.py: build a tiny FAKE repo in a tmp dir
+with 3 isolated pure-leaf modules (each with a green test) PLUS a coupled pair
+(two modules that import each other) as a NEGATIVE control. Run the full
+acquire -> inject-N -> verify-each-red -> revert-all flow end-to-end with real
+pytest subprocesses, never touching the live repo.
+
+Reuse-first: every test exercises the EXISTING purity/mutation/verify/manifest/
+revert primitives via the new N-target orchestration; none of those are rewritten.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+import textwrap
+
+import pytest
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+_MODULE_PATH = os.path.join(_REPO_ROOT, "scripts", "chaos_injector_ast.py")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("chaos_injector_ast", _MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    sys.modules["chaos_injector_ast"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+cia = _load_module()
+
+
+# --------------------------------------------------------------------------- #
+# Fake-repo builders.
+# --------------------------------------------------------------------------- #
+
+def _write(path, text):
+    os.makedirs(os.path.dirname(path), exist_ok=True)
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(text)
+
+
+def _build_isolated_repo(tmp_path, *, n_isolated=3, with_coupled_pair=True):
+    """Build a repo with ``n_isolated`` mutually-isolated pure-leaf modules
+    (each with a green test) and, optionally, a coupled pair (two modules where
+    one imports the other) as a negative control.
+
+    Returns (repo_root, {modname: abs_path}).
+    """
+    repo = tmp_path / "repo"
+    pkg = repo / "backend" / "utils"
+    _write(str(repo / "backend" / "__init__.py"), "")
+    _write(str(pkg / "__init__.py"), "")
+    tests = repo / "tests"
+    _write(str(tests / "__init__.py"), "")
+
+    modpaths = {}
+    # Each isolated module imports NOTHING from sibling modules. They share only
+    # the stdlib (none here) so the import graph has zero cross-edges.
+    for i in range(n_isolated):
+        name = f"calc{i}"
+        fn = f"op{i}"
+        _write(
+            str(pkg / f"{name}.py"),
+            textwrap.dedent(f"""\
+                from __future__ import annotations
+
+
+                def {fn}(a, b):
+                    return a + b + {i}
+            """),
+        )
+        _write(
+            str(tests / f"test_{name}.py"),
+            textwrap.dedent(f"""\
+                from backend.utils.{name} import {fn}
+
+
+                def test_{fn}():
+                    assert {fn}(2, 3) == {5 + i}
+            """),
+        )
+        modpaths[name] = str(pkg / f"{name}.py")
+
+    if with_coupled_pair:
+        # coupled_a defines a pure leaf; coupled_b IMPORTS coupled_a. Both have
+        # green tests, so both look individually viable -- but the pair must
+        # NEVER be co-selected because they are import-coupled.
+        _write(
+            str(pkg / "coupled_a.py"),
+            textwrap.dedent("""\
+                from __future__ import annotations
+
+
+                def adda(a, b):
+                    return a * b
+            """),
+        )
+        _write(
+            str(pkg / "coupled_b.py"),
+            textwrap.dedent("""\
+                from __future__ import annotations
+
+                from backend.utils.coupled_a import adda
+
+
+                def addb(a, b):
+                    return a - b
+            """),
+        )
+        _write(
+            str(tests / "test_coupled_a.py"),
+            textwrap.dedent("""\
+                from backend.utils.coupled_a import adda
+
+
+                def test_adda():
+                    assert adda(3, 4) == 12
+            """),
+        )
+        _write(
+            str(tests / "test_coupled_b.py"),
+            textwrap.dedent("""\
+                from backend.utils.coupled_b import addb
+
+
+                def test_addb():
+                    assert addb(10, 4) == 6
+            """),
+        )
+        modpaths["coupled_a"] = str(pkg / "coupled_a.py")
+        modpaths["coupled_b"] = str(pkg / "coupled_b.py")
+
+    return str(repo), modpaths
+
+
+def _cfg(repo, **kw):
+    return cia.InjectConfig(repo_root=str(repo), **kw)
+
+
+# --------------------------------------------------------------------------- #
+# Import-graph coupling primitive (bounded AST scan).
+# --------------------------------------------------------------------------- #
+
+def test_module_dotted_name_from_path():
+    repo, mods = _build_isolated_repo(_tmp(), n_isolated=1, with_coupled_pair=False)
+    name = cia._module_dotted_name(repo, mods["calc0"])
+    assert name == "backend.utils.calc0"
+
+
+def test_file_imports_extracts_dotted_targets(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=True)
+    imports = cia._file_import_targets(mods["coupled_b"])
+    # coupled_b imports coupled_a.
+    assert "backend.utils.coupled_a" in imports
+
+
+def test_files_are_import_coupled_detects_pair(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=True)
+    # b imports a -> coupled.
+    assert cia._files_are_import_coupled(repo, mods["coupled_a"], mods["coupled_b"]) is True
+    # symmetric: order should not matter.
+    assert cia._files_are_import_coupled(repo, mods["coupled_b"], mods["coupled_a"]) is True
+
+
+def test_isolated_files_not_coupled(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=False)
+    assert cia._files_are_import_coupled(repo, mods["calc0"], mods["calc1"]) is False
+    assert cia._files_are_import_coupled(repo, mods["calc1"], mods["calc2"]) is False
+    assert cia._files_are_import_coupled(repo, mods["calc0"], mods["calc2"]) is False
+
+
+# --------------------------------------------------------------------------- #
+# acquire_isolated_targets.
+# --------------------------------------------------------------------------- #
+
+def test_acquire_isolated_targets_returns_3_distinct_files(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=True)
+    cfg = _cfg(repo, seed=0)
+    targets = cia.acquire_isolated_targets(cfg, n=3)
+    assert len(targets) == 3
+    files = [t.target_file for t in targets]
+    # All three in DIFFERENT files.
+    assert len(set(files)) == 3
+
+
+def test_acquire_isolated_targets_are_pairwise_uncoupled(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=True)
+    cfg = _cfg(repo, seed=0)
+    targets = cia.acquire_isolated_targets(cfg, n=3)
+    files = [t.target_file for t in targets]
+    # ASSERT pairwise isolation via the real import graph.
+    for i in range(len(files)):
+        for j in range(i + 1, len(files)):
+            assert cia._files_are_import_coupled(repo, files[i], files[j]) is False
+
+
+def test_acquire_isolated_targets_excludes_coupled_pair(tmp_path):
+    # Repo where ONLY a coupled pair (plus 1 isolated) exists: cannot form a
+    # set of 3 that includes both coupled files. The selection must never pick
+    # two files that import each other.
+    repo, mods = _build_isolated_repo(tmp_path, n_isolated=1, with_coupled_pair=True)
+    cfg = _cfg(repo, seed=0)
+    targets = cia.acquire_isolated_targets(cfg, n=3)
+    files = set(t.target_file for t in targets)
+    # If both coupled files were selected they'd be coupled -> forbidden.
+    assert not (mods["coupled_a"] in files and mods["coupled_b"] in files)
+
+
+def test_acquire_fewer_when_not_enough_isolated(tmp_path):
+    # Only 2 isolated leaves available (+ coupled pair which can contribute at
+    # most ONE of its two files). Request 3 -> honestly return fewer, never
+    # fabricate.
+    repo, mods = _build_isolated_repo(tmp_path, n_isolated=2, with_coupled_pair=False)
+    cfg = _cfg(repo, seed=0)
+    targets = cia.acquire_isolated_targets(cfg, n=3)
+    assert len(targets) == 2  # honest: fewer, not fabricated
+    assert len(set(t.target_file for t in targets)) == 2
+
+
+# --------------------------------------------------------------------------- #
+# inject_decomposable: all N go red + N-entry manifest.
+# --------------------------------------------------------------------------- #
+
+def test_inject_decomposable_turns_all_three_red(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=True)
+    cfg = _cfg(repo, seed=0, now_iso="2026-06-25T00:00:00Z", test_timeout_s=120.0)
+
+    rc = cia.do_inject_decomposable(cfg, n=3)
+    assert rc == 0, "decomposable inject should turn all 3 tests red"
+
+    manifest = cia._read_manifest(str(repo))
+    assert manifest is not None
+    assert manifest.get("schema_version") == 2
+    targets = manifest["targets"]
+    assert len(targets) == 3
+    # Every target turned its OWN test red.
+    for t in targets:
+        assert t["test_red_post"] is True
+        assert t["test_was_green_pre"] is True
+    # Three distinct files.
+    assert len({t["target_file"] for t in targets}) == 3
+
+    cia.do_revert(cfg)
+
+
+def test_inject_decomposable_files_actually_mutated(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=False)
+    before = {name: open(p, "rb").read() for name, p in mods.items()}
+    cfg = _cfg(repo, seed=0, now_iso="t", test_timeout_s=120.0)
+    rc = cia.do_inject_decomposable(cfg, n=3)
+    assert rc == 0
+    manifest = cia._read_manifest(str(repo))
+    mutated_files = {t["target_file_abs"] for t in manifest["targets"]}
+    # Each mutated file differs from its original bytes.
+    for abs_path in mutated_files:
+        name = os.path.splitext(os.path.basename(abs_path))[0]
+        assert open(abs_path, "rb").read() != before[name]
+    cia.do_revert(cfg)
+
+
+# --------------------------------------------------------------------------- #
+# revert-ALL byte-identical (incl partial-failure cleanup, no half-state).
+# --------------------------------------------------------------------------- #
+
+def test_revert_restores_all_three_byte_identical(tmp_path):
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=False)
+    before = {name: open(p, "rb").read() for name, p in mods.items()}
+    cfg = _cfg(repo, seed=0, now_iso="t", test_timeout_s=120.0)
+
+    assert cia.do_inject_decomposable(cfg, n=3) == 0
+    # Mutated on disk.
+    assert any(open(p, "rb").read() != before[name] for name, p in mods.items())
+
+    assert cia.do_revert(cfg) == 0
+    # ALL restored byte-identically.
+    for name, p in mods.items():
+        assert open(p, "rb").read() == before[name]
+    assert cia._read_manifest(str(repo)) is None
+
+
+def test_partial_failure_leaves_no_half_state(tmp_path, monkeypatch):
+    # Force the THIRD target to fail to go red: monkeypatch the post-mutation
+    # pytest run so the 3rd injection cannot be confirmed red. The orchestration
+    # must revert ALL already-injected targets (no half-injected state) and
+    # honestly report fewer / failure -- never leave files mutated.
+    repo, mods = _build_isolated_repo(tmp_path, with_coupled_pair=False)
+    before = {name: open(p, "rb").read() for name, p in mods.items()}
+    cfg = _cfg(repo, seed=0, now_iso="t", test_timeout_s=120.0)
+
+    # Make EVERY post-mutation verification report "still green" (inert) so NO
+    # target can ever turn red -> the whole decomposable inject must fail and
+    # leave zero mutations on disk.
+    real_run = cia._run_pytest_node
+    call = {"n": 0}
+
+    def fake_run(repo_root, node_id, timeout_s):
+        # Pre-injection green checks must pass; post-injection checks (after a
+        # file write) must report green (inert) so red is never produced.
+        # We detect post-injection by checking if any target file currently
+        # differs from its original on disk.
+        for name, p in mods.items():
+            if open(p, "rb").read() != before[name]:
+                return True  # report still-green => inert => fail to go red
+        return real_run(repo_root, node_id, timeout_s)
+
+    monkeypatch.setattr(cia, "_run_pytest_node", fake_run)
+
+    rc = cia.do_inject_decomposable(cfg, n=3)
+    assert rc != 0  # could not produce 3 reds
+    # CRITICAL: no half-state -- every file is byte-identical to its original.
+    for name, p in mods.items():
+        assert open(p, "rb").read() == before[name], f"{name} left mutated!"
+    # No active manifest left behind.
+    assert cia._read_manifest(str(repo)) is None
+
+
+# --------------------------------------------------------------------------- #
+# Honesty: fewer-than-N isolated leaves available => fewer targets, no fabricate.
+# --------------------------------------------------------------------------- #
+
+def test_inject_decomposable_honest_when_fewer_available(tmp_path):
+    # Only 2 isolated leaves: a strict n=3 request can't be satisfied. Default
+    # behaviour: inject the 2 it CAN isolate and report honestly (rc==0 with a
+    # 2-entry manifest), never fabricate a 3rd.
+    repo, mods = _build_isolated_repo(tmp_path, n_isolated=2, with_coupled_pair=False)
+    cfg = _cfg(repo, seed=0, now_iso="t", test_timeout_s=120.0)
+    rc = cia.do_inject_decomposable(cfg, n=3, require_exact=False)
+    assert rc == 0
+    manifest = cia._read_manifest(str(repo))
+    assert manifest["schema_version"] == 2
+    assert len(manifest["targets"]) == 2  # honest fewer
+    cia.do_revert(cfg)
+
+
+def test_inject_decomposable_require_exact_refuses_fewer(tmp_path):
+    # With require_exact=True and only 2 isolated leaves, refuse rather than
+    # inject a partial set. No mutation left on disk.
+    repo, mods = _build_isolated_repo(tmp_path, n_isolated=2, with_coupled_pair=False)
+    before = {name: open(p, "rb").read() for name, p in mods.items()}
+    cfg = _cfg(repo, seed=0, now_iso="t", test_timeout_s=120.0)
+    rc = cia.do_inject_decomposable(cfg, n=3, require_exact=True)
+    assert rc != 0
+    for name, p in mods.items():
+        assert open(p, "rb").read() == before[name]
+    assert cia._read_manifest(str(repo)) is None
+
+
+# --------------------------------------------------------------------------- #
+# Back-compat: single-target manifest still reverts via do_revert.
+# --------------------------------------------------------------------------- #
+
+def test_single_target_manifest_still_reverts(tmp_path):
+    # The existing single-target inject writes a schema_version==1 manifest;
+    # do_revert must still handle it (back-compat).
+    repo, mods = _build_isolated_repo(tmp_path, n_isolated=1, with_coupled_pair=False)
+    before = open(mods["calc0"], "rb").read()
+    cfg = _cfg(repo, seed=0, now_iso="t", test_timeout_s=120.0)
+    rc = cia.do_inject(cfg)  # legacy single-target path
+    assert rc == 0
+    m = cia._read_manifest(str(repo))
+    assert m.get("schema_version") == 1  # legacy shape preserved
+    assert cia.do_revert(cfg) == 0
+    assert open(mods["calc0"], "rb").read() == before
+
+
+# --------------------------------------------------------------------------- #
+# tiny tmp_path helper for the one non-fixture test above.
+# --------------------------------------------------------------------------- #
+
+def _tmp():
+    import tempfile
+    import pathlib
+    return pathlib.Path(tempfile.mkdtemp())


### PR DESCRIPTION
Three L3 pieces (linear): proactive AST Collision Matrix (pre-submit, zero-trust, Oracle import graph, emits the dormant COLLISION_FORCED_SEQUENTIAL) + DecomposableChaosInjector (3 import-isolated leaves → collision-free 3-way fan-out) + per-subagent worktree-lifespan + DW-cost telemetry. Makes parallel L3 fan-out collision-safe + observable. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens L3 fan-out by preventing parallel runs on same or import-coupled files, adds a 3-way decomposable chaos injector for safe fan-out, and exposes per-subagent telemetry for worktree lifespan and DW cost. Aligns with the L3 fan-out hardening requirements in Linear.

- **New Features**
  - AST Collision Matrix: pre-submit partitioning using the Oracle import graph with zero-trust default deny on unknown coupling; integrates with parallel dispatch and adds `ReasonCode.COLLISION_FORCED_SEQUENTIAL`.
  - Decomposable chaos injection: `DecomposableChaosInjector` in `scripts/chaos_injector_ast.py` acquires and mutates 3 mutually isolated leaf functions in different files, writes an N-entry manifest, and supports byte-identical revert-all.
  - Per-subagent telemetry: adds `worktree_lifespan_s` and `dw_cost_usd` on `WorkUnitResult`; emits `[L3Telemetry]` per-unit and graph totals; gated by `JARVIS_L3_TELEMETRY_ENABLED` (default on) and fail-soft.

<sup>Written for commit e381af5f8b93aadc4e61c1884e550bf670ab5173. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

