### PR TITLE
feat(a1): adaptive time physics — EWMA round budgets + time-dilated deadlines + arm-time walls

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2699,6 +2699,48 @@ async def _await_jprime_ready(
         await asyncio.sleep(max(0.01, poll_s))
 
 
+def _dilate_sovereign_deadline(deadline: "datetime", profiler: Any,
+                               num_ctx: int = 0) -> "datetime":
+    """Time-Dilated Sovereign Deadline (bt-iso-1782973775: resumed / late-
+    cascade dispatches reached the sealed 32B seam with 8-13s of a spent route
+    budget while a single streaming round costs 200-400s).
+
+    A COMMITTED sovereign dispatch derives its runway from the node's OWN
+    measured physics: ``now + expected_rounds x profiler.adaptive_timeout_ms``
+    (EWMA-floored; cold = the heavy-mult ctx-scaled seed -- the GPU speeding
+    up SHRINKS the dilation automatically), clamped by the operator's op
+    envelope ``JARVIS_PIPELINE_TIMEOUT_S``. Only ever EXTENDS (max) -- a
+    healthy deadline passes through untouched. Master
+    ``JARVIS_TIME_DILATION_ENABLED`` (default true). NEVER raises."""
+    try:
+        if (os.environ.get("JARVIS_TIME_DILATION_ENABLED", "true") or "").strip().lower() \
+                in ("0", "false", "no", "off"):
+            return deadline
+        if profiler is None:
+            return deadline
+        rounds = max(1, int(float(os.environ.get(
+            "JARVIS_A1_MAX_AGENTIC_ROUNDS", "5") or 5)))
+        est_ms = float(profiler.adaptive_timeout_ms(
+            prompt_tokens=max(1, int(num_ctx or 4096) // 4)))
+        runway_s = (est_ms / 1000.0) * rounds
+        envelope_s = max(1.0, float(os.environ.get(
+            "JARVIS_PIPELINE_TIMEOUT_S", "600") or 600))
+        runway_s = min(runway_s, envelope_s)
+        now = datetime.now(tz=timezone.utc)
+        dilated = now + timedelta(seconds=runway_s)
+        if dilated <= deadline:
+            return deadline
+        logger.info(
+            "[CandidateGenerator] Time-Dilated Sovereign Deadline: remaining "
+            "%.0fs -> %.0fs (rounds=%d x est=%.0fs, envelope<=%.0fs)",
+            max(0.0, (deadline - now).total_seconds()), runway_s, rounds,
+            est_ms / 1000.0, envelope_s,
+        )
+        return dilated
+    except Exception:  # noqa: BLE001 -- dilation is protective, never fatal
+        return deadline
+
+
 def _awakened_vram_bytes() -> int:
     """VRAM (bytes) of the awakened GPU tier -- the controller's live awakened tier
     if available, else the QUALITY provisioning spec. 0 if not a GPU tier / unknown
@@ -4353,6 +4395,10 @@ class CandidateGenerator:
             _init_overrides["num_ctx"] = int(_num_ctx)
         _init_cfg = _f3c_dc.replace(_F3cLocalConfig.from_env(), **_init_overrides)
         _prof = self._failover_profiler_for(endpoint, _init_cfg)
+        # Time-Dilated Sovereign Deadline: derive the committed dispatch's
+        # runway from THIS node's measured round physics (never from the
+        # scraps a spent route budget left behind).
+        deadline = _dilate_sovereign_deadline(deadline, _prof, int(_num_ctx or 0))
 
         # LLM Prefill Re-Ignition: if this op is a RESUME, its checkpointed partial
         # thought rides in the intake evidence -> feed it to the client as a prefill

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -1795,6 +1795,11 @@ class UnifiedIntakeRouter:
             provider_route=_pre_route,
             provider_route_reason=_pre_route_reason,
         )
+        # Time-Dilated Hydration: a resumed op is REBORN here -- stamp a
+        # fresh pipeline wall so no downstream reader (tool-loop envelope,
+        # L2 repair's direct pipeline_deadline read) inherits window-1's
+        # spent clock.
+        ctx = _stamp_resume_pipeline_deadline(ctx, envelope.source)
 
         # SWE-bench op-isolation + routing fix (#2): stamp the
         # complexity floor at the EARLIEST point — here, before the op
@@ -2329,6 +2334,25 @@ def reset_default_intake_router_for_tests() -> None:
             _DEFAULT_INTAKE_ROUTER = None
     except Exception:  # noqa: BLE001 — defensive
         pass
+
+
+def _stamp_resume_pipeline_deadline(ctx: Any, source: str) -> Any:
+    """Time-Dilated Hydration: a resumed op must NEVER inherit a spent
+    window-1 pipeline wall (the L2 repair path reads ``pipeline_deadline``
+    DIRECTLY, no phase-deadline floor -- a stale value collapses its budget
+    to seconds). Stamp a FRESH envelope at rebirth from the operator's
+    ``JARVIS_PIPELINE_TIMEOUT_S``. Non-resume sources pass through untouched.
+    NEVER raises."""
+    try:
+        if str(source or "") != "fsm_resume":
+            return ctx
+        from datetime import datetime, timedelta, timezone  # noqa: PLC0415
+        _pt_s = max(1.0, float(os.environ.get(
+            "JARVIS_PIPELINE_TIMEOUT_S", "600") or 600))
+        return ctx.with_pipeline_deadline(
+            datetime.now(tz=timezone.utc) + timedelta(seconds=_pt_s))
+    except Exception:  # noqa: BLE001 -- hydration hygiene, never fatal
+        return ctx
 
 
 def _resume_envelope_kwargs(env: "Dict[str, Any]") -> "Dict[str, Any]":

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -2149,6 +2149,37 @@ def _should_compact_for_jprime() -> bool:
         return False
 
 
+def _round_budget_safety_factor() -> float:
+    """Safety multiplier over the profiler's expected round wall (>=1.0)."""
+    try:
+        return max(1.0, float(os.environ.get(
+            "JARVIS_TOOL_ROUND_BUDGET_SAFETY", "1.25") or 1.25))
+    except Exception:  # noqa: BLE001
+        return 1.25
+
+
+def _profiler_round_hint_s(client: Any, prompt: str) -> Optional[float]:
+    """EWMA-Coupled Dynamic Round Budget: derive the expected single-LLM-round
+    wall (seconds) for the CURRENT node from its calibrated LatencyProfiler --
+    ``adaptive_timeout_ms`` (mean TTFT + per-token x expected output +
+    margin-sigma, EWMA-floored; cold = the heavy-mult ctx-scaled seed) x a
+    safety factor. Unwraps the TieredPrimeClient composite (no ``.profiler``
+    attr -- the tiers own their profilers). ``None`` when no profiler is in
+    the seat (e.g. DW) or on any error -> the tool loop keeps its legacy
+    static ceiling. NEVER raises."""
+    try:
+        prof = getattr(client, "profiler", None)
+        if prof is None:
+            prof = getattr(getattr(client, "_light", None), "profiler", None)
+        if prof is None:
+            return None
+        est_ms = prof.adaptive_timeout_ms(
+            prompt_tokens=max(1, len(prompt or "") // 4))
+        return (float(est_ms) / 1000.0) * _round_budget_safety_factor()
+    except Exception:  # noqa: BLE001 -- a sizing hint must never break generation
+        return None
+
+
 def _build_tool_section(
     mcp_tools: Optional[List[Dict[str, Any]]] = None,
     *,
@@ -5634,6 +5665,9 @@ class PrimeProvider:
                     op_weight_lines=_op_weight_lines,
                     prefetched_candidates=getattr(context, "prefetch_manifest", None),
                     governor=_epi_governor,
+                    # EWMA-coupled: the plan's round arithmetic follows the
+                    # node's measured physics (None on profiler-less seats).
+                    round_budget_hint_s=_profiler_round_hint_s(self._client, prompt),
                 )
             finally:
                 # Idempotent close — no-op when master flag off.

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -5835,6 +5835,7 @@ class ToolLoopCoordinator:
 
     def _build_budget_plan(
         self, deadline: float, op_weight_lines: Optional[int] = None,
+        round_budget_hint_s: Optional[float] = None,
     ) -> BudgetPlan:
         """Construct a ``BudgetPlan`` for this ``run()`` invocation.
 
@@ -5858,10 +5859,24 @@ class ToolLoopCoordinator:
             total_budget_s=total_budget_s,
             target_line_count=op_weight_lines,
         )
+        # EWMA-Coupled Dynamic Round Budget: a profiler-derived hint (expected
+        # single-LLM-round wall on THIS node -- a heavy 32B/L4 runs 200-400s
+        # per streaming round) WIDENS the per-round ceiling so viability /
+        # fair-share / tool-deadline arithmetic reflects measured physics
+        # instead of the static DW-sized default (bt-iso-1782973775). A fast
+        # node's hint below the operator ceiling never lowers it; garbage /
+        # NaN fail-soft to legacy.
+        _max_per_round = self._tool_timeout_s
+        try:
+            if round_budget_hint_s is not None and \
+                    float(round_budget_hint_s) > _max_per_round:
+                _max_per_round = float(round_budget_hint_s)
+        except (TypeError, ValueError):
+            pass
         return BudgetPlan.build(
             total_budget_s=total_budget_s,
             hard_max_rounds=self._max_rounds,
-            max_per_round_s=self._tool_timeout_s,
+            max_per_round_s=_max_per_round,
             min_per_round_s=self._min_per_round_s,
             final_write_reserve_s=_reserve,
         )
@@ -5991,6 +6006,11 @@ class ToolLoopCoordinator:
         # static Slice-85 threshold). The caller computes it via the existing
         # ``providers._max_target_line_count``; no parallel weight calc here.
         prefetched_candidates: Optional[Sequence[Any]] = None,
+        # EWMA-Coupled Dynamic Round Budget: the caller's profiler-derived
+        # expected single-LLM-round wall (seconds) on the CURRENT node.
+        # Widens BudgetPlan.max_per_round_s for slow heavy hardware; ``None``
+        # (no profiler in the seat, e.g. DW) is byte-identical legacy.
+        round_budget_hint_s: Optional[float] = None,
         # Sovereign Epistemological Context Matrix (spec §5.1) — memory-supplied
         # PrefetchEntry sequence. When present, a bounded, clearly-labelled
         # "memory-supplied hints" block is PREPENDED to the opening prompt so
@@ -6041,7 +6061,10 @@ class ToolLoopCoordinator:
         # ── Structural budget plan ──
         # Built once per run() so all timing decisions are derived from
         # the same consistent snapshot of the deadline.
-        plan = self._build_budget_plan(deadline, op_weight_lines=op_weight_lines)
+        plan = self._build_budget_plan(
+            deadline, op_weight_lines=op_weight_lines,
+            round_budget_hint_s=round_budget_hint_s,
+        )
         self._last_budget_plan = plan
         effective_max_rounds = plan.effective_max_rounds
 

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -511,17 +511,42 @@ _ready_budget = _env_float("JARVIS_HYBRID_MESH_READY_BUDGET_S", 900.0)
 _failover_wall = _ready_budget + 600.0  # ~90s boot + audit + slack; READY_BUDGET_S + 600 < harness --max-wall-seconds (2400)
 
 
+def _expected_agentic_cycle_s() -> float:
+    """Arm-time derivation of ONE full multi-round agentic cycle on the heavy
+    tier (Slice-47-safe: computed BEFORE launch, immutable once armed -- the
+    running wall stays blind to application state).
+
+    cycle = rounds x (cold-round seed x heavy-mult x ctx-factor) -- the SAME
+    physics the LatencyProfiler's ``_cold_seed_ms`` uses, so the wall and the
+    per-round budgets are derived from one model. ``JARVIS_HYBRID_MESH_
+    EXPECTED_NUM_CTX`` (default 16384) is the arm-time expectation of the
+    negotiated window (the runtime Negotiator measures the real one). Floored
+    at the legacy 600s margin; falls back to 600 on any error."""
+    try:
+        rounds = max(1, int(_env_float("JARVIS_A1_MAX_AGENTIC_ROUNDS", 5.0)))
+        seed_s = _env_float("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", 30_000.0) / 1000.0
+        mult = max(1.0, _env_float("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", 4.0))
+        baseline = max(1.0, _env_float("JARVIS_LOCAL_SEED_CTX_BASELINE", 8192.0))
+        expected_ctx = max(1.0, _env_float("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", 16384.0))
+        ctx_factor = max(1.0, expected_ctx / baseline)
+        return max(600.0, rounds * seed_s * mult * ctx_factor)
+    except Exception:  # noqa: BLE001 -- arm-time sizing must never block ignition
+        return 600.0
+
+
 def _failover_soak_wall(enable_failover: bool) -> int:
     """Return the soak-child wall-clock budget in seconds.
 
     enable_failover=False -> 300 (byte-identical default).
-    enable_failover=True  -> READY_BUDGET_S + 600 to accommodate 32B cold-start.
-    # READY_BUDGET_S + 600 < harness --max-wall-seconds (2400)
+    enable_failover=True  -> READY_BUDGET_S + _expected_agentic_cycle_s() --
+    the margin is DERIVED from round physics at arm time (was a static +600
+    that the 32B's multi-round loops outlived every run). Keep the result
+    below the harness --max-wall-seconds.
     """
     if not enable_failover:
         return 300
     budget = _env_float("JARVIS_HYBRID_MESH_READY_BUDGET_S", 900.0)
-    return int(budget + 600.0)
+    return int(budget + _expected_agentic_cycle_s())
 
 
 def _probe_api_tags(url: str) -> int:
@@ -1043,6 +1068,13 @@ class IsomorphicA1Driver:
                     # (bt-iso-1782957492). Driver teardown + Dead-Man's Switch
                     # remain the cost backstops.
                     env.setdefault("JARVIS_FAILOVER_HANDBACK_ENABLED", "false")
+                    # Arm-time adaptive audit patience: the deferral absolute
+                    # ceiling is DERIVED from the same round physics as the
+                    # soak wall (one model, no magic numbers) -- the verdict
+                    # can outwait one full multi-round agentic cycle.
+                    _cycle_s = str(int(_expected_agentic_cycle_s()))
+                    env.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)
+                    os.environ.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)
 
                 # ---- Iron Triad: arm the three gates + enforcer for the A1 soak ----
                 # (all default OFF in prod; this driver IS the A1 ignition harness).

--- a/tests/governance/test_adaptive_walls_and_resume_stamp.py
+++ b/tests/governance/test_adaptive_walls_and_resume_stamp.py
@@ -1,0 +1,87 @@
+"""Time-Dilated Hydration (resume pipeline re-stamp) + arm-time adaptive walls.
+
+(1) A resumed op must never inherit a spent window-1 pipeline_deadline (the
+L2 repair path reads it DIRECTLY, no phase-deadline floor): the intake seam
+stamps a FRESH envelope at rebirth, derived from the operator's
+JARVIS_PIPELINE_TIMEOUT_S.
+
+(2) The driver's soak-child wall margin was a static +600s. It is now DERIVED
+at arm time (Slice-47-safe: computed BEFORE launch, immutable after) from the
+profiler's own cold-round physics: rounds x seed x heavy-mult x ctx-factor.
+"""
+from __future__ import annotations
+
+import importlib.util
+import pathlib
+import sys
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.intake import unified_intake_router as uir
+
+
+class TestResumePipelineRestamp:
+    def test_fsm_resume_gets_fresh_pipeline_deadline(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_PIPELINE_TIMEOUT_S", "600")
+        stamped = {}
+
+        class _Ctx:
+            def with_pipeline_deadline(self, dl):
+                stamped["dl"] = dl
+                return self
+
+        out = uir._stamp_resume_pipeline_deadline(_Ctx(), "fsm_resume")
+        assert out is not None
+        remaining = (stamped["dl"] - datetime.now(tz=timezone.utc)).total_seconds()
+        assert 590.0 <= remaining <= 610.0
+
+    def test_non_resume_source_untouched(self):
+        ctx = SimpleNamespace()          # no with_pipeline_deadline -- must not be called
+        assert uir._stamp_resume_pipeline_deadline(ctx, "test_failure") is ctx
+
+    def test_failsoft_on_broken_ctx(self):
+        class _Broken:
+            def with_pipeline_deadline(self, dl):
+                raise RuntimeError("frozen")
+
+        b = _Broken()
+        assert uir._stamp_resume_pipeline_deadline(b, "fsm_resume") is b
+
+
+def _load_driver():
+    p = pathlib.Path(__file__).resolve().parents[2] / "scripts" / "isomorphic_a1_local.py"
+    spec = importlib.util.spec_from_file_location("_iso_walls_test", str(p))
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["_iso_walls_test"] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class TestArmTimeAdaptiveWall:
+    def test_cycle_derived_from_round_physics(self, monkeypatch):
+        mod = _load_driver()
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "4.0")
+        monkeypatch.setenv("JARVIS_LOCAL_SEED_CTX_BASELINE", "8192")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        monkeypatch.setenv("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", "30000")
+        # 5 rounds x 30s x 4 x (16384/8192=2) = 1200s
+        assert mod._expected_agentic_cycle_s() == pytest.approx(1200.0, rel=0.05)
+
+    def test_more_rounds_more_wall(self, monkeypatch):
+        mod = _load_driver()
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        five = mod._expected_agentic_cycle_s()
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "10")
+        ten = mod._expected_agentic_cycle_s()
+        assert ten > five
+
+    def test_never_below_legacy_margin(self, monkeypatch):
+        mod = _load_driver()
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "1")
+        monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "1.0")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "1024")
+        assert mod._expected_agentic_cycle_s() >= 600.0

--- a/tests/governance/test_ewma_round_budget.py
+++ b/tests/governance/test_ewma_round_budget.py
@@ -1,0 +1,129 @@
+"""EWMA-Coupled Dynamic Round Budgets -- no hardcoded 30s (bt-iso-1782973775).
+
+The tool loop's BudgetPlan sized `max_per_round_s` from the static
+JARVIS_GOVERNED_TOOL_TIMEOUT_S=30 (DW API economics). On a heavy sovereign
+node a single streaming round costs 200-400s, so the plan's viability gate /
+tool deadlines / fair-share arithmetic were computed against a fantasy round
+cost. The coordinator must be dynamically coupled to the node's calibrated
+LatencyProfiler: the provider derives `round_budget_hint_s = adaptive_timeout
+x safety_factor` per dispatch and threads it into the plan. GPU speeds up ->
+the hint (EWMA) shrinks -> budgets shrink automatically. No profiler / DW
+path -> hint None -> byte-identical legacy.
+"""
+from __future__ import annotations
+
+import time
+from types import SimpleNamespace
+
+import pytest
+
+import backend.core.ouroboros.governance.providers as prov
+from backend.core.ouroboros.governance.tool_executor import ToolLoopCoordinator
+
+
+class _Backend:
+    async def execute_async(self, call, ctx, deadline):  # pragma: no cover
+        raise AssertionError("not exercised")
+
+
+class _Policy:
+    def evaluate(self, call, ctx):  # pragma: no cover
+        raise AssertionError("not exercised")
+
+    def repo_root_for(self, repo):  # pragma: no cover
+        return None
+
+
+def _coord(**kw):
+    return ToolLoopCoordinator(
+        backend=_Backend(), policy=_Policy(), max_rounds=10, tool_timeout_s=30.0, **kw,
+    )
+
+
+class TestPlanHint:
+    def test_hint_raises_max_per_round(self):
+        plan = _coord()._build_budget_plan(
+            time.monotonic() + 900.0, round_budget_hint_s=305.0,
+        )
+        assert plan.max_per_round_s == 305.0
+
+    def test_no_hint_is_legacy(self):
+        plan = _coord()._build_budget_plan(time.monotonic() + 900.0)
+        assert plan.max_per_round_s == 30.0
+
+    def test_hint_below_static_keeps_static(self):
+        """A FAST node (EWMA below the static ceiling) never LOWERS the
+        operator's configured ceiling -- the hint only widens for slow HW."""
+        plan = _coord()._build_budget_plan(
+            time.monotonic() + 900.0, round_budget_hint_s=5.0,
+        )
+        assert plan.max_per_round_s == 30.0
+
+    def test_hint_failsoft_on_garbage(self):
+        plan = _coord()._build_budget_plan(
+            time.monotonic() + 900.0, round_budget_hint_s=float("nan"),
+        )
+        assert plan.max_per_round_s == 30.0
+
+
+class TestRunThreadsHint:
+    async def test_run_threads_hint_into_plan(self, monkeypatch):
+        coord = _coord()
+        seen = {}
+        _orig = coord._build_budget_plan
+
+        def _spy(deadline, op_weight_lines=None, round_budget_hint_s=None):
+            seen["hint"] = round_budget_hint_s
+            return _orig(deadline, op_weight_lines,
+                         round_budget_hint_s=round_budget_hint_s)
+
+        monkeypatch.setattr(coord, "_build_budget_plan", _spy)
+
+        async def gen(prompt):
+            return '{"schema_version": "2b.1", "candidates": []}'
+
+        raw, records = await coord.run(
+            prompt="p", generate_fn=gen, parse_fn=lambda raw: None,
+            repo="jarvis", op_id="op-hint", deadline=time.monotonic() + 60.0,
+            round_budget_hint_s=222.0,
+        )
+        assert seen["hint"] == 222.0
+        assert records == []
+
+
+class TestProviderHintDerivation:
+    def test_local_client_profiler(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TOOL_ROUND_BUDGET_SAFETY", "1.5")
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 200_000.0)
+        client = SimpleNamespace(profiler=prof)
+        hint = prov._profiler_round_hint_s(client, "x" * 400)
+        assert hint == pytest.approx(300.0)          # 200s x 1.5
+
+    def test_tiered_composite_unwraps_light(self):
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 100_000.0)
+        client = SimpleNamespace(_light=SimpleNamespace(profiler=prof))
+        hint = prov._profiler_round_hint_s(client, "hello")
+        assert hint == pytest.approx(125.0)          # default safety 1.25
+
+    def test_no_profiler_is_none(self):
+        assert prov._profiler_round_hint_s(SimpleNamespace(), "p") is None
+
+    def test_profiler_error_failsoft_none(self):
+        def _boom(*, prompt_tokens):
+            raise RuntimeError("ceiling")
+        client = SimpleNamespace(profiler=SimpleNamespace(adaptive_timeout_ms=_boom))
+        assert prov._profiler_round_hint_s(client, "p") is None
+
+
+def test_generate_impl_call_site_threads_hint():
+    """Source pin (repo invariant-pin pattern): the tool-loop call site in
+    _generate_impl derives + passes round_budget_hint_s so the plan is
+    EWMA-coupled wherever a profiler-bearing client is in the seat."""
+    import pathlib
+    src = (pathlib.Path(prov.__file__)).read_text()
+    anchor = src.find("await self._tool_loop.run(")
+    assert anchor != -1
+    window = src[anchor:anchor + 1200]
+    assert "round_budget_hint_s" in window, (
+        "tool-loop call site must thread the profiler-derived round hint"
+    )

--- a/tests/governance/test_hydration_handshake.py
+++ b/tests/governance/test_hydration_handshake.py
@@ -89,6 +89,7 @@ def test_multibyte_partial_bytes_not_chars():
 # --- 4. end-to-end: resume dispatch emits the prefill handshake -------------
 
 def test_resume_dispatch_emits_prefill_handshake(tmp_path, monkeypatch, caplog, capsys):
+    monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "false")  # gate predates this test
     monkeypatch.setenv("JARVIS_CHECKPOINT_DIR", str(tmp_path / "cp"))
     monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "hs")
     import json
@@ -109,7 +110,7 @@ def test_resume_dispatch_emits_prefill_handshake(tmp_path, monkeypatch, caplog, 
             pass
 
     class _FakeProvider:
-        def __init__(self, client, repo_root=None):
+        def __init__(self, client, repo_root=None, **_kw):  # venom/dilation kwargs
             self._client = client
         async def generate(self, context, deadline):
             # Prove the prefill actually reached the client.

--- a/tests/governance/test_time_dilated_deadline.py
+++ b/tests/governance/test_time_dilated_deadline.py
@@ -1,0 +1,125 @@
+"""Time-Dilated Hydration/Dispatch Deadlines -- cure the stale clock.
+
+Live evidence (bt-iso-1782973775): resumed-checkpoint ops entered the Venom
+loop with budget=8.5-13.5s (late-cascade dispatches reach the sovereign seam
+after DW-exhaust legs consumed the route budget; resurrection paths carry the
+window-1 pipeline_deadline verbatim), while fresh ops got ~400s. A committed
+sovereign dispatch on a heavy node must derive its runway from the node's OWN
+physics: deadline = max(deadline, now + expected_rounds x EWMA_round_estimate),
+clamped by the operator's op-envelope (JARVIS_PIPELINE_TIMEOUT_S) -- nothing
+hardcoded; the GPU speeding up shrinks the dilation automatically.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import backend.core.ouroboros.governance.candidate_generator as cg
+from backend.core.ouroboros.governance.candidate_generator import (
+    CandidateGenerator,
+)
+
+
+def _remaining_s(deadline):
+    return (deadline - datetime.now(tz=timezone.utc)).total_seconds()
+
+
+class TestDilationMath:
+    def test_scrap_deadline_is_dilated_to_round_economics(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        monkeypatch.setenv("JARVIS_PIPELINE_TIMEOUT_S", "600")
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 100_000.0)
+        scraps = datetime.now(tz=timezone.utc) + timedelta(seconds=9.0)
+        dilated = cg._dilate_sovereign_deadline(scraps, prof, num_ctx=16640)
+        # 5 rounds x 100s = 500s runway (< 600 envelope clamp)
+        assert 480.0 <= _remaining_s(dilated) <= 510.0
+
+    def test_envelope_clamps_the_dilation(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "10")
+        monkeypatch.setenv("JARVIS_PIPELINE_TIMEOUT_S", "600")
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 400_000.0)
+        scraps = datetime.now(tz=timezone.utc) + timedelta(seconds=5.0)
+        dilated = cg._dilate_sovereign_deadline(scraps, prof, num_ctx=16640)
+        # 10 x 400s = 4000s -> clamped to the operator's 600s op envelope
+        assert 580.0 <= _remaining_s(dilated) <= 610.0
+
+    def test_generous_deadline_never_shrinks(self, monkeypatch):
+        """Dilation only EXTENDS -- a healthy remaining deadline larger than
+        the computed runway is preserved (max, never min)."""
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "2")
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 50_000.0)
+        generous = datetime.now(tz=timezone.utc) + timedelta(seconds=550.0)
+        dilated = cg._dilate_sovereign_deadline(generous, prof, num_ctx=16640)
+        assert _remaining_s(dilated) >= 540.0
+
+    def test_fast_gpu_shrinks_dilation(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 10_000.0)
+        scraps = datetime.now(tz=timezone.utc) + timedelta(seconds=9.0)
+        dilated = cg._dilate_sovereign_deadline(scraps, prof, num_ctx=16640)
+        # 5 x 10s = 50s -- a fast node gets a SMALL dilation, not a fixed wall
+        assert 40.0 <= _remaining_s(dilated) <= 70.0
+
+    def test_no_profiler_failsoft_identity(self):
+        scraps = datetime.now(tz=timezone.utc) + timedelta(seconds=9.0)
+        assert cg._dilate_sovereign_deadline(scraps, None, num_ctx=0) is scraps
+
+    def test_master_disable_is_identity(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TIME_DILATION_ENABLED", "false")
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 100_000.0)
+        scraps = datetime.now(tz=timezone.utc) + timedelta(seconds=9.0)
+        assert cg._dilate_sovereign_deadline(scraps, prof, num_ctx=16640) is scraps
+
+
+class TestDispatchWiring:
+    async def test_dispatch_dilates_scrap_deadline(self, monkeypatch):
+        """Drive the REAL _failover_local_dispatch with a 9s scrap deadline and
+        a stub profiler: the fake provider must receive a DILATED deadline."""
+        import backend.core.ouroboros.governance.providers as prov
+        monkeypatch.setenv("JARVIS_JPRIME_DISPATCH_READY_ENABLED", "false")
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        monkeypatch.setenv("JARVIS_PIPELINE_TIMEOUT_S", "600")
+
+        gen = CandidateGenerator(
+            primary=SimpleNamespace(provider_name="doubleword", _tool_loop=None,
+                                    _mcp_client=None),
+            jprime=None,
+        )
+
+        async def _model(ep):
+            return "qwen2.5-coder:32b"
+
+        async def _nctx(ep):
+            return 16640
+
+        class _Prof:
+            def adaptive_timeout_ms(self, *, prompt_tokens):
+                return 100_000.0
+
+            async def run_calibrated(self, fn):
+                return await fn()
+
+        monkeypatch.setattr(gen, "_resolve_dispatch_model_name", _model)
+        monkeypatch.setattr(gen, "_negotiate_num_ctx", _nctx)
+        monkeypatch.setattr(gen, "_failover_profiler_for", lambda ep, cfg: _Prof())
+
+        received = {}
+
+        class _FakeProvider:
+            def __init__(self, client, **kw):
+                pass
+
+            async def generate(self, context, deadline):
+                received["deadline"] = deadline
+                return SimpleNamespace(candidates=("p",), provider_name="gcp-jprime")
+
+        monkeypatch.setattr(prov, "PrimeProvider", _FakeProvider)
+
+        ctx = SimpleNamespace(op_id="op-dilate", intake_evidence_json="")
+        scraps = datetime.now(tz=timezone.utc) + timedelta(seconds=9.0)
+        res = await gen._failover_local_dispatch(ctx, scraps, "http://n:11434")
+
+        assert res is not None
+        assert _remaining_s(received["deadline"]) >= 400.0   # dilated, not scraps


### PR DESCRIPTION
Every time budget now derives from the node's measured physics: EWMA-coupled tool-loop round budgets, time-dilated sovereign/hydration deadlines (clamped by the operator envelope), and arm-time-derived soak/audit walls (Slice-47-safe: immutable once armed). Zero hardcoded timeouts. TDD RED-first, 23 new tests, 165+ regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make all time budgets adapt to real node speed: EWMA-based round budgets, time‑dilated dispatch/hydration deadlines, and arm‑time walls for soak/audit. Removes hardcoded timeouts and prevents resumed or late dispatches from failing with only seconds left.

- New Features
  - EWMA-coupled round budgets: providers derive `round_budget_hint_s` from `adaptive_timeout_ms` x safety; `ToolLoopCoordinator` widens per‑round ceiling. Hint never lowers the static ceiling; no profiler keeps legacy behavior.
  - Time-dilated sovereign deadline: at dispatch, set deadline = max(existing, now + expected_rounds x EWMA estimate), clamped by `JARVIS_PIPELINE_TIMEOUT_S`; gated by `JARVIS_TIME_DILATION_ENABLED`; only extends.
  - Time-dilated hydration: on `fsm_resume`, stamp a fresh `pipeline_deadline` from `JARVIS_PIPELINE_TIMEOUT_S` so downstream paths don’t inherit a spent clock.
  - Arm-time adaptive walls: driver derives soak wall and audit deferral from expected agentic cycle (rounds x cold seed x heavy multiplier x ctx factor), replacing fixed +600s/+900s.

- Bug Fixes
  - Resumed and late-cascade dispatches no longer inherit a near‑spent deadline.
  - Heavy-model tool loops no longer size viability and tool deadlines using a 30s per‑round default.
  - Soak/audit no longer time out under heavy 32B cold paths due to fixed margins.

<sup>Written for commit c3295a3474f356b6810d5ff1837812aef7d2c5dd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69821?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

