### PR TITLE
feat(a1): the Amnesia Cure — cross-run latency-physics persistence

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -4290,8 +4290,12 @@ class CandidateGenerator:
             if prof is None:
                 from backend.core.ouroboros.governance.local_inference_director import (  # noqa: PLC0415
                     LatencyProfiler,
+                    physics_key,
                 )
-                prof = LatencyProfiler(cfg)
+                # The Amnesia Cure: key the profiler by its DURABLE physics
+                # identity (model@ctx -- endpoints/IPs change every run) so
+                # the EWMA warm-starts from the cross-run ledger.
+                prof = LatencyProfiler(cfg, ledger_key=physics_key(cfg))
                 store[endpoint] = prof
             return prof
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/local_inference_director.py
+++ b/backend/core/ouroboros/governance/local_inference_director.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import gc
+import json
 import logging
 import math
 import os
@@ -157,7 +158,22 @@ def expected_agentic_cycle_s(profiler: "Optional[LatencyProfiler]" = None,
         if ctx <= 0:
             ctx = float(os.environ.get(
                 "JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384") or 16384)
-        return rounds * seed_s * mult * max(1.0, ctx / baseline)
+        per_round_s = seed_s * mult * max(1.0, ctx / baseline)
+        # The Amnesia Cure: fold the cross-run physics ledger into the cold
+        # path -- run N+1's very first floors/walls are sized from run N's
+        # MEASURED per-round truth (the max persisted EWMA), never below the
+        # seed formula. Fail-soft: empty/corrupt ledger -> formula only.
+        try:
+            if _physics_ledger_enabled():
+                _persisted = [
+                    float((v or {}).get("ewma_ms", 0.0) or 0.0) / 1000.0
+                    for v in _physics_ledger_load().values()
+                ]
+                if _persisted:
+                    per_round_s = max(per_round_s, max(_persisted))
+        except Exception:  # noqa: BLE001
+            pass
+        return rounds * per_round_s
     except Exception:  # noqa: BLE001 -- physics sizing must never break a caller
         return rounds * 120.0
 
@@ -231,6 +247,55 @@ def fit_prompt_to_window(
     return system, head + marker + tail, True
 
 
+def _physics_ledger_enabled() -> bool:
+    return (os.environ.get("JARVIS_LATENCY_LEDGER_ENABLED", "true") or "").strip().lower() \
+        not in ("0", "false", "no", "off")
+
+
+def _physics_ledger_path() -> str:
+    return os.environ.get(
+        "JARVIS_LATENCY_LEDGER_PATH",
+        os.path.join(".jarvis", "latency_physics.json"),
+    )
+
+
+def _physics_ledger_load() -> dict:
+    """The Amnesia Cure ledger (bandit_router idiom): keyed physics dict at
+    .jarvis/latency_physics.json. Fail-soft: corrupt/missing -> {}."""
+    try:
+        with open(_physics_ledger_path(), encoding="utf-8") as fh:
+            data = json.loads(fh.read())
+        return data if isinstance(data, dict) else {}
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _physics_ledger_save(key: str, payload: dict) -> None:
+    """Write-through one key (few hundred bytes). NEVER raises into dispatch."""
+    try:
+        path = _physics_ledger_path()
+        os.makedirs(os.path.dirname(path) or ".", exist_ok=True)
+        data = _physics_ledger_load()
+        data[str(key)] = payload
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(json.dumps(data))
+        os.replace(tmp, path)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def physics_key(cfg: "LocalConfig") -> str:
+    """The DURABLE physics identity: (model, ctx-bucket) -- NOT the endpoint
+    (node IPs change every run; the physics belongs to the brain+window)."""
+    try:
+        model = str(getattr(cfg, "model_name", "") or "unknown")
+        ctx = int(getattr(cfg, "num_ctx", 0) or 0)
+        return "%s@%s" % (model, ctx if ctx > 0 else "cpu")
+    except Exception:  # noqa: BLE001
+        return "unknown@cpu"
+
+
 class LatencyProfiler:
     """Thread-safe sliding window of (ttft_ms, per_token_ms) -> bounded adaptive timeout.
 
@@ -239,16 +304,33 @@ class LatencyProfiler:
     wedged model still trips the breaker (watchdog-isolation invariant).
     """
 
-    def __init__(self, cfg: "LocalConfig") -> None:
+    def __init__(self, cfg: "LocalConfig", ledger_key: str = "") -> None:
         self._cfg = cfg
         self._lock = threading.Lock()
         self._ttft: Deque[float] = deque(maxlen=cfg.window_size)
         self._per_tok: Deque[float] = deque(maxlen=cfg.window_size)
         self._total: Deque[float] = deque(maxlen=cfg.window_size)
+        # The Amnesia Cure: warm-start from the cross-run physics ledger so a
+        # fresh process inherits the MEASURED truth instead of the blind seed.
+        self._ledger_key = str(ledger_key or "") if _physics_ledger_enabled() else ""
+        if self._ledger_key:
+            try:
+                _prior = _physics_ledger_load().get(self._ledger_key) or {}
+                for _v in (_prior.get("ttft") or [])[-cfg.window_size:]:
+                    self._ttft.append(float(_v))
+                for _v in (_prior.get("per_tok") or [])[-cfg.window_size:]:
+                    self._per_tok.append(float(_v))
+                for _v in (_prior.get("total") or [])[-cfg.window_size:]:
+                    self._total.append(float(_v))
+                self._ewma_prior = float(_prior.get("ewma_ms", 0.0) or 0.0)
+            except Exception:  # noqa: BLE001
+                self._ewma_prior = 0.0
+        else:
+            self._ewma_prior = 0.0
         # Asymmetric EWMA (ms): timeouts jump it UP (penalty), successes blend it
         # down toward the real latency. Acts as an escalating floor on the adaptive
         # timeout so a starved cold profiler still expands the window. 0 = no data.
-        self._ewma_ms: float = 0.0
+        self._ewma_ms: float = float(getattr(self, '_ewma_prior', 0.0) or 0.0)
         # Async Calibration Mutex (Scout Lock): the FIRST cold coroutine calibrates
         # (Scout) while the concurrent herd waits on the lock; once calibrated, the
         # gate is open and dispatches run fully concurrently on the escalated EWMA.
@@ -317,6 +399,7 @@ class LatencyProfiler:
             else:
                 a = _ewma_alpha()
                 self._ewma_ms = a * float(total_ms) + (1.0 - a) * self._ewma_ms
+        self._flush_physics()
 
     def record_timeout_penalty(self, timeout_ms: float) -> None:
         """Asymmetric penalty injection: a TIMEOUT jumps the EWMA UP to
@@ -326,6 +409,23 @@ class LatencyProfiler:
             penalty = float(timeout_ms) * _timeout_escalation_factor()
             with self._lock:
                 self._ewma_ms = max(self._ewma_ms, penalty)
+            self._flush_physics()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _flush_physics(self) -> None:
+        """Write-through the durable physics (Amnesia Cure). NEVER raises."""
+        if not self._ledger_key:
+            return
+        try:
+            with self._lock:
+                payload = {
+                    "ewma_ms": float(self._ewma_ms),
+                    "ttft": list(self._ttft),
+                    "per_tok": list(self._per_tok),
+                    "total": list(self._total),
+                }
+            _physics_ledger_save(self._ledger_key, payload)
         except Exception:  # noqa: BLE001
             pass
 

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1060,6 +1060,11 @@ class IsomorphicA1Driver:
                     )
                     env["JARVIS_STREAM_HEARTBEAT_FILE"] = _hb_file
                     os.environ["JARVIS_STREAM_HEARTBEAT_FILE"] = _hb_file
+                    # The Amnesia Cure ledger must survive the EPHEMERAL
+                    # isomorphic cwd (same trap as JARVIS_CHECKPOINT_DIR):
+                    # pin the cross-run physics ledger to the REAL repo.
+                    env.setdefault("JARVIS_LATENCY_LEDGER_PATH", str(
+                        Path(self.repo_root) / ".jarvis" / "latency_physics.json"))
                     # Scenario-premise pin: this soak's premise is a DEAD DW
                     # (adversary chaos-kills generation) but the adversary's
                     # PROBE path is healthy by design -- without this pin the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -155,6 +155,11 @@ def _isolate_fsm_checkpoint_dir(tmp_path, monkeypatch):
     monkeypatch.setenv(
         "JARVIS_CHECKPOINT_DIR", str(tmp_path / "_fsm_checkpoints"),
     )
+    # Same isolation for the cross-run latency-physics ledger (Amnesia Cure):
+    # tests must never read/poison the repo's real measured physics.
+    monkeypatch.setenv(
+        "JARVIS_LATENCY_LEDGER_PATH", str(tmp_path / "_latency_physics.json"),
+    )
 
 
 @pytest.fixture(autouse=True)

--- a/tests/governance/test_latency_physics_ledger.py
+++ b/tests/governance/test_latency_physics_ledger.py
@@ -1,0 +1,114 @@
+"""The Amnesia Cure: cross-run latency-physics persistence.
+
+The LatencyProfiler learns the node's TRUE round physics (EWMA ~800s/round on
+the L4 vs the 240s cold seed -- a 3.4x underestimate) and forgets ALL of it at
+process exit; every ignition re-learns from scratch and usually dies of the
+miscalibration it was correcting (operator had to hand-feed measured seeds).
+
+Cure (bandit_router ledger idiom -- .jarvis/, write_text/read_text, fail-soft,
+NEVER raises into the dispatch path): a keyed physics ledger at
+``.jarvis/latency_physics.json``. KEY = (model, ctx-bucket) -- NOT endpoint:
+node IPs change every run; the physics belongs to the brain+window, not the
+address. Profiler warm-starts from the persisted prior; record()/penalty
+write through; the cold-path cycle formula reads the same prior so run N+1's
+floors/walls/plans are sized from run N's MEASURED truth at second zero.
+"""
+from __future__ import annotations
+
+import dataclasses
+import json
+
+import pytest
+
+import backend.core.ouroboros.governance.local_inference_director as lid
+
+
+def _cfg(**over):
+    return dataclasses.replace(lid.LocalConfig.from_env(), **over)
+
+
+@pytest.fixture
+def ledger(tmp_path, monkeypatch):
+    p = tmp_path / "latency_physics.json"
+    monkeypatch.setenv("JARVIS_LATENCY_LEDGER_PATH", str(p))
+    return p
+
+
+class TestLedgerBasics:
+    def test_physics_key_is_model_and_ctx_not_endpoint(self):
+        cfg = _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640)
+        assert lid.physics_key(cfg) == "qwen2.5-coder:32b@16640"
+        cfg2 = _cfg(model_name="qwen2.5-coder:3b", num_ctx=0)
+        assert lid.physics_key(cfg2) == "qwen2.5-coder:3b@cpu"
+
+    def test_corrupt_ledger_failsoft(self, ledger):
+        ledger.write_text("{not json")
+        assert lid._physics_ledger_load() == {}
+
+
+class TestWarmStart:
+    def test_record_persists_and_new_profiler_warm_starts(self, ledger):
+        cfg = _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640, min_samples=1)
+        key = lid.physics_key(cfg)
+        p1 = lid.LatencyProfiler(cfg, ledger_key=key)
+        assert p1.is_warm() is False
+        p1.record(ttft_ms=120_000.0, total_ms=800_000.0, output_tokens=8000)
+        assert ledger.exists()
+
+        # A FRESH profiler (new process simulation) warm-starts from the ledger.
+        p2 = lid.LatencyProfiler(cfg, ledger_key=key)
+        assert p2.is_warm() is True
+        est = p2.adaptive_timeout_ms(prompt_tokens=4000)
+        assert est >= 300_000.0            # sized from measured truth, not the seed
+
+    def test_timeout_penalty_persists_ewma(self, ledger):
+        cfg = _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640)
+        key = lid.physics_key(cfg)
+        p1 = lid.LatencyProfiler(cfg, ledger_key=key)
+        p1.record_timeout_penalty(600_000.0)
+        data = json.loads(ledger.read_text())
+        assert data[key]["ewma_ms"] >= 600_000.0
+
+    def test_no_key_is_legacy_no_writes(self, ledger):
+        cfg = _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640)
+        p = lid.LatencyProfiler(cfg)
+        p.record(ttft_ms=1.0, total_ms=2.0, output_tokens=1)
+        assert not ledger.exists()
+
+    def test_keys_are_isolated(self, ledger):
+        cfg32 = _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640)
+        cfg3 = _cfg(model_name="qwen2.5-coder:3b", num_ctx=0, min_samples=1)
+        lid.LatencyProfiler(cfg32, ledger_key=lid.physics_key(cfg32)).record_timeout_penalty(900_000.0)
+        p3 = lid.LatencyProfiler(cfg3, ledger_key=lid.physics_key(cfg3))
+        assert p3.is_warm() is False       # the 3B never inherits 32B physics
+
+
+class TestColdPathReadsPrior:
+    def test_cycle_formula_uses_persisted_truth(self, ledger, monkeypatch):
+        """Run N measured ~800s rounds; run N+1's COLD cycle estimate (no live
+        profiler yet) must be sized from the ledger, not the blind seed."""
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "4")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        cfg = _cfg(model_name="qwen2.5-coder:32b", num_ctx=16640)
+        p = lid.LatencyProfiler(cfg, ledger_key=lid.physics_key(cfg))
+        p.record_timeout_penalty(800_000.0)   # persisted ewma >= 800s
+
+        cold = lid.expected_agentic_cycle_s()
+        assert cold >= 4 * 800.0 * 0.9        # 4 rounds x measured truth
+
+    def test_cycle_formula_seed_when_ledger_empty(self, ledger, monkeypatch):
+        monkeypatch.setenv("JARVIS_A1_MAX_AGENTIC_ROUNDS", "5")
+        monkeypatch.setenv("JARVIS_LOCAL_INFERENCE_TIMEOUT_SEED_MS", "30000")
+        monkeypatch.setenv("JARVIS_JPRIME_HEAVY_COLDSTART_MULT", "4.0")
+        monkeypatch.setenv("JARVIS_LOCAL_SEED_CTX_BASELINE", "8192")
+        monkeypatch.setenv("JARVIS_HYBRID_MESH_EXPECTED_NUM_CTX", "16384")
+        assert lid.expected_agentic_cycle_s() == pytest.approx(1200.0, rel=0.05)
+
+
+def test_dispatch_profiler_gets_ledger_key():
+    """Source pin: the per-endpoint profiler singleton is constructed with the
+    physics ledger key so cross-run persistence flows through the dispatch."""
+    import pathlib
+    import backend.core.ouroboros.governance.candidate_generator as cg
+    src = pathlib.Path(cg.__file__).read_text()
+    assert "ledger_key=" in src and "physics_key" in src


### PR DESCRIPTION
The profiler now remembers its measured physics across runs (.jarvis ledger, keyed by model@ctx, bandit_router idiom — PIM scouted and rejected: restore has zero callers). Warm-start EWMA + windows; cold-path cycle formula reads the same prior. TDD RED-first, 9 tests, 96 regression green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Persist latency “physics” across runs with a keyed ledger so profilers warm-start and cold-path timing uses measured data from previous runs. This reduces cold-start miscalibration and improves timeout estimates from the first request.

- **New Features**
  - Added cross-run ledger at `.jarvis/latency_physics.json` (config via `JARVIS_LATENCY_LEDGER_PATH`, toggle with `JARVIS_LATENCY_LEDGER_ENABLED`).
  - `LatencyProfiler` warm-starts EWMA and windows from the ledger and writes through on updates; keyed by `model@ctx` via `physics_key(cfg)`.
  - `candidate_generator` now builds profilers with `ledger_key=physics_key(cfg)` so per-endpoint singletons share durable physics.
  - `expected_agentic_cycle_s` sizes cold cycles with `max(seed, persisted EWMA)` for more accurate initial floors.
  - Driver pins the ledger path to the repo root; tests isolate the ledger file and cover warm-start, persistence, and cold-path behavior.

- **Bug Fixes**
  - Added missing `json` import in `local_inference_director` to enable ledger load/save.

<sup>Written for commit b1d4fae2b8295742cea52f7c137da8daccf332bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69826?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

