### PR TITLE
fix(a1): arm in-flight registry so FSM suspend can capture live ops

### DIFF
--- a/scripts/ignite_a1_soak.py
+++ b/scripts/ignite_a1_soak.py
@@ -480,6 +480,9 @@ def main() -> int:  # noqa: C901 -- intentionally linear top-level flow
         _soak_env.setdefault(
             "JARVIS_CHECKPOINT_DIR", str(repo_root / ".ouroboros" / "checkpoints"),
         )
+        # In-flight registry must be master-ON for capture_inflight() to see the
+        # ops it should checkpoint on suspend (register_op_safely no-ops when off).
+        _soak_env.setdefault("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "true")
         if args.live_failover:
             _arm_failover_env(_soak_env)
         _write_log_header(log_fh, argv=soak_argv, cwd=repo_root)

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1019,6 +1019,11 @@ class IsomorphicA1Driver:
                     )
                     env.setdefault("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
                     env.setdefault("JARVIS_FSM_RESUME_ENABLED", "true")
+                    # capture_inflight() reads the in-flight registry to know WHICH
+                    # ops to checkpoint -- but register_op_safely no-ops when the
+                    # registry master flag is off (default). Arm it so in-flight ops
+                    # are tracked and thus captured on suspend.
+                    env.setdefault("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "true")
 
                 # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
                 # (all default OFF in prod; this driver IS the A1 ignition harness).


### PR DESCRIPTION
Third live-surfaced gap: `capture_inflight()` reads the in-flight registry snapshot, but `register_op_safely()` no-ops when `JARVIS_IN_FLIGHT_REGISTRY_ENABLED` is off (default §33.1) — so the soak's registry was empty → 0 ops captured → 0 checkpoints (wall_clock_cap fired with 10 streaming calls but captured nothing). Arms the flag in both the ignite + isomorphic organism envs so in-flight ops are tracked and captured on suspend. Capture path already TDD-proven (`test_capture_inflight_from_registry`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable the in-flight registry in A1 soak and local isomorphic runs so FSM suspend can capture active ops and create checkpoints. Sets `JARVIS_IN_FLIGHT_REGISTRY_ENABLED=true` in `scripts/ignite_a1_soak.py` and `scripts/isomorphic_a1_local.py`, fixing empty registry reads where `capture_inflight()` saw no ops because `register_op_safely()` no-ops when the flag is off.

<sup>Written for commit fea0e8e609b2a7729a65e197295cff4e9d7b653a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

