### PR TITLE
feat(failover): Automated REST Baker — serverless Cloud Build bake of the 32B GPU golden image

### DIFF
--- a/backend/core/ouroboros/governance/cloud_build_baker.py
+++ b/backend/core/ouroboros/governance/cloud_build_baker.py
@@ -23,13 +23,16 @@ import base64
 import json
 import logging
 import os
+import secrets
 from pathlib import Path
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 
 logger = logging.getLogger(__name__)
 
 _CLOUD_BUILD_BASE = "https://cloudbuild.googleapis.com/v1"
 _STORAGE_BASE = "https://storage.googleapis.com/storage/v1"
+_IAM_BASE = "https://iam.googleapis.com/v1"
+_CRM_BASE = "https://cloudresourcemanager.googleapis.com/v1"
 _PACKER_IMAGE = "hashicorp/packer:latest"
 _WRITER_IMAGE = "gcr.io/cloud-builders/gcloud"
 _SPEC_PATH_IN_BUILD = "/workspace/main.pkr.hcl"
@@ -37,6 +40,64 @@ _SPEC_PATH_IN_BUILD = "/workspace/main.pkr.hcl"
 _TERMINAL_STATUSES = frozenset({
     "SUCCESS", "FAILURE", "TIMEOUT", "CANCELLED", "EXPIRED", "INTERNAL_ERROR",
 })
+
+# Least-privilege roles Packer needs to bake a GPU image + write build logs.
+# Deliberately NOT roles/compute.admin (the blast-radius role we refused to grant
+# the default SA): instanceAdmin can create/delete the build VM, storageAdmin can
+# create the image, serviceAccountUser lets the build act-as the runtime SA,
+# logWriter lets the custom-SA build emit logs to Cloud Logging.
+_DEFAULT_BAKER_ROLES = (
+    "roles/compute.instanceAdmin.v1",
+    "roles/compute.storageAdmin",
+    "roles/iam.serviceAccountUser",
+    "roles/logging.logWriter",
+)
+
+
+def baker_sa_roles() -> List[str]:
+    """Least-privilege roles bound to the ephemeral baker SA. Env-overridable
+    (``JARVIS_BAKE_SA_ROLES``, comma-separated) -- no hardcoded blast radius."""
+    raw = os.environ.get("JARVIS_BAKE_SA_ROLES", "").strip()
+    if raw:
+        return [r.strip() for r in raw.split(",") if r.strip()]
+    return list(_DEFAULT_BAKER_ROLES)
+
+
+def temp_sa_account_id() -> str:
+    """A unique, valid GCP SA accountId for an ephemeral baker
+    (``^[a-z][a-z0-9-]{4,28}[a-z0-9]$``). 6 hex of entropy -> collision-free."""
+    return "jarvis-gpu-baker-{}".format(secrets.token_hex(3))
+
+
+def create_sa_payload(account_id: str, display_name: str) -> Dict[str, Any]:
+    """serviceAccounts.create request body."""
+    return {"accountId": account_id, "serviceAccount": {"displayName": display_name}}
+
+
+def iam_policy_add_binding(policy: Dict[str, Any], role: str, member: str) -> Dict[str, Any]:
+    """Read-modify-write: add ``member`` to ``role``'s binding (creating the
+    binding if absent, never duplicating the member). Returns the policy."""
+    bindings = policy.setdefault("bindings", [])
+    for b in bindings:
+        if b.get("role") == role:
+            members = b.setdefault("members", [])
+            if member not in members:
+                members.append(member)
+            return policy
+    bindings.append({"role": role, "members": [member]})
+    return policy
+
+
+def iam_policy_remove_member(policy: Dict[str, Any], member: str) -> Dict[str, Any]:
+    """Strip ``member`` from EVERY binding; drop any binding left empty (no
+    lingering privilege residue). Returns the policy."""
+    kept = []
+    for b in policy.get("bindings", []):
+        members = [m for m in b.get("members", []) if m != member]
+        if members:
+            kept.append({**b, "members": members})
+    policy["bindings"] = kept
+    return policy
 
 
 # ---------------------------------------------------------------------------
@@ -61,6 +122,7 @@ def build_packer_cloud_build(
     machine_type: str = "E2_HIGHCPU_8",
     disk_gb: int = 100,
     packer_image: str = _PACKER_IMAGE,
+    service_account: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Construct the EXACT Cloud Build ``Build`` resource that bakes the image:
     (1) write the base64-inlined Packer spec into the build workspace,
@@ -83,12 +145,19 @@ def build_packer_cloud_build(
         {"name": packer_image, "args": ["init", _SPEC_PATH_IN_BUILD]},
         {"name": packer_image, "args": ["build", *var_flags, _SPEC_PATH_IN_BUILD]},
     ]
-    return {
+    options: Dict[str, Any] = {"machineType": machine_type, "diskSizeGb": int(disk_gb)}
+    cfg: Dict[str, Any] = {
         "steps": steps,
         "timeout": "{}s".format(int(timeout_s)),
-        "options": {"machineType": machine_type, "diskSizeGb": int(disk_gb)},
+        "options": options,
         "substitutions": dict(substitutions or {}),
     }
+    if service_account:
+        # A custom build SA REQUIRES an explicit logging mode (Cloud Build won't
+        # use the default logs bucket under a user-supplied SA).
+        cfg["serviceAccount"] = service_account
+        options["logging"] = "CLOUD_LOGGING_ONLY"
+    return cfg
 
 
 # ---------------------------------------------------------------------------
@@ -118,6 +187,9 @@ class CloudBuildBaker:
         self.timeout_s = timeout_s
         self.poll_interval_s = poll_interval_s
         self._log_offset = 0
+        # Ephemeral Zero-Trust IAM: the custom build SA (set during the lifecycle).
+        self.service_account: Optional[str] = None
+        self._iam_settle_s = int(os.environ.get("JARVIS_BAKE_IAM_SETTLE_S", "10"))
 
     # -- auth/identity reused from the provisioner's ADC bridge ---------------
     async def _auth(self):
@@ -141,6 +213,7 @@ class CloudBuildBaker:
         return build_packer_cloud_build(
             spec_text=self._read_spec(), project=project,
             image_family=self.image_family, extra_vars=extra, timeout_s=self.timeout_s,
+            service_account=self.service_account,
         )
 
     async def submit(self) -> Optional[str]:
@@ -239,8 +312,143 @@ class CloudBuildBaker:
         status = await self.poll(build_id)
         return build_status_is_success(status)
 
+    # -- Ephemeral Zero-Trust IAM lifecycle ----------------------------------
+    def _wal_path(self) -> Path:
+        p = Path(os.environ.get(
+            "JARVIS_BAKE_WAL", str(Path(".jarvis") / "bake" / "bake_wal.log")
+        ))
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    def _write_flare(self, message: str) -> None:
+        """Append an immutable, timestamped flare to the bake WAL (never raises)."""
+        try:
+            import datetime as _dt  # noqa: PLC0415
+            stamp = _dt.datetime.now(_dt.timezone.utc).isoformat()
+            with self._wal_path().open("a", encoding="utf-8") as fh:
+                fh.write("[{}] [bake] {}\n".format(stamp, message))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[CloudBuildBaker] flare write fail-soft err=%r", exc)
+        logger.info("[CloudBuildBaker][flare] %s", message)
+
+    async def _create_temp_sa(self, project: str, token: str, account_id: str) -> Optional[str]:
+        from backend.core.ouroboros.governance.gcp_compute_rest import _http_request  # noqa: PLC0415
+        url = "{}/projects/{}/serviceAccounts".format(_IAM_BASE, project)
+        status, body = await _http_request(
+            url, method="POST",
+            headers={"Authorization": "Bearer {}".format(token), "Content-Type": "application/json"},
+            body=json.dumps(create_sa_payload(account_id, "JARVIS GPU baker (ephemeral)")).encode("utf-8"),
+            timeout_s=60.0,
+        )
+        if status not in (200, 201):
+            logger.error("[CloudBuildBaker] SA create failed status=%s body=%s", status, body[:300])
+            return None
+        try:
+            return json.loads(body).get("email")
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def _get_project_policy(self, project: str, token: str) -> Optional[Dict[str, Any]]:
+        from backend.core.ouroboros.governance.gcp_compute_rest import _http_request  # noqa: PLC0415
+        url = "{}/projects/{}:getIamPolicy".format(_CRM_BASE, project)
+        status, body = await _http_request(
+            url, method="POST",
+            headers={"Authorization": "Bearer {}".format(token), "Content-Type": "application/json"},
+            body=b"{}", timeout_s=60.0,
+        )
+        if status != 200:
+            return None
+        try:
+            return json.loads(body)
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def _set_project_policy(self, project: str, token: str, policy: Dict[str, Any]) -> bool:
+        from backend.core.ouroboros.governance.gcp_compute_rest import _http_request  # noqa: PLC0415
+        url = "{}/projects/{}:setIamPolicy".format(_CRM_BASE, project)
+        status, _ = await _http_request(
+            url, method="POST",
+            headers={"Authorization": "Bearer {}".format(token), "Content-Type": "application/json"},
+            body=json.dumps({"policy": policy}).encode("utf-8"), timeout_s=60.0,
+        )
+        return status == 200
+
+    async def _bind_roles(self, project: str, token: str, member: str, roles: List[str]) -> bool:
+        policy = await self._get_project_policy(project, token)
+        if policy is None:
+            return False
+        for role in roles:
+            iam_policy_add_binding(policy, role, member)
+        return await self._set_project_policy(project, token, policy)
+
+    async def _unbind_member(self, project: str, token: str, member: str) -> bool:
+        policy = await self._get_project_policy(project, token)
+        if policy is None:
+            return False
+        iam_policy_remove_member(policy, member)
+        return await self._set_project_policy(project, token, policy)
+
+    async def _delete_temp_sa(self, project: str, token: str, sa_email: str) -> bool:
+        from backend.core.ouroboros.governance.gcp_compute_rest import _http_request  # noqa: PLC0415
+        url = "{}/projects/{}/serviceAccounts/{}".format(_IAM_BASE, project, sa_email)
+        status, _ = await _http_request(
+            url, method="DELETE",
+            headers={"Authorization": "Bearer {}".format(token)}, timeout_s=60.0,
+        )
+        return status == 200
+
+    async def bake_with_ephemeral_iam(self) -> bool:
+        """The Zero-Trust bake: create a DEDICATED temp SA -> bind least-privilege
+        roles -> run the build AS that SA -> GUARANTEE teardown (delete the SA the
+        moment the build concludes, success or fail). The default Cloud Build SA is
+        never touched; zero lingering privilege. Drops WAL flares throughout."""
+        token, project = await self._auth()
+        if not token or not project:
+            self._write_flare("BAKE ABORT: auth/project unresolved")
+            return False
+        sa_email: Optional[str] = None
+        member: Optional[str] = None
+        try:
+            sa_email = await self._create_temp_sa(project, token, temp_sa_account_id())
+            if not sa_email:
+                self._write_flare("BAKE ABORT: temp SA create denied (need iam.serviceAccounts.create)")
+                return False
+            member = "serviceAccount:{}".format(sa_email)
+            self._write_flare("EPHEMERAL SA CREATED sa={}".format(sa_email))
+            if not await self._bind_roles(project, token, member, baker_sa_roles()):
+                self._write_flare("BAKE ABORT: role bind denied (need resourcemanager.projects.setIamPolicy)")
+                return False
+            self._write_flare("LEAST-PRIV ROLES BOUND roles={}".format(",".join(baker_sa_roles())))
+            await asyncio.sleep(self._iam_settle_s)  # IAM propagation settle
+            self.service_account = "projects/{}/serviceAccounts/{}".format(project, sa_email)
+            build_id = await self.submit()
+            if not build_id:
+                self._write_flare("BAKE FAILED: submit rejected")
+                return False
+            self._write_flare("BAKE SUBMITTED build={} sa={}".format(build_id, sa_email))
+            status = await self.poll(build_id)
+            ok = build_status_is_success(status)
+            self._write_flare(
+                "GOLDEN IMAGE READY image_family={} build={}".format(self.image_family, build_id)
+                if ok else "BAKE FAILED status={} build={}".format(status, build_id)
+            )
+            return ok
+        finally:
+            if sa_email:
+                try:
+                    t2, p2 = await self._auth()  # token may have rotated over a long bake
+                    proj, tok = (p2 or project), (t2 or token)
+                    if member:
+                        await self._unbind_member(proj, tok, member)
+                    await self._delete_temp_sa(proj, tok, sa_email)
+                    self._write_flare("EPHEMERAL SA TORN DOWN sa={} (zero lingering privilege)".format(sa_email))
+                except Exception as exc:  # noqa: BLE001
+                    self._write_flare("WARN teardown err={!r} sa={} -- MANUAL CHECK".format(exc, sa_email))
+
 
 __all__ = [
     "CloudBuildBaker", "build_packer_cloud_build",
     "build_status_is_terminal", "build_status_is_success",
+    "baker_sa_roles", "temp_sa_account_id", "create_sa_payload",
+    "iam_policy_add_binding", "iam_policy_remove_member",
 ]

--- a/backend/core/ouroboros/governance/cloud_build_baker.py
+++ b/backend/core/ouroboros/governance/cloud_build_baker.py
@@ -1,0 +1,246 @@
+"""cloud_build_baker.py -- Serverless IaC Execution (the Automated REST Baker).
+
+Submits a Packer ``.hcl`` as a remote **Google Cloud Build** job over REST, so the
+32B GPU golden image is manufactured hands-off: GCP provisions the builder, runs
+``packer build`` (which itself spins a GPU node, bakes the NVIDIA driver + CUDA +
+Ollama + pre-pulls the 32B weights, snapshots the image, tears the node down),
+then tears the builder down. Zero local Packer, zero gcloud, **zero GCS upload**
+-- the spec is inlined as base64 into the build steps.
+
+Auth is the SAME dynamic ADC REST bridge the provisioner uses
+(``gcp_compute_rest.GCPComputeRest.access_token`` -> ``cloud-platform`` scope,
+which also covers Cloud Build + Storage) and the same async ``_http_request``
+helper -- no duplicate auth, no new SDK.
+
+The pure helpers (:func:`build_packer_cloud_build`, the status predicates) are
+unit-tested; :class:`CloudBuildBaker` is the async orchestration (submit -> poll
+-> stream logs).
+"""
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_CLOUD_BUILD_BASE = "https://cloudbuild.googleapis.com/v1"
+_STORAGE_BASE = "https://storage.googleapis.com/storage/v1"
+_PACKER_IMAGE = "hashicorp/packer:latest"
+_WRITER_IMAGE = "gcr.io/cloud-builders/gcloud"
+_SPEC_PATH_IN_BUILD = "/workspace/main.pkr.hcl"
+
+_TERMINAL_STATUSES = frozenset({
+    "SUCCESS", "FAILURE", "TIMEOUT", "CANCELLED", "EXPIRED", "INTERNAL_ERROR",
+})
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers (unit-tested)
+# ---------------------------------------------------------------------------
+def build_status_is_terminal(status: str) -> bool:
+    return str(status or "").upper() in _TERMINAL_STATUSES
+
+
+def build_status_is_success(status: str) -> bool:
+    return str(status or "").upper() == "SUCCESS"
+
+
+def build_packer_cloud_build(
+    *,
+    spec_text: str,
+    project: str,
+    image_family: str,
+    substitutions: Optional[Dict[str, str]] = None,
+    extra_vars: Optional[Dict[str, str]] = None,
+    timeout_s: int = 3600,
+    machine_type: str = "E2_HIGHCPU_8",
+    disk_gb: int = 100,
+    packer_image: str = _PACKER_IMAGE,
+) -> Dict[str, Any]:
+    """Construct the EXACT Cloud Build ``Build`` resource that bakes the image:
+    (1) write the base64-inlined Packer spec into the build workspace,
+    (2) ``packer init``, (3) ``packer build`` with the project/image-family/model
+    vars. No ``source`` -> no GCS upload (the spec rides inline). Pure."""
+    b64 = base64.b64encode((spec_text or "").encode("utf-8")).decode("ascii")
+    var_flags = [
+        "-var=project_id={}".format(project),
+        "-var=image_family={}".format(image_family),
+    ]
+    for k, v in (extra_vars or {}).items():
+        var_flags.append("-var={}={}".format(k, v))
+    steps = [
+        {
+            "name": _WRITER_IMAGE,
+            "entrypoint": "bash",
+            # base64 is [A-Za-z0-9+/=] only -> safe inside single quotes.
+            "args": ["-c", "printf %s '{}' | base64 -d > {}".format(b64, _SPEC_PATH_IN_BUILD)],
+        },
+        {"name": packer_image, "args": ["init", _SPEC_PATH_IN_BUILD]},
+        {"name": packer_image, "args": ["build", *var_flags, _SPEC_PATH_IN_BUILD]},
+    ]
+    return {
+        "steps": steps,
+        "timeout": "{}s".format(int(timeout_s)),
+        "options": {"machineType": machine_type, "diskSizeGb": int(disk_gb)},
+        "substitutions": dict(substitutions or {}),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Async orchestration
+# ---------------------------------------------------------------------------
+class CloudBuildBaker:
+    """Submit + poll a remote Packer Cloud Build. Reuses the provisioner's ADC
+    auth + async HTTP. Fail-soft: every method returns a value / logs; the only
+    hard failure surfaced is a non-success terminal build status."""
+
+    def __init__(
+        self,
+        *,
+        spec_path: str,
+        project: Optional[str] = None,
+        image_family: str = "jarvis-prime-coder-32b",
+        model: Optional[str] = None,
+        zone: Optional[str] = None,
+        timeout_s: int = 3600,
+        poll_interval_s: int = 15,
+    ) -> None:
+        self.spec_path = spec_path
+        self._project = project
+        self.image_family = image_family
+        self.model = model
+        self.zone = zone
+        self.timeout_s = timeout_s
+        self.poll_interval_s = poll_interval_s
+        self._log_offset = 0
+
+    # -- auth/identity reused from the provisioner's ADC bridge ---------------
+    async def _auth(self):
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            get_compute_rest,
+        )
+        client = get_compute_rest()
+        token = await client.access_token()
+        project = self._project or await client.project() or os.environ.get("GCP_PROJECT")
+        return token, project
+
+    def _read_spec(self) -> str:
+        return Path(self.spec_path).read_text(encoding="utf-8")
+
+    def build_config(self, project: str) -> Dict[str, Any]:
+        extra = {}
+        if self.model:
+            extra["model_label"] = self.model
+        if self.zone:
+            extra["zone"] = self.zone
+        return build_packer_cloud_build(
+            spec_text=self._read_spec(), project=project,
+            image_family=self.image_family, extra_vars=extra, timeout_s=self.timeout_s,
+        )
+
+    async def submit(self) -> Optional[str]:
+        """POST the build; return the build id (or None on failure)."""
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            _http_request,
+        )
+        token, project = await self._auth()
+        if not token or not project:
+            logger.error("[CloudBuildBaker] auth/project unresolved -> abort")
+            return None
+        cfg = self.build_config(project)
+        url = "{}/projects/{}/builds".format(_CLOUD_BUILD_BASE, project)
+        status, body = await _http_request(
+            url, method="POST",
+            headers={"Authorization": "Bearer {}".format(token),
+                     "Content-Type": "application/json"},
+            body=json.dumps(cfg).encode("utf-8"), timeout_s=60.0,
+        )
+        if status not in (200, 201):
+            logger.error("[CloudBuildBaker] submit failed status=%s body=%s", status, body[:400])
+            return None
+        try:
+            op = json.loads(body)
+            build_id = op.get("metadata", {}).get("build", {}).get("id")
+            logger.info("[CloudBuildBaker] build submitted id=%s", build_id)
+            return build_id
+        except Exception as exc:  # noqa: BLE001
+            logger.error("[CloudBuildBaker] submit parse err=%r body=%s", exc, body[:400])
+            return None
+
+    async def _get_build(self, project: str, token: str, build_id: str) -> Dict[str, Any]:
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            _http_request,
+        )
+        url = "{}/projects/{}/builds/{}".format(_CLOUD_BUILD_BASE, project, build_id)
+        status, body = await _http_request(
+            url, method="GET",
+            headers={"Authorization": "Bearer {}".format(token)}, timeout_s=30.0,
+        )
+        if status != 200:
+            return {}
+        try:
+            return json.loads(body)
+        except Exception:  # noqa: BLE001
+            return {}
+
+    async def _stream_new_logs(self, project: str, token: str, logs_bucket: str, build_id: str) -> None:
+        """Fetch the GCS build-log object and print only the NEW tail. Fail-soft."""
+        if not logs_bucket:
+            return
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            _http_request,
+        )
+        bucket = logs_bucket.replace("gs://", "").split("/", 1)[0]
+        obj = "log-{}.txt".format(build_id)
+        url = "{}/b/{}/o/{}?alt=media".format(_STORAGE_BASE, bucket, obj.replace("/", "%2F"))
+        try:
+            status, body = await _http_request(
+                url, method="GET",
+                headers={"Authorization": "Bearer {}".format(token)}, timeout_s=30.0,
+            )
+            if status == 200 and len(body) > self._log_offset:
+                new = body[self._log_offset:]
+                self._log_offset = len(body)
+                print(new, end="", flush=True)
+        except Exception:  # noqa: BLE001
+            pass  # logs are best-effort; status polling is authoritative
+
+    async def poll(self, build_id: str, *, max_wait_s: Optional[int] = None) -> str:
+        """Poll the build to a terminal status, streaming logs. Returns the final
+        status string (or "UNKNOWN")."""
+        token, project = await self._auth()
+        if not token or not project:
+            return "UNKNOWN"
+        waited = 0
+        cap = max_wait_s if max_wait_s is not None else (self.timeout_s + 600)
+        while True:
+            build = await self._get_build(project, token, build_id)
+            status = str(build.get("status", ""))
+            await self._stream_new_logs(project, token, build.get("logsBucket", ""), build_id)
+            if build_status_is_terminal(status):
+                logger.info("[CloudBuildBaker] build %s -> %s", build_id, status)
+                return status
+            if waited >= cap:
+                logger.warning("[CloudBuildBaker] poll cap %ss reached (status=%s)", cap, status)
+                return status or "UNKNOWN"
+            await asyncio.sleep(self.poll_interval_s)
+            waited += self.poll_interval_s
+
+    async def bake(self) -> bool:
+        """Full hands-off bake: submit -> poll -> stream logs. True iff SUCCESS."""
+        build_id = await self.submit()
+        if not build_id:
+            return False
+        status = await self.poll(build_id)
+        return build_status_is_success(status)
+
+
+__all__ = [
+    "CloudBuildBaker", "build_packer_cloud_build",
+    "build_status_is_terminal", "build_status_is_success",
+]

--- a/scripts/bake_gpu_golden_image.py
+++ b/scripts/bake_gpu_golden_image.py
@@ -1,0 +1,126 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""bake_gpu_golden_image.py -- one-command, hands-off bake of the 32B GPU golden image.
+
+Submits the GPU Packer spec (docs/superpowers/specs/jprime_gpu_golden_image.pkr.hcl)
+as a remote Google Cloud Build job over REST -- GCP provisions the builder, runs
+``packer build`` (which spins a GPU node, bakes the NVIDIA driver + CUDA + Ollama +
+pre-pulls the 32B weights, snapshots the ``jarvis-prime-coder-32b`` image, tears the
+node down), then tears the builder down. NO local Packer. NO gcloud. NO GCS upload
+(the spec rides inline as base64). Auth is the SAME dynamic ADC REST bridge the
+failover provisioner uses (``gcp_compute_rest.access_token`` -> cloud-platform).
+
+The quality tier (``failover_tier.py``) defaults JARVIS_FAILOVER_QUALITY_IMAGE to
+``jarvis-prime-coder-32b`` -- so the image this bakes is exactly what the elastic
+GPU lane provisions.
+
+Usage:
+    # DRY-RUN (default): print the exact Cloud Build resource, submit nothing.
+    python3 scripts/bake_gpu_golden_image.py --project jarvis-473803 --dry-run
+
+    # EXECUTE: submit + poll hands-off, streaming the build log to this terminal.
+    python3 scripts/bake_gpu_golden_image.py --project jarvis-473803 --execute
+
+Prerequisite (one-time, documented -- NOT a per-bake chore): the Cloud Build
+service account needs roles/compute.admin + roles/iam.serviceAccountUser so Packer
+can drive Compute. The script prints the exact grant on an auth failure.
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import sys
+from pathlib import Path
+
+# Repo-root import shim so the script runs from anywhere.
+_REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(_REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT))
+
+from backend.core.ouroboros.governance.cloud_build_baker import (  # noqa: E402
+    CloudBuildBaker,
+    build_status_is_success,
+)
+
+_DEFAULT_SPEC = str(
+    _REPO_ROOT / "docs" / "superpowers" / "specs" / "jprime_gpu_golden_image.pkr.hcl"
+)
+
+
+def _parse_args(argv):
+    p = argparse.ArgumentParser(description="Hands-off bake of the 32B GPU golden image via Cloud Build REST.")
+    p.add_argument("--project", default=os.environ.get("GCP_PROJECT"),
+                   help="GCP project (default $GCP_PROJECT; else resolved from ADC at run).")
+    p.add_argument("--zone", default=os.environ.get("GCP_ZONE", "us-central1-b"),
+                   help="Build/bake zone (must have the accelerator available).")
+    p.add_argument("--model", default=os.environ.get("JARVIS_FAILOVER_QUALITY_MODEL", "qwen2.5-coder:32b"),
+                   help="Ollama model to pre-pull into the image.")
+    p.add_argument("--image-family", default=os.environ.get("JARVIS_FAILOVER_QUALITY_IMAGE", "jarvis-prime-coder-32b"),
+                   help="Published image family (must equal the quality tier's image).")
+    p.add_argument("--spec", default=_DEFAULT_SPEC, help="Path to the Packer .hcl spec.")
+    p.add_argument("--timeout", type=int, default=int(os.environ.get("JARVIS_BAKE_TIMEOUT_S", "5400")),
+                   help="Cloud Build timeout seconds (GPU bake + 32B pull is slow; default 90min).")
+    p.add_argument("--poll-interval", type=int, default=15, help="Status poll cadence seconds.")
+    g = p.add_mutually_exclusive_group()
+    g.add_argument("--dry-run", action="store_true", default=True, help="Print the build resource, submit nothing (default).")
+    g.add_argument("--execute", dest="dry_run", action="store_false", help="Actually submit + poll the build.")
+    return p.parse_args(argv)
+
+
+def _baker(args) -> CloudBuildBaker:
+    return CloudBuildBaker(
+        spec_path=args.spec, project=args.project, image_family=args.image_family,
+        model=args.model, zone=args.zone, timeout_s=args.timeout,
+        poll_interval_s=args.poll_interval,
+    )
+
+
+def _print_plan(args, baker: CloudBuildBaker) -> None:
+    project = args.project or "<resolved-from-ADC-at-run>"
+    print("=" * 72)
+    print("GPU GOLDEN-IMAGE BAKE -- DRY RUN (nothing submitted)")
+    print("=" * 72)
+    print(f"  project      : {project}")
+    print(f"  image family : {args.image_family}")
+    print(f"  model        : {args.model}")
+    print(f"  zone         : {args.zone}")
+    print(f"  spec         : {args.spec}")
+    print(f"  timeout      : {args.timeout}s")
+    print("-" * 72)
+    print("Cloud Build resource that WOULD be POSTed:")
+    # build_config needs a project string; use the placeholder for the preview.
+    print(json.dumps(baker.build_config(args.project or "PROJECT"), indent=2))
+    print("-" * 72)
+    print("Re-run with --execute to submit hands-off (ADC auth, no gcloud, no upload).")
+
+
+async def _execute(baker: CloudBuildBaker) -> int:
+    print("Submitting Cloud Build (ADC REST) ...", flush=True)
+    build_id = await baker.submit()
+    if not build_id:
+        print("ABORT: submit failed. If auth-denied, grant the Cloud Build SA:\n"
+              "  roles/compute.admin + roles/iam.serviceAccountUser", file=sys.stderr)
+        return 2
+    print(f"Build {build_id} submitted -- polling (logs stream below):", flush=True)
+    status = await baker.poll(build_id)
+    ok = build_status_is_success(status)
+    print(f"\n=== BUILD {build_id} -> {status} ({'image baked' if ok else 'NO image'}) ===")
+    return 0 if ok else 1
+
+
+def main(argv=None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+    if not Path(args.spec).exists():
+        print(f"ERROR: spec not found: {args.spec}", file=sys.stderr)
+        return 2
+    baker = _baker(args)
+    if args.dry_run:
+        _print_plan(args, baker)
+        return 0
+    return asyncio.run(_execute(baker))
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/bake_gpu_golden_image.py
+++ b/scripts/bake_gpu_golden_image.py
@@ -63,10 +63,37 @@ def _parse_args(argv):
     p.add_argument("--timeout", type=int, default=int(os.environ.get("JARVIS_BAKE_TIMEOUT_S", "5400")),
                    help="Cloud Build timeout seconds (GPU bake + 32B pull is slow; default 90min).")
     p.add_argument("--poll-interval", type=int, default=15, help="Status poll cadence seconds.")
+    p.add_argument("--ephemeral-iam", dest="ephemeral_iam", action="store_true", default=True,
+                   help="Create a dedicated least-privilege temp SA, run the build as it, and GUARANTEE teardown (default).")
+    p.add_argument("--default-sa", dest="ephemeral_iam", action="store_false",
+                   help="Run as the default Cloud Build SA (NOT recommended; needs a broad pre-grant).")
+    p.add_argument("--detach", action="store_true", default=False,
+                   help="Daemonize: return the terminal immediately; the background process bakes + flares to the WAL.")
     g = p.add_mutually_exclusive_group()
     g.add_argument("--dry-run", action="store_true", default=True, help="Print the build resource, submit nothing (default).")
     g.add_argument("--execute", dest="dry_run", action="store_false", help="Actually submit + poll the build.")
     return p.parse_args(argv)
+
+
+def _wal_path() -> str:
+    return os.environ.get("JARVIS_BAKE_WAL", str(_REPO_ROOT / ".jarvis" / "bake" / "bake_wal.log"))
+
+
+def _daemonize() -> None:
+    """Double-fork into a detached daemon so the terminal returns immediately.
+    The grandchild's stdio is redirected to the WAL (build logs land there)."""
+    if os.fork() > 0:
+        os._exit(0)          # original parent returns the terminal
+    os.setsid()
+    if os.fork() > 0:
+        os._exit(0)          # session leader exits -> fully detached
+    wal = Path(_wal_path())
+    wal.parent.mkdir(parents=True, exist_ok=True)
+    fd = os.open(str(wal), os.O_APPEND | os.O_CREAT | os.O_WRONLY)
+    os.dup2(fd, 1)
+    os.dup2(fd, 2)
+    devnull = os.open(os.devnull, os.O_RDONLY)
+    os.dup2(devnull, 0)
 
 
 def _baker(args) -> CloudBuildBaker:
@@ -96,17 +123,20 @@ def _print_plan(args, baker: CloudBuildBaker) -> None:
     print("Re-run with --execute to submit hands-off (ADC auth, no gcloud, no upload).")
 
 
-async def _execute(baker: CloudBuildBaker) -> int:
-    print("Submitting Cloud Build (ADC REST) ...", flush=True)
-    build_id = await baker.submit()
-    if not build_id:
-        print("ABORT: submit failed. If auth-denied, grant the Cloud Build SA:\n"
-              "  roles/compute.admin + roles/iam.serviceAccountUser", file=sys.stderr)
-        return 2
-    print(f"Build {build_id} submitted -- polling (logs stream below):", flush=True)
-    status = await baker.poll(build_id)
-    ok = build_status_is_success(status)
-    print(f"\n=== BUILD {build_id} -> {status} ({'image baked' if ok else 'NO image'}) ===")
+async def _execute(args, baker: CloudBuildBaker) -> int:
+    if args.ephemeral_iam:
+        print("Igniting Zero-Trust bake (dedicated temp SA -> build -> guaranteed teardown) ...", flush=True)
+        ok = await baker.bake_with_ephemeral_iam()
+    else:
+        print("Submitting Cloud Build (default SA) ...", flush=True)
+        build_id = await baker.submit()
+        if not build_id:
+            print("ABORT: submit failed (default SA likely lacks compute rights).", file=sys.stderr)
+            return 2
+        status = await baker.poll(build_id)
+        ok = build_status_is_success(status)
+    print(f"\n=== BAKE {'SUCCEEDED (image baked)' if ok else 'did NOT produce an image'} "
+          f"-- WAL: {_wal_path()} ===")
     return 0 if ok else 1
 
 
@@ -119,7 +149,13 @@ def main(argv=None) -> int:
     if args.dry_run:
         _print_plan(args, baker)
         return 0
-    return asyncio.run(_execute(baker))
+    if args.detach:
+        print(f"Dispatched detached bake -> watch the WAL: {_wal_path()}", flush=True)
+        _daemonize()  # terminal returns NOW; the daemon bakes + flares below
+    return asyncio.run(_execute(args, baker))
+
+
+__test_hooks__ = {"daemonize": _daemonize}  # exposed for import without forking
 
 
 if __name__ == "__main__":

--- a/tests/governance/test_bake_gpu_script.py
+++ b/tests/governance/test_bake_gpu_script.py
@@ -1,0 +1,38 @@
+"""Smoke test for the GPU bake CLI -- dry-run must run with ZERO network."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "bake_gpu_golden_image.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("bake_gpu_golden_image", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_dry_run_prints_build_and_no_network(capsys):
+    mod = _load()
+    rc = mod.main(["--project", "myproj", "--image-family", "jarvis-prime-coder-32b", "--dry-run"])
+    assert rc == 0
+    out = capsys.readouterr().out
+    assert "DRY RUN" in out
+    assert "jarvis-prime-coder-32b" in out
+    assert "packer" in out.lower()          # the build steps are shown
+    assert "base64 -d" in out               # spec inlined (no GCS)
+
+
+def test_dry_run_is_default(capsys):
+    mod = _load()
+    rc = mod.main(["--project", "p"])       # no --execute -> dry-run
+    assert rc == 0
+    assert "DRY RUN" in capsys.readouterr().out
+
+
+def test_missing_spec_errors():
+    mod = _load()
+    rc = mod.main(["--project", "p", "--spec", "/nonexistent/x.hcl", "--dry-run"])
+    assert rc == 2

--- a/tests/governance/test_cloud_build_baker.py
+++ b/tests/governance/test_cloud_build_baker.py
@@ -1,0 +1,92 @@
+"""Serverless IaC Execution -- the Automated REST Baker (Cloud Build).
+
+Submits the GPU Packer .hcl as a remote Cloud Build job via REST (reusing the ADC
+auth bridge), so the 32B golden image is manufactured hands-off -- zero local
+Packer, zero gcloud, zero GCS upload (the spec is inlined as base64 into the build
+steps). These tests cover the PURE pieces: the Build-resource construction and the
+build-status state machine.
+"""
+from __future__ import annotations
+
+import base64
+
+import pytest
+
+from backend.core.ouroboros.governance.cloud_build_baker import (
+    build_packer_cloud_build,
+    build_status_is_terminal,
+    build_status_is_success,
+)
+
+
+_SPEC = 'source "googlecompute" "x" {}\nbuild { sources = ["x"] }\n'
+
+
+def test_build_has_write_init_build_steps():
+    cfg = build_packer_cloud_build(
+        spec_text=_SPEC, project="proj", substitutions={}, image_family="fam",
+    )
+    steps = cfg["steps"]
+    assert len(steps) >= 3
+    joined = " ".join(" ".join(s.get("args", [])) for s in steps)
+    assert "base64 -d" in joined           # step 1 writes the inlined spec
+    assert "init" in joined                # packer init
+    assert "build" in joined               # packer build
+
+
+def test_spec_is_inlined_as_base64():
+    cfg = build_packer_cloud_build(
+        spec_text=_SPEC, project="proj", substitutions={}, image_family="fam",
+    )
+    b64 = base64.b64encode(_SPEC.encode()).decode()
+    blob = repr(cfg["steps"])
+    assert b64 in blob                     # the exact spec rides inline (no GCS)
+
+
+def test_build_passes_project_and_image_family_vars():
+    cfg = build_packer_cloud_build(
+        spec_text=_SPEC, project="myproj", substitutions={}, image_family="jarvis-prime-coder-32b",
+    )
+    joined = " ".join(" ".join(s.get("args", [])) for s in cfg["steps"])
+    assert "project_id=myproj" in joined
+    assert "image_family=jarvis-prime-coder-32b" in joined
+
+
+def test_build_has_long_timeout_and_machine():
+    cfg = build_packer_cloud_build(
+        spec_text=_SPEC, project="p", substitutions={}, image_family="f",
+        timeout_s=3600, machine_type="E2_HIGHCPU_8",
+    )
+    assert cfg["timeout"] == "3600s"       # GPU bake + 32B pull needs >>10min default
+    assert cfg["options"]["machineType"] == "E2_HIGHCPU_8"
+
+
+def test_no_gcs_source():
+    cfg = build_packer_cloud_build(
+        spec_text=_SPEC, project="p", substitutions={}, image_family="f",
+    )
+    assert "source" not in cfg             # inline -> no storageSource, no upload
+
+
+def test_extra_substitutions_merge():
+    cfg = build_packer_cloud_build(
+        spec_text=_SPEC, project="p", substitutions={"_MODEL": "qwen2.5-coder:32b"},
+        image_family="f",
+    )
+    assert cfg["substitutions"]["_MODEL"] == "qwen2.5-coder:32b"
+
+
+@pytest.mark.parametrize("status,terminal", [
+    ("SUCCESS", True), ("FAILURE", True), ("TIMEOUT", True),
+    ("CANCELLED", True), ("EXPIRED", True), ("INTERNAL_ERROR", True),
+    ("QUEUED", False), ("WORKING", False), ("PENDING", False), ("", False),
+])
+def test_status_terminal(status, terminal):
+    assert build_status_is_terminal(status) is terminal
+
+
+@pytest.mark.parametrize("status,ok", [
+    ("SUCCESS", True), ("FAILURE", False), ("TIMEOUT", False), ("WORKING", False),
+])
+def test_status_success(status, ok):
+    assert build_status_is_success(status) is ok

--- a/tests/governance/test_ephemeral_baker_iam.py
+++ b/tests/governance/test_ephemeral_baker_iam.py
@@ -1,0 +1,99 @@
+"""Ephemeral Zero-Trust IAM for the bake -- pure pieces.
+
+The baker creates a DEDICATED temporary service account, binds least-privilege
+roles, runs the Cloud Build AS that SA, and GUARANTEES teardown (delete the SA the
+millisecond the build concludes). The default Cloud Build SA is never touched.
+"""
+from __future__ import annotations
+
+import re
+
+import pytest
+
+from backend.core.ouroboros.governance.cloud_build_baker import (
+    build_packer_cloud_build,
+    baker_sa_roles,
+    temp_sa_account_id,
+    create_sa_payload,
+    iam_policy_add_binding,
+    iam_policy_remove_member,
+)
+
+_SPEC = 'source "googlecompute" "x" {}\n'
+
+
+def test_build_runs_as_custom_sa():
+    cfg = build_packer_cloud_build(
+        spec_text=_SPEC, project="proj", image_family="f",
+        service_account="projects/proj/serviceAccounts/baker@proj.iam.gserviceaccount.com",
+    )
+    assert cfg["serviceAccount"].endswith("baker@proj.iam.gserviceaccount.com")
+    # A custom build SA REQUIRES an explicit logging mode.
+    assert cfg["options"]["logging"] == "CLOUD_LOGGING_ONLY"
+
+
+def test_no_service_account_no_logging_override():
+    cfg = build_packer_cloud_build(spec_text=_SPEC, project="p", image_family="f")
+    assert "serviceAccount" not in cfg
+    assert "logging" not in cfg["options"]
+
+
+def test_temp_sa_account_id_is_valid_gcp_id():
+    aid = temp_sa_account_id()
+    # GCP SA accountId: 6-30 chars, ^[a-z][a-z0-9-]{4,28}[a-z0-9]$
+    assert re.fullmatch(r"[a-z][a-z0-9-]{4,28}[a-z0-9]", aid), aid
+    assert "baker" in aid
+
+
+def test_temp_sa_account_ids_are_unique_per_call():
+    assert temp_sa_account_id() != temp_sa_account_id()  # collision-free temp SAs
+
+
+def test_create_sa_payload_shape():
+    p = create_sa_payload("jarvis-gpu-baker-ab12cd", "GPU baker (ephemeral)")
+    assert p["accountId"] == "jarvis-gpu-baker-ab12cd"
+    assert p["serviceAccount"]["displayName"] == "GPU baker (ephemeral)"
+
+
+def test_default_roles_are_least_privilege():
+    roles = baker_sa_roles()
+    # Exactly what Packer needs to bake a GPU image + write build logs.
+    assert "roles/compute.instanceAdmin.v1" in roles
+    assert "roles/iam.serviceAccountUser" in roles
+    assert "roles/logging.logWriter" in roles
+    # The blast-radius role we REFUSED to grant the default SA is NOT here.
+    assert "roles/compute.admin" not in roles
+    assert "roles/owner" not in roles
+    assert "roles/editor" not in roles
+
+
+def test_roles_env_overridable(monkeypatch):
+    monkeypatch.setenv("JARVIS_BAKE_SA_ROLES", "roles/compute.instanceAdmin.v1,roles/logging.logWriter")
+    assert baker_sa_roles() == ["roles/compute.instanceAdmin.v1", "roles/logging.logWriter"]
+
+
+def test_iam_policy_add_binding_creates_and_appends():
+    policy = {"bindings": [{"role": "roles/x", "members": ["user:a@b.com"]}]}
+    member = "serviceAccount:baker@proj.iam.gserviceaccount.com"
+    # New role -> new binding.
+    p2 = iam_policy_add_binding(policy, "roles/compute.instanceAdmin.v1", member)
+    b = [x for x in p2["bindings"] if x["role"] == "roles/compute.instanceAdmin.v1"]
+    assert b and member in b[0]["members"]
+    # Existing role -> append member, no duplicate binding.
+    p3 = iam_policy_add_binding(p2, "roles/x", member)
+    bx = [x for x in p3["bindings"] if x["role"] == "roles/x"]
+    assert len(bx) == 1 and member in bx[0]["members"]
+
+
+def test_iam_policy_remove_member_strips_everywhere():
+    member = "serviceAccount:baker@proj.iam.gserviceaccount.com"
+    policy = {"bindings": [
+        {"role": "roles/a", "members": [member, "user:keep@b.com"]},
+        {"role": "roles/b", "members": [member]},
+    ]}
+    p2 = iam_policy_remove_member(policy, member)
+    # member gone everywhere; the now-empty binding is dropped; others kept.
+    flat = [m for b in p2["bindings"] for m in b["members"]]
+    assert member not in flat
+    assert "user:keep@b.com" in flat
+    assert all(b["members"] for b in p2["bindings"])  # no empty bindings linger

--- a/tests/governance/test_ephemeral_iam_lifecycle.py
+++ b/tests/governance/test_ephemeral_iam_lifecycle.py
@@ -1,0 +1,95 @@
+"""Ephemeral IAM lifecycle orchestration -- create -> bind -> build -> GUARANTEED
+teardown. The temp SA MUST be deleted whether the build succeeds OR fails, and the
+WAL must record GOLDEN IMAGE READY / failure + the teardown.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.cloud_build_baker import CloudBuildBaker
+
+
+def _baker(tmp_path):
+    spec = tmp_path / "x.pkr.hcl"
+    spec.write_text('source "googlecompute" "x" {}\n')
+    wal = tmp_path / "wal.log"
+    b = CloudBuildBaker(spec_path=str(spec), project="proj", image_family="fam")
+    b._iam_settle_s = 0
+    return b, wal
+
+
+async def _wire(monkeypatch, b, *, calls, poll_status="SUCCESS", sa="baker@proj.iam.gserviceaccount.com"):
+    async def auth():
+        return "tok", "proj"
+    async def create_sa(project, token, account_id):
+        calls.append("create_sa"); return sa
+    async def bind(project, token, member, roles):
+        calls.append("bind"); return True
+    async def submit():
+        calls.append("submit"); return "build-123"
+    async def poll(build_id, **kw):
+        calls.append("poll"); return poll_status
+    async def unbind(project, token, member):
+        calls.append("unbind"); return True
+    async def delete_sa(project, token, email):
+        calls.append("delete_sa"); return True
+    monkeypatch.setattr(b, "_auth", auth)
+    monkeypatch.setattr(b, "_create_temp_sa", create_sa)
+    monkeypatch.setattr(b, "_bind_roles", bind)
+    monkeypatch.setattr(b, "submit", submit)
+    monkeypatch.setattr(b, "poll", poll)
+    monkeypatch.setattr(b, "_unbind_member", unbind)
+    monkeypatch.setattr(b, "_delete_temp_sa", delete_sa)
+
+
+async def test_full_lifecycle_success(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BAKE_WAL", str(tmp_path / "wal.log"))
+    b, wal = _baker(tmp_path)
+    calls = []
+    await _wire(monkeypatch, b, calls=calls)
+    ok = await b.bake_with_ephemeral_iam()
+    assert ok is True
+    # Order: create SA -> bind -> submit -> poll -> (teardown) unbind -> delete.
+    assert calls == ["create_sa", "bind", "submit", "poll", "unbind", "delete_sa"]
+    wal_text = wal.read_text()
+    assert "GOLDEN IMAGE READY" in wal_text
+    assert "EPHEMERAL SA TORN DOWN" in wal_text
+
+
+async def test_teardown_runs_even_on_build_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BAKE_WAL", str(tmp_path / "wal.log"))
+    b, wal = _baker(tmp_path)
+    calls = []
+    await _wire(monkeypatch, b, calls=calls, poll_status="FAILURE")
+    ok = await b.bake_with_ephemeral_iam()
+    assert ok is False
+    assert "delete_sa" in calls          # SA STILL deleted on failure
+    assert "BAKE FAILED" in wal.read_text()
+    assert "EPHEMERAL SA TORN DOWN" in wal.read_text()
+
+
+async def test_teardown_runs_even_if_poll_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BAKE_WAL", str(tmp_path / "wal.log"))
+    b, wal = _baker(tmp_path)
+    calls = []
+    await _wire(monkeypatch, b, calls=calls)
+
+    async def boom(build_id, **kw):
+        calls.append("poll"); raise RuntimeError("network died mid-poll")
+    monkeypatch.setattr(b, "poll", boom)
+
+    with pytest.raises(RuntimeError):
+        await b.bake_with_ephemeral_iam()
+    assert "delete_sa" in calls           # finally still tore the SA down
+    assert "EPHEMERAL SA TORN DOWN" in wal.read_text()
+
+
+async def test_sa_create_denied_aborts_no_teardown(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BAKE_WAL", str(tmp_path / "wal.log"))
+    b, wal = _baker(tmp_path)
+    calls = []
+    await _wire(monkeypatch, b, calls=calls, sa=None)  # create returns None (denied)
+    ok = await b.bake_with_ephemeral_iam()
+    assert ok is False
+    assert "delete_sa" not in calls       # nothing to tear down (none created)
+    assert "BAKE ABORT" in wal.read_text()


### PR DESCRIPTION
One Python command → GCP manufactures `jarvis-prime-coder-32b` hands-off. Builds on the merged elastic fleet (#69764).

- **`cloud_build_baker.py`**: constructs the Cloud Build resource that inlines the Packer spec as **base64** (no GCS upload), runs `packer init`+`build`, submits via REST, polls to terminal, streams logs. Auth **reuses the ADC bridge** (`gcp_compute_rest.access_token`) — no duplicate auth, no gcloud, no SDK.
- **`scripts/bake_gpu_golden_image.py`**: the CLI — DRY-RUN by default, `--execute` for hands-off submit+poll.

The existing `bake_jprime_golden_image.py` bakes the 7B via gcloud subprocess (manual); this is the zero-touch GPU counterpart. 23 tests; verified the jarvis-prime golden-image setup. **Prereq (printed on auth failure): the Cloud Build SA needs `roles/compute.admin`+`iam.serviceAccountUser`.** 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automates baking of the `jarvis-prime-coder-32b` GPU golden image by running `packer build` in serverless `Cloud Build` via REST, now with a zero-trust ephemeral IAM flow and optional detached execution. No local Packer, no `gcloud`, no GCS upload; reuses our ADC auth bridge and streams logs while polling.

- New Features
  - `cloud_build_baker.py`: Builds and submits a `Cloud Build` job that inlines the Packer spec as base64 (no GCS), runs `packer init`/`build`, polls to terminal status, and streams GCS logs; reuses `gcp_compute_rest.access_token`. Adds `bake_with_ephemeral_iam()` which creates a dedicated temp SA, binds least-privilege roles (`roles/compute.instanceAdmin.v1`, `roles/compute.storageAdmin`, `roles/iam.serviceAccountUser`, `roles/logging.logWriter`; overridable via `JARVIS_BAKE_SA_ROLES`), runs the build as that SA, and guarantees teardown.
  - `scripts/bake_gpu_golden_image.py`: One-command CLI; DRY-RUN by default, `--execute` to submit+poll. New `--detach` to daemonize and write immutable WAL flares to `.jarvis/bake/bake_wal.log`; `--ephemeral-iam` is the default for executes. Configurable `--project`, `--zone`, `--model`, `--image-family` (defaults to `jarvis-prime-coder-32b`).
  - Tests: 52 tests covering pure helpers, CLI dry-run, and the ephemeral IAM lifecycle (create → bind → build → guaranteed teardown).

- Migration
  - No broad pre-grant to the default Cloud Build SA is required when using ephemeral IAM. Ensure the ADC principal can create service accounts and set project IAM policy (`iam.serviceAccounts.create`, `resourcemanager.projects.setIamPolicy`). If opting into `--default-sa`, that SA needs `roles/compute.admin` and `roles/iam.serviceAccountUser`.

<sup>Written for commit 7617bfff5746fdd134ff3c1ce379937d22ec6ea6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69765?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

