### PR TITLE
feat(a1): distributed trace lineage + activity-gated audit deferral + FSM-aware timebox

### DIFF
--- a/backend/core/ouroboros/governance/a1_trace.py
+++ b/backend/core/ouroboros/governance/a1_trace.py
@@ -25,7 +25,7 @@ import collections
 import logging
 import os
 import time
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 logger = logging.getLogger(__name__)
 
@@ -106,6 +106,51 @@ def emit_probe(goal_id: Any, *, source: str = "?") -> None:
             "[A1Trace][emit-probe] EMIT goal=%s source=%s emit_ts=%.6f "
             "orchestrator_enabled=%s",
             gid, source, ts, orch,
+        )
+    except Exception:  # noqa: BLE001 — a probe must never break a hop
+        pass
+
+
+def get_emit_record(goal_id: Any) -> "Optional[tuple]":
+    """Read the ``(emit_ts_monotonic, source)`` record for *goal_id* from the
+    emit ledger -- ``None`` when absent. Read-only, NEVER raises. Consumed by
+    the FSM checkpoint layer to serialize Distributed Trace Lineage."""
+    try:
+        return _emit_ledger.get(str(goal_id))
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def restore_emit_record(goal_id: Any, *, source: str,
+                        original_emit_wall: "Optional[float]" = None) -> None:
+    """Distributed Trace Lineage: re-establish the emit hop from HMAC-verified
+    checkpoint lineage after a cross-window suspend/resume.
+
+    The original emit fired in a PRIOR process whose monotonic clock is
+    meaningless here, so the ledger is re-seeded with a FRESH monotonic stamp
+    taken NOW -- hydration runs BEFORE ingest, so ``emit_ts <= ingest_ts``
+    genuinely holds in this process and the probe reports ``ordered=True``
+    honestly. The hop line carries ``lineage=resumed`` (+ the original
+    wall-clock ts when known) so the census entry is an ATTESTATION of
+    verified window-1 evidence, never a fabrication. Observe-only, fail-soft.
+    """
+    if not emit_probe_enabled():
+        return
+    try:
+        gid = str(goal_id)
+        ts = time.monotonic()
+        _emit_ledger[gid] = (ts, source)
+        _emit_ledger.move_to_end(gid)
+        while len(_emit_ledger) > _EMIT_LEDGER_MAX:
+            _emit_ledger.popitem(last=False)
+        # The hop-census line (auditor's _A1TRACE_RE) -- lineage-tagged.
+        a1trace("emit", gid, source=source, lineage="resumed",
+                original_emit_wall=original_emit_wall)
+        # The origin-witness probe line (auditor's _EMIT_PROBE_SOURCE_RE).
+        logger.warning(
+            "[A1Trace][emit-probe] EMIT goal=%s source=%s emit_ts=%.6f "
+            "orchestrator_enabled=%s lineage=resumed",
+            gid, source, ts, _roadmap_enabled_repr(),
         )
     except Exception:  # noqa: BLE001 — a probe must never break a hop
         pass

--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -1276,9 +1276,43 @@ class BackgroundAgentPool:
                             _target_file_count, _is_read_only,
                             _op_timeout_base_s,
                         )
-                    result = await asyncio.wait_for(
-                        _orch.run(op.context), timeout=_op_timeout_s,
-                    )
+                    # Dynamic FSM-Aware Timeboxing: the ceiling is enforced in
+                    # slices around a shielded task. At each expiry the LIVE
+                    # failover FSM is consulted (_fsm_timebox_extension_s) --
+                    # engaged lifecycle (zone hunt / heavy streaming) grants a
+                    # bounded extension; DORMANT kills exactly like the legacy
+                    # single wait_for (cancel + TimeoutError to the handler).
+                    _run_task = asyncio.ensure_future(_orch.run(op.context))
+                    _fsm_granted_s = 0.0
+                    _next_timeout_s = _op_timeout_s
+                    try:
+                        while True:
+                            try:
+                                result = await asyncio.wait_for(
+                                    asyncio.shield(_run_task),
+                                    timeout=_next_timeout_s,
+                                )
+                                break
+                            except asyncio.TimeoutError:
+                                _ext_s = _fsm_timebox_extension_s(_fsm_granted_s)
+                                if _ext_s <= 0.0:
+                                    _run_task.cancel()
+                                    try:
+                                        await _run_task
+                                    except BaseException:  # noqa: BLE001 -- drain the cancel
+                                        pass
+                                    raise
+                                _fsm_granted_s += _ext_s
+                                _next_timeout_s = _ext_s
+                                logger.info(
+                                    "Worker %d: %s bg_timebox reached but failover "
+                                    "FSM engaged (cold-start/heavy path) -- extending "
+                                    "%.0fs (granted %.0fs total)",
+                                    worker_id, op.op_id, _ext_s, _fsm_granted_s,
+                                )
+                    finally:
+                        if not _run_task.done():
+                            _run_task.cancel()
                     op.result = result
                     op.status = "completed"
                     self._completed_count += 1
@@ -1431,3 +1465,34 @@ class BackgroundAgentPool:
             logger.exception("Worker %d crashed unexpectedly", worker_id)
         finally:
             logger.debug("Worker %d exited", worker_id)
+
+
+def _fsm_timebox_extension_s(already_granted_s: float) -> float:
+    """Dynamic FSM-Aware Timeboxing: at bg_timebox expiry, consult the LIVE
+    failover FSM before killing the op.
+
+    When the lifecycle is engaged (AWAKENING zone-hunt / SERVING slow heavy
+    streaming), the elapsed wall is infrastructure cold-start or heavy-tier
+    inference -- not a wedged op -- so grant a bounded extension slice (env
+    ``JARVIS_BG_WORKER_FSM_EXTENSION_SLICE_S``, default 120) up to a total
+    budget (``JARVIS_BG_WORKER_FSM_EXTENSION_MAX_S``, default 900). DORMANT
+    (normal DW ops) returns 0.0 => byte-identical legacy anti-hang watchdog.
+    Live evidence: bt-iso-1782944904 killed a resumed op at its static 415s
+    ceiling while the FSM was 4 minutes into an AWAKENING zone hunt.
+    Master ``JARVIS_BG_FSM_TIMEBOX_ENABLED`` (default true). NEVER raises."""
+    try:
+        if (os.environ.get("JARVIS_BG_FSM_TIMEBOX_ENABLED", "true") or "").strip().lower() \
+                in ("0", "false", "no", "off"):
+            return 0.0
+        max_total = float(os.environ.get("JARVIS_BG_WORKER_FSM_EXTENSION_MAX_S", "900") or 900)
+        if already_granted_s >= max_total:
+            return 0.0
+        from backend.core.ouroboros.governance import failover_lifecycle as _fl  # noqa: PLC0415
+        if not _fl.lifecycle_enabled():
+            return 0.0
+        if _fl.get_failover_controller().state == _fl.FailoverState.DORMANT:
+            return 0.0
+        slice_s = float(os.environ.get("JARVIS_BG_WORKER_FSM_EXTENSION_SLICE_S", "120") or 120)
+        return max(0.0, min(slice_s, max_total - already_granted_s))
+    except Exception:  # noqa: BLE001 -- the watchdog must never break on a probe
+        return 0.0

--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -166,6 +166,11 @@ class FSMCheckpoint:
     # stream was cooperatively interrupted (may be half a tool call / code block).
     # Window-2 resume prefills this so the model continues from the interrupted char.
     partial_completion: str = ""
+    # Distributed Trace Lineage -- the op's span identity across windows:
+    # origin_goal_id (the window-1 causal_id), origin_source (roadmap/sensor/...),
+    # emit_source + emit_wall_ts (the original emit hop evidence), resume_count.
+    # Rides INSIDE the HMAC-signed payload => tamper-evident nametag.
+    trace_lineage: Dict[str, Any] = field(default_factory=dict)
     created_at: float = 0.0
     resume_reason: str = ""
     schema_version: int = _SCHEMA_VERSION
@@ -205,6 +210,48 @@ def pop_partial(op_id: str) -> str:
         return ""
 
 
+def _build_trace_lineage(context: Any, op_id: str) -> Dict[str, Any]:
+    """Distributed Trace Lineage: mint (or carry forward) the op's span identity.
+
+    A RESUMED op's ORIGINAL lineage (window 1) rides in its intake evidence --
+    preserve it verbatim except the resume counter, so window N+2 still points
+    at window 1's identity. Otherwise mint fresh from this context + the live
+    a1_trace emit ledger (the original emit evidence, wall-clock-translated so
+    it stays meaningful across processes). NEVER raises."""
+    try:
+        prior: Dict[str, Any] = {}
+        try:
+            _ev = json.loads(getattr(context, "intake_evidence_json", "") or "{}")
+            _cand = _ev.get("trace_lineage") or {}
+            if isinstance(_cand, dict) and _cand.get("origin_goal_id"):
+                prior = dict(_cand)
+        except Exception:  # noqa: BLE001
+            prior = {}
+        if prior:
+            prior["resume_count"] = int(prior.get("resume_count", 0) or 0) + 1
+            return prior
+        lineage: Dict[str, Any] = {
+            "origin_goal_id": op_id,
+            "origin_source": str(getattr(context, "signal_source", "") or ""),
+            "resume_count": 1,
+        }
+        try:
+            from backend.core.ouroboros.governance import a1_trace as _a1t  # noqa: PLC0415
+            _rec = _a1t.get_emit_record(op_id)
+            if _rec is not None:
+                _emit_mono, _emit_src = _rec
+                lineage["emit_source"] = str(_emit_src)
+                # Translate the process-local monotonic stamp to wall-clock so
+                # the evidence survives the process boundary.
+                lineage["emit_wall_ts"] = time.time() - max(
+                    0.0, time.monotonic() - float(_emit_mono))
+        except Exception:  # noqa: BLE001
+            pass
+        return lineage
+    except Exception:  # noqa: BLE001
+        return {}
+
+
 def capture_from_context(context: Any, *, phase: str, tool_history: "Optional[List[Dict[str, Any]]]" = None,
                          exploration_records: "Optional[List[Dict[str, Any]]]" = None,
                          resume_reason: str = "wall_clock_cap") -> "Optional[FSMCheckpoint]":
@@ -225,6 +272,7 @@ def capture_from_context(context: Any, *, phase: str, tool_history: "Optional[Li
             intake_evidence_json=str(getattr(context, "intake_evidence_json", "") or ""),
             provider_route=str(getattr(context, "provider_route", "") or ""),
             partial_completion=pop_partial(op_id),
+            trace_lineage=_build_trace_lineage(context, op_id),
             created_at=time.time(),
             resume_reason=str(resume_reason),
         )
@@ -347,6 +395,7 @@ def build_resume_envelope(cp: FSMCheckpoint) -> Dict[str, Any]:
         "intake_evidence_json": cp.intake_evidence_json,
         "provider_route": cp.provider_route,
         "partial_completion": cp.partial_completion,
+        "trace_lineage": dict(cp.trace_lineage or {}),
     }
 
 

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -952,38 +952,28 @@ class UnifiedIntakeRouter:
             )
 
             async def _reinject(env: "Dict[str, Any]") -> None:
-                import json as _rj  # noqa: PLC0415
-                _tf = tuple(env.get("target_files") or ())
-                # Embed the partial thought + resume markers into intake_evidence_json
-                # (the string the GENERATE dispatch parses) so the prefill re-ignition
-                # reaches the LLM request -- the model continues from the exact char.
-                _ev_json = _rj.dumps({
-                    "resume": True,
-                    "resume_phase": env.get("resume_phase", ""),
-                    "partial_completion": env.get("partial_completion", ""),
-                    "resumed_op_id": env.get("op_id", ""),
-                })
-                _ev = {
-                    "resume": True,
-                    "resume_phase": env.get("resume_phase", ""),
-                    "partial_completion": env.get("partial_completion", ""),
-                    "resumed_op_id": env.get("op_id", ""),
-                    "tool_history": env.get("tool_history") or [],
-                    "exploration_records": env.get("exploration_records") or [],
-                    "intake_evidence_json": _ev_json,
-                    "signature": "fsm_resume:%s" % (env.get("op_id", "")),
-                }
-                envelope = _make_env(
-                    source="fsm_resume",
-                    description=env.get("description") or "resume suspended op",
-                    target_files=_tf,
-                    repo=os.environ.get("JARVIS_REPO_ROOT", "."),
-                    confidence=1.0,
-                    urgency="high",
-                    evidence=_ev,
-                    requires_human_ack=False,
-                    routing_override=(env.get("provider_route") or ""),
-                )
+                # Distributed Trace Lineage: the kwargs reuse the ORIGINAL
+                # causal_id + carry the verified lineage; the partial thought
+                # + resume markers ride intake_evidence_json so the prefill
+                # re-ignition reaches the LLM (model continues the exact char).
+                _kw = _resume_envelope_kwargs(env)
+                _lin = _kw["evidence"].get("trace_lineage") or {}
+                if _lin.get("emit_source"):
+                    # Re-establish the window-1 emit hop from HMAC-verified
+                    # lineage BEFORE ingest, so the chain stays ordered in
+                    # THIS window's ledger + log (span continuation).
+                    try:
+                        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                            a1_trace as _a1t,
+                        )
+                        _a1t.restore_emit_record(
+                            _kw["causal_id"],
+                            source=str(_lin["emit_source"]),
+                            original_emit_wall=_lin.get("emit_wall_ts"),
+                        )
+                    except Exception:  # noqa: BLE001 -- lineage is observability
+                        pass
+                envelope = _make_env(**_kw)
                 await self.ingest(envelope)
 
             # hydrate_pending_checkpoints wants a sync ingest_fn; bridge to async by
@@ -1062,7 +1052,9 @@ class UnifiedIntakeRouter:
             from backend.core.ouroboros.governance.provenance_ledger import (  # noqa: PLC0415
                 stamp_provenance as _stamp_provenance,
             )
-            _stamp_provenance(envelope.causal_id, envelope.source)
+            # Trace Lineage: a resumed op stamps its ORIGINAL origin (from
+            # HMAC-verified checkpoint lineage), not the resume transport.
+            _stamp_provenance(envelope.causal_id, _provenance_origin_for(envelope))
         except Exception:  # noqa: BLE001
             pass
         # 1. Dedup check
@@ -2337,3 +2329,62 @@ def reset_default_intake_router_for_tests() -> None:
             _DEFAULT_INTAKE_ROUTER = None
     except Exception:  # noqa: BLE001 — defensive
         pass
+
+
+def _resume_envelope_kwargs(env: "Dict[str, Any]") -> "Dict[str, Any]":
+    """Build the ``make_envelope`` kwargs for an FSM-resume re-injection.
+
+    Distributed Trace Lineage: reuse the ORIGINAL causal_id (span continuation
+    -- the resumed op IS the same goal, so the A1Trace chain stays ONE span
+    across windows instead of minting an orphan id the auditor can never
+    verify) and carry the HMAC-verified lineage in the evidence so a further
+    suspension preserves window-1's identity."""
+    import json as _rj  # noqa: PLC0415
+
+    _lineage = dict(env.get("trace_lineage") or {})
+    _ev_json = _rj.dumps({
+        "resume": True,
+        "resume_phase": env.get("resume_phase", ""),
+        "partial_completion": env.get("partial_completion", ""),
+        "resumed_op_id": env.get("op_id", ""),
+        "trace_lineage": _lineage,
+    })
+    _ev = {
+        "resume": True,
+        "resume_phase": env.get("resume_phase", ""),
+        "partial_completion": env.get("partial_completion", ""),
+        "resumed_op_id": env.get("op_id", ""),
+        "tool_history": env.get("tool_history") or [],
+        "exploration_records": env.get("exploration_records") or [],
+        "trace_lineage": _lineage,
+        "intake_evidence_json": _ev_json,
+        "signature": "fsm_resume:%s" % (env.get("op_id", "")),
+    }
+    return {
+        "source": "fsm_resume",
+        "description": env.get("description") or "resume suspended op",
+        "target_files": tuple(env.get("target_files") or ()),
+        "repo": os.environ.get("JARVIS_REPO_ROOT", "."),
+        "confidence": 1.0,
+        "urgency": "high",
+        "evidence": _ev,
+        "requires_human_ack": False,
+        "causal_id": str(_lineage.get("origin_goal_id") or env.get("op_id") or ""),
+        "routing_override": (env.get("provider_route") or ""),
+    }
+
+
+def _provenance_origin_for(envelope: Any) -> str:
+    """Resolve the provenance-stamp origin for an envelope.
+
+    A resumed op's provenance class is a property of the SPAN, not of the
+    resume transport: when HMAC-verified checkpoint lineage carries the
+    original origin (e.g. ``roadmap``), stamp THAT -- so the auditor's
+    origin-driven ``required_hops`` sees the same pipeline it saw in window 1.
+    Falls back to the envelope source. NEVER raises."""
+    try:
+        _lin = (getattr(envelope, "evidence", None) or {}).get("trace_lineage") or {}
+        _orig = str(_lin.get("origin_source") or "").strip()
+        return _orig or str(getattr(envelope, "source", "") or "")
+    except Exception:  # noqa: BLE001
+        return str(getattr(envelope, "source", "") or "")

--- a/scripts/a1_graduation_auditor.py
+++ b/scripts/a1_graduation_auditor.py
@@ -1427,6 +1427,38 @@ async def log_tail_source(
 # ===========================================================================
 
 
+def _audit_defer_enabled() -> bool:
+    """Activity-Gated Audit Deferral master (default ON)."""
+    return (os.environ.get("JARVIS_A1_AUDIT_DEFER_ENABLED", "true") or "").strip().lower() \
+        not in {"0", "false", "no", "off"}
+
+
+def _audit_defer_slice_s() -> float:
+    return float(os.environ.get("JARVIS_A1_AUDIT_DEFER_SLICE_S", "30") or 30)
+
+
+def _audit_defer_absolute_s() -> float:
+    return float(os.environ.get("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", "900") or 900)
+
+
+def default_activity_probe() -> bool:
+    """Cross-process organism-activity probe: reads the stream_heartbeat FILE
+    mirror (env ``JARVIS_STREAM_HEARTBEAT_FILE``, wall-epoch text written by the
+    organism's ``_emit_stream_token`` on every streamed token). Fresh within
+    ``JARVIS_A1_AUDIT_ACTIVITY_WINDOW_S`` (default 90) => ACTIVE. Missing env /
+    file / parse error => inactive (fail-quiet: never blocks a verdict)."""
+    path = (os.environ.get("JARVIS_STREAM_HEARTBEAT_FILE", "") or "").strip()
+    if not path:
+        return False
+    try:
+        with open(path, encoding="utf-8") as fh:
+            ts = float((fh.read() or "").strip() or 0.0)
+    except Exception:  # noqa: BLE001
+        return False
+    window = float(os.environ.get("JARVIS_A1_AUDIT_ACTIVITY_WINDOW_S", "90") or 90)
+    return (time.time() - ts) <= max(0.0, window)
+
+
 async def run_watch(
     auditor: A1GraduationAuditor,
     *,
@@ -1434,6 +1466,7 @@ async def run_watch(
     log_file: Optional[str],
     timeout_s: float,
     log: Callable[[str], None] = print,
+    activity_probe: Optional[Callable[[], bool]] = None,
 ) -> A1Verdict:
     """Run the live audit until A1_DISPATCH_PROVEN, an intervention trip, or a
     timeout. Returns the final verdict. Fail-CLOSED: a GraduationFailedException
@@ -1471,9 +1504,37 @@ async def run_watch(
     async def _deadline() -> None:
         try:
             await asyncio.wait_for(stop.wait(), timeout=timeout_s)
+            return
         except asyncio.TimeoutError:
-            log("[A1Auditor] timeout after %.0fs -- emitting partial verdict" % (timeout_s,))
-            stop.set()
+            pass
+        # Activity-Gated Audit Deferral: never render a blind verdict over a
+        # LIVE organism. On ceiling expiry, consult the activity probe (default:
+        # the stream_heartbeat cross-process file mirror); while the organism is
+        # actively streaming, defer assessment in bounded slices up to the
+        # absolute deferral ceiling. This gates ONLY the assessor's verdict
+        # timing -- the harness wall-clock hard cap stays completely blind
+        # (Slice-47 Watchdog Isolation Invariant) and still backstops the run.
+        if _audit_defer_enabled() and not stop.is_set():
+            _probe = activity_probe if activity_probe is not None else default_activity_probe
+            _absolute = _audit_defer_absolute_s()
+            _deferred = 0.0
+            while not stop.is_set() and _deferred < _absolute:
+                try:
+                    _active = bool(_probe())
+                except Exception:  # noqa: BLE001 -- a probe error never wedges the verdict
+                    _active = False
+                if not _active:
+                    break
+                _slice = min(_audit_defer_slice_s(), _absolute - _deferred)
+                log("[A1Auditor] ceiling reached but organism ACTIVE -- deferring "
+                    "verdict %.0fs (deferred %.0f/%.0fs)" % (_slice, _deferred, _absolute))
+                try:
+                    await asyncio.wait_for(stop.wait(), timeout=_slice)
+                    return  # proven / intervention landed during deferral
+                except asyncio.TimeoutError:
+                    _deferred += _slice
+        log("[A1Auditor] timeout after %.0fs -- emitting partial verdict" % (timeout_s,))
+        stop.set()
 
     deadline_task = asyncio.ensure_future(_deadline())
     tasks.append(deadline_task)

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1024,6 +1024,17 @@ class IsomorphicA1Driver:
                     # registry master flag is off (default). Arm it so in-flight ops
                     # are tracked and thus captured on suspend.
                     env.setdefault("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "true")
+                    # Activity-Gated Audit Deferral: the organism mirrors its
+                    # stream heartbeat to this file on every streamed token; the
+                    # in-process auditor's default_activity_probe reads it
+                    # (cross-process, no new IPC) so the verdict defers while the
+                    # 32B is genuinely mid-thought. Armed in BOTH the organism
+                    # env (writer) and the driver process env (reader).
+                    _hb_file = str(
+                        Path(self.repo_root) / ".ouroboros" / "stream_heartbeat.epoch"
+                    )
+                    env["JARVIS_STREAM_HEARTBEAT_FILE"] = _hb_file
+                    os.environ["JARVIS_STREAM_HEARTBEAT_FILE"] = _hb_file
 
                 # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
                 # (all default OFF in prod; this driver IS the A1 ignition harness).

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -140,6 +140,24 @@ def pytest_report_header(config):
 
 
 @pytest.fixture(autouse=True)
+def _isolate_fsm_checkpoint_dir(tmp_path, monkeypatch):
+    """Point the FSM suspend/resume checkpoint ledger at a per-test tmp dir.
+
+    The REAL ``.ouroboros/checkpoints`` (the CWD-relative default) can hold
+    live PENDING checkpoints between soak windows; any test that starts an
+    intake router would otherwise hydrate + CONSUME them (``mark_resumed``
+    deletes the file) and re-inject heavy resume ops into the test's router --
+    the exact contamination that ate window-2's pending checkpoints and hung
+    the intake suite on 2026-07-01. Tests that need a specific dir still
+    override via their own ``monkeypatch.setenv`` (applied after this
+    autouse fixture).
+    """
+    monkeypatch.setenv(
+        "JARVIS_CHECKPOINT_DIR", str(tmp_path / "_fsm_checkpoints"),
+    )
+
+
+@pytest.fixture(autouse=True)
 async def _cancel_pending_async_tasks():
     """
     Cancel any tasks left pending after each async test completes.

--- a/tests/governance/test_audit_deferral.py
+++ b/tests/governance/test_audit_deferral.py
@@ -1,0 +1,114 @@
+"""Activity-Gated Audit Deferral -- cure the impatient grader.
+
+Live evidence (Window-2, bt-iso-1782944904): `run_watch`'s ceiling expired and the
+partial FAILED verdict was rendered while the resumed ops were actively streaming at
+31% progress on the 32B. The assessor must not render a blind verdict over a live
+organism: on ceiling expiry it consults an activity probe (the stream_heartbeat
+cross-process FILE mirror) and defers assessment in bounded slices, up to an
+absolute deferral ceiling. The harness wall-clock hard cap stays completely blind
+(Slice-47 Watchdog Isolation Invariant) -- this gates only the AUDITOR's verdict.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import pathlib
+import time
+
+import pytest
+
+
+def _load_auditor():
+    import sys
+    p = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "a1_graduation_auditor.py"
+    spec = importlib.util.spec_from_file_location("_aud_defer_test", str(p))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_aud_defer_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture(scope="module")
+def aud_mod():
+    return _load_auditor()
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+def _watch(mod, tmp_path, *, timeout_s, probe, logs):
+    auditor = mod.A1GraduationAuditor(chaos_manifest_path=None)
+    log_file = tmp_path / "debug.log"
+    log_file.write_text("")
+    return mod.run_watch(
+        auditor, base=None, log_file=str(log_file),
+        timeout_s=timeout_s, log=logs.append, activity_probe=probe,
+    )
+
+
+class TestDeferral:
+    def test_defers_while_active_then_concludes(self, aud_mod, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_AUDIT_DEFER_SLICE_S", "0.2")
+        monkeypatch.setenv("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", "10")
+        calls = {"n": 0}
+
+        def probe():
+            calls["n"] += 1
+            return calls["n"] <= 2          # active for two slices, then idle
+
+        logs = []
+        start = time.monotonic()
+        verdict = _run(_watch(aud_mod, tmp_path, timeout_s=0.3, probe=probe, logs=logs))
+        elapsed = time.monotonic() - start
+        assert elapsed >= 0.3 + 2 * 0.2 - 0.05      # ceiling + two deferral slices
+        assert verdict.proven is False
+        assert any("defer" in ln.lower() for ln in logs)
+
+    def test_absolute_ceiling_bounds_deferral(self, aud_mod, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_AUDIT_DEFER_SLICE_S", "0.2")
+        monkeypatch.setenv("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", "0.5")
+        logs = []
+        start = time.monotonic()
+        _run(_watch(aud_mod, tmp_path, timeout_s=0.2, probe=lambda: True, logs=logs))
+        elapsed = time.monotonic() - start
+        assert elapsed < 0.2 + 0.5 + 1.0            # bounded: never runs away
+
+    def test_disabled_master_reverts_to_legacy(self, aud_mod, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_AUDIT_DEFER_ENABLED", "false")
+        monkeypatch.setenv("JARVIS_A1_AUDIT_DEFER_SLICE_S", "5")
+        logs = []
+        start = time.monotonic()
+        _run(_watch(aud_mod, tmp_path, timeout_s=0.2, probe=lambda: True, logs=logs))
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0                        # no deferral: legacy ceiling only
+
+    def test_no_probe_and_no_default_is_legacy(self, aud_mod, tmp_path, monkeypatch):
+        monkeypatch.delenv("JARVIS_STREAM_HEARTBEAT_FILE", raising=False)
+        logs = []
+        start = time.monotonic()
+        _run(_watch(aud_mod, tmp_path, timeout_s=0.2, probe=None, logs=logs))
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0
+
+
+class TestDefaultActivityProbe:
+    def test_fresh_heartbeat_file_is_active(self, aud_mod, tmp_path, monkeypatch):
+        hb = tmp_path / "hb.txt"
+        hb.write_text(str(time.time()))
+        monkeypatch.setenv("JARVIS_STREAM_HEARTBEAT_FILE", str(hb))
+        monkeypatch.setenv("JARVIS_A1_AUDIT_ACTIVITY_WINDOW_S", "90")
+        assert aud_mod.default_activity_probe() is True
+
+    def test_stale_heartbeat_file_is_inactive(self, aud_mod, tmp_path, monkeypatch):
+        hb = tmp_path / "hb.txt"
+        hb.write_text(str(time.time() - 3600))
+        monkeypatch.setenv("JARVIS_STREAM_HEARTBEAT_FILE", str(hb))
+        monkeypatch.setenv("JARVIS_A1_AUDIT_ACTIVITY_WINDOW_S", "90")
+        assert aud_mod.default_activity_probe() is False
+
+    def test_missing_file_or_env_is_inactive(self, aud_mod, tmp_path, monkeypatch):
+        monkeypatch.setenv("JARVIS_STREAM_HEARTBEAT_FILE", str(tmp_path / "nope.txt"))
+        assert aud_mod.default_activity_probe() is False
+        monkeypatch.delenv("JARVIS_STREAM_HEARTBEAT_FILE", raising=False)
+        assert aud_mod.default_activity_probe() is False

--- a/tests/governance/test_bg_pool_fsm_timebox.py
+++ b/tests/governance/test_bg_pool_fsm_timebox.py
@@ -1,0 +1,142 @@
+"""Dynamic FSM-Aware Timeboxing -- the pool ceiling consults the live failover FSM.
+
+Live evidence (Window-2, bt-iso-1782944904): a resumed op was bg_timebox-killed at
+its static 415s ceiling while the failover FSM was mid zone-hunt (4 minutes of
+AWAKENING before SERVING) -- the delay was infrastructure cold-start, not a wedged
+op. At ceiling expiry the worker now consults the LIVE FSM state: when the failover
+lifecycle is engaged (AWAKENING/SERVING -- the slow heavy path), it grants bounded
+extension slices instead of a blind kill. DORMANT (normal DW ops) is byte-identical
+legacy: no extension, anti-hang watchdog intact.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+from typing import Any, List, Optional, cast
+
+import pytest
+
+import backend.core.ouroboros.governance.background_agent_pool as bap
+from backend.core.ouroboros.governance.background_agent_pool import (
+    BackgroundAgentPool,
+)
+
+
+class _StubController:
+    def __init__(self, state):
+        self.state = state
+
+
+@pytest.fixture
+def fsm_state(monkeypatch):
+    """Install a stub failover controller with a settable state."""
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+    holder = {"ctrl": _StubController(fl.FailoverState.DORMANT)}
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: holder["ctrl"])
+    monkeypatch.setattr(fl, "lifecycle_enabled", lambda: True)
+
+    def _set(state_name: str):
+        holder["ctrl"] = _StubController(getattr(fl.FailoverState, state_name))
+
+    return _set
+
+
+# --- unit: the extension helper -----------------------------------------------
+
+
+class TestExtensionHelper:
+    def test_awakening_grants_slice(self, fsm_state, monkeypatch):
+        fsm_state("AWAKENING")
+        monkeypatch.setenv("JARVIS_BG_WORKER_FSM_EXTENSION_SLICE_S", "120")
+        monkeypatch.setenv("JARVIS_BG_WORKER_FSM_EXTENSION_MAX_S", "900")
+        assert bap._fsm_timebox_extension_s(0.0) == 120.0
+
+    def test_serving_grants_slice(self, fsm_state):
+        fsm_state("SERVING")
+        assert bap._fsm_timebox_extension_s(0.0) > 0
+
+    def test_dormant_grants_nothing(self, fsm_state):
+        fsm_state("DORMANT")
+        assert bap._fsm_timebox_extension_s(0.0) == 0.0
+
+    def test_budget_exhaustion_caps_extension(self, fsm_state, monkeypatch):
+        fsm_state("AWAKENING")
+        monkeypatch.setenv("JARVIS_BG_WORKER_FSM_EXTENSION_SLICE_S", "120")
+        monkeypatch.setenv("JARVIS_BG_WORKER_FSM_EXTENSION_MAX_S", "900")
+        assert bap._fsm_timebox_extension_s(850.0) == 50.0     # remaining budget only
+        assert bap._fsm_timebox_extension_s(900.0) == 0.0      # exhausted
+
+    def test_master_off_is_legacy(self, fsm_state, monkeypatch):
+        fsm_state("AWAKENING")
+        monkeypatch.setenv("JARVIS_BG_FSM_TIMEBOX_ENABLED", "false")
+        assert bap._fsm_timebox_extension_s(0.0) == 0.0
+
+    def test_lifecycle_disabled_is_legacy(self, fsm_state, monkeypatch):
+        import backend.core.ouroboros.governance.failover_lifecycle as fl
+        fsm_state("AWAKENING")
+        monkeypatch.setattr(fl, "lifecycle_enabled", lambda: False)
+        assert bap._fsm_timebox_extension_s(0.0) == 0.0
+
+
+# --- integration: the worker loop survives the ceiling while FSM is engaged ----
+
+
+@dataclass
+class _FakeOpContext:
+    op_id: str
+    goal: str = "fake"
+    provider_route: str = "background"
+    description: str = "fsm timebox test"
+    target_files: List[str] = field(default_factory=lambda: ["a.py"])
+
+
+class _SlowOrchestrator:
+    def __init__(self, delay_s: float) -> None:
+        self.delay_s = delay_s
+        self.completed: List[str] = []
+
+    async def run(self, ctx: _FakeOpContext) -> Any:
+        await asyncio.sleep(self.delay_s)
+        self.completed.append(ctx.op_id)
+        return ctx
+
+
+async def _wait_until(pred, timeout_s: float = 5.0) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while asyncio.get_event_loop().time() < deadline:
+        if pred():
+            return True
+        await asyncio.sleep(0.02)
+    return pred()
+
+
+class TestWorkerLoopExtension:
+    async def test_op_survives_ceiling_when_fsm_awakening(self, fsm_state, monkeypatch):
+        fsm_state("AWAKENING")
+        monkeypatch.setenv("JARVIS_BG_WORKER_OP_TIMEOUT_S", "1")        # tiny ceiling
+        monkeypatch.setenv("JARVIS_BG_WORKER_FSM_EXTENSION_SLICE_S", "1")
+        monkeypatch.setenv("JARVIS_BG_WORKER_FSM_EXTENSION_MAX_S", "5")
+        orch = _SlowOrchestrator(delay_s=1.6)                          # past base ceiling
+        pool = BackgroundAgentPool(orchestrator=cast(Any, orch), pool_size=1, queue_size=4)
+        await pool.start()
+        try:
+            await pool.submit(cast(Any, _FakeOpContext(op_id="op-fsm-ext-1")))
+            assert await _wait_until(lambda: orch.completed, timeout_s=6.0)
+            assert orch.completed == ["op-fsm-ext-1"]
+        finally:
+            await pool.stop()
+
+    async def test_op_still_killed_when_dormant(self, fsm_state, monkeypatch):
+        fsm_state("DORMANT")
+        monkeypatch.setenv("JARVIS_BG_WORKER_OP_TIMEOUT_S", "1")
+        orch = _SlowOrchestrator(delay_s=3.0)
+        pool = BackgroundAgentPool(orchestrator=cast(Any, orch), pool_size=1, queue_size=4)
+        await pool.start()
+        try:
+            await pool.submit(cast(Any, _FakeOpContext(op_id="op-fsm-kill-1")))
+            await asyncio.sleep(1.6)
+            assert orch.completed == []                                # legacy timebox kill
+            st = pool.health()
+            assert st.get("failed_count", st.get("failed", 1)) >= 1 or not orch.completed
+        finally:
+            await pool.stop()

--- a/tests/governance/test_trace_lineage.py
+++ b/tests/governance/test_trace_lineage.py
@@ -1,0 +1,222 @@
+"""Distributed Trace Lineage -- the cryptographic nametag across suspend/resume windows.
+
+Live evidence (Window-2, bt-iso-1782944904): resumed ops got a BRAND-NEW causal_id
+(`make_envelope` minted one because `_reinject` passed none), so the emit-probe logged
+`MISSING ... ordered=False source=non-roadmap`, provenance classified `origin_class=
+unknown`, `required_hops` returned None (UNVERIFIABLE), and the audit saw
+`a1trace_hops: (none)` despite the chain genuinely spanning both windows.
+
+Proves the span-continuation design:
+  1. a1_trace can RESTORE an emit record from HMAC-verified checkpoint lineage --
+     re-seeding the ledger BEFORE ingest (ordering genuinely holds in-process) and
+     re-attesting the emit hop with an honest `lineage=resumed` tag.
+  2. The checkpoint captures trace_lineage (origin goal id + origin source + emit
+     evidence + resume_count) inside the HMAC-signed payload.
+  3. A re-suspended RESUMED op carries the ORIGINAL lineage forward (window N+2
+     still points at window 1's identity).
+  4. The resume envelope kwargs reuse the ORIGINAL causal_id and carry the lineage.
+  5. The REAL auditor recognizes the restored chain as one continuous winning goal.
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import logging
+import pathlib
+
+import pytest
+
+import backend.core.ouroboros.governance.a1_trace as a1t
+import backend.core.ouroboros.governance.fsm_checkpoint as ckpt
+
+
+class _Ctx:
+    """Minimal OperationContext stand-in for capture_from_context."""
+
+    def __init__(self, op_id, signal_source="roadmap", intake_evidence_json=""):
+        self.op_id = op_id
+        self.signal_source = signal_source
+        self.target_files = ["a.py"]
+        self.description = "A1 self-audit goal"
+        self.intake_evidence_json = intake_evidence_json
+        self.provider_route = "standard"
+
+
+# --- 1. a1_trace restore: emit ledger re-seeded + honest lineage-tagged hop --
+
+
+def test_restore_emit_record_makes_ingest_ordered(caplog):
+    a1t.reset_emit_probe()
+    with caplog.at_level(logging.WARNING):
+        a1t.restore_emit_record("op-orig-1", source="roadmap", original_emit_wall=1751400000.0)
+        a1t.probe_ingest_order("op-orig-1")
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "ordered=True" in logged
+    assert "MISSING" not in logged
+
+
+def test_restore_emits_lineage_tagged_hop_line(caplog):
+    """The restored emit must appear as a REAL `[A1Trace] emit goal=` hop line
+    (the auditor's census) tagged lineage=resumed -- attestation, not fabrication."""
+    a1t.reset_emit_probe()
+    with caplog.at_level(logging.WARNING):
+        a1t.restore_emit_record("op-orig-2", source="roadmap", original_emit_wall=1751400000.0)
+    logged = "\n".join(r.getMessage() for r in caplog.records)
+    assert "[A1Trace] emit goal=op-orig-2" in logged
+    assert "lineage=resumed" in logged
+    assert "source=roadmap" in logged
+
+
+def test_get_emit_record_roundtrip():
+    a1t.reset_emit_probe()
+    a1t.emit_probe("op-orig-3", source="roadmap")
+    rec = a1t.get_emit_record("op-orig-3")
+    assert rec is not None
+    ts, source = rec
+    assert source == "roadmap" and ts > 0
+    assert a1t.get_emit_record("op-never") is None
+
+
+# --- 2. checkpoint captures lineage ------------------------------------------
+
+
+def test_capture_mints_trace_lineage_with_emit_evidence():
+    a1t.reset_emit_probe()
+    a1t.emit_probe("op-orig-4", source="roadmap")
+    cp = ckpt.capture_from_context(_Ctx("op-orig-4"), phase="GENERATE")
+    lin = cp.trace_lineage
+    assert lin["origin_goal_id"] == "op-orig-4"
+    assert lin["origin_source"] == "roadmap"
+    assert lin["emit_source"] == "roadmap"
+    assert lin["emit_wall_ts"] > 0
+    assert lin["resume_count"] == 1
+
+
+def test_capture_without_emit_still_mints_lineage():
+    a1t.reset_emit_probe()
+    cp = ckpt.capture_from_context(_Ctx("op-sensor-1", signal_source="test_failure"),
+                                   phase="GENERATE")
+    lin = cp.trace_lineage
+    assert lin["origin_goal_id"] == "op-sensor-1"
+    assert lin["origin_source"] == "test_failure"
+    assert lin["resume_count"] == 1
+    assert "emit_source" not in lin or not lin.get("emit_source")
+
+
+# --- 3. carry-forward across a second suspension ------------------------------
+
+
+def test_resuspension_preserves_original_lineage():
+    prior = {"origin_goal_id": "op-orig-5", "origin_source": "roadmap",
+             "emit_source": "roadmap", "emit_wall_ts": 1751400000.0, "resume_count": 1}
+    ev = json.dumps({"resume": True, "trace_lineage": prior})
+    cp = ckpt.capture_from_context(
+        _Ctx("op-orig-5", signal_source="fsm_resume", intake_evidence_json=ev),
+        phase="GENERATE",
+    )
+    lin = cp.trace_lineage
+    assert lin["origin_goal_id"] == "op-orig-5"
+    assert lin["origin_source"] == "roadmap"          # NOT fsm_resume
+    assert lin["emit_source"] == "roadmap"
+    assert lin["resume_count"] == 2                    # incremented
+
+
+# --- 4. lineage rides the HMAC-signed payload + resume envelope --------------
+
+
+def test_lineage_survives_signed_roundtrip_and_envelope(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "lineage-secret")
+    cp = ckpt.FSMCheckpoint(
+        op_id="op-orig-6", phase="GENERATE",
+        trace_lineage={"origin_goal_id": "op-orig-6", "origin_source": "roadmap",
+                       "emit_source": "roadmap", "emit_wall_ts": 1751400000.0,
+                       "resume_count": 1},
+    )
+    assert ckpt.write_checkpoint(cp)
+    pend = ckpt.list_pending()
+    assert len(pend) == 1
+    assert pend[0].trace_lineage["origin_source"] == "roadmap"
+    env = ckpt.build_resume_envelope(pend[0])
+    assert env["trace_lineage"]["origin_goal_id"] == "op-orig-6"
+
+
+def test_old_schema_checkpoint_still_hydrates(tmp_path, monkeypatch):
+    """A v1 checkpoint written WITHOUT trace_lineage must still verify + hydrate
+    (from_json tolerance) with an empty lineage -- no fail-closed regression."""
+    monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "lineage-secret")
+    cp = ckpt.FSMCheckpoint(op_id="op-old-1", phase="GENERATE")
+    blob = json.loads(cp.to_json())
+    blob.pop("trace_lineage", None)                    # simulate pre-lineage payload
+    payload = json.dumps(blob, sort_keys=True)
+    import os
+    d = ckpt.checkpoint_dir(None)
+    sig = ckpt._sign(payload, ckpt._checkpoint_key(None))
+    with open(os.path.join(d, "op-old-1.json"), "w", encoding="utf-8") as fh:
+        fh.write(json.dumps({"schema": 1, "payload": payload, "hmac": sig}))
+    pend = ckpt.list_pending()
+    assert any(c.op_id == "op-old-1" for c in pend)
+    assert isinstance(pend[0].trace_lineage, dict)
+
+
+# --- 4b. resume envelope kwargs reuse the original causal id ------------------
+
+
+def test_resume_envelope_kwargs_reuse_original_causal_id():
+    from backend.core.ouroboros.governance.intake import unified_intake_router as uir
+    env = {"op_id": "op-orig-7", "description": "goal", "target_files": ["a.py"],
+           "resume_phase": "GENERATE", "partial_completion": "def f(", "provider_route": "",
+           "tool_history": [], "exploration_records": [], "intake_evidence_json": "",
+           "trace_lineage": {"origin_goal_id": "op-orig-7", "origin_source": "roadmap",
+                             "emit_source": "roadmap", "emit_wall_ts": 1.0,
+                             "resume_count": 1}}
+    kw = uir._resume_envelope_kwargs(env)
+    assert kw["causal_id"] == "op-orig-7"
+    assert kw["evidence"]["trace_lineage"]["origin_source"] == "roadmap"
+
+
+def test_provenance_origin_resolves_from_lineage():
+    from backend.core.ouroboros.governance.intake import unified_intake_router as uir
+
+    class _Env:
+        source = "fsm_resume"
+        evidence = {"trace_lineage": {"origin_source": "roadmap"}}
+
+    class _EnvNoLineage:
+        source = "fsm_resume"
+        evidence = {}
+
+    assert uir._provenance_origin_for(_Env()) == "roadmap"
+    assert uir._provenance_origin_for(_EnvNoLineage()) == "fsm_resume"
+
+
+# --- 5. the REAL auditor credits the restored chain as one winning goal -------
+
+
+def _load_auditor():
+    import sys
+    p = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "a1_graduation_auditor.py"
+    spec = importlib.util.spec_from_file_location("_aud_lineage_test", str(p))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_aud_lineage_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_auditor_credits_restored_chain_as_winning_goal():
+    mod = _load_auditor()
+    auditor = mod.A1GraduationAuditor(chaos_manifest_path=None)
+    gid = "op-orig-8"
+    lines = [
+        f"[Provenance] op={gid} origin=roadmap origin_class=roadmap chain_ok=True",
+        f"[A1Trace] emit goal={gid} source=roadmap lineage=resumed",
+        f"[A1Trace] ingest goal={gid} router=attached",
+        f"[A1Trace] dequeue goal={gid}",
+        f"[A1Trace] submit goal={gid} target=GLS",
+        f"[A1Trace] accept goal={gid} phase=CLASSIFY",
+    ]
+    for ln in lines:
+        auditor.ingest_log_line(ln)
+    assert auditor.trace.winning_goal() == gid
+    assert auditor.trace.all_hops_in_order() is True


### PR DESCRIPTION
## SUPER DUPER BEEF UP — three structural constraints, zero workarounds

Closes the two Window-2 blockers (bt-iso-1782944904) at the root, per mandate: no fake telemetry, no suspension loops, no hardcoding, built on existing seams.

### 1. Distributed Trace Lineage (the cryptographic nametag)
Root cause: `_reinject` minted a **new** `causal_id` → the resumed op was an orphan span (`emit-probe MISSING`, `origin_class=unknown`, `required_hops=None` → unverifiable). Now the checkpoint's HMAC-signed payload carries `trace_lineage` (origin goal id, origin source, emit evidence wall-clock-translated, resume counter); hydration **reuses the original causal_id**, re-seeds the emit ledger via `a1_trace.restore_emit_record()` *before* ingest (ordering genuinely holds), logs the census emit hop tagged `lineage=resumed`, and provenance stamps the original origin from verified lineage. Window 2 is mathematically a continuation of Window 1's span — OpenTelemetry-style. **Zero auditor changes needed**: the capstone test proves the real auditor sees one continuous winning goal.

### 2. Activity-Gated Audit Deferral (cure the impatient grader)
The FAILED verdict fired while resumed ops streamed at 31%. `run_watch` now defers its verdict in bounded slices while `default_activity_probe()` (stream_heartbeat file mirror — the cross-process channel that already existed for exactly this) reports the organism mid-thought, capped by an absolute deferral ceiling (900s). Driver arms the mirror for writer + reader. **Slice-47 kept sacred**: this gates only the assessor's verdict timing; the harness wall-clock hard cap stays completely blind and still backstops everything.

### 3. Dynamic FSM-Aware Timeboxing
A resumed op died at the static 415s pool ceiling during a 4-minute zone hunt. The worker ceiling is now enforced in slices around a shielded task; each expiry consults the **live** failover FSM — engaged lifecycle grants bounded extensions; DORMANT kills byte-identical to legacy.

### Plus: checkpoint-dir test isolation (found live during this work)
Intake tests booting a real router were hydrating + **consuming** the repo's real pending checkpoints (`mark_resumed` deletes them) and injecting heavy resume ops into test routers. Autouse conftest fixture now isolates `JARVIS_CHECKPOINT_DIR` per-test.

## Proof
- TDD: 26 new tests, RED verified first (orphan-span, blind-verdict-timing, static-kill all reproduced).
- 113 affected-suite + 161 checkpoint/pool/streaming + 53 trace/provenance + 63 auditor regression green.
- Live probe chain verified: organism `pulse()` → file mirror → auditor probe.
- Intake-dir batch failures/hangs proven **pre-existing on unmodified main** via stash-compare (batch and individual), as are the 4 `test_isomorphic_a1_e2e.py` time.sleep policy failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds distributed trace lineage across suspend/resume, activity-gated audit deferral, and FSM-aware timeboxing to prevent false failures and keep one continuous span across windows. Closes Window‑2 audit gaps (bt-iso-1782944904) without changing the auditor.

- **New Features**
  - Distributed Trace Lineage: adds `trace_lineage` to `FSMCheckpoint` (origin id/source, emit evidence, resume_count); resume reuses the original `causal_id`, restores the emit hop via `a1_trace.restore_emit_record()` before ingest, and stamps provenance with the original origin.
  - Activity-Gated Audit Deferral: `run_watch` defers verdicts in slices while `default_activity_probe` (stream heartbeat file) reports activity, bounded by `JARVIS_A1_AUDIT_DEFER_SLICE_S` and `JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S`; driver arms `JARVIS_STREAM_HEARTBEAT_FILE` for writer and reader.
  - Dynamic FSM-Aware Timeboxing: the background pool enforces timeouts in slices and consults the live failover FSM to grant bounded extensions (`JARVIS_BG_FSM_TIMEBOX_ENABLED`, `JARVIS_BG_WORKER_FSM_EXTENSION_SLICE_S`, `JARVIS_BG_WORKER_FSM_EXTENSION_MAX_S`); DORMANT remains legacy kill.

- **Bug Fixes**
  - Test isolation: autouse fixture points `JARVIS_CHECKPOINT_DIR` to a per-test temp dir to avoid consuming real pending checkpoints during intake tests.

<sup>Written for commit 2600ec2f19b039844142a6ca2e2e6493c521d1a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

