### PR TITLE
fix(a1): AutoCommitter durable-apply (dead-cwd) + failover-pin + infra teardown (PR F)

### DIFF
--- a/.hypervisor_state.json
+++ b/.hypervisor_state.json
@@ -1,0 +1,30 @@
+{
+  "external_ip": "",
+  "node_name": "sovereign-sandbox-20260628-030804",
+  "phases": {
+    "booted": {
+      "status": "complete",
+      "ts": "2026-06-28T10:10:21Z"
+    },
+    "docker_ready": {
+      "status": "complete",
+      "ts": "2026-06-28T10:09:45Z"
+    },
+    "prebaked": {
+      "status": "complete",
+      "ts": "2026-06-28T10:10:21Z"
+    },
+    "provisioned": {
+      "status": "complete",
+      "ts": "2026-06-28T10:08:20Z"
+    },
+    "synced": {
+      "status": "complete",
+      "ts": "2026-06-28T10:10:21Z"
+    }
+  },
+  "project": "jarvis-473803",
+  "run_id": "20260628-030804",
+  "updated": "2026-06-28T10:10:21Z",
+  "zone": "us-central1-a"
+}

--- a/A1_LAUNCH_MANIFEST.json
+++ b/A1_LAUNCH_MANIFEST.json
@@ -1,0 +1,10 @@
+{
+  "schema_version": "a1-launch.1",
+  "model": "Qwen/Qwen3.5-397B-A17B-FP8",
+  "native_tool_forcing": true,
+  "epistemic_feedback": true,
+  "seed": 42,
+  "cost_cap": 2.0,
+  "max_wall_seconds": 2400,
+  "generated_for": "2026-06-28T10:08:04.624905Z"
+}

--- a/backend/core/ouroboros/governance/auto_committer.py
+++ b/backend/core/ouroboros/governance/auto_committer.py
@@ -248,7 +248,28 @@ class AutoCommitter:
         """
         override = os.environ.get("JARVIS_AUTO_COMMIT_WORKSPACE")
         if override:
-            return Path(override)
+            override_path = Path(override)
+            # A1 dead-cwd fix: a stale / never-created worktree override (e.g.
+            # a branch-named path ``.worktrees/ouroboros/auto/...`` the producer
+            # never materialized, or whose on-disk dir is the ``__``-mangled
+            # form) makes EVERY git subprocess in this class fail with
+            # ``fatal: cannot change to '<path>'`` (exit 128). The op then
+            # reaches APPLIED in memory but never durably commits -> ledger
+            # ``written=False`` -> the A1 auditor's ``fsm_classify_to_applied``
+            # stays False. Validate the override is a real, usable git working
+            # tree before adopting it; otherwise fall back to the main checkout
+            # so the commit still lands durably rather than dying on a dead
+            # cwd. Fail-safe, never raises.
+            try:
+                if override_path.is_dir() and (override_path / ".git").exists():
+                    return override_path
+            except OSError:  # noqa: BLE001 — unreadable path -> fall back
+                pass
+            logger.warning(
+                "[AutoCommitter] workspace override invalid (%s) -- falling "
+                "back to repo_root (commit lands durably in the main checkout)",
+                override,
+            )
         return self._repo_root
 
     def _assert_commit_target_sovereign(self) -> None:

--- a/scripts/a1_launch_manifest.py
+++ b/scripts/a1_launch_manifest.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 SCHEMA_VERSION = "a1-launch.1"
-REQUIRED_KEYS = {"schema_version", "model", "native_tool_forcing", "epistemic_feedback"}
+REQUIRED_KEYS = {"schema_version", "model", "native_tool_forcing", "epistemic_feedback", "failover_lifecycle"}
 
 
 class A1ManifestError(Exception):
@@ -34,6 +34,7 @@ def build_manifest(
     model: str,
     native_tool_forcing: bool,
     epistemic_feedback: bool,
+    failover_lifecycle: bool = False,
     seed: Optional[int] = None,
     cost_cap: Optional[float] = None,
     max_wall_seconds: Optional[int] = None,
@@ -45,6 +46,7 @@ def build_manifest(
         "model": model,
         "native_tool_forcing": native_tool_forcing,
         "epistemic_feedback": epistemic_feedback,
+        "failover_lifecycle": failover_lifecycle,
     }
     if seed is not None:
         core["seed"] = seed
@@ -96,6 +98,10 @@ def apply_manifest(manifest: Dict[str, Any], env: Dict[str, str]) -> Dict[str, s
         env["JARVIS_DW_NATIVE_TOOL_FORCING_ENABLED"] = "true"
     if manifest.get("epistemic_feedback"):
         env["JARVIS_EPISTEMIC_FEEDBACK_ENABLED"] = "true"
+    # Deterministic failover-lifecycle pin: always written (true/false), never absent.
+    # Prevents the shell-var-propagation gap that let JARVIS_FAILOVER_LIFECYCLE_ENABLED
+    # default to "true" on the node and spawn J-Prime mid-soak.
+    env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] = "true" if manifest.get("failover_lifecycle") else "false"
     if manifest.get("seed") is not None:
         env["JARVIS_CHAOS_SEED"] = str(manifest["seed"])
     if manifest.get("cost_cap") is not None:

--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -84,6 +84,13 @@ _OMNI_ENV_OVERLAY = os.path.join(_REPO_ROOT, "deploy", "ouroboros_omni_prod.env"
 # Cost model for the remote node (e2-standard-8 Spot ~ $0.08/hr; see hypervisor).
 _NODE_COST_PER_HOUR = float(os.environ.get("JARVIS_A1_NODE_COST_PER_HOUR", "0.08"))
 
+# Grace added to the soak wall when computing the GCP --max-run-duration ceiling
+# (infra-level, GIL-immune hard stop: GCP kills the VM when soak_wall + grace elapses).
+# Shared by both the --surgery-timeout-s and --max-run-duration-s so they stay
+# consistent (surgery timeout = Python soft bound; max-run-duration = GCP hard kill).
+# Respects the Slice-47 watchdog-isolation invariant: reads only time, no op-ledger.
+_WALL_CLOCK_GRACE_S = int(os.environ.get("JARVIS_A1_WALL_GRACE_S", "600"))
+
 
 def _load_auditor_module():
     """Import the auditor as a module (reuse its CADENCE_POLICY flag loader,
@@ -269,6 +276,7 @@ def compose_env(*, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         model="Qwen/Qwen3.5-397B-A17B-FP8",
         native_tool_forcing=True,
         epistemic_feedback=True,
+        failover_lifecycle=False,
     )
     apply_manifest(_a1_manifest, env)
     return env
@@ -1197,7 +1205,14 @@ def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
         sys.executable, _HYPERVISOR_SCRIPT,
         "--execute", "--i-understand-this-spends-money",
         "--surgery-cmd", remote_cmd,
-        "--surgery-timeout-s", str(wall_seconds + 600),
+        "--surgery-timeout-s", str(wall_seconds + _WALL_CLOCK_GRACE_S),
+        # GCP hard ceiling: soak wall + grace. Infra-level, GIL-immune.
+        # The Python watchdog thread can be starved; GCP kills the VM regardless.
+        # Grace matches --surgery-timeout-s so the Python soft bound fires first
+        # (clean summary.json), then GCP hard-stops if the process refuses to die.
+        # Respects Slice-47 watchdog-isolation: GCP reads only the clock, never
+        # the orchestrator op-ledger.
+        "--max-run-duration-s", str(wall_seconds + _WALL_CLOCK_GRACE_S),
     ]
     # --on-demand pass-through (env-gated): provision a STANDARD (no Spot
     # preemption) node for an uninterrupted multi-stage run when the operator
@@ -1224,6 +1239,7 @@ def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
         model="Qwen/Qwen3.5-397B-A17B-FP8",
         native_tool_forcing=True,
         epistemic_feedback=True,
+        failover_lifecycle=False,
         seed=seed,
         cost_cap=cost_cap,
         max_wall_seconds=wall_seconds,

--- a/tests/governance/test_auto_committer_effective_root.py
+++ b/tests/governance/test_auto_committer_effective_root.py
@@ -1,0 +1,69 @@
+"""Regression for the A1 dead-cwd fix in ``AutoCommitter._effective_repo_root``.
+
+The cloud A1 run reached ``state=applied`` but the ledger recorded
+``written=False`` because ``JARVIS_AUTO_COMMIT_WORKSPACE`` pointed at a
+worktree path that did not exist (a branch-named ``.worktrees/ouroboros/auto/...``
+the producer never materialized). Every git subprocess then died with
+``fatal: cannot change to '<path>'`` (exit 128), so APPLIED never durably
+committed and the auditor's ``fsm_classify_to_applied`` stayed False.
+
+The fix: validate the override is a real, usable git working tree; otherwise
+fall back to ``repo_root`` so the commit still lands durably. Fail-safe.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from backend.core.ouroboros.governance.auto_committer import AutoCommitter
+
+_ENV = "JARVIS_AUTO_COMMIT_WORKSPACE"
+
+
+def _ac(repo_root: Path) -> AutoCommitter:
+    ac = AutoCommitter.__new__(AutoCommitter)  # bypass __init__ — unit-isolate
+    ac._repo_root = repo_root
+    return ac
+
+
+def test_unset_override_returns_repo_root(monkeypatch, tmp_path):
+    monkeypatch.delenv(_ENV, raising=False)
+    ac = _ac(tmp_path)
+    assert ac._effective_repo_root() == tmp_path
+
+
+def test_nonexistent_override_falls_back_to_repo_root(monkeypatch, tmp_path):
+    # The exact A1 failure: a worktree path that was never created.
+    monkeypatch.setenv(_ENV, str(tmp_path / ".worktrees" / "ouroboros" / "nope"))
+    ac = _ac(tmp_path)
+    assert ac._effective_repo_root() == tmp_path  # fail-safe fallback
+
+
+def test_existing_dir_without_git_falls_back(monkeypatch, tmp_path):
+    # Exists + is a dir but is NOT a git worktree -> git ops would fail -> fall back.
+    plain = tmp_path / "plain_dir"
+    plain.mkdir()
+    monkeypatch.setenv(_ENV, str(plain))
+    ac = _ac(tmp_path)
+    assert ac._effective_repo_root() == tmp_path
+
+
+def test_valid_git_worktree_override_is_used(monkeypatch, tmp_path):
+    # A real git working tree (has a .git entry) -> adopted as the cwd.
+    wt = tmp_path / "wt"
+    wt.mkdir()
+    (wt / ".git").write_text("gitdir: /somewhere/.git/worktrees/wt\n")
+    monkeypatch.setenv(_ENV, str(wt))
+    ac = _ac(tmp_path)
+    assert ac._effective_repo_root() == wt
+
+
+def test_file_dot_git_worktree_form_is_accepted(monkeypatch, tmp_path):
+    # Git worktrees use a .git FILE (not dir); the check must accept both.
+    wt = tmp_path / "wt2"
+    (wt / ".git").parent.mkdir(parents=True, exist_ok=True)
+    wt.mkdir(exist_ok=True)
+    (wt / ".git").mkdir()  # bare .git dir form (main checkout)
+    monkeypatch.setenv(_ENV, str(wt))
+    ac = _ac(tmp_path)
+    assert ac._effective_repo_root() == wt

--- a/tests/scripts/test_a1_launch_manifest.py
+++ b/tests/scripts/test_a1_launch_manifest.py
@@ -209,6 +209,102 @@ def test_apply_manifest_returns_mutated_env():
 
 
 # ===========================================================================
+# failover_lifecycle: required key, apply writes JARVIS_FAILOVER_LIFECYCLE_ENABLED
+# ===========================================================================
+
+
+def test_build_manifest_failover_lifecycle_default_false():
+    """build_manifest includes failover_lifecycle=False by default."""
+    m = build_manifest(model="x", native_tool_forcing=True, epistemic_feedback=True)
+    assert "failover_lifecycle" in m
+    assert m["failover_lifecycle"] is False
+
+
+def test_build_manifest_failover_lifecycle_explicit_false():
+    """build_manifest(failover_lifecycle=False) is explicit and present."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        failover_lifecycle=False,
+    )
+    assert m["failover_lifecycle"] is False
+
+
+def test_build_manifest_failover_lifecycle_true():
+    """build_manifest(failover_lifecycle=True) round-trips correctly."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        failover_lifecycle=True,
+    )
+    assert m["failover_lifecycle"] is True
+
+
+def test_apply_manifest_failover_lifecycle_false():
+    """apply_manifest sets JARVIS_FAILOVER_LIFECYCLE_ENABLED=false when flag is False."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        failover_lifecycle=False,
+    )
+    env: dict = {}
+    apply_manifest(m, env)
+    assert env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] == "false"
+
+
+def test_apply_manifest_failover_lifecycle_true():
+    """apply_manifest sets JARVIS_FAILOVER_LIFECYCLE_ENABLED=true when flag is True."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        failover_lifecycle=True,
+    )
+    env: dict = {}
+    apply_manifest(m, env)
+    assert env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] == "true"
+
+
+def test_load_and_validate_requires_failover_lifecycle(tmp_path):
+    """Manifest missing failover_lifecycle -> A1ManifestError (missing required keys)."""
+    p = tmp_path / "no_failover.json"
+    p.write_text(json.dumps({
+        "schema_version": SCHEMA_VERSION,
+        "model": "x",
+        "native_tool_forcing": True,
+        "epistemic_feedback": True,
+        # failover_lifecycle intentionally omitted
+    }))
+    with pytest.raises(A1ManifestError, match="missing required keys"):
+        load_and_validate(p)
+
+
+def test_round_trip_includes_failover_lifecycle(tmp_path):
+    """build -> write -> load_and_validate preserves failover_lifecycle."""
+    m = build_manifest(
+        model="Qwen/Qwen3.5-397B-A17B-FP8",
+        native_tool_forcing=True,
+        epistemic_feedback=True,
+        failover_lifecycle=False,
+    )
+    p = tmp_path / "A1_LAUNCH_MANIFEST.json"
+    write_manifest(p, m)
+    loaded = load_and_validate(p)
+    assert loaded["failover_lifecycle"] is False
+
+
+def test_apply_manifest_failover_always_written():
+    """apply_manifest writes JARVIS_FAILOVER_LIFECYCLE_ENABLED whether True or False
+    (never absent -- prevents the default=true node gap)."""
+    for flag_val in (True, False):
+        m = build_manifest(
+            model="x", native_tool_forcing=False, epistemic_feedback=False,
+            failover_lifecycle=flag_val,
+        )
+        env: dict = {}
+        apply_manifest(m, env)
+        assert "JARVIS_FAILOVER_LIFECYCLE_ENABLED" in env, (
+            "JARVIS_FAILOVER_LIFECYCLE_ENABLED must always be present in env "
+            "(prevents node default=true gap)"
+        )
+
+
+# ===========================================================================
 # compose_env compat: the 3 flag keys must appear via apply_manifest
 # ===========================================================================
 
@@ -233,6 +329,11 @@ def test_compose_env_compat():
         )
         assert "JARVIS_EPISTEMIC_FEEDBACK_ENABLED" in env, (
             "compose_env must set JARVIS_EPISTEMIC_FEEDBACK_ENABLED via apply_manifest"
+        )
+        # Failover must be deterministically pinned OFF by the A1 manifest.
+        assert env.get("JARVIS_FAILOVER_LIFECYCLE_ENABLED") == "false", (
+            "compose_env must pin JARVIS_FAILOVER_LIFECYCLE_ENABLED=false via apply_manifest "
+            "(prevents J-Prime spawn mid-soak when the shell var does not propagate)"
         )
     except Exception as exc:
         pytest.skip("compose_env import requires full harness setup: %s" % exc)


### PR DESCRIPTION
## Clear the last plumbing layer to A1-green

Cloud Confirm 3 proved the **cognitive loop works** — Qwen explored (5 read_file + 5 search_code) and reached `state=applied`. But APPLIED never **durably committed** (ledger `written=False`), so the auditor's `fsm_classify_to_applied` stayed False. Root cause + two infra hardenings here.

### The A1 blocker — AutoCommitter dead-cwd
`AutoCommitter._effective_repo_root()` returned `JARVIS_AUTO_COMMIT_WORKSPACE` verbatim with no existence check. A stale/never-created worktree override → every git subprocess `fatal: cannot change to '<path>'` (exit 128) → applied-in-memory but not committed → `written=False`. **Fix:** validate the override is a real git working tree; **fail-safe fallback to `repo_root`** so the commit always lands durably. (5 regression tests.)

> The cloud `gitignore guard refused requirements.txt` was a **downstream symptom** of this dead-cwd (the guard ran inside the broken worktree) — NOT a guard bug. `requirements.txt` is tracked + matched by no `.gitignore` rule. The load-bearing guard is left **intact** (a rejected attempt to weaken it was discarded).

### Two infra hardenings
- **Failover pinned OFF via the launch manifest** — DW degraded mid-soak → the Sovereign Failover Lifecycle auto-spun J-Prime nodes (cost + 16 failures). The shell pin didn't propagate; now deterministic via the manifest (`failover_lifecycle: false`).
- **GCP `--max-run-duration` = soak-wall + grace** — the Python wall-watchdog was GIL-starvable and the run overran. Now the GCP-enforced ceiling tracks the soak wall (infra-level, GIL-immune, respects the Slice-47 watchdog-isolation invariant).

**Tests:** manifest + AutoCommitter suites green. (Note: 5 *pre-existing* failures in `test_auto_committer_gitignore_guard.py` on main are unrelated to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes durable apply by validating `JARVIS_AUTO_COMMIT_WORKSPACE` and falling back to the main repo when invalid. Pins failover off via the launch manifest and adds a GCP run-duration ceiling to ensure clean teardown.

- **Bug Fixes**
  - `AutoCommitter._effective_repo_root`: verify override is a real git worktree (`.git` present); otherwise warn and use `_repo_root`. Prevents dead CWD (exit 128) and ensures commits land durably.
  - Added regression tests for valid/invalid overrides.

- **New Features**
  - Launch manifest now includes required `failover_lifecycle`; `apply_manifest` always writes `JARVIS_FAILOVER_LIFECYCLE_ENABLED` (true/false), default pinned to false to stop mid-soak failover spawns.
  - Chaos harness enforces `--max-run-duration-s = wall + grace` and aligns `--surgery-timeout-s` using `_WALL_CLOCK_GRACE_S` for deterministic teardown (GIL-immune).
  - Added `A1_LAUNCH_MANIFEST.json` and `.hypervisor_state.json` for launch config and hypervisor state tracking.

<sup>Written for commit f216467dd1daa2e66ca94ea3e01ae766163690a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

