### PR TITLE
fix(a1): propagate JARVIS_A1_OMNI_SOAK to node surgery

### DIFF
--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -1146,8 +1146,14 @@ def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
     failure path withholds the completion-sentinel until the local PULL + sha256
     verification authorizes it (the checksum-gated teardown). Only reached AFTER
     the money-gate."""
+    # Propagate the Omni-Soak arming to the NODE so its compose_env loads the omni
+    # overlay (the full MAS/fan-out stack) + the inject step uses the decomposable
+    # 3-target injector. Without this prefix the node's compose_env never sees the
+    # flag and falls back to the linux_prod overlay (no fan-out).
+    _omni_prefix = "JARVIS_A1_OMNI_SOAK=1 " if _omni_soak_armed(os.environ) else ""
     remote_cmd = (
-        "JARVIS_IAC_HYPERVISOR_ENABLED=1 python3 scripts/a1_live_fire_chaos_harness.py "
+        "JARVIS_IAC_HYPERVISOR_ENABLED=1 " + _omni_prefix
+        + "python3 scripts/a1_live_fire_chaos_harness.py "
         "--execute-on-node --cost-cap %s --max-wall-seconds %d --seed %d"
         % (cost_cap, wall_seconds, seed)
     )


### PR DESCRIPTION
Node compose_env must see the flag to load the omni overlay. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Propagates the `JARVIS_A1_OMNI_SOAK=1` flag to node-side execution so the node’s compose_env loads the omni overlay instead of falling back to `linux_prod`. This enables the full MAS/fan-out stack and the 3-target injector during on-node surgery.

<sup>Written for commit bfb88a841555e73ac22f31cbdbbc650a3e83dd50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69719?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

