### PR TITLE
feat(a1): Adaptive Compute-Context Router — DW→J-Prime 32B fallback, financial decoupling, violent teardown

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -6087,6 +6087,29 @@ class CandidateGenerator:
                 )
             else:
                 self.fsm.record_primary_failure(mode=mode)
+            # CR5 -- header-aware DW recovery. When the primary failed on a DW
+            # rate-limit (429) that carried the provider's own Retry-After /
+            # x-ratelimit-reset header, signal the failover controller so the
+            # SERVING recovery probe can suspend until that exact reset deadline
+            # instead of blind polling. Gated default-OFF + fail-soft: never let
+            # the recovery signal perturb the existing fallback cascade.
+            if mode is FailureMode.RATE_LIMITED:
+                try:
+                    from .failover_lifecycle import (
+                        lifecycle_enabled,
+                        header_aware_recovery_enabled,
+                        get_failover_controller,
+                    )
+                    if lifecycle_enabled() and header_aware_recovery_enabled():
+                        _reset = None
+                        for _layer in _walk_exception_chain(exc):
+                            _reset = getattr(_layer, "ratelimit_reset_ts", None)
+                            if _reset is not None:
+                                break
+                        if _reset is not None:
+                            get_failover_controller().note_rate_limited(_reset)
+                except Exception:  # noqa: BLE001 -- signal must never break the op
+                    pass
             return await self._call_fallback(context, deadline)
 
     async def _slice28_phase3_classify_ttft_failure(

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -6694,6 +6694,17 @@ class CandidateGenerator:
                 "fallback_skipped sentinel (NOT counted toward "
                 "ExhaustionWatcher hibernation threshold)"
             )
+            # Multi-Vector Awaken (CR2): cloud primary exhausted with NO cloud
+            # fallback -> wake the J-Prime golden-image fallback (budget/credit
+            # exhaustion is a valid awaken vector, not just a data-plane outage).
+            try:
+                from .failover_lifecycle import (
+                    lifecycle_enabled, budget_awaken_enabled, get_failover_controller,
+                )
+                if lifecycle_enabled() and budget_awaken_enabled():
+                    get_failover_controller().note_budget_exhausted()
+            except Exception:  # noqa: BLE001 -- never let the signal break the exhaustion path
+                pass
             self._raise_exhausted(
                 "fallback_skipped:no_fallback_configured",
                 context=context,

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1810,11 +1810,18 @@ class DoublewordProvider:
             self._daily_spend = 0.0
             self._budget_reset_date = today
 
-    def _check_budget(self) -> None:
+    def _check_budget(self, compute_context: Optional[str] = None) -> None:
         """Raise if daily budget is exhausted OR session-budget preflight
         refuses. Called before each generation (including from
         ``complete_sync``, which means the DW heavy non-streaming lane
-        inherits the gate transparently)."""
+        inherits the gate transparently).
+
+        ``compute_context`` (Task CR1 -- Financial Context Decoupling): threaded
+        from the callers that hold an OperationContext (``_generate_realtime``,
+        ``submit_batch``). When it equals ``"Local_Open_Source"`` the session
+        preflight ALLOWS the op (free local compute). Cognition-layer callers
+        without a context (``prompt_only``, ``complete_sync``) pass ``None`` --
+        byte-identical to the legacy gate."""
         self._maybe_reset_daily_budget()
         if self._daily_spend >= self._daily_budget:
             raise DoublewordInfraError(
@@ -1847,6 +1854,11 @@ class DoublewordProvider:
                 provider_name="doubleword",
                 estimated_cost_usd=float(self._max_cost_per_op or 0.0),
                 signal_source=None,
+                # Financial Context Decoupling (Task CR1) -- threaded from the
+                # caller's OperationContext (None for context-free cognition
+                # callers). "Local_Open_Source" bypasses the wallet gate;
+                # absent on billed cloud ops, so this is byte-identical.
+                compute_context=compute_context,
             )
         except ImportError:
             # Module absent on this build — graceful fall-through to
@@ -1883,7 +1895,9 @@ class DoublewordProvider:
         """
         if not self.is_available:
             return None
-        self._check_budget()
+        self._check_budget(
+            compute_context=getattr(ctx, "compute_context", None),
+        )
 
         from backend.core.ouroboros.governance.providers import (
             _build_codegen_prompt,
@@ -3124,7 +3138,9 @@ class DoublewordProvider:
         )
         from datetime import datetime, timezone
 
-        self._check_budget()
+        self._check_budget(
+            compute_context=getattr(context, "compute_context", None),
+        )
         t0 = time.monotonic()
         total_cost = 0.0
         self._last_chunk_at = 0.0  # reset — prevents stale timestamps from prior generation

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1182,6 +1182,84 @@ def _dw_heavy_fn_lane_enable_thinking() -> bool:
         return True
 
 
+def _parse_retry_after_headers(headers) -> Optional[float]:
+    """Return an absolute UNIX wake-up timestamp from Retry-After / x-ratelimit-reset,
+    or None. Retry-After may be delta-seconds or an HTTP-date; x-ratelimit-reset is a
+    UNIX ts (or delta). Never raises -> None on any parse failure.
+
+    Task CR5: lets the failover SERVING recovery probe suspend until the
+    provider's OWN stated reset deadline instead of a blind poll interval. Picks
+    the SOONEST sane FUTURE deadline across the recognised headers. Additive +
+    fail-soft -- a missing/garbage header simply yields None (legacy behaviour).
+    """
+    try:
+        if not headers:
+            return None
+        now = time.time()
+        # Case-insensitive lookup that tolerates dict / aiohttp CIMultiDict.
+        def _get(name: str):
+            try:
+                getter = getattr(headers, "get", None)
+                if getter is not None:
+                    val = getter(name)
+                    if val is None:
+                        val = getter(name.lower())
+                    if val is None:
+                        val = getter(name.upper())
+                    return val
+            except Exception:  # noqa: BLE001
+                return None
+            return None
+
+        candidates: List[float] = []
+
+        # --- Retry-After: delta-seconds OR an HTTP-date. ---
+        ra = _get("Retry-After")
+        if ra is not None:
+            ra_str = str(ra).strip()
+            if ra_str:
+                try:
+                    # Integer/float delta-seconds.
+                    candidates.append(now + float(ra_str))
+                except (ValueError, TypeError):
+                    # HTTP-date (RFC 7231) -> absolute ts.
+                    try:
+                        from email.utils import parsedate_to_datetime  # noqa: PLC0415
+                        dt = parsedate_to_datetime(ra_str)
+                        if dt is not None:
+                            candidates.append(dt.timestamp())
+                    except Exception:  # noqa: BLE001
+                        pass
+
+        # --- x-ratelimit-reset[-requests]: a UNIX ts (if large) else a delta. ---
+        for _name in ("x-ratelimit-reset", "x-ratelimit-reset-requests"):
+            rl = _get(_name)
+            if rl is None:
+                continue
+            rl_str = str(rl).strip()
+            if not rl_str:
+                continue
+            try:
+                rl_val = float(rl_str)
+            except (ValueError, TypeError):
+                continue
+            # Heuristic: a value already in absolute-UNIX-ts range is a deadline;
+            # a small value is a delta-seconds offset from now. 1e6 (~Jan 1970+12d)
+            # cleanly separates any realistic delta from any real epoch ts.
+            if rl_val >= 1_000_000.0:
+                candidates.append(rl_val)
+            else:
+                candidates.append(now + rl_val)
+
+        # Keep only sane FUTURE deadlines; return the soonest.
+        future = [c for c in candidates if c > now]
+        if not future:
+            return None
+        return min(future)
+    except Exception:  # noqa: BLE001 -- never raise from header parsing
+        return None
+
+
 class DoublewordInfraError(Exception):
     """Infrastructure failure from DoublewordProvider.
 
@@ -1214,11 +1292,17 @@ class DoublewordInfraError(Exception):
         *,
         response_body: str = "",
         model_id: str = "",
+        ratelimit_reset_ts: Optional[float] = None,
     ) -> None:
         super().__init__(reason)
         self.status_code = status_code
         self.response_body = (response_body or "")[:1024]  # bounded
         self.model_id = (model_id or "")[:128]
+        # Task CR5 (additive, default None): absolute UNIX wake-up deadline parsed
+        # from the 429's own Retry-After / x-ratelimit-reset header, so the
+        # failover SERVING recovery probe can suspend until the provider's stated
+        # reset instead of a blind interval. None -> legacy 429 behaviour.
+        self.ratelimit_reset_ts = ratelimit_reset_ts
 
     def is_modality_error(self) -> bool:
         """True iff the response indicates the model can't accept
@@ -3623,6 +3707,10 @@ class DoublewordProvider:
                                     status_code=resp.status,
                                     response_body=err_body,
                                     model_id=_effective_model,
+                                    # CR5: capture the provider's own reset deadline
+                                    # (Retry-After / x-ratelimit-reset) -> header-aware
+                                    # failover recovery sleep. None on non-429/no header.
+                                    ratelimit_reset_ts=_parse_retry_after_headers(resp.headers),
                                 )
 
                             # Two-Phase Stream Rupture Breaker.
@@ -4087,6 +4175,8 @@ class DoublewordProvider:
                                     status_code=resp.status,
                                     response_body=err_body,
                                     model_id=_effective_model,
+                                    # CR5: header-aware failover recovery deadline.
+                                    ratelimit_reset_ts=_parse_retry_after_headers(resp.headers),
                                 )
 
                             data = await resp.json()
@@ -5600,6 +5690,8 @@ class DoublewordProvider:
                     raise DoublewordInfraError(
                         f"complete_sync[{caller_id}] HTTP {resp.status}: {err_body[:200]}",
                         status_code=resp.status,
+                        # CR5: header-aware failover recovery deadline.
+                        ratelimit_reset_ts=_parse_retry_after_headers(resp.headers),
                     )
                 data = await resp.json()
                 choices = data.get("choices", [])

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -78,6 +78,7 @@ import enum
 import logging
 import os
 import subprocess
+import time
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
 
 # Phase 3c -- Cryo-DLQ re-entry. Imported at module level (bound as a module
@@ -147,6 +148,20 @@ def budget_awaken_enabled() -> bool:
     with reason ``BUDGET_EXHAUSTED``."""
     return os.environ.get(
         "JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED", "false"
+    ).strip().lower() in ("1", "true", "yes")
+
+
+def header_aware_recovery_enabled() -> bool:
+    """Master gate for header-aware DW-recovery sleep (Task CR5). Default OFF ->
+    byte-identical (the SERVING probe paces itself by the forecast-driven jitter
+    backoff, exactly as today). When ARMED, a DW 429 that carried a
+    ``Retry-After`` / ``x-ratelimit-reset`` header (anchored via
+    ``note_rate_limited``) makes the recovery probe suspend until the provider's
+    OWN reset deadline before falling through to the semantic deep probe. Reuses
+    the existing deep probe + jitter backoff -- it ONLY changes the next-probe
+    interval while the rate-limit anchor is live."""
+    return os.environ.get(
+        "JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED", "false"
     ).strip().lower() in ("1", "true", "yes")
 
 
@@ -805,6 +820,14 @@ class FailoverLifecycleController:
         # note_budget_exhausted(); consumed (single-shot) by the dormant tick's
         # budget branch when the budget-awaken master flag is armed.
         self._budget_exhausted_at: Optional[float] = None
+        # Rate-limit recovery anchor (Task CR5). An absolute WALL-CLOCK
+        # (time.time()) wake-up deadline parsed from the DW 429's own
+        # Retry-After / x-ratelimit-reset header. Set by note_rate_limited();
+        # consumed by _probe_interval's header-aware branch (master flag armed)
+        # to suspend the SERVING recovery probe until the provider's stated
+        # reset, then cleared once the deadline passes. None -> legacy blind
+        # forecast-driven interval.
+        self._rate_limit_reset_ts: Optional[float] = None
 
         # Timestamps (monotonic via clock_fn).
         self._outage_started_at: Optional[float] = None  # set on note_outage
@@ -987,6 +1010,13 @@ class FailoverLifecycleController:
                 self._budget_exhausted_at = self._clock_fn()
             except Exception:  # noqa: BLE001
                 self._budget_exhausted_at = 0.0
+
+    def note_rate_limited(self, reset_ts: Optional[float] = None) -> None:
+        """Anchor a DW rate-limit (429) recovery deadline from the provider's own
+        Retry-After/x-ratelimit-reset. The SERVING probe sleeps until reset_ts
+        instead of a blind interval. Fail-soft; ignored if reset_ts is past/None."""
+        if reset_ts is not None and reset_ts > time.time():
+            self._rate_limit_reset_ts = reset_ts
 
     def note_dw_success(self) -> None:
         """A successful DW dispatch was observed -- clear the outage anchor."""
@@ -1703,10 +1733,18 @@ class FailoverLifecycleController:
             "reactive_outage": AWAKEN_REASON_DATA_PLANE,
             "heartbeat_hard_outage": AWAKEN_REASON_DATA_PLANE,
             "heartbeat_early_prewarm": AWAKEN_REASON_DATA_PLANE,
+            "rate_limited": AWAKEN_REASON_RATE_LIMIT,  # CR5
         }
         self._awaken_reason = _reason_by_trigger.get(
             trigger, AWAKEN_REASON_DATA_PLANE
         )
+        # CR5: a live rate-limit anchor (set by note_rate_limited from the DW
+        # 429's own Retry-After/x-ratelimit-reset header) means the recovery
+        # strategy is header-aware regardless of which trigger initiated the
+        # awaken. Override to RATE_LIMIT so _probe_interval's header-aware branch
+        # can suspend the SERVING probe until the provider's stated reset.
+        if self._rate_limit_reset_ts is not None:
+            self._awaken_reason = AWAKEN_REASON_RATE_LIMIT
         self._state = FailoverState.AWAKENING
         self._awakening_started_at = now
         self._recovered_streak = 0
@@ -2046,6 +2084,26 @@ class FailoverLifecycleController:
             return False
 
     def _probe_interval(self, *, now: float) -> float:
+        # CR5 -- Header-aware DW-recovery sleep. Default-OFF: when the master flag
+        # is unset this whole branch is skipped and the method is byte-identical
+        # to the legacy forecast-driven jitter backoff below. When ARMED and we
+        # awakened on a rate-limit (429) carrying the provider's own
+        # Retry-After/x-ratelimit-reset deadline, suspend the SERVING probe until
+        # that exact wall-clock reset instead of blind polling. The wait then
+        # falls through to the SAME semantic deep probe (_deep_probe_recovered),
+        # which still gates handback on real generation success.
+        if (
+            header_aware_recovery_enabled()
+            and self._awaken_reason == AWAKEN_REASON_RATE_LIMIT
+            and self._rate_limit_reset_ts is not None
+        ):
+            remaining = self._rate_limit_reset_ts - time.time()
+            if remaining > 0:
+                # Header-aware async sleep: suspend the probe until the provider's
+                # own reset deadline -- zero blind polling. (asyncio.sleep happens
+                # via the FSM tick gate; we just return the exact interval.)
+                return max(0.0, remaining)
+            self._rate_limit_reset_ts = None  # deadline passed -> resume normal probing
         try:
             from backend.core.ouroboros.governance.recovery_throttle import (  # noqa: PLC0415
                 probe_interval,
@@ -2303,6 +2361,7 @@ __all__ = [
     "lifecycle_enabled",
     "budget_awaken_enabled",
     "violent_teardown_enabled",
+    "header_aware_recovery_enabled",
     "AWAKEN_REASON_DATA_PLANE",
     "AWAKEN_REASON_BUDGET",
     "AWAKEN_REASON_RATE_LIMIT",

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -89,6 +89,17 @@ logger = logging.getLogger(__name__)
 
 
 # ---------------------------------------------------------------------------
+# Awaken-reason taxonomy (Task CR2 -- Multi-Vector Awaken Trigger)
+# ---------------------------------------------------------------------------
+# The controller REMEMBERS *why* it awakened so a later recovery strategy can
+# branch on the vector. DW stays primary; J-Prime is the fallback. A data-plane
+# outage and a cloud-budget exhaustion are BOTH valid awaken vectors.
+AWAKEN_REASON_DATA_PLANE = "DATA_PLANE_OUTAGE"
+AWAKEN_REASON_BUDGET = "BUDGET_EXHAUSTED"
+AWAKEN_REASON_RATE_LIMIT = "RATE_LIMITED"  # reserved for CR5 (set up now)
+
+
+# ---------------------------------------------------------------------------
 # Env helpers (fail-soft, never raise)
 # ---------------------------------------------------------------------------
 
@@ -127,6 +138,16 @@ def lifecycle_enabled() -> bool:
     Hot-revert: ``export JARVIS_FAILOVER_LIFECYCLE_ENABLED=false`` -> inert
     (stays DORMANT, today's behavior exactly)."""
     return _enabled("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+
+
+def budget_awaken_enabled() -> bool:
+    """Master gate for the budget-exhaustion awaken vector (Task CR2). Default
+    OFF -> byte-identical (only a data-plane outage awakens). When ARMED, a
+    ``note_budget_exhausted()`` anchor awakens J-Prime on the next dormant tick
+    with reason ``BUDGET_EXHAUSTED``."""
+    return os.environ.get(
+        "JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED", "false"
+    ).strip().lower() in ("1", "true", "yes")
 
 
 def _route() -> str:
@@ -764,6 +785,16 @@ class FailoverLifecycleController:
         # SECOND, concurrent GPU node lifecycle with crypto-namespaced assets.
         self._gpu_lane: Optional[Any] = None
 
+        # Multi-Vector Awaken (Task CR2). The controller remembers WHY it
+        # awakened (data-plane outage vs cloud-budget exhaustion) so a later
+        # recovery strategy can branch on the vector. Inert ("") until a
+        # transition stamps it; default-OFF keeps it byte-identical.
+        self._awaken_reason: str = ""
+        # Budget-exhaustion anchor (monotonic via clock_fn). Set by
+        # note_budget_exhausted(); consumed (single-shot) by the dormant tick's
+        # budget branch when the budget-awaken master flag is armed.
+        self._budget_exhausted_at: Optional[float] = None
+
         # Timestamps (monotonic via clock_fn).
         self._outage_started_at: Optional[float] = None  # set on note_outage
         self._awakening_started_at: Optional[float] = None  # set on -> AWAKENING
@@ -934,6 +965,17 @@ class FailoverLifecycleController:
                 self._outage_started_at = self._clock_fn()
             except Exception:  # noqa: BLE001
                 self._outage_started_at = 0.0
+
+    def note_budget_exhausted(self) -> None:
+        """Anchor a cloud-budget-exhaustion event (DW refused on budget, no cloud
+        fallback). The next dormant tick awakens J-Prime with reason
+        BUDGET_EXHAUSTED. Idempotent; gated by the budget-awaken master flag at
+        the tick."""
+        if self._budget_exhausted_at is None:
+            try:
+                self._budget_exhausted_at = self._clock_fn()
+            except Exception:  # noqa: BLE001
+                self._budget_exhausted_at = 0.0
 
     def note_dw_success(self) -> None:
         """A successful DW dispatch was observed -- clear the outage anchor."""
@@ -1452,6 +1494,20 @@ class FailoverLifecycleController:
             )
             return
 
+        # Multi-Vector Awaken (Task CR2) -- BUDGET-EXHAUSTION vector. The LAST
+        # branch so a REAL data-plane outage (the branches above) always takes
+        # precedence. The cloud primary refused on budget with NO cloud fallback
+        # (anchored by note_budget_exhausted from candidate_generator's
+        # no-fallback exhaustion exit). Gated default-OFF -> byte-identical.
+        # Single-shot: consume the anchor before awakening so it can't re-fire
+        # every tick.
+        if budget_awaken_enabled() and self._budget_exhausted_at is not None:
+            self._budget_exhausted_at = None
+            await self._enter_awakening(
+                now=now, trigger="session_budget_exhausted", route=self._route,
+            )
+            return
+
     def _real_outage(self) -> bool:
         """The AUTHORITATIVE real-generation-failure awaken signal.
 
@@ -1628,6 +1684,18 @@ class FailoverLifecycleController:
         recorder captures which signal initiated the failover, regardless of the
         GCE boot outcome."""
         self._emit_flare(trigger=trigger, route=route, now=now)
+        # Multi-Vector Awaken (Task CR2): remember WHY we awakened so a later
+        # recovery strategy can branch on the vector. Derive from the trigger;
+        # default to DATA_PLANE (the data-plane outage is the legacy vector).
+        _reason_by_trigger = {
+            "session_budget_exhausted": AWAKEN_REASON_BUDGET,
+            "reactive_outage": AWAKEN_REASON_DATA_PLANE,
+            "heartbeat_hard_outage": AWAKEN_REASON_DATA_PLANE,
+            "heartbeat_early_prewarm": AWAKEN_REASON_DATA_PLANE,
+        }
+        self._awaken_reason = _reason_by_trigger.get(
+            trigger, AWAKEN_REASON_DATA_PLANE
+        )
         self._state = FailoverState.AWAKENING
         self._awakening_started_at = now
         self._recovered_streak = 0
@@ -2177,4 +2245,8 @@ __all__ = [
     "FailoverLifecycleController",
     "get_failover_controller",
     "lifecycle_enabled",
+    "budget_awaken_enabled",
+    "AWAKEN_REASON_DATA_PLANE",
+    "AWAKEN_REASON_BUDGET",
+    "AWAKEN_REASON_RATE_LIMIT",
 ]

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -2261,38 +2261,43 @@ class FailoverLifecycleController:
         then node + ephemeral /32 firewall vacate together via ``asyncio.gather``)
         so nothing keeps billing or routing. Idempotent + fail-soft: a no-op when
         already DORMANT; NEVER raises. After reaping, drops to DORMANT and arms the
-        same anti-thrash cooldown anchor the HANDBACK path uses."""
-        if self._state == FailoverState.DORMANT:
-            return  # nothing to reap
-        logger.warning(
-            "[FailoverFlare] VIOLENT TEARDOWN reason=%s state=%s -- reaping GPU node now",
-            reason, self._state.name,
-        )
-        # 1. Reap the elastic GPU node + its /32 firewall (CPU node survives until
-        #    the node-delete below). Fail-soft -- never block the rest of teardown.
-        try:
-            await self._reap_gpu_node()
-        except Exception as exc:  # noqa: BLE001
+        same anti-thrash cooldown anchor the HANDBACK path uses.
+
+        The body is wrapped in ``self._lock`` so that a concurrent ``tick()``
+        mid-transition (e.g. _do_awaken) cannot race the state + endpoint
+        mutations here -- matching every other FSM transition."""
+        async with self._lock:
+            if self._state == FailoverState.DORMANT:
+                return  # nothing to reap
             logger.warning(
-                "[FailoverFlare] violent teardown gpu-reap error (continuing): %s", exc)
-        # 2. Delete-to-snapshot the node + close the ephemeral /32 perimeter -- the
-        #    SAME guaranteed-parallel gather the FSM teardowns use (zero orphan node
-        #    AND zero orphan firewall hole; the lock-race fix).
-        try:
-            await asyncio.gather(
-                self._maybe_await(self._vm_delete_fn),
-                self._close_ephemeral_perimeter(),
-                return_exceptions=True,
+                "[FailoverFlare] VIOLENT TEARDOWN reason=%s state=%s -- reaping GPU node now",
+                reason, self._state.name,
             )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "[FailoverFlare] violent teardown node/fw error (continuing): %s", exc)
-        # 3. DORMANT + arm the anti-thrash cooldown anchor + drop the endpoint so
-        #    is_jprime_serving()/jprime_endpoint() stop pointing at the dead node.
-        self._state = FailoverState.DORMANT
-        self._last_handback_at = self._clock_fn()  # arm anti-thrash cooldown
-        self._endpoint = None
-        logger.info("[FailoverFlare] VIOLENT TEARDOWN complete -- DORMANT, cooldown armed")
+            # 1. Reap the elastic GPU node + its /32 firewall (CPU node survives until
+            #    the node-delete below). Fail-soft -- never block the rest of teardown.
+            try:
+                await self._reap_gpu_node()
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[FailoverFlare] violent teardown gpu-reap error (continuing): %s", exc)
+            # 2. Delete-to-snapshot the node + close the ephemeral /32 perimeter -- the
+            #    SAME guaranteed-parallel gather the FSM teardowns use (zero orphan node
+            #    AND zero orphan firewall hole; the lock-race fix).
+            try:
+                await asyncio.gather(
+                    self._maybe_await(self._vm_delete_fn),
+                    self._close_ephemeral_perimeter(),
+                    return_exceptions=True,
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[FailoverFlare] violent teardown node/fw error (continuing): %s", exc)
+            # 3. DORMANT + arm the anti-thrash cooldown anchor + drop the endpoint so
+            #    is_jprime_serving()/jprime_endpoint() stop pointing at the dead node.
+            self._state = FailoverState.DORMANT
+            self._last_handback_at = self._clock_fn()  # arm anti-thrash cooldown
+            self._endpoint = None
+            logger.info("[FailoverFlare] VIOLENT TEARDOWN complete -- DORMANT, cooldown armed")
 
     # ------------------------------------------------------------------
     # Await helper (boundaries may be sync or async)

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -150,6 +150,17 @@ def budget_awaken_enabled() -> bool:
     ).strip().lower() in ("1", "true", "yes")
 
 
+def violent_teardown_enabled() -> bool:
+    """Master gate for the Violent Ephemeral Teardown (Task CR4). Default OFF ->
+    byte-identical (only the passive HANDBACK/dead-man reaps J-Prime). When ARMED,
+    the GPU node + node + both /32 firewalls vacate the INSTANT the A1 DAG hits a
+    terminal state (PR opened OR fail-closed at any gate) -- zero idle GPU while a
+    g2 sits waiting for human review."""
+    return os.environ.get(
+        "JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED", "false"
+    ).strip().lower() in ("1", "true", "yes")
+
+
 def _route() -> str:
     return _env_str("JARVIS_FAILOVER_ROUTE", "dw")
 
@@ -2181,6 +2192,51 @@ class FailoverLifecycleController:
             logger.debug("[FailoverLifecycle] drain fail-soft err=%r", exc)
 
     # ------------------------------------------------------------------
+    # Violent Ephemeral Teardown (Task CR4)
+    # ------------------------------------------------------------------
+
+    async def force_teardown(self, *, reason: str = "a1_terminal") -> None:
+        """Deterministically reap the J-Prime (GPU) node the instant the A1 DAG
+        hits a terminal state -- zero idle GPU while waiting for human review.
+
+        Reuses the proven parallel-teardown idiom (GPU node + GPU /32 firewall,
+        then node + ephemeral /32 firewall vacate together via ``asyncio.gather``)
+        so nothing keeps billing or routing. Idempotent + fail-soft: a no-op when
+        already DORMANT; NEVER raises. After reaping, drops to DORMANT and arms the
+        same anti-thrash cooldown anchor the HANDBACK path uses."""
+        if self._state == FailoverState.DORMANT:
+            return  # nothing to reap
+        logger.warning(
+            "[FailoverFlare] VIOLENT TEARDOWN reason=%s state=%s -- reaping GPU node now",
+            reason, self._state.name,
+        )
+        # 1. Reap the elastic GPU node + its /32 firewall (CPU node survives until
+        #    the node-delete below). Fail-soft -- never block the rest of teardown.
+        try:
+            await self._reap_gpu_node()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[FailoverFlare] violent teardown gpu-reap error (continuing): %s", exc)
+        # 2. Delete-to-snapshot the node + close the ephemeral /32 perimeter -- the
+        #    SAME guaranteed-parallel gather the FSM teardowns use (zero orphan node
+        #    AND zero orphan firewall hole; the lock-race fix).
+        try:
+            await asyncio.gather(
+                self._maybe_await(self._vm_delete_fn),
+                self._close_ephemeral_perimeter(),
+                return_exceptions=True,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "[FailoverFlare] violent teardown node/fw error (continuing): %s", exc)
+        # 3. DORMANT + arm the anti-thrash cooldown anchor + drop the endpoint so
+        #    is_jprime_serving()/jprime_endpoint() stop pointing at the dead node.
+        self._state = FailoverState.DORMANT
+        self._last_handback_at = self._clock_fn()  # arm anti-thrash cooldown
+        self._endpoint = None
+        logger.info("[FailoverFlare] VIOLENT TEARDOWN complete -- DORMANT, cooldown armed")
+
+    # ------------------------------------------------------------------
     # Await helper (boundaries may be sync or async)
     # ------------------------------------------------------------------
 
@@ -2246,6 +2302,7 @@ __all__ = [
     "get_failover_controller",
     "lifecycle_enabled",
     "budget_awaken_enabled",
+    "violent_teardown_enabled",
     "AWAKEN_REASON_DATA_PLANE",
     "AWAKEN_REASON_BUDGET",
     "AWAKEN_REASON_RATE_LIMIT",

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3959,6 +3959,27 @@ class GovernedLoopService:
             outcome_source="governed_loop",
         )
 
+        # CR4: Violent Ephemeral Teardown -- reap the GPU J-Prime node the instant
+        # the A1 DAG reaches terminal (PR opened OR fail-closed). Zero idle GPU.
+        # Double-gated (lifecycle + violent-teardown) + fail-soft; default-OFF
+        # stays byte-identical because force_teardown is never reached.
+        try:
+            from .failover_lifecycle import (  # noqa: PLC0415
+                lifecycle_enabled,
+                violent_teardown_enabled,
+                get_failover_controller,
+            )
+            if lifecycle_enabled() and violent_teardown_enabled():
+                _terminal_phase = getattr(
+                    getattr(result, "terminal_phase", None), "name",
+                    getattr(result, "terminal_phase", "?"),
+                )
+                await get_failover_controller().force_teardown(
+                    reason="a1_terminal:%s" % _terminal_phase,
+                )
+        except Exception:  # noqa: BLE001 -- teardown is best-effort; never break finalization
+            pass
+
     def health(self) -> Dict[str, Any]:
         """Return structured health report."""
         uptime = (

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -1012,6 +1012,7 @@ class OperationContext:
     # ---- Signal metadata (propagated from IntentEnvelope at intake) ----
     signal_urgency: str = ""   # "critical" | "high" | "normal" | "low"
     signal_source: str = ""    # "test_failure" | "voice_human" | "ai_miner" | etc.
+    compute_context: str = ""  # "" | "Local_Open_Source" (free local Ollama) -- bypasses the financial preflight
     # JSON-encoded snapshot of the originating envelope's
     # ``evidence`` dict. Frozen-friendly (string, no Mapping
     # ordering issues). Default empty string when no envelope (op
@@ -1394,6 +1395,18 @@ class OperationContext:
 
         # Final instance with correct hash
         return dataclasses.replace(intermediate, context_hash=new_hash)
+
+    def with_compute_context(self, compute_context: str) -> "OperationContext":
+        """Return a new context tagged with a compute_context.
+
+        ``"Local_Open_Source"`` marks an op as free local open-source compute
+        (e.g. local Ollama, $0.00), which bypasses the financial preflight in
+        :func:`session_budget_authority.check_preflight`. Mirrors the existing
+        ``with_*`` dataclasses.replace idiom (no hash-chain rewrite needed --
+        this is a pre-pipeline tag set alongside signal metadata).
+        """
+        import dataclasses as _dc
+        return _dc.replace(self, compute_context=compute_context)
 
     def with_pipeline_deadline(self, deadline: "datetime") -> "OperationContext":
         """Return a new context with pipeline_deadline set (no phase change).

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -8659,6 +8659,10 @@ class ClaudeProvider:
                     getattr(context, "signal_source", None)
                 ),
                 op_id=getattr(context, "op_id", None),
+                # Financial Context Decoupling (Task CR1) -- free local
+                # open-source ops bypass the wallet gate. Absent on billed
+                # cloud ops (default ""), so this is byte-identical for Claude.
+                compute_context=getattr(context, "compute_context", None),
             )
         except ImportError:
             # Module absent on this build (graceful) — fall through to

--- a/backend/core/ouroboros/governance/session_budget_authority.py
+++ b/backend/core/ouroboros/governance/session_budget_authority.py
@@ -500,6 +500,13 @@ _BACKGROUND_TIER_SIGNAL_SOURCES: frozenset = frozenset({
     "intent_discovery",
 })
 
+# Financial Context Decoupling (Task CR1) -- the compute_context tag value that
+# marks an op as free local open-source compute (e.g. local Ollama, $0.00).
+# When ``check_preflight`` sees this tag it ALLOWS the op unconditionally --
+# free local compute is not financially gated. Billed cloud providers (Claude,
+# DoubleWord) never set this tag, so their behavior is byte-identical.
+LOCAL_OPEN_SOURCE = "Local_Open_Source"
+
 
 def is_background_tier_source(signal_source: Optional[str]) -> bool:
     """Return True iff the signal_source identifies a
@@ -566,6 +573,7 @@ def check_preflight(
     estimated_cost_usd: float,
     signal_source: Optional[str] = None,
     op_id: Optional[str] = None,
+    compute_context: Optional[str] = None,
 ) -> None:
     """Hard wallet gate. Call BEFORE provider dispatch.
 
@@ -614,6 +622,19 @@ def check_preflight(
         return  # fail-OPEN on adapter fault
     if remaining is None:
         return  # no authority active
+
+    # -- Financial Context Decoupling (Task CR1) --
+    # Free local open-source compute ($0.00) is not financially gated.
+    # This early-return ALLOW wins over BOTH the background-spend ceiling
+    # and the generic est>remaining refusal below. Only the EXACT free-tier
+    # tag bypasses; billed cloud providers (Claude/DW) never set it, so this
+    # branch is inert (prod byte-identical) when compute_context is absent.
+    if compute_context == LOCAL_OPEN_SOURCE:
+        logger.info(
+            "[SBA] preflight ALLOWED: compute_context=%s (free local compute, "
+            "$0.00) provider=%s op_id=%s", compute_context, provider_name, op_id)
+        return  # free local open-source compute is not financially gated
+
     try:
         est = float(max(0.0, estimated_cost_usd or 0.0))
     except (TypeError, ValueError):

--- a/scripts/a1_gcp_preflight.py
+++ b/scripts/a1_gcp_preflight.py
@@ -1,0 +1,166 @@
+#!/usr/bin/env python3
+"""a1_gcp_preflight -- $0 GCP credential preflight before any awaken/REST call.
+
+Asserts that GCP credentials, project, and zone are properly configured.
+On missing/invalid config: FAILS GRACEFULLY with the EXACT export commands
+the operator needs -- no stack trace, no GCP API call, no node created.
+
+Reuses seams from gcp_compute_rest.GCPComputeRest (auth resolution +
+verify_compute_scopes) and mirrors the shape of smoke_sa_token_mint.py.
+
+Usage (standalone):
+    python3 scripts/a1_gcp_preflight.py
+
+Importable:
+    from scripts.a1_gcp_preflight import preflight_gcp_ready
+    ok, problems = await preflight_gcp_ready()
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import sys
+
+_REPO = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+sys.path.insert(0, _REPO)
+
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+_RESET = "\033[0m"
+
+
+async def preflight_gcp_ready(
+    *,
+    require_zone: bool = True,
+    rest=None,
+) -> tuple[bool, list[str]]:
+    """($0) Assert GCP is ready to awaken a node. Returns (ok, problems).
+
+    Each problem string includes the EXACT ``export ...`` command to fix it.
+    Performs NO instances.insert -- only credential/project/zone resolution
+    and a $0 token-mint structural check. Never raises (fail-soft -> (False, [...])).
+
+    Parameters
+    ----------
+    require_zone:
+        When True (default), flag a missing/empty GCP_ZONE as a problem.
+    rest:
+        Optional pre-built GCPComputeRest-like object (for tests). When None
+        the real GCPComputeRest is constructed from the environment.
+    """
+    problems: list[str] = []
+
+    # --- 1. resolve the rest client --------------------------------------
+    if rest is None:
+        try:
+            from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                GCPComputeRest,
+            )
+            rest = GCPComputeRest()
+        except Exception as exc:  # noqa: BLE001
+            return (
+                False,
+                [f"Cannot init GCPComputeRest: {exc} -- ensure google-auth is installed"],
+            )
+
+    # --- 2. auth check ---------------------------------------------------
+    try:
+        auth_mode = rest._auth_mode  # "sa" | "adc" | "metadata"
+        if auth_mode == "metadata":
+            # Off-GCE with no SA JSON and no ADC -- metadata auth only works
+            # when running inside GCE and requires no local credential.
+            # For an off-GCE awaken orchestrator this means no credential.
+            auth_ok = False
+        else:
+            scope_result = await rest.verify_compute_scopes()
+            # verify_compute_scopes returns (bool, str); accept (bool,) or plain bool
+            if isinstance(scope_result, tuple):
+                auth_ok = bool(scope_result[0])
+            else:
+                auth_ok = bool(scope_result)
+    except Exception:  # noqa: BLE001
+        auth_ok = False
+
+    if not auth_ok:
+        problems.append(
+            "No valid GCP auth. Fix ONE:\n"
+            "    export GOOGLE_APPLICATION_CREDENTIALS=/abs/path/to/sa.json\n"
+            "  OR run: gcloud auth application-default login"
+        )
+
+    # --- 3. project check ------------------------------------------------
+    try:
+        proj = await rest.project()
+    except Exception:  # noqa: BLE001
+        proj = None
+    if not proj:
+        problems.append(
+            "GCP project unresolved -- "
+            "export GCP_PROJECT_ID=<your-project>  (e.g. jarvis-473803)"
+        )
+
+    # --- 4. zone check ---------------------------------------------------
+    if require_zone:
+        try:
+            z = await rest.zone()
+        except Exception:  # noqa: BLE001
+            z = None
+        if not z:
+            problems.append(
+                "GCP zone unset -- "
+                "export GCP_ZONE=<zone>  (a g2/nvidia-l4 GPU zone, e.g. us-central1-a)"
+            )
+
+    ok = len(problems) == 0
+    return (ok, problems)
+
+
+def main() -> None:
+    """CLI entry point. Exits 0 on success, 2 on any problem. Never raises."""
+    try:
+        ok, problems = asyncio.run(preflight_gcp_ready())
+    except Exception as exc:  # noqa: BLE001
+        print(f"[a1-gcp-preflight] INTERNAL ERROR: {exc}")
+        sys.exit(2)
+
+    if ok:
+        # Resolve display values for the success banner (best-effort, no error).
+        try:
+            import asyncio as _a  # noqa: PLC0415
+
+            async def _resolve():
+                from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                    GCPComputeRest,
+                )
+                r = GCPComputeRest()
+                p = await r.project()
+                z = await r.zone()
+                return r._auth_mode, p or "?", z or "?"
+
+            mode, proj, zone = _a.run(_resolve())
+        except Exception:  # noqa: BLE001
+            mode, proj, zone = "?", "?", "?"
+
+        print(
+            f"{_GREEN}[a1-gcp-preflight] OK -- "
+            f"project={proj} zone={zone} auth={mode}{_RESET}"
+        )
+        sys.exit(0)
+    else:
+        lines = [
+            f"{_RED}[a1-gcp-preflight] NOT READY -- "
+            "the live 32B awaken cannot proceed.",
+            "Run these in THIS terminal, then re-run:",
+            "",
+        ]
+        for problem in problems:
+            for line in problem.splitlines():
+                lines.append(f"    {line}")
+            lines.append("")
+        lines.append(f"(All checks are $0 -- no node was created.){_RESET}")
+        print("\n".join(lines))
+        sys.exit(2)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -237,6 +237,72 @@ def _read_tail(log_path: Path, n: int = 40) -> list[str]:
 
 
 # ---------------------------------------------------------------------------
+# Helpers: live-failover
+# ---------------------------------------------------------------------------
+
+def _arm_failover_env(env: dict) -> dict:
+    """Stamp all JARVIS_FAILOVER_* keys into *env* for a live-failover run.
+
+    Returns the same dict (mutated in place).  GCP_PROJECT_ID / GCP_ZONE are
+    NOT set here -- they come from the operator's exported environment via the
+    caller's os.environ copy.
+    """
+    env.update({
+        # Failover mesh armed: DW primary -> J-Prime 32B golden-image fallback
+        "JARVIS_FAILOVER_LIFECYCLE_ENABLED": "true",
+        "JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED": "true",
+        "JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED": "true",
+        "JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED": "true",
+        # Force the 32B QUALITY GPU tier (g2-standard-4 + nvidia-l4 + jarvis-prime-coder-32b)
+        "JARVIS_FAILOVER_QUALITY_TIER_ENABLED": "true",
+        "JARVIS_FAILOVER_AWAKEN_URGENCY": "immediate",
+        "JARVIS_FAILOVER_QUALITY_MACHINE": "g2-standard-4",
+        "JARVIS_FAILOVER_QUALITY_ACCEL_TYPE": "nvidia-l4",
+        "JARVIS_FAILOVER_QUALITY_ACCEL_COUNT": "1",
+        "JARVIS_FAILOVER_QUALITY_IMAGE": "jarvis-prime-coder-32b",
+        "JARVIS_FAILOVER_INFERENCE_BIND_ENABLED": "true",
+    })
+    return env
+
+
+def _build_soak_argv(repo_root: Path, run_root: Path, *, live_failover: bool) -> list[str]:
+    """Build the soak driver argv.  Appends ``--enable-failover`` when *live_failover*."""
+    argv = [
+        sys.executable,
+        str(repo_root / "scripts" / "isomorphic_a1_local.py"),
+        "--mode", "container",
+        "--run-root", str(run_root),
+    ]
+    if live_failover:
+        argv.append("--enable-failover")
+    return argv
+
+
+def _load_preflight_fn(scripts_dir: Path):
+    """Return ``preflight_gcp_ready`` from the sibling a1_gcp_preflight module.
+
+    Tries a direct import first (works when scripts/ is on sys.path), then
+    falls back to importlib path-loading so this script works as __main__ too.
+    Never raises -- callers should catch ImportError.
+    """
+    try:
+        from a1_gcp_preflight import preflight_gcp_ready  # noqa: PLC0415
+        return preflight_gcp_ready
+    except Exception:
+        pass
+    import importlib.util as _ilu
+    _spec = _ilu.spec_from_file_location(
+        "a1_gcp_preflight",
+        scripts_dir / "a1_gcp_preflight.py",
+    )
+    if _spec is None or _spec.loader is None:
+        raise ImportError("Cannot load a1_gcp_preflight.py from " + str(scripts_dir))
+    _mod = _ilu.module_from_spec(_spec)
+    _spec.loader.exec_module(_mod)  # type: ignore[union-attr]
+    return _mod.preflight_gcp_ready
+
+
+# ---------------------------------------------------------------------------
 # main()
 # ---------------------------------------------------------------------------
 
@@ -269,6 +335,15 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
         action="store_true",
         help="Stub real subprocesses -- exercises wiring without Docker or soak.",
     )
+    parser.add_argument(
+        "--live-failover",
+        action="store_true",
+        help=(
+            "Awaken the GCP J-Prime 32B golden image as DW's fallback for a REAL "
+            "autonomous-PR run (real bounded GPU spend; runs the $0 credential "
+            "preflight first)."
+        ),
+    )
     args = parser.parse_args()
 
     repo_root = Path(__file__).resolve().parents[1]
@@ -283,6 +358,7 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
     log_file = logs_dir / f"a1_ignition_{stamp}.log"
 
     # ------------------------------------------------------------------ dry-run stubs
+    _scripts_dir = Path(__file__).resolve().parent
     if args.dry_run:
         print("[DRY-RUN] Adaptive Ignition Harness (no real subprocesses)")
         print(f"[DRY-RUN] log_file   : {log_file}")
@@ -290,6 +366,28 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
         print(f"[DRY-RUN] max-wall-s : {args.max_wall_seconds}")
         print(f"[DRY-RUN] preflight  : {'SKIP' if args.skip_preflight else 'would run'}")
         print("[DRY-RUN] Docker check: STUBBED -> OK")
+        if args.live_failover:
+            print("[>] live-failover: running $0 GCP credential preflight ...")
+            try:
+                import asyncio as _aio
+                _preflight_fn = _load_preflight_fn(_scripts_dir)
+                _ok, _problems = _aio.run(_preflight_fn())
+            except Exception as _exc:
+                print(f"[!] live-failover preflight raised unexpectedly: {_exc}")
+                return 2
+            if not _ok:
+                print("\n[!] live-failover ABORTED at $0 -- GCP not ready (no node was created).")
+                print("    Run these in THIS terminal, then re-run with --live-failover:\n")
+                for _p in _problems:
+                    print("    " + _p.replace("\n", "\n    "))
+                return 2
+            print("[OK] GCP preflight green.")
+            _armed = _arm_failover_env({})
+            print("[DRY-RUN] live-failover env armed:")
+            for _k, _v in sorted(_armed.items()):
+                print(f"  {_k}={_v}")
+            _argv_preview = _build_soak_argv(repo_root, run_root, live_failover=True)
+            print(f"[DRY-RUN] soak argv: {' '.join(_argv_preview)}")
         print("[DRY-RUN] Soak       : STUBBED -> exit 0 (A1_DISPATCH_PROVEN)")
         print("")
         print("[OK] A1_DISPATCH_PROVEN (dry-run stub)")
@@ -305,6 +403,24 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
         return 2
 
     print(f"[OK] Docker daemon: {reason}")
+
+    # ------------------------------------------------------------------ GCP preflight (live-failover only)
+    if args.live_failover:
+        print("[>] live-failover: running $0 GCP credential preflight ...")
+        try:
+            import asyncio as _aio
+            _preflight_fn = _load_preflight_fn(_scripts_dir)
+            _ok, _problems = _aio.run(_preflight_fn())
+        except Exception as _exc:
+            print(f"[!] live-failover preflight raised unexpectedly: {_exc}")
+            return 2
+        if not _ok:
+            print("\n[!] live-failover ABORTED at $0 -- GCP not ready (no node was created).")
+            print("    Run these in THIS terminal, then re-run with --live-failover:\n")
+            for _p in _problems:
+                print("    " + _p.replace("\n", "\n    "))
+            return 2
+        print("[OK] GCP preflight green -- proceeding to awaken the 32B fallback.")
 
     # ------------------------------------------------------------------ open log
     log_file.parent.mkdir(parents=True, exist_ok=True)
@@ -334,18 +450,15 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
 
         # ---------------------------------------------------------------- soak
         run_root.mkdir(parents=True, exist_ok=True)
-        soak_argv = [
-            sys.executable,
-            str(repo_root / "scripts" / "isomorphic_a1_local.py"),
-            "--mode", "container",
-            "--run-root", str(run_root),
-        ]
+        soak_argv = _build_soak_argv(repo_root, run_root, live_failover=args.live_failover)
         # The isomorphic driver does NOT take --max-wall-seconds; the wall cap is
         # read from the env by the battle-test harness the SoakRunner spawns
         # (OUROBOROS_BATTLE_MAX_WALL_SECONDS). Headless too, since this is non-TTY.
         _soak_env = dict(os.environ)
         _soak_env["OUROBOROS_BATTLE_MAX_WALL_SECONDS"] = str(args.max_wall_seconds)
         _soak_env.setdefault("OUROBOROS_BATTLE_HEADLESS", "1")
+        if args.live_failover:
+            _arm_failover_env(_soak_env)
         _write_log_header(log_fh, argv=soak_argv, cwd=repo_root)
         print(f"[>] Soak: {' '.join(soak_argv)}  (OUROBOROS_BATTLE_MAX_WALL_SECONDS={args.max_wall_seconds})")
         soak_rc = tee_run(soak_argv, log_fh, cwd=str(repo_root), env=_soak_env)

--- a/tests/governance/test_compute_context_budget_bypass.py
+++ b/tests/governance/test_compute_context_budget_bypass.py
@@ -1,0 +1,108 @@
+"""Task CR1 -- Financial Context Decoupling.
+
+Proves the hard wallet gate ``session_budget_authority.check_preflight``
+EXPLICITLY allows requests tagged ``compute_context="Local_Open_Source"``
+(free local open-source compute, $0.00) while leaving billed cloud providers
+(Claude, DoubleWord) byte-identical when the tag is absent or different.
+
+The scenario is the exact soak failure mode: remaining session budget is
+$0.00, a $0.10 estimate is requested. For billed cloud this MUST refuse; for
+free local compute it MUST pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import session_budget_authority as sba
+from backend.core.ouroboros.governance.session_budget_authority import (
+    LOCAL_OPEN_SOURCE,
+    SessionBudgetPreflightRefused,
+    check_preflight,
+    set_session_budget_provider,
+)
+from backend.core.ouroboros.governance.op_context import OperationContext
+
+
+class _FakeBudgetProvider:
+    """Minimal duck-typed session-budget provider exposing ``.remaining``.
+
+    Mirrors how ``battle_test/cost_tracker.py``'s ``CostTracker`` is registered
+    via ``set_session_budget_provider`` -- ``get_session_remaining_usd`` resolves
+    the registered provider's numeric ``.remaining`` property.
+    """
+
+    def __init__(self, remaining: float) -> None:
+        self.remaining = remaining
+
+
+@pytest.fixture()
+def zero_budget_provider():
+    """Register a $0.00-remaining provider; clear it again in teardown so
+    other tests in the process are unaffected."""
+    set_session_budget_provider(_FakeBudgetProvider(remaining=0.0))
+    try:
+        yield
+    finally:
+        set_session_budget_provider(None)
+
+
+def test_local_open_source_bypasses_refusal(zero_budget_provider):
+    """The exact soak scenario: $0.00 remaining, $0.10 estimate, but tagged
+    free local open-source compute -> ALLOWED (returns None, no raise)."""
+    result = check_preflight(
+        provider_name="doubleword",
+        estimated_cost_usd=0.10,
+        compute_context="Local_Open_Source",
+        op_id="op-1",
+    )
+    assert result is None
+
+
+def test_billed_still_refused_without_tag(zero_budget_provider):
+    """$0.00 remaining, $0.10 estimate, no compute_context tag -> billed cloud
+    refusal is UNCHANGED."""
+    with pytest.raises(SessionBudgetPreflightRefused):
+        check_preflight(
+            provider_name="doubleword",
+            estimated_cost_usd=0.10,
+            compute_context=None,
+            op_id="op-2",
+        )
+    # Empty-string tag (the dataclass default) is likewise NOT a bypass.
+    with pytest.raises(SessionBudgetPreflightRefused):
+        check_preflight(
+            provider_name="doubleword",
+            estimated_cost_usd=0.10,
+            compute_context="",
+            op_id="op-2b",
+        )
+
+
+def test_billed_still_refused_with_other_tag(zero_budget_provider):
+    """Only the EXACT free-tier string bypasses; any other tag still refuses."""
+    with pytest.raises(SessionBudgetPreflightRefused):
+        check_preflight(
+            provider_name="claude",
+            estimated_cost_usd=0.10,
+            compute_context="Billed_Cloud",
+            op_id="op-3",
+        )
+
+
+def test_local_open_source_constant_value():
+    """The module constant is the exact tag string consumers must use."""
+    assert LOCAL_OPEN_SOURCE == "Local_Open_Source"
+
+
+def test_operation_context_with_compute_context():
+    """``OperationContext.with_compute_context`` stamps the tag via the
+    dataclasses.replace ``with_*`` idiom, default empty otherwise."""
+    ctx = OperationContext.create(
+        op_id="op-ctx", target_files=(), description="ctx test"
+    )
+    assert ctx.compute_context == ""
+    tagged = ctx.with_compute_context("Local_Open_Source")
+    assert tagged.compute_context == "Local_Open_Source"
+    # Original is unchanged (frozen dataclass -- replace returns a new instance).
+    assert ctx.compute_context == ""

--- a/tests/governance/test_failover_budget_awaken.py
+++ b/tests/governance/test_failover_budget_awaken.py
@@ -1,0 +1,141 @@
+"""Tests for the Multi-Vector Awaken Trigger (Task CR2).
+
+The J-Prime golden-image fallback node must awaken not only on a DW data-plane
+outage but ALSO on cloud-budget exhaustion (the cloud primary refused on budget
+with NO cloud fallback configured). The controller must additionally REMEMBER
+*why* it awakened (``_awaken_reason``) so a later recovery strategy can branch.
+
+DW stays primary; J-Prime is the fallback. All boundaries are injected fakes ->
+ZERO real GCP / network. Default-OFF byte-identical: the budget vector fires only
+when ``JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED=true``.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import provider_quarantine as pq
+from backend.core.ouroboros.governance.failover_lifecycle import (
+    AWAKEN_REASON_BUDGET,
+    AWAKEN_REASON_DATA_PLANE,
+    FailoverLifecycleController,
+    FailoverState,
+)
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    # Keep the other awaken vectors quiet so only the budget vector is exercised.
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED", raising=False)
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+def _make_ctrl(clock, awakens=None, flares=None, **kw):
+    awakens = awakens if awakens is not None else []
+    flares = flares if flares is not None else []
+
+    def _awaken(*, startup_script):
+        awakens.append(startup_script)
+        return True
+
+    defaults = dict(
+        vm_awaken_fn=_awaken,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+        is_degrading_fn=lambda: False,
+        flare_fn=lambda payload: flares.append(payload),
+    )
+    defaults.update(kw)
+    return FailoverLifecycleController(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# note_budget_exhausted anchors the budget vector (idempotent)
+# ---------------------------------------------------------------------------
+
+def test_note_budget_exhausted_sets_anchor():
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    assert ctrl._budget_exhausted_at is None
+
+    ctrl.note_budget_exhausted()
+    first = ctrl._budget_exhausted_at
+    assert first is not None
+
+    # Idempotent: a second call does NOT re-anchor (only the first wins).
+    clock.t += 50.0
+    ctrl.note_budget_exhausted()
+    assert ctrl._budget_exhausted_at == first
+
+
+# ---------------------------------------------------------------------------
+# Budget vector awakens J-Prime when the master flag is ON
+# ---------------------------------------------------------------------------
+
+async def test_budget_vector_awakens_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED", "true")
+    clock = FakeClock()
+    awakens = []
+    ctrl = _make_ctrl(clock, awakens=awakens)
+    # No data-plane outage at all -- only the budget vector should fire.
+    assert ctrl.state == FailoverState.DORMANT
+
+    ctrl.note_budget_exhausted()
+    await ctrl.tick()
+
+    assert ctrl.state == FailoverState.AWAKENING
+    assert ctrl._awaken_reason == AWAKEN_REASON_BUDGET
+    assert len(awakens) == 1  # the GCE awaken boundary actually fired
+    # Anchor is consumed (single-shot) so it doesn't re-fire every tick.
+    assert ctrl._budget_exhausted_at is None
+
+
+# ---------------------------------------------------------------------------
+# Default-OFF byte-identical: budget vector inert when the flag is OFF
+# ---------------------------------------------------------------------------
+
+async def test_budget_vector_inert_when_flag_off(monkeypatch):
+    # Flag intentionally NOT set (default OFF).
+    clock = FakeClock()
+    awakens = []
+    ctrl = _make_ctrl(clock, awakens=awakens)
+
+    ctrl.note_budget_exhausted()
+    await ctrl.tick()
+
+    assert ctrl.state == FailoverState.DORMANT
+    assert awakens == []
+    assert ctrl._awaken_reason == ""  # reason field stays inert
+
+
+# ---------------------------------------------------------------------------
+# awaken_reason taxonomy: a data-plane trigger maps to DATA_PLANE_OUTAGE
+# ---------------------------------------------------------------------------
+
+async def test_awaken_reason_data_plane_for_outage_trigger():
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+
+    await ctrl._enter_awakening(
+        now=clock(), trigger="reactive_outage", route="background",
+    )
+
+    assert ctrl._awaken_reason == AWAKEN_REASON_DATA_PLANE

--- a/tests/governance/test_failover_header_aware_recovery.py
+++ b/tests/governance/test_failover_header_aware_recovery.py
@@ -1,0 +1,244 @@
+"""Tests for header-aware DW-recovery (Task CR5).
+
+When DW is rate-limited (429), the failover SERVING recovery probe must suspend
+until the provider's OWN ``Retry-After`` / ``x-ratelimit-reset`` deadline instead
+of a blind forecast interval -- then fall through to the EXISTING semantic deep
+probe (untouched) which gates handback on real generation success.
+
+ADDITIVE + DEFAULT-OFF: with ``JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED``
+unset, ``_probe_interval`` is byte-identical (the new branch is skipped) and the
+DoublewordInfraError ``ratelimit_reset_ts`` field defaults None. All boundaries
+are injected fakes -> ZERO real GCP / network. The jitter backoff + deep probe
+are REUSED, not rebuilt.
+"""
+from __future__ import annotations
+
+import time
+from email.utils import formatdate
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import provider_quarantine as pq
+from backend.core.ouroboros.governance.failover_lifecycle import (
+    AWAKEN_REASON_DATA_PLANE,
+    AWAKEN_REASON_RATE_LIMIT,
+    FailoverLifecycleController,
+)
+from backend.core.ouroboros.governance.doubleword_provider import (
+    DoublewordInfraError,
+    _parse_retry_after_headers,
+)
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED", raising=False)
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+def _make_ctrl(clock, **kw):
+    defaults = dict(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+        is_degrading_fn=lambda: False,
+        flare_fn=lambda payload: None,
+    )
+    defaults.update(kw)
+    return FailoverLifecycleController(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Change 1 -- header parse helper
+# ---------------------------------------------------------------------------
+
+def test_parse_retry_after_seconds():
+    now = time.time()
+    ts = _parse_retry_after_headers({"Retry-After": "30"})
+    assert ts is not None
+    assert now + 28 <= ts <= now + 32
+
+
+def test_parse_retry_after_http_date():
+    now = time.time()
+    # HTTP-date 60s in the future.
+    http_date = formatdate(now + 60, usegmt=True)
+    ts = _parse_retry_after_headers({"Retry-After": http_date})
+    assert ts is not None
+    # HTTP-date has 1s resolution.
+    assert now + 57 <= ts <= now + 63
+
+
+def test_parse_x_ratelimit_reset_unix_ts():
+    now = time.time()
+    target = now + 45
+    ts = _parse_retry_after_headers({"x-ratelimit-reset": str(target)})
+    assert ts is not None
+    assert abs(ts - target) <= 1.0
+
+
+def test_parse_x_ratelimit_reset_small_delta():
+    now = time.time()
+    # A small value (< 1e6) is treated as delta-seconds, not an absolute epoch.
+    ts = _parse_retry_after_headers({"x-ratelimit-reset": "20"})
+    assert ts is not None
+    assert now + 18 <= ts <= now + 22
+
+
+def test_parse_soonest_future_wins():
+    now = time.time()
+    ts = _parse_retry_after_headers(
+        {"Retry-After": "90", "x-ratelimit-reset": str(now + 10)}
+    )
+    assert ts is not None
+    # Soonest sane future deadline (the x-ratelimit-reset @ now+10) wins.
+    assert now + 8 <= ts <= now + 12
+
+
+def test_parse_garbage_and_empty_return_none():
+    assert _parse_retry_after_headers({}) is None
+    assert _parse_retry_after_headers(None) is None
+    assert _parse_retry_after_headers({"Retry-After": "not-a-number"}) is None
+    assert _parse_retry_after_headers({"Retry-After": ""}) is None
+    assert _parse_retry_after_headers({"x-ratelimit-reset": "abc"}) is None
+
+
+def test_parse_past_values_return_none():
+    now = time.time()
+    # Past delta-seconds is impossible; past absolute reset must be dropped.
+    assert _parse_retry_after_headers({"x-ratelimit-reset": str(now - 100)}) is None
+    # Retry-After negative delta -> not a future deadline.
+    assert _parse_retry_after_headers({"Retry-After": "-5"}) is None
+
+
+def test_infra_error_carries_reset_ts_field():
+    # Additive field defaults None for existing callers.
+    err_default = DoublewordInfraError("boom", status_code=429)
+    assert err_default.ratelimit_reset_ts is None
+    # Explicit value is preserved.
+    err = DoublewordInfraError("boom", status_code=429, ratelimit_reset_ts=12345.0)
+    assert err.ratelimit_reset_ts == 12345.0
+
+
+# ---------------------------------------------------------------------------
+# Change 2a -- note_rate_limited anchor
+# ---------------------------------------------------------------------------
+
+def test_note_rate_limited_sets_deadline(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    fixed_now = 5000.0
+    monkeypatch.setattr(fl.time, "time", lambda: fixed_now)
+
+    assert ctrl._rate_limit_reset_ts is None
+
+    # Future deadline -> anchored.
+    ctrl.note_rate_limited(fixed_now + 60)
+    assert ctrl._rate_limit_reset_ts == fixed_now + 60
+
+    # Past deadline -> ignored (anchor unchanged).
+    ctrl.note_rate_limited(fixed_now - 10)
+    assert ctrl._rate_limit_reset_ts == fixed_now + 60
+
+    # None -> ignored.
+    ctrl.note_rate_limited(None)
+    assert ctrl._rate_limit_reset_ts == fixed_now + 60
+
+
+# ---------------------------------------------------------------------------
+# Change 2b -- header-aware _probe_interval branch
+# ---------------------------------------------------------------------------
+
+def test_probe_interval_header_aware(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    monkeypatch.setenv("JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED", "true")
+    fixed_now = 5000.0
+    monkeypatch.setattr(fl.time, "time", lambda: fixed_now)
+
+    ctrl._awaken_reason = AWAKEN_REASON_RATE_LIMIT
+    ctrl._rate_limit_reset_ts = fixed_now + 50
+
+    interval = ctrl._probe_interval(now=clock.t)
+    assert abs(interval - 50.0) <= 0.5
+
+
+def test_probe_interval_flag_off_falls_through(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    # Flag OFF (default) -> header-aware branch skipped -> forecast interval.
+    fixed_now = 5000.0
+    monkeypatch.setattr(fl.time, "time", lambda: fixed_now)
+    ctrl._awaken_reason = AWAKEN_REASON_RATE_LIMIT
+    ctrl._rate_limit_reset_ts = fixed_now + 50
+
+    interval = ctrl._probe_interval(now=clock.t)
+    # Must NOT return the ~50s header deadline; uses the normal jitter interval.
+    assert not (abs(interval - 50.0) <= 0.5)
+    assert interval >= 0.0
+
+
+def test_probe_interval_deadline_passed_clears_and_resumes(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    monkeypatch.setenv("JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED", "true")
+    fixed_now = 5000.0
+    monkeypatch.setattr(fl.time, "time", lambda: fixed_now)
+    ctrl._awaken_reason = AWAKEN_REASON_RATE_LIMIT
+    # Deadline already in the past.
+    ctrl._rate_limit_reset_ts = fixed_now - 5
+
+    interval = ctrl._probe_interval(now=clock.t)
+    # Anchor cleared -> resume normal probing (NOT a negative/zero header sleep).
+    assert ctrl._rate_limit_reset_ts is None
+    assert interval >= 0.0
+
+
+def test_data_plane_uses_jitter_unchanged(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    monkeypatch.setenv("JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED", "true")
+    fixed_now = 5000.0
+    monkeypatch.setattr(fl.time, "time", lambda: fixed_now)
+    # Non-rate-limit reason -> header-aware path skipped even with flag ON.
+    ctrl._awaken_reason = AWAKEN_REASON_DATA_PLANE
+    ctrl._rate_limit_reset_ts = fixed_now + 50
+
+    interval = ctrl._probe_interval(now=clock.t)
+    assert not (abs(interval - 50.0) <= 0.5)
+    assert ctrl._rate_limit_reset_ts == fixed_now + 50  # untouched
+
+
+# ---------------------------------------------------------------------------
+# Change 2c -- _enter_awakening reason override
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_enter_awakening_rate_limit_anchor_sets_reason(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    monkeypatch.setattr(fl.time, "time", lambda: clock.t)
+    ctrl._rate_limit_reset_ts = clock.t + 60
+
+    # Even a data-plane trigger is overridden to RATE_LIMIT when the anchor lives.
+    await ctrl._enter_awakening(now=clock.t, trigger="reactive_outage", route="dw")
+    assert ctrl._awaken_reason == AWAKEN_REASON_RATE_LIMIT

--- a/tests/governance/test_failover_violent_teardown.py
+++ b/tests/governance/test_failover_violent_teardown.py
@@ -1,0 +1,159 @@
+"""Tests for the Violent Ephemeral Teardown (Task CR4).
+
+The FailoverLifecycleController must reap the GPU J-Prime node the INSTANT an A1
+DAG op reaches a terminal state (PR opened OR fail-closed at any gate) so a g2 GPU
+never idles waiting for human review. It reuses the proven node + /32-firewall
+parallel-teardown idiom and does NOT rely only on the passive dead-man.
+
+All boundaries are injected fakes / monkeypatched -> ZERO real GCP / network.
+Default-OFF byte-identical: ``violent_teardown_enabled()`` is False by default and
+the seam call is skipped, so ``force_teardown`` is never reached.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import provider_quarantine as pq
+from backend.core.ouroboros.governance.failover_lifecycle import (
+    FailoverLifecycleController,
+    FailoverState,
+    violent_teardown_enabled,
+)
+
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    monkeypatch.delenv("JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED", raising=False)
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+def _make_ctrl(clock, vm_deletes=None, **kw):
+    vm_deletes = vm_deletes if vm_deletes is not None else []
+
+    def _vm_delete():
+        vm_deletes.append(True)
+        return True
+
+    defaults = dict(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=_vm_delete,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+        is_degrading_fn=lambda: False,
+        flare_fn=lambda payload: None,
+    )
+    defaults.update(kw)
+    return FailoverLifecycleController(**defaults)
+
+
+def _stub_reaps(ctrl, monkeypatch, calls):
+    """Replace the GPU-reap + ephemeral-perimeter boundaries with recorders."""
+
+    async def _reap_gpu():
+        calls.append("reap_gpu")
+
+    async def _close_perimeter():
+        calls.append("close_perimeter")
+
+    monkeypatch.setattr(ctrl, "_reap_gpu_node", _reap_gpu)
+    monkeypatch.setattr(ctrl, "_close_ephemeral_perimeter", _close_perimeter)
+
+
+# ---------------------------------------------------------------------------
+# force_teardown when SERVING reaps everything and drops to DORMANT
+# ---------------------------------------------------------------------------
+
+async def test_force_teardown_when_serving_reaps_and_dormant(monkeypatch):
+    clock = FakeClock()
+    vm_deletes = []
+    calls = []
+    ctrl = _make_ctrl(clock, vm_deletes=vm_deletes)
+    _stub_reaps(ctrl, monkeypatch, calls)
+    ctrl._state = FailoverState.SERVING
+    ctrl._endpoint = "http://10.0.0.1:8000"
+
+    await ctrl.force_teardown(reason="a1_terminal:COMPLETE")
+
+    # GPU node + node-delete + ephemeral /32 firewall all vacated.
+    assert "reap_gpu" in calls
+    assert "close_perimeter" in calls
+    assert vm_deletes == [True]
+    # State dropped to DORMANT, cooldown anchor armed, endpoint cleared.
+    assert ctrl._state == FailoverState.DORMANT
+    assert ctrl._last_handback_at == clock()
+    assert ctrl._endpoint is None
+
+
+# ---------------------------------------------------------------------------
+# force_teardown is a no-op when already DORMANT (nothing to reap)
+# ---------------------------------------------------------------------------
+
+async def test_force_teardown_dormant_is_noop(monkeypatch):
+    clock = FakeClock()
+    vm_deletes = []
+    calls = []
+    ctrl = _make_ctrl(clock, vm_deletes=vm_deletes)
+    _stub_reaps(ctrl, monkeypatch, calls)
+    assert ctrl._state == FailoverState.DORMANT
+
+    await ctrl.force_teardown()
+
+    assert calls == []
+    assert vm_deletes == []
+    assert ctrl._state == FailoverState.DORMANT
+    assert ctrl._last_handback_at is None  # cooldown not armed -- nothing happened
+
+
+# ---------------------------------------------------------------------------
+# Fail-soft: a reap that raises still completes teardown + reaches DORMANT
+# ---------------------------------------------------------------------------
+
+async def test_force_teardown_never_raises(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    ctrl._state = FailoverState.SERVING
+
+    async def _boom():
+        raise RuntimeError("gpu reap exploded")
+
+    monkeypatch.setattr(ctrl, "_reap_gpu_node", _boom)
+
+    async def _close_perimeter():
+        return None
+
+    monkeypatch.setattr(ctrl, "_close_ephemeral_perimeter", _close_perimeter)
+
+    # Must NOT raise despite the exploding reap boundary.
+    await ctrl.force_teardown(reason="a1_terminal:POSTMORTEM")
+
+    assert ctrl._state == FailoverState.DORMANT
+    assert ctrl._last_handback_at == clock()
+    assert ctrl._endpoint is None
+
+
+# ---------------------------------------------------------------------------
+# Default-OFF byte-identical: the master gate is False by default
+# ---------------------------------------------------------------------------
+
+def test_violent_teardown_flag_default_off(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED", raising=False)
+    assert violent_teardown_enabled() is False
+
+    monkeypatch.setenv("JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED", "true")
+    assert violent_teardown_enabled() is True

--- a/tests/governance/test_failover_violent_teardown.py
+++ b/tests/governance/test_failover_violent_teardown.py
@@ -11,6 +11,8 @@ the seam call is skipped, so ``force_teardown`` is never reached.
 """
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 import backend.core.ouroboros.governance.failover_lifecycle as fl
@@ -157,3 +159,49 @@ def test_violent_teardown_flag_default_off(monkeypatch):
 
     monkeypatch.setenv("JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED", "true")
     assert violent_teardown_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# Serialization: force_teardown waits for the lock held by a concurrent tick()
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_force_teardown_serializes_under_lock(monkeypatch):
+    """force_teardown MUST acquire self._lock before mutating state, so it
+    cannot race an in-flight tick()/_do_awaken() that already holds the lock.
+
+    Proof: we hold the lock externally (simulating tick()) and confirm that
+    force_teardown blocks -- no reap, no state mutation -- until the lock is
+    released.
+    """
+    clock = FakeClock()
+    calls = []
+    ctrl = _make_ctrl(clock)
+    _stub_reaps(ctrl, monkeypatch, calls)
+
+    ctrl._state = FailoverState.SERVING
+    ctrl._endpoint = "http://10.0.0.2:8000"
+
+    # Simulate tick() holding the FSM lock mid-transition.
+    await ctrl._lock.acquire()
+    try:
+        task = asyncio.create_task(ctrl.force_teardown(reason="a1_terminal:COMPLETE"))
+
+        # Give the task a chance to run up to the lock acquisition point.
+        await asyncio.sleep(0.05)
+
+        # Must still be blocked -- lock is held, reap must NOT have fired yet.
+        assert not task.done(), "force_teardown ran without acquiring the lock"
+        assert calls == [], f"reap was called before lock was released: {calls}"
+        assert ctrl._state == FailoverState.SERVING, "state mutated before lock acquired"
+    finally:
+        ctrl._lock.release()
+
+    # Now the lock is free -- force_teardown should complete quickly.
+    await asyncio.wait_for(task, timeout=1.0)
+
+    assert task.done()
+    assert "reap_gpu" in calls, "reap_gpu not called after lock release"
+    assert "close_perimeter" in calls, "close_perimeter not called after lock release"
+    assert ctrl._state == FailoverState.DORMANT
+    assert ctrl._endpoint is None

--- a/tests/scripts/test_a1_gcp_preflight.py
+++ b/tests/scripts/test_a1_gcp_preflight.py
@@ -1,0 +1,159 @@
+"""test_a1_gcp_preflight -- TDD spine for scripts/a1_gcp_preflight.py.
+
+All checks are $0: NO network calls, NO node creation, NO real GCPComputeRest.
+A fake rest object is injected via the ``rest=`` parameter.
+
+asyncio_mode = auto (pytest.ini), so no @pytest.mark.asyncio needed.
+"""
+from __future__ import annotations
+
+import sys
+import os
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+import pytest  # noqa: E402
+
+from scripts.a1_gcp_preflight import preflight_gcp_ready  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fake rest object -- mirrors the real GCPComputeRest async interface.
+# ---------------------------------------------------------------------------
+
+class _FakeRest:
+    """Minimal injectable double for GCPComputeRest."""
+
+    def __init__(
+        self,
+        *,
+        auth_mode: str = "adc",
+        scope_ok: bool = True,
+        project_val: str | None = "jarvis-473803",
+        zone_val: str | None = "us-central1-a",
+        project_raises: bool = False,
+        zone_raises: bool = False,
+    ) -> None:
+        self._auth_mode = auth_mode
+        self._scope_ok = scope_ok
+        self._project_val = project_val
+        self._zone_val = zone_val
+        self._project_raises = project_raises
+        self._zone_raises = zone_raises
+
+    async def verify_compute_scopes(self):
+        return (self._scope_ok, "fake:scope_result")
+
+    async def access_token(self):
+        return "fake-token" if self._scope_ok else None
+
+    async def project(self):
+        if self._project_raises:
+            raise RuntimeError("injected project() failure")
+        return self._project_val
+
+    async def zone(self):
+        if self._zone_raises:
+            raise RuntimeError("injected zone() failure")
+        return self._zone_val
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+async def test_all_present_returns_ok():
+    """Happy path: valid auth + project + zone -> (True, [])."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="adc", scope_ok=True,
+                       project_val="jarvis-473803", zone_val="us-central1-a")
+    )
+    assert ok is True
+    assert problems == []
+
+
+async def test_missing_zone_reports_export():
+    """Empty zone -> ok=False, problem contains export GCP_ZONE=."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="adc", scope_ok=True,
+                       project_val="jarvis-473803", zone_val="")
+    )
+    assert ok is False
+    assert any("export GCP_ZONE=" in p for p in problems), problems
+
+
+async def test_missing_zone_none_reports_export():
+    """None zone -> same export GCP_ZONE= message."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="adc", scope_ok=True,
+                       project_val="jarvis-473803", zone_val=None)
+    )
+    assert ok is False
+    assert any("export GCP_ZONE=" in p for p in problems), problems
+
+
+async def test_missing_project_reports_export():
+    """None project -> ok=False, problem contains export GCP_PROJECT_ID=."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="adc", scope_ok=True,
+                       project_val=None, zone_val="us-central1-a")
+    )
+    assert ok is False
+    assert any("export GCP_PROJECT_ID=" in p for p in problems), problems
+
+
+async def test_no_auth_reports_both_options():
+    """_auth_mode=='metadata' -> problem mentions GOOGLE_APPLICATION_CREDENTIALS
+    AND gcloud auth application-default login."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="metadata", scope_ok=False,
+                       project_val="jarvis-473803", zone_val="us-central1-a")
+    )
+    assert ok is False
+    combined = " ".join(problems)
+    assert "GOOGLE_APPLICATION_CREDENTIALS" in combined, combined
+    assert "gcloud auth application-default login" in combined, combined
+
+
+async def test_no_auth_via_verify_scope_failure():
+    """verify_compute_scopes returns False even with sa mode -> auth problem."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="sa", scope_ok=False,
+                       project_val="jarvis-473803", zone_val="us-central1-a")
+    )
+    assert ok is False
+    assert any("GOOGLE_APPLICATION_CREDENTIALS" in p for p in problems), problems
+
+
+async def test_never_raises():
+    """A fake whose project() raises must not propagate -- returns (False, [...])."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="adc", scope_ok=True,
+                       project_val=None, project_raises=True,
+                       zone_val="us-central1-a")
+    )
+    assert ok is False
+    # Must have at least a project problem (or a generic error entry)
+    assert len(problems) >= 1
+
+
+async def test_require_zone_false_skips_zone_check():
+    """require_zone=False: missing zone is NOT a problem."""
+    ok, problems = await preflight_gcp_ready(
+        require_zone=False,
+        rest=_FakeRest(auth_mode="adc", scope_ok=True,
+                       project_val="jarvis-473803", zone_val=None)
+    )
+    assert ok is True
+    assert not any("GCP_ZONE" in p for p in problems)
+
+
+async def test_multiple_problems_all_reported():
+    """Missing project AND zone both appear in problems list."""
+    ok, problems = await preflight_gcp_ready(
+        rest=_FakeRest(auth_mode="adc", scope_ok=True,
+                       project_val=None, zone_val=None)
+    )
+    assert ok is False
+    assert any("GCP_PROJECT_ID" in p for p in problems)
+    assert any("GCP_ZONE" in p for p in problems)

--- a/tests/scripts/test_ignite_a1_soak.py
+++ b/tests/scripts/test_ignite_a1_soak.py
@@ -15,6 +15,8 @@ REPO_ROOT = Path(__file__).resolve().parents[2]
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from ignite_a1_soak import (  # noqa: E402
+    _arm_failover_env,
+    _build_soak_argv,
     docker_responsive,
     find_failure_telemetry,
     format_for_claude,
@@ -210,3 +212,54 @@ class TestTeeRun:
         captured = capsys.readouterr()
         assert "dualwrite" in captured.out
         assert "dualwrite" in log_path.read_text()
+
+
+# ---------------------------------------------------------------------------
+# live-failover helpers
+# ---------------------------------------------------------------------------
+
+_FAILOVER_REQUIRED_ENV_KEYS = {
+    "JARVIS_FAILOVER_QUALITY_TIER_ENABLED",
+    "JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED",
+    "JARVIS_FAILOVER_LIFECYCLE_ENABLED",
+    "JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED",
+    "JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED",
+    "JARVIS_FAILOVER_AWAKEN_URGENCY",
+    "JARVIS_FAILOVER_QUALITY_MACHINE",
+    "JARVIS_FAILOVER_QUALITY_ACCEL_TYPE",
+    "JARVIS_FAILOVER_QUALITY_ACCEL_COUNT",
+    "JARVIS_FAILOVER_QUALITY_IMAGE",
+    "JARVIS_FAILOVER_INFERENCE_BIND_ENABLED",
+}
+
+
+class TestLiveFailoverHelpers:
+    def test_live_failover_arms_env(self, tmp_path):
+        """_arm_failover_env stamps all required keys; critical values correct."""
+        env: dict = {}
+        result = _arm_failover_env(env)
+        assert result is env, "_arm_failover_env must return the same dict"
+        for key in _FAILOVER_REQUIRED_ENV_KEYS:
+            assert key in env, f"Missing key: {key}"
+        assert env["JARVIS_FAILOVER_QUALITY_TIER_ENABLED"] == "true"
+        assert env["JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED"] == "true"
+        assert env["JARVIS_FAILOVER_QUALITY_IMAGE"] == "jarvis-prime-coder-32b"
+        assert env["JARVIS_FAILOVER_QUALITY_MACHINE"] == "g2-standard-4"
+
+    def test_live_failover_argv_contains_enable_failover(self, tmp_path):
+        """_build_soak_argv appends --enable-failover when live_failover=True."""
+        argv = _build_soak_argv(Path("/repo"), tmp_path, live_failover=True)
+        assert "--enable-failover" in argv
+
+    def test_default_no_failover_env(self, tmp_path):
+        """Without live-failover, none of the JARVIS_FAILOVER_* keys are added."""
+        # Simulate building the soak env without arming failover
+        env: dict = {"OUROBOROS_BATTLE_MAX_WALL_SECONDS": "2400"}
+        # Do NOT call _arm_failover_env
+        for key in _FAILOVER_REQUIRED_ENV_KEYS:
+            assert key not in env, f"Unexpected key in default env: {key}"
+
+    def test_default_no_enable_failover_in_argv(self, tmp_path):
+        """Without live-failover, --enable-failover must not appear in soak argv."""
+        argv = _build_soak_argv(Path("/repo"), tmp_path, live_failover=False)
+        assert "--enable-failover" not in argv


### PR DESCRIPTION
## Adaptive Compute-Context Router — DW primary → J-Prime golden-image fallback (env-aware, cost-locked)

When DoubleWord (the cheaper Tier-0 primary) is **exhausted (budget) or down (data-plane)**, the GCP J-Prime golden-image node awakens as the fallback, serves GENERATE, then either **hands back when DW recovers** or is **violently reaped the instant an A1 op terminates**. Pure composition of the proven Sovereign Failover Mesh — no new providers, no duplication. **Every new path is default-OFF** (verified path-by-path by an opus whole-branch review: 0 Critical).

- **CR1 — Financial Context Decoupling**: `check_preflight` early-allows `compute_context="Local_Open_Source"` (free self-hosted compute) without touching `cost_cap` or weakening the gate for billed cloud.
- **CR2 — Multi-vector awaken**: budget-exhaustion becomes a valid awaken vector (not just data-plane outage); the controller now records *why* it awakened (`_awaken_reason`).
- **CR3 — `$0` GCP credential preflight**: asserts auth/project/zone, prints the exact `export` commands, never creates a node.
- **CR4 — Violent ephemeral teardown**: reaps node + /32 firewall + GPU the instant the A1 DAG hits terminal (PR opened or fail-closed). Now **lock-serialized** vs in-flight awaken (final-review fix).
- **CR5 — Header-aware recovery**: captures `Retry-After`/`x-ratelimit-reset` and async-sleeps until the provider's own reset; reuses the existing semantic deep-probe + full-jitter backoff (no brute-force polling).
- **CR6 — Live-failover ignition arming**: `ignite_a1_soak.py --live-failover` runs the `$0` preflight first, arms the 32B-QUALITY (`g2-standard-4` + `nvidia-l4` + `jarvis-prime-coder-32b`) + awaken + teardown env, and enables failover.

61 tests green; existing failover suite unchanged. Default-OFF byte-identical → merging cannot cause GPU spend or break the DW path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an adaptive DW→J-Prime 32B fallback with budget-aware awaken, header-aware recovery, and instant teardown to cut idle GPU time. Also decouples financial checks for free local compute and adds a $0 GCP preflight plus live-failover ignition.

- **New Features**
  - DW primary with GCP J‑Prime 32B fallback:
    - Awakens on data-plane outage or budget exhaustion and records the reason.
    - Header-aware recovery: sleeps until `Retry-After`/`x-ratelimit-reset` before probing.
    - Violent teardown: reaps GPU/node/firewalls as soon as the A1 DAG is terminal; lock-serialized.
  - Financial decoupling:
    - `session_budget_authority.check_preflight` allows `compute_context="Local_Open_Source"`.
    - Tag via `OperationContext.with_compute_context("Local_Open_Source")`; plumbed through providers.
  - `$0` GCP preflight and ignition:
    - `scripts/a1_gcp_preflight.py` checks auth/project/zone and prints exact `export` fixes (no node created).
    - `ignite_a1_soak.py --live-failover` runs the preflight, arms the 32B `g2-standard-4`/`nvidia-l4` env, and adds `--enable-failover`.
  - Tests cover budget awaken, header-aware recovery, violent teardown, preflight, and ignition helpers.
  - Default-OFF via env flags; DW-only path remains unchanged and incurs no spend.

- **Migration**
  - To enable failover: set `JARVIS_FAILOVER_LIFECYCLE_ENABLED=true` and optionally `JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED`, `JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED`, `JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED`.
  - Configure cloud: export `GCP_PROJECT_ID` and `GCP_ZONE`, then run `python scripts/a1_gcp_preflight.py`.
  - Mark free local runs: use `ctx.with_compute_context("Local_Open_Source")`.
  - End-to-end: `python scripts/ignite_a1_soak.py --live-failover`.

<sup>Written for commit 79b883b7b90c73ee7d3501f17b612d5167c2fd0f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69775?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

