### PR TITLE
fix(a1): GracefulStreamInterruption → BaseException + preemptive async race (cooperative cancel closes locally)

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4246,6 +4246,7 @@ class CandidateGenerator:
         import dataclasses as _f3c_dc
 
         from backend.core.ouroboros.governance.local_inference_director import (
+            GracefulStreamInterruption,
             LocalConfig as _F3cLocalConfig,
             LocalPrimeClient as _F3cLocalPrimeClient,
         )
@@ -4338,33 +4339,37 @@ class CandidateGenerator:
                         _provider.generate(context, deadline),
                         timeout=remaining,
                     )
+                except GracefulStreamInterruption as _gsi:
+                    # Cooperative freeze-mid-sentence. GSI is a BaseException by design
+                    # (the Earmuff Bypass) -- it pierced the Venom tool loop's
+                    # `except Exception` and lands HERE at the checkpoint boundary.
+                    # Capture the partial thought + write the checkpoint
+                    # DETERMINISTICALLY (we hold both the ctx and the partial), avoiding
+                    # the registry-unregister race, then re-raise so the op suspends
+                    # (never retried -- resumes next ignition via prefill).
+                    _last_exc = _gsi
+                    try:
+                        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                            fsm_checkpoint as _gsi_ckpt,
+                        )
+                        _partial = getattr(_gsi, "partial", "") or ""
+                        _gsi_ckpt.stash_partial(_op, _partial)
+                        _cp = _gsi_ckpt.capture_from_context(
+                            context, phase="GENERATE",
+                            resume_reason="graceful_stream_interruption",
+                        )
+                        if _cp is not None:
+                            _gsi_ckpt.write_checkpoint(_cp)
+                            logger.warning(
+                                "[CandidateGenerator] FROZE mid-stream op=%s -> "
+                                "checkpointed %d-char partial thought; resumes "
+                                "next ignition via prefill", _op, len(_partial),
+                            )
+                    except Exception:  # noqa: BLE001
+                        pass
+                    raise
                 except Exception as _exc:  # noqa: BLE001
                     _last_exc = _exc
-                    # Cooperative freeze-mid-sentence: capture the partial thought +
-                    # write the checkpoint DETERMINISTICALLY here (we hold both the
-                    # ctx and the partial), avoiding the registry-unregister race, then
-                    # re-raise so the op suspends (never retried).
-                    if type(_exc).__name__ == "GracefulStreamInterruption":
-                        try:
-                            from backend.core.ouroboros.governance import (  # noqa: PLC0415
-                                fsm_checkpoint as _gsi_ckpt,
-                            )
-                            _partial = getattr(_exc, "partial", "") or ""
-                            _gsi_ckpt.stash_partial(_op, _partial)
-                            _cp = _gsi_ckpt.capture_from_context(
-                                context, phase="GENERATE",
-                                resume_reason="graceful_stream_interruption",
-                            )
-                            if _cp is not None:
-                                _gsi_ckpt.write_checkpoint(_cp)
-                                logger.warning(
-                                    "[CandidateGenerator] FROZE mid-stream op=%s -> "
-                                    "checkpointed %d-char partial thought; resumes "
-                                    "next ignition via prefill", _op, len(_partial),
-                                )
-                        except Exception:  # noqa: BLE001
-                            pass
-                        raise
                     # Non-recoverable OR out of retries -> propagate (sentinel seals).
                     if _try >= _n or not _is_l7_recoverable(_exc):
                         raise

--- a/backend/core/ouroboros/governance/cooperative_shutdown.py
+++ b/backend/core/ouroboros/governance/cooperative_shutdown.py
@@ -9,23 +9,66 @@ buffered partial) instead of holding the event loop hostage until a blind SIGKIL
 Advisory + decoupled: this is NOT a watchdog and shares no state-ledger with the
 blind wall-clock cap (Slice-47 intact) -- it is a one-way "please wind down at the
 next safe boundary" flag. Thread + async safe (a plain bool set/read under a lock).
+
+Loop-safe async race (constraint 2, the Preemptive Asynchronous Race): a caller in
+ANY running loop can `await wait_async()` and be woken the instant `request()` fires
+-- even when `request()` is driven from a signal-handler thread with no running loop.
+We do NOT cache a single loop-bound `asyncio.Event` (that object binds to the loop it
+was first awaited on and raises "bound to a different event loop" the moment a second
+loop -- a new `asyncio.run`, a re-ignition -- tries to await it). Instead each
+`wait_async()` mints a FRESH event on ITS running loop, registers it, and `request()`
+wakes every live waiter on its own loop via `call_soon_threadsafe`. This mirrors the
+canonical cross-thread wakeup already used by `backend/core/async_safety.py`.
 """
 from __future__ import annotations
 
+import asyncio
 import threading
+from typing import List, Set, Tuple
 
 _lock = threading.Lock()
 _requested: bool = False
 _reason: str = ""
+# Live async waiters: (loop, event). Each wait_async() adds one on entry and removes
+# it on exit; request() wakes each on its own loop. No stale global singleton.
+_waiters: "Set[Tuple[asyncio.AbstractEventLoop, asyncio.Event]]" = set()
+
+
+async def wait_async() -> None:
+    """Await the cooperative-shutdown signal (for asyncio.wait racing). Returns
+    immediately if already requested; otherwise blocks until request() fires. Loop-safe:
+    the event is bound to the CURRENT running loop, never a stale one."""
+    loop = asyncio.get_running_loop()
+    ev = asyncio.Event()
+    key = (loop, ev)
+    # Register + fast-path check under the SAME lock section that request() snapshots
+    # waiters under -> no lost wakeup: either we see _requested here, or request() sees
+    # our event in _waiters and sets it.
+    with _lock:
+        if _requested:
+            return
+        _waiters.add(key)
+    try:
+        await ev.wait()
+    finally:
+        with _lock:
+            _waiters.discard(key)
 
 
 def request(reason: str = "shutdown") -> None:
-    """Signal a cooperative wind-down. Idempotent; the first reason sticks."""
+    """Signal a cooperative wind-down. Idempotent; the first reason sticks. Wakes every
+    live async waiter on its own loop (thread-safe: callable from a signal handler)."""
     global _requested, _reason
     with _lock:
         if not _requested:
             _reason = str(reason or "shutdown")
         _requested = True
+        waiters: List[Tuple[asyncio.AbstractEventLoop, asyncio.Event]] = list(_waiters)
+    for loop, ev in waiters:
+        try:
+            loop.call_soon_threadsafe(ev.set)
+        except Exception:  # noqa: BLE001 -- best-effort wake (loop may be closing)
+            pass
 
 
 def is_requested() -> bool:
@@ -39,8 +82,10 @@ def reason() -> str:
 
 
 def reset() -> None:
-    """Test / re-arm hook -- clear the signal."""
+    """Test / re-arm hook -- clear the signal + drop any registered waiters (so the
+    next run/loop starts clean, not bound to a dead loop)."""
     global _requested, _reason
     with _lock:
         _requested = False
         _reason = ""
+        _waiters.clear()

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -406,13 +406,17 @@ def _ewma_alpha() -> float:
         return 0.3
 
 
-class GracefulStreamInterruption(RuntimeError):
-    """Raised by the streaming loop when a cooperative shutdown is requested mid-
-    generation (wall-clock cap / SIGTERM / Spot preemption). Distinct from a network
-    drop (ServerDisconnected) or a stall (InterTokenStall): this is a DELIBERATE,
-    orderly freeze-mid-sentence. Carries the exact buffered ``partial`` thought so
-    the FSM checkpointer can preserve it and window-2 resume can prefill it. NON-
-    recoverable (the op suspends -> checkpoint, never a retry)."""
+class GracefulStreamInterruption(BaseException):
+    """Cooperative freeze-mid-sentence (wall-clock cap / SIGTERM / Spot preemption).
+
+    Strict Exception Hierarchy Elevation: inherits from ``BaseException`` (like
+    ``asyncio.CancelledError`` / ``SystemExit``), NOT ``Exception`` -- so it PIERCES
+    the Venom tool loop's ``except Exception`` per-round guards (the Earmuff Bypass)
+    and propagates straight to the dispatch's explicit ``except GracefulStreamInterruption``
+    checkpoint boundary, instead of being swallowed as a round failure (whack-a-mole).
+    Distinct from a network drop / stall -- a DELIBERATE orderly suspend. Carries the
+    exact buffered ``partial`` thought so the checkpointer preserves it and window-2
+    resume prefills it. NON-recoverable (the op suspends -> checkpoint, never retry)."""
     failure_class = "graceful_stream_interruption"
 
     def __init__(self, message: str = "", *, partial: str = "") -> None:
@@ -655,35 +659,62 @@ class LocalPrimeClient:
         ttft_ms = 0.0
         t0 = time.monotonic()
         first = True
+
+        def _freeze() -> "GracefulStreamInterruption":
+            return GracefulStreamInterruption(
+                "cooperative shutdown (%s) mid-stream" % _coop.reason(),
+                partial="".join(parts),
+            )
+
         async with sess.post(url, json=body) as resp:
             reader = resp.content  # aiohttp StreamReader (line-iterable)
-            while True:
-                # Event-Driven Cooperative Yielding: at a SAFE chunk boundary, if a
-                # cooperative shutdown was requested, freeze mid-sentence and hand the
-                # buffered partial thought to the checkpointer -- do NOT hold the loop.
-                if _coop.is_requested():
-                    raise GracefulStreamInterruption(
-                        "cooperative shutdown (%s) mid-stream" % _coop.reason(),
-                        partial="".join(parts),
+            # Preemptive Asynchronous Race: one long-lived shutdown waiter raced
+            # against each readline. The instant the OS signal fires the event, the
+            # readline task is dropped and we yield the partial to THIS millisecond --
+            # zero-latency, not up to the inter-token window later.
+            _shutdown_task = asyncio.ensure_future(_coop.wait_async())
+            try:
+                while True:
+                    if _coop.is_requested():  # cheap fast-path (already requested)
+                        raise _freeze()
+                    _read_task = asyncio.ensure_future(reader.readline())
+                    done, _pending = await asyncio.wait(
+                        {_read_task, _shutdown_task},
+                        timeout=inter_token_s,
+                        return_when=asyncio.FIRST_COMPLETED,
                     )
-                try:
-                    line = await asyncio.wait_for(reader.readline(), timeout=inter_token_s)
-                except asyncio.TimeoutError as e:
-                    raise InterTokenStall(
-                        "inter-token stall: no chunk within %.0fs (stream wedged)"
-                        % inter_token_s
-                    ) from e
-                if not line:
-                    break  # EOF -> stream complete
-                delta = _parse_sse_delta(line)
-                if delta is _SSE_DONE:
-                    break
-                if delta:
-                    if first:
-                        ttft_ms = (time.monotonic() - t0) * 1000.0
-                        first = False
-                    parts.append(delta)
-                    _emit_stream_token(delta)
+                    if _read_task in done:
+                        # A chunk (or EOF) is already in hand -- NEVER drop it, even if
+                        # shutdown fired in the same tick. We buffer it here; the
+                        # cooperative check at the top of the NEXT iteration freezes
+                        # AFTER this chunk is appended, so the partial loses nothing.
+                        line = _read_task.result()
+                    elif _shutdown_task in done:
+                        # Read still blocked -> drop the in-flight I/O + yield NOW
+                        # (zero-latency: this millisecond, not after the read unblocks).
+                        _read_task.cancel()
+                        raise _freeze()
+                    else:
+                        # Neither fired within the window -> the stream is wedged.
+                        _read_task.cancel()
+                        raise InterTokenStall(
+                            "inter-token stall: no chunk within %.0fs (stream wedged)"
+                            % inter_token_s
+                        )
+                    if not line:
+                        break  # EOF -> stream complete
+                    delta = _parse_sse_delta(line)
+                    if delta is _SSE_DONE:
+                        break
+                    if delta:
+                        if first:
+                            ttft_ms = (time.monotonic() - t0) * 1000.0
+                            first = False
+                        parts.append(delta)
+                        _emit_stream_token(delta)
+            finally:
+                if not _shutdown_task.done():
+                    _shutdown_task.cancel()
         total_ms = (time.monotonic() - t0) * 1000.0
         text = "".join(parts)
         out_toks = max(1, len(text) // 4)

--- a/scripts/prove_cooperative_checkpoint_local.py
+++ b/scripts/prove_cooperative_checkpoint_local.py
@@ -1,0 +1,148 @@
+#!/usr/bin/env python3
+"""LOCAL PROOF (no cloud): cooperative stream cancellation -> GSI propagation ->
+signed checkpoint written to the REAL repo .ouroboros/checkpoints.
+
+Exercises the production modules end-to-end (no pytest, no mocks of our own code):
+  1. Real LocalPrimeClient streaming a BLOCKED read; cooperative_shutdown.request()
+     fires mid-stream from a sibling task.
+  2. The Preemptive Async Race drops the blocked I/O and raises the BaseException
+     GracefulStreamInterruption carrying the exact partial buffer -- zero-latency.
+  3. We prove GSI PIERCES a `try/except Exception` (the Venom tool-loop mimic).
+  4. The real fsm_checkpoint writes a HMAC-signed checkpoint (with the partial) to the
+     actual <repo>/.ouroboros/checkpoints, and list_pending reads it back verified.
+
+Run:  python3 scripts/prove_cooperative_checkpoint_local.py
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import os
+import sys
+import time
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[1]
+if str(_REPO) not in sys.path:
+    sys.path.insert(0, str(_REPO))
+_CKPT_DIR = _REPO / ".ouroboros" / "checkpoints"
+os.environ.setdefault("JARVIS_FAILOVER_USE_ADC", "false")
+os.environ["JARVIS_CHECKPOINT_DIR"] = str(_CKPT_DIR)
+os.environ.setdefault("JARVIS_CHECKPOINT_HMAC_SECRET", "local-proof-secret")
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+import backend.core.ouroboros.governance.cooperative_shutdown as coop
+from backend.core.ouroboros.governance import fsm_checkpoint as ckpt
+
+
+def _ok(msg: str) -> None:
+    print(f"  \033[32m[OK]\033[0m {msg}")
+
+
+def _hdr(msg: str) -> None:
+    print(f"\n\033[1m{msg}\033[0m")
+
+
+class _BlockingReader:
+    async def readline(self):
+        await asyncio.sleep(9999)   # simulates the 32B mid-generation (slow chunk)
+        return b""
+
+
+class _Resp:
+    def __init__(self, reader):
+        self.content = reader
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Sess:
+    def __init__(self, reader):
+        self._r = reader
+    def post(self, url, **kw):
+        return _Resp(self._r)
+    async def close(self):
+        pass
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+async def _race_and_checkpoint():
+    coop.reset()
+    _hdr("1. Exception hierarchy (the Earmuff Bypass)")
+    assert issubclass(lid.GracefulStreamInterruption, BaseException)
+    assert not issubclass(lid.GracefulStreamInterruption, Exception)
+    _ok("GracefulStreamInterruption is a BaseException, NOT an Exception")
+
+    _hdr("2. Preemptive async race (real LocalPrimeClient, blocked read)")
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_BlockingReader()))
+
+    async def _fire():
+        await asyncio.sleep(0.2)
+        coop.request("wall_clock_cap")
+
+    asyncio.ensure_future(_fire())
+    t0 = time.monotonic()
+    partial = None
+    try:
+        await client.complete(system="s", user="u", prompt_tokens=10, stream=True,
+                              prefill="def solve(x):\n    # begin real 32B thought")
+    except lid.GracefulStreamInterruption as gsi:
+        partial = gsi.partial
+    elapsed = time.monotonic() - t0
+    assert partial is not None, "stream was NOT interrupted"
+    assert elapsed < 2.0, f"interrupt took {elapsed:.2f}s (should be ~0.2s)"
+    _ok(f"blocked read dropped + GSI raised in {elapsed*1000:.0f}ms (buffer preserved)")
+
+    _hdr("3. GSI pierces `try/except Exception` (Venom tool-loop mimic)")
+    pierced = False
+    try:
+        try:
+            raise lid.GracefulStreamInterruption("freeze", partial=partial)
+        except Exception:  # noqa: BLE001 -- the tool loop's per-round guard
+            print("  [!!] swallowed by except Exception -- BUG")
+    except lid.GracefulStreamInterruption:
+        pierced = True
+    assert pierced, "GSI was swallowed by except Exception"
+    _ok("GSI propagated straight through the tool-loop's except Exception")
+
+    _hdr("4. Signed checkpoint written to the REAL .ouroboros/checkpoints")
+    from types import SimpleNamespace
+    op_id = f"op-local-proof-{int(time.time())}"
+    ckpt.stash_partial(op_id, partial)
+    ctx = SimpleNamespace(op_id=op_id, phase="GENERATE", description="local proof",
+                          target_files=("solve.py",), intake_evidence_json="",
+                          provider_route="standard")
+    cp = ckpt.capture_from_context(ctx, phase="GENERATE",
+                                   resume_reason="graceful_stream_interruption")
+    assert cp is not None
+    path = ckpt.write_checkpoint(cp)
+    coop.reset()
+
+    pend = ckpt.list_pending(base_dir=None)
+    mine = [c for c in pend if c.op_id == op_id]
+    assert mine, "checkpoint not found on disk / failed HMAC verification"
+    got = mine[0]
+    _ok(f"HMAC-signed checkpoint on disk: {path}")
+    _ok(f"read back verified: op_id={got.op_id} phase={got.phase}")
+    _ok(f"partial_completion preserved ({len(got.partial_completion)} chars):")
+    print("       \033[36m" + repr(got.partial_completion) + "\033[0m")
+    assert got.partial_completion == partial, "partial mismatch after roundtrip"
+    return path
+
+
+def main() -> int:
+    print("\033[1m=== LOCAL PROOF: cooperative cancellation -> checkpoint (no cloud) ===\033[0m")
+    print(f"checkpoint dir: {_CKPT_DIR}")
+    path = asyncio.run(_race_and_checkpoint())
+    print("\n\033[1;32mALL LOCAL PROOFS PASSED.\033[0m")
+    print(f"Inspect the on-disk checkpoint: cat {path}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/governance/test_baseexception_race_reignition.py
+++ b/tests/governance/test_baseexception_race_reignition.py
@@ -1,0 +1,182 @@
+"""Strict exception elevation + preemptive async race — the local repro harness.
+
+Proves, deterministically + locally (no cloud), that:
+  1. GracefulStreamInterruption is a BaseException (not Exception) -> it PIERCES the
+     Venom tool loop's `except Exception` blocks and reaches the checkpoint boundary.
+  2. The streaming generator RACES readline vs the shutdown event -> the instant the
+     signal fires it drops the I/O and yields the partial (zero-latency, not up to
+     the 30s inter-token window).
+  3. End-to-end: a cooperatively-interrupted dispatch writes a signed checkpoint with
+     the partial to .ouroboros -- even when the intermediate layer swallows Exception.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import time
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+import backend.core.ouroboros.governance.cooperative_shutdown as coop
+import backend.core.ouroboros.governance.fsm_checkpoint as ckpt
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+def _sse(content):
+    import json
+    return ("data: " + json.dumps({"choices": [{"delta": {"content": content}}]}) + "\n").encode()
+
+
+# --- 1. Exception hierarchy elevation ---------------------------------------
+
+def test_graceful_interruption_is_baseexception_not_exception():
+    assert issubclass(lid.GracefulStreamInterruption, BaseException)
+    assert not issubclass(lid.GracefulStreamInterruption, Exception)
+
+
+def test_graceful_interruption_pierces_except_exception():
+    """The Earmuff Bypass: a standard `except Exception` (as in the Venom tool loop)
+    does NOT swallow it -- it propagates straight through."""
+    swallowed = {"n": 0}
+
+    def _tool_loop_round():
+        try:
+            raise lid.GracefulStreamInterruption("freeze", partial="x")
+        except Exception:  # noqa: BLE001 -- mimics the tool loop's per-round guard
+            swallowed["n"] += 1
+            return "swallowed"
+
+    with pytest.raises(lid.GracefulStreamInterruption):
+        _tool_loop_round()
+    assert swallowed["n"] == 0   # never entered the except Exception block
+
+
+# --- 2. Preemptive async race (zero-latency interruption) -------------------
+
+class _BlockingReader:
+    """readline() blocks ~forever -- simulates the 32B mid-generation (slow chunk)."""
+    async def readline(self):
+        await asyncio.sleep(9999)
+        return b""
+
+
+class _Resp:
+    def __init__(self, reader):
+        self.content = reader
+    async def __aenter__(self):
+        return self
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Sess:
+    def __init__(self, reader):
+        self._r = reader
+        self.posted = []
+    def post(self, url, **kw):
+        self.posted.append(kw)
+        return _Resp(self._r)
+    async def close(self):
+        pass
+
+
+def test_async_race_interrupts_blocked_read_instantly():
+    coop.reset()
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_BlockingReader()))
+
+    async def _run():
+        # Fire the shutdown 0.2s in, while readline is blocked for 9999s.
+        async def _fire():
+            await asyncio.sleep(0.2)
+            coop.request("wall_clock_cap")
+        asyncio.ensure_future(_fire())
+        start = time.monotonic()
+        try:
+            await client.complete(system="s", user="u", prompt_tokens=10, stream=True,
+                                  prefill="partial so far")
+            return None, 0.0
+        except lid.GracefulStreamInterruption as e:
+            return e.partial, time.monotonic() - start
+
+    partial, elapsed = asyncio.run(_run())
+    coop.reset()
+    assert partial == "partial so far"      # buffered partial preserved
+    assert elapsed < 2.0                    # interrupted at the signal, NOT after 30s/9999s
+
+
+def test_race_normal_stream_still_completes():
+    coop.reset()
+    lines = [_sse("hi"), b"data: [DONE]\n"]
+    r = type("R", (), {"i": 0, "lines": lines})()
+    async def _readline(self=r):
+        if self.i >= len(self.lines):
+            return b""
+        ln = self.lines[self.i]; self.i += 1; return ln
+    r.readline = _readline
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(r))
+    lc = asyncio.run(client.complete(system="s", user="u", prompt_tokens=10, stream=True))
+    assert lc.text == "hi"
+
+
+# --- 3. End-to-end local repro: pierce + checkpoint written -----------------
+
+def test_local_dispatch_checkpoints_on_interruption(tmp_path, monkeypatch):
+    """The full local proof: a dispatch whose generation raises GSI THROUGH an
+    intermediate `except Exception` (the tool-loop mimic) still writes a signed
+    checkpoint (with the partial) to .ouroboros. No cloud, deterministic."""
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "local-secret")
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    import backend.core.ouroboros.governance.local_inference_director as lidmod
+    import backend.core.ouroboros.governance.providers as provmod
+    from types import SimpleNamespace
+    import datetime as _dt
+
+    class _FakeClient:
+        def __init__(self, cfg, session=None, profiler=None):
+            self._resume_prefill = ""
+        async def warmup(self, *, timeout_s):
+            return True
+        async def aclose(self):
+            pass
+
+    class _FakeProvider:
+        def __init__(self, client, repo_root=None):
+            pass
+        async def generate(self, context, deadline):
+            # Mimic the Venom tool loop swallowing Exception -- GSI (BaseException)
+            # must pierce it.
+            try:
+                raise lidmod.GracefulStreamInterruption("freeze", partial="def foo(): retu")
+            except Exception:  # noqa: BLE001
+                return SimpleNamespace(candidates=("should-not-reach",))
+
+    monkeypatch.setattr(lidmod, "LocalPrimeClient", _FakeClient)
+    monkeypatch.setattr(provmod, "PrimeProvider", _FakeProvider)
+
+    class _Stub:
+        _repo_root = None
+        def _remaining_seconds(self, dl):
+            return 60.0
+        async def _resolve_dispatch_model_name(self, ep):
+            return "qwen2.5-coder:32b"
+        async def _negotiate_num_ctx(self, ep):
+            return 8192
+        def _failover_profiler_for(self, ep, cfg):
+            return lidmod.LatencyProfiler(cfg)
+
+    dl = _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=60)
+    ctx = SimpleNamespace(op_id="op-frozen", phase="GENERATE", description="fix",
+                          target_files=("m.py",), intake_evidence_json="", provider_route="standard")
+
+    with pytest.raises(BaseException):  # noqa: B017 -- GSI or the converted terminal
+        asyncio.run(cg.CandidateGenerator._failover_local_dispatch(_Stub(), ctx, dl, "http://n:11434"))
+
+    pend = ckpt.list_pending(base_dir=None)
+    assert any(c.op_id == "op-frozen" for c in pend)
+    cp = [c for c in pend if c.op_id == "op-frozen"][0]
+    assert cp.partial_completion == "def foo(): retu"   # partial preserved via checkpoint


### PR DESCRIPTION
## What

Closes the last integration gap in cooperative stream cancellation — the frozen partial now reaches the checkpoint boundary and lands a **signed checkpoint in `.ouroboros`**, proven locally + deterministically (no cloud).

Three coupled root-cause fixes (no whack-a-mole):

### 1. Earmuff Bypass — `GracefulStreamInterruption` → `BaseException`
Now inherits `BaseException` (like `asyncio.CancelledError`/`SystemExit`), not `Exception`. It pierces the Venom tool loop's `except Exception` per-round guards and propagates straight to the Orchestrator's checkpoint boundary. `candidate_generator._failover_local_dispatch` gains an **explicit** `except GracefulStreamInterruption` (before `except Exception`, which no longer catches it) that stashes the partial + writes the checkpoint deterministically, then re-raises so the op suspends (never retried → resumes next ignition via prefill).

### 2. Preemptive Asynchronous Race — zero-latency interruption
`_complete_streaming` races `reader.readline()` against `cooperative_shutdown.wait_async()` via `asyncio.wait(FIRST_COMPLETED)`. The instant the OS signal fires the event, the blocked I/O is dropped and the partial yielded **this millisecond** (203ms measured vs a 9999s blocked read) — not up to the inter-token window later. A chunk already in hand is **never** dropped: a completed read is always drained + buffered before shutdown is honored, so the partial loses nothing.

### 3. Loop-safe cooperative signal
`cooperative_shutdown` no longer caches a single loop-bound `asyncio.Event` (which raises *"bound to a different event loop"* the moment a second loop — a re-ignition, a new `asyncio.run` — awaits it, spuriously completing the shutdown task and firing a false freeze). Each `wait_async()` mints a **fresh event on its own running loop** and registers it; `request()` wakes every live waiter on its own loop via `call_soon_threadsafe` (thread-safe from a signal handler). Mirrors the canonical cross-thread wakeup already used in `backend/core/async_safety.py`.

## Proof (local, no cloud)

- **TDD**: `tests/governance/test_baseexception_race_reignition.py` (5 tests). RED confirmed first — the blocked-read test hung to the pytest timeout, proving the race was absent.
- **Regression**: 174 tests green across streaming / cooperative / checkpoint / dispatch / coldstart suites.
- **End-to-end proof driver**: `scripts/prove_cooperative_checkpoint_local.py` exercises the real modules and writes + HMAC-verifies a checkpoint to the actual `.ouroboros/checkpoints`:
  ```
  [OK] GracefulStreamInterruption is a BaseException, NOT an Exception
  [OK] blocked read dropped + GSI raised in 203ms (buffer preserved)
  [OK] GSI propagated straight through the tool-loop's except Exception
  [OK] HMAC-signed checkpoint on disk … partial_completion preserved (42 chars)
  ```

## Next
Only after this local proof: the cross-window cloud suspend/resume run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make cooperative stream cancellation reliable and deterministic. Interrupted streams now propagate a `GracefulStreamInterruption` to the checkpoint boundary and write a signed checkpoint locally with zero-latency shutdown handling.

- **Bug Fixes**
  - Elevated `GracefulStreamInterruption` to `BaseException` and added an explicit handler in the local dispatch to stash the partial and write a checkpoint, then re-raise to suspend.
  - Implemented a preemptive async race in streaming: race `reader.readline()` vs `cooperative_shutdown.wait_async()` using `asyncio.wait(FIRST_COMPLETED)`; cancel blocked reads on shutdown and never drop a chunk already read.
  - Made `cooperative_shutdown` loop-safe with per-loop events and `call_soon_threadsafe` wakeups; `reset()` now clears waiters to avoid cross-run loop binding issues.
  - Added `tests/governance/test_baseexception_race_reignition.py` and a local proof script `scripts/prove_cooperative_checkpoint_local.py` that writes and verifies an HMAC-signed checkpoint in `.ouroboros/checkpoints`.

<sup>Written for commit d531c8b3d600f4d678c185e9e90efca9336e07ee. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

