### PR TITLE
feat(a1): Omni-Soak harness wiring (omni overlay + decomposable 3-target inject)

### DIFF
--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -63,6 +63,10 @@ _AUDITOR_SCRIPT = os.path.join(_SCRIPTS_DIR, "a1_graduation_auditor.py")
 _HYPERVISOR_SCRIPT = os.path.join(_SCRIPTS_DIR, "sovereign_iac_hypervisor.py")
 _SENTINEL_SCRIPT = os.path.join(_SCRIPTS_DIR, "sovereign_sentinel.py")
 _LINUX_ENV_OVERLAY = os.path.join(_REPO_ROOT, "deploy", "ouroboros_linux_prod.env")
+# The Omni-Soak overlay: sources the linux base (superset) + flips the full
+# MAS / fan-out stack (WAVE3 parallel dispatch + DAG_COMPOSE + SWARM + the
+# REVIEW/PLAN enforce promotions + safe flags). Armed only under JARVIS_A1_OMNI_SOAK.
+_OMNI_ENV_OVERLAY = os.path.join(_REPO_ROOT, "deploy", "ouroboros_omni_prod.env")
 
 # Cost model for the remote node (e2-standard-8 Spot ~ $0.08/hr; see hypervisor).
 _NODE_COST_PER_HOUR = float(os.environ.get("JARVIS_A1_NODE_COST_PER_HOUR", "0.08"))
@@ -87,6 +91,24 @@ GraduationFailedException = _AUD.GraduationFailedException
 
 def _log(msg: str) -> None:
     print("[A1Harness] %s" % (msg,), flush=True)
+
+
+def _truthy(val: Optional[str]) -> bool:
+    """Standard env truthiness: 1/true/yes/on (case-insensitive)."""
+    return str(val or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def omni_soak_enabled(env: Optional[Dict[str, str]] = None) -> bool:
+    """Whether the Omni-Soak is armed via ``JARVIS_A1_OMNI_SOAK`` (default off).
+    When OFF the normal A1 soak is byte-identical (linux overlay + single inject)."""
+    src = env if env is not None else os.environ
+    return _truthy(src.get("JARVIS_A1_OMNI_SOAK"))
+
+
+def _selected_overlay_path(env: Optional[Dict[str, str]] = None) -> str:
+    """The env overlay to compose: the omni overlay when armed, else linux prod.
+    The omni env ``source``s the linux base, so it is a strict superset."""
+    return _OMNI_ENV_OVERLAY if omni_soak_enabled(env) else _LINUX_ENV_OVERLAY
 
 
 # ===========================================================================
@@ -188,8 +210,17 @@ def compose_env(*, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     caller. Precedence (lowest->highest): process env -> linux overlay -> derived
     cognitive flags -> orchestration-required flags."""
     env: Dict[str, str] = dict(base_env if base_env is not None else os.environ)
-    # 1. Linux production overlay (pytest 180s, AST pool, Claude-disabled autarky).
+    # 1. Production overlay. Always layer the linux base FIRST (pytest caps, AST
+    #    pool, Claude-disabled autarky) -- the omni env `source`s it in bash, which
+    #    the line-based parser cannot follow, so we compose the inheritance here.
+    #    Under JARVIS_A1_OMNI_SOAK we then layer the omni overlay ON TOP (the full
+    #    MAS / fan-out stack), making omni a strict superset. OFF -> linux only,
+    #    byte-identical to the normal A1 soak.
+    overlay_path = _selected_overlay_path(env)
     env.update(_parse_env_overlay(_LINUX_ENV_OVERLAY))
+    if overlay_path != _LINUX_ENV_OVERLAY:
+        env.update(_parse_env_overlay(overlay_path))
+    _log("overlay=%s" % ("omni" if overlay_path == _OMNI_ENV_OVERLAY else "linux_prod",))
     # 2. Every derived cognitive flag ON.
     flags = derive_cognitive_flags()
     for flag in flags:
@@ -300,6 +331,32 @@ class ChaosController:
             _log("chaos inject rc=%d stderr=%s" % (cp.returncode, (cp.stderr or "")[:200]))
         st = self.status()
         return bool(st.get("active")) and bool(st.get("test_red_post"))
+
+    def inject_decomposable(self, n: int = 3) -> "tuple":
+        """Inject N MUTUALLY-ISOLATED pure-leaf bugs (the DecomposableChaosInjector)
+        so the swarm fans out N-way into parallel L3 subagents. Subprocesses the
+        existing ``--inject-decomposable -n N`` CLI and parses its JSON status.
+
+        Returns ``(ok, count)`` where ``ok`` is True iff exactly N targets were
+        injected AND every one went RED (``test_red_post``). Reuses the same
+        ``_run`` / JSON plumbing as ``inject``; revert (the N-entry manifest) is
+        handled byte-identically by the existing ``--revert`` path."""
+        cp = self._run([
+            "--inject-decomposable", "-n", str(n), "--force",
+            "--repo-root", self.repo_root,
+            "--test-timeout", str(self.test_timeout_s),
+        ])
+        if cp.returncode != 0:
+            _log("chaos inject-decomposable rc=%d stderr=%s"
+                 % (cp.returncode, (cp.stderr or "")[:200]))
+        out = self._json_out(cp)
+        targets = out.get("targets") or []
+        count = int(out.get("count", len(targets)))
+        all_red = bool(targets) and all(
+            bool(t.get("test_red_post")) for t in targets
+        )
+        ok = (count == int(n)) and all_red
+        return (ok, count)
 
     def revert(self) -> bool:
         cp = self._run(["--revert", "--repo-root", self.repo_root])
@@ -784,6 +841,15 @@ class HarnessRun:
     autopsy_fn: Callable[..., Any] = local_autopsy
     stub_soak: bool = False
     stub_log_goal: str = "GOAL-A1-STUB"
+    # Omni-Soak: when True the inject step fans out a 3-way decomposable chaos set
+    # (3 mutually-isolated targets) so the MAS / swarm stack fans out 3-way. When
+    # False the inject step uses the single-target path (normal A1 soak, byte-
+    # identical). Set from JARVIS_A1_OMNI_SOAK at build time; default OFF.
+    omni_soak: bool = False
+    # The number of mutually-isolated targets to inject under the Omni-Soak. The 3
+    # targets themselves are DISCOVERED by the injector (not a literal list); this
+    # is only the fan-out width N.
+    omni_targets: int = 3
     env: Optional[Dict[str, str]] = None
     # Black Box Flight Recorder: when set (remote on-node runs), a FAILED verdict
     # runs the checksum-gated, fail-CLOSED teardown decision BEFORE any node burn.
@@ -821,9 +887,18 @@ class HarnessRun:
                 return 1
             _log("STEP preflight OK: %d candidate(s)" % (n,))
 
-            # b. INJECT (real bug, manifest, test confirmed RED).
-            _log("STEP inject: seed=%d" % (self.seed,))
-            red = self.chaos.inject(self.seed)
+            # b. INJECT (real bug, manifest, test confirmed RED). Under the Omni-
+            #    Soak the inject fans out a 3-way decomposable chaos set (3 mutually-
+            #    isolated targets) so the MAS / swarm stack actually fans out 3-way;
+            #    OFF -> the single-target path is byte-identical. Revert-ALWAYS (the
+            #    finally) covers BOTH the single + the N-entry manifest.
+            if self.omni_soak:
+                _log("STEP inject (omni): decomposable n=%d" % (self.omni_targets,))
+                red, decomp_count = self.chaos.inject_decomposable(self.omni_targets)
+            else:
+                _log("STEP inject: seed=%d" % (self.seed,))
+                red = self.chaos.inject(self.seed)
+                decomp_count = 0
             injected = True
             if not red:
                 if self.stub_soak:
@@ -837,6 +912,8 @@ class HarnessRun:
                     _log("STEP inject ABORT: test did not go RED post-injection")
                     verdict = {"proven": False, "failure_locus": "inject:not_red"}
                     return 1
+            elif self.omni_soak:
+                _log("STEP inject OK: %d decomposable targets RED" % (decomp_count,))
             else:
                 _log("STEP inject OK: bug live, test RED")
 
@@ -1131,6 +1208,7 @@ def build_dry_run_local(args: argparse.Namespace) -> HarnessRun:
         soak=None,
         auditor=auditor,
         stub_soak=bool(args.stub_soak),
+        omni_soak=omni_soak_enabled(),
     )
 
 
@@ -1156,6 +1234,7 @@ def build_live_run(args: argparse.Namespace) -> HarnessRun:
         soak=soak,
         auditor=auditor,
         env=env,
+        omni_soak=omni_soak_enabled(env),
     )
 
 

--- a/tests/scripts/test_a1_omni_soak_wiring.py
+++ b/tests/scripts/test_a1_omni_soak_wiring.py
@@ -1,0 +1,326 @@
+"""Omni-Soak wiring TDD spine.
+
+Proves the ``JARVIS_A1_OMNI_SOAK`` flag arms the omni activation overlay (full
+MAS / fan-out stack) + the DecomposableChaosInjector 3-target inject (3-way swarm
+fan-out) -- and that with the flag OFF the normal A1 soak is byte-identical (the
+linux prod overlay + single-target inject).
+
+Constraints mirror the harness: ``from __future__ import annotations``, Python
+3.9+, ASCII-only. No spend, no subprocess to the real injector -- the chaos
+``runner`` is mocked so we assert the exact argv the harness would subprocess.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "scripts", "a1_live_fire_chaos_harness.py",
+)
+_spec = importlib.util.spec_from_file_location("a1_live_fire_chaos_harness", _SCRIPT)
+assert _spec and _spec.loader
+harness = importlib.util.module_from_spec(_spec)
+sys.modules["a1_live_fire_chaos_harness"] = harness
+_spec.loader.exec_module(harness)
+
+
+# ===========================================================================
+# Fakes (mirror test_a1_live_fire_harness.py so the sequence test composes).
+# ===========================================================================
+
+
+class FakeChaos:
+    """Records the chaos lifecycle calls in order -- supports BOTH the single
+    ``inject`` and the decomposable ``inject_decomposable`` paths."""
+
+    def __init__(self, *, candidates=3, inject_red=True, decomp_count=3):
+        self.calls = []
+        self._candidates = candidates
+        self._inject_red = inject_red
+        self._decomp_count = decomp_count
+
+    def status(self):
+        self.calls.append("status")
+        return {"active": False}
+
+    def list_candidates(self):
+        self.calls.append("list_candidates")
+        return self._candidates
+
+    def inject(self, seed):
+        self.calls.append(("inject", seed))
+        return self._inject_red
+
+    def inject_decomposable(self, n=3):
+        self.calls.append(("inject_decomposable", n))
+        return (self._inject_red, self._decomp_count)
+
+    def revert(self):
+        self.calls.append("revert")
+        return True
+
+
+class FakeSoak:
+    def __init__(self, debug_log):
+        self._debug_log = debug_log
+        self.calls = []
+
+    def launch(self, env, run_dir):
+        self.calls.append(("launch", run_dir, env))
+        return harness.SoakHandle(debug_log=self._debug_log, session_dir=run_dir, proc=None)
+
+    def stop(self):
+        self.calls.append("stop")
+
+
+class FakeAuditor:
+    def __init__(self, *, proven=True):
+        self._proven = proven
+        self.calls = []
+
+    def watch(self, *, base, log_file, timeout_s, verdict_out):
+        self.calls.append(("watch", base, log_file))
+        verdict = {"verdict": "proven" if self._proven else "failed", "proven": self._proven}
+        Path(verdict_out).write_text(json.dumps(verdict))
+        return verdict
+
+
+def _make_run(tmp_path, *, chaos, soak, auditor, **kw):
+    return harness.HarnessRun(
+        run_id="omni-test-run",
+        run_root=str(tmp_path / "a1_runs"),
+        autopsy_root=str(tmp_path / "a1_autopsy"),
+        cost_cap=0.0,
+        wall_seconds=120,
+        seed=7,
+        sse_base="http://127.0.0.1:8099",
+        chaos=chaos,
+        soak=soak,
+        auditor=auditor,
+        **kw,
+    )
+
+
+# ===========================================================================
+# 1. compose_env overlay selection: OFF -> linux prod, ON -> omni.
+# ===========================================================================
+
+
+def test_omni_flag_off_loads_linux_overlay(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_OMNI_SOAK", raising=False)
+    monkeypatch.delenv("JARVIS_A1_AUDIT_FLAGS", raising=False)
+    env = harness.compose_env()
+    # Linux prod overlay keys present.
+    assert env.get("JARVIS_PROVIDER_CLAUDE_DISABLED") == "true"
+    # The omni-only MAS flags are NOT injected by the linux overlay.
+    assert "JARVIS_SWARM_ORCHESTRATOR_ENABLED" not in _overlay_only(harness, omni=False)
+
+
+def test_omni_flag_on_loads_omni_overlay(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_OMNI_SOAK", "1")
+    monkeypatch.delenv("JARVIS_A1_AUDIT_FLAGS", raising=False)
+    env = harness.compose_env()
+    # The omni overlay sources the linux base (superset) AND adds the MAS stack.
+    assert env.get("JARVIS_PROVIDER_CLAUDE_DISABLED") == "true", "linux base inherited"
+    assert env.get("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED") == "true"
+    assert env.get("JARVIS_SWARM_ORCHESTRATOR_ENABLED") == "true"
+    assert env.get("JARVIS_WAVE3_DAG_COMPOSE_ENABLED") == "true"
+
+
+def test_omni_overlay_is_a_superset_of_linux(monkeypatch):
+    """OFF env must be byte-identical to the linux overlay (no omni keys leak)."""
+    monkeypatch.delenv("JARVIS_A1_AUDIT_FLAGS", raising=False)
+    linux = _overlay_only(harness, omni=False)
+    omni = _overlay_only(harness, omni=True)
+    # Every linux key is in omni (superset), and omni adds the MAS flags.
+    for k, v in linux.items():
+        assert omni.get(k) == v, "omni must inherit linux base byte-identical for %s" % k
+    assert "JARVIS_SWARM_ORCHESTRATOR_ENABLED" in omni
+    assert "JARVIS_SWARM_ORCHESTRATOR_ENABLED" not in linux
+
+
+def _overlay_only(h, *, omni):
+    """The composed overlay dict the harness would merge (no process env noise).
+    The omni env ``source``s the linux base in bash, which the line parser cannot
+    follow, so the harness composes the inheritance: linux base first, omni on top.
+    """
+    merged = dict(h._parse_env_overlay(h._LINUX_ENV_OVERLAY))
+    if omni:
+        merged.update(h._parse_env_overlay(h._OMNI_ENV_OVERLAY))
+    return merged
+
+
+def test_overlay_selection_helper(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_OMNI_SOAK", raising=False)
+    assert harness.omni_soak_enabled() is False
+    assert harness._selected_overlay_path() == harness._LINUX_ENV_OVERLAY
+    monkeypatch.setenv("JARVIS_A1_OMNI_SOAK", "true")
+    assert harness.omni_soak_enabled() is True
+    assert harness._selected_overlay_path() == harness._OMNI_ENV_OVERLAY
+
+
+# ===========================================================================
+# 2. inject_decomposable parses the decomposable JSON.
+# ===========================================================================
+
+
+def _decomp_runner(count, *, all_red=True):
+    """A fake subprocess runner returning the decomposable injector JSON."""
+    import subprocess as _sp
+
+    def run(argv):
+        if "--inject-decomposable" in argv:
+            payload = {
+                "status": "injected_decomposable",
+                "count": count,
+                "requested_n": count,
+                "targets": [
+                    {
+                        "target_file": "pkg/mod_%d.py" % i,
+                        "function": "fn_%d" % i,
+                        "line": 10 + i,
+                        "mutation_kind": "comparison_flip",
+                        "test_node": "tests/test_%d.py::test_fn_%d" % (i, i),
+                        "test_red_post": all_red,
+                    }
+                    for i in range(count)
+                ],
+            }
+            return _sp.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+        if "--status" in argv:
+            return _sp.CompletedProcess(argv, 0, stdout=json.dumps({"active": True}), stderr="")
+        return _sp.CompletedProcess(argv, 0, stdout="{}", stderr="")
+
+    return run
+
+
+def test_inject_decomposable_parses_json_ok():
+    cc = harness.ChaosController(runner=_decomp_runner(3, all_red=True))
+    ok, count = cc.inject_decomposable(3)
+    assert ok is True
+    assert count == 3
+
+
+def test_inject_decomposable_subprocesses_correct_cli(monkeypatch):
+    seen = {}
+
+    import subprocess as _sp
+
+    def run(argv):
+        seen["argv"] = list(argv)
+        payload = {"status": "injected_decomposable", "count": 3, "requested_n": 3,
+                   "targets": [{"test_red_post": True} for _ in range(3)]}
+        return _sp.CompletedProcess(argv, 0, stdout=json.dumps(payload), stderr="")
+
+    cc = harness.ChaosController(runner=run)
+    cc.inject_decomposable(3)
+    assert "--inject-decomposable" in seen["argv"]
+    # The CLI uses -n/--num-targets for the count (zero hardcoding of 3 in argv).
+    assert "3" in seen["argv"]
+    assert ("-n" in seen["argv"]) or ("--num-targets" in seen["argv"])
+
+
+def test_inject_decomposable_not_ok_when_short():
+    # Asked for 3 but only 2 injected -> not ok.
+    cc = harness.ChaosController(runner=_decomp_runner(2, all_red=True))
+    ok, count = cc.inject_decomposable(3)
+    assert ok is False
+    assert count == 2
+
+
+def test_inject_decomposable_not_ok_when_not_all_red():
+    cc = harness.ChaosController(runner=_decomp_runner(3, all_red=False))
+    ok, count = cc.inject_decomposable(3)
+    assert ok is False
+
+
+# ===========================================================================
+# 3. revert covers the N-entry decomposable manifest (reuses --revert path).
+# ===========================================================================
+
+
+def test_revert_reuses_existing_plumbing():
+    seen = {}
+
+    import subprocess as _sp
+
+    def run(argv):
+        seen["argv"] = list(argv)
+        return _sp.CompletedProcess(argv, 0, stdout="{}", stderr="")
+
+    cc = harness.ChaosController(runner=run)
+    assert cc.revert() is True
+    assert "--revert" in seen["argv"]
+
+
+# ===========================================================================
+# 4. The inject STEP: OFF -> single inject; ON -> inject_decomposable(3).
+# ===========================================================================
+
+
+def test_inject_step_off_uses_single_target(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_OMNI_SOAK", raising=False)
+    debug_log = tmp_path / "debug.log"
+    debug_log.write_text("")
+    chaos = FakeChaos()
+    soak = FakeSoak(str(debug_log))
+    auditor = FakeAuditor(proven=True)
+    run = _make_run(tmp_path, chaos=chaos, soak=soak, auditor=auditor, omni_soak=False)
+    rc = run.execute()
+    assert rc == 0
+    # Single-target inject was called; decomposable was NOT.
+    assert ("inject", 7) in chaos.calls
+    assert not any(c[0] == "inject_decomposable" for c in chaos.calls if isinstance(c, tuple))
+    assert "revert" in chaos.calls
+
+
+def test_inject_step_on_uses_decomposable(tmp_path, monkeypatch):
+    debug_log = tmp_path / "debug.log"
+    debug_log.write_text("")
+    chaos = FakeChaos(decomp_count=3)
+    soak = FakeSoak(str(debug_log))
+    auditor = FakeAuditor(proven=True)
+    run = _make_run(tmp_path, chaos=chaos, soak=soak, auditor=auditor, omni_soak=True)
+    rc = run.execute()
+    assert rc == 0
+    # Decomposable 3-target inject was called; single-target was NOT.
+    assert ("inject_decomposable", 3) in chaos.calls
+    assert not any(
+        isinstance(c, tuple) and c[0] == "inject" for c in chaos.calls
+    )
+    # Revert-ALWAYS still covers it (the N-entry manifest).
+    assert "revert" in chaos.calls
+
+
+def test_inject_step_on_aborts_when_not_all_red(tmp_path):
+    debug_log = tmp_path / "debug.log"
+    debug_log.write_text("")
+    chaos = FakeChaos(inject_red=False, decomp_count=3)
+    soak = FakeSoak(str(debug_log))
+    auditor = FakeAuditor(proven=True)
+    run = _make_run(tmp_path, chaos=chaos, soak=soak, auditor=auditor, omni_soak=True)
+    rc = run.execute()
+    # Decomposable inject did not turn all RED -> abort, but revert ALWAYS.
+    assert rc != 0
+    assert "revert" in chaos.calls
+    # Soak never launched.
+    assert soak.calls == []
+
+
+def test_default_run_field_off_byte_identical(tmp_path):
+    """A HarnessRun built without omni_soak defaults to single-target (OFF)."""
+    debug_log = tmp_path / "debug.log"
+    debug_log.write_text("")
+    chaos = FakeChaos()
+    soak = FakeSoak(str(debug_log))
+    auditor = FakeAuditor(proven=True)
+    run = _make_run(tmp_path, chaos=chaos, soak=soak, auditor=auditor)  # no omni_soak
+    assert run.omni_soak is False
+    run.execute()
+    assert ("inject", 7) in chaos.calls


### PR DESCRIPTION
JARVIS_A1_OMNI_SOAK arms the omni overlay + DecomposableChaosInjector 3-target inject. Gated default-off byte-identical. 13 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Omni-Soak to the A1 harness: when `JARVIS_A1_OMNI_SOAK` is on we load the omni env overlay and run a 3-target decomposable chaos inject (fan-out); when off, behavior stays byte-identical to the current single-target soak.

- **New Features**
  - Env overlays: always load linux base, then layer the omni overlay when armed; added `_OMNI_ENV_OVERLAY`, overlay selection helper, and overlay logging.
  - Chaos inject: added `inject_decomposable(n)` that runs `--inject-decomposable -n N`, parses JSON, and succeeds only if N targets are injected and all go RED; reuse existing `--revert`.
  - Harness gating: `HarnessRun` gets `omni_soak` and `omni_targets` (default 3); `execute()` uses decomposable path when armed, otherwise single-target; wired through local and live builders.
  - Tests: new suite validates overlay selection (omni is a superset of linux), helpers, decomposable CLI/JSON handling, revert coverage, and that OFF remains single-target.

<sup>Written for commit fb150d8f204aafcf01c319f7b890e7fd944eb87f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69718?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

