### PR TITLE
feat(transport): Stage 0 -- distributed TrinityEventBus over WebSocket (dark-shipped)

### DIFF
--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -518,6 +518,7 @@ def _compute_priority(
     repo_root: "Optional[Path]" = None,
     resurrected: bool = False,
     semantic_boost_override: "Optional[int]" = None,
+    stratification_penalty_override: "Optional[int]" = None,
 ) -> Tuple[int, Optional[Any]]:
     """Compute cost-aware priority score + rich goal alignment for an envelope.
 
@@ -699,7 +700,15 @@ def _compute_priority(
     # Authority invariant: priority ordering ONLY — never fed to UrgencyRouter,
     # Iron Gate, risk tier, policy engine, FORBIDDEN_PATH, or approval gating.
     stratification_penalty = 0
-    if repo_root is not None and _ingest_stratification_enabled():
+    if stratification_penalty_override is not None:
+        # Tier-4 — the caller (``_ingest_impl``) already computed (or
+        # deliberately degraded) the stratification penalty OFF the asyncio
+        # loop. The inline path below runs file_has_test_coverage's
+        # tests-tree rglob + cold AST-map build synchronously — the traced
+        # 41.7 s on-loop block (bt-iso-1783102490) — so the hot intake path
+        # must NEVER reach it. Evidence stash is done by the caller.
+        stratification_penalty = max(0, int(stratification_penalty_override))
+    elif repo_root is not None and _ingest_stratification_enabled():
         try:
             from backend.core.ouroboros.governance.target_stratification import (
                 ingest_priority_penalty,
@@ -1245,10 +1254,68 @@ class UnifiedIntakeRouter:
                 "[Router] offloaded semantic scorer skipped: %s", _sem_exc,
             )
             _semantic_override = None
+        # Tier-4 — stratification coverage penalty OFF the asyncio loop.
+        # The inline path (``_compute_priority`` → ``ingest_priority_penalty``
+        # → ``file_has_test_coverage``) rglob-walks the ENTIRE tests/ tree
+        # (~2,839 files) per signal and cold-builds the AST import map
+        # (read + ast.parse of ~963K test lines) on first miss — the traced
+        # 41,713 ms single on-loop block of bt-iso-1783102490 (plus the
+        # 1–16 s recurring blocks). Here we branch on index warmth:
+        #   * warm  → penalty via cheap in-memory lookups, dispatched
+        #     through ``cooperative_fs_io.offload`` (thread hop covers the
+        #     residual ``_count_lines`` file read);
+        #   * cold  → PROCEED DEGRADED (override 0 — no penalty, no
+        #     evidence) and fire the single-flight off-loop index build.
+        #     The prior is advisory priority-ordering only, so ops flowing
+        #     unbiased while the index warms mirrors the SemanticIndex
+        #     Tier-2b fail-soft convention; intake never waits ~40 s.
+        # Fail-soft: ANY fault degrades to 0 — never None, because None
+        # would route ``_compute_priority`` back onto the inline on-loop
+        # scan (the bug this block eradicates).
+        _strat_override: Optional[int] = None
+        if envelope.target_files and _ingest_stratification_enabled():
+            _strat_override = 0  # degraded-proceed default
+            try:
+                from backend.core.ouroboros.governance.target_stratification import (  # noqa: E501
+                    coverage_index_ready,
+                    ingest_priority_penalty,
+                    trigger_coverage_index_build,
+                )
+                _idx_ready = coverage_index_ready(self._config.project_root)
+                # Always fire the trigger — it self-gates (single-flight
+                # "building" set, TTL freshness, failure cooldown) and
+                # returns immediately; also covers TTL refresh when warm.
+                trigger_coverage_index_build(self._config.project_root)
+                if _idx_ready:
+                    from backend.core.ouroboros.governance.cooperative_fs_io import (  # noqa: E501
+                        is_offload_error,
+                        offload,
+                    )
+                    _pen = await offload(
+                        ingest_priority_penalty,
+                        envelope.target_files,
+                        self._config.project_root,
+                        suppress=_is_test_generation_intent(envelope),
+                        cpu_bound=False,
+                    )
+                    if not is_offload_error(_pen):
+                        _strat_override = max(0, int(_pen))
+                        if _strat_override > 0 and isinstance(
+                            envelope.evidence, dict,
+                        ):
+                            envelope.evidence["stratification_penalty"] = (
+                                _strat_override
+                            )
+            except Exception as _strat_exc:  # noqa: BLE001 — never break intake
+                logger.debug(
+                    "[Router] offloaded stratification skipped (degraded): %s",
+                    _strat_exc,
+                )
         priority, alignment = _compute_priority(
             envelope, dependency_credit=_dep_credit,
             repo_root=self._config.project_root,
             semantic_boost_override=_semantic_override,
+            stratification_penalty_override=_strat_override,
         )
         # Stash goal-alignment diagnostics on the envelope so downstream
         # phases (orchestrator, SerpentFlow postmortems, dead-letter audit)

--- a/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
+++ b/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
@@ -52,6 +52,7 @@ import ast
 import asyncio as _asyncio
 import logging
 import os
+import re
 import threading
 import time as _time
 from dataclasses import dataclass, field
@@ -3474,6 +3475,70 @@ def _validate_replay_lazy_imports_sse_publisher(
 
 
 # ---------------------------------------------------------------------------
+# Stage 0 -- distributed event-bus transport substrate: structural
+# isolation pins (Task 8)
+# ---------------------------------------------------------------------------
+
+_IPV4_RE = re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_WSURL_RE = re.compile(r"wss?://")
+
+
+def _validate_realtime_actuation_no_remote_transport(
+    tree: ast.Module, source: str,  # noqa: ARG001 -- interface
+) -> Tuple[str, ...]:
+    """Real-time actuation layers (Ghost Hands) MUST NOT import the
+    network transport subpackage. A remote dependency on a
+    hard-real-time cursor/keyboard path would couple actuation
+    latency to network RTT. Structural block. NEVER raises."""
+    out: List[str] = []
+    try:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if "governance.transport" in mod:
+                    out.append(
+                        f"real-time actuation imports remote "
+                        f"transport: from {mod} "
+                        f"(line {node.lineno})"
+                    )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if "governance.transport" in (alias.name or ""):
+                        out.append(
+                            f"real-time actuation imports remote "
+                            f"transport: import {alias.name} "
+                            f"(line {node.lineno})"
+                        )
+    except Exception:  # noqa: BLE001 -- validators never raise
+        return ()
+    return tuple(out)
+
+
+def _validate_transport_no_hardcoded_endpoints(
+    tree: ast.Module, source: str,  # noqa: ARG001 -- interface
+) -> Tuple[str, ...]:
+    """The transport config module must resolve every endpoint from
+    env -- no baked IPv4 literals, no baked ws:// / wss:// URLs.
+    NEVER raises."""
+    out: List[str] = []
+    try:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(
+                node.value, str,
+            ):
+                val = node.value
+                if _IPV4_RE.search(val) or _WSURL_RE.search(val):
+                    out.append(
+                        f"hardcoded endpoint literal {val!r} "
+                        f"(line {getattr(node, 'lineno', -1)}) "
+                        f"-- resolve from env"
+                    )
+    except Exception:  # noqa: BLE001
+        return ()
+    return tuple(out)
+
+
+# ---------------------------------------------------------------------------
 # Seed registration
 # ---------------------------------------------------------------------------
 
@@ -4972,6 +5037,54 @@ def _register_seed_invariants() -> None:
                 "registration."
             ),
             validate=_validate_confidence_threshold_tightener,
+        ),
+    )
+
+    # -- Stage 0 transport substrate (Task 8) -----------------------
+    # Real-time actuation isolation: registered ONCE PER real-time
+    # Ghost Hands module -- a network transport dependency on any of
+    # these hard-real-time paths would couple actuation latency to
+    # network RTT.
+    for _module_stem in (
+        "cgevent_worker",
+        "silent_actuator",
+        "background_actuator",
+        "yabai_aware_actuator",
+        "orchestrator",
+    ):
+        register_shipped_code_invariant(
+            ShippedCodeInvariant(
+                invariant_name=(
+                    "realtime_actuation_no_remote_transport__"
+                    f"{_module_stem}"
+                ),
+                target_file=f"backend/ghost_hands/{_module_stem}.py",
+                description=(
+                    "Real-time actuation (Ghost Hands) MUST NOT "
+                    "import backend.core.ouroboros.governance."
+                    "transport -- a hard-real-time path cannot "
+                    "take a network dependency (Stage 0 "
+                    "latency-scope invariant)."
+                ),
+                validate=(
+                    _validate_realtime_actuation_no_remote_transport
+                ),
+            ),
+        )
+
+    register_shipped_code_invariant(
+        ShippedCodeInvariant(
+            invariant_name="transport_config_no_hardcoded_endpoints",
+            target_file=(
+                "backend/core/ouroboros/governance/transport/"
+                "transport_config.py"
+            ),
+            description=(
+                "TransportConfig must resolve every endpoint from "
+                "env -- no baked IPv4 or ws:// / wss:// literals "
+                "(Stage 0 no-hardcoding invariant)."
+            ),
+            validate=_validate_transport_no_hardcoded_endpoints,
         ),
     )
 

--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -273,9 +273,22 @@ async def _coverage_index_build_task(scan_root: Path) -> None:
             except Exception:  # noqa: BLE001
                 idx = None
         else:
+            # cpu_bound=True → ProcessPoolExecutor (not the thread pool):
+            # _build_coverage_index_sync runs ast.parse over the whole test
+            # tree (~963K lines) = pure-Python, GIL-holding CPU. A thread
+            # offload would hold the GIL for the entire parse and still leave
+            # a ~592ms on-loop residual (grazing the 500ms starvation floor);
+            # only a separate process frees the loop. Safe because the target
+            # is a module-level function with picklable args (Path + frozenset)
+            # and a picklable return (the _CoverageIndex NamedTuple of str/Path
+            # containers — round-trip pinned by test_coverage_index_pickle_
+            # roundtrip). Fail-soft is preserved: offload catches worker faults
+            # (OffloadError) and pool-creation faults (spawn blocked) alike, and
+            # the outer except is belt-and-suspenders — a failed build leaves
+            # callers degraded, never raises into intake.
             result = await offload(
                 _build_coverage_index_sync, scan_root, dir_names,
-                cpu_bound=False,
+                cpu_bound=True,
             )
             idx = None if is_offload_error(result) else result
     except Exception:  # noqa: BLE001 — belt-and-suspenders
@@ -343,7 +356,21 @@ def trigger_coverage_index_build(repo_root: Union[str, Path]) -> str:
         with _COVERAGE_IDX_LOCK:
             _coverage_index_building.discard(scan_root)
         return "skipped_no_loop"
-    task = loop.create_task(_coverage_index_build_task(scan_root))
+    try:
+        task = loop.create_task(_coverage_index_build_task(scan_root))
+    except Exception:  # noqa: BLE001 — scheduling fault must not wedge the flag
+        # If create_task raised (loop closing, etc.) the "building" flag would
+        # otherwise leak and every future trigger returns "skipped_running"
+        # forever — the repo wedged out of ever rebuilding the index. Discard
+        # it under the lock so the next trigger can retry.
+        with _COVERAGE_IDX_LOCK:
+            _coverage_index_building.discard(scan_root)
+        logger.debug(
+            "[Stratification] coverage index build task scheduling failed "
+            "root=%s (flag released, will retry on next trigger)",
+            scan_root, exc_info=True,
+        )
+        return "skipped_no_loop"
     _coverage_index_tasks.add(task)
     task.add_done_callback(_coverage_index_tasks.discard)
     return "started"

--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -36,9 +36,25 @@ Both ``alpha`` and ``max_lines`` are env-tunable (no hardcoding):
 from __future__ import annotations
 
 import ast as _ast
+import bisect
+import logging
 import os
+import threading
+import time
 from pathlib import Path
-from typing import Dict, FrozenSet, Iterable, List, Union
+from typing import (
+    Dict,
+    FrozenSet,
+    Iterable,
+    List,
+    NamedTuple,
+    Optional,
+    Set,
+    Tuple,
+    Union,
+)
+
+logger = logging.getLogger(__name__)
 
 # Defaults are module constants so tests + callers share one source of truth.
 DEFAULT_PENALTY_ALPHA: float = 0.75
@@ -91,45 +107,307 @@ def _strat_ast_import_enabled() -> bool:
 _strat_ast_cache: Dict[Path, Dict[str, List[Path]]] = {}
 
 
-def _strat_build_ast_map(
+# ---------------------------------------------------------------------------
+# Tier-4 loop-starvation fix — off-loop coverage index
+# ---------------------------------------------------------------------------
+#
+# Traced mechanism (session bt-iso-1783102490): ``file_has_test_coverage``
+# was invoked synchronously ON the asyncio loop from the intake hot path
+# (UnifiedIntakeRouter._ingest_impl → _compute_priority →
+# ingest_priority_penalty). Strategy 1 materializes
+# ``sorted(top.rglob("test_*.py"))`` — a full recursive walk + stat of the
+# entire tests/ tree (~2,839 files here) on EVERY call — and Strategy 2
+# cold-builds the AST import map by reading + ``ast.parse``-ing ALL test
+# files (~963K lines) on the FIRST cache miss: the observed 41,713 ms
+# single on-loop block, with 1–16 s recurring blocks from the per-call
+# rglob afterwards.
+#
+# The fix: a per-repo in-memory **coverage index** — the sorted tuple of
+# test-file basenames (Strategy 1 becomes two bisect/set lookups) plus the
+# existing AST import map (Strategy 2 becomes a dict lookup) — built in a
+# SINGLE tree traversal OFF the event loop via the unified
+# ``cooperative_fs_io.offload`` substrate.
+#
+#   * Single-flight: concurrent triggers coalesce on ``_COVERAGE_IDX_LOCK``
+#     + the ``building`` set — at most one build per repo_root at a time.
+#   * Atomic swap: the index is assembled entirely in the worker, then
+#     swapped into ``_coverage_index`` under the lock — readers observe
+#     the old index or the new one, never a partial.
+#   * Degraded-proceed: while the index is cold/building, async callers
+#     (intake) proceed WITHOUT the stratification prior (advisory-only,
+#     priority ordering — never authority), mirroring the SemanticIndex
+#     Tier-2b convention. Sync callers keep the legacy scan, byte-identical.
+#   * Fail-soft: a failed build logs at DEBUG, arms a retry cooldown, and
+#     leaves callers degraded — never raises into intake.
+#
+# Env knobs (no hardcoding):
+#   * ``JARVIS_STRATIFICATION_INDEX_ENABLED``  (default "true") — master.
+#   * ``JARVIS_STRATIFICATION_INDEX_TTL_S``    (default 600) — refresh age;
+#     a stale index is STILL served while the refresh rebuilds off-loop
+#     (eventually consistent; the signal is advisory). ``0`` = build once.
+#   * ``JARVIS_STRATIFICATION_INDEX_RETRY_S``  (default 600) — failure
+#     cooldown before another build attempt.
+
+
+class _CoverageIndex(NamedTuple):
+    """Immutable per-repo test-coverage index (atomic-swap unit)."""
+
+    names_set: FrozenSet[str]      # every test_*.py basename (exact match)
+    names_sorted: Tuple[str, ...]  # same names, sorted (prefix bisect)
+    ast_map: Dict[str, List[Path]]
+    built_at: float
+
+
+_coverage_index: Dict[Path, _CoverageIndex] = {}
+_coverage_index_building: Set[Path] = set()
+_coverage_index_failed_at: Dict[Path, float] = {}
+_coverage_index_tasks: Set[object] = set()  # strong refs to build tasks
+_COVERAGE_IDX_LOCK = threading.Lock()
+
+
+def _coverage_index_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_STRATIFICATION_INDEX_ENABLED", "true",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _coverage_index_ttl_s() -> float:
+    return max(0.0, _env_float("JARVIS_STRATIFICATION_INDEX_TTL_S", 600.0))
+
+
+def _coverage_index_retry_s() -> float:
+    return max(0.0, _env_float("JARVIS_STRATIFICATION_INDEX_RETRY_S", 600.0))
+
+
+def _resolve_scan_root(repo_root: Union[str, Path]) -> Path:
+    """Canonical scan-root resolution shared by every coverage entrypoint.
+
+    Applies the same ``.worktrees/<name>`` → parent-repo translation as
+    ``file_has_test_coverage`` (READS stay authoritative) and resolves the
+    path so the index cache key is stable across spellings.
+    """
+    try:
+        from backend.core.ouroboros.governance.execution_context import (
+            authoritative_repo_root as _auth_root,
+        )
+        root = _auth_root(Path(repo_root))
+    except Exception:  # noqa: BLE001 — fail-soft, never breaks coverage
+        root = Path(repo_root)
+    try:
+        return root.resolve()
+    except OSError:  # circular symlinks — keep syntactic form
+        return root
+
+
+def _build_coverage_index_sync(
     repo_root: Path,
     dir_names: FrozenSet[str],
-) -> Dict[str, List[Path]]:
-    """Synchronous AST import-map builder (mirrors test_runner._build_test_import_map).
+) -> _CoverageIndex:
+    """ONE traversal of the test tree → name index + AST import map.
 
-    Scans every ``test_*.py`` under the configured test roots and maps
-    ``dotted_module_path → [test_files that import it]``.
+    Heavy by design (this is the 41.7 s cold cost) — MUST only run off the
+    event loop (offload substrate / worker thread). Pure function of the
+    filesystem; assembles the full index before the caller swaps it in.
     """
-    import_map: Dict[str, List[Path]] = {}
+    files = list(_iter_test_files(repo_root, dir_names))
+    names = frozenset(f.name for f in files)
+    ast_map = _strat_build_ast_map(repo_root, dir_names, files=files)
+    return _CoverageIndex(
+        names_set=names,
+        names_sorted=tuple(sorted(names)),
+        ast_map=ast_map,
+        built_at=time.time(),
+    )
+
+
+def _coverage_index_lookup(scan_root: Path) -> Optional[_CoverageIndex]:
+    """Return the warm index for an already-resolved scan root (or None)."""
+    if not _coverage_index_enabled():
+        return None
+    with _COVERAGE_IDX_LOCK:
+        return _coverage_index.get(scan_root)
+
+
+def coverage_index_ready(repo_root: Union[str, Path]) -> bool:
+    """True when a warm in-memory coverage index exists for ``repo_root``.
+
+    Async hot paths branch on this: ready → compute the stratification
+    penalty via cheap index lookups (offloaded); not ready → proceed
+    DEGRADED (no penalty) and let :func:`trigger_coverage_index_build`
+    warm the index in the background.
+    """
+    return _coverage_index_lookup(_resolve_scan_root(repo_root)) is not None
+
+
+def reset_coverage_index() -> None:
+    """Test hook — drop all coverage-index state (mirrors reset_default_index)."""
+    with _COVERAGE_IDX_LOCK:
+        _coverage_index.clear()
+        _coverage_index_building.clear()
+        _coverage_index_failed_at.clear()
+        _coverage_index_tasks.clear()
+
+
+async def _coverage_index_build_task(scan_root: Path) -> None:
+    """Detached build task — offloads the heavy traversal, swaps atomically.
+
+    NEVER raises out (fire-and-forget). Failure arms the retry cooldown and
+    logs at DEBUG; success also warms the legacy ``_strat_ast_cache`` so
+    synchronous callers skip their own cold AST build.
+    """
+    idx: Optional[_CoverageIndex] = None
+    try:
+        dir_names = _strat_test_dir_names()
+        try:
+            from backend.core.ouroboros.governance.cooperative_fs_io import (
+                is_offload_error,
+                offload,
+            )
+        except Exception:  # noqa: BLE001 — substrate import fault
+            # Still keep the multi-second build off the loop (bare thread).
+            import asyncio as _aio
+            try:
+                idx = await _aio.to_thread(
+                    _build_coverage_index_sync, scan_root, dir_names,
+                )
+            except Exception:  # noqa: BLE001
+                idx = None
+        else:
+            result = await offload(
+                _build_coverage_index_sync, scan_root, dir_names,
+                cpu_bound=False,
+            )
+            idx = None if is_offload_error(result) else result
+    except Exception:  # noqa: BLE001 — belt-and-suspenders
+        idx = None
+        logger.debug(
+            "[Stratification] coverage index build raised root=%s",
+            scan_root, exc_info=True,
+        )
+    finally:
+        with _COVERAGE_IDX_LOCK:
+            if idx is not None:
+                _coverage_index[scan_root] = idx  # atomic swap
+                _coverage_index_failed_at.pop(scan_root, None)
+            else:
+                _coverage_index_failed_at[scan_root] = time.time()
+            _coverage_index_building.discard(scan_root)
+        if idx is not None:
+            # Warm the legacy per-process AST cache too — sync callers
+            # (miner scan_once, Advisor coverage) skip their cold build.
+            _strat_ast_cache[scan_root] = idx.ast_map
+            logger.info(
+                "[Stratification] coverage index built root=%s "
+                "test_files=%d ast_modules=%d",
+                scan_root, len(idx.names_set), len(idx.ast_map),
+            )
+        else:
+            logger.debug(
+                "[Stratification] coverage index build failed root=%s "
+                "(degraded — no stratification prior until retry window)",
+                scan_root,
+            )
+
+
+def trigger_coverage_index_build(repo_root: Union[str, Path]) -> str:
+    """Non-blocking, single-flight build trigger (mirrors build_async).
+
+    Returns a string sentinel for logs/tests:
+      * ``"started"``                — a detached build task was scheduled
+      * ``"skipped_running"``        — a build is already in flight
+      * ``"skipped_fresh"``          — index exists and is within TTL
+      * ``"skipped_failed_cooldown"``— last build failed; retry window open
+      * ``"skipped_no_loop"``        — no running event loop (sync caller)
+      * ``"skipped_disabled"``       — master switch off
+    """
+    if not _coverage_index_enabled():
+        return "skipped_disabled"
+    scan_root = _resolve_scan_root(repo_root)
+    now = time.time()
+    with _COVERAGE_IDX_LOCK:
+        if scan_root in _coverage_index_building:
+            return "skipped_running"
+        idx = _coverage_index.get(scan_root)
+        if idx is not None:
+            ttl = _coverage_index_ttl_s()
+            if ttl <= 0 or (now - idx.built_at) < ttl:
+                return "skipped_fresh"
+        failed_at = _coverage_index_failed_at.get(scan_root)
+        if failed_at is not None and (now - failed_at) < _coverage_index_retry_s():
+            return "skipped_failed_cooldown"
+        _coverage_index_building.add(scan_root)
+    import asyncio as _aio
+    try:
+        loop = _aio.get_running_loop()
+    except RuntimeError:
+        with _COVERAGE_IDX_LOCK:
+            _coverage_index_building.discard(scan_root)
+        return "skipped_no_loop"
+    task = loop.create_task(_coverage_index_build_task(scan_root))
+    _coverage_index_tasks.add(task)
+    task.add_done_callback(_coverage_index_tasks.discard)
+    return "started"
+
+
+def _iter_test_files(
+    repo_root: Path,
+    dir_names: FrozenSet[str],
+) -> "Iterable[Path]":
+    """Yield every ``test_*.py`` regular file under the configured test roots.
+
+    Single source of truth for the test-tree traversal so the AST-map
+    builder and the coverage-index builder can never drift (and so the
+    expensive walk happens exactly ONCE when both are built together).
+    """
     for tdn in sorted(dir_names):
         top = repo_root / tdn
         if not top.is_dir():
             continue
         for test_file in sorted(top.rglob("test_*.py")):
-            if not test_file.is_file():
-                continue
-            try:
-                source = test_file.read_text(encoding="utf-8", errors="replace")
-                tree = _ast.parse(source, filename=str(test_file))
-            except (SyntaxError, OSError, UnicodeDecodeError):
-                continue
-            for node in _ast.walk(tree):
-                if isinstance(node, _ast.Import):
-                    for alias in node.names:
-                        lst = import_map.setdefault(alias.name, [])
-                        if test_file not in lst:
-                            lst.append(test_file)
-                elif isinstance(node, _ast.ImportFrom):
-                    module = node.module or ""
-                    if module:
-                        lst = import_map.setdefault(module, [])
-                        if test_file not in lst:
-                            lst.append(test_file)
-                    for alias in node.names:
-                        full = f"{module}.{alias.name}" if module else alias.name
-                        lst = import_map.setdefault(full, [])
-                        if test_file not in lst:
-                            lst.append(test_file)
+            if test_file.is_file():
+                yield test_file
+
+
+def _strat_build_ast_map(
+    repo_root: Path,
+    dir_names: FrozenSet[str],
+    *,
+    files: "Optional[List[Path]]" = None,
+) -> Dict[str, List[Path]]:
+    """Synchronous AST import-map builder (mirrors test_runner._build_test_import_map).
+
+    Scans every ``test_*.py`` under the configured test roots and maps
+    ``dotted_module_path → [test_files that import it]``. ``files`` lets a
+    caller that already walked the tree (the coverage-index builder) reuse
+    its file list instead of paying a second full traversal.
+    """
+    import_map: Dict[str, List[Path]] = {}
+    for test_file in (
+        files if files is not None
+        else _iter_test_files(repo_root, dir_names)
+    ):
+        try:
+            source = test_file.read_text(encoding="utf-8", errors="replace")
+            tree = _ast.parse(source, filename=str(test_file))
+        except (SyntaxError, OSError, UnicodeDecodeError):
+            continue
+        for node in _ast.walk(tree):
+            if isinstance(node, _ast.Import):
+                for alias in node.names:
+                    lst = import_map.setdefault(alias.name, [])
+                    if test_file not in lst:
+                        lst.append(test_file)
+            elif isinstance(node, _ast.ImportFrom):
+                module = node.module or ""
+                if module:
+                    lst = import_map.setdefault(module, [])
+                    if test_file not in lst:
+                        lst.append(test_file)
+                for alias in node.names:
+                    full = f"{module}.{alias.name}" if module else alias.name
+                    lst = import_map.setdefault(full, [])
+                    if test_file not in lst:
+                        lst.append(test_file)
     return import_map
 
 
@@ -203,6 +481,37 @@ def file_has_test_coverage(
     dir_names = _strat_test_dir_names()
     exact_name = f"test_{stem}.py"
     suffix_prefix = f"test_{stem}_"
+
+    # Tier-4 fast path — when the off-loop coverage index is warm, answer
+    # from memory: Strategy 1 collapses to a set lookup + one bisect prefix
+    # probe, Strategy 2 to a dict lookup. NO filesystem traversal. This is
+    # what makes the function safe to call from latency-sensitive contexts
+    # once the index is built (the intake hot path additionally never calls
+    # it on the loop at all — see UnifiedIntakeRouter._ingest_impl).
+    try:
+        _idx_key = _scan_root.resolve()
+    except OSError:  # noqa: PERF203 — circular symlink, keep syntactic form
+        _idx_key = _scan_root
+    _idx = _coverage_index_lookup(_idx_key)
+    if _idx is not None:
+        if exact_name in _idx.names_set:
+            return True
+        _i = bisect.bisect_left(_idx.names_sorted, suffix_prefix)
+        if _i < len(_idx.names_sorted) and _idx.names_sorted[_i].startswith(
+            suffix_prefix,
+        ):
+            return True  # suffix variants all end with ".py" by construction
+        if _strat_ast_import_enabled():
+            try:
+                _fp = Path(file_path)
+                if not _fp.is_absolute():
+                    _fp = _scan_root / _fp
+                _module_path = _strat_path_to_module(_fp, _scan_root)
+                if _module_path and _idx.ast_map.get(_module_path):
+                    return True
+            except Exception:  # noqa: BLE001 — fail-soft, mirror Strategy 2
+                pass
+        return False
 
     # Strategy 1: suffix-aware recursive search across all test roots.
     # Finds test_<stem>.py (exact) AND test_<stem>_*.py (suffix variants).

--- a/backend/core/ouroboros/governance/transport/__init__.py
+++ b/backend/core/ouroboros/governance/transport/__init__.py
@@ -10,9 +10,27 @@ from __future__ import annotations
 __all__ = [
     "TransportConfig",
     "distributed_bus_enabled",
+    "DistributedEventBus",
+    "BusBridgeServer",
+    "BusBridgeClient",
+    "build_client_ssl_context",
+    "build_server_ssl_context",
 ]
 
-from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: E402
+from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: E402,F401
     TransportConfig,
     distributed_bus_enabled,
+)
+from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: E402,F401
+    DistributedEventBus,
+)
+from backend.core.ouroboros.governance.transport.bus_bridge_server import (  # noqa: E402,F401
+    BusBridgeServer,
+)
+from backend.core.ouroboros.governance.transport.bus_bridge_client import (  # noqa: E402,F401
+    BusBridgeClient,
+)
+from backend.core.ouroboros.governance.transport.transport_security import (  # noqa: E402,F401
+    build_client_ssl_context,
+    build_server_ssl_context,
 )

--- a/backend/core/ouroboros/governance/transport/__init__.py
+++ b/backend/core/ouroboros/governance/transport/__init__.py
@@ -1,0 +1,18 @@
+"""Distributed TrinityEventBus transport substrate (Stage 0).
+
+Extends the in-process StreamEventBroker across a WebSocket so
+publish() on one host reaches subscribers on the other. Ships dark
+(JARVIS_DISTRIBUTED_BUS_ENABLED default false) until Stage 2 wires it
+into the live loop.
+"""
+from __future__ import annotations
+
+__all__ = [
+    "TransportConfig",
+    "distributed_bus_enabled",
+]
+
+from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: E402
+    TransportConfig,
+    distributed_bus_enabled,
+)

--- a/backend/core/ouroboros/governance/transport/_smoke_server.py
+++ b/backend/core/ouroboros/governance/transport/_smoke_server.py
@@ -1,0 +1,44 @@
+# backend/core/ouroboros/governance/transport/_smoke_server.py
+"""Runnable brain-side WS server for the two-process loopback smoke test.
+Host/port/TLS come entirely from env -- no hardcoded endpoint. Writes the
+bound port to the file named by JARVIS_BRAIN_WS_PORTFILE so the parent can
+discover it (loopback stand-in for Stage 1's Reachability discovery)."""
+from __future__ import annotations
+
+import asyncio
+import os
+
+from aiohttp import web
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.distributed_event_bus import DistributedEventBus
+from backend.core.ouroboros.governance.transport.transport_security import (
+    build_server_ssl_context,
+)
+
+
+async def _main() -> None:
+    cfg = TransportConfig.from_env(role="server")
+    broker = StreamEventBroker(history_maxlen=cfg.history_maxlen)
+    bus = DistributedEventBus(broker, cfg, role="server")
+    app = web.Application()
+    bus.register_server_routes(app)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    ssl_ctx = build_server_ssl_context(cfg)
+    site = web.TCPSite(runner, cfg.host or "127.0.0.1", cfg.port, ssl_context=ssl_ctx)
+    await site.start()
+    # Publish one heartbeat event on a timer so the client observes traffic.
+    portfile = os.environ.get("JARVIS_BRAIN_WS_PORTFILE")
+    bound = site._server.sockets[0].getsockname()[1]  # actual bound port
+    if portfile:
+        with open(portfile, "w") as fh:
+            fh.write(str(bound))
+    for i in range(1000):
+        broker.publish("task_updated", "op-smoke", {"i": i})
+        await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())

--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -1,0 +1,202 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from typing import Callable, Optional, Set
+
+import aiohttp
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    EVENT_TYPE_HEARTBEAT,
+    EVENT_TYPE_REPLAY_END,
+    EVENT_TYPE_REPLAY_START,
+    EVENT_TYPE_STREAM_LAG,
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.transport_security import (
+    build_client_ssl_context,
+)
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+
+logger = logging.getLogger(__name__)
+
+# Broker-internal bookkeeping event types. Same rationale as
+# bus_bridge_server.py: these are produced by
+# StreamEventBroker.subscribe()/stream_iter() for SSE-side replay
+# framing and are not part of the peer-to-peer bus wire protocol
+# (bus_frame.py only knows hello/event/heartbeat/ack). replay_start
+# and replay_end are dropped; heartbeat is translated to the wire
+# heartbeat frame kind rather than forwarded as a generic event.
+_CONTROL_EVENT_TYPES = frozenset({EVENT_TYPE_REPLAY_START, EVENT_TYPE_REPLAY_END, EVENT_TYPE_STREAM_LAG})
+
+
+class BusBridgeClient:
+    """Connects to a BusBridgeServer, resumes via Last-Event-ID, and
+    mirrors the two brokers. Reconnect is exp-backoff + jitter; a
+    heartbeat-window miss flips degraded mode deterministically."""
+
+    def __init__(
+        self,
+        broker: StreamEventBroker,
+        cfg: TransportConfig,
+        *,
+        url: Optional[str] = None,
+        session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None,
+    ) -> None:
+        self._broker = broker
+        self._cfg = cfg
+        self._url = url
+        self._session_factory = session_factory
+        self._stopped = False
+        self._last_event_id: Optional[str] = None
+        self._high_water: int = 0
+        self._degraded = False
+        self._missed_hb = 0
+        self._seen: Set[str] = set()
+
+    @property
+    def last_event_id(self) -> Optional[str]:
+        return self._last_event_id
+
+    @property
+    def degraded(self) -> bool:
+        return self._degraded
+
+    def _next_backoff(self, attempt: int) -> float:
+        base = min(self._cfg.reconnect_base_s * (2 ** attempt), self._cfg.reconnect_max_s)
+        if self._cfg.reconnect_jitter <= 0:
+            return base
+        span = base * self._cfg.reconnect_jitter
+        return base + random.uniform(-span, span)
+
+    def _advance_contiguous(self, event_id: str) -> None:
+        """Advance the contiguous high-water mark ONLY when event_id is
+        exactly one past the current high-water. A gap is left
+        unfilled -- the next reconnect's ``hello`` replays the missing
+        span via Last-Event-ID. Do NOT simplify to "track the last id
+        seen"; that would defeat gap resolution."""
+        try:
+            seq = int(event_id, 16)
+        except (ValueError, TypeError):
+            return
+        if seq == self._high_water + 1:
+            self._high_water = seq
+            self._last_event_id = event_id
+
+    def _resolve_url(self) -> str:
+        if self._url:
+            return self._url
+        scheme = "wss" if self._cfg.tls_enabled else "ws"
+        host = self._cfg.host or "127.0.0.1"
+        return f"{scheme}://{host}:{self._cfg.port}{self._cfg.path}"
+
+    async def stop(self) -> None:
+        self._stopped = True
+
+    async def run(self) -> None:
+        attempt = 0
+        while not self._stopped:
+            try:
+                await self._connect_once()
+                attempt = 0  # clean disconnect resets backoff
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 -- any drop -> reconnect
+                logger.debug("[BusBridgeClient] connection ended", exc_info=True)
+            if self._stopped:
+                break
+            delay = self._next_backoff(attempt)
+            attempt += 1
+            await asyncio.sleep(delay)
+
+    async def _connect_once(self) -> None:
+        ssl_ctx = build_client_ssl_context(self._cfg)
+        session = (self._session_factory() if self._session_factory
+                   else aiohttp.ClientSession())
+        try:
+            async with session.ws_connect(
+                self._resolve_url(), ssl=ssl_ctx, heartbeat=None,
+            ) as ws:
+                await ws.send_bytes(
+                    bf.hello_frame(self._cfg.source_id, self._last_event_id).encode()
+                )
+                out_task = asyncio.ensure_future(self._pump_outbound(ws))
+                try:
+                    await self._pump_inbound(ws)
+                finally:
+                    out_task.cancel()
+                    try:
+                        await out_task
+                    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                        pass
+        finally:
+            await session.close()
+
+    async def _pump_outbound(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """Subscribe to the local broker and stream events (with
+        replay) to the peer. Replay seeding, heartbeat cadence, and
+        drop-oldest backpressure all come from
+        StreamEventBroker.subscribe()/stream_iter() -- this method
+        only filters broker-internal control events and translates
+        StreamEvent -> BusFrame, writing bytes to the socket."""
+        sub = self._broker.subscribe(op_id_filter=None, last_event_id=None)
+        if sub is None:
+            return
+        try:
+            hb = self._cfg.heartbeat_s
+            async for event in self._broker.stream_iter(sub, heartbeat_s=hb):
+                if ws.closed:
+                    break
+                if event.event_type in _CONTROL_EVENT_TYPES:
+                    continue  # broker-internal replay/lag bookkeeping, not on-wire
+                if event.event_type == EVENT_TYPE_HEARTBEAT:
+                    await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
+                    continue
+                frame = bf.event_frame(event, source_id=self._cfg.source_id)
+                await ws.send_bytes(frame.encode())
+        except (asyncio.CancelledError, ConnectionResetError):
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[BusBridgeClient] outbound pump ended", exc_info=True)
+
+    async def _pump_inbound(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        hb = self._cfg.heartbeat_s
+        while not ws.closed and not self._stopped:
+            try:
+                if hb > 0:
+                    msg = await asyncio.wait_for(ws.receive(), timeout=hb * 1.5)
+                else:
+                    msg = await ws.receive()
+            except asyncio.TimeoutError:
+                self._missed_hb += 1
+                if self._missed_hb >= self._cfg.degrade_after_missed_hb:
+                    self._degraded = True
+                continue
+            if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING,
+                            aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                break
+            self._missed_hb = 0
+            self._degraded = False
+            frame = bf.BusFrame.decode(msg.data)
+            if frame is None or frame.kind != bf.FRAME_EVENT:
+                continue
+            self._apply_inbound(frame)
+
+    def _apply_inbound(self, frame: bf.BusFrame) -> None:
+        ev_dict = frame.event or {}
+        event_id = ev_dict.get("event_id", "")
+        qid = bf.qualified_id(frame.source_id, event_id)
+        if qid in self._seen:
+            return
+        self._seen.add(qid)
+        try:
+            self._broker.publish(
+                ev_dict.get("event_type", ""),
+                ev_dict.get("op_id", ""),
+                ev_dict.get("payload", {}) or {},
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[BusBridgeClient] local republish failed", exc_info=True)
+        self._advance_contiguous(event_id)

--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -189,6 +189,15 @@ class BusBridgeClient:
         event_id = ev_dict.get("event_id", "")
         qid = bf.qualified_id(frame.source_id, event_id)
         if qid in self._seen:
+            # Already republished locally, but the contiguous high-water
+            # mark tracks what has been RECEIVED on the wire (for
+            # Last-Event-ID replay resumption), independent of local
+            # republish dedup. A replay that re-delivers already-seen
+            # events MUST still advance the mark across them -- otherwise
+            # the mark stalls, every reconnect replays the same prefix
+            # from high_water+1, and a drop_after fault starves the still
+            # -missing tail forever (zero-drop guarantee broken).
+            self._advance_contiguous(event_id)
             return
         self._seen.add(qid)
         try:

--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -3,7 +3,8 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
-from typing import Callable, Optional, Set
+from collections import OrderedDict
+from typing import Callable, Optional
 
 import aiohttp
 
@@ -21,6 +22,8 @@ from backend.core.ouroboros.governance.transport.transport_security import (
 from backend.core.ouroboros.governance.transport import bus_frame as bf
 
 logger = logging.getLogger(__name__)
+
+_DEDUP_MAX = 8192  # bounded seen-id memory (mirrors bus_bridge_server.py)
 
 # Broker-internal bookkeeping event types. Same rationale as
 # bus_bridge_server.py: these are produced by
@@ -54,7 +57,7 @@ class BusBridgeClient:
         self._high_water: int = 0
         self._degraded = False
         self._missed_hb = 0
-        self._seen: Set[str] = set()
+        self._seen: "OrderedDict[str, None]" = OrderedDict()
 
     @property
     def last_event_id(self) -> Optional[str]:
@@ -84,6 +87,17 @@ class BusBridgeClient:
         if seq == self._high_water + 1:
             self._high_water = seq
             self._last_event_id = event_id
+
+    def _mark_seen(self, qid: str) -> bool:
+        """Return True if NEW (not seen before). Bounded FIFO eviction --
+        mirrors BusBridgeServer._mark_seen so the client's dedup memory
+        cannot grow unbounded across a long-lived session."""
+        if qid in self._seen:
+            return False
+        self._seen[qid] = None
+        if len(self._seen) > _DEDUP_MAX:
+            self._seen.popitem(last=False)
+        return True
 
     def _resolve_url(self) -> str:
         if self._url:
@@ -188,7 +202,7 @@ class BusBridgeClient:
         ev_dict = frame.event or {}
         event_id = ev_dict.get("event_id", "")
         qid = bf.qualified_id(frame.source_id, event_id)
-        if qid in self._seen:
+        if not self._mark_seen(qid):
             # Already republished locally, but the contiguous high-water
             # mark tracks what has been RECEIVED on the wire (for
             # Last-Event-ID replay resumption), independent of local
@@ -199,7 +213,6 @@ class BusBridgeClient:
             # -missing tail forever (zero-drop guarantee broken).
             self._advance_contiguous(event_id)
             return
-        self._seen.add(qid)
         try:
             self._broker.publish(
                 ev_dict.get("event_type", ""),

--- a/backend/core/ouroboros/governance/transport/bus_bridge_server.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_server.py
@@ -1,0 +1,141 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import OrderedDict
+from typing import Callable, Optional
+
+from aiohttp import WSMsgType, web
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    EVENT_TYPE_HEARTBEAT,
+    EVENT_TYPE_REPLAY_END,
+    EVENT_TYPE_REPLAY_START,
+    EVENT_TYPE_STREAM_LAG,
+    StreamEvent,
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+
+logger = logging.getLogger(__name__)
+
+_DEDUP_MAX = 8192  # bounded seen-id memory
+
+# Broker-internal bookkeeping event types. These are produced by
+# StreamEventBroker.subscribe()/stream_iter() for SSE-side replay
+# framing and are not part of the peer-to-peer bus wire protocol
+# (bus_frame.py only knows hello/event/heartbeat/ack). replay_start
+# and replay_end are dropped; heartbeat is translated to the wire
+# heartbeat frame kind rather than forwarded as a generic event.
+_CONTROL_EVENT_TYPES = frozenset({EVENT_TYPE_REPLAY_START, EVENT_TYPE_REPLAY_END, EVENT_TYPE_STREAM_LAG})
+
+
+class BusBridgeServer:
+    """Hosts the WS endpoint that bridges a local StreamEventBroker to a
+    remote peer. Server-authoritative history + Last-Event-ID replay come
+    from the broker; inbound peer events are deduped by qualified id and
+    republished locally."""
+
+    def __init__(
+        self,
+        broker: StreamEventBroker,
+        cfg: TransportConfig,
+        *,
+        on_inbound: Optional[Callable[[StreamEvent], None]] = None,
+    ) -> None:
+        self._broker = broker
+        self._cfg = cfg
+        self._on_inbound = on_inbound
+        self._seen: "OrderedDict[str, None]" = OrderedDict()
+
+    def seen_count(self) -> int:
+        return len(self._seen)
+
+    def register_routes(self, app: web.Application) -> None:
+        app.router.add_get(self._cfg.path, self._handle_ws)
+
+    def _mark_seen(self, qid: str) -> bool:
+        """Return True if NEW (not seen before). Bounded FIFO eviction."""
+        if qid in self._seen:
+            return False
+        self._seen[qid] = None
+        if len(self._seen) > _DEDUP_MAX:
+            self._seen.popitem(last=False)
+        return True
+
+    def _ingest(self, frame: bf.BusFrame) -> None:
+        ev_dict = frame.event or {}
+        event_id = ev_dict.get("event_id", "")
+        qid = bf.qualified_id(frame.source_id, event_id)
+        if not self._mark_seen(qid):
+            return  # idempotent -- already applied
+        ev = StreamEvent(
+            event_id=event_id,
+            event_type=ev_dict.get("event_type", ""),
+            op_id=ev_dict.get("op_id", ""),
+            timestamp=ev_dict.get("timestamp", ""),
+            payload=ev_dict.get("payload", {}) or {},
+        )
+        try:
+            if self._on_inbound is not None:
+                self._on_inbound(ev)
+        except Exception:  # noqa: BLE001 -- never crash the WS loop
+            logger.debug("[BusBridgeServer] on_inbound raised", exc_info=True)
+
+    async def _pump_outbound(self, ws: web.WebSocketResponse, last_event_id: Optional[str]) -> None:
+        """Subscribe to the broker and stream events (with replay) to the
+        peer. Replay seeding, heartbeat cadence, and drop-oldest
+        backpressure all come from StreamEventBroker.subscribe()/
+        stream_iter() -- this method only translates StreamEvent ->
+        BusFrame and writes bytes to the socket."""
+        sub = self._broker.subscribe(op_id_filter=None, last_event_id=last_event_id)
+        if sub is None:
+            return
+        try:
+            hb = self._cfg.heartbeat_s
+            async for event in self._broker.stream_iter(sub, heartbeat_s=hb):
+                if ws.closed:
+                    break
+                if event.event_type in _CONTROL_EVENT_TYPES:
+                    continue  # broker-internal replay/lag bookkeeping, not on-wire
+                if event.event_type == EVENT_TYPE_HEARTBEAT:
+                    await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
+                    continue
+                frame = bf.event_frame(event, source_id=self._cfg.source_id)
+                await ws.send_bytes(frame.encode())
+        except (asyncio.CancelledError, ConnectionResetError):
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[BusBridgeServer] outbound pump ended", exc_info=True)
+
+    async def _handle_ws(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse(heartbeat=None)
+        await ws.prepare(request)
+        pump_task: Optional[asyncio.Task] = None
+        try:
+            async for msg in ws:
+                if msg.type != WSMsgType.BINARY and msg.type != WSMsgType.TEXT:
+                    if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.ERROR):
+                        break
+                    continue
+                frame = bf.BusFrame.decode(msg.data)
+                if frame is None:
+                    continue
+                if frame.kind == bf.FRAME_HELLO and pump_task is None:
+                    pump_task = asyncio.ensure_future(
+                        self._pump_outbound(ws, frame.last_event_id)
+                    )
+                elif frame.kind == bf.FRAME_EVENT:
+                    self._ingest(frame)
+                elif frame.kind == bf.FRAME_HEARTBEAT:
+                    await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
+                # FRAME_ACK is plumbed for Stage 3 WAL trim; no-op here.
+        finally:
+            if pump_task is not None:
+                pump_task.cancel()
+                try:
+                    await pump_task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+        return ws

--- a/backend/core/ouroboros/governance/transport/bus_frame.py
+++ b/backend/core/ouroboros/governance/transport/bus_frame.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Union
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEvent
+
+FRAME_HELLO = "hello"
+FRAME_EVENT = "event"
+FRAME_HEARTBEAT = "heartbeat"
+FRAME_ACK = "ack"
+
+_VALID_KINDS = (FRAME_HELLO, FRAME_EVENT, FRAME_HEARTBEAT, FRAME_ACK)
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def qualified_id(source_id: str, event_id: str) -> str:
+    """Cross-host dedup key: source-scoped so two brokers' native
+    monotonic ids never collide."""
+    return f"{source_id}:{event_id}"
+
+
+@dataclass(frozen=True)
+class BusFrame:
+    kind: str
+    source_id: str
+    seq: int = -1
+    last_event_id: Optional[str] = None
+    event: Optional[Dict[str, Any]] = None
+    ts: str = ""
+
+    def encode(self) -> bytes:
+        return json.dumps({
+            "kind": self.kind,
+            "source_id": self.source_id,
+            "seq": self.seq,
+            "last_event_id": self.last_event_id,
+            "event": self.event,
+            "ts": self.ts or _iso_now(),
+        }, ensure_ascii=True).encode("utf-8")
+
+    @classmethod
+    def decode(cls, raw: Union[str, bytes]) -> Optional["BusFrame"]:
+        try:
+            if isinstance(raw, (bytes, bytearray)):
+                raw = raw.decode("utf-8")
+            obj = json.loads(raw)
+        except (ValueError, UnicodeDecodeError):
+            return None
+        if not isinstance(obj, dict):
+            return None
+        kind = obj.get("kind")
+        if not isinstance(kind, str) or kind not in _VALID_KINDS:
+            return None
+        source_id = obj.get("source_id")
+        if not isinstance(source_id, str):
+            return None
+        event = obj.get("event")
+        if event is not None and not isinstance(event, dict):
+            return None
+        seq = obj.get("seq", -1)
+        if not isinstance(seq, int):
+            seq = -1
+        return cls(
+            kind=kind,
+            source_id=source_id,
+            seq=seq,
+            last_event_id=obj.get("last_event_id"),
+            event=event,
+            ts=obj.get("ts", "") if isinstance(obj.get("ts"), str) else "",
+        )
+
+
+def event_frame(ev: StreamEvent, source_id: str) -> BusFrame:
+    try:
+        seq = int(ev.event_id, 16)
+    except (ValueError, TypeError):
+        seq = -1
+    return BusFrame(
+        kind=FRAME_EVENT,
+        source_id=source_id,
+        seq=seq,
+        event=ev.to_dict(),
+        ts=_iso_now(),
+    )
+
+
+def hello_frame(source_id: str, last_event_id: Optional[str]) -> BusFrame:
+    return BusFrame(kind=FRAME_HELLO, source_id=source_id, last_event_id=last_event_id, ts=_iso_now())
+
+
+def heartbeat_frame(source_id: str) -> BusFrame:
+    return BusFrame(kind=FRAME_HEARTBEAT, source_id=source_id, ts=_iso_now())
+
+
+def ack_frame(source_id: str, last_event_id: str) -> BusFrame:
+    return BusFrame(kind=FRAME_ACK, source_id=source_id, last_event_id=last_event_id, ts=_iso_now())

--- a/backend/core/ouroboros/governance/transport/distributed_event_bus.py
+++ b/backend/core/ouroboros/governance/transport/distributed_event_bus.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import logging
+from typing import Optional
+
+from aiohttp import web
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+
+logger = logging.getLogger(__name__)
+
+
+class DistributedEventBus:
+    """The publish()-here-subscribers-there seam. Wraps a local
+    StreamEventBroker; a server- or client-role bridge propagates events
+    across the socket. TrinityEventBus callers are unchanged -- they still
+    publish/subscribe on the local broker."""
+
+    def __init__(self, broker: StreamEventBroker, cfg: TransportConfig, *, role: str) -> None:
+        if role not in ("server", "client"):
+            raise ValueError(f"role must be server|client, got {role!r}")
+        self._broker = broker
+        self._cfg = cfg
+        self._role = role
+        self._server: Optional[BusBridgeServer] = None
+        self._client: Optional[BusBridgeClient] = None
+
+    def publish(self, event_type: str, op_id: str, payload: dict) -> Optional[str]:
+        return self._broker.publish(event_type, op_id, payload)
+
+    def register_server_routes(self, app: web.Application) -> None:
+        if self._role != "server":
+            raise RuntimeError("register_server_routes requires role=server")
+        # Inbound peer events republish into the local broker so local
+        # subscribers see them (idempotent -- server dedups by qualified id).
+        self._server = BusBridgeServer(
+            self._broker, self._cfg,
+            on_inbound=lambda ev: self._broker.publish(
+                ev.event_type, ev.op_id, dict(ev.payload)
+            ),
+        )
+        self._server.register_routes(app)
+
+    async def start_client(self, url: Optional[str] = None) -> None:
+        if self._role != "client":
+            raise RuntimeError("start_client requires role=client")
+        self._client = BusBridgeClient(self._broker, self._cfg, url=url)
+        await self._client.run()
+
+    async def stop(self) -> None:
+        if self._client is not None:
+            await self._client.stop()

--- a/backend/core/ouroboros/governance/transport/transport_config.py
+++ b/backend/core/ouroboros/governance/transport/transport_config.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import Optional
+
+
+def _env_str(key: str, default: Optional[str]) -> Optional[str]:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
+    raw = raw.strip()
+    return raw if raw else default
+
+
+def _env_float(key: str, default: float) -> float:
+    raw = os.environ.get(key, "")
+    try:
+        return float(raw.strip())
+    except (ValueError, AttributeError):
+        return default
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.environ.get(key, "")
+    try:
+        return int(raw.strip())
+    except (ValueError, AttributeError):
+        return default
+
+
+def _env_bool(key: str, default: bool) -> bool:
+    raw = os.environ.get(key, "").strip().lower()
+    if raw == "":
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def distributed_bus_enabled() -> bool:
+    """Master switch. Default False -- Stage 0 ships dark."""
+    return _env_bool("JARVIS_DISTRIBUTED_BUS_ENABLED", False)
+
+
+@dataclass(frozen=True)
+class TransportConfig:
+    """Fully env-resolved transport configuration. No baked thresholds."""
+
+    host: Optional[str]
+    port: int
+    path: str
+    heartbeat_s: float
+    reconnect_base_s: float
+    reconnect_max_s: float
+    reconnect_jitter: float
+    queue_maxsize: int
+    history_maxlen: int
+    degrade_after_missed_hb: int
+    tls_enabled: bool
+    tls_cert: Optional[str]
+    tls_key: Optional[str]
+    tls_ca: Optional[str]
+    tls_ephemeral: bool
+    source_id: str
+
+    @classmethod
+    def from_env(cls, *, role: str) -> "TransportConfig":
+        default_source = _env_str(
+            "JARVIS_BRAIN_WS_SOURCE_ID",
+            f"{role}-{socket.gethostname()}",
+        )
+        return cls(
+            host=_env_str("JARVIS_BRAIN_WS_HOST", None),
+            port=_env_int("JARVIS_BRAIN_WS_PORT", 0),
+            path=_env_str("JARVIS_BRAIN_WS_PATH", "/ws/trinity-bus") or "/ws/trinity-bus",
+            heartbeat_s=_env_float("JARVIS_BRAIN_WS_HEARTBEAT_S", 15.0),
+            reconnect_base_s=_env_float("JARVIS_BRAIN_WS_RECONNECT_BASE_S", 0.5),
+            reconnect_max_s=_env_float("JARVIS_BRAIN_WS_RECONNECT_MAX_S", 30.0),
+            reconnect_jitter=_env_float("JARVIS_BRAIN_WS_RECONNECT_JITTER", 0.3),
+            queue_maxsize=_env_int("JARVIS_BRAIN_WS_QUEUE_MAXSIZE", 256),
+            history_maxlen=_env_int("JARVIS_BRAIN_WS_HISTORY_MAXLEN", 1024),
+            degrade_after_missed_hb=_env_int("JARVIS_BRAIN_WS_DEGRADE_AFTER_MISSED_HB", 2),
+            tls_enabled=_env_bool("JARVIS_BRAIN_WS_TLS_ENABLED", True),
+            tls_cert=_env_str("JARVIS_BRAIN_WS_TLS_CERT", None),
+            tls_key=_env_str("JARVIS_BRAIN_WS_TLS_KEY", None),
+            tls_ca=_env_str("JARVIS_BRAIN_WS_TLS_CA", None),
+            tls_ephemeral=_env_bool("JARVIS_BRAIN_WS_TLS_EPHEMERAL", False),
+            source_id=default_source or f"{role}-unknown",
+        )

--- a/backend/core/ouroboros/governance/transport/transport_security.py
+++ b/backend/core/ouroboros/governance/transport/transport_security.py
@@ -1,0 +1,111 @@
+# backend/core/ouroboros/governance/transport/transport_security.py
+from __future__ import annotations
+
+import datetime
+import ipaddress
+import os
+import ssl
+import tempfile
+from typing import Optional, Tuple
+
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+
+
+class EphemeralMaterialUnavailable(RuntimeError):
+    """Raised when ephemeral self-signed material is requested but the
+    `cryptography` package is not installed. Loopback-test-only path."""
+
+
+def generate_ephemeral_material() -> Tuple[str, str]:
+    """Generate an in-memory self-signed cert/key pair for loopback
+    tests. Returns (cert_path, key_path) under a fresh temp dir.
+
+    NOT for production -- production resolves cert/key/CA from
+    TransportConfig paths (which come from env / the golden-image
+    metadata pattern in Stage 1).
+    """
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+    except ImportError as exc:  # pragma: no cover - env-dependent
+        raise EphemeralMaterialUnavailable(str(exc)) from exc
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.utcnow()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(hours=1))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.DNSName("localhost"),
+                x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+            ]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    tmpdir = tempfile.mkdtemp(prefix="jarvis-ws-tls-")
+    cert_path = os.path.join(tmpdir, "cert.pem")
+    key_path = os.path.join(tmpdir, "key.pem")
+    with open(cert_path, "wb") as fh:
+        fh.write(cert.public_bytes(serialization.Encoding.PEM))
+    with open(key_path, "wb") as fh:
+        fh.write(key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        ))
+    return cert_path, key_path
+
+
+def _resolve_material(cfg: TransportConfig) -> Tuple[str, str, Optional[str]]:
+    """Return (cert_path, key_path, ca_path). Ephemeral when requested;
+    otherwise the env-resolved paths from cfg."""
+    if cfg.tls_ephemeral:
+        cert, key = generate_ephemeral_material()
+        return cert, key, cfg.tls_ca
+    if not cfg.tls_cert or not cfg.tls_key:
+        raise EphemeralMaterialUnavailable(
+            "tls_enabled but no cert/key resolved from env "
+            "(JARVIS_BRAIN_WS_TLS_CERT / _KEY) and tls_ephemeral is false"
+        )
+    return cfg.tls_cert, cfg.tls_key, cfg.tls_ca
+
+
+def build_server_ssl_context(cfg: TransportConfig) -> Optional[ssl.SSLContext]:
+    if not cfg.tls_enabled:
+        return None
+    cert, key, ca = _resolve_material(cfg)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile=cert, keyfile=key)
+    ctx.verify_mode = ssl.CERT_REQUIRED  # mutual TLS
+    if ca:
+        ctx.load_verify_locations(cafile=ca)
+    elif cfg.tls_ephemeral:
+        # Loopback: trust our own ephemeral cert as the peer CA so the
+        # two ends of a self-signed handshake verify each other.
+        ctx.load_verify_locations(cafile=cert)
+    return ctx
+
+
+def build_client_ssl_context(cfg: TransportConfig) -> Optional[ssl.SSLContext]:
+    if not cfg.tls_enabled:
+        return None
+    cert, key, ca = _resolve_material(cfg)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.load_cert_chain(certfile=cert, keyfile=key)
+    if ca:
+        ctx.load_verify_locations(cafile=ca)
+        ctx.check_hostname = True
+    elif cfg.tls_ephemeral:
+        ctx.load_verify_locations(cafile=cert)
+        ctx.check_hostname = False  # self-signed loopback
+    return ctx

--- a/backend/core/ouroboros/governance/transport/transport_security.py
+++ b/backend/core/ouroboros/governance/transport/transport_security.py
@@ -34,7 +34,7 @@ def generate_ephemeral_material() -> Tuple[str, str]:
 
     key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
     name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
-    now = datetime.datetime.utcnow()
+    now = datetime.datetime.now(datetime.timezone.utc)
     cert = (
         x509.CertificateBuilder()
         .subject_name(name)

--- a/docs/superpowers/plans/2026-07-03-stage0-transport-substrate.md
+++ b/docs/superpowers/plans/2026-07-03-stage0-transport-substrate.md
@@ -1,0 +1,2014 @@
+# Stage 0 — Transport Substrate Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a bidirectional WebSocket bridge that extends the in-process `TrinityEventBus`/`StreamEventBroker` across a socket, so `publish()` on one host reaches subscribers on the other — with exact Last-Event-ID replay, heartbeat, drop-oldest backpressure, mTLS with dynamically-resolved material, and a static AST invariant that structurally forbids real-time actuation layers from importing the remote transport.
+
+**Architecture:** A new focused subpackage `backend/core/ouroboros/governance/transport/` wraps the *existing* `StreamEventBroker` (never reimplements it). A server component mounts an aiohttp `WebSocketResponse` route (mountable on the existing `EventChannelServer` app); a client component connects with exp-backoff+jitter reconnect and resumes via Last-Event-ID. A frame codec serializes `StreamEvent` to/from JSON with source-qualified IDs for cross-host dedup. All thresholds and all cryptographic material resolve dynamically from environment config at boot — zero baked constants. Stage 0 is loopback-only (real TCP over `127.0.0.1`, plus one two-OS-process smoke test); NO VM provisioning and NO sensor migration.
+
+**Tech Stack:** Python 3.9+, `asyncio` (no `asyncio.timeout`; use `asyncio.wait_for`), `aiohttp` (already a dependency — WS server `web.WebSocketResponse` + client `ClientSession.ws_connect`), stdlib `ssl` for mTLS, stdlib `ast` for the invariant, `pytest`/`pytest-asyncio` for tests. Reuses `StreamEventBroker`/`IDEStreamRouter` (`ide_observability_stream.py`), `EventChannelServer` (`event_channel.py`), `TrinityEventBus`/`LifecycleEventPublisher` (`lifecycle_event_orchestrator.py`), and the `shipped_code_invariants` AST-check registry (`meta/shipped_code_invariants.py`).
+
+## Global Constraints
+
+- **Python 3.9+ only** — never `asyncio.timeout` (3.11+); use `asyncio.wait_for` everywhere. Every new module starts with `from __future__ import annotations`.
+- **No hardcoded endpoints, IPs, ports, or cryptographic paths** — every network address and every TLS material path resolves from `JARVIS_*` environment variables at call time. A grep/AST invariant enforces this (Task 8). Loopback tests pass `127.0.0.1`/ephemeral port **via env or fixture**, never as a module constant.
+- **Every threshold is env-resolved with a sensible default** — heartbeat cadence, reconnect base/max/jitter, queue maxsize, history maxlen, degraded-mode miss count, TLS on/off. Resolve at call time (read `os.environ` inside a function), never at import time, so tests can monkeypatch.
+- **Reuse `StreamEventBroker`, never reimplement it** — the bridge owns a broker instance and calls its public `publish` / `subscribe` / `stream_iter` / `_seed_replay`-backed replay. Bounded history, drop-oldest `stream_lag`, and heartbeat come from the broker, not new code.
+- **Master switch `JARVIS_DISTRIBUTED_BUS_ENABLED` (default `false`)** — Stage 0 ships dark. No live loop wires the bridge in until Stage 2. Nothing in this plan mutates the running organism's boot path.
+- **Defensive contract on hot hooks** — publish-side and frame-ingest hooks NEVER raise and NEVER block the event loop (mirror `StreamEventBroker.publish`'s "never raises, never blocks" contract).
+- **ASCII-only source** (Iron Gate ASCII-strictness applies to shipped code).
+- **mTLS material is dynamically resolved** — cert/key/CA come from env-resolved paths; loopback tests use an in-memory ephemeral self-signed pair generated at runtime, never a checked-in cert. The ephemeral `/32` cloud firewall rule is **Stage 1** (cross-host) and explicitly out of Stage 0 scope; the transport is mTLS-*capable* from Stage 0 so Stage 1 only adds the firewall, not the crypto.
+- **Real-time actuation isolation invariant** — `backend/ghost_hands/**` and any real-time actuation module MUST NOT import the transport subpackage. Enforced by an AST invariant (Task 8), not by convention.
+
+---
+
+## File Structure
+
+**New subpackage** `backend/core/ouroboros/governance/transport/`:
+- `__init__.py` — exports the public surface (`DistributedEventBus`, `BusBridgeServer`, `BusBridgeClient`, `TransportConfig`, `build_client_ssl_context`, `build_server_ssl_context`).
+- `transport_config.py` — env-resolved config dataclass; zero baked thresholds.
+- `transport_security.py` — mTLS SSL-context builders + ephemeral self-signed material for loopback.
+- `bus_frame.py` — wire frame codec (`BusFrame`: `hello`/`event`/`heartbeat`/`ack`), source-qualified IDs, `StreamEvent` <-> JSON.
+- `bus_bridge_server.py` — `BusBridgeServer`: aiohttp WS route over a `StreamEventBroker`; Last-Event-ID replay on connect; inbound-frame dedup + republish.
+- `bus_bridge_client.py` — `BusBridgeClient`: `ws_connect` with exp-backoff+jitter reconnect, heartbeat-miss degraded flip, contiguous-id tracking + Last-Event-ID resume.
+- `distributed_event_bus.py` — `DistributedEventBus`: the `publish()`-here-subscribers-there seam tying a broker to either a server or a client transport.
+
+**Modified:**
+- `backend/core/ouroboros/governance/meta/shipped_code_invariants.py` — add `_validate_realtime_actuation_no_remote_transport` + `_validate_transport_no_hardcoded_endpoints`, register both in `_register_seed_invariants`.
+
+**Tests** under `tests/governance/transport/`:
+- `test_transport_config.py`, `test_transport_security.py`, `test_bus_frame.py`, `test_bus_bridge_server.py`, `test_bus_bridge_client.py`, `test_distributed_event_bus.py`, `test_hostile_network_replay.py`, `test_two_process_loopback.py`
+- `hostile_network.py` — reusable fault-injection proxy fixture (latency/jitter/reorder/partial-drop).
+- `tests/governance/test_transport_invariants.py` — the two AST invariants.
+
+---
+
+## Task 1: Transport Config (env-resolved, zero baked thresholds)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/transport/__init__.py`
+- Create: `backend/core/ouroboros/governance/transport/transport_config.py`
+- Test: `tests/governance/transport/test_transport_config.py`
+
+**Interfaces:**
+- Produces:
+  - `distributed_bus_enabled() -> bool` — reads `JARVIS_DISTRIBUTED_BUS_ENABLED` (default `False`).
+  - `@dataclass(frozen=True) class TransportConfig` with fields: `host: Optional[str]`, `port: int`, `path: str`, `heartbeat_s: float`, `reconnect_base_s: float`, `reconnect_max_s: float`, `reconnect_jitter: float`, `queue_maxsize: int`, `history_maxlen: int`, `degrade_after_missed_hb: int`, `tls_enabled: bool`, `tls_cert: Optional[str]`, `tls_key: Optional[str]`, `tls_ca: Optional[str]`, `tls_ephemeral: bool`, `source_id: str`.
+  - `TransportConfig.from_env(*, role: str) -> TransportConfig` — classmethod resolving every field from `os.environ` at call time. `role` is `"server"` or `"client"`; `source_id` defaults to `f"{role}-{socket.gethostname()}"` when `JARVIS_BRAIN_WS_SOURCE_ID` is unset.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/transport/test_transport_config.py
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.core.ouroboros.governance.transport.transport_config import (
+    TransportConfig,
+    distributed_bus_enabled,
+)
+
+
+def test_defaults_are_dark_and_sane(monkeypatch):
+    # Clear every knob so we observe pure defaults.
+    for key in list(os.environ):
+        if key.startswith("JARVIS_BRAIN_WS_") or key == "JARVIS_DISTRIBUTED_BUS_ENABLED":
+            monkeypatch.delenv(key, raising=False)
+    assert distributed_bus_enabled() is False  # ships dark
+    cfg = TransportConfig.from_env(role="client")
+    assert cfg.host is None  # no baked endpoint — must be discovered
+    assert cfg.port == 0  # ephemeral by default
+    assert cfg.path == "/ws/trinity-bus"
+    assert cfg.heartbeat_s == 15.0
+    assert cfg.reconnect_base_s == 0.5
+    assert cfg.reconnect_max_s == 30.0
+    assert 0.0 <= cfg.reconnect_jitter <= 1.0
+    assert cfg.queue_maxsize == 256
+    assert cfg.history_maxlen == 1024
+    assert cfg.degrade_after_missed_hb == 2
+    assert cfg.tls_enabled is True
+    assert cfg.tls_ephemeral is False
+    assert cfg.source_id.startswith("client-")
+
+
+def test_every_threshold_is_env_overridable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DISTRIBUTED_BUS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HOST", "10.1.2.3")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PATH", "/ws/x")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "3.5")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_BASE_S", "0.1")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_MAX_S", "9.0")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_JITTER", "0.5")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_QUEUE_MAXSIZE", "512")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HISTORY_MAXLEN", "2048")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_DEGRADE_AFTER_MISSED_HB", "4")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_EPHEMERAL", "true")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_SOURCE_ID", "brain-01")
+    assert distributed_bus_enabled() is True
+    cfg = TransportConfig.from_env(role="server")
+    assert (cfg.host, cfg.port, cfg.path) == ("10.1.2.3", 8443, "/ws/x")
+    assert cfg.heartbeat_s == 3.5
+    assert (cfg.reconnect_base_s, cfg.reconnect_max_s, cfg.reconnect_jitter) == (0.1, 9.0, 0.5)
+    assert cfg.queue_maxsize == 512
+    assert cfg.history_maxlen == 2048
+    assert cfg.degrade_after_missed_hb == 4
+    assert cfg.tls_enabled is False
+    assert cfg.tls_ephemeral is True
+    assert cfg.source_id == "brain-01"
+
+
+def test_malformed_numeric_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "not-a-number")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "")
+    cfg = TransportConfig.from_env(role="client")
+    assert cfg.heartbeat_s == 15.0  # bad value -> default, never crash
+    assert cfg.port == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/transport/test_transport_config.py -v`
+Expected: FAIL — `ModuleNotFoundError: No module named '...transport.transport_config'`
+
+- [ ] **Step 3: Create the package init**
+
+```python
+# backend/core/ouroboros/governance/transport/__init__.py
+"""Distributed TrinityEventBus transport substrate (Stage 0).
+
+Extends the in-process StreamEventBroker across a WebSocket so
+publish() on one host reaches subscribers on the other. Ships dark
+(JARVIS_DISTRIBUTED_BUS_ENABLED default false) until Stage 2 wires it
+into the live loop.
+"""
+from __future__ import annotations
+
+__all__ = [
+    "TransportConfig",
+    "distributed_bus_enabled",
+]
+
+from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: E402
+    TransportConfig,
+    distributed_bus_enabled,
+)
+```
+
+- [ ] **Step 4: Implement the config resolver**
+
+```python
+# backend/core/ouroboros/governance/transport/transport_config.py
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from typing import Optional
+
+
+def _env_str(key: str, default: Optional[str]) -> Optional[str]:
+    raw = os.environ.get(key)
+    if raw is None:
+        return default
+    raw = raw.strip()
+    return raw if raw else default
+
+
+def _env_float(key: str, default: float) -> float:
+    raw = os.environ.get(key, "")
+    try:
+        return float(raw.strip())
+    except (ValueError, AttributeError):
+        return default
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.environ.get(key, "")
+    try:
+        return int(raw.strip())
+    except (ValueError, AttributeError):
+        return default
+
+
+def _env_bool(key: str, default: bool) -> bool:
+    raw = os.environ.get(key, "").strip().lower()
+    if raw == "":
+        return default
+    return raw in ("1", "true", "yes", "on")
+
+
+def distributed_bus_enabled() -> bool:
+    """Master switch. Default False — Stage 0 ships dark."""
+    return _env_bool("JARVIS_DISTRIBUTED_BUS_ENABLED", False)
+
+
+@dataclass(frozen=True)
+class TransportConfig:
+    """Fully env-resolved transport configuration. No baked thresholds."""
+
+    host: Optional[str]
+    port: int
+    path: str
+    heartbeat_s: float
+    reconnect_base_s: float
+    reconnect_max_s: float
+    reconnect_jitter: float
+    queue_maxsize: int
+    history_maxlen: int
+    degrade_after_missed_hb: int
+    tls_enabled: bool
+    tls_cert: Optional[str]
+    tls_key: Optional[str]
+    tls_ca: Optional[str]
+    tls_ephemeral: bool
+    source_id: str
+
+    @classmethod
+    def from_env(cls, *, role: str) -> "TransportConfig":
+        default_source = _env_str(
+            "JARVIS_BRAIN_WS_SOURCE_ID",
+            f"{role}-{socket.gethostname()}",
+        )
+        return cls(
+            host=_env_str("JARVIS_BRAIN_WS_HOST", None),
+            port=_env_int("JARVIS_BRAIN_WS_PORT", 0),
+            path=_env_str("JARVIS_BRAIN_WS_PATH", "/ws/trinity-bus") or "/ws/trinity-bus",
+            heartbeat_s=_env_float("JARVIS_BRAIN_WS_HEARTBEAT_S", 15.0),
+            reconnect_base_s=_env_float("JARVIS_BRAIN_WS_RECONNECT_BASE_S", 0.5),
+            reconnect_max_s=_env_float("JARVIS_BRAIN_WS_RECONNECT_MAX_S", 30.0),
+            reconnect_jitter=_env_float("JARVIS_BRAIN_WS_RECONNECT_JITTER", 0.3),
+            queue_maxsize=_env_int("JARVIS_BRAIN_WS_QUEUE_MAXSIZE", 256),
+            history_maxlen=_env_int("JARVIS_BRAIN_WS_HISTORY_MAXLEN", 1024),
+            degrade_after_missed_hb=_env_int("JARVIS_BRAIN_WS_DEGRADE_AFTER_MISSED_HB", 2),
+            tls_enabled=_env_bool("JARVIS_BRAIN_WS_TLS_ENABLED", True),
+            tls_cert=_env_str("JARVIS_BRAIN_WS_TLS_CERT", None),
+            tls_key=_env_str("JARVIS_BRAIN_WS_TLS_KEY", None),
+            tls_ca=_env_str("JARVIS_BRAIN_WS_TLS_CA", None),
+            tls_ephemeral=_env_bool("JARVIS_BRAIN_WS_TLS_EPHEMERAL", False),
+            source_id=default_source or f"{role}-unknown",
+        )
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_transport_config.py -v`
+Expected: PASS (3 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/transport/__init__.py backend/core/ouroboros/governance/transport/transport_config.py tests/governance/transport/test_transport_config.py
+git commit -m "feat(transport): env-resolved TransportConfig for distributed bus (Stage 0, dark)"
+```
+
+---
+
+## Task 2: mTLS material resolver (dynamic material, ephemeral for loopback)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/transport/transport_security.py`
+- Test: `tests/governance/transport/test_transport_security.py`
+
+**Interfaces:**
+- Consumes: `TransportConfig` (Task 1).
+- Produces:
+  - `generate_ephemeral_material() -> Tuple[str, str]` — returns `(cert_pem_path, key_pem_path)` for a freshly generated in-memory self-signed pair written to a `tempfile` dir (loopback tests only). Uses stdlib only where possible; if `cryptography` is unavailable, raises `EphemeralMaterialUnavailable`.
+  - `build_server_ssl_context(cfg: TransportConfig) -> Optional[ssl.SSLContext]` — returns `None` when `cfg.tls_enabled is False`; otherwise a `PROTOCOL_TLS_SERVER` context loading cert/key from `cfg` (or ephemeral when `cfg.tls_ephemeral`), with `verify_mode = CERT_REQUIRED` and the CA loaded when `cfg.tls_ca` is set (mutual auth).
+  - `build_client_ssl_context(cfg: TransportConfig) -> Optional[ssl.SSLContext]` — mirror for the client (`PROTOCOL_TLS_CLIENT`), loading the client cert/key and trusting the CA.
+  - `class EphemeralMaterialUnavailable(RuntimeError)`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/transport/test_transport_security.py
+from __future__ import annotations
+
+import ssl
+
+import pytest
+
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport import transport_security as ts
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=15.0,
+        reconnect_base_s=0.5, reconnect_max_s=30.0, reconnect_jitter=0.3,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=True, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=True, source_id="test",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+def test_tls_disabled_returns_none():
+    cfg = _cfg(tls_enabled=False, tls_ephemeral=False)
+    assert ts.build_server_ssl_context(cfg) is None
+    assert ts.build_client_ssl_context(cfg) is None
+
+
+def test_ephemeral_material_builds_a_real_server_context():
+    cfg = _cfg()
+    ctx = ts.build_server_ssl_context(cfg)
+    assert isinstance(ctx, ssl.SSLContext)
+    # mTLS: server demands a client cert.
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_no_hardcoded_material_paths_in_module_source():
+    import inspect
+    src = inspect.getsource(ts)
+    # No absolute cert/key paths baked in.
+    assert "/etc/ssl" not in src
+    assert "-----BEGIN" not in src  # no inlined PEM
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/transport/test_transport_security.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...transport_security`
+
+- [ ] **Step 3: Implement the security module**
+
+```python
+# backend/core/ouroboros/governance/transport/transport_security.py
+from __future__ import annotations
+
+import datetime
+import ipaddress
+import os
+import ssl
+import tempfile
+from typing import Optional, Tuple
+
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+
+
+class EphemeralMaterialUnavailable(RuntimeError):
+    """Raised when ephemeral self-signed material is requested but the
+    `cryptography` package is not installed. Loopback-test-only path."""
+
+
+def generate_ephemeral_material() -> Tuple[str, str]:
+    """Generate an in-memory self-signed cert/key pair for loopback
+    tests. Returns (cert_path, key_path) under a fresh temp dir.
+
+    NOT for production — production resolves cert/key/CA from
+    TransportConfig paths (which come from env / the golden-image
+    metadata pattern in Stage 1).
+    """
+    try:
+        from cryptography import x509
+        from cryptography.hazmat.primitives import hashes, serialization
+        from cryptography.hazmat.primitives.asymmetric import rsa
+        from cryptography.x509.oid import NameOID
+    except ImportError as exc:  # pragma: no cover - env-dependent
+        raise EphemeralMaterialUnavailable(str(exc)) from exc
+
+    key = rsa.generate_private_key(public_exponent=65537, key_size=2048)
+    name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, "localhost")])
+    now = datetime.datetime.utcnow()
+    cert = (
+        x509.CertificateBuilder()
+        .subject_name(name)
+        .issuer_name(name)
+        .public_key(key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(now - datetime.timedelta(minutes=1))
+        .not_valid_after(now + datetime.timedelta(hours=1))
+        .add_extension(
+            x509.SubjectAlternativeName([
+                x509.DNSName("localhost"),
+                x509.IPAddress(ipaddress.ip_address("127.0.0.1")),
+            ]),
+            critical=False,
+        )
+        .sign(key, hashes.SHA256())
+    )
+    tmpdir = tempfile.mkdtemp(prefix="jarvis-ws-tls-")
+    cert_path = os.path.join(tmpdir, "cert.pem")
+    key_path = os.path.join(tmpdir, "key.pem")
+    with open(cert_path, "wb") as fh:
+        fh.write(cert.public_bytes(serialization.Encoding.PEM))
+    with open(key_path, "wb") as fh:
+        fh.write(key.private_bytes(
+            serialization.Encoding.PEM,
+            serialization.PrivateFormat.TraditionalOpenSSL,
+            serialization.NoEncryption(),
+        ))
+    return cert_path, key_path
+
+
+def _resolve_material(cfg: TransportConfig) -> Tuple[str, str, Optional[str]]:
+    """Return (cert_path, key_path, ca_path). Ephemeral when requested;
+    otherwise the env-resolved paths from cfg."""
+    if cfg.tls_ephemeral:
+        cert, key = generate_ephemeral_material()
+        return cert, key, cfg.tls_ca
+    if not cfg.tls_cert or not cfg.tls_key:
+        raise EphemeralMaterialUnavailable(
+            "tls_enabled but no cert/key resolved from env "
+            "(JARVIS_BRAIN_WS_TLS_CERT / _KEY) and tls_ephemeral is false"
+        )
+    return cfg.tls_cert, cfg.tls_key, cfg.tls_ca
+
+
+def build_server_ssl_context(cfg: TransportConfig) -> Optional[ssl.SSLContext]:
+    if not cfg.tls_enabled:
+        return None
+    cert, key, ca = _resolve_material(cfg)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_SERVER)
+    ctx.load_cert_chain(certfile=cert, keyfile=key)
+    ctx.verify_mode = ssl.CERT_REQUIRED  # mutual TLS
+    if ca:
+        ctx.load_verify_locations(cafile=ca)
+    elif cfg.tls_ephemeral:
+        # Loopback: trust our own ephemeral cert as the peer CA so the
+        # two ends of a self-signed handshake verify each other.
+        ctx.load_verify_locations(cafile=cert)
+    return ctx
+
+
+def build_client_ssl_context(cfg: TransportConfig) -> Optional[ssl.SSLContext]:
+    if not cfg.tls_enabled:
+        return None
+    cert, key, ca = _resolve_material(cfg)
+    ctx = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    ctx.load_cert_chain(certfile=cert, keyfile=key)
+    if ca:
+        ctx.load_verify_locations(cafile=ca)
+        ctx.check_hostname = True
+    elif cfg.tls_ephemeral:
+        ctx.load_verify_locations(cafile=cert)
+        ctx.check_hostname = False  # self-signed loopback
+    return ctx
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_transport_security.py -v`
+Expected: PASS (3 passed). If `cryptography` is not installed, `test_ephemeral_material_builds_a_real_server_context` errors with `EphemeralMaterialUnavailable` — install with `python3 -m pip install cryptography` (it is already a transitive dependency of the repo's auth stack) and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/transport/transport_security.py tests/governance/transport/test_transport_security.py
+git commit -m "feat(transport): mTLS context builders with dynamic + ephemeral material (Stage 0)"
+```
+
+---
+
+## Task 3: Wire frame codec (source-qualified IDs, StreamEvent round-trip)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/transport/bus_frame.py`
+- Test: `tests/governance/transport/test_bus_frame.py`
+
+**Interfaces:**
+- Consumes: `StreamEvent` from `ide_observability_stream.py` (fields: `event_id`, `event_type`, `op_id`, `timestamp`, `payload`, `schema_version`; has `.to_dict()`).
+- Produces:
+  - `FRAME_HELLO = "hello"`, `FRAME_EVENT = "event"`, `FRAME_HEARTBEAT = "heartbeat"`, `FRAME_ACK = "ack"` (str constants).
+  - `@dataclass(frozen=True) class BusFrame` with `kind: str`, `source_id: str`, `seq: int` (source-native monotonic sequence; for events it is `int(event_id, 16)`), `last_event_id: Optional[str]`, `event: Optional[Dict[str, Any]]` (a `StreamEvent.to_dict()` payload), `ts: str`.
+  - `BusFrame.encode() -> bytes` — UTF-8 JSON.
+  - `BusFrame.decode(raw: Union[str, bytes]) -> Optional["BusFrame"]` — returns `None` on malformed input (never raises).
+  - `event_frame(ev: StreamEvent, source_id: str) -> BusFrame`.
+  - `hello_frame(source_id: str, last_event_id: Optional[str]) -> BusFrame`.
+  - `heartbeat_frame(source_id: str) -> BusFrame`.
+  - `ack_frame(source_id: str, last_event_id: str) -> BusFrame`.
+  - `qualified_id(source_id: str, event_id: str) -> str` — returns `f"{source_id}:{event_id}"` (cross-host dedup key).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/transport/test_bus_frame.py
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEvent
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+
+
+def _ev(seq: int) -> StreamEvent:
+    return StreamEvent(
+        event_id=format(seq, "012x"),
+        event_type="task_started",
+        op_id="op-1",
+        timestamp="2026-07-03T00:00:00.000Z",
+        payload={"k": "v"},
+    )
+
+
+def test_event_frame_roundtrip_preserves_all_fields():
+    frame = bf.event_frame(_ev(42), source_id="brain-01")
+    raw = frame.encode()
+    back = bf.BusFrame.decode(raw)
+    assert back is not None
+    assert back.kind == bf.FRAME_EVENT
+    assert back.source_id == "brain-01"
+    assert back.seq == 42  # int(event_id, 16)
+    assert back.event["event_id"] == format(42, "012x")
+    assert back.event["payload"] == {"k": "v"}
+
+
+def test_hello_frame_carries_last_event_id():
+    frame = bf.hello_frame("mac-01", last_event_id="0000000000ff")
+    back = bf.BusFrame.decode(frame.encode())
+    assert back.kind == bf.FRAME_HELLO
+    assert back.last_event_id == "0000000000ff"
+
+
+def test_decode_malformed_returns_none_never_raises():
+    assert bf.BusFrame.decode(b"not json") is None
+    assert bf.BusFrame.decode("{}") is None  # missing required kind
+    assert bf.BusFrame.decode(b'{"kind": 123}') is None  # wrong type
+
+
+def test_qualified_id_is_source_scoped():
+    assert bf.qualified_id("mac-01", "0000000000ff") == "mac-01:0000000000ff"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/transport/test_bus_frame.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...bus_frame`
+
+- [ ] **Step 3: Implement the codec**
+
+```python
+# backend/core/ouroboros/governance/transport/bus_frame.py
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any, Dict, Optional, Union
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEvent
+
+FRAME_HELLO = "hello"
+FRAME_EVENT = "event"
+FRAME_HEARTBEAT = "heartbeat"
+FRAME_ACK = "ack"
+
+_VALID_KINDS = (FRAME_HELLO, FRAME_EVENT, FRAME_HEARTBEAT, FRAME_ACK)
+
+
+def _iso_now() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%f")[:-3] + "Z"
+
+
+def qualified_id(source_id: str, event_id: str) -> str:
+    """Cross-host dedup key: source-scoped so two brokers' native
+    monotonic ids never collide."""
+    return f"{source_id}:{event_id}"
+
+
+@dataclass(frozen=True)
+class BusFrame:
+    kind: str
+    source_id: str
+    seq: int = -1
+    last_event_id: Optional[str] = None
+    event: Optional[Dict[str, Any]] = None
+    ts: str = ""
+
+    def encode(self) -> bytes:
+        return json.dumps({
+            "kind": self.kind,
+            "source_id": self.source_id,
+            "seq": self.seq,
+            "last_event_id": self.last_event_id,
+            "event": self.event,
+            "ts": self.ts or _iso_now(),
+        }, ensure_ascii=True).encode("utf-8")
+
+    @classmethod
+    def decode(cls, raw: Union[str, bytes]) -> Optional["BusFrame"]:
+        try:
+            if isinstance(raw, (bytes, bytearray)):
+                raw = raw.decode("utf-8")
+            obj = json.loads(raw)
+        except (ValueError, UnicodeDecodeError):
+            return None
+        if not isinstance(obj, dict):
+            return None
+        kind = obj.get("kind")
+        if not isinstance(kind, str) or kind not in _VALID_KINDS:
+            return None
+        source_id = obj.get("source_id")
+        if not isinstance(source_id, str):
+            return None
+        event = obj.get("event")
+        if event is not None and not isinstance(event, dict):
+            return None
+        seq = obj.get("seq", -1)
+        if not isinstance(seq, int):
+            seq = -1
+        return cls(
+            kind=kind,
+            source_id=source_id,
+            seq=seq,
+            last_event_id=obj.get("last_event_id"),
+            event=event,
+            ts=obj.get("ts", "") if isinstance(obj.get("ts"), str) else "",
+        )
+
+
+def event_frame(ev: StreamEvent, source_id: str) -> BusFrame:
+    try:
+        seq = int(ev.event_id, 16)
+    except (ValueError, TypeError):
+        seq = -1
+    return BusFrame(
+        kind=FRAME_EVENT,
+        source_id=source_id,
+        seq=seq,
+        event=ev.to_dict(),
+        ts=_iso_now(),
+    )
+
+
+def hello_frame(source_id: str, last_event_id: Optional[str]) -> BusFrame:
+    return BusFrame(kind=FRAME_HELLO, source_id=source_id, last_event_id=last_event_id, ts=_iso_now())
+
+
+def heartbeat_frame(source_id: str) -> BusFrame:
+    return BusFrame(kind=FRAME_HEARTBEAT, source_id=source_id, ts=_iso_now())
+
+
+def ack_frame(source_id: str, last_event_id: str) -> BusFrame:
+    return BusFrame(kind=FRAME_ACK, source_id=source_id, last_event_id=last_event_id, ts=_iso_now())
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_bus_frame.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/transport/bus_frame.py tests/governance/transport/test_bus_frame.py
+git commit -m "feat(transport): BusFrame codec with source-qualified IDs (Stage 0)"
+```
+
+---
+
+## Task 4: Bridge server (WS route over a StreamEventBroker; Last-Event-ID replay + inbound dedup)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/transport/bus_bridge_server.py`
+- Test: `tests/governance/transport/test_bus_bridge_server.py`
+
+**Interfaces:**
+- Consumes: `TransportConfig` (Task 1), `build_server_ssl_context` (Task 2), `BusFrame`/`event_frame`/`hello_frame`/`heartbeat_frame`/`qualified_id`/frame constants (Task 3), `StreamEventBroker` + `StreamEvent` (`ide_observability_stream.py`).
+- Produces:
+  - `class BusBridgeServer` constructed as `BusBridgeServer(broker: StreamEventBroker, cfg: TransportConfig, *, on_inbound: Optional[Callable[[StreamEvent], None]] = None)`.
+    - `def register_routes(self, app: web.Application) -> None` — mounts the WS handler at `cfg.path` (so `EventChannelServer`'s app can host it).
+    - `async def _handle_ws(self, request: web.Request) -> web.WebSocketResponse` — the handler: on `hello`, seed replay from the broker's history since `last_event_id` and stream subsequent events; ingest inbound `event` frames, dedup by `qualified_id`, and republish to the broker via `on_inbound` (or the broker directly).
+    - `def seen_count(self) -> int` — number of distinct inbound qualified-ids applied (test hook).
+  - Server dedups inbound: a bounded `set`/`OrderedDict` of `qualified_id` values; a replayed frame already seen is dropped (idempotent ingest).
+
+- [ ] **Step 1: Write the failing test** (uses aiohttp's test server; TLS off for this unit — TLS handshake is covered in Task 9)
+
+```python
+# tests/governance/transport/test_bus_bridge_server.py
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+    StreamEvent,
+)
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cfg():
+    return TransportConfig(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.5, reconnect_max_s=30.0, reconnect_jitter=0.3,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain-test",
+    )
+
+
+async def _mk_client(broker, cfg, inbound_sink):
+    server = BusBridgeServer(broker, cfg, on_inbound=lambda ev: inbound_sink.append(ev))
+    app = web.Application()
+    server.register_routes(app)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return server, client
+
+
+async def test_server_replays_history_since_last_event_id():
+    broker = StreamEventBroker(history_maxlen=100)
+    # Pre-load three events into history.
+    id1 = broker.publish("task_started", "op-1", {"n": 1})
+    id2 = broker.publish("task_progress", "op-1", {"n": 2})
+    id3 = broker.publish("task_completed", "op-1", {"n": 3})
+    sink = []
+    server, client = await _mk_client(broker, _cfg(), sink)
+    try:
+        ws = await client.ws_connect("/ws/trinity-bus")
+        await ws.send_bytes(bf.hello_frame("mac-test", last_event_id=id1).encode())
+        got = []
+        # Expect replay of id2, id3 (everything after id1).
+        for _ in range(2):
+            msg = await asyncio.wait_for(ws.receive(), timeout=2.0)
+            frame = bf.BusFrame.decode(msg.data)
+            if frame and frame.kind == bf.FRAME_EVENT:
+                got.append(frame.event["event_id"])
+        assert got == [id2, id3]
+        await ws.close()
+    finally:
+        await client.close()
+
+
+async def test_server_dedups_replayed_inbound_events():
+    broker = StreamEventBroker(history_maxlen=100)
+    sink = []
+    server, client = await _mk_client(broker, _cfg(), sink)
+    try:
+        ws = await client.ws_connect("/ws/trinity-bus")
+        await ws.send_bytes(bf.hello_frame("mac-test", last_event_id=None).encode())
+        ev = StreamEvent(event_id=format(7, "012x"), event_type="task_started",
+                         op_id="op-9", timestamp="2026-07-03T00:00:00.000Z", payload={})
+        frame = bf.event_frame(ev, source_id="mac-test").encode()
+        await ws.send_bytes(frame)
+        await ws.send_bytes(frame)  # duplicate resend
+        await asyncio.sleep(0.2)
+        assert len(sink) == 1  # deduped by qualified_id
+        assert server.seen_count() == 1
+        await ws.close()
+    finally:
+        await client.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/transport/test_bus_bridge_server.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...bus_bridge_server`
+
+- [ ] **Step 3: Implement the server**
+
+```python
+# backend/core/ouroboros/governance/transport/bus_bridge_server.py
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections import OrderedDict
+from typing import Callable, Optional
+
+from aiohttp import WSMsgType, web
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEvent,
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+
+logger = logging.getLogger(__name__)
+
+_DEDUP_MAX = 8192  # bounded seen-id memory
+
+
+class BusBridgeServer:
+    """Hosts the WS endpoint that bridges a local StreamEventBroker to a
+    remote peer. Server-authoritative history + Last-Event-ID replay come
+    from the broker; inbound peer events are deduped by qualified id and
+    republished locally."""
+
+    def __init__(
+        self,
+        broker: StreamEventBroker,
+        cfg: TransportConfig,
+        *,
+        on_inbound: Optional[Callable[[StreamEvent], None]] = None,
+    ) -> None:
+        self._broker = broker
+        self._cfg = cfg
+        self._on_inbound = on_inbound
+        self._seen: "OrderedDict[str, None]" = OrderedDict()
+
+    def seen_count(self) -> int:
+        return len(self._seen)
+
+    def register_routes(self, app: web.Application) -> None:
+        app.router.add_get(self._cfg.path, self._handle_ws)
+
+    def _mark_seen(self, qid: str) -> bool:
+        """Return True if NEW (not seen before). Bounded FIFO eviction."""
+        if qid in self._seen:
+            return False
+        self._seen[qid] = None
+        if len(self._seen) > _DEDUP_MAX:
+            self._seen.popitem(last=False)
+        return True
+
+    def _ingest(self, frame: bf.BusFrame) -> None:
+        ev_dict = frame.event or {}
+        event_id = ev_dict.get("event_id", "")
+        qid = bf.qualified_id(frame.source_id, event_id)
+        if not self._mark_seen(qid):
+            return  # idempotent — already applied
+        ev = StreamEvent(
+            event_id=event_id,
+            event_type=ev_dict.get("event_type", ""),
+            op_id=ev_dict.get("op_id", ""),
+            timestamp=ev_dict.get("timestamp", ""),
+            payload=ev_dict.get("payload", {}) or {},
+        )
+        try:
+            if self._on_inbound is not None:
+                self._on_inbound(ev)
+        except Exception:  # noqa: BLE001 — never crash the WS loop
+            logger.debug("[BusBridgeServer] on_inbound raised", exc_info=True)
+
+    async def _pump_outbound(self, ws: web.WebSocketResponse, last_event_id: Optional[str]) -> None:
+        """Subscribe to the broker and stream events (with replay) to the peer."""
+        sub = self._broker.subscribe(op_id_filter=None, last_event_id=last_event_id)
+        if sub is None:
+            return
+        try:
+            hb = self._cfg.heartbeat_s
+            async for event in self._broker.stream_iter(sub, heartbeat_s=hb):
+                if ws.closed:
+                    break
+                frame = bf.event_frame(event, source_id=self._cfg.source_id)
+                await ws.send_bytes(frame.encode())
+        except (asyncio.CancelledError, ConnectionResetError):
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[BusBridgeServer] outbound pump ended", exc_info=True)
+
+    async def _handle_ws(self, request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse(heartbeat=None)
+        await ws.prepare(request)
+        pump_task: Optional[asyncio.Task] = None
+        try:
+            async for msg in ws:
+                if msg.type != WSMsgType.BINARY and msg.type != WSMsgType.TEXT:
+                    if msg.type in (WSMsgType.CLOSE, WSMsgType.CLOSING, WSMsgType.ERROR):
+                        break
+                    continue
+                frame = bf.BusFrame.decode(msg.data)
+                if frame is None:
+                    continue
+                if frame.kind == bf.FRAME_HELLO and pump_task is None:
+                    pump_task = asyncio.ensure_future(
+                        self._pump_outbound(ws, frame.last_event_id)
+                    )
+                elif frame.kind == bf.FRAME_EVENT:
+                    self._ingest(frame)
+                elif frame.kind == bf.FRAME_HEARTBEAT:
+                    await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
+                # FRAME_ACK is plumbed for Stage 3 WAL trim; no-op here.
+        finally:
+            if pump_task is not None:
+                pump_task.cancel()
+                try:
+                    await pump_task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+        return ws
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_bus_bridge_server.py -v`
+Expected: PASS (2 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/transport/bus_bridge_server.py tests/governance/transport/test_bus_bridge_server.py
+git commit -m "feat(transport): BusBridgeServer WS route with Last-Event-ID replay + inbound dedup (Stage 0)"
+```
+
+---
+
+## Task 5: Bridge client (reconnect backoff+jitter, heartbeat-miss degraded flip, contiguous-id resume)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/transport/bus_bridge_client.py`
+- Test: `tests/governance/transport/test_bus_bridge_client.py`
+
+**Interfaces:**
+- Consumes: `TransportConfig` (Task 1), `build_client_ssl_context` (Task 2), `BusFrame`/frame builders/constants (Task 3), `StreamEventBroker`/`StreamEvent` (`ide_observability_stream.py`).
+- Produces:
+  - `class BusBridgeClient(broker: StreamEventBroker, cfg: TransportConfig, *, url: Optional[str] = None, session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None)`.
+    - `async def run(self) -> None` — the reconnect loop: connect, send `hello` with `self.last_event_id`, pump broker events out + apply inbound events, retry on drop with exp-backoff+jitter.
+    - `async def stop(self) -> None` — cancel the loop cleanly.
+    - `property last_event_id: Optional[str]` — highest **contiguous** server event_id applied (drives replay). Starts `None`.
+    - `property degraded: bool` — True after `cfg.degrade_after_missed_hb` consecutive heartbeat-window misses; flips back False on a live frame.
+    - `def _next_backoff(self, attempt: int) -> float` — `min(base * 2**attempt, max) * (1 +/- jitter)`; pure, unit-testable.
+    - `def _advance_contiguous(self, event_id: str) -> None` — update `last_event_id` only when `int(event_id,16)` is exactly one past the current high-water; a gap is left unfilled so the next reconnect replays it.
+
+- [ ] **Step 1: Write the failing test** (backoff math + contiguity are pure; the live socket path is exercised end-to-end in Tasks 6-7-9)
+
+```python
+# tests/governance/transport/test_bus_bridge_client.py
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.5, reconnect_max_s=8.0, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="mac-test",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+def test_backoff_grows_geometrically_and_caps():
+    c = BusBridgeClient(StreamEventBroker(), _cfg())
+    assert c._next_backoff(0) == 0.5
+    assert c._next_backoff(1) == 1.0
+    assert c._next_backoff(2) == 2.0
+    assert c._next_backoff(20) == 8.0  # capped at reconnect_max_s
+
+
+def test_backoff_jitter_stays_in_band():
+    c = BusBridgeClient(StreamEventBroker(), _cfg(reconnect_jitter=0.3))
+    for attempt in range(6):
+        base = min(0.5 * 2 ** attempt, 8.0)
+        val = c._next_backoff(attempt)
+        assert base * 0.7 <= val <= base * 1.3
+
+
+def test_contiguous_advance_leaves_gaps_for_replay():
+    c = BusBridgeClient(StreamEventBroker(), _cfg())
+    assert c.last_event_id is None
+    c._advance_contiguous(format(1, "012x"))
+    assert c.last_event_id == format(1, "012x")
+    c._advance_contiguous(format(2, "012x"))
+    assert c.last_event_id == format(2, "012x")
+    # A gap (skip 3, receive 4) must NOT advance the high-water past 2.
+    c._advance_contiguous(format(4, "012x"))
+    assert c.last_event_id == format(2, "012x")  # replay will refetch 3,4
+    # Filling the gap advances again.
+    c._advance_contiguous(format(3, "012x"))
+    assert c.last_event_id == format(3, "012x")
+
+
+def test_degraded_defaults_false():
+    c = BusBridgeClient(StreamEventBroker(), _cfg())
+    assert c.degraded is False
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/transport/test_bus_bridge_client.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...bus_bridge_client`
+
+- [ ] **Step 3: Implement the client**
+
+```python
+# backend/core/ouroboros/governance/transport/bus_bridge_client.py
+from __future__ import annotations
+
+import asyncio
+import logging
+import random
+from typing import Callable, Optional, Set
+
+import aiohttp
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEvent,
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.transport_security import (
+    build_client_ssl_context,
+)
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+
+logger = logging.getLogger(__name__)
+
+
+class BusBridgeClient:
+    """Connects to a BusBridgeServer, resumes via Last-Event-ID, and
+    mirrors the two brokers. Reconnect is exp-backoff + jitter; a
+    heartbeat-window miss flips degraded mode deterministically."""
+
+    def __init__(
+        self,
+        broker: StreamEventBroker,
+        cfg: TransportConfig,
+        *,
+        url: Optional[str] = None,
+        session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None,
+    ) -> None:
+        self._broker = broker
+        self._cfg = cfg
+        self._url = url
+        self._session_factory = session_factory
+        self._stopped = False
+        self._last_event_id: Optional[str] = None
+        self._high_water: int = 0
+        self._degraded = False
+        self._missed_hb = 0
+        self._seen: Set[str] = set()
+
+    @property
+    def last_event_id(self) -> Optional[str]:
+        return self._last_event_id
+
+    @property
+    def degraded(self) -> bool:
+        return self._degraded
+
+    def _next_backoff(self, attempt: int) -> float:
+        base = min(self._cfg.reconnect_base_s * (2 ** attempt), self._cfg.reconnect_max_s)
+        if self._cfg.reconnect_jitter <= 0:
+            return base
+        span = base * self._cfg.reconnect_jitter
+        return base + random.uniform(-span, span)
+
+    def _advance_contiguous(self, event_id: str) -> None:
+        try:
+            seq = int(event_id, 16)
+        except (ValueError, TypeError):
+            return
+        if seq == self._high_water + 1:
+            self._high_water = seq
+            self._last_event_id = event_id
+            # Absorb any already-received events that now become contiguous.
+            # (Gap-fill: caller applies events as they arrive; the high-water
+            # only tracks the contiguous prefix.)
+
+    def _resolve_url(self) -> str:
+        if self._url:
+            return self._url
+        scheme = "wss" if self._cfg.tls_enabled else "ws"
+        host = self._cfg.host or "127.0.0.1"
+        return f"{scheme}://{host}:{self._cfg.port}{self._cfg.path}"
+
+    async def stop(self) -> None:
+        self._stopped = True
+
+    async def run(self) -> None:
+        attempt = 0
+        while not self._stopped:
+            try:
+                await self._connect_once()
+                attempt = 0  # clean disconnect resets backoff
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — any drop -> reconnect
+                logger.debug("[BusBridgeClient] connection ended", exc_info=True)
+            if self._stopped:
+                break
+            delay = self._next_backoff(attempt)
+            attempt += 1
+            await asyncio.sleep(delay)
+
+    async def _connect_once(self) -> None:
+        ssl_ctx = build_client_ssl_context(self._cfg)
+        session = (self._session_factory() if self._session_factory
+                   else aiohttp.ClientSession())
+        try:
+            async with session.ws_connect(
+                self._resolve_url(), ssl=ssl_ctx, heartbeat=None,
+            ) as ws:
+                await ws.send_bytes(
+                    bf.hello_frame(self._cfg.source_id, self._last_event_id).encode()
+                )
+                out_task = asyncio.ensure_future(self._pump_outbound(ws))
+                try:
+                    await self._pump_inbound(ws)
+                finally:
+                    out_task.cancel()
+                    try:
+                        await out_task
+                    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                        pass
+        finally:
+            await session.close()
+
+    async def _pump_outbound(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        sub = self._broker.subscribe(op_id_filter=None, last_event_id=None)
+        if sub is None:
+            return
+        async for event in self._broker.stream_iter(sub, heartbeat_s=self._cfg.heartbeat_s):
+            if ws.closed:
+                break
+            await ws.send_bytes(bf.event_frame(event, source_id=self._cfg.source_id).encode())
+
+    async def _pump_inbound(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        hb = self._cfg.heartbeat_s
+        while not ws.closed and not self._stopped:
+            try:
+                if hb > 0:
+                    msg = await asyncio.wait_for(ws.receive(), timeout=hb * 1.5)
+                else:
+                    msg = await ws.receive()
+            except asyncio.TimeoutError:
+                self._missed_hb += 1
+                if self._missed_hb >= self._cfg.degrade_after_missed_hb:
+                    self._degraded = True
+                continue
+            if msg.type in (aiohttp.WSMsgType.CLOSE, aiohttp.WSMsgType.CLOSING,
+                            aiohttp.WSMsgType.CLOSED, aiohttp.WSMsgType.ERROR):
+                break
+            self._missed_hb = 0
+            self._degraded = False
+            frame = bf.BusFrame.decode(msg.data)
+            if frame is None or frame.kind != bf.FRAME_EVENT:
+                continue
+            self._apply_inbound(frame)
+
+    def _apply_inbound(self, frame: bf.BusFrame) -> None:
+        ev_dict = frame.event or {}
+        event_id = ev_dict.get("event_id", "")
+        qid = bf.qualified_id(frame.source_id, event_id)
+        if qid in self._seen:
+            return
+        self._seen.add(qid)
+        try:
+            self._broker.publish(
+                ev_dict.get("event_type", ""),
+                ev_dict.get("op_id", ""),
+                ev_dict.get("payload", {}) or {},
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[BusBridgeClient] local republish failed", exc_info=True)
+        self._advance_contiguous(event_id)
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_bus_bridge_client.py -v`
+Expected: PASS (4 passed)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/transport/bus_bridge_client.py tests/governance/transport/test_bus_bridge_client.py
+git commit -m "feat(transport): BusBridgeClient with backoff+jitter reconnect, degraded flip, contiguous resume (Stage 0)"
+```
+
+---
+
+## Task 6: Distributed bus adapter + real-socket integration
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/transport/distributed_event_bus.py`
+- Modify: `backend/core/ouroboros/governance/transport/__init__.py` (export the new surface)
+- Test: `tests/governance/transport/test_distributed_event_bus.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-5.
+- Produces:
+  - `class DistributedEventBus(broker: StreamEventBroker, cfg: TransportConfig, *, role: str)`.
+    - `def publish(self, event_type: str, op_id: str, payload: dict) -> Optional[str]` — delegates to the local broker (unchanged TrinityEventBus semantics); the bridge propagates it across the socket.
+    - `def register_server_routes(self, app: web.Application) -> None` — server role only; mounts `BusBridgeServer`.
+    - `async def start_client(self, url: Optional[str] = None) -> None` / `async def stop(self) -> None` — client role; drives a `BusBridgeClient`.
+  - Exports added to `__init__.py`: `DistributedEventBus`, `BusBridgeServer`, `BusBridgeClient`, `build_client_ssl_context`, `build_server_ssl_context`.
+
+- [ ] **Step 1: Write the failing test — publish here, observed there, over a real loopback socket**
+
+```python
+# tests/governance/transport/test_distributed_event_bus.py
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.distributed_event_bus import DistributedEventBus
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.1, reconnect_max_s=1.0, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain-test",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+async def test_publish_on_server_reaches_client_broker():
+    server_broker = StreamEventBroker(history_maxlen=100)
+    client_broker = StreamEventBroker(history_maxlen=100)
+    server_bus = DistributedEventBus(server_broker, _cfg(source_id="brain"), role="server")
+    app = web.Application()
+    server_bus.register_server_routes(app)
+    tclient = TestClient(TestServer(app))
+    await tclient.start_server()
+    url = str(tclient.make_url("/ws/trinity-bus")).replace("http", "ws")
+
+    client_bus = DistributedEventBus(client_broker, _cfg(source_id="mac"), role="client")
+    run_task = asyncio.ensure_future(client_bus.start_client(url=url))
+    try:
+        await asyncio.sleep(0.3)  # allow connect + hello
+        # Publish on the SERVER; assert it lands in the CLIENT's broker.
+        server_broker.publish("task_started", "op-42", {"hello": "world"})
+        deadline = asyncio.get_event_loop().time() + 3.0
+        found = False
+        while asyncio.get_event_loop().time() < deadline:
+            hist = client_broker.recent_history()
+            if any(e.op_id == "op-42" and e.event_type == "task_started" for e in hist):
+                found = True
+                break
+            await asyncio.sleep(0.05)
+        assert found, "event published on server never reached client broker"
+    finally:
+        await client_bus.stop()
+        run_task.cancel()
+        try:
+            await run_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        await tclient.close()
+```
+
+Note: confirm `StreamEventBroker.recent_history()` returns the events (signature seen at `ide_observability_stream.py:1861`); if its parameter differs, pass the documented arguments — it returns a fresh list of `StreamEvent`.
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `python3 -m pytest tests/governance/transport/test_distributed_event_bus.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...distributed_event_bus`
+
+- [ ] **Step 3: Implement the adapter**
+
+```python
+# backend/core/ouroboros/governance/transport/distributed_event_bus.py
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Optional
+
+from aiohttp import web
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+
+logger = logging.getLogger(__name__)
+
+
+class DistributedEventBus:
+    """The publish()-here-subscribers-there seam. Wraps a local
+    StreamEventBroker; a server- or client-role bridge propagates events
+    across the socket. TrinityEventBus callers are unchanged — they still
+    publish/subscribe on the local broker."""
+
+    def __init__(self, broker: StreamEventBroker, cfg: TransportConfig, *, role: str) -> None:
+        if role not in ("server", "client"):
+            raise ValueError(f"role must be server|client, got {role!r}")
+        self._broker = broker
+        self._cfg = cfg
+        self._role = role
+        self._server: Optional[BusBridgeServer] = None
+        self._client: Optional[BusBridgeClient] = None
+
+    def publish(self, event_type: str, op_id: str, payload: dict) -> Optional[str]:
+        return self._broker.publish(event_type, op_id, payload)
+
+    def register_server_routes(self, app: web.Application) -> None:
+        if self._role != "server":
+            raise RuntimeError("register_server_routes requires role=server")
+        # Inbound peer events republish into the local broker so local
+        # subscribers see them (idempotent — server dedups by qualified id).
+        self._server = BusBridgeServer(
+            self._broker, self._cfg,
+            on_inbound=lambda ev: self._broker.publish(
+                ev.event_type, ev.op_id, dict(ev.payload)
+            ),
+        )
+        self._server.register_routes(app)
+
+    async def start_client(self, url: Optional[str] = None) -> None:
+        if self._role != "client":
+            raise RuntimeError("start_client requires role=client")
+        self._client = BusBridgeClient(self._broker, self._cfg, url=url)
+        await self._client.run()
+
+    async def stop(self) -> None:
+        if self._client is not None:
+            await self._client.stop()
+```
+
+- [ ] **Step 4: Update the package exports**
+
+```python
+# backend/core/ouroboros/governance/transport/__init__.py  (append to __all__ + imports)
+__all__ = [
+    "TransportConfig",
+    "distributed_bus_enabled",
+    "DistributedEventBus",
+    "BusBridgeServer",
+    "BusBridgeClient",
+    "build_client_ssl_context",
+    "build_server_ssl_context",
+]
+
+from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: E402,F401
+    TransportConfig,
+    distributed_bus_enabled,
+)
+from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: E402,F401
+    DistributedEventBus,
+)
+from backend.core.ouroboros.governance.transport.bus_bridge_server import (  # noqa: E402,F401
+    BusBridgeServer,
+)
+from backend.core.ouroboros.governance.transport.bus_bridge_client import (  # noqa: E402,F401
+    BusBridgeClient,
+)
+from backend.core.ouroboros.governance.transport.transport_security import (  # noqa: E402,F401
+    build_client_ssl_context,
+    build_server_ssl_context,
+)
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_distributed_event_bus.py -v`
+Expected: PASS (1 passed)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/transport/distributed_event_bus.py backend/core/ouroboros/governance/transport/__init__.py tests/governance/transport/test_distributed_event_bus.py
+git commit -m "feat(transport): DistributedEventBus seam + real-socket loopback integration (Stage 0)"
+```
+
+---
+
+## Task 7: Hostile-network simulation + exact Last-Event-ID replay (LOAD-BEARING)
+
+**Files:**
+- Create: `tests/governance/transport/hostile_network.py` (reusable fault-injection proxy)
+- Test: `tests/governance/transport/test_hostile_network_replay.py`
+
+**Interfaces:**
+- Consumes: `BusBridgeServer` (Task 4), `BusBridgeClient` (Task 5), `StreamEventBroker`.
+- Produces:
+  - `class HostileProxy` — an aiohttp app that sits between client and the real server WS, applying: `latency_s` (fixed delay per frame), `jitter_s` (uniform extra delay), `reorder_window` (buffer N frames and flush shuffled), `drop_then_close_after` (deliver K frames, drop the connection to force a client reconnect). Deterministic via a seeded `random.Random`.
+  - `async def run_hostile_case(*, n_events, faults) -> Tuple[List[str], List[str]]` — returns `(published_ids, client_final_ids)` for assertions.
+
+**The load-bearing assertion:** after the hostile transport churns (drops mid-stream, forces a reconnect, replays via Last-Event-ID), the set of event ids the client ultimately holds equals the set the server published — **no gap, no duplicate** — and the contiguous prefix matches exactly.
+
+- [ ] **Step 1: Write the fault-injection proxy**
+
+```python
+# tests/governance/transport/hostile_network.py
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import List, Optional
+
+from aiohttp import ClientSession, WSMsgType, web
+
+
+class HostileProxy:
+    """WS proxy that degrades the link between a client and the real
+    upstream server. Deterministic (seeded)."""
+
+    def __init__(
+        self,
+        upstream_url: str,
+        *,
+        latency_s: float = 0.0,
+        jitter_s: float = 0.0,
+        reorder_window: int = 1,
+        drop_after: Optional[int] = None,
+        seed: int = 1234,
+    ) -> None:
+        self._upstream = upstream_url
+        self._latency = latency_s
+        self._jitter = jitter_s
+        self._reorder_window = max(1, reorder_window)
+        self._drop_after = drop_after
+        self._rng = random.Random(seed)
+
+    def register(self, app: web.Application, path: str) -> None:
+        app.router.add_get(path, self._handle)
+
+    async def _delay(self) -> None:
+        d = self._latency + (self._rng.uniform(0, self._jitter) if self._jitter else 0.0)
+        if d > 0:
+            await asyncio.sleep(d)
+
+    async def _handle(self, request: web.Request) -> web.WebSocketResponse:
+        downstream = web.WebSocketResponse(heartbeat=None)
+        await downstream.prepare(request)
+        session = ClientSession()
+        delivered = 0
+        buf: List[bytes] = []
+        try:
+            async with session.ws_connect(self._upstream, heartbeat=None) as upstream:
+                async def c2u() -> None:
+                    async for msg in downstream:
+                        if msg.type in (WSMsgType.BINARY, WSMsgType.TEXT):
+                            await upstream.send_bytes(
+                                msg.data if isinstance(msg.data, bytes) else msg.data.encode()
+                            )
+                        else:
+                            break
+
+                async def u2c() -> None:
+                    nonlocal delivered
+                    async for msg in upstream:
+                        if msg.type not in (WSMsgType.BINARY, WSMsgType.TEXT):
+                            break
+                        data = msg.data if isinstance(msg.data, bytes) else msg.data.encode()
+                        await self._delay()
+                        buf.append(data)
+                        if len(buf) >= self._reorder_window:
+                            self._rng.shuffle(buf)
+                            for frame in buf:
+                                if self._drop_after is not None and delivered >= self._drop_after:
+                                    await downstream.close()
+                                    return
+                                await downstream.send_bytes(frame)
+                                delivered += 1
+                            buf.clear()
+
+                await asyncio.gather(c2u(), u2c(), return_exceptions=True)
+                # Flush any remaining buffered frames unless we already dropped.
+                for frame in buf:
+                    if self._drop_after is not None and delivered >= self._drop_after:
+                        break
+                    await downstream.send_bytes(frame)
+                    delivered += 1
+        finally:
+            await session.close()
+            if not downstream.closed:
+                await downstream.close()
+        return downstream
+```
+
+- [ ] **Step 2: Write the failing load-bearing test**
+
+```python
+# tests/governance/transport/test_hostile_network_replay.py
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+from tests.governance.transport.hostile_network import HostileProxy
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.05, reconnect_max_s=0.5, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=4096, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+async def test_replay_is_exact_across_drop_and_reorder():
+    server_broker = StreamEventBroker(history_maxlen=4096)
+    # Real upstream server hosting the bridge.
+    up_app = web.Application()
+    BusBridgeServer(server_broker, _cfg(source_id="brain")).register_routes(up_app)
+    up = TestClient(TestServer(up_app))
+    await up.start_server()
+    upstream_url = str(up.make_url("/ws/trinity-bus")).replace("http", "ws")
+
+    # Hostile proxy in front of it: reorder in windows of 3, drop the
+    # connection after 5 frames to force a reconnect + Last-Event-ID replay.
+    proxy = HostileProxy(upstream_url, reorder_window=3, drop_after=5,
+                         latency_s=0.001, jitter_s=0.003, seed=7)
+    px_app = web.Application()
+    proxy.register(px_app, "/ws/trinity-bus")
+    px = TestClient(TestServer(px_app))
+    await px.start_server()
+    proxy_url = str(px.make_url("/ws/trinity-bus")).replace("http", "ws")
+
+    client_broker = StreamEventBroker(history_maxlen=4096)
+    client = BusBridgeClient(client_broker, _cfg(source_id="mac"), url=proxy_url)
+    run_task = asyncio.ensure_future(client.run())
+
+    published = []
+    try:
+        await asyncio.sleep(0.2)
+        # Publish 12 events on the server. The proxy drops mid-stream;
+        # the client must reconnect and replay the gap from Last-Event-ID.
+        for i in range(12):
+            eid = server_broker.publish("task_progress", "op-hostile", {"i": i})
+            published.append(eid)
+            await asyncio.sleep(0.02)
+        # Give reconnect + replay time to converge.
+        deadline = asyncio.get_event_loop().time() + 6.0
+        while asyncio.get_event_loop().time() < deadline:
+            got = {e.event_id for e in client_broker.recent_history()
+                   if e.op_id == "op-hostile"}
+            if set(published).issubset(got):
+                break
+            await asyncio.sleep(0.1)
+        got_ids = [e.event_id for e in client_broker.recent_history()
+                   if e.op_id == "op-hostile"]
+        # EXACT: every published id present, no duplicates.
+        assert set(published).issubset(set(got_ids)), (
+            f"missing after replay: {set(published) - set(got_ids)}"
+        )
+        assert len(got_ids) == len(set(got_ids)), "duplicate events after replay"
+    finally:
+        await client.stop()
+        run_task.cancel()
+        try:
+            await run_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        await px.close()
+        await up.close()
+```
+
+- [ ] **Step 3: Run test to verify it fails, then passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_hostile_network_replay.py -v`
+Expected FIRST: FAIL — either `ModuleNotFoundError` on `hostile_network` (if Step 1 not saved) or an assertion gap if replay is imperfect. If it fails on a replay gap, the bug is in `BusBridgeClient._advance_contiguous`/hello resume — fix there (this is the whole point of the task), do not weaken the assertion.
+Expected AFTER fixes: PASS (1 passed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/governance/transport/hostile_network.py tests/governance/transport/test_hostile_network_replay.py
+git commit -m "test(transport): hostile-network sim proving exact Last-Event-ID replay across drop+reorder (Stage 0)"
+```
+
+---
+
+## Task 8: AST invariants — real-time actuation isolation + no hardcoded endpoints
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/meta/shipped_code_invariants.py` (add two validators + register both in `_register_seed_invariants`, near line 3481)
+- Test: `tests/governance/test_transport_invariants.py`
+
+**Interfaces:**
+- Consumes: the `ShippedCodeInvariant` schema (`invariant_name`, `target_file`, `description`, `validate`), `register_shipped_code_invariant`, and the validator contract `Callable[[ast.Module, str], Tuple[str, ...]]` (all in `shipped_code_invariants.py`; validators never raise, empty tuple = holds).
+- Produces:
+  - `_validate_realtime_actuation_no_remote_transport(tree: ast.Module, source: str) -> Tuple[str, ...]` — target file `backend/ghost_hands/ghost_hands_controller.py` (the real-time actuation entry; adjust to the actual controller module name found in `backend/ghost_hands/`): flags any `import`/`from ... import` whose module path contains `governance.transport`.
+  - `_validate_transport_no_hardcoded_endpoints(tree: ast.Module, source: str) -> Tuple[str, ...]` — target file `backend/core/ouroboros/governance/transport/transport_config.py`: flags any string literal matching an IPv4 dotted-quad or a `ws://`/`wss://` URL (endpoints must be env-resolved, not baked). The loopback default `127.0.0.1` lives in tests/fixtures, never in this module — so the module must contain zero such literals.
+
+- [ ] **Step 1: Confirm the real-time actuation entry module name**
+
+Run: `ls backend/ghost_hands/ && grep -rlE "class .*(Controller|Actuator|GhostHands)" backend/ghost_hands/*.py | head`
+Use the identified controller module path as `target_file` in Step 3. If multiple real-time modules exist, register one invariant per module (repeat the `ShippedCodeInvariant(...)` block with each `target_file`).
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/governance/test_transport_invariants.py
+from __future__ import annotations
+
+import ast
+
+from backend.core.ouroboros.governance.meta.shipped_code_invariants import (
+    _validate_realtime_actuation_no_remote_transport,
+    _validate_transport_no_hardcoded_endpoints,
+)
+
+
+def test_actuation_importing_transport_is_flagged():
+    bad = (
+        "from backend.core.ouroboros.governance.transport import DistributedEventBus\n"
+        "def click(x, y):\n    pass\n"
+    )
+    violations = _validate_realtime_actuation_no_remote_transport(ast.parse(bad), bad)
+    assert violations
+    assert any("transport" in v for v in violations)
+
+
+def test_actuation_without_transport_import_holds():
+    good = "import time\ndef click(x, y):\n    time.sleep(0)\n"
+    violations = _validate_realtime_actuation_no_remote_transport(ast.parse(good), good)
+    assert violations == ()
+
+
+def test_hardcoded_ipv4_in_config_is_flagged():
+    bad = 'HOST = "10.1.2.3"\nURL = "wss://10.1.2.3:8443/ws"\n'
+    violations = _validate_transport_no_hardcoded_endpoints(ast.parse(bad), bad)
+    assert violations
+
+
+def test_env_resolved_config_holds():
+    good = 'import os\nhost = os.environ.get("JARVIS_BRAIN_WS_HOST")\n'
+    violations = _validate_transport_no_hardcoded_endpoints(ast.parse(good), good)
+    assert violations == ()
+```
+
+- [ ] **Step 3: Implement the two validators** (add near the other `_validate_*` functions)
+
+```python
+# backend/core/ouroboros/governance/meta/shipped_code_invariants.py  (add these functions)
+import re as _re  # if `re` is not already imported at module top; otherwise reuse it
+
+_IPV4_RE = _re.compile(r"\b(?:\d{1,3}\.){3}\d{1,3}\b")
+_WSURL_RE = _re.compile(r"wss?://")
+
+
+def _validate_realtime_actuation_no_remote_transport(
+    tree: "ast.Module", source: str,
+) -> "Tuple[str, ...]":
+    """Real-time actuation layers MUST NOT import the network transport
+    subpackage. A remote dependency on a hard-real-time path would couple
+    cursor/keyboard latency to network RTT. Structural block."""
+    out = []
+    try:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                if "governance.transport" in mod:
+                    out.append(
+                        f"real-time actuation imports remote transport: "
+                        f"from {mod} (line {node.lineno})"
+                    )
+            elif isinstance(node, ast.Import):
+                for alias in node.names:
+                    if "governance.transport" in (alias.name or ""):
+                        out.append(
+                            f"real-time actuation imports remote transport: "
+                            f"import {alias.name} (line {node.lineno})"
+                        )
+    except Exception:  # noqa: BLE001 — validators never raise
+        return ()
+    return tuple(out)
+
+
+def _validate_transport_no_hardcoded_endpoints(
+    tree: "ast.Module", source: str,
+) -> "Tuple[str, ...]":
+    """The transport config module must resolve every endpoint from env —
+    no baked IPv4 literals, no baked ws:// / wss:// URLs."""
+    out = []
+    try:
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                val = node.value
+                if _IPV4_RE.search(val) or _WSURL_RE.search(val):
+                    out.append(
+                        f"hardcoded endpoint literal {val!r} "
+                        f"(line {getattr(node, 'lineno', -1)}) — resolve from env"
+                    )
+    except Exception:  # noqa: BLE001
+        return ()
+    return tuple(out)
+```
+
+- [ ] **Step 4: Register both invariants** (inside `_register_seed_invariants`, after the last existing `register_shipped_code_invariant(...)` block)
+
+```python
+    register_shipped_code_invariant(
+        ShippedCodeInvariant(
+            invariant_name="realtime_actuation_no_remote_transport",
+            target_file="backend/ghost_hands/ghost_hands_controller.py",  # <- Step 1 result
+            description=(
+                "Real-time actuation (Ghost Hands) MUST NOT import "
+                "backend.core.ouroboros.governance.transport — a hard-real-time "
+                "path cannot take a network dependency (Stage 0 latency-scope "
+                "invariant)."
+            ),
+            validate=_validate_realtime_actuation_no_remote_transport,
+        ),
+    )
+    register_shipped_code_invariant(
+        ShippedCodeInvariant(
+            invariant_name="transport_config_no_hardcoded_endpoints",
+            target_file=(
+                "backend/core/ouroboros/governance/transport/transport_config.py"
+            ),
+            description=(
+                "TransportConfig must resolve every endpoint from env — no baked "
+                "IPv4 or ws:// / wss:// literals (Stage 0 no-hardcoding invariant)."
+            ),
+            validate=_validate_transport_no_hardcoded_endpoints,
+        ),
+    )
+```
+
+- [ ] **Step 5: Run the invariant unit test + the whole-registry validation**
+
+Run: `python3 -m pytest tests/governance/test_transport_invariants.py -v`
+Expected: PASS (4 passed)
+
+Run: `python3 -c "from backend.core.ouroboros.governance.meta.shipped_code_invariants import validate_all; v=[x for x in validate_all() if 'transport' in x.invariant_name or 'actuation' in x.invariant_name]; print('violations:', [x.to_dict() for x in v]); assert not v, v"`
+Expected: `violations: []` — the real Ghost Hands controller does NOT import the transport, and `transport_config.py` has no baked endpoint. If either fires, that is a real violation to fix in the source (do not weaken the validator).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/meta/shipped_code_invariants.py tests/governance/test_transport_invariants.py
+git commit -m "feat(invariant): structural block on real-time actuation importing remote transport + no-hardcoded-endpoint pin (Stage 0)"
+```
+
+---
+
+## Task 9: Two-process loopback smoke + mTLS handshake end-to-end
+
+**Files:**
+- Create: `tests/governance/transport/test_two_process_loopback.py`
+- Create: `backend/core/ouroboros/governance/transport/_smoke_server.py` (a tiny runnable brain-side server for the subprocess smoke — env-driven, no hardcoded host/port)
+- Test: same file above
+
+**Interfaces:**
+- Consumes: `DistributedEventBus`, `TransportConfig`, `build_server_ssl_context`/`build_client_ssl_context`.
+- Produces: proof that (a) a real second OS process hosting the server exchanges events with an in-test client, and (b) the mTLS handshake succeeds with ephemeral material and is REQUIRED (a plaintext client is rejected).
+
+- [ ] **Step 1: Write the env-driven smoke server**
+
+```python
+# backend/core/ouroboros/governance/transport/_smoke_server.py
+"""Runnable brain-side WS server for the two-process loopback smoke test.
+Host/port/TLS come entirely from env — no hardcoded endpoint. Writes the
+bound port to the file named by JARVIS_BRAIN_WS_PORTFILE so the parent can
+discover it (loopback stand-in for Stage 1's Reachability discovery)."""
+from __future__ import annotations
+
+import asyncio
+import os
+
+from aiohttp import web
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.distributed_event_bus import DistributedEventBus
+from backend.core.ouroboros.governance.transport.transport_security import (
+    build_server_ssl_context,
+)
+
+
+async def _main() -> None:
+    cfg = TransportConfig.from_env(role="server")
+    broker = StreamEventBroker(history_maxlen=cfg.history_maxlen)
+    bus = DistributedEventBus(broker, cfg, role="server")
+    app = web.Application()
+    bus.register_server_routes(app)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    ssl_ctx = build_server_ssl_context(cfg)
+    site = web.TCPSite(runner, cfg.host or "127.0.0.1", cfg.port, ssl_context=ssl_ctx)
+    await site.start()
+    # Publish one heartbeat event on a timer so the client observes traffic.
+    portfile = os.environ.get("JARVIS_BRAIN_WS_PORTFILE")
+    bound = site._server.sockets[0].getsockname()[1]  # actual bound port
+    if portfile:
+        with open(portfile, "w") as fh:
+            fh.write(str(bound))
+    for i in range(1000):
+        broker.publish("task_progress", "op-smoke", {"i": i})
+        await asyncio.sleep(0.1)
+
+
+if __name__ == "__main__":
+    asyncio.run(_main())
+```
+
+- [ ] **Step 2: Write the failing test**
+
+```python
+# tests/governance/transport/test_two_process_loopback.py
+from __future__ import annotations
+
+import asyncio
+import os
+import ssl
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+from backend.core.ouroboros.governance.transport.transport_security import (
+    build_server_ssl_context,
+    build_client_ssl_context,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _tls_cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.05, reconnect_max_s=0.5, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=True, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=True, source_id="brain",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+async def test_mtls_handshake_succeeds_and_is_required():
+    # Shared ephemeral material for both ends (loopback stands in for a
+    # shared CA). Resolve once, feed both contexts the same cert/key.
+    from backend.core.ouroboros.governance.transport import transport_security as ts
+    cert, key = ts.generate_ephemeral_material()
+    cfg = _tls_cfg(tls_ephemeral=False, tls_cert=cert, tls_key=key, tls_ca=cert)
+
+    broker = StreamEventBroker(history_maxlen=100)
+    app = web.Application()
+    BusBridgeServer(broker, cfg).register_routes(app)
+    server_ssl = build_server_ssl_context(cfg)
+    tserver = TestServer(app)
+    await tserver.start_server(ssl=server_ssl)
+    host, port = tserver.host, tserver.port
+
+    import aiohttp
+    client_ssl = build_client_ssl_context(cfg)
+    # (a) mTLS client connects.
+    async with aiohttp.ClientSession() as s:
+        async with s.ws_connect(f"wss://{host}:{port}/ws/trinity-bus", ssl=client_ssl) as ws:
+            assert not ws.closed
+    # (b) a plaintext / no-cert client is rejected (mTLS required).
+    with pytest.raises((aiohttp.ClientConnectorError, ssl.SSLError, aiohttp.ClientError,
+                        ConnectionResetError, aiohttp.WSServerHandshakeError)):
+        no_verify = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        no_verify.check_hostname = False
+        no_verify.verify_mode = ssl.CERT_NONE
+        async with aiohttp.ClientSession() as s:
+            # No client cert loaded -> server's CERT_REQUIRED rejects.
+            async with s.ws_connect(f"wss://{host}:{port}/ws/trinity-bus", ssl=no_verify) as ws:
+                await ws.receive()
+    await tserver.close()
+
+
+async def test_two_os_process_server_exchanges_events():
+    portfile = os.path.join(tempfile.mkdtemp(prefix="jarvis-smoke-"), "port")
+    env = dict(os.environ)
+    env.update({
+        "JARVIS_BRAIN_WS_HOST": "127.0.0.1",
+        "JARVIS_BRAIN_WS_PORT": "0",
+        "JARVIS_BRAIN_WS_TLS_ENABLED": "false",
+        "JARVIS_BRAIN_WS_PORTFILE": portfile,
+        "JARVIS_BRAIN_WS_SOURCE_ID": "brain-proc",
+    })
+    repo_root = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True,
+    ).stdout.strip()
+    proc = subprocess.Popen(
+        [sys.executable, "-m",
+         "backend.core.ouroboros.governance.transport._smoke_server"],
+        env=env, cwd=repo_root,
+    )
+    try:
+        # Wait for the child to write its bound port.
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not os.path.exists(portfile):
+            await asyncio.sleep(0.1)
+        assert os.path.exists(portfile), "smoke server never bound"
+        with open(portfile) as fh:
+            port = int(fh.read().strip())
+
+        client_broker = StreamEventBroker(history_maxlen=1024)
+        from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+        cfg = _tls_cfg(tls_enabled=False, tls_ephemeral=False)
+        url = f"ws://127.0.0.1:{port}/ws/trinity-bus"
+        client = BusBridgeClient(client_broker, cfg, url=url)
+        run_task = asyncio.ensure_future(client.run())
+        try:
+            deadline = asyncio.get_event_loop().time() + 8.0
+            got = False
+            while asyncio.get_event_loop().time() < deadline:
+                if any(e.op_id == "op-smoke" for e in client_broker.recent_history()):
+                    got = True
+                    break
+                await asyncio.sleep(0.1)
+            assert got, "no events crossed the two-process boundary"
+        finally:
+            await client.stop()
+            run_task.cancel()
+            try:
+                await run_task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+```
+
+- [ ] **Step 3: Run test to verify it fails, then implement fixes, then passes**
+
+Run: `python3 -m pytest tests/governance/transport/test_two_process_loopback.py -v`
+Expected FIRST: FAIL — `ModuleNotFoundError` on `_smoke_server` until Step 1 saved; then possibly TLS-context wiring. Fix in `_smoke_server.py`/`transport_security.py` (not by relaxing the mTLS-required assertion).
+Expected AFTER: PASS (2 passed).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/transport/_smoke_server.py tests/governance/transport/test_two_process_loopback.py
+git commit -m "test(transport): two-process loopback smoke + mTLS-required handshake (Stage 0)"
+```
+
+---
+
+## Task 10: Full-suite gate + progress ledger
+
+**Files:**
+- Modify: `.superpowers/sdd/progress.md` (append Stage 0 completion)
+
+- [ ] **Step 1: Run the whole transport suite + the invariant suite together**
+
+Run: `python3 -m pytest tests/governance/transport/ tests/governance/test_transport_invariants.py -v`
+Expected: all pass. Record the count.
+
+- [ ] **Step 2: Confirm the master switch keeps Stage 0 dark**
+
+Run: `python3 -c "import os; os.environ.pop('JARVIS_DISTRIBUTED_BUS_ENABLED', None); from backend.core.ouroboros.governance.transport import distributed_bus_enabled; assert distributed_bus_enabled() is False; print('Stage 0 ships dark: OK')"`
+Expected: `Stage 0 ships dark: OK`
+
+- [ ] **Step 3: Confirm no live boot path imports the transport** (nothing wired in yet)
+
+Run: `grep -rnE "governance\.transport|DistributedEventBus" backend --include=*.py | grep -v "governance/transport/" | grep -v "/tests/"`
+Expected: no matches (the subpackage is self-contained; nothing in the running organism references it until Stage 2).
+
+- [ ] **Step 4: Append the ledger entry and commit**
+
+```bash
+# Append a Stage 0 completion block to .superpowers/sdd/progress.md, then:
+git add .superpowers/sdd/progress.md
+git commit -m "docs(ledger): Stage 0 transport substrate complete (dark; N tests green)"
+```
+
+---
+
+## Self-Review
+
+**1. Spec coverage** (against `2026-07-03-gcp-orchestrator-relocation-design.md` §Staging item 0 + §Testing Strategy + the three user invariants):
+- Bidirectional WS bridge over `StreamEventBroker` → Tasks 4, 5, 6. ✓
+- `TrinityEventBus` network-transport adapter (publish here → subscribers there) → Task 6 (`DistributedEventBus`). ✓
+- Exact `Last-Event-ID` replay → Task 4 (server replay via broker) + Task 5 (contiguous resume) + Task 7 (hostile-net proof). ✓
+- Heartbeat → Task 5 (`_pump_inbound` timeout + degraded flip) + broker `stream_iter` heartbeat. ✓
+- Drop-oldest backpressure → inherited from `StreamEventBroker` (Task 4/5 use its `subscribe`/`stream_iter`; the `stream_lag` behavior is the broker's, unchanged). ✓
+- mTLS with dynamically-resolved material → Task 2 + Task 9 (handshake required). ✓ User invariant #3 (crypto material dynamic). The ephemeral `/32` firewall is explicitly deferred to Stage 1 and noted in Global Constraints. ✓
+- Static AST invariant blocking real-time actuation from remote transport → Task 8. ✓ User invariant #1.
+- All thresholds dynamic / no hardcoding → Task 1 (env-resolved config) + Task 8 (no-hardcoded-endpoint invariant). ✓ User invariant #2.
+- Hostile-network simulation (latency, jitter, out-of-order, partial drop) → Task 7 `HostileProxy`. ✓
+- Loopback two-process scope, no VM, no sensor migration → Task 9 (two-process), and Task 10 Step 3 proves nothing is wired into the live loop. ✓
+
+**2. Placeholder scan:** No "TBD"/"implement later". Task 8 Step 1 requires confirming the actual Ghost Hands controller filename before writing the `target_file` — that is a lookup step with an exact command, not a placeholder. All code blocks are complete.
+
+**3. Type consistency:** `TransportConfig` field names are identical across Tasks 1-9. `BusFrame` kind constants (`FRAME_HELLO`/`FRAME_EVENT`/`FRAME_HEARTBEAT`/`FRAME_ACK`) used consistently. `StreamEventBroker.publish(event_type, op_id, payload)` and `.subscribe(op_id_filter, last_event_id)` and `.stream_iter(sub, heartbeat_s)` match the real signatures read from `ide_observability_stream.py`. Validator signature `(ast.Module, str) -> Tuple[str, ...]` matches the `ShippedCodeValidator` contract. `recent_history()` is flagged in Task 6 Step 1 for signature confirmation (it exists at `ide_observability_stream.py:1861`).
+
+**Known verification points for the implementer** (surfaced, not hidden):
+- `StreamEventBroker.recent_history()` exact parameters — confirm at first use (Task 6).
+- The real-time actuation controller module path under `backend/ghost_hands/` — confirm in Task 8 Step 1 before registering the invariant.
+- `TestServer.start_server(ssl=...)` / `TCPSite(..., ssl_context=...)` argument names are aiohttp-version-dependent — if the installed aiohttp rejects the kwarg, use the version's documented spelling (`ssl` vs `ssl_context`); this does not change the design.

--- a/docs/superpowers/plans/2026-07-03-stage0-transport-substrate.md
+++ b/docs/superpowers/plans/2026-07-03-stage0-transport-substrate.md
@@ -721,7 +721,7 @@ async def test_server_replays_history_since_last_event_id():
     broker = StreamEventBroker(history_maxlen=100)
     # Pre-load three events into history.
     id1 = broker.publish("task_started", "op-1", {"n": 1})
-    id2 = broker.publish("task_progress", "op-1", {"n": 2})
+    id2 = broker.publish("task_updated", "op-1", {"n": 2})
     id3 = broker.publish("task_completed", "op-1", {"n": 3})
     sink = []
     server, client = await _mk_client(broker, _cfg(), sink)
@@ -1544,7 +1544,7 @@ async def test_replay_is_exact_across_drop_and_reorder():
         # Publish 12 events on the server. The proxy drops mid-stream;
         # the client must reconnect and replay the gap from Last-Event-ID.
         for i in range(12):
-            eid = server_broker.publish("task_progress", "op-hostile", {"i": i})
+            eid = server_broker.publish("task_updated", "op-hostile", {"i": i})
             published.append(eid)
             await asyncio.sleep(0.02)
         # Give reconnect + replay time to converge.
@@ -1805,7 +1805,7 @@ async def _main() -> None:
         with open(portfile, "w") as fh:
             fh.write(str(bound))
     for i in range(1000):
-        broker.publish("task_progress", "op-smoke", {"i": i})
+        broker.publish("task_updated", "op-smoke", {"i": i})
         await asyncio.sleep(0.1)
 
 

--- a/docs/superpowers/specs/2026-07-03-gcp-orchestrator-relocation-design.md
+++ b/docs/superpowers/specs/2026-07-03-gcp-orchestrator-relocation-design.md
@@ -1,0 +1,114 @@
+# GCP Orchestrator Relocation — Distributed Body/Brain Design
+
+**Date:** 2026-07-03
+**Status:** DRAFT — awaiting user approval (brainstorming gate; no implementation until approved)
+**Author:** O+V campaign (Claude, for Derek J. Russell)
+**Supersedes:** the discarded local process-isolation design (rejected: N isolated Python runtimes would exhaust the M1's 16GB unified memory → swap-thrash, trading a CPU bottleneck for an I/O one).
+
+## Problem
+
+The Ouroboros governance brain — orchestrator event loop, FSM pipeline, 16 sensors, posture/semantic/cost observers, cognitive components — runs in one process on a 16GB M1 Mac. Two hard ceilings, proven across the A1 campaign:
+
+1. **GIL contention** — five point-fixed starvation tiers plus a sixth un-instrumented 81s stall; sync/CPU work on any subsystem stalls the control-plane loop. Non-convergent.
+2. **Memory** — the M1's 16GB unified memory cannot host the brain's full working set alongside the macOS Body; local process isolation would multiply the runtime footprint into swap.
+
+Both dissolve if the brain runs on a right-sized cloud CPU VM and the Mac serves purely as the **macOS-native Body** (screen/voice/keyboard/Ghost Hands) + **operator console**, decoupled across an async network boundary.
+
+## Goal
+
+A **pure distributed client-server architecture**: the governance Brain runs on a GCP CPU VM with its own compute/memory; the Mac Body captures/actuates locally and streams events to the Brain over an async, self-healing transport. Network partitions degrade gracefully and reconcile on reconnect **without corrupting the FSM ledger**. No local emulation of the cloud; no hardcoded endpoints; no brittle polling.
+
+## Non-Goals (YAGNI)
+
+- Not moving the macOS Body — screen capture, voice I/O, keyboard, Ghost Hands need Mac APIs and stay local by definition.
+- Not moving J-Prime inference (separate L4 GPU node; the Brain VM is CPU-only). The Brain *calls* DW/J-Prime as it does today.
+- Not the hedge-governor batch-vs-RT routing fix (queued as the immediately-following slice per user).
+- Not a new messaging protocol — we extend `TrinityEventBus` across the wire, not replace it.
+
+## Architecture
+
+```
+┌─ Mac — Body + Operator Console (local) ──────┐            ┌─ GCP CPU VM — Governance Brain (persistent) ─┐
+│  Ghost Hands (screen/voice/keyboard actuate) │            │  Ouroboros orchestrator + FSM pipeline        │
+│  Body-DEPENDENT sensors:                     │  async WS  │  Body-INDEPENDENT sensors (TestFailure,       │
+│    VisionSensor (needs screen frames),       │◄══════════►│    GitHubIssue, Backlog, DocStaleness, …)     │
+│    VoiceCommand (needs mic)                  │  (Trinity  │  posture / semantic / cost observers          │
+│  SerpentFlow operator REPL/TUI               │   EventBus │  cognitive components                         │
+│  Local TrinityEventBus + durable WAL queue   │   bridge)  │  GCP TrinityEventBus + EventChannelServer     │
+│  WS client + Reachability discovery          │            │  mutation-target repo clone (/opt/trinity/…)  │
+└───────────────────────────────────────────────┘           └───────────────────────────────────────────────┘
+```
+
+### The split (what runs where)
+- **Mac (Body + console):** Ghost Hands actuation; the two Body-dependent sensors (`VisionSensor` reads the Ferrari frame server; `VoiceCommand` reads the mic); the SerpentFlow operator REPL/TUI; a local `TrinityEventBus`; a durable local event WAL; the WS client.
+- **GCP Brain VM:** the orchestrator + full FSM pipeline; the 14 Body-independent sensors; posture/semantic/cost observers; cognitive components; the GCP `TrinityEventBus`; `EventChannelServer` (already hosts webhooks + `/observability/*`) now also hosting the WS server; the **mutation-target repo clone** at `/opt/trinity/jarvis` (the `IsomorphicEnv` path pattern, now the primary runtime rather than a soak sandbox).
+
+### Mutation target (resolves "where does O+V write")
+O+V mutates code on the **Brain VM's own repo clone** (`/opt/trinity/jarvis`), commits with the O+V signature (`AutoCommitter`), and pushes via the sovereign cross-repo mutator (Immutable-Orange rules preserved). The Mac's local repo is the operator's working copy, which pulls Brain-authored commits. This reuses the already-proven `IsomorphicEnv` node runtime — the migration promotes it from soak-sandbox to primary.
+
+## Distributed TrinityEventBus (DRY — extend, don't replace)
+
+The core move: `TrinityEventBus` publish/subscribe stays the *only* messaging API. We add a **network transport adapter** that bridges the Mac-local bus and the GCP bus so a `publish()` on either side propagates to subscribers on both — callers are unchanged; only the transport spans a socket.
+
+- **Substrate to reuse:** `StreamEventBroker` (`ide_observability_stream.py`) already provides the exact partition-recovery surface — bounded history ring, **drop-oldest backpressure with a single `stream_lag` event**, **`Last-Event-ID` replay on reconnect**, **heartbeat cadence**, all env-tunable. The bridge is a thin bidirectional WS layer over this broker rather than net-new plumbing. `EventChannelServer` already runs the aiohttp server that will host the WS endpoint alongside the webhooks it already serves.
+- **Direction of flow:** Mac→Brain carries Body sensor signals (Vision/Voice `SignalEnvelope`s — already serializable) + operator console commands (`/cancel`, `/posture`, `/attach`, approvals). Brain→Mac carries actuation intents (Ghost Hands: click/type/narrate), NOTIFY_APPLY diff previews, streaming generation tokens for the console, and posture/status telemetry for the TUI.
+
+## Transport & Discovery (async, no hardcoded IP)
+
+- **Async WS** (aiohttp — already a dependency). No blocking calls on either event loop; the Mac's UI and the Brain's loop both stay responsive under latency.
+- **Service discovery — no hardcoded IP:** the Mac discovers the Brain VM's endpoint the same way the failover path already discovers J-Prime — `gcp_compute_rest.get_node_endpoints()` (zone-aware natIP/internal-IP lookup) + the **Reachability Racer** (`failover_lifecycle`) that probes candidate endpoints concurrently and binds the first healthy 200. A stable Brain-VM name/label is resolved to its current IP dynamically at connect time and on every reconnect.
+- **Reconnect:** exp-backoff + jitter (the VS Code/Sublime extensions' proven client pattern), with `Last-Event-ID` replay so no event is missed across a blip.
+
+## Bulletproof — Network Partition Semantics
+
+Distributed faults are the design's hardest requirement. Structural coverage:
+
+1. **Brain unreachable (partition or VM down):**
+   - The Mac Body **keeps capturing** (screen/voice) and **queues signals to a durable local WAL** (reuse the intake WAL persistence pattern — append-only, fsync'd).
+   - The console degrades gracefully: it surfaces "Brain offline — N signals queued" and continues local-only functions (screen capture, history). No new autonomous ops start (correct — the FSM lives on the Brain).
+   - No busy-poll: reconnect is exp-backoff; discovery re-races on each attempt.
+2. **Reconnect + state-sync WITHOUT FSM-ledger corruption:**
+   - Every event carries a **monotonic, per-source event ID** (already the `Last-Event-ID` contract). On reconnect the Mac replays its WAL from the last Brain-acked ID; the Brain **deduplicates by event ID** (idempotent ingest — the intake router already dedups).
+   - The FSM ledger is **authoritative on the Brain** and already crash-safe: strict Two-Phase Commit + the cryptographic phantom-write gate + HMAC-signed checkpoints. Replayed events re-enter intake as *signals*, not as ledger writes — they cannot corrupt terminal states. An op suspended when the partition hit resumes from its signed checkpoint (the suspend/resume machinery proven live this campaign).
+3. **Split-brain avoidance:** the Brain is the single writer of the FSM ledger and the single mutator of the repo clone. The Mac never writes the ledger; it only emits signals and renders console/actuation. There is exactly one authority — no reconciliation conflict is possible by construction.
+4. **Heartbeat both directions:** WS ping/pong; a missed heartbeat window flips each side to degraded mode deterministically (no ambiguous half-open sockets).
+
+## Leverage-Existing Map (DRY)
+
+| Need | Reuse |
+|---|---|
+| WS server host | `EventChannelServer` (already aiohttp, serves webhooks + `/observability/*`) |
+| Bounded broker + replay + heartbeat + backpressure | `StreamEventBroker` / `IDEStreamRouter` (`ide_observability_stream.py`) |
+| Reconnect client (backoff+jitter, Last-Event-ID) | VS Code/Sublime/JetBrains extension clients (`extensions/*`) |
+| Endpoint discovery (no hardcoded IP) | `gcp_compute_rest.get_node_endpoints` + `failover_lifecycle` Reachability Racer |
+| Brain-VM provisioning | `gcp_compute_rest` / golden-image bake (CPU node variant of the J-Prime bake) |
+| Brain-side repo runtime | `IsomorphicEnv` (`/opt/trinity/jarvis`), promoted from sandbox to primary |
+| Durable local queue | intake WAL persistence pattern |
+| Messaging API | `TrinityEventBus` publish/subscribe (unchanged; transport adapter added) |
+
+## Staging (each stage independently shippable + testable)
+
+0. **Transport substrate.** Bidirectional WS bridge over `StreamEventBroker` + a `TrinityEventBus` network-transport adapter (publish here → subscribers there). TDD: local two-process loopback proving publish/subscribe crosses the socket, `Last-Event-ID` replay, heartbeat, drop-oldest backpressure. No relocation yet.
+1. **Brain-VM provisioning + repo runtime.** CPU golden-image node hosting the orchestrator + `/opt/trinity/jarvis`; discovery wired (Racer). Orchestrator boots headless on the VM, reachable via WS. Mac still runs everything locally — VM is a warm standby.
+2. **Move Body-independent sensors + observers + FSM to the Brain VM.** The 14 non-Body sensors, posture/semantic/cost, cognitive components, and the FSM pipeline run on the VM. The Mac runs only Vision/Voice sensors + console + Ghost Hands, streaming over WS. Live soak: `ControlPlaneStarvation` on the **Mac** → ~0 (the brain's compute is gone); Brain-VM loop censused separately.
+3. **Partition hardening + cutover.** Local WAL, degrade/reconnect/replay, heartbeat-driven degraded mode, split-brain-free single-writer proof. The deliberate-partition test (kill the WS mid-op, assert: Body queues, op suspends to signed checkpoint, reconnect replays, FSM ledger uncorrupted) is the proof the distributed guarantee holds.
+
+## Testing Strategy
+
+- **Partition simulation** (load-bearing): sever the WS mid-op → assert Mac WAL queues signals, the in-flight op suspends to a signed checkpoint, reconnect replays from last-acked ID, the FSM ledger shows no torn/duplicated terminal state.
+- Transport: publish/subscribe crosses the process/socket boundary; `Last-Event-ID` replay is exact; drop-oldest emits a single lag event; heartbeat-miss flips degraded deterministically.
+- Discovery: no hardcoded IP anywhere (grep-enforced invariant, like the existing authority-invariant greps); a VM IP change is picked up on reconnect.
+- Idempotency: replayed events dedup (no double-enqueue); single-writer (Mac never writes the ledger — AST/grep-enforced).
+- Live soak per stage with `ControlPlaneStarvation` census on both hosts.
+
+## Risks / Open Questions (for user review)
+
+1. **Latency budget.** Body→Brain→actuation round-trips now cross a network. For autonomous code ops (the A1 path) this is fine (seconds-scale). For real-time Ghost Hands actuation driven by Vision, added RTT may matter — is real-time visual actuation in scope, or is the Brain's role autonomous code-dev (latency-tolerant)? **Recommend:** scope the WS to autonomous-dev signals first; keep any hard-real-time Body loop local.
+2. **Cost.** A persistent CPU Brain VM runs 24/7 (unlike the ephemeral failover node). Right-size (e.g. `e2-standard-4`/`e2-highmem-4`) + an idle-suspend policy? Or on-demand-per-session?
+3. **The repo-clone sync model.** Brain mutates `/opt/trinity/jarvis` and pushes; the Mac pulls. Confirm the operator is comfortable that autonomous commits originate from the VM's clone (the sovereign cross-repo mutator's Immutable-Orange rules still gate merges).
+4. **Secrets/auth on the VM** (DW keys, GitHub, gcloud ADC) — the golden-image + metadata pattern already handles this for J-Prime; confirm reuse.
+5. **Security of the WS boundary** — loopback-only won't work across hosts; needs auth (token/mTLS) + the ephemeral-/32-firewall pattern already used for the J-Prime mesh.
+
+## Decision needed from user
+
+Approve this distributed Body/Brain design (Approach B), or adjust the open questions above (esp. #1 latency scope, #2 cost/lifecycle, #5 WS auth) before I invoke `writing-plans` for Stage 0 (the transport substrate — shippable with no relocation).

--- a/tests/governance/test_slice48_target_stratification.py
+++ b/tests/governance/test_slice48_target_stratification.py
@@ -369,3 +369,78 @@ def test_trigger_sentinels_lifecycle(tmp_path: Path) -> None:
     assert _ts.trigger_coverage_index_build(tmp_path) == (
         "skipped_failed_cooldown"
     )
+
+
+# ── Fix 1: _CoverageIndex survives the ProcessPoolExecutor boundary ──────
+def test_coverage_index_pickle_roundtrip(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The build now dispatches with ``cpu_bound=True`` (process pool) so the
+    ``_CoverageIndex`` return crosses a pickle boundary. Prove a representative
+    index round-trips byte-faithfully — including the ``ast_map``'s
+    ``List[Path]`` values (Path is picklable) — so the process-pool path is
+    structurally sound without needing to actually spawn a worker.
+    """
+    import pickle
+
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    src = tmp_path / "backend" / "core" / "widget.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("def some_func():\n    return 1\n")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    (tmp_path / "tests" / "test_other.py").write_text(
+        "from backend.core.widget import some_func\ndef t(): pass\n"
+    )
+
+    idx = _ts._build_coverage_index_sync(
+        _ts._resolve_scan_root(tmp_path), _ts._strat_test_dir_names(),
+    )
+    restored = pickle.loads(pickle.dumps(idx))
+
+    assert isinstance(restored, _ts._CoverageIndex)
+    assert restored.names_set == idx.names_set
+    assert restored.names_sorted == idx.names_sorted
+    assert restored.ast_map == idx.ast_map
+    assert restored.built_at == idx.built_at
+    # ast_map values are List[Path] — confirm Path objects survived the trip.
+    assert restored.ast_map  # non-empty (test_other imports the module)
+    for paths in restored.ast_map.values():
+        for p in paths:
+            assert isinstance(p, Path)
+
+
+# ── Fix 3: create_task scheduling failure must release the building flag ──
+@pytest.mark.asyncio
+async def test_trigger_create_task_failure_releases_building_flag(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """If ``loop.create_task`` raises, the ``scan_root`` flag (added under the
+    lock before scheduling) must be discarded — otherwise every future trigger
+    returns ``skipped_running`` forever and the repo is wedged out of ever
+    rebuilding its coverage index.
+    """
+    import asyncio
+
+    _ts.reset_coverage_index()
+    loop = asyncio.get_running_loop()
+
+    def _boom(*a, **k):
+        raise RuntimeError("synthetic create_task scheduling failure")
+
+    monkeypatch.setattr(loop, "create_task", _boom)
+    result = _ts.trigger_coverage_index_build(tmp_path)
+    assert result == "skipped_no_loop"  # scheduling fault → non-started sentinel
+
+    scan_root = _ts._resolve_scan_root(tmp_path)
+    with _ts._COVERAGE_IDX_LOCK:
+        assert scan_root not in _ts._coverage_index_building, (
+            "building flag leaked after create_task failure — repo wedged in "
+            "perpetual skipped_running"
+        )
+
+    # Not wedged: with create_task restored a fresh trigger can proceed again
+    # (i.e. NOT skipped_running).
+    monkeypatch.undo()
+    assert _ts.trigger_coverage_index_build(tmp_path) != "skipped_running"
+    _ts.reset_coverage_index()

--- a/tests/governance/test_slice48_target_stratification.py
+++ b/tests/governance/test_slice48_target_stratification.py
@@ -261,3 +261,111 @@ def test_analyze_file_stamps_coverage(tmp_path: Path) -> None:
     assert covered.has_test_coverage is True
     assert uncovered.has_test_coverage is False
     assert none_root.has_test_coverage is True  # unknown → no penalty
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Tier-4 — off-loop coverage index (warm fast path parity + lifecycle).
+# The index answers Strategy 1 via set/bisect lookups and Strategy 2 via
+# the prebuilt AST map — it must be semantically identical to the legacy
+# filesystem scan for every case above.
+# ═══════════════════════════════════════════════════════════════════════
+import time as _time
+
+import backend.core.ouroboros.governance.target_stratification as _ts
+
+
+@pytest.fixture(autouse=True)
+def _tier4_reset_index_state():
+    _ts.reset_coverage_index()
+    _strat_ast_cache.clear()
+    yield
+    _ts.reset_coverage_index()
+    _strat_ast_cache.clear()
+
+
+def _install_index(root: Path) -> None:
+    """Build + install the coverage index synchronously (test-only shortcut)."""
+    idx = _ts._build_coverage_index_sync(
+        _ts._resolve_scan_root(root), _ts._strat_test_dir_names(),
+    )
+    with _ts._COVERAGE_IDX_LOCK:
+        _ts._coverage_index[_ts._resolve_scan_root(root)] = idx
+
+
+@pytest.mark.parametrize("covered_case", ["exact", "suffix", "ast", "none"])
+def test_warm_index_parity_with_legacy_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch, covered_case: str,
+) -> None:
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    src = tmp_path / "backend" / "core" / "widget.py"
+    src.parent.mkdir(parents=True)
+    src.write_text("def some_func():\n    return 1\n")
+    (tmp_path / "tests").mkdir()
+    if covered_case == "exact":
+        (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    elif covered_case == "suffix":
+        (tmp_path / "tests" / "test_widget_slice4.py").write_text(
+            "def test_x(): pass\n"
+        )
+    elif covered_case == "ast":
+        (tmp_path / "tests" / "test_other.py").write_text(
+            "from backend.core.widget import some_func\n"
+            "def test_it(): assert some_func() is not None\n"
+        )
+
+    legacy = file_has_test_coverage("backend/core/widget.py", tmp_path)
+    _strat_ast_cache.clear()  # legacy run may have warmed it — isolate
+
+    _install_index(tmp_path)
+    warm = file_has_test_coverage("backend/core/widget.py", tmp_path)
+
+    assert warm == legacy == (covered_case != "none")
+
+
+def test_warm_index_answers_without_filesystem_scan(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)
+
+    # Sever the traversal paths entirely — a warm index must not walk.
+    def _boom(*a, **k):
+        raise AssertionError("filesystem traversal ran despite warm index")
+
+    monkeypatch.setattr(_ts, "_iter_test_files", _boom)
+    monkeypatch.setattr(_ts, "_strat_build_ast_map", _boom)
+    monkeypatch.setattr(Path, "rglob", _boom)
+
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+    assert file_has_test_coverage("backend/core/nope.py", tmp_path) is False
+
+
+def test_index_master_switch_off_restores_legacy_path(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)
+    monkeypatch.setenv("JARVIS_STRATIFICATION_INDEX_ENABLED", "false")
+    # Index ignored (lookup returns None) → legacy scan still answers.
+    assert _ts.coverage_index_ready(tmp_path) is False
+    assert _ts.trigger_coverage_index_build(tmp_path) == "skipped_disabled"
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+
+
+def test_trigger_sentinels_lifecycle(tmp_path: Path) -> None:
+    # No running loop → sync callers can't schedule a task.
+    assert _ts.trigger_coverage_index_build(tmp_path) == "skipped_no_loop"
+    # Fresh index within TTL → skipped.
+    _install_index(tmp_path)
+    assert _ts.trigger_coverage_index_build(tmp_path) == "skipped_fresh"
+    # Failure cooldown → skipped.
+    _ts.reset_coverage_index()
+    with _ts._COVERAGE_IDX_LOCK:
+        _ts._coverage_index_failed_at[_ts._resolve_scan_root(tmp_path)] = (
+            _time.time()
+        )
+    assert _ts.trigger_coverage_index_build(tmp_path) == (
+        "skipped_failed_cooldown"
+    )

--- a/tests/governance/test_slice49_ingest_stratification.py
+++ b/tests/governance/test_slice49_ingest_stratification.py
@@ -82,3 +82,247 @@ def test_compute_priority_deprioritizes_huge_uncovered(tmp_path: Path) -> None:
 
     # lower int = higher priority; the huge uncovered op must rank WORSE
     assert p_huge > p_small
+
+
+# ═══════════════════════════════════════════════════════════════════════
+# Tier-4 loop-starvation fix — the stratification coverage scan must NEVER
+# run synchronously on the event loop inside ingest.
+#
+# Traced mechanism (bt-iso-1783102490): _ingest_impl → _compute_priority →
+# ingest_priority_penalty → file_has_test_coverage, whose Strategy 1 does
+# sorted(top.rglob("test_*.py")) over the FULL tests/ tree (~2,839 files)
+# on EVERY call, and whose Strategy 2 cold-builds an AST import map by
+# reading + ast.parse-ing ALL test files (~963K lines) on the FIRST miss —
+# the observed 41,713 ms single on-loop block.
+#
+# Fix contract:
+#   * ingest proceeds DEGRADED (penalty override 0, no evidence stash)
+#     until the coverage index is built off-loop (single-flight);
+#   * once warm, the penalty is computed via the offload substrate
+#     (pure in-memory index lookups in a worker thread);
+#   * file_has_test_coverage is never invoked on the loop thread by ingest;
+#   * builder failure is fail-soft: ingest still returns "enqueued".
+# ═══════════════════════════════════════════════════════════════════════
+import asyncio
+import threading
+import time
+from unittest.mock import AsyncMock, MagicMock
+
+import backend.core.ouroboros.governance.target_stratification as ts
+from backend.core.ouroboros.governance.intake.intent_envelope import make_envelope
+from backend.core.ouroboros.governance.intake.unified_intake_router import (
+    IntakeRouterConfig,
+    UnifiedIntakeRouter,
+)
+
+
+def _mk_router(tmp_path: Path):
+    gls = MagicMock()
+    gls.submit = AsyncMock()
+    config = IntakeRouterConfig(project_root=tmp_path, dedup_window_s=60.0)
+    return UnifiedIntakeRouter(gls=gls, config=config)
+
+
+def _mk_env(rel: str, n: int = 0):
+    return make_envelope(
+        source="backlog",
+        description=f"improve module {n}",
+        target_files=(rel,),
+        repo="jarvis",
+        confidence=0.5,
+        urgency="normal",
+        evidence={"signature": f"sig-{n}-{time.monotonic()}"},
+        requires_human_ack=False,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _reset_coverage_index_state():
+    """Isolate per-test module-level coverage-index state (fail-soft pre-fix)."""
+    reset = getattr(ts, "reset_coverage_index", None)
+    if reset is not None:
+        reset()
+    ts._strat_ast_cache.clear()
+    yield
+    if reset is not None:
+        reset()
+    ts._strat_ast_cache.clear()
+
+
+async def _hb_gaps(run_coro, cadence: float = 0.02):
+    """Run ``run_coro`` while measuring event-loop heartbeat gaps."""
+    gaps: list = []
+    stop = asyncio.Event()
+
+    async def _hb() -> None:
+        last = time.monotonic()
+        while not stop.is_set():
+            await asyncio.sleep(cadence)
+            now = time.monotonic()
+            gaps.append(now - last)
+            last = now
+
+    hb = asyncio.create_task(_hb())
+    try:
+        result = await run_coro
+    finally:
+        stop.set()
+        await hb
+    return result, gaps
+
+
+# ── RED §6: the coverage scan must not execute on the loop thread ───────
+@pytest.mark.asyncio
+async def test_ingest_never_runs_coverage_scan_on_loop_thread(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
+    router = _mk_router(tmp_path)
+
+    loop_thread = threading.get_ident()
+    on_loop_calls = {"n": 0}
+    real = ts.file_has_test_coverage
+
+    def slow_spy(*a, **k):
+        if threading.get_ident() == loop_thread:
+            on_loop_calls["n"] += 1
+        time.sleep(0.4)  # stand-in for the 2,839-file rglob / AST cold build
+        return real(*a, **k)
+
+    monkeypatch.setattr(ts, "file_has_test_coverage", slow_spy)
+
+    result, gaps = await _hb_gaps(router.ingest(_mk_env(rel)))
+    assert result == "enqueued"
+    # The traced bug: file_has_test_coverage ran synchronously on the loop.
+    assert on_loop_calls["n"] == 0, (
+        f"coverage scan executed {on_loop_calls['n']}x on the event-loop "
+        "thread inside ingest (Tier-4 starvation mechanism)"
+    )
+    assert gaps and max(gaps) < 0.3, (
+        f"event loop starved during ingest: max heartbeat gap {max(gaps):.3f}s"
+    )
+
+
+# ── §7: heartbeat keeps ticking while the FIRST-ingest index build runs ──
+@pytest.mark.asyncio
+async def test_loop_responsive_while_first_ingest_index_builds(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
+    router = _mk_router(tmp_path)
+
+    builds = {"n": 0}
+    real_builder = ts._build_coverage_index_sync
+
+    def slow_builder(*a, **k):
+        builds["n"] += 1
+        time.sleep(0.5)  # slow cold build, via the offload substrate
+        return real_builder(*a, **k)
+
+    monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+
+    t0 = time.monotonic()
+    result, gaps = await _hb_gaps(router.ingest(_mk_env(rel)))
+    ingest_wall = time.monotonic() - t0
+
+    assert result == "enqueued"
+    # Degraded-proceed: ingest must NOT wait for the cold build.
+    assert ingest_wall < 0.45, f"ingest blocked on cold index build: {ingest_wall:.3f}s"
+    assert gaps and max(gaps) < 0.3, (
+        f"event loop starved while index built: max gap {max(gaps):.3f}s"
+    )
+    # Build was actually triggered off-loop (single-flight, fire-and-forget).
+    deadline = time.monotonic() + 3.0
+    while builds["n"] == 0 and time.monotonic() < deadline:
+        await asyncio.sleep(0.02)
+    assert builds["n"] == 1
+
+
+# ── §8: N concurrent first-ingests → exactly ONE build, no deadlock ─────
+@pytest.mark.asyncio
+async def test_concurrent_first_ingests_single_flight_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rels = [_mk(tmp_path, f"backend/mod{i}.py", 3000, covered=False) for i in range(6)]
+    router = _mk_router(tmp_path)
+
+    builds = {"n": 0}
+    real_builder = ts._build_coverage_index_sync
+
+    def slow_builder(*a, **k):
+        builds["n"] += 1
+        time.sleep(0.3)
+        return real_builder(*a, **k)
+
+    monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+
+    t0 = time.monotonic()
+    results = await asyncio.wait_for(
+        asyncio.gather(*(router.ingest(_mk_env(r, n=i)) for i, r in enumerate(rels))),
+        timeout=5.0,
+    )
+    wall = time.monotonic() - t0
+
+    assert all(r == "enqueued" for r in results)
+    # Degraded-proceed: none of the 6 waited for the 0.3s build (nor serialized
+    # 6 × inline scans — the pre-fix behavior).
+    assert wall < 1.0, f"concurrent ingests blocked behind index build: {wall:.3f}s"
+    # Ops that ran during the build got the DEGRADED path: no penalty stash.
+    # (Design choice: semantic/stratification priors are advisory — intake
+    # never waits on them; parity returns once the index is warm.)
+    await asyncio.sleep(0.6)  # let the single-flight build finish
+    assert builds["n"] == 1, f"expected exactly ONE build, got {builds['n']}"
+
+
+# ── §9: warm index → penalty parity with the legacy inline path ─────────
+@pytest.mark.asyncio
+async def test_warm_index_restores_penalty_with_evidence(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
+    router = _mk_router(tmp_path)
+
+    # First ingest: cold → degraded, triggers the off-loop build.
+    env1 = _mk_env(rel, n=1)
+    assert await router.ingest(env1) == "enqueued"
+    assert "stratification_penalty" not in env1.evidence  # degraded
+
+    deadline = time.monotonic() + 5.0
+    while not ts.coverage_index_ready(tmp_path) and time.monotonic() < deadline:
+        await asyncio.sleep(0.02)
+    assert ts.coverage_index_ready(tmp_path)
+
+    # Second ingest: warm → penalty computed (off-loop) + evidence stashed,
+    # numerically identical to the legacy inline computation.
+    env2 = _mk_env(rel, n=2)
+    assert await router.ingest(env2) == "enqueued"
+    expected = ts.ingest_priority_penalty([rel], tmp_path)
+    assert expected > 0
+    assert env2.evidence.get("stratification_penalty") == expected
+
+
+# ── §10: builder failure is fail-soft — ingest still enqueues ────────────
+@pytest.mark.asyncio
+async def test_index_build_failure_is_fail_soft(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    rel = _mk(tmp_path, "backend/huge.py", 3000, covered=False)
+    router = _mk_router(tmp_path)
+
+    builds = {"n": 0}
+
+    def broken_builder(*a, **k):
+        builds["n"] += 1
+        raise RuntimeError("synthetic index build failure")
+
+    monkeypatch.setattr(ts, "_build_coverage_index_sync", broken_builder)
+
+    assert await router.ingest(_mk_env(rel, n=1)) == "enqueued"
+    await asyncio.sleep(0.3)  # let the failed build task settle
+    # Still degraded forever (never inline-scans on the loop), still enqueues.
+    env2 = _mk_env(rel, n=2)
+    assert await router.ingest(env2) == "enqueued"
+    assert "stratification_penalty" not in env2.evidence
+    await asyncio.sleep(0.2)
+    # Failure cooldown: no rebuild storm (one attempt within the window).
+    assert builds["n"] == 1

--- a/tests/governance/test_slice49_ingest_stratification.py
+++ b/tests/governance/test_slice49_ingest_stratification.py
@@ -108,12 +108,85 @@ import threading
 import time
 from unittest.mock import AsyncMock, MagicMock
 
+import backend.core.ouroboros.governance.cooperative_fs_io as _cfsio
 import backend.core.ouroboros.governance.target_stratification as ts
 from backend.core.ouroboros.governance.intake.intent_envelope import make_envelope
 from backend.core.ouroboros.governance.intake.unified_intake_router import (
     IntakeRouterConfig,
     UnifiedIntakeRouter,
 )
+
+
+def _patch_inproc_offload(monkeypatch: pytest.MonkeyPatch, seen: dict) -> None:
+    """Route the coverage-index offload through an in-process, off-loop double.
+
+    Fix 1 makes the real build dispatch with ``cpu_bound=True`` → a *spawn*
+    ``ProcessPoolExecutor`` whose worker re-imports the module fresh, so a
+    ``monkeypatch`` of ``_build_coverage_index_sync`` (how these orchestration
+    tests inject slowness/failure and count builds) can never reach the worker
+    process. This double keeps the orchestration under test deterministic and
+    observable in-process while staying faithful on the load-bearing points:
+
+      * it records the dispatch ``cpu_bound`` so these tests still GUARD that
+        Fix 1 stayed ``cpu_bound=True`` (a revert to the thread pool trips the
+        end-of-test assertion), and
+      * it runs the (possibly-monkeypatched) fn via ``asyncio.to_thread`` —
+        genuinely OFF the event loop, in this process — mirroring offload's
+        fail-soft ``OffloadError`` contract on any raise.
+
+    The REAL process-pool + GIL-freeing behaviour is proven separately by
+    ``test_warm_index_restores_penalty_with_evidence`` (real-pool E2E) and
+    ``test_offload_cpu_bound_frees_loop_during_gil_build`` (Fix 2).
+    """
+    async def _fake_offload(fn, *args, cpu_bound=False, **kwargs):
+        # Record cpu_bound ONLY for the coverage-index build dispatch (the
+        # intake path issues other cpu_bound=False offloads that would
+        # otherwise clobber the guard). ``_build_coverage_index_sync`` is the
+        # module global the build task looks up at call time, so it resolves
+        # to whichever (possibly-monkeypatched) builder this test installed.
+        if fn is ts._build_coverage_index_sync:
+            seen["cpu_bound"] = cpu_bound
+        try:
+            return await asyncio.to_thread(fn, *args, **kwargs)
+        except Exception as exc:  # noqa: BLE001 — mirror offload fail-soft
+            return _cfsio.OffloadError(
+                fn_name=getattr(fn, "__name__", repr(fn)),
+                exc_type=type(exc).__name__,
+                message=str(exc),
+                cpu_bound=cpu_bound,
+            )
+
+    monkeypatch.setattr(_cfsio, "offload", _fake_offload)
+
+
+async def _require_process_pool() -> None:
+    """Skip (not fail) when the real ``cpu_bound=True`` process pool can't spawn.
+
+    The cpu_bound offload path needs a spawn ``ProcessPoolExecutor``; a
+    sandboxed / process-creation-restricted test environment makes that
+    unavailable, in which case offload returns a fail-soft ``OffloadError``.
+    Tests that assert the REAL pool's behaviour probe it here and skip with a
+    clear reason rather than reporting a spurious failure (run with the
+    sandbox disabled to exercise them).
+    """
+    probe = await _cfsio.offload(_gil_busy_spin, 0.0, cpu_bound=True)
+    if _cfsio.is_offload_error(probe):
+        pytest.skip(f"process pool unavailable (sandbox?): {probe}")
+
+
+def _gil_busy_spin(duration_s: float, *_a, **_k) -> int:
+    """Module-level (picklable) pure-Python GIL-holding busy spin.
+
+    Spins holding the GIL for ~``duration_s`` — NOT ``time.sleep`` (which
+    releases the GIL). Module-level so it pickles by reference across the
+    spawn process-pool boundary. Stand-in for ``_build_coverage_index_sync``'s
+    real ``ast.parse``-over-963K-lines CPU cost.
+    """
+    end = time.monotonic() + duration_s
+    total = 0
+    while time.monotonic() < end:
+        total += 1
+    return total
 
 
 def _mk_router(tmp_path: Path):
@@ -216,10 +289,12 @@ async def test_loop_responsive_while_first_ingest_index_builds(
 
     def slow_builder(*a, **k):
         builds["n"] += 1
-        time.sleep(0.5)  # slow cold build, via the offload substrate
+        time.sleep(0.5)  # slow cold build, via the (in-process) offload double
         return real_builder(*a, **k)
 
     monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+    seen: dict = {}
+    _patch_inproc_offload(monkeypatch, seen)
 
     t0 = time.monotonic()
     result, gaps = await _hb_gaps(router.ingest(_mk_env(rel)))
@@ -236,6 +311,8 @@ async def test_loop_responsive_while_first_ingest_index_builds(
     while builds["n"] == 0 and time.monotonic() < deadline:
         await asyncio.sleep(0.02)
     assert builds["n"] == 1
+    # Guard Fix 1: the build dispatched with cpu_bound=True (process pool).
+    assert seen.get("cpu_bound") is True
 
 
 # ── §8: N concurrent first-ingests → exactly ONE build, no deadlock ─────
@@ -255,6 +332,8 @@ async def test_concurrent_first_ingests_single_flight_build(
         return real_builder(*a, **k)
 
     monkeypatch.setattr(ts, "_build_coverage_index_sync", slow_builder)
+    seen: dict = {}
+    _patch_inproc_offload(monkeypatch, seen)
 
     t0 = time.monotonic()
     results = await asyncio.wait_for(
@@ -272,6 +351,8 @@ async def test_concurrent_first_ingests_single_flight_build(
     # never waits on them; parity returns once the index is warm.)
     await asyncio.sleep(0.6)  # let the single-flight build finish
     assert builds["n"] == 1, f"expected exactly ONE build, got {builds['n']}"
+    # Guard Fix 1: the build dispatched with cpu_bound=True (process pool).
+    assert seen.get("cpu_bound") is True
 
 
 # ── §9: warm index → penalty parity with the legacy inline path ─────────
@@ -279,6 +360,7 @@ async def test_concurrent_first_ingests_single_flight_build(
 async def test_warm_index_restores_penalty_with_evidence(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    await _require_process_pool()  # real cpu_bound=True pool (sandbox → skip)
     rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
     router = _mk_router(tmp_path)
 
@@ -316,6 +398,8 @@ async def test_index_build_failure_is_fail_soft(
         raise RuntimeError("synthetic index build failure")
 
     monkeypatch.setattr(ts, "_build_coverage_index_sync", broken_builder)
+    seen: dict = {}
+    _patch_inproc_offload(monkeypatch, seen)
 
     assert await router.ingest(_mk_env(rel, n=1)) == "enqueued"
     await asyncio.sleep(0.3)  # let the failed build task settle
@@ -326,3 +410,54 @@ async def test_index_build_failure_is_fail_soft(
     await asyncio.sleep(0.2)
     # Failure cooldown: no rebuild storm (one attempt within the window).
     assert builds["n"] == 1
+    # Guard Fix 1: even the failing build dispatched with cpu_bound=True.
+    assert seen.get("cpu_bound") is True
+
+
+# ── Fix 2: cpu_bound=True frees the loop during a GIL-HOLDING cold build ──
+@pytest.mark.asyncio
+async def test_offload_cpu_bound_frees_loop_during_gil_build(
+    tmp_path: Path,
+) -> None:
+    """A GIL-holding pure-Python build (the real ``ast.parse`` cost class),
+    dispatched through the SAME ``offload(..., cpu_bound=True)`` path the
+    coverage-index build uses, must NOT starve the event loop.
+
+    Unlike the ``time.sleep``-based responsiveness tests (which release the
+    GIL and therefore prove only that intake doesn't *await* the build), this
+    drives a genuine GIL-holding busy-spin. With cpu_bound=True the spin runs
+    in a separate PROCESS, so a concurrent heartbeat coroutine keeps ticking;
+    a thread offload (the pre-Fix-1 behaviour) would hold the GIL for the whole
+    spin and the heartbeat would stall. Requires the real process pool → skips
+    (not fails) where spawn is unavailable (sandboxed env).
+    """
+    await _require_process_pool()
+
+    spin_s = 0.5
+    ticks = {"n": 0}
+    stop = asyncio.Event()
+
+    async def _hb() -> None:
+        while not stop.is_set():
+            await asyncio.sleep(0.02)
+            ticks["n"] += 1
+
+    hb = asyncio.create_task(_hb())
+    try:
+        t0 = time.monotonic()
+        result = await _cfsio.offload(_gil_busy_spin, spin_s, cpu_bound=True)
+        elapsed = time.monotonic() - t0
+    finally:
+        stop.set()
+        await hb
+
+    assert not _cfsio.is_offload_error(result), result
+    assert elapsed >= spin_s * 0.8, (
+        f"busy-spin returned too fast ({elapsed:.3f}s) — did it actually run?"
+    )
+    # ~spin_s / 0.02s ≈ 25 ideal ticks; a thread offload would yield ~0.
+    # Assert a healthy fraction to stay robust to scheduler jitter.
+    assert ticks["n"] >= 10, (
+        f"event loop starved during GIL-holding build: only {ticks['n']} "
+        "heartbeat ticks (process pool did not free the GIL)"
+    )

--- a/tests/governance/test_transport_invariants.py
+++ b/tests/governance/test_transport_invariants.py
@@ -1,0 +1,36 @@
+from __future__ import annotations
+
+import ast
+
+from backend.core.ouroboros.governance.meta.shipped_code_invariants import (
+    _validate_realtime_actuation_no_remote_transport,
+    _validate_transport_no_hardcoded_endpoints,
+)
+
+
+def test_actuation_importing_transport_is_flagged():
+    bad = (
+        "from backend.core.ouroboros.governance.transport import DistributedEventBus\n"
+        "def click(x, y):\n    pass\n"
+    )
+    violations = _validate_realtime_actuation_no_remote_transport(ast.parse(bad), bad)
+    assert violations
+    assert any("transport" in v for v in violations)
+
+
+def test_actuation_without_transport_import_holds():
+    good = "import time\ndef click(x, y):\n    time.sleep(0)\n"
+    violations = _validate_realtime_actuation_no_remote_transport(ast.parse(good), good)
+    assert violations == ()
+
+
+def test_hardcoded_ipv4_in_config_is_flagged():
+    bad = 'HOST = "10.1.2.3"\nURL = "wss://10.1.2.3:8443/ws"\n'
+    violations = _validate_transport_no_hardcoded_endpoints(ast.parse(bad), bad)
+    assert violations
+
+
+def test_env_resolved_config_holds():
+    good = 'import os\nhost = os.environ.get("JARVIS_BRAIN_WS_HOST")\n'
+    violations = _validate_transport_no_hardcoded_endpoints(ast.parse(good), good)
+    assert violations == ()

--- a/tests/governance/transport/hostile_network.py
+++ b/tests/governance/transport/hostile_network.py
@@ -1,0 +1,114 @@
+from __future__ import annotations
+
+import asyncio
+import random
+from typing import List, Optional
+
+from aiohttp import ClientSession, WSMsgType, web
+
+
+class HostileProxy:
+    """WS proxy that degrades the link between a client and the real
+    upstream server. Deterministic (seeded)."""
+
+    def __init__(
+        self,
+        upstream_url: str,
+        *,
+        latency_s: float = 0.0,
+        jitter_s: float = 0.0,
+        reorder_window: int = 1,
+        drop_after: Optional[int] = None,
+        max_hold_s: float = 0.1,
+        seed: int = 1234,
+    ) -> None:
+        self._upstream = upstream_url
+        self._latency = latency_s
+        self._jitter = jitter_s
+        self._reorder_window = max(1, reorder_window)
+        self._drop_after = drop_after
+        # Max-hold for the reorder buffer. A real reorder/jitter buffer
+        # shuffles frames within a window but releases a trailing partial
+        # window after a bounded idle, rather than withholding it until the
+        # connection closes. Without this a persistent (never-dropped)
+        # connection whose replay tail is shorter than reorder_window would
+        # hold the last frames FOREVER -- a phantom "drop the tail" fault
+        # distinct from the four intended faults (latency, jitter, windowed
+        # shuffle, mid-stream drop-close). It is deterministic: the idle
+        # timeout (default 0.1s) is far larger than the live publish cadence
+        # and sub-ms replay bursts, so it never splits a window mid-stream --
+        # it only releases the trailing residual once the upstream is quiet.
+        self._max_hold = max_hold_s
+        self._rng = random.Random(seed)
+
+    def register(self, app: web.Application, path: str) -> None:
+        app.router.add_get(path, self._handle)
+
+    async def _delay(self) -> None:
+        d = self._latency + (self._rng.uniform(0, self._jitter) if self._jitter else 0.0)
+        if d > 0:
+            await asyncio.sleep(d)
+
+    async def _handle(self, request: web.Request) -> web.WebSocketResponse:
+        downstream = web.WebSocketResponse(heartbeat=None)
+        await downstream.prepare(request)
+        session = ClientSession()
+        delivered = 0
+        buf: List[bytes] = []
+        try:
+            async with session.ws_connect(self._upstream, heartbeat=None) as upstream:
+                async def c2u() -> None:
+                    async for msg in downstream:
+                        if msg.type in (WSMsgType.BINARY, WSMsgType.TEXT):
+                            await upstream.send_bytes(
+                                msg.data if isinstance(msg.data, bytes) else msg.data.encode()
+                            )
+                        else:
+                            break
+
+                async def _flush() -> bool:
+                    """Shuffle + deliver the current buffer. Returns False
+                    iff the drop fault fired (connection closed)."""
+                    nonlocal delivered
+                    self._rng.shuffle(buf)
+                    while buf:
+                        if self._drop_after is not None and delivered >= self._drop_after:
+                            await downstream.close()
+                            return False
+                        frame = buf.pop(0)
+                        await downstream.send_bytes(frame)
+                        delivered += 1
+                    return True
+
+                async def u2c() -> None:
+                    while True:
+                        try:
+                            msg = await asyncio.wait_for(
+                                upstream.receive(), timeout=self._max_hold
+                            )
+                        except asyncio.TimeoutError:
+                            # Upstream idle: release the trailing partial window
+                            # (bounded max-hold) so it is never withheld forever.
+                            if buf and not await _flush():
+                                return
+                            continue
+                        if msg.type not in (WSMsgType.BINARY, WSMsgType.TEXT):
+                            break
+                        data = msg.data if isinstance(msg.data, bytes) else msg.data.encode()
+                        await self._delay()
+                        buf.append(data)
+                        if len(buf) >= self._reorder_window and not await _flush():
+                            return
+
+                await asyncio.gather(c2u(), u2c(), return_exceptions=True)
+                # Flush any remaining buffered frames unless we already dropped.
+                for frame in buf:
+                    if self._drop_after is not None and delivered >= self._drop_after:
+                        break
+                    await downstream.send_bytes(frame)
+                    delivered += 1
+        finally:
+            await session.close()
+            if not downstream.closed:
+                await downstream.close()
+        return downstream

--- a/tests/governance/transport/test_bus_bridge_client.py
+++ b/tests/governance/transport/test_bus_bridge_client.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-import pytest
-
 from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
 from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
 from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient

--- a/tests/governance/transport/test_bus_bridge_client.py
+++ b/tests/governance/transport/test_bus_bridge_client.py
@@ -1,0 +1,55 @@
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.5, reconnect_max_s=8.0, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="mac-test",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+def test_backoff_grows_geometrically_and_caps():
+    c = BusBridgeClient(StreamEventBroker(), _cfg())
+    assert c._next_backoff(0) == 0.5
+    assert c._next_backoff(1) == 1.0
+    assert c._next_backoff(2) == 2.0
+    assert c._next_backoff(20) == 8.0  # capped at reconnect_max_s
+
+
+def test_backoff_jitter_stays_in_band():
+    c = BusBridgeClient(StreamEventBroker(), _cfg(reconnect_jitter=0.3))
+    for attempt in range(6):
+        base = min(0.5 * 2 ** attempt, 8.0)
+        val = c._next_backoff(attempt)
+        assert base * 0.7 <= val <= base * 1.3
+
+
+def test_contiguous_advance_leaves_gaps_for_replay():
+    c = BusBridgeClient(StreamEventBroker(), _cfg())
+    assert c.last_event_id is None
+    c._advance_contiguous(format(1, "012x"))
+    assert c.last_event_id == format(1, "012x")
+    c._advance_contiguous(format(2, "012x"))
+    assert c.last_event_id == format(2, "012x")
+    # A gap (skip 3, receive 4) must NOT advance the high-water past 2.
+    c._advance_contiguous(format(4, "012x"))
+    assert c.last_event_id == format(2, "012x")  # replay will refetch 3,4
+    # Filling the gap advances again.
+    c._advance_contiguous(format(3, "012x"))
+    assert c.last_event_id == format(3, "012x")
+
+
+def test_degraded_defaults_false():
+    c = BusBridgeClient(StreamEventBroker(), _cfg())
+    assert c.degraded is False

--- a/tests/governance/transport/test_bus_bridge_server.py
+++ b/tests/governance/transport/test_bus_bridge_server.py
@@ -1,0 +1,80 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+    StreamEvent,
+)
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cfg():
+    return TransportConfig(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.5, reconnect_max_s=30.0, reconnect_jitter=0.3,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain-test",
+    )
+
+
+async def _mk_client(broker, cfg, inbound_sink):
+    server = BusBridgeServer(broker, cfg, on_inbound=lambda ev: inbound_sink.append(ev))
+    app = web.Application()
+    server.register_routes(app)
+    client = TestClient(TestServer(app))
+    await client.start_server()
+    return server, client
+
+
+async def test_server_replays_history_since_last_event_id():
+    broker = StreamEventBroker(history_maxlen=100)
+    # Pre-load three events into history.
+    id1 = broker.publish("task_started", "op-1", {"n": 1})
+    id2 = broker.publish("task_updated", "op-1", {"n": 2})
+    id3 = broker.publish("task_completed", "op-1", {"n": 3})
+    sink = []
+    server, client = await _mk_client(broker, _cfg(), sink)
+    try:
+        ws = await client.ws_connect("/ws/trinity-bus")
+        await ws.send_bytes(bf.hello_frame("mac-test", last_event_id=id1).encode())
+        got = []
+        # Expect replay of id2, id3 (everything after id1).
+        for _ in range(2):
+            msg = await asyncio.wait_for(ws.receive(), timeout=2.0)
+            frame = bf.BusFrame.decode(msg.data)
+            if frame and frame.kind == bf.FRAME_EVENT:
+                got.append(frame.event["event_id"])
+        assert got == [id2, id3]
+        await ws.close()
+    finally:
+        await client.close()
+
+
+async def test_server_dedups_replayed_inbound_events():
+    broker = StreamEventBroker(history_maxlen=100)
+    sink = []
+    server, client = await _mk_client(broker, _cfg(), sink)
+    try:
+        ws = await client.ws_connect("/ws/trinity-bus")
+        await ws.send_bytes(bf.hello_frame("mac-test", last_event_id=None).encode())
+        ev = StreamEvent(event_id=format(7, "012x"), event_type="task_started",
+                         op_id="op-9", timestamp="2026-07-03T00:00:00.000Z", payload={})
+        frame = bf.event_frame(ev, source_id="mac-test").encode()
+        await ws.send_bytes(frame)
+        await ws.send_bytes(frame)  # duplicate resend
+        await asyncio.sleep(0.2)
+        assert len(sink) == 1  # deduped by qualified_id
+        assert server.seen_count() == 1
+        await ws.close()
+    finally:
+        await client.close()

--- a/tests/governance/transport/test_bus_frame.py
+++ b/tests/governance/transport/test_bus_frame.py
@@ -1,0 +1,43 @@
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEvent
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+
+
+def _ev(seq: int) -> StreamEvent:
+    return StreamEvent(
+        event_id=format(seq, "012x"),
+        event_type="task_started",
+        op_id="op-1",
+        timestamp="2026-07-03T00:00:00.000Z",
+        payload={"k": "v"},
+    )
+
+
+def test_event_frame_roundtrip_preserves_all_fields():
+    frame = bf.event_frame(_ev(42), source_id="brain-01")
+    raw = frame.encode()
+    back = bf.BusFrame.decode(raw)
+    assert back is not None
+    assert back.kind == bf.FRAME_EVENT
+    assert back.source_id == "brain-01"
+    assert back.seq == 42  # int(event_id, 16)
+    assert back.event["event_id"] == format(42, "012x")
+    assert back.event["payload"] == {"k": "v"}
+
+
+def test_hello_frame_carries_last_event_id():
+    frame = bf.hello_frame("mac-01", last_event_id="0000000000ff")
+    back = bf.BusFrame.decode(frame.encode())
+    assert back.kind == bf.FRAME_HELLO
+    assert back.last_event_id == "0000000000ff"
+
+
+def test_decode_malformed_returns_none_never_raises():
+    assert bf.BusFrame.decode(b"not json") is None
+    assert bf.BusFrame.decode("{}") is None  # missing required kind
+    assert bf.BusFrame.decode(b'{"kind": 123}') is None  # wrong type
+
+
+def test_qualified_id_is_source_scoped():
+    assert bf.qualified_id("mac-01", "0000000000ff") == "mac-01:0000000000ff"

--- a/tests/governance/transport/test_distributed_event_bus.py
+++ b/tests/governance/transport/test_distributed_event_bus.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.distributed_event_bus import DistributedEventBus
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.1, reconnect_max_s=1.0, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain-test",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+async def test_publish_on_server_reaches_client_broker():
+    server_broker = StreamEventBroker(history_maxlen=100)
+    client_broker = StreamEventBroker(history_maxlen=100)
+    server_bus = DistributedEventBus(server_broker, _cfg(source_id="brain"), role="server")
+    app = web.Application()
+    server_bus.register_server_routes(app)
+    tclient = TestClient(TestServer(app))
+    await tclient.start_server()
+    url = str(tclient.make_url("/ws/trinity-bus")).replace("http", "ws")
+
+    client_bus = DistributedEventBus(client_broker, _cfg(source_id="mac"), role="client")
+    run_task = asyncio.ensure_future(client_bus.start_client(url=url))
+    try:
+        await asyncio.sleep(0.3)  # allow connect + hello
+        # Publish on the SERVER; assert it lands in the CLIENT's broker.
+        server_broker.publish("task_started", "op-42", {"hello": "world"})
+        deadline = asyncio.get_event_loop().time() + 3.0
+        found = False
+        while asyncio.get_event_loop().time() < deadline:
+            hist = client_broker.recent_history()
+            if any(e.op_id == "op-42" and e.event_type == "task_started" for e in hist):
+                found = True
+                break
+            await asyncio.sleep(0.05)
+        assert found, "event published on server never reached client broker"
+    finally:
+        await client_bus.stop()
+        run_task.cancel()
+        try:
+            await run_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        await tclient.close()

--- a/tests/governance/transport/test_hostile_network_replay.py
+++ b/tests/governance/transport/test_hostile_network_replay.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+from tests.governance.transport.hostile_network import HostileProxy
+
+pytestmark = pytest.mark.asyncio
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.05, reconnect_max_s=0.5, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=4096, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+async def test_replay_is_exact_across_drop_and_reorder():
+    server_broker = StreamEventBroker(history_maxlen=4096)
+    # Real upstream server hosting the bridge.
+    up_app = web.Application()
+    BusBridgeServer(server_broker, _cfg(source_id="brain")).register_routes(up_app)
+    up = TestClient(TestServer(up_app))
+    await up.start_server()
+    upstream_url = str(up.make_url("/ws/trinity-bus")).replace("http", "ws")
+
+    # Hostile proxy in front of it: reorder in windows of 3, drop the
+    # connection after 5 frames to force a reconnect + Last-Event-ID replay.
+    proxy = HostileProxy(upstream_url, reorder_window=3, drop_after=5,
+                         latency_s=0.001, jitter_s=0.003, seed=7)
+    px_app = web.Application()
+    proxy.register(px_app, "/ws/trinity-bus")
+    px = TestClient(TestServer(px_app))
+    await px.start_server()
+    proxy_url = str(px.make_url("/ws/trinity-bus")).replace("http", "ws")
+
+    client_broker = StreamEventBroker(history_maxlen=4096)
+    client = BusBridgeClient(client_broker, _cfg(source_id="mac"), url=proxy_url)
+    run_task = asyncio.ensure_future(client.run())
+
+    published = []
+    try:
+        await asyncio.sleep(0.2)
+        # Publish 12 events on the server. The proxy drops mid-stream;
+        # the client must reconnect and replay the gap from Last-Event-ID.
+        for i in range(12):
+            eid = server_broker.publish("task_updated", "op-hostile", {"i": i})
+            published.append(eid)
+            await asyncio.sleep(0.02)
+        # Give reconnect + replay time to converge.
+        deadline = asyncio.get_event_loop().time() + 6.0
+        while asyncio.get_event_loop().time() < deadline:
+            got = {e.event_id for e in client_broker.recent_history(limit=500)
+                   if e.op_id == "op-hostile"}
+            if set(published).issubset(got):
+                break
+            await asyncio.sleep(0.1)
+        got_ids = [e.event_id for e in client_broker.recent_history(limit=500)
+                   if e.op_id == "op-hostile"]
+        # EXACT: every published id present, no duplicates.
+        assert set(published).issubset(set(got_ids)), (
+            f"missing after replay: {set(published) - set(got_ids)}"
+        )
+        assert len(got_ids) == len(set(got_ids)), "duplicate events after replay"
+    finally:
+        await client.stop()
+        run_task.cancel()
+        try:
+            await run_task
+        except (asyncio.CancelledError, Exception):
+            pass
+        await px.close()
+        await up.close()

--- a/tests/governance/transport/test_transport_config.py
+++ b/tests/governance/transport/test_transport_config.py
@@ -1,0 +1,66 @@
+from __future__ import annotations
+
+import os
+
+from backend.core.ouroboros.governance.transport.transport_config import (
+    TransportConfig,
+    distributed_bus_enabled,
+)
+
+
+def test_defaults_are_dark_and_sane(monkeypatch):
+    # Clear every knob so we observe pure defaults.
+    for key in list(os.environ):
+        if key.startswith("JARVIS_BRAIN_WS_") or key == "JARVIS_DISTRIBUTED_BUS_ENABLED":
+            monkeypatch.delenv(key, raising=False)
+    assert distributed_bus_enabled() is False  # ships dark
+    cfg = TransportConfig.from_env(role="client")
+    assert cfg.host is None  # no baked endpoint -- must be discovered
+    assert cfg.port == 0  # ephemeral by default
+    assert cfg.path == "/ws/trinity-bus"
+    assert cfg.heartbeat_s == 15.0
+    assert cfg.reconnect_base_s == 0.5
+    assert cfg.reconnect_max_s == 30.0
+    assert 0.0 <= cfg.reconnect_jitter <= 1.0
+    assert cfg.queue_maxsize == 256
+    assert cfg.history_maxlen == 1024
+    assert cfg.degrade_after_missed_hb == 2
+    assert cfg.tls_enabled is True
+    assert cfg.tls_ephemeral is False
+    assert cfg.source_id.startswith("client-")
+
+
+def test_every_threshold_is_env_overridable(monkeypatch):
+    monkeypatch.setenv("JARVIS_DISTRIBUTED_BUS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HOST", "10.1.2.3")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PATH", "/ws/x")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "3.5")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_BASE_S", "0.1")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_MAX_S", "9.0")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_JITTER", "0.5")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_QUEUE_MAXSIZE", "512")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HISTORY_MAXLEN", "2048")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_DEGRADE_AFTER_MISSED_HB", "4")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_EPHEMERAL", "true")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_SOURCE_ID", "brain-01")
+    assert distributed_bus_enabled() is True
+    cfg = TransportConfig.from_env(role="server")
+    assert (cfg.host, cfg.port, cfg.path) == ("10.1.2.3", 8443, "/ws/x")
+    assert cfg.heartbeat_s == 3.5
+    assert (cfg.reconnect_base_s, cfg.reconnect_max_s, cfg.reconnect_jitter) == (0.1, 9.0, 0.5)
+    assert cfg.queue_maxsize == 512
+    assert cfg.history_maxlen == 2048
+    assert cfg.degrade_after_missed_hb == 4
+    assert cfg.tls_enabled is False
+    assert cfg.tls_ephemeral is True
+    assert cfg.source_id == "brain-01"
+
+
+def test_malformed_numeric_falls_back_to_default(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "not-a-number")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "")
+    cfg = TransportConfig.from_env(role="client")
+    assert cfg.heartbeat_s == 15.0  # bad value -> default, never crash
+    assert cfg.port == 0

--- a/tests/governance/transport/test_transport_security.py
+++ b/tests/governance/transport/test_transport_security.py
@@ -3,8 +3,6 @@ from __future__ import annotations
 
 import ssl
 
-import pytest
-
 from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
 from backend.core.ouroboros.governance.transport import transport_security as ts
 

--- a/tests/governance/transport/test_transport_security.py
+++ b/tests/governance/transport/test_transport_security.py
@@ -1,0 +1,43 @@
+# tests/governance/transport/test_transport_security.py
+from __future__ import annotations
+
+import ssl
+
+import pytest
+
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport import transport_security as ts
+
+
+def _cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=15.0,
+        reconnect_base_s=0.5, reconnect_max_s=30.0, reconnect_jitter=0.3,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=True, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=True, source_id="test",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+def test_tls_disabled_returns_none():
+    cfg = _cfg(tls_enabled=False, tls_ephemeral=False)
+    assert ts.build_server_ssl_context(cfg) is None
+    assert ts.build_client_ssl_context(cfg) is None
+
+
+def test_ephemeral_material_builds_a_real_server_context():
+    cfg = _cfg()
+    ctx = ts.build_server_ssl_context(cfg)
+    assert isinstance(ctx, ssl.SSLContext)
+    # mTLS: server demands a client cert.
+    assert ctx.verify_mode == ssl.CERT_REQUIRED
+
+
+def test_no_hardcoded_material_paths_in_module_source():
+    import inspect
+    src = inspect.getsource(ts)
+    # No absolute cert/key paths baked in.
+    assert "/etc/ssl" not in src
+    assert "-----BEGIN" not in src  # no inlined PEM

--- a/tests/governance/transport/test_two_process_loopback.py
+++ b/tests/governance/transport/test_two_process_loopback.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import asyncio
+import os
+import ssl
+import subprocess
+import sys
+import tempfile
+import time
+
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient, TestServer
+
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+from backend.core.ouroboros.governance.transport.transport_security import (
+    build_server_ssl_context,
+    build_client_ssl_context,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+def _tls_cfg(**over):
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.05, reconnect_max_s=0.5, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=True, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=True, source_id="brain",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+async def test_mtls_handshake_succeeds_and_is_required():
+    # Shared ephemeral material for both ends (loopback stands in for a
+    # shared CA). Resolve once, feed both contexts the same cert/key.
+    from backend.core.ouroboros.governance.transport import transport_security as ts
+    cert, key = ts.generate_ephemeral_material()
+    cfg = _tls_cfg(tls_ephemeral=False, tls_cert=cert, tls_key=key, tls_ca=cert)
+
+    broker = StreamEventBroker(history_maxlen=100)
+    app = web.Application()
+    BusBridgeServer(broker, cfg).register_routes(app)
+    server_ssl = build_server_ssl_context(cfg)
+    tserver = TestServer(app)
+    await tserver.start_server(ssl=server_ssl)
+    host, port = tserver.host, tserver.port
+
+    import aiohttp
+    client_ssl = build_client_ssl_context(cfg)
+    # (a) mTLS client connects.
+    async with aiohttp.ClientSession() as s:
+        async with s.ws_connect(f"wss://{host}:{port}/ws/trinity-bus", ssl=client_ssl) as ws:
+            assert not ws.closed
+    # (b) a plaintext / no-cert client is rejected (mTLS required).
+    with pytest.raises((aiohttp.ClientConnectorError, ssl.SSLError, aiohttp.ClientError,
+                        ConnectionResetError, aiohttp.WSServerHandshakeError)):
+        no_verify = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+        no_verify.check_hostname = False
+        no_verify.verify_mode = ssl.CERT_NONE
+        async with aiohttp.ClientSession() as s:
+            # No client cert loaded -> server's CERT_REQUIRED rejects.
+            async with s.ws_connect(f"wss://{host}:{port}/ws/trinity-bus", ssl=no_verify) as ws:
+                await ws.receive()
+    await tserver.close()
+
+
+async def test_two_os_process_server_exchanges_events():
+    portfile = os.path.join(tempfile.mkdtemp(prefix="jarvis-smoke-"), "port")
+    env = dict(os.environ)
+    env.update({
+        "JARVIS_BRAIN_WS_HOST": "127.0.0.1",
+        "JARVIS_BRAIN_WS_PORT": "0",
+        "JARVIS_BRAIN_WS_TLS_ENABLED": "false",
+        "JARVIS_BRAIN_WS_PORTFILE": portfile,
+        "JARVIS_BRAIN_WS_SOURCE_ID": "brain-proc",
+    })
+    repo_root = subprocess.run(
+        ["git", "rev-parse", "--show-toplevel"], capture_output=True, text=True,
+    ).stdout.strip()
+    proc = subprocess.Popen(
+        [sys.executable, "-m",
+         "backend.core.ouroboros.governance.transport._smoke_server"],
+        env=env, cwd=repo_root,
+    )
+    try:
+        # Wait for the child to write its bound port.
+        deadline = time.time() + 10.0
+        while time.time() < deadline and not os.path.exists(portfile):
+            await asyncio.sleep(0.1)
+        assert os.path.exists(portfile), "smoke server never bound"
+        with open(portfile) as fh:
+            port = int(fh.read().strip())
+
+        client_broker = StreamEventBroker(history_maxlen=1024)
+        from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+        cfg = _tls_cfg(tls_enabled=False, tls_ephemeral=False)
+        url = f"ws://127.0.0.1:{port}/ws/trinity-bus"
+        client = BusBridgeClient(client_broker, cfg, url=url)
+        run_task = asyncio.ensure_future(client.run())
+        try:
+            deadline = asyncio.get_event_loop().time() + 8.0
+            got = False
+            while asyncio.get_event_loop().time() < deadline:
+                if any(e.op_id == "op-smoke" for e in client_broker.recent_history(limit=200)):
+                    got = True
+                    break
+                await asyncio.sleep(0.1)
+            assert got, "no events crossed the two-process boundary"
+        finally:
+            await client.stop()
+            run_task.cancel()
+            try:
+                await run_task
+            except (asyncio.CancelledError, Exception):
+                pass
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=5)
+        except subprocess.TimeoutExpired:
+            proc.kill()

--- a/tests/governance/transport/test_two_process_loopback.py
+++ b/tests/governance/transport/test_two_process_loopback.py
@@ -10,7 +10,7 @@ import time
 
 import pytest
 from aiohttp import web
-from aiohttp.test_utils import TestClient, TestServer
+from aiohttp.test_utils import TestServer
 
 from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
 from backend.core.ouroboros.governance.transport.transport_config import TransportConfig


### PR DESCRIPTION
## Stage 0 — Transport Substrate (distributed TrinityEventBus over WebSocket)

First stage of the GCP orchestrator relocation. Adds a self-contained subpackage `backend/core/ouroboros/governance/transport/` that extends the in-process `StreamEventBroker`/`TrinityEventBus` across a WebSocket, so `publish()` on one host reaches subscribers on the other.

**Ships DARK** — master switch `JARVIS_DISTRIBUTED_BUS_ENABLED` defaults `false`; nothing is wired into the live loop. Loopback-only (no VM, no sensor migration — those are Stages 1-3).

### What's here (12 commits, 9 TDD tasks)
- `transport_config.py` — every threshold env-resolved, zero baked constants.
- `transport_security.py` — mTLS SSL contexts with dynamically-resolved material (ephemeral self-signed for loopback tests); `CERT_REQUIRED` mutual auth.
- `bus_frame.py` — wire codec with source-qualified dedup ids; `decode()` total (never raises).
- `bus_bridge_server.py` — aiohttp WS route; Last-Event-ID replay + heartbeat + drop-oldest backpressure all delegated to `StreamEventBroker` (pure proxy, no reimplementation); inbound dedup, bounded FIFO.
- `bus_bridge_client.py` — exp-backoff+jitter reconnect, degraded-mode flip, **contiguous-id Last-Event-ID gap resolution**; bounded dedup set.
- `distributed_event_bus.py` — the publish()-here-subscribers-there seam.
- Two AST invariants in `meta/shipped_code_invariants.py`: (1) real-time actuation (5 real Ghost Hands modules) structurally blocked from importing the transport; (2) `transport_config.py` pinned to zero hardcoded IPv4/ws:// endpoints.

### Three enforced invariants (per design)
1. **Latency scope** — AST invariant forbids Ghost Hands from taking a network dependency on the transport.
2. **Dynamic config** — all thresholds env-resolved; no-hardcoded-endpoint AST pin.
3. **mTLS** — `CERT_REQUIRED`, dynamic material; a certless client is genuinely rejected (proven in the two-process smoke).

### Test evidence
`24 passed` (20 transport + 4 invariant), sandbox disabled (socket/subprocess tests bind loopback).
- **Load-bearing:** `test_hostile_network_replay.py` proves zero-drop / zero-duplicate exact sync under injected latency + jitter + windowed reordering + a mid-stream disconnect. It caught a real replay-stall bug in the client (dedup path wasn't advancing the contiguous high-water mark); fixed at root.
- Two-process loopback smoke spawns a real second OS process and proves mTLS both succeeds and is required.

### Review
All 9 tasks task-reviewed; final whole-branch review clean after one applied fix (bounded the client dedup set to mirror the server's FIFO cap).

---
### ⚠️ Merge note (base scope)
This branch descends from a local `main` that is ahead of `origin/main` by two **Tier-4 loop-starvation** commits (`a1bd8c5428`, `24ae2ec124`) — the content of the still-open **PR #69828** (`sync/tier4-ingest-coverage-index`), reserved for manual review. Against the current `origin/main`, this PR's diff therefore also shows those two commits.

**To land Stage 0 cleanly, merge #69828 first** — once it's on `origin/main`, this PR's diff auto-scopes to Stage 0 + its design/plan docs only. (Alternatively, bundling is fine if intended.) I did not merge this to protected `main` unilaterally, to avoid pulling #69828's reserved content in without your gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a dark-shipped distributed event bus over WebSocket to mirror `StreamEventBroker` across hosts, plus a fix for ingest loop starvation by moving test-coverage stratification off the event loop.

- **New Features**
  - New `backend/core/ouroboros/governance/transport/` bridging the local bus over WS with `BusBridgeServer`/`BusBridgeClient` and `DistributedEventBus`.
  - Exact Last-Event-ID replay, bounded dedup, drop-oldest backpressure, heartbeats, and reconnect with backoff+jitter.
  - mTLS with dynamic material; optional ephemeral certs for loopback tests.
  - Env-driven config via `TransportConfig`; `distributed_bus_enabled()` is false by default; no hardcoded endpoints.
  - AST invariants: block real-time actuation from importing transport; flag hardcoded IPv4/ws endpoints in `transport_config.py`.

- **Bug Fixes**
  - Ingest stratification no longer blocks the loop: builds a single-flight coverage index off-loop (AST in a process pool), with TTL/cooldown controls (`JARVIS_STRATIFICATION_INDEX_*`).
  - Intake uses a `stratification_penalty_override` to proceed degraded until the index is warm.

<sup>Written for commit d8e42a88e7de78dee5c57c507f9fb37f59e0cef8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69829?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

