### PR TITLE
feat(a1): JARVIS_FAILOVER_HANDBACK_ENABLED pin — scenario owns the sovereign node's lifetime

### DIFF
--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -309,6 +309,19 @@ def _ready_backoff_cap_s() -> float:
     return max(0.01, _env_float("JARVIS_FAILOVER_READY_BACKOFF_CAP_S", 15.0))
 
 
+def _handback_enabled() -> bool:
+    """Master handback gate (default ON = legacy). ``=false`` pins SERVING --
+    the operator/scenario owns the sovereign node's lifetime. Built for the A1
+    soak, whose PREMISE is a dead DW: the sandbox adversary's probe path is
+    healthy by design (independent probe/gen paths), so deep_probe_recovered
+    kept handing the node back mid-scenario and deleting it under committed
+    32B ops (bt-iso-1782957492: even the 480s heavy drain expired with 5 ops
+    in flight). The Dead-Man's Switch + driver teardown remain the cost
+    backstops when handback is pinned off."""
+    return (os.environ.get("JARVIS_FAILOVER_HANDBACK_ENABLED", "true") or "").strip().lower() \
+        not in ("0", "false", "no", "off")
+
+
 def _handback_drain_budget_s() -> float:
     """Max seconds HANDBACK waits for in-flight J-Prime ops to drain to 0 before
     tearing down anyway (bounded -- never deadlock the FSM; the Dead-Man's Switch
@@ -2387,6 +2400,17 @@ class FailoverLifecycleController:
         deep_ok = self._deep_probe_recovered()
 
         if (hyst_ok or deep_ok) and uptime_ok:
+            if not _handback_enabled():
+                # Scenario/operator pin: recovery observed but handback is
+                # master-off -- the sovereign node stays SERVING (A1 soak:
+                # the premise is a dead DW; a healthy PROBE must not delete
+                # the node mid-scenario). Cost backstops: Dead-Man's Switch
+                # + driver teardown.
+                logger.debug(
+                    "[FailoverLifecycle] handback gate met but "
+                    "JARVIS_FAILOVER_HANDBACK_ENABLED=false -- staying SERVING",
+                )
+                return
             logger.info(
                 "[FailoverLifecycle] HANDBACK gate passed: gradient_streak=%d (>=%d) "
                 "deep_probe_recovered=%s uptime=%.1fs (>=%.1fs)",

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1035,6 +1035,14 @@ class IsomorphicA1Driver:
                     )
                     env["JARVIS_STREAM_HEARTBEAT_FILE"] = _hb_file
                     os.environ["JARVIS_STREAM_HEARTBEAT_FILE"] = _hb_file
+                    # Scenario-premise pin: this soak's premise is a DEAD DW
+                    # (adversary chaos-kills generation) but the adversary's
+                    # PROBE path is healthy by design -- without this pin the
+                    # FSM hands the sovereign node back every ~6min of uptime
+                    # and deletes it under committed 32B ops
+                    # (bt-iso-1782957492). Driver teardown + Dead-Man's Switch
+                    # remain the cost backstops.
+                    env.setdefault("JARVIS_FAILOVER_HANDBACK_ENABLED", "false")
 
                 # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
                 # (all default OFF in prod; this driver IS the A1 ignition harness).

--- a/tests/governance/test_failover_handback_protocol.py
+++ b/tests/governance/test_failover_handback_protocol.py
@@ -188,3 +188,31 @@ async def test_handback_drain_budget_scales_for_heavy_tier(monkeypatch):
     await drainer
     assert seen_at_teardown["n"] == 0     # zero-drop honored (waited past base budget)
     assert ctrl.state.name == "DORMANT"
+
+
+async def test_handback_master_disable_pins_serving(monkeypatch):
+    """Scenario-premise pin (A1 soak): the sandbox adversary's PROBE path is
+    healthy BY DESIGN while generation is chaos-killed, so deep_probe_recovered
+    kept triggering handback every ~6min and the FSM deleted the node the
+    scenario depends on (bt-iso-1782957492: even the 480s heavy drain expired
+    with 5 ops in flight). JARVIS_FAILOVER_HANDBACK_ENABLED=false pins SERVING
+    (default true = legacy handback, byte-identical)."""
+    monkeypatch.setenv("JARVIS_FAILOVER_HANDBACK_ENABLED", "false")
+    torn = {"n": 0}
+    ctrl = FailoverLifecycleController(
+        vm_awaken_fn=lambda *, startup_script: True,
+        vm_delete_fn=lambda: torn.__setitem__("n", 1) or True,
+        node_ready_fn=lambda e: True,
+        clock_fn=FakeClock(),
+        in_flight_fn=lambda: 0,
+        dw_probe_fn=lambda: True,          # DW looks healthy on every probe
+    )
+    monkeypatch.setattr(ctrl, "_close_ephemeral_perimeter", _noop)
+    ctrl._state = fl.FailoverState.SERVING
+    ctrl._serving_started_at = 0.0
+    monkeypatch.setattr(ctrl, "_deep_probe_recovered", lambda: True)
+
+    await ctrl._tick_serving(now=100000.0)   # uptime huge, deep probe recovered
+
+    assert ctrl.state.name == "SERVING"      # pinned -- no handback fired
+    assert torn["n"] == 0                    # node NEVER deleted


### PR DESCRIPTION
The sandbox adversary probe (healthy by design) re-triggers handback every ~6min, deleting the node under committed 32B ops — no drain budget can outrun the loop. Master pin (default legacy), armed in the iso driver. TDD RED-first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a master handback gate to control when a recovered DW triggers handback. By setting JARVIS_FAILOVER_HANDBACK_ENABLED=false, A1 can pin the sovereign node in SERVING to prevent mid-scenario deletion.

- **New Features**
  - Added `_handback_enabled()` check in `failover_lifecycle` to skip handback when disabled (default true keeps legacy behavior).
  - A1 local driver sets `JARVIS_FAILOVER_HANDBACK_ENABLED=false` by default for the soak.
  - New test verifies SERVING is pinned and the node is not deleted when the gate is off.

<sup>Written for commit a6b5800ea0ffc74d02ef36ed98a95adcb8f8c033. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69818?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

