### PR TITLE
feat(a1): Context-Hardware Negotiator + Cognitive Compression + L7 auto-heal

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2490,11 +2490,18 @@ class FailbackStateMachine:
 _JPRIME_SERVED_MODEL_CACHE: Dict[str, str] = {}
 
 
+# Sibling cache: the served model's on-disk BYTES (from the SAME /api/tags), used
+# by the Context-Hardware Negotiator to derive the VRAM-safe num_ctx.
+_JPRIME_SERVED_BYTES_CACHE: Dict[str, int] = {}
+
+
 def _invalidate_jprime_model_cache() -> None:
-    """Clear the memoized per-endpoint served-model map. Called on FSM->DORMANT
-    (the node is gone); a fresh awaken re-queries /api/tags. Per-endpoint keying
-    already self-invalidates on a node/IP change -- this covers same-IP reuse."""
+    """Clear the memoized per-endpoint served-model maps (name + bytes). Called on
+    FSM->DORMANT (the node is gone); a fresh awaken re-queries /api/tags.
+    Per-endpoint keying already self-invalidates on a node/IP change -- this covers
+    same-IP reuse."""
     _JPRIME_SERVED_MODEL_CACHE.clear()
+    _JPRIME_SERVED_BYTES_CACHE.clear()
 
 
 def _parse_served_model(tags: Optional[Dict[str, Any]]) -> Optional[str]:
@@ -2576,6 +2583,129 @@ async def _resolve_served_model(
 # ---------------------------------------------------------------------------
 # CandidateGenerator
 # ---------------------------------------------------------------------------
+
+
+def _parse_served_model_bytes(tags: Optional[Dict[str, Any]]) -> int:
+    """On-disk BYTES of the largest model in an ollama /api/tags payload (the same
+    model _parse_served_model names). Pure, fail-soft -> 0."""
+    try:
+        models = (tags or {}).get("models") or []
+        if not models:
+            return 0
+        best = max(models, key=lambda m: (m or {}).get("size", 0) or 0)
+        return int(best.get("size", 0) or 0)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+async def _fetch_served_model_bytes(endpoint: str, *, timeout_s: float = 8.0) -> int:
+    """GET <endpoint>/api/tags -> the served model's on-disk size in bytes.
+    Fail-soft -> 0."""
+    try:
+        import aiohttp
+        url = endpoint.rstrip("/") + "/api/tags"
+        timeout = aiohttp.ClientTimeout(total=timeout_s)
+        async with aiohttp.ClientSession(timeout=timeout) as sess:
+            async with sess.get(url) as resp:
+                if resp.status != 200:
+                    return 0
+                data = await resp.json(content_type=None)
+        return _parse_served_model_bytes(data)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+async def _resolve_served_model_bytes(
+    endpoint: Optional[str],
+    *,
+    fetcher: "Optional[Any]" = None,
+) -> int:
+    """Memoized per-endpoint served-model byte size (Context-Hardware Negotiator
+    input). Fetched once; a 0 result is not cached (retried). NEVER raises."""
+    if not endpoint:
+        return 0
+    cached = _JPRIME_SERVED_BYTES_CACHE.get(endpoint)
+    if cached:
+        return cached
+    fn = fetcher or _fetch_served_model_bytes
+    size = await fn(endpoint)
+    if size:
+        _JPRIME_SERVED_BYTES_CACHE[endpoint] = int(size)
+    return int(size or 0)
+
+
+def _awakened_vram_bytes() -> int:
+    """VRAM (bytes) of the awakened GPU tier -- the controller's live awakened tier
+    if available, else the QUALITY provisioning spec. 0 if not a GPU tier / unknown
+    (the negotiator then keeps the legacy path). NEVER raises."""
+    accel = ""
+    try:
+        from .failover_lifecycle import get_failover_controller  # noqa: PLC0415
+        _t = getattr(get_failover_controller(), "_awakened_tier", None)
+        accel = (getattr(_t, "accelerator_type", "") or "").strip()
+    except Exception:  # noqa: BLE001
+        accel = ""
+    if not accel:
+        try:
+            from .failover_tier import _quality_tier  # noqa: PLC0415
+            accel = (getattr(_quality_tier(), "accelerator_type", "") or "").strip()
+        except Exception:  # noqa: BLE001
+            accel = ""
+    try:
+        from .failover_tier import accelerator_vram_bytes  # noqa: PLC0415
+        return accelerator_vram_bytes(accel)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+# --- Resilient L7 Recovery (auto-heal on connection drop) -------------------
+
+def _l7_recovery_attempts() -> int:
+    """Extra retries after a recoverable L7 failure (ServerDisconnect) before the
+    dispatch raises (-> sentinel seam seals). Default 2. NEVER raises."""
+    try:
+        return max(0, int(os.environ.get("JARVIS_FAILOVER_L7_RECOVERY_ATTEMPTS", "2")))
+    except (TypeError, ValueError):
+        return 2
+
+
+def _l7_tighten_factor() -> float:
+    """num_ctx shrink factor applied on each auto-heal retry (more aggressive
+    compression). Default 0.6. Clamped to (0,1). NEVER raises."""
+    try:
+        f = float(os.environ.get("JARVIS_FAILOVER_L7_TIGHTEN_FACTOR", "0.6"))
+        return f if 0.0 < f < 1.0 else 0.6
+    except (TypeError, ValueError):
+        return 0.6
+
+
+def _l7_rewarm_timeout_s() -> float:
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_FAILOVER_L7_REWARM_TIMEOUT_S", "120")))
+    except (TypeError, ValueError):
+        return 120.0
+
+
+_L7_RECOVERABLE_NAMES = frozenset({
+    "ServerDisconnectedError", "ClientConnectionError", "ClientConnectionResetError",
+    "ClientOSError", "ClientPayloadError", "ConnectionResetError",
+    "ConnectionError", "ConnectionAbortedError", "ServerTimeoutError",
+})
+
+
+def _is_l7_recoverable(exc: BaseException) -> bool:
+    """True iff *exc* is a transient connection-drop the auto-heal can retry (a
+    warm worker that dropped mid-request -- e.g. a KV-cache OOM crash). A logic
+    error (ValueError, KeyError) is NOT recoverable. NEVER raises."""
+    try:
+        if isinstance(exc, (ConnectionError, ConnectionResetError, ConnectionAbortedError)):
+            return True
+        name = type(exc).__name__
+        if name in _L7_RECOVERABLE_NAMES:
+            return True
+        return "disconnect" in str(exc).lower()
+    except Exception:  # noqa: BLE001
+        return False
 
 
 class CandidateGenerator:
@@ -4022,6 +4152,25 @@ class CandidateGenerator:
         default). Fail-soft -- NEVER raises."""
         return await _resolve_served_model(endpoint)
 
+    async def _negotiate_num_ctx(self, endpoint: Optional[str]) -> Optional[int]:
+        """Autonomous Context-Hardware Negotiator: derive the VRAM-safe context
+        window for *endpoint* from the MEASURED buffer -- node VRAM (awakened GPU
+        tier) minus the served model's on-disk bytes (its own /api/tags) -- so the
+        KV cache can never overflow VRAM (the warm-32B ServerDisconnect root cause).
+        None when undeterminable (not a GPU tier / size unknown) -> caller keeps the
+        legacy path. Fail-soft -- NEVER raises."""
+        try:
+            model_bytes = await _resolve_served_model_bytes(endpoint)
+            vram_bytes = _awakened_vram_bytes()
+            if not model_bytes or not vram_bytes:
+                return None
+            from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+                derive_safe_num_ctx,
+            )
+            return derive_safe_num_ctx(vram_bytes=vram_bytes, model_bytes=model_bytes)
+        except Exception:  # noqa: BLE001
+            return None
+
     async def _failover_local_dispatch(
         self,
         context: OperationContext,
@@ -4032,16 +4181,26 @@ class CandidateGenerator:
 
         Builds a ``PrimeProvider`` wrapping a ``LocalPrimeClient`` pointed at the
         awakened J-Prime node's OpenAI-compatible endpoint and calls its
-        ``.generate(context, deadline)``. The PrimeProvider seat produces the
-        exact ``GenerationResult`` shape the dispatch returns, so APPLY/VERIFY
-        downstream is byte-identical.
+        ``.generate(context, deadline)``. The PrimeProvider seat produces the exact
+        ``GenerationResult`` shape the dispatch returns, so APPLY/VERIFY downstream
+        is byte-identical.
 
-        Reuses the existing PrimeProvider seat + LocalPrimeClient -- NO new
-        provider. The client is bound at the endpoint via ``LocalConfig`` (the
-        ``base_url`` override); nothing is hardcoded. Bounded by the op's own
-        remaining budget. Returns the ``GenerationResult`` on success or ``None``
-        to fall through to the DW path (the caller treats both empty + None as
-        fall-through). Fail-soft -- the caller's try/except is the final net.
+        Three intelligences layered here (all reuse existing seats -- no new
+        provider, nothing hardcoded):
+          * model name = the node's OWN /api/tags truth (deterministic L7), so the
+            request never asks for a model the node lacks (the KeyError('choices'));
+          * ``num_ctx`` = the Context-Hardware Negotiator's VRAM-safe window, which
+            drives Dynamic Cognitive Compression inside ``LocalPrimeClient`` so the
+            KV cache can never overflow VRAM;
+          * Resilient L7 Recovery: on a transient connection drop (a warm worker
+            that crashed mid-request -- e.g. a KV-cache OOM), AUTO-HEAL by
+            re-warming + tightening num_ctx and retrying, up to N times, before
+            raising (which lets the sentinel seam SEAL/halt -- never cascade).
+
+        Bounded by the op's own remaining budget. Returns the ``GenerationResult``
+        on success or ``None`` to fall through. Raises only when the auto-heal is
+        exhausted on a recoverable fault (so sealing halts) or on a non-recoverable
+        error (the caller's try/except is the final net).
         """
         import dataclasses as _f3c_dc
 
@@ -4053,38 +4212,66 @@ class CandidateGenerator:
             PrimeProvider as _F3cPrimeProvider,
         )
 
-        # Point a LocalConfig at the awakened endpoint (base_url override) AND at
-        # the model the awakened node actually serves. LocalConfig.from_env()
-        # defaults model_name to a small survival model (qwen2.5-coder:3b); the
-        # QUALITY failover node serves qwen2.5-coder:32b, so without this override
-        # the OpenAI-compat request asks for a model the node does not have and
-        # ollama returns an error object with no "choices" -> KeyError('choices').
-        # The model name is the node's OWN /api/tags truth (deterministic L7),
-        # memoized per-endpoint -- not the lagging FSM _active_model_label.
-        _overrides = {"base_url": endpoint}
+        _base_overrides: Dict[str, Any] = {"base_url": endpoint}
         _model = await self._resolve_dispatch_model_name(endpoint)
         if _model:
-            _overrides["model_name"] = _model
-        _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)
-        _client = _F3cLocalPrimeClient(_cfg)
-        try:
-            _provider = _F3cPrimeProvider(
-                _client,
-                repo_root=self._repo_root if hasattr(self, "_repo_root") else None,
+            _base_overrides["model_name"] = _model
+        _num_ctx = await self._negotiate_num_ctx(endpoint)
+        _op = getattr(context, "op_id", "?")[:16]
+        if _num_ctx:
+            logger.info(
+                "[CandidateGenerator] Context-Hardware Negotiator: VRAM-safe "
+                "num_ctx=%d for the 32B at %s op=%s", _num_ctx, endpoint, _op,
             )
-            remaining = self._remaining_seconds(deadline)
-            if remaining <= 0.0:
-                return None
-            return await asyncio.wait_for(
-                _provider.generate(context, deadline),
-                timeout=remaining,
-            )
-        finally:
-            # Release the pooled aiohttp session (zero hanging FDs). Best-effort.
+
+        _attempts = _l7_recovery_attempts()
+        _last_exc: Optional[BaseException] = None
+        for _try in range(_attempts + 1):
+            _overrides = dict(_base_overrides)
+            if _num_ctx:
+                _overrides["num_ctx"] = int(_num_ctx)
+            _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)
+            _client = _F3cLocalPrimeClient(_cfg)
             try:
-                await _client.aclose()
-            except Exception:  # noqa: BLE001
-                pass
+                _provider = _F3cPrimeProvider(
+                    _client,
+                    repo_root=self._repo_root if hasattr(self, "_repo_root") else None,
+                )
+                remaining = self._remaining_seconds(deadline)
+                if remaining <= 0.0:
+                    return None
+                return await asyncio.wait_for(
+                    _provider.generate(context, deadline),
+                    timeout=remaining,
+                )
+            except Exception as _exc:  # noqa: BLE001
+                _last_exc = _exc
+                # Non-recoverable OR out of retries -> propagate (sentinel seals).
+                if _try >= _attempts or not _is_l7_recoverable(_exc):
+                    raise
+                # AUTO-HEAL: tighten the window (more aggressive compression) +
+                # re-warm the worker, then retry. This is the sovereign path the
+                # sealer guards -- we exhaust recovery BEFORE halting.
+                if _num_ctx:
+                    _num_ctx = max(512, int(_num_ctx * _l7_tighten_factor()))
+                logger.warning(
+                    "[CandidateGenerator] L7 AUTO-HEAL: %s on the 32B -> re-warm + "
+                    "tighten num_ctx=%s, retry %d/%d op=%s",
+                    type(_exc).__name__, _num_ctx, _try + 1, _attempts, _op,
+                )
+                try:
+                    await _client.warmup(timeout_s=_l7_rewarm_timeout_s())
+                except Exception:  # noqa: BLE001
+                    pass
+            finally:
+                try:
+                    await _client.aclose()
+                except Exception:  # noqa: BLE001
+                    pass
+        # Unreachable in practice (the loop returns or raises), but keep the net.
+        if _last_exc is not None:
+            raise _last_exc
+        return None
 
     async def _dispatch_via_sentinel(
         self,

--- a/backend/core/ouroboros/governance/failover_tier.py
+++ b/backend/core/ouroboros/governance/failover_tier.py
@@ -23,6 +23,37 @@ from dataclasses import dataclass
 
 _PARAM_RE = re.compile(r"(\d+(?:\.\d+)?)\s*b\b", re.IGNORECASE)
 
+# VRAM (GiB) per GCP accelerator type -- the physical ceiling the Context-Hardware
+# Negotiator derives the safe num_ctx from. Descriptive hardware facts, NOT a
+# tunable cap; an operator may override the resolved value with JARVIS_GPU_VRAM_GIB.
+_GPU_VRAM_GIB = {
+    "nvidia-l4": 24,
+    "nvidia-tesla-t4": 16,
+    "nvidia-t4": 16,
+    "nvidia-tesla-p100": 16,
+    "nvidia-tesla-v100": 16,
+    "nvidia-tesla-a100": 40,
+    "nvidia-a100": 40,
+    "nvidia-a100-80gb": 80,
+    "nvidia-h100": 80,
+    "nvidia-h100-80gb": 80,
+    "nvidia-h100-mega-80gb": 80,
+}
+
+
+def accelerator_vram_bytes(accel_type: str) -> int:
+    """Physical VRAM (bytes) for a GCP accelerator type. ``JARVIS_GPU_VRAM_GIB``
+    force-overrides the lookup (any node); an unknown type returns 0 so the caller
+    floors the context window rather than guessing. NEVER raises."""
+    try:
+        forced = (os.environ.get("JARVIS_GPU_VRAM_GIB", "") or "").strip()
+        if forced:
+            return int(float(forced) * (1024 ** 3))
+        gib = _GPU_VRAM_GIB.get((accel_type or "").strip().lower(), 0)
+        return int(gib * (1024 ** 3))
+    except Exception:  # noqa: BLE001 -- descriptive helper must never raise
+        return 0
+
 
 def _env(name: str, default: str) -> str:
     return (os.environ.get(name, default) or default).strip()

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -9,15 +9,18 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import logging
 import math
 import os
 import threading
 import time
 from collections import deque
 from dataclasses import dataclass
-from typing import Any, Deque, Dict, List, Optional
+from typing import Any, Deque, Dict, List, Optional, Tuple
 
 from .memory_pressure_gate import PressureLevel, get_default_gate, is_enabled as memory_gate_enabled
+
+logger = logging.getLogger(__name__)
 
 _TRUE = {"1", "true", "yes", "on"}
 
@@ -46,12 +49,17 @@ class LocalConfig:
     min_samples: int
     max_concurrency: int
     pool_limit: int
+    # Autonomous Context-Hardware Negotiator output: the VRAM-safe context window
+    # injected as ollama ``options.num_ctx`` + used as the Cognitive Compression
+    # budget. None -> legacy (no injection, no compression) = byte-identical.
+    num_ctx: Optional[int] = None
 
     @classmethod
     def from_env(cls) -> "LocalConfig":
         def _i(n: str, d: int) -> int: return int(os.environ.get(n, str(d)))
         def _f(n: str, d: float) -> float: return float(os.environ.get(n, str(d)))
         ceiling = _i("JARVIS_LOCAL_INFERENCE_TIMEOUT_MS", 120_000)
+        _nc = os.environ.get("JARVIS_LOCAL_NUM_CTX", "").strip()
         return cls(
             base_url=os.environ.get("JARVIS_LOCAL_MODEL_BASE_URL", "http://127.0.0.1:11434"),
             model_name=os.environ.get("JARVIS_LOCAL_MODEL_NAME", "qwen2.5-coder:3b"),
@@ -65,7 +73,107 @@ class LocalConfig:
             min_samples=_i("JARVIS_LOCAL_PROFILER_MIN_SAMPLES", 5),
             max_concurrency=_i("JARVIS_LOCAL_MODEL_MAX_CONCURRENCY", 2),
             pool_limit=_i("JARVIS_LOCAL_POOL_LIMIT", 8),
+            num_ctx=int(_nc) if _nc.isdigit() else None,
         )
+
+
+# ---------------------------------------------------------------------------
+# Autonomous Context-Hardware Negotiator + Dynamic Cognitive Compression
+# ---------------------------------------------------------------------------
+#
+# The warm 32B ServerDisconnects on an L4 because the KV cache for a large prompt
+# overflows the VRAM left after the ~20GB model weights. We solve this in software:
+# derive the max SAFE num_ctx from the MEASURED VRAM buffer (no static cap), then
+# compress the payload to fit it (preserve the system rules + recent tool outputs).
+
+_KV_BYTES_PER_TOKEN_DEFAULT = 524288      # ~512KB/token: 2(K+V)*64L*8kv*128d*2B for a 32B GQA fp16 KV
+_CTX_OVERHEAD_BYTES_DEFAULT = 1_500_000_000  # CUDA/runtime/activation headroom
+_NUM_CTX_FLOOR_DEFAULT = 2048
+_NUM_CTX_CEILING_DEFAULT = 32768
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def estimate_tokens(text: Any) -> int:
+    """Cheap deterministic token estimate (~4 chars/token). NEVER raises."""
+    try:
+        return max(0, len(text or "") // 4)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def derive_safe_num_ctx(
+    *,
+    vram_bytes: int,
+    model_bytes: int,
+    kv_bytes_per_token: "Optional[int]" = None,
+    overhead_bytes: "Optional[int]" = None,
+    floor: "Optional[int]" = None,
+    ceiling: "Optional[int]" = None,
+) -> int:
+    """Mathematically derive the max SAFE context window from the MEASURED VRAM
+    buffer: ``(vram - model - overhead) / kv_bytes_per_token``, floored to a 256
+    multiple and clamped to [floor, ceiling]. NOT a static cap -- a bigger GPU or a
+    smaller model widens the window automatically. Fail-soft -> floor on any
+    non-positive buffer / bad input."""
+    kvbpt = kv_bytes_per_token if kv_bytes_per_token is not None else _int_env(
+        "JARVIS_KV_BYTES_PER_TOKEN", _KV_BYTES_PER_TOKEN_DEFAULT)
+    ovh = overhead_bytes if overhead_bytes is not None else _int_env(
+        "JARVIS_CTX_OVERHEAD_BYTES", _CTX_OVERHEAD_BYTES_DEFAULT)
+    flr = floor if floor is not None else _int_env("JARVIS_NUM_CTX_FLOOR", _NUM_CTX_FLOOR_DEFAULT)
+    ceil = ceiling if ceiling is not None else _int_env("JARVIS_NUM_CTX_CEILING", _NUM_CTX_CEILING_DEFAULT)
+    try:
+        if vram_bytes <= 0 or model_bytes <= 0 or kvbpt <= 0:
+            return flr
+        kv_buffer = int(vram_bytes) - int(model_bytes) - int(ovh)
+        if kv_buffer <= 0:
+            return flr
+        nctx = (int(kv_buffer // kvbpt) // 256) * 256  # 256-multiple for engine friendliness
+        return max(flr, min(ceil, nctx))
+    except Exception:  # noqa: BLE001
+        return flr
+
+
+def fit_prompt_to_window(
+    system: str,
+    user: str,
+    *,
+    max_tokens: int,
+    head_frac: float = 0.35,
+    tail_frac: float = 0.5,
+) -> "Tuple[str, str, bool]":
+    """Dynamic Cognitive Compression (sliding window). Preserve the SYSTEM prompt
+    (Iron Gate rules) IN FULL + a HEAD (task/plan) and TAIL (most recent tool
+    outputs) of the user payload; compress the older intermediate middle into a
+    deterministic marker. GUARANTEES ``estimate_tokens(system)+estimate_tokens(user)
+    <= max_tokens`` (best-effort; the system is never cut, so if it alone exceeds
+    the window the user is reduced to a stub). Returns (system, user, compressed?)."""
+    system = system or ""
+    user = user or ""
+    if estimate_tokens(system) + estimate_tokens(user) <= max_tokens:
+        return system, user, False
+    user_budget_toks = max_tokens - estimate_tokens(system)
+    if user_budget_toks <= 0:
+        return system, "[context omitted: system prompt already fills the VRAM-safe window]", True
+    char_budget = user_budget_toks * 4
+    head_chars = max(0, int(char_budget * head_frac))
+    tail_chars = max(0, int(char_budget * tail_frac))
+    if len(user) <= head_chars + tail_chars or head_chars + tail_chars == 0:
+        return system, user[:char_budget], True
+    head = user[:head_chars]
+    tail = user[-tail_chars:]
+    dropped = len(user) - head_chars - tail_chars
+    marker = (
+        "\n\n[...cognitive compression: %d chars of older intermediate history "
+        "elided to fit the %d-token VRAM-safe window; system rules + recent tool "
+        "outputs preserved...]\n\n" % (dropped, max_tokens)
+    )
+    return system, head + marker + tail, True
 
 
 class LatencyProfiler:
@@ -210,6 +318,24 @@ class LocalPrimeClient:
                        max_tokens: "Optional[int]" = None) -> LocalCompletion:
         sess = await self._ensure_session()
         url = self._cfg.base_url.rstrip("/") + "/v1/chat/completions"
+        # Dynamic Cognitive Compression + num_ctx injection (Context-Hardware
+        # Negotiator). When a VRAM-safe num_ctx is configured, fit the payload to
+        # the INPUT budget (num_ctx minus reserved output) so the KV cache can never
+        # overflow VRAM -> no ServerDisconnect. The system prompt (Iron Gate rules)
+        # is preserved in full; older intermediate history is compressed. num_ctx is
+        # also declared to the engine so it never pre-allocates a fatal KV cache.
+        if self._cfg.num_ctx:
+            _reserve_out = max_tokens or 0
+            _in_budget = max(256, int(self._cfg.num_ctx) - _reserve_out)
+            system, user, _compressed = fit_prompt_to_window(
+                system, user, max_tokens=_in_budget,
+            )
+            if _compressed:
+                logger.info(
+                    "[LocalPrimeClient] Cognitive Compression applied: fit payload "
+                    "to %d-token input budget (num_ctx=%d, reserved_out=%d)",
+                    _in_budget, int(self._cfg.num_ctx), _reserve_out,
+                )
         body: Dict[str, Any] = {
             "model": self._cfg.model_name,
             "keep_alive": self._cfg.keep_alive_seconds,
@@ -219,6 +345,10 @@ class LocalPrimeClient:
                 {"role": "user", "content": user},
             ],
         }
+        if self._cfg.num_ctx:
+            # ollama-native option; harmless if a given engine ignores it (the
+            # compression above is the hard guarantee, this is the declarative one).
+            body["options"] = {"num_ctx": int(self._cfg.num_ctx)}
         if max_tokens is not None:
             body["max_tokens"] = max_tokens
         t0 = time.monotonic()

--- a/tests/governance/test_context_negotiator.py
+++ b/tests/governance/test_context_negotiator.py
@@ -1,0 +1,277 @@
+"""Autonomous Context-Hardware Negotiator + Dynamic Cognitive Compression.
+
+Solves the VRAM/KV-cache OOM (warm 32B ServerDisconnect on an L4) via software
+intelligence, not hardware scaling:
+
+  1. `derive_safe_num_ctx` mathematically derives the max safe context window from
+     the MEASURED VRAM buffer (VRAM - model_size - overhead) / kv_bytes_per_token.
+     No static cap -- a bigger GPU or smaller model yields a bigger window
+     automatically.
+  2. `accelerator_vram_bytes` maps a GCP accelerator to its VRAM (env-overridable).
+  3. `fit_prompt_to_window` is the sliding-window Cognitive Compression: preserve
+     the system prompt (Iron Gate rules) IN FULL + the recent tail (latest tool
+     outputs), compress the older intermediate middle, GUARANTEE the result fits.
+"""
+from __future__ import annotations
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+import backend.core.ouroboros.governance.failover_tier as ft
+
+
+_GIB = 1024 ** 3
+
+
+# --- Negotiator: derive safe num_ctx from measured VRAM buffer ---------------
+
+def test_negotiator_derives_from_vram_buffer():
+    # L4 24GiB, model ~20GiB, 1.5GB overhead, 512KB/token KV -> a positive window.
+    n = lid.derive_safe_num_ctx(
+        vram_bytes=24 * _GIB, model_bytes=20 * _GIB,
+        kv_bytes_per_token=524288, overhead_bytes=1_500_000_000,
+        floor=2048, ceiling=32768,
+    )
+    # buffer = 24GiB - 20GiB - 1.5GB ~= 2.79GB ; /512KB ~= 5300 -> clamp, /256 round
+    assert 2048 <= n <= 32768
+    assert n % 256 == 0
+    assert 4000 <= n <= 7000  # sane L4 window for a 32B
+
+
+def test_negotiator_bigger_gpu_yields_bigger_window():
+    small = lid.derive_safe_num_ctx(vram_bytes=24 * _GIB, model_bytes=20 * _GIB,
+                                    kv_bytes_per_token=524288, overhead_bytes=1_500_000_000,
+                                    floor=2048, ceiling=131072)
+    big = lid.derive_safe_num_ctx(vram_bytes=80 * _GIB, model_bytes=20 * _GIB,
+                                  kv_bytes_per_token=524288, overhead_bytes=1_500_000_000,
+                                  floor=2048, ceiling=131072)
+    assert big > small  # adaptive: more VRAM -> more context, no code change
+
+
+def test_negotiator_floors_when_no_buffer():
+    # Model bigger than VRAM -> negative buffer -> floor (never negative / crash).
+    n = lid.derive_safe_num_ctx(vram_bytes=16 * _GIB, model_bytes=20 * _GIB,
+                                kv_bytes_per_token=524288, overhead_bytes=1_500_000_000,
+                                floor=2048, ceiling=32768)
+    assert n == 2048
+
+
+def test_negotiator_clamps_to_ceiling():
+    n = lid.derive_safe_num_ctx(vram_bytes=200 * _GIB, model_bytes=20 * _GIB,
+                                kv_bytes_per_token=524288, overhead_bytes=1_500_000_000,
+                                floor=2048, ceiling=8192)
+    assert n == 8192
+
+
+def test_negotiator_failsoft_on_bad_input():
+    assert lid.derive_safe_num_ctx(vram_bytes=0, model_bytes=0,
+                                   kv_bytes_per_token=1, overhead_bytes=0,
+                                   floor=2048, ceiling=32768) == 2048
+
+
+# --- VRAM lookup ------------------------------------------------------------
+
+def test_vram_lookup_known_accelerators():
+    assert ft.accelerator_vram_bytes("nvidia-l4") == 24 * _GIB
+    assert ft.accelerator_vram_bytes("nvidia-a100") == 40 * _GIB
+
+
+def test_vram_lookup_unknown_is_zero():
+    assert ft.accelerator_vram_bytes("nvidia-unobtainium") == 0
+    assert ft.accelerator_vram_bytes("") == 0
+
+
+def test_vram_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_GPU_VRAM_GIB", "48")
+    assert ft.accelerator_vram_bytes("nvidia-l4") == 48 * _GIB
+
+
+# --- Cognitive Compression sliding window -----------------------------------
+
+def test_fit_noop_when_within_window():
+    sys_p = "SYSTEM RULES"
+    usr = "short user payload"
+    s, u, compressed = lid.fit_prompt_to_window(sys_p, usr, max_tokens=10_000)
+    assert s == sys_p and u == usr and compressed is False
+
+
+def test_fit_preserves_system_and_tail_compresses_middle():
+    sys_p = "IRON GATE: explore >=2 before patch. " * 5
+    # Build a large user payload: HEAD (task) + huge middle + TAIL (recent tools).
+    head = "TASK: fix the bug in module X.\n"
+    middle = "OLD TOOL RESULT LINE\n" * 5000
+    tail = "\nRECENT read_file(x.py) -> def foo(): ...\n"
+    usr = head + middle + tail
+    s, u, compressed = lid.fit_prompt_to_window(sys_p, usr, max_tokens=1024)
+    assert compressed is True
+    assert s == sys_p                                   # system preserved IN FULL
+    assert "TASK: fix the bug" in u                     # head preserved
+    assert "RECENT read_file(x.py)" in u                # recent tail preserved
+    assert "compression" in u.lower()                   # deterministic marker present
+    # GUARANTEE it fits the window (system + user <= max_tokens).
+    assert lid.estimate_tokens(s) + lid.estimate_tokens(u) <= 1024
+
+
+def test_fit_guarantees_fit_even_when_system_dominates():
+    sys_p = "S" * 40_000  # system alone exceeds the window
+    usr = "U" * 40_000
+    s, u, compressed = lid.fit_prompt_to_window(sys_p, usr, max_tokens=1024)
+    assert s == sys_p            # never cut the system (Iron Gate rules)
+    assert compressed is True
+    assert lid.estimate_tokens(u) <= 1024  # user reduced to (near) nothing
+
+
+def test_estimate_tokens_monotonic():
+    assert lid.estimate_tokens("") == 0
+    assert lid.estimate_tokens("abcd") == 1
+    assert lid.estimate_tokens("x" * 400) == 100
+
+
+# --- candidate_generator: /api/tags size + negotiation + L7 auto-heal --------
+
+import asyncio  # noqa: E402
+import datetime as _dt  # noqa: E402
+
+import backend.core.ouroboros.governance.candidate_generator as cg  # noqa: E402
+
+
+def test_parse_served_model_bytes_picks_largest():
+    tags = {"models": [
+        {"name": "qwen2.5-coder:3b", "size": 2_000_000_000},
+        {"name": "qwen2.5-coder:32b", "size": 20_000_000_000},
+    ]}
+    assert cg._parse_served_model_bytes(tags) == 20_000_000_000
+    assert cg._parse_served_model_bytes({}) == 0
+    assert cg._parse_served_model_bytes(None) == 0
+
+
+def test_negotiate_num_ctx_combines_vram_and_model(monkeypatch):
+    async def _bytes(endpoint, **_kw):
+        return 20 * (1024 ** 3)  # ~20GiB model
+    monkeypatch.setattr(cg, "_resolve_served_model_bytes", _bytes)
+    monkeypatch.setattr(cg, "_awakened_vram_bytes", lambda: 24 * (1024 ** 3))  # L4
+
+    class _Stub:
+        pass
+
+    n = asyncio.run(cg.CandidateGenerator._negotiate_num_ctx(_Stub(), "http://n:11434"))
+    assert n is not None and 2048 <= n <= 32768 and n % 256 == 0
+
+
+def test_negotiate_num_ctx_none_when_undeterminable(monkeypatch):
+    async def _zero(endpoint, **_kw):
+        return 0
+    monkeypatch.setattr(cg, "_resolve_served_model_bytes", _zero)
+    monkeypatch.setattr(cg, "_awakened_vram_bytes", lambda: 0)
+
+    class _Stub:
+        pass
+
+    assert asyncio.run(cg.CandidateGenerator._negotiate_num_ctx(_Stub(), "http://n:11434")) is None
+
+
+def test_is_l7_recoverable_classifies_disconnects():
+    import aiohttp
+    assert cg._is_l7_recoverable(aiohttp.ServerDisconnectedError()) is True
+    assert cg._is_l7_recoverable(ConnectionResetError()) is True
+    assert cg._is_l7_recoverable(ValueError("nope")) is False
+
+
+def _deadline(s=120.0):
+    return _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=s)
+
+
+def test_l7_autoheal_retries_then_succeeds(monkeypatch):
+    """A ServerDisconnected on the warm 32B triggers re-warm + tighten + retry --
+    the second attempt (tighter window) succeeds, no permanent halt."""
+    monkeypatch.setenv("JARVIS_FAILOVER_L7_RECOVERY_ATTEMPTS", "2")
+    import backend.core.ouroboros.governance.local_inference_director as lidmod
+    import backend.core.ouroboros.governance.providers as provmod
+    import aiohttp
+
+    warmups = {"n": 0}
+    ctx_windows = []
+
+    class _FakeClient:
+        def __init__(self, cfg):
+            self.cfg = cfg
+            ctx_windows.append(getattr(cfg, "num_ctx", None))
+        async def warmup(self, *, timeout_s):
+            warmups["n"] += 1
+            return True
+        async def aclose(self):
+            pass
+
+    class _Result:
+        candidates = ("cand",)
+
+    class _FakeProvider:
+        _calls = {"n": 0}
+        def __init__(self, client, repo_root=None):
+            self.client = client
+        async def generate(self, context, deadline):
+            _FakeProvider._calls["n"] += 1
+            if _FakeProvider._calls["n"] == 1:
+                raise aiohttp.ServerDisconnectedError("worker dropped")
+            return _Result()
+
+    monkeypatch.setattr(lidmod, "LocalPrimeClient", _FakeClient)
+    monkeypatch.setattr(provmod, "PrimeProvider", _FakeProvider)
+
+    class _Stub:
+        _repo_root = None
+        def _remaining_seconds(self, dl):
+            return 60.0
+        async def _resolve_dispatch_model_name(self, ep):
+            return "qwen2.5-coder:32b"
+        async def _negotiate_num_ctx(self, ep):
+            return 8192
+
+    res = asyncio.run(
+        cg.CandidateGenerator._failover_local_dispatch(_Stub(), object(), _deadline(), "http://n:11434")
+    )
+    assert res is not None and getattr(res, "candidates", None)
+    assert warmups["n"] >= 1                      # re-warm ping fired
+    assert len(ctx_windows) >= 2                  # a second (retry) client was built
+    assert ctx_windows[1] < ctx_windows[0]        # window tightened on retry
+
+
+def test_l7_autoheal_exhausts_then_raises(monkeypatch):
+    """If every attempt disconnects, the auto-heal exhausts and RAISES (so the
+    sentinel seam seals/halts -- never cascades)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_L7_RECOVERY_ATTEMPTS", "1")
+    import backend.core.ouroboros.governance.local_inference_director as lidmod
+    import backend.core.ouroboros.governance.providers as provmod
+    import aiohttp
+
+    class _FakeClient:
+        def __init__(self, cfg):
+            pass
+        async def warmup(self, *, timeout_s):
+            return True
+        async def aclose(self):
+            pass
+
+    class _FakeProvider:
+        def __init__(self, client, repo_root=None):
+            pass
+        async def generate(self, context, deadline):
+            raise aiohttp.ServerDisconnectedError("always down")
+
+    monkeypatch.setattr(lidmod, "LocalPrimeClient", _FakeClient)
+    monkeypatch.setattr(provmod, "PrimeProvider", _FakeProvider)
+
+    class _Stub:
+        _repo_root = None
+        def _remaining_seconds(self, dl):
+            return 60.0
+        async def _resolve_dispatch_model_name(self, ep):
+            return "qwen2.5-coder:32b"
+        async def _negotiate_num_ctx(self, ep):
+            return 8192
+
+    try:
+        asyncio.run(
+            cg.CandidateGenerator._failover_local_dispatch(_Stub(), object(), _deadline(), "http://n:11434")
+        )
+        assert False, "expected the exhausted auto-heal to raise"
+    except aiohttp.ServerDisconnectedError:
+        pass  # exhausted -> raised -> the sentinel seam will seal (halt, no cascade)


### PR DESCRIPTION
Solves the warm-32B `ServerDisconnectedError` (KV-cache VRAM OOM on an L4) via **software intelligence, not hardware scaling**. Three constraints, built on existing seats, nothing hardcoded.

## 1. Autonomous Context-Hardware Negotiator
`derive_safe_num_ctx` (local_inference_director) + `accelerator_vram_bytes` (failover_tier) + `_negotiate_num_ctx` (candidate_generator): mathematically derive the max safe `num_ctx` from the **measured** buffer — node VRAM (awakened GPU tier) − served-model bytes (its own `/api/tags`) − overhead, ÷ `kv_bytes_per_token`. **Not a static cap**: a bigger GPU or smaller model widens the window automatically. All physics constants env-tunable. Activates only on GPU tiers → CPU/survival stays byte-identical.

## 2. Dynamic Cognitive Compression (sliding window)
`fit_prompt_to_window`, applied in `LocalPrimeClient.complete()` before the wire: fit the payload to the negotiated input budget (num_ctx − reserved output). **Preserves the system prompt (Iron Gate rules) in full + head (task) + tail (recent tool outputs)**, compresses the older middle into a deterministic marker. **Guarantees fit** → KV cache can't overflow VRAM. Also declares `options.num_ctx` so the engine never pre-allocates a fatal cache.

## 3. Resilient L7 Recovery (auto-heal)
`_failover_local_dispatch`: on a transient drop (`ServerDisconnectedError` — a warm worker that crashed mid-request), **re-warm + tighten num_ctx + retry** up to `JARVIS_FAILOVER_L7_RECOVERY_ATTEMPTS` (default 2) before raising. Raising lets the Absolute Route Sealer halt (never cascade) — but only *after* recovery is exhausted. Non-recoverable errors propagate immediately.

## Tests (TDD)
18 new + 121 green regression (negotiator/warmup/compression/lifecycle/override/route-sealing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops warm-32B disconnects by computing a VRAM‑safe context window, fitting prompts to it, and auto‑healing transient L7 drops. No hardware scaling; adapts to the awakened GPU and the served model.

- **New Features**
  - Context‑Hardware Negotiator: `derive_safe_num_ctx` + `accelerator_vram_bytes` + `CandidateGenerator._negotiate_num_ctx` compute a safe `num_ctx` from live VRAM minus served‑model bytes and overhead. Tunables: `JARVIS_KV_BYTES_PER_TOKEN`, `JARVIS_CTX_OVERHEAD_BYTES`, `JARVIS_NUM_CTX_FLOOR`, `JARVIS_NUM_CTX_CEILING`, `JARVIS_GPU_VRAM_GIB`.
  - Dynamic Cognitive Compression: `fit_prompt_to_window` in `LocalPrimeClient.complete()` preserves the system prompt and recent tail, compresses the middle to fit the input budget (`num_ctx` minus reserved output). Also sets `options.num_ctx` so the engine avoids fatal KV pre‑allocation.
  - Resilient L7 auto‑heal: `_failover_local_dispatch` retries on recoverable disconnects by re‑warming and tightening `num_ctx`. Controls: `JARVIS_FAILOVER_L7_RECOVERY_ATTEMPTS`, `JARVIS_FAILOVER_L7_TIGHTEN_FACTOR`, `JARVIS_FAILOVER_L7_REWARM_TIMEOUT_S`.

- **Migration**
  - No action needed; activates automatically on GPU tiers. Env knobs above are optional for tuning.

<sup>Written for commit 96cc8a4f650a9bd4a6509a1cffeb8b920272a398. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69797?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

