### PR TITLE
feat: meta-goal-aggregator

### DIFF
--- a/backend/core/ouroboros/governance/meta_goal_aggregator.py
+++ b/backend/core/ouroboros/governance/meta_goal_aggregator.py
@@ -1,0 +1,744 @@
+"""Adaptive Meta-Goal Aggregator -- bundle N disjoint single-file ops into a
+fan-outable Meta-Goal DAG (the Omni-Soak #3 ``single_file_op`` fix).
+
+THE BUG (Omni-Soak #3)
+----------------------
+When N independent single-file ops pool in the dispatch queue (e.g. 3
+isolated chaos failures), each is dispatched as a SEPARATE
+``single_file_op`` -> :func:`~parallel_dispatch.is_fanout_eligible`
+returns ``allowed=False reason=single_file_op`` -> NO fan-out, ever. The
+swarm only fans out ONE goal that decomposes into a multi-unit DAG. So 3
+parallelizable bug-fixes queue serially while the swarm starves.
+
+THE FIX (this module)
+---------------------
+Watch the pooled single-file ops (reusing the signal-coalescing window
+notion). When ``count(single_file_ops) >= JARVIS_META_GOAL_MIN_OPS`` within
+the window, ask the existing zero-trust
+:mod:`~backend.core.ouroboros.governance.collision_matrix` which ops are
+pairwise-DISJOINT, then bundle the largest disjoint set into ONE Meta-Goal
+whose :class:`~backend.core.ouroboros.governance.autonomy.subagent_types.ExecutionGraph`
+is built by the EXISTING :func:`~parallel_dispatch.build_execution_graph`
+(one node per bundled op). The Meta-Goal then takes the proven fan-out path
+through :func:`is_fanout_eligible` (with ``force=True`` so a genuine
+>=2-disjoint-unit Meta-Goal authoritatively engages fan-out without flipping
+the standalone WAVE3 flags) -> ``allowed=True n=N``.
+
+Reuse-first -- this module is *upstream intelligence*; the proven executor is
+untouched. It reuses, never duplicates:
+
+- :func:`parallel_dispatch.is_fanout_eligible` (+ ``force``) -- the Meta-Goal
+  fan-out eligibility decision (replaces the ``SINGLE_FILE_OP`` reject).
+- :func:`parallel_dispatch.build_execution_graph` -- the ONE node-per-op DAG.
+- :func:`collision_matrix.partition_parallel_safe` -- which ops are disjoint.
+- :func:`dag_composer.compose_fanout_result` (over the SUCCESSFUL subset) --
+  the sha256 zero-loss union for partial (Poison-Pill) recomposition.
+- :func:`intake_dlq.append_dlq` -- the Cryo-DLQ for failed unit(s).
+- :class:`memory_pressure_gate.MemoryPressureGate` -- live worker capacity for
+  the dynamic resource-aware batching ceiling.
+
+Constraints honoured
+---------------------
+- **Dynamic resource-aware batching**: chunk size = ``min(max_concurrent_
+  workers, gate_allowed, max_units_cap)`` from LIVE capacity, never a
+  hardcoded N. 50 ops -> multiple capacity-sized Meta-Goals, never one
+  mega-DAG (OOM / API rate-limit guard).
+- **Fail-CLOSED on the collision invariant**: coupled ops are never bundled
+  together (the collision matrix is authoritative; indeterminate coupling
+  is a collision under zero-trust).
+- **Partial-tolerant on unit failure (Poison-Pill)**: when a Meta-Goal
+  bundles 3 and 2 succeed + 1 fails, the 2 successful disjoint patches are
+  composed into ONE PR and the failed unit is routed to the Cryo-DLQ for a
+  standalone retry. Good cognition is never scrapped for one bad sibling.
+- **Failover-aware**: a single node's mid-flight DW collapse routes that unit
+  to J-Prime via the existing ``provider_override`` Cryo-DLQ handoff and
+  resumes only that node; siblings keep crunching.
+- **Granular telemetry**: every emitted line tags BOTH the parent
+  ``meta_goal_id`` AND the origin ``single_file_op`` id.
+- **Gated default-OFF (byte-identical)**: master
+  ``JARVIS_META_GOAL_AGGREGATOR_ENABLED`` (default ``false``). OFF -> the
+  aggregator never bundles; pooled ops are returned as-is and the legacy
+  single-file dispatch path is byte-identical.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import time
+from dataclasses import dataclass, field
+from typing import (
+    Any,
+    Callable,
+    Dict,
+    List,
+    Optional,
+    Sequence,
+    Tuple,
+)
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    GraphExecutionState,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+from backend.core.ouroboros.governance.collision_matrix import (
+    partition_parallel_safe,
+)
+from backend.core.ouroboros.governance.dag_composer import (
+    ComposeFailure,
+    ComposedCandidate,
+    compose_fanout_result,
+)
+from backend.core.ouroboros.governance.intake_dlq import append_dlq
+from backend.core.ouroboros.governance.memory_pressure_gate import (
+    MemoryPressureGate,
+    get_default_gate,
+)
+from backend.core.ouroboros.governance.parallel_dispatch import (
+    CandidateFile,
+    FanoutEligibility,
+    build_execution_graph,
+    is_fanout_eligible,
+    parallel_dispatch_max_units,
+)
+from backend.core.ouroboros.governance.posture import Posture
+
+logger = logging.getLogger("Ouroboros.MetaGoalAggregator")
+
+
+# ---------------------------------------------------------------------------
+# Env flags (default-OFF master; threshold env; no hardcoded batch size)
+# ---------------------------------------------------------------------------
+
+META_GOAL_FLAG = "JARVIS_META_GOAL_AGGREGATOR_ENABLED"
+_MIN_OPS_FLAG = "JARVIS_META_GOAL_MIN_OPS"
+_WINDOW_FLAG = "JARVIS_META_GOAL_COALESCE_WINDOW_S"
+_MAX_WORKERS_FLAG = "JARVIS_MAX_CONCURRENT_WORKERS"
+
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def _env_bool(name: str, default: bool = False) -> bool:
+    raw = os.environ.get(name, "").strip().lower()
+    if raw in _TRUTHY:
+        return True
+    if raw in _FALSY:
+        return False
+    return default
+
+
+def _env_int(name: str, default: int, *, minimum: int = 1) -> int:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        v = int(raw)
+    except ValueError:
+        return default
+    if v < minimum:
+        return minimum
+    return v
+
+
+def _env_float(name: str, default: float) -> float:
+    raw = os.environ.get(name, "").strip()
+    if not raw:
+        return default
+    try:
+        v = float(raw)
+    except ValueError:
+        return default
+    if v <= 0.0:
+        return default
+    return v
+
+
+def meta_goal_aggregator_enabled() -> bool:
+    """Master flag -- ``JARVIS_META_GOAL_AGGREGATOR_ENABLED`` (default ``false``).
+
+    When ``false`` (graduation default), :meth:`MetaGoalAggregator.offer`
+    still pools ops, but :meth:`MetaGoalAggregator.drain_ready_bundles`
+    NEVER returns a bundle -- ops fall through to the legacy single-file
+    dispatch path, byte-identical to pre-aggregator behaviour.
+    """
+    return _env_bool(META_GOAL_FLAG, False)
+
+
+def meta_goal_min_ops(default: int = 2) -> int:
+    """Min pooled single-file ops before a Meta-Goal forms (env, default 2)."""
+    return _env_int(_MIN_OPS_FLAG, default, minimum=2)
+
+
+def meta_goal_coalesce_window_s(default: float = 30.0) -> float:
+    """Coalescing window seconds (env; mirrors JARVIS_COALESCE_WINDOW_S default).
+
+    Ops offered within this window of each other are eligible to bundle
+    together. Default 30s matches the orchestrator's signal-coalescing window.
+    """
+    return _env_float(_WINDOW_FLAG, default)
+
+
+def max_concurrent_workers(default: int = 5) -> int:
+    """Live worker-capacity ceiling -- ``JARVIS_MAX_CONCURRENT_WORKERS``.
+
+    The dynamic batch ceiling is ``min(this, gate_allowed, max_units_cap)``;
+    this is the worker-pool dimension of that strictest-wins minimum.
+    """
+    return _env_int(_MAX_WORKERS_FLAG, default, minimum=1)
+
+
+# ---------------------------------------------------------------------------
+# Pooled op + bundle records
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class PooledOp:
+    """A single-file op pooled in the dispatch window awaiting aggregation.
+
+    Mirrors the shape a chaos-failure (or any single-file) op carries into
+    the queue WITHOUT importing the orchestrator's op-context type (authority
+    -import ban). ``offered_at`` is stamped at :meth:`MetaGoalAggregator.offer`
+    so the coalescing window can age ops out.
+    """
+
+    op_id: str
+    file_path: str
+    full_content: str = ""
+    rationale: str = ""
+    repo: str = "jarvis"
+    offered_at: float = field(default_factory=time.monotonic)
+
+    def __post_init__(self) -> None:
+        if not self.op_id or not str(self.op_id).strip():
+            raise ValueError("PooledOp.op_id must be non-empty")
+        if not self.file_path or not str(self.file_path).strip():
+            raise ValueError("PooledOp.file_path must be non-empty")
+
+
+@dataclass(frozen=True)
+class MetaGoalBundle:
+    """One fan-outable Meta-Goal: a graph + the eligibility that authorized it.
+
+    Attributes
+    ----------
+    meta_goal_id:
+        Deterministic id derived from the bundled op-ids.
+    graph:
+        The :class:`ExecutionGraph` (one node per bundled op) built by the
+        EXISTING :func:`build_execution_graph`.
+    eligibility:
+        The :class:`FanoutEligibility` (``allowed=True n_allowed=N``) that
+        replaced the per-op ``SINGLE_FILE_OP`` reject.
+    unit_to_op:
+        ``unit_id -> origin single_file_op id`` -- the granular-telemetry +
+        partial-recomposition trace.
+    ops:
+        The :class:`PooledOp` records bundled into this Meta-Goal.
+    """
+
+    meta_goal_id: str
+    graph: ExecutionGraph
+    eligibility: FanoutEligibility
+    unit_to_op: Dict[str, str]
+    ops: Tuple[PooledOp, ...]
+
+
+@dataclass(frozen=True)
+class PartialRecomposition:
+    """Outcome of :meth:`MetaGoalAggregator.partial_recompose` (Poison-Pill).
+
+    Attributes
+    ----------
+    composed:
+        The :class:`ComposedCandidate` over the SUCCESSFUL disjoint subset
+        (ONE PR), or ``None`` when zero units succeeded (nothing to commit).
+    dlq_op_ids:
+        Origin single_file_op ids routed back to the Cryo-DLQ for standalone
+        retry (the failed siblings).
+    composed_op_ids:
+        Origin single_file_op ids whose patches made it into the composed PR.
+    """
+
+    composed: Optional[ComposedCandidate]
+    dlq_op_ids: Tuple[str, ...]
+    composed_op_ids: Tuple[str, ...]
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+def _meta_goal_id_for(op_ids: Sequence[str]) -> str:
+    digest = hashlib.sha256(
+        "\x1f".join(sorted(op_ids)).encode("utf-8")
+    ).hexdigest()
+    return f"mg-{digest[:12]}"
+
+
+class MetaGoalAggregator:
+    """Pools single-file ops and bundles disjoint ones into Meta-Goal DAGs.
+
+    The aggregator is the upstream intelligence that turns the Omni-Soak #3
+    ``single_file_op`` reject into a fan-out feast. It owns no executor; it
+    only decides *what to bundle* and *how big each batch may be* given live
+    capacity, then hands a :class:`MetaGoalBundle` to the proven fan-out path.
+
+    Thread-safety: callers drive ``offer`` / ``drain_ready_bundles`` from a
+    single asyncio loop (the dispatch coalescing tick). No internal locking;
+    the operations are synchronous + fast (pure partition + graph build).
+    """
+
+    def __init__(
+        self,
+        *,
+        gate: Optional[MemoryPressureGate] = None,
+        posture_fn: Optional[
+            Callable[[], Tuple[Optional[Posture], Optional[float]]]
+        ] = None,
+        oracle: Any = None,
+        max_concurrent_workers: Optional[int] = None,
+        repo: str = "jarvis",
+    ) -> None:
+        self._gate = gate if gate is not None else get_default_gate()
+        self._posture_fn = posture_fn
+        self._oracle = oracle
+        self._repo = repo
+        # None -> read from env at decision time (live capacity). An explicit
+        # int (tests / operator override) pins the worker dimension.
+        self._max_workers_override = max_concurrent_workers
+        self._pool: List[PooledOp] = []
+
+    # -- intake -------------------------------------------------------------
+
+    def offer(self, op: PooledOp) -> None:
+        """Pool a single-file op for possible Meta-Goal aggregation.
+
+        Idempotent on ``op_id`` -- re-offering the same op replaces the
+        prior entry (keeps the latest content/rationale). Never raises on a
+        well-formed :class:`PooledOp`.
+        """
+        self._pool = [p for p in self._pool if p.op_id != op.op_id]
+        self._pool.append(op)
+
+    def pending_ops(self) -> Tuple[PooledOp, ...]:
+        """The currently-pooled ops (legacy single-file path consumes these)."""
+        return tuple(self._pool)
+
+    # -- capacity -----------------------------------------------------------
+
+    def _effective_worker_cap(self) -> int:
+        if self._max_workers_override is not None:
+            return max(1, int(self._max_workers_override))
+        return max_concurrent_workers()
+
+    def _dynamic_batch_ceiling(self, n_disjoint: int) -> int:
+        """STRICTEST-wins live ceiling on a single Meta-Goal's degree.
+
+        ``min(worker_cap, gate_allowed, max_units_cap, n_disjoint)`` -- never
+        a hardcoded constant. A flood of 50 ops therefore chunks into many
+        capacity-sized Meta-Goals instead of one OOM mega-DAG.
+        """
+        worker_cap = self._effective_worker_cap()
+        gate_allowed = self._gate.can_fanout(n_disjoint).n_allowed
+        max_units = parallel_dispatch_max_units()
+        ceiling = min(worker_cap, gate_allowed, max_units, n_disjoint)
+        return max(1, int(ceiling))
+
+    # -- bundling -----------------------------------------------------------
+
+    def _window_ops(self, now: float, window_s: float) -> List[PooledOp]:
+        """Ops still inside the coalescing window (reuse-first window notion)."""
+        return [p for p in self._pool if (now - p.offered_at) <= window_s]
+
+    def _op_to_unit_spec(self, op: PooledOp) -> WorkUnitSpec:
+        """One node per bundled single-file op (deterministic unit_id)."""
+        digest = hashlib.sha256(
+            f"{op.op_id}\x1f{op.file_path}".encode("utf-8")
+        ).hexdigest()
+        return WorkUnitSpec(
+            unit_id=f"unit-{digest[:12]}",
+            repo=op.repo or self._repo,
+            goal=op.rationale or f"fix {op.file_path}",
+            target_files=(op.file_path,),
+            owned_paths=(op.file_path,),
+        )
+
+    def drain_ready_bundles(self) -> List[MetaGoalBundle]:
+        """Form + return all ready Meta-Goal bundles; drain bundled ops.
+
+        Master-OFF -> always ``[]`` (legacy single-file dispatch; pooled ops
+        stay retrievable via :meth:`pending_ops`).
+
+        Otherwise:
+
+        1. Take the ops inside the coalescing window. If fewer than
+           ``JARVIS_META_GOAL_MIN_OPS``, nothing is ready yet.
+        2. Partition them via the zero-trust collision matrix
+           (:func:`partition_parallel_safe`) -- coupled ops are NEVER
+           co-grouped (fail-CLOSED collision invariant).
+        3. For each disjoint group, CHUNK it into capacity-sized Meta-Goals
+           via :meth:`_dynamic_batch_ceiling` (no OOM mega-DAG).
+        4. For each chunk of >= 2 units, run :func:`is_fanout_eligible`
+           (``force=True``) on the chunk degree, then
+           :func:`build_execution_graph`. ``allowed=True n=chunk`` -> a
+           :class:`MetaGoalBundle`.
+
+        Bundled ops are removed from the pool; un-bundled ops (singletons,
+        coupled remainders, sub-min windows) stay pooled for the next tick or
+        the legacy single-file path.
+        """
+        if not meta_goal_aggregator_enabled():
+            return []
+
+        now = time.monotonic()
+        window_s = meta_goal_coalesce_window_s()
+        window = self._window_ops(now, window_s)
+        if len(window) < meta_goal_min_ops():
+            return []
+
+        # Map unit_id -> PooledOp so we can recover origin ops + content.
+        op_by_path = {op.file_path: op for op in window}
+        specs = [self._op_to_unit_spec(op) for op in window]
+        spec_by_unit = {s.unit_id: s for s in specs}
+
+        # Zero-trust disjoint partition -- coupled ops are never co-grouped.
+        parallel_groups, _sequential = partition_parallel_safe(
+            specs, oracle=self._oracle
+        )
+
+        bundles: List[MetaGoalBundle] = []
+        bundled_op_ids: set = set()
+
+        for group in parallel_groups:
+            # Deterministic order within the group.
+            group_sorted = sorted(group, key=lambda u: u.unit_id)
+            # CHUNK by live capacity -- never a single mega-DAG.
+            ceiling = self._dynamic_batch_ceiling(len(group_sorted))
+            if ceiling < 2:
+                continue  # capacity collapsed to serial; leave ops pooled
+            for start in range(0, len(group_sorted), ceiling):
+                chunk = group_sorted[start : start + ceiling]
+                if len(chunk) < 2:
+                    # A trailing singleton chunk is serial-equivalent; leave
+                    # it pooled for the next tick / legacy single-file path.
+                    continue
+                bundle = self._build_bundle(chunk, spec_by_unit, op_by_path)
+                if bundle is None:
+                    continue
+                bundles.append(bundle)
+                bundled_op_ids.update(bundle.unit_to_op.values())
+
+        # Drain only the ops that actually got bundled.
+        if bundled_op_ids:
+            self._pool = [p for p in self._pool if p.op_id not in bundled_op_ids]
+
+        return bundles
+
+    def _build_bundle(
+        self,
+        chunk: Sequence[WorkUnitSpec],
+        spec_by_unit: Dict[str, WorkUnitSpec],
+        op_by_path: Dict[str, PooledOp],
+    ) -> Optional[MetaGoalBundle]:
+        """Build ONE Meta-Goal from a >=2 disjoint chunk (reuse fan-out path)."""
+        ops = [op_by_path[s.target_files[0]] for s in chunk]
+        op_ids = [o.op_id for o in ops]
+        meta_goal_id = _meta_goal_id_for(op_ids)
+
+        # The run-#3 fix: force=True so a genuine >=2-disjoint-unit Meta-Goal
+        # authoritatively engages the proven fan-out path WITHOUT flipping the
+        # standalone WAVE3_PARALLEL_DISPATCH flags. All real clamps (memory
+        # CRITICAL, posture, max_units) remain authoritative.
+        eligibility = is_fanout_eligible(
+            op_id=meta_goal_id,
+            n_candidate_files=len(chunk),
+            gate=self._gate,
+            posture_fn=self._posture_fn,
+            emit_log=True,
+            force=True,
+        )
+        if not eligibility.allowed or eligibility.n_allowed < 2:
+            logger.info(
+                "[MetaGoal] meta=%s NOT-eligible n_requested=%d "
+                "n_allowed=%d reason=%s -> ops stay single-file",
+                meta_goal_id,
+                len(chunk),
+                eligibility.n_allowed,
+                eligibility.reason_code.value,
+            )
+            return None
+
+        # If eligibility clamped below the chunk size (posture/memory), trim
+        # to the allowed degree; the trimmed ops stay pooled (not bundled).
+        n = eligibility.n_allowed
+        chunk = list(chunk)[:n]
+        ops = ops[:n]
+        op_ids = op_ids[:n]
+        # Recompute meta-goal id + eligibility for the trimmed set so the
+        # graph degree matches eligibility.n_allowed exactly.
+        if len(chunk) != n or n != eligibility.n_requested:
+            meta_goal_id = _meta_goal_id_for(op_ids)
+            eligibility = is_fanout_eligible(
+                op_id=meta_goal_id,
+                n_candidate_files=len(chunk),
+                gate=self._gate,
+                posture_fn=self._posture_fn,
+                emit_log=False,
+                force=True,
+            )
+            if not eligibility.allowed or eligibility.n_allowed < 2:
+                return None
+
+        candidate_files = [
+            CandidateFile(
+                file_path=op_by_path[s.target_files[0]].file_path,
+                full_content=op_by_path[s.target_files[0]].full_content,
+                rationale=op_by_path[s.target_files[0]].rationale,
+            )
+            for s in chunk
+        ]
+        # Reuse the EXISTING graph builder -- one node per bundled op.
+        graph = build_execution_graph(
+            op_id=meta_goal_id,
+            repo=self._repo,
+            candidate_files=candidate_files,
+            eligibility=eligibility,
+        )
+
+        # unit_id -> origin op id, keyed by the graph's actual units (the
+        # graph builder derives its OWN unit_ids from meta_goal_id + path).
+        path_to_op = {op_by_path[s.target_files[0]].file_path: op_by_path[s.target_files[0]].op_id for s in chunk}
+        unit_to_op = {
+            u.unit_id: path_to_op[u.target_files[0]] for u in graph.units
+        }
+
+        logger.info(
+            "[MetaGoal] meta=%s formed n_units=%d files=%s graph=%s "
+            "(run-#3 single_file_op fix: %d disjoint single-file ops -> 1 fan-out)",
+            meta_goal_id,
+            len(graph.units),
+            [u.target_files[0] for u in graph.units],
+            graph.graph_id,
+            len(graph.units),
+        )
+
+        return MetaGoalBundle(
+            meta_goal_id=meta_goal_id,
+            graph=graph,
+            eligibility=eligibility,
+            unit_to_op=unit_to_op,
+            ops=tuple(ops),
+        )
+
+    # -- failover-aware per-node resume -------------------------------------
+
+    def build_failover_override(
+        self, bundle: MetaGoalBundle, unit_id: str
+    ) -> Dict[str, Any]:
+        """Per-unit J-Prime failover handoff descriptor (the existing vehicle).
+
+        A single node's mid-flight DW collapse routes ONLY that unit to
+        J-Prime via the existing ``provider_override`` Cryo-DLQ handoff +
+        scheduler resume; siblings keep crunching. This builds the override
+        envelope (the same shape the failover lifecycle consumes), tagged with
+        the meta+unit lineage so the resumed node re-joins THIS Meta-Goal's
+        recomposition (returns paused->resumed, never FAILED, so partial-
+        recomp still gets it).
+
+        We do NOT add a new failover engine -- we reuse the per-unit override
+        + scheduler batch resume already proven in the failover lifecycle.
+        """
+        origin_op = bundle.unit_to_op.get(unit_id, "")
+        return {
+            "provider_override": "gcp-jprime",
+            "unit_id": unit_id,
+            "op_id": origin_op,
+            "meta_goal_id": bundle.meta_goal_id,
+            "reason": "dw_collapse_node_failover",
+        }
+
+    # -- partial (Poison-Pill) recomposition --------------------------------
+
+    def partial_recompose(
+        self, bundle: MetaGoalBundle, state: GraphExecutionState
+    ) -> PartialRecomposition:
+        """Poison-Pill: commit the successful patches; Cryo-DLQ the failures.
+
+        If a Meta-Goal bundles N and some units FAIL (even after J-Prime
+        failover), do NOT scrap the DAG. Extract the SUCCESSFUL disjoint
+        patches -> compose them via the EXISTING
+        :func:`dag_composer.compose_fanout_result` (sha256 zero-loss union
+        over the successful subset) -> ONE PR; route the FAILED unit(s) back
+        to the Cryo-DLQ (:func:`intake_dlq.append_dlq`) for a future
+        standalone retry. Good cognition is never thrown away for one bad
+        sibling.
+
+        This is a NEW *partial* mode -- the original single-decompose path
+        keeps its fail-CLOSED behaviour; the Meta-Goal path uses partial. The
+        composer's union+sha256 logic is REUSED over the successful subset (a
+        synthetic single-success ExecutionGraph), never rewritten.
+        """
+        results = dict(getattr(state, "results", {}) or {})
+        succeeded: List[WorkUnitSpec] = []
+        failed_units: List[str] = []
+        for unit in bundle.graph.units:
+            r = results.get(unit.unit_id)
+            if r is not None and getattr(r, "status", None) == WorkUnitState.COMPLETED:
+                succeeded.append(unit)
+            else:
+                failed_units.append(unit.unit_id)
+
+        composed: Optional[ComposedCandidate] = None
+        composed_op_ids: List[str] = []
+
+        if succeeded:
+            # Build a synthetic graph over ONLY the successful units so the
+            # existing composer's count/sha/no-overwrite proof passes over the
+            # subset (the full graph would trip UNIT_NOT_SUCCESS, by design).
+            sub_graph = self._subset_graph(bundle.graph, succeeded)
+            sub_results = {u.unit_id: results[u.unit_id] for u in succeeded}
+            result = compose_fanout_result(sub_graph, sub_results)
+            if isinstance(result, ComposeFailure):
+                logger.warning(
+                    "[MetaGoal] meta=%s partial compose FAILED reason=%s "
+                    "detail=%s -> successful subset not committed this pass",
+                    bundle.meta_goal_id,
+                    result.reason.value,
+                    result.detail,
+                )
+            else:
+                composed = result
+                composed_op_ids = [
+                    bundle.unit_to_op[u.unit_id] for u in succeeded
+                ]
+                logger.info(
+                    "[MetaGoal] meta=%s partial-recompose committed n_files=%d "
+                    "ops=%s (Poison-Pill: %d/%d succeeded -> ONE PR, DAG not scrapped)",
+                    bundle.meta_goal_id,
+                    composed.n_files,
+                    composed_op_ids,
+                    len(succeeded),
+                    len(bundle.graph.units),
+                )
+
+        # Route failed siblings to the Cryo-DLQ for standalone retry.
+        dlq_op_ids: List[str] = []
+        for unit_id in failed_units:
+            origin_op = bundle.unit_to_op.get(unit_id, "")
+            unit = bundle.graph.unit_map.get(unit_id)
+            envelope = {
+                "op_id": origin_op,
+                "meta_goal_id": bundle.meta_goal_id,
+                "unit_id": unit_id,
+                "file_path": (unit.target_files[0] if unit else ""),
+                "goal": (unit.goal if unit else ""),
+            }
+            try:
+                append_dlq(
+                    envelope,
+                    reason=(
+                        f"meta_goal_partial_failure:poison_pill:"
+                        f"meta={bundle.meta_goal_id}"
+                    ),
+                )
+                dlq_op_ids.append(origin_op)
+                logger.info(
+                    "[MetaGoal] meta=%s unit=%s op=%s file=%s status=failed "
+                    "-> Cryo-DLQ (standalone retry)",
+                    bundle.meta_goal_id,
+                    unit_id,
+                    origin_op,
+                    (unit.target_files[0] if unit else ""),
+                )
+            except Exception:  # noqa: BLE001 -- DLQ is fail-soft, never crash recomp
+                logger.warning(
+                    "[MetaGoal] meta=%s DLQ append failed for unit=%s op=%s",
+                    bundle.meta_goal_id,
+                    unit_id,
+                    origin_op,
+                    exc_info=True,
+                )
+
+        return PartialRecomposition(
+            composed=composed,
+            dlq_op_ids=tuple(dlq_op_ids),
+            composed_op_ids=tuple(composed_op_ids),
+        )
+
+    def _subset_graph(
+        self, graph: ExecutionGraph, units: Sequence[WorkUnitSpec]
+    ) -> ExecutionGraph:
+        """A synthetic ExecutionGraph over a disjoint SUCCESSFUL subset.
+
+        Reuses the same graph type so the composer is fed its native input.
+        Dependency ids are stripped to the subset (the units are disjoint by
+        the collision-matrix invariant, so they are independent anyway).
+        """
+        subset_ids = {u.unit_id for u in units}
+        rescoped = tuple(
+            WorkUnitSpec(
+                unit_id=u.unit_id,
+                repo=u.repo,
+                goal=u.goal,
+                target_files=u.target_files,
+                dependency_ids=tuple(
+                    d for d in u.dependency_ids if d in subset_ids
+                ),
+                owned_paths=u.owned_paths,
+                max_attempts=u.max_attempts,
+                timeout_s=u.timeout_s,
+            )
+            for u in units
+        )
+        return ExecutionGraph(
+            graph_id=f"{graph.graph_id}-partial",
+            op_id=graph.op_id,
+            planner_id=graph.planner_id,
+            schema_version=graph.schema_version,
+            units=rescoped,
+            concurrency_limit=max(1, len(rescoped)),
+        )
+
+    # -- telemetry ----------------------------------------------------------
+
+    def telemetry_lines(self, bundle: MetaGoalBundle) -> List[str]:
+        """Per-unit ``[MetaGoal]`` lines tagging meta_goal_id + origin op-id.
+
+        Every worker's output + the existing ``[L3Telemetry]`` lines should
+        carry BOTH the parent ``meta_goal_id`` AND the origin
+        ``single_file_op`` id, so the fan-out + recomposition matrix is fully
+        observable. This returns those lines (and emits them) for the caller
+        to thread into the scheduler's per-unit telemetry.
+        """
+        lines: List[str] = []
+        for unit in bundle.graph.units:
+            origin_op = bundle.unit_to_op.get(unit.unit_id, "")
+            line = (
+                f"[MetaGoal] meta={bundle.meta_goal_id} "
+                f"unit={origin_op} "
+                f"sub_unit={unit.unit_id} "
+                f"file={unit.target_files[0]} "
+                f"status=dispatched"
+            )
+            lines.append(line)
+            logger.info(line)
+        return lines
+
+
+__all__ = [
+    "META_GOAL_FLAG",
+    "MetaGoalAggregator",
+    "MetaGoalBundle",
+    "PartialRecomposition",
+    "PooledOp",
+    "append_dlq",  # re-exported for monkeypatch seam in tests
+    "max_concurrent_workers",
+    "meta_goal_aggregator_enabled",
+    "meta_goal_coalesce_window_s",
+    "meta_goal_min_ops",
+]

--- a/scripts/bake_soak_golden_image.py
+++ b/scripts/bake_soak_golden_image.py
@@ -1,0 +1,718 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Sovereign Soak Golden-Image Bake -- pre-install the soak host deps once.
+
+MIRRORS scripts/bake_jprime_golden_image.py (the PROVEN bake flow). The Omni-Soak
+boots a fresh Debian node and spends ~15-20 min on a detached `pip install` of the
+host deps -- the dominant wall-clock cost of every run. This tool bakes those deps
+into a reusable GCP golden image ONCE so the IaC hypervisor can boot straight into
+the soak (no pip install).
+
+The bake flow (identical shape to the J-Prime baker):
+
+    provision a cheap CPU node (debian-12, ON-DEMAND for bake reliability)
+      -> install the FULL soak deps (the hard-ensure core + requirements.txt,
+         ML libs filtered exactly as the surgery does)
+      -> VALIDATE before snapshot (the load-bearing lock):
+           * the deps import clean (aiohttp, uuid6, fastapi, pydantic, ...)
+           * `python3 -m pytest --collect-only -q` runs with NO collection error
+           * O+V core imports resolve (operation_id etc.)
+      -> snapshot the boot disk to a reusable GCP golden image (family
+         jarvis-soak-golden), STAMPED with the requirements.txt sha (a label) for
+         staleness checks
+      -> delete the bake VM + disk (the image is the durable artifact)
+
+VALIDATION LOCK: we NEVER snapshot a broken image. If validation fails we ABORT,
+delete the node, and exit non-zero -- no image is created.
+
+Standalone by design -- imports the hard-ensure dep list + requirements path from
+sovereign_iac_hypervisor (single source of truth, no dep-logic duplication) but
+otherwise pure subprocess(gcloud / gcloud-ssh) + stdlib. Fully parameterized
+(argparse with env-var defaults; zero hardcoding). Every gcloud call is fail-soft;
+after the node exists the cleanup path ALWAYS attempts node + disk teardown so a
+failed bake never leaks billing.
+
+Usage:
+    # default DRY-RUN: print the full plan + every gcloud command, spend nothing
+    python3 scripts/bake_soak_golden_image.py --dry-run
+
+    # actually bake (operator-monitored step, after review):
+    python3 scripts/bake_soak_golden_image.py --execute
+"""
+from __future__ import annotations
+
+import argparse
+import datetime as _dt
+import hashlib
+import os
+import pathlib
+import re
+import shlex
+import subprocess
+import sys
+import time
+from typing import List, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Reuse the IaC hypervisor's single-source-of-truth dep list + requirements
+# location -- NO duplicate dep logic. Import is fail-soft: if the hypervisor
+# can't load (it shouldn't fail, it's pure-stdlib), fall back to a conservative
+# inline default so the baker still works.
+# --------------------------------------------------------------------------- #
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+
+def _load_hard_ensure_deps() -> List[str]:
+    """Import the hard-ensure dep list from the IaC hypervisor (no dup)."""
+    try:
+        import importlib.util
+
+        spec = importlib.util.spec_from_file_location(
+            "_iac_for_bake", str(_REPO_ROOT / "scripts" / "sovereign_iac_hypervisor.py")
+        )
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+            deps = mod.hard_ensure_deps()
+            if deps:
+                return list(deps)
+    except Exception:  # noqa: BLE001 -- never crash the baker on an import edge
+        pass
+    # Conservative fallback (kept in sync with the hypervisor default).
+    return [
+        "aiohttp", "httpx", "pydantic", "pytest", "pytest-asyncio", "pyyaml",
+        "requests", "anyio", "sniffio", "fastapi", "uvicorn", "orjson", "uuid6",
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Defaults (every value is overridable via argparse; argparse defaults read env).
+# --------------------------------------------------------------------------- #
+_DEFAULT_PROJECT = os.environ.get("GCP_PROJECT", "jarvis-473803")
+_DEFAULT_ZONE = os.environ.get("GCP_ZONE", "us-central1-a")
+_DEFAULT_MACHINE = os.environ.get("JARVIS_SOAK_BAKE_MACHINE", "e2-standard-4")
+_DEFAULT_IMAGE_FAMILY = os.environ.get(
+    "JARVIS_IAC_SOAK_GOLDEN_IMAGE_FAMILY", "jarvis-soak-golden"
+)
+_DEFAULT_BOOT_DISK = os.environ.get("JARVIS_SOAK_BAKE_BOOT_DISK_SIZE", "50GB")
+_DEFAULT_BAKE_TIMEOUT_S = int(os.environ.get("JARVIS_SOAK_BAKE_TIMEOUT_S", "1800"))
+_DEFAULT_DEBIAN_IMAGE_FAMILY = os.environ.get(
+    "JARVIS_SOAK_BAKE_SOURCE_IMAGE_FAMILY", "debian-12"
+)
+_DEFAULT_DEBIAN_IMAGE_PROJECT = os.environ.get(
+    "JARVIS_SOAK_BAKE_SOURCE_IMAGE_PROJECT", "debian-cloud"
+)
+_DEFAULT_REQUIREMENTS = os.environ.get(
+    "JARVIS_SOAK_BAKE_REQUIREMENTS", str(_REPO_ROOT / "requirements.txt")
+)
+
+# The requirements-sha label key the IaC staleness check reads. Keep in sync with
+# the IaC hypervisor's golden-staleness probe.
+_REQ_SHA_LABEL_KEY = os.environ.get(
+    "JARVIS_IAC_GOLDEN_REQ_SHA_LABEL", "jarvis_req_sha"
+)
+
+# Readiness sentinel written by the startup-script ONLY after the dep install
+# completes -- the poll loop keys on this.
+_SENTINEL_PATH = "/var/run/soak_bake_ready"
+
+# The ML / native-build libs a BARE Debian node cannot build -- filtered exactly
+# as the IaC surgery filters them (no native portaudio/pyobjc/etc.). Kept as the
+# same alternation so the baked image matches the surgery's installed set.
+_ML_FILTER = (
+    "^(#|torch|torchaudio|torchvision|tensorflow|transformers|vllm|"
+    "llama|nvidia|triton|xformers|onnx|scipy|scikit|sentencepiece|accelerate|"
+    "bitsandbytes|fastembed|peft|trl|datasets|pyaudio|pyobjc|webrtcvad|"
+    "sounddevice|soundfile|pyttsx3|playsound)"
+)
+
+
+def _now_stamp() -> str:
+    return _dt.datetime.now().strftime("%Y%m%d")
+
+
+def _default_image_name() -> str:
+    return os.environ.get(
+        "JARVIS_SOAK_IMAGE_NAME", f"jarvis-soak-golden-{_now_stamp()}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# requirements.txt sha (the staleness stamp).
+# --------------------------------------------------------------------------- #
+def requirements_sha(req_path: str) -> str:
+    """sha256[:16] of the requirements.txt bytes -- the image staleness stamp.
+
+    A GCP label value must be lowercase alnum/dash/underscore <= 63 chars; the
+    truncated hex digest satisfies that. Fail-soft: a missing file yields a
+    sentinel 'norequirements' so the bake still proceeds (with a loud label).
+    """
+    try:
+        data = pathlib.Path(req_path).read_bytes()
+    except Exception:  # noqa: BLE001
+        return "norequirements"
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+# --------------------------------------------------------------------------- #
+# Logging.
+# --------------------------------------------------------------------------- #
+def _log(msg: str) -> None:
+    print(f"[SOAK-BAKE] {msg}", flush=True)
+
+
+def _abort(msg: str) -> None:
+    print(f"[SOAK-BAKE ABORTED: {msg}]", flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# THE single subprocess boundary. ALL gcloud / ssh funnel through here so tests
+# can intercept it with a monkeypatch and assert dry-run never executes.
+# --------------------------------------------------------------------------- #
+def _run(cmd: List[str], *, timeout_s: float = 120.0) -> Tuple[int, str]:
+    """Run a command fail-soft. Returns (returncode, combined_output).
+
+    Never raises -- a non-zero rc or an exception both surface as a failure the
+    caller inspects. This is the ONLY place the script touches subprocess.
+    """
+    try:
+        p = subprocess.run(
+            cmd, capture_output=True, text=True, timeout=timeout_s,
+        )
+        return p.returncode, (p.stdout or "") + (p.stderr or "")
+    except Exception as exc:  # noqa: BLE001 -- the bake never crashes on a call
+        return 1, f"[run failed: {exc!r}]"
+
+
+# --------------------------------------------------------------------------- #
+# Startup-script generator (installs the soak host deps + writes the sentinel).
+# --------------------------------------------------------------------------- #
+# The node-side file the image stamps the baked requirements sha into. The IaC
+# surgery's staleness check reads this; keep in sync with the IaC hypervisor's
+# _GOLDEN_BAKED_SHA_PATH default.
+_GOLDEN_BAKED_SHA_PATH = os.environ.get(
+    "JARVIS_IAC_GOLDEN_BAKED_SHA_PATH", "/etc/jarvis_soak_golden_sha"
+)
+
+
+def build_startup_script(
+    deps: List[str],
+    *,
+    sentinel_path: str = _SENTINEL_PATH,
+    remote_root: str = "/opt/trinity/jarvis",
+    baked_sha: str = "",
+) -> str:
+    """Return the metadata startup-script that bakes the soak deps.
+
+    Installs python3-pip + build tools (apt), then pip-installs the FULL soak deps
+    (requirements.txt with ML libs filtered, then the hard-ensure core), STAMPS
+    the baked requirements sha into the image (for the IaC staleness check), and
+    writes the readiness sentinel ONLY after the install completes. The
+    requirements.txt is shipped via metadata (a second metadata file the IaC
+    node-create path also uses) and read from /opt/trinity/jarvis. Pure string
+    assembly -- no I/O, no subprocess. ASCII only.
+    """
+    sentinel_q = shlex.quote(sentinel_path)
+    hard_ensure = " ".join(shlex.quote(d) for d in deps)
+    root_q = shlex.quote(remote_root)
+    req_remote = f"{remote_root}/requirements.txt"
+    req_q = shlex.quote(req_remote)
+    baked_sha_path_q = shlex.quote(_GOLDEN_BAKED_SHA_PATH)
+    baked_sha_q = shlex.quote(baked_sha)
+    return f"""#!/usr/bin/env bash
+# JARVIS soak golden-image bake startup-script (auto-generated).
+# Installs the soak host deps (requirements.txt + hard-ensure core, ML libs
+# filtered) and writes the readiness sentinel ONLY after the install completes.
+set -uo pipefail
+
+# ROOT-CAUSE FIX (mirrors J-Prime bake): GCP metadata startup-scripts run as root
+# with HOME unset; export it before anything that reads it.
+export HOME=/root
+export DEBIAN_FRONTEND=noninteractive
+
+LOG=/var/log/soak_bake.log
+exec > >(tee -a "$LOG") 2>&1
+echo "[soak-bake] startup-script begin $(date -u +%FT%TZ) (HOME=$HOME)"
+
+# Never leave a stale sentinel from a re-run.
+rm -f {sentinel_q} || true
+
+# 1. System packages: python3-pip + build tools (matches the IaC node boot).
+echo "[soak-bake] installing python3-pip + build tools"
+apt-get update -y -qq || true
+apt-get install -y -q python3-pip python3-dev build-essential || true
+python3 -m pip --version >/dev/null 2>&1 \\
+    || (curl -fsSL https://bootstrap.pypa.io/get-pip.py | sudo python3) >/dev/null 2>&1 || true
+
+# 2. Stage requirements.txt from instance metadata (shipped by the baker).
+mkdir -p {root_q} || true
+if curl -fsS -H 'Metadata-Flavor: Google' \\
+    'http://metadata.google.internal/computeMetadata/v1/instance/attributes/jarvis-requirements' \\
+    -o {req_q} 2>/dev/null; then
+    echo "[soak-bake] requirements.txt staged from metadata -> {req_remote}"
+else
+    echo "[soak-bake] WARNING: requirements.txt metadata absent; baking hard-ensure core only"
+    : > {req_q} || true
+fi
+
+# 3. Filter the multi-GB ML libs + native-build packages (EXACTLY the surgery's
+#    filter) so a bare Debian node never tries to build portaudio/pyobjc/etc.
+grep -ivE '{_ML_FILTER}' {req_q} \\
+    | sed -E 's/[[:space:]]*#.*$//; s/[[:space:]]*$//' > /tmp/req_light.txt 2>/dev/null \\
+    || : > /tmp/req_light.txt
+
+# 4. PER-PACKAGE, continue-on-failure install (a single unbuildable straggler
+#    must NOT abort the batch -- the proven surgery pattern).
+echo "[soak-bake] installing requirements.txt (filtered, per-package)"
+while IFS= read -r _pkg; do
+    case "$_pkg" in ''|\\#*) continue;; esac
+    sudo python3 -m pip install --break-system-packages -q "$_pkg" 2>/dev/null \\
+        || echo "[soak-bake] skip unbuildable: $_pkg"
+done < /tmp/req_light.txt
+
+# 5. HARD-ENSURE the A1-critical core (the loop is dead without these).
+echo "[soak-bake] hard-ensuring core deps"
+if sudo python3 -m pip install --break-system-packages -q {hard_ensure} 2>&1 | tail -1; then
+    echo "[soak-bake] hard-ensure install complete -- stamping baked sha + sentinel"
+    # Stamp the baked requirements sha into the image (IaC staleness check reads it).
+    echo {baked_sha_q} | sudo tee {baked_sha_path_q} >/dev/null 2>&1 \\
+        || echo {baked_sha_q} > {baked_sha_path_q} 2>/dev/null || true
+    echo "ready ts=$(date -u +%FT%TZ)" > {sentinel_q}
+    echo "[soak-bake] startup-script done $(date -u +%FT%TZ)"
+else
+    echo "[soak-bake] ERROR: hard-ensure pip install failed -- NOT writing sentinel"
+    exit 1
+fi
+"""
+
+
+# --------------------------------------------------------------------------- #
+# Validation-verdict parser (the load-bearing lock).
+# --------------------------------------------------------------------------- #
+# The remote validation script echoes one terminal marker line. PASS iff the
+# clean-import + pytest-collect + O+V-core-import all succeeded.
+_VALIDATION_OK_MARKER = "SOAK_BAKE_VALIDATION_OK"
+_VALIDATION_FAIL_MARKER = "SOAK_BAKE_VALIDATION_FAIL"
+
+
+def parse_validation_verdict(rc: int, body: str) -> Tuple[bool, str]:
+    """Decide PASS/ABORT from the remote validation result.
+
+    PASS iff the SSH call succeeded (rc == 0) AND the body contains the OK marker
+    AND does NOT contain the FAIL marker. Otherwise FAIL -- the caller ABORTS and
+    never snapshots. Returns (passed, reason). `reason` doubles as the diagnostic.
+    """
+    if rc != 0:
+        return False, f"transport/SSH failure (rc={rc})"
+    text = (body or "").strip()
+    if not text:
+        return False, "empty validation output"
+    if _VALIDATION_FAIL_MARKER in text:
+        # Surface the failing stanza for the operator.
+        return False, f"validation reported failure: {text[-400:]}"
+    if _VALIDATION_OK_MARKER not in text:
+        return False, f"no OK marker in validation output: {text[-400:]}"
+    return True, text[-300:]
+
+
+# The remote validation program (a single bash -c string). It runs the THREE
+# checks the spec mandates and echoes exactly one terminal marker. A failure of
+# ANY check echoes the FAIL marker (first-miss-wins) so the lock holds.
+def build_validation_remote(remote_root: str = "/opt/trinity/jarvis") -> str:
+    """Render the remote validation shell (deps import + pytest-collect + O+V core).
+
+    first-miss-wins: any failing check echoes SOAK_BAKE_VALIDATION_FAIL and exits.
+    Only when all three pass do we echo SOAK_BAKE_VALIDATION_OK.
+    """
+    root_q = shlex.quote(remote_root)
+    return (
+        "set -uo pipefail; export HOME=${HOME:-/root}; "
+        # CHECK 1: the baked deps import clean.
+        "if ! python3 -c 'import aiohttp, uuid6, fastapi, pydantic' 2>/tmp/soak_val_err; then "
+        f"echo \"{_VALIDATION_FAIL_MARKER} deps-import: $(cat /tmp/soak_val_err 2>/dev/null | tail -3)\"; exit 1; fi; "
+        # CHECK 2: pytest collection runs without a collection ERROR (the
+        # pytest-asyncio / conftest-autouse-fixture class of failure). cd into the
+        # synced repo if present; else collection of nothing is still a clean run.
+        f"if [ -d {root_q} ]; then cd {root_q} || true; fi; "
+        "if ! python3 -m pytest --collect-only -q 2>/tmp/soak_collect_err 1>/dev/null; then "
+        f"echo \"{_VALIDATION_FAIL_MARKER} pytest-collect: $(tail -3 /tmp/soak_collect_err 2>/dev/null)\"; exit 1; fi; "
+        # CHECK 3: O+V core imports resolve (operation_id etc.). Only meaningful
+        # when the repo is synced; absent repo skips this check (a fresh bake node
+        # has deps but no repo -- the IaC node syncs the repo at run time). We run
+        # from inside the repo root (PYTHONPATH=root) so the package resolves
+        # without any sys.path string-literal quoting hazard.
+        f"if [ -f {root_q}/backend/core/ouroboros/operation_id.py ]; then "
+        f"if ! ( cd {root_q} && PYTHONPATH={root_q} python3 -c "
+        "'from backend.core.ouroboros import operation_id' ) 2>/tmp/soak_ov_err; then "
+        f"echo \"{_VALIDATION_FAIL_MARKER} ov-core-import: $(tail -3 /tmp/soak_ov_err 2>/dev/null)\"; exit 1; fi; fi; "
+        f"echo {_VALIDATION_OK_MARKER}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# gcloud command builders (pure -- so dry-run can print them; _run executes).
+# --------------------------------------------------------------------------- #
+def _ssh_cmd(args: argparse.Namespace, node: str, remote: str) -> List[str]:
+    return [
+        "gcloud", "compute", "ssh", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--tunnel-through-iap", "--command", remote,
+    ]
+
+
+def _create_node_cmd(
+    args: argparse.Namespace, node: str, startup_script_path: str, requirements_path: str
+) -> List[str]:
+    # ON-DEMAND (no SPOT) for bake reliability: Spot is for active bursts, not the
+    # one-time bake. Ship requirements.txt via a metadata file the startup-script
+    # reads (so the baked deps match the repo exactly).
+    return [
+        "gcloud", "compute", "instances", "create", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        f"--machine-type={args.machine_type}",
+        f"--image-family={args.source_image_family}",
+        f"--image-project={args.source_image_project}",
+        f"--boot-disk-size={args.boot_disk_size}",
+        "--boot-disk-type=pd-balanced",
+        f"--metadata-from-file=startup-script={startup_script_path},"
+        f"jarvis-requirements={requirements_path}",
+    ]
+
+
+def _image_exists(args: argparse.Namespace) -> bool:
+    rc, _ = _run([
+        "gcloud", "compute", "images", "describe", args.image_name,
+        f"--project={args.project}", "--format=value(name)",
+    ])
+    return rc == 0
+
+
+# --------------------------------------------------------------------------- #
+# Cleanup (ALWAYS attempted once the node exists -- no orphaned billing).
+# --------------------------------------------------------------------------- #
+def _cleanup_node(args: argparse.Namespace, node: str) -> None:
+    """Delete the bake VM + its boot disk. Fail-soft, best-effort."""
+    _log(f"cleanup: deleting bake node {node} + disk (no orphaned billing)")
+    rc, out = _run([
+        "gcloud", "compute", "instances", "delete", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--delete-disks=all", "--quiet",
+    ], timeout_s=300.0)
+    if rc == 0:
+        _log(f"cleanup: node {node} + disk deleted")
+    else:
+        _log(f"cleanup: WARNING node delete rc={rc}: {out.strip()[:300]}")
+
+
+# --------------------------------------------------------------------------- #
+# Poll loop.
+# --------------------------------------------------------------------------- #
+_EARLY_FAIL_PATTERNS: List[re.Pattern] = [
+    re.compile(r"\bERROR\b", re.IGNORECASE),
+    re.compile(r"pip install failed", re.IGNORECASE),
+    re.compile(r"startup-script.*exit.*[1-9]", re.IGNORECASE),
+    re.compile(r"\bsoak-bake\].*ERROR", re.IGNORECASE),
+]
+
+
+def _check_bake_log(args: argparse.Namespace, node: str
+                    ) -> Tuple[Optional[str], Optional[str]]:
+    """SSH-fetch the last 5 lines of the bake log; return (last_line, fail_reason).
+
+    Fail-soft: any SSH/parse error returns (None, None).
+    """
+    remote = "sudo tail -n 5 /var/log/soak_bake.log 2>/dev/null || true"
+    try:
+        rc, out = _run(_ssh_cmd(args, node, remote), timeout_s=30.0)
+        if rc != 0 or not out:
+            return None, None
+        text = out.strip()
+        lines = [l for l in text.splitlines() if l.strip()]
+        last_line = lines[-1] if lines else None
+        for line in lines:
+            for pat in _EARLY_FAIL_PATTERNS:
+                if pat.search(line):
+                    return last_line, f"early-failure marker in log: {line.strip()[:200]}"
+        return last_line, None
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
+def _poll_readiness(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
+    """Poll the node (via SSH) for the readiness sentinel.
+
+    Exponential-ish backoff, bounded by --bake-timeout-s. Returns (ready, reason).
+    """
+    deadline = time.monotonic() + float(args.bake_timeout_s)
+    delay = 15.0
+    attempt = 0
+    check = (
+        f"test -f {shlex.quote(_SENTINEL_PATH)} "
+        "&& echo SOAK_READY || echo SOAK_NOT_READY"
+    )
+    while time.monotonic() < deadline:
+        attempt += 1
+        rc, out = _run(_ssh_cmd(args, node, check), timeout_s=90.0)
+        if rc == 0 and "SOAK_READY" in out:
+            _log(f"readiness: node ready (attempt {attempt})")
+            return True, ""
+
+        last_line, fail_reason = _check_bake_log(args, node)
+        if last_line:
+            _log(f"node progress: {last_line}")
+        if fail_reason:
+            _log(f"readiness: EARLY ABORT -- {fail_reason}")
+            return False, f"early_failure: {fail_reason}"
+
+        remaining = int(deadline - time.monotonic())
+        _log(
+            f"readiness: not ready (attempt {attempt}, rc={rc}); "
+            f"{remaining}s left, sleeping {int(delay)}s"
+        )
+        if time.monotonic() + delay >= deadline:
+            break
+        time.sleep(delay)
+        delay = min(delay * 1.5, 120.0)
+    _log(f"readiness: TIMEOUT after {args.bake_timeout_s}s")
+    return False, "readiness_timeout"
+
+
+# --------------------------------------------------------------------------- #
+# Validation (the load-bearing lock -- run the 3 checks before snapshot).
+# --------------------------------------------------------------------------- #
+def _validate_deps(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
+    """SSH-run the validation program (deps import + pytest-collect + O+V core)."""
+    remote = build_validation_remote()
+    _log("validation: running deps-import + pytest-collect + O+V-core checks")
+    rc, out = _run(_ssh_cmd(args, node, remote), timeout_s=300.0)
+    return parse_validation_verdict(rc, out)
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run plan printer.
+# --------------------------------------------------------------------------- #
+def _print_plan(
+    args: argparse.Namespace, node: str, startup_script: str, deps: List[str]
+) -> None:
+    req_sha = requirements_sha(args.requirements)
+    print("=" * 72)
+    print("SOAK GOLDEN-IMAGE BAKE -- PLAN (dry-run, spends nothing)")
+    print("=" * 72)
+    print(f"  project        : {args.project}")
+    print(f"  zone           : {args.zone}")
+    print(f"  machine-type   : {args.machine_type}")
+    print(f"  bake node      : {node}  (ON-DEMAND for bake reliability)")
+    print(f"  source image   : {args.source_image_family}/{args.source_image_project}")
+    print(f"  boot disk      : {args.boot_disk_size}")
+    print(f"  bake timeout   : {args.bake_timeout_s}s")
+    print(f"  requirements   : {args.requirements}")
+    print(f"  req sha label  : {_REQ_SHA_LABEL_KEY}={req_sha}")
+    print(f"  hard-ensure    : {' '.join(deps)}")
+    print(f"  -> image name  : {args.image_name}")
+    print(f"  -> image family: {args.image_family}")
+    print("-" * 72)
+    print("STARTUP-SCRIPT (metadata startup-script):")
+    print(startup_script)
+    print("-" * 72)
+    print("GCLOUD COMMANDS THAT WOULD RUN (in order):")
+    print("  1. PROVISION (ships requirements.txt as metadata):")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _create_node_cmd(args, node, "<startup-script-tmpfile>",
+                                               args.requirements)))
+    print("  2. POLL READINESS (repeated, bounded):")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _ssh_cmd(args, node, "test -f " + _SENTINEL_PATH + " ...")))
+    print("  3. VALIDATION LOCK (deps import + pytest-collect + O+V; NO snapshot unless PASS):")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _ssh_cmd(args, node, build_validation_remote())))
+    print("  4. STOP instance (consistent image):")
+    print(f"     gcloud compute instances stop {node} "
+          f"--project={args.project} --zone={args.zone} --quiet")
+    print("  5. CREATE GOLDEN IMAGE (stamped with req-sha label):")
+    print(f"     gcloud compute images create {args.image_name} "
+          f"--project={args.project} --source-disk={node} "
+          f"--source-disk-zone={args.zone} --family={args.image_family} "
+          f"--labels={_REQ_SHA_LABEL_KEY}={req_sha}")
+    print("  6. DELETE-TO-SNAPSHOT (node + disk; image is the durable artifact):")
+    print(f"     gcloud compute instances delete {node} "
+          f"--project={args.project} --zone={args.zone} --delete-disks=all --quiet")
+    print("-" * 72)
+    print("AFTER THE BAKE: arm the IaC golden path with")
+    print("  export JARVIS_IAC_SOAK_GOLDEN_ENABLED=1")
+    print("=" * 72)
+    print("[SOAK-BAKE] --dry-run: nothing executed, no money spent. Use --execute to bake.")
+
+
+# --------------------------------------------------------------------------- #
+# Execute pipeline.
+# --------------------------------------------------------------------------- #
+def _execute_bake(
+    args: argparse.Namespace, node: str, startup_script: str
+) -> int:
+    # Idempotency guard: refuse to clobber an existing image unless --force.
+    if _image_exists(args):
+        if not args.force:
+            _abort(
+                f"image '{args.image_name}' already exists -- "
+                "rerun with --force to replace, or pass a new --image-name"
+            )
+            return 3
+        _log(f"WARNING: image '{args.image_name}' exists -- --force given, "
+             "will delete + recreate after a clean bake")
+
+    import tempfile
+    fd, sp_path = tempfile.mkstemp(prefix="soak_startup_", suffix=".sh")
+    node_exists = False
+    req_sha = requirements_sha(args.requirements)
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(startup_script)
+
+        # 1. PROVISION (ON-DEMAND, ship requirements.txt as metadata).
+        _log(f"provisioning bake node {node} (ON-DEMAND, {args.machine_type})")
+        rc, out = _run(
+            _create_node_cmd(args, node, sp_path, args.requirements), timeout_s=300.0
+        )
+        if rc != 0:
+            _abort(f"provision failed rc={rc}: {out.strip()[:400]}")
+            return 4
+        node_exists = True
+        _log(f"node {node} created; startup-script installing soak deps")
+
+        # 2. POLL READINESS.
+        ready, poll_reason = _poll_readiness(args, node)
+        if not ready:
+            _abort(f"readiness abort: {poll_reason}")
+            return 5
+
+        # 3. VALIDATION LOCK -- never snapshot a broken image.
+        passed, sample = _validate_deps(args, node)
+        if not passed:
+            _abort(f"validation failed: {sample}")
+            return 6
+        _log("validation: PASS -- deps import + pytest-collect + O+V core all clean")
+        _log(f"validation sample: {sample[:300]!r}")
+
+        # 4. STOP for a consistent image.
+        _log(f"stopping {node} for a consistent image snapshot")
+        rc, out = _run([
+            "gcloud", "compute", "instances", "stop", node,
+            f"--project={args.project}", f"--zone={args.zone}", "--quiet",
+        ], timeout_s=300.0)
+        if rc != 0:
+            _abort(f"instance stop failed rc={rc}: {out.strip()[:300]}")
+            return 7
+
+        # If --force replacing an existing image, delete the old one first.
+        if args.force and _image_exists(args):
+            _log(f"--force: deleting existing image {args.image_name}")
+            _run([
+                "gcloud", "compute", "images", "delete", args.image_name,
+                f"--project={args.project}", "--quiet",
+            ], timeout_s=300.0)
+
+        # 5. CREATE GOLDEN IMAGE (stamped with the req-sha label for staleness).
+        _log(f"creating golden image {args.image_name} (family={args.image_family}, "
+             f"{_REQ_SHA_LABEL_KEY}={req_sha})")
+        rc, out = _run([
+            "gcloud", "compute", "images", "create", args.image_name,
+            f"--project={args.project}", f"--source-disk={node}",
+            f"--source-disk-zone={args.zone}", f"--family={args.image_family}",
+            f"--labels={_REQ_SHA_LABEL_KEY}={req_sha}",
+        ], timeout_s=900.0)
+        if rc != 0:
+            _abort(f"image create failed rc={rc}: {out.strip()[:400]}")
+            return 8
+        _log(f"golden image created: {args.image_name}")
+
+        _report_success(args, node, req_sha, sample)
+        return 0
+    finally:
+        try:
+            os.unlink(sp_path)
+        except OSError:
+            pass
+        # ALWAYS tear the node + disk down -- success or failure. The image (if
+        # created) is the durable artifact; the VM must never linger.
+        if node_exists:
+            _cleanup_node(args, node)
+
+
+def _report_success(
+    args: argparse.Namespace, node: str, req_sha: str, sample: str
+) -> None:
+    print("=" * 72)
+    print("[SOAK-BAKE] SUCCESS -- golden image baked + validated")
+    print("=" * 72)
+    print(f"  image name   : {args.image_name}")
+    print(f"  image family : {args.image_family}")
+    print(f"  req sha label: {_REQ_SHA_LABEL_KEY}={req_sha}")
+    print("  validation   : PASS (deps import + pytest-collect + O+V core)")
+    print(f"  sample       : {sample[:200]!r}")
+    print("-" * 72)
+    print("  ARM the IaC golden path:")
+    print("    export JARVIS_IAC_SOAK_GOLDEN_ENABLED=1")
+    print("=" * 72)
+
+
+# --------------------------------------------------------------------------- #
+# CLI.
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "One-time autonomous bake of the soak host-deps golden image "
+            "(provision -> install deps -> VALIDATE -> snapshot -> "
+            "delete-to-snapshot). Default is --dry-run."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--project", default=_DEFAULT_PROJECT,
+                   help="GCP project (env GCP_PROJECT)")
+    p.add_argument("--zone", default=_DEFAULT_ZONE,
+                   help="GCP zone (env GCP_ZONE)")
+    p.add_argument("--machine-type", default=_DEFAULT_MACHINE,
+                   help="bake machine type (env JARVIS_SOAK_BAKE_MACHINE)")
+    p.add_argument("--image-name", default=_default_image_name(),
+                   help="golden image name (env JARVIS_SOAK_IMAGE_NAME)")
+    p.add_argument("--image-family", default=_DEFAULT_IMAGE_FAMILY,
+                   help="golden image family (env JARVIS_IAC_SOAK_GOLDEN_IMAGE_FAMILY)")
+    p.add_argument("--boot-disk-size", default=_DEFAULT_BOOT_DISK,
+                   help="bake node boot disk size")
+    p.add_argument("--bake-timeout-s", type=int, default=_DEFAULT_BAKE_TIMEOUT_S,
+                   help="readiness poll timeout (seconds)")
+    p.add_argument("--source-image-family", default=_DEFAULT_DEBIAN_IMAGE_FAMILY,
+                   help="base OS image family (Debian)")
+    p.add_argument("--source-image-project", default=_DEFAULT_DEBIAN_IMAGE_PROJECT,
+                   help="base OS image project")
+    p.add_argument("--requirements", default=_DEFAULT_REQUIREMENTS,
+                   help="requirements.txt path (env JARVIS_SOAK_BAKE_REQUIREMENTS)")
+    p.add_argument("--node-name", default=None,
+                   help="bake node name (default jarvis-soak-bake-<stamp>)")
+    p.add_argument("--force", action="store_true",
+                   help="replace an existing image of the same name")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="dry_run", action="store_true",
+                      help="print the plan + commands WITHOUT executing (default)")
+    mode.add_argument("--execute", dest="dry_run", action="store_false",
+                      help="actually run the bake (spends money)")
+    p.set_defaults(dry_run=True)
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    node = args.node_name or f"jarvis-soak-bake-{_now_stamp()}-{int(time.time()) % 100000}"
+    deps = _load_hard_ensure_deps()
+    startup_script = build_startup_script(deps, baked_sha=requirements_sha(args.requirements))
+
+    if args.dry_run:
+        _print_plan(args, node, startup_script, deps)
+        return 0
+
+    _log("EXECUTE mode -- this WILL provision a GCP node and spend money")
+    return _execute_bake(args, node, startup_script)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -280,6 +280,87 @@ def _env_truthy_off(name: str) -> bool:
 
 _FAULT_TOLERANT_OBS_ENABLED = _env_truthy_off("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED")
 
+
+# --------------------------------------------------------------------------- #
+# SOAK GOLDEN IMAGE (kills the ~20-min pip-install sink).
+#
+# Master gate default-OFF -> the CURRENT debian-12 + full-pip path is byte-
+# identical. When armed AND the jarvis-soak-golden image exists, node-create
+# boots from the golden image (deps pre-installed) and the surgery's deps step
+# DETECTS pre-installed deps and SKIPS the pip install. Staleness: if the
+# image's requirements.txt sha label != the current sha, the deps step
+# DELTA-ensures (pip the missing/changed only) -- never silently runs stale.
+#
+# CONSTRAINT 3 -- INDESTRUCTIBLE bootstrapper: if the golden image fails to boot
+# OR the deps-present probe fails within the verify timeout, the surgery logs a
+# LOUD warning and FALLS BACK to the raw Debian + full pip-install path. A
+# corrupt/missing image NEVER hard-blocks a run (completion > speed).
+# --------------------------------------------------------------------------- #
+_SOAK_GOLDEN_ENABLED = _env_truthy_off("JARVIS_IAC_SOAK_GOLDEN_ENABLED")
+_DEFAULT_SOAK_GOLDEN_IMAGE_FAMILY = os.environ.get(
+    "JARVIS_IAC_SOAK_GOLDEN_IMAGE_FAMILY", "jarvis-soak-golden"
+)
+# The label key the baker stamps the requirements.txt sha into.
+_GOLDEN_REQ_SHA_LABEL = os.environ.get(
+    "JARVIS_IAC_GOLDEN_REQ_SHA_LABEL", "jarvis_req_sha"
+)
+# How long the deps-present probe gets before the indestructible fallback fires.
+_DEFAULT_GOLDEN_VERIFY_TIMEOUT_S = int(
+    os.environ.get("JARVIS_IAC_GOLDEN_VERIFY_TIMEOUT_S", "120")
+)
+# The repo requirements.txt (for the local-side staleness sha compute).
+_DEFAULT_REQUIREMENTS_PATH = os.environ.get(
+    "JARVIS_IAC_REQUIREMENTS_PATH", "requirements.txt"
+)
+# The node-side file the baker stamps the baked requirements sha into (read by
+# the surgery's staleness check). Absent on a non-golden node -> mismatch.
+_GOLDEN_BAKED_SHA_PATH = os.environ.get(
+    "JARVIS_IAC_GOLDEN_BAKED_SHA_PATH", "/etc/jarvis_soak_golden_sha"
+)
+
+
+def _soak_golden_enabled(args: Optional["argparse.Namespace"] = None) -> bool:
+    """Resolve the soak-golden master gate from args (if present) else env.
+    Default-OFF -> the current debian-12 + full-pip behavior (byte-identical)."""
+    if args is not None:
+        val = getattr(args, "soak_golden", None)
+        if val is not None:
+            return bool(val)
+    return _env_truthy_off("JARVIS_IAC_SOAK_GOLDEN_ENABLED")
+
+
+def requirements_sha(req_path: str) -> str:
+    """sha256[:16] of requirements.txt -- the staleness stamp (matches the baker).
+
+    Fail-soft: a missing file yields 'norequirements' so the staleness check
+    treats it as a guaranteed mismatch (delta-ensure / full path), never a crash.
+    """
+    try:
+        data = pathlib.Path(req_path).read_bytes()
+    except Exception:  # noqa: BLE001
+        return "norequirements"
+    return hashlib.sha256(data).hexdigest()[:16]
+
+
+def golden_image_status(
+    args: argparse.Namespace,
+) -> Tuple[bool, Optional[str]]:
+    """Describe the golden image: (exists, req_sha_label_or_None). Fail-soft.
+
+    Reads the most-recent image in the family + its req-sha label via gcloud.
+    Any failure -> (False, None) so the caller uses the debian-12 + pip path.
+    """
+    family = getattr(args, "soak_golden_image_family", _DEFAULT_SOAK_GOLDEN_IMAGE_FAMILY)
+    rc, out = _run([
+        "gcloud", "compute", "images", "describe-from-family", family,
+        f"--project={args.project}",
+        f"--format=value(labels.{_GOLDEN_REQ_SHA_LABEL})",
+    ])
+    if rc != 0:
+        return False, None
+    label = (out or "").strip() or None
+    return True, label
+
 # Heartbeat: node-side setsid loop interval + elevated OS priority (so a swarm
 # redlining CPU/IO at 100% can NEVER starve/OOM-kill it -> no false freeze).
 _DEFAULT_HEARTBEAT_INTERVAL_S = float(
@@ -860,24 +941,54 @@ def build_startup_script(
 # --------------------------------------------------------------------------- #
 # gcloud / ssh / rsync command builders (pure -- so dry-run can print them).
 # --------------------------------------------------------------------------- #
+def _resolve_node_image(args: argparse.Namespace) -> Tuple[str, str]:
+    """Resolve the (image_family, image_project) the node boots from.
+
+    SOAK GOLDEN (gated default-OFF, byte-identical when off): when
+    JARVIS_IAC_SOAK_GOLDEN_ENABLED AND the jarvis-soak-golden image EXISTS, boot
+    from the golden family in THIS project (deps pre-installed). Otherwise (gate
+    off OR no image) use the configured debian-12 family/project -- byte-identical
+    to the legacy path. Fail-soft: any describe error falls back to debian-12.
+    """
+    if _soak_golden_enabled(args):
+        try:
+            exists, _label = golden_image_status(args)
+        except Exception:  # noqa: BLE001 -- never crash node-create on a probe
+            exists = False
+        if exists:
+            family = getattr(
+                args, "soak_golden_image_family", _DEFAULT_SOAK_GOLDEN_IMAGE_FAMILY
+            )
+            _log(f"[golden] booting from soak golden image family '{family}' "
+                 "(deps pre-installed)")
+            # The golden image lives in THIS project, not debian-cloud.
+            return family, args.project
+        _log("[golden] soak-golden enabled but image absent -- using debian-12 + pip")
+    return args.source_image_family, args.source_image_project
+
+
 def _create_node_cmd(
     args: argparse.Namespace, node: str, startup_script_path: str
 ) -> List[str]:
     """e2-standard-8 (32GB) node, max_run_duration + DELETE (cost ceiling),
     cloud-platform scope (the dead-man needs it). SPOT by default (cheapest);
     --on-demand uses STANDARD for an UNINTERRUPTED window (no preemption) when a
-    multi-stage run needs to complete without a Spot reclaim mid-surgery."""
+    multi-stage run needs to complete without a Spot reclaim mid-surgery.
+
+    Image family/project resolved via _resolve_node_image (soak-golden when
+    enabled+present, else debian-12 -- byte-identical when the gate is off)."""
     on_demand = bool(getattr(args, "on_demand", False))
     sched = (
         ["--provisioning-model=STANDARD"] if on_demand
         else ["--provisioning-model=SPOT"]
     )
+    image_family, image_project = _resolve_node_image(args)
     return [
         "gcloud", "compute", "instances", "create", node,
         f"--project={args.project}", f"--zone={args.zone}",
         f"--machine-type={args.machine_type}",
-        f"--image-family={args.source_image_family}",
-        f"--image-project={args.source_image_project}",
+        f"--image-family={image_family}",
+        f"--image-project={image_project}",
         f"--boot-disk-size={args.boot_disk_size}",
         "--boot-disk-type=pd-balanced",
         *sched,
@@ -1470,9 +1581,36 @@ def _surgery_env_exports() -> str:
     )
 
 
+# --------------------------------------------------------------------------- #
+# HARD-ENSURE core deps -- the single source of truth (no literal duplication).
+#
+# These are the A1-critical packages the code-repair loop is DEAD without. The
+# surgery's dep-install hard-ensures them after the requirements.txt batch; the
+# golden-image baker bakes EXACTLY this set + requirements.txt so a golden node
+# can SKIP the pip install entirely; and the golden deps-present probe imports a
+# representative subset of these to verify the image is good. Env-overridable so
+# the set is never hardcoded in two places.
+# --------------------------------------------------------------------------- #
+_HARD_ENSURE_DEPS: List[str] = (
+    os.environ.get(
+        "JARVIS_IAC_HARD_ENSURE_DEPS",
+        "aiohttp httpx pydantic pytest pytest-asyncio pyyaml requests anyio "
+        "sniffio fastapi uvicorn orjson uuid6",
+    )
+    .strip()
+    .split()
+)
+
+
+def hard_ensure_deps() -> List[str]:
+    """Return the hard-ensure core dep list (single source of truth)."""
+    return list(_HARD_ENSURE_DEPS)
+
+
 def _surgery_dep_install() -> str:
     """The host-python dep install (heavy pip -- the run-#15 SSH-drop locus).
     Shared verbatim by the legacy single-stream + the detached daemon paths."""
+    _hard_ensure = " ".join(_HARD_ENSURE_DEPS)
     return os.environ.get(
         "JARVIS_IAC_SURGERY_DEP_INSTALL",
         "echo '[deps] installing jarvis host deps (pip from boot; ML libs filtered)'; "
@@ -1503,9 +1641,71 @@ def _surgery_dep_install() -> str:
         # uuid6 is UNDECLARED in requirements.txt but imported by core governance
         # (operation_id.py) -- O+V crashes at boot without it (the run #8 wall: the
         # soak never produced a debug.log, no A1Trace, because the import died).
-        "sudo python3 -m pip install --break-system-packages -q aiohttp httpx pydantic "
-        "pytest pytest-asyncio pyyaml requests anyio sniffio fastapi uvicorn orjson uuid6 2>&1 | tail -1; "
+        "sudo python3 -m pip install --break-system-packages -q " + _hard_ensure + " 2>&1 | tail -1; "
         "python3 -c 'import aiohttp; print(\"[deps] aiohttp ok\", aiohttp.__version__)' 2>&1 | tail -1",
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Golden-image-aware deps step (CONSTRAINT 2 + CONSTRAINT 3).
+#
+# When the soak-golden gate is OFF -> returns the legacy full-pip body verbatim
+# (byte-identical). When ON, returns a node-side bash program that:
+#   * probes for the pre-installed deps within the verify timeout;
+#   * deps PRESENT + sha MATCHES   -> SKIP pip (logs the skip line);
+#   * deps PRESENT + sha MISMATCH  -> DELTA-ENSURE (hard-ensure only the core,
+#                                     never silently run stale);
+#   * deps ABSENT / probe FAILS    -> INDESTRUCTIBLE FALLBACK: loud warning +
+#                                     the FULL pip-install path (never blocks).
+# `expected_sha` is computed LOCALLY (the repo requirements.txt) and embedded;
+# the node reads the baked sha from /etc/jarvis_soak_golden_sha (stamped by the
+# baker's image -- absent on a non-golden node -> treated as a mismatch).
+# --------------------------------------------------------------------------- #
+def _surgery_dep_step(args: argparse.Namespace) -> str:
+    """Dispatch the deps step: golden-aware when enabled, else legacy (byte-id)."""
+    if not _soak_golden_enabled(args):
+        return _surgery_dep_install()
+    return _golden_dep_install(args)
+
+
+def _golden_dep_install(args: argparse.Namespace) -> str:
+    """Golden-aware deps body: probe -> skip / delta-ensure / fallback-to-pip."""
+    full_pip = _surgery_dep_install()  # the indestructible fallback path
+    hard_ensure = " ".join(shlex.quote(d) for d in _HARD_ENSURE_DEPS)
+    # Local-side expected sha of THIS checkout's requirements.txt.
+    req_path = getattr(args, "requirements_path", _DEFAULT_REQUIREMENTS_PATH)
+    expected_sha = requirements_sha(req_path)
+    verify_to = int(getattr(args, "golden_verify_timeout_s",
+                            _DEFAULT_GOLDEN_VERIFY_TIMEOUT_S))
+    baked_sha_file = shlex.quote(_GOLDEN_BAKED_SHA_PATH)
+    # The deps-present probe: a representative import of the hard-ensure core. We
+    # wrap it in `timeout` so a hung interpreter can't exceed the verify budget ->
+    # CONSTRAINT 3 fires (fall back to pip) instead of stalling the run.
+    probe = (
+        f"timeout {verify_to} python3 -c "
+        "'import aiohttp, uuid6, fastapi, pydantic, pytest_asyncio' "
+        "2>/tmp/golden_probe_err"
+    )
+    return (
+        "echo '[deps] soak-golden enabled -- probing pre-installed deps'; "
+        f"if {probe}; then "
+        # Deps present. Compare the baked sha to the expected sha for staleness.
+        f"_baked_sha=$(cat {baked_sha_file} 2>/dev/null || echo ''); "
+        f"if [ \"$_baked_sha\" = {shlex.quote(expected_sha)} ]; then "
+        "echo '[deps] golden image -- deps present, skipping install'; "
+        "else "
+        "echo \"[deps] golden image STALE (baked=$_baked_sha "
+        f"expected={expected_sha}) -- delta-ensuring core deps\"; "
+        f"sudo python3 -m pip install --break-system-packages -q {hard_ensure} 2>&1 | tail -1 || true; "
+        "fi; "
+        "else "
+        # CONSTRAINT 3: probe failed within the verify timeout (corrupt/missing
+        # image OR a deps interpreter that won't import). LOUD warning + FULL pip.
+        "echo '[bootstrap] golden image unavailable/unverified -- FALLING BACK "
+        "to raw Debian + full pip install'; "
+        "echo \"[bootstrap] probe stderr: $(tail -3 /tmp/golden_probe_err 2>/dev/null)\"; "
+        f"{full_pip}; "
+        "fi"
     )
 
 
@@ -1543,7 +1743,7 @@ def _remote_surgery_shell(args: argparse.Namespace) -> str:
     daemon path is OFF (JARVIS_IAC_DETACHED_SURGERY_ENABLED=false) -- byte-identical."""
     jr = f"{_REMOTE_TRINITY_ROOT}/jarvis"
     env = _surgery_env_exports()
-    dep_install = _surgery_dep_install()
+    dep_install = _surgery_dep_step(args)
     out_q = shlex.quote(_DEFAULT_SURGERY_OUT_PATH)
     # cd into the synced jarvis repo, install deps, run the surgery. The completion
     # sentinel (which arms the node-side dead-man to burn IMMEDIATELY) is dropped
@@ -1646,7 +1846,7 @@ def _remote_surgery_body_script(args: argparse.Namespace) -> str:
     trap. ASCII only, no f-string brace conflicts in the JSON (built via printf)."""
     jr = f"{_REMOTE_TRINITY_ROOT}/jarvis"
     env = _surgery_env_exports()
-    dep_install = _surgery_dep_install()
+    dep_install = _surgery_dep_step(args)
     state_q = shlex.quote(_DEFAULT_SOAK_STATE_PATH)
     lock_q = shlex.quote(_DEFAULT_SOAK_LOCK_PATH)
     out_q = shlex.quote(_DEFAULT_SURGERY_OUT_PATH)
@@ -2960,6 +3160,26 @@ def build_parser() -> argparse.ArgumentParser:
     p.add_argument("--boot-disk-size", default=_DEFAULT_BOOT_DISK)
     p.add_argument("--source-image-family", default=_DEFAULT_DEBIAN_IMAGE_FAMILY)
     p.add_argument("--source-image-project", default=_DEFAULT_DEBIAN_IMAGE_PROJECT)
+    # ---- Soak golden image (kills the ~20-min pip-install sink). Default-OFF --- #
+    p.add_argument(
+        "--soak-golden", dest="soak_golden", action="store_true",
+        default=_env_truthy_off("JARVIS_IAC_SOAK_GOLDEN_ENABLED"),
+        help="boot from the jarvis-soak-golden image (deps pre-installed) when it "
+             "exists + skip pip; INDESTRUCTIBLE fallback to debian-12+pip on any "
+             "golden failure (default OFF -> byte-identical debian-12+pip)",
+    )
+    p.add_argument(
+        "--no-soak-golden", dest="soak_golden", action="store_false",
+        help="force the legacy debian-12 + full-pip path (byte-identical OFF path)",
+    )
+    p.add_argument("--soak-golden-image-family", default=_DEFAULT_SOAK_GOLDEN_IMAGE_FAMILY,
+                   help="soak golden image family (env JARVIS_IAC_SOAK_GOLDEN_IMAGE_FAMILY)")
+    p.add_argument("--golden-verify-timeout-s", type=int,
+                   default=_DEFAULT_GOLDEN_VERIFY_TIMEOUT_S,
+                   help="deps-present probe budget before the indestructible "
+                        "fallback fires (env JARVIS_IAC_GOLDEN_VERIFY_TIMEOUT_S)")
+    p.add_argument("--requirements-path", default=_DEFAULT_REQUIREMENTS_PATH,
+                   help="requirements.txt for the staleness sha (env JARVIS_IAC_REQUIREMENTS_PATH)")
     p.add_argument("--max-run-duration-s", type=int, default=_DEFAULT_MAX_RUN_DURATION_S,
                    help="GCP hard ceiling (env JARVIS_IAC_MAX_RUN_DURATION_S)")
     p.add_argument("--ready-timeout-s", type=int, default=_DEFAULT_READY_TIMEOUT_S)

--- a/tests/governance/test_meta_goal_aggregator.py
+++ b/tests/governance/test_meta_goal_aggregator.py
@@ -1,0 +1,471 @@
+"""Tests for the Adaptive Meta-Goal Aggregator (swarm run-#3 single_file_op fix).
+
+The aggregator bundles N *disjoint* single-file ops pooled in the dispatch
+queue into ONE fan-outable Meta-Goal whose ExecutionGraph fans out to
+parallel swarm workers -- instead of each single-file op hitting the
+``SINGLE_FILE_OP`` reject in ``is_fanout_eligible`` and queuing serially.
+
+Coverage:
+- 3 disjoint single-file ops in the window -> ONE Meta-Goal,
+  ``is_fanout_eligible(... force=...)`` returns ``allowed=True n=3``
+  (the run-#3 fix).
+- collision-COUPLED ops are NOT bundled together.
+- 50 ops -> CHUNKED into capacity-sized Meta-Goals (no single DAG >
+  capacity; batch size adapts to a mocked MemoryPressureGate / worker cap).
+- partial recomposition (Poison-Pill): 2 succeed + 1 fail -> composed
+  candidate has the 2, the failed unit routed to the Cryo-DLQ
+  (``append_dlq`` called), ONE PR not scrapped.
+- a node failover mid-flight -> the unit resumes via the override handoff,
+  siblings unaffected, DAG completes.
+- telemetry tags meta_goal_id + unit op-id.
+- master OFF -> single-file dispatch byte-identical (no Meta-Goal).
+"""
+from __future__ import annotations
+
+import os
+from typing import Optional, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomy.subagent_types import (
+    ExecutionGraph,
+    GraphExecutionPhase,
+    GraphExecutionState,
+    WorkUnitResult,
+    WorkUnitSpec,
+    WorkUnitState,
+)
+from backend.core.ouroboros.governance.memory_pressure_gate import (
+    FanoutDecision,
+    MemoryPressureGate,
+    PressureLevel,
+)
+from backend.core.ouroboros.governance.saga.saga_types import (
+    FileOp,
+    PatchedFile,
+    RepoPatch,
+)
+
+import backend.core.ouroboros.governance.meta_goal_aggregator as mga
+from backend.core.ouroboros.governance.meta_goal_aggregator import (
+    MetaGoalAggregator,
+    PooledOp,
+    MetaGoalBundle,
+    META_GOAL_FLAG,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    """Default-ON aggregator + parallel master for the bundling tests.
+
+    Individual tests that need master-OFF byte-identical behaviour flip the
+    flags back off explicitly.
+    """
+    monkeypatch.setenv(META_GOAL_FLAG, "true")
+    monkeypatch.setenv("JARVIS_WAVE3_PARALLEL_DISPATCH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_META_GOAL_MIN_OPS", "2")
+    # Make memory + posture deterministic / permissive by default.
+    monkeypatch.setenv("JARVIS_WAVE3_PARALLEL_MAX_UNITS", "5")
+    yield
+
+
+def _gate_allowing(n: int) -> MemoryPressureGate:
+    """A MemoryPressureGate whose can_fanout clamps to <= n (OK level)."""
+
+    class _G(MemoryPressureGate):
+        def can_fanout(self, n_requested: int) -> FanoutDecision:  # type: ignore[override]
+            allowed = min(int(n_requested), n)
+            return FanoutDecision(
+                allowed=allowed >= 1,
+                n_requested=int(n_requested),
+                n_allowed=allowed,
+                level=PressureLevel.OK,
+                free_pct=90.0,
+                reason_code="test.capped",
+                source="test",
+            )
+
+    return _G()
+
+
+def _posture_neutral():
+    return (None, None)
+
+
+class _DisjointOracle:
+    """Oracle stub: every file is indexed with NO coupling -> provably disjoint.
+
+    This models the common case the aggregator targets: isolated single-file
+    chaos failures on distinct, import-isolated files. The zero-trust
+    collision matrix needs *positive* Oracle data to PROVE disjointness; an
+    absent Oracle would (correctly) treat unknown coupling as a collision.
+    """
+
+    class _Node:
+        def __init__(self, fp):
+            self.file_path = fp
+
+    def find_nodes_in_file(self, file_path):
+        return [self._Node(file_path)]
+
+    def get_dependencies(self, node):
+        return []
+
+    def get_dependents(self, node):
+        return []
+
+
+def _op(op_id: str, file_path: str) -> PooledOp:
+    return PooledOp(op_id=op_id, file_path=file_path, full_content=f"# {file_path}\n", rationale=f"fix {file_path}")
+
+
+def _completed_result(unit_id: str, file_path: str) -> WorkUnitResult:
+    patch = RepoPatch(
+        repo="jarvis",
+        files=(PatchedFile(path=file_path, op=FileOp.CREATE, preimage=None),),
+        new_content=((file_path, f"# patched {file_path}\n".encode("utf-8")),),
+    )
+    return WorkUnitResult(
+        unit_id=unit_id,
+        repo="jarvis",
+        status=WorkUnitState.COMPLETED,
+        patch=patch,
+        attempt_count=1,
+        started_at_ns=1,
+        finished_at_ns=2,
+    )
+
+
+def _failed_result(unit_id: str) -> WorkUnitResult:
+    return WorkUnitResult(
+        unit_id=unit_id,
+        repo="jarvis",
+        status=WorkUnitState.FAILED,
+        patch=None,
+        attempt_count=1,
+        started_at_ns=1,
+        finished_at_ns=2,
+        failure_class="infra",
+        error="dw collapse + jprime failover exhausted",
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. The run-#3 fix: 3 disjoint single-file ops -> ONE Meta-Goal, allowed=True n=3
+# ---------------------------------------------------------------------------
+
+
+def test_three_disjoint_single_file_ops_form_one_meta_goal():
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(5),
+        posture_fn=_posture_neutral,
+        oracle=_DisjointOracle(),  # None oracle => zero-trust; single-file unique paths still disjoint via direct-overlap check only
+    )
+    ops = [
+        _op("op-aaa", "backend/a.py"),
+        _op("op-bbb", "backend/b.py"),
+        _op("op-ccc", "backend/c.py"),
+    ]
+    for o in ops:
+        agg.offer(o)
+
+    bundles = agg.drain_ready_bundles()
+    assert len(bundles) == 1, "3 disjoint single-file ops should form exactly one Meta-Goal"
+    bundle = bundles[0]
+    assert isinstance(bundle, MetaGoalBundle)
+    # The run-#3 fix: eligibility allows fan-out of 3, NOT a SINGLE_FILE_OP reject.
+    assert bundle.eligibility.allowed is True
+    assert bundle.eligibility.n_allowed == 3
+    assert len(bundle.graph.units) == 3
+    # target_files = union of the 3 single-file ops
+    union = {f for u in bundle.graph.units for f in u.target_files}
+    assert union == {"backend/a.py", "backend/b.py", "backend/c.py"}
+    # meta_goal_id present + each unit traceable back to its origin op
+    assert bundle.meta_goal_id
+    assert set(bundle.unit_to_op.values()) == {"op-aaa", "op-bbb", "op-ccc"}
+
+
+def test_below_min_ops_does_not_bundle(monkeypatch):
+    monkeypatch.setenv("JARVIS_META_GOAL_MIN_OPS", "3")
+    agg = MetaGoalAggregator(gate=_gate_allowing(5), posture_fn=_posture_neutral, oracle=_DisjointOracle())
+    agg.offer(_op("op-a", "backend/a.py"))
+    agg.offer(_op("op-b", "backend/b.py"))
+    # Only 2 < min 3 -> nothing ready.
+    assert agg.drain_ready_bundles() == []
+
+
+# ---------------------------------------------------------------------------
+# 2. Collision-coupled ops are NOT bundled together
+# ---------------------------------------------------------------------------
+
+
+class _CouplingOracle:
+    """Tiny Oracle stub: a.py and b.py are import-coupled; c.py is isolated."""
+
+    class _Node:
+        def __init__(self, fp):
+            self.file_path = fp
+
+    _COUPLING = {
+        "backend/a.py": {"backend/b.py"},
+        "backend/b.py": {"backend/a.py"},
+        "backend/c.py": set(),
+        "backend/d.py": set(),
+    }
+
+    def find_nodes_in_file(self, file_path):
+        if file_path in self._COUPLING:
+            return [self._Node(file_path)]
+        return []
+
+    def get_dependencies(self, node):
+        return [self._Node(f) for f in self._COUPLING.get(node.file_path, set())]
+
+    def get_dependents(self, node):
+        return []
+
+
+def test_collision_coupled_ops_are_not_bundled_together():
+    oracle = _CouplingOracle()
+    agg = MetaGoalAggregator(gate=_gate_allowing(5), posture_fn=_posture_neutral, oracle=oracle)
+    # a + b are coupled; c + d are isolated. The largest disjoint group must
+    # NOT contain both a and b.
+    for o in [
+        _op("op-a", "backend/a.py"),
+        _op("op-b", "backend/b.py"),
+        _op("op-c", "backend/c.py"),
+        _op("op-d", "backend/d.py"),
+    ]:
+        agg.offer(o)
+
+    bundles = agg.drain_ready_bundles()
+    # At least one bundle formed; no bundle co-groups a.py and b.py.
+    assert bundles, "isolated c+d (plus one of a/b) should still bundle"
+    for bundle in bundles:
+        files = {f for u in bundle.graph.units for f in u.target_files}
+        assert not ({"backend/a.py", "backend/b.py"} <= files), (
+            "coupled a.py + b.py must never be in the same Meta-Goal"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 3. 50 ops -> CHUNKED by live capacity (no mega-DAG / OOM)
+# ---------------------------------------------------------------------------
+
+
+def test_fifty_ops_chunk_by_capacity_no_mega_dag():
+    capacity = 4
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(capacity),
+        posture_fn=_posture_neutral,
+        oracle=_DisjointOracle(),
+        max_concurrent_workers=capacity,
+    )
+    for i in range(50):
+        agg.offer(_op(f"op-{i:03d}", f"backend/mod_{i:03d}.py"))
+
+    bundles = agg.drain_ready_bundles()
+    assert len(bundles) >= 1
+    # No single Meta-Goal DAG may exceed the live capacity (no OOM mega-DAG).
+    for b in bundles:
+        assert len(b.graph.units) <= capacity, (
+            f"Meta-Goal exceeded capacity {capacity}: {len(b.graph.units)} units"
+        )
+        assert b.graph.concurrency_limit <= capacity
+    # All 50 ops accounted for across bundles (none lost).
+    total_units = sum(len(b.graph.units) for b in bundles)
+    assert total_units == 50
+
+
+def test_chunk_size_adapts_to_lower_capacity():
+    """Tighter memory gate -> smaller Meta-Goal batches."""
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(2),  # gate clamps to 2
+        posture_fn=_posture_neutral,
+        oracle=_DisjointOracle(),
+        max_concurrent_workers=10,  # workers permit more, but gate wins (strictest)
+    )
+    for i in range(6):
+        agg.offer(_op(f"op-{i}", f"backend/f{i}.py"))
+    bundles = agg.drain_ready_bundles()
+    for b in bundles:
+        assert len(b.graph.units) <= 2
+
+
+# ---------------------------------------------------------------------------
+# 4. Partial recomposition (Poison-Pill): 2 succeed + 1 fail
+# ---------------------------------------------------------------------------
+
+
+def test_partial_recompose_commits_successes_and_dlqs_failure(monkeypatch):
+    agg = MetaGoalAggregator(gate=_gate_allowing(5), posture_fn=_posture_neutral, oracle=_DisjointOracle())
+    for o in [
+        _op("op-a", "backend/a.py"),
+        _op("op-b", "backend/b.py"),
+        _op("op-c", "backend/c.py"),
+    ]:
+        agg.offer(o)
+    bundle = agg.drain_ready_bundles()[0]
+
+    units = list(bundle.graph.units)
+    # 2 succeed, 1 fails (even after failover).
+    results = {
+        units[0].unit_id: _completed_result(units[0].unit_id, units[0].target_files[0]),
+        units[1].unit_id: _completed_result(units[1].unit_id, units[1].target_files[0]),
+        units[2].unit_id: _failed_result(units[2].unit_id),
+    }
+    state = GraphExecutionState(
+        graph=bundle.graph,
+        phase=GraphExecutionPhase.FAILED,
+        completed_units=(units[0].unit_id, units[1].unit_id),
+        failed_units=(units[2].unit_id,),
+        results=results,
+    )
+
+    dlq_calls = []
+    monkeypatch.setattr(
+        mga, "append_dlq",
+        lambda envelope, *, reason, path=None: dlq_calls.append((envelope, reason)),
+    )
+
+    recomp = agg.partial_recompose(bundle, state)
+
+    # The composed candidate keeps the 2 successes -> ONE PR, not scrapped.
+    assert recomp.composed is not None
+    assert recomp.composed.is_failure is False
+    composed_files = set(recomp.composed.file_paths)
+    assert units[0].target_files[0] in composed_files
+    assert units[1].target_files[0] in composed_files
+    assert units[2].target_files[0] not in composed_files
+    # The failed sibling was routed to the Cryo-DLQ for standalone retry.
+    assert len(dlq_calls) == 1
+    env, reason = dlq_calls[0]
+    assert "op-c" in str(env) or env.get("op_id") == "op-c"
+    assert "meta_goal" in reason or "poison" in reason or "partial" in reason
+
+
+def test_all_success_composes_full_union_no_dlq(monkeypatch):
+    agg = MetaGoalAggregator(gate=_gate_allowing(5), posture_fn=_posture_neutral, oracle=_DisjointOracle())
+    for o in [_op("op-a", "backend/a.py"), _op("op-b", "backend/b.py")]:
+        agg.offer(o)
+    bundle = agg.drain_ready_bundles()[0]
+    units = list(bundle.graph.units)
+    results = {
+        u.unit_id: _completed_result(u.unit_id, u.target_files[0]) for u in units
+    }
+    state = GraphExecutionState(
+        graph=bundle.graph,
+        phase=GraphExecutionPhase.COMPLETED,
+        completed_units=tuple(u.unit_id for u in units),
+        results=results,
+    )
+    dlq_calls = []
+    monkeypatch.setattr(
+        mga, "append_dlq",
+        lambda envelope, *, reason, path=None: dlq_calls.append((envelope, reason)),
+    )
+    recomp = agg.partial_recompose(bundle, state)
+    assert recomp.composed is not None and recomp.composed.is_failure is False
+    assert len(recomp.composed.file_paths) == 2
+    assert dlq_calls == []  # nothing failed -> nothing DLQ'd
+
+
+# ---------------------------------------------------------------------------
+# 5. Failover-aware per-node resume (siblings unaffected)
+# ---------------------------------------------------------------------------
+
+
+def test_failover_resumed_unit_is_treated_as_success_for_recompose(monkeypatch):
+    """A node that DW-collapsed then resumed via override returns COMPLETED;
+    partial-recomp still includes its patch (not scrapped)."""
+    agg = MetaGoalAggregator(gate=_gate_allowing(5), posture_fn=_posture_neutral, oracle=_DisjointOracle())
+    for o in [_op("op-a", "backend/a.py"), _op("op-b", "backend/b.py")]:
+        agg.offer(o)
+    bundle = agg.drain_ready_bundles()[0]
+    units = list(bundle.graph.units)
+
+    # Build the per-unit failover override (the existing handoff vehicle).
+    override = agg.build_failover_override(bundle, units[0].unit_id)
+    assert override["provider_override"] == "gcp-jprime"
+    assert override["unit_id"] == units[0].unit_id
+    assert override["meta_goal_id"] == bundle.meta_goal_id
+
+    # Both units complete (unit 0 resumed via jprime; sibling unaffected).
+    results = {u.unit_id: _completed_result(u.unit_id, u.target_files[0]) for u in units}
+    state = GraphExecutionState(
+        graph=bundle.graph,
+        phase=GraphExecutionPhase.COMPLETED,
+        completed_units=tuple(u.unit_id for u in units),
+        results=results,
+    )
+    dlq_calls = []
+    monkeypatch.setattr(
+        mga, "append_dlq",
+        lambda envelope, *, reason, path=None: dlq_calls.append((envelope, reason)),
+    )
+    recomp = agg.partial_recompose(bundle, state)
+    assert recomp.composed is not None and recomp.composed.is_failure is False
+    assert len(recomp.composed.file_paths) == 2  # sibling unaffected, both present
+    assert dlq_calls == []
+
+
+# ---------------------------------------------------------------------------
+# 6. Telemetry tags meta_goal_id + unit op-id
+# ---------------------------------------------------------------------------
+
+
+def test_telemetry_tags_meta_and_unit(caplog):
+    import logging
+    agg = MetaGoalAggregator(gate=_gate_allowing(5), posture_fn=_posture_neutral, oracle=_DisjointOracle())
+    for o in [
+        _op("op-a", "backend/a.py"),
+        _op("op-b", "backend/b.py"),
+    ]:
+        agg.offer(o)
+    with caplog.at_level(logging.INFO):
+        bundle = agg.drain_ready_bundles()[0]
+        lines = agg.telemetry_lines(bundle)
+    # Every per-unit telemetry line carries BOTH meta-goal id AND the origin op id.
+    assert lines, "expected per-unit telemetry lines"
+    for line in lines:
+        assert "[MetaGoal]" in line
+        assert f"meta={bundle.meta_goal_id}" in line
+        assert "unit=" in line
+        assert "file=" in line
+    # The origin op-ids appear across the lines.
+    joined = "\n".join(lines)
+    assert "op-a" in joined and "op-b" in joined
+
+
+# ---------------------------------------------------------------------------
+# 7. Master OFF -> single-file dispatch byte-identical (no Meta-Goal)
+# ---------------------------------------------------------------------------
+
+
+def test_master_off_is_byte_identical_no_bundle(monkeypatch):
+    monkeypatch.setenv(META_GOAL_FLAG, "false")
+    agg = MetaGoalAggregator(gate=_gate_allowing(5), posture_fn=_posture_neutral, oracle=_DisjointOracle())
+    for o in [
+        _op("op-a", "backend/a.py"),
+        _op("op-b", "backend/b.py"),
+        _op("op-c", "backend/c.py"),
+    ]:
+        agg.offer(o)
+    # OFF -> no bundles ever; ops stay single-file (pooled ops returned as-is).
+    assert agg.drain_ready_bundles() == []
+    # The pooled ops are still retrievable for the legacy single-file path.
+    pending = agg.pending_ops()
+    assert {p.op_id for p in pending} == {"op-a", "op-b", "op-c"}
+
+
+def test_aggregator_enabled_helper(monkeypatch):
+    monkeypatch.setenv(META_GOAL_FLAG, "false")
+    assert mga.meta_goal_aggregator_enabled() is False
+    monkeypatch.setenv(META_GOAL_FLAG, "true")
+    assert mga.meta_goal_aggregator_enabled() is True

--- a/tests/scripts/test_bake_soak_golden.py
+++ b/tests/scripts/test_bake_soak_golden.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""Pure-logic tests for scripts/bake_soak_golden_image.py.
+
+No real gcloud. ALL subprocess goes through the script's single `_run` boundary,
+which these tests monkeypatch to assert dry-run never executes, the VALIDATION
+LOCK aborts (no snapshot) on broken deps, the image is stamped with the
+requirements sha label, and execute deletes the bake node on every exit path.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "bake_soak_golden_image.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bake_soak_golden_image", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def bake():
+    return _load_module()
+
+
+@pytest.fixture()
+def args(bake):
+    return bake.build_parser().parse_args([])
+
+
+class _Recorder:
+    """Records every (cmd) passed to the faked _run, in order, with scripted rcs."""
+
+    def __init__(self, responses=None):
+        self.calls = []
+        # responses: list of (predicate, (rc, out)). First match wins.
+        self.responses = responses or []
+        self.default = (0, "")
+
+    def __call__(self, cmd, *, timeout_s=120.0):
+        self.calls.append(list(cmd))
+        joined = " ".join(cmd)
+        for pred, resp in self.responses:
+            if pred(joined):
+                return resp
+        return self.default
+
+    def joined(self):
+        return [" ".join(c) for c in self.calls]
+
+
+# --------------------------------------------------------------------------- #
+# Startup-script generator.
+# --------------------------------------------------------------------------- #
+def test_startup_script_installs_deps_and_sentinels(bake):
+    deps = bake._load_hard_ensure_deps()
+    script = bake.build_startup_script(deps)
+    # Installs pip + build tools.
+    assert "python3-pip" in script
+    # Hard-ensure core deps appear in the install line.
+    for core in ("aiohttp", "uuid6", "fastapi", "pydantic"):
+        assert core in script
+    # ROOT-CAUSE REGRESSION GUARD: HOME exported before anything.
+    assert "export HOME=" in script
+    # Sentinel written ONLY after the install (mirrors J-Prime).
+    assert bake._SENTINEL_PATH in script
+    # Filters the ML libs (no native portaudio/torch build on a bare node).
+    assert "torch" in script and "pyaudio" in script  # they appear in the filter
+    # requirements.txt staged from metadata.
+    assert "jarvis-requirements" in script
+
+
+def test_startup_script_sentinel_after_install(bake):
+    deps = bake._load_hard_ensure_deps()
+    script = bake.build_startup_script(deps)
+    # The sentinel write must come AFTER the hard-ensure install command.
+    assert script.index("hard-ensuring core deps") < script.index("hard-ensure install complete")
+
+
+# --------------------------------------------------------------------------- #
+# requirements sha (the staleness stamp).
+# --------------------------------------------------------------------------- #
+def test_requirements_sha_stable_and_truncated(bake, tmp_path):
+    req = tmp_path / "requirements.txt"
+    req.write_text("aiohttp\nuuid6\n")
+    sha = bake.requirements_sha(str(req))
+    assert len(sha) == 16
+    assert sha == bake.requirements_sha(str(req))  # deterministic
+    # Changing the content changes the sha.
+    req.write_text("aiohttp\nuuid6\nhttpx\n")
+    assert bake.requirements_sha(str(req)) != sha
+
+
+def test_requirements_sha_missing_file_failsoft(bake, tmp_path):
+    assert bake.requirements_sha(str(tmp_path / "nope.txt")) == "norequirements"
+
+
+def test_real_requirements_sha_is_valid_label(bake):
+    """The repo's real requirements.txt produces a GCP-label-safe sha value."""
+    import re as _re
+
+    sha = bake.requirements_sha(bake._DEFAULT_REQUIREMENTS)
+    assert _re.fullmatch(r"[a-z0-9_-]{1,63}", sha), sha
+
+
+# --------------------------------------------------------------------------- #
+# Validation verdict parser (the load-bearing lock).
+# --------------------------------------------------------------------------- #
+def test_validation_pass_on_ok_marker(bake):
+    ok, _ = bake.parse_validation_verdict(0, "some output\nSOAK_BAKE_VALIDATION_OK\n")
+    assert ok is True
+
+
+def test_validation_fail_on_fail_marker(bake):
+    ok, reason = bake.parse_validation_verdict(
+        0, "SOAK_BAKE_VALIDATION_FAIL deps-import: ModuleNotFoundError uuid6"
+    )
+    assert ok is False
+    assert "uuid6" in reason
+
+
+def test_validation_fail_on_missing_ok(bake):
+    ok, _ = bake.parse_validation_verdict(0, "no markers here")
+    assert ok is False
+
+
+def test_validation_fail_on_transport_error(bake):
+    ok, reason = bake.parse_validation_verdict(1, "SOAK_BAKE_VALIDATION_OK")
+    assert ok is False
+    assert "rc=" in reason
+
+
+def test_validation_fail_on_empty(bake):
+    ok, _ = bake.parse_validation_verdict(0, "   ")
+    assert ok is False
+
+
+def test_validation_remote_runs_three_checks(bake):
+    remote = bake.build_validation_remote()
+    assert "import aiohttp, uuid6, fastapi, pydantic" in remote  # CHECK 1
+    assert "pytest --collect-only" in remote  # CHECK 2
+    assert "operation_id" in remote  # CHECK 3 (O+V core)
+    assert "SOAK_BAKE_VALIDATION_OK" in remote
+    assert "SOAK_BAKE_VALIDATION_FAIL" in remote
+
+
+# --------------------------------------------------------------------------- #
+# Node-create: ON-DEMAND, debian source image, ships requirements as metadata.
+# --------------------------------------------------------------------------- #
+def test_create_node_cmd_ships_requirements_metadata(bake, args):
+    cmd = bake._create_node_cmd(args, "soak-bake-x", "/tmp/startup.sh", "/repo/requirements.txt")
+    joined = " ".join(cmd)
+    assert "--image-family=debian-12" in joined
+    assert "--image-project=debian-cloud" in joined
+    # No SPOT for the bake (reliability).
+    assert "SPOT" not in joined
+    # Ships both the startup-script AND the requirements metadata.
+    assert "startup-script=/tmp/startup.sh" in joined
+    assert "jarvis-requirements=/repo/requirements.txt" in joined
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run: prints the plan + req-sha label, executes NOTHING.
+# --------------------------------------------------------------------------- #
+def test_dry_run_executes_nothing(bake, monkeypatch, capsys):
+    rec = _Recorder()
+    monkeypatch.setattr(bake, "_run", rec)
+    rc = bake.main(["--dry-run"])
+    assert rc == 0
+    assert rec.calls == []  # NOTHING executed
+    out = capsys.readouterr().out
+    assert "jarvis_req_sha=" in out  # staleness label printed in the plan
+    assert "spends nothing" in out
+
+
+# --------------------------------------------------------------------------- #
+# EXECUTE happy path: validate PASS -> snapshot WITH req-sha label -> node deleted.
+# --------------------------------------------------------------------------- #
+def test_execute_happy_path_snapshots_with_label_and_cleans_up(bake, monkeypatch):
+    # readiness sentinel present immediately; validation passes.
+    rec = _Recorder(responses=[
+        (lambda j: "test -f " in j, (0, "SOAK_READY")),
+        (lambda j: "SOAK_BAKE_VALIDATION_OK" in j or "import aiohttp" in j,
+         (0, "SOAK_BAKE_VALIDATION_OK")),
+        (lambda j: "images describe" in j, (1, "NOT_FOUND")),  # image absent
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-n", "<startup>")
+    assert rc == 0
+    j = rec.joined()
+    # An image was created with the req-sha label.
+    create = [c for c in j if "images create" in c]
+    assert create, "no image create issued"
+    assert "--labels=jarvis_req_sha=" in create[0]
+    # Node + disk deleted (no orphaned billing) -- on the success path too.
+    assert any("instances delete" in c and "--delete-disks=all" in c for c in j)
+
+
+# --------------------------------------------------------------------------- #
+# THE VALIDATION LOCK: broken deps -> ABORT, NO image, node deleted, non-zero.
+# --------------------------------------------------------------------------- #
+def test_validation_failure_aborts_no_snapshot_deletes_node(bake, monkeypatch):
+    rec = _Recorder(responses=[
+        (lambda j: "test -f " in j, (0, "SOAK_READY")),
+        # validation FAILS (broken deps).
+        (lambda j: "import aiohttp" in j,
+         (0, "SOAK_BAKE_VALIDATION_FAIL deps-import: No module named 'uuid6'")),
+        (lambda j: "images describe" in j, (1, "NOT_FOUND")),
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-n", "<startup>")
+    assert rc == 6  # validation-failure exit code (non-zero)
+    j = rec.joined()
+    # NO image was ever created (never snapshot a broken image).
+    assert not any("images create" in c for c in j)
+    # The node was STILL deleted (no orphaned billing on abort).
+    assert any("instances delete" in c for c in j)
+    # ORDER: validation ran, then delete -- and NO create between them.
+    idx_val = next(i for i, c in enumerate(j) if "import aiohttp" in c)
+    idx_del = next(i for i, c in enumerate(j) if "instances delete" in c)
+    assert idx_del > idx_val
+    assert not any("images create" in c for c in j[idx_val:idx_del])
+
+
+# --------------------------------------------------------------------------- #
+# Readiness timeout (early-fail) also aborts + deletes (no snapshot).
+# --------------------------------------------------------------------------- #
+def test_readiness_early_fail_aborts_and_deletes(bake, monkeypatch):
+    rec = _Recorder(responses=[
+        (lambda j: "test -f " in j, (0, "SOAK_NOT_READY")),
+        # bake log shows an ERROR -> early abort.
+        (lambda j: "tail -n 5" in j, (0, "[soak-bake] ERROR: pip install failed")),
+        (lambda j: "images describe" in j, (1, "NOT_FOUND")),
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-n", "<startup>")
+    assert rc == 5
+    j = rec.joined()
+    assert not any("images create" in c for c in j)
+    assert any("instances delete" in c for c in j)
+
+
+# --------------------------------------------------------------------------- #
+# Provision failure -> abort, node never created so no delete needed, non-zero.
+# --------------------------------------------------------------------------- #
+def test_provision_failure_aborts(bake, monkeypatch):
+    rec = _Recorder(responses=[
+        (lambda j: "images describe" in j, (1, "NOT_FOUND")),
+        (lambda j: "instances create" in j, (1, "QUOTA_EXCEEDED")),
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-n", "<startup>")
+    assert rc == 4
+    # Node never came up -> no delete issued.
+    assert not any("instances delete" in c for c in rec.joined())
+
+
+# --------------------------------------------------------------------------- #
+# Idempotency: existing image without --force refuses (exit 3, no provision).
+# --------------------------------------------------------------------------- #
+def test_existing_image_without_force_refuses(bake, monkeypatch):
+    rec = _Recorder(responses=[
+        (lambda j: "images describe" in j, (0, "jarvis-soak-golden-x")),  # exists
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-n", "<startup>")
+    assert rc == 3
+    assert not any("instances create" in c for c in rec.joined())
+
+
+# --------------------------------------------------------------------------- #
+# Reuse: the baker pulls the hard-ensure list from the IaC hypervisor (no dup).
+# --------------------------------------------------------------------------- #
+def test_hard_ensure_deps_match_iac(bake):
+    deps = bake._load_hard_ensure_deps()
+    assert "uuid6" in deps and "pytest-asyncio" in deps and "aiohttp" in deps
+    # Load the IaC module directly and compare -- they must be the same source.
+    import importlib.util as _u
+
+    iac_path = Path(__file__).resolve().parents[2] / "scripts" / "sovereign_iac_hypervisor.py"
+    spec = _u.spec_from_file_location("_iac_cmp", str(iac_path))
+    iac = _u.module_from_spec(spec)
+    spec.loader.exec_module(iac)
+    assert deps == iac.hard_ensure_deps()

--- a/tests/scripts/test_iac_soak_golden.py
+++ b/tests/scripts/test_iac_soak_golden.py
@@ -1,0 +1,222 @@
+# -*- coding: utf-8 -*-
+"""Soak golden-image wiring tests for scripts/sovereign_iac_hypervisor.py.
+
+No real GCP/SSH. Verifies (a) node-create uses jarvis-soak-golden when enabled +
+present, debian-12 otherwise (byte-identical OFF); (b) the surgery SKIPS pip when
+deps present + sha matches; (c) DELTA-ensures on a stale sha; (d) the
+INDESTRUCTIBLE fallback: golden-unverified-within-timeout -> loud warn + full
+pip path runs; (e) reuses the J-Prime baker shape + the existing deps path
+(no dup -- the full-pip body is embedded verbatim in the golden body).
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "sovereign_iac_hypervisor.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("sovereign_iac_hypervisor", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def iac():
+    return _load_module()
+
+
+@pytest.fixture(autouse=True)
+def _gate_off_by_default(monkeypatch):
+    """Default the master gate OFF so each test arms it explicitly."""
+    monkeypatch.delenv("JARVIS_IAC_SOAK_GOLDEN_ENABLED", raising=False)
+
+
+@pytest.fixture()
+def args(iac):
+    return iac.build_parser().parse_args([])
+
+
+# --------------------------------------------------------------------------- #
+# (e) reuse: hard-ensure list is a single source of truth, exported.
+# --------------------------------------------------------------------------- #
+def test_hard_ensure_deps_exported(iac):
+    deps = iac.hard_ensure_deps()
+    assert "uuid6" in deps and "pytest-asyncio" in deps and "aiohttp" in deps
+
+
+# --------------------------------------------------------------------------- #
+# OFF path: node-create is byte-identical debian-12 (gate off).
+# --------------------------------------------------------------------------- #
+def test_node_create_off_uses_debian12(iac, args, monkeypatch):
+    # Gate OFF (default). golden_image_status must NEVER be consulted.
+    called = {"status": False}
+
+    def _boom(*a, **k):
+        called["status"] = True
+        return (True, "abc")
+
+    monkeypatch.setattr(iac, "golden_image_status", _boom)
+    args.soak_golden = False
+    cmd = iac._create_node_cmd(args, "node-x", "/tmp/su.sh")
+    joined = " ".join(cmd)
+    assert "--image-family=debian-12" in joined
+    assert "--image-project=debian-cloud" in joined
+    assert "jarvis-soak-golden" not in joined
+    assert called["status"] is False  # never probed when gate off
+
+
+# --------------------------------------------------------------------------- #
+# (a) ON + image present -> node-create uses jarvis-soak-golden in this project.
+# --------------------------------------------------------------------------- #
+def test_node_create_golden_present_uses_golden(iac, args, monkeypatch):
+    monkeypatch.setattr(iac, "golden_image_status", lambda a: (True, "deadbeef"))
+    args.soak_golden = True
+    cmd = iac._create_node_cmd(args, "node-x", "/tmp/su.sh")
+    joined = " ".join(cmd)
+    assert "--image-family=jarvis-soak-golden" in joined
+    # Golden image lives in THIS project, not debian-cloud.
+    assert f"--image-project={args.project}" in joined
+    assert "debian-cloud" not in joined
+
+
+# --------------------------------------------------------------------------- #
+# (a/d) ON but image ABSENT -> indestructible: falls back to debian-12.
+# --------------------------------------------------------------------------- #
+def test_node_create_golden_absent_falls_back_to_debian12(iac, args, monkeypatch):
+    monkeypatch.setattr(iac, "golden_image_status", lambda a: (False, None))
+    args.soak_golden = True
+    cmd = iac._create_node_cmd(args, "node-x", "/tmp/su.sh")
+    joined = " ".join(cmd)
+    assert "--image-family=debian-12" in joined
+    assert "jarvis-soak-golden" not in joined
+
+
+def test_node_create_golden_probe_raises_falls_back(iac, args, monkeypatch):
+    """A describe exception must NOT crash node-create -> debian-12 fallback."""
+    def _raise(a):
+        raise RuntimeError("gcloud blew up")
+
+    monkeypatch.setattr(iac, "golden_image_status", _raise)
+    args.soak_golden = True
+    cmd = iac._create_node_cmd(args, "node-x", "/tmp/su.sh")
+    assert "--image-family=debian-12" in " ".join(cmd)
+
+
+# --------------------------------------------------------------------------- #
+# golden_image_status: parses the req-sha label, fail-soft on describe error.
+# --------------------------------------------------------------------------- #
+def test_golden_image_status_reads_label(iac, args, monkeypatch):
+    def _fake_run(cmd, *, timeout_s=120.0):
+        assert "describe-from-family" in " ".join(cmd)
+        return (0, "cafef00d\n")
+
+    monkeypatch.setattr(iac, "_run", _fake_run)
+    exists, label = iac.golden_image_status(args)
+    assert exists is True
+    assert label == "cafef00d"
+
+
+def test_golden_image_status_failsoft(iac, args, monkeypatch):
+    monkeypatch.setattr(iac, "_run", lambda c, **k: (1, "NOT_FOUND"))
+    exists, label = iac.golden_image_status(args)
+    assert exists is False and label is None
+
+
+# --------------------------------------------------------------------------- #
+# (OFF) deps step byte-identical to the legacy full-pip body.
+# --------------------------------------------------------------------------- #
+def test_deps_step_off_is_legacy_full_pip(iac, args):
+    args.soak_golden = False
+    step = iac._surgery_dep_step(args)
+    assert step == iac._surgery_dep_install()  # byte-identical
+    assert "skipping install" not in step  # no golden logic on the OFF path
+
+
+# --------------------------------------------------------------------------- #
+# (b) ON: deps present + sha matches -> SKIP pip (no install command in skip arm).
+# --------------------------------------------------------------------------- #
+def test_deps_step_golden_skips_pip(iac, args, tmp_path):
+    args.soak_golden = True
+    step = iac._surgery_dep_step(args)
+    # Probes pre-installed deps.
+    assert "probing pre-installed deps" in step
+    assert "import aiohttp, uuid6, fastapi, pydantic, pytest_asyncio" in step
+    # The skip path logs the mandated line.
+    assert "golden image -- deps present, skipping install" in step
+    # Has a verify timeout on the probe (CONSTRAINT 3 budget).
+    assert "timeout " in step
+
+
+# --------------------------------------------------------------------------- #
+# (c) ON: stale sha -> DELTA-ensure (hard-ensure core re-installed), not full -r.
+# --------------------------------------------------------------------------- #
+def test_deps_step_golden_delta_ensures_on_stale(iac, args):
+    args.soak_golden = True
+    step = iac._surgery_dep_step(args)
+    assert "STALE" in step
+    assert "delta-ensuring core deps" in step
+    # The delta arm pip-installs ONLY the hard-ensure core (not requirements -r).
+    for core in ("aiohttp", "uuid6", "pytest-asyncio"):
+        assert core in step
+
+
+# --------------------------------------------------------------------------- #
+# (d) THE INDESTRUCTIBLE FALLBACK: probe fail -> loud warn + FULL pip path.
+# --------------------------------------------------------------------------- #
+def test_deps_step_golden_fallback_runs_full_pip(iac, args):
+    args.soak_golden = True
+    step = iac._surgery_dep_step(args)
+    # The loud, mandated fallback warning.
+    assert "golden image unavailable/unverified -- FALLING BACK to raw Debian" in step
+    # The FULL legacy pip body is embedded VERBATIM (reuse, no dup) in the fallback.
+    full = iac._surgery_dep_install()
+    # A distinctive fragment of the full-pip body must appear in the golden body.
+    assert "installing jarvis host deps" in step
+    assert "skip unbuildable" in step
+    # And the embedded body is exactly the legacy one (reuse, not a reimpl).
+    assert full in step
+
+
+# --------------------------------------------------------------------------- #
+# staleness sha helper (matches the baker's algorithm).
+# --------------------------------------------------------------------------- #
+def test_requirements_sha_matches_baker(iac, tmp_path):
+    req = tmp_path / "requirements.txt"
+    req.write_text("aiohttp\nuuid6\n")
+    sha = iac.requirements_sha(str(req))
+    assert len(sha) == 16
+    # Same algorithm as the baker.
+    bake_path = Path(__file__).resolve().parents[2] / "scripts" / "bake_soak_golden_image.py"
+    spec = importlib.util.spec_from_file_location("_bake_cmp", str(bake_path))
+    bake = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(bake)
+    assert sha == bake.requirements_sha(str(req))
+
+
+def test_requirements_sha_missing_failsoft(iac, tmp_path):
+    assert iac.requirements_sha(str(tmp_path / "nope.txt")) == "norequirements"
+
+
+# --------------------------------------------------------------------------- #
+# Surgery body integration: the body uses the golden step when armed.
+# --------------------------------------------------------------------------- #
+def test_surgery_body_uses_golden_step_when_armed(iac, args):
+    args.soak_golden = True
+    body = iac._remote_surgery_body_script(args)
+    assert "probing pre-installed deps" in body
+    assert "FALLING BACK to raw Debian" in body
+
+
+def test_surgery_body_legacy_when_gate_off(iac, args):
+    args.soak_golden = False
+    body = iac._remote_surgery_body_script(args)
+    assert "probing pre-installed deps" not in body
+    # The legacy full-pip body is present.
+    assert "installing jarvis host deps" in body


### PR DESCRIPTION
Meta-Goal Aggregator / Golden Image baker. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Adaptive Meta-Goal Aggregator to bundle disjoint single-file ops into a fan-outable DAG (fixes single_file_op fanout starvation) and a soak golden-image bake + IaC wiring to skip the ~20‑minute pip install with a safe fallback. Both features are gated and default-off; no behavior change by default.

- **New Features**
  - Meta-Goal Aggregator: bundles disjoint single-file ops into one meta-DAG; enables parallel fan-out.
  - Capacity-aware batching: chunks into worker-capacity sized DAGs (prevents mega-DAG OOM).
  - Collision-aware: excludes coupled ops; only bundles pairwise-disjoint units.
  - Partial recomposition: commits successful units; routes failed siblings to DLQ (no whole-DAG scrap).
  - Failover-aware resume and granular telemetry for meta + unit execution.
  - Soak golden image bake: validation-locked snapshot with `requirements.txt` SHA label.
  - IaC wiring: uses `jarvis-soak-golden` when enabled; surgery skips pip if deps present; delta-installs on stale SHA.
  - Indestructible fallback: unverified/failed golden image triggers loud warn and reverts to Debian + full pip.
  - Extensive tests for aggregator and golden-image paths.

<sup>Written for commit 965a92c5c9a60bc7b3285b68877292b5c2edc60b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

