### PR TITLE
feat(a1): Asynchronous Inter-Token Watchdog (streaming, no total-duration cap)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4298,6 +4298,21 @@ class CandidateGenerator:
                     remaining = self._remaining_seconds(deadline)
                     if remaining <= 0.0:
                         return None
+                    # Master Wall Yielding (constraint 3, invariant-safe): on the
+                    # STREAMING path DROP the outer op-deadline wait_for -- an
+                    # actively-emitting stream must run indefinitely, bounded ONLY by
+                    # the per-chunk inter-token watchdog (inside the client) + the
+                    # STATIC hard wall-clock cap (kept blind per Slice-47). The
+                    # non-streaming survival path keeps the op-deadline cap.
+                    try:
+                        from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+                            _streaming_enabled as _f3c_stream_on,
+                        )
+                        _streaming = bool(_num_ctx) and _f3c_stream_on()
+                    except Exception:  # noqa: BLE001
+                        _streaming = False
+                    if _streaming:
+                        return await _provider.generate(context, deadline)
                     return await asyncio.wait_for(
                         _provider.generate(context, deadline),
                         timeout=remaining,

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -406,6 +406,69 @@ def _ewma_alpha() -> float:
         return 0.3
 
 
+class InterTokenStall(RuntimeError):
+    """Asynchronous Inter-Token Watchdog trip: the streamed generation went silent
+    (no token chunk within the inter-token timeout). A stalled stream = a wedged
+    worker; NON-recoverable (the L7 auto-heal seals/halts, never retries). A stream
+    that keeps emitting is allowed to run indefinitely -- total duration is NOT a
+    kill condition on the streaming (heavy) path."""
+    failure_class = "inter_token_stall"
+
+
+def _streaming_enabled() -> bool:
+    """Master switch for the streaming inter-token watchdog on the heavy (num_ctx)
+    generation path. Default TRUE. OFF -> legacy total-duration adaptive timeout."""
+    return _envb("JARVIS_LOCAL_STREAMING_ENABLED", True) if os.environ.get(
+        "JARVIS_LOCAL_STREAMING_ENABLED") is not None else True
+
+
+def _inter_token_timeout_s() -> float:
+    """Max wall-time between streamed token chunks before the Stream Breaker trips.
+    The model may run indefinitely as long as it emits within this gap. Default 30s."""
+    return max(1.0, _f_env("JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S", 30.0))
+
+
+_SSE_DONE = object()  # sentinel: the [DONE] terminator of an OpenAI-compat SSE stream
+
+
+def _parse_sse_delta(line: bytes) -> "Any":
+    """Parse ONE line of an ollama /v1/chat/completions SSE stream. Returns the
+    incremental content string, the ``_SSE_DONE`` sentinel on ``data: [DONE]``, or
+    None for keep-alives / non-data / parse errors. Pure + fail-soft."""
+    try:
+        s = line.decode("utf-8", "ignore").strip() if isinstance(line, (bytes, bytearray)) else str(line).strip()
+        if not s or not s.startswith("data:"):
+            return None
+        payload = s[len("data:"):].strip()
+        if payload == "[DONE]":
+            return _SSE_DONE
+        import json as _json  # noqa: PLC0415
+        obj = _json.loads(payload)
+        choices = obj.get("choices") or []
+        if not choices:
+            return None
+        delta = (choices[0] or {}).get("delta") or {}
+        return delta.get("content") or None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _emit_stream_token(text: str) -> None:
+    """Yield a streamed chunk to stdout for real-time observability (constraint 2).
+    Best-effort -- observability never breaks the generation. The 'wall yields to an
+    active stream' behavior (constraint 3) is achieved structurally at the dispatch
+    layer: the streaming path drops the outer op-deadline wait_for, so an
+    actively-emitting call is bounded ONLY by the per-chunk inter-token watchdog +
+    the STATIC hard wall-clock cap (kept blind per the Slice-47 Watchdog Isolation
+    Invariant -- never coupled to stream state)."""
+    try:
+        import sys  # noqa: PLC0415
+        sys.stdout.write(text)
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 class LocalMemoryCritical(RuntimeError):
     """Raised when host memory is CRITICAL at local-generate admission time.
 
@@ -475,7 +538,8 @@ class LocalPrimeClient:
 
     async def complete(self, *, system: str, user: str, prompt_tokens: int,
                        temperature: float = 0.2,
-                       max_tokens: "Optional[int]" = None) -> LocalCompletion:
+                       max_tokens: "Optional[int]" = None,
+                       stream: "Optional[bool]" = None) -> LocalCompletion:
         sess = await self._ensure_session()
         url = self._cfg.base_url.rstrip("/") + "/v1/chat/completions"
         # Dynamic Cognitive Compression + num_ctx injection (Context-Hardware
@@ -517,6 +581,12 @@ class LocalPrimeClient:
             body["options"] = {"num_ctx": int(self._cfg.num_ctx)}
         if max_tokens is not None:
             body["max_tokens"] = max_tokens
+
+        _use_stream = stream if stream is not None else (
+            bool(self._cfg.num_ctx) and _streaming_enabled())
+        if _use_stream:
+            return await self._complete_streaming(sess, url, body)
+
         t0 = time.monotonic()
         async with sess.post(url, json=body) as resp:
             data = await resp.json()
@@ -527,19 +597,70 @@ class LocalPrimeClient:
         self.profiler.record(ttft_ms=ttft_ms, total_ms=total_ms, output_tokens=out_toks)
         return LocalCompletion(text=text, output_tokens=out_toks, ttft_ms=ttft_ms, total_ms=total_ms)
 
+    async def _complete_streaming(self, sess: Any, url: str, body: Dict[str, Any]) -> LocalCompletion:
+        """Streaming generation with the Asynchronous Inter-Token Watchdog. Reads the
+        SSE stream chunk-by-chunk; each ``readline`` is bounded by the inter-token
+        timeout (NOT the total duration), so a model that keeps emitting runs
+        indefinitely and only a genuine STALL (silence > timeout) trips the breaker.
+        Buffers the deltas (constraint 2) while yielding them to stdout, and records
+        the REAL end-to-end latency as a profiler sample on success."""
+        body = dict(body)
+        body["stream"] = True
+        inter_token_s = _inter_token_timeout_s()
+        parts: List[str] = []
+        ttft_ms = 0.0
+        t0 = time.monotonic()
+        first = True
+        async with sess.post(url, json=body) as resp:
+            reader = resp.content  # aiohttp StreamReader (line-iterable)
+            while True:
+                try:
+                    line = await asyncio.wait_for(reader.readline(), timeout=inter_token_s)
+                except asyncio.TimeoutError as e:
+                    raise InterTokenStall(
+                        "inter-token stall: no chunk within %.0fs (stream wedged)"
+                        % inter_token_s
+                    ) from e
+                if not line:
+                    break  # EOF -> stream complete
+                delta = _parse_sse_delta(line)
+                if delta is _SSE_DONE:
+                    break
+                if delta:
+                    if first:
+                        ttft_ms = (time.monotonic() - t0) * 1000.0
+                        first = False
+                    parts.append(delta)
+                    _emit_stream_token(delta)
+        total_ms = (time.monotonic() - t0) * 1000.0
+        text = "".join(parts)
+        out_toks = max(1, len(text) // 4)
+        # A completed stream is a REAL latency sample -> the EWMA learns + decays.
+        self.profiler.record(ttft_ms=ttft_ms or min(total_ms, 0.1 * total_ms),
+                             total_ms=total_ms, output_tokens=out_toks)
+        return LocalCompletion(text=text, output_tokens=out_toks, ttft_ms=ttft_ms, total_ms=total_ms)
+
     async def complete_guarded(self, *, system: str, user: str, prompt_tokens: int,
                                temperature: float = 0.2,
                                max_tokens: "Optional[int]" = None) -> LocalCompletion:
-        # May raise UnrecoverableInferenceLatency (absolute breaker) -> propagates
-        # as terminal (non-recoverable; the L7 auto-heal seals/halts, no retry).
-        timeout_ms = self.profiler.adaptive_timeout_ms(prompt_tokens=prompt_tokens)
-        if self._cfg.num_ctx:
-            # Emit the adaptive per-call budget so the Dynamic Global Audit Ceiling
-            # can derive itself (budget x max agentic rounds) from observed reality.
+        # HEAVY (num_ctx) STREAMING path: deprecate the total-duration timeout. The
+        # Inter-Token Watchdog inside _complete_streaming is the sole guard -- a
+        # model that keeps emitting tokens runs indefinitely; only a STALL trips it.
+        # This is the mathematically-robust replacement for guessing total latency.
+        if self._cfg.num_ctx and _streaming_enabled():
             logger.info(
-                "[LocalPrimeClient] adaptive inference budget=%.0fms warm=%s num_ctx=%d",
-                timeout_ms, self.profiler.is_warm(), int(self._cfg.num_ctx),
+                "[LocalPrimeClient] streaming generation (inter-token watchdog=%.0fs, "
+                "no total-duration cap) num_ctx=%d",
+                _inter_token_timeout_s(), int(self._cfg.num_ctx),
             )
+            return await self.complete(
+                system=system, user=user, prompt_tokens=prompt_tokens,
+                temperature=temperature, max_tokens=max_tokens, stream=True,
+            )
+
+        # SURVIVAL / non-streaming path: legacy total-duration adaptive timeout.
+        # May raise UnrecoverableInferenceLatency (absolute breaker) -> terminal.
+        timeout_ms = self.profiler.adaptive_timeout_ms(prompt_tokens=prompt_tokens)
         try:
             return await asyncio.wait_for(
                 self.complete(system=system, user=user, prompt_tokens=prompt_tokens,
@@ -547,8 +668,6 @@ class LocalPrimeClient:
                 timeout=timeout_ms / 1000.0,
             )
         except asyncio.TimeoutError as e:
-            # Asymmetric penalty injection: escalate the EWMA so the next dispatch
-            # gets a bigger budget (cures the cold-profiler starvation).
             self.profiler.record_timeout_penalty(timeout_ms)
             raise LocalLatencyLockup(
                 f"local_inference timeout: budget={timeout_ms:.0f}ms "

--- a/tests/governance/test_adaptive_ewma_profiler.py
+++ b/tests/governance/test_adaptive_ewma_profiler.py
@@ -108,10 +108,12 @@ def test_unrecoverable_is_not_l7_recoverable():
 # --- integration: complete_guarded injects the penalty on timeout -----------
 
 def test_complete_guarded_injects_penalty_on_timeout():
+    # The total-duration timeout + penalty lives on the NON-streaming (survival)
+    # path now; the heavy num_ctx path streams (inter-token watchdog, no total cap).
     import asyncio
 
-    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
-    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=object(), profiler=prof)
+    prof = lid.LatencyProfiler(_cfg(num_ctx=None))
+    client = lid.LocalPrimeClient(_cfg(num_ctx=None), session=object(), profiler=prof)
 
     async def _timeout_complete(**kw):
         raise asyncio.TimeoutError()

--- a/tests/governance/test_streaming_inter_token.py
+++ b/tests/governance/test_streaming_inter_token.py
@@ -1,0 +1,135 @@
+"""Asynchronous Inter-Token Watchdog (Stream Breaker) + stream buffering.
+
+Deprecates the total-duration timeout for the heavy 32B path: the model streams,
+and each token chunk resets a per-chunk inter-token deadline. A model that keeps
+emitting runs INDEFINITELY (total duration is not a kill condition); only a genuine
+STALL (silence > inter-token timeout) trips InterTokenStall. The deltas are buffered
+(and yielded to stdout) and assembled into the final response.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+def _sse(content: str) -> bytes:
+    import json
+    return ("data: " + json.dumps({"choices": [{"delta": {"content": content}}]}) + "\n").encode()
+
+
+class _Reader:
+    def __init__(self, lines, gaps=None):
+        self.lines = list(lines)
+        self.gaps = list(gaps or [0] * len(lines))
+        self.i = 0
+
+    async def readline(self):
+        if self.i >= len(self.lines):
+            return b""
+        g = self.gaps[self.i] if self.i < len(self.gaps) else 0
+        if g:
+            await asyncio.sleep(g)
+        ln = self.lines[self.i]
+        self.i += 1
+        return ln
+
+
+class _Resp:
+    def __init__(self, reader):
+        self.content = reader
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Sess:
+    def __init__(self, reader):
+        self._r = reader
+        self.posted = []
+
+    def post(self, url, **kw):
+        self.posted.append(kw)
+        return _Resp(self._r)
+
+    async def close(self):
+        pass
+
+
+# --- SSE parser -------------------------------------------------------------
+
+def test_parse_sse_delta_content():
+    assert lid._parse_sse_delta(_sse("Hello")) == "Hello"
+
+
+def test_parse_sse_delta_done_and_noise():
+    assert lid._parse_sse_delta(b"data: [DONE]\n") is lid._SSE_DONE
+    assert lid._parse_sse_delta(b": keep-alive\n") is None
+    assert lid._parse_sse_delta(b"\n") is None
+    assert lid._parse_sse_delta(b"data: {not json}\n") is None
+
+
+def test_env_defaults():
+    assert lid._inter_token_timeout_s() == 30.0
+    assert lid._streaming_enabled() is True
+
+
+# --- streaming assembles the buffered deltas --------------------------------
+
+def test_streaming_assembles_full_text():
+    lines = [_sse("Hel"), _sse("lo, "), _sse("world"), b"data: [DONE]\n"]
+    prof = lid.LatencyProfiler(_cfg(num_ctx=8192))
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_Reader(lines)), profiler=prof)
+    lc = asyncio.run(client.complete(system="s", user="u", prompt_tokens=10, stream=True))
+    assert lc.text == "Hello, world"
+    assert len(prof._total) == 1          # a REAL latency sample was recorded
+
+
+def test_streaming_runs_while_emitting_no_total_cap(monkeypatch):
+    """Steady slow tokens (each gap < inter-token) complete even though the TOTAL
+    duration would blow a small total budget -- total duration is not the killer."""
+    monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S", "0.5")
+    lines = [_sse("a"), _sse("b"), _sse("c"), _sse("d"), b"data: [DONE]\n"]
+    gaps = [0.1, 0.1, 0.1, 0.1, 0.0]      # 0.4s total, each gap < 0.5s inter-token
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_Reader(lines, gaps)))
+    lc = asyncio.run(client.complete(system="s", user="u", prompt_tokens=10, stream=True))
+    assert lc.text == "abcd"
+
+
+def test_inter_token_stall_trips_fast(monkeypatch):
+    monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S", "0.2")
+    lines = [_sse("Hel"), _sse("lo")]
+    gaps = [0.0, 100.0]                    # 2nd chunk silent for 100s -> stall
+    import time
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_Reader(lines, gaps)))
+    start = time.monotonic()
+    with pytest.raises(lid.InterTokenStall):
+        asyncio.run(client.complete(system="s", user="u", prompt_tokens=10, stream=True))
+    assert time.monotonic() - start < 2.0   # tripped fast, not 100s
+
+
+def test_complete_guarded_heavy_path_streams(monkeypatch):
+    """complete_guarded on the heavy (num_ctx) path uses streaming (no total-duration
+    wait_for) -- proven by a stream slower than any adaptive budget still completing."""
+    monkeypatch.setenv("JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S", "0.5")
+    monkeypatch.setenv("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", "10")  # tiny total seed
+    lines = [_sse("x"), _sse("y"), _sse("z"), b"data: [DONE]\n"]
+    gaps = [0.1, 0.1, 0.1, 0.0]           # 0.3s > 0.01s seed, but streams fine
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_Reader(lines, gaps)))
+    lc = asyncio.run(client.complete_guarded(system="s", user="u", prompt_tokens=10))
+    assert lc.text == "xyz"
+
+
+def test_inter_token_stall_is_not_l7_recoverable():
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    assert cg._is_l7_recoverable(lid.InterTokenStall("stall")) is False


### PR DESCRIPTION
Deprecates the total-duration EWMA timeout for the heavy 32B generation in favor of **streaming + an inter-token watchdog** — the robust way to bound a dynamic agentic loop without predicting total latency. A model that keeps emitting runs **indefinitely**; only a genuine **stall** trips the breaker.

## 1. Asynchronous Inter-Token Watchdog (`_complete_streaming`)
Heavy (num_ctx) path streams (`stream:true`); each SSE chunk read is bounded by `JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S` (default 30s), **not** the total duration. Silence past the gap → `InterTokenStall` (non-recoverable → sentinel seals). `complete_guarded` heavy path drops the total-duration `wait_for`; survival path keeps the legacy adaptive-timeout + EWMA penalty. Master `JARVIS_LOCAL_STREAMING_ENABLED` (default true).

## 2. Dynamic Stream-Buffer Tool Parsing
`_parse_sse_delta` parses each `data:` chunk; deltas are buffered **and** yielded to stdout for real-time observability, then assembled into the final response at `[DONE]`/EOF. A completed stream records its **real** end-to-end latency as a profiler sample.

## 3. Master Wall Yielding (invariant-safe)
`_failover_local_dispatch` **drops the outer op-deadline `wait_for`** on the streaming path — an actively-emitting stream is bounded only by the inter-token watchdog + the **static** hard wall-clock cap. The hard cap is deliberately **not** coupled to stream state, per the load-bearing Slice-47 Watchdog Isolation Invariant; the intent ("don't kill a working stream") is met structurally by removing the premature op-deadline kill.

## Tests (TDD)
8 new + 169 green regression (survival path unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the heavy `num_ctx` generation timeout with streaming plus an inter-token watchdog, so active streams continue without a total-duration cap and only stalls fail. The non-streaming path keeps the adaptive EWMA timeout.

- **New Features**
  - Heavy path streams by default when `num_ctx` and `JARVIS_LOCAL_STREAMING_ENABLED` are true; each SSE read uses `JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S` (30s default). Silence past the gap raises `InterTokenStall` (non-recoverable).
  - `_complete_streaming` buffers SSE deltas, writes chunks to stdout in real time, assembles final text, and records real TTFT/total latency in the profiler.
  - `complete_guarded` and the streaming dispatch in `candidate_generator` drop the total-duration `wait_for`; the non-streaming path retains the adaptive timeout and EWMA penalty.
  - New tests cover SSE parsing, streaming assembly, stall detection, and guarded streaming; profiler timeout test now targets the non-streaming path.

- **Migration**
  - Toggle behavior with `JARVIS_LOCAL_STREAMING_ENABLED` (default true).
  - Tune stall sensitivity with `JARVIS_LOCAL_INTER_TOKEN_TIMEOUT_S` (seconds).
  - `LocalPrimeClient.complete()` now accepts `stream` to force enable/disable per call (non-breaking).

<sup>Written for commit 242a36b1a7a114eba1f828eb9c9565419089fe90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69802?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

