### PR TITLE
fix(launcher): arm IAC node-lifetime (ON_DEMAND, no Spot-preempt mid-soak)

### DIFF
--- a/scripts/autonomous_omni_launcher.py
+++ b/scripts/autonomous_omni_launcher.py
@@ -101,6 +101,18 @@ _ARM_FLAGS = (
 )
 _GOLDEN_FLAG = "JARVIS_IAC_SOAK_GOLDEN_ENABLED"
 
+# Node-lifetime env the soak inherits so the IAC node is ON-DEMAND (NOT Spot --
+# a preempted Spot node vanishes mid-soak and kills the run) with a long
+# dead-man / max-run / idle horizon that outlives the ~1.5h pipeline. Applied
+# with setdefault semantics: an explicit operator env value always wins.
+_NODE_LIFETIME_ENV = {
+    "JARVIS_IAC_ON_DEMAND": os.environ.get("JARVIS_LAUNCHER_IAC_ON_DEMAND", "1"),
+    "JARVIS_IAC_MAX_RUN_DURATION_S": os.environ.get("JARVIS_LAUNCHER_IAC_MAX_RUN_DURATION_S", "7200"),
+    "JARVIS_IAC_NODE_IDLE_TIMEOUT_S": os.environ.get("JARVIS_LAUNCHER_IAC_NODE_IDLE_TIMEOUT_S", "7200"),
+    "JARVIS_IAC_DEADMAN_IDLE_TIMEOUT_S": os.environ.get("JARVIS_LAUNCHER_IAC_DEADMAN_IDLE_TIMEOUT_S", "7200"),
+    "JARVIS_IAC_MAX_WALL_SECONDS": os.environ.get("JARVIS_LAUNCHER_IAC_MAX_WALL_SECONDS", "6000"),
+}
+
 
 # --------------------------------------------------------------------------- #
 # Reuse the baker's requirements_sha (single source of truth, NO dup). Fail-soft:
@@ -396,6 +408,10 @@ def _compose_soak_env(golden_armed: bool) -> Dict[str, str]:
     env = dict(os.environ)
     for flag in _ARM_FLAGS:
         env[flag] = "1"
+    # Node-lifetime: on-demand + long horizon so the soak node never gets
+    # Spot-preempted or dead-man-reaped mid-feast. setdefault -> explicit env wins.
+    for key, val in _NODE_LIFETIME_ENV.items():
+        env.setdefault(key, val)
     if golden_armed:
         env[_GOLDEN_FLAG] = "1"
     else:


### PR DESCRIPTION
The vanished node was Spot-preempted. Launcher now arms ON_DEMAND + long timeouts (setdefault, env wins). 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure soak runs use ON_DEMAND IAC nodes with long timeouts so nodes aren’t Spot-preempted or reaped mid-run. The launcher sets safe defaults and still respects operator-provided env.

- **Bug Fixes**
  - Added `_NODE_LIFETIME_ENV` defaults: `JARVIS_IAC_ON_DEMAND=1`, 7200s for max-run/idle/dead-man, 6000s wall; values can be sourced from `JARVIS_LAUNCHER_*`.
  - Applied via `env.setdefault(...)` in `_compose_soak_env` so explicit env values are not overridden.

<sup>Written for commit bfbbc6e74780783f0a08f659294d0f4152311d98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69728?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

