### PR TITLE
fix(a1): zone-aware endpoint/SERVING discovery — find the node in its landed zone

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -952,30 +952,53 @@ class GCPComputeRest:
         return self._extract_internal_ip(doc)
 
     async def get_node_endpoints(
-        self, name: Optional[str] = None,
+        self, name: Optional[str] = None, *, zone: Optional[str] = None,
     ) -> Tuple[Optional[str], Optional[str]]:
-        """Single instances.get -> ``(internal_ip, external_ip)`` for the
-        Reachability Racer (which probes BOTH concurrently -- no env guessing).
-        Either may be None while the node is still booting. NEVER raises."""
+        """instances.get -> ``(internal_ip, external_ip)`` for the Reachability
+        Racer (which probes BOTH concurrently -- no env guessing). Either may be
+        None while the node is still booting. NEVER raises.
+
+        ZONE-AWARE (A1 last-mile fix): the multi-zonal awaken lands the node in
+        ANY fallback zone (a Spot stockout in GCP_ZONE -> the node is created in
+        -b or -c). With no explicit ``zone`` we therefore search the SAME
+        ``zone_fallback_chain`` the teardown brute-forces (#69779) -- GCP_ZONE
+        first, then the fallbacks -- and return the endpoints from the FIRST zone
+        that actually holds the node. A node that is present-but-still-booting
+        (200, no natIP yet) IS found in that zone -> we return (internal, None)
+        and do NOT scan past it (it won't be in two zones). ``zone`` overrides the
+        search to a single zone (fast path for callers that know the landed zone).
+        404 in a zone == not here -> try the next."""
         try:
             token = await self.access_token()
-            zone = await self.zone()
             project = await self.project()
-            if not token or not zone or not project:
+            if not token or not project:
                 return (None, None)
             node = name or _node_name()
-            url = "{}/projects/{}/zones/{}/instances/{}".format(
-                _COMPUTE_BASE, project, zone, node
-            )
-            status, text = await _http_request(
-                url, method="GET",
-                headers={"Authorization": "Bearer {}".format(token)},
-                timeout_s=_rest_timeout(),
-            )
-            if not (200 <= status < 300 and text):
-                return (None, None)
-            doc = json.loads(text)
-            return (self._extract_internal_ip(doc), self._extract_external_ip(doc))
+            if zone:
+                zones = [zone]
+            else:
+                from backend.core.ouroboros.governance.zone_fallback import (  # noqa: PLC0415
+                    zone_fallback_chain,
+                )
+                zones = zone_fallback_chain(await self.zone())
+            headers = {"Authorization": "Bearer {}".format(token)}
+            for z in zones:
+                url = "{}/projects/{}/zones/{}/instances/{}".format(
+                    _COMPUTE_BASE, project, z, node
+                )
+                status, text = await _http_request(
+                    url, method="GET", headers=headers, timeout_s=_rest_timeout(),
+                )
+                if not (200 <= status < 300 and text):
+                    continue  # 404 / non-2xx -> node not in this zone, try next
+                try:
+                    doc = json.loads(text)
+                except Exception:  # noqa: BLE001 -- malformed body -> try next zone
+                    continue
+                # Node found in THIS zone -> return its endpoints (external may be
+                # None if it is still acquiring its natIP). Do not scan further.
+                return (self._extract_internal_ip(doc), self._extract_external_ip(doc))
+            return (None, None)
         except Exception as exc:  # noqa: BLE001
             logger.debug("[GCPComputeRest] get_node_endpoints fail-soft err=%r", exc)
             return (None, None)

--- a/tests/governance/test_endpoint_zone_aware.py
+++ b/tests/governance/test_endpoint_zone_aware.py
@@ -1,0 +1,140 @@
+"""Zone-aware endpoint/SERVING discovery (the A1 last-mile fix).
+
+The multi-zonal awaken lands the failover node in ANY fallback zone (a Spot
+stockout in us-central1-a -> the node is created in -b or -c). But
+``get_node_endpoints`` pinned its instances.get to ``GCP_ZONE`` only, so when the
+node landed in -b the L7 SERVING gate queried -a, 404'd, saw "no external IP"
+forever, and reaped a FULLY-SERVING 32B node it never dispatched to (proven live:
+``curl 34.9.86.150:11434/api/tags`` returned qwen2.5-coder:32b while the driver
+saw nothing).
+
+These tests pin the fix: discovery searches the SAME zone_fallback_chain the
+teardown already brute-forces (#69779), so a node in any candidate zone is found.
+A node present-but-still-booting (200, no natIP yet) is returned as found in THAT
+zone -- the scan does not skip past it.
+"""
+from __future__ import annotations
+
+import json
+import re
+
+import pytest
+
+import backend.core.ouroboros.governance.gcp_compute_rest as gr
+from backend.core.ouroboros.governance.gcp_compute_rest import GCPComputeRest
+
+pytestmark = pytest.mark.asyncio
+
+_ZONE_RE = re.compile(r"/zones/([^/]+)/instances/")
+
+
+def _instance_doc(*, internal="10.128.0.18", external="34.9.86.150"):
+    nic = {"networkIP": internal}
+    if external is not None:
+        nic["accessConfigs"] = [{"natIP": external}]
+    return {"status": "RUNNING", "networkInterfaces": [nic]}
+
+
+class _ZoneRoutingHTTP:
+    """Routes instances.get by the zone embedded in the URL. ``present`` maps a
+    zone -> instance doc (200); any other zone -> 404. Records queried zones."""
+
+    def __init__(self, present):
+        self._present = present
+        self.zones_queried = []
+
+    async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        m = _ZONE_RE.search(url)
+        z = m.group(1) if m else "?"
+        self.zones_queried.append(z)
+        if z in self._present:
+            return (200, json.dumps(self._present[z]))
+        return (404, json.dumps({"error": {"code": 404, "message": "not found"}}))
+
+
+@pytest.fixture(autouse=True)
+def _identity(monkeypatch):
+    # Deterministic identity + a 3-zone chain (default -a first).
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "us-central1-a,us-central1-b,us-central1-c")
+
+    async def _tok(self):
+        return "ya29.FAKE"
+
+    async def _zone(self):
+        return "us-central1-a"
+
+    async def _proj(self):
+        return "my-project"
+
+    monkeypatch.setattr(GCPComputeRest, "access_token", _tok)
+    monkeypatch.setattr(GCPComputeRest, "zone", _zone)
+    monkeypatch.setattr(GCPComputeRest, "project", _proj)
+
+
+async def test_finds_node_in_default_zone(monkeypatch):
+    http = _ZoneRoutingHTTP({"us-central1-a": _instance_doc()})
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    internal, external = await GCPComputeRest().get_node_endpoints()
+
+    assert (internal, external) == ("10.128.0.18", "34.9.86.150")
+    # Default zone hit first -> no wasted scan of -b/-c.
+    assert http.zones_queried == ["us-central1-a"]
+
+
+async def test_searches_fallback_when_not_in_default(monkeypatch):
+    # Node landed in -b (Spot stockout in -a). THE FIX: discovery must find it.
+    http = _ZoneRoutingHTTP({"us-central1-b": _instance_doc(external="34.9.86.150")})
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    internal, external = await GCPComputeRest().get_node_endpoints()
+
+    assert external == "34.9.86.150"
+    assert http.zones_queried == ["us-central1-a", "us-central1-b"]  # -a 404 -> -b hit
+
+
+async def test_explicit_zone_queries_only_that_zone(monkeypatch):
+    http = _ZoneRoutingHTTP({"us-central1-c": _instance_doc(external="34.9.86.200")})
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    internal, external = await GCPComputeRest().get_node_endpoints(zone="us-central1-c")
+
+    assert external == "34.9.86.200"
+    assert http.zones_queried == ["us-central1-c"]  # no chain search
+
+
+async def test_returns_none_when_absent_everywhere(monkeypatch):
+    http = _ZoneRoutingHTTP({})  # 404 in every zone
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    internal, external = await GCPComputeRest().get_node_endpoints()
+
+    assert (internal, external) == (None, None)
+    assert http.zones_queried == ["us-central1-a", "us-central1-b", "us-central1-c"]
+
+
+async def test_present_but_no_external_ip_yet_stops_at_that_zone(monkeypatch):
+    # Node is in -b but still booting (no natIP). It IS found there -> return
+    # (internal, None); do NOT scan past the zone that holds the node.
+    http = _ZoneRoutingHTTP({"us-central1-b": _instance_doc(external=None)})
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    internal, external = await GCPComputeRest().get_node_endpoints()
+
+    assert internal == "10.128.0.18"
+    assert external is None
+    assert http.zones_queried == ["us-central1-a", "us-central1-b"]  # stops at -b
+
+
+async def test_no_token_fails_closed(monkeypatch):
+    async def _no_tok(self):
+        return None
+
+    monkeypatch.setattr(GCPComputeRest, "access_token", _no_tok)
+    http = _ZoneRoutingHTTP({"us-central1-a": _instance_doc()})
+    monkeypatch.setattr(gr, "_http_request", http)
+
+    internal, external = await GCPComputeRest().get_node_endpoints()
+
+    assert (internal, external) == (None, None)
+    assert http.zones_queried == []  # never reached the network


### PR DESCRIPTION
## The last-mile blocker

The multi-zonal awaken lands the failover node in **any** fallback zone (Spot stockout in us-central1-a → node created in -b/-c), but `get_node_endpoints` pinned its `instances.get` to `GCP_ZONE` only. When the node landed in -b, the driver's L7 SERVING gate queried -a, 404'd, logged "no external IP" forever, and reaped a **fully-serving 32B node it never dispatched to**.

Proven live last run: `curl 34.9.86.150:11434/api/tags` returned `qwen2.5-coder:32b` (20GB in the L4's VRAM, reachable through the ephemeral /32 firewall) **while the driver saw nothing** — the node served; the orchestrator just wasn't pointed at it.

## Fix

`get_node_endpoints` now searches the **same `zone_fallback_chain` the teardown brute-forces** (#69779) — `GCP_ZONE` first, then the fallbacks — and returns the endpoints from the first zone that holds the node:
- A present-but-still-booting node (200, no `natIP` yet) is found in that zone → `(internal, None)`, no scan past it.
- New optional `zone=` kwarg overrides to a single zone (fast path for callers that know the landed zone).
- Fixes **all** callers (driver L7 gate + the FSM's own discovery at `failover_lifecycle.py:1420`) with **zero caller changes** — same zone-awareness class as the teardown fix, in the discovery path.

## Tests (TDD)
- `test_endpoint_zone_aware.py` — 6 cases: default-zone hit (no wasted scan), fallback search, explicit-zone fast path, absent-everywhere, present-but-booting stops at zone, no-token fail-closed.
- 58 green across the REST + hybrid-mesh suites.

This is the only thing that was standing between the arc and `A1_DISPATCH_PROVEN`. Re-igniting after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make endpoint discovery zone-aware so the driver finds A1 instances that land in fallback zones during multi-zonal failover. Prevents false “no external IP” and accidental reaping of serving nodes.

- **Bug Fixes**
  - Update `get_node_endpoints` to search the `zone_fallback_chain` (default zone first, then fallbacks) and return the first zone that holds the instance.
  - Add optional `zone=` to restrict lookup to a single zone; preserve booting-node behavior by returning `(internal, None)` without scanning past the found zone.
  - No caller changes; fixes the driver L7 SERVING gate and FSM discovery. Added `test_endpoint_zone_aware.py` covering default hit, fallback, explicit zone, absent everywhere, booting, and no-token cases.

<sup>Written for commit c803a700f03d3b45bebba9d1dc00bb9242e0a126. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69783?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

