### PR TITLE
feat(a1): FSM-tied VRAM residency + stateful profiler + accurate KV re-negotiation

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2686,6 +2686,18 @@ def _l7_rewarm_timeout_s() -> float:
         return 120.0
 
 
+def _failover_keep_alive_seconds() -> int:
+    """Deterministic VRAM residency: the keep_alive every failover dispatch passes
+    so ollama keeps the model RESIDENT while we're routing to the node (no ~109s
+    reload between ops). Default -1 (keep forever while SERVING); the FSM's
+    ``_reap_gpu_node`` fires the explicit ``keep_alive:0`` flush on teardown. Env
+    ``JARVIS_FAILOVER_KEEP_ALIVE_SECONDS``. NEVER raises."""
+    try:
+        return int(os.environ.get("JARVIS_FAILOVER_KEEP_ALIVE_SECONDS", "-1"))
+    except (TypeError, ValueError):
+        return -1
+
+
 _L7_RECOVERABLE_NAMES = frozenset({
     "ServerDisconnectedError", "ClientConnectionError", "ClientConnectionResetError",
     "ClientOSError", "ClientPayloadError", "ConnectionResetError",
@@ -4152,6 +4164,30 @@ class CandidateGenerator:
         default). Fail-soft -- NEVER raises."""
         return await _resolve_served_model(endpoint)
 
+    def _failover_profiler_for(self, endpoint: str, cfg: "Any") -> "Any":
+        """Session-scoped LatencyProfiler singleton, one per failover endpoint,
+        held on this generator so its EWMA/sample state persists across ops + L7
+        retries (cures profiler amnesia). A new endpoint (re-awaken) gets a fresh
+        profiler. Fail-soft -> a fresh profiler if the store is unavailable."""
+        try:
+            store = getattr(self, "_failover_profilers", None)
+            if store is None:
+                store = {}
+                self._failover_profilers = store  # type: ignore[attr-defined]
+            prof = store.get(endpoint)
+            if prof is None:
+                from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+                    LatencyProfiler,
+                )
+                prof = LatencyProfiler(cfg)
+                store[endpoint] = prof
+            return prof
+        except Exception:  # noqa: BLE001
+            from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+                LatencyProfiler,
+            )
+            return LatencyProfiler(cfg)
+
     async def _negotiate_num_ctx(self, endpoint: Optional[str]) -> Optional[int]:
         """Autonomous Context-Hardware Negotiator: derive the VRAM-safe context
         window for *endpoint* from the MEASURED buffer -- node VRAM (awakened GPU
@@ -4212,7 +4248,12 @@ class CandidateGenerator:
             PrimeProvider as _F3cPrimeProvider,
         )
 
-        _base_overrides: Dict[str, Any] = {"base_url": endpoint}
+        _base_overrides: Dict[str, Any] = {
+            "base_url": endpoint,
+            # Deterministic VRAM residency: keep the model resident while we route
+            # to this node (no ~109s reload between ops); the FSM reap flushes it.
+            "keep_alive_seconds": _failover_keep_alive_seconds(),
+        }
         _model = await self._resolve_dispatch_model_name(endpoint)
         if _model:
             _base_overrides["model_name"] = _model
@@ -4231,7 +4272,13 @@ class CandidateGenerator:
             if _num_ctx:
                 _overrides["num_ctx"] = int(_num_ctx)
             _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)
-            _client = _F3cLocalPrimeClient(_cfg)
+            # Stateful, session-scoped Latency Profiler kept PER ENDPOINT on this
+            # generator: the EWMA/sample window survives across ops + L7 retries, so
+            # the client learns the 32B's real latency and scales its timeout up
+            # (cures the per-dispatch "profiler amnesia" that pinned it to the cold
+            # seed). A new endpoint (re-awaken) naturally gets a fresh profiler.
+            _prof = self._failover_profiler_for(endpoint, _cfg)
+            _client = _F3cLocalPrimeClient(_cfg, profiler=_prof)
             try:
                 _provider = _F3cPrimeProvider(
                     _client,

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -1105,6 +1105,27 @@ class FailoverLifecycleController:
         """Reap the GPU node: delete the VM + its firewall rule (by reconstructed
         crypto-namespaced names) + unregister from the Fleet Registry. The CPU
         node is untouched. Idempotent + fail-soft. NEVER raises."""
+        # Deterministic VRAM flush (constraint 1): BEFORE the GCP delete, fire a
+        # synchronous keep_alive:0 to the node so ollama unloads the model from VRAM
+        # -- a violent, safe-termination flush bracketing the FSM-tied residency
+        # (dispatches keep the model resident with keep_alive=-1; the reap releases
+        # it here). Best-effort + short-bounded: a flush miss NEVER blocks the reap.
+        try:
+            _endpoint = self._endpoint or self._build_endpoint()
+            _model = getattr(self._awakened_tier, "model_label", "") or ""
+            if _endpoint and _model:
+                from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+                    flush_vram as _flush_vram,
+                )
+                _flushed = await _flush_vram(_endpoint, _model, timeout_s=_env_float(
+                    "JARVIS_FAILOVER_VRAM_FLUSH_TIMEOUT_S", 10.0))
+                logger.info(
+                    "[FailoverLifecycle] VRAM flush (keep_alive:0) endpoint=%s model=%s ok=%s",
+                    _endpoint, _model, _flushed,
+                )
+        except Exception as _flush_exc:  # noqa: BLE001
+            logger.debug("[FailoverLifecycle] VRAM flush fail-soft err=%r", _flush_exc)
+
         try:
             from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
                 get_compute_rest,

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -86,10 +86,19 @@ class LocalConfig:
 # derive the max SAFE num_ctx from the MEASURED VRAM buffer (no static cap), then
 # compress the payload to fit it (preserve the system rules + recent tool outputs).
 
-_KV_BYTES_PER_TOKEN_DEFAULT = 524288      # ~512KB/token: 2(K+V)*64L*8kv*128d*2B for a 32B GQA fp16 KV
+# Accurate KV cache per token for a 32B GQA fp16 model: 2(K+V) * 64 layers *
+# (8 kv_heads * 128 head_dim = 1024 kv_dim) * 2 bytes = 262144 = 256KB. (The prior
+# 512KB was 2x too conservative -- it double-counted the kv_dim -- which crushed
+# num_ctx and over-compressed the payload into empty responses.) Env-tunable.
+_KV_BYTES_PER_TOKEN_DEFAULT = 262144
 _CTX_OVERHEAD_BYTES_DEFAULT = 1_500_000_000  # CUDA/runtime/activation headroom
 _NUM_CTX_FLOOR_DEFAULT = 2048
 _NUM_CTX_CEILING_DEFAULT = 32768
+# Tokens reserved for the model's OUTPUT inside num_ctx. The generation cap
+# (max_tokens) is often 4096, but a patch is ~1-2K tokens; reserving the full cap
+# halved the INPUT budget and over-compressed. Reserve a bounded, env-tunable
+# output slice so the input window stays wide. Default 2048.
+_OUTPUT_RESERVE_TOKENS_DEFAULT = 2048
 
 
 def _int_env(name: str, default: int) -> int:
@@ -288,10 +297,16 @@ class LocalPrimeClient:
     TCPConnector + keep-alive eliminates per-call socket setup across L2 passes.
     """
 
-    def __init__(self, cfg: LocalConfig, session: Optional[Any] = None) -> None:
+    def __init__(self, cfg: LocalConfig, session: Optional[Any] = None,
+                 profiler: "Optional[LatencyProfiler]" = None) -> None:
         self._cfg = cfg
         self._session = session
-        self.profiler = LatencyProfiler(cfg)
+        # Stateful Latency Profiler: when injected (a session-scoped singleton kept
+        # per-endpoint by the dispatcher), the EWMA/sample window SURVIVES across
+        # ops + L7 retries -- so the client learns the 32B's real latency (incl. the
+        # one-time ~109s load) and adapts its timeout up instead of resetting to the
+        # cold seed on every fresh client (the "profiler amnesia").
+        self.profiler = profiler if profiler is not None else LatencyProfiler(cfg)
         self._governor: Any = None
 
     def attach_governor(self, governor: Any) -> None:
@@ -325,7 +340,13 @@ class LocalPrimeClient:
         # is preserved in full; older intermediate history is compressed. num_ctx is
         # also declared to the engine so it never pre-allocates a fatal KV cache.
         if self._cfg.num_ctx:
-            _reserve_out = max_tokens or 0
+            # Reserve only a BOUNDED output slice (not the full max_tokens cap) so
+            # the input window stays wide -> less compression -> fewer empty results.
+            _reserve_out = min(
+                max_tokens or 0,
+                _int_env("JARVIS_FAILOVER_OUTPUT_RESERVE_TOKENS", _OUTPUT_RESERVE_TOKENS_DEFAULT),
+            ) if max_tokens else _int_env(
+                "JARVIS_FAILOVER_OUTPUT_RESERVE_TOKENS", _OUTPUT_RESERVE_TOKENS_DEFAULT)
             _in_budget = max(256, int(self._cfg.num_ctx) - _reserve_out)
             system, user, _compressed = fit_prompt_to_window(
                 system, user, max_tokens=_in_budget,
@@ -462,6 +483,25 @@ class LocalPrimeClient:
         if self._session is not None:
             await self._session.close()
             self._session = None
+
+
+async def flush_vram(endpoint: str, model_name: str, *, timeout_s: float = 10.0) -> bool:
+    """Deterministic VRAM flush: POST ``keep_alive:0`` to the node so ollama
+    immediately unloads the model from VRAM. Fired synchronously by the FSM's
+    ``_reap_gpu_node`` BEFORE the GCP delete -- a violent, safe-termination flush so
+    the node never lingers holding VRAM. Best-effort -> bool; NEVER raises."""
+    if not endpoint or not model_name:
+        return False
+    try:
+        import aiohttp  # noqa: PLC0415
+        url = endpoint.rstrip("/") + "/api/generate"
+        timeout = aiohttp.ClientTimeout(total=max(1.0, timeout_s))
+        async with aiohttp.ClientSession(timeout=timeout) as sess:
+            async with sess.post(url, json={"model": model_name, "keep_alive": 0}) as resp:
+                await resp.read()
+        return True
+    except Exception:  # noqa: BLE001 -- flush is best-effort; teardown proceeds regardless
+        return False
 
 
 def build_local_prime_client() -> "Optional[LocalPrimeClient]":

--- a/tests/governance/test_context_negotiator.py
+++ b/tests/governance/test_context_negotiator.py
@@ -191,8 +191,9 @@ def test_l7_autoheal_retries_then_succeeds(monkeypatch):
     ctx_windows = []
 
     class _FakeClient:
-        def __init__(self, cfg):
+        def __init__(self, cfg, session=None, profiler=None):
             self.cfg = cfg
+            self.profiler = profiler
             ctx_windows.append(getattr(cfg, "num_ctx", None))
         async def warmup(self, *, timeout_s):
             warmups["n"] += 1
@@ -224,6 +225,8 @@ def test_l7_autoheal_retries_then_succeeds(monkeypatch):
             return "qwen2.5-coder:32b"
         async def _negotiate_num_ctx(self, ep):
             return 8192
+        def _failover_profiler_for(self, ep, cfg):
+            return None
 
     res = asyncio.run(
         cg.CandidateGenerator._failover_local_dispatch(_Stub(), object(), _deadline(), "http://n:11434")
@@ -243,7 +246,7 @@ def test_l7_autoheal_exhausts_then_raises(monkeypatch):
     import aiohttp
 
     class _FakeClient:
-        def __init__(self, cfg):
+        def __init__(self, cfg, session=None, profiler=None):
             pass
         async def warmup(self, *, timeout_s):
             return True
@@ -267,6 +270,8 @@ def test_l7_autoheal_exhausts_then_raises(monkeypatch):
             return "qwen2.5-coder:32b"
         async def _negotiate_num_ctx(self, ep):
             return 8192
+        def _failover_profiler_for(self, ep, cfg):
+            return None
 
     try:
         asyncio.run(

--- a/tests/governance/test_vram_residency_profiler.py
+++ b/tests/governance/test_vram_residency_profiler.py
@@ -1,0 +1,141 @@
+"""Deterministic VRAM residency + stateful profiler + dynamic re-negotiation.
+
+Cures the last-mile 32B dispatch failures on the (now-loadable) g2-standard-8:
+
+  1. FSM-tied VRAM residency: dispatches pass a persistent keep_alive so ollama
+     keeps the model resident (no ~109s reload between ops); the FSM reap fires a
+     synchronous keep_alive:0 flush BEFORE the GCP delete.
+  2. Stateful Latency Profiler: a session-scoped per-endpoint singleton whose EWMA
+     survives across ops + L7 retries (cures "profiler amnesia").
+  3. Dynamic context re-negotiation: accurate KV physics (256KB/token, not 512KB)
+     + bounded output reservation widen num_ctx to the true VRAM-safe max, ending
+     the over-compression empty responses.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+import backend.core.ouroboros.governance.candidate_generator as cg
+
+
+_GIB = 1024 ** 3
+
+
+# --- 1. FSM-tied VRAM residency ---------------------------------------------
+
+def test_failover_keep_alive_default_resident():
+    assert cg._failover_keep_alive_seconds() == -1  # keep forever while serving
+
+
+def test_failover_keep_alive_env_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_KEEP_ALIVE_SECONDS", "600")
+    assert cg._failover_keep_alive_seconds() == 600
+
+
+def test_flush_vram_posts_keep_alive_zero():
+    captured = {}
+
+    class _Resp:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        async def read(self): return b""
+
+    class _Sess:
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+        def post(self, url, json=None):
+            captured["url"] = url
+            captured["json"] = json
+            return _Resp()
+
+    import backend.core.ouroboros.governance.local_inference_director as _lid
+    import aiohttp
+    orig = aiohttp.ClientSession
+    aiohttp.ClientSession = lambda *a, **k: _Sess()  # type: ignore
+    try:
+        ok = asyncio.run(_lid.flush_vram("http://10.0.0.5:11434", "qwen2.5-coder:32b"))
+    finally:
+        aiohttp.ClientSession = orig  # type: ignore
+    assert ok is True
+    assert captured["url"].endswith("/api/generate")
+    assert captured["json"] == {"model": "qwen2.5-coder:32b", "keep_alive": 0}
+
+
+def test_flush_vram_failsoft_on_bad_input():
+    assert asyncio.run(lid.flush_vram("", "m")) is False
+    assert asyncio.run(lid.flush_vram("http://x", "")) is False
+
+
+# --- 2. Stateful Latency Profiler (cure amnesia) ----------------------------
+
+def test_client_uses_injected_profiler():
+    cfg = lid.LocalConfig.from_env()
+    prof = lid.LatencyProfiler(cfg)
+    client = lid.LocalPrimeClient(cfg, profiler=prof)
+    assert client.profiler is prof  # injected singleton, not a fresh one
+
+
+def test_profiler_singleton_persists_per_endpoint():
+    gen = cg.CandidateGenerator.__new__(cg.CandidateGenerator)  # no __init__ needed
+    cfg = lid.LocalConfig.from_env()
+    p1 = gen._failover_profiler_for("http://10.0.0.5:11434", cfg)
+    p2 = gen._failover_profiler_for("http://10.0.0.5:11434", cfg)   # same endpoint
+    p3 = gen._failover_profiler_for("http://10.0.0.9:11434", cfg)   # new endpoint
+    assert p1 is p2            # persists across dispatches (retains EWMA)
+    assert p3 is not p1        # a re-awaken (new IP) gets a fresh profiler
+
+
+def test_injected_profiler_retains_samples_across_clients():
+    """The whole point: a rebuilt client (L7 retry) that reuses the profiler keeps
+    the EWMA warm instead of resetting to the cold seed."""
+    cfg = lid.LocalConfig.from_env()
+    prof = lid.LatencyProfiler(cfg)
+    for _ in range(cfg.min_samples):
+        prof.record(ttft_ms=500.0, total_ms=120_000.0, output_tokens=200)
+    assert prof.is_warm() is True
+    # A brand-new client that reuses this profiler sees a WARM profiler.
+    client = lid.LocalPrimeClient(cfg, profiler=prof)
+    assert client.profiler.is_warm() is True
+
+
+# --- 3. Dynamic context re-negotiation (accurate KV -> wider num_ctx) --------
+
+def test_accurate_kv_widens_num_ctx_vs_conservative():
+    # Same L4/32B envelope: the corrected 256KB/token default yields a WIDER window
+    # than the old 512KB, ending the over-compression (default now = 262144).
+    default_n = lid.derive_safe_num_ctx(vram_bytes=24 * _GIB, model_bytes=20 * _GIB)
+    conservative_n = lid.derive_safe_num_ctx(
+        vram_bytes=24 * _GIB, model_bytes=20 * _GIB, kv_bytes_per_token=524288)
+    assert default_n > conservative_n
+    assert default_n >= 8192  # meaningfully wide on an L4
+
+
+def test_negotiator_still_vram_bounded_not_ram():
+    # KV lives in VRAM: a 32GB-RAM host with the SAME L4 (24GB VRAM) does NOT get a
+    # bigger window from RAM -- the negotiator is correctly VRAM-bounded.
+    n = lid.derive_safe_num_ctx(vram_bytes=24 * _GIB, model_bytes=20 * _GIB)
+    assert n <= 32768  # bounded by the L4 VRAM, not the 32GB system RAM
+
+
+# --- WIRING: _reap_gpu_node flushes VRAM (keep_alive:0) BEFORE the GCP delete -
+
+def test_reap_gpu_node_flushes_vram_before_delete(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_USE_ADC", "false")
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+    from types import SimpleNamespace
+
+    calls = []
+
+    async def _fake_flush(endpoint, model, *, timeout_s=10.0):
+        calls.append((endpoint, model))
+        return True
+
+    monkeypatch.setattr(lid, "flush_vram", _fake_flush)
+    controller = fl.FailoverLifecycleController()
+    controller._endpoint = "http://10.0.0.5:11434"
+    controller._awakened_tier = SimpleNamespace(model_label="qwen2.5-coder:32b")
+
+    asyncio.run(controller._reap_gpu_node())  # fail-soft delete; flush fires first
+
+    assert calls == [("http://10.0.0.5:11434", "qwen2.5-coder:32b")]


### PR DESCRIPTION
Last-mile fixes so the now-loadable 32B (g2-standard-8) completes a dispatch instead of timing out. Three constraints, existing seats, nothing hardcoded.

## 1. Deterministic VRAM Residency (FSM-tied keep_alive)
- Every failover dispatch passes `keep_alive = _failover_keep_alive_seconds()` (default **-1** = resident while serving) so ollama doesn't reload the ~20 GB model (~109 s) between ops.
- `flush_vram(endpoint, model)` POSTs `keep_alive:0`, wired into `_reap_gpu_node` **before the GCP delete** — a synchronous, bounded flush bracketing the residency. A miss never blocks the reap.

## 2. Stateful Latency Profiler (cure the amnesia)
- `LocalPrimeClient` accepts an injected profiler; `CandidateGenerator._failover_profiler_for` holds a **session-scoped `LatencyProfiler` singleton per endpoint**, passed to every (re)built client so the EWMA survives across ops + L7 retries. The client learns the 32B's real latency and scales its timeout up instead of resetting to the cold seed. A re-awaken (new IP) gets a fresh profiler.

## 3. Dynamic Context Re-Negotiation (end over-compression)
- Corrected KV physics: `_KV_BYTES_PER_TOKEN_DEFAULT` 512 KB → **256 KB** (the true `2×64L×1024kv_dim×2B` for a 32B GQA fp16 KV; the old value double-counted). num_ctx on L4/32B widens **8192 → ~10496** from the *same* measured VRAM.
- Bounded output reservation: reserve `min(max_tokens, 2048)` not the full 4096 cap → wider input budget → fewer empty results. KV stays correctly **VRAM-bounded** (not system RAM).

## Tests (TDD)
10 new + 145 green regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps 32B models resident in VRAM during failover, preserves latency history across retries, and corrects KV math to widen the VRAM-safe context window. This reduces reloads, prevents timeouts, and cuts empty responses on g2-standard-8.

- **New Features**
  - Deterministic VRAM residency: pass `keep_alive` on every failover dispatch (env `JARVIS_FAILOVER_KEEP_ALIVE_SECONDS`, default -1). Added `flush_vram` to send `keep_alive:0` before VM delete.
  - Stateful latency profiler: `LocalPrimeClient` accepts an injected profiler; per-endpoint singleton persists EWMA across ops and L7 retries.
  - Accurate context re-negotiation: KV cost set to 256 KB/token (was 512 KB). Reserve only `min(max_tokens, 2048)` for output to widen input. Wider `num_ctx` from the same VRAM.

<sup>Written for commit 03a0d2fe3811f8c19eef839077be2d8b2756149b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

