### PR TITLE
feat(a1): Async Calibration Mutex (Scout Lock) + Dynamic Global Audit Ceiling

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4270,60 +4270,69 @@ class CandidateGenerator:
                 "num_ctx=%d for the 32B at %s op=%s", _num_ctx, endpoint, _op,
             )
 
-        _attempts = _l7_recovery_attempts()
-        _last_exc: Optional[BaseException] = None
-        for _try in range(_attempts + 1):
-            _overrides = dict(_base_overrides)
-            if _num_ctx:
-                _overrides["num_ctx"] = int(_num_ctx)
-            _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)
-            # Stateful, session-scoped Latency Profiler kept PER ENDPOINT on this
-            # generator: the EWMA/sample window survives across ops + L7 retries, so
-            # the client learns the 32B's real latency and scales its timeout up
-            # (cures the per-dispatch "profiler amnesia" that pinned it to the cold
-            # seed). A new endpoint (re-awaken) naturally gets a fresh profiler.
-            _prof = self._failover_profiler_for(endpoint, _cfg)
-            _client = _F3cLocalPrimeClient(_cfg, profiler=_prof)
-            try:
-                _provider = _F3cPrimeProvider(
-                    _client,
-                    repo_root=self._repo_root if hasattr(self, "_repo_root") else None,
-                )
-                remaining = self._remaining_seconds(deadline)
-                if remaining <= 0.0:
-                    return None
-                return await asyncio.wait_for(
-                    _provider.generate(context, deadline),
-                    timeout=remaining,
-                )
-            except Exception as _exc:  # noqa: BLE001
-                _last_exc = _exc
-                # Non-recoverable OR out of retries -> propagate (sentinel seals).
-                if _try >= _attempts or not _is_l7_recoverable(_exc):
-                    raise
-                # AUTO-HEAL: tighten the window (more aggressive compression) +
-                # re-warm the worker, then retry. This is the sovereign path the
-                # sealer guards -- we exhaust recovery BEFORE halting.
+        # Stateful, session-scoped Latency Profiler kept PER ENDPOINT on this
+        # generator (EWMA survives across ops + L7 retries -- cures profiler
+        # amnesia). Built ONCE from the initial cfg; the L7 tighten rebuilds the
+        # client but reuses this profiler. A new endpoint (re-awaken) -> fresh one.
+        _init_overrides = dict(_base_overrides)
+        if _num_ctx:
+            _init_overrides["num_ctx"] = int(_num_ctx)
+        _init_cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_init_overrides)
+        _prof = self._failover_profiler_for(endpoint, _init_cfg)
+
+        async def _attempts() -> Optional[GenerationResult]:
+            nonlocal _num_ctx
+            _n = _l7_recovery_attempts()
+            _last_exc: Optional[BaseException] = None
+            for _try in range(_n + 1):
+                _overrides = dict(_base_overrides)
                 if _num_ctx:
-                    _num_ctx = max(512, int(_num_ctx * _l7_tighten_factor()))
-                logger.warning(
-                    "[CandidateGenerator] L7 AUTO-HEAL: %s on the 32B -> re-warm + "
-                    "tighten num_ctx=%s, retry %d/%d op=%s",
-                    type(_exc).__name__, _num_ctx, _try + 1, _attempts, _op,
-                )
+                    _overrides["num_ctx"] = int(_num_ctx)
+                _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)
+                _client = _F3cLocalPrimeClient(_cfg, profiler=_prof)
                 try:
-                    await _client.warmup(timeout_s=_l7_rewarm_timeout_s())
-                except Exception:  # noqa: BLE001
-                    pass
-            finally:
-                try:
-                    await _client.aclose()
-                except Exception:  # noqa: BLE001
-                    pass
-        # Unreachable in practice (the loop returns or raises), but keep the net.
-        if _last_exc is not None:
-            raise _last_exc
-        return None
+                    _provider = _F3cPrimeProvider(
+                        _client,
+                        repo_root=self._repo_root if hasattr(self, "_repo_root") else None,
+                    )
+                    remaining = self._remaining_seconds(deadline)
+                    if remaining <= 0.0:
+                        return None
+                    return await asyncio.wait_for(
+                        _provider.generate(context, deadline),
+                        timeout=remaining,
+                    )
+                except Exception as _exc:  # noqa: BLE001
+                    _last_exc = _exc
+                    # Non-recoverable OR out of retries -> propagate (sentinel seals).
+                    if _try >= _n or not _is_l7_recoverable(_exc):
+                        raise
+                    # AUTO-HEAL: tighten the window + re-warm, then retry.
+                    if _num_ctx:
+                        _num_ctx = max(512, int(_num_ctx * _l7_tighten_factor()))
+                    logger.warning(
+                        "[CandidateGenerator] L7 AUTO-HEAL: %s on the 32B -> re-warm "
+                        "+ tighten num_ctx=%s, retry %d/%d op=%s",
+                        type(_exc).__name__, _num_ctx, _try + 1, _n, _op,
+                    )
+                    try:
+                        await _client.warmup(timeout_s=_l7_rewarm_timeout_s())
+                    except Exception:  # noqa: BLE001
+                        pass
+                finally:
+                    try:
+                        await _client.aclose()
+                    except Exception:  # noqa: BLE001
+                        pass
+            if _last_exc is not None:
+                raise _last_exc
+            return None
+
+        # Async Calibration Mutex (Scout Lock): on a COLD profiler the first
+        # concurrent op scouts (calibrates the EWMA) while the herd awaits the lock;
+        # once calibrated the herd runs CONCURRENTLY on the escalated seed -- the DAG
+        # is never serialized, only the one-shot cold calibration is gated.
+        return await _prof.run_calibrated(_attempts)
 
     async def _dispatch_via_sentinel(
         self,

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -210,6 +210,42 @@ class LatencyProfiler:
         # down toward the real latency. Acts as an escalating floor on the adaptive
         # timeout so a starved cold profiler still expands the window. 0 = no data.
         self._ewma_ms: float = 0.0
+        # Async Calibration Mutex (Scout Lock): the FIRST cold coroutine calibrates
+        # (Scout) while the concurrent herd waits on the lock; once calibrated, the
+        # gate is open and dispatches run fully concurrently on the escalated EWMA.
+        # Lazily bound to the running loop on first use.
+        self._calibrated: bool = False
+        self._scout_lock: "Optional[asyncio.Lock]" = None
+
+    def is_calibrated(self) -> bool:
+        return self._calibrated
+
+    def mark_calibrated(self) -> None:
+        self._calibrated = True
+
+    def _get_scout_lock(self) -> "asyncio.Lock":
+        if self._scout_lock is None:
+            self._scout_lock = asyncio.Lock()
+        return self._scout_lock
+
+    async def run_calibrated(self, coro_factory: "Any") -> Any:
+        """Async Calibration Mutex. If already calibrated -> run ``coro_factory()``
+        immediately (no lock, full concurrency). Otherwise the FIRST caller acquires
+        the scout lock and runs as the Scout; the concurrent herd awaits the lock.
+        The Scout marks the profiler calibrated when it finishes (success OR
+        timeout+escalate -- in ``finally``, so the herd is never stuck) and releases;
+        the herd then runs CONCURRENTLY, reading the newly escalated EWMA seed.
+        ``coro_factory`` is a zero-arg async callable (a fresh coroutine per call)."""
+        if self.is_calibrated():
+            return await coro_factory()
+        lock = self._get_scout_lock()
+        async with lock:
+            if not self.is_calibrated():
+                try:
+                    return await coro_factory()          # Scout
+                finally:
+                    self.mark_calibrated()
+        return await coro_factory()                       # herd (calibrated)
 
     def _cold_seed_ms(self) -> float:
         """Context-Aware Dynamic Seed. Survival/CPU (no num_ctx) -> plain base seed
@@ -497,6 +533,13 @@ class LocalPrimeClient:
         # May raise UnrecoverableInferenceLatency (absolute breaker) -> propagates
         # as terminal (non-recoverable; the L7 auto-heal seals/halts, no retry).
         timeout_ms = self.profiler.adaptive_timeout_ms(prompt_tokens=prompt_tokens)
+        if self._cfg.num_ctx:
+            # Emit the adaptive per-call budget so the Dynamic Global Audit Ceiling
+            # can derive itself (budget x max agentic rounds) from observed reality.
+            logger.info(
+                "[LocalPrimeClient] adaptive inference budget=%.0fms warm=%s num_ctx=%d",
+                timeout_ms, self.profiler.is_warm(), int(self._cfg.num_ctx),
+            )
         try:
             return await asyncio.wait_for(
                 self.complete(system=system, user=user, prompt_tokens=prompt_tokens,

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -457,15 +457,35 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
-def _a1_audit_ceiling_s() -> float:
-    """Tier-aware audit ceiling (no hardcoded window). The auditor early-exits the
-    moment the verdict is proven; this is the SAFETY ceiling. It is derived from
-    the resolved failover tier: a heavy 32B/L4 op runs a MULTI-TURN Venom tool loop
-    (explore -> read -> patch -> validate) that is I/O-heavy and slow, so we scale
-    the base by the SAME JARVIS_JPRIME_HEAVY_COLDSTART_MULT as the cold-start
-    timeouts. Base default 300s x4 = 1200s (~20 min) gives the agentic explore-then
-    -fix cycle real wall-clock. Survival (7B/CPU) -> base unchanged. Fail-soft."""
+def _a1_audit_ceiling_s(debug_log: "Optional[str]" = None) -> float:
+    """Dynamic Global Audit Ceiling (no hardcoded window). The auditor early-exits
+    the moment the verdict is proven; this is the SAFETY ceiling.
+
+    DYNAMIC path: derive it from OBSERVED reality -- the largest per-call inference
+    budget the profiler actually used (the escalated EWMA seed, logged as
+    ``budget=Xms``) multiplied by the expected max agentic rounds
+    (``JARVIS_A1_MAX_AGENTIC_ROUNDS``, default 5): a heavy op runs a multi-turn Venom
+    loop (explore -> read -> patch -> validate), so the run needs
+    ``per_call x rounds`` of wall-clock. This adapts to the 32B's real (escalating)
+    latency instead of a flat guess.
+
+    FALLBACK (no budget observed yet): the tier-aware base scaled by
+    ``JARVIS_JPRIME_HEAVY_COLDSTART_MULT``. Fail-soft -- NEVER raises."""
     base = _env_float("JARVIS_A1_AUDIT_BASE_S", 300.0)
+    max_rounds = max(1.0, _env_float("JARVIS_A1_MAX_AGENTIC_ROUNDS", 5.0))
+    # --- DYNAMIC: largest observed per-call budget x max agentic rounds ---
+    per_call_ms = 0.0
+    if debug_log:
+        try:
+            import re  # noqa: PLC0415
+            with open(debug_log, "r", encoding="utf-8", errors="ignore") as _fh:
+                for _m in re.finditer(r"budget=(\d+)ms", _fh.read()):
+                    per_call_ms = max(per_call_ms, float(_m.group(1)))
+        except Exception:  # noqa: BLE001
+            per_call_ms = 0.0
+    if per_call_ms > 0.0:
+        return max(base, (per_call_ms / 1000.0) * max_rounds)
+    # --- FALLBACK: tier-aware heavy-scaled base ---
     try:
         from backend.core.ouroboros.governance.failover_tier import (  # noqa: PLC0415
             resolve_tier,
@@ -1168,7 +1188,7 @@ class IsomorphicA1Driver:
                         verdict = aud_runner.watch(
                             base=self.sse_base,
                             log_file=debug_log,
-                            timeout_s=_a1_audit_ceiling_s(),
+                            timeout_s=_a1_audit_ceiling_s(debug_log=debug_log),
                             verdict_out=verdict_out,
                         )
 

--- a/tests/governance/test_context_negotiator.py
+++ b/tests/governance/test_context_negotiator.py
@@ -226,7 +226,8 @@ def test_l7_autoheal_retries_then_succeeds(monkeypatch):
         async def _negotiate_num_ctx(self, ep):
             return 8192
         def _failover_profiler_for(self, ep, cfg):
-            return None
+            import backend.core.ouroboros.governance.local_inference_director as _lid
+            return _lid.LatencyProfiler(cfg)
 
     res = asyncio.run(
         cg.CandidateGenerator._failover_local_dispatch(_Stub(), object(), _deadline(), "http://n:11434")
@@ -271,7 +272,8 @@ def test_l7_autoheal_exhausts_then_raises(monkeypatch):
         async def _negotiate_num_ctx(self, ep):
             return 8192
         def _failover_profiler_for(self, ep, cfg):
-            return None
+            import backend.core.ouroboros.governance.local_inference_director as _lid
+            return _lid.LatencyProfiler(cfg)
 
     try:
         asyncio.run(

--- a/tests/governance/test_scout_lock_calibration.py
+++ b/tests/governance/test_scout_lock_calibration.py
@@ -1,0 +1,122 @@
+"""Asynchronous Calibration Mutex (Scout Lock) + Dynamic Global Audit Ceiling.
+
+The BG pool dispatches concurrently, so on a cold profiler ALL ops read ewma=0 and
+cold-start together -- the escalation never converges (thundering herd). The Scout
+Lock fixes this WITHOUT serializing the DAG: the FIRST cold coroutine acquires the
+lock and dispatches as the Scout; the herd awaits the lock; once the Scout finishes
+(success or timeout+escalate) it marks the profiler calibrated and releases, and the
+herd runs CONCURRENTLY reading the escalated EWMA seed. Steady-state = full
+concurrency (calibrated -> no lock).
+
+The audit ceiling then derives dynamically from the observed per-call budget x the
+expected max agentic rounds (no hardcoded flat limit).
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+# --- Scout Lock primitives --------------------------------------------------
+
+def test_profiler_starts_uncalibrated():
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    assert prof.is_calibrated() is False
+    prof.mark_calibrated()
+    assert prof.is_calibrated() is True
+
+
+def test_calibrated_shortcircuits_no_lock():
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    prof.mark_calibrated()
+    calls = []
+
+    async def _factory():
+        calls.append(1)
+        return "ok"
+
+    assert asyncio.run(prof.run_calibrated(_factory)) == "ok"
+    assert calls == [1]
+
+
+def test_scout_runs_alone_then_herd_concurrent():
+    """Only the Scout runs while uncalibrated; the herd waits on the lock, then
+    runs concurrently once the Scout marks calibrated."""
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    events = []
+    scout_release = asyncio.Event()
+
+    async def _run():
+        async def _factory():
+            is_scout = not prof.is_calibrated()
+            events.append("start")
+            if is_scout:
+                await scout_release.wait()   # Scout holds the lock here
+            events.append("end")
+            return "ok"
+
+        tasks = [asyncio.create_task(prof.run_calibrated(_factory)) for _ in range(3)]
+        await asyncio.sleep(0.05)
+        # Only the Scout has started; the herd is blocked on the scout lock.
+        mid = events.count("start")
+        scout_release.set()
+        results = await asyncio.gather(*tasks)
+        return mid, results
+
+    mid, results = asyncio.run(_run())
+    assert mid == 1                       # exactly one Scout ran while cold
+    assert results == ["ok", "ok", "ok"]
+    assert events.count("start") == 3 and events.count("end") == 3
+    assert prof.is_calibrated() is True
+
+
+def test_scout_marks_calibrated_even_on_exception():
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+
+    async def _boom():
+        raise RuntimeError("scout dispatch failed/timed out")
+
+    with pytest.raises(RuntimeError):
+        asyncio.run(prof.run_calibrated(_boom))
+    assert prof.is_calibrated() is True    # calibrated in finally -> herd not stuck
+
+
+# --- Dynamic Global Audit Ceiling -------------------------------------------
+
+def test_audit_ceiling_derives_from_observed_budget(tmp_path, monkeypatch):
+    import scripts.isomorphic_a1_local as iso
+    monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+    log = tmp_path / "debug.log"
+    log.write_text(
+        "some line\n"
+        "local_inference timeout: budget=243750ms warm=False\n"
+        "[LocalPrimeClient] adaptive inference budget=366000ms warm=False\n"
+    )
+    ceiling = iso._a1_audit_ceiling_s(debug_log=str(log))
+    # largest observed budget (366000ms) x 5 rounds = 1830s.
+    assert ceiling == pytest.approx(366.0 * 5, rel=0.01)
+
+
+def test_audit_ceiling_falls_back_without_budget(tmp_path):
+    import scripts.isomorphic_a1_local as iso
+    log = tmp_path / "empty.log"
+    log.write_text("no budget lines here\n")
+    # No observed budget -> heavy-scaled base (>= base), never crashes.
+    ceiling = iso._a1_audit_ceiling_s(debug_log=str(log))
+    assert ceiling >= _env_base()
+
+
+def _env_base() -> float:
+    import os
+    try:
+        return float(os.environ.get("JARVIS_A1_AUDIT_BASE_S", "300"))
+    except ValueError:
+        return 300.0


### PR DESCRIPTION
Conquers the time envelope **without serializing the DAG or reducing 32B rounds**.

## 1. Async Calibration Mutex / Scout Lock (`LatencyProfiler.run_calibrated`)
The BG pool dispatches concurrently, so on a **cold** profiler all ops read `ewma=0` and cold-start together (thundering herd) — escalation never converges. Now the **first** cold coroutine acquires an `asyncio.Lock` and dispatches as the **Scout** while the herd awaits; when the Scout finishes (success OR timeout+escalate — marked in `finally` so the herd is never stuck) it sets `calibrated=True` and releases, and the herd runs **concurrently** on the escalated EWMA seed. Steady-state takes **no lock** → full concurrency; only the one-shot cold calibration is gated. Wired at `_failover_local_dispatch`: the L7 retry loop is now an inner `_attempts()` run via `_prof.run_calibrated(_attempts)`.

## 2. Dynamic Global Audit Ceiling (`_a1_audit_ceiling_s(debug_log=...)`)
No hardcoded 20 min. Derives from **observed reality** — the largest per-call inference budget the profiler actually used (escalated EWMA seed, logged as `budget=Xms`) × `JARVIS_A1_MAX_AGENTIC_ROUNDS` (default 5). `complete_guarded` now logs the adaptive budget on every heavy call. Falls back to the tier-aware heavy-scaled base when no budget observed yet.

## Tests (TDD)
6 new + 161 green regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add an async “Scout Lock” to calibrate latency once per cold start without serializing the DAG, and replace the fixed 20‑min audit cap with a dynamic ceiling from observed per‑call budgets. This stabilizes 32B failover latency and adapts audit time to real conditions.

- **New Features**
  - Async Calibration Mutex in `LatencyProfiler.run_calibrated`: the first cold call scouts and calibrates EWMA while others wait; once done, all run concurrently with no lock. Wired by running the L7 retry `_attempts()` via `run_calibrated` in `_failover_local_dispatch`.
  - Dynamic Global Audit Ceiling in `_a1_audit_ceiling_s(debug_log=...)`: reads the largest logged `budget=Xms` and multiplies by `JARVIS_A1_MAX_AGENTIC_ROUNDS` (default 5); falls back to tier‑aware base if no budget seen. `complete_guarded` now logs the adaptive budget per heavy call.

<sup>Written for commit dd4f71f9b60def76410edf5e44f889abb1853ee6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69801?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

