### PR TITLE
fix(a1): virtualize intake storage root via JARVIS_TRINITY_ROOT (live-soak Blocker #4)

### DIFF
--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -725,12 +725,26 @@ class IntakeRouterConfig:
     dispatch_timeout_s: float = 300.0
 
     @property
+    def _state_root(self) -> Path:
+        """Writable root for intake state (.jarvis WAL/lock/...).
+
+        Virtualizes the storage boundary so the code never depends on a
+        hardcoded, possibly-unprivileged absolute path. ``JARVIS_TRINITY_ROOT``
+        (when set) is the authoritative writable root -- the isomorphic local
+        soak injects a temp dir there so the literal ``/opt/trinity`` production
+        path is never required off the node. Unset => ``project_root`` (prod is
+        byte-identical: nothing reads the env var on the real node).
+        """
+        env_root = os.environ.get("JARVIS_TRINITY_ROOT", "").strip()
+        return Path(env_root) if env_root else self.project_root
+
+    @property
     def resolved_wal_path(self) -> Path:
-        return self.wal_path or (self.project_root / ".jarvis" / "intake_wal.jsonl")
+        return self.wal_path or (self._state_root / ".jarvis" / "intake_wal.jsonl")
 
     @property
     def resolved_lock_path(self) -> Path:
-        return self.lock_path or (self.project_root / ".jarvis" / "intake_router.lock")
+        return self.lock_path or (self._state_root / ".jarvis" / "intake_router.lock")
 
 
 class PendingAckStore:

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -497,6 +497,18 @@ class IsomorphicA1Driver:
                 env["JARVIS_FILE_ISOLATION_ENABLED"] = "false"
                 env["JARVIS_DETERMINISTIC_ISOLATION_LOCK_ENABLED"] = "false"
 
+                # ---- Virtualized writable Trinity root (Blocker #4 structural fix) ----
+                # The isomorphic env makes the organism believe it lives at the
+                # literal /opt/trinity/jarvis (the production path) -- but that base
+                # is not writable off the GCE node (no admin on the dev host). Inject
+                # a writable, per-run state root so JARVIS_TRINITY_ROOT-aware storage
+                # (intake WAL/lock, ...) lands somewhere unprivileged. The code stays
+                # byte-identical in production: the env var is unset on the real node,
+                # where storage falls back to project_root exactly as before.
+                _trinity_root = os.path.join(run_dir, "trinity_root")
+                os.makedirs(_trinity_root, exist_ok=True)
+                env["JARVIS_TRINITY_ROOT"] = _trinity_root
+
                 _log("env composed: %d keys total, adversary overrides applied, "
                      "failover=%s" % (len(env), "enabled" if self.enable_failover
                                       else "pinned-off"))

--- a/tests/governance/intake/test_intake_trinity_root.py
+++ b/tests/governance/intake/test_intake_trinity_root.py
@@ -1,0 +1,49 @@
+"""Regression: intake storage virtualizes its root via JARVIS_TRINITY_ROOT.
+
+Surfaced by firing the A1 ignition harness live -- the isomorphic soak makes the
+organism believe it lives at the literal ``/opt/trinity/jarvis`` (production
+path), which is not writable off the GCE node, so the intake WAL's
+``mkdir(parents=True)`` died with ``Permission denied: '/opt/trinity'``.
+
+The fix virtualizes the writable boundary: ``JARVIS_TRINITY_ROOT`` (when set) is
+the authoritative writable state root; unset => ``project_root`` (production is
+byte-identical -- nothing sets the env var on the real node).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.intake.unified_intake_router import (
+    IntakeRouterConfig,
+)
+
+
+def test_wal_and_lock_default_to_project_root(monkeypatch):
+    monkeypatch.delenv("JARVIS_TRINITY_ROOT", raising=False)
+    cfg = IntakeRouterConfig(project_root=Path("/opt/trinity/jarvis"))
+    assert cfg.resolved_wal_path == Path("/opt/trinity/jarvis/.jarvis/intake_wal.jsonl")
+    assert cfg.resolved_lock_path == Path("/opt/trinity/jarvis/.jarvis/intake_router.lock")
+
+
+def test_trinity_root_env_overrides_writable_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path))
+    cfg = IntakeRouterConfig(project_root=Path("/opt/trinity/jarvis"))
+    assert cfg.resolved_wal_path == tmp_path / ".jarvis" / "intake_wal.jsonl"
+    assert cfg.resolved_lock_path == tmp_path / ".jarvis" / "intake_router.lock"
+    # And the parent is genuinely creatable under the writable root (the exact
+    # operation that failed against literal /opt/trinity).
+    cfg.resolved_wal_path.parent.mkdir(parents=True, exist_ok=True)
+    assert cfg.resolved_wal_path.parent.is_dir()
+
+
+def test_explicit_wal_path_still_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path / "ignored"))
+    explicit = tmp_path / "explicit" / "wal.jsonl"
+    cfg = IntakeRouterConfig(project_root=Path("/opt/trinity/jarvis"), wal_path=explicit)
+    assert cfg.resolved_wal_path == explicit
+
+
+def test_empty_env_falls_back_to_project_root(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", "   ")  # whitespace = unset
+    cfg = IntakeRouterConfig(project_root=Path("/opt/trinity/jarvis"))
+    assert cfg.resolved_wal_path == Path("/opt/trinity/jarvis/.jarvis/intake_wal.jsonl")


### PR DESCRIPTION
## Virtualize intake storage root via `JARVIS_TRINITY_ROOT` (live-soak Blocker #4)

Found by firing the A1 ignition harness: the isomorphic soak makes the organism believe it lives at the literal production path `/opt/trinity/jarvis`, which isn't writable off the GCE node, so the intake WAL's `mkdir(parents=True)` died with `Permission denied: '/opt/trinity'` → IntakeLayerService failed to boot → intake router never ready → roadmap circuit-breaker.

**Structural fix (zero hardcoding, zero sudo):** `IntakeRouterConfig` now resolves a `_state_root` from `JARVIS_TRINITY_ROOT` (the authoritative writable root) with a `project_root` fallback — so **production is byte-identical** (nothing sets the env var on the real node), while the isomorphic driver injects a writable per-run `trinity_root`. The boundary is virtualized; the code is identical in prod and adapts to unprivileged local execution.

Verified live: after this fix the intake layer boots (`[IntakeLayer] Started: state=ACTIVE`) and the organism runs the full cognitive loop (A1Trace hops emit → CLASSIFY → GENERATE). 4 regression tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Virtualizes intake storage root via `JARVIS_TRINITY_ROOT` to fix permission errors in isomorphic A1 runs. Intake WAL/lock now resolve under a writable root; production behavior is unchanged.

- **Bug Fixes**
  - Added `_state_root` in `IntakeRouterConfig` that prefers `JARVIS_TRINITY_ROOT`, falling back to `project_root`.
  - Updated `scripts/isomorphic_a1_local.py` to set a per-run writable `JARVIS_TRINITY_ROOT`.
  - Added regression tests covering env override, fallback, and explicit path precedence.

<sup>Written for commit a3d116f90f6ebb944dac6ef7f7bfce440b5c118f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69774?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

