### PR TITLE
fix(a1): fail-closed insert-op verification — kill phantom-node fail-open

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -247,9 +247,18 @@ def _rest_timeout() -> float:
 
 
 def _insert_op_poll_cap_s() -> float:
-    """Max seconds to poll a zonal insert operation for a STOCKOUT before letting
-    the readiness racer take over. A GPU stockout errors within a few seconds."""
-    return _env_float("JARVIS_INSERT_OP_POLL_CAP_S", 25.0, lo=0.0, hi=120.0)
+    """ABSOLUTE safety ceiling (seconds) for polling a zonal insert operation to a
+    TERMINAL state. The control-plane operation reaches DONE within seconds-to-tens
+    normally (a GPU capacity failure surfaces AS the op completing with error), so a
+    generous ceiling makes a breach a genuine anomaly. On breach the verdict is
+    'unknown' (fail-closed phantom protection) -- NEVER an optimistic 'ok'."""
+    return _env_float("JARVIS_INSERT_OP_POLL_CAP_S", 90.0, lo=0.0, hi=600.0)
+
+
+def _insert_op_poll_interval_s() -> float:
+    """Delay between insert-operation status polls. Env-tunable (no hardcoded
+    cadence); floored > 0 so the poll loop always makes progress."""
+    return _env_float("JARVIS_INSERT_OP_POLL_INTERVAL_S", 3.0, lo=0.001, hi=60.0)
 
 
 def _running_timeout() -> float:
@@ -722,23 +731,43 @@ class GCPComputeRest:
             )
             mode = "SPOT" if spot else "on-demand"
             if 200 <= status < 300:
-                # The insert returns a PENDING operation; a GPU STOCKOUT surfaces
-                # when it runs. Track the operation to catch it (skip if untrackable).
+                # The insert returns a PENDING operation; a GPU STOCKOUT (or other
+                # async failure) surfaces only when the operation RUNS. We MUST poll
+                # it to a terminal state -- an accepted insert is NOT a created node.
                 op = None
                 try:
                     op = json.loads(text or "{}").get("name")
                 except Exception:  # noqa: BLE001
                     op = None
-                if op:
-                    verdict = await self._await_insert_operation(project, zone, op, token)
-                    if verdict == "stockout":
-                        if spot and _ondemand_on_stockout_enabled():
-                            logger.warning("[GCPComputeRest] SPOT stockout zone=%s -> trying ON-DEMAND same zone (quota'd region)", zone)
-                            continue
-                        return ("stockout", "zone={}:op_stockout".format(zone))
-                    if verdict == "error":
-                        logger.warning("[GCPComputeRest] insert op error zone=%s mode=%s", zone, mode)
-                        continue  # try on-demand
+                # No trackable operation name -> we cannot verify the outcome.
+                # Fail-closed: treat exactly like 'unknown' (reap + roll), never 'ok'.
+                verdict = (
+                    await self._await_insert_operation(project, zone, op, token)
+                    if op else "unknown"
+                )
+                if verdict == "stockout":
+                    if spot and _ondemand_on_stockout_enabled():
+                        logger.warning("[GCPComputeRest] SPOT stockout zone=%s -> trying ON-DEMAND same zone (quota'd region)", zone)
+                        continue
+                    return ("stockout", "zone={}:op_stockout".format(zone))
+                if verdict == "unknown":
+                    # Fail-closed phantom protection: a node may have spawned late
+                    # even though we never saw DONE. Violently reap it BEFORE moving
+                    # on (idempotent; 404 == already gone), then roll the chain.
+                    logger.warning(
+                        "[GCPComputeRest] insert UNVERIFIED zone=%s mode=%s -> reaping "
+                        "any phantom node + rolling to next zone", zone, mode,
+                    )
+                    try:
+                        await self.delete_instance(node, zone=zone)
+                    except Exception as exc:  # noqa: BLE001 -- reap is best-effort
+                        logger.debug("[GCPComputeRest] phantom reap fail-soft err=%r", exc)
+                    if spot and _ondemand_on_stockout_enabled():
+                        continue  # escalate to on-demand same zone first
+                    return ("stockout", "zone={}:unknown_reaped".format(zone))
+                if verdict == "error":
+                    logger.warning("[GCPComputeRest] insert op error zone=%s mode=%s", zone, mode)
+                    continue  # try on-demand
                 logger.info("[GCPComputeRest] instances.insert ok node=%s zone=%s mode=%s",
                             node, zone, mode)
                 return ("created", "zone={}:mode={}".format(zone, mode))
@@ -753,32 +782,55 @@ class GCPComputeRest:
         return ("failed", "zone={}:spot_and_on_demand_rejected".format(zone))
 
     async def _await_insert_operation(self, project, zone, op_name, token) -> str:
-        """Poll a zonal insert operation to DONE (bounded). Returns 'ok' |
-        'stockout' | 'error'. A timeout -> 'ok' (the readiness racer is the real
-        gate). NEVER raises."""
+        """Poll a zonal insert operation to a TERMINAL state. FAIL-CLOSED.
+
+        Returns:
+          'ok'       -- operations.get returned status=DONE with NO error object
+                        (the ONLY success path -- explicit terminal confirmation).
+          'stockout' -- DONE with a transient capacity error (retry the next zone).
+          'error'    -- DONE with a non-stockout error (stop the chain).
+          'unknown'  -- the absolute safety ceiling was breached WITHOUT a confirmed
+                        DONE, or operations.get was unreachable throughout. The
+                        operation's outcome is genuinely unverified -- the caller
+                        must assume a phantom node may exist (reap) and roll over.
+                        NEVER an optimistic 'ok'.
+
+        NEVER raises."""
         from backend.core.ouroboros.governance.zone_fallback import (  # noqa: PLC0415
             is_stockout_error,
         )
         url = "{}/projects/{}/zones/{}/operations/{}".format(_COMPUTE_BASE, project, zone, op_name)
         cap = _insert_op_poll_cap_s()
+        interval = _insert_op_poll_interval_s()
         waited = 0.0
         while waited < cap:
             status, text = await _http_request(
                 url, method="GET", headers={"Authorization": "Bearer {}".format(token)},
                 timeout_s=30.0,
             )
-            try:
-                op = json.loads(text or "{}")
-            except Exception:  # noqa: BLE001
-                op = {}
-            if op.get("status") == "DONE":
-                err = op.get("error")
-                if not err:
-                    return "ok"
-                return "stockout" if is_stockout_error(json.dumps(err)) else "error"
-            await asyncio.sleep(3)
-            waited += 3
-        return "ok"  # still running at the cap -> let the readiness racer decide
+            # Only a successfully-fetched, parseable, DONE response is terminal.
+            # A non-2xx fetch / unparseable body is NOT terminal -> keep polling
+            # (it may be transient); if it persists to the ceiling -> 'unknown'.
+            if 200 <= status < 300:
+                try:
+                    op = json.loads(text or "{}")
+                except Exception:  # noqa: BLE001
+                    op = {}
+                if op.get("status") == "DONE":
+                    err = op.get("error")
+                    if not err:
+                        return "ok"
+                    return "stockout" if is_stockout_error(json.dumps(err)) else "error"
+            await asyncio.sleep(interval)
+            waited += interval
+        # Ceiling breached without a confirmed terminal DONE. We do NOT know whether
+        # a node spawned -> fail-closed 'unknown' (the caller reaps + rolls over).
+        logger.warning(
+            "[GCPComputeRest] insert op UNVERIFIED after %.1fs (no terminal DONE) "
+            "zone=%s op=%s -> 'unknown' (fail-closed; will reap + roll zone)",
+            cap, zone, op_name,
+        )
+        return "unknown"
 
     # -- poll-to-RUNNING + internal-IP extraction ------------------------
 

--- a/tests/governance/test_gcp_compute_rest.py
+++ b/tests/governance/test_gcp_compute_rest.py
@@ -51,6 +51,8 @@ class FakeHTTP:
         }))]
         self._get_idx = 0
         self.delete_response = (200, json.dumps({"name": "op-delete"}))
+        # Insert-operation poll: DONE + no error == insert succeeded (terminal).
+        self.operation_response = (200, json.dumps({"status": "DONE"}))
 
     async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
         self.calls.append({"url": url, "method": method, "headers": headers, "body": body})
@@ -71,6 +73,11 @@ class FakeHTTP:
                 resp = self.insert_responses[min(self._insert_idx, len(self.insert_responses) - 1)]
                 self._insert_idx += 1
                 return resp
+            # Zonal operation poll (insert-op terminal-state verification): a
+            # DONE-with-no-error operation == the insert succeeded. Distinct from
+            # the instances.get poll below (which returns RUNNING + the IP).
+            if method == "GET" and "/operations/" in url:
+                return self.operation_response
             if method == "GET":
                 resp = self.get_responses[min(self._get_idx, len(self.get_responses) - 1)]
                 self._get_idx += 1
@@ -162,7 +169,7 @@ async def test_create_instance_builds_correct_payload_and_url(http, monkeypatch)
     c = GCPComputeRest()
     ok, detail = await c.create_instance(startup_script="#!/bin/bash\necho hi")
     assert ok is True
-    assert detail.startswith("created:SPOT")
+    assert "mode=SPOT" in detail  # detail == "created:zone=us-west2-b:mode=SPOT"
 
     post = [call for call in http.calls if call["method"] == "POST"][0]
     # Zone-correct URL -- zone came from metadata (us-west2-b), NOT a literal.
@@ -195,7 +202,7 @@ async def test_create_instance_spot_fails_falls_back_to_on_demand(http):
     c = GCPComputeRest()
     ok, detail = await c.create_instance(startup_script="x")
     assert ok is True
-    assert detail.startswith("created:on-demand")
+    assert "mode=on-demand" in detail  # detail == "created:zone=...:mode=on-demand"
     posts = [call for call in http.calls if call["method"] == "POST"]
     assert len(posts) == 2
     # First was Spot, second on-demand (no scheduling block).

--- a/tests/governance/test_insert_op_failclosed.py
+++ b/tests/governance/test_insert_op_failclosed.py
@@ -1,0 +1,248 @@
+"""Fail-closed insert-operation verification (phantom-node protection).
+
+The A1-on-32B soak halted on a PHANTOM node: an on-demand L4 insert whose async
+operation took ~31s to surface ZONE_RESOURCE_POOL_EXHAUSTED, but the 25s poll cap
+expired first and ``_await_insert_operation`` returned an optimistic ``"ok"``. The
+FSM went AWAKENING on a node GCE then rolled back, and the zone chain never tried
+the next zone.
+
+These tests pin the fail-closed contract:
+  1. Terminal-state verification -- ``"ok"`` ONLY on operations.get status=DONE
+     with NO error object.
+  2. Phantom protection -- a breached safety ceiling (or an unreachable API)
+     returns ``"unknown"``, NEVER an optimistic ``"ok"``.
+  3. Multi-zonal rollover -- an ``"unknown"`` makes _insert_in_zone reap any late
+     phantom (delete_instance) and return ``"stockout"`` so create_instance
+     advances to the next zone.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import backend.core.ouroboros.governance.gcp_compute_rest as gr
+from backend.core.ouroboros.governance.gcp_compute_rest import GCPComputeRest
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture(autouse=True)
+def _fast_poll(monkeypatch):
+    # Tiny cap + interval so the poll loop is fast + deterministic.
+    monkeypatch.setenv("JARVIS_INSERT_OP_POLL_CAP_S", "0.05")
+    monkeypatch.setenv("JARVIS_INSERT_OP_POLL_INTERVAL_S", "0.001")
+
+
+def _op(status, *, error=None):
+    body = {"status": status}
+    if error is not None:
+        body["error"] = error
+    return (200, json.dumps(body))
+
+
+_STOCKOUT_ERR = {"errors": [{"code": "ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS"}]}
+_QUOTA_ERR = {"errors": [{"code": "QUOTA_EXCEEDED"}]}
+
+
+class _ScriptedGET:
+    """Returns scripted operations.get responses in order; records calls."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = 0
+
+    async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        i = min(self.calls, len(self._responses) - 1)
+        self.calls += 1
+        return self._responses[i]
+
+
+# ---------------------------------------------------------------------------
+# _await_insert_operation -- terminal-state verification
+# ---------------------------------------------------------------------------
+
+async def test_await_ok_only_on_done_no_error(monkeypatch):
+    monkeypatch.setattr(gr, "_http_request", _ScriptedGET([_op("DONE")]))
+    v = await GCPComputeRest()._await_insert_operation("p", "z", "op-1", "tok")
+    assert v == "ok"
+
+
+async def test_await_stockout_on_done_with_stockout_error(monkeypatch):
+    monkeypatch.setattr(gr, "_http_request", _ScriptedGET([_op("DONE", error=_STOCKOUT_ERR)]))
+    v = await GCPComputeRest()._await_insert_operation("p", "z", "op-1", "tok")
+    assert v == "stockout"
+
+
+async def test_await_error_on_done_with_nonstockout_error(monkeypatch):
+    monkeypatch.setattr(gr, "_http_request", _ScriptedGET([_op("DONE", error=_QUOTA_ERR)]))
+    v = await GCPComputeRest()._await_insert_operation("p", "z", "op-1", "tok")
+    assert v == "error"
+
+
+async def test_await_polls_through_running_until_done(monkeypatch):
+    # RUNNING twice, then DONE+no-error -> it must keep polling, not bail.
+    http = _ScriptedGET([_op("RUNNING"), _op("RUNNING"), _op("DONE")])
+    monkeypatch.setattr(gr, "_http_request", http)
+    monkeypatch.setenv("JARVIS_INSERT_OP_POLL_CAP_S", "5.0")  # room to reach DONE
+    v = await GCPComputeRest()._await_insert_operation("p", "z", "op-1", "tok")
+    assert v == "ok"
+    assert http.calls >= 3
+
+
+async def test_await_unknown_on_ceiling_breach_never_ok(monkeypatch):
+    # The operation NEVER reaches DONE within the ceiling -> 'unknown', NOT 'ok'.
+    monkeypatch.setattr(gr, "_http_request", _ScriptedGET([_op("RUNNING")]))
+    v = await GCPComputeRest()._await_insert_operation("p", "z", "op-1", "tok")
+    assert v == "unknown"
+
+
+async def test_await_unknown_on_persistent_api_failure(monkeypatch):
+    # operations.get is unreachable throughout (5xx) -> 'unknown', NOT 'ok'.
+    monkeypatch.setattr(gr, "_http_request", _ScriptedGET([(503, "backend error")]))
+    v = await GCPComputeRest()._await_insert_operation("p", "z", "op-1", "tok")
+    assert v == "unknown"
+
+
+# ---------------------------------------------------------------------------
+# _insert_in_zone -- 'unknown' reaps the phantom + rolls over
+# ---------------------------------------------------------------------------
+
+_INSERT_KW = dict(
+    zone="us-central1-a",
+    project="my-project",
+    token="ya29.FAKE",
+    headers={"Authorization": "Bearer ya29.FAKE"},
+    node="jarvis-prime-failover",
+    machine="g2-standard-4",
+    family="jarvis-prime-coder-32b",
+    startup_script="#!/bin/bash\ntrue\n",
+    accelerator_type="nvidia-l4",
+    accelerator_count=1,
+)
+
+
+class _PostHTTP:
+    """Accepts every POST insert (200 + op name); records POST count."""
+
+    def __init__(self):
+        self.posts = 0
+
+    async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        if method == "POST":
+            self.posts += 1
+        return (200, json.dumps({"name": "op-insert"}))
+
+
+def _patch_await(monkeypatch, verdicts):
+    seq = list(verdicts)
+    n = {"i": 0}
+
+    async def _fake(self, project, zone, op_name, token):
+        v = seq[min(n["i"], len(seq) - 1)]
+        n["i"] += 1
+        return v
+
+    monkeypatch.setattr(GCPComputeRest, "_await_insert_operation", _fake)
+
+
+def _patch_reap(monkeypatch):
+    reaped = []
+
+    async def _fake_delete(self, name=None, *, zone=None):
+        reaped.append((name, zone))
+        return (True, "deleted:200")
+
+    monkeypatch.setattr(GCPComputeRest, "delete_instance", _fake_delete)
+    return reaped
+
+
+async def test_unknown_ondemand_reaps_phantom_and_rolls_over(monkeypatch):
+    # On-demand op returns 'unknown' -> reap the phantom + return 'stockout'
+    # (so create_instance advances to the next zone). Flag ON so spot escalates.
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
+    http = _PostHTTP()
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["stockout", "unknown"])  # spot stockout -> ondemand unknown
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"          # rolls the chain to the next zone
+    assert "unknown" in detail
+    assert reaped == [("jarvis-prime-failover", "us-central1-a")]  # phantom reaped in-zone
+
+
+async def test_unknown_spot_reaps_then_tries_ondemand_same_zone(monkeypatch):
+    # Spot op 'unknown' -> reap, then escalate to on-demand SAME zone (which is ok).
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
+    http = _PostHTTP()
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["unknown", "ok"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "mode=on-demand" in detail
+    assert http.posts == 2                # spot + on-demand
+    assert reaped == [("jarvis-prime-failover", "us-central1-a")]  # spot phantom reaped
+
+
+async def test_missing_op_name_is_fail_closed_not_created(monkeypatch):
+    # A 200 insert with NO operation name -> cannot verify -> fail-closed
+    # (reap + roll), NEVER an optimistic 'created'.
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+
+    class _NoName:
+        def __init__(self):
+            self.posts = 0
+
+        async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+            if method == "POST":
+                self.posts += 1
+            return (200, json.dumps({}))  # accepted, but no "name"
+
+    monkeypatch.setattr(gr, "_http_request", _NoName())
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict != "created"
+    assert reaped  # phantom-protection reap fired
+
+
+# ---------------------------------------------------------------------------
+# create_instance -- the chain HUNTS across zones on 'unknown'
+# ---------------------------------------------------------------------------
+
+async def test_create_instance_rolls_zones_on_unknown(monkeypatch):
+    # Zone 1 op -> unknown (reap + stockout); zone 2 op -> ok (created).
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "us-central1-a,us-central1-b")
+
+    # Identity resolution: stub access_token/zone/project so create_instance runs.
+    async def _tok(self):
+        return "ya29.FAKE"
+
+    async def _zone(self):
+        return "us-central1-a"
+
+    async def _proj(self):
+        return "my-project"
+
+    monkeypatch.setattr(GCPComputeRest, "access_token", _tok)
+    monkeypatch.setattr(GCPComputeRest, "zone", _zone)
+    monkeypatch.setattr(GCPComputeRest, "project", _proj)
+
+    http = _PostHTTP()
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["unknown", "ok"])  # zone-a unknown, zone-b ok
+    reaped = _patch_reap(monkeypatch)
+
+    ok, detail = await GCPComputeRest().create_instance(startup_script="#!/bin/bash\ntrue\n")
+
+    assert ok is True
+    assert "created" in detail
+    # Reaped the zone-a phantom before rolling to zone-b.
+    assert ("jarvis-prime-failover", "us-central1-a") in reaped


### PR DESCRIPTION
## The bug

The A1-on-32B soak halted on a **phantom node**: an on-demand L4 insert whose async operation took ~31s to surface `ZONE_RESOURCE_POOL_EXHAUSTED_WITH_DETAILS`, but the 25s poll cap expired first and `_await_insert_operation` returned an optimistic `"ok"`. The FSM went AWAKENING on a node GCE then rolled back, and the zone chain never advanced to us-central1-c. A classic fail-open synchronization bug — unacceptable for cloud-infra management.

## Structural fixes (no env-knob workaround)

1. **Terminal-state verification** — `_await_insert_operation` returns `"ok"` **only** when `operations.get` explicitly returns `status:"DONE"` with **no** `error` object. A non-2xx / unparseable fetch is *not* terminal → keep polling.
2. **Fail-closed phantom protection** — a breached safety ceiling (or an API unreachable throughout) returns a new `"unknown"` verdict — **never** an optimistic `"ok"`. Ceiling raised 25s→90s (a breach is now a genuine anomaly); poll cadence is env-tunable via the new `JARVIS_INSERT_OP_POLL_INTERVAL_S` (removes the hardcoded 3s sleep).
3. **Multi-zonal rollover** — on `"unknown"` (and on a missing operation name — unverifiable == fail-closed), `_insert_in_zone` **violently reaps any late phantom** (`delete_instance`, idempotent) *before* returning `"stockout"`, so `create_instance` advances to the next zone and keeps hunting for L4 capacity.

## Tests (TDD)
- `test_insert_op_failclosed.py` — 10 new cases (terminal-state, ceiling→unknown, API-failure→unknown, reap+rollover, missing-op-name, full create_instance zone-hunt).
- Test-infra: `FakeHTTP` in `test_gcp_compute_rest.py` now models `operations.get` (DONE) distinctly from `instances.get` — required now that op-polling is load-bearing. This also **fixes 2 pre-existing stale-assertion failures** (detail format became `created:zone=<z>:mode=<m>` in the merged zone-aware work) and drops that file's runtime **82s → 1.2s**.
- 35 green across the REST/insert suites.

(Run REST tests on a machine with real Google ADC via `JARVIS_FAILOVER_USE_ADC=false` to force the mocked metadata path.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make instance insert polling fail-closed to prevent phantom nodes and stalled zone fallback. Success now requires a confirmed DONE; we return 'unknown' on ceiling/API issues, reap possible phantoms, and roll to the next zone; poll cap raised and interval is configurable.

- **Bug Fixes**
  - Only return `ok` when `operations.get` is `DONE` with no `error`. Non-2xx or unparseable responses are not terminal.
  - Add `unknown` verdict on ceiling breach or unreachable API; cap increased 25s → 90s, interval set by `JARVIS_INSERT_OP_POLL_INTERVAL_S`.
  - On `unknown` or missing operation name, delete any potential phantom (idempotent), then treat as `stockout` so the chain rolls; Spot can escalate to on-demand in-zone when enabled.
  - Keep `stockout` vs `error` routing for terminal failures.

- **Refactors**
  - Add `tests/governance/test_insert_op_failclosed.py` with 10 cases; update `tests/governance/test_gcp_compute_rest.py` to model `operations.get` distinctly from `instances.get`, fix two stale assertions, and cut runtime from 82s to 1.2s.

<sup>Written for commit 9f2e1703b0b32291028d00314184fd5e257ca95a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69782?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

