### PR TITLE
feat(a1): strict pre-rollover confirmed reap + deterministic synthetic roadmap generator

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -261,6 +261,26 @@ def _insert_op_poll_interval_s() -> float:
     return _env_float("JARVIS_INSERT_OP_POLL_INTERVAL_S", 3.0, lo=0.001, hi=60.0)
 
 
+def _reap_confirm_attempts() -> int:
+    """Max delete+recheck rounds in the strict pre-rollover confirmed reap (an
+    'unknown' insert op may materialize a node LATE -- a single blind delete races
+    it). Bounded so a wedged zone never blocks the rollover forever."""
+    return int(_env_float("JARVIS_REAP_CONFIRM_ATTEMPTS", 6, lo=1.0, hi=60.0))
+
+
+def _reap_confirm_settle_s() -> float:
+    """Delay between confirmed-reap rounds -- the window in which a late async
+    insert would surface so we catch + delete it. Env-tunable."""
+    return _env_float("JARVIS_REAP_CONFIRM_SETTLE_S", 5.0, lo=0.0, hi=120.0)
+
+
+def _reap_confirm_clean_streak() -> int:
+    """Consecutive 'already gone' (404) observations required to declare a zone
+    confirmed-clean. >1 so a node that materializes DURING the settle window
+    resets the streak and is deleted before we trust the zone is empty."""
+    return int(_env_float("JARVIS_REAP_CONFIRM_CLEAN_STREAK", 2, lo=1.0, hi=10.0))
+
+
 def _running_timeout() -> float:
     return _env_float(_ENV_RUNNING_TIMEOUT, 180.0, lo=1.0, hi=3600.0)
 
@@ -751,17 +771,15 @@ class GCPComputeRest:
                         continue
                     return ("stockout", "zone={}:op_stockout".format(zone))
                 if verdict == "unknown":
-                    # Fail-closed phantom protection: a node may have spawned late
-                    # even though we never saw DONE. Violently reap it BEFORE moving
-                    # on (idempotent; 404 == already gone), then roll the chain.
+                    # Fail-closed phantom protection: the op is still in-flight, so
+                    # a node may materialize LATE. Strictly CONFIRM the zone is clean
+                    # (delete + re-check until it stays gone) BEFORE rolling -- do not
+                    # rely on the global teardown to catch a late phantom.
                     logger.warning(
-                        "[GCPComputeRest] insert UNVERIFIED zone=%s mode=%s -> reaping "
-                        "any phantom node + rolling to next zone", zone, mode,
+                        "[GCPComputeRest] insert UNVERIFIED zone=%s mode=%s -> "
+                        "confirmed-reap (catch late phantom) + roll next zone", zone, mode,
                     )
-                    try:
-                        await self.delete_instance(node, zone=zone)
-                    except Exception as exc:  # noqa: BLE001 -- reap is best-effort
-                        logger.debug("[GCPComputeRest] phantom reap fail-soft err=%r", exc)
+                    await self._reap_zone_confirmed(node, zone)
                     if spot and _ondemand_on_stockout_enabled():
                         continue  # escalate to on-demand same zone first
                     return ("stockout", "zone={}:unknown_reaped".format(zone))
@@ -1004,6 +1022,53 @@ class GCPComputeRest:
             return (None, None)
 
     # -- delete (delete-to-snapshot keeps the golden image untouched) ----
+
+    async def _reap_zone_confirmed(self, node: str, zone: str) -> bool:
+        """Strict pre-rollover reap: delete ``node`` in ``zone`` and CONFIRM the
+        zone is clean before the caller rolls to the next zone. An 'unknown'
+        insert op is still in-flight, so a node may materialize AFTER the first
+        delete -- a single blind delete races it (the v3 transient double-node).
+        We therefore delete + re-check until we observe ``_reap_confirm_clean_streak``
+        consecutive 'already gone' (404) results; a node that surfaces mid-window
+        (200/202) RESETS the streak and is deleted. Bounded by
+        ``_reap_confirm_attempts`` so a wedged zone never blocks forever (the
+        global teardown remains the final backstop). Returns True iff confirmed
+        clean. NEVER raises."""
+        need = _reap_confirm_clean_streak()
+        attempts = _reap_confirm_attempts()
+        settle = _reap_confirm_settle_s()
+        clean = 0
+        for i in range(attempts):
+            try:
+                ok, detail = await self.delete_instance(node, zone=zone)
+            except Exception as exc:  # noqa: BLE001 -- reap must never raise
+                logger.debug("[GCPComputeRest] confirmed-reap delete err=%r", exc)
+                ok, detail = (False, "")
+            gone = ok and "404" in detail
+            if gone:
+                clean += 1
+                if clean >= need:
+                    logger.info(
+                        "[GCPComputeRest] confirmed-reap CLEAN zone=%s node=%s "
+                        "(%d consecutive gone)", zone, node, clean,
+                    )
+                    return True
+            else:
+                # A node was present (200/202) or the delete failed -> the zone is
+                # NOT clean yet (possibly a late-materialized phantom). Reset.
+                if clean:
+                    logger.warning(
+                        "[GCPComputeRest] confirmed-reap caught late node zone=%s "
+                        "node=%s (detail=%s) -- re-deleting", zone, node, detail,
+                    )
+                clean = 0
+            if i < attempts - 1 and settle > 0:
+                await asyncio.sleep(settle)
+        logger.warning(
+            "[GCPComputeRest] confirmed-reap UNCONFIRMED zone=%s node=%s after %d "
+            "rounds -- global teardown remains backstop", zone, node, attempts,
+        )
+        return clean >= need
 
     async def delete_instance(
         self, name: Optional[str] = None, *, zone: Optional[str] = None

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -308,6 +308,72 @@ async def _open_failover_firewall(fw_name: str) -> Optional[str]:
         return None
 
 
+def _arm_synthetic_roadmap(env: Dict[str, str], run_dir: str) -> str:
+    """Deterministic Synthetic Roadmap Generator -- emit the A1 `emit source=roadmap`
+    provenance hop with a GENUINE signed payload (no hardcoded fake trace, no
+    REQUIRE_SIGNATURE bypass).
+
+    Builds a strategic GOAL and signs it with the PRODUCTION primitives
+    (``strategy_signer.sign_roadmap_doc`` -> ``roadmap_reader._build_signing_payload``
+    + ``compute_signature``: canonical compact sorted-key JSON, HMAC-SHA256) -- the
+    exact bytes the reader re-derives to verify. Writes it to an absolute path the
+    organism subprocess can read (same accessibility contract as JARVIS_TRINITY_ROOT)
+    and arms the reader env. compose_env already sets JARVIS_ROADMAP_ORCHESTRATOR_ENABLED
+    + JARVIS_A1_TRACE_ENABLED; the missing master gate was JARVIS_ROADMAP_READER_ENABLED.
+    The organism's _roadmap_ignition_daemon then ingests this goal -> the A1Trace emit
+    hop fires. Returns the roadmap file path.
+
+    The HMAC secret is a real per-run token (``generate_secret``, mirroring the
+    per-deployment GCE metadata secret) -- overridable via
+    JARVIS_A1_SYNTHETIC_ROADMAP_SECRET for byte-reproducible runs; never a committed
+    literal. The driver signs and injects the SAME secret into the child env so the
+    reader's verification (REQUIRE_SIGNATURE on) succeeds."""
+    import yaml as _yaml  # noqa: PLC0415
+    from datetime import datetime, timezone  # noqa: PLC0415
+    from backend.core.ouroboros.governance.strategy_signer import (  # noqa: PLC0415
+        generate_secret,
+        sign_roadmap_doc,
+    )
+
+    secret = (os.environ.get("JARVIS_A1_SYNTHETIC_ROADMAP_SECRET", "") or "").strip()
+    if not secret:
+        secret = generate_secret()
+
+    doc = {
+        "version": 1,
+        "operator_id": "a1-soak@jarvis.local",
+        "signed_at": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "goals": [
+            {
+                "id": "GOAL-001",
+                "title": "A1 self-audit: confirm the autonomous dispatch chain is live",
+                "description": (
+                    "Synthetic strategic goal for the A1 soak -- exercises the full "
+                    "emit->ingest->dequeue->submit->accept provenance chain end to end."
+                ),
+                "priority": "high",
+                "target_files": ["backend/core/ouroboros/governance/a1_trace.py"],
+                "success_criteria": (
+                    "A complete 5-hop A1Trace chain is observed for this roadmap goal."
+                ),
+            }
+        ],
+    }
+    signed = sign_roadmap_doc(doc, secret)
+
+    rm_dir = os.path.join(run_dir, ".jarvis")
+    os.makedirs(rm_dir, exist_ok=True)
+    path = os.path.join(rm_dir, "roadmap.yaml")
+    with open(path, "w", encoding="utf-8") as fh:
+        _yaml.safe_dump(signed, fh, sort_keys=False)
+
+    env["JARVIS_ROADMAP_READER_ENABLED"] = "true"
+    env["JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE"] = "true"
+    env["JARVIS_ROADMAP_READER_HMAC_SECRET"] = secret
+    env["JARVIS_ROADMAP_READER_PATH"] = path
+    return path
+
+
 async def _arm_failover_mesh(env: Dict[str, str]) -> None:
     """Arm the Hybrid Execution Mesh on the soak env, register the failover node
     for teardown UP FRONT, then open the driver-owned /32 firewall.
@@ -853,6 +919,21 @@ class IsomorphicA1Driver:
                 _trinity_root = os.path.join(run_dir, "trinity_root")
                 os.makedirs(_trinity_root, exist_ok=True)
                 env["JARVIS_TRINITY_ROOT"] = _trinity_root
+
+                # ---- Deterministic Synthetic Roadmap (A1 emit-hop provenance) ----
+                # compose_env arms the orchestrator + A1Trace flags but NOT the
+                # roadmap READER, and no signed roadmap exists -> the strategic-GOAL
+                # `emit source=roadmap` hop never fires and the A1 audit fails on a
+                # missing chain. Generate a GENUINE signed GOAL (production crypto)
+                # so _roadmap_ignition_daemon emits it. Skipped for stub wiring runs.
+                if not self.stub_soak:
+                    try:
+                        _rm_path = _arm_synthetic_roadmap(env, run_dir)
+                        _log("[A1] synthetic signed roadmap armed -> %s "
+                             "(reader ENABLED, REQUIRE_SIGNATURE on, real HMAC)" % _rm_path)
+                    except Exception as _exc:  # noqa: BLE001 -- never block the soak
+                        _log("[A1] WARN synthetic roadmap arming failed "
+                             "(emit hop will be absent): %r" % (_exc,))
 
                 _log("env composed: %d keys total, adversary overrides applied, "
                      "failover=%s" % (len(env), "enabled" if self.enable_failover

--- a/tests/governance/test_insert_op_failclosed.py
+++ b/tests/governance/test_insert_op_failclosed.py
@@ -32,6 +32,8 @@ def _fast_poll(monkeypatch):
     # Tiny cap + interval so the poll loop is fast + deterministic.
     monkeypatch.setenv("JARVIS_INSERT_OP_POLL_CAP_S", "0.05")
     monkeypatch.setenv("JARVIS_INSERT_OP_POLL_INTERVAL_S", "0.001")
+    # Tiny confirmed-reap settle so the pre-rollover reap loop is fast.
+    monkeypatch.setenv("JARVIS_REAP_CONFIRM_SETTLE_S", "0.001")
 
 
 def _op(status, *, error=None):
@@ -151,7 +153,7 @@ def _patch_reap(monkeypatch):
 
     async def _fake_delete(self, name=None, *, zone=None):
         reaped.append((name, zone))
-        return (True, "deleted:200")
+        return (True, "deleted:404")  # nothing present -> confirmed-clean fast
 
     monkeypatch.setattr(GCPComputeRest, "delete_instance", _fake_delete)
     return reaped
@@ -170,7 +172,7 @@ async def test_unknown_ondemand_reaps_phantom_and_rolls_over(monkeypatch):
 
     assert verdict == "stockout"          # rolls the chain to the next zone
     assert "unknown" in detail
-    assert reaped == [("jarvis-prime-failover", "us-central1-a")]  # phantom reaped in-zone
+    assert ("jarvis-prime-failover", "us-central1-a") in reaped  # phantom reaped in-zone
 
 
 async def test_unknown_spot_reaps_then_tries_ondemand_same_zone(monkeypatch):
@@ -186,7 +188,7 @@ async def test_unknown_spot_reaps_then_tries_ondemand_same_zone(monkeypatch):
     assert verdict == "created"
     assert "mode=on-demand" in detail
     assert http.posts == 2                # spot + on-demand
-    assert reaped == [("jarvis-prime-failover", "us-central1-a")]  # spot phantom reaped
+    assert ("jarvis-prime-failover", "us-central1-a") in reaped  # spot phantom reaped
 
 
 async def test_missing_op_name_is_fail_closed_not_created(monkeypatch):
@@ -246,3 +248,71 @@ async def test_create_instance_rolls_zones_on_unknown(monkeypatch):
     assert "created" in detail
     # Reaped the zone-a phantom before rolling to zone-b.
     assert ("jarvis-prime-failover", "us-central1-a") in reaped
+
+
+# ---------------------------------------------------------------------------
+# _reap_zone_confirmed -- strict pre-rollover reap that CATCHES a late node
+# ---------------------------------------------------------------------------
+
+def _patch_delete_sequence(monkeypatch, details):
+    """Patch delete_instance to return scripted (ok, detail) in order; records."""
+    seq = list(details)
+    calls = {"n": 0}
+
+    async def _fake(self, name=None, *, zone=None):
+        d = seq[min(calls["n"], len(seq) - 1)]
+        calls["n"] += 1
+        return (True, d)
+
+    monkeypatch.setattr(GCPComputeRest, "delete_instance", _fake)
+    return calls
+
+
+async def test_reap_confirmed_clean_when_already_gone(monkeypatch):
+    monkeypatch.setenv("JARVIS_REAP_CONFIRM_CLEAN_STREAK", "2")
+    calls = _patch_delete_sequence(monkeypatch, ["deleted:404"])
+    ok = await GCPComputeRest()._reap_zone_confirmed("node", "us-central1-a")
+    assert ok is True
+    assert calls["n"] >= 2  # required consecutive 404s to declare clean
+
+
+async def test_reap_confirmed_catches_late_materialization(monkeypatch):
+    # 404 (nothing yet) -> 200 (node materialized AFTER first delete!) -> 404,404.
+    # The 200 must RESET the clean streak so the late node is actually deleted.
+    monkeypatch.setenv("JARVIS_REAP_CONFIRM_CLEAN_STREAK", "2")
+    monkeypatch.setenv("JARVIS_REAP_CONFIRM_ATTEMPTS", "8")
+    calls = _patch_delete_sequence(
+        monkeypatch, ["deleted:404", "deleted:200", "deleted:404", "deleted:404"]
+    )
+    ok = await GCPComputeRest()._reap_zone_confirmed("node", "us-central1-a")
+    assert ok is True
+    # Must have continued PAST the late 200 (>= 4 deletes), not stopped at the
+    # first 404 -- that is the race fix.
+    assert calls["n"] >= 4
+
+
+async def test_reap_confirmed_gives_up_when_never_clears(monkeypatch):
+    # Node never deletes (always present) -> bounded give-up (False); the global
+    # teardown remains the backstop, but we never block forever.
+    monkeypatch.setenv("JARVIS_REAP_CONFIRM_ATTEMPTS", "3")
+    monkeypatch.setenv("JARVIS_REAP_CONFIRM_CLEAN_STREAK", "2")
+    calls = _patch_delete_sequence(monkeypatch, ["deleted:200"])
+    ok = await GCPComputeRest()._reap_zone_confirmed("node", "us-central1-a")
+    assert ok is False
+    assert calls["n"] == 3  # bounded by attempts
+
+
+async def test_insert_unknown_uses_confirmed_reap(monkeypatch):
+    # _insert_in_zone on 'unknown' must call the CONFIRMED reap (multiple deletes
+    # until clean), not a single blind delete.
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    monkeypatch.setenv("JARVIS_REAP_CONFIRM_CLEAN_STREAK", "2")
+    http = _PostHTTP()
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["unknown"])
+    calls = _patch_delete_sequence(monkeypatch, ["deleted:404"])
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"
+    assert calls["n"] >= 2  # confirmed reap, not a single delete

--- a/tests/scripts/test_synthetic_roadmap_generator.py
+++ b/tests/scripts/test_synthetic_roadmap_generator.py
@@ -1,0 +1,90 @@
+"""Deterministic Synthetic Roadmap Generator (the A1 `emit source=roadmap` hop).
+
+The isomorphic A1 soak must emit a REAL HMAC-signed strategic GOAL through the
+production roadmap pipeline so the auditor's first hop (emit→ingest→dequeue→
+submit→accept) fires -- WITHOUT a hardcoded fake trace and WITHOUT bypassing the
+signature gate. The proof here: the driver's generated payload verifies against
+the ACTUAL production `roadmap_reader` (same canonical-JSON HMAC-SHA256), and a
+wrong secret is genuinely rejected.
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = str((Path(__file__).parent.parent.parent).resolve())
+_SCRIPTS_DIR = str((Path(__file__).parent.parent.parent / "scripts").resolve())
+for _p in (_REPO_ROOT, _SCRIPTS_DIR, os.path.join(_REPO_ROOT, "backend")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_script(name: str):
+    if name in sys.modules:
+        return sys.modules[name]
+    path = os.path.join(_SCRIPTS_DIR, name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_driver = _load_script("isomorphic_a1_local")
+
+from backend.core.ouroboros.governance.roadmap_reader import (  # noqa: E402
+    RoadmapVerdict,
+    read_roadmap,
+)
+
+
+def test_synthetic_roadmap_verifies_against_real_reader(tmp_path):
+    env: dict = {}
+    path = _driver._arm_synthetic_roadmap(env, str(tmp_path))
+
+    assert Path(path).is_file()
+    # The reader gates are armed by the generator (compose_env only sets the
+    # orchestrator flag; the READER master gate was the missing piece).
+    assert env["JARVIS_ROADMAP_READER_ENABLED"] == "true"
+    assert env["JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE"] == "true"
+    assert env["JARVIS_ROADMAP_READER_HMAC_SECRET"]
+    assert env["JARVIS_ROADMAP_READER_PATH"] == str(path)
+
+    # THE PROOF: the production reader verifies the signature with the SAME secret
+    # the driver signed with -> VALID, and GOAL-001 is parsed.
+    verdict, doc, diag = read_roadmap(
+        path_override=Path(path),
+        secret_override=env["JARVIS_ROADMAP_READER_HMAC_SECRET"],
+    )
+    assert verdict == RoadmapVerdict.VALID, diag
+    assert doc is not None
+    assert any(g.goal_id == "GOAL-001" for g in doc.goals)
+
+
+def test_synthetic_roadmap_rejected_under_wrong_secret(tmp_path):
+    # Genuinely signed (not a REQUIRE_SIGNATURE bypass) -> a different secret MUST
+    # fail verification. This proves the provenance is real crypto.
+    env: dict = {}
+    path = _driver._arm_synthetic_roadmap(env, str(tmp_path))
+
+    verdict, _doc, _diag = read_roadmap(
+        path_override=Path(path), secret_override="a-different-wrong-secret"
+    )
+    assert verdict == RoadmapVerdict.INVALID_SIGNATURE
+
+
+def test_synthetic_roadmap_secret_override_is_deterministic(tmp_path, monkeypatch):
+    # An explicit secret makes the signed payload reproducible (no committed
+    # literal in source; the override is the determinism knob).
+    monkeypatch.setenv("JARVIS_A1_SYNTHETIC_ROADMAP_SECRET", "fixed-secret-abc123")
+    env: dict = {}
+    path = _driver._arm_synthetic_roadmap(env, str(tmp_path))
+
+    assert env["JARVIS_ROADMAP_READER_HMAC_SECRET"] == "fixed-secret-abc123"
+    verdict, doc, diag = read_roadmap(
+        path_override=Path(path), secret_override="fixed-secret-abc123"
+    )
+    assert verdict == RoadmapVerdict.VALID, diag


### PR DESCRIPTION
Two fixes from run #3's findings — closing the cloud-provisioning race AND satisfying the A1 provenance audit. Both TDD, no shortcuts.

## Fix 1 — Strict pre-rollover confirmed reap (the race)
Run #3 exposed an eventual-consistency race: an on-demand op was `unknown` at the 90s ceiling, the single blind delete fired, but GCE then materialized the node (`-a STAGING`) *after* the delete missed it — a transient double-node.

`_reap_zone_confirmed(node, zone)` replaces the one-shot delete on `unknown`: it deletes + re-checks until it observes `JARVIS_REAP_CONFIRM_CLEAN_STREAK` (default 2) consecutive *already-gone* (404) results; a node that surfaces mid-window (200/202) **resets the streak and is deleted**. Bounded by `JARVIS_REAP_CONFIRM_ATTEMPTS` (6) × `JARVIS_REAP_CONFIRM_SETTLE_S` (5s) so a wedged zone never blocks the rollover forever (global teardown stays the final backstop). Fired synchronously **before** the next zone's insert.

## Fix 2 — Deterministic synthetic roadmap generator (the emit hop)
The A1 audit failed with zero `emit source=roadmap` hops. Root cause: the isomorphic soak armed `JARVIS_ROADMAP_ORCHESTRATOR_ENABLED` but never the **reader** (`JARVIS_ROADMAP_READER_ENABLED`, default OFF) and shipped no signed roadmap — so `_roadmap_ignition_daemon` had nothing to emit. (The pipe demonstrably flowed for sensor ops: `ingest→dequeue→submit→accept`.)

`_arm_synthetic_roadmap()` generates a **genuine HMAC-signed** strategic GOAL using the **production crypto primitives** (`strategy_signer.sign_roadmap_doc` → `roadmap_reader._build_signing_payload` + `compute_signature`: canonical compact sorted-key JSON, HMAC-SHA256 — the exact bytes the reader re-derives). Writes it to an absolute path the organism reads (same accessibility contract as `JARVIS_TRINITY_ROOT`) and arms the reader env with the **same secret** for verification. **No hardcoded fake trace, no `REQUIRE_SIGNATURE` bypass.** Real per-run secret (`generate_secret`, mirroring the GCE metadata secret); `JARVIS_A1_SYNTHETIC_ROADMAP_SECRET` overrides for reproducible runs.

## Tests (TDD)
- `test_insert_op_failclosed.py` +4 — confirmed reap: clean-when-gone, **catches-late-materialization**, bounded give-up, insert-unknown-uses-confirmed-reap.
- `test_synthetic_roadmap_generator.py` +3 — payload verifies against the **actual production `roadmap_reader`** (`VALID`); wrong secret genuinely rejected (`INVALID_SIGNATURE`); secret-override determinism.
- 65 green across the REST + script suites.

Re-igniting after merge to claim `A1_DISPATCH_PROVEN`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the GCE provisioning race by confirming zone cleanup before rolling to the next zone, preventing late phantom nodes. Also adds a deterministic, HMAC-signed synthetic roadmap so the `emit source=roadmap` hop fires and the A1 provenance audit can pass.

- **Bug Fixes**
  - Replaced the one-shot delete on `unknown` inserts with `_reap_zone_confirmed(...)`: delete + re-check until `JARVIS_REAP_CONFIRM_CLEAN_STREAK` consecutive 404s; any 200/202 resets and deletes.
  - Bounded by `JARVIS_REAP_CONFIRM_ATTEMPTS` and `JARVIS_REAP_CONFIRM_SETTLE_S`; runs synchronously before rolling to the next zone.

- **New Features**
  - `_arm_synthetic_roadmap()` generates a real HMAC-SHA256–signed roadmap using production signer and enables the reader via `JARVIS_ROADMAP_READER_ENABLED`, `JARVIS_ROADMAP_READER_REQUIRE_SIGNATURE`, `JARVIS_ROADMAP_READER_HMAC_SECRET`, and `JARVIS_ROADMAP_READER_PATH`.
  - Uses a per-run secret (`generate_secret`), with `JARVIS_A1_SYNTHETIC_ROADMAP_SECRET` for reproducible runs; wired into the A1 driver (skipped for stub runs).

<sup>Written for commit 2870822f5b3c4c13811f99e7e0703fe91116be16. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69784?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

