### PR TITLE
feat(failover): quality_tier() single source of truth for the bake (drift-kill)

### DIFF
--- a/backend/core/ouroboros/governance/cloud_build_baker.py
+++ b/backend/core/ouroboros/governance/cloud_build_baker.py
@@ -96,6 +96,22 @@ def verify_cross_repo_spec(path) -> Path:
     return p
 
 
+def _quality_tier_defaults() -> tuple:
+    """Resolve ``(image_family, model_label)`` from the SINGLE runtime source of
+    truth (:func:`failover_tier.quality_tier`), so a baked image can NEVER drift
+    from what the failover provisioner will request. Fail-soft to the legacy
+    literals if the import/resolution breaks -- baking must never crash on a
+    metadata lookup. Pure."""
+    try:
+        from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+            quality_tier,
+        )
+        t = quality_tier()
+        return t.image_family, t.model_label
+    except Exception:  # noqa: BLE001 -- any failure -> safe legacy defaults
+        return "jarvis-prime-coder-32b", "qwen2.5-coder:32b"
+
+
 def baker_sa_roles() -> List[str]:
     """Least-privilege roles bound to the ephemeral baker SA. Env-overridable
     (``JARVIS_BAKE_SA_ROLES``, comma-separated) -- no hardcoded blast radius."""
@@ -228,7 +244,7 @@ class CloudBuildBaker:
         *,
         spec_path: Optional[str] = None,
         project: Optional[str] = None,
-        image_family: str = "jarvis-prime-coder-32b",
+        image_family: Optional[str] = None,
         model: Optional[str] = None,
         zone: Optional[str] = None,
         timeout_s: int = 3600,
@@ -236,8 +252,13 @@ class CloudBuildBaker:
     ) -> None:
         self.spec_path = spec_path
         self._project = project
-        self.image_family = image_family
-        self.model = model
+        # Source-of-truth dictation: image_family + model are DERIVED from the
+        # quality tier (the same spec the provisioner requests) unless the caller
+        # explicitly overrides -- e.g. a small-model validation bake. This is the
+        # drift-kill: a bare CloudBuildBaker() can never bake the wrong artifact.
+        _fam, _model = _quality_tier_defaults()
+        self.image_family = image_family or _fam
+        self.model = model or _model
         self.zone = zone
         self.timeout_s = timeout_s
         self.poll_interval_s = poll_interval_s

--- a/backend/core/ouroboros/governance/failover_tier.py
+++ b/backend/core/ouroboros/governance/failover_tier.py
@@ -79,6 +79,21 @@ def _quality_tier() -> FailoverTier:
     )
 
 
+def quality_tier() -> FailoverTier:
+    """The QUALITY (GPU/32B) provisioning spec, resolved UNCONDITIONALLY -- the
+    single source of truth for what the golden image must contain.
+
+    Deliberately bypasses ``quality_tier_enabled()``: that cost gate governs
+    whether to PROVISION a GPU node at RUNTIME, not what to BAKE ahead of time. The
+    image is manufactured before any outage; the baker must always produce the 32B
+    image the provisioner WILL request once the gate is opened. Routing the baker
+    through ``resolve_tier`` would (gate-off, the default) bake the 7B SURVIVAL
+    image -- a silent drift bug. This accessor is that drift's structural cure: the
+    baker, the bake CLI, and the Packer default all derive from HERE. NEVER raises.
+    """
+    return _quality_tier()
+
+
 def _is_high_priority(urgency: str, complexity: str) -> bool:
     """A workload warrants the GPU tier iff it is IMMEDIATE urgency OR a COMPLEX /
     heavy-code op. BACKGROUND / STANDARD / simple never do (cost discipline)."""

--- a/docs/superpowers/specs/2026-06-29-jprime-bake-hardening-design.md
+++ b/docs/superpowers/specs/2026-06-29-jprime-bake-hardening-design.md
@@ -1,0 +1,109 @@
+# J-Prime Golden-Image Bake Hardening — Design / Decision Record
+
+**Date:** 2026-06-29
+**Author:** Derek J. Russell (+ O+V)
+**Status:** Implemented; remote 0.5B validation → real 32B bake in progress
+**Repos touched:** `jarvis-prime` (Layer 1), `JARVIS-AI-Agent` (Layer 2)
+
+## Problem
+
+The J-Prime QUALITY-tier golden-image bake had been fixed four times in sequence
+(backports-strip → zstd-first → ollama daemon-pull → `HOME=/root` panic), each a
+real root-cause fix — but each discovered only on real metal. That sequential
+"passes-bake-fails-live" discovery loop is the standing root problem, the same
+class as the wider C+ diagnosis. Hardening means attacking that *class*
+structurally, not adding a fifth patch.
+
+Two latent fragilities + one architectural drift remained:
+
+1. **Single-shot pull** — one transient network reset on a ~20 GB pull wastes the
+   whole bake.
+2. **Presence, not integrity** — `ollama list | grep` proves only that the
+   *manifest* exists; a truncated blob layer passes it and fails at runtime.
+3. **3-place hardcode drift** — `jarvis-prime-coder-32b` / `qwen2.5-coder:32b`
+   were independently hardcoded in `failover_tier.py` (runtime), the packer
+   template, and `CloudBuildBaker.__init__` (and a 4th: the bake CLI's argparse
+   defaults). Only comments kept them in sync; a model bump in one place would
+   silently bake an image the provisioner never requests.
+
+## Design
+
+### Layer 1 — Packer template robustness (`jarvis-prime`)
+`infra/packer/jprime_gpu_golden_image.pkr.hcl`, pull provisioner:
+
+- **Dynamic disk preflight (no magic numbers).** Resolve the *exact* byte
+  footprint of `${model_label}` from its Ollama registry manifest
+  (`https://${ollama_registry}/v2/<ns>/<name>/manifests/<tag>`, sum
+  `[.layers[].size] + [.config.size]`), apply a ×1.5 unpack/headroom heuristic,
+  and assert live `df`. The required size *adapts* to whatever the model is — no
+  GB is ever hardcoded **or parameterized** (a parameterized magic number is
+  still a magic number). The only constant is the 1.5 overhead ratio (intrinsic,
+  not a footprint guess). The manifest probe shares the bounded retry so a
+  registry blip doesn't false-fail the preflight.
+- **Resumable retry + backoff** on the pull. `ollama pull` keeps already-fetched
+  blobs, so a retry *resumes*. Vars `pull_max_attempts` (3), `pull_backoff_base_s`
+  (20).
+- **Integrity proof** via `ollama show` — dereferences the manifest + config blob;
+  an incomplete/corrupt model fails here, unlike `list`. (`pull` exit-0 already
+  sha256-verifies each blob; `show` is a second independent read path proving
+  usability, kept alongside the `list|grep` presence check.)
+
+### Layer 2 — Orchestration drift-kill (`JARVIS-AI-Agent`)
+`failover_tier.quality_tier()` becomes the **single source of truth** — a public
+accessor returning the QUALITY spec *unconditionally* (deliberately bypassing the
+`quality_tier_enabled()` cost gate: that gate governs whether to *provision* a GPU
+node at runtime, not what to *bake*; routing through `resolve_tier` would bake the
+7B survival image when the gate is off — the drift bug itself).
+
+- `CloudBuildBaker.__init__` derives `image_family` + `model` from
+  `_quality_tier_defaults()` (→ `quality_tier()`), fail-soft to legacy literals.
+  Explicit caller args still win (the validation bake path).
+- `scripts/bake_gpu_golden_image.py` argparse defaults resolve from
+  `quality_tier()` too, collapsing the 4th hardcode site.
+
+Net: a bare `CloudBuildBaker()` / a default `--execute` can never manufacture the
+wrong artifact, and one env var (`JARVIS_FAILOVER_QUALITY_{IMAGE,MODEL}`) moves
+the provisioner *and* the baker together.
+
+## Validation discipline
+- Layer 2: pure-Python regression tests (`test_cloud_build_baker_drift.py` ×5,
+  `test_failover_tier_router.py` +3) — 50/50 green incl. existing baker/IAM suites.
+- Layer 1: static gates (bash `-n`, live registry byte-math dry-run, HCL `${}`
+  escaping invariant scan) → then the authoritative proof: a **remote 0.5B bake
+  via CloudBuildBaker** (faithful to the production path — ephemeral IAM, zone
+  failover), exercising every new step on real metal before the 32B spend.
+
+## Ship sequence
+1. Layer 1 + Layer 2 edits (working tree).
+2. Remote 0.5B validation bake (reads working-tree spec + baker) → green.
+3. Commit + PR + merge both repos to `main`.
+4. Ignite the real 32B bake via `CloudBuildBaker.bake_with_ephemeral_iam()`.
+
+## Root causes found DURING validation (the real "passes-static-fails-live" payload)
+
+The remote 0.5B validation surfaced two latent failures that static checks + manual
+SSH had never exercised — both fixed in Layer 1:
+
+1. **`${var.model_label}` inside a `variable` *description*** → `packer init`
+   failure ("Variables may not be used here"). Interpolation is illegal in a
+   variable block even in prose. Caught in ~30s via a faithful
+   `hashicorp/packer:latest` Docker `init`/`validate` repro — not a slow cloud
+   bake. (Lesson: the escaping scan's "`${var.` is always valid" heuristic has a
+   blind spot for non-interpolatable contexts.)
+2. **`set -o pipefail` under packer's default `/bin/sh` = dash** (Debian DLVM) →
+   `Illegal option -o pipefail`, killing provisioner line 2 on **every** prior
+   Cloud Build bake. The earlier "test6 green" was validated by manual SSH in an
+   interactive *bash* shell, never through packer's dash provisioner. Fixed with
+   `inline_shebang = "/bin/bash -e"` on all three provisioners (dash-fails /
+   bash-works confirmed in `debian:11`; pipefail is load-bearing for the new
+   pipe-heavy pull steps). This was the actual long-standing blocker.
+
+Validation proof: build `912b7aca` SUCCESS, all 3 steps green, image READY; the new
+disk-preflight ran on real metal (`need_bytes=397821516 required_x1.5=596732274
+avail_bytes=122860478464`, `[disk-preflight] OK`). Reusable fast gate added to the
+workflow: container `packer init`+`validate` before any remote bake.
+
+## Non-goals / rejected
+- A static/parameterized `min_free_disk_gb` — rejected as a hardcoded guess.
+- Local `packer build` for the real bake — rejected; we do not bypass the
+  Zero-Trust ephemeral-IAM remote path for local convenience.

--- a/scripts/bake_gpu_golden_image.py
+++ b/scripts/bake_gpu_golden_image.py
@@ -45,18 +45,25 @@ from backend.core.ouroboros.governance.cloud_build_baker import (  # noqa: E402
     build_status_is_success,
     verify_cross_repo_spec,
 )
+from backend.core.ouroboros.governance.failover_tier import quality_tier  # noqa: E402
 
 
 def _parse_args(argv):
-    p = argparse.ArgumentParser(description="Hands-off bake of the 32B GPU golden image via Cloud Build REST.")
+    # The QUALITY tier is the absolute dictator of model + image family: both
+    # defaults resolve from failover_tier.quality_tier() (env-overridable there),
+    # so the bake CLI can NEVER request an artifact that differs from what the
+    # provisioner awakens. Explicit --model/--image-family still override (the
+    # small-model validation bake path).
+    _qt = quality_tier()
+    p = argparse.ArgumentParser(description="Hands-off bake of the GPU golden image via Cloud Build REST.")
     p.add_argument("--project", default=os.environ.get("GCP_PROJECT"),
                    help="GCP project (default $GCP_PROJECT; else resolved from ADC at run).")
     p.add_argument("--zone", default=os.environ.get("GCP_ZONE", "us-central1-b"),
                    help="Build/bake zone (must have the accelerator available).")
-    p.add_argument("--model", default=os.environ.get("JARVIS_FAILOVER_QUALITY_MODEL", "qwen2.5-coder:32b"),
-                   help="Ollama model to pre-pull into the image.")
-    p.add_argument("--image-family", default=os.environ.get("JARVIS_FAILOVER_QUALITY_IMAGE", "jarvis-prime-coder-32b"),
-                   help="Published image family (must equal the quality tier's image).")
+    p.add_argument("--model", default=_qt.model_label,
+                   help="Ollama model to pre-pull into the image (default: the quality tier's model).")
+    p.add_argument("--image-family", default=_qt.image_family,
+                   help="Published image family (default: the quality tier's image -- the dictator).")
     p.add_argument("--spec", default=None,
                    help="Path to the Packer .hcl spec (default: the SOVEREIGN jarvis-prime spec "
                         "$JARVIS_PRIME_PATH/infra/packer/jprime_gpu_golden_image.pkr.hcl).")

--- a/tests/governance/test_cloud_build_baker_drift.py
+++ b/tests/governance/test_cloud_build_baker_drift.py
@@ -1,0 +1,68 @@
+"""Drift-kill regression: the baker's image_family/model are DICTATED by the single
+runtime source of truth (``failover_tier.quality_tier()``), so a baked image can
+NEVER diverge from what the failover provisioner will request. Three hardcode sites
+(baker default, CLI default, packer default) collapse into one dictator. Explicit
+caller overrides (e.g. a small-model validation bake) still win.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.cloud_build_baker import CloudBuildBaker
+from backend.core.ouroboros.governance import cloud_build_baker as cbb
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    # Quality-tier specs resolve from defaults unless a test overrides.
+    for k in ("JARVIS_FAILOVER_QUALITY_IMAGE", "JARVIS_FAILOVER_QUALITY_MODEL"):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def test_baker_derives_family_and_model_from_source_of_truth():
+    b = CloudBuildBaker(project="p")
+    assert b.image_family == "jarvis-prime-coder-32b"
+    assert b.model == "qwen2.5-coder:32b"
+
+
+def test_env_override_flows_through_to_baker(monkeypatch):
+    # The dictator (quality_tier) reads env -> a single override moves the baker too.
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_IMAGE", "fam-z")
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_MODEL", "qwen2.5-coder:14b")
+    b = CloudBuildBaker(project="p")
+    assert b.image_family == "fam-z"
+    assert b.model == "qwen2.5-coder:14b"
+
+
+def test_explicit_args_win_over_source_of_truth():
+    # A validation bake (0.5B, throwaway family) must be able to override.
+    b = CloudBuildBaker(project="p", image_family="jarvis-prime-coder-validate", model="qwen2.5-coder:0.5b")
+    assert b.image_family == "jarvis-prime-coder-validate"
+    assert b.model == "qwen2.5-coder:0.5b"
+
+
+def test_build_config_now_pins_model_label_var(tmp_path):
+    # Because the baker always carries a resolved model, build_config emits an
+    # explicit -var=model_label -> the bake can't silently fall back to the packer
+    # template's own default (drift-kill at the wire).
+    spec = tmp_path / "x.pkr.hcl"
+    spec.write_text('source "googlecompute" "x" {}\nbuild { sources = ["x"] }\n')
+    b = CloudBuildBaker(project="p", spec_path=str(spec))
+    cfg = b.build_config("proj")
+    joined = " ".join(" ".join(s.get("args", [])) for s in cfg["steps"])
+    assert "model_label=qwen2.5-coder:32b" in joined
+    assert "image_family=jarvis-prime-coder-32b" in joined
+
+
+def test_fail_soft_when_source_of_truth_raises(monkeypatch):
+    # A metadata lookup must NEVER crash a bake -> fall back to legacy literals.
+    import backend.core.ouroboros.governance.failover_tier as ft
+
+    def _boom():
+        raise RuntimeError("source of truth unavailable")
+
+    monkeypatch.setattr(ft, "quality_tier", _boom)
+    fam, model = cbb._quality_tier_defaults()
+    assert fam == "jarvis-prime-coder-32b"
+    assert model == "qwen2.5-coder:32b"

--- a/tests/governance/test_failover_tier_router.py
+++ b/tests/governance/test_failover_tier_router.py
@@ -12,6 +12,7 @@ import pytest
 
 from backend.core.ouroboros.governance.failover_tier import (
     FailoverTier,
+    quality_tier,
     resolve_tier,
 )
 
@@ -82,3 +83,30 @@ def test_failover_tier_is_frozen_value():
     assert isinstance(t, FailoverTier)
     with pytest.raises(Exception):
         t.machine_type = "x"  # type: ignore[misc]  -- frozen
+
+
+# -- quality_tier(): the bake-time source of truth ---------------------------
+def test_quality_tier_accessor_returns_quality_spec():
+    t = quality_tier()
+    assert t.name == "quality"
+    assert t.image_family == "jarvis-prime-coder-32b"
+    assert t.model_label == "qwen2.5-coder:32b"
+    assert t.is_gpu is True
+
+
+def test_quality_tier_bypasses_the_cost_gate(monkeypatch):
+    """The cost gate governs PROVISIONING, not BAKING. With the gate OFF (default)
+    resolve_tier returns survival -- but the bake-time accessor MUST still dictate
+    the quality spec, else the baker would manufacture the 7B survival image."""
+    monkeypatch.delenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", raising=False)
+    assert resolve_tier(urgency="immediate", complexity="complex").name == "survival"
+    assert quality_tier().name == "quality"
+    assert "32b" in quality_tier().model_label.lower()
+
+
+def test_quality_tier_honors_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_IMAGE", "fam-x")
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_MODEL", "model-x:7b")
+    t = quality_tier()
+    assert t.image_family == "fam-x"
+    assert t.model_label == "model-x:7b"


### PR DESCRIPTION
## Why
The 32B image family + model were hardcoded in **three** places (`failover_tier`, `CloudBuildBaker.__init__`, the bake CLI argparse), kept in sync only by comments. A model bump in one place would silently bake an image the provisioner never requests.

## What
- **`failover_tier.quality_tier()`** — public accessor returning the QUALITY spec *unconditionally*, deliberately bypassing the `quality_tier_enabled()` cost gate (that gate governs *provisioning*, not *baking*; `resolve_tier` would bake the 7B survival image when the gate is off).
- `CloudBuildBaker` derives `image_family` + `model` from it (fail-soft to legacy literals; explicit args still win — the validation-bake path).
- `bake_gpu_golden_image.py` argparse defaults resolve from it too (4th hardcode site collapsed). One env var now moves provisioner **and** baker together.

## Tests
`test_cloud_build_baker_drift.py` (5) + `quality_tier()` cases (3) → **50/50 green** incl. existing baker/cross-repo/ephemeral-IAM suites.

Companion to jarvis-prime#8 (Layer 1 packer hardening). Spec: `docs/superpowers/specs/2026-06-29-jprime-bake-hardening-design.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `failover_tier.quality_tier()` the single source of truth for the QUALITY (GPU/32B) image spec to prevent bake/provision drift. The baker and CLI now default `image_family` and `model` from it, with explicit overrides allowed and safe fallback.

- **Refactors**
  - Added public `failover_tier.quality_tier()` returning the QUALITY spec unconditionally (bypasses the cost gate).
  - `CloudBuildBaker` and `scripts/bake_gpu_golden_image.py` now resolve default `image_family`/`model` from `quality_tier()`; explicit args still win; fail-soft to legacy literals on resolution errors.
  - Collapsed prior hardcoded sites into one env-controlled source (`JARVIS_FAILOVER_QUALITY_{IMAGE,MODEL}`) to eliminate drift.
  - Added drift/override tests and a design record at `docs/superpowers/specs/2026-06-29-jprime-bake-hardening-design.md`.

<sup>Written for commit b2b2340169451d1ce100b0ebc54e3ef4d47c8185. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69769?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

