### PR TITLE
feat(failover): wire live J-Prime in-flight count into the zero-drop drain

### DIFF
--- a/backend/core/ouroboros/governance/_governance_state.py
+++ b/backend/core/ouroboros/governance/_governance_state.py
@@ -311,6 +311,11 @@ class PrimeProviderState:
     """
 
     client: Any = None  # PrimeClient
+    # Generation-scoped in-flight counter -- the number of J-Prime generations
+    # currently crunching. The failover Zero-Drop Drain reads this to await
+    # in-flight ops before teardown. Hoisted here (not on the provider instance)
+    # so it survives importlib.reload(). GIL-safe int incr/decr.
+    inflight: int = 0
 
     @classmethod
     def fresh(cls) -> "PrimeProviderState":

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -1862,12 +1862,22 @@ class FailoverLifecycleController:
         logger.info("[FailoverLifecycle] DORMANT (delete-to-snapshot complete)")
 
     def _inflight_count(self) -> int:
-        """Count of in-flight J-Prime ops. Injected ``in_flight_fn`` or 0 (no
-        tracker -> immediate teardown). NEVER raises -> 0 on error (fail-open to
-        teardown; the Dead-Man's Switch backstops a wrong 0)."""
+        """Count of in-flight J-Prime ops. An explicit injected ``in_flight_fn``
+        wins; otherwise lazily resolves the LIVE generation count from the
+        providers module (``get_jprime_inflight_count`` -- the PrimeProvider
+        increments it for the duration of each J-Prime generation). Symmetric
+        with how ``_is_degrading`` resolves the heartbeat. NEVER raises -> 0
+        (fail-open to teardown; the Dead-Man's Switch backstops a wrong 0)."""
         fn = self._in_flight_fn
         if fn is None:
-            return 0
+            try:
+                from backend.core.ouroboros.governance.providers import (  # noqa: PLC0415
+                    get_jprime_inflight_count,
+                )
+                fn = get_jprime_inflight_count
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[FailoverLifecycle] inflight resolve fail-soft err=%r", exc)
+                return 0
         try:
             return max(0, int(fn()))
         except Exception as exc:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import base64
+import contextlib
 import contextvars
 import dataclasses
 import functools
@@ -5126,6 +5127,39 @@ def _parse_generation_response(
 # ---------------------------------------------------------------------------
 
 
+def get_jprime_inflight_count() -> int:
+    """The live count of J-Prime generations currently crunching. Read by the
+    failover Zero-Drop Drain to await in-flight ops before teardown. Fail-soft
+    -> 0 (fail-open to teardown; the node Dead-Man's Switch backstops a wrong 0)."""
+    try:
+        from ._governance_state import get_prime_provider_state  # noqa: PLC0415
+        return max(0, int(getattr(get_prime_provider_state(), "inflight", 0)))
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+@contextlib.contextmanager
+def _jprime_inflight_guard():
+    """Bracket a single J-Prime generation: increment the hoisted in-flight
+    counter for its duration, decrement on EVERY exit (return OR exception) so a
+    failed generation never leaks a phantom in-flight op. GIL-safe int math."""
+    st = None
+    try:
+        from ._governance_state import get_prime_provider_state  # noqa: PLC0415
+        st = get_prime_provider_state()
+        st.inflight = int(getattr(st, "inflight", 0)) + 1
+    except Exception:  # noqa: BLE001
+        st = None
+    try:
+        yield
+    finally:
+        if st is not None:
+            try:
+                st.inflight = max(0, int(getattr(st, "inflight", 1)) - 1)
+            except Exception:  # noqa: BLE001
+                pass
+
+
 class PrimeProvider:
     """CandidateProvider adapter wrapping PrimeClient.generate().
 
@@ -5191,6 +5225,22 @@ class PrimeProvider:
         return "gcp-jprime"
 
     async def generate(
+        self,
+        context: OperationContext,
+        deadline: datetime,
+        repair_context: Optional[Any] = None,
+        *,
+        temperature: Optional[float] = None,
+    ) -> GenerationResult:
+        """Generation entrypoint. Brackets the J-Prime generation with the
+        in-flight guard (the failover Zero-Drop Drain awaits this count before
+        teardown -- no op severed mid-generation), then delegates to the impl."""
+        with _jprime_inflight_guard():
+            return await self._generate_impl(
+                context, deadline, repair_context, temperature=temperature,
+            )
+
+    async def _generate_impl(
         self,
         context: OperationContext,
         deadline: datetime,

--- a/tests/governance/test_jprime_inflight_wiring.py
+++ b/tests/governance/test_jprime_inflight_wiring.py
@@ -1,0 +1,83 @@
+"""Wire the live J-Prime in-flight count into the failover controller's drain.
+
+The Zero-Drop Drain's ``in_flight_fn`` was injectable but defaulted to 0. The
+PRECISE in-flight signal is the ``PrimeProvider.generate`` scope itself -- a
+generation-scoped counter on the hoisted PrimeProviderState (reload-surviving),
+incremented for the duration of each J-Prime generation. The controller resolves
+it lazily (symmetric with how it resolves the DW heartbeat) -- no GLS poking, no
+duplication of the existing in_flight_registry (which is op-lifecycle-scoped and
+stamps provider at intake, before routing resolves).
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.providers as providers
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import provider_quarantine as pq
+from backend.core.ouroboros.governance.failover_lifecycle import (
+    FailoverLifecycleController,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    # Reset the hoisted counter.
+    try:
+        from backend.core.ouroboros.governance._governance_state import (
+            get_prime_provider_state,
+        )
+        get_prime_provider_state().inflight = 0
+    except Exception:
+        pass
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+def test_inflight_count_zero_when_idle():
+    assert providers.get_jprime_inflight_count() == 0
+
+
+def test_guard_increments_for_duration():
+    assert providers.get_jprime_inflight_count() == 0
+    with providers._jprime_inflight_guard():
+        assert providers.get_jprime_inflight_count() == 1
+        with providers._jprime_inflight_guard():
+            assert providers.get_jprime_inflight_count() == 2  # nested generations
+        assert providers.get_jprime_inflight_count() == 1
+    assert providers.get_jprime_inflight_count() == 0  # drained on exit
+
+
+def test_guard_decrements_on_exception():
+    try:
+        with providers._jprime_inflight_guard():
+            assert providers.get_jprime_inflight_count() == 1
+            raise RuntimeError("generation failed")
+    except RuntimeError:
+        pass
+    assert providers.get_jprime_inflight_count() == 0  # never leaks a phantom op
+
+
+def test_controller_inflight_defaults_to_jprime_count(monkeypatch):
+    """With NO injected in_flight_fn, the controller reads the live J-Prime
+    generation count from the providers module (lazy default)."""
+    monkeypatch.setattr(providers, "get_jprime_inflight_count", lambda: 3)
+    ctrl = FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: True, vm_delete_fn=lambda: True,
+        node_ready_fn=lambda e: True, clock_fn=lambda: 1.0,
+        # in_flight_fn intentionally omitted -> lazy default
+    )
+    assert ctrl._inflight_count() == 3
+
+
+def test_injected_in_flight_fn_still_wins(monkeypatch):
+    monkeypatch.setattr(providers, "get_jprime_inflight_count", lambda: 99)
+    ctrl = FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: True, vm_delete_fn=lambda: True,
+        node_ready_fn=lambda e: True, clock_fn=lambda: 1.0,
+        in_flight_fn=lambda: 1,
+    )
+    assert ctrl._inflight_count() == 1  # explicit injection overrides the default


### PR DESCRIPTION
## Summary
Completes the Zero-Drop Drain production hookup. The failover HANDBACK now awaits the **real, live count of J-Prime generations currently crunching** before teardown — no op severed mid-generation.

- `PrimeProviderState.inflight` — reload-surviving, generation-scoped counter (leverages the existing hoisted state; no duplication of the op-lifecycle `in_flight_registry`, which stamps provider at intake before routing resolves).
- `providers._jprime_inflight_guard()` brackets each `PrimeProvider.generate` (rename → `_generate_impl` + thin wrapper): +1 for the duration, −1 on **every** exit (return or exception → no phantom leak). GIL-safe.
- `get_jprime_inflight_count()` — the live read.
- `FailoverLifecycleController._inflight_count` lazily resolves it when no `in_flight_fn` is injected (symmetric with how `_is_degrading` resolves the heartbeat). Explicit injection still wins. Fail-soft → 0.

5 new tests. Builds on the merged Sovereign Failover Mesh (#69746).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Failover handback now waits on the live count of J‑Prime generations before teardown, preventing mid-generation cuts. This wires a real in-flight signal into the Zero‑Drop Drain.

- **New Features**
  - Added `PrimeProviderState.inflight`: reload‑surviving generation counter.
  - Added `providers._jprime_inflight_guard()` to bracket each generation (+1 on enter, −1 on any exit).
  - Wrapped `PrimeProvider.generate` with the guard and moved logic to `_generate_impl`.
  - Exposed `providers.get_jprime_inflight_count()` for a live read.
  - Updated `FailoverLifecycleController._inflight_count` to lazily use the live count when no `in_flight_fn` is injected (explicit injection still wins; fail‑soft to 0).
  - Added tests for idle, nesting, exception, default resolution, and injection precedence.

<sup>Written for commit 5d1b8476772694457fa1fc9e639a496b6e779837. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

