### PR TITLE
fix(a1): fire cooperative-shutdown on the internal wall-race path

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1906,6 +1906,16 @@ class BattleTestHarness:
                 if os.environ.get(
                     "JARVIS_FSM_CHECKPOINT_ENABLED", "true",
                 ).strip().lower() not in ("0", "false", "no", "off"):
+                    # Fire cooperative shutdown FIRST so an in-flight STREAMING op
+                    # freezes at its next chunk boundary (raising
+                    # GracefulStreamInterruption -> its dispatch checkpoints the
+                    # partial deterministically) instead of holding the event loop
+                    # hostage until the blind SIGKILL. The subsequent GLS teardown
+                    # awaits the op, giving it the tick it needs to freeze.
+                    from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                        cooperative_shutdown as _coop_race,
+                    )
+                    _coop_race.request(self._stop_reason or "wall_clock_cap")
                     from backend.core.ouroboros.governance import (  # noqa: PLC0415
                         fsm_checkpoint as _fsm_ckpt,
                     )


### PR DESCRIPTION
The internal wall_clock_cap fires the run() race (not the signal handler where cooperative_shutdown.request lived), so a streaming op never froze there and held the loop until SIGKILL. Fire the request at the top of the race-path suspend block too. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Request cooperative shutdown on the internal wall-clock race path so streaming ops freeze and checkpoint instead of hanging the event loop until SIGKILL. This prevents stuck processes and ensures deterministic partial checkpoints.

- **Bug Fixes**
  - Call cooperative_shutdown.request() at the start of the run() race-path suspend block (before FSM checkpoint) when `wall_clock_cap` fires.

<sup>Written for commit 9dd94c210b3124d7651772230612d82c7020e8d8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

