### PR TITLE
fix(ouroboros): cognitive-gate hardening — 6 real autonomy bugs found by the Isomorphic Sandbox

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -417,3 +417,11 @@ autopsy_reports/
 # A1 Live-Fire Chaos Harness run outputs (transient)
 a1_runs/
 a1_autopsy/
+
+# Agentic scratch / SDD working dirs — never version-controlled (enforced)
+.superpowers/
+_preview*.html
+_preview*.png
+_meritfirst_resume.html
+logs/autopsies/
+proof_telemetry/

--- a/backend/core/ouroboros/governance/ascii_strict_gate.py
+++ b/backend/core/ouroboros/governance/ascii_strict_gate.py
@@ -50,7 +50,9 @@ because they can occupy identifier positions. Gated by
 """
 from __future__ import annotations
 
+import io
 import os
+import tokenize
 from dataclasses import dataclass
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 
@@ -410,6 +412,138 @@ def scan_content(
     return offenders
 
 
+def scan_content_token_aware(
+    content: str,
+    file_path: str = "?",
+    max_samples: int = _DEFAULT_MAX_SAMPLES,
+) -> List[BadCodepoint]:
+    """Token-aware scan for Python source content.
+
+    Uses stdlib :mod:`tokenize` to classify every token and flags non-ASCII
+    codepoints ONLY in *code-token* positions:
+
+    **Allowed** (non-ASCII permitted — per policy):
+      - ``STRING`` tokens  (string literals, docstrings)
+      - ``COMMENT`` tokens
+      - ``NL``, ``NEWLINE``, ``INDENT``, ``DEDENT``, ``ENCODING``, ``ENDMARKER``
+      - ``FSTRING_START`` / ``FSTRING_MIDDLE`` / ``FSTRING_END`` (Python 3.12+)
+
+    **Rejected** (non-ASCII flagged — the ``rapidفuzz`` threat):
+      - ``NAME`` tokens (identifier positions)
+      - ``OP``, ``NUMBER``, and any other code token
+
+    On ``tokenize.TokenError`` or ``IndentationError`` (unparseable Python) the
+    function falls back conservatively to :func:`scan_content` (whole-content
+    scan) so a broken file cannot smuggle homoglyphs past the gate.
+    """
+    if not isinstance(content, str) or not content:
+        return []
+
+    # Fast path — common case where content is already clean ASCII.
+    if content.isascii():
+        return []
+
+    # Token types where non-ASCII is allowed (string literals, comments,
+    # whitespace structural tokens).  Built once per call — cheap set lookup.
+    _allowed_token_types = {
+        tokenize.STRING,
+        tokenize.COMMENT,
+        tokenize.NL,
+        tokenize.NEWLINE,
+        tokenize.INDENT,
+        tokenize.DEDENT,
+        tokenize.ENCODING,
+        tokenize.ENDMARKER,
+    }
+    # Python 3.12+ splits f-strings into FSTRING_START / FSTRING_MIDDLE /
+    # FSTRING_END.  The *literal* parts (MIDDLE) carry the user-visible text
+    # and should be allowed; START/END are delimiters.  Add them all to the
+    # allow set so emoji in f-string text is never rejected.
+    for _attr in ("FSTRING_START", "FSTRING_MIDDLE", "FSTRING_END"):
+        _v = getattr(tokenize, _attr, None)
+        if _v is not None:
+            _allowed_token_types.add(_v)
+    _allowed_token_types = frozenset(_allowed_token_types)
+
+    # Build a zero-indexed line → absolute-character-offset map so each
+    # BadCodepoint carries accurate (offset, line, column) even in multi-line
+    # tokens (NAME tokens are always single-line; we compute it generically).
+    line_start: List[int] = []
+    pos = 0
+    for _ln in content.splitlines(keepends=True):
+        line_start.append(pos)
+        pos += len(_ln)
+    # Safety entry so _abs_offset never goes out of bounds on the last line.
+    line_start.append(pos)
+
+    def _abs_offset(srow: int, scol: int) -> int:
+        """Convert tokenize (1-based row, 0-based col) to absolute offset."""
+        idx = srow - 1
+        if 0 <= idx < len(line_start):
+            return line_start[idx] + scol
+        return len(content)
+
+    offenders: List[BadCodepoint] = []
+
+    try:
+        _tokens = tokenize.generate_tokens(io.StringIO(content).readline)
+        for tok_type, tok_string, tok_start, _tok_end, _line_text in _tokens:
+            if tok_type in _allowed_token_types:
+                # Unicode allowed inside string literals, comments, whitespace.
+                continue
+            if not tok_string or tok_string.isascii():
+                # No non-ASCII in this code token — fast path.
+                continue
+            # Scan this code token character by character.
+            srow, scol = tok_start
+            base_offset = _abs_offset(srow, scol)
+            cur_line = srow      # 1-based
+            cur_col = scol       # 0-based; report as cur_col + 1
+            for i, ch in enumerate(tok_string):
+                cp = ord(ch)
+                if cp > 127:
+                    offenders.append(BadCodepoint(
+                        file_path=file_path,
+                        offset=base_offset + i,
+                        char=ch,
+                        codepoint=cp,
+                        line=cur_line,
+                        column=cur_col + 1,  # 1-based output
+                    ))
+                    if max_samples > 0 and len(offenders) >= max_samples:
+                        return offenders
+                if ch == "\n":
+                    cur_line += 1
+                    cur_col = 0
+                else:
+                    cur_col += 1
+    except (tokenize.TokenError, IndentationError):
+        # Unparseable Python — conservative fallback ensures broken content
+        # never bypasses the gate by hiding homoglyphs behind a syntax error.
+        return scan_content(content, file_path, max_samples)
+
+    return offenders
+
+
+def _scan_content_for_path(
+    content: str,
+    file_path: str,
+    max_samples: int = _DEFAULT_MAX_SAMPLES,
+) -> List[BadCodepoint]:
+    """Dispatch to the right scan based on file extension.
+
+    * ``.py`` files → :func:`scan_content_token_aware` (allows Unicode in
+      string literals / comments, rejects it in identifier positions).
+    * All other files → :func:`scan_content` (conservative whole-content scan).
+
+    Falls back to :func:`scan_content` automatically if token-aware parsing
+    fails (via the error handling inside :func:`scan_content_token_aware`).
+    """
+    if isinstance(file_path, str) and file_path.endswith(".py"):
+        return scan_content_token_aware(content, file_path, max_samples)
+    return scan_content(content, file_path, max_samples)
+
+
 def scan_candidate(
     candidate: Dict[str, Any],
     max_samples: int = _DEFAULT_MAX_SAMPLES,
@@ -455,7 +589,7 @@ def scan_candidate(
                 fc = entry.get("raw_content", "") or ""
             if not isinstance(fc, str):
                 continue
-            found = scan_content(fc, fp, max_samples=remaining)
+            found = _scan_content_for_path(fc, fp, max_samples=remaining)
             offenders.extend(found)
             if max_samples > 0:
                 remaining = max_samples - len(offenders)
@@ -472,7 +606,9 @@ def scan_candidate(
         primary_content = candidate.get("raw_content", "") or ""
     if isinstance(primary_content, str) and primary_content:
         fp = str(candidate.get("file_path", "") or "?")
-        offenders.extend(scan_content(primary_content, fp, max_samples=remaining))
+        offenders.extend(
+            _scan_content_for_path(primary_content, fp, max_samples=remaining)
+        )
 
     return offenders
 

--- a/backend/core/ouroboros/governance/execution_context.py
+++ b/backend/core/ouroboros/governance/execution_context.py
@@ -117,4 +117,57 @@ def _is_cloud_container() -> bool:
         return False
 
 
-__all__ = ["_is_cloud_container", "is_autonomous", "is_primary_checkout"]
+def authoritative_repo_root(path: "Path | str") -> Path:
+    """Translate a path inside a ``.worktrees/<name>`` directory to the
+    authoritative parent repository root.
+
+    When the orchestrator is running with file isolation enabled, it uses a
+    linked worktree under ``<repo>/.worktrees/<session>/`` as its
+    ``project_root``.  Coverage lookups, blast-radius scans, and test
+    discovery MUST read from the authoritative tree (where test files
+    actually exist), not from the worktree which may be empty or partially
+    cleaned.  WRITES continue to target the worktree — this function is
+    READ-path only.
+
+    Algorithm: walk *path* upward; if any ancestor is named ``.worktrees``,
+    return its parent (the repo root).  If no ``.worktrees`` component is
+    found the path is not an isolation worktree and is returned unchanged.
+
+    Examples
+    --------
+    >>> authoritative_repo_root('/repo/.worktrees/foo')
+    PosixPath('/repo')
+    >>> authoritative_repo_root('/repo/.worktrees/foo/backend/bar.py')
+    PosixPath('/repo')
+    >>> authoritative_repo_root('/repo/backend/bar.py')
+    PosixPath('/repo/backend/bar.py')
+
+    NEVER raises — any failure returns ``Path(path)`` unchanged (fail-soft).
+    Authority posture: pure path math, zero I/O, zero git calls.
+    """
+    try:
+        p = Path(path).resolve()
+        current = p
+        while True:
+            parent = current.parent
+            if parent == current:
+                # Reached filesystem root without finding .worktrees
+                break
+            if current.name == ".worktrees":
+                # parent is the repo root that OWNS .worktrees/
+                return parent
+            current = parent
+        return p
+    except Exception:  # noqa: BLE001 — defensive
+        try:
+            return Path(path)
+        except Exception:
+            return Path(".")
+
+
+__all__ = [
+    "_is_cloud_container",
+    "authoritative_repo_root",
+    "is_autonomous",
+    "is_primary_checkout",
+]

--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -2126,8 +2126,23 @@ class OperationAdvisor:
 
         ``root`` (B.2.0) — scan tree. Defaults to ``self._project_root`` when
         ``None`` (pre-B.2.0 behavior).
+
+        The scan root is translated via
+        :func:`execution_context.authoritative_repo_root` so that a
+        ``.worktrees/<name>/`` path (L3 isolation worktree) never returns 0%
+        coverage due to an empty or partially-cleaned worktree.
         """
         scan_root = root if root is not None else self._project_root
+        # Defense-in-depth: if scan_root is inside a .worktrees/<name> path,
+        # translate to the parent repo root for READ operations so test
+        # discovery succeeds even when the worktree is empty.
+        try:
+            from backend.core.ouroboros.governance.execution_context import (
+                authoritative_repo_root as _auth_root,
+            )
+            scan_root = _auth_root(scan_root)
+        except Exception:  # noqa: BLE001 — fail-soft
+            pass
         if not target_files:
             return 1.0
         py_files = [f for f in target_files if f.endswith(".py") and "test_" not in f]

--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -5,12 +5,18 @@ small / test-covered files and away from massive zero-coverage core modules —
 WITHOUT a hardcoded filename denylist (Manifesto §5: intelligence-driven
 routing, no hardcoded tables).
 
-Two pure functions, no class state, no I/O beyond a single ``Path.exists()``:
+Two pure functions, no class state:
 
   * ``file_has_test_coverage`` — the canonical "does this source file have a
-    sibling test" signal (``tests/test_{stem}.py`` existence). OperationAdvisor
-    delegates its per-file coverage check here so the convention has a single
-    definition.
+    specific test" signal.  Uses the SAME multi-strategy global AST-aware
+    resolver as ``TestRunner.resolve_affected_tests`` (Strategies 1–3, no
+    broad-repo fallback) so the Advisor gate and sensor stratification can
+    never drift.  OperationAdvisor delegates its per-file coverage check here.
+
+    Strategy 2 (suffix-aware recursive across all test roots) catches names
+    like ``test_repl_input_polish_slice4.py`` that the old single-path
+    ``tests/test_{stem}.py`` existence check missed — fixing the spurious
+    Advisor BLOCK on files that DO have tests.
 
   * ``stratification_penalty_multiplier`` — the soft down-rank weight. A file's
     baseline priority is multiplied by this in (1 - alpha, 1.0]. Covered files
@@ -23,12 +29,16 @@ Two pure functions, no class state, no I/O beyond a single ``Path.exists()``:
 Both ``alpha`` and ``max_lines`` are env-tunable (no hardcoding):
   * ``JARVIS_STRATIFICATION_PENALTY_ALPHA`` (default 0.75) — max down-rank.
   * ``JARVIS_STRATIFICATION_MAX_LINES``    (default 2000) — saturation point.
+  * ``JARVIS_TEST_DIR_NAMES``              (default "tests,test") — test roots.
+  * ``JARVIS_STRATIFICATION_AST_IMPORT_ENABLED`` (default "true") — enable
+    Strategy 3 AST-import scan (cached per repo_root per process).
 """
 from __future__ import annotations
 
+import ast as _ast
 import os
 from pathlib import Path
-from typing import Iterable, Union
+from typing import Dict, FrozenSet, Iterable, List, Union
 
 # Defaults are module constants so tests + callers share one source of truth.
 DEFAULT_PENALTY_ALPHA: float = 0.75
@@ -60,21 +70,181 @@ def _env_int(name: str, default: int) -> int:
         return default
 
 
+# ---------------------------------------------------------------------------
+# AST-aware coverage resolver helpers
+# ---------------------------------------------------------------------------
+
+def _strat_test_dir_names() -> FrozenSet[str]:
+    """Return the configured test-root directory names (read from env at call time)."""
+    return frozenset(os.environ.get("JARVIS_TEST_DIR_NAMES", "tests,test").split(","))
+
+
+def _strat_ast_import_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true",
+    ).strip().lower() not in ("0", "false", "no")
+
+
+# Lazy AST import map per repo_root — built once, cached per process.
+# Keyed by resolved repo_root (Path); value is {dotted_module: [test_files]}.
+# Thread-safe for reads; idempotent racy writes are benign.
+_strat_ast_cache: Dict[Path, Dict[str, List[Path]]] = {}
+
+
+def _strat_build_ast_map(
+    repo_root: Path,
+    dir_names: FrozenSet[str],
+) -> Dict[str, List[Path]]:
+    """Synchronous AST import-map builder (mirrors test_runner._build_test_import_map).
+
+    Scans every ``test_*.py`` under the configured test roots and maps
+    ``dotted_module_path → [test_files that import it]``.
+    """
+    import_map: Dict[str, List[Path]] = {}
+    for tdn in sorted(dir_names):
+        top = repo_root / tdn
+        if not top.is_dir():
+            continue
+        for test_file in sorted(top.rglob("test_*.py")):
+            if not test_file.is_file():
+                continue
+            try:
+                source = test_file.read_text(encoding="utf-8", errors="replace")
+                tree = _ast.parse(source, filename=str(test_file))
+            except (SyntaxError, OSError, UnicodeDecodeError):
+                continue
+            for node in _ast.walk(tree):
+                if isinstance(node, _ast.Import):
+                    for alias in node.names:
+                        lst = import_map.setdefault(alias.name, [])
+                        if test_file not in lst:
+                            lst.append(test_file)
+                elif isinstance(node, _ast.ImportFrom):
+                    module = node.module or ""
+                    if module:
+                        lst = import_map.setdefault(module, [])
+                        if test_file not in lst:
+                            lst.append(test_file)
+                    for alias in node.names:
+                        full = f"{module}.{alias.name}" if module else alias.name
+                        lst = import_map.setdefault(full, [])
+                        if test_file not in lst:
+                            lst.append(test_file)
+    return import_map
+
+
+def _strat_path_to_module(source_file: Path, repo_root: Path) -> str | None:
+    """Convert a repo-relative source path to a dotted module string.
+
+    Mirrors ``test_runner._path_to_module``.  Returns ``None`` when
+    ``source_file`` is outside ``repo_root``.
+    """
+    try:
+        rel = source_file.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    parts = list(rel.parts)
+    if not parts:
+        return None
+    if parts[-1].endswith(".py"):
+        parts[-1] = parts[-1][:-3]
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else None
+
+
 def file_has_test_coverage(
     file_path: Union[str, Path],
     repo_root: Path,
 ) -> bool:
-    """Return True if ``file_path`` has a sibling ``tests/test_{stem}.py``.
+    """Return True if ``file_path`` has ≥1 specific test via global AST-aware resolution.
 
-    Canonical definition of the codebase's test-existence signal. Mirrors
-    (and is delegated to by) ``OperationAdvisor._compute_test_coverage``.
+    Canonical definition of the codebase's test-existence signal.  Uses the
+    SAME multi-strategy resolver logic as ``TestRunner.resolve_affected_tests``
+    (Strategies 1–3), so the OperationAdvisor gate and sensor stratification
+    bias can never drift from the test runner's own discovery.
+
+    Strategy 1 — **Suffix-aware recursive** (subsumes the old exact-match):
+        Search all configured test roots for ``test_<stem>.py`` *and*
+        ``test_<stem>_*.py`` (catches ``_slice4``-style suffix variants).
+
+    Strategy 2 — **AST-import** (cached per ``repo_root`` per process):
+        A test file whose AST directly imports this module counts as
+        coverage.  Gated by ``JARVIS_STRATIFICATION_AST_IMPORT_ENABLED``
+        (default ``true``).
+
+    Deliberately excludes the broad repo-level ``tests/`` fallback
+    (Strategy 4 in the TestRunner): that path signals *no specific test
+    found* and MUST NOT be mistaken for coverage.
+
     Non-``.py`` and ``test_*`` inputs are treated as covered (no penalty).
+
+    ``repo_root`` is automatically translated via
+    :func:`execution_context.authoritative_repo_root` so that a
+    ``.worktrees/<name>/`` path (an L3 isolation worktree that may be empty
+    or partially cleaned) is silently redirected to the parent repo root
+    where test files actually live. READS stay authoritative; WRITES still
+    target the worktree.
     """
+    # Defense-in-depth: translate .worktrees/<name> paths to the real repo
+    # root so coverage detection never returns 0 due to an empty worktree.
+    try:
+        from backend.core.ouroboros.governance.execution_context import (
+            authoritative_repo_root as _auth_root,
+        )
+        _scan_root = _auth_root(Path(repo_root))
+    except Exception:  # noqa: BLE001 — fail-soft, never breaks coverage
+        _scan_root = Path(repo_root)
+
     name = Path(file_path).name
     if not name.endswith(".py") or "test_" in name:
         return True
     stem = Path(file_path).stem
-    return (repo_root / "tests" / f"test_{stem}.py").exists()
+    dir_names = _strat_test_dir_names()
+    exact_name = f"test_{stem}.py"
+    suffix_prefix = f"test_{stem}_"
+
+    # Strategy 1: suffix-aware recursive search across all test roots.
+    # Finds test_<stem>.py (exact) AND test_<stem>_*.py (suffix variants).
+    # This subsumes the old single-path tests/test_{stem}.py existence check.
+    # Uses _scan_root (translated from .worktrees/<name> to the real repo root
+    # via authoritative_repo_root) so coverage detection never returns 0 due
+    # to an empty isolation worktree.
+    for tdn in sorted(dir_names):
+        top = _scan_root / tdn
+        if not top.is_dir():
+            continue
+        for match in sorted(top.rglob("test_*.py")):
+            if not match.is_file():
+                continue
+            mname = match.name
+            if mname == exact_name or (
+                mname.startswith(suffix_prefix) and mname.endswith(".py")
+            ):
+                return True
+
+    # Strategy 2: AST-import scan (lazy cached per _scan_root, env-opt-out).
+    # Uses _scan_root (authoritative repo root) so the import map is built
+    # from real test files, never from an empty isolation worktree.
+    if _strat_ast_import_enabled():
+        try:
+            fp = Path(file_path)
+            if not fp.is_absolute():
+                fp = _scan_root / fp
+            module_path = _strat_path_to_module(fp, _scan_root)
+            if module_path:
+                resolved_root = _scan_root.resolve()
+                if resolved_root not in _strat_ast_cache:
+                    _strat_ast_cache[resolved_root] = _strat_build_ast_map(
+                        resolved_root, dir_names
+                    )
+                if _strat_ast_cache[resolved_root].get(module_path):
+                    return True
+        except Exception:  # noqa: BLE001 — fail-soft, never raises
+            pass
+
+
+    return False
 
 
 def stratification_penalty_multiplier(

--- a/backend/core/ouroboros/governance/test_runner.py
+++ b/backend/core/ouroboros/governance/test_runner.py
@@ -11,6 +11,7 @@ Provides deterministic test scoping and async pytest execution with:
 """
 from __future__ import annotations
 
+import ast as _ast
 import asyncio
 import json
 import logging
@@ -792,6 +793,146 @@ async def _find_test_recursive(
     return await loop.run_in_executor(None, _scan)
 
 
+async def _find_tests_suffix_aware(
+    source_stem: str,
+    repo_root: Path,
+    dir_names: FrozenSet[str] = _TEST_DIR_NAMES,
+) -> List[Path]:
+    """Recursively search for ``test_<stem>.py`` AND ``test_<stem>_*.py`` under
+    all top-level test directories.
+
+    This catches suffix-named test variants such as ``test_foo_slice4.py`` that
+    the exact-name :func:`_find_test_recursive` misses.  Results are returned in
+    stable sorted order.
+    """
+    exact_name = f"test_{source_stem}.py"
+    suffix_prefix = f"test_{source_stem}_"
+    loop = asyncio.get_running_loop()
+
+    def _scan() -> List[Path]:
+        results: List[Path] = []
+        for tdn in sorted(dir_names):
+            top_tests = repo_root / tdn
+            if not top_tests.is_dir():
+                continue
+            for match in sorted(top_tests.rglob("test_*.py")):
+                if not match.is_file():
+                    continue
+                name = match.name
+                if name == exact_name or (
+                    name.startswith(suffix_prefix) and name.endswith(".py")
+                ):
+                    results.append(match)
+        return results
+
+    return await loop.run_in_executor(None, _scan)
+
+
+def _path_to_module(source_file: Path, repo_root: Path) -> Optional[str]:
+    """Convert a repo-relative source file path to a dotted module string.
+
+    Example::
+
+        repo/backend/core/ouroboros/battle_test/repl_input_polish.py
+        → "backend.core.ouroboros.battle_test.repl_input_polish"
+
+    Returns ``None`` when *source_file* is outside *repo_root*.
+    """
+    try:
+        rel = source_file.resolve().relative_to(repo_root.resolve())
+    except ValueError:
+        return None
+    parts = list(rel.parts)
+    if not parts:
+        return None
+    if parts[-1].endswith(".py"):
+        parts[-1] = parts[-1][:-3]
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else None
+
+
+def _register_import(
+    import_map: Dict[str, List[Path]],
+    key: str,
+    test_file: Path,
+) -> None:
+    """Append *test_file* to *import_map[key]* (deduplicated)."""
+    if not key:
+        return
+    lst = import_map.setdefault(key, [])
+    if test_file not in lst:
+        lst.append(test_file)
+
+
+def _build_test_import_map(
+    repo_root: Path,
+    dir_names: FrozenSet[str],
+) -> Dict[str, List[Path]]:
+    """Scan every ``test_*.py`` under *dir_names* and build a map of
+    ``dotted_module_path → [test_files that import it]``.
+
+    Parsing is done with :mod:`ast` — no import side-effects, no pytest run.
+    Syntax-invalid or unreadable files are silently skipped.
+
+    This map lets :meth:`TestRunner.resolve_affected_tests` Strategy 3 answer
+    "which tests directly import the changed module?" in O(1) after the
+    one-time build (cached per ``repo_root`` at module level).
+    """
+    import_map: Dict[str, List[Path]] = {}
+
+    for tdn in sorted(dir_names):
+        top_tests = repo_root / tdn
+        if not top_tests.is_dir():
+            continue
+        for test_file in sorted(top_tests.rglob("test_*.py")):
+            if not test_file.is_file():
+                continue
+            try:
+                source = test_file.read_text(encoding="utf-8", errors="replace")
+                tree = _ast.parse(source, filename=str(test_file))
+            except (SyntaxError, OSError, UnicodeDecodeError):
+                continue
+            for node in _ast.walk(tree):
+                if isinstance(node, _ast.Import):
+                    for alias in node.names:
+                        _register_import(import_map, alias.name, test_file)
+                elif isinstance(node, _ast.ImportFrom):
+                    module = node.module or ""
+                    if module:
+                        _register_import(import_map, module, test_file)
+                    for alias in node.names:
+                        full = f"{module}.{alias.name}" if module else alias.name
+                        _register_import(import_map, full, test_file)
+
+    return import_map
+
+
+def _find_tests_by_ast_import(
+    module_path: str,
+    import_map: Dict[str, List[Path]],
+    seen: set,
+) -> List[Path]:
+    """Return test files whose AST directly imports *module_path*.
+
+    Performs an exact lookup — partial/parent-module matches are intentionally
+    excluded to avoid false positives (e.g. a test importing ``backend.core``
+    would otherwise match every source file under that package).
+    """
+    result: List[Path] = []
+    for test_file in import_map.get(module_path, []):
+        if test_file not in seen and test_file not in result:
+            result.append(test_file)
+    return sorted(result)
+
+
+# AST import map cache: repo_root → {module_path: [test_files]}
+# Populated lazily on the first resolve_affected_tests call; valid for the
+# process lifetime.  Thread-safe for reads; built exactly once per repo_root
+# (the executor call is idempotent and cheap races are benign).
+_ast_import_cache: Dict[Path, Dict[str, List[Path]]] = {}
+
+
 # ---------------------------------------------------------------------------
 # TestRunner
 # ---------------------------------------------------------------------------
@@ -828,6 +969,29 @@ class TestRunner:
         self._timeout = timeout
         self._event_callback = event_callback
 
+    # -- internal helpers ---------------------------------------------------
+
+    async def _get_ast_import_map(self) -> Dict[str, List[Path]]:
+        """Return the AST import map for this repo, building and caching if needed.
+
+        The map is built once in a thread executor (non-blocking) and cached at
+        module level keyed by ``self._repo_root``.  Subsequent calls are O(1).
+        """
+        if self._repo_root not in _ast_import_cache:
+            loop = asyncio.get_running_loop()
+            import_map = await loop.run_in_executor(
+                None,
+                _build_test_import_map,
+                self._repo_root,
+                _TEST_DIR_NAMES,
+            )
+            _ast_import_cache[self._repo_root] = import_map
+            logger.debug(
+                "[TestRunner] AST import map built: %d module keys indexed",
+                len(import_map),
+            )
+        return _ast_import_cache[self._repo_root]
+
     # -- public API ---------------------------------------------------------
 
     async def resolve_affected_tests(
@@ -849,13 +1013,24 @@ class TestRunner:
             repo path to locate sibling ``tests/`` directories.
 
         Strategy (evaluated per changed file, first match wins):
-        1. **Name convention** — ``foo.py`` → ``test_foo.py`` in nearest
-           sibling ``tests/`` directory (using original path).
-        2. **Recursive search** — ``test_foo.py`` anywhere under repo
-           test directories (async, off-main-thread).
-        3. **Package fallback** — all ``test_*.py`` files in the nearest
-           sibling ``tests/`` directory.
-        4. **Repo fallback** — repo-level ``tests/`` directory.
+
+        0. **Self** — if the changed file is already a test file, use it directly.
+           Prevents double-resolving when a candidate edits both ``foo.py`` and
+           ``test_foo.py``.
+        1. **Name convention** — ``foo.py`` → ``test_foo.py`` in nearest sibling
+           ``tests/`` directory (using original path).
+        2. **Suffix-aware recursive** — search ALL repo test directories for
+           ``test_<stem>.py`` AND ``test_<stem>_*.py`` (catches ``_slice4``-style
+           suffixed names that the old exact-match missed).
+        3. **AST-import** — scan ALL test files in repo test trees for those whose
+           AST directly imports the changed module.  Results cached per repo_root.
+        4. **Repo fallback** — repo-level ``tests/`` directory (last resort; signals
+           to the Synthesizer that no specific test was located).
+
+        **Removed (was Strategy 3):** the near-source-sibling package glob
+        ``test_*.py`` in the nearest ``tests/`` directory.  That strategy returned
+        unrelated tests from coincidentally nearby directories (e.g.
+        ``test_cross_repo_resolution.py`` for ``repl_input_polish.py``).
 
         Results are capped at ``JARVIS_TEST_MAX_FILES`` (default 50).
         Symlinks resolving outside ``repo_root`` (and outside /tmp, /var)
@@ -864,10 +1039,29 @@ class TestRunner:
         matched: List[Path] = []
         seen: set = set()
 
+        # Build (or retrieve from cache) the AST import map for Strategy 3.
+        import_map = await self._get_ast_import_map()
+
+        # Defense-in-depth: translate .worktrees/<name> paths to the real repo
+        # root for test DISCOVERY so tests are found even when the isolation
+        # worktree is empty or partially cleaned. READS come from the
+        # authoritative tree; WRITES still target the worktree. Safety checks
+        # accept both the worktree and real-repo paths since the worktree lives
+        # physically inside the real repo (under .worktrees/).
+        try:
+            from backend.core.ouroboros.governance.execution_context import (
+                authoritative_repo_root as _auth_root,
+            )
+            _discovery_root = _auth_root(self._repo_root)
+        except Exception:  # noqa: BLE001 — fail-soft, never breaks discovery
+            _discovery_root = self._repo_root
+
         for changed in changed_files:
             effective = _resolve_original_path(changed, original_paths)
 
-            if not _is_safe_path(effective, self._repo_root):
+            if not _is_safe_path(effective, self._repo_root) and not _is_safe_path(
+                effective, _discovery_root
+            ):
                 logger.warning(
                     "[TestRunner] Skipping path outside repo_root: %s (original: %s)",
                     changed, effective,
@@ -879,8 +1073,6 @@ class TestRunner:
             tests_dir = _find_sibling_tests_dir(effective)
 
             # Strategy 0: if the changed file is already a test file, use it directly.
-            # Prevents double-resolving (e.g. candidate edits both foo.py and test_foo.py
-            # → test_foo.py would otherwise fall through to the 44-file package fallback).
             if effective.name.startswith("test_") and effective.suffix == ".py" and effective.is_file():
                 if effective not in seen:
                     seen.add(effective)
@@ -891,7 +1083,7 @@ class TestRunner:
                     )
                 continue
 
-            # Strategy 1: name convention in sibling tests/
+            # Strategy 1: exact name convention in nearest sibling tests/
             if tests_dir is not None:
                 candidate = tests_dir / test_name
                 if candidate.is_file() and candidate not in seen:
@@ -903,36 +1095,41 @@ class TestRunner:
                     )
                     continue
 
-            # Strategy 2: recursive search under all test directories
-            recursive_match = await _find_test_recursive(
-                stem, self._repo_root,
-            )
-            if recursive_match is not None and recursive_match not in seen:
-                seen.add(recursive_match)
-                matched.append(recursive_match)
+            # Strategy 2: suffix-aware recursive search across ALL test roots.
+            # Finds test_<stem>.py (exact) AND test_<stem>_*.py (suffix variants).
+            # Uses _discovery_root (authoritative) so tests are found even
+            # when self._repo_root is an empty isolation worktree.
+            recursive_matches = await _find_tests_suffix_aware(stem, _discovery_root)
+            if recursive_matches:
+                for m in recursive_matches:
+                    if m not in seen:
+                        seen.add(m)
+                        matched.append(m)
                 logger.debug(
-                    "[TestRunner] Strategy 2 (recursive): %s → %s",
-                    effective.name, recursive_match,
+                    "[TestRunner] Strategy 2 (suffix-aware recursive): %s → %d file(s)",
+                    effective.name, len(recursive_matches),
                 )
                 continue
 
-            # Strategy 3: package fallback — all test files in tests_dir
-            if tests_dir is not None and tests_dir not in seen:
-                test_files = sorted(tests_dir.glob("test_*.py"))
-                for tf in test_files:
-                    if tf not in seen:
-                        seen.add(tf)
-                        matched.append(tf)
-                if test_files:
+            # Strategy 3: AST-import — tests that directly import this module.
+            module_path = _path_to_module(effective, self._repo_root)
+            if module_path:
+                ast_matches = _find_tests_by_ast_import(module_path, import_map, seen)
+                if ast_matches:
+                    for m in ast_matches:
+                        seen.add(m)
+                        matched.append(m)
                     logger.debug(
-                        "[TestRunner] Strategy 3 (package fallback): %s → %d files in %s",
-                        effective.name, len(test_files), tests_dir,
+                        "[TestRunner] Strategy 3 (AST import): %s → %d file(s) via module '%s'",
+                        effective.name, len(ast_matches), module_path,
                     )
                     continue
 
-            # Strategy 4: repo fallback
+            # Strategy 4: repo fallback — signals "no specific test found".
+            # Uses _discovery_root so tests/ is found even when self._repo_root
+            # is an empty isolation worktree.
             for tdn in sorted(_TEST_DIR_NAMES):
-                repo_tests = self._repo_root / tdn
+                repo_tests = _discovery_root / tdn
                 if repo_tests.is_dir() and repo_tests not in seen:
                     seen.add(repo_tests)
                     matched.append(repo_tests)
@@ -945,7 +1142,7 @@ class TestRunner:
         # Last resort: repo-level test dir if nothing matched at all
         if not matched:
             for tdn in sorted(_TEST_DIR_NAMES):
-                repo_tests = self._repo_root / tdn
+                repo_tests = _discovery_root / tdn
                 if repo_tests.is_dir():
                     matched.append(repo_tests)
                     logger.info(

--- a/backend/core/ouroboros/governance/worktree_manager.py
+++ b/backend/core/ouroboros/governance/worktree_manager.py
@@ -158,9 +158,13 @@ class WorktreeManager:
         repo_root: Path,
         worktree_base: Optional[Path] = None,
     ) -> None:
-        self._repo_root = Path(repo_root)
+        # Resolve to an absolute, symlink-free path so all git operations and
+        # path comparisons use a canonical form regardless of caller CWD or
+        # symlinked mount points (the "isomorphic" worktree-in-worktree case
+        # where '.' in a Claude-Code worktree resolves to the wrong git root).
+        self._repo_root = Path(os.path.realpath(repo_root))
         self._worktree_base: Path = (
-            Path(worktree_base) if worktree_base is not None
+            Path(os.path.realpath(worktree_base)) if worktree_base is not None
             else self._repo_root / ".worktrees"
         )
 
@@ -215,6 +219,41 @@ class WorktreeManager:
             raise RuntimeError(
                 f"git worktree add failed (rc={proc.returncode}) "
                 f"for branch '{branch_name}': {stderr.decode().strip()}"
+            )
+
+        # Isomorphic Worktree Hydration post-condition (2026-06-27):
+        # Verify the checkout is populated for every sentinel directory that
+        # exists in the real repo root. An empty worktree (only .jarvis/ present)
+        # causes Advisor 0%-coverage blocks. We mirror the repo's own structure:
+        # if the repo has 'backend/' it must exist in the worktree too; likewise
+        # for 'tests/'. Synthetic repos used by unit tests (no backend/ or tests/)
+        # bypass the check entirely — no directories to verify → no assertion.
+        _sentinels = ("backend", "tests")
+        _missing = [
+            d for d in _sentinels
+            if (self._repo_root / d).is_dir() and not (wt_path / d).is_dir()
+        ]
+        if _missing:
+            # Attempt best-effort cleanup before raising so we don't leak a
+            # partially-constructed worktree entry in git's registry.
+            try:
+                _cleanup_proc = await asyncio.create_subprocess_exec(
+                    "git", "-C", str(self._repo_root),
+                    "worktree", "remove", "--force", str(wt_path),
+                    stdout=asyncio.subprocess.DEVNULL,
+                    stderr=asyncio.subprocess.DEVNULL,
+                )
+                await _cleanup_proc.communicate()
+            except Exception:  # noqa: BLE001 — best-effort only
+                pass
+            raise RuntimeError(
+                f"git worktree add for branch '{branch_name}' succeeded "
+                f"(rc=0) but the checkout is incomplete — "
+                f"{_missing} present in repo but absent from {wt_path}. "
+                f"The repo_root used was '{self._repo_root}'. "
+                "This usually means the repo root was wrong (symlink / "
+                "relative-path CWD mismatch). Check JARVIS_REPO_ROOT or "
+                "the WorktreeManager constructor call site."
             )
 
         # P1 Slice 2 — Ledger Sovereignty marker. Stamps a typed

--- a/tests/governance/self_dev/test_test_runner.py
+++ b/tests/governance/self_dev/test_test_runner.py
@@ -24,8 +24,14 @@ from typing import Dict
 
 from backend.core.ouroboros.governance.test_runner import (
     TestRunner,
+    _TEST_DIR_NAMES,
+    _ast_import_cache,
+    _build_test_import_map,
     _find_test_recursive,
+    _find_tests_by_ast_import,
+    _find_tests_suffix_aware,
     _is_safe_path,
+    _path_to_module,
     _resolve_original_path,
 )
 
@@ -441,3 +447,155 @@ class TestRetryToggle:
         result = await runner.run(test_files=(fail_path,))
         assert result.passed is False
         assert "--- RETRY ---" not in result.stdout
+
+
+# ---------------------------------------------------------------------------
+# 17. test_suffix_aware_recursive  (new Strategy 2)
+# ---------------------------------------------------------------------------
+
+class TestSuffixAwareRecursive:
+    """Suffix-aware recursive search finds test_<stem>_*.py variants."""
+
+    async def test_finds_exact_name(self) -> None:
+        """Exact-name match still works via suffix-aware helper."""
+        results = await _find_tests_suffix_aware("calculator", REPO_ROOT)
+        assert any(p.name == "test_calculator.py" for p in results), (
+            f"Expected test_calculator.py in suffix-aware results: {results}"
+        )
+
+    async def test_finds_suffix_named_test(self) -> None:
+        """test_repl_input_polish_slice4.py is found via the _* suffix pattern."""
+        results = await _find_tests_suffix_aware("repl_input_polish", REPO_ROOT)
+        names = [p.name for p in results]
+        assert "test_repl_input_polish_slice4.py" in names, (
+            f"Expected test_repl_input_polish_slice4.py in {names}"
+        )
+
+    async def test_returns_empty_for_no_match(self) -> None:
+        """A stem with no test anywhere returns an empty list."""
+        results = await _find_tests_suffix_aware(
+            "zzz_no_test_exists_qwerty_12345", REPO_ROOT,
+        )
+        assert results == []
+
+
+# ---------------------------------------------------------------------------
+# 18. test_ast_import_map  (new Strategy 3)
+# ---------------------------------------------------------------------------
+
+class TestASTImportMap:
+    """AST import map correctly indexes module→test_file relationships."""
+
+    def test_build_map_finds_repl_input_polish(self) -> None:
+        """_build_test_import_map maps repl_input_polish → test_repl_input_polish_slice4.py."""
+        import_map = _build_test_import_map(REPO_ROOT, _TEST_DIR_NAMES)
+        key = "backend.core.ouroboros.battle_test.repl_input_polish"
+        matches = import_map.get(key, [])
+        names = [p.name for p in matches]
+        assert "test_repl_input_polish_slice4.py" in names, (
+            f"AST import map for '{key}': {names}"
+        )
+
+    def test_path_to_module_conversion(self) -> None:
+        """_path_to_module converts source path to dotted module string."""
+        source = REPO_ROOT / "backend/core/ouroboros/battle_test/repl_input_polish.py"
+        result = _path_to_module(source, REPO_ROOT)
+        assert result == "backend.core.ouroboros.battle_test.repl_input_polish"
+
+    def test_path_to_module_outside_repo_returns_none(self) -> None:
+        """_path_to_module returns None for paths outside repo_root."""
+        outside = Path("/etc/passwd")
+        assert _path_to_module(outside, REPO_ROOT) is None
+
+    def test_find_tests_by_ast_import_exact(self) -> None:
+        """_find_tests_by_ast_import returns only tests that import the exact module."""
+        import_map = _build_test_import_map(REPO_ROOT, _TEST_DIR_NAMES)
+        key = "backend.core.ouroboros.battle_test.repl_input_polish"
+        matches = _find_tests_by_ast_import(key, import_map, seen=set())
+        names = [p.name for p in matches]
+        assert "test_repl_input_polish_slice4.py" in names
+
+    def test_find_tests_by_ast_import_no_false_positives(self) -> None:
+        """_find_tests_by_ast_import does NOT return tests for an unimported module."""
+        import_map = _build_test_import_map(REPO_ROOT, _TEST_DIR_NAMES)
+        key = "zzz_no_test_exists_qwerty_module_path"
+        matches = _find_tests_by_ast_import(key, import_map, seen=set())
+        assert matches == []
+
+    async def test_get_ast_import_map_caches(self) -> None:
+        """_get_ast_import_map is cached per repo_root after the first build."""
+        # Clear cache for this repo_root to start clean
+        repo_resolved = REPO_ROOT.resolve()
+        _ast_import_cache.pop(repo_resolved, None)
+
+        runner = TestRunner(repo_root=REPO_ROOT)
+        map1 = await runner._get_ast_import_map()
+        map2 = await runner._get_ast_import_map()
+        assert map1 is map2, "Second call should return the exact same dict object"
+
+
+# ---------------------------------------------------------------------------
+# 19. test_regression_repl_input_polish  (THE bug fix)
+# ---------------------------------------------------------------------------
+
+class TestRegressionReplInputPolish:
+    """Regression: repl_input_polish.py must resolve to test_repl_input_polish_slice4.py,
+    NOT test_cross_repo_resolution.py."""
+
+    async def test_resolves_to_correct_suffix_test(self) -> None:
+        """Strategy 2 (suffix-aware recursive) must find test_repl_input_polish_slice4.py."""
+        runner = TestRunner(repo_root=REPO_ROOT)
+        source = REPO_ROOT / "backend/core/ouroboros/battle_test/repl_input_polish.py"
+        result = await runner.resolve_affected_tests(changed_files=(source,))
+
+        names = [p.name for p in result]
+        assert "test_repl_input_polish_slice4.py" in names, (
+            f"Expected test_repl_input_polish_slice4.py in resolved tests; got: {names}"
+        )
+
+    async def test_does_not_return_coincidental_near_dir_test(self) -> None:
+        """The near-source-sibling package glob (old Strategy 3) must NOT fire.
+
+        test_cross_repo_resolution.py lives in backend/core/ouroboros/tests/ —
+        it's a coincidental near-dir match, not a real test for repl_input_polish.
+        """
+        runner = TestRunner(repo_root=REPO_ROOT)
+        source = REPO_ROOT / "backend/core/ouroboros/battle_test/repl_input_polish.py"
+        result = await runner.resolve_affected_tests(changed_files=(source,))
+
+        names = [p.name for p in result]
+        assert "test_cross_repo_resolution.py" not in names, (
+            f"Got coincidental near-dir test in result — near-dir glob was NOT demoted: {names}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 20. test_no_false_match  (Synthesizer-fallback hook)
+# ---------------------------------------------------------------------------
+
+class TestNoFalseMatch:
+    """A source file with no real test must NOT pick up a coincidental near-dir test.
+
+    This is the Synthesizer-fallback contract: the result should be empty or
+    only the repo-level tests/ directory (last resort), never an unrelated test
+    from a coincidentally nearby tests/ dir.
+    """
+
+    async def test_no_test_does_not_return_unrelated_file(self) -> None:
+        """A unique, non-existent source file in battle_test/ should NOT resolve to
+        test_cross_repo_resolution.py (the only file in the near ouroboros/tests/ dir).
+        """
+        runner = TestRunner(repo_root=REPO_ROOT)
+        # Use a stem guaranteed to have no matching test anywhere
+        source = REPO_ROOT / "backend/core/ouroboros/battle_test/zzz_synthetic_untested_99.py"
+        result = await runner.resolve_affected_tests(changed_files=(source,))
+
+        names = [p.name for p in result]
+        assert "test_cross_repo_resolution.py" not in names, (
+            f"Coincidental near-dir test leaked into resolution: {names}"
+        )
+        # May contain repo-level tests/ directory (Strategy 4 last resort) — that's OK
+        for p in result:
+            assert p.is_dir() or p.name.startswith("test_"), (
+                f"Unexpected non-test file in fallback result: {p}"
+            )

--- a/tests/governance/test_l3_worktree_hydration.py
+++ b/tests/governance/test_l3_worktree_hydration.py
@@ -1,0 +1,216 @@
+"""Tests for L3 worktree full hydration and authoritative-root translation.
+
+Covers the bug where WorktreeManager.create() returned a relative or
+symlink-containing path, and where advisor/coverage/test-resolver scans
+against an empty .worktrees/<name>/ root returned 0% coverage and blocked
+every op.
+
+Five test groups:
+  1. WorktreeManager.create() returns an absolute path with full checkout.
+  2. authoritative_repo_root() translates .worktrees/<name> to parent repo.
+  3. authoritative_repo_root() leaves non-worktree paths unchanged.
+  4. file_has_test_coverage() translates worktree root → real repo root.
+  5. OperationAdvisor._compute_test_coverage() is not blocked under a
+     worktree root when the real repo has tests.
+"""
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+from typing import Optional
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]  # tests/governance/ → repo
+
+
+def _git(*args: str, cwd: Optional[Path] = None) -> subprocess.CompletedProcess:
+    return subprocess.run(
+        ["git", *args],
+        cwd=str(cwd or _REPO_ROOT),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. WorktreeManager.create() — integration (requires git)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_worktree_create_fully_populated(tmp_path):
+    """WorktreeManager.create() must return an ABSOLUTE path whose checkout
+    contains both 'tests/' and 'backend/', and the worktree must appear in
+    ``git worktree list``."""
+    from backend.core.ouroboros.governance.worktree_manager import WorktreeManager
+
+    branch = "ouroboros/auto/test-hydration-check-001"
+    wm = WorktreeManager(repo_root=_REPO_ROOT, worktree_base=tmp_path / "wt")
+    wt_path: Optional[Path] = None
+    try:
+        wt_path = await wm.create(branch)
+
+        # Must be absolute
+        assert wt_path.is_absolute(), f"create() returned relative path: {wt_path}"
+
+        # Must have a full checkout
+        assert (wt_path / "tests").is_dir(), f"tests/ missing in worktree {wt_path}"
+        assert (wt_path / "backend").is_dir(), f"backend/ missing in worktree {wt_path}"
+
+        # Must appear in git worktree list
+        result = _git("worktree", "list", "--porcelain")
+        assert str(wt_path) in result.stdout, (
+            f"worktree {wt_path} not in git worktree list:\n{result.stdout}"
+        )
+    finally:
+        if wt_path is not None:
+            await wm.cleanup(wt_path)
+        _git("branch", "-D", branch)
+
+
+# ---------------------------------------------------------------------------
+# 2. authoritative_repo_root — .worktrees/<name> → parent repo
+# ---------------------------------------------------------------------------
+
+def test_authoritative_repo_root_inside_worktrees():
+    """Path directly under .worktrees/<name> must resolve to the parent."""
+    from backend.core.ouroboros.governance.execution_context import (
+        authoritative_repo_root,
+    )
+    fake_repo = Path("/repo/project")
+    worktree_path = fake_repo / ".worktrees" / "some-session"
+    result = authoritative_repo_root(worktree_path)
+    assert result == fake_repo, f"Expected {fake_repo}, got {result}"
+
+
+def test_authoritative_repo_root_deep_inside_worktrees():
+    """A file deep inside .worktrees/<name>/... must resolve to the parent."""
+    from backend.core.ouroboros.governance.execution_context import (
+        authoritative_repo_root,
+    )
+    fake_repo = Path("/repo/project")
+    deep_path = fake_repo / ".worktrees" / "some-session" / "backend" / "foo.py"
+    result = authoritative_repo_root(deep_path)
+    assert result == fake_repo, f"Expected {fake_repo}, got {result}"
+
+
+# ---------------------------------------------------------------------------
+# 3. authoritative_repo_root — non-worktree path unchanged
+# ---------------------------------------------------------------------------
+
+def test_authoritative_repo_root_non_worktree_path():
+    """A path NOT inside .worktrees must be returned unchanged (resolved)."""
+    from backend.core.ouroboros.governance.execution_context import (
+        authoritative_repo_root,
+    )
+    non_worktree = Path("/repo/project/backend/core/foo.py")
+    result = authoritative_repo_root(non_worktree)
+    # resolve() may differ on case-insensitive filesystems; compare resolved
+    assert result == non_worktree.resolve(), (
+        f"Expected {non_worktree.resolve()}, got {result}"
+    )
+
+
+def test_authoritative_repo_root_repo_root_itself():
+    """The repo root itself must be returned unchanged."""
+    from backend.core.ouroboros.governance.execution_context import (
+        authoritative_repo_root,
+    )
+    result = authoritative_repo_root(_REPO_ROOT)
+    assert result == _REPO_ROOT.resolve()
+
+
+# ---------------------------------------------------------------------------
+# 4. file_has_test_coverage — worktree root → real repo lookup
+# ---------------------------------------------------------------------------
+
+def test_coverage_lookup_translates_to_authoritative_root(tmp_path):
+    """file_has_test_coverage(tested_file, empty_worktree_root) must return
+    True because the worktree root is translated to the real repo root where
+    the test actually lives.
+
+    Target: operation_advisor.py — covered by test_operation_advisor_*.py
+    files (suffix-prefix strategy), which live in tests/governance/.
+    """
+    from backend.core.ouroboros.governance.target_stratification import (
+        file_has_test_coverage,
+    )
+
+    # Build a fake .worktrees/<name>/ directory with the _REPO_ROOT as parent
+    # (EMPTY — simulates the bug: only .jarvis/ survives after git worktree remove)
+    wt_base = _REPO_ROOT / ".worktrees" / "ouroboros__auto__bt-test-session-cov"
+    wt_base.mkdir(parents=True, exist_ok=True)
+    # No tests/ inside — exactly the broken state described in the bug report.
+
+    # operation_advisor.py is covered by test_operation_advisor_*.py files.
+    target_file = "backend/core/ouroboros/governance/operation_advisor.py"
+    assert (_REPO_ROOT / target_file).exists(), (
+        f"{target_file} not found in repo — pick a different sentinel"
+    )
+    assert any(
+        (_REPO_ROOT / "tests").rglob("test_operation_advisor_*.py")
+    ), "No test_operation_advisor_*.py found — test sentinel is wrong"
+
+    try:
+        # Passing the EMPTY worktree root should still succeed because
+        # authoritative_repo_root translates wt_base → _REPO_ROOT.
+        result = file_has_test_coverage(target_file, wt_base)
+        assert result is True, (
+            "file_has_test_coverage returned False for a covered file when "
+            "given an empty .worktrees/ root — authoritative_repo_root "
+            "translation is not working"
+        )
+    finally:
+        import shutil
+        if wt_base.exists():
+            shutil.rmtree(wt_base)
+
+
+def test_coverage_lookup_real_repo_root_unchanged():
+    """file_has_test_coverage works identically when given the real repo root
+    (no .worktrees component — the translate is a no-op)."""
+    from backend.core.ouroboros.governance.target_stratification import (
+        file_has_test_coverage,
+    )
+    # operation_advisor.py has test_operation_advisor_*.py coverage
+    target_file = "backend/core/ouroboros/governance/operation_advisor.py"
+    assert (_REPO_ROOT / target_file).exists()
+    result = file_has_test_coverage(target_file, _REPO_ROOT)
+    assert result is True
+
+
+# ---------------------------------------------------------------------------
+# 5. OperationAdvisor._compute_test_coverage — not blocked under worktree root
+# ---------------------------------------------------------------------------
+
+def test_advisor_coverage_not_blocked_under_worktree_root(tmp_path):
+    """OperationAdvisor._compute_test_coverage must return > 0 for a tested
+    file even when the scan root is an empty .worktrees/<name>/ directory."""
+    from backend.core.ouroboros.governance.operation_advisor import OperationAdvisor
+
+    # Empty worktree root under the REAL repo — simulates the exact bug state
+    wt_base = _REPO_ROOT / ".worktrees" / "ouroboros__auto__bt-advisor-test"
+    wt_base.mkdir(parents=True, exist_ok=True)
+
+    try:
+        advisor = OperationAdvisor(project_root=wt_base)
+        # operation_advisor.py has test_operation_advisor_*.py coverage
+        target = "backend/core/ouroboros/governance/operation_advisor.py"
+        coverage = advisor._compute_test_coverage((target,), root=wt_base)
+        assert coverage > 0.0, (
+            f"Advisor returned 0% coverage for {target!r} when given an empty "
+            f".worktrees/ root — authoritative_repo_root translation in "
+            f"_compute_test_coverage is not working (coverage={coverage})"
+        )
+    finally:
+        import shutil
+        if wt_base.exists():
+            shutil.rmtree(wt_base)

--- a/tests/governance/test_slice48_target_stratification.py
+++ b/tests/governance/test_slice48_target_stratification.py
@@ -1,7 +1,13 @@
 """Slice 48 — Semantic Target Stratification regression spine.
 
 Pins (shared scoring substrate + OpportunityMiner wiring):
-  §1  file_has_test_coverage — tests/test_{stem}.py existence convention
+  §1  file_has_test_coverage — global AST-aware resolver (suffix + AST-import)
+  §1a  exact test_<stem>.py still detected
+  §1b  suffix variant test_<stem>_slice4.py detected (was the bug)
+  §1c  test in nested subdirectory detected
+  §1d  AST-importing test detected via Strategy 2
+  §1e  genuinely-untested file → False
+  §1f  Advisor _compute_test_coverage returns 1.0 for suffix-tested file
   §2  penalty multiplier — covered file is never penalized (== 1.0)
   §3  penalty multiplier — suppress=True bypasses penalty (test-gen escape)
   §4  penalty multiplier — huge zero-coverage file is heavily down-ranked
@@ -23,21 +29,113 @@ import pytest
 from backend.core.ouroboros.governance.target_stratification import (
     DEFAULT_PENALTY_ALPHA,
     DEFAULT_PENALTY_MAX_LINES,
+    _strat_ast_cache,
     file_has_test_coverage,
     stratification_penalty_multiplier,
 )
 
 
-# ── §1 coverage convention ──────────────────────────────────────────────
+# ── §1a exact test_<stem>.py detected (unchanged behavior) ──────────────
 def test_file_has_test_coverage_detects_test_file(tmp_path: Path) -> None:
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
     assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
 
 
+# ── §1e genuinely-untested file → False ─────────────────────────────────
 def test_file_has_test_coverage_false_when_absent(tmp_path: Path) -> None:
     (tmp_path / "tests").mkdir()
     assert file_has_test_coverage("backend/core/widget.py", tmp_path) is False
+
+
+# ── §1b suffix variant test_<stem>_slice4.py detected (was the bug) ─────
+def test_file_has_test_coverage_suffix_variant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """repl_input_polish.py style: test lives as test_<stem>_slice4.py in a subdir."""
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "false")
+    (tmp_path / "tests" / "battle_test").mkdir(parents=True)
+    (tmp_path / "tests" / "battle_test" / "test_repl_input_polish_slice4.py").write_text(
+        "def test_x(): pass\n"
+    )
+    assert file_has_test_coverage(
+        "backend/core/ouroboros/battle_test/repl_input_polish.py", tmp_path
+    ) is True
+
+
+# ── §1c test in nested subdirectory detected ─────────────────────────────
+def test_file_has_test_coverage_nested_subdir(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """test_<stem>.py anywhere under a test root is sufficient for coverage."""
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "false")
+    (tmp_path / "tests" / "governance" / "autonomy").mkdir(parents=True)
+    (tmp_path / "tests" / "governance" / "autonomy" / "test_widget.py").write_text(
+        "def test_y(): pass\n"
+    )
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+
+
+# ── §1d AST-importing test (non-conventional name) detected ─────────────
+def test_file_has_test_coverage_ast_import_detects(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A test file that AST-imports the module counts as coverage even when
+    neither exact nor suffix filename conventions are matched."""
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    # Ensure no suffix-match file exists so only AST path fires.
+    (tmp_path / "tests").mkdir()
+    test_content = (
+        "from backend.core.special_util import some_func\n"
+        "def test_it(): assert some_func() is not None\n"
+    )
+    (tmp_path / "tests" / "test_integration_suite.py").write_text(test_content)
+    # Clear cache for this tmp_path so Strategy 2 rebuilds fresh.
+    _strat_ast_cache.pop(tmp_path.resolve(), None)
+    result = file_has_test_coverage("backend/core/special_util.py", tmp_path)
+    _strat_ast_cache.pop(tmp_path.resolve(), None)  # cleanup
+    assert result is True
+
+
+# ── §1e genuinely-untested file → False (explicit named case) ───────────
+def test_file_has_test_coverage_genuinely_untested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A file with NO matching test (by name or AST) must return False."""
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    (tmp_path / "tests").mkdir()
+    # test_other.py imports something else — not orphan.py
+    (tmp_path / "tests" / "test_other.py").write_text(
+        "from backend.core.other import foo\ndef test_foo(): pass\n"
+    )
+    _strat_ast_cache.pop(tmp_path.resolve(), None)
+    result = file_has_test_coverage("backend/core/orphan.py", tmp_path)
+    _strat_ast_cache.pop(tmp_path.resolve(), None)  # cleanup
+    assert result is False
+
+
+# ── §1f Advisor _compute_test_coverage returns 1.0 for suffix-tested file ─
+def test_advisor_compute_coverage_suffix_variant(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """OperationAdvisor._compute_test_coverage must not return 0% for a file
+    whose test uses a suffix variant name (the iteration-13 spurious BLOCK)."""
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "false")
+    from backend.core.ouroboros.governance.operation_advisor import OperationAdvisor
+    (tmp_path / "tests" / "battle_test").mkdir(parents=True)
+    (tmp_path / "tests" / "battle_test" / "test_repl_input_polish_slice4.py").write_text(
+        "def test_x(): pass\n"
+    )
+    adv = OperationAdvisor.__new__(OperationAdvisor)
+    adv._project_root = tmp_path  # type: ignore[attr-defined]
+    cov = adv._compute_test_coverage(
+        ("backend/core/ouroboros/battle_test/repl_input_polish.py",),
+        root=tmp_path,
+    )
+    assert cov == pytest.approx(1.0), (
+        f"Expected coverage=1.0 for suffix-tested file, got {cov:.2%}. "
+        "This is the iteration-13 spurious BLOCK bug."
+    )
 
 
 # ── §2 covered never penalized ──────────────────────────────────────────

--- a/tests/test_ouroboros_governance/test_ascii_strict_gate.py
+++ b/tests/test_ouroboros_governance/test_ascii_strict_gate.py
@@ -27,6 +27,7 @@ from backend.core.ouroboros.governance.ascii_strict_gate import (
     reset_rejection_count,
     scan_candidate,
     scan_content,
+    scan_content_token_aware,
 )
 
 
@@ -520,3 +521,210 @@ class TestRegressionBattleTest:
         assert ok is True
         assert reason is None
         assert samples == []
+
+
+# ─────────────────────────────────────────────────────────────────────
+# Token-aware scan: scan_content_token_aware
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestTokenAwareScan:
+    """Verify the token-aware scan honours the gate's stated policy:
+    Unicode in string literals / comments is ALLOWED; Unicode in identifier
+    positions is REJECTED (``rapidفuzz`` protection preserved).
+    """
+
+    def test_emoji_only_in_docstring_is_allowed(self):
+        """📁 emoji in a module / function docstring must NOT be flagged.
+
+        This is the repl_input_polish.py regression case: the file has emoji
+        characters inside docstrings (U+1F4C1, U+1F517 etc.), which are
+        meaningful Unicode in a *string literal* and cannot be a homoglyph
+        attack. The whole-content scan incorrectly rejected them.
+        """
+        content = (
+            'def show_files():\n'
+            '    """📁 Show a list of files. 🔗 Click to open."""\n'
+            '    return []\n'
+        )
+        offenders = scan_content_token_aware(content, "repl_input_polish.py")
+        assert offenders == [], (
+            "emoji in a docstring string literal must be allowed "
+            f"(got {offenders})"
+        )
+
+    def test_cyrillic_in_identifier_is_rejected(self):
+        """Cyrillic 'а' (U+0430) in an identifier must still be caught.
+
+        This is the core ``rapidفuzz``-class threat: a Unicode letter that
+        looks like an ASCII letter slips into an identifier position. The
+        token-aware scan must flag it regardless of what surrounds it.
+        """
+        # 'lаunch' — Latin 'l', Cyrillic 'а' (U+0430), rest ASCII.
+        content = "def lаunch():\n    pass\n"
+        offenders = scan_content_token_aware(content, "launcher.py")
+        assert len(offenders) == 1
+        assert offenders[0].codepoint == 0x0430
+        assert offenders[0].file_path == "launcher.py"
+
+    def test_arabic_in_identifier_is_rejected(self):
+        """Arabic ف (U+0641) in a name token must be flagged — the canonical
+        ``rapidفuzz`` case."""
+        content = "import rapidفuzz\n"
+        offenders = scan_content_token_aware(content, "requirements.py")
+        assert len(offenders) == 1
+        assert offenders[0].codepoint == 0x0641
+
+    def test_unicode_in_comment_is_allowed(self):
+        """Unicode in a ``#`` comment must not be flagged.
+
+        Comments are ``COMMENT`` tokens and cannot occupy identifier positions.
+        """
+        content = "x = 1  # résumé 📎 done\n"
+        offenders = scan_content_token_aware(content, "foo.py")
+        assert offenders == [], (
+            f"Unicode in comment must be allowed (got {offenders})"
+        )
+
+    def test_unicode_in_string_literal_is_allowed(self):
+        """Emoji inside a regular string literal must be allowed."""
+        content = "msg = '🚀 launch complete'\n"
+        offenders = scan_content_token_aware(content, "status.py")
+        assert offenders == [], (
+            f"emoji in string literal must be allowed (got {offenders})"
+        )
+
+    def test_unparseable_python_falls_back_to_whole_content_scan(self):
+        """Unclosed string → TokenError → falls back to conservative
+        whole-content scan, which still rejects the non-ASCII character.
+
+        This is the critical safety invariant: a syntactically broken file
+        cannot smuggle homoglyphs past the gate by triggering a parse error.
+        """
+        # Unclosed string literal — tokenize will raise TokenError.
+        content = "x = 'unclosed\nfubar = rapidفuzz\n"
+        offenders = scan_content_token_aware(content, "broken.py")
+        # Falls back to whole-content scan → Arabic ف must still be found.
+        assert any(bc.codepoint == 0x0641 for bc in offenders), (
+            "unparseable Python must fall back to whole-content scan (rejected)"
+        )
+
+    def test_ascii_only_content_returns_empty(self):
+        """Pure ASCII content fast-paths and returns empty list."""
+        content = "def add(a, b):\n    return a + b\n"
+        assert scan_content_token_aware(content, "math.py") == []
+
+    def test_non_ascii_only_in_docstring_multi_line(self):
+        """Multi-line docstring with emoji on several lines — all allowed."""
+        content = (
+            'class Foo:\n'
+            '    """Bar.\n\n'
+            '    📌 Note: see §6 for details.\n'
+            '    Arrows: → left, ← right.\n'
+            '    """\n'
+            '    pass\n'
+        )
+        offenders = scan_content_token_aware(content, "foo.py")
+        assert offenders == [], (
+            f"multi-line docstring Unicode must be allowed (got {offenders})"
+        )
+
+    def test_max_samples_respected(self):
+        """max_samples cap applies to token-aware scan too."""
+        # Three identifiers each with non-ASCII: only 2 should be returned.
+        content = "а = 1\nб = 2\nв = 3\n"  # Cyrillic variable names
+        offenders = scan_content_token_aware(content, "vars.py", max_samples=2)
+        assert len(offenders) == 2
+
+    def test_line_column_accuracy_in_identifier(self):
+        """Offender line / column must be correct for identifier position."""
+        content = "x = 1\ny = rаpid\n"  # 'а' is Cyrillic, on line 2
+        offenders = scan_content_token_aware(content, "x.py")
+        assert len(offenders) == 1
+        bc = offenders[0]
+        assert bc.line == 2
+        # 'r' is col 5 (1-based), 'а' is at index 1 within token 'rаpid' → col 6
+        assert bc.column == 6
+        assert bc.codepoint == 0x0430
+
+
+# ─────────────────────────────────────────────────────────────────────
+# scan_candidate token-aware routing
+# ─────────────────────────────────────────────────────────────────────
+
+
+class TestScanCandidateTokenAware:
+    """scan_candidate must route .py files through the token-aware scan and
+    non-.py files through the conservative whole-content scan."""
+
+    def test_py_file_with_docstring_emoji_passes(self):
+        """A .py file whose only non-ASCII is emoji in a docstring → clean."""
+        candidate = {
+            "file_path": "src/ui.py",
+            "full_content": (
+                'def render():\n'
+                '    """📁 Render the UI."""\n'
+                '    return ""\n'
+            ),
+        }
+        offenders = scan_candidate(candidate)
+        assert offenders == [], (
+            "scan_candidate must allow emoji in .py docstrings "
+            f"(got {offenders})"
+        )
+
+    def test_py_file_with_identifier_unicode_rejected(self):
+        """A .py file with Cyrillic in an identifier must still be rejected."""
+        candidate = {
+            "file_path": "src/core.py",
+            "full_content": "def rаpid():\n    pass\n",
+        }
+        offenders = scan_candidate(candidate)
+        assert len(offenders) == 1
+        assert offenders[0].codepoint == 0x0430
+
+    def test_non_py_file_whole_content_scan(self):
+        """A non-.py file with any non-ASCII is rejected by whole-content scan."""
+        candidate = {
+            "file_path": "config.yaml",
+            "full_content": "# résumé\nname: foo\n",
+        }
+        offenders = scan_candidate(candidate)
+        # 'é' (U+00E9) must be flagged via whole-content scan.
+        assert any(bc.codepoint == 0x00E9 for bc in offenders)
+
+    def test_multi_file_py_docstring_allowed_txt_identifier_rejected(self):
+        """Multi-file candidate: .py docstring passes, .txt Arabic fails."""
+        candidate = {
+            "files": [
+                {
+                    "file_path": "src/app.py",
+                    "full_content": 'def go():\n    """🚀 Launch."""\n    pass\n',
+                },
+                {
+                    "file_path": "requirements.txt",
+                    "full_content": "rapidفuzz==3.5.0\n",
+                },
+            ],
+        }
+        offenders = scan_candidate(candidate)
+        # Only the .txt file's Arabic fa must be flagged.
+        assert len(offenders) == 1
+        assert offenders[0].file_path == "requirements.txt"
+        assert offenders[0].codepoint == 0x0641
+
+    def test_gate_check_py_docstring_emoji_passes(self):
+        """AsciiStrictGate.check passes a .py file with emoji in docstring."""
+        gate = AsciiStrictGate(auto_repair=False)
+        candidate = {
+            "file_path": "src/repl.py",
+            "full_content": (
+                'def polish():\n'
+                '    """📌 Polishes the REPL input. 🔗"""\n'
+                '    return True\n'
+            ),
+        }
+        ok, reason, samples = gate.check(candidate)
+        assert ok is True, (
+            f"gate.check must pass .py with docstring emoji (reason={reason!r})"
+        )


### PR DESCRIPTION
## O+V cognitive-gate hardening — 6 real bugs found by the Isomorphic Local Sandbox

These are **production-affecting fixes to O+V's autonomous-development gates**, surfaced by running the full A1 chain locally under GCP-node-isomorphic conditions (the Isomorphic Sandbox, PR B). Each would have **blocked a real autonomous cycle on the live cloud** — they are the execution-grade payoff of the sandbox, found for $0 across 16 local iterations.

> **PR A of 2** — file-disjoint from PR B (the harness). Merge A first, then B. The 6 fixes are *interdependent* (they share `test_runner.py`, `operation_advisor.py`, `target_stratification.py`, `execution_context.py`), so they ship as one cohesive PR rather than artificially-split conflicting ones.

### The fixes
1. **Global AST-aware test resolution** (`test_runner.py`): `resolve_affected_tests` blindly globbed a near-source sibling dir → resolved *unrelated* tests (e.g. `test_cross_repo_resolution.py` for `repl_input_polish.py`). Now: AST-import mapping (tests that import the changed module) + suffix-aware recursive name match (`test_<stem>_*.py`, catches `_slice4`); the near-dir glob is removed. Preserves the "return None when truly untested" contract (the test-synthesizer hook).
2. **Advisor coverage signal** (`target_stratification.py`, `operation_advisor.py`): `file_has_test_coverage` false-negatived tested files → the OperationAdvisor blocked changes with a bogus "0% coverage + extreme blast radius." Now delegates to the global resolver (unifies the advisor + sensor coverage signal so they can't drift).
3. **Token-aware ASCII gate** (`ascii_strict_gate.py`): the Iron Gate rejected non-ASCII in **string literals / docstrings**, contradicting its own stated policy and making O+V unable to repair any file with emoji/Unicode in a string. Now `tokenize`-aware: flags non-ASCII only in identifier/NAME tokens (the `rapidфuzz` homoglyph threat) and allows it in STRING + COMMENT tokens; unparseable/non-`.py` → conservative whole-content scan.
4. **L3 worktree hydration** (`worktree_manager.py`): the file-isolation worktree was created empty/unregistered (symlinked/relative `repo_root`), so the advisor scanned 0 files → 0% coverage block. Now `realpath`-canonicalizes the repo root + post-condition-asserts the worktree contains `tests/`+`backend/` (raises so the caller's fail-safe fires — never routes to an empty worktree).
5. **`.worktrees/` path translation** (`execution_context.authoritative_repo_root` + reuse in advisor/resolver): read-only signals (coverage/blast/test-resolution) running inside a nested `.worktrees/` boundary now translate to the authoritative parent repo, so isolation nesting can't false-negative coverage. Writes still isolate to the worktree.
6. (the DW-streaming `write_eof` fix lives in PR B — it's a mock/harness change, not O+V core.)

### Tests
- New/extended suites all green: `test_test_runner.py`, `test_l3_worktree_hydration.py`, `test_slice48_target_stratification.py`, `test_ascii_strict_gate.py` (part of the 316-passing branch check).
- Each fix has a regression test (e.g. `repl_input_polish.py` → `test_repl_input_polish_slice4.py`; emoji-docstring allowed but identifier-homoglyph still rejected; worktree post-condition).

### Plus: `.gitignore` root-cause hygiene
Permanently bans `.superpowers/` + agentic scratch dirs from the index (enforced, not manually excluded).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the autonomy gates by fixing test discovery, coverage checks, non-ASCII policy, and worktree isolation to prevent false blocks and wrong test runs. Adds AST-aware/suffix-aware test resolution, unifies coverage signals, enforces token-aware ASCII checks, and makes `.worktrees/` reads authoritative.

- **Bug Fixes**
  - Test resolution: `TestRunner.resolve_affected_tests` now uses suffix-aware search (`test_<stem>.py` and `test_<stem>_*.py`) plus an AST import map; removes the near-dir glob that pulled unrelated tests.
  - Coverage signal: `OperationAdvisor` now delegates to `target_stratification.file_has_test_coverage`, which uses the same global resolver to avoid 0% false negatives.
  - ASCII gate: `ascii_strict_gate` adds token-aware scanning that allows Unicode in `STRING`/`COMMENT` tokens and rejects it in identifiers; falls back to whole-file scan on parse errors and for non-`.py`.
  - Worktree hydration: `WorktreeManager` canonicalizes `repo_root` and asserts new worktrees contain `tests/` and `backend/`; raises and cleans up if not.
  - `.worktrees/` translation: `execution_context.authoritative_repo_root` routes read-only signals (coverage, blast, test discovery) to the parent repo while keeping writes in the worktree.
  - `.gitignore`: blocks `.superpowers/` and other agent scratch dirs from version control.

<sup>Written for commit 169e8ded4af1ddea04c68a2c4fc7625d6aadd3a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

