### PR TITLE
feat(a1): one L4 = one generation lane

### DIFF
--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1072,6 +1072,14 @@ class IsomorphicA1Driver:
                     # ceiling is DERIVED from the same round physics as the
                     # soak wall (one model, no magic numbers) -- the verdict
                     # can outwait one full multi-round agentic cycle.
+                    # One L4 = ONE generation lane (bt-iso-1782980003: the
+                    # 32B ran a REAL 3-round tool chain but 5 concurrent pool
+                    # ops serialized on the single GPU inflated every op's
+                    # effective round time by queue depth -- nobody finished).
+                    # Scenario-premise config, like the handback pin: the
+                    # physics formulas assume exclusive node access; give the
+                    # soak exactly that.
+                    env.setdefault("JARVIS_BG_POOL_SIZE", "1")
                     _cycle_s = str(int(_expected_agentic_cycle_s()))
                     env.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)
                     os.environ.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)


### PR DESCRIPTION
First real multi-round tool chain proven live; killed only by pool-concurrency contention on the single GPU. Soak arms JARVIS_BG_POOL_SIZE=1 (existing knob, scenario config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Default the A1 isomorphic local runner to `JARVIS_BG_POOL_SIZE=1` so a single L4 GPU runs one generation lane. This removes pool concurrency on single‑GPU runs, preventing inflated round times and allowing multi‑round chains to complete as expected (bt-iso-1782980003).

<sup>Written for commit 89bec81eae4f325800b78de2ac64faa4c5db56ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69823?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

