### PR TITLE
fix(a1): streaming transport sovereignty + prefill-aware heartbeat

### DIFF
--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -674,13 +674,39 @@ class LocalPrimeClient:
         # checkpoint path (live gap bt-iso-1782942507: SIGTERM at 59s into prefill,
         # tokens=0, no stall -> GSI never raised, 0 checkpoints).
         _shutdown_task = asyncio.ensure_future(_coop.wait_async())
-        _req_cm = sess.post(url, json=body)
+        # Transport sovereignty: response-begin patience is owned by THIS
+        # machinery (cooperative race + heartbeat + the pool/audit ceilings
+        # above), NEVER by aiohttp's ambient 300s session default -- which
+        # killed L4-queued sealed ops at exactly 300s while they legitimately
+        # waited behind another op's generation (iso-a1-20260701-172436).
+        # Connection ESTABLISHMENT stays bounded (a dead host fails fast).
+        _req_kw: Dict[str, Any] = {"json": body}
+        try:
+            import aiohttp  # noqa: PLC0415 -- session is aiohttp when live
+            _req_kw["timeout"] = aiohttp.ClientTimeout(
+                total=None,
+                connect=float(os.environ.get(
+                    "JARVIS_STREAM_CONNECT_TIMEOUT_S", "30") or 30),
+            )
+        except Exception:  # noqa: BLE001 -- fakes/tests without aiohttp
+            pass
+        _req_cm = sess.post(url, **_req_kw)
         try:
             _enter_task = asyncio.ensure_future(_req_cm.__aenter__())
-            _done_begin, _ = await asyncio.wait(
-                {_enter_task, _shutdown_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            # Prefill-aware heartbeat: while headers are withheld (model
+            # prefill / L4 queue) the GPU is genuinely working -- pulse every
+            # JARVIS_STREAM_REQUEST_PULSE_S so the idle watchdog + the audit
+            # deferral probe see ACTIVE (tokens can't pulse yet by definition).
+            _pulse_s = float(os.environ.get("JARVIS_STREAM_REQUEST_PULSE_S", "15") or 15)
+            while True:
+                _done_begin, _ = await asyncio.wait(
+                    {_enter_task, _shutdown_task},
+                    timeout=max(0.01, _pulse_s),
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if _done_begin:
+                    break
+                _emit_stream_token("")  # heartbeat-only pulse (empty delta)
             if _enter_task not in _done_begin:
                 # Shutdown fired while awaiting response headers (prefill) ->
                 # drop the in-flight request and freeze this millisecond.

--- a/tests/governance/test_response_begin_race.py
+++ b/tests/governance/test_response_begin_race.py
@@ -105,3 +105,91 @@ def test_response_begin_error_still_propagates_faithfully():
                                   stream=True)
 
     asyncio.run(_run())
+
+
+# ---------------------------------------------------------------------------
+# Transport sovereignty + prefill-aware heartbeat (run iso-a1-20260701-172436,
+# 5/6): (a) aiohttp's AMBIENT 300s session timeout killed queued sealed ops
+# whose response-begin waited behind another op on the single L4 (TimeoutError
+# -> sovereign_route_sealed death, including the winning-chain op); (b) the
+# stream heartbeat only pulses on TOKENS, so a long prefill read as IDLE to
+# the audit-deferral probe and the verdict fired over a live op.
+# ---------------------------------------------------------------------------
+
+
+class _SseReader:
+    """Yields scripted SSE lines then EOF."""
+
+    def __init__(self, lines):
+        self._lines = list(lines)
+
+    async def readline(self):
+        return self._lines.pop(0) if self._lines else b""
+
+
+class _OkResp:
+    def __init__(self, reader):
+        self.content = reader
+
+
+class _OkCM:
+    def __init__(self, reader):
+        self._r = reader
+
+    async def __aenter__(self):
+        return _OkResp(self._r)
+
+    async def __aexit__(self, *a):
+        return False
+
+
+def _sse(content):
+    import json as _j
+    return ("data: " + _j.dumps({"choices": [{"delta": {"content": content}}]}) + "\n").encode()
+
+
+def test_streaming_post_owns_transport_timeout():
+    """The streaming request must carry its OWN per-request ClientTimeout with
+    total=None -- response-begin patience is owned by the cooperative race /
+    watchdog stack, never by aiohttp's ambient session default (which killed
+    L4-queued sealed ops at exactly 300s)."""
+    import aiohttp
+    coop.reset()
+    sess = _Sess(_OkCM(_SseReader([_sse("hi"), b""])))
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=sess)
+
+    async def _run():
+        out = await client.complete(system="s", user="u", prompt_tokens=10, stream=True)
+        assert "hi" in out.text
+
+    asyncio.run(_run())
+    assert sess.posted, "no request recorded"
+    kw = sess.posted[0]
+    assert "timeout" in kw, "streaming post must override the ambient session timeout"
+    assert isinstance(kw["timeout"], aiohttp.ClientTimeout)
+    assert kw["timeout"].total is None
+
+
+def test_response_begin_await_pulses_heartbeat(monkeypatch):
+    """While awaiting response headers (prefill / L4 queue) the client must
+    pulse the stream heartbeat periodically -- the GPU is genuinely working,
+    and the audit-deferral probe + idle watchdog must see ACTIVE."""
+    from backend.core.ouroboros.governance import stream_heartbeat as shb
+    monkeypatch.setenv("JARVIS_STREAM_REQUEST_PULSE_S", "0.05")
+    coop.reset()
+    shb.reset()
+    client = lid.LocalPrimeClient(_cfg(num_ctx=8192), session=_Sess(_StalledEnterCM()))
+
+    async def _run():
+        task = asyncio.ensure_future(
+            client.complete(system="s", user="u", prompt_tokens=10,
+                            stream=True, prefill="p"))
+        await asyncio.sleep(0.4)
+        pulses = shb.pulse_count()
+        coop.request("sigterm")            # release the stalled await
+        with pytest.raises(lid.GracefulStreamInterruption):
+            await task
+        return pulses
+
+    pulses = asyncio.run(_run())
+    assert pulses >= 3, "prefill window must pulse the heartbeat (got %d)" % pulses


### PR DESCRIPTION
5/6 autopsy fixes — the last criterion (`fsm_classify_to_applied`) was blocked by (1) aiohttp's ambient 300s session timeout killing L4-queued sealed ops (streaming post now owns its transport timeout: `total=None`, bounded connect), and (2) the heartbeat being token-only so prefill read as idle to the audit-deferral probe (response-begin loop now pulses periodically). TDD, RED-first, 49 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Override `aiohttp` session timeouts for streaming requests and add a prefill-aware heartbeat to prevent 300s kills and false idle during response-begin.
This keeps queued/working ops alive and correctly marked as active.

- **Bug Fixes**
  - Transport sovereignty: streaming POST sets per-request `aiohttp.ClientTimeout(total=None, connect=JARVIS_STREAM_CONNECT_TIMEOUT_S=30)` so response-begin patience is managed by our cooperative race, not the session default.
  - Prefill-aware heartbeat: while awaiting headers, emit empty-delta pulses every `JARVIS_STREAM_REQUEST_PULSE_S` (default 15s) so watchdogs and audit-deferral see activity.
  - Tests: added checks for timeout override and heartbeat pulsing during prefill.

<sup>Written for commit 970c20fd494c4edea3b5b67257d175a3a128646f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

