### PR TITLE
feat(a1): Iron Triad — cryptographically-chained autonomous-PR gates

### DIFF
--- a/backend/core/ouroboros/governance/autonomous_pr_pipeline.py
+++ b/backend/core/ouroboros/governance/autonomous_pr_pipeline.py
@@ -222,6 +222,12 @@ async def run_pr_gate_pipeline(
         except (SandboxLockFailed, RequiresCloudExecution) as exc:
             raise PRGatePipelineError(f"gate1: {exc}") from exc
 
+        # Capture pre-apply tree SHA BEFORE writing any candidate files so
+        # Gate 2's rollback assertion compares HEAD (pre-op) against HEAD (restored).
+        _tree_sha = tree_sha_fn or _default_tree_sha
+        _scope = [p for p, _ in candidate_files]
+        pre_sha = await _tree_sha(wt)
+
         # Apply the candidate into the worktree so Gate 2 tests see it.
         await (apply_candidate or _default_apply_candidate)(
             wt, list(candidate_files)
@@ -236,10 +242,7 @@ async def run_pr_gate_pipeline(
         from .reverse_dep_resolver import resolve_reverse_dependency_tests
 
         _resolver = graph_resolver or resolve_reverse_dependency_tests
-        _tree_sha = tree_sha_fn or _default_tree_sha
         _runner = test_run_fn or _default_test_run
-        _scope = [p for p, _ in candidate_files]
-        pre_sha = await _tree_sha(wt)
 
         async def _graph_fn(files):
             return await _resolver(files, repo_root=str(wt), oracle=None)

--- a/backend/core/ouroboros/governance/autonomous_pr_pipeline.py
+++ b/backend/core/ouroboros/governance/autonomous_pr_pipeline.py
@@ -1,0 +1,286 @@
+from __future__ import annotations
+
+# backend/core/ouroboros/governance/autonomous_pr_pipeline.py
+"""
+Autonomous PR Gate Pipeline (Iron Triad, Task 13b)
+==================================================
+Capstone of the Iron Triad: make ONE autonomous-PR op assemble the full
+branch-bound token chain by running Gate (1) (container exec) + Gate (2)
+(blast radius) inside an ISOLATED git worktree, then handing the SAME chain
+to Gate (3) + the enforced ``create_review_pr``.
+
+Closes the final-review finding that the three gates sat on mutually-exclusive
+risk-tier branches: previously a candidate that reached the Orange (APPROVAL_
+REQUIRED) PR path carried no sandbox/blast tokens (those were minted only on
+the auto-apply tiers), so ``create_review_pr``'s enforcement was inert.
+
+Invariants
+----------
+* The worktree is a VALIDATION sandbox. The REAL repo tree is NEVER touched --
+  the candidate is written into, and tests run inside, the worktree only.
+* The worktree branch (``ouroboros/a1-validate/<op_id>``) is uniform across
+  Gate (1), Gate (2), and Gate (3) so the branch-bound chain verifies and the
+  ``expected_branch_context`` assertion in ``create_review_pr`` passes.
+* Cleanup ALWAYS runs (``finally``) and is best-effort: a cleanup failure is
+  logged but never masks the real gate result or error.
+* Fail-closed: a gate rejection raises ``PRGatePipelineError`` so the wiring
+  routes POSTMORTEM (no PR) -- never a silent PR.
+* Async-first: no blocking on the loop (subprocess via asyncio; file writes via
+  ``run_in_executor``). Python 3.9 compatible.
+
+Injectable seams keep the orchestration unit-testable with NO real Docker/git;
+the ``_default_*`` helpers wire the real production components.
+"""
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Awaitable, Callable, Optional, Sequence, Set, Tuple
+
+logger = logging.getLogger("Ouroboros.Orchestrator")
+
+
+class PRGatePipelineError(RuntimeError):
+    """A gate rejected the candidate in the isolated worktree -> no PR."""
+
+
+@dataclass(frozen=True)
+class PRGateResult:
+    sandbox_token: object
+    blast_token: object
+    branch_context: str
+
+
+def pipeline_enabled() -> bool:
+    """The unification runs only when the enforcer is armed (same master flag
+    as the PR token gate, ``JARVIS_A1_TOKEN_ENFORCER_ENABLED``)."""
+    return os.environ.get(
+        "JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false"
+    ).strip().lower() in ("1", "true", "yes")
+
+
+# ---------------------------------------------------------------------------
+# Default seam helpers (real production wiring)
+# ---------------------------------------------------------------------------
+
+
+def _default_worktree_factory(
+    repo_root: str,
+) -> Callable[[str], Awaitable[Path]]:
+    """Return an async fn that creates an isolated worktree for ``branch``."""
+
+    async def _factory(branch: str) -> Path:
+        from .worktree_manager import WorktreeManager
+
+        mgr = WorktreeManager(Path(repo_root))
+        return await mgr.create(branch)
+
+    return _factory
+
+
+def _default_worktree_cleanup(
+    repo_root: str,
+) -> Callable[[Path], Awaitable[None]]:
+    """Return an async fn that removes a worktree (git deregister + rmtree)."""
+
+    async def _cleanup(wt: Path) -> None:
+        from .worktree_manager import WorktreeManager
+
+        mgr = WorktreeManager(Path(repo_root))
+        await mgr.cleanup(wt)
+
+    return _cleanup
+
+
+async def _default_apply_candidate(
+    wt: Path, files: Sequence[Tuple[str, str]]
+) -> None:
+    """Write each ``(relpath, content)`` into ``wt/relpath`` so Gate (2)'s
+    tests see the candidate. Runs off-loop via the default executor.
+    """
+
+    def _write() -> None:
+        for relpath, content in files:
+            dest = Path(wt) / relpath
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            dest.write_text(content, encoding="utf-8")
+
+    loop = asyncio.get_running_loop()
+    await loop.run_in_executor(None, _write)
+
+
+async def _run_git(args: Sequence[str], *, cwd: Path) -> Tuple[int, str, str]:
+    """Run ``git <args>`` with cwd=<wt>. Returns (rc, stdout, stderr)."""
+    proc = await asyncio.create_subprocess_exec(
+        "git",
+        *args,
+        cwd=str(cwd),
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+    )
+    out, err = await proc.communicate()
+    rc = proc.returncode if proc.returncode is not None else 1
+    return rc, out.decode(errors="replace"), err.decode(errors="replace")
+
+
+async def _default_tree_sha(wt: Path) -> str:
+    """Deterministic content tree-SHA of the worktree, including the applied
+    (uncommitted) candidate files.
+
+    Mirrors ``workspace_checkpoint.working_tree_content_sha`` scoped to
+    ``cwd=wt``: ``git stash create`` snapshots the working tree into a dangling
+    commit without mutating it, and ``<commit>^{tree}`` resolves its tree
+    object. When the working tree is clean (stash create prints nothing) we
+    fall back to the committed ``HEAD^{tree}`` so the value stays deterministic.
+    """
+    rc, out, _ = await _run_git(["stash", "create"], cwd=wt)
+    snapshot = out.strip()
+    if rc == 0 and snapshot:
+        rc2, tree_out, _ = await _run_git(
+            ["rev-parse", f"{snapshot}^{{tree}}"], cwd=wt
+        )
+        if rc2 == 0 and tree_out.strip():
+            return tree_out.strip()
+    rc3, head_tree, _ = await _run_git(
+        ["rev-parse", "HEAD^{tree}"], cwd=wt
+    )
+    return head_tree.strip()
+
+
+async def _default_test_run(tests: Set[str], wt: Path) -> dict:
+    """Run the reverse-dep test closure inside the worktree."""
+    from .test_runner import TestRunner
+
+    runner = TestRunner(repo_root=Path(wt))
+    test_files = tuple(Path(wt) / t for t in tests)
+    result = await runner.run(test_files=test_files, sandbox_dir=None)
+    return {
+        "failed": list(result.failed_tests),
+        "total": result.total,
+    }
+
+
+async def _reset_worktree(wt: Path) -> None:
+    """Best-effort reset of the ephemeral worktree to its pre-op state."""
+    try:
+        await _run_git(["checkout", "--", "."], cwd=wt)
+    except Exception as exc:  # noqa: BLE001 -- best-effort rollback
+        logger.debug("[A1-PR] worktree reset best-effort failed: %s", exc)
+
+
+# ---------------------------------------------------------------------------
+# Pipeline
+# ---------------------------------------------------------------------------
+
+
+async def run_pr_gate_pipeline(
+    *,
+    op_id: str,
+    candidate_files: Sequence[Tuple[str, str]],  # (relpath, full_content)
+    repo_root: str,
+    chain,  # DAGProofChain (the SAME instance create_review_pr will verify)
+    worktree_factory: Optional[Callable[[str], Awaitable[Path]]] = None,
+    worktree_cleanup: Optional[Callable[[Path], Awaitable[None]]] = None,
+    sandbox_gate: Optional[Callable[..., Awaitable]] = None,
+    blast_gate: Optional[Callable[..., Awaitable]] = None,
+    apply_candidate: Optional[
+        Callable[[Path, Sequence[Tuple[str, str]]], Awaitable[None]]
+    ] = None,
+    graph_resolver: Optional[Callable[..., Awaitable]] = None,
+    test_run_fn: Optional[Callable[[set, Path], Awaitable[dict]]] = None,
+    tree_sha_fn: Optional[Callable[[Path], Awaitable[str]]] = None,
+) -> PRGateResult:
+    """Run Gate (1) + Gate (2) in an isolated worktree, branch-bound.
+
+    Raises ``PRGatePipelineError`` if either gate rejects the candidate.
+    ALWAYS cleans up the worktree (``finally``). The real repo tree is NEVER
+    touched.
+    """
+    branch = f"ouroboros/a1-validate/{op_id}"
+    _factory = worktree_factory or _default_worktree_factory(repo_root)
+    _cleanup = worktree_cleanup or _default_worktree_cleanup(repo_root)
+    wt = await _factory(branch)
+    try:
+        # Gate 1 -- container-exec the candidate in the worktree, branch-bound.
+        from .pre_apply_exec_lock import (
+            acquire_sandbox_execution_token,
+            SandboxLockFailed,
+            RequiresCloudExecution,
+        )
+
+        _sbx = sandbox_gate or acquire_sandbox_execution_token
+        try:
+            sandbox_token = await _sbx(
+                op_id=op_id,
+                candidate_files=list(candidate_files),
+                repo_root=str(wt),
+                chain=chain,
+                branch_context=branch,
+            )
+        except (SandboxLockFailed, RequiresCloudExecution) as exc:
+            raise PRGatePipelineError(f"gate1: {exc}") from exc
+
+        # Apply the candidate into the worktree so Gate 2 tests see it.
+        await (apply_candidate or _default_apply_candidate)(
+            wt, list(candidate_files)
+        )
+
+        # Gate 2 -- reverse-dep tests in the worktree, branch-bound.
+        from .blast_radius_verify import (
+            acquire_blast_radius_token,
+            BlastRadiusBreach,
+            BlastRadiusGraphFailure,
+        )
+        from .reverse_dep_resolver import resolve_reverse_dependency_tests
+
+        _resolver = graph_resolver or resolve_reverse_dependency_tests
+        _tree_sha = tree_sha_fn or _default_tree_sha
+        _runner = test_run_fn or _default_test_run
+        _scope = [p for p, _ in candidate_files]
+        pre_sha = await _tree_sha(wt)
+
+        async def _graph_fn(files):
+            return await _resolver(files, repo_root=str(wt), oracle=None)
+
+        async def _test_fn(tests):
+            return await _runner(set(tests), wt)
+
+        async def _cur_sha():
+            return await _tree_sha(wt)
+
+        async def _rollback(_sha):
+            # Worktree is ephemeral; reset it to the pre-op state (best-effort).
+            await _reset_worktree(wt)
+
+        _blast = blast_gate or acquire_blast_radius_token
+        try:
+            blast_token = await _blast(
+                op_id=op_id,
+                scope_files=_scope,
+                pre_op_tree_sha=pre_sha,
+                chain=chain,
+                prev_token=sandbox_token,
+                graph_fn=_graph_fn,
+                test_fn=_test_fn,
+                current_tree_sha_fn=_cur_sha,
+                rollback_fn=_rollback,
+                dlq_fn=None,
+                branch_context=branch,
+            )
+        except (BlastRadiusBreach, BlastRadiusGraphFailure) as exc:
+            raise PRGatePipelineError(f"gate2: {exc}") from exc
+
+        return PRGateResult(
+            sandbox_token=sandbox_token,
+            blast_token=blast_token,
+            branch_context=branch,
+        )
+    finally:
+        try:
+            await _cleanup(wt)
+        except Exception as exc:  # noqa: BLE001 -- cleanup is best-effort
+            logger.warning(
+                "[A1-PR] op=%s worktree cleanup failed: %s", op_id, exc
+            )

--- a/backend/core/ouroboros/governance/blast_radius_verify.py
+++ b/backend/core/ouroboros/governance/blast_radius_verify.py
@@ -41,6 +41,7 @@ async def acquire_blast_radius_token(
     current_tree_sha_fn: Callable[[], Awaitable[str]],
     rollback_fn: Optional[Callable[[str], Awaitable[None]]],
     dlq_fn: Optional[Callable[[str], None]],
+    branch_context: str = "",
 ) -> BlastRadiusClearedToken:
     """Run the full reverse-dependency closure of the modified AST.
 
@@ -109,6 +110,7 @@ async def acquire_blast_radius_token(
                 "post_tree_sha": post_tree_sha,
             },
             prev=prev_token,
+            branch_context=branch_context,
         )
         return token  # type: ignore[return-value]
     except (BlastRadiusBreach, BlastRadiusGraphFailure):

--- a/backend/core/ouroboros/governance/blast_radius_verify.py
+++ b/backend/core/ouroboros/governance/blast_radius_verify.py
@@ -84,29 +84,35 @@ async def acquire_blast_radius_token(
         # rollback is the more alarming signal and intentionally takes priority.
         raise BlastRadiusGraphFailure(f"op={op_id}: {exc}") from exc
 
-    # Phase 2 -- run the closure; no retry
-    result: dict = await test_fn(set(tests))
-    failed = list(result.get("failed", []))
-    if failed:
-        logger.warning(
-            "[Gate2] op=%s blast-radius FAIL %d/%s",
-            op_id,
-            len(failed),
-            result.get("total"),
-        )
-        await _rollback_and_assert("blast_radius_breach")
-        raise BlastRadiusBreach(f"op={op_id} failed={failed}")
+    # Phase 2 + 3 -- wrapped so ANY unexpected crash forces rollback
+    try:
+        result: dict = await test_fn(set(tests))
+        failed = list(result.get("failed", []))
+        if failed:
+            logger.warning(
+                "[Gate2] op=%s blast-radius FAIL %d/%s",
+                op_id,
+                len(failed),
+                result.get("total"),
+            )
+            await _rollback_and_assert("blast_radius_breach")
+            raise BlastRadiusBreach(f"op={op_id} failed={failed}")
 
-    # Phase 3 -- all pass; read post-op SHA for the token payload
-    post_tree_sha = await current_tree_sha_fn()
-    token = chain.mint(
-        kind=TokenKind.BLAST_RADIUS_CLEARED,
-        op_id=op_id,
-        state_binding=pre_op_tree_sha,
-        payload={
-            "n_tests": str(result.get("total", len(tests))),
-            "post_tree_sha": post_tree_sha,
-        },
-        prev=prev_token,
-    )
-    return token  # type: ignore[return-value]
+        # Phase 3 -- all pass; read post-op SHA for the token payload
+        post_tree_sha = await current_tree_sha_fn()
+        token = chain.mint(
+            kind=TokenKind.BLAST_RADIUS_CLEARED,
+            op_id=op_id,
+            state_binding=pre_op_tree_sha,
+            payload={
+                "n_tests": str(result.get("total", len(tests))),
+                "post_tree_sha": post_tree_sha,
+            },
+            prev=prev_token,
+        )
+        return token  # type: ignore[return-value]
+    except (BlastRadiusBreach, BlastRadiusGraphFailure):
+        raise  # rollback already performed; do not double-roll
+    except Exception as exc:  # noqa: BLE001 -- any unexpected crash forces rollback
+        await _rollback_and_assert("blast_radius_unexpected")
+        raise BlastRadiusBreach(f"op={op_id} unexpected blast-radius error: {exc}") from exc

--- a/backend/core/ouroboros/governance/blast_radius_verify.py
+++ b/backend/core/ouroboros/governance/blast_radius_verify.py
@@ -64,7 +64,10 @@ async def acquire_blast_radius_token(
             await rollback_fn(pre_op_tree_sha)
         restored = await current_tree_sha_fn()
         if dlq_fn is not None:
-            dlq_fn(reason)
+            try:
+                dlq_fn(reason)
+            except Exception as _dlq_exc:  # noqa: BLE001 — DLQ is best-effort; never mask the primary failure
+                logger.warning("[Gate2] op=%s dlq_fn failed (best-effort): %s", op_id, _dlq_exc)
         if restored != pre_op_tree_sha:
             raise BlastRadiusBreach(
                 f"op={op_id} ROLLBACK FAILED restored={restored!r} != pre={pre_op_tree_sha!r}"
@@ -76,6 +79,9 @@ async def acquire_blast_radius_token(
     except Exception as exc:  # noqa: BLE001
         logger.warning("[Gate2] op=%s graph FAILURE: %s", op_id, exc)
         await _rollback_and_assert("blast_radius_graph_failure")
+        # NOTE: if _rollback_and_assert raised BlastRadiusBreach (rollback left
+        # the tree at a different SHA), that propagates instead — a broken
+        # rollback is the more alarming signal and intentionally takes priority.
         raise BlastRadiusGraphFailure(f"op={op_id}: {exc}") from exc
 
     # Phase 2 -- run the closure; no retry

--- a/backend/core/ouroboros/governance/blast_radius_verify.py
+++ b/backend/core/ouroboros/governance/blast_radius_verify.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+import logging
+import os
+from typing import Awaitable, Callable, Optional, Sequence, Set
+
+from .dag_capability_token import (
+    BlastRadiusClearedToken,
+    CapabilityToken,
+    DAGProofChain,
+    TokenKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BlastRadiusBreach(RuntimeError):
+    """A test in the reverse-dep closure failed -- rolled back to pre-op SHA."""
+
+
+class BlastRadiusGraphFailure(RuntimeError):
+    """The reverse-dep graph could not be built -- fail-closed, no marker fallback."""
+
+
+def blast_radius_enabled() -> bool:
+    return (
+        os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower()
+        in ("1", "true", "yes")
+    )
+
+
+async def acquire_blast_radius_token(
+    *,
+    op_id: str,
+    scope_files: Sequence[str],
+    pre_op_tree_sha: str,
+    chain: DAGProofChain,
+    prev_token: CapabilityToken,
+    graph_fn: Callable[[Sequence[str]], Awaitable[Set[str]]],
+    test_fn: Callable[[Set[str]], Awaitable[dict]],
+    current_tree_sha_fn: Callable[[], Awaitable[str]],
+    rollback_fn: Optional[Callable[[str], Awaitable[None]]],
+    dlq_fn: Optional[Callable[[str], None]],
+) -> BlastRadiusClearedToken:
+    """Run the full reverse-dependency closure of the modified AST.
+
+    Phases:
+      1. graph_fn(scope_files) -- ANY exception => fail-closed rollback + DLQ +
+         raise BlastRadiusGraphFailure. test_fn is NEVER called on graph failure.
+      2. test_fn(tests) -- any non-empty failed list (NO retry) => rollback to
+         pre_op_tree_sha, assert SHA equality cryptographically, DLQ, raise
+         BlastRadiusBreach.
+      3. All pass => mint BlastRadiusClearedToken chained to prev_token.
+
+    rollback_fn and current_tree_sha_fn are ASYNC callables so they integrate
+    with WorkspaceCheckpointManager.restore_checkpoint (async) and the async
+    git-subprocess tree-SHA reader without blocking the event loop.
+    dlq_fn is sync (intake_dlq.append_dlq is sync); called fail-soft after
+    rollback confirming the SHA before the exception propagates.
+    """
+
+    async def _rollback_and_assert(reason: str) -> None:
+        if rollback_fn is not None:
+            await rollback_fn(pre_op_tree_sha)
+        restored = await current_tree_sha_fn()
+        if dlq_fn is not None:
+            dlq_fn(reason)
+        if restored != pre_op_tree_sha:
+            raise BlastRadiusBreach(
+                f"op={op_id} ROLLBACK FAILED restored={restored!r} != pre={pre_op_tree_sha!r}"
+            )
+
+    # Phase 1 -- graph build; ANY exception is fail-closed
+    try:
+        tests: Set[str] = await graph_fn(scope_files)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("[Gate2] op=%s graph FAILURE: %s", op_id, exc)
+        await _rollback_and_assert("blast_radius_graph_failure")
+        raise BlastRadiusGraphFailure(f"op={op_id}: {exc}") from exc
+
+    # Phase 2 -- run the closure; no retry
+    result: dict = await test_fn(set(tests))
+    failed = list(result.get("failed", []))
+    if failed:
+        logger.warning(
+            "[Gate2] op=%s blast-radius FAIL %d/%s",
+            op_id,
+            len(failed),
+            result.get("total"),
+        )
+        await _rollback_and_assert("blast_radius_breach")
+        raise BlastRadiusBreach(f"op={op_id} failed={failed}")
+
+    # Phase 3 -- all pass; read post-op SHA for the token payload
+    post_tree_sha = await current_tree_sha_fn()
+    token = chain.mint(
+        kind=TokenKind.BLAST_RADIUS_CLEARED,
+        op_id=op_id,
+        state_binding=pre_op_tree_sha,
+        payload={
+            "n_tests": str(result.get("total", len(tests))),
+            "post_tree_sha": post_tree_sha,
+        },
+        prev=prev_token,
+    )
+    return token  # type: ignore[return-value]

--- a/backend/core/ouroboros/governance/dag_capability_token.py
+++ b/backend/core/ouroboros/governance/dag_capability_token.py
@@ -26,13 +26,14 @@ _CHAIN_ORDER = (
 
 def _canonical(kind: TokenKind, op_id: str, state_binding: str,
                prev_hash: str, payload: Mapping[str, str],
-               issued_monotonic: float) -> bytes:
+               issued_monotonic: float, branch_context: str) -> bytes:
     return json.dumps(
         {
             "issued_monotonic": format(issued_monotonic, ".9f"),
             "kind": kind.value,
             "op_id": op_id,
             "state_binding": state_binding,
+            "branch_context": branch_context,
             "prev_hash": prev_hash,
             "payload": {str(k): str(v) for k, v in payload.items()},
         },
@@ -50,11 +51,16 @@ class CapabilityToken:
     payload: Mapping[str, str]
     issued_monotonic: float
     sig: str
+    # Git branch/worktree context the token was minted in. Defaults to "" so
+    # pre-existing (unbound) callers and tokens stay valid; when set, it is
+    # folded into the signed envelope and enforced uniform across a chain.
+    branch_context: str = ""
 
     def digest(self) -> str:
         """Identity hash used as the next token's ``prev_hash`` (chain link)."""
         body = _canonical(self.kind, self.op_id, self.state_binding,
-                          self.prev_hash, self.payload, self.issued_monotonic)
+                          self.prev_hash, self.payload, self.issued_monotonic,
+                          self.branch_context)
         return hashlib.sha256(body + self.sig.encode("utf-8")).hexdigest()
 
 
@@ -91,34 +97,43 @@ class DAGProofChain:
 
     def _sign(self, kind: TokenKind, op_id: str, state_binding: str,
               prev_hash: str, payload: Mapping[str, str],
-              issued_monotonic: float) -> str:
+              issued_monotonic: float, branch_context: str) -> str:
         return hmac.new(
             self._secret,
-            _canonical(kind, op_id, state_binding, prev_hash, payload, issued_monotonic),
+            _canonical(kind, op_id, state_binding, prev_hash, payload,
+                       issued_monotonic, branch_context),
             hashlib.sha256,
         ).hexdigest()
 
     def mint(self, *, kind: TokenKind, op_id: str, state_binding: str,
              payload: Mapping[str, str],
-             prev: Optional[CapabilityToken] = None) -> CapabilityToken:
+             prev: Optional[CapabilityToken] = None,
+             branch_context: str = "") -> CapabilityToken:
         prev_hash = prev.digest() if prev is not None else ""
         norm = {str(k): str(v) for k, v in payload.items()}
         ts = time.monotonic()
-        sig = self._sign(kind, op_id, state_binding, prev_hash, norm, ts)
+        sig = self._sign(kind, op_id, state_binding, prev_hash, norm, ts,
+                         branch_context)
         cls = _KIND_CLS[kind]
-        token = cls(kind, op_id, state_binding, prev_hash, norm, ts, sig)
+        token = cls(kind, op_id, state_binding, prev_hash, norm, ts, sig,
+                    branch_context)
         from . import token_audit  # local import avoids a module cycle
         token_audit.append_mint(token)
         return token
 
     def verify(self, token: CapabilityToken) -> bool:
         expected = self._sign(token.kind, token.op_id, token.state_binding,
-                              token.prev_hash, token.payload, token.issued_monotonic)
+                              token.prev_hash, token.payload,
+                              token.issued_monotonic, token.branch_context)
         return hmac.compare_digest(expected, token.sig)
 
     def verify_chain(self, tokens: Sequence[CapabilityToken], *, op_id: str) -> bool:
         if len(tokens) != len(_CHAIN_ORDER):
             return False
+        # Anti-injection invariant: every token in the chain MUST have been
+        # minted in the SAME branch/worktree context. A token from worktree A
+        # cannot be spliced into a chain rooted in worktree B.
+        expected_ctx = tokens[0].branch_context
         prev_hash = ""
         for token, expected_kind in zip(tokens, _CHAIN_ORDER):
             if token.kind != expected_kind:
@@ -126,6 +141,8 @@ class DAGProofChain:
             if not isinstance(token, _KIND_CLS[expected_kind]):
                 return False
             if token.op_id != op_id:
+                return False
+            if token.branch_context != expected_ctx:
                 return False
             if token.prev_hash != prev_hash:
                 return False

--- a/backend/core/ouroboros/governance/dag_capability_token.py
+++ b/backend/core/ouroboros/governance/dag_capability_token.py
@@ -107,6 +107,8 @@ class DAGProofChain:
         sig = self._sign(kind, op_id, state_binding, prev_hash, norm, ts)
         cls = _KIND_CLS[kind]
         token = cls(kind, op_id, state_binding, prev_hash, norm, ts, sig)
+        from . import token_audit  # local import avoids a module cycle
+        token_audit.append_mint(token)
         return token
 
     def verify(self, token: CapabilityToken) -> bool:

--- a/backend/core/ouroboros/governance/dag_capability_token.py
+++ b/backend/core/ouroboros/governance/dag_capability_token.py
@@ -25,9 +25,11 @@ _CHAIN_ORDER = (
 
 
 def _canonical(kind: TokenKind, op_id: str, state_binding: str,
-               prev_hash: str, payload: Mapping[str, str]) -> bytes:
+               prev_hash: str, payload: Mapping[str, str],
+               issued_monotonic: float) -> bytes:
     return json.dumps(
         {
+            "issued_monotonic": format(issued_monotonic, ".9f"),
             "kind": kind.value,
             "op_id": op_id,
             "state_binding": state_binding,
@@ -52,7 +54,7 @@ class CapabilityToken:
     def digest(self) -> str:
         """Identity hash used as the next token's ``prev_hash`` (chain link)."""
         body = _canonical(self.kind, self.op_id, self.state_binding,
-                          self.prev_hash, self.payload)
+                          self.prev_hash, self.payload, self.issued_monotonic)
         return hashlib.sha256(body + self.sig.encode("utf-8")).hexdigest()
 
 
@@ -88,10 +90,11 @@ class DAGProofChain:
         self._secret = secret if secret is not None else secrets.token_bytes(32)
 
     def _sign(self, kind: TokenKind, op_id: str, state_binding: str,
-              prev_hash: str, payload: Mapping[str, str]) -> str:
+              prev_hash: str, payload: Mapping[str, str],
+              issued_monotonic: float) -> str:
         return hmac.new(
             self._secret,
-            _canonical(kind, op_id, state_binding, prev_hash, payload),
+            _canonical(kind, op_id, state_binding, prev_hash, payload, issued_monotonic),
             hashlib.sha256,
         ).hexdigest()
 
@@ -100,15 +103,15 @@ class DAGProofChain:
              prev: Optional[CapabilityToken] = None) -> CapabilityToken:
         prev_hash = prev.digest() if prev is not None else ""
         norm = {str(k): str(v) for k, v in payload.items()}
-        sig = self._sign(kind, op_id, state_binding, prev_hash, norm)
+        ts = time.monotonic()
+        sig = self._sign(kind, op_id, state_binding, prev_hash, norm, ts)
         cls = _KIND_CLS[kind]
-        token = cls(kind, op_id, state_binding, prev_hash, norm,
-                    time.monotonic(), sig)
+        token = cls(kind, op_id, state_binding, prev_hash, norm, ts, sig)
         return token
 
     def verify(self, token: CapabilityToken) -> bool:
         expected = self._sign(token.kind, token.op_id, token.state_binding,
-                              token.prev_hash, token.payload)
+                              token.prev_hash, token.payload, token.issued_monotonic)
         return hmac.compare_digest(expected, token.sig)
 
     def verify_chain(self, tokens: Sequence[CapabilityToken], *, op_id: str) -> bool:

--- a/backend/core/ouroboros/governance/dag_capability_token.py
+++ b/backend/core/ouroboros/governance/dag_capability_token.py
@@ -1,0 +1,130 @@
+from __future__ import annotations
+import dataclasses
+import enum
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+
+class TokenKind(str, enum.Enum):
+    SANDBOX_EXECUTION = "sandbox_execution"
+    BLAST_RADIUS_CLEARED = "blast_radius_cleared"
+    LINT_CLEARED = "lint_cleared"
+
+
+# Canonical order of the gate chain. The terminal token MUST be LINT_CLEARED.
+_CHAIN_ORDER = (
+    TokenKind.SANDBOX_EXECUTION,
+    TokenKind.BLAST_RADIUS_CLEARED,
+    TokenKind.LINT_CLEARED,
+)
+
+
+def _canonical(kind: TokenKind, op_id: str, state_binding: str,
+               prev_hash: str, payload: Mapping[str, str]) -> bytes:
+    return json.dumps(
+        {
+            "kind": kind.value,
+            "op_id": op_id,
+            "state_binding": state_binding,
+            "prev_hash": prev_hash,
+            "payload": {str(k): str(v) for k, v in payload.items()},
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class CapabilityToken:
+    kind: TokenKind
+    op_id: str
+    state_binding: str
+    prev_hash: str
+    payload: Mapping[str, str]
+    issued_monotonic: float
+    sig: str
+
+    def digest(self) -> str:
+        """Identity hash used as the next token's ``prev_hash`` (chain link)."""
+        body = _canonical(self.kind, self.op_id, self.state_binding,
+                          self.prev_hash, self.payload)
+        return hashlib.sha256(body + self.sig.encode("utf-8")).hexdigest()
+
+
+# Typed aliases -- frozen subclasses add no fields, so the parent __init__ is
+# inherited. A function can demand the SPECIFIC type as a mandatory argument.
+class SandboxExecutionToken(CapabilityToken):
+    pass
+
+
+class BlastRadiusClearedToken(CapabilityToken):
+    pass
+
+
+class LintClearedToken(CapabilityToken):
+    pass
+
+
+_KIND_CLS = {
+    TokenKind.SANDBOX_EXECUTION: SandboxExecutionToken,
+    TokenKind.BLAST_RADIUS_CLEARED: BlastRadiusClearedToken,
+    TokenKind.LINT_CLEARED: LintClearedToken,
+}
+
+
+class DAGProofChain:
+    """Per-op accumulator that mints/verifies unforgeable capability tokens."""
+
+    def __init__(self, *, secret: Optional[bytes] = None) -> None:
+        # Each instance gets its own secret by default so tokens from one
+        # DAGProofChain cannot be verified by a different one (cross-secret
+        # forgery guard). The secret is in-memory only -- never logged,
+        # persisted, or returned.
+        self._secret = secret if secret is not None else secrets.token_bytes(32)
+
+    def _sign(self, kind: TokenKind, op_id: str, state_binding: str,
+              prev_hash: str, payload: Mapping[str, str]) -> str:
+        return hmac.new(
+            self._secret,
+            _canonical(kind, op_id, state_binding, prev_hash, payload),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def mint(self, *, kind: TokenKind, op_id: str, state_binding: str,
+             payload: Mapping[str, str],
+             prev: Optional[CapabilityToken] = None) -> CapabilityToken:
+        prev_hash = prev.digest() if prev is not None else ""
+        norm = {str(k): str(v) for k, v in payload.items()}
+        sig = self._sign(kind, op_id, state_binding, prev_hash, norm)
+        cls = _KIND_CLS[kind]
+        token = cls(kind, op_id, state_binding, prev_hash, norm,
+                    time.monotonic(), sig)
+        return token
+
+    def verify(self, token: CapabilityToken) -> bool:
+        expected = self._sign(token.kind, token.op_id, token.state_binding,
+                              token.prev_hash, token.payload)
+        return hmac.compare_digest(expected, token.sig)
+
+    def verify_chain(self, tokens: Sequence[CapabilityToken], *, op_id: str) -> bool:
+        if len(tokens) != len(_CHAIN_ORDER):
+            return False
+        prev_hash = ""
+        for token, expected_kind in zip(tokens, _CHAIN_ORDER):
+            if token.kind != expected_kind:
+                return False
+            if not isinstance(token, _KIND_CLS[expected_kind]):
+                return False
+            if token.op_id != op_id:
+                return False
+            if token.prev_hash != prev_hash:
+                return False
+            if not self.verify(token):
+                return False
+            prev_hash = token.digest()
+        return True

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -5264,6 +5264,7 @@ SEED_SPECS: list = [
         source_file="backend/core/ouroboros/governance/pr_self_linter.py",
         example="4",
         since="2026-06-29",
+        posture_relevance={},
     ),
     FlagSpec(
         name="JARVIS_TOKEN_AUDIT_PATH",
@@ -5277,6 +5278,7 @@ SEED_SPECS: list = [
         source_file="backend/core/ouroboros/governance/token_audit.py",
         example=".jarvis/token_audit.jsonl",
         since="2026-06-29",
+        posture_relevance={},
     ),
     FlagSpec(
         name="JARVIS_TOKEN_AUDIT_MAX",
@@ -5291,6 +5293,7 @@ SEED_SPECS: list = [
         source_file="backend/core/ouroboros/governance/token_audit.py",
         example="500",
         since="2026-06-29",
+        posture_relevance={},
     ),
 ]
 

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -5247,6 +5247,51 @@ SEED_SPECS: list = [
         since="2026-06-29",
         posture_relevance=_ALL_POSTURES_CRITICAL,
     ),
+    # ====================================================================
+    # Iron Triad tuning + observability knobs (Task 14)
+    # ====================================================================
+    FlagSpec(
+        name="JARVIS_A1_PR_LINTER_THRESHOLD",
+        type=FlagType.INT, default=4,
+        description=(
+            "Minimum severity score (0-10) for the PR self-linter to "
+            "block a PR from being filed. Findings below this threshold "
+            "are logged as warnings only; at or above it the linter "
+            "returns a blocking verdict and the op routes to "
+            "APPROVAL_REQUIRED."
+        ),
+        category=Category.TUNING,
+        source_file="backend/core/ouroboros/governance/pr_self_linter.py",
+        example="4",
+        since="2026-06-29",
+    ),
+    FlagSpec(
+        name="JARVIS_TOKEN_AUDIT_PATH",
+        type=FlagType.STR, default=".jarvis/token_audit.jsonl",
+        description=(
+            "Path to the immutable token-mint WAL file. Relative paths "
+            "are resolved against the project root. The file is "
+            "append-only; each line is a JSON record of one mint event."
+        ),
+        category=Category.OBSERVABILITY,
+        source_file="backend/core/ouroboros/governance/token_audit.py",
+        example=".jarvis/token_audit.jsonl",
+        since="2026-06-29",
+    ),
+    FlagSpec(
+        name="JARVIS_TOKEN_AUDIT_MAX",
+        type=FlagType.INT, default=500,
+        description=(
+            "Maximum number of token-mint WAL records retained in memory "
+            "for the in-process bounded buffer. Records beyond this cap "
+            "are flushed to disk and evicted from the buffer. Does not "
+            "affect the on-disk WAL which is always append-only."
+        ),
+        category=Category.CAPACITY,
+        source_file="backend/core/ouroboros/governance/token_audit.py",
+        example="500",
+        since="2026-06-29",
+    ),
 ]
 
 

--- a/backend/core/ouroboros/governance/flag_registry_seed.py
+++ b/backend/core/ouroboros/governance/flag_registry_seed.py
@@ -5174,6 +5174,79 @@ SEED_SPECS: list = [
         example=".jarvis/fleet_calibration.json",
         since="2026-06-19",
     ),
+    # ====================================================================
+    # Iron Triad A1 gate flags (Task 10)
+    # ====================================================================
+    FlagSpec(
+        name="JARVIS_A1_TOKEN_ENFORCER_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Enable the A1 token-chain enforcer: PRs may only be merged "
+            "when a verified, cryptographically-signed token chain is "
+            "present. Off by default; turn on before A1 promotion."
+        ),
+        category=Category.SAFETY,
+        source_file="backend/core/ouroboros/governance/orange_pr_reviewer.py",
+        example="true",
+        since="2026-06-29",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_A1_SANDBOX_LOCK_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Gate 1 of the Iron Triad: requires an L4 container exec-lock "
+            "before any APPLY step proceeds. Prevents concurrent "
+            "out-of-sandbox mutations."
+        ),
+        category=Category.SAFETY,
+        source_file="backend/core/ouroboros/governance/pre_apply_exec_lock.py",
+        example="true",
+        since="2026-06-29",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_A1_BLAST_RADIUS_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Gate 2 of the Iron Triad: runs a reverse-dependency regression "
+            "check after APPLY to verify no callers of changed symbols "
+            "regress. Blocking — APPLY is rolled back on failure."
+        ),
+        category=Category.SAFETY,
+        source_file="backend/core/ouroboros/governance/blast_radius_verify.py",
+        example="true",
+        since="2026-06-29",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_A1_PR_LINTER_ENABLED",
+        type=FlagType.BOOL, default=False,
+        description=(
+            "Gate 3 of the Iron Triad: runs a blocking LLM architectural-"
+            "rules critique on the PR diff before it is filed. Rejects "
+            "PRs that violate documented design invariants."
+        ),
+        category=Category.SAFETY,
+        source_file="backend/core/ouroboros/governance/pr_self_linter.py",
+        example="true",
+        since="2026-06-29",
+        posture_relevance=_HARDEN_CRITICAL,
+    ),
+    FlagSpec(
+        name="JARVIS_TOKEN_AUDIT_ENABLED",
+        type=FlagType.BOOL, default=True,
+        description=(
+            "Enable the immutable token-mint Write-Ahead Log (WAL). "
+            "Every token minted by the A1 enforcer is durably recorded; "
+            "disabling this flag removes the audit trail."
+        ),
+        category=Category.OBSERVABILITY,
+        source_file="backend/core/ouroboros/governance/token_audit.py",
+        example="true",
+        since="2026-06-29",
+        posture_relevance=_ALL_POSTURES_CRITICAL,
+    ),
 ]
 
 

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1380,6 +1380,14 @@ class GovernedLoopService:
 
             await self._build_components()
 
+            # Task 9 -- async Docker pre-flight: surfaces daemon absence BEFORE
+            # any op reaches APPLY.  Fail-soft: boot continues regardless.
+            try:
+                from .pre_apply_exec_lock import docker_preflight
+                self._docker_ready = await docker_preflight()
+            except Exception:  # noqa: BLE001
+                self._docker_ready = None
+
             # Phase 4: initialize preemption FSM executor (ledger available after _build_components)
             self._fsm_engine = PreemptionFsmEngine()
             if self._ledger is not None:

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1219,6 +1219,7 @@ class GovernedLoopService:
         self._graph_coalescer: Optional[Any] = None
         self._advanced_autonomy: Optional[Any] = None
         self._mcp_client: Optional[Any] = None  # Phase A: GovernanceMCPClient, wired in start()
+        self._docker_ready: Optional[bool] = None  # set in start() by docker_preflight; None = not yet run
 
         # Compute-class admission gate (set externally after fetching /v1/capability;
         # None = gate disabled — backward-compatible default)

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -1381,13 +1381,13 @@ class GovernedLoopService:
 
             await self._build_components()
 
-            # Task 9 -- async Docker pre-flight: surfaces daemon absence BEFORE
-            # any op reaches APPLY.  Fail-soft: boot continues regardless.
-            try:
-                from .pre_apply_exec_lock import docker_preflight
-                self._docker_ready = await docker_preflight()
-            except Exception:  # noqa: BLE001
-                self._docker_ready = None
+            # Task 9 -- async Docker pre-flight (only when A1 is armed -> byte-identical OFF)
+            if os.environ.get("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false").strip().lower() in ("1", "true", "yes"):
+                try:
+                    from .pre_apply_exec_lock import docker_preflight
+                    self._docker_ready = await docker_preflight()
+                except Exception:  # noqa: BLE001
+                    self._docker_ready = None
 
             # Phase 4: initialize preemption FSM executor (ledger available after _build_components)
             self._fsm_engine = PreemptionFsmEngine()

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1068,6 +1068,13 @@ class OperationContext:
     # a concurrent operation and the candidate is stale.
     generate_file_hashes: Tuple[Tuple[str, str], ...] = ()
 
+    # ---- Gate 1: Isomorphic Execution Lock (pre-write L4 proof chain) ----
+    # Set at APPLY-start by the Gate 1 block in slice4b_runner when
+    # JARVIS_A1_SANDBOX_LOCK_ENABLED=true.  Both fields are None (default-OFF)
+    # on every path that does not activate the gate — zero behavioural change.
+    proof_chain: object = None    # DAGProofChain (per-op accumulator)
+    sandbox_token: object = None  # SandboxExecutionToken minted at Gate 1
+
     # ---- Model-reasoned implementation plan (stamped at PLAN phase) ----
     # Structured JSON plan produced by PlanGenerator before GENERATE.
     # Contains: approach, file_changes (ordered with dependencies), risk_factors,

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1074,6 +1074,7 @@ class OperationContext:
     # on every path that does not activate the gate — zero behavioural change.
     proof_chain: object = None    # DAGProofChain (per-op accumulator)
     sandbox_token: object = None  # SandboxExecutionToken minted at Gate 1
+    blast_token: object = None    # BlastRadiusClearedToken minted at Gate 2
 
     # ---- Model-reasoned implementation plan (stamped at PLAN phase) ----
     # Structured JSON plan produced by PlanGenerator before GENERATE.

--- a/backend/core/ouroboros/governance/orange_pr_reviewer.py
+++ b/backend/core/ouroboros/governance/orange_pr_reviewer.py
@@ -69,6 +69,20 @@ def is_orange_pr_enabled() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+def _token_enforcer_enabled() -> bool:
+    """True when the Iron Triad token enforcer gates ``create_review_pr``.
+
+    Default-OFF (``JARVIS_A1_TOKEN_ENFORCER_ENABLED`` unset/false) is
+    byte-identical legacy: the enforcer block is fully skipped and no
+    token-machinery imports are evaluated.
+    """
+    return os.environ.get("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false").strip().lower() in (
+        "1",
+        "true",
+        "yes",
+    )
+
+
 def build_commit_message(
     op_id: str,
     description: str,
@@ -215,6 +229,10 @@ class OrangePRReviewer:
     async def _run_gh(self, *args: str) -> Tuple[int, str, str]:
         return await asyncio.to_thread(self._run_gh_sync, list(args))
 
+    def _enforcer_enabled(self) -> bool:
+        """Instance accessor for the Iron Triad token enforcer flag."""
+        return _token_enforcer_enabled()
+
     # ------------------------------------------------------------------
     # Public entry point
     # ------------------------------------------------------------------
@@ -228,6 +246,11 @@ class OrangePRReviewer:
         risk_tier_name: str = "APPROVAL_REQUIRED",
         body_override: Optional[str] = None,
         title_override: Optional[str] = None,
+        *,
+        chain: Any = None,
+        sandbox_token: Any = None,
+        blast_token: Any = None,
+        lint_token: Any = None,
     ) -> Optional[PRReviewResult]:
         """Open an async-review PR for the given candidate.
 
@@ -243,6 +266,59 @@ class OrangePRReviewer:
         if not files:
             logger.warning("[OrangePR] no files in candidate for op=%s", op_id)
             return None
+
+        # ---- Iron Triad enforcer: no verified token chain -> no PR ----
+        # Default-OFF (JARVIS_A1_TOKEN_ENFORCER_ENABLED unset/false): this whole
+        # block is skipped and the method behaves byte-identically to legacy.
+        # All token-machinery imports live INSIDE this block so the OFF path
+        # never evaluates them. Placed BEFORE any git op so an invalid/missing
+        # chain refuses cheaply, without touching the working tree.
+        if _token_enforcer_enabled():
+            from .dag_capability_token import (
+                SandboxExecutionToken,
+                BlastRadiusClearedToken,
+                LintClearedToken,
+            )
+            from .pr_self_linter import (
+                acquire_lint_cleared_token,
+                linter_enabled,
+                LintRejected,
+            )
+
+            # Gate 3: mint the lint token here if not already supplied.
+            if (
+                linter_enabled()
+                and lint_token is None
+                and blast_token is not None
+                and chain is not None
+            ):
+                _diff = "\n".join(f"--- {p}\n{c}" for p, c in files)
+                try:
+                    lint_token = await acquire_lint_cleared_token(
+                        op_id=op_id,
+                        diff=_diff,
+                        chain=chain,
+                        prev_token=blast_token,
+                    )
+                except LintRejected as _lr:
+                    logger.warning("[Gate3] op=%s LINT_REJECTED: %s", op_id, _lr)
+                    return None
+
+            # Mandatory typed token objects + verified hash chain, or refuse.
+            if not (
+                isinstance(sandbox_token, SandboxExecutionToken)
+                and isinstance(blast_token, BlastRadiusClearedToken)
+                and isinstance(lint_token, LintClearedToken)
+                and chain is not None
+                and chain.verify_chain(
+                    [sandbox_token, blast_token, lint_token], op_id=op_id
+                )
+            ):
+                logger.warning(
+                    "[Enforcer] op=%s missing/invalid token chain -> refuse PR",
+                    op_id,
+                )
+                return None
 
         rc, base_branch, err = await self._run_git("rev-parse", "--abbrev-ref", "HEAD")
         if rc != 0 or not base_branch:

--- a/backend/core/ouroboros/governance/orange_pr_reviewer.py
+++ b/backend/core/ouroboros/governance/orange_pr_reviewer.py
@@ -251,6 +251,7 @@ class OrangePRReviewer:
         sandbox_token: Any = None,
         blast_token: Any = None,
         lint_token: Any = None,
+        expected_branch_context: Optional[str] = None,
     ) -> Optional[PRReviewResult]:
         """Open an async-review PR for the given candidate.
 
@@ -299,6 +300,7 @@ class OrangePRReviewer:
                         diff=_diff,
                         chain=chain,
                         prev_token=blast_token,
+                        branch_context=expected_branch_context or "",
                     )
                 except LintRejected as _lr:
                     logger.warning("[Gate3] op=%s LINT_REJECTED: %s", op_id, _lr)
@@ -317,6 +319,21 @@ class OrangePRReviewer:
                 logger.warning(
                     "[Enforcer] op=%s missing/invalid token chain -> refuse PR",
                     op_id,
+                )
+                return None
+
+            # Branch-context assertion: verify_chain guarantees the chain is
+            # internally uniform; this asserts the chain is rooted in the EXPECTED
+            # isolated worktree, not merely self-consistent.
+            if (
+                expected_branch_context is not None
+                and sandbox_token is not None
+                and getattr(sandbox_token, "branch_context", "") != expected_branch_context
+            ):
+                logger.warning(
+                    "[Enforcer] op=%s token branch_context mismatch (expected=%s) -> refuse PR",
+                    op_id,
+                    expected_branch_context,
                 )
                 return None
 

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -9468,6 +9468,55 @@ class GovernedOrchestrator:
                 if _orange_pr_on:
                     try:
                         _files_for_pr = self._iter_candidate_files(best_candidate)
+                        # Iron Triad (Task 13b): when the enforcer is armed, run
+                        # Gate (1) + Gate (2) inside an ISOLATED worktree so this
+                        # ONE op assembles the branch-bound chain that Gate (3) +
+                        # create_review_pr then verify. Default-OFF byte-
+                        # identical: all pipeline machinery imports inside the
+                        # guard, tokens come from ctx (None on the Orange path)
+                        # exactly as today.
+                        _pr_chain = getattr(ctx, "proof_chain", None)
+                        _expected_branch = None
+                        _sbx_tok = getattr(ctx, "sandbox_token", None)
+                        _blast_tok = getattr(ctx, "blast_token", None)
+                        from backend.core.ouroboros.governance.autonomous_pr_pipeline import (
+                            pipeline_enabled,
+                            run_pr_gate_pipeline,
+                            PRGatePipelineError,
+                        )
+                        if pipeline_enabled():
+                            from backend.core.ouroboros.governance.dag_capability_token import (
+                                DAGProofChain,
+                            )
+                            _pr_chain = _pr_chain or DAGProofChain()
+                            try:
+                                _pipe = await run_pr_gate_pipeline(
+                                    op_id=ctx.op_id,
+                                    candidate_files=list(_files_for_pr),
+                                    repo_root=str(self._config.project_root),
+                                    chain=_pr_chain,
+                                )
+                                _sbx_tok, _blast_tok, _expected_branch = (
+                                    _pipe.sandbox_token,
+                                    _pipe.blast_token,
+                                    _pipe.branch_context,
+                                )
+                            except PRGatePipelineError as _pe:
+                                logger.warning(
+                                    "[A1-PR] op=%s gate pipeline rejected "
+                                    "candidate: %s -> no PR",
+                                    ctx.op_id, _pe,
+                                )
+                                ctx = ctx.advance(
+                                    OperationPhase.POSTMORTEM,
+                                    terminal_reason_code="pr_gate_rejected",
+                                )
+                                await self._record_ledger(
+                                    ctx,
+                                    OperationState.FAILED,
+                                    {"reason": "pr_gate_rejected"},
+                                )
+                                return ctx
                         _reviewer = OrangePRReviewer(self._config.project_root)
                         _pr_result = await _reviewer.create_review_pr(
                             op_id=ctx.op_id,
@@ -9479,9 +9528,10 @@ class GovernedOrchestrator:
                                 "file_count": len(_files_for_pr),
                             },
                             risk_tier_name=risk_tier.name,
-                            chain=getattr(ctx, "proof_chain", None),
-                            sandbox_token=getattr(ctx, "sandbox_token", None),
-                            blast_token=getattr(ctx, "blast_token", None),
+                            chain=_pr_chain,
+                            sandbox_token=_sbx_tok,
+                            blast_token=_blast_tok,
+                            expected_branch_context=_expected_branch,
                         )
                     except Exception:
                         logger.exception(

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -9479,12 +9479,11 @@ class GovernedOrchestrator:
                         _expected_branch = None
                         _sbx_tok = getattr(ctx, "sandbox_token", None)
                         _blast_tok = getattr(ctx, "blast_token", None)
-                        from backend.core.ouroboros.governance.autonomous_pr_pipeline import (
-                            pipeline_enabled,
-                            run_pr_gate_pipeline,
-                            PRGatePipelineError,
-                        )
-                        if pipeline_enabled():
+                        if os.environ.get("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false").strip().lower() in ("1", "true", "yes"):
+                            from backend.core.ouroboros.governance.autonomous_pr_pipeline import (
+                                run_pr_gate_pipeline,
+                                PRGatePipelineError,
+                            )
                             from backend.core.ouroboros.governance.dag_capability_token import (
                                 DAGProofChain,
                             )

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -9479,6 +9479,9 @@ class GovernedOrchestrator:
                                 "file_count": len(_files_for_pr),
                             },
                             risk_tier_name=risk_tier.name,
+                            chain=getattr(ctx, "proof_chain", None),
+                            sandbox_token=getattr(ctx, "sandbox_token", None),
+                            blast_token=getattr(ctx, "blast_token", None),
                         )
                     except Exception:
                         logger.exception(

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -204,6 +204,9 @@ class Slice4bRunner(PhaseRunner):
                             "file_count": len(_files_for_pr),
                         },
                         risk_tier_name=risk_tier.name,
+                        chain=getattr(ctx, "proof_chain", None),
+                        sandbox_token=getattr(ctx, "sandbox_token", None),
+                        blast_token=getattr(ctx, "blast_token", None),
                     )
                 except Exception:
                     logger.exception(

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -82,6 +82,7 @@ accessed via ``orch._stack.change_engine`` — same as inline).
 from __future__ import annotations
 
 import asyncio
+import dataclasses
 import hashlib
 import logging
 import os
@@ -564,6 +565,47 @@ class Slice4bRunner(PhaseRunner):
                     )
         except Exception:
             logger.debug("[Orchestrator] LiveWorkSensor check skipped", exc_info=True)
+
+        # ---- Gate 1: Isomorphic Execution Lock (pre-write, strict L4) ----
+        # Runs AFTER execution_graph materialisation (best_candidate is final)
+        # and BEFORE any snapshot or write touches the real tree.
+        # Default-OFF: JARVIS_A1_SANDBOX_LOCK_ENABLED controls activation.
+        from backend.core.ouroboros.governance.pre_apply_exec_lock import (
+            acquire_sandbox_execution_token,
+            lock_enabled,
+            RequiresCloudExecution,
+            SandboxLockFailed,
+        )
+        from backend.core.ouroboros.governance.dag_capability_token import DAGProofChain
+        if lock_enabled():
+            _g1_chain = getattr(ctx, "proof_chain", None) or DAGProofChain()
+            _g1_cand_files = list(orch._iter_candidate_files(best_candidate))
+            try:
+                _g1_sbx_tok = await acquire_sandbox_execution_token(
+                    op_id=ctx.op_id,
+                    candidate_files=_g1_cand_files,
+                    repo_root=str(orch._config.project_root),
+                    chain=_g1_chain,
+                )
+            except (SandboxLockFailed, RequiresCloudExecution) as _g1_exc:
+                _g1_reason = (
+                    "requires_cloud_execution"
+                    if isinstance(_g1_exc, RequiresCloudExecution)
+                    else "sandbox_lock_failed"
+                )
+                logger.warning(
+                    "[Gate1] op=%s %s: %s", ctx.op_id, _g1_reason, _g1_exc,
+                )
+                ctx = ctx.advance(
+                    OperationPhase.POSTMORTEM,
+                    terminal_reason_code=_g1_reason,
+                )
+                return PhaseResult(
+                    next_ctx=ctx, next_phase=None, status="fail",
+                    reason=_g1_reason,
+                    artifacts={"t_apply": _t_apply},
+                )
+            ctx = dataclasses.replace(ctx, proof_chain=_g1_chain, sandbox_token=_g1_sbx_tok)
 
         # Pre-apply snapshots
         snapshots: Dict[str, str] = {}

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -193,6 +193,58 @@ class Slice4bRunner(PhaseRunner):
             if _orange_pr_on:
                 try:
                     _files_for_pr = orch._iter_candidate_files(best_candidate)
+                    # Iron Triad (Task 13b): when the enforcer is armed, run
+                    # Gate (1) + Gate (2) inside an ISOLATED worktree so this
+                    # ONE op assembles the branch-bound chain that Gate (3) +
+                    # create_review_pr then verify. Default-OFF byte-identical:
+                    # all pipeline machinery imports inside the guard, tokens
+                    # come from ctx (None on the Orange path) exactly as today.
+                    _pr_chain = getattr(ctx, "proof_chain", None)
+                    _expected_branch = None
+                    _sbx_tok = getattr(ctx, "sandbox_token", None)
+                    _blast_tok = getattr(ctx, "blast_token", None)
+                    from backend.core.ouroboros.governance.autonomous_pr_pipeline import (
+                        pipeline_enabled,
+                        run_pr_gate_pipeline,
+                        PRGatePipelineError,
+                    )
+                    if pipeline_enabled():
+                        from backend.core.ouroboros.governance.dag_capability_token import (
+                            DAGProofChain,
+                        )
+                        _pr_chain = _pr_chain or DAGProofChain()
+                        try:
+                            _pipe = await run_pr_gate_pipeline(
+                                op_id=ctx.op_id,
+                                candidate_files=list(_files_for_pr),
+                                repo_root=str(orch._config.project_root),
+                                chain=_pr_chain,
+                            )
+                            _sbx_tok, _blast_tok, _expected_branch = (
+                                _pipe.sandbox_token,
+                                _pipe.blast_token,
+                                _pipe.branch_context,
+                            )
+                        except PRGatePipelineError as _pe:
+                            logger.warning(
+                                "[A1-PR] op=%s gate pipeline rejected "
+                                "candidate: %s -> no PR",
+                                ctx.op_id, _pe,
+                            )
+                            ctx = ctx.advance(
+                                OperationPhase.POSTMORTEM,
+                                terminal_reason_code="pr_gate_rejected",
+                            )
+                            await orch._record_ledger(
+                                ctx,
+                                OperationState.FAILED,
+                                {"reason": "pr_gate_rejected"},
+                            )
+                            return PhaseResult(
+                                next_ctx=ctx, next_phase=None, status="fail",
+                                reason="pr_gate_rejected",
+                                artifacts={"t_apply": _t_apply},
+                            )
                     _reviewer = OrangePRReviewer(orch._config.project_root)
                     _pr_result = await _reviewer.create_review_pr(
                         op_id=ctx.op_id,
@@ -204,9 +256,10 @@ class Slice4bRunner(PhaseRunner):
                             "file_count": len(_files_for_pr),
                         },
                         risk_tier_name=risk_tier.name,
-                        chain=getattr(ctx, "proof_chain", None),
-                        sandbox_token=getattr(ctx, "sandbox_token", None),
-                        blast_token=getattr(ctx, "blast_token", None),
+                        chain=_pr_chain,
+                        sandbox_token=_sbx_tok,
+                        blast_token=_blast_tok,
+                        expected_branch_context=_expected_branch,
                     )
                 except Exception:
                     logger.exception(

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -203,12 +203,11 @@ class Slice4bRunner(PhaseRunner):
                     _expected_branch = None
                     _sbx_tok = getattr(ctx, "sandbox_token", None)
                     _blast_tok = getattr(ctx, "blast_token", None)
-                    from backend.core.ouroboros.governance.autonomous_pr_pipeline import (
-                        pipeline_enabled,
-                        run_pr_gate_pipeline,
-                        PRGatePipelineError,
-                    )
-                    if pipeline_enabled():
+                    if os.environ.get("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false").strip().lower() in ("1", "true", "yes"):
+                        from backend.core.ouroboros.governance.autonomous_pr_pipeline import (
+                            run_pr_gate_pipeline,
+                            PRGatePipelineError,
+                        )
                         from backend.core.ouroboros.governance.dag_capability_token import (
                             DAGProofChain,
                         )

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -1142,6 +1142,12 @@ class Slice4bRunner(PhaseRunner):
         # Default-OFF: JARVIS_A1_BLAST_RADIUS_ENABLED controls activation.
         # Inline env check + all imports INSIDE the guard so the OFF path
         # imports NOTHING (byte-identical to pre-Gate-2 behavior — Task 4 lesson).
+        if os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes"):
+            if getattr(ctx, "sandbox_token", None) is None:
+                logger.warning(
+                    "[Gate2] op=%s armed but no sandbox_token (Gate 1 disabled?) -- skipping",
+                    ctx.op_id,
+                )
         if (os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
                 and getattr(ctx, "sandbox_token", None) is not None
                 and getattr(ctx, "proof_chain", None) is not None):

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -1131,6 +1131,102 @@ class Slice4bRunner(PhaseRunner):
                 artifacts={"t_apply": _t_apply},
             )
 
+        # ---- Gate 2: Cryptographic Blast-Radius Verification ----
+        # Runs AFTER the scoped Phase-8a verify gate cleared (only reached
+        # when those tests passed) and BEFORE Phase 8b auto-commit. Chains
+        # onto Gate 1's sandbox_token: if Gate 1 didn't run there is no token
+        # to chain, so Gate 2 is skipped rather than broken.
+        # Default-OFF: JARVIS_A1_BLAST_RADIUS_ENABLED controls activation.
+        # Inline env check + all imports INSIDE the guard so the OFF path
+        # imports NOTHING (byte-identical to pre-Gate-2 behavior — Task 4 lesson).
+        if (os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+                and getattr(ctx, "sandbox_token", None) is not None
+                and getattr(ctx, "proof_chain", None) is not None):
+            from ..blast_radius_verify import (
+                acquire_blast_radius_token,
+                BlastRadiusBreach,
+                BlastRadiusGraphFailure,
+            )
+            from ..reverse_dep_resolver import resolve_reverse_dependency_tests
+            from .. import intake_dlq as _g2_dlq
+            from ..test_runner import TestRunner as _G2TestRunner
+
+            _g2_root = orch._config.project_root  # Path
+            _g2_scope = sorted(
+                set(ctx.target_files)
+                | {cf for cf, _ in orch._iter_candidate_files(best_candidate) if cf}
+            )
+            # Reuse the APPLY-start checkpoint's tree SHA as the pre-op anchor.
+            _g2_pre_sha = getattr(_checkpoint, "stash_ref", "") if _checkpoint is not None else ""
+
+            async def _g2_graph_fn(files):
+                return await resolve_reverse_dependency_tests(
+                    files, repo_root=str(_g2_root), oracle=None,
+                )
+
+            async def _g2_test_fn(tests):
+                if not tests:
+                    return {"failed": [], "total": 0}
+                _paths = tuple((_g2_root / t) for t in tests)
+                _runner = _G2TestRunner(repo_root=_g2_root)
+                _tr = await _runner.run(test_files=_paths, sandbox_dir=None)
+                return {"failed": list(_tr.failed_tests), "total": _tr.total}
+
+            async def _g2_rollback(_sha):
+                # Non-destructive restore via the existing APPLY-start checkpoint.
+                if _checkpoint is not None and _ckpt_mgr is not None:
+                    await _ckpt_mgr.restore_checkpoint(_checkpoint.checkpoint_id)
+
+            async def _g2_tree_sha():
+                if _ckpt_mgr is None:
+                    return ""
+                _ck = await _ckpt_mgr.create_checkpoint(ctx.op_id, "blast-radius: current-tree")
+                return getattr(_ck, "stash_ref", "") if _ck is not None else ""
+
+            def _g2_dlq_fn(reason):
+                _g2_dlq.append_dlq({"op_id": ctx.op_id, "phase": "blast_radius"}, reason=reason)
+
+            try:
+                _blast_tok = await acquire_blast_radius_token(
+                    op_id=ctx.op_id,
+                    scope_files=_g2_scope,
+                    pre_op_tree_sha=_g2_pre_sha,
+                    chain=ctx.proof_chain,
+                    prev_token=ctx.sandbox_token,
+                    graph_fn=_g2_graph_fn,
+                    test_fn=_g2_test_fn,
+                    current_tree_sha_fn=_g2_tree_sha,
+                    rollback_fn=_g2_rollback,
+                    dlq_fn=_g2_dlq_fn,
+                )
+            except BlastRadiusGraphFailure:
+                logger.warning("[Gate2] op=%s blast_radius_graph_failure", ctx.op_id)
+                if _serpent: _serpent.update_phase("POSTMORTEM")
+                ctx = ctx.advance(
+                    OperationPhase.POSTMORTEM,
+                    terminal_reason_code="blast_radius_graph_failure",
+                    rollback_occurred=True,
+                )
+                return PhaseResult(
+                    next_ctx=ctx, next_phase=None, status="fail",
+                    reason="blast_radius_graph_failure",
+                    artifacts={"t_apply": _t_apply},
+                )
+            except BlastRadiusBreach:
+                logger.warning("[Gate2] op=%s blast_radius_breach", ctx.op_id)
+                if _serpent: _serpent.update_phase("POSTMORTEM")
+                ctx = ctx.advance(
+                    OperationPhase.POSTMORTEM,
+                    terminal_reason_code="blast_radius_breach",
+                    rollback_occurred=True,
+                )
+                return PhaseResult(
+                    next_ctx=ctx, next_phase=None, status="fail",
+                    reason="blast_radius_breach",
+                    artifacts={"t_apply": _t_apply},
+                )
+            ctx = dataclasses.replace(ctx, blast_token=_blast_tok)
+
         # ---- Phase 8b: Auto-commit ----
         _committed_hash: Optional[str] = None
         try:

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -570,14 +570,15 @@ class Slice4bRunner(PhaseRunner):
         # Runs AFTER execution_graph materialisation (best_candidate is final)
         # and BEFORE any snapshot or write touches the real tree.
         # Default-OFF: JARVIS_A1_SANDBOX_LOCK_ENABLED controls activation.
-        from backend.core.ouroboros.governance.pre_apply_exec_lock import (
-            acquire_sandbox_execution_token,
-            lock_enabled,
-            RequiresCloudExecution,
-            SandboxLockFailed,
-        )
-        from backend.core.ouroboros.governance.dag_capability_token import DAGProofChain
-        if lock_enabled():
+        # Inline env check mirrors pre_apply_exec_lock.lock_enabled() so the
+        # OFF path imports NOTHING (byte-identical to pre-Gate-1 behavior).
+        if os.environ.get("JARVIS_A1_SANDBOX_LOCK_ENABLED", "false").strip().lower() in ("1", "true", "yes"):
+            from ..pre_apply_exec_lock import (
+                acquire_sandbox_execution_token,
+                SandboxLockFailed,
+                RequiresCloudExecution,
+            )
+            from ..dag_capability_token import DAGProofChain
             _g1_chain = getattr(ctx, "proof_chain", None) or DAGProofChain()
             _g1_cand_files = list(orch._iter_candidate_files(best_candidate))
             try:

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -1156,8 +1156,12 @@ class Slice4bRunner(PhaseRunner):
                 set(ctx.target_files)
                 | {cf for cf, _ in orch._iter_candidate_files(best_candidate) if cf}
             )
-            # Reuse the APPLY-start checkpoint's tree SHA as the pre-op anchor.
-            _g2_pre_sha = getattr(_checkpoint, "stash_ref", "") if _checkpoint is not None else ""
+            # Reuse the APPLY-start checkpoint's content TREE SHA as the pre-op anchor.
+            # stash_ref is a timestamped COMMIT sha; ^{tree} is content-addressed and
+            # deterministic — identical content produces identical tree SHA.
+            _g2_pre_sha = await _ckpt_mgr.tree_sha_for_ref(
+                getattr(_checkpoint, "stash_ref", "") if _checkpoint is not None else ""
+            )
 
             async def _g2_graph_fn(files):
                 return await resolve_reverse_dependency_tests(
@@ -1180,8 +1184,7 @@ class Slice4bRunner(PhaseRunner):
             async def _g2_tree_sha():
                 if _ckpt_mgr is None:
                     return ""
-                _ck = await _ckpt_mgr.create_checkpoint(ctx.op_id, "blast-radius: current-tree")
-                return getattr(_ck, "stash_ref", "") if _ck is not None else ""
+                return await _ckpt_mgr.working_tree_content_sha()
 
             def _g2_dlq_fn(reason):
                 _g2_dlq.append_dlq({"op_id": ctx.op_id, "phase": "blast_radius"}, reason=reason)

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -1210,6 +1210,13 @@ class Slice4bRunner(PhaseRunner):
                     terminal_reason_code="blast_radius_graph_failure",
                     rollback_occurred=True,
                 )
+                await orch._record_ledger(
+                    ctx,
+                    OperationState.FAILED,
+                    {"reason": "blast_radius_graph_failure", "rollback_occurred": True},
+                )
+                orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
+                await orch._publish_outcome(ctx, OperationState.FAILED, "blast_radius_graph_failure")
                 return PhaseResult(
                     next_ctx=ctx, next_phase=None, status="fail",
                     reason="blast_radius_graph_failure",
@@ -1223,6 +1230,13 @@ class Slice4bRunner(PhaseRunner):
                     terminal_reason_code="blast_radius_breach",
                     rollback_occurred=True,
                 )
+                await orch._record_ledger(
+                    ctx,
+                    OperationState.FAILED,
+                    {"reason": "blast_radius_breach", "rollback_occurred": True},
+                )
+                orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
+                await orch._publish_outcome(ctx, OperationState.FAILED, "blast_radius_breach")
                 return PhaseResult(
                     next_ctx=ctx, next_phase=None, status="fail",
                     reason="blast_radius_breach",

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -1142,13 +1142,14 @@ class Slice4bRunner(PhaseRunner):
         # Default-OFF: JARVIS_A1_BLAST_RADIUS_ENABLED controls activation.
         # Inline env check + all imports INSIDE the guard so the OFF path
         # imports NOTHING (byte-identical to pre-Gate-2 behavior — Task 4 lesson).
-        if os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes"):
+        _blast_armed = os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+        if _blast_armed:
             if getattr(ctx, "sandbox_token", None) is None:
                 logger.warning(
                     "[Gate2] op=%s armed but no sandbox_token (Gate 1 disabled?) -- skipping",
                     ctx.op_id,
                 )
-        if (os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+        if (_blast_armed
                 and getattr(ctx, "sandbox_token", None) is not None
                 and getattr(ctx, "proof_chain", None) is not None):
             from ..blast_radius_verify import (

--- a/backend/core/ouroboros/governance/pr_self_linter.py
+++ b/backend/core/ouroboros/governance/pr_self_linter.py
@@ -5,7 +5,7 @@ import os
 from typing import Awaitable, Callable, Optional
 
 from .dag_capability_token import (
-    BlastRadiusClearedToken, CapabilityToken, DAGProofChain, LintClearedToken, TokenKind,
+    CapabilityToken, DAGProofChain, LintClearedToken, TokenKind,
 )
 
 logger = logging.getLogger(__name__)
@@ -45,7 +45,10 @@ async def default_critique_fn(diff: str) -> dict:
         response_format={"type": "json_object"},
         max_tokens=512,
     )
-    parsed, _ok = parse_critique_json(raw, op_id="pr_self_linter")
+    parsed, ok = parse_critique_json(raw, op_id="pr_self_linter")
+    if not ok:
+        logger.warning("[Gate3] pr_self_linter: critique parse failed; fail-closed rating=0")
+        return {"rating": 0, "concerns": ["parse_failure"]}
     return parsed
 
 
@@ -61,7 +64,10 @@ async def acquire_lint_cleared_token(
     _crit = critique_fn or default_critique_fn
     _thr = threshold if threshold is not None else _threshold()
     verdict = await _crit(diff)
-    rating = int(verdict.get("rating", 0))
+    try:
+        rating = int(verdict.get("rating") or 0)
+    except (TypeError, ValueError):
+        rating = 0
     if rating < _thr:
         raise LintRejected(
             f"op={op_id} rating={rating}<{_thr} concerns={verdict.get('concerns')}")

--- a/backend/core/ouroboros/governance/pr_self_linter.py
+++ b/backend/core/ouroboros/governance/pr_self_linter.py
@@ -60,6 +60,7 @@ async def acquire_lint_cleared_token(
     prev_token: CapabilityToken,
     critique_fn: Optional[Callable[[str], Awaitable[dict]]] = None,
     threshold: Optional[int] = None,
+    branch_context: str = "",
 ) -> LintClearedToken:
     _crit = critique_fn or default_critique_fn
     _thr = threshold if threshold is not None else _threshold()
@@ -77,5 +78,6 @@ async def acquire_lint_cleared_token(
         state_binding=hashlib.sha256(diff.encode("utf-8")).hexdigest(),
         payload={"rating": str(rating)},
         prev=prev_token,
+        branch_context=branch_context,
     )
     return token  # type: ignore[return-value]

--- a/backend/core/ouroboros/governance/pr_self_linter.py
+++ b/backend/core/ouroboros/governance/pr_self_linter.py
@@ -1,0 +1,75 @@
+from __future__ import annotations
+import hashlib
+import logging
+import os
+from typing import Awaitable, Callable, Optional
+
+from .dag_capability_token import (
+    BlastRadiusClearedToken, CapabilityToken, DAGProofChain, LintClearedToken, TokenKind,
+)
+
+logger = logging.getLogger(__name__)
+
+_RULES = (
+    "Critique this diff against the repository's architectural rules. Return JSON "
+    '{"rating": 1-5, "concerns": [..]}. Rules: (1) NO hardcoding -- values/paths/'
+    "models must be env/config-derived; (2) DRY -- no duplicated logic that an "
+    "existing helper covers; (3) explicit error handling -- no bare/silent excepts; "
+    "(4) async-first -- no blocking calls on the event loop. Rate 5 only if all hold."
+)
+
+
+def linter_enabled() -> bool:
+    return os.environ.get("JARVIS_A1_PR_LINTER_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
+def _threshold() -> int:
+    try:
+        return int(os.environ.get("JARVIS_A1_PR_LINTER_THRESHOLD", "4"))
+    except ValueError:
+        return 4
+
+
+class LintRejected(RuntimeError):
+    """The model's own architectural critique rejected the diff -- no PR."""
+
+
+async def default_critique_fn(diff: str) -> dict:
+    """Bounded, structured one-shot critique via the cheapest existing provider."""
+    from .doubleword_provider import DoublewordProvider
+    from .self_critique import parse_critique_json
+    provider = DoublewordProvider()
+    raw = await provider.prompt_only(
+        prompt=f"{_RULES}\n\nDIFF:\n{diff}",
+        caller_id="pr_self_linter",
+        response_format={"type": "json_object"},
+        max_tokens=512,
+    )
+    parsed, _ok = parse_critique_json(raw, op_id="pr_self_linter")
+    return parsed
+
+
+async def acquire_lint_cleared_token(
+    *,
+    op_id: str,
+    diff: str,
+    chain: DAGProofChain,
+    prev_token: CapabilityToken,
+    critique_fn: Optional[Callable[[str], Awaitable[dict]]] = None,
+    threshold: Optional[int] = None,
+) -> LintClearedToken:
+    _crit = critique_fn or default_critique_fn
+    _thr = threshold if threshold is not None else _threshold()
+    verdict = await _crit(diff)
+    rating = int(verdict.get("rating", 0))
+    if rating < _thr:
+        raise LintRejected(
+            f"op={op_id} rating={rating}<{_thr} concerns={verdict.get('concerns')}")
+    token = chain.mint(
+        kind=TokenKind.LINT_CLEARED,
+        op_id=op_id,
+        state_binding=hashlib.sha256(diff.encode("utf-8")).hexdigest(),
+        payload={"rating": str(rating)},
+        prev=prev_token,
+    )
+    return token  # type: ignore[return-value]

--- a/backend/core/ouroboros/governance/pre_apply_exec_lock.py
+++ b/backend/core/ouroboros/governance/pre_apply_exec_lock.py
@@ -45,6 +45,7 @@ async def acquire_sandbox_execution_token(
     docker_available: Optional[Callable[[], bool]] = None,
     runner: Optional[Callable[..., Awaitable]] = None,
     sandbox_image: Optional[Callable[[], str]] = None,
+    branch_context: str = "",
 ) -> SandboxExecutionToken:
     """Run the candidate in a hardened L4 container; mint a token iff exit==0.
 
@@ -82,6 +83,7 @@ async def acquire_sandbox_execution_token(
             "py_files": str(len([p for p, _ in candidate_files if p.endswith(".py")])),
         },
         prev=prev_token,
+        branch_context=branch_context,
     )
     return token  # type: ignore[return-value]  # mint() returns the typed subclass
 

--- a/backend/core/ouroboros/governance/pre_apply_exec_lock.py
+++ b/backend/core/ouroboros/governance/pre_apply_exec_lock.py
@@ -96,7 +96,7 @@ async def docker_preflight(*, probe=None) -> bool:
     """
     import asyncio
     from . import container_sandbox
-    _probe = probe or container_sandbox.docker_available
+    _probe = probe if probe is not None else container_sandbox.docker_available
     available = await asyncio.get_running_loop().run_in_executor(None, _probe)
     if not available and lock_enabled():
         logger.warning(

--- a/backend/core/ouroboros/governance/pre_apply_exec_lock.py
+++ b/backend/core/ouroboros/governance/pre_apply_exec_lock.py
@@ -86,6 +86,25 @@ async def acquire_sandbox_execution_token(
     return token  # type: ignore[return-value]  # mint() returns the typed subclass
 
 
+async def docker_preflight(*, probe=None) -> bool:
+    """Async, non-blocking daemon ping run once at A1-loop start.
+
+    Surfaces Docker absence BEFORE an op reaches APPLY, so the orchestrator
+    can flag REQUIRES_CLOUD_EXECUTION early rather than failing mid-DAG.
+    Default-OFF safety: only warns when lock_enabled(); otherwise just returns
+    the bool with no side effects.
+    """
+    import asyncio
+    from . import container_sandbox
+    _probe = probe or container_sandbox.docker_available
+    available = await asyncio.get_running_loop().run_in_executor(None, _probe)
+    if not available and lock_enabled():
+        logger.warning(
+            "[Gate1] Docker daemon ABSENT at preflight -- ops will route REQUIRES_CLOUD_EXECUTION"
+        )
+    return available
+
+
 def _build_probe(candidate_files: Sequence[Tuple[str, str]]) -> str:
     """A deterministic compile-check payload over the candidate's .py files."""
     py = [p for p, _ in candidate_files if p.endswith(".py")]

--- a/backend/core/ouroboros/governance/pre_apply_exec_lock.py
+++ b/backend/core/ouroboros/governance/pre_apply_exec_lock.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+import hashlib
+import logging
+import os
+from typing import Awaitable, Callable, Optional, Sequence, Tuple
+
+from .dag_capability_token import (
+    CapabilityToken, DAGProofChain, SandboxExecutionToken, TokenKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxLockFailed(RuntimeError):
+    """Candidate failed to compile/run in the L4 container -- terminate the DAG."""
+
+
+class RequiresCloudExecution(RuntimeError):
+    """No local Docker daemon -- strict L4 policy forbids a process downgrade.
+
+    Phase 1: terminate + flag the op. Phase 2: route execution to the GCP node.
+    """
+
+
+def lock_enabled() -> bool:
+    return os.environ.get("JARVIS_A1_SANDBOX_LOCK_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
+def _candidate_hash(candidate_files: Sequence[Tuple[str, str]]) -> str:
+    h = hashlib.sha256()
+    for path, content in sorted(candidate_files):
+        h.update(path.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(content.encode("utf-8"))
+    return h.hexdigest()
+
+
+async def acquire_sandbox_execution_token(
+    *,
+    op_id: str,
+    candidate_files: Sequence[Tuple[str, str]],
+    repo_root: str,
+    chain: DAGProofChain,
+    prev_token: Optional[CapabilityToken] = None,
+    docker_available: Optional[Callable[[], bool]] = None,
+    runner: Optional[Callable[..., Awaitable]] = None,
+) -> SandboxExecutionToken:
+    """Run the candidate in a hardened L4 container; mint a token iff exit==0.
+
+    Strict container-only: no Docker -> RequiresCloudExecution (no fallback).
+    Any non-zero exit / containment breach -> SandboxLockFailed (nothing is
+    written to the real tree; the caller terminates the DAG).
+    """
+    from . import container_sandbox  # lazy import keeps module load cheap
+
+    _docker = docker_available or container_sandbox.docker_available
+    if not _docker():
+        raise RequiresCloudExecution(f"op={op_id} no local Docker daemon")
+
+    _run = runner or container_sandbox.run_in_container
+    # Build a compile+import probe over the candidate's changed modules.
+    probe = _build_probe(candidate_files)
+    result = await _run(code=probe, worktree=repo_root, op_id=op_id)
+
+    exit_code = getattr(result, "exit_code", 1)
+    breached = bool(getattr(result, "breached", False))
+    if exit_code != 0 or breached:
+        raise SandboxLockFailed(
+            f"op={op_id} exit={exit_code} breached={breached} "
+            f"diag={getattr(result, 'diagnostic', '')}")
+
+    state_binding = _candidate_hash(candidate_files)
+    token = chain.mint(
+        kind=TokenKind.SANDBOX_EXECUTION,
+        op_id=op_id,
+        state_binding=state_binding,
+        payload={"exit_code": "0", "image": container_sandbox.sandbox_image()},
+        prev=prev_token,
+    )
+    return token  # type: ignore[return-value]  # mint() returns the typed subclass
+
+
+def _build_probe(candidate_files: Sequence[Tuple[str, str]]) -> str:
+    """A deterministic compile-check payload over the candidate's .py files."""
+    py = [p for p, _ in candidate_files if p.endswith(".py")]
+    listing = ",".join(repr(p) for p in py)
+    return (
+        "import py_compile, sys\n"
+        f"paths = [{listing}]\n"
+        "for p in paths:\n"
+        "    py_compile.compile(p, doraise=True)\n"
+        "print('compile-ok')\n"
+    )

--- a/backend/core/ouroboros/governance/pre_apply_exec_lock.py
+++ b/backend/core/ouroboros/governance/pre_apply_exec_lock.py
@@ -44,6 +44,7 @@ async def acquire_sandbox_execution_token(
     prev_token: Optional[CapabilityToken] = None,
     docker_available: Optional[Callable[[], bool]] = None,
     runner: Optional[Callable[..., Awaitable]] = None,
+    sandbox_image: Optional[Callable[[], str]] = None,
 ) -> SandboxExecutionToken:
     """Run the candidate in a hardened L4 container; mint a token iff exit==0.
 
@@ -58,6 +59,7 @@ async def acquire_sandbox_execution_token(
         raise RequiresCloudExecution(f"op={op_id} no local Docker daemon")
 
     _run = runner or container_sandbox.run_in_container
+    _image = sandbox_image or container_sandbox.sandbox_image
     # Build a compile+import probe over the candidate's changed modules.
     probe = _build_probe(candidate_files)
     result = await _run(code=probe, worktree=repo_root, op_id=op_id)
@@ -74,7 +76,11 @@ async def acquire_sandbox_execution_token(
         kind=TokenKind.SANDBOX_EXECUTION,
         op_id=op_id,
         state_binding=state_binding,
-        payload={"exit_code": "0", "image": container_sandbox.sandbox_image()},
+        payload={
+            "exit_code": "0",
+            "image": _image(),
+            "py_files": str(len([p for p, _ in candidate_files if p.endswith(".py")])),
+        },
         prev=prev_token,
     )
     return token  # type: ignore[return-value]  # mint() returns the typed subclass

--- a/backend/core/ouroboros/governance/reverse_dep_resolver.py
+++ b/backend/core/ouroboros/governance/reverse_dep_resolver.py
@@ -153,6 +153,7 @@ def _build_forward_import_graph(root: str) -> Dict[str, Set[str]]:
         module = _module_from_relpath(rel)
         if not module:
             continue
+        is_init = rel == "__init__.py" or rel.endswith("/__init__.py")
         try:
             source = py_file.read_text(encoding="utf-8", errors="replace")
             tree = _ast.parse(source, filename=str(py_file))
@@ -167,19 +168,67 @@ def _build_forward_import_graph(root: str) -> Dict[str, Set[str]]:
                     if alias.name:
                         imports.add(alias.name)
             elif isinstance(node, _ast.ImportFrom):
-                # Ignore relative imports (level > 0) -- they cannot be mapped
-                # to a stable dotted name without package context; the absolute
-                # forms below cover the synthetic + production flat cases.
-                mod = node.module or ""
                 if node.level and node.level > 0:
-                    continue
-                if mod:
-                    imports.add(mod)
-                    for alias in node.names:
-                        if alias.name:
-                            imports.add(f"{mod}.{alias.name}")
+                    # Relative import -- resolve against the importing module's
+                    # package using CPython's algorithm, so intra-package edges
+                    # (``from . import sib``) stay visible to the reverse graph.
+                    _add_relative_import_edges(imports, module, is_init, node)
+                else:
+                    mod = node.module or ""
+                    if mod:
+                        imports.add(mod)
+                        for alias in node.names:
+                            if alias.name:
+                                imports.add(f"{mod}.{alias.name}")
 
     return graph
+
+
+def _add_relative_import_edges(
+    imports: Set[str],
+    importing_module: str,
+    is_init: bool,
+    node: _ast.ImportFrom,
+) -> None:
+    """Resolve a relative ``ImportFrom`` to absolute dotted target(s) and add
+    the corresponding forward edges to *imports*.
+
+    Mirrors CPython's resolution: the importing module's package is the seed,
+    ``node.level`` walks upward. A relative import that escapes the tree (more
+    levels than the package is deep) is skipped safely -- never raises.
+    """
+    # Package of the importing module. ``_module_from_relpath`` already
+    # collapses ``pkg/__init__.py`` -> ``pkg``, so an __init__ module IS its
+    # own package; any other module's package drops its trailing leaf.
+    if is_init:
+        package = importing_module
+    elif "." in importing_module:
+        package = importing_module.rsplit(".", 1)[0]
+    else:
+        package = ""
+
+    pkg_parts = package.split(".") if package else []
+    drop = node.level - 1
+    if drop > len(pkg_parts):
+        # Escapes above the package tree -- not resolvable; skip safely.
+        return
+    base = ".".join(pkg_parts[: len(pkg_parts) - drop])
+
+    if node.module:
+        target_module = f"{base}.{node.module}" if base else node.module
+    else:
+        target_module = base
+
+    if target_module:
+        imports.add(target_module)
+    for alias in node.names:
+        if not alias.name:
+            continue
+        if target_module:
+            imports.add(f"{target_module}.{alias.name}")
+        elif not node.module:
+            # Top-level ``from . import x`` -> the top-level module ``x``.
+            imports.add(alias.name)
 
 
 def _invert(graph: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
@@ -351,8 +400,20 @@ async def resolve_reverse_dependency_tests(
         )
 
     # Fail-closed: at least one changed file must resolve to a module under root.
+    # Distinguish a config-only changeset (no ``.py`` at all -> nothing Python to
+    # analyze -> EMPTY result is correct) from a genuine build problem (``.py``
+    # present but unresolvable under root -> fail-closed raise). UNDER-inclusion
+    # of a real dependent test is the dangerous direction, so only the latter
+    # trips Gate (2)'s fail-closed guard.
     changed_modules = _changed_modules(changed_files, root)
     if not changed_modules:
+        has_py = any(
+            cf.replace("\\", "/").endswith(".py") for cf in changed_files
+        )
+        if not has_py:
+            # Config-only changeset (.yaml/.md/...): no Python changed -> no
+            # dependent tests. Empty set is the correct, valid answer.
+            return set()
         raise ReverseDepGraphError(
             "no changed file resolves to a module under repo_root "
             f"(changed_files={list(changed_files)!r})"
@@ -378,7 +439,7 @@ async def resolve_reverse_dependency_tests(
 
 async def _impacted_via_ast_async(changed_modules: Set[str], root: str) -> Set[str]:
     """Run the heavy AST build off the event loop via run_in_executor."""
-    loop = asyncio.get_event_loop()
+    loop = asyncio.get_running_loop()
     return await loop.run_in_executor(
         None, _impacted_via_ast, changed_modules, root
     )

--- a/backend/core/ouroboros/governance/reverse_dep_resolver.py
+++ b/backend/core/ouroboros/governance/reverse_dep_resolver.py
@@ -1,0 +1,384 @@
+"""Adaptive Hybrid Reverse-Dependency Resolver (Task 5b).
+
+Powers Gate (2) of the Iron Triad -- it answers "every test that transitively
+touches the modified code". It is the async ``graph_fn(scope_files) -> Set[str]``
+consumed by ``blast_radius_verify.acquire_blast_radius_token``.
+
+Design: an **adaptive hybrid** -- Oracle-first when the index is warm (the
+changed files are indexed), AST-fallback when the Oracle is cold, missing, or
+erroring. Both paths converge on an "impacted module set", which a shared
+``_modules_to_tests`` step maps to repo-relative test-file paths.
+
+Load-bearing guarantees:
+
+* **Cyclic Dependency Armor** -- the transitive reverse closure is ITERATIVE
+  (a ``collections.deque`` worklist + a ``visited`` set), never recursive. A
+  circular import (A <-> B) terminates via the ``visited`` set; a deep chain
+  (thousands deep) never raises ``RecursionError``. A cycle is RESOLVED, never
+  treated as a build failure.
+* **Fail-closed only on real build failure** -- ``ReverseDepGraphError`` is
+  raised ONLY when the graph genuinely cannot be built (unreadable
+  ``repo_root``, or no changed file resolves to a module under root). A
+  per-file syntax error in an UNRELATED file is skipped, not fatal. An empty
+  result (no dependent tests) is a VALID return.
+* **Oracle never breaks Gate 2** -- every Oracle interaction is wrapped in
+  try/except and falls back to the AST path on any error.
+
+Constraints: Python 3.9 (``asyncio.wait_for`` only, no ``asyncio.timeout``),
+ASCII-only, ``from __future__ import annotations``.
+"""
+
+from __future__ import annotations
+
+import ast as _ast
+import asyncio
+import collections
+import logging
+import os
+from pathlib import Path
+from typing import Dict, Sequence, Set
+
+logger = logging.getLogger(__name__)
+
+
+# Default reverse-reachability depth for the Oracle blast-radius call. The AST
+# path is unbounded (iterative closure); the Oracle path uses its own BFS, so
+# we ask for a generous depth to capture deep transitive impact.
+_ORACLE_MAX_DEPTH = 50
+
+
+# Test directory names -- mirrors test_runner's JARVIS_TEST_DIR_NAMES default.
+def _test_dir_names() -> frozenset:
+    return frozenset(
+        n.strip()
+        for n in os.environ.get("JARVIS_TEST_DIR_NAMES", "tests,test").split(",")
+        if n.strip()
+    )
+
+
+class ReverseDepGraphError(RuntimeError):
+    """Graph could not be built (IO error, unresolvable changed-file module).
+
+    Raised ONLY on a genuine build failure so Gate (2)'s fail-closed guard
+    fires. Cycles and empty results never raise.
+    """
+
+
+# ---------------------------------------------------------------------------
+# Module <-> path mapping
+# ---------------------------------------------------------------------------
+
+def _module_from_relpath(rel_path: str) -> str:
+    """Map a repo-relative ``*.py`` path to a dotted module name.
+
+    ``a.py`` -> ``a``; ``tests/test_c.py`` -> ``tests.test_c``;
+    ``pkg/__init__.py`` -> ``pkg``. Returns ``""`` for non-``.py`` paths.
+    """
+    rel = rel_path.replace("\\", "/").strip("/")
+    if not rel.endswith(".py"):
+        return ""
+    rel = rel[: -len(".py")]
+    parts = [p for p in rel.split("/") if p]
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts)
+
+
+def _relpath_under_root(file_path: str, root: str) -> str:
+    """Return *file_path* as a path relative to *root*, or ``""`` if it escapes
+    root or is not a ``.py`` file. Accepts already-relative paths."""
+    fp = file_path.replace("\\", "/")
+    if os.path.isabs(fp):
+        try:
+            rel = os.path.relpath(fp, root)
+        except ValueError:
+            return ""
+    else:
+        rel = fp
+    rel = rel.replace("\\", "/")
+    if rel.startswith("..") or rel.startswith("/"):
+        return ""
+    if not rel.endswith(".py"):
+        return ""
+    return rel
+
+
+def _changed_modules(changed_files: Sequence[str], root: str) -> Set[str]:
+    """Dotted modules of the changed files themselves (under root)."""
+    mods: Set[str] = set()
+    for cf in changed_files:
+        rel = _relpath_under_root(cf, root)
+        if not rel:
+            continue
+        mod = _module_from_relpath(rel)
+        if mod:
+            mods.add(mod)
+    return mods
+
+
+def _is_test_module(module: str, dir_names: frozenset) -> bool:
+    """True if *module* names a ``test_*.py`` file under a test directory."""
+    parts = module.split(".")
+    if not parts:
+        return False
+    leaf = parts[-1]
+    if not leaf.startswith("test_"):
+        return False
+    return any(p in dir_names for p in parts[:-1]) or (
+        # allow a top-level test_*.py only if it lives directly under a test dir
+        len(parts) > 1 and parts[0] in dir_names
+    )
+
+
+# ---------------------------------------------------------------------------
+# AST forward graph build + inversion + iterative closure
+# ---------------------------------------------------------------------------
+
+def _build_forward_import_graph(root: str) -> Dict[str, Set[str]]:
+    """AST-parse every ``*.py`` under *root*, mapping
+    ``dotted_module -> {dotted module names it imports}``.
+
+    Mirrors ``test_runner._build_test_import_map``: syntactically broken or
+    unreadable files are silently skipped (a broken UNRELATED file is not a
+    build failure). Wholesale IO failure is the caller's concern (it checks
+    ``os.path.isdir`` first).
+    """
+    graph: Dict[str, Set[str]] = {}
+    root_path = Path(root)
+
+    for py_file in root_path.rglob("*.py"):
+        if not py_file.is_file():
+            continue
+        rel = os.path.relpath(str(py_file), root).replace("\\", "/")
+        module = _module_from_relpath(rel)
+        if not module:
+            continue
+        try:
+            source = py_file.read_text(encoding="utf-8", errors="replace")
+            tree = _ast.parse(source, filename=str(py_file))
+        except (SyntaxError, OSError, UnicodeDecodeError, ValueError):
+            # Skip unrelated broken/unreadable files -- not a build failure.
+            continue
+
+        imports: Set[str] = graph.setdefault(module, set())
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.Import):
+                for alias in node.names:
+                    if alias.name:
+                        imports.add(alias.name)
+            elif isinstance(node, _ast.ImportFrom):
+                # Ignore relative imports (level > 0) -- they cannot be mapped
+                # to a stable dotted name without package context; the absolute
+                # forms below cover the synthetic + production flat cases.
+                mod = node.module or ""
+                if node.level and node.level > 0:
+                    continue
+                if mod:
+                    imports.add(mod)
+                    for alias in node.names:
+                        if alias.name:
+                            imports.add(f"{mod}.{alias.name}")
+
+    return graph
+
+
+def _invert(graph: Dict[str, Set[str]]) -> Dict[str, Set[str]]:
+    """Invert ``importer -> {imported}`` into ``imported -> {importers}``."""
+    reverse: Dict[str, Set[str]] = {}
+    for importer, imported_set in graph.items():
+        for imported in imported_set:
+            reverse.setdefault(imported, set()).add(importer)
+    return reverse
+
+
+def _transitive_reverse_closure(
+    reverse_graph: Dict[str, Set[str]],
+    seed_modules: Set[str],
+) -> Set[str]:
+    """Iterative reverse reachability -- THE cyclic-dependency armor.
+
+    Uses a ``deque`` worklist + a ``visited`` set. A cycle (A <-> B) terminates
+    because re-encountered nodes are not re-queued; a deep chain never recurses,
+    so no ``RecursionError``. Returns every module reachable by following
+    "imported-by" edges from the seeds (seeds excluded from the result).
+    """
+    visited: Set[str] = set(seed_modules)
+    worklist = collections.deque(seed_modules)
+
+    while worklist:
+        current = worklist.popleft()
+        for importer in reverse_graph.get(current, ()):  # cheap miss -> ()
+            if importer not in visited:
+                visited.add(importer)
+                worklist.append(importer)
+
+    return visited - set(seed_modules)
+
+
+def _impacted_via_ast(changed_modules: Set[str], root: str) -> Set[str]:
+    """Build the forward graph, invert it, and return the transitive reverse
+    closure of *changed_modules*. Cycle-armored (iterative)."""
+    forward = _build_forward_import_graph(root)
+    reverse = _invert(forward)
+    return _transitive_reverse_closure(reverse, changed_modules)
+
+
+# ---------------------------------------------------------------------------
+# Oracle path
+# ---------------------------------------------------------------------------
+
+def _oracle_can_answer(
+    oracle: object,
+    changed_files: Sequence[str],
+    root: str,
+) -> bool:
+    """Warmth check: are ALL changed files indexed by the Oracle?
+
+    Returns True only if every changed file resolves to >= 1 node via
+    ``find_nodes_in_file``. Any Oracle error -> False (fall back to AST; the
+    Oracle can never break Gate 2). An empty ``changed_files`` -> False.
+    """
+    find_nodes = getattr(oracle, "find_nodes_in_file", None)
+    if find_nodes is None:
+        return False
+    try:
+        any_file = False
+        for cf in changed_files:
+            rel = _relpath_under_root(cf, root)
+            if not rel:
+                continue
+            any_file = True
+            nodes = find_nodes(rel)
+            if not nodes:
+                return False
+        return any_file
+    except Exception:  # noqa: BLE001 -- Oracle must never break Gate 2
+        logger.debug("Oracle warmth check failed; falling back to AST", exc_info=True)
+        return False
+
+
+def _impacted_via_oracle(
+    oracle: object,
+    changed_files: Sequence[str],
+    root: str,
+) -> Set[str]:
+    """Transitive impacted modules via the Oracle blast radius.
+
+    For each changed file's nodes, union ``directly_affected`` and
+    ``transitively_affected`` and map each affected NodeID to its dotted module
+    via ``NodeID.file_path``.
+    """
+    impacted: Set[str] = set()
+    for cf in changed_files:
+        rel = _relpath_under_root(cf, root)
+        if not rel:
+            continue
+        for node in oracle.find_nodes_in_file(rel):  # type: ignore[attr-defined]
+            blast = oracle.compute_blast_radius(  # type: ignore[attr-defined]
+                node, max_depth=_ORACLE_MAX_DEPTH
+            )
+            affected = set(getattr(blast, "directly_affected", set()))
+            affected |= set(getattr(blast, "transitively_affected", set()))
+            for affected_node in affected:
+                node_fp = getattr(affected_node, "file_path", None)
+                if not node_fp:
+                    continue
+                mod = _module_from_relpath(node_fp.replace("\\", "/"))
+                if mod:
+                    impacted.add(mod)
+    return impacted
+
+
+# ---------------------------------------------------------------------------
+# Shared module -> tests mapping
+# ---------------------------------------------------------------------------
+
+def _modules_to_tests(modules: Set[str], root: str) -> Set[str]:
+    """Select the test files among *modules* and add name-convention matches.
+
+    A module is a test if it names ``test_*.py`` under a test directory. Plus
+    name-convention resolution: a changed/impacted ``foo`` whose sibling
+    ``test_foo.py`` (or ``tests/test_foo.py``) exists on disk is included.
+    Returns repo-relative test paths.
+    """
+    dir_names = _test_dir_names()
+    tests: Set[str] = set()
+
+    for module in modules:
+        if _is_test_module(module, dir_names):
+            tests.add(module.replace(".", "/") + ".py")
+            continue
+        # Name-convention: foo -> test_foo.py (sibling) or tests/test_foo.py.
+        parts = module.split(".")
+        leaf = parts[-1]
+        prefix = parts[:-1]
+        candidates = []
+        sibling = "/".join(prefix + [f"test_{leaf}.py"])
+        candidates.append(sibling)
+        for tdn in sorted(dir_names):
+            candidates.append(f"{tdn}/test_{leaf}.py")
+        for cand in candidates:
+            if (Path(root) / cand).is_file():
+                tests.add(cand)
+
+    return tests
+
+
+# ---------------------------------------------------------------------------
+# Public facade
+# ---------------------------------------------------------------------------
+
+async def resolve_reverse_dependency_tests(
+    changed_files: Sequence[str],
+    *,
+    repo_root: str,
+    oracle: object | None = None,
+) -> Set[str]:
+    """Resolve the set of repo-relative test files that transitively touch
+    *changed_files*.
+
+    Adaptive hybrid: Oracle-first when warm, AST-fallback otherwise. Raises
+    ``ReverseDepGraphError`` only on a genuine build failure (unreadable
+    ``repo_root``, or no changed file resolves to a module under root). An empty
+    result is a VALID return.
+    """
+    root = os.path.abspath(repo_root)
+
+    # Fail-closed: repo_root must be a readable directory.
+    if not os.path.isdir(root):
+        raise ReverseDepGraphError(
+            f"repo_root is not a readable directory: {repo_root!r}"
+        )
+
+    # Fail-closed: at least one changed file must resolve to a module under root.
+    changed_modules = _changed_modules(changed_files, root)
+    if not changed_modules:
+        raise ReverseDepGraphError(
+            "no changed file resolves to a module under repo_root "
+            f"(changed_files={list(changed_files)!r})"
+        )
+
+    impacted: Set[str]
+
+    # Oracle-first (warm) -- guarded so the Oracle can never break Gate 2.
+    if oracle is not None and _oracle_can_answer(oracle, changed_files, root):
+        try:
+            impacted = _impacted_via_oracle(oracle, changed_files, root)
+        except Exception:  # noqa: BLE001 -- fall back to AST on any Oracle error
+            logger.debug(
+                "Oracle blast-radius failed; falling back to AST", exc_info=True
+            )
+            impacted = await _impacted_via_ast_async(changed_modules, root)
+    else:
+        impacted = await _impacted_via_ast_async(changed_modules, root)
+
+    all_modules = impacted | changed_modules
+    return _modules_to_tests(all_modules, root)
+
+
+async def _impacted_via_ast_async(changed_modules: Set[str], root: str) -> Set[str]:
+    """Run the heavy AST build off the event loop via run_in_executor."""
+    loop = asyncio.get_event_loop()
+    return await loop.run_in_executor(
+        None, _impacted_via_ast, changed_modules, root
+    )

--- a/backend/core/ouroboros/governance/token_audit.py
+++ b/backend/core/ouroboros/governance/token_audit.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+from .dag_capability_token import CapabilityToken
+
+logger = logging.getLogger(__name__)
+_SCHEMA_VERSION = 1
+
+
+def _enabled() -> bool:
+    return os.environ.get("JARVIS_TOKEN_AUDIT_ENABLED", "true").strip().lower() in ("1", "true", "yes")
+
+
+def _default_path() -> str:
+    return os.environ.get("JARVIS_TOKEN_AUDIT_PATH", os.path.join(".jarvis", "token_audit.jsonl"))
+
+
+def _max() -> int:
+    try:
+        return int(os.environ.get("JARVIS_TOKEN_AUDIT_MAX", "500"))
+    except ValueError:
+        return 500
+
+
+def append_mint(token: CapabilityToken, *, path: Optional[str] = None) -> None:
+    """Durably append a token-mint record. Fail-soft -- never raises.
+
+    The HMAC ``sig`` is recorded as audit evidence; the SECRET is never written.
+    """
+    if not _enabled():
+        return
+    p = path if path is not None else _default_path()
+    record = {
+        "ts": time.time(),
+        "schema_version": _SCHEMA_VERSION,
+        "kind": token.kind.value,
+        "op_id": token.op_id,
+        "state_binding": token.state_binding,
+        "prev_hash": token.prev_hash,
+        "sig": token.sig,
+        "payload": dict(token.payload),
+    }
+    try:
+        os.makedirs(os.path.dirname(p) or ".", exist_ok=True)
+        with open(p, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        _trim(p)
+    except Exception as exc:  # noqa: BLE001 -- audit is best-effort
+        logger.warning("[TokenAudit] append failed: %s", exc)
+
+
+def _trim(p: str) -> None:
+    try:
+        with open(p, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+        cap = _max()
+        if len(lines) > cap:
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.writelines(lines[-cap:])
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def read_audit(path: Optional[str] = None) -> List[Dict[str, Any]]:
+    p = path if path is not None else _default_path()
+    try:
+        with open(p, "r", encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+    except FileNotFoundError:
+        return []

--- a/backend/core/ouroboros/governance/workspace_checkpoint.py
+++ b/backend/core/ouroboros/governance/workspace_checkpoint.py
@@ -203,5 +203,45 @@ class WorkspaceCheckpointManager:
         )
         return False
 
+    async def tree_sha_for_ref(self, ref: str) -> str:
+        """Deterministic content TREE sha for a commit/ref. Empty/falsy ref -> HEAD.
+
+        ``git stash create`` returns a timestamped COMMIT sha; its ``^{tree}`` is
+        the content-addressed tree, identical for identical content.
+        """
+        target = (ref or "").strip() or "HEAD"
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git", "rev-parse", f"{target}^{{tree}}",
+                cwd=str(self._project_root),
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+        except (asyncio.TimeoutError, OSError) as exc:
+            logger.warning("[Checkpoint] tree_sha_for_ref(%s) failed: %s", target, exc)
+            return ""
+        if proc.returncode != 0:
+            return ""
+        return stdout.decode().strip()
+
+    async def working_tree_content_sha(self) -> str:
+        """Deterministic content TREE sha of the CURRENT working tree.
+
+        ``git stash create`` snapshots the WIP (empty output when clean -> HEAD),
+        then we resolve its ``^{tree}``.
+        """
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                "git", "stash", "create",
+                cwd=str(self._project_root),
+                stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.PIPE,
+            )
+            stdout, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
+        except (asyncio.TimeoutError, OSError) as exc:
+            logger.warning("[Checkpoint] working_tree_content_sha stash create failed: %s", exc)
+            return ""
+        ref = stdout.decode().strip()  # empty when the tree is clean
+        return await self.tree_sha_for_ref(ref)  # empty -> HEAD inside the helper
+
     def list_checkpoints(self) -> List[Checkpoint]:
         return list(self._checkpoints)

--- a/docs/superpowers/plans/2026-06-29-iron-triad-a1-gate.md
+++ b/docs/superpowers/plans/2026-06-29-iron-triad-a1-gate.md
@@ -1,0 +1,1502 @@
+# Iron Triad — A1 Gate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Bind the autonomous Ouroboros→PR path with three fail-closed gates chained by unforgeable capability tokens, so O+V can complete its first full autonomous cycle E2E (close the A1 gate).
+
+**Architecture:** Three thin gates on the single mandatory generate→PR path — ① pre-APPLY L4 container exec lock, ② post-VERIFY blast-radius regression, ③ pre-PR LLM linter. Each mints a state-bound HMAC capability token; `gh pr create` requires the typed token objects as mandatory arguments and re-verifies the hash chain. ~90% reuse of existing machinery; the spine (`dag_capability_token.py`) is the only substantial net-new module. Every token mint is durably appended to an immutable WAL.
+
+**Tech Stack:** Python 3.9+ (asyncio, `from __future__ import annotations`), `hmac`/`hashlib`/`secrets` (stdlib), pytest. Reuses `container_sandbox`, `IsomorphicEnv`, `WorktreeManager`, `WorkspaceCheckpointManager`, `call_graph_blast`/`blast_radius_adapter`, `intake_dlq`, `self_critique`, `DoublewordProvider`, `OrangePRReviewer`, `outage_ledger` (WAL pattern).
+
+## Global Constraints
+
+- **Spec:** `docs/superpowers/specs/2026-06-29-iron-triad-a1-gate-design.md` (authoritative).
+- **Async-first:** all I/O via `asyncio`; `asyncio.wait_for` (never `asyncio.timeout` — Python 3.9 floor).
+- **`from __future__ import annotations`** at the top of every new file.
+- **No hardcoded models:** any LLM call resolves provider via existing policy/`DoublewordProvider`.
+- **Env-var-driven, default-OFF:** `JARVIS_A1_TOKEN_ENFORCER_ENABLED`, `JARVIS_A1_SANDBOX_LOCK_ENABLED`, `JARVIS_A1_BLAST_RADIUS_ENABLED`, `JARVIS_A1_PR_LINTER_ENABLED`, `JARVIS_TOKEN_AUDIT_ENABLED` — all read with sensible defaults; the four A1 gates default **false** (byte-identical legacy rollback), WAL defaults **true**.
+- **Fail-closed:** gates never return a falsy token; on failure they raise a typed exception the FSM routes to terminate/rollback/Cryo-DLQ.
+- **No `git reset --hard`** in the apply path — rollback is `WorkspaceCheckpointManager.restore_checkpoint` + post-restore tree-SHA equality assertion.
+- **Secret hygiene:** the per-process HMAC secret (`secrets.token_bytes(32)`) lives only in memory; never logged, persisted, or written to the WAL.
+- **ASCII-only** source (Iron Gate ASCII strictness).
+- **Commit hygiene:** `git add` only the named files for each task; never `-A`/`.`.
+
+---
+
+## File Structure
+
+| File | Responsibility | Task |
+|---|---|---|
+| `backend/core/ouroboros/governance/dag_capability_token.py` | CREATE — token types, `DAGProofChain` (mint/verify/verify_chain), per-process secret | 1 |
+| `backend/core/ouroboros/governance/token_audit.py` | CREATE — immutable append-only WAL for token mints (mirrors `outage_ledger`) | 2 |
+| `backend/core/ouroboros/governance/pre_apply_exec_lock.py` | CREATE — Gate ① isomorphic L4 container exec lock | 3 |
+| `backend/core/ouroboros/governance/orchestrator.py` | MODIFY — wire Gate ① post-IronGate/pre-VALIDATE; Docker pre-flight + `REQUIRES_CLOUD_EXECUTION` | 4, 9 |
+| `backend/core/ouroboros/governance/blast_radius_verify.py` | CREATE — Gate ② reverse-dep regression + fail-closed graph guard | 5 |
+| `backend/core/ouroboros/governance/phase_runners/slice4b_runner.py` | MODIFY — capture pre-op tree-SHA; wire Gate ② between verify-gate and auto-commit | 6 |
+| `backend/core/ouroboros/governance/pr_self_linter.py` | CREATE — Gate ③ blocking LLM architectural-rules critique | 7 |
+| `backend/core/ouroboros/governance/orange_pr_reviewer.py` | MODIFY — token-gated `create_review_pr` signature + `verify_chain` | 8 |
+| `backend/core/ouroboros/governance/flag_registry.py` (seed) | MODIFY — register the 5 new flags | 10 |
+| Tests under `tests/governance/` | CREATE — one suite per module | 1–8 |
+
+---
+
+## Task 1: Capability-token enforcer (adversarial TDD first)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/dag_capability_token.py`
+- Test: `tests/governance/test_dag_capability_token.py`
+
+**Interfaces:**
+- Produces: `TokenKind` (enum), `CapabilityToken` (frozen), typed aliases `SandboxExecutionToken`/`BlastRadiusClearedToken`/`LintClearedToken`, `DAGProofChain` with `mint(*, kind, op_id, state_binding, payload, prev=None) -> CapabilityToken`, `verify(token) -> bool`, `verify_chain(tokens, *, op_id) -> bool`, and `token.digest() -> str`.
+
+- [ ] **Step 1: Write the failing adversarial tests** (attack `verify`/`verify_chain` before any implementation exists)
+
+```python
+# tests/governance/test_dag_capability_token.py
+from __future__ import annotations
+import dataclasses
+import pytest
+from backend.core.ouroboros.governance.dag_capability_token import (
+    TokenKind, CapabilityToken, SandboxExecutionToken, BlastRadiusClearedToken,
+    LintClearedToken, DAGProofChain,
+)
+
+OP = "op-123"
+
+def _full_chain(chain: DAGProofChain, op_id: str = OP):
+    t1 = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=op_id,
+                    state_binding="cand-sha", payload={"exit_code": "0"})
+    t2 = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=op_id,
+                    state_binding="tree-sha", payload={"n_tests": "7"}, prev=t1)
+    t3 = chain.mint(kind=TokenKind.LINT_CLEARED, op_id=op_id,
+                    state_binding="diff-sha", payload={"rating": "5"}, prev=t2)
+    return t1, t2, t3
+
+def test_valid_chain_passes():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert chain.verify(t1) and chain.verify(t2) and chain.verify(t3)
+    assert chain.verify_chain([t1, t2, t3], op_id=OP) is True
+
+def test_typed_aliases_match_kind():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert isinstance(t1, SandboxExecutionToken)
+    assert isinstance(t2, BlastRadiusClearedToken)
+    assert isinstance(t3, LintClearedToken)
+
+def test_forged_hmac_rejected():
+    chain = DAGProofChain()
+    t1, _, _ = _full_chain(chain)
+    forged = dataclasses.replace(t1, sig="deadbeef" * 8)
+    assert chain.verify(forged) is False
+    assert chain.verify_chain([forged, *_full_chain(chain)[1:]], op_id=OP) is False
+
+def test_replayed_state_binding_rejected():
+    # A token signed for state A cannot be re-pointed at state B.
+    chain = DAGProofChain()
+    t1, _, _ = _full_chain(chain)
+    replayed = dataclasses.replace(t1, state_binding="DIFFERENT-sha")
+    assert chain.verify(replayed) is False
+
+def test_cross_secret_forgery_rejected():
+    # A token minted by a different process/secret never verifies here.
+    foreign = DAGProofChain()
+    t1, _, _ = _full_chain(foreign)
+    local = DAGProofChain()
+    assert local.verify(t1) is False
+
+def test_out_of_order_chain_rejected():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert chain.verify_chain([t2, t1, t3], op_id=OP) is False
+
+def test_omitted_token_rejected():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert chain.verify_chain([t1, t3], op_id=OP) is False
+
+def test_tampered_prev_hash_rejected():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    broken = dataclasses.replace(t2, prev_hash="0" * 64)
+    assert chain.verify_chain([t1, broken, t3], op_id=OP) is False
+
+def test_cross_op_token_rejected():
+    chain = DAGProofChain()
+    good = _full_chain(chain, op_id=OP)
+    intruder = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id="other-op",
+                          state_binding="tree-sha", payload={}, prev=good[0])
+    assert chain.verify_chain([good[0], intruder, good[2]], op_id=OP) is False
+
+def test_wrong_terminal_kind_rejected():
+    # The final token MUST be LINT_CLEARED.
+    chain = DAGProofChain()
+    t1 = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=OP, state_binding="a", payload={})
+    t2 = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=OP, state_binding="b", payload={}, prev=t1)
+    assert chain.verify_chain([t1, t2], op_id=OP) is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/governance/test_dag_capability_token.py -q`
+Expected: FAIL with `ModuleNotFoundError: dag_capability_token`.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# backend/core/ouroboros/governance/dag_capability_token.py
+from __future__ import annotations
+import dataclasses
+import enum
+import hashlib
+import hmac
+import json
+import secrets
+import time
+from dataclasses import dataclass
+from typing import Mapping, Optional, Sequence
+
+
+class TokenKind(str, enum.Enum):
+    SANDBOX_EXECUTION = "sandbox_execution"
+    BLAST_RADIUS_CLEARED = "blast_radius_cleared"
+    LINT_CLEARED = "lint_cleared"
+
+
+# Canonical order of the gate chain. The terminal token MUST be LINT_CLEARED.
+_CHAIN_ORDER = (
+    TokenKind.SANDBOX_EXECUTION,
+    TokenKind.BLAST_RADIUS_CLEARED,
+    TokenKind.LINT_CLEARED,
+)
+
+_SESSION_SECRET: Optional[bytes] = None
+
+
+def _session_secret() -> bytes:
+    """Per-process HMAC secret. In-memory only; never logged or persisted."""
+    global _SESSION_SECRET
+    if _SESSION_SECRET is None:
+        _SESSION_SECRET = secrets.token_bytes(32)
+    return _SESSION_SECRET
+
+
+def _canonical(kind: TokenKind, op_id: str, state_binding: str,
+               prev_hash: str, payload: Mapping[str, str]) -> bytes:
+    return json.dumps(
+        {
+            "kind": kind.value,
+            "op_id": op_id,
+            "state_binding": state_binding,
+            "prev_hash": prev_hash,
+            "payload": {str(k): str(v) for k, v in payload.items()},
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+@dataclass(frozen=True)
+class CapabilityToken:
+    kind: TokenKind
+    op_id: str
+    state_binding: str
+    prev_hash: str
+    payload: Mapping[str, str]
+    issued_monotonic: float
+    sig: str
+
+    def digest(self) -> str:
+        """Identity hash used as the next token's ``prev_hash`` (chain link)."""
+        body = _canonical(self.kind, self.op_id, self.state_binding,
+                          self.prev_hash, self.payload)
+        return hashlib.sha256(body + self.sig.encode("utf-8")).hexdigest()
+
+
+# Typed aliases — frozen subclasses add no fields, so the parent __init__ is
+# inherited. A function can demand the SPECIFIC type as a mandatory argument.
+class SandboxExecutionToken(CapabilityToken):
+    pass
+
+
+class BlastRadiusClearedToken(CapabilityToken):
+    pass
+
+
+class LintClearedToken(CapabilityToken):
+    pass
+
+
+_KIND_CLS = {
+    TokenKind.SANDBOX_EXECUTION: SandboxExecutionToken,
+    TokenKind.BLAST_RADIUS_CLEARED: BlastRadiusClearedToken,
+    TokenKind.LINT_CLEARED: LintClearedToken,
+}
+
+
+class DAGProofChain:
+    """Per-op accumulator that mints/verifies unforgeable capability tokens."""
+
+    def __init__(self, *, secret: Optional[bytes] = None) -> None:
+        self._secret = secret if secret is not None else _session_secret()
+
+    def _sign(self, kind: TokenKind, op_id: str, state_binding: str,
+              prev_hash: str, payload: Mapping[str, str]) -> str:
+        return hmac.new(
+            self._secret,
+            _canonical(kind, op_id, state_binding, prev_hash, payload),
+            hashlib.sha256,
+        ).hexdigest()
+
+    def mint(self, *, kind: TokenKind, op_id: str, state_binding: str,
+             payload: Mapping[str, str],
+             prev: Optional[CapabilityToken] = None) -> CapabilityToken:
+        prev_hash = prev.digest() if prev is not None else ""
+        norm = {str(k): str(v) for k, v in payload.items()}
+        sig = self._sign(kind, op_id, state_binding, prev_hash, norm)
+        cls = _KIND_CLS[kind]
+        token = cls(kind, op_id, state_binding, prev_hash, norm,
+                    time.monotonic(), sig)
+        return token
+
+    def verify(self, token: CapabilityToken) -> bool:
+        expected = self._sign(token.kind, token.op_id, token.state_binding,
+                              token.prev_hash, token.payload)
+        return hmac.compare_digest(expected, token.sig)
+
+    def verify_chain(self, tokens: Sequence[CapabilityToken], *, op_id: str) -> bool:
+        if len(tokens) != len(_CHAIN_ORDER):
+            return False
+        prev_hash = ""
+        for token, expected_kind in zip(tokens, _CHAIN_ORDER):
+            if token.kind != expected_kind:
+                return False
+            if not isinstance(token, _KIND_CLS[expected_kind]):
+                return False
+            if token.op_id != op_id:
+                return False
+            if token.prev_hash != prev_hash:
+                return False
+            if not self.verify(token):
+                return False
+            prev_hash = token.digest()
+        return True
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/governance/test_dag_capability_token.py -q`
+Expected: PASS (11 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/dag_capability_token.py tests/governance/test_dag_capability_token.py
+git commit -m "feat(a1): cryptographic DAG capability-token enforcer (adversarial TDD)"
+```
+
+---
+
+## Task 2: Immutable token-mint WAL (audit trail)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/token_audit.py`
+- Modify: `backend/core/ouroboros/governance/dag_capability_token.py` (call WAL on mint)
+- Test: `tests/governance/test_token_audit.py`
+
+**Interfaces:**
+- Consumes: `CapabilityToken` (Task 1).
+- Produces: `append_mint(token: CapabilityToken, *, path: str | None = None) -> None` (fail-soft, never raises); `read_audit(path=None) -> list[dict]`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_token_audit.py
+from __future__ import annotations
+import json
+from backend.core.ouroboros.governance import token_audit
+from backend.core.ouroboros.governance.dag_capability_token import DAGProofChain, TokenKind
+
+def test_append_mint_writes_durable_record(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TOKEN_AUDIT_ENABLED", "true")
+    p = tmp_path / "token_audit.jsonl"
+    chain = DAGProofChain()
+    tok = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id="op-9",
+                     state_binding="cand-sha", payload={"exit_code": "0"})
+    token_audit.append_mint(tok, path=str(p))
+    rows = [json.loads(line) for line in p.read_text().splitlines()]
+    assert rows[-1]["op_id"] == "op-9"
+    assert rows[-1]["kind"] == "sandbox_execution"
+    assert rows[-1]["state_binding"] == "cand-sha"
+    assert "sig" in rows[-1]
+    assert "secret" not in json.dumps(rows[-1])  # secret never persisted
+
+def test_append_mint_fail_soft_on_bad_path(tmp_path):
+    chain = DAGProofChain()
+    tok = chain.mint(kind=TokenKind.LINT_CLEARED, op_id="op-9",
+                     state_binding="x", payload={})
+    # Unwritable path must NOT raise.
+    token_audit.append_mint(tok, path="/nonexistent-dir/deep/none.jsonl")
+
+def test_disabled_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TOKEN_AUDIT_ENABLED", "false")
+    p = tmp_path / "audit.jsonl"
+    chain = DAGProofChain()
+    tok = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id="op-1",
+                     state_binding="a", payload={})
+    token_audit.append_mint(tok, path=str(p))
+    assert not p.exists()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_token_audit.py -q`
+Expected: FAIL with `ModuleNotFoundError: token_audit`.
+
+- [ ] **Step 3: Write the WAL implementation (mirrors `outage_ledger` append-only ring)**
+
+```python
+# backend/core/ouroboros/governance/token_audit.py
+from __future__ import annotations
+import json
+import logging
+import os
+import time
+from typing import Any, Dict, List, Optional
+
+from .dag_capability_token import CapabilityToken
+
+logger = logging.getLogger(__name__)
+_SCHEMA_VERSION = 1
+
+
+def _enabled() -> bool:
+    return os.environ.get("JARVIS_TOKEN_AUDIT_ENABLED", "true").strip().lower() in ("1", "true", "yes")
+
+
+def _default_path() -> str:
+    return os.environ.get("JARVIS_TOKEN_AUDIT_PATH", os.path.join(".jarvis", "token_audit.jsonl"))
+
+
+def _max() -> int:
+    try:
+        return int(os.environ.get("JARVIS_TOKEN_AUDIT_MAX", "500"))
+    except ValueError:
+        return 500
+
+
+def append_mint(token: CapabilityToken, *, path: Optional[str] = None) -> None:
+    """Durably append a token-mint record. Fail-soft — never raises.
+
+    The HMAC ``sig`` is recorded as audit evidence; the SECRET is never written.
+    """
+    if not _enabled():
+        return
+    p = path if path is not None else _default_path()
+    record = {
+        "ts": time.time(),
+        "schema_version": _SCHEMA_VERSION,
+        "kind": token.kind.value,
+        "op_id": token.op_id,
+        "state_binding": token.state_binding,
+        "prev_hash": token.prev_hash,
+        "sig": token.sig,
+        "payload": dict(token.payload),
+    }
+    try:
+        os.makedirs(os.path.dirname(p) or ".", exist_ok=True)
+        with open(p, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(record, separators=(",", ":")) + "\n")
+        _trim(p)
+    except Exception as exc:  # noqa: BLE001 — audit is best-effort
+        logger.warning("[TokenAudit] append failed: %s", exc)
+
+
+def _trim(p: str) -> None:
+    try:
+        with open(p, "r", encoding="utf-8") as fh:
+            lines = fh.readlines()
+        cap = _max()
+        if len(lines) > cap:
+            with open(p, "w", encoding="utf-8") as fh:
+                fh.writelines(lines[-cap:])
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def read_audit(path: Optional[str] = None) -> List[Dict[str, Any]]:
+    p = path if path is not None else _default_path()
+    try:
+        with open(p, "r", encoding="utf-8") as fh:
+            return [json.loads(line) for line in fh if line.strip()]
+    except FileNotFoundError:
+        return []
+```
+
+- [ ] **Step 4: Wire the WAL into `mint` (durable on every mint)**
+
+In `dag_capability_token.py`, inside `DAGProofChain.mint`, immediately before `return token`:
+
+```python
+        from . import token_audit  # local import avoids a module cycle
+        token_audit.append_mint(token)
+        return token
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/governance/test_token_audit.py tests/governance/test_dag_capability_token.py -q`
+Expected: PASS (14 passed).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/token_audit.py backend/core/ouroboros/governance/dag_capability_token.py tests/governance/test_token_audit.py
+git commit -m "feat(a1): immutable append-only WAL for every token mint"
+```
+
+---
+
+## Task 3: Gate ① — Isomorphic Execution Lock module
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/pre_apply_exec_lock.py`
+- Test: `tests/governance/test_pre_apply_exec_lock.py`
+
+**Interfaces:**
+- Consumes: `DAGProofChain`, `SandboxExecutionToken`, `TokenKind` (Task 1); `container_sandbox.docker_available`, `container_sandbox.run_in_container` (existing); `container_sandbox.ContainmentResult` (existing).
+- Produces: exceptions `SandboxLockFailed`, `RequiresCloudExecution`; `async def acquire_sandbox_execution_token(*, op_id, candidate_files, repo_root, chain, prev_token=None, docker_available=None, runner=None) -> SandboxExecutionToken`. `candidate_files` is `Sequence[Tuple[str, str]]` (path, full_content). `docker_available`/`runner` are injectable for tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_pre_apply_exec_lock.py
+from __future__ import annotations
+import hashlib
+import pytest
+from backend.core.ouroboros.governance import pre_apply_exec_lock as lock
+from backend.core.ouroboros.governance.dag_capability_token import (
+    DAGProofChain, SandboxExecutionToken,
+)
+
+CANDIDATE = [("backend/x.py", "def f():\n    return 1\n")]
+
+class _FakeResult:
+    def __init__(self, exit_code, breached=False):
+        self.exit_code = exit_code
+        self.breached = breached
+        self.diagnostic = "ok" if exit_code == 0 else "boom"
+
+@pytest.mark.asyncio
+async def test_exit_zero_mints_token():
+    chain = DAGProofChain()
+    async def runner(**_):
+        return _FakeResult(0)
+    tok = await lock.acquire_sandbox_execution_token(
+        op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+        chain=chain, docker_available=lambda: True, runner=runner)
+    assert isinstance(tok, SandboxExecutionToken)
+    assert tok.payload["exit_code"] == "0"
+    # state_binding binds the EXACT candidate content
+    expect = hashlib.sha256(b"backend/x.py\x00def f():\n    return 1\n").hexdigest()
+    assert tok.state_binding == expect
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_raises_sandbox_lock_failed():
+    chain = DAGProofChain()
+    async def runner(**_):
+        return _FakeResult(1)
+    with pytest.raises(lock.SandboxLockFailed):
+        await lock.acquire_sandbox_execution_token(
+            op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+            chain=chain, docker_available=lambda: True, runner=runner)
+
+@pytest.mark.asyncio
+async def test_no_docker_raises_requires_cloud_execution_no_process_fallback():
+    chain = DAGProofChain()
+    async def runner(**_):
+        raise AssertionError("runner must NOT be called without Docker")
+    with pytest.raises(lock.RequiresCloudExecution):
+        await lock.acquire_sandbox_execution_token(
+            op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+            chain=chain, docker_available=lambda: False, runner=runner)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/governance/test_pre_apply_exec_lock.py -q`
+Expected: FAIL with `ModuleNotFoundError: pre_apply_exec_lock`.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# backend/core/ouroboros/governance/pre_apply_exec_lock.py
+from __future__ import annotations
+import hashlib
+import logging
+import os
+from typing import Awaitable, Callable, Optional, Sequence, Tuple
+
+from .dag_capability_token import (
+    CapabilityToken, DAGProofChain, SandboxExecutionToken, TokenKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SandboxLockFailed(RuntimeError):
+    """Candidate failed to compile/run in the L4 container — terminate the DAG."""
+
+
+class RequiresCloudExecution(RuntimeError):
+    """No local Docker daemon — strict L4 policy forbids a process downgrade.
+
+    Phase 1: terminate + flag the op. Phase 2: route execution to the GCP node.
+    """
+
+
+def lock_enabled() -> bool:
+    return os.environ.get("JARVIS_A1_SANDBOX_LOCK_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
+def _candidate_hash(candidate_files: Sequence[Tuple[str, str]]) -> str:
+    h = hashlib.sha256()
+    for path, content in sorted(candidate_files):
+        h.update(path.encode("utf-8"))
+        h.update(b"\x00")
+        h.update(content.encode("utf-8"))
+    return h.hexdigest()
+
+
+async def acquire_sandbox_execution_token(
+    *,
+    op_id: str,
+    candidate_files: Sequence[Tuple[str, str]],
+    repo_root: str,
+    chain: DAGProofChain,
+    prev_token: Optional[CapabilityToken] = None,
+    docker_available: Optional[Callable[[], bool]] = None,
+    runner: Optional[Callable[..., Awaitable]] = None,
+) -> SandboxExecutionToken:
+    """Run the candidate in a hardened L4 container; mint a token iff exit==0.
+
+    Strict container-only: no Docker -> RequiresCloudExecution (no fallback).
+    Any non-zero exit / containment breach -> SandboxLockFailed (nothing is
+    written to the real tree; the caller terminates the DAG).
+    """
+    from . import container_sandbox  # lazy import keeps module load cheap
+
+    _docker = docker_available or container_sandbox.docker_available
+    if not _docker():
+        raise RequiresCloudExecution(f"op={op_id} no local Docker daemon")
+
+    _run = runner or container_sandbox.run_in_container
+    # Build a compile+import probe over the candidate's changed modules.
+    probe = _build_probe(candidate_files)
+    result = await _run(code=probe, worktree=repo_root, op_id=op_id)
+
+    exit_code = getattr(result, "exit_code", 1)
+    breached = bool(getattr(result, "breached", False))
+    if exit_code != 0 or breached:
+        raise SandboxLockFailed(
+            f"op={op_id} exit={exit_code} breached={breached} "
+            f"diag={getattr(result, 'diagnostic', '')}")
+
+    state_binding = _candidate_hash(candidate_files)
+    token = chain.mint(
+        kind=TokenKind.SANDBOX_EXECUTION,
+        op_id=op_id,
+        state_binding=state_binding,
+        payload={"exit_code": "0", "image": container_sandbox.sandbox_image()},
+        prev=prev_token,
+    )
+    return token  # type: ignore[return-value]  # mint() returns the typed subclass
+
+
+def _build_probe(candidate_files: Sequence[Tuple[str, str]]) -> str:
+    """A deterministic compile-check payload over the candidate's .py files."""
+    py = [p for p, _ in candidate_files if p.endswith(".py")]
+    listing = ",".join(repr(p) for p in py)
+    return (
+        "import py_compile, sys\n"
+        f"paths = [{listing}]\n"
+        "for p in paths:\n"
+        "    py_compile.compile(p, doraise=True)\n"
+        "print('compile-ok')\n"
+    )
+```
+
+> Note: the probe deliberately starts with `py_compile` (compile parity). Task 4 expands `worktree` to the candidate-materialized worktree so the probe compiles the *new* content, and adds the scoped-test stage; the unit tests inject `runner` so they stay hermetic.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/governance/test_pre_apply_exec_lock.py -q`
+Expected: PASS (3 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/pre_apply_exec_lock.py tests/governance/test_pre_apply_exec_lock.py
+git commit -m "feat(a1): Gate 1 isomorphic L4 container exec lock (strict, fail-closed)"
+```
+
+---
+
+## Task 4: Wire Gate ① into the orchestrator (default-OFF, OFF-parity proven)
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/orchestrator.py` (post-Iron-Gate, pre-VALIDATE seam, ~`:6271` after the ASCII gate block)
+- Test: `tests/governance/test_gate1_orchestrator_wiring.py`
+
+**Interfaces:**
+- Consumes: `acquire_sandbox_execution_token`, `lock_enabled`, `SandboxLockFailed`, `RequiresCloudExecution` (Task 3); the per-op `DAGProofChain` (stored on `ctx`, added here).
+- Produces: a `SandboxExecutionToken` stashed on the op context (`ctx.sandbox_token`) for Task 6/8 to chain from; terminal routing to POSTMORTEM on lock failure.
+
+- [ ] **Step 1: Write the failing wiring test** (OFF-parity + ON-terminates)
+
+```python
+# tests/governance/test_gate1_orchestrator_wiring.py
+from __future__ import annotations
+import os
+import pytest
+from backend.core.ouroboros.governance import pre_apply_exec_lock as lock
+
+def test_lock_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_SANDBOX_LOCK_ENABLED", raising=False)
+    assert lock.lock_enabled() is False
+
+def test_lock_enabled_when_flagged(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_SANDBOX_LOCK_ENABLED", "true")
+    assert lock.lock_enabled() is True
+```
+
+> The deep FSM-routing assertion (lock failure → POSTMORTEM, token stashed on ctx) is exercised E2E by `isomorphic_a1_local.py` in Task 11; this unit test pins the gate flag-parity so the OFF path is byte-identical.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_gate1_orchestrator_wiring.py -q`
+Expected: FAIL (the `lock_enabled` import path resolves, but assert the test file runs; if green already, proceed — these pin existing behavior).
+
+- [ ] **Step 3: Add the gate at the post-Iron-Gate seam**
+
+In `orchestrator.py`, immediately after the ASCII-strict gate block (the candidate is finalized, nothing written yet), insert:
+
+```python
+        # ---- Gate 1: Isomorphic Execution Lock (pre-APPLY, strict L4) ----
+        from .pre_apply_exec_lock import (
+            acquire_sandbox_execution_token, lock_enabled,
+            SandboxLockFailed, RequiresCloudExecution,
+        )
+        from .dag_capability_token import DAGProofChain
+
+        if lock_enabled():
+            _chain = getattr(ctx, "proof_chain", None) or DAGProofChain()
+            _cand_files = list(self._iter_candidate_files(best_candidate))
+            try:
+                _sbx_tok = await acquire_sandbox_execution_token(
+                    op_id=ctx.op_id,
+                    candidate_files=_cand_files,
+                    repo_root=str(self._config.project_root),
+                    chain=_chain,
+                )
+            except RequiresCloudExecution as exc:
+                logger.warning("[Gate1] op=%s REQUIRES_CLOUD_EXECUTION: %s", ctx.op_id, exc)
+                ctx = ctx.advance(
+                    OperationPhase.POSTMORTEM,
+                    terminal_reason_code="requires_cloud_execution",
+                )
+                return ctx
+            except SandboxLockFailed as exc:
+                logger.warning("[Gate1] op=%s SANDBOX_LOCK_FAILED: %s", ctx.op_id, exc)
+                ctx = ctx.advance(
+                    OperationPhase.POSTMORTEM,
+                    terminal_reason_code="sandbox_lock_failed",
+                )
+                return ctx
+            ctx = dataclasses.replace(ctx, proof_chain=_chain, sandbox_token=_sbx_tok)
+```
+
+Add the two optional fields to the op context dataclass (`op_context.py`, alongside `generate_file_hashes`):
+
+```python
+    proof_chain: object = None        # DAGProofChain (per-op), set at Gate 1
+    sandbox_token: object = None      # SandboxExecutionToken, set at Gate 1
+```
+
+- [ ] **Step 4: Run the gate flag-parity + a smoke import**
+
+Run: `python3 -m pytest tests/governance/test_gate1_orchestrator_wiring.py -q && python3 -c "import backend.core.ouroboros.governance.orchestrator"`
+Expected: PASS + clean import.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/orchestrator.py backend/core/ouroboros/governance/op_context.py tests/governance/test_gate1_orchestrator_wiring.py
+git commit -m "feat(a1): wire Gate 1 exec lock post-IronGate (default-OFF, OFF byte-identical)"
+```
+
+---
+
+## Task 5: Gate ② — Blast-radius regression module
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/blast_radius_verify.py`
+- Test: `tests/governance/test_blast_radius_verify.py`
+
+**Interfaces:**
+- Consumes: `DAGProofChain`, `BlastRadiusClearedToken`, `TokenKind`, `SandboxExecutionToken` (Tasks 1/3); injectable `graph_fn` (reverse-dep resolver), `test_fn` (runs a test set), `rollback_fn`, `current_tree_sha_fn`, `dlq_fn`.
+- Produces: exceptions `BlastRadiusBreach`, `BlastRadiusGraphFailure`; `async def acquire_blast_radius_token(*, op_id, scope_files, pre_op_tree_sha, chain, prev_token, graph_fn, test_fn, current_tree_sha_fn, rollback_fn, dlq_fn) -> BlastRadiusClearedToken`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_blast_radius_verify.py
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import blast_radius_verify as brv
+from backend.core.ouroboros.governance.dag_capability_token import (
+    DAGProofChain, TokenKind, BlastRadiusClearedToken,
+)
+
+SCOPE = ["backend/x.py"]
+PRE = "tree-sha-pre"
+
+def _prev(chain):
+    return chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id="op-1",
+                      state_binding="cand", payload={"exit_code": "0"})
+
+@pytest.mark.asyncio
+async def test_all_pass_mints_chained_token():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def graph_fn(files): return {"tests/test_x.py"}
+    async def test_fn(tests): return {"failed": [], "total": 3}
+    tok = await brv.acquire_blast_radius_token(
+        op_id="op-1", scope_files=SCOPE, pre_op_tree_sha=PRE, chain=chain,
+        prev_token=prev, graph_fn=graph_fn, test_fn=test_fn,
+        current_tree_sha_fn=lambda: PRE, rollback_fn=None, dlq_fn=None)
+    assert isinstance(tok, BlastRadiusClearedToken)
+    assert tok.prev_hash == prev.digest()  # chained to Gate 1
+    assert tok.state_binding == PRE
+
+@pytest.mark.asyncio
+async def test_any_failure_rolls_back_and_asserts_sha_and_dlqs():
+    chain = DAGProofChain(); prev = _prev(chain)
+    calls = {"rollback": 0, "dlq": []}
+    async def graph_fn(files): return {"tests/test_x.py"}
+    async def test_fn(tests): return {"failed": ["tests/test_x.py::t"], "total": 3}
+    def rollback_fn(sha): calls["rollback"] += 1
+    def dlq_fn(reason): calls["dlq"].append(reason)
+    with pytest.raises(brv.BlastRadiusBreach):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1", scope_files=SCOPE, pre_op_tree_sha=PRE, chain=chain,
+            prev_token=prev, graph_fn=graph_fn, test_fn=test_fn,
+            current_tree_sha_fn=lambda: PRE, rollback_fn=rollback_fn, dlq_fn=dlq_fn)
+    assert calls["rollback"] == 1
+    assert calls["dlq"] == ["blast_radius_breach"]
+
+@pytest.mark.asyncio
+async def test_graph_failure_is_fail_closed_and_dlqs():
+    chain = DAGProofChain(); prev = _prev(chain)
+    calls = {"rollback": 0, "dlq": []}
+    async def graph_fn(files): raise ValueError("cyclic")
+    async def test_fn(tests): raise AssertionError("must not run tests on graph failure")
+    def rollback_fn(sha): calls["rollback"] += 1
+    def dlq_fn(reason): calls["dlq"].append(reason)
+    with pytest.raises(brv.BlastRadiusGraphFailure):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1", scope_files=SCOPE, pre_op_tree_sha=PRE, chain=chain,
+            prev_token=prev, graph_fn=graph_fn, test_fn=test_fn,
+            current_tree_sha_fn=lambda: PRE, rollback_fn=rollback_fn, dlq_fn=dlq_fn)
+    assert calls["rollback"] == 1
+    assert calls["dlq"] == ["blast_radius_graph_failure"]
+
+@pytest.mark.asyncio
+async def test_rollback_sha_mismatch_raises():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def graph_fn(files): return {"tests/test_x.py"}
+    async def test_fn(tests): return {"failed": ["t"], "total": 1}
+    with pytest.raises(brv.BlastRadiusBreach):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1", scope_files=SCOPE, pre_op_tree_sha=PRE, chain=chain,
+            prev_token=prev, graph_fn=graph_fn, test_fn=test_fn,
+            current_tree_sha_fn=lambda: "DIFFERENT", rollback_fn=lambda s: None,
+            dlq_fn=lambda r: None)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/governance/test_blast_radius_verify.py -q`
+Expected: FAIL with `ModuleNotFoundError: blast_radius_verify`.
+
+- [ ] **Step 3: Write the implementation**
+
+```python
+# backend/core/ouroboros/governance/blast_radius_verify.py
+from __future__ import annotations
+import logging
+import os
+from typing import Awaitable, Callable, Optional, Sequence, Set
+
+from .dag_capability_token import (
+    BlastRadiusClearedToken, CapabilityToken, DAGProofChain, TokenKind,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class BlastRadiusBreach(RuntimeError):
+    """A test in the reverse-dep closure failed — rolled back to pre-op SHA."""
+
+
+class BlastRadiusGraphFailure(RuntimeError):
+    """The reverse-dep graph could not be built — fail-closed, no marker fallback."""
+
+
+def blast_radius_enabled() -> bool:
+    return os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
+async def acquire_blast_radius_token(
+    *,
+    op_id: str,
+    scope_files: Sequence[str],
+    pre_op_tree_sha: str,
+    chain: DAGProofChain,
+    prev_token: CapabilityToken,
+    graph_fn: Callable[[Sequence[str]], Awaitable[Set[str]]],
+    test_fn: Callable[[Set[str]], Awaitable[dict]],
+    current_tree_sha_fn: Callable[[], str],
+    rollback_fn: Optional[Callable[[str], None]],
+    dlq_fn: Optional[Callable[[str], None]],
+) -> BlastRadiusClearedToken:
+    """Run the full reverse-dependency closure of the modified AST.
+
+    - graph build error -> fail-closed: rollback + DLQ + raise GraphFailure.
+    - any test failure (no retry) -> rollback to the pre-op tree-SHA, assert
+      restoration cryptographically, DLQ, raise Breach.
+    - all pass -> mint a token chained to the sandbox token.
+    """
+    def _rollback_and_assert(reason: str) -> None:
+        if rollback_fn is not None:
+            rollback_fn(pre_op_tree_sha)
+        restored = current_tree_sha_fn()
+        if dlq_fn is not None:
+            dlq_fn(reason)
+        if restored != pre_op_tree_sha:
+            raise BlastRadiusBreach(
+                f"op={op_id} ROLLBACK FAILED restored={restored} != pre={pre_op_tree_sha}")
+
+    try:
+        tests = await graph_fn(scope_files)
+    except Exception as exc:  # noqa: BLE001 — fail-closed on ANY graph error
+        logger.warning("[Gate2] op=%s graph FAILURE: %s", op_id, exc)
+        _rollback_and_assert("blast_radius_graph_failure")
+        raise BlastRadiusGraphFailure(f"op={op_id}: {exc}") from exc
+
+    result = await test_fn(set(tests))
+    failed = list(result.get("failed", []))
+    if failed:
+        logger.warning("[Gate2] op=%s blast-radius FAIL %d/%s", op_id, len(failed), result.get("total"))
+        _rollback_and_assert("blast_radius_breach")
+        raise BlastRadiusBreach(f"op={op_id} failed={failed}")
+
+    token = chain.mint(
+        kind=TokenKind.BLAST_RADIUS_CLEARED,
+        op_id=op_id,
+        state_binding=pre_op_tree_sha,
+        payload={"n_tests": str(result.get("total", len(tests))),
+                 "post_tree_sha": current_tree_sha_fn()},
+        prev=prev_token,
+    )
+    return token  # type: ignore[return-value]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/governance/test_blast_radius_verify.py -q`
+Expected: PASS (4 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/blast_radius_verify.py tests/governance/test_blast_radius_verify.py
+git commit -m "feat(a1): Gate 2 blast-radius regression (fail-closed graph, no flake-retry)"
+```
+
+---
+
+## Task 6: Wire Gate ② into `slice4b_runner` (capture pre-op SHA; default-OFF)
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/phase_runners/slice4b_runner.py` (capture pre-op tree-SHA near checkpoint create ~`:415`; gate between verify-gate ~`:1034` and auto-commit `:1091`)
+- Test: `tests/governance/test_gate2_slice4b_wiring.py`
+
+**Interfaces:**
+- Consumes: `acquire_blast_radius_token`, `blast_radius_enabled`, `BlastRadiusBreach`, `BlastRadiusGraphFailure` (Task 5); `ctx.sandbox_token`/`ctx.proof_chain` (Task 4); `WorkspaceCheckpointManager` (existing); `call_graph_blast`/`blast_radius_adapter` (existing); `TestRunner` (existing); `intake_dlq.append_dlq` (existing).
+- Produces: `ctx.blast_token` set on pass; POSTMORTEM with `terminal_reason_code="blast_radius_breach"`/`"blast_radius_graph_failure"` on failure.
+
+- [ ] **Step 1: Write the failing wiring test** (flag-parity)
+
+```python
+# tests/governance/test_gate2_slice4b_wiring.py
+from __future__ import annotations
+from backend.core.ouroboros.governance import blast_radius_verify as brv
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_BLAST_RADIUS_ENABLED", raising=False)
+    assert brv.blast_radius_enabled() is False
+
+def test_enabled_when_flagged(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_BLAST_RADIUS_ENABLED", "true")
+    assert brv.blast_radius_enabled() is True
+```
+
+- [ ] **Step 2: Run test to verify it fails/passes-pin**
+
+Run: `python3 -m pytest tests/governance/test_gate2_slice4b_wiring.py -q`
+Expected: PASS (pins flag parity).
+
+- [ ] **Step 3: Capture the pre-op tree-SHA** at checkpoint creation (~`:415`)
+
+In `slice4b_runner.py`, where `_ckpt_mgr.create_checkpoint(...)` is called at APPLY start, capture the raw tree SHA alongside it (the `Checkpoint.stash_ref` is the tree SHA):
+
+```python
+        _pre_op_ckpt = await orch._ckpt_mgr.create_checkpoint(op_id=ctx.op_id)
+        _pre_op_tree_sha = getattr(_pre_op_ckpt, "stash_ref", "") if _pre_op_ckpt else ""
+```
+
+- [ ] **Step 4: Insert the gate** between the verify gate (~`:1034`) and Phase 8b auto-commit (`:1091`)
+
+```python
+        # ---- Gate 2: Cryptographic Blast-Radius Verification ----
+        from ..blast_radius_verify import (
+            acquire_blast_radius_token, blast_radius_enabled,
+            BlastRadiusBreach, BlastRadiusGraphFailure,
+        )
+        if blast_radius_enabled() and getattr(ctx, "sandbox_token", None) is not None:
+            from ..import call_graph_blast
+            from .. import intake_dlq as _dlq
+            _scope = set(ctx.target_files) | {cf for cf, _ in orch._iter_candidate_files(best_candidate)}
+
+            async def _graph_fn(files):
+                return call_graph_blast.reverse_dependency_tests(files, repo_root=str(orch._config.project_root))
+
+            async def _test_fn(tests):
+                _res = await orch._validation_runner.run(
+                    changed_files=tuple(orch._config.project_root / t for t in tests),
+                    timeout_budget_s=_verify_budget_s, op_id=ctx.op_id)
+                _failed = [a for a in _res.adapter_results if not a.passed]
+                return {"failed": _failed, "total": len(_res.adapter_results)}
+
+            def _rollback(sha):
+                # non-destructive: restore the pre-op checkpoint (tree-SHA)
+                import asyncio as _aio
+                _aio.get_event_loop().run_until_complete(
+                    orch._ckpt_mgr.restore_checkpoint(_pre_op_ckpt.checkpoint_id))
+
+            def _tree_sha():
+                return orch._ckpt_mgr.current_tree_sha()  # see Step 5
+
+            try:
+                _blast_tok = await acquire_blast_radius_token(
+                    op_id=ctx.op_id, scope_files=sorted(_scope),
+                    pre_op_tree_sha=_pre_op_tree_sha, chain=ctx.proof_chain,
+                    prev_token=ctx.sandbox_token, graph_fn=_graph_fn, test_fn=_test_fn,
+                    current_tree_sha_fn=_tree_sha,
+                    rollback_fn=_rollback,
+                    dlq_fn=lambda reason: _dlq.append_dlq(ctx.op_id, reason=reason))
+            except BlastRadiusGraphFailure:
+                return PhaseResult(next_ctx=ctx.advance(OperationPhase.POSTMORTEM,
+                    terminal_reason_code="blast_radius_graph_failure", rollback_occurred=True),
+                    next_phase=OperationPhase.POSTMORTEM)
+            except BlastRadiusBreach:
+                return PhaseResult(next_ctx=ctx.advance(OperationPhase.POSTMORTEM,
+                    terminal_reason_code="blast_radius_breach", rollback_occurred=True),
+                    next_phase=OperationPhase.POSTMORTEM)
+            ctx = dataclasses.replace(ctx, blast_token=_blast_tok)
+```
+
+Add `blast_token: object = None` to the op context dataclass.
+
+- [ ] **Step 5: Add the reuse helpers** they depend on
+
+In `workspace_checkpoint.py`, add a thin read-only helper (reuses the same argv style):
+
+```python
+    def current_tree_sha(self) -> str:
+        """Current working-tree SHA via ``git stash create`` (non-destructive)."""
+        out = subprocess.run(["git", "stash", "create"], cwd=self._repo_root,
+                             capture_output=True, text=True, timeout=10)
+        return out.stdout.strip()
+```
+
+In `call_graph_blast.py`, add the reverse-dep test resolver if not already exposed:
+
+```python
+def reverse_dependency_tests(changed_files, *, repo_root: str) -> set:
+    """All tests that transitively import any changed file (reverse-dep closure)."""
+    # delegate to the existing blast_radius_adapter graph; raise on any graph error
+    from .blast_radius_adapter import build_reverse_import_graph, tests_touching
+    graph = build_reverse_import_graph(repo_root)
+    return tests_touching(graph, changed_files)
+```
+
+> If `blast_radius_adapter` already exposes an equivalent, import it directly and skip the shim — confirm symbol names during implementation (`grep -n "def " blast_radius_adapter.py`). The gate's `graph_fn` must **raise** (never return empty) on a graph build error so Task 5's fail-closed path triggers.
+
+- [ ] **Step 6: Run tests + smoke import**
+
+Run: `python3 -m pytest tests/governance/test_gate2_slice4b_wiring.py tests/governance/test_blast_radius_verify.py -q && python3 -c "import backend.core.ouroboros.governance.phase_runners.slice4b_runner"`
+Expected: PASS + clean import.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/phase_runners/slice4b_runner.py backend/core/ouroboros/governance/workspace_checkpoint.py backend/core/ouroboros/governance/call_graph_blast.py backend/core/ouroboros/governance/op_context.py tests/governance/test_gate2_slice4b_wiring.py
+git commit -m "feat(a1): wire Gate 2 blast-radius into VERIFY (tree-SHA rollback, default-OFF)"
+```
+
+---
+
+## Task 7: Gate ③ — Autonomous PR Linter module
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/pr_self_linter.py`
+- Test: `tests/governance/test_pr_self_linter.py`
+
+**Interfaces:**
+- Consumes: `DAGProofChain`, `LintClearedToken`, `TokenKind`, `BlastRadiusClearedToken` (Tasks 1/5); `self_critique.parse_critique_json` (existing, reuse for parsing); an injectable `critique_fn` (the bounded LLM call) for tests.
+- Produces: exception `LintRejected`; `async def acquire_lint_cleared_token(*, op_id, diff, chain, prev_token, critique_fn, threshold=4) -> LintClearedToken`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/governance/test_pr_self_linter.py
+from __future__ import annotations
+import hashlib
+import pytest
+from backend.core.ouroboros.governance import pr_self_linter as lint
+from backend.core.ouroboros.governance.dag_capability_token import (
+    DAGProofChain, TokenKind, LintClearedToken,
+)
+
+DIFF = "+def f():\n+    return 1\n"
+
+def _prev(chain):
+    s = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id="op-1", state_binding="c", payload={})
+    return chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id="op-1",
+                      state_binding="t", payload={}, prev=s)
+
+@pytest.mark.asyncio
+async def test_pass_mints_chained_lint_token():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def critique_fn(diff): return {"rating": 5, "concerns": []}
+    tok = await lint.acquire_lint_cleared_token(
+        op_id="op-1", diff=DIFF, chain=chain, prev_token=prev, critique_fn=critique_fn)
+    assert isinstance(tok, LintClearedToken)
+    assert tok.prev_hash == prev.digest()
+    assert tok.state_binding == hashlib.sha256(DIFF.encode()).hexdigest()
+
+@pytest.mark.asyncio
+async def test_low_rating_raises_lint_rejected():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def critique_fn(diff): return {"rating": 2, "concerns": ["hardcoded path"]}
+    with pytest.raises(lint.LintRejected):
+        await lint.acquire_lint_cleared_token(
+            op_id="op-1", diff=DIFF, chain=chain, prev_token=prev, critique_fn=critique_fn)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `python3 -m pytest tests/governance/test_pr_self_linter.py -q`
+Expected: FAIL with `ModuleNotFoundError: pr_self_linter`.
+
+- [ ] **Step 3: Write the implementation** (reuses `self_critique` prompt/parse + `DoublewordProvider`)
+
+```python
+# backend/core/ouroboros/governance/pr_self_linter.py
+from __future__ import annotations
+import hashlib
+import logging
+import os
+from typing import Awaitable, Callable, Optional
+
+from .dag_capability_token import (
+    BlastRadiusClearedToken, CapabilityToken, DAGProofChain, LintClearedToken, TokenKind,
+)
+
+logger = logging.getLogger(__name__)
+
+_RULES = (
+    "Critique this diff against the repository's architectural rules. Return JSON "
+    '{"rating": 1-5, "concerns": [..]}. Rules: (1) NO hardcoding — values/paths/'
+    "models must be env/config-derived; (2) DRY — no duplicated logic that an "
+    "existing helper covers; (3) explicit error handling — no bare/silent excepts; "
+    "(4) async-first — no blocking calls on the event loop. Rate 5 only if all hold."
+)
+
+
+def linter_enabled() -> bool:
+    return os.environ.get("JARVIS_A1_PR_LINTER_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+
+
+def _threshold() -> int:
+    try:
+        return int(os.environ.get("JARVIS_A1_PR_LINTER_THRESHOLD", "4"))
+    except ValueError:
+        return 4
+
+
+class LintRejected(RuntimeError):
+    """The model's own architectural critique rejected the diff — no PR."""
+
+
+async def default_critique_fn(diff: str) -> dict:
+    """Bounded, structured one-shot critique via the cheapest existing provider."""
+    from .doubleword_provider import DoublewordProvider
+    from .self_critique import parse_critique_json
+    provider = DoublewordProvider()
+    raw = await provider.prompt_only(
+        prompt=f"{_RULES}\n\nDIFF:\n{diff}",
+        caller_id="pr_self_linter",
+        response_format={"type": "json_object"},
+        max_tokens=512,
+    )
+    parsed, _ok = parse_critique_json(raw, op_id="pr_self_linter")
+    return parsed
+
+
+async def acquire_lint_cleared_token(
+    *,
+    op_id: str,
+    diff: str,
+    chain: DAGProofChain,
+    prev_token: CapabilityToken,
+    critique_fn: Optional[Callable[[str], Awaitable[dict]]] = None,
+    threshold: Optional[int] = None,
+) -> LintClearedToken:
+    _crit = critique_fn or default_critique_fn
+    _thr = threshold if threshold is not None else _threshold()
+    verdict = await _crit(diff)
+    rating = int(verdict.get("rating", 0))
+    if rating < _thr:
+        raise LintRejected(
+            f"op={op_id} rating={rating}<{_thr} concerns={verdict.get('concerns')}")
+    token = chain.mint(
+        kind=TokenKind.LINT_CLEARED,
+        op_id=op_id,
+        state_binding=hashlib.sha256(diff.encode("utf-8")).hexdigest(),
+        payload={"rating": str(rating)},
+        prev=prev_token,
+    )
+    return token  # type: ignore[return-value]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `python3 -m pytest tests/governance/test_pr_self_linter.py -q`
+Expected: PASS (2 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/pr_self_linter.py tests/governance/test_pr_self_linter.py
+git commit -m "feat(a1): Gate 3 blocking PR linter (reuses self_critique + DoublewordProvider)"
+```
+
+---
+
+## Task 8: Token-gate `create_review_pr` (the enforcer bite)
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/orange_pr_reviewer.py` (`create_review_pr` signature + `verify_chain` before `gh pr create` ~`:303–324`)
+- Test: `tests/governance/test_orange_pr_token_gate.py`
+
+**Interfaces:**
+- Consumes: `SandboxExecutionToken`, `BlastRadiusClearedToken`, `LintClearedToken`, `DAGProofChain.verify_chain` (Tasks 1/3/5/7); `acquire_lint_cleared_token`, `linter_enabled` (Task 7).
+- Produces: `create_review_pr` returns `None` (refuses) unless a verified 3-token chain is supplied when the enforcer is enabled.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_orange_pr_token_gate.py
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance.orange_pr_reviewer import OrangePRReviewer
+from backend.core.ouroboros.governance.dag_capability_token import DAGProofChain, TokenKind
+
+def _chain_tokens(chain, op_id="op-1"):
+    s = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=op_id, state_binding="c", payload={})
+    b = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=op_id, state_binding="t", payload={}, prev=s)
+    l = chain.mint(kind=TokenKind.LINT_CLEARED, op_id=op_id, state_binding="d", payload={}, prev=b)
+    return s, b, l
+
+@pytest.mark.asyncio
+async def test_refuses_without_valid_chain(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "true")
+    rv = OrangePRReviewer(str(tmp_path))
+    chain = DAGProofChain()
+    s, b, l = _chain_tokens(chain)
+    # Tamper: swap in a foreign-secret token -> verify_chain fails -> None.
+    foreign = DAGProofChain()
+    s2, _, _ = _chain_tokens(foreign)
+    result = await rv.create_review_pr(
+        op_id="op-1", files=[("x.py", "...")], description="d", base_branch="main",
+        chain=chain, sandbox_token=s2, blast_token=b, lint_token=l)
+    assert result is None
+
+@pytest.mark.asyncio
+async def test_enforcer_off_is_legacy(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false")
+    rv = OrangePRReviewer(str(tmp_path))
+    # With enforcer off, tokens may be None and the chain check is skipped
+    # (the real gh call is mocked out separately in integration tests).
+    assert rv._enforcer_enabled() is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_orange_pr_token_gate.py -q`
+Expected: FAIL (new kwargs/`_enforcer_enabled` not present).
+
+- [ ] **Step 3: Modify `create_review_pr`** — add mandatory typed token args + chain verify + Gate ③ call
+
+Add near the top of `orange_pr_reviewer.py`:
+
+```python
+import os
+def _token_enforcer_enabled() -> bool:
+    return os.environ.get("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+```
+
+Add the instance helper and extend the signature:
+
+```python
+    def _enforcer_enabled(self) -> bool:
+        return _token_enforcer_enabled()
+
+    async def create_review_pr(self, *, op_id, files, description, base_branch,
+                               chain=None, sandbox_token=None, blast_token=None,
+                               lint_token=None):
+        # ---- Gate 3 (run the linter if armed and no token supplied) ----
+        from .pr_self_linter import acquire_lint_cleared_token, linter_enabled, LintRejected
+        if self._enforcer_enabled():
+            if linter_enabled() and lint_token is None and blast_token is not None and chain is not None:
+                _diff = "\n".join(f"--- {p}\n{c}" for p, c in files)
+                try:
+                    lint_token = await acquire_lint_cleared_token(
+                        op_id=op_id, diff=_diff, chain=chain, prev_token=blast_token)
+                except LintRejected as exc:
+                    logger.warning("[Gate3] op=%s LINT_REJECTED: %s", op_id, exc)
+                    return None
+            # ---- Enforcer: the chain MUST verify or no PR is opened ----
+            if chain is None or not chain.verify_chain(
+                    [sandbox_token, blast_token, lint_token], op_id=op_id):
+                logger.warning("[Enforcer] op=%s token chain INVALID -> refuse PR", op_id)
+                return None
+        # ... existing body: checkout branch, write files, commit, push,
+        #     `gh pr create` (unchanged) ...
+```
+
+> The existing positional callers must be updated to the keyword form; the orchestrator call site (Task references `orchestrator.py:9471`) passes `op_id=ctx.op_id, files=..., description=ctx.description, base_branch=base, chain=ctx.proof_chain, sandbox_token=ctx.sandbox_token, blast_token=ctx.blast_token`.
+
+- [ ] **Step 4: Update the orchestrator call site** (`orchestrator.py` ~`:9471`) to pass the tokens from `ctx`:
+
+```python
+            _pr = await OrangePRReviewer(str(self._config.project_root)).create_review_pr(
+                op_id=ctx.op_id,
+                files=list(self._iter_candidate_files(best_candidate)),
+                description=ctx.description,
+                base_branch=_base_branch,
+                chain=getattr(ctx, "proof_chain", None),
+                sandbox_token=getattr(ctx, "sandbox_token", None),
+                blast_token=getattr(ctx, "blast_token", None),
+            )
+```
+
+- [ ] **Step 5: Run tests + smoke import**
+
+Run: `python3 -m pytest tests/governance/test_orange_pr_token_gate.py -q && python3 -c "import backend.core.ouroboros.governance.orange_pr_reviewer, backend.core.ouroboros.governance.orchestrator"`
+Expected: PASS + clean import.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/orange_pr_reviewer.py backend/core/ouroboros/governance/orchestrator.py tests/governance/test_orange_pr_token_gate.py
+git commit -m "feat(a1): token-gate create_review_pr — skipping a gate is now a type error"
+```
+
+---
+
+## Task 9: Async Docker pre-flight at A1-loop start
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/orchestrator.py` (or `governed_loop_service.py` boot) — async daemon ping at loop start; expose `REQUIRES_CLOUD_EXECUTION` posture
+- Test: `tests/governance/test_docker_preflight.py`
+
+**Interfaces:**
+- Consumes: `container_sandbox.docker_available` (existing).
+- Produces: `async def docker_preflight() -> bool` (logs + caches the result for the session); when False and the sandbox lock is armed, ops are flagged `requires_cloud_execution` early instead of discovering it mid-DAG.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_docker_preflight.py
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import pre_apply_exec_lock as lock
+
+@pytest.mark.asyncio
+async def test_preflight_reports_daemon_state():
+    assert await lock.docker_preflight(probe=lambda: True) is True
+    assert await lock.docker_preflight(probe=lambda: False) is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_docker_preflight.py -q`
+Expected: FAIL (`docker_preflight` not defined).
+
+- [ ] **Step 3: Add `docker_preflight`** to `pre_apply_exec_lock.py`
+
+```python
+async def docker_preflight(*, probe=None) -> bool:
+    """Async, non-blocking daemon ping run once at A1-loop start.
+
+    Surfaces Docker absence BEFORE an op reaches APPLY, so the orchestrator
+    can flag REQUIRES_CLOUD_EXECUTION early rather than failing mid-DAG.
+    """
+    import asyncio
+    from . import container_sandbox
+    _probe = probe or container_sandbox.docker_available
+    available = await asyncio.get_event_loop().run_in_executor(None, _probe)
+    if not available and lock_enabled():
+        logger.warning("[Gate1] Docker daemon ABSENT at preflight — ops will route REQUIRES_CLOUD_EXECUTION")
+    return available
+```
+
+Call it once at the A1 loop start (in `governed_loop_service.py` boot, fire-and-forget logged):
+
+```python
+        from .pre_apply_exec_lock import docker_preflight
+        self._docker_ready = await docker_preflight()
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/test_docker_preflight.py -q`
+Expected: PASS (1 passed).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/pre_apply_exec_lock.py backend/core/ouroboros/governance/governed_loop_service.py tests/governance/test_docker_preflight.py
+git commit -m "feat(a1): async Docker pre-flight at loop start (early REQUIRES_CLOUD_EXECUTION)"
+```
+
+---
+
+## Task 10: Register flags + reconcile A1 branches
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/flag_registry.py` (seed entries)
+- Test: `tests/governance/test_a1_flags_registered.py`
+
+**Interfaces:**
+- Produces: the 5 new flags discoverable via `/help flags`; the `feat/a1-disable-file-isolation` manifest pin folded into the A1 launch manifest.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_a1_flags_registered.py
+from __future__ import annotations
+from backend.core.ouroboros.governance.flag_registry import FlagRegistry
+
+def test_iron_triad_flags_registered():
+    reg = FlagRegistry()
+    names = set(reg.all_flag_names())
+    for f in ("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "JARVIS_A1_SANDBOX_LOCK_ENABLED",
+              "JARVIS_A1_BLAST_RADIUS_ENABLED", "JARVIS_A1_PR_LINTER_ENABLED",
+              "JARVIS_TOKEN_AUDIT_ENABLED"):
+        assert f in names
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/test_a1_flags_registered.py -q`
+Expected: FAIL (flags not yet seeded).
+
+- [ ] **Step 3: Seed the 5 flags** in `flag_registry.py` (follow the existing seed entry shape — type, category, source_file, example, posture-relevance). Match the curated-seed structure already in the file.
+
+- [ ] **Step 4: Reconcile the A1 branches** (verification, not re-implementation)
+
+```bash
+git log --oneline main..origin/feat/a1-disable-file-isolation   # confirm the manifest pin
+git show origin/feat/a1-disable-file-isolation -- <launch manifest path>
+# fold the file-isolation-OFF manifest pin into the A1 launch manifest used by
+# scripts/isomorphic_a1_local.py; cherry-pick if it is a clean isolated change.
+```
+
+Document in the commit which commit(s) were folded and why (the `fsm_classify_to_applied` durability fix).
+
+- [ ] **Step 5: Run test + flag-list smoke**
+
+Run: `python3 -m pytest tests/governance/test_a1_flags_registered.py -q`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/flag_registry.py tests/governance/test_a1_flags_registered.py <reconciled manifest>
+git commit -m "feat(a1): register Iron Triad flags + fold file-isolation-OFF A1 manifest pin"
+```
+
+---
+
+## Task 11: E2E ignition dry-run + full-suite green
+
+**Files:**
+- Modify: `scripts/isomorphic_a1_local.py` (ensure it arms the 4 flags for the A1 soak; no behavior change when unset)
+- Test: run the existing `tests/integration/test_isomorphic_a1_e2e.py` + the new suites together
+
+- [ ] **Step 1: Arm the gates in the driver's composed env** (only inside the driver, never global)
+
+In `isomorphic_a1_local.py` `compose_env`/child-env section, set the four `JARVIS_A1_*_ENABLED=true` + `JARVIS_RUNTIME_SANDBOX_ENABLED=true` for the soak child process.
+
+- [ ] **Step 2: Run the full new-suite + the OFF-parity regression**
+
+Run: `python3 -m pytest tests/governance/test_dag_capability_token.py tests/governance/test_token_audit.py tests/governance/test_pre_apply_exec_lock.py tests/governance/test_blast_radius_verify.py tests/governance/test_pr_self_linter.py tests/governance/test_orange_pr_token_gate.py tests/governance/test_docker_preflight.py tests/governance/test_a1_flags_registered.py tests/governance/test_gate1_orchestrator_wiring.py tests/governance/test_gate2_slice4b_wiring.py -q`
+Expected: PASS (all green).
+
+- [ ] **Step 3: Local A1 dry-run** (Docker Desktop UP)
+
+Run: `python3 scripts/isomorphic_a1_local.py --mode container --max-wall-seconds 1200`
+Expected: drives to `A1_DISPATCH_PROVEN`, OR a captured `failure_telemetry` artifact pinpointing the next integration bug (the $0/minutes loop). Iterate until proven locally.
+
+- [ ] **Step 4: Commit the driver arming**
+
+```bash
+git add scripts/isomorphic_a1_local.py
+git commit -m "feat(a1): arm Iron Triad gates inside the local A1 ignition driver"
+```
+
+- [ ] **Step 5: Open the integration PR** for the branch `feat/iron-triad-a1-gate` once the local A1 chain is green; one confirming cloud soak (`--max-wall-seconds 2400 --headless`) is the final gate before flipping any default.
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- §3 Token Enforcer → Tasks 1, 2 (WAL), 8 (verify_chain enforcement). ✓
+- §4 Gate ① Sandbox Lock → Tasks 3, 4, 9 (pre-flight). ✓
+- §5 Gate ② Blast Radius → Tasks 5, 6 (tree-SHA rollback + fail-closed graph + no-retry). ✓
+- §6 Gate ③ PR Linter → Tasks 7, 8. ✓
+- §7 Phase 2 hybrid-cloud → deliberately deferred; Task 4 emits `REQUIRES_CLOUD_EXECUTION` (the Phase-1 boundary). ✓
+- §8 branch reconciliation → Task 10. ✓
+- §10 flags default-OFF → every gate task pins flag-parity; Task 10 registers. ✓
+- §11 testing (forgery/replay/chain/OFF-parity/E2E) → Tasks 1, 4, 6, 11. ✓
+- Adversarial-TDD-first + WAL (operator amendments) → Task 1 Step 1 (negative vectors before impl), Task 2. ✓
+
+**Placeholder scan:** the two reuse shims (`call_graph_blast.reverse_dependency_tests` in Task 6 Step 5; `flag_registry` seed shape in Task 10 Step 3) are flagged to confirm exact existing symbol names at implementation time via `grep` — real code is shown, with the verify-the-symbol caveat called out explicitly. No "TBD/handle edge cases" placeholders remain.
+
+**Type consistency:** `mint(*, kind, op_id, state_binding, payload, prev=None)`, `verify_chain(tokens, *, op_id)`, `acquire_sandbox_execution_token(...) -> SandboxExecutionToken`, `acquire_blast_radius_token(...) -> BlastRadiusClearedToken`, `acquire_lint_cleared_token(...) -> LintClearedToken`, and `create_review_pr(*, op_id, files, description, base_branch, chain, sandbox_token, blast_token, lint_token)` are consistent across Tasks 1–8. The chain order `SANDBOX → BLAST_RADIUS → LINT` (terminal `LINT_CLEARED`) is consistent in `dag_capability_token._CHAIN_ORDER` and every `prev=` linkage.

--- a/docs/superpowers/specs/2026-06-29-iron-triad-a1-gate-design.md
+++ b/docs/superpowers/specs/2026-06-29-iron-triad-a1-gate-design.md
@@ -212,3 +212,18 @@ When the Docker pre-flight finds no local daemon, the op is flagged `REQUIRES_CL
 2. `python3 scripts/isomorphic_a1_local.py --mode container` with Docker Desktop up → drive to `A1_DISPATCH_PROVEN` locally.
 3. Capture failure telemetry on any non-proven (`failure_telemetry.capture_failure_telemetry`); fix; repeat at $0/minutes.
 4. One confirming cloud soak (`--max-wall-seconds 2400 --headless`) → `A1_DISPATCH_PROVEN` live → **first autonomous PR** → A1 gate passes → EXECUTION grade moves off C+.
+
+---
+
+## Addendum (2026-06-29) — FSM-routing correction: the PR-path unification
+
+The §2 "single mandatory path" assumed a linear op flow (generate → sandbox → apply → blast → lint → PR). The whole-branch review found the real Ouroboros FSM **branches by risk tier**: auto-apply ops (SAFE_AUTO/NOTIFY_APPLY) run Gate ①+② → auto-**commit** (no PR); Orange ops (APPROVAL_REQUIRED) hit `create_review_pr` (Gate ③ + enforcer) on a branch that runs *before* APPLY — so no single op assembled all three tokens, and an armed enforcer would refuse every autonomous PR.
+
+**Resolution (Tasks 12, 13a, 13b, 14):**
+- **Branch-bound tokens** (`dag_capability_token`): the HMAC binds a `branch_context`; `verify_chain` rejects a chain whose tokens were minted in different contexts (anti-injection from concurrent workspaces).
+- **`autonomous_pr_pipeline.run_pr_gate_pipeline`**: on the autonomous-PR path, materializes the candidate in an **isolated git worktree** (`ouroboros/a1-validate/<op_id>`), runs Gate ① (container exec) + Gate ② (blast radius) **there** (real tree untouched), mints sandbox+blast bound to the worktree branch, cleans up always. `create_review_pr` then mints lint, verifies the full chain, and asserts the tokens were minted in the expected worktree context.
+- **Hardening**: Docker pre-flight gated on `JARVIS_A1_TOKEN_ENFORCER_ENABLED` (true byte-identical OFF); Gate ② strict catch-all → tree-SHA rollback on any crash; tuning flags registered.
+
+**Net:** one autonomous op now survives the container, clears the blast radius, and passes the linter before its PR — the spec's single mandatory path, realized against the real FSM. All gates remain default-OFF.
+
+**Graduation blocker (tracked):** 4 non-autonomous `create_review_pr` callers (strategy_simulator, genesis_proposal, graduation_pr_proposer, bridge_adapters) don't pass tokens → refuse under enforcer-ON; reconcile (token-wire or CLI-approval exemption) before flipping `JARVIS_A1_TOKEN_ENFORCER_ENABLED` default-ON. Live container A1 soak is operator-run.

--- a/docs/superpowers/specs/2026-06-29-iron-triad-a1-gate-design.md
+++ b/docs/superpowers/specs/2026-06-29-iron-triad-a1-gate-design.md
@@ -1,0 +1,214 @@
+# Iron Triad — Cryptographically-Chained Autonomous-PR Gates to Close the A1 Gate (2026-06-29)
+
+**Status:** design (approved direction; pending spec review → implementation plan)
+**Author:** Derek J. Russell + O+V
+**Branch:** `feat/iron-triad-a1-gate`
+**Supersedes/builds on:** `docs/superpowers/plans/2026-06-27-isomorphic-local-sandbox.md` (MERGED PR #69735), `docs/memory_topics/intake/project_a1_live_fire_result.md`
+
+---
+
+## 1. Problem — the C+ root cause
+
+O+V's cognitive loop is **proven** (190 A1Trace hops, 4× live) but it has **never completed one full autonomous cycle end-to-end** — detect gap → generate → validate → apply → **open its own PR** — on a real node. Across 13+ cloud runs, each died on a *different* integration bug that passed unit tests and failed only live ("unit-green-fails-live"). That gap **is** the C+ EXECUTION grade.
+
+The A1 success criterion is the verdict `A1_DISPATCH_PROVEN` (`scripts/a1_graduation_auditor.py:1173`), requiring **all** of: 5 A1Trace hops in order, `fsm_classify_to_applied`, the 12-flag cognitive audit, a clean intervention-lock, **`autonomous_pr_observed`**, and verifiable lineage.
+
+This spec closes the gate by binding the autonomous cycle with three **fail-closed** gates on the *single mandatory path* an op traverses to reach a PR — and chaining them with unforgeable capability tokens so that **skipping a gate is a type error, not a policy violation**. This directly answers the operator mandate: *no workarounds, no shortcuts, no hardcoding; advanced, asynchronous, dynamic, adaptive, robust; reuse existing architecture, zero duplication.*
+
+### Why "wiring-first"
+The recurring failure mode in this codebase (`feedback_security_filter_must_be_wired`, hit 3× last arc) is **a guard that exists but is not on the mandatory path**. The scouting for this spec confirmed it again: the hardened container executor `container_sandbox.run_in_container()` exists and is wired into Venom's bash/run_tests tools, but **the generated candidate code is never executed in a container as a pre-APPLY gate** (`grep run_in_container` over orchestrator/phase_runners/candidate_generator = 0 hits). Each gate below is ~90% reuse + a thin wiring layer.
+
+---
+
+## 2. The mandatory path and where each gate sits
+
+```
+per-op DAGProofChain (HMAC-SHA256, per-process secret, state-bound, hash-chained)
+──────────────────────────────────────────────────────────────────────────────────►
+GENERATE ─ IronGate(explore/ascii) ─[① SANDBOX EXEC LOCK]─ VALIDATE ─ GATE(SemGuard/REVIEW)
+   ─ APPLY ─ VERIFY(scoped tests) ─[② BLAST RADIUS]─ auto-commit ─[③ PR LINTER]─ gh_pr_create(tok₁,tok₂,tok₃)
+            │ mints SandboxExecutionToken          │ mints BlastRadiusClearedToken     │ mints LintClearedToken
+            └──────────────── chain ───────────────┴──────────────── chain ────────────┘  verify_chain() or refuse
+```
+
+---
+
+## 3. The Cryptographic DAG Token Enforcer (the spine)
+
+**New module:** `backend/core/ouroboros/governance/dag_capability_token.py`
+
+A capability-security pattern: each gate, on success, mints an **unforgeable, state-bound, hash-chained** token. The terminal PR-creation function requires the specific typed token objects as **mandatory arguments**, and re-verifies the chain before invoking `gh`. The AI cannot *physically* construct a valid token without (a) the per-process secret and (b) the exact repository state the gate validated.
+
+### Token structure
+```python
+@dataclass(frozen=True)
+class CapabilityToken:
+    kind: TokenKind                 # SANDBOX_EXECUTION | BLAST_RADIUS_CLEARED | LINT_CLEARED
+    op_id: str
+    state_binding: str              # SHA-256 the gate actually validated (candidate-hash / tree-SHA / diff-hash)
+    prev_hash: str                  # hash of the previous token in the chain ("" for the first)
+    payload: Mapping[str, str]      # gate-specific evidence (exit_code, test_set_hash, lint_rating, ...)
+    issued_monotonic: float
+    sig: str                        # HMAC-SHA256(secret, canonical(kind,op_id,state_binding,prev_hash,payload))
+```
+
+Typed aliases `SandboxExecutionToken`, `BlastRadiusClearedToken`, `LintClearedToken` (frozen subclasses pinned to one `kind`) so a function signature can demand the *specific* type — an `isinstance` + chain verify enforce it at runtime; the type annotation enforces it for any static checker.
+
+### `DAGProofChain` (per-op accumulator)
+- `mint(kind, op_id, state_binding, payload, prev) -> CapabilityToken` — HMAC-signs; links `prev_hash`.
+- `verify(token) -> bool` — recomputes HMAC; rejects on tamper.
+- `verify_chain(tokens: Sequence[CapabilityToken], *, op_id) -> bool` — every token verifies, `op_id` matches across all, `prev_hash` links are intact and in canonical order, and the final token's kind is `LINT_CLEARED`.
+
+### Security properties
+- **Unforgeable:** HMAC-SHA256 with a secret from `secrets.token_bytes(32)` minted at orchestrator init, held only in memory, **never logged or persisted**. A buggy/compromised path cannot fabricate a token literal.
+- **Replay-proof:** `state_binding` ties each token to the exact SHA it validated; a stale token fails against a mutated tree.
+- **Skip-proof:** the PR wrapper signature *requires* the token objects; there is no code path that opens a PR without them.
+- **Tamper-evident chain:** `prev_hash` forms a mini hash-chain; reordering or omitting a gate breaks `verify_chain`.
+
+### Failure semantics
+Gates do not return falsy tokens. On failure they **raise** a typed exception that the FSM routes to terminate/rollback/Cryo-DLQ. A missing token therefore can never be silently coerced to "passed."
+
+Env: `JARVIS_A1_TOKEN_ENFORCER_ENABLED` (default **false** → wrapper accepts `None` tokens and skips chain verify = byte-identical legacy).
+
+---
+
+## 4. Gate ① — Isomorphic Execution Lock (pre-APPLY, fail-closed, L4-only)
+
+**New module:** `backend/core/ouroboros/governance/pre_apply_exec_lock.py`
+**Wired:** orchestrator, after the Iron Gate, before VALIDATE (candidate exists, nothing written to the real tree yet).
+
+```python
+async def acquire_sandbox_execution_token(
+    *, op_id, candidate_files, repo_root, chain, prev_token=None
+) -> SandboxExecutionToken           # raises SandboxLockFailed | RequiresCloudExecution
+```
+
+**Behavior (reuse-heavy):**
+1. **Daemon pre-flight** — `container_sandbox.docker_available()`. (Also run **once asynchronously at A1-loop start** so Docker absence is known before the op reaches APPLY, not discovered mid-DAG.)
+2. **No Docker → strict, no downgrade.** Raise `RequiresCloudExecution`. Phase 1: terminate DAG + flag the op `REQUIRES_CLOUD_EXECUTION`. Phase 2: route execution to the GCP node (§7). **Never** fall back to process isolation.
+3. Materialize the candidate into an **isolated git worktree** (`WorktreeManager`, COW) under **`IsomorphicEnv`** (forces `/opt/trinity/jarvis` path, disjoint cwd, disabled `/tmp` whitelist — `JARVIS_SANDBOX_PREFIXES`).
+4. Execute in the **hardened container** (`run_in_container`: `--network none --cap-drop ALL --read-only --pids-limit`): import/compile the changed modules + run the candidate's own scoped tests.
+5. **Exit 0** → mint `SandboxExecutionToken` bound to `op_id`, `state_binding = sha256(candidate_files)`, `payload = {exit_code: "0", iso_fingerprint, image}`. **Non-zero / container spawn failure** → `SandboxLockFailed` → terminate DAG, rollback, **zero writes to the real tree**.
+
+Token is "strictly tied to a successful L4 container exit code" per mandate.
+Env: `JARVIS_A1_SANDBOX_LOCK_ENABLED` (default false); composes under `JARVIS_RUNTIME_SANDBOX_ENABLED`.
+
+---
+
+## 5. Gate ② — Cryptographic Blast-Radius Verification (post-VERIFY, pre-commit)
+
+**New module:** `backend/core/ouroboros/governance/blast_radius_verify.py`
+**Wired:** `phase_runners/slice4b_runner.py`, between the verify gate (~:1034) and Phase 8b auto-commit (:1091). Pre-op tree-SHA captured alongside the existing `WorkspaceCheckpointManager.create_checkpoint` (~:415).
+
+```python
+async def acquire_blast_radius_token(
+    *, op_id, ctx, pre_op_tree_sha, best_candidate, chain, prev_token
+) -> BlastRadiusClearedToken         # raises BlastRadiusBreach | BlastRadiusGraphFailure
+```
+
+**Behavior:**
+1. **Reverse-dependency closure** — compute the full set of tests that touch the modified AST via `call_graph_blast` / `blast_radius_adapter` (reverse-deps of `ctx.target_files ∪ _iter_candidate_files(best_candidate)`).
+2. **Fail-Closed Graph Guard** — any parse error, cyclic-dependency crash, or invalid graph → raise `BlastRadiusGraphFailure` → tree-SHA rollback + `intake_dlq.append_dlq(reason="blast_radius_graph_failure")` → POSTMORTEM. **No marker fallback, no skip.**
+3. **Run that exact set, no retry** (strict flake isolation — A1 phase). One failure = hard failure.
+4. **Out-of-scope failure** (failing test's source ∉ scope) **or any failure** → `WorkspaceCheckpointManager.restore_checkpoint(pre_op_tree_sha)`; **assert** `current_tree_sha == pre_op_tree_sha` (cryptographic rollback proof); `append_dlq(reason="blast_radius_breach")`; advance POSTMORTEM mirroring the existing `verify_regression` terminal block.
+5. **All pass** → mint `BlastRadiusClearedToken`(prev=`sandbox_token`, `state_binding = pre_op_tree_sha`, `payload = {post_tree_sha, test_set_hash, n_tests}`).
+
+Rollback is the **non-destructive tree-SHA checkpoint restore**, never `git reset --hard` (which would nuke concurrent autonomous work and fight `git_index_guard`).
+Env: `JARVIS_A1_BLAST_RADIUS_ENABLED` (default false).
+
+---
+
+## 6. Gate ③ — Autonomous PR Linter (pre-`gh pr create`, blocking)
+
+**New module:** `backend/core/ouroboros/governance/pr_self_linter.py`
+**Wired:** `orange_pr_reviewer.py::create_review_pr`, before the `git push` / `gh pr create` (~:303–324).
+
+```python
+async def acquire_lint_cleared_token(
+    *, op_id, diff, description, chain, prev_token
+) -> LintClearedToken                # raises LintRejected
+```
+
+**Behavior:** a **blocking** LLM architectural-rules critique. Reuse `self_critique.build_critique_prompt` / `parse_critique_json` / `collect_op_diff` and `DoublewordProvider.prompt_only(response_format={"type":"json_object"})` (cheapest bounded structured call). Critique the diff against this repo's rules — **no hardcoding (intent), DRY, explicit error handling, async-first, env-var-driven config**. Below threshold → raise `LintRejected` → `create_review_pr` returns `None` → existing CLI-approval fall-through. This is genuinely new surface: SemanticGuardian covers deterministic *patterns*; this covers *semantic intent* the regex/AST gate cannot.
+
+**Signature change (the enforcer bite):**
+```python
+async def create_review_pr(self, *, ..., sandbox_token: SandboxExecutionToken,
+                           blast_token: BlastRadiusClearedToken, lint_token: LintClearedToken) -> PRReviewResult | None:
+    if not self._chain.verify_chain([sandbox_token, blast_token, lint_token], op_id=op_id):
+        return None    # refuse — cannot reach `gh pr create`
+```
+Env: `JARVIS_A1_PR_LINTER_ENABLED` (default false). When `JARVIS_A1_TOKEN_ENFORCER_ENABLED=false`, tokens default `None` and the verify is skipped (legacy parity).
+
+---
+
+## 7. Phase 2 — Hybrid-Cloud sandbox routing (the adaptive edge case)
+
+When the Docker pre-flight finds no local daemon, the op is flagged `REQUIRES_CLOUD_EXECUTION` and the Sandbox Exec Lock runs **on the GCP node** (native container support), not locally.
+
+**Reuse:** the proven failover mesh — ADC IAM bridge (`gcp_compute_rest.py`), REST `instances.insert`, /32 ephemeral firewall, Reachability Racer, dead-man teardown.
+**New (Phase 2 only):** `remote_sandbox_executor.py` — a thin service on the node that accepts the candidate, runs `run_in_container` there, and **streams the exit code + iso-fingerprint back** over the existing event-channel; the local `DAGProofChain` mints the `SandboxExecutionToken` from the streamed L4 result (the secret never leaves the local process — the node returns *evidence*, the local chain mints the *token*).
+
+**Phase 1 deliberately stops at the flag** (terminate + emit `REQUIRES_CLOUD_EXECUTION`). The first A1 ignition runs the local driver with Docker Desktop up, so the local container path mints the token. This keeps the heaviest subsystem off the critical path to the first autonomous PR. YAGNI until the local proof lands.
+
+---
+
+## 8. Branch reconciliation (no duplication)
+
+- **`feat/a1-disable-file-isolation`** (unmerged) — pins file-isolation OFF via launch manifest so autonomous writes land durably in `repo_root` (`written=True`), *"the last `fsm_classify_to_applied` blocker."* **Required** for A1 to reach `applied`. Reconcile into the A1 launch manifest, not re-implement.
+- **`feat/isomorphic-sandbox-enhancements`** (unmerged) — faithful DW-mock (dynamic `/v1` schema, 4-stage batch API, SSE). Fold into `synthetic_adversary.py` / the local driver fidelity.
+
+---
+
+## 9. Reuse map (existing → role; zero duplication)
+
+| Need | Existing asset | Net-new |
+|---|---|---|
+| Hardened L4 container exec | `container_sandbox.run_in_container` | call it on the *candidate* (was inert) |
+| Isomorphic path/env parity | `IsomorphicEnv`, `WorktreeManager` | compose in the lock |
+| Crypto pre-op tree hash | `WorkspaceCheckpointManager` (`git stash create` SHA) | post-restore SHA-equality assertion |
+| SHA-256 primitive | `state_drift`, `change_engine`, `verify_gate` | — |
+| Reverse-dep test graph | `call_graph_blast`, `blast_radius_adapter` | run-the-set + fail-closed guard |
+| Cryo-DLQ entry | `intake_dlq.append_dlq(reason=…)` | new reasons |
+| Rollback restore | `verify_gate.rollback_files`, `WorkspaceCheckpointManager.restore_checkpoint` | — |
+| LLM diff critique helpers | `self_critique.{build_critique_prompt,parse_critique_json,collect_op_diff}` | **blocking** variant + token |
+| Cheapest structured LLM call | `DoublewordProvider.prompt_only(json_object)` | — |
+| PR creation | `OrangePRReviewer.create_review_pr` | token-gated signature |
+| Local A1 E2E driver | `scripts/isomorphic_a1_local.py` | ignition runbook |
+| A1 verdict | `scripts/a1_graduation_auditor.py` (`A1_DISPATCH_PROVEN`) | — |
+
+---
+
+## 10. Env flags (all default-OFF → byte-identical rollback)
+
+`JARVIS_A1_TOKEN_ENFORCER_ENABLED`, `JARVIS_A1_SANDBOX_LOCK_ENABLED`, `JARVIS_A1_BLAST_RADIUS_ENABLED`, `JARVIS_A1_PR_LINTER_ENABLED` — each independently gated; composes under the existing `JARVIS_RUNTIME_SANDBOX_ENABLED`. Armed only for the A1 soak. Registered in `FlagRegistry`.
+
+---
+
+## 11. Testing strategy
+
+- **Token enforcer:** forgery rejected (bad HMAC), replay rejected (mutated `state_binding`), chain tamper rejected (reordered/omitted), `create_review_pr` un-callable without tokens.
+- **Gate ①:** non-zero container exit → `SandboxLockFailed` + zero writes; no-Docker → `RequiresCloudExecution` (no process fallback); pass → valid chained token.
+- **Gate ②:** out-of-scope failure → tree-SHA restore + `restored==pre_op` assert + DLQ; graph failure → fail-closed + DLQ; pass → token chains to ①.
+- **Gate ③:** rule violation → `LintRejected` → `create_review_pr` returns `None`; pass → token chains to ②.
+- **OFF parity:** every flag off → byte-identical (0 behavioral delta) regression.
+- **E2E:** `isomorphic_a1_local.py` drives the full chain locally to `A1_DISPATCH_PROVEN` ($0/minutes), then one cloud confirm.
+
+---
+
+## 12. Non-goals / YAGNI
+
+- No `git reset --hard` in the apply path (rejected: destroys concurrent work; tree-SHA restore is the correct primitive).
+- No marker-curated or full-suite regression set (rejected: hardcoded or budget-blowing).
+- No process-isolation fallback for the sandbox (rejected: L4→L3 downgrade violates zero-trust).
+- Phase 2 hybrid-cloud executor is built **after** the local A1 proof, not before.
+- No new model names; all provider routing via existing policy.
+
+---
+
+## 13. Ignition runbook (endgame)
+
+1. Land Phase 1 (Triad + Enforcer) behind the four flags; reconcile the two branches.
+2. `python3 scripts/isomorphic_a1_local.py --mode container` with Docker Desktop up → drive to `A1_DISPATCH_PROVEN` locally.
+3. Capture failure telemetry on any non-proven (`failure_telemetry.capture_failure_telemetry`); fix; repeat at $0/minutes.
+4. One confirming cloud soak (`--max-wall-seconds 2400 --headless`) → `A1_DISPATCH_PROVEN` live → **first autonomous PR** → A1 gate passes → EXECUTION grade moves off C+.

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -483,6 +483,20 @@ class IsomorphicA1Driver:
                 if not self.enable_failover:
                     env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] = "false"
 
+                # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
+                # (all default OFF in prod; this driver IS the A1 ignition harness).
+                env["JARVIS_RUNTIME_SANDBOX_ENABLED"] = "true"   # L4 container backend
+                env["JARVIS_A1_SANDBOX_LOCK_ENABLED"] = "true"   # Gate 1
+                env["JARVIS_A1_BLAST_RADIUS_ENABLED"] = "true"   # Gate 2
+                env["JARVIS_A1_PR_LINTER_ENABLED"] = "true"      # Gate 3
+                env["JARVIS_A1_TOKEN_ENFORCER_ENABLED"] = "true" # enforcer (PR needs token chain)
+                # File-isolation OFF -> autonomous writes land in repo_root ->
+                # durable commit (written=True) -> fixes the fsm_classify_to_applied
+                # blocker. Mirrors the failover_lifecycle pin (stale a1-disable-file-
+                # isolation branch folded here as 2 env vars).
+                env["JARVIS_FILE_ISOLATION_ENABLED"] = "false"
+                env["JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED"] = "false"
+
                 _log("env composed: %d keys total, adversary overrides applied, "
                      "failover=%s" % (len(env), "enabled" if self.enable_failover
                                       else "pinned-off"))

--- a/tests/governance/test_a1_flags_registered.py
+++ b/tests/governance/test_a1_flags_registered.py
@@ -14,3 +14,14 @@ def test_iron_triad_flags_registered():
         "JARVIS_TOKEN_AUDIT_ENABLED",
     ):
         assert f in names, f"{f} not registered"
+
+
+def test_iron_triad_tuning_flags_registered():
+    reg = ensure_seeded()
+    names = {s.name for s in reg.list_all()}
+    for f in (
+        "JARVIS_A1_PR_LINTER_THRESHOLD",
+        "JARVIS_TOKEN_AUDIT_PATH",
+        "JARVIS_TOKEN_AUDIT_MAX",
+    ):
+        assert f in names, f"{f} not registered"

--- a/tests/governance/test_a1_flags_registered.py
+++ b/tests/governance/test_a1_flags_registered.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.flag_registry import ensure_seeded
+
+
+def test_iron_triad_flags_registered():
+    reg = ensure_seeded()
+    names = {s.name for s in reg.list_all()}
+    for f in (
+        "JARVIS_A1_TOKEN_ENFORCER_ENABLED",
+        "JARVIS_A1_SANDBOX_LOCK_ENABLED",
+        "JARVIS_A1_BLAST_RADIUS_ENABLED",
+        "JARVIS_A1_PR_LINTER_ENABLED",
+        "JARVIS_TOKEN_AUDIT_ENABLED",
+    ):
+        assert f in names, f"{f} not registered"

--- a/tests/governance/test_autonomous_pr_pipeline.py
+++ b/tests/governance/test_autonomous_pr_pipeline.py
@@ -1,0 +1,251 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import autonomous_pr_pipeline as app
+from backend.core.ouroboros.governance.autonomous_pr_pipeline import (
+    PRGatePipelineError,
+    PRGateResult,
+    pipeline_enabled,
+    run_pr_gate_pipeline,
+)
+from backend.core.ouroboros.governance.blast_radius_verify import (
+    acquire_blast_radius_token,
+)
+from backend.core.ouroboros.governance.dag_capability_token import (
+    BlastRadiusClearedToken,
+    DAGProofChain,
+    SandboxExecutionToken,
+    TokenKind,
+)
+from backend.core.ouroboros.governance.pre_apply_exec_lock import (
+    RequiresCloudExecution,
+    SandboxLockFailed,
+)
+
+OP_ID = "op-13b"
+BRANCH = f"ouroboros/a1-validate/{OP_ID}"
+CANDIDATE = [("backend/x.py", "x = 1\n")]
+
+
+def _real_sandbox_gate(chain: DAGProofChain):
+    """A seam that mints a REAL branch-bound SandboxExecutionToken on the chain
+    (so the branch-bound chain genuinely chains + verifies)."""
+
+    async def _gate(*, op_id, candidate_files, repo_root, chain, branch_context):
+        return chain.mint(
+            kind=TokenKind.SANDBOX_EXECUTION,
+            op_id=op_id,
+            state_binding="cand",
+            payload={"exit_code": "0"},
+            prev=None,
+            branch_context=branch_context,
+        )
+
+    return _gate
+
+
+@pytest.mark.asyncio
+async def test_pipeline_success_assembles_chain(tmp_path):
+    chain = DAGProofChain()
+    cleanup_calls = []
+
+    async def factory(branch):
+        assert branch == BRANCH
+        return tmp_path
+
+    async def cleanup(wt):
+        cleanup_calls.append(wt)
+
+    async def apply_candidate(wt, files):
+        return None
+
+    async def graph_resolver(files, *, repo_root, oracle=None):
+        return {"tests/test_x.py"}
+
+    async def test_run_fn(tests, wt):
+        return {"failed": [], "total": 1}
+
+    async def tree_sha_fn(wt):
+        return "sha"
+
+    result = await run_pr_gate_pipeline(
+        op_id=OP_ID,
+        candidate_files=CANDIDATE,
+        repo_root=str(tmp_path),
+        chain=chain,
+        worktree_factory=factory,
+        worktree_cleanup=cleanup,
+        sandbox_gate=_real_sandbox_gate(chain),
+        blast_gate=acquire_blast_radius_token,  # the REAL Gate 2
+        apply_candidate=apply_candidate,
+        graph_resolver=graph_resolver,
+        test_run_fn=test_run_fn,
+        tree_sha_fn=tree_sha_fn,
+    )
+
+    assert isinstance(result, PRGateResult)
+    assert isinstance(result.sandbox_token, SandboxExecutionToken)
+    assert isinstance(result.blast_token, BlastRadiusClearedToken)
+    assert result.branch_context == BRANCH
+    # Both tokens minted in the SAME branch context.
+    assert result.sandbox_token.branch_context == BRANCH
+    assert result.blast_token.branch_context == BRANCH
+    # blast chains onto sandbox (prev-link).
+    assert result.blast_token.prev_hash == result.sandbox_token.digest()
+    # Both verify on the SAME chain instance.
+    assert chain.verify(result.sandbox_token)
+    assert chain.verify(result.blast_token)
+    # Cleanup WAS called (success path).
+    assert cleanup_calls == [tmp_path]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("exc", [SandboxLockFailed("boom"), RequiresCloudExecution("no docker")])
+async def test_pipeline_gate1_failure_raises_and_cleans_up(tmp_path, exc):
+    chain = DAGProofChain()
+    cleanup_calls = []
+
+    async def factory(branch):
+        return tmp_path
+
+    async def cleanup(wt):
+        cleanup_calls.append(wt)
+
+    async def sandbox_gate(**kwargs):
+        raise exc
+
+    with pytest.raises(PRGatePipelineError):
+        await run_pr_gate_pipeline(
+            op_id=OP_ID,
+            candidate_files=CANDIDATE,
+            repo_root=str(tmp_path),
+            chain=chain,
+            worktree_factory=factory,
+            worktree_cleanup=cleanup,
+            sandbox_gate=sandbox_gate,
+        )
+    # Cleanup ran via finally even though Gate 1 rejected.
+    assert cleanup_calls == [tmp_path]
+
+
+@pytest.mark.asyncio
+async def test_pipeline_gate2_failure_raises_and_cleans_up(tmp_path):
+    chain = DAGProofChain()
+    cleanup_calls = []
+
+    async def factory(branch):
+        return tmp_path
+
+    async def cleanup(wt):
+        cleanup_calls.append(wt)
+
+    async def apply_candidate(wt, files):
+        return None
+
+    async def graph_resolver(files, *, repo_root, oracle=None):
+        return {"tests/test_x.py"}
+
+    async def test_run_fn(tests, wt):
+        # A real Gate 2 breach: a non-empty failed list.
+        return {"failed": ["tests/test_x.py::test_a"], "total": 1}
+
+    async def tree_sha_fn(wt):
+        return "sha-pre"
+
+    with pytest.raises(PRGatePipelineError):
+        await run_pr_gate_pipeline(
+            op_id=OP_ID,
+            candidate_files=CANDIDATE,
+            repo_root=str(tmp_path),
+            chain=chain,
+            worktree_factory=factory,
+            worktree_cleanup=cleanup,
+            sandbox_gate=_real_sandbox_gate(chain),
+            blast_gate=acquire_blast_radius_token,  # REAL Gate 2
+            apply_candidate=apply_candidate,
+            graph_resolver=graph_resolver,
+            test_run_fn=test_run_fn,
+            tree_sha_fn=tree_sha_fn,
+        )
+    assert cleanup_calls == [tmp_path]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_runs_even_on_unexpected_error(tmp_path):
+    chain = DAGProofChain()
+    cleanup_calls = []
+
+    async def factory(branch):
+        return tmp_path
+
+    async def cleanup(wt):
+        cleanup_calls.append(wt)
+
+    async def apply_candidate(wt, files):
+        raise ValueError("unexpected seam crash")
+
+    with pytest.raises(ValueError):
+        await run_pr_gate_pipeline(
+            op_id=OP_ID,
+            candidate_files=CANDIDATE,
+            repo_root=str(tmp_path),
+            chain=chain,
+            worktree_factory=factory,
+            worktree_cleanup=cleanup,
+            sandbox_gate=_real_sandbox_gate(chain),
+            apply_candidate=apply_candidate,
+        )
+    # An UNEXPECTED (non-gate) error still triggers cleanup via finally.
+    assert cleanup_calls == [tmp_path]
+
+
+@pytest.mark.asyncio
+async def test_cleanup_failure_does_not_mask_result(tmp_path):
+    """A best-effort cleanup failure is swallowed -- the real result wins."""
+    chain = DAGProofChain()
+
+    async def factory(branch):
+        return tmp_path
+
+    async def cleanup(wt):
+        raise OSError("rmtree boom")
+
+    async def apply_candidate(wt, files):
+        return None
+
+    async def graph_resolver(files, *, repo_root, oracle=None):
+        return set()
+
+    async def test_run_fn(tests, wt):
+        return {"failed": [], "total": 0}
+
+    async def tree_sha_fn(wt):
+        return "sha"
+
+    result = await run_pr_gate_pipeline(
+        op_id=OP_ID,
+        candidate_files=CANDIDATE,
+        repo_root=str(tmp_path),
+        chain=chain,
+        worktree_factory=factory,
+        worktree_cleanup=cleanup,
+        sandbox_gate=_real_sandbox_gate(chain),
+        blast_gate=acquire_blast_radius_token,
+        apply_candidate=apply_candidate,
+        graph_resolver=graph_resolver,
+        test_run_fn=test_run_fn,
+        tree_sha_fn=tree_sha_fn,
+    )
+    assert isinstance(result, PRGateResult)
+
+
+def test_pipeline_disabled_flag(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", raising=False)
+    assert pipeline_enabled() is False
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "true")
+    assert pipeline_enabled() is True
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false")
+    assert pipeline_enabled() is False
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "1")
+    assert pipeline_enabled() is True

--- a/tests/governance/test_blast_radius_verify.py
+++ b/tests/governance/test_blast_radius_verify.py
@@ -198,6 +198,36 @@ async def test_dlq_fn_exception_does_not_mask_primary_failure():
 
 
 @pytest.mark.asyncio
+async def test_branch_context_forwarded_to_token():
+    chain = DAGProofChain()
+    prev = _prev(chain)
+
+    async def graph_fn(files):
+        return {"tests/test_x.py"}
+
+    async def test_fn(tests):
+        return {"failed": [], "total": 1}
+
+    async def sha_fn():
+        return PRE
+
+    tok = await brv.acquire_blast_radius_token(
+        op_id="op-1",
+        scope_files=SCOPE,
+        pre_op_tree_sha=PRE,
+        chain=chain,
+        prev_token=prev,
+        graph_fn=graph_fn,
+        test_fn=test_fn,
+        current_tree_sha_fn=sha_fn,
+        rollback_fn=None,
+        dlq_fn=None,
+        branch_context="wt-1",
+    )
+    assert tok.branch_context == "wt-1"
+
+
+@pytest.mark.asyncio
 async def test_unexpected_test_fn_error_rolls_back():
     chain = DAGProofChain()
     prev = _prev(chain)

--- a/tests/governance/test_blast_radius_verify.py
+++ b/tests/governance/test_blast_radius_verify.py
@@ -195,3 +195,41 @@ async def test_dlq_fn_exception_does_not_mask_primary_failure():
             rollback_fn=rollback_fn,
             dlq_fn=boom_dlq,
         )
+
+
+@pytest.mark.asyncio
+async def test_unexpected_test_fn_error_rolls_back():
+    chain = DAGProofChain()
+    prev = _prev(chain)
+    calls: dict = {"rollback": 0, "dlq": []}
+
+    async def graph_fn(files):
+        return {"tests/test_x.py"}
+
+    async def test_fn(tests):
+        raise RuntimeError("pytest harness exploded")
+
+    async def rollback_fn(sha):
+        calls["rollback"] += 1
+
+    async def sha_pre():
+        return PRE
+
+    def dlq_fn(reason):
+        calls["dlq"].append(reason)
+
+    with pytest.raises(brv.BlastRadiusBreach):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1",
+            scope_files=SCOPE,
+            pre_op_tree_sha=PRE,
+            chain=chain,
+            prev_token=prev,
+            graph_fn=graph_fn,
+            test_fn=test_fn,
+            current_tree_sha_fn=sha_pre,
+            rollback_fn=rollback_fn,
+            dlq_fn=dlq_fn,
+        )
+    assert calls["rollback"] == 1
+    assert calls["dlq"] == ["blast_radius_unexpected"]

--- a/tests/governance/test_blast_radius_verify.py
+++ b/tests/governance/test_blast_radius_verify.py
@@ -1,0 +1,161 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import blast_radius_verify as brv
+from backend.core.ouroboros.governance.dag_capability_token import (
+    BlastRadiusClearedToken,
+    DAGProofChain,
+    TokenKind,
+)
+
+SCOPE = ["backend/x.py"]
+PRE = "tree-sha-pre"
+
+
+def _prev(chain: DAGProofChain):
+    return chain.mint(
+        kind=TokenKind.SANDBOX_EXECUTION,
+        op_id="op-1",
+        state_binding="cand",
+        payload={"exit_code": "0"},
+    )
+
+
+@pytest.mark.asyncio
+async def test_all_pass_mints_chained_token():
+    chain = DAGProofChain()
+    prev = _prev(chain)
+
+    async def graph_fn(files):
+        return {"tests/test_x.py"}
+
+    async def test_fn(tests):
+        return {"failed": [], "total": 3}
+
+    async def sha_fn():
+        return PRE
+
+    tok = await brv.acquire_blast_radius_token(
+        op_id="op-1",
+        scope_files=SCOPE,
+        pre_op_tree_sha=PRE,
+        chain=chain,
+        prev_token=prev,
+        graph_fn=graph_fn,
+        test_fn=test_fn,
+        current_tree_sha_fn=sha_fn,
+        rollback_fn=None,
+        dlq_fn=None,
+    )
+    assert isinstance(tok, BlastRadiusClearedToken)
+    assert tok.prev_hash == prev.digest()  # chained to Gate 1
+    assert tok.state_binding == PRE
+
+
+@pytest.mark.asyncio
+async def test_any_failure_rolls_back_and_asserts_sha_and_dlqs():
+    chain = DAGProofChain()
+    prev = _prev(chain)
+    calls: dict = {"rollback": 0, "dlq": []}
+
+    async def graph_fn(files):
+        return {"tests/test_x.py"}
+
+    async def test_fn(tests):
+        return {"failed": ["tests/test_x.py::t"], "total": 3}
+
+    async def rollback_fn(sha):
+        calls["rollback"] += 1
+
+    async def sha_fn():
+        return PRE
+
+    def dlq_fn(reason):
+        calls["dlq"].append(reason)
+
+    with pytest.raises(brv.BlastRadiusBreach):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1",
+            scope_files=SCOPE,
+            pre_op_tree_sha=PRE,
+            chain=chain,
+            prev_token=prev,
+            graph_fn=graph_fn,
+            test_fn=test_fn,
+            current_tree_sha_fn=sha_fn,
+            rollback_fn=rollback_fn,
+            dlq_fn=dlq_fn,
+        )
+    assert calls["rollback"] == 1
+    assert calls["dlq"] == ["blast_radius_breach"]
+
+
+@pytest.mark.asyncio
+async def test_graph_failure_is_fail_closed_and_dlqs():
+    chain = DAGProofChain()
+    prev = _prev(chain)
+    calls: dict = {"rollback": 0, "dlq": []}
+
+    async def graph_fn(files):
+        raise ValueError("cyclic")
+
+    async def test_fn(tests):
+        raise AssertionError("must not run tests on graph failure")
+
+    async def rollback_fn(sha):
+        calls["rollback"] += 1
+
+    async def sha_fn():
+        return PRE
+
+    def dlq_fn(reason):
+        calls["dlq"].append(reason)
+
+    with pytest.raises(brv.BlastRadiusGraphFailure):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1",
+            scope_files=SCOPE,
+            pre_op_tree_sha=PRE,
+            chain=chain,
+            prev_token=prev,
+            graph_fn=graph_fn,
+            test_fn=test_fn,
+            current_tree_sha_fn=sha_fn,
+            rollback_fn=rollback_fn,
+            dlq_fn=dlq_fn,
+        )
+    assert calls["rollback"] == 1
+    assert calls["dlq"] == ["blast_radius_graph_failure"]
+
+
+@pytest.mark.asyncio
+async def test_rollback_sha_mismatch_raises():
+    chain = DAGProofChain()
+    prev = _prev(chain)
+
+    async def graph_fn(files):
+        return {"tests/test_x.py"}
+
+    async def test_fn(tests):
+        return {"failed": ["t"], "total": 1}
+
+    async def sha_fn():
+        return "DIFFERENT"
+
+    async def rollback_fn(sha):
+        pass
+
+    with pytest.raises(brv.BlastRadiusBreach):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1",
+            scope_files=SCOPE,
+            pre_op_tree_sha=PRE,
+            chain=chain,
+            prev_token=prev,
+            graph_fn=graph_fn,
+            test_fn=test_fn,
+            current_tree_sha_fn=sha_fn,
+            rollback_fn=rollback_fn,
+            dlq_fn=lambda r: None,
+        )

--- a/tests/governance/test_blast_radius_verify.py
+++ b/tests/governance/test_blast_radius_verify.py
@@ -159,3 +159,39 @@ async def test_rollback_sha_mismatch_raises():
             rollback_fn=rollback_fn,
             dlq_fn=lambda r: None,
         )
+
+
+@pytest.mark.asyncio
+async def test_dlq_fn_exception_does_not_mask_primary_failure():
+    chain = DAGProofChain()
+    prev = _prev(chain)
+
+    async def graph_fn(files):
+        return {"tests/test_x.py"}
+
+    async def test_fn(tests):
+        return {"failed": ["tests/test_x.py::t"], "total": 1}
+
+    async def rollback_fn(sha):
+        pass
+
+    async def sha_pre():
+        return PRE
+
+    def boom_dlq(reason):
+        raise IOError("dlq disk full")
+
+    # The primary BlastRadiusBreach must still surface, NOT the IOError.
+    with pytest.raises(brv.BlastRadiusBreach):
+        await brv.acquire_blast_radius_token(
+            op_id="op-1",
+            scope_files=SCOPE,
+            pre_op_tree_sha=PRE,
+            chain=chain,
+            prev_token=prev,
+            graph_fn=graph_fn,
+            test_fn=test_fn,
+            current_tree_sha_fn=sha_pre,
+            rollback_fn=rollback_fn,
+            dlq_fn=boom_dlq,
+        )

--- a/tests/governance/test_checkpoint_tree_sha.py
+++ b/tests/governance/test_checkpoint_tree_sha.py
@@ -27,6 +27,21 @@ async def test_working_tree_content_sha_is_deterministic(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_clean_tree_resolves_to_head_tree(tmp_path):
+    _git(["init"], tmp_path)
+    _git(["config", "user.email", "t@t"], tmp_path)
+    _git(["config", "user.name", "t"], tmp_path)
+    (tmp_path / "a.py").write_text("x = 1\n")
+    _git(["add", "."], tmp_path)
+    _git(["commit", "-m", "init"], tmp_path)
+    mgr = WorkspaceCheckpointManager(tmp_path)
+    # clean tree: git stash create is empty -> falls back to HEAD^{tree}
+    clean_sha = await mgr.working_tree_content_sha()
+    head_tree = await mgr.tree_sha_for_ref("")  # "" -> HEAD inside the helper
+    assert clean_sha and clean_sha == head_tree
+
+
+@pytest.mark.asyncio
 async def test_content_sha_changes_with_content(tmp_path):
     _git(["init"], tmp_path)
     _git(["config", "user.email", "t@t"], tmp_path)

--- a/tests/governance/test_checkpoint_tree_sha.py
+++ b/tests/governance/test_checkpoint_tree_sha.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+import asyncio
+import subprocess
+
+import pytest
+from backend.core.ouroboros.governance.workspace_checkpoint import WorkspaceCheckpointManager
+
+
+def _git(args, cwd):
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+@pytest.mark.asyncio
+async def test_working_tree_content_sha_is_deterministic(tmp_path):
+    _git(["init"], tmp_path)
+    _git(["config", "user.email", "t@t"], tmp_path)
+    _git(["config", "user.name", "t"], tmp_path)
+    (tmp_path / "a.py").write_text("x = 1\n")
+    _git(["add", "."], tmp_path)
+    _git(["commit", "-m", "init"], tmp_path)
+    # make a working-tree change so stash create is non-empty
+    (tmp_path / "a.py").write_text("x = 2\n")
+    mgr = WorkspaceCheckpointManager(tmp_path)
+    sha1 = await mgr.working_tree_content_sha()
+    sha2 = await mgr.working_tree_content_sha()
+    assert sha1 and sha1 == sha2  # SAME content -> SAME tree sha (the bug was: differ)
+
+
+@pytest.mark.asyncio
+async def test_content_sha_changes_with_content(tmp_path):
+    _git(["init"], tmp_path)
+    _git(["config", "user.email", "t@t"], tmp_path)
+    _git(["config", "user.name", "t"], tmp_path)
+    (tmp_path / "a.py").write_text("x = 1\n")
+    _git(["add", "."], tmp_path)
+    _git(["commit", "-m", "init"], tmp_path)
+    mgr = WorkspaceCheckpointManager(tmp_path)
+    (tmp_path / "a.py").write_text("x = 2\n")
+    sha_a = await mgr.working_tree_content_sha()
+    (tmp_path / "a.py").write_text("x = 3\n")
+    sha_b = await mgr.working_tree_content_sha()
+    assert sha_a != sha_b  # different content -> different tree sha

--- a/tests/governance/test_dag_capability_token.py
+++ b/tests/governance/test_dag_capability_token.py
@@ -32,10 +32,13 @@ def test_typed_aliases_match_kind():
 
 def test_forged_hmac_rejected():
     chain = DAGProofChain()
-    t1, _, _ = _full_chain(chain)
+    t1, t2, t3 = _full_chain(chain)
     forged = dataclasses.replace(t1, sig="deadbeef" * 8)
+    # Isolates HMAC failure: recomputed HMAC over correct fields does not match forged sig.
     assert chain.verify(forged) is False
-    assert chain.verify_chain([forged, *_full_chain(chain)[1:]], op_id=OP) is False
+    # Defense-in-depth: forgery is rejected at the chain level (position-0 HMAC fails;
+    # t2/t3 are the originals from the same mint so their prev_hash links are intact).
+    assert chain.verify_chain([forged, t2, t3], op_id=OP) is False
 
 def test_replayed_state_binding_rejected():
     # A token signed for state A cannot be re-pointed at state B.
@@ -80,3 +83,10 @@ def test_wrong_terminal_kind_rejected():
     t1 = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=OP, state_binding="a", payload={})
     t2 = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=OP, state_binding="b", payload={}, prev=t1)
     assert chain.verify_chain([t1, t2], op_id=OP) is False
+
+def test_tampered_timestamp_rejected():
+    # issued_monotonic is now inside the HMAC envelope; rolling it back to 0.0 must fail.
+    chain = DAGProofChain()
+    t1, _, _ = _full_chain(chain)
+    tampered = dataclasses.replace(t1, issued_monotonic=0.0)
+    assert chain.verify(tampered) is False

--- a/tests/governance/test_dag_capability_token.py
+++ b/tests/governance/test_dag_capability_token.py
@@ -90,3 +90,61 @@ def test_tampered_timestamp_rejected():
     t1, _, _ = _full_chain(chain)
     tampered = dataclasses.replace(t1, issued_monotonic=0.0)
     assert chain.verify(tampered) is False
+
+
+def _full_chain_ctx(chain: DAGProofChain, ctx: str, op_id: str = OP):
+    """Mint a full SANDBOX -> BLAST -> LINT chain, every token bound to ``ctx``."""
+    t1 = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=op_id,
+                    state_binding="cand-sha", payload={"exit_code": "0"},
+                    branch_context=ctx)
+    t2 = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=op_id,
+                    state_binding="tree-sha", payload={"n_tests": "7"}, prev=t1,
+                    branch_context=ctx)
+    t3 = chain.mint(kind=TokenKind.LINT_CLEARED, op_id=op_id,
+                    state_binding="diff-sha", payload={"rating": "5"}, prev=t2,
+                    branch_context=ctx)
+    return t1, t2, t3
+
+
+def test_branch_context_signed():
+    # branch_context is part of the HMAC envelope: re-pointing a token minted in
+    # worktree wt-1 at wt-2 breaks the signature (token-injection guard).
+    chain = DAGProofChain()
+    tok = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=OP,
+                     state_binding="cand-sha", payload={"exit_code": "0"},
+                     branch_context="wt-1")
+    assert chain.verify(tok) is True
+    tampered = dataclasses.replace(tok, branch_context="wt-2")
+    assert chain.verify(tampered) is False
+
+
+def test_chain_rejects_mixed_branch_context():
+    # A chain whose tokens were minted in DIFFERENT worktrees must be rejected:
+    # a token from wt-2 cannot be spliced into a chain rooted in wt-1.
+    chain = DAGProofChain()
+    t1 = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=OP,
+                    state_binding="cand-sha", payload={"exit_code": "0"},
+                    branch_context="wt-1")
+    t2 = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=OP,
+                    state_binding="tree-sha", payload={"n_tests": "7"}, prev=t1,
+                    branch_context="wt-2")
+    t3 = chain.mint(kind=TokenKind.LINT_CLEARED, op_id=OP,
+                    state_binding="diff-sha", payload={"rating": "5"}, prev=t2,
+                    branch_context="wt-1")
+    # prev-links are valid (real mint() chaining) but contexts are not uniform.
+    assert chain.verify_chain([t1, t2, t3], op_id=OP) is False
+
+
+def test_chain_accepts_uniform_branch_context():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain_ctx(chain, "wt-1")
+    assert chain.verify_chain([t1, t2, t3], op_id=OP) is True
+
+
+def test_empty_branch_context_backward_compatible():
+    # Existing-style tokens minted WITHOUT branch_context default to "" -- a
+    # uniform-"" chain stays valid (Tasks 1-11 auto-apply path is unbroken).
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert all(t.branch_context == "" for t in (t1, t2, t3))
+    assert chain.verify_chain([t1, t2, t3], op_id=OP) is True

--- a/tests/governance/test_dag_capability_token.py
+++ b/tests/governance/test_dag_capability_token.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+import dataclasses
+import pytest
+from backend.core.ouroboros.governance.dag_capability_token import (
+    TokenKind, CapabilityToken, SandboxExecutionToken, BlastRadiusClearedToken,
+    LintClearedToken, DAGProofChain,
+)
+
+OP = "op-123"
+
+def _full_chain(chain: DAGProofChain, op_id: str = OP):
+    t1 = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=op_id,
+                    state_binding="cand-sha", payload={"exit_code": "0"})
+    t2 = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=op_id,
+                    state_binding="tree-sha", payload={"n_tests": "7"}, prev=t1)
+    t3 = chain.mint(kind=TokenKind.LINT_CLEARED, op_id=op_id,
+                    state_binding="diff-sha", payload={"rating": "5"}, prev=t2)
+    return t1, t2, t3
+
+def test_valid_chain_passes():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert chain.verify(t1) and chain.verify(t2) and chain.verify(t3)
+    assert chain.verify_chain([t1, t2, t3], op_id=OP) is True
+
+def test_typed_aliases_match_kind():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert isinstance(t1, SandboxExecutionToken)
+    assert isinstance(t2, BlastRadiusClearedToken)
+    assert isinstance(t3, LintClearedToken)
+
+def test_forged_hmac_rejected():
+    chain = DAGProofChain()
+    t1, _, _ = _full_chain(chain)
+    forged = dataclasses.replace(t1, sig="deadbeef" * 8)
+    assert chain.verify(forged) is False
+    assert chain.verify_chain([forged, *_full_chain(chain)[1:]], op_id=OP) is False
+
+def test_replayed_state_binding_rejected():
+    # A token signed for state A cannot be re-pointed at state B.
+    chain = DAGProofChain()
+    t1, _, _ = _full_chain(chain)
+    replayed = dataclasses.replace(t1, state_binding="DIFFERENT-sha")
+    assert chain.verify(replayed) is False
+
+def test_cross_secret_forgery_rejected():
+    # A token minted by a different process/secret never verifies here.
+    foreign = DAGProofChain()
+    t1, _, _ = _full_chain(foreign)
+    local = DAGProofChain()
+    assert local.verify(t1) is False
+
+def test_out_of_order_chain_rejected():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert chain.verify_chain([t2, t1, t3], op_id=OP) is False
+
+def test_omitted_token_rejected():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    assert chain.verify_chain([t1, t3], op_id=OP) is False
+
+def test_tampered_prev_hash_rejected():
+    chain = DAGProofChain()
+    t1, t2, t3 = _full_chain(chain)
+    broken = dataclasses.replace(t2, prev_hash="0" * 64)
+    assert chain.verify_chain([t1, broken, t3], op_id=OP) is False
+
+def test_cross_op_token_rejected():
+    chain = DAGProofChain()
+    good = _full_chain(chain, op_id=OP)
+    intruder = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id="other-op",
+                          state_binding="tree-sha", payload={}, prev=good[0])
+    assert chain.verify_chain([good[0], intruder, good[2]], op_id=OP) is False
+
+def test_wrong_terminal_kind_rejected():
+    # The final token MUST be LINT_CLEARED.
+    chain = DAGProofChain()
+    t1 = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id=OP, state_binding="a", payload={})
+    t2 = chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id=OP, state_binding="b", payload={}, prev=t1)
+    assert chain.verify_chain([t1, t2], op_id=OP) is False

--- a/tests/governance/test_docker_preflight.py
+++ b/tests/governance/test_docker_preflight.py
@@ -1,0 +1,9 @@
+from __future__ import annotations
+import pytest
+from backend.core.ouroboros.governance import pre_apply_exec_lock as lock
+
+
+@pytest.mark.asyncio
+async def test_preflight_reports_daemon_state():
+    assert await lock.docker_preflight(probe=lambda: True) is True
+    assert await lock.docker_preflight(probe=lambda: False) is False

--- a/tests/governance/test_docker_preflight.py
+++ b/tests/governance/test_docker_preflight.py
@@ -7,3 +7,25 @@ from backend.core.ouroboros.governance import pre_apply_exec_lock as lock
 async def test_preflight_reports_daemon_state():
     assert await lock.docker_preflight(probe=lambda: True) is True
     assert await lock.docker_preflight(probe=lambda: False) is False
+
+
+@pytest.mark.asyncio
+async def test_preflight_warns_when_gate_armed_and_absent(monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(lock, "lock_enabled", lambda: True)
+    with caplog.at_level(logging.WARNING):
+        result = await lock.docker_preflight(probe=lambda: False)
+    assert result is False
+    assert any(
+        "Docker daemon ABSENT" in r.getMessage() for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_preflight_no_warn_when_gate_off(monkeypatch, caplog):
+    import logging
+    monkeypatch.setattr(lock, "lock_enabled", lambda: False)
+    with caplog.at_level(logging.WARNING):
+        result = await lock.docker_preflight(probe=lambda: False)
+    assert result is False
+    assert not any("Docker daemon ABSENT" in r.getMessage() for r in caplog.records)

--- a/tests/governance/test_gate1_orchestrator_wiring.py
+++ b/tests/governance/test_gate1_orchestrator_wiring.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+import backend.core.ouroboros.governance.pre_apply_exec_lock as lock
+
+
+def test_lock_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_SANDBOX_LOCK_ENABLED", raising=False)
+    assert lock.lock_enabled() is False
+
+
+def test_lock_enabled_when_flagged(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_SANDBOX_LOCK_ENABLED", "true")
+    assert lock.lock_enabled() is True

--- a/tests/governance/test_gate2_slice4b_wiring.py
+++ b/tests/governance/test_gate2_slice4b_wiring.py
@@ -13,8 +13,8 @@ def test_enabled_when_flagged(monkeypatch):
     assert brv.blast_radius_enabled() is True
 
 
-def test_blast_token_field_present_and_carried():
-    """op_context exposes ``blast_token`` (default None) and ``advance`` carries it."""
+def test_blast_token_field_present():
+    """op_context exposes ``blast_token`` (default None)."""
     import dataclasses
     from backend.core.ouroboros.governance.op_context import OperationContext
 

--- a/tests/governance/test_gate2_slice4b_wiring.py
+++ b/tests/governance/test_gate2_slice4b_wiring.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+
+from backend.core.ouroboros.governance import blast_radius_verify as brv
+
+
+def test_disabled_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_BLAST_RADIUS_ENABLED", raising=False)
+    assert brv.blast_radius_enabled() is False
+
+
+def test_enabled_when_flagged(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_BLAST_RADIUS_ENABLED", "true")
+    assert brv.blast_radius_enabled() is True
+
+
+def test_blast_token_field_present_and_carried():
+    """op_context exposes ``blast_token`` (default None) and ``advance`` carries it."""
+    import dataclasses
+    from backend.core.ouroboros.governance.op_context import OperationContext
+
+    field_names = {f.name for f in dataclasses.fields(OperationContext)}
+    assert "blast_token" in field_names
+    # Default-OFF: zero behavioural change unless explicitly set.
+    default = next(
+        f for f in dataclasses.fields(OperationContext) if f.name == "blast_token"
+    )
+    assert default.default is None

--- a/tests/governance/test_orange_pr_token_gate.py
+++ b/tests/governance/test_orange_pr_token_gate.py
@@ -1,0 +1,59 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.orange_pr_reviewer import OrangePRReviewer
+from backend.core.ouroboros.governance.dag_capability_token import (
+    DAGProofChain,
+    TokenKind,
+)
+
+
+def _chain_tokens(chain, op_id="op-1"):
+    s = chain.mint(
+        kind=TokenKind.SANDBOX_EXECUTION, op_id=op_id, state_binding="c", payload={}
+    )
+    b = chain.mint(
+        kind=TokenKind.BLAST_RADIUS_CLEARED,
+        op_id=op_id,
+        state_binding="t",
+        payload={},
+        prev=s,
+    )
+    l = chain.mint(
+        kind=TokenKind.LINT_CLEARED,
+        op_id=op_id,
+        state_binding="d",
+        payload={},
+        prev=b,
+    )
+    return s, b, l
+
+
+@pytest.mark.asyncio
+async def test_refuses_without_valid_chain(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_A1_PR_LINTER_ENABLED", "false")  # don't trigger live linter
+    rv = OrangePRReviewer(str(tmp_path))
+    chain = DAGProofChain()
+    s, b, l = _chain_tokens(chain)
+    # Foreign-secret sandbox token -> verify_chain fails -> None (refuse), no git touched.
+    foreign = DAGProofChain()
+    s2, _, _ = _chain_tokens(foreign)
+    result = await rv.create_review_pr(
+        op_id="op-1",
+        description="d",
+        files=[("x.py", "y = 1\n")],
+        chain=chain,
+        sandbox_token=s2,
+        blast_token=b,
+        lint_token=l,
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_enforcer_off_is_legacy(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false")
+    rv = OrangePRReviewer(str(tmp_path))
+    assert rv._enforcer_enabled() is False

--- a/tests/governance/test_orange_pr_token_gate.py
+++ b/tests/governance/test_orange_pr_token_gate.py
@@ -9,9 +9,10 @@ from backend.core.ouroboros.governance.dag_capability_token import (
 )
 
 
-def _chain_tokens(chain, op_id="op-1"):
+def _chain_tokens(chain, op_id="op-1", branch_context=""):
     s = chain.mint(
-        kind=TokenKind.SANDBOX_EXECUTION, op_id=op_id, state_binding="c", payload={}
+        kind=TokenKind.SANDBOX_EXECUTION, op_id=op_id, state_binding="c",
+        payload={}, branch_context=branch_context,
     )
     b = chain.mint(
         kind=TokenKind.BLAST_RADIUS_CLEARED,
@@ -19,6 +20,7 @@ def _chain_tokens(chain, op_id="op-1"):
         state_binding="t",
         payload={},
         prev=s,
+        branch_context=branch_context,
     )
     l = chain.mint(
         kind=TokenKind.LINT_CLEARED,
@@ -26,6 +28,7 @@ def _chain_tokens(chain, op_id="op-1"):
         state_binding="d",
         payload={},
         prev=b,
+        branch_context=branch_context,
     )
     return s, b, l
 
@@ -57,3 +60,59 @@ async def test_enforcer_off_is_legacy(monkeypatch, tmp_path):
     monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "false")
     rv = OrangePRReviewer(str(tmp_path))
     assert rv._enforcer_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_refuses_on_branch_context_mismatch(monkeypatch, tmp_path):
+    """Tokens minted with branch_context='wt-A' must be refused when
+    expected_branch_context='wt-B'."""
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_A1_PR_LINTER_ENABLED", "false")
+    chain = DAGProofChain()
+    s, b, l = _chain_tokens(chain, branch_context="wt-A")
+    rv = OrangePRReviewer(str(tmp_path))
+    result = await rv.create_review_pr(
+        op_id="op-1",
+        description="d",
+        files=[("x.py", "y = 1\n")],
+        chain=chain,
+        sandbox_token=s,
+        blast_token=b,
+        lint_token=l,
+        expected_branch_context="wt-B",
+    )
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_matching_branch_context_passes_branch_check(monkeypatch, tmp_path):
+    """Tokens minted with branch_context='wt-A' and expected='wt-A' pass the
+    branch check (reaches git ops; returns None only due to no real git repo)."""
+    monkeypatch.setenv("JARVIS_A1_TOKEN_ENFORCER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_A1_PR_LINTER_ENABLED", "false")
+    chain = DAGProofChain()
+    s, b, l = _chain_tokens(chain, branch_context="wt-A")
+    rv = OrangePRReviewer(str(tmp_path))
+    # Inject a fake _run_git_sync that records calls and fails on rev-parse
+    # (simulates no real git repo) so the test stays hermetic.
+    calls: list = []
+
+    def fake_git(args):
+        calls.append(args)
+        return 1, "", "not a git repo"
+
+    rv._run_git_sync = fake_git
+    result = await rv.create_review_pr(
+        op_id="op-1",
+        description="d",
+        files=[("x.py", "y = 1\n")],
+        chain=chain,
+        sandbox_token=s,
+        blast_token=b,
+        lint_token=l,
+        expected_branch_context="wt-A",
+    )
+    # Result is None (git failed), but git was ATTEMPTED — proving the
+    # branch check was passed (not short-circuited by the mismatch guard).
+    assert result is None
+    assert any("rev-parse" in " ".join(c) for c in calls)

--- a/tests/governance/test_pr_self_linter.py
+++ b/tests/governance/test_pr_self_linter.py
@@ -30,3 +30,13 @@ async def test_low_rating_raises_lint_rejected():
     with pytest.raises(lint.LintRejected):
         await lint.acquire_lint_cleared_token(
             op_id="op-1", diff=DIFF, chain=chain, prev_token=prev, critique_fn=critique_fn)
+
+@pytest.mark.asyncio
+async def test_malformed_rating_fails_closed():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def critique_none(diff): return {"rating": None}
+    async def critique_garbage(diff): return {"rating": "five"}
+    for cf in (critique_none, critique_garbage):
+        with pytest.raises(lint.LintRejected):
+            await lint.acquire_lint_cleared_token(
+                op_id="op-1", diff=DIFF, chain=chain, prev_token=prev, critique_fn=cf)

--- a/tests/governance/test_pr_self_linter.py
+++ b/tests/governance/test_pr_self_linter.py
@@ -1,0 +1,32 @@
+from __future__ import annotations
+import hashlib
+import pytest
+from backend.core.ouroboros.governance import pr_self_linter as lint
+from backend.core.ouroboros.governance.dag_capability_token import (
+    DAGProofChain, TokenKind, LintClearedToken,
+)
+
+DIFF = "+def f():\n+    return 1\n"
+
+def _prev(chain):
+    s = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id="op-1", state_binding="c", payload={})
+    return chain.mint(kind=TokenKind.BLAST_RADIUS_CLEARED, op_id="op-1",
+                      state_binding="t", payload={}, prev=s)
+
+@pytest.mark.asyncio
+async def test_pass_mints_chained_lint_token():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def critique_fn(diff): return {"rating": 5, "concerns": []}
+    tok = await lint.acquire_lint_cleared_token(
+        op_id="op-1", diff=DIFF, chain=chain, prev_token=prev, critique_fn=critique_fn)
+    assert isinstance(tok, LintClearedToken)
+    assert tok.prev_hash == prev.digest()
+    assert tok.state_binding == hashlib.sha256(DIFF.encode()).hexdigest()
+
+@pytest.mark.asyncio
+async def test_low_rating_raises_lint_rejected():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def critique_fn(diff): return {"rating": 2, "concerns": ["hardcoded path"]}
+    with pytest.raises(lint.LintRejected):
+        await lint.acquire_lint_cleared_token(
+            op_id="op-1", diff=DIFF, chain=chain, prev_token=prev, critique_fn=critique_fn)

--- a/tests/governance/test_pr_self_linter.py
+++ b/tests/governance/test_pr_self_linter.py
@@ -32,6 +32,15 @@ async def test_low_rating_raises_lint_rejected():
             op_id="op-1", diff=DIFF, chain=chain, prev_token=prev, critique_fn=critique_fn)
 
 @pytest.mark.asyncio
+async def test_branch_context_forwarded_to_token():
+    chain = DAGProofChain(); prev = _prev(chain)
+    async def critique_fn(diff): return {"rating": 5, "concerns": []}
+    tok = await lint.acquire_lint_cleared_token(
+        op_id="op-1", diff=DIFF, chain=chain, prev_token=prev,
+        critique_fn=critique_fn, branch_context="wt-1")
+    assert tok.branch_context == "wt-1"
+
+@pytest.mark.asyncio
 async def test_malformed_rating_fails_closed():
     chain = DAGProofChain(); prev = _prev(chain)
     async def critique_none(diff): return {"rating": None}

--- a/tests/governance/test_pre_apply_exec_lock.py
+++ b/tests/governance/test_pre_apply_exec_lock.py
@@ -47,3 +47,23 @@ async def test_no_docker_raises_requires_cloud_execution_no_process_fallback():
         await lock.acquire_sandbox_execution_token(
             op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
             chain=chain, docker_available=lambda: False, runner=runner)
+
+@pytest.mark.asyncio
+async def test_containment_breach_raises_sandbox_lock_failed():
+    chain = DAGProofChain()
+    async def runner(**_):
+        return _FakeResult(0, breached=True)
+    with pytest.raises(lock.SandboxLockFailed):
+        await lock.acquire_sandbox_execution_token(
+            op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+            chain=chain, docker_available=lambda: True, runner=runner)
+
+@pytest.mark.asyncio
+async def test_token_records_py_file_count():
+    chain = DAGProofChain()
+    async def runner(**_):
+        return _FakeResult(0)
+    tok = await lock.acquire_sandbox_execution_token(
+        op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+        chain=chain, docker_available=lambda: True, runner=runner)
+    assert tok.payload["py_files"] == "1"

--- a/tests/governance/test_pre_apply_exec_lock.py
+++ b/tests/governance/test_pre_apply_exec_lock.py
@@ -67,3 +67,14 @@ async def test_token_records_py_file_count():
         op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
         chain=chain, docker_available=lambda: True, runner=runner)
     assert tok.payload["py_files"] == "1"
+
+@pytest.mark.asyncio
+async def test_branch_context_forwarded_to_token():
+    chain = DAGProofChain()
+    async def runner(**_):
+        return _FakeResult(0)
+    tok = await lock.acquire_sandbox_execution_token(
+        op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+        chain=chain, docker_available=lambda: True, runner=runner,
+        branch_context="wt-1")
+    assert tok.branch_context == "wt-1"

--- a/tests/governance/test_pre_apply_exec_lock.py
+++ b/tests/governance/test_pre_apply_exec_lock.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+import hashlib
+import pytest
+from backend.core.ouroboros.governance import pre_apply_exec_lock as lock
+from backend.core.ouroboros.governance.dag_capability_token import (
+    DAGProofChain, SandboxExecutionToken,
+)
+
+CANDIDATE = [("backend/x.py", "def f():\n    return 1\n")]
+
+class _FakeResult:
+    def __init__(self, exit_code, breached=False):
+        self.exit_code = exit_code
+        self.breached = breached
+        self.diagnostic = "ok" if exit_code == 0 else "boom"
+
+@pytest.mark.asyncio
+async def test_exit_zero_mints_token():
+    chain = DAGProofChain()
+    async def runner(**_):
+        return _FakeResult(0)
+    tok = await lock.acquire_sandbox_execution_token(
+        op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+        chain=chain, docker_available=lambda: True, runner=runner)
+    assert isinstance(tok, SandboxExecutionToken)
+    assert tok.payload["exit_code"] == "0"
+    # state_binding binds the EXACT candidate content
+    expect = hashlib.sha256(b"backend/x.py\x00def f():\n    return 1\n").hexdigest()
+    assert tok.state_binding == expect
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_raises_sandbox_lock_failed():
+    chain = DAGProofChain()
+    async def runner(**_):
+        return _FakeResult(1)
+    with pytest.raises(lock.SandboxLockFailed):
+        await lock.acquire_sandbox_execution_token(
+            op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+            chain=chain, docker_available=lambda: True, runner=runner)
+
+@pytest.mark.asyncio
+async def test_no_docker_raises_requires_cloud_execution_no_process_fallback():
+    chain = DAGProofChain()
+    async def runner(**_):
+        raise AssertionError("runner must NOT be called without Docker")
+    with pytest.raises(lock.RequiresCloudExecution):
+        await lock.acquire_sandbox_execution_token(
+            op_id="op-1", candidate_files=CANDIDATE, repo_root="/repo",
+            chain=chain, docker_available=lambda: False, runner=runner)

--- a/tests/governance/test_reverse_dep_resolver.py
+++ b/tests/governance/test_reverse_dep_resolver.py
@@ -1,0 +1,265 @@
+"""Tests for the Adaptive Hybrid Reverse-Dependency Resolver (Task 5b).
+
+Powers Gate (2) of the Iron Triad: "every test that transitively touches the
+modified code". Built strictly TDD -- the cycle-armor tests (4, 5) are the
+load-bearing proof that the transitive reverse closure is ITERATIVE, never
+recursive.
+
+AST-path tests build a real synthetic repo under ``tmp_path`` (real ``.py``
+files, no parser mocks). Oracle-path tests use a light fake -- the real
+``TheOracle`` is never imported or constructed here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import reverse_dep_resolver as rdr
+from backend.core.ouroboros.governance.reverse_dep_resolver import (
+    ReverseDepGraphError,
+    resolve_reverse_dependency_tests,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers -- synthetic repo construction
+# ---------------------------------------------------------------------------
+
+def _write(root, rel_path: str, body: str = "") -> None:
+    p = root / rel_path
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Light Oracle fakes (NO real TheOracle import)
+# ---------------------------------------------------------------------------
+
+class _FakeNode:
+    def __init__(self, file_path: str) -> None:
+        self.file_path = file_path
+
+    def __hash__(self) -> int:
+        return hash(self.file_path)
+
+    def __eq__(self, other) -> bool:
+        return isinstance(other, _FakeNode) and other.file_path == self.file_path
+
+
+class _FakeBlast:
+    def __init__(self, directly, transitively) -> None:
+        self.directly_affected = set(directly)
+        self.transitively_affected = set(transitively)
+
+
+class _FakeOracle:
+    """Configurable fake. ``nodes_by_file`` maps rel-path -> list[_FakeNode];
+    ``blast`` is returned by every compute_blast_radius call. If
+    ``raise_on_lookup`` is set, find_nodes_in_file raises it."""
+
+    def __init__(self, nodes_by_file=None, blast=None, raise_on_lookup=None) -> None:
+        self._nodes_by_file = nodes_by_file or {}
+        self._blast = blast or _FakeBlast(set(), set())
+        self._raise = raise_on_lookup
+
+    def find_nodes_in_file(self, file_path: str):
+        if self._raise is not None:
+            raise self._raise
+        return list(self._nodes_by_file.get(file_path, []))
+
+    def compute_blast_radius(self, node_id, max_depth=10):
+        return self._blast
+
+
+# ---------------------------------------------------------------------------
+# 1. Two-hop transitive (the case one-hop would MISS)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_transitive_two_hop(tmp_path):
+    _write(tmp_path, "a.py", "X = 1\n")
+    _write(tmp_path, "b.py", "import a\n")
+    _write(tmp_path, "tests/test_c.py", "import b\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["a.py"], repo_root=str(tmp_path)
+    )
+
+    assert "tests/test_c.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 2. Direct one-hop
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_direct_one_hop(tmp_path):
+    _write(tmp_path, "a.py", "X = 1\n")
+    _write(tmp_path, "tests/test_a.py", "import a\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["a.py"], repo_root=str(tmp_path)
+    )
+
+    assert "tests/test_a.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 3. Unrelated test excluded
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_unrelated_excluded(tmp_path):
+    _write(tmp_path, "a.py", "X = 1\n")
+    _write(tmp_path, "tests/test_a.py", "import a\n")
+    _write(tmp_path, "tests/test_z.py", "import os\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["a.py"], repo_root=str(tmp_path)
+    )
+
+    assert "tests/test_z.py" not in result
+    assert "tests/test_a.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 4. CYCLE ARMOR -- a real circular import must terminate, never RecursionError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_cycle_armor_no_recursion(tmp_path):
+    # a <-> b circular import
+    _write(tmp_path, "a.py", "import b\n")
+    _write(tmp_path, "b.py", "import a\n")
+    _write(tmp_path, "tests/test_a.py", "import a\n")
+
+    # Must RETURN (no hang, no RecursionError) and include the dependent test.
+    result = await resolve_reverse_dependency_tests(
+        ["a.py"], repo_root=str(tmp_path)
+    )
+
+    assert "tests/test_a.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 5. DEEP CHAIN -- 2000-deep import chain must not raise RecursionError
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_deep_chain_no_recursionerror(tmp_path):
+    depth = 2000
+    _write(tmp_path, "m0.py", "X = 1\n")
+    for i in range(1, depth + 1):
+        _write(tmp_path, f"m{i}.py", f"import m{i - 1}\n")
+    _write(tmp_path, "tests/test_top.py", f"import m{depth}\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["m0.py"], repo_root=str(tmp_path)
+    )
+
+    # Proves the closure is iterative: a recursive walk would RecursionError.
+    assert "tests/test_top.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 6. Build failure -> fail-closed raise
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_build_error_raises(tmp_path):
+    missing = tmp_path / "does_not_exist"
+    with pytest.raises(ReverseDepGraphError):
+        await resolve_reverse_dependency_tests(
+            ["a.py"], repo_root=str(missing)
+        )
+
+
+# ---------------------------------------------------------------------------
+# 7. Empty result is VALID, not an error
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_empty_result_is_not_error(tmp_path):
+    # A changed file nobody imports and with no matching test_*.py.
+    _write(tmp_path, "lonely.py", "X = 1\n")
+    _write(tmp_path, "tests/test_unrelated.py", "import os\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["lonely.py"], repo_root=str(tmp_path)
+    )
+
+    assert isinstance(result, set)
+    assert "tests/test_unrelated.py" not in result
+
+
+# ---------------------------------------------------------------------------
+# 8. Oracle warm path used, AST builder NOT invoked
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_oracle_warm_path_used(tmp_path, monkeypatch):
+    _write(tmp_path, "a.py", "X = 1\n")
+
+    node_a = _FakeNode("a.py")
+    impacted_node = _FakeNode("tests/test_c.py")
+    oracle = _FakeOracle(
+        nodes_by_file={"a.py": [node_a]},
+        blast=_FakeBlast(directly={impacted_node}, transitively=set()),
+    )
+
+    # Spy: the AST forward-graph builder must NOT run on the warm Oracle path.
+    called = {"ast": False}
+    real_builder = rdr._build_forward_import_graph
+
+    def _spy(*args, **kwargs):
+        called["ast"] = True
+        return real_builder(*args, **kwargs)
+
+    monkeypatch.setattr(rdr, "_build_forward_import_graph", _spy)
+
+    result = await resolve_reverse_dependency_tests(
+        ["a.py"], repo_root=str(tmp_path), oracle=oracle
+    )
+
+    assert called["ast"] is False
+    assert "tests/test_c.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 9. Oracle cold (empty nodes) -> AST fallback
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_oracle_cold_falls_back_to_ast(tmp_path):
+    _write(tmp_path, "a.py", "X = 1\n")
+    _write(tmp_path, "b.py", "import a\n")
+    _write(tmp_path, "tests/test_c.py", "import b\n")
+
+    # Cold for this file -> find_nodes_in_file returns [].
+    oracle = _FakeOracle(nodes_by_file={})
+
+    result = await resolve_reverse_dependency_tests(
+        ["a.py"], repo_root=str(tmp_path), oracle=oracle
+    )
+
+    # AST path ran and found the transitive result.
+    assert "tests/test_c.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 10. Oracle error -> swallowed -> AST fallback (Oracle never breaks Gate 2)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_oracle_error_falls_back_to_ast(tmp_path):
+    _write(tmp_path, "a.py", "X = 1\n")
+    _write(tmp_path, "b.py", "import a\n")
+    _write(tmp_path, "tests/test_c.py", "import b\n")
+
+    oracle = _FakeOracle(raise_on_lookup=RuntimeError("oracle boom"))
+
+    result = await resolve_reverse_dependency_tests(
+        ["a.py"], repo_root=str(tmp_path), oracle=oracle
+    )
+
+    assert "tests/test_c.py" in result

--- a/tests/governance/test_reverse_dep_resolver.py
+++ b/tests/governance/test_reverse_dep_resolver.py
@@ -263,3 +263,64 @@ async def test_oracle_error_falls_back_to_ast(tmp_path):
     )
 
     assert "tests/test_c.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 11. Config-only changeset -> empty set, NOT a fail-closed raise
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_config_only_changeset_returns_empty_not_raise(tmp_path):
+    # A valid repo, but the changeset touches zero .py files. No Python changed
+    # -> no dependent tests -> EMPTY result is correct (not "graph broken").
+    _write(tmp_path, "config/app.yaml", "key: value\n")
+    _write(tmp_path, "README.md", "# readme\n")
+    _write(tmp_path, "a.py", "X = 1\n")
+    _write(tmp_path, "tests/test_a.py", "import a\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["config/app.yaml", "README.md"], repo_root=str(tmp_path)
+    )
+
+    assert result == set()
+
+
+# ---------------------------------------------------------------------------
+# 12. Relative import transitive (close the false-negative gap)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_relative_import_transitive(tmp_path):
+    # b imports a via a RELATIVE sibling import; the test imports b. Without
+    # relative-import resolution b's edge to a is invisible and test_b is MISSED.
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/a.py", "X = 1\n")
+    _write(tmp_path, "pkg/b.py", "from . import a\n")
+    _write(tmp_path, "pkg/tests/__init__.py", "")
+    _write(tmp_path, "tests/test_b.py", "import pkg.b\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["pkg/a.py"], repo_root=str(tmp_path)
+    )
+
+    assert "tests/test_b.py" in result
+
+
+# ---------------------------------------------------------------------------
+# 13. Relative parent import (level 2: ``from .. import x``)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_relative_import_parent(tmp_path):
+    # pkg/sub/c reaches up to the parent package for ``a`` via ``from .. import a``.
+    _write(tmp_path, "pkg/__init__.py", "")
+    _write(tmp_path, "pkg/a.py", "X = 1\n")
+    _write(tmp_path, "pkg/sub/__init__.py", "")
+    _write(tmp_path, "pkg/sub/c.py", "from .. import a\n")
+    _write(tmp_path, "tests/test_c.py", "import pkg.sub.c\n")
+
+    result = await resolve_reverse_dependency_tests(
+        ["pkg/a.py"], repo_root=str(tmp_path)
+    )
+
+    assert "tests/test_c.py" in result

--- a/tests/governance/test_token_audit.py
+++ b/tests/governance/test_token_audit.py
@@ -1,0 +1,34 @@
+from __future__ import annotations
+import json
+from backend.core.ouroboros.governance import token_audit
+from backend.core.ouroboros.governance.dag_capability_token import DAGProofChain, TokenKind
+
+def test_append_mint_writes_durable_record(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TOKEN_AUDIT_ENABLED", "true")
+    p = tmp_path / "token_audit.jsonl"
+    chain = DAGProofChain()
+    tok = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id="op-9",
+                     state_binding="cand-sha", payload={"exit_code": "0"})
+    token_audit.append_mint(tok, path=str(p))
+    rows = [json.loads(line) for line in p.read_text().splitlines()]
+    assert rows[-1]["op_id"] == "op-9"
+    assert rows[-1]["kind"] == "sandbox_execution"
+    assert rows[-1]["state_binding"] == "cand-sha"
+    assert "sig" in rows[-1]
+    assert "secret" not in json.dumps(rows[-1])  # secret never persisted
+
+def test_append_mint_fail_soft_on_bad_path(tmp_path):
+    chain = DAGProofChain()
+    tok = chain.mint(kind=TokenKind.LINT_CLEARED, op_id="op-9",
+                     state_binding="x", payload={})
+    # Unwritable path must NOT raise.
+    token_audit.append_mint(tok, path="/nonexistent-dir/deep/none.jsonl")
+
+def test_disabled_is_noop(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_TOKEN_AUDIT_ENABLED", "false")
+    p = tmp_path / "audit.jsonl"
+    chain = DAGProofChain()
+    tok = chain.mint(kind=TokenKind.SANDBOX_EXECUTION, op_id="op-1",
+                     state_binding="a", payload={})
+    token_audit.append_mint(tok, path=str(p))
+    assert not p.exists()


### PR DESCRIPTION
## Iron Triad — cryptographically-chained autonomous-PR gates (closes the A1 "unit-green-fails-live" gap)

Three fail-closed gates on the autonomous Ouroboros→PR path, chained by unforgeable capability tokens, so one autonomous op must **survive the container, clear the blast radius, and pass the linter** before its PR. All gates **default-OFF / byte-identical**.

### What's in it
- **Spine** (`dag_capability_token`, `token_audit`): HMAC-SHA256 per-instance-secret capability tokens, **branch-bound**; `verify_chain` rejects forgery / replay / reorder / omission / cross-secret / cross-op / mixed-worktree-context. Immutable token-mint WAL.
- **Gate ①** (`pre_apply_exec_lock`): strict L4-container execution of the candidate — no Docker → `RequiresCloudExecution` (no process downgrade).
- **Gate ②** (`blast_radius_verify` + `reverse_dep_resolver`): full reverse-dependency test closure via an **adaptive hybrid resolver** (Oracle-first, **cycle-armored** iterative AST fallback), fail-closed graph guard, non-destructive **content-tree-SHA** rollback, no flake-retry.
- **Gate ③ + enforcer** (`pr_self_linter`, `orange_pr_reviewer`): blocking LLM architectural-rules critique; `create_review_pr` **requires** the verified 3-token chain — skipping a gate is a refusal, not a policy check.
- **PR-path unification** (`autonomous_pr_pipeline`): runs Gate ①+② inside an **isolated git worktree** (real tree untouched, cleanup-always) so one op assembles all three branch-bound tokens → enforced PR. Closes the whole-branch review's FSM-routing finding (gates had sat on mutually-exclusive risk-tier branches).

### Verification
- 72 Iron-Triad tests green; every task TDD + two-stage reviewed (including a whole-branch adversarial review that caught the FSM-routing gap at $0 before any cloud soak).
- Default-OFF byte-identical (18 legacy `orange_pr_reviewer` tests unchanged).
- Spec + plan: `docs/superpowers/specs/2026-06-29-iron-triad-a1-gate-design.md`, `docs/superpowers/plans/2026-06-29-iron-triad-a1-gate.md`.

### Not in scope (tracked)
- **Graduation blocker** before flipping `JARVIS_A1_TOKEN_ENFORCER_ENABLED` default-ON: 4 non-autonomous `create_review_pr` callers (strategy_simulator, genesis_proposal, graduation_pr_proposer, bridge_adapters) need token-wiring or a CLI-approval exemption (currently fail-safe / refuse + log).
- Live container A1 soak is operator-run (needs Docker Desktop + ~20 min).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Iron Triad: three fail-closed gates chained by HMAC capability tokens to secure autonomous PRs. One operation must pass container execution, reverse-dependency tests, and a PR linter; `create_review_pr` now requires the verified token chain, closing the A1 “unit-green-fails-live” gap.

- **New Features**
  - Capability-token spine: HMAC-SHA256, branch-bound chain; rejects forgery/replay/order/omission/mixed-context; append-only mint audit log.
  - Gate 1: strict L4 container exec lock; async Docker preflight; `RequiresCloudExecution` if no Docker (no process downgrade).
  - Gate 2: blast-radius verification via adaptive reverse-dep resolver (Oracle-first, cycle-armored AST fallback); deterministic content tree-SHA rollback; fail-closed, no flake-retry.
  - Gate 3: blocking PR self-linter; `create_review_pr` enforcer requires the 3-token chain and verifies branch context.
  - PR-path unification: runs Gate 1+2 in an isolated git worktree so a single op assembles all tokens for the same branch.
  - Flags registered and default OFF; comprehensive tests and docs added.

- **Migration**
  - No behavior change by default. To enable: set JARVIS_RUNTIME_SANDBOX_ENABLED, JARVIS_A1_SANDBOX_LOCK_ENABLED, JARVIS_A1_BLAST_RADIUS_ENABLED, JARVIS_A1_PR_LINTER_ENABLED, JARVIS_A1_TOKEN_ENFORCER_ENABLED.
  - Non-autonomous `create_review_pr` callers must add token wiring or a CLI-approval exemption before turning the enforcer on by default.
  - Docker is required when Gate 1 is enabled; absence triggers `RequiresCloudExecution` (preflight warns).

<sup>Written for commit 4ab3163fcf56ca3d1aff9d232b88f2aa8520d32b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69770?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

