### PR TITLE
feat(a1): Hybrid Execution Mesh — local driver owns real GCP 32B node (ironclad teardown + /32 firewall + L7 readiness)

### DIFF
--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -235,20 +235,15 @@ def _reap_failover_resources() -> None:
 
     try:
         try:
-            running_loop = asyncio.get_running_loop()
-        except RuntimeError:
-            running_loop = None
-        if running_loop is not None:
-            # A live loop owns this thread -- asyncio.run() would raise. Reap on
-            # a side thread with its own loop so the node delete is still the
-            # last breath even when fired from a signal handler mid-soak.
+            loop = asyncio.get_running_loop()
+            # running-loop -> daemon-thread branch
             import threading
-
             t = threading.Thread(
                 target=_run_blocking, name="failover-reap", daemon=True)
             t.start()
-            t.join(timeout=30.0)
-        else:
+            t.join(timeout=float(os.environ.get("JARVIS_FAILOVER_REST_TIMEOUT_S", "30")) + 5.0)
+        except RuntimeError:
+            # no-loop -> asyncio.run branch
             _run_blocking()
         _log("[HybridMesh] reaped %d failover resource(s) -- "
              "node(s)+firewall(s) deleted" % len(resources))
@@ -272,12 +267,12 @@ def _register_failover_resource(
     })
 
 
-async def _open_failover_firewall(fw_name: str) -> bool:
+async def _open_failover_firewall(fw_name: str) -> Optional[str]:
     """Open the driver-owned ephemeral /32 INGRESS firewall for THIS host's
     public IP -> the failover node's inference port.  Reuses the existing GCP
     primitives (``resolve_local_public_ip`` + ``create_firewall_rule``) -- NO
-    ``0.0.0.0/0``, ever.  Fail-soft -> False; the teardown stays armed
-    regardless (the node was registered before this call)."""
+    ``0.0.0.0/0``, ever.  Returns ``fw_name`` on success, ``None`` on skip/fail;
+    the teardown stays armed regardless (the node was registered before this call)."""
     try:
         from backend.core.ouroboros.governance.gcp_compute_rest import (
             get_compute_rest,
@@ -288,17 +283,17 @@ async def _open_failover_firewall(fw_name: str) -> bool:
         if not ip:
             _log("[HybridMesh] WARN could not resolve local public IP -- "
                  "firewall NOT opened; node may be unreachable")
-            return False
+            return None
         ok, detail = await get_compute_rest().create_firewall_rule(
             name=fw_name, source_ip=ip, port=_FAILOVER_INFERENCE_PORT)
         _log("[HybridMesh] ephemeral /32 firewall %s for %s/32:%d -> %s (%s)" % (
             fw_name, ip, _FAILOVER_INFERENCE_PORT,
             "OPEN" if ok else "FAILED", detail))
-        return bool(ok)
+        return fw_name if ok else None
     except Exception as exc:  # noqa: BLE001
         _log("[HybridMesh] firewall open error "
              "(continuing -- teardown still armed): %r" % (exc,))
-        return False
+        return None
 
 
 async def _arm_failover_mesh(env: Dict[str, str]) -> None:
@@ -319,8 +314,13 @@ async def _arm_failover_mesh(env: Dict[str, str]) -> None:
         "JARVIS_FAILOVER_FW_RULE_NAME", _FAILOVER_FW_RULE_DEFAULT)
     node_name = os.environ.get(
         "JARVIS_FAILOVER_NODE_NAME", _FAILOVER_NODE_DEFAULT)
-    _register_failover_resource(node=node_name, fw_rule=fw_name)
-    await _open_failover_firewall(fw_name)
+    # Register the node for teardown UP FRONT (orphan safety) with fw_rule=None;
+    # fw_rule is updated to the opened name only if the firewall was actually
+    # created -- so a reap never deletes a rule that was never opened.
+    _register_failover_resource(node=node_name, fw_rule=None)
+    opened_fw = await _open_failover_firewall(fw_name)
+    if _ACTIVE_FAILOVER_RESOURCES:
+        _ACTIVE_FAILOVER_RESOURCES[-1]["fw_rule"] = opened_fw
 
 
 # ---------------------------------------------------------------------------
@@ -337,6 +337,25 @@ def _env_float(name: str, default: float) -> float:
         return float(os.environ.get(name, str(default)))
     except (TypeError, ValueError):
         return default
+
+
+# Soak-child wall budget: read at module load for logging; the helper re-reads
+# at call time so monkeypatch.setenv in tests takes effect.
+_ready_budget = _env_float("JARVIS_HYBRID_MESH_READY_BUDGET_S", 900.0)
+_failover_wall = _ready_budget + 600.0  # ~90s boot + audit + slack; READY_BUDGET_S + 600 < harness --max-wall-seconds (2400)
+
+
+def _failover_soak_wall(enable_failover: bool) -> int:
+    """Return the soak-child wall-clock budget in seconds.
+
+    enable_failover=False -> 300 (byte-identical default).
+    enable_failover=True  -> READY_BUDGET_S + 600 to accommodate 32B cold-start.
+    # READY_BUDGET_S + 600 < harness --max-wall-seconds (2400)
+    """
+    if not enable_failover:
+        return 300
+    budget = _env_float("JARVIS_HYBRID_MESH_READY_BUDGET_S", 900.0)
+    return int(budget + 600.0)
 
 
 def _probe_api_tags(url: str) -> int:
@@ -412,7 +431,7 @@ async def _await_jprime_serving(
             url = "http://%s:%d/api/tags" % (external, port)
             status = 0
             try:
-                loop = asyncio.get_event_loop()
+                loop = asyncio.get_running_loop()
                 status = await asyncio.wait_for(
                     loop.run_in_executor(None, _probe_api_tags, url),
                     timeout=probe_to + 1.0,
@@ -858,10 +877,16 @@ class IsomorphicA1Driver:
                     else:
                         _log("STEP soak: launching production O+V (pre-inject boot) "
                              "iso_cwd=%s" % iso_cwd)
+                        if self.enable_failover:
+                            _log("[HybridMesh] soak-child wall extended to %ds "
+                                 "(32B cold-start: readiness %ds + margin)" % (
+                                     _failover_soak_wall(True),
+                                     int(_env_float(
+                                         "JARVIS_HYBRID_MESH_READY_BUDGET_S", 900.0))))
                         soak_runner = harness_mod.SoakRunner(
                             repo_root=self.repo_root,
                             cost_cap=0.0,
-                            wall_seconds=300,
+                            wall_seconds=_failover_soak_wall(self.enable_failover),
                         )
                         # Thread IsomorphicEnv: launch child with disjoint cwd so
                         # os.getcwd()-as-repo-root bugs surface in the real chain.

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -66,6 +66,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import atexit
 import importlib.util
 import json
 import os
@@ -166,11 +167,162 @@ def _truthy(val: Optional[str]) -> bool:
 _ACTIVE_CHAOS: List[Any] = []
 
 
+# ---------------------------------------------------------------------------
+# Hybrid Execution Mesh (Task HM-A) -- failover-resource registry + IRONCLAD
+# teardown.  The LOCAL driver owns the GCP failover node's networking (an
+# ephemeral, zero-trust /32 INGRESS firewall for THIS host's public IP) AND its
+# teardown, so a real GPU node can NEVER be orphaned: every awakened node + its
+# firewall is reaped on finally + atexit + signal -- whichever fires first.
+#
+# Each entry mirrors the _ACTIVE_CHAOS pattern:
+#   {"node": <name>, "zone": <zone>, "project": <proj>, "fw_rule": <fw|None>}
+# ---------------------------------------------------------------------------
+
+_ACTIVE_FAILOVER_RESOURCES: List[Dict[str, Optional[str]]] = []
+
+# Defaults match the failover lifecycle's node/firewall naming; overridable via
+# env so the driver and the organism agree on the same resource names.
+_FAILOVER_FW_RULE_DEFAULT: str = "jarvis-ephemeral-failover-allow"
+_FAILOVER_NODE_DEFAULT: str = "jarvis-prime-failover"
+_FAILOVER_INFERENCE_PORT: int = 11434
+
+
+def _reap_failover_resources() -> None:
+    """Violently reap every awakened failover node + its ephemeral /32 firewall.
+
+    Idempotent (clears the registry so a second call is a no-op) + fail-soft
+    (NEVER raises) -- safe to call from a ``finally``, an ``atexit`` hook, AND a
+    signal handler.  The node's GCP REST delete is the process's last breath.
+
+    When invoked from inside a live event loop (e.g. a signal handler that
+    interrupted ``asyncio.run(driver.run())``), ``asyncio.run`` would raise, so
+    the reap is dispatched on a dedicated thread with its own loop and joined --
+    the node delete still completes even on Ctrl+C mid-soak.
+    """
+    if not _ACTIVE_FAILOVER_RESOURCES:
+        return
+    resources = list(_ACTIVE_FAILOVER_RESOURCES)
+    _ACTIVE_FAILOVER_RESOURCES.clear()
+
+    async def _del_all() -> None:
+        from backend.core.ouroboros.governance.gcp_compute_rest import (
+            get_compute_rest,
+        )
+
+        client = get_compute_rest()
+        tasks = []
+        for r in resources:
+            if r.get("node"):
+                tasks.append(client.delete_instance(r["node"]))
+            if r.get("fw_rule"):
+                tasks.append(client.delete_firewall_rule(r["fw_rule"]))
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+
+    def _run_blocking() -> None:
+        asyncio.run(_del_all())
+
+    try:
+        try:
+            running_loop = asyncio.get_running_loop()
+        except RuntimeError:
+            running_loop = None
+        if running_loop is not None:
+            # A live loop owns this thread -- asyncio.run() would raise. Reap on
+            # a side thread with its own loop so the node delete is still the
+            # last breath even when fired from a signal handler mid-soak.
+            import threading
+
+            t = threading.Thread(
+                target=_run_blocking, name="failover-reap", daemon=True)
+            t.start()
+            t.join(timeout=30.0)
+        else:
+            _run_blocking()
+        _log("[HybridMesh] reaped %d failover resource(s) -- "
+             "node(s)+firewall(s) deleted" % len(resources))
+    except Exception as exc:  # noqa: BLE001 -- teardown must NEVER raise
+        _log("[HybridMesh] reap error (continuing): %r" % (exc,))
+
+
+def _register_failover_resource(
+    *, node: Optional[str], fw_rule: Optional[str],
+) -> None:
+    """Register a failover node + its ephemeral firewall for teardown UP FRONT
+    (before the node even exists) so a crash mid-awaken still reaps whatever got
+    created.  Zone/project are recorded for the audit trail; the GCP REST client
+    resolves them lazily from metadata/env at delete time."""
+    _ACTIVE_FAILOVER_RESOURCES.append({
+        "node": node,
+        "zone": os.environ.get("GCP_ZONE"),
+        "project": (os.environ.get("GCP_PROJECT_ID")
+                    or os.environ.get("GCP_PROJECT")),
+        "fw_rule": fw_rule,
+    })
+
+
+async def _open_failover_firewall(fw_name: str) -> bool:
+    """Open the driver-owned ephemeral /32 INGRESS firewall for THIS host's
+    public IP -> the failover node's inference port.  Reuses the existing GCP
+    primitives (``resolve_local_public_ip`` + ``create_firewall_rule``) -- NO
+    ``0.0.0.0/0``, ever.  Fail-soft -> False; the teardown stays armed
+    regardless (the node was registered before this call)."""
+    try:
+        from backend.core.ouroboros.governance.gcp_compute_rest import (
+            get_compute_rest,
+            resolve_local_public_ip,
+        )
+
+        ip = await resolve_local_public_ip()
+        if not ip:
+            _log("[HybridMesh] WARN could not resolve local public IP -- "
+                 "firewall NOT opened; node may be unreachable")
+            return False
+        ok, detail = await get_compute_rest().create_firewall_rule(
+            name=fw_name, source_ip=ip, port=_FAILOVER_INFERENCE_PORT)
+        _log("[HybridMesh] ephemeral /32 firewall %s for %s/32:%d -> %s (%s)" % (
+            fw_name, ip, _FAILOVER_INFERENCE_PORT,
+            "OPEN" if ok else "FAILED", detail))
+        return bool(ok)
+    except Exception as exc:  # noqa: BLE001
+        _log("[HybridMesh] firewall open error "
+             "(continuing -- teardown still armed): %r" % (exc,))
+        return False
+
+
+async def _arm_failover_mesh(env: Dict[str, str]) -> None:
+    """Arm the Hybrid Execution Mesh on the soak env, register the failover node
+    for teardown UP FRONT, then open the driver-owned /32 firewall.
+
+    - external-natIP routing so the Mac can reach the node's inference server;
+    - the node binds ``0.0.0.0`` (reachable from off-box);
+    - the DRIVER owns the firewall (NOT the organism -- we do NOT arm
+      ``JARVIS_FAILOVER_EPHEMERAL_FW_ENABLED``), so it is reaped on any exit.
+
+    Registration happens BEFORE the firewall open so a crash during firewall
+    setup still reaps whatever got created.
+    """
+    env["JARVIS_FAILOVER_HYBRID_MESH"] = "true"             # external-natIP route
+    env["JARVIS_FAILOVER_INFERENCE_BIND_ENABLED"] = "true"  # node binds 0.0.0.0
+    fw_name = os.environ.get(
+        "JARVIS_FAILOVER_FW_RULE_NAME", _FAILOVER_FW_RULE_DEFAULT)
+    node_name = os.environ.get(
+        "JARVIS_FAILOVER_NODE_NAME", _FAILOVER_NODE_DEFAULT)
+    _register_failover_resource(node=node_name, fw_rule=fw_name)
+    await _open_failover_firewall(fw_name)
+
+
 def _install_revert_signal_handlers() -> None:
     """Install SIGINT/SIGTERM handlers that revert any active chaos before exit.
     The repo must NEVER be left broken on any exit path."""
     def _handler(signum: int, _frame: Any) -> None:
-        _log("signal %d received -- reverting chaos before exit" % (signum,))
+        _log("signal %d received -- reaping failover + reverting chaos before "
+             "exit" % (signum,))
+        # The node REST-delete is the last breath even on Ctrl+C -- reap FIRST.
+        try:
+            _reap_failover_resources()
+        except Exception:  # noqa: BLE001 -- teardown must never block exit
+            pass
         for chaos in list(_ACTIVE_CHAOS):
             try:
                 chaos.revert()
@@ -502,6 +654,15 @@ class IsomorphicA1Driver:
                     # it is ON even if the harness only passed --enable-failover.
                     env["JARVIS_FAILOVER_LIFECYCLE_ENABLED"] = "true"
 
+                    # Hybrid Execution Mesh (Task HM-A): arm external-IP routing +
+                    # bind, and have the DRIVER (this local orchestrator) own the
+                    # ephemeral /32 firewall for its OWN public IP -- zero-trust,
+                    # no 0.0.0.0/0, reaped on any exit (finally+atexit+signal). The
+                    # node is registered for teardown UP FRONT, before it exists.
+                    # run() is already async -> await directly (NEVER asyncio.run
+                    # inside a live loop; only _reap_failover_resources uses run()).
+                    await _arm_failover_mesh(env)
+
                 # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
                 # (all default OFF in prod; this driver IS the A1 ignition harness).
                 env["JARVIS_RUNTIME_SANDBOX_ENABLED"] = "true"   # L4 container backend
@@ -689,6 +850,10 @@ class IsomorphicA1Driver:
                 _log("adversary stopped")
             except Exception as exc:  # noqa: BLE001
                 _log("adversary stop warning: %r" % (exc,))
+            # IRONCLAD teardown (Task HM-A): reap any awakened failover node + its
+            # firewall AFTER the soak completes/fails/cancels. No-op (registry
+            # empty) when failover was never armed -> default path byte-identical.
+            _reap_failover_resources()
 
 
 # ---------------------------------------------------------------------------
@@ -756,6 +921,12 @@ def main(argv: Optional[List[str]] = None) -> int:
     parser = build_arg_parser()
     args = parser.parse_args(argv)
     _install_revert_signal_handlers()
+    if args.enable_failover:
+        # IRONCLAD teardown (Task HM-A): a process-exit safety net in addition to
+        # run()'s finally + the signal handlers. Idempotent -> at most one real
+        # reap. Only registered when failover is opted in, so the default path is
+        # byte-identical (no atexit hook).
+        atexit.register(_reap_failover_resources)
     driver = IsomorphicA1Driver(
         mode=args.mode,
         seed=args.seed,

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -186,6 +186,17 @@ _FAILOVER_FW_RULE_DEFAULT: str = "jarvis-ephemeral-failover-allow"
 _FAILOVER_NODE_DEFAULT: str = "jarvis-prime-failover"
 _FAILOVER_INFERENCE_PORT: int = 11434
 
+# Hybrid Execution Mesh (Task HM-B) -- L7 semantic-readiness poller defaults. The
+# audit must SUSPEND until the awakened 32B node returns HTTP 200 on /api/tags
+# (proving the ~20GB model is loaded into L4 VRAM) -- NO hardcoded sleeps:
+# exponential backoff (capped) bounded by a budget. All env-tunable so the soak
+# operator and the tests can shrink them.  Read at CALL time (not module-load) so
+# monkeypatch.setenv in tests takes effect.
+_READY_PROBE_BASE_S: float = 3.0          # env JARVIS_HYBRID_MESH_READY_BASE_S
+_READY_PROBE_CAP_S: float = 30.0          # env JARVIS_HYBRID_MESH_READY_CAP_S
+_READY_PROBE_TIMEOUT_S: float = 5.0       # env JARVIS_HYBRID_MESH_READY_PROBE_TIMEOUT_S
+_READY_BUDGET_DEFAULT_S: float = 900.0    # env JARVIS_HYBRID_MESH_READY_BUDGET_S
+
 
 def _reap_failover_resources() -> None:
     """Violently reap every awakened failover node + its ephemeral /32 firewall.
@@ -310,6 +321,123 @@ async def _arm_failover_mesh(env: Dict[str, str]) -> None:
         "JARVIS_FAILOVER_NODE_NAME", _FAILOVER_NODE_DEFAULT)
     _register_failover_resource(node=node_name, fw_rule=fw_name)
     await _open_failover_firewall(fw_name)
+
+
+# ---------------------------------------------------------------------------
+# Hybrid Execution Mesh (Task HM-B) -- L7 semantic-readiness poller. The A1
+# audit must SUSPEND until the awakened 32B node's inference server returns HTTP
+# 200 on /api/tags (the ~20GB model is loaded into L4 VRAM). Without this gate
+# the audit fires FAILED before the node can serve -- the exact failure of the
+# last live run.  No hardcoded sleeps: exponential backoff (capped) + a budget.
+# ---------------------------------------------------------------------------
+
+def _env_float(name: str, default: float) -> float:
+    """Read a float env var with a fail-soft fallback (NEVER raises)."""
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _probe_api_tags(url: str) -> int:
+    """Blocking HTTP GET of the inference server's ``/api/tags`` -> status code.
+
+    Factored out as a TINY testable seam (tests monkeypatch THIS, not the real
+    network).  Mirrors the failover ``_default_node_ready_fn`` urllib style.
+    Returns the HTTP status (200 == 32B served; a real non-2xx like 503 while the
+    model still loads is returned verbatim so the poller treats it as 'not ready
+    yet').  Transport errors (connection refused, timeout, DNS) PROPAGATE -- the
+    caller catches them as 'not ready' and keeps backing off.
+    """
+    import urllib.error
+    import urllib.request
+
+    timeout = _env_float(
+        "JARVIS_HYBRID_MESH_READY_PROBE_TIMEOUT_S", _READY_PROBE_TIMEOUT_S)
+    req = urllib.request.Request(url, method="GET")
+    try:
+        with urllib.request.urlopen(req, timeout=timeout) as resp:  # noqa: S310
+            return int(getattr(resp, "status", None) or resp.getcode() or 0)
+    except urllib.error.HTTPError as he:
+        # A genuine HTTP status (e.g. 503 while VRAM still loading) -> not a
+        # transport error; return the code so the caller backs off, not aborts.
+        return int(getattr(he, "code", 0) or 0)
+
+
+async def _await_jprime_serving(
+    node_name: str, *, budget_s: float, port: int = 11434,
+) -> bool:
+    """Suspend until the awakened GCP node's inference server returns HTTP 200 on
+    ``/api/tags`` (the 32B is loaded into VRAM). Exponential backoff (cap'd),
+    bounded by ``budget_s``. Returns True on first 200, False if the budget
+    elapses. Fail-soft: transport errors are just 'not ready yet' -> keep backing
+    off.  NEVER raises -- worst case returns False and the audit proceeds (and the
+    ironclad teardown reaps the node).
+    """
+    base = _env_float("JARVIS_HYBRID_MESH_READY_BASE_S", _READY_PROBE_BASE_S)
+    cap = _env_float("JARVIS_HYBRID_MESH_READY_CAP_S", _READY_PROBE_CAP_S)
+    probe_to = _env_float(
+        "JARVIS_HYBRID_MESH_READY_PROBE_TIMEOUT_S", _READY_PROBE_TIMEOUT_S)
+
+    delay = base
+    start = time.monotonic()
+    deadline = start + budget_s
+    no_ip_logged = False
+
+    try:
+        from backend.core.ouroboros.governance.gcp_compute_rest import (
+            get_compute_rest,
+        )
+    except Exception as exc:  # noqa: BLE001 -- import must never crash the run
+        _log("[HybridMesh] WARN readiness poller cannot import gcp_compute_rest "
+             "(%r) -- skipping gate" % (exc,))
+        return False
+
+    while time.monotonic() < deadline:
+        external: Optional[str] = None
+        try:
+            _internal, external = await get_compute_rest().get_node_endpoints(
+                node_name)
+        except Exception as exc:  # noqa: BLE001 -- treat as 'not ready yet'
+            _log("[HybridMesh] endpoint resolve fail-soft (%r) -- backing off"
+                 % (exc,))
+            external = None
+
+        if not external:
+            if not no_ip_logged:
+                _log("[HybridMesh] node %s not RUNNING yet (no external IP) -- "
+                     "backing off" % node_name)
+                no_ip_logged = True
+        else:
+            url = "http://%s:%d/api/tags" % (external, port)
+            status = 0
+            try:
+                loop = asyncio.get_event_loop()
+                status = await asyncio.wait_for(
+                    loop.run_in_executor(None, _probe_api_tags, url),
+                    timeout=probe_to + 1.0,
+                )
+            except Exception:  # noqa: BLE001 -- timeout/transport -> not ready
+                status = 0
+            if status == 200:
+                elapsed = time.monotonic() - start
+                _log("[HybridMesh] J-Prime SERVING: 32B ready at %s after %.0fs"
+                     % (url, elapsed))
+                return True
+
+        # Not ready -> exponential backoff, clamped to the remaining budget.
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            await asyncio.sleep(min(delay, remaining))
+        except asyncio.CancelledError:
+            return False
+        delay = min(delay * 2.0, cap)
+
+    _log("[HybridMesh] WARN J-Prime NOT ready after %.0fs -- proceeding to audit "
+         "(will likely FAIL; teardown will reap)" % budget_s)
+    return False
 
 
 def _install_revert_signal_handlers() -> None:
@@ -771,6 +899,25 @@ class IsomorphicA1Driver:
                                 scoped[0] if scoped else "<none found locally>"))
                     else:
                         _log("run-#12: no chaos files in manifest (stub mode?)")
+
+                    # ── d.5 L7 SEMANTIC READINESS GATE (Task HM-B) ───────────
+                    # When failover is armed the audit MUST suspend until the
+                    # awakened 32B node returns HTTP 200 on /api/tags (model loaded
+                    # into VRAM) -- otherwise the audit fires FAILED before the node
+                    # can serve (the exact failure of the last live run). Default
+                    # path (no --enable-failover): skipped entirely -> byte-identical.
+                    if self.enable_failover:
+                        _node = os.environ.get(
+                            "JARVIS_FAILOVER_NODE_NAME", _FAILOVER_NODE_DEFAULT)
+                        _budget = _env_float(
+                            "JARVIS_HYBRID_MESH_READY_BUDGET_S",
+                            _READY_BUDGET_DEFAULT_S)
+                        _log("[HybridMesh] L7 readiness gate: awaiting 32B SERVING "
+                             "(budget=%.0fs) before audit ..." % _budget)
+                        _served = await _await_jprime_serving(
+                            _node, budget_s=_budget)
+                        _log("[HybridMesh] L7 readiness gate -> %s"
+                             % ("SERVING" if _served else "TIMEOUT"))
 
                     # ── e. LAUNCH AUDITOR ────────────────────────────────────
                     _log("STEP audit: sse=%s log=%s" % (self.sse_base, debug_log))

--- a/tests/scripts/test_hybrid_mesh_readiness.py
+++ b/tests/scripts/test_hybrid_mesh_readiness.py
@@ -173,3 +173,33 @@ def test_probe_failsoft(monkeypatch: Any) -> None:
         _driver._await_jprime_serving("node-d", budget_s=0.05))
 
     assert served is False
+
+
+# ---------------------------------------------------------------------------
+# Fix 1: soak-child wall budget
+# ---------------------------------------------------------------------------
+
+def test_failover_wall_exceeds_readiness_budget(monkeypatch: Any) -> None:
+    """Fix 1: _failover_soak_wall accounts for 32B cold-start.
+
+    enable_failover=True  -> READY_BUDGET_S + 600 >= 1500 and > 300
+    enable_failover=False -> 300 (byte-identical default path)
+    """
+    # Default budget (900) -> wall must be 900 + 600 = 1500.
+    wall_on = _driver._failover_soak_wall(True)
+    assert wall_on >= 900 + 600, "failover wall must cover readiness budget + 600s margin"
+    assert wall_on > 300, "failover wall must exceed the non-failover default"
+
+    wall_off = _driver._failover_soak_wall(False)
+    assert wall_off == 300, "default (no failover) wall must be byte-identical 300"
+
+
+def test_failover_wall_respects_env_override(monkeypatch: Any) -> None:
+    """_failover_soak_wall re-reads env at call time so monkeypatch takes effect."""
+    monkeypatch.setenv("JARVIS_HYBRID_MESH_READY_BUDGET_S", "600")
+
+    wall_on = _driver._failover_soak_wall(True)
+    assert wall_on == 600 + 600  # 1200
+
+    wall_off = _driver._failover_soak_wall(False)
+    assert wall_off == 300  # unchanged

--- a/tests/scripts/test_hybrid_mesh_readiness.py
+++ b/tests/scripts/test_hybrid_mesh_readiness.py
@@ -1,0 +1,175 @@
+"""tests/scripts/test_hybrid_mesh_readiness.py -- Task HM-B (Hybrid Execution Mesh).
+
+Proves the L7 SEMANTIC-READINESS poller suspends the A1 audit until the awakened
+GCP 32B node's inference server returns HTTP 200 on ``/api/tags`` (the ~20GB model
+is loaded into L4 VRAM) -- the gate that stops the audit from firing FAILED before
+the node can serve (the exact failure of the last live run):
+
+  - ``_await_jprime_serving`` returns True on the FIRST 200.
+  - It waits (exponential backoff) while the node has no external IP yet, then
+    while the inference server is still warming (503), then succeeds on 200 --
+    proving it actually polls (probe called > 1).
+  - On budget exhaustion it returns False WITHOUT raising (the audit proceeds;
+    the ironclad HM-A teardown reaps the node).
+  - A transport error from the probe is fail-soft -> treated as 'not ready'.
+
+All GCP I/O is faked by monkeypatching ``get_compute_rest`` on the source module;
+the actual HTTP GET is factored into the ``_probe_api_tags`` seam, which the tests
+monkeypatch instead of touching the real network -- zero real network/spend.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Any, List, Optional, Tuple
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap -- scripts are not packages; add repo root + scripts + backend
+# ---------------------------------------------------------------------------
+_REPO_ROOT = str((Path(__file__).parent.parent.parent).resolve())
+_SCRIPTS_DIR = str((Path(__file__).parent.parent.parent / "scripts").resolve())
+
+for _p in (_REPO_ROOT, _SCRIPTS_DIR, os.path.join(_REPO_ROOT, "backend")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_script(name: str) -> Any:
+    """Cache-first script load so monkeypatch targets the SAME module object the
+    driver's own ``_load_module`` returns."""
+    if name in sys.modules:
+        return sys.modules[name]
+    path = os.path.join(_SCRIPTS_DIR, name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, "Cannot load %s from %s" % (name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_driver = _load_script("isomorphic_a1_local")
+
+# The source module whose symbols the driver imports at call-time; monkeypatch
+# here so the lazy ``from ... import get_compute_rest`` picks up the fake.
+import backend.core.ouroboros.governance.gcp_compute_rest as gcp_rest  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class _FakeCompute:
+    """get_node_endpoints returns a scripted (internal, external) sequence;
+    the last entry repeats once the script is exhausted."""
+
+    def __init__(self, sequence: List[Tuple[Optional[str], Optional[str]]]) -> None:
+        self._seq = list(sequence)
+        self.calls = 0
+
+    async def get_node_endpoints(
+        self, name: Optional[str] = None,
+    ) -> Tuple[Optional[str], Optional[str]]:
+        self.calls += 1
+        idx = min(self.calls - 1, len(self._seq) - 1)
+        return self._seq[idx]
+
+
+def _install_compute(
+    monkeypatch: Any, sequence: List[Tuple[Optional[str], Optional[str]]],
+) -> _FakeCompute:
+    fake = _FakeCompute(sequence)
+    monkeypatch.setattr(gcp_rest, "get_compute_rest", lambda: fake)
+    return fake
+
+
+def _install_probe(monkeypatch: Any, side: Any) -> List[str]:
+    """Stub ``_probe_api_tags`` with a callable or a list of status codes /
+    exceptions to yield in order (last repeats). Records probed URLs."""
+    probed: List[str] = []
+
+    if callable(side):
+        def _fn(url: str) -> int:
+            probed.append(url)
+            return side(url)
+    else:
+        seq = list(side)
+
+        def _fn(url: str) -> int:
+            probed.append(url)
+            item = seq[min(len(probed) - 1, len(seq) - 1)]
+            if isinstance(item, BaseException):
+                raise item
+            return int(item)
+
+    monkeypatch.setattr(_driver, "_probe_api_tags", _fn)
+    return probed
+
+
+@pytest.fixture(autouse=True)
+def _tiny_backoff(monkeypatch: Any) -> Any:
+    """Shrink backoff/cap so the polling tests are fast."""
+    monkeypatch.setenv("JARVIS_HYBRID_MESH_READY_BASE_S", "0.01")
+    monkeypatch.setenv("JARVIS_HYBRID_MESH_READY_CAP_S", "0.02")
+    monkeypatch.setenv("JARVIS_HYBRID_MESH_READY_PROBE_TIMEOUT_S", "0.5")
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+def test_serving_returns_true_on_200(monkeypatch: Any) -> None:
+    _install_compute(monkeypatch, [(None, "203.0.113.9")])
+    probed = _install_probe(monkeypatch, [200])
+
+    served = asyncio.run(
+        _driver._await_jprime_serving("node-a", budget_s=5.0))
+
+    assert served is True
+    assert probed == ["http://203.0.113.9:11434/api/tags"]
+
+
+def test_waits_until_ip_then_200(monkeypatch: Any) -> None:
+    # No external IP twice, then an IP; probe 503 once, then 200.
+    fake = _install_compute(monkeypatch, [
+        (None, None), (None, None), (None, "198.51.100.7"),
+    ])
+    probed = _install_probe(monkeypatch, [503, 200])
+
+    served = asyncio.run(
+        _driver._await_jprime_serving("node-b", budget_s=5.0))
+
+    assert served is True
+    # Polled the endpoint repeatedly (waited for IP) ...
+    assert fake.calls >= 3
+    # ... and probed more than once (503 -> backoff -> 200).
+    assert len(probed) > 1
+
+
+def test_budget_exhaustion_returns_false(monkeypatch: Any) -> None:
+    # IP is present but the server is permanently warming (503) + a tiny budget.
+    _install_compute(monkeypatch, [(None, "203.0.113.50")])
+    _install_probe(monkeypatch, [503])
+
+    served = asyncio.run(
+        _driver._await_jprime_serving("node-c", budget_s=0.05))
+
+    assert served is False  # never raised
+
+
+def test_probe_failsoft(monkeypatch: Any) -> None:
+    # Probe raises (transport error) -> treated as not-ready, loop continues to
+    # budget, returns False, NEVER raises.
+    _install_compute(monkeypatch, [(None, "203.0.113.77")])
+    _install_probe(monkeypatch, [ConnectionRefusedError("refused")])
+
+    served = asyncio.run(
+        _driver._await_jprime_serving("node-d", budget_s=0.05))
+
+    assert served is False

--- a/tests/scripts/test_hybrid_mesh_teardown.py
+++ b/tests/scripts/test_hybrid_mesh_teardown.py
@@ -177,10 +177,29 @@ def test_firewall_opens_with_slash32_source(monkeypatch: Any) -> None:
 
     ok = asyncio.run(_driver._open_failover_firewall("fw-mesh"))
 
-    assert ok is True
+    # Fix 3: _open_failover_firewall returns the fw_name on success (not bool).
+    assert ok == "fw-mesh"
     assert rec.created_firewalls == [
         {"name": "fw-mesh", "source_ip": "203.0.113.7", "port": 11434},
     ]
+
+
+def test_fw_rule_none_when_not_opened(monkeypatch: Any) -> None:
+    """Fix 3: when resolve_local_public_ip returns None the firewall is NOT opened,
+    but the node is STILL registered for teardown (orphan safety)."""
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec, ip=None)  # cannot resolve public IP
+
+    env: Dict[str, str] = {}
+    asyncio.run(_driver._arm_failover_mesh(env))
+
+    # Node must be registered (orphan safety never weakened).
+    assert len(_driver._ACTIVE_FAILOVER_RESOURCES) == 1
+    assert _driver._ACTIVE_FAILOVER_RESOURCES[0]["node"]
+    # fw_rule must be None because the firewall was never actually opened.
+    assert _driver._ACTIVE_FAILOVER_RESOURCES[0]["fw_rule"] is None
+    # No firewall rule was created.
+    assert rec.created_firewalls == []
 
 
 def test_no_public_ip_skips_open_but_keeps_teardown(monkeypatch: Any) -> None:

--- a/tests/scripts/test_hybrid_mesh_teardown.py
+++ b/tests/scripts/test_hybrid_mesh_teardown.py
@@ -1,0 +1,246 @@
+"""tests/scripts/test_hybrid_mesh_teardown.py -- Task HM-A (Hybrid Execution Mesh).
+
+Proves the LOCAL A1 driver owns the GCP failover node's networking + an
+UNBREAKABLE teardown so a real GPU node can NEVER be orphaned:
+
+  - ``_reap_failover_resources`` deletes BOTH the node AND its ephemeral /32
+    firewall, is IDEMPOTENT (clears the registry -> second call is a no-op), and
+    is FAIL-SOFT (a delete that raises does not abort the rest of the teardown).
+  - ``_open_failover_firewall`` reuses the existing GCP primitives
+    (``resolve_local_public_ip`` + ``create_firewall_rule``) to open a /32 rule
+    for THIS host's public IP -- never ``0.0.0.0/0``.
+  - When the public IP cannot be resolved the firewall is NOT opened, but the
+    node stays registered for teardown.
+  - The SIGTERM/SIGINT handler path reaps the failover resources.
+
+All GCP I/O is faked via a recorder injected by monkeypatching ``get_compute_rest``
+and ``resolve_local_public_ip`` on the source module -- zero real network/spend.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap -- scripts are not packages; add repo root + scripts + backend
+# ---------------------------------------------------------------------------
+_REPO_ROOT = str((Path(__file__).parent.parent.parent).resolve())
+_SCRIPTS_DIR = str((Path(__file__).parent.parent.parent / "scripts").resolve())
+
+for _p in (_REPO_ROOT, _SCRIPTS_DIR, os.path.join(_REPO_ROOT, "backend")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_script(name: str) -> Any:
+    """Cache-first script load so monkeypatch targets the SAME module object the
+    driver's own ``_load_module`` returns."""
+    if name in sys.modules:
+        return sys.modules[name]
+    path = os.path.join(_SCRIPTS_DIR, name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, "Cannot load %s from %s" % (name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_driver = _load_script("isomorphic_a1_local")
+
+# The source module whose symbols the driver imports at call-time; monkeypatch
+# here so the lazy ``from ... import get_compute_rest`` picks up the fake.
+import backend.core.ouroboros.governance.gcp_compute_rest as gcp_rest  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+class _Recorder:
+    """Records every GCP REST call the teardown / firewall-open makes."""
+
+    def __init__(self, *, instance_raises: bool = False) -> None:
+        self.deleted_instances: List[Optional[str]] = []
+        self.deleted_firewalls: List[str] = []
+        self.created_firewalls: List[Dict[str, Any]] = []
+        self._instance_raises = instance_raises
+
+    async def delete_instance(self, name: Optional[str] = None) -> Tuple[bool, str]:
+        if self._instance_raises:
+            raise RuntimeError("boom: instance delete blew up")
+        self.deleted_instances.append(name)
+        return (True, "deleted:200")
+
+    async def delete_firewall_rule(self, name: str) -> Tuple[bool, str]:
+        self.deleted_firewalls.append(name)
+        return (True, "deleted:200")
+
+    async def create_firewall_rule(
+        self, *, name: str, source_ip: str, port: int = 11434,
+    ) -> Tuple[bool, str]:
+        self.created_firewalls.append(
+            {"name": name, "source_ip": source_ip, "port": port})
+        return (True, "created:200")
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    """Every test starts + ends with an empty failover registry."""
+    _driver._ACTIVE_FAILOVER_RESOURCES.clear()
+    yield
+    _driver._ACTIVE_FAILOVER_RESOURCES.clear()
+
+
+def _install_recorder(
+    monkeypatch: Any, recorder: _Recorder, *, ip: Optional[str] = "203.0.113.7",
+) -> None:
+    monkeypatch.setattr(gcp_rest, "get_compute_rest", lambda: recorder)
+
+    async def _fake_resolve(*_a: Any, **_k: Any) -> Optional[str]:
+        return ip
+
+    monkeypatch.setattr(gcp_rest, "resolve_local_public_ip", _fake_resolve)
+
+
+# ---------------------------------------------------------------------------
+# Reap tests
+# ---------------------------------------------------------------------------
+
+def test_reap_deletes_node_and_firewall(monkeypatch: Any) -> None:
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec)
+    _driver._ACTIVE_FAILOVER_RESOURCES.append({
+        "node": "jarvis-prime-failover", "zone": "us-central1-a",
+        "project": "proj", "fw_rule": "jarvis-ephemeral-failover-allow",
+    })
+
+    _driver._reap_failover_resources()
+
+    assert rec.deleted_instances == ["jarvis-prime-failover"]
+    assert rec.deleted_firewalls == ["jarvis-ephemeral-failover-allow"]
+    # Registry cleared -> a second reap is a no-op.
+    assert _driver._ACTIVE_FAILOVER_RESOURCES == []
+
+
+def test_reap_idempotent(monkeypatch: Any) -> None:
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec)
+    _driver._ACTIVE_FAILOVER_RESOURCES.append({
+        "node": "node-1", "zone": None, "project": None, "fw_rule": "fw-1",
+    })
+
+    _driver._reap_failover_resources()
+    _driver._reap_failover_resources()  # second call must be a pure no-op
+
+    assert rec.deleted_instances == ["node-1"]
+    assert rec.deleted_firewalls == ["fw-1"]
+
+
+def test_reap_failsoft(monkeypatch: Any) -> None:
+    # delete_instance raises -> reap MUST still return cleanly and STILL attempt
+    # the firewall delete (gather(..., return_exceptions=True)).
+    rec = _Recorder(instance_raises=True)
+    _install_recorder(monkeypatch, rec)
+    _driver._ACTIVE_FAILOVER_RESOURCES.append({
+        "node": "node-x", "zone": None, "project": None, "fw_rule": "fw-x",
+    })
+
+    _driver._reap_failover_resources()  # must NOT raise
+
+    assert rec.deleted_firewalls == ["fw-x"]  # firewall delete still attempted
+    assert _driver._ACTIVE_FAILOVER_RESOURCES == []
+
+
+def test_reap_empty_registry_is_noop(monkeypatch: Any) -> None:
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec)
+    # Registry empty (default-OFF path) -> no client touched at all.
+    _driver._reap_failover_resources()
+    assert rec.deleted_instances == []
+    assert rec.deleted_firewalls == []
+
+
+# ---------------------------------------------------------------------------
+# Firewall-open tests
+# ---------------------------------------------------------------------------
+
+def test_firewall_opens_with_slash32_source(monkeypatch: Any) -> None:
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec, ip="203.0.113.7")
+
+    ok = asyncio.run(_driver._open_failover_firewall("fw-mesh"))
+
+    assert ok is True
+    assert rec.created_firewalls == [
+        {"name": "fw-mesh", "source_ip": "203.0.113.7", "port": 11434},
+    ]
+
+
+def test_no_public_ip_skips_open_but_keeps_teardown(monkeypatch: Any) -> None:
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec, ip=None)  # public IP unresolvable
+
+    env: Dict[str, str] = {}
+    asyncio.run(_driver._arm_failover_mesh(env))
+
+    # Firewall NOT opened ...
+    assert rec.created_firewalls == []
+    # ... but the node IS registered for teardown (and the mesh env was armed).
+    assert len(_driver._ACTIVE_FAILOVER_RESOURCES) == 1
+    assert _driver._ACTIVE_FAILOVER_RESOURCES[0]["node"]
+    assert env["JARVIS_FAILOVER_HYBRID_MESH"] == "true"
+    assert env["JARVIS_FAILOVER_INFERENCE_BIND_ENABLED"] == "true"
+    # The driver owns the firewall -> it must NOT delegate to the organism.
+    assert "JARVIS_FAILOVER_EPHEMERAL_FW_ENABLED" not in env
+
+
+def test_arm_registers_then_opens(monkeypatch: Any) -> None:
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec, ip="198.51.100.4")
+    monkeypatch.setenv("JARVIS_FAILOVER_NODE_NAME", "node-custom")
+    monkeypatch.setenv("JARVIS_FAILOVER_FW_RULE_NAME", "fw-custom")
+
+    env: Dict[str, str] = {}
+    asyncio.run(_driver._arm_failover_mesh(env))
+
+    assert _driver._ACTIVE_FAILOVER_RESOURCES[0]["node"] == "node-custom"
+    assert _driver._ACTIVE_FAILOVER_RESOURCES[0]["fw_rule"] == "fw-custom"
+    assert rec.created_firewalls == [
+        {"name": "fw-custom", "source_ip": "198.51.100.4", "port": 11434},
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Signal-handler teardown
+# ---------------------------------------------------------------------------
+
+def test_signal_handler_reaps(monkeypatch: Any) -> None:
+    reaped: List[bool] = []
+    monkeypatch.setattr(
+        _driver, "_reap_failover_resources", lambda: reaped.append(True))
+
+    captured: Dict[int, Any] = {}
+
+    def _fake_signal(sig: int, handler: Any) -> Any:
+        captured[sig] = handler
+        return None
+
+    # Capture the installed handler, neuter the re-raise so the test process
+    # survives, and stub chaos-revert (none active anyway).
+    monkeypatch.setattr(_driver.signal, "signal", _fake_signal)
+    monkeypatch.setattr(_driver.os, "kill", lambda *_a, **_k: None)
+
+    _driver._install_revert_signal_handlers()
+
+    handler = captured.get(_driver.signal.SIGTERM)
+    assert handler is not None, "SIGTERM handler must be installed"
+    handler(_driver.signal.SIGTERM, None)  # simulate SIGTERM delivery
+
+    assert reaped == [True], "signal handler must reap failover resources"


### PR DESCRIPTION
Makes the local macOS A1 driver safely own a real GCP 32B GPU node (DW's fallback). Final-review: **0 Critical, cost-leak risk CLOSED** (register-before-create, every exit reaps, cross-loop-safe, default-OFF byte-identical).

- **Ironclad teardown** — node registered (deterministic name) BEFORE it can be created; `_reap_failover_resources()` wired to `finally` + `atexit` + `SIGINT/SIGTERM`, idempotent + fail-soft; daemon-thread dispatch so Ctrl+C mid-soak still deletes the node (join > REST timeout).
- **Zero-trust /32 firewall** — driver resolves its OWN public IP and opens an ephemeral /32 for it (reusing `resolve_local_public_ip` + `create_firewall_rule`, never `0.0.0.0/0`); reaped with the node; registered-on-open.
- **L7 readiness gate** — `_await_jprime_serving` polls the node's external IP `/api/tags` with exponential backoff until HTTP 200 (32B in VRAM) before the audit. Soak-child wall derived to fit the cold-start (readiness 900s + 600s margin = 1500s < 2400s cap).

Arms `JARVIS_FAILOVER_HYBRID_MESH` + `INFERENCE_BIND` so the external-IP racer wins. 15 tests; default-OFF byte-identical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Hybrid Execution Mesh so the local A1 driver can safely own a real GCP 32B failover node, with ironclad teardown and a zero‑trust /32 firewall, and waits for the node to actually serve before auditing via an L7 readiness gate. Default OFF; non‑failover runs remain byte‑identical.

- New Features
  - Ironclad teardown: register-before-create, reap on finally + atexit + SIGINT/SIGTERM, idempotent, fail‑soft, and deletes both node and firewall (uses a daemon thread if an event loop is active).
  - Zero‑trust /32 firewall: resolves the driver’s public IP, opens an ephemeral rule for port 11434 (never 0.0.0.0/0), owned and reaped by the driver; pairs with the node lifecycle.
  - L7 readiness gate: polls the node’s external IP `/api/tags` with exponential backoff until HTTP 200; env‑tunable base/cap/timeout/budget; transport errors are treated as “not ready” and do not raise.
  - Extended soak wall when failover is enabled: wall_seconds = readiness budget + 600 (e.g., 1500s by default); remains 300 without failover.
  - Arms `JARVIS_FAILOVER_HYBRID_MESH` and `JARVIS_FAILOVER_INFERENCE_BIND_ENABLED` so external IP routing wins while keeping the default path unchanged.

<sup>Written for commit fc7662dc6d6304d1a7df47ee5bf775aa1e8856c0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69777?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

