### PR TITLE
fix(a1): pre-SERVING dispatch readiness gate — committed ops wait for the node

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2634,6 +2634,71 @@ async def _resolve_served_model_bytes(
     return int(size or 0)
 
 
+async def _await_jprime_ready(
+    endpoint: str,
+    *,
+    probe_fn: "Optional[Any]" = None,
+    op_id: str = "",
+) -> bool:
+    """Pre-SERVING dispatch readiness gate (bt-iso-1782959216): a COMMITTED
+    sovereign dispatch fired while the node was still BOOTING died on the 30s
+    survival probe and was SEALED TERMINAL (20 of 23 dispatches that run).
+    Wait for the node's own /api/tags to answer (the same L7 truth the driver
+    gate and the model resolver use) before dispatching:
+
+      * bounded by ``JARVIS_JPRIME_DISPATCH_READY_BUDGET_S`` (600s -- covers a
+        cold awaken) polling every ``_POLL_S`` (10s);
+      * each poll PULSES the stream heartbeat -- waiting for the sovereign
+        node IS activity (idle watchdog + audit-deferral probe stay fresh);
+      * cooperative shutdown FREEZES the wait (GracefulStreamInterruption ->
+        the dispatch's checkpoint boundary) so a suspend never burns budget;
+      * returns False on budget expiry -> caller proceeds with the legacy
+        attempt (no new failure mode, only added patience);
+      * master ``JARVIS_JPRIME_DISPATCH_READY_ENABLED`` (default true);
+        ``=false`` = legacy immediate dispatch, byte-identical.
+    """
+    if (os.environ.get("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "true") or "").strip().lower() \
+            in ("0", "false", "no", "off"):
+        return True
+    from backend.core.ouroboros.governance import cooperative_shutdown as _coop  # noqa: PLC0415
+    from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+        GracefulStreamInterruption as _GSI,
+        _emit_stream_token as _hb_pulse,
+    )
+    _probe = probe_fn or _resolve_served_model_bytes
+    budget_s = float(os.environ.get("JARVIS_JPRIME_DISPATCH_READY_BUDGET_S", "600") or 600)
+    poll_s = float(os.environ.get("JARVIS_JPRIME_DISPATCH_READY_POLL_S", "10") or 10)
+    deadline = time.monotonic() + max(0.0, budget_s)
+    first = True
+    while True:
+        if _coop.is_requested():
+            raise _GSI(
+                "cooperative shutdown (%s) while awaiting sovereign node readiness"
+                % _coop.reason(), partial="",
+            )
+        try:
+            if await _probe(endpoint):
+                return True
+        except Exception:  # noqa: BLE001 -- a probe error is just "not ready yet"
+            pass
+        if time.monotonic() >= deadline:
+            logger.warning(
+                "[CandidateGenerator] sovereign node NOT ready after %.0fs "
+                "(endpoint=%s op=%s) -> proceeding with legacy attempt",
+                budget_s, endpoint, op_id,
+            )
+            return False
+        if first:
+            logger.info(
+                "[CandidateGenerator] sovereign node not ready yet (endpoint=%s "
+                "op=%s) -> waiting up to %.0fs (poll=%.0fs, heartbeat-pulsed)",
+                endpoint, op_id, budget_s, poll_s,
+            )
+            first = False
+        _hb_pulse("")  # waiting for the node IS activity
+        await asyncio.sleep(max(0.01, poll_s))
+
+
 def _awakened_vram_bytes() -> int:
     """VRAM (bytes) of the awakened GPU tier -- the controller's live awakened tier
     if available, else the QUALITY provisioning spec. 0 if not a GPU tier / unknown
@@ -4254,6 +4319,14 @@ class CandidateGenerator:
             PrimeProvider as _F3cPrimeProvider,
         )
 
+        # Pre-SERVING readiness gate: a committed dispatch against a node that
+        # is still booting dies on the 30s survival probe and gets SEALED
+        # (bt-iso-1782959216: 20/23 dispatches). Wait (bounded, heartbeat-
+        # pulsed, suspend-aware) for /api/tags before building the client --
+        # the model resolver + num_ctx negotiator then see the REAL node.
+        await _await_jprime_ready(
+            endpoint, op_id=getattr(context, "op_id", "?")[:16],
+        )
         _base_overrides: Dict[str, Any] = {
             "base_url": endpoint,
             # Deterministic VRAM residency: keep the model resident while we route

--- a/tests/governance/test_jprime_dispatch_readiness.py
+++ b/tests/governance/test_jprime_dispatch_readiness.py
@@ -1,0 +1,113 @@
+"""Pre-SERVING dispatch readiness gate -- the last seam (bt-iso-1782959216).
+
+With the node's lifetime finally pinned (handback off, on-demand, transport
+sovereign), the census showed 10 routed dispatches but only 3 streams: 20
+dispatches sealed `sovereign_route_sealed:gcp-jprime:LocalLatencyLockup`
+because they fired while the node was still BOOTING -- /api/tags unanswered ->
+num_ctx negotiation None -> non-streaming survival path -> 30s cold budget ->
+terminal seal. A COMMITTED sovereign dispatch must WAIT for node readiness
+(bounded, heartbeat-pulsing, suspend-aware) instead of dying on a 30s probe
+against a node that is still loading its model.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+import backend.core.ouroboros.governance.candidate_generator as cg
+import backend.core.ouroboros.governance.cooperative_shutdown as coop
+from backend.core.ouroboros.governance import stream_heartbeat as shb
+from backend.core.ouroboros.governance.local_inference_director import (
+    GracefulStreamInterruption,
+)
+
+
+def _run(coro):
+    return asyncio.run(coro)
+
+
+class TestAwaitJprimeReady:
+    def test_ready_immediately(self, monkeypatch):
+        calls = {"n": 0}
+
+        async def probe(ep):
+            calls["n"] += 1
+            return 19_850_000_000          # model listed -> ready
+
+        ok = _run(cg._await_jprime_ready("http://n:11434", probe_fn=probe))
+        assert ok is True
+        assert calls["n"] == 1
+
+    def test_waits_until_ready(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_POLL_S", "0.02")
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_BUDGET_S", "5")
+        calls = {"n": 0}
+
+        async def probe(ep):
+            calls["n"] += 1
+            return 1 if calls["n"] >= 3 else None    # ready on 3rd poll
+
+        ok = _run(cg._await_jprime_ready("http://n:11434", probe_fn=probe))
+        assert ok is True
+        assert calls["n"] == 3
+
+    def test_budget_expiry_returns_false(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_POLL_S", "0.02")
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_BUDGET_S", "0.1")
+
+        async def probe(ep):
+            return None                    # never ready
+
+        start = time.monotonic()
+        ok = _run(cg._await_jprime_ready("http://n:11434", probe_fn=probe))
+        assert ok is False
+        assert time.monotonic() - start < 2.0        # bounded
+
+    def test_pulses_heartbeat_while_waiting(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_POLL_S", "0.02")
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_BUDGET_S", "5")
+        shb.reset()
+        calls = {"n": 0}
+
+        async def probe(ep):
+            calls["n"] += 1
+            return 1 if calls["n"] >= 4 else None
+
+        _run(cg._await_jprime_ready("http://n:11434", probe_fn=probe))
+        assert shb.pulse_count() >= 3      # waiting IS activity (deferral-visible)
+
+    def test_cooperative_shutdown_freezes_the_wait(self, monkeypatch):
+        """A suspend during the readiness wait must freeze (GSI -> checkpoint
+        boundary), not burn the budget against a dead run."""
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_POLL_S", "0.02")
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_BUDGET_S", "30")
+        coop.reset()
+
+        async def probe(ep):
+            return None                    # never ready; shutdown interrupts
+
+        async def scenario():
+            async def fire():
+                await asyncio.sleep(0.1)
+                coop.request("sigterm")
+            asyncio.ensure_future(fire())
+            with pytest.raises(GracefulStreamInterruption):
+                await cg._await_jprime_ready("http://n:11434", probe_fn=probe)
+
+        start = time.monotonic()
+        _run(scenario())
+        assert time.monotonic() - start < 2.0        # freeze was prompt
+
+    def test_master_disable_skips_wait(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "false")
+        calls = {"n": 0}
+
+        async def probe(ep):
+            calls["n"] += 1
+            return None
+
+        ok = _run(cg._await_jprime_ready("http://n:11434", probe_fn=probe))
+        assert ok is True                  # legacy: proceed immediately
+        assert calls["n"] == 0


### PR DESCRIPTION
20/23 dispatches sealed dead against a still-booting node (30s survival probe). Committed sovereign dispatches now wait for /api/tags (bounded, heartbeat-pulsed, suspend-aware). TDD RED-first, 6 cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pre-SERVING readiness gate so committed sovereign dispatches wait for the node before starting. This prevents sealed dispatches when `jprime` is still booting by waiting for `/api/tags` with a bounded, heartbeat-pulsed, suspend-aware loop.

- **Bug Fixes**
  - Added `_await_jprime_ready()` and call it at the start of `_failover_local_dispatch`.
  - Waits for `/api/tags` up to `JARVIS_JPRIME_DISPATCH_READY_BUDGET_S` (default 600s), polling every `JARVIS_JPRIME_DISPATCH_READY_POLL_S` (default 10s).
  - Pulses the stream heartbeat while waiting and honors cooperative shutdown via `GracefulStreamInterruption` (freezes without burning budget).
  - On timeout, proceeds with the legacy attempt; can be turned off via `JARVIS_JPRIME_DISPATCH_READY_ENABLED=false`.

<sup>Written for commit fa5ccf494c2c9a4734ae026b870fdf6ec0df3d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

