### PR TITLE
fix(a1): L4 provisioning robustness — on-demand-on-stockout fallback + L4-capable zone list

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -272,6 +272,14 @@ def _machine_type() -> str:
     return _env_str(_ENV_MACHINE_TYPE, _DEFAULT_MACHINE_TYPE)
 
 
+def _ondemand_on_stockout_enabled() -> bool:
+    """When true, a SPOT stockout in a zone falls through to an on-demand insert
+    in the SAME zone before giving up on it (L4 Spot is scarce; on-demand has
+    capacity in a quota'd region). Default OFF -> Spot-only across zones (prod
+    failover stays cheap)."""
+    return os.environ.get("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false").strip().lower() in ("1", "true", "yes")
+
+
 # ---------------------------------------------------------------------------
 # Low-level async HTTP (aiohttp if present, else stdlib urllib on the executor)
 # ---------------------------------------------------------------------------
@@ -724,6 +732,9 @@ class GCPComputeRest:
                 if op:
                     verdict = await self._await_insert_operation(project, zone, op, token)
                     if verdict == "stockout":
+                        if spot and _ondemand_on_stockout_enabled():
+                            logger.warning("[GCPComputeRest] SPOT stockout zone=%s -> trying ON-DEMAND same zone (quota'd region)", zone)
+                            continue
                         return ("stockout", "zone={}:op_stockout".format(zone))
                     if verdict == "error":
                         logger.warning("[GCPComputeRest] insert op error zone=%s mode=%s", zone, mode)
@@ -733,6 +744,9 @@ class GCPComputeRest:
                 return ("created", "zone={}:mode={}".format(zone, mode))
             # Synchronous rejection: a stockout here -> retry next zone.
             if is_stockout_error(text):
+                if spot and _ondemand_on_stockout_enabled():
+                    logger.warning("[GCPComputeRest] SPOT sync-stockout zone=%s -> trying ON-DEMAND same zone", zone)
+                    continue
                 return ("stockout", "zone={}:sync_stockout".format(zone))
             logger.warning("[GCPComputeRest] insert %s failed zone=%s status=%s detail=%s",
                            mode, zone, status, (text or "")[-200:])

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -310,6 +310,12 @@ async def _arm_failover_mesh(env: Dict[str, str]) -> None:
     """
     env["JARVIS_FAILOVER_HYBRID_MESH"] = "true"             # external-natIP route
     env["JARVIS_FAILOVER_INFERENCE_BIND_ENABLED"] = "true"  # node binds 0.0.0.0
+    # L4-capable zones ONLY (drop non-L4 zones like us-central1-f whose 400
+    # halts the multi-zonal chain). Quota is confirmed in us-central1.
+    env.setdefault("JARVIS_GCP_ZONE_FALLBACK", "us-central1-a,us-central1-b,us-central1-c")
+    # L4 Spot is scarce -> let a Spot stockout fall through to on-demand in
+    # the same quota'd zone (bounded $; the run is short + violently reaped).
+    env.setdefault("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
     fw_name = os.environ.get(
         "JARVIS_FAILOVER_FW_RULE_NAME", _FAILOVER_FW_RULE_DEFAULT)
     node_name = os.environ.get(

--- a/tests/governance/test_ondemand_on_stockout.py
+++ b/tests/governance/test_ondemand_on_stockout.py
@@ -1,0 +1,168 @@
+"""Fix A regression: on-demand-on-stockout fallback (gated) in _insert_in_zone.
+
+When ``JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT`` is ON, a SPOT stockout in a zone
+falls through to an on-demand insert in the SAME zone before giving up (L4 Spot
+is scarce; on-demand has capacity in a quota'd region). Default OFF -> byte
+identical to today's immediate-stockout-return Spot-only behavior.
+
+Covers BOTH stockout seams:
+  - op-stockout: HTTP 200 -> insert op resolves "stockout" via _await_insert_operation.
+  - sync-stockout: HTTP 4xx whose body is_stockout_error(text).
+
+Seams mocked: module ``_http_request`` (returns (status, text)) +
+``_await_insert_operation`` (returns "ok"/"stockout"/"error"). is_stockout_error
+is driven via real bodies for the sync path.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import backend.core.ouroboros.governance.gcp_compute_rest as gr
+from backend.core.ouroboros.governance.gcp_compute_rest import GCPComputeRest
+
+pytestmark = pytest.mark.asyncio
+
+_OK_INSERT = (200, json.dumps({"name": "op-insert"}))
+# A synchronous stockout rejection body (matched by is_stockout_error).
+_SYNC_STOCKOUT = (
+    503,
+    json.dumps({"error": {"errors": [{"reason": "ZONE_RESOURCE_POOL_EXHAUSTED"}]}}),
+)
+_INSERT_KW = dict(
+    zone="us-central1-a",
+    project="my-project",
+    token="ya29.FAKE",
+    headers={"Authorization": "Bearer ya29.FAKE"},
+    node="jarvis-prime-failover",
+    machine="g2-standard-4",
+    family="jarvis-prime-coder",
+    startup_script="#!/bin/bash\ntrue\n",
+    accelerator_type="nvidia-l4",
+    accelerator_count=1,
+)
+
+
+class _RecordingHTTP:
+    """Returns scripted (status, text) per POST call; records every call."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+    async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        self.calls.append({"url": url, "method": method, "body": body})
+        idx = min(len(self.calls) - 1, len(self._responses) - 1)
+        return self._responses[idx]
+
+    @property
+    def insert_attempts(self) -> int:
+        return sum(1 for c in self.calls if c["method"] == "POST")
+
+
+def _patch_await(monkeypatch, verdicts):
+    """Patch _await_insert_operation to pop scripted verdicts in order."""
+    seq = list(verdicts)
+    calls = {"n": 0}
+
+    async def _fake(self, project, zone, op_name, token):
+        v = seq[min(calls["n"], len(seq) - 1)]
+        calls["n"] += 1
+        return v
+
+    monkeypatch.setattr(GCPComputeRest, "_await_insert_operation", _fake)
+    return calls
+
+
+# --------------------------------------------------------------------------
+# op-stockout path (HTTP 200 -> op resolves "stockout")
+# --------------------------------------------------------------------------
+
+async def test_spot_stockout_falls_through_to_ondemand_when_enabled(monkeypatch):
+    """Flag ON: Spot op-stockout -> on-demand insert created. TWO inserts."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
+    http = _RecordingHTTP([_OK_INSERT, _OK_INSERT])
+    monkeypatch.setattr(gr, "_http_request", http)
+    # spot op -> stockout; on-demand op -> ok.
+    _patch_await(monkeypatch, ["stockout", "ok"])
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "mode=on-demand" in detail
+    assert http.insert_attempts == 2
+
+
+async def test_spot_stockout_returns_stockout_when_disabled(monkeypatch):
+    """Flag OFF: Spot op-stockout -> immediate stockout. ONE insert (byte-identical)."""
+    monkeypatch.delenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", raising=False)
+    http = _RecordingHTTP([_OK_INSERT, _OK_INSERT])
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["stockout", "ok"])
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"
+    assert "op_stockout" in detail
+    assert http.insert_attempts == 1
+
+
+async def test_ondemand_also_stockout_gives_up(monkeypatch):
+    """Flag ON: both Spot + on-demand op-stockout -> give up on the zone (not created)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
+    http = _RecordingHTTP([_OK_INSERT, _OK_INSERT])
+    monkeypatch.setattr(gr, "_http_request", http)
+    # spot -> stockout, on-demand -> stockout (returns immediately, spot is False).
+    _patch_await(monkeypatch, ["stockout", "stockout"])
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"  # on-demand pass returned stockout
+    assert verdict != "created"
+    assert http.insert_attempts == 2
+
+
+# --------------------------------------------------------------------------
+# sync-stockout path (HTTP 4xx whose body is_stockout_error)
+# --------------------------------------------------------------------------
+
+async def test_sync_stockout_falls_through_to_ondemand_when_enabled(monkeypatch):
+    """Flag ON: Spot sync-stockout -> on-demand insert created. TWO inserts."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
+    http = _RecordingHTTP([_SYNC_STOCKOUT, _OK_INSERT])
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["ok"])  # only the on-demand 200 reaches _await
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "mode=on-demand" in detail
+    assert http.insert_attempts == 2
+
+
+async def test_sync_stockout_returns_stockout_when_disabled(monkeypatch):
+    """Flag OFF: Spot sync-stockout -> immediate stockout. ONE insert (byte-identical)."""
+    monkeypatch.delenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", raising=False)
+    http = _RecordingHTTP([_SYNC_STOCKOUT, _OK_INSERT])
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"
+    assert "sync_stockout" in detail
+    assert http.insert_attempts == 1
+
+
+async def test_sync_stockout_ondemand_also_stockout_gives_up(monkeypatch):
+    """Flag ON: both Spot + on-demand sync-stockout -> give up on the zone."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
+    http = _RecordingHTTP([_SYNC_STOCKOUT, _SYNC_STOCKOUT])
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    # On-demand also sync-stockout: spot is False -> returns ("stockout", sync_stockout).
+    assert verdict == "stockout"
+    assert verdict != "created"
+    assert http.insert_attempts == 2

--- a/tests/scripts/test_hybrid_mesh_teardown.py
+++ b/tests/scripts/test_hybrid_mesh_teardown.py
@@ -237,6 +237,40 @@ def test_arm_registers_then_opens(monkeypatch: Any) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Fix B: _arm_failover_mesh arms an L4-capable zone list + on-demand-on-stockout
+# ---------------------------------------------------------------------------
+
+def test_arm_sets_l4_zone_list_and_ondemand(monkeypatch: Any) -> None:
+    """The mesh arming seeds the 3 L4-capable us-central1 zones + on-demand flag,
+    so the live ignition can actually land a node (drops non-L4 zones whose 400
+    halts the chain; Spot-stockout falls through to on-demand in the quota'd zone)."""
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec, ip="198.51.100.4")
+
+    env: Dict[str, str] = {}
+    asyncio.run(_driver._arm_failover_mesh(env))
+
+    assert env["JARVIS_GCP_ZONE_FALLBACK"] == "us-central1-a,us-central1-b,us-central1-c"
+    assert env["JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT"] == "true"
+
+
+def test_arm_respects_operator_zone_and_ondemand_overrides(monkeypatch: Any) -> None:
+    """setdefault: an operator-preset value in env (from os.environ via compose_env)
+    is NOT overridden by the mesh defaults."""
+    rec = _Recorder()
+    _install_recorder(monkeypatch, rec, ip="198.51.100.4")
+
+    env: Dict[str, str] = {
+        "JARVIS_GCP_ZONE_FALLBACK": "us-east1-b,us-east1-c",
+        "JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT": "false",
+    }
+    asyncio.run(_driver._arm_failover_mesh(env))
+
+    assert env["JARVIS_GCP_ZONE_FALLBACK"] == "us-east1-b,us-east1-c"
+    assert env["JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT"] == "false"
+
+
+# ---------------------------------------------------------------------------
 # Signal-handler teardown
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
Live 4th ignition proved L4 Spot stockout in us-central1-a/b/c, and the zone chain fell to non-L4 us-central1-f whose 400 HALTED the chain before L4 regions, never trying on-demand.

- **Gated on-demand-on-stockout** (`JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT`, default OFF): a Spot stockout falls through to an on-demand insert in the SAME quota'd zone before giving up. Default-OFF byte-identical (prod failover stays Spot-only).
- **L4-capable zone list** armed by the driver: `JARVIS_GCP_ZONE_FALLBACK=us-central1-a,b,c` (drops non-L4 zones that halt the chain; quota confirmed there). `setdefault` respects operator override.

23 tests green; the on-demand fallback covers both the op-stockout and sync-stockout paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves L4 provisioning reliability by falling back to on-demand in the same zone when SPOT is out of capacity (flag-gated). Also restricts fallback zones to L4-capable ones to prevent 400s that stop the chain; prod behavior is unchanged by default.

- **Bug Fixes**
  - Added on-demand-on-stockout fallback controlled by `JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT` (default OFF). Applies to both op-stockout and sync-stockout paths.
  - `_arm_failover_mesh` now seeds `JARVIS_GCP_ZONE_FALLBACK=us-central1-a,us-central1-b,us-central1-c` via `setdefault`, dropping non‑L4 zones; operator overrides are respected.
  - Added tests covering both stockout seams and mesh env defaults.

<sup>Written for commit 779d920ee9ee2f784834b38f3b49edf304e55899. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69778?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

