### PR TITLE
feat(failover): Elastic GPU fleet FSM + cost-aware gate + GPU golden-image Packer spec

### DIFF
--- a/backend/core/ouroboros/governance/failover_gpu_lane.py
+++ b/backend/core/ouroboros/governance/failover_gpu_lane.py
@@ -1,0 +1,157 @@
+"""failover_gpu_lane.py -- the Elastic Multi-Tier Fleet's GPU Escalation Lane.
+
+During a SUSTAINED DW outage the 7B CPU survival node is the always-on baseline.
+This lane manages a SECOND, elastic GPU node that is provisioned on demand for a
+high-priority / token-overflowing op and reaped the instant its work drains:
+
+    IDLE --request(needs GPU)--> PROVISIONING --ready--> ACTIVE
+    ACTIVE --in-flight drains to 0--> REAPING --> IDLE
+
+Routing is the return value of :meth:`request`: a GPU endpoint string means "send
+this op to the 32B node"; ``None`` means "the 7B survival node handles it". The
+lane never double-provisions (a single node serves all concurrent GPU ops) and
+reaps to STOP BILLING the moment the last GPU op completes.
+
+Boundaries (provision/reap/ready) are injected -> zero GCP coupling, fully
+testable. Cost-safe: escalation requires the quality-tier master gate ON (via
+``resolve_tier_for_op``) AND a confirmed sustained outage. Fail-soft throughout.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import logging
+import time
+from typing import Awaitable, Callable, Optional, Set
+
+from backend.core.ouroboros.governance.failover_tier import resolve_tier_for_op
+
+logger = logging.getLogger(__name__)
+
+
+class GpuLaneState(str, enum.Enum):
+    IDLE = "idle"
+    PROVISIONING = "provisioning"
+    ACTIVE = "active"
+    REAPING = "reaping"
+
+
+class GpuEscalationLane:
+    """Elastic GPU sub-fleet manager. One instance per failover controller."""
+
+    def __init__(
+        self,
+        *,
+        provision_fn: Callable[[], Awaitable[Optional[str]]],
+        reap_fn: Callable[[], Awaitable[None]],
+        ready_fn: Optional[Callable[[str], Awaitable[bool]]] = None,
+        outage_confirmed_fn: Optional[Callable[[], bool]] = None,
+        clock_fn: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._provision_fn = provision_fn
+        self._reap_fn = reap_fn
+        self._ready_fn = ready_fn
+        self._outage_confirmed_fn = outage_confirmed_fn
+        self._clock = clock_fn
+        self._state = GpuLaneState.IDLE
+        self._endpoint: Optional[str] = None
+        self._inflight: Set[str] = set()
+        self._lock = asyncio.Lock()
+
+    # ------------------------------------------------------------------
+    # Introspection
+    # ------------------------------------------------------------------
+    def is_gpu_active(self) -> bool:
+        return self._state == GpuLaneState.ACTIVE
+
+    def gpu_inflight_count(self) -> int:
+        return len(self._inflight)
+
+    @property
+    def endpoint(self) -> Optional[str]:
+        return self._endpoint if self._state == GpuLaneState.ACTIVE else None
+
+    # ------------------------------------------------------------------
+    # Demand-driven escalation
+    # ------------------------------------------------------------------
+    async def request(
+        self,
+        op_id: str,
+        *,
+        urgency: str = "",
+        complexity: str = "",
+        estimated_tokens: int = 0,
+    ) -> Optional[str]:
+        """Route one op. Returns the GPU endpoint if this op is escalated to the
+        32B node (provisioning it on first demand), or ``None`` to route the op to
+        the 7B survival node. NEVER raises -> ``None`` (safe fallback to 7B)."""
+        try:
+            tier = resolve_tier_for_op(
+                urgency=urgency, complexity=complexity, estimated_tokens=estimated_tokens,
+            )
+            if not tier.is_gpu:
+                return None  # 7B survival node handles it
+            # Sustained-outage gate: never spin a GPU for a transient blip.
+            if self._outage_confirmed_fn is not None and not self._outage_confirmed_fn():
+                return None
+            async with self._lock:
+                if self._state == GpuLaneState.IDLE:
+                    self._state = GpuLaneState.PROVISIONING
+                    ep = await self._provision_fn()
+                    if not ep:
+                        self._state = GpuLaneState.IDLE
+                        logger.warning("[GpuLane] provision returned no endpoint -> 7B")
+                        return None
+                    if self._ready_fn is not None and not await self._ready_fn(ep):
+                        logger.warning("[GpuLane] node never became ready -> reap + 7B")
+                        await self._reap_locked()
+                        return None
+                    self._endpoint = ep
+                    self._state = GpuLaneState.ACTIVE
+                    logger.info("[GpuLane] GPU node ACTIVE endpoint=%s", ep)
+                if self._state != GpuLaneState.ACTIVE:
+                    return None  # mid-transition -> 7B this round
+                self._inflight.add(op_id)
+                return self._endpoint
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[GpuLane] request fail-soft err=%r -> 7B", exc)
+            return None
+
+    async def complete(self, op_id: str) -> None:
+        """Mark a GPU op done. When the LAST GPU op drains, reap the node to stop
+        billing. NEVER raises."""
+        try:
+            async with self._lock:
+                self._inflight.discard(op_id)
+                if not self._inflight and self._state == GpuLaneState.ACTIVE:
+                    self._state = GpuLaneState.REAPING
+                    logger.info("[GpuLane] GPU in-flight drained to 0 -> reaping")
+                    await self._reap_locked()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[GpuLane] complete fail-soft err=%r", exc)
+
+    async def drain_and_reap(self) -> None:
+        """Force-reap the GPU node regardless of in-flight (handback / shutdown).
+        NEVER raises."""
+        try:
+            async with self._lock:
+                if self._state in (GpuLaneState.ACTIVE, GpuLaneState.PROVISIONING):
+                    self._state = GpuLaneState.REAPING
+                    await self._reap_locked()
+                self._inflight.clear()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[GpuLane] drain_and_reap fail-soft err=%r", exc)
+
+    # ------------------------------------------------------------------
+    async def _reap_locked(self) -> None:
+        """Reap the GPU node (caller holds the lock). Always returns to IDLE."""
+        try:
+            await self._reap_fn()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[GpuLane] reap_fn err=%r (node may orphan)", exc)
+        finally:
+            self._endpoint = None
+            self._state = GpuLaneState.IDLE
+
+
+__all__ = ["GpuEscalationLane", "GpuLaneState"]

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -760,6 +760,9 @@ class FailoverLifecycleController:
         # The model label of the actively-provisioned tier (drives model-aware
         # schema compaction). None until a tier is provisioned -> survival default.
         self._active_model_label: Optional[str] = None
+        # Elastic GPU escalation lane (lazily built on first demand). Manages the
+        # SECOND, concurrent GPU node lifecycle with crypto-namespaced assets.
+        self._gpu_lane: Optional[Any] = None
 
         # Timestamps (monotonic via clock_fn).
         self._outage_started_at: Optional[float] = None  # set on note_outage
@@ -809,6 +812,113 @@ class FailoverLifecycleController:
             return resolve_tier().model_label  # default (survival) tier model
         except Exception:  # noqa: BLE001
             return "qwen2.5-coder:7b"
+
+    # ------------------------------------------------------------------
+    # Elastic GPU escalation lane (the SECOND, concurrent node)
+    # ------------------------------------------------------------------
+    @property
+    def gpu_lane(self):
+        """Lazily-built elastic GPU lane wired to REAL provision/reap boundaries.
+        Provisions a crypto-namespaced ``gpu``-class node (its own VM + /32
+        firewall, never colliding with the live CPU node), registers it in the
+        Fleet Registry, and reaps it the instant its in-flight drains. Returns
+        ``None`` if the lane module is unavailable (fail-soft)."""
+        if self._gpu_lane is None:
+            try:
+                from backend.core.ouroboros.governance.failover_gpu_lane import (  # noqa: PLC0415
+                    GpuEscalationLane,
+                )
+                self._gpu_lane = GpuEscalationLane(
+                    provision_fn=self._provision_gpu_node,
+                    reap_fn=self._reap_gpu_node,
+                    outage_confirmed_fn=self._hard_outage_confirmed,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[FailoverLifecycle] gpu_lane build fail-soft err=%r", exc)
+                return None
+        return self._gpu_lane
+
+    async def _provision_gpu_node(self) -> Optional[str]:
+        """Provision the crypto-namespaced GPU node (quality tier): instances.insert
+        + its OWN /32 firewall rule + race readiness -> register the external
+        endpoint in the Fleet Registry. Returns the endpoint or None. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                get_compute_rest, resolve_local_public_ip,
+            )
+            from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+                resolve_tier_for_op,
+            )
+            from backend.core.ouroboros.governance.failover_naming import (  # noqa: PLC0415
+                node_name, firewall_name,
+            )
+            from backend.core.ouroboros.governance.fleet_registry import (  # noqa: PLC0415
+                get_fleet_registry,
+            )
+            tier = resolve_tier_for_op(urgency="immediate", complexity="complex")
+            if not tier.is_gpu:
+                return None  # quality gate OFF -> never spend
+            client = get_compute_rest()
+            gpu_vm = node_name("gpu")
+            ok, detail = await client.create_instance(
+                startup_script=self._build_startup_script(),
+                name=gpu_vm,
+                machine_type=tier.machine_type,
+                image_family=tier.image_family,
+                accelerator_type=tier.accelerator_type,
+                accelerator_count=tier.accelerator_count,
+            )
+            if not ok:
+                logger.warning("[FailoverLifecycle] GPU provision insert failed: %s", detail)
+                return None
+            # Own /32 firewall rule (crypto-namespaced -> no collision with cpu).
+            if _ephemeral_fw_enabled():
+                ip = await resolve_local_public_ip()
+                if ip:
+                    await client.create_firewall_rule(
+                        name=firewall_name("gpu"), source_ip=ip, port=_failover_port(),
+                    )
+            internal_ip, external_ip = await client.get_node_endpoints(gpu_vm)
+            candidates = [
+                "http://{}:{}".format(h, _failover_port())
+                for h in (external_ip, internal_ip) if h
+            ]
+            winner = await self._race_node_ready(candidates) if candidates else None
+            if not winner:
+                logger.warning("[FailoverLifecycle] GPU node never became ready -> reap")
+                await self._reap_gpu_node()
+                return None
+            get_fleet_registry().register("gpu", winner)
+            logger.info("[FailoverLifecycle] GPU node SERVING endpoint=%s vm=%s", winner, gpu_vm)
+            return winner
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[FailoverLifecycle] GPU provision fail-soft err=%r", exc)
+            return None
+
+    async def _reap_gpu_node(self) -> None:
+        """Reap the GPU node: delete the VM + its firewall rule (by reconstructed
+        crypto-namespaced names) + unregister from the Fleet Registry. The CPU
+        node is untouched. Idempotent + fail-soft. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                get_compute_rest,
+            )
+            from backend.core.ouroboros.governance.failover_naming import (  # noqa: PLC0415
+                node_name, firewall_name,
+            )
+            from backend.core.ouroboros.governance.fleet_registry import (  # noqa: PLC0415
+                get_fleet_registry,
+            )
+            client = get_compute_rest()
+            await asyncio.gather(
+                client.delete_instance(node_name("gpu")),
+                client.delete_firewall_rule(firewall_name("gpu")),
+                return_exceptions=True,
+            )
+            get_fleet_registry().unregister("gpu")
+            logger.info("[FailoverLifecycle] GPU node REAPED (CPU survives)")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[FailoverLifecycle] GPU reap fail-soft err=%r", exc)
 
     # ------------------------------------------------------------------
     # Event hooks (gated, fail-soft)
@@ -1731,6 +1841,16 @@ class FailoverLifecycleController:
         self._serving_started_at = now
         self._last_probe_at = None
         self._recovered_streak = 0
+        # Fleet Registry: publish the CPU (survival) node's endpoint so the
+        # per-op router can resolve it independently of the elastic GPU node.
+        try:
+            from backend.core.ouroboros.governance.fleet_registry import (  # noqa: PLC0415
+                get_fleet_registry,
+            )
+            if self._endpoint:
+                get_fleet_registry().register("cpu", self._endpoint)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FailoverLifecycle] fleet register(cpu) fail-soft err=%r", exc)
         logger.info("[FailoverLifecycle] SERVING via J-Prime endpoint=%s", self._endpoint)
         # ABSOLUTE HANDOFF PROOF: record the exact winning endpoint the GENERATE
         # queue is now routed to (the Reachability-Racer winner + the wired
@@ -1873,6 +1993,20 @@ class FailoverLifecycleController:
         #    is_jprime_serving()/jprime_endpoint() stop pointing at the node and
         #    ALL NEW ops route to DW instantly (T4 re-routes to DW).
         self._endpoint = None
+        # Fleet teardown: unpublish the CPU node + force-reap any elastic GPU node
+        # (both must vacate on handback so nothing keeps billing or routing).
+        try:
+            from backend.core.ouroboros.governance.fleet_registry import (  # noqa: PLC0415
+                get_fleet_registry,
+            )
+            get_fleet_registry().unregister("cpu")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FailoverLifecycle] fleet unregister(cpu) fail-soft err=%r", exc)
+        try:
+            if self._gpu_lane is not None:
+                await self._gpu_lane.drain_and_reap()
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[FailoverLifecycle] gpu lane reap fail-soft err=%r", exc)
 
         # 2.5 ZERO-DROP DRAIN: await any IN-FLIGHT J-Prime ops to finish before
         #     teardown so none is severed mid-generation. Bounded by a budget

--- a/backend/core/ouroboros/governance/failover_naming.py
+++ b/backend/core/ouroboros/governance/failover_naming.py
@@ -1,0 +1,76 @@
+"""failover_naming.py -- Cryptographic Asset Namespacing for the elastic fleet.
+
+Concurrent CPU + GPU node lifecycles require GCP asset names that are guaranteed
+not to collide. Every ephemeral VM and firewall rule is named:
+
+    {base}-{class}-{hash8}          e.g. jarvis-prime-failover-gpu-a1b2c3d4
+    {base}-{class}-{hash8}-fw       the matching firewall rule
+
+The 8-char suffix is ``sha256(salt : class : kind)[:8]`` -- DETERMINISTIC (so
+teardown reconstructs the name without persisting it) yet class-DISTINCT (CPU and
+GPU hash different inputs -> mathematically cannot collide). The class label is
+kept in the name for human/operator legibility. All outputs are valid GCE
+resource names (``[a-z]([-a-z0-9]*[a-z0-9])?``, <=63 chars, lowercase).
+
+Env
+---
+JARVIS_FAILOVER_NODE_NAME        base name (default "jarvis-prime-failover")
+JARVIS_FAILOVER_NAMESPACE_SALT   per-deployment salt (default = the base name)
+"""
+from __future__ import annotations
+
+import hashlib
+import os
+import re
+
+_DEFAULT_BASE = "jarvis-prime-failover"
+_NON_DNS = re.compile(r"[^a-z0-9-]")
+
+
+def _base() -> str:
+    raw = (os.environ.get("JARVIS_FAILOVER_NODE_NAME", _DEFAULT_BASE) or _DEFAULT_BASE)
+    return _sanitize(raw) or _DEFAULT_BASE
+
+
+def _salt() -> str:
+    # A distinct salt per deployment -> distinct namespace. Defaults to the base
+    # name so a single deployment is stable across restarts.
+    return (os.environ.get("JARVIS_FAILOVER_NAMESPACE_SALT", "") or _base()).strip()
+
+
+def _sanitize(s: str) -> str:
+    return _NON_DNS.sub("-", str(s or "").strip().lower()).strip("-")
+
+
+def _suffix(node_class: str, kind: str) -> str:
+    raw = "{}:{}:{}".format(_salt(), _sanitize(node_class), kind).encode("utf-8")
+    return hashlib.sha256(raw).hexdigest()[:8]
+
+
+def _clamp_gce(name: str) -> str:
+    """Guarantee a valid GCE resource name: lowercase DNS chars, leading letter,
+    <=63 chars (truncate the BASE, never the discriminating class+hash tail)."""
+    name = _sanitize(name)
+    if not name or not name[0].isalpha():
+        name = "j" + name
+    if len(name) > 63:
+        # Preserve the class+hash tail (the collision-discriminating part).
+        tail = name[-40:]
+        name = (name[:63 - len(tail)] + tail)[:63]
+    return name.strip("-")
+
+
+def node_name(node_class: str) -> str:
+    """Crypto-namespaced ephemeral VM name for a node class (e.g. cpu / gpu)."""
+    cls = _sanitize(node_class) or "node"
+    return _clamp_gce("{}-{}-{}".format(_base(), cls, _suffix(node_class, "vm")))
+
+
+def firewall_name(node_class: str) -> str:
+    """Crypto-namespaced ephemeral /32 firewall-rule name for a node class. A
+    distinct rule per class -> reaping one node never deletes another's rule."""
+    cls = _sanitize(node_class) or "node"
+    return _clamp_gce("{}-{}-{}-fw".format(_base(), cls, _suffix(node_class, "fw")))
+
+
+__all__ = ["node_name", "firewall_name"]

--- a/backend/core/ouroboros/governance/failover_tier.py
+++ b/backend/core/ouroboros/governance/failover_tier.py
@@ -99,6 +99,41 @@ def resolve_tier(*, urgency: str = "", complexity: str = "") -> FailoverTier:
     return _survival_tier()
 
 
+def op_exceeds_small_capacity(*, estimated_tokens: int) -> bool:
+    """Predictable cost-aware gate: True iff the op's estimated token budget
+    exceeds the small (7B) model's working capacity (env
+    ``JARVIS_FAILOVER_7B_TOKEN_CAPACITY`` default 24000 -- headroom under the 32K
+    window for the generation). 0/unknown -> False (never forces GPU on no info).
+    NEVER raises."""
+    try:
+        n = int(estimated_tokens or 0)
+        if n <= 0:
+            return False
+        return n > _env_int("JARVIS_FAILOVER_7B_TOKEN_CAPACITY", 24000)
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def resolve_tier_for_op(
+    *, urgency: str = "", complexity: str = "", estimated_tokens: int = 0,
+) -> FailoverTier:
+    """Tier selection with the cost-aware gate folded in. The quality (GPU/32B)
+    tier is selected when the master gate is ON AND EITHER the op is high-priority
+    (urgency/complexity) OR its token budget mathematically overflows the 7B's
+    capacity (a strict guarantee -- the 7B literally cannot fit the context).
+    The master cost gate is absolute: disabled -> survival even on overflow
+    (degraded best-effort, never silent GPU spend). NEVER raises."""
+    try:
+        if quality_tier_enabled() and (
+            _is_high_priority(urgency, complexity)
+            or op_exceeds_small_capacity(estimated_tokens=estimated_tokens)
+        ):
+            return _quality_tier()
+    except Exception:  # noqa: BLE001
+        pass
+    return _survival_tier()
+
+
 def model_param_billions(model_label: str) -> float:
     """Parse the parameter size (in billions) from a model label, e.g.
     ``qwen2.5-coder:32b-instruct`` -> 32.0. Unknown -> 0.0. NEVER raises."""
@@ -121,6 +156,6 @@ def is_small_model(model_label: str, *, threshold_b: float = 0.0) -> bool:
 
 
 __all__ = [
-    "FailoverTier", "resolve_tier", "quality_tier_enabled",
-    "model_param_billions", "is_small_model",
+    "FailoverTier", "resolve_tier", "resolve_tier_for_op", "quality_tier_enabled",
+    "op_exceeds_small_capacity", "model_param_billions", "is_small_model",
 ]

--- a/backend/core/ouroboros/governance/fleet_registry.py
+++ b/backend/core/ouroboros/governance/fleet_registry.py
@@ -1,0 +1,88 @@
+"""fleet_registry.py -- Centralized Fleet Registry (dynamic multi-node topology).
+
+The elastic fleet runs more than one J-Prime node concurrently (a 7B CPU survival
+node + an elastic 32B GPU node). The orchestrator can no longer assume a single
+SERVING endpoint. This registry holds each node CLASS's resolved endpoint
+INDEPENDENTLY; the Reachability Racer registers each external IP as it wins, and
+the router queries :meth:`endpoint_for` per-op to pick the exact node. Reaping a
+class clears only that entry -- the survivor stays addressable.
+
+Thread-safe (a plain ``threading.Lock`` -- registration happens from async
+provision paths AND sync teardown). Process-wide singleton via
+:func:`get_fleet_registry`.
+"""
+from __future__ import annotations
+
+import logging
+import threading
+from typing import Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class FleetRegistry:
+    """A class -> endpoint map for the live fleet. Empty endpoints are ignored
+    (never register a half-resolved node)."""
+
+    def __init__(self) -> None:
+        self._endpoints: Dict[str, str] = {}
+        self._lock = threading.Lock()
+
+    def register(self, node_class: str, endpoint: str) -> None:
+        cls = str(node_class or "").strip()
+        ep = str(endpoint or "").strip()
+        if not cls or not ep:
+            return
+        with self._lock:
+            self._endpoints[cls] = ep
+        logger.info("[FleetRegistry] register class=%s endpoint=%s", cls, ep)
+
+    def unregister(self, node_class: str) -> None:
+        cls = str(node_class or "").strip()
+        with self._lock:
+            existed = self._endpoints.pop(cls, None)
+        if existed is not None:
+            logger.info("[FleetRegistry] unregister class=%s (was %s)", cls, existed)
+
+    def endpoint_for(self, node_class: str) -> Optional[str]:
+        with self._lock:
+            return self._endpoints.get(str(node_class or "").strip())
+
+    def is_registered(self, node_class: str) -> bool:
+        with self._lock:
+            return str(node_class or "").strip() in self._endpoints
+
+    def classes(self) -> Tuple[str, ...]:
+        with self._lock:
+            return tuple(self._endpoints.keys())
+
+    def snapshot(self) -> Dict[str, str]:
+        with self._lock:
+            return dict(self._endpoints)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._endpoints.clear()
+
+
+_SINGLETON: Optional[FleetRegistry] = None
+_SINGLETON_LOCK = threading.Lock()
+
+
+def get_fleet_registry() -> FleetRegistry:
+    global _SINGLETON
+    if _SINGLETON is None:
+        with _SINGLETON_LOCK:
+            if _SINGLETON is None:
+                _SINGLETON = FleetRegistry()
+    return _SINGLETON
+
+
+def reset_fleet_registry() -> None:
+    """Test-only: drop the singleton's state."""
+    global _SINGLETON
+    with _SINGLETON_LOCK:
+        _SINGLETON = FleetRegistry()
+
+
+__all__ = ["FleetRegistry", "get_fleet_registry", "reset_fleet_registry"]

--- a/docs/superpowers/specs/jprime_gpu_golden_image.pkr.hcl
+++ b/docs/superpowers/specs/jprime_gpu_golden_image.pkr.hcl
@@ -1,0 +1,181 @@
+# =============================================================================
+# jprime_gpu_golden_image.pkr.hcl
+#
+# HashiCorp Packer template to BAKE the `jarvis-prime-coder-32b` GPU golden image
+# for the Sovereign Failover Mesh's QUALITY tier (Adaptive Workload Provisioner).
+#
+# WHY PRE-BAKED (not cloud-init): the failover node is a TEMPORARY survival tier.
+# Installing NVIDIA drivers + CUDA + pulling a 32B model at boot costs 5-10 min of
+# cold-boot — unacceptable. This image bakes the driver, CUDA, Ollama, AND the
+# pre-pulled 32B weights so the quality node boots READY. The runtime cloud-init
+# only forces the Ollama bind (failover_deadman.build_inference_bind_block) and
+# the TTFT armor (prime_client) absorbs the model-load latency.
+#
+# The companion survival image (`jarvis-prime-coder`, 7B/CPU) is a separate, much
+# simpler bake (no driver/CUDA) and is NOT in scope here.
+#
+# Build:
+#   packer init  jprime_gpu_golden_image.pkr.hcl
+#   packer build -var "project_id=jarvis-473803" jprime_gpu_golden_image.pkr.hcl
+#
+# Notes
+#   * Everything is a `variable` — NO hardcoded project / zone / model / GPU.
+#   * The BUILD instance carries a GPU so `ollama pull` warms + verifies on-device.
+#   * Image family `jarvis-prime-coder-32b` is what failover_tier.py's
+#     JARVIS_FAILOVER_QUALITY_IMAGE default resolves to — the provisioner POSTs
+#     sourceImage=.../family/jarvis-prime-coder-32b.
+# =============================================================================
+
+packer {
+  required_plugins {
+    googlecompute = {
+      source  = "github.com/hashicorp/googlecompute"
+      version = ">= 1.1.0"
+    }
+  }
+}
+
+# ----------------------------------------------------------------------------
+# Variables — override at build time; defaults match failover_tier.py.
+# ----------------------------------------------------------------------------
+variable "project_id" {
+  type        = string
+  description = "GCP project to build + publish the image in."
+}
+
+variable "zone" {
+  type        = string
+  default     = "us-central1-b" # an L4-available zone
+  description = "Build zone — MUST have the chosen accelerator available."
+}
+
+variable "image_family" {
+  type        = string
+  default     = "jarvis-prime-coder-32b"
+  description = "Published family — must equal JARVIS_FAILOVER_QUALITY_IMAGE."
+}
+
+variable "source_image_family" {
+  type        = string
+  default     = "ubuntu-2204-lts"
+  description = "Base OS family (GPU-driver compatible)."
+}
+
+variable "build_machine_type" {
+  type        = string
+  default     = "g2-standard-8"
+  description = "Build VM — a GPU box so `ollama pull` warms on-device."
+}
+
+variable "accelerator_type" {
+  type        = string
+  default     = "nvidia-l4"
+  description = "GPU for the BUILD instance (match the runtime quality tier)."
+}
+
+variable "accelerator_count" {
+  type    = number
+  default = 1
+}
+
+variable "model_label" {
+  type        = string
+  default     = "qwen2.5-coder:32b"
+  description = "Ollama model to PRE-PULL into the image. Must equal JARVIS_FAILOVER_QUALITY_MODEL."
+}
+
+variable "cuda_keyring_deb" {
+  type        = string
+  default     = "https://developer.download.nvidia.com/compute/cuda/repos/ubuntu2204/x86_64/cuda-keyring_1.1-1_all.deb"
+  description = "NVIDIA CUDA keyring (pin/override as needed)."
+}
+
+variable "disk_size_gb" {
+  type        = number
+  default     = 80 # 32B Q4 weights ~20GB + CUDA toolkit headroom
+}
+
+# ----------------------------------------------------------------------------
+# Source — the GPU build instance.
+# ----------------------------------------------------------------------------
+source "googlecompute" "jprime_gpu" {
+  project_id              = var.project_id
+  zone                    = var.zone
+  source_image_family     = var.source_image_family
+  image_name              = "${var.image_family}-{{timestamp}}"
+  image_family            = var.image_family
+  image_description       = "JARVIS J-Prime QUALITY tier: ${var.model_label} on ${var.accelerator_type}, pre-baked driver+CUDA+Ollama."
+  machine_type            = var.build_machine_type
+  disk_size               = var.disk_size_gb
+  ssh_username            = "packer"
+  on_host_maintenance     = "TERMINATE" # GPUs cannot live-migrate — mirrors gcp_compute_rest._build_insert_payload
+
+  accelerator_type  = "projects/${var.project_id}/zones/${var.zone}/acceleratorTypes/${var.accelerator_type}"
+  accelerator_count = var.accelerator_count
+
+  image_labels = {
+    role  = "jprime-failover-quality"
+    model = replace(replace(var.model_label, ":", "_"), ".", "-")
+    tier  = "gpu-32b"
+  }
+}
+
+# ----------------------------------------------------------------------------
+# Build — driver → CUDA → Ollama → pre-pull model → systemd → verify.
+# ----------------------------------------------------------------------------
+build {
+  sources = ["source.googlecompute.jprime_gpu"]
+
+  # 1) NVIDIA driver + CUDA toolkit (pre-baked — never installed at boot).
+  provisioner "shell" {
+    inline = [
+      "set -euxo pipefail",
+      "sudo apt-get update -y",
+      "sudo apt-get install -y build-essential dkms curl jq linux-headers-$(uname -r)",
+      "curl -fsSL ${var.cuda_keyring_deb} -o /tmp/cuda-keyring.deb",
+      "sudo dpkg -i /tmp/cuda-keyring.deb",
+      "sudo apt-get update -y",
+      # cuda-drivers pulls the matched kernel driver + libs; headless server build.
+      "sudo apt-get install -y cuda-drivers cuda-toolkit",
+      "echo 'export PATH=/usr/local/cuda/bin:$PATH' | sudo tee /etc/profile.d/cuda.sh",
+    ]
+  }
+
+  # 2) Ollama (GPU-aware runtime).
+  provisioner "shell" {
+    inline = [
+      "set -euxo pipefail",
+      "curl -fsSL https://ollama.com/install.sh | sudo sh",
+      "sudo systemctl enable ollama",
+    ]
+  }
+
+  # 3) PRE-PULL the 32B weights INTO the image (the whole point — no boot download).
+  #    Start the daemon transiently, pull, verify it loads on the GPU, stop.
+  provisioner "shell" {
+    inline = [
+      "set -euxo pipefail",
+      "sudo systemctl start ollama",
+      "for i in $(seq 1 30); do curl -sf http://127.0.0.1:11434/api/tags && break || sleep 2; done",
+      "sudo -u ollama OLLAMA_HOST=127.0.0.1:11434 ollama pull ${var.model_label}",
+      # On-device smoke: a 1-token generation proves driver+CUDA+model coherence.
+      "curl -sf http://127.0.0.1:11434/api/generate -d '{\"model\":\"${var.model_label}\",\"prompt\":\"ok\",\"stream\":false,\"options\":{\"num_predict\":1}}' | jq -e '.response' >/dev/null",
+      "nvidia-smi || (echo 'DRIVER VERIFY FAILED' && exit 1)",
+      "sudo systemctl stop ollama",
+    ]
+  }
+
+  # 4) Bake the systemd drop-in so the runtime cloud-init only needs to (re)bind.
+  #    Mirrors failover_deadman.build_inference_bind_block — bind 0.0.0.0 so the
+  #    Reachability Racer's external natIP probe can reach it.
+  provisioner "shell" {
+    inline = [
+      "set -euxo pipefail",
+      "sudo mkdir -p /etc/systemd/system/ollama.service.d",
+      "printf '[Service]\\nEnvironment=\"OLLAMA_HOST=0.0.0.0:11434\"\\nEnvironment=\"OLLAMA_KEEP_ALIVE=-1\"\\n' | sudo tee /etc/systemd/system/ollama.service.d/10-jarvis-bind.conf",
+      "sudo systemctl daemon-reload",
+      # Clean cloud-init state so the published image boots fresh.
+      "sudo cloud-init clean --logs || true",
+    ]
+  }
+}

--- a/tests/governance/test_cost_aware_gpu_gate.py
+++ b/tests/governance/test_cost_aware_gpu_gate.py
@@ -1,0 +1,78 @@
+"""Predictable Cost-Aware FSM Gate.
+
+The escalation FSM mathematically evaluates the incoming op's token budget. If
+the op's context requirement exceeds the 7B model's cognitive capacity, GPU
+escalation is STRICTLY GUARANTEED (the 7B literally cannot fit the context) --
+independent of urgency. Provisioning still respects the master cost gate.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_tier as ft
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAILOVER_7B_TOKEN_CAPACITY", raising=False)
+    monkeypatch.delenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", raising=False)
+    yield
+
+
+def test_under_capacity_does_not_require_gpu():
+    assert ft.op_exceeds_small_capacity(estimated_tokens=4_000) is False
+
+
+def test_over_capacity_requires_gpu():
+    # Default 7B working capacity ~24000 (headroom under the 32K window).
+    assert ft.op_exceeds_small_capacity(estimated_tokens=30_000) is True
+
+
+def test_capacity_threshold_env_driven(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_7B_TOKEN_CAPACITY", "8000")
+    assert ft.op_exceeds_small_capacity(estimated_tokens=9_000) is True
+    assert ft.op_exceeds_small_capacity(estimated_tokens=7_000) is False
+
+
+def test_zero_or_unknown_tokens_does_not_force_gpu():
+    assert ft.op_exceeds_small_capacity(estimated_tokens=0) is False
+
+
+# ---------------------------------------------------------------------------
+# resolve_tier_for_op: token-budget overflow STRICTLY guarantees GPU (when
+# quality is enabled); urgency is the other escalation path.
+# ---------------------------------------------------------------------------
+
+def test_overflow_forces_quality_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    # A BACKGROUND op that nonetheless overflows the 7B -> MUST get the GPU.
+    t = ft.resolve_tier_for_op(
+        urgency="background", complexity="simple", estimated_tokens=40_000,
+    )
+    assert t.name == "quality" and t.is_gpu is True
+
+
+def test_overflow_blocked_when_quality_disabled(monkeypatch):
+    """Master cost gate OFF -> no GPU even on overflow (degraded best-effort on
+    7B). The NEED is real but spend is never silent."""
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "false")
+    t = ft.resolve_tier_for_op(
+        urgency="background", complexity="simple", estimated_tokens=40_000,
+    )
+    assert t.name == "survival"
+
+
+def test_small_op_stays_survival(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    t = ft.resolve_tier_for_op(
+        urgency="background", complexity="simple", estimated_tokens=2_000,
+    )
+    assert t.name == "survival"
+
+
+def test_immediate_still_escalates_via_urgency(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    t = ft.resolve_tier_for_op(
+        urgency="immediate", complexity="simple", estimated_tokens=1_000,
+    )
+    assert t.name == "quality"  # urgency path, not the token path

--- a/tests/governance/test_dual_node_fleet_soak.py
+++ b/tests/governance/test_dual_node_fleet_soak.py
@@ -1,0 +1,95 @@
+"""DUAL-NODE FLEET SOAK -- the full elastic-mesh choreography, proven locally.
+
+Exercises the REAL GpuEscalationLane + FleetRegistry + crypto naming with a
+simulated GCP substrate, proving structurally (in seconds, no cloud cost) that:
+
+  1. the CPU (7B) survival node boots + registers,
+  2. a heavy op dynamically scales the GPU (32B) node IN PARALLEL,
+  3. the two nodes carry crypto-distinct names + firewall rules (ZERO collision),
+  4. both endpoints live concurrently in the registry; the router picks per-op,
+  5. draining the heavy op REAPS the GPU node while the CPU stays alive.
+
+This is the local proof; a single real-GCP confirm is the follow-up.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.failover_gpu_lane import GpuEscalationLane
+from backend.core.ouroboros.governance.failover_naming import firewall_name, node_name
+from backend.core.ouroboros.governance.fleet_registry import (
+    get_fleet_registry,
+    reset_fleet_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    reset_fleet_registry()
+    yield
+    reset_fleet_registry()
+
+
+async def test_dual_node_full_choreography(capsys):
+    reg = get_fleet_registry()
+    log = []
+
+    # ---- Phase 1: CPU survival node boots + registers (crypto-namespaced) ----
+    cpu_name, cpu_fw = node_name("cpu"), firewall_name("cpu")
+    reg.register("cpu", "http://cpu-ext-ip:11434")
+    log.append(f"[1] CPU node UP   vm={cpu_name} fw={cpu_fw} ep={reg.endpoint_for('cpu')}")
+    assert reg.classes() == ("cpu",)
+
+    # ---- Build the GPU lane over a SIMULATED GCP substrate that uses the REAL
+    #      naming + registry, asserting collision-freedom at provision time. ----
+    seen = {}
+
+    async def provision_gpu():
+        gpu_name, gpu_fw = node_name("gpu"), firewall_name("gpu")
+        # STRUCTURAL collision guarantee: GPU assets differ from the live CPU's.
+        assert gpu_name != cpu_name, "VM name collision!"
+        assert gpu_fw != cpu_fw, "firewall name collision!"
+        seen["gpu_name"], seen["gpu_fw"] = gpu_name, gpu_fw
+        ep = "http://gpu-ext-ip:11434"
+        reg.register("gpu", ep)
+        log.append(f"[3] GPU node UP   vm={gpu_name} fw={gpu_fw} ep={ep}")
+        return ep
+
+    async def reap_gpu():
+        reg.unregister("gpu")
+        log.append(f"[5] GPU node REAPED vm={seen.get('gpu_name')} -- CPU still UP")
+
+    lane = GpuEscalationLane(
+        provision_fn=provision_gpu, reap_fn=reap_gpu,
+        outage_confirmed_fn=lambda: True,
+    )
+
+    # ---- Phase 2-3: a heavy COMPLEX op arrives -> dynamic GPU scale-out --------
+    log.append("[2] heavy COMPLEX op arrives -> requesting escalation")
+    gpu_ep = await lane.request("heavy-op", urgency="immediate", complexity="complex")
+    assert gpu_ep == "http://gpu-ext-ip:11434"
+
+    # ---- Phase 4: both nodes live concurrently; router picks per-op -----------
+    assert set(reg.classes()) == {"cpu", "gpu"}
+    assert reg.endpoint_for("cpu") != reg.endpoint_for("gpu")  # distinct endpoints
+    assert lane.endpoint == reg.endpoint_for("gpu")
+    log.append(f"[4] FLEET LIVE    cpu={reg.endpoint_for('cpu')} gpu={reg.endpoint_for('gpu')}")
+    # A concurrent BACKGROUND op must NOT touch the GPU -> router sends it to CPU.
+    bg = await lane.request("bg-op", urgency="background", complexity="simple")
+    assert bg is None
+    assert lane.gpu_inflight_count() == 1  # bg op did not land on the GPU
+
+    # ---- Phase 5: drain the heavy op -> GPU reaped, CPU survives --------------
+    await lane.complete("heavy-op")
+    assert reg.endpoint_for("gpu") is None, "GPU should be reaped on drain"
+    assert reg.endpoint_for("cpu") == "http://cpu-ext-ip:11434", "CPU must survive"
+    assert lane.is_gpu_active() is False
+    assert reg.classes() == ("cpu",)
+
+    print("\n".join(log))
+    with capsys.disabled():
+        print("\n=== DUAL-NODE FLEET SOAK CHOREOGRAPHY ===")
+        for line in log:
+            print(line)
+        print("=== CPU survived; GPU elastically scaled + reaped; zero collision ===")

--- a/tests/governance/test_failover_naming.py
+++ b/tests/governance/test_failover_naming.py
@@ -1,0 +1,75 @@
+"""Cryptographic Asset Namespacing -- eradicate dual-node GCP naming collisions.
+
+To run CPU + GPU node lifecycles concurrently, every ephemeral VM and firewall
+rule MUST carry a cryptographically deterministic, class-distinct namespace
+suffix. CPU and GPU names are mathematically guaranteed to differ (different
+hash input) AND each is deterministic (reproducible for teardown without storing
+the name). All names are valid GCE resource names.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from backend.core.ouroboros.governance.failover_naming import (
+    firewall_name,
+    node_name,
+)
+
+_GCE_NAME = re.compile(r"^[a-z]([-a-z0-9]*[a-z0-9])?$")
+
+
+@pytest.fixture(autouse=True)
+def _env(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAILOVER_NAMESPACE_SALT", raising=False)
+    monkeypatch.delenv("JARVIS_FAILOVER_NODE_NAME", raising=False)
+    yield
+
+
+def test_cpu_and_gpu_node_names_differ():
+    assert node_name("cpu") != node_name("gpu")
+
+
+def test_cpu_and_gpu_firewall_names_differ():
+    assert firewall_name("cpu") != firewall_name("gpu")
+
+
+def test_node_and_firewall_names_differ_within_class():
+    assert node_name("gpu") != firewall_name("gpu")
+
+
+def test_names_are_deterministic():
+    # Reproducible -> teardown can reconstruct the name without persisting it.
+    assert node_name("cpu") == node_name("cpu")
+    assert firewall_name("gpu") == firewall_name("gpu")
+
+
+def test_class_label_is_human_readable_in_name():
+    assert "cpu" in node_name("cpu")
+    assert "gpu" in node_name("gpu")
+
+
+def test_names_are_valid_gce_resource_names():
+    for nm in (node_name("cpu"), node_name("gpu"),
+               firewall_name("cpu"), firewall_name("gpu")):
+        assert _GCE_NAME.match(nm), nm
+        assert len(nm) <= 63
+
+
+def test_salt_changes_the_suffix(monkeypatch):
+    a = node_name("cpu")
+    monkeypatch.setenv("JARVIS_FAILOVER_NAMESPACE_SALT", "different-deployment")
+    b = node_name("cpu")
+    assert a != b  # a different deployment salt -> a different namespace
+
+
+def test_suffix_is_a_short_hex_hash():
+    nm = node_name("gpu")
+    suffix = nm.rsplit("-", 1)[-1]
+    assert re.fullmatch(r"[0-9a-f]{8}", suffix)  # 8-char sha256 prefix
+
+
+def test_unknown_class_still_valid_and_distinct():
+    assert _GCE_NAME.match(node_name("speculative"))
+    assert node_name("speculative") != node_name("cpu")

--- a/tests/governance/test_fleet_registry.py
+++ b/tests/governance/test_fleet_registry.py
@@ -1,0 +1,89 @@
+"""Centralized Fleet Registry -- dynamic multi-node topology.
+
+The orchestrator can no longer assume a single SERVING endpoint. The registry
+holds each node class's endpoint INDEPENDENTLY (cpu + gpu resolved/registered
+separately by the Reachability Racer). The router queries endpoint_for(class)
+per-op to execute the exact handoff. Reaping a class clears only that entry.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.fleet_registry import (
+    FleetRegistry,
+    get_fleet_registry,
+    reset_fleet_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh():
+    reset_fleet_registry()
+    yield
+    reset_fleet_registry()
+
+
+def test_register_and_resolve():
+    r = FleetRegistry()
+    r.register("cpu", "http://10.0.0.1:11434")
+    assert r.endpoint_for("cpu") == "http://10.0.0.1:11434"
+
+
+def test_classes_are_independent():
+    r = FleetRegistry()
+    r.register("cpu", "http://cpu:11434")
+    r.register("gpu", "http://gpu:11434")
+    assert r.endpoint_for("cpu") == "http://cpu:11434"
+    assert r.endpoint_for("gpu") == "http://gpu:11434"
+
+
+def test_unregister_one_leaves_the_other():
+    r = FleetRegistry()
+    r.register("cpu", "http://cpu:11434")
+    r.register("gpu", "http://gpu:11434")
+    r.unregister("gpu")  # reap GPU
+    assert r.endpoint_for("gpu") is None
+    assert r.endpoint_for("cpu") == "http://cpu:11434"  # CPU survives
+
+
+def test_unknown_class_resolves_none():
+    assert FleetRegistry().endpoint_for("nope") is None
+
+
+def test_reregister_overwrites():
+    r = FleetRegistry()
+    r.register("gpu", "http://old:11434")
+    r.register("gpu", "http://new:11434")
+    assert r.endpoint_for("gpu") == "http://new:11434"
+
+
+def test_register_empty_endpoint_is_ignored():
+    r = FleetRegistry()
+    r.register("cpu", "")
+    assert r.endpoint_for("cpu") is None
+    assert "cpu" not in r.classes()
+
+
+def test_classes_and_snapshot():
+    r = FleetRegistry()
+    r.register("cpu", "http://cpu:11434")
+    r.register("gpu", "http://gpu:11434")
+    assert set(r.classes()) == {"cpu", "gpu"}
+    snap = r.snapshot()
+    assert snap == {"cpu": "http://cpu:11434", "gpu": "http://gpu:11434"}
+    snap["cpu"] = "mutated"  # snapshot is a copy
+    assert r.endpoint_for("cpu") == "http://cpu:11434"
+
+
+def test_is_registered():
+    r = FleetRegistry()
+    assert r.is_registered("gpu") is False
+    r.register("gpu", "http://gpu:11434")
+    assert r.is_registered("gpu") is True
+
+
+def test_singleton_accessor_is_stable():
+    a = get_fleet_registry()
+    a.register("cpu", "http://cpu:11434")
+    b = get_fleet_registry()
+    assert b.endpoint_for("cpu") == "http://cpu:11434"  # same instance

--- a/tests/governance/test_gpu_escalation_lane.py
+++ b/tests/governance/test_gpu_escalation_lane.py
@@ -1,0 +1,132 @@
+"""Elastic Multi-Tier Fleet -- the GPU Escalation Lane.
+
+During a sustained outage the 7B CPU survival node is the baseline. When a
+COMPLEX/IMMEDIATE (or token-overflowing) op arrives, the lane provisions the 32B
+GPU node IN PARALLEL and routes that op to it. The 7B keeps serving BACKGROUND
+ops. The instant the GPU in-flight count drains to zero the lane REAPS the GPU
+node (stops billing) and falls back to the single 7B. Injected provision/reap
+boundaries -> no real GCP in tests.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.failover_gpu_lane import (
+    GpuEscalationLane,
+    GpuLaneState,
+)
+
+
+def _lane(provisioned_ep="http://gpu:11434", outage=True, ready=True, calls=None):
+    calls = calls if calls is not None else {}
+    calls.setdefault("provision", 0)
+    calls.setdefault("reap", 0)
+
+    async def provision_fn():
+        calls["provision"] += 1
+        return provisioned_ep
+
+    async def reap_fn():
+        calls["reap"] += 1
+
+    async def ready_fn(ep):
+        return ready
+
+    lane = GpuEscalationLane(
+        provision_fn=provision_fn, reap_fn=reap_fn, ready_fn=ready_fn,
+        outage_confirmed_fn=lambda: outage,
+    )
+    return lane, calls
+
+
+@pytest.fixture(autouse=True)
+def _quality_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    yield
+
+
+async def test_background_op_never_escalates():
+    lane, calls = _lane()
+    ep = await lane.request("op1", urgency="background", complexity="simple")
+    assert ep is None  # 7B handles it
+    assert calls["provision"] == 0
+    assert lane.is_gpu_active() is False
+
+
+async def test_complex_op_provisions_gpu():
+    lane, calls = _lane()
+    ep = await lane.request("op1", urgency="standard", complexity="complex")
+    assert ep == "http://gpu:11434"
+    assert calls["provision"] == 1
+    assert lane.gpu_inflight_count() == 1
+    assert lane.is_gpu_active() is True
+
+
+async def test_second_complex_op_reuses_one_gpu():
+    lane, calls = _lane()
+    await lane.request("op1", urgency="immediate", complexity="simple")
+    await lane.request("op2", urgency="immediate", complexity="simple")
+    assert calls["provision"] == 1          # ONE node for both
+    assert lane.gpu_inflight_count() == 2
+
+
+async def test_token_overflow_escalates():
+    lane, calls = _lane()
+    ep = await lane.request("op1", urgency="background", complexity="simple",
+                            estimated_tokens=40_000)
+    assert ep is not None and calls["provision"] == 1  # overflow forced the GPU
+
+
+async def test_drain_to_zero_reaps_gpu():
+    lane, calls = _lane()
+    await lane.request("op1", urgency="immediate", complexity="complex")
+    await lane.request("op2", urgency="immediate", complexity="complex")
+    await lane.complete("op1")
+    assert calls["reap"] == 0                # still one in-flight
+    assert lane.is_gpu_active() is True
+    await lane.complete("op2")
+    assert calls["reap"] == 1                # drained -> reaped
+    assert lane.is_gpu_active() is False
+    assert lane.gpu_inflight_count() == 0
+
+
+async def test_disabled_quality_never_provisions(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "false")
+    lane, calls = _lane()
+    ep = await lane.request("op1", urgency="immediate", complexity="complex")
+    assert ep is None and calls["provision"] == 0
+
+
+async def test_no_outage_does_not_escalate():
+    lane, calls = _lane(outage=False)
+    ep = await lane.request("op1", urgency="immediate", complexity="complex")
+    assert ep is None and calls["provision"] == 0  # only escalate on sustained outage
+
+
+async def test_provision_failure_failsoft():
+    lane, calls = _lane(provisioned_ep=None)  # provision returns no endpoint
+    ep = await lane.request("op1", urgency="immediate", complexity="complex")
+    assert ep is None
+    assert lane.is_gpu_active() is False
+    assert lane.gpu_inflight_count() == 0     # no phantom in-flight
+    assert lane._state == GpuLaneState.IDLE
+
+
+async def test_not_ready_reaps_and_failsoft():
+    lane, calls = _lane(ready=False)          # node comes up but never ready
+    ep = await lane.request("op1", urgency="immediate", complexity="complex")
+    assert ep is None
+    assert calls["reap"] == 1                 # orphan node torn down
+    assert lane._state == GpuLaneState.IDLE
+
+
+async def test_concurrent_requests_single_provision():
+    import asyncio
+    lane, calls = _lane()
+    results = await asyncio.gather(*[
+        lane.request(f"op{i}", urgency="immediate", complexity="complex")
+        for i in range(5)
+    ])
+    assert all(r == "http://gpu:11434" for r in results)
+    assert calls["provision"] == 1            # no double-spend under concurrency
+    assert lane.gpu_inflight_count() == 5


### PR DESCRIPTION
Builds the elastic multi-tier J-Prime fleet for a sustained DW outage. **GPU gated OFF by default.** Builds on #69763.

- **Cost-aware FSM gate**: token-budget overflow past the 7B capacity strictly guarantees GPU escalation (`resolve_tier_for_op`).
- **Elastic GPU lane** (`failover_gpu_lane.py`): demand-driven second-node FSM — provision one GPU node on first complex op, route by tier, **reap the instant in-flight drains to 0** (stops billing), fall back to 7B. Lock-guarded (no double-spend), sustained-outage-gated, injected boundaries → fully tested.
- **Packer IaC spec**: pre-bakes the 32B GPU golden image (driver+CUDA+Ollama+weights) so it boots ready — no cold-boot install.

18 new tests + the spec. **Remaining live integration (noted in commit): the lane's second-node provision/reap boundaries (separate firewall + racer) + the orchestrator per-op routing call — a dedicated pass with a live soak.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an elastic GPU failover lane with a cost-aware gate, a pre-baked 32B GPU image, and now a live dual-node fleet wired with crypto namespacing and a central registry. GPU stays off by default, scales only when needed, and reaps the moment in-flight hits zero.

- **New Features**
  - Cryptographic namespacing: deterministic, class-scoped GCE names for VMs and /32 firewall rules (no CPU/GPU collisions; reconstructable at teardown).
  - Fleet Registry: thread-safe class→endpoint map (`get_fleet_registry()`); CPU registers on SERVING, GPU registers on readiness; reaping clears only that class.
  - Live GPU wiring: `failover_lifecycle.gpu_lane` provisions the second GPU node (own firewall, readiness race, registry register/unregister) and force-reaps on handback.

- **Migration**
  - GPU tier is off by default; enable with `JARVIS_FAILOVER_QUALITY_TIER_ENABLED=true`.
  - Build and publish the `jarvis-prime-coder-32b` image family using the Packer spec (`docs/superpowers/specs/jprime_gpu_golden_image.pkr.hcl`); provisioner defaults align.

<sup>Written for commit afb8f73e815354090dcacfc602bd010cb3c68975. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69764?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

