### PR TITLE
feat(launcher): Autonomous Pre-Flight Provisioner (bake-if-needed → Omni-Soak, degrade + sweep)

### DIFF
--- a/deploy/ouroboros_omni_prod.env
+++ b/deploy/ouroboros_omni_prod.env
@@ -27,6 +27,25 @@ source "${BASH_SOURCE%/*}/ouroboros_linux_prod.env" 2>/dev/null \
   || true
 
 # ======================================================================
+# 0. AUTONOMOUS PRE-FLIGHT PROVISIONER  (the omni-launcher overlay)
+# ----------------------------------------------------------------------
+# The autonomous_omni_launcher arms these in the env it hands to the soak;
+# they are ALSO exported here so the overlay carries them on the node (the
+# launcher subprocesses the harness --remote, which boots the node from
+# this profile). Default-OFF in code -- this is the single arming site.
+#   * META_GOAL_AGGREGATOR  -- aggregate strategic sub-goals (the omni feast).
+#   * A1_OMNI_SOAK          -- layer the full MAS/fan-out omni overlay on top.
+#   * IAC_FAULT_TOLERANT_OBS-- node-side fault-tolerant observability.
+#   * IAC_SOAK_GOLDEN       -- boot from the jarvis-soak-golden image (deps
+#                              pre-installed); the launcher unsets this on a
+#                              bake failure so the node degrades to debian+pip.
+# ======================================================================
+export JARVIS_META_GOAL_AGGREGATOR_ENABLED=1
+export JARVIS_A1_OMNI_SOAK=1
+export JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED=1
+export JARVIS_IAC_SOAK_GOLDEN_ENABLED=1
+
+# ======================================================================
 # 1. L3 PARALLEL FAN-OUT  (collision-safe multi-worktree subagents)
 # ======================================================================
 # Eligibility + enforce: multi-unit work fans out to parallel worktree

--- a/scripts/autonomous_omni_launcher.py
+++ b/scripts/autonomous_omni_launcher.py
@@ -1,0 +1,522 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Autonomous Pre-Flight Provisioner -- one command: bake-if-needed -> Omni-Soak.
+
+THE FEAST LAUNCHER. A thin orchestration layer over the EXISTING scripts (no
+logic duplication -- it subprocesses / imports them):
+
+    1. PRE-FLIGHT IMAGE CHECK
+       gcloud compute images list --filter="family:jarvis-soak-golden" + read
+       the jarvis_req_sha label. Compute the CURRENT requirements.txt sha (reusing
+       the baker's helper). MATCH -> fresh; mismatch -> stale; absent -> missing.
+
+         fresh   -> arm JARVIS_IAC_SOAK_GOLDEN_ENABLED=1, SKIP the bake, go to soak.
+         missing -> autonomously subprocess bake_soak_golden_image.py --execute,
+         /stale     verify the image now exists with the matching sha, then arm
+                    JARVIS_IAC_SOAK_GOLDEN_ENABLED=1 and proceed.
+
+    2. GRACEFUL DEGRADATION (never block the feast)
+       If the autonomous bake FAILS (non-zero exit / transient GCP error / the
+       image never appears) -> CATCH, log a SEVERE warning, UNSET the golden flag
+       (so the harness uses its raw-Debian + live-pip fallback), and CONTINUE. A
+       bake failure NEVER aborts the run.
+
+    3. TRANSITION TO THE OMNI-SOAK
+       Subprocess a1_live_fire_chaos_harness.py --remote
+       --i-understand-this-spends-money with the armed launch env inherited.
+       Propagate its exit code.
+
+    4. IRONCLAD ANTI-ZOMBIE SWEEP (the launcher-level backstop)
+       The ENTIRE pipeline (bake + soak) is wrapped in try/finally AND guarded by
+       SIGINT/SIGTERM/SIGHUP handlers. On ANY exit -- success, exception, signal,
+       the harness's own wall-hit -- a cleanup sweep fires that deletes EVERY stray
+       GCP instance from this run: the baker VM (jarvis-soak-bake-*) AND the soak
+       VM (sovereign-sandbox-*), via `gcloud compute instances list` + `delete`
+       (reusing the hypervisor's reap idiom). Idempotent, best-effort, never
+       raises. Guarantee: zero GCP instances left running, even on a Python crash.
+
+    5. ARM THE FLAGS
+       Sets JARVIS_META_GOAL_AGGREGATOR_ENABLED=1 + JARVIS_A1_OMNI_SOAK=1 +
+       JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED=1 (and the golden flag per the image
+       result) in the env handed to the soak. Also added to
+       deploy/ouroboros_omni_prod.env so the overlay carries them on the node.
+
+The launcher is PURE orchestration: check -> (bake | degrade) -> soak -> ALWAYS
+sweep. Zero hardcoding (image family / timeouts / flags are env-tunable). ASCII
+only, fail-soft throughout.
+
+Usage:
+    # the real feast (spends money on a GCP soak node):
+    python3 scripts/autonomous_omni_launcher.py --i-understand-this-spends-money
+
+    # dry-run (print the plan, touch NOTHING):
+    python3 scripts/autonomous_omni_launcher.py --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import importlib.util
+import os
+import pathlib
+import signal
+import subprocess
+import sys
+from typing import Dict, List, Optional, Tuple
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+_BAKER_SCRIPT = str(_REPO_ROOT / "scripts" / "bake_soak_golden_image.py")
+_HARNESS_SCRIPT = str(_REPO_ROOT / "scripts" / "a1_live_fire_chaos_harness.py")
+
+# --------------------------------------------------------------------------- #
+# Defaults -- every value env-tunable (zero hardcoding). The GCP coordinates +
+# the image family + the req-sha label mirror the baker / hypervisor exactly.
+# --------------------------------------------------------------------------- #
+_DEFAULT_PROJECT = os.environ.get("GCP_PROJECT", "jarvis-473803")
+_DEFAULT_ZONE = os.environ.get("GCP_ZONE", "us-central1-a")
+_DEFAULT_IMAGE_FAMILY = os.environ.get(
+    "JARVIS_IAC_SOAK_GOLDEN_IMAGE_FAMILY", "jarvis-soak-golden"
+)
+_REQ_SHA_LABEL_KEY = os.environ.get(
+    "JARVIS_IAC_GOLDEN_REQ_SHA_LABEL", "jarvis_req_sha"
+)
+_DEFAULT_REQUIREMENTS = os.environ.get(
+    "JARVIS_SOAK_BAKE_REQUIREMENTS", str(_REPO_ROOT / "requirements.txt")
+)
+_DEFAULT_BAKE_TIMEOUT_S = int(os.environ.get("JARVIS_LAUNCHER_BAKE_TIMEOUT_S", "2700"))
+_DEFAULT_SOAK_TIMEOUT_S = int(os.environ.get("JARVIS_LAUNCHER_SOAK_TIMEOUT_S", "0"))  # 0 = no harness-side cap
+_DEFAULT_SWEEP_TIMEOUT_S = float(os.environ.get("JARVIS_LAUNCHER_SWEEP_TIMEOUT_S", "300"))
+
+# The stray-instance name prefixes the sweep reaps (env-tunable, comma-list).
+_BAKE_NODE_PREFIX = os.environ.get("JARVIS_LAUNCHER_BAKE_NODE_PREFIX", "jarvis-soak-bake-")
+_SOAK_NODE_PREFIX = os.environ.get("JARVIS_LAUNCHER_SOAK_NODE_PREFIX", "sovereign-sandbox-")
+
+# The flags the launcher arms in the soak env (CONSTRAINT 4). Golden is armed
+# separately, conditional on the image-freshness result.
+_ARM_FLAGS = (
+    "JARVIS_META_GOAL_AGGREGATOR_ENABLED",
+    "JARVIS_A1_OMNI_SOAK",
+    "JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED",
+)
+_GOLDEN_FLAG = "JARVIS_IAC_SOAK_GOLDEN_ENABLED"
+
+
+# --------------------------------------------------------------------------- #
+# Reuse the baker's requirements_sha (single source of truth, NO dup). Fail-soft:
+# if the baker can't import (it shouldn't -- pure stdlib), fall back to an inline
+# sha256 with the IDENTICAL algorithm so the staleness check still works.
+# --------------------------------------------------------------------------- #
+def _load_baker_sha():
+    try:
+        spec = importlib.util.spec_from_file_location("_baker_for_launcher", _BAKER_SCRIPT)
+        if spec and spec.loader:
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+            fn = getattr(mod, "requirements_sha", None)
+            if callable(fn):
+                return fn
+    except Exception:  # noqa: BLE001 -- never crash the launcher on an import edge
+        pass
+
+    def _inline(req_path: str) -> str:
+        import hashlib
+        try:
+            data = pathlib.Path(req_path).read_bytes()
+        except Exception:  # noqa: BLE001
+            return "norequirements"
+        return hashlib.sha256(data).hexdigest()[:16]
+
+    return _inline
+
+
+_baker_requirements_sha = _load_baker_sha()
+
+
+def current_requirements_sha(req_path: Optional[str] = None) -> str:
+    """sha256[:16] of requirements.txt -- the staleness stamp (reuses the baker)."""
+    return _baker_requirements_sha(req_path or _DEFAULT_REQUIREMENTS)
+
+
+def default_requirements_path() -> str:
+    return _DEFAULT_REQUIREMENTS
+
+
+# --------------------------------------------------------------------------- #
+# Config -- a tiny namespace the orchestration threads through (so every gcloud
+# coordinate is resolved once, env-tunable, never hardcoded mid-flow).
+# --------------------------------------------------------------------------- #
+class Config:
+    __slots__ = (
+        "project", "zone", "image_family", "req_sha_label", "requirements",
+        "bake_timeout_s", "soak_timeout_s", "sweep_timeout_s",
+        "bake_prefix", "soak_prefix", "dry_run", "money_gate",
+    )
+
+    def __init__(self, **kw):
+        self.project = kw.get("project", _DEFAULT_PROJECT)
+        self.zone = kw.get("zone", _DEFAULT_ZONE)
+        self.image_family = kw.get("image_family", _DEFAULT_IMAGE_FAMILY)
+        self.req_sha_label = kw.get("req_sha_label", _REQ_SHA_LABEL_KEY)
+        self.requirements = kw.get("requirements", _DEFAULT_REQUIREMENTS)
+        self.bake_timeout_s = kw.get("bake_timeout_s", _DEFAULT_BAKE_TIMEOUT_S)
+        self.soak_timeout_s = kw.get("soak_timeout_s", _DEFAULT_SOAK_TIMEOUT_S)
+        self.sweep_timeout_s = kw.get("sweep_timeout_s", _DEFAULT_SWEEP_TIMEOUT_S)
+        self.bake_prefix = kw.get("bake_prefix", _BAKE_NODE_PREFIX)
+        self.soak_prefix = kw.get("soak_prefix", _SOAK_NODE_PREFIX)
+        self.dry_run = kw.get("dry_run", False)
+        self.money_gate = kw.get("money_gate", False)
+
+
+def build_config(args: Optional[argparse.Namespace] = None) -> Config:
+    if args is None:
+        return Config()
+    return Config(
+        project=args.project, zone=args.zone, image_family=args.image_family,
+        requirements=args.requirements, bake_timeout_s=args.bake_timeout_s,
+        dry_run=getattr(args, "dry_run", False),
+        money_gate=getattr(args, "money_gate", False),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Logging.
+# --------------------------------------------------------------------------- #
+def _log(msg: str) -> None:
+    print(f"[launcher] {msg}", flush=True)
+
+
+# --------------------------------------------------------------------------- #
+# THE single subprocess boundary for gcloud. ALL gcloud funnels through here so
+# tests intercept it with one monkeypatch. Never raises -- returns (rc, output).
+# --------------------------------------------------------------------------- #
+def _run(cmd: List[str], *, timeout_s: float = 120.0) -> Tuple[int, str]:
+    try:
+        p = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout_s)
+        return p.returncode, (p.stdout or "") + (p.stderr or "")
+    except Exception as exc:  # noqa: BLE001 -- the launcher never crashes on a call
+        return 1, f"[run failed: {exc!r}]"
+
+
+# --------------------------------------------------------------------------- #
+# STEP 1 -- pre-flight image freshness probe.
+# --------------------------------------------------------------------------- #
+def check_image_freshness(cfg: Config) -> str:
+    """Return 'fresh' | 'stale' | 'missing'.
+
+    Lists the jarvis-soak-golden family + reads its jarvis_req_sha label, compares
+    against the CURRENT requirements.txt sha. Fail-soft: any gcloud error or an
+    empty list -> 'missing' (forces a bake / degrade -- never a false 'fresh').
+    """
+    cur = current_requirements_sha(cfg.requirements)
+    rc, out = _run([
+        "gcloud", "compute", "images", "list",
+        f"--project={cfg.project}",
+        f"--filter=family:{cfg.image_family}",
+        f"--format=value(labels.{cfg.req_sha_label})",
+        "--sort-by=~creationTimestamp", "--limit=1",
+    ])
+    label = (out or "").strip()
+    if rc != 0 or not label:
+        _log(f"pre-flight: no '{cfg.image_family}' image found (rc={rc}) -> MISSING")
+        return "missing"
+    if label == cur:
+        _log(f"pre-flight: image fresh (req_sha={cur} matches label) -> FRESH")
+        return "fresh"
+    _log(f"pre-flight: image STALE (label={label} != current={cur}) -> STALE")
+    return "stale"
+
+
+# --------------------------------------------------------------------------- #
+# STEP 1 (cont) -- autonomous bake (subprocess the baker; verify it landed).
+# --------------------------------------------------------------------------- #
+def bake_golden(cfg: Config, env: Dict[str, str]) -> bool:
+    """Subprocess bake_soak_golden_image.py --execute; verify the image is fresh.
+
+    Returns True iff the baker exits 0 AND the post-bake freshness probe reports
+    'fresh'. NO bake logic duplicated -- we drive the existing baker script.
+    Never raises (a crash surfaces as False -> the caller degrades).
+    """
+    argv = [
+        sys.executable, _BAKER_SCRIPT, "--execute",
+        f"--project={cfg.project}", f"--zone={cfg.zone}",
+        f"--image-family={cfg.image_family}",
+        f"--requirements={cfg.requirements}",
+        f"--bake-timeout-s={cfg.bake_timeout_s}",
+    ]
+    _log("STEP bake: image missing/stale -> autonomously baking the golden image")
+    _log("  " + " ".join(argv))
+    try:
+        cp = subprocess.run(argv, env=env, check=False, timeout=cfg.bake_timeout_s + 900)
+        if cp.returncode != 0:
+            _log(f"bake: baker exited non-zero (rc={cp.returncode})")
+            return False
+    except Exception as exc:  # noqa: BLE001
+        _log(f"bake: baker subprocess error: {exc!r}")
+        return False
+    # Verify the image now exists with the matching sha (don't trust rc alone).
+    state = check_image_freshness(cfg)
+    if state == "fresh":
+        _log("bake: SUCCESS -- golden image present + sha-fresh")
+        return True
+    _log(f"bake: post-bake verify FAILED (image state={state})")
+    return False
+
+
+# --------------------------------------------------------------------------- #
+# STEP 3 -- transition to the Omni-Soak (subprocess the harness --remote).
+# --------------------------------------------------------------------------- #
+def run_soak(cfg: Config, env: Dict[str, str]) -> int:
+    """Subprocess a1_live_fire_chaos_harness.py --remote (the Omni-Soak).
+
+    Inherits the armed launch env. Propagates the harness exit code. The harness
+    owns its own money-gate; we pass it through. No soak logic duplicated.
+    """
+    argv = [
+        sys.executable, _HARNESS_SCRIPT,
+        "--remote", "--i-understand-this-spends-money",
+    ]
+    _log("STEP soak: transitioning to the Omni-Soak (--remote)")
+    _log("  " + " ".join(argv))
+    try:
+        cp = subprocess.run(argv, env=env, check=False)
+        return cp.returncode
+    except Exception as exc:  # noqa: BLE001
+        _log(f"soak: harness subprocess error: {exc!r}")
+        return 1
+
+
+# --------------------------------------------------------------------------- #
+# STEP 4 -- the ironclad anti-zombie sweep (reuses the hypervisor reap idiom:
+# `gcloud instances list` + `instances delete --delete-disks=all --quiet`).
+# Idempotent, best-effort, NEVER raises.
+# --------------------------------------------------------------------------- #
+def _list_stray_instances(cfg: Config, prefix: str) -> List[Tuple[str, str]]:
+    """Return [(name, zone), ...] for instances whose name starts with `prefix`.
+
+    Fail-soft: any error yields an empty list (the sweep simply finds nothing).
+    """
+    try:
+        rc, out = _run([
+            "gcloud", "compute", "instances", "list",
+            f"--project={cfg.project}",
+            f"--filter=name~^{prefix}",
+            "--format=value(name,zone)",
+        ], timeout_s=cfg.sweep_timeout_s)
+        if rc != 0 or not out:
+            return []
+        pairs: List[Tuple[str, str]] = []
+        for line in out.splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            # `value(name,zone)` is tab/space separated; the zone may be a full URL.
+            parts = line.split()
+            name = parts[0]
+            zone = parts[1].rsplit("/", 1)[-1] if len(parts) > 1 else cfg.zone
+            if name.startswith(prefix):
+                pairs.append((name, zone))
+        return pairs
+    except Exception:  # noqa: BLE001 -- the sweep never raises
+        return []
+
+
+def _delete_instance(cfg: Config, name: str, zone: str) -> None:
+    """Best-effort delete of a single instance (+ its disks). Never raises."""
+    try:
+        rc, out = _run([
+            "gcloud", "compute", "instances", "delete", name,
+            f"--project={cfg.project}", f"--zone={zone}",
+            "--delete-disks=all", "--quiet",
+        ], timeout_s=cfg.sweep_timeout_s)
+        if rc == 0:
+            _log(f"sweep: deleted stray instance {name} ({zone})")
+        else:
+            _log(f"sweep: WARNING delete {name} rc={rc}: {(out or '').strip()[:200]}")
+    except Exception as exc:  # noqa: BLE001 -- the sweep never raises
+        _log(f"sweep: WARNING delete {name} raised (swallowed): {exc!r}")
+
+
+def anti_zombie_sweep(cfg: Config) -> None:
+    """Delete EVERY stray instance from this run (baker + soak VMs). Never raises.
+
+    Reuses the hypervisor's reap idiom (`instances list` -> `instances delete
+    --delete-disks=all --quiet`). Idempotent: re-running finds nothing the second
+    time. Guarantee: zero GCP instances left running even on a catastrophic crash.
+    """
+    try:
+        _log("sweep: anti-zombie backstop -- reaping stray baker + soak instances")
+        seen = set()
+        for prefix in (cfg.bake_prefix, cfg.soak_prefix):
+            for name, zone in _list_stray_instances(cfg, prefix):
+                if name in seen:
+                    continue
+                seen.add(name)
+                _delete_instance(cfg, name, zone)
+        if not seen:
+            _log("sweep: clean -- no stray instances found")
+    except Exception as exc:  # noqa: BLE001 -- ABSOLUTE: the sweep never raises
+        _log(f"sweep: WARNING swept with errors (swallowed): {exc!r}")
+
+
+# --------------------------------------------------------------------------- #
+# Signal handling -- SIGINT/SIGTERM/SIGHUP -> sweep -> exit. The handler closes
+# over the active Config so it can reap even on an external kill.
+# --------------------------------------------------------------------------- #
+def _signal_handler(cfg: Config):
+    def _handler(signum, _frame):
+        _log(f"signal {signum} received -- firing anti-zombie sweep then exiting")
+        anti_zombie_sweep(cfg)
+        # Exit with the conventional 128+signum so the parent sees the cause.
+        raise SystemExit(128 + int(signum))
+    return _handler
+
+
+def _install_signal_handlers(cfg: Config) -> None:
+    for sig in (signal.SIGINT, signal.SIGTERM, getattr(signal, "SIGHUP", None)):
+        if sig is None:
+            continue
+        try:
+            signal.signal(sig, _signal_handler(cfg))
+        except (ValueError, OSError):  # not in main thread / unsupported -- skip
+            pass
+
+
+# --------------------------------------------------------------------------- #
+# Env composition -- arm the flags the soak inherits (CONSTRAINT 4 + golden).
+# --------------------------------------------------------------------------- #
+def _compose_soak_env(golden_armed: bool) -> Dict[str, str]:
+    env = dict(os.environ)
+    for flag in _ARM_FLAGS:
+        env[flag] = "1"
+    if golden_armed:
+        env[_GOLDEN_FLAG] = "1"
+    else:
+        # Degraded path -- the harness uses raw Debian + live pip. Unset so a
+        # stale inherited value can't force a broken golden boot.
+        env.pop(_GOLDEN_FLAG, None)
+    return env
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration -- check -> (bake | degrade) -> soak -> ALWAYS sweep.
+# --------------------------------------------------------------------------- #
+def _orchestrate(cfg: Config) -> int:
+    # STEP 1: pre-flight freshness.
+    state = check_image_freshness(cfg)
+    golden_armed = False
+
+    if state == "fresh":
+        golden_armed = True
+    else:
+        # STEP 1 (cont): autonomous bake. The bake env arms the same flags (the
+        # baker only reads GCP coordinates, but inheriting is harmless + uniform).
+        bake_env = _compose_soak_env(golden_armed=True)
+        baked = False
+        try:
+            baked = bake_golden(cfg, bake_env)
+        except Exception as exc:  # noqa: BLE001 -- bake failure NEVER aborts the run
+            _log(f"bake raised (treated as failure): {exc!r}")
+            baked = False
+
+        if baked:
+            golden_armed = True
+        else:
+            # CONSTRAINT 2 -- graceful degradation. NEVER block the feast.
+            _log("[launcher] golden bake FAILED -- degrading to raw Debian + live "
+                 "pip install; soak continues")
+            golden_armed = False
+
+    # STEP 5 (env) + STEP 3 -- arm flags + transition to the Omni-Soak.
+    soak_env = _compose_soak_env(golden_armed=golden_armed)
+    _log("STEP arm: META_GOAL + OMNI_SOAK + FAULT_TOLERANT_OBS armed; golden=%s"
+         % ("1" if golden_armed else "UNSET"))
+    return run_soak(cfg, soak_env)
+
+
+def _print_dry_run_plan(cfg: Config) -> None:
+    cur = current_requirements_sha(cfg.requirements)
+    print("=" * 72)
+    print("AUTONOMOUS OMNI LAUNCHER -- PLAN (dry-run, touches NOTHING)")
+    print("=" * 72)
+    print(f"  project        : {cfg.project}")
+    print(f"  zone           : {cfg.zone}")
+    print(f"  image family   : {cfg.image_family}")
+    print(f"  req sha label  : {cfg.req_sha_label}")
+    print(f"  requirements   : {cfg.requirements}")
+    print(f"  current sha    : {cur}")
+    print(f"  bake timeout   : {cfg.bake_timeout_s}s")
+    print(f"  reap prefixes  : {cfg.bake_prefix}* , {cfg.soak_prefix}*")
+    print("-" * 72)
+    print("PIPELINE (what --i-understand-this-spends-money would do):")
+    print("  1. pre-flight  : gcloud images list --filter=family:%s -> fresh|stale|missing"
+          % cfg.image_family)
+    print("  2. fresh       : arm %s=1, SKIP bake" % _GOLDEN_FLAG)
+    print("     stale/miss  : subprocess bake_soak_golden_image.py --execute, verify, arm")
+    print("     bake-fail   : SEVERE warn, UNSET %s, CONTINUE (never block)" % _GOLDEN_FLAG)
+    print("  3. arm flags   : %s" % " ".join(_ARM_FLAGS))
+    print("  4. soak        : subprocess a1_live_fire_chaos_harness.py --remote "
+          "--i-understand-this-spends-money")
+    print("  5. ALWAYS sweep: delete %s* + %s* (try/finally + SIGINT/SIGTERM/SIGHUP)"
+          % (cfg.bake_prefix, cfg.soak_prefix))
+    print("=" * 72)
+    print("[launcher] --dry-run: nothing executed, no money spent. Use "
+          "--i-understand-this-spends-money to launch.")
+
+
+# --------------------------------------------------------------------------- #
+# CLI.
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Autonomous Pre-Flight Provisioner -- one command: check the "
+            "jarvis-soak-golden image, bake it if missing/stale (graceful "
+            "degradation to raw Debian + pip on failure -- never blocks), then "
+            "transition into the Omni-Soak, with an ironclad anti-zombie sweep "
+            "on ANY exit."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--project", default=_DEFAULT_PROJECT, help="GCP project (env GCP_PROJECT)")
+    p.add_argument("--zone", default=_DEFAULT_ZONE, help="GCP zone (env GCP_ZONE)")
+    p.add_argument("--image-family", default=_DEFAULT_IMAGE_FAMILY,
+                   help="golden image family (env JARVIS_IAC_SOAK_GOLDEN_IMAGE_FAMILY)")
+    p.add_argument("--requirements", default=_DEFAULT_REQUIREMENTS,
+                   help="requirements.txt path (env JARVIS_SOAK_BAKE_REQUIREMENTS)")
+    p.add_argument("--bake-timeout-s", type=int, default=_DEFAULT_BAKE_TIMEOUT_S,
+                   help="bake readiness timeout (env JARVIS_LAUNCHER_BAKE_TIMEOUT_S)")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="dry_run", action="store_true",
+                      help="print the plan + commands WITHOUT executing (default)")
+    mode.add_argument("--i-understand-this-spends-money", dest="money_gate",
+                      action="store_true",
+                      help="REAL-MONEY safety gate -- required to actually launch")
+    p.set_defaults(dry_run=False, money_gate=False)
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    cfg = build_config(args)
+
+    if args.dry_run:
+        _print_dry_run_plan(cfg)
+        return 0
+
+    if not args.money_gate:
+        _log("REFUSED: launching the Omni-Soak spends real money. Pass "
+             "--i-understand-this-spends-money (or --dry-run to preview).")
+        return 2
+
+    # CONSTRAINT 3 -- arm the signal handlers BEFORE any GCP work, so even a kill
+    # during the bake reaps the baker VM.
+    _install_signal_handlers(cfg)
+
+    # The ENTIRE pipeline (bake + soak) is wrapped so the sweep ALWAYS fires.
+    try:
+        return _orchestrate(cfg)
+    finally:
+        anti_zombie_sweep(cfg)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_autonomous_omni_launcher.py
+++ b/tests/scripts/test_autonomous_omni_launcher.py
@@ -1,0 +1,347 @@
+from __future__ import annotations
+
+"""Tests for the Autonomous Pre-Flight Provisioner (autonomous_omni_launcher.py).
+
+ALL gcloud / subprocess is mocked -- these tests NEVER touch real GCP. They prove
+the orchestration contract:
+
+  * image fresh (sha match)        -> NO bake, golden armed, soak invoked
+  * image stale / missing          -> bake invoked, then (on success) soak armed
+  * bake FAILS                     -> degrade (golden UNSET, severe warning),
+                                      soak STILL invoked (never-block guarantee)
+  * the anti-zombie sweep fires in finally on success AND on exception AND on
+    SIGTERM, deletes both jarvis-soak-bake-* and sovereign-sandbox-*, and never
+    raises even when a delete fails
+  * the launcher arms META_GOAL + OMNI_SOAK + FAULT_TOLERANT_OBS in the soak env
+  * deploy/ouroboros_omni_prod.env exports the omni flags
+"""
+
+import importlib.util
+import pathlib
+import sys
+
+import pytest
+
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_LAUNCHER_PATH = _REPO_ROOT / "scripts" / "autonomous_omni_launcher.py"
+
+
+def _load_launcher():
+    spec = importlib.util.spec_from_file_location(
+        "autonomous_omni_launcher", str(_LAUNCHER_PATH)
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["autonomous_omni_launcher"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture()
+def L():
+    return _load_launcher()
+
+
+# --------------------------------------------------------------------------- #
+# A fake _run that records every gcloud command and answers from a script.
+# --------------------------------------------------------------------------- #
+class FakeRun:
+    """Records calls; answers `images list`-style queries from a fixed sha.
+
+    image_sha=None simulates a MISSING image (empty list output).
+    delete_rc lets a test force the sweep's delete to fail.
+    """
+
+    def __init__(self, image_sha=None, list_instances=None, delete_rc=0):
+        self.calls = []
+        self.image_sha = image_sha
+        # instances the sweep's `instances list` returns, newline-joined.
+        self.list_instances = list_instances or []
+        self.delete_rc = delete_rc
+
+    def __call__(self, cmd, timeout_s=120.0):
+        self.calls.append(list(cmd))
+        joined = " ".join(cmd)
+        if "images" in cmd and "list" in cmd:
+            # Return the sha label (or empty -> missing).
+            return (0, (self.image_sha or "") + ("\n" if self.image_sha else ""))
+        if "instances" in cmd and "list" in cmd:
+            return (0, "\n".join(self.list_instances) + ("\n" if self.list_instances else ""))
+        if "instances" in cmd and "delete" in cmd:
+            return (self.delete_rc, "" if self.delete_rc == 0 else "boom")
+        return (0, "")
+
+    def deletes(self):
+        return [c for c in self.calls if "instances" in c and "delete" in c]
+
+
+# --------------------------------------------------------------------------- #
+# requirements sha reuse (no dup).
+# --------------------------------------------------------------------------- #
+def test_requirements_sha_reused_from_baker(L):
+    # The launcher must reuse the baker's sha helper -- same digest for same file.
+    from importlib.util import spec_from_file_location, module_from_spec
+
+    spec = spec_from_file_location(
+        "_baker_for_test", str(_REPO_ROOT / "scripts" / "bake_soak_golden_image.py")
+    )
+    baker = module_from_spec(spec)
+    spec.loader.exec_module(baker)  # type: ignore[union-attr]
+    req = str(_REPO_ROOT / "requirements.txt")
+    assert L.current_requirements_sha(req) == baker.requirements_sha(req)
+
+
+# --------------------------------------------------------------------------- #
+# Freshness probe.
+# --------------------------------------------------------------------------- #
+def test_freshness_fresh_when_label_matches(L, monkeypatch):
+    cur = L.current_requirements_sha(L.default_requirements_path())
+    fake = FakeRun(image_sha=cur)
+    monkeypatch.setattr(L, "_run", fake)
+    state = L.check_image_freshness(L.build_config())
+    assert state == "fresh"
+
+
+def test_freshness_stale_when_label_mismatches(L, monkeypatch):
+    fake = FakeRun(image_sha="deadbeefdeadbeef")
+    monkeypatch.setattr(L, "_run", fake)
+    state = L.check_image_freshness(L.build_config())
+    assert state == "stale"
+
+
+def test_freshness_missing_when_no_image(L, monkeypatch):
+    fake = FakeRun(image_sha=None)
+    monkeypatch.setattr(L, "_run", fake)
+    state = L.check_image_freshness(L.build_config())
+    assert state == "missing"
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration: fresh -> NO bake, golden armed, soak invoked.
+# --------------------------------------------------------------------------- #
+def test_fresh_skips_bake_arms_golden_runs_soak(L, monkeypatch):
+    cur = L.current_requirements_sha(L.default_requirements_path())
+    fake = FakeRun(image_sha=cur)
+    monkeypatch.setattr(L, "_run", fake)
+
+    bake_called = {"n": 0}
+    monkeypatch.setattr(L, "bake_golden", lambda cfg, env: bake_called.__setitem__("n", bake_called["n"] + 1) or True)
+
+    soak_env = {}
+
+    def fake_soak(cfg, env):
+        soak_env.update(env)
+        return 0
+
+    monkeypatch.setattr(L, "run_soak", fake_soak)
+    monkeypatch.setattr(L, "anti_zombie_sweep", lambda cfg: None)
+
+    rc = L.main(["--i-understand-this-spends-money"])
+    assert rc == 0
+    assert bake_called["n"] == 0, "fresh image must NOT bake"
+    assert soak_env.get("JARVIS_IAC_SOAK_GOLDEN_ENABLED") == "1"
+
+
+# --------------------------------------------------------------------------- #
+# Orchestration: stale/missing -> bake invoked, then soak armed.
+# --------------------------------------------------------------------------- #
+def test_stale_triggers_bake_then_soak_with_golden(L, monkeypatch):
+    fake = FakeRun(image_sha="staleeeeeeeeeeee")
+    monkeypatch.setattr(L, "_run", fake)
+
+    bake_called = {"n": 0}
+
+    def fake_bake(cfg, env):
+        bake_called["n"] += 1
+        return True  # bake succeeds
+
+    monkeypatch.setattr(L, "bake_golden", fake_bake)
+
+    soak_env = {}
+    monkeypatch.setattr(L, "run_soak", lambda cfg, env: soak_env.update(env) or 0)
+    monkeypatch.setattr(L, "anti_zombie_sweep", lambda cfg: None)
+
+    rc = L.main(["--i-understand-this-spends-money"])
+    assert rc == 0
+    assert bake_called["n"] == 1, "stale image must trigger exactly one bake"
+    assert soak_env.get("JARVIS_IAC_SOAK_GOLDEN_ENABLED") == "1"
+
+
+# --------------------------------------------------------------------------- #
+# CONSTRAINT 2 -- bake FAILS -> degrade (golden UNSET), soak STILL runs.
+# --------------------------------------------------------------------------- #
+def test_bake_failure_degrades_but_soak_still_runs(L, monkeypatch, capsys):
+    fake = FakeRun(image_sha=None)  # missing -> wants a bake
+    monkeypatch.setattr(L, "_run", fake)
+    monkeypatch.setattr(L, "bake_golden", lambda cfg, env: False)  # bake FAILS
+
+    soak_called = {"n": 0}
+    soak_env = {}
+
+    def fake_soak(cfg, env):
+        soak_called["n"] += 1
+        soak_env.update(env)
+        return 0
+
+    monkeypatch.setattr(L, "run_soak", fake_soak)
+    monkeypatch.setattr(L, "anti_zombie_sweep", lambda cfg: None)
+
+    rc = L.main(["--i-understand-this-spends-money"])
+    assert rc == 0
+    assert soak_called["n"] == 1, "bake failure must NEVER abort the soak"
+    # Golden must be UNSET (or not '1') so the harness uses raw Debian + pip.
+    assert soak_env.get("JARVIS_IAC_SOAK_GOLDEN_ENABLED") != "1"
+    out = capsys.readouterr().out
+    assert "golden bake FAILED" in out
+    assert "degrading to raw Debian" in out
+
+
+# --------------------------------------------------------------------------- #
+# CONSTRAINT 4 -- flags armed in the soak env.
+# --------------------------------------------------------------------------- #
+def test_launcher_arms_meta_goal_omni_and_fault_tolerant_flags(L, monkeypatch):
+    cur = L.current_requirements_sha(L.default_requirements_path())
+    fake = FakeRun(image_sha=cur)
+    monkeypatch.setattr(L, "_run", fake)
+
+    soak_env = {}
+    monkeypatch.setattr(L, "run_soak", lambda cfg, env: soak_env.update(env) or 0)
+    monkeypatch.setattr(L, "anti_zombie_sweep", lambda cfg: None)
+
+    rc = L.main(["--i-understand-this-spends-money"])
+    assert rc == 0
+    assert soak_env.get("JARVIS_META_GOAL_AGGREGATOR_ENABLED") == "1"
+    assert soak_env.get("JARVIS_A1_OMNI_SOAK") == "1"
+    assert soak_env.get("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED") == "1"
+
+
+# --------------------------------------------------------------------------- #
+# CONSTRAINT 3 -- the sweep fires in finally on SUCCESS, deletes both VM types.
+# --------------------------------------------------------------------------- #
+def test_sweep_fires_on_success_deletes_both_vm_types(L, monkeypatch):
+    cur = L.current_requirements_sha(L.default_requirements_path())
+    fake = FakeRun(
+        image_sha=cur,
+        list_instances=["jarvis-soak-bake-20260101-99", "sovereign-sandbox-20260101-1"],
+    )
+    monkeypatch.setattr(L, "_run", fake)
+    monkeypatch.setattr(L, "run_soak", lambda cfg, env: 0)
+
+    rc = L.main(["--i-understand-this-spends-money"])
+    assert rc == 0
+    deleted = " ".join(" ".join(d) for d in fake.deletes())
+    assert "jarvis-soak-bake-20260101-99" in deleted
+    assert "sovereign-sandbox-20260101-1" in deleted
+
+
+# --------------------------------------------------------------------------- #
+# CONSTRAINT 3 -- the sweep fires in finally even when the soak RAISES.
+# --------------------------------------------------------------------------- #
+def test_sweep_fires_on_exception(L, monkeypatch):
+    cur = L.current_requirements_sha(L.default_requirements_path())
+    fake = FakeRun(
+        image_sha=cur,
+        list_instances=["jarvis-soak-bake-x", "sovereign-sandbox-y"],
+    )
+    monkeypatch.setattr(L, "_run", fake)
+
+    def boom(cfg, env):
+        raise RuntimeError("catastrophic crash mid-soak")
+
+    monkeypatch.setattr(L, "run_soak", boom)
+
+    # main must still tear down (it may re-raise or return non-zero, but the
+    # sweep MUST have run).
+    try:
+        L.main(["--i-understand-this-spends-money"])
+    except RuntimeError:
+        pass
+    deleted = " ".join(" ".join(d) for d in fake.deletes())
+    assert "jarvis-soak-bake-x" in deleted
+    assert "sovereign-sandbox-y" in deleted
+
+
+# --------------------------------------------------------------------------- #
+# CONSTRAINT 3 -- the sweep fires on SIGTERM (signal handler -> sweep).
+# --------------------------------------------------------------------------- #
+def test_sweep_fires_on_sigterm(L, monkeypatch):
+    fake = FakeRun(
+        list_instances=["jarvis-soak-bake-sig", "sovereign-sandbox-sig"],
+    )
+    monkeypatch.setattr(L, "_run", fake)
+
+    swept = {"n": 0}
+    real_sweep = L.anti_zombie_sweep
+
+    def counting_sweep(cfg):
+        swept["n"] += 1
+        return real_sweep(cfg)
+
+    monkeypatch.setattr(L, "anti_zombie_sweep", counting_sweep)
+
+    cfg = L.build_config()
+    # Simulate the signal handler firing.
+    with pytest.raises(SystemExit):
+        L._signal_handler(cfg)(15, None)
+    assert swept["n"] >= 1
+    deleted = " ".join(" ".join(d) for d in fake.deletes())
+    assert "jarvis-soak-bake-sig" in deleted
+    assert "sovereign-sandbox-sig" in deleted
+
+
+# --------------------------------------------------------------------------- #
+# CONSTRAINT 3 -- the sweep NEVER raises even when delete fails.
+# --------------------------------------------------------------------------- #
+def test_sweep_never_raises_on_delete_failure(L, monkeypatch):
+    fake = FakeRun(
+        list_instances=["jarvis-soak-bake-fail", "sovereign-sandbox-fail"],
+        delete_rc=1,  # every delete fails
+    )
+    monkeypatch.setattr(L, "_run", fake)
+    # Must NOT raise.
+    L.anti_zombie_sweep(L.build_config())
+    assert len(fake.deletes()) >= 2
+
+
+def test_sweep_never_raises_when_run_itself_throws(L, monkeypatch):
+    def explode(cmd, timeout_s=120.0):
+        raise OSError("gcloud not found")
+
+    monkeypatch.setattr(L, "_run", explode)
+    # Must swallow everything.
+    L.anti_zombie_sweep(L.build_config())
+
+
+# --------------------------------------------------------------------------- #
+# Money gate -- refuse a real run without the safety flag.
+# --------------------------------------------------------------------------- #
+def test_refuses_without_money_gate(L, monkeypatch):
+    monkeypatch.setattr(L, "run_soak", lambda cfg, env: 0)
+    monkeypatch.setattr(L, "anti_zombie_sweep", lambda cfg: None)
+    rc = L.main([])  # no --i-understand-this-spends-money
+    assert rc != 0
+
+
+# --------------------------------------------------------------------------- #
+# --help / --dry-run smoke (no GCP).
+# --------------------------------------------------------------------------- #
+def test_dry_run_does_not_touch_gcloud(L, monkeypatch):
+    called = {"n": 0}
+    monkeypatch.setattr(L, "_run", lambda *a, **k: called.__setitem__("n", called["n"] + 1) or (0, ""))
+    monkeypatch.setattr(L, "bake_golden", lambda *a, **k: True)
+    soak = {"n": 0}
+    monkeypatch.setattr(L, "run_soak", lambda *a, **k: soak.__setitem__("n", soak["n"] + 1) or 0)
+    rc = L.main(["--dry-run"])
+    assert rc == 0
+    assert soak["n"] == 0, "dry-run must not invoke the real soak"
+
+
+# --------------------------------------------------------------------------- #
+# deploy/ouroboros_omni_prod.env now exports the omni flags.
+# --------------------------------------------------------------------------- #
+def test_prod_env_exports_omni_flags():
+    env_text = (_REPO_ROOT / "deploy" / "ouroboros_omni_prod.env").read_text()
+    assert "JARVIS_META_GOAL_AGGREGATOR_ENABLED" in env_text
+    assert "JARVIS_IAC_SOAK_GOLDEN_ENABLED" in env_text
+    assert "JARVIS_A1_OMNI_SOAK" in env_text
+    assert "JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED" in env_text


### PR DESCRIPTION
One-command autonomous pipeline: golden-image staleness check → bake or degrade → soak → ironclad anti-zombie sweep. Flags armed. 16 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an autonomous pre-flight provisioner that checks the `jarvis-soak-golden` image by requirements SHA, bakes if needed, degrades safely on bake failure, runs the Omni‑Soak, and always reaps stray GCP instances. Also exports and arms the Omni flags so nodes boot with the full overlay.

- **New Features**
  - One-command launcher: check → bake-or-degrade → soak → sweep.
  - Uses `labels.jarvis_req_sha` to decide freshness; bakes with `bake_soak_golden_image.py` and verifies; skips bake if fresh.
  - On bake failure, unsets `JARVIS_IAC_SOAK_GOLDEN_ENABLED` and still runs `a1_live_fire_chaos_harness.py --remote`.
  - Anti-zombie sweep on success, errors, and SIGINT/SIGTERM/SIGHUP; deletes `jarvis-soak-bake-*` and `sovereign-sandbox-*`.
  - Arms `JARVIS_META_GOAL_AGGREGATOR_ENABLED`, `JARVIS_A1_OMNI_SOAK`, `JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED`, and conditional `JARVIS_IAC_SOAK_GOLDEN_ENABLED`; exported in `deploy/ouroboros_omni_prod.env`.
  - `--dry-run` and money gate flag; env‑tunable project/zone/image family/timeouts; single gcloud shim for testability.

<sup>Written for commit 024a9ca5e64bc584a6bb4625c30ad181614cc4bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69726?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

