### PR TITLE
feat(omni): the Omni-Integration activation profile (ouroboros_omni_prod.env)

### DIFF
--- a/deploy/ouroboros_omni_prod.env
+++ b/deploy/ouroboros_omni_prod.env
@@ -1,0 +1,87 @@
+# ======================================================================
+# ouroboros_omni_prod.env -- THE OMNI-INTEGRATION ACTIVATION PROFILE
+# ----------------------------------------------------------------------
+# Single centralized profile that turns ON the full O+V capability stack:
+# the L3 parallel fan-out (collision-safe), the Sovereign Swarm (dynamic
+# worker synthesis + symbiotic bus + ephemeral sandbox), the Slice-4b
+# map-reduce composer, the shadow->enforce promotions, and the safe
+# capability flags. Everything here is gated default-OFF in code, so this
+# file is the SINGLE place the activation lives -- unset it and the system
+# reverts to byte-identical conservative defaults.
+#
+# RUNTIME REALITY (read before flipping in production):
+#   * The fan-out is collision-gated (AST Collision Matrix), memory-gated
+#     (MemoryPressureGate freezes wide fan-out on a 16GB host, bursts on a
+#     32GB GCP node), and cost-gated (DW serves the per-subagent cognition
+#     cheaply; SensorGovernor caps global op volume).
+#   * This profile is SOAK-GATED: it should be validated on a real GCP node
+#     before being trusted in steady state. Flipping it is "armed", not
+#     "proven".
+# ======================================================================
+
+# ---- Base: inherit the Linux production overlay (DW-primary autarky,
+#      failover mesh, boot-hydration, pytest caps, AST pool, etc.). ----
+# shellcheck source=/dev/null
+source "${BASH_SOURCE%/*}/ouroboros_linux_prod.env" 2>/dev/null \
+  || source "deploy/ouroboros_linux_prod.env" 2>/dev/null \
+  || true
+
+# ======================================================================
+# 1. L3 PARALLEL FAN-OUT  (collision-safe multi-worktree subagents)
+# ======================================================================
+# Eligibility + enforce: multi-unit work fans out to parallel worktree
+# subagents. The AST Collision Matrix fires automatically under WAVE3 --
+# it forbids parallel on same-file / import-coupled targets (zero-trust),
+# so no separate flag is needed for collision safety.
+export JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED=true
+export JARVIS_WAVE3_PARALLEL_DISPATCH_ENFORCE=true
+# Slice 4b map-reduce: parallel unit patches compose into ONE multi-file
+# candidate that walks VALIDATE/GATE/APPLY once (no duplicate serial APPLY).
+export JARVIS_WAVE3_DAG_COMPOSE_ENABLED=true
+# Per-subagent telemetry: worktree lifespan + DW inference cost.
+export JARVIS_L3_TELEMETRY_ENABLED=true
+
+# ======================================================================
+# 2. THE SOVEREIGN SWARM  (dynamic worker synthesis -- G1/G2/G3)
+# ======================================================================
+# G1: a multi-node parallelizable DAG routes each unit through dynamic
+#     worker synthesis (shape SYNTHESIZED from the sub-goal, no static roles)
+#     -> ScopedToolBackend cage -> caged execute. Now has a live caller.
+export JARVIS_SWARM_ORCHESTRATOR_ENABLED=true
+# G2: symbiotic inter-agent messaging (declarative data only) + the
+#     Epistemic Deadlock Breaker (max-turn budget -> kill+dissolve).
+export JARVIS_SWARM_MESSAGE_BUS_ENABLED=true
+# G3: per-worker ephemeral memory sandbox, gc-collected on Iron Return.
+export JARVIS_SWARM_EPHEMERAL_SANDBOX_ENABLED=true
+
+# ======================================================================
+# 3. SHADOW -> ENFORCE  (REVIEW + PLAN become authoritative)
+# ======================================================================
+# REVIEW verdict becomes a hard risk-tier/retry gate (was observe-only).
+export JARVIS_REVIEW_SUBAGENT_ENFORCE=true
+# PLAN ExecutionGraph DAG becomes authoritative -- it DRIVES the fan-out
+# (this is what produces the multi-node DAG the swarm consumes).
+export JARVIS_PLAN_SUBAGENT_ENFORCE=true
+
+# ======================================================================
+# 4. SAFE CAPABILITY FLAGS  (byte-identical OFF, low risk)
+# ======================================================================
+export JARVIS_CONVERSATION_BRIDGE_ENABLED=true      # TUI/Venom dialogue -> CONTEXT_EXPANSION (Tier -1 sanitized)
+export JARVIS_LAST_SESSION_SUMMARY_ENABLED=true     # cross-session continuity digest
+export JARVIS_WEB_SEARCH_TIER3_ENABLED=true         # web context in CONTEXT_EXPANSION
+export JARVIS_VISION_VERIFY_ENABLED=true            # post-APPLY UI sanity (cannot overturn tests)
+export JARVIS_SCHEDULE_RUNNER_ENABLED=true          # scheduled wake runner
+
+# ======================================================================
+# DELIBERATELY NOT FLIPPED HERE (need infra or a master lock that was
+# never built -- do not add without the prerequisite):
+#   * JARVIS_JPRIME_PRIMACY / _TIERED / _LASTRESORT -- no-ops without a
+#     live J-Prime VM serving (the failover mesh awakens one on demand).
+#   * JARVIS_CROSS_REPO_PROMOTER_ENABLED -- the master WRITE flag was
+#     deliberately never built ("lock before the door"); cross-repo
+#     autonomous writes stay OFF.
+#   * JARVIS_INTERACTIVE_REPAIR_ENABLED / forensic inoculation -- write
+#     side-effects outside the Iron Gate; need their own review + soak.
+#   * JARVIS_VISION_SENSOR_ENABLED -- needs a live frame stream; Tier 2
+#     VLM costs money.
+# ======================================================================


### PR DESCRIPTION
Single profile flipping the full now-wired stack: L3 fan-out + collision matrix + Slice-4b composer + Swarm G1/G2/G3 + REVIEW/PLAN enforce + safe flags. Soak-gated; excludes infra-dependent/never-built flags. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `deploy/ouroboros_omni_prod.env`, a single activation profile that turns on the full O+V stack in production. It inherits the Linux prod base and can be reverted by not sourcing the file.

- **New Features**
  - L3 parallel fan‑out with collision matrix; Slice‑4b DAG compose; per‑subagent telemetry.
  - Sovereign Swarm G1–G3: orchestrator, message bus, ephemeral sandbox.
  - REVIEW and PLAN now enforce gates and drive the DAG.
  - Safe flags on; infra‑dependent and master‑locked features remain off.

- **Migration**
  - Source `deploy/ouroboros_omni_prod.env` after `ouroboros_linux_prod.env` on a real GCP node; soak before steady use.
  - To roll back, stop sourcing this file; all flags default off.

<sup>Written for commit bb70fbdcce82a6add4fdad45972a052f3889f551. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69715?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

