### PR TITLE
feat(a1): RAM Pre-Flight Gate + host bump to g2-standard-8

### DIFF
--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -1996,6 +1996,42 @@ class FailoverLifecycleController:
 
         Fail-soft: on any failure, revert to DORMANT (retry next tick). The op
         is never lost -- the quarantine Cryo-DLQ remains the backstop."""
+        # RAM Pre-Flight Gate (before ANY instances.insert): assert the resolved
+        # tier's machine RAM can physically hold its model + OS overhead. A certain
+        # mismatch (e.g. g2-standard-4/16GB vs the 19.85GB 32B GGUF -> kernel OOM at
+        # load) HALTS the awaken here -- the impossible node is NEVER created. This
+        # is a distinct terminal from a transient awaken failure: revert DORMANT +
+        # arm the anti-thrash cooldown so we don't re-attempt the impossible config
+        # every tick, and flare it for observability.
+        try:
+            from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
+                resolve_tier as _rt,
+                assert_host_ram_fits_model as _assert_ram,
+                HardwareProvisioningMismatchError as _HWMismatch,
+            )
+            _tier_preflight = _rt(
+                urgency=_env_str("JARVIS_FAILOVER_AWAKEN_URGENCY", ""),
+                complexity=_env_str("JARVIS_FAILOVER_AWAKEN_COMPLEXITY", ""),
+            )
+            _assert_ram(_tier_preflight.machine_type, _tier_preflight.model_label)
+        except _HWMismatch as _hw_exc:
+            logger.error(
+                "[FailoverLifecycle] RAM PRE-FLIGHT GATE FAILED -- %s. Refusing to "
+                "provision; reverting DORMANT + arming cooldown (no impossible "
+                "instances.insert).", _hw_exc,
+            )
+            try:
+                self._emit_flare(trigger="hw_provisioning_mismatch", route=self._route,
+                                 now=self._clock_fn())
+            except Exception:  # noqa: BLE001
+                pass
+            self._state = FailoverState.DORMANT
+            self._awakening_started_at = None
+            self._last_handback_at = self._clock_fn()  # anti-thrash: block re-awaken
+            return
+        except Exception as _pf_exc:  # noqa: BLE001 -- gate must be fail-OPEN on its own error
+            logger.debug("[FailoverLifecycle] RAM pre-flight gate fail-soft (proceeding) err=%r", _pf_exc)
+
         try:
             # The primary node's runtime GPU gate follows its resolved tier (the
             # survival 7B/CPU tier has no GPU -> no gate; a quality GPU tier does).

--- a/backend/core/ouroboros/governance/failover_tier.py
+++ b/backend/core/ouroboros/governance/failover_tier.py
@@ -55,6 +55,100 @@ def accelerator_vram_bytes(accel_type: str) -> int:
         return 0
 
 
+class HardwareProvisioningMismatchError(RuntimeError):
+    """Raised by the RAM Pre-Flight Gate when a machine type's system RAM cannot
+    physically hold the model + OS overhead -- so the impossible ``instances.insert``
+    is NEVER attempted (the g2-standard-4/16GB vs 19.85GB-model kernel OOM class)."""
+
+
+# System RAM (MB) for machine types we provision. Descriptive hardware facts. The
+# g2-standard-N family derives N*4GiB by pattern; this map covers the survival
+# tier + pins the common g2 sizes. Override any type via
+# ``JARVIS_MACHINE_RAM_MB_<TYPE>`` (dashes -> underscores, upper-cased).
+_STATIC_MACHINE_RAM_MB = {
+    "e2-highmem-2": 16384,
+    "e2-highmem-4": 32768,
+    "e2-highmem-8": 65536,
+    "g2-standard-4": 16384,
+    "g2-standard-8": 32768,
+    "g2-standard-12": 49152,
+    "g2-standard-16": 65536,
+    "g2-standard-24": 98304,
+    "g2-standard-32": 131072,
+    "g2-standard-48": 196608,
+    "g2-standard-96": 393216,
+}
+
+_G2_STANDARD_RE = re.compile(r"^g2-standard-(\d+)$")
+
+
+def machine_type_ram_bytes(machine_type: str) -> int:
+    """System RAM (bytes) for a GCP machine type. Resolution order: env override
+    (``JARVIS_MACHINE_RAM_MB_<TYPE>``) -> static map -> g2-standard-N pattern
+    (N*4GiB). 0 when undeterminable (the gate then fails OPEN). NEVER raises."""
+    t = (machine_type or "").strip().lower()
+    if not t:
+        return 0
+    try:
+        env = os.environ.get("JARVIS_MACHINE_RAM_MB_" + t.upper().replace("-", "_"), "").strip()
+        if env:
+            return int(float(env) * 1024 * 1024)
+        mb = _STATIC_MACHINE_RAM_MB.get(t)
+        if mb:
+            return int(mb) * 1024 * 1024
+        m = _G2_STANDARD_RE.match(t)
+        if m:
+            return int(m.group(1)) * 4 * (1024 ** 3)
+        return 0
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def estimate_gguf_bytes(model_label: str) -> int:
+    """Estimate a model's on-disk GGUF size (bytes) from its parameter count:
+    ``params_B * 1e9 * JARVIS_GGUF_BYTES_PER_PARAM`` (default 0.62, ~q4_K_M -- this
+    yields ~19.8GB for a 32B, matching the observed 19.85GB /api/tags size).
+    ``JARVIS_FAILOVER_QUALITY_MODEL_BYTES`` force-overrides. 0 if the label has no
+    parseable param count. NEVER raises."""
+    try:
+        forced = (os.environ.get("JARVIS_FAILOVER_QUALITY_MODEL_BYTES", "") or "").strip()
+        if forced:
+            return int(forced)
+        billions = model_param_billions(model_label)
+        if billions <= 0:
+            return 0
+        bpp = float(os.environ.get("JARVIS_GGUF_BYTES_PER_PARAM", "0.62"))
+        return int(billions * 1e9 * bpp)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+def assert_host_ram_fits_model(
+    machine_type: str,
+    model_label: str,
+    *,
+    overhead_bytes: "int | None" = None,
+) -> None:
+    """RAM Pre-Flight Gate: assert the machine's system RAM strictly exceeds the
+    model's GGUF size + OS overhead (``JARVIS_HOST_RAM_OVERHEAD_BYTES``, default
+    4GiB), BEFORE ``instances.insert``. Raises :class:`HardwareProvisioningMismatchError`
+    on a certain mismatch (the kernel-OOM-at-load class). Fails OPEN when RAM or
+    GGUF size is undeterminable -- block only when CERTAIN the load is impossible."""
+    ram = machine_type_ram_bytes(machine_type)
+    gguf = estimate_gguf_bytes(model_label)
+    if ram <= 0 or gguf <= 0:
+        return  # undeterminable -> do not block on ignorance
+    ovh = overhead_bytes if overhead_bytes is not None else _env_int(
+        "JARVIS_HOST_RAM_OVERHEAD_BYTES", 4 * (1024 ** 3))
+    required = gguf + max(0, ovh)
+    if ram <= required:
+        raise HardwareProvisioningMismatchError(
+            "host RAM %d bytes (%s) <= model GGUF %d + overhead %d = %d required -- "
+            "refusing to provision an impossible load (kernel OOM-at-load class)"
+            % (ram, machine_type, gguf, ovh, required)
+        )
+
+
 def _env(name: str, default: str) -> str:
     return (os.environ.get(name, default) or default).strip()
 

--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -253,10 +253,15 @@ def _arm_failover_env(env: dict) -> dict:
         "JARVIS_FAILOVER_BUDGET_AWAKEN_ENABLED": "true",
         "JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED": "true",
         "JARVIS_FAILOVER_HEADER_AWARE_RECOVERY_ENABLED": "true",
-        # Force the 32B QUALITY GPU tier (g2-standard-4 + nvidia-l4 + jarvis-prime-coder-32b)
+        # Force the 32B QUALITY GPU tier (g2-standard-8 + nvidia-l4 + jarvis-prime-coder-32b).
+        # Host bump 4->8: g2-standard-4 has only 16GB system RAM, but the 32B GGUF is
+        # ~19.85GB -> llama-server was kernel-OOM-killed loading weights into RAM
+        # (BEFORE the L4 VRAM was ever used). g2-standard-8 = 32GB RAM > 19.85GB +
+        # 4GB overhead; SAME nvidia-l4 GPU + SAME model (no GPU/quality change). The
+        # RAM Pre-Flight Gate now asserts this mathematically before instances.insert.
         "JARVIS_FAILOVER_QUALITY_TIER_ENABLED": "true",
         "JARVIS_FAILOVER_AWAKEN_URGENCY": "immediate",
-        "JARVIS_FAILOVER_QUALITY_MACHINE": "g2-standard-4",
+        "JARVIS_FAILOVER_QUALITY_MACHINE": "g2-standard-8",
         "JARVIS_FAILOVER_QUALITY_ACCEL_TYPE": "nvidia-l4",
         "JARVIS_FAILOVER_QUALITY_ACCEL_COUNT": "1",
         "JARVIS_FAILOVER_QUALITY_IMAGE": "jarvis-prime-coder-32b",

--- a/tests/governance/test_hardware_ram_preflight.py
+++ b/tests/governance/test_hardware_ram_preflight.py
@@ -1,0 +1,183 @@
+"""Intelligent Hardware-Model RAM Assertion (Pre-Flight Gate).
+
+The g2-standard-4 (16GB RAM) OOM-killed llama-server loading the 19.85GB
+qwen2.5-coder:32b GGUF -- the kernel global_oom, BEFORE the L4 VRAM was ever
+used. This gate refuses to provision a host whose system RAM cannot physically
+hold the model + OS overhead: it derives the machine's RAM + the model's GGUF
+size and mathematically asserts RAM > gguf + overhead BEFORE the instances.insert,
+raising HardwareProvisioningMismatchError (never attempting an impossible load).
+"""
+from __future__ import annotations
+
+import pytest
+
+import backend.core.ouroboros.governance.failover_tier as ft
+
+
+_GIB = 1024 ** 3
+
+
+# --- machine RAM resolution -------------------------------------------------
+
+def test_machine_ram_known_g2_types():
+    assert ft.machine_type_ram_bytes("g2-standard-4") == 16 * _GIB
+    assert ft.machine_type_ram_bytes("g2-standard-8") == 32 * _GIB
+    assert ft.machine_type_ram_bytes("g2-standard-16") == 64 * _GIB
+
+
+def test_machine_ram_survival_and_unknown():
+    assert ft.machine_type_ram_bytes("e2-highmem-2") == 16 * _GIB
+    assert ft.machine_type_ram_bytes("totally-made-up") == 0
+    assert ft.machine_type_ram_bytes("") == 0
+
+
+def test_machine_ram_g2_pattern_derivation():
+    # g2-standard-N derives N*4GiB even if not in the static map.
+    assert ft.machine_type_ram_bytes("g2-standard-48") == 192 * _GIB
+
+
+def test_machine_ram_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_MACHINE_RAM_MB_G2_STANDARD_4", "65536")
+    assert ft.machine_type_ram_bytes("g2-standard-4") == 64 * _GIB
+
+
+# --- GGUF size estimate -----------------------------------------------------
+
+def test_gguf_estimate_matches_observed_32b():
+    # 32B * ~0.62 bytes/param ~= 19.8GB (the observed /api/tags size was 19.85GB).
+    n = ft.estimate_gguf_bytes("qwen2.5-coder:32b")
+    assert 18 * _GIB < n < 21 * _GIB
+
+
+def test_gguf_estimate_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_MODEL_BYTES", str(5 * _GIB))
+    assert ft.estimate_gguf_bytes("qwen2.5-coder:32b") == 5 * _GIB
+
+
+def test_gguf_estimate_unknown_label_zero():
+    assert ft.estimate_gguf_bytes("no-param-count-here") == 0
+
+
+# --- the assertion ----------------------------------------------------------
+
+def test_assert_raises_on_g2_standard_4_with_32b():
+    # 16GB RAM < 19.85GB model + 4GB overhead -> IMPOSSIBLE load -> raise.
+    with pytest.raises(ft.HardwareProvisioningMismatchError):
+        ft.assert_host_ram_fits_model("g2-standard-4", "qwen2.5-coder:32b")
+
+
+def test_assert_passes_on_g2_standard_8_with_32b():
+    # 32GB RAM > 19.85GB + 4GB = 23.85GB -> fits -> no raise.
+    ft.assert_host_ram_fits_model("g2-standard-8", "qwen2.5-coder:32b")
+
+
+def test_assert_failopen_on_unknown_ram():
+    # Can't determine RAM -> do NOT block (only block when CERTAIN it won't fit).
+    ft.assert_host_ram_fits_model("mystery-machine", "qwen2.5-coder:32b")
+
+
+def test_assert_failopen_on_unknown_model():
+    ft.assert_host_ram_fits_model("g2-standard-4", "opaque-model")
+
+
+def test_assert_overhead_is_tunable(monkeypatch):
+    # Tighten overhead so g2-standard-4 + a 7B model still fits (7B*0.62~=4.3GB).
+    ft.assert_host_ram_fits_model("g2-standard-4", "qwen2.5-coder:7b")
+    # ...but a huge overhead makes even that fail.
+    monkeypatch.setenv("JARVIS_HOST_RAM_OVERHEAD_BYTES", str(20 * _GIB))
+    with pytest.raises(ft.HardwareProvisioningMismatchError):
+        ft.assert_host_ram_fits_model("g2-standard-4", "qwen2.5-coder:7b")
+
+
+# --- WIRING: _do_awaken halts (never inserts) on a RAM mismatch --------------
+
+import backend.core.ouroboros.governance.failover_lifecycle as fl  # noqa: E402
+from backend.core.ouroboros.governance import provider_quarantine as pq  # noqa: E402
+
+
+class _Clock:
+    def __init__(self, t=1000.0):
+        self.t = t
+    def __call__(self):
+        return self.t
+
+
+def _fake_forecast(conf="HIGH"):
+    class _F:
+        confidence = conf
+        p50_s = 300.0
+        p90_s = 600.0
+        velocity_hint = 1.0
+        samples = 5
+    return _F()
+
+
+@pytest.fixture
+def _fresh(monkeypatch):
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+    for k, v in {
+        "JARVIS_FAILOVER_LIFECYCLE_ENABLED": "true",
+        "JARVIS_FAILOVER_ROUTE": "dw",
+        "JARVIS_QUARANTINE_WINDOW": "5",
+        "JARVIS_JPRIME_COLDSTART_S": "100",
+        "JARVIS_CRYO_AWAKEN_MARGIN": "1.5",
+        "JARVIS_OUTAGE_CONFIRM_S": "120",
+        # QUALITY tier: g2-standard-4 (16GB) + 32B (19.85GB) -> IMPOSSIBLE.
+        "JARVIS_FAILOVER_QUALITY_TIER_ENABLED": "true",
+        "JARVIS_FAILOVER_AWAKEN_URGENCY": "immediate",
+        "JARVIS_FAILOVER_QUALITY_MACHINE": "g2-standard-4",
+        "JARVIS_FAILOVER_QUALITY_MODEL": "qwen2.5-coder:32b",
+    }.items():
+        monkeypatch.setenv(k, v)
+    yield
+    pq._PROVIDER_HEALTH_GRADIENT_SINGLETON = None
+    fl._reset_singleton_for_tests()
+
+
+async def test_do_awaken_halts_on_ram_mismatch(_fresh):
+    """A g2-standard-4 + 32B awaken must be REFUSED at the pre-flight gate: the
+    vm_awaken_fn (which would fire instances.insert) is NEVER called, and the FSM
+    reverts DORMANT (no impossible node)."""
+    clock = _Clock()
+    awaken_calls = []
+    ctrl = fl.FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+    )
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH")
+    grad = pq.get_provider_health_gradient()
+    for _ in range(5):
+        grad.record_sweep("dw", success=False)
+
+    await ctrl.tick()  # DORMANT -> AWAKENING -> _do_awaken -> gate FAILS -> DORMANT
+
+    assert awaken_calls == []                       # instances.insert NEVER attempted
+    assert ctrl.state == fl.FailoverState.DORMANT   # halted (no impossible node)
+
+
+async def test_do_awaken_proceeds_on_ram_fit(_fresh, monkeypatch):
+    """Bump to g2-standard-8 (32GB) -> the gate PASSES and the awaken proceeds
+    (vm_awaken_fn IS called)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_QUALITY_MACHINE", "g2-standard-8")
+    clock = _Clock()
+    awaken_calls = []
+    ctrl = fl.FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: awaken_calls.append(1) or True,
+        vm_delete_fn=lambda: True,
+        dw_probe_fn=lambda: False,
+        node_ready_fn=lambda endpoint: True,
+        clock_fn=clock,
+    )
+    ctrl._get_forecast = lambda: _fake_forecast("HIGH")
+    grad = pq.get_provider_health_gradient()
+    for _ in range(5):
+        grad.record_sweep("dw", success=False)
+
+    await ctrl.tick()  # -> AWAKENING -> gate PASSES -> vm_awaken_fn called
+
+    assert awaken_calls == [1]                       # provisioning proceeded
+    assert ctrl.state == fl.FailoverState.AWAKENING


### PR DESCRIPTION
The g2-standard-4 (16GB RAM) **kernel-OOM-killed** llama-server loading the 19.85GB qwen2.5-coder:32b GGUF (`anon-rss 15.7GB, global_oom`) **before the L4's 24GB VRAM was ever used**. Root cause was host system RAM, not KV/context.

## 1. Intelligent Hardware-Model RAM Assertion (`failover_tier.py`)
- `machine_type_ram_bytes()` — env override → static map → `g2-standard-N` pattern (N×4 GiB).
- `estimate_gguf_bytes()` — derives GGUF size from param count (`params_B × 1e9 × JARVIS_GGUF_BYTES_PER_PARAM`, default 0.62 ≈ q4_K_M → ~19.8 GB for a 32B, matching the observed 19.85 GB). Nothing hardcoded; env-overridable.
- `assert_host_ram_fits_model()` — asserts `RAM > gguf + overhead` (default 4 GB), raises `HardwareProvisioningMismatchError` on a **certain** mismatch; **fails open** when undeterminable (block only when certain).
- Wired into `_do_awaken` **before `instances.insert`**: a mismatch **halts** the awaken (revert DORMANT + anti-thrash cooldown + flare) — the impossible node is never created.

## 2. Host bump
`JARVIS_FAILOVER_QUALITY_MACHINE` `g2-standard-4` → `g2-standard-8` (16→32 GB RAM, **same nvidia-l4 GPU, same 32B model**). Right-sizes the host so the ~20 GB model loads — not a GPU upgrade, not a quality change.

## Tests (TDD)
14 new (RAM lookup/pattern/override, GGUF estimate, assertion raise/pass/fail-open/overhead, `_do_awaken` halt-on-mismatch / proceed-on-fit) + 40 green regression (lifecycle + warmup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a RAM pre-flight gate to block provisioning when the host can’t fit the model in system RAM, and bump the quality host to `g2-standard-8` so the 32B model loads safely. This prevents kernel OOMs during load and avoids wasteful `instances.insert` calls.

- **New Features**
  - Assert host RAM > estimated GGUF size + overhead (default 4 GiB) before any `instances.insert`.
  - RAM resolution: env override -> static map -> `g2-standard-N` pattern (N×4 GiB). GGUF estimate from param count with `JARVIS_GGUF_BYTES_PER_PARAM` (0.62 default) or explicit bytes override.
  - On certain mismatch, raise `HardwareProvisioningMismatchError`; otherwise fail open. Lifecycle halts awaken, reverts to DORMANT, arms cooldown, and emits a flare.

- **Bug Fixes**
  - Quality tier host `g2-standard-4` -> `g2-standard-8` (16 -> 32 GB RAM); same `nvidia-l4` and model.
  - Resolves OOM when loading ~19.85 GB `qwen2.5-coder:32b` GGUF.
  - Added tests for RAM lookup, GGUF estimate, assertion behavior, and lifecycle wiring.

<sup>Written for commit 6c46126e0cb1b1441117153d09de556f7ab2b89f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69798?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

