### PR TITLE
fix(a1): heavy-tier local-inference timeouts — let the cold 32B's first call finish

### DIFF
--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -413,6 +413,13 @@ async def _arm_failover_mesh(env: Dict[str, str]) -> None:
     # search_code before any patch) so it does not emit zero-shot diffs that the
     # gate rejects -> GENERATE_RETRY. Injected into the Prime-path system prompt.
     env.setdefault("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", "true")
+    # Heavy-tier local-inference timeouts: the LocalPrimeClient's adaptive timeout
+    # seeds at 30s (fine for a 7B), but a cold 32B's FIRST generation exceeds 30s ->
+    # LocalLatencyLockup -> no latency sample is ever recorded -> it never adapts up
+    # (stuck at the seed). Seed the cold-start budget + raise the ceiling to fit the
+    # slow 32B multi-turn tool loop so the first call actually completes.
+    env.setdefault("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", "150000")   # 150s cold seed
+    env.setdefault("JARVIS_LOCAL_INFERENCE_TIMEOUT_MS", "300000")        # 300s ceiling
     # Cross-Region Capacity Matrix: do NOT pin a single region -- a whole-region L4
     # stockout must fall to a fallback region. Leave JARVIS_GCP_ZONE_FALLBACK unset
     # so zone_fallback._DEFAULT_ZONES (the region-ordered L4 matrix) applies; an


### PR DESCRIPTION
Run #9's 32B dispatch failed with `LocalLatencyLockup('local_inference timeout: budget=30000ms')`. The LocalPrimeClient's adaptive timeout **seeds at 30s** (fine for a 7B); a cold 32B's first generation exceeds 30s → lockup → **no latency sample recorded → never adapts up → stuck at the 30s seed**. Every 32B call timed out on the first token and fell through to chaos-killed DW. Fix: the driver arms `JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS=150000` + `JARVIS_LOCAL_INFERENCE_TIMEOUT_MS=300000` for the heavy tier (same pattern as the QUALITY-tier env), so the first call completes and the existing adaptive timer takes over. Env-driven; prod default byte-identical.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents local-inference lockups on heavy-tier (32B) models by raising the adaptive timeout seed and ceiling so the first cold call can finish and seed latency.

- **Bug Fixes**
  - Set `JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS=150000` and `JARVIS_LOCAL_INFERENCE_TIMEOUT_MS=300000` in the heavy-tier driver path.
  - First 32B call now completes; adaptive timing kicks in for later calls. Other tiers’ defaults are unchanged.

<sup>Written for commit 347aab8cbcc8eedfdb5cc41d4cfd10622b91a81f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69793?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

