### PR TITLE
feat(iac): resilient SSH wrapper + bake-node lease (activates OrphanReaper) + reaper filter fix (PR I)

### DIFF
--- a/scripts/a1_orphan_reaper.py
+++ b/scripts/a1_orphan_reaper.py
@@ -107,8 +107,13 @@ async def _default_instance_lister(
     warning -- the caller will simply find nothing to reap this pass.
     """
     # One regex alternation covers all prefixes in a single API call.
-    alt = "|".join(f"^{p}" for p in prefixes)
-    filter_str = f"name~({alt})"
+    # gcloud --filter wants the regex as a single QUOTED operand; a bare
+    # ``name~(^a|^b)`` makes its expression parser choke ("Term operand
+    # expected") because it reads ``(`` as a filter-grouping operator. Anchor
+    # ONCE at the front of a quoted group instead. The quotes are gcloud-filter
+    # syntax (parsed by gcloud, not the shell — we exec, never shell=True).
+    alt = "|".join(prefixes)
+    filter_str = f'name~"^({alt})"'
     cmd: List[str] = [
         "gcloud", "compute", "instances", "list",
         f"--project={project}",

--- a/scripts/a1_orphan_reaper.py
+++ b/scripts/a1_orphan_reaper.py
@@ -130,8 +130,13 @@ async def _default_instance_lister(
     warning -- the caller will simply find nothing to reap this pass.
     """
     # One regex alternation covers all prefixes in a single API call.
-    alt = "|".join(f"^{p}" for p in prefixes)
-    filter_str = f"name~({alt})"
+    # gcloud --filter wants the regex as a single QUOTED operand; a bare
+    # ``name~(^a|^b)`` makes its expression parser choke ("Term operand
+    # expected") because it reads ``(`` as a filter-grouping operator. Anchor
+    # ONCE at the front of a quoted group instead. The quotes are gcloud-filter
+    # syntax (parsed by gcloud, not the shell -- we exec, never shell=True).
+    alt = "|".join(prefixes)
+    filter_str = f'name~"^({alt})"'
     cmd: List[str] = [
         "gcloud", "compute", "instances", "list",
         f"--project={project}",

--- a/scripts/a1_orphan_reaper.py
+++ b/scripts/a1_orphan_reaper.py
@@ -38,6 +38,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import datetime as _dt
+import importlib.util as _importlib_util
 import json
 import logging
 import os
@@ -49,6 +50,25 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 # Repo root.
 # --------------------------------------------------------------------------- #
 _REPO_ROOT = pathlib.Path(__file__).resolve().parent.parent
+
+# --------------------------------------------------------------------------- #
+# Shared lease primitives (iac_lease.py is the single source of truth for the
+# lease JSON shape -- neither consumer duplicates it).
+# --------------------------------------------------------------------------- #
+def _load_iac_lease():
+    """Load scripts/iac_lease.py via importlib (fail-soft)."""
+    _p = pathlib.Path(__file__).resolve().parent / "iac_lease.py"
+    try:
+        spec = _importlib_util.spec_from_file_location("iac_lease", str(_p))
+        if spec and spec.loader:
+            mod = _importlib_util.module_from_spec(spec)
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+            return mod
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+_iac_lease = _load_iac_lease()
 
 # --------------------------------------------------------------------------- #
 # Node-name prefixes -- ONE canonical definition, never duplicated.
@@ -76,7 +96,10 @@ _DEFAULT_BOOT_GRACE_S: int = int(os.environ.get("JARVIS_ORPHAN_REAPER_BOOT_GRACE
 _DEFAULT_LEASE_TTL_S: int = int(os.environ.get("JARVIS_ORPHAN_REAPER_LEASE_TTL_S", "600"))
 _GCLOUD_TIMEOUT_S: float = float(os.environ.get("JARVIS_ORPHAN_REAPER_GCLOUD_TIMEOUT_S", "60"))
 
-_DEFAULT_LEASE_DIR: pathlib.Path = _REPO_ROOT / ".jarvis" / "iac_leases"
+_DEFAULT_LEASE_DIR: pathlib.Path = (
+    _iac_lease.DEFAULT_LEASE_DIR if _iac_lease is not None
+    else _REPO_ROOT / ".jarvis" / "iac_leases"
+)
 
 # --------------------------------------------------------------------------- #
 # Logging -- a module-level logger; caller can configure level/handler.
@@ -107,13 +130,8 @@ async def _default_instance_lister(
     warning -- the caller will simply find nothing to reap this pass.
     """
     # One regex alternation covers all prefixes in a single API call.
-    # gcloud --filter wants the regex as a single QUOTED operand; a bare
-    # ``name~(^a|^b)`` makes its expression parser choke ("Term operand
-    # expected") because it reads ``(`` as a filter-grouping operator. Anchor
-    # ONCE at the front of a quoted group instead. The quotes are gcloud-filter
-    # syntax (parsed by gcloud, not the shell — we exec, never shell=True).
-    alt = "|".join(prefixes)
-    filter_str = f'name~"^({alt})"'
+    alt = "|".join(f"^{p}" for p in prefixes)
+    filter_str = f"name~({alt})"
     cmd: List[str] = [
         "gcloud", "compute", "instances", "list",
         f"--project={project}",
@@ -200,11 +218,13 @@ async def _default_instance_deleter(project: str, node: str, zone: str) -> None:
 # Lease helpers (pure functions -- no class dependency).
 # --------------------------------------------------------------------------- #
 def _lease_path(lease_dir: pathlib.Path, node: str) -> pathlib.Path:
-    """Return the lease file path for *node*.
+    """Return the lease file path for *node*.  Delegates to iac_lease (single source).
 
-    Sanitises the node name to prevent path traversal (only alnum + hyphen +
-    underscore + dot are allowed in a GCP instance name anyway).
+    Falls back to an inline implementation if iac_lease failed to load so the
+    reaper remains self-contained.
     """
+    if _iac_lease is not None:
+        return _iac_lease.lease_path(node, lease_dir)
     safe = "".join(c for c in node if c.isalnum() or c in "-_.")
     return lease_dir / f"{safe}.lease"
 
@@ -270,7 +290,12 @@ class OrphanReaper:
         Atomic write: temp file + os.replace so readers never see a partial
         JSON. Creates the lease directory on first call.
         Fail-soft: a filesystem error is logged and swallowed.
+        Delegates to iac_lease (single source of truth for the JSON shape).
         """
+        if _iac_lease is not None:
+            _iac_lease.write_lease(node, zone, pid, ttl_s, self.lease_dir)
+            return
+        # Fallback: inline implementation (keeps the reaper self-contained).
         try:
             self.lease_dir.mkdir(parents=True, exist_ok=True)
             payload: Dict[str, Any] = {
@@ -294,22 +319,22 @@ class OrphanReaper:
           valid=False, reason='no-lease' -- file absent or unreadable
           valid=False, reason='expired'  -- file present but expires_ts < now()
           valid=False, reason='dead-pid' -- pid does not exist
+
+        Delegates to iac_lease (single source of truth for the JSON shape).
         """
+        if _iac_lease is not None:
+            return _iac_lease.is_lease_valid(node, self.lease_dir)
+        # Fallback: inline implementation (keeps the reaper self-contained).
         path = _lease_path(self.lease_dir, node)
         if not path.exists():
             return False, "no-lease"
-
         try:
             data: Dict[str, Any] = json.loads(path.read_text(encoding="utf-8"))
         except Exception:  # noqa: BLE001
             return False, "no-lease"
-
-        # Check expiry first (cheapest).
         expires_ts = float(data.get("expires_ts", 0.0))
         if time.time() > expires_ts:
             return False, "expired"
-
-        # Check pid liveness via signal 0 (probe-only, never kills).
         pid = int(data.get("pid", 0))
         if pid <= 0:
             return False, "dead-pid"
@@ -318,7 +343,6 @@ class OrphanReaper:
         except ProcessLookupError:
             return False, "dead-pid"
         except PermissionError:
-            # EPERM: pid exists but belongs to a different user -> still alive.
             return True, "ok"
         return True, "ok"
 

--- a/scripts/bake_soak_golden_image.py
+++ b/scripts/bake_soak_golden_image.py
@@ -44,14 +44,16 @@ from __future__ import annotations
 import argparse
 import datetime as _dt
 import hashlib
+import importlib.util as _importlib_util
 import os
 import pathlib
+import random
 import re
 import shlex
 import subprocess
 import sys
 import time
-from typing import List, Optional, Tuple
+from typing import Callable, List, Optional, Tuple
 
 # --------------------------------------------------------------------------- #
 # Reuse the IaC hypervisor's single-source-of-truth dep list + requirements
@@ -60,6 +62,40 @@ from typing import List, Optional, Tuple
 # inline default so the baker still works.
 # --------------------------------------------------------------------------- #
 _REPO_ROOT = pathlib.Path(__file__).resolve().parents[1]
+
+# --------------------------------------------------------------------------- #
+# Shared lease module (iac_lease.py owns the JSON shape -- no duplication).
+# --------------------------------------------------------------------------- #
+def _load_iac_lease_module():
+    """Load scripts/iac_lease.py via importlib (fail-soft)."""
+    _p = pathlib.Path(__file__).resolve().parent / "iac_lease.py"
+    try:
+        spec = _importlib_util.spec_from_file_location("iac_lease", str(_p))
+        if spec and spec.loader:
+            mod = _importlib_util.module_from_spec(spec)
+            spec.loader.exec_module(mod)  # type: ignore[union-attr]
+            return mod
+    except Exception:  # noqa: BLE001 -- never crash the baker on an import edge
+        pass
+    return None
+
+_iac_lease = _load_iac_lease_module()
+
+# Lease TTL for bake nodes (extend by the same TTL on each heartbeat).
+_BAKE_LEASE_TTL_S: int = int(os.environ.get("JARVIS_BAKE_LEASE_TTL_S", "1800"))
+
+# SSH transport-retry tuning (all tunable via env, no hardcoding).
+_BAKE_SSH_MAX_RETRIES: int = int(os.environ.get("JARVIS_BAKE_SSH_MAX_RETRIES", "3"))
+_BAKE_SSH_BACKOFF_BASE_S: float = float(os.environ.get("JARVIS_BAKE_SSH_BACKOFF_BASE_S", "10"))
+_BAKE_SSH_BACKOFF_CAP_S: float = float(os.environ.get("JARVIS_BAKE_SSH_BACKOFF_CAP_S", "120"))
+
+# Connection-error patterns that indicate a transport-layer SSH flake (safe to
+# retry).  These never appear in legitimate validation verdict output.
+_TRANSPORT_ERROR_RE: re.Pattern = re.compile(
+    r"Connection reset|Connection refused|Connection timed out|"
+    r"kex_exchange|Broken pipe|port 22|ssh: connect",
+    re.IGNORECASE,
+)
 
 
 def _load_hard_ensure_deps() -> List[str]:
@@ -182,6 +218,93 @@ def _run(cmd: List[str], *, timeout_s: float = 120.0) -> Tuple[int, str]:
         return p.returncode, (p.stdout or "") + (p.stderr or "")
     except Exception as exc:  # noqa: BLE001 -- the bake never crashes on a call
         return 1, f"[run failed: {exc!r}]"
+
+
+# --------------------------------------------------------------------------- #
+# Transport-vs-payload SSH classifier (the load-bearing retry gate).
+# --------------------------------------------------------------------------- #
+def _is_ssh_transport_failure(rc: int, out: str) -> bool:
+    """True iff this SSH result is a transport-layer flake (safe to retry).
+
+    Priority rules (first match wins):
+      1. FAIL marker present  -> payload failure -> NOT transport (fail-closed)
+      2. rc == 255            -> SSH own exit code for connection failures -> transport
+      3. connection-error pattern in output -> transport
+      4. no verdict marker at all -> remote never completed output -> transport
+      5. otherwise (OK marker present, rc=0) -> not transport (success or clean)
+    """
+    # Payload: FAIL marker explicitly present -- never retry, fail-closed.
+    if _VALIDATION_FAIL_MARKER in out:
+        return False
+    # SSH own exit code for connection-level failures.
+    if rc == 255:
+        return True
+    # Connection-level error pattern in the combined output.
+    if _TRANSPORT_ERROR_RE.search(out):
+        return True
+    # Remote never produced a verdict marker (died mid-stream or before the
+    # validation script ran).
+    if _VALIDATION_OK_MARKER not in out:
+        return True
+    # OK marker present -- clean success path, not a transport issue.
+    return False
+
+
+def _run_ssh_with_transport_retry(
+    cmd: List[str],
+    *,
+    timeout_s: float = 300.0,
+    max_retries: Optional[int] = None,
+    backoff_base: Optional[float] = None,
+    backoff_cap: Optional[float] = None,
+    heartbeat_fn: Optional[Callable[[], None]] = None,
+) -> Tuple[int, str]:
+    """Run an SSH validation command, retrying on transport-layer flakes.
+
+    Transport failure (retry with exponential backoff + jitter):
+      - SSH rc == 255 (SSH's own connection-failed exit code)
+      - Connection-error patterns in output (Connection reset / refused / etc.)
+      - Remote produced no validation verdict marker (died before completion)
+
+    Payload failure (fail-closed immediately, no retry):
+      - SOAK_BAKE_VALIDATION_FAIL marker present in output
+      - Any other non-transport result (OK marker present, or clean non-zero exit)
+
+    All tunable params default from env vars:
+      JARVIS_BAKE_SSH_MAX_RETRIES   (default 3)
+      JARVIS_BAKE_SSH_BACKOFF_BASE_S (default 10)
+      JARVIS_BAKE_SSH_BACKOFF_CAP_S  (default 120)
+    """
+    _max = max_retries if max_retries is not None else _BAKE_SSH_MAX_RETRIES
+    _base = backoff_base if backoff_base is not None else _BAKE_SSH_BACKOFF_BASE_S
+    _cap = backoff_cap if backoff_cap is not None else _BAKE_SSH_BACKOFF_CAP_S
+
+    last_rc, last_out = 255, ""
+    for attempt in range(1, _max + 1):
+        last_rc, last_out = _run(cmd, timeout_s=timeout_s)
+
+        if not _is_ssh_transport_failure(last_rc, last_out):
+            # Either a clean pass (OK marker), payload fail (FAIL marker), or
+            # other non-transport result -- return immediately, no retry.
+            return last_rc, last_out
+
+        # Transport flake detected.
+        if attempt < _max:
+            jitter = random.uniform(0.8, 1.2)
+            delay = min(_base * (2 ** (attempt - 1)) * jitter, _cap)
+            _log(
+                f"[soak-bake] validation transport flake "
+                f"(attempt {attempt}/{_max}, rc={last_rc}) -- backoff {int(delay)}s"
+            )
+            if heartbeat_fn is not None:
+                try:
+                    heartbeat_fn()
+                except Exception:  # noqa: BLE001
+                    pass
+            time.sleep(delay)
+
+    # All retries exhausted -- return the last result.
+    return last_rc, last_out
 
 
 # --------------------------------------------------------------------------- #
@@ -427,6 +550,29 @@ def _cleanup_node(args: argparse.Namespace, node: str) -> None:
 
 
 # --------------------------------------------------------------------------- #
+# Bake-lease helpers (thin wrappers around iac_lease -- fail-soft if absent).
+# --------------------------------------------------------------------------- #
+def _bake_write_lease(node: str, zone: str) -> None:
+    """Write (or refresh) the bake lease for *node*.  Fail-soft."""
+    if _iac_lease is None:
+        return
+    try:
+        _iac_lease.write_lease(node, zone, os.getpid(), _BAKE_LEASE_TTL_S)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _bake_delete_lease(node: str) -> None:
+    """Delete the bake lease for *node*.  Fail-soft."""
+    if _iac_lease is None:
+        return
+    try:
+        _iac_lease.delete_lease(node)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# --------------------------------------------------------------------------- #
 # Poll loop.
 # --------------------------------------------------------------------------- #
 _EARLY_FAIL_PATTERNS: List[re.Pattern] = [
@@ -460,10 +606,16 @@ def _check_bake_log(args: argparse.Namespace, node: str
         return None, None
 
 
-def _poll_readiness(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
+def _poll_readiness(
+    args: argparse.Namespace,
+    node: str,
+    heartbeat_fn: Optional[Callable[[], None]] = None,
+) -> Tuple[bool, str]:
     """Poll the node (via SSH) for the readiness sentinel.
 
     Exponential-ish backoff, bounded by --bake-timeout-s. Returns (ready, reason).
+    heartbeat_fn is called each iteration so bake leases are refreshed and
+    never expire mid-bake.
     """
     deadline = time.monotonic() + float(args.bake_timeout_s)
     delay = 15.0
@@ -486,6 +638,13 @@ def _poll_readiness(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
             _log(f"readiness: EARLY ABORT -- {fail_reason}")
             return False, f"early_failure: {fail_reason}"
 
+        # Heartbeat: refresh the lease so the reaper does not expire it mid-bake.
+        if heartbeat_fn is not None:
+            try:
+                heartbeat_fn()
+            except Exception:  # noqa: BLE001
+                pass
+
         remaining = int(deadline - time.monotonic())
         _log(
             f"readiness: not ready (attempt {attempt}, rc={rc}); "
@@ -502,11 +661,24 @@ def _poll_readiness(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
 # --------------------------------------------------------------------------- #
 # Validation (the load-bearing lock -- run the 3 checks before snapshot).
 # --------------------------------------------------------------------------- #
-def _validate_deps(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
-    """SSH-run the validation program (deps import + pytest-collect + O+V core)."""
+def _validate_deps(
+    args: argparse.Namespace,
+    node: str,
+    heartbeat_fn: Optional[Callable[[], None]] = None,
+) -> Tuple[bool, str]:
+    """SSH-run the validation program (deps import + pytest-collect + O+V core).
+
+    Uses _run_ssh_with_transport_retry to survive transient SSH flakes while
+    failing closed immediately on a genuine VALIDATION_FAIL verdict.
+    heartbeat_fn is called in each retry backoff so bake leases stay fresh.
+    """
     remote = build_validation_remote()
     _log("validation: running deps-import + pytest-collect + O+V-core checks")
-    rc, out = _run(_ssh_cmd(args, node, remote), timeout_s=300.0)
+    rc, out = _run_ssh_with_transport_retry(
+        _ssh_cmd(args, node, remote),
+        timeout_s=300.0,
+        heartbeat_fn=heartbeat_fn,
+    )
     return parse_validation_verdict(rc, out)
 
 
@@ -601,14 +773,27 @@ def _execute_bake(
         node_exists = True
         _log(f"node {node} created; startup-script installing soak deps")
 
-        # 2. POLL READINESS.
-        ready, poll_reason = _poll_readiness(args, node)
+        # Write the initial bake lease so the OrphanReaper knows this node is
+        # actively managed.  A crashed baker leaves a dead-pid lease -> reaper
+        # reaps.  A live baker keeps refreshing the lease -> reaper spares it.
+        _bake_write_lease(node, args.zone)
+        _log(
+            f"lease written for {node} (pid={os.getpid()}, ttl={_BAKE_LEASE_TTL_S}s)"
+        )
+
+        def _heartbeat() -> None:
+            """Refresh the bake lease so it never expires mid-bake."""
+            _bake_write_lease(node, args.zone)
+
+        # 2. POLL READINESS (with lease heartbeat on each iteration).
+        ready, poll_reason = _poll_readiness(args, node, heartbeat_fn=_heartbeat)
         if not ready:
             _abort(f"readiness abort: {poll_reason}")
             return 5
 
         # 3. VALIDATION LOCK -- never snapshot a broken image.
-        passed, sample = _validate_deps(args, node)
+        #    Uses _run_ssh_with_transport_retry internally; heartbeat in backoff.
+        passed, sample = _validate_deps(args, node, heartbeat_fn=_heartbeat)
         if not passed:
             _abort(f"validation failed: {sample}")
             return 6
@@ -658,6 +843,9 @@ def _execute_bake(
         # created) is the durable artifact; the VM must never linger.
         if node_exists:
             _cleanup_node(args, node)
+        # Delete the bake lease on every exit path (success or abort).
+        # A missing iac_lease module is silently tolerated (fail-soft).
+        _bake_delete_lease(node)
 
 
 def _report_success(

--- a/scripts/iac_lease.py
+++ b/scripts/iac_lease.py
@@ -1,0 +1,133 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Shared synchronous lease primitives for IaC bake + OrphanReaper.
+
+Both bake_soak_golden_image.py (sync baker) and a1_orphan_reaper.py (async
+reaper) need the same lease JSON shape.  This module owns that shape --
+neither consumer duplicates it.
+
+Lease JSON: {"node": str, "zone": str, "pid": int, "expires_ts": float}
+
+Semantics:
+  A crashed baker leaves a lease whose pid is dead -> reaper reaps the orphan.
+  A live baker keeps a valid lease               -> reaper spares it.
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import pathlib
+import time
+from typing import Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# Repo root + default lease directory (single canonical location).
+# --------------------------------------------------------------------------- #
+_REPO_ROOT: pathlib.Path = pathlib.Path(__file__).resolve().parents[1]
+
+# Mirror of a1_orphan_reaper._DEFAULT_LEASE_DIR -- one definition, both import.
+DEFAULT_LEASE_DIR: pathlib.Path = _REPO_ROOT / ".jarvis" / "iac_leases"
+
+# --------------------------------------------------------------------------- #
+# Module logger.
+# --------------------------------------------------------------------------- #
+log = logging.getLogger("iac_lease")
+if not log.handlers:
+    _h = logging.StreamHandler()
+    _h.setFormatter(logging.Formatter("[%(name)s] %(message)s"))
+    log.addHandler(_h)
+log.setLevel(logging.INFO)
+
+
+# --------------------------------------------------------------------------- #
+# Public API.
+# --------------------------------------------------------------------------- #
+
+def lease_path(node: str, lease_dir: Optional[pathlib.Path] = None) -> pathlib.Path:
+    """Return the lease file path for *node*.
+
+    Sanitises the node name (GCP instance names: alnum + hyphen + underscore +
+    dot) to prevent any path traversal.
+    """
+    d = pathlib.Path(lease_dir) if lease_dir is not None else DEFAULT_LEASE_DIR
+    safe = "".join(c for c in node if c.isalnum() or c in "-_.")
+    return d / f"{safe}.lease"
+
+
+def write_lease(
+    node: str,
+    zone: str,
+    pid: int,
+    ttl_s: int,
+    lease_dir: Optional[pathlib.Path] = None,
+) -> None:
+    """Write (or refresh) the lease file for *node*.  Sync, atomic write.
+
+    Atomic write via temp file + os.replace so readers never see partial JSON.
+    Creates the lease directory on first call.  Fail-soft: a filesystem error is
+    logged and swallowed.
+    """
+    try:
+        d = pathlib.Path(lease_dir) if lease_dir is not None else DEFAULT_LEASE_DIR
+        d.mkdir(parents=True, exist_ok=True)
+        payload = {
+            "node": node,
+            "zone": zone,
+            "pid": pid,
+            "expires_ts": time.time() + ttl_s,
+        }
+        p = lease_path(node, d)
+        tmp = p.with_suffix(".lease.tmp")
+        tmp.write_text(json.dumps(payload), encoding="utf-8")
+        os.replace(tmp, p)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("write_lease(%s) failed (fail-soft): %r", node, exc)
+
+
+def delete_lease(
+    node: str,
+    lease_dir: Optional[pathlib.Path] = None,
+) -> None:
+    """Delete the lease file for *node*.  Fail-soft."""
+    try:
+        p = lease_path(node, lease_dir)
+        p.unlink(missing_ok=True)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("delete_lease(%s) failed (fail-soft): %r", node, exc)
+
+
+def is_lease_valid(
+    node: str,
+    lease_dir: Optional[pathlib.Path] = None,
+) -> Tuple[bool, str]:
+    """Synchronous lease-validity check.  Returns (valid, reason).
+
+    valid=True,  reason='ok'        lease file present, pid alive, not expired
+    valid=False, reason='no-lease'  file absent or unreadable
+    valid=False, reason='expired'   expires_ts < now()
+    valid=False, reason='dead-pid'  pid does not exist
+    """
+    p = lease_path(node, lease_dir)
+    if not p.exists():
+        return False, "no-lease"
+    try:
+        data = json.loads(p.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return False, "no-lease"
+
+    expires_ts = float(data.get("expires_ts", 0.0))
+    if time.time() > expires_ts:
+        return False, "expired"
+
+    pid = int(data.get("pid", 0))
+    if pid <= 0:
+        return False, "dead-pid"
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False, "dead-pid"
+    except PermissionError:
+        # EPERM: pid exists but owned by different user -> still alive.
+        return True, "ok"
+    return True, "ok"

--- a/tests/scripts/test_bake_soak_golden.py
+++ b/tests/scripts/test_bake_soak_golden.py
@@ -8,8 +8,12 @@ requirements sha label, and execute deletes the bake node on every exit path.
 """
 from __future__ import annotations
 
+import asyncio
 import importlib.util
+import os
+import time
 from pathlib import Path
+from typing import Any, Dict, List
 
 import pytest
 
@@ -347,3 +351,331 @@ def test_hard_ensure_deps_match_iac(bake):
     iac = _u.module_from_spec(spec)
     spec.loader.exec_module(iac)
     assert deps == iac.hard_ensure_deps()
+
+
+# --------------------------------------------------------------------------- #
+# Loader helpers for iac_lease and a1_orphan_reaper.
+# --------------------------------------------------------------------------- #
+_SCRIPTS = Path(__file__).resolve().parents[2] / "scripts"
+
+
+def _load_iac_lease():
+    spec = importlib.util.spec_from_file_location(
+        "iac_lease", str(_SCRIPTS / "iac_lease.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_reaper():
+    spec = importlib.util.spec_from_file_location(
+        "a1_orphan_reaper", str(_SCRIPTS / "a1_orphan_reaper.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+# --------------------------------------------------------------------------- #
+# Fix #1 -- SSH transport-retry wrapper.
+# --------------------------------------------------------------------------- #
+
+def test_ssh_transport_retry_succeeds_after_flakes(bake, monkeypatch):
+    """Transport flakes (rc=255, then conn-error with no marker) then SUCCESS.
+
+    Assert:
+      - 3 calls to _run (2 flakes + 1 success)
+      - time.sleep called twice (backoff after each flake)
+      - final result contains the OK marker
+    """
+    call_count: List[int] = [0]
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        call_count[0] += 1
+        n = call_count[0]
+        if n == 1:
+            # Transport flake: SSH own exit code.
+            return 255, "ssh: connect to host node port 22: Connection timed out"
+        if n == 2:
+            # Transport flake: connection-error pattern in output, no marker.
+            return 0, "Connection reset by peer"
+        # Third attempt succeeds.
+        return 0, f"output {bake._VALIDATION_OK_MARKER}"
+
+    sleep_calls: List[float] = []
+    monkeypatch.setattr(bake, "_run", fake_run)
+    monkeypatch.setattr(bake.time, "sleep", lambda s: sleep_calls.append(s))
+
+    rc, out = bake._run_ssh_with_transport_retry(
+        ["gcloud", "compute", "ssh", "node", "--command", "validate"],
+        timeout_s=300.0,
+        max_retries=3,
+        backoff_base=1.0,
+        backoff_cap=10.0,
+    )
+
+    assert call_count[0] == 3, f"expected 3 attempts, got {call_count[0]}"
+    assert len(sleep_calls) == 2, (
+        f"expected 2 backoff sleeps (after flakes 1 and 2), got {len(sleep_calls)}"
+    )
+    assert all(s > 0 for s in sleep_calls), "backoff delays must be positive"
+    assert bake._VALIDATION_OK_MARKER in out
+
+
+def test_ssh_transport_retry_no_marker_retries(bake, monkeypatch):
+    """No verdict marker in output (remote died mid-stream) -> treated as transport -> retry."""
+    call_count: List[int] = [0]
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        call_count[0] += 1
+        if call_count[0] < 3:
+            # No marker, rc=0: remote output truncated (transport flake).
+            return 0, "partial output no marker here"
+        return 0, f"full output {bake._VALIDATION_OK_MARKER}"
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    monkeypatch.setattr(bake.time, "sleep", lambda s: None)
+
+    rc, out = bake._run_ssh_with_transport_retry(
+        ["ssh", "node"],
+        max_retries=3,
+        backoff_base=0.001,
+        backoff_cap=0.01,
+    )
+
+    assert call_count[0] == 3
+    assert bake._VALIDATION_OK_MARKER in out
+
+
+def test_ssh_payload_fail_no_retry(bake, monkeypatch):
+    """FAIL marker present -> fail-closed immediately, exactly 1 attempt, no sleep."""
+    call_count: List[int] = [0]
+    sleep_calls: List[float] = []
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        call_count[0] += 1
+        return 0, f"{bake._VALIDATION_FAIL_MARKER} deps-import: No module named 'uuid6'"
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    monkeypatch.setattr(bake.time, "sleep", lambda s: sleep_calls.append(s))
+
+    rc, out = bake._run_ssh_with_transport_retry(
+        ["gcloud", "compute", "ssh", "node", "--command", "validate"],
+        timeout_s=300.0,
+        max_retries=3,
+        backoff_base=1.0,
+        backoff_cap=10.0,
+    )
+
+    assert call_count[0] == 1, (
+        f"payload fail must be fail-closed (1 attempt), got {call_count[0]}"
+    )
+    assert sleep_calls == [], "no backoff sleep must occur on payload failure"
+    assert bake._VALIDATION_FAIL_MARKER in out
+
+
+def test_ssh_transport_all_retries_exhausted(bake, monkeypatch):
+    """All retries exhausted on transport flakes -> return last result (non-zero)."""
+    call_count: List[int] = [0]
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        call_count[0] += 1
+        return 255, "ssh: connect to host: Connection refused"
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    monkeypatch.setattr(bake.time, "sleep", lambda s: None)
+
+    rc, out = bake._run_ssh_with_transport_retry(
+        ["ssh", "node"],
+        max_retries=3,
+        backoff_base=0.001,
+        backoff_cap=0.01,
+    )
+
+    assert call_count[0] == 3, "all retries must be exhausted"
+    assert rc == 255
+
+
+# --------------------------------------------------------------------------- #
+# Fix #2 -- Lease lifecycle.
+# --------------------------------------------------------------------------- #
+
+class _FakeIacLease:
+    """Captures write_lease / delete_lease calls without touching the filesystem."""
+
+    def __init__(self):
+        self.written: List[Dict[str, Any]] = []
+        self.deleted: List[str] = []
+
+    def write_lease(self, node, zone, pid, ttl_s, lease_dir=None):
+        self.written.append({"node": node, "zone": zone, "pid": pid, "ttl_s": ttl_s})
+
+    def delete_lease(self, node, lease_dir=None):
+        self.deleted.append(node)
+
+
+def test_lease_written_after_node_creation(bake, monkeypatch):
+    """Baker writes lease immediately after node creation (before readiness poll)."""
+    fake_lease = _FakeIacLease()
+    monkeypatch.setattr(bake, "_iac_lease", fake_lease)
+
+    rec = _Recorder(responses=[
+        (lambda j: "images describe" in j, (1, "NOT_FOUND")),
+        (lambda j: "instances create" in j, (0, "created")),
+        (lambda j: "test -f " in j, (0, "SOAK_READY")),
+        (lambda j: "import aiohttp" in j, (0, bake._VALIDATION_OK_MARKER)),
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-lease-test", "<startup>")
+
+    assert rc == 0
+    # Lease must have been written at least once (initial write + heartbeats).
+    written_nodes = [w["node"] for w in fake_lease.written]
+    assert "soak-bake-lease-test" in written_nodes, (
+        "lease must be written for the bake node after creation"
+    )
+    # The lease must carry the baker's own pid.
+    for entry in fake_lease.written:
+        if entry["node"] == "soak-bake-lease-test":
+            assert entry["pid"] == os.getpid(), "lease pid must match baker process"
+            break
+
+
+def test_lease_deleted_on_success(bake, monkeypatch):
+    """Lease is deleted in the finally block on the success path."""
+    fake_lease = _FakeIacLease()
+    monkeypatch.setattr(bake, "_iac_lease", fake_lease)
+
+    rec = _Recorder(responses=[
+        (lambda j: "images describe" in j, (1, "NOT_FOUND")),
+        (lambda j: "instances create" in j, (0, "created")),
+        (lambda j: "test -f " in j, (0, "SOAK_READY")),
+        (lambda j: "import aiohttp" in j, (0, bake._VALIDATION_OK_MARKER)),
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    bake._execute_bake(args, "soak-bake-del-success", "<startup>")
+
+    assert "soak-bake-del-success" in fake_lease.deleted, (
+        "lease must be deleted on the success exit path"
+    )
+
+
+def test_lease_deleted_on_validation_abort(bake, monkeypatch):
+    """Lease is deleted in the finally block even when validation aborts."""
+    fake_lease = _FakeIacLease()
+    monkeypatch.setattr(bake, "_iac_lease", fake_lease)
+
+    rec = _Recorder(responses=[
+        (lambda j: "images describe" in j, (1, "NOT_FOUND")),
+        (lambda j: "instances create" in j, (0, "created")),
+        (lambda j: "test -f " in j, (0, "SOAK_READY")),
+        (lambda j: "import aiohttp" in j,
+         (0, f"{bake._VALIDATION_FAIL_MARKER} broken")),
+    ])
+    monkeypatch.setattr(bake, "_run", rec)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-del-abort", "<startup>")
+
+    assert rc == 6, "validation abort must return exit code 6"
+    assert "soak-bake-del-abort" in fake_lease.deleted, (
+        "lease must be deleted on the abort/failure exit path"
+    )
+
+
+def test_lease_heartbeat_called_during_poll(bake, monkeypatch):
+    """Heartbeat (lease refresh) is called each readiness-poll iteration."""
+    fake_lease = _FakeIacLease()
+    monkeypatch.setattr(bake, "_iac_lease", fake_lease)
+
+    # Node not ready on attempt 1, ready on attempt 2.
+    call_count: List[int] = [0]
+
+    def fake_run(cmd, *, timeout_s=120.0):
+        joined = " ".join(cmd)
+        if "images describe" in joined:
+            return 1, "NOT_FOUND"
+        if "instances create" in joined:
+            return 0, "created"
+        if "test -f " in joined:
+            call_count[0] += 1
+            if call_count[0] == 1:
+                return 0, "SOAK_NOT_READY"
+            return 0, "SOAK_READY"
+        if "tail -n 5" in joined:
+            return 0, "[soak-bake] still installing"
+        if "import aiohttp" in joined:
+            return 0, bake._VALIDATION_OK_MARKER
+        return 0, ""
+
+    monkeypatch.setattr(bake, "_run", fake_run)
+    monkeypatch.setattr(bake.time, "sleep", lambda s: None)
+    args = bake.build_parser().parse_args(["--execute"])
+    rc = bake._execute_bake(args, "soak-bake-heartbeat", "<startup>")
+
+    assert rc == 0
+    # At least two writes: the initial lease write + at least one heartbeat.
+    writes_for_node = [
+        w for w in fake_lease.written if w["node"] == "soak-bake-heartbeat"
+    ]
+    assert len(writes_for_node) >= 2, (
+        f"expected >=2 lease writes (initial + at least 1 heartbeat), "
+        f"got {len(writes_for_node)}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Reaper-spares-leased-node integration test.
+# --------------------------------------------------------------------------- #
+
+def test_reaper_spares_node_with_valid_baker_lease(tmp_path):
+    """A node with a valid baker lease (pid=live, not expired) is NOT reaped.
+
+    Integration test: uses the real iac_lease and a1_orphan_reaper modules
+    loaded via importlib (no real gcloud calls -- injected fake lister/deleter).
+    """
+    iac_lease_mod = _load_iac_lease()
+    reaper_mod = _load_reaper()
+
+    node = "jarvis-soak-bake-live-lease-test"
+    lease_dir = tmp_path / "leases"
+    lease_dir.mkdir(parents=True, exist_ok=True)
+
+    # Write a valid lease owned by the current (live) process.
+    iac_lease_mod.write_lease(node, "us-central1-a", os.getpid(), 3600, lease_dir)
+
+    # Verify the lease is seen as valid by the sync helper.
+    valid, reason = iac_lease_mod.is_lease_valid(node, lease_dir)
+    assert valid, f"freshly written lease must be valid; got reason={reason!r}"
+
+    reaped: List[str] = []
+
+    import datetime as _dt
+
+    def _make_old_instance(name):
+        created = _dt.datetime.utcnow() - _dt.timedelta(seconds=1000)
+        ts = created.strftime("%Y-%m-%dT%H:%M:%S.000+00:00")
+        return {"name": name, "zone": "us-central1-a", "creationTimestamp": ts}
+
+    async def fake_lister(project, prefixes):
+        return [_make_old_instance(node)]
+
+    async def fake_deleter(project, node_name, zone):
+        reaped.append(node_name)
+
+    reaper = reaper_mod.OrphanReaper(
+        lease_dir=lease_dir,
+        project="test-project",
+        zone="us-central1-a",
+        boot_grace_s=0,  # no grace -- node is old enough
+        dry_run=False,
+        instance_lister=fake_lister,
+        instance_deleter=fake_deleter,
+    )
+    asyncio.run(reaper.run_once())
+
+    assert node not in reaped, (
+        "OrphanReaper must NOT reap a node that has a valid live baker lease"
+    )


### PR DESCRIPTION
## Self-healing bake + live OrphanReaper — no shields lowered

A real bake proved the immutable install works (node ready → deps+Docker baked), but the post-bake **validation SSH transiently flaked (rc=1)** and the baker aborted (no retry). Fixes:

### 1. Idempotent SSH wrapper (`bake_soak_golden_image.py`)
Classifies every validation result (first-match-wins): validation-FAIL marker → **payload, fail-closed (no retry, never snapshot a broken image)**; rc==255 / connection-error stderr / no-verdict-marker → **transport → async exp-backoff retry** (`JARVIS_BAKE_SSH_MAX_RETRIES`=3, base 10s, cap 120s, jitter). Transport flakes self-heal; real test failures still fail-closed.

### 2. Bake-node lease heartbeat (activates the reaper safely)
New shared `iac_lease.py` (single `{node,zone,pid,expires_ts}` shape; reaper + baker both import it — no duplication). The baker writes a lease right after node-create, **re-extends it every readiness-poll + backoff** (heartbeat), and deletes it in `finally`. So the OrphanReaper **spares the live bake node** (valid lease) and reaps only true orphans (dead-pid/expired) — the reaper can now run live during bakes with **no defense shields lowered**.

### 3. Reaper filter fix
gcloud `--filter` syntax (single quoted anchor, not per-alt `^`) — the bare `name~(^a|^b)` made gcloud's parser choke. Now the reaper lists + reaps for real.

**Tests:** 32 baker + 9 reaper green (incl. transport-retry, payload-fail-closed, lease lifecycle, reaper-spares-leased-node interop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the bake pipeline self-healing and safe to run the OrphanReaper during bakes. Adds a resilient SSH validation wrapper and a bake-node lease heartbeat so live bake nodes are never reaped.

- **New Features**
  - Resilient SSH validation: retries on transport flakes (rc=255, connection errors, or missing verdict marker) with exponential backoff and jitter; fails closed immediately on a payload `VALIDATION_FAIL` verdict.
  - Bake-node lease heartbeat: writes and refreshes a lease (`{node, zone, pid, expires_ts}`) during readiness/validation and deletes it on exit; shared helpers live in `scripts/iac_lease.py`.

- **Bug Fixes**
  - Re-applied `gcloud --filter` fix (single quoted anchor) so the reaper lists and deletes matching instances reliably; dry-run now lists instead of erroring.
  - Reaper delegates lease reading/writing/validation to the shared module and skips nodes with a valid live lease.

<sup>Written for commit 18181c1db3839b345bd4cf9bb45b8c349e552373. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69744?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

