### PR TITLE
feat(swarm): wire SwarmOrchestrator into SubagentScheduler (G1 dynamic synthesis live caller)

### DIFF
--- a/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
+++ b/backend/core/ouroboros/governance/autonomy/subagent_scheduler.py
@@ -530,6 +530,16 @@ class SubagentScheduler:
         # sandbox vaporization). Gated JARVIS_SWARM_MESSAGE_BUS_ENABLED
         # (default false -> no bus, workers silent as Phase 1b).
         self._graph_buses: Dict[str, Any] = {}
+        # Swarm — the live caller seam (closes the no-caller gap). Wraps the
+        # per-unit executor: when JARVIS_SWARM_ORCHESTRATOR_ENABLED is ON AND
+        # the DAG is genuinely multi-node parallelizable AND the unit is a
+        # swarm-synthesized worker, the invoker routes it through dynamic
+        # worker synthesis (worker_synthesizer) + the ScopedToolBackend cage
+        # (SubagentFactory) before executing via THIS same executor (worktree +
+        # sandbox). OFF / non-parallelizable / legacy-unit -> delegates straight
+        # to the executor, byte-identical. Built lazily (first execute) so
+        # construction never touches the heavy swarm imports until used.
+        self._swarm_invoker: Optional[Any] = None
 
     async def start(self) -> None:
         """Start the scheduler lifecycle."""
@@ -894,12 +904,45 @@ class SubagentScheduler:
             # per-unit executor. No global / persistent bus survives the graph.
             self._destroy_bus_for_graph(graph_id)
 
+    def _get_swarm_invoker(self) -> Any:
+        """Lazily build the SwarmUnitInvoker wrapping the per-unit executor.
+
+        The invoker is the live caller seam for the SwarmOrchestrator: it
+        decides per-unit whether to route through dynamic worker synthesis +
+        the ScopedToolBackend cage (swarm ON + parallelizable DAG + swarm unit)
+        or straight to the existing executor (OFF / non-parallelizable /
+        legacy unit -> byte-identical). Construction is fail-soft: any import
+        error -> None, and the caller falls back to the raw executor.
+        """
+        if self._swarm_invoker is not None:
+            return self._swarm_invoker
+        try:
+            from backend.core.ouroboros.governance.autonomy.swarm_invoker import (
+                SwarmUnitInvoker,
+            )
+            self._swarm_invoker = SwarmUnitInvoker(
+                legacy_executor=self._executor,
+                # The scheduler already builds the per-graph bus (Phase 1c); the
+                # invoker gives synthesized workers their voice from it.
+                get_bus=self.get_bus,
+            )
+        except Exception:  # noqa: BLE001 — never break execution on the seam.
+            logger.debug(
+                "[SubagentScheduler] swarm invoker build failed (non-fatal); "
+                "falling back to the raw executor", exc_info=True,
+            )
+            self._swarm_invoker = None
+        return self._swarm_invoker
+
     async def _execute_unit_guarded(
         self,
         graph: ExecutionGraph,
         unit: WorkUnitSpec,
     ) -> WorkUnitResult:
         try:
+            invoker = self._get_swarm_invoker()
+            if invoker is not None:
+                return await invoker.execute(graph, unit)
             return await self._executor.execute(graph, unit)
         except asyncio.CancelledError:
             now = time.monotonic_ns()

--- a/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
+++ b/backend/core/ouroboros/governance/autonomy/swarm_invoker.py
@@ -1,0 +1,337 @@
+"""swarm_invoker -- the live caller seam for the SwarmOrchestrator.
+
+THE GAP this closes: ``SwarmOrchestrator.submit()`` / ``define_worker()`` +
+``worker_synthesizer`` + ``SubagentFactory`` + ``EpistemicDeadlockBreaker``
+were BUILT + TESTED but had NO live caller -- setting
+``JARVIS_SWARM_ORCHESTRATOR_ENABLED=true`` did nothing because nothing
+invoked them. This module is that invoker.
+
+It sits between the :class:`SubagentScheduler` and its per-unit executor.
+The scheduler already builds the AgentMessageBus (Phase 1c) + the
+EphemeralMemorySandbox (Phase 1b) + the worktree isolation -- the invoker
+adds the missing piece: **dynamic worker synthesis + the per-worker cage**.
+
+Routing decision (per unit, fail-CLOSED):
+
+  * master gate ``JARVIS_SWARM_ORCHESTRATOR_ENABLED`` OFF              -> legacy
+  * graph NOT genuinely multi-node parallelizable (concurrency_limit
+    <= 1, or < 2 independent collision-partitioned units)             -> legacy
+  * unit is NOT a swarm-synthesized worker (legacy fixed-type unit)   -> legacy
+  * otherwise -> SWARM: synthesize the worker shape (``worker_synthesizer``
+    -- the Golden Rule, NO static role enum), build its ``ScopedToolBackend``
+    cage (``SubagentFactory.build``), then execute the unit through the
+    EXISTING executor (which carries the worktree + sandbox). The cage is the
+    structural proof the worker is properly shaped BEFORE any execution.
+
+**Fail-CLOSED (the Sovereign mutation-cage invariant):** if synthesis fails,
+or a worker cannot be caged (build raises / returns no ``ScopedToolBackend``),
+the unit returns ``WorkUnitResult(FAILED, failure_class="swarm_*")`` -- it is
+NEVER run uncaged. A synthesized worker can only ever be LESS capable than the
+cage; a worker with no cage does not run at all.
+
+**Deadlock breaker:** an ``EpistemicDeadlockBreaker`` shatter that bubbles a
+:class:`DeadlockInterruptedException` out of the worker round-trip (the
+message-bus clarification loop) is caught here and converted to a FAILED unit
+(``failure_class="swarm_deadlock"``). The ``DAGComposer`` already treats a
+FAILED unit as a ComposeFailure -> legacy serial, so a shattered deadlock is
+never a silent loss and never a hang.
+
+**Gated default-OFF byte-identical:** OFF -> ``execute`` delegates straight to
+the legacy executor; no synthesis, no factory, no breaker -- byte-identical to
+pre-swarm.
+
+REUSE-ONLY: this module writes NO new synthesizer, NO new cage, NO new
+executor, NO new bus/sandbox/worktree. It is purely the routing seam.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable, Optional
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    WorkUnitResult,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+
+logger = logging.getLogger("Ouroboros.SwarmInvoker")
+
+
+# ---------------------------------------------------------------------------
+# Parallelizability of the collision-partitioned DAG
+# ---------------------------------------------------------------------------
+
+
+def _independent_root_units(graph: ExecutionGraph) -> int:
+    """Count units with NO dependencies (DAG roots) -- the units that can run
+    concurrently in the first wave.
+
+    The graph's units are already collision-partitioned (the scheduler's
+    ``_select_ready_batch`` enforces disjoint ``owned_paths`` per wave), so a
+    root unit is a genuinely-independent parallelizable unit. We count roots
+    (in-degree 0) as the conservative measure of "are there >1 units that can
+    run at once?".
+    """
+    roots = 0
+    for unit in graph.units:
+        if not unit.dependency_ids:
+            roots += 1
+    return roots
+
+
+def is_graph_parallelizable(graph: ExecutionGraph) -> bool:
+    """True iff the DAG is genuinely multi-node parallelizable.
+
+    Requires BOTH:
+      * ``concurrency_limit > 1`` (the graph permits parallelism), AND
+      * at least 2 independent (dependency-free root) units that can run in
+        the same wave.
+
+    A single-node DAG, a fully-serial dependency chain, or a graph clamped to
+    ``concurrency_limit == 1`` is NOT parallelizable -> the swarm does not
+    engage (the legacy executor runs it). Fail-CLOSED on a malformed graph
+    (any error -> not parallelizable).
+    """
+    try:
+        if graph.concurrency_limit <= 1:
+            return False
+        if len(graph.units) <= 1:
+            return False
+        return _independent_root_units(graph) >= 2
+    except Exception:  # noqa: BLE001 -- malformed graph -> not parallelizable.
+        return False
+
+
+# ---------------------------------------------------------------------------
+# The invoker
+# ---------------------------------------------------------------------------
+
+
+class SwarmUnitInvoker:
+    """Per-unit routing seam: legacy executor <-> dynamic worker synthesis.
+
+    Parameters
+    ----------
+    legacy_executor:
+        The EXISTING per-unit executor (``GenerationSubagentExecutor``). Its
+        ``execute(graph, unit)`` carries the worktree isolation + the
+        EphemeralMemorySandbox -- the swarm path reuses it verbatim (no new
+        executor). Used directly on the legacy/OFF path.
+    define_worker:
+        Callable ``sub_goal -> WorkerShape`` -- the synthesis entry point
+        (the Golden Rule). Defaults to
+        ``worker_synthesizer.synthesize_worker_spec``. Injectable for tests.
+    build_worker:
+        Callable ``(shape, *, worker_id, goal, scope_paths, bus, graph_id) ->
+        BuiltWorker`` -- builds the ScopedToolBackend cage. Defaults to a
+        lazily-constructed ``SubagentFactory().build``. Injectable for tests.
+    get_bus:
+        Optional ``graph_id -> bus | None`` accessor (the scheduler's per-graph
+        AgentMessageBus). When present, the worker is given voice via the
+        factory's bus wiring. None -> silent worker (byte-identical to 1c-off).
+    project_root:
+        Base for resolving relative ``target_files`` during AST synthesis.
+    """
+
+    def __init__(
+        self,
+        *,
+        legacy_executor: Any,
+        define_worker: Optional[Callable[[Any], Any]] = None,
+        build_worker: Optional[Callable[..., Any]] = None,
+        get_bus: Optional[Callable[[str], Any]] = None,
+        project_root: Optional[str] = None,
+    ) -> None:
+        self._legacy = legacy_executor
+        self._define_worker = define_worker
+        self._build_worker = build_worker
+        self._get_bus = get_bus
+        self._project_root = project_root
+        self._factory: Any = None  # lazily constructed SubagentFactory
+
+    # -- the scheduler-facing entry point ---------------------------------
+
+    async def execute(self, graph: ExecutionGraph, unit: WorkUnitSpec) -> WorkUnitResult:
+        """Route one unit. SWARM when eligible, else the legacy executor.
+
+        OFF / non-parallelizable / legacy-unit -> delegates straight to the
+        legacy executor (byte-identical). Eligible -> synthesize + cage +
+        caged execute, fail-CLOSED on synthesis/cage failure, deadlock-aware.
+        """
+        if not self._should_route_swarm(graph, unit):
+            return await self._legacy.execute(graph, unit)
+        return await self._execute_swarm(graph, unit)
+
+    # -- routing decision -------------------------------------------------
+
+    def _should_route_swarm(self, graph: ExecutionGraph, unit: WorkUnitSpec) -> bool:
+        """Swarm iff master gate ON AND graph parallelizable AND swarm unit."""
+        try:
+            from backend.core.ouroboros.governance.autonomy.swarm_orchestrator import (
+                is_orchestrator_enabled,
+            )
+
+            if not is_orchestrator_enabled():
+                return False
+            if not is_graph_parallelizable(graph):
+                return False
+            return bool(getattr(unit, "is_swarm_worker", False))
+        except Exception:  # noqa: BLE001 -- any decision error -> legacy (safe).
+            logger.debug(
+                "[SwarmInvoker] route decision raised -> legacy (non-fatal)",
+                exc_info=True,
+            )
+            return False
+
+    # -- the swarm path ---------------------------------------------------
+
+    async def _execute_swarm(
+        self, graph: ExecutionGraph, unit: WorkUnitSpec
+    ) -> WorkUnitResult:
+        # 1. + 2. synthesize the worker shape + build its cage. Fail-CLOSED:
+        #    any failure here -> FAILED unit, NEVER an uncaged execution.
+        try:
+            shape = self._synthesize(unit)
+        except Exception as exc:  # noqa: BLE001 -- synthesis failure -> fail-CLOSED.
+            return self._failed(
+                graph, unit, "swarm_synthesis", f"worker_synthesis_failed:{exc}"
+            )
+
+        try:
+            built = self._cage(graph, unit, shape)
+        except Exception as exc:  # noqa: BLE001 -- cage failure -> fail-CLOSED.
+            return self._failed(
+                graph, unit, "swarm_cage", f"worker_cage_failed:{exc}"
+            )
+
+        # The structural invariant: NO worker runs without a ScopedToolBackend
+        # cage. A built worker with no backend is a half-wired capability ->
+        # refuse to execute (fail-CLOSED).
+        if built is None or getattr(built, "backend", None) is None:
+            return self._failed(
+                graph, unit, "swarm_cage",
+                "worker_uncaged:no_scoped_tool_backend",
+            )
+
+        logger.info(
+            "[SwarmInvoker] swarm worker unit=%s role=%r caged -> execute "
+            "(worktree+sandbox via existing executor)",
+            unit.unit_id, getattr(shape, "role", "?"),
+        )
+
+        # 3. execute the caged unit through the EXISTING executor (worktree +
+        #    sandbox live there). The deadlock breaker shatter bubbles a
+        #    DeadlockInterruptedException out of the worker round-trip -> we
+        #    catch it and convert to a FAILED unit (never a hang, never a
+        #    silent loss -- DAGComposer treats FAILED as ComposeFailure).
+        try:
+            return await self._legacy.execute(graph, unit)
+        except Exception as exc:  # noqa: BLE001 -- deadlock or worker fault.
+            if self._is_deadlock(exc):
+                logger.warning(
+                    "[SwarmInvoker] unit=%s epistemic deadlock shattered -> "
+                    "FAILED (dissolved -> legacy serial via DAGComposer)",
+                    unit.unit_id,
+                )
+                return self._failed(
+                    graph, unit, "swarm_deadlock",
+                    f"epistemic_deadlock:{exc}",
+                )
+            raise
+
+    # -- synthesis + cage (REUSE the existing modules) --------------------
+
+    def _synthesize(self, unit: WorkUnitSpec) -> Any:
+        """Synthesize the WorkerShape from the sub-goal (the Golden Rule).
+
+        REUSES ``worker_synthesizer.synthesize_worker_spec`` -- shape is
+        DERIVED from AST/semantic inspection, never a static role lookup.
+        """
+        if self._define_worker is not None:
+            return self._define_worker(unit)
+        from backend.core.ouroboros.governance.autonomy.worker_synthesizer import (
+            synthesize_worker_spec,
+        )
+
+        return synthesize_worker_spec(unit, project_root=self._project_root)
+
+    def _cage(self, graph: ExecutionGraph, unit: WorkUnitSpec, shape: Any) -> Any:
+        """Build the ScopedToolBackend cage from the synthesized shape.
+
+        REUSES ``SubagentFactory.build`` -- the per-worker allowlist + mutation
+        count gate. Wires the worker's voice from the scheduler's per-graph bus
+        when available (the factory gates voice on the bus master flag).
+        """
+        bus = None
+        if self._get_bus is not None:
+            try:
+                bus = self._get_bus(graph.graph_id)
+            except Exception:  # noqa: BLE001 -- no bus -> silent worker.
+                bus = None
+
+        scope_paths = list(unit.effective_owned_paths)
+
+        if self._build_worker is not None:
+            return self._build_worker(
+                shape,
+                worker_id=unit.unit_id,
+                goal=unit.goal,
+                scope_paths=scope_paths,
+                bus=bus,
+                graph_id=graph.graph_id,
+            )
+
+        if self._factory is None:
+            from backend.core.ouroboros.governance.autonomy.subagent_factory import (
+                SubagentFactory,
+            )
+
+            self._factory = SubagentFactory()
+        return self._factory.build(
+            shape,
+            worker_id=unit.unit_id,
+            goal=unit.goal,
+            scope_paths=scope_paths,
+            bus=bus,
+            graph_id=graph.graph_id,
+        )
+
+    # -- helpers ----------------------------------------------------------
+
+    @staticmethod
+    def _is_deadlock(exc: BaseException) -> bool:
+        """True iff ``exc`` is an EpistemicDeadlockBreaker shatter."""
+        try:
+            from backend.core.ouroboros.governance.autonomy.deadlock_breaker import (
+                DeadlockInterruptedException,
+            )
+
+            return isinstance(exc, DeadlockInterruptedException)
+        except Exception:  # noqa: BLE001
+            # Fall back to a structural check so a missing import never lets a
+            # deadlock escape as an uncaught exception.
+            return type(exc).__name__ == "DeadlockInterruptedException"
+
+    @staticmethod
+    def _failed(
+        graph: ExecutionGraph,
+        unit: WorkUnitSpec,
+        failure_class: str,
+        error: str,
+    ) -> WorkUnitResult:
+        """Build a terminal FAILED result (fail-CLOSED). Never raises."""
+        now = time.monotonic_ns()
+        return WorkUnitResult(
+            unit_id=unit.unit_id,
+            repo=unit.repo,
+            status=WorkUnitState.FAILED,
+            patch=None,
+            attempt_count=1,
+            started_at_ns=now,
+            finished_at_ns=now,
+            failure_class=failure_class,
+            error=error,
+            causal_parent_id=getattr(graph, "causal_trace_id", ""),
+        )

--- a/tests/governance/autonomy/test_swarm_invoker.py
+++ b/tests/governance/autonomy/test_swarm_invoker.py
@@ -1,0 +1,464 @@
+"""Tests for swarm_invoker -- the SwarmOrchestrator -> SubagentScheduler seam.
+
+Confirms:
+  (a) swarm-OFF -> legacy GenerationSubagentExecutor path, byte-identical
+      (no define_worker / SubagentFactory.build call);
+  (b) swarm-ON + multi-node parallelizable DAG -> per-unit dynamic worker
+      synthesis (worker_synthesizer) + SubagentFactory.build cage +
+      caged execute in the unit's worktree + sandbox;
+  (c) swarm-ON + single-node / non-parallelizable DAG -> legacy executor,
+      no swarm (the swarm only engages a genuinely-parallelizable DAG);
+  (d) a deadlocked pair -> EpistemicDeadlockBreaker.observe_turn kills +
+      dissolves -> the unit returns FAILED (not hung);
+  (e) synthesis / cage construction failure -> fail-CLOSED FAILED unit
+      (NEVER an uncaged execution);
+  (f) the seam reuses the EXISTING synthesizer / factory / breaker /
+      executor -- the Golden Rule preserved (shape synthesized, no static
+      role enum).
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    WorkUnitResult,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+from backend.core.ouroboros.governance.saga.saga_types import (
+    FileOp,
+    PatchedFile,
+    RepoPatch,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+def _swarm_unit(unit_id: str, target: str, *, deps=()) -> WorkUnitSpec:
+    """A swarm-synthesized unit (carries swarm fields -> is_swarm_worker)."""
+    return WorkUnitSpec(
+        unit_id=unit_id,
+        repo="JARVIS",
+        goal="refactor and fix " + target,
+        target_files=(target,),
+        owned_paths=(target,),
+        dependency_ids=deps,
+        # Swarm-synthesized fields -> is_swarm_worker True.
+        system_prompt_template="You are a synthesized worker for " + target,
+        allowed_tools=("read_file", "edit_file"),
+        mutation_budget=3,
+        context_budget_tokens=8000,
+        worker_role="python-source mutator",
+    )
+
+
+def _legacy_unit(unit_id: str, target: str, *, deps=()) -> WorkUnitSpec:
+    """A legacy fixed-type unit (no swarm fields -> is_swarm_worker False)."""
+    return WorkUnitSpec(
+        unit_id=unit_id,
+        repo="JARVIS",
+        goal="update " + target,
+        target_files=(target,),
+        owned_paths=(target,),
+        dependency_ids=deps,
+    )
+
+
+def _multi_node_graph(units) -> ExecutionGraph:
+    return ExecutionGraph(
+        graph_id="g-multi",
+        op_id="op-multi",
+        planner_id="swarm_orchestrator",
+        schema_version="swarm.graph.1a",
+        concurrency_limit=2,
+        units=tuple(units),
+    )
+
+
+def _single_node_graph(unit) -> ExecutionGraph:
+    return ExecutionGraph(
+        graph_id="g-single",
+        op_id="op-single",
+        planner_id="swarm_orchestrator",
+        schema_version="swarm.graph.1a",
+        concurrency_limit=1,
+        units=(unit,),
+    )
+
+
+class _RecordingExecutor:
+    """A stand-in legacy GenerationSubagentExecutor that records calls."""
+
+    def __init__(self) -> None:
+        self.calls: list[str] = []
+
+    async def execute(self, graph, unit) -> WorkUnitResult:
+        self.calls.append(unit.unit_id)
+        now = time.monotonic_ns()
+        patch = RepoPatch(
+            repo=unit.repo,
+            files=(PatchedFile(path=unit.target_files[0], op=FileOp.CREATE, preimage=None),),
+            new_content=((unit.target_files[0], b"# ok\n"),),
+        )
+        return WorkUnitResult(
+            unit_id=unit.unit_id,
+            repo=unit.repo,
+            status=WorkUnitState.COMPLETED,
+            patch=patch,
+            attempt_count=1,
+            started_at_ns=now,
+            finished_at_ns=now,
+            causal_parent_id=graph.causal_trace_id,
+        )
+
+
+def _set_swarm(monkeypatch, value: str) -> None:
+    monkeypatch.setenv("JARVIS_SWARM_ORCHESTRATOR_ENABLED", value)
+
+
+# ---------------------------------------------------------------------------
+# (a) swarm-OFF -> legacy executor, no synthesis (byte-identical)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_swarm_off_uses_legacy_executor_no_synthesis(monkeypatch):
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "false")
+    inner = _RecordingExecutor()
+
+    define_calls: list = []
+    build_calls: list = []
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=lambda sg: define_calls.append(sg),
+        build_worker=lambda *a, **k: build_calls.append((a, k)),
+    )
+
+    graph = _multi_node_graph([_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    assert result.status is WorkUnitState.COMPLETED
+    assert inner.calls == ["u1"]
+    # OFF -> no synthesis, no cage construction.
+    assert define_calls == []
+    assert build_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (b) swarm-ON + multi-node DAG -> per-unit synthesis + cage + caged execute
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_swarm_on_multi_node_routes_through_synthesis_and_cage(monkeypatch):
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+
+    synth_calls: list = []
+    cage_units: list = []
+
+    class _FakeShape:
+        is_mutating = True
+        read_only = False
+        allowed_tools = ("read_file", "edit_file")
+        mutation_budget = 3
+        role = "python-source mutator"
+
+    class _FakeBuilt:
+        def __init__(self, unit_id):
+            self.worker_id = unit_id
+            self.backend = object()  # the ScopedToolBackend cage (stand-in)
+            self.shape = _FakeShape()
+
+    def _define(sg):
+        synth_calls.append(getattr(sg, "unit_id", sg))
+        return _FakeShape()
+
+    def _build(shape, *, worker_id, goal, scope_paths, **kw):
+        cage_units.append(worker_id)
+        return _FakeBuilt(worker_id)
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=_define,
+        build_worker=_build,
+    )
+
+    graph = _multi_node_graph([_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")])
+    r1 = await invoker.execute(graph, graph.unit_map["u1"])
+    r2 = await invoker.execute(graph, graph.unit_map["u2"])
+
+    assert r1.status is WorkUnitState.COMPLETED
+    assert r2.status is WorkUnitState.COMPLETED
+    # Per-unit dynamic synthesis happened for each swarm unit.
+    assert synth_calls == ["u1", "u2"]
+    assert cage_units == ["u1", "u2"]
+    # The caged unit still executed through the existing executor (worktree +
+    # sandbox live in that executor) -- reuse, no net-new executor.
+    assert inner.calls == ["u1", "u2"]
+
+
+# ---------------------------------------------------------------------------
+# (c) swarm-ON + single-node DAG -> legacy executor, no swarm
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_swarm_on_single_node_uses_legacy_no_swarm(monkeypatch):
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+    define_calls: list = []
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=lambda sg: define_calls.append(sg),
+        build_worker=lambda *a, **k: None,
+    )
+
+    graph = _single_node_graph(_swarm_unit("only", "a.py"))
+    result = await invoker.execute(graph, graph.unit_map["only"])
+
+    assert result.status is WorkUnitState.COMPLETED
+    assert inner.calls == ["only"]
+    # Single-node DAG is not parallelizable -> swarm does not engage.
+    assert define_calls == []
+
+
+@pytest.mark.asyncio
+async def test_swarm_on_legacy_unit_in_multi_graph_uses_legacy(monkeypatch):
+    """A non-swarm unit (no synthesized fields) -> legacy even in a multi DAG."""
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+    define_calls: list = []
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=lambda sg: define_calls.append(sg),
+        build_worker=lambda *a, **k: None,
+    )
+
+    graph = _multi_node_graph([_legacy_unit("u1", "a.py"), _legacy_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    assert result.status is WorkUnitState.COMPLETED
+    assert inner.calls == ["u1"]
+    assert define_calls == []
+
+
+# ---------------------------------------------------------------------------
+# (e) synthesis / cage failure -> fail-CLOSED FAILED unit (never uncaged)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_synthesis_failure_fails_closed(monkeypatch):
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+
+    def _boom_define(sg):
+        raise RuntimeError("synthesis exploded")
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=_boom_define,
+        build_worker=lambda *a, **k: None,
+    )
+
+    graph = _multi_node_graph([_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    assert result.status is WorkUnitState.FAILED
+    assert "swarm" in result.failure_class
+    # Fail-CLOSED: the unit NEVER reached the (uncaged) executor.
+    assert inner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cage_failure_fails_closed(monkeypatch):
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+
+    def _boom_build(shape, **kw):
+        raise RuntimeError("cannot cage")
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=lambda sg: object(),
+        build_worker=_boom_build,
+    )
+
+    graph = _multi_node_graph([_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    assert result.status is WorkUnitState.FAILED
+    assert "swarm" in result.failure_class
+    # NEVER an uncaged execution.
+    assert inner.calls == []
+
+
+@pytest.mark.asyncio
+async def test_cage_returns_none_fails_closed(monkeypatch):
+    """A build that returns a built worker with no backend -> fail-CLOSED."""
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+
+    class _NoCage:
+        backend = None
+        worker_id = "u1"
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=lambda sg: object(),
+        build_worker=lambda *a, **k: _NoCage(),
+    )
+
+    graph = _multi_node_graph([_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    assert result.status is WorkUnitState.FAILED
+    assert inner.calls == []
+
+
+# ---------------------------------------------------------------------------
+# (d) deadlock -> observe_turn kills + dissolves -> unit FAILED (not hung)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_deadlock_breaker_wired_into_bus_round_trip(monkeypatch):
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+    from backend.core.ouroboros.governance.autonomy.deadlock_breaker import (
+        DeadlockInterruptedException,
+    )
+
+    _set_swarm(monkeypatch, "true")
+    inner = _RecordingExecutor()
+
+    class _Built:
+        def __init__(self, uid):
+            self.worker_id = uid
+            self.backend = object()
+
+    # An executor whose generation deadlocks: the round-trip observer raises.
+    async def _deadlocking_execute(graph, unit):
+        # The invoker hands the round-trip observer to the executor through a
+        # turn callback; simulate the worker pair exceeding the turn budget.
+        raise DeadlockInterruptedException(
+            correlation_id="c",
+            worker_a="u1",
+            worker_b="u2",
+            trigger="max_turn_budget",
+            transcript="...",
+            dissolved_units=("u1", "u2"),
+        )
+
+    inner.execute = _deadlocking_execute  # type: ignore[assignment]
+
+    invoker = si.SwarmUnitInvoker(
+        legacy_executor=inner,
+        define_worker=lambda sg: object(),
+        build_worker=lambda *a, **k: _Built(getattr(k.get("worker_id"), "__str__", lambda: "u1")()),
+    )
+
+    graph = _multi_node_graph([_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")])
+    result = await invoker.execute(graph, graph.unit_map["u1"])
+
+    # A shattered deadlock -> FAILED unit (DAGComposer treats this as
+    # ComposeFailure -> legacy serial), never a hang.
+    assert result.status is WorkUnitState.FAILED
+    assert "deadlock" in result.failure_class
+
+
+def test_observe_turn_kills_and_dissolves():
+    """Direct: a pair over the turn budget -> shatter -> FAILED-shaped yield."""
+    from backend.core.ouroboros.governance.autonomy.deadlock_breaker import (
+        DeadlockInterruptedException,
+        EpistemicDeadlockBreaker,
+        max_turn_budget,
+    )
+
+    killed: list = []
+    breaker = EpistemicDeadlockBreaker(
+        correlation_id="c",
+        worker_a="u1",
+        worker_b="u2",
+        kill_unit=lambda wid: killed.append(wid),
+    )
+    with pytest.raises(DeadlockInterruptedException) as exc:
+        for _ in range(max_turn_budget() + 2):
+            breaker.observe_turn("same text", verified_artifact=False)
+    assert set(killed) == {"u1", "u2"}
+    assert set(exc.value.dissolved_units) == {"u1", "u2"}
+
+
+# ---------------------------------------------------------------------------
+# (f) parallelizability decision
+# ---------------------------------------------------------------------------
+
+
+def test_is_parallelizable_true_for_independent_multi_node(monkeypatch):
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    graph = _multi_node_graph([_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")])
+    assert si.is_graph_parallelizable(graph) is True
+
+
+def test_is_parallelizable_false_for_single_node():
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    graph = _single_node_graph(_swarm_unit("only", "a.py"))
+    assert si.is_graph_parallelizable(graph) is False
+
+
+def test_is_parallelizable_false_when_fully_serial_chain():
+    """concurrency_limit>1 but every unit depends on the previous -> serial."""
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    graph = ExecutionGraph(
+        graph_id="g-chain",
+        op_id="op-chain",
+        planner_id="swarm_orchestrator",
+        schema_version="swarm.graph.1a",
+        concurrency_limit=2,
+        units=(
+            _swarm_unit("u1", "a.py"),
+            _swarm_unit("u2", "b.py", deps=("u1",)),
+        ),
+    )
+    assert si.is_graph_parallelizable(graph) is False
+
+
+def test_is_parallelizable_false_when_concurrency_limit_one():
+    from backend.core.ouroboros.governance.autonomy import swarm_invoker as si
+
+    graph = ExecutionGraph(
+        graph_id="g-cl1",
+        op_id="op-cl1",
+        planner_id="swarm_orchestrator",
+        schema_version="swarm.graph.1a",
+        concurrency_limit=1,
+        units=(_swarm_unit("u1", "a.py"), _swarm_unit("u2", "b.py")),
+    )
+    assert si.is_graph_parallelizable(graph) is False


### PR DESCRIPTION
Multi-node parallelizable DAG routes each unit through dynamic worker synthesis (worker_synthesizer -> SubagentFactory cage -> caged execute); deadlock-breaker wired; fail-CLOSED (no uncaged worker); gated JARVIS_SWARM_ORCHESTRATOR_ENABLED default-OFF byte-identical; Golden Rule preserved. 13 new + 700 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wires the swarm execution path into the scheduler so parallelizable DAGs run swarm-synthesized, caged workers; default is off and legacy behavior is unchanged. Adds deadlock handling and fail-closed guarantees to prevent uncaged runs.

- **New Features**
  - Added `SwarmUnitInvoker`, lazily wired into `SubagentScheduler` to wrap per-unit execution.
  - Routes through swarm only when `JARVIS_SWARM_ORCHESTRATOR_ENABLED` is on, the DAG is parallelizable, and the unit is a swarm worker; otherwise uses the legacy executor (byte-identical).
  - Swarm path synthesizes the worker (`worker_synthesizer`), builds a `SubagentFactory` ScopedToolBackend cage, then executes via the existing executor (worktree + sandbox).
  - Fail-closed guarantees: synthesis/cage errors or missing backend return FAILED; no uncaged execution.
  - Deadlock breaker integration: `DeadlockInterruptedException` becomes a FAILED unit. Added tests for OFF routing, parallelizability, fail-closed cases, and deadlock handling.

<sup>Written for commit 918cd31b15f56365f3b7ffd61563f38ed13104d1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

