### PR TITLE
feat(venom): cognitive armor — semantic loop breaker + provider-aware schema compaction

### DIFF
--- a/backend/core/ouroboros/governance/cognitive_loop_breaker.py
+++ b/backend/core/ouroboros/governance/cognitive_loop_breaker.py
@@ -1,0 +1,131 @@
+"""cognitive_loop_breaker.py -- Semantic Loop Breaker (Venom cognitive armor).
+
+A small (7B) model will confidently emit the SAME broken tool call several rounds
+in a row -- a repetition hallucination that the coarse budget/iteration guards
+don't catch until tokens and deadline are already burned. This heuristic breaker
+tracks the SEMANTIC SIMILARITY of the last ``window`` rounds' tool calls; when the
+model is provably stuck it snaps the circuit so the loop can eject early with the
+best context already gathered.
+
+Pure + dependency-free: an order-independent normalized signature per round +
+``difflib.SequenceMatcher`` ratio (stdlib, no embeddings). Fail-soft + gated:
+any error / OFF / sub-window history -> ``False`` (never a false eject).
+
+Env
+---
+JARVIS_VENOM_LOOP_BREAKER_ENABLED     default "true"
+JARVIS_VENOM_LOOP_BREAKER_WINDOW      default 3  (consecutive rounds to compare)
+JARVIS_VENOM_LOOP_BREAKER_SIMILARITY  default 0.9 (>= -> 'same' round)
+"""
+from __future__ import annotations
+
+import logging
+import os
+import re
+from collections import deque
+from difflib import SequenceMatcher
+from typing import Any, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+_WS = re.compile(r"\s+")
+
+
+def _enabled() -> bool:
+    val = (os.environ.get("JARVIS_VENOM_LOOP_BREAKER_ENABLED", "true") or "true").strip().lower()
+    return val not in ("false", "0", "no", "off")
+
+
+def _window() -> int:
+    try:
+        return max(2, int(os.environ.get("JARVIS_VENOM_LOOP_BREAKER_WINDOW", "3")))
+    except (ValueError, TypeError):
+        return 3
+
+
+def _similarity_threshold() -> float:
+    try:
+        return min(1.0, max(0.0, float(
+            os.environ.get("JARVIS_VENOM_LOOP_BREAKER_SIMILARITY", "0.9")
+        )))
+    except (ValueError, TypeError):
+        return 0.9
+
+
+def call_signature(tool_calls: Optional[Sequence[Any]]) -> str:
+    """Deterministic, ORDER-INDEPENDENT normalized signature for one round of
+    tool calls (each has ``.name`` + ``.arguments``). NEVER raises -> "" on error."""
+    try:
+        parts = []
+        for c in (tool_calls or []):
+            name = str(getattr(c, "name", "") or "")
+            args = getattr(c, "arguments", {}) or {}
+            try:
+                arg_str = ",".join("{}={}".format(k, args[k]) for k in sorted(args, key=str))
+            except Exception:  # noqa: BLE001
+                arg_str = str(args)
+            parts.append("{}({})".format(name, arg_str))
+        parts.sort()  # order-independent across the round's calls
+        return _WS.sub(" ", "|".join(parts).strip().lower())
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _name_set(tool_calls: Optional[Sequence[Any]]) -> frozenset:
+    """The multiset-as-set of tool NAMES in a round. A round that calls a
+    DIFFERENT tool is genuine progress, never repetition -- the name is the
+    dominant discriminator (args alone can look similar across distinct actions)."""
+    try:
+        return frozenset(str(getattr(c, "name", "") or "") for c in (tool_calls or []))
+    except Exception:  # noqa: BLE001
+        return frozenset()
+
+
+class SemanticLoopBreaker:
+    """Stateful per-tool-loop repetition detector. One instance per Venom run."""
+
+    def __init__(self) -> None:
+        # Each entry: (name_set, signature_string).
+        self._rounds: "deque" = deque(maxlen=_window())
+
+    def observe(self, tool_calls: Optional[Sequence[Any]]) -> bool:
+        """Record this round's tool calls; return True iff the model is stuck in
+        a semantic repetition loop -- the last ``window`` rounds ALL call the SAME
+        tools with args pairwise-similar at/above the threshold. Gated + fail-soft
+        -> False (never a false eject; an empty round is not repetition)."""
+        try:
+            if not _enabled() or not tool_calls:
+                return False
+            sig = call_signature(tool_calls)
+            if not sig:
+                return False
+            self._rounds.append((_name_set(tool_calls), sig))
+            win = _window()
+            if len(self._rounds) < win:
+                return False
+            recent = list(self._rounds)[-win:]
+            thr = _similarity_threshold()
+            for (na, sa), (nb, sb) in zip(recent, recent[1:]):
+                # Different tools => progress, not a loop. Same tools => compare args.
+                if na != nb or SequenceMatcher(None, sa, sb).ratio() < thr:
+                    return False
+            logger.warning(
+                "[CognitiveLoopBreaker] semantic repetition over %d rounds "
+                "(same tools, args pairwise >=%.2f) -- snapping the circuit "
+                "(model stuck)", win, thr,
+            )
+            return True
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[CognitiveLoopBreaker] observe fail-soft err=%r", exc)
+            return False
+
+    def reset(self) -> None:
+        """Genuine progress -> clear the window (caller may reset on a successful
+        mutating tool result). Fail-soft."""
+        try:
+            self._rounds.clear()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+__all__ = ["SemanticLoopBreaker", "call_signature"]

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -2052,6 +2052,67 @@ def _route_stable_tail(
         parts.append(schema_section)
 
 
+import re as _re_compact
+
+# Verbose optional tool-section blocks a small (7B) model does not need and that
+# overflow its context. Matched by the START of their "### " header (substring).
+_COMPACT_DROP_HEADERS = ("parallel tool calls", "voice-first")
+
+
+def _compact_tool_budget() -> int:
+    try:
+        return max(100, int(os.environ.get("JARVIS_VENOM_COMPACT_TOOL_MAX_CHARS", "4000")))
+    except (ValueError, TypeError):
+        return 4000
+
+
+def compact_tool_section(section: str) -> str:
+    """Provider-aware cognitive armor: strip the verbose optional essays from the
+    tool section (keeping the essential envelope + tool list), collapse blank
+    lines, and hard-truncate to a char budget -- so a 7B model isn't drowned.
+    Marker-driven (no hardcoded content). Fail-soft -> the original on any error."""
+    try:
+        if not section or not isinstance(section, str):
+            return section
+        # Split into the leading content + ("### header", body) pairs.
+        chunks = _re_compact.split(r"(?m)^(### .+)$", section)
+        out = [chunks[0]]
+        i = 1
+        while i < len(chunks):
+            header = chunks[i]
+            body = chunks[i + 1] if i + 1 < len(chunks) else ""
+            drop = any(h in header.lower() for h in _COMPACT_DROP_HEADERS)
+            if not drop:
+                out.append(header)
+                out.append(body)
+            i += 2
+        result = _re_compact.sub(r"\n{3,}", "\n\n", "".join(out)).strip()
+        budget = _compact_tool_budget()
+        if len(result) > budget:
+            result = result[:budget].rstrip() + (
+                "\n... [tool list truncated for compact context] ...\n"
+            )
+        return result
+    except Exception:  # noqa: BLE001
+        return section
+
+
+def _should_compact_for_jprime() -> bool:
+    """Compact the tool section iff the failover FSM reports J-Prime is the active
+    generator. Dynamic + provider-aware with NO hardcoded provider check -- the
+    FSM IS the signal. Master-gated (default ON). Fail-soft -> False."""
+    val = (os.environ.get("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "true") or "true").strip().lower()
+    if val in ("false", "0", "no", "off"):
+        return False
+    try:
+        from backend.core.ouroboros.governance.failover_lifecycle import (  # noqa: PLC0415
+            get_failover_controller,
+        )
+        return bool(get_failover_controller().is_jprime_serving())
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _build_tool_section(
     mcp_tools: Optional[List[Dict[str, Any]]] = None,
     *,
@@ -2518,7 +2579,13 @@ def _build_exploration_manifest_block(manifest: Any) -> str:
             if _extra_ft > 0:
                 lines.append(f"- _(+{_extra_ft} more)_")
 
-        return "\n".join(lines)
+        _section = "\n".join(lines)
+        # Cognitive armor: when the failover FSM reports J-Prime (7B) is the
+        # active generator, dynamically compact the section to cut cognitive load
+        # + context overflow. Fail-soft -> the full section.
+        if _should_compact_for_jprime():
+            _section = compact_tool_section(_section)
+        return _section
     except Exception:  # noqa: BLE001 — Slice 89 never-raises contract
         return ""
 

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -6097,6 +6097,16 @@ class ToolLoopCoordinator:
         # generation deadline.
         round_index = -1
         _explore_only_rounds = 0
+        # Cognitive armor (Venom): semantic loop breaker -- snaps the circuit when
+        # a (small) model is stuck hallucinating the SAME tool call across rounds.
+        try:
+            from backend.core.ouroboros.governance.cognitive_loop_breaker import (  # noqa: PLC0415
+                SemanticLoopBreaker,
+            )
+            _loop_breaker = SemanticLoopBreaker()
+        except Exception:  # noqa: BLE001 -- never block the loop on the armor
+            _loop_breaker = None
+        _breaker_nudged = False
         # Slice 85 Phase 3 — cumulative read-only-call counter (evasion-proof
         # convergence axis; mixed-tool wandering still accrues here).
         _cumulative_explore_calls = 0
@@ -6283,6 +6293,33 @@ class ToolLoopCoordinator:
             if tool_calls is None:
                 self._finalize_run(op_id)
                 return raw, records   # Final non-tool response
+
+            # Cognitive armor: SEMANTIC LOOP BREAKER. A stuck (small) model emits
+            # the same broken tool call(s) round after round. First trip -> one
+            # forced synthesis nudge ("stop, answer now with what you have").
+            # Persisting -> HARD EJECT with the best context already gathered,
+            # rather than burning tokens/deadline on the hallucination. Fail-soft.
+            if _loop_breaker is not None and _loop_breaker.observe(tool_calls):
+                if not _breaker_nudged:
+                    _breaker_nudged = True
+                    current_prompt += (
+                        "\n\n[SYSTEM] You are REPEATING the same tool call(s) -- "
+                        "this is a loop and the result will not change. STOP calling "
+                        "tools. Emit your FINAL answer NOW, synthesizing the context "
+                        "you have already gathered.\n"
+                    )
+                    logger.warning(
+                        "[ToolLoop] op=%s semantic repetition -> forced synthesis "
+                        "nudge (one chance before hard eject)", op_id,
+                    )
+                    continue
+                logger.warning(
+                    "[ToolLoop] op=%s semantic repetition PERSISTS after nudge -> "
+                    "HARD EJECT with best gathered context (%d record(s))",
+                    op_id, len(records),
+                )
+                self._finalize_run(op_id)
+                return raw, records   # best-available context, not blind burn
 
             # Slice 233 — parse-gate enforcement of convergence. Once the
             # final-write nudge has fired we promised the model "further tool

--- a/tests/governance/test_cognitive_loop_breaker.py
+++ b/tests/governance/test_cognitive_loop_breaker.py
@@ -1,0 +1,92 @@
+"""Semantic Loop Breaker -- cognitive armor for the Venom tool loop.
+
+A small (7B) model will confidently hallucinate the SAME broken tool call several
+rounds in a row, burning tokens and deadline. The existing budget/iteration
+guards are too coarse. This heuristic breaker tracks the SEMANTIC SIMILARITY of
+the last N rounds' tool calls; when the model is stuck in a repetition loop it
+snaps the circuit so the orchestrator can eject with the best context gathered.
+
+Pure, dependency-free (token-Jaccard, no embeddings) -- fail-soft, gated.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.cognitive_loop_breaker import (
+    SemanticLoopBreaker,
+    call_signature,
+)
+
+
+class _Call:
+    def __init__(self, name, arguments):
+        self.name = name
+        self.arguments = arguments
+
+
+def _round(*calls):
+    return [_Call(n, a) for n, a in calls]
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_LOOP_BREAKER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_VENOM_LOOP_BREAKER_WINDOW", "3")
+    monkeypatch.setenv("JARVIS_VENOM_LOOP_BREAKER_SIMILARITY", "0.9")
+    yield
+
+
+def test_identical_call_three_rounds_trips():
+    b = SemanticLoopBreaker()
+    assert b.observe(_round(("read_file", {"path": "a.py"}))) is False  # round 1
+    assert b.observe(_round(("read_file", {"path": "a.py"}))) is False  # round 2
+    assert b.observe(_round(("read_file", {"path": "a.py"}))) is True   # round 3 -> LOOP
+
+
+def test_varied_calls_never_trip():
+    b = SemanticLoopBreaker()
+    assert b.observe(_round(("read_file", {"path": "a.py"}))) is False
+    assert b.observe(_round(("search_code", {"q": "foo"}))) is False
+    assert b.observe(_round(("edit_file", {"path": "b.py"}))) is False
+
+
+def test_below_window_does_not_trip():
+    b = SemanticLoopBreaker()
+    assert b.observe(_round(("read_file", {"path": "a.py"}))) is False
+    assert b.observe(_round(("read_file", {"path": "a.py"}))) is False  # only 2 (<3)
+
+
+def test_near_identical_trips_above_threshold():
+    """Tiny variation (one extra arg) still >0.9 similar -> stuck loop."""
+    b = SemanticLoopBreaker()
+    b.observe(_round(("bash", {"cmd": "pytest tests/foo.py -x -v -q --tb=short"})))
+    b.observe(_round(("bash", {"cmd": "pytest tests/foo.py -x -v -q --tb=long"})))
+    assert b.observe(_round(("bash", {"cmd": "pytest tests/foo.py -x -v -q --tb=auto"}))) is True
+
+
+def test_progress_resets_the_loop():
+    b = SemanticLoopBreaker()
+    b.observe(_round(("read_file", {"path": "a.py"})))
+    b.observe(_round(("read_file", {"path": "a.py"})))
+    b.observe(_round(("edit_file", {"path": "a.py"})))  # genuine progress
+    # The window no longer has 3 identical -> not looping.
+    assert b.observe(_round(("read_file", {"path": "a.py"}))) is False
+
+
+def test_gate_off_never_trips(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_LOOP_BREAKER_ENABLED", "false")
+    b = SemanticLoopBreaker()
+    for _ in range(5):
+        assert b.observe(_round(("read_file", {"path": "a.py"}))) is False
+
+
+def test_empty_rounds_are_safe():
+    b = SemanticLoopBreaker()
+    assert b.observe([]) is False
+    assert b.observe(None) is False  # type: ignore[arg-type]
+
+
+def test_call_signature_is_order_independent():
+    s1 = call_signature(_round(("a", {"x": 1}), ("b", {"y": 2})))
+    s2 = call_signature(_round(("b", {"y": 2}), ("a", {"x": 1})))
+    assert s1 == s2  # same multiset of calls regardless of order

--- a/tests/governance/test_jprime_tool_schema_compaction.py
+++ b/tests/governance/test_jprime_tool_schema_compaction.py
@@ -1,0 +1,91 @@
+"""Provider-aware tool-schema compaction -- cognitive armor for the 7B J-Prime.
+
+The full tool section feeds Claude a large block (envelope examples + a
+parallel-call essay + voice guidance + the tool list). A 7B model drowns in it
+(cognitive load + context overflow). When the failover FSM reports J-Prime is the
+active generator (``is_jprime_serving()``), the tool section is dynamically
+compacted: verbose optional essays stripped, blank lines collapsed, hard
+char-budget truncation. No hardcoded provider check -- the FSM IS the signal.
+Gated + fail-soft.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.providers as providers
+
+
+_FULL = (
+    "Use the tool-call JSON envelope.\n\n"
+    "### Parallel tool calls (preferred when tools are independent)\n"
+    "A long essay about asyncio.gather and batching 3 sequential rounds into 1 "
+    "that a 7B model does not need and that overflows its context window...\n"
+    "...more verbose guidance...\n\n"
+    "### Voice-First Prompt Mode (REQUIRED for this op)\n"
+    "Spoken-language preamble guidance the failover node never speaks aloud...\n\n"
+    "### Available tools\n\n"
+    "- `read_file(path)` -- read a file\n"
+    "- `search_code(pattern)` -- regex search\n"
+)
+
+
+def test_drops_verbose_essays_keeps_tools():
+    out = providers.compact_tool_section(_FULL)
+    assert "Parallel tool calls" not in out      # verbose essay stripped
+    assert "Voice-First" not in out              # voice block stripped
+    assert "### Available tools" in out          # essential list kept
+    assert "read_file(path)" in out and "search_code(pattern)" in out
+
+
+def test_collapses_excess_blank_lines():
+    out = providers.compact_tool_section("a\n\n\n\n\nb")
+    assert "\n\n\n" not in out
+
+
+def test_truncates_to_budget(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_COMPACT_TOOL_MAX_CHARS", "120")
+    out = providers.compact_tool_section("### Available tools\n" + ("- x\n" * 500))
+    assert len(out) <= 200  # budget + a short truncation marker
+    assert "truncated" in out.lower()
+
+
+def test_failsoft_non_string():
+    assert providers.compact_tool_section(None) is None  # type: ignore[arg-type]
+
+
+def test_empty_passthrough():
+    assert providers.compact_tool_section("") == ""
+
+
+# ---------------------------------------------------------------------------
+# Dynamic gate: compact iff the failover FSM says J-Prime is serving.
+# ---------------------------------------------------------------------------
+
+def test_compact_gate_off_when_jprime_not_serving(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "true")
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+
+    class _Ctrl:
+        def is_jprime_serving(self):
+            return False
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: _Ctrl())
+    assert providers._should_compact_for_jprime() is False
+
+
+def test_compact_gate_on_when_jprime_serving(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "true")
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+
+    class _Ctrl:
+        def is_jprime_serving(self):
+            return True
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: _Ctrl())
+    assert providers._should_compact_for_jprime() is True
+
+
+def test_compact_gate_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "false")
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+    monkeypatch.setattr(fl, "get_failover_controller",
+                        lambda: type("C", (), {"is_jprime_serving": lambda s: True})())
+    assert providers._should_compact_for_jprime() is False  # master gate wins


### PR DESCRIPTION
Protects the Venom tool loop from a 7B J-Prime model's cognitive limits. Builds on the merged Sovereign Failover Mesh (#69746, #69747).

- **Semantic Loop Breaker**: detects same-tool repetition hallucination (difflib similarity, no embeddings) → one synthesis nudge → hard eject with best context. Gated, fail-soft.
- **Provider-aware Schema Compaction**: when `is_jprime_serving()` (the FSM is the signal — no hardcoded provider check), the tool section is dynamically stripped of verbose essays + truncated to budget. Gated, fail-soft.

16 new tests. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cognitive armor to the Venom tool loop to stop repeated tool-call hallucinations and trim tool-schema noise for small models. Improves reliability and reduces wasted tokens, especially when `J-Prime` is serving.

- **New Features**
  - Semantic Loop Breaker: detects same-tool repetition via normalized call signatures + `difflib` similarity; first trip nudges to synthesize, persistent repetition hard-ejects with best gathered context. Gated by `JARVIS_VENOM_LOOP_BREAKER_ENABLED`; window (`JARVIS_VENOM_LOOP_BREAKER_WINDOW`) and threshold (`JARVIS_VENOM_LOOP_BREAKER_SIMILARITY`) tunable; fail-soft.
  - Provider-aware Schema Compaction: when the failover FSM reports `is_jprime_serving()`, compacts the tool section by stripping optional essays, collapsing blanks, and truncating to `JARVIS_VENOM_COMPACT_TOOL_MAX_CHARS`. Gated by `JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED`; no hardcoded provider checks; fail-soft.

<sup>Written for commit 5863d30a4acfac271d66d3232b829c5eba490828. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69748?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

