### PR TITLE
feat(a1): JARVIS_FAILOVER_SPOT_ENABLED opt-out — preemption-free verdict runs

### DIFF
--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -762,7 +762,13 @@ class GCPComputeRest:
             is_stockout_error,
         )
         url = "{}/projects/{}/zones/{}/instances".format(_COMPUTE_BASE, project, zone)
-        for spot in (True, False):
+        # Spot opt-out (JARVIS_FAILOVER_SPOT_ENABLED, default true = legacy
+        # Spot-first): a Spot node was PREEMPTED mid-generation
+        # (iso-a1-20260701-173804) killing every candidate op -- verdict-
+        # critical runs arm =false for a preemption-free on-demand node.
+        _spot_enabled = (os.environ.get("JARVIS_FAILOVER_SPOT_ENABLED", "true")
+                         or "").strip().lower() not in ("0", "false", "no", "off")
+        for spot in ((True, False) if _spot_enabled else (False,)):
             payload = self._build_insert_payload(
                 name=node, zone=zone, project=project, machine_type=machine,
                 image_family=family, startup_script=startup_script, spot=spot,

--- a/tests/governance/test_insert_op_failclosed.py
+++ b/tests/governance/test_insert_op_failclosed.py
@@ -543,3 +543,39 @@ async def test_evaporated_spot_keep_escalates_to_ondemand_same_zone(monkeypatch)
     assert "mode=on-demand" in detail
     assert http.posts == 2
     assert ("jarvis-prime-failover", "us-central1-a") in reaped
+
+
+# ---------------------------------------------------------------------------
+# Spot opt-out: JARVIS_FAILOVER_SPOT_ENABLED=false -> on-demand ONLY.
+# A Spot node was PREEMPTED mid-generation (iso-a1-20260701-173804: STOPPING
+# at 17:49, mass ClientConnectorError, every candidate op sealed-dead) --
+# verdict-critical runs need a preemption-free node.
+# ---------------------------------------------------------------------------
+
+
+async def test_spot_disabled_goes_straight_to_ondemand(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_SPOT_ENABLED", "false")
+    _stub_identity(monkeypatch)
+    http = _PostHTTP()
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["ok"])
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "mode=on-demand" in detail
+    assert http.posts == 1                    # never tried Spot
+
+
+async def test_spot_default_unchanged(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAILOVER_SPOT_ENABLED", raising=False)
+    _stub_identity(monkeypatch)
+    http = _PostHTTP()
+    monkeypatch.setattr(gr, "_http_request", http)
+    _patch_await(monkeypatch, ["ok"])
+
+    verdict, detail = await GCPComputeRest()._insert_in_zone(**_INSERT_KW)
+
+    assert verdict == "created"
+    assert "mode=SPOT" in detail              # legacy Spot-first pinned
+    assert http.posts == 1


### PR DESCRIPTION
Spot preemption killed every candidate op mid-generation (run still 5/6). Env opt-out, default byte-identical. TDD RED-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a Spot failover opt-out via `JARVIS_FAILOVER_SPOT_ENABLED` so verdict-critical runs can go straight to preemption-free on-demand nodes when needed. Default remains legacy Spot-first; no change unless the env var is set.

- **New Features**
  - `GCPComputeRest._insert_in_zone` checks `JARVIS_FAILOVER_SPOT_ENABLED`; when `false`, it skips Spot and provisions on-demand directly.
  - Tests cover disabled and default paths to ensure behavior is correct.

- **Migration**
  - To force on-demand: set `JARVIS_FAILOVER_SPOT_ENABLED=false`.

<sup>Written for commit cef8bd10b3307f65a5c3a9256cb8d5f9aff7dbe2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69815?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

