### PR TITLE
fix(a1): intelligent state-inspection handoff + dynamic artifact context injection

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -350,6 +350,19 @@ class HarnessConfig:
 # ---------------------------------------------------------------------------
 
 
+def _resolve_active_session_dir(default_dir: Path) -> Path:
+    """Dynamic Artifact Context Injection: if the ignition driver dictated an
+    absolute debug.log path via ``JARVIS_ACTIVE_SESSION_LOG``, colocate ALL session
+    artifacts in its parent dir so the auditor reads EXACTLY where this organism
+    writes (no ``bt-<ts>`` vs ``pending`` split). Returns the injected log's parent
+    when set, else ``default_dir``. NEVER raises."""
+    try:
+        inj = (os.environ.get("JARVIS_ACTIVE_SESSION_LOG", "") or "").strip()
+        return Path(inj).parent if inj else default_dir
+    except Exception:  # noqa: BLE001
+        return default_dir
+
+
 class BattleTestHarness:
     """Orchestrates the full Ouroboros boot, event-driven session loop, and shutdown.
 
@@ -393,8 +406,16 @@ class BattleTestHarness:
         ts = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d-%H%M%S")
         self._session_id = f"bt-{ts}"
 
-        # Session directories
-        self._session_dir = config.session_dir or Path(f".ouroboros/sessions/{self._session_id}")
+        # Session directories. Honor a driver-dictated JARVIS_ACTIVE_SESSION_LOG so
+        # every artifact (summary.json, WAL, debug.log) colocates where the auditor
+        # reads -- single shared memory space (Dynamic Artifact Context Injection).
+        self._session_dir = _resolve_active_session_dir(
+            config.session_dir or Path(f".ouroboros/sessions/{self._session_id}")
+        )
+        # Keep the session id consistent with the (possibly injected) dir name so
+        # downstream id-keyed paths agree with the artifact dir.
+        if self._session_dir.name:
+            self._session_id = self._session_dir.name
         self._notebook_output_dir = config.notebook_output_dir or Path("notebooks")
 
         # Publish session dir for downstream non-streaming callers
@@ -798,7 +819,7 @@ class BattleTestHarness:
                 configure_silent_boot,
             )
             _silent_boot_handler = configure_silent_boot(
-                session_dir=(
+                session_dir=_resolve_active_session_dir(
                     self._config.repo_path / ".ouroboros"
                     / "sessions" / self._session_id
                 ),

--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -274,6 +274,12 @@ def _reap_confirm_settle_s() -> float:
     return _env_float("JARVIS_REAP_CONFIRM_SETTLE_S", 5.0, lo=0.0, hi=120.0)
 
 
+# GCE instance.status values that mean "the node is materializing or up" -- a
+# slow-but-real node, NOT a phantom. On an 'unknown' insert op we KEEP these and
+# hand patience to the L7 readiness gate; we reap ONLY genuinely-dead/absent nodes.
+_MATERIALIZING_STATES = ("PROVISIONING", "STAGING", "RUNNING", "REPAIRING")
+
+
 def _reap_confirm_clean_streak() -> int:
     """Consecutive 'already gone' (404) observations required to declare a zone
     confirmed-clean. >1 so a node that materializes DURING the settle window
@@ -771,13 +777,36 @@ class GCPComputeRest:
                         continue
                     return ("stockout", "zone={}:op_stockout".format(zone))
                 if verdict == "unknown":
-                    # Fail-closed phantom protection: the op is still in-flight, so
-                    # a node may materialize LATE. Strictly CONFIRM the zone is clean
-                    # (delete + re-check until it stays gone) BEFORE rolling -- do not
-                    # rely on the global teardown to catch a late phantom.
+                    # Intelligent state-inspection handoff: an 'unknown' op (no
+                    # terminal DONE within the ceiling) is EITHER a slow-but-real
+                    # node OR a phantom. Inspect the instance before acting -- do NOT
+                    # blindly reap (that kills a slow-but-valid L4 node) and do NOT
+                    # blindly trust (that leaves a phantom).
+                    inst_status, http_code = await self.get_instance_status(node, zone=zone)
+                    if (inst_status or "").upper() in _MATERIALIZING_STATES:
+                        # Slow-but-REAL: the node is materializing/up. KEEP it, do NOT
+                        # reap, do NOT advance -> route to AWAKENING and hand patience
+                        # to the L7 readiness gate/racer (the right owner of "wait for
+                        # SERVING"). This resolves the strict-reap-vs-slow-op tension.
+                        logger.info(
+                            "[GCPComputeRest] insert op unverified BUT node MATERIALIZING "
+                            "(status=%s) zone=%s mode=%s -> KEEP + hand to L7 readiness gate",
+                            inst_status, zone, mode,
+                        )
+                        return (
+                            "created",
+                            "zone={}:mode={}:materializing_{}".format(
+                                zone, mode, inst_status.lower()
+                            ),
+                        )
+                    # TERMINATED / absent (404) / errored / unknowable -> a genuine
+                    # phantom or hardware/quota failure. Strictly CONFIRM the zone is
+                    # clean (catch a late-materializing one) BEFORE rolling -- never
+                    # rely on the global teardown alone.
                     logger.warning(
-                        "[GCPComputeRest] insert UNVERIFIED zone=%s mode=%s -> "
-                        "confirmed-reap (catch late phantom) + roll next zone", zone, mode,
+                        "[GCPComputeRest] insert op unverified + node NOT materializing "
+                        "(status=%s http=%s) zone=%s mode=%s -> confirmed-reap + roll next zone",
+                        inst_status, http_code, zone, mode,
                     )
                     await self._reap_zone_confirmed(node, zone)
                     if spot and _ondemand_on_stockout_enabled():
@@ -1022,6 +1051,40 @@ class GCPComputeRest:
             return (None, None)
 
     # -- delete (delete-to-snapshot keeps the golden image untouched) ----
+
+    async def get_instance_status(
+        self, name: Optional[str] = None, *, zone: Optional[str] = None,
+    ) -> Tuple[Optional[str], int]:
+        """instances.get -> ``(status_string, http_status)``. ``status_string`` is
+        the GCE instance ``status`` field (PROVISIONING / STAGING / RUNNING /
+        STOPPING / TERMINATED / ...), or None if absent/unreadable. ``http_status``
+        is the raw GET code (404 == the instance does not exist in that zone). Used
+        by the intelligent state-inspection handoff to distinguish a slow-but-real
+        node from a phantom. NEVER raises."""
+        try:
+            token = await self.access_token()
+            project = await self.project()
+            zone = zone or await self.zone()
+            if not token or not project or not zone:
+                return (None, 0)
+            node = name or _node_name()
+            url = "{}/projects/{}/zones/{}/instances/{}".format(
+                _COMPUTE_BASE, project, zone, node
+            )
+            status, text = await _http_request(
+                url, method="GET",
+                headers={"Authorization": "Bearer {}".format(token)},
+                timeout_s=_rest_timeout(),
+            )
+            if 200 <= status < 300 and text:
+                try:
+                    return (json.loads(text).get("status"), status)
+                except Exception:  # noqa: BLE001
+                    return (None, status)
+            return (None, status)
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[GCPComputeRest] get_instance_status fail-soft err=%r", exc)
+            return (None, 0)
 
     async def _reap_zone_confirmed(self, node: str, zone: str) -> bool:
         """Strict pre-rollover reap: delete ``node`` in ``zone`` and CONFIRM the

--- a/scripts/a1_graduation_auditor.py
+++ b/scripts/a1_graduation_auditor.py
@@ -1518,6 +1518,17 @@ def _render_verdict(verdict: A1Verdict, log: Callable[[str], None] = print) -> N
         )
 
 
+def _resolve_log_file(arg_log_file: Optional[str]) -> Optional[str]:
+    """Resolve which debug.log to tail for [A1Trace] lines. An explicit
+    ``--log-file`` wins; otherwise honor ``JARVIS_ACTIVE_SESSION_LOG`` (the
+    ignition driver's DICTATED absolute path) so the auditor reads EXACTLY where
+    the organism writes -- Dynamic Artifact Context Injection, no hardcoded
+    ``bt-<ts>`` and no ``pending`` placeholder. None if neither is set."""
+    if arg_log_file:
+        return arg_log_file
+    return (os.environ.get("JARVIS_ACTIVE_SESSION_LOG") or "").strip() or None
+
+
 def main(argv: Optional[Sequence[str]] = None) -> int:
     ap = argparse.ArgumentParser(
         description=(
@@ -1534,7 +1545,11 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         "--base", default=os.environ.get("JARVIS_OBSERVABILITY_BASE", "http://localhost:8099"),
         help="Observability base URL (default loopback / env JARVIS_OBSERVABILITY_BASE).",
     )
-    ap.add_argument("--log-file", default=None, help="Soak log file to tail for [A1Trace] lines.")
+    ap.add_argument(
+        "--log-file", default=None,
+        help="Soak log file to tail for [A1Trace] lines. If omitted, falls back to "
+             "the JARVIS_ACTIVE_SESSION_LOG env var (the driver's dictated path).",
+    )
     ap.add_argument(
         "--timeout", type=float,
         default=float(os.environ.get("JARVIS_A1_AUDIT_TIMEOUT_S", "3600") or 3600),
@@ -1601,7 +1616,7 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
             run_watch(
                 auditor,
                 base=args.base,
-                log_file=args.log_file,
+                log_file=_resolve_log_file(args.log_file),
                 timeout_s=args.timeout,
             )
         )

--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -443,7 +443,21 @@ class SoakRunner:
             return set()
 
     def launch(self, env: Dict[str, str], run_dir: str) -> SoakHandle:
-        before = self._snapshot_sessions()
+        # Dynamic Artifact Context Injection: DICTATE the organism's debug.log path
+        # BEFORE launch and inject it into the child env, so the organism writes and
+        # the auditor reads the EXACT same file -- no post-boot discovery race, no
+        # 'pending' placeholder (the bug that made the auditor see 0 [A1Trace] hops
+        # while the chain fired). Honor a caller-preset override.
+        log_path = (env.get("JARVIS_ACTIVE_SESSION_LOG", "") or "").strip()
+        if not log_path:
+            log_path = os.path.join(
+                self._sessions_root(), "bt-iso-{}".format(int(time.time())), "debug.log"
+            )
+        env["JARVIS_ACTIVE_SESSION_LOG"] = log_path
+        try:
+            os.makedirs(os.path.dirname(log_path), exist_ok=True)
+        except OSError:
+            pass
         argv = [
             sys.executable, _SOAK_SCRIPT,
             "--production-soak", "--headless",
@@ -456,9 +470,9 @@ class SoakRunner:
         self._proc = subprocess.Popen(
             argv, cwd=self.repo_root, env=env, stdout=fh, stderr=subprocess.STDOUT,
         )
-        debug_log = self._await_session_debug_log(before, deadline_s=60.0)
-        session_dir = os.path.dirname(debug_log) if debug_log else self._sessions_root()
-        return SoakHandle(debug_log=debug_log, session_dir=session_dir, proc=self._proc)
+        return SoakHandle(
+            debug_log=log_path, session_dir=os.path.dirname(log_path), proc=self._proc,
+        )
 
     def _await_session_debug_log(self, before: set, deadline_s: float) -> str:
         """Poll the sessions root for a NEW bt-* dir that the soak created, then
@@ -522,6 +536,9 @@ class AuditorRunner:
         # on the auditor's env from the already-derived flag set (no CADENCE import).
         env = dict(os.environ)
         env.setdefault("JARVIS_A1_AUDIT_FLAGS", ",".join(derive_cognitive_flags()))
+        # Same memory space: the auditor's env-fallback (_resolve_log_file) agrees
+        # with the explicit --log-file we pass -- both resolve to the dictated path.
+        env["JARVIS_ACTIVE_SESSION_LOG"] = log_file
         cp = subprocess.run(argv, capture_output=True, text=True, check=False, env=env)
         if os.path.exists(verdict_out):
             try:

--- a/tests/governance/test_insert_op_failclosed.py
+++ b/tests/governance/test_insert_op_failclosed.py
@@ -302,6 +302,124 @@ async def test_reap_confirmed_gives_up_when_never_clears(monkeypatch):
     assert calls["n"] == 3  # bounded by attempts
 
 
+def _stub_identity(monkeypatch):
+    async def _tok(self):
+        return "ya29.FAKE"
+
+    async def _proj(self):
+        return "my-project"
+
+    async def _zone(self):
+        return "us-central1-a"
+
+    monkeypatch.setattr(GCPComputeRest, "access_token", _tok)
+    monkeypatch.setattr(GCPComputeRest, "project", _proj)
+    monkeypatch.setattr(GCPComputeRest, "zone", _zone)
+
+
+class _InsertAndStatusHTTP:
+    """POST insert -> 200 op-insert; GET instances/<node> -> scripted status."""
+
+    def __init__(self, inst_status, inst_http=200):
+        self.inst_status = inst_status
+        self.inst_http = inst_http
+        self.posts = 0
+        self.status_gets = 0
+
+    async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        if method == "POST":
+            self.posts += 1
+            return (200, json.dumps({"name": "op-insert"}))
+        if method == "GET" and "/instances/" in url:
+            self.status_gets += 1
+            if self.inst_status is None:
+                return (self.inst_http, json.dumps({"error": {"code": self.inst_http}}))
+            return (self.inst_http, json.dumps({"status": self.inst_status}))
+        return (0, "[unrouted]")
+
+
+# ---------------------------------------------------------------------------
+# get_instance_status -- raw status probe
+# ---------------------------------------------------------------------------
+
+async def test_get_instance_status_running(monkeypatch):
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP("RUNNING"))
+    st, code = await GCPComputeRest().get_instance_status("node", zone="us-central1-b")
+    assert st == "RUNNING"
+    assert code == 200
+
+
+async def test_get_instance_status_absent_404(monkeypatch):
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP(None, inst_http=404))
+    st, code = await GCPComputeRest().get_instance_status("node", zone="us-central1-b")
+    assert st is None
+    assert code == 404
+
+
+# ---------------------------------------------------------------------------
+# Intelligent state-inspection handoff: KEEP materializing, reap only dead
+# ---------------------------------------------------------------------------
+
+async def test_unknown_keeps_provisioning_node(monkeypatch):
+    # 'unknown' op BUT instances.get says STAGING -> slow-but-real -> KEEP it,
+    # do NOT reap, do NOT advance; hand to the L7 readiness gate (route AWAKENING).
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP("STAGING"))
+    _patch_await(monkeypatch, ["unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"          # routes to AWAKENING -> L7 gate owns patience
+    assert "materializing" in detail
+    assert reaped == []                  # the materializing node is NOT reaped
+
+
+async def test_unknown_keeps_running_node(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP("RUNNING"))
+    _patch_await(monkeypatch, ["unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, _detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert reaped == []
+
+
+async def test_unknown_reaps_terminated_node(monkeypatch):
+    # 'unknown' AND instances.get says TERMINATED -> genuine failure -> reap + roll.
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP("TERMINATED"))
+    _patch_await(monkeypatch, ["unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, _detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"
+    assert ("jarvis-prime-failover", "us-central1-a") in reaped
+
+
+async def test_unknown_reaps_absent_node(monkeypatch):
+    # 'unknown' AND instances.get 404 (nothing materialized) -> confirmed-reap
+    # (catch a late one) + roll. NEVER kept.
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP(None, inst_http=404))
+    _patch_await(monkeypatch, ["unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, _detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"
+    assert reaped  # phantom-protection reap fired
+
+
 async def test_insert_unknown_uses_confirmed_reap(monkeypatch):
     # _insert_in_zone on 'unknown' must call the CONFIRMED reap (multiple deletes
     # until clean), not a single blind delete.

--- a/tests/scripts/test_dynamic_audit_log_context.py
+++ b/tests/scripts/test_dynamic_audit_log_context.py
@@ -1,0 +1,119 @@
+"""Dynamic Artifact Context Injection (A1 auditor visibility).
+
+The driver, the organism, and the auditor must all resolve to ONE debug.log via a
+single env var (JARVIS_ACTIVE_SESSION_LOG) -- no hardcoded `bt-<ts>`, no `pending`
+placeholder. This mathematically guarantees the auditor reads exactly where the
+FSM/organism writes its [A1Trace] lines.
+
+Three seams, one contract:
+  - driver  (SoakRunner.launch)            -> DICTATES the absolute path into env
+  - organism (harness._resolve_active_session_dir) -> WRITES debug.log there
+  - auditor (a1_graduation_auditor._resolve_log_file) -> READS that path
+"""
+from __future__ import annotations
+
+import importlib.util
+import os
+import sys
+from pathlib import Path
+
+_REPO_ROOT = str((Path(__file__).parent.parent.parent).resolve())
+_SCRIPTS_DIR = str((Path(__file__).parent.parent.parent / "scripts").resolve())
+for _p in (_REPO_ROOT, _SCRIPTS_DIR, os.path.join(_REPO_ROOT, "backend")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_script(name: str):
+    if name in sys.modules:
+        return sys.modules[name]
+    spec = importlib.util.spec_from_file_location(
+        name, os.path.join(_SCRIPTS_DIR, name + ".py")
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+# ---------------------------------------------------------------------------
+# Auditor: _resolve_log_file (explicit arg wins; else env; else None)
+# ---------------------------------------------------------------------------
+
+def test_auditor_resolve_log_file_prefers_explicit_arg(monkeypatch):
+    aud = _load_script("a1_graduation_auditor")
+    monkeypatch.setenv("JARVIS_ACTIVE_SESSION_LOG", "/env/path/debug.log")
+    assert aud._resolve_log_file("/explicit/debug.log") == "/explicit/debug.log"
+
+
+def test_auditor_resolve_log_file_falls_back_to_env(monkeypatch):
+    aud = _load_script("a1_graduation_auditor")
+    monkeypatch.setenv("JARVIS_ACTIVE_SESSION_LOG", "/env/path/debug.log")
+    assert aud._resolve_log_file(None) == "/env/path/debug.log"
+
+
+def test_auditor_resolve_log_file_none_when_neither(monkeypatch):
+    aud = _load_script("a1_graduation_auditor")
+    monkeypatch.delenv("JARVIS_ACTIVE_SESSION_LOG", raising=False)
+    assert aud._resolve_log_file(None) is None
+
+
+# ---------------------------------------------------------------------------
+# Organism: _resolve_active_session_dir honors the injected path
+# ---------------------------------------------------------------------------
+
+def test_organism_session_dir_honors_env(monkeypatch):
+    from backend.core.ouroboros.battle_test.harness import _resolve_active_session_dir
+    monkeypatch.setenv("JARVIS_ACTIVE_SESSION_LOG", "/abs/sessions/bt-iso-9/debug.log")
+    got = _resolve_active_session_dir(Path("/default/dir"))
+    assert str(got) == "/abs/sessions/bt-iso-9"
+
+
+def test_organism_session_dir_default_when_unset(monkeypatch):
+    from backend.core.ouroboros.battle_test.harness import _resolve_active_session_dir
+    monkeypatch.delenv("JARVIS_ACTIVE_SESSION_LOG", raising=False)
+    got = _resolve_active_session_dir(Path("/default/dir"))
+    assert str(got) == "/default/dir"
+
+
+# ---------------------------------------------------------------------------
+# Driver: SoakRunner.launch DICTATES the path (no discovery, no 'pending')
+# ---------------------------------------------------------------------------
+
+class _FakeProc:
+    def poll(self):
+        return None
+
+
+def test_driver_dictates_session_log_into_child_env(monkeypatch, tmp_path):
+    chaos = _load_script("a1_live_fire_chaos_harness")
+    captured = {}
+
+    def _fake_popen(argv, **kw):
+        captured["env"] = kw.get("env")
+        return _FakeProc()
+
+    monkeypatch.setattr(chaos.subprocess, "Popen", _fake_popen)
+    runner = chaos.SoakRunner(repo_root=str(tmp_path), wall_seconds=10)
+    env: dict = {}
+
+    handle = runner.launch(env, str(tmp_path / "run"))
+
+    assert handle.debug_log.endswith("debug.log")
+    assert "pending" not in handle.debug_log          # no placeholder on the live path
+    assert env["JARVIS_ACTIVE_SESSION_LOG"] == handle.debug_log
+    # The SAME path is injected into the organism child's env (one memory space).
+    assert captured["env"]["JARVIS_ACTIVE_SESSION_LOG"] == handle.debug_log
+
+
+def test_driver_honors_preset_session_log(monkeypatch, tmp_path):
+    chaos = _load_script("a1_live_fire_chaos_harness")
+    monkeypatch.setattr(chaos.subprocess, "Popen", lambda argv, **kw: _FakeProc())
+    runner = chaos.SoakRunner(repo_root=str(tmp_path), wall_seconds=10)
+    preset = str(tmp_path / "custom" / "debug.log")
+    env = {"JARVIS_ACTIVE_SESSION_LOG": preset}
+
+    handle = runner.launch(env, str(tmp_path / "run"))
+
+    assert handle.debug_log == preset


### PR DESCRIPTION
The final two gaps between the proven 5-hop provenance chain and `A1_DISPATCH_PROVEN`. Both TDD, structural, no hardcoding.

## Fix 1 — Intelligent state-inspection handoff (the reap race / slow-op tension)
Run #4: when L4 capacity is scarce the insert *operation* takes >90s to reach terminal DONE (queued), so every op hit the ceiling → `unknown` → the strict reap killed nodes that **were** materializing → nothing ever served.

The `unknown` handler now does `instances.get` **before** acting (constraints #2/#3):
- status ∈ `{PROVISIONING, STAGING, RUNNING, REPAIRING}` → slow-but-**real** → **keep it**, don't reap, don't advance; return `created` → route to AWAKENING and hand patience to the **L7 readiness gate/racer** (the correct owner of "wait for SERVING").
- status `TERMINATED` / absent (404) / errored / unknowable → genuine phantom/failure → **confirmed-reap + roll**.

New `get_instance_status(name, zone)`. Resolves reap-vs-slow-op without trusting an unverified op.

## Fix 2 — Dynamic artifact context injection (the auditor visibility gap)
Run #4: the chain **fired** (44 `[A1Trace]` hops incl. full `emit→…→accept`) but the audit read `.ouroboros/sessions/pending/debug.log` (empty placeholder) while the organism wrote to `bt-<ts>/debug.log` → `a1trace_5_hops_in_order=False`. Evidence existed; the auditor read the wrong source.

One dictated env var `JARVIS_ACTIVE_SESSION_LOG` all three honor — no hardcoded `bt-<ts>`, no discovery race, no `pending`:
- **driver** (`SoakRunner.launch`) dictates an absolute path, injects it into the organism child env before `Popen`, returns it directly (removed the post-boot discovery + `pending` fallback);
- **organism** (`harness._resolve_active_session_dir`) colocates session dir + `configure_silent_boot` debug.log there;
- **auditor** (`a1_graduation_auditor._resolve_log_file`) `--log-file` wins, else the env var.

## Tests (TDD)
- `test_insert_op_failclosed.py` +6 — `get_instance_status`; keep PROVISIONING/RUNNING; reap TERMINATED/absent.
- `test_dynamic_audit_log_context.py` +7 — auditor arg/env/precedence; organism honors/defaults; driver dictates into child env + honors preset.
- 78 green across the scripts + REST suites.

Re-igniting after merge to flip `a1trace_5_hops_in_order` → True.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two A1 gaps: we now keep real nodes when GCE insert ops are slow, and the auditor reads the exact debug log the organism writes. This stabilizes provisioning and makes the 5-hop trace audit reliable.

- **Bug Fixes**
  - Intelligent state-inspection handoff: on an "unknown" insert op, call instances.get; if status is PROVISIONING/STAGING/RUNNING/REPAIRING, keep the node and return created (L7 gate waits); otherwise confirmed-reap and roll. Added `get_instance_status(name, zone)` to `GCPComputeRest`.
  - Dynamic artifact context injection: use one env var `JARVIS_ACTIVE_SESSION_LOG` across driver/organism/auditor. `SoakRunner.launch` dictates an absolute path and injects it before spawn; the organism colocates all session artifacts there and aligns `session_id`; the auditor uses `--log-file` or the env var. Added tests for arg/env precedence and the new keep-vs-reap logic.

<sup>Written for commit ff663affb16fb726daa9a241e9f85c3bbe4aea6a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69785?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

