### PR TITLE
fix: Pre-Flight Init Barrier (prewarm) + daemonized heartbeat with Death Rattle (the v4-v6 1815s-freeze + prewarm-race fixes)

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1570,6 +1570,21 @@ class GovernedLoopService:
             # byte-identical). Fail-soft: never blocks/raises into boot.
             self._start_failover_loop()
 
+            # Pre-Flight Init Barrier (Omni-Soak v5/v6 fix) — INGEST the
+            # SHA256-validated oracle_prewarm.json and WARM the shared Oracle
+            # handle BEFORE the drain/flush loops below are scheduled. This is
+            # an ABSOLUTE BLOCKING boot step: the JIT pre-warm was wired into
+            # the drain path (dispatch_ready_bundles -> prewarm_window) but ops
+            # exit via the OTHER path (_flush_aged_ops), which ran its OWN COLD
+            # disjointness check and flushed them to legacy ("no disjoint
+            # sibling found") BEFORE the drain's pre-warm fired. Pre-warming is
+            # an INITIALIZATION event, not a runtime-loop event -> warm the
+            # Oracle here so BOTH _flush_aged_ops AND drain see DISJOINT on the
+            # first tick. Gated on JARVIS_ORACLE_SELF_WARMING_ENABLED (OFF ->
+            # no-op, byte-identical). Fail-soft: missing/mismatch payload logs
+            # + boot proceeds (runtime JIT remains the cold-miss fallback).
+            await self._prewarm_oracle_barrier()
+
             # Built-but-no-caller fix — start the Meta-Goal aggregator drain
             # loop alongside the failover loop. The aggregator bundles N
             # disjoint pooled single-file ops into ONE fan-outable Meta-Goal
@@ -6767,6 +6782,30 @@ class GovernedLoopService:
             except Exception:  # noqa: BLE001
                 pass
         self._failover_task = None
+
+    async def _prewarm_oracle_barrier(self) -> int:
+        """ABSOLUTE PRE-FLIGHT INITIALIZATION BARRIER (Omni-Soak v5/v6 fix).
+
+        Ingest the SHA256-validated ``oracle_prewarm.json`` and warm the
+        shared Oracle handle's ``_file_index`` for the known chaos targets as a
+        **blocking** boot step BEFORE the Meta-Goal drain/flush loops are
+        scheduled. Pure delegation to the wiring module's
+        :func:`ingest_prewarm_barrier` (which REUSES the Oracle's existing
+        ``ingest_prewarm_payload`` -- no new ingester). Gated on
+        ``JARVIS_ORACLE_SELF_WARMING_ENABLED`` (OFF -> no-op, byte-identical).
+        Fail-soft: a missing payload / mismatch / error logs and boot proceeds
+        (the runtime JIT remains the cold-miss fallback). Returns warmed count.
+        """
+        try:
+            from backend.core.ouroboros.governance.meta_goal_wiring import (
+                ingest_prewarm_barrier as _barrier,
+            )
+            return await _barrier(self)
+        except Exception as exc:  # noqa: BLE001 -- never block boot
+            logger.debug(
+                "[GovernedLoop] oracle pre-warm barrier skipped: %r", exc,
+            )
+            return 0
 
     def _start_meta_goal_drain_loop(self) -> None:
         """Start the Meta-Goal aggregator drain loop as a peer background task

--- a/backend/core/ouroboros/governance/meta_goal_wiring.py
+++ b/backend/core/ouroboros/governance/meta_goal_wiring.py
@@ -67,6 +67,101 @@ logger = logging.getLogger("Ouroboros.MetaGoalWiring")
 _TICK_INTERVAL_FLAG = "JARVIS_META_GOAL_TICK_INTERVAL_S"
 _DEFAULT_TICK_INTERVAL_S = 5.0
 
+# Pre-Flight Init Barrier (Omni-Soak v5/v6 fix) -- the ChaosInjector writes a
+# SHA256-validated pre-warm payload; the Oracle ingests it as a BLOCKING boot
+# step BEFORE the drain/flush loops are ever scheduled, so the disjointness
+# check is never cold at runtime. Env-overridable, never hardcoded.
+_PREWARM_PAYLOAD_FLAG = "JARVIS_ORACLE_PREWARM_PAYLOAD_PATH"
+_DEFAULT_PREWARM_REL_PATH = os.path.join(".jarvis", "oracle_prewarm.json")
+
+
+def oracle_prewarm_payload_path() -> str:
+    """Absolute/relative path to the Oracle pre-warm payload the boot barrier
+    ingests. ``JARVIS_ORACLE_PREWARM_PAYLOAD_PATH`` overrides; default is
+    ``.jarvis/oracle_prewarm.json`` (the path the ChaosInjector writes, mirror
+    of ``scripts/chaos_injector_ast.py::PREWARM_REL_PATH``). Never hardcoded
+    at a call site."""
+    raw = os.environ.get(_PREWARM_PAYLOAD_FLAG, "").strip()
+    return raw or _DEFAULT_PREWARM_REL_PATH
+
+
+async def ingest_prewarm_barrier(host: Any) -> int:
+    """ABSOLUTE PRE-FLIGHT INITIALIZATION BARRIER (Omni-Soak v5/v6 fix).
+
+    Ingest the SHA256-validated ``oracle_prewarm.json`` and WARM the Oracle's
+    ``_file_index`` for the known chaos targets as a **blocking** boot step --
+    called from the GovernedLoopService ``start()`` sequence BEFORE the
+    Meta-Goal drain/flush loops are scheduled (``asyncio.create_task``). The
+    timers literally cannot start until this returns: "the timer cannot start
+    until the brain is fully loaded."
+
+    THE BUG THIS CLOSES: the JIT pre-warm was wired into the *drain* path
+    (``dispatch_ready_bundles -> prewarm_window``), but ops exit via the OTHER
+    path -- ``_flush_aged_ops`` -- which runs its OWN cold disjointness check
+    and flushes them to legacy ("no disjoint sibling found") BEFORE the drain's
+    pre-warm ever fires. Pre-warming is an INITIALIZATION event, not a runtime-
+    loop event. The barrier warms the SHARED Oracle handle that BOTH
+    ``_flush_aged_ops`` AND ``drain_ready_bundles`` partition against, so both
+    see DISJOINT on the very first tick.
+
+    REUSE-only: the Oracle's existing :meth:`ingest_prewarm_payload` (the
+    injector WRITES, the Oracle READS -- no new ingester) is run off the event
+    loop via :func:`asyncio.to_thread` (it is sync blocking IO + AST parse),
+    so the boot coroutine never blocks the loop. The runtime JIT
+    (``ensure_file_indexed`` / ``prewarm_collision_files``) REMAINS the cold-
+    miss fallback for files NOT in the payload -- the barrier is best-effort
+    warm, the JIT is the safety net.
+
+    Gating: a no-op (returns 0, byte-identical) when
+    ``JARVIS_ORACLE_SELF_WARMING_ENABLED`` is OFF, or when there is no Oracle.
+    Fully fail-soft -- a missing payload / sha256 mismatch / ingest error is
+    logged and boot PROCEEDS (the runtime JIT covers it). Returns the number of
+    target files warmed (0 on any no-op / error).
+    """
+    try:
+        from backend.core.ouroboros.governance.collision_matrix import (
+            self_warming_enabled,
+        )
+        if not self_warming_enabled():
+            return 0  # OFF -> no ingest, byte-identical.
+        oracle = getattr(host, "_oracle", None)
+        if oracle is None:
+            return 0
+        ingest = getattr(oracle, "ingest_prewarm_payload", None)
+        if ingest is None:
+            return 0
+        path = oracle_prewarm_payload_path()
+        # ``ingest_prewarm_payload`` is SYNC (blocking read + AST parse). Run it
+        # off the event loop so the barrier is awaited cleanly (async-clean),
+        # but is STILL blocking w.r.t. the boot sequence: create_task for the
+        # drain/flush loops cannot run until this await returns.
+        warmed = await asyncio.to_thread(ingest, path)
+        if warmed:
+            logger.info(
+                "[MetaGoalWiring] Pre-Flight Init Barrier: ingested oracle "
+                "pre-warm payload -> %d chaos target(s) warmed BEFORE the "
+                "drain/flush loops are scheduled (disjointness never cold at "
+                "runtime). path=%s",
+                warmed, path,
+            )
+        else:
+            logger.info(
+                "[MetaGoalWiring] Pre-Flight Init Barrier: no payload warmed "
+                "(missing / sha256 mismatch / empty) -> boot proceeds, runtime "
+                "JIT remains the cold-miss fallback. path=%s",
+                path,
+            )
+        return int(warmed or 0)
+    except asyncio.CancelledError:
+        raise
+    except Exception:  # noqa: BLE001 -- barrier is best-effort; never block boot
+        logger.warning(
+            "[MetaGoalWiring] Pre-Flight Init Barrier ingest failed (fail-soft "
+            "-> boot proceeds, runtime JIT fallback active)",
+            exc_info=True,
+        )
+        return 0
+
 # CONSTRAINT 4 -- absolute anti-zombie ceiling on a proof-in-flight hold.
 _PROOF_MAX_WAIT_FLAG = "JARVIS_META_GOAL_PROOF_MAX_WAIT_S"
 _DEFAULT_PROOF_MAX_WAIT_S = 15.0
@@ -618,8 +713,10 @@ async def stop_meta_goal_drain_loop(host: Any) -> None:
 __all__ = [
     "clear_proof_in_flight",
     "dispatch_ready_bundles",
+    "ingest_prewarm_barrier",
     "mark_proof_in_flight",
     "meta_goal_tick_interval_s",
+    "oracle_prewarm_payload_path",
     "pooled_op_from_ctx",
     "proof_max_wait_s",
     "start_meta_goal_drain_loop",

--- a/scripts/sovereign_iac_hypervisor.py
+++ b/scripts/sovereign_iac_hypervisor.py
@@ -376,6 +376,19 @@ _DEFAULT_HEARTBEAT_IONICE_PRIO = os.environ.get("JARVIS_IAC_HEARTBEAT_IONICE_PRI
 _DEFAULT_HEARTBEAT_STALE_S = float(
     os.environ.get("JARVIS_IAC_HEARTBEAT_STALE_S", "120")
 )
+# Heartbeat DAEMON PID file (the double-forked daemon writes its own PID here so
+# the surgery EXIT trap can reap it on a NORMAL exit -- while the daemon survives
+# the battle_test process-group reaper DURING the soak). Env-tunable; defaults
+# alongside the soak_state path. The `.hb.pid` suffix mirrors the writer's shape.
+_DEFAULT_HEARTBEAT_PID_PATH = os.environ.get(
+    "JARVIS_IAC_HEARTBEAT_PID_PATH", f"{_DEFAULT_SOAK_STATE_PATH}.hb.pid"
+)
+# The DEATH RATTLE phase the daemon writes (atomically) to soak_state.json the
+# instant it is signalled (SIGINT/SIGTERM/EXIT) -- so a kill is INSTANTLY
+# observable to the local poll instead of a 100-min silent stale-out. Env-tunable.
+_DEFAULT_HEARTBEAT_ASSASSINATED_PHASE = os.environ.get(
+    "JARVIS_IAC_HEARTBEAT_ASSASSINATED_PHASE", "HEARTBEAT_ASSASSINATED_BY_SIGNAL"
+)
 
 # Per-phase wall allowances (env-tunable). deps gets a tight budget; the swarm
 # fanout / soak a wider one. Active (advancing heartbeat) extends WITHIN the per-
@@ -1795,17 +1808,66 @@ def _fault_tolerant_obs_enabled(args: argparse.Namespace) -> bool:
     return _env_truthy_off("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED")
 
 
+def _heartbeat_daemon_inner_program(loop_body: str) -> str:
+    """Build the inner DAEMON program (the SECOND fork's bash -c arg): set the
+    rattle phase var, install the DEATH RATTLE trap (SIGINT/SIGTERM/EXIT), write
+    OUR OWN pid (`$$` of this `bash -c`, the second-fork daemon) to the dedicated PID
+    file, then run the (caller-supplied, reused) writer loop.
+
+    The DEATH RATTLE atomically (temp+mv, reusing the writer's shape) stamps
+    phase=<assassinated_phase> + a fresh ts into soak_state.json BEFORE exiting --
+    so a kill is INSTANTLY observable to the local poll, not a 100-min silent
+    stale-out. Held in a var so the phase string stays ASCII + brace-safe under
+    printf. POSIX-portable -- no Linux-only binaries -- so a test can launch this
+    core directly (via os.setsid) on a host lacking `setsid`/`ionice`."""
+    state_q = shlex.quote(_DEFAULT_SOAK_STATE_PATH)
+    pid_q = shlex.quote(_DEFAULT_HEARTBEAT_PID_PATH)
+    rattle_phase_q = shlex.quote(_DEFAULT_HEARTBEAT_ASSASSINATED_PHASE)
+    rattle = (
+        f"_rattle() {{ _rt={state_q}.rattle.$$; "
+        "printf '{\"phase\":\"%s\",\"status\":\"running\",\"rc\":null,\"ts\":%s,"
+        "\"verdict\":\"running\",\"last_active\":%s,\"step_seq\":-1}\\n' "
+        f"\"$_RATTLE_PHASE\" \"$(date +%s)\" \"$(date +%s)\" "
+        f"> \"$_rt\" 2>/dev/null && mv -f \"$_rt\" {state_q} 2>/dev/null || true; "
+        "exit 0; }; "
+    )
+    # We record `$$` -- the pid of THIS `bash -c '<inner>'` process. Under the
+    # production wrapper the inner runs as `( bash -c '<inner>' & )`, so this bash
+    # IS the second-fork daemon and `$$` is its own pid (portable to bash 3.2,
+    # unlike $BASHPID which is bash >=4.0 only -- macOS /bin/bash is 3.2).
+    return (
+        f"_RATTLE_PHASE={rattle_phase_q}; "
+        f"{rattle}"
+        "trap _rattle SIGINT SIGTERM EXIT; "
+        f"echo $$ > {pid_q} 2>/dev/null || true; "
+        f"{loop_body}"
+    )
+
+
 def _heartbeat_block(args: argparse.Namespace) -> str:
-    """Render the node-side anti-starvation HEARTBEAT (CONSTRAINT 1): a setsid
-    background loop that ATOMICALLY (temp+mv) ticks soak_state.json.last_active +
-    step_seq every ~interval seconds -- even during a long quiet step (deps).
+    """Render the node-side anti-starvation HEARTBEAT (CONSTRAINT 1): a background
+    loop that ATOMICALLY (temp+mv) ticks soak_state.json.last_active + step_seq
+    every ~interval seconds -- even during a long quiet step (deps).
 
     Launched at ELEVATED OS priority (`nice -n -20 ionice -c1 -n0`, realtime IO)
     so a swarm redlining CPU/IO at 100%% can NEVER starve/OOM-kill it -> no false
     heartbeat freeze. `ionice -c1` falls back to `-c2 -n0` (best-effort highest)
     at RUNTIME if -c1 is denied (it needs root/CAP_SYS_ADMIN). The heartbeat reads
     the current phase from the marker file the writer drops, so its ticks carry
-    the live phase. Its PID is exported (_HB_PID) so the EXIT trap can kill it."""
+    the live phase.
+
+    GATING (JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED):
+      OFF -> the LEGACY `setsid ... & _HB_PID=$!` snippet, byte-identical.
+      ON  -> a TRUE DOUBLE-FORK DAEMON: setsid (new session, no controlling TTY)
+             -> fork again (cannot reacquire a TTY, immune to session-group
+             signals) -> writes its own dedicated PID file -> the daemon loop
+             installs a DEATH RATTLE trap (SIGINT/SIGTERM/EXIT) that atomically
+             writes phase=<assassinated> to soak_state.json BEFORE exiting. This
+             survives the battle_test process-group reaper (kill -- -<pgid> /
+             pkill -g) that DETERMINISTICALLY killed the weak setsid loop at
+             soak-launch (the 1815s freeze in Omni-Soak v4/v5/v6), and -- if ever
+             killed -- makes the kill INSTANTLY observable instead of a 100-min
+             silent stale-out."""
     state_q = shlex.quote(_DEFAULT_SOAK_STATE_PATH)
     phase_marker_q = f"{state_q}.phase"
     interval = float(getattr(args, "heartbeat_interval_s", _DEFAULT_HEARTBEAT_INTERVAL_S))
@@ -1831,26 +1893,87 @@ def _heartbeat_block(args: argparse.Namespace) -> str:
         f"sleep {interval}; "
         "done"
     )
-    loop_q = shlex.quote(loop_body)
     nice_q = shlex.quote(nice)
     ioc_q = shlex.quote(ioc)
     iop_q = shlex.quote(iop)
-    # Launch at REALTIME io class -c1 (preferred); on EPERM fall back to the
-    # best-effort highest -c2 -n0. setsid detaches it from the surgery TTY. The
-    # priority prefix is applied to the launched child; the loop body is a single
-    # `bash -c '<program>'` arg so it runs intact in the elevated child.
+
+    # ---- LEGACY path (FT-obs OFF): byte-identical setsid background loop ----- #
+    if not _fault_tolerant_obs_enabled(args):
+        loop_q = shlex.quote(loop_body)
+        # Launch at REALTIME io class -c1 (preferred); on EPERM fall back to the
+        # best-effort highest -c2 -n0. setsid detaches it from the surgery TTY. The
+        # priority prefix is applied to the launched child; the loop body is a single
+        # `bash -c '<program>'` arg so it runs intact in the elevated child.
+        return (
+            "# ---- CONSTRAINT 1: anti-starvation heartbeat (elevated nice/ionice) ----\n"
+            f"if ionice -c{ioc_q} -n{iop_q} true 2>/dev/null; then "
+            f"setsid nice -n {nice_q} ionice -c{ioc_q} -n{iop_q} "
+            f"bash -c {loop_q} </dev/null >/dev/null 2>&1 & _HB_PID=$!; "
+            "else "
+            f"setsid nice -n {nice_q} ionice -c2 -n0 "
+            f"bash -c {loop_q} </dev/null >/dev/null 2>&1 & _HB_PID=$!; "
+            "fi; "
+            "export _HB_PID; "
+            "echo \"[iac] heartbeat launched pid=$_HB_PID "
+            f"(nice {nice} ionice -c{ioc} -n{iop} realtime, fallback -c2 -n0)\";\n"
+        )
+
+    # ---- DAEMON path (FT-obs ON): double-fork + PID file + DEATH RATTLE ------ #
+    pid_q = shlex.quote(_DEFAULT_HEARTBEAT_PID_PATH)
+    rattle_phase = _DEFAULT_HEARTBEAT_ASSASSINATED_PHASE
+    # The inner daemon program (loop + PID file + death-rattle trap) is built by a
+    # standalone helper so a test can launch JUST that POSIX core (portably, via
+    # os.setsid in a preexec_fn) on a host that lacks the Linux-only `setsid`/
+    # `ionice` binaries the rendered wrapper uses.
+    inner_daemon = _heartbeat_daemon_inner_program(loop_body)
+    inner_q = shlex.quote(inner_daemon)
+    # The SESSION-LEADER program (fork #1, under setsid): it forks the loop into a
+    # backgrounded child subshell (fork #2) and EXITS immediately. The child is a
+    # NON session-leader -> can NEVER reacquire a controlling TTY, and it is
+    # reparented to init when its session-leader parent exits.
+    session_program = (
+        f"( bash -c {inner_q} </dev/null >/dev/null 2>&1 & ) ; exit 0"
+    )
+    daemon_q = shlex.quote(session_program)
+    # TRUE DOUBLE-FORK: `setsid bash -c '( bash -c <loop> & ) ; exit 0'`:
+    #   fork #1 + setsid -> a NEW SESSION leader, no controlling TTY;
+    #   the inner `( ... & )` is fork #2 -> a NON session-leader child in its OWN
+    #     process group, IMMUNE to `kill -- -<pgid>` / `pkill -g` sweeps targeting
+    #     the surgery's process group (the battle_test reaper's weapon);
+    #   the session leader EXITS at once -> the loop child is reparented to init.
+    # </dev/null + full redirection severs all std streams. The OUTER setsid launch
+    # is trailing-`&`+`disown`ed so it is NOT in the surgery's process group either.
+    # The loop child writes ITS OWN `$$` to the PID file; we read it back so the
+    # surgery EXIT trap can reap the real daemon on a NORMAL exit. Priority prefix
+    # wraps the setsid.
+    def _launch(ioc_eff: str, iop_eff: str) -> str:
+        return (
+            f"setsid nice -n {nice_q} ionice -c{ioc_eff} -n{iop_eff} "
+            f"bash -c {daemon_q} </dev/null >/dev/null 2>&1 & "
+        )
+    launch_pref = _launch(ioc_q, iop_q)
+    launch_fallback = _launch("2", "0")
     return (
-        "# ---- CONSTRAINT 1: anti-starvation heartbeat (elevated nice/ionice) ----\n"
+        "# ---- CONSTRAINT 1: anti-starvation heartbeat DAEMON "
+        "(double-fork + PID file + death-rattle) ----\n"
+        # fresh PID file each launch (idempotent relaunch).
+        f": > {pid_q} 2>/dev/null || true; "
         f"if ionice -c{ioc_q} -n{iop_q} true 2>/dev/null; then "
-        f"setsid nice -n {nice_q} ionice -c{ioc_q} -n{iop_q} "
-        f"bash -c {loop_q} </dev/null >/dev/null 2>&1 & _HB_PID=$!; "
+        f"{launch_pref}"
         "else "
-        f"setsid nice -n {nice_q} ionice -c2 -n0 "
-        f"bash -c {loop_q} </dev/null >/dev/null 2>&1 & _HB_PID=$!; "
+        f"{launch_fallback}"
         "fi; "
-        "export _HB_PID; "
-        "echo \"[iac] heartbeat launched pid=$_HB_PID "
-        f"(nice {nice} ionice -c{ioc} -n{iop} realtime, fallback -c2 -n0)\";\n"
+        # the OUTER setsid bash is disowned so it is NOT in the surgery's process
+        # group; the daemon it forked is reparented to init and writes its own PID.
+        "disown 2>/dev/null || true; "
+        # give the double-fork a brief moment to land its PID file, then read it.
+        f"for _i in 1 2 3 4 5 6 7 8 9 10; do "
+        f"[ -s {pid_q} ] && break; sleep 0.2; done; "
+        f"_HB_PID=$(cat {pid_q} 2>/dev/null || true); export _HB_PID; "
+        "echo \"[iac] heartbeat DAEMON launched pid=$_HB_PID "
+        f"(double-fork, pidfile {_DEFAULT_HEARTBEAT_PID_PATH}, death-rattle "
+        f"{rattle_phase}, nice {nice} ionice -c{ioc} -n{iop} realtime, "
+        "fallback -c2 -n0)\";\n"
     )
 
 
@@ -1899,10 +2022,20 @@ def _remote_surgery_body_script(args: argparse.Namespace) -> str:
     # additive (bash runs all EXIT traps -- we chain via a single handler).
     # When the heartbeat is armed the trap ALSO kills the heartbeat PID.
     if ft_obs:
+        # NORMAL-surgery-exit cleanup reaps the heartbeat DAEMON: kill the exported
+        # _HB_PID AND (belt-and-suspenders) the pid recorded in the dedicated PID
+        # file -- so even if _HB_PID was not captured (double-fork race) the daemon
+        # is still reaped on a clean surgery exit. The daemon SURVIVES the
+        # battle_test process-group reaper DURING the soak (different session/pgroup);
+        # only THIS explicit, targeted kill on normal exit takes it down.
+        pid_q = shlex.quote(_DEFAULT_HEARTBEAT_PID_PATH)
         lock_trap = (
             f"echo \"$$\" > {lock_q} 2>/dev/null || true; "
             f"_cleanup() {{ rm -f {lock_q} 2>/dev/null || true; "
-            "[ -n \"${_HB_PID:-}\" ] && kill \"$_HB_PID\" 2>/dev/null || true; }; "
+            "[ -n \"${_HB_PID:-}\" ] && kill \"$_HB_PID\" 2>/dev/null || true; "
+            f"_hbf=$(cat {pid_q} 2>/dev/null || true); "
+            "[ -n \"$_hbf\" ] && kill \"$_hbf\" 2>/dev/null || true; "
+            f"rm -f {pid_q} 2>/dev/null || true; }}; "
             "trap _cleanup EXIT INT TERM; "
         )
     else:
@@ -2502,6 +2635,17 @@ async def _poll_surgery_to_terminal(
         # EXTEND, but CAPPED by MAX_PHASE_CEILING (a zombie ticking-but-stuck
         # swarm is still reaped, no infinite extend).
         if ft_obs:
+            # DEATH RATTLE: the daemon stamps phase=<assassinated_phase> the instant
+            # it is signalled (SIGINT/SIGTERM/EXIT). Treat it as an IMMEDIATE
+            # reap-with-cause -- do NOT wait the full stale allowance; the kill is
+            # already known, so a 100-min silent stale-out is replaced by an
+            # instant, attributed reap.
+            if phase == _DEFAULT_HEARTBEAT_ASSASSINATED_PHASE:
+                _emit(f"[iac] heartbeat DEATH RATTLE: phase='{phase}' -- the daemon "
+                      "was assassinated by a signal -- IMMEDIATE reap-with-cause "
+                      "(no stale-allowance wait)\n")
+                rc, verdict = 137, parse_verdict(captured)
+                break
             cur_active = state.get("last_active")
             try:
                 cur_active_i = int(cur_active) if cur_active is not None else None
@@ -3244,6 +3388,10 @@ def build_parser() -> argparse.ArgumentParser:
                    help="heartbeat ionice priority (env JARVIS_IAC_HEARTBEAT_IONICE_PRIO)")
     p.add_argument("--heartbeat-stale-s", type=float, default=_DEFAULT_HEARTBEAT_STALE_S,
                    help="last_active staleness -> heartbeat FROZEN (env JARVIS_IAC_HEARTBEAT_STALE_S)")
+    p.add_argument("--heartbeat-pid-path", default=_DEFAULT_HEARTBEAT_PID_PATH,
+                   help="heartbeat DAEMON pid file (env JARVIS_IAC_HEARTBEAT_PID_PATH)")
+    p.add_argument("--heartbeat-assassinated-phase", default=_DEFAULT_HEARTBEAT_ASSASSINATED_PHASE,
+                   help="death-rattle phase string (env JARVIS_IAC_HEARTBEAT_ASSASSINATED_PHASE)")
     p.add_argument("--global-ceiling-s", type=float, default=_DEFAULT_GLOBAL_CEILING_S,
                    help="global hard wall ceiling, 0=use max-wall (env JARVIS_IAC_GLOBAL_CEILING_SECONDS)")
     p.add_argument("--rescue-retries", type=int, default=_DEFAULT_RESCUE_RETRIES,

--- a/tests/governance/test_prewarm_init_barrier.py
+++ b/tests/governance/test_prewarm_init_barrier.py
@@ -1,0 +1,331 @@
+"""Pre-Flight Init Barrier -- regression spine (Omni-Soak v5/v6 fix).
+
+THE BUG (captured live): the JIT pre-warm was wired into the DRAIN path
+(``dispatch_ready_bundles -> prewarm_window``), but ops exit via the OTHER
+path -- ``_flush_aged_ops`` -- which runs its OWN cold disjointness check and
+flushes them to legacy ("no disjoint sibling found") BEFORE the drain's
+pre-warm ever fires. ``pre-warming oracle`` telemetry NEVER appeared (0 lines).
+Root flaw: pre-warming is an INITIALIZATION event, not a runtime-loop event.
+
+THE FIX: the GovernedLoopService ``start()`` sequence ingests
+``oracle_prewarm.json`` and warms the SHARED Oracle handle as a BLOCKING boot
+step BEFORE the drain/flush loops are scheduled. The timers cannot start until
+the brain is fully loaded.
+
+This spine pins (all proofs use a MOCKED / dilated asyncio clock -- NO real
+sleeps; the barrier is gated on a controllable :class:`asyncio.Event`):
+
+(a) BARRIER HOLDS: the drain/flush tasks are NOT scheduled until
+    ``ingest_prewarm_payload`` returns (an ingest that awaits a controllable
+    event -> assert no drain task exists until it resolves).
+(b) FIRST-TICK BUNDLE (the v5/v6 fix): after the barrier warms the Oracle, 3
+    disjoint-file ops -> on the FIRST ``_flush_aged_ops`` tick the Oracle is
+    ALREADY warm -> they are DISJOINT (would BUNDLE allowed=true n=3), NONE
+    age out to legacy ("no disjoint sibling found").
+(c) OFF byte-identical: master flag off -> no ingest, warmed=0, no payload read.
+(d) MISSING / MISMATCH payload -> fail-soft boot proceeds + the runtime JIT
+    (``ensure_file_indexed``) is still reachable as the cold-miss fallback.
+(e) REUSE: the barrier drives the Oracle's EXISTING ``ingest_prewarm_payload``
+    + the EXISTING ``ensure_file_indexed`` JIT -- no new ingester / Oracle.
+"""
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import meta_goal_wiring as mgw
+from backend.core.ouroboros.governance.meta_goal_wiring import (
+    ingest_prewarm_barrier,
+    oracle_prewarm_payload_path,
+)
+
+
+# ---------------------------------------------------------------------------
+# Test doubles -- reuse the real ingest/JIT CONTRACT, not the AST parser.
+# ---------------------------------------------------------------------------
+
+
+class _Node:
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+
+
+class _BarrierOracle:
+    """A fake Oracle exposing the EXISTING contract the barrier reuses:
+
+    - ``ingest_prewarm_payload(path)`` -- SYNC, SHA256-validates each target
+      against the live file, warms ``_file_index`` (mirrors the real Oracle).
+    - ``ensure_file_indexed(fp)`` -- the runtime JIT cold-miss fallback.
+    - ``find_nodes_in_file(fp)`` -- the sync collision probe surface.
+
+    Starts COLD (``_file_index`` empty). Optionally an ``ingest_gate`` event
+    lets a test HOLD the (off-loop) ingest mid-flight to prove the barrier
+    blocks scheduling.
+    """
+
+    def __init__(self, *, ingest_gate=None) -> None:
+        self._file_index = {}
+        self._ingest_calls = 0
+        self._jit_calls = 0
+        self._ingest_gate = ingest_gate
+
+    # -- EXISTING ingest contract the barrier reuses (SYNC, blocking) --------
+    def ingest_prewarm_payload(self, path: str) -> int:
+        self._ingest_calls += 1
+        if self._ingest_gate is not None:
+            # Block this off-loop thread until the test releases it -> proves
+            # the barrier's await has NOT returned, so nothing downstream was
+            # scheduled yet. ``wait()`` is a threading.Event (cross-thread).
+            self._ingest_gate.wait()
+        try:
+            p = Path(path)
+            if not p.exists():
+                return 0
+            data = json.loads(p.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            return 0
+        targets = data.get("targets") if isinstance(data, dict) else None
+        if not isinstance(targets, list) or not targets:
+            return 0
+        verified = []
+        for entry in targets:
+            fp = str(entry.get("file_path") or "").strip()
+            want = str(entry.get("sha256") or "").strip().lower()
+            live = Path(fp)
+            if not fp or not want or not live.exists():
+                return 0
+            got = hashlib.sha256(live.read_bytes()).hexdigest()
+            if got != want:
+                return 0  # mismatch -> DISCARD entire payload, fall to JIT.
+            verified.append(fp)
+        for fp in verified:
+            self._file_index[fp] = {f"{fp}::node"}
+        return len(verified)
+
+    # -- EXISTING runtime JIT (cold-miss fallback) --------------------------
+    async def ensure_file_indexed(self, file_path, *, _visited=None, _depth=0):
+        self._jit_calls += 1
+        self._file_index[file_path] = {f"{file_path}::node"}
+        return True
+
+    # -- sync collision probe surface ---------------------------------------
+    def find_nodes_in_file(self, file_path):
+        return [_Node(file_path) for _ in self._file_index.get(file_path, ())]
+
+
+class _Host:
+    """Minimal GLS-shaped host: only ``_oracle`` is read by the barrier."""
+
+    def __init__(self, oracle) -> None:
+        self._oracle = oracle
+
+
+def _write_payload(tmp_path: Path, files) -> Path:
+    """Write a SHA256-valid oracle_prewarm.json over real on-disk files."""
+    targets = []
+    for name in files:
+        f = tmp_path / name
+        f.write_text(f"# {name}\nX = 1\n", encoding="utf-8")
+        sha = hashlib.sha256(f.read_bytes()).hexdigest()
+        targets.append({"file_path": str(f), "sha256": sha, "coupled": []})
+    payload = tmp_path / "oracle_prewarm.json"
+    payload.write_text(json.dumps({"targets": targets}), encoding="utf-8")
+    return payload
+
+
+@pytest.fixture(autouse=True)
+def _enable_self_warming(monkeypatch):
+    monkeypatch.setenv("JARVIS_ORACLE_SELF_WARMING_ENABLED", "true")
+    yield
+
+
+# ---------------------------------------------------------------------------
+# (a) BARRIER HOLDS -- drain/flush not scheduled until ingest returns.
+#     Time-dilated: the ingest blocks on a controllable event; we assert the
+#     barrier coroutine has NOT completed (and thus nothing after it ran)
+#     until the event is released. No real sleeps.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_barrier_blocks_scheduling_until_ingest_returns(tmp_path, monkeypatch):
+    import threading
+
+    gate = threading.Event()
+    oracle = _BarrierOracle(ingest_gate=gate)
+    payload = _write_payload(tmp_path, ["a.py", "b.py", "c.py"])
+    monkeypatch.setenv("JARVIS_ORACLE_PREWARM_PAYLOAD_PATH", str(payload))
+    host = _Host(oracle)
+
+    # Stand-in for "schedule the drain/flush loops" -- it must NOT run until
+    # the barrier's await returns (the barrier is awaited BEFORE scheduling).
+    scheduled = {"drain": False}
+
+    async def boot():
+        await ingest_prewarm_barrier(host)
+        scheduled["drain"] = True  # only reachable AFTER the barrier returns.
+
+    task = asyncio.create_task(boot())
+
+    # Drain the event loop WITHOUT releasing the ingest gate. The barrier is
+    # parked in asyncio.to_thread waiting on the (still-closed) gate -> the
+    # post-barrier scheduling line is UNREACHABLE.
+    for _ in range(5):
+        await asyncio.sleep(0)
+    assert scheduled["drain"] is False, "drain scheduled before ingest returned"
+    assert oracle._file_index == {}, "Oracle warmed before ingest released"
+    assert not task.done()
+
+    # Release the ingest -> the barrier completes -> THEN scheduling proceeds.
+    gate.set()
+    await asyncio.wait_for(task, timeout=5.0)
+    assert scheduled["drain"] is True
+    assert oracle._ingest_calls == 1
+    # The barrier warmed the SHARED Oracle handle for the chaos targets.
+    assert set(oracle._file_index) == {
+        str(tmp_path / "a.py"),
+        str(tmp_path / "b.py"),
+        str(tmp_path / "c.py"),
+    }
+
+
+# ---------------------------------------------------------------------------
+# (b) FIRST-TICK BUNDLE (the v5/v6 fix) -- post-barrier, an IMMEDIATE
+#     _flush_aged_ops tick finds DISJOINT (Oracle already warm), so 3 disjoint
+#     ops would BUNDLE (allowed=true n=3) and NONE age out to legacy.
+#     Time-dilated: ops are offered already-aged (offered_at far in the past)
+#     so the FIRST tick is the age-out moment -- and yet they are not flushed,
+#     because the warm Oracle proves them disjoint -> they bundle/drain.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_post_barrier_first_tick_bundles_none_age_out(tmp_path, monkeypatch):
+    from backend.core.ouroboros.governance.collision_matrix import (
+        build_collision_matrix,
+        partition_parallel_safe,
+        CollisionVerdict,
+    )
+    from backend.core.ouroboros.governance.autonomy.subagent_types import (
+        WorkUnitSpec,
+    )
+
+    oracle = _BarrierOracle()  # no gate -> ingest returns immediately.
+    payload = _write_payload(tmp_path, ["a.py", "b.py", "c.py"])
+    monkeypatch.setenv("JARVIS_ORACLE_PREWARM_PAYLOAD_PATH", str(payload))
+    host = _Host(oracle)
+
+    # COLD before the barrier: the partition would COLLIDE on every pair.
+    assert oracle._file_index == {}
+
+    # THE BARRIER: blocking boot ingest BEFORE any drain/flush tick.
+    warmed = await ingest_prewarm_barrier(host)
+    assert warmed == 3
+    fa, fb, fc = (str(tmp_path / n) for n in ("a.py", "b.py", "c.py"))
+    assert set(oracle._file_index) == {fa, fb, fc}
+
+    # FIRST tick: the partition (what _flush_aged_ops/drain both read) sees the
+    # ALREADY-warm shared Oracle -> DISJOINT, not "no disjoint sibling".
+    units = [
+        WorkUnitSpec(unit_id="u1", repo="jarvis", goal="g", target_files=(fa,)),
+        WorkUnitSpec(unit_id="u2", repo="jarvis", goal="g", target_files=(fb,)),
+        WorkUnitSpec(unit_id="u3", repo="jarvis", goal="g", target_files=(fc,)),
+    ]
+    matrix = build_collision_matrix(units, oracle=oracle)
+    assert matrix.verdict("u1", "u2") is CollisionVerdict.DISJOINT
+    assert matrix.verdict("u1", "u3") is CollisionVerdict.DISJOINT
+    assert matrix.verdict("u2", "u3") is CollisionVerdict.DISJOINT
+
+    parallel, sequential = partition_parallel_safe(units, oracle=oracle, matrix=matrix)
+    # allowed=true n=3: ONE fan-out group of all 3 -> NONE forced serial / aged.
+    assert len(parallel) == 1 and len(parallel[0]) == 3
+    assert sequential == []
+    # No runtime JIT was needed -- the barrier did the warming up front.
+    assert oracle._jit_calls == 0
+
+
+# ---------------------------------------------------------------------------
+# (c) OFF byte-identical -- master flag off -> NO ingest, NO warm.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_off_flag_no_ingest_byte_identical(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_ORACLE_SELF_WARMING_ENABLED", "false")
+    oracle = _BarrierOracle()
+    payload = _write_payload(tmp_path, ["a.py", "b.py"])
+    monkeypatch.setenv("JARVIS_ORACLE_PREWARM_PAYLOAD_PATH", str(payload))
+    host = _Host(oracle)
+
+    warmed = await ingest_prewarm_barrier(host)
+    assert warmed == 0
+    assert oracle._ingest_calls == 0  # payload never even read (OFF).
+    assert oracle._file_index == {}
+
+
+# ---------------------------------------------------------------------------
+# (d) MISSING payload -> fail-soft boot proceeds + runtime JIT still available.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_missing_payload_failsoft_boot_then_jit_fallback(tmp_path, monkeypatch):
+    oracle = _BarrierOracle()
+    monkeypatch.setenv(
+        "JARVIS_ORACLE_PREWARM_PAYLOAD_PATH", str(tmp_path / "does_not_exist.json"),
+    )
+    host = _Host(oracle)
+
+    warmed = await ingest_prewarm_barrier(host)
+    assert warmed == 0  # missing payload -> graceful no-op (boot proceeds).
+    assert oracle._file_index == {}
+
+    # The runtime JIT (ensure_file_indexed) is STILL reachable as the cold-miss
+    # fallback for files the barrier did not pre-warm.
+    ok = await oracle.ensure_file_indexed("z.py")
+    assert ok is True
+    assert "z.py" in oracle._file_index
+    assert oracle._jit_calls == 1
+
+
+# ---------------------------------------------------------------------------
+# (d') SHA256 MISMATCH -> entire payload discarded -> fail-soft + JIT fallback.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_sha_mismatch_discards_payload_failsoft(tmp_path, monkeypatch):
+    oracle = _BarrierOracle()
+    payload = _write_payload(tmp_path, ["a.py", "b.py"])
+    # Mutate a live target AFTER the payload was hashed -> sha mismatch.
+    (tmp_path / "a.py").write_text("# tampered\nY = 2\n", encoding="utf-8")
+    monkeypatch.setenv("JARVIS_ORACLE_PREWARM_PAYLOAD_PATH", str(payload))
+    host = _Host(oracle)
+
+    warmed = await ingest_prewarm_barrier(host)
+    assert warmed == 0  # mismatch -> discard entire payload (boot proceeds).
+    assert oracle._file_index == {}
+    # JIT fallback intact.
+    assert await oracle.ensure_file_indexed("a.py") is True
+
+
+# ---------------------------------------------------------------------------
+# (e) REUSE -- no oracle / no ingest method -> graceful 0 (no new ingester).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_no_oracle_handle_graceful(monkeypatch):
+    host = _Host(None)
+    assert await ingest_prewarm_barrier(host) == 0
+
+
+def test_payload_path_default_and_override(monkeypatch):
+    monkeypatch.delenv("JARVIS_ORACLE_PREWARM_PAYLOAD_PATH", raising=False)
+    assert oracle_prewarm_payload_path().endswith("oracle_prewarm.json")
+    monkeypatch.setenv("JARVIS_ORACLE_PREWARM_PAYLOAD_PATH", "/custom/p.json")
+    assert oracle_prewarm_payload_path() == "/custom/p.json"

--- a/tests/scripts/test_heartbeat_daemon.py
+++ b/tests/scripts/test_heartbeat_daemon.py
@@ -1,0 +1,398 @@
+# -*- coding: utf-8 -*-
+"""True-daemonized fault-tolerant-obs HEARTBEAT tests for
+scripts/sovereign_iac_hypervisor.py (the Omni-Soak v4/v5/v6 1815s-freeze fix).
+
+THE BUG (DETERMINISTIC): the heartbeat froze at EXACTLY 1815s in v4/v5/v6 -- it
+stopped ticking soak_state.json.last_active the instant the O+V soak (battle_test)
+launched. The OLD launch was a weak `setsid nice -20 ionice bash -c '<loop>' &`,
+which the battle_test harness's process-group zombie-reaper (it "auto-reaps any
+zombie ouroboros_battle_test.py processes" on startup) swept up WITH the soak --
+taking the heartbeat down. The dual-boundary wall then correctly reaped at
+~1815s+allowance, but with verdict=UNKNOWN: no soak ever completed.
+
+THE FIX (rendered into _heartbeat_block when FT-obs is ON):
+  1. TRUE DOUBLE-FORK DAEMON: setsid (new session, no controlling TTY) -> a second
+     fork (a `( ... ) &` subshell that can NEVER reacquire a TTY, in its OWN
+     process group) -> dedicated PID file -> the loop. The OUTER setsid bash is
+     disowned -> the daemon is reparented to init, NOT in the surgery's process
+     group, IMMUNE to `kill -- -<pgid>` / `pkill -g` sweeps (the v4/v5/v6 killer).
+  2. THE DEATH RATTLE: the daemon installs `trap _rattle SIGINT SIGTERM EXIT`. The
+     rattle ATOMICALLY (temp+mv) writes phase=HEARTBEAT_ASSASSINATED_BY_SIGNAL +
+     a fresh ts to soak_state.json BEFORE exiting -> a kill is INSTANTLY
+     observable to the local poll (reap-with-cause), NOT a 100-min silent
+     stale-out.
+  3. The surgery EXIT trap STILL reaps the daemon on a NORMAL surgery exit (kills
+     the PID-file pid) -- but the daemon survives the soak-launch reaper DURING
+     the soak (different session/pgroup).
+
+Master gate JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED default-OFF -> the LEGACY
+setsid snippet is byte-identical. NO real GCP/SSH in the rendered-snippet tests;
+the real-process tests fork/killpg a minimal local copy of the daemon snippet and
+are guarded to skip cleanly where the sandbox forbids fork/killpg.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import signal
+import subprocess
+import time
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "sovereign_iac_hypervisor.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "sovereign_iac_hypervisor_hbd", _SCRIPT
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def iac():
+    return _load_module()
+
+
+@pytest.fixture()
+def args_on(iac, monkeypatch, tmp_path):
+    """FT-obs ON args, with the soak_state + PID paths redirected into tmp."""
+    monkeypatch.setenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", "true")
+    state = str(tmp_path / "soak_state.json")
+    monkeypatch.setenv("JARVIS_IAC_SOAK_STATE_PATH", state)
+    monkeypatch.setenv("JARVIS_IAC_HEARTBEAT_PID_PATH", state + ".hb.pid")
+    monkeypatch.setenv("JARVIS_IAC_HEARTBEAT_INTERVAL_S", "0.2")
+    # The module read the path consts at import time -> reload so the redirected
+    # paths take effect in the freshly-loaded module.
+    mod = _load_module()
+    a = mod.build_parser().parse_args([])
+    a.surgery_cmd = "echo soak"
+    return mod, a, state
+
+
+# --------------------------------------------------------------------------- #
+# (a) Rendered-snippet asserts: double-fork + PID file + death-rattle trap.
+# --------------------------------------------------------------------------- #
+def test_rendered_block_has_double_fork(iac, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", "true")
+    a = iac.build_parser().parse_args([])
+    block = iac._heartbeat_block(a)
+    # setsid (fork #1 + new session) + a backgrounded child (fork #2) + disown so
+    # the daemon is NOT in the surgery's process group.
+    assert "setsid nice" in block
+    assert "disown" in block
+    assert "DAEMON" in block  # the daemon banner, not the legacy launch
+    # still elevated priority (reused, not duplicated).
+    assert "nice -n -20" in block
+    assert "ionice -c1 -n0" in block
+    assert "ionice -c2 -n0" in block  # runtime fallback
+
+
+def test_rendered_block_writes_pid_file(iac, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", "true")
+    a = iac.build_parser().parse_args([])
+    block = iac._heartbeat_block(a)
+    # the daemon (second fork, a `bash -c`) writes its OWN $$ to the dedicated PID
+    # file; the launcher reads it back into _HB_PID.
+    assert "echo $$ >" in block
+    assert ".hb.pid" in block
+    assert "_HB_PID=$(cat" in block
+    assert "export _HB_PID" in block
+
+
+def test_rendered_block_has_death_rattle_trap(iac, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", "true")
+    a = iac.build_parser().parse_args([])
+    block = iac._heartbeat_block(a)
+    # the trap fires on SIGINT/SIGTERM/EXIT and writes the assassinated phase.
+    assert "trap _rattle SIGINT SIGTERM EXIT" in block
+    assert "HEARTBEAT_ASSASSINATED_BY_SIGNAL" in block
+    # the rattle writes atomically (temp + mv), reusing the writer shape.
+    assert "mv -f" in block
+
+
+def test_rattle_phase_is_env_tunable(iac, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IAC_HEARTBEAT_ASSASSINATED_PHASE", "CUSTOM_RATTLE")
+    mod = _load_module()
+    a = mod.build_parser().parse_args([])
+    block = mod._heartbeat_block(a)
+    assert "CUSTOM_RATTLE" in block
+
+
+def test_rendered_block_is_ascii_and_bash_valid(iac, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", "true")
+    a = iac.build_parser().parse_args([])
+    block = iac._heartbeat_block(a)
+    assert block.isascii()
+    r = subprocess.run(["bash", "-n"], input=block, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+def test_surgery_body_trap_reaps_daemon_via_pid_file(iac, monkeypatch):
+    monkeypatch.setenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", "true")
+    a = iac.build_parser().parse_args([])
+    a.surgery_cmd = "echo x"
+    body = iac._remote_surgery_body_script(a)
+    # the EXIT trap reaps via the exported pid AND the pid file (belt+suspenders).
+    assert 'kill "$_HB_PID"' in body
+    assert ".hb.pid" in body
+    assert 'kill "$_hbf"' in body
+    r = subprocess.run(["bash", "-n"], input=body, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+
+
+# --------------------------------------------------------------------------- #
+# (d) OFF flag -> legacy setsid snippet byte-identical.
+# --------------------------------------------------------------------------- #
+def test_off_flag_is_legacy_setsid_byte_identical(iac, monkeypatch):
+    monkeypatch.delenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", raising=False)
+    a = iac.build_parser().parse_args([])
+    block = iac._heartbeat_block(a)
+    # legacy markers present, daemon markers ABSENT.
+    assert "setsid nice" in block
+    assert "& _HB_PID=$!" in block
+    assert "DAEMON" not in block
+    assert "trap _rattle" not in block
+    assert "HEARTBEAT_ASSASSINATED_BY_SIGNAL" not in block
+    assert ".hb.pid" not in block
+    assert "disown" not in block
+
+
+def test_off_flag_byte_identical_to_git_head(iac, monkeypatch):
+    """The OFF heartbeat snippet must be byte-identical to the pre-change HEAD
+    rendering -- the gated default-OFF byte-identical guarantee."""
+    head_src = subprocess.run(
+        ["git", "show", "HEAD:scripts/sovereign_iac_hypervisor.py"],
+        cwd=str(_SCRIPT.resolve().parents[1]),
+        capture_output=True,
+        text=True,
+    )
+    if head_src.returncode != 0:
+        pytest.skip("git HEAD unavailable")
+    head_path = _SCRIPT.parent / "_hbd_head_snapshot.py"
+    head_path.write_text(head_src.stdout)
+    try:
+        spec = importlib.util.spec_from_file_location("iac_head_hbd", head_path)
+        old = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(old)
+    finally:
+        head_path.unlink(missing_ok=True)
+    monkeypatch.delenv("JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED", raising=False)
+    a_old = old.build_parser().parse_args([])
+    a_new = iac.build_parser().parse_args([])
+    assert old._heartbeat_block(a_old) == iac._heartbeat_block(a_new)
+
+
+# --------------------------------------------------------------------------- #
+# Real-process integration tests. Guarded to skip cleanly where fork/killpg are
+# unavailable (some sandboxes). The rendered wrapper uses Linux-only `setsid` /
+# `ionice`; on a host that lacks `setsid` (macOS dev) we launch the SAME inner
+# daemon PROGRAM (reused via _heartbeat_daemon_inner_program) ourselves through
+# os.setsid in a preexec_fn -- replicating the new-session double-fork portably.
+# On Linux/CI (setsid present) the same path also holds, so the tests run on both.
+# --------------------------------------------------------------------------- #
+_FORK_OK = (
+    hasattr(os, "fork")
+    and hasattr(os, "setsid")
+    and hasattr(os, "killpg")
+    and hasattr(os, "getpgid")
+)
+
+
+def _read_last_active(path: str):
+    import json
+
+    try:
+        with open(path, "r") as fh:
+            return json.load(fh)
+    except Exception:
+        return None
+
+
+def _fast_loop(state: str) -> str:
+    """A minimal fast-interval writer loop (the SAME shape as the production
+    loop_body: phase + last_active + advancing step_seq, atomic temp+mv)."""
+    return (
+        "_seq=0; while true; do _seq=$((_seq+1)); "
+        f"_tmp={state}.hb.$$; "
+        "printf '{\"phase\":\"running\",\"status\":\"running\",\"rc\":null,"
+        "\"ts\":%s,\"verdict\":\"running\",\"last_active\":%s,\"step_seq\":%s}\\n' "
+        "\"$(date +%s)\" \"$(date +%s)\" \"$_seq\" "
+        f"> \"$_tmp\" 2>/dev/null && mv -f \"$_tmp\" {state} 2>/dev/null || true; "
+        "sleep 0.2; done"
+    )
+
+
+def _spawn_daemon_own_session(mod, state: str):
+    """Launch the reused inner daemon program (loop + PID file + death-rattle) in
+    its OWN new session via os.setsid -- portable across Linux/macOS. Returns the
+    Popen handle (the session leader). The daemon (this process) is thus NOT in the
+    test runner's process group: a killpg of the SURGERY pgroup cannot reach it."""
+    inner = mod._heartbeat_daemon_inner_program(_fast_loop(state))
+    return subprocess.Popen(
+        ["bash", "-c", inner],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        stdin=subprocess.DEVNULL,
+        preexec_fn=os.setsid,  # NEW SESSION -> own pgroup, no controlling TTY
+    )
+
+
+@pytest.mark.skipif(not _FORK_OK, reason="fork/setsid/killpg unavailable in sandbox")
+def test_daemon_survives_process_group_kill_and_keeps_advancing(args_on, tmp_path):
+    """THE v4/v5/v6 FIX, PROVEN: a 'surgery' process lives in its OWN process
+    group; the heartbeat daemon is launched into a DIFFERENT session/pgroup (the
+    double-fork). Fire a process-group kill at the SURGERY's pgid (the battle_test
+    reaper's weapon). The daemon SURVIVES and KEEPS advancing last_active. The old
+    weak in-pgroup setsid loop would have been swept (the 1815s freeze)."""
+    mod, a, state = args_on
+
+    # the SURGERY: a process in its own new session/pgroup, just sleeping (the soak).
+    surgery = subprocess.Popen(
+        ["bash", "-c", "sleep 30"],
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+        preexec_fn=os.setsid,
+    )
+    surgery_pgid = os.getpgid(surgery.pid)
+
+    # the DAEMON: launched into ITS OWN session/pgroup (the double-fork), distinct
+    # from the surgery's pgroup -> a killpg(surgery_pgid) cannot reach it.
+    daemon = _spawn_daemon_own_session(mod, state)
+    daemon_pgid = os.getpgid(daemon.pid)
+    assert daemon_pgid != surgery_pgid, "daemon must NOT share the surgery's pgroup"
+    try:
+        deadline = time.time() + 10
+        first = None
+        while time.time() < deadline:
+            first = _read_last_active(state)
+            if first and first.get("last_active"):
+                break
+            time.sleep(0.1)
+        assert first and first.get("last_active"), "daemon never wrote last_active"
+        la1 = int(first["last_active"])
+        seq1 = int(first.get("step_seq", 0))
+
+        # FIRE THE PROCESS-GROUP KILL at the surgery's whole pgroup (the exact
+        # sweep that took the old in-pgroup setsid loop down at soak-launch).
+        os.killpg(surgery_pgid, signal.SIGKILL)
+        try:
+            surgery.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            pass
+
+        # the DAEMON must STILL be alive and STILL advancing across an interval.
+        time.sleep(1.0)
+        after = _read_last_active(state)
+        assert after is not None, "state file vanished after pgroup kill"
+        assert after.get("phase") != "HEARTBEAT_ASSASSINATED_BY_SIGNAL"
+        assert daemon.poll() is None, "daemon died on the pgroup sweep (the bug!)"
+        la2 = int(after["last_active"])
+        seq2 = int(after.get("step_seq", 0))
+        assert la2 >= la1, "daemon stopped advancing after the pgroup kill"
+        assert seq2 > seq1, "daemon alive but step_seq not advancing past the sweep"
+    finally:
+        for pg in (daemon_pgid, surgery_pgid):
+            try:
+                os.killpg(pg, signal.SIGKILL)
+            except Exception:
+                pass
+
+
+@pytest.mark.skipif(not _FORK_OK, reason="fork/setsid/killpg unavailable in sandbox")
+def test_direct_term_writes_death_rattle_before_dying(args_on, tmp_path):
+    """(c) THE RATTLE: a direct SIGTERM to the daemon -> it writes
+    phase=HEARTBEAT_ASSASSINATED_BY_SIGNAL to soak_state.json BEFORE it dies
+    (proven by reading the file after the kill)."""
+    mod, a, state = args_on
+    daemon = _spawn_daemon_own_session(mod, state)
+    daemon_pgid = os.getpgid(daemon.pid)
+    pidf = state + ".hb.pid"
+    dpid = None
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                dpid = int(Path(pidf).read_text().strip())
+                if dpid:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.1)
+        assert dpid, "daemon never wrote its PID file"
+        time.sleep(0.5)
+        pre = _read_last_active(state)
+        assert pre and pre.get("phase") != "HEARTBEAT_ASSASSINATED_BY_SIGNAL"
+
+        # DIRECT SIGTERM to the daemon -> the rattle MUST fire before it exits.
+        os.kill(dpid, signal.SIGTERM)
+        deadline = time.time() + 5
+        rattled = None
+        while time.time() < deadline:
+            cur = _read_last_active(state)
+            if cur and cur.get("phase") == "HEARTBEAT_ASSASSINATED_BY_SIGNAL":
+                rattled = cur
+                break
+            time.sleep(0.1)
+        assert rattled is not None, (
+            "no death rattle: phase=HEARTBEAT_ASSASSINATED_BY_SIGNAL never written"
+        )
+        assert rattled.get("step_seq") == -1  # the rattle marker
+        assert int(rattled.get("last_active", 0)) > 0  # fresh ts stamped
+    finally:
+        try:
+            os.killpg(daemon_pgid, signal.SIGKILL)
+        except Exception:
+            pass
+
+
+@pytest.mark.skipif(not _FORK_OK, reason="fork/setsid/killpg unavailable in sandbox")
+def test_normal_surgery_exit_reaps_daemon_via_pid_file(args_on, tmp_path):
+    """The surgery EXIT-trap cleanup reaps the daemon on a NORMAL exit: spawn the
+    daemon, then run the SAME cleanup the surgery trap runs (kill the pid-file pid)
+    and assert the daemon is dead -- distinct from the soak-launch reaper that must
+    NOT take it (proven by the survives-pgroup-kill test above)."""
+    mod, a, state = args_on
+    daemon = _spawn_daemon_own_session(mod, state)
+    daemon_pgid = os.getpgid(daemon.pid)
+    pidf = state + ".hb.pid"
+    dpid = None
+    try:
+        deadline = time.time() + 10
+        while time.time() < deadline:
+            try:
+                dpid = int(Path(pidf).read_text().strip())
+                if dpid:
+                    break
+            except Exception:
+                pass
+            time.sleep(0.1)
+        assert dpid, "daemon never wrote its PID file"
+        assert os.path.exists(pidf)
+
+        # the surgery EXIT trap's cleanup: read the pid file, kill it, rm the file.
+        cleanup = (
+            f'_hbf=$(cat {state}.hb.pid 2>/dev/null || true); '
+            '[ -n "$_hbf" ] && kill "$_hbf" 2>/dev/null || true; '
+            f'rm -f {state}.hb.pid 2>/dev/null || true'
+        )
+        subprocess.run(["bash", "-c", cleanup], timeout=10)
+        # the daemon must EXIT on the normal-exit cleanup kill (the rattle trap
+        # fires, then it exits). Since this test process is its parent, wait() to
+        # reap it and confirm it actually terminated (a bare os.kill(pid,0) would
+        # falsely see the un-reaped zombie as 'alive').
+        rc = daemon.wait(timeout=5)
+        assert rc is not None  # the daemon terminated on the cleanup kill
+        assert not os.path.exists(pidf)  # pid file removed by the cleanup
+    finally:
+        try:
+            os.killpg(daemon_pgid, signal.SIGKILL)
+        except Exception:
+            pass


### PR DESCRIPTION
Barrier: blocking oracle_prewarm ingest before drain/flush loops scheduled. Heartbeat: double-fork daemon + PID file (survives process-group reaper) + SIGTERM rattle. Time-dilated + real-killpg proofs. ~95 tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two soak stability issues: adds a pre-flight oracle prewarm barrier to eliminate the v5/v6 disjointness cold-start race, and daemonizes the node heartbeat with a death‑rattle for instant, attributed failures.

- **Bug Fixes**
  - Pre-warm barrier: ingest `oracle_prewarm.json` as a blocking boot step before drain/flush start, so both paths see a warm index on first tick; gated by `JARVIS_ORACLE_SELF_WARMING_ENABLED` (fail‑soft, default OFF).
  - Wiring: new `ingest_prewarm_barrier` and `_prewarm_oracle_barrier()` reuse the existing `ingest_prewarm_payload` via `asyncio.to_thread`; path overridable with `JARVIS_ORACLE_PREWARM_PAYLOAD_PATH`.
  - Heartbeat: true double‑fork daemon with dedicated PID file; survives process‑group reapers; installs SIGINT/SIGTERM/EXIT trap that writes `HEARTBEAT_ASSASSINATED_BY_SIGNAL` to `soak_state.json` for immediate, attributed reaps; gated by `JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED` (default OFF).
  - Monitoring: normal surgery exit reaps the daemon by PID file; assassinated phase triggers instant rc=137 handling. Adds tests for barrier scheduling, first‑tick bundling, daemon survival, and death‑rattle.

- **Migration**
  - To enable the barrier: set `JARVIS_ORACLE_SELF_WARMING_ENABLED=true` (optional: `JARVIS_ORACLE_PREWARM_PAYLOAD_PATH`).
  - To enable the daemon heartbeat: set `JARVIS_IAC_FAULT_TOLERANT_OBS_ENABLED=true` (optional: `JARVIS_IAC_HEARTBEAT_PID_PATH`, `JARVIS_IAC_HEARTBEAT_ASSASSINATED_PHASE`).

<sup>Written for commit a450707f31c2f7317a8633caec3a69a5f9334d2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69732?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

