### PR TITLE
feat(l3): DAGComposer closes Slice 4b (map-reduce fan-out → unified candidate)

### DIFF
--- a/backend/core/ouroboros/governance/dag_composer.py
+++ b/backend/core/ouroboros/governance/dag_composer.py
@@ -1,0 +1,408 @@
+"""Wave 3 (6) — Slice 4b — DAGComposer (map-reduce fan-out -> unified candidate).
+
+Closes the Slice-4b gap (audit-confirmed): when
+``JARVIS_WAVE3_PARALLEL_DISPATCH_ENFORCE`` runs a parallel L3 fan-out, the
+per-unit ``WorkUnitResult`` patches are stashed in
+``pctx.extras["parallel_dispatch_fanout_result"]`` and the **sequential
+phase walk continues unchanged** -- so a successful parallel fan-out re-does
+APPLY serially (duplicate work) while the parallel patches are ignored.
+
+This module map-reduces a *successful* fan-out's per-unit patches back into
+the parent FSM by composing them into ONE unified multi-file candidate of
+the EXACT shape the orchestrator's existing multi-file path consumes
+(``{file_path, full_content, files: [{file_path, full_content, rationale},
+...]}`` per CLAUDE.md "Multi-file coordinated generation"). The composed
+candidate then walks VALIDATE -> GATE -> APPLY ONCE via
+``orchestrator._iter_candidate_files`` / ``_apply_multi_file_candidate``
+(the existing batch-rollback multi-file consumer) -- NOT a new apply path.
+
+KEY REUSE INSIGHT
+-----------------
+The Collision Matrix
+(:mod:`~backend.core.ouroboros.governance.collision_matrix`) already
+guarantees -- at pre-submit partition time -- that the parallel units touch
+DISJOINT, import-isolated files. So composing N successful unit patches is a
+clean UNION of disjoint per-file changes, NOT a 3-way merge. We do NOT build
+an AST merger with conflict resolution. We DO verify the disjointness
+invariant defensively here and **fail CLOSED** if it is somehow violated
+(``collision_invariant_violated``) rather than silently overwrite a file.
+
+Fail-CLOSED contract
+--------------------
+* ANY unit not terminally SUCCESS -> :class:`ComposeFailure` -> the caller
+  falls back to the legacy serial path (stash + sequential walk). No partial
+  compose, no silent data loss.
+* Two units claiming the SAME file -> :class:`ComposeFailure`
+  (``collision_invariant_violated``). Never a silent merge/overwrite.
+* A successful unit carrying no usable patch -> :class:`ComposeFailure`
+  (``unit_missing_patch``). We never fabricate content.
+
+Gating
+------
+``JARVIS_WAVE3_DAG_COMPOSE_ENABLED`` (default **false**). OFF -> the
+phase_dispatcher hook is byte-identical to today (stash, no consumption).
+This module is pure + import-safe regardless of the flag; only the
+phase_dispatcher wiring reads it.
+
+§4 invariants:
+
+1. No new apply path -- the composed candidate is consumed by the EXISTING
+   orchestrator multi-file path + its batch-level rollback.
+2. Disjoint UNION -- never a conflict merge; collision invariant verified
+   defensively and fails CLOSED.
+3. Fail-CLOSED -- any unit failure / missing-patch / collision -> a
+   ComposeFailure that routes the caller to the legacy serial path.
+4. Pure + deterministic -- same inputs -> same composed candidate, stable
+   file ordering (graph unit order, which is deterministic).
+5. Authority-import ban -- this module imports NONE of orchestrator,
+   policy, iron_gate, risk_tier, change_engine, candidate_generator, gate.
+   It only reads the autonomy result/graph dataclasses + the gating env.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Mapping, Optional, Sequence, Tuple
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    WorkUnitResult,
+    WorkUnitState,
+)
+
+logger = logging.getLogger("Ouroboros.DAGComposer")
+
+
+# ---------------------------------------------------------------------------
+# Env gate
+# ---------------------------------------------------------------------------
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if raw in _TRUTHY:
+        return True
+    if raw in _FALSY:
+        return False
+    return default
+
+
+def dag_compose_enabled() -> bool:
+    """Master flag -- ``JARVIS_WAVE3_DAG_COMPOSE_ENABLED`` (default ``false``).
+
+    When ``false`` (graduation default), the phase_dispatcher Slice-4b hook
+    keeps stashing the fan-out result and continues the sequential walk
+    unchanged (byte-identical to pre-Slice-4b). The composer itself is pure
+    and may be called by tests regardless of this flag; only the wiring
+    seam reads it.
+    """
+    return _env_bool("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", False)
+
+
+# Planner/composer lineage tag stamped onto composed candidates so downstream
+# telemetry can distinguish DAG-composed candidates from single-shot GENERATE
+# output. Grep-friendly + stable.
+COMPOSER_ID: str = "dag_composer.v1"
+
+
+# ---------------------------------------------------------------------------
+# Result records
+# ---------------------------------------------------------------------------
+
+
+class ComposeFailureReason(str, enum.Enum):
+    """Deterministic reason codes for a :class:`ComposeFailure`.
+
+    Stable, grep-friendly. New codes added additively; never repurposed.
+    """
+
+    NO_UNITS = "no_units"
+    UNIT_NOT_SUCCESS = "unit_not_success"
+    UNIT_MISSING_PATCH = "unit_missing_patch"
+    COLLISION_INVARIANT_VIOLATED = "collision_invariant_violated"
+    EMPTY_COMPOSITION = "empty_composition"
+
+
+@dataclass(frozen=True)
+class ComposeFailure:
+    """Fail-CLOSED outcome -- caller falls back to the legacy serial path.
+
+    Attributes
+    ----------
+    reason:
+        Primary cause -- see :class:`ComposeFailureReason`.
+    detail:
+        Human-readable amplifier (which unit failed, which file collided).
+    offending_unit_id:
+        The first unit_id that triggered the failure, when applicable.
+    """
+
+    reason: ComposeFailureReason
+    detail: str = ""
+    offending_unit_id: str = ""
+
+    @property
+    def is_failure(self) -> bool:
+        return True
+
+
+@dataclass(frozen=True)
+class ComposedCandidate:
+    """Successful UNION of disjoint per-unit patches into one multi-file candidate.
+
+    Attributes
+    ----------
+    op_id:
+        Parent operation id (carried from the :class:`ExecutionGraph`).
+    candidate:
+        The candidate dict, shaped EXACTLY as
+        ``orchestrator._iter_candidate_files`` /
+        ``_apply_multi_file_candidate`` consume:
+        ``{file_path, full_content, files: [{file_path, full_content,
+        rationale}, ...], rationale}``. The first ``files`` entry is the
+        primary/authoritative file; ``file_path`` / ``full_content`` mirror
+        it for legacy single-file consumers.
+    file_paths:
+        Convenience accessor -- ordered, disjoint file paths in the union.
+    """
+
+    op_id: str
+    candidate: Dict[str, Any]
+    file_paths: Tuple[str, ...]
+
+    @property
+    def is_failure(self) -> bool:
+        return False
+
+    @property
+    def n_files(self) -> int:
+        return len(self.file_paths)
+
+
+# ---------------------------------------------------------------------------
+# Patch extraction helper
+# ---------------------------------------------------------------------------
+
+
+def _unit_files(result: WorkUnitResult) -> List[Tuple[str, str]]:
+    """Extract ``(file_path, full_content)`` pairs from a unit's patch.
+
+    A ``WorkUnitResult.patch`` is a :class:`RepoPatch` whose ``new_content``
+    is a tuple of ``(path, bytes)`` pairs. The scheduler builds one entry per
+    owned file (units own a single file in the Slice-2 build path, but we do
+    not hardcode that -- we union every ``new_content`` entry the patch
+    carries). Returns an empty list when there is nothing usable; the caller
+    fails CLOSED on emptiness rather than fabricating content.
+    """
+    patch = getattr(result, "patch", None)
+    if patch is None:
+        return []
+    new_content = getattr(patch, "new_content", ()) or ()
+    pairs: List[Tuple[str, str]] = []
+    for entry in new_content:
+        try:
+            path, content = entry
+        except (TypeError, ValueError):
+            continue
+        if not isinstance(path, str) or not path:
+            continue
+        if isinstance(content, (bytes, bytearray)):
+            try:
+                text = bytes(content).decode("utf-8")
+            except UnicodeDecodeError:
+                # Non-UTF-8 content is not something the text-oriented
+                # multi-file APPLY path can consume -- fail CLOSED upstream
+                # by surfacing nothing for this entry.
+                continue
+        elif isinstance(content, str):
+            text = content
+        else:
+            continue
+        pairs.append((path, text))
+    return pairs
+
+
+# ---------------------------------------------------------------------------
+# Public: compose_fanout_result
+# ---------------------------------------------------------------------------
+
+
+def compose_fanout_result(
+    graph: ExecutionGraph,
+    unit_results: Mapping[str, WorkUnitResult],
+) -> "ComposedCandidate":
+    """Map-reduce a successful fan-out's per-unit patches into ONE candidate.
+
+    Pure deterministic function. Returns a :class:`ComposedCandidate` on a
+    clean UNION of disjoint per-file patches, or a :class:`ComposeFailure`
+    on ANY unit failure / missing patch / collision-invariant violation. The
+    return type is annotated as ``ComposedCandidate`` for call sites that
+    pattern-match on ``.is_failure``; the runtime type is one of the two.
+
+    Parameters
+    ----------
+    graph:
+        The :class:`ExecutionGraph` that drove the fan-out. Its ``units``
+        tuple supplies the DETERMINISTIC ordering for the composed file list
+        (so identical fan-outs yield byte-identical candidates) and the
+        parent ``op_id``.
+    unit_results:
+        Mapping ``unit_id -> WorkUnitResult`` for the graph's units. The
+        caller (phase_dispatcher) passes the terminal scheduler results
+        (``GraphExecutionState.results``). EVERY graph unit must be present
+        AND terminally SUCCESS; otherwise -> ComposeFailure.
+
+    Returns
+    -------
+    ComposedCandidate | ComposeFailure
+        ``ComposedCandidate`` on success (``.is_failure is False``);
+        ``ComposeFailure`` on any fail-CLOSED condition
+        (``.is_failure is True``).
+
+    Notes
+    -----
+    Fail-CLOSED order (first trip wins):
+
+    1. Empty graph units -> ``NO_UNITS``.
+    2. Any graph unit missing from ``unit_results`` OR not terminally
+       SUCCESS -> ``UNIT_NOT_SUCCESS`` (no partial compose).
+    3. A SUCCESS unit carrying no usable ``(path, content)`` patch ->
+       ``UNIT_MISSING_PATCH`` (we never fabricate content).
+    4. Two units claiming the SAME file_path -> ``COLLISION_INVARIANT_VIOLATED``
+       (the collision matrix promised disjointness; verify defensively, never
+       silently overwrite).
+    5. Net-empty union -> ``EMPTY_COMPOSITION`` (defensive; should be
+       unreachable once 1-3 pass).
+    """
+    units = tuple(getattr(graph, "units", ()) or ())
+    if not units:
+        return ComposeFailure(  # type: ignore[return-value]
+            reason=ComposeFailureReason.NO_UNITS,
+            detail="execution graph carries zero units",
+        )
+
+    op_id = str(getattr(graph, "op_id", "") or "")
+
+    # Deterministic union: iterate units in GRAPH order. Each file is owned by
+    # exactly one unit (collision-matrix disjointness); a repeated path is a
+    # hard fail-CLOSED. ``seen_paths`` maps path -> the unit that first
+    # claimed it, for a precise collision detail string.
+    ordered_files: List[Dict[str, str]] = []
+    seen_paths: Dict[str, str] = {}
+
+    for spec in units:
+        unit_id = str(getattr(spec, "unit_id", "") or "")
+        result = unit_results.get(unit_id)
+
+        # (2) Presence + terminal success.
+        if result is None:
+            return ComposeFailure(  # type: ignore[return-value]
+                reason=ComposeFailureReason.UNIT_NOT_SUCCESS,
+                detail=f"unit {unit_id!r} has no terminal result",
+                offending_unit_id=unit_id,
+            )
+        status = getattr(result, "status", None)
+        if status != WorkUnitState.COMPLETED:
+            status_val = getattr(status, "value", status)
+            return ComposeFailure(  # type: ignore[return-value]
+                reason=ComposeFailureReason.UNIT_NOT_SUCCESS,
+                detail=(
+                    f"unit {unit_id!r} status={status_val!r} "
+                    "(expected COMPLETED) -> legacy serial"
+                ),
+                offending_unit_id=unit_id,
+            )
+
+        # (3) Usable patch.
+        pairs = _unit_files(result)
+        if not pairs:
+            return ComposeFailure(  # type: ignore[return-value]
+                reason=ComposeFailureReason.UNIT_MISSING_PATCH,
+                detail=f"SUCCESS unit {unit_id!r} carried no usable patch content",
+                offending_unit_id=unit_id,
+            )
+
+        rationale = str(getattr(spec, "goal", "") or "") or (
+            f"composed from fan-out unit {unit_id}"
+        )
+
+        for file_path, full_content in pairs:
+            # (4) Disjointness invariant -- fail CLOSED on overlap.
+            prior = seen_paths.get(file_path)
+            if prior is not None:
+                return ComposeFailure(  # type: ignore[return-value]
+                    reason=ComposeFailureReason.COLLISION_INVARIANT_VIOLATED,
+                    detail=(
+                        f"file {file_path!r} claimed by both unit {prior!r} "
+                        f"and unit {unit_id!r}; collision-matrix disjointness "
+                        "invariant violated -> refusing silent merge"
+                    ),
+                    offending_unit_id=unit_id,
+                )
+            seen_paths[file_path] = unit_id
+            ordered_files.append(
+                {
+                    "file_path": file_path,
+                    "full_content": full_content,
+                    "rationale": rationale,
+                }
+            )
+
+    # (5) Defensive net-empty guard.
+    if not ordered_files:
+        return ComposeFailure(  # type: ignore[return-value]
+            reason=ComposeFailureReason.EMPTY_COMPOSITION,
+            detail="no files survived composition",
+        )
+
+    primary = ordered_files[0]
+    file_paths = tuple(entry["file_path"] for entry in ordered_files)
+    composed_rationale = (
+        f"[{COMPOSER_ID}] composed {len(ordered_files)} disjoint fan-out "
+        f"unit patches into one multi-file candidate for op={op_id[:16]}"
+    )
+
+    candidate: Dict[str, Any] = {
+        # Primary/authoritative file mirrors files[0] for legacy single-file
+        # consumers (orchestrator._iter_candidate_files falls back to these
+        # when JARVIS_MULTI_FILE_GEN_ENABLED is off; the multi-file path uses
+        # ``files``).
+        "file_path": primary["file_path"],
+        "full_content": primary["full_content"],
+        # The multi-file shape consumed by _iter_candidate_files /
+        # _apply_multi_file_candidate (batch-level rollback).
+        "files": ordered_files,
+        "rationale": composed_rationale,
+        # Lineage so downstream telemetry can tell composed candidates apart.
+        "composed_by": COMPOSER_ID,
+        "composed_op_id": op_id,
+    }
+
+    logger.info(
+        "[DAGComposer] op=%s composed n_files=%d files=%s composer=%s",
+        op_id[:16],
+        len(ordered_files),
+        list(file_paths),
+        COMPOSER_ID,
+    )
+
+    return ComposedCandidate(
+        op_id=op_id,
+        candidate=candidate,
+        file_paths=file_paths,
+    )
+
+
+__all__ = [
+    "COMPOSER_ID",
+    "ComposeFailure",
+    "ComposeFailureReason",
+    "ComposedCandidate",
+    "compose_fanout_result",
+    "dag_compose_enabled",
+]

--- a/backend/core/ouroboros/governance/phase_dispatcher.py
+++ b/backend/core/ouroboros/governance/phase_dispatcher.py
@@ -674,6 +674,109 @@ async def _fire_terminal_postmortem(
 
 
 # ---------------------------------------------------------------------------
+# Wave 3 (6) Slice 4b — DAGComposer map-reduce wiring helper
+# ---------------------------------------------------------------------------
+
+
+def _maybe_compose_fanout(
+    *,
+    ctx: OperationContext,
+    pctx: PhaseContext,
+    fanout_result: Any,
+) -> Any:
+    """Compose a COMPLETED fan-out's per-unit patches into one candidate.
+
+    Returns a NEW ``GenerationResult`` whose single candidate is the
+    DAG-composed unified multi-file candidate when ALL of:
+
+    * ``JARVIS_WAVE3_DAG_COMPOSE_ENABLED`` is on, AND
+    * the fan-out terminal outcome is ``COMPLETED``, AND
+    * the composer returns a :class:`ComposedCandidate` (fail-CLOSED: every
+      unit terminally SUCCESS, no missing patch, disjointness intact).
+
+    Returns ``None`` in every other case — the caller then leaves
+    ``pctx.generation`` untouched and the legacy serial walk proceeds
+    exactly as today. This helper NEVER raises into the hot path: the
+    composer is a pure function, but any unexpected shape error here would
+    only cost us the composition optimization, so it is caught and treated
+    as a fall-through to serial (the safe, behavior-preserving default).
+    """
+    from backend.core.ouroboros.governance.dag_composer import (
+        ComposedCandidate,
+        compose_fanout_result,
+        dag_compose_enabled,
+    )
+    from backend.core.ouroboros.governance.parallel_dispatch import (
+        FanoutOutcome,
+    )
+
+    if not dag_compose_enabled():
+        return None
+
+    # Only a cleanly COMPLETED fan-out is composable. SKIPPED / FAILED /
+    # CANCELLED / TIMEOUT / SUBMIT_* all fall through to legacy serial.
+    if getattr(fanout_result, "outcome", None) != FanoutOutcome.COMPLETED:
+        return None
+
+    graph = getattr(fanout_result, "graph", None)
+    state = getattr(fanout_result, "state", None)
+    if graph is None or state is None:
+        return None
+    unit_results = getattr(state, "results", None)
+    if not unit_results:
+        return None
+
+    try:
+        composed = compose_fanout_result(graph, unit_results)
+    except Exception:  # noqa: BLE001 — composition is an optimization; any
+        # unexpected error falls back to the byte-identical serial path.
+        logger.debug(
+            "[PhaseDispatcher] dag_compose raised (suppressed) — "
+            "falling back to legacy serial",
+            exc_info=True,
+        )
+        return None
+
+    if not isinstance(composed, ComposedCandidate):
+        # ComposeFailure (fail-CLOSED) — legacy serial path. The composer
+        # already logged the reason; surface a single dispatcher breadcrumb.
+        logger.info(
+            "[PhaseDispatcher] dag_compose declined op=%s reason=%s "
+            "(fan-out result stashed; legacy serial walk proceeds)",
+            ctx.op_id[:16],
+            getattr(getattr(composed, "reason", None), "value", "unknown"),
+        )
+        return None
+
+    # Build a replacement GenerationResult carrying the unified candidate so
+    # VALIDATE -> GATE -> APPLY consume it via the EXISTING multi-file path.
+    from backend.core.ouroboros.governance.op_context import GenerationResult
+
+    prior = pctx.generation
+    replacement = GenerationResult(
+        candidates=(composed.candidate,),
+        provider_name=(
+            f"{getattr(prior, 'provider_name', '') or 'unknown'}"
+            "+dag_composer"
+        ),
+        generation_duration_s=float(
+            getattr(prior, "generation_duration_s", 0.0) or 0.0
+        ),
+        model_id=getattr(prior, "model_id", "") or "",
+    )
+    logger.info(
+        "[PhaseDispatcher] dag_compose op=%s replaced generation with "
+        "unified multi-file candidate n_files=%d (one VALIDATE/GATE/APPLY "
+        "walk via _apply_multi_file_candidate batch rollback)",
+        ctx.op_id[:16],
+        composed.n_files,
+    )
+    # Stash the composed candidate too for operator/test inspection.
+    pctx.extras["dag_composed_candidate"] = composed
+    return replacement
+
+
+# ---------------------------------------------------------------------------
 # Dispatcher — the main event
 # ---------------------------------------------------------------------------
 
@@ -1002,17 +1105,37 @@ async def dispatch_pipeline(
                         scheduler=_scheduler,
                     )
                     # Slice 4 ships the submit + await primitive with
-                    # loud-fail error handling. Consumption of
-                    # per-unit results by downstream phases (VALIDATE /
-                    # slice4b) is a later-slice concern — for now the
-                    # result is stashed in extras so operators + tests
-                    # can inspect it, and the sequential phase walk
-                    # continues unchanged. This preserves behavioral
-                    # parity with the serial path while the enforce
-                    # surface matures.
+                    # loud-fail error handling. The result is ALWAYS
+                    # stashed in extras so operators + tests can inspect
+                    # it, regardless of whether Slice 4b composition runs.
                     pctx.extras["parallel_dispatch_fanout_result"] = (
                         _fanout_result
                     )
+
+                    # Wave 3 (6) Slice 4b — DAGComposer map-reduce.
+                    # When the fan-out COMPLETED and the composer flag is
+                    # on, union the successful disjoint per-unit patches
+                    # into ONE multi-file candidate and REPLACE
+                    # pctx.generation with it — so VALIDATE -> GATE ->
+                    # APPLY run ONCE on the unified set via the existing
+                    # multi-file consumer (_iter_candidate_files /
+                    # _apply_multi_file_candidate + batch rollback),
+                    # instead of re-running APPLY serially while the
+                    # parallel patches are ignored (the Slice-4b gap).
+                    #
+                    # Fail-CLOSED: on ANY unit failure / missing patch /
+                    # collision-invariant violation the composer returns
+                    # a ComposeFailure and we leave pctx.generation
+                    # untouched — the legacy serial walk proceeds exactly
+                    # as today (stash, no consumption). Flag OFF (default)
+                    # → byte-identical to pre-Slice-4b.
+                    _slice4b_composed = _maybe_compose_fanout(
+                        ctx=ctx,
+                        pctx=pctx,
+                        fanout_result=_fanout_result,
+                    )
+                    if _slice4b_composed is not None:
+                        pctx.generation = _slice4b_composed
             elif _master_on() and _shadow_on():
                 # Shadow-only path — per Slice 3, broad exception
                 # catch is acceptable because shadow has no

--- a/tests/governance/test_dag_composer.py
+++ b/tests/governance/test_dag_composer.py
@@ -1,0 +1,458 @@
+"""Tests for Wave 3 (6) Slice 4b -- DAGComposer.
+
+Closes the Slice-4b gap: a *successful* WAVE3 parallel L3 fan-out's per-unit
+patches must be map-reduced into ONE unified multi-file candidate that walks
+VALIDATE -> GATE -> APPLY via the EXISTING orchestrator multi-file path
+(``_iter_candidate_files`` / ``_apply_multi_file_candidate`` + batch
+rollback) -- instead of being stashed + ignored while APPLY re-runs serially.
+
+Invariants pinned here:
+
+(a) N disjoint successful units -> ONE composed multi-file candidate in the
+    existing ``{file_path, full_content, files:[{...}]}`` shape, carrying the
+    parent op_id, deterministic file ordering.
+(b) ANY unit failure -> ComposeFailure -> caller uses the legacy serial path
+    (no partial compose, no silent data loss).
+(c) Two units claiming the SAME file -> fail-CLOSED
+    ``collision_invariant_violated`` (never a silent merge).
+(d) The composed candidate matches the shape ``_iter_candidate_files``
+    accepts (asserted against the REAL consumer).
+(e) OFF flag (default) -> phase_dispatcher hook stashes unchanged
+    (byte-identical); composer is a pure function callable regardless.
+"""
+from __future__ import annotations
+
+import time
+from typing import Dict, List, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    GraphExecutionPhase,
+    GraphExecutionState,
+    WorkUnitResult,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+from backend.core.ouroboros.governance.saga.saga_types import (
+    FileOp,
+    PatchedFile,
+    RepoPatch,
+)
+from backend.core.ouroboros.governance import dag_composer
+from backend.core.ouroboros.governance.dag_composer import (
+    COMPOSER_ID,
+    ComposeFailure,
+    ComposeFailureReason,
+    ComposedCandidate,
+    compose_fanout_result,
+    dag_compose_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Builders
+# ---------------------------------------------------------------------------
+
+
+def _spec(unit_id: str, file_path: str, goal: str = "") -> WorkUnitSpec:
+    return WorkUnitSpec(
+        unit_id=unit_id,
+        repo="jarvis",
+        goal=goal or f"edit {file_path}",
+        target_files=(file_path,),
+        owned_paths=(file_path,),
+    )
+
+
+def _graph(specs: List[WorkUnitSpec], op_id: str = "op-deadbeef") -> ExecutionGraph:
+    return ExecutionGraph(
+        graph_id="graph-test01",
+        op_id=op_id,
+        planner_id="parallel_dispatch.v1",
+        schema_version="wave3_item6_slice2.v1",
+        units=tuple(specs),
+        concurrency_limit=max(2, len(specs)),
+    )
+
+
+def _result(
+    unit_id: str,
+    file_path: str,
+    content: str,
+    *,
+    status: WorkUnitState = WorkUnitState.COMPLETED,
+    with_patch: bool = True,
+) -> WorkUnitResult:
+    patch = None
+    if with_patch:
+        patch = RepoPatch(
+            repo="jarvis",
+            files=(PatchedFile(path=file_path, op=FileOp.CREATE, preimage=None),),
+            new_content=((file_path, content.encode("utf-8")),),
+        )
+    now = time.monotonic_ns()
+    return WorkUnitResult(
+        unit_id=unit_id,
+        repo="jarvis",
+        status=status,
+        patch=patch,
+        attempt_count=1,
+        started_at_ns=now,
+        finished_at_ns=now,
+    )
+
+
+def _three_disjoint() -> Tuple[ExecutionGraph, Dict[str, WorkUnitResult]]:
+    specs = [
+        _spec("unit-a", "pkg/a.py", goal="add a"),
+        _spec("unit-b", "pkg/b.py", goal="add b"),
+        _spec("unit-c", "pkg/c.py", goal="add c"),
+    ]
+    graph = _graph(specs)
+    results = {
+        "unit-a": _result("unit-a", "pkg/a.py", "# a\npass\n"),
+        "unit-b": _result("unit-b", "pkg/b.py", "# b\npass\n"),
+        "unit-c": _result("unit-c", "pkg/c.py", "# c\npass\n"),
+    }
+    return graph, results
+
+
+# ---------------------------------------------------------------------------
+# (a) N disjoint successful units -> ONE composed multi-file candidate
+# ---------------------------------------------------------------------------
+
+
+def test_three_disjoint_units_compose_into_one_multifile_candidate():
+    graph, results = _three_disjoint()
+    out = compose_fanout_result(graph, results)
+
+    assert isinstance(out, ComposedCandidate)
+    assert out.is_failure is False
+    assert out.op_id == "op-deadbeef"
+
+    cand = out.candidate
+    # Multi-file shape present.
+    assert isinstance(cand["files"], list)
+    assert len(cand["files"]) == 3
+    # Every entry carries file_path + full_content + rationale.
+    for entry in cand["files"]:
+        assert set(("file_path", "full_content", "rationale")).issubset(entry.keys())
+        assert isinstance(entry["file_path"], str) and entry["file_path"]
+        assert isinstance(entry["full_content"], str)
+
+    # All three files present, content preserved.
+    by_path = {e["file_path"]: e["full_content"] for e in cand["files"]}
+    assert by_path == {
+        "pkg/a.py": "# a\npass\n",
+        "pkg/b.py": "# b\npass\n",
+        "pkg/c.py": "# c\npass\n",
+    }
+    # Lineage stamp.
+    assert cand["composed_by"] == COMPOSER_ID
+    assert cand["composed_op_id"] == "op-deadbeef"
+
+
+def test_composition_is_deterministic_in_graph_order():
+    graph, results = _three_disjoint()
+    out1 = compose_fanout_result(graph, results)
+    out2 = compose_fanout_result(graph, results)
+    assert isinstance(out1, ComposedCandidate)
+    assert isinstance(out2, ComposedCandidate)
+    # File ordering follows graph unit order -> stable across calls.
+    assert out1.file_paths == ("pkg/a.py", "pkg/b.py", "pkg/c.py")
+    assert out1.file_paths == out2.file_paths
+    assert out1.candidate["files"] == out2.candidate["files"]
+
+
+def test_primary_file_mirrors_first_files_entry():
+    graph, results = _three_disjoint()
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposedCandidate)
+    cand = out.candidate
+    assert cand["file_path"] == cand["files"][0]["file_path"]
+    assert cand["full_content"] == cand["files"][0]["full_content"]
+
+
+# ---------------------------------------------------------------------------
+# (b) ANY unit failure -> ComposeFailure -> caller uses legacy serial path
+# ---------------------------------------------------------------------------
+
+
+def test_any_unit_failed_yields_compose_failure_no_partial():
+    graph, results = _three_disjoint()
+    # Flip unit-b to FAILED.
+    results["unit-b"] = _result(
+        "unit-b", "pkg/b.py", "", status=WorkUnitState.FAILED, with_patch=False
+    )
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.is_failure is True
+    assert out.reason == ComposeFailureReason.UNIT_NOT_SUCCESS
+    assert out.offending_unit_id == "unit-b"
+
+
+def test_missing_unit_result_yields_compose_failure():
+    graph, results = _three_disjoint()
+    del results["unit-c"]
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.UNIT_NOT_SUCCESS
+    assert out.offending_unit_id == "unit-c"
+
+
+def test_success_unit_with_no_patch_fails_closed():
+    graph, results = _three_disjoint()
+    # SUCCESS but no patch content -> never fabricate.
+    results["unit-a"] = _result(
+        "unit-a", "pkg/a.py", "", with_patch=False
+    )
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.UNIT_MISSING_PATCH
+    assert out.offending_unit_id == "unit-a"
+
+
+def test_cancelled_unit_treated_as_failure():
+    graph, results = _three_disjoint()
+    results["unit-b"] = _result(
+        "unit-b", "pkg/b.py", "x", status=WorkUnitState.CANCELLED
+    )
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.UNIT_NOT_SUCCESS
+
+
+# ---------------------------------------------------------------------------
+# (c) Two units claiming the SAME file -> fail-CLOSED collision_invariant_violated
+# ---------------------------------------------------------------------------
+
+
+def test_two_units_same_file_fail_closed_collision():
+    specs = [
+        _spec("unit-a", "pkg/shared.py"),
+        _spec("unit-b", "pkg/shared.py"),
+    ]
+    graph = _graph(specs)
+    results = {
+        "unit-a": _result("unit-a", "pkg/shared.py", "# from a\n"),
+        "unit-b": _result("unit-b", "pkg/shared.py", "# from b\n"),
+    }
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.COLLISION_INVARIANT_VIOLATED
+    assert out.offending_unit_id == "unit-b"
+    assert "pkg/shared.py" in out.detail
+
+
+def test_empty_graph_units_fail_closed():
+    # Build a graph then strip units defensively -- compose must not crash.
+    specs = [_spec("unit-a", "pkg/a.py"), _spec("unit-b", "pkg/b.py")]
+    graph = _graph(specs)
+    object.__setattr__(graph, "units", ())
+    out = compose_fanout_result(graph, {})
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.NO_UNITS
+
+
+# ---------------------------------------------------------------------------
+# (d) Composed candidate matches the REAL _iter_candidate_files consumer
+# ---------------------------------------------------------------------------
+
+
+def test_composed_candidate_consumed_by_real_iter_candidate_files(monkeypatch):
+    """The composed candidate must feed the EXISTING orchestrator multi-file
+    consumer (reuse, no new apply path). Drive the REAL static method."""
+    from backend.core.ouroboros.governance.orchestrator import Orchestrator
+
+    monkeypatch.setenv("JARVIS_MULTI_FILE_GEN_ENABLED", "true")
+
+    graph, results = _three_disjoint()
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposedCandidate)
+
+    pairs = Orchestrator._iter_candidate_files(out.candidate)
+    # All three (file_path, full_content) pairs surface through the real
+    # multi-file unpacker, in deterministic order.
+    assert pairs == [
+        ("pkg/a.py", "# a\npass\n"),
+        ("pkg/b.py", "# b\npass\n"),
+        ("pkg/c.py", "# c\npass\n"),
+    ]
+
+
+def test_iter_candidate_files_off_falls_back_to_primary(monkeypatch):
+    """With multi-file gen OFF, the consumer uses the primary mirror -- proving
+    the composed candidate is back-compatible with the legacy single-file
+    contract too."""
+    from backend.core.ouroboros.governance.orchestrator import Orchestrator
+
+    monkeypatch.setenv("JARVIS_MULTI_FILE_GEN_ENABLED", "false")
+
+    graph, results = _three_disjoint()
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposedCandidate)
+
+    pairs = Orchestrator._iter_candidate_files(out.candidate)
+    assert pairs == [("pkg/a.py", "# a\npass\n")]
+
+
+# ---------------------------------------------------------------------------
+# (e) OFF flag default + gating
+# ---------------------------------------------------------------------------
+
+
+def test_dag_compose_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", raising=False)
+    assert dag_compose_enabled() is False
+
+
+def test_dag_compose_enable_flag(monkeypatch):
+    monkeypatch.setenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", "true")
+    assert dag_compose_enabled() is True
+    monkeypatch.setenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", "0")
+    assert dag_compose_enabled() is False
+
+
+def test_compose_is_pure_regardless_of_flag(monkeypatch):
+    """compose_fanout_result is a pure function -- it does NOT read the gate;
+    only the phase_dispatcher wiring does. Same inputs -> same output with the
+    flag in either state."""
+    graph, results = _three_disjoint()
+    monkeypatch.delenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", raising=False)
+    out_off = compose_fanout_result(graph, results)
+    monkeypatch.setenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", "true")
+    out_on = compose_fanout_result(graph, results)
+    assert isinstance(out_off, ComposedCandidate)
+    assert isinstance(out_on, ComposedCandidate)
+    assert out_off.candidate == out_on.candidate
+
+
+# ---------------------------------------------------------------------------
+# phase_dispatcher integration — _maybe_compose_fanout wiring seam
+#   COMPLETED fan-out + compose-on -> pctx.generation replaced with the
+#   unified multi-file candidate that VALIDATE/GATE then see.
+# ---------------------------------------------------------------------------
+
+
+from dataclasses import dataclass, field  # noqa: E402
+
+from backend.core.ouroboros.governance.op_context import GenerationResult  # noqa: E402
+from backend.core.ouroboros.governance.parallel_dispatch import (  # noqa: E402
+    FanoutOutcome,
+    FanoutResult,
+)
+from backend.core.ouroboros.governance import phase_dispatcher  # noqa: E402
+
+
+@dataclass
+class _Ctx:
+    op_id: str = "op-deadbeef"
+
+
+@dataclass
+class _Pctx:
+    generation: object = None
+    extras: dict = field(default_factory=dict)
+
+
+def _completed_fanout(graph, results) -> FanoutResult:
+    state = GraphExecutionState(
+        graph=graph,
+        phase=GraphExecutionPhase.COMPLETED,
+        completed_units=tuple(results.keys()),
+        results=dict(results),
+    )
+    return FanoutResult(
+        outcome=FanoutOutcome.COMPLETED,
+        graph=graph,
+        state=state,
+        n_units_requested=len(results),
+        n_units_completed=len(results),
+    )
+
+
+def test_dispatcher_completed_fanout_compose_on_replaces_generation(monkeypatch):
+    monkeypatch.setenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MULTI_FILE_GEN_ENABLED", "true")
+
+    graph, results = _three_disjoint()
+    fr = _completed_fanout(graph, results)
+
+    prior_gen = GenerationResult(
+        candidates=({"file_path": "stale.py", "full_content": "# stale\n"},),
+        provider_name="doubleword",
+        generation_duration_s=1.5,
+        model_id="dw-397b",
+    )
+    pctx = _Pctx(generation=prior_gen)
+    ctx = _Ctx()
+
+    replacement = phase_dispatcher._maybe_compose_fanout(
+        ctx=ctx, pctx=pctx, fanout_result=fr
+    )
+    assert replacement is not None
+    assert isinstance(replacement, GenerationResult)
+
+    # The replacement carries ONE unified multi-file candidate with all 3 files.
+    assert len(replacement.candidates) == 1
+    cand = replacement.candidates[0]
+    assert len(cand["files"]) == 3
+
+    # Drive the REAL VALIDATE-facing consumer against the replacement to prove
+    # VALIDATE/GATE/APPLY would see the unified multi-file set.
+    from backend.core.ouroboros.governance.orchestrator import Orchestrator
+
+    pairs = Orchestrator._iter_candidate_files(replacement.candidates[0])
+    assert pairs == [
+        ("pkg/a.py", "# a\npass\n"),
+        ("pkg/b.py", "# b\npass\n"),
+        ("pkg/c.py", "# c\npass\n"),
+    ]
+    # Provider lineage shows composition; prior duration preserved.
+    assert "dag_composer" in replacement.provider_name
+    assert replacement.generation_duration_s == 1.5
+
+
+def test_dispatcher_compose_off_returns_none_byte_identical(monkeypatch):
+    monkeypatch.delenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", raising=False)
+    graph, results = _three_disjoint()
+    fr = _completed_fanout(graph, results)
+    pctx = _Pctx(generation="SENTINEL")
+    ctx = _Ctx()
+    out = phase_dispatcher._maybe_compose_fanout(ctx=ctx, pctx=pctx, fanout_result=fr)
+    assert out is None
+    # Caller would NOT replace -> generation untouched, no compose stash.
+    assert pctx.generation == "SENTINEL"
+    assert "dag_composed_candidate" not in pctx.extras
+
+
+def test_dispatcher_failed_unit_compose_on_falls_through_to_serial(monkeypatch):
+    monkeypatch.setenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", "true")
+    graph, results = _three_disjoint()
+    results["unit-b"] = _result(
+        "unit-b", "pkg/b.py", "", status=WorkUnitState.FAILED, with_patch=False
+    )
+    fr = _completed_fanout(graph, results)  # graph COMPLETED but a unit FAILED
+    pctx = _Pctx(generation="SENTINEL")
+    ctx = _Ctx()
+    out = phase_dispatcher._maybe_compose_fanout(ctx=ctx, pctx=pctx, fanout_result=fr)
+    # Fail-CLOSED: composer declines -> None -> legacy serial (generation kept).
+    assert out is None
+    assert pctx.generation == "SENTINEL"
+
+
+def test_dispatcher_non_completed_outcome_no_compose(monkeypatch):
+    monkeypatch.setenv("JARVIS_WAVE3_DAG_COMPOSE_ENABLED", "true")
+    graph, results = _three_disjoint()
+    state = GraphExecutionState(
+        graph=graph, phase=GraphExecutionPhase.FAILED, results=dict(results)
+    )
+    fr = FanoutResult(outcome=FanoutOutcome.FAILED, graph=graph, state=state)
+    pctx = _Pctx(generation="SENTINEL")
+    out = phase_dispatcher._maybe_compose_fanout(
+        ctx=_Ctx(), pctx=pctx, fanout_result=fr
+    )
+    assert out is None
+    assert pctx.generation == "SENTINEL"


### PR DESCRIPTION
Composes disjoint successful fan-out unit patches into ONE multi-file candidate that walks VALIDATE/GATE/APPLY via the existing _apply_multi_file_candidate batch-rollback path. Fail-CLOSED to legacy serial on any unit failure/collision. Gated JARVIS_WAVE3_DAG_COMPOSE_ENABLED default-OFF byte-identical. 18 new + 299 existing green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Composes successful L3 parallel fan-out patches into one unified multi-file candidate so VALIDATE/GATE/APPLY run once via the existing multi-file batch-rollback path, removing duplicate serial APPLY. Gated by `JARVIS_WAVE3_DAG_COMPOSE_ENABLED` (default off) with fail-closed fallback to the legacy serial path.

- New Features
  - Added `backend/core/ouroboros/governance/dag_composer.py` with `compose_fanout_result` to union disjoint per-unit patches into the exact shape consumed by `_iter_candidate_files` / `_apply_multi_file_candidate` (deterministic order, lineage `composed_by: dag_composer.v1`).
  - Wired `_maybe_compose_fanout` in `phase_dispatcher` to replace `pctx.generation` when fan-out COMPLETED and the flag is on; always stash `parallel_dispatch_fanout_result`, and stash `dag_composed_candidate` when composed; never throws (falls through to serial on any issue).
  - Fail-closed rules: any non-success unit, missing patch, or duplicate file path → decline composition and continue legacy serial.

- Migration
  - Off by default. Enable with `JARVIS_WAVE3_DAG_COMPOSE_ENABLED=true`.
  - No API or schema changes; automatic fallback preserves current behavior.

<sup>Written for commit 0b85e71b33a769842303063ff3e7af7aeaaea4a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

