### PR TITLE
feat(a1): cognitive last mile — DRY 32B router + exploration prompt + agentic ceiling

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4028,30 +4028,33 @@ class CandidateGenerator:
         # LocalPrimeClient raises, empty result), we log + fall through to the
         # normal DW path -- the op is NEVER lost.
         try:
-            if lifecycle_enabled() and get_failover_controller().is_jprime_serving():
-                _ep = get_failover_controller().jprime_endpoint()
-                if _ep:
-                    _local_result = await self._failover_local_dispatch(
-                        context, deadline, _ep,
-                    )
-                    if _local_result is not None and len(
-                        getattr(_local_result, "candidates", ()) or ()
-                    ) > 0:
-                        logger.info(
-                            "[CandidateGenerator] Phase 3c DAG re-entry: J-Prime "
-                            "SERVING -> routed generation to LocalPrimeClient "
-                            "endpoint=%s (DW bypassed) op=%s route=%s",
-                            _ep,
-                            getattr(context, "op_id", "?")[:16],
-                            provider_route,
-                        )
-                        return _local_result
+            # DRY universal router: EVERY DW dispatch (primary, GENERATE_RETRY,
+            # critique, immortal re-queue) funnels through this chokepoint, so one
+            # branch re-routes them all to the awakened 32B. Use the ROBUST
+            # discovery (_discover_jprime_endpoint: controller-published endpoint
+            # when SERVING, else a direct zone-aware GCP query) instead of only
+            # is_jprime_serving() -- so a RETRY routes to the 32B even when this
+            # process's controller FSM isn't itself in SERVING state.
+            _ep = await self._discover_jprime_endpoint()
+            if _ep:
+                _local_result = await self._failover_local_dispatch(
+                    context, deadline, _ep,
+                )
+                if _local_result is not None and len(
+                    getattr(_local_result, "candidates", ()) or ()
+                ) > 0:
                     logger.info(
-                        "[CandidateGenerator] Phase 3c DAG re-entry: J-Prime "
-                        "local route empty/failed -> falling through to DW "
-                        "(op=%s route=%s)",
-                        getattr(context, "op_id", "?")[:16], provider_route,
+                        "[CandidateGenerator] Phase 3c DAG re-entry: routed "
+                        "generation to the awakened 32B endpoint=%s (DW bypassed) "
+                        "op=%s route=%s",
+                        _ep, getattr(context, "op_id", "?")[:16], provider_route,
                     )
+                    return _local_result
+                logger.info(
+                    "[CandidateGenerator] Phase 3c DAG re-entry: J-Prime local "
+                    "route empty/failed -> falling through to DW (op=%s route=%s)",
+                    getattr(context, "op_id", "?")[:16], provider_route,
+                )
         except Exception as _f3c_exc:  # noqa: BLE001 -- seam must never break the op
             logger.warning(
                 "[CandidateGenerator] Phase 3c failover seam fail-soft err=%r "

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -198,6 +198,34 @@ _CODEGEN_SYSTEM_PROMPT = (
     )
 )
 
+
+def _a1_exploration_addendum() -> str:
+    """A1 soak: teach the model the Iron Gate's exploration-first contract so it
+    does NOT emit zero-shot diffs (which the gate rejects -> GENERATE_RETRY). Text
+    names the exact _EXPLORATION_TOOLS + the >=2-before-patch floor the gate
+    enforces (orchestrator._min_explore). Read at CALL time (not frozen at import)
+    so it can be toggled per-run. Gated by JARVIS_A1_EXPLORATION_PROMPT_ENABLED
+    (default off -> byte-identical). NEVER raises."""
+    try:
+        val = (os.environ.get("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", "") or "").strip().lower()
+        if val not in ("1", "true", "yes", "on"):
+            return ""
+        try:
+            floor = max(2, int(os.environ.get("JARVIS_MIN_EXPLORATION_CALLS", "2") or 2))
+        except (TypeError, ValueError):
+            floor = 2
+        return (
+            "\n\nEXPLORATION-FIRST MANDATE (hard-enforced by an Iron Gate): before "
+            "you emit ANY patch or full_content, you MUST first call the exploration "
+            "tools -- read_file and/or search_code (get_callers, list_symbols, "
+            "glob_files, list_dir also count) -- AT LEAST %d times. Read the target "
+            "file(s) and search for callers/usages FIRST, then propose your patch. A "
+            "patch proposed with fewer than %d exploration tool calls is AGGRESSIVELY "
+            "REJECTED and forces a retry. Explore, then patch." % (floor, floor)
+        )
+    except Exception:  # noqa: BLE001
+        return ""
+
 # ── Phase 2B: size/security constants ────────────────────────────────────
 # Prompt compression: aggressive defaults to reduce token cost.
 # With Venom tool loop active, the model can read_file to see specific
@@ -5452,7 +5480,7 @@ class PrimeProvider:
         async def _generate_raw(p: str) -> str:
             resp = await self._client.generate(
                 prompt=p,
-                system_prompt=_CODEGEN_SYSTEM_PROMPT,
+                system_prompt=_CODEGEN_SYSTEM_PROMPT + _a1_exploration_addendum(),
                 max_tokens=_retry_max_tokens,
                 temperature=_eff_temperature,
                 model_name=_brain_model,

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -409,6 +409,10 @@ async def _arm_failover_mesh(env: Dict[str, str]) -> None:
     """
     env["JARVIS_FAILOVER_HYBRID_MESH"] = "true"             # external-natIP route
     env["JARVIS_FAILOVER_INFERENCE_BIND_ENABLED"] = "true"  # node binds 0.0.0.0
+    # Teach the 32B the Iron Gate's exploration-first contract (>=2 read_file/
+    # search_code before any patch) so it does not emit zero-shot diffs that the
+    # gate rejects -> GENERATE_RETRY. Injected into the Prime-path system prompt.
+    env.setdefault("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", "true")
     # Cross-Region Capacity Matrix: do NOT pin a single region -- a whole-region L4
     # stockout must fall to a fallback region. Leave JARVIS_GCP_ZONE_FALLBACK unset
     # so zone_fallback._DEFAULT_ZONES (the region-ordered L4 matrix) applies; an
@@ -448,11 +452,12 @@ def _env_float(name: str, default: float) -> float:
 def _a1_audit_ceiling_s() -> float:
     """Tier-aware audit ceiling (no hardcoded window). The auditor early-exits the
     moment the verdict is proven; this is the SAFETY ceiling. It is derived from
-    the resolved failover tier: a heavy 32B/L4 op needs minutes to traverse
-    CLASSIFY->...->APPLY->terminal, so we scale the base by the SAME
-    JARVIS_JPRIME_HEAVY_COLDSTART_MULT used for the cold-start timeouts. Survival
-    (7B/CPU) -> base unchanged. Fail-soft -> base on any error."""
-    base = _env_float("JARVIS_A1_AUDIT_BASE_S", 120.0)
+    the resolved failover tier: a heavy 32B/L4 op runs a MULTI-TURN Venom tool loop
+    (explore -> read -> patch -> validate) that is I/O-heavy and slow, so we scale
+    the base by the SAME JARVIS_JPRIME_HEAVY_COLDSTART_MULT as the cold-start
+    timeouts. Base default 300s x4 = 1200s (~20 min) gives the agentic explore-then
+    -fix cycle real wall-clock. Survival (7B/CPU) -> base unchanged. Fail-soft."""
+    base = _env_float("JARVIS_A1_AUDIT_BASE_S", 300.0)
     try:
         from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
             resolve_tier,

--- a/tests/governance/test_a1_exploration_prompt.py
+++ b/tests/governance/test_a1_exploration_prompt.py
@@ -1,0 +1,39 @@
+"""A1 exploration-forcing system-prompt addendum.
+
+The 32B fails the Iron Gate by emitting zero-shot diffs. This addendum (injected
+into the Prime-path system prompt, gated to the A1 soak) teaches it the gate's
+contract: >=2 read_file/search_code calls BEFORE any patch. Byte-identical (empty)
+when the flag is off.
+"""
+from __future__ import annotations
+
+import backend.core.ouroboros.governance.providers as providers
+
+
+def test_addendum_empty_when_disabled(monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", raising=False)
+    assert providers._a1_exploration_addendum() == ""
+
+
+def test_addendum_present_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", "true")
+    txt = providers._a1_exploration_addendum()
+    assert txt  # non-empty
+    # Names the exact exploration tools + the >=2-before-patch floor the gate enforces.
+    assert "read_file" in txt and "search_code" in txt
+    assert "2" in txt
+    assert "patch" in txt.lower()
+
+
+def test_addendum_floor_tracks_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_MIN_EXPLORATION_CALLS", "3")
+    txt = providers._a1_exploration_addendum()
+    assert "3 times" in txt or "least 3" in txt
+
+
+def test_addendum_fail_soft_on_bad_floor(monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", "on")
+    monkeypatch.setenv("JARVIS_MIN_EXPLORATION_CALLS", "not-a-number")
+    txt = providers._a1_exploration_addendum()  # must not raise; floor -> 2
+    assert "2" in txt


### PR DESCRIPTION
Run #8 reached the 32B (route_to_32B=9, no KeyError) but candidates failed the Iron Gate → 12× GENERATE_RETRY → no APPLY. Three fixes:

**1. DRY universal router** — the Phase 3c sentinel chokepoint (every dispatch: primary, GENERATE_RETRY, critique, immortal re-queue) now uses the robust `_discover_jprime_endpoint()` instead of only `is_jprime_serving()`, so **retries route to the 32B**, not chaos-killed DW.

**2. Exploration-forcing system prompt** — `_a1_exploration_addendum()` injected at the single Prime-path `_generate_raw` chokepoint (Venom loop + no-tool). Names the exact `_EXPLORATION_TOOLS` + the ≥2-before-patch floor, so the 32B explores-then-patches on the first attempt. Gated `JARVIS_A1_EXPLORATION_PROMPT_ENABLED`; floor tracks `JARVIS_MIN_EXPLORATION_CALLS`.

**3. Agentic audit ceiling** — base 120→300s × heavy mult = **1200s (~20 min)** for the multi-turn tool loop; still early-exits on proven.

TDD: 4 addendum cases + 15 override/ceiling green. Re-igniting to watch the 32B explore → pass the Iron Gate → APPLIED → 6/6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies routing so every retry hits the 32B, teaches the model to explore before patching, and extends the audit ceiling so multi‑turn loops can complete. This fixes Iron Gate failures and avoids dead-end DW fallbacks.

- New Features
  - Exploration-first system prompt: injects `_a1_exploration_addendum()` into the Prime path (`_generate_raw`). Gated by `JARVIS_A1_EXPLORATION_PROMPT_ENABLED` (off by default; local script sets to `true`). Names `read_file`, `search_code`, etc., and enforces a floor from `JARVIS_MIN_EXPLORATION_CALLS` (min 2).
  - Agentic audit ceiling: default base `JARVIS_A1_AUDIT_BASE_S` 300s, scaled by `JARVIS_JPRIME_HEAVY_COLDSTART_MULT` (e.g., 4 → ~1200s). Still early-exits when proven.

- Bug Fixes
  - DRY universal router: Phase 3c uses `_discover_jprime_endpoint()` so primary, `GENERATE_RETRY`, critique, and re-queue all route to the 32B instead of DW. Adds fail-soft logging and keeps DW as fallback when local route is empty.

<sup>Written for commit 504d2285420d6914e094ec273db3706fbfbdb309. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

