### PR TITLE
fix(a1): pin file-isolation OFF for ephemeral cloud soak — the last durable-apply blocker (PR J)

### DIFF
--- a/scripts/a1_launch_manifest.py
+++ b/scripts/a1_launch_manifest.py
@@ -22,7 +22,7 @@ from pathlib import Path
 from typing import Any, Dict, Optional
 
 SCHEMA_VERSION = "a1-launch.1"
-REQUIRED_KEYS = {"schema_version", "model", "native_tool_forcing", "epistemic_feedback", "failover_lifecycle"}
+REQUIRED_KEYS = {"schema_version", "model", "native_tool_forcing", "epistemic_feedback", "failover_lifecycle", "file_isolation"}
 
 
 class A1ManifestError(Exception):
@@ -35,6 +35,7 @@ def build_manifest(
     native_tool_forcing: bool,
     epistemic_feedback: bool,
     failover_lifecycle: bool = False,
+    file_isolation: bool = False,
     seed: Optional[int] = None,
     cost_cap: Optional[float] = None,
     max_wall_seconds: Optional[int] = None,
@@ -47,6 +48,7 @@ def build_manifest(
         "native_tool_forcing": native_tool_forcing,
         "epistemic_feedback": epistemic_feedback,
         "failover_lifecycle": failover_lifecycle,
+        "file_isolation": file_isolation,
     }
     if seed is not None:
         core["seed"] = seed
@@ -102,6 +104,13 @@ def apply_manifest(manifest: Dict[str, Any], env: Dict[str, str]) -> Dict[str, s
     # Prevents the shell-var-propagation gap that let JARVIS_FAILOVER_LIFECYCLE_ENABLED
     # default to "true" on the node and spawn J-Prime mid-soak.
     env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] = "true" if manifest.get("failover_lifecycle") else "false"
+    # Deterministic file-isolation pin: always written (true/false), never absent.
+    # On an ephemeral cloud node there is no operator checkout to protect, so both
+    # isolation flags MUST be false -> autonomous writes land in repo_root ->
+    # durable commit (written=True), fixing the fsm_classify_to_applied A1 blocker.
+    # Mirrors the failover_lifecycle pin: BOTH flags written deterministically.
+    env["JARVIS_FILE_ISOLATION_ENABLED"] = "true" if manifest.get("file_isolation") else "false"
+    env["JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED"] = "true" if manifest.get("file_isolation") else "false"
     if manifest.get("seed") is not None:
         env["JARVIS_CHAOS_SEED"] = str(manifest["seed"])
     if manifest.get("cost_cap") is not None:

--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -277,6 +277,7 @@ def compose_env(*, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         native_tool_forcing=True,
         epistemic_feedback=True,
         failover_lifecycle=False,
+        file_isolation=False,
     )
     apply_manifest(_a1_manifest, env)
     return env
@@ -1240,6 +1241,7 @@ def provision_and_run_remote(*, cost_cap: float, wall_seconds: int, seed: int,
         native_tool_forcing=True,
         epistemic_feedback=True,
         failover_lifecycle=False,
+        file_isolation=False,
         seed=seed,
         cost_cap=cost_cap,
         max_wall_seconds=wall_seconds,

--- a/tests/scripts/test_a1_launch_manifest.py
+++ b/tests/scripts/test_a1_launch_manifest.py
@@ -309,6 +309,110 @@ def test_apply_manifest_failover_always_written():
 # ===========================================================================
 
 
+# ===========================================================================
+# file_isolation: required key, apply writes BOTH isolation flags
+# ===========================================================================
+
+
+def test_build_manifest_file_isolation_default_false():
+    """build_manifest includes file_isolation=False by default."""
+    m = build_manifest(model="x", native_tool_forcing=True, epistemic_feedback=True)
+    assert "file_isolation" in m
+    assert m["file_isolation"] is False
+
+
+def test_build_manifest_file_isolation_explicit_false():
+    """build_manifest(file_isolation=False) is explicit and present."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        file_isolation=False,
+    )
+    assert m["file_isolation"] is False
+
+
+def test_build_manifest_file_isolation_true():
+    """build_manifest(file_isolation=True) round-trips correctly."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        file_isolation=True,
+    )
+    assert m["file_isolation"] is True
+
+
+def test_apply_manifest_file_isolation_false_sets_both_flags_false():
+    """apply_manifest(file_isolation=False) writes BOTH isolation flags as 'false'."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        file_isolation=False,
+    )
+    env: dict = {}
+    apply_manifest(m, env)
+    assert env["JARVIS_FILE_ISOLATION_ENABLED"] == "false"
+    assert env["JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED"] == "false"
+
+
+def test_apply_manifest_file_isolation_true_sets_both_flags_true():
+    """apply_manifest(file_isolation=True) writes BOTH isolation flags as 'true'."""
+    m = build_manifest(
+        model="x", native_tool_forcing=True, epistemic_feedback=True,
+        file_isolation=True,
+    )
+    env: dict = {}
+    apply_manifest(m, env)
+    assert env["JARVIS_FILE_ISOLATION_ENABLED"] == "true"
+    assert env["JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED"] == "true"
+
+
+def test_apply_manifest_file_isolation_always_written():
+    """apply_manifest writes BOTH isolation env vars whether True or False
+    (never absent -- prevents the force-arm gap on an ephemeral cloud node)."""
+    for flag_val in (True, False):
+        m = build_manifest(
+            model="x", native_tool_forcing=False, epistemic_feedback=False,
+            file_isolation=flag_val,
+        )
+        env: dict = {}
+        apply_manifest(m, env)
+        assert "JARVIS_FILE_ISOLATION_ENABLED" in env, (
+            "JARVIS_FILE_ISOLATION_ENABLED must always be present in env "
+            "(prevents cloud-node force-arm gap)"
+        )
+        assert "JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED" in env, (
+            "JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED must always be present in env "
+            "(prevents cloud-node force-arm gap)"
+        )
+
+
+def test_load_and_validate_requires_file_isolation(tmp_path):
+    """Manifest missing file_isolation -> A1ManifestError (missing required keys)."""
+    p = tmp_path / "no_file_isolation.json"
+    p.write_text(json.dumps({
+        "schema_version": SCHEMA_VERSION,
+        "model": "x",
+        "native_tool_forcing": True,
+        "epistemic_feedback": True,
+        "failover_lifecycle": False,
+        # file_isolation intentionally omitted
+    }))
+    with pytest.raises(A1ManifestError, match="missing required keys"):
+        load_and_validate(p)
+
+
+def test_round_trip_includes_file_isolation(tmp_path):
+    """build -> write -> load_and_validate preserves file_isolation."""
+    m = build_manifest(
+        model="Qwen/Qwen3.5-397B-A17B-FP8",
+        native_tool_forcing=True,
+        epistemic_feedback=True,
+        failover_lifecycle=False,
+        file_isolation=False,
+    )
+    p = tmp_path / "A1_LAUNCH_MANIFEST.json"
+    write_manifest(p, m)
+    loaded = load_and_validate(p)
+    assert loaded["file_isolation"] is False
+
+
 def test_compose_env_compat():
     """compose_env output contains the 3 flag keys injected via apply_manifest
     (byte-compatible with the A1 launch spec)."""
@@ -334,6 +438,15 @@ def test_compose_env_compat():
         assert env.get("JARVIS_FAILOVER_LIFECYCLE_ENABLED") == "false", (
             "compose_env must pin JARVIS_FAILOVER_LIFECYCLE_ENABLED=false via apply_manifest "
             "(prevents J-Prime spawn mid-soak when the shell var does not propagate)"
+        )
+        # File-isolation must be deterministically pinned OFF on the cloud node.
+        assert env.get("JARVIS_FILE_ISOLATION_ENABLED") == "false", (
+            "compose_env must pin JARVIS_FILE_ISOLATION_ENABLED=false via apply_manifest "
+            "(ephemeral cloud node has no operator checkout; isolation worktree is unusable)"
+        )
+        assert env.get("JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED") == "false", (
+            "compose_env must pin JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED=false via apply_manifest "
+            "(prevents force-arm of file-isolation that routes writes to a broken worktree)"
         )
     except Exception as exc:
         pytest.skip("compose_env import requires full harness setup: %s" % exc)


### PR DESCRIPTION
## The last `written=False` blocker — file-isolation on an ephemeral node

Cloud Confirm 5 proved the cognitive loop end-to-end (Qwen explored → `state=applied`), and PR F's AutoCommitter fallback fired correctly (`4 workspace override invalid`). But APPLIED still wasn't durable (`written=False`) because of `6 cannot change to '.../.worktrees/ouroboros__auto__bt-<session>'`: the **deterministic isolation lock** (`JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED`, default-true) force-armed **file-isolation** on the node, routing autonomous WRITES to a worktree that isn't usable there → the patch landed nowhere durable.

**On an ephemeral, disposable cloud node there is no operator checkout to protect** — file-isolation is a dev-machine concern, unnecessary here. Pinning it OFF (both `JARVIS_FILE_ISOLATION_ENABLED` and the deterministic lock = false) via the launch manifest sends writes straight to `repo_root` → durable commit → `written=True` → `fsm_classify_to_applied=TRUE`. This is the correct posture for the environment, mirroring the existing `failover_lifecycle` manifest pin (no new mechanism).

**Tests:** 30 manifest green (both isolation flags written deterministically; default-False = current prod default → zero behavior change off the A1 path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins file isolation OFF for ephemeral cloud runs by adding a `file_isolation` flag to the A1 launch manifest and writing both isolation env vars deterministically. Autonomous writes now land in `repo_root`, making commits durable (`written=True`) and unblocking `fsm_classify_to_applied`.

- **Bug Fixes**
  - Added `file_isolation` (default false) to manifest schema and required keys.
  - `apply_manifest` sets `JARVIS_FILE_ISOLATION_ENABLED` and `JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED` based on `file_isolation` (always written, true/false).
  - Harness pins `file_isolation=False` for compose and remote runs.
  - Tests validate default/explicit values, deterministic flag writing, required key enforcement, and `compose_env` expectations.

- **Migration**
  - Update existing A1 launch manifests to include `file_isolation: false`.

<sup>Written for commit 21a06d0562cda2e310b51f1b7b447b1e7546f7f3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69745?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

