### PR TITLE
feat(a1): adaptive cold-start timeouts + autonomous diagnostic reaper

### DIFF
--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -370,6 +370,127 @@ def _warmup_timeout_s() -> float:
     return max(1.0, _env_float("JARVIS_FAILOVER_WARMUP_TIMEOUT_S", 180.0))
 
 
+def _heavy_coldstart_mult() -> float:
+    """Multiplier applied to cold-start timeouts when the awakened tier is HEAVY
+    (a large model on a GPU -- e.g. qwen2.5-coder:32b on an L4, which needs minutes
+    to load ~20GB into VRAM, vs seconds for a 7B CPU model). Default 4.0 -> the 180s
+    warmup becomes 720s, the 600s awaken deadline becomes 2400s. Env-tunable; set 1.0
+    to disable."""
+    return max(1.0, _env_float("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", 4.0))
+
+
+def _tier_is_heavy(tier) -> bool:
+    """A tier is heavy if it requests a GPU OR a large (>= threshold-B) model.
+    Derived from the hardware request, not a static flag."""
+    if tier is None:
+        return False
+    try:
+        from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+            model_param_billions,
+        )
+        if getattr(tier, "is_gpu", False):
+            return True
+        thresh = _env_float("JARVIS_FAILOVER_HEAVY_MODEL_B", 14.0)
+        return model_param_billions(getattr(tier, "model_label", "")) >= thresh
+    except Exception:  # noqa: BLE001
+        return False
+
+
+# ---------------------------------------------------------------------------
+# Task HW2 -- Autonomous Diagnostic Reaper
+#
+# When a cold-start node never becomes ready, the boot serial console is the
+# ONE artifact that explains WHY. The reaper reads it BEFORE the delete and
+# classifies the failure so the next ignition is informed, not blind.
+# ---------------------------------------------------------------------------
+
+def _diagnostic_reaper_enabled() -> bool:
+    """Master switch for the Autonomous Diagnostic Reaper. Default ON -- the
+    reaper is read-only + fully fail-soft (it never blocks a teardown), so the
+    only reason to disable it is to silence the extra serial-port REST call."""
+    return _env_str("JARVIS_FAILOVER_DIAGNOSTIC_REAPER_ENABLED", "true").lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+# Failure signatures, scanned in priority order. The FIRST family with a hit
+# wins -- on a GPU cold-start an NVIDIA fault is the actionable root cause even
+# when a downstream OOM/panic also appears, so it is checked first. Each entry
+# is (classification, [case-insensitive substrings]).
+_SERIAL_FAILURE_SIGNATURES = (
+    (
+        "nvidia_driver_fault",
+        (
+            "nvrm:",
+            "nvidia-smi has failed",
+            "failed to initialize nvml",
+            "rminitadapter failed",
+            "no devices were found",
+            "nvidia: probe of",
+        ),
+    ),
+    (
+        "kernel_panic",
+        (
+            "kernel panic",
+            "bug: unable to handle kernel",
+            "not syncing:",
+            "general protection fault",
+        ),
+    ),
+    (
+        "oom",
+        (
+            "out of memory",
+            "oom-killer",
+            "oom_kill",
+            "killed process",
+            "cannot allocate memory",
+        ),
+    ),
+    (
+        "disk_full",
+        (
+            "no space left on device",
+            "disk quota exceeded",
+        ),
+    ),
+)
+
+
+def _classify_serial_output(text: Optional[str]) -> str:
+    """Classify a boot serial console dump into a failure family.
+
+    Returns one of: ``nvidia_driver_fault`` / ``kernel_panic`` / ``oom`` /
+    ``disk_full`` (a matched signature, priority-ordered), ``empty`` (no
+    contents to inspect), or ``unknown`` (contents present, no signature hit).
+    Pure + total -- never raises."""
+    if not text or not text.strip():
+        return "empty"
+    haystack = text.lower()
+    for classification, needles in _SERIAL_FAILURE_SIGNATURES:
+        if any(n in haystack for n in needles):
+            return classification
+    return "unknown"
+
+
+async def _default_serial_port_fn() -> Optional[str]:
+    """Read the failover node's boot serial console via native Compute REST
+    (the same metadata-token bridge as the delete path). Returns the console
+    text, or None if unavailable. Fail-soft -- never raises."""
+    try:
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            get_compute_rest,
+        )
+        contents, detail = await get_compute_rest().get_serial_port_output()
+        if contents is None:
+            logger.debug("[FailoverLifecycle] serial read unavailable (%s)", detail)
+        return contents
+    except Exception as exc:  # noqa: BLE001 -- diagnosis must never crash the loop
+        logger.debug("[FailoverLifecycle] serial read fail-soft err=%r", exc)
+        return None
+
+
 # ---------------------------------------------------------------------------
 # FailoverState
 # ---------------------------------------------------------------------------
@@ -755,9 +876,14 @@ class FailoverLifecycleController:
         flare_fn: Optional[Callable[[Dict[str, Any]], Any]] = None,
         degrade_streak_fn: Optional[Callable[[], int]] = None,
         in_flight_fn: Optional[Callable[[], int]] = None,
+        serial_port_fn: Optional[Callable[[], Any]] = None,
     ) -> None:
         self._vm_awaken_fn = vm_awaken_fn or _default_vm_awaken_fn
         self._vm_delete_fn = vm_delete_fn or _default_vm_delete_fn
+        # Task HW2 -- serial console read boundary for the Autonomous Diagnostic
+        # Reaper. Default: native Compute REST get_serial_port_output. Injectable
+        # for tests (no real GCE touched). Fail-soft -> None on any error.
+        self._serial_port_fn = serial_port_fn or _default_serial_port_fn
         self._dw_probe_fn = dw_probe_fn or _default_dw_probe_fn
         self._node_ready_fn = node_ready_fn or _default_node_ready_fn
         self._clock_fn = clock_fn or _default_clock_fn
@@ -807,6 +933,11 @@ class FailoverLifecycleController:
         # The model label of the actively-provisioned tier (drives model-aware
         # schema compaction). None until a tier is provisioned -> survival default.
         self._active_model_label: Optional[str] = None
+        # The FULL awakened tier object (not just its label) -- drives the adaptive
+        # hardware-aware cold-start timeouts. A heavy 32B/GPU tier earns scaled
+        # awaken/warmup patience; the survival 7B/CPU tier stays byte-identical.
+        # None while DORMANT (no tier awakened) -> scaling never applies.
+        self._awakened_tier: Optional["FailoverTier"] = None
         # Elastic GPU escalation lane (lazily built on first demand). Manages the
         # SECOND, concurrent GPU node lifecycle with crypto-namespaced assets.
         self._gpu_lane: Optional[Any] = None
@@ -1328,6 +1459,75 @@ class FailoverLifecycleController:
         except Exception as exc:  # noqa: BLE001
             logger.debug("[FailoverLifecycle] prime client hot-swap fail-soft err=%r", exc)
 
+    def _adaptive_timeout(self, base_s: float) -> float:
+        """Scale a base cold-start timeout by the heavy multiplier when the tier
+        the FSM actually awakened is heavy (32B/GPU). Survival (7B/CPU) -> base
+        unchanged (byte-identical)."""
+        if _tier_is_heavy(self._awakened_tier):
+            return base_s * _heavy_coldstart_mult()
+        return base_s
+
+    async def _diagnose_before_reap(self) -> str:
+        """Task HW2 -- Autonomous Diagnostic Reaper.
+
+        Read the dying node's boot serial console, classify WHY the cold-start
+        failed (NVIDIA driver fault / kernel panic / OOM / disk-full), and seal
+        that classification into the Cryo-DLQ + a flare so the next ignition is
+        informed. Returns the classification string (``disabled`` if master-off,
+        ``unavailable`` if the serial read failed). FULLY fail-soft -- it MUST
+        NOT raise or block the teardown that follows it (a cost-leak guard)."""
+        if not _diagnostic_reaper_enabled():
+            return "disabled"
+        try:
+            raw = await self._maybe_await(self._serial_port_fn)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[DiagnosticReaper] serial read raised err=%r", exc)
+            raw = None
+            classification = "unavailable"
+        else:
+            classification = _classify_serial_output(raw)
+
+        # Resolve the node name the SAME way the delete path does (env-driven,
+        # not a hardcoded literal) so the diagnosis points at the real instance.
+        node = _env_str("JARVIS_FAILOVER_NODE_NAME", _GCLOUD_NODE_NAME)
+        excerpt = (raw or "")[-2000:]
+        envelope = {
+            "kind": "node_coldstart_diagnosis",
+            "schema_version": 1,
+            "classification": classification,
+            "instance": node,
+            "awakened_model": self._active_model_label or "",
+            "awakened_tier_heavy": _tier_is_heavy(self._awakened_tier),
+            "serial_excerpt": excerpt,
+        }
+        reason = "node_coldstart_failure:{}".format(classification)
+
+        # (a) Seal to the Cryo-DLQ -- the next boot can read WHY the last died.
+        try:
+            from backend.core.ouroboros.governance import intake_dlq  # noqa: PLC0415
+            intake_dlq.append_dlq(envelope, reason=reason)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[DiagnosticReaper] Cryo-DLQ append fail-soft err=%r", exc)
+
+        # (b) Emit an attribution flare for live observability.
+        try:
+            self._flare_fn(
+                {
+                    "event": "coldstart_diagnosis",
+                    "classification": classification,
+                    "reason": reason,
+                    "instance": node,
+                }
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[DiagnosticReaper] flare fail-soft err=%r", exc)
+
+        logger.warning(
+            "[DiagnosticReaper] cold-start failure classified=%s instance=%s "
+            "-- sealed to Cryo-DLQ before reap", classification, node,
+        )
+        return classification
+
     def _build_default_warmup_fn(self) -> Callable[[], Awaitable[bool]]:
         """Build the default warmup callable: LocalPrimeClient pointed at
         the awakened endpoint, calling warmup(timeout_s=_warmup_timeout_s()).
@@ -1341,7 +1541,7 @@ class FailoverLifecycleController:
             LocalPrimeClient,
         )
         endpoint = self._endpoint or self._build_endpoint()
-        timeout = _warmup_timeout_s()
+        timeout = self._adaptive_timeout(_warmup_timeout_s())
 
         import dataclasses  # noqa: PLC0415
         # Build a config that targets the awakened node's base URL.
@@ -1792,11 +1992,14 @@ class FailoverLifecycleController:
             from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
                 resolve_tier,
             )
-            self._active_model_label = resolve_tier(
+            _tier = resolve_tier(
                 urgency=_env_str("JARVIS_FAILOVER_AWAKEN_URGENCY", ""),
                 complexity=_env_str("JARVIS_FAILOVER_AWAKEN_COMPLEXITY", ""),
-            ).model_label
+            )
+            self._awakened_tier = _tier
+            self._active_model_label = _tier.model_label
         except Exception:  # noqa: BLE001
+            self._awakened_tier = None
             self._active_model_label = None
         # IaC ephemeral micro-perimeter: open a /32 hole for THIS orchestrator's
         # detected egress IP so the Reachability Racer's external path can reach
@@ -1885,12 +2088,24 @@ class FailoverLifecycleController:
         awakening_started = self._awakening_started_at
         if awakening_started is not None:
             elapsed = now - awakening_started
-            if elapsed > _awaken_timeout_s():
+            _awaken_deadline = self._adaptive_timeout(_awaken_timeout_s())
+            if elapsed > _awaken_deadline:
                 logger.warning(
-                    "[FailoverLifecycle] AWAKENING timed out after %.1fs -- "
-                    "node never became ready, tearing down + reverting to DORMANT",
+                    "[FailoverLifecycle] AWAKENING timed out after %.1fs "
+                    "(adaptive deadline %.1fs) -- node never became ready, "
+                    "tearing down + reverting to DORMANT",
                     elapsed,
+                    _awaken_deadline,
                 )
+                # Task HW2 -- Autonomous Diagnostic Reaper: read + classify the
+                # boot serial console BEFORE the delete destroys the evidence.
+                # Fail-soft -- a diagnosis error never blocks the reap below.
+                try:
+                    await self._diagnose_before_reap()
+                except Exception as exc:  # noqa: BLE001
+                    logger.debug(
+                        "[FailoverLifecycle] diagnostic reaper fail-soft err=%r", exc
+                    )
                 # PARALLEL teardown (fail-soft): node delete + ephemeral firewall
                 # close together -- zero orphan nodes AND zero orphan firewall holes.
                 try:
@@ -1910,6 +2125,7 @@ class FailoverLifecycleController:
                 self._state = FailoverState.DORMANT
                 self._awakening_started_at = None
                 self._endpoint = None
+                self._awakened_tier = None  # drop the stale tier (no inflated re-awaken)
                 self._last_handback_at = now
                 return
 
@@ -1951,7 +2167,7 @@ class FailoverLifecycleController:
                 logger.warning(
                     "[FailoverLifecycle] warmup did not confirm within %.0fs "
                     "-- proceeding to SERVING (first op may be cold)",
-                    _warmup_timeout_s(),
+                    self._adaptive_timeout(_warmup_timeout_s()),
                 )
 
         # Gap 3a -- WIRE the awakened node's reachable endpoint to PrimeClient
@@ -2186,6 +2402,7 @@ class FailoverLifecycleController:
 
         # 4. DORMANT + arm anti-thrash cooldown.
         self._state = FailoverState.DORMANT
+        self._awakened_tier = None  # drop the awakened tier on handback
         self._awakening_started_at = None
         self._serving_started_at = None
         self._last_probe_at = None
@@ -2295,6 +2512,7 @@ class FailoverLifecycleController:
             # 3. DORMANT + arm the anti-thrash cooldown anchor + drop the endpoint so
             #    is_jprime_serving()/jprime_endpoint() stop pointing at the dead node.
             self._state = FailoverState.DORMANT
+            self._awakened_tier = None  # drop the awakened tier on violent teardown
             self._last_handback_at = self._clock_fn()  # arm anti-thrash cooldown
             self._endpoint = None
             logger.info("[FailoverFlare] VIOLENT TEARDOWN complete -- DORMANT, cooldown armed")

--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -974,6 +974,44 @@ class GCPComputeRest:
         )
         return (False, "DELETE_FAILED:{}".format(status))
 
+    async def get_serial_port_output(
+        self, name: Optional[str] = None, *, zone: Optional[str] = None, port: int = 1,
+    ) -> Tuple[Optional[str], str]:
+        """GET instances/<name>/serialPort?port=<port> via the SAME REST contract
+        as the dead-man delete -- reads the node's boot serial console for the
+        Autonomous Diagnostic Reaper (Task HW2). Returns (contents, detail):
+        (text, "ok:200") on success, (None, "<LOCUS>:..") on any failure.
+        Fail-CLOSED -- NEVER raises."""
+        token = await self.access_token()
+        if not token:
+            return (None, "AUTH_TOKEN_UNAVAILABLE:metadata_unreachable")
+        zone = zone or await self.zone()
+        project = await self.project()
+        if not zone or not project:
+            return (
+                None,
+                "IDENTITY_UNRESOLVED:zone={!r}:project={!r}".format(zone, project),
+            )
+        node = name or _node_name()
+        url = "{}/projects/{}/zones/{}/instances/{}/serialPort?port={}".format(
+            _COMPUTE_BASE, project, zone, node, int(port),
+        )
+        headers = {"Authorization": "Bearer {}".format(token)}
+        status, text = await _http_request(
+            url, method="GET", headers=headers, timeout_s=_rest_timeout(),
+        )
+        if 200 <= status < 300:
+            try:
+                contents = json.loads(text).get("contents", "") if text else ""
+            except Exception:  # noqa: BLE001 -- malformed body is still fail-soft
+                contents = text or ""
+            return (contents, "ok:{}".format(status))
+        logger.warning(
+            "[GCPComputeRest] serialPort read failed node=%s status=%s detail=%s",
+            node, status, (text or "")[-200:],
+        )
+        return (None, "SERIAL_READ_FAILED:{}".format(status))
+
     # -- ephemeral firewall micro-perimeter (IaC, same REST bridge) -------
 
     async def create_firewall_rule(

--- a/tests/governance/test_adaptive_coldstart_timeout.py
+++ b/tests/governance/test_adaptive_coldstart_timeout.py
@@ -1,0 +1,192 @@
+"""Task HW1 -- adaptive hardware-aware cold-start timeouts.
+
+A heavy 32B/L4 node needs minutes to load ~20GB into VRAM, but the FSM's
+cold-start deadlines (awaken self-heal 600s, warmup 180s) were sized for a 7B
+CPU survival node -- so the heavy node got reaped before it finished loading.
+These tests prove the patience is DERIVED from the awakened tier's heaviness
+(GPU OR large model), that the survival/CPU path stays byte-identical (the
+multiplier never applies), and that the tier is persisted + reset correctly.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import provider_quarantine as pq
+from backend.core.ouroboros.governance.failover_lifecycle import (
+    FailoverLifecycleController,
+    FailoverState,
+)
+from backend.core.ouroboros.governance.failover_tier import FailoverTier
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers (mirror tests/governance/test_failover_budget_awaken.py)
+# ---------------------------------------------------------------------------
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+def _make_ctrl(clock, awakens=None, flares=None, **kw):
+    awakens = awakens if awakens is not None else []
+    flares = flares if flares is not None else []
+
+    def _awaken(*, startup_script):
+        awakens.append(startup_script)
+        return True
+
+    defaults = dict(
+        vm_awaken_fn=_awaken,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+        is_degrading_fn=lambda: False,
+        flare_fn=lambda payload: flares.append(payload),
+    )
+    defaults.update(kw)
+    return FailoverLifecycleController(**defaults)
+
+
+def _heavy_tier() -> FailoverTier:
+    return FailoverTier(
+        name="quality",
+        machine_type="g2-standard-4",
+        image_family="x",
+        model_label="qwen2.5-coder:32b",
+        accelerator_type="nvidia-l4",
+        accelerator_count=1,
+    )
+
+
+def _survival_tier() -> FailoverTier:
+    return FailoverTier(
+        name="survival",
+        machine_type="g2-standard-4",
+        image_family="x",
+        model_label="qwen2.5-coder:7b",
+    )
+
+
+# ---------------------------------------------------------------------------
+# _tier_is_heavy: derived from the hardware request, not a static flag
+# ---------------------------------------------------------------------------
+
+def test_tier_is_heavy():
+    assert fl._tier_is_heavy(_heavy_tier()) is True
+    assert fl._tier_is_heavy(_survival_tier()) is False
+    assert fl._tier_is_heavy(None) is False
+
+
+def test_tier_is_heavy_large_cpu_model(monkeypatch):
+    # No GPU but a large model (>= 14B threshold) -> still heavy.
+    big_cpu = FailoverTier(
+        name="quality",
+        machine_type="e2-highmem-8",
+        image_family="x",
+        model_label="qwen2.5-coder:32b",
+    )
+    assert fl._tier_is_heavy(big_cpu) is True
+    # A 7B model under the threshold is not heavy.
+    assert fl._tier_is_heavy(_survival_tier()) is False
+
+
+# ---------------------------------------------------------------------------
+# _adaptive_timeout scales for heavy, byte-identical for survival/None
+# ---------------------------------------------------------------------------
+
+def test_adaptive_timeout_scales_for_heavy(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+
+    ctrl._awakened_tier = _heavy_tier()
+    assert ctrl._adaptive_timeout(180.0) == 720.0  # 180 * 4.0
+
+    ctrl._awakened_tier = _survival_tier()
+    assert ctrl._adaptive_timeout(180.0) == 180.0  # byte-identical
+
+    ctrl._awakened_tier = None
+    assert ctrl._adaptive_timeout(180.0) == 180.0  # byte-identical
+
+    # Tunable multiplier: bump to 5.0 -> heavy scales accordingly.
+    monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "5.0")
+    ctrl._awakened_tier = _heavy_tier()
+    assert ctrl._adaptive_timeout(180.0) == 900.0
+
+
+def test_mult_one_disables(monkeypatch):
+    monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "1.0")
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    ctrl._awakened_tier = _heavy_tier()
+    assert ctrl._adaptive_timeout(180.0) == 180.0
+
+
+# ---------------------------------------------------------------------------
+# _do_awaken persists the WHOLE tier object, not just the label
+# ---------------------------------------------------------------------------
+
+async def test_do_awaken_persists_tier(monkeypatch):
+    # Arm the quality tier so resolve_tier returns the heavy 32B/GPU spec.
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_TIER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_AWAKEN_URGENCY", "immediate")
+    monkeypatch.setenv("JARVIS_FAILOVER_AWAKEN_COMPLEXITY", "complex")
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    assert ctrl._awakened_tier is None
+
+    await ctrl._do_awaken()
+
+    assert isinstance(ctrl._awakened_tier, FailoverTier)
+    assert ctrl._awakened_tier.is_gpu is True
+    assert ctrl._active_model_label == ctrl._awakened_tier.model_label
+    assert fl._tier_is_heavy(ctrl._awakened_tier) is True
+
+
+async def test_do_awaken_survival_tier_not_heavy(monkeypatch):
+    # Quality gate OFF (default) -> survival 7B/CPU tier -> not heavy.
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    await ctrl._do_awaken()
+    assert isinstance(ctrl._awakened_tier, FailoverTier)
+    assert ctrl._awakened_tier.is_gpu is False
+    assert fl._tier_is_heavy(ctrl._awakened_tier) is False
+    assert ctrl._adaptive_timeout(600.0) == 600.0  # byte-identical
+
+
+# ---------------------------------------------------------------------------
+# A return to DORMANT nulls the awakened tier (no stale heavy inflation)
+# ---------------------------------------------------------------------------
+
+async def test_dormant_resets_tier(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    # Simulate an awakened heavy tier sitting in AWAKENING.
+    ctrl._awakened_tier = _heavy_tier()
+    ctrl._state = FailoverState.AWAKENING
+    ctrl._awakening_started_at = clock.t
+    # Push the clock past the (adaptive) self-heal deadline so the reap fires.
+    clock.t += ctrl._adaptive_timeout(fl._awaken_timeout_s()) + 10.0
+
+    await ctrl._tick_awakening(now=clock.t)
+
+    assert ctrl.state == FailoverState.DORMANT
+    assert ctrl._awakened_tier is None

--- a/tests/governance/test_coldstart_diagnostic_reaper.py
+++ b/tests/governance/test_coldstart_diagnostic_reaper.py
@@ -1,0 +1,257 @@
+"""Task HW2 -- Autonomous Diagnostic Reaper.
+
+When a heavy cold-start node never goes green (AWAKENING times out / L7 never
+serves), blindly deleting it throws away the ONE artifact that explains WHY it
+failed: the boot serial console. These tests prove the FSM autonomously reads
+``get_serial_port_output`` BEFORE issuing the delete, classifies the failure
+(NVIDIA driver fault / kernel panic / OOM / disk-full), and seals that
+classification into the Cryo-DLQ + a flare -- so the next ignition is informed,
+not blind. The reaper is fail-soft (never blocks the teardown) and gated by a
+master switch.
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl
+from backend.core.ouroboros.governance import intake_dlq
+from backend.core.ouroboros.governance import provider_quarantine as pq
+from backend.core.ouroboros.governance.failover_lifecycle import (
+    FailoverLifecycleController,
+    FailoverState,
+)
+from backend.core.ouroboros.governance.failover_tier import FailoverTier
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+class FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+
+@pytest.fixture(autouse=True)
+def _fresh(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    monkeypatch.setenv("JARVIS_FAILOVER_LIFECYCLE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAILOVER_ROUTE", "dw")
+    monkeypatch.setenv("JARVIS_FAILOVER_ANY_ROUTE_OUTAGE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FAILOVER_EARLY_PREWARM_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FAILOVER_DIAGNOSTIC_REAPER_ENABLED", "true")
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+@pytest.fixture
+def dlq_capture(monkeypatch):
+    """Capture every Cryo-DLQ write, bypassing the JARVIS_INTAKE_DLQ_ENABLED
+    gate, with auto-restore (monkeypatch) so it never pollutes sibling files."""
+    sink: list = []
+
+    def _append_dlq(envelope, *, reason, path=None):
+        sink.append((envelope, reason))
+
+    monkeypatch.setattr(intake_dlq, "append_dlq", _append_dlq)
+    return sink
+
+
+def _make_ctrl(clock, *, serial=None, serial_raises=False, calls=None, **kw):
+    flares = kw.pop("flares", [])
+
+    def _serial_port_fn():
+        if calls is not None:
+            calls.append("serial")
+        if serial_raises:
+            raise RuntimeError("metadata unreachable")
+        return serial
+
+    def _delete():
+        if calls is not None:
+            calls.append("delete")
+        return True
+
+    defaults = dict(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=_delete,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: False,
+        clock_fn=clock,
+        is_degrading_fn=lambda: False,
+        flare_fn=lambda payload: flares.append(payload),
+        serial_port_fn=_serial_port_fn,
+    )
+    defaults.update(kw)
+    ctrl = FailoverLifecycleController(**defaults)
+    ctrl._captured_flares = flares  # type: ignore[attr-defined]
+    return ctrl
+
+
+def _heavy_tier() -> FailoverTier:
+    return FailoverTier(
+        name="quality",
+        machine_type="g2-standard-4",
+        image_family="x",
+        model_label="qwen2.5-coder:32b",
+        accelerator_type="nvidia-l4",
+        accelerator_count=1,
+    )
+
+
+# Representative serial console fragments (trimmed real-world boot logs).
+_NVIDIA = (
+    "[   42.118] NVRM: GPU 0000:00:04.0: RmInitAdapter failed! (0x26:0xffff:1456)\n"
+    "[   42.119] NVRM: rm_init_adapter failed for device bearing minor number 0\n"
+    "nvidia-smi: NVIDIA-SMI has failed because it couldn't communicate with the "
+    "NVIDIA driver.\n"
+)
+_PANIC = (
+    "[   13.882] Kernel panic - not syncing: VFS: Unable to mount root fs on "
+    "unknown-block(0,0)\n[   13.883] CPU: 0 PID: 1 Comm: swapper/0 Not tainted\n"
+)
+_OOM = (
+    "[  301.55] Out of memory: Killed process 1442 (ollama) total-vm:24190000kB\n"
+    "[  301.56] oom-killer: gfp_mask=0x..., order=0\n"
+)
+_DISK = "[   88.1] write error: No space left on device\n"
+_BENIGN = "[    0.00] Linux version 6.1.0\n[    2.31] systemd[1]: Reached target.\n"
+
+
+# ---------------------------------------------------------------------------
+# _classify_serial_output -- pure classifier, priority-ordered
+# ---------------------------------------------------------------------------
+
+def test_classify_nvidia_driver_fault():
+    assert fl._classify_serial_output(_NVIDIA) == "nvidia_driver_fault"
+
+
+def test_classify_kernel_panic():
+    assert fl._classify_serial_output(_PANIC) == "kernel_panic"
+
+
+def test_classify_oom():
+    assert fl._classify_serial_output(_OOM) == "oom"
+
+
+def test_classify_disk_full():
+    assert fl._classify_serial_output(_DISK) == "disk_full"
+
+
+def test_classify_empty():
+    assert fl._classify_serial_output(None) == "empty"
+    assert fl._classify_serial_output("") == "empty"
+    assert fl._classify_serial_output("   \n  ") == "empty"
+
+
+def test_classify_unknown():
+    assert fl._classify_serial_output(_BENIGN) == "unknown"
+
+
+def test_classify_priority_nvidia_beats_oom():
+    # On a GPU cold-start, an NVIDIA fault is the actionable root cause even when
+    # an OOM also appears downstream -- the GPU classification must win.
+    both = _OOM + _NVIDIA
+    assert fl._classify_serial_output(both) == "nvidia_driver_fault"
+
+
+# ---------------------------------------------------------------------------
+# _diagnose_before_reap -- reads serial, classifies, seals to Cryo-DLQ + flare
+# ---------------------------------------------------------------------------
+
+async def test_diagnose_seals_classification_to_cryo_dlq(dlq_capture):
+    dlq = dlq_capture
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock, serial=_NVIDIA)
+    ctrl._awakened_tier = _heavy_tier()
+
+    classification = await ctrl._diagnose_before_reap()
+
+    assert classification == "nvidia_driver_fault"
+    assert len(dlq) == 1
+    envelope, reason = dlq[0]
+    assert reason == "node_coldstart_failure:nvidia_driver_fault"
+    assert envelope["classification"] == "nvidia_driver_fault"
+    # The serial excerpt must be carried so the diagnosis is auditable.
+    assert "NVRM" in envelope["serial_excerpt"]
+
+
+async def test_diagnose_emits_flare(dlq_capture):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock, serial=_PANIC)
+
+    await ctrl._diagnose_before_reap()
+
+    flares = ctrl._captured_flares  # type: ignore[attr-defined]
+    assert any(
+        f.get("classification") == "kernel_panic" for f in flares
+    ), flares
+
+
+async def test_diagnose_fail_soft_when_serial_unavailable(dlq_capture):
+    # Serial read raises (metadata unreachable) -> classified 'unavailable',
+    # NEVER raises, and still seals a record so the teardown is auditable.
+    dlq = dlq_capture
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock, serial_raises=True)
+
+    classification = await ctrl._diagnose_before_reap()
+
+    assert classification == "unavailable"
+    assert dlq and dlq[0][1] == "node_coldstart_failure:unavailable"
+
+
+async def test_diagnose_disabled_skips_serial_read(dlq_capture, monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_DIAGNOSTIC_REAPER_ENABLED", "false")
+    clock = FakeClock()
+    calls: list = []
+    ctrl = _make_ctrl(clock, serial=_NVIDIA, calls=calls)
+
+    classification = await ctrl._diagnose_before_reap()
+
+    assert classification == "disabled"
+    assert "serial" not in calls  # no serial read when master-off
+    assert dlq_capture == []
+
+
+# ---------------------------------------------------------------------------
+# Integration: AWAKENING timeout invokes the reaper BEFORE the delete
+# ---------------------------------------------------------------------------
+
+async def test_awakening_timeout_diagnoses_before_delete(dlq_capture):
+    dlq = dlq_capture
+    clock = FakeClock()
+    calls: list = []
+    ctrl = _make_ctrl(clock, serial=_NVIDIA, calls=calls)
+    ctrl._awakened_tier = _heavy_tier()
+    ctrl._state = FailoverState.AWAKENING
+    ctrl._awakening_started_at = clock.t
+    # Push past the (adaptive, heavy-scaled) self-heal deadline.
+    clock.t += ctrl._adaptive_timeout(fl._awaken_timeout_s()) + 10.0
+
+    await ctrl._tick_awakening(now=clock.t)
+
+    # The serial read MUST precede the delete -- diagnose, then reap.
+    assert calls.index("serial") < calls.index("delete"), calls
+    assert ctrl.state == FailoverState.DORMANT
+    assert dlq and dlq[0][1] == "node_coldstart_failure:nvidia_driver_fault"
+
+
+async def test_awakening_timeout_still_reaps_when_diagnosis_raises(dlq_capture):
+    # Even if diagnosis blows up, the node is STILL deleted (cost-leak guard).
+    clock = FakeClock()
+    calls: list = []
+    ctrl = _make_ctrl(clock, serial_raises=True, calls=calls)
+    ctrl._state = FailoverState.AWAKENING
+    ctrl._awakening_started_at = clock.t
+    clock.t += ctrl._adaptive_timeout(fl._awaken_timeout_s()) + 10.0
+
+    await ctrl._tick_awakening(now=clock.t)
+
+    assert "delete" in calls
+    assert ctrl.state == FailoverState.DORMANT

--- a/tests/governance/test_gcp_compute_rest.py
+++ b/tests/governance/test_gcp_compute_rest.py
@@ -307,6 +307,45 @@ async def test_delete_instance_no_token_fails_closed(monkeypatch, http):
 
 
 # ---------------------------------------------------------------------------
+# Task HW2 -- serial console read for the Autonomous Diagnostic Reaper.
+# ---------------------------------------------------------------------------
+
+async def test_serial_port_output_reads_contents(http):
+    http.get_responses = [(200, json.dumps({"contents": "NVRM: RmInitAdapter failed!"}))]
+    c = GCPComputeRest()
+    contents, detail = await c.get_serial_port_output()
+    assert contents == "NVRM: RmInitAdapter failed!"
+    assert detail == "ok:200"
+    get = [call for call in http.calls
+           if call["method"] == "GET" and "serialPort" in call["url"]][0]
+    assert get["url"] == (
+        "https://compute.googleapis.com/compute/v1/projects/my-test-project"
+        "/zones/us-west2-b/instances/jarvis-prime-failover/serialPort?port=1"
+    )
+    assert get["headers"]["Authorization"] == "Bearer ya29.FAKE"
+
+
+async def test_serial_port_output_no_token_fails_closed(monkeypatch, http):
+    async def _no_token(url, **kw):
+        if url.endswith("/token"):
+            return (0, "")
+        return (200, "")
+    monkeypatch.setattr(gr, "_http_request", _no_token)
+    c = GCPComputeRest()
+    contents, detail = await c.get_serial_port_output()
+    assert contents is None
+    assert detail.startswith("AUTH_TOKEN_UNAVAILABLE")
+
+
+async def test_serial_port_output_5xx_fails_soft(http):
+    http.get_responses = [(503, "backend error")]
+    c = GCPComputeRest()
+    contents, detail = await c.get_serial_port_output()
+    assert contents is None
+    assert detail == "SERIAL_READ_FAILED:503"
+
+
+# ---------------------------------------------------------------------------
 # No hardcoding guard: identity is fully metadata-driven.
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## What

Two advanced constraints on the `FailoverLifecycleController` so a heavy 32B/L4 J-Prime node survives **and self-diagnoses** its cold start — no hardcoded patience, no passive logs.

### HW1 — Adaptive hardware-aware timeouts
- Persist the **whole** awakened `FailoverTier` (not just its label) at `_do_awaken`.
- `_tier_is_heavy()` derives heaviness from the hardware request (GPU **or** `>= JARVIS_FAILOVER_HEAVY_MODEL_B` model) — never a static flag.
- `_adaptive_timeout()` scales awaken/warmup deadlines by `JARVIS_JPRIME_HEAVY_COLDSTART_MULT` (default `4.0`) **only** for heavy tiers; the 7B/CPU survival path stays byte-identical. Tier nulled on every DORMANT transition (no stale inflation).

### HW2 — Autonomous Diagnostic Reaper
- `GCPComputeRest.get_serial_port_output()` reads the boot serial console via the same metadata-token REST bridge as the dead-man delete (fail-closed, never raises).
- `_classify_serial_output()` priority-classifies the failure: `nvidia_driver_fault` > `kernel_panic` > `oom` > `disk_full` > `empty`/`unknown`.
- `_diagnose_before_reap()` reads + classifies **before** the delete destroys the evidence, then seals the classification to the **Cryo-DLQ** + an attribution flare. Fully fail-soft — a diagnosis error **never** blocks the teardown (cost-leak guard). Master switch `JARVIS_FAILOVER_DIAGNOSTIC_REAPER_ENABLED` (default `true`).
- Wired into the AWAKENING-timeout (L7-never-green) teardown path.

## Tests (TDD)
- `test_adaptive_coldstart_timeout.py` — 7 (HW1)
- `test_coldstart_diagnostic_reaper.py` — 13 (HW2)
- `test_gcp_compute_rest.py` — +3 (REST serial read)

All green in isolated processes. (Note: the failover suite has a pre-existing `importlib.reload` enum-identity pollution in `test_failover_lifecycle.py` that breaks unrelated failover files when run in the same session — orthogonal to this change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes heavy 32B/GPU cold starts reliable and self-diagnosing. Timeouts now adapt to hardware, and a diagnostic reaper captures boot console root-cause before teardown.

- **New Features**
  - Adaptive cold-start timeouts in `FailoverLifecycleController`: persists the awakened tier; treats a tier as heavy if GPU or model size ≥ `JARVIS_FAILOVER_HEAVY_MODEL_B`; scales awaken/warmup deadlines by `JARVIS_JPRIME_HEAVY_COLDSTART_MULT` (default 4.0); survival/CPU path unchanged; tier cleared on DORMANT.
  - Autonomous diagnostic reaper: `GCPComputeRest.get_serial_port_output()` reads the boot serial console; output is classified (nvidia_driver_fault > kernel_panic > oom > disk_full > empty/unknown); runs before delete on AWAKENING timeout; writes to Cryo-DLQ and emits a flare; fully fail-soft and gated by `JARVIS_FAILOVER_DIAGNOSTIC_REAPER_ENABLED` (default on).

<sup>Written for commit f5c02f5328307e17eebf7ccbc3bebc7024ad91eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69781?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

