### PR TITLE
feat(a1): wire cryptographic FSM Suspend & Resume into boot + shutdown

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1895,6 +1895,34 @@ class BattleTestHarness:
                 except asyncio.CancelledError:
                     pass
 
+            # ── Autonomous FSM Suspend ──────────────────────────────────────
+            # Any op still in-flight when a graceful stop is decided (wall-clock
+            # cap, process-memory cap, idle, signal) is CHECKPOINTED here -- while
+            # the in-flight registry still holds its ctx -- so the NEXT ignition
+            # rehydrates and resumes it (invincible to the blind wall + Spot
+            # preemption; the wall stays blind per Slice-47). Fully fail-soft;
+            # no-op when nothing is in-flight. Gated JARVIS_FSM_CHECKPOINT_ENABLED.
+            try:
+                if os.environ.get(
+                    "JARVIS_FSM_CHECKPOINT_ENABLED", "true",
+                ).strip().lower() not in ("0", "false", "no", "off"):
+                    from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                        fsm_checkpoint as _fsm_ckpt,
+                    )
+                    _suspended = _fsm_ckpt.capture_inflight(
+                        reason=self._stop_reason or "graceful_shutdown",
+                    )
+                    if _suspended:
+                        logger.warning(
+                            "[FSMCheckpoint] SUSPENDED %d in-flight op(s) -> signed "
+                            "checkpoint; resumes on next ignition", _suspended,
+                        )
+            except Exception:  # noqa: BLE001 -- suspend never blocks shutdown
+                logger.debug(
+                    "[FSMCheckpoint] suspend capture skipped (fail-soft)",
+                    exc_info=True,
+                )
+
             # Determine stop reason — but preserve a restart_pending stamp
             # if the restart monitor already set it (otherwise it would be
             # overwritten with the generic "shutdown_signal").

--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -13,13 +13,67 @@ like the other observability ledgers).
 """
 from __future__ import annotations
 
+import hashlib
+import hmac
 import json
+import logging
 import os
 import time
 from dataclasses import dataclass, field, asdict
 from typing import Any, Dict, List, Optional
 
+logger = logging.getLogger(__name__)
+
 _SCHEMA_VERSION = 1
+
+
+# ---------------------------------------------------------------------------
+# Cryptographic State Verification (anti-corruption, fail-closed)
+# ---------------------------------------------------------------------------
+
+def _checkpoint_key(base_dir: "Optional[str]" = None) -> bytes:
+    """Locally-derived HMAC session key. ``JARVIS_CHECKPOINT_HMAC_SECRET`` if set
+    (driver-provisioned, like the signed roadmap), else a persisted local key
+    (generated ONCE via os.urandom at ``.ouroboros/checkpoint_key``, 0600). A resume
+    across ignitions on the SAME host verifies against the same persisted key.
+    NEVER raises (falls back to a process-stable default)."""
+    env = os.environ.get("JARVIS_CHECKPOINT_HMAC_SECRET", "").strip()
+    if env:
+        return env.encode("utf-8")
+    try:
+        d = checkpoint_dir(base_dir)
+        key_path = os.path.join(os.path.dirname(d), "checkpoint_key")
+        if os.path.isfile(key_path):
+            with open(key_path, "rb") as fh:
+                k = fh.read().strip()
+                if k:
+                    return k
+        k = hashlib.sha256(os.urandom(32)).hexdigest().encode("ascii")
+        tmp = key_path + ".tmp"
+        with open(tmp, "wb") as fh:
+            fh.write(k)
+        try:
+            os.chmod(tmp, 0o600)
+        except Exception:  # noqa: BLE001
+            pass
+        os.replace(tmp, key_path)
+        return k
+    except Exception:  # noqa: BLE001
+        return b"jarvis-checkpoint-fallback-key"
+
+
+def _sign(payload_json: str, key: bytes) -> str:
+    return hmac.new(key, payload_json.encode("utf-8"), hashlib.sha256).hexdigest()
+
+
+def _verify(payload_json: str, signature: str, key: bytes) -> bool:
+    """Constant-time HMAC verify. Fail-closed on any defect. NEVER raises."""
+    try:
+        if not payload_json or not signature:
+            return False
+        return hmac.compare_digest(_sign(payload_json, key), str(signature))
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def checkpoint_dir(base_dir: "Optional[str]" = None) -> str:
@@ -91,14 +145,19 @@ def capture_from_context(context: Any, *, phase: str, tool_history: "Optional[Li
 
 
 def write_checkpoint(cp: FSMCheckpoint, *, base_dir: "Optional[str]" = None) -> "Optional[str]":
-    """Serialize a checkpoint to ``<dir>/<op_id>.json`` (atomic tmp+rename).
-    Returns the path, or None on failure. NEVER raises."""
+    """Serialize + HMAC-SIGN a checkpoint to ``<dir>/<op_id>.json`` (atomic
+    tmp+rename). The on-disk wrapper is ``{schema, payload, hmac}`` where ``hmac``
+    binds the exact payload bytes -- any tamper invalidates it. Returns the path, or
+    None on failure. NEVER raises."""
     try:
         d = checkpoint_dir(base_dir)
+        payload_json = cp.to_json()
+        sig = _sign(payload_json, _checkpoint_key(base_dir))
+        wrapper = json.dumps({"schema": _SCHEMA_VERSION, "payload": payload_json, "hmac": sig})
         path = os.path.join(d, "%s.json" % cp.op_id)
         tmp = path + ".tmp"
         with open(tmp, "w", encoding="utf-8") as fh:
-            fh.write(cp.to_json())
+            fh.write(wrapper)
         os.replace(tmp, path)
         return path
     except Exception:  # noqa: BLE001
@@ -106,22 +165,112 @@ def write_checkpoint(cp: FSMCheckpoint, *, base_dir: "Optional[str]" = None) -> 
 
 
 def list_pending(*, base_dir: "Optional[str]" = None) -> List[FSMCheckpoint]:
-    """All un-resumed checkpoints (oldest first). Corrupt files are skipped.
-    NEVER raises."""
+    """All un-resumed checkpoints whose HMAC VERIFIES (oldest first). Corrupt,
+    tampered, empty, or unsigned files are REJECTED (fail-closed) + logged, never
+    returned -- zero corrupted executions. NEVER raises."""
     out: List[FSMCheckpoint] = []
     try:
         d = checkpoint_dir(base_dir)
+        key = _checkpoint_key(base_dir)
         names = [n for n in os.listdir(d) if n.endswith(".json") and not n.endswith(".tmp")]
         for n in sorted(names):
             try:
                 with open(os.path.join(d, n), "r", encoding="utf-8") as fh:
-                    out.append(FSMCheckpoint.from_json(fh.read()))
+                    wrapper = json.loads(fh.read())
+                payload_json = wrapper.get("payload") if isinstance(wrapper, dict) else None
+                sig = wrapper.get("hmac") if isinstance(wrapper, dict) else None
+                if not isinstance(payload_json, str) or not _verify(payload_json, sig or "", key):
+                    logger.warning(
+                        "[fsm_checkpoint] REJECT %s -- HMAC verify failed "
+                        "(corrupt/tampered/unsigned) -> clean boot for this op", n,
+                    )
+                    continue
+                out.append(FSMCheckpoint.from_json(payload_json))
             except Exception:  # noqa: BLE001
+                logger.warning("[fsm_checkpoint] REJECT %s -- unreadable -> clean boot", n)
                 continue
         out.sort(key=lambda c: c.created_at)
     except Exception:  # noqa: BLE001
         pass
     return out
+
+
+def capture_inflight(*, base_dir: "Optional[str]" = None, reason: str = "wall_clock_cap") -> int:
+    """SUSPEND: on graceful shutdown (wall-clock cap / SIGTERM preemption), read the
+    in-flight registry and serialize a signed checkpoint for each active op (from its
+    ctx_ref + last_phase_name). Returns the count checkpointed. Fully fail-soft --
+    NEVER raises into the shutdown path (a checkpoint miss just means that op
+    restarts clean, never a crash)."""
+    n = 0
+    try:
+        from backend.core.ouroboros.governance.in_flight_registry import (  # noqa: PLC0415
+            get_default_registry,
+        )
+        for rec in get_default_registry().snapshot():
+            try:
+                ctx = getattr(rec, "ctx_ref", None)
+                if ctx is None:
+                    continue
+                cp = capture_from_context(
+                    ctx, phase=getattr(rec, "last_phase_name", "") or "GENERATE",
+                    resume_reason=reason,
+                )
+                if cp is not None and write_checkpoint(cp, base_dir=base_dir):
+                    n += 1
+                    logger.info(
+                        "[fsm_checkpoint] SUSPENDED op=%s phase=%s reason=%s -> signed "
+                        "checkpoint (resumes next ignition)", cp.op_id, cp.phase, reason,
+                    )
+            except Exception:  # noqa: BLE001
+                continue
+    except Exception:  # noqa: BLE001
+        pass
+    return n
+
+
+def build_resume_envelope(cp: FSMCheckpoint) -> Dict[str, Any]:
+    """Build a resume intake envelope from a verified checkpoint. Carries the
+    preserved tool/exploration context (Seamless Venom Hydration) so the model
+    FAST-FORWARDS -- it does not re-read files it already explored last window; the
+    Iron Gate credits the preserved exploration and generation picks up where it
+    left off."""
+    return {
+        "op_id": cp.op_id,
+        "description": cp.goal_description,
+        "target_files": list(cp.target_files),
+        "source": "fsm_resume",
+        "resume": True,
+        "resume_phase": cp.phase,
+        "tool_history": list(cp.tool_history),
+        "exploration_records": list(cp.exploration_records),
+        "intake_evidence_json": cp.intake_evidence_json,
+        "provider_route": cp.provider_route,
+    }
+
+
+def hydrate_pending_checkpoints(ingest_fn: Any, *, base_dir: "Optional[str]" = None) -> int:
+    """Autonomous-startup resume: read HMAC-VERIFIED pending checkpoints, re-inject
+    each via *ingest_fn* (with preserved exploration context), and consume it
+    (mark_resumed -> exactly once). Rejected (unverified) checkpoints are already
+    filtered by list_pending (fail-closed -> clean boot). Returns the count resumed.
+    NEVER raises -- a resume failure leaves that checkpoint pending for the next boot."""
+    n = 0
+    for cp in list_pending(base_dir=base_dir):
+        try:
+            ingest_fn(build_resume_envelope(cp))
+            mark_resumed(cp.op_id, base_dir=base_dir)
+            n += 1
+            logger.info(
+                "[fsm_checkpoint] RESUMED op=%s phase=%s (%d exploration records "
+                "preserved -> Venom fast-forward, no re-read)",
+                cp.op_id, cp.phase, len(cp.exploration_records),
+            )
+        except Exception:  # noqa: BLE001
+            logger.warning(
+                "[fsm_checkpoint] resume re-inject failed op=%s -- left pending "
+                "for next boot", cp.op_id,
+            )
+    return n
 
 
 def mark_resumed(op_id: str, *, base_dir: "Optional[str]" = None) -> bool:

--- a/backend/core/ouroboros/governance/intake/intent_envelope.py
+++ b/backend/core/ouroboros/governance/intake/intent_envelope.py
@@ -97,6 +97,13 @@ _VALID_SOURCES = frozenset({
     # Resurrected > Normal) and trigger preemption of a running resurrected op.
     "cli_emergency",
     "human_override",
+    # Added 2026-07-01 for the Autonomous FSM Checkpoint/Resume hydrator. A
+    # suspended op (checkpointed on the wall-clock cap / Spot preemption) is
+    # re-injected at the NEXT ignition's intake boot with its preserved
+    # exploration context (Venom fast-forward). Honest-source token: a resumed op
+    # MUST NOT masquerade as its original source -- observability + the resume
+    # ledger filter on it. Carries the HMAC-verified checkpoint context in evidence.
+    "fsm_resume",
 })
 _VALID_URGENCIES = frozenset({"critical", "high", "normal", "low"})
 
@@ -136,6 +143,9 @@ _VALID_ROUTING_OVERRIDES = frozenset({
 _EMPTY_TARGET_FILES_EXEMPT_SOURCES = frozenset({
     "vision_sensor",
     "swe_bench_pro",
+    # A resumed op may re-localize from its preserved exploration context rather
+    # than a pinned target list (the checkpoint carries tool/exploration history).
+    "fsm_resume",
 })
 
 

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -935,6 +935,65 @@ class UnifiedIntakeRouter:
             self._dispatch_loop(), name="intake_dispatch"
         )
         await self._replay_wal()
+        await self._hydrate_fsm_checkpoints()
+
+    async def _hydrate_fsm_checkpoints(self) -> None:
+        """Autonomous startup resume: re-inject HMAC-VERIFIED suspended ops (from a
+        prior window's wall-clock cap / Spot preemption) with their preserved
+        exploration context, so the DAG fast-forwards instead of re-exploring.
+        Gated by ``JARVIS_FSM_RESUME_ENABLED`` (default on). Fully fail-soft --
+        NEVER blocks boot. Rejected (unverified) checkpoints fall back to clean boot."""
+        if os.environ.get("JARVIS_FSM_RESUME_ENABLED", "true").strip().lower() in ("0", "false", "no", "off"):
+            return
+        try:
+            from backend.core.ouroboros.governance import fsm_checkpoint as _ckpt  # noqa: PLC0415
+            from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: PLC0415
+                make_envelope as _make_env,
+            )
+
+            async def _reinject(env: "Dict[str, Any]") -> None:
+                _tf = tuple(env.get("target_files") or ())
+                _ev = {
+                    "resume": True,
+                    "resume_phase": env.get("resume_phase", ""),
+                    "resumed_op_id": env.get("op_id", ""),
+                    "tool_history": env.get("tool_history") or [],
+                    "exploration_records": env.get("exploration_records") or [],
+                    "intake_evidence_json": env.get("intake_evidence_json", ""),
+                    "signature": "fsm_resume:%s" % (env.get("op_id", "")),
+                }
+                envelope = _make_env(
+                    source="fsm_resume",
+                    description=env.get("description") or "resume suspended op",
+                    target_files=_tf,
+                    repo=os.environ.get("JARVIS_REPO_ROOT", "."),
+                    confidence=1.0,
+                    urgency="high",
+                    evidence=_ev,
+                    requires_human_ack=False,
+                    routing_override=(env.get("provider_route") or ""),
+                )
+                await self.ingest(envelope)
+
+            # hydrate_pending_checkpoints wants a sync ingest_fn; bridge to async by
+            # scheduling each re-inject and consuming the checkpoint on success.
+            _pending = _ckpt.list_pending()
+            for _cp in _pending:
+                try:
+                    await _reinject(_ckpt.build_resume_envelope(_cp))
+                    _ckpt.mark_resumed(_cp.op_id)
+                    logger.info(
+                        "Router: RESUMED suspended op=%s phase=%s (%d exploration "
+                        "records preserved -> Venom fast-forward)",
+                        _cp.op_id, _cp.phase, len(_cp.exploration_records),
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "Router: FSM resume re-inject failed op=%s -- left pending",
+                        getattr(_cp, "op_id", "?"),
+                    )
+        except Exception:  # noqa: BLE001
+            logger.debug("Router: FSM checkpoint hydration skipped (fail-soft)", exc_info=True)
 
     async def stop(self) -> None:
         """Gracefully stop the dispatch loop and release the advisory lock."""

--- a/tests/governance/test_heartbeat_and_checkpoint.py
+++ b/tests/governance/test_heartbeat_and_checkpoint.py
@@ -98,3 +98,111 @@ def test_list_pending_skips_corrupt(tmp_path):
     ckpt.write_checkpoint(ckpt.FSMCheckpoint(op_id="ok", phase="GENERATE"), base_dir=base)
     got = ckpt.list_pending(base_dir=base)
     assert [c.op_id for c in got] == ["ok"]   # corrupt skipped, valid survives
+
+
+# --- Cryptographic State Verification (fail-closed) -------------------------
+
+def test_signed_checkpoint_verifies(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "test-secret-key")
+    base = str(tmp_path)
+    ckpt.write_checkpoint(ckpt.FSMCheckpoint(op_id="op-sig", phase="GENERATE"), base_dir=base)
+    got = ckpt.list_pending(base_dir=base)
+    assert [c.op_id for c in got] == ["op-sig"]   # valid HMAC -> accepted
+
+
+def test_tampered_payload_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "test-secret-key")
+    base = str(tmp_path)
+    import json as _json
+    import os
+    path = ckpt.write_checkpoint(ckpt.FSMCheckpoint(op_id="op-t", phase="GENERATE"), base_dir=base)
+    # Tamper the payload but keep the old signature.
+    with open(path) as fh:
+        w = _json.load(fh)
+    payload = _json.loads(w["payload"])
+    payload["goal_description"] = "MALICIOUS INJECTION"
+    w["payload"] = _json.dumps(payload)  # sig no longer matches
+    with open(path, "w") as fh:
+        _json.dump(w, fh)
+    assert ckpt.list_pending(base_dir=base) == []   # fail-closed -> clean boot
+
+
+def test_wrong_key_rejected(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "key-A")
+    base = str(tmp_path)
+    ckpt.write_checkpoint(ckpt.FSMCheckpoint(op_id="op-k", phase="GENERATE"), base_dir=base)
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "key-B")   # attacker/rotated key
+    assert ckpt.list_pending(base_dir=base) == []   # HMAC mismatch -> rejected
+
+
+def test_missing_hmac_rejected(tmp_path):
+    base = str(tmp_path)
+    d = ckpt.checkpoint_dir(base)
+    import os, json as _json
+    with open(os.path.join(d, "nosig.json"), "w") as fh:
+        _json.dump({"schema": 1, "payload": '{"op_id":"x","phase":"GENERATE"}'}, fh)  # no hmac
+    assert ckpt.list_pending(base_dir=base) == []
+
+
+# --- Resume hydration (Venom fast-forward) ----------------------------------
+
+def test_hydrate_reinjects_and_consumes(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "k")
+    base = str(tmp_path)
+    ckpt.write_checkpoint(ckpt.FSMCheckpoint(
+        op_id="op-r", phase="GENERATE", goal_description="finish the patch",
+        target_files=["m.py"], exploration_records=[{"tool": "read_file", "path": "m.py"}],
+    ), base_dir=base)
+
+    injected = []
+    ckpt.hydrate_pending_checkpoints(lambda env: injected.append(env), base_dir=base)
+
+    assert len(injected) == 1
+    env = injected[0]
+    assert env["op_id"] == "op-r" and env["resume"] is True and env["resume_phase"] == "GENERATE"
+    assert env["exploration_records"] == [{"tool": "read_file", "path": "m.py"}]  # preserved
+    # consumed exactly once -> a second boot re-injects nothing.
+    assert ckpt.list_pending(base_dir=base) == []
+    injected2 = []
+    ckpt.hydrate_pending_checkpoints(lambda env: injected2.append(env), base_dir=base)
+    assert injected2 == []
+
+
+def test_capture_inflight_from_registry(tmp_path, monkeypatch):
+    """SUSPEND: capture_inflight reads the in-flight registry and writes a signed
+    checkpoint per active op (from its ctx_ref)."""
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "k")
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
+    from backend.core.ouroboros.governance import in_flight_registry as ifr
+    ifr.reset_default_registry()
+    reg = ifr.get_default_registry()
+    ctx = SimpleNamespace(op_id="op-live", phase="GENERATE", description="fix it",
+                          target_files=("z.py",), intake_evidence_json="{}", provider_route="standard")
+    reg.register("op-live", ctx_ref=ctx, last_phase_name="GENERATE")
+
+    n = ckpt.capture_inflight(reason="wall_clock_cap")
+    assert n == 1
+    pending = ckpt.list_pending()
+    assert [c.op_id for c in pending] == ["op-live"]
+    assert pending[0].resume_reason == "wall_clock_cap"
+    ifr.reset_default_registry()
+
+
+def test_capture_inflight_empty_registry_is_noop(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp2"))
+    from backend.core.ouroboros.governance import in_flight_registry as ifr
+    ifr.reset_default_registry()
+    assert ckpt.capture_inflight(reason="x") == 0   # nothing in-flight -> no-op
+
+
+def test_hydrate_leaves_pending_on_ingest_failure(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "k")
+    base = str(tmp_path)
+    ckpt.write_checkpoint(ckpt.FSMCheckpoint(op_id="op-f", phase="GENERATE"), base_dir=base)
+
+    def _boom(env):
+        raise RuntimeError("intake down")
+
+    ckpt.hydrate_pending_checkpoints(_boom, base_dir=base)
+    # ingest failed -> NOT consumed -> still pending for the next boot.
+    assert [c.op_id for c in ckpt.list_pending(base_dir=base)] == ["op-f"]


### PR DESCRIPTION
Completes checkpoint/resume (foundation in #69803) with HMAC verification + the two live seams. The wall-clock cap stays **blind** (Slice-47); a thought survives it by suspend→resume across ignitions.

## 1. Cryptographic State Verification (fail-closed)
Checkpoints = `{schema, payload, hmac}`; HMAC-SHA256 binds the payload with a locally-derived session key (`JARVIS_CHECKPOINT_HMAC_SECRET`, else a persisted `os.urandom` key at `.ouroboros/checkpoint_key`, 0600). `list_pending()` verifies via `compare_digest` and **rejects** corrupt/tampered/unsigned/empty → clean boot.

## 2. SUSPEND (harness graceful-shutdown)
On any graceful stop (wall_clock_cap / mem / idle / signal) — while the in-flight registry still holds each op's ctx — every active op is serialized to a **signed** checkpoint. Fail-soft, no-op when idle, wall untouched. Gated `JARVIS_FSM_CHECKPOINT_ENABLED`.

## 3. RESUME + Venom fast-forward (intake `start()`)
After WAL replay, re-injects each **HMAC-verified** checkpoint as a `fsm_resume` envelope carrying preserved tool/exploration records → the model doesn't re-read explored files; picks up its phase. Consumed once. Gated `JARVIS_FSM_RESUME_ENABLED`.

## Tests
+8 (HMAC reject paths, hydrate reinject/consume, capture_inflight) → 17 in-suite; 114 green across the stack.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cryptographic FSM suspend and resume so active ops survive shutdowns and preemptions without rework. Checkpoints are HMAC-signed and verified at startup; invalid files are ignored for a clean boot.

- **New Features**
  - HMAC-signed checkpoints `{schema, payload, hmac}` using `JARVIS_CHECKPOINT_HMAC_SECRET` or a persisted `.ouroboros/checkpoint_key` (0600); fail-closed verify on boot.
  - Graceful shutdown writes signed checkpoints for in-flight ops (`capture_inflight`); gated by `JARVIS_FSM_CHECKPOINT_ENABLED`.
  - Startup hydrates verified checkpoints and re-injects them as `fsm_resume` envelopes with preserved tool/exploration records; consumed once; gated by `JARVIS_FSM_RESUME_ENABLED`.
  - Intake adds `source: "fsm_resume"` and allows empty target files for resumes.

- **Migration**
  - No action required; features are on by default.
  - Optional: set `JARVIS_CHECKPOINT_HMAC_SECRET` for shared/multi-host environments; use `JARVIS_CHECKPOINT_DIR` to control storage; toggle with `JARVIS_FSM_CHECKPOINT_ENABLED` and `JARVIS_FSM_RESUME_ENABLED`.

<sup>Written for commit e49cfeba155c4557094b9286b96ef0f39ca05149. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69804?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

