### PR TITLE
fix(a1): live budget-exhaustion awaken — signal at sentinel-cascade exit + driver arms failover past manifest pin

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -5119,6 +5119,22 @@ class CandidateGenerator:
                     deadline=_imm_budget, now=_imm_now, claude_available=False,
                     attempt=_immortal_attempt, max_attempts=_imm_max(),
                 ):
+                    # CR2 (LIVE sentinel-cascade path): DW is exhausted with NO cloud
+                    # fallback -> wake the J-Prime golden-image fallback. This Immortal
+                    # re-attempt loop keeps the op alive (deadline-detached) until the
+                    # failover FSM reaches SERVING, after which the recursive
+                    # _dispatch_via_sentinel routes this very op to J-Prime via the
+                    # Phase-3c seam. Double-gated + fail-soft; idempotent anchor.
+                    try:
+                        from .failover_lifecycle import (
+                            lifecycle_enabled as _fo_on,
+                            budget_awaken_enabled as _fo_budget,
+                            get_failover_controller as _fo_ctrl,
+                        )
+                        if _fo_on() and _fo_budget():
+                            _fo_ctrl().note_budget_exhausted()
+                    except Exception:  # noqa: BLE001 -- never let the awaken signal break the op
+                        pass
                     _imm_delay = _imm_backoff(_immortal_attempt)
                     logger.warning(
                         "[Immortal] DW exhausted + NO fallback → QUEUE_ONLY (deadline-detached): "

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -482,6 +482,25 @@ class IsomorphicA1Driver:
                 # (Minor-5: no time-decay on the any-route window by design.)
                 if not self.enable_failover:
                     env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] = "false"
+                else:
+                    # Live-failover A1 run: compose_env()'s apply_manifest() pins
+                    # failover_lifecycle=False, so merely SKIPPING the false-pin above
+                    # is not enough -- the manifest already wrote "false" into env and
+                    # would keep the failover loop from ever starting. Override it here
+                    # (AFTER compose_env, exactly as the Iron Triad block does below) by
+                    # propagating the ignition harness's / operator's JARVIS_FAILOVER_*
+                    # and GCP_* env verbatim -- NO hardcoded tier/flag values; the
+                    # ignite_a1_soak.py --live-failover arming is the single source.
+                    for _k, _v in os.environ.items():
+                        if (
+                            _k.startswith("JARVIS_FAILOVER_")
+                            or _k.startswith("GCP_")
+                            or _k in ("GOOGLE_APPLICATION_CREDENTIALS", "GOOGLE_CLOUD_PROJECT")
+                        ):
+                            env[_k] = _v
+                    # The failover mesh is inert unless the lifecycle loop runs; ensure
+                    # it is ON even if the harness only passed --enable-failover.
+                    env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] = "true"
 
                 # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
                 # (all default OFF in prod; this driver IS the A1 ignition harness).


### PR DESCRIPTION
Two fixes the LIVE 32B ignition proved necessary (validated: the budget-exhaustion awaken fired + a real g2-standard-4+L4 node was created on GCP):

1. **Live-path awaken signal** (`candidate_generator.py:5118`): the budget-exhaustion travels the sentinel-cascade Immortal QUEUE_ONLY exit, not the `_call_fallback:6728` exit CR2 first wired. Signal `note_budget_exhausted()` here too.
2. **Driver arms failover past the manifest pin** (`isomorphic_a1_local.py`): `compose_env()`'s `apply_manifest(failover_lifecycle=False)` overrode the harness's `true`; the driver now propagates `JARVIS_FAILOVER_*` + GCP env verbatim after compose_env and forces lifecycle on.

Live proof: `[FailoverFlare] awaken_trigger trigger=session_budget_exhausted DORMANT->AWAKENING` + `instances.insert ok node=jarvis-prime-failover g2-standard-4 mode=SPOT`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes live failover not waking on budget exhaustion and ensures the A1 driver actually starts the failover lifecycle. This makes J‑Prime spin up when DW models are exhausted, without blocking the request loop.

- **Bug Fixes**
  - Emit the budget‑exhaustion awaken signal on the live sentinel‑cascade path (Immortal QUEUE_ONLY exit), guarded and idempotent, so failover can progress while the op stays alive.
  - After `compose_env()` pins lifecycle=false, propagate `JARVIS_FAILOVER_*` and `GCP_*` env vars verbatim and force `JARVIS_FAILOVER_LIFECYCLE_ENABLED=true` so the driver correctly arms failover.

<sup>Written for commit 54e8248c395ed967e44ac35b4ccd1d0c9ed6083d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69776?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

