### PR TITLE
feat(a1): Adaptive EWMA Profiler -- dynamic seed + penalty escalation + circuit breaker

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2708,11 +2708,16 @@ _L7_RECOVERABLE_NAMES = frozenset({
 def _is_l7_recoverable(exc: BaseException) -> bool:
     """True iff *exc* is a transient connection-drop the auto-heal can retry (a
     warm worker that dropped mid-request -- e.g. a KV-cache OOM crash). A logic
-    error (ValueError, KeyError) is NOT recoverable. NEVER raises."""
+    error (ValueError, KeyError) is NOT recoverable. The Absolute Global Circuit
+    Breaker (``UnrecoverableInferenceLatency``) is explicitly NON-recoverable --
+    retrying a wedged model just re-inflates + bills; it must seal/halt. NEVER
+    raises."""
     try:
+        name = type(exc).__name__
+        if name == "UnrecoverableInferenceLatency":
+            return False
         if isinstance(exc, (ConnectionError, ConnectionResetError, ConnectionAbortedError)):
             return True
-        name = type(exc).__name__
         if name in _L7_RECOVERABLE_NAMES:
             return True
         return "disconnect" in str(exc).lower()

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -108,6 +108,13 @@ def _int_env(name: str, default: int) -> int:
         return default
 
 
+def _f_env(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
 def estimate_tokens(text: Any) -> int:
     """Cheap deterministic token estimate (~4 chars/token). NEVER raises."""
     try:
@@ -199,6 +206,29 @@ class LatencyProfiler:
         self._ttft: Deque[float] = deque(maxlen=cfg.window_size)
         self._per_tok: Deque[float] = deque(maxlen=cfg.window_size)
         self._total: Deque[float] = deque(maxlen=cfg.window_size)
+        # Asymmetric EWMA (ms): timeouts jump it UP (penalty), successes blend it
+        # down toward the real latency. Acts as an escalating floor on the adaptive
+        # timeout so a starved cold profiler still expands the window. 0 = no data.
+        self._ewma_ms: float = 0.0
+
+    def _cold_seed_ms(self) -> float:
+        """Context-Aware Dynamic Seed. Survival/CPU (no num_ctx) -> plain base seed
+        (byte-identical legacy). Heavy/GPU (negotiated num_ctx) -> the base seed
+        scaled by JARVIS_JPRIME_HEAVY_COLDSTART_MULT AND the token payload
+        (num_ctx / baseline) -- a 16k window inherently needs a longer first budget
+        than 8k. Capped at half the absolute ceiling so escalation has room before
+        the breaker. NEVER raises."""
+        base = float(self._cfg.timeout_seed_ms)
+        if not self._cfg.num_ctx:
+            return base
+        try:
+            heavy_mult = max(1.0, _f_env("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", 4.0))
+            baseline = max(1, _int_env("JARVIS_LOCAL_SEED_CTX_BASELINE", 8192))
+            ctx_factor = max(1.0, float(self._cfg.num_ctx) / baseline)
+            seed = base * heavy_mult * ctx_factor
+            return min(seed, _absolute_ceiling_ms() * 0.5)
+        except Exception:  # noqa: BLE001
+            return base
 
     def record(self, *, ttft_ms: float, total_ms: float, output_tokens: int) -> None:
         per_tok = (total_ms - ttft_ms) / max(1, output_tokens)
@@ -206,6 +236,23 @@ class LatencyProfiler:
             self._ttft.append(float(ttft_ms))
             self._per_tok.append(max(0.0, per_tok))
             self._total.append(float(total_ms))
+            # SUCCESS blends the EWMA DOWN toward the observed latency (asymmetric).
+            if self._ewma_ms <= 0.0:
+                self._ewma_ms = float(total_ms)
+            else:
+                a = _ewma_alpha()
+                self._ewma_ms = a * float(total_ms) + (1.0 - a) * self._ewma_ms
+
+    def record_timeout_penalty(self, timeout_ms: float) -> None:
+        """Asymmetric penalty injection: a TIMEOUT jumps the EWMA UP to
+        ``timeout_ms * escalation_factor`` so the very next dispatch expands the
+        window aggressively (breaks the cold-profiler starvation). NEVER raises."""
+        try:
+            penalty = float(timeout_ms) * _timeout_escalation_factor()
+            with self._lock:
+                self._ewma_ms = max(self._ewma_ms, penalty)
+        except Exception:  # noqa: BLE001
+            pass
 
     def is_warm(self) -> bool:
         with self._lock:
@@ -229,12 +276,40 @@ class LatencyProfiler:
             ttft_m = self._mean(self._ttft)
             tok_m = self._mean(self._per_tok)
             tot_sd = self._stddev(self._total)
-        if not warm:
-            return float(min(cfg.timeout_seed_ms, cfg.timeout_ceiling_ms))
-        est_out = max(1.0, prompt_tokens * cfg.output_ratio)
-        expected = ttft_m + tok_m * est_out
-        flexed = expected + cfg.margin_sigma * tot_sd
-        return float(max(cfg.timeout_floor_ms, min(flexed, cfg.timeout_ceiling_ms)))
+            ewma = self._ewma_ms
+
+        # SURVIVAL / CPU path (no negotiated num_ctx): BYTE-IDENTICAL legacy -- no
+        # EWMA escalation, no absolute breaker, soft ceiling is the cap.
+        if not cfg.num_ctx:
+            if not warm:
+                return float(min(cfg.timeout_seed_ms, cfg.timeout_ceiling_ms))
+            est_out = max(1.0, prompt_tokens * cfg.output_ratio)
+            flexed = ttft_m + tok_m * est_out + cfg.margin_sigma * tot_sd
+            return float(max(cfg.timeout_floor_ms, min(flexed, cfg.timeout_ceiling_ms)))
+
+        # HEAVY / GPU path: Context-Aware Dynamic Seed + asymmetric EWMA escalation
+        # + Absolute Global Circuit Breaker.
+        absolute = _absolute_ceiling_ms()
+        if warm:
+            est_out = max(1.0, prompt_tokens * cfg.output_ratio)
+            value = ttft_m + tok_m * est_out + cfg.margin_sigma * tot_sd
+        else:
+            value = self._cold_seed_ms()
+        # Never below the (timeout-escalated) EWMA -- a starved cold profiler still
+        # expands the window on the next dispatch.
+        if ewma > 0.0:
+            value = max(value, ewma)
+        # Runaway EWMA past the absolute ceiling kills the loop (no infinite
+        # inflation / endless billing on a genuinely wedged model).
+        if value >= absolute:
+            raise UnrecoverableInferenceLatency(
+                "adaptive inference timeout %.0fms >= absolute ceiling %.0fms "
+                "(EWMA=%.0fms) -- wedged model, halting to prevent endless billing"
+                % (value, absolute, ewma)
+            )
+        # The absolute ceiling is the cap so the dynamic seed / escalation is not
+        # crushed by the (survival-sized) soft ceiling.
+        return float(max(cfg.timeout_floor_ms, min(absolute, value)))
 
     def is_terminal_lag(self, *, elapsed_ms: float) -> bool:
         cfg = self._cfg
@@ -259,6 +334,40 @@ class LocalLatencyLockup(RuntimeError):
     J-Prime to PRIMARY_DEGRADED and cascade the op upstream.
     """
     failure_class = "terminal_lag_lockup"
+
+
+class UnrecoverableInferenceLatency(RuntimeError):
+    """Absolute Global Circuit Breaker: the adaptive/EWMA timeout inflated past the
+    absolute ceiling (default 20min). Raised to KILL the loop -- prevents infinite
+    EWMA inflation + endless billing on a genuinely wedged model. Non-recoverable:
+    the L7 auto-heal treats it as terminal (seal/halt), never retries."""
+    failure_class = "unrecoverable_inference_latency"
+
+
+def _absolute_ceiling_ms() -> float:
+    """Hard absolute inference-timeout ceiling (ms). The EWMA escalation can grow
+    the budget on timeouts; this is the un-inflatable kill line. Default 20min."""
+    return max(1000.0, _int_env("JARVIS_LOCAL_INFERENCE_ABSOLUTE_CEILING_MS", 1_200_000))
+
+
+def _timeout_escalation_factor() -> float:
+    """Asymmetric penalty multiplier: a timeout injects timeout*factor into the
+    EWMA so the next dispatch aggressively expands the window. Default 1.5."""
+    try:
+        f = float(os.environ.get("JARVIS_LOCAL_TIMEOUT_ESCALATION_FACTOR", "1.5"))
+        return f if f > 1.0 else 1.5
+    except (TypeError, ValueError):
+        return 1.5
+
+
+def _ewma_alpha() -> float:
+    """EWMA blend weight for SUCCESS samples (decays an escalated budget back
+    toward the real latency). Default 0.3. Timeouts jump UP (asymmetric max)."""
+    try:
+        a = float(os.environ.get("JARVIS_LOCAL_EWMA_ALPHA", "0.3"))
+        return a if 0.0 < a <= 1.0 else 0.3
+    except (TypeError, ValueError):
+        return 0.3
 
 
 class LocalMemoryCritical(RuntimeError):
@@ -385,6 +494,8 @@ class LocalPrimeClient:
     async def complete_guarded(self, *, system: str, user: str, prompt_tokens: int,
                                temperature: float = 0.2,
                                max_tokens: "Optional[int]" = None) -> LocalCompletion:
+        # May raise UnrecoverableInferenceLatency (absolute breaker) -> propagates
+        # as terminal (non-recoverable; the L7 auto-heal seals/halts, no retry).
         timeout_ms = self.profiler.adaptive_timeout_ms(prompt_tokens=prompt_tokens)
         try:
             return await asyncio.wait_for(
@@ -393,6 +504,9 @@ class LocalPrimeClient:
                 timeout=timeout_ms / 1000.0,
             )
         except asyncio.TimeoutError as e:
+            # Asymmetric penalty injection: escalate the EWMA so the next dispatch
+            # gets a bigger budget (cures the cold-profiler starvation).
+            self.profiler.record_timeout_penalty(timeout_ms)
             raise LocalLatencyLockup(
                 f"local_inference timeout: budget={timeout_ms:.0f}ms "
                 f"warm={self.profiler.is_warm()}"

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -413,13 +413,14 @@ async def _arm_failover_mesh(env: Dict[str, str]) -> None:
     # search_code before any patch) so it does not emit zero-shot diffs that the
     # gate rejects -> GENERATE_RETRY. Injected into the Prime-path system prompt.
     env.setdefault("JARVIS_A1_EXPLORATION_PROMPT_ENABLED", "true")
-    # Heavy-tier local-inference timeouts: the LocalPrimeClient's adaptive timeout
-    # seeds at 30s (fine for a 7B), but a cold 32B's FIRST generation exceeds 30s ->
-    # LocalLatencyLockup -> no latency sample is ever recorded -> it never adapts up
-    # (stuck at the seed). Seed the cold-start budget + raise the ceiling to fit the
-    # slow 32B multi-turn tool loop so the first call actually completes.
-    env.setdefault("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", "150000")   # 150s cold seed
-    env.setdefault("JARVIS_LOCAL_INFERENCE_TIMEOUT_MS", "300000")        # 300s ceiling
+    # Heavy-tier local-inference timeouts are now DERIVED by the Adaptive EWMA
+    # Profiler, not a manual base timer: the Context-Aware Dynamic Seed scales the
+    # 30s base by JARVIS_JPRIME_HEAVY_COLDSTART_MULT x (num_ctx/baseline) (~244s for
+    # a 16k window on the 32B), asymmetric penalty injection escalates the EWMA on a
+    # timeout so the profiler is never starved, and the Absolute Global Circuit
+    # Breaker (default 20min) kills a genuinely wedged model. We therefore no longer
+    # hardcode SEED_MS/TIMEOUT_MS here -- only the absolute breaker safety ceiling.
+    env.setdefault("JARVIS_LOCAL_INFERENCE_ABSOLUTE_CEILING_MS", "1200000")  # 20min hard kill
     # Cross-Region Capacity Matrix: do NOT pin a single region -- a whole-region L4
     # stockout must fall to a fallback region. Leave JARVIS_GCP_ZONE_FALLBACK unset
     # so zone_fallback._DEFAULT_ZONES (the region-ordered L4 matrix) applies; an

--- a/tests/governance/test_adaptive_ewma_profiler.py
+++ b/tests/governance/test_adaptive_ewma_profiler.py
@@ -1,0 +1,124 @@
+"""Adaptive EWMA Profiler -- cure the EWMA starvation (chicken-and-egg).
+
+The 32B multi-round generation exceeded the 150s cold seed, timed out, recorded
+NO sample (record fires only on success), so the persistent profiler stayed cold
+forever. Three structural cures:
+
+  1. Context-Aware Dynamic Seed: the cold seed is derived from
+     JARVIS_JPRIME_HEAVY_COLDSTART_MULT * (num_ctx / baseline) -- a 16k window
+     inherently needs a bigger first budget than 8k. No arbitrary base bump.
+  2. Asymmetric EWMA Escalation: a TimeoutException injects a PENALTY sample
+     (timeout * escalation_factor) that jumps the EWMA UP, so the next dispatch
+     aggressively expands the window and rapidly finds the true ceiling.
+  3. Absolute Global Circuit Breaker: if the EWMA breaches an absolute ceiling
+     (default 20min), adaptive_timeout raises UnrecoverableInferenceLatency to
+     kill the loop -- no infinite inflation / endless billing.
+"""
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+# --- 1. Context-Aware Dynamic Seed ------------------------------------------
+
+def test_dynamic_seed_scales_with_ctx_and_heavy(monkeypatch):
+    monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "4.0")
+    monkeypatch.setenv("JARVIS_LOCAL_SEED_CTX_BASELINE", "8192")
+    base = _cfg().timeout_seed_ms
+    prof = lid.LatencyProfiler(_cfg(num_ctx=16640))
+    seed = prof._cold_seed_ms()
+    # base * 4 * (16640/8192 ~= 2.03) -> ~8x base, and strictly > base.
+    assert seed > base * 4                # heavy + ctx both applied
+    assert seed < lid._absolute_ceiling_ms()  # never above the breaker
+
+
+def test_dynamic_seed_survival_path_byte_identical(monkeypatch):
+    # No num_ctx (survival/CPU) -> plain base seed, no heavy/ctx scaling.
+    prof = lid.LatencyProfiler(_cfg(num_ctx=None))
+    assert prof._cold_seed_ms() == float(_cfg().timeout_seed_ms)
+
+
+def test_dynamic_seed_capped_below_absolute():
+    prof = lid.LatencyProfiler(_cfg(num_ctx=10_000_000))  # absurd ctx
+    assert prof._cold_seed_ms() <= lid._absolute_ceiling_ms() * 0.5 + 1
+
+
+# --- 2. Asymmetric EWMA Escalation (penalty injection) ----------------------
+
+def test_timeout_penalty_escalates_next_budget(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_TIMEOUT_ESCALATION_FACTOR", "1.5")
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    prof.record_timeout_penalty(150_000)
+    nxt = prof.adaptive_timeout_ms(prompt_tokens=100)
+    assert nxt >= 150_000 * 1.5   # the next dispatch gets an escalated budget
+
+
+def test_penalty_escalates_geometrically(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_TIMEOUT_ESCALATION_FACTOR", "1.5")
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    prof.record_timeout_penalty(150_000)
+    a = prof.adaptive_timeout_ms(prompt_tokens=100)
+    prof.record_timeout_penalty(a)   # timed out again at the escalated budget
+    b = prof.adaptive_timeout_ms(prompt_tokens=100)
+    assert b > a                     # rapidly climbs toward the true ceiling
+
+
+def test_success_blends_ewma_down(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_EWMA_ALPHA", "0.5")
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    prof.record_timeout_penalty(400_000)          # ewma jumps to 600k
+    high = prof.adaptive_timeout_ms(prompt_tokens=100)
+    for _ in range(_cfg().min_samples + 3):        # real fast successes
+        prof.record(ttft_ms=1_000.0, total_ms=120_000.0, output_tokens=300)
+    low = prof.adaptive_timeout_ms(prompt_tokens=100)
+    assert low < high                              # decays toward real latency
+
+
+# --- 3. Absolute Global Circuit Breaker -------------------------------------
+
+def test_absolute_breaker_raises(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_INFERENCE_ABSOLUTE_CEILING_MS", "1200000")
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    prof.record_timeout_penalty(1_000_000)   # penalty -> ewma = 1.5M >= 1.2M absolute
+    with pytest.raises(lid.UnrecoverableInferenceLatency):
+        prof.adaptive_timeout_ms(prompt_tokens=100)
+
+
+def test_below_absolute_does_not_raise(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_INFERENCE_ABSOLUTE_CEILING_MS", "1200000")
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    prof.record_timeout_penalty(300_000)     # ewma 450k < 1.2M
+    assert prof.adaptive_timeout_ms(prompt_tokens=100) < 1_200_000
+
+
+def test_unrecoverable_is_not_l7_recoverable():
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    exc = lid.UnrecoverableInferenceLatency("boom")
+    assert cg._is_l7_recoverable(exc) is False   # halts the op, no infinite retry
+
+
+# --- integration: complete_guarded injects the penalty on timeout -----------
+
+def test_complete_guarded_injects_penalty_on_timeout():
+    import asyncio
+
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=object(), profiler=prof)
+
+    async def _timeout_complete(**kw):
+        raise asyncio.TimeoutError()
+
+    client.complete = _timeout_complete  # type: ignore[assignment]
+
+    before = prof._ewma_ms
+    with pytest.raises(lid.LocalLatencyLockup):
+        asyncio.run(client.complete_guarded(system="s", user="u", prompt_tokens=10))
+    assert prof._ewma_ms > before   # a penalty sample was injected on the timeout


### PR DESCRIPTION
Cures the EWMA starvation (chicken-and-egg): the 32B multi-round generation exceeded the 150 s cold seed → timed out → `record` fires only on success → the persistent profiler stayed cold forever. Three cures in `LatencyProfiler`, gated to the **heavy (negotiated num_ctx) path** — the survival/CPU path is byte-identical.

## 1. Context-Aware Dynamic Seed (`_cold_seed_ms`)
Derived, not a base timer: `base × JARVIS_JPRIME_HEAVY_COLDSTART_MULT × (num_ctx / baseline)` → ~244 s for a 16k window (vs the old 150 s), capped at half the absolute ceiling. The driver no longer hardcodes SEED_MS/TIMEOUT_MS.

## 2. Asymmetric EWMA Escalation (`record_timeout_penalty`)
A `TimeoutException` injects `timeout × 1.5` and jumps the EWMA **up** (max), so the next dispatch aggressively expands the window and rapidly finds the true ceiling. `complete_guarded` calls it on timeout. **Success blends the EWMA back down** toward real latency — asymmetric. `adaptive_timeout_ms` floors on the EWMA.

## 3. Absolute Global Circuit Breaker (`UnrecoverableInferenceLatency`)
If the value breaches `JARVIS_LOCAL_INFERENCE_ABSOLUTE_CEILING_MS` (default 20 min), `adaptive_timeout_ms` raises to kill the loop — no infinite inflation / endless billing. `_is_l7_recoverable` classifies it **non-recoverable** (seal/halt, never retry).

## Tests (TDD)
10 new + 155 green regression (survival path proven byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an Adaptive EWMA Profiler for heavy local inference to prevent cold-start starvation and quickly find the right timeout budget. Heavy path gets dynamic seeding, timeout-driven escalation, and a hard ceiling breaker; survival/CPU path is unchanged.

- New Features
  - Dynamic cold-start seed: `_cold_seed_ms` scales the base by `JARVIS_JPRIME_HEAVY_COLDSTART_MULT` and `num_ctx / JARVIS_LOCAL_SEED_CTX_BASELINE`, capped at 50% of `JARVIS_LOCAL_INFERENCE_ABSOLUTE_CEILING_MS`. Script no longer hardcodes `SEED_MS/TIMEOUT_MS`.
  - Asymmetric EWMA: `record_timeout_penalty()` injects `timeout * JARVIS_LOCAL_TIMEOUT_ESCALATION_FACTOR` on timeouts; successes decay via `JARVIS_LOCAL_EWMA_ALPHA`. `adaptive_timeout_ms` floors on the EWMA.
  - Absolute breaker: raises `UnrecoverableInferenceLatency` when the budget reaches `JARVIS_LOCAL_INFERENCE_ABSOLUTE_CEILING_MS`. `_is_l7_recoverable` treats it as non-recoverable (no retries).
  - Tests: cover dynamic seed scaling, escalation/decay, breaker raise, non-recoverable handling, and penalty injection in `complete_guarded`.

<sup>Written for commit 4e21287853ead5f871809d200eccbbe3612da120. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

