### PR TITLE
fix(a1): deterministic L7 model resolution -- node /api/tags, memoized

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2474,6 +2474,82 @@ class FailbackStateMachine:
 
 
 # ---------------------------------------------------------------------------
+# Deterministic L7 model resolution (awakened J-Prime failover node)
+# ---------------------------------------------------------------------------
+#
+# The Phase 3c dispatch must name the model the awakened node ACTUALLY serves
+# (loaded in VRAM). The old path read the FSM's ``_active_model_label``, which
+# lags -- empty when the endpoint is found by direct GCP query -- so it fell back
+# to the survival 7B and the node returned an error object with no "choices"
+# (KeyError('choices')). The race-free source of truth is the node's own ollama
+# ``/api/tags``. We query it ONCE per endpoint and memoize per-endpoint: a new
+# endpoint (node changed / re-awaken at a new IP) is a natural cache miss;
+# ``_invalidate_jprime_model_cache()`` clears it on FSM->DORMANT. No per-dispatch
+# network spam.
+
+_JPRIME_SERVED_MODEL_CACHE: Dict[str, str] = {}
+
+
+def _invalidate_jprime_model_cache() -> None:
+    """Clear the memoized per-endpoint served-model map. Called on FSM->DORMANT
+    (the node is gone); a fresh awaken re-queries /api/tags. Per-endpoint keying
+    already self-invalidates on a node/IP change -- this covers same-IP reuse."""
+    _JPRIME_SERVED_MODEL_CACHE.clear()
+
+
+def _parse_served_model(tags: Optional[Dict[str, Any]]) -> Optional[str]:
+    """From an ollama ``/api/tags`` payload, pick the model loaded in VRAM -- the
+    largest by ``size`` (the 32B, not any small sidecar), preferring ``name`` then
+    ``model``. Pure + fail-soft -> None on empty/malformed input."""
+    try:
+        models = (tags or {}).get("models") or []
+        if not models:
+            return None
+        best = max(models, key=lambda m: (m or {}).get("size", 0) or 0)
+        return ((best.get("name") or best.get("model") or "").strip()) or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def _fetch_served_model(endpoint: str, *, timeout_s: float = 8.0) -> Optional[str]:
+    """GET ``<endpoint>/api/tags`` -> the model the node has loaded. Bounded by
+    *timeout_s*. Fail-soft -> None (node unreachable / non-200 / bad JSON)."""
+    try:
+        import aiohttp
+        url = endpoint.rstrip("/") + "/api/tags"
+        timeout = aiohttp.ClientTimeout(total=timeout_s)
+        async with aiohttp.ClientSession(timeout=timeout) as sess:
+            async with sess.get(url) as resp:
+                if resp.status != 200:
+                    return None
+                data = await resp.json(content_type=None)
+        return _parse_served_model(data)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def _resolve_served_model(
+    endpoint: Optional[str],
+    *,
+    fetcher: "Optional[Any]" = None,
+) -> Optional[str]:
+    """Memoized per-endpoint served-model lookup. Fetches ONCE per endpoint via
+    *fetcher* (defaults to :func:`_fetch_served_model`) then serves from cache --
+    no per-dispatch spam. A ``None`` fetch result is NOT cached (transient node
+    unreachable -> retried next dispatch). *fetcher* is injectable for tests."""
+    if not endpoint:
+        return None
+    cached = _JPRIME_SERVED_MODEL_CACHE.get(endpoint)
+    if cached is not None:
+        return cached
+    fn = fetcher or _fetch_served_model
+    model = await fn(endpoint)
+    if model:
+        _JPRIME_SERVED_MODEL_CACHE[endpoint] = model
+    return model
+
+
+# ---------------------------------------------------------------------------
 # CandidateGenerator
 # ---------------------------------------------------------------------------
 
@@ -3904,18 +3980,23 @@ class CandidateGenerator:
             pass
         return None
 
-    def _resolve_dispatch_model_name(self) -> Optional[str]:
-        """The model the awakened J-Prime node actually serves -- the FSM's
-        awakened-tier truth (``active_jprime_model`` -> HW1 ``_active_model_label``,
-        e.g. ``qwen2.5-coder:32b``), so the OpenAI-compat request names a model the
-        node has loaded. None if undeterminable (caller keeps the env default).
-        Fail-soft -- NEVER raises."""
-        try:
-            from .failover_lifecycle import get_failover_controller
-            model = (get_failover_controller().active_jprime_model() or "").strip()
-            return model or None
-        except Exception:  # noqa: BLE001
-            return None
+    async def _resolve_dispatch_model_name(self, endpoint: Optional[str]) -> Optional[str]:
+        """The model the awakened J-Prime node ACTUALLY serves (loaded in VRAM) --
+        the deterministic L7 source of truth, queried from the node's own
+        ``/api/tags`` at *endpoint* and memoized per-endpoint.
+
+        Deliberately abandons the lagging FSM ``_active_model_label``: when the
+        endpoint is discovered by direct GCP query (controller not SERVING
+        in-process) that label is empty, so the old path fell back to the survival
+        7B and the node rejected the request with ``KeyError('choices')``. Asking
+        the node itself is race-free.
+
+        Memoized: fetched ONCE per endpoint, then served from cache -- no
+        per-dispatch/-retry network spam. A new endpoint (node changed / re-awaken
+        at a new IP) is a natural cache miss; ``_invalidate_jprime_model_cache()``
+        clears it on FSM->DORMANT. None if undeterminable (caller keeps the env
+        default). Fail-soft -- NEVER raises."""
+        return await _resolve_served_model(endpoint)
 
     async def _failover_local_dispatch(
         self,
@@ -3954,10 +4035,10 @@ class CandidateGenerator:
         # QUALITY failover node serves qwen2.5-coder:32b, so without this override
         # the OpenAI-compat request asks for a model the node does not have and
         # ollama returns an error object with no "choices" -> KeyError('choices').
-        # The model label is the FSM's awakened-tier truth (HW1 _active_model_label),
-        # not a hardcoded string.
+        # The model name is the node's OWN /api/tags truth (deterministic L7),
+        # memoized per-endpoint -- not the lagging FSM _active_model_label.
         _overrides = {"base_url": endpoint}
-        _model = self._resolve_dispatch_model_name()
+        _model = await self._resolve_dispatch_model_name(endpoint)
         if _model:
             _overrides["model_name"] = _model
         _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -1115,6 +1115,19 @@ class FailoverLifecycleController:
             logger.info("[FailoverLifecycle] GPU node REAPED (CPU survives)")
         except Exception as exc:  # noqa: BLE001
             logger.warning("[FailoverLifecycle] GPU reap fail-soft err=%r", exc)
+        finally:
+            # FSM -> DORMANT: the awakened endpoint is dead. Drop the memoized
+            # per-endpoint served-model map so a fresh awaken re-queries the new
+            # node's /api/tags (deterministic L7). Lazy import breaks the cycle;
+            # fail-soft. Per-endpoint keying already self-invalidates a new IP --
+            # this also covers same-IP reuse.
+            try:
+                from backend.core.ouroboros.governance.candidate_generator import (  # noqa: PLC0415
+                    _invalidate_jprime_model_cache,
+                )
+                _invalidate_jprime_model_cache()
+            except Exception:  # noqa: BLE001
+                pass
 
     # ------------------------------------------------------------------
     # Event hooks (gated, fail-soft)

--- a/tests/governance/test_dispatch_model_resolution.py
+++ b/tests/governance/test_dispatch_model_resolution.py
@@ -1,0 +1,152 @@
+"""Deterministic L7 model resolution for the awakened J-Prime failover node.
+
+The Phase 3c dispatch must name the model the node ACTUALLY serves (loaded in
+VRAM), not the lagging FSM ``_active_model_label`` -- which is empty when the
+endpoint is discovered by direct GCP query (controller not SERVING in-process),
+so the dispatch fell back to the survival 7B and the node rejected it with
+``KeyError('choices')``.
+
+The source of truth is the node's own ``/api/tags`` (ollama). We query it ONCE
+per endpoint and memoize per-endpoint: a new endpoint (node changed / re-awaken
+at a new IP) is a natural cache miss; ``_invalidate_jprime_model_cache()`` clears
+it on FSM->DORMANT. No per-dispatch network spam.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import backend.core.ouroboros.governance.candidate_generator as cg
+
+
+def setup_function(_fn):
+    cg._invalidate_jprime_model_cache()
+
+
+# --- pure parse of the /api/tags payload -----------------------------------
+
+def test_parse_picks_largest_model_by_size():
+    tags = {"models": [
+        {"name": "qwen2.5-coder:3b", "size": 2_000_000_000},
+        {"name": "qwen2.5-coder:32b", "size": 20_000_000_000},
+    ]}
+    assert cg._parse_served_model(tags) == "qwen2.5-coder:32b"
+
+
+def test_parse_falls_back_to_model_key():
+    tags = {"models": [{"model": "qwen2.5-coder:32b"}]}
+    assert cg._parse_served_model(tags) == "qwen2.5-coder:32b"
+
+
+def test_parse_empty_or_malformed_returns_none():
+    assert cg._parse_served_model({}) is None
+    assert cg._parse_served_model({"models": []}) is None
+    assert cg._parse_served_model(None) is None
+    assert cg._parse_served_model({"models": [{}]}) is None
+
+
+# --- memoized resolution ----------------------------------------------------
+
+def test_resolve_fetches_once_and_memoizes():
+    calls = {"n": 0}
+
+    async def _fetcher(endpoint):
+        calls["n"] += 1
+        return "qwen2.5-coder:32b"
+
+    async def _run():
+        ep = "http://10.0.0.5:11434"
+        a = await cg._resolve_served_model(ep, fetcher=_fetcher)
+        b = await cg._resolve_served_model(ep, fetcher=_fetcher)
+        return a, b
+
+    a, b = asyncio.run(_run())
+    assert a == b == "qwen2.5-coder:32b"
+    assert calls["n"] == 1  # fetched once, second call served from cache
+
+
+def test_resolve_refetches_on_node_change():
+    calls = {"n": 0}
+
+    async def _fetcher(endpoint):
+        calls["n"] += 1
+        return "model-for-" + endpoint
+
+    async def _run():
+        a = await cg._resolve_served_model("http://10.0.0.5:11434", fetcher=_fetcher)
+        b = await cg._resolve_served_model("http://10.0.0.9:11434", fetcher=_fetcher)
+        return a, b
+
+    a, b = asyncio.run(_run())
+    assert a != b
+    assert calls["n"] == 2  # a new endpoint (node changed) is a cache miss
+
+
+def test_invalidate_clears_cache():
+    calls = {"n": 0}
+
+    async def _fetcher(endpoint):
+        calls["n"] += 1
+        return "qwen2.5-coder:32b"
+
+    async def _run():
+        ep = "http://10.0.0.5:11434"
+        await cg._resolve_served_model(ep, fetcher=_fetcher)
+        cg._invalidate_jprime_model_cache()  # FSM -> DORMANT
+        await cg._resolve_served_model(ep, fetcher=_fetcher)
+
+    asyncio.run(_run())
+    assert calls["n"] == 2  # cleared -> re-fetched
+
+
+def test_resolve_none_endpoint_never_fetches():
+    calls = {"n": 0}
+
+    async def _fetcher(endpoint):
+        calls["n"] += 1
+        return "x"
+
+    assert asyncio.run(cg._resolve_served_model(None, fetcher=_fetcher)) is None
+    assert calls["n"] == 0
+
+
+def test_resolve_failsoft_does_not_cache_none():
+    calls = {"n": 0}
+
+    async def _fetcher(endpoint):
+        calls["n"] += 1
+        return None  # node unreachable / empty tags
+
+    async def _run():
+        ep = "http://10.0.0.5:11434"
+        await cg._resolve_served_model(ep, fetcher=_fetcher)
+        await cg._resolve_served_model(ep, fetcher=_fetcher)
+
+    asyncio.run(_run())
+    assert calls["n"] == 2  # a None result is not cached -> retried next dispatch
+
+
+# --- method delegates to the memoized resolver, abandons _active_model_label -
+
+def test_method_delegates_to_resolver_without_active_label():
+    cg._JPRIME_SERVED_MODEL_CACHE["http://10.0.0.5:11434"] = "qwen2.5-coder:32b"
+
+    class _Stub:
+        pass
+
+    model = asyncio.run(
+        cg.CandidateGenerator._resolve_dispatch_model_name(_Stub(), "http://10.0.0.5:11434")
+    )
+    assert model == "qwen2.5-coder:32b"
+
+
+def test_reap_gpu_node_invalidates_cache(monkeypatch):
+    """WIRING: FSM teardown (_reap_gpu_node -> DORMANT) must clear the memoized
+    served-model map so a fresh awaken re-queries the new node. Proves the
+    invalidation has a live caller (not theater)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_USE_ADC", "false")
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+
+    cg._JPRIME_SERVED_MODEL_CACHE["http://10.0.0.5:11434"] = "qwen2.5-coder:32b"
+    controller = fl.FailoverLifecycleController()
+    asyncio.run(controller._reap_gpu_node())  # fail-soft; finally clears the cache
+    assert cg._JPRIME_SERVED_MODEL_CACHE == {}

--- a/tests/governance/test_failover_provider_override.py
+++ b/tests/governance/test_failover_provider_override.py
@@ -216,29 +216,30 @@ async def test_unrecognized_override_falls_through(monkeypatch):
     assert result is None
 
 
-async def test_dispatch_model_name_is_awakened_tier_model(monkeypatch):
+async def test_dispatch_model_name_is_node_served_model(monkeypatch):
     """The J-Prime dispatch must request the model the awakened node SERVES
-    (qwen2.5-coder:32b), not LocalConfig's small default -- else ollama returns an
-    error object with no 'choices' (the KeyError that severed the live GENERATE)."""
-    import backend.core.ouroboros.governance.failover_lifecycle as fl
+    (qwen2.5-coder:32b), read from the node's OWN /api/tags (deterministic L7) --
+    NOT the lagging FSM _active_model_label -- else ollama returns an error object
+    with no 'choices' (the KeyError that severed the live GENERATE)."""
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    cg._invalidate_jprime_model_cache()
     gen = _make_generator(jprime=None)
 
-    monkeypatch.setattr(
-        fl, "get_failover_controller",
-        lambda: SimpleNamespace(active_jprime_model=lambda: "qwen2.5-coder:32b"),
-    )
-    assert gen._resolve_dispatch_model_name() == "qwen2.5-coder:32b"
+    async def _fetch(endpoint, **_kw):  # node's /api/tags truth
+        return "qwen2.5-coder:32b"
+
+    monkeypatch.setattr(cg, "_fetch_served_model", _fetch)
+    got = await gen._resolve_dispatch_model_name("http://10.0.0.5:11434")
+    assert got == "qwen2.5-coder:32b"
 
 
-async def test_dispatch_model_name_fail_soft(monkeypatch):
-    import backend.core.ouroboros.governance.failover_lifecycle as fl
+async def test_dispatch_model_name_fail_soft():
+    """Undeterminable endpoint -> None, never raises (caller keeps env default)."""
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    cg._invalidate_jprime_model_cache()
     gen = _make_generator(jprime=None)
-
-    def _boom():
-        raise RuntimeError("no controller")
-
-    monkeypatch.setattr(fl, "get_failover_controller", _boom)
-    assert gen._resolve_dispatch_model_name() is None  # never raises
+    assert await gen._resolve_dispatch_model_name(None) is None
+    assert await gen._resolve_dispatch_model_name("") is None
 
 
 async def test_override_field_on_operation_context_roundtrips():


### PR DESCRIPTION
## Root problem
Phase 3c failover dispatch named the model from the FSM's lagging `_active_model_label`, which is **empty** when the endpoint is discovered by direct GCP query (controller not SERVING in-process). The dispatch fell back to LocalConfig's survival 7B → the 32B node rejected the unknown model → ollama returned an error object with no `"choices"` → `KeyError('choices')` severed the live GENERATE.

## Fix — ask the node itself
`_resolve_dispatch_model_name(endpoint)` now reads the node's own ollama `/api/tags` (deterministic L7 source of truth) and picks the model loaded in VRAM (largest by size). **Memoized per-endpoint**: fetched ONCE, then served from cache — no per-dispatch/-retry network spam. A new endpoint (node changed / re-awaken at new IP) is a natural cache miss; `_invalidate_jprime_model_cache()` clears it on FSM→DORMANT, wired live into `_reap_gpu_node()`'s `finally` (proven by a wiring test, not theater).

Abandons `active_jprime_model()`/`_active_model_label` for dispatch entirely.

## Tests (TDD)
- 10 new: parse (largest-by-size / model-key fallback / malformed), memoize-once, node-change refetch, invalidate, none-endpoint short-circuit, fail-soft-no-cache-None, method delegation, **reap→invalidate wiring**.
- Updated 2 obsolete override tests to the `/api/tags` contract.
- Regression: `test_failover_lifecycle.py` (26) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make J‑Prime failover model selection deterministic by querying the node’s `/api/tags` and caching per endpoint to prevent the KeyError caused by an empty FSM label.

- **Bug Fixes**
  - Phase 3c dispatch now resolves the served model from the node’s `/api/tags` (largest by size), not the lagging `_active_model_label`.
  - Per-endpoint memoization added; `None` results aren’t cached. Cache is cleared on FSM→DORMANT in `_reap_gpu_node`.
  - Updated tests: new coverage for parsing, memoization, invalidation, and wiring; refreshed override tests to the `/api/tags` contract.

<sup>Written for commit 031059a0e88ef695e294ae1138fe52168cfe9058. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69795?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

