### PR TITLE
fix(a1): FSM suspend on signal/reap path + stable cross-window checkpoint dir

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -5423,6 +5423,30 @@ class BattleTestHarness:
         except Exception:  # noqa: BLE001 — never let watchdog arm crash signal handler
             pass
 
+        # Autonomous FSM Suspend (signal/preemption path) — checkpoint in-flight ops
+        # BEFORE the async cleanup, so an external SIGTERM reap / GCP Spot preemption
+        # (not just the internal wall-event race) resumes on the next ignition.
+        # Sync, fast, fail-soft; no-op when nothing in-flight. Gated
+        # JARVIS_FSM_CHECKPOINT_ENABLED. Sits alongside the Preemption Shield.
+        try:
+            if os.environ.get(
+                "JARVIS_FSM_CHECKPOINT_ENABLED", "true",
+            ).strip().lower() not in ("0", "false", "no", "off"):
+                from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                    fsm_checkpoint as _fsm_ckpt_sig,
+                )
+                _sig_suspended = _fsm_ckpt_sig.capture_inflight(
+                    reason=(signal_name or self._stop_reason or "signal"),
+                )
+                if _sig_suspended:
+                    logger.warning(
+                        "[FSMCheckpoint] SUSPENDED %d in-flight op(s) on %s -> signed "
+                        "checkpoint; resumes next ignition",
+                        _sig_suspended, signal_name or "shutdown",
+                    )
+        except Exception:  # noqa: BLE001 — never let checkpoint crash the signal path
+            pass
+
         # Graceful Preemption Shield — SYNCHRONOUS, corruption-first. On a GCP
         # Spot SIGTERM we have ~30s before SIGKILL; the existing async cleanup
         # below can exceed that and says nothing about the working tree. Engage

--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -473,6 +473,13 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
         _soak_env = dict(os.environ)
         _soak_env["OUROBOROS_BATTLE_MAX_WALL_SECONDS"] = str(args.max_wall_seconds)
         _soak_env.setdefault("OUROBOROS_BATTLE_HEADLESS", "1")
+        # Autonomous FSM Suspend/Resume: pin a STABLE, absolute checkpoint dir (+ its
+        # persisted HMAC key) so a suspended op checkpointed in window 1 is found +
+        # verified in window 2 -- the organism runs in an EPHEMERAL isomorphic cwd,
+        # so a CWD-relative default would land in a temp dir that never survives.
+        _soak_env.setdefault(
+            "JARVIS_CHECKPOINT_DIR", str(repo_root / ".ouroboros" / "checkpoints"),
+        )
         if args.live_failover:
             _arm_failover_env(_soak_env)
         _write_log_header(log_fh, argv=soak_argv, cwd=repo_root)

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1007,6 +1007,19 @@ class IsomorphicA1Driver:
                     # inside a live loop; only _reap_failover_resources uses run()).
                     await _arm_failover_mesh(env)
 
+                    # Autonomous FSM Suspend/Resume: pin a STABLE absolute checkpoint
+                    # dir into the ORGANISM env (compose_env starts from a manifest,
+                    # so JARVIS_CHECKPOINT_* is NOT inherited unless set here). The
+                    # organism runs in an ephemeral isomorphic cwd, so a CWD-relative
+                    # default would never survive to the next window. This shared dir
+                    # (+ its persisted HMAC key) lets window-1 suspend -> window-2
+                    # resume across ignitions.
+                    env["JARVIS_CHECKPOINT_DIR"] = str(
+                        Path(self.repo_root) / ".ouroboros" / "checkpoints"
+                    )
+                    env.setdefault("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+                    env.setdefault("JARVIS_FSM_RESUME_ENABLED", "true")
+
                 # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
                 # (all default OFF in prod; this driver IS the A1 ignition harness).
                 env["JARVIS_RUNTIME_SANDBOX_ENABLED"] = "true"   # L4 container backend


### PR DESCRIPTION
Live window-1 run surfaced two wiring gaps in the merged checkpoint/resume:

1. **Suspend missed the reap path** — capture was only in the run() internal wall-event race, but the isomorphic soak ends via the driver externally SIGTERM-reaping the organism (through the harness signal handler, not the race). Added `capture_inflight()` to `_handle_shutdown_signal` (alongside the Graceful Preemption Shield) so external SIGTERM / Spot preemption checkpoints too.

2. **Ephemeral checkpoint dir** — `checkpoint_dir()` defaulted CWD-relative, but the organism runs in an ephemeral isomorphic temp cwd. The driver now pins `JARVIS_CHECKPOINT_DIR` to a stable absolute `<repo>/.ouroboros/checkpoints` in both the ignite + isomorphic organism envs, so window-1 suspend and window-2 resume share the ledger + persisted HMAC key.

Pure wiring of the already-TDD'd checkpoint/resume onto the real teardown/boot paths. 17 checkpoint tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FSM suspend/resume so in-flight ops are checkpointed on shutdown signals and checkpoints persist across windows. This makes window-1 suspend reliably resume in window-2.

- **Bug Fixes**
  - Capture in-flight ops in `_handle_shutdown_signal` via `capture_inflight()` to cover external `SIGTERM` and Spot preemption. Fail-soft; no-op when idle.
  - Pin `JARVIS_CHECKPOINT_DIR` to an absolute `<repo>/.ouroboros/checkpoints` in both ignite and isomorphic organism envs, and enable `JARVIS_FSM_CHECKPOINT_ENABLED` / `JARVIS_FSM_RESUME_ENABLED`, avoiding ephemeral CWD issues.

<sup>Written for commit ed51b9b24a9ca6c7ca52149ade874738de700142. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

