### PR TITLE
fix(swarm): wire Self-Warming Oracle JIT into Meta-Goal aggregator (the v5 'JIT never fired' fix)

### DIFF
--- a/backend/core/ouroboros/governance/meta_goal_aggregator.py
+++ b/backend/core/ouroboros/governance/meta_goal_aggregator.py
@@ -62,6 +62,7 @@ Constraints honoured
 """
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -383,6 +384,72 @@ class MetaGoalAggregator:
             target_files=(op.file_path,),
             owned_paths=(op.file_path,),
         )
+
+    async def prewarm_window(self) -> int:
+        """Self-Warming Oracle JIT seam -- async-warm the Oracle for the ops in
+        the coalescing window BEFORE the (sync) disjointness partition.
+
+        The bug this closes (Omni-Soak v5): ``drain_ready_bundles`` is SYNC and
+        runs the zero-trust collision partition against ``self._oracle``. On a
+        fresh node the Oracle has NO data for the pooled files, so every
+        cross-file pair is INDETERMINATE -> COLLIDE and nothing bundles
+        ("aged out ... no disjoint sibling found"). ``prewarm_collision_files``
+        (built, but never AWAITED from the live bundle path) JIT-indexes those
+        files so the subsequent ``_coupled_files`` probe finds them indexed ->
+        DISJOINT -> the disjoint set BUNDLES.
+
+        REUSE-only: warms the SAME window ``drain_ready_bundles`` will partition,
+        via the SAME injected ``self._oracle`` handle and the existing
+        ``prewarm_collision_files`` (which itself reuses ``ensure_file_indexed``).
+        No new Oracle is constructed; no new logic.
+
+        Gating: a no-op (returns 0, byte-identical) when the Meta-Goal master is
+        OFF, when ``JARVIS_ORACLE_SELF_WARMING_ENABLED`` is OFF (the
+        ``prewarm_collision_files`` gate), or when there is no Oracle. Fully
+        fail-soft -- a warm error is swallowed and the drain falls through to
+        the existing COLD behaviour (COLLIDE), never crashing the drain.
+
+        Returns the count of files warmed-attempted (0 on any no-op / error).
+        """
+        if not meta_goal_aggregator_enabled():
+            return 0
+        try:
+            from backend.core.ouroboros.governance.collision_matrix import (
+                prewarm_collision_files,
+                self_warming_enabled,
+            )
+
+            if not self_warming_enabled() or self._oracle is None:
+                return 0
+            now = time.monotonic()
+            window = self._window_ops(now, meta_goal_coalesce_window_s())
+            if len(window) < meta_goal_min_ops():
+                return 0
+            # De-duped file set the partition will probe -- same notion as the
+            # drain (each pooled op owns a single target file).
+            files: List[str] = []
+            seen: set = set()
+            for op in window:
+                fp = getattr(op, "file_path", None)
+                if fp and fp not in seen:
+                    seen.add(fp)
+                    files.append(fp)
+            if not files:
+                return 0
+            logger.info(
+                "[MetaGoal] pre-warming oracle for %d files before "
+                "disjointness check (self-warming JIT)",
+                len(files),
+            )
+            return await prewarm_collision_files(self._oracle, files)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 -- warm is advisory; never sink the drain
+            logger.debug(
+                "[MetaGoal] prewarm_window failed (fail-soft -> cold partition)",
+                exc_info=True,
+            )
+            return 0
 
     def drain_ready_bundles(self) -> List[MetaGoalBundle]:
         """Form + return all ready Meta-Goal bundles; drain bundled ops.

--- a/backend/core/ouroboros/governance/meta_goal_wiring.py
+++ b/backend/core/ouroboros/governance/meta_goal_wiring.py
@@ -364,6 +364,20 @@ async def dispatch_ready_bundles(
     """
     if scheduler is None:
         return []
+    # Self-Warming Oracle JIT seam (Omni-Soak v5 fix): async-warm the Oracle for
+    # the window-of-ops the partition is about to probe BEFORE the (sync)
+    # disjointness check, so a cold-node Oracle is JIT-indexed -> disjoint ops
+    # actually bundle instead of all-COLLIDE. No-op when self-warming is OFF
+    # (byte-identical); fail-soft -- a warm error never blocks the drain.
+    try:
+        await aggregator.prewarm_window()
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 -- warm is advisory; drain proceeds cold
+        logger.debug(
+            "[MetaGoalWiring] prewarm_window failed (fail-soft -> cold drain)",
+            exc_info=True,
+        )
     try:
         bundles = aggregator.drain_ready_bundles()
     except Exception:  # noqa: BLE001 -- aggregator error -> legacy fallthrough

--- a/tests/governance/test_meta_goal_wiring.py
+++ b/tests/governance/test_meta_goal_wiring.py
@@ -411,3 +411,179 @@ async def test_aged_single_op_flushes_to_legacy_pool(monkeypatch):
     # A second flush is a no-op (no double-submit).
     await wiring._flush_aged_ops(host, host._meta_goal_aggregator)
     assert len(host._bg_pool.submitted) == 1
+
+
+# ---------------------------------------------------------------------------
+# Self-Warming Oracle JIT wire: the v5 'JIT never fired' fix
+#
+# The aggregator's SYNC ``drain_ready_bundles`` partitions over a COLD Oracle
+# on a fresh node -> every cross-file pair INDETERMINATE -> COLLIDE -> nothing
+# bundles ('aged out ... no disjoint sibling found'). The fix: the live bundle
+# path (``dispatch_ready_bundles``) AWAITs ``aggregator.prewarm_window()`` ->
+# ``prewarm_collision_files(oracle, op-files)`` BEFORE the partition, gated by
+# JARVIS_ORACLE_SELF_WARMING_ENABLED. Warmed Oracle -> _coupled_files finds the
+# files indexed -> DISJOINT -> the disjoint set BUNDLES (allowed=true n=3).
+# ---------------------------------------------------------------------------
+
+
+class _ColdOracle:
+    """Oracle stub that starts COLD (no file indexed) and warms ONLY via the
+    async ``ensure_file_indexed`` JIT -- models the real fresh-node TheOracle.
+
+    Before a file is warmed, ``find_nodes_in_file`` returns ``[]`` (the genuine
+    'no data' miss the zero-trust matrix reads as INDETERMINATE -> COLLIDE).
+    After ``ensure_file_indexed`` is awaited for it, the file resolves to a
+    single node with NO coupling -> provably DISJOINT.
+    """
+
+    class _Node:
+        def __init__(self, fp):
+            self.file_path = fp
+
+    def __init__(self) -> None:
+        self._indexed: set = set()
+        self.warmed_calls: List[str] = []
+
+    def find_nodes_in_file(self, file_path):
+        if file_path in self._indexed:
+            return [self._Node(file_path)]
+        return []  # COLD miss -> indeterminate -> COLLIDE
+
+    async def ensure_file_indexed(self, file_path, **_kw):
+        self.warmed_calls.append(file_path)
+        self._indexed.add(file_path)
+        return True
+
+    def get_dependencies(self, node):
+        return []
+
+    def get_dependents(self, node):
+        return []
+
+
+@pytest.mark.asyncio
+async def test_cold_oracle_prewarm_bundles_three_disjoint_ops(monkeypatch):
+    """Flag ON + COLD oracle + 3 disjoint-file ops -> prewarm AWAITED with
+    those files BEFORE the partition -> oracle warmed -> the 3 ops BUNDLE into
+    ONE Meta-Goal (allowed=true n=3). This is the v5 node's failing path now
+    succeeding on the LIVE seam."""
+    monkeypatch.setenv("JARVIS_ORACLE_SELF_WARMING_ENABLED", "1")
+    oracle = _ColdOracle()
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(8), posture_fn=_posture_maintain(), oracle=oracle,
+    )
+    for i in range(3):
+        agg.offer(PooledOp(op_id=f"op-{i}", file_path=f"pkg/m_{i}.py", rationale=f"r{i}"))
+
+    # Sanity: a COLD drain WITHOUT a prewarm bundles NOTHING (the v5 bug).
+    assert oracle.warmed_calls == []
+
+    sched = _RecordingScheduler()
+    results = await dispatch_ready_bundles(
+        agg, scheduler=sched, gate=_gate_allowing(8), posture_fn=_posture_maintain(),
+    )
+
+    # The prewarm AWAITED ensure_file_indexed for the exact op files BEFORE the
+    # (sync) partition warmed the cold oracle.
+    assert set(oracle.warmed_calls) == {"pkg/m_0.py", "pkg/m_1.py", "pkg/m_2.py"}
+    # Warmed -> disjoint proven -> ONE multi-unit Meta-Goal fanned out (n=3).
+    assert len(results) == 1
+    assert results[0].outcome == FanoutOutcome.COMPLETED
+    assert len(sched.submitted_graphs) == 1
+    assert len(sched.submitted_graphs[0].units) == 3
+    assert agg.pending_ops() == ()
+
+
+@pytest.mark.asyncio
+async def test_prewarm_window_emits_observable_telemetry(monkeypatch, caplog):
+    """The pre-warm fires an observable one-line telemetry the soak debug.log
+    can grep (v5 diagnostic was 'JIT log lines: 0')."""
+    import logging as _logging
+
+    monkeypatch.setenv("JARVIS_ORACLE_SELF_WARMING_ENABLED", "1")
+    oracle = _ColdOracle()
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(8), posture_fn=_posture_maintain(), oracle=oracle,
+    )
+    for i in range(3):
+        agg.offer(PooledOp(op_id=f"op-{i}", file_path=f"pkg/m_{i}.py"))
+
+    with caplog.at_level(_logging.INFO, logger="Ouroboros.MetaGoalAggregator"):
+        warmed = await agg.prewarm_window()
+
+    assert warmed == 3
+    joined = "\n".join(r.getMessage() for r in caplog.records)
+    assert "pre-warming oracle" in joined
+    assert "before disjointness check" in joined
+
+
+@pytest.mark.asyncio
+async def test_prewarm_off_byte_identical_no_bundle_on_cold(monkeypatch):
+    """Flag OFF -> NO pre-warm call, ops do NOT bundle on a cold oracle
+    (byte-identical to today). The cold partition reads indeterminate ->
+    COLLIDE -> nothing fans out; ops stay pooled."""
+    monkeypatch.delenv("JARVIS_ORACLE_SELF_WARMING_ENABLED", raising=False)
+    oracle = _ColdOracle()
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(8), posture_fn=_posture_maintain(), oracle=oracle,
+    )
+    for i in range(3):
+        agg.offer(PooledOp(op_id=f"op-{i}", file_path=f"pkg/m_{i}.py"))
+
+    sched = _RecordingScheduler()
+    results = await dispatch_ready_bundles(
+        agg, scheduler=sched, gate=_gate_allowing(8), posture_fn=_posture_maintain(),
+    )
+
+    # OFF -> no warm, no bundle (cold oracle stays indeterminate -> COLLIDE).
+    assert oracle.warmed_calls == []
+    assert results == []
+    assert sched.submitted_graphs == []
+    # Ops are NOT lost -- they stay pooled for the legacy single-file flush.
+    assert len(agg.pending_ops()) == 3
+
+
+@pytest.mark.asyncio
+async def test_prewarm_error_fails_soft(monkeypatch):
+    """A pre-warm raise is swallowed -> the drain still runs (fail-soft) on the
+    cold oracle -> nothing bundles, ops fall through, NO crash."""
+    monkeypatch.setenv("JARVIS_ORACLE_SELF_WARMING_ENABLED", "1")
+
+    class _BoomOracle(_ColdOracle):
+        async def ensure_file_indexed(self, file_path, **_kw):
+            raise RuntimeError("oracle warm exploded")
+
+    oracle = _BoomOracle()
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(8), posture_fn=_posture_maintain(), oracle=oracle,
+    )
+    for i in range(3):
+        agg.offer(PooledOp(op_id=f"op-{i}", file_path=f"pkg/m_{i}.py"))
+
+    sched = _RecordingScheduler()
+    # Must NOT raise -- fail-soft. prewarm_collision_files swallows per-file.
+    results = await dispatch_ready_bundles(
+        agg, scheduler=sched, gate=_gate_allowing(8), posture_fn=_posture_maintain(),
+    )
+    # Warm failed -> cold partition -> no bundle, ops not lost, no crash.
+    assert results == []
+    assert sched.submitted_graphs == []
+    assert len(agg.pending_ops()) == 3
+
+
+@pytest.mark.asyncio
+async def test_prewarm_window_no_op_when_master_off(monkeypatch):
+    """``prewarm_window`` is a no-op when the Meta-Goal master flag is OFF
+    (no aggregation -> nothing to warm), even if self-warming is ON."""
+    monkeypatch.setenv(META_GOAL_FLAG, "false")
+    monkeypatch.setenv("JARVIS_ORACLE_SELF_WARMING_ENABLED", "1")
+    oracle = _ColdOracle()
+    agg = MetaGoalAggregator(
+        gate=_gate_allowing(8), posture_fn=_posture_maintain(), oracle=oracle,
+    )
+    for i in range(3):
+        agg.offer(PooledOp(op_id=f"op-{i}", file_path=f"pkg/m_{i}.py"))
+
+    warmed = await agg.prewarm_window()
+    assert warmed == 0
+    assert oracle.warmed_calls == []


### PR DESCRIPTION
await prewarm_window() before partition_parallel_safe -> cold Oracle gets JIT-warmed -> disjoint ops bundle. Observable telemetry. 57 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the “JIT never fired” bundling bug by warming the Oracle just before the disjointness partition, so disjoint ops bundle correctly on fresh nodes. Adds one-line telemetry; default-off and fail-soft.

- **Bug Fixes**
  - Added `MetaGoalAggregator.prewarm_window()` to async-warm the window’s files via `prewarm_collision_files` on the injected Oracle; awaited in `dispatch_ready_bundles` before the sync partition.
  - Gated by the meta-goal master flag and `JARVIS_ORACLE_SELF_WARMING_ENABLED`; exceptions are swallowed so the drain proceeds cold; no new Oracle is created.
  - Emits a single INFO log when pre-warming; tests cover warm-path bundling, flag-off byte-identical behavior, fail-soft on warm errors, and master-flag no-op.

<sup>Written for commit a80d62b8477c8299a1ddf91318c1d2107972f6c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69731?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

