### PR TITLE
feat(iac): true-immutable soak golden image + autonomous OrphanReaper (PR H)

### DIFF
--- a/scripts/a1_orphan_reaper.py
+++ b/scripts/a1_orphan_reaper.py
@@ -1,0 +1,487 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Autonomous out-of-band OrphanReaper -- continuously reaps soak/bake GCP
+nodes lacking an active local lease (closes the interrupted-launcher zombie
+blindspot).
+
+Lease model: local file .jarvis/iac_leases/<node>.lease with JSON:
+  {"node": str, "zone": str, "pid": int, "expires_ts": float}
+
+A node is reaped when:
+  * no lease file exists                        (reason=no-lease)
+  * lease file exists but expires_ts < now()    (reason=expired)
+  * lease file exists but owning pid is dead    (reason=dead-pid)
+
+A node is NEVER reaped when:
+  * its local lease is valid (pid alive + not expired), OR
+  * it is within the boot-grace window (creation age < boot_grace_s) --
+    freshly-created nodes may not have had time to register a lease.
+
+All gcloud calls funnel through injectable lister/deleter so tests can
+substitute fakes and pay $0.
+
+Default-ON when the master gate is set (JARVIS_ORPHAN_REAPER_ENABLED=true).
+Async-first; asyncio.wait_for everywhere (Python 3.9+; never asyncio.timeout).
+
+Usage:
+    # watch loop (120 s interval by default):
+    JARVIS_ORPHAN_REAPER_ENABLED=1 python3 scripts/a1_orphan_reaper.py --watch
+
+    # single pass:
+    python3 scripts/a1_orphan_reaper.py --once
+
+    # dry-run (print what WOULD be reaped, delete nothing):
+    python3 scripts/a1_orphan_reaper.py --once --dry-run
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import datetime as _dt
+import json
+import logging
+import os
+import pathlib
+import time
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Repo root.
+# --------------------------------------------------------------------------- #
+_REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# --------------------------------------------------------------------------- #
+# Node-name prefixes -- ONE canonical definition, never duplicated.
+# Derived from:
+#   autonomous_omni_launcher._SOAK_NODE_PREFIX  = "sovereign-sandbox-"
+#   autonomous_omni_launcher._BAKE_NODE_PREFIX  = "jarvis-soak-bake-"
+#   sovereign_iac_hypervisor node_name()        = "sovereign-sandbox-<stamp>"
+# Plus the plain soak ("jarvis-soak-") and bake ("jarvis-bake-") variants
+# used by independent provisioners.
+# --------------------------------------------------------------------------- #
+NODE_PREFIXES: Tuple[str, ...] = (
+    "sovereign-sandbox-",
+    "jarvis-soak-",
+    "jarvis-bake-",
+    "jarvis-soak-bake-",
+)
+
+# --------------------------------------------------------------------------- #
+# Env-var driven config -- every tunable reads from env with a sensible default.
+# --------------------------------------------------------------------------- #
+_DEFAULT_PROJECT: str = os.environ.get("GCP_PROJECT", "jarvis-473803")
+_DEFAULT_ZONE: str = os.environ.get("GCP_ZONE", "us-central1-a")
+_DEFAULT_INTERVAL_S: int = int(os.environ.get("JARVIS_ORPHAN_REAPER_INTERVAL_S", "120"))
+_DEFAULT_BOOT_GRACE_S: int = int(os.environ.get("JARVIS_ORPHAN_REAPER_BOOT_GRACE_S", "300"))
+_DEFAULT_LEASE_TTL_S: int = int(os.environ.get("JARVIS_ORPHAN_REAPER_LEASE_TTL_S", "600"))
+_GCLOUD_TIMEOUT_S: float = float(os.environ.get("JARVIS_ORPHAN_REAPER_GCLOUD_TIMEOUT_S", "60"))
+
+_DEFAULT_LEASE_DIR: pathlib.Path = _REPO_ROOT / ".jarvis" / "iac_leases"
+
+# --------------------------------------------------------------------------- #
+# Logging -- a module-level logger; caller can configure level/handler.
+# --------------------------------------------------------------------------- #
+log = logging.getLogger("a1_orphan_reaper")
+if not log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("[%(name)s] %(message)s"))
+    log.addHandler(_h)
+log.setLevel(logging.INFO)
+
+
+def _env_truthy(name: str, default: str = "false") -> bool:
+    return os.environ.get(name, default).strip().lower() in ("1", "true", "yes", "on")
+
+
+# --------------------------------------------------------------------------- #
+# Default gcloud lister -- asyncio.create_subprocess_exec, never shell=True.
+# --------------------------------------------------------------------------- #
+async def _default_instance_lister(
+    project: str,
+    prefixes: Tuple[str, ...],
+) -> List[Dict[str, Any]]:
+    """List GCP instances whose names start with any of *prefixes*.
+
+    Returns a list of {name, zone, creationTimestamp} dicts.
+    Fail-soft: any error (network, auth, gcloud absent) yields [] and logs a
+    warning -- the caller will simply find nothing to reap this pass.
+    """
+    # One regex alternation covers all prefixes in a single API call.
+    alt = "|".join(f"^{p}" for p in prefixes)
+    filter_str = f"name~({alt})"
+    cmd: List[str] = [
+        "gcloud", "compute", "instances", "list",
+        f"--project={project}",
+        f"--filter={filter_str}",
+        "--format=json(name,zone,creationTimestamp)",
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        stdout, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_GCLOUD_TIMEOUT_S
+        )
+        if proc.returncode != 0:
+            log.warning(
+                "instance lister rc=%d: %s",
+                proc.returncode,
+                stderr.decode(errors="replace")[:300],
+            )
+            return []
+        raw = stdout.decode(errors="replace").strip()
+        if not raw:
+            return []
+        instances: List[Dict[str, Any]] = json.loads(raw)
+        result: List[Dict[str, Any]] = []
+        for inst in instances:
+            name: str = inst.get("name", "")
+            if not any(name.startswith(p) for p in prefixes):
+                continue
+            zone_raw: str = inst.get("zone", "")
+            zone = zone_raw.rsplit("/", 1)[-1] if "/" in zone_raw else zone_raw
+            result.append(
+                {
+                    "name": name,
+                    "zone": zone,
+                    "creationTimestamp": inst.get("creationTimestamp", ""),
+                }
+            )
+        return result
+    except Exception as exc:  # noqa: BLE001
+        log.warning("instance lister raised (fail-soft): %r", exc)
+        return []
+
+
+# --------------------------------------------------------------------------- #
+# Default gcloud deleter -- asyncio.create_subprocess_exec, never shell=True.
+# --------------------------------------------------------------------------- #
+async def _default_instance_deleter(project: str, node: str, zone: str) -> None:
+    """Delete a single GCP instance and all its disks. Fail-soft: never raises.
+
+    Mirrors the hypervisor's reap idiom:
+        gcloud compute instances delete <node> --delete-disks=all --quiet
+    """
+    cmd: List[str] = [
+        "gcloud", "compute", "instances", "delete", node,
+        f"--project={project}",
+        f"--zone={zone}",
+        "--delete-disks=all",
+        "--quiet",
+    ]
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *cmd,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+        )
+        _, stderr = await asyncio.wait_for(
+            proc.communicate(), timeout=_GCLOUD_TIMEOUT_S
+        )
+        if proc.returncode != 0:
+            log.warning(
+                "delete %s rc=%d: %s",
+                node,
+                proc.returncode,
+                stderr.decode(errors="replace")[:300],
+            )
+    except Exception as exc:  # noqa: BLE001
+        log.warning("delete %s raised (fail-soft): %r", node, exc)
+
+
+# --------------------------------------------------------------------------- #
+# Lease helpers (pure functions -- no class dependency).
+# --------------------------------------------------------------------------- #
+def _lease_path(lease_dir: pathlib.Path, node: str) -> pathlib.Path:
+    """Return the lease file path for *node*.
+
+    Sanitises the node name to prevent path traversal (only alnum + hyphen +
+    underscore + dot are allowed in a GCP instance name anyway).
+    """
+    safe = "".join(c for c in node if c.isalnum() or c in "-_.")
+    return lease_dir / f"{safe}.lease"
+
+
+def _parse_creation_ts(ts_str: str) -> Optional[float]:
+    """Parse a GCP creationTimestamp (RFC 3339) into a Unix epoch float.
+
+    GCP format: "2024-01-15T12:34:56.000-07:00" or ending with 'Z'.
+    Returns None on any parse failure (fail-soft).
+    """
+    if not ts_str:
+        return None
+    try:
+        # Python 3.7+ fromisoformat does not handle the 'Z' suffix -- replace it.
+        normalised = ts_str.replace("Z", "+00:00")
+        return _dt.datetime.fromisoformat(normalised).timestamp()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# --------------------------------------------------------------------------- #
+# OrphanReaper.
+# --------------------------------------------------------------------------- #
+class OrphanReaper:
+    """Async orphan-node reaper with local lease-based liveness checking.
+
+    Instantiate with injectable *instance_lister* / *instance_deleter* to keep
+    tests $0 (no real gcloud calls needed).
+    """
+
+    def __init__(
+        self,
+        lease_dir: pathlib.Path = _DEFAULT_LEASE_DIR,
+        project: str = _DEFAULT_PROJECT,
+        zone: str = _DEFAULT_ZONE,
+        interval_s: int = _DEFAULT_INTERVAL_S,
+        boot_grace_s: int = _DEFAULT_BOOT_GRACE_S,
+        dry_run: bool = False,
+        instance_lister: Optional[Callable] = None,
+        instance_deleter: Optional[Callable] = None,
+    ) -> None:
+        self.lease_dir = pathlib.Path(lease_dir)
+        self.project = project
+        self.zone = zone
+        self.interval_s = interval_s
+        self.boot_grace_s = boot_grace_s
+        self.dry_run = dry_run
+        self._lister: Callable = instance_lister or _default_instance_lister
+        self._deleter: Callable = instance_deleter or _default_instance_deleter
+
+    # ---------------------------------------------------------------------- #
+    # Lease API.
+    # ---------------------------------------------------------------------- #
+    async def write_lease(
+        self,
+        node: str,
+        zone: str,
+        pid: int,
+        ttl_s: int = _DEFAULT_LEASE_TTL_S,
+    ) -> None:
+        """Write (or refresh) the lease file for *node*.
+
+        Atomic write: temp file + os.replace so readers never see a partial
+        JSON. Creates the lease directory on first call.
+        Fail-soft: a filesystem error is logged and swallowed.
+        """
+        try:
+            self.lease_dir.mkdir(parents=True, exist_ok=True)
+            payload: Dict[str, Any] = {
+                "node": node,
+                "zone": zone,
+                "pid": pid,
+                "expires_ts": time.time() + ttl_s,
+            }
+            path = _lease_path(self.lease_dir, node)
+            tmp = path.with_suffix(".lease.tmp")
+            tmp.write_text(json.dumps(payload), encoding="utf-8")
+            os.replace(tmp, path)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("write_lease(%s) failed (fail-soft): %r", node, exc)
+
+    async def is_lease_valid(self, node: str) -> Tuple[bool, str]:
+        """Check whether the local lease for *node* is currently valid.
+
+        Returns (valid: bool, reason: str).
+          valid=True,  reason='ok'       -- lease file exists, pid alive, not expired
+          valid=False, reason='no-lease' -- file absent or unreadable
+          valid=False, reason='expired'  -- file present but expires_ts < now()
+          valid=False, reason='dead-pid' -- pid does not exist
+        """
+        path = _lease_path(self.lease_dir, node)
+        if not path.exists():
+            return False, "no-lease"
+
+        try:
+            data: Dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
+        except Exception:  # noqa: BLE001
+            return False, "no-lease"
+
+        # Check expiry first (cheapest).
+        expires_ts = float(data.get("expires_ts", 0.0))
+        if time.time() > expires_ts:
+            return False, "expired"
+
+        # Check pid liveness via signal 0 (probe-only, never kills).
+        pid = int(data.get("pid", 0))
+        if pid <= 0:
+            return False, "dead-pid"
+        try:
+            os.kill(pid, 0)
+        except ProcessLookupError:
+            return False, "dead-pid"
+        except PermissionError:
+            # EPERM: pid exists but belongs to a different user -> still alive.
+            return True, "ok"
+        return True, "ok"
+
+    # ---------------------------------------------------------------------- #
+    # Core reap logic.
+    # ---------------------------------------------------------------------- #
+    async def run_once(self) -> None:
+        """Single reap pass: list instances, check leases, reap orphans.
+
+        Per-node errors are swallowed (fail-soft) so a single bad node never
+        halts processing of subsequent nodes.
+        """
+        try:
+            instances = await self._lister(self.project, NODE_PREFIXES)
+        except Exception as exc:  # noqa: BLE001
+            log.warning("instance lister raised (fail-soft, skip pass): %r", exc)
+            return
+
+        now = time.time()
+        for inst in instances:
+            node: str = inst.get("name", "")
+            if not node:
+                continue
+            zone: str = inst.get("zone", "") or self.zone
+
+            # --- Boot-grace check (creation timestamp). -------------------- #
+            created = _parse_creation_ts(inst.get("creationTimestamp", ""))
+            if created is not None:
+                age = now - created
+                if age < self.boot_grace_s:
+                    log.debug(
+                        "boot-grace: skip %s (age=%.0fs < grace=%ds)",
+                        node, age, self.boot_grace_s,
+                    )
+                    continue
+
+            # --- Lease validity check (fail-soft per-node). ---------------- #
+            try:
+                valid, reason = await self.is_lease_valid(node)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("is_lease_valid(%s) raised (skip node): %r", node, exc)
+                continue
+
+            if valid:
+                log.debug("valid lease: skip %s", node)
+                continue
+
+            # --- Orphan detected. ----------------------------------------- #
+            if self.dry_run:
+                log.info(
+                    "[OrphanReaper] dry-run: would reap %s (reason=%s)", node, reason
+                )
+                continue
+
+            log.info("[OrphanReaper] reaped %s (reason=%s)", node, reason)
+            try:
+                await self._deleter(self.project, node, zone)
+            except Exception as exc:  # noqa: BLE001
+                log.warning("deleter(%s) raised (fail-soft): %r", node, exc)
+
+    async def reap_loop(self, interval_s: Optional[int] = None) -> None:
+        """Continuous reap loop: run_once() every *interval_s* seconds.
+
+        Runs forever (or until cancelled). Suitable for use as a background
+        asyncio task:
+            asyncio.create_task(reaper.reap_loop())
+        """
+        effective_interval = interval_s if interval_s is not None else self.interval_s
+        while True:
+            await self.run_once()
+            await asyncio.sleep(effective_interval)
+
+
+# --------------------------------------------------------------------------- #
+# CLI entry point.
+# --------------------------------------------------------------------------- #
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "Autonomous out-of-band OrphanReaper -- reaps soak/bake GCP nodes "
+            "lacking an active local lease. Default: --once (single pass)."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument(
+        "--watch",
+        action="store_true",
+        help="run continuously every --interval seconds",
+    )
+    mode.add_argument(
+        "--once",
+        action="store_true",
+        default=True,
+        help="single reap pass then exit (default)",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="log what WOULD be reaped; never delete anything",
+    )
+    p.add_argument(
+        "--project",
+        default=_DEFAULT_PROJECT,
+        help="GCP project (env GCP_PROJECT)",
+    )
+    p.add_argument(
+        "--zone",
+        default=_DEFAULT_ZONE,
+        help="GCP zone fallback (env GCP_ZONE)",
+    )
+    p.add_argument(
+        "--interval",
+        dest="interval_s",
+        type=int,
+        default=_DEFAULT_INTERVAL_S,
+        help="watch-mode poll interval in seconds (env JARVIS_ORPHAN_REAPER_INTERVAL_S)",
+    )
+    p.add_argument(
+        "--boot-grace",
+        dest="boot_grace_s",
+        type=int,
+        default=_DEFAULT_BOOT_GRACE_S,
+        help="seconds after creation during which a node is never reaped "
+             "(env JARVIS_ORPHAN_REAPER_BOOT_GRACE_S)",
+    )
+    p.add_argument(
+        "--lease-dir",
+        dest="lease_dir",
+        type=pathlib.Path,
+        default=_DEFAULT_LEASE_DIR,
+        help="directory containing .lease files",
+    )
+    return p
+
+
+def _main(argv: Optional[List[str]] = None) -> int:
+    if not _env_truthy("JARVIS_ORPHAN_REAPER_ENABLED", "true"):
+        log.info("[OrphanReaper] JARVIS_ORPHAN_REAPER_ENABLED=false -- not running")
+        return 0
+
+    args = _build_parser().parse_args(argv)
+
+    reaper = OrphanReaper(
+        lease_dir=args.lease_dir,
+        project=args.project,
+        zone=args.zone,
+        interval_s=args.interval_s,
+        boot_grace_s=args.boot_grace_s,
+        dry_run=args.dry_run,
+    )
+
+    if args.watch:
+        log.info(
+            "[OrphanReaper] watch mode: interval=%ds boot_grace=%ds dry_run=%s",
+            args.interval_s, args.boot_grace_s, args.dry_run,
+        )
+        asyncio.run(reaper.reap_loop())
+    else:
+        log.info(
+            "[OrphanReaper] single pass: boot_grace=%ds dry_run=%s",
+            args.boot_grace_s, args.dry_run,
+        )
+        asyncio.run(reaper.run_once())
+
+    return 0
+
+
+if __name__ == "__main__":
+    import sys as _sys
+    _sys.exit(_main())

--- a/scripts/bake_soak_golden_image.py
+++ b/scripts/bake_soak_golden_image.py
@@ -272,17 +272,39 @@ done < /tmp/req_light.txt
 
 # 5. HARD-ENSURE the A1-critical core (the loop is dead without these).
 echo "[soak-bake] hard-ensuring core deps"
-if sudo python3 -m pip install --break-system-packages -q {hard_ensure} 2>&1 | tail -1; then
-    echo "[soak-bake] hard-ensure install complete -- stamping baked sha + sentinel"
-    # Stamp the baked requirements sha into the image (IaC staleness check reads it).
-    echo {baked_sha_q} | sudo tee {baked_sha_path_q} >/dev/null 2>&1 \\
-        || echo {baked_sha_q} > {baked_sha_path_q} 2>/dev/null || true
-    echo "ready ts=$(date -u +%FT%TZ)" > {sentinel_q}
-    echo "[soak-bake] startup-script done $(date -u +%FT%TZ)"
-else
+if ! sudo python3 -m pip install --break-system-packages -q {hard_ensure} 2>&1 | tail -1; then
     echo "[soak-bake] ERROR: hard-ensure pip install failed -- NOT writing sentinel"
     exit 1
 fi
+echo "[soak-bake] hard-ensure install complete"
+
+# 6. Docker engine: pre-bake into the golden image so the IaC boot's
+#    'installing Docker' step finds it present and finishes in seconds, and
+#    'docker info' at the IaC ready-probe (poll_node_ready) passes immediately
+#    instead of timing out (the Confirm-4 ready_timeout root cause).
+#    The soak itself runs python3 directly -- no docker run / docker pull at
+#    runtime (pure-python O+V); no image pre-pull is required.
+echo "[soak-bake] baking Docker engine (apt-get docker.io + docker-compose-plugin)"
+apt-get install -y docker.io docker-compose-plugin rsync 2>&1 \\
+    || curl -fsSL https://get.docker.com | sh 2>&1 || true
+# Enable the daemon so it auto-starts on every boot: when the golden image
+# node boots, 'systemctl enable --now docker' in the IaC startup-script is
+# instant (already enabled) and 'docker info' at the ready-probe passes fast.
+systemctl enable docker 2>/dev/null || true
+if ! command -v docker >/dev/null 2>&1; then
+    echo "[soak-bake] ERROR: docker not found after install -- NOT writing sentinel (fail-closed)"
+    exit 1
+fi
+echo "[soak-bake] Docker engine baked + daemon enabled for instant boot"
+echo "[soak-bake] no docker pull required (soak is pure-python, no runtime containers)"
+
+# ALL bake steps succeeded: stamp the baked sha + write the readiness sentinel.
+# Sentinel is written ONLY here -- after deps + Docker both verified (fail-closed).
+echo "[soak-bake] all steps complete -- stamping baked sha + writing sentinel"
+echo {baked_sha_q} | sudo tee {baked_sha_path_q} >/dev/null 2>&1 \\
+    || echo {baked_sha_q} > {baked_sha_path_q} 2>/dev/null || true
+echo "ready ts=$(date -u +%FT%TZ)" > {sentinel_q}
+echo "[soak-bake] startup-script done $(date -u +%FT%TZ)"
 """
 
 

--- a/tests/scripts/test_a1_orphan_reaper.py
+++ b/tests/scripts/test_a1_orphan_reaper.py
@@ -1,0 +1,330 @@
+from __future__ import annotations
+
+"""Tests for a1_orphan_reaper.OrphanReaper -- $0 (no real gcloud calls).
+
+All 8 required scenarios are covered:
+  1. valid-lease node            -> NOT reaped
+  2. expired-lease node          -> REAPED, reason=expired
+  3. dead-pid node               -> REAPED, reason=dead-pid
+  4. no-lease node               -> REAPED, reason=no-lease
+  5. boot-grace node             -> NOT reaped (even without a lease)
+  6. dry-run                     -> expired + dead-pid nodes NOT deleted
+  7. lease write/read/expiry     -> roundtrip + advance-time expiry
+  8. fail-soft                   -> deleter raises for one node; others processed
+
+Fake lister/deleter are injected -- zero real gcloud calls, zero dollars.
+Uses asyncio.run() for each async test (compatible with pytest without
+pytest-asyncio; works under Python 3.9+).
+"""
+
+import asyncio
+import datetime
+import importlib.util
+import json
+import os
+import pathlib
+import sys
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+# --------------------------------------------------------------------------- #
+# Load the module under test via importlib so the test suite works even when
+# the scripts/ directory is not on sys.path.
+# --------------------------------------------------------------------------- #
+_REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_REAPER_PATH = _REPO_ROOT / "scripts" / "a1_orphan_reaper.py"
+
+
+def _load_reaper():
+    spec = importlib.util.spec_from_file_location("a1_orphan_reaper", str(_REAPER_PATH))
+    assert spec and spec.loader, f"could not load spec from {_REAPER_PATH}"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["a1_orphan_reaper"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+@pytest.fixture(scope="module")
+def R():
+    """Module-scoped fixture: load the reaper module once per test session."""
+    return _load_reaper()
+
+
+# --------------------------------------------------------------------------- #
+# Helpers.
+# --------------------------------------------------------------------------- #
+
+def _make_instance(
+    name: str,
+    zone: str = "us-central1-a",
+    age_s: float = 1000.0,
+) -> Dict[str, Any]:
+    """Build a fake GCP instance dict.
+
+    age_s defaults to 1000 s (>> default boot_grace_s=300) so the instance is
+    considered past boot-grace and eligible for reaping.
+    """
+    created = datetime.datetime.utcnow() - datetime.timedelta(seconds=age_s)
+    ts = created.strftime("%Y-%m-%dT%H:%M:%S.000+00:00")
+    return {"name": name, "zone": zone, "creationTimestamp": ts}
+
+
+def _make_reaper(
+    R,
+    tmp_path: pathlib.Path,
+    instances: List[Dict[str, Any]],
+    dry_run: bool = False,
+    boot_grace_s: int = 300,
+) -> Tuple["Any", List[str]]:
+    """Construct an OrphanReaper with injected fake lister/deleter.
+
+    Returns (reaper, deleted_list).  deleted_list is mutated by fake_deleter
+    so tests can inspect which nodes were actually deleted.
+    """
+    deleted: List[str] = []
+
+    async def fake_lister(project: str, prefixes: tuple) -> List[Dict[str, Any]]:
+        return list(instances)
+
+    async def fake_deleter(project: str, node: str, zone: str) -> None:
+        deleted.append(node)
+
+    reaper = R.OrphanReaper(
+        lease_dir=tmp_path / "leases",
+        project="test-project",
+        zone="us-central1-a",
+        interval_s=1,
+        boot_grace_s=boot_grace_s,
+        dry_run=dry_run,
+        instance_lister=fake_lister,
+        instance_deleter=fake_deleter,
+    )
+    return reaper, deleted
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 1: valid-lease node -> NOT reaped.
+# --------------------------------------------------------------------------- #
+
+def test_valid_lease_not_reaped(R, tmp_path):
+    """A node with a valid lease (pid alive, not expired) must never be deleted."""
+    node = "sovereign-sandbox-valid"
+    instances = [_make_instance(node)]
+    reaper, deleted = _make_reaper(R, tmp_path, instances)
+
+    async def run():
+        # Write a lease owned by this process, expiring in 1 h.
+        await reaper.write_lease(node, "us-central1-a", os.getpid(), ttl_s=3600)
+        await reaper.run_once()
+
+    asyncio.run(run())
+    assert node not in deleted, "valid-lease node must NOT be reaped"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 2: expired-lease node -> REAPED, reason=expired.
+# --------------------------------------------------------------------------- #
+
+def test_expired_lease_reaped(R, tmp_path):
+    """A node whose lease's expires_ts is in the past must be reaped."""
+    node = "sovereign-sandbox-expired"
+    instances = [_make_instance(node)]
+    reaper, deleted = _make_reaper(R, tmp_path, instances)
+
+    async def run():
+        lease_dir = tmp_path / "leases"
+        lease_dir.mkdir(parents=True, exist_ok=True)
+        path = lease_dir / f"{node}.lease"
+        payload = {
+            "node": node,
+            "zone": "us-central1-a",
+            "pid": os.getpid(),
+            "expires_ts": time.time() - 1.0,  # already expired
+        }
+        path.write_text(json.dumps(payload), encoding="utf-8")
+        await reaper.run_once()
+
+    asyncio.run(run())
+    assert node in deleted, "expired-lease node must be reaped"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 3: dead-pid node -> REAPED, reason=dead-pid.
+# --------------------------------------------------------------------------- #
+
+def test_dead_pid_reaped(R, tmp_path):
+    """A node whose lease names a non-existent PID must be reaped."""
+    node = "jarvis-soak-deadpid"
+    instances = [_make_instance(node)]
+    reaper, deleted = _make_reaper(R, tmp_path, instances)
+
+    async def run():
+        # pid 999999 is virtually never alive on a developer machine.
+        await reaper.write_lease(node, "us-central1-a", 999999, ttl_s=3600)
+        await reaper.run_once()
+
+    asyncio.run(run())
+    assert node in deleted, "dead-pid node must be reaped"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 4: no-lease node -> REAPED, reason=no-lease.
+# --------------------------------------------------------------------------- #
+
+def test_no_lease_reaped(R, tmp_path):
+    """A node with no lease file at all must be reaped."""
+    node = "jarvis-bake-nolease"
+    instances = [_make_instance(node)]
+    reaper, deleted = _make_reaper(R, tmp_path, instances)
+
+    asyncio.run(reaper.run_once())
+    assert node in deleted, "no-lease node must be reaped"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 5: boot-grace node -> NOT reaped, even without a lease.
+# --------------------------------------------------------------------------- #
+
+def test_boot_grace_not_reaped(R, tmp_path):
+    """A freshly-created node (within boot_grace_s) must not be reaped."""
+    node = "sovereign-sandbox-fresh"
+    # age_s=10 << boot_grace_s=300 -> still in grace window.
+    instances = [_make_instance(node, age_s=10.0)]
+    reaper, deleted = _make_reaper(R, tmp_path, instances, boot_grace_s=300)
+
+    asyncio.run(reaper.run_once())
+    assert node not in deleted, (
+        "boot-grace node must NOT be reaped even without a lease"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 6: dry-run -> nothing deleted even for expired + dead-pid nodes.
+# --------------------------------------------------------------------------- #
+
+def test_dry_run_no_delete(R, tmp_path):
+    """With dry_run=True the deleter must NEVER be called."""
+    expired_node = "sovereign-sandbox-exp"
+    deadpid_node = "jarvis-soak-dead"
+    instances = [_make_instance(expired_node), _make_instance(deadpid_node)]
+    reaper, deleted = _make_reaper(R, tmp_path, instances, dry_run=True)
+
+    async def run():
+        lease_dir = tmp_path / "leases"
+        lease_dir.mkdir(parents=True, exist_ok=True)
+
+        # Expired lease.
+        (lease_dir / f"{expired_node}.lease").write_text(
+            json.dumps({
+                "node": expired_node,
+                "zone": "us-central1-a",
+                "pid": os.getpid(),
+                "expires_ts": time.time() - 1.0,
+            }),
+            encoding="utf-8",
+        )
+        # Dead-pid lease (still unexpired).
+        (lease_dir / f"{deadpid_node}.lease").write_text(
+            json.dumps({
+                "node": deadpid_node,
+                "zone": "us-central1-a",
+                "pid": 999999,
+                "expires_ts": time.time() + 3600,
+            }),
+            encoding="utf-8",
+        )
+        await reaper.run_once()
+
+    asyncio.run(run())
+    assert deleted == [], "dry-run must never call the deleter"
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 7: lease write/read/expiry roundtrip.
+# --------------------------------------------------------------------------- #
+
+def test_lease_write_read_expiry(R, tmp_path):
+    """write_lease -> is_lease_valid=True; overwrite expires_ts -> is_lease_valid=False."""
+    node = "jarvis-soak-bake-roundtrip"
+    reaper, _ = _make_reaper(R, tmp_path, instances=[])
+
+    async def run():
+        # Write a fresh lease.
+        await reaper.write_lease(node, "us-central1-a", os.getpid(), ttl_s=3600)
+        valid, reason = await reaper.is_lease_valid(node)
+        assert valid, f"freshly written lease must be valid; got reason={reason!r}"
+        assert reason == "ok", f"expected reason 'ok', got {reason!r}"
+
+        # Manually expire the lease by back-dating expires_ts.
+        lease_dir = tmp_path / "leases"
+        path = lease_dir / f"{node}.lease"
+        data = json.loads(path.read_text(encoding="utf-8"))
+        data["expires_ts"] = time.time() - 1.0
+        path.write_text(json.dumps(data), encoding="utf-8")
+
+        valid2, reason2 = await reaper.is_lease_valid(node)
+        assert not valid2, "back-dated lease must be invalid"
+        assert reason2 == "expired", f"expected reason 'expired', got {reason2!r}"
+
+    asyncio.run(run())
+
+
+# --------------------------------------------------------------------------- #
+# Scenario 8: fail-soft -- deleter raises for one node; others still processed.
+# --------------------------------------------------------------------------- #
+
+def test_fail_soft_per_node(R, tmp_path):
+    """A deleter exception on one node must not prevent other nodes from being reaped."""
+    node_bad = "sovereign-sandbox-badfail"
+    node_ok  = "sovereign-sandbox-goodnode"
+    instances = [_make_instance(node_bad), _make_instance(node_ok)]
+
+    deleted: List[str] = []
+    call_count: List[int] = [0]
+
+    async def fake_lister(project: str, prefixes: tuple) -> List[Dict[str, Any]]:
+        return list(instances)
+
+    async def fake_deleter(project: str, node: str, zone: str) -> None:
+        call_count[0] += 1
+        if node == node_bad:
+            raise RuntimeError("simulated delete failure for node_bad")
+        deleted.append(node)
+
+    reaper = R.OrphanReaper(
+        lease_dir=tmp_path / "leases",
+        project="test-project",
+        zone="us-central1-a",
+        boot_grace_s=300,
+        dry_run=False,
+        instance_lister=fake_lister,
+        instance_deleter=fake_deleter,
+    )
+
+    asyncio.run(reaper.run_once())
+
+    assert node_ok in deleted, (
+        "fail-soft: the good node must still be reaped after bad node raises"
+    )
+    assert call_count[0] == 2, (
+        f"deleter must be called for BOTH nodes; called {call_count[0]} time(s)"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Bonus: NODE_PREFIXES is a tuple of exactly the expected four prefixes.
+# --------------------------------------------------------------------------- #
+
+def test_node_prefixes_constant(R):
+    """NODE_PREFIXES must contain exactly the four canonical prefixes."""
+    expected = {
+        "sovereign-sandbox-",
+        "jarvis-soak-",
+        "jarvis-bake-",
+        "jarvis-soak-bake-",
+    }
+    assert set(R.NODE_PREFIXES) == expected, (
+        f"NODE_PREFIXES mismatch: {set(R.NODE_PREFIXES)} != {expected}"
+    )

--- a/tests/scripts/test_bake_soak_golden.py
+++ b/tests/scripts/test_bake_soak_golden.py
@@ -84,6 +84,59 @@ def test_startup_script_sentinel_after_install(bake):
     assert script.index("hard-ensuring core deps") < script.index("hard-ensure install complete")
 
 
+def test_startup_script_bakes_docker(bake):
+    """Golden image must bake the Docker engine so the IaC boot's 'installing
+    Docker' + 'docker info' ready-probe are instant (the Confirm-4 fix)."""
+    deps = bake._load_hard_ensure_deps()
+    script = bake.build_startup_script(deps)
+    # Docker package install is in the startup-script.
+    assert "docker.io" in script
+    assert "docker-compose-plugin" in script
+    # Daemon is enabled so it auto-starts on every golden boot.
+    assert "systemctl enable docker" in script
+    # Fail-closed guard: script verifies docker binary is present.
+    assert "command -v docker" in script
+
+
+def test_startup_script_no_docker_pull_logged(bake):
+    """Soak is pure-python -- no docker pull at runtime. The script must log
+    this explicitly so operators know no pre-pull step is missing."""
+    deps = bake._load_hard_ensure_deps()
+    script = bake.build_startup_script(deps)
+    assert "no docker pull required" in script
+
+
+def test_startup_script_sentinel_after_docker(bake):
+    """Sentinel must appear AFTER the Docker install + verify block (all-or-nothing)."""
+    deps = bake._load_hard_ensure_deps()
+    script = bake.build_startup_script(deps)
+    docker_install_pos = script.index("docker.io")
+    sentinel_pos = script.index(bake._SENTINEL_PATH)
+    # sentinel_path appears in the 'rm -f' guard AND the write -- use the LAST
+    # occurrence (the actual write) for the ordering check.
+    sentinel_write_pos = script.rindex(bake._SENTINEL_PATH)
+    assert docker_install_pos < sentinel_write_pos, (
+        "sentinel write must come AFTER the Docker install step"
+    )
+
+
+def test_startup_script_fail_closed_docker(bake):
+    """If Docker is not found after install, the script must exit 1 and NOT
+    write the sentinel (fail-closed: no broken golden image)."""
+    deps = bake._load_hard_ensure_deps()
+    script = bake.build_startup_script(deps)
+    # The fail-closed exit must appear before the sentinel write.
+    docker_fail_exit_pos = script.index(
+        "docker not found after install -- NOT writing sentinel"
+    )
+    sentinel_write_pos = script.rindex(bake._SENTINEL_PATH)
+    assert docker_fail_exit_pos < sentinel_write_pos, (
+        "docker fail-closed exit must appear before the sentinel write"
+    )
+    # And the exit statement must be present.
+    assert "exit 1" in script[docker_fail_exit_pos:sentinel_write_pos]
+
+
 # --------------------------------------------------------------------------- #
 # requirements sha (the staleness stamp).
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Immutable infra + zombie immunity — the root fix for the Confirm-4 boot flake

### True-immutable soak golden image (`bake_soak_golden_image.py`)
Confirm 4 died on `ready_timeout` because the IaC boot ran a **cold `apt-get install docker.io`** (the soak runs pure-`python3`, but `poll_node_ready` gates on `docker info`). Now the bake **pre-installs the Docker engine + enables the daemon** (+ full pip deps, already baked) so a node boots from the image in ~60s with **zero runtime apt/pip/docker-pull**: the deps-probe finds the baked sha → skips pip; `apt-get install docker.io` → already present → instant; `docker info` → passes fast. Sentinel written only after all-baked (fail-closed). No `docker pull` (soak is pure-python; logged).

### Autonomous OrphanReaper (`a1_orphan_reaper.py`)
Closes the interrupted-launcher zombie blindspot. A lease-based, out-of-band reaper: the driver maintains a local lease (`.jarvis/iac_leases/<node>.lease`, atomic); the reaper continuously lists GCP nodes by the soak/bake prefixes and **ruthlessly terminates any without a valid lease** (no-lease / expired / dead-pid), with a boot-grace so a just-created node is never reaped. CLI `--watch [--once] [--dry-run]` + importable `OrphanReaper` for in-launch background reaping. Fail-soft.

**Tests:** 23 baker + 9 reaper green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pre-bakes Docker into the soak golden image and adds an autonomous OrphanReaper to clean up orphaned soak/bake nodes, fixing the “ready_timeout” boot flake and reducing zombie instances.

- **New Features**
  - Golden image: installs `docker.io` + `docker-compose-plugin`, enables the daemon, verifies `docker` before writing the sentinel; no runtime apt/pip/docker-pull on boot.
  - OrphanReaper (`scripts/a1_orphan_reaper.py`): deletes GCP instances with soak/bake prefixes that lack a valid local lease (`.jarvis/iac_leases/<node>.lease`), honoring a boot-grace; async, dry-run, fail-soft, and testable with injectable lister/deleter.

- **Migration**
  - Rebuild and publish the soak golden image so nodes boot fast and pass the ready probe.
  - Enable and run the reaper: set `JARVIS_ORPHAN_REAPER_ENABLED=true` and run `scripts/a1_orphan_reaper.py --watch` (or import `OrphanReaper` and start a background task).

<sup>Written for commit aff64c6f7efb2030dcad7b4e510b1ce4e6041422. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69743?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

