### PR TITLE
fix(a1): race response-begin await + register pool ops in the in-flight registry

### DIFF
--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -1047,6 +1047,33 @@ class BackgroundAgentPool:
                             worker_id, _ctx_op_id, _exc,
                         )
 
+                # Suspend gap 6b -- mirror the op into the typed in-flight
+                # registry (master-gated, silent no-op when off) so a graceful
+                # shutdown's capture_inflight() can checkpoint POOL ops too.
+                # Registration previously existed only on the direct
+                # GovernedLoopService.submit() path; a SIGTERM mid-soak saw an
+                # EMPTY registry and wrote 0 checkpoints despite 3 in-flight
+                # pool ops (bt-iso-1782942507). Symmetric unregister in the
+                # finally below.
+                _inflight_registered = False
+                try:
+                    from backend.core.ouroboros.governance.in_flight_registry import (  # noqa: PLC0415,E501
+                        register_op_safely as _reg_op_safely,
+                    )
+                    _inflight_registered = _reg_op_safely(
+                        _ctx_op_id or op.op_id,
+                        ctx_ref=op.context,
+                        last_phase_name=getattr(
+                            getattr(op.context, "phase", None), "name", "",
+                        ),
+                        metadata={
+                            "pool_worker": worker_id,
+                            "pool_op_id": str(op.op_id),
+                        },
+                    )
+                except Exception:  # noqa: BLE001 -- registry is observability, never blocks pickup
+                    _inflight_registered = False
+
                 try:
                     # Phase 1 Step 3C: § 4 bind contract dispatch. Read
                     # the live orchestrator from the process-wide bind
@@ -1385,6 +1412,18 @@ class BackgroundAgentPool:
                                 "failed for %s: %s",
                                 worker_id, _registered_ctx_op_id, _exc,
                             )
+                    # Suspend gap 6b cleanup -- symmetric with the in-flight
+                    # registry registration above. Unconditional on terminal
+                    # AND parked/preempted exits (a resumed dispatch
+                    # re-registers on its next worker pickup).
+                    if _inflight_registered:
+                        try:
+                            from backend.core.ouroboros.governance.in_flight_registry import (  # noqa: PLC0415,E501
+                                unregister_op_safely as _unreg_op_safely,
+                            )
+                            _unreg_op_safely(_ctx_op_id or op.op_id)
+                        except Exception:  # noqa: BLE001 -- never leak the worker
+                            pass
 
         except asyncio.CancelledError:
             logger.debug("Worker %d shutting down (cancelled)", worker_id)

--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -317,6 +317,15 @@ def capture_inflight(*, base_dir: "Optional[str]" = None, reason: str = "wall_cl
                 continue
     except Exception:  # noqa: BLE001
         pass
+    if n == 0:
+        # A suspend that captures NOTHING must say so -- a silent 0 here cost a
+        # full cloud window to diagnose (bt-iso-1782942507: SIGTERM landed, the
+        # registry was empty because pool ops never registered, and this
+        # returned 0 without a trace).
+        logger.warning(
+            "[fsm_checkpoint] capture_inflight captured 0 op(s) (reason=%s) -- "
+            "in-flight registry empty or unavailable; nothing to suspend", reason,
+        )
     return n
 
 

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -666,14 +666,33 @@ class LocalPrimeClient:
                 partial="".join(parts),
             )
 
-        async with sess.post(url, json=body) as resp:
-            reader = resp.content  # aiohttp StreamReader (line-iterable)
-            # Preemptive Asynchronous Race: one long-lived shutdown waiter raced
-            # against each readline. The instant the OS signal fires the event, the
-            # readline task is dropped and we yield the partial to THIS millisecond --
-            # zero-latency, not up to the inter-token window later.
-            _shutdown_task = asyncio.ensure_future(_coop.wait_async())
+        # Preemptive Asynchronous Race, phase 0 (response-begin): the server does
+        # not return response HEADERS until the model prefill completes (1-4 min on
+        # a heavy tier), so the ``post`` await is the LONGEST blocking window of a
+        # streaming call. A cooperative shutdown during prefill must freeze NOW with
+        # the prefill-seed partial -- not sit deaf until an outer cancel bypasses the
+        # checkpoint path (live gap bt-iso-1782942507: SIGTERM at 59s into prefill,
+        # tokens=0, no stall -> GSI never raised, 0 checkpoints).
+        _shutdown_task = asyncio.ensure_future(_coop.wait_async())
+        _req_cm = sess.post(url, json=body)
+        try:
+            _enter_task = asyncio.ensure_future(_req_cm.__aenter__())
+            _done_begin, _ = await asyncio.wait(
+                {_enter_task, _shutdown_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if _enter_task not in _done_begin:
+                # Shutdown fired while awaiting response headers (prefill) ->
+                # drop the in-flight request and freeze this millisecond.
+                _enter_task.cancel()
+                raise _freeze()
+            resp = _enter_task.result()  # re-raises genuine request errors faithfully
             try:
+                reader = resp.content  # aiohttp StreamReader (line-iterable)
+                # Phase 1 (chunk loop): the SAME long-lived waiter raced against
+                # each readline. The instant the OS signal fires the event, the
+                # readline task is dropped and we yield the partial to THIS
+                # millisecond -- zero-latency, not up to the inter-token window.
                 while True:
                     if _coop.is_requested():  # cheap fast-path (already requested)
                         raise _freeze()
@@ -713,8 +732,13 @@ class LocalPrimeClient:
                         parts.append(delta)
                         _emit_stream_token(delta)
             finally:
-                if not _shutdown_task.done():
-                    _shutdown_task.cancel()
+                try:
+                    await _req_cm.__aexit__(None, None, None)
+                except BaseException:  # noqa: BLE001 -- release never masks the freeze
+                    pass
+        finally:
+            if not _shutdown_task.done():
+                _shutdown_task.cancel()
         total_ms = (time.monotonic() - t0) * 1000.0
         text = "".join(parts)
         out_toks = max(1, len(text) // 4)

--- a/tests/governance/test_bg_pool_inflight_registration.py
+++ b/tests/governance/test_bg_pool_inflight_registration.py
@@ -1,0 +1,126 @@
+"""BackgroundAgentPool ops must be visible to the in-flight registry (suspend gap 6b).
+
+Live evidence (bt-iso-1782942507): SIGTERM's ``capture_inflight()`` wrote 0 checkpoints
+despite 3 in-flight pool ops -- registration only exists on the direct
+``GovernedLoopService.submit()`` path (line ~3176), but the soak's autonomous ops all
+execute via ``BackgroundAgentPool._worker_loop -> orchestrator.run()`` which never
+registers. The registry was empty, and capture_inflight's zero was SILENT.
+
+Proves: (1) a pool worker registers its op in the in-flight registry for the duration
+of orchestrator.run() and unregisters after; (2) capture_inflight() checkpoints a
+mid-run pool op; (3) a zero-capture logs loudly instead of silently returning 0.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, cast
+
+import pytest
+
+import backend.core.ouroboros.governance.fsm_checkpoint as ckpt
+from backend.core.ouroboros.governance.background_agent_pool import (
+    BackgroundAgentPool,
+)
+from backend.core.ouroboros.governance.in_flight_registry import (
+    get_default_registry,
+    reset_default_registry,
+)
+
+_MASTER_FLAG = "JARVIS_IN_FLIGHT_REGISTRY_ENABLED"
+
+
+@dataclass
+class _FakeOpContext:
+    op_id: str
+    goal: str = "fake"
+    provider_route: str = "background"
+    description: str = "pool op under suspend test"
+    target_files: List[str] = field(default_factory=lambda: ["a.py"])
+
+
+class _FakeOrchestrator:
+    def __init__(self) -> None:
+        self.started: List[str] = []
+        self.completed: List[str] = []
+        self.hold_event: Optional[asyncio.Event] = None
+
+    async def run(self, ctx: _FakeOpContext) -> Any:
+        self.started.append(ctx.op_id)
+        if self.hold_event is not None:
+            await self.hold_event.wait()
+        self.completed.append(ctx.op_id)
+        return ctx
+
+
+async def _wait_until(pred, timeout_s: float = 2.0) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while asyncio.get_event_loop().time() < deadline:
+        if pred():
+            return True
+        await asyncio.sleep(0.01)
+    return pred()
+
+
+@pytest.fixture
+def armed_registry(monkeypatch):
+    monkeypatch.setenv(_MASTER_FLAG, "true")
+    reset_default_registry()
+    yield
+    reset_default_registry()
+
+
+def _registry_op_ids() -> List[str]:
+    return [str(getattr(r, "op_id", "")) for r in get_default_registry().snapshot()]
+
+
+class TestPoolInFlightRegistration:
+    async def test_worker_registers_op_while_running(self, armed_registry):
+        orch = _FakeOrchestrator()
+        orch.hold_event = asyncio.Event()
+        pool = BackgroundAgentPool(orchestrator=cast(Any, orch), pool_size=1, queue_size=4)
+        await pool.start()
+        try:
+            await pool.submit(cast(Any, _FakeOpContext(op_id="op-suspend-6b")))
+            assert await _wait_until(lambda: orch.started)
+            assert "op-suspend-6b" in _registry_op_ids()
+        finally:
+            orch.hold_event.set()
+            await pool.stop()
+
+    async def test_capture_inflight_checkpoints_running_pool_op(self, armed_registry, tmp_path):
+        orch = _FakeOrchestrator()
+        orch.hold_event = asyncio.Event()
+        pool = BackgroundAgentPool(orchestrator=cast(Any, orch), pool_size=1, queue_size=4)
+        await pool.start()
+        try:
+            await pool.submit(cast(Any, _FakeOpContext(op_id="op-suspend-ckpt")))
+            assert await _wait_until(lambda: orch.started)
+            n = ckpt.capture_inflight(base_dir=str(tmp_path), reason="sigterm")
+            assert n == 1
+            assert (tmp_path / ".ouroboros" / "checkpoints" / "op-suspend-ckpt.json").exists()
+        finally:
+            orch.hold_event.set()
+            await pool.stop()
+
+    async def test_worker_unregisters_after_completion(self, armed_registry):
+        orch = _FakeOrchestrator()
+        pool = BackgroundAgentPool(orchestrator=cast(Any, orch), pool_size=1, queue_size=4)
+        await pool.start()
+        try:
+            await pool.submit(cast(Any, _FakeOpContext(op_id="op-suspend-done")))
+            assert await _wait_until(lambda: orch.completed)
+            assert await _wait_until(lambda: "op-suspend-done" not in _registry_op_ids())
+        finally:
+            await pool.stop()
+
+
+class TestCaptureInflightZeroIsLoud:
+    def test_zero_capture_logs_warning(self, armed_registry, tmp_path, caplog):
+        """A suspend that captures NOTHING must say so -- the live run's silent 0 cost
+        a full cloud window to diagnose ([[feedback_observability_over_silent_reroute]])."""
+        with caplog.at_level(logging.WARNING):
+            n = ckpt.capture_inflight(base_dir=str(tmp_path), reason="sigterm")
+        assert n == 0
+        assert any("captured 0" in r.getMessage() for r in caplog.records)

--- a/tests/governance/test_response_begin_race.py
+++ b/tests/governance/test_response_begin_race.py
@@ -1,0 +1,107 @@
+"""Response-begin cooperative race — the 6th live integration gap (Window-1 SIGTERM run).
+
+Live evidence (bt-iso-1782942507): a SIGTERM landed 59s into a streaming op that had
+tokens=0 / first_token_ms=-1 and NO InterTokenStall — i.e. the coroutine was parked
+inside ``sess.post(...)`` awaiting response HEADERS (ollama holds them through the
+entire 1-4min L4 prefill), which is OUTSIDE the readline race added by PR #69809.
+cooperative_shutdown fired, nobody was listening, and 3s later the pool cancel killed
+the task -> GracefulStreamInterruption never raised -> 0 checkpoints.
+
+Proves: the cooperative race must cover the response-begin await too, so a freeze
+during prefill yields instantly with the prefill-seed partial.
+"""
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+import time
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+import backend.core.ouroboros.governance.cooperative_shutdown as coop
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+class _StalledEnterCM:
+    """Response headers never arrive -- simulates ollama holding the HTTP response
+    open through the entire model prefill (the live-observed 1-4min window)."""
+
+    def __init__(self):
+        self.exited = False
+
+    async def __aenter__(self):
+        await asyncio.sleep(9999)
+        raise AssertionError("unreachable")
+
+    async def __aexit__(self, *a):
+        self.exited = True
+        return False
+
+
+class _FailingEnterCM:
+    """Request fails at response-begin -- the faithful-propagation pin."""
+
+    async def __aenter__(self):
+        raise ConnectionResetError("boom at response-begin")
+
+    async def __aexit__(self, *a):
+        return False
+
+
+class _Sess:
+    def __init__(self, cm):
+        self._cm = cm
+        self.posted = []
+
+    def post(self, url, **kw):
+        self.posted.append(kw)
+        return self._cm
+
+    async def close(self):
+        pass
+
+
+def test_shutdown_during_response_begin_freezes_instantly():
+    """Cooperative shutdown fired while awaiting response headers (prefill window)
+    must raise GracefulStreamInterruption within ~2s carrying the prefill partial --
+    NOT hang until an outer cancel bypasses the checkpoint path."""
+    coop.reset()
+    cm = _StalledEnterCM()
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(cm))
+
+    async def _run():
+        async def _fire():
+            await asyncio.sleep(0.2)
+            coop.request("sigterm")
+
+        asyncio.ensure_future(_fire())
+        start = time.monotonic()
+        with pytest.raises(lid.GracefulStreamInterruption) as ei:
+            await asyncio.wait_for(
+                client.complete(system="s", user="u", prompt_tokens=10,
+                                stream=True, prefill="partial so far"),
+                timeout=5.0,
+            )
+        elapsed = time.monotonic() - start
+        assert elapsed < 2.0, "freeze must be preemptive (ms), got %.1fs" % elapsed
+        assert ei.value.partial == "partial so far"
+
+    asyncio.run(_run())
+
+
+def test_response_begin_error_still_propagates_faithfully():
+    """No-shutdown path: a genuine request failure at response-begin propagates
+    unchanged (the race must not swallow or reclassify real errors)."""
+    coop.reset()
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_FailingEnterCM()))
+
+    async def _run():
+        with pytest.raises(ConnectionResetError):
+            await client.complete(system="s", user="u", prompt_tokens=10,
+                                  stream=True)
+
+    asyncio.run(_run())


### PR DESCRIPTION
## The 6th live suspend gap — diagnosed with SIGTERM-time evidence, fixed with TDD

Window-1 run `bt-iso-1782942507` (2026-07-01): watchdog SIGTERMed the organism 50s into a live 32B streaming op. The handler ran (`ShutdownWatchdog ARMED reason='sigterm'`), cooperative fired — **0 checkpoints, no GSI, no freeze lines**. Two independent holes:

### 1. Un-raced response-begin await (`local_inference_director.py`)
The PR #69809 cooperative race covered only the chunk-read loop; `async with sess.post(...)` awaits response HEADERS un-raced — and ollama holds headers through the entire 1–4 min L4 prefill. Live proof: `tokens=0 / first_token_ms=-1` at 59s with **no InterTokenStall** (the 30s stall guard lives inside the read loop → the coroutine never reached it). The SIGTERM landed exactly in that deaf window; 3s later `_bg_pool.stop()` cancelled the task, bypassing the checkpoint path.

**Fix:** the shutdown waiter starts BEFORE the request and races `__aenter__` (response-begin), then each `readline` as before. A freeze during prefill raises `GracefulStreamInterruption` immediately with the prefill-seed partial. Genuine request errors propagate unchanged (pinned by test).

### 2. Pool ops invisible to `capture_inflight()` (`background_agent_pool.py`)
Registry registration existed only on the direct `GovernedLoopService.submit()` path (line ~3176) — but every autonomous soak op executes via `BackgroundAgentPool._worker_loop → orchestrator.run()` directly. The registry was empty at suspend time. The worker now mirrors its existing Move-2-v5 register/unregister pattern into the typed in-flight registry (master-gated, fail-soft, symmetric `finally` cleanup).

### 3. Loud zero (`fsm_checkpoint.py`)
`capture_inflight()` returning 0 was silent — it cost a full cloud window to diagnose. Now logs a WARNING with the reason.

## Proof
- TDD: 6 new tests, RED confirmed first (race test hung to `wait_for` timeout — the live hang exactly; registry asserts saw `[]`).
- 177 sibling regression green (streaming, cooperative interrupt, inter-token, in-flight registry, bg-pool suites, heartbeat/checkpoint, hydration handshake).
- `scripts/prove_cooperative_checkpoint_local.py`: ALL PASSED (GSI in 201ms, buffer preserved, signed checkpoint, both handshake lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a suspend gap where SIGTERM during model prefill left streaming requests deaf and produced 0 checkpoints. Ensures graceful freezes with partials and makes pool ops visible to `capture_inflight()`.

- **Bug Fixes**
  - Race response-begin await in `local_inference_director`: start shutdown waiter before `sess.post(...)`, race `__aenter__`, and freeze immediately with the prefill partial on shutdown; real request errors still propagate.
  - Register pool ops in the in‑flight registry in `background_agent_pool._worker_loop`: master‑gated safe register/unregister so `capture_inflight()` can checkpoint running pool ops.
  - Warn on zero captures in `fsm_checkpoint`: `capture_inflight()` logs a WARNING when it writes 0 checkpoints.

<sup>Written for commit a790baac102038a17ae1983133c9ade6cb0997a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

