### PR TITLE
fix(a1): hard-assign the single generation lane

### DIFF
--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1079,7 +1079,7 @@ class IsomorphicA1Driver:
                     # Scenario-premise config, like the handback pin: the
                     # physics formulas assume exclusive node access; give the
                     # soak exactly that.
-                    env.setdefault("JARVIS_BG_POOL_SIZE", "1")
+                    env["JARVIS_BG_POOL_SIZE"] = "1"  # HARD: compose_env manifest sets 6
                     _cycle_s = str(int(_expected_agentic_cycle_s()))
                     env.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)
                     os.environ.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)


### PR DESCRIPTION
setdefault lost to the manifest; 6 workers ran. Hard assignment like the Iron Triad envs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hard-assign `JARVIS_BG_POOL_SIZE=1` in `scripts/isomorphic_a1_local.py` to enforce a single generation lane and prevent contention. This overrides the compose_env manifest (which sets 6) to restore the exclusive node access required by the scenario/soak.

<sup>Written for commit 955c1b23a03b154d391c392a88e482d3838caf1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69824?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

