### PR TITLE
feat(a1): sovereign physics floor — the last static clock derives from round physics

### DIFF
--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -123,6 +123,45 @@ def estimate_tokens(text: Any) -> int:
         return 0
 
 
+def expected_agentic_cycle_s(profiler: "Optional[LatencyProfiler]" = None,
+                             *, num_ctx: "Optional[int]" = None) -> float:
+    """THE shared time-physics formula: expected wall for ONE full multi-round
+    agentic cycle = rounds x expected-single-round wall.
+
+    EWMA-COUPLED when a calibrated ``LatencyProfiler`` is supplied
+    (``adaptive_timeout_ms`` -- the GPU speeding up shrinks the cycle
+    automatically); otherwise the cold-seed physics the profiler itself uses
+    (seed x heavy-mult x ctx-factor). ``num_ctx`` defaults to the configured
+    window, else the arm-time expectation ``JARVIS_HYBRID_MESH_EXPECTED_
+    NUM_CTX`` (16384). Consumed by the BudgetPlan hint, the Time-Dilated
+    Sovereign Deadline, the sovereign GENERATE physics floor, and the
+    driver's arm-time walls -- ONE model, no magic numbers. NEVER raises."""
+    rounds = 5
+    try:
+        rounds = max(1, int(float(os.environ.get(
+            "JARVIS_A1_MAX_AGENTIC_ROUNDS", "5") or 5)))
+        if profiler is not None:
+            try:
+                est_ms = float(profiler.adaptive_timeout_ms(
+                    prompt_tokens=max(1, int(num_ctx or 4096) // 4)))
+                return rounds * est_ms / 1000.0
+            except Exception:  # noqa: BLE001 -- fall back to cold physics
+                pass
+        cfg = LocalConfig.from_env()
+        seed_s = float(getattr(cfg, "timeout_seed_ms", 30_000) or 30_000) / 1000.0
+        mult = max(1.0, float(os.environ.get(
+            "JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "4.0") or 4.0))
+        baseline = max(1.0, float(os.environ.get(
+            "JARVIS_LOCAL_SEED_CTX_BASELINE", "8192") or 8192))
+        ctx = float(num_ctx or getattr(cfg, "num_ctx", 0) or 0)
+        if ctx <= 0:
+            ctx = float(os.environ.get(
+                "JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384") or 16384)
+        return rounds * seed_s * mult * max(1.0, ctx / baseline)
+    except Exception:  # noqa: BLE001 -- physics sizing must never break a caller
+        return rounds * 120.0
+
+
 def derive_safe_num_ctx(
     *,
     vram_bytes: int,

--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -128,6 +128,38 @@ logger = logging.getLogger("Ouroboros.Orchestrator")
 # Re-raises CancelledError so the asyncio cascade can drain WAL +
 # exit before the WallClockWatchdog Layer-3 hard-kill fires.
 
+def _sovereign_physics_floor_s(base_s: float) -> float:
+    """Sovereign-heavy physics floor for the route GENERATE budget.
+
+    The route table is DW-API-sized; when the failover lifecycle is ENGAGED
+    (AWAKENING/SERVING -- this op will route to the awakened heavy node whose
+    single streaming round costs 200-400s), the outer wait_for it feeds
+    severed EVERY multi-round attempt at ~375s (bt-iso-1782977669:
+    'Generation attempt failed' with asyncio.TimeoutError's empty str at
+    exactly the scaled budget). Floor the budget at
+    ``expected_agentic_cycle_s()`` -- the SAME rounds x round-wall physics the
+    BudgetPlan hint / Time-Dilated Deadline / arm-time walls share. DORMANT
+    (normal DW ops) / master-off / any error -> base unchanged. Only ever
+    RAISES (the route table stays the floor's floor). Master
+    ``JARVIS_SOVEREIGN_GEN_PHYSICS_FLOOR_ENABLED`` (default true).
+    NEVER raises."""
+    try:
+        if (os.environ.get("JARVIS_SOVEREIGN_GEN_PHYSICS_FLOOR_ENABLED", "true")
+                or "").strip().lower() in ("0", "false", "no", "off"):
+            return base_s
+        from backend.core.ouroboros.governance import failover_lifecycle as _fl  # noqa: PLC0415
+        if not _fl.lifecycle_enabled():
+            return base_s
+        if _fl.get_failover_controller().state == _fl.FailoverState.DORMANT:
+            return base_s
+        from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+            expected_agentic_cycle_s,
+        )
+        return max(float(base_s), float(expected_agentic_cycle_s()))
+    except Exception:  # noqa: BLE001 -- a sizing floor must never break GENERATE
+        return base_s
+
+
 async def _slice12o_maybe_cooldown(
     *, orch: Any, ctx: Any, exc: BaseException, route: str,
 ) -> bool:
@@ -743,6 +775,19 @@ class GENERATERunner(PhaseRunner):
                         "[Orchestrator] adaptive gen budget skipped "
                         "(fail-open to route base)", exc_info=True,
                     )
+                # Sovereign-heavy physics floor — the LAST static clock:
+                # engaged lifecycle => budget floors at rounds x round-wall
+                # so one floored value propagates to deadline + outer
+                # wait_for + tool-loop budget.
+                _physics_gt = _sovereign_physics_floor_s(_gen_timeout)
+                if _physics_gt > _gen_timeout:
+                    logger.info(
+                        "[Orchestrator] sovereign physics floor: gen_timeout "
+                        "%.0fs → %.0fs route=%s op=%s",
+                        _gen_timeout, _physics_gt, _route,
+                        getattr(ctx, "op_id", "?"),
+                    )
+                    _gen_timeout = _physics_gt
                 deadline = datetime.now(tz=timezone.utc) + timedelta(
                     seconds=_gen_timeout
                 )

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -523,13 +523,13 @@ def _expected_agentic_cycle_s() -> float:
     negotiated window (the runtime Negotiator measures the real one). Floored
     at the legacy 600s margin; falls back to 600 on any error."""
     try:
-        rounds = max(1, int(_env_float("JARVIS_A1_MAX_AGENTIC_ROUNDS", 5.0)))
-        seed_s = _env_float("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", 30_000.0) / 1000.0
-        mult = max(1.0, _env_float("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", 4.0))
-        baseline = max(1.0, _env_float("JARVIS_LOCAL_SEED_CTX_BASELINE", 8192.0))
-        expected_ctx = max(1.0, _env_float("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", 16384.0))
-        ctx_factor = max(1.0, expected_ctx / baseline)
-        return max(600.0, rounds * seed_s * mult * ctx_factor)
+        # ONE physics model: delegate to the shared formula (the same one the
+        # BudgetPlan hint / Time-Dilated Deadline / sovereign GENERATE floor
+        # consume) -- floored at the legacy 600s margin.
+        from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
+            expected_agentic_cycle_s,
+        )
+        return max(600.0, float(expected_agentic_cycle_s()))
     except Exception:  # noqa: BLE001 -- arm-time sizing must never block ignition
         return 600.0
 

--- a/tests/governance/test_sovereign_gen_physics_floor.py
+++ b/tests/governance/test_sovereign_gen_physics_floor.py
@@ -1,0 +1,112 @@
+"""Sovereign-heavy physics floor for the route GENERATE budget.
+
+Live evidence (bt-iso-1782977669): with EWMA plans + dilation live, every
+attempt still died at exactly the route budget -- `adaptive gen budget: 330s
+-> 375s` then `Generation attempt 1/2 failed ... :` (asyncio.TimeoutError's
+empty str) ~380s later. The route-table timeout is the LAST static clock: it
+wraps the whole tool loop in an outer wait_for sized for DW API rounds. When
+the failover lifecycle is engaged (the op routes to the awakened 32B), the
+budget must floor at rounds x expected-round wall -- the SAME physics formula
+the BudgetPlan hint, the dilation, and the arm-time walls already share.
+"""
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+import backend.core.ouroboros.governance.phase_runners.generate_runner as gr
+
+
+class TestExpectedAgenticCycle:
+    def test_cold_physics_formula(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        monkeypatch.setenv("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", "30000")
+        monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "4.0")
+        monkeypatch.setenv("JARVIS_LOCAL_SEED_CTX_BASELINE", "8192")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        # 5 x 30s x 4 x (16384/8192=2) = 1200s
+        assert lid.expected_agentic_cycle_s() == pytest.approx(1200.0, rel=0.05)
+
+    def test_ewma_coupled_when_profiler_supplied(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "4")
+        prof = SimpleNamespace(adaptive_timeout_ms=lambda *, prompt_tokens: 250_000.0)
+        assert lid.expected_agentic_cycle_s(prof, num_ctx=16640) == pytest.approx(1000.0)
+
+    def test_rounds_monotonic(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "3")
+        three = lid.expected_agentic_cycle_s()
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "6")
+        assert lid.expected_agentic_cycle_s() > three
+
+    def test_profiler_error_falls_back_to_cold(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+
+        def _boom(*, prompt_tokens):
+            raise RuntimeError("ceiling")
+
+        prof = SimpleNamespace(adaptive_timeout_ms=_boom)
+        assert lid.expected_agentic_cycle_s(prof) == pytest.approx(1200.0, rel=0.05)
+
+
+class _StubController:
+    def __init__(self, state):
+        self.state = state
+
+
+@pytest.fixture
+def fsm_state(monkeypatch):
+    import backend.core.ouroboros.governance.failover_lifecycle as fl
+    holder = {"ctrl": _StubController(fl.FailoverState.DORMANT)}
+    monkeypatch.setattr(fl, "get_failover_controller", lambda: holder["ctrl"])
+    monkeypatch.setattr(fl, "lifecycle_enabled", lambda: True)
+
+    def _set(name):
+        holder["ctrl"] = _StubController(getattr(fl.FailoverState, name))
+
+    return _set
+
+
+class TestRunnerFloor:
+    def test_engaged_lifecycle_floors_to_cycle(self, fsm_state, monkeypatch):
+        fsm_state("SERVING")
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        assert gr._sovereign_physics_floor_s(375.0) == pytest.approx(1200.0, rel=0.05)
+
+    def test_awakening_also_floors(self, fsm_state, monkeypatch):
+        fsm_state("AWAKENING")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        assert gr._sovereign_physics_floor_s(375.0) > 375.0
+
+    def test_dormant_is_identity(self, fsm_state):
+        fsm_state("DORMANT")
+        assert gr._sovereign_physics_floor_s(375.0) == 375.0
+
+    def test_only_ever_raises(self, fsm_state, monkeypatch):
+        fsm_state("SERVING")
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "1")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "1024")
+        assert gr._sovereign_physics_floor_s(5000.0) == 5000.0
+
+    def test_master_disable_is_identity(self, fsm_state, monkeypatch):
+        fsm_state("SERVING")
+        monkeypatch.setenv("JARVIS_SOVEREIGN_GEN_PHYSICS_FLOOR_ENABLED", "false")
+        assert gr._sovereign_physics_floor_s(375.0) == 375.0
+
+
+def test_runner_applies_floor_before_deadline_mint():
+    """Source pin: the floor runs after the adaptive scale, before the
+    deadline mint, so ONE floored value propagates to deadline + outer
+    wait_for + tool-loop budget (the runner's own propagation contract)."""
+    import pathlib
+    src = pathlib.Path(gr.__file__).read_text()
+    a = src.find("_gen_timeout = _adaptive_gt")
+    b = src.find("deadline = datetime.now(tz=timezone.utc) + timedelta(\n                    seconds=_gen_timeout")
+    assert a != -1 and b != -1 and a < b
+    assert "_sovereign_physics_floor_s" in src[a:b], (
+        "sovereign physics floor must run between adaptive scale and deadline mint"
+    )


### PR DESCRIPTION
The route GENERATE timeout (the outer wait_for wrapping the whole tool loop) severed every heavy multi-round attempt at ~375s. It now floors at the shared physics formula (rounds x EWMA/cold-seed round wall) whenever the failover lifecycle is engaged. One formula now feeds plan hints, dilation, this floor, and the arm-time walls. TDD RED-first, 10 tests, 72 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Floors the `GENERATE` route timeout to the shared round-physics when sovereign failover is engaged, preventing heavy multi-round cycles from being cut off at ~375s. Centralizes the time-physics formula and reuses it across planning, deadlines, and driver walls.

- **Bug Fixes**
  - Apply a physics floor in `backend.core.ouroboros.governance.phase_runners.generate_runner` when failover is AWAKENING/SERVING, using `expected_agentic_cycle_s()`.
  - Runs after adaptive scaling and before deadline mint, so the same value flows to deadline, outer `wait_for`, and the tool loop.
  - Respect `JARVIS_SOVEREIGN_GEN_PHYSICS_FLOOR_ENABLED`; DORMANT or errors keep the base timeout (only ever raises the budget).

- **Refactors**
  - Add `expected_agentic_cycle_s()` in `backend.core.ouroboros.governance.local_inference_director` (EWMA-coupled; else cold seed × heavy mult × ctx factor) and use it for BudgetPlan hints, Time-Dilated Deadline, sovereign floor, and driver walls.
  - `scripts/isomorphic_a1_local.py` now delegates to the shared formula (keeps the legacy 600s floor).
  - Add focused tests for the cycle math, lifecycle gating, and runner placement.

<sup>Written for commit 419a88c3a830e0159343932f9d2c65713fb94ed8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

