### PR TITLE
fix(a1): ActivityMonitor pulses the heartbeat mirror — cross-phase activity truth

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -5751,6 +5751,20 @@ class BattleTestHarness:
                     # Decision: poke or starve the watchdog
                     if progressing_count > 0:
                         self._idle_watchdog.poke()
+                        # Cross-process activity truth: pulse the stream
+                        # heartbeat FILE mirror too, so the audit-deferral
+                        # probe (driver-side) sees ops progressing through
+                        # NON-streaming phases (VALIDATE / Iron Gate / APPLY)
+                        # as ACTIVE. Token pulses go blind there -- the
+                        # verdict fired over a mid-pipeline op in
+                        # iso-a1-20260701-180418. Best-effort, fail-soft.
+                        try:
+                            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                                stream_heartbeat as _act_hb,
+                            )
+                            _act_hb.pulse()
+                        except Exception:  # noqa: BLE001
+                            pass
                         if stale_count > 0:
                             logger.info(
                                 "[ActivityMonitor] %d progressing, %d stale — poked watchdog",

--- a/tests/governance/test_phase_aware_heartbeats.py
+++ b/tests/governance/test_phase_aware_heartbeats.py
@@ -191,3 +191,23 @@ def test_authority_invariant_no_orchestrator_imports():
     for tok in forbidden:
         assert f"import {tok}" not in src, f"forbidden import: {tok}"
         assert f"from backend.core.ouroboros.governance.{tok}" not in src
+
+
+def test_activity_monitor_poke_also_pulses_heartbeat_mirror():
+    """Cross-process activity truth (run iso-a1-20260701-180418): the audit
+    deferral probe reads the stream_heartbeat FILE mirror, but pulses only
+    flowed during response-begin + token streaming -- VALIDATE/Iron-Gate/APPLY
+    were BLIND phases, so the verdict fired over an op that was mid-pipeline.
+    The ActivityMonitor's poke decision (progressing ops in ANY phase) must
+    also pulse the heartbeat mirror. Source-level pin (same pattern as the
+    authority invariant): the poke block wires stream_heartbeat."""
+    import pathlib
+    src = (pathlib.Path(__file__).resolve().parents[2]
+           / "backend/core/ouroboros/battle_test/harness.py").read_text()
+    anchor = src.find("Decision: poke or starve the watchdog")
+    assert anchor != -1, "ActivityMonitor decision block moved -- update this pin"
+    window = src[anchor:anchor + 2000]
+    assert "stream_heartbeat" in window and "pulse" in window, (
+        "ActivityMonitor poke must pulse the stream_heartbeat mirror so the "
+        "audit-deferral probe sees non-streaming phases (VALIDATE/APPLY) as ACTIVE"
+    )


### PR DESCRIPTION
The audit deferral released mid-pipeline because VALIDATE/Iron-Gate/APPLY produce no token pulses. The ActivityMonitor poke (any-phase progressing ops) now pulses the mirror. Source-pin TDD RED-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ActivityMonitor pulse the `stream_heartbeat` file mirror when any ops are progressing, so the audit-deferral probe sees non-streaming phases as active. Prevents premature audit release mid-pipeline.

- **Bug Fixes**
  - When `progressing_count > 0`, also call `backend.core.ouroboros.governance.stream_heartbeat.pulse()` to reflect activity in VALIDATE, Iron Gate, and APPLY.
  - Best-effort and fail-soft: wrapped in try/except, independent of the watchdog poke.
  - Added `test_activity_monitor_poke_also_pulses_heartbeat_mirror` to pin the wiring in the ActivityMonitor decision block.

<sup>Written for commit 070c418ff5f964331e819a9cb86423ecae175be7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69816?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

