### PR TITLE
feat(a1): Atomic Hydration Handshake — strict cross-window suspend/resume observability

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4294,11 +4294,21 @@ class CandidateGenerator:
         except Exception:  # noqa: BLE001
             _resume_prefill = ""
         if _resume_prefill:
-            logger.info(
-                "[CandidateGenerator] RESUME prefill: continuing a %d-char partial "
-                "thought op=%s (32B resumes typing, no re-generation)",
-                len(_resume_prefill), _op,
-            )
+            # Atomic Hydration Handshake (facet 2): the EXACT bytes + snippet of the
+            # partial thought re-entering the LLM as the assistant prefill -> stdout.
+            try:
+                from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                    fsm_checkpoint as _hs_ckpt,
+                )
+                _hs_ckpt.emit_handshake(
+                    _hs_ckpt.format_prefill_handshake(_op, _resume_prefill)
+                )
+            except Exception:  # noqa: BLE001
+                logger.info(
+                    "[CandidateGenerator] RESUME prefill: continuing a %d-char partial "
+                    "thought op=%s (32B resumes typing, no re-generation)",
+                    len(_resume_prefill), _op,
+                )
 
         async def _attempts() -> Optional[GenerationResult]:
             nonlocal _num_ctx

--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -76,6 +76,64 @@ def _verify(payload_json: str, signature: str, key: bytes) -> bool:
         return False
 
 
+# ---------------------------------------------------------------------------
+# Atomic Hydration Handshake (strict cross-window observability)
+# ---------------------------------------------------------------------------
+# The window-1 (suspend) -> window-2 (resume) transition must be cryptographically
+# LEGIBLE, never silent. The handshake is forced to BOTH the module logger (debug.log,
+# greppable) AND stdout (the operator console) -- mirroring the streaming token
+# emitter's stdout discipline. Two facets: the crypto-verify handshake (proving the
+# checkpoint is authentic) and the prefill-inject handshake (proving the exact partial
+# thought that re-enters the LLM). Observability only -- authority-free, never raises.
+
+def emit_handshake(line: str) -> None:
+    """Emit one Atomic Hydration Handshake line to BOTH the logger and stdout.
+    Best-effort on every leg -- observability never breaks suspend/resume."""
+    try:
+        logger.info(line)
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        import sys  # noqa: PLC0415
+        sys.stdout.write(line + "\n")
+        sys.stdout.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _handshake_snippet(text: str, *, head: int = 48, tail: int = 24) -> str:
+    """A bounded but EXACT (repr) snippet of the partial -- full repr when short, an
+    unambiguous head…tail elision when long (repr preserves newlines/escapes so the
+    operator sees the true bytes, not a lossy print)."""
+    text = text or ""
+    if len(text) <= head + tail + 1:
+        return repr(text)
+    return "%s … %s" % (repr(text[:head]), repr(text[-tail:]))
+
+
+def format_verified_handshake(op_id: str, phase: str, signature: str) -> str:
+    """Strict cryptographic handshake: the checkpoint's HMAC-SHA256 signature VERIFIED
+    (fail-closed gate passed). Carries a digest prefix so two windows can be correlated."""
+    return (
+        "[HYDRATION-HANDSHAKE] HMAC-SHA256 VERIFIED op=%s phase=%s digest=%s… "
+        "-> checkpoint AUTHENTIC (fail-closed crypto gate passed)"
+        % (op_id, phase, str(signature)[:16])
+    )
+
+
+def format_prefill_handshake(op_id: str, partial: str) -> str:
+    """Strict prefill-injection handshake: the EXACT byte-length + char-length + repr
+    snippet of the partial_completion being injected into the LLM as the assistant
+    prefill (the thought the 32B resumes typing from)."""
+    partial = partial or ""
+    n_bytes = len(partial.encode("utf-8"))
+    return (
+        "[HYDRATION-HANDSHAKE] PREFILL-INJECT op=%s partial_bytes=%d partial_chars=%d "
+        "snippet=%s -> injected as assistant prefill (32B continues the thought)"
+        % (op_id, n_bytes, len(partial), _handshake_snippet(partial))
+    )
+
+
 def checkpoint_dir(base_dir: "Optional[str]" = None) -> str:
     """Resolve the checkpoint ledger dir (env ``JARVIS_CHECKPOINT_DIR`` or
     ``<base>/.ouroboros/checkpoints``). Created on demand. NEVER raises."""
@@ -215,7 +273,11 @@ def list_pending(*, base_dir: "Optional[str]" = None) -> List[FSMCheckpoint]:
                         "(corrupt/tampered/unsigned) -> clean boot for this op", n,
                     )
                     continue
-                out.append(FSMCheckpoint.from_json(payload_json))
+                _cp = FSMCheckpoint.from_json(payload_json)
+                # Atomic Hydration Handshake (facet 1): positive proof the signature
+                # verified -- symmetric with the REJECT log above, forced to stdout.
+                emit_handshake(format_verified_handshake(_cp.op_id, _cp.phase, sig or ""))
+                out.append(_cp)
             except Exception:  # noqa: BLE001
                 logger.warning("[fsm_checkpoint] REJECT %s -- unreadable -> clean boot", n)
                 continue

--- a/scripts/prove_cooperative_checkpoint_local.py
+++ b/scripts/prove_cooperative_checkpoint_local.py
@@ -123,15 +123,18 @@ async def _race_and_checkpoint():
     path = ckpt.write_checkpoint(cp)
     coop.reset()
 
+    _hdr("5. Atomic Hydration Handshake (exactly what Window 2 prints)")
+    # list_pending re-verifies HMAC -> emits the crypto handshake to stdout below.
     pend = ckpt.list_pending(base_dir=None)
     mine = [c for c in pend if c.op_id == op_id]
     assert mine, "checkpoint not found on disk / failed HMAC verification"
     got = mine[0]
-    _ok(f"HMAC-signed checkpoint on disk: {path}")
-    _ok(f"read back verified: op_id={got.op_id} phase={got.phase}")
-    _ok(f"partial_completion preserved ({len(got.partial_completion)} chars):")
-    print("       \033[36m" + repr(got.partial_completion) + "\033[0m")
     assert got.partial_completion == partial, "partial mismatch after roundtrip"
+    # The prefill-inject handshake fires when the resume dispatch feeds the partial to
+    # the 32B; emit it here to show the operator the exact bytes + snippet.
+    ckpt.emit_handshake(ckpt.format_prefill_handshake(op_id, got.partial_completion))
+    _ok("both handshake lines emitted above (HMAC-SHA256 VERIFIED + PREFILL-INJECT)")
+    _ok(f"on-disk checkpoint: {path}")
     return path
 
 

--- a/tests/governance/test_hydration_handshake.py
+++ b/tests/governance/test_hydration_handshake.py
@@ -1,0 +1,146 @@
+"""Atomic Hydration Handshake -- strict cross-window observability.
+
+The window-1 (suspend) -> window-2 (resume) transition must be cryptographically
+LEGIBLE, never silent. Proves:
+  1. list_pending emits a POSITIVE "HMAC-SHA256 VERIFIED" handshake (op + digest) when
+     a checkpoint's signature verifies -- symmetric with the existing REJECT log.
+  2. The handshake is forced to BOTH the logger (debug.log) AND stdout (operator console).
+  3. The prefill-injection handshake reports the EXACT byte-length + a repr snippet of
+     the partial_completion being injected into the LLM as the assistant prefill.
+  4. End-to-end: a resume dispatch (partial rides in intake evidence) emits the
+     prefill-injection handshake with the right bytes + snippet.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import logging
+
+import pytest
+
+import backend.core.ouroboros.governance.fsm_checkpoint as ckpt
+
+
+# --- 1+2. crypto verification handshake -> logger + stdout ------------------
+
+def test_list_pending_emits_hmac_verified_handshake(tmp_path, monkeypatch, caplog, capsys):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "handshake-secret")
+    cp = ckpt.FSMCheckpoint(op_id="op-hs-1", phase="GENERATE",
+                            partial_completion="def f(): pass")
+    assert ckpt.write_checkpoint(cp)
+
+    with caplog.at_level(logging.INFO):
+        pend = ckpt.list_pending(base_dir=None)
+    assert any(c.op_id == "op-hs-1" for c in pend)
+
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "HMAC-SHA256 VERIFIED" in logged
+    assert "op-hs-1" in logged
+    assert "digest=" in logged                       # the verified signature prefix
+    # forced to stdout too (operator console), not just the log file
+    assert "HMAC-SHA256 VERIFIED" in capsys.readouterr().out
+
+
+def test_rejected_checkpoint_emits_no_verified_handshake(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "handshake-secret")
+    cp = ckpt.FSMCheckpoint(op_id="op-hs-bad", phase="GENERATE", partial_completion="x")
+    assert ckpt.write_checkpoint(cp)
+    # Tamper: flip the secret so the HMAC no longer verifies.
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "different-secret")
+    with caplog.at_level(logging.INFO):
+        pend = ckpt.list_pending(base_dir=None)
+    assert pend == []                                # fail-closed
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "HMAC-SHA256 VERIFIED" not in logged      # no false handshake on reject
+    assert "REJECT" in logged
+
+
+# --- 3. prefill-injection handshake: exact bytes + snippet ------------------
+
+def test_format_prefill_handshake_reports_bytes_and_snippet():
+    partial = "def solve(x):\n    return x"
+    line = ckpt.format_prefill_handshake("op-pi", partial)
+    assert "PREFILL-INJECT" in line
+    assert "op-pi" in line
+    assert "partial_bytes=%d" % len(partial.encode("utf-8")) in line
+    assert "partial_chars=%d" % len(partial) in line
+    assert repr(partial) in line                     # exact snippet (short -> full repr)
+
+
+def test_format_prefill_handshake_truncates_long_partial_exactly():
+    partial = "A" * 400
+    line = ckpt.format_prefill_handshake("op-long", partial)
+    assert "partial_bytes=400" in line
+    assert " … " in line                             # head … tail elision
+    assert repr("A" * 48) in line                    # exact head preserved
+
+
+def test_multibyte_partial_bytes_not_chars():
+    partial = "café — 日本語"                         # multibyte: bytes != chars
+    line = ckpt.format_prefill_handshake("op-mb", partial)
+    b = len(partial.encode("utf-8"))
+    assert "partial_bytes=%d" % b in line
+    assert "partial_chars=%d" % len(partial) in line
+    assert b != len(partial)                          # sanity: they genuinely differ
+
+
+# --- 4. end-to-end: resume dispatch emits the prefill handshake -------------
+
+def test_resume_dispatch_emits_prefill_handshake(tmp_path, monkeypatch, caplog, capsys):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "hs")
+    import json
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    import backend.core.ouroboros.governance.local_inference_director as lidmod
+    import backend.core.ouroboros.governance.providers as provmod
+    from types import SimpleNamespace
+    import datetime as _dt
+
+    partial = "def resumed():\n    # continue here"
+
+    class _FakeClient:
+        def __init__(self, cfg, session=None, profiler=None):
+            self._resume_prefill = ""
+        async def warmup(self, *, timeout_s):
+            return True
+        async def aclose(self):
+            pass
+
+    class _FakeProvider:
+        def __init__(self, client, repo_root=None):
+            self._client = client
+        async def generate(self, context, deadline):
+            # Prove the prefill actually reached the client.
+            assert self._client._resume_prefill == partial
+            return SimpleNamespace(candidates=("ok",))
+
+    monkeypatch.setattr(lidmod, "LocalPrimeClient", _FakeClient)
+    monkeypatch.setattr(provmod, "PrimeProvider", _FakeProvider)
+
+    class _Stub:
+        _repo_root = None
+        def _remaining_seconds(self, dl):
+            return 60.0
+        async def _resolve_dispatch_model_name(self, ep):
+            return "qwen2.5-coder:32b"
+        async def _negotiate_num_ctx(self, ep):
+            return 8192
+        def _failover_profiler_for(self, ep, cfg):
+            return lidmod.LatencyProfiler(cfg)
+
+    dl = _dt.datetime.now(_dt.timezone.utc) + _dt.timedelta(seconds=60)
+    ctx = SimpleNamespace(
+        op_id="op-resume", phase="GENERATE", description="resume",
+        target_files=("m.py",), provider_route="standard",
+        intake_evidence_json=json.dumps({"partial_completion": partial}),
+    )
+    with caplog.at_level(logging.INFO):
+        asyncio.run(cg.CandidateGenerator._failover_local_dispatch(
+            _Stub(), ctx, dl, "http://n:11434"))
+
+    out = caplog.text + capsys.readouterr().out
+    assert "PREFILL-INJECT" in out
+    assert "op-resume" in out
+    assert "partial_bytes=%d" % len(partial.encode("utf-8")) in out


### PR DESCRIPTION
## What

The window-1 (suspend) → window-2 (resume) transition must be **cryptographically legible**, never silent. Adds a two-facet handshake, both forced to **both** the logger (debug.log, greppable) *and* stdout (operator console) via a single `emit_handshake()` mirroring the streaming token emitter's stdout discipline.

### Facet 1 — `HMAC-SHA256 VERIFIED`
`list_pending` emits a **positive** handshake with `op_id` + verified digest prefix the moment a checkpoint signature verifies — symmetric with the existing REJECT log. No false handshake on a tampered/unsigned checkpoint (fail-closed).

### Facet 2 — `PREFILL-INJECT`
At the resume dispatch's prefill-injection site (`candidate_generator._failover_local_dispatch`), the handshake prints the **exact** byte-length + char-length + a `repr` snippet of the `partial_completion` re-entering the LLM as the assistant prefill. `bytes != chars` is reported honestly for multibyte partials; long partials get an unambiguous head…tail `repr` elision.

Pure formatters (`format_verified_handshake` / `format_prefill_handshake` / `_handshake_snippet`) live in `fsm_checkpoint` (owner of the crypto + resume envelope) — one source of truth for the format, independently testable, no hardcoding.

## Sample output (from the local proof driver, exactly what Window 2 prints)
```
[HYDRATION-HANDSHAKE] HMAC-SHA256 VERIFIED op=… phase=GENERATE digest=46dc462f44603d14… -> checkpoint AUTHENTIC (fail-closed crypto gate passed)
[HYDRATION-HANDSHAKE] PREFILL-INJECT op=… partial_bytes=42 partial_chars=42 snippet='def solve(x):\n    # begin real 32B thought' -> injected as assistant prefill (32B continues the thought)
```

## Proof
- **TDD**: `tests/governance/test_hydration_handshake.py` (6 tests, RED confirmed first — includes a tamper test proving no false-positive handshake, and a multibyte test proving bytes≠chars).
- **Regression**: 139 tests green across handshake/checkpoint/dispatch/streaming/cooperative suites.
- `scripts/prove_cooperative_checkpoint_local.py` now prints both handshake lines.

## Next
Fire the live two-window cloud soak — Window 2 will now emit this handshake on resume.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an atomic hydration handshake so suspend → resume is always visible and verifiable. Emits clear lines to both the logger and stdout to prove checkpoint authenticity and the exact prefill sent back to the model.

- **New Features**
  - Added `fsm_checkpoint.emit_handshake` and formatters to emit one consistent line to logger and stdout.
  - `fsm_checkpoint.list_pending` now emits “HMAC-SHA256 VERIFIED op=… digest=…” on successful verification; nothing emits on rejects (fail-closed).
  - `candidate_generator._failover_local_dispatch` now emits “PREFILL-INJECT” with byte count, char count, and a repr snippet of the partial prefill (accurate for multibyte; long text uses head…tail).
  - Added tests for verification, no false-positive on tamper, multibyte lengths, and end-to-end resume emission; updated `scripts/prove_cooperative_checkpoint_local.py` to print both handshake lines.

<sup>Written for commit dc606415d7aac11cca848ffd99e494f2d3b1db78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

