### PR TITLE
feat(a1): Dynamic Fleet Registry Service Discovery + the Immutability Lock

### DIFF
--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -347,6 +347,15 @@ class BackgroundAgentPool:
             queue_size if queue_size is not None
             else _read_env_int("JARVIS_BG_QUEUE_SIZE", 16)
         )
+        # Dynamic Fleet Topology (lanes track the mesh): the live worker
+        # TARGET. Boot = configured size (governs the mesh-dormant DW-era
+        # regime); while sovereign endpoints serve, the FleetRegistry
+        # observer locks the target to the node count (one GPU = one lane).
+        self._target_pool_size: int = self._pool_size
+        # Immutability Lock: while True, hardware-derived topology is the
+        # mathematical authority -- lower-ranked writers (env/config/
+        # manifest) are silently rejected.
+        self._topology_locked: bool = False
         # PriorityQueue: items are (priority, submission_order, op).
         # Lower priority number = runs first.  Ensures IMMEDIATE ops
         # don't starve BACKGROUND ops when workers free up.
@@ -398,6 +407,57 @@ class BackgroundAgentPool:
 
     # -- Lifecycle -----------------------------------------------------------
 
+    def set_target_pool_size(self, n: int, *, source: str = "config",
+                             lock: bool = False) -> bool:
+        """Dynamic Fleet Topology resize + the Immutability Lock.
+
+        ``source="fleet_topology"`` is the hardware-derived authority: it
+        always applies and sets/releases the lock. Any other source
+        (env/config/manifest) is silently REJECTED while the lock is held --
+        the mesh's physical lane count is a mathematical truth, not a
+        preference. Shrink is cooperative (workers retire between dequeues);
+        grow respawns retired worker ids. Returns True when applied."""
+        try:
+            _n = max(1, int(n))
+        except (TypeError, ValueError):
+            return False
+        if self._topology_locked and source != "fleet_topology":
+            logger.info(
+                "Immutability Lock: rejected pool resize to %d from source=%s "
+                "(topology-derived target=%d is authoritative)",
+                _n, source, self._target_pool_size,
+            )
+            return False
+        self._target_pool_size = _n
+        if source == "fleet_topology":
+            self._topology_locked = bool(lock)
+            logger.info(
+                "Fleet topology: lane target=%d (locked=%s) -- lanes track "
+                "the serving mesh", _n, self._topology_locked,
+            )
+        if self._running:
+            self._reconcile_workers()
+        return True
+
+    def _reconcile_workers(self) -> None:
+        """Spawn workers for ids below the target whose task is missing or
+        done (grow); shrink is cooperative via the worker-loop retire check.
+        NEVER raises."""
+        try:
+            for i in range(self._target_pool_size):
+                if i >= len(self._workers):
+                    self._workers.append(asyncio.create_task(
+                        self._worker_loop(worker_id=i),
+                        name=f"bg-agent-worker-{i}",
+                    ))
+                elif self._workers[i].done():
+                    self._workers[i] = asyncio.create_task(
+                        self._worker_loop(worker_id=i),
+                        name=f"bg-agent-worker-{i}",
+                    )
+        except Exception:  # noqa: BLE001 -- reconcile must never break the pool
+            logger.debug("worker reconcile fail-soft", exc_info=True)
+
     async def start(self) -> None:
         """Create the worker coroutines and begin processing the queue.
 
@@ -414,7 +474,7 @@ class BackgroundAgentPool:
                 self._worker_loop(worker_id=i),
                 name=f"bg-agent-worker-{i}",
             )
-            for i in range(self._pool_size)
+            for i in range(self._target_pool_size)
         ]
         # Stage 1.6 — register self in the process-wide bind so the
         # GENERATE-park wrapper can re-submit resumed dispatches
@@ -975,6 +1035,16 @@ class BackgroundAgentPool:
         logger.debug("Worker %d started", worker_id)
         try:
             while self._running:
+                # Dynamic Fleet Topology: cooperative retire when the live
+                # target shrank below this worker's id (mesh topology says
+                # fewer lanes than workers). Never mid-op -- only between
+                # dequeues, so in-flight work always completes.
+                if worker_id >= self._target_pool_size:
+                    logger.info(
+                        "Worker %d retiring (topology target=%d)",
+                        worker_id, self._target_pool_size,
+                    )
+                    break
                 # HIBERNATION_MODE: block here while paused. Bounded wait so
                 # stop() still reacts within ~2s even if resume() never fires.
                 if not self._unpaused_event.is_set():

--- a/backend/core/ouroboros/governance/fleet_registry.py
+++ b/backend/core/ouroboros/governance/fleet_registry.py
@@ -27,6 +27,34 @@ class FleetRegistry:
     def __init__(self) -> None:
         self._endpoints: Dict[str, str] = {}
         self._lock = threading.Lock()
+        # Topology observers (Dynamic Fleet Service Discovery): called with
+        # the post-change SNAPSHOT dict on every register/unregister. The
+        # dict payload is structurally extensible -- richer per-node metadata
+        # (VRAM, heterogeneous tiers from the J-Prime golden image, which is
+        # Immutable-Orange and ships via human-approved PR) rides the same
+        # channel without an API change. Observer errors NEVER break the
+        # registry (fail-soft).
+        self._observers: list = []
+
+    def subscribe(self, fn) -> None:
+        """Register a topology observer: ``fn(snapshot_dict)`` fires after
+        every register/unregister. NEVER raises."""
+        try:
+            if callable(fn):
+                self._observers.append(fn)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _notify(self) -> None:
+        try:
+            snap = self.snapshot()
+            for fn in tuple(self._observers):
+                try:
+                    fn(snap)
+                except Exception:  # noqa: BLE001 -- an observer bug never breaks the fleet
+                    logger.debug("[FleetRegistry] observer fail-soft", exc_info=True)
+        except Exception:  # noqa: BLE001
+            pass
 
     def register(self, node_class: str, endpoint: str) -> None:
         cls = str(node_class or "").strip()
@@ -36,6 +64,7 @@ class FleetRegistry:
         with self._lock:
             self._endpoints[cls] = ep
         logger.info("[FleetRegistry] register class=%s endpoint=%s", cls, ep)
+        self._notify()
 
     def unregister(self, node_class: str) -> None:
         cls = str(node_class or "").strip()
@@ -43,6 +72,7 @@ class FleetRegistry:
             existed = self._endpoints.pop(cls, None)
         if existed is not None:
             logger.info("[FleetRegistry] unregister class=%s (was %s)", cls, existed)
+            self._notify()
 
     def endpoint_for(self, node_class: str) -> Optional[str]:
         with self._lock:

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -5875,6 +5875,27 @@ class GovernedLoopService:
                 on_op_active_unregister=_bg_unregister_active,
             )
             await self._bg_pool.start()
+            # Dynamic Fleet Registry Service Discovery: lanes TRACK the mesh.
+            # While sovereign endpoints serve, the worker count locks to the
+            # node count (one GPU = one lane; an N-node fleet = N lanes);
+            # when the fleet empties, the configured size restores. The
+            # Immutability Lock rejects env/manifest writers meanwhile.
+            try:
+                from backend.core.ouroboros.governance.fleet_registry import (  # noqa: PLC0415
+                    get_fleet_registry,
+                )
+                _pool_ref = self._bg_pool
+                _configured = int(self._bg_pool._pool_size)
+                get_fleet_registry().subscribe(
+                    lambda snap: _fleet_lane_sync(_pool_ref, _configured, snap)
+                )
+                # Reconcile against the CURRENT fleet too (a node may already
+                # be serving when the pool boots -- resume/rebind paths).
+                _fleet_lane_sync(
+                    _pool_ref, _configured, get_fleet_registry().snapshot()
+                )
+            except Exception:  # noqa: BLE001 -- discovery is enhancement, never blocks boot
+                logger.debug("[GLS] fleet lane sync wiring skipped", exc_info=True)
             logger.info(
                 "[GLS] BackgroundAgentPool started (pool_size=%d, queue_size=%d)",
                 self._bg_pool._pool_size, self._bg_pool._queue_size,
@@ -7318,3 +7339,24 @@ class GovernedLoopService:
             logger.warning("[GovernedLoop] L3 graph abort: graph_id=%s aborted=%s", graph_id, aborted)
         else:
             logger.debug("[GovernedLoop] Unhandled command: %s", ct)
+
+
+def _fleet_lane_sync(pool: Any, configured_size: int, snapshot: "Dict[str, str]") -> None:
+    """Topology observer -> pool lane target (Dynamic Fleet Service Discovery).
+
+    Non-empty fleet snapshot => lanes strictly equal the serving sovereign
+    node count, LOCKED (hardware-derived truth overrides env/manifest).
+    Empty fleet => the configured size restores, unlocked (DW-era regime).
+    The snapshot dict is structurally extensible -- future golden-image
+    topology payloads (VRAM, tiers) can weight lanes here without touching
+    the observer channel. NEVER raises."""
+    try:
+        _nodes = len(snapshot or {})
+        if _nodes > 0:
+            pool.set_target_pool_size(_nodes, source="fleet_topology", lock=True)
+        else:
+            pool.set_target_pool_size(
+                max(1, int(configured_size)), source="fleet_topology", lock=False,
+            )
+    except Exception:  # noqa: BLE001 -- lane sync must never break the fleet path
+        logger.debug("[GLS] fleet lane sync fail-soft", exc_info=True)

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1072,14 +1072,11 @@ class IsomorphicA1Driver:
                     # ceiling is DERIVED from the same round physics as the
                     # soak wall (one model, no magic numbers) -- the verdict
                     # can outwait one full multi-round agentic cycle.
-                    # One L4 = ONE generation lane (bt-iso-1782980003: the
-                    # 32B ran a REAL 3-round tool chain but 5 concurrent pool
-                    # ops serialized on the single GPU inflated every op's
-                    # effective round time by queue depth -- nobody finished).
-                    # Scenario-premise config, like the handback pin: the
-                    # physics formulas assume exclusive node access; give the
-                    # soak exactly that.
-                    env["JARVIS_BG_POOL_SIZE"] = "1"  # HARD: compose_env manifest sets 6
+                    # Lane count: Dynamic Fleet Registry Service Discovery
+                    # (governed_loop_service._fleet_lane_sync) -- the pool
+                    # tracks serving sovereign endpoints live (one GPU = one
+                    # lane). The former hard-assign is deprecated; the
+                    # Immutability Lock also defeats the manifest's static 6.
                     _cycle_s = str(int(_expected_agentic_cycle_s()))
                     env.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)
                     os.environ.setdefault("JARVIS_A1_AUDIT_DEFER_ABSOLUTE_S", _cycle_s)

--- a/tests/governance/test_fleet_topology_lanes.py
+++ b/tests/governance/test_fleet_topology_lanes.py
@@ -1,0 +1,165 @@
+"""Dynamic Fleet Registry Service Discovery + the Immutability Lock.
+
+bt-iso-1782982736: 6 pool workers serialized on ONE remote L4 — each op's
+effective round wall multiplied by queue depth, violating the exclusive-access
+physics every derived budget assumes. The hard-assign fix (#69824) is
+DEPRECATED as static config. The pool must TRACK the mesh topology live:
+
+  * The FleetRegistry (the existing class->endpoint map the failover FSM
+    already registers winners into) grows observer hooks -- extensible
+    payloads (the snapshot dict rides the channel; future golden-image
+    VRAM/tier metadata extends it without API change).
+  * The pool gains cooperative live resizing: lanes strictly equal the
+    number of registered sovereign endpoints while the mesh serves; the
+    configured size governs only the mesh-dormant (DW-era) regime.
+  * The Immutability Lock: while topology governs, lower-ranked writers
+    (env/config/manifest) are silently REJECTED -- hardware-derived truth
+    is mathematically authoritative.
+"""
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, List, cast
+
+import pytest
+
+from backend.core.ouroboros.governance.background_agent_pool import (
+    BackgroundAgentPool,
+)
+from backend.core.ouroboros.governance.fleet_registry import (
+    get_fleet_registry,
+    reset_fleet_registry,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_registry():
+    reset_fleet_registry()
+    yield
+    reset_fleet_registry()
+
+
+class _IdleOrch:
+    async def run(self, ctx: Any) -> Any:  # pragma: no cover
+        await asyncio.sleep(0.01)
+        return ctx
+
+
+def _live_workers(pool) -> int:
+    return sum(1 for t in pool._workers if not t.done())
+
+
+async def _converge(pool, n, timeout_s=6.0) -> bool:
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while asyncio.get_event_loop().time() < deadline:
+        if _live_workers(pool) == n:
+            return True
+        await asyncio.sleep(0.1)
+    return _live_workers(pool) == n
+
+
+class TestRegistryObservers:
+    def test_subscribe_fires_on_register_and_unregister(self):
+        reg = get_fleet_registry()
+        seen: List[dict] = []
+        reg.subscribe(lambda snap: seen.append(dict(snap)))
+        reg.register("gpu", "http://n1:11434")
+        reg.register("gpu2", "http://n2:11434")
+        reg.unregister("gpu")
+        assert seen == [
+            {"gpu": "http://n1:11434"},
+            {"gpu": "http://n1:11434", "gpu2": "http://n2:11434"},
+            {"gpu2": "http://n2:11434"},
+        ]
+
+    def test_broken_observer_never_breaks_registry(self):
+        reg = get_fleet_registry()
+
+        def _boom(snap):
+            raise RuntimeError("observer bug")
+
+        reg.subscribe(_boom)
+        reg.register("gpu", "http://n1:11434")     # must not raise
+        assert reg.is_registered("gpu")
+
+
+class TestPoolLiveResize:
+    async def test_shrink_to_topology_then_grow_back(self):
+        pool = BackgroundAgentPool(orchestrator=cast(Any, _IdleOrch()),
+                                   pool_size=3, queue_size=4)
+        await pool.start()
+        try:
+            assert _live_workers(pool) == 3
+            assert pool.set_target_pool_size(1, source="fleet_topology", lock=True)
+            assert await _converge(pool, 1)
+            assert pool.set_target_pool_size(3, source="fleet_topology", lock=False)
+            assert await _converge(pool, 3)
+        finally:
+            await pool.stop()
+
+    async def test_immutability_lock_rejects_lower_rank(self):
+        pool = BackgroundAgentPool(orchestrator=cast(Any, _IdleOrch()),
+                                   pool_size=3, queue_size=4)
+        await pool.start()
+        try:
+            assert pool.set_target_pool_size(1, source="fleet_topology", lock=True)
+            assert await _converge(pool, 1)
+            # env/config/manifest writers are silently rejected while locked
+            assert pool.set_target_pool_size(6, source="config") is False
+            await asyncio.sleep(0.3)
+            assert _live_workers(pool) == 1
+        finally:
+            await pool.stop()
+
+    async def test_unlocked_config_resize_allowed(self):
+        pool = BackgroundAgentPool(orchestrator=cast(Any, _IdleOrch()),
+                                   pool_size=2, queue_size=4)
+        await pool.start()
+        try:
+            assert pool.set_target_pool_size(3, source="config")
+            assert await _converge(pool, 3)
+        finally:
+            await pool.stop()
+
+
+class TestGlsLaneSync:
+    def test_serving_fleet_locks_lanes_to_node_count(self):
+        from backend.core.ouroboros.governance import governed_loop_service as gls
+        calls = {}
+
+        class _FakePool:
+            def set_target_pool_size(self, n, *, source="config", lock=False):
+                calls.update(n=n, source=source, lock=lock)
+                return True
+
+        gls._fleet_lane_sync(_FakePool(), 6, {"gpu": "http://n1:11434"})
+        assert calls == {"n": 1, "source": "fleet_topology", "lock": True}
+
+    def test_empty_fleet_restores_configured_unlocked(self):
+        from backend.core.ouroboros.governance import governed_loop_service as gls
+        calls = {}
+
+        class _FakePool:
+            def set_target_pool_size(self, n, *, source="config", lock=False):
+                calls.update(n=n, source=source, lock=lock)
+                return True
+
+        gls._fleet_lane_sync(_FakePool(), 6, {})
+        assert calls == {"n": 6, "source": "fleet_topology", "lock": False}
+
+
+def test_driver_hard_assign_deprecated():
+    """Source pin: the driver no longer statically assigns the pool size --
+    topology discovery owns the lane count."""
+    import pathlib
+    src = pathlib.Path("scripts/isomorphic_a1_local.py").read_text()
+    assert 'env["JARVIS_BG_POOL_SIZE"]' not in src
+
+
+def test_gls_subscribes_lane_sync():
+    """Source pin: GLS wires the registry observer to the pool after start."""
+    import pathlib
+    from backend.core.ouroboros.governance import governed_loop_service as gls
+    src = pathlib.Path(gls.__file__).read_text()
+    assert "_fleet_lane_sync" in src and ".subscribe(" in src


### PR DESCRIPTION
Lanes track the serving mesh live (1 GPU = 1 lane, N nodes = N lanes); hardware-derived truth locks against env/manifest writers; extensible topology payloads for future golden-image metadata. Hard-assign deprecated. TDD RED-first, 9 tests, 85 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the background worker pool track the live fleet: lanes auto-match active nodes (1 GPU = 1 lane) via registry observers, with an Immutability Lock that rejects config overrides while topology is present. Removes the previous hard-assign of `JARVIS_BG_POOL_SIZE` and adds safe live grow/shrink.

- **New Features**
  - `FleetRegistry.subscribe(fn)` publishes a snapshot on every register/unregister; observer errors are fail-soft.
  - `BackgroundAgentPool.set_target_pool_size(n, source, lock)` enables live resizing; shrink is cooperative (workers retire between dequeues); the Immutability Lock blocks env/config/manifest changes while topology governs.
  - `GovernedLoopService` subscribes at start and reconciles immediately; non-empty fleet locks lanes to node count, empty fleet restores the configured size.

- **Migration**
  - Remove any `JARVIS_BG_POOL_SIZE` overrides in manifests or scripts; lane count now derives from serving nodes (1 node/GPU = 1 lane).
  - No other changes required; when no nodes are serving, the pool uses the configured size.

<sup>Written for commit 20d33f4857b26de803019e74f8f575c34f94bfaa. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

