### PR TITLE
fix(a1): omni_soak_enabled NameError in node-cmd prefix

### DIFF
--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -1150,7 +1150,7 @@ def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
     # overlay (the full MAS/fan-out stack) + the inject step uses the decomposable
     # 3-target injector. Without this prefix the node's compose_env never sees the
     # flag and falls back to the linux_prod overlay (no fan-out).
-    _omni_prefix = "JARVIS_A1_OMNI_SOAK=1 " if _omni_soak_armed(os.environ) else ""
+    _omni_prefix = "JARVIS_A1_OMNI_SOAK=1 " if omni_soak_enabled(os.environ) else ""
     remote_cmd = (
         "JARVIS_IAC_HYPERVISOR_ENABLED=1 " + _omni_prefix
         + "python3 scripts/a1_live_fire_chaos_harness.py "


### PR DESCRIPTION
🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a NameError in the remote node command prefix by calling the correct `omni_soak_enabled(os.environ)` function. Prevents `--remote` runs from crashing before provisioning and correctly sets `JARVIS_A1_OMNI_SOAK=1` when omni soak is enabled.

<sup>Written for commit 4c9ac1e08cf02cf88436bef6f3191a9dc0b72858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69720?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

