### PR TITLE
fix(a1): harness wall-cap env + Aegis daemon cwd-independent PYTHONPATH (live-soak fixes)

### DIFF
--- a/backend/core/ouroboros/aegis/preflight.py
+++ b/backend/core/ouroboros/aegis/preflight.py
@@ -133,6 +133,19 @@ def _spawn_daemon(
     sub_env = dict(os.environ)
     sub_env.update(credentials)
 
+    # Make ``-m backend.core.ouroboros.aegis.daemon`` resolve regardless of the
+    # parent's cwd. Production runs the organism from the repo root (so cwd is on
+    # sys.path), but the isomorphic soak deliberately runs from a DISJOINT cwd to
+    # surface exactly this class of fragility -- without an explicit repo-root on
+    # PYTHONPATH the daemon dies with ModuleNotFoundError: No module named
+    # 'backend'. Prepend the repo root (the dir containing ``backend/``) so the
+    # spawn is cwd-independent in every environment.
+    _repo_root = str(Path(__file__).resolve().parents[4])
+    _existing_pp = sub_env.get("PYTHONPATH", "")
+    sub_env["PYTHONPATH"] = (
+        _repo_root + (os.pathsep + _existing_pp if _existing_pp else "")
+    )
+
     cmd = [
         sys.executable,
         "-m",

--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -339,11 +339,16 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
             str(repo_root / "scripts" / "isomorphic_a1_local.py"),
             "--mode", "container",
             "--run-root", str(run_root),
-            "--max-wall-seconds", str(args.max_wall_seconds),
         ]
+        # The isomorphic driver does NOT take --max-wall-seconds; the wall cap is
+        # read from the env by the battle-test harness the SoakRunner spawns
+        # (OUROBOROS_BATTLE_MAX_WALL_SECONDS). Headless too, since this is non-TTY.
+        _soak_env = dict(os.environ)
+        _soak_env["OUROBOROS_BATTLE_MAX_WALL_SECONDS"] = str(args.max_wall_seconds)
+        _soak_env.setdefault("OUROBOROS_BATTLE_HEADLESS", "1")
         _write_log_header(log_fh, argv=soak_argv, cwd=repo_root)
-        print(f"[>] Soak: {' '.join(soak_argv)}")
-        soak_rc = tee_run(soak_argv, log_fh, cwd=str(repo_root))
+        print(f"[>] Soak: {' '.join(soak_argv)}  (OUROBOROS_BATTLE_MAX_WALL_SECONDS={args.max_wall_seconds})")
+        soak_rc = tee_run(soak_argv, log_fh, cwd=str(repo_root), env=_soak_env)
 
         # ---------------------------------------------------------------- result
         if soak_rc == 0:


### PR DESCRIPTION
## Two A1-soak fixes surfaced by firing the Adaptive Ignition Harness live

Both found in the $0 ignition loop (minutes, no cloud spend):

1. **Harness wall-cap arg** — `isomorphic_a1_local.py` has no `--max-wall-seconds` flag; the wall cap is the env var `OUROBOROS_BATTLE_MAX_WALL_SECONDS` read by the battle-test harness the SoakRunner spawns. The ignition harness now sets that env (+ `OUROBOROS_BATTLE_HEADLESS=1` for the non-TTY run) instead of passing an unsupported flag.

2. **Aegis daemon cwd-coupling (real production hardening)** — the Aegis credential-bootstrap daemon is spawned as `python -m backend.core.ouroboros.aegis.daemon`, inheriting the parent's cwd. The isomorphic soak runs the organism from a *disjoint* cwd (run-#13 class), so the daemon died with `ModuleNotFoundError: No module named 'backend'` → Aegis preflight failed → whole organism boot aborted. The spawn now prepends the repo root (the dir containing `backend/`) to the daemon subprocess `PYTHONPATH`, making it cwd-independent in every environment. Reproduced the failure and verified the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two A1 soak ignition issues: the harness now sets the wall-time cap via env and the Aegis daemon spawn is cwd-independent by prepending the repo root to `PYTHONPATH`. This makes live soak runs stable and prevents boot failures from disjoint working directories.

- **Bug Fixes**
  - Set `OUROBOROS_BATTLE_MAX_WALL_SECONDS` and default `OUROBOROS_BATTLE_HEADLESS=1`; removed unsupported `--max-wall-seconds` when calling `isomorphic_a1_local.py`.
  - Prepend repo root to child `PYTHONPATH` before spawning `-m backend.core.ouroboros.aegis.daemon`, avoiding `ModuleNotFoundError` when not launched from repo root.

<sup>Written for commit 4b8015155a3d448b5dd92dc03f645c1d13ccbfd6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69773?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

