### PR TITLE
fix(baker): duration-gate the zone walk (stop on real bake errors)

### DIFF
--- a/backend/core/ouroboros/governance/cloud_build_baker.py
+++ b/backend/core/ouroboros/governance/cloud_build_baker.py
@@ -246,6 +246,10 @@ class CloudBuildBaker:
         self.service_account: Optional[str] = None
         self._iam_settle_s = int(os.environ.get("JARVIS_BAKE_IAM_SETTLE_S", "10"))
         self._iam_rmw_retries = max(1, int(os.environ.get("JARVIS_BAKE_IAM_RMW_RETRIES", "5")))
+        # A build that fails FASTER than this (s) is a capacity stockout (rejected
+        # at instance creation) -> walk the next zone. A SLOWER failure means the
+        # instance was placed and a bake step failed -> STOP (real error).
+        self._stockout_max_s = max(30, int(os.environ.get("JARVIS_BAKE_STOCKOUT_MAX_S", "150")))
 
     # -- auth/identity reused from the provisioner's ADC bridge ---------------
     async def _auth(self):
@@ -505,9 +509,11 @@ class CloudBuildBaker:
             from backend.core.ouroboros.governance.zone_fallback import (  # noqa: PLC0415
                 zone_fallback_chain,
             )
+            import time  # noqa: PLC0415
             chain = zone_fallback_chain(self.zone)
             for zone in chain:
                 self.zone = zone
+                _t0 = time.monotonic()
                 build_id = await self.submit()
                 if not build_id:
                     self._write_flare("BAKE FAILED: submit rejected zone={}".format(zone))
@@ -518,17 +524,25 @@ class CloudBuildBaker:
                     self._write_flare("GOLDEN IMAGE READY image_family={} build={} zone={}".format(
                         self.image_family, build_id, zone))
                     return True
-                # The spec is PROVEN valid (it resolves the image + requests the
-                # instance), so a post-submit build failure means this zone could
-                # not PLACE the GPU instance = capacity/stockout. Walk the next zone
-                # (bounded by the chain). Custom-SA logs aren't queryable, so this
-                # is the robust signal -- bounded, never an unbounded retry storm.
+                # DURATION-gated failover. A capacity STOCKOUT is rejected at
+                # instance creation -> FAST failure (~80s). A SLOW failure means the
+                # instance WAS placed and a later bake step (Ollama/pull) failed ->
+                # walking other zones is futile + wastes ~5min/zone. So: fast fail ->
+                # next zone; slow fail -> STOP (real error -- diagnose, don't storm).
+                _dur = time.monotonic() - _t0
+                if _dur < self._stockout_max_s:
+                    self._write_flare(
+                        "STOCKOUT zone={} ({:.0f}s fast fail) build={} -> failover to "
+                        "next zone".format(zone, _dur, build_id))
+                    continue
                 self._write_flare(
-                    "BUILD FAILED zone={} status={} build={} -> failover to next zone "
-                    "(spec validated; treating as GPU capacity)".format(zone, status, build_id))
+                    "BAKE FAILED zone={} status={} build={} ({:.0f}s -- past instance "
+                    "creation = REAL bake-step error, NOT capacity) -> STOP (diagnose)".format(
+                        zone, status, build_id, _dur))
+                return False
             self._write_flare(
-                "BAKE FAILED: all {} zones failed to place the GPU ({}) -- L4 capacity "
-                "drought, retry later".format(len(chain), ",".join(chain)))
+                "BAKE FAILED: all {} zones STOCKED OUT ({}) -- L4 capacity drought, "
+                "retry later".format(len(chain), ",".join(chain)))
             return False
         finally:
             if sa_email:

--- a/tests/governance/test_ephemeral_iam_lifecycle.py
+++ b/tests/governance/test_ephemeral_iam_lifecycle.py
@@ -108,7 +108,7 @@ async def test_multizonal_fallback_walks_next_zone_on_failure(tmp_path, monkeypa
     assert calls.count("submit") == 2        # walked to zone B
     assert calls.count("delete_sa") == 1     # torn down once
     text = wal.read_text()
-    assert "BUILD FAILED zone=zoneA" in text and "failover" in text
+    assert "STOCKOUT zone=zoneA" in text and "failover" in text
     assert "GOLDEN IMAGE READY" in text and "zone=zoneB" in text
 
 
@@ -122,7 +122,7 @@ async def test_all_zones_failing_reports_capacity_drought(tmp_path, monkeypatch)
     assert ok is False
     assert calls.count("submit") == 2        # walked the whole 2-zone chain
     assert calls.count("delete_sa") == 1     # SA still reaped
-    assert "all 2 zones failed to place the GPU" in wal.read_text()
+    assert "all 2 zones STOCKED OUT" in wal.read_text()
 
 
 async def test_sa_create_denied_aborts_no_teardown(tmp_path, monkeypatch):


### PR DESCRIPTION
The walk-all-on-failure burned all 7 zones on a real bake-step error (missing zstd) that walking can't fix. Now: fast failure (<150s) = stockout → walk; slow failure = instance placed + bake step failed → STOP and flare for diagnosis. 27 tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops walking all zones on real bake-step errors by gating zone failover on build duration. Fast failures are treated as capacity stockouts and walk; slow failures stop and surface a diagnostic flare to avoid zone storms.

- **Bug Fixes**
  - Added `_stockout_max_s` threshold (config via `JARVIS_BAKE_STOCKOUT_MAX_S`, default 150s, min 30s) to classify failures.
  - Fast fail (< threshold) -> log "STOCKOUT" and try next zone; slow fail -> log "REAL bake-step error" and stop.
  - Updated flare messages and tests (e.g., "STOCKOUT zone=…" and "all N zones STOCKED OUT").

<sup>Written for commit c2ebbcbaa8a6c4a6083410ab9e1eccf9c6c53341. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69768?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

