### PR TITLE
fix(a1): J-Prime dispatch requests the awakened node's model (kill KeyError choices)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3904,6 +3904,19 @@ class CandidateGenerator:
             pass
         return None
 
+    def _resolve_dispatch_model_name(self) -> Optional[str]:
+        """The model the awakened J-Prime node actually serves -- the FSM's
+        awakened-tier truth (``active_jprime_model`` -> HW1 ``_active_model_label``,
+        e.g. ``qwen2.5-coder:32b``), so the OpenAI-compat request names a model the
+        node has loaded. None if undeterminable (caller keeps the env default).
+        Fail-soft -- NEVER raises."""
+        try:
+            from .failover_lifecycle import get_failover_controller
+            model = (get_failover_controller().active_jprime_model() or "").strip()
+            return model or None
+        except Exception:  # noqa: BLE001
+            return None
+
     async def _failover_local_dispatch(
         self,
         context: OperationContext,
@@ -3935,11 +3948,19 @@ class CandidateGenerator:
             PrimeProvider as _F3cPrimeProvider,
         )
 
-        # Point a LocalConfig at the awakened endpoint (base_url override).
-        # All other knobs read from env via from_env() -> nothing hardcoded.
-        _cfg = _f3c_dc.replace(
-            _F3cLocalConfig.from_env(), base_url=endpoint,
-        )
+        # Point a LocalConfig at the awakened endpoint (base_url override) AND at
+        # the model the awakened node actually serves. LocalConfig.from_env()
+        # defaults model_name to a small survival model (qwen2.5-coder:3b); the
+        # QUALITY failover node serves qwen2.5-coder:32b, so without this override
+        # the OpenAI-compat request asks for a model the node does not have and
+        # ollama returns an error object with no "choices" -> KeyError('choices').
+        # The model label is the FSM's awakened-tier truth (HW1 _active_model_label),
+        # not a hardcoded string.
+        _overrides = {"base_url": endpoint}
+        _model = self._resolve_dispatch_model_name()
+        if _model:
+            _overrides["model_name"] = _model
+        _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)
         _client = _F3cLocalPrimeClient(_cfg)
         try:
             _provider = _F3cPrimeProvider(

--- a/tests/governance/test_failover_provider_override.py
+++ b/tests/governance/test_failover_provider_override.py
@@ -216,6 +216,31 @@ async def test_unrecognized_override_falls_through(monkeypatch):
     assert result is None
 
 
+async def test_dispatch_model_name_is_awakened_tier_model(monkeypatch):
+    """The J-Prime dispatch must request the model the awakened node SERVES
+    (qwen2.5-coder:32b), not LocalConfig's small default -- else ollama returns an
+    error object with no 'choices' (the KeyError that severed the live GENERATE)."""
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+    gen = _make_generator(jprime=None)
+
+    monkeypatch.setattr(
+        fl, "get_failover_controller",
+        lambda: SimpleNamespace(active_jprime_model=lambda: "qwen2.5-coder:32b"),
+    )
+    assert gen._resolve_dispatch_model_name() == "qwen2.5-coder:32b"
+
+
+async def test_dispatch_model_name_fail_soft(monkeypatch):
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+    gen = _make_generator(jprime=None)
+
+    def _boom():
+        raise RuntimeError("no controller")
+
+    monkeypatch.setattr(fl, "get_failover_controller", _boom)
+    assert gen._resolve_dispatch_model_name() is None  # never raises
+
+
 async def test_override_field_on_operation_context_roundtrips():
     """The provider_override field is a real, replace-able field on the frozen
     OperationContext (so the seal stamp is durable)."""


### PR DESCRIPTION
After dynamic routing (#69789) reached the 32B, GENERATE still failed with `Phase 3c failover seam fail-soft err=KeyError('choices')`. Root cause: `_failover_local_dispatch` overrode only `base_url`, so `LocalConfig`'s default `model_name=qwen2.5-coder:3b` was sent to the QUALITY node serving `qwen2.5-coder:32b` → ollama returns an error object with no `choices` → KeyError → fail-soft → exhaust. Fix: `_resolve_dispatch_model_name()` uses the FSM's awakened-tier truth (`active_jprime_model()` → HW1 `_active_model_label`) and overrides `LocalConfig.model_name`. No hardcoded string; fail-soft. +2 TDD, 12 green. Re-igniting for 6/6.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes J-Prime failover dispatch to request the awakened node’s actual model, preventing KeyError('choices') during GENERATE and restoring seamless failover.

- **Bug Fixes**
  - Resolve model from the FSM (`active_jprime_model`) and override `model_name` alongside `base_url` in local dispatch.
  - Fail-soft: if the model can’t be determined, keep the env default.
  - Added tests for model selection and fallback behavior.

<sup>Written for commit 4330813702cebac203d7b5b3cce51d2515568155. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

