### PR TITLE
feat(a1): cross-region L4 capacity hunter + fast-fail short-circuit

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -733,7 +733,23 @@ class GCPComputeRest:
                 logger.warning("[GCPComputeRest] STOCKOUT zone=%s -> failover to next zone", z)
                 continue
             return (False, "INSERT_FAILED:{}".format(detail))  # non-stockout -> stop
-        return (False, "INSERT_FAILED:all_zones_stockout:{}".format(last))
+        # The ENTIRE cross-region matrix stocked out -> a genuine global L4 capacity
+        # wall. Emit a distinct, greppable marker so the ignition driver can
+        # fast-fail (short-circuit the L7 gate + audit) instead of waiting them out.
+        try:
+            from backend.core.ouroboros.governance.zone_fallback import (  # noqa: PLC0415
+                regions_in_chain,
+            )
+            _regions = ",".join(regions_in_chain(zone))
+        except Exception:  # noqa: BLE001
+            _regions = "?"
+        logger.error(
+            "[GCPComputeRest] HARDWARE_CAPACITY_EXHAUSTED: L4 stockout across ALL "
+            "regions in the cross-region matrix (regions=%s zones=%d) -- global "
+            "capacity wall, no node materialized", _regions, len(chain),
+        )
+        return (False, "INSERT_FAILED:all_zones_stockout:regions={}:{}".format(
+            _regions, last))
 
     async def _insert_in_zone(
         self, *, zone, project, token, headers, node, machine, family,

--- a/backend/core/ouroboros/governance/zone_fallback.py
+++ b/backend/core/ouroboros/governance/zone_fallback.py
@@ -16,12 +16,26 @@ from __future__ import annotations
 import os
 from typing import List, Optional
 
-# Cross-region L4-capable chain (mirrors jarvis-prime gcp_vm_manager's us-central1
-# array, extended cross-region so a single regional stockout can't strand a bake).
-_DEFAULT_ZONES = (
-    "us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f",
-    "us-west1-b", "us-east4-a", "us-east1-b",
+# Cross-Region L4 Capacity Matrix -- grouped by region, region-ordered. When an
+# ENTIRE region is ZONE_RESOURCE_POOL_EXHAUSTED the hunt falls to the next region,
+# so provisioning adapts to GLOBAL L4 capacity, not local scarcity. The zones are
+# the nvidia-l4-capable zones per region (US-first; extend via env for EU/APAC).
+# Env JARVIS_GCP_ZONE_FALLBACK overrides the whole matrix (comma-separated).
+_L4_REGION_MATRIX = (
+    ("us-central1", ("us-central1-a", "us-central1-b", "us-central1-c", "us-central1-f")),
+    ("us-east1", ("us-east1-c", "us-east1-d")),
+    ("us-east4", ("us-east4-a", "us-east4-c")),
+    ("us-west1", ("us-west1-a", "us-west1-b")),
+    ("us-west4", ("us-west4-a",)),
+    ("us-south1", ("us-south1-a",)),
 )
+_DEFAULT_ZONES = tuple(z for _region, _zones in _L4_REGION_MATRIX for z in _zones)
+
+
+def region_of(zone: str) -> str:
+    """The region a zone belongs to (``us-east4-a`` -> ``us-east4``). NEVER raises."""
+    z = str(zone or "").strip()
+    return z.rsplit("-", 1)[0] if "-" in z else z
 
 # A STOCKOUT (transient capacity) is RETRYABLE in another zone. A QUOTA error is
 # NOT -- retrying elsewhere just fails again (regional quota), so we must NOT
@@ -37,20 +51,40 @@ _STOCKOUT_SIGNS = (
 
 
 def zone_fallback_chain(preferred: Optional[str] = None) -> List[str]:
-    """Ordered zone chain; ``preferred`` (e.g. the metadata zone) is tried first,
-    then the rest, de-duplicated. NEVER raises."""
+    """Ordered cross-region zone chain. ``preferred`` (e.g. the metadata zone) leads,
+    then the REST OF ITS REGION (exhaust the local region first), then every other
+    region in matrix order -- so a whole-region stockout falls to a fallback region.
+    Env ``JARVIS_GCP_ZONE_FALLBACK`` overrides the matrix (honored verbatim, still
+    preferred-led + region-front-loaded). De-duplicated. NEVER raises."""
     raw = os.environ.get("JARVIS_GCP_ZONE_FALLBACK", "").strip()
     base = [z.strip() for z in raw.split(",") if z.strip()] if raw else list(_DEFAULT_ZONES)
     ordered: List[str] = []
-    if preferred and preferred.strip():
-        ordered.append(preferred.strip())
+    pref = preferred.strip() if (preferred and preferred.strip()) else ""
+    if pref:
+        ordered.append(pref)
+        # Front-load the rest of the preferred zone's region before other regions.
+        pref_region = region_of(pref)
+        ordered.extend(z for z in base if region_of(z) == pref_region)
     ordered.extend(base)
     seen = set()
-    out = []
+    out: List[str] = []
     for z in ordered:
         if z and z not in seen:
             seen.add(z)
             out.append(z)
+    return out
+
+
+def regions_in_chain(preferred: Optional[str] = None) -> List[str]:
+    """The ordered, unique regions the fallback chain will hunt (for cross-region
+    logging + 'all regions exhausted' detection). NEVER raises."""
+    seen = set()
+    out: List[str] = []
+    for z in zone_fallback_chain(preferred):
+        r = region_of(z)
+        if r and r not in seen:
+            seen.add(r)
+            out.append(r)
     return out
 
 
@@ -63,4 +97,6 @@ def is_stockout_error(text: str) -> bool:
     return any(s in t for s in _STOCKOUT_SIGNS)
 
 
-__all__ = ["zone_fallback_chain", "is_stockout_error"]
+__all__ = [
+    "zone_fallback_chain", "is_stockout_error", "region_of", "regions_in_chain",
+]

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -409,9 +409,10 @@ async def _arm_failover_mesh(env: Dict[str, str]) -> None:
     """
     env["JARVIS_FAILOVER_HYBRID_MESH"] = "true"             # external-natIP route
     env["JARVIS_FAILOVER_INFERENCE_BIND_ENABLED"] = "true"  # node binds 0.0.0.0
-    # L4-capable zones ONLY (drop non-L4 zones like us-central1-f whose 400
-    # halts the multi-zonal chain). Quota is confirmed in us-central1.
-    env.setdefault("JARVIS_GCP_ZONE_FALLBACK", "us-central1-a,us-central1-b,us-central1-c")
+    # Cross-Region Capacity Matrix: do NOT pin a single region -- a whole-region L4
+    # stockout must fall to a fallback region. Leave JARVIS_GCP_ZONE_FALLBACK unset
+    # so zone_fallback._DEFAULT_ZONES (the region-ordered L4 matrix) applies; an
+    # operator may still override with an explicit cross-region list.
     # L4 Spot is scarce -> let a Spot stockout fall through to on-demand in
     # the same quota'd zone (bounded $; the run is short + violently reaped).
     env.setdefault("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
@@ -515,8 +516,27 @@ def _probe_api_tags(url: str) -> int:
         return int(getattr(he, "code", 0) or 0)
 
 
+_CAPACITY_EXHAUSTED_MARKER = "HARDWARE_CAPACITY_EXHAUSTED"
+
+
+def _hardware_capacity_exhausted(debug_log: Optional[str]) -> bool:
+    """True iff the organism logged a global L4 capacity wall (the cross-region
+    matrix stocked out with no node). Lets the L7 gate + audit fast-fail instead
+    of waiting out their full budgets. Fail-soft -> False when unreadable."""
+    if not debug_log:
+        return False
+    try:
+        if not os.path.isfile(debug_log):
+            return False
+        with open(debug_log, "r", encoding="utf-8", errors="ignore") as fh:
+            return _CAPACITY_EXHAUSTED_MARKER in fh.read()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 async def _await_jprime_serving(
     node_name: str, *, budget_s: float, port: int = 11434,
+    debug_log: Optional[str] = None,
 ) -> bool:
     """Suspend until the awakened GCP node's inference server returns HTTP 200 on
     ``/api/tags`` (the 32B is loaded into VRAM). Exponential backoff (cap'd),
@@ -545,6 +565,12 @@ async def _await_jprime_serving(
         return False
 
     while time.monotonic() < deadline:
+        # Fast-Fail short-circuit: if the organism hit a global L4 capacity wall
+        # (cross-region matrix exhausted), stop waiting out the L7 budget NOW.
+        if _hardware_capacity_exhausted(debug_log):
+            _log("[HybridMesh] HardwareCapacityExhausted -> L7 gate fast-fail "
+                 "(cross-region L4 stockout; not waiting out %.0fs)" % budget_s)
+            return False
         external: Optional[str] = None
         try:
             _internal, external = await get_compute_rest().get_node_endpoints(
@@ -1096,28 +1122,46 @@ class IsomorphicA1Driver:
                         _log("[HybridMesh] L7 readiness gate: awaiting 32B SERVING "
                              "(budget=%.0fs) before audit ..." % _budget)
                         _served = await _await_jprime_serving(
-                            _node, budget_s=_budget)
+                            _node, budget_s=_budget, debug_log=debug_log)
                         _log("[HybridMesh] L7 readiness gate -> %s"
                              % ("SERVING" if _served else "TIMEOUT"))
 
-                    # ── e. LAUNCH AUDITOR ────────────────────────────────────
-                    _log("STEP audit: sse=%s log=%s" % (self.sse_base, debug_log))
-                    if self.stub_soak:
-                        aud_runner = harness_mod.StubAuditorRunner(
-                            strict=self.strict, goal_id="GOAL-ISO-A1")
-                    else:
-                        aud_runner = harness_mod.AuditorRunner(strict=self.strict)
-
-                    verdict = aud_runner.watch(
-                        base=self.sse_base,
-                        log_file=debug_log,
-                        timeout_s=_a1_audit_ceiling_s(),
-                        verdict_out=verdict_out,
+                    # ── Fast-Fail short-circuit: a global L4 capacity wall means the
+                    # cognitive loop can NEVER reach APPLIED this run. Skip the audit
+                    # ceiling entirely, emit a capacity verdict, and flow to teardown
+                    # -- zero wasted wall-clock (no 480s audit on a foregone result).
+                    _capacity_wall = (
+                        self.enable_failover and _hardware_capacity_exhausted(debug_log)
                     )
+                    if _capacity_wall:
+                        _log("[HybridMesh] HardwareCapacityExhausted -> short-circuit "
+                             "A1 audit (global L4 stockout; NOT a cognitive failure)")
+                        verdict = {
+                            "proven": False,
+                            "failure_locus": "hardware_capacity_exhausted:no_l4_global",
+                            "capacity_exhausted": True,
+                        }
+                        proven = False
+                        _log("STEP audit VERDICT: SKIPPED (hardware_capacity_exhausted)")
+                    else:
+                        # ── e. LAUNCH AUDITOR ────────────────────────────────
+                        _log("STEP audit: sse=%s log=%s" % (self.sse_base, debug_log))
+                        if self.stub_soak:
+                            aud_runner = harness_mod.StubAuditorRunner(
+                                strict=self.strict, goal_id="GOAL-ISO-A1")
+                        else:
+                            aud_runner = harness_mod.AuditorRunner(strict=self.strict)
 
-                    proven = bool(verdict.get("proven"))
-                    _log("STEP audit VERDICT: %s"
-                         % ("A1_DISPATCH_PROVEN" if proven else "FAILED"))
+                        verdict = aud_runner.watch(
+                            base=self.sse_base,
+                            log_file=debug_log,
+                            timeout_s=_a1_audit_ceiling_s(),
+                            verdict_out=verdict_out,
+                        )
+
+                        proven = bool(verdict.get("proven"))
+                        _log("STEP audit VERDICT: %s"
+                             % ("A1_DISPATCH_PROVEN" if proven else "FAILED"))
 
                     # ── f. FAILURE PATH: T5 telemetry + local autopsy ────────
                     if not proven:

--- a/tests/governance/test_cross_region_matrix.py
+++ b/tests/governance/test_cross_region_matrix.py
@@ -1,0 +1,97 @@
+"""Cross-region L4 capacity matrix (beat a whole-region stockout).
+
+A single-region zone chain strands the awaken when that region is fully
+ZONE_RESOURCE_POOL_EXHAUSTED. The fallback chain must span regions -- preferred
+region first, then fall to other L4-capable regions -- so the hunt adapts to
+GLOBAL capacity, not local scarcity. Env-driven; no hardcoded single region.
+"""
+from __future__ import annotations
+
+import backend.core.ouroboros.governance.zone_fallback as zf
+
+
+def test_default_chain_spans_multiple_regions(monkeypatch):
+    monkeypatch.delenv("JARVIS_GCP_ZONE_FALLBACK", raising=False)
+    chain = zf.zone_fallback_chain("us-central1-a")
+    regions = {zf.region_of(z) for z in chain}
+    assert "us-central1" in regions
+    # Must fall out of us-central1 into other L4 regions.
+    assert len(regions) >= 3, regions
+    assert any(r != "us-central1" for r in regions)
+
+
+def test_preferred_region_ordered_first(monkeypatch):
+    monkeypatch.delenv("JARVIS_GCP_ZONE_FALLBACK", raising=False)
+    chain = zf.zone_fallback_chain("us-west1-b")
+    # The preferred zone leads; its region's zones precede other regions.
+    assert chain[0] == "us-west1-b"
+    first_other = next(i for i, z in enumerate(chain) if zf.region_of(z) != "us-west1")
+    west_idxs = [i for i, z in enumerate(chain) if zf.region_of(z) == "us-west1"]
+    assert max(west_idxs) < first_other  # all us-west1 zones before any other region
+
+
+def test_region_of():
+    assert zf.region_of("us-east4-a") == "us-east4"
+    assert zf.region_of("us-central1-f") == "us-central1"
+    assert zf.region_of("") == ""
+
+
+def test_regions_in_chain_ordered_unique(monkeypatch):
+    monkeypatch.delenv("JARVIS_GCP_ZONE_FALLBACK", raising=False)
+    regions = zf.regions_in_chain()
+    assert regions[0] == zf.region_of(zf.zone_fallback_chain()[0])
+    assert len(regions) == len(set(regions))  # unique, order-preserved
+
+
+def test_env_override_still_honored(monkeypatch):
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "europe-west4-a,europe-west1-b")
+    chain = zf.zone_fallback_chain()
+    assert chain[:2] == ["europe-west4-a", "europe-west1-b"]
+
+
+def test_dedup_preserves_order(monkeypatch):
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "us-east1-c,us-east1-c,us-west1-a")
+    chain = zf.zone_fallback_chain("us-east1-c")
+    assert chain == ["us-east1-c", "us-west1-a"]
+
+
+# ---------------------------------------------------------------------------
+# Fast-Fail: create_instance emits HARDWARE_CAPACITY_EXHAUSTED on global stockout
+# ---------------------------------------------------------------------------
+
+import logging  # noqa: E402
+import pytest  # noqa: E402
+import backend.core.ouroboros.governance.gcp_compute_rest as gr  # noqa: E402
+from backend.core.ouroboros.governance.gcp_compute_rest import GCPComputeRest  # noqa: E402
+
+pytestmark_async = pytest.mark.asyncio
+
+
+@pytest.mark.asyncio
+async def test_create_instance_emits_capacity_exhausted_on_global_stockout(monkeypatch, caplog):
+    monkeypatch.delenv("JARVIS_GCP_ZONE_FALLBACK", raising=False)
+
+    async def _tok(self):
+        return "ya29.FAKE"
+
+    async def _zone(self):
+        return "us-central1-a"
+
+    async def _proj(self):
+        return "p"
+
+    async def _all_stockout(self, **kw):
+        return ("stockout", "zone={}:op_stockout".format(kw.get("zone")))
+
+    monkeypatch.setattr(GCPComputeRest, "access_token", _tok)
+    monkeypatch.setattr(GCPComputeRest, "zone", _zone)
+    monkeypatch.setattr(GCPComputeRest, "project", _proj)
+    monkeypatch.setattr(GCPComputeRest, "_insert_in_zone", _all_stockout)
+
+    with caplog.at_level(logging.ERROR):
+        ok, detail = await GCPComputeRest().create_instance(startup_script="x")
+
+    assert ok is False
+    assert "all_zones_stockout:regions=" in detail          # regions recorded
+    blob = "\n".join(r.getMessage() for r in caplog.records)
+    assert "HARDWARE_CAPACITY_EXHAUSTED" in blob            # the fast-fail marker

--- a/tests/scripts/test_soak_process_group_teardown.py
+++ b/tests/scripts/test_soak_process_group_teardown.py
@@ -159,3 +159,24 @@ def test_reap_soak_runners_never_raises():
     _drv._reap_soak_runners()  # must not raise
 
     assert _drv._ACTIVE_SOAK_RUNNERS == []
+
+
+# ---------------------------------------------------------------------------
+# Fast-Fail: driver detects the global L4 capacity wall marker
+# ---------------------------------------------------------------------------
+
+def test_hardware_capacity_exhausted_detects_marker(tmp_path):
+    log = tmp_path / "debug.log"
+    log.write_text("...\n[GCPComputeRest] HARDWARE_CAPACITY_EXHAUSTED: L4 stockout ...\n...")
+    assert _drv._hardware_capacity_exhausted(str(log)) is True
+
+
+def test_hardware_capacity_exhausted_absent(tmp_path):
+    log = tmp_path / "debug.log"
+    log.write_text("[GCPComputeRest] instances.insert ok node=x zone=us-west1-a\n")
+    assert _drv._hardware_capacity_exhausted(str(log)) is False
+
+
+def test_hardware_capacity_exhausted_missing_file_is_false():
+    assert _drv._hardware_capacity_exhausted("/no/such/debug.log") is False
+    assert _drv._hardware_capacity_exhausted(None) is False


### PR DESCRIPTION
Run #7 stranded on a whole-region L4 stockout (driver pinned us-central1-a/b/c) then wasted the 900s L7 gate + 480s audit ceiling. Two structural fixes:

**1. Cross-Region Capacity Matrix** — `_L4_REGION_MATRIX` (region-grouped, region-ordered across us-central1/east1/east4/west1/west4/south1); `zone_fallback_chain()` exhausts the preferred region then falls to a fallback region; `region_of()`/`regions_in_chain()`. Driver stops clobbering the chain to one region. The insert payload is already region-agnostic (global sourceImage + auto-subnet + zone-scoped machineType).

**2. Fast-Fail short-circuit** — `create_instance` emits `HARDWARE_CAPACITY_EXHAUSTED` when the whole matrix stocks out; the driver detects it and instantly short-circuits both the L7 gate and the audit ceiling (verdict `hardware_capacity_exhausted:no_l4_global`) → straight to teardown. Zero wasted wall-clock on a capacity wall.

TDD: 16 green (chain/region ordering, create_instance marker, driver detector). Re-igniting to scour the regions for an L4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cross‑region L4 capacity fallback and a fast‑fail path to avoid wasting L7 and audit budgets when global L4 capacity is exhausted. Prevents runs from getting pinned to a single region and timing out on a foregone result.

- **New Features**
  - Cross‑region capacity matrix: `_L4_REGION_MATRIX` spans `us-central1`, `us-east1`, `us-east4`, `us-west1`, `us-west4`, `us-south1`. `zone_fallback_chain()` tries the preferred zone, then the rest of its region, then other regions. Helpers `region_of()` and `regions_in_chain()` added. `JARVIS_GCP_ZONE_FALLBACK` still overrides. Default driver config no longer pins to `us-central1` only.
  - Fast‑fail short‑circuit: `create_instance` emits `HARDWARE_CAPACITY_EXHAUSTED` when all zones in the matrix stock out. Driver `_hardware_capacity_exhausted()` detects the marker, skips the L7 gate and the audit ceiling, and returns a capacity verdict (`failure_locus=hardware_capacity_exhausted:no_l4_global`) before teardown.

<sup>Written for commit 5b67a57e5b15fb80555ea4ccc2cbd145f19827d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69791?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

