### PR TITLE
feat(a1): Adaptive Ignition Harness — operator Big Red Button for the A1 soak

### DIFF
--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -7,7 +7,7 @@ Usage:
 
 Exit codes:
     0   A1_DISPATCH_PROVEN
-    1   soak non-zero (failure telemetry printed as [FOR CLAUDE] block)
+    non-zero (the driver's own exit code)   soak non-zero (failure telemetry printed as [FOR CLAUDE] block)
     2   docker daemon not responsive
     3   preflight (integration test) failed -- soak skipped
 """
@@ -71,6 +71,8 @@ def tee_run(argv: list[str], log_handle, *, env=None, cwd=None) -> int:
     Both streams are flushed after every line -- zero data loss guarantee.
     Returns the exit code of the subprocess.
     """
+    _env = dict(env if env is not None else os.environ)
+    _env.setdefault("PYTHONUNBUFFERED", "1")   # real-time tee: child flushes per line
     proc = subprocess.Popen(
         argv,
         stdout=PIPE,
@@ -78,9 +80,10 @@ def tee_run(argv: list[str], log_handle, *, env=None, cwd=None) -> int:
         text=True,
         bufsize=1,
         cwd=cwd,
-        env=env,
+        env=_env,
     )
-    assert proc.stdout is not None  # always present when stdout=PIPE
+    if proc.stdout is None:
+        raise RuntimeError("tee_run: subprocess stdout pipe was not created")
     for line in proc.stdout:
         sys.stdout.write(line)
         sys.stdout.flush()

--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -1,0 +1,372 @@
+#!/usr/bin/env python3
+"""Adaptive Ignition Harness -- docker-aware preflight + immutable tee + [FOR CLAUDE] summarizer.
+
+Usage:
+    python3 scripts/ignite_a1_soak.py [--max-wall-seconds N] [--skip-preflight]
+                                       [--run-root DIR] [--dry-run]
+
+Exit codes:
+    0   A1_DISPATCH_PROVEN
+    1   soak non-zero (failure telemetry printed as [FOR CLAUDE] block)
+    2   docker daemon not responsive
+    3   preflight (integration test) failed -- soak skipped
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+from subprocess import PIPE, STDOUT
+
+
+# ---------------------------------------------------------------------------
+# Helper: Docker daemon check
+# ---------------------------------------------------------------------------
+
+def docker_responsive(probe=None) -> tuple[bool, str]:
+    """(ok, reason).  Pings the daemon via `docker info` (not just PATH).
+
+    Parameters
+    ----------
+    probe : callable | None
+        Injectable for tests -- called as ``probe()`` returning ``(bool, str)``.
+        When None the real subprocess path runs.
+    """
+    if probe is not None:
+        return probe()
+
+    if shutil.which("docker") is None:
+        return (False, "docker CLI not found on PATH")
+
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            text=True,
+            timeout=15,
+        )
+        if result.returncode == 0:
+            return (True, "daemon responsive")
+        stderr_lines = [ln.strip() for ln in result.stderr.splitlines() if ln.strip()]
+        reason = stderr_lines[-1] if stderr_lines else "docker info failed"
+        return (False, reason)
+    except subprocess.TimeoutExpired:
+        return (False, "docker info timed out (daemon may be hung)")
+    except OSError as exc:
+        return (False, str(exc))
+
+
+# ---------------------------------------------------------------------------
+# Helper: Immutable tee runner
+# ---------------------------------------------------------------------------
+
+def tee_run(argv: list[str], log_handle, *, env=None, cwd=None) -> int:
+    """Run *argv*; stream merged stdout+stderr to both sys.stdout and log_handle.
+
+    Both streams are flushed after every line -- zero data loss guarantee.
+    Returns the exit code of the subprocess.
+    """
+    proc = subprocess.Popen(
+        argv,
+        stdout=PIPE,
+        stderr=STDOUT,
+        text=True,
+        bufsize=1,
+        cwd=cwd,
+        env=env,
+    )
+    assert proc.stdout is not None  # always present when stdout=PIPE
+    for line in proc.stdout:
+        sys.stdout.write(line)
+        sys.stdout.flush()
+        log_handle.write(line)
+        log_handle.flush()
+    return proc.wait()
+
+
+# ---------------------------------------------------------------------------
+# Helper: Telemetry discovery
+# ---------------------------------------------------------------------------
+
+def find_failure_telemetry(run_root: Path) -> dict | None:
+    """Find the newest failure_telemetry.json under *run_root*.
+
+    Searches ``<run_root>/**/failure_telemetry_*/failure_telemetry.json``,
+    picks the newest by mtime, parses JSON, requires a ``fsm_phase`` key.
+    Attaches ``_artifact_path`` (str) to the returned dict.
+    Returns None if nothing valid is found.
+    """
+    candidates = list(run_root.glob("**/failure_telemetry_*/failure_telemetry.json"))
+    if not candidates:
+        return None
+
+    # Sort newest-last, iterate in reverse
+    candidates.sort(key=lambda p: p.stat().st_mtime)
+    for path in reversed(candidates):
+        try:
+            data = json.loads(path.read_text())
+            if "fsm_phase" not in data:
+                continue
+            data["_artifact_path"] = str(path)
+            return data
+        except (json.JSONDecodeError, OSError):
+            continue
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Helper: [FOR CLAUDE] block formatter
+# ---------------------------------------------------------------------------
+
+def format_for_claude(
+    telemetry: dict | None,
+    *,
+    log_path: str,
+    exit_code: int,
+    log_tail: list[str],
+) -> str:
+    """Return a fenced markdown block the operator can blindly copy-paste."""
+    lines: list[str] = []
+    lines.append("```markdown")
+    lines.append("[FOR CLAUDE] A1 soak failed")
+    lines.append("")
+    lines.append(f"exit_code: {exit_code}")
+    lines.append(f"verdict:   FAILED")
+    lines.append(f"log_path:  {log_path}")
+    lines.append("")
+
+    if telemetry is None:
+        lines.append("[!] No failure_telemetry.json found under run-root.")
+        lines.append("    The soak may have crashed before writing telemetry,")
+        lines.append("    or --run-root was not passed to the driver.")
+    else:
+        artifact = telemetry.get("_artifact_path", "(unknown)")
+        lines.append(f"artifact_path: {artifact}")
+        lines.append("")
+
+        fsm_phase = telemetry.get("fsm_phase")
+        lines.append(f"fsm_phase: {fsm_phase}")
+        lines.append("")
+
+        # Causal chain
+        causal_chain = telemetry.get("causal_chain")
+        if causal_chain:
+            lines.append("causal_chain:")
+            for hop in causal_chain:
+                seq = hop.get("seq", "?")
+                parent = hop.get("causal_parent_seq", "?")
+                rest = {k: v for k, v in hop.items() if k not in ("seq", "causal_parent_seq")}
+                rest_str = "  " + str(rest) if rest else ""
+                lines.append(f"  seq={seq} -> parent={parent}{rest_str}")
+        else:
+            lines.append("causal_chain: (none)")
+        lines.append("")
+
+        # Memory snapshot
+        mem = telemetry.get("memory_snapshot")
+        if mem:
+            lines.append("memory_snapshot:")
+            for k, v in mem.items():
+                lines.append(f"  {k}: {v}")
+        else:
+            lines.append("memory_snapshot: (none)")
+        lines.append("")
+
+        # A1 trace hops
+        hops = telemetry.get("a1trace_hops")
+        if hops:
+            lines.append(f"a1trace_hops ({len(hops)} total):")
+            for h in hops:
+                lines.append(f"  {h}")
+        else:
+            lines.append("a1trace_hops: (none)")
+        lines.append("")
+
+    # Log tail
+    lines.append(f"--- last {len(log_tail)} lines of log ---")
+    lines.extend(log_tail)
+    lines.append("```")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Log helpers
+# ---------------------------------------------------------------------------
+
+def _utc_stamp() -> str:
+    return datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+
+
+def _git_head(cwd: Path) -> str:
+    try:
+        result = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True,
+            text=True,
+            cwd=str(cwd),
+            timeout=5,
+        )
+        return result.stdout.strip() if result.returncode == 0 else "(unknown)"
+    except Exception:
+        return "(unknown)"
+
+
+def _write_log_header(fh, *, argv: list[str], cwd: Path) -> None:
+    stamp = datetime.now(timezone.utc).isoformat()
+    fh.write(f"# A1 Ignition Harness -- {stamp}\n")
+    fh.write(f"# git HEAD: {_git_head(cwd)}\n")
+    fh.write(f"# command: {' '.join(argv)}\n")
+    fh.write("#\n")
+    fh.flush()
+
+
+def _read_tail(log_path: Path, n: int = 40) -> list[str]:
+    try:
+        lines = log_path.read_text(errors="replace").splitlines()
+        return lines[-n:]
+    except OSError:
+        return ["(log unreadable)"]
+
+
+# ---------------------------------------------------------------------------
+# main()
+# ---------------------------------------------------------------------------
+
+def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
+    parser = argparse.ArgumentParser(
+        description="Adaptive Ignition Harness: fire A1 live soak with docker pre-flight and autonomous failure summary.",
+    )
+    parser.add_argument(
+        "--max-wall-seconds",
+        type=int,
+        default=2400,
+        metavar="N",
+        help="Hard wall-clock ceiling passed to the soak driver (default: 2400).",
+    )
+    parser.add_argument(
+        "--skip-preflight",
+        action="store_true",
+        help="Skip the integration test pre-flight (tests/integration/test_iron_triad_live_pipeline.py).",
+    )
+    parser.add_argument(
+        "--run-root",
+        type=Path,
+        default=None,
+        metavar="DIR",
+        help="Directory under which the soak driver writes its run_id/ tree. "
+             "Default: <repo>/logs/a1_runs/<stamp>.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Stub real subprocesses -- exercises wiring without Docker or soak.",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).resolve().parents[1]
+
+    # ------------------------------------------------------------------ stamp
+    stamp = _utc_stamp()
+    run_root: Path = args.run_root if args.run_root is not None else repo_root / "logs" / "a1_runs" / stamp
+
+    # ------------------------------------------------------------------ logs dir
+    logs_dir = repo_root / "logs"
+    logs_dir.mkdir(parents=True, exist_ok=True)
+    log_file = logs_dir / f"a1_ignition_{stamp}.log"
+
+    # ------------------------------------------------------------------ dry-run stubs
+    if args.dry_run:
+        print("[DRY-RUN] Adaptive Ignition Harness (no real subprocesses)")
+        print(f"[DRY-RUN] log_file   : {log_file}")
+        print(f"[DRY-RUN] run_root   : {run_root}")
+        print(f"[DRY-RUN] max-wall-s : {args.max_wall_seconds}")
+        print(f"[DRY-RUN] preflight  : {'SKIP' if args.skip_preflight else 'would run'}")
+        print("[DRY-RUN] Docker check: STUBBED -> OK")
+        print("[DRY-RUN] Soak       : STUBBED -> exit 0 (A1_DISPATCH_PROVEN)")
+        print("")
+        print("[OK] A1_DISPATCH_PROVEN (dry-run stub)")
+        return 0
+
+    # ------------------------------------------------------------------ docker check
+    ok, reason = docker_responsive()
+    if not ok:
+        print(
+            f"\n  Docker daemon is not responding -- please open Docker Desktop and wait for it to start, then re-run.\n"
+            f"  Reason: {reason}\n"
+        )
+        return 2
+
+    print(f"[OK] Docker daemon: {reason}")
+
+    # ------------------------------------------------------------------ open log
+    log_file.parent.mkdir(parents=True, exist_ok=True)
+    log_fh = log_file.open("w", encoding="utf-8", errors="replace")
+
+    try:
+        # ---------------------------------------------------------------- preflight
+        if not args.skip_preflight:
+            preflight_argv = [
+                sys.executable,
+                "-m",
+                "pytest",
+                "tests/integration/test_iron_triad_live_pipeline.py",
+                "-q",
+            ]
+            _write_log_header(log_fh, argv=preflight_argv, cwd=repo_root)
+            print(f"\n[>] Preflight: {' '.join(preflight_argv)}")
+            pf_rc = tee_run(preflight_argv, log_fh, cwd=str(repo_root))
+            if pf_rc != 0:
+                print(f"\n[!] Preflight FAILED (exit {pf_rc}) -- aborting before expensive soak.")
+                log_fh.write(f"\n# Preflight FAILED -- soak skipped\n")
+                log_fh.flush()
+                return 3
+            print("[OK] Preflight passed.\n")
+        else:
+            print("[SKIP] Preflight skipped (--skip-preflight).")
+
+        # ---------------------------------------------------------------- soak
+        run_root.mkdir(parents=True, exist_ok=True)
+        soak_argv = [
+            sys.executable,
+            str(repo_root / "scripts" / "isomorphic_a1_local.py"),
+            "--mode", "container",
+            "--run-root", str(run_root),
+            "--max-wall-seconds", str(args.max_wall_seconds),
+        ]
+        _write_log_header(log_fh, argv=soak_argv, cwd=repo_root)
+        print(f"[>] Soak: {' '.join(soak_argv)}")
+        soak_rc = tee_run(soak_argv, log_fh, cwd=str(repo_root))
+
+        # ---------------------------------------------------------------- result
+        if soak_rc == 0:
+            print("\n[OK] A1_DISPATCH_PROVEN")
+            log_fh.write("\n# A1_DISPATCH_PROVEN\n")
+            return 0
+
+        # Non-zero -- locate telemetry and emit [FOR CLAUDE] block
+        telemetry = find_failure_telemetry(run_root)
+        log_tail = _read_tail(log_file)
+        summary = format_for_claude(
+            telemetry,
+            log_path=str(log_file),
+            exit_code=soak_rc,
+            log_tail=log_tail,
+        )
+        print(summary)
+        log_fh.write("\n")
+        log_fh.write(summary)
+        log_fh.write("\n")
+        log_fh.flush()
+        return soak_rc
+
+    finally:
+        log_fh.close()
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scripts/test_ignite_a1_soak.py
+++ b/tests/scripts/test_ignite_a1_soak.py
@@ -1,0 +1,212 @@
+"""Tests for scripts/ignite_a1_soak.py -- pure-helper unit tests (no Docker, no soak)."""
+from __future__ import annotations
+
+import io
+import json
+import sys
+import tempfile
+import time
+from pathlib import Path
+
+import pytest
+
+# Make the repo root importable so we can import the script as a module.
+REPO_ROOT = Path(__file__).resolve().parents[2]
+sys.path.insert(0, str(REPO_ROOT / "scripts"))
+
+from ignite_a1_soak import (  # noqa: E402
+    docker_responsive,
+    find_failure_telemetry,
+    format_for_claude,
+    tee_run,
+)
+
+
+# ---------------------------------------------------------------------------
+# docker_responsive -- probe injection
+# ---------------------------------------------------------------------------
+
+class TestDockerResponsive:
+    def test_probe_ok(self):
+        ok, reason = docker_responsive(probe=lambda: (True, "ok"))
+        assert ok is True
+        assert reason == "ok"
+
+    def test_probe_down(self):
+        ok, reason = docker_responsive(probe=lambda: (False, "down"))
+        assert ok is False
+        assert reason == "down"
+
+    def test_probe_callable_used_not_real_subprocess(self):
+        """Ensure the probe bypasses the real subprocess path."""
+        calls = []
+
+        def counting_probe():
+            calls.append(1)
+            return (True, "stub")
+
+        ok, reason = docker_responsive(probe=counting_probe)
+        assert ok is True
+        assert len(calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# find_failure_telemetry
+# ---------------------------------------------------------------------------
+
+_VALID_TELEMETRY = {
+    "fsm_phase": "APPLY",
+    "causal_chain": [{"seq": 1, "causal_parent_seq": 0}],
+    "memory_snapshot": {"level": "OK"},
+    "a1trace_hops": ["emit", "ingest"],
+}
+
+
+def _write_telemetry(root: Path, stamp: str, data: dict) -> Path:
+    subdir = root / "r1" / "telemetry" / f"failure_telemetry_{stamp}"
+    subdir.mkdir(parents=True, exist_ok=True)
+    p = subdir / "failure_telemetry.json"
+    p.write_text(json.dumps(data))
+    return p
+
+
+class TestFindFailureTelemetry:
+    def test_finds_artifact(self, tmp_path):
+        _write_telemetry(tmp_path, "20260630T0000Z", _VALID_TELEMETRY)
+        result = find_failure_telemetry(tmp_path)
+        assert result is not None
+        assert result["fsm_phase"] == "APPLY"
+        assert "_artifact_path" in result
+        assert result["causal_chain"] == [{"seq": 1, "causal_parent_seq": 0}]
+        assert result["a1trace_hops"] == ["emit", "ingest"]
+
+    def test_returns_none_when_absent(self, tmp_path):
+        result = find_failure_telemetry(tmp_path)
+        assert result is None
+
+    def test_picks_newest_when_two_exist(self, tmp_path):
+        import os
+
+        # Write first artifact then backdate it so it's definitively older
+        p1 = _write_telemetry(tmp_path, "20260630T0000Z", {**_VALID_TELEMETRY, "fsm_phase": "VALIDATE"})
+        old_time = time.time() - 10
+        os.utime(str(p1), (old_time, old_time))
+
+        # Write second artifact -- newer by wall clock
+        _write_telemetry(tmp_path, "20260630T0001Z", {**_VALID_TELEMETRY, "fsm_phase": "GENERATE"})
+
+        result = find_failure_telemetry(tmp_path)
+        assert result is not None
+        assert result["fsm_phase"] == "GENERATE"
+
+    def test_skips_missing_fsm_phase(self, tmp_path):
+        """A JSON file without fsm_phase must be skipped."""
+        bad_dir = tmp_path / "r1" / "telemetry" / "failure_telemetry_bad"
+        bad_dir.mkdir(parents=True)
+        (bad_dir / "failure_telemetry.json").write_text(json.dumps({"other": "key"}))
+        result = find_failure_telemetry(tmp_path)
+        assert result is None
+
+    def test_artifact_path_is_string(self, tmp_path):
+        _write_telemetry(tmp_path, "20260630T0002Z", _VALID_TELEMETRY)
+        result = find_failure_telemetry(tmp_path)
+        assert isinstance(result["_artifact_path"], str)
+
+
+# ---------------------------------------------------------------------------
+# format_for_claude
+# ---------------------------------------------------------------------------
+
+class TestFormatForClaude:
+    _LOG_TAIL = ["line A", "line B", "line C"]
+
+    def test_with_telemetry_contains_marker(self, tmp_path):
+        tel = {**_VALID_TELEMETRY, "_artifact_path": str(tmp_path / "failure_telemetry.json")}
+        out = format_for_claude(tel, log_path="/logs/run.log", exit_code=1, log_tail=self._LOG_TAIL)
+        assert "[FOR CLAUDE]" in out
+
+    def test_with_telemetry_contains_fsm_phase(self, tmp_path):
+        tel = {**_VALID_TELEMETRY, "_artifact_path": str(tmp_path / "t.json")}
+        out = format_for_claude(tel, log_path="/logs/run.log", exit_code=1, log_tail=self._LOG_TAIL)
+        assert "APPLY" in out
+
+    def test_with_telemetry_contains_log_path(self, tmp_path):
+        tel = {**_VALID_TELEMETRY, "_artifact_path": str(tmp_path / "t.json")}
+        out = format_for_claude(tel, log_path="/logs/run.log", exit_code=99, log_tail=self._LOG_TAIL)
+        assert "/logs/run.log" in out
+
+    def test_with_telemetry_contains_hop_count(self, tmp_path):
+        tel = {**_VALID_TELEMETRY, "_artifact_path": str(tmp_path / "t.json")}
+        out = format_for_claude(tel, log_path="/logs/run.log", exit_code=1, log_tail=self._LOG_TAIL)
+        assert "2 total" in out  # 2 hops in _VALID_TELEMETRY
+
+    def test_with_telemetry_contains_log_tail(self, tmp_path):
+        tel = {**_VALID_TELEMETRY, "_artifact_path": str(tmp_path / "t.json")}
+        out = format_for_claude(tel, log_path="/logs/run.log", exit_code=1, log_tail=self._LOG_TAIL)
+        for line in self._LOG_TAIL:
+            assert line in out
+
+    def test_none_telemetry_contains_marker(self):
+        out = format_for_claude(None, log_path="/logs/run.log", exit_code=1, log_tail=self._LOG_TAIL)
+        assert "[FOR CLAUDE]" in out
+
+    def test_none_telemetry_contains_artifact_not_found(self):
+        out = format_for_claude(None, log_path="/logs/run.log", exit_code=1, log_tail=self._LOG_TAIL)
+        # Must mention no telemetry found
+        assert "No failure_telemetry" in out or "artifact" in out.lower()
+
+    def test_none_telemetry_contains_log_tail(self):
+        out = format_for_claude(None, log_path="/logs/run.log", exit_code=1, log_tail=self._LOG_TAIL)
+        for line in self._LOG_TAIL:
+            assert line in out
+
+
+# ---------------------------------------------------------------------------
+# tee_run -- live subprocess, proves merged tee + zero loss
+# ---------------------------------------------------------------------------
+
+class TestTeeRun:
+    def test_returns_zero_on_success(self, tmp_path):
+        log_path = tmp_path / "tee.log"
+        with log_path.open("w") as fh:
+            rc = tee_run(
+                [sys.executable, "-c", "print('hello')"],
+                fh,
+            )
+        assert rc == 0
+
+    def test_stdout_and_stderr_both_captured(self, tmp_path):
+        log_path = tmp_path / "tee.log"
+        with log_path.open("w") as fh:
+            rc = tee_run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import sys; print('hello'); sys.stderr.write('werr\\n')",
+                ],
+                fh,
+            )
+        assert rc == 0
+        content = log_path.read_text()
+        assert "hello" in content
+        assert "werr" in content
+
+    def test_returns_nonzero_exit_code(self, tmp_path):
+        log_path = tmp_path / "tee.log"
+        with log_path.open("w") as fh:
+            rc = tee_run(
+                [sys.executable, "-c", "raise SystemExit(42)"],
+                fh,
+            )
+        assert rc == 42
+
+    def test_writes_to_both_stdout_and_log(self, tmp_path, capsys):
+        log_path = tmp_path / "tee.log"
+        with log_path.open("w") as fh:
+            tee_run(
+                [sys.executable, "-c", "print('dualwrite')"],
+                fh,
+            )
+        captured = capsys.readouterr()
+        assert "dualwrite" in captured.out
+        assert "dualwrite" in log_path.read_text()


### PR DESCRIPTION
## Adaptive Ignition Harness — the operator "Big Red Button" for the A1 live soak

`scripts/ignite_a1_soak.py` — a robust pure-Python (zero bash) wrapper that fires the A1 soak with three guarantees:

1. **Daemon-aware Docker pre-flight** — pings the daemon via `docker info` (not just `shutil.which`, the gap that caused a real Gate ① bug); if it's down, prints a friendly "open Docker Desktop" message and exits cleanly (no stack trace).
2. **Immutable teeing** — runs the real-infra pre-flight test + the soak, streaming merged stdout+stderr line-by-line to the terminal AND `logs/a1_ignition_<ts>.log` with per-line flush (zero loss on SIGTERM). Sets `PYTHONUNBUFFERED=1` so children flush in real time.
3. **Autonomous `[FOR CLAUDE]` summarizer** — on any non-`A1_DISPATCH_PROVEN` exit, locates `<run_root>/**/failure_telemetry_*/failure_telemetry.json`, parses FSM phase + causal chain + memory snapshot + a1trace hops, and prints a copy-paste markdown block to instantly start the $0 fix loop.

No hardcoded paths (repo root resolved relatively; run-root passed explicitly to the driver so telemetry is always findable). 20 unit tests on the pure helpers (tee dual-write, telemetry discovery newest/absent/bad-key, format with/without telemetry, docker probe injection). `--dry-run` exercises the flow without Docker.

**Run it:** `python3 scripts/ignite_a1_soak.py` (Docker Desktop up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Adaptive Ignition Harness (`scripts/ignite_a1_soak.py`) to run the A1 soak with a Docker preflight, real-time logging, and automatic failure summaries. Includes unit tests for helpers and a `--dry-run` mode.

- **New Features**
  - Docker daemon probe via `docker info`; prints a friendly message and exits with code 2 if unavailable.
  - Immutable tee: merge stdout/stderr to terminal and `logs/a1_ignition_<ts>.log` with per-line flush; sets `PYTHONUNBUFFERED=1`.
  - Optional preflight (pytest) before the soak; aborts with exit 3 on failure.
  - Discovers failure telemetry under `--run-root` and prints a `[FOR CLAUDE]` summary on non-zero exit with log tail and key fields.
  - CLI: `--max-wall-seconds`, `--skip-preflight`, `--run-root`, `--dry-run`; default run-root `logs/a1_runs/<stamp>`; no hardcoded paths.
  - Tests: 20 unit tests for tee, telemetry discovery, formatter, and Docker probe.

<sup>Written for commit c72f9463cab6fa909f1825fe0540799fb3dabdc0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

