### PR TITLE
fix(intake): Tier-4 loop starvation — off-loop coverage index (kills 41.7s ingest scan)

### DIFF
--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -8,6 +8,7 @@ Pipeline: schema_validate → normalize → dedup → priority_arbitration →
 Dispatch loop runs as a background asyncio.Task.
 File advisory lock prevents two router instances on the same project root.
 """
+
 from __future__ import annotations
 
 import asyncio
@@ -119,6 +120,7 @@ async def await_router_ready(bus: Any, timeout_s: float) -> bool:
     """
     woke = asyncio.Event()
     if bus is not None:
+
         async def _on_ready(_ev: Any) -> None:
             woke.set()
 
@@ -218,10 +220,16 @@ def _intake_priority_scheduler_shadow_enabled() -> bool:
     Shadow is inert when the master flag is on (primary mode dominates).
     Default off.
     """
-    raw = os.environ.get(
-        "JARVIS_INTAKE_PRIORITY_SCHEDULER_SHADOW", "",
-    ).strip().lower()
+    raw = (
+        os.environ.get(
+            "JARVIS_INTAKE_PRIORITY_SCHEDULER_SHADOW",
+            "",
+        )
+        .strip()
+        .lower()
+    )
     return raw in {"1", "true", "yes", "on"}
+
 
 # ---------------------------------------------------------------------------
 # Priority map — lower int = higher priority
@@ -261,21 +269,23 @@ _PRIORITY_MAP: Dict[str, int] = {
 # `tests/governance/test_unified_intake_router_priority_map.py`
 # catches drift.  Migration removes entries here as their tiers are
 # assigned.
-_PRIORITY_MAP_DEFERRED: frozenset = frozenset({
-    "auto_proposed",
-    "cadence_synthetic",
-    "cross_repo_drift",
-    "doc_staleness",
-    "github_issue",
-    "intent_discovery",
-    "meta_dormancy_alarm",
-    "performance_regression",
-    "security_advisory",
-    "test_coverage",  # Slice 239 — decoupled background test-gen (deferred tier)
-    "todo_scanner",
-    "vision_sensor",
-    "web_intelligence",
-})
+_PRIORITY_MAP_DEFERRED: frozenset = frozenset(
+    {
+        "auto_proposed",
+        "cadence_synthetic",
+        "cross_repo_drift",
+        "doc_staleness",
+        "github_issue",
+        "intent_discovery",
+        "meta_dormancy_alarm",
+        "performance_regression",
+        "security_advisory",
+        "test_coverage",  # Slice 239 — decoupled background test-gen (deferred tier)
+        "todo_scanner",
+        "vision_sensor",
+        "web_intelligence",
+    }
+)
 
 # Urgency → priority boost (subtracted from base, so lower = higher priority)
 _URGENCY_BOOST: Dict[str, int] = {
@@ -350,9 +360,9 @@ _SOURCE_TO_GOVERNOR_SENSOR: Dict[str, str] = {
 # (adds SPECULATIVE which isn't currently produced by sensors).
 _URGENCY_STR_TO_GOVERNOR: Dict[str, str] = {
     "critical": "immediate",  # 2.0x multiplier
-    "high": "standard",       # 1.0x multiplier
-    "normal": "complex",      # 0.8x multiplier
-    "low": "background",      # 0.5x multiplier
+    "high": "standard",  # 1.0x multiplier
+    "normal": "complex",  # 0.8x multiplier
+    "low": "background",  # 0.5x multiplier
 }
 
 
@@ -384,9 +394,14 @@ def _intake_cognitive_shed_mode() -> str:
     DISABLED verdict until explicitly enabled, so ``shadow`` is inert by
     default. ``enforce`` sheds ONLY the lowest-urgency deferrable signals.
     """
-    raw = os.environ.get(
-        "JARVIS_INTAKE_COGNITIVE_SHED_MODE", "shadow",
-    ).strip().lower()
+    raw = (
+        os.environ.get(
+            "JARVIS_INTAKE_COGNITIVE_SHED_MODE",
+            "shadow",
+        )
+        .strip()
+        .lower()
+    )
     if raw in ("off", "shadow", "enforce"):
         return raw
     return "shadow"
@@ -405,9 +420,14 @@ def _allow_log_mode() -> str:
     INFO noise is unacceptable. Default is ``off``; ``summary`` rate-limits
     to 1/N; ``debug`` requires explicit verbose opt-in.
     """
-    raw = os.environ.get(
-        "JARVIS_INTAKE_GOVERNOR_ALLOW_LOG", "off",
-    ).strip().lower()
+    raw = (
+        os.environ.get(
+            "JARVIS_INTAKE_GOVERNOR_ALLOW_LOG",
+            "off",
+        )
+        .strip()
+        .lower()
+    )
     if raw in ("off", "summary", "debug"):
         return raw
     return "off"
@@ -424,6 +444,7 @@ def _allow_log_interval() -> int:
     except (TypeError, ValueError):
         return 100
     return max(1, min(10000, v))
+
 
 # P2.4: Module-level GoalTracker reference.  Set by UnifiedIntakeRouter on
 # init so _compute_priority can apply goal-alignment boost without changing
@@ -452,7 +473,8 @@ def _ingest_stratification_enabled() -> bool:
     """Slice 49 master switch (default ON). Off → byte-identical pre-Slice-49
     priority (no penalty, no file reads in the hot intake path)."""
     return os.environ.get(
-        "JARVIS_INGEST_STRATIFICATION_ENABLED", "true",
+        "JARVIS_INGEST_STRATIFICATION_ENABLED",
+        "true",
     ).strip().lower() not in ("false", "0", "no", "off")
 
 
@@ -576,7 +598,8 @@ def _compute_priority(
     if _active_goal_tracker is not None:
         try:
             alignment = _active_goal_tracker.alignment_context(
-                envelope.description, envelope.target_files,
+                envelope.description,
+                envelope.target_files,
             )
             goal_boost = int(getattr(alignment, "boost", 0) or 0)
         except Exception as exc:
@@ -586,12 +609,14 @@ def _compute_priority(
                 logger.warning(
                     "[Router] goal alignment scorer failed (first occurrence, "
                     "subsequent failures will log at DEBUG): %s",
-                    exc, exc_info=True,
+                    exc,
+                    exc_info=True,
                 )
             else:
                 logger.debug(
                     "[Router] goal alignment scorer failed (total=%d): %s",
-                    _goal_alignment_failures, exc,
+                    _goal_alignment_failures,
+                    exc,
                 )
 
     # SemanticIndex v0.1: soft semantic prior capped at BOOST_MAX (default 1)
@@ -616,6 +641,7 @@ def _compute_priority(
             from backend.core.ouroboros.governance.semantic_index import (
                 get_default_index,
             )
+
             _si = get_default_index()
             # Q3 Slice 3 — non-blocking build trigger. The hot intake path
             # must not stall on git-log subprocesses + corpus assembly +
@@ -656,6 +682,7 @@ def _compute_priority(
             inference_enabled,
             priority_boost_for_signal,
         )
+
         if inference_enabled():
             _engine = get_default_engine()
             if _engine is not None:
@@ -675,21 +702,18 @@ def _compute_priority(
                     # value above so operators set the FLOAT ceiling
                     # and the INT projection follows naturally.
                     import math as _math
-                    inferred_direction_boost = (
-                        int(_math.ceil(_raw)) if _raw > 0.0 else 0
-                    )
+
+                    inferred_direction_boost = int(_math.ceil(_raw)) if _raw > 0.0 else 0
                     if inferred_direction_boost > 0 and isinstance(
-                        envelope.evidence, dict,
+                        envelope.evidence,
+                        dict,
                     ):
-                        envelope.evidence["inferred_direction_boost"] = (
-                            inferred_direction_boost
-                        )
-                        envelope.evidence[
-                            "inferred_direction_raw"
-                        ] = round(float(_raw), 3)
+                        envelope.evidence["inferred_direction_boost"] = inferred_direction_boost
+                        envelope.evidence["inferred_direction_raw"] = round(float(_raw), 3)
     except Exception as exc:  # noqa: BLE001 -- defensive fail-soft
         logger.debug(
-            "[Router] inferred-direction boost skipped: %s", exc,
+            "[Router] inferred-direction boost skipped: %s",
+            exc,
         )
 
     # Slice 49 — universal ingestion stratification (SOFT). Add a bounded
@@ -713,6 +737,7 @@ def _compute_priority(
             from backend.core.ouroboros.governance.target_stratification import (
                 ingest_priority_penalty,
             )
+
             stratification_penalty = ingest_priority_penalty(
                 envelope.target_files or (),
                 repo_root,
@@ -724,8 +749,13 @@ def _compute_priority(
             logger.debug("[Router] ingest stratification skipped: %s", exc)
 
     priority = (
-        base - urgency + cost_penalty - confidence_bonus
-        - dep_bonus - goal_boost - semantic_boost
+        base
+        - urgency
+        + cost_penalty
+        - confidence_bonus
+        - dep_bonus
+        - goal_boost
+        - semantic_boost
         - inferred_direction_boost
         + stratification_penalty
     )
@@ -797,7 +827,9 @@ class UnifiedIntakeRouter:
     - Dead-letter queue after max retries are exhausted
     """
 
-    def __init__(self, gls: Any, config: IntakeRouterConfig, runtime_orchestrator: Any = None) -> None:
+    def __init__(
+        self, gls: Any, config: IntakeRouterConfig, runtime_orchestrator: Any = None
+    ) -> None:
         global _active_goal_tracker
         self._gls = gls
         self._runtime_orchestrator = runtime_orchestrator
@@ -808,9 +840,7 @@ class UnifiedIntakeRouter:
         # through to envelope comparison — see _HEAP_TIE_SEQ module
         # docstring + the dedicated regression spine at
         # tests/governance/intake/test_unified_intake_router_heap_tiebreak.py
-        self._queue: asyncio.PriorityQueue[
-            Tuple[int, float, int, IntentEnvelope]
-        ] = (
+        self._queue: asyncio.PriorityQueue[Tuple[int, float, int, IntentEnvelope]] = (
             asyncio.PriorityQueue(maxsize=config.max_queue_size)
         )
         self._dedup: Dict[str, float] = {}
@@ -833,6 +863,7 @@ class UnifiedIntakeRouter:
         # Sets the module-level reference so _compute_priority can use it.
         try:
             from backend.core.ouroboros.governance.strategic_direction import GoalTracker
+
             self._goal_tracker = GoalTracker(config.project_root)
             _active_goal_tracker = self._goal_tracker
         except Exception:
@@ -864,20 +895,18 @@ class UnifiedIntakeRouter:
         # is *identity-equivalent* before deletion. A concurrent
         # write that overwrote the entry between capture and
         # re-verify causes the CAS to abort the delete.
-        self._active_file_ops: Dict[str, Tuple[str, float]] = {}  # file_path -> (op_id, time.monotonic())
+        self._active_file_ops: Dict[str, Tuple[str, float]] = (
+            {}
+        )  # file_path -> (op_id, time.monotonic())
         self._active_file_ops_lock: threading.Lock = threading.Lock()
         self._queued_behind: Dict[str, List[IntentEnvelope]] = {}  # op_id -> [envelopes]
-        self._file_lock_ttl_s: float = float(
-            os.environ.get("JARVIS_FILE_LOCK_TTL_S", "300")
-        )
+        self._file_lock_ttl_s: float = float(os.environ.get("JARVIS_FILE_LOCK_TTL_S", "300"))
 
         # ── Signal coalescing buffer ──
         # Envelopes targeting overlapping files within a window are merged into
         # a single multi-goal operation before dispatch (reduces cost by N×).
         # HIGH urgency signals bypass coalescing and dispatch immediately.
-        self._coalesce_window_s: float = float(
-            os.environ.get("JARVIS_COALESCE_WINDOW_S", "30")
-        )
+        self._coalesce_window_s: float = float(os.environ.get("JARVIS_COALESCE_WINDOW_S", "30"))
         # Maps frozenset(target_files) key -> (first_arrival_monotonic, [envelopes])
         self._coalesce_buffer: Dict[str, List[IntentEnvelope]] = {}
         self._coalesce_timestamps: Dict[str, float] = {}  # key -> first arrival
@@ -937,8 +966,8 @@ class UnifiedIntakeRouter:
             set_default_intake_router(self)
         except Exception as exc:  # noqa: BLE001
             logger.debug(
-                "[UnifiedIntakeRouter] auto-register-default "
-                "degraded: %s", exc,
+                "[UnifiedIntakeRouter] auto-register-default " "degraded: %s",
+                exc,
             )
 
     # ------------------------------------------------------------------
@@ -951,9 +980,7 @@ class UnifiedIntakeRouter:
             return
         self._acquire_lock()
         self._running = True
-        self._dispatch_task = asyncio.create_task(
-            self._dispatch_loop(), name="intake_dispatch"
-        )
+        self._dispatch_task = asyncio.create_task(self._dispatch_loop(), name="intake_dispatch")
         await self._replay_wal()
         await self._hydrate_fsm_checkpoints()
 
@@ -963,7 +990,12 @@ class UnifiedIntakeRouter:
         exploration context, so the DAG fast-forwards instead of re-exploring.
         Gated by ``JARVIS_FSM_RESUME_ENABLED`` (default on). Fully fail-soft --
         NEVER blocks boot. Rejected (unverified) checkpoints fall back to clean boot."""
-        if os.environ.get("JARVIS_FSM_RESUME_ENABLED", "true").strip().lower() in ("0", "false", "no", "off"):
+        if os.environ.get("JARVIS_FSM_RESUME_ENABLED", "true").strip().lower() in (
+            "0",
+            "false",
+            "no",
+            "off",
+        ):
             return
         try:
             from backend.core.ouroboros.governance import fsm_checkpoint as _ckpt  # noqa: PLC0415
@@ -986,6 +1018,7 @@ class UnifiedIntakeRouter:
                         from backend.core.ouroboros.governance import (  # noqa: PLC0415
                             a1_trace as _a1t,
                         )
+
                         _a1t.restore_emit_record(
                             _kw["causal_id"],
                             source=str(_lin["emit_source"]),
@@ -1006,7 +1039,9 @@ class UnifiedIntakeRouter:
                     logger.info(
                         "Router: RESUMED suspended op=%s phase=%s (%d exploration "
                         "records preserved -> Venom fast-forward)",
-                        _cp.op_id, _cp.phase, len(_cp.exploration_records),
+                        _cp.op_id,
+                        _cp.phase,
+                        len(_cp.exploration_records),
                     )
                 except Exception:  # noqa: BLE001
                     logger.warning(
@@ -1019,6 +1054,7 @@ class UnifiedIntakeRouter:
             # it just replayed. Idempotent (module cache is just refreshed).
             try:
                 from backend.core.ouroboros.governance import cognitive_persistence as _cogp
+
                 if _cogp.is_enabled() and _cogp._env_bool(
                     "JARVIS_COGNITIVE_HYDRATE_ON_CHECKPOINT_RESUME", True
                 ):
@@ -1057,6 +1093,7 @@ class UnifiedIntakeRouter:
         from backend.core.ouroboros.telemetry.loop_sink import (
             sink_async as _ls_sink_async,
         )
+
         async with _ls_sink_async("intake.UnifiedIntakeRouter.ingest"):
             return await self._ingest_impl(envelope)
 
@@ -1067,6 +1104,7 @@ class UnifiedIntakeRouter:
                 a1trace as _a1trace,
                 probe_ingest_order as _probe_ingest_order,
             )
+
             _a1trace("ingest", envelope.causal_id, router="attached")
             # Deep emit-hop telemetry (Run #17): emit the order-assertion vs
             # this goal's prior emit (MISSING if none -- the Run-#17 mode).
@@ -1084,6 +1122,7 @@ class UnifiedIntakeRouter:
             from backend.core.ouroboros.governance.provenance_ledger import (  # noqa: PLC0415
                 stamp_provenance as _stamp_provenance,
             )
+
             # Trace Lineage: a resumed op stamps its ORIGINAL origin (from
             # HMAC-verified checkpoint lineage), not the resume transport.
             _stamp_provenance(envelope.causal_id, _provenance_origin_for(envelope))
@@ -1131,18 +1170,22 @@ class UnifiedIntakeRouter:
                     logger.info(
                         "[Router] governor ENFORCE deny: "
                         "sensor=%s urgency=%s reason=%s cap=%d count=%d",
-                        envelope.source, envelope.urgency,
+                        envelope.source,
+                        envelope.urgency,
                         gov_decision.reason_code,
-                        gov_decision.weighted_cap, gov_decision.current_count,
+                        gov_decision.weighted_cap,
+                        gov_decision.current_count,
                     )
                     return "governor_throttled"
                 # shadow: would have denied but allow through
                 logger.info(
                     "[Router] governor SHADOW deny (would have thrown): "
                     "sensor=%s urgency=%s reason=%s cap=%d count=%d",
-                    envelope.source, envelope.urgency,
+                    envelope.source,
+                    envelope.urgency,
                     gov_decision.reason_code,
-                    gov_decision.weighted_cap, gov_decision.current_count,
+                    gov_decision.weighted_cap,
+                    gov_decision.current_count,
                 )
             elif gov_decision is not None and gov_decision.allowed:
                 # Follow-up #1 — visibility into "governor allowed this"
@@ -1157,18 +1200,24 @@ class UnifiedIntakeRouter:
         # critical/high/normal intake. The substrate master keeps it inert by
         # default. NEVER raises into intake.
         shed_mode = _intake_cognitive_shed_mode()
-        if shed_mode != "off" and str(
-            getattr(envelope, "urgency", ""),
-        ) in _SHEDDABLE_URGENCIES:
+        if (
+            shed_mode != "off"
+            and str(
+                getattr(envelope, "urgency", ""),
+            )
+            in _SHEDDABLE_URGENCIES
+        ):
             try:
                 from backend.core.ouroboros.governance.cognitive_load_shedding import (  # noqa: E501
                     LoadVerdict,
                     ShedKind,
                     evaluate_cognitive_load,
                 )
+
                 _load = evaluate_cognitive_load()
                 _should_shed = _load.verdict in (
-                    LoadVerdict.ELEVATED, LoadVerdict.OVERLOADED,
+                    LoadVerdict.ELEVATED,
+                    LoadVerdict.OVERLOADED,
                 ) and _load.shed_kind in (
                     ShedKind.SPECULATIVE_SHED,
                     ShedKind.BACKGROUND_SHED,
@@ -1179,16 +1228,20 @@ class UnifiedIntakeRouter:
                         logger.info(
                             "[Router] cognitive-shed ENFORCE: source=%s "
                             "urgency=%s verdict=%s shed=%s load=%.3f",
-                            envelope.source, envelope.urgency,
-                            _load.verdict.value, _load.shed_kind.value,
+                            envelope.source,
+                            envelope.urgency,
+                            _load.verdict.value,
+                            _load.shed_kind.value,
                             _load.load_score,
                         )
                         return "cognitive_shed"
                     logger.info(
                         "[Router] cognitive-shed SHADOW (would shed): "
                         "source=%s urgency=%s verdict=%s shed=%s load=%.3f",
-                        envelope.source, envelope.urgency,
-                        _load.verdict.value, _load.shed_kind.value,
+                        envelope.source,
+                        envelope.urgency,
+                        _load.verdict.value,
+                        _load.shed_kind.value,
                         _load.load_score,
                     )
             except Exception:  # noqa: BLE001 — never break intake
@@ -1197,13 +1250,15 @@ class UnifiedIntakeRouter:
         # 4. WAL enqueue — durable before placing on in-memory queue
         lease_id = generate_operation_id("lse")
         envelope = envelope.with_lease(lease_id)
-        self._wal.append(WALEntry(
-            lease_id=lease_id,
-            envelope_dict=envelope.to_dict(),
-            status="pending",
-            ts_monotonic=time.monotonic(),
-            ts_utc=datetime.now(timezone.utc).isoformat(),
-        ))
+        self._wal.append(
+            WALEntry(
+                lease_id=lease_id,
+                envelope_dict=envelope.to_dict(),
+                status="pending",
+                ts_monotonic=time.monotonic(),
+                ts_utc=datetime.now(timezone.utc).isoformat(),
+            )
+        )
 
         # 5. Register dedup key now so subsequent duplicates are caught
         self._register_dedup(envelope)
@@ -1213,7 +1268,7 @@ class UnifiedIntakeRouter:
         # Dependency credit: count how many signals are queued behind files
         # this op would touch — completing it unblocks them.
         _dep_credit = 0
-        for _fpath in (envelope.target_files or ()):
+        for _fpath in envelope.target_files or ():
             _blocking_entry = self._active_file_ops.get(_fpath)
             if _blocking_entry is not None:
                 _blocking_id, _ = _blocking_entry
@@ -1232,6 +1287,7 @@ class UnifiedIntakeRouter:
             from backend.core.ouroboros.governance.semantic_index import (
                 get_default_index,
             )
+
             # Per-repo index keyed on the router's configured project_root
             # (matches orchestrator / classify_runner CONTEXT_EXPANSION) — in
             # production this resolves to the same singleton the legacy
@@ -1243,15 +1299,18 @@ class UnifiedIntakeRouter:
             )
             _semantic_override = int(_sem_boost)
             if (_sem_boost > 0 or _si.stats().built_at > 0) and isinstance(
-                envelope.evidence, dict,
+                envelope.evidence,
+                dict,
             ):
                 envelope.evidence["semantic_alignment"] = round(
-                    float(_sem_score), 4,
+                    float(_sem_score),
+                    4,
                 )
                 envelope.evidence["semantic_boost"] = int(_sem_boost)
         except Exception as _sem_exc:  # noqa: BLE001 — never break intake
             logger.debug(
-                "[Router] offloaded semantic scorer skipped: %s", _sem_exc,
+                "[Router] offloaded semantic scorer skipped: %s",
+                _sem_exc,
             )
             _semantic_override = None
         # Tier-4 — stratification coverage penalty OFF the asyncio loop.
@@ -1281,6 +1340,7 @@ class UnifiedIntakeRouter:
                     ingest_priority_penalty,
                     trigger_coverage_index_build,
                 )
+
                 _idx_ready = coverage_index_ready(self._config.project_root)
                 # Always fire the trigger — it self-gates (single-flight
                 # "building" set, TTL freshness, failure cooldown) and
@@ -1291,6 +1351,7 @@ class UnifiedIntakeRouter:
                         is_offload_error,
                         offload,
                     )
+
                     _pen = await offload(
                         ingest_priority_penalty,
                         envelope.target_files,
@@ -1301,18 +1362,18 @@ class UnifiedIntakeRouter:
                     if not is_offload_error(_pen):
                         _strat_override = max(0, int(_pen))
                         if _strat_override > 0 and isinstance(
-                            envelope.evidence, dict,
+                            envelope.evidence,
+                            dict,
                         ):
-                            envelope.evidence["stratification_penalty"] = (
-                                _strat_override
-                            )
+                            envelope.evidence["stratification_penalty"] = _strat_override
             except Exception as _strat_exc:  # noqa: BLE001 — never break intake
                 logger.debug(
                     "[Router] offloaded stratification skipped (degraded): %s",
                     _strat_exc,
                 )
         priority, alignment = _compute_priority(
-            envelope, dependency_credit=_dep_credit,
+            envelope,
+            dependency_credit=_dep_credit,
             repo_root=self._config.project_root,
             semantic_boost_override=_semantic_override,
             stratification_penalty_override=_strat_override,
@@ -1371,13 +1432,17 @@ class UnifiedIntakeRouter:
         """
         try:
             from backend.core.ouroboros.governance.sensor_governor import (
-                Urgency as GovernorUrgency, ensure_seeded,
+                Urgency as GovernorUrgency,
+                ensure_seeded,
             )
+
             sensor_name = _SOURCE_TO_GOVERNOR_SENSOR.get(
-                envelope.source, envelope.source,
+                envelope.source,
+                envelope.source,
             )
             urgency_str = _URGENCY_STR_TO_GOVERNOR.get(
-                envelope.urgency, "standard",
+                envelope.urgency,
+                "standard",
             )
             urgency = GovernorUrgency(urgency_str)
             governor = ensure_seeded()
@@ -1390,7 +1455,9 @@ class UnifiedIntakeRouter:
             return None
 
     def _note_governor_allow(
-        self, envelope: IntentEnvelope, decision: Any,
+        self,
+        envelope: IntentEnvelope,
+        decision: Any,
     ) -> None:
         """Follow-up #1 — rate-limited / opt-in visibility for governor allows.
 
@@ -1410,18 +1477,17 @@ class UnifiedIntakeRouter:
             sensor = envelope.source
             if mode == "debug":
                 logger.debug(
-                    "[Router] governor allow: sensor=%s urgency=%s "
-                    "cap=%d count=%d remaining=%d",
-                    sensor, envelope.urgency,
-                    decision.weighted_cap, decision.current_count,
+                    "[Router] governor allow: sensor=%s urgency=%s " "cap=%d count=%d remaining=%d",
+                    sensor,
+                    envelope.urgency,
+                    decision.weighted_cap,
+                    decision.current_count,
                     decision.remaining,
                 )
                 return
             # summary: accumulate and emit one structured line per N allows
             self._gov_allow_total += 1
-            self._gov_allow_by_sensor[sensor] = (
-                self._gov_allow_by_sensor.get(sensor, 0) + 1
-            )
+            self._gov_allow_by_sensor[sensor] = self._gov_allow_by_sensor.get(sensor, 0) + 1
             interval = _allow_log_interval()
             if self._gov_allow_total >= interval:
                 top5 = sorted(
@@ -1430,9 +1496,10 @@ class UnifiedIntakeRouter:
                 )[:5]
                 pairs = " ".join(f"{k}={v}" for k, v in top5)
                 logger.info(
-                    "[Router] governor allow rollup: total=%d window=%d "
-                    "top_sensors=[%s]",
-                    self._gov_allow_total, interval, pairs,
+                    "[Router] governor allow rollup: total=%d window=%d " "top_sensors=[%s]",
+                    self._gov_allow_total,
+                    interval,
+                    pairs,
                 )
                 self._gov_allow_total = 0
                 self._gov_allow_by_sensor.clear()
@@ -1446,13 +1513,17 @@ class UnifiedIntakeRouter:
         """Record emission in the rolling-window counter. Never raises."""
         try:
             from backend.core.ouroboros.governance.sensor_governor import (
-                Urgency as GovernorUrgency, ensure_seeded,
+                Urgency as GovernorUrgency,
+                ensure_seeded,
             )
+
             sensor_name = _SOURCE_TO_GOVERNOR_SENSOR.get(
-                envelope.source, envelope.source,
+                envelope.source,
+                envelope.source,
             )
             urgency_str = _URGENCY_STR_TO_GOVERNOR.get(
-                envelope.urgency, "standard",
+                envelope.urgency,
+                "standard",
             )
             urgency = GovernorUrgency(urgency_str)
             ensure_seeded().record_emission(sensor_name, urgency)
@@ -1499,6 +1570,7 @@ class UnifiedIntakeRouter:
                 return None
             # Reverse URGENCY_RANK lookup (small dict; O(4)).
             from .intake_priority_queue import URGENCY_RANK as _RANK
+
             for urgency_str, r in _RANK.items():
                 if r == rank:
                     return urgency_str
@@ -1538,6 +1610,7 @@ class UnifiedIntakeRouter:
         if envelope is None:
             return False
         from .intent_envelope import make_envelope
+
         merged_evidence = dict(envelope.evidence)
         if extra_evidence:
             merged_evidence.update(extra_evidence)
@@ -1580,9 +1653,7 @@ class UnifiedIntakeRouter:
             return "|".join(sorted(envelope.target_files))
         _sig = ""
         try:
-            _sig = str(
-                (envelope.evidence or {}).get("signature", "")
-            ).strip()
+            _sig = str((envelope.evidence or {}).get("signature", "")).strip()
         except Exception:  # noqa: BLE001 — never raise in dispatch hot path
             _sig = ""
         if _sig:
@@ -1614,7 +1685,8 @@ class UnifiedIntakeRouter:
         _merged_desc = " | ".join(_descs)
         logger.info(
             "[Router] Coalesced %d signals targeting %s into single operation",
-            len(envelopes), list(_merged_files)[:3],
+            len(envelopes),
+            list(_merged_files)[:3],
         )
         # Use the first envelope as base, replace merged fields
         base = envelopes[0]
@@ -1622,8 +1694,10 @@ class UnifiedIntakeRouter:
             try:
                 self._wal.update_status(_absorbed.lease_id, "acked")
             except Exception:  # noqa: BLE001 — ack is best-effort; never block the flush
-                logger.warning("[Intake] absorbed-lease ack failed lease=%s",
-                               getattr(_absorbed, "lease_id", "?"))
+                logger.warning(
+                    "[Intake] absorbed-lease ack failed lease=%s",
+                    getattr(_absorbed, "lease_id", "?"),
+                )
         return IntentEnvelope(
             schema_version=base.schema_version,
             source=base.source,
@@ -1689,8 +1763,11 @@ class UnifiedIntakeRouter:
                 logger.debug(
                     "[IntakePriority] primary dequeue urgency=%s source=%s "
                     "waited_s=%.2f mode=%s depth=%d",
-                    decision.urgency, decision.source, decision.waited_s,
-                    decision.dequeue_mode, len(self._priority_queue),
+                    decision.urgency,
+                    decision.source,
+                    decision.waited_s,
+                    decision.dequeue_mode,
+                    len(self._priority_queue),
                 )
             else:
                 # Legacy path (byte-identical to pre-F1).
@@ -1720,8 +1797,10 @@ class UnifiedIntakeRouter:
                                 "[IntakePriority shadow_delta] "
                                 "legacy_popped=%s:%s shadow_would_pop=%s:%s "
                                 "(mode=%s waited_s=%.2f)",
-                                envelope.source, envelope.urgency,
-                                shadow_decision.source, shadow_decision.urgency,
+                                envelope.source,
+                                envelope.urgency,
+                                shadow_decision.source,
+                                shadow_decision.urgency,
                                 shadow_decision.dequeue_mode,
                                 shadow_decision.waited_s,
                             )
@@ -1739,9 +1818,7 @@ class UnifiedIntakeRouter:
                 except asyncio.CancelledError:
                     break
                 except Exception:
-                    logger.exception(
-                        "Router: dispatch error for lease_id=%s", envelope.lease_id
-                    )
+                    logger.exception("Router: dispatch error for lease_id=%s", envelope.lease_id)
                 finally:
                     if _legacy_task_done_owed:
                         self._queue.task_done()
@@ -1763,8 +1840,7 @@ class UnifiedIntakeRouter:
         """Dispatch any coalescing buffers whose window has expired."""
         _now = time.monotonic()
         _expired_keys = [
-            k for k, ts in self._coalesce_timestamps.items()
-            if _now - ts >= self._coalesce_window_s
+            k for k, ts in self._coalesce_timestamps.items() if _now - ts >= self._coalesce_window_s
         ]
         for _key in _expired_keys:
             merged = self._flush_coalesced(_key)
@@ -1772,9 +1848,7 @@ class UnifiedIntakeRouter:
                 try:
                     await self._dispatch_one(merged)
                 except Exception:
-                    logger.exception(
-                        "Router: dispatch error for coalesced key=%s", _key[:50]
-                    )
+                    logger.exception("Router: dispatch error for coalesced key=%s", _key[:50])
 
     @staticmethod
     def _is_runtime_task(envelope: IntentEnvelope) -> bool:
@@ -1791,9 +1865,21 @@ class UnifiedIntakeRouter:
         desc = envelope.description.lower()
         # Code change indicators — if present, route to GLS
         _CODE_SIGNALS = (
-            "fix bug", "implement", "refactor", "add feature", "update code",
-            "write function", "create module", "modify file", "change the code",
-            "add test", "fix the", "patch", "debug", "commit", "merge",
+            "fix bug",
+            "implement",
+            "refactor",
+            "add feature",
+            "update code",
+            "write function",
+            "create module",
+            "modify file",
+            "change the code",
+            "add test",
+            "fix the",
+            "patch",
+            "debug",
+            "commit",
+            "merge",
         )
         if any(signal in desc for signal in _CODE_SIGNALS):
             return False
@@ -1818,6 +1904,7 @@ class UnifiedIntakeRouter:
             from backend.core.ouroboros.governance.a1_trace import (  # noqa: PLC0415
                 a1trace as _a1trace,
             )
+
             _a1trace("dequeue", envelope.causal_id)
         except Exception:  # noqa: BLE001
             pass
@@ -1847,7 +1934,8 @@ class UnifiedIntakeRouter:
                 return
             except Exception as exc:
                 logger.warning(
-                    "[Router] Runtime dispatch failed, falling back to GLS: %s", exc,
+                    "[Router] Runtime dispatch failed, falling back to GLS: %s",
+                    exc,
                 )
                 # Fall through to GLS as fallback
 
@@ -1869,9 +1957,7 @@ class UnifiedIntakeRouter:
         # op.context.is_read_only is already True by the time the pool sees
         # the op, so the 900s read-only ceiling branch at
         # background_agent_pool.py:~691 fires correctly.
-        _is_read_only_at_intake = bool(infer_read_only_intent(
-            envelope.description or ""
-        ))
+        _is_read_only_at_intake = bool(infer_read_only_intent(envelope.description or ""))
         # F2 Slice 2: when the envelope carries a non-empty
         # routing_override (set by a sensor that emitted a valid
         # routing_hint under the F2 master flag), stamp ctx.provider_route
@@ -1881,11 +1967,7 @@ class UnifiedIntakeRouter:
         # normally via UrgencyRouter.classify source-type mapping).
         _env_routing = getattr(envelope, "routing_override", "") or ""
         _pre_route = _env_routing if _env_routing else ""
-        _pre_route_reason = (
-            f"envelope_routing_override:{_env_routing}"
-            if _env_routing
-            else ""
-        )
+        _pre_route_reason = f"envelope_routing_override:{_env_routing}" if _env_routing else ""
         # A1-T3 — stamp intake-origin DAG weight onto evidence BEFORE the
         # snapshot below, so a heavy multi-file GOAL's heaviness rides the
         # existing intake_evidence_json side-channel onto ctx (observable to
@@ -1903,11 +1985,14 @@ class UnifiedIntakeRouter:
         # "corrupt signal".
         try:
             import json as _json_local
+
             _intake_evidence_json = (
                 _json_local.dumps(
-                    dict(envelope.evidence or {}), sort_keys=True,
+                    dict(envelope.evidence or {}),
+                    sort_keys=True,
                 )
-                if envelope.evidence else ""
+                if envelope.evidence
+                else ""
             )
         except (TypeError, ValueError):
             _intake_evidence_json = ""
@@ -1945,6 +2030,7 @@ class UnifiedIntakeRouter:
             from backend.core.ouroboros.governance.complexity_classifier import (  # noqa: E501
                 _COMPLEX_FLOOR_SOURCES,
             )
+
             if envelope.source in _COMPLEX_FLOOR_SOURCES:
                 object.__setattr__(ctx, "task_complexity", "complex")
         except Exception:  # noqa: BLE001 — floor is best-effort; never block intake
@@ -1978,6 +2064,7 @@ class UnifiedIntakeRouter:
             from backend.core.ouroboros.governance.op_context import (
                 Attachment,
             )
+
             _hoisted: List[Any] = []
 
             # (1) VisionSensor autonomous path.
@@ -1995,8 +2082,11 @@ class UnifiedIntakeRouter:
                     logger.info(
                         "[IntakeRouter] attachments_hoisted op=%s kind=sensor_frame "
                         "hash8=%s mime=%s app_id=%s source=%s",
-                        envelope.causal_id, _att.hash8, _att.mime_type,
-                        (_app_id or "-"), envelope.source,
+                        envelope.causal_id,
+                        _att.hash8,
+                        _att.mime_type,
+                        (_app_id or "-"),
+                        envelope.source,
                     )
 
             # (2) Operator-initiated /attach path.
@@ -2013,8 +2103,11 @@ class UnifiedIntakeRouter:
                     logger.info(
                         "[IntakeRouter] attachments_hoisted op=%s kind=user_provided "
                         "hash8=%s mime=%s basename=%s source=%s",
-                        envelope.causal_id, _att.hash8, _att.mime_type,
-                        os.path.basename(_p), envelope.source,
+                        envelope.causal_id,
+                        _att.hash8,
+                        _att.mime_type,
+                        os.path.basename(_p),
+                        envelope.source,
                     )
 
             if _hoisted:
@@ -2024,7 +2117,8 @@ class UnifiedIntakeRouter:
             # text-only. Log at DEBUG so a stale frame_path doesn't spam.
             logger.debug(
                 "[IntakeRouter] attachment hoist skipped op=%s: %s",
-                envelope.causal_id, _exc,
+                envelope.causal_id,
+                _exc,
             )
         # A1-T4 — hop 4/5 (submit): the envelope's OperationContext is handed
         # to the GovernedLoopService (the FSM entry). goal id == ctx.op_id.
@@ -2032,6 +2126,7 @@ class UnifiedIntakeRouter:
             from backend.core.ouroboros.governance.a1_trace import (  # noqa: PLC0415
                 a1trace as _a1trace,
             )
+
             _a1trace("submit", ctx.op_id, target="GLS")
         except Exception:  # noqa: BLE001
             pass
@@ -2074,12 +2169,14 @@ class UnifiedIntakeRouter:
                 # If the queue is full, dead-letter immediately rather than stall.
                 priority, _alignment = _compute_priority(envelope)
                 try:
-                    self._queue.put_nowait((
-                        priority,
-                        envelope.submitted_at,
-                        next(_HEAP_TIE_SEQ),
-                        envelope,
-                    ))
+                    self._queue.put_nowait(
+                        (
+                            priority,
+                            envelope.submitted_at,
+                            next(_HEAP_TIE_SEQ),
+                            envelope,
+                        )
+                    )
                 except asyncio.QueueFull:
                     logger.error(
                         "Router: queue full during retry — dead-lettering lease_id=%s",
@@ -2100,6 +2197,7 @@ class UnifiedIntakeRouter:
             return
         logger.info("Router: replaying %d pending WAL entries", len(pending))
         from .intent_envelope import IntentEnvelope as IE
+
         for entry in pending:
             try:
                 envelope = IE.from_dict(entry.envelope_dict)
@@ -2109,21 +2207,21 @@ class UnifiedIntakeRouter:
                 # with a second round of scorer failures if the tracker
                 # happens to be broken at replay time.
                 priority, _alignment = _compute_priority(envelope)
-                await self._queue.put((
-                    priority,
-                    envelope.submitted_at,
-                    next(_HEAP_TIE_SEQ),
-                    envelope,
-                ))
+                await self._queue.put(
+                    (
+                        priority,
+                        envelope.submitted_at,
+                        next(_HEAP_TIE_SEQ),
+                        envelope,
+                    )
+                )
                 logger.debug(
                     "Router: replayed lease_id=%s source=%s",
                     entry.lease_id,
                     envelope.source,
                 )
             except Exception:
-                logger.exception(
-                    "Router: WAL replay failed for lease_id=%s", entry.lease_id
-                )
+                logger.exception("Router: WAL replay failed for lease_id=%s", entry.lease_id)
 
     # ------------------------------------------------------------------
     # Operation dependency tracking (DAG-based signal merging)
@@ -2140,7 +2238,7 @@ class UnifiedIntakeRouter:
         is never silently clobbered.
         """
         _now = time.monotonic()
-        for fpath in (envelope.target_files or []):
+        for fpath in envelope.target_files or []:
             with self._active_file_ops_lock:
                 entry = self._active_file_ops.get(fpath)
                 if entry is None:
@@ -2154,19 +2252,22 @@ class UnifiedIntakeRouter:
                     # the identity check fails and we abort the delete.
                     current = self._active_file_ops.get(fpath)
                     if current is not None and (
-                        current[0] == _op_id
-                        and current[1] == _registered_at
+                        current[0] == _op_id and current[1] == _registered_at
                     ):
                         logger.warning(
                             "[Router] Force-releasing stale file lock: %s held by %s for %.0fs (TTL %ds)",
-                            fpath, _op_id[:12], age, self._file_lock_ttl_s,
+                            fpath,
+                            _op_id[:12],
+                            age,
+                            self._file_lock_ttl_s,
                         )
                         del self._active_file_ops[fpath]
                     else:
                         logger.debug(
                             "[Router] CAS aborted stale-release on %s: "
                             "entry mutated under us (was %s, now %s)",
-                            fpath, _op_id[:12],
+                            fpath,
+                            _op_id[:12],
                             current[0][:12] if current else "(absent)",
                         )
                     continue
@@ -2200,10 +2301,7 @@ class UnifiedIntakeRouter:
         # under the lock so we never delete a key that was already
         # rewritten to a different op_id by a concurrent registrant.
         with self._active_file_ops_lock:
-            stale_keys = [
-                k for k, v in self._active_file_ops.items()
-                if v[0] == op_id
-            ]
+            stale_keys = [k for k, v in self._active_file_ops.items() if v[0] == op_id]
             for k in stale_keys:
                 # Re-verify identity under the same lock — defends
                 # against a concurrent register_active_op that
@@ -2218,7 +2316,8 @@ class UnifiedIntakeRouter:
         for envelope in queued:
             logger.info(
                 "[Router] Re-ingesting signal queued behind completed op %s: %s",
-                op_id[:12], envelope.description[:50],
+                op_id[:12],
+                envelope.description[:50],
             )
             await self.ingest(envelope)
 
@@ -2292,6 +2391,7 @@ class UnifiedIntakeRouter:
         self._lock_fd = fd
         try:
             import json as _json
+
             _prior_pid: Optional[int] = None
             _prior_age_s: Optional[float] = None
             try:
@@ -2315,27 +2415,28 @@ class UnifiedIntakeRouter:
             #   * session_id — links lock to the session dir on disk
             # Old readers continue to work (they read pid + ts only).
             from datetime import datetime, timezone
+
             _session_id = os.environ.get("OUROBOROS_SESSION_ID", "")
-            _meta = _json.dumps({
-                "pid": os.getpid(),
-                "ts": time.time(),
-                "monotonic_ts": time.monotonic(),
-                "wall_iso": datetime.now(tz=timezone.utc).strftime(
-                    "%Y-%m-%dT%H:%M:%SZ"
-                ),
-                "session_id": _session_id,
-            })
+            _meta = _json.dumps(
+                {
+                    "pid": os.getpid(),
+                    "ts": time.time(),
+                    "monotonic_ts": time.monotonic(),
+                    "wall_iso": datetime.now(tz=timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "session_id": _session_id,
+                }
+            )
             os.write(fd, _meta.encode())
             os.fsync(fd)
 
             if _prior_pid and _prior_pid != os.getpid():
-                _age_str = (
-                    f"{_prior_age_s:.0f}s" if _prior_age_s is not None else "?s"
-                )
+                _age_str = f"{_prior_age_s:.0f}s" if _prior_age_s is not None else "?s"
                 logger.info(
                     "[IntakeRouter] Overwrote stale lock metadata "
                     "(prior_pid=%d prior_age=%s new_pid=%d)",
-                    _prior_pid, _age_str, os.getpid(),
+                    _prior_pid,
+                    _age_str,
+                    os.getpid(),
                 )
         except OSError:
             pass  # Lock is held — metadata is advisory
@@ -2357,6 +2458,7 @@ class UnifiedIntakeRouter:
         """
         try:
             import json as _json
+
             data = _json.loads(lock_path.read_text())
             pid = data.get("pid", 0)
             ts = float(data.get("ts", 0.0)) if data.get("ts") else 0.0
@@ -2367,14 +2469,16 @@ class UnifiedIntakeRouter:
                 except ProcessLookupError:
                     lock_path.unlink(missing_ok=True)
                     logger.warning(
-                        "[IntakeRouter] Removed stale lock (dead PID %d)", pid,
+                        "[IntakeRouter] Removed stale lock (dead PID %d)",
+                        pid,
                     )
                     return True
                 except PermissionError:
                     pass  # PID alive, different user — fall through to TTL check
                 # (2) Wedged-but-alive TTL check (Slice 2)
                 _stale_ttl_raw = os.environ.get(
-                    "JARVIS_INTAKE_LOCK_STALE_TTL_S", "7200",
+                    "JARVIS_INTAKE_LOCK_STALE_TTL_S",
+                    "7200",
                 )
                 try:
                     _stale_ttl = float(_stale_ttl_raw)
@@ -2387,7 +2491,9 @@ class UnifiedIntakeRouter:
                         "[IntakeRouter] Removed wedged-but-alive stale lock "
                         "(PID=%d alive, age=%.0fs > TTL=%.0fs — treating as "
                         "Py_FinalizeEx-class zombie)",
-                        pid, _age_s, _stale_ttl,
+                        pid,
+                        _age_s,
+                        _stale_ttl,
                     )
                     return True
         except (ValueError, OSError, KeyError):
@@ -2438,8 +2544,8 @@ def set_default_intake_router(router: "UnifiedIntakeRouter") -> None:
             _DEFAULT_INTAKE_ROUTER = router
     except Exception as exc:  # noqa: BLE001 — defensive
         logger.debug(
-            "[UnifiedIntakeRouter] set_default_intake_router "
-            "degraded: %s", exc,
+            "[UnifiedIntakeRouter] set_default_intake_router " "degraded: %s",
+            exc,
         )
 
 
@@ -2474,10 +2580,9 @@ def _stamp_resume_pipeline_deadline(ctx: Any, source: str) -> Any:
         if str(source or "") != "fsm_resume":
             return ctx
         from datetime import datetime, timedelta, timezone  # noqa: PLC0415
-        _pt_s = max(1.0, float(os.environ.get(
-            "JARVIS_PIPELINE_TIMEOUT_S", "600") or 600))
-        return ctx.with_pipeline_deadline(
-            datetime.now(tz=timezone.utc) + timedelta(seconds=_pt_s))
+
+        _pt_s = max(1.0, float(os.environ.get("JARVIS_PIPELINE_TIMEOUT_S", "600") or 600))
+        return ctx.with_pipeline_deadline(datetime.now(tz=timezone.utc) + timedelta(seconds=_pt_s))
     except Exception:  # noqa: BLE001 -- hydration hygiene, never fatal
         return ctx
 
@@ -2493,13 +2598,15 @@ def _resume_envelope_kwargs(env: "Dict[str, Any]") -> "Dict[str, Any]":
     import json as _rj  # noqa: PLC0415
 
     _lineage = dict(env.get("trace_lineage") or {})
-    _ev_json = _rj.dumps({
-        "resume": True,
-        "resume_phase": env.get("resume_phase", ""),
-        "partial_completion": env.get("partial_completion", ""),
-        "resumed_op_id": env.get("op_id", ""),
-        "trace_lineage": _lineage,
-    })
+    _ev_json = _rj.dumps(
+        {
+            "resume": True,
+            "resume_phase": env.get("resume_phase", ""),
+            "partial_completion": env.get("partial_completion", ""),
+            "resumed_op_id": env.get("op_id", ""),
+            "trace_lineage": _lineage,
+        }
+    )
     _ev = {
         "resume": True,
         "resume_phase": env.get("resume_phase", ""),

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -518,6 +518,7 @@ def _compute_priority(
     repo_root: "Optional[Path]" = None,
     resurrected: bool = False,
     semantic_boost_override: "Optional[int]" = None,
+    stratification_penalty_override: "Optional[int]" = None,
 ) -> Tuple[int, Optional[Any]]:
     """Compute cost-aware priority score + rich goal alignment for an envelope.
 
@@ -699,7 +700,15 @@ def _compute_priority(
     # Authority invariant: priority ordering ONLY — never fed to UrgencyRouter,
     # Iron Gate, risk tier, policy engine, FORBIDDEN_PATH, or approval gating.
     stratification_penalty = 0
-    if repo_root is not None and _ingest_stratification_enabled():
+    if stratification_penalty_override is not None:
+        # Tier-4 — the caller (``_ingest_impl``) already computed (or
+        # deliberately degraded) the stratification penalty OFF the asyncio
+        # loop. The inline path below runs file_has_test_coverage's
+        # tests-tree rglob + cold AST-map build synchronously — the traced
+        # 41.7 s on-loop block (bt-iso-1783102490) — so the hot intake path
+        # must NEVER reach it. Evidence stash is done by the caller.
+        stratification_penalty = max(0, int(stratification_penalty_override))
+    elif repo_root is not None and _ingest_stratification_enabled():
         try:
             from backend.core.ouroboros.governance.target_stratification import (
                 ingest_priority_penalty,
@@ -1245,10 +1254,68 @@ class UnifiedIntakeRouter:
                 "[Router] offloaded semantic scorer skipped: %s", _sem_exc,
             )
             _semantic_override = None
+        # Tier-4 — stratification coverage penalty OFF the asyncio loop.
+        # The inline path (``_compute_priority`` → ``ingest_priority_penalty``
+        # → ``file_has_test_coverage``) rglob-walks the ENTIRE tests/ tree
+        # (~2,839 files) per signal and cold-builds the AST import map
+        # (read + ast.parse of ~963K test lines) on first miss — the traced
+        # 41,713 ms single on-loop block of bt-iso-1783102490 (plus the
+        # 1–16 s recurring blocks). Here we branch on index warmth:
+        #   * warm  → penalty via cheap in-memory lookups, dispatched
+        #     through ``cooperative_fs_io.offload`` (thread hop covers the
+        #     residual ``_count_lines`` file read);
+        #   * cold  → PROCEED DEGRADED (override 0 — no penalty, no
+        #     evidence) and fire the single-flight off-loop index build.
+        #     The prior is advisory priority-ordering only, so ops flowing
+        #     unbiased while the index warms mirrors the SemanticIndex
+        #     Tier-2b fail-soft convention; intake never waits ~40 s.
+        # Fail-soft: ANY fault degrades to 0 — never None, because None
+        # would route ``_compute_priority`` back onto the inline on-loop
+        # scan (the bug this block eradicates).
+        _strat_override: Optional[int] = None
+        if envelope.target_files and _ingest_stratification_enabled():
+            _strat_override = 0  # degraded-proceed default
+            try:
+                from backend.core.ouroboros.governance.target_stratification import (  # noqa: E501
+                    coverage_index_ready,
+                    ingest_priority_penalty,
+                    trigger_coverage_index_build,
+                )
+                _idx_ready = coverage_index_ready(self._config.project_root)
+                # Always fire the trigger — it self-gates (single-flight
+                # "building" set, TTL freshness, failure cooldown) and
+                # returns immediately; also covers TTL refresh when warm.
+                trigger_coverage_index_build(self._config.project_root)
+                if _idx_ready:
+                    from backend.core.ouroboros.governance.cooperative_fs_io import (  # noqa: E501
+                        is_offload_error,
+                        offload,
+                    )
+                    _pen = await offload(
+                        ingest_priority_penalty,
+                        envelope.target_files,
+                        self._config.project_root,
+                        suppress=_is_test_generation_intent(envelope),
+                        cpu_bound=False,
+                    )
+                    if not is_offload_error(_pen):
+                        _strat_override = max(0, int(_pen))
+                        if _strat_override > 0 and isinstance(
+                            envelope.evidence, dict,
+                        ):
+                            envelope.evidence["stratification_penalty"] = (
+                                _strat_override
+                            )
+            except Exception as _strat_exc:  # noqa: BLE001 — never break intake
+                logger.debug(
+                    "[Router] offloaded stratification skipped (degraded): %s",
+                    _strat_exc,
+                )
         priority, alignment = _compute_priority(
             envelope, dependency_credit=_dep_credit,
             repo_root=self._config.project_root,
             semantic_boost_override=_semantic_override,
+            stratification_penalty_override=_strat_override,
         )
         # Stash goal-alignment diagnostics on the envelope so downstream
         # phases (orchestrator, SerpentFlow postmortems, dead-letter audit)

--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -33,6 +33,7 @@ Both ``alpha`` and ``max_lines`` are env-tunable (no hardcoding):
   * ``JARVIS_STRATIFICATION_AST_IMPORT_ENABLED`` (default "true") — enable
     Strategy 3 AST-import scan (cached per repo_root per process).
 """
+
 from __future__ import annotations
 
 import ast as _ast
@@ -90,6 +91,7 @@ def _env_int(name: str, default: int) -> int:
 # AST-aware coverage resolver helpers
 # ---------------------------------------------------------------------------
 
+
 def _strat_test_dir_names() -> FrozenSet[str]:
     """Return the configured test-root directory names (read from env at call time)."""
     return frozenset(os.environ.get("JARVIS_TEST_DIR_NAMES", "tests,test").split(","))
@@ -97,7 +99,8 @@ def _strat_test_dir_names() -> FrozenSet[str]:
 
 def _strat_ast_import_enabled() -> bool:
     return os.environ.get(
-        "JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true",
+        "JARVIS_STRATIFICATION_AST_IMPORT_ENABLED",
+        "true",
     ).strip().lower() not in ("0", "false", "no")
 
 
@@ -152,7 +155,7 @@ _strat_ast_cache: Dict[Path, Dict[str, List[Path]]] = {}
 class _CoverageIndex(NamedTuple):
     """Immutable per-repo test-coverage index (atomic-swap unit)."""
 
-    names_set: FrozenSet[str]      # every test_*.py basename (exact match)
+    names_set: FrozenSet[str]  # every test_*.py basename (exact match)
     names_sorted: Tuple[str, ...]  # same names, sorted (prefix bisect)
     ast_map: Dict[str, List[Path]]
     built_at: float
@@ -167,7 +170,8 @@ _COVERAGE_IDX_LOCK = threading.Lock()
 
 def _coverage_index_enabled() -> bool:
     return os.environ.get(
-        "JARVIS_STRATIFICATION_INDEX_ENABLED", "true",
+        "JARVIS_STRATIFICATION_INDEX_ENABLED",
+        "true",
     ).strip().lower() not in ("0", "false", "no", "off")
 
 
@@ -190,6 +194,7 @@ def _resolve_scan_root(repo_root: Union[str, Path]) -> Path:
         from backend.core.ouroboros.governance.execution_context import (
             authoritative_repo_root as _auth_root,
         )
+
         root = _auth_root(Path(repo_root))
     except Exception:  # noqa: BLE001 — fail-soft, never breaks coverage
         root = Path(repo_root)
@@ -266,9 +271,12 @@ async def _coverage_index_build_task(scan_root: Path) -> None:
         except Exception:  # noqa: BLE001 — substrate import fault
             # Still keep the multi-second build off the loop (bare thread).
             import asyncio as _aio
+
             try:
                 idx = await _aio.to_thread(
-                    _build_coverage_index_sync, scan_root, dir_names,
+                    _build_coverage_index_sync,
+                    scan_root,
+                    dir_names,
                 )
             except Exception:  # noqa: BLE001
                 idx = None
@@ -287,7 +295,9 @@ async def _coverage_index_build_task(scan_root: Path) -> None:
             # the outer except is belt-and-suspenders — a failed build leaves
             # callers degraded, never raises into intake.
             result = await offload(
-                _build_coverage_index_sync, scan_root, dir_names,
+                _build_coverage_index_sync,
+                scan_root,
+                dir_names,
                 cpu_bound=True,
             )
             idx = None if is_offload_error(result) else result
@@ -295,7 +305,8 @@ async def _coverage_index_build_task(scan_root: Path) -> None:
         idx = None
         logger.debug(
             "[Stratification] coverage index build raised root=%s",
-            scan_root, exc_info=True,
+            scan_root,
+            exc_info=True,
         )
     finally:
         with _COVERAGE_IDX_LOCK:
@@ -310,9 +321,10 @@ async def _coverage_index_build_task(scan_root: Path) -> None:
             # (miner scan_once, Advisor coverage) skip their cold build.
             _strat_ast_cache[scan_root] = idx.ast_map
             logger.info(
-                "[Stratification] coverage index built root=%s "
-                "test_files=%d ast_modules=%d",
-                scan_root, len(idx.names_set), len(idx.ast_map),
+                "[Stratification] coverage index built root=%s " "test_files=%d ast_modules=%d",
+                scan_root,
+                len(idx.names_set),
+                len(idx.ast_map),
             )
         else:
             logger.debug(
@@ -350,6 +362,7 @@ def trigger_coverage_index_build(repo_root: Union[str, Path]) -> str:
             return "skipped_failed_cooldown"
         _coverage_index_building.add(scan_root)
     import asyncio as _aio
+
     try:
         loop = _aio.get_running_loop()
     except RuntimeError:
@@ -368,7 +381,8 @@ def trigger_coverage_index_build(repo_root: Union[str, Path]) -> str:
         logger.debug(
             "[Stratification] coverage index build task scheduling failed "
             "root=%s (flag released, will retry on next trigger)",
-            scan_root, exc_info=True,
+            scan_root,
+            exc_info=True,
         )
         return "skipped_no_loop"
     _coverage_index_tasks.add(task)
@@ -409,10 +423,7 @@ def _strat_build_ast_map(
     its file list instead of paying a second full traversal.
     """
     import_map: Dict[str, List[Path]] = {}
-    for test_file in (
-        files if files is not None
-        else _iter_test_files(repo_root, dir_names)
-    ):
+    for test_file in (files if files is not None else _iter_test_files(repo_root, dir_names)):
         try:
             source = test_file.read_text(encoding="utf-8", errors="replace")
             tree = _ast.parse(source, filename=str(test_file))
@@ -497,6 +508,7 @@ def file_has_test_coverage(
         from backend.core.ouroboros.governance.execution_context import (
             authoritative_repo_root as _auth_root,
         )
+
         _scan_root = _auth_root(Path(repo_root))
     except Exception:  # noqa: BLE001 — fail-soft, never breaks coverage
         _scan_root = Path(repo_root)
@@ -554,9 +566,7 @@ def file_has_test_coverage(
             if not match.is_file():
                 continue
             mname = match.name
-            if mname == exact_name or (
-                mname.startswith(suffix_prefix) and mname.endswith(".py")
-            ):
+            if mname == exact_name or (mname.startswith(suffix_prefix) and mname.endswith(".py")):
                 return True
 
     # Strategy 2: AST-import scan (lazy cached per _scan_root, env-opt-out).
@@ -571,14 +581,11 @@ def file_has_test_coverage(
             if module_path:
                 resolved_root = _scan_root.resolve()
                 if resolved_root not in _strat_ast_cache:
-                    _strat_ast_cache[resolved_root] = _strat_build_ast_map(
-                        resolved_root, dir_names
-                    )
+                    _strat_ast_cache[resolved_root] = _strat_build_ast_map(resolved_root, dir_names)
                 if _strat_ast_cache[resolved_root].get(module_path):
                     return True
         except Exception:  # noqa: BLE001 — fail-soft, never raises
             pass
-
 
     return False
 
@@ -669,7 +676,10 @@ def ingest_priority_penalty(
         if lines <= 0:
             continue
         mult = stratification_penalty_multiplier(
-            lines, has_test_coverage=False, alpha=a, max_lines=max_lines,
+            lines,
+            has_test_coverage=False,
+            alpha=a,
+            max_lines=max_lines,
         )
         worst = max(worst, 1.0 - mult)  # 0..alpha
 

--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -273,9 +273,22 @@ async def _coverage_index_build_task(scan_root: Path) -> None:
             except Exception:  # noqa: BLE001
                 idx = None
         else:
+            # cpu_bound=True → ProcessPoolExecutor (not the thread pool):
+            # _build_coverage_index_sync runs ast.parse over the whole test
+            # tree (~963K lines) = pure-Python, GIL-holding CPU. A thread
+            # offload would hold the GIL for the entire parse and still leave
+            # a ~592ms on-loop residual (grazing the 500ms starvation floor);
+            # only a separate process frees the loop. Safe because the target
+            # is a module-level function with picklable args (Path + frozenset)
+            # and a picklable return (the _CoverageIndex NamedTuple of str/Path
+            # containers — round-trip pinned by test_coverage_index_pickle_
+            # roundtrip). Fail-soft is preserved: offload catches worker faults
+            # (OffloadError) and pool-creation faults (spawn blocked) alike, and
+            # the outer except is belt-and-suspenders — a failed build leaves
+            # callers degraded, never raises into intake.
             result = await offload(
                 _build_coverage_index_sync, scan_root, dir_names,
-                cpu_bound=False,
+                cpu_bound=True,
             )
             idx = None if is_offload_error(result) else result
     except Exception:  # noqa: BLE001 — belt-and-suspenders
@@ -343,7 +356,21 @@ def trigger_coverage_index_build(repo_root: Union[str, Path]) -> str:
         with _COVERAGE_IDX_LOCK:
             _coverage_index_building.discard(scan_root)
         return "skipped_no_loop"
-    task = loop.create_task(_coverage_index_build_task(scan_root))
+    try:
+        task = loop.create_task(_coverage_index_build_task(scan_root))
+    except Exception:  # noqa: BLE001 — scheduling fault must not wedge the flag
+        # If create_task raised (loop closing, etc.) the "building" flag would
+        # otherwise leak and every future trigger returns "skipped_running"
+        # forever — the repo wedged out of ever rebuilding the index. Discard
+        # it under the lock so the next trigger can retry.
+        with _COVERAGE_IDX_LOCK:
+            _coverage_index_building.discard(scan_root)
+        logger.debug(
+            "[Stratification] coverage index build task scheduling failed "
+            "root=%s (flag released, will retry on next trigger)",
+            scan_root, exc_info=True,
+        )
+        return "skipped_no_loop"
     _coverage_index_tasks.add(task)
     task.add_done_callback(_coverage_index_tasks.discard)
     return "started"

--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -36,9 +36,25 @@ Both ``alpha`` and ``max_lines`` are env-tunable (no hardcoding):
 from __future__ import annotations
 
 import ast as _ast
+import bisect
+import logging
 import os
+import threading
+import time
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterable, List, Union
+from typing import (
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+logger = logging.getLogger(__name__)
 
 # Defaults are module constants so tests + callers share one source of truth.
 DEFAULT_PENALTY_ALPHA: float = 0.75
@@ -91,45 +107,307 @@ def _strat_ast_import_enabled() -> bool:
 _strat_ast_cache: Dict[Path, Dict[str, List[Path]]] = {}
 
 
-def _strat_build_ast_map(
+# ---------------------------------------------------------------------------
+# Tier-4 loop-starvation fix — off-loop coverage index
+# ---------------------------------------------------------------------------
+#
+# Traced mechanism (session bt-iso-1783102490): ``file_has_test_coverage``
+# was invoked synchronously ON the asyncio loop from the intake hot path
+# (UnifiedIntakeRouter._ingest_impl → _compute_priority →
+# ingest_priority_penalty). Strategy 1 materializes
+# ``sorted(top.rglob("test_*.py"))`` — a full recursive walk + stat of the
+# entire tests/ tree (~2,839 files here) on EVERY call — and Strategy 2
+# cold-builds the AST import map by reading + ``ast.parse``-ing ALL test
+# files (~963K lines) on the FIRST cache miss: the observed 41,713 ms
+# single on-loop block, with 1–16 s recurring blocks from the per-call
+# rglob afterwards.
+#
+# The fix: a per-repo in-memory **coverage index** — the sorted tuple of
+# test-file basenames (Strategy 1 becomes two bisect/set lookups) plus the
+# existing AST import map (Strategy 2 becomes a dict lookup) — built in a
+# SINGLE tree traversal OFF the event loop via the unified
+# ``cooperative_fs_io.offload`` substrate.
+#
+#   * Single-flight: concurrent triggers coalesce on ``_COVERAGE_IDX_LOCK``
+#     + the ``building`` set — at most one build per repo_root at a time.
+#   * Atomic swap: the index is assembled entirely in the worker, then
+#     swapped into ``_coverage_index`` under the lock — readers observe
+#     the old index or the new one, never a partial.
+#   * Degraded-proceed: while the index is cold/building, async callers
+#     (intake) proceed WITHOUT the stratification prior (advisory-only,
+#     priority ordering — never authority), mirroring the SemanticIndex
+#     Tier-2b convention. Sync callers keep the legacy scan, byte-identical.
+#   * Fail-soft: a failed build logs at DEBUG, arms a retry cooldown, and
+#     leaves callers degraded — never raises into intake.
+#
+# Env knobs (no hardcoding):
+#   * ``JARVIS_STRATIFICATION_INDEX_ENABLED``  (default "true") — master.
+#   * ``JARVIS_STRATIFICATION_INDEX_TTL_S``    (default 600) — refresh age;
+#     a stale index is STILL served while the refresh rebuilds off-loop
+#     (eventually consistent; the signal is advisory). ``0`` = build once.
+#   * ``JARVIS_STRATIFICATION_INDEX_RETRY_S``  (default 600) — failure
+#     cooldown before another build attempt.
+
+
+class _CoverageIndex(NamedTuple):
+    """Immutable per-repo test-coverage index (atomic-swap unit)."""
+
+    names_set: FrozenSet[str]      # every test_*.py basename (exact match)
+    names_sorted: Tuple[str, ...]  # same names, sorted (prefix bisect)
+    ast_map: Dict[str, List[Path]]
+    built_at: float
+
+
+_coverage_index: Dict[Path, _CoverageIndex] = {}
+_coverage_index_building: Set[Path] = set()
+_coverage_index_failed_at: Dict[Path, float] = {}
+_coverage_index_tasks: Set[object] = set()  # strong refs to build tasks
+_COVERAGE_IDX_LOCK = threading.Lock()
+
+
+def _coverage_index_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_STRATIFICATION_INDEX_ENABLED", "true",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _coverage_index_ttl_s() -> float:
+    return max(0.0, _env_float("JARVIS_STRATIFICATION_INDEX_TTL_S", 600.0))
+
+
+def _coverage_index_retry_s() -> float:
+    return max(0.0, _env_float("JARVIS_STRATIFICATION_INDEX_RETRY_S", 600.0))
+
+
+def _resolve_scan_root(repo_root: Union[str, Path]) -> Path:
+    """Canonical scan-root resolution shared by every coverage entrypoint.
+
+    Applies the same ``.worktrees/<name>`` → parent-repo translation as
+    ``file_has_test_coverage`` (READS stay authoritative) and resolves the
+    path so the index cache key is stable across spellings.
+    """
+    try:
+        from backend.core.ouroboros.governance.execution_context import (
+            authoritative_repo_root as _auth_root,
+        )
+        root = _auth_root(Path(repo_root))
+    except Exception:  # noqa: BLE001 — fail-soft, never breaks coverage
+        root = Path(repo_root)
+    try:
+        return root.resolve()
+    except OSError:  # circular symlinks — keep syntactic form
+        return root
+
+
+def _build_coverage_index_sync(
     repo_root: Path,
     dir_names: FrozenSet[str],
-) -> Dict[str, List[Path]]:
-    """Synchronous AST import-map builder (mirrors test_runner._build_test_import_map).
+) -> _CoverageIndex:
+    """ONE traversal of the test tree → name index + AST import map.
 
-    Scans every ``test_*.py`` under the configured test roots and maps
-    ``dotted_module_path → [test_files that import it]``.
+    Heavy by design (this is the 41.7 s cold cost) — MUST only run off the
+    event loop (offload substrate / worker thread). Pure function of the
+    filesystem; assembles the full index before the caller swaps it in.
     """
-    import_map: Dict[str, List[Path]] = {}
+    files = list(_iter_test_files(repo_root, dir_names))
+    names = frozenset(f.name for f in files)
+    ast_map = _strat_build_ast_map(repo_root, dir_names, files=files)
+    return _CoverageIndex(
+        names_set=names,
+        names_sorted=tuple(sorted(names)),
+        ast_map=ast_map,
+        built_at=time.time(),
+    )
+
+
+def _coverage_index_lookup(scan_root: Path) -> Optional[_CoverageIndex]:
+    """Return the warm index for an already-resolved scan root (or None)."""
+    if not _coverage_index_enabled():
+        return None
+    with _COVERAGE_IDX_LOCK:
+        return _coverage_index.get(scan_root)
+
+
+def coverage_index_ready(repo_root: Union[str, Path]) -> bool:
+    """True when a warm in-memory coverage index exists for ``repo_root``.
+
+    Async hot paths branch on this: ready → compute the stratification
+    penalty via cheap index lookups (offloaded); not ready → proceed
+    DEGRADED (no penalty) and let :func:`trigger_coverage_index_build`
+    warm the index in the background.
+    """
+    return _coverage_index_lookup(_resolve_scan_root(repo_root)) is not None
+
+
+def reset_coverage_index() -> None:
+    """Test hook — drop all coverage-index state (mirrors reset_default_index)."""
+    with _COVERAGE_IDX_LOCK:
+        _coverage_index.clear()
+        _coverage_index_building.clear()
+        _coverage_index_failed_at.clear()
+        _coverage_index_tasks.clear()
+
+
+async def _coverage_index_build_task(scan_root: Path) -> None:
+    """Detached build task — offloads the heavy traversal, swaps atomically.
+
+    NEVER raises out (fire-and-forget). Failure arms the retry cooldown and
+    logs at DEBUG; success also warms the legacy ``_strat_ast_cache`` so
+    synchronous callers skip their own cold AST build.
+    """
+    idx: Optional[_CoverageIndex] = None
+    try:
+        dir_names = _strat_test_dir_names()
+        try:
+            from backend.core.ouroboros.governance.cooperative_fs_io import (
+                is_offload_error,
+                offload,
+            )
+        except Exception:  # noqa: BLE001 — substrate import fault
+            # Still keep the multi-second build off the loop (bare thread).
+            import asyncio as _aio
+            try:
+                idx = await _aio.to_thread(
+                    _build_coverage_index_sync, scan_root, dir_names,
+                )
+            except Exception:  # noqa: BLE001
+                idx = None
+        else:
+            result = await offload(
+                _build_coverage_index_sync, scan_root, dir_names,
+                cpu_bound=False,
+            )
+            idx = None if is_offload_error(result) else result
+    except Exception:  # noqa: BLE001 — belt-and-suspenders
+        idx = None
+        logger.debug(
+            "[Stratification] coverage index build raised root=%s",
+            scan_root, exc_info=True,
+        )
+    finally:
+        with _COVERAGE_IDX_LOCK:
+            if idx is not None:
+                _coverage_index[scan_root] = idx  # atomic swap
+                _coverage_index_failed_at.pop(scan_root, None)
+            else:
+                _coverage_index_failed_at[scan_root] = time.time()
+            _coverage_index_building.discard(scan_root)
+        if idx is not None:
+            # Warm the legacy per-process AST cache too — sync callers
+            # (miner scan_once, Advisor coverage) skip their cold build.
+            _strat_ast_cache[scan_root] = idx.ast_map
+            logger.info(
+                "[Stratification] coverage index built root=%s "
+                "test_files=%d ast_modules=%d",
+                scan_root, len(idx.names_set), len(idx.ast_map),
+            )
+        else:
+            logger.debug(
+                "[Stratification] coverage index build failed root=%s "
+                "(degraded — no stratification prior until retry window)",
+                scan_root,
+            )
+
+
+def trigger_coverage_index_build(repo_root: Union[str, Path]) -> str:
+    """Non-blocking, single-flight build trigger (mirrors build_async).
+
+    Returns a string sentinel for logs/tests:
+      * ``"started"``                — a detached build task was scheduled
+      * ``"skipped_running"``        — a build is already in flight
+      * ``"skipped_fresh"``          — index exists and is within TTL
+      * ``"skipped_failed_cooldown"``— last build failed; retry window open
+      * ``"skipped_no_loop"``        — no running event loop (sync caller)
+      * ``"skipped_disabled"``       — master switch off
+    """
+    if not _coverage_index_enabled():
+        return "skipped_disabled"
+    scan_root = _resolve_scan_root(repo_root)
+    now = time.time()
+    with _COVERAGE_IDX_LOCK:
+        if scan_root in _coverage_index_building:
+            return "skipped_running"
+        idx = _coverage_index.get(scan_root)
+        if idx is not None:
+            ttl = _coverage_index_ttl_s()
+            if ttl <= 0 or (now - idx.built_at) < ttl:
+                return "skipped_fresh"
+        failed_at = _coverage_index_failed_at.get(scan_root)
+        if failed_at is not None and (now - failed_at) < _coverage_index_retry_s():
+            return "skipped_failed_cooldown"
+        _coverage_index_building.add(scan_root)
+    import asyncio as _aio
+    try:
+        loop = _aio.get_running_loop()
+    except RuntimeError:
+        with _COVERAGE_IDX_LOCK:
+            _coverage_index_building.discard(scan_root)
+        return "skipped_no_loop"
+    task = loop.create_task(_coverage_index_build_task(scan_root))
+    _coverage_index_tasks.add(task)
+    task.add_done_callback(_coverage_index_tasks.discard)
+    return "started"
+
+
+def _iter_test_files(
+    repo_root: Path,
+    dir_names: FrozenSet[str],
+) -> "Iterable[Path]":
+    """Yield every ``test_*.py`` regular file under the configured test roots.
+
+    Single source of truth for the test-tree traversal so the AST-map
+    builder and the coverage-index builder can never drift (and so the
+    expensive walk happens exactly ONCE when both are built together).
+    """
     for tdn in sorted(dir_names):
         top = repo_root / tdn
         if not top.is_dir():
             continue
         for test_file in sorted(top.rglob("test_*.py")):
-            if not test_file.is_file():
-                continue
-            try:
-                source = test_file.read_text(encoding="utf-8", errors="replace")
-                tree = _ast.parse(source, filename=str(test_file))
-            except (SyntaxError, OSError, UnicodeDecodeError):
-                continue
-            for node in _ast.walk(tree):
-                if isinstance(node, _ast.Import):
-                    for alias in node.names:
-                        lst = import_map.setdefault(alias.name, [])
-                        if test_file not in lst:
-                            lst.append(test_file)
-                elif isinstance(node, _ast.ImportFrom):
-                    module = node.module or ""
-                    if module:
-                        lst = import_map.setdefault(module, [])
-                        if test_file not in lst:
-                            lst.append(test_file)
-                    for alias in node.names:
-                        full = f"{module}.{alias.name}" if module else alias.name
-                        lst = import_map.setdefault(full, [])
-                        if test_file not in lst:
-                            lst.append(test_file)
+            if test_file.is_file():
+                yield test_file
+
+
+def _strat_build_ast_map(
+    repo_root: Path,
+    dir_names: FrozenSet[str],
+    *,
+    files: "Optional[List[Path]]" = None,
+) -> Dict[str, List[Path]]:
+    """Synchronous AST import-map builder (mirrors test_runner._build_test_import_map).
+
+    Scans every ``test_*.py`` under the configured test roots and maps
+    ``dotted_module_path → [test_files that import it]``. ``files`` lets a
+    caller that already walked the tree (the coverage-index builder) reuse
+    its file list instead of paying a second full traversal.
+    """
+    import_map: Dict[str, List[Path]] = {}
+    for test_file in (
+        files if files is not None
+        else _iter_test_files(repo_root, dir_names)
+    ):
+        try:
+            source = test_file.read_text(encoding="utf-8", errors="replace")
+            tree = _ast.parse(source, filename=str(test_file))
+        except (SyntaxError, OSError, UnicodeDecodeError):
+            continue
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.Import):
+                for alias in node.names:
+                    lst = import_map.setdefault(alias.name, [])
+                    if test_file not in lst:
+                        lst.append(test_file)
+            elif isinstance(node, _ast.ImportFrom):
+                module = node.module or ""
+                if module:
+                    lst = import_map.setdefault(module, [])
+                    if test_file not in lst:
+                        lst.append(test_file)
+                for alias in node.names:
+                    full = f"{module}.{alias.name}" if module else alias.name
+                    lst = import_map.setdefault(full, [])
+                    if test_file not in lst:
+                        lst.append(test_file)
     return import_map
 
 
@@ -203,6 +481,37 @@ def file_has_test_coverage(
     dir_names = _strat_test_dir_names()
     exact_name = f"test_{stem}.py"
     suffix_prefix = f"test_{stem}_"
+
+    # Tier-4 fast path — when the off-loop coverage index is warm, answer
+    # from memory: Strategy 1 collapses to a set lookup + one bisect prefix
+    # probe, Strategy 2 to a dict lookup. NO filesystem traversal. This is
+    # what makes the function safe to call from latency-sensitive contexts
+    # once the index is built (the intake hot path additionally never calls
+    # it on the loop at all — see UnifiedIntakeRouter._ingest_impl).
+    try:
+        _idx_key = _scan_root.resolve()
+    except OSError:  # noqa: PERF203 — circular symlink, keep syntactic form
+        _idx_key = _scan_root
+    _idx = _coverage_index_lookup(_idx_key)
+    if _idx is not None:
+        if exact_name in _idx.names_set:
+            return True
+        _i = bisect.bisect_left(_idx.names_sorted, suffix_prefix)
+        if _i < len(_idx.names_sorted) and _idx.names_sorted[_i].startswith(
+            suffix_prefix,
+        ):
+            return True  # suffix variants all end with ".py" by construction
+        if _strat_ast_import_enabled():
+            try:
+                _fp = Path(file_path)
+                if not _fp.is_absolute():
+                    _fp = _scan_root / _fp
+                _module_path = _strat_path_to_module(_fp, _scan_root)
+                if _module_path and _idx.ast_map.get(_module_path):
+                    return True
+            except Exception:  # noqa: BLE001 — fail-soft, mirror Strategy 2
+                pass
+        return False
 
     # Strategy 1: suffix-aware recursive search across all test roots.
     # Finds test_<stem>.py (exact) AND test_<stem>_*.py (suffix variants).

--- a/tests/governance/test_slice48_target_stratification.py
+++ b/tests/governance/test_slice48_target_stratification.py
@@ -19,6 +19,7 @@ Pins (shared scoring substrate + OpportunityMiner wiring):
   §10 _select_diverse_candidates down-ranks huge-untested vs small-tested
   §11 _analyze_file stamps has_test_coverage from repo_root (None → safe 1.0)
 """
+
 from __future__ import annotations
 
 import os
@@ -58,9 +59,10 @@ def test_file_has_test_coverage_suffix_variant(
     (tmp_path / "tests" / "battle_test" / "test_repl_input_polish_slice4.py").write_text(
         "def test_x(): pass\n"
     )
-    assert file_has_test_coverage(
-        "backend/core/ouroboros/battle_test/repl_input_polish.py", tmp_path
-    ) is True
+    assert (
+        file_has_test_coverage("backend/core/ouroboros/battle_test/repl_input_polish.py", tmp_path)
+        is True
+    )
 
 
 # ── §1c test in nested subdirectory detected ─────────────────────────────
@@ -122,6 +124,7 @@ def test_advisor_compute_coverage_suffix_variant(
     whose test uses a suffix variant name (the iteration-13 spurious BLOCK)."""
     monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "false")
     from backend.core.ouroboros.governance.operation_advisor import OperationAdvisor
+
     (tmp_path / "tests" / "battle_test").mkdir(parents=True)
     (tmp_path / "tests" / "battle_test" / "test_repl_input_polish_slice4.py").write_text(
         "def test_x(): pass\n"
@@ -146,15 +149,16 @@ def test_covered_file_multiplier_is_one() -> None:
 # ── §3 suppress (test-gen escape hatch) ─────────────────────────────────
 def test_suppress_bypasses_penalty() -> None:
     # huge, uncovered — but suppress wins
-    assert stratification_penalty_multiplier(
-        9999, has_test_coverage=False, suppress=True
-    ) == 1.0
+    assert stratification_penalty_multiplier(9999, has_test_coverage=False, suppress=True) == 1.0
 
 
 # ── §4 huge uncovered heavily down-ranked ───────────────────────────────
 def test_huge_uncovered_file_is_penalized() -> None:
     m = stratification_penalty_multiplier(
-        5000, has_test_coverage=False, alpha=0.75, max_lines=2000,
+        5000,
+        has_test_coverage=False,
+        alpha=0.75,
+        max_lines=2000,
     )
     # lines >> max_lines → saturates → 1 - alpha
     assert m == pytest.approx(0.25, abs=1e-9)
@@ -163,7 +167,10 @@ def test_huge_uncovered_file_is_penalized() -> None:
 # ── §5 small uncovered barely touched ───────────────────────────────────
 def test_small_uncovered_file_barely_penalized() -> None:
     m = stratification_penalty_multiplier(
-        100, has_test_coverage=False, alpha=0.75, max_lines=2000,
+        100,
+        has_test_coverage=False,
+        alpha=0.75,
+        max_lines=2000,
     )
     # 1 - 0.75 * (100/2000) = 1 - 0.0375 = 0.9625
     assert m == pytest.approx(0.9625, abs=1e-9)
@@ -175,9 +182,9 @@ def test_multiplier_monotonic_and_clamped() -> None:
     a = stratification_penalty_multiplier(0, has_test_coverage=False)
     b = stratification_penalty_multiplier(500, has_test_coverage=False)
     c = stratification_penalty_multiplier(50_000, has_test_coverage=False)
-    assert a == 1.0            # zero lines → no penalty
-    assert a >= b >= c         # bigger files → smaller multiplier
-    assert c >= (1.0 - DEFAULT_PENALTY_ALPHA) - 1e-9   # clamp floor
+    assert a == 1.0  # zero lines → no penalty
+    assert a >= b >= c  # bigger files → smaller multiplier
+    assert c >= (1.0 - DEFAULT_PENALTY_ALPHA) - 1e-9  # clamp floor
 
 
 # ── §7 env defaults honoured ────────────────────────────────────────────
@@ -194,12 +201,17 @@ def test_file_analysis_stratified_score_wiring() -> None:
     from backend.core.ouroboros.governance.intake.sensors.opportunity_miner_sensor import (
         _FileAnalysis,
     )
+
     covered = _FileAnalysis(
-        file_path="a.py", cyclomatic_complexity=100, total_lines=5000,
+        file_path="a.py",
+        cyclomatic_complexity=100,
+        total_lines=5000,
         has_test_coverage=True,
     )
     uncovered = _FileAnalysis(
-        file_path="b.py", cyclomatic_complexity=100, total_lines=5000,
+        file_path="b.py",
+        cyclomatic_complexity=100,
+        total_lines=5000,
         has_test_coverage=False,
     )
     assert covered.stratification_penalty == 1.0
@@ -211,6 +223,7 @@ def test_file_analysis_stratified_score_wiring() -> None:
 # ── §9 Advisor delegation (no behavior change) ──────────────────────────
 def test_advisor_coverage_matches_shared_definition(tmp_path: Path) -> None:
     from backend.core.ouroboros.governance.operation_advisor import OperationAdvisor
+
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_covered.py").write_text("def test_x(): pass\n")
     adv = OperationAdvisor.__new__(OperationAdvisor)  # avoid heavy __init__
@@ -226,20 +239,26 @@ def test_selection_prefers_small_tested_over_huge_untested() -> None:
         OpportunityMinerSensor,
         _FileAnalysis,
     )
+
     sensor = OpportunityMinerSensor(repo_root=Path("/tmp"), router=object())
     # Equal strategy metric (cyclomatic_complexity); differ only in size+coverage
     huge_untested = _FileAnalysis(
-        file_path="core/huge.py", cyclomatic_complexity=200, total_lines=5000,
+        file_path="core/huge.py",
+        cyclomatic_complexity=200,
+        total_lines=5000,
         has_test_coverage=False,
     )
     small_tested = _FileAnalysis(
-        file_path="leaf/small.py", cyclomatic_complexity=200, total_lines=80,
+        file_path="leaf/small.py",
+        cyclomatic_complexity=200,
+        total_lines=80,
         has_test_coverage=True,
     )
     sensor._max_per_scan = 1
     sensor._explore_ratio = 0.0  # pure exploit so the assertion is deterministic
     _eligible, selected = sensor._select_diverse_candidates(
-        [huge_untested, small_tested], "cyclomatic_complexity",
+        [huge_untested, small_tested],
+        "cyclomatic_complexity",
     )
     assert len(selected) == 1
     assert selected[0].file_path == "leaf/small.py"
@@ -250,8 +269,10 @@ def test_analyze_file_stamps_coverage(tmp_path: Path) -> None:
     from backend.core.ouroboros.governance.intake.sensors.opportunity_miner_sensor import (
         _analyze_file,
     )
+
     src = "x = 1\n"
     import ast as _ast
+
     tree = _ast.parse(src)
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_thing.py").write_text("def test_x(): pass\n")
@@ -286,7 +307,8 @@ def _tier4_reset_index_state():
 def _install_index(root: Path) -> None:
     """Build + install the coverage index synchronously (test-only shortcut)."""
     idx = _ts._build_coverage_index_sync(
-        _ts._resolve_scan_root(root), _ts._strat_test_dir_names(),
+        _ts._resolve_scan_root(root),
+        _ts._strat_test_dir_names(),
     )
     with _ts._COVERAGE_IDX_LOCK:
         _ts._coverage_index[_ts._resolve_scan_root(root)] = idx
@@ -294,7 +316,9 @@ def _install_index(root: Path) -> None:
 
 @pytest.mark.parametrize("covered_case", ["exact", "suffix", "ast", "none"])
 def test_warm_index_parity_with_legacy_scan(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, covered_case: str,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+    covered_case: str,
 ) -> None:
     monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
     src = tmp_path / "backend" / "core" / "widget.py"
@@ -304,9 +328,7 @@ def test_warm_index_parity_with_legacy_scan(
     if covered_case == "exact":
         (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
     elif covered_case == "suffix":
-        (tmp_path / "tests" / "test_widget_slice4.py").write_text(
-            "def test_x(): pass\n"
-        )
+        (tmp_path / "tests" / "test_widget_slice4.py").write_text("def test_x(): pass\n")
     elif covered_case == "ast":
         (tmp_path / "tests" / "test_other.py").write_text(
             "from backend.core.widget import some_func\n"
@@ -323,7 +345,8 @@ def test_warm_index_parity_with_legacy_scan(
 
 
 def test_warm_index_answers_without_filesystem_scan(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
@@ -342,7 +365,8 @@ def test_warm_index_answers_without_filesystem_scan(
 
 
 def test_index_master_switch_off_restores_legacy_path(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
@@ -363,17 +387,14 @@ def test_trigger_sentinels_lifecycle(tmp_path: Path) -> None:
     # Failure cooldown → skipped.
     _ts.reset_coverage_index()
     with _ts._COVERAGE_IDX_LOCK:
-        _ts._coverage_index_failed_at[_ts._resolve_scan_root(tmp_path)] = (
-            _time.time()
-        )
-    assert _ts.trigger_coverage_index_build(tmp_path) == (
-        "skipped_failed_cooldown"
-    )
+        _ts._coverage_index_failed_at[_ts._resolve_scan_root(tmp_path)] = _time.time()
+    assert _ts.trigger_coverage_index_build(tmp_path) == ("skipped_failed_cooldown")
 
 
 # ── Fix 1: _CoverageIndex survives the ProcessPoolExecutor boundary ──────
 def test_coverage_index_pickle_roundtrip(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """The build now dispatches with ``cpu_bound=True`` (process pool) so the
     ``_CoverageIndex`` return crosses a pickle boundary. Prove a representative
@@ -394,7 +415,8 @@ def test_coverage_index_pickle_roundtrip(
     )
 
     idx = _ts._build_coverage_index_sync(
-        _ts._resolve_scan_root(tmp_path), _ts._strat_test_dir_names(),
+        _ts._resolve_scan_root(tmp_path),
+        _ts._strat_test_dir_names(),
     )
     restored = pickle.loads(pickle.dumps(idx))
 
@@ -413,7 +435,8 @@ def test_coverage_index_pickle_roundtrip(
 # ── Fix 3: create_task scheduling failure must release the building flag ──
 @pytest.mark.asyncio
 async def test_trigger_create_task_failure_releases_building_flag(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """If ``loop.create_task`` raises, the ``scan_root`` flag (added under the
     lock before scheduling) must be discarded — otherwise every future trigger

--- a/tests/governance/test_slice48_target_stratification.py
+++ b/tests/governance/test_slice48_target_stratification.py
@@ -369,3 +369,78 @@ def test_trigger_sentinels_lifecycle(tmp_path: Path) -> None:
     assert _ts.trigger_coverage_index_build(tmp_path) == (
         "skipped_failed_cooldown"
     )
+
+
+# ── Fix 1: _CoverageIndex survives the ProcessPoolExecutor boundary ──────
+def test_coverage_index_pickle_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The build now dispatches with ``cpu_bound=True`` (process pool) so the
+    ``_CoverageIndex`` return crosses a pickle boundary. Prove a representative
+    index round-trips byte-faithfully — including the ``ast_map``'s
+    ``List[Path]`` values (Path is picklable) — so the process-pool path is
+    structurally sound without needing to actually spawn a worker.
+    """
+    import pickle
+
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    src = tmp_path / "backend" / "core" / "widget.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("def some_func():\n    return 1\n")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    (tmp_path / "tests" / "test_other.py").write_text(
+        "from backend.core.widget import some_func\ndef t(): pass\n"
+    )
+
+    idx = _ts._build_coverage_index_sync(
+        _ts._resolve_scan_root(tmp_path), _ts._strat_test_dir_names(),
+    )
+    restored = pickle.loads(pickle.dumps(idx))
+
+    assert isinstance(restored, _ts._CoverageIndex)
+    assert restored.names_set == idx.names_set
+    assert restored.names_sorted == idx.names_sorted
+    assert restored.ast_map == idx.ast_map
+    assert restored.built_at == idx.built_at
+    # ast_map values are List[Path] — confirm Path objects survived the trip.
+    assert restored.ast_map  # non-empty (test_other imports the module)
+    for paths in restored.ast_map.values():
+        for p in paths:
+            assert isinstance(p, Path)
+
+
+# ── Fix 3: create_task scheduling failure must release the building flag ──
+@pytest.mark.asyncio
+async def test_trigger_create_task_failure_releases_building_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``loop.create_task`` raises, the ``scan_root`` flag (added under the
+    lock before scheduling) must be discarded — otherwise every future trigger
+    returns ``skipped_running`` forever and the repo is wedged out of ever
+    rebuilding its coverage index.
+    """
+    import asyncio
+
+    _ts.reset_coverage_index()
+    loop = asyncio.get_running_loop()
+
+    def _boom(*a, **k):
+        raise RuntimeError("synthetic create_task scheduling failure")
+
+    monkeypatch.setattr(loop, "create_task", _boom)
+    result = _ts.trigger_coverage_index_build(tmp_path)
+    assert result == "skipped_no_loop"  # scheduling fault → non-started sentinel
+
+    scan_root = _ts._resolve_scan_root(tmp_path)
+    with _ts._COVERAGE_IDX_LOCK:
+        assert scan_root not in _ts._coverage_index_building, (
+            "building flag leaked after create_task failure — repo wedged in "
+            "perpetual skipped_running"
+        )
+
+    # Not wedged: with create_task restored a fresh trigger can proceed again
+    # (i.e. NOT skipped_running).
+    monkeypatch.undo()
+    assert _ts.trigger_coverage_index_build(tmp_path) != "skipped_running"
+    _ts.reset_coverage_index()

--- a/tests/governance/test_slice48_target_stratification.py
+++ b/tests/governance/test_slice48_target_stratification.py
@@ -261,3 +261,111 @@ def test_analyze_file_stamps_coverage(tmp_path: Path) -> None:
     assert covered.has_test_coverage is True
     assert uncovered.has_test_coverage is False
     assert none_root.has_test_coverage is True  # unknown → no penalty
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Tier-4 — off-loop coverage index (warm fast path parity + lifecycle).
+# The index answers Strategy 1 via set/bisect lookups and Strategy 2 via
+# the prebuilt AST map — it must be semantically identical to the legacy
+# filesystem scan for every case above.
+# ═══════════════════════════════════════════════════════════════════════
+import time as _time
+
+import backend.core.ouroboros.governance.target_stratification as _ts
+
+
+@pytest.fixture(autouse=True)
+def _tier4_reset_index_state():
+    _ts.reset_coverage_index()
+    _strat_ast_cache.clear()
+    yield
+    _ts.reset_coverage_index()
+    _strat_ast_cache.clear()
+
+
+def _install_index(root: Path) -> None:
+    """Build + install the coverage index synchronously (test-only shortcut)."""
+    idx = _ts._build_coverage_index_sync(
+        _ts._resolve_scan_root(root), _ts._strat_test_dir_names(),
+    )
+    with _ts._COVERAGE_IDX_LOCK:
+        _ts._coverage_index[_ts._resolve_scan_root(root)] = idx
+
+
+@pytest.mark.parametrize("covered_case", ["exact", "suffix", "ast", "none"])
+def test_warm_index_parity_with_legacy_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, covered_case: str,
+) -> None:
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    src = tmp_path / "backend" / "core" / "widget.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("def some_func():\n    return 1\n")
+    (tmp_path / "tests").mkdir()
+    if covered_case == "exact":
+        (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    elif covered_case == "suffix":
+        (tmp_path / "tests" / "test_widget_slice4.py").write_text(
+            "def test_x(): pass\n"
+        )
+    elif covered_case == "ast":
+        (tmp_path / "tests" / "test_other.py").write_text(
+            "from backend.core.widget import some_func\n"
+            "def test_it(): assert some_func() is not None\n"
+        )
+
+    legacy = file_has_test_coverage("backend/core/widget.py", tmp_path)
+    _strat_ast_cache.clear()  # legacy run may have warmed it — isolate
+
+    _install_index(tmp_path)
+    warm = file_has_test_coverage("backend/core/widget.py", tmp_path)
+
+    assert warm == legacy == (covered_case != "none")
+
+
+def test_warm_index_answers_without_filesystem_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)
+
+    # Sever the traversal paths entirely — a warm index must not walk.
+    def _boom(*a, **k):
+        raise AssertionError("filesystem traversal ran despite warm index")
+
+    monkeypatch.setattr(_ts, "_iter_test_files", _boom)
+    monkeypatch.setattr(_ts, "_strat_build_ast_map", _boom)
+    monkeypatch.setattr(Path, "rglob", _boom)
+
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+    assert file_has_test_coverage("backend/core/nope.py", tmp_path) is False
+
+
+def test_index_master_switch_off_restores_legacy_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)
+    monkeypatch.setenv("JARVIS_STRATIFICATION_INDEX_ENABLED", "false")
+    # Index ignored (lookup returns None) → legacy scan still answers.
+    assert _ts.coverage_index_ready(tmp_path) is False
+    assert _ts.trigger_coverage_index_build(tmp_path) == "skipped_disabled"
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+
+
+def test_trigger_sentinels_lifecycle(tmp_path: Path) -> None:
+    # No running loop → sync callers can't schedule a task.
+    assert _ts.trigger_coverage_index_build(tmp_path) == "skipped_no_loop"
+    # Fresh index within TTL → skipped.
+    _install_index(tmp_path)
+    assert _ts.trigger_coverage_index_build(tmp_path) == "skipped_fresh"
+    # Failure cooldown → skipped.
+    _ts.reset_coverage_index()
+    with _ts._COVERAGE_IDX_LOCK:
+        _ts._coverage_index_failed_at[_ts._resolve_scan_root(tmp_path)] = (
+            _time.time()
+        )
+    assert _ts.trigger_coverage_index_build(tmp_path) == (
+        "skipped_failed_cooldown"
+    )

--- a/tests/governance/test_slice49_ingest_stratification.py
+++ b/tests/governance/test_slice49_ingest_stratification.py
@@ -82,3 +82,247 @@ def test_compute_priority_deprioritizes_huge_uncovered(tmp_path: Path) -> None:
 
     # lower int = higher priority; the huge uncovered op must rank WORSE
     assert p_huge > p_small
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Tier-4 loop-starvation fix — the stratification coverage scan must NEVER
+# run synchronously on the event loop inside ingest.
+#
+# Traced mechanism (bt-iso-1783102490): _ingest_impl → _compute_priority →
+# ingest_priority_penalty → file_has_test_coverage, whose Strategy 1 does
+# sorted(top.rglob("test_*.py")) over the FULL tests/ tree (~2,839 files)
+# on EVERY call, and whose Strategy 2 cold-builds an AST import map by
+# reading + ast.parse-ing ALL test files (~963K lines) on the FIRST miss —
+# the observed 41,713 ms single on-loop block.
+#
+# Fix contract:
+#   * ingest proceeds DEGRADED (penalty override 0, no evidence stash)
+#     until the coverage index is built off-loop (single-flight);
+#   * once warm, the penalty is computed via the offload substrate
+#     (pure in-memory index lookups in a worker thread);
+#   * file_has_test_coverage is never invoked on the loop thread by ingest;
+#   * builder failure is fail-soft: ingest still returns "enqueued".
+# ═══════════════════════════════════════════════════════════════════════
+import asyncio
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import backend.core.ouroboros.governance.target_stratification as ts
+from backend.core.ouroboros.governance.intake.intent_envelope import make_envelope
+from backend.core.ouroboros.governance.intake.unified_intake_router import (
+    IntakeRouterConfig,
+    UnifiedIntakeRouter,
+)
+
+
+def _mk_router(tmp_path: Path):
+    gls = MagicMock()
+    gls.submit = AsyncMock()
+    config = IntakeRouterConfig(project_root=tmp_path, dedup_window_s=60.0)
+    return UnifiedIntakeRouter(gls=gls, config=config)
+
+
+def _mk_env(rel: str, n: int = 0):
+    return make_envelope(
+        source="backlog",
+        description=f"improve module {n}",
+        target_files=(rel,),
+        repo="jarvis",
+        confidence=0.5,
+        urgency="normal",
+        evidence={"signature": f"sig-{n}-{time.monotonic()}"},
+        requires_human_ack=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_coverage_index_state():
+    """Isolate per-test module-level coverage-index state (fail-soft pre-fix)."""
+    reset = getattr(ts, "reset_coverage_index", None)
+    if reset is not None:
+        reset()
+    ts._strat_ast_cache.clear()
+    yield
+    if reset is not None:
+        reset()
+    ts._strat_ast_cache.clear()
+
+
+async def _hb_gaps(run_coro, cadence: float = 0.02):
+    """Run ``run_coro`` while measuring event-loop heartbeat gaps."""
+    gaps: list = []
+    stop = asyncio.Event()
+
+    async def _hb() -> None:
+        last = time.monotonic()
+        while not stop.is_set():
+            await asyncio.sleep(cadence)
+            now = time.monotonic()
+            gaps.append(now - last)
+            last = now
+
+    hb = asyncio.create_task(_hb())
+    try:
+        result = await run_coro
+    finally:
+        stop.set()
+        await hb
+    return result, gaps
+
+
+# ── RED §6: the coverage scan must not execute on the loop thread ───────
+@pytest.mark.asyncio
+async def test_ingest_never_runs_coverage_scan_on_loop_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
+    router = _mk_router(tmp_path)
+
+    loop_thread = threading.get_ident()
+    on_loop_calls = {"n": 0}
+    real = ts.file_has_test_coverage
+
+    def slow_spy(*a, **k):
+        if threading.get_ident() == loop_thread:
+            on_loop_calls["n"] += 1
+        time.sleep(0.4)  # stand-in for the 2,839-file rglob / AST cold build
+        return real(*a, **k)
+
+    monkeypatch.setattr(ts, "file_has_test_coverage", slow_spy)
+
+    result, gaps = await _hb_gaps(router.ingest(_mk_env(rel)))
+    assert result == "enqueued"
+    # The traced bug: file_has_test_coverage ran synchronously on the loop.
+    assert on_loop_calls["n"] == 0, (
+        f"coverage scan executed {on_loop_calls['n']}x on the event-loop "
+        "thread inside ingest (Tier-4 starvation mechanism)"
+    )
+    assert gaps and max(gaps) < 0.3, (
+        f"event loop starved during ingest: max heartbeat gap {max(gaps):.3f}s"
+    )
+
+
+# ── §7: heartbeat keeps ticking while the FIRST-ingest index build runs ──
+@pytest.mark.asyncio
+async def test_loop_responsive_while_first_ingest_index_builds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
+    router = _mk_router(tmp_path)
+
+    builds = {"n": 0}
+    real_builder = ts._build_coverage_index_sync
+
+    def slow_builder(*a, **k):
+        builds["n"] += 1
+        time.sleep(0.5)  # slow cold build, via the offload substrate
+        return real_builder(*a, **k)
+
+    monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+
+    t0 = time.monotonic()
+    result, gaps = await _hb_gaps(router.ingest(_mk_env(rel)))
+    ingest_wall = time.monotonic() - t0
+
+    assert result == "enqueued"
+    # Degraded-proceed: ingest must NOT wait for the cold build.
+    assert ingest_wall < 0.45, f"ingest blocked on cold index build: {ingest_wall:.3f}s"
+    assert gaps and max(gaps) < 0.3, (
+        f"event loop starved while index built: max gap {max(gaps):.3f}s"
+    )
+    # Build was actually triggered off-loop (single-flight, fire-and-forget).
+    deadline = time.monotonic() + 3.0
+    while builds["n"] == 0 and time.monotonic() < deadline:
+        await asyncio.sleep(0.02)
+    assert builds["n"] == 1
+
+
+# ── §8: N concurrent first-ingests → exactly ONE build, no deadlock ─────
+@pytest.mark.asyncio
+async def test_concurrent_first_ingests_single_flight_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rels = [_mk(tmp_path, f"backend/mod{i}.py", 3000, covered=False) for i in range(6)]
+    router = _mk_router(tmp_path)
+
+    builds = {"n": 0}
+    real_builder = ts._build_coverage_index_sync
+
+    def slow_builder(*a, **k):
+        builds["n"] += 1
+        time.sleep(0.3)
+        return real_builder(*a, **k)
+
+    monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+
+    t0 = time.monotonic()
+    results = await asyncio.wait_for(
+        asyncio.gather(*(router.ingest(_mk_env(r, n=i)) for i, r in enumerate(rels))),
+        timeout=5.0,
+    )
+    wall = time.monotonic() - t0
+
+    assert all(r == "enqueued" for r in results)
+    # Degraded-proceed: none of the 6 waited for the 0.3s build (nor serialized
+    # 6 × inline scans — the pre-fix behavior).
+    assert wall < 1.0, f"concurrent ingests blocked behind index build: {wall:.3f}s"
+    # Ops that ran during the build got the DEGRADED path: no penalty stash.
+    # (Design choice: semantic/stratification priors are advisory — intake
+    # never waits on them; parity returns once the index is warm.)
+    await asyncio.sleep(0.6)  # let the single-flight build finish
+    assert builds["n"] == 1, f"expected exactly ONE build, got {builds['n']}"
+
+
+# ── §9: warm index → penalty parity with the legacy inline path ─────────
+@pytest.mark.asyncio
+async def test_warm_index_restores_penalty_with_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
+    router = _mk_router(tmp_path)
+
+    # First ingest: cold → degraded, triggers the off-loop build.
+    env1 = _mk_env(rel, n=1)
+    assert await router.ingest(env1) == "enqueued"
+    assert "stratification_penalty" not in env1.evidence  # degraded
+
+    deadline = time.monotonic() + 5.0
+    while not ts.coverage_index_ready(tmp_path) and time.monotonic() < deadline:
+        await asyncio.sleep(0.02)
+    assert ts.coverage_index_ready(tmp_path)
+
+    # Second ingest: warm → penalty computed (off-loop) + evidence stashed,
+    # numerically identical to the legacy inline computation.
+    env2 = _mk_env(rel, n=2)
+    assert await router.ingest(env2) == "enqueued"
+    expected = ts.ingest_priority_penalty([rel], tmp_path)
+    assert expected > 0
+    assert env2.evidence.get("stratification_penalty") == expected
+
+
+# ── §10: builder failure is fail-soft — ingest still enqueues ────────────
+@pytest.mark.asyncio
+async def test_index_build_failure_is_fail_soft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
+    router = _mk_router(tmp_path)
+
+    builds = {"n": 0}
+
+    def broken_builder(*a, **k):
+        builds["n"] += 1
+        raise RuntimeError("synthetic index build failure")
+
+    monkeypatch.setattr(ts, "_build_coverage_index_sync", broken_builder)
+
+    assert await router.ingest(_mk_env(rel, n=1)) == "enqueued"
+    await asyncio.sleep(0.3)  # let the failed build task settle
+    # Still degraded forever (never inline-scans on the loop), still enqueues.
+    env2 = _mk_env(rel, n=2)
+    assert await router.ingest(env2) == "enqueued"
+    assert "stratification_penalty" not in env2.evidence
+    await asyncio.sleep(0.2)
+    # Failure cooldown: no rebuild storm (one attempt within the window).
+    assert builds["n"] == 1

--- a/tests/governance/test_slice49_ingest_stratification.py
+++ b/tests/governance/test_slice49_ingest_stratification.py
@@ -13,6 +13,7 @@ Pins:
   §4  penalty is bounded (cannot dominate the whole priority scale)
   §5  _compute_priority: huge-uncovered envelope ranks WORSE than small-covered
 """
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -71,8 +72,13 @@ def test_compute_priority_deprioritizes_huge_uncovered(tmp_path: Path) -> None:
     small = _mk(tmp_path, "backend/small.py", 40, covered=True)
 
     common = dict(
-        source="ai_miner", description="improve", repo="jarvis",
-        confidence=0.5, urgency="normal", evidence={}, requires_human_ack=True,
+        source="ai_miner",
+        description="improve",
+        repo="jarvis",
+        confidence=0.5,
+        urgency="normal",
+        evidence={},
+        requires_human_ack=True,
     )
     env_huge = make_envelope(target_files=(huge,), **common)
     env_small = make_envelope(target_files=(small,), **common)
@@ -138,6 +144,7 @@ def _patch_inproc_offload(monkeypatch: pytest.MonkeyPatch, seen: dict) -> None:
     ``test_warm_index_restores_penalty_with_evidence`` (real-pool E2E) and
     ``test_offload_cpu_bound_frees_loop_during_gil_build`` (Fix 2).
     """
+
     async def _fake_offload(fn, *args, cpu_bound=False, **kwargs):
         # Record cpu_bound ONLY for the coverage-index build dispatch (the
         # intake path issues other cpu_bound=False offloads that would
@@ -247,7 +254,8 @@ async def _hb_gaps(run_coro, cadence: float = 0.02):
 # ── RED §6: the coverage scan must not execute on the loop thread ───────
 @pytest.mark.asyncio
 async def test_ingest_never_runs_coverage_scan_on_loop_thread(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
     router = _mk_router(tmp_path)
@@ -271,15 +279,16 @@ async def test_ingest_never_runs_coverage_scan_on_loop_thread(
         f"coverage scan executed {on_loop_calls['n']}x on the event-loop "
         "thread inside ingest (Tier-4 starvation mechanism)"
     )
-    assert gaps and max(gaps) < 0.3, (
-        f"event loop starved during ingest: max heartbeat gap {max(gaps):.3f}s"
-    )
+    assert (
+        gaps and max(gaps) < 0.3
+    ), f"event loop starved during ingest: max heartbeat gap {max(gaps):.3f}s"
 
 
 # ── §7: heartbeat keeps ticking while the FIRST-ingest index build runs ──
 @pytest.mark.asyncio
 async def test_loop_responsive_while_first_ingest_index_builds(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
     router = _mk_router(tmp_path)
@@ -303,9 +312,9 @@ async def test_loop_responsive_while_first_ingest_index_builds(
     assert result == "enqueued"
     # Degraded-proceed: ingest must NOT wait for the cold build.
     assert ingest_wall < 0.45, f"ingest blocked on cold index build: {ingest_wall:.3f}s"
-    assert gaps and max(gaps) < 0.3, (
-        f"event loop starved while index built: max gap {max(gaps):.3f}s"
-    )
+    assert (
+        gaps and max(gaps) < 0.3
+    ), f"event loop starved while index built: max gap {max(gaps):.3f}s"
     # Build was actually triggered off-loop (single-flight, fire-and-forget).
     deadline = time.monotonic() + 3.0
     while builds["n"] == 0 and time.monotonic() < deadline:
@@ -318,7 +327,8 @@ async def test_loop_responsive_while_first_ingest_index_builds(
 # ── §8: N concurrent first-ingests → exactly ONE build, no deadlock ─────
 @pytest.mark.asyncio
 async def test_concurrent_first_ingests_single_flight_build(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     rels = [_mk(tmp_path, f"backend/mod{i}.py", 3000, covered=False) for i in range(6)]
     router = _mk_router(tmp_path)
@@ -358,7 +368,8 @@ async def test_concurrent_first_ingests_single_flight_build(
 # ── §9: warm index → penalty parity with the legacy inline path ─────────
 @pytest.mark.asyncio
 async def test_warm_index_restores_penalty_with_evidence(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     await _require_process_pool()  # real cpu_bound=True pool (sandbox → skip)
     rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
@@ -386,7 +397,8 @@ async def test_warm_index_restores_penalty_with_evidence(
 # ── §10: builder failure is fail-soft — ingest still enqueues ────────────
 @pytest.mark.asyncio
 async def test_index_build_failure_is_fail_soft(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
     router = _mk_router(tmp_path)
@@ -452,9 +464,9 @@ async def test_offload_cpu_bound_frees_loop_during_gil_build(
         await hb
 
     assert not _cfsio.is_offload_error(result), result
-    assert elapsed >= spin_s * 0.8, (
-        f"busy-spin returned too fast ({elapsed:.3f}s) — did it actually run?"
-    )
+    assert (
+        elapsed >= spin_s * 0.8
+    ), f"busy-spin returned too fast ({elapsed:.3f}s) — did it actually run?"
     # ~spin_s / 0.02s ≈ 25 ideal ticks; a thread offload would yield ~0.
     # Assert a healthy fraction to stay robust to scheduler jitter.
     assert ticks["n"] >= 10, (

--- a/tests/governance/test_slice49_ingest_stratification.py
+++ b/tests/governance/test_slice49_ingest_stratification.py
@@ -108,12 +108,85 @@ import threading
 import time
 from unittest.mock import AsyncMock, MagicMock
 
+import backend.core.ouroboros.governance.cooperative_fs_io as _cfsio
 import backend.core.ouroboros.governance.target_stratification as ts
 from backend.core.ouroboros.governance.intake.intent_envelope import make_envelope
 from backend.core.ouroboros.governance.intake.unified_intake_router import (
     IntakeRouterConfig,
     UnifiedIntakeRouter,
 )
+
+
+def _patch_inproc_offload(monkeypatch: pytest.MonkeyPatch, seen: dict) -> None:
+    """Route the coverage-index offload through an in-process, off-loop double.
+
+    Fix 1 makes the real build dispatch with ``cpu_bound=True`` → a *spawn*
+    ``ProcessPoolExecutor`` whose worker re-imports the module fresh, so a
+    ``monkeypatch`` of ``_build_coverage_index_sync`` (how these orchestration
+    tests inject slowness/failure and count builds) can never reach the worker
+    process. This double keeps the orchestration under test deterministic and
+    observable in-process while staying faithful on the load-bearing points:
+
+      * it records the dispatch ``cpu_bound`` so these tests still GUARD that
+        Fix 1 stayed ``cpu_bound=True`` (a revert to the thread pool trips the
+        end-of-test assertion), and
+      * it runs the (possibly-monkeypatched) fn via ``asyncio.to_thread`` —
+        genuinely OFF the event loop, in this process — mirroring offload's
+        fail-soft ``OffloadError`` contract on any raise.
+
+    The REAL process-pool + GIL-freeing behaviour is proven separately by
+    ``test_warm_index_restores_penalty_with_evidence`` (real-pool E2E) and
+    ``test_offload_cpu_bound_frees_loop_during_gil_build`` (Fix 2).
+    """
+    async def _fake_offload(fn, *args, cpu_bound=False, **kwargs):
+        # Record cpu_bound ONLY for the coverage-index build dispatch (the
+        # intake path issues other cpu_bound=False offloads that would
+        # otherwise clobber the guard). ``_build_coverage_index_sync`` is the
+        # module global the build task looks up at call time, so it resolves
+        # to whichever (possibly-monkeypatched) builder this test installed.
+        if fn is ts._build_coverage_index_sync:
+            seen["cpu_bound"] = cpu_bound
+        try:
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 — mirror offload fail-soft
+            return _cfsio.OffloadError(
+                fn_name=getattr(fn, "__name__", repr(fn)),
+                exc_type=type(exc).__name__,
+                message=str(exc),
+                cpu_bound=cpu_bound,
+            )
+
+    monkeypatch.setattr(_cfsio, "offload", _fake_offload)
+
+
+async def _require_process_pool() -> None:
+    """Skip (not fail) when the real ``cpu_bound=True`` process pool can't spawn.
+
+    The cpu_bound offload path needs a spawn ``ProcessPoolExecutor``; a
+    sandboxed / process-creation-restricted test environment makes that
+    unavailable, in which case offload returns a fail-soft ``OffloadError``.
+    Tests that assert the REAL pool's behaviour probe it here and skip with a
+    clear reason rather than reporting a spurious failure (run with the
+    sandbox disabled to exercise them).
+    """
+    probe = await _cfsio.offload(_gil_busy_spin, 0.0, cpu_bound=True)
+    if _cfsio.is_offload_error(probe):
+        pytest.skip(f"process pool unavailable (sandbox?): {probe}")
+
+
+def _gil_busy_spin(duration_s: float, *_a, **_k) -> int:
+    """Module-level (picklable) pure-Python GIL-holding busy spin.
+
+    Spins holding the GIL for ~``duration_s`` — NOT ``time.sleep`` (which
+    releases the GIL). Module-level so it pickles by reference across the
+    spawn process-pool boundary. Stand-in for ``_build_coverage_index_sync``'s
+    real ``ast.parse``-over-963K-lines CPU cost.
+    """
+    end = time.monotonic() + duration_s
+    total = 0
+    while time.monotonic() < end:
+        total += 1
+    return total
 
 
 def _mk_router(tmp_path: Path):
@@ -216,10 +289,12 @@ async def test_loop_responsive_while_first_ingest_index_builds(
 
     def slow_builder(*a, **k):
         builds["n"] += 1
-        time.sleep(0.5)  # slow cold build, via the offload substrate
+        time.sleep(0.5)  # slow cold build, via the (in-process) offload double
         return real_builder(*a, **k)
 
     monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+    seen: dict = {}
+    _patch_inproc_offload(monkeypatch, seen)
 
     t0 = time.monotonic()
     result, gaps = await _hb_gaps(router.ingest(_mk_env(rel)))
@@ -236,6 +311,8 @@ async def test_loop_responsive_while_first_ingest_index_builds(
     while builds["n"] == 0 and time.monotonic() < deadline:
         await asyncio.sleep(0.02)
     assert builds["n"] == 1
+    # Guard Fix 1: the build dispatched with cpu_bound=True (process pool).
+    assert seen.get("cpu_bound") is True
 
 
 # ── §8: N concurrent first-ingests → exactly ONE build, no deadlock ─────
@@ -255,6 +332,8 @@ async def test_concurrent_first_ingests_single_flight_build(
         return real_builder(*a, **k)
 
     monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+    seen: dict = {}
+    _patch_inproc_offload(monkeypatch, seen)
 
     t0 = time.monotonic()
     results = await asyncio.wait_for(
@@ -272,6 +351,8 @@ async def test_concurrent_first_ingests_single_flight_build(
     # never waits on them; parity returns once the index is warm.)
     await asyncio.sleep(0.6)  # let the single-flight build finish
     assert builds["n"] == 1, f"expected exactly ONE build, got {builds['n']}"
+    # Guard Fix 1: the build dispatched with cpu_bound=True (process pool).
+    assert seen.get("cpu_bound") is True
 
 
 # ── §9: warm index → penalty parity with the legacy inline path ─────────
@@ -279,6 +360,7 @@ async def test_concurrent_first_ingests_single_flight_build(
 async def test_warm_index_restores_penalty_with_evidence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    await _require_process_pool()  # real cpu_bound=True pool (sandbox → skip)
     rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
     router = _mk_router(tmp_path)
 
@@ -316,6 +398,8 @@ async def test_index_build_failure_is_fail_soft(
         raise RuntimeError("synthetic index build failure")
 
     monkeypatch.setattr(ts, "_build_coverage_index_sync", broken_builder)
+    seen: dict = {}
+    _patch_inproc_offload(monkeypatch, seen)
 
     assert await router.ingest(_mk_env(rel, n=1)) == "enqueued"
     await asyncio.sleep(0.3)  # let the failed build task settle
@@ -326,3 +410,54 @@ async def test_index_build_failure_is_fail_soft(
     await asyncio.sleep(0.2)
     # Failure cooldown: no rebuild storm (one attempt within the window).
     assert builds["n"] == 1
+    # Guard Fix 1: even the failing build dispatched with cpu_bound=True.
+    assert seen.get("cpu_bound") is True
+
+
+# ── Fix 2: cpu_bound=True frees the loop during a GIL-HOLDING cold build ──
+@pytest.mark.asyncio
+async def test_offload_cpu_bound_frees_loop_during_gil_build(
+    tmp_path: Path,
+) -> None:
+    """A GIL-holding pure-Python build (the real ``ast.parse`` cost class),
+    dispatched through the SAME ``offload(..., cpu_bound=True)`` path the
+    coverage-index build uses, must NOT starve the event loop.
+
+    Unlike the ``time.sleep``-based responsiveness tests (which release the
+    GIL and therefore prove only that intake doesn't *await* the build), this
+    drives a genuine GIL-holding busy-spin. With cpu_bound=True the spin runs
+    in a separate PROCESS, so a concurrent heartbeat coroutine keeps ticking;
+    a thread offload (the pre-Fix-1 behaviour) would hold the GIL for the whole
+    spin and the heartbeat would stall. Requires the real process pool → skips
+    (not fails) where spawn is unavailable (sandboxed env).
+    """
+    await _require_process_pool()
+
+    spin_s = 0.5
+    ticks = {"n": 0}
+    stop = asyncio.Event()
+
+    async def _hb() -> None:
+        while not stop.is_set():
+            await asyncio.sleep(0.02)
+            ticks["n"] += 1
+
+    hb = asyncio.create_task(_hb())
+    try:
+        t0 = time.monotonic()
+        result = await _cfsio.offload(_gil_busy_spin, spin_s, cpu_bound=True)
+        elapsed = time.monotonic() - t0
+    finally:
+        stop.set()
+        await hb
+
+    assert not _cfsio.is_offload_error(result), result
+    assert elapsed >= spin_s * 0.8, (
+        f"busy-spin returned too fast ({elapsed:.3f}s) — did it actually run?"
+    )
+    # ~spin_s / 0.02s ≈ 25 ideal ticks; a thread offload would yield ~0.
+    # Assert a healthy fraction to stay robust to scheduler jitter.
+    assert ticks["n"] >= 10, (
+        f"event loop starved during GIL-holding build: only {ticks['n']} "
+        "heartbeat ticks (process pool did not free the GIL)"
+    )


### PR DESCRIPTION
Closes the 4th and final event-loop-starvation tier blocking the A1 pipeline. TDD + reviewed (MERGE verdict).

## Root cause (traced, not assumed)
`_ingest_impl → _compute_priority → file_has_test_coverage` ran `sorted(rglob("test_*.py"))` over 2,839 files + a cold AST-import-map (`ast.parse` ~963K lines) on **every ingest** = a 41.7s synchronous loop block. Proven by 6/6 profiler stuck-frame captures in `file_has_test_coverage → pathlib.stat`.

## Fix
Per-repo `_CoverageIndex` (name-set/bisect + AST map) built in ONE traversal via `cooperative_fs_io.offload(cpu_bound=True)` (process pool — AST parse is GIL-holding). Ingest degrades (penalty override 0, advisory-only) while cold + single-flight build trigger; warm path is zero-traversal. Live-fire: cold ingest 41,713ms → 3,348ms, **max loop gap 41,713ms → sub-threshold**, warm ingest 163ms.

## Guarantees
Single-flight (6 concurrent ingests → 1 build, no deadlock), atomic immutable-NamedTuple swap, fail-soft (build failure → degraded + cooldown retry, never raises), TTL rebuild off-loop. Review-verified: no None re-enters the scan, fast path is on the live ingest chain (not wired-but-inert). +24 tests incl. picklability round-trip + GIL-holding responsiveness.

## Follow-ups (non-blocking, ledgered)
- `opportunity_miner_sensor:686` / `operation_advisor:2158` still legacy-scan if hit before the index warms (periodic/advisor, off the per-op loop).
- The CPU-VM migration of the monolithic Body remains the durable architectural fix (this was tier 4 of point-fixes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes event-loop starvation in ingest by moving test-coverage checks off the loop and adding a per-repo coverage index. Removes the ~41.7s sync block; cold ingest ~3.3s, warm ~163ms; index cold-build ~38s off-loop.

- **Bug Fixes**
  - Added `_CoverageIndex` built off-loop via `cooperative_fs_io.offload(cpu_bound=True)` (process pool); single-flight build, atomic swap, TTL refresh, retry cooldown, and a guard that releases the building flag if `create_task` fails.
  - Updated `UnifiedIntakeRouter._ingest_impl`: warm path computes penalty offloaded and stashes `stratification_penalty`; cold degrades to 0 and triggers a background build. `_compute_priority` now accepts `stratification_penalty_override`.
  - Optimized `file_has_test_coverage` to read the warm index (set/bisect/dict) with no FS traversal; legacy scan remains behind env flags: `JARVIS_STRATIFICATION_INDEX_ENABLED`, `JARVIS_STRATIFICATION_INDEX_TTL_S`, `JARVIS_STRATIFICATION_INDEX_RETRY_S`.
  - Exposed `coverage_index_ready`, `trigger_coverage_index_build`, and `reset_coverage_index` for readiness checks, non-blocking builds, and tests.
  - Added tests for warm-path parity, index lifecycle, loop responsiveness during first build, concurrent single-flight, process-pool GIL freeing, create_task flag-leak guard, and fail-soft behavior. Result: loop gaps stay below threshold.

- **Refactors**
  - Black-formatted the Tier-4 delta files to repo config (line-length=100); functionally inert.

<sup>Written for commit 75ba46b00d8eccaa5b59057c1c562242f249420b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69828?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

