### PR TITLE
feat(a1): Venom on the sovereign path — the 32B gets the tool loop

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4396,9 +4396,30 @@ class CandidateGenerator:
                 if _resume_prefill:
                     _client._resume_prefill = _resume_prefill  # continue the partial
                 try:
+                    # Venom on the sovereign path (the 6/6 last boss,
+                    # bt-iso-1782960801: 19 one-shot streams, 40 Iron Gate
+                    # rejections, ZERO tool executions). Hand the primary
+                    # provider's already-wired ToolLoopCoordinator (the SAME
+                    # loop the DW path runs; governed_loop_service wires it
+                    # into every provider seat) to the local PrimeProvider --
+                    # _generate_impl then takes the multi-turn tool branch:
+                    # tool advertisements, 2b.2-tool envelope parsing, REAL
+                    # read_file/search_code executions, with_tool_records()
+                    # crediting -> the exploration-first Iron Gate becomes
+                    # satisfiable on the 32B. Master JARVIS_JPRIME_VENOM_ENABLED
+                    # (default true); =false restores the one-shot legacy.
+                    _venom_on = (os.environ.get(
+                        "JARVIS_JPRIME_VENOM_ENABLED", "true") or "").strip().lower() \
+                        not in ("0", "false", "no", "off")
                     _provider = _F3cPrimeProvider(
                         _client,
                         repo_root=self._repo_root if hasattr(self, "_repo_root") else None,
+                        tool_loop=(getattr(getattr(self, "_primary", None),
+                                           "_tool_loop", None)
+                                   if _venom_on else None),
+                        mcp_client=(getattr(getattr(self, "_primary", None),
+                                            "_mcp_client", None)
+                                    if _venom_on else None),
                     )
                     remaining = self._remaining_seconds(deadline)
                     if remaining <= 0.0:

--- a/tests/governance/test_baseexception_race_reignition.py
+++ b/tests/governance/test_baseexception_race_reignition.py
@@ -128,6 +128,7 @@ def test_local_dispatch_checkpoints_on_interruption(tmp_path, monkeypatch):
     """The full local proof: a dispatch whose generation raises GSI THROUGH an
     intermediate `except Exception` (the tool-loop mimic) still writes a signed
     checkpoint (with the partial) to .ouroboros. No cloud, deterministic."""
+    monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "false")  # gate predates this test
     monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
     monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "local-secret")
     import backend.core.ouroboros.governance.candidate_generator as cg
@@ -145,7 +146,7 @@ def test_local_dispatch_checkpoints_on_interruption(tmp_path, monkeypatch):
             pass
 
     class _FakeProvider:
-        def __init__(self, client, repo_root=None):
+        def __init__(self, client, repo_root=None, **_kw):  # tool_loop/mcp_client (venom wiring)
             pass
         async def generate(self, context, deadline):
             # Mimic the Venom tool loop swallowing Exception -- GSI (BaseException)

--- a/tests/governance/test_context_negotiator.py
+++ b/tests/governance/test_context_negotiator.py
@@ -182,6 +182,7 @@ def _deadline(s=120.0):
 def test_l7_autoheal_retries_then_succeeds(monkeypatch):
     """A ServerDisconnected on the warm 32B triggers re-warm + tighten + retry --
     the second attempt (tighter window) succeeds, no permanent halt."""
+    monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "false")  # gate predates this test
     monkeypatch.setenv("JARVIS_FAILOVER_L7_RECOVERY_ATTEMPTS", "2")
     import backend.core.ouroboros.governance.local_inference_director as lidmod
     import backend.core.ouroboros.governance.providers as provmod
@@ -206,7 +207,7 @@ def test_l7_autoheal_retries_then_succeeds(monkeypatch):
 
     class _FakeProvider:
         _calls = {"n": 0}
-        def __init__(self, client, repo_root=None):
+        def __init__(self, client, repo_root=None, **_kw):  # tool_loop/mcp_client (venom wiring)
             self.client = client
         async def generate(self, context, deadline):
             _FakeProvider._calls["n"] += 1
@@ -241,6 +242,7 @@ def test_l7_autoheal_retries_then_succeeds(monkeypatch):
 def test_l7_autoheal_exhausts_then_raises(monkeypatch):
     """If every attempt disconnects, the auto-heal exhausts and RAISES (so the
     sentinel seam seals/halts -- never cascades)."""
+    monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "false")  # gate predates this test
     monkeypatch.setenv("JARVIS_FAILOVER_L7_RECOVERY_ATTEMPTS", "1")
     import backend.core.ouroboros.governance.local_inference_director as lidmod
     import backend.core.ouroboros.governance.providers as provmod
@@ -255,7 +257,7 @@ def test_l7_autoheal_exhausts_then_raises(monkeypatch):
             pass
 
     class _FakeProvider:
-        def __init__(self, client, repo_root=None):
+        def __init__(self, client, repo_root=None, **_kw):  # tool_loop/mcp_client (venom wiring)
             pass
         async def generate(self, context, deadline):
             raise aiohttp.ServerDisconnectedError("always down")

--- a/tests/governance/test_jprime_venom_wiring.py
+++ b/tests/governance/test_jprime_venom_wiring.py
@@ -1,0 +1,106 @@
+"""Venom on the sovereign path -- the 6/6 last boss (bt-iso-1782960801).
+
+Definitive census with every infra layer fixed (node pinned, transport
+sovereign, readiness-gated): 19 one-shot streams, 40 Iron Gate rejections,
+ZERO tool-loop activity. `_failover_local_dispatch` builds its PrimeProvider
+WITHOUT `tool_loop`/`mcp_client`, so `_generate_impl` takes the single-shot
+branch (providers.py:5721) -- the 32B cannot execute read_file/search_code and
+the exploration-first Iron Gate is STRUCTURALLY unsatisfiable on the local
+path (infinite GENERATE_RETRY until the wall).
+
+Proves: the local dispatch passes the primary provider's already-wired
+ToolLoopCoordinator (the same one the DW path runs, governed_loop_service
+wires it into every provider) into the local PrimeProvider, flipping
+generation onto the existing multi-turn Venom branch (providers.py:5555) --
+tool advertisements, envelope parser, exploration crediting all downstream.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import backend.core.ouroboros.governance.providers as prov
+from backend.core.ouroboros.governance.candidate_generator import (
+    CandidateGenerator,
+)
+
+
+def _deadline():
+    return datetime.now(timezone.utc) + timedelta(seconds=120)
+
+
+class _Prof:
+    async def run_calibrated(self, fn):
+        return await fn()
+
+
+def _wire(monkeypatch, gen, captured):
+    monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "false")
+
+    async def _model(ep):
+        return "qwen2.5-coder:32b"
+
+    async def _nctx(ep):
+        return 8192
+
+    monkeypatch.setattr(gen, "_resolve_dispatch_model_name", _model)
+    monkeypatch.setattr(gen, "_negotiate_num_ctx", _nctx)
+    monkeypatch.setattr(gen, "_failover_profiler_for", lambda ep, cfg: _Prof())
+
+    class _FakeProvider:
+        def __init__(self, client, **kw):
+            captured.update(kw)
+
+        async def generate(self, context, deadline):
+            return SimpleNamespace(candidates=("patch",), provider_name="gcp-jprime")
+
+    monkeypatch.setattr(prov, "PrimeProvider", _FakeProvider)
+
+
+async def test_local_dispatch_passes_primary_tool_loop(monkeypatch):
+    sentinel_loop = object()
+    sentinel_mcp = object()
+    fake_primary = SimpleNamespace(
+        provider_name="doubleword", _tool_loop=sentinel_loop, _mcp_client=sentinel_mcp,
+    )
+    gen = CandidateGenerator(primary=fake_primary, jprime=None)
+    captured = {}
+    _wire(monkeypatch, gen, captured)
+
+    ctx = SimpleNamespace(op_id="op-venom-wire", intake_evidence_json="")
+    res = await gen._failover_local_dispatch(ctx, _deadline(), "http://n:11434")
+
+    assert res is not None
+    assert captured.get("tool_loop") is sentinel_loop
+    assert captured.get("mcp_client") is sentinel_mcp
+
+
+async def test_local_dispatch_tolerates_loopless_primary(monkeypatch):
+    fake_primary = SimpleNamespace(provider_name="claude")   # no _tool_loop attr
+    gen = CandidateGenerator(primary=fake_primary, jprime=None)
+    captured = {}
+    _wire(monkeypatch, gen, captured)
+
+    ctx = SimpleNamespace(op_id="op-venom-none", intake_evidence_json="")
+    res = await gen._failover_local_dispatch(ctx, _deadline(), "http://n:11434")
+
+    assert res is not None
+    assert captured.get("tool_loop") is None                 # legacy one-shot preserved
+
+
+async def test_local_dispatch_venom_master_disable(monkeypatch):
+    monkeypatch.setenv("JARVIS_JPRIME_VENOM_ENABLED", "false")
+    fake_primary = SimpleNamespace(
+        provider_name="doubleword", _tool_loop=object(), _mcp_client=object(),
+    )
+    gen = CandidateGenerator(primary=fake_primary, jprime=None)
+    captured = {}
+    _wire(monkeypatch, gen, captured)
+
+    ctx = SimpleNamespace(op_id="op-venom-off", intake_evidence_json="")
+    res = await gen._failover_local_dispatch(ctx, _deadline(), "http://n:11434")
+
+    assert res is not None
+    assert captured.get("tool_loop") is None                 # kill switch honored


### PR DESCRIPTION
The last boss: the local J-Prime dispatch was one-shot (no tool loop), making the exploration-first Iron Gate structurally unsatisfiable (40/40 rejections). The fix hands the already-wired ToolLoopCoordinator into the local PrimeProvider — the existing multi-turn Venom branch does the rest (advertisements, envelope parser, real tool execution, Iron-Gate crediting). Master kill switch, TDD RED-first, 102 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable Venom’s multi‑turn tool loop on the local J‑Prime path by passing the primary provider’s `tool_loop` and `mcp_client` into the local `PrimeProvider`. This lets the 32B perform real tool calls and satisfy Iron Gate exploration.

- **New Features**
  - Local dispatch now forwards `tool_loop` and `mcp_client` to `PrimeProvider`, activating the existing multi‑turn Venom branch.
  - Providers without a loop are supported and will fall back to the one‑shot path.

- **Migration**
  - Default is on; set `JARVIS_JPRIME_VENOM_ENABLED=false` to restore legacy one‑shot behavior.

<sup>Written for commit b1cb0267352819e42c1f667accb25c985ff59a61. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

