### PR TITLE
fix(a1): keep-confirmation window — a kept materializing node can evaporate

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -62,6 +62,7 @@ import json
 import logging
 import os
 import re
+import time
 import urllib.error
 import urllib.request
 from typing import Any, Dict, List, Optional, Tuple
@@ -800,14 +801,31 @@ class GCPComputeRest:
                     # blindly trust (that leaves a phantom).
                     inst_status, http_code = await self.get_instance_status(node, zone=zone)
                     if (inst_status or "").upper() in _MATERIALIZING_STATES:
-                        # Slow-but-REAL: the node is materializing/up. KEEP it, do NOT
+                        # Slow-but-REAL: the node is materializing/up. But a kept
+                        # node can still EVAPORATE -- GCE rolls back a capacity
+                        # failure AFTER STAGING (live: bt-iso-1782950534 kept a
+                        # STAGING on-demand node that vanished, wedging AWAKENING
+                        # on a phantom for the full L7 budget with no re-hunt).
+                        # Confirm within a bounded window before committing.
+                        _fate = await self._confirm_kept_node(node, zone)
+                        if _fate == "phantom":
+                            logger.warning(
+                                "[GCPComputeRest] KEPT node EVAPORATED (GCE rollback "
+                                "after %s) zone=%s mode=%s -> confirmed-reap + roll "
+                                "next zone", inst_status, zone, mode,
+                            )
+                            await self._reap_zone_confirmed(node, zone)
+                            if spot and _ondemand_on_stockout_enabled():
+                                continue  # escalate to on-demand same zone first
+                            return ("stockout", "zone={}:kept_node_evaporated".format(zone))
+                        # 'live' or still-materializing at window end: KEEP, do NOT
                         # reap, do NOT advance -> route to AWAKENING and hand patience
-                        # to the L7 readiness gate/racer (the right owner of "wait for
-                        # SERVING"). This resolves the strict-reap-vs-slow-op tension.
+                        # to the L7 readiness gate/racer (the right owner of "wait
+                        # for SERVING"). Resolves strict-reap-vs-slow-op tension.
                         logger.info(
                             "[GCPComputeRest] insert op unverified BUT node MATERIALIZING "
-                            "(status=%s) zone=%s mode=%s -> KEEP + hand to L7 readiness gate",
-                            inst_status, zone, mode,
+                            "(status=%s confirm=%s) zone=%s mode=%s -> KEEP + hand to "
+                            "L7 readiness gate", inst_status, _fate, zone, mode,
                         )
                         return (
                             "created",
@@ -1101,6 +1119,34 @@ class GCPComputeRest:
         except Exception as exc:  # noqa: BLE001
             logger.debug("[GCPComputeRest] get_instance_status fail-soft err=%r", exc)
             return (None, 0)
+
+    async def _confirm_kept_node(self, node: str, zone: str) -> str:
+        """Keep-Confirmation Window (phantom-keep guard).
+
+        A node KEPT on 'materializing' can still be ROLLED BACK by GCE moments
+        later (capacity failure after STAGING). Poll the instance until it
+        either proves LIVE (``'live'`` on RUNNING), proves PHANTOM
+        (``'phantom'`` on 404/TERMINATED -- evaporated), or is still
+        materializing when the window closes (``'materializing'`` -- keep,
+        legacy behavior: only proof-of-absence aborts a keep). Bounded by
+        ``JARVIS_KEEP_CONFIRM_WINDOW_S`` (120) x ``_INTERVAL_S`` (10).
+        NEVER raises."""
+        try:
+            window_s = float(os.environ.get("JARVIS_KEEP_CONFIRM_WINDOW_S", "120") or 120)
+            interval_s = float(os.environ.get("JARVIS_KEEP_CONFIRM_INTERVAL_S", "10") or 10)
+            deadline = time.monotonic() + max(0.0, window_s)
+            while True:
+                st, http_code = await self.get_instance_status(node, zone=zone)
+                stu = (st or "").upper()
+                if stu == "RUNNING":
+                    return "live"
+                if stu == "TERMINATED" or (st is None and http_code == 404):
+                    return "phantom"
+                if time.monotonic() >= deadline:
+                    return "materializing"
+                await asyncio.sleep(max(0.01, interval_s))
+        except Exception:  # noqa: BLE001 -- confirmation is a guard, never a blocker
+            return "materializing"
 
     async def _reap_zone_confirmed(self, node: str, zone: str) -> bool:
         """Strict pre-rollover reap: delete ``node`` in ``zone`` and CONFIRM the

--- a/tests/governance/test_insert_op_failclosed.py
+++ b/tests/governance/test_insert_op_failclosed.py
@@ -366,6 +366,7 @@ async def test_unknown_keeps_provisioning_node(monkeypatch):
     # 'unknown' op BUT instances.get says STAGING -> slow-but-real -> KEEP it,
     # do NOT reap, do NOT advance; hand to the L7 readiness gate (route AWAKENING).
     monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_WINDOW_S", "0")  # keep test instant
     _stub_identity(monkeypatch)
     monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP("STAGING"))
     _patch_await(monkeypatch, ["unknown"])
@@ -380,6 +381,7 @@ async def test_unknown_keeps_provisioning_node(monkeypatch):
 
 async def test_unknown_keeps_running_node(monkeypatch):
     monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_WINDOW_S", "0")  # keep test instant
     _stub_identity(monkeypatch)
     monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP("RUNNING"))
     _patch_await(monkeypatch, ["unknown"])
@@ -434,3 +436,110 @@ async def test_insert_unknown_uses_confirmed_reap(monkeypatch):
 
     assert verdict == "stockout"
     assert calls["n"] >= 2  # confirmed reap, not a single delete
+
+
+# ---------------------------------------------------------------------------
+# Keep-Confirmation Window: a KEPT materializing node can still EVAPORATE
+# (GCE rolls back a post-STAGING capacity failure). Live: bt-iso-1782950534
+# kept a STAGING on-demand node that vanished -> AWAKENING wedged on a
+# phantom for the full 900s L7 budget with no re-hunt.
+# ---------------------------------------------------------------------------
+
+
+class _SequencedStatusHTTP:
+    """POST insert -> 200 op-insert; each GET instances/<node> consumes the
+    next scripted (status, http) pair (last repeats)."""
+
+    def __init__(self, seq):
+        self.seq = list(seq)
+        self.posts = 0
+        self.status_gets = 0
+
+    async def __call__(self, url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        if method == "POST":
+            self.posts += 1
+            return (200, json.dumps({"name": "op-insert"}))
+        if method == "GET" and "/instances/" in url:
+            st, code = self.seq[min(self.status_gets, len(self.seq) - 1)]
+            self.status_gets += 1
+            if st is None:
+                return (code, json.dumps({"error": {"code": code}}))
+            return (code, json.dumps({"status": st}))
+        return (0, "[unrouted]")
+
+
+async def test_kept_node_that_evaporates_is_reaped_and_rolled(monkeypatch):
+    # Handoff sees STAGING (KEEP path) but the confirmation window then sees
+    # 404 (GCE rollback) -> confirmed-reap + roll, NEVER a phantom 'created'.
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_WINDOW_S", "5")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_INTERVAL_S", "0.01")
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(
+        gr, "_http_request",
+        _SequencedStatusHTTP([("STAGING", 200), ("STAGING", 200), (None, 404)]),
+    )
+    _patch_await(monkeypatch, ["unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "stockout"
+    assert "evaporated" in detail
+    assert ("jarvis-prime-failover", "us-central1-a") in reaped
+
+
+async def test_kept_node_that_reaches_running_is_confirmed_live(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_WINDOW_S", "5")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_INTERVAL_S", "0.01")
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(
+        gr, "_http_request",
+        _SequencedStatusHTTP([("STAGING", 200), ("STAGING", 200), ("RUNNING", 200)]),
+    )
+    _patch_await(monkeypatch, ["unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "materializing" in detail
+    assert reaped == []
+
+
+async def test_kept_node_still_materializing_at_window_end_stays_kept(monkeypatch):
+    # Legacy pin: a node that EXISTS but is slow stays KEPT at window end --
+    # only proof-of-absence aborts the keep.
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "false")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_WINDOW_S", "0")
+    _stub_identity(monkeypatch)
+    monkeypatch.setattr(gr, "_http_request", _InsertAndStatusHTTP("STAGING"))
+    _patch_await(monkeypatch, ["unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "materializing" in detail
+    assert reaped == []
+
+
+async def test_evaporated_spot_keep_escalates_to_ondemand_same_zone(monkeypatch):
+    # Spot KEEP evaporates -> reap, then escalate to on-demand in the SAME
+    # zone first (mirrors the not-materializing branch's escalation).
+    monkeypatch.setenv("JARVIS_FAILOVER_ONDEMAND_ON_STOCKOUT", "true")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_WINDOW_S", "5")
+    monkeypatch.setenv("JARVIS_KEEP_CONFIRM_INTERVAL_S", "0.01")
+    _stub_identity(monkeypatch)
+    http = _SequencedStatusHTTP([("STAGING", 200), (None, 404), ("RUNNING", 200)])
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["unknown", "unknown"])
+    reaped = _patch_reap(monkeypatch)
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "mode=on-demand" in detail
+    assert http.posts == 2
+    assert ("jarvis-prime-failover", "us-central1-a") in reaped


### PR DESCRIPTION
## The phantom-keep race (inverse of the run-#4 reap race)

Live evidence (bt-iso-1782950534): the intelligent handoff **kept** a STAGING on-demand node, but GCE rolled the instance back moments later (capacity failure after STAGING). AWAKENING wedged on a phantom for the full 900s L7 budget — no re-hunt path exists after a KEEP — and every op exhausted providers before any node could serve.

**Fix:** `_confirm_kept_node()` — after a KEEP decision, poll the instance within a bounded window (`JARVIS_KEEP_CONFIRM_WINDOW_S=120` × `_INTERVAL_S=10`): `RUNNING` → confirmed live; 404/`TERMINATED` → phantom (GCE rollback) → confirmed-reap + roll next zone (spot escalates to on-demand same-zone first, mirroring the existing branch); still-materializing at window end → keep (legacy pin: only proof-of-absence aborts a keep). Fail-soft.

TDD: 4 new cases (RED confirmed — evaporate previously returned `created`), 2 existing KEEP pins updated with `window=0` env (instant, behavior unchanged). 24 + 19 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a keep-confirmation window to verify GCE instances after we decide to KEEP a materializing node, preventing phantom keeps when GCE rolls back after STAGING. If the instance evaporates, we confirmed-reap and roll; otherwise we keep and hand off to L7 readiness.

- **Bug Fixes**
  - Added `_confirm_kept_node()` to poll instance status within a bounded window (`JARVIS_KEEP_CONFIRM_WINDOW_S` default 120s, `JARVIS_KEEP_CONFIRM_INTERVAL_S` default 10s).
  - Actions: RUNNING → keep; 404/TERMINATED → confirmed-reap and roll; still materializing at window end → keep.
  - Spot evaporation escalates to on-demand in the same zone before rolling; tests added to cover evaporation, live confirm, and window-end cases (existing keep tests use `window=0` to remain instant).

<sup>Written for commit 9682c034f8fb14f332cd1c71ce84616db3600ed0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

