### PR TITLE
feat(a1): Unified Provenance Ledger — dynamic provenance-aware auditor (fixes Run-#17 emit-hop)

### DIFF
--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -962,6 +962,19 @@ class UnifiedIntakeRouter:
             _probe_ingest_order(envelope.causal_id)
         except Exception:  # noqa: BLE001
             pass
+        # Unified Provenance Ledger -- stamp a tamper-evident hash-chained
+        # ProvenanceRecord{op_id, origin=SignalSource, ...} at THE ingestion
+        # point so the GraduationAuditor can validate the origin-correct
+        # pipeline (sensor ops legitimately have NO emit hop -- the Run-#17
+        # fix). Gated JARVIS_PROVENANCE_LEDGER_ENABLED (default on), fail-soft:
+        # a ledger error NEVER blocks ingestion; OFF is byte-identical.
+        try:
+            from backend.core.ouroboros.governance.provenance_ledger import (  # noqa: PLC0415
+                stamp_provenance as _stamp_provenance,
+            )
+            _stamp_provenance(envelope.causal_id, envelope.source)
+        except Exception:  # noqa: BLE001
+            pass
         # 1. Dedup check
         if self._is_duplicate(envelope):
             return "deduplicated"

--- a/backend/core/ouroboros/governance/intent/signals.py
+++ b/backend/core/ouroboros/governance/intent/signals.py
@@ -54,9 +54,48 @@ class SignalSource(str, Enum):
     ``SignalSource.VISION_SENSOR == "vision_sensor"`` is ``True`` (StrEnum
     semantics), so string-based consumers and typed consumers interoperate
     transparently.
+
+    Members mirror the ``_VALID_SOURCES`` whitelist in
+    ``governance.intake.intent_envelope`` so a typed consumer can classify any
+    envelope's ``source`` string into an origin CLASS without a hardcoded
+    if/elif of specific op-ids. Each member's *value* is the exact source
+    token an envelope carries, so ``SignalSource("roadmap") is
+    SignalSource.ROADMAP`` and ``SignalSource("test_failure") is
+    SignalSource.TEST_FAILURE``.
     """
 
+    # The strategic-GOAL origin: RoadmapOrchestrator EMITS via the ``emit``
+    # hop (a1trace("emit", ..., source="roadmap")). The ONLY origin whose
+    # pipeline begins with an ``emit`` hop.
+    ROADMAP = "roadmap"
+
+    # Sensor origins -- each ingests an envelope WITHOUT a prior ``emit`` hop
+    # (the Run-#17 mode). Sourced from the _VALID_SOURCES whitelist.
+    TEST_FAILURE = "test_failure"
+    AI_MINER = "ai_miner"
+    CAPABILITY_GAP = "capability_gap"
+    RUNTIME_HEALTH = "runtime_health"
+    EXPLORATION = "exploration"
+    BACKLOG = "backlog"
+    ARCHITECTURE = "architecture"
+    CU_EXECUTION = "cu_execution"
+    INTENT_DISCOVERY = "intent_discovery"
+    TODO_SCANNER = "todo_scanner"
+    DOC_STALENESS = "doc_staleness"
+    GITHUB_ISSUE = "github_issue"
+    PERFORMANCE_REGRESSION = "performance_regression"
+    CROSS_REPO_DRIFT = "cross_repo_drift"
+    SECURITY_ADVISORY = "security_advisory"
+    META_DORMANCY_ALARM = "meta_dormancy_alarm"
+    WEB_INTELLIGENCE = "web_intelligence"
+    AUTO_PROPOSED = "auto_proposed"
     VISION_SENSOR = "vision_sensor"
+    CADENCE_SYNTHETIC = "cadence_synthetic"
+    SWE_BENCH_PRO = "swe_bench_pro"
+    TEST_COVERAGE = "test_coverage"
+    VOICE_HUMAN = "voice_human"
+    CLI_EMERGENCY = "cli_emergency"
+    HUMAN_OVERRIDE = "human_override"
 
 
 # ---------------------------------------------------------------------------

--- a/backend/core/ouroboros/governance/provenance_ledger.py
+++ b/backend/core/ouroboros/governance/provenance_ledger.py
@@ -1,0 +1,391 @@
+"""Unified Provenance Ledger -- tamper-evident origin graph per IntentEnvelope.
+================================================================================
+
+Every :class:`IntentEnvelope` that arrives at the intake router is stamped with
+a hash-chained :class:`ProvenanceRecord` binding *op_id -> origin -> ingest_ts*.
+The records are cryptographically chained (``record_hash = sha256(prev_hash +
+canonical(payload))``) so a forged, dropped, or reordered record breaks the
+chain, which :meth:`ProvenanceLedger.verify_chain` detects.
+
+Why this exists (Run #17)
+-------------------------
+The A1 GraduationAuditor's ``A1_DISPATCH_PROVEN`` check expected the 5-hop
+sequence ``emit -> ingest -> dequeue -> submit -> accept``. But the ``emit`` hop
+is emitted ONLY by ``roadmap_orchestrator`` (source="roadmap"); a sensor op
+(TestFailure / OpportunityMiner / ...) ingests WITHOUT an emit BY DESIGN. The
+auditor wrongly failed an emit-less sensor op ``missing_or_out_of_order:emit``.
+
+The fix is provenance-awareness: this ledger records each envelope's ORIGIN
+(its :class:`SignalSource`) at ingestion, classified into an
+:class:`OriginClass`. The auditor then traverses the provenance to validate the
+pipeline THAT origin actually produces -- no hardcoded op-id -> pipeline map.
+
+Design constraints
+------------------
+- **Reuse, no new crypto**: the hash-chain idiom is the SAME one used by
+  ``command_node/biometric_audit_ledger`` (sha256 of prev-link + canonical
+  payload, GENESIS sentinel). Imported here.
+- **Origin from the enum, not op-ids**: :func:`classify_origin` maps a source
+  token to an :class:`OriginClass` via :class:`SignalSource` enum membership +
+  the ROADMAP-emits-only invariant -- NEVER a hardcoded if/elif of op-ids.
+- **Fail-soft**: a ledger error NEVER blocks ingestion. Every public entry is
+  wrapped so a stamp failure logs loudly but returns gracefully.
+- **Gated**: ``JARVIS_PROVENANCE_LEDGER_ENABLED`` (default ``"true"``). OFF is
+  byte-identical (no stamp, no log, no record).
+- **Append-only + bounded**: an in-memory ring (newest-wins) caps growth on
+  long soaks; the chain head is preserved so verification stays valid.
+"""
+from __future__ import annotations
+
+import collections
+import hashlib
+import json
+import logging
+import os
+import time
+from dataclasses import dataclass
+from enum import Enum
+from typing import Any, Deque, Dict, List, Optional
+
+# Reuse the EXISTING hash-chain idiom (no new crypto scheme): the GENESIS
+# sentinel + the ``sha256(prev_hash + canonical(payload))`` chain link shape
+# from command_node/biometric_audit_ledger. We canonicalize OUR payload fields
+# the same way (compact json.dumps, sort_keys) -- the construction is identical,
+# only the field set differs (provenance fields vs biometric fields).
+from backend.core.ouroboros.governance.command_node.biometric_audit_ledger import (
+    GENESIS_HASH,
+)
+from backend.core.ouroboros.governance.intent.signals import SignalSource
+
+logger = logging.getLogger(__name__)
+
+_ENV_ENABLED = "JARVIS_PROVENANCE_LEDGER_ENABLED"
+
+# Bounded ring: cap records held in memory on a long soak. Newest-wins FIFO
+# eviction. The CHAIN HEAD (last record_hash) is tracked separately so the
+# chain continues correctly even after the oldest records are evicted.
+_LEDGER_MAX_DEFAULT = 4096
+
+
+def ledger_enabled() -> bool:
+    """Return True unless ``JARVIS_PROVENANCE_LEDGER_ENABLED`` is explicitly
+    falsy. Default ON; OFF is byte-identical (no stamp emitted)."""
+    val = (os.environ.get(_ENV_ENABLED, "true") or "").strip().lower()
+    return val not in {"0", "false", "no", "off"}
+
+
+# ===========================================================================
+# OriginClass -- the pipeline a source's ops actually produce
+# ===========================================================================
+
+
+class OriginClass(str, Enum):
+    """The pipeline-shape class an envelope's origin produces.
+
+    * ``ROADMAP``  -- RoadmapOrchestrator ops EMIT (the ``emit`` hop fires);
+      their pipeline is ``emit -> ingest -> dequeue -> submit -> accept``.
+    * ``SENSOR``   -- every autonomous sensor (TestFailure / OpportunityMiner /
+      ...) ingests an envelope WITHOUT a prior emit; their pipeline is
+      ``ingest -> dequeue -> submit -> accept`` (NO emit -- this is VALID).
+    * ``UNKNOWN``  -- a source the enum does not recognize. The auditor grades
+      these UNVERIFIABLE (honest non-pass, never a fake-pass / bypass).
+    """
+
+    ROADMAP = "roadmap"
+    SENSOR = "sensor"
+    UNKNOWN = "unknown"
+
+
+def classify_origin(source: Any) -> OriginClass:
+    """Map an envelope ``source`` (string or :class:`SignalSource`) to an
+    :class:`OriginClass`.
+
+    Derivation is from the :class:`SignalSource` enum + the ROADMAP-emits-only
+    invariant -- NOT a hardcoded if/elif of specific op-ids:
+
+      * The source token is resolved against ``SignalSource`` membership. An
+        unrecognized token -> ``OriginClass.UNKNOWN``.
+      * ``SignalSource.ROADMAP`` is the ONLY origin whose pipeline begins with
+        an ``emit`` hop (RoadmapOrchestrator emits the strategic GOAL). It maps
+        to ``OriginClass.ROADMAP``.
+      * Every OTHER recognized source is an autonomous sensor that ingests
+        without a prior emit -> ``OriginClass.SENSOR``.
+
+    Pure; NEVER raises."""
+    try:
+        if isinstance(source, SignalSource):
+            member: Optional[SignalSource] = source
+        else:
+            token = str(source).strip()
+            if not token:
+                return OriginClass.UNKNOWN
+            try:
+                member = SignalSource(token)
+            except ValueError:
+                return OriginClass.UNKNOWN
+        # The ROADMAP origin is the sole emit-producing source. Every other
+        # recognized SignalSource is a sensor (ingest without emit).
+        if member is SignalSource.ROADMAP:
+            return OriginClass.ROADMAP
+        return OriginClass.SENSOR
+    except Exception:  # noqa: BLE001 -- classification must never raise
+        return OriginClass.UNKNOWN
+
+
+# ===========================================================================
+# ProvenanceRecord -- one tamper-evident chain link per envelope
+# ===========================================================================
+
+# The ordered, canonical payload fields hashed into the chain. Order is
+# load-bearing (it is part of the canonicalization). ``prev_hash`` and
+# ``record_hash`` are chain metadata, NOT part of the hashed payload -- the
+# SAME discipline as biometric_audit_ledger._PAYLOAD_FIELDS.
+_PAYLOAD_FIELDS = (
+    "op_id",
+    "origin",
+    "origin_class",
+    "ingested_ts",
+)
+
+
+@dataclass(frozen=True)
+class ProvenanceRecord:
+    """One immutable, hash-chained provenance link for an envelope.
+
+    ``record_hash = sha256(prev_hash + canonical({op_id, origin, origin_class,
+    ingested_ts}))`` -- so a forged / dropped / reordered record breaks the
+    chain (detected by :meth:`ProvenanceLedger.verify_chain`)."""
+
+    op_id: str
+    origin: str              # the raw source token (e.g. "test_failure")
+    origin_class: str        # OriginClass value (e.g. "sensor")
+    ingested_ts: float       # wall-clock ingest time
+    prev_hash: str
+    record_hash: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "op_id": self.op_id,
+            "origin": self.origin,
+            "origin_class": self.origin_class,
+            "ingested_ts": self.ingested_ts,
+            "prev_hash": self.prev_hash,
+            "record_hash": self.record_hash,
+        }
+
+
+def _canonical_payload(record: Dict[str, Any]) -> str:
+    """Deterministic canonical serialization of the hashed payload -- mirrors
+    biometric_audit_ledger._canonical_payload exactly (project onto the ordered
+    fields, compact separators, sort_keys) so the hash is stable + independent
+    of dict insertion order. ``prev_hash`` / ``record_hash`` are NOT hashed."""
+    ordered = {k: record.get(k) for k in _PAYLOAD_FIELDS}
+    return json.dumps(ordered, separators=(",", ":"), sort_keys=True)
+
+
+def compute_provenance_hash(prev_hash: str, payload: Dict[str, Any]) -> str:
+    """``sha256(prev_hash + canonical(payload))`` -- the chain link. Same
+    construction as biometric_audit_ledger.compute_record_hash, applied to the
+    provenance payload fields."""
+    h = hashlib.sha256()
+    h.update((prev_hash or GENESIS_HASH).encode("utf-8"))
+    h.update(_canonical_payload(payload).encode("utf-8"))
+    return h.hexdigest()
+
+
+# ===========================================================================
+# ProvenanceLedger -- append-only, bounded, hash-chained
+# ===========================================================================
+
+
+class ProvenanceLedger:
+    """In-memory, append-only, hash-chained provenance ledger.
+
+    Bounded: holds at most ``max_records`` records (newest-wins FIFO). The
+    chain head (last ``record_hash``) is tracked separately, so appends
+    continue the chain even after the oldest records are evicted, and
+    :meth:`verify_chain` validates the retained window from its first record.
+
+    Fail-soft: :meth:`append` NEVER raises -- a hash/append error logs loudly
+    and returns the computed record (or None) without blocking the caller."""
+
+    def __init__(self, *, max_records: Optional[int] = None) -> None:
+        if max_records is None:
+            raw = (os.environ.get("JARVIS_PROVENANCE_LEDGER_MAX", "") or "").strip()
+            try:
+                max_records = int(raw) if raw else _LEDGER_MAX_DEFAULT
+            except ValueError:
+                max_records = _LEDGER_MAX_DEFAULT
+        self.max_records = max(1, int(max_records))
+        self._records: Deque[ProvenanceRecord] = collections.deque(
+            maxlen=self.max_records
+        )
+        # The hash of the most-recent appended record -- the chain head. Stays
+        # valid across eviction (we never re-genesis on eviction).
+        self._head_hash: str = GENESIS_HASH
+
+    @property
+    def head_hash(self) -> str:
+        return self._head_hash
+
+    def append(
+        self,
+        *,
+        op_id: str,
+        origin: Any,
+        ingested_ts: Optional[float] = None,
+    ) -> Optional[ProvenanceRecord]:
+        """Append a hash-chained provenance record for an envelope. Returns the
+        record (with its hash) or None on failure. NEVER raises."""
+        try:
+            origin_token = (
+                origin.value if isinstance(origin, SignalSource) else str(origin)
+            )
+            origin_class = classify_origin(origin).value
+            ts = float(ingested_ts) if ingested_ts is not None else time.time()
+            payload = {
+                "op_id": str(op_id),
+                "origin": origin_token,
+                "origin_class": origin_class,
+                "ingested_ts": ts,
+            }
+            prev = self._head_hash
+            record_hash = compute_provenance_hash(prev, payload)
+            record = ProvenanceRecord(
+                op_id=str(op_id),
+                origin=origin_token,
+                origin_class=origin_class,
+                ingested_ts=ts,
+                prev_hash=prev,
+                record_hash=record_hash,
+            )
+            self._records.append(record)
+            self._head_hash = record_hash
+            return record
+        except Exception:  # noqa: BLE001 -- a ledger error NEVER blocks ingest
+            logger.warning(
+                "[Provenance] append failed for op=%s -- ingestion continues",
+                op_id,
+                exc_info=True,
+            )
+            return None
+
+    def verify_chain(self) -> bool:
+        """Recompute the retained window's chain; True iff every link is intact
+        (tamper-evident). Empty ledger -> True (vacuously valid). Any hash
+        mismatch / broken prev-link -> False. NEVER raises."""
+        try:
+            records = list(self._records)
+            if not records:
+                return True
+            prev = records[0].prev_hash
+            for rec in records:
+                if rec.prev_hash != prev:
+                    return False
+                expected = compute_provenance_hash(prev, rec.to_dict())
+                if rec.record_hash != expected:
+                    return False
+                prev = rec.record_hash
+            return True
+        except Exception:  # noqa: BLE001 -- any error -> NOT verified
+            logger.warning("[Provenance] verify_chain failed", exc_info=True)
+            return False
+
+    def records(self) -> List[ProvenanceRecord]:
+        """Read-only snapshot of the retained records (oldest-first)."""
+        return list(self._records)
+
+    def latest_for_op(self, op_id: str) -> Optional[ProvenanceRecord]:
+        """Most-recent retained record for ``op_id`` (or None)."""
+        for rec in reversed(self._records):
+            if rec.op_id == op_id:
+                return rec
+        return None
+
+    def clear(self) -> None:
+        """Reset the ledger to genesis (test hook + boot reset)."""
+        self._records.clear()
+        self._head_hash = GENESIS_HASH
+
+
+# ===========================================================================
+# Process-default ledger + the ingestion stamp entry point
+# ===========================================================================
+
+_DEFAULT_LEDGER: Optional[ProvenanceLedger] = None
+
+
+def get_default_ledger() -> ProvenanceLedger:
+    global _DEFAULT_LEDGER
+    if _DEFAULT_LEDGER is None:
+        _DEFAULT_LEDGER = ProvenanceLedger()
+    return _DEFAULT_LEDGER
+
+
+def reset_default_ledger() -> None:
+    """Test hook + boot reset for the process-default ledger."""
+    global _DEFAULT_LEDGER
+    _DEFAULT_LEDGER = None
+
+
+def stamp_provenance(
+    op_id: str,
+    origin: Any,
+    *,
+    ledger: Optional[ProvenanceLedger] = None,
+    ingested_ts: Optional[float] = None,
+) -> Optional[ProvenanceRecord]:
+    """Stamp a hash-chained provenance record at INGESTION and emit a
+    structured ``[Provenance] op=.. origin=.. origin_class=.. chain_ok=..``
+    line at WARNING level (so it survives ``silent_boot``).
+
+    Gated by ``JARVIS_PROVENANCE_LEDGER_ENABLED`` (default ON): when disabled
+    this is a silent no-op (byte-identical to no instrumentation).
+
+    Fail-soft: a ledger error NEVER blocks ingestion -- returns None and logs.
+    NEVER raises into the caller (the intake hot path)."""
+    if not ledger_enabled():
+        return None
+    try:
+        led = ledger if ledger is not None else get_default_ledger()
+        record = led.append(op_id=op_id, origin=origin, ingested_ts=ingested_ts)
+        if record is None:
+            # append already logged loudly; emit the structured line anyway so
+            # the auditor sees a (failed) stamp attempt.
+            logger.warning(
+                "[Provenance] op=%s origin=%s origin_class=%s chain_ok=False",
+                op_id,
+                origin.value if isinstance(origin, SignalSource) else origin,
+                classify_origin(origin).value,
+            )
+            return None
+        chain_ok = led.verify_chain()
+        logger.warning(
+            "[Provenance] op=%s origin=%s origin_class=%s chain_ok=%s",
+            record.op_id,
+            record.origin,
+            record.origin_class,
+            chain_ok,
+        )
+        return record
+    except Exception:  # noqa: BLE001 -- provenance NEVER blocks ingestion
+        logger.warning(
+            "[Provenance] stamp failed for op=%s -- ingestion continues",
+            op_id,
+            exc_info=True,
+        )
+        return None
+
+
+__all__ = [
+    "GENESIS_HASH",
+    "OriginClass",
+    "ProvenanceLedger",
+    "ProvenanceRecord",
+    "classify_origin",
+    "compute_provenance_hash",
+    "get_default_ledger",
+    "ledger_enabled",
+    "reset_default_ledger",
+    "stamp_provenance",
+]

--- a/scripts/a1_graduation_auditor.py
+++ b/scripts/a1_graduation_auditor.py
@@ -462,6 +462,49 @@ class OpLineageGraph:
 
 A1TRACE_HOPS: Tuple[str, ...] = ("emit", "ingest", "dequeue", "submit", "accept")
 
+# ---------------------------------------------------------------------------
+# Provenance-driven, origin-correct pipeline traversal (Run #17 fix)
+# ---------------------------------------------------------------------------
+#
+# THE BUG (run #17): the trace check required ALL five hops including ``emit``.
+# But the ``emit`` hop is produced ONLY by roadmap_orchestrator (source=
+# "roadmap"); a sensor op (TestFailure / OpportunityMiner / ...) ingests
+# WITHOUT an emit BY DESIGN. So an emit-less sensor op legitimately has no
+# ``emit`` hop, and the auditor wrongly failed it ``missing_or_out_of_order:
+# emit``.
+#
+# THE FIX: the auditor reads each op's ORIGIN from the Unified Provenance
+# Ledger's structured ``[Provenance]`` line (stamped at ingestion) -- after
+# verifying the hash-chain is intact (``chain_ok=True``) -- and validates the
+# pipeline THAT origin produces:
+#
+#   * SENSOR  -> ingest -> dequeue -> submit -> accept   (NO emit; VALID)
+#   * ROADMAP -> emit -> ingest -> dequeue -> submit -> accept
+#   * UNKNOWN / broken chain -> UNVERIFIABLE (honest, never a fake-pass /
+#     hardcoded bypass).
+#
+# The pipeline-to-validate is DERIVED from the origin CLASS -- there is NO
+# hardcoded op-id -> pipeline map. The origin class names + the per-class
+# required-hop sequences mirror ``governance.provenance_ledger.OriginClass``.
+
+# Origin-class -> the ordered hop sequence that origin's pipeline produces.
+# These mirror provenance_ledger.OriginClass semantics; SENSOR omits ``emit``.
+_PIPELINE_BY_ORIGIN: Dict[str, Tuple[str, ...]] = {
+    "sensor": ("ingest", "dequeue", "submit", "accept"),
+    "roadmap": ("emit", "ingest", "dequeue", "submit", "accept"),
+}
+
+# [Provenance] op=<id> origin=<src> origin_class=<class> chain_ok=<bool>
+_PROVENANCE_RE = re.compile(
+    r"\[Provenance\]\s+op=(?P<op>\S+)\s+origin=(?P<origin>\S+)\s+"
+    r"origin_class=(?P<klass>\S+)\s+chain_ok=(?P<chain>\S+)"
+)
+# [A1Trace][emit-probe] ... goal=<id> ... source=<src> -- the emit-probe also
+# witnesses an op's origin (roadmap vs non-roadmap) from the log stream alone.
+_EMIT_PROBE_SOURCE_RE = re.compile(
+    r"\[A1Trace\]\[emit-probe\].*goal=(?P<goal>\S+).*source=(?P<source>\S+)"
+)
+
 # [A1Trace] <hop> goal=<id> [k=v ...]
 _A1TRACE_RE = re.compile(r"\[A1Trace\]\s+(?P<hop>\w+)\s+goal=(?P<goal>\S+)")
 # [A1Trace] ... target_files=<csv> (optional extra kv carrying the op's files)
@@ -482,16 +525,94 @@ def parse_a1trace_line(line: str) -> Optional[Tuple[str, str]]:
         return None
 
 
+def parse_provenance_line(line: str) -> Optional[Tuple[str, str, str, bool]]:
+    """Parse one ``[Provenance] op=.. origin=.. origin_class=.. chain_ok=..``
+    line stamped by the Unified Provenance Ledger at ingestion. Returns
+    ``(op_id, origin, origin_class, chain_ok)`` or None. NEVER raises."""
+    try:
+        m = _PROVENANCE_RE.search(line)
+        if not m:
+            return None
+        chain = m.group("chain").strip().lower() in {"true", "1", "yes", "on"}
+        return m.group("op"), m.group("origin"), m.group("klass").lower(), chain
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def parse_emit_probe_source(line: str) -> Optional[Tuple[str, str]]:
+    """Parse the emit-probe's ``goal=`` + ``source=`` from an
+    ``[A1Trace][emit-probe]`` line. Returns ``(goal_id, source)`` or None.
+    A secondary origin witness when no explicit [Provenance] line is present.
+    NEVER raises."""
+    try:
+        m = _EMIT_PROBE_SOURCE_RE.search(line)
+        if not m:
+            return None
+        return m.group("goal"), m.group("source")
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _classify_origin_from_source(source: str) -> str:
+    """Derive an OriginClass VALUE ('sensor' / 'roadmap' / 'unknown') for a
+    raw source token. Reuses ``provenance_ledger.classify_origin`` (the SAME
+    enum-derived classifier the ingestion stamp uses) so the auditor and the
+    ledger agree -- no second hardcoded source map. Falls back to a minimal
+    local derivation only if the import is unavailable (standalone observer
+    outside the repo). NEVER raises."""
+    try:
+        import importlib
+
+        repo_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        backend = os.path.join(repo_root, "backend")
+        for entry in (backend, repo_root):
+            if entry not in sys.path:
+                sys.path.insert(0, entry)
+        for mod_path in (
+            "backend.core.ouroboros.governance.provenance_ledger",
+            "core.ouroboros.governance.provenance_ledger",
+        ):
+            try:
+                mod = importlib.import_module(mod_path)
+                return mod.classify_origin(source).value
+            except Exception:  # noqa: BLE001 -- try the next import path
+                continue
+    except Exception:  # noqa: BLE001
+        pass
+    # Minimal fallback: ROADMAP is the sole emit-producing origin; the empty /
+    # missing token is unknowable. Any other recognized-looking token defaults
+    # to SENSOR (the emit-less majority). This mirrors the enum invariant
+    # WITHOUT a hardcoded op-id list.
+    token = (source or "").strip().lower()
+    if not token:
+        return "unknown"
+    if token == "roadmap":
+        return "roadmap"
+    return "sensor"
+
+
 @dataclass
 class A1TraceTimeline:
-    """Tracks the ordered observation of the 5 A1Trace hops per goal id, plus a
-    global ordered-observation log. The criterion "5 hops in order" is met when
-    SOME goal id has all 5 hops observed in the canonical order."""
+    """Tracks the ordered observation of the A1Trace hops per goal id, plus a
+    global ordered-observation log.
+
+    Provenance-driven (Run #17 fix): the "hops in order" criterion is met when
+    SOME goal observed the hop sequence its ORIGIN actually produces:
+      * SENSOR  -> ingest -> dequeue -> submit -> accept   (NO emit)
+      * ROADMAP -> emit -> ingest -> dequeue -> submit -> accept
+    The per-goal origin class is fed via :meth:`set_origin` from the
+    ``[Provenance]`` line (or the emit-probe source) AFTER its hash-chain
+    verified intact. A goal whose origin is UNKNOWN or whose provenance chain
+    is broken is graded UNVERIFIABLE -- never a fake-pass / hardcoded bypass."""
 
     # goal_id -> list of (hop, ts) in observation order
     per_goal: Dict[str, List[Tuple[str, float]]] = field(default_factory=dict)
     # global ordered list of (hop, goal, ts)
     ordered: List[Tuple[str, str, float]] = field(default_factory=list)
+    # goal_id -> origin class ('sensor' / 'roadmap' / 'unknown')
+    origin_by_goal: Dict[str, str] = field(default_factory=dict)
+    # goal_ids whose provenance hash-chain was reported broken (chain_ok=False)
+    broken_chain_goals: set = field(default_factory=set)
 
     def observe(self, hop: str, goal_id: str, ts: Optional[float] = None) -> None:
         if hop not in A1TRACE_HOPS:
@@ -500,20 +621,69 @@ class A1TraceTimeline:
         self.per_goal.setdefault(goal_id, []).append((hop, ts))
         self.ordered.append((hop, goal_id, ts))
 
+    def set_origin(
+        self, goal_id: str, origin_class: str, *, chain_ok: bool = True
+    ) -> None:
+        """Record a goal's origin CLASS (from provenance). A broken chain
+        (``chain_ok=False``) marks the goal UNVERIFIABLE regardless of class."""
+        if not goal_id:
+            return
+        oc = (origin_class or "unknown").strip().lower()
+        if oc not in ("sensor", "roadmap"):
+            oc = "unknown"
+        self.origin_by_goal[goal_id] = oc
+        if not chain_ok:
+            self.broken_chain_goals.add(goal_id)
+
+    def set_origin_from_source(
+        self, goal_id: str, source: str, *, chain_ok: bool = True
+    ) -> None:
+        """Record a goal's origin from a raw source token (emit-probe witness),
+        classified via the SAME enum-derived classifier the ledger uses."""
+        self.set_origin(
+            goal_id, _classify_origin_from_source(source), chain_ok=chain_ok
+        )
+
+    def provenance_active(self) -> bool:
+        """True iff ANY provenance origin/chain signal was witnessed in this
+        stream. When False the auditor falls back to the LEGACY all-5-hops
+        (roadmap-shaped) check -- byte-identical pre-provenance behavior, so a
+        stream that never emits a [Provenance] line audits exactly as before."""
+        return bool(self.origin_by_goal) or bool(self.broken_chain_goals)
+
+    def required_hops(self, goal_id: str) -> Optional[Tuple[str, ...]]:
+        """The ordered hop sequence required for ``goal_id`` GIVEN its origin
+        class. Returns None when origin is UNKNOWN or the provenance chain was
+        reported broken (-> UNVERIFIABLE, never a fake-pass).
+
+        Legacy fallback: when NO provenance was witnessed anywhere in the
+        stream, every goal defaults to the full 5-hop roadmap pipeline (the
+        pre-provenance behavior) so existing audits stay byte-identical."""
+        if goal_id in self.broken_chain_goals:
+            return None
+        oc = self.origin_by_goal.get(goal_id)
+        if oc is None:
+            if not self.provenance_active():
+                # Pre-provenance stream -> legacy all-5-hops requirement.
+                return A1TRACE_HOPS
+            # Provenance is active but THIS goal had no witness -> indeterminate.
+            return None
+        return _PIPELINE_BY_ORIGIN.get(oc)  # None for 'unknown'
+
     def all_hops_in_order(self) -> bool:
-        """True iff some goal observed all 5 hops in canonical order."""
-        for goal_id, obs in self.per_goal.items():
-            if self._goal_in_order(obs):
-                return True
-        return False
+        """True iff some goal observed the hop sequence ITS ORIGIN produces, in
+        canonical order. Provenance-driven (Run #17 fix)."""
+        return self.winning_goal() is not None
 
     @staticmethod
-    def _goal_in_order(obs: Sequence[Tuple[str, float]]) -> bool:
-        # Walk the canonical hop list; each hop must appear at or after the
-        # index of the previous one in the observation sequence.
+    def _goal_in_order(
+        obs: Sequence[Tuple[str, float]], required: Sequence[str]
+    ) -> bool:
+        # Walk the REQUIRED hop list for this origin; each hop must appear at or
+        # after the index of the previous one in the observation sequence.
         seq = [h for h, _ in obs]
         cursor = 0
-        for hop in A1TRACE_HOPS:
+        for hop in required:
             found = -1
             for i in range(cursor, len(seq)):
                 if seq[i] == hop:
@@ -526,7 +696,8 @@ class A1TraceTimeline:
 
     def winning_goal(self) -> Optional[str]:
         for goal_id, obs in self.per_goal.items():
-            if self._goal_in_order(obs):
+            required = self.required_hops(goal_id)
+            if required and self._goal_in_order(obs, required):
                 return goal_id
         return None
 
@@ -537,6 +708,8 @@ class A1TraceTimeline:
             ],
             "all_hops_in_order": self.all_hops_in_order(),
             "winning_goal": self.winning_goal(),
+            "origin_by_goal": dict(self.origin_by_goal),
+            "broken_chain_goals": sorted(self.broken_chain_goals),
         }
 
 
@@ -901,6 +1074,24 @@ class A1GraduationAuditor:
         (e.g. ``[SemanticGuard]``, ``[IronGate]``). May raise (intervention)."""
         if not line:
             return
+        # Provenance line (origin stamp) -- record the goal's origin class +
+        # chain integrity so the trace check validates the ORIGIN-CORRECT
+        # pipeline (Run #17 fix). Checked BEFORE the A1Trace hop parse because a
+        # [Provenance] line is not an [A1Trace] hop line.
+        prov = parse_provenance_line(line)
+        if prov is not None:
+            op_id, _origin, origin_class, chain_ok = prov
+            self.trace.set_origin(op_id, origin_class, chain_ok=chain_ok)
+            return
+        # Emit-probe source witness -- a secondary origin signal (roadmap vs
+        # non-roadmap) when no explicit [Provenance] line was emitted. Does NOT
+        # override an existing provenance-stamped origin.
+        probe = parse_emit_probe_source(line)
+        if probe is not None:
+            goal, source = probe
+            if goal not in self.trace.origin_by_goal:
+                self.trace.set_origin_from_source(goal, source)
+            return
         # A1Trace hop?
         parsed = parse_a1trace_line(line)
         if parsed is not None:
@@ -1046,7 +1237,25 @@ class A1GraduationAuditor:
         winning = self.trace.winning_goal()
         if winning is not None:
             return []
-        # Report hops never observed for ANY goal.
+        # Origin-aware (Run #17 fix): if SOME goal has a determinate origin,
+        # report the hops missing for ITS required pipeline (sensor ops do NOT
+        # require ``emit``). Otherwise the origin itself is indeterminate ->
+        # UNVERIFIABLE rather than a false ``missing:emit``.
+        best: List[str] = []
+        for goal_id, obs in self.trace.per_goal.items():
+            required = self.trace.required_hops(goal_id)
+            if not required:
+                continue
+            seq = {h for (h, _t) in obs}
+            missing = [h for h in required if h not in seq]
+            if not best or len(missing) < len(best):
+                best = missing
+        if best:
+            return best
+        # No goal had a determinate (chain-verified, known) origin.
+        if self.trace.per_goal:
+            return ["unverifiable_origin"]
+        # Nothing observed at all.
         seen_hops = {h for (h, _g, _t) in self.trace.ordered}
         return [h for h in A1TRACE_HOPS if h not in seen_hops]
 

--- a/tests/governance/test_provenance_ledger.py
+++ b/tests/governance/test_provenance_ledger.py
@@ -1,0 +1,189 @@
+"""Unified Provenance Ledger -- tamper-evident hash-chained origin graph.
+
+Behavioural spine for ``governance.provenance_ledger``:
+
+* ingestion stamps a hash-chained ProvenanceRecord per envelope;
+* a tampered / dropped chain link is DETECTED (hash mismatch / broken prev);
+* ``classify_origin`` maps TestFailure -> SENSOR, RoadmapOrchestrator ->
+  ROADMAP from the SignalSource ENUM (no hardcoded op-id list);
+* an unknown source -> UNKNOWN (honest, never silently SENSOR);
+* fail-soft: a ledger error NEVER blocks ingestion;
+* gated: OFF flag -> stamp is a byte-identical no-op.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from backend.core.ouroboros.governance import provenance_ledger as pl
+from backend.core.ouroboros.governance.intent.signals import SignalSource
+
+
+# --- classify_origin: from the SignalSource ENUM, not a hardcoded op-id list -
+
+
+def test_classify_test_failure_is_sensor():
+    assert pl.classify_origin("test_failure") is pl.OriginClass.SENSOR
+    assert pl.classify_origin(SignalSource.TEST_FAILURE) is pl.OriginClass.SENSOR
+
+
+def test_classify_roadmap_is_roadmap():
+    assert pl.classify_origin("roadmap") is pl.OriginClass.ROADMAP
+    assert pl.classify_origin(SignalSource.ROADMAP) is pl.OriginClass.ROADMAP
+
+
+def test_classify_other_known_sensors_are_sensor():
+    # Every recognized SignalSource that is NOT roadmap is a sensor (ingest
+    # without emit). Derived from the enum -- no hardcoded op-id map.
+    for member in SignalSource:
+        if member is SignalSource.ROADMAP:
+            continue
+        assert pl.classify_origin(member) is pl.OriginClass.SENSOR, member
+
+
+def test_classify_unknown_source_is_unknown():
+    assert pl.classify_origin("not_a_real_source") is pl.OriginClass.UNKNOWN
+    assert pl.classify_origin("") is pl.OriginClass.UNKNOWN
+    assert pl.classify_origin(None) is pl.OriginClass.UNKNOWN
+
+
+def test_classify_never_raises_on_exotic_input():
+    class _Boom:
+        def __str__(self):  # noqa: D401
+            raise RuntimeError("boom")
+
+    assert pl.classify_origin(_Boom()) is pl.OriginClass.UNKNOWN
+
+
+# --- hash-chained ledger: stamp + tamper detection -------------------------
+
+
+def test_append_chains_records_from_genesis():
+    led = pl.ProvenanceLedger()
+    r1 = led.append(op_id="op-1", origin="test_failure", ingested_ts=1.0)
+    r2 = led.append(op_id="op-2", origin="roadmap", ingested_ts=2.0)
+    assert r1 is not None and r2 is not None
+    assert r1.prev_hash == pl.GENESIS_HASH
+    assert r2.prev_hash == r1.record_hash
+    assert led.verify_chain() is True
+
+
+def test_record_carries_origin_and_class():
+    led = pl.ProvenanceLedger()
+    r = led.append(op_id="op-1", origin="test_failure", ingested_ts=1.0)
+    assert r.origin == "test_failure"
+    assert r.origin_class == "sensor"
+    r2 = led.append(op_id="op-2", origin=SignalSource.ROADMAP, ingested_ts=2.0)
+    assert r2.origin == "roadmap"
+    assert r2.origin_class == "roadmap"
+
+
+def test_tampered_record_hash_is_detected():
+    led = pl.ProvenanceLedger()
+    led.append(op_id="op-1", origin="test_failure", ingested_ts=1.0)
+    led.append(op_id="op-2", origin="roadmap", ingested_ts=2.0)
+    assert led.verify_chain() is True
+    # Forge the first record's origin in place (frozen dataclass -> rebuild +
+    # splice into the internal deque to simulate on-the-wire tampering).
+    recs = led.records()
+    forged = pl.ProvenanceRecord(
+        op_id=recs[0].op_id,
+        origin="roadmap",  # tampered: was test_failure
+        origin_class=recs[0].origin_class,
+        ingested_ts=recs[0].ingested_ts,
+        prev_hash=recs[0].prev_hash,
+        record_hash=recs[0].record_hash,  # stale hash -> mismatch
+    )
+    led._records[0] = forged
+    assert led.verify_chain() is False
+
+
+def test_dropped_record_breaks_chain():
+    led = pl.ProvenanceLedger()
+    led.append(op_id="op-1", origin="test_failure", ingested_ts=1.0)
+    led.append(op_id="op-2", origin="roadmap", ingested_ts=2.0)
+    led.append(op_id="op-3", origin="ai_miner", ingested_ts=3.0)
+    # Drop the MIDDLE record -> op-3.prev_hash no longer matches op-1's hash.
+    del led._records[1]
+    assert led.verify_chain() is False
+
+
+def test_empty_ledger_is_vacuously_valid():
+    led = pl.ProvenanceLedger()
+    assert led.verify_chain() is True
+
+
+def test_bounded_ring_evicts_oldest_but_chain_head_persists():
+    led = pl.ProvenanceLedger(max_records=3)
+    for i in range(6):
+        led.append(op_id=f"op-{i}", origin="test_failure", ingested_ts=float(i))
+    recs = led.records()
+    assert len(recs) == 3  # bounded
+    assert recs[0].op_id == "op-3"  # oldest evicted
+    # The retained window still verifies (head_hash continuity preserved).
+    assert led.verify_chain() is True
+
+
+def test_latest_for_op_returns_record():
+    led = pl.ProvenanceLedger()
+    led.append(op_id="op-1", origin="test_failure", ingested_ts=1.0)
+    assert led.latest_for_op("op-1").origin == "test_failure"
+    assert led.latest_for_op("nope") is None
+
+
+# --- stamp_provenance: structured line, gating, fail-soft ------------------
+
+
+def test_stamp_emits_structured_line(caplog):
+    led = pl.ProvenanceLedger()
+    with caplog.at_level(logging.WARNING, logger=pl.logger.name):
+        pl.stamp_provenance("op-abc", "test_failure", ledger=led)
+    line = [r.getMessage() for r in caplog.records if "[Provenance]" in r.getMessage()]
+    assert line, "no [Provenance] line emitted"
+    msg = line[-1]
+    assert "op=op-abc" in msg
+    assert "origin=test_failure" in msg
+    assert "origin_class=sensor" in msg
+    assert "chain_ok=True" in msg
+
+
+def test_stamp_roadmap_origin_class(caplog):
+    led = pl.ProvenanceLedger()
+    with caplog.at_level(logging.WARNING, logger=pl.logger.name):
+        pl.stamp_provenance("op-r", SignalSource.ROADMAP, ledger=led)
+    msg = [r.getMessage() for r in caplog.records if "[Provenance]" in r.getMessage()][-1]
+    assert "origin_class=roadmap" in msg
+
+
+def test_stamp_off_flag_is_byte_identical_noop(caplog, monkeypatch):
+    monkeypatch.setenv("JARVIS_PROVENANCE_LEDGER_ENABLED", "false")
+    led = pl.ProvenanceLedger()
+    with caplog.at_level(logging.WARNING, logger=pl.logger.name):
+        result = pl.stamp_provenance("op-x", "test_failure", ledger=led)
+    assert result is None
+    assert not [r for r in caplog.records if "[Provenance]" in r.getMessage()]
+    assert led.records() == []  # nothing appended when OFF
+
+
+def test_stamp_never_raises_into_caller():
+    # A broken ledger must not propagate -- ingestion is the hot path.
+    class _ExplodingLedger:
+        def append(self, **_kw):
+            raise RuntimeError("disk full")
+
+        def verify_chain(self):
+            return True
+
+    # stamp_provenance swallows everything internally.
+    out = pl.stamp_provenance("op-x", "test_failure", ledger=_ExplodingLedger())
+    assert out is None
+
+
+def test_default_ledger_singleton_and_reset():
+    pl.reset_default_ledger()
+    a = pl.get_default_ledger()
+    b = pl.get_default_ledger()
+    assert a is b
+    pl.reset_default_ledger()
+    assert pl.get_default_ledger() is not a

--- a/tests/scripts/test_a1_provenance_auditor.py
+++ b/tests/scripts/test_a1_provenance_auditor.py
@@ -1,0 +1,197 @@
+"""A1 GraduationAuditor -- provenance-driven, origin-correct pipeline traversal.
+
+The Run-#17 fix: the auditor reads each op's ORIGIN (from the Unified
+Provenance Ledger's ``[Provenance]`` line, after the hash-chain verified
+intact) and validates the pipeline THAT origin produces:
+
+  * SENSOR  -> ingest -> dequeue -> submit -> accept   (NO emit -- VALID)
+  * ROADMAP -> emit -> ingest -> dequeue -> submit -> accept
+  * UNKNOWN / broken chain -> UNVERIFIABLE (no fake-pass, no hardcoded bypass).
+
+These tests drive the PURE auditor core (no network) via ``ingest_log_line``.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_SCRIPT = _REPO_ROOT / "scripts" / "a1_graduation_auditor.py"
+_spec = importlib.util.spec_from_file_location("a1_graduation_auditor", _SCRIPT)
+assert _spec is not None and _spec.loader is not None
+aud = importlib.util.module_from_spec(_spec)
+sys.modules["a1_graduation_auditor"] = aud
+_spec.loader.exec_module(aud)
+
+
+def _fresh_auditor(strict: bool = True):
+    # Empty flag set so the trace/origin logic is isolated from the flag audit.
+    return aud.A1GraduationAuditor(
+        flags=[], strict=strict, chaos_manifest_path=None,
+        lineage_scoping_enabled=False,
+    )
+
+
+# --- provenance line parsing -----------------------------------------------
+
+
+def test_parse_provenance_line():
+    out = aud.parse_provenance_line(
+        "WARNING [Provenance] op=op-1 origin=test_failure "
+        "origin_class=sensor chain_ok=True"
+    )
+    assert out == ("op-1", "test_failure", "sensor", True)
+
+
+def test_parse_provenance_line_chain_false():
+    out = aud.parse_provenance_line(
+        "[Provenance] op=op-9 origin=roadmap origin_class=roadmap chain_ok=False"
+    )
+    assert out == ("op-9", "roadmap", "roadmap", False)
+
+
+def test_parse_non_provenance_line_returns_none():
+    assert aud.parse_provenance_line("[A1Trace] ingest goal=op-1") is None
+
+
+# --- THE Run-#17 FIX: sensor op with NO emit is PROVEN ----------------------
+
+
+def test_sensor_origin_emitless_op_is_in_order():
+    a = _fresh_auditor()
+    # Provenance stamps op-S as a SENSOR origin (chain intact).
+    a.ingest_log_line(
+        "[Provenance] op=op-S origin=test_failure origin_class=sensor chain_ok=True"
+    )
+    # The sensor pipeline -- NO emit hop, by design.
+    for hop in ("ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-S")
+    assert a.trace.all_hops_in_order() is True
+    assert a.trace.winning_goal() == "op-S"
+
+
+def test_sensor_origin_emitless_op_full_verdict_proven():
+    a = _fresh_auditor()
+    a.ingest_log_line(
+        "[Provenance] op=op-S origin=test_failure origin_class=sensor chain_ok=True"
+    )
+    for hop in ("ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-S")
+    a.ingest_event("fsm_phase_changed", {"phase": "CLASSIFY", "op_id": "op-S"})
+    a.ingest_event("fsm_phase_changed", {"phase": "APPLY", "op_id": "op-S"})
+    a.ingest_event("operation_terminal", {"op_id": "op-S", "state": "applied"})
+    a.ingest_event("review_branch_created", {"op_id": "op-S"})
+    v = a.verdict()
+    # Trace + fsm + pr all hold; empty flag set -> flag audit passes; no
+    # intervention. A1_DISPATCH_PROVEN despite the missing emit hop.
+    assert v.criteria["a1trace_5_hops_in_order"] is True
+    assert v.proven is True, v.failure_locus
+
+
+# --- ROADMAP op MISSING emit still FAILS -----------------------------------
+
+
+def test_roadmap_origin_missing_emit_fails():
+    a = _fresh_auditor()
+    a.ingest_log_line(
+        "[Provenance] op=op-R origin=roadmap origin_class=roadmap chain_ok=True"
+    )
+    # Roadmap pipeline requires emit -- omit it.
+    for hop in ("ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-R")
+    assert a.trace.all_hops_in_order() is False
+    v = a.verdict()
+    assert v.criteria["a1trace_5_hops_in_order"] is False
+    assert "emit" in v.failure_locus
+
+
+def test_roadmap_origin_with_emit_is_in_order():
+    a = _fresh_auditor()
+    a.ingest_log_line(
+        "[Provenance] op=op-R origin=roadmap origin_class=roadmap chain_ok=True"
+    )
+    for hop in ("emit", "ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-R")
+    assert a.trace.all_hops_in_order() is True
+    assert a.trace.winning_goal() == "op-R"
+
+
+# --- tampered / unknown origin -> UNVERIFIABLE (not a fake-pass) ------------
+
+
+def test_broken_provenance_chain_is_unverifiable():
+    a = _fresh_auditor()
+    # chain_ok=False -> the origin cannot be trusted.
+    a.ingest_log_line(
+        "[Provenance] op=op-T origin=test_failure origin_class=sensor chain_ok=False"
+    )
+    for hop in ("ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-T")
+    # Even a perfectly-ordered sensor pipeline does NOT pass on a broken chain.
+    assert a.trace.all_hops_in_order() is False
+    assert "op-T" in a.trace.broken_chain_goals
+    v = a.verdict()
+    assert v.criteria["a1trace_5_hops_in_order"] is False
+
+
+def test_unknown_origin_is_unverifiable():
+    a = _fresh_auditor()
+    a.ingest_log_line(
+        "[Provenance] op=op-U origin=mystery origin_class=unknown chain_ok=True"
+    )
+    for hop in ("ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-U")
+    # Unknown origin -> no required pipeline -> not provable (no fake-pass).
+    assert a.trace.all_hops_in_order() is False
+    assert a.trace.required_hops("op-U") is None
+
+
+def test_no_hardcoded_bypass_unknown_never_passes_even_with_all_hops():
+    a = _fresh_auditor()
+    a.ingest_log_line(
+        "[Provenance] op=op-U origin=mystery origin_class=unknown chain_ok=True"
+    )
+    # Feed EVERY hop including emit -- an unknown origin must still not pass
+    # (the pipeline is DERIVED from origin class, never bypassed).
+    for hop in aud.A1TRACE_HOPS:
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-U")
+    assert a.trace.all_hops_in_order() is False
+
+
+# --- emit-probe source as a secondary origin witness -----------------------
+
+
+def test_emit_probe_source_classifies_origin():
+    a = _fresh_auditor()
+    # No explicit [Provenance] line; the emit-probe MISSING line carries source.
+    a.ingest_log_line(
+        "[A1Trace][emit-probe] MISSING goal=op-P emit_ts=MISSING ingest_ts=1.0 "
+        "ordered=False source=test_failure"
+    )
+    for hop in ("ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=op-P")
+    assert a.trace.origin_by_goal.get("op-P") == "sensor"
+    assert a.trace.all_hops_in_order() is True
+
+
+# --- legacy fallback: no provenance -> byte-identical all-5-hops -----------
+
+
+def test_no_provenance_legacy_all_five_hops_required():
+    a = _fresh_auditor()
+    # No [Provenance] line anywhere -> legacy roadmap-shaped check (all 5).
+    for hop in aud.A1TRACE_HOPS:
+        a.ingest_log_line(f"[A1Trace] {hop} goal=G-LEGACY")
+    assert a.trace.provenance_active() is False
+    assert a.trace.all_hops_in_order() is True
+
+
+def test_no_provenance_legacy_missing_emit_fails():
+    a = _fresh_auditor()
+    for hop in ("ingest", "dequeue", "submit", "accept"):
+        a.ingest_log_line(f"[A1Trace] {hop} goal=G-LEGACY")
+    # Legacy mode (no provenance) still requires emit -> fails (pre-fix behavior).
+    assert a.trace.all_hops_in_order() is False


### PR DESCRIPTION
Hash-chained ProvenanceGraph at ingestion (origin=SignalSource); auditor dynamically validates origin-correct pipeline (SENSOR no-emit / ROADMAP emit); tampered/unknown→UNVERIFIABLE. No hardcoded bypass. 71 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tamper‑evident Unified Provenance Ledger and makes the A1 GraduationAuditor origin‑aware, fixing the false “missing emit” failure for sensor ops (Run‑#17). Sensors now pass without an emit hop; roadmap still requires it.

- **New Features**
  - Stamps a hash‑chained `ProvenanceRecord` at ingestion (op_id, origin, origin_class, ts) via a bounded in‑memory ledger; gated by `JARVIS_PROVENANCE_LEDGER_ENABLED` (default on) and sized by `JARVIS_PROVENANCE_LEDGER_MAX`. Reuses `GENESIS_HASH` chain shape; fail‑soft so ingestion never blocks.
  - Expands `SignalSource` and derives `OriginClass` via `classify_origin` (enum‑based, no hardcoded op IDs).
  - Emits a structured line `[Provenance] op=… origin=… origin_class=… chain_ok=…`; auditor consumes it. Also reads `[A1Trace][emit-probe]` as a secondary origin signal.
  - Adds comprehensive tests for the ledger and the auditor’s provenance flow.

- **Bug Fixes**
  - Auditor validates the origin‑correct pipeline: SENSOR = ingest→dequeue→submit→accept (no emit), ROADMAP = emit→ingest→dequeue→submit→accept; unknown origin or broken chain → UNVERIFIABLE.
  - Falls back to legacy “all five hops” only when no provenance is present in the stream, keeping pre‑change behavior byte‑identical.
  - Removes any hardcoded bypass paths; classification and checks are driven by the provenance record.

<sup>Written for commit 21c55ce4ee14476f4a51e0910474a56c63887ff5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69717?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

