### PR TITLE
fix(iac): JARVIS_IAC_ON_DEMAND env forces STANDARD provisioning (no Spot preempt mid-soak)

### DIFF
--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -977,7 +977,15 @@ def _create_node_cmd(
 
     Image family/project resolved via _resolve_node_image (soak-golden when
     enabled+present, else debian-12 -- byte-identical when the gate is off)."""
-    on_demand = bool(getattr(args, "on_demand", False))
+    # on-demand (STANDARD, no Spot preemption) when the CLI flag is set OR the
+    # JARVIS_IAC_ON_DEMAND env override is truthy -- the env path is what lets a
+    # programmatic caller (the harness builds the args Namespace, not the CLI)
+    # force a non-preemptible node for a long multi-stage soak that must not be
+    # reclaimed mid-feast.
+    on_demand = bool(getattr(args, "on_demand", False)) or (
+        os.environ.get("JARVIS_IAC_ON_DEMAND", "").strip().lower()
+        in ("1", "true", "yes", "on")
+    )
     sched = (
         ["--provisioning-model=STANDARD"] if on_demand
         else ["--provisioning-model=SPOT"]
@@ -1438,7 +1446,13 @@ def provision_sandbox_node(
     try:
         with os.fdopen(fd, "w") as fh:
             fh.write(startup_script)
-        _log(f"provisioning {node} (e2-standard-8 SPOT, 32GB, DELETE-on-preempt)")
+        _prov_mode = (
+            "ON-DEMAND/STANDARD"
+            if os.environ.get("JARVIS_IAC_ON_DEMAND", "").strip().lower()
+            in ("1", "true", "yes", "on")
+            else "SPOT, DELETE-on-preempt"
+        )
+        _log(f"provisioning {node} (e2-standard-8 {_prov_mode}, 32GB)")
         rc, captured = _run_streaming_labeled(
             _create_node_cmd(args, node, sp_path),
             label="provision", log_path=log_path, timeout_s=300.0,


### PR DESCRIPTION
The harness builds args programmatically so --on-demand never fired -> every soak node was Spot -> preempted. Provisioning now reads the env override. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor the `JARVIS_IAC_ON_DEMAND` env to force STANDARD (on-demand) provisioning when args are built programmatically, preventing Spot preemption during soaks. Logging now shows the selected provisioning model.

- **Bug Fixes**
  - Provisioning checks `JARVIS_IAC_ON_DEMAND` in addition to the CLI flag; accepts 1/true/yes/on.
  - STANDARD is used when set; otherwise SPOT. Log prints "ON-DEMAND/STANDARD" or "SPOT, DELETE-on-preempt".

<sup>Written for commit 667dc8c57cf329fead8d9717317776166fe3db01. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69729?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

