### PR TITLE
fix(a1): heavy-tier handback drain budget — FSM deleted its own node under committed ops

### DIFF
--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -2562,7 +2562,12 @@ class FailoverLifecycleController:
                 "J-Prime op(s) to finish before teardown", n,
             )
             loop = asyncio.get_event_loop()
-            deadline = loop.time() + _handback_drain_budget_s()
+            # Heavy-tier drain patience: the base budget covers 'a slow CPU
+            # generation' (survival 7B), but a 32B multi-round op runs
+            # 200-400s PER CALL -- the FSM deleted its own node under 3
+            # committed ops (iso-a1-20260701-182533). Scale by the SAME
+            # heavy mult HW1 uses for awaken/warmup; survival byte-identical.
+            deadline = loop.time() + self._adaptive_timeout(_handback_drain_budget_s())
             poll = _handback_drain_poll_s()
             while self._inflight_count() > 0:
                 if loop.time() >= deadline:

--- a/tests/governance/test_failover_handback_protocol.py
+++ b/tests/governance/test_failover_handback_protocol.py
@@ -144,3 +144,47 @@ async def test_handback_drain_bounded_by_budget(monkeypatch):
 
 async def _noop(*a, **k):
     return None
+
+
+async def test_handback_drain_budget_scales_for_heavy_tier(monkeypatch):
+    """Heavy-tier drain patience (iso-a1-20260701-182533): the 120s drain budget
+    was sized for 'a slow CPU generation' -- a 32B multi-round op needs 200-400s
+    PER CALL, so the drain 'budget exhausted with 3 op(s) still in flight' and
+    the FSM deleted its own node under committed work. The drain budget must
+    scale by the SAME heavy mult HW1 uses for awaken/warmup deadlines (survival
+    tier byte-identical)."""
+    from backend.core.ouroboros.governance.failover_tier import FailoverTier
+    monkeypatch.setenv("JARVIS_HANDBACK_DRAIN_BUDGET_S", "0.2")
+    monkeypatch.setenv("JARVIS_HANDBACK_DRAIN_POLL_S", "0.05")
+    monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "4.0")
+    inflight = {"n": 2}
+    seen_at_teardown = {}
+
+    def vm_delete():
+        seen_at_teardown["n"] = inflight["n"]
+        return True
+
+    ctrl = FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=vm_delete,
+        node_ready_fn=lambda e: True,
+        clock_fn=FakeClock(),
+        in_flight_fn=lambda: inflight["n"],
+    )
+    ctrl._awakened_tier = FailoverTier(
+        name="quality", machine_type="g2-standard-8", image_family="x",
+        model_label="qwen2.5-coder:32b", accelerator_type="nvidia-l4",
+        accelerator_count=1,
+    )
+    monkeypatch.setattr(ctrl, "_close_ephemeral_perimeter", _noop)
+
+    # Drain to 0 at 0.5s: PAST the 0.2s base budget, INSIDE the 0.8s heavy budget.
+    async def _drain():
+        await asyncio.sleep(0.5)
+        inflight["n"] = 0
+    drainer = asyncio.create_task(_drain())
+
+    await ctrl._tick_handback(now=1000.0)
+    await drainer
+    assert seen_at_teardown["n"] == 0     # zero-drop honored (waited past base budget)
+    assert ctrl.state.name == "DORMANT"


### PR DESCRIPTION
The handback zero-drop drain budget (120s, sized for CPU 7B) expired under 3 committed 32B ops and the FSM deleted its own serving node. One-line fix via the existing HW1 adaptive-timeout idiom. TDD RED-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale the handback drain budget using the controller’s adaptive timeout so heavy-tier nodes wait long enough for long 32B J-Prime calls before teardown. Prevents the FSM from deleting its own node under committed ops; other tiers remain unchanged.

- **Bug Fixes**
  - Use `self._adaptive_timeout(_handback_drain_budget_s())` to align drain deadline with HW1 awaken/warmup scaling.
  - Add a test that drains past the base budget but within the heavy budget using `JARVIS_JPRIME_HEAVY_COLDSTART_MULT`.
  - Ensures zero-drop handback: teardown waits until in-flight ops reach 0 on heavy tier.

<sup>Written for commit 2a68b1d5b01bc2c056aef3f7ce13d1df6711f8b0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

