### PR TITLE
fix(durability): overlay-safe ledger writes + AutoCommit workspace + loud transaction lifecycle

### DIFF
--- a/backend/core/ouroboros/governance/autonomous_workspace.py
+++ b/backend/core/ouroboros/governance/autonomous_workspace.py
@@ -193,7 +193,13 @@ async def resolve_loop_project_root(
     # the Ledger-Sovereignty phase sets) so AutoCommitter + ChangeEngine +
     # the orchestrator all converge on this one worktree. This is the
     # established workspace-handoff env, NOT process-cwd mutation.
-    os.environ[_ENV_COMMIT_WORKSPACE] = str(wt_path)
+    #
+    # This is the SINGLE canonical materialization seam for
+    # JARVIS_AUTO_COMMIT_WORKSPACE (the Ledger-Sovereignty boot phase in
+    # harness.py reuses whatever lands here via its own already-set check).
+    # setdefault, NOT unconditional assignment: an operator-pinned workspace
+    # must survive this call untouched (durability-substrate Task 3).
+    os.environ.setdefault(_ENV_COMMIT_WORKSPACE, str(wt_path))
     os.environ.setdefault(_ENV_SESSION_ID, str(session_id))
     # §7 absolute observability — emit a grep-stable marker so a soak can
     # verify the redirect fired and identify the quarantine zone.

--- a/backend/core/ouroboros/governance/cross_process_jsonl.py
+++ b/backend/core/ouroboros/governance/cross_process_jsonl.py
@@ -366,6 +366,10 @@ def flock_append_line(
     ``\\n``. Caller is responsible for ensuring ``line`` does not
     already contain newlines (the JSONL contract — one record per
     line)."""
+    from backend.core.ouroboros.governance.workspace_resolver import (
+        resolve_durable_path,
+    )
+    path = resolve_durable_path(path)
     # Slice 33 Arc 0 — diagnostic only. v26 saw 12 CrossProcessJSONL
     # WARNs (stale-lock detection); under contention this can block.
     from backend.core.ouroboros.telemetry.loop_sink import (
@@ -399,6 +403,10 @@ def flock_critical_section(
     inside the block, the caller handles it (defensive contract is
     caller-owned)."""
     try:
+        from backend.core.ouroboros.governance.workspace_resolver import (
+            resolve_durable_path,
+        )
+        path = resolve_durable_path(path)
         target = Path(path)
         lock_path = target.with_suffix(target.suffix + ".lock")
         try:
@@ -437,6 +445,10 @@ def flock_append_lines(
     cannot interleave. Cheaper than calling ``flock_append_line``
     in a loop when batching."""
     try:
+        from backend.core.ouroboros.governance.workspace_resolver import (
+            resolve_durable_path,
+        )
+        path = resolve_durable_path(path)
         target = Path(path)
         lock_path = target.with_suffix(target.suffix + ".lock")
         try:
@@ -530,6 +542,10 @@ async def async_flock_critical_section(
         flock'd JSONL Persistence pattern across awaitable
         operations.
     """
+    from backend.core.ouroboros.governance.workspace_resolver import (
+        resolve_durable_path,
+    )
+    path = resolve_durable_path(path)
     # Use a sync ExitStack — we drive it from worker threads
     # via asyncio.to_thread on enter + exit. The sync CM's fd
     # persists across the async yield because the stack holds

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -950,678 +950,707 @@ class Slice4bRunner(PhaseRunner):
             {"op_id": ctx.op_id},
         )
 
-        # ---- Phase 8a: Scoped post-apply test run ----
-        _verify_test_passed = True
-        _verify_test_total = 0
-        _verify_test_failures = 0
-        _verify_failed_names: Tuple[str, ...] = ()
-
-        if orch._validation_runner is not None and ctx.target_files:
-            _changed = tuple(
-                orch._config.project_root / f for f in ctx.target_files
-            )
-            _files_str = ", ".join(str(f) for f in list(ctx.target_files)[:3])
-
-            try:
-                await orch._stack.comm.emit_heartbeat(
-                    op_id=ctx.op_id, phase="verify",
-                    verify_test_starting=True,
-                    verify_target_files=list(ctx.target_files),
-                )
-            except Exception:
-                pass
-
-            _verify_budget_s = min(
-                60.0,
-                float(os.environ.get("JARVIS_VERIFY_TIMEOUT_S", "60")),
-            )
-            try:
-                _multi = await asyncio.wait_for(
-                    orch._validation_runner.run(
-                        changed_files=_changed,
-                        sandbox_dir=None,
-                        timeout_budget_s=_verify_budget_s,
-                        op_id=ctx.op_id,
-                    ),
-                    timeout=_verify_budget_s + 5.0,
-                )
-                _verify_test_passed = _multi.passed
-                for _ar in _multi.adapter_results:
-                    _verify_test_total += _ar.test_result.total
-                    _verify_test_failures += _ar.test_result.failed
-                    _verify_failed_names += _ar.test_result.failed_tests
-                if _verify_test_total == 0 and _verify_test_failures == 0:
-                    _verify_test_passed = True
-            except (asyncio.TimeoutError, asyncio.CancelledError):
-                logger.warning("[Orchestrator] Verify scoped test timed out [%s]", ctx.op_id)
-                _verify_test_passed = False
-                _verify_test_failures = 1
-            except BlockedPathError:
-                pass
-            except Exception as exc:
-                logger.debug("[Orchestrator] Verify scoped test error: %s", exc)
-
-            try:
-                await orch._stack.comm.emit_heartbeat(
-                    op_id=ctx.op_id, phase="verify",
-                    verify_test_passed=_verify_test_passed,
-                    verify_test_total=_verify_test_total,
-                    verify_test_failures=_verify_test_failures,
-                    verify_target_files=list(ctx.target_files),
-                )
-            except Exception:
-                pass
-
-            try:
-                from backend.core.ouroboros.governance.ops_digest_observer import (
-                    get_ops_digest_observer,
-                )
-                _verify_passed_count = max(
-                    0, _verify_test_total - _verify_test_failures,
-                )
-                get_ops_digest_observer().on_verify_completed(
-                    op_id=ctx.op_id,
-                    passed=_verify_passed_count,
-                    total=_verify_test_total,
-                    scoped_to_applied_op=True,
-                )
-            except Exception:
-                logger.debug(
-                    "[Orchestrator] on_verify_completed observer call failed",
-                    exc_info=True,
-                )
-
-            # On failure: L2 repair before rollback
-            if not _verify_test_passed and orch._config.repair_engine is not None:
-                logger.info(
-                    "[Orchestrator] VERIFY test failed (%d/%d) — routing to L2 repair [%s]",
-                    _verify_test_failures, _verify_test_total, ctx.op_id,
-                )
-                _pl_deadline = ctx.pipeline_deadline or (
-                    datetime.now(timezone.utc) + timedelta(seconds=60)
-                )
-                _synth_val = ValidationResult(
-                    passed=False,
-                    best_candidate=best_candidate,
-                    validation_duration_s=0.0,
-                    error=f"post-apply verify: {_verify_test_failures}/{_verify_test_total} failing",
-                    failure_class="test",
-                    short_summary=f"verify: {', '.join(_verify_failed_names[:3])}",
-                    adapter_names_run=(),
-                )
-                try:
-                    directive = await orch._l2_hook(ctx, _synth_val, _pl_deadline)
-                    if directive[0] == "break":
-                        _l2_candidate = directive[1]
-                        _l2_change = orch._build_change_request(ctx, _l2_candidate)
-                        try:
-                            # Anti-Venom C2 — shield L2 VERIFY repair apply.
-                            _l2_result = await asyncio.shield(
-                                orch._stack.change_engine.execute(_l2_change)
-                            )
-                            if _l2_result.success:
-                                _verify_test_passed = True
-                                _verify_test_failures = 0
-                                logger.info(
-                                    "[Orchestrator] L2 repair applied in VERIFY phase [%s]",
-                                    ctx.op_id,
-                                )
-                            else:
-                                logger.warning(
-                                    "[Orchestrator] L2 repair candidate failed to apply [%s]",
-                                    ctx.op_id,
-                                )
-                        except Exception as _apply_exc:
-                            logger.debug("[Orchestrator] L2 repair apply error: %s", _apply_exc)
-                    elif directive[0] in ("cancel", "fatal"):
-                        ctx = directive[1]
-                        logger.info(
-                            "[Orchestrator] L2 escaped VERIFY phase — "
-                            "op ctx advanced to %s [%s]",
-                            ctx.phase.name, ctx.op_id,
-                        )
-                        return PhaseResult(
-                            next_ctx=ctx, next_phase=None, status="fail",
-                            reason=ctx.terminal_reason_code or "l2_escape_verify",
-                            artifacts={"t_apply": _t_apply},
-                        )
-                except Exception as _l2_exc:
-                    logger.debug(
-                        "[Orchestrator] L2 repair in VERIFY failed: %s: %s",
-                        type(_l2_exc).__name__, _l2_exc,
-                    )
-
-        ctx = await orch._run_benchmark(ctx, [])
-
-        # ---- Verify Gate: enforce regression thresholds ----
-        _verify_error = None
+        # Transactional-lifecycle guard (Task 4, durability substrate):
+        # the APPLIED ledger row is now written and the file mutation is on
+        # disk. From here the ONLY legitimate exits are Phase 8b (auto-commit)
+        # or a governed rollback/gate-failure that CLOSES the transaction. A
+        # silent exit in between (the op-944c defect) must be made LOUD.
+        from backend.core.ouroboros.governance.transaction_lifecycle import (
+            TransactionLifecycleError,
+            txn_lifecycle_guard_enabled,
+        )
+        _txn_commit_stage_reached = False
         try:
-            from backend.core.ouroboros.governance.verify_gate import (
-                enforce_verify_thresholds,
-                rollback_files,
-            )
-            _br = getattr(ctx, "benchmark_result", None)
-            if _br is not None:
-                _baseline_cov = None
-                _snapshots = getattr(ctx, "pre_apply_snapshots", {})
-                if isinstance(_snapshots, dict):
-                    _baseline_cov = _snapshots.get("_coverage_baseline")
-                _verify_error = enforce_verify_thresholds(_br, baseline_coverage=_baseline_cov)
-        except Exception as exc:
-            logger.debug("[Orchestrator] Verify gate skipped: %s", exc)
+            # ---- Phase 8a: Scoped post-apply test run ----
+            _verify_test_passed = True
+            _verify_test_total = 0
+            _verify_test_failures = 0
+            _verify_failed_names: Tuple[str, ...] = ()
 
-        if _verify_error is None and not _verify_test_passed:
-            _verify_error = f"scoped verify: {_verify_test_failures}/{_verify_test_total} tests failing"
-
-        # Slice 67 — swe_bench_pro VERIFY regression gate is advisory (LIVE
-        # extracted-runner path; mirrors the inline orchestrator block). The
-        # repo tests can't run without the container env; the held-out
-        # container scoring (Slice 65) is authoritative. Clearing the error
-        # keeps the patch applied (no rollback) so the autoscore layer captures
-        # it. Lazy import avoids a runner↔orchestrator module cycle.
-        try:
-            from backend.core.ouroboros.governance.orchestrator import (
-                _swe_bench_verify_advisory,
-            )
-            _verify_error = _swe_bench_verify_advisory(
-                getattr(ctx, "signal_source", "") or "", _verify_error, ctx.op_id,
-            )
-        except Exception:  # noqa: BLE001 — advisory must never break VERIFY
-            pass
-
-        if _verify_error is not None:
-            logger.warning(
-                "[Orchestrator] VERIFY regression gate fired: %s [%s]",
-                _verify_error, ctx.op_id,
-            )
-            try:
-                await orch._stack.comm.emit_postmortem(
-                    op_id=ctx.op_id,
-                    root_cause=f"verify_regression: {_verify_error}",
-                    failed_phase="VERIFY",
-                    target_files=list(ctx.target_files),
+            if orch._validation_runner is not None and ctx.target_files:
+                _changed = tuple(
+                    orch._config.project_root / f for f in ctx.target_files
                 )
-            except Exception:
-                pass
-            try:
-                _snapshots = getattr(ctx, "pre_apply_snapshots", {})
-                if _snapshots:
-                    from backend.core.ouroboros.governance.verify_gate import (
-                        rollback_files as _rollback_files,
-                    )
-                    _rollback_files(
-                        pre_apply_snapshots=_snapshots,
-                        target_files=list(ctx.target_files),
-                        repo_root=orch._config.project_root,
-                    )
-            except Exception as exc:
-                logger.error("[Orchestrator] Verify rollback failed: %s", exc)
+                _files_str = ", ".join(str(f) for f in list(ctx.target_files)[:3])
 
-            if _checkpoint is not None and _ckpt_mgr is not None:
-                try:
-                    await _ckpt_mgr.restore_checkpoint(_checkpoint.checkpoint_id)
-                    logger.info(
-                        "[Orchestrator] Git checkpoint restored: %s [%s]",
-                        _checkpoint.checkpoint_id, ctx.op_id,
-                    )
-                except Exception:
-                    logger.debug("[Orchestrator] Checkpoint restore failed", exc_info=True)
-
-            if _serpent: _serpent.update_phase("POSTMORTEM")
-            ctx = ctx.advance(
-                OperationPhase.POSTMORTEM,
-                terminal_reason_code="verify_regression",
-                rollback_occurred=True,
-            )
-            await orch._record_ledger(
-                ctx,
-                OperationState.FAILED,
-                {"reason": "verify_regression", "detail": _verify_error, "rollback_occurred": True},
-            )
-            orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
-            await orch._publish_outcome(ctx, OperationState.FAILED, "verify_regression")
-            return PhaseResult(
-                next_ctx=ctx, next_phase=None, status="fail",
-                reason="verify_regression",
-                artifacts={"t_apply": _t_apply},
-            )
-
-        # ---- Gate 2: Cryptographic Blast-Radius Verification ----
-        # Runs AFTER the scoped Phase-8a verify gate cleared (only reached
-        # when those tests passed) and BEFORE Phase 8b auto-commit. Chains
-        # onto Gate 1's sandbox_token: if Gate 1 didn't run there is no token
-        # to chain, so Gate 2 is skipped rather than broken.
-        # Default-OFF: JARVIS_A1_BLAST_RADIUS_ENABLED controls activation.
-        # Inline env check + all imports INSIDE the guard so the OFF path
-        # imports NOTHING (byte-identical to pre-Gate-2 behavior — Task 4 lesson).
-        _blast_armed = os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
-        if _blast_armed:
-            if getattr(ctx, "sandbox_token", None) is None:
-                logger.warning(
-                    "[Gate2] op=%s armed but no sandbox_token (Gate 1 disabled?) -- skipping",
-                    ctx.op_id,
-                )
-        if (_blast_armed
-                and getattr(ctx, "sandbox_token", None) is not None
-                and getattr(ctx, "proof_chain", None) is not None):
-            from ..blast_radius_verify import (
-                acquire_blast_radius_token,
-                BlastRadiusBreach,
-                BlastRadiusGraphFailure,
-            )
-            from ..reverse_dep_resolver import resolve_reverse_dependency_tests
-            from .. import intake_dlq as _g2_dlq
-            from ..test_runner import TestRunner as _G2TestRunner
-
-            _g2_root = orch._config.project_root  # Path
-            _g2_scope = sorted(
-                set(ctx.target_files)
-                | {cf for cf, _ in orch._iter_candidate_files(best_candidate) if cf}
-            )
-            # Reuse the APPLY-start checkpoint's content TREE SHA as the pre-op anchor.
-            # stash_ref is a timestamped COMMIT sha; ^{tree} is content-addressed and
-            # deterministic — identical content produces identical tree SHA.
-            _g2_pre_sha = await _ckpt_mgr.tree_sha_for_ref(
-                getattr(_checkpoint, "stash_ref", "") if _checkpoint is not None else ""
-            )
-
-            async def _g2_graph_fn(files):
-                return await resolve_reverse_dependency_tests(
-                    files, repo_root=str(_g2_root), oracle=None,
-                )
-
-            async def _g2_test_fn(tests):
-                if not tests:
-                    return {"failed": [], "total": 0}
-                _paths = tuple((_g2_root / t) for t in tests)
-                _runner = _G2TestRunner(repo_root=_g2_root)
-                _tr = await _runner.run(test_files=_paths, sandbox_dir=None)
-                return {"failed": list(_tr.failed_tests), "total": _tr.total}
-
-            async def _g2_rollback(_sha):
-                # Non-destructive restore via the existing APPLY-start checkpoint.
-                if _checkpoint is not None and _ckpt_mgr is not None:
-                    await _ckpt_mgr.restore_checkpoint(_checkpoint.checkpoint_id)
-
-            async def _g2_tree_sha():
-                if _ckpt_mgr is None:
-                    return ""
-                return await _ckpt_mgr.working_tree_content_sha()
-
-            def _g2_dlq_fn(reason):
-                _g2_dlq.append_dlq({"op_id": ctx.op_id, "phase": "blast_radius"}, reason=reason)
-
-            try:
-                _blast_tok = await acquire_blast_radius_token(
-                    op_id=ctx.op_id,
-                    scope_files=_g2_scope,
-                    pre_op_tree_sha=_g2_pre_sha,
-                    chain=ctx.proof_chain,
-                    prev_token=ctx.sandbox_token,
-                    graph_fn=_g2_graph_fn,
-                    test_fn=_g2_test_fn,
-                    current_tree_sha_fn=_g2_tree_sha,
-                    rollback_fn=_g2_rollback,
-                    dlq_fn=_g2_dlq_fn,
-                )
-            except BlastRadiusGraphFailure:
-                logger.warning("[Gate2] op=%s blast_radius_graph_failure", ctx.op_id)
-                if _serpent: _serpent.update_phase("POSTMORTEM")
-                ctx = ctx.advance(
-                    OperationPhase.POSTMORTEM,
-                    terminal_reason_code="blast_radius_graph_failure",
-                    rollback_occurred=True,
-                )
-                await orch._record_ledger(
-                    ctx,
-                    OperationState.FAILED,
-                    {"reason": "blast_radius_graph_failure", "rollback_occurred": True},
-                )
-                orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
-                await orch._publish_outcome(ctx, OperationState.FAILED, "blast_radius_graph_failure")
-                return PhaseResult(
-                    next_ctx=ctx, next_phase=None, status="fail",
-                    reason="blast_radius_graph_failure",
-                    artifacts={"t_apply": _t_apply},
-                )
-            except BlastRadiusBreach:
-                logger.warning("[Gate2] op=%s blast_radius_breach", ctx.op_id)
-                if _serpent: _serpent.update_phase("POSTMORTEM")
-                ctx = ctx.advance(
-                    OperationPhase.POSTMORTEM,
-                    terminal_reason_code="blast_radius_breach",
-                    rollback_occurred=True,
-                )
-                await orch._record_ledger(
-                    ctx,
-                    OperationState.FAILED,
-                    {"reason": "blast_radius_breach", "rollback_occurred": True},
-                )
-                orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
-                await orch._publish_outcome(ctx, OperationState.FAILED, "blast_radius_breach")
-                return PhaseResult(
-                    next_ctx=ctx, next_phase=None, status="fail",
-                    reason="blast_radius_breach",
-                    artifacts={"t_apply": _t_apply},
-                )
-            ctx = dataclasses.replace(ctx, blast_token=_blast_tok)
-
-        # ---- Phase 8b: Auto-commit ----
-        _committed_hash: Optional[str] = None
-        try:
-            from backend.core.ouroboros.governance.auto_committer import AutoCommitter
-            _committer = AutoCommitter(repo_root=orch._config.project_root)
-            _gen = ctx.generation
-            _provider = getattr(_gen, "provider_name", "") if _gen else ""
-            _cost = 0.0
-            if _gen:
-                _in_tok = getattr(_gen, "total_input_tokens", 0) or 0
-                _out_tok = getattr(_gen, "total_output_tokens", 0) or 0
-                _cost = (_in_tok * 0.0000001 + _out_tok * 0.0000004)
-            _commit_result = await asyncio.wait_for(
-                _committer.commit(
-                    op_id=ctx.op_id,
-                    description=ctx.description,
-                    target_files=ctx.target_files,
-                    risk_tier=ctx.risk_tier,
-                    provider_name=_provider,
-                    generation_cost=_cost,
-                    signal_source=getattr(ctx, "signal_source", ""),
-                    signal_urgency=getattr(ctx, "signal_urgency", ""),
-                    rationale=ctx.description,
-                ),
-                timeout=30.0,
-            )
-            if _commit_result.committed:
-                _committed_hash = _commit_result.commit_hash
                 try:
                     await orch._stack.comm.emit_heartbeat(
-                        op_id=ctx.op_id, phase="commit",
-                        progress_pct=98.0,
-                        commit_hash=_commit_result.commit_hash,
-                        commit_pushed=_commit_result.pushed,
-                        commit_branch=_commit_result.push_branch,
+                        op_id=ctx.op_id, phase="verify",
+                        verify_test_starting=True,
+                        verify_target_files=list(ctx.target_files),
                     )
                 except Exception:
                     pass
-                logger.info(
-                    "[Orchestrator] Auto-committed %s for op=%s",
-                    _commit_result.commit_hash, ctx.op_id,
+
+                _verify_budget_s = min(
+                    60.0,
+                    float(os.environ.get("JARVIS_VERIFY_TIMEOUT_S", "60")),
                 )
+                try:
+                    _multi = await asyncio.wait_for(
+                        orch._validation_runner.run(
+                            changed_files=_changed,
+                            sandbox_dir=None,
+                            timeout_budget_s=_verify_budget_s,
+                            op_id=ctx.op_id,
+                        ),
+                        timeout=_verify_budget_s + 5.0,
+                    )
+                    _verify_test_passed = _multi.passed
+                    for _ar in _multi.adapter_results:
+                        _verify_test_total += _ar.test_result.total
+                        _verify_test_failures += _ar.test_result.failed
+                        _verify_failed_names += _ar.test_result.failed_tests
+                    if _verify_test_total == 0 and _verify_test_failures == 0:
+                        _verify_test_passed = True
+                except (asyncio.TimeoutError, asyncio.CancelledError):
+                    logger.warning("[Orchestrator] Verify scoped test timed out [%s]", ctx.op_id)
+                    _verify_test_passed = False
+                    _verify_test_failures = 1
+                except BlockedPathError:
+                    pass
+                except Exception as exc:
+                    logger.debug("[Orchestrator] Verify scoped test error: %s", exc)
+
+                try:
+                    await orch._stack.comm.emit_heartbeat(
+                        op_id=ctx.op_id, phase="verify",
+                        verify_test_passed=_verify_test_passed,
+                        verify_test_total=_verify_test_total,
+                        verify_test_failures=_verify_test_failures,
+                        verify_target_files=list(ctx.target_files),
+                    )
+                except Exception:
+                    pass
 
                 try:
                     from backend.core.ouroboros.governance.ops_digest_observer import (
                         get_ops_digest_observer,
                     )
-                    get_ops_digest_observer().on_commit_succeeded(
+                    _verify_passed_count = max(
+                        0, _verify_test_total - _verify_test_failures,
+                    )
+                    get_ops_digest_observer().on_verify_completed(
                         op_id=ctx.op_id,
-                        commit_hash=_commit_result.commit_hash or "",
+                        passed=_verify_passed_count,
+                        total=_verify_test_total,
+                        scoped_to_applied_op=True,
                     )
                 except Exception:
                     logger.debug(
-                        "[Orchestrator] on_commit_succeeded observer call failed",
+                        "[Orchestrator] on_verify_completed observer call failed",
                         exc_info=True,
                     )
-            elif _commit_result.skipped_reason:
-                logger.debug(
-                    "[Orchestrator] Auto-commit skipped: %s",
-                    _commit_result.skipped_reason,
-                )
-        except ImportError:
-            logger.debug("[Orchestrator] AutoCommitter not available")
-        except Exception as exc:
-            logger.warning(
-                "[Orchestrator] Auto-commit failed for op=%s: %s; "
-                "change is applied but not committed",
-                ctx.op_id, exc,
-            )
 
-        # ---- Phase 8b2: In-process hot-reload ----
-        if orch._hot_reloader is not None:
-            try:
-                _hr_batch = orch._hot_reloader.reload_for_op(
-                    op_id=ctx.op_id,
-                    target_files=ctx.target_files,
-                )
-                if _hr_batch.overall_status == "success":
-                    _reloaded_names = [
-                        o.module_name.rsplit(".", 1)[-1]
-                        for o in _hr_batch.outcomes
-                        if o.status == "reloaded"
-                    ]
+                # On failure: L2 repair before rollback
+                if not _verify_test_passed and orch._config.repair_engine is not None:
                     logger.info(
-                        "[Orchestrator] Hot-reloaded %d module(s) for op=%s: %s",
-                        len(_reloaded_names), ctx.op_id, _reloaded_names,
+                        "[Orchestrator] VERIFY test failed (%d/%d) — routing to L2 repair [%s]",
+                        _verify_test_failures, _verify_test_total, ctx.op_id,
+                    )
+                    _pl_deadline = ctx.pipeline_deadline or (
+                        datetime.now(timezone.utc) + timedelta(seconds=60)
+                    )
+                    _synth_val = ValidationResult(
+                        passed=False,
+                        best_candidate=best_candidate,
+                        validation_duration_s=0.0,
+                        error=f"post-apply verify: {_verify_test_failures}/{_verify_test_total} failing",
+                        failure_class="test",
+                        short_summary=f"verify: {', '.join(_verify_failed_names[:3])}",
+                        adapter_names_run=(),
                     )
                     try:
-                        await orch._stack.comm.emit_heartbeat(
-                            op_id=ctx.op_id, phase="hot_reload",
-                            progress_pct=99.0,
-                            reloaded_modules=_reloaded_names,
-                            reload_count=orch._hot_reloader.reload_count,
+                        directive = await orch._l2_hook(ctx, _synth_val, _pl_deadline)
+                        if directive[0] == "break":
+                            _l2_candidate = directive[1]
+                            _l2_change = orch._build_change_request(ctx, _l2_candidate)
+                            try:
+                                # Anti-Venom C2 — shield L2 VERIFY repair apply.
+                                _l2_result = await asyncio.shield(
+                                    orch._stack.change_engine.execute(_l2_change)
+                                )
+                                if _l2_result.success:
+                                    _verify_test_passed = True
+                                    _verify_test_failures = 0
+                                    logger.info(
+                                        "[Orchestrator] L2 repair applied in VERIFY phase [%s]",
+                                        ctx.op_id,
+                                    )
+                                else:
+                                    logger.warning(
+                                        "[Orchestrator] L2 repair candidate failed to apply [%s]",
+                                        ctx.op_id,
+                                    )
+                            except Exception as _apply_exc:
+                                logger.debug("[Orchestrator] L2 repair apply error: %s", _apply_exc)
+                        elif directive[0] in ("cancel", "fatal"):
+                            ctx = directive[1]
+                            logger.info(
+                                "[Orchestrator] L2 escaped VERIFY phase — "
+                                "op ctx advanced to %s [%s]",
+                                ctx.phase.name, ctx.op_id,
+                            )
+                            _txn_commit_stage_reached = True
+                            return PhaseResult(
+                                next_ctx=ctx, next_phase=None, status="fail",
+                                reason=ctx.terminal_reason_code or "l2_escape_verify",
+                                artifacts={"t_apply": _t_apply},
+                            )
+                    except Exception as _l2_exc:
+                        logger.debug(
+                            "[Orchestrator] L2 repair in VERIFY failed: %s: %s",
+                            type(_l2_exc).__name__, _l2_exc,
+                        )
+
+            ctx = await orch._run_benchmark(ctx, [])
+
+            # ---- Verify Gate: enforce regression thresholds ----
+            _verify_error = None
+            try:
+                from backend.core.ouroboros.governance.verify_gate import (
+                    enforce_verify_thresholds,
+                    rollback_files,
+                )
+                _br = getattr(ctx, "benchmark_result", None)
+                if _br is not None:
+                    _baseline_cov = None
+                    _snapshots = getattr(ctx, "pre_apply_snapshots", {})
+                    if isinstance(_snapshots, dict):
+                        _baseline_cov = _snapshots.get("_coverage_baseline")
+                    _verify_error = enforce_verify_thresholds(_br, baseline_coverage=_baseline_cov)
+            except Exception as exc:
+                logger.debug("[Orchestrator] Verify gate skipped: %s", exc)
+
+            if _verify_error is None and not _verify_test_passed:
+                _verify_error = f"scoped verify: {_verify_test_failures}/{_verify_test_total} tests failing"
+
+            # Slice 67 — swe_bench_pro VERIFY regression gate is advisory (LIVE
+            # extracted-runner path; mirrors the inline orchestrator block). The
+            # repo tests can't run without the container env; the held-out
+            # container scoring (Slice 65) is authoritative. Clearing the error
+            # keeps the patch applied (no rollback) so the autoscore layer captures
+            # it. Lazy import avoids a runner↔orchestrator module cycle.
+            try:
+                from backend.core.ouroboros.governance.orchestrator import (
+                    _swe_bench_verify_advisory,
+                )
+                _verify_error = _swe_bench_verify_advisory(
+                    getattr(ctx, "signal_source", "") or "", _verify_error, ctx.op_id,
+                )
+            except Exception:  # noqa: BLE001 — advisory must never break VERIFY
+                pass
+
+            if _verify_error is not None:
+                logger.warning(
+                    "[Orchestrator] VERIFY regression gate fired: %s [%s]",
+                    _verify_error, ctx.op_id,
+                )
+                try:
+                    await orch._stack.comm.emit_postmortem(
+                        op_id=ctx.op_id,
+                        root_cause=f"verify_regression: {_verify_error}",
+                        failed_phase="VERIFY",
+                        target_files=list(ctx.target_files),
+                    )
+                except Exception:
+                    pass
+                try:
+                    _snapshots = getattr(ctx, "pre_apply_snapshots", {})
+                    if _snapshots:
+                        from backend.core.ouroboros.governance.verify_gate import (
+                            rollback_files as _rollback_files,
+                        )
+                        _rollback_files(
+                            pre_apply_snapshots=_snapshots,
+                            target_files=list(ctx.target_files),
+                            repo_root=orch._config.project_root,
+                        )
+                except Exception as exc:
+                    logger.error("[Orchestrator] Verify rollback failed: %s", exc)
+
+                if _checkpoint is not None and _ckpt_mgr is not None:
+                    try:
+                        await _ckpt_mgr.restore_checkpoint(_checkpoint.checkpoint_id)
+                        logger.info(
+                            "[Orchestrator] Git checkpoint restored: %s [%s]",
+                            _checkpoint.checkpoint_id, ctx.op_id,
                         )
                     except Exception:
-                        pass
-                elif _hr_batch.overall_status in ("reload_failed", "preflight_failed"):
-                    logger.warning(
-                        "[Orchestrator] Hot-reload failed for op=%s: %s; "
-                        "restart will be queued",
-                        ctx.op_id, _hr_batch.restart_reason,
-                    )
-                elif _hr_batch.restart_required:
-                    logger.info(
-                        "[Orchestrator] Hot-reload deferred to restart for op=%s: %s",
-                        ctx.op_id, _hr_batch.restart_reason,
-                    )
-            except Exception as exc:
-                logger.warning(
-                    "[Orchestrator] Hot-reload hook raised for op=%s: %s",
-                    ctx.op_id, exc,
+                        logger.debug("[Orchestrator] Checkpoint restore failed", exc_info=True)
+
+                if _serpent: _serpent.update_phase("POSTMORTEM")
+                ctx = ctx.advance(
+                    OperationPhase.POSTMORTEM,
+                    terminal_reason_code="verify_regression",
+                    rollback_occurred=True,
+                )
+                await orch._record_ledger(
+                    ctx,
+                    OperationState.FAILED,
+                    {"reason": "verify_regression", "detail": _verify_error, "rollback_occurred": True},
+                )
+                orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
+                await orch._publish_outcome(ctx, OperationState.FAILED, "verify_regression")
+                _txn_commit_stage_reached = True
+                return PhaseResult(
+                    next_ctx=ctx, next_phase=None, status="fail",
+                    reason="verify_regression",
+                    artifacts={"t_apply": _t_apply},
                 )
 
-        # ---- Phase 8c: Self-critique ----
-        if orch._critique_engine is not None:
+            # ---- Gate 2: Cryptographic Blast-Radius Verification ----
+            # Runs AFTER the scoped Phase-8a verify gate cleared (only reached
+            # when those tests passed) and BEFORE Phase 8b auto-commit. Chains
+            # onto Gate 1's sandbox_token: if Gate 1 didn't run there is no token
+            # to chain, so Gate 2 is skipped rather than broken.
+            # Default-OFF: JARVIS_A1_BLAST_RADIUS_ENABLED controls activation.
+            # Inline env check + all imports INSIDE the guard so the OFF path
+            # imports NOTHING (byte-identical to pre-Gate-2 behavior — Task 4 lesson).
+            _blast_armed = os.environ.get("JARVIS_A1_BLAST_RADIUS_ENABLED", "false").strip().lower() in ("1", "true", "yes")
+            if _blast_armed:
+                if getattr(ctx, "sandbox_token", None) is None:
+                    logger.warning(
+                        "[Gate2] op=%s armed but no sandbox_token (Gate 1 disabled?) -- skipping",
+                        ctx.op_id,
+                    )
+            if (_blast_armed
+                    and getattr(ctx, "sandbox_token", None) is not None
+                    and getattr(ctx, "proof_chain", None) is not None):
+                from ..blast_radius_verify import (
+                    acquire_blast_radius_token,
+                    BlastRadiusBreach,
+                    BlastRadiusGraphFailure,
+                )
+                from ..reverse_dep_resolver import resolve_reverse_dependency_tests
+                from .. import intake_dlq as _g2_dlq
+                from ..test_runner import TestRunner as _G2TestRunner
+
+                _g2_root = orch._config.project_root  # Path
+                _g2_scope = sorted(
+                    set(ctx.target_files)
+                    | {cf for cf, _ in orch._iter_candidate_files(best_candidate) if cf}
+                )
+                # Reuse the APPLY-start checkpoint's content TREE SHA as the pre-op anchor.
+                # stash_ref is a timestamped COMMIT sha; ^{tree} is content-addressed and
+                # deterministic — identical content produces identical tree SHA.
+                _g2_pre_sha = await _ckpt_mgr.tree_sha_for_ref(
+                    getattr(_checkpoint, "stash_ref", "") if _checkpoint is not None else ""
+                )
+
+                async def _g2_graph_fn(files):
+                    return await resolve_reverse_dependency_tests(
+                        files, repo_root=str(_g2_root), oracle=None,
+                    )
+
+                async def _g2_test_fn(tests):
+                    if not tests:
+                        return {"failed": [], "total": 0}
+                    _paths = tuple((_g2_root / t) for t in tests)
+                    _runner = _G2TestRunner(repo_root=_g2_root)
+                    _tr = await _runner.run(test_files=_paths, sandbox_dir=None)
+                    return {"failed": list(_tr.failed_tests), "total": _tr.total}
+
+                async def _g2_rollback(_sha):
+                    # Non-destructive restore via the existing APPLY-start checkpoint.
+                    if _checkpoint is not None and _ckpt_mgr is not None:
+                        await _ckpt_mgr.restore_checkpoint(_checkpoint.checkpoint_id)
+
+                async def _g2_tree_sha():
+                    if _ckpt_mgr is None:
+                        return ""
+                    return await _ckpt_mgr.working_tree_content_sha()
+
+                def _g2_dlq_fn(reason):
+                    _g2_dlq.append_dlq({"op_id": ctx.op_id, "phase": "blast_radius"}, reason=reason)
+
+                try:
+                    _blast_tok = await acquire_blast_radius_token(
+                        op_id=ctx.op_id,
+                        scope_files=_g2_scope,
+                        pre_op_tree_sha=_g2_pre_sha,
+                        chain=ctx.proof_chain,
+                        prev_token=ctx.sandbox_token,
+                        graph_fn=_g2_graph_fn,
+                        test_fn=_g2_test_fn,
+                        current_tree_sha_fn=_g2_tree_sha,
+                        rollback_fn=_g2_rollback,
+                        dlq_fn=_g2_dlq_fn,
+                    )
+                except BlastRadiusGraphFailure:
+                    logger.warning("[Gate2] op=%s blast_radius_graph_failure", ctx.op_id)
+                    if _serpent: _serpent.update_phase("POSTMORTEM")
+                    ctx = ctx.advance(
+                        OperationPhase.POSTMORTEM,
+                        terminal_reason_code="blast_radius_graph_failure",
+                        rollback_occurred=True,
+                    )
+                    await orch._record_ledger(
+                        ctx,
+                        OperationState.FAILED,
+                        {"reason": "blast_radius_graph_failure", "rollback_occurred": True},
+                    )
+                    orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
+                    await orch._publish_outcome(ctx, OperationState.FAILED, "blast_radius_graph_failure")
+                    _txn_commit_stage_reached = True
+                    return PhaseResult(
+                        next_ctx=ctx, next_phase=None, status="fail",
+                        reason="blast_radius_graph_failure",
+                        artifacts={"t_apply": _t_apply},
+                    )
+                except BlastRadiusBreach:
+                    logger.warning("[Gate2] op=%s blast_radius_breach", ctx.op_id)
+                    if _serpent: _serpent.update_phase("POSTMORTEM")
+                    ctx = ctx.advance(
+                        OperationPhase.POSTMORTEM,
+                        terminal_reason_code="blast_radius_breach",
+                        rollback_occurred=True,
+                    )
+                    await orch._record_ledger(
+                        ctx,
+                        OperationState.FAILED,
+                        {"reason": "blast_radius_breach", "rollback_occurred": True},
+                    )
+                    orch._record_canary_for_ctx(ctx, False, time.monotonic() - _t_apply, rolled_back=True)
+                    await orch._publish_outcome(ctx, OperationState.FAILED, "blast_radius_breach")
+                    _txn_commit_stage_reached = True
+                    return PhaseResult(
+                        next_ctx=ctx, next_phase=None, status="fail",
+                        reason="blast_radius_breach",
+                        artifacts={"t_apply": _t_apply},
+                    )
+                ctx = dataclasses.replace(ctx, blast_token=_blast_tok)
+
+            # ---- Phase 8b: Auto-commit ----
+            _txn_commit_stage_reached = True
+            _committed_hash: Optional[str] = None
             try:
-                _test_summary = "(no test summary captured)"
-                _vr = ctx.validation
-                if _vr is not None:
-                    _passed = getattr(_vr, "tests_passed", 0) or 0
-                    _total = getattr(_vr, "tests_total", 0) or 0
-                    if _total:
-                        _test_summary = f"{_passed}/{_total} tests passed"
-                    elif _passed:
-                        _test_summary = f"{_passed} tests passed"
-                _critique_result = await asyncio.wait_for(
-                    orch._critique_engine.critique_op(
+                from backend.core.ouroboros.governance.auto_committer import AutoCommitter
+                _committer = AutoCommitter(repo_root=orch._config.project_root)
+                _gen = ctx.generation
+                _provider = getattr(_gen, "provider_name", "") if _gen else ""
+                _cost = 0.0
+                if _gen:
+                    _in_tok = getattr(_gen, "total_input_tokens", 0) or 0
+                    _out_tok = getattr(_gen, "total_output_tokens", 0) or 0
+                    _cost = (_in_tok * 0.0000001 + _out_tok * 0.0000004)
+                _commit_result = await asyncio.wait_for(
+                    _committer.commit(
                         op_id=ctx.op_id,
                         description=ctx.description,
                         target_files=ctx.target_files,
                         risk_tier=ctx.risk_tier,
-                        commit_hash=_committed_hash,
-                        test_summary=_test_summary,
+                        provider_name=_provider,
+                        generation_cost=_cost,
+                        signal_source=getattr(ctx, "signal_source", ""),
+                        signal_urgency=getattr(ctx, "signal_urgency", ""),
+                        rationale=ctx.description,
                     ),
-                    timeout=float(os.environ.get("JARVIS_CRITIQUE_TIMEOUT_S", "30")) + 5.0,
+                    timeout=30.0,
                 )
-                try:
-                    await orch._stack.comm.emit_heartbeat(
-                        op_id=ctx.op_id,
-                        phase="critique",
-                        progress_pct=99.0,
-                        critique_rating=int(getattr(_critique_result, "rating", 0)),
-                        critique_matches_goal=bool(
-                            getattr(_critique_result, "matches_goal", True)
-                        ),
-                        critique_rationale=str(
-                            getattr(_critique_result, "rationale", "")
-                        )[:200],
-                        critique_provider=str(
-                            getattr(_critique_result, "provider_name", "")
-                        ),
-                        critique_parse_ok=bool(
-                            getattr(_critique_result, "parse_ok", True)
-                        ),
+                if _commit_result.committed:
+                    _committed_hash = _commit_result.commit_hash
+                    try:
+                        await orch._stack.comm.emit_heartbeat(
+                            op_id=ctx.op_id, phase="commit",
+                            progress_pct=98.0,
+                            commit_hash=_commit_result.commit_hash,
+                            commit_pushed=_commit_result.pushed,
+                            commit_branch=_commit_result.push_branch,
+                        )
+                    except Exception:
+                        pass
+                    logger.info(
+                        "[Orchestrator] Auto-committed %s for op=%s",
+                        _commit_result.commit_hash, ctx.op_id,
                     )
-                except Exception:
-                    pass
-                if (
-                    getattr(_critique_result, "parse_ok", False)
-                    and getattr(_critique_result, "is_poor", False)
-                ):
-                    _files_short = ", ".join(
-                        p.rsplit("/", 1)[-1] for p in ctx.target_files[:3]
+
+                    try:
+                        from backend.core.ouroboros.governance.ops_digest_observer import (
+                            get_ops_digest_observer,
+                        )
+                        get_ops_digest_observer().on_commit_succeeded(
+                            op_id=ctx.op_id,
+                            commit_hash=_commit_result.commit_hash or "",
+                        )
+                    except Exception:
+                        logger.debug(
+                            "[Orchestrator] on_commit_succeeded observer call failed",
+                            exc_info=True,
+                        )
+                elif _commit_result.skipped_reason:
+                    logger.debug(
+                        "[Orchestrator] Auto-commit skipped: %s",
+                        _commit_result.skipped_reason,
                     )
-                    orch._add_session_lesson(
-                        "code",
-                        f"[CRITIQUE POOR {getattr(_critique_result, 'rating', '?')}/5] "
-                        f"{ctx.description[:60]} ({_files_short}): "
-                        f"{str(getattr(_critique_result, 'rationale', ''))[:120]}",
-                        op_id=ctx.op_id,
-                    )
-            except asyncio.TimeoutError:
-                logger.info(
-                    "[Orchestrator] Self-critique timed out for op=%s — "
-                    "non-blocking, continuing to COMPLETE",
-                    ctx.op_id,
-                )
+            except ImportError:
+                logger.debug("[Orchestrator] AutoCommitter not available")
             except Exception as exc:
-                logger.debug(
-                    "[Orchestrator] Self-critique failed for op=%s: %s",
+                logger.warning(
+                    "[Orchestrator] Auto-commit failed for op=%s: %s; "
+                    "change is applied but not committed",
                     ctx.op_id, exc,
                 )
 
-        # ---- Phase 8d: Visual VERIFY ----
-        try:
-            from backend.core.ouroboros.governance.visual_verify import (
-                run_post_verify,
-            )
-            _vv_outcome = run_post_verify(
-                target_files=ctx.target_files,
-                attachments=ctx.attachments,
-                op_id=ctx.op_id,
-                op_description=ctx.description,
-                plan_ui_affected=False,
-                test_targets_resolved=(
-                    ctx.validation.adapter_names_run if ctx.validation else None
-                ),
-                risk_tier=(
-                    ctx.risk_tier.name.lower() if ctx.risk_tier else ""
-                ),
-                test_runner_result="passed",
-            )
-            if _vv_outcome.ran:
-                _vv_verdict = (
-                    _vv_outcome.result.verdict if _vv_outcome.result else "?"
-                )
-                logger.info(
-                    "[Orchestrator] Visual VERIFY outcome=%s "
-                    "l2_triggered=%s [%s] %s",
-                    _vv_verdict, _vv_outcome.l2_triggered,
-                    ctx.op_id, _vv_outcome.reasoning,
-                )
+            # ---- Phase 8b2: In-process hot-reload ----
+            if orch._hot_reloader is not None:
                 try:
-                    ctx = ctx.advance(OperationPhase.VISUAL_VERIFY)
-                except ValueError as _adv_exc:
-                    logger.debug(
-                        "[Orchestrator] VISUAL_VERIFY advance rejected "
-                        "(ctx at %s): %s", ctx.phase.name, _adv_exc,
+                    _hr_batch = orch._hot_reloader.reload_for_op(
+                        op_id=ctx.op_id,
+                        target_files=ctx.target_files,
+                    )
+                    if _hr_batch.overall_status == "success":
+                        _reloaded_names = [
+                            o.module_name.rsplit(".", 1)[-1]
+                            for o in _hr_batch.outcomes
+                            if o.status == "reloaded"
+                        ]
+                        logger.info(
+                            "[Orchestrator] Hot-reloaded %d module(s) for op=%s: %s",
+                            len(_reloaded_names), ctx.op_id, _reloaded_names,
+                        )
+                        try:
+                            await orch._stack.comm.emit_heartbeat(
+                                op_id=ctx.op_id, phase="hot_reload",
+                                progress_pct=99.0,
+                                reloaded_modules=_reloaded_names,
+                                reload_count=orch._hot_reloader.reload_count,
+                            )
+                        except Exception:
+                            pass
+                    elif _hr_batch.overall_status in ("reload_failed", "preflight_failed"):
+                        logger.warning(
+                            "[Orchestrator] Hot-reload failed for op=%s: %s; "
+                            "restart will be queued",
+                            ctx.op_id, _hr_batch.restart_reason,
+                        )
+                    elif _hr_batch.restart_required:
+                        logger.info(
+                            "[Orchestrator] Hot-reload deferred to restart for op=%s: %s",
+                            ctx.op_id, _hr_batch.restart_reason,
+                        )
+                except Exception as exc:
+                    logger.warning(
+                        "[Orchestrator] Hot-reload hook raised for op=%s: %s",
+                        ctx.op_id, exc,
                     )
 
-                _vv_fail = (
-                    _vv_outcome.l2_triggered
-                    or (
-                        _vv_outcome.result is not None
-                        and _vv_outcome.result.verdict == "fail"
-                    )
-                )
-                if _vv_fail and orch._config.repair_engine is not None:
-                    logger.info(
-                        "[Orchestrator] Visual VERIFY fail/advisory — "
-                        "routing to L2 repair [%s]", ctx.op_id,
-                    )
-                    _vv_deadline = ctx.pipeline_deadline or (
-                        datetime.now(timezone.utc) + timedelta(seconds=60)
-                    )
-                    _vv_synth_val = ValidationResult(
-                        passed=False,
-                        best_candidate=best_candidate,
-                        validation_duration_s=0.0,
-                        error=f"visual_verify: {_vv_outcome.reasoning}",
-                        failure_class="test",
-                        short_summary=(
-                            f"visual_verify: "
-                            f"{_vv_outcome.result.check if _vv_outcome.result else 'advisory'}"
+            # ---- Phase 8c: Self-critique ----
+            if orch._critique_engine is not None:
+                try:
+                    _test_summary = "(no test summary captured)"
+                    _vr = ctx.validation
+                    if _vr is not None:
+                        _passed = getattr(_vr, "tests_passed", 0) or 0
+                        _total = getattr(_vr, "tests_total", 0) or 0
+                        if _total:
+                            _test_summary = f"{_passed}/{_total} tests passed"
+                        elif _passed:
+                            _test_summary = f"{_passed} tests passed"
+                    _critique_result = await asyncio.wait_for(
+                        orch._critique_engine.critique_op(
+                            op_id=ctx.op_id,
+                            description=ctx.description,
+                            target_files=ctx.target_files,
+                            risk_tier=ctx.risk_tier,
+                            commit_hash=_committed_hash,
+                            test_summary=_test_summary,
                         ),
-                        adapter_names_run=(),
+                        timeout=float(os.environ.get("JARVIS_CRITIQUE_TIMEOUT_S", "30")) + 5.0,
                     )
                     try:
-                        _vv_directive = await orch._l2_hook(
-                            ctx, _vv_synth_val, _vv_deadline,
+                        await orch._stack.comm.emit_heartbeat(
+                            op_id=ctx.op_id,
+                            phase="critique",
+                            progress_pct=99.0,
+                            critique_rating=int(getattr(_critique_result, "rating", 0)),
+                            critique_matches_goal=bool(
+                                getattr(_critique_result, "matches_goal", True)
+                            ),
+                            critique_rationale=str(
+                                getattr(_critique_result, "rationale", "")
+                            )[:200],
+                            critique_provider=str(
+                                getattr(_critique_result, "provider_name", "")
+                            ),
+                            critique_parse_ok=bool(
+                                getattr(_critique_result, "parse_ok", True)
+                            ),
                         )
-                        if _vv_directive[0] == "break":
-                            _vv_l2_candidate = _vv_directive[1]
-                            _vv_l2_change = orch._build_change_request(
-                                ctx, _vv_l2_candidate,
-                            )
-                            try:
-                                # Anti-Venom C2 — shield Visual VERIFY L2
-                                # repair apply (cancel-safe, same as
-                                # primary apply + VERIFY L2 above).
-                                _vv_l2_result = await asyncio.shield(
-                                    orch._stack.change_engine.execute(
-                                        _vv_l2_change
-                                    )
-                                )
-                                if _vv_l2_result.success:
-                                    logger.info(
-                                        "[Orchestrator] Visual VERIFY L2 "
-                                        "repair applied [%s]", ctx.op_id,
-                                    )
-                                else:
-                                    logger.warning(
-                                        "[Orchestrator] Visual VERIFY L2 "
-                                        "repair candidate failed to apply [%s]",
-                                        ctx.op_id,
-                                    )
-                            except Exception as _vv_apply_exc:
-                                logger.debug(
-                                    "[Orchestrator] Visual VERIFY L2 apply "
-                                    "error: %s", _vv_apply_exc,
-                                )
-                        elif _vv_directive[0] in ("cancel", "fatal"):
-                            ctx = _vv_directive[1]
-                            logger.info(
-                                "[Orchestrator] L2 escaped Visual VERIFY — "
-                                "op ctx advanced to %s [%s]",
-                                ctx.phase.name, ctx.op_id,
-                            )
-                            return PhaseResult(
-                                next_ctx=ctx, next_phase=None, status="fail",
-                                reason=ctx.terminal_reason_code or "l2_escape_visual_verify",
-                                artifacts={"t_apply": _t_apply},
-                            )
-                    except Exception as _vv_l2_exc:
-                        logger.debug(
-                            "[Orchestrator] Visual VERIFY L2 failed: "
-                            "%s: %s",
-                            type(_vv_l2_exc).__name__, _vv_l2_exc,
+                    except Exception:
+                        pass
+                    if (
+                        getattr(_critique_result, "parse_ok", False)
+                        and getattr(_critique_result, "is_poor", False)
+                    ):
+                        _files_short = ", ".join(
+                            p.rsplit("/", 1)[-1] for p in ctx.target_files[:3]
                         )
-        except Exception as _vv_exc:
-            logger.debug(
-                "[Orchestrator] Visual VERIFY dispatch error: %s: %s",
-                type(_vv_exc).__name__, _vv_exc,
-            )
-        # ---- end verbatim transcription ----
+                        orch._add_session_lesson(
+                            "code",
+                            f"[CRITIQUE POOR {getattr(_critique_result, 'rating', '?')}/5] "
+                            f"{ctx.description[:60]} ({_files_short}): "
+                            f"{str(getattr(_critique_result, 'rationale', ''))[:120]}",
+                            op_id=ctx.op_id,
+                        )
+                except asyncio.TimeoutError:
+                    logger.info(
+                        "[Orchestrator] Self-critique timed out for op=%s — "
+                        "non-blocking, continuing to COMPLETE",
+                        ctx.op_id,
+                    )
+                except Exception as exc:
+                    logger.debug(
+                        "[Orchestrator] Self-critique failed for op=%s: %s",
+                        ctx.op_id, exc,
+                    )
 
-        # Success — hand off to COMPLETE via COMPLETERunner-equivalent.
-        # The orchestrator hook at this point will either call
-        # COMPLETERunner (if slice 1 flag on) or inline COMPLETE code.
-        return PhaseResult(
-            next_ctx=ctx,
-            next_phase=OperationPhase.COMPLETE,
-            status="ok",
-            reason="applied_and_verified",
-            artifacts={"t_apply": _t_apply},
-        )
+            # ---- Phase 8d: Visual VERIFY ----
+            try:
+                from backend.core.ouroboros.governance.visual_verify import (
+                    run_post_verify,
+                )
+                _vv_outcome = run_post_verify(
+                    target_files=ctx.target_files,
+                    attachments=ctx.attachments,
+                    op_id=ctx.op_id,
+                    op_description=ctx.description,
+                    plan_ui_affected=False,
+                    test_targets_resolved=(
+                        ctx.validation.adapter_names_run if ctx.validation else None
+                    ),
+                    risk_tier=(
+                        ctx.risk_tier.name.lower() if ctx.risk_tier else ""
+                    ),
+                    test_runner_result="passed",
+                )
+                if _vv_outcome.ran:
+                    _vv_verdict = (
+                        _vv_outcome.result.verdict if _vv_outcome.result else "?"
+                    )
+                    logger.info(
+                        "[Orchestrator] Visual VERIFY outcome=%s "
+                        "l2_triggered=%s [%s] %s",
+                        _vv_verdict, _vv_outcome.l2_triggered,
+                        ctx.op_id, _vv_outcome.reasoning,
+                    )
+                    try:
+                        ctx = ctx.advance(OperationPhase.VISUAL_VERIFY)
+                    except ValueError as _adv_exc:
+                        logger.debug(
+                            "[Orchestrator] VISUAL_VERIFY advance rejected "
+                            "(ctx at %s): %s", ctx.phase.name, _adv_exc,
+                        )
+
+                    _vv_fail = (
+                        _vv_outcome.l2_triggered
+                        or (
+                            _vv_outcome.result is not None
+                            and _vv_outcome.result.verdict == "fail"
+                        )
+                    )
+                    if _vv_fail and orch._config.repair_engine is not None:
+                        logger.info(
+                            "[Orchestrator] Visual VERIFY fail/advisory — "
+                            "routing to L2 repair [%s]", ctx.op_id,
+                        )
+                        _vv_deadline = ctx.pipeline_deadline or (
+                            datetime.now(timezone.utc) + timedelta(seconds=60)
+                        )
+                        _vv_synth_val = ValidationResult(
+                            passed=False,
+                            best_candidate=best_candidate,
+                            validation_duration_s=0.0,
+                            error=f"visual_verify: {_vv_outcome.reasoning}",
+                            failure_class="test",
+                            short_summary=(
+                                f"visual_verify: "
+                                f"{_vv_outcome.result.check if _vv_outcome.result else 'advisory'}"
+                            ),
+                            adapter_names_run=(),
+                        )
+                        try:
+                            _vv_directive = await orch._l2_hook(
+                                ctx, _vv_synth_val, _vv_deadline,
+                            )
+                            if _vv_directive[0] == "break":
+                                _vv_l2_candidate = _vv_directive[1]
+                                _vv_l2_change = orch._build_change_request(
+                                    ctx, _vv_l2_candidate,
+                                )
+                                try:
+                                    # Anti-Venom C2 — shield Visual VERIFY L2
+                                    # repair apply (cancel-safe, same as
+                                    # primary apply + VERIFY L2 above).
+                                    _vv_l2_result = await asyncio.shield(
+                                        orch._stack.change_engine.execute(
+                                            _vv_l2_change
+                                        )
+                                    )
+                                    if _vv_l2_result.success:
+                                        logger.info(
+                                            "[Orchestrator] Visual VERIFY L2 "
+                                            "repair applied [%s]", ctx.op_id,
+                                        )
+                                    else:
+                                        logger.warning(
+                                            "[Orchestrator] Visual VERIFY L2 "
+                                            "repair candidate failed to apply [%s]",
+                                            ctx.op_id,
+                                        )
+                                except Exception as _vv_apply_exc:
+                                    logger.debug(
+                                        "[Orchestrator] Visual VERIFY L2 apply "
+                                        "error: %s", _vv_apply_exc,
+                                    )
+                            elif _vv_directive[0] in ("cancel", "fatal"):
+                                ctx = _vv_directive[1]
+                                logger.info(
+                                    "[Orchestrator] L2 escaped Visual VERIFY — "
+                                    "op ctx advanced to %s [%s]",
+                                    ctx.phase.name, ctx.op_id,
+                                )
+                                return PhaseResult(
+                                    next_ctx=ctx, next_phase=None, status="fail",
+                                    reason=ctx.terminal_reason_code or "l2_escape_visual_verify",
+                                    artifacts={"t_apply": _t_apply},
+                                )
+                        except Exception as _vv_l2_exc:
+                            logger.debug(
+                                "[Orchestrator] Visual VERIFY L2 failed: "
+                                "%s: %s",
+                                type(_vv_l2_exc).__name__, _vv_l2_exc,
+                            )
+            except Exception as _vv_exc:
+                logger.debug(
+                    "[Orchestrator] Visual VERIFY dispatch error: %s: %s",
+                    type(_vv_exc).__name__, _vv_exc,
+                )
+            # ---- end verbatim transcription ----
+
+            # Success — hand off to COMPLETE via COMPLETERunner-equivalent.
+            # The orchestrator hook at this point will either call
+            # COMPLETERunner (if slice 1 flag on) or inline COMPLETE code.
+            return PhaseResult(
+                next_ctx=ctx,
+                next_phase=OperationPhase.COMPLETE,
+                status="ok",
+                reason="applied_and_verified",
+                artifacts={"t_apply": _t_apply},
+            )
+        finally:
+            if not _txn_commit_stage_reached and txn_lifecycle_guard_enabled():
+                logger.critical(
+                    "[TxnLifecycle] op=%s recorded APPLIED but NEVER reached "
+                    "the auto-commit stage -- transactional boundary breached",
+                    ctx.op_id,
+                )
+                # Any exception already in flight (incl. asyncio.CancelledError)
+                # must propagate UNCONVERTED -- finally does not swallow it, and
+                # we only synthesize the error on the SILENT exit path.
+                import sys as _sys
+                if _sys.exc_info()[0] is None:
+                    raise TransactionLifecycleError(ctx.op_id, "phase_8b_auto_commit")
 
 
 __all__ = ["Slice4bRunner"]

--- a/backend/core/ouroboros/governance/transaction_lifecycle.py
+++ b/backend/core/ouroboros/governance/transaction_lifecycle.py
@@ -1,0 +1,71 @@
+"""Transactional-lifecycle guard for the APPLY/VERIFY phase runner.
+
+A durability-substrate primitive. When the runner records the terminal
+``APPLIED`` ledger row for an op, the file mutation is already on disk and the
+op is inside a transactional span whose ONLY legitimate exits are:
+
+* reaching Phase 8b (auto-commit), or
+* a governed rollback / gate-failure that CLOSES the transaction (records a
+  ``FAILED`` ledger row, restores the pre-apply snapshot, publishes an
+  outcome).
+
+The failure this module makes impossible is the *silent third path*: an op
+that records ``APPLIED`` (mutation on disk, VERIFY green) yet exits the runner
+without ever reaching auto-commit and without any terminal signal -- no commit
+attempt, no exception, no log. That op simply vanishes; the ledger claims
+``APPLIED`` while nothing downstream ever learns the transaction closed.
+
+:class:`TransactionLifecycleError` converts that silence into a loud failure.
+The guard is enforced in a ``finally`` in the runner: it fires a
+``logger.critical`` ALWAYS, and raises this exception ONLY when the span is
+exiting without an in-flight exception (so a ``CancelledError`` or any other
+live exception propagates UNCONVERTED -- the guard never masks it).
+"""
+
+from __future__ import annotations
+
+import os
+
+
+class TransactionLifecycleError(RuntimeError):
+    """An op recorded APPLIED but exited the runner before auto-commit.
+
+    Raised only on the *silent* exit path (no in-flight exception). Carries the
+    ``op_id`` and the transactional ``boundary`` that was breached so the
+    failure is auditable.
+    """
+
+    def __init__(self, op_id: str, boundary: str) -> None:
+        self.op_id = op_id
+        self.boundary = boundary
+        super().__init__(
+            "op={op} recorded APPLIED but never reached transactional "
+            "boundary '{boundary}' -- silent post-apply exit".format(
+                op=op_id, boundary=boundary
+            )
+        )
+
+    def __str__(self) -> str:  # pragma: no cover - trivial
+        return (
+            "TransactionLifecycleError(op_id={op!r}, boundary={boundary!r}): "
+            "recorded APPLIED but never reached '{boundary}'".format(
+                op=self.op_id, boundary=self.boundary
+            )
+        )
+
+
+def txn_lifecycle_guard_enabled() -> bool:
+    """Return whether the transactional-lifecycle guard is armed.
+
+    Env ``JARVIS_TXN_LIFECYCLE_GUARD_ENABLED``, default ``true``. Read at call
+    time (never cached) so the kill switch is live. NEVER raises: any parsing
+    surprise resolves to the default-on posture.
+    """
+    try:
+        raw = os.environ.get("JARVIS_TXN_LIFECYCLE_GUARD_ENABLED", "true")
+        return str(raw).strip().lower() not in ("0", "false", "no", "off", "")
+    except Exception:  # noqa: BLE001 - a gate must never raise
+        return True
+
+
+__all__ = ["TransactionLifecycleError", "txn_lifecycle_guard_enabled"]

--- a/backend/core/ouroboros/governance/workspace_resolver.py
+++ b/backend/core/ouroboros/governance/workspace_resolver.py
@@ -51,12 +51,18 @@ import threading
 from pathlib import Path
 from typing import Dict, Optional
 
-__all__ = ["resolve_repo_root", "clear_cache"]
+__all__ = ["resolve_repo_root", "clear_cache", "resolve_durable_path"]
 
 # Operator override env var — the SAME one the existing TestWatcher /
 # TestFailureSensor already read, so this resolver is a drop-in single source
 # of truth rather than a competing convention.
 _ENV_REPO_PATH = "JARVIS_REPO_PATH"
+
+# Durable-path re-anchor env keys (isomorphic harness overlay fix). See
+# resolve_durable_path() below for the full contract.
+_ENV_REROOT_ENABLED = "JARVIS_DURABLE_REROOT_ENABLED"
+_ENV_REROOT_FROM = "JARVIS_DURABLE_REROOT_FROM"
+_ENV_DURABLE_ROOT = "JARVIS_TRINITY_ROOT"
 
 # Cache: resolved-start-path -> resolved repo root. Bounded by the number of
 # distinct start anchors (effectively 1-2 in production: the module path and
@@ -196,3 +202,37 @@ def clear_cache() -> None:
     """Drop the memoized resolutions (test isolation / env-flip support)."""
     with _CACHE_LOCK:
         _CACHE.clear()
+
+
+def resolve_durable_path(path):
+    """Re-anchor a DURABLE-state write path from a declared workspace
+    overlay root onto the harness-provided durable root.
+
+    Pure path algebra, env-driven at call time, identity when the
+    overlay pair is not declared (real node / plain local). The
+    harness that OWNS the overlay declares both ends:
+
+        JARVIS_DURABLE_REROOT_FROM=/opt/trinity/jarvis   (overlay root)
+        JARVIS_TRINITY_ROOT=<writable per-run durable root>
+
+    No host detection, no permission probing, no literal paths.
+    NEVER raises -- any error returns the input unchanged."""
+    try:
+        p = Path(path)
+        raw = os.environ.get(_ENV_REROOT_ENABLED, "true").strip().lower()
+        if raw not in ("1", "true", "yes", "on"):
+            return p
+        src = os.environ.get(_ENV_REROOT_FROM, "").strip()
+        dst = os.environ.get(_ENV_DURABLE_ROOT, "").strip()
+        if not src or not dst:
+            return p
+        try:
+            rel = p.relative_to(src)
+        except ValueError:
+            return p  # not under the overlay root -- untouched
+        return Path(dst) / rel
+    except Exception:  # noqa: BLE001 -- module contract: never raises
+        try:
+            return Path(path)
+        except Exception:  # noqa: BLE001
+            return Path(".")

--- a/docs/superpowers/plans/2026-07-04-durability-substrate-fix.md
+++ b/docs/superpowers/plans/2026-07-04-durability-substrate-fix.md
@@ -1,0 +1,287 @@
+# Durability Substrate Fix Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make the durability chain (ledger rows, AutoCommit, transaction lifecycle) structurally correct under ANY workspace overlay — no literal paths, no permission-swallowing, no host detection — and make Phase-8b non-arrival a thrown exception instead of silence.
+
+**Architecture:** (1) Extend the existing `workspace_resolver` contract with a pure, env-driven durable-path re-anchor (`resolve_durable_path`): when the harness declares an overlay pair (`JARVIS_DURABLE_REROOT_FROM` -> `JARVIS_TRINITY_ROOT`), any durable write targeting the overlay root is re-anchored onto the writable durable root by pure path algebra; with the pair unset (real node / normal local) it is the identity function. (2) Wire it at the single chokepoint every durable JSONL write already flows through (`cross_process_jsonl`'s 4 entry points) — zero per-caller edits. (3) Harness wires `JARVIS_AUTO_COMMIT_WORKSPACE` (already consumed by `AutoCommitter._effective_repo_root`) to the session worktree. (4) A `TransactionLifecycleError` sentinel in `slice4b_runner`: an op that records APPLIED but exits the runner without reaching Phase 8b raises loudly up the orchestrator tree. (5) Loop Deadman armed structurally in the ignition env composition.
+
+**Tech Stack:** Python 3.9+ stdlib (`pathlib`, `os`), existing `workspace_resolver.py` / `cross_process_jsonl.py` / `slice4b_runner.py` / `isomorphic_a1_local.py`. pytest TDD.
+
+## Root Cause (evidence, session bt-iso-1783130209)
+
+- 36× `[CrossProcessJSONL] parent mkdir failed: [Errno 13] Permission denied: '/opt/trinity'` — durable writers derive paths from the iso-overlaid project root (`/opt/trinity/jarvis`), unwritable on the macOS host → ledger rows `written=False` (op-944c).
+- The harness ALREADY exports `JARVIS_TRINITY_ROOT` → a real writable per-run dir; no writer consumes it (wired-but-inert #5). `workspace_resolver.py` exists precisely to kill literal-path divergence; the durable writers bypass it.
+- op-944c recorded APPLIED, mutated disk (git-verified, +11/−8), passed VERIFY 21/21 — then the runner went silent before Phase 8b (AutoCommit). Every branch of Phase 8b logs; nothing logged → non-arrival, and nothing raised. Silence at a transactional boundary is itself the defect.
+
+## Global Constraints
+
+- Python 3.9+; `from __future__ import annotations` at top of every touched module; ASCII-only in added lines.
+- NO host-detection conditionals (no `platform`/`sys.platform`/`os.uname` checks). NO catching `PermissionError`/`OSError` to paper over unwritable paths (the existing fail-soft in `flock_append_lines` stays as-is — we fix WHY it fires, we do not add more swallowing).
+- NO literal paths anywhere: `JARVIS_TRINITY_ROOT`, `JARVIS_DURABLE_REROOT_FROM`, `JARVIS_AUTO_COMMIT_WORKSPACE` are read from `os.environ` AT CALL TIME. Identity behavior when unset (real node / plain local = byte-identical).
+- DRY: the ONLY new path logic lives in `workspace_resolver.py`; `cross_process_jsonl` calls it at its entry points; no per-caller edits, no new directory-creator/scrubber utilities.
+- `TransactionLifecycleError` must NOT convert `asyncio.CancelledError` (log CRITICAL, re-raise the cancellation); must not fire on legitimate non-APPLIED exits (verify_regression/FAILED paths return before the sentinel arms).
+- Kill switches: `JARVIS_DURABLE_REROOT_ENABLED` (default `true`; off = identity even when the pair is set), `JARVIS_TXN_LIFECYCLE_GUARD_ENABLED` (default `true`; off = legacy silent behavior). Byte-identical legacy when off.
+
+---
+
+## Task 1: `resolve_durable_path` in `workspace_resolver.py`
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/workspace_resolver.py` (append; extend `__all__`)
+- Test: `tests/governance/test_workspace_resolver_durable.py` (new)
+
+**Interfaces:**
+- Produces: `resolve_durable_path(path: Union[str, Path]) -> Path` — pure, deterministic, never raises. Rules, in order:
+  1. `JARVIS_DURABLE_REROOT_ENABLED` false → return `Path(path)` unchanged.
+  2. Read `JARVIS_DURABLE_REROOT_FROM` and `JARVIS_TRINITY_ROOT` at call time. Either unset/empty → identity.
+  3. If `Path(path)` is relative to `FROM` (use `Path.resolve()`-free lexical containment — `os.path.commonpath` or `relative_to` in try/except `ValueError` ONLY, which is path algebra, not permission-swallowing) → return `TO / path.relative_to(FROM)`.
+  4. Otherwise identity.
+- Any internal exception → return the input unchanged (fail-soft to legacy; matches the module's existing "never raises" contract).
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_workspace_resolver_durable.py
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance.workspace_resolver import resolve_durable_path
+
+
+def test_identity_when_pair_unset(monkeypatch):
+    monkeypatch.delenv("JARVIS_DURABLE_REROOT_FROM", raising=False)
+    monkeypatch.delenv("JARVIS_TRINITY_ROOT", raising=False)
+    p = Path("/opt/trinity/jarvis/.jarvis/ledger.jsonl")
+    assert resolve_durable_path(p) == p  # real node / plain local: byte-identical
+
+
+def test_reanchors_overlay_path_onto_durable_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path / "trinity_root"))
+    out = resolve_durable_path(Path("/opt/trinity/jarvis/.jarvis/a1_lineage.jsonl"))
+    assert out == tmp_path / "trinity_root" / ".jarvis" / "a1_lineage.jsonl"
+
+
+def test_non_overlay_path_untouched(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path))
+    p = Path.cwd() / ".jarvis" / "local.jsonl"
+    assert resolve_durable_path(p) == p  # only overlay-rooted paths re-anchor
+
+
+def test_kill_switch_reverts_to_identity(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path))
+    p = Path("/opt/trinity/jarvis/.jarvis/x.jsonl")
+    assert resolve_durable_path(p) == p
+
+
+def test_never_raises_on_garbage(monkeypatch):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "\x00bad")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", "also-bad")
+    out = resolve_durable_path("/opt/trinity/jarvis/.jarvis/x.jsonl")
+    assert isinstance(out, Path)  # fail-soft identity, never raises
+```
+
+- [ ] **Step 2: Run — fails** (`python3 -m pytest tests/governance/test_workspace_resolver_durable.py -v` → ImportError)
+
+- [ ] **Step 3: Implement** (append to `workspace_resolver.py`; add `resolve_durable_path` to `__all__`; reuse the module's existing style)
+
+```python
+_ENV_REROOT_ENABLED = "JARVIS_DURABLE_REROOT_ENABLED"
+_ENV_REROOT_FROM = "JARVIS_DURABLE_REROOT_FROM"
+_ENV_DURABLE_ROOT = "JARVIS_TRINITY_ROOT"
+
+
+def resolve_durable_path(path):
+    """Re-anchor a DURABLE-state write path from a declared workspace
+    overlay root onto the harness-provided durable root.
+
+    Pure path algebra, env-driven at call time, identity when the
+    overlay pair is not declared (real node / plain local). The
+    harness that OWNS the overlay declares both ends:
+
+        JARVIS_DURABLE_REROOT_FROM=/opt/trinity/jarvis   (overlay root)
+        JARVIS_TRINITY_ROOT=<writable per-run durable root>
+
+    No host detection, no permission probing, no literal paths.
+    NEVER raises -- any error returns the input unchanged."""
+    try:
+        p = Path(path)
+        raw = os.environ.get(_ENV_REROOT_ENABLED, "true").strip().lower()
+        if raw not in ("1", "true", "yes", "on"):
+            return p
+        src = os.environ.get(_ENV_REROOT_FROM, "").strip()
+        dst = os.environ.get(_ENV_DURABLE_ROOT, "").strip()
+        if not src or not dst:
+            return p
+        try:
+            rel = p.relative_to(src)
+        except ValueError:
+            return p  # not under the overlay root -- untouched
+        return Path(dst) / rel
+    except Exception:  # noqa: BLE001 -- module contract: never raises
+        try:
+            return Path(path)
+        except Exception:  # noqa: BLE001
+            return Path(".")
+```
+
+- [ ] **Step 4: Run — 5 passed.**
+- [ ] **Step 5: Commit** — `git add backend/core/ouroboros/governance/workspace_resolver.py tests/governance/test_workspace_resolver_durable.py && git commit -m "feat(workspace): resolve_durable_path -- env-declared overlay re-anchor for durable writes (pure path algebra)"`
+
+---
+
+## Task 2: Chokepoint wiring in `cross_process_jsonl.py`
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/cross_process_jsonl.py` — the 4 public entry points (`flock_append_line` ~353, `flock_critical_section` ~381, `flock_append_lines` ~425, `async_flock_critical_section` ~504)
+- Test: `tests/governance/test_cross_process_jsonl_durable.py` (new)
+
+**Interfaces:**
+- Consumes: `resolve_durable_path` (Task 1).
+- Change: at the TOP of each entry point, before any `Path(path)` use: `path = resolve_durable_path(path)` (lazy import inside the function to avoid import cycles, matching the codebase convention). `lock_path` derives from the RESOLVED target (it already derives from `target`), so lock and data stay co-located. NO other logic changes; the existing fail-soft mkdir stays exactly as-is.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/governance/test_cross_process_jsonl_durable.py
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.core.ouroboros.governance.cross_process_jsonl import (
+    flock_append_line,
+    flock_append_lines,
+)
+
+
+def test_append_reanchors_overlay_path(monkeypatch, tmp_path):
+    """The bt-iso-1783130209 failure shape: a writer targets the overlay
+    root; with the pair declared, the write LANDS in the durable root."""
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path / "troot"))
+    ok = flock_append_line(
+        "/opt/trinity/jarvis/.jarvis/test_ledger.jsonl",
+        json.dumps({"op": "x", "state": "applied"}),
+    )
+    assert ok is True  # written=True -- the 944c failure mode killed
+    landed = tmp_path / "troot" / ".jarvis" / "test_ledger.jsonl"
+    assert landed.exists()
+    assert json.loads(landed.read_text().splitlines()[0])["state"] == "applied"
+    # the flock lock co-locates with the resolved target
+    assert not Path("/opt/trinity").exists()  # nothing touched the overlay root
+
+
+def test_append_lines_reanchors_and_batches(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path / "troot"))
+    ok = flock_append_lines(
+        "/opt/trinity/jarvis/.jarvis/batch.jsonl", ["{}", "{}"],
+    )
+    assert ok is True
+    assert len((tmp_path / "troot" / ".jarvis" / "batch.jsonl").read_text().splitlines()) == 2
+
+
+def test_identity_when_pair_unset(monkeypatch, tmp_path):
+    monkeypatch.delenv("JARVIS_DURABLE_REROOT_FROM", raising=False)
+    monkeypatch.delenv("JARVIS_TRINITY_ROOT", raising=False)
+    target = tmp_path / "plain.jsonl"
+    assert flock_append_line(str(target), "{}") is True
+    assert target.exists()  # legacy path byte-identical
+```
+
+- [ ] **Step 2: Run — first two tests fail** (write attempts `/opt/trinity` → `ok is False`).
+- [ ] **Step 3: Implement** — in each of the 4 entry points, first statement of the `try` body:
+
+```python
+        from backend.core.ouroboros.governance.workspace_resolver import (
+            resolve_durable_path,
+        )
+        path = resolve_durable_path(path)
+```
+
+(For `flock_critical_section`/`async_flock_critical_section` apply to their path/lock derivation input the same way — read each function first; the resolved path must feed BOTH the target and the lock derivation.)
+
+- [ ] **Step 4: Run new tests + the module's existing suite** — `python3 -m pytest tests/governance/test_cross_process_jsonl_durable.py tests/governance/ -k "cross_process or flock" -q` → all pass.
+- [ ] **Step 5: Commit** — `git commit -m "feat(durability): route all CrossProcessJSONL entry points through resolve_durable_path (kills written=False under overlay)"`
+
+---
+
+## Task 3: Harness declares the overlay pair + AutoCommit workspace
+
+**Files:**
+- Modify: `scripts/isomorphic_a1_local.py` (the env-composition block — find via `grep -n "JARVIS_TRINITY_ROOT" scripts/isomorphic_a1_local.py`, add the two new keys beside it)
+- Test: `tests/battle_test/test_iso_env_durable_pair.py` (new; match the existing iso-env test file conventions — check `ls tests/battle_test/ | grep iso` first and extend the existing env-composition test module if one exists instead of creating a parallel one)
+
+**Change:** where the driver composes the child env (it already sets `JARVIS_TRINITY_ROOT`), add:
+- `JARVIS_DURABLE_REROOT_FROM=<the iso overlay root>` (the same value the driver passes as the isomorphic repo root, e.g. its `iso_root`/`/opt/trinity/jarvis` variable — use the VARIABLE, never a literal),
+- `JARVIS_AUTO_COMMIT_WORKSPACE=<the session auto worktree path>` IF the driver/harness knows it at compose time; if the worktree is created later by the harness, set it in `battle_test/harness.py` at worktree creation instead (find via `grep -n "ouroboros__auto__" backend/core/ouroboros/battle_test/harness.py` — set `os.environ["JARVIS_AUTO_COMMIT_WORKSPACE"] = str(worktree_path)` right where the auto worktree is materialized; `AutoCommitter._effective_repo_root` already consumes and VALIDATES it, falling back safely — zero committer changes).
+
+- [ ] **Step 1: failing test** — assert the composed env dict contains both keys with values derived from the driver's own variables (not literals). Write against the driver's env-compose function (read it first; it returned "147 keys" in the live run, so there is a compose function to unit-test).
+- [ ] **Step 2-4: implement, run, commit** — `git commit -m "feat(iso): declare durable-reroot pair + auto-commit workspace in composed env (harness owns the overlay ends)"`
+
+---
+
+## Task 4: `TransactionLifecycleError` — Phase-8b non-arrival is LOUD
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/transaction_lifecycle.py` (tiny: the exception + the env gate)
+- Modify: `backend/core/ouroboros/governance/phase_runners/slice4b_runner.py` (sentinel around the APPLIED→Phase-8b span: arm after `_record_ledger(ctx, OperationState.APPLIED, ...)` at ~line 947; disarm at the first statement of Phase 8b at ~line 1310; enforce in a `finally`)
+- Test: `tests/governance/test_transaction_lifecycle_guard.py` (new)
+
+**Interfaces:**
+- `class TransactionLifecycleError(RuntimeError)` with `op_id` and `boundary` attrs.
+- `txn_lifecycle_guard_enabled() -> bool` — env `JARVIS_TXN_LIFECYCLE_GUARD_ENABLED`, default True.
+
+**Runner change shape (adapt names to the actual code):**
+
+```python
+        # arm immediately after the APPLIED ledger row
+        _txn_commit_stage_reached = False
+        try:
+            ... existing 8a scoped tests / benchmark / gates ...
+            # first statement of Phase 8b:
+            _txn_commit_stage_reached = True
+            ... existing Phase 8b + rest ...
+        finally:
+            if not _txn_commit_stage_reached and txn_lifecycle_guard_enabled():
+                logger.critical(
+                    "[TxnLifecycle] op=%s recorded APPLIED but NEVER reached "
+                    "the auto-commit stage -- transactional boundary breached",
+                    ctx.op_id,
+                )
+                # CancelledError/exceptions already in flight propagate on
+                # their own (finally does not swallow); ONLY raise when the
+                # block is exiting WITHOUT an active exception:
+                import sys as _sys
+                if _sys.exc_info()[0] is None:
+                    raise TransactionLifecycleError(ctx.op_id, "phase_8b_auto_commit")
+```
+
+Semantics the tests must pin: (a) normal path (reaches 8b) → no raise, no CRITICAL; (b) a silent early `return` between APPLIED and 8b → `TransactionLifecycleError` raised; (c) an exception in the span (incl. `asyncio.CancelledError`) → CRITICAL logged, ORIGINAL exception propagates (not converted); (d) legitimate pre-APPLIED failure exits (verify_regression path returns before the sentinel arms) → untouched; (e) kill switch off → legacy silence. NOTE: the verify_regression rollback path between APPLIED and 8b DOES return legitimately — the implementer must disarm the sentinel on that path too (`_txn_commit_stage_reached = True` before its `return`, or arm-scope placed after it): a rolled-back FAILED op is a CLOSED transaction, not a breach. Test (f) pins that.
+
+- [ ] Steps: failing tests (unit-test the guard shape with a minimal async fn mimicking the spans; plus a source-level assertion that `slice4b_runner.py` contains the arm/disarm/finally trio) → implement → run `tests/governance/test_transaction_lifecycle_guard.py` + `python3 -m pytest tests/governance/ -k "slice4b or apply" -q` → commit `git commit -m "feat(txn): TransactionLifecycleError -- APPLIED ops that never reach auto-commit now raise loudly (kill silent boundary exits)"`
+
+---
+
+## Task 5: Arm the Loop Deadman structurally + full regression
+
+**Files:**
+- Modify: `scripts/isomorphic_a1_local.py` env composition (same block as Task 3): `JARVIS_LOOP_DEADMAN_TIMEOUT_S` (default "8") and `JARVIS_LOOP_DEADMAN_STACK_DUMP` (default "true") — `setdefault` semantics so an operator override wins (LESSON: `setdefault` LOST to the compose-env manifest once before, #69824 — verify the compose function's precedence and use whichever mechanism actually lands the key, with a test).
+- Test: extend the Task-3 env test: both keys present in the composed env.
+- Full sweep: `python3 -m pytest tests/governance/test_workspace_resolver_durable.py tests/governance/test_cross_process_jsonl_durable.py tests/governance/test_transaction_lifecycle_guard.py tests/battle_test/ -k "iso_env or durable or lifecycle" -q` plus `python3 -m pytest tests/governance/ -k "workspace or cross_process or slice4b" -q`.
+- Ledger entry + commit.
+
+---
+
+## Self-Review
+
+1. **Mandate coverage:** #1 root-cause (resolution layer only; no OS checks — the design has zero `platform` reads; no new permission catches — only the pre-existing fail-soft remains) → Tasks 1-2. #2 dynamic (all three env keys read at call time; identity when unset) → Tasks 1-3. #3 DRY (one resolver function; 4-line chokepoint wiring; zero per-caller edits; AutoCommitter untouched — its existing env seam is wired by the harness) → Tasks 1-3. #4 bulletproof (thrown `TransactionLifecycleError`, CancelledError-safe, rollback-path-safe; Deadman armed structurally) → Tasks 4-5.
+2. **Placeholder scan:** Task 3/5 contain grep-first lookup steps with exact commands (compose-function location, worktree-creation site) — lookups, not placeholders; all code shapes given.
+3. **Type consistency:** `resolve_durable_path(path) -> Path` consumed identically in Task 2; env key names identical across Tasks 1/3/5; `TransactionLifecycleError(op_id, boundary)` consistent in Task 4.
+4. **Honest limits:** this fixes the durability WRITE class + makes the silent-exit class impossible to miss. The exact line where 944c's runner stopped remains undiagnosed — Task 4's guard + Task 5's Deadman convert any recurrence into a stack-trace-bearing, loudly-failing event on the next ignition, which is the correct instrument to close it.

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1219,6 +1219,26 @@ class IsomorphicA1Driver:
                 # and container mode (the real bind-mount path).
                 env["JARVIS_DURABLE_REROOT_FROM"] = str(env_ctx.root)
 
+                # ---- Loop Deadman, armed structurally (durability-substrate
+                # fix, Task 5) ----
+                # compose_env() (a1_live_fire_chaos_harness.py) copies
+                # os.environ FIRST, then layers overlay files + derived
+                # cognitive flags + apply_manifest() -- none of which
+                # mention JARVIS_LOOP_DEADMAN_* (verified: absent from both
+                # deploy/ouroboros_linux_prod.env and
+                # deploy/ouroboros_omni_prod.env, and apply_manifest()'s
+                # fixed key set), so an operator-set value already sitting
+                # in os.environ survives untouched into `env`. setdefault
+                # here therefore has correct override semantics -- unlike
+                # the JARVIS_BG_POOL_SIZE case (#69824) where the compose
+                # manifest itself later stomped the key, a plain
+                # env[...] = default would have been wrong THERE but is
+                # unnecessary caution HERE. Armed so any future silent-stop
+                # (the op-944c class) yields a faulthandler stack dump
+                # instead of an open-ended investigation.
+                env.setdefault("JARVIS_LOOP_DEADMAN_TIMEOUT_S", "8")
+                env.setdefault("JARVIS_LOOP_DEADMAN_STACK_DUMP", "true")
+
                 # ---- Deterministic Synthetic Roadmap (A1 emit-hop provenance) ----
                 # compose_env arms the orchestrator + A1Trace flags but NOT the
                 # roadmap READER, and no signed roadmap exists -> the strategic-GOAL

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1206,6 +1206,19 @@ class IsomorphicA1Driver:
                 os.makedirs(_trinity_root, exist_ok=True)
                 env["JARVIS_TRINITY_ROOT"] = _trinity_root
 
+                # ---- Durable re-root overlay pair (durability-substrate fix,
+                # Task 3) ----
+                # workspace_resolver.resolve_durable_path() (Task 1) re-anchors
+                # any path an organism component computes under the overlay
+                # root onto JARVIS_TRINITY_ROOT above. The FROM side of that
+                # pair MUST be the driver's OWN overlay-root variable --
+                # env_ctx.root IS the IsomorphicEnv's live-shaped path (the
+                # symlink the organism believes is its literal
+                # /opt/trinity/jarvis) -- never a hardcoded literal, so this
+                # stays correct under both process mode (tmp-rooted symlink)
+                # and container mode (the real bind-mount path).
+                env["JARVIS_DURABLE_REROOT_FROM"] = str(env_ctx.root)
+
                 # ---- Deterministic Synthetic Roadmap (A1 emit-hop provenance) ----
                 # compose_env arms the orchestrator + A1Trace flags but NOT the
                 # roadmap READER, and no signed roadmap exists -> the strategic-GOAL

--- a/tests/battle_test/test_iso_env_durable_pair.py
+++ b/tests/battle_test/test_iso_env_durable_pair.py
@@ -1,0 +1,206 @@
+"""tests/battle_test/test_iso_env_durable_pair.py -- Task 3 (durability
+substrate, "the HARNESS declares both ends of the durable-reroot overlay
+pair").
+
+Pins the harness-side declaration of the durable-reroot overlay pair that
+``workspace_resolver.resolve_durable_path`` (Task 1) consumes:
+
+  * ``JARVIS_TRINITY_ROOT`` -- the writable per-run state root (pre-existing,
+    Blocker #4 fix) -- resolve_durable_path's TO side.
+  * ``JARVIS_DURABLE_REROOT_FROM`` -- the isomorphic env's OWN overlay-root
+    variable (``env_ctx.root``, e.g. the live-shaped ``/opt/trinity/jarvis``
+    symlink the organism believes it lives at), never a hardcoded literal --
+    resolve_durable_path's FROM side.
+
+Both keys must land in the SAME composed env dict the organism subprocess
+receives, and the FROM value must equal the driver's own ``env_ctx.root``
+(proven by varying the fake IsomorphicEnv's root across runs and asserting
+equality each time -- a literal would fail on the second run).
+
+Test conventions mirror ``tests/integration/test_isomorphic_a1_e2e.py``'s
+``TestSubprocessIsomorphismPropagation`` group (same script-loading shim,
+same capturing-compose_env pattern, same stub-soak driver invocation).
+"""
+from __future__ import annotations
+
+import importlib.util
+import json
+import os
+import sys
+from pathlib import Path
+from typing import Any, Dict, List
+from unittest.mock import patch
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Path bootstrap -- scripts are not packages; add them to sys.path
+# ---------------------------------------------------------------------------
+_REPO_ROOT = str((Path(__file__).parent.parent.parent).resolve())
+_SCRIPTS_DIR = str((Path(__file__).parent.parent.parent / "scripts").resolve())
+
+for _p in (_REPO_ROOT, _SCRIPTS_DIR, os.path.join(_REPO_ROOT, "backend")):
+    if _p not in sys.path:
+        sys.path.insert(0, _p)
+
+
+def _load_script(name: str) -> Any:
+    """Load a script by name; return cached module if already in sys.modules.
+
+    Cache-first is CRITICAL: patch.object(mod, attr) must patch the SAME
+    object that the driver's _load_module() returns -- both must be the
+    same sys.modules entry.
+    """
+    if name in sys.modules:
+        return sys.modules[name]
+    path = os.path.join(_SCRIPTS_DIR, name + ".py")
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, "Cannot load %s from %s" % (name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod  # store BEFORE exec (handle circular refs)
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_driver_mod = _load_script("isomorphic_a1_local")
+IsomorphicA1Driver = _driver_mod.IsomorphicA1Driver
+
+
+class _MockAdversary:
+    async def start(self) -> Dict[str, str]:
+        return {"doubleword": "http://127.0.0.1:19996/dw"}
+
+    async def stop(self) -> None:
+        pass
+
+    def env_overrides(self) -> Dict[str, str]:
+        return {}
+
+    def schedule(self, **_: Any) -> None:
+        pass
+
+    def set_simulate_zero_shot(self, enabled: bool) -> None:
+        pass
+
+
+class _NoopEnv:
+    """Stand-in for IsomorphicEnv -- ``root`` is the ONLY attribute the
+    driver reads off it for the durable-reroot pair, so this fake stays
+    deliberately minimal (mirrors the precedent fake in
+    test_isomorphic_a1_e2e.py's TestSubprocessIsomorphismPropagation)."""
+
+    def __init__(self, root: Path) -> None:
+        self.root = root
+
+    def __enter__(self) -> "_NoopEnv":
+        return self
+
+    def __exit__(self, *args: Any) -> bool:
+        return False
+
+
+class _CapturingChaos:
+    def status(self) -> Dict[str, Any]:
+        return {"active": False}
+
+    def inject(self, seed: int) -> bool:
+        return True
+
+    def revert(self) -> bool:
+        return True
+
+
+class _CapturingAuditor:
+    def watch(self, **kwargs: Any) -> Dict[str, Any]:
+        vpath = kwargs.get("verdict_out", "")
+        v: Dict[str, Any] = {"proven": False, "failure_locus": "test"}
+        if vpath:
+            Path(vpath).parent.mkdir(parents=True, exist_ok=True)
+            Path(vpath).write_text(json.dumps(v))
+        return v
+
+
+async def _run_driver_and_capture_env(
+    tmp_path: Path, overlay_root: Path,
+) -> Dict[str, str]:
+    """Runs the stub-soak driver end to end and returns the FINAL composed
+    env dict (post in-place mutations) the organism subprocess would see."""
+    harness_mod = _load_script("a1_live_fire_chaos_harness")
+    original_compose = harness_mod.compose_env
+    # Capture the dict REFERENCE returned by compose_env so we see the
+    # driver's in-place mutations (env["JARVIS_TRINITY_ROOT"] = ...,
+    # env["JARVIS_DURABLE_REROOT_FROM"] = ...) that happen AFTER compose_env
+    # returns.
+    env_ref: List[Dict[str, str]] = []
+
+    def _capturing_compose(**kwargs: Any) -> Dict[str, str]:
+        env = original_compose(**kwargs)
+        env_ref.append(env)  # store reference; driver mutates in-place
+        return env
+
+    driver = IsomorphicA1Driver(
+        repo_root=str(tmp_path),
+        stub_soak=True,
+        seed=0,
+        run_root=str(tmp_path / "runs"),
+        enable_failover=False,  # default
+        _adversary_factory=lambda: _MockAdversary(),
+    )
+
+    with (
+        patch(
+            "backend.core.ouroboros.battle_test.isomorphic_env.IsomorphicEnv",
+            return_value=_NoopEnv(overlay_root),
+        ),
+        patch.object(harness_mod, "compose_env", _capturing_compose),
+        patch.object(harness_mod, "ChaosController", lambda **kw: _CapturingChaos()),
+        patch.object(harness_mod, "StubAuditorRunner", lambda **kw: _CapturingAuditor()),
+    ):
+        await driver.run()
+
+    assert env_ref, "compose_env must have been called"
+    return env_ref[0]
+
+
+async def test_composed_env_carries_both_durable_reroot_keys(
+    tmp_path: Path,
+) -> None:
+    """The composed env MUST carry both halves of the durable-reroot overlay
+    pair: JARVIS_TRINITY_ROOT (the writable TO side, pre-existing Blocker #4
+    fix) and JARVIS_DURABLE_REROOT_FROM (the overlay FROM side, this task)."""
+    overlay_root = tmp_path / "opt" / "trinity" / "jarvis"
+    overlay_root.mkdir(parents=True, exist_ok=True)
+
+    final_env = await _run_driver_and_capture_env(tmp_path, overlay_root)
+
+    assert "JARVIS_TRINITY_ROOT" in final_env, (
+        "JARVIS_TRINITY_ROOT must remain composed (pre-existing Blocker #4 "
+        "fix) -- got keys: %r" % sorted(final_env.keys())
+    )
+    assert "JARVIS_DURABLE_REROOT_FROM" in final_env, (
+        "JARVIS_DURABLE_REROOT_FROM must be composed alongside "
+        "JARVIS_TRINITY_ROOT so resolve_durable_path() has both halves "
+        "of the overlay pair"
+    )
+
+
+async def test_durable_reroot_from_equals_driver_own_overlay_root(
+    tmp_path: Path,
+) -> None:
+    """JARVIS_DURABLE_REROOT_FROM must equal the driver's OWN overlay-root
+    variable (env_ctx.root) -- never a hardcoded literal. Proven by varying
+    the fake IsomorphicEnv's root across two independent runs and asserting
+    the composed value tracks it each time; a literal (e.g. a bare
+    "/opt/trinity/jarvis" string) would fail this on the second run because
+    the fake root here is a tmp_path-scoped directory, not that literal."""
+    for i in range(2):
+        overlay_root = tmp_path / ("run_%d" % i) / "opt" / "trinity" / "jarvis"
+        overlay_root.mkdir(parents=True, exist_ok=True)
+
+        final_env = await _run_driver_and_capture_env(tmp_path, overlay_root)
+
+        assert final_env["JARVIS_DURABLE_REROOT_FROM"] == str(overlay_root), (
+            "FROM must derive from the driver's OWN env_ctx.root variable, "
+            "never a literal; got %r for overlay_root=%r"
+            % (final_env.get("JARVIS_DURABLE_REROOT_FROM"), overlay_root)
+        )

--- a/tests/battle_test/test_iso_env_durable_pair.py
+++ b/tests/battle_test/test_iso_env_durable_pair.py
@@ -204,3 +204,70 @@ async def test_durable_reroot_from_equals_driver_own_overlay_root(
             "never a literal; got %r for overlay_root=%r"
             % (final_env.get("JARVIS_DURABLE_REROOT_FROM"), overlay_root)
         )
+
+
+# ---------------------------------------------------------------------------
+# Task 5 -- Loop Deadman armed structurally in the iso driver's env compose.
+#
+# compose_env() (a1_live_fire_chaos_harness.py:227) starts from
+# ``dict(os.environ)`` (inherits operator overrides) then layers overlay
+# files + derived cognitive flags + apply_manifest() -- none of which
+# mention JARVIS_LOOP_DEADMAN_* (grepped: not in ouroboros_linux_prod.env,
+# ouroboros_omni_prod.env, or apply_manifest's fixed key set), so nothing
+# inside compose_env() re-touches these two keys after the driver assigns
+# them. That is the SAME precondition the Task-3 durable-reroot pair above
+# relies on -- direct post-compose_env mutation on the returned dict
+# reference is proven (by this file's own capturing-compose_env harness) to
+# survive to the organism subprocess.
+# ---------------------------------------------------------------------------
+
+
+async def test_composed_env_carries_loop_deadman_defaults(
+    tmp_path: Path,
+) -> None:
+    """Both Loop Deadman keys must land in the composed env with the iso
+    soak's fast-feedback defaults (8s timeout, stack dump on) when the
+    operator did not already set them."""
+    overlay_root = tmp_path / "opt" / "trinity" / "jarvis"
+    overlay_root.mkdir(parents=True, exist_ok=True)
+
+    for _k in ("JARVIS_LOOP_DEADMAN_TIMEOUT_S", "JARVIS_LOOP_DEADMAN_STACK_DUMP"):
+        os.environ.pop(_k, None)
+
+    final_env = await _run_driver_and_capture_env(tmp_path, overlay_root)
+
+    assert final_env.get("JARVIS_LOOP_DEADMAN_TIMEOUT_S") == "8", (
+        "JARVIS_LOOP_DEADMAN_TIMEOUT_S must default to the iso soak's fast "
+        "8s ceiling -- got %r" % final_env.get("JARVIS_LOOP_DEADMAN_TIMEOUT_S")
+    )
+    assert final_env.get("JARVIS_LOOP_DEADMAN_STACK_DUMP") == "true", (
+        "JARVIS_LOOP_DEADMAN_STACK_DUMP must default to true so a fired "
+        "deadman yields a faulthandler stack -- got %r"
+        % final_env.get("JARVIS_LOOP_DEADMAN_STACK_DUMP")
+    )
+
+
+async def test_operator_loop_deadman_override_wins(tmp_path: Path) -> None:
+    """An operator-preseeded value in os.environ (which compose_env() copies
+    into the composed dict BEFORE the driver's post-compose assignment)
+    must be preserved -- never clobbered by the driver's defaults."""
+    overlay_root = tmp_path / "opt" / "trinity" / "jarvis"
+    overlay_root.mkdir(parents=True, exist_ok=True)
+
+    with patch.dict(
+        os.environ,
+        {
+            "JARVIS_LOOP_DEADMAN_TIMEOUT_S": "45",
+            "JARVIS_LOOP_DEADMAN_STACK_DUMP": "false",
+        },
+    ):
+        final_env = await _run_driver_and_capture_env(tmp_path, overlay_root)
+
+    assert final_env["JARVIS_LOOP_DEADMAN_TIMEOUT_S"] == "45", (
+        "operator override must win over the driver's '8' default -- got %r"
+        % final_env.get("JARVIS_LOOP_DEADMAN_TIMEOUT_S")
+    )
+    assert final_env["JARVIS_LOOP_DEADMAN_STACK_DUMP"] == "false", (
+        "operator override must win over the driver's 'true' default -- got %r"
+        % final_env.get("JARVIS_LOOP_DEADMAN_STACK_DUMP")
+    )

--- a/tests/governance/test_autonomous_workspace.py
+++ b/tests/governance/test_autonomous_workspace.py
@@ -106,6 +106,31 @@ async def test_autonomous_route_unifies_commit_workspace_env(
     assert os.environ["JARVIS_AUTO_COMMIT_WORKSPACE"] == str(out)
 
 
+async def test_autonomous_route_does_not_clobber_operator_override(
+    tmp_path, monkeypatch,
+):
+    """Task 3 (durability substrate): this is the SINGLE canonical
+    materialization seam for JARVIS_AUTO_COMMIT_WORKSPACE (Ledger-Sovereignty
+    reuses it via its own already-set check). An operator-supplied value MUST
+    win -- setdefault semantics, not unconditional overwrite -- otherwise a
+    deliberately pinned workspace gets silently clobbered by whatever
+    worktree this call happens to create."""
+    import os
+    from backend.core.ouroboros.governance import autonomous_workspace as aw
+    monkeypatch.setenv("JARVIS_FILE_ISOLATION_ENABLED", "true")
+    monkeypatch.setattr(ec, "is_autonomous", lambda *a, **k: True)
+    operator_pin = str(tmp_path / "operator-pinned-workspace")
+    monkeypatch.setenv("JARVIS_AUTO_COMMIT_WORKSPACE", operator_pin)
+    mgr = _FakeMgr(tmp_path)
+    out = await aw.resolve_loop_project_root(
+        tmp_path, session_id="bt-1", worktree_manager=mgr,
+    )
+    # A worktree IS still created (routing still happens)...
+    assert out != tmp_path
+    # ...but the operator's pin survives untouched in the env.
+    assert os.environ["JARVIS_AUTO_COMMIT_WORKSPACE"] == operator_pin
+
+
 async def test_create_failure_falls_back_to_repo_root(tmp_path, monkeypatch):
     from backend.core.ouroboros.governance import autonomous_workspace as aw
     monkeypatch.setenv("JARVIS_FILE_ISOLATION_ENABLED", "true")

--- a/tests/governance/test_cross_process_jsonl.py
+++ b/tests/governance/test_cross_process_jsonl.py
@@ -475,13 +475,16 @@ class TestAuthorityInvariants:
         assert "LOCK_UN" in source
 
     def test_public_api_exported(self):
+        # Synced 2026-07-03: added async_flock_critical_section + stale_lock_age_s (pre-existing drift, predates durability branch)
         expected = {
             "CROSS_PROCESS_JSONL_SCHEMA_VERSION",
+            "async_flock_critical_section",
             "fcntl_available",
             "flock_append_line",
             "flock_append_lines",
             "flock_critical_section",
             "lock_timeout_s",
+            "stale_lock_age_s",
         }
         assert set(cpj.__all__) == expected
 

--- a/tests/governance/test_cross_process_jsonl.py
+++ b/tests/governance/test_cross_process_jsonl.py
@@ -379,6 +379,31 @@ def _module_path() -> Path:
 
 
 class TestAuthorityInvariants:
+    # NARROW SELF-SEALING ALLOWLIST (durable-reroot fix, 2026-07-04).
+    #
+    # cross_process_jsonl may import EXACTLY ONE governance module:
+    # workspace_resolver. Rationale:
+    #
+    #   * workspace_resolver is the repo's single-source-of-truth path
+    #     resolver -- stdlib-only, pure path algebra, zero authority
+    #     (no orchestrator/policy/iron_gate coupling, never raises).
+    #   * The durable-reroot fix requires the flock substrate itself to
+    #     resolve durable paths via resolve_durable_path() so overlay-
+    #     rooted ledger/WAL/audit writes land in the durable root
+    #     instead of silently returning written=False (op-944c shape).
+    #   * Env-driven resolution at the chokepoint is the ONLY mechanism
+    #     that inherits correctly into subprocess pool workers -- a
+    #     boot-injected hook would NOT propagate cross-process.
+    #
+    # The allowance is EXACT-MATCH (not prefix/substring): every other
+    # governance.* import stays banned, and the companion test below
+    # (test_workspace_resolver_stays_stdlib_only) pins the resolver to
+    # a stdlib-only import surface so this allowlist can never become
+    # an authority tunnel.
+    _ALLOWED_GOVERNANCE_IMPORTS = (
+        "backend.core.ouroboros.governance.workspace_resolver",
+    )
+
     def test_no_governance_imports(self):
         path = _module_path()
         source = path.read_text(encoding="utf-8")
@@ -389,6 +414,8 @@ class TestAuthorityInvariants:
                 for alias in node.names:
                     if alias.name.startswith(
                         "backend.core.ouroboros.governance",
+                    ) and alias.name not in (
+                        self._ALLOWED_GOVERNANCE_IMPORTS
                     ):
                         offenders.append(alias.name)
                     for fb in _FORBIDDEN_GOVERNANCE_SUBSTRINGS:
@@ -398,11 +425,43 @@ class TestAuthorityInvariants:
                 mod = node.module or ""
                 if mod.startswith(
                     "backend.core.ouroboros.governance",
-                ):
+                ) and mod not in self._ALLOWED_GOVERNANCE_IMPORTS:
                     offenders.append(mod)
         assert offenders == [], (
             f"cross_process_jsonl imports forbidden modules: "
             f"{offenders}"
+        )
+
+    def test_workspace_resolver_stays_stdlib_only(self):
+        # SELF-SEALING COMPANION to the allowlist above: the ONLY
+        # governance module cross_process_jsonl may import must itself
+        # import stdlib only. Any future governance / third-party
+        # import inside workspace_resolver re-fails the invariant
+        # suite loudly, so the exact-match allowance can never become
+        # an authority tunnel into the flock substrate.
+        allowed_stdlib = {"os", "threading", "pathlib", "typing", "__future__"}
+        resolver_path = (
+            _module_path().parent / "workspace_resolver.py"
+        )
+        source = resolver_path.read_text(encoding="utf-8")
+        tree = ast.parse(source, filename=str(resolver_path))
+        offenders = []
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Import):
+                for alias in node.names:
+                    top = alias.name.split(".")[0]
+                    if top not in allowed_stdlib:
+                        offenders.append(alias.name)
+            elif isinstance(node, ast.ImportFrom):
+                mod = node.module or ""
+                top = mod.split(".")[0]
+                if top not in allowed_stdlib:
+                    offenders.append(mod)
+        assert offenders == [], (
+            f"workspace_resolver must stay stdlib-only "
+            f"(allowed: {sorted(allowed_stdlib)}); found forbidden "
+            f"imports: {offenders} -- the cross_process_jsonl "
+            f"allowlist depends on this purity"
         )
 
     def test_uses_fcntl_for_cross_process_lock(self):

--- a/tests/governance/test_cross_process_jsonl_durable.py
+++ b/tests/governance/test_cross_process_jsonl_durable.py
@@ -1,0 +1,55 @@
+"""Task 2 (durability-substrate fix) -- proves the 4 CrossProcessJSONL
+public entry points route through ``resolve_durable_path`` before any
+``Path(path)`` use, so an overlay-rooted writer lands in the durable
+root instead of silently returning ``written=False`` (the op-944c /
+bt-iso-1783130209 failure shape)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from backend.core.ouroboros.governance.cross_process_jsonl import (
+    flock_append_line,
+    flock_append_lines,
+)
+
+
+def test_append_reanchors_overlay_path(monkeypatch, tmp_path):
+    """The bt-iso-1783130209 failure shape: a writer targets the overlay
+    root; with the pair declared, the write LANDS in the durable root."""
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path / "troot"))
+    ok = flock_append_line(
+        "/opt/trinity/jarvis/.jarvis/test_ledger.jsonl",
+        json.dumps({"op": "x", "state": "applied"}),
+    )
+    assert ok is True  # written=True -- the 944c failure mode killed
+    landed = tmp_path / "troot" / ".jarvis" / "test_ledger.jsonl"
+    assert landed.exists()
+    assert json.loads(landed.read_text().splitlines()[0])["state"] == "applied"
+    # the flock lock co-locates with the resolved target, never the overlay
+    lock_path = landed.with_suffix(landed.suffix + ".lock")
+    assert lock_path.exists()
+    assert not Path("/opt/trinity").exists()  # nothing touched the overlay root
+
+
+def test_append_lines_reanchors_and_batches(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path / "troot"))
+    ok = flock_append_lines(
+        "/opt/trinity/jarvis/.jarvis/batch.jsonl", ["{}", "{}"],
+    )
+    assert ok is True
+    landed = tmp_path / "troot" / ".jarvis" / "batch.jsonl"
+    assert len(landed.read_text().splitlines()) == 2
+    lock_path = landed.with_suffix(landed.suffix + ".lock")
+    assert lock_path.exists()
+    assert not Path("/opt/trinity").exists()
+
+
+def test_identity_when_pair_unset(monkeypatch, tmp_path):
+    monkeypatch.delenv("JARVIS_DURABLE_REROOT_FROM", raising=False)
+    monkeypatch.delenv("JARVIS_TRINITY_ROOT", raising=False)
+    target = tmp_path / "plain.jsonl"
+    assert flock_append_line(str(target), "{}") is True
+    assert target.exists()  # legacy path byte-identical

--- a/tests/governance/test_transaction_lifecycle_guard.py
+++ b/tests/governance/test_transaction_lifecycle_guard.py
@@ -1,0 +1,250 @@
+"""Guard-shape + source-wiring pins for the transactional-lifecycle guard.
+
+Task 4 of the durability-substrate fix. Kills the op-944c silent-exit defect:
+an op that records the APPLIED ledger row but exits the runner WITHOUT reaching
+Phase 8b (auto-commit) must raise loudly instead of vanishing.
+
+Two layers:
+1. Guard SHAPE (matrix a-f) -- a minimal async function replicating the
+   arm/disarm/finally trio, exercising the real ``TransactionLifecycleError``
+   and ``txn_lifecycle_guard_enabled`` against the full semantics matrix.
+2. Source-level WIRING pins -- structural assertions that
+   ``slice4b_runner.py`` actually contains the arm/disarm/finally trio in the
+   right places (the convention this repo uses to guard wiring; see
+   ``tests/governance/test_hedge_governor_wiring.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import re
+
+import pytest
+
+from backend.core.ouroboros.governance.transaction_lifecycle import (
+    TransactionLifecycleError,
+    txn_lifecycle_guard_enabled,
+)
+
+
+# --------------------------------------------------------------------------
+# A minimal faithful replica of the runner's arm/disarm/finally trio. It
+# mirrors the CONTROL FLOW exactly (arm after APPLIED, disarm at 8b, disarm
+# before legitimate returns, finally with the sys.exc_info gate) without
+# booting the orchestrator.
+# --------------------------------------------------------------------------
+async def _span(
+    *,
+    op_id: str = "op-944c",
+    reach_8b: bool = True,
+    silent_return_before_8b: bool = False,
+    rollback_return: bool = False,
+    raise_exc: BaseException | None = None,
+):
+    """Replica span. Returns a sentinel string on normal / closed exits."""
+    import sys as _sys
+
+    _txn_commit_stage_reached = False
+    try:
+        # ---- span body: 8a scoped tests / gates ----
+        if raise_exc is not None:
+            raise raise_exc
+
+        if rollback_return:
+            # verify_regression / blast-radius rollback: a CLOSED transaction.
+            _txn_commit_stage_reached = True
+            return "rolled_back"
+
+        if silent_return_before_8b:
+            # The DEFECT: exit the span without reaching 8b and without any
+            # terminal signal. Deliberately does NOT disarm.
+            return "silent"
+
+        if reach_8b:
+            # ---- Phase 8b: first statement disarms ----
+            _txn_commit_stage_reached = True
+            return "committed"
+
+        # Fall-through with no disarm also models a silent breach.
+        return "fell_through"
+    finally:
+        if not _txn_commit_stage_reached and txn_lifecycle_guard_enabled():
+            if _sys.exc_info()[0] is None:
+                raise TransactionLifecycleError(op_id, "phase_8b_auto_commit")
+
+
+# --------------------------------------------------------------------------
+# Exception-carrier attrs / __str__
+# --------------------------------------------------------------------------
+def test_exception_carries_op_id_and_boundary():
+    err = TransactionLifecycleError("op-xyz", "phase_8b_auto_commit")
+    assert err.op_id == "op-xyz"
+    assert err.boundary == "phase_8b_auto_commit"
+    assert isinstance(err, RuntimeError)
+    text = str(err)
+    assert "op-xyz" in text
+    assert "phase_8b_auto_commit" in text
+
+
+def test_gate_default_true_and_never_raises(monkeypatch):
+    monkeypatch.delenv("JARVIS_TXN_LIFECYCLE_GUARD_ENABLED", raising=False)
+    assert txn_lifecycle_guard_enabled() is True
+    for val in ("true", "1", "yes", "on", "TRUE", "anything"):
+        monkeypatch.setenv("JARVIS_TXN_LIFECYCLE_GUARD_ENABLED", val)
+        assert txn_lifecycle_guard_enabled() is True
+    for val in ("false", "0", "no", "off", "", "  FALSE  "):
+        monkeypatch.setenv("JARVIS_TXN_LIFECYCLE_GUARD_ENABLED", val)
+        assert txn_lifecycle_guard_enabled() is False
+
+
+# --------------------------------------------------------------------------
+# Semantics matrix a-f
+# --------------------------------------------------------------------------
+def test_a_normal_reach_8b_no_raise(caplog):
+    """(a) normal path reaches 8b -> no raise, no CRITICAL from the guard."""
+    with caplog.at_level("CRITICAL"):
+        out = asyncio.run(_span(reach_8b=True))
+    assert out == "committed"
+
+
+def test_b_silent_early_return_raises():
+    """(b) silent early return between APPLIED and 8b -> TransactionLifecycleError."""
+    with pytest.raises(TransactionLifecycleError) as ei:
+        asyncio.run(_span(reach_8b=False, silent_return_before_8b=True))
+    assert ei.value.boundary == "phase_8b_auto_commit"
+    assert ei.value.op_id == "op-944c"
+
+
+def test_c_exception_in_span_propagates_unconverted():
+    """(c) a plain exception in the span -> ORIGINAL exception propagates, NOT
+    converted to TransactionLifecycleError."""
+    class _Boom(RuntimeError):
+        pass
+
+    with pytest.raises(_Boom):
+        asyncio.run(_span(reach_8b=False, raise_exc=_Boom("boom")))
+
+
+def test_c_cancelled_error_propagates_unconverted():
+    """(c) CancelledError in the span -> propagates UNCONVERTED (the guard must
+    never swallow or reclassify cancellation)."""
+    async def _drive():
+        with pytest.raises(asyncio.CancelledError):
+            await _span(reach_8b=False, raise_exc=asyncio.CancelledError())
+
+    asyncio.run(_drive())
+
+
+def test_c_in_flight_exception_not_masked_by_guard():
+    """(c) even though the sentinel is un-disarmed, an in-flight exception is
+    never converted -- sys.exc_info gate blocks the raise."""
+    with pytest.raises(ValueError):
+        asyncio.run(_span(reach_8b=False, raise_exc=ValueError("orig")))
+
+
+def test_d_pre_applied_failure_untouched():
+    """(d) A failure BEFORE the sentinel arms is out of scope -- modeled by the
+    sentinel never being armed. Here the guard function short-circuits when
+    the env kill switch is off, standing in for the pre-arm region."""
+    # The pre-APPLIED region simply never runs the trio; assert the trio is
+    # inert when disarmed-and-reached (equivalent to never-armed for guard).
+    out = asyncio.run(_span(reach_8b=True))
+    assert out == "committed"
+
+
+def test_e_kill_switch_off_legacy_silence(monkeypatch):
+    """(e) kill switch off -> legacy silence: the silent breach returns its
+    value with NO raise."""
+    monkeypatch.setenv("JARVIS_TXN_LIFECYCLE_GUARD_ENABLED", "false")
+    out = asyncio.run(_span(reach_8b=False, silent_return_before_8b=True))
+    assert out == "silent"
+
+
+def test_f_rollback_return_is_closed_transaction():
+    """(f) verify_regression / blast-radius rollback return -> NO raise (a
+    rolled-back FAILED op is a CLOSED transaction, not a breach)."""
+    out = asyncio.run(_span(reach_8b=False, rollback_return=True))
+    assert out == "rolled_back"
+
+
+# --------------------------------------------------------------------------
+# Source-level wiring pins on slice4b_runner.py
+# --------------------------------------------------------------------------
+def _runner_src() -> str:
+    from backend.core.ouroboros.governance.phase_runners import slice4b_runner
+    return inspect.getsource(slice4b_runner)
+
+
+def test_runner_arm_follows_applied_record():
+    """The sentinel arms (=False) immediately after the APPLIED ledger row."""
+    src = _runner_src()
+    # APPLIED record ... then, within a short window, the arm line.
+    applied = src.find("OperationState.APPLIED,\n            {\"op_id\": ctx.op_id},")
+    assert applied != -1, "APPLIED ledger record not found"
+    window = src[applied:applied + 800]
+    assert "_txn_commit_stage_reached = False" in window, (
+        "sentinel arm (=False) does not follow the APPLIED ledger record"
+    )
+    # The lazy import of the guard module is co-located with the arm.
+    assert "from backend.core.ouroboros.governance.transaction_lifecycle import" in src
+    assert "txn_lifecycle_guard_enabled" in src
+    assert "TransactionLifecycleError" in src
+
+
+def test_runner_disarm_is_first_statement_of_phase_8b():
+    """Phase 8b's first executable statement is the disarm (=True)."""
+    src = _runner_src()
+    marker = src.find("# ---- Phase 8b: Auto-commit ----")
+    assert marker != -1, "Phase 8b marker not found"
+    tail = src[marker:marker + 200]
+    # First non-comment statement after the marker is the disarm.
+    assert re.search(
+        r"# ---- Phase 8b: Auto-commit ----\n\s+_txn_commit_stage_reached = True",
+        tail,
+    ), "disarm (=True) is not the first statement of Phase 8b"
+
+
+def test_runner_every_legit_return_in_span_is_disarmed():
+    """Every function-exiting return BETWEEN the arm and Phase 8b is preceded
+    by a disarm (closed-transaction returns must not trip the guard)."""
+    src = _runner_src()
+    start = src.find("_txn_commit_stage_reached = False")
+    end = src.find("# ---- Phase 8b: Auto-commit ----")
+    assert start != -1 and end != -1 and start < end
+    span = src[start:end]
+    # The four governed terminal returns in the span, keyed by reason.
+    for reason in (
+        'reason=ctx.terminal_reason_code or "l2_escape_verify"',
+        'reason="verify_regression"',
+        'reason="blast_radius_graph_failure"',
+        'reason="blast_radius_breach"',
+    ):
+        idx = span.find(reason)
+        assert idx != -1, "governed return %r not found in span" % reason
+        # Look back from the reason to the enclosing `return PhaseResult(` and
+        # assert a disarm precedes it.
+        ret = span.rfind("return PhaseResult(", 0, idx)
+        assert ret != -1
+        preceding = span[max(0, ret - 120):ret]
+        assert "_txn_commit_stage_reached = True" in preceding, (
+            "return for %r is not preceded by a disarm" % reason
+        )
+
+
+def test_runner_finally_has_exc_info_gate_and_critical():
+    """The finally logs CRITICAL always and gates the raise on
+    sys.exc_info()[0] is None (so live exceptions propagate unconverted)."""
+    src = _runner_src()
+    assert "finally:" in src
+    assert "exc_info()[0] is None" in src
+    assert "logger.critical(" in src
+    assert "raise TransactionLifecycleError(ctx.op_id, \"phase_8b_auto_commit\")" in src
+    # The critical log must be OUTSIDE the exc_info gate (fires always).
+    crit = src.find("logger.critical(\n                \"[TxnLifecycle]")
+    if crit == -1:
+        crit = src.find("[TxnLifecycle]")
+    gate = src.find("exc_info()[0] is None")
+    assert crit != -1 and gate != -1 and crit < gate, (
+        "CRITICAL log must precede (fire regardless of) the exc_info raise gate"
+    )

--- a/tests/governance/test_workspace_resolver_durable.py
+++ b/tests/governance/test_workspace_resolver_durable.py
@@ -1,0 +1,51 @@
+# tests/governance/test_workspace_resolver_durable.py
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+from backend.core.ouroboros.governance.workspace_resolver import resolve_durable_path
+
+
+def test_identity_when_pair_unset(monkeypatch):
+    monkeypatch.delenv("JARVIS_DURABLE_REROOT_FROM", raising=False)
+    monkeypatch.delenv("JARVIS_TRINITY_ROOT", raising=False)
+    p = Path("/opt/trinity/jarvis/.jarvis/ledger.jsonl")
+    assert resolve_durable_path(p) == p  # real node / plain local: byte-identical
+
+
+def test_reanchors_overlay_path_onto_durable_root(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path / "trinity_root"))
+    out = resolve_durable_path(Path("/opt/trinity/jarvis/.jarvis/a1_lineage.jsonl"))
+    assert out == tmp_path / "trinity_root" / ".jarvis" / "a1_lineage.jsonl"
+
+
+def test_non_overlay_path_untouched(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path))
+    p = Path.cwd() / ".jarvis" / "local.jsonl"
+    assert resolve_durable_path(p) == p  # only overlay-rooted paths re-anchor
+
+
+def test_kill_switch_reverts_to_identity(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_DURABLE_REROOT_FROM", "/opt/trinity/jarvis")
+    monkeypatch.setenv("JARVIS_TRINITY_ROOT", str(tmp_path))
+    p = Path("/opt/trinity/jarvis/.jarvis/x.jsonl")
+    assert resolve_durable_path(p) == p
+
+
+def test_never_raises_on_garbage(monkeypatch):
+    # os.environ.__setitem__ (os.putenv under the hood) rejects an embedded
+    # null byte with ValueError at the OS layer -- a cross-platform CPython
+    # restriction, not something resolve_durable_path controls. Swap the
+    # os.environ mapping itself for a plain dict so the exact garbage
+    # payload reaches the function under test unfiltered by that OS-level
+    # guard (monkeypatch.setenv would raise before the call ever happens).
+    fake_env = dict(os.environ)
+    fake_env["JARVIS_DURABLE_REROOT_FROM"] = "\x00bad"
+    fake_env["JARVIS_TRINITY_ROOT"] = "also-bad"
+    monkeypatch.setattr(os, "environ", fake_env)
+    out = resolve_durable_path("/opt/trinity/jarvis/.jarvis/x.jsonl")
+    assert isinstance(out, Path)  # fail-soft identity, never raises


### PR DESCRIPTION
## Durability substrate fix — ledger writes + AutoCommit correct under any workspace overlay

Root-cause fix for the live A1 finding (session bt-iso-1783130209): the first autonomous mutation APPLIED + VERIFIED (21/21) but ledger rows landed `written=False` (36x `/opt/trinity` Permission denied under the isomorphic overlay on macOS) and the runner exited before AutoCommit with zero telemetry.

### What landed (6 task commits + merge + one pre-existing test sync)
- `workspace_resolver.resolve_durable_path` — pure env-pair path re-anchor (`JARVIS_DURABLE_REROOT_FROM` -> `JARVIS_TRINITY_ROOT`); identity when unset (real node / plain local = byte-identical). Zero host detection, zero permission probing.
- Wired at the single chokepoint all durable JSONL writes flow through (4 CrossProcessJSONL entry points; lock co-locates with the resolved target). Authority invariant amended with an EXACT-MATCH allowlist for the stdlib-pure resolver + a self-sealing companion pin (any future non-stdlib import inside the resolver re-fails the suite).
- Iso driver declares the overlay pair from its own `env_ctx.root` (never a literal); `autonomous_workspace` setdefaults `JARVIS_AUTO_COMMIT_WORKSPACE` to the real on-disk session worktree (AutoCommitter already consumes + validates it — zero committer changes).
- `TransactionLifecycleError`: an op that records APPLIED but exits the runner without reaching the auto-commit stage now RAISES (CRITICAL always; in-flight exceptions incl. CancelledError propagate unconverted; the 4 legitimate rollback returns are exempt). Catch-path verified: clean FAILED terminal + postmortem, worker survives.
- Loop Deadman armed structurally in the composed ignition env (silent stop -> faulthandler stack).

### Evidence
53-test gate green on the merged result; per-task + final whole-branch reviews (READY TO MERGE); `git diff -w` proof the 82KB runner re-indent is purely additive; kill switches `JARVIS_DURABLE_REROOT_ENABLED` / `JARVIS_TXN_LIFECYCLE_GUARD_ENABLED` default-on, byte-identical legacy when off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes durability under workspace overlays so ledger writes always land in the durable root, AutoCommit respects operator overrides, and APPLIED-without-commit exits fail loudly.

- **Bug Fixes**
  - Added `resolve_durable_path`: env-driven re-root from `JARVIS_DURABLE_REROOT_FROM` to `JARVIS_TRINITY_ROOT` (identity when unset).
  - Routed all CrossProcessJSONL writes through the resolver; `.lock` files colocate with the resolved target.
  - Iso driver now declares both overlay ends in env, sourcing FROM via its own `env_ctx.root` (no literals).
  - `JARVIS_AUTO_COMMIT_WORKSPACE` is set via `setdefault`; operator-pinned values are preserved.
  - Introduced `TransactionLifecycleError`: ops that record APPLIED but never reach auto-commit now raise; legitimate rollbacks are exempt.
  - Armed loop deadman via env defaults to emit stack dumps on silent stops.

<sup>Written for commit 7b9ab81b6e4be81992023a2cd89508283b6d0d7f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

