### PR TITLE
feat(failover): Adaptive Workload Provisioner — tier router + GPU IaC + model-aware compaction

### DIFF
--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -403,11 +403,30 @@ async def _default_vm_awaken_fn(*, startup_script: str) -> bool:
                 "DORMANT, op stays sealed in Cryo-DLQ (loop not crashed)", detail,
             )
             return False
-        ok_create, cdetail = await client.create_instance(startup_script=startup_script)
+        # Adaptive Workload Provisioning: resolve the tier (survival 7B-CPU by
+        # default; quality 32B-GPU only when the gate is ON for a high-priority
+        # op). Inject the tier's machine type, golden image (== baked model), and
+        # any GPU accelerator into the REST provision. Deterministic from env ->
+        # consistent with the controller's stored active model.
+        from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+            resolve_tier,
+        )
+        _tier = resolve_tier(
+            urgency=_env_str("JARVIS_FAILOVER_AWAKEN_URGENCY", ""),
+            complexity=_env_str("JARVIS_FAILOVER_AWAKEN_COMPLEXITY", ""),
+        )
+        ok_create, cdetail = await client.create_instance(
+            startup_script=startup_script,
+            machine_type=_tier.machine_type,
+            image_family=_tier.image_family,
+            accelerator_type=_tier.accelerator_type,
+            accelerator_count=_tier.accelerator_count,
+        )
         if ok_create:
             logger.info(
-                "[FailoverLifecycle] awaken: node created via native Compute REST "
-                "(%s) -- zero gcloud", cdetail,
+                "[FailoverLifecycle] awaken: %s-tier node created via native "
+                "Compute REST (%s, model=%s, gpu=%s) -- zero gcloud",
+                _tier.name, cdetail, _tier.model_label, _tier.is_gpu,
             )
             return True
         logger.warning(
@@ -738,6 +757,9 @@ class FailoverLifecycleController:
         # IaC ephemeral firewall micro-perimeter: the rule name opened at AWAKEN,
         # torn down (alongside the node) on EVERY exit path. None == no hole open.
         self._ephemeral_fw_rule: Optional[str] = None
+        # The model label of the actively-provisioned tier (drives model-aware
+        # schema compaction). None until a tier is provisioned -> survival default.
+        self._active_model_label: Optional[str] = None
 
         # Timestamps (monotonic via clock_fn).
         self._outage_started_at: Optional[float] = None  # set on note_outage
@@ -773,6 +795,20 @@ class FailoverLifecycleController:
         if self._state == FailoverState.SERVING:
             return self._endpoint
         return None
+
+    def active_jprime_model(self) -> str:
+        """The model label of the actively-provisioned tier (drives model-aware
+        compaction: a small model -> compact, a 32B GPU node -> full schema).
+        Falls back to the configured survival-tier model. NEVER raises."""
+        if self._active_model_label:
+            return self._active_model_label
+        try:
+            from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+                resolve_tier,
+            )
+            return resolve_tier().model_label  # default (survival) tier model
+        except Exception:  # noqa: BLE001
+            return "qwen2.5-coder:7b"
 
     # ------------------------------------------------------------------
     # Event hooks (gated, fail-soft)
@@ -1510,6 +1546,18 @@ class FailoverLifecycleController:
             return
         self._endpoint = self._build_endpoint()
         logger.info("[FailoverLifecycle] AWAKENING node endpoint=%s", self._endpoint)
+        # Record the active tier's model (drives model-aware schema compaction).
+        # Deterministic from the same env the awaken_fn resolved, so they agree.
+        try:
+            from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+                resolve_tier,
+            )
+            self._active_model_label = resolve_tier(
+                urgency=_env_str("JARVIS_FAILOVER_AWAKEN_URGENCY", ""),
+                complexity=_env_str("JARVIS_FAILOVER_AWAKEN_COMPLEXITY", ""),
+            ).model_label
+        except Exception:  # noqa: BLE001
+            self._active_model_label = None
         # IaC ephemeral micro-perimeter: open a /32 hole for THIS orchestrator's
         # detected egress IP so the Reachability Racer's external path can reach
         # the node. Fail-soft -- a firewall miss never blocks awaken (the racer

--- a/backend/core/ouroboros/governance/failover_tier.py
+++ b/backend/core/ouroboros/governance/failover_tier.py
@@ -1,0 +1,126 @@
+"""failover_tier.py -- Adaptive Workload Provisioning tier router.
+
+J-Prime is a TEMPORARY, cost-bounded survival tier that O+V hands back to DW the
+moment DW recovers. This router deterministically selects WHICH node to provision
+for the outage based on the workload's urgency/complexity:
+
+  * survival (DEFAULT): cheap ``e2-highmem-2`` CPU node + 7B model -- keeps O+V
+    alive during ANY outage at ~$0.04/hr Spot.
+  * quality (OPT-IN, gated OFF by default): a ``g2-standard`` GPU node + 32B model
+    for a high-priority IMMEDIATE / COMPLEX op -- dynamically authorizing the
+    higher OPEX ONLY for critical workloads.
+
+THE GPU TIER CAN NEVER SPEND BY ACCIDENT: ``JARVIS_FAILOVER_QUALITY_TIER_ENABLED``
+defaults OFF -> ``resolve_tier`` always returns the survival tier. Every spec is
+env-driven (machine type / image / model / accelerator) -- zero hardcoding past
+the final defaults. Pure + frozen value objects.
+"""
+from __future__ import annotations
+
+import os
+import re
+from dataclasses import dataclass
+
+_PARAM_RE = re.compile(r"(\d+(?:\.\d+)?)\s*b\b", re.IGNORECASE)
+
+
+def _env(name: str, default: str) -> str:
+    return (os.environ.get(name, default) or default).strip()
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (ValueError, TypeError):
+        return default
+
+
+@dataclass(frozen=True)
+class FailoverTier:
+    """An immutable provisioning spec: which machine, image (== baked model),
+    model label, and optional GPU accelerator to awaken for the outage."""
+
+    name: str
+    machine_type: str
+    image_family: str
+    model_label: str
+    accelerator_type: str = ""
+    accelerator_count: int = 0
+
+    @property
+    def is_gpu(self) -> bool:
+        return bool(self.accelerator_type and self.accelerator_count > 0)
+
+
+def quality_tier_enabled() -> bool:
+    """Master gate for the GPU/32B quality tier. DEFAULT OFF -- a GPU node is
+    NEVER provisioned unless the operator explicitly opts in (cost safety)."""
+    val = (os.environ.get("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "false") or "").strip().lower()
+    return val in ("1", "true", "yes", "on")
+
+
+def _survival_tier() -> FailoverTier:
+    return FailoverTier(
+        name="survival",
+        machine_type=_env("JARVIS_FAILOVER_SURVIVAL_MACHINE", "e2-highmem-2"),
+        image_family=_env("JARVIS_FAILOVER_SURVIVAL_IMAGE", "jarvis-prime-coder"),
+        model_label=_env("JARVIS_FAILOVER_SURVIVAL_MODEL", "qwen2.5-coder:7b"),
+    )
+
+
+def _quality_tier() -> FailoverTier:
+    return FailoverTier(
+        name="quality",
+        machine_type=_env("JARVIS_FAILOVER_QUALITY_MACHINE", "g2-standard-8"),
+        image_family=_env("JARVIS_FAILOVER_QUALITY_IMAGE", "jarvis-prime-coder-32b"),
+        model_label=_env("JARVIS_FAILOVER_QUALITY_MODEL", "qwen2.5-coder:32b"),
+        accelerator_type=_env("JARVIS_FAILOVER_QUALITY_ACCEL_TYPE", "nvidia-l4"),
+        accelerator_count=max(0, _env_int("JARVIS_FAILOVER_QUALITY_ACCEL_COUNT", 1)),
+    )
+
+
+def _is_high_priority(urgency: str, complexity: str) -> bool:
+    """A workload warrants the GPU tier iff it is IMMEDIATE urgency OR a COMPLEX /
+    heavy-code op. BACKGROUND / STANDARD / simple never do (cost discipline)."""
+    u = (urgency or "").strip().lower()
+    c = (complexity or "").strip().lower()
+    return u in ("immediate",) or c in ("complex", "heavy_code", "heavy")
+
+
+def resolve_tier(*, urgency: str = "", complexity: str = "") -> FailoverTier:
+    """Deterministically pick the provisioning tier for the interrupted workload.
+    Quality (GPU/32B) ONLY when the master gate is ON AND the op is high-priority;
+    otherwise the cost-optimized survival tier. NEVER raises."""
+    try:
+        if quality_tier_enabled() and _is_high_priority(urgency, complexity):
+            return _quality_tier()
+    except Exception:  # noqa: BLE001 -- any error -> safe survival default
+        pass
+    return _survival_tier()
+
+
+def model_param_billions(model_label: str) -> float:
+    """Parse the parameter size (in billions) from a model label, e.g.
+    ``qwen2.5-coder:32b-instruct`` -> 32.0. Unknown -> 0.0. NEVER raises."""
+    try:
+        m = _PARAM_RE.search(str(model_label or ""))
+        return float(m.group(1)) if m else 0.0
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+def is_small_model(model_label: str, *, threshold_b: float = 0.0) -> bool:
+    """True iff the model is 'small' enough to warrant aggressive cognitive
+    compaction (<= the threshold, env ``JARVIS_VENOM_COMPACT_MAX_MODEL_B`` default
+    14B). An UNKNOWN size (0.0) is treated as small (conservative -> compact).
+    A large model (e.g. 32B GPU) is NOT small -> it gets the full schema."""
+    if threshold_b <= 0:
+        threshold_b = float(_env("JARVIS_VENOM_COMPACT_MAX_MODEL_B", "14") or 14)
+    b = model_param_billions(model_label)
+    return b == 0.0 or b <= threshold_b
+
+
+__all__ = [
+    "FailoverTier", "resolve_tier", "quality_tier_enabled",
+    "model_param_billions", "is_small_model",
+]

--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -509,6 +509,8 @@ class GCPComputeRest:
         image_family: str,
         startup_script: str,
         spot: bool,
+        accelerator_type: str = "",
+        accelerator_count: int = 0,
     ) -> Dict[str, Any]:
         """Construct the EXACT instances.insert JSON payload. Dynamic zone +
         project from metadata; sourceImage = the golden-image family; Spot
@@ -557,6 +559,22 @@ class GCPComputeRest:
                 "automaticRestart": False,
                 "preemptible": True,
             }
+        # Dynamic IaC accelerator injection (quality tier). A GPU cannot live-
+        # migrate, so onHostMaintenance MUST be TERMINATE; the acceleratorType is
+        # a DYNAMIC zonal URL (never a hardcoded full path). count<=0 -> CPU
+        # payload (no accidental GPU spend).
+        if accelerator_type and accelerator_count > 0:
+            payload["guestAccelerators"] = [
+                {
+                    "acceleratorType": "zones/{}/acceleratorTypes/{}".format(
+                        zone, accelerator_type
+                    ),
+                    "acceleratorCount": int(accelerator_count),
+                }
+            ]
+            sched = payload.setdefault("scheduling", {})
+            sched["onHostMaintenance"] = "TERMINATE"
+            sched.setdefault("automaticRestart", False)
         return payload
 
     async def create_instance(
@@ -566,6 +584,8 @@ class GCPComputeRest:
         name: Optional[str] = None,
         machine_type: Optional[str] = None,
         image_family: Optional[str] = None,
+        accelerator_type: str = "",
+        accelerator_count: int = 0,
     ) -> Tuple[bool, str]:
         """Async REST bootstrapper: launch the golden image via instances.insert.
 
@@ -604,6 +624,8 @@ class GCPComputeRest:
                 image_family=family,
                 startup_script=startup_script,
                 spot=spot,
+                accelerator_type=accelerator_type,
+                accelerator_count=accelerator_count,
             )
             body = json.dumps(payload).encode("utf-8")
             status, text = await _http_request(

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -2108,7 +2108,15 @@ def _should_compact_for_jprime() -> bool:
         from backend.core.ouroboros.governance.failover_lifecycle import (  # noqa: PLC0415
             get_failover_controller,
         )
-        return bool(get_failover_controller().is_jprime_serving())
+        ctrl = get_failover_controller()
+        if not ctrl.is_jprime_serving():
+            return False
+        # MODEL-AWARE: a small (7B) node gets aggressive compaction; a 32B GPU
+        # node bypasses it and receives the FULL Claude-level schema.
+        from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+            is_small_model,
+        )
+        return bool(is_small_model(ctrl.active_jprime_model()))
     except Exception:  # noqa: BLE001
         return False
 

--- a/tests/governance/test_failover_tier_router.py
+++ b/tests/governance/test_failover_tier_router.py
@@ -1,0 +1,84 @@
+"""Adaptive Workload Provisioning -- the Intelligent Tier Router.
+
+J-Prime is a TEMPORARY, cost-bounded survival tier. By default O+V provisions the
+cheap e2-highmem-2 + 7B node. For a high-priority IMMEDIATE/COMPLEX op the router
+MAY escalate to a g2-standard GPU + 32B node -- but ONLY when the quality tier is
+explicitly enabled (gated OFF by default so a GPU node can NEVER spend by
+accident). Pure, deterministic, config-driven -- no hardcoded machine/model.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.failover_tier import (
+    FailoverTier,
+    resolve_tier,
+)
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    # Clean slate -- tier specs resolve from defaults unless a test overrides.
+    for k in list(__import__("os").environ):
+        if k.startswith("JARVIS_FAILOVER_SURVIVAL_") or k.startswith("JARVIS_FAILOVER_QUALITY_"):
+            monkeypatch.delenv(k, raising=False)
+    monkeypatch.delenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", raising=False)
+    yield
+
+
+def test_survival_tier_for_background():
+    t = resolve_tier(urgency="background", complexity="simple")
+    assert t.name == "survival"
+    assert "e2" in t.machine_type and t.is_gpu is False
+    assert "7b" in t.model_label.lower()
+
+
+def test_survival_tier_for_standard():
+    assert resolve_tier(urgency="standard", complexity="moderate").name == "survival"
+
+
+def test_quality_disabled_means_survival_even_for_immediate(monkeypatch):
+    """Master OFF (default) -> a GPU node can NEVER be provisioned by accident."""
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "false")
+    t = resolve_tier(urgency="immediate", complexity="complex")
+    assert t.name == "survival"
+    assert t.is_gpu is False
+
+
+def test_immediate_escalates_to_quality_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    t = resolve_tier(urgency="immediate", complexity="simple")
+    assert t.name == "quality"
+    assert t.is_gpu is True
+    assert t.accelerator_count >= 1 and "l4" in t.accelerator_type.lower()
+    assert "32b" in t.model_label.lower()
+
+
+def test_complex_escalates_to_quality_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    assert resolve_tier(urgency="standard", complexity="complex").name == "quality"
+
+
+def test_background_stays_survival_even_when_quality_enabled(monkeypatch):
+    """Quality enabled, but a BACKGROUND op never warrants the GPU OPEX."""
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    assert resolve_tier(urgency="background", complexity="simple").name == "survival"
+
+
+def test_tier_specs_are_env_driven(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_MACHINE", "g2-standard-16")
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_MODEL", "qwen2.5-coder:32b-instruct")
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_ACCEL_TYPE", "nvidia-l4")
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_ACCEL_COUNT", "2")
+    t = resolve_tier(urgency="immediate", complexity="complex")
+    assert t.machine_type == "g2-standard-16"
+    assert t.accelerator_count == 2
+    assert t.model_label == "qwen2.5-coder:32b-instruct"
+
+
+def test_failover_tier_is_frozen_value():
+    t = resolve_tier(urgency="background", complexity="simple")
+    assert isinstance(t, FailoverTier)
+    with pytest.raises(Exception):
+        t.machine_type = "x"  # type: ignore[misc]  -- frozen

--- a/tests/governance/test_gpu_accelerator_payload.py
+++ b/tests/governance/test_gpu_accelerator_payload.py
@@ -1,0 +1,82 @@
+"""Dynamic IaC Accelerator Injection -- GPU guestAccelerators in the REST payload.
+
+When the tier router selects the GPU/32B quality tier, the native Compute REST
+provisioning bridge must inject ``guestAccelerators`` (e.g. an L4) AND the GPU-
+mandatory ``scheduling.onHostMaintenance=TERMINATE`` into the instances.insert
+payload. No accelerator on the survival tier -> byte-identical CPU payload.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.gcp_compute_rest as gcr
+
+
+def _client():
+    return gcr.GCPComputeRest()
+
+
+def test_no_accelerator_by_default():
+    p = _client()._build_insert_payload(
+        name="n", zone="us-central1-b", project="p",
+        machine_type="e2-highmem-2", image_family="img", startup_script="x", spot=True,
+    )
+    assert "guestAccelerators" not in p
+    assert "onHostMaintenance" not in p.get("scheduling", {})
+
+
+def test_injects_guest_accelerator():
+    p = _client()._build_insert_payload(
+        name="n", zone="us-central1-b", project="p",
+        machine_type="g2-standard-8", image_family="img32b", startup_script="x", spot=True,
+        accelerator_type="nvidia-l4", accelerator_count=2,
+    )
+    accs = p.get("guestAccelerators")
+    assert accs and accs[0]["acceleratorCount"] == 2
+    # Zonal acceleratorType URL -- dynamic, never a hardcoded full path.
+    assert accs[0]["acceleratorType"].endswith(
+        "zones/us-central1-b/acceleratorTypes/nvidia-l4"
+    )
+
+
+def test_gpu_forces_onhostmaintenance_terminate():
+    """GPUs cannot live-migrate -> onHostMaintenance MUST be TERMINATE."""
+    p = _client()._build_insert_payload(
+        name="n", zone="us-central1-b", project="p",
+        machine_type="g2-standard-8", image_family="i", startup_script="x", spot=False,
+        accelerator_type="nvidia-l4", accelerator_count=1,
+    )
+    assert p["scheduling"]["onHostMaintenance"] == "TERMINATE"
+
+
+def test_zero_count_is_not_gpu():
+    p = _client()._build_insert_payload(
+        name="n", zone="z", project="p", machine_type="e2", image_family="i",
+        startup_script="x", spot=True, accelerator_type="nvidia-l4", accelerator_count=0,
+    )
+    assert "guestAccelerators" not in p  # count 0 -> CPU payload (no accidental GPU)
+
+
+async def test_create_instance_threads_accelerator(monkeypatch):
+    """create_instance forwards the accelerator into the payload it POSTs."""
+    seen = {}
+
+    async def fake_http(url, *, method, headers=None, body=None, timeout_s=30.0):
+        import json
+        seen["payload"] = json.loads(body.decode()) if body else None
+        return (200, '{"status":"PENDING"}')
+
+    async def fake_token(self):
+        return "tok"
+    monkeypatch.setattr(gcr, "_http_request", fake_http)
+    monkeypatch.setattr(gcr.GCPComputeRest, "access_token", fake_token)
+    monkeypatch.setenv("GCP_PROJECT_ID", "p")
+    monkeypatch.setenv("GCP_ZONE", "us-central1-b")
+
+    c = _client()
+    ok, _ = await c.create_instance(
+        startup_script="x", machine_type="g2-standard-8",
+        accelerator_type="nvidia-l4", accelerator_count=1,
+    )
+    assert ok is True
+    assert seen["payload"]["guestAccelerators"][0]["acceleratorCount"] == 1

--- a/tests/governance/test_jprime_tool_schema_compaction.py
+++ b/tests/governance/test_jprime_tool_schema_compaction.py
@@ -79,6 +79,8 @@ def test_compact_gate_on_when_jprime_serving(monkeypatch):
     class _Ctrl:
         def is_jprime_serving(self):
             return True
+        def active_jprime_model(self):
+            return "qwen2.5-coder:7b"  # small -> compact
     monkeypatch.setattr(fl, "get_failover_controller", lambda: _Ctrl())
     assert providers._should_compact_for_jprime() is True
 
@@ -86,6 +88,7 @@ def test_compact_gate_on_when_jprime_serving(monkeypatch):
 def test_compact_gate_master_off(monkeypatch):
     monkeypatch.setenv("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "false")
     import backend.core.ouroboros.governance.failover_lifecycle as fl
-    monkeypatch.setattr(fl, "get_failover_controller",
-                        lambda: type("C", (), {"is_jprime_serving": lambda s: True})())
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: type(
+        "C", (), {"is_jprime_serving": lambda s: True,
+                  "active_jprime_model": lambda s: "qwen2.5-coder:7b"})())
     assert providers._should_compact_for_jprime() is False  # master gate wins

--- a/tests/governance/test_model_aware_compaction.py
+++ b/tests/governance/test_model_aware_compaction.py
@@ -1,0 +1,88 @@
+"""Model-Aware Compaction Routing.
+
+compact_tool_section must not blindly truncate just because J-Prime is serving.
+It queries the DEPLOYED model: a small (<=14B) node gets the aggressive cognitive
+compaction; a 32B GPU node bypasses it and receives the FULL Claude-level schema.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_tier as ft
+import backend.core.ouroboros.governance.providers as providers
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+
+
+# ---------------------------------------------------------------------------
+# Model size parsing
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("label,b", [
+    ("qwen2.5-coder:7b", 7.0),
+    ("qwen2.5-coder:32b", 32.0),
+    ("qwen2.5-coder:14b-instruct", 14.0),
+    ("llama3.1:70b", 70.0),
+    ("mystery-model", 0.0),
+])
+def test_model_param_billions(label, b):
+    assert ft.model_param_billions(label) == b
+
+
+def test_is_small_model_default_threshold():
+    assert ft.is_small_model("qwen2.5-coder:7b") is True
+    assert ft.is_small_model("qwen2.5-coder:14b") is True
+    assert ft.is_small_model("qwen2.5-coder:32b") is False
+    assert ft.is_small_model("unknown") is True  # unknown -> compact (conservative)
+
+
+def test_is_small_model_env_threshold(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_COMPACT_MAX_MODEL_B", "8")
+    assert ft.is_small_model("qwen2.5-coder:7b") is True
+    assert ft.is_small_model("qwen2.5-coder:14b") is False  # now above the 8B line
+
+
+# ---------------------------------------------------------------------------
+# Compaction gate is model-aware
+# ---------------------------------------------------------------------------
+
+def _serving_ctrl(model):
+    class _C:
+        def is_jprime_serving(self):
+            return True
+        def active_jprime_model(self):
+            return model
+    return _C()
+
+
+def test_compacts_for_small_model(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "true")
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: _serving_ctrl("qwen2.5-coder:7b"))
+    assert providers._should_compact_for_jprime() is True
+
+
+def test_bypasses_for_large_gpu_model(monkeypatch):
+    """32B node -> NO compaction -> full Claude-level schema."""
+    monkeypatch.setenv("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "true")
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: _serving_ctrl("qwen2.5-coder:32b"))
+    assert providers._should_compact_for_jprime() is False
+
+
+def test_no_compact_when_not_serving(monkeypatch):
+    monkeypatch.setenv("JARVIS_VENOM_SCHEMA_SIMPLIFY_ENABLED", "true")
+    class _C:
+        def is_jprime_serving(self):
+            return False
+        def active_jprime_model(self):
+            return "qwen2.5-coder:7b"
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: _C())
+    assert providers._should_compact_for_jprime() is False
+
+
+def test_controller_active_model_defaults_to_survival(monkeypatch):
+    """A fresh controller (no tier provisioned) reports the survival model."""
+    fl._reset_singleton_for_tests()
+    ctrl = fl.FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: True, vm_delete_fn=lambda: True,
+        node_ready_fn=lambda e: True, clock_fn=lambda: 1.0,
+    )
+    assert "7b" in ctrl.active_jprime_model().lower()


### PR DESCRIPTION
Adapts the temporary J-Prime survival node to the workload. **GPU gated OFF by default — can never spend by accident.** Builds on the merged mesh (#69746/#69747/#69748).

- **Tier router** (`resolve_tier`): survival (e2+7B) vs quality (g2-GPU+32B) by urgency/complexity, opt-in.
- **IaC accelerator injection**: `guestAccelerators` + GPU `onHostMaintenance=TERMINATE` in the REST payload.
- **Model-aware compaction**: 7B → compact; 32B GPU → full schema (queries `active_jprime_model()`).

45 new tests. Follow-ups (noted in PR): per-op urgency signal at awaken + the 32B golden-image bake. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Adaptive Workload Provisioner to J-Prime failover. It defaults to a survival CPU (7B) tier, can opt into a GPU (32B) tier for urgent/complex ops, injects GPU IaC, and makes tool schema compaction model-aware.

- New Features
  - Tier router: `resolve_tier(urgency, complexity)` selects survival `e2-highmem-2` + `qwen2.5-coder:7b` or quality `g2-standard` + `qwen2.5-coder:32b`; gated by `JARVIS_FAILOVER_QUALITY_TIER_ENABLED` (off by default).
  - GPU IaC: Adds `guestAccelerators` and `scheduling.onHostMaintenance=TERMINATE` to the Compute REST payload; threaded through `create_instance`; no GPU when `accelerator_count <= 0`.
  - Model-aware compaction: `providers._should_compact_for_jprime()` uses `active_jprime_model()`; small models compact, 32B gets the full schema.
  - Tests: 45 new tests cover routing, GPU payload, and compaction.

- Migration
  - No changes required; survival tier stays the default.
  - To enable the quality tier, set `JARVIS_FAILOVER_QUALITY_TIER_ENABLED=true` and optionally override `JARVIS_FAILOVER_QUALITY_*` envs (machine/image/model/accelerator). You can tune the compaction threshold with `JARVIS_VENOM_COMPACT_MAX_MODEL_B` (default 14).

<sup>Written for commit 10898a1adeaf77d52c89359df0e6a53b9ab22ee4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

