### PR TITLE
feat(a1): Semantic Pre-Flight FSM boundary + Absolute Route Sealing

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2528,6 +2528,30 @@ async def _fetch_served_model(endpoint: str, *, timeout_s: float = 8.0) -> Optio
         return None
 
 
+def _absolute_route_sealing(context: "Any") -> bool:
+    """Absolute Route Sealing predicate. When TRUE, a J-Prime dispatch that was
+    COMMITTED to (endpoint discovered) and then failed/empty must RAISE terminal --
+    NEVER cascade to the DW/adversary-stub lane (the hybrid-mesh cascade leak).
+
+    Two triggers:
+      * ``context.provider_override == "gcp-jprime"`` -- a Cryo-DLQ pin: the op was
+        SEALED for J-Prime, so a fall-through to dead DW would violate the seal
+        (ALWAYS absolute, independent of any flag);
+      * ``JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING`` env flag -- arms sealing globally
+        for the hybrid-execution-mesh soak.
+
+    Default OFF -> byte-identical legacy fail-soft cascade. Fail-soft -> False."""
+    try:
+        override = (getattr(context, "provider_override", "") or "").strip()
+    except Exception:  # noqa: BLE001
+        override = ""
+    if override == "gcp-jprime":
+        return True
+    return os.environ.get(
+        "JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", "false"
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
 async def _resolve_served_model(
     endpoint: Optional[str],
     *,
@@ -4108,6 +4132,15 @@ class CandidateGenerator:
         # Fail-soft ABSOLUTE: if the local route errors (endpoint missing,
         # LocalPrimeClient raises, empty result), we log + fall through to the
         # normal DW path -- the op is NEVER lost.
+        # Absolute Route Sealing: when the router has committed to the sovereign
+        # J-Prime provider (Cryo-DLQ pin or the hybrid-mesh flag), a discovered-
+        # and-dispatched 32B FAILURE must be TERMINAL -- never cascade to the dead
+        # DW/adversary-stub lane. Only a COMMITTED dispatch (endpoint discovered)
+        # can seal; a pre-dispatch miss (no endpoint) is not "a 32B failure during
+        # generation" and falls through to the legacy path.
+        _sealing = _absolute_route_sealing(context)
+        _committed = False
+        _seal_reason: Optional[str] = None
         try:
             # DRY universal router: EVERY DW dispatch (primary, GENERATE_RETRY,
             # critique, immortal re-queue) funnels through this chokepoint, so one
@@ -4118,6 +4151,7 @@ class CandidateGenerator:
             # process's controller FSM isn't itself in SERVING state.
             _ep = await self._discover_jprime_endpoint()
             if _ep:
+                _committed = True
                 _local_result = await self._failover_local_dispatch(
                     context, deadline, _ep,
                 )
@@ -4131,15 +4165,33 @@ class CandidateGenerator:
                         _ep, getattr(context, "op_id", "?")[:16], provider_route,
                     )
                     return _local_result
+                _seal_reason = "empty_result"
                 logger.info(
                     "[CandidateGenerator] Phase 3c DAG re-entry: J-Prime local "
-                    "route empty/failed -> falling through to DW (op=%s route=%s)",
+                    "route empty/failed (op=%s route=%s)",
                     getattr(context, "op_id", "?")[:16], provider_route,
                 )
         except Exception as _f3c_exc:  # noqa: BLE001 -- seam must never break the op
+            if _committed:
+                _seal_reason = type(_f3c_exc).__name__
             logger.warning(
-                "[CandidateGenerator] Phase 3c failover seam fail-soft err=%r "
-                "-> legacy DW path (op never lost)", _f3c_exc,
+                "[CandidateGenerator] Phase 3c failover seam err=%r%s", _f3c_exc,
+                "" if _committed else " (pre-dispatch, not committed)",
+            )
+
+        # SEAL: committed sovereign dispatch failed AND sealing is armed -> HALT the
+        # cognitive loop with a terminal reason (classified non-retryable by the
+        # orchestrator). The DW fall-through below is NEVER reached -- no cascade to
+        # the dead/adversary lane.
+        if _sealing and _committed and _seal_reason:
+            logger.warning(
+                "[CandidateGenerator] ABSOLUTE ROUTE SEAL op=%s reason=%s -- "
+                "HALTING cognitive loop (sovereign J-Prime committed + failed; DW "
+                "cascade FORBIDDEN)",
+                getattr(context, "op_id", "?")[:16], _seal_reason,
+            )
+            raise RuntimeError(
+                "sovereign_route_sealed:gcp-jprime:%s" % _seal_reason
             )
 
         from backend.core.ouroboros.governance.provider_topology import (

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -370,6 +370,16 @@ def _warmup_timeout_s() -> float:
     return max(1.0, _env_float("JARVIS_FAILOVER_WARMUP_TIMEOUT_S", 180.0))
 
 
+def _warmup_strict() -> bool:
+    """Semantic Pre-Flight FSM boundary. When TRUE (default), a HEAVY tier
+    (32B/GPU) is only legally SERVING after a CONFIRMED warmup -- a failed warmup
+    keeps the FSM in AWAKENING (re-tick, bounded by the outer AWAKENING deadline)
+    rather than advertising a cold node whose first op times out and cascades. The
+    survival (7B/CPU) tier stays advisory (byte-identical legacy) regardless. Set
+    ``JARVIS_FAILOVER_WARMUP_STRICT=false`` to make even a heavy tier advisory."""
+    return _enabled("JARVIS_FAILOVER_WARMUP_STRICT", "true")
+
+
 def _heavy_coldstart_mult() -> float:
     """Multiplier applied to cold-start timeouts when the awakened tier is HEAVY
     (a large model on a GPU -- e.g. qwen2.5-coder:32b on an L4, which needs minutes
@@ -1557,12 +1567,29 @@ class FailoverLifecycleController:
         timeout = self._adaptive_timeout(_warmup_timeout_s())
 
         import dataclasses  # noqa: PLC0415
-        # Build a config that targets the awakened node's base URL.
         base_cfg = LocalConfig.from_env()
-        node_cfg = dataclasses.replace(base_cfg, base_url=endpoint)
-        client = LocalPrimeClient(node_cfg)
 
         async def _warmup() -> bool:
+            # Resolve the model the node ACTUALLY serves from its own /api/tags
+            # (deterministic L7, memoized) so warmup loads the RIGHT weights into
+            # VRAM -- NOT LocalConfig's default 3B (which the 32B node doesn't have,
+            # so the warmup would fail and the first real op time out cold). This
+            # also POPULATES the shared per-endpoint cache, so the dispatch
+            # resolver gets a cache hit later -- zero extra /api/tags calls.
+            served: Optional[str] = None
+            try:
+                from backend.core.ouroboros.governance.candidate_generator import (  # noqa: PLC0415
+                    _resolve_served_model,
+                )
+                served = await _resolve_served_model(endpoint)
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[FailoverLifecycle] warmup model resolve fail-soft err=%r", exc)
+            node_cfg = dataclasses.replace(
+                base_cfg,
+                base_url=endpoint,
+                **({"model_name": served} if served else {}),
+            )
+            client = LocalPrimeClient(node_cfg)
             try:
                 return await client.warmup(timeout_s=timeout)
             finally:
@@ -2177,6 +2204,22 @@ class FailoverLifecycleController:
                     "-- proceeding to SERVING (first op may be cold)", exc,
                 )
             if not warmup_ok:
+                # Semantic Pre-Flight FSM boundary: a HEAVY tier (32B/GPU) is only
+                # legally SERVING after a confirmed 1-token response. On a failed
+                # warmup, STAY in AWAKENING and re-tick (the outer adaptive AWAKENING
+                # deadline still reaps a genuinely wedged node) rather than
+                # advertising a cold node whose first real op times out at the
+                # inference budget and cascades to the dead DW/stub lane. The
+                # survival (7B/CPU) tier stays advisory (byte-identical legacy).
+                if _warmup_strict() and _tier_is_heavy(self._awakened_tier):
+                    logger.warning(
+                        "[FailoverLifecycle] warmup NOT confirmed for HEAVY tier "
+                        "(model=%s) -- STAYING AWAKENING (Semantic Pre-Flight gate); "
+                        "re-tick pending (outer deadline %.0fs bounds a wedged node)",
+                        getattr(self._awakened_tier, "model_label", "?"),
+                        self._adaptive_timeout(_awaken_timeout_s()),
+                    )
+                    return  # do NOT flip to SERVING; next tick re-warms
                 logger.warning(
                     "[FailoverLifecycle] warmup did not confirm within %.0fs "
                     "-- proceeding to SERVING (first op may be cold)",

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -297,7 +297,18 @@ class LocalPrimeClient:
                 "num_predict": 1,
                 "temperature": 0.0,
             }
-            async with sess.post(url, json=body) as resp:
+            # Dedicated Cold-Start HTTP Context: give the warmup POST its OWN total
+            # timeout == the (heavy-mult-scaled) warmup budget, overriding aiohttp's
+            # 300s session default. A 32B is ~20GB; the PCIe->VRAM cold-load can
+            # exceed 300s, and without this the socket would be dropped mid-transfer
+            # (min(720s wait_for, 300s default) = 300s). Fail-soft if aiohttp is
+            # unavailable -- fall back to the session default.
+            try:
+                import aiohttp  # noqa: PLC0415
+                _post_kw = {"timeout": aiohttp.ClientTimeout(total=max(1.0, timeout_s))}
+            except Exception:  # noqa: BLE001
+                _post_kw = {}
+            async with sess.post(url, json=body, **_post_kw) as resp:
                 await resp.json()
             return True
 

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -491,6 +491,8 @@ _NONRETRYABLE_TERMINAL_REASONS: "frozenset[str]" = frozenset({
     "validation_budget_exhausted",   # VALIDATE budget gone
     "op_cost_cap_exceeded",          # per-op cost cap blown
     "user_cancelled",                # cooperative cancellation
+    "sovereign_route_sealed",        # Absolute Route Sealing: committed J-Prime
+                                     # dispatch failed; DW cascade forbidden -> halt
     _FAILFAST_CIRCUIT_OPEN_REASON,   # fail-fast exhaustion breaker open
 })
 
@@ -506,9 +508,15 @@ def _is_nonretryable_terminal(reason_code: str) -> bool:
 
     Pure, side-effect-free classifier over ``_NONRETRYABLE_TERMINAL_REASONS``.
     Always returns a ``bool`` and never raises (coerces non-str input to str).
+    Matches an exact code OR a ``prefix:detail`` shape by its colon-prefix head
+    (e.g. ``sovereign_route_sealed:gcp-jprime:LocalLatencyLockup`` -> matches
+    ``sovereign_route_sealed``). Existing colon-free codes are unaffected.
     """
     try:
-        return str(reason_code) in _NONRETRYABLE_TERMINAL_REASONS
+        code = str(reason_code)
+        if code in _NONRETRYABLE_TERMINAL_REASONS:
+            return True
+        return code.split(":", 1)[0] in _NONRETRYABLE_TERMINAL_REASONS
     except Exception:  # noqa: BLE001 — classifier must never raise
         return False
 

--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -1790,6 +1790,36 @@ class GENERATERunner(PhaseRunner):
 
                     )
 
+                # ── Absolute Route Sealing terminal ──
+                # The router committed to the sovereign J-Prime provider and it
+                # failed; the DW cascade is FORBIDDEN. This is a non-retryable
+                # terminal (re-driving through GENERATE_RETRY would just re-hit the
+                # same wedged/absent sovereign node) -- HALT the op cleanly rather
+                # than letting it cascade or retry-storm.
+                if "sovereign_route_sealed" in _err_msg:
+                    logger.warning(
+                        "[Orchestrator] ABSOLUTE ROUTE SEAL — op halted (sovereign "
+                        "J-Prime committed + failed, DW cascade forbidden) [%s] %s",
+                        ctx.op_id, _err_msg[:120],
+                    )
+                    ctx = ctx.advance(
+                        OperationPhase.CANCELLED,
+                        terminal_reason_code=f"sovereign_route_sealed:{_err_msg[:80]}",
+                    )
+                    await orch._record_ledger(
+                        ctx, OperationState.FAILED,
+                        {
+                            "reason": "sovereign_route_sealed",
+                            "error": _err_msg[:200],
+                            "route": _route or "unknown",
+                        },
+                    )
+                    return PhaseResult(
+                        next_ctx=ctx, next_phase=None, status="fail",
+                        reason=ctx.terminal_reason_code or "generate_terminal",
+                        artifacts={"generation": generation, "episodic_memory": _episodic_memory},
+                    )
+
                 logger.warning(
                     "Generation attempt %d/%d failed for %s: %s",
                     attempt + 1,

--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -261,6 +261,17 @@ def _arm_failover_env(env: dict) -> dict:
         "JARVIS_FAILOVER_QUALITY_ACCEL_COUNT": "1",
         "JARVIS_FAILOVER_QUALITY_IMAGE": "jarvis-prime-coder-32b",
         "JARVIS_FAILOVER_INFERENCE_BIND_ENABLED": "true",
+        # Semantic Pre-Flight FSM boundary: a HEAVY (32B/GPU) tier is only legally
+        # SERVING after a CONFIRMED warmup (loads ~20GB into L4 VRAM with the RIGHT
+        # model, via /api/tags). A failed warmup keeps the FSM in AWAKENING (bounded
+        # by the outer deadline) instead of advertising a cold node whose first op
+        # times out and cascades. Default TRUE; set explicit for the soak record.
+        "JARVIS_FAILOVER_WARMUP_STRICT": "true",
+        # Absolute Route Sealing: once the router commits to the sovereign 32B, a
+        # failure/timeout HALTS the op (terminal) -- it must NEVER cascade to the
+        # dead DW / synthetic-adversary lane (the cascade leak that retry-stalled
+        # the last soak). The 32B is the designated provider here, not a bonus.
+        "JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING": "true",
     })
     return env
 

--- a/tests/governance/test_absolute_route_sealing.py
+++ b/tests/governance/test_absolute_route_sealing.py
@@ -1,0 +1,136 @@
+"""Absolute Route Sealing -- kill the cascade leak.
+
+The hybrid-execution-mesh soak revealed a routing leak: when the awakened 32B
+timed out mid-generation, the Phase 3c sentinel seam caught the failure and
+CASCADED to the DoubleWord lane -- which, under the synthetic adversary, is the
+``adversary-stub-model``. The stub then retry-stalled and the watchdog killed
+the run.
+
+When the router has COMMITTED to the sovereign J-Prime provider (a Cryo-DLQ pin
+``provider_override=gcp-jprime``, or the hybrid-mesh flag is armed), a 32B
+failure/timeout must be TERMINAL -- raise ``sovereign_route_sealed`` and halt the
+cognitive loop, NEVER cascade to the local/stub lane.
+
+Default OFF (no override, no flag) -> byte-identical legacy fail-soft cascade.
+"""
+from __future__ import annotations
+
+import datetime as _dt
+from types import SimpleNamespace
+
+import pytest
+
+import backend.core.ouroboros.governance.candidate_generator as cg
+
+
+def _deadline(seconds: float = 60.0):
+    return _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=seconds)
+
+
+# --- sealing predicate ------------------------------------------------------
+
+def test_sealing_true_on_override():
+    ctx = SimpleNamespace(provider_override="gcp-jprime", op_id="op-1")
+    assert cg._absolute_route_sealing(ctx) is True
+
+
+def test_sealing_true_on_env_flag(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", "true")
+    ctx = SimpleNamespace(provider_override="", op_id="op-2")
+    assert cg._absolute_route_sealing(ctx) is True
+
+
+def test_sealing_false_by_default(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", raising=False)
+    ctx = SimpleNamespace(provider_override="", op_id="op-3")
+    assert cg._absolute_route_sealing(ctx) is False
+
+
+def test_sealing_failsoft_on_bad_ctx(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", raising=False)
+    assert cg._absolute_route_sealing(object()) is False  # no attr -> False, no raise
+
+
+# --- the sentinel seam SEALS instead of cascading (when committed) ----------
+
+class _StubGen:
+    """Minimal stub carrying only the two seam collaborators. If the seal fires,
+    the DW code below the seam is never reached (so no other attrs are needed)."""
+
+    def __init__(self, *, endpoint, dispatch):
+        self._endpoint = endpoint
+        self._dispatch = dispatch
+
+    async def _discover_jprime_endpoint(self):
+        return self._endpoint
+
+    async def _failover_local_dispatch(self, context, deadline, endpoint):
+        return await self._dispatch(context, deadline, endpoint)
+
+
+async def test_sentinel_seals_on_32b_exception_under_sealing(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", "true")
+
+    async def _raise(*_a):
+        raise RuntimeError("LocalLatencyLockup: local_inference timeout budget=150000ms")
+
+    stub = _StubGen(endpoint="http://10.0.0.5:11434", dispatch=_raise)
+    ctx = SimpleNamespace(provider_override="", op_id="op-seal-1")
+    with pytest.raises(RuntimeError) as ei:
+        await cg.CandidateGenerator._dispatch_via_sentinel(stub, ctx, _deadline(), "standard")
+    assert "sovereign_route_sealed" in str(ei.value)
+
+
+async def test_sentinel_seals_on_empty_result_under_sealing(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", "true")
+
+    async def _empty(*_a):
+        return None  # discovered + dispatched but yielded nothing
+
+    stub = _StubGen(endpoint="http://10.0.0.5:11434", dispatch=_empty)
+    ctx = SimpleNamespace(provider_override="gcp-jprime", op_id="op-seal-2")
+    with pytest.raises(RuntimeError, match="sovereign_route_sealed"):
+        await cg.CandidateGenerator._dispatch_via_sentinel(stub, ctx, _deadline(), "standard")
+
+
+async def test_sentinel_does_not_seal_when_off(monkeypatch):
+    """Sealing OFF -> legacy fail-soft: the seam does NOT raise sovereign_route_sealed;
+    it falls through to the DW path (which errors on the stub, proving fall-through)."""
+    monkeypatch.delenv("JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", raising=False)
+
+    async def _empty(*_a):
+        return None
+
+    stub = _StubGen(endpoint="http://10.0.0.5:11434", dispatch=_empty)
+    ctx = SimpleNamespace(provider_override="", op_id="op-nofell")
+    with pytest.raises(Exception) as ei:
+        await cg.CandidateGenerator._dispatch_via_sentinel(stub, ctx, _deadline(), "standard")
+    # It fell through to the (stub-incompatible) DW path -> NOT a seal.
+    assert "sovereign_route_sealed" not in str(ei.value)
+
+
+async def test_sentinel_no_seal_when_not_committed(monkeypatch):
+    """No endpoint discovered = we never committed to J-Prime -> not a '32B failure
+    during generation'. Even with sealing ON, fall through to legacy (do not seal
+    on a pre-dispatch miss)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING", "true")
+
+    async def _never_called(*_a):
+        raise AssertionError("dispatch must not be called when no endpoint")
+
+    stub = _StubGen(endpoint=None, dispatch=_never_called)
+    ctx = SimpleNamespace(provider_override="", op_id="op-nocommit")
+    with pytest.raises(Exception) as ei:
+        await cg.CandidateGenerator._dispatch_via_sentinel(stub, ctx, _deadline(), "standard")
+    assert "sovereign_route_sealed" not in str(ei.value)
+
+
+# --- the terminal reason is classified non-retryable (halt, no GENERATE_RETRY) -
+
+def test_sovereign_route_sealed_is_nonretryable():
+    from backend.core.ouroboros.governance.orchestrator import _is_nonretryable_terminal
+    assert _is_nonretryable_terminal("sovereign_route_sealed") is True
+    assert _is_nonretryable_terminal("sovereign_route_sealed:gcp-jprime:LocalLatencyLockup") is True
+    # existing exact-match codes unaffected
+    assert _is_nonretryable_terminal("advisor_blocked") is True
+    assert _is_nonretryable_terminal("some_retryable_thing") is False

--- a/tests/governance/test_failover_warmup_integration.py
+++ b/tests/governance/test_failover_warmup_integration.py
@@ -314,6 +314,132 @@ async def test_warmup_timeout_default():
 # (g) Existing AWAKENING-timeout still fires even when warmup is pending
 # ---------------------------------------------------------------------------
 
+## ---------------------------------------------------------------------------
+## (h) Semantic Pre-Flight FSM boundary: HEAVY tier is only legally SERVING
+##     after a confirmed warmup. Survival stays advisory (byte-identical legacy).
+## ---------------------------------------------------------------------------
+
+def _heavy_tier():
+    from types import SimpleNamespace
+    return SimpleNamespace(is_gpu=True, model_label="qwen2.5-coder:32b")
+
+
+async def test_heavy_tier_warmup_failure_stays_awakening(monkeypatch):
+    """HEAVY tier (32B/GPU) + strict gate: a failed warmup keeps the FSM in
+    AWAKENING (re-tick) -- it must NOT advertise a cold node whose first op times
+    out and cascades. The outer AWAKENING deadline still bounds a wedged node."""
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_STRICT", "true")
+    clock = FakeClock()
+
+    async def failing_warmup_fn():
+        return False
+
+    ctrl = _make_ctrl(clock, warmup_fn=failing_warmup_fn)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+    await ctrl.tick()  # DORMANT -> AWAKENING
+    ctrl._awakened_tier = _heavy_tier()  # force HEAVY
+    await ctrl.tick()  # warmup fails -> HEAVY strict gate -> STAY AWAKENING
+    assert ctrl.state == fl.FailoverState.AWAKENING
+    assert ctrl.is_jprime_serving() is False
+
+
+async def test_heavy_tier_warmup_success_reaches_serving(monkeypatch):
+    """HEAVY tier + strict gate: a CONFIRMED warmup transitions to SERVING."""
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_STRICT", "true")
+    clock = FakeClock()
+
+    async def ok_warmup_fn():
+        return True
+
+    ctrl = _make_ctrl(clock, warmup_fn=ok_warmup_fn)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+    await ctrl.tick()  # -> AWAKENING
+    ctrl._awakened_tier = _heavy_tier()
+    await ctrl.tick()  # warmup OK -> SERVING
+    assert ctrl.state == fl.FailoverState.SERVING
+    assert ctrl.is_jprime_serving() is True
+
+
+async def test_heavy_tier_strict_off_is_advisory(monkeypatch):
+    """Strict gate OFF -> even a HEAVY tier is advisory (legacy): a failed warmup
+    still proceeds to SERVING (escape hatch)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_STRICT", "false")
+    clock = FakeClock()
+
+    async def failing_warmup_fn():
+        return False
+
+    ctrl = _make_ctrl(clock, warmup_fn=failing_warmup_fn)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+    await ctrl.tick()  # -> AWAKENING
+    ctrl._awakened_tier = _heavy_tier()
+    await ctrl.tick()  # strict OFF -> advisory -> SERVING despite warmup fail
+    assert ctrl.state == fl.FailoverState.SERVING
+
+
+async def test_survival_tier_warmup_failure_still_serving(monkeypatch):
+    """Survival (7B/CPU, non-heavy) tier stays advisory even with strict ON --
+    the hard gate is HEAVY-only (byte-identical legacy for the survival tier)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_WARMUP_STRICT", "true")
+    clock = FakeClock()
+
+    async def failing_warmup_fn():
+        return False
+
+    ctrl = _make_ctrl(clock, warmup_fn=failing_warmup_fn)
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH", p50=300.0)
+    _fill_outage()
+    await ctrl.tick()  # -> AWAKENING (default survival tier, non-heavy)
+    await ctrl.tick()  # warmup fails but survival -> advisory -> SERVING
+    assert ctrl.state == fl.FailoverState.SERVING
+
+
+## ---------------------------------------------------------------------------
+## (i) The default warmup_fn resolves the node's ACTUAL served model (/api/tags)
+##     so it loads the RIGHT weights -- not LocalConfig's default 3B.
+## ---------------------------------------------------------------------------
+
+async def test_default_warmup_fn_resolves_served_model(monkeypatch):
+    clock = FakeClock()
+    ctrl = _make_ctrl(clock)
+    ctrl._endpoint = "http://10.0.0.9:11434"
+
+    import backend.core.ouroboros.governance.local_inference_director as lid
+    import backend.core.ouroboros.governance.candidate_generator as cg
+
+    captured = {}
+
+    class _FakeClient:
+        def __init__(self, cfg):
+            captured["cfg"] = cfg
+
+        async def warmup(self, *, timeout_s):
+            captured["timeout_s"] = timeout_s
+            return True
+
+        async def aclose(self):
+            captured["closed"] = True
+
+    async def _fake_resolve(endpoint, **_kw):
+        captured["resolve_ep"] = endpoint
+        return "qwen2.5-coder:32b"
+
+    monkeypatch.setattr(lid, "LocalPrimeClient", _FakeClient)
+    monkeypatch.setattr(cg, "_resolve_served_model", _fake_resolve)
+
+    warmup_fn = ctrl._build_default_warmup_fn()
+    ok = await warmup_fn()
+
+    assert ok is True
+    assert captured["resolve_ep"] == "http://10.0.0.9:11434"
+    assert captured["cfg"].model_name == "qwen2.5-coder:32b"  # NOT the 3B default
+    assert captured["cfg"].base_url == "http://10.0.0.9:11434"
+    assert captured.get("closed") is True
+
+
 async def test_awakening_timeout_fires_even_with_warmup_enabled(monkeypatch):
     """The outer AWAKENING deadline (JARVIS_FAILOVER_AWAKEN_TIMEOUT_S) still
     terminates a stuck node even when warmup is enabled. The warmup happens

--- a/tests/governance/test_local_prime_warmup.py
+++ b/tests/governance/test_local_prime_warmup.py
@@ -175,3 +175,17 @@ async def test_warmup_timeout_is_respected():
     elapsed = asyncio.get_event_loop().time() - start
     # Should complete well within 1 second (not hang for 9999s).
     assert elapsed < 1.0, f"warmup took {elapsed:.2f}s, expected <1.0s"
+
+
+async def test_warmup_post_uses_dedicated_client_timeout():
+    """Dedicated Cold-Start HTTP Context: the warmup POST must carry its OWN
+    aiohttp ClientTimeout(total=timeout_s), overriding the session's 300s default
+    -- so a 19.9GB PCIe->VRAM transfer isn't dropped mid cold-load. Without this,
+    the effective warmup cap is min(720s wait_for, 300s aiohttp default) = 300s."""
+    import aiohttp
+    sess = _OkSession()
+    client = LocalPrimeClient(_cfg(), session=sess)
+    await client.warmup(timeout_s=600.0)
+    tmo = sess.posts[0].get("timeout")
+    assert isinstance(tmo, aiohttp.ClientTimeout), f"expected ClientTimeout, got {tmo!r}"
+    assert tmo.total == 600.0


### PR DESCRIPTION
Root-cause fix for the last soak's `warm=False` 32B timeout → DW/adversary-stub cascade → retry-stall. Three structural constraints, no duct-tape, built on existing infra.

## 1. Semantic Pre-Flight FSM Boundary (`failover_lifecycle.py`)
- `_tick_awakening`: a **HEAVY** (32B/GPU) tier is only legally SERVING after a **confirmed** warmup. Failed warmup → stay AWAKENING + re-tick (bounded by the outer adaptive deadline, which still reaps a wedged node). Survival (7B/CPU) stays advisory (byte-identical). Gate `JARVIS_FAILOVER_WARMUP_STRICT` (default true).
- `_build_default_warmup_fn` warms the model the node **actually serves** (its own `/api/tags` via `_resolve_served_model`, memoized) — not LocalConfig's default 3B (the bug that made warmup always fail). Populating the shared cache also gives the dispatch resolver a cache hit.

## 2. Dedicated Cold-Start HTTP Context (`local_inference_director.py`)
- `warmup()` POST carries its own `aiohttp.ClientTimeout(total=timeout_s)`, overriding aiohttp's 300s session default so a ~20 GB PCIe→VRAM cold-load (heavy-mult-scaled to ~720s) isn't dropped mid-transfer.

## 3. Absolute Route Sealing (`candidate_generator.py` + `orchestrator.py` + `generate_runner.py`)
- `_absolute_route_sealing(context)`: True on `provider_override=gcp-jprime` (Cryo-DLQ pin, always) OR `JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING`. Default OFF → byte-identical legacy.
- `_dispatch_via_sentinel`: once **committed** to the 32B (endpoint discovered + dispatched), a failure/empty **raises `sovereign_route_sealed`** and halts — the DW fall-through is never reached. Pre-dispatch miss (no endpoint) is not a committed failure → legacy path.
- `sovereign_route_sealed` registered non-retryable (+ colon-prefix matching); `generate_runner` maps it to terminal FAILED (no GENERATE_RETRY).

Armed for the soak in `ignite_a1_soak.py`.

## Tests (TDD)
43 new/updated + regressions (`test_failover_lifecycle` 26, `test_local_inference_director` 22, `test_failover_provider_override` 12) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 32B cold-start timeout that cascaded to DW/adversary and caused retry stalls. Adds strict warmup gating, a dedicated warmup HTTP timeout, and absolute route sealing to stop cascades once J‑Prime is committed.

- **New Features**
  - Semantic Pre-Flight FSM boundary: HEAVY tier only becomes SERVING after a confirmed warmup; survival tier remains advisory. Controlled by `JARVIS_FAILOVER_WARMUP_STRICT` (default true).
  - Warmup targets the model the node actually serves by resolving via `/api/tags` (memoized), avoiding the wrong 3B default and priming the shared cache.
  - Dedicated cold-start HTTP context: warmup POST uses its own `aiohttp.ClientTimeout(total=timeout_s)` to tolerate long PCIe→VRAM loads.
  - Absolute Route Sealing: when `provider_override=gcp-jprime` or `JARVIS_FAILOVER_ABSOLUTE_ROUTE_SEALING` is set, a committed J‑Prime failure/empty raises `sovereign_route_sealed` (terminal, non-retryable). Orchestrator now matches colon-prefixed reason codes; `generate_runner` halts without GENERATE_RETRY. The soak script enables both flags.

<sup>Written for commit 9cc7bd5233bff1dd5274287ec8305a680dd077aa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69796?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

