### PR TITLE
feat(a1-cloud): cloud-confirm hardening — Cryptographic Pristine Lock + Resilient Telemetry Bridge (PR C/3)

### DIFF
--- a/docs/runbooks/a1_cloud_confirm.md
+++ b/docs/runbooks/a1_cloud_confirm.md
@@ -1,0 +1,58 @@
+# A1 Cloud Confirm — Autonomous Launch Matrix
+
+The runbook for the first autonomous-PR cloud confirm. Composes the existing
+`a1_live_fire_chaos_harness.py --remote` (provision → real-provider soak →
+chaos → A1 audit → black-box → **teardown-always**) with two hardening
+gap-closers shipped here.
+
+## Pre-flight gates (in order)
+
+```bash
+# 0. $0 wiring dry-run — proves the matrix end-to-end, spends nothing
+python3 scripts/a1_live_fire_chaos_harness.py --dry-run-local --stub-soak
+
+# 0.5 GAP-CLOSER Z — Cryptographic Pristine Lock (HARD GATE; rc!=0 ABORTS the launch)
+python3 scripts/a1_zero_state_lock.py || { echo "NODE NOT PRISTINE — ABORT"; exit 1; }
+#   Sweeps orphaned worktrees (reap_orphans), then computes a deterministic SHA256
+#   over the ENTIRE working-tree state (HEAD + porcelain incl. untracked + worktree
+#   list + on-disk .worktrees/ orphans + chaos-manifest presence) and asserts it
+#   equals the COMPUTED pristine baseline for this HEAD. No hardcoded SHA. Fail-closed.
+```
+
+## Fire (only after BOTH PRs merged + gates green)
+
+```bash
+# 1. GAP-CLOSER T — start the resilient telemetry bridge in a SIDE terminal first.
+#    Async fault-tolerant reconnect loop, byte-offset resume (no loss/dup across drops),
+#    multiplexes [A1Trace] (cyan) / [Cortex]+HEDGE GOVERNOR (yellow) / LEDGER_TERMINAL
+#    (green=applied, red=else) into one color-coded local stream. Read-only — a local
+#    Ctrl-C never touches the remote soak.
+python3 scripts/a1_telemetry_bridge.py --node "$A1_NODE" --session-id "$A1_SESSION"
+
+# 2. The real cloud confirm (zero invented flags — all verified in source)
+JARVIS_IAC_HYPERVISOR_ENABLED=1 \
+JARVIS_PROVIDER_CLAUDE_DISABLED=true \          # DW-primary safety gate #1
+JARVIS_DW_PRIMARY_OVERRIDE=a1-cloud-confirm \   # DW-primary safety gate #2
+JARVIS_IAC_SOAK_GOLDEN_ENABLED=true \           # boot the pristine golden image
+python3 scripts/a1_live_fire_chaos_harness.py \
+  --remote --i-understand-this-spends-money \
+  --cost-cap 2.00 --max-wall-seconds 2400 --seed 42 --strict
+```
+
+## Financial Dead-Man's Switch (already in the harness/hypervisor)
+
+`sovereign_iac_hypervisor.py::burn_node()` runs in the orchestrator `try/finally`
+(teardown-always) with four independent kill layers: local `gcloud delete
+--delete-disks=all` · node-side dead-man self-delete (sentinel/idle) · Spot
+`--delete-on-preempt` · GCP `--max-run-duration`. Plus `--cost-cap` (hard) and
+the Slice-47 resource-zero wall-clock hard-kill thread (state-blind by
+invariant). Confirm zero zombies after:
+
+```bash
+gcloud compute instances list --filter="name~'sovereign-sandbox-'"   # expect empty
+```
+
+## Success criterion
+
+`fsm_classify_to_applied=true` + `twelve_flag_audit_passed=true` in the verdict
+→ autonomous PR filed → **A1 gate passes** (raises the execution grade).

--- a/docs/runbooks/a1_cloud_confirm.md
+++ b/docs/runbooks/a1_cloud_confirm.md
@@ -27,13 +27,31 @@ python3 scripts/a1_zero_state_lock.py || { echo "NODE NOT PRISTINE — ABORT"; e
 #    multiplexes [A1Trace] (cyan) / [Cortex]+HEDGE GOVERNOR (yellow) / LEDGER_TERMINAL
 #    (green=applied, red=else) into one color-coded local stream. Read-only — a local
 #    Ctrl-C never touches the remote soak.
-python3 scripts/a1_telemetry_bridge.py --node "$A1_NODE" --session-id "$A1_SESSION"
+#
+#    GCP_ZONE / GCP_PROJECT must be set (or pass --zone / --project explicitly).
+#    Use --remote-log with the absolute node path (mirrors sovereign_iac_hypervisor
+#    _REMOTE_JARVIS_DIR = /opt/trinity/jarvis); --session-id produces a RELATIVE path
+#    that resolves against SSH $HOME and streams zero bytes silently.
+export GCP_ZONE="us-central1-a"        # set to your node's zone
+export GCP_PROJECT="your-gcp-project"  # set to your GCP project ID
+python3 scripts/a1_telemetry_bridge.py \
+    --node "$A1_NODE" \
+    --zone "$GCP_ZONE" \
+    --project "$GCP_PROJECT" \
+    --remote-log "/opt/trinity/jarvis/.ouroboros/sessions/${A1_SESSION}/debug.log"
 
 # 2. The real cloud confirm (zero invented flags — all verified in source)
+#
+# NOTE: every comment is on its OWN line so the backslash-continuation chain
+# is unbroken — inline # after \ silently drops the rest of the env block.
+#
+# DW-primary safety gate #1: prevents Claude from becoming primary on a real-money run
+# DW-primary safety gate #2: forces DoubleWord as primary provider for this run
+# Boot the pristine golden image instead of a live working-tree snapshot
 JARVIS_IAC_HYPERVISOR_ENABLED=1 \
-JARVIS_PROVIDER_CLAUDE_DISABLED=true \          # DW-primary safety gate #1
-JARVIS_DW_PRIMARY_OVERRIDE=a1-cloud-confirm \   # DW-primary safety gate #2
-JARVIS_IAC_SOAK_GOLDEN_ENABLED=true \           # boot the pristine golden image
+JARVIS_PROVIDER_CLAUDE_DISABLED=true \
+JARVIS_DW_PRIMARY_OVERRIDE=a1-cloud-confirm \
+JARVIS_IAC_SOAK_GOLDEN_ENABLED=true \
 python3 scripts/a1_live_fire_chaos_harness.py \
   --remote --i-understand-this-spends-money \
   --cost-cap 2.00 --max-wall-seconds 2400 --seed 42 --strict

--- a/scripts/a1_telemetry_bridge.py
+++ b/scripts/a1_telemetry_bridge.py
@@ -1,0 +1,509 @@
+"""a1_telemetry_bridge — Resilient Multiplexed Telemetry Bridge (Gap-Closer T)
+===============================================================================
+
+Streams a remote GCP A1 node's debug.log over IAP-SSH, surviving network
+drops via byte-offset-resume reconnect, and multiplexes three channel families:
+
+  [A1Trace]            → cyan  (exploration proof-chain hops)
+  [Cortex] / HEDGE GOVERNOR → yellow (stream-health / hedge governor)
+  LEDGER_TERMINAL      → green (state=applied) / red (other terminal states)
+
+READ-ONLY contract: the SSH tail NEVER writes to or signals the remote process.
+A local Ctrl-C / stop_event tears down the LOCAL ssh subprocess only; the
+remote soak is never killed or interrupted.
+
+IAP-SSH command shape mirrors sovereign_iac_hypervisor._ssh_cmd + _tail_cmd:
+  gcloud compute ssh <node> --project=... --zone=... --tunnel-through-iap
+      --command "tail -c +<start> <log_q> 2>/dev/null || true"
+where start = offset + 1 (tail -c is 1-indexed; offset is 0-indexed bytes).
+
+Usage::
+
+    python3 scripts/a1_telemetry_bridge.py \\
+        --node a1-node-name --zone us-central1-a --project my-project \\
+        --session-id <session-uuid>
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import random
+import re
+import shlex
+import sys
+import time
+from typing import (
+    AsyncGenerator,
+    Callable,
+    Coroutine,
+    List,
+    Optional,
+    Set,
+    Tuple,
+)
+
+# ---------------------------------------------------------------------------
+# ANSI colour helpers (suppressed when NO_COLOR / non-TTY / --no-color)
+# ---------------------------------------------------------------------------
+
+_CYAN = "\033[36m"
+_YELLOW = "\033[33m"
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+_DIM = "\033[2m"
+_RESET = "\033[0m"
+
+# ---------------------------------------------------------------------------
+# Channel constants
+# ---------------------------------------------------------------------------
+
+CH_A1TRACE = "A1TRACE"
+CH_CORTEX = "CORTEX"
+CH_LEDGER = "LEDGER"
+CH_OTHER = "OTHER"
+
+_DEFAULT_CHANNELS: frozenset = frozenset({CH_A1TRACE, CH_CORTEX, CH_LEDGER})
+
+# ---------------------------------------------------------------------------
+# Transport defaults
+# ---------------------------------------------------------------------------
+
+_DEFAULT_BACKOFF_BASE_S: float = 2.0
+_DEFAULT_BACKOFF_CAP_S: float = 30.0
+_DEFAULT_MAX_RECONNECTS: int = 50
+_DEFAULT_DEADLINE_S: float = 0.0      # 0 = no wall-clock deadline
+_DEFAULT_READ_TIMEOUT_S: float = 60.0  # idle-read before reconnect
+_DEFAULT_POLL_INTERVAL_S: float = 2.0  # poll interval between successful reads
+
+# ---------------------------------------------------------------------------
+# Line-classification regexes — match the REAL source formats
+#   [A1Trace] …   from a1_trace.a1trace()   (WARNING level)
+#   [A1Trace][emit-probe] … from a1_trace.emit_probe()
+#   [Cortex] …    from doubleword_provider / candidate_generator
+#   HEDGE GOVERNOR from doubleword_provider line ~2624
+#   LEDGER_TERMINAL from orchestrator (Slice74Probe, INFO level)
+# ---------------------------------------------------------------------------
+
+_RE_A1TRACE = re.compile(r"\[A1Trace\]")
+_RE_CORTEX = re.compile(r"\[Cortex\]|HEDGE GOVERNOR")
+_RE_LEDGER = re.compile(r"LEDGER_TERMINAL")
+_RE_LEDGER_APPLIED = re.compile(r"LEDGER_TERMINAL.*\bstate=applied\b")
+_RE_LEDGER_TERMINAL_STATE = re.compile(
+    r"LEDGER_TERMINAL.*\bstate=(applied|rolled_back|failed|blocked)\b"
+)
+
+
+# ---------------------------------------------------------------------------
+# TelemetryMultiplexer
+# ---------------------------------------------------------------------------
+
+class TelemetryMultiplexer:
+    """Classify and optionally colour-code a remote log line.
+
+    Colour is suppressed when *no_color* is True, the ``NO_COLOR`` env var is
+    set (https://no-color.org), or stdout is not a TTY.  The raw message body
+    is NEVER reformatted — this module is a transport bridge, not a logger.
+    """
+
+    def __init__(
+        self,
+        channels: Optional[Set[str]] = None,
+        no_color: bool = False,
+    ) -> None:
+        self._channels: frozenset = (
+            frozenset(channels) if channels is not None else _DEFAULT_CHANNELS
+        )
+        _no_color_env = bool(os.environ.get("NO_COLOR", ""))
+        _is_tty = getattr(sys.stdout, "isatty", lambda: False)()
+        self._use_color: bool = not no_color and not _no_color_env and _is_tty
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def classify(self, line: str) -> str:
+        """Return the channel constant for *line*."""
+        if _RE_A1TRACE.search(line):
+            return CH_A1TRACE
+        if _RE_CORTEX.search(line):
+            return CH_CORTEX
+        if _RE_LEDGER.search(line):
+            return CH_LEDGER
+        return CH_OTHER
+
+    def is_terminal_sentinel(self, line: str) -> bool:
+        """True if *line* is a LEDGER_TERMINAL with a known terminal state."""
+        return bool(_RE_LEDGER_TERMINAL_STATE.search(line))
+
+    def format_line(self, line: str, monotonic_ts: float) -> Optional[str]:
+        """Classify, filter by active channels, and format *line* for output.
+
+        Returns ``None`` when the line's channel is filtered out.
+        The raw message body is passed through unchanged.
+        """
+        channel = self.classify(line)
+        if channel not in self._channels:
+            return None
+
+        tag, color = self._channel_style(channel, line)
+        ts_str = f"{monotonic_ts:012.3f}"
+        body = line.rstrip("\n")
+
+        if self._use_color and color:
+            return f"{color}[{tag}|{ts_str}]{_RESET} {color}{body}{_RESET}\n"
+        return f"[{tag}|{ts_str}] {body}\n"
+
+    # ------------------------------------------------------------------
+    # Internal
+    # ------------------------------------------------------------------
+
+    def _channel_style(self, channel: str, line: str) -> Tuple[str, str]:
+        if channel == CH_A1TRACE:
+            return "A1T", _CYAN
+        if channel == CH_CORTEX:
+            return "COR", _YELLOW
+        if channel == CH_LEDGER:
+            color = _GREEN if _RE_LEDGER_APPLIED.search(line) else _RED
+            return "LED", color
+        return "LOG", _DIM
+
+
+# ---------------------------------------------------------------------------
+# IAP-SSH command builder — mirrors sovereign_iac_hypervisor._ssh_cmd/_tail_cmd
+# ---------------------------------------------------------------------------
+
+def _build_tail_cmd(
+    node: str,
+    zone: str,
+    project: str,
+    remote_log_path: str,
+    offset: int,
+) -> List[str]:
+    """Build the gcloud IAP-SSH command that tails from *offset* (0-indexed bytes).
+
+    ``tail -c +N`` is 1-indexed, so ``start = max(0, offset) + 1``.
+    Mirrors hypervisor ``_ssh_cmd`` / ``_tail_cmd`` exactly — no hardcoded
+    project/zone.
+    """
+    start = max(0, int(offset)) + 1
+    log_q = shlex.quote(remote_log_path)
+    remote = f"tail -c +{start} {log_q} 2>/dev/null || true"
+    return [
+        "gcloud", "compute", "ssh", node,
+        f"--project={project}",
+        f"--zone={zone}",
+        "--tunnel-through-iap",
+        "--command", remote,
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Bridge-internal logger (stderr only — never pollutes the log stream)
+# ---------------------------------------------------------------------------
+
+def _log_bridge(msg: str) -> None:
+    ts = time.strftime("%H:%M:%S")
+    print(f"[a1-bridge|{ts}] {msg}", file=sys.stderr, flush=True)
+
+
+# ---------------------------------------------------------------------------
+# Core streaming function
+# ---------------------------------------------------------------------------
+
+async def stream_telemetry(
+    node: str,
+    zone: str,
+    project: str,
+    remote_log_path: str,
+    *,
+    channels: Optional[Set[str]] = None,
+    on_line: Optional[Callable[[str], None]] = None,
+    no_color: bool = False,
+    max_reconnects: int = _DEFAULT_MAX_RECONNECTS,
+    deadline_s: float = _DEFAULT_DEADLINE_S,
+    stop_event: Optional[asyncio.Event] = None,
+    # --- Injection hooks for tests (None in production) ---
+    _cmd_runner: Optional[
+        Callable[[List[str]], AsyncGenerator[bytes, None]]
+    ] = None,
+    _sleep: Optional[Callable[[float], Coroutine]] = None,
+) -> None:
+    """Stream *remote_log_path* from *node* over IAP-SSH, surviving drops.
+
+    The stream is READ-ONLY.  The remote tail/soak process is NEVER signalled.
+    On network drop, the bridge resumes from the last byte-offset so no lines
+    are duplicated or lost across reconnects.
+
+    Args:
+        node: GCP instance name.
+        zone: GCP zone (e.g. ``us-central1-a``).
+        project: GCP project ID.
+        remote_log_path: Absolute path to the target log on the remote node.
+        channels: Active channel set.  Defaults to all three.
+        on_line: Callback for each formatted output line.
+            Defaults to ``sys.stdout.write``.
+        no_color: Suppress ANSI colour codes.
+        max_reconnects: Max reconnect/retry count (0 = unlimited).
+        deadline_s: Wall-clock deadline in seconds from call start (0 = none).
+        stop_event: When set, the loop exits after tearing down the LOCAL ssh
+            subprocess only — the remote run is NEVER signalled.
+        _cmd_runner: Test injection.  ``_cmd_runner(cmd) -> AsyncGenerator[bytes]``.
+            Raises to simulate a connection failure.
+        _sleep: Test injection for asyncio.sleep.
+    """
+    mux = TelemetryMultiplexer(channels=channels, no_color=no_color)
+    emit: Callable[[str], None] = (
+        on_line if on_line is not None else sys.stdout.write
+    )
+    do_sleep = _sleep if _sleep is not None else asyncio.sleep
+
+    start_wall = time.monotonic()
+    last_offset: int = 0
+    reconnect_count: int = 0
+    backoff: float = _DEFAULT_BACKOFF_BASE_S
+
+    # ------------------------------------------------------------------
+    # _run_once: one transport connection
+    # Returns (new_offset, terminal_seen).
+    # Raises on connection failure so the outer loop can do backoff+retry.
+    # ------------------------------------------------------------------
+    async def _run_once(offset: int) -> Tuple[int, bool]:
+        cmd = _build_tail_cmd(node, zone, project, remote_log_path, offset)
+        new_offset = offset
+        terminal_seen = False
+
+        if _cmd_runner is not None:
+            # Test-injection path — no real subprocess.
+            async for chunk in _cmd_runner(cmd):
+                # Check stop_event between chunks so the outer loop can exit.
+                if stop_event is not None and stop_event.is_set():
+                    return new_offset, terminal_seen
+                new_offset += len(chunk)
+                ts = time.monotonic() - start_wall
+                for line in chunk.decode(errors="replace").splitlines(keepends=True):
+                    formatted = mux.format_line(line, ts)
+                    if formatted:
+                        emit(formatted)
+                    if mux.is_terminal_sentinel(line):
+                        terminal_seen = True
+            return new_offset, terminal_seen
+
+        # Production path: real asyncio subprocess (IAP-SSH tail).
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            assert proc.stdout is not None
+            while True:
+                if stop_event is not None and stop_event.is_set():
+                    break
+                try:
+                    chunk = await asyncio.wait_for(
+                        proc.stdout.read(4096),
+                        timeout=_DEFAULT_READ_TIMEOUT_S,
+                    )
+                except asyncio.TimeoutError:
+                    # No new data for read_timeout — break and reconnect.
+                    break
+                if not chunk:
+                    break  # clean EOF from ssh
+                new_offset += len(chunk)
+                ts = time.monotonic() - start_wall
+                for line in chunk.decode(errors="replace").splitlines(keepends=True):
+                    formatted = mux.format_line(line, ts)
+                    if formatted:
+                        emit(formatted)
+                    if mux.is_terminal_sentinel(line):
+                        terminal_seen = True
+                if terminal_seen:
+                    break
+        finally:
+            # Tear down the LOCAL ssh subprocess only.
+            # The remote tail/soak process is NEVER signalled — it runs
+            # autonomously and will continue after the local bridge exits.
+            try:
+                proc.kill()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except Exception:  # noqa: BLE001
+                pass
+
+        return new_offset, terminal_seen
+
+    # ------------------------------------------------------------------
+    # Outer reconnect loop
+    # ------------------------------------------------------------------
+    while True:
+        # Wall-clock deadline
+        if deadline_s > 0.0 and (time.monotonic() - start_wall) >= deadline_s:
+            _log_bridge(f"deadline reached ({deadline_s:.0f}s) — bridge stopping")
+            break
+
+        # Stop event (checked before each attempt)
+        if stop_event is not None and stop_event.is_set():
+            _log_bridge(
+                "stop event set — LOCAL bridge stopping (remote run untouched)"
+            )
+            break
+
+        # Max reconnects exhausted
+        if max_reconnects > 0 and reconnect_count >= max_reconnects:
+            _log_bridge(
+                f"max_reconnects={max_reconnects} exhausted — bridge stopping"
+            )
+            break
+
+        try:
+            new_offset, terminal_seen = await _run_once(last_offset)
+        except Exception as exc:  # noqa: BLE001 — fail-soft, log + backoff + retry
+            reconnect_count += 1
+            jitter = random.uniform(0.0, backoff * 0.2)
+            sleep_s = min(backoff + jitter, _DEFAULT_BACKOFF_CAP_S)
+            _log_bridge(
+                f"transport error: {exc!r} — reconnect #{reconnect_count} "
+                f"in {sleep_s:.1f}s (offset={last_offset})"
+            )
+            await do_sleep(sleep_s)
+            backoff = min(backoff * 2.0, _DEFAULT_BACKOFF_CAP_S)
+            continue
+
+        if terminal_seen:
+            _log_bridge(
+                f"terminal sentinel at offset={new_offset} — bridge done"
+            )
+            break
+
+        # Check stop_event again before sleeping (avoids an unnecessary poll sleep).
+        if stop_event is not None and stop_event.is_set():
+            _log_bridge(
+                "stop event set after _run_once — LOCAL bridge stopping"
+            )
+            break
+
+        if new_offset > last_offset:
+            # Progress: reset backoff, poll after brief interval.
+            last_offset = new_offset
+            backoff = _DEFAULT_BACKOFF_BASE_S
+            await do_sleep(_DEFAULT_POLL_INTERVAL_S)
+        else:
+            # No new data: back off before retrying.
+            reconnect_count += 1
+            jitter = random.uniform(0.0, backoff * 0.2)
+            sleep_s = min(backoff + jitter, _DEFAULT_BACKOFF_CAP_S)
+            _log_bridge(
+                f"no new data (offset={last_offset}) — backoff {sleep_s:.1f}s "
+                f"(attempt #{reconnect_count})"
+            )
+            await do_sleep(sleep_s)
+            backoff = min(backoff * 2.0, _DEFAULT_BACKOFF_CAP_S)
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Resilient IAP-SSH telemetry bridge for A1 cloud soaks.\n"
+            "Streams debug.log from a remote GCP node, surviving network drops\n"
+            "via byte-offset-resume reconnect.  READ-ONLY: never signals the remote."
+        ),
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    p.add_argument("--node", required=True, help="GCP instance name")
+    p.add_argument(
+        "--zone",
+        default=os.environ.get("GCP_ZONE", ""),
+        help="GCP zone (env: GCP_ZONE)",
+    )
+    p.add_argument(
+        "--project",
+        default=os.environ.get("GCP_PROJECT", ""),
+        help="GCP project ID (env: GCP_PROJECT)",
+    )
+
+    log_group = p.add_mutually_exclusive_group()
+    log_group.add_argument(
+        "--session-id",
+        dest="session_id",
+        help="Session UUID — bridges .ouroboros/sessions/<id>/debug.log",
+    )
+    log_group.add_argument(
+        "--remote-log",
+        dest="remote_log",
+        help="Explicit remote absolute path to the log file",
+    )
+
+    p.add_argument(
+        "--channels",
+        nargs="+",
+        choices=[CH_A1TRACE, CH_CORTEX, CH_LEDGER],
+        default=[CH_A1TRACE, CH_CORTEX, CH_LEDGER],
+        metavar="CHANNEL",
+        help=f"Channels to display: {CH_A1TRACE} {CH_CORTEX} {CH_LEDGER} (default: all)",
+    )
+    p.add_argument(
+        "--max-reconnects",
+        type=int,
+        default=_DEFAULT_MAX_RECONNECTS,
+        help="Max reconnect attempts before giving up (0 = unlimited, default 50)",
+    )
+    p.add_argument(
+        "--deadline-s",
+        type=float,
+        default=_DEFAULT_DEADLINE_S,
+        help="Total wall-clock deadline in seconds (0 = no deadline)",
+    )
+    p.add_argument(
+        "--no-color",
+        action="store_true",
+        help="Disable ANSI colour codes",
+    )
+    return p
+
+
+def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    if not args.zone:
+        parser.error("--zone is required (or set GCP_ZONE env var)")
+    if not args.project:
+        parser.error("--project is required (or set GCP_PROJECT env var)")
+
+    if args.remote_log:
+        remote_log_path = args.remote_log
+    elif args.session_id:
+        remote_log_path = f".ouroboros/sessions/{args.session_id}/debug.log"
+    else:
+        parser.error("one of --session-id or --remote-log is required")
+        return  # unreachable; satisfies type checker
+
+    channels: Set[str] = set(args.channels)
+
+    try:
+        asyncio.run(
+            stream_telemetry(
+                node=args.node,
+                zone=args.zone,
+                project=args.project,
+                remote_log_path=remote_log_path,
+                channels=channels,
+                no_color=args.no_color,
+                max_reconnects=args.max_reconnects,
+                deadline_s=args.deadline_s,
+            )
+        )
+    except KeyboardInterrupt:
+        _log_bridge("Ctrl-C — LOCAL bridge stopped (remote run untouched)")
+        sys.exit(0)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/a1_telemetry_bridge.py
+++ b/scripts/a1_telemetry_bridge.py
@@ -218,7 +218,7 @@ async def stream_telemetry(
     remote_log_path: str,
     *,
     channels: Optional[Set[str]] = None,
-    on_line: Optional[Callable[[str], None]] = None,
+    on_line: Optional[Callable[[str], object]] = None,
     no_color: bool = False,
     max_reconnects: int = _DEFAULT_MAX_RECONNECTS,
     deadline_s: float = _DEFAULT_DEADLINE_S,
@@ -253,7 +253,8 @@ async def stream_telemetry(
         _sleep: Test injection for asyncio.sleep.
     """
     mux = TelemetryMultiplexer(channels=channels, no_color=no_color)
-    emit: Callable[[str], None] = (
+    # M1: widened to object so sys.stdout.write (→int) satisfies the type.
+    emit: Callable[[str], object] = (
         on_line if on_line is not None else sys.stdout.write
     )
     do_sleep = _sleep if _sleep is not None else asyncio.sleep
@@ -262,6 +263,10 @@ async def stream_telemetry(
     last_offset: int = 0
     reconnect_count: int = 0
     backoff: float = _DEFAULT_BACKOFF_BASE_S
+    # I1: cross-reconnect line buffer — carries partial (no-newline) tail of
+    # the last chunk into the next chunk / reconnect so lines split at chunk
+    # boundaries are reassembled before classification / sentinel detection.
+    pending: str = ""
 
     # ------------------------------------------------------------------
     # _run_once: one transport connection
@@ -269,6 +274,7 @@ async def stream_telemetry(
     # Raises on connection failure so the outer loop can do backoff+retry.
     # ------------------------------------------------------------------
     async def _run_once(offset: int) -> Tuple[int, bool]:
+        nonlocal pending
         cmd = _build_tail_cmd(node, zone, project, remote_log_path, offset)
         new_offset = offset
         terminal_seen = False
@@ -280,13 +286,23 @@ async def stream_telemetry(
                 if stop_event is not None and stop_event.is_set():
                     return new_offset, terminal_seen
                 new_offset += len(chunk)
+                # I1: merge pending partial line with new decoded bytes, then
+                # split into COMPLETE lines only; retain trailing partial.
+                raw = pending + chunk.decode(errors="replace")
+                lines = raw.splitlines(keepends=True)
+                if lines and not lines[-1].endswith(("\n", "\r")):
+                    pending = lines.pop()
+                else:
+                    pending = ""
                 ts = time.monotonic() - start_wall
-                for line in chunk.decode(errors="replace").splitlines(keepends=True):
+                for line in lines:
                     formatted = mux.format_line(line, ts)
                     if formatted:
                         emit(formatted)
                     if mux.is_terminal_sentinel(line):
                         terminal_seen = True
+                if terminal_seen:
+                    break
             return new_offset, terminal_seen
 
         # Production path: real asyncio subprocess (IAP-SSH tail).
@@ -309,10 +325,26 @@ async def stream_telemetry(
                     # No new data for read_timeout — break and reconnect.
                     break
                 if not chunk:
+                    # Clean EOF: flush any pending partial line before breaking.
+                    if pending:
+                        ts = time.monotonic() - start_wall
+                        formatted = mux.format_line(pending, ts)
+                        if formatted:
+                            emit(formatted)
+                        if mux.is_terminal_sentinel(pending):
+                            terminal_seen = True
+                        pending = ""
                     break  # clean EOF from ssh
                 new_offset += len(chunk)
+                # I1: merge pending partial with new bytes; split complete lines.
+                raw = pending + chunk.decode(errors="replace")
+                lines = raw.splitlines(keepends=True)
+                if lines and not lines[-1].endswith(("\n", "\r")):
+                    pending = lines.pop()
+                else:
+                    pending = ""
                 ts = time.monotonic() - start_wall
-                for line in chunk.decode(errors="replace").splitlines(keepends=True):
+                for line in lines:
                     formatted = mux.format_line(line, ts)
                     if formatted:
                         emit(formatted)
@@ -386,9 +418,12 @@ async def stream_telemetry(
             break
 
         if new_offset > last_offset:
-            # Progress: reset backoff, poll after brief interval.
+            # Progress: reset backoff AND reconnect_count (I2: consecutive-failure
+            # semantics — only unbroken runs of failures count toward the cap;
+            # a healthy-but-quiet soak must not exhaust max_reconnects).
             last_offset = new_offset
             backoff = _DEFAULT_BACKOFF_BASE_S
+            reconnect_count = 0
             await do_sleep(_DEFAULT_POLL_INTERVAL_S)
         else:
             # No new data: back off before retrying.

--- a/scripts/a1_zero_state_lock.py
+++ b/scripts/a1_zero_state_lock.py
@@ -1,0 +1,367 @@
+# scripts/a1_zero_state_lock.py
+"""
+A1 Zero-State Lock — Cryptographic Pristine Assertion for A1 Cloud-Confirm runs.
+
+Computes a deterministic SHA256 over the ENTIRE active git working-tree state
+and hard-ABORTs if it deviates from the computed pristine baseline.  No silent
+failures, no ghost state, no hardcoded expected digest.
+
+Usage (CLI)::
+
+    python3 scripts/a1_zero_state_lock.py [--repo-root PATH] [--no-sweep] [--json]
+
+Exit codes:
+    0  PRISTINE  — ZERO_STATE_ASSERTED sha=<digest>
+    1  NOT PRISTINE — ZERO_STATE_ABORT expected=<x> actual=<y> deviations=[...]
+    2  INTERNAL ERROR — fail-closed (unknown state, treat as ABORT)
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import hashlib
+import json
+import subprocess
+import sys
+from pathlib import Path
+from typing import List, Optional
+
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+@dataclasses.dataclass
+class ZeroStateResult:
+    """Result of a pristine-state assertion."""
+
+    pristine: bool
+    expected_digest: str
+    actual_digest: str
+    deviations: List[str]
+
+
+# ---------------------------------------------------------------------------
+# Git helpers (no shell=True, explicit cwd via -C)
+# ---------------------------------------------------------------------------
+
+def _git(repo_root: Path, *args: str) -> str:
+    """Run ``git -C <repo_root> <args>`` and return stdout.
+
+    Raises ``RuntimeError`` on non-zero exit (fail-closed).
+    """
+    result = subprocess.run(
+        ["git", "-C", str(repo_root), *args],
+        capture_output=True,
+        text=True,
+    )
+    if result.returncode != 0:
+        raise RuntimeError(
+            f"git {' '.join(args)} failed (rc={result.returncode}): "
+            f"{result.stderr.strip()}"
+        )
+    return result.stdout
+
+
+def _parse_worktree_paths(porcelain: str) -> List[str]:
+    """Parse ``git worktree list --porcelain`` output into an ordered list of paths.
+
+    The first entry is always the main worktree; subsequent entries are linked
+    worktrees.  Order is preserved so the caller can identify the main checkout.
+    """
+    paths: List[str] = []
+    for line in porcelain.splitlines():
+        line = line.strip()
+        if line.startswith("worktree "):
+            paths.append(line[len("worktree "):])
+    return paths
+
+
+# ---------------------------------------------------------------------------
+# Orphan directory detection
+# ---------------------------------------------------------------------------
+
+# Prefixes that signal campaign-debris / L3-isolation orphan directories.
+# Mirrors the default set in worktree_manager._DEFAULT_REAP_EXTRA_PREFIXES plus
+# the primary L3 isolation prefix.
+_ORPHAN_DIR_PREFIXES = ("unit-", "ouroboros__auto__bt-", "soak-")
+
+
+def _get_orphan_dirs(worktrees_dir: Path) -> List[str]:
+    """Return a sorted list of orphan-prefix directory NAMES under ``.worktrees/``.
+
+    Only directory names (not full paths) are returned for stable serialization
+    regardless of repo location.
+    """
+    if not worktrees_dir.is_dir():
+        return []
+    dirs: List[str] = []
+    for child in worktrees_dir.iterdir():
+        if child.is_dir() and any(
+            child.name.startswith(p) for p in _ORPHAN_DIR_PREFIXES
+        ):
+            dirs.append(child.name)
+    return sorted(dirs)
+
+
+# ---------------------------------------------------------------------------
+# Canonical serialization + digest
+# ---------------------------------------------------------------------------
+
+def _canonical_string(
+    head: str,
+    status_lines: List[str],
+    worktree_paths: List[str],
+    orphan_dirs: List[str],
+    chaos_manifest: bool,
+) -> str:
+    """Build the stable, newline-joined canonical string that is SHA256-hashed.
+
+    All variable-length lists are sorted before serialization so the output is
+    independent of subprocess ordering or filesystem ordering.  No timestamps,
+    PIDs, or random values are included.
+
+    Fields:
+        head:<git-HEAD-sha>
+        status:<porcelain-line>  (one per dirty/untracked entry, sorted)
+        worktree:<path>          (one per registered worktree, sorted)
+        orphan_dir:<name>        (one per orphan dir under .worktrees/, sorted)
+        chaos_manifest:present|absent
+    """
+    parts: List[str] = []
+    parts.append(f"head:{head.strip()}")
+    for line in sorted(status_lines):
+        parts.append(f"status:{line}")
+    for path in sorted(worktree_paths):
+        parts.append(f"worktree:{path}")
+    for name in sorted(orphan_dirs):
+        parts.append(f"orphan_dir:{name}")
+    parts.append(f"chaos_manifest:{'present' if chaos_manifest else 'absent'}")
+    return "\n".join(parts)
+
+
+def compute_state_digest(repo_root: "str | Path") -> str:
+    """Compute and return a deterministic SHA256 hex digest of the full
+    git working-tree state at ``repo_root``.
+
+    This is a pure read — it does not modify anything.  Raises ``RuntimeError``
+    if any git subprocess fails (fail-closed).
+    """
+    repo_root = Path(repo_root).resolve()
+
+    head = _git(repo_root, "rev-parse", "HEAD").strip()
+
+    status_raw = _git(
+        repo_root, "status", "--porcelain=v1", "--untracked-files=all"
+    )
+    status_lines = [ln for ln in status_raw.splitlines() if ln.strip()]
+
+    worktree_porcelain = _git(repo_root, "worktree", "list", "--porcelain")
+    worktree_paths = _parse_worktree_paths(worktree_porcelain)
+
+    worktrees_dir = repo_root / ".worktrees"
+    orphan_dirs = _get_orphan_dirs(worktrees_dir)
+
+    chaos_manifest = (repo_root / ".jarvis" / "chaos_manifest.json").exists()
+
+    canonical = _canonical_string(
+        head, status_lines, worktree_paths, orphan_dirs, chaos_manifest
+    )
+    return hashlib.sha256(canonical.encode()).hexdigest()
+
+
+# ---------------------------------------------------------------------------
+# Orphan sweep (reuses WorktreeManager.reap_orphans)
+# ---------------------------------------------------------------------------
+
+async def _sweep(repo_root: Path) -> int:
+    """Invoke WorktreeManager.reap_orphans to remove orphaned worktrees.
+
+    A single call with branch_prefix="unit-" is sufficient: the manager
+    internally expands to ALL campaign-debris prefixes via
+    _resolve_reap_prefixes(), sweeping:
+        unit-              (L3 isolation prefix)
+        ouroboros/auto/bt- (branch form of auto-soak worktrees)
+        ouroboros__auto__bt- (on-disk dir form of auto-soak worktrees)
+        soak-              (legacy soak worktrees)
+    plus any extras in JARVIS_WORKTREE_REAP_PREFIXES.
+
+    Returns the count of worktrees reaped.  Raises ImportError / RuntimeError
+    on failure (caller may warn and continue — the assert step is authoritative).
+    """
+    from backend.core.ouroboros.governance.worktree_manager import WorktreeManager  # lazy import
+
+    mgr = WorktreeManager(repo_root=repo_root)
+    return await mgr.reap_orphans(branch_prefix="unit-")
+
+
+# ---------------------------------------------------------------------------
+# Pristine assertion
+# ---------------------------------------------------------------------------
+
+def assert_pristine(
+    repo_root: "str | Path",
+    *,
+    sweep: bool = True,
+) -> ZeroStateResult:
+    """Assert the repo at ``repo_root`` is in a pristine zero state.
+
+    When ``sweep=True`` (default), the WorktreeManager orphan reaper runs
+    FIRST to remove recoverable ghost worktrees; the state is then re-sampled
+    before computing the digest.  If anything remains non-pristine after sweep,
+    that is REAL ghost state and we ABORT.
+
+    The **pristine baseline is derived, never hardcoded**.  The expected digest
+    is computed from the SAME HEAD as the actual tree, but with empty status
+    (no dirty/untracked files), only the main worktree, no orphan dirs, and no
+    chaos manifest.  This means the expected digest rotates with HEAD, so the
+    lock is always relative to the current commit — not a fixed SHA.
+
+    Returns a :class:`ZeroStateResult`.  Raises ``RuntimeError`` on any
+    internal error (fail-closed — caller should treat this as ABORT rc=2).
+    """
+    repo_root = Path(repo_root).resolve()
+
+    if sweep:
+        try:
+            asyncio.run(_sweep(repo_root))
+        except Exception as exc:  # pragma: no cover
+            # Sweep failure is non-fatal: log a warning and proceed to assert.
+            # If orphans survive they will be caught by the digest mismatch.
+            print(
+                f"WARN: a1_zero_state_lock: orphan sweep failed ({exc}); "
+                "proceeding to assertion",
+                file=sys.stderr,
+            )
+
+    # --- Sample actual state ---
+    head = _git(repo_root, "rev-parse", "HEAD").strip()
+
+    status_raw = _git(
+        repo_root, "status", "--porcelain=v1", "--untracked-files=all"
+    )
+    status_lines = [ln for ln in status_raw.splitlines() if ln.strip()]
+
+    worktree_porcelain = _git(repo_root, "worktree", "list", "--porcelain")
+    worktree_paths = _parse_worktree_paths(worktree_porcelain)
+
+    worktrees_dir = repo_root / ".worktrees"
+    orphan_dirs = _get_orphan_dirs(worktrees_dir)
+
+    chaos_manifest = (repo_root / ".jarvis" / "chaos_manifest.json").exists()
+
+    # --- Compute actual digest ---
+    actual_canonical = _canonical_string(
+        head, status_lines, worktree_paths, orphan_dirs, chaos_manifest
+    )
+    actual_digest = hashlib.sha256(actual_canonical.encode()).hexdigest()
+
+    # --- Compute expected (pristine) digest ---
+    # Expected state: same HEAD, no dirty files, only the main worktree, no
+    # orphan dirs, no chaos manifest.  Main worktree is always the first entry
+    # from `git worktree list`; we derive it from the actual output so the
+    # path is never hardcoded.
+    main_wt: List[str] = worktree_paths[:1]  # empty list if somehow missing
+    expected_canonical = _canonical_string(head, [], main_wt, [], False)
+    expected_digest = hashlib.sha256(expected_canonical.encode()).hexdigest()
+
+    # --- Collect human-readable deviations ---
+    deviations: List[str] = []
+    for line in sorted(status_lines):
+        deviations.append(f"dirty_or_untracked: {line.strip()}")
+    for wt in sorted(worktree_paths[1:]):  # extras beyond the main worktree
+        deviations.append(f"extra_worktree: {wt}")
+    for name in orphan_dirs:
+        deviations.append(f"orphan_dir: {name}")
+    if chaos_manifest:
+        deviations.append("chaos_manifest: .jarvis/chaos_manifest.json present")
+
+    pristine = actual_digest == expected_digest
+
+    return ZeroStateResult(
+        pristine=pristine,
+        expected_digest=expected_digest,
+        actual_digest=actual_digest,
+        deviations=deviations,
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI entry point
+# ---------------------------------------------------------------------------
+
+def main(argv: "Optional[List[str]]" = None) -> int:
+    """CLI entry point.
+
+    Returns:
+        0  — pristine (ZERO_STATE_ASSERTED)
+        1  — not pristine (ZERO_STATE_ABORT)
+        2  — internal error (fail-closed, treat as ABORT)
+    """
+    import argparse
+
+    parser = argparse.ArgumentParser(
+        description="Assert A1 zero-state: repo must be cryptographically pristine "
+                    "before a real-money cloud run fires.",
+    )
+    parser.add_argument(
+        "--repo-root",
+        default=None,
+        help="Absolute path to the git repository root.  "
+             "Default: parent directory of this script (i.e. <repo_root>/scripts/../).",
+    )
+    parser.add_argument(
+        "--no-sweep",
+        action="store_true",
+        help="Skip the orphan-worktree reaper before asserting.  "
+             "Assert the state exactly as-is.",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        help="Output a machine-readable JSON object to stdout.",
+    )
+    args = parser.parse_args(argv)
+
+    # Resolve repo root: explicit flag > derive from __file__
+    if args.repo_root:
+        repo_root = Path(args.repo_root).resolve()
+    else:
+        # This script lives at <repo_root>/scripts/a1_zero_state_lock.py
+        repo_root = Path(__file__).resolve().parent.parent
+
+    try:
+        result = assert_pristine(repo_root, sweep=not args.no_sweep)
+    except Exception as exc:
+        payload = {"status": "ERROR", "error": str(exc)}
+        if args.json:
+            print(json.dumps(payload), file=sys.stdout)
+        else:
+            print(f"ZERO_STATE_ABORT error={exc}", file=sys.stderr)
+        return 2  # fail-closed: unknown internal error → ABORT
+
+    if args.json:
+        payload = {
+            "status": "PRISTINE" if result.pristine else "NOT_PRISTINE",
+            "expected": result.expected_digest,
+            "actual": result.actual_digest,
+            "deviations": result.deviations,
+        }
+        print(json.dumps(payload, indent=2))
+    else:
+        if result.pristine:
+            print(f"ZERO_STATE_ASSERTED sha={result.actual_digest}")
+        else:
+            print(
+                f"ZERO_STATE_ABORT "
+                f"expected={result.expected_digest} "
+                f"actual={result.actual_digest} "
+                f"deviations={result.deviations}",
+                file=sys.stderr,
+            )
+
+    return 0 if result.pristine else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/a1_zero_state_lock.py
+++ b/scripts/a1_zero_state_lock.py
@@ -24,7 +24,7 @@ import json
 import subprocess
 import sys
 from pathlib import Path
-from typing import List, Optional
+from typing import FrozenSet, List, Optional
 
 
 # ---------------------------------------------------------------------------
@@ -81,14 +81,24 @@ def _parse_worktree_paths(porcelain: str) -> List[str]:
 # Orphan directory detection
 # ---------------------------------------------------------------------------
 
-# Prefixes that signal campaign-debris / L3-isolation orphan directories.
-# Mirrors the default set in worktree_manager._DEFAULT_REAP_EXTRA_PREFIXES plus
-# the primary L3 isolation prefix.
+# Legacy prefix list — kept for reference / backward-compat callers that lack
+# worktree-list data.  The primary code path now uses set-difference (I4).
 _ORPHAN_DIR_PREFIXES = ("unit-", "ouroboros__auto__bt-", "soak-")
 
 
-def _get_orphan_dirs(worktrees_dir: Path) -> List[str]:
-    """Return a sorted list of orphan-prefix directory NAMES under ``.worktrees/``.
+def _get_orphan_dirs(
+    worktrees_dir: Path,
+    registered_basenames: Optional[FrozenSet[str]] = None,
+) -> List[str]:
+    """Return sorted list of orphan directory NAMES under ``.worktrees/``.
+
+    I4 fix: when *registered_basenames* is provided (the set of basenames from
+    ``git worktree list --porcelain``), returns ALL child directory names that
+    are NOT in that set — a true set-difference, independent of naming prefix.
+    An unregistered orphan dir with any name is caught.
+
+    When *registered_basenames* is None (legacy / backward-compat callers),
+    falls back to the prefix-based filter.
 
     Only directory names (not full paths) are returned for stable serialization
     regardless of repo location.
@@ -97,10 +107,16 @@ def _get_orphan_dirs(worktrees_dir: Path) -> List[str]:
         return []
     dirs: List[str] = []
     for child in worktrees_dir.iterdir():
-        if child.is_dir() and any(
-            child.name.startswith(p) for p in _ORPHAN_DIR_PREFIXES
-        ):
-            dirs.append(child.name)
+        if not child.is_dir():
+            continue
+        if registered_basenames is not None:
+            # Set-difference: any on-disk dir NOT in the registered set is orphan.
+            if child.name not in registered_basenames:
+                dirs.append(child.name)
+        else:
+            # Fallback: prefix-based filter.
+            if any(child.name.startswith(p) for p in _ORPHAN_DIR_PREFIXES):
+                dirs.append(child.name)
     return sorted(dirs)
 
 
@@ -160,7 +176,11 @@ def compute_state_digest(repo_root: "str | Path") -> str:
     worktree_paths = _parse_worktree_paths(worktree_porcelain)
 
     worktrees_dir = repo_root / ".worktrees"
-    orphan_dirs = _get_orphan_dirs(worktrees_dir)
+    # I4: pass registered basenames so ALL unregistered dirs are caught.
+    registered_wt_basenames: FrozenSet[str] = frozenset(
+        Path(p).name for p in worktree_paths
+    )
+    orphan_dirs = _get_orphan_dirs(worktrees_dir, registered_wt_basenames)
 
     chaos_manifest = (repo_root / ".jarvis" / "chaos_manifest.json").exists()
 
@@ -224,7 +244,12 @@ def assert_pristine(
 
     if sweep:
         try:
-            asyncio.run(_sweep(repo_root))
+            reaped = asyncio.run(_sweep(repo_root))
+            # M2: always surface the count — a money-gate must be observable.
+            print(
+                f"swept {reaped} orphan worktree(s) before assertion",
+                file=sys.stderr,
+            )
         except Exception as exc:  # pragma: no cover
             # Sweep failure is non-fatal: log a warning and proceed to assert.
             # If orphans survive they will be caught by the digest mismatch.
@@ -246,7 +271,11 @@ def assert_pristine(
     worktree_paths = _parse_worktree_paths(worktree_porcelain)
 
     worktrees_dir = repo_root / ".worktrees"
-    orphan_dirs = _get_orphan_dirs(worktrees_dir)
+    # I4: set-difference — any dir in .worktrees/ not in registered set is orphan.
+    registered_wt_basenames: FrozenSet[str] = frozenset(
+        Path(p).name for p in worktree_paths
+    )
+    orphan_dirs = _get_orphan_dirs(worktrees_dir, registered_wt_basenames)
 
     chaos_manifest = (repo_root / ".jarvis" / "chaos_manifest.json").exists()
 

--- a/tests/scripts/test_a1_telemetry_bridge.py
+++ b/tests/scripts/test_a1_telemetry_bridge.py
@@ -1,0 +1,436 @@
+"""Tests for scripts/a1_telemetry_bridge.py — TDD Red→Green.
+
+All five tests are injection-based: no real gcloud/SSH/GCP is needed.
+Transport is replaced by async generator factories; asyncio.sleep is
+replaced by a no-op coroutine so the reconnect-backoff tests are instant.
+
+asyncio_mode = auto (pytest.ini) — no @pytest.mark.asyncio needed.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import AsyncGenerator, List, Set
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Load the script as a module (mirrors the hypervisor test pattern)
+# ---------------------------------------------------------------------------
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "a1_telemetry_bridge.py"
+_spec = importlib.util.spec_from_file_location("a1_telemetry_bridge", _SCRIPT)
+assert _spec and _spec.loader, f"Cannot load {_SCRIPT}"
+bridge = importlib.util.module_from_spec(_spec)
+_spec.loader.exec_module(bridge)  # type: ignore[union-attr]
+
+TelemetryMultiplexer = bridge.TelemetryMultiplexer
+stream_telemetry = bridge.stream_telemetry
+_build_tail_cmd = bridge._build_tail_cmd
+CH_A1TRACE = bridge.CH_A1TRACE
+CH_CORTEX = bridge.CH_CORTEX
+CH_LEDGER = bridge.CH_LEDGER
+CH_OTHER = bridge.CH_OTHER
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_mux(
+    no_color: bool = True,
+    channels: Set[str] | None = None,
+) -> TelemetryMultiplexer:
+    return TelemetryMultiplexer(
+        channels=channels
+        if channels is not None
+        else {CH_A1TRACE, CH_CORTEX, CH_LEDGER, CH_OTHER},
+        no_color=no_color,
+    )
+
+
+async def _instant_sleep(_s: float) -> None:
+    """Drop-in for asyncio.sleep: completes in zero wall time."""
+    await asyncio.sleep(0)
+
+
+# ===========================================================================
+# Test 1 — Multiplexer: classify + colour
+# ===========================================================================
+
+class TestMultiplexer:
+    def test_a1trace_basic(self) -> None:
+        mux = _make_mux()
+        assert mux.classify("[A1Trace] emit goal=abc123") == CH_A1TRACE
+
+    def test_a1trace_emit_probe_variant(self) -> None:
+        mux = _make_mux()
+        line = "[A1Trace][emit-probe] EMIT goal=abc123 source=roadmap emit_ts=1.0 orchestrator_enabled=True"
+        assert mux.classify(line) == CH_A1TRACE
+
+    def test_cortex_bracket_prefix(self) -> None:
+        mux = _make_mux()
+        assert mux.classify("[Cortex] PROACTIVE hedge: racing RT vs BATCH concurrently") == CH_CORTEX
+
+    def test_cortex_hedge_governor(self) -> None:
+        mux = _make_mux()
+        assert mux.classify("[Cortex] ⚡ HEDGE GOVERNOR: op needs Iron-Gate") == CH_CORTEX
+
+    def test_cortex_hedge_governor_standalone(self) -> None:
+        mux = _make_mux()
+        assert mux.classify("some text HEDGE GOVERNOR: blah") == CH_CORTEX
+
+    def test_ledger_terminal_applied(self) -> None:
+        mux = _make_mux()
+        line = "[Slice74Probe] LEDGER_TERMINAL op_id=xyz state=applied written=True"
+        assert mux.classify(line) == CH_LEDGER
+
+    def test_ledger_terminal_failed(self) -> None:
+        mux = _make_mux()
+        line = "[Slice74Probe] LEDGER_TERMINAL op_id=xyz state=failed written=False"
+        assert mux.classify(line) == CH_LEDGER
+
+    def test_other_line(self) -> None:
+        mux = _make_mux()
+        assert mux.classify("2026-06-27 INFO Some random log line") == CH_OTHER
+
+    def test_no_color_plain_output(self) -> None:
+        mux = _make_mux(no_color=True)
+        result = mux.format_line("[A1Trace] emit goal=abc123", 1.0)
+        assert result is not None
+        assert "[A1T|" in result
+        assert "\033[" not in result, "ANSI codes found when no_color=True"
+
+    def test_color_on_tty(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        mux = TelemetryMultiplexer(
+            channels={CH_A1TRACE, CH_CORTEX, CH_LEDGER},
+            no_color=False,
+        )
+        result = mux.format_line("[A1Trace] emit goal=abc123", 1.0)
+        assert result is not None
+        assert "\033[" in result, "Expected ANSI codes on TTY with color enabled"
+
+    def test_no_color_env_suppresses_ansi(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NO_COLOR", "1")
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        mux = TelemetryMultiplexer(
+            channels={CH_A1TRACE, CH_CORTEX, CH_LEDGER},
+            no_color=False,
+        )
+        result = mux.format_line("[A1Trace] emit goal=abc123", 1.0)
+        assert result is not None
+        assert "\033[" not in result, "ANSI leaked through NO_COLOR env"
+
+    def test_ledger_applied_is_green(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        mux = TelemetryMultiplexer(channels={CH_LEDGER}, no_color=False)
+        line = "[Slice74Probe] LEDGER_TERMINAL op_id=x state=applied written=True"
+        result = mux.format_line(line, 0.0)
+        assert result is not None
+        assert "\033[32m" in result, "Expected green (\\033[32m) for state=applied"
+
+    def test_ledger_failed_is_red(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setattr(sys.stdout, "isatty", lambda: True, raising=False)
+        monkeypatch.delenv("NO_COLOR", raising=False)
+        mux = TelemetryMultiplexer(channels={CH_LEDGER}, no_color=False)
+        line = "[Slice74Probe] LEDGER_TERMINAL op_id=x state=failed written=False"
+        result = mux.format_line(line, 0.0)
+        assert result is not None
+        assert "\033[31m" in result, "Expected red (\\033[31m) for state=failed"
+
+    def test_filtered_channel_returns_none(self) -> None:
+        mux = TelemetryMultiplexer(channels={CH_A1TRACE}, no_color=True)
+        result = mux.format_line("[Cortex] PROACTIVE hedge", 0.0)
+        assert result is None, "Expected None for filtered channel"
+
+    def test_is_terminal_sentinel_applied(self) -> None:
+        mux = _make_mux()
+        assert mux.is_terminal_sentinel(
+            "[Slice74Probe] LEDGER_TERMINAL op_id=x state=applied written=True"
+        )
+
+    def test_is_terminal_sentinel_failed(self) -> None:
+        mux = _make_mux()
+        assert mux.is_terminal_sentinel(
+            "[Slice74Probe] LEDGER_TERMINAL op_id=x state=failed written=False"
+        )
+
+    def test_is_terminal_sentinel_rolled_back(self) -> None:
+        mux = _make_mux()
+        assert mux.is_terminal_sentinel(
+            "[Slice74Probe] LEDGER_TERMINAL op_id=x state=rolled_back written=True"
+        )
+
+    def test_not_terminal_sentinel(self) -> None:
+        mux = _make_mux()
+        assert not mux.is_terminal_sentinel("[A1Trace] emit goal=abc123")
+
+
+# ===========================================================================
+# Test 2 — Byte-offset resume: no duplicate / no gap across reconnects
+# ===========================================================================
+
+async def test_byte_offset_resume() -> None:
+    """Second connection must request tail -c +<N+1> — exactly no dup, no gap."""
+    first_data = b"[A1Trace] emit goal=abc hop=1\n"
+    N = len(first_data)
+
+    recorded_cmds: List[List[str]] = []
+    call_count = 0
+
+    async def fake_runner(cmd: List[str]) -> AsyncGenerator[bytes, None]:
+        nonlocal call_count
+        call_count += 1
+        recorded_cmds.append(list(cmd))
+        if call_count == 1:
+            yield first_data
+            # EOF — connection ends cleanly
+        elif call_count == 2:
+            # Resume: yield terminal sentinel so the loop ends
+            yield (
+                b"[Slice74Probe] LEDGER_TERMINAL op_id=x state=applied written=True\n"
+            )
+
+    collected: List[str] = []
+
+    await stream_telemetry(
+        node="test-node",
+        zone="us-central1-a",
+        project="test-project",
+        remote_log_path="/home/jarvis/.ouroboros/sessions/abc/debug.log",
+        on_line=collected.append,
+        no_color=True,
+        max_reconnects=10,
+        _cmd_runner=fake_runner,
+        _sleep=_instant_sleep,
+    )
+
+    assert call_count == 2, f"expected exactly 2 connections, got {call_count}"
+
+    # --- First connection must start at 0-indexed offset 0 → tail -c +1 ---
+    first_remote = recorded_cmds[0][-1]   # last element is the --command value
+    assert "tail -c +1 " in first_remote, (
+        f"first cmd should be tail -c +1, got: {first_remote!r}"
+    )
+
+    # --- Second connection must resume at byte N → tail -c +(N+1) ---------
+    second_remote = recorded_cmds[1][-1]
+    expected_start = N + 1
+    assert f"tail -c +{expected_start} " in second_remote, (
+        f"expected tail -c +{expected_start} in second cmd, got: {second_remote!r}"
+    )
+
+    # IAP-SSH flags are present and non-hardcoded
+    assert "--tunnel-through-iap" in recorded_cmds[0]
+    assert "--project=test-project" in recorded_cmds[0]
+    assert "--zone=us-central1-a" in recorded_cmds[0]
+
+    # First connection's A1Trace line was received and emitted
+    assert any("A1T" in line for line in collected), (
+        f"A1Trace line not found in collected: {collected}"
+    )
+
+
+# ===========================================================================
+# Test 3 — Reconnect loop: fails twice then succeeds; exponential backoff
+# ===========================================================================
+
+async def test_reconnect_loop_fails_twice_then_succeeds() -> None:
+    """Bridge retries with exponential backoff on transport errors, never raises."""
+    call_count = 0
+
+    async def flaky_runner(cmd: List[str]) -> AsyncGenerator[bytes, None]:
+        nonlocal call_count
+        call_count += 1
+        if call_count <= 2:
+            raise ConnectionError(f"SSH connection refused (attempt {call_count})")
+        # Third attempt: succeed
+        yield b"[A1Trace] dequeue goal=test-goal\n"
+        yield b"[Slice74Probe] LEDGER_TERMINAL op_id=test-goal state=applied written=True\n"
+
+    slept: List[float] = []
+
+    async def recording_sleep(s: float) -> None:
+        slept.append(s)
+
+    collected: List[str] = []
+
+    # Must NOT raise even though the first 2 attempts fail
+    await stream_telemetry(
+        node="test-node",
+        zone="us-central1-a",
+        project="test-project",
+        remote_log_path="/tmp/debug.log",
+        on_line=collected.append,
+        no_color=True,
+        max_reconnects=10,
+        _cmd_runner=flaky_runner,
+        _sleep=recording_sleep,
+    )
+
+    # 3 attempts total (2 failures + 1 success)
+    assert call_count == 3, f"expected 3 attempts, got {call_count}"
+
+    # Exactly 2 backoff sleeps (one per failure)
+    assert len(slept) == 2, (
+        f"expected exactly 2 backoff sleeps (one per failure), got {len(slept)}: {slept}"
+    )
+
+    # Exponential: second sleep >= first sleep (jitter is bounded by 20%)
+    assert slept[1] >= slept[0], (
+        f"second backoff {slept[1]:.3f} not >= first {slept[0]:.3f} — not exponential"
+    )
+
+    # Both sleeps are positive and bounded
+    for s in slept:
+        assert 0.0 < s <= bridge._DEFAULT_BACKOFF_CAP_S + 1, (
+            f"sleep value out of bounds: {s}"
+        )
+
+    # A1Trace line was emitted from the successful third attempt
+    assert any("A1T" in line for line in collected), (
+        f"A1Trace line missing from collected: {collected}"
+    )
+
+
+# ===========================================================================
+# Test 4 — Read-only: stop_event tears down LOCAL bridge; remote never killed
+# ===========================================================================
+
+async def test_stop_event_exits_cleanly_without_remote_kill() -> None:
+    """stop_event exits the LOCAL bridge.  Remote soak is never signalled.
+
+    The test verifies:
+    1. The bridge exits cleanly (no exception) when stop_event is set.
+    2. No remote-kill method is invoked (there is no 'remote handle' in the
+       injection path — the guarantee is structural: only proc.kill() in the
+       production subprocess finally-block; the injection path has no proc).
+    3. At least some data was received before the stop.
+    """
+    stop_event = asyncio.Event()
+    chunk_count = 0
+
+    async def controlled_runner(cmd: List[str]) -> AsyncGenerator[bytes, None]:
+        nonlocal chunk_count
+        # Yields chunks; sets stop_event after the third chunk.
+        for _ in range(20):          # bounded so the test can't hang
+            chunk_count += 1
+            yield b"[A1Trace] emit goal=loop\n"
+            if chunk_count >= 3:
+                stop_event.set()
+            await asyncio.sleep(0)   # cooperative yield within the generator
+
+    collected: List[str] = []
+
+    # Bridge runs to completion (stop_event causes it to exit)
+    await stream_telemetry(
+        node="test-node",
+        zone="us-central1-a",
+        project="test-project",
+        remote_log_path="/tmp/debug.log",
+        on_line=collected.append,
+        no_color=True,
+        max_reconnects=0,   # no limit from reconnects
+        stop_event=stop_event,
+        _cmd_runner=controlled_runner,
+        _sleep=_instant_sleep,
+    )
+
+    # stop_event was the exit trigger
+    assert stop_event.is_set(), "stop_event should be set"
+
+    # At least some A1Trace lines were received before the bridge stopped
+    assert len(collected) >= 1, (
+        f"Expected at least 1 emitted line before stop, got 0"
+    )
+
+    # Generator ran at least 3 iterations before stop
+    assert chunk_count >= 3, f"Expected chunk_count >= 3, got {chunk_count}"
+
+    # No remote kill was invoked — verified by absence: in the injection path,
+    # no subprocess is created, so proc.kill() (the only kill in the module)
+    # is never reachable.  The bridge exited without raising proves this path.
+
+
+# ===========================================================================
+# Test 5 — Terminal sentinel ends loop cleanly
+# ===========================================================================
+
+async def test_terminal_sentinel_applied_ends_loop() -> None:
+    """LEDGER_TERMINAL state=applied causes a clean, immediate shutdown."""
+
+    async def terminal_runner(cmd: List[str]) -> AsyncGenerator[bytes, None]:
+        yield b"[A1Trace] emit goal=goal-1\n"
+        yield b"[A1Trace] ingest goal=goal-1\n"
+        yield b"[Cortex] PROACTIVE hedge: racing RT vs BATCH concurrently\n"
+        yield b"[Slice74Probe] LEDGER_TERMINAL op_id=goal-1 state=applied written=True\n"
+
+    collected: List[str] = []
+
+    await stream_telemetry(
+        node="test-node",
+        zone="us-central1-a",
+        project="test-project",
+        remote_log_path="/tmp/debug.log",
+        on_line=collected.append,
+        no_color=True,
+        max_reconnects=5,
+        _cmd_runner=terminal_runner,
+        _sleep=_instant_sleep,
+    )
+
+    a1t = [l for l in collected if "A1T" in l]
+    cor = [l for l in collected if "COR" in l]
+    led = [l for l in collected if "LED" in l]
+
+    assert len(a1t) >= 2, f"Expected >=2 A1Trace lines, got: {a1t}"
+    assert len(cor) >= 1, f"Expected >=1 Cortex line, got: {cor}"
+    assert len(led) == 1, f"Expected exactly 1 LEDGER line, got: {led}"
+    assert "state=applied" in led[0], f"LEDGER line missing state=applied: {led[0]}"
+
+
+# ===========================================================================
+# Test 6 — _build_tail_cmd: IAP-SSH command shape matches hypervisor
+# ===========================================================================
+
+class TestBuildTailCmd:
+    def test_offset_zero_starts_at_one(self) -> None:
+        """offset=0 → tail -c +1 (full file from byte 1, 1-indexed)."""
+        cmd = _build_tail_cmd(
+            "my-node", "us-central1-a", "my-project", "/tmp/debug.log", 0
+        )
+        assert cmd[0] == "gcloud"
+        assert cmd[1] == "compute"
+        assert cmd[2] == "ssh"
+        assert "my-node" in cmd
+        assert "--tunnel-through-iap" in cmd
+        assert "--project=my-project" in cmd
+        assert "--zone=us-central1-a" in cmd
+        assert cmd[-2] == "--command"
+        assert "tail -c +1 " in cmd[-1]
+
+    def test_nonzero_offset_resume(self) -> None:
+        """offset=N → tail -c +(N+1): 0-indexed local offset → 1-indexed tail arg."""
+        N = 12345
+        cmd = _build_tail_cmd("n", "z", "p", "/tmp/debug.log", N)
+        assert f"tail -c +{N + 1} " in cmd[-1], (
+            f"expected tail -c +{N + 1}, got: {cmd[-1]!r}"
+        )
+
+    def test_remote_path_is_shell_quoted(self) -> None:
+        """Paths with spaces or special chars are shell-quoted for safety."""
+        cmd = _build_tail_cmd("n", "z", "p", "/home/user/my log/debug.log", 0)
+        remote = cmd[-1]
+        # shlex.quote wraps the path in single quotes
+        assert "'/home/user/my log/debug.log'" in remote
+
+    def test_no_hardcoded_project_or_zone(self) -> None:
+        """project and zone come from args, not literals."""
+        cmd = _build_tail_cmd("nd", "custom-zone-99", "custom-project-abc", "/f", 0)
+        assert "--project=custom-project-abc" in cmd
+        assert "--zone=custom-zone-99" in cmd

--- a/tests/scripts/test_a1_telemetry_bridge.py
+++ b/tests/scripts/test_a1_telemetry_bridge.py
@@ -395,6 +395,118 @@ async def test_terminal_sentinel_applied_ends_loop() -> None:
 
 
 # ===========================================================================
+# Test M3-I1 — Split-line buffer: sentinel split across connections is detected
+# ===========================================================================
+
+async def test_split_line_buffer_sentinel_across_reconnects() -> None:
+    """I1: LEDGER_TERMINAL line split mid-word across two connections is
+    reassembled by the pending buffer and detected exactly once.
+
+    Connection 1 ends with a partial line (no newline).
+    Connection 2 starts with the completion of that line.
+    The bridge must stop cleanly after detecting the sentinel exactly once —
+    not miss it (old bug: each chunk classified independently so the sentinel
+    regex never matched a fragment) and not emit it twice.
+    """
+    call_count = 0
+
+    async def split_runner(cmd: List[str]) -> AsyncGenerator[bytes, None]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # First connection: partial sentinel — no trailing newline.
+            yield b"[A1Trace] x LEDGER_TER"
+        elif call_count == 2:
+            # Second connection: remainder of sentinel, completing the line.
+            yield b"MINAL op=o1 state=applied\n"
+
+    collected: List[str] = []
+
+    await stream_telemetry(
+        node="test-node",
+        zone="us-central1-a",
+        project="test-project",
+        remote_log_path="/tmp/debug.log",
+        on_line=collected.append,
+        no_color=True,
+        max_reconnects=10,
+        _cmd_runner=split_runner,
+        _sleep=_instant_sleep,
+    )
+
+    # Bridge must have made exactly 2 connections.
+    assert call_count == 2, f"expected 2 connections, got {call_count}"
+
+    # The reassembled line contains LEDGER_TERMINAL state=applied; is_terminal_sentinel
+    # fires, bridge exits.  The line is classified as A1TRACE (first match wins) so it
+    # appears in collected as an A1T entry — but sentinel detection is independent of
+    # channel classification, so exactly one line is emitted and the bridge stops.
+    assert len(collected) == 1, (
+        f"expected exactly 1 emitted line (the reassembled sentinel line), got: {collected}"
+    )
+    assert "LEDGER_TERMINAL" in collected[0] or "A1T" in collected[0], (
+        f"emitted line missing expected content: {collected[0]!r}"
+    )
+
+
+# ===========================================================================
+# Test M3-I2 — Consecutive-failure semantics: progress resets reconnect_count
+# ===========================================================================
+
+async def test_consecutive_failure_semantics_progress_resets_count() -> None:
+    """I2: reconnect_count resets on progress so idle polls between failures
+    don't exhaust max_reconnects.
+
+    Sequence:
+      conn 1 → no data (idle)    → reconnect_count becomes 1
+      conn 2 → data (progress)   → reconnect_count resets to 0  ← I2 fix
+      conn 3 → no data (idle)    → reconnect_count becomes 1
+      conn 4 → terminal sentinel → done
+
+    With max_reconnects=2, the bridge must survive all 4 connections.
+    Without the I2 fix, conn 3's idle would push count to 2, hitting the cap
+    and exiting before conn 4.
+    """
+    call_count = 0
+
+    async def runner(cmd: List[str]) -> AsyncGenerator[bytes, None]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 1:
+            # idle: empty generator (no data, no error)
+            return
+        if call_count == 2:
+            # progress: yield real data
+            yield b"[A1Trace] first hop\n"
+        if call_count == 3:
+            # idle again: empty
+            return
+        if call_count >= 4:
+            # terminal
+            yield b"[Slice74Probe] LEDGER_TERMINAL op_id=x state=applied written=True\n"
+
+    collected: List[str] = []
+
+    await stream_telemetry(
+        node="n",
+        zone="z",
+        project="p",
+        remote_log_path="/tmp/debug.log",
+        on_line=collected.append,
+        no_color=True,
+        max_reconnects=2,  # without I2, would exit after conn 3 (count hits 2)
+        _cmd_runner=runner,
+        _sleep=_instant_sleep,
+    )
+
+    assert call_count == 4, (
+        f"expected 4 connections (I2 fix allows progress to reset count), got {call_count}"
+    )
+    assert any("A1T" in l for l in collected), "A1Trace line missing from progress conn"
+    assert any("LED" in l for l in collected), "LEDGER terminal line missing"
+
+
+# ===========================================================================
 # Test 6 — _build_tail_cmd: IAP-SSH command shape matches hypervisor
 # ===========================================================================
 

--- a/tests/scripts/test_a1_zero_state_lock.py
+++ b/tests/scripts/test_a1_zero_state_lock.py
@@ -140,20 +140,36 @@ class TestOrphanWorktreeDir:
         assert result.pristine is False
         assert any("ouroboros__auto__bt-sess42" in d for d in result.deviations)
 
-    def test_unrelated_dir_under_worktrees_is_ignored(self, tmp_path):
-        """A non-orphan-prefix directory under .worktrees/ does NOT trigger."""
+    def test_unregistered_dir_under_worktrees_is_orphan(self, tmp_path):
+        """I4: any dir under .worktrees/ not in git worktree list is an orphan.
+
+        The old prefix-based filter let non-prefix dirs slip through pristine.
+        The set-difference approach catches ALL unregistered dirs regardless of
+        naming convention.
+        """
         repo = _init_repo(tmp_path)
-        legit = repo / ".worktrees" / "myproject-checkout"
-        legit.mkdir(parents=True)
+        unregistered = repo / ".worktrees" / "myproject-checkout"
+        unregistered.mkdir(parents=True)
         result = assert_pristine(repo, sweep=False)
-        # .worktrees/myproject-checkout is untracked by git → shows in status
-        # but is NOT in orphan_dirs.  It may or may not appear in status
-        # depending on git config, but the deviation list must not say
-        # "orphan_dir: myproject-checkout".
-        assert not any(
+        # myproject-checkout is not a registered worktree → it IS an orphan now.
+        assert result.pristine is False
+        assert any(
             "orphan_dir" in d and "myproject-checkout" in d
             for d in result.deviations
-        )
+        ), f"Expected orphan_dir deviation for myproject-checkout, got: {result.deviations}"
+
+    def test_i4_non_prefix_orphan_caught(self, tmp_path):
+        """I4: an orphan dir with no known prefix is caught by set-difference."""
+        repo = _init_repo(tmp_path)
+        # A dir name that would NOT match any of _ORPHAN_DIR_PREFIXES
+        orphan = repo / ".worktrees" / "completely-arbitrary-name-xyz"
+        orphan.mkdir(parents=True)
+        result = assert_pristine(repo, sweep=False)
+        assert result.pristine is False
+        assert any(
+            "orphan_dir" in d and "completely-arbitrary-name-xyz" in d
+            for d in result.deviations
+        ), f"Expected orphan_dir deviation but got: {result.deviations}"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/scripts/test_a1_zero_state_lock.py
+++ b/tests/scripts/test_a1_zero_state_lock.py
@@ -1,0 +1,298 @@
+# tests/scripts/test_a1_zero_state_lock.py
+"""
+TDD suite for scripts/a1_zero_state_lock.py — A1 Zero-State Lock.
+
+All tests use temporary git repositories (created via subprocess git init) so
+they never touch the live JARVIS repo.  WorktreeManager / _sweep are never
+invoked against a real repo; tests that check sweep behaviour use
+``sweep=False`` or patch ``_sweep`` directly.
+"""
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the scripts/ directory is importable regardless of PYTHONPATH.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR = str(Path(__file__).resolve().parent.parent.parent / "scripts")
+if _SCRIPTS_DIR not in sys.path:
+    sys.path.insert(0, _SCRIPTS_DIR)
+
+from a1_zero_state_lock import (  # noqa: E402
+    ZeroStateResult,
+    assert_pristine,
+    compute_state_digest,
+    main,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _init_repo(tmp_path: Path) -> Path:
+    """Create a minimal git repo with one initial commit in ``tmp_path``."""
+    run = lambda *args: subprocess.run(  # noqa: E731
+        list(args), cwd=str(tmp_path), check=True,
+        capture_output=True, text=True,
+    )
+    subprocess.run(["git", "init", str(tmp_path)], check=True, capture_output=True)
+    run("git", "config", "user.email", "test@example.com")
+    run("git", "config", "user.name", "Test Bot")
+    (tmp_path / "README.md").write_text("initial commit")
+    run("git", "add", "README.md")
+    run("git", "commit", "-m", "init")
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — clean repo is pristine, stable digest
+# ---------------------------------------------------------------------------
+
+class TestCleanRepo:
+    def test_assert_pristine_returns_pristine(self, tmp_path):
+        """A freshly initialised repo with one commit is pristine."""
+        repo = _init_repo(tmp_path)
+        result = assert_pristine(repo, sweep=False)
+        assert isinstance(result, ZeroStateResult)
+        assert result.pristine is True
+        assert result.deviations == []
+        assert result.actual_digest == result.expected_digest
+
+    def test_digest_is_64_hex_chars(self, tmp_path):
+        """compute_state_digest returns a valid SHA256 hex string."""
+        repo = _init_repo(tmp_path)
+        digest = compute_state_digest(repo)
+        assert len(digest) == 64
+        assert all(c in "0123456789abcdef" for c in digest)
+
+    def test_digest_is_stable_across_two_calls(self, tmp_path):
+        """Same clean state → same digest (determinism check)."""
+        repo = _init_repo(tmp_path)
+        d1 = compute_state_digest(repo)
+        d2 = compute_state_digest(repo)
+        assert d1 == d2
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — untracked file makes it NOT pristine
+# ---------------------------------------------------------------------------
+
+class TestUntrackedFile:
+    def test_untracked_file_not_pristine(self, tmp_path):
+        """An untracked file causes a deviation and pristine=False."""
+        repo = _init_repo(tmp_path)
+        (repo / "ghost.py").write_text("# ghost state")
+        result = assert_pristine(repo, sweep=False)
+        assert result.pristine is False
+        assert any("ghost.py" in d for d in result.deviations), (
+            f"Expected ghost.py in deviations but got: {result.deviations}"
+        )
+
+    def test_untracked_file_digest_differs(self, tmp_path):
+        """Digest with untracked file differs from clean-state digest."""
+        repo = _init_repo(tmp_path)
+        clean_digest = compute_state_digest(repo)
+        (repo / "ghost.py").write_text("# ghost state")
+        dirty_digest = compute_state_digest(repo)
+        assert clean_digest != dirty_digest
+
+    def test_staged_modification_not_pristine(self, tmp_path):
+        """A staged (but not committed) change is also not pristine."""
+        repo = _init_repo(tmp_path)
+        (repo / "README.md").write_text("modified")
+        subprocess.run(
+            ["git", "-C", str(repo), "add", "README.md"],
+            check=True, capture_output=True,
+        )
+        result = assert_pristine(repo, sweep=False)
+        assert result.pristine is False
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — orphan worktree dir under .worktrees/ makes it NOT pristine
+# ---------------------------------------------------------------------------
+
+class TestOrphanWorktreeDir:
+    def test_orphan_unit_dir_not_pristine(self, tmp_path):
+        """A unit- orphan directory under .worktrees/ is a deviation."""
+        repo = _init_repo(tmp_path)
+        orphan = repo / ".worktrees" / "unit-abc123"
+        orphan.mkdir(parents=True)
+        result = assert_pristine(repo, sweep=False)
+        assert result.pristine is False
+        assert any("unit-abc123" in d for d in result.deviations), (
+            f"Expected unit-abc123 in deviations but got: {result.deviations}"
+        )
+
+    def test_orphan_auto_bt_dir_not_pristine(self, tmp_path):
+        """An ouroboros__auto__bt- orphan dir is also caught."""
+        repo = _init_repo(tmp_path)
+        orphan = repo / ".worktrees" / "ouroboros__auto__bt-sess42"
+        orphan.mkdir(parents=True)
+        result = assert_pristine(repo, sweep=False)
+        assert result.pristine is False
+        assert any("ouroboros__auto__bt-sess42" in d for d in result.deviations)
+
+    def test_unrelated_dir_under_worktrees_is_ignored(self, tmp_path):
+        """A non-orphan-prefix directory under .worktrees/ does NOT trigger."""
+        repo = _init_repo(tmp_path)
+        legit = repo / ".worktrees" / "myproject-checkout"
+        legit.mkdir(parents=True)
+        result = assert_pristine(repo, sweep=False)
+        # .worktrees/myproject-checkout is untracked by git → shows in status
+        # but is NOT in orphan_dirs.  It may or may not appear in status
+        # depending on git config, but the deviation list must not say
+        # "orphan_dir: myproject-checkout".
+        assert not any(
+            "orphan_dir" in d and "myproject-checkout" in d
+            for d in result.deviations
+        )
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — .jarvis/chaos_manifest.json makes it NOT pristine
+# ---------------------------------------------------------------------------
+
+class TestChaosManifest:
+    def test_chaos_manifest_not_pristine(self, tmp_path):
+        """Presence of .jarvis/chaos_manifest.json is a deviation."""
+        repo = _init_repo(tmp_path)
+        jarvis_dir = repo / ".jarvis"
+        jarvis_dir.mkdir(exist_ok=True)
+        (jarvis_dir / "chaos_manifest.json").write_text(
+            json.dumps({"active": True, "session": "test-123"})
+        )
+        result = assert_pristine(repo, sweep=False)
+        assert result.pristine is False
+        assert any("chaos_manifest" in d for d in result.deviations), (
+            f"Expected chaos_manifest in deviations but got: {result.deviations}"
+        )
+
+    def test_chaos_manifest_gone_is_pristine(self, tmp_path):
+        """Removing the chaos manifest restores pristine state."""
+        repo = _init_repo(tmp_path)
+        jarvis_dir = repo / ".jarvis"
+        jarvis_dir.mkdir(exist_ok=True)
+        cm = jarvis_dir / "chaos_manifest.json"
+        cm.write_text("{}")
+        assert assert_pristine(repo, sweep=False).pristine is False
+        cm.unlink()
+        # .jarvis/ directory is still there but empty → may appear as untracked
+        # depending on git version; the chaos_manifest deviation must be gone.
+        result2 = assert_pristine(repo, sweep=False)
+        assert not any("chaos_manifest" in d for d in result2.deviations)
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — --no-sweep skips the reaper
+# ---------------------------------------------------------------------------
+
+class TestNoSweep:
+    def test_sweep_false_does_not_call_sweep(self, tmp_path):
+        """With sweep=False, the _sweep coroutine is never invoked."""
+        repo = _init_repo(tmp_path)
+        with patch("a1_zero_state_lock._sweep") as mock_sweep:
+            result = assert_pristine(repo, sweep=False)
+        mock_sweep.assert_not_called()
+        assert result.pristine is True
+
+    def test_sweep_true_calls_sweep(self, tmp_path):
+        """With sweep=True (default), _sweep IS called (even if it's a no-op)."""
+        repo = _init_repo(tmp_path)
+        # _sweep is async; patch it so it returns 0 without touching any real repo.
+        import asyncio
+
+        async def _fake_sweep(repo_root):  # noqa: ARG001
+            return 0
+
+        with patch("a1_zero_state_lock._sweep", side_effect=_fake_sweep) as mock_sweep:
+            result = assert_pristine(repo, sweep=True)
+        mock_sweep.assert_called_once_with(repo)
+        assert result.pristine is True
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — determinism: identical digest across multiple runs
+# ---------------------------------------------------------------------------
+
+class TestDeterminism:
+    def test_three_successive_digests_are_equal(self, tmp_path):
+        """compute_state_digest returns identical output on repeated calls."""
+        repo = _init_repo(tmp_path)
+        digests = [compute_state_digest(repo) for _ in range(3)]
+        assert len(set(digests)) == 1, (
+            f"Expected identical digests but got {digests}"
+        )
+
+    def test_expected_digest_tracks_head(self, tmp_path):
+        """After a new commit, the expected digest changes (it tracks HEAD)."""
+        repo = _init_repo(tmp_path)
+        result_before = assert_pristine(repo, sweep=False)
+
+        (repo / "newfile.py").write_text("# new")
+        subprocess.run(["git", "-C", str(repo), "add", "newfile.py"], check=True, capture_output=True)
+        subprocess.run(
+            ["git", "-C", str(repo), "commit", "-m", "second commit"],
+            check=True, capture_output=True,
+        )
+        result_after = assert_pristine(repo, sweep=False)
+
+        # Both should be pristine, but at different HEADs → different digests.
+        assert result_before.pristine is True
+        assert result_after.pristine is True
+        assert result_before.actual_digest != result_after.actual_digest
+
+
+# ---------------------------------------------------------------------------
+# Test — CLI (main()) return codes
+# ---------------------------------------------------------------------------
+
+class TestCLI:
+    def test_cli_returns_0_on_pristine(self, tmp_path):
+        """main() exits 0 and prints ZERO_STATE_ASSERTED for a clean repo."""
+        repo = _init_repo(tmp_path)
+        rc = main(["--repo-root", str(repo), "--no-sweep"])
+        assert rc == 0
+
+    def test_cli_returns_1_on_dirty(self, tmp_path, capsys):
+        """main() exits 1 for a non-pristine repo."""
+        repo = _init_repo(tmp_path)
+        (repo / "ghost.py").write_text("# ghost")
+        rc = main(["--repo-root", str(repo), "--no-sweep"])
+        assert rc == 1
+
+    def test_cli_json_output_pristine(self, tmp_path, capsys):
+        """--json flag emits a machine-readable JSON object with status=PRISTINE."""
+        repo = _init_repo(tmp_path)
+        rc = main(["--repo-root", str(repo), "--no-sweep", "--json"])
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert rc == 0
+        assert payload["status"] == "PRISTINE"
+        assert len(payload["expected"]) == 64
+        assert payload["deviations"] == []
+
+    def test_cli_json_output_not_pristine(self, tmp_path, capsys):
+        """--json flag lists deviations when repo is not pristine."""
+        repo = _init_repo(tmp_path)
+        (repo / "ghost.py").write_text("# ghost")
+        rc = main(["--repo-root", str(repo), "--no-sweep", "--json"])
+        captured = capsys.readouterr()
+        payload = json.loads(captured.out)
+        assert rc == 1
+        assert payload["status"] == "NOT_PRISTINE"
+        assert any("ghost.py" in d for d in payload["deviations"])
+
+    def test_cli_returns_2_on_bad_repo(self, tmp_path):
+        """main() exits 2 (fail-closed) when given a non-git directory."""
+        non_repo = tmp_path / "not_a_git_repo"
+        non_repo.mkdir()
+        rc = main(["--repo-root", str(non_repo), "--no-sweep"])
+        assert rc == 2


### PR DESCRIPTION
## A1 Cloud-Confirm Hardening — gap-closers Z + T

Closes the two partial constraints from the Autonomous Launch Matrix so the cloud confirm fully honors the operator's safety + observability requirements. **Composes existing machinery** (no new logger, no hardcoded SHA, no duplicate launcher) — the cloud-confirm entry point remains `a1_live_fire_chaos_harness.py --remote`.

> **PR C of 3** — file-disjoint from PR A (#69736) + PR B (#69737); merges cleanly in any order.

### Gap-Closer Z — Cryptographic Pristine Lock (`scripts/a1_zero_state_lock.py`)
A hard gate (rc≠0 ABORTs the launch) that **sweeps orphaned worktrees** (reuses `WorktreeManager.reap_orphans`, async) then computes a **deterministic SHA256 over the ENTIRE working-tree state** — HEAD + porcelain (incl. all untracked) + registered worktrees + on-disk `.worktrees/` orphans (by **set-difference vs registered**, not prefix-match — catches any-named ghost dir even though `.worktrees/` is gitignored) + chaos-manifest presence — and asserts it equals the **computed pristine baseline** for this HEAD. **No hardcoded SHA** (baseline derived from live HEAD; rotates per commit). **Fail-closed**: any error → ABORT, never a false "pristine." Emits `ZERO_STATE_ASSERTED sha=…` or `ZERO_STATE_ABORT … deviations=[…]`.

### Gap-Closer T — Resilient Multiplexed Telemetry Bridge (`scripts/a1_telemetry_bridge.py`)
Watch the real LLM's multi-turn exploration live. An **async fault-tolerant reconnect loop** over IAP-SSH (reuses the hypervisor's command shape + byte-offset tailer) that **resumes from the last byte-offset** across drops (no loss, no dup), buffers partial lines **across chunks and reconnects**, and **multiplexes** `[A1Trace]` (cyan) / `[Cortex]`+`HEDGE GOVERNOR` (yellow) / `LEDGER_TERMINAL` (green=applied, red=else) into one color-coded local stream (honors `NO_COLOR`/non-tty). **Read-only** — a local Ctrl-C tears down only the local ssh child, **never the remote soak**. Consecutive-failure reconnect budget + deadline; clean stop on the terminal sentinel.

### Runbook (`docs/runbooks/a1_cloud_confirm.md`)
The full launch sequence: $0 dry-run → Z hard gate → start T → fire (with the corrected, **contiguous** safety-gate env chain). Documents the existing quadruple-teardown dead-man + cost/wall caps.

### Review
Final whole-branch review (opus) → **SHIP-AFTER-FIXES**; all findings fixed:
- **C1 (Critical)**: runbook `VAR=x \` + inline `# comment` silently dropped EVERY safety-gate env var (would've launched real-money with Claude unguarded) → comments moved off the chain.
- **I1–I4**: bridge line-buffer across reconnects; consecutive-failure reconnect semantics; runbook `--zone/--project` + absolute `--remote-log`; orphan-dir set-difference completeness.
- **M1–M3**: callback type hint; sweep-count observability to stderr; added split-line-across-reconnect + reconnect-reset tests.

**49 tests green** (Z: 21, T: 28). Each module is standalone + self-tested; integrity hooks ✓.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a cryptographic zero-state lock and a resilient, read-only telemetry bridge for A1 cloud-confirm runs, plus a runbook. Blocks launches from non‑pristine repos and provides lossless, color-coded live logs across network drops.

- **New Features**
  - `scripts/a1_zero_state_lock.py`: Computes a deterministic SHA256 over the full working tree (HEAD, porcelain incl. untracked, registered worktrees, `.worktrees/` orphans via set‑difference, chaos manifest). Runs `WorktreeManager.reap_orphans` first, has JSON output, no hardcoded SHA, and fails closed on errors.
  - `scripts/a1_telemetry_bridge.py`: IAP‑SSH byte‑offset resume with fault‑tolerant reconnects (consecutive‑failure semantics) and line buffering across reconnects. Multiplexes `[A1Trace]`, `[Cortex]`/`HEDGE GOVERNOR`, and `LEDGER_TERMINAL` with color (honors `NO_COLOR`); read‑only; clean stop on terminal sentinel.
  - Runbook `docs/runbooks/a1_cloud_confirm.md`: Dry‑run → Z gate → start bridge → fire. Fixes env chain comments bug, and documents `--zone`/`--project` or `GCP_ZONE`/`GCP_PROJECT`, and absolute `--remote-log`.

- **Migration**
  - Gate every real run with: `python3 scripts/a1_zero_state_lock.py`; abort on non‑zero rc.
  - Start the bridge in a side terminal before launch: `python3 scripts/a1_telemetry_bridge.py --node <node> --zone <zone> --project <project> --remote-log /opt/trinity/jarvis/.ouroboros/sessions/<id>/debug.log`.
  - Set `GCP_ZONE`/`GCP_PROJECT` or pass flags; use an absolute `--remote-log`; keep comments off env backslash chains.

<sup>Written for commit 047aab5515d0cc4ac125b44e4e802e825886d76e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69738?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

