### PR TITLE
feat(a1): cooperative stream cancellation + partial-thought buffer + prefill re-ignition

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -5432,6 +5432,14 @@ class BattleTestHarness:
             if os.environ.get(
                 "JARVIS_FSM_CHECKPOINT_ENABLED", "true",
             ).strip().lower() not in ("0", "false", "no", "off"):
+                # Fire the cooperative-shutdown signal FIRST so any in-flight
+                # streaming op freezes mid-sentence at its next chunk boundary
+                # (raising GracefulStreamInterruption -> its dispatch checkpoints the
+                # partial deterministically) instead of holding the loop hostage.
+                from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                    cooperative_shutdown as _coop_sig,
+                )
+                _coop_sig.request(signal_name or self._stop_reason or "signal")
                 from backend.core.ouroboros.governance import (  # noqa: PLC0415
                     fsm_checkpoint as _fsm_ckpt_sig,
                 )

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4280,6 +4280,25 @@ class CandidateGenerator:
         _init_cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_init_overrides)
         _prof = self._failover_profiler_for(endpoint, _init_cfg)
 
+        # LLM Prefill Re-Ignition: if this op is a RESUME, its checkpointed partial
+        # thought rides in the intake evidence -> feed it to the client as a prefill
+        # so the 32B continues from the interrupted character (no re-generation).
+        _resume_prefill = ""
+        try:
+            import json as _rj  # noqa: PLC0415
+            _ev_raw = getattr(context, "intake_evidence_json", "") or ""
+            if _ev_raw:
+                _ev = _rj.loads(_ev_raw)
+                _resume_prefill = str((_ev or {}).get("partial_completion", "") or "")
+        except Exception:  # noqa: BLE001
+            _resume_prefill = ""
+        if _resume_prefill:
+            logger.info(
+                "[CandidateGenerator] RESUME prefill: continuing a %d-char partial "
+                "thought op=%s (32B resumes typing, no re-generation)",
+                len(_resume_prefill), _op,
+            )
+
         async def _attempts() -> Optional[GenerationResult]:
             nonlocal _num_ctx
             _n = _l7_recovery_attempts()
@@ -4290,6 +4309,8 @@ class CandidateGenerator:
                     _overrides["num_ctx"] = int(_num_ctx)
                 _cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_overrides)
                 _client = _F3cLocalPrimeClient(_cfg, profiler=_prof)
+                if _resume_prefill:
+                    _client._resume_prefill = _resume_prefill  # continue the partial
                 try:
                     _provider = _F3cPrimeProvider(
                         _client,
@@ -4319,6 +4340,31 @@ class CandidateGenerator:
                     )
                 except Exception as _exc:  # noqa: BLE001
                     _last_exc = _exc
+                    # Cooperative freeze-mid-sentence: capture the partial thought +
+                    # write the checkpoint DETERMINISTICALLY here (we hold both the
+                    # ctx and the partial), avoiding the registry-unregister race, then
+                    # re-raise so the op suspends (never retried).
+                    if type(_exc).__name__ == "GracefulStreamInterruption":
+                        try:
+                            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                                fsm_checkpoint as _gsi_ckpt,
+                            )
+                            _partial = getattr(_exc, "partial", "") or ""
+                            _gsi_ckpt.stash_partial(_op, _partial)
+                            _cp = _gsi_ckpt.capture_from_context(
+                                context, phase="GENERATE",
+                                resume_reason="graceful_stream_interruption",
+                            )
+                            if _cp is not None:
+                                _gsi_ckpt.write_checkpoint(_cp)
+                                logger.warning(
+                                    "[CandidateGenerator] FROZE mid-stream op=%s -> "
+                                    "checkpointed %d-char partial thought; resumes "
+                                    "next ignition via prefill", _op, len(_partial),
+                                )
+                        except Exception:  # noqa: BLE001
+                            pass
+                        raise
                     # Non-recoverable OR out of retries -> propagate (sentinel seals).
                     if _try >= _n or not _is_l7_recoverable(_exc):
                         raise

--- a/backend/core/ouroboros/governance/cooperative_shutdown.py
+++ b/backend/core/ouroboros/governance/cooperative_shutdown.py
@@ -1,0 +1,46 @@
+"""Process-global cooperative-shutdown signal.
+
+Bridges the harness shutdown decision (wall-clock cap / SIGTERM / Spot preemption)
+to deep-in-the-stack coroutines (the streaming inference loop) WITHOUT threading a
+handle through every layer. The harness sets it; the streaming loop polls it between
+token chunks and yields COOPERATIVELY (raising GracefulStreamInterruption with its
+buffered partial) instead of holding the event loop hostage until a blind SIGKILL.
+
+Advisory + decoupled: this is NOT a watchdog and shares no state-ledger with the
+blind wall-clock cap (Slice-47 intact) -- it is a one-way "please wind down at the
+next safe boundary" flag. Thread + async safe (a plain bool set/read under a lock).
+"""
+from __future__ import annotations
+
+import threading
+
+_lock = threading.Lock()
+_requested: bool = False
+_reason: str = ""
+
+
+def request(reason: str = "shutdown") -> None:
+    """Signal a cooperative wind-down. Idempotent; the first reason sticks."""
+    global _requested, _reason
+    with _lock:
+        if not _requested:
+            _reason = str(reason or "shutdown")
+        _requested = True
+
+
+def is_requested() -> bool:
+    with _lock:
+        return _requested
+
+
+def reason() -> str:
+    with _lock:
+        return _reason
+
+
+def reset() -> None:
+    """Test / re-arm hook -- clear the signal."""
+    global _requested, _reason
+    with _lock:
+        _requested = False
+        _reason = ""

--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -104,6 +104,10 @@ class FSMCheckpoint:
     exploration_records: List[Dict[str, Any]] = field(default_factory=list)
     intake_evidence_json: str = ""
     provider_route: str = ""
+    # Partial-Thought Buffer: the exact raw string the LLM had emitted when the
+    # stream was cooperatively interrupted (may be half a tool call / code block).
+    # Window-2 resume prefills this so the model continues from the interrupted char.
+    partial_completion: str = ""
     created_at: float = 0.0
     resume_reason: str = ""
     schema_version: int = _SCHEMA_VERSION
@@ -116,6 +120,31 @@ class FSMCheckpoint:
         data = json.loads(blob)
         known = {k: data.get(k) for k in cls.__dataclass_fields__ if k in data}  # type: ignore[attr-defined]
         return cls(**known)
+
+
+# Partial-Thought side-channel: the streaming layer knows the partial string but not
+# the op_id; the dispatch layer knows the op_id but not the partial. The dispatch
+# stashes the interrupted partial keyed by op_id here; capture_from_context (invoked
+# by the harness suspend, which has the ctx/op_id) pops it into the checkpoint.
+_PARTIAL_STASH: Dict[str, str] = {}
+
+
+def stash_partial(op_id: str, partial: str) -> None:
+    """Record the partial thought of a cooperatively-interrupted op (by op_id) so the
+    suspend capture can fold it into the checkpoint. NEVER raises."""
+    try:
+        if op_id:
+            _PARTIAL_STASH[str(op_id)] = str(partial or "")
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def pop_partial(op_id: str) -> str:
+    """Consume a stashed partial (once). Returns "" if none. NEVER raises."""
+    try:
+        return _PARTIAL_STASH.pop(str(op_id), "")
+    except Exception:  # noqa: BLE001
+        return ""
 
 
 def capture_from_context(context: Any, *, phase: str, tool_history: "Optional[List[Dict[str, Any]]]" = None,
@@ -137,6 +166,7 @@ def capture_from_context(context: Any, *, phase: str, tool_history: "Optional[Li
             exploration_records=list(exploration_records or []),
             intake_evidence_json=str(getattr(context, "intake_evidence_json", "") or ""),
             provider_route=str(getattr(context, "provider_route", "") or ""),
+            partial_completion=pop_partial(op_id),
             created_at=time.time(),
             resume_reason=str(resume_reason),
         )
@@ -245,6 +275,7 @@ def build_resume_envelope(cp: FSMCheckpoint) -> Dict[str, Any]:
         "exploration_records": list(cp.exploration_records),
         "intake_evidence_json": cp.intake_evidence_json,
         "provider_route": cp.provider_route,
+        "partial_completion": cp.partial_completion,
     }
 
 

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -952,14 +952,25 @@ class UnifiedIntakeRouter:
             )
 
             async def _reinject(env: "Dict[str, Any]") -> None:
+                import json as _rj  # noqa: PLC0415
                 _tf = tuple(env.get("target_files") or ())
+                # Embed the partial thought + resume markers into intake_evidence_json
+                # (the string the GENERATE dispatch parses) so the prefill re-ignition
+                # reaches the LLM request -- the model continues from the exact char.
+                _ev_json = _rj.dumps({
+                    "resume": True,
+                    "resume_phase": env.get("resume_phase", ""),
+                    "partial_completion": env.get("partial_completion", ""),
+                    "resumed_op_id": env.get("op_id", ""),
+                })
                 _ev = {
                     "resume": True,
                     "resume_phase": env.get("resume_phase", ""),
+                    "partial_completion": env.get("partial_completion", ""),
                     "resumed_op_id": env.get("op_id", ""),
                     "tool_history": env.get("tool_history") or [],
                     "exploration_records": env.get("exploration_records") or [],
-                    "intake_evidence_json": env.get("intake_evidence_json", ""),
+                    "intake_evidence_json": _ev_json,
                     "signature": "fsm_resume:%s" % (env.get("op_id", "")),
                 }
                 envelope = _make_env(

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -406,6 +406,20 @@ def _ewma_alpha() -> float:
         return 0.3
 
 
+class GracefulStreamInterruption(RuntimeError):
+    """Raised by the streaming loop when a cooperative shutdown is requested mid-
+    generation (wall-clock cap / SIGTERM / Spot preemption). Distinct from a network
+    drop (ServerDisconnected) or a stall (InterTokenStall): this is a DELIBERATE,
+    orderly freeze-mid-sentence. Carries the exact buffered ``partial`` thought so
+    the FSM checkpointer can preserve it and window-2 resume can prefill it. NON-
+    recoverable (the op suspends -> checkpoint, never a retry)."""
+    failure_class = "graceful_stream_interruption"
+
+    def __init__(self, message: str = "", *, partial: str = "") -> None:
+        super().__init__(message)
+        self.partial = partial
+
+
 class InterTokenStall(RuntimeError):
     """Asynchronous Inter-Token Watchdog trip: the streamed generation went silent
     (no token chunk within the inter-token timeout). A stalled stream = a wedged
@@ -524,6 +538,10 @@ class LocalPrimeClient:
         # cold seed on every fresh client (the "profiler amnesia").
         self.profiler = profiler if profiler is not None else LatencyProfiler(cfg)
         self._governor: Any = None
+        # LLM Prefill Re-Ignition: when set (by the dispatch on a RESUMED op), the
+        # next generation continues from this saved partial thought instead of
+        # starting over. Consumed once per generate() call.
+        self._resume_prefill: str = ""
 
     def attach_governor(self, governor: Any) -> None:
         """Attach a LocalInferenceDirector so generate() consults memory_guard()
@@ -547,7 +565,8 @@ class LocalPrimeClient:
     async def complete(self, *, system: str, user: str, prompt_tokens: int,
                        temperature: float = 0.2,
                        max_tokens: "Optional[int]" = None,
-                       stream: "Optional[bool]" = None) -> LocalCompletion:
+                       stream: "Optional[bool]" = None,
+                       prefill: str = "") -> LocalCompletion:
         sess = await self._ensure_session()
         url = self._cfg.base_url.rstrip("/") + "/v1/chat/completions"
         # Dynamic Cognitive Compression + num_ctx injection (Context-Hardware
@@ -574,14 +593,25 @@ class LocalPrimeClient:
                     "to %d-token input budget (num_ctx=%d, reserved_out=%d)",
                     _in_budget, int(self._cfg.num_ctx), _reserve_out,
                 )
+        # Explicit prefill arg wins; else the client-carried resume prefill (set by
+        # the dispatch on a RESUMED op), consumed once.
+        _eff_prefill = prefill or self._resume_prefill
+        self._resume_prefill = ""
+        _messages = [
+            {"role": "system", "content": system},
+            {"role": "user", "content": user},
+        ]
+        # LLM Prefill Re-Ignition: on RESUME, inject the saved partial thought as a
+        # trailing assistant message so the model CONTINUES it (ollama/OpenAI treat a
+        # trailing assistant message as a prefill to keep typing) instead of starting
+        # the generation over. The returned text is prefill + continuation.
+        if _eff_prefill:
+            _messages.append({"role": "assistant", "content": _eff_prefill})
         body: Dict[str, Any] = {
             "model": self._cfg.model_name,
             "keep_alive": self._cfg.keep_alive_seconds,
             "temperature": temperature,
-            "messages": [
-                {"role": "system", "content": system},
-                {"role": "user", "content": user},
-            ],
+            "messages": _messages,
         }
         if self._cfg.num_ctx:
             # ollama-native option; harmless if a given engine ignores it (the
@@ -593,7 +623,7 @@ class LocalPrimeClient:
         _use_stream = stream if stream is not None else (
             bool(self._cfg.num_ctx) and _streaming_enabled())
         if _use_stream:
-            return await self._complete_streaming(sess, url, body)
+            return await self._complete_streaming(sess, url, body, prefill=_eff_prefill)
 
         t0 = time.monotonic()
         async with sess.post(url, json=body) as resp:
@@ -605,23 +635,37 @@ class LocalPrimeClient:
         self.profiler.record(ttft_ms=ttft_ms, total_ms=total_ms, output_tokens=out_toks)
         return LocalCompletion(text=text, output_tokens=out_toks, ttft_ms=ttft_ms, total_ms=total_ms)
 
-    async def _complete_streaming(self, sess: Any, url: str, body: Dict[str, Any]) -> LocalCompletion:
-        """Streaming generation with the Asynchronous Inter-Token Watchdog. Reads the
-        SSE stream chunk-by-chunk; each ``readline`` is bounded by the inter-token
-        timeout (NOT the total duration), so a model that keeps emitting runs
-        indefinitely and only a genuine STALL (silence > timeout) trips the breaker.
-        Buffers the deltas (constraint 2) while yielding them to stdout, and records
-        the REAL end-to-end latency as a profiler sample on success."""
+    async def _complete_streaming(self, sess: Any, url: str, body: Dict[str, Any],
+                                  *, prefill: str = "") -> LocalCompletion:
+        """Streaming generation with the Asynchronous Inter-Token Watchdog +
+        cooperative shutdown. Reads the SSE stream chunk-by-chunk; each ``readline``
+        is bounded by the inter-token timeout (NOT the total duration). Between
+        chunks it polls the cooperative-shutdown signal and, if set, raises
+        GracefulStreamInterruption carrying the exact buffered partial (freeze
+        mid-sentence -> the loop never holds the graceful shutdown hostage). On
+        RESUME the *prefill* seeds the buffer so the returned text is the prior
+        partial + the continuation (the model resumes from the interrupted char).
+        Records the REAL end-to-end latency on a clean finish."""
+        from backend.core.ouroboros.governance import cooperative_shutdown as _coop  # noqa: PLC0415
         body = dict(body)
         body["stream"] = True
         inter_token_s = _inter_token_timeout_s()
-        parts: List[str] = []
+        # Seed with the resume prefill so the assembled text continues the partial.
+        parts: List[str] = [prefill] if prefill else []
         ttft_ms = 0.0
         t0 = time.monotonic()
         first = True
         async with sess.post(url, json=body) as resp:
             reader = resp.content  # aiohttp StreamReader (line-iterable)
             while True:
+                # Event-Driven Cooperative Yielding: at a SAFE chunk boundary, if a
+                # cooperative shutdown was requested, freeze mid-sentence and hand the
+                # buffered partial thought to the checkpointer -- do NOT hold the loop.
+                if _coop.is_requested():
+                    raise GracefulStreamInterruption(
+                        "cooperative shutdown (%s) mid-stream" % _coop.reason(),
+                        partial="".join(parts),
+                    )
                 try:
                     line = await asyncio.wait_for(reader.readline(), timeout=inter_token_s)
                 except asyncio.TimeoutError as e:

--- a/tests/governance/test_cooperative_stream_interrupt.py
+++ b/tests/governance/test_cooperative_stream_interrupt.py
@@ -1,0 +1,169 @@
+"""Cooperative stream cancellation + partial-thought buffer + prefill re-ignition.
+
+Resolves the Event-Loop Monopolization deadlock: a streaming op no longer holds the
+graceful shutdown hostage. On the shutdown signal, _complete_streaming raises
+GracefulStreamInterruption carrying the exact buffered partial; the checkpointer
+saves that partial; window-2 resume injects it as an assistant-message PREFILL so
+the 32B resumes typing from the interrupted character (no restart-from-scratch).
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+import backend.core.ouroboros.governance.fsm_checkpoint as ckpt
+import backend.core.ouroboros.governance.cooperative_shutdown as coop
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+def _sse(content):
+    import json
+    return ("data: " + json.dumps({"choices": [{"delta": {"content": content}}]}) + "\n").encode()
+
+
+class _Reader:
+    def __init__(self, lines, on_chunk=None):
+        self.lines = list(lines)
+        self.i = 0
+        self.on_chunk = on_chunk
+
+    async def readline(self):
+        if self.i >= len(self.lines):
+            return b""
+        ln = self.lines[self.i]
+        self.i += 1
+        if self.on_chunk:
+            self.on_chunk(self.i)
+        return ln
+
+
+class _Resp:
+    def __init__(self, reader):
+        self.content = reader
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Sess:
+    def __init__(self, reader):
+        self._r = reader
+        self.posted = []
+    def post(self, url, **kw):
+        self.posted.append(kw)
+        return _Resp(self._r)
+    async def close(self):
+        pass
+
+
+# --- 1. cooperative shutdown signal -----------------------------------------
+
+def test_cooperative_shutdown_signal():
+    coop.reset()
+    assert coop.is_requested() is False
+    coop.request("wall_clock_cap")
+    assert coop.is_requested() is True
+    assert coop.reason() == "wall_clock_cap"
+    coop.reset()
+    assert coop.is_requested() is False
+
+
+# --- 1+2. mid-stream interruption raises with the buffered partial ----------
+
+def test_stream_interrupts_and_captures_partial():
+    coop.reset()
+
+    # After 2 chunks arrive, request shutdown; the loop must raise on the next check.
+    def _after(i):
+        if i == 2:
+            coop.request("wall_clock_cap")
+
+    lines = [_sse("def foo("), _sse("): retu"), _sse("rn 1"), b"data: [DONE]\n"]
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_Reader(lines, _after)))
+    try:
+        with pytest.raises(lid.GracefulStreamInterruption) as ei:
+            asyncio.run(client.complete(system="s", user="u", prompt_tokens=10, stream=True))
+        # Shutdown is requested while chunk 2 is read; the loop appends it, then the
+        # next-iteration cooperative check trips -> the buffer preserves EVERYTHING
+        # received so far (chunks 1+2), losing nothing.
+        assert ei.value.partial == "def foo(): retu"
+    finally:
+        coop.reset()
+
+
+def test_no_interruption_when_not_requested():
+    coop.reset()
+    lines = [_sse("hello"), b"data: [DONE]\n"]
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_Reader(lines)))
+    lc = asyncio.run(client.complete(system="s", user="u", prompt_tokens=10, stream=True))
+    assert lc.text == "hello"
+
+
+def test_graceful_interruption_not_l7_recoverable():
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    assert cg._is_l7_recoverable(lid.GracefulStreamInterruption("x", partial="p")) is False
+
+
+# --- 2. checkpoint stores the partial + stash/pop side-channel ---------------
+
+def test_checkpoint_partial_roundtrip():
+    cp = ckpt.FSMCheckpoint(op_id="op-p", phase="GENERATE", partial_completion="def foo(")
+    back = ckpt.FSMCheckpoint.from_json(cp.to_json())
+    assert back.partial_completion == "def foo("
+
+
+def test_partial_stash_pop():
+    ckpt.stash_partial("op-x", "half a tool call {")
+    assert ckpt.pop_partial("op-x") == "half a tool call {"
+    assert ckpt.pop_partial("op-x") == ""   # popped once, gone
+
+
+def test_capture_reads_stashed_partial():
+    from types import SimpleNamespace
+    ckpt.stash_partial("op-cap", "interrupted mid-")
+    cp = ckpt.capture_from_context(SimpleNamespace(op_id="op-cap", phase="GENERATE"), phase="GENERATE")
+    assert cp is not None and cp.partial_completion == "interrupted mid-"
+
+
+def test_resume_envelope_carries_partial():
+    cp = ckpt.FSMCheckpoint(op_id="op-r", phase="GENERATE", partial_completion="return ")
+    env = ckpt.build_resume_envelope(cp)
+    assert env["partial_completion"] == "return "
+
+
+# --- 3. prefill re-ignition -------------------------------------------------
+
+def test_prefill_injected_as_assistant_message():
+    """A resumed generation injects the saved partial as an assistant prefill so the
+    model continues from it; the returned text INCLUDES the prefill + continuation."""
+    coop.reset()
+    lines = [_sse("rn 42"), b"data: [DONE]\n"]   # model continues "...retu|rn 42"
+    sess = _Sess(_Reader(lines))
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=sess)
+    lc = asyncio.run(client.complete(system="s", user="u", prompt_tokens=10,
+                                     stream=True, prefill="def f(): retu"))
+    # request body carried the assistant prefill message
+    msgs = sess.posted[0]["json"]["messages"]
+    assert msgs[-1] == {"role": "assistant", "content": "def f(): retu"}
+    # returned text = prefill + streamed continuation (resumes from the exact char)
+    assert lc.text == "def f(): return 42"
+
+
+def test_client_resume_prefill_attr_used():
+    """The dispatch sets client._resume_prefill on a resumed op; complete() consumes
+    it (once) when no explicit prefill is passed."""
+    coop.reset()
+    lines = [_sse("rn 7"), b"data: [DONE]\n"]
+    sess = _Sess(_Reader(lines))
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=sess)
+    client._resume_prefill = "def g(): retu"
+    lc = asyncio.run(client.complete(system="s", user="u", prompt_tokens=10, stream=True))
+    assert lc.text == "def g(): return 7"
+    assert client._resume_prefill == ""   # consumed once


### PR DESCRIPTION
Resolves the Event-Loop Monopolization deadlock — a streaming op held the graceful shutdown hostage until the blind SIGKILL bypassed the checkpoint. The AI now **freezes mid-sentence** on the wall, saves the exact partial, and **resumes typing from that character** next ignition.

## 1. Event-Driven Cooperative Yielding
Harness fires `cooperative_shutdown.request()` on the wall/signal path; `_complete_streaming` polls it at each chunk boundary and raises `GracefulStreamInterruption` (distinct from network-drop/stall — the DAG knows it was a deliberate freeze) carrying the exact buffered partial. Non-recoverable → suspends, never retries.

## 2. Semantic State Preservation
`_failover_local_dispatch` catches it and **deterministically** writes the checkpoint (holds both ctx + partial → no registry-unregister race). `FSMCheckpoint.partial_completion` serializes the raw partial; `build_resume_envelope` carries it.

## 3. LLM Prefill Re-Ignition
On resume, intake embeds the partial in `intake_evidence_json`; the dispatch sets `client._resume_prefill`; `complete()` injects it as a trailing **assistant** message so the 32B continues (returned text = partial + continuation), not regenerates.

## Tests
10 new + 100 green (streaming/checkpoint/profiler) + lifecycle 26.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds cooperative stream cancellation and resume-from-partial for LLM streaming. Fixes the shutdown deadlock by freezing mid-sentence, checkpointing the exact partial, and continuing from that character on the next run.

- **Bug Fixes**
  - Resolves event-loop monopolization during graceful shutdown. The harness now fires `cooperative_shutdown.request()` before checkpointing, so streaming no longer blocks exit.

- **New Features**
  - Cooperative yielding: the streaming loop polls the signal each chunk and raises `GracefulStreamInterruption` with the buffered partial; it is non-recoverable and suspends the op.
  - Partial-thought checkpointing: saves the exact partial via `FSMCheckpoint.partial_completion` with `stash_partial`/`pop_partial`, written deterministically in `_failover_local_dispatch`.
  - Prefill re-ignition: resume embeds the partial in `intake_evidence_json`; the dispatcher sets `client._resume_prefill`; `complete()` appends it as an assistant message so output = prefill + continuation.

<sup>Written for commit 584cf8d6d5821f43f6d089960b38ef3b43ffac8b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69807?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

