### PR TITLE
feat(l3-demo): Hermetic L3 validator + DAGComposer zero-loss + emit-hop probe

### DIFF
--- a/backend/core/ouroboros/governance/a1_trace.py
+++ b/backend/core/ouroboros/governance/a1_trace.py
@@ -21,19 +21,129 @@ Design constraints
 """
 from __future__ import annotations
 
+import collections
 import logging
 import os
-from typing import Any
+import time
+from typing import Any, Dict
 
 logger = logging.getLogger(__name__)
 
 _ENV_ENABLED = "JARVIS_A1_TRACE_ENABLED"
+
+# --- deep emit-hop probe (Run #17 diagnosis) ------------------------------
+#
+# Run #17 failed the A1 auditor on ``a1trace:missing_or_out_of_order:emit``:
+# the first hop (roadmap_orchestrator emitting a strategic GOAL) was missing
+# or out of order vs the ``ingest`` hop. The probe below records the exact
+# emit state per goal so the verdict self-diagnoses to one of:
+#   - orchestrator-off  (the original A1 gap — emit never fires)
+#   - non-roadmap source (sensor/TestFailure ops ingest WITHOUT an emit)
+#   - genuine reorder    (emit fired but after ingest)
+#
+# Observe-only + fail-soft: a probe error NEVER affects emit/ingest/the loop.
+_ENV_EMIT_PROBE = "JARVIS_A1_EMIT_PROBE_ENABLED"
+_ENV_ROADMAP_ENABLED = "JARVIS_ROADMAP_ORCHESTRATOR_ENABLED"
+
+# Bounded ring of goal_id -> (emit_ts_monotonic, source); prevents unbounded
+# growth on long soaks. Newest-wins eviction (FIFO) via OrderedDict.
+_EMIT_LEDGER_MAX = 4096
+_emit_ledger: "collections.OrderedDict[str, tuple]" = collections.OrderedDict()
 
 
 def trace_enabled() -> bool:
     """Return True unless ``JARVIS_A1_TRACE_ENABLED`` is explicitly falsy."""
     val = (os.environ.get(_ENV_ENABLED, "true") or "").strip().lower()
     return val not in {"0", "false", "no", "off"}
+
+
+def emit_probe_enabled() -> bool:
+    """Probe defaults ON; OFF only when the master trace flag or the probe
+    flag is explicitly falsy. Riding the master flag keeps OFF byte-identical.
+    """
+    if not trace_enabled():
+        return False
+    val = (os.environ.get(_ENV_EMIT_PROBE, "true") or "").strip().lower()
+    return val not in {"0", "false", "no", "off"}
+
+
+def _roadmap_enabled_repr() -> bool:
+    """Live read of the roadmap-orchestrator master flag (no hardcoding)."""
+    val = (os.environ.get(_ENV_ROADMAP_ENABLED, "") or "").strip().lower()
+    return val in {"1", "true", "yes", "on"}
+
+
+def reset_emit_probe() -> None:
+    """Clear the per-goal emit ledger (test hook + boot reset)."""
+    try:
+        _emit_ledger.clear()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _emit_ledger_size() -> int:
+    return len(_emit_ledger)
+
+
+def emit_probe(goal_id: Any, *, source: str = "?") -> None:
+    """Record the emit hop for *goal_id* and log a structured probe line.
+
+    Captures the monotonic emit timestamp + source + whether the roadmap
+    orchestrator is ENABLED, so a missing/out-of-order emit later self-
+    explains. Observe-only (returns ``None``), fail-soft (NEVER raises).
+    """
+    if not emit_probe_enabled():
+        return
+    try:
+        gid = str(goal_id)
+        ts = time.monotonic()
+        _emit_ledger[gid] = (ts, source)
+        _emit_ledger.move_to_end(gid)
+        while len(_emit_ledger) > _EMIT_LEDGER_MAX:
+            _emit_ledger.popitem(last=False)
+        orch = _roadmap_enabled_repr()
+        logger.warning(
+            "[A1Trace][emit-probe] EMIT goal=%s source=%s emit_ts=%.6f "
+            "orchestrator_enabled=%s",
+            gid, source, ts, orch,
+        )
+    except Exception:  # noqa: BLE001 — a probe must never break a hop
+        pass
+
+
+def probe_ingest_order(goal_id: Any) -> None:
+    """At the ingest hop, emit the order-assertion line for *goal_id*.
+
+    Compares the prior emit_ts (if any) against this ingest_ts so the
+    auditor's ``missing_or_out_of_order:emit`` verdict is immediately
+    traceable. If no prior emit was recorded, logs ``MISSING`` (the Run-#17
+    mode: an ingest without a roadmap emit — likely a sensor/TestFailure op).
+
+    Observe-only (returns ``None``), fail-soft (NEVER raises).
+    """
+    if not emit_probe_enabled():
+        return
+    try:
+        gid = str(goal_id)
+        ingest_ts = time.monotonic()
+        record = _emit_ledger.get(gid)
+        if record is None:
+            logger.warning(
+                "[A1Trace][emit-probe] MISSING goal=%s emit_ts=MISSING "
+                "ingest_ts=%.6f ordered=False source=non-roadmap "
+                "(ingest without prior emit -- sensor/non-roadmap source?)",
+                gid, ingest_ts,
+            )
+            return
+        emit_ts, source = record
+        ordered = emit_ts <= ingest_ts
+        logger.warning(
+            "[A1Trace][emit-probe] goal=%s emit_ts=%.6f ingest_ts=%.6f "
+            "ordered=%s source=%s",
+            gid, emit_ts, ingest_ts, ordered, source,
+        )
+    except Exception:  # noqa: BLE001 — a probe must never break a hop
+        pass
 
 
 def a1trace(hop: str, goal_id: Any, **kw: Any) -> None:

--- a/backend/core/ouroboros/governance/dag_composer.py
+++ b/backend/core/ouroboros/governance/dag_composer.py
@@ -60,7 +60,9 @@ phase_dispatcher wiring reads it.
 """
 from __future__ import annotations
 
+import ast
 import enum
+import hashlib
 import logging
 import os
 from dataclasses import dataclass, field
@@ -126,6 +128,11 @@ class ComposeFailureReason(str, enum.Enum):
     UNIT_MISSING_PATCH = "unit_missing_patch"
     COLLISION_INVARIANT_VIOLATED = "collision_invariant_violated"
     EMPTY_COMPOSITION = "empty_composition"
+    # Zero-loss merge guarantee -- the composed candidate failed the
+    # post-union mathematical proof (count / content-sha / no-overwrite / AST).
+    # ``detail`` is prefixed ``lossless_proof_failed:<which>`` so the exact
+    # failing invariant is grep-visible.
+    LOSSLESS_PROOF_FAILED = "lossless_proof_failed"
 
 
 @dataclass(frozen=True)
@@ -228,6 +235,217 @@ def _unit_files(result: WorkUnitResult) -> List[Tuple[str, str]]:
 
 
 # ---------------------------------------------------------------------------
+# Zero-loss merge guarantee helpers (sha256 merge ledger + AST validation)
+# ---------------------------------------------------------------------------
+
+
+def _sha256_text(text: str) -> str:
+    """Deterministic content hash for the merge ledger.
+
+    Hashes the UTF-8 bytes of the patch content. Stable across processes so
+    the input ledger (built from the per-unit patches) and the output ledger
+    (built from the composed candidate's ``files``) are directly comparable.
+    """
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _build_input_ledger(
+    ordered_files: Sequence[Mapping[str, str]],
+) -> Tuple[Tuple[str, str], ...]:
+    """Build a deterministic, sorted ``(file_path, sha256(content))`` ledger.
+
+    Used for BOTH the input ledger (built from the per-unit union the moment
+    each patch is admitted) and the output ledger (re-derived from the
+    composed candidate's ``files`` just before VALIDATE/GATE). A pure function
+    of the (path, content) pairs -- sorting makes the comparison order-
+    independent so a re-ordering during the map-reduce can never masquerade as
+    a loss.
+    """
+    ledger = [
+        (str(entry["file_path"]), _sha256_text(str(entry["full_content"])))
+        for entry in ordered_files
+    ]
+    ledger.sort()
+    return tuple(ledger)
+
+
+def _prove_lossless(
+    input_ledger: Tuple[Tuple[str, str], ...],
+    output_files: Sequence[Mapping[str, str]],
+) -> Optional[str]:
+    """Mathematically prove the disjoint union is zero-loss + AST-valid.
+
+    Returns ``None`` when every invariant holds; otherwise returns a
+    ``"<which>: <detail>"`` string naming the FIRST failing invariant (the
+    caller wraps it into ``ComposeFailure(LOSSLESS_PROOF_FAILED, ...)`` so a
+    silent drop / overwrite / mutation / syntax break can NEVER leak to the
+    gates).
+
+    Invariants (first failure wins):
+
+    * ``count``   -- ``len(input_ledger) == len(output_files)`` (no patch
+      dropped, none duplicated by the union).
+    * ``content`` -- every input ``(path, sha)`` appears EXACTLY once in the
+      output ledger and vice-versa (no content dropped or silently mutated --
+      the composed file hashes back to its source unit's patch).
+    * ``overwrite`` -- no two output files share a ``file_path`` (the
+      collision-matrix invariant, re-proven over the ACTUAL composed hashes).
+    * ``ast`` -- each ``.py`` composed file ``ast.parse``-es cleanly; a unit
+      that produced syntactically-broken Python is caught HERE, before VALIDATE.
+      Non-Python files skip AST (but are still hash-conserved above).
+    """
+    output_ledger = _build_input_ledger(output_files)
+
+    # (1) Count conservation.
+    if len(input_ledger) != len(output_ledger):
+        return (
+            f"count: inputs={len(input_ledger)} != outputs={len(output_ledger)} "
+            "(a patch was dropped or duplicated by the union)"
+        )
+
+    # (3) No-overwrite -- duplicate output path means an overwrite happened.
+    out_paths = [str(entry["file_path"]) for entry in output_files]
+    if len(set(out_paths)) != len(out_paths):
+        from collections import Counter
+
+        dup = [p for p, n in Counter(out_paths).items() if n > 1]
+        return (
+            f"overwrite: output file_path(s) {sorted(dup)!r} appear more than "
+            "once (a patch overwrote another during the union)"
+        )
+
+    # (2) Content conservation -- the sorted ledgers must be byte-identical.
+    if input_ledger != output_ledger:
+        in_set = set(input_ledger)
+        out_set = set(output_ledger)
+        missing = sorted(in_set - out_set)
+        extra = sorted(out_set - in_set)
+        return (
+            "content: input (path, sha256) set != output set "
+            f"(dropped_or_mutated={missing!r} unexpected={extra!r})"
+        )
+
+    # (4) AST validity of composed Python files.
+    for entry in output_files:
+        path = str(entry["file_path"])
+        if not path.endswith(".py"):
+            continue
+        content = str(entry["full_content"])
+        try:
+            ast.parse(content, filename=path)
+        except SyntaxError as exc:
+            return (
+                f"ast: composed file {path!r} is not valid Python "
+                f"(line {exc.lineno}: {exc.msg})"
+            )
+
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Disjoint UNION (the existing map-reduce, extracted for the proof layer)
+# ---------------------------------------------------------------------------
+
+
+def _compose_ordered_files(
+    graph: ExecutionGraph,
+    unit_results: Mapping[str, WorkUnitResult],
+) -> Any:
+    """Build the deterministic disjoint UNION of per-unit patches.
+
+    Returns either ``(ordered_files, input_ledger)`` on a clean union, or a
+    :class:`ComposeFailure` on any fail-CLOSED union condition (no units /
+    unit-not-success / missing-patch / same-file collision / net-empty). The
+    ``input_ledger`` is the authoritative ``(path, sha256)`` ledger captured
+    from the patches AT admission time -- it is the ground truth the
+    post-compose proof checks the output against.
+
+    This is the same logic that previously lived inline in
+    :func:`compose_fanout_result`; extracting it lets the zero-loss proof run
+    over the composed result without duplicating the union.
+    """
+    units = tuple(getattr(graph, "units", ()) or ())
+    if not units:
+        return ComposeFailure(
+            reason=ComposeFailureReason.NO_UNITS,
+            detail="execution graph carries zero units",
+        )
+
+    ordered_files: List[Dict[str, str]] = []
+    seen_paths: Dict[str, str] = {}
+
+    for spec in units:
+        unit_id = str(getattr(spec, "unit_id", "") or "")
+        result = unit_results.get(unit_id)
+
+        # (2) Presence + terminal success.
+        if result is None:
+            return ComposeFailure(
+                reason=ComposeFailureReason.UNIT_NOT_SUCCESS,
+                detail=f"unit {unit_id!r} has no terminal result",
+                offending_unit_id=unit_id,
+            )
+        status = getattr(result, "status", None)
+        if status != WorkUnitState.COMPLETED:
+            status_val = getattr(status, "value", status)
+            return ComposeFailure(
+                reason=ComposeFailureReason.UNIT_NOT_SUCCESS,
+                detail=(
+                    f"unit {unit_id!r} status={status_val!r} "
+                    "(expected COMPLETED) -> legacy serial"
+                ),
+                offending_unit_id=unit_id,
+            )
+
+        # (3) Usable patch.
+        pairs = _unit_files(result)
+        if not pairs:
+            return ComposeFailure(
+                reason=ComposeFailureReason.UNIT_MISSING_PATCH,
+                detail=f"SUCCESS unit {unit_id!r} carried no usable patch content",
+                offending_unit_id=unit_id,
+            )
+
+        rationale = str(getattr(spec, "goal", "") or "") or (
+            f"composed from fan-out unit {unit_id}"
+        )
+
+        for file_path, full_content in pairs:
+            # (4) Disjointness invariant -- fail CLOSED on overlap.
+            prior = seen_paths.get(file_path)
+            if prior is not None:
+                return ComposeFailure(
+                    reason=ComposeFailureReason.COLLISION_INVARIANT_VIOLATED,
+                    detail=(
+                        f"file {file_path!r} claimed by both unit {prior!r} "
+                        f"and unit {unit_id!r}; collision-matrix disjointness "
+                        "invariant violated -> refusing silent merge"
+                    ),
+                    offending_unit_id=unit_id,
+                )
+            seen_paths[file_path] = unit_id
+            ordered_files.append(
+                {
+                    "file_path": file_path,
+                    "full_content": full_content,
+                    "rationale": rationale,
+                }
+            )
+
+    # (5) Defensive net-empty guard.
+    if not ordered_files:
+        return ComposeFailure(
+            reason=ComposeFailureReason.EMPTY_COMPOSITION,
+            detail="no files survived composition",
+        )
+
+    # Capture the authoritative INPUT ledger from the admitted patches -- this
+    # is the ground truth the post-compose zero-loss proof checks against.
+    input_ledger = _build_input_ledger(ordered_files)
+    return ordered_files, input_ledger
+
+
+# ---------------------------------------------------------------------------
 # Public: compose_fanout_result
 # ---------------------------------------------------------------------------
 
@@ -279,85 +497,45 @@ def compose_fanout_result(
     5. Net-empty union -> ``EMPTY_COMPOSITION`` (defensive; should be
        unreachable once 1-3 pass).
     """
-    units = tuple(getattr(graph, "units", ()) or ())
-    if not units:
-        return ComposeFailure(  # type: ignore[return-value]
-            reason=ComposeFailureReason.NO_UNITS,
-            detail="execution graph carries zero units",
-        )
-
     op_id = str(getattr(graph, "op_id", "") or "")
 
-    # Deterministic union: iterate units in GRAPH order. Each file is owned by
-    # exactly one unit (collision-matrix disjointness); a repeated path is a
-    # hard fail-CLOSED. ``seen_paths`` maps path -> the unit that first
-    # claimed it, for a precise collision detail string.
-    ordered_files: List[Dict[str, str]] = []
-    seen_paths: Dict[str, str] = {}
+    # Deterministic disjoint UNION (the existing map-reduce), extracted so the
+    # zero-loss proof can run over the result without duplicating union logic.
+    # Returns either ``(ordered_files, input_ledger)`` or a ComposeFailure.
+    composed = _compose_ordered_files(graph, unit_results)
+    if isinstance(composed, ComposeFailure):
+        return composed  # type: ignore[return-value]
+    ordered_files, input_ledger = composed
 
-    for spec in units:
-        unit_id = str(getattr(spec, "unit_id", "") or "")
-        result = unit_results.get(unit_id)
-
-        # (2) Presence + terminal success.
-        if result is None:
-            return ComposeFailure(  # type: ignore[return-value]
-                reason=ComposeFailureReason.UNIT_NOT_SUCCESS,
-                detail=f"unit {unit_id!r} has no terminal result",
-                offending_unit_id=unit_id,
-            )
-        status = getattr(result, "status", None)
-        if status != WorkUnitState.COMPLETED:
-            status_val = getattr(status, "value", status)
-            return ComposeFailure(  # type: ignore[return-value]
-                reason=ComposeFailureReason.UNIT_NOT_SUCCESS,
-                detail=(
-                    f"unit {unit_id!r} status={status_val!r} "
-                    "(expected COMPLETED) -> legacy serial"
-                ),
-                offending_unit_id=unit_id,
-            )
-
-        # (3) Usable patch.
-        pairs = _unit_files(result)
-        if not pairs:
-            return ComposeFailure(  # type: ignore[return-value]
-                reason=ComposeFailureReason.UNIT_MISSING_PATCH,
-                detail=f"SUCCESS unit {unit_id!r} carried no usable patch content",
-                offending_unit_id=unit_id,
-            )
-
-        rationale = str(getattr(spec, "goal", "") or "") or (
-            f"composed from fan-out unit {unit_id}"
-        )
-
-        for file_path, full_content in pairs:
-            # (4) Disjointness invariant -- fail CLOSED on overlap.
-            prior = seen_paths.get(file_path)
-            if prior is not None:
-                return ComposeFailure(  # type: ignore[return-value]
-                    reason=ComposeFailureReason.COLLISION_INVARIANT_VIOLATED,
-                    detail=(
-                        f"file {file_path!r} claimed by both unit {prior!r} "
-                        f"and unit {unit_id!r}; collision-matrix disjointness "
-                        "invariant violated -> refusing silent merge"
-                    ),
-                    offending_unit_id=unit_id,
-                )
-            seen_paths[file_path] = unit_id
-            ordered_files.append(
-                {
-                    "file_path": file_path,
-                    "full_content": full_content,
-                    "rationale": rationale,
-                }
-            )
-
-    # (5) Defensive net-empty guard.
-    if not ordered_files:
+    # ---------------------------------------------------------------------
+    # ZERO-LOSS MERGE GUARANTEE (verification layer over the disjoint union).
+    # Prove -- BEFORE the candidate reaches VALIDATE/GATE -- that every input
+    # unit's patch is present, byte-preserved (sha256), not overwritten, and
+    # AST-valid. ANY violation -> fail-CLOSED ComposeFailure -> legacy serial.
+    # A dropped / overwritten / mutated / syntactically-broken patch is now
+    # mathematically impossible to leak to the gates.
+    # ---------------------------------------------------------------------
+    proof_failure = _prove_lossless(input_ledger, ordered_files)
+    output_ledger = _build_input_ledger(ordered_files)
+    sha_match = input_ledger == output_ledger
+    ast_ok = not (
+        proof_failure is not None and proof_failure.startswith("ast")
+    )
+    logger.info(
+        "[DAGCompose] lossless proof: inputs=%d outputs=%d sha_match=%s "
+        "ast_ok=%s op=%s result=%s",
+        len(input_ledger),
+        len(output_ledger),
+        sha_match,
+        ast_ok,
+        op_id[:16],
+        "PASS" if proof_failure is None else f"FAIL({proof_failure.split(':', 1)[0]})",
+    )
+    if proof_failure is not None:
         return ComposeFailure(  # type: ignore[return-value]
-            reason=ComposeFailureReason.EMPTY_COMPOSITION,
-            detail="no files survived composition",
+            reason=ComposeFailureReason.LOSSLESS_PROOF_FAILED,
+            detail=f"lossless_proof_failed:{proof_failure}",
+            offending_unit_id="",
         )
 
     primary = ordered_files[0]
@@ -405,4 +583,8 @@ __all__ = [
     "ComposedCandidate",
     "compose_fanout_result",
     "dag_compose_enabled",
+    # Zero-loss merge guarantee surface (verification layer over the union).
+    "_build_input_ledger",
+    "_compose_ordered_files",
+    "_prove_lossless",
 ]

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -953,8 +953,13 @@ class UnifiedIntakeRouter:
         try:
             from backend.core.ouroboros.governance.a1_trace import (  # noqa: PLC0415
                 a1trace as _a1trace,
+                probe_ingest_order as _probe_ingest_order,
             )
             _a1trace("ingest", envelope.causal_id, router="attached")
+            # Deep emit-hop telemetry (Run #17): emit the order-assertion vs
+            # this goal's prior emit (MISSING if none -- the Run-#17 mode).
+            # Observe-only, fail-soft.
+            _probe_ingest_order(envelope.causal_id)
         except Exception:  # noqa: BLE001
             pass
         # 1. Dedup check

--- a/backend/core/ouroboros/governance/roadmap_orchestrator.py
+++ b/backend/core/ouroboros/governance/roadmap_orchestrator.py
@@ -686,13 +686,17 @@ class _TeeRouter:
         try:
             from backend.core.ouroboros.governance.a1_trace import (  # noqa: PLC0415
                 a1trace as _a1trace,
+                emit_probe as _emit_probe,
             )
-            _a1trace(
-                "emit",
+            _gid = (
                 getattr(envelope, "causal_id", None)
-                or getattr(envelope, "goal_id", "?"),
-                source="roadmap",
+                or getattr(envelope, "goal_id", "?")
             )
+            _a1trace("emit", _gid, source="roadmap")
+            # Deep emit-hop telemetry (Run #17): capture goal_id, emit_ts,
+            # source, orchestrator-enabled so a later missing/out-of-order
+            # emit self-diagnoses. Observe-only, fail-soft.
+            _emit_probe(_gid, source="roadmap")
         except Exception:  # noqa: BLE001
             pass
         if self._upstream is None:

--- a/tests/governance/test_a1_emit_probe.py
+++ b/tests/governance/test_a1_emit_probe.py
@@ -1,0 +1,143 @@
+"""A1 deep emit-hop telemetry — ``[A1Trace][emit-probe]`` regression spine.
+
+Run #17 failed the A1 auditor on ``a1trace:missing_or_out_of_order:emit``:
+the first hop (the roadmap orchestrator emitting a strategic GOAL) was
+missing or out of order vs the subsequent ``ingest`` hop. These tests pin
+the diagnostic probe that makes the locus self-explaining:
+
+- emit-then-ingest  -> ordered probe (emit_ts < ingest_ts, source=roadmap)
+- ingest-without-emit -> ``MISSING`` probe (the Run-#17 mode, non-roadmap)
+- orchestrator-off   -> probe records ``orchestrator_enabled=False``
+- probe exception    -> swallowed, emit/ingest unaffected (fail-soft)
+- gated OFF          -> no probe lines (byte-identical)
+
+The probe is observe-only: it never changes emit/ingest behaviour.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from backend.core.ouroboros.governance import a1_trace
+
+
+@pytest.fixture(autouse=True)
+def _reset_probe_state(monkeypatch):
+    # Probe defaults ON; clear the per-goal emit-ledger between tests so
+    # ordering assertions are isolated.
+    monkeypatch.delenv("JARVIS_A1_EMIT_PROBE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_A1_TRACE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_ROADMAP_ORCHESTRATOR_ENABLED", raising=False)
+    a1_trace.reset_emit_probe()
+    yield
+    a1_trace.reset_emit_probe()
+
+
+def _probe_lines(caplog):
+    return [
+        r.getMessage()
+        for r in caplog.records
+        if "[A1Trace][emit-probe]" in r.getMessage()
+    ]
+
+
+# --- (a) emit-then-ingest -> ordered probe --------------------------------
+
+
+def test_emit_then_ingest_records_ordered_probe(caplog):
+    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+        a1_trace.emit_probe("g-1", source="roadmap")
+        a1_trace.probe_ingest_order("g-1")
+    lines = _probe_lines(caplog)
+    assert any("goal=g-1" in m for m in lines), lines
+    final = [m for m in lines if "ingest_ts=" in m]
+    assert final, f"no ordering line emitted: {lines}"
+    msg = final[-1]
+    assert "ordered=True" in msg, msg
+    assert "source=roadmap" in msg, msg
+    assert "emit_ts=" in msg and "MISSING" not in msg, msg
+
+
+# --- (b) ingest-without-emit -> MISSING probe (Run-#17 mode) ---------------
+
+
+def test_ingest_without_emit_logs_missing(caplog):
+    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+        # No prior emit_probe for this goal — the sensor-op / Run-#17 mode.
+        a1_trace.probe_ingest_order("g-sensor")
+    lines = _probe_lines(caplog)
+    assert any("MISSING" in m and "goal=g-sensor" in m for m in lines), lines
+    miss = [m for m in lines if "MISSING" in m][-1]
+    # Self-explaining: the line names the likely cause.
+    assert "emit_ts=MISSING" in miss, miss
+    assert "ordered=False" in miss, miss
+
+
+# --- (c) orchestrator-off captured ----------------------------------------
+
+
+def test_orchestrator_off_is_captured(caplog, monkeypatch):
+    monkeypatch.setenv("JARVIS_ROADMAP_ORCHESTRATOR_ENABLED", "false")
+    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+        a1_trace.emit_probe("g-2", source="roadmap")
+    lines = _probe_lines(caplog)
+    assert any("orchestrator_enabled=False" in m for m in lines), lines
+
+
+def test_orchestrator_on_is_captured(caplog, monkeypatch):
+    monkeypatch.setenv("JARVIS_ROADMAP_ORCHESTRATOR_ENABLED", "true")
+    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+        a1_trace.emit_probe("g-3", source="roadmap")
+    lines = _probe_lines(caplog)
+    assert any("orchestrator_enabled=True" in m for m in lines), lines
+
+
+# --- (d) fail-soft + observe-only -----------------------------------------
+
+
+def test_probe_exception_is_swallowed(monkeypatch):
+    # Break the internal clock so the probe body raises; it must not escape.
+    monkeypatch.setattr(
+        a1_trace.time, "monotonic", lambda: (_ for _ in ()).throw(RuntimeError("boom"))
+    )
+    # Neither call may raise.
+    a1_trace.emit_probe("g-x", source="roadmap")
+    a1_trace.probe_ingest_order("g-x")
+
+
+def test_emit_probe_returns_none_observe_only():
+    # The probe is diagnostic — it returns nothing the caller can act on.
+    assert a1_trace.emit_probe("g-4", source="roadmap") is None
+    assert a1_trace.probe_ingest_order("g-4") is None
+
+
+# --- (e) gated OFF -> byte-identical (no probe lines) ----------------------
+
+
+def test_gated_off_emits_no_probe_lines(caplog, monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_EMIT_PROBE_ENABLED", "false")
+    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+        a1_trace.emit_probe("g-5", source="roadmap")
+        a1_trace.probe_ingest_order("g-5")
+    assert not _probe_lines(caplog)
+
+
+def test_master_trace_off_also_silences_probe(caplog, monkeypatch):
+    # The probe rides the same surface; killing the master A1Trace flag
+    # also silences the probe (defence in depth).
+    monkeypatch.setenv("JARVIS_A1_TRACE_ENABLED", "false")
+    with caplog.at_level(logging.WARNING, logger=a1_trace.logger.name):
+        a1_trace.emit_probe("g-6", source="roadmap")
+        a1_trace.probe_ingest_order("g-6")
+    assert not _probe_lines(caplog)
+
+
+# --- bounded ledger: no unbounded growth ----------------------------------
+
+
+def test_emit_ledger_is_bounded():
+    for i in range(5000):
+        a1_trace.emit_probe(f"g-{i}", source="roadmap")
+    # Bounded ring must not retain every goal forever.
+    assert a1_trace._emit_ledger_size() <= a1_trace._EMIT_LEDGER_MAX

--- a/tests/governance/test_dag_composer_lossless.py
+++ b/tests/governance/test_dag_composer_lossless.py
@@ -1,0 +1,299 @@
+"""Tests for the DAGComposer zero-loss merge guarantee (Slice 4b upgrade).
+
+Before the composed fan-out candidate is handed to VALIDATE/GATE, the composer
+MUST mathematically PROVE that every parallel unit's patch is present,
+byte-preserved, and AST-valid -- zero patches dropped or overwritten during the
+map-reduce union. This is a VERIFICATION layer over the existing disjoint UNION
+(``compose_fanout_result``) -- it proves what the Collision Matrix promised.
+
+Invariants pinned here:
+
+(1) Count conservation: ``len(input_patches) == len(output_files)``.
+(2) Content conservation: every input ``(file_path, sha256)`` appears EXACTLY
+    once in the output ledger (no content dropped or silently mutated).
+(3) No-overwrite: no two inputs map to the same output file_path (collision
+    invariant re-proven over the ACTUAL hashes at compose time).
+(4) AST validity: each composed ``.py`` file ``ast.parse`` cleanly; non-Python
+    files skip AST but stay hash-conserved.
+(5) Fail-CLOSED: ANY violation -> ``ComposeFailure(reason="lossless_proof_failed:<which>")``
+    -> the caller falls back to legacy serial. No partial merge reaches the gates.
+(6) Telemetry: a structured ``[DAGCompose] lossless proof: inputs=N outputs=M
+    sha_match=.. ast_ok=..`` line is emitted.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import time
+from typing import Dict, List, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    WorkUnitResult,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+from backend.core.ouroboros.governance.saga.saga_types import (
+    FileOp,
+    PatchedFile,
+    RepoPatch,
+)
+from backend.core.ouroboros.governance import dag_composer
+from backend.core.ouroboros.governance.dag_composer import (
+    ComposeFailure,
+    ComposeFailureReason,
+    ComposedCandidate,
+    compose_fanout_result,
+)
+
+
+# ---------------------------------------------------------------------------
+# Builders (mirror test_dag_composer.py)
+# ---------------------------------------------------------------------------
+
+
+def _spec(unit_id: str, file_path: str, goal: str = "") -> WorkUnitSpec:
+    return WorkUnitSpec(
+        unit_id=unit_id,
+        repo="jarvis",
+        goal=goal or f"edit {file_path}",
+        target_files=(file_path,),
+        owned_paths=(file_path,),
+    )
+
+
+def _graph(specs: List[WorkUnitSpec], op_id: str = "op-deadbeef") -> ExecutionGraph:
+    return ExecutionGraph(
+        graph_id="graph-test01",
+        op_id=op_id,
+        planner_id="parallel_dispatch.v1",
+        schema_version="wave3_item6_slice2.v1",
+        units=tuple(specs),
+        concurrency_limit=max(2, len(specs)),
+    )
+
+
+def _result(
+    unit_id: str,
+    file_path: str,
+    content: str,
+    *,
+    status: WorkUnitState = WorkUnitState.COMPLETED,
+    with_patch: bool = True,
+) -> WorkUnitResult:
+    patch = None
+    if with_patch:
+        patch = RepoPatch(
+            repo="jarvis",
+            files=(PatchedFile(path=file_path, op=FileOp.CREATE, preimage=None),),
+            new_content=((file_path, content.encode("utf-8")),),
+        )
+    now = time.monotonic_ns()
+    return WorkUnitResult(
+        unit_id=unit_id,
+        repo="jarvis",
+        status=status,
+        patch=patch,
+        attempt_count=1,
+        started_at_ns=now,
+        finished_at_ns=now,
+    )
+
+
+def _three_disjoint_valid() -> Tuple[ExecutionGraph, Dict[str, WorkUnitResult]]:
+    specs = [
+        _spec("unit-a", "pkg/a.py", goal="add a"),
+        _spec("unit-b", "pkg/b.py", goal="add b"),
+        _spec("unit-c", "pkg/c.py", goal="add c"),
+    ]
+    graph = _graph(specs)
+    results = {
+        "unit-a": _result("unit-a", "pkg/a.py", "# a\ndef a():\n    return 1\n"),
+        "unit-b": _result("unit-b", "pkg/b.py", "# b\ndef b():\n    return 2\n"),
+        "unit-c": _result("unit-c", "pkg/c.py", "# c\ndef c():\n    return 3\n"),
+    }
+    return graph, results
+
+
+def _sha(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# (1)/(2)/(3) Happy path: lossless proof PASSES, all hashes match.
+# ---------------------------------------------------------------------------
+
+
+def test_three_disjoint_valid_pass_lossless_proof():
+    graph, results = _three_disjoint_valid()
+    out = compose_fanout_result(graph, results)
+
+    assert isinstance(out, ComposedCandidate)
+    assert out.is_failure is False
+    cand = out.candidate
+    assert len(cand["files"]) == 3
+
+    # Content conservation -- each composed file hashes back to its source.
+    by_path = {e["file_path"]: e["full_content"] for e in cand["files"]}
+    assert _sha(by_path["pkg/a.py"]) == _sha("# a\ndef a():\n    return 1\n")
+    assert _sha(by_path["pkg/b.py"]) == _sha("# b\ndef b():\n    return 2\n")
+    assert _sha(by_path["pkg/c.py"]) == _sha("# c\ndef c():\n    return 3\n")
+
+
+# ---------------------------------------------------------------------------
+# (1) Count conservation: a drop (composer that loses a file) -> FAIL.
+# ---------------------------------------------------------------------------
+
+
+def test_dropped_file_fails_count_conservation(monkeypatch):
+    """Synthetic drop -- patch the union builder to silently lose one file.
+    The lossless proof MUST catch the count mismatch and fail CLOSED."""
+    graph, results = _three_disjoint_valid()
+
+    # Monkeypatch the union builder to silently drop one file post-union while
+    # keeping the (3-entry) input ledger intact -> count-conservation must trip.
+    orig = dag_composer._compose_ordered_files
+
+    def _lossy(graph_, unit_results_):
+        res = orig(graph_, unit_results_)
+        if isinstance(res, ComposeFailure):
+            return res
+        ordered, ledger = res
+        return ordered[:-1], ledger  # drop one -> count mismatch
+
+    monkeypatch.setattr(dag_composer, "_compose_ordered_files", _lossy)
+
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.LOSSLESS_PROOF_FAILED
+    assert "count" in out.detail
+
+
+# ---------------------------------------------------------------------------
+# (2) Content conservation: a mutation (hash != source) -> FAIL.
+# ---------------------------------------------------------------------------
+
+
+def test_mutated_content_fails_content_conservation(monkeypatch):
+    """Synthetic mutation -- the composed file content is silently changed so
+    its sha256 no longer matches the source unit's patch. The proof MUST catch
+    it (no silent mutation reaches the gates)."""
+    graph, results = _three_disjoint_valid()
+    orig = dag_composer._compose_ordered_files
+
+    def _mutate(graph_, unit_results_):
+        res = orig(graph_, unit_results_)
+        if isinstance(res, ComposeFailure):
+            return res
+        ordered, ledger = res
+        # Corrupt one composed file's content without touching the ledger.
+        ordered[0]["full_content"] = ordered[0]["full_content"] + "# TAMPERED\n"
+        return ordered, ledger
+
+    monkeypatch.setattr(dag_composer, "_compose_ordered_files", _mutate)
+
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.LOSSLESS_PROOF_FAILED
+    assert "content" in out.detail
+
+
+# ---------------------------------------------------------------------------
+# (4) AST validity: a syntactically-broken unit patch -> FAIL.
+# ---------------------------------------------------------------------------
+
+
+def test_syntactically_broken_python_fails_ast_validity():
+    graph, results = _three_disjoint_valid()
+    # unit-b emits broken Python.
+    results["unit-b"] = _result("unit-b", "pkg/b.py", "def b(:\n    pass\n")
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    assert out.reason == ComposeFailureReason.LOSSLESS_PROOF_FAILED
+    assert "ast" in out.detail
+    assert out.offending_unit_id == "unit-b" or "pkg/b.py" in out.detail
+
+
+# ---------------------------------------------------------------------------
+# (4) Non-Python files: hash-conserved, AST skipped, PASS.
+# ---------------------------------------------------------------------------
+
+
+def test_non_python_files_skip_ast_but_hash_conserved():
+    specs = [
+        _spec("unit-a", "docs/readme.md", goal="docs"),
+        _spec("unit-b", "config/data.json", goal="config"),
+    ]
+    graph = _graph(specs)
+    results = {
+        # Content that would NOT parse as Python -- must not be AST-checked.
+        "unit-a": _result("unit-a", "docs/readme.md", "# Title\nnot:python at all{\n"),
+        "unit-b": _result("unit-b", "config/data.json", '{"k": [1, 2,}\n'),
+    }
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposedCandidate)
+    by_path = {e["file_path"]: e["full_content"] for e in out.candidate["files"]}
+    assert _sha(by_path["docs/readme.md"]) == _sha("# Title\nnot:python at all{\n")
+    assert _sha(by_path["config/data.json"]) == _sha('{"k": [1, 2,}\n')
+
+
+# ---------------------------------------------------------------------------
+# (3) No-overwrite re-proven over actual hashes -> still collision fail.
+# ---------------------------------------------------------------------------
+
+
+def test_same_file_still_fails_closed_collision():
+    specs = [
+        _spec("unit-a", "pkg/shared.py"),
+        _spec("unit-b", "pkg/shared.py"),
+    ]
+    graph = _graph(specs)
+    results = {
+        "unit-a": _result("unit-a", "pkg/shared.py", "# a\npass\n"),
+        "unit-b": _result("unit-b", "pkg/shared.py", "# b\npass\n"),
+    }
+    out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposeFailure)
+    # The union-time collision guard fires first (before the proof), which is
+    # also a fail-CLOSED no-overwrite outcome.
+    assert out.reason in (
+        ComposeFailureReason.COLLISION_INVARIANT_VIOLATED,
+        ComposeFailureReason.LOSSLESS_PROOF_FAILED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (6) Telemetry line emits the right counts.
+# ---------------------------------------------------------------------------
+
+
+def test_lossless_proof_telemetry_line_emitted(caplog):
+    graph, results = _three_disjoint_valid()
+    with caplog.at_level(logging.INFO, logger="Ouroboros.DAGComposer"):
+        out = compose_fanout_result(graph, results)
+    assert isinstance(out, ComposedCandidate)
+    line = next(
+        (r.getMessage() for r in caplog.records if "lossless proof" in r.getMessage()),
+        None,
+    )
+    assert line is not None, "expected a [DAGCompose] lossless proof telemetry line"
+    assert "inputs=3" in line
+    assert "outputs=3" in line
+    assert "sha_match=" in line
+    assert "ast_ok=" in line
+
+
+# ---------------------------------------------------------------------------
+# Determinism: the proof does not perturb the composed candidate.
+# ---------------------------------------------------------------------------
+
+
+def test_proof_does_not_change_candidate_output():
+    graph, results = _three_disjoint_valid()
+    out1 = compose_fanout_result(graph, results)
+    out2 = compose_fanout_result(graph, results)
+    assert isinstance(out1, ComposedCandidate)
+    assert isinstance(out2, ComposedCandidate)
+    assert out1.candidate == out2.candidate

--- a/tests/integration/test_hermetic_l3_swarm.py
+++ b/tests/integration/test_hermetic_l3_swarm.py
@@ -1,0 +1,826 @@
+"""Hermetic L3 Concurrency Validator -- the $0 in-memory L3 fan-out proof rig.
+
+The L3 analog of ``test_hermetic_a1_matrix.py``. Where the A1 matrix proves the
+SENSE->DETECT->DISPATCH leg locally, this rig proves the downstream
+DISPATCH->FAN-OUT->RECOMPOSE leg: a collision-cleared set of import-isolated
+chaos targets fans out into N PARALLEL git-worktree subagents, each runs a
+simulated DoubleWord inference, the per-unit patches recompose into ONE
+multi-file candidate, and a worker failure fails CLOSED to the legacy serial
+path. All local, async, event-driven, in milliseconds, for $0 (NO GCP, NO real
+DW calls -- only the generation is stubbed; the orchestration is REAL).
+
+What is REAL here (not mocked):
+
+* A real ``git init`` fixture repo carrying 3 import-isolated pure-leaf
+  functions + their 3 GREEN pytests, committed.
+* The real ``DecomposableChaosInjector`` (``acquire_isolated_targets(3)`` /
+  ``do_inject_decomposable``) -- the same external saboteur the live-fire chaos
+  harness uses -- acquires the 3 mutually-isolated targets and plants the 3 RED
+  mutations against the FIXTURE repo.
+* The real zero-trust ``CollisionMatrix`` (``build_collision_matrix`` /
+  ``partition_parallel_safe``) -- proves the 3 disjoint targets partition into
+  exactly ONE parallel group (the matrix is the gate that authorizes fan-out).
+* The real ``SubagentScheduler`` + real ``GenerationSubagentExecutor`` + real
+  ``WorktreeManager`` -- the live scheduler drives the wave: real ``git worktree
+  add`` per unit, real concurrency batching, real worktree reap. Only the
+  generator inside the executor is a stub.
+* The real ``MemoryPressureGate`` consultation inside the scheduler (the RAM
+  backpressure cap the demo respects to protect the local host).
+* The real ``compose_fanout_result`` (DAGComposer) -- recomposes the terminal
+  scheduler results into ONE multi-file candidate of the exact shape the
+  orchestrator's multi-file APPLY path consumes.
+* The real ``[L3Telemetry]`` emits (per-unit worktree lifespan + simulated DW
+  cost + graph-aggregate).
+
+The ONLY bypassed boundary is the DoubleWord cloud edge -- a STUB generator
+that returns a real candidate (a fix for the unit's own file) + a ``cost_usd``
++ blocks on a per-unit ``asyncio.Event`` the test fires, so concurrency is
+DETERMINISTIC and event-driven, never sleep-based. Each worker captures the
+exact ``time.monotonic()`` (ms) it starts and finishes its simulated inference,
+so concurrency is PROVEN by OVERLAP of captured timestamps, not assumed.
+
+ACCEPTANCE BAR: this file GREEN ==
+  (a) the 3 collision-cleared targets partition into ONE parallel group,
+  (b) 3 worktrees are created concurrently (overlapping captured windows) and
+      ALL reaped (none leaked),
+  (c) the fan-out is event-driven (no sync sleeps) and the concurrency cap is
+      respected (RAM protection),
+  (d) ``[L3Telemetry]`` captures each worktree's lifespan + simulated DW cost +
+      a graph-aggregate,
+  (e) the DAGComposer recomposes EXACTLY 3 file-patches into ONE multi-file
+      candidate (zero dropped), and a simulated worker FAILURE ->
+      ``ComposeFailure`` -> legacy serial (no partial compose).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+import time
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, Iterator, List, Optional, Tuple
+
+import pytest
+
+# --- REAL L3 chassis (driven, not mocked) ---------------------------------
+from backend.core.ouroboros.governance.collision_matrix import (
+    CollisionVerdict,
+    build_collision_matrix,
+    partition_parallel_safe,
+)
+from backend.core.ouroboros.governance.dag_composer import (
+    ComposeFailureReason,
+    compose_fanout_result,
+)
+from backend.core.ouroboros.governance.memory_pressure_gate import (
+    FanoutDecision,
+    PressureLevel,
+    reset_default_gate,
+)
+from backend.core.ouroboros.governance.worktree_manager import WorktreeManager
+from backend.core.ouroboros.governance.autonomy.command_bus import CommandBus
+from backend.core.ouroboros.governance.autonomy.execution_graph_store import (
+    ExecutionGraphStore,
+)
+from backend.core.ouroboros.governance.autonomy.subagent_scheduler import (
+    GenerationSubagentExecutor,
+    SubagentScheduler,
+)
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    GraphExecutionPhase,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+
+# --- The real external saboteur (standalone script; load by path) ---------
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+if str(_REPO_ROOT / "scripts") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "scripts"))
+import chaos_injector_ast as ci  # noqa: E402
+
+
+# ===========================================================================
+# Fixture repo -- real git init, 3 import-isolated green leaves, 3 RED chaos
+# ===========================================================================
+
+
+def _git(root: Path, *args: str) -> None:
+    subprocess.run(
+        ["git", *args],
+        cwd=str(root),
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+
+
+# Three import-isolated pure-leaf functions. Each lives in its OWN module and
+# imports NOTHING from the others -> the zero-trust collision matrix proves
+# them pairwise DISJOINT -> they fan out as a single parallel group.
+_N_TARGETS = 3
+
+
+def _leaf_src(i: int) -> str:
+    # ``a + b + i`` is a pure leaf; the chaos injector flips ``+`` -> ``-``,
+    # turning the leaf's own green assertion RED while keeping it pure.
+    return f"def compute{i}(a, b):\n    return a + b + {i}\n"
+
+
+def _leaf_test_src(i: int) -> str:
+    return (
+        f"from src.calc{i} import compute{i}\n"
+        "\n"
+        "\n"
+        f"def test_compute{i}():\n"
+        f"    assert compute{i}(1, 2) == {3 + i}\n"
+    )
+
+
+@pytest.fixture
+def l3_chaos_repo(tmp_path: Path) -> Iterator[dict]:
+    """A real committed git repo: 3 import-isolated GREEN leaves, then the real
+    DecomposableChaosInjector plants 3 RED mutations (one per file).
+
+    Yields a dict carrying the repo ``root``, the absolute ``targets`` paths,
+    and the acquired ``ChaosTarget`` list (so the test asserts on real injector
+    output, not fabricated paths).
+    """
+    root = tmp_path / "l3_fixture"
+    src_dir = root / "src"
+    tests_dir = root / "tests"
+    src_dir.mkdir(parents=True)
+    tests_dir.mkdir(parents=True)
+    # ``conftest.py`` at root so ``from src.calcN import ...`` resolves.
+    (root / "conftest.py").write_text("")
+    (src_dir / "__init__.py").write_text("")
+
+    for i in range(_N_TARGETS):
+        (src_dir / f"calc{i}.py").write_text(_leaf_src(i))
+        (tests_dir / f"test_calc{i}.py").write_text(_leaf_test_src(i))
+
+    _git(root, "init", "-q")
+    _git(root, "config", "user.email", "hermetic-l3@matrix.local")
+    _git(root, "config", "user.name", "Hermetic L3 Matrix")
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "green isolated baseline")
+
+    # Drive the REAL injector against the fixture. JARVIS_CHAOS_TARGET_DIRS
+    # points it at the fixture's src/ (the only bypass: directing the saboteur
+    # at the fixture instead of backend/). Readiness probe off -- no live bus.
+    saved_dirs = os.environ.get("JARVIS_CHAOS_TARGET_DIRS")
+    saved_probe = os.environ.get("JARVIS_CHAOS_READINESS_PROBE_ENABLED")
+    os.environ["JARVIS_CHAOS_TARGET_DIRS"] = str(src_dir)
+    os.environ["JARVIS_CHAOS_READINESS_PROBE_ENABLED"] = "false"
+    try:
+        cfg = ci.InjectConfig(
+            repo_root=str(root), test_timeout_s=30.0, verify_green=True,
+        )
+        targets = ci.acquire_isolated_targets(cfg, n=_N_TARGETS)
+        assert len(targets) == _N_TARGETS, (
+            f"injector acquired {len(targets)}/{_N_TARGETS} isolated targets "
+            "(honest-fewer, NOT fabricated) -- fixture should yield exactly 3"
+        )
+        rc = ci.do_inject_decomposable(cfg, n=_N_TARGETS, require_exact=True)
+        assert rc == 0, f"decomposable inject failed rc={rc}"
+    finally:
+        if saved_dirs is None:
+            os.environ.pop("JARVIS_CHAOS_TARGET_DIRS", None)
+        else:
+            os.environ["JARVIS_CHAOS_TARGET_DIRS"] = saved_dirs
+        if saved_probe is None:
+            os.environ.pop("JARVIS_CHAOS_READINESS_PROBE_ENABLED", None)
+        else:
+            os.environ["JARVIS_CHAOS_READINESS_PROBE_ENABLED"] = saved_probe
+
+    # Commit the chaos so each worktree branches from a RED HEAD (the worktree
+    # is a fresh checkout of the committed tree; uncommitted chaos would not
+    # propagate to ``git worktree add``).
+    _git(root, "add", "-A")
+    _git(root, "commit", "-q", "-m", "chaos: 3 isolated RED leaves")
+
+    target_paths = [str(t.target_file) for t in targets]
+    yield {
+        "root": root,
+        "targets": target_paths,
+        "chaos_targets": targets,
+        "rel_targets": [
+            str(Path(p).relative_to(root)).replace(os.sep, "/")
+            for p in target_paths
+        ],
+    }
+
+
+# ===========================================================================
+# Omni-flag arming (in-process) + gate isolation
+# ===========================================================================
+
+_OMNI_FLAGS = {
+    "JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED": "true",
+    "JARVIS_WAVE3_PARALLEL_DISPATCH_ENFORCE": "true",
+    "JARVIS_WAVE3_DAG_COMPOSE_ENABLED": "true",
+    "JARVIS_SWARM_ORCHESTRATOR_ENABLED": "true",
+    "JARVIS_L3_TELEMETRY_ENABLED": "true",
+}
+
+
+@pytest.fixture(autouse=True)
+def _omni_flags_and_gate_isolation(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    for name, val in _OMNI_FLAGS.items():
+        monkeypatch.setenv(name, val)
+    # The default MemoryPressureGate is a process singleton -- reset before and
+    # after so a stub probe injected by one test can never leak into another.
+    reset_default_gate()
+    try:
+        yield
+    finally:
+        reset_default_gate()
+
+
+# ===========================================================================
+# Simulated DoubleWord inference -- a STUB generator, event-driven (NO sleeps)
+# ===========================================================================
+
+
+class _StubGeneration:
+    """Minimal generation result mirroring GenerationResult's consumed shape."""
+
+    def __init__(self, *, candidates: tuple, cost_usd: float) -> None:
+        self.is_noop = False
+        self.candidates = candidates
+        self.cost_usd = cost_usd
+
+
+class _SimulatedDWGenerator:
+    """A per-worker simulated DoubleWord inference.
+
+    * Returns a real candidate -- a *fix* for the unit's own target file (flips
+      the chaos ``-`` back to ``+``) so the patch is genuine, file-scoped, and
+      recomposable.
+    * Reports a ``cost_usd`` so [L3Telemetry] threads a real DW cost.
+    * BLOCKS on a per-unit ``asyncio.Event`` the test fires -- the inference
+      "finishes" only when the test resolves that unit's gate. This makes
+      concurrency deterministic + event-driven (no sleep is the sync mechanism).
+    * Captures ``time.monotonic()`` at start (gate await begins) and finish
+      (gate released) so the test PROVES overlap from real timestamps.
+    """
+
+    def __init__(
+        self,
+        *,
+        fix_by_relpath: Dict[str, str],
+        cost_by_unit: Dict[str, float],
+        gate_by_unit: Dict[str, asyncio.Event],
+        started_at: Dict[str, float],
+        finished_at: Dict[str, float],
+        active_now: List[str],
+        max_active_seen: List[int],
+        fail_units: Optional[set] = None,
+    ) -> None:
+        self._fix_by_relpath = fix_by_relpath
+        self._cost_by_unit = cost_by_unit
+        self._gate_by_unit = gate_by_unit
+        self._started_at = started_at
+        self._finished_at = finished_at
+        self._active_now = active_now
+        self._max_active_seen = max_active_seen
+        self._fail_units = fail_units or set()
+
+    @staticmethod
+    def _unit_id_from_ctx(ctx: Any) -> str:
+        # op_id is "<graph.op_id>:<unit_id>" (set by the executor).
+        op_id = str(getattr(ctx, "op_id", ""))
+        return op_id.rsplit(":", 1)[-1] if ":" in op_id else op_id
+
+    @staticmethod
+    def _relpath_from_ctx(ctx: Any) -> str:
+        tf = getattr(ctx, "target_files", ()) or ()
+        return str(tf[0]) if tf else ""
+
+    async def generate(self, ctx: Any, deadline: Any) -> Any:
+        unit_id = self._unit_id_from_ctx(ctx)
+        relpath = self._relpath_from_ctx(ctx)
+
+        # --- enter the simulated inference window (timestamped) ------------
+        self._started_at[unit_id] = time.monotonic()
+        self._active_now.append(unit_id)
+        self._max_active_seen[0] = max(self._max_active_seen[0], len(self._active_now))
+
+        gate = self._gate_by_unit.get(unit_id)
+        try:
+            if gate is not None:
+                # Event-driven barrier: block until the test fires this unit's
+                # gate. THIS is the synchronization mechanism -- not a sleep.
+                await asyncio.wait_for(gate.wait(), timeout=30.0)
+        finally:
+            self._finished_at[unit_id] = time.monotonic()
+            try:
+                self._active_now.remove(unit_id)
+            except ValueError:
+                pass
+
+        if unit_id in self._fail_units:
+            # Simulate a worker whose generation produced nothing usable ->
+            # no candidate survives validation -> the unit terminates FAILED.
+            return _StubGeneration(candidates=(), cost_usd=0.0)
+
+        fix = self._fix_by_relpath.get(relpath, "")
+        candidate = {"file_path": relpath, "full_content": fix}
+        return _StubGeneration(
+            candidates=(candidate,),
+            cost_usd=self._cost_by_unit.get(unit_id, 0.0),
+        )
+
+
+# ===========================================================================
+# Minimal event sink (the scheduler's emitter is best-effort + async)
+# ===========================================================================
+
+
+class _RecordingEventEmitter:
+    """Captures EventEnvelopes the scheduler emits (proves phase transitions)."""
+
+    def __init__(self) -> None:
+        self.events: List[Any] = []
+
+    async def emit(self, envelope: Any) -> None:
+        self.events.append(envelope)
+
+
+# ===========================================================================
+# Builders
+# ===========================================================================
+
+
+def _build_units(rel_targets: List[str]) -> Tuple[WorkUnitSpec, ...]:
+    """One work unit per isolated chaos file -- no dependencies (parallel)."""
+    return tuple(
+        WorkUnitSpec(
+            unit_id=f"u{i}",
+            repo="jarvis",
+            goal=f"repair {rel}",
+            target_files=(rel,),
+            owned_paths=(rel,),
+        )
+        for i, rel in enumerate(sorted(rel_targets))
+    )
+
+
+def _build_graph(units: Tuple[WorkUnitSpec, ...], *, concurrency_limit: int) -> ExecutionGraph:
+    return ExecutionGraph(
+        graph_id="l3-hermetic-graph",
+        op_id="op-l3-hermetic",
+        planner_id="hermetic-l3",
+        schema_version="2d.1",
+        units=units,
+        concurrency_limit=concurrency_limit,
+    )
+
+
+def _fix_content(rel: str) -> str:
+    """The 'fix' a simulated DW worker returns for its file: the green source
+    (flip the chaos ``-`` back to ``+``). Derived from the file basename so the
+    fix is genuine + file-scoped (NOT fabricated boilerplate)."""
+    stem = Path(rel).stem  # calcN
+    i = int(stem.replace("calc", ""))
+    return _leaf_src(i)
+
+
+async def _wait_until(
+    pred: Callable[[], bool], *, timeout: float, interval: float = 0.01
+) -> None:
+    """Await until *pred()* is truthy or *timeout* elapses (fully async)."""
+    async def _spin() -> None:
+        while not pred():
+            await asyncio.sleep(interval)
+    try:
+        await asyncio.wait_for(_spin(), timeout=timeout)
+    except asyncio.TimeoutError:
+        pass  # caller asserts on the predicate -> clear failure surface
+
+
+def _windows_overlap(
+    started: Dict[str, float], finished: Dict[str, float], unit_ids: List[str]
+) -> bool:
+    """True iff EVERY pair of unit execution windows [start, finish] overlaps --
+    the mathematical proof of concurrency (computed from captured timestamps,
+    never assumed)."""
+    for a in unit_ids:
+        for b in unit_ids:
+            if a >= b:
+                continue
+            # Overlap iff start_a <= finish_b AND start_b <= finish_a.
+            if not (started[a] <= finished[b] and started[b] <= finished[a]):
+                return False
+    return True
+
+
+# ===========================================================================
+# (A) COLLISION MATRIX -- 3 disjoint targets clear as ONE parallel group
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_collision_matrix_clears_three_as_one_parallel_group(
+    l3_chaos_repo: dict,
+) -> None:
+    """The zero-trust collision matrix proves the 3 import-isolated targets are
+    pairwise DISJOINT and partition into exactly ONE parallel group (no Oracle
+    needed -- disjointness comes from the disjoint ``target_files`` sets)."""
+    units = _build_units(l3_chaos_repo["rel_targets"])
+    assert len(units) == _N_TARGETS
+
+    # oracle=None: distinct files never set-overlap -> DISJOINT pairwise even
+    # under zero-trust (the import-coupling probe is only consulted when files
+    # could otherwise be coupled; distinct disjoint files short-circuit to
+    # DISJOINT via no set-overlap + no coupling edges, here proven via the
+    # injected-disjoint fixture). Provide a coupling-free oracle stub so the
+    # matrix resolves coupling deterministically rather than zero-trust-denying.
+    class _NoCouplingOracle:
+        def find_nodes_in_file(self, file_path: str) -> list:
+            # Each file has exactly one indexed node with no neighbours ->
+            # resolved + uncoupled (the real injector PROVED import-isolation).
+            return [type("N", (), {"file_path": file_path})()]
+
+        def get_dependencies(self, node: Any) -> list:
+            return []
+
+        def get_dependents(self, node: Any) -> list:
+            return []
+
+    oracle = _NoCouplingOracle()
+    matrix = build_collision_matrix(units, oracle=oracle)
+    for i in range(len(units)):
+        for j in range(i + 1, len(units)):
+            assert matrix.verdict(units[i].unit_id, units[j].unit_id) is (
+                CollisionVerdict.DISJOINT
+            ), f"{units[i].unit_id} vs {units[j].unit_id} not proven disjoint"
+
+    parallel_groups, sequential = partition_parallel_safe(units, oracle=oracle)
+    assert len(parallel_groups) == 1, (
+        f"expected ONE parallel group, got {len(parallel_groups)}"
+    )
+    assert len(parallel_groups[0]) == _N_TARGETS, (
+        "the one parallel group must hold all 3 disjoint units"
+    )
+    assert sequential == [], "no unit should be forced serial -- all 3 disjoint"
+
+
+# ===========================================================================
+# (B+C+D) FAN-OUT -- 3 concurrent worktree subagents, event-driven, telemetry
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_three_concurrent_worktree_subagents_event_driven(
+    l3_chaos_repo: dict,
+    tmp_path: Path,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Drive the REAL scheduler: 3 isolated units fan out into 3 concurrent git
+    worktrees (overlap proven by captured timestamps), the concurrency cap is
+    respected (RAM protection), all 3 worktrees are reaped, and [L3Telemetry]
+    captures each worktree's lifespan + simulated DW cost + a graph-aggregate.
+    """
+    root: Path = l3_chaos_repo["root"]
+    rel_targets: List[str] = l3_chaos_repo["rel_targets"]
+    units = _build_units(rel_targets)
+    # concurrency_limit = 3 so all three may run in one wave; the
+    # MemoryPressureGate is the dynamic cap the scheduler additionally honors.
+    graph = _build_graph(units, concurrency_limit=_N_TARGETS)
+
+    # --- Simulated DW wiring: per-unit gate + timestamp capture -----------
+    gate_by_unit = {u.unit_id: asyncio.Event() for u in units}
+    started_at: Dict[str, float] = {}
+    finished_at: Dict[str, float] = {}
+    active_now: List[str] = []
+    max_active_seen = [0]
+    cost_by_unit = {u.unit_id: 0.001 * (idx + 1) for idx, u in enumerate(units)}
+    fix_by_relpath = {rel: _fix_content(rel) for rel in rel_targets}
+
+    generator = _SimulatedDWGenerator(
+        fix_by_relpath=fix_by_relpath,
+        cost_by_unit=cost_by_unit,
+        gate_by_unit=gate_by_unit,
+        started_at=started_at,
+        finished_at=finished_at,
+        active_now=active_now,
+        max_active_seen=max_active_seen,
+    )
+
+    # --- REAL chassis: store + bus + emitter + executor + worktree mgr ----
+    store = ExecutionGraphStore(state_dir=tmp_path / "graph_state")
+    command_bus = CommandBus()
+    emitter = _RecordingEventEmitter()
+    worktree_base = tmp_path / "worktrees"
+    worktree_mgr = WorktreeManager(repo_root=root, worktree_base=worktree_base)
+    executor = GenerationSubagentExecutor(
+        generator=generator,
+        validation_runner=None,  # candidate is a .py we don't need to re-run
+        repo_roots={"jarvis": root},
+        worktree_manager=worktree_mgr,
+    )
+    scheduler = SubagentScheduler(
+        store=store,
+        command_bus=command_bus,
+        event_emitter=emitter,
+        executor=executor,
+        max_concurrent_graphs=1,
+    )
+
+    import logging
+
+    caplog.set_level(logging.INFO, logger="Ouroboros.SubagentScheduler")
+
+    await scheduler.start()
+    try:
+        submitted = await scheduler.submit(graph)
+        assert submitted, "scheduler refused the graph"
+
+        # Wait (event-driven) until ALL 3 workers have ENTERED their simulated
+        # inference -- i.e. all 3 worktrees are live simultaneously. This is the
+        # concurrency proof window: if the scheduler serialized them, only 1
+        # would ever be active and this wait would time out.
+        await _wait_until(
+            lambda: len(active_now) >= _N_TARGETS, timeout=20.0,
+        )
+        assert len(active_now) >= _N_TARGETS, (
+            f"expected {_N_TARGETS} workers concurrently active, "
+            f"only {len(active_now)} entered -- fan-out serialized"
+        )
+        # The worktree dirs exist NOW, while all 3 are mid-inference.
+        live_worktrees = sorted(p.name for p in worktree_base.iterdir()) if (
+            worktree_base.exists()
+        ) else []
+        assert len(live_worktrees) >= _N_TARGETS, (
+            f"expected {_N_TARGETS} live worktrees during fan-out, "
+            f"saw {live_worktrees}"
+        )
+
+        # Now release every worker's simulated DW inference (event-driven).
+        for ev in gate_by_unit.values():
+            ev.set()
+
+        terminal = await scheduler.wait_for_graph(graph.graph_id, timeout_s=25.0)
+    finally:
+        await scheduler.stop()
+
+    # --- (B) all units COMPLETED + concurrency proven by overlap ----------
+    assert terminal.phase is GraphExecutionPhase.COMPLETED, (
+        f"graph not COMPLETED: phase={terminal.phase} err={terminal.last_error}"
+    )
+    assert len(terminal.results) == _N_TARGETS
+    assert all(
+        r.status is WorkUnitState.COMPLETED for r in terminal.results.values()
+    ), "every fan-out unit must COMPLETE"
+
+    unit_ids = [u.unit_id for u in units]
+    assert set(started_at) == set(unit_ids) and set(finished_at) == set(unit_ids)
+    assert _windows_overlap(started_at, finished_at, unit_ids), (
+        "execution windows do not all overlap -- concurrency NOT proven "
+        f"(started={started_at} finished={finished_at})"
+    )
+    # The peak simultaneously-active count reached the full fan-out degree.
+    assert max_active_seen[0] == _N_TARGETS, (
+        f"peak concurrency {max_active_seen[0]} != {_N_TARGETS} (RAM-bound or serialized)"
+    )
+
+    # --- (C) concurrency cap respected (RAM protection) -------------------
+    # Peak concurrency never exceeded the scheduler's concurrency_limit (and,
+    # transitively, the MemoryPressureGate cap consulted inside the scheduler).
+    assert max_active_seen[0] <= graph.concurrency_limit, (
+        f"peak {max_active_seen[0]} exceeded concurrency cap {graph.concurrency_limit}"
+    )
+
+    # --- (B) all 3 worktrees reaped (none leaked) -------------------------
+    await _wait_until(
+        lambda: (not worktree_base.exists())
+        or not any(worktree_base.iterdir()),
+        timeout=10.0,
+    )
+    leaked = sorted(p.name for p in worktree_base.iterdir()) if (
+        worktree_base.exists()
+    ) else []
+    assert leaked == [], f"worktrees leaked (not reaped): {leaked}"
+
+    # --- (D) telemetry: per-unit lifespan + DW cost + graph-aggregate -----
+    per_unit_lines = [
+        rec.message for rec in caplog.records
+        if "[L3Telemetry] unit=" in rec.getMessage()
+    ]
+    assert len(per_unit_lines) >= _N_TARGETS, (
+        f"expected >={_N_TARGETS} per-unit [L3Telemetry] lines, got {len(per_unit_lines)}"
+    )
+    # Each unit result carries a real worktree lifespan + the simulated DW cost.
+    for uid, res in terminal.results.items():
+        assert res.worktree_lifespan_s is not None and res.worktree_lifespan_s >= 0.0, (
+            f"unit {uid} missing worktree lifespan telemetry"
+        )
+        assert res.dw_cost_usd == cost_by_unit[uid], (
+            f"unit {uid} DW cost {res.dw_cost_usd} != injected {cost_by_unit[uid]}"
+        )
+    agg_lines = [
+        rec.getMessage() for rec in caplog.records
+        if "[L3Telemetry] graph=" in rec.getMessage()
+    ]
+    assert agg_lines, "no graph-aggregate [L3Telemetry] line emitted"
+    expected_total = round(sum(cost_by_unit.values()), 6)
+    assert any(
+        f"total_dw_cost_usd={expected_total!r}" in line for line in agg_lines
+    ), f"graph-aggregate DW cost not {expected_total} in {agg_lines}"
+
+
+# ===========================================================================
+# (E) DAG COMPOSE -- exactly 3 patches -> ONE candidate (zero-loss)
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_dag_composer_recomposes_three_patches_into_one_candidate(
+    l3_chaos_repo: dict,
+    tmp_path: Path,
+) -> None:
+    """The terminal fan-out results recompose into EXACTLY ONE multi-file
+    candidate carrying all 3 disjoint per-file patches (zero dropped)."""
+    root: Path = l3_chaos_repo["root"]
+    rel_targets: List[str] = l3_chaos_repo["rel_targets"]
+    units = _build_units(rel_targets)
+    graph = _build_graph(units, concurrency_limit=_N_TARGETS)
+
+    terminal = await _run_fanout_to_terminal(
+        graph, units, rel_targets, root, tmp_path,
+    )
+    assert terminal.phase is GraphExecutionPhase.COMPLETED
+
+    composed = compose_fanout_result(graph, terminal.results)
+    assert composed.is_failure is False, (
+        f"compose failed: {getattr(composed, 'reason', None)}"
+    )
+    assert composed.n_files == _N_TARGETS, (
+        f"composed {composed.n_files} files, expected {_N_TARGETS} (patch dropped!)"
+    )
+    # Exactly the 3 disjoint target files, no duplicates, no omissions.
+    assert set(composed.file_paths) == set(rel_targets)
+    assert len(composed.candidate["files"]) == _N_TARGETS
+    # The composed candidate is the orchestrator multi-file shape.
+    assert "file_path" in composed.candidate and "full_content" in composed.candidate
+    assert composed.candidate["composed_by"]  # lineage stamped
+
+
+@pytest.mark.asyncio
+async def test_worker_failure_fails_closed_to_serial_no_partial(
+    l3_chaos_repo: dict,
+    tmp_path: Path,
+) -> None:
+    """A simulated worker FAILURE -> the DAGComposer fails CLOSED
+    (ComposeFailure) -> legacy serial path. NO partial compose, no silent
+    patch loss."""
+    root: Path = l3_chaos_repo["root"]
+    rel_targets: List[str] = l3_chaos_repo["rel_targets"]
+    units = _build_units(rel_targets)
+    graph = _build_graph(units, concurrency_limit=_N_TARGETS)
+
+    # Fail exactly one worker (its simulated DW returns no usable candidate ->
+    # the unit terminates FAILED).
+    fail_unit = units[1].unit_id
+    terminal = await _run_fanout_to_terminal(
+        graph, units, rel_targets, root, tmp_path, fail_units={fail_unit},
+    )
+    # The graph itself terminates FAILED (a unit failed) -- never COMPLETED.
+    assert terminal.phase is not GraphExecutionPhase.COMPLETED
+
+    composed = compose_fanout_result(graph, terminal.results)
+    assert composed.is_failure is True, "compose must fail CLOSED on a failed unit"
+    assert composed.reason is ComposeFailureReason.UNIT_NOT_SUCCESS, (
+        f"expected UNIT_NOT_SUCCESS fail-closed, got {composed.reason}"
+    )
+    assert composed.offending_unit_id == fail_unit
+    # Fail-closed contract: NO ComposedCandidate, no partial union -> the caller
+    # falls back to the legacy serial walk (proven here by the absence of a
+    # composed candidate, not by a half-built one).
+    assert not hasattr(composed, "n_files")
+
+
+# ===========================================================================
+# (C) RAM backpressure -- the MemoryPressureGate cap is honored
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_memory_pressure_gate_clamps_fanout(
+    l3_chaos_repo: dict,
+    tmp_path: Path,
+) -> None:
+    """Under simulated HIGH memory pressure the scheduler clamps the fan-out to
+    the gate's per-level cap (RAM protection) -- proven by peak concurrency
+    never exceeding the cap, while ALL units still complete (overflow replayed,
+    zero work loss)."""
+    from backend.core.ouroboros.governance import memory_pressure_gate as mpg
+
+    root: Path = l3_chaos_repo["root"]
+    rel_targets: List[str] = l3_chaos_repo["rel_targets"]
+    units = _build_units(rel_targets)
+    graph = _build_graph(units, concurrency_limit=_N_TARGETS)
+
+    # Inject a HIGH-pressure probe (free_pct in [10,20) -> HIGH -> cap 3, but
+    # we tighten the HIGH cap to 1 so the clamp is observable on a 3-unit graph).
+    high_probe = mpg.MemoryProbe(
+        free_pct=15.0, total_bytes=16 * 1024**3,
+        available_bytes=int(0.15 * 16 * 1024**3), source="stub",
+    )
+    gate = mpg.MemoryPressureGate(probe_fn=lambda: high_probe)
+    mpg._default_gate = gate  # the scheduler pulls get_default_gate()
+    os.environ["JARVIS_MEMORY_PRESSURE_HIGH_FANOUT_CAP"] = "1"
+    try:
+        decision: FanoutDecision = gate.can_fanout(_N_TARGETS)
+        assert decision.level is PressureLevel.HIGH
+        assert decision.n_allowed == 1, "HIGH cap should clamp 3 -> 1"
+
+        terminal = await _run_fanout_to_terminal(
+            graph, units, rel_targets, root, tmp_path,
+            track_peak=True,
+        )
+    finally:
+        os.environ.pop("JARVIS_MEMORY_PRESSURE_HIGH_FANOUT_CAP", None)
+
+    # All units still COMPLETED -- overflow was deferred + replayed, not lost.
+    assert terminal.phase is GraphExecutionPhase.COMPLETED
+    assert len(terminal.results) == _N_TARGETS
+    # Peak concurrency was clamped to the gate cap (1), NOT the graph limit (3).
+    assert _PEAK_HOLDER[0] == 1, (
+        f"peak concurrency {_PEAK_HOLDER[0]} != gate cap 1 (RAM clamp not honored)"
+    )
+
+
+# ===========================================================================
+# Shared fan-out driver (real scheduler) used by (E) + RAM tests
+# ===========================================================================
+
+# Module-level peak holder the RAM test reads (set per-run inside the driver).
+_PEAK_HOLDER = [0]
+
+
+async def _run_fanout_to_terminal(
+    graph: ExecutionGraph,
+    units: Tuple[WorkUnitSpec, ...],
+    rel_targets: List[str],
+    root: Path,
+    tmp_path: Path,
+    *,
+    fail_units: Optional[set] = None,
+    track_peak: bool = False,
+) -> Any:
+    """Drive the REAL scheduler to a terminal state. Workers auto-release as
+    soon as they enter (event-driven via a pre-set gate) so the helper returns
+    the terminal GraphExecutionState. Returns the terminal state."""
+    gate_by_unit = {u.unit_id: asyncio.Event() for u in units}
+    # Pre-set every gate: each worker proceeds the moment it enters (still
+    # event-driven -- the Event is the barrier, never a sleep).
+    for ev in gate_by_unit.values():
+        ev.set()
+    started_at: Dict[str, float] = {}
+    finished_at: Dict[str, float] = {}
+    active_now: List[str] = []
+    max_active_seen = [0]
+    cost_by_unit = {u.unit_id: 0.002 for u in units}
+    fix_by_relpath = {rel: _fix_content(rel) for rel in rel_targets}
+
+    generator = _SimulatedDWGenerator(
+        fix_by_relpath=fix_by_relpath,
+        cost_by_unit=cost_by_unit,
+        gate_by_unit=gate_by_unit,
+        started_at=started_at,
+        finished_at=finished_at,
+        active_now=active_now,
+        max_active_seen=max_active_seen,
+        fail_units=fail_units,
+    )
+
+    store = ExecutionGraphStore(state_dir=tmp_path / f"gs_{graph.graph_id}")
+    command_bus = CommandBus()
+    emitter = _RecordingEventEmitter()
+    worktree_base = tmp_path / f"wt_{id(generator)}"
+    worktree_mgr = WorktreeManager(repo_root=root, worktree_base=worktree_base)
+    executor = GenerationSubagentExecutor(
+        generator=generator,
+        validation_runner=None,
+        repo_roots={"jarvis": root},
+        worktree_manager=worktree_mgr,
+    )
+    scheduler = SubagentScheduler(
+        store=store,
+        command_bus=command_bus,
+        event_emitter=emitter,
+        executor=executor,
+        max_concurrent_graphs=1,
+    )
+    await scheduler.start()
+    try:
+        assert await scheduler.submit(graph)
+        terminal = await scheduler.wait_for_graph(graph.graph_id, timeout_s=25.0)
+    finally:
+        await scheduler.stop()
+    if track_peak:
+        _PEAK_HOLDER[0] = max_active_seen[0]
+    return terminal


### PR DESCRIPTION
Hermetic L3 Concurrency Validator (local $0 async, 3 concurrent worktrees proven by timestamp overlap, simulated DW) + DAGComposer sha256 zero-loss guarantee + emit-hop telemetry probe (Run-#17 self-diagnosis). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a hermetic L3 fan‑out validator, a zero‑loss merge proof in the DAG composer, and an A1 emit‑hop telemetry probe to prevent silent patch loss and diagnose missing/out‑of‑order emits. This improves correctness, observability, and confidence in parallel recomposition.

- **New Features**
  - DAGComposer zero‑loss proof: verifies count, sha256 content, no‑overwrite, and `.py` AST validity before gating; failures return `LOSSLESS_PROOF_FAILED` with a clear detail and log a `[DAGCompose] lossless proof` line.
  - A1 emit‑hop probe: records `emit_ts` and compares against `ingest_ts`, capturing `source` and `orchestrator_enabled`; bounded ring buffer, fail‑soft, defaults on via `JARVIS_A1_EMIT_PROBE_ENABLED` (rides `JARVIS_A1_TRACE_ENABLED`) and consults `JARVIS_ROADMAP_ORCHESTRATOR_ENABLED`.
  - Hermetic L3 Concurrency Validator (local, async): drives real git worktrees and the scheduler with an event‑driven simulated generator to prove concurrent overlap, honor `MemoryPressureGate`, emit `[L3Telemetry]` (lifespan + cost), recompose exactly 3 patches into one candidate, and fail closed to serial on unit failure.

<sup>Written for commit 1ee8ccf2dd6fbe0df05dc9316a5834e015af1274. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

