### PR TITLE
fix(a1): zone-aware node reap — no cross-zone GPU orphans

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -930,15 +930,22 @@ class GCPComputeRest:
 
     # -- delete (delete-to-snapshot keeps the golden image untouched) ----
 
-    async def delete_instance(self, name: Optional[str] = None) -> Tuple[bool, str]:
+    async def delete_instance(
+        self, name: Optional[str] = None, *, zone: Optional[str] = None
+    ) -> Tuple[bool, str]:
         """DELETE instances/<name> via the SAME REST contract as the bash
         dead-man. Deleting the instance does NOT touch the golden image. Returns
         (ok, detail). Fail-CLOSED -> (False, "<LOCUS>:..") on any error. NEVER
-        raises."""
+        raises.
+
+        ``zone`` overrides the resolved default zone -- REQUIRED to reap a node
+        that the multi-zonal awaken landed in a fallback zone (not ``GCP_ZONE``);
+        without it a node created in us-central1-c is orphaned when the reap only
+        looks in us-central1-a."""
         token = await self.access_token()
         if not token:
             return (False, "AUTH_TOKEN_UNAVAILABLE:metadata_unreachable")
-        zone = await self.zone()
+        zone = zone or await self.zone()
         project = await self.project()
         if not zone or not project:
             return (

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -220,11 +220,23 @@ def _reap_failover_resources() -> None:
             get_compute_rest,
         )
 
+        from backend.core.ouroboros.governance.zone_fallback import (
+            zone_fallback_chain,
+        )
+
         client = get_compute_rest()
+        # The multi-zonal awaken can land the node in ANY fallback zone (a Spot
+        # stockout in us-central1-a -> the node is created in -b or -c). The reap
+        # must therefore attempt the delete in EVERY candidate zone, not just
+        # GCP_ZONE -- otherwise a node in -c is orphaned (the exact cost-leak the
+        # 4th live ignition hit). delete_instance is 404-idempotent, so deleting
+        # in the zones that DON'T hold the node is a clean no-op.
+        _zones = zone_fallback_chain(os.environ.get("GCP_ZONE"))
         tasks = []
         for r in resources:
             if r.get("node"):
-                tasks.append(client.delete_instance(r["node"]))
+                for _z in _zones:
+                    tasks.append(client.delete_instance(r["node"], zone=_z))
             if r.get("fw_rule"):
                 tasks.append(client.delete_firewall_rule(r["fw_rule"]))
         if tasks:

--- a/tests/scripts/test_hybrid_mesh_teardown.py
+++ b/tests/scripts/test_hybrid_mesh_teardown.py
@@ -68,14 +68,18 @@ class _Recorder:
 
     def __init__(self, *, instance_raises: bool = False) -> None:
         self.deleted_instances: List[Optional[str]] = []
+        self.deleted_zones: List[Optional[str]] = []
         self.deleted_firewalls: List[str] = []
         self.created_firewalls: List[Dict[str, Any]] = []
         self._instance_raises = instance_raises
 
-    async def delete_instance(self, name: Optional[str] = None) -> Tuple[bool, str]:
+    async def delete_instance(
+        self, name: Optional[str] = None, *, zone: Optional[str] = None
+    ) -> Tuple[bool, str]:
         if self._instance_raises:
             raise RuntimeError("boom: instance delete blew up")
         self.deleted_instances.append(name)
+        self.deleted_zones.append(zone)
         return (True, "deleted:200")
 
     async def delete_firewall_rule(self, name: str) -> Tuple[bool, str]:
@@ -90,11 +94,22 @@ class _Recorder:
         return (True, "created:200")
 
 
+_TEST_ZONES = "us-central1-a,us-central1-b,us-central1-c"
+
+
 @pytest.fixture(autouse=True)
 def _clean_registry() -> Any:
-    """Every test starts + ends with an empty failover registry."""
+    """Every test starts + ends with an empty failover registry, and pins a
+    deterministic 3-zone fallback chain so the multi-zonal reap sweep is
+    predictable (the reap deletes the node in EVERY candidate zone)."""
     _driver._ACTIVE_FAILOVER_RESOURCES.clear()
+    _prev = os.environ.get("JARVIS_GCP_ZONE_FALLBACK")
+    os.environ["JARVIS_GCP_ZONE_FALLBACK"] = _TEST_ZONES
     yield
+    if _prev is None:
+        os.environ.pop("JARVIS_GCP_ZONE_FALLBACK", None)
+    else:
+        os.environ["JARVIS_GCP_ZONE_FALLBACK"] = _prev
     _driver._ACTIVE_FAILOVER_RESOURCES.clear()
 
 
@@ -123,7 +138,10 @@ def test_reap_deletes_node_and_firewall(monkeypatch: Any) -> None:
 
     _driver._reap_failover_resources()
 
-    assert rec.deleted_instances == ["jarvis-prime-failover"]
+    # The node is deleted in EVERY candidate zone (zone-aware reap -- a node that
+    # landed in a fallback zone is never orphaned). 404-idempotent on empty zones.
+    assert set(rec.deleted_instances) == {"jarvis-prime-failover"}
+    assert rec.deleted_zones == ["us-central1-a", "us-central1-b", "us-central1-c"]
     assert rec.deleted_firewalls == ["jarvis-ephemeral-failover-allow"]
     # Registry cleared -> a second reap is a no-op.
     assert _driver._ACTIVE_FAILOVER_RESOURCES == []
@@ -139,7 +157,9 @@ def test_reap_idempotent(monkeypatch: Any) -> None:
     _driver._reap_failover_resources()
     _driver._reap_failover_resources()  # second call must be a pure no-op
 
-    assert rec.deleted_instances == ["node-1"]
+    # First reap swept all 3 zones once; the second was a pure no-op (not 6).
+    assert set(rec.deleted_instances) == {"node-1"}
+    assert len(rec.deleted_instances) == 3
     assert rec.deleted_firewalls == ["fw-1"]
 
 


### PR DESCRIPTION
5th live ignition cost-leak fix: the multi-zonal awaken lands the node in any fallback zone, but the reap only looked in GCP_ZONE -> a node in us-central1-c was orphaned. `delete_instance` gains `zone=` override; `_reap_failover_resources` sweeps the full `zone_fallback_chain` (404-idempotent). 23 tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make node teardown zone-aware to prevent orphaned GPU instances when multi-zonal awaken launches in a fallback zone. Reap now deletes across all candidate zones to close the cost leak.

- **Bug Fixes**
  - `delete_instance` accepts a `zone=` override to delete outside the default `GCP_ZONE`.
  - Reaper `_reap_failover_resources` sweeps the full `zone_fallback_chain` and deletes in each zone (404-idempotent).
  - Tests updated to assert multi-zone deletes and pin `JARVIS_GCP_ZONE_FALLBACK` for deterministic behavior.

<sup>Written for commit 5a75b10fc8cc72c4e7e1d7a733ad7878974fc19c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69779?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

