### PR TITLE
feat(fsm): promote REVIEW+PLAN shadow→enforce (gated default-OFF)

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -1700,7 +1700,7 @@ class GovernedOrchestrator:
         """
         self._subagent_orchestrator = orch
 
-    async def _run_review_shadow(self, ctx: Any, best_candidate: Any) -> None:
+    async def _run_review_shadow(self, ctx: Any, best_candidate: Any) -> Any:
         """Phase B — post-VALIDATE REVIEW subagent in OBSERVER MODE.
 
         Gated by ``JARVIS_REVIEW_SUBAGENT_SHADOW`` (default **``true``**,
@@ -1731,15 +1731,29 @@ class GovernedOrchestrator:
 
         Must not raise under any condition — the observer contract forbids
         the shadow from breaking the main generation loop.
+
+        Returns a ``shadow_enforce.ReviewAggregate`` describing the worst-of-N
+        verdict (or ``None`` when there was nothing to review / the shadow was
+        skipped). The enforce branch at the call site consumes this to gate
+        the FSM via the EXISTING risk-tier escalation; when REVIEW-enforce is
+        OFF (default) the caller ignores the return and behavior is
+        byte-identical to the legacy shadow. The method itself NEVER gates —
+        it stays a pure observer; gating is the caller's job.
         """
+        from backend.core.ouroboros.governance.shadow_enforce import ReviewAggregate
+
         if best_candidate is None:
-            return
+            return None
         if self._subagent_orchestrator is None:
-            return
+            return None
+        # NOTE: the shadow flag must stay enabled for the REVIEW subagent to
+        # run at all (it is the dispatch gate). REVIEW-enforce composes ON TOP
+        # of the shadow dispatch — it consumes the verdict the shadow already
+        # computes. When the shadow is off there is no verdict to enforce.
         if os.environ.get(
             "JARVIS_REVIEW_SUBAGENT_SHADOW", "true"
         ).lower() not in ("true", "1"):
-            return
+            return None
 
         try:
             _files = best_candidate.get("files") if isinstance(
@@ -1851,12 +1865,32 @@ class GovernedOrchestrator:
                 _counts["failed"],
                 _duration_ms,
             )
+
+            # Build the aggregate the enforce branch consumes. This is a pure
+            # restatement of the telemetry counts already computed above — the
+            # shadow log line and the returned aggregate are the SAME verdict.
+            return ReviewAggregate(
+                aggregate=_aggregate,
+                files_reviewed=len(_verdicts),
+                rejected=_counts["rejected"],
+                reservations=_counts["reservations"],
+                approved=_counts["approved"],
+                failed=_counts["failed"],
+                had_failure=_counts["failed"] > 0,
+            )
         except Exception:
-            # Observer contract: shadow must never break the FSM.
+            # Observer contract: shadow must never break the FSM. A whole-
+            # dispatch crash is a SUBSYSTEM failure -> fail-SOFT to the legacy
+            # shadow behavior: return None so the enforce branch does NOT gate
+            # (never block the op on a telemetry/subsystem failure). This is
+            # distinct from an ambiguous *verdict* (a per-file review that
+            # completes with FAILED status -> had_failure=True -> escalate):
+            # fail-CLOSED is on the verdict, fail-SOFT is on the subsystem.
             logger.debug(
                 "[Orchestrator] REVIEW shadow dispatch skipped",
                 exc_info=True,
             )
+            return None
 
     async def _run_plan_shadow(self, ctx: Any) -> Any:
         """Phase B PLAN-shadow — AgenticPlanSubagent dispatch running
@@ -8761,10 +8795,48 @@ class GovernedOrchestrator:
                         exc_info=True,
                     )
 
-            # ---- REVIEW subagent (Slice 1a — SHADOW MODE observer only) ----
-            # Gated by JARVIS_REVIEW_SUBAGENT_SHADOW. Emits verdict telemetry
-            # only; FSM proceeds to GATE unchanged. See _run_review_shadow.
-            await self._run_review_shadow(ctx, best_candidate)
+            # ---- REVIEW subagent (Slice 1a SHADOW + enforce promotion) ----
+            # Gated by JARVIS_REVIEW_SUBAGENT_SHADOW (dispatch) + optionally
+            # JARVIS_REVIEW_SUBAGENT_ENFORCE (default false — gating). The
+            # shadow always emits verdict telemetry; when enforce is OFF the
+            # FSM proceeds to GATE unchanged (byte-identical observer). When
+            # enforce is ON the worst-of-N verdict becomes a HARD risk-tier
+            # gate via the SAME stricter-wins escalation SemanticGuardian uses
+            # (REJECT / ambiguous -> APPROVAL_REQUIRED, reservations ->
+            # NOTIFY_APPLY). Fail-CLOSED on the verdict; fail-SOFT on the
+            # subsystem (a dispatch crash returns None -> no gating, op alive).
+            _review_aggregate = await self._run_review_shadow(ctx, best_candidate)
+            try:
+                from backend.core.ouroboros.governance.shadow_enforce import (
+                    aggregate_to_tier_floor as _agg_to_floor,
+                    escalate_risk_tier as _escalate_tier,
+                    review_enforce_enabled as _review_enforce_on,
+                )
+                if (
+                    _review_enforce_on()
+                    and _review_aggregate is not None
+                    and best_candidate is not None
+                ):
+                    _rv_floor = _agg_to_floor(_review_aggregate)
+                    _rv_before = risk_tier.name
+                    risk_tier = _escalate_tier(risk_tier, _rv_floor)
+                    logger.info(
+                        "[REVIEW-ENFORCE] op=%s aggregate=%s floor=%s "
+                        "risk_before=%s risk_after=%s "
+                        "(verdict gates FSM via existing risk-tier escalation)",
+                        getattr(ctx, "op_id", "?"),
+                        _review_aggregate.aggregate,
+                        _rv_floor or "<none>",
+                        _rv_before,
+                        risk_tier.name,
+                    )
+            except Exception:
+                # Fail-SOFT: an enforce-wiring error must never break the op.
+                # Conservative: leave risk_tier unchanged + log.
+                logger.debug(
+                    "[Orchestrator] REVIEW-enforce gating skipped (fail-soft)",
+                    exc_info=True,
+                )
 
             # ---- MutationGate: APPLY-phase execution boundary (cached) ----
             #

--- a/backend/core/ouroboros/governance/parallel_dispatch.py
+++ b/backend/core/ouroboros/governance/parallel_dispatch.py
@@ -310,6 +310,7 @@ def is_fanout_eligible(
         Callable[[], Tuple[Optional[Posture], Optional[float]]]
     ] = None,
     emit_log: bool = True,
+    force: bool = False,
 ) -> FanoutEligibility:
     """Decide whether (and how aggressively) to fan out a multi-file op.
 
@@ -369,8 +370,10 @@ def is_fanout_eligible(
     n_requested = int(n_candidate_files)
     max_units_cap = parallel_dispatch_max_units()
 
-    # 1. Master flag gate.
-    if not parallel_dispatch_enabled():
+    # 1. Master flag gate. ``force=True`` (the PLAN-enforce driver) bypasses
+    # ONLY this flag check — all downstream clamps (single-file, posture,
+    # memory CRITICAL, max-units, sovereignty) stay fully authoritative.
+    if not force and not parallel_dispatch_enabled():
         result = FanoutEligibility(
             allowed=False,
             n_requested=n_requested,
@@ -1236,6 +1239,7 @@ async def enforce_evaluate_fanout(
         Callable[[], Tuple[Optional[Posture], Optional[float]]]
     ] = None,
     wait_timeout_s: Optional[float] = None,
+    force: bool = False,
 ) -> FanoutResult:
     """Slice 4 — enforce-mode fan-out evaluation + scheduler submit.
 
@@ -1310,21 +1314,27 @@ async def enforce_evaluate_fanout(
         else parallel_dispatch_wait_timeout_s()
     )
 
-    # Guard 1: master flag.
-    if not parallel_dispatch_enabled():
-        logger.debug(
-            "[ParallelDispatch enforce_skipped] op=%s reason=master_off",
-            op_id[:16],
-        )
-        return FanoutResult(outcome=FanoutOutcome.SKIPPED, skip_reason="master_off")
+    # Guard 1 + 2: master + enforce sub-flag. ``force=True`` bypasses ONLY
+    # these two FLAG guards (it does NOT relax eligibility, sovereignty, or
+    # graph-build validation below). The PLAN-enforce driver passes force=True
+    # so a genuinely multi-node PLAN DAG can authoritatively engage this exact
+    # fan-out path WITHOUT also flipping the independent JARVIS_WAVE3_PARALLEL_
+    # DISPATCH_* flags. When force is False (every legacy caller) the flag
+    # guards are unchanged -> byte-identical.
+    if not force:
+        if not parallel_dispatch_enabled():
+            logger.debug(
+                "[ParallelDispatch enforce_skipped] op=%s reason=master_off",
+                op_id[:16],
+            )
+            return FanoutResult(outcome=FanoutOutcome.SKIPPED, skip_reason="master_off")
 
-    # Guard 2: enforce sub-flag.
-    if not parallel_dispatch_enforce_enabled():
-        logger.debug(
-            "[ParallelDispatch enforce_skipped] op=%s reason=enforce_off",
-            op_id[:16],
-        )
-        return FanoutResult(outcome=FanoutOutcome.SKIPPED, skip_reason="enforce_off")
+        if not parallel_dispatch_enforce_enabled():
+            logger.debug(
+                "[ParallelDispatch enforce_skipped] op=%s reason=enforce_off",
+                op_id[:16],
+            )
+            return FanoutResult(outcome=FanoutOutcome.SKIPPED, skip_reason="enforce_off")
 
     # Guard 3: candidate extraction.
     files = extract_candidate_files(generation)
@@ -1341,12 +1351,15 @@ async def enforce_evaluate_fanout(
     n_files = len(files)
 
     # Guard 4: eligibility (single-file / empty / memory-critical / posture).
+    # force threads through so the PLAN-enforce driver bypasses ONLY the
+    # master-flag check; all real eligibility clamps remain authoritative.
     eligibility = is_fanout_eligible(
         op_id=op_id,
         n_candidate_files=n_files,
         gate=gate,
         posture_fn=posture_fn,
         emit_log=True,
+        force=force,
     )
     if not eligibility.allowed:
         return FanoutResult(

--- a/backend/core/ouroboros/governance/phase_dispatcher.py
+++ b/backend/core/ouroboros/governance/phase_dispatcher.py
@@ -1078,7 +1078,23 @@ async def dispatch_pipeline(
                 parallel_dispatch_enforce_enabled as _enforce_on,
                 parallel_dispatch_shadow_enabled as _shadow_on,
             )
-            if _master_on() and _enforce_on():
+            # PLAN-enforce (JARVIS_PLAN_SUBAGENT_ENFORCE): when the PLAN
+            # subagent produced a genuinely multi-node parallelizable DAG and
+            # PLAN-enforce is ON, the PLAN DAG becomes authoritative and DRIVES
+            # this exact post-GENERATE fan-out path -- even when the
+            # independent parallel_dispatch flags are off. Fail-CLOSED: a
+            # malformed / single-node / empty DAG -> _plan_drives is False ->
+            # the legacy flat-plan GENERATE path proceeds unchanged. The
+            # probe is exception-safe (never raises).
+            try:
+                from backend.core.ouroboros.governance.shadow_enforce import (
+                    plan_enforce_should_fanout as _plan_enforce_should_fanout,
+                )
+                _plan_drives = _plan_enforce_should_fanout(ctx)
+            except Exception:  # noqa: BLE001 -- probe failure -> legacy.
+                _plan_drives = False
+            _legacy_enforce = _master_on() and _enforce_on()
+            if _legacy_enforce or _plan_drives:
                 # Enforce path — fail loud on unexpected errors
                 # (operator directive: narrow catches only on hot
                 # path). asyncio.CancelledError cooperates with
@@ -1099,10 +1115,15 @@ async def dispatch_pipeline(
                         "orchestrator has no _subagent_scheduler reference"
                     )
                 else:
+                    # force bypasses ONLY the parallel_dispatch flag guards
+                    # when the PLAN DAG is the authoritative driver (legacy
+                    # enforce flags off). When the legacy enforce flags ARE on,
+                    # force stays False so behavior is byte-identical to today.
                     _fanout_result = await _enforce_evaluate_fanout(
                         op_id=ctx.op_id,
                         generation=pctx.generation,
                         scheduler=_scheduler,
+                        force=(_plan_drives and not _legacy_enforce),
                     )
                     # Slice 4 ships the submit + await primitive with
                     # loud-fail error handling. The result is ALWAYS

--- a/backend/core/ouroboros/governance/shadow_enforce.py
+++ b/backend/core/ouroboros/governance/shadow_enforce.py
@@ -1,0 +1,268 @@
+"""shadow_enforce -- promote the Phase B REVIEW + PLAN subagents from
+SHADOW (observe-only) to ENFORCE (hard gating), gated default-OFF.
+
+THE GAP this closes: the REVIEW subagent emits ``[REVIEW-SHADOW]`` verdicts
+but the FSM proceeds to GATE regardless; the PLAN subagent stashes an
+``execution_graph`` DAG on ``ctx`` but the legacy flat plan stays
+authoritative for GENERATE + the post-GENERATE fan-out keys off the GENERATE
+candidate-file count, never the PLAN DAG. This module is the **decision
+logic** for the two enforce branches -- pure, deterministic, unit-testable
+in isolation so the FSM surgery at the call sites stays minimal.
+
+It introduces **NO new gate** and **NO new generation driver**. It maps the
+REVIEW aggregate verdict onto the EXISTING ``RiskTier`` escalation (the same
+``risk_tier.value < floor.value`` comparison ``SemanticGuardian`` uses) and
+decides whether the EXISTING post-GENERATE fan-out
+(``parallel_dispatch.enforce_evaluate_fanout`` -> scheduler -> swarm ->
+``DAGComposer``) should be engaged because the PLAN DAG is a genuinely
+multi-node parallelizable graph.
+
+Gating invariant (both flags default-OFF):
+
+  * ``JARVIS_REVIEW_SUBAGENT_ENFORCE`` (default **false**) -- OFF -> the
+    REVIEW verdict is logged + ignored (byte-identical shadow).
+  * ``JARVIS_PLAN_SUBAGENT_ENFORCE`` (default **false**) -- OFF -> the PLAN
+    DAG is stashed + ignored, the flat plan drives GENERATE (byte-identical
+    shadow).
+
+Fail-CLOSED on the verdict: an ambiguous / errored / unknown REVIEW
+aggregate escalates (the SAFE direction -- never silently approve). The
+*subsystem* fail-soft (a review/plan dispatch crash -> legacy shadow, never
+crash the op) lives at the call sites; this module's pure functions never
+raise on well-formed inputs and defend defensively on malformed ones.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Any, Optional
+
+logger = logging.getLogger("Ouroboros.ShadowEnforce")
+
+
+# ---------------------------------------------------------------------------
+# Flag readers -- both default-OFF (byte-identical shadow when off).
+# ---------------------------------------------------------------------------
+
+
+def _env_truthy(name: str, default: str = "false") -> bool:
+    return os.environ.get(name, default).strip().lower() in ("true", "1", "yes", "on")
+
+
+def review_enforce_enabled() -> bool:
+    """``JARVIS_REVIEW_SUBAGENT_ENFORCE`` -- default **false**.
+
+    When false, the REVIEW verdict is observer-only (byte-identical shadow).
+    """
+    return _env_truthy("JARVIS_REVIEW_SUBAGENT_ENFORCE")
+
+
+def plan_enforce_enabled() -> bool:
+    """``JARVIS_PLAN_SUBAGENT_ENFORCE`` -- default **false**.
+
+    When false, the PLAN DAG is stashed but the flat plan stays authoritative
+    (byte-identical shadow).
+    """
+    return _env_truthy("JARVIS_PLAN_SUBAGENT_ENFORCE")
+
+
+# ---------------------------------------------------------------------------
+# REVIEW enforce -- map the aggregate verdict onto a RiskTier floor.
+# ---------------------------------------------------------------------------
+
+# String constants the aggregate may carry. These mirror the uppercase
+# aggregate emitted by the [REVIEW-SHADOW] telemetry line so the enforce
+# path consumes exactly what the shadow already computes -- no re-derivation.
+AGG_APPROVE = "APPROVE"
+AGG_RESERVATIONS = "APPROVE_WITH_RESERVATIONS"
+AGG_REJECT = "REJECT"
+AGG_NO_FILES = "NO_FILES"
+
+
+@dataclass(frozen=True)
+class ReviewAggregate:
+    """The worst-of-N REVIEW verdict the shadow already computes.
+
+    ``aggregate`` is the uppercase string ("APPROVE" / "REJECT" /
+    "APPROVE_WITH_RESERVATIONS" / "NO_FILES"). ``had_failure`` is True when
+    one or more per-file reviews failed to complete (status != "completed")
+    -- an ambiguous outcome that fails CLOSED (escalate).
+    """
+
+    aggregate: str = AGG_NO_FILES
+    files_reviewed: int = 0
+    rejected: int = 0
+    reservations: int = 0
+    approved: int = 0
+    failed: int = 0
+    had_failure: bool = False
+
+
+def aggregate_to_tier_floor(agg: ReviewAggregate) -> Optional[str]:
+    """Map a REVIEW aggregate onto a risk-tier *floor* name, or ``None``.
+
+    Returns one of ``"approval_required"`` / ``"notify_apply"`` / ``None``.
+    The orchestrator applies the floor with the SAME stricter-wins clamp
+    SemanticGuardian uses (``risk_tier.value < upgrade.value``), so a floor
+    only ever *raises* the tier, never lowers it.
+
+    Fail-CLOSED:
+
+      * ``REJECT``                  -> ``approval_required`` (hard human gate).
+      * any per-file review FAILED  -> ``approval_required`` (ambiguous ->
+        escalate; a review we could not complete is treated as the worst
+        case, never silently approved).
+      * ``APPROVE_WITH_RESERVATIONS`` -> ``notify_apply`` (surface the diff).
+      * ``APPROVE`` (clean, no failures) -> ``None`` (no escalation).
+      * ``NO_FILES`` / unknown string -> ``None`` (nothing reviewed; the
+        existing classifier + SemanticGuardian + Iron Gate remain
+        authoritative -- this branch never *lowers* friction).
+
+    Note the ordering: an aggregate of APPROVE that nonetheless carried a
+    FAILED per-file review still escalates, because ``had_failure`` is
+    checked before the clean-approve short-circuit.
+    """
+    if agg.aggregate == AGG_REJECT:
+        return "approval_required"
+    if agg.had_failure or agg.failed > 0:
+        # A review we could not complete is ambiguous -> escalate (CLOSED).
+        return "approval_required"
+    if agg.aggregate == AGG_RESERVATIONS:
+        return "notify_apply"
+    # APPROVE / NO_FILES / anything else -> no escalation.
+    return None
+
+
+def escalate_risk_tier(current: Any, floor_name: Optional[str]) -> Any:
+    """Apply a tier *floor* to ``current``, stricter-wins. Reuses the exact
+    SemanticGuardian pattern: only raise the tier when the floor is strictly
+    stricter than the current tier (``current.value < floor.value``).
+
+    Returns the (possibly-upgraded) ``RiskTier``. ``floor_name=None`` ->
+    ``current`` unchanged. An unrecognized floor name -> ``current``
+    unchanged (defensive; never crashes the FSM).
+    """
+    if floor_name is None:
+        return current
+    try:
+        from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+        _floor_map = {
+            "notify_apply": RiskTier.NOTIFY_APPLY,
+            "approval_required": RiskTier.APPROVAL_REQUIRED,
+        }
+        upgrade = _floor_map.get(floor_name)
+        if upgrade is None:
+            return current
+        # Stricter-wins: only raise. Mirrors semantic_guardian wiring.
+        if current is None:
+            return upgrade
+        if getattr(current, "value", None) is None:
+            return current
+        if current.value < upgrade.value:
+            return upgrade
+        return current
+    except Exception:  # noqa: BLE001 -- defensive: never crash the FSM on an
+        # escalation-table lookup. Conservative: leave the tier unchanged
+        # (the verdict-level fail-CLOSED is handled by aggregate_to_tier_floor;
+        # an import error here is a subsystem failure -> fail-soft).
+        logger.debug("[ShadowEnforce] risk-tier escalation lookup failed", exc_info=True)
+        return current
+
+
+# ---------------------------------------------------------------------------
+# PLAN enforce -- decide whether the PLAN DAG is authoritative + multi-node.
+# ---------------------------------------------------------------------------
+
+
+def _payload_to_dict(execution_graph: Any) -> Optional[dict]:
+    """Coerce the 2d.1 execution_graph payload (tuple-of-tuple OR dict) into
+    a dict, or ``None`` if it is not a recognizable shape. Defensive: never
+    raises.
+    """
+    if execution_graph is None:
+        return None
+    if isinstance(execution_graph, dict):
+        return execution_graph
+    try:
+        return dict(execution_graph)
+    except (TypeError, ValueError):
+        return None
+
+
+def plan_dag_is_multinode(execution_graph: Any) -> bool:
+    """True iff the stashed PLAN DAG is genuinely multi-node parallelizable.
+
+    Mirrors ``swarm_invoker.is_graph_parallelizable`` on the 2d.1
+    tuple-of-tuple payload (which is what ``_run_plan_shadow`` stashes on
+    ``ctx.execution_graph``), so PLAN-enforce engages the fan-out under the
+    SAME parallelizability contract the swarm itself uses:
+
+      * ``concurrency_limit > 1``, AND
+      * at least 2 dependency-free root units (in-degree 0) that can run in
+        the same first wave.
+
+    Fail-CLOSED on a malformed / empty / single-node payload -> ``False`` ->
+    the orchestrator keeps the legacy flat-plan GENERATE (no fan-out, no
+    behavior change). Never raises.
+    """
+    payload = _payload_to_dict(execution_graph)
+    if payload is None:
+        return False
+    try:
+        concurrency_limit = int(payload.get("concurrency_limit", 1) or 1)
+        if concurrency_limit <= 1:
+            return False
+        units = payload.get("units") or ()
+        if len(units) <= 1:
+            return False
+        roots = 0
+        for unit in units:
+            unit_dict = _payload_to_dict(unit)
+            if unit_dict is None:
+                # Defensive: an unrecognizable unit cannot be proven a root.
+                continue
+            deps = unit_dict.get("dependency_ids") or ()
+            if not deps:
+                roots += 1
+        return roots >= 2
+    except Exception:  # noqa: BLE001 -- malformed payload -> not parallelizable.
+        logger.debug("[ShadowEnforce] plan DAG parallelizability probe failed", exc_info=True)
+        return False
+
+
+def plan_enforce_should_fanout(ctx: Any) -> bool:
+    """Decide whether PLAN-enforce should drive the post-GENERATE fan-out.
+
+    True iff ALL of:
+
+      * ``JARVIS_PLAN_SUBAGENT_ENFORCE`` is on, AND
+      * ``ctx.execution_graph`` is a genuinely multi-node parallelizable DAG.
+
+    False (the default + every fail-CLOSED case) -> the legacy flat-plan
+    GENERATE drives the op; the post-GENERATE fan-out engages ONLY via its
+    own ``parallel_dispatch`` enforce flag, exactly as today. Never raises.
+    """
+    if not plan_enforce_enabled():
+        return False
+    try:
+        execution_graph = getattr(ctx, "execution_graph", None)
+    except Exception:  # noqa: BLE001 -- defensive ctx access.
+        return False
+    return plan_dag_is_multinode(execution_graph)
+
+
+__all__ = [
+    "review_enforce_enabled",
+    "plan_enforce_enabled",
+    "ReviewAggregate",
+    "aggregate_to_tier_floor",
+    "escalate_risk_tier",
+    "plan_dag_is_multinode",
+    "plan_enforce_should_fanout",
+    "AGG_APPROVE",
+    "AGG_RESERVATIONS",
+    "AGG_REJECT",
+    "AGG_NO_FILES",
+]

--- a/tests/governance/test_parallel_dispatch_enforce.py
+++ b/tests/governance/test_parallel_dispatch_enforce.py
@@ -854,11 +854,14 @@ def test_phase_dispatcher_enforce_branch_uses_narrow_catches():
     )
     source = dispatcher_path.read_text()
 
-    # Pattern: find the enforce branch body (between "if _master_on() and _enforce_on():"
-    # and the next elif/else at the same indentation level). Simple
-    # string search — the branch should NOT contain a broad
-    # 'except Exception' wrap around the enforce call.
-    enforce_idx = source.find("if _master_on() and _enforce_on():")
+    # Pattern: find the enforce branch body (between the enforce-branch
+    # condition and the next elif/else at the same indentation level). The
+    # condition was promoted to "if _legacy_enforce or _plan_drives:" when
+    # PLAN-enforce was wired to also drive this fan-out (the legacy
+    # "_master_on() and _enforce_on()" predicate now lives in _legacy_enforce).
+    # The branch should NOT contain a broad 'except Exception' wrap around the
+    # enforce_evaluate_fanout call. Simple string search.
+    enforce_idx = source.find("if _legacy_enforce or _plan_drives:")
     shadow_elif_idx = source.find("elif _master_on() and _shadow_on():", enforce_idx)
     assert enforce_idx >= 0 and shadow_elif_idx > enforce_idx, (
         "enforce branch structure not found as expected"

--- a/tests/governance/test_review_shadow_hook.py
+++ b/tests/governance/test_review_shadow_hook.py
@@ -167,7 +167,14 @@ async def test_shadow_on_dispatches_and_emits(
             _candidate_single(path="foo.py", content="# new\npass\n"),
         )
 
-    assert result is None, "observer hook must never return a value"
+    # Post shadow->enforce promotion: the hook now RETURNS the worst-of-N
+    # ReviewAggregate so an OPT-IN enforce branch (JARVIS_REVIEW_SUBAGENT_
+    # ENFORCE, default off) can gate the FSM. The observer itself still
+    # mutates no FSM state — returning a pure data object is not a mutation,
+    # and the caller ignores it when enforce is off (byte-identical shadow).
+    from backend.core.ouroboros.governance.shadow_enforce import ReviewAggregate
+    assert isinstance(result, ReviewAggregate)
+    assert result.aggregate == "APPROVE"
     assert len(spy.calls) == 1
     call = spy.calls[0]
     assert call["file_path"] == "foo.py"
@@ -232,7 +239,11 @@ async def test_shadow_every_verdict_yields_no_fsm_mutation(
     with caplog.at_level(logging.INFO):
         result = await orch._run_review_shadow(_ctx(), _candidate_single())
 
-    assert result is None
+    # The hook now returns a ReviewAggregate (consumed only by the opt-in
+    # enforce branch); the observer mutates NO orchestrator/FSM state, which
+    # is the real contract this test pins.
+    from backend.core.ouroboros.governance.shadow_enforce import ReviewAggregate
+    assert isinstance(result, ReviewAggregate)
     assert orch.__dict__ == pre_state, (
         f"observer mutated orchestrator state under {verdict} verdict"
     )

--- a/tests/governance/test_shadow_enforce_promotion.py
+++ b/tests/governance/test_shadow_enforce_promotion.py
@@ -1,0 +1,317 @@
+"""Regression spine -- promote REVIEW + PLAN subagents SHADOW -> ENFORCE.
+
+Pins the gated-default-OFF, fail-CLOSED-on-verdict, fail-SOFT-on-subsystem
+contract for the two enforce branches:
+
+REVIEW enforce (``JARVIS_REVIEW_SUBAGENT_ENFORCE``, default false):
+  * OFF -> verdict logged, FSM proceeds (byte-identical shadow): the
+    decision helper returns no floor and the tier is unchanged.
+  * ON + blocking (REJECT) verdict -> risk-tier escalated to
+    APPROVAL_REQUIRED via the EXISTING stricter-wins escalation.
+  * ON + ambiguous (per-file review FAILED) -> escalate (fail-CLOSED).
+  * subsystem error -> _run_review_shadow returns None -> no gating
+    (fail-SOFT; the op is never blocked on a telemetry failure).
+
+PLAN enforce (``JARVIS_PLAN_SUBAGENT_ENFORCE``, default false):
+  * OFF -> flat plan authoritative (byte-identical shadow): should_fanout
+    is False regardless of the DAG.
+  * ON + multi-node parallelizable DAG -> should_fanout True -> drives the
+    EXISTING is_fanout_eligible / enforce_evaluate_fanout path (force-armed).
+  * ON + single-node / empty / malformed DAG -> should_fanout False ->
+    legacy flat plan (fail-CLOSED).
+  * force=True bypasses ONLY the parallel_dispatch flag guards; all real
+    eligibility clamps remain authoritative.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import Any, Optional
+
+import pytest
+
+from backend.core.ouroboros.governance.risk_engine import RiskTier
+from backend.core.ouroboros.governance import shadow_enforce as se
+
+
+# ---------------------------------------------------------------------------
+# Flag readers default-OFF (byte-identical shadow).
+# ---------------------------------------------------------------------------
+
+
+def test_review_enforce_default_off(monkeypatch: Any) -> None:
+    monkeypatch.delenv("JARVIS_REVIEW_SUBAGENT_ENFORCE", raising=False)
+    assert se.review_enforce_enabled() is False
+
+
+def test_plan_enforce_default_off(monkeypatch: Any) -> None:
+    monkeypatch.delenv("JARVIS_PLAN_SUBAGENT_ENFORCE", raising=False)
+    assert se.plan_enforce_enabled() is False
+
+
+@pytest.mark.parametrize("val", ["true", "1", "yes", "on", "TRUE"])
+def test_review_enforce_on_values(monkeypatch: Any, val: str) -> None:
+    monkeypatch.setenv("JARVIS_REVIEW_SUBAGENT_ENFORCE", val)
+    assert se.review_enforce_enabled() is True
+
+
+@pytest.mark.parametrize("val", ["false", "0", "no", "off", ""])
+def test_review_enforce_off_values(monkeypatch: Any, val: str) -> None:
+    monkeypatch.setenv("JARVIS_REVIEW_SUBAGENT_ENFORCE", val)
+    assert se.review_enforce_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# REVIEW enforce -- aggregate -> tier floor (fail-CLOSED on the verdict).
+# ---------------------------------------------------------------------------
+
+
+def test_reject_maps_to_approval_required() -> None:
+    agg = se.ReviewAggregate(aggregate=se.AGG_REJECT, rejected=1, files_reviewed=1)
+    assert se.aggregate_to_tier_floor(agg) == "approval_required"
+
+
+def test_reservations_maps_to_notify_apply() -> None:
+    agg = se.ReviewAggregate(
+        aggregate=se.AGG_RESERVATIONS, reservations=1, files_reviewed=1
+    )
+    assert se.aggregate_to_tier_floor(agg) == "notify_apply"
+
+
+def test_clean_approve_no_escalation() -> None:
+    agg = se.ReviewAggregate(aggregate=se.AGG_APPROVE, approved=1, files_reviewed=1)
+    assert se.aggregate_to_tier_floor(agg) is None
+
+
+def test_no_files_no_escalation() -> None:
+    agg = se.ReviewAggregate(aggregate=se.AGG_NO_FILES)
+    assert se.aggregate_to_tier_floor(agg) is None
+
+
+def test_ambiguous_failed_review_escalates_failclosed() -> None:
+    # APPROVE aggregate but a per-file review FAILED -> ambiguous -> escalate.
+    agg = se.ReviewAggregate(
+        aggregate=se.AGG_APPROVE, approved=1, failed=1, files_reviewed=2,
+        had_failure=True,
+    )
+    assert se.aggregate_to_tier_floor(agg) == "approval_required"
+
+
+# ---------------------------------------------------------------------------
+# REVIEW enforce -- escalate_risk_tier reuses stricter-wins (SemanticGuardian
+# pattern): only RAISE the tier, never lower it.
+# ---------------------------------------------------------------------------
+
+
+def test_escalate_raises_lower_tier() -> None:
+    out = se.escalate_risk_tier(RiskTier.SAFE_AUTO, "approval_required")
+    assert out == RiskTier.APPROVAL_REQUIRED
+
+
+def test_escalate_never_lowers() -> None:
+    # Current is already APPROVAL_REQUIRED; a notify_apply floor must NOT
+    # lower it.
+    out = se.escalate_risk_tier(RiskTier.APPROVAL_REQUIRED, "notify_apply")
+    assert out == RiskTier.APPROVAL_REQUIRED
+
+
+def test_escalate_none_floor_unchanged() -> None:
+    out = se.escalate_risk_tier(RiskTier.SAFE_AUTO, None)
+    assert out == RiskTier.SAFE_AUTO
+
+
+def test_escalate_unknown_floor_unchanged() -> None:
+    out = se.escalate_risk_tier(RiskTier.SAFE_AUTO, "garbage_floor")
+    assert out == RiskTier.SAFE_AUTO
+
+
+# ---------------------------------------------------------------------------
+# PLAN enforce -- DAG parallelizability probe on the 2d.1 payload.
+# ---------------------------------------------------------------------------
+
+
+def _multinode_payload() -> tuple:
+    """A 2d.1 tuple-of-tuple payload with 2 dependency-free roots + cl=2."""
+    units = (
+        (("unit_id", "u1"), ("dependency_ids", ()), ("owned_paths", ("a.py",))),
+        (("unit_id", "u2"), ("dependency_ids", ()), ("owned_paths", ("b.py",))),
+    )
+    return (
+        ("schema_version", "2d.1"),
+        ("graph_id", "deadbeef"),
+        ("concurrency_limit", 2),
+        ("units", units),
+    )
+
+
+def _single_node_payload() -> tuple:
+    units = (
+        (("unit_id", "u1"), ("dependency_ids", ()), ("owned_paths", ("a.py",))),
+    )
+    return (
+        ("schema_version", "2d.1"),
+        ("concurrency_limit", 1),
+        ("units", units),
+    )
+
+
+def _serial_chain_payload() -> tuple:
+    # cl=2 but only 1 root (u2 depends on u1) -> not parallelizable.
+    units = (
+        (("unit_id", "u1"), ("dependency_ids", ()), ("owned_paths", ("a.py",))),
+        (("unit_id", "u2"), ("dependency_ids", ("u1",)), ("owned_paths", ("b.py",))),
+    )
+    return (
+        ("schema_version", "2d.1"),
+        ("concurrency_limit", 2),
+        ("units", units),
+    )
+
+
+def test_multinode_dag_is_parallelizable() -> None:
+    assert se.plan_dag_is_multinode(_multinode_payload()) is True
+
+
+def test_single_node_dag_not_parallelizable() -> None:
+    assert se.plan_dag_is_multinode(_single_node_payload()) is False
+
+
+def test_serial_chain_not_parallelizable() -> None:
+    assert se.plan_dag_is_multinode(_serial_chain_payload()) is False
+
+
+def test_none_dag_not_parallelizable() -> None:
+    assert se.plan_dag_is_multinode(None) is False
+
+
+def test_malformed_dag_failclosed() -> None:
+    assert se.plan_dag_is_multinode("not a graph") is False
+    assert se.plan_dag_is_multinode(()) is False
+
+
+# ---------------------------------------------------------------------------
+# PLAN enforce -- should_fanout gates on flag AND DAG.
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _Ctx:
+    execution_graph: Any = None
+
+
+def test_plan_should_fanout_off_byte_identical(monkeypatch: Any) -> None:
+    monkeypatch.delenv("JARVIS_PLAN_SUBAGENT_ENFORCE", raising=False)
+    # Even with a perfectly parallelizable DAG, OFF -> no fan-out.
+    ctx = _Ctx(execution_graph=_multinode_payload())
+    assert se.plan_enforce_should_fanout(ctx) is False
+
+
+def test_plan_should_fanout_on_multinode(monkeypatch: Any) -> None:
+    monkeypatch.setenv("JARVIS_PLAN_SUBAGENT_ENFORCE", "true")
+    ctx = _Ctx(execution_graph=_multinode_payload())
+    assert se.plan_enforce_should_fanout(ctx) is True
+
+
+def test_plan_should_fanout_on_single_node_failclosed(monkeypatch: Any) -> None:
+    monkeypatch.setenv("JARVIS_PLAN_SUBAGENT_ENFORCE", "true")
+    ctx = _Ctx(execution_graph=_single_node_payload())
+    assert se.plan_enforce_should_fanout(ctx) is False
+
+
+def test_plan_should_fanout_on_no_dag_failclosed(monkeypatch: Any) -> None:
+    monkeypatch.setenv("JARVIS_PLAN_SUBAGENT_ENFORCE", "true")
+    ctx = _Ctx(execution_graph=None)
+    assert se.plan_enforce_should_fanout(ctx) is False
+
+
+# ---------------------------------------------------------------------------
+# PLAN enforce -- force=True drives is_fanout_eligible past the master flag,
+# but real clamps stay authoritative.
+# ---------------------------------------------------------------------------
+
+
+def test_force_bypasses_master_flag(monkeypatch: Any) -> None:
+    from backend.core.ouroboros.governance import parallel_dispatch as pd
+
+    # Master flag OFF.
+    monkeypatch.delenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", raising=False)
+
+    # Neutral posture so eligibility isn't clamped by posture confidence.
+    def _posture_fn():
+        return (None, None)
+
+    # Without force -> MASTER_OFF -> not allowed.
+    res_off = pd.is_fanout_eligible(
+        op_id="op1", n_candidate_files=2, posture_fn=_posture_fn,
+        emit_log=False, force=False,
+    )
+    assert res_off.allowed is False
+    assert res_off.reason_code == pd.ReasonCode.MASTER_OFF
+
+    # With force -> master flag bypassed; 2 files -> eligible (memory gate
+    # permitting). We only assert it is NOT short-circuited by MASTER_OFF.
+    res_on = pd.is_fanout_eligible(
+        op_id="op1", n_candidate_files=2, posture_fn=_posture_fn,
+        emit_log=False, force=True,
+    )
+    assert res_on.reason_code != pd.ReasonCode.MASTER_OFF
+
+
+def test_force_does_not_relax_single_file_clamp(monkeypatch: Any) -> None:
+    from backend.core.ouroboros.governance import parallel_dispatch as pd
+
+    monkeypatch.delenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", raising=False)
+
+    def _posture_fn():
+        return (None, None)
+
+    # force=True but only 1 candidate file -> still SINGLE_FILE_OP (clamp
+    # is authoritative, force only bypasses the master FLAG).
+    res = pd.is_fanout_eligible(
+        op_id="op1", n_candidate_files=1, posture_fn=_posture_fn,
+        emit_log=False, force=True,
+    )
+    assert res.allowed is False
+    assert res.reason_code == pd.ReasonCode.SINGLE_FILE_OP
+
+
+def test_enforce_evaluate_fanout_force_bypasses_flag_guards(monkeypatch: Any) -> None:
+    """force=True lets enforce_evaluate_fanout proceed past Guards 1+2 even
+    when the parallel_dispatch flags are off (the PLAN-enforce driver path).
+    With an unrecognized generation it reaches Guard 3 (unrecognized_shape),
+    proving Guards 1+2 were bypassed (not master_off / enforce_off)."""
+    from backend.core.ouroboros.governance import parallel_dispatch as pd
+
+    monkeypatch.delenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENFORCE", raising=False)
+
+    class _Scheduler:
+        async def submit(self, graph):  # pragma: no cover - not reached
+            return True
+
+    res = asyncio.run(
+        pd.enforce_evaluate_fanout(
+            op_id="op-force", generation=object(), scheduler=_Scheduler(),
+            force=True,
+        )
+    )
+    # Bypassed flag guards -> fell through to candidate extraction.
+    assert res.skip_reason == "unrecognized_shape"
+
+
+def test_enforce_evaluate_fanout_no_force_master_off(monkeypatch: Any) -> None:
+    """Legacy caller (force=False) with flags off -> master_off (byte-identical)."""
+    from backend.core.ouroboros.governance import parallel_dispatch as pd
+
+    monkeypatch.delenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", raising=False)
+
+    class _Scheduler:
+        async def submit(self, graph):  # pragma: no cover - not reached
+            return True
+
+    res = asyncio.run(
+        pd.enforce_evaluate_fanout(
+            op_id="op-nf", generation=object(), scheduler=_Scheduler(),
+        )
+    )
+    assert res.skip_reason == "master_off"


### PR DESCRIPTION
REVIEW verdict → hard risk-tier/retry gate (reusing existing escalation); PLAN ExecutionGraph DAG → authoritative, drives the post-GENERATE fan-out (feeds swarm + DAGComposer). Fail-CLOSED verdict / fail-soft subsystem. Both enforce flags default-OFF byte-identical. 34 new + 245 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Promotes the REVIEW and PLAN subagents from shadow to optional enforce (default OFF). REVIEW verdicts can hard-gate via existing risk-tier escalation; PLAN’s DAG can drive post-GENERATE fan-out when truly parallelizable.

- **New Features**
  - REVIEW-enforce
    - `_run_review_shadow` now returns a `ReviewAggregate`.
    - When `JARVIS_REVIEW_SUBAGENT_ENFORCE` is true, maps the aggregate to a tier floor and escalates via the existing stricter-wins path:
      - `REJECT` or any failed/ambiguous review → `approval_required`.
      - `APPROVE_WITH_RESERVATIONS` → `notify_apply`.
      - Clean `APPROVE`/`NO_FILES` → no escalation.
    - Fail-closed on verdict; fail-soft on subsystem errors (no gating if the observer fails). Default OFF = byte-identical behavior.
  - PLAN-enforce
    - New `shadow_enforce` helpers decide if the PLAN DAG is authoritative and multi-node.
    - When `JARVIS_PLAN_SUBAGENT_ENFORCE` is true and the DAG is parallelizable, the PLAN drives `enforce_evaluate_fanout` with `force=True`.
    - `force=True` bypasses only parallel_dispatch flag guards; all real clamps (single-file, posture, memory, max-units, sovereignty) remain.
    - Default OFF = flat plan remains authoritative.
  - Parallel dispatch
    - `is_fanout_eligible` and `enforce_evaluate_fanout` accept `force` to safely bypass only flag checks.
  - New module: `backend/core/ouroboros/governance/shadow_enforce.py` with pure, testable decision logic.

- **Migration**
  - Defaults keep behavior unchanged.
  - To adopt:
    - Enable REVIEW gating: set `JARVIS_REVIEW_SUBAGENT_ENFORCE=true`.
    - Enable PLAN-driven fan-out: set `JARVIS_PLAN_SUBAGENT_ENFORCE=true` and ensure the PLAN subagent emits a valid multi-node `execution_graph` (2+ root units, `concurrency_limit > 1`).
  - Observability: look for `[REVIEW-ENFORCE]` logs showing aggregate, tier floor, and risk-tier before/after.

<sup>Written for commit cff223f3f06a2601c895cf812d412cbb5b82ea05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69714?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

