### PR TITLE
fix(resilience): Slice 12K hard watch budget + LoopDeadman MainThread-first dump

### DIFF
--- a/backend/core/ouroboros/governance/loop_deadman.py
+++ b/backend/core/ouroboros/governance/loop_deadman.py
@@ -196,6 +196,129 @@ def deadman_tombstone_to_logger_enabled() -> bool:
 
 
 # ============================================================================
+# Tombstone dump ordering (fix/watch-budget-deadman-dump)
+# ============================================================================
+#
+# bt-iso-1783137488 surfaced that a 34.9s wedge dumped 76 thread
+# tombstones but the MainThread tombstone was MISSING -- os._exit(75)
+# cut the dump off before it reached the MainThread frame. The
+# MainThread stack IS the diagnostic payload (it names the loop's exact
+# block location); losing it defeats the instrument's entire purpose.
+#
+# Fix: the MainThread frame is now identified + dumped FIRST, the
+# logging handlers are explicitly flushed, THEN the remaining threads
+# are dumped, flushed again, and only then does os._exit(75) fire.
+# ``_dump_tombstones`` is factored out as a pure, injectable helper so
+# the ordering + defensive per-thread isolation can be unit-tested
+# directly (see tests/governance/test_loop_deadman_dump_order.py).
+
+
+def _emit_tombstone(tid: int, frame, is_main: bool) -> None:
+    """Format + log a single thread's tombstone frame. ``is_main`` tags
+    the MainThread line distinctly (``[LoopDeadman.TOMBSTONE.MAIN]``) so
+    operators can grep for the diagnostic payload directly instead of
+    scanning 70+ worker tombstones for it. May raise (frame extraction
+    can fail on an exotic frame); callers MUST wrap per-thread."""
+    import traceback as _tb
+    _stack = _tb.extract_stack(frame)
+    _stack_str = "".join(_tb.format_list(_stack))
+    _tag = "[LoopDeadman.TOMBSTONE.MAIN]" if is_main else "[LoopDeadman.TOMBSTONE]"
+    logger.critical(
+        "%s thread_id=%d\n%s",
+        _tag, tid, _stack_str,
+    )
+
+
+def _flush_all_logging() -> None:
+    """Best-effort flush of every logging handler reachable from the
+    root logger + this module's logger, plus ``sys.stderr``. NEVER
+    raises. Called immediately after the MainThread tombstone is
+    written (and again after the remainder) so buffered handler I/O
+    reaches disk before ``os._exit(75)`` can cut it off mid-write --
+    the exact failure mode that lost the MainThread tombstone in
+    bt-iso-1783137488."""
+    try:
+        for _h in logging.getLogger().handlers:
+            try:
+                _h.flush()
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        for _h in logger.handlers:
+            try:
+                _h.flush()
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001
+        pass
+    try:
+        sys.stderr.flush()
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _dump_tombstones(frames, main_ident, emit=_emit_tombstone, flush=None) -> None:
+    """Dump every thread's tombstone with the MainThread FIRST.
+
+    Order: MainThread (if present in ``frames``) -> ``flush()`` ->
+    remaining threads in ``frames`` order -> ``flush()``. Per-thread
+    dumps (and the optional ``flush``) are individually wrapped in
+    try/except so one bad frame -- or a raising flush -- NEVER skips
+    the rest of the dump. This function itself must NEVER raise; it
+    runs on the wedge-exit path immediately before ``os._exit(75)``.
+
+    ``frames`` is a mapping of ``{thread_id: frame}`` (the shape
+    ``sys._current_frames()`` returns). ``emit(tid, frame, is_main)``
+    performs the actual per-thread formatting/logging. ``flush`` is an
+    optional zero-arg callable invoked before AND after the remainder
+    dump.
+    """
+    try:
+        items = list(frames.items())
+    except Exception:  # noqa: BLE001
+        items = []
+
+    # 1) MainThread first -- the diagnostic payload.
+    _main_frame = None
+    for _tid, _frame in items:
+        if _tid == main_ident:
+            _main_frame = _frame
+            break
+    if _main_frame is not None:
+        try:
+            emit(main_ident, _main_frame, True)
+        except Exception:  # noqa: BLE001
+            pass
+
+    # 2) Flush -- get the MainThread tombstone to disk before anything
+    #    else can wedge or the process can exit.
+    if flush is not None:
+        try:
+            flush()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # 3) Remaining threads -- unchanged tombstone format, one bad frame
+    #    never aborts the rest.
+    for _tid, _frame in items:
+        if _tid == main_ident:
+            continue
+        try:
+            emit(_tid, _frame, False)
+        except Exception:  # noqa: BLE001
+            continue
+
+    # 4) Flush again -- the remainder's I/O must also land before exit.
+    if flush is not None:
+        try:
+            flush()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ============================================================================
 # LoopDeadman
 # ============================================================================
 
@@ -530,27 +653,23 @@ class LoopDeadman:
             # (3) per-thread frame dump via the logger — lands in
             # debug.log via the harness's file handler, no stderr
             # plumbing required. ``sys._current_frames()`` returns
-            # a dict {thread_id: frame}; we walk each frame's
-            # f_back chain to produce a compact traceback.
+            # a dict {thread_id: frame}.
+            #
+            # fix/watch-budget-deadman-dump: the MainThread frame is
+            # dumped FIRST and FLUSHED before the remaining ~70+
+            # worker tombstones are dumped, so a hard os._exit(75)
+            # arriving mid-dump can never cut off the diagnostic
+            # payload (bt-iso-1783137488 lost exactly this frame).
             try:
                 if deadman_tombstone_to_logger_enabled():
-                    import traceback as _tb
                     _frames = sys._current_frames()
-                    for _tid, _frame in _frames.items():
-                        try:
-                            _stack = _tb.extract_stack(_frame)
-                            _stack_str = "".join(
-                                _tb.format_list(_stack)
-                            )
-                            logger.critical(
-                                "[LoopDeadman.TOMBSTONE] thread_id=%d\n%s",
-                                _tid, _stack_str,
-                            )
-                        except Exception:  # noqa: BLE001
-                            # Per-thread failure — keep walking
-                            # the rest; never abort the dump for
-                            # one bad frame.
-                            continue
+                    _main_ident = threading.main_thread().ident
+                    _dump_tombstones(
+                        _frames,
+                        main_ident=_main_ident,
+                        emit=_emit_tombstone,
+                        flush=_flush_all_logging,
+                    )
             except Exception:  # noqa: BLE001
                 pass
 

--- a/backend/core/resilience/file_watch_guard.py
+++ b/backend/core/resilience/file_watch_guard.py
@@ -240,6 +240,39 @@ _SCHEDULE_GROUP_KIND_NESTED_VENV_SPLIT = "nested_venv_split"
 _SCHEDULE_GROUP_KIND_PATTERN_DESCENT = "pattern_descent"
 _SCHEDULE_GROUP_KIND_COALESCED = "nested_venv_split_coalesced"
 
+# Slice 12K (2026-07-03) — the UNCONDITIONALLY hard tier of the
+# schedule budget. Emitted when Slice 12J's venv-split coalescing
+# (``_SCHEDULE_GROUP_KIND_COALESCED``) is NOT enough to fit
+# ``max_scheduled_roots`` — i.e. the plan is dominated by distinct
+# depth-1 recursive schedules (SIMPLE_RECURSIVE + already-coalesced
+# venv splits) rather than by a few fat venv splits. That was the
+# live failure in bt-iso-1783137488: ``candidate_roots=168
+# scheduled_roots=51 max_scheduled_roots=30`` — Slice 12J collapsed
+# every venv split but still landed 70% OVER cap because it had no
+# lever for the ~45 plain depth-1 siblings, and 51 PollingObserver
+# snapshot-walk threads aggregate-GIL-wedged the loop (34.9s
+# starvation → LoopDeadman kill).
+#
+# Depth-1 siblings share only ``watch_dir`` as a recursive ancestor,
+# so the ONLY sub-cap collapse is a single ``(watch_dir, True)`` root
+# — the "in the limit: one recursive root schedule of the watch root"
+# the operator binding authorises ("fewer observer schedules beats
+# perfect nested-dir exclusion"). The legacy ``ignore_patterns``
+# post-event filter still drops the re-included excluded-subtree
+# (venv/cache) events; one slow-but-alive poll thread strictly beats
+# N GIL-contending ones. This kind is a TERMINAL collapse target — it
+# is never itself coalesced further.
+#
+# ABSOLUTE CONSTRAINT: a ``watch_dir`` root is created ONLY when NO
+# ``_SCHEDULE_GROUP_KIND_PATTERN_DESCENT`` group is present. A
+# recursive watch-root schedule would drag the protected
+# ``.jarvis/swe_bench_pro/worktrees`` subtree (56K-file element-web
+# clone) back into the poll walk and resurrect the exact wedge Slice
+# 12I closed. When pattern-descent groups exist the cap is FLOORED —
+# we honour 12I over the 12J/12K cap and WARN (never violate 12I to
+# satisfy 12J).
+_SCHEDULE_GROUP_KIND_HARD_COALESCED = "hard_coalesced_root"
+
 
 class _ScheduleGroup(NamedTuple):
     """Slice 12J — schedule group emitted by ``_resolve_watch_paths``.
@@ -271,6 +304,14 @@ class _ResolvedSchedule(NamedTuple):
     skipped_by_pattern: int
     candidate_count: int  # Schedules BEFORE budget enforcement.
     coalesced_count: int  # Groups collapsed back to recursive parent.
+    # Slice 12K — collapsible groups folded into the single hard
+    # ``(watch_dir, True)`` root when venv-coalescing alone could not
+    # fit the budget. ``0`` when the hard tier never engaged (either
+    # venv-coalescing sufficed, the plan was already within budget, or
+    # a pattern-descent group floored the cap and blocked the collapse).
+    # Trailing default keeps the legacy early-return construction sites
+    # (missing root / iterdir failure) source-compatible.
+    hard_coalesced_count: int = 0
 
 
 class GlobalWatchRegistry:
@@ -782,6 +823,7 @@ class FileWatchGuard:
         skipped_by_pattern = resolved.skipped_by_pattern
         candidate_count = resolved.candidate_count
         coalesced_count = resolved.coalesced_count
+        hard_coalesced_count = resolved.hard_coalesced_count
 
         scheduled_ok: List[Tuple[Path, bool]] = []
         for path, recursive in scheduled_paths:
@@ -828,6 +870,7 @@ class FileWatchGuard:
             "[FileWatchGuard] Observer backend: %s (polling_fallback=%s), "
             "candidate_roots=%d scheduled_roots=%d "
             "max_scheduled_roots=%s coalesced_roots=%d "
+            "hard_coalesced_roots=%d "
             "(recursive=%d, non_recursive=%d, "
             "excluded_top_level=%s, "
             "excluded_path_patterns=%s, "
@@ -838,6 +881,7 @@ class FileWatchGuard:
             len(scheduled_ok),
             max_scheduled_roots if max_scheduled_roots > 0 else "unbounded",
             coalesced_count,
+            hard_coalesced_count,
             recursive_count,
             len(scheduled_ok) - recursive_count,
             sorted(excluded) if excluded else "(none)",
@@ -860,6 +904,30 @@ class FileWatchGuard:
                 "SWE worktree exclusions) were preserved.",
                 candidate_count, len(scheduled_ok),
                 max_scheduled_roots, coalesced_count, coalesced_count,
+            )
+
+        # Slice 12K — schedule_budget_hard_coalesced WARNING. Surface
+        # ONCE per boot when the HARD tier engaged (venv-coalescing
+        # alone could not fit the cap, so the collapsible depth-1
+        # siblings were folded into a single recursive watch-root
+        # schedule). This is a stronger signal than the venv-tier
+        # WARNING: per-subtree event granularity is gone; the whole
+        # watch root is now one poll thread and ignore_patterns is the
+        # only excluded-subtree filter. It is still strictly better
+        # than the polling-thread storm that wedged the loop.
+        if hard_coalesced_count > 0:
+            logger.warning(
+                "[FileWatchGuard] schedule_budget_hard_coalesced "
+                "candidate=%d scheduled=%d cap=%d hard_coalesced_groups=%d — "
+                "venv-split coalescing was insufficient; %d collapsible "
+                "depth-1 group(s) folded into a single recursive watch-root "
+                "schedule to stay under the polling-thread budget "
+                "(bt-iso-1783137488 class: 51>30 loop-wedge). Excluded "
+                "subtrees still drop events via ignore_patterns; "
+                "pattern-descent groups (Slice 12I) are never folded.",
+                candidate_count, len(scheduled_ok),
+                max_scheduled_roots, hard_coalesced_count,
+                hard_coalesced_count,
             )
 
         # Slice 12I — runaway-watching early warning (preserved).
@@ -1153,6 +1221,22 @@ class FileWatchGuard:
         NamedTuple so the boot log can surface candidate /
         scheduled / coalesced telemetry to the operator.
 
+        Slice 12K addition (2026-07-03): venv-split coalescing is a
+        SOFT budget — it only shrinks fat ``NESTED_VENV_SPLIT`` groups
+        and has no lever for a plan dominated by many distinct depth-1
+        recursive schedules. bt-iso-1783137488 landed 51>30 (70% over)
+        after every venv split was collapsed, and 51 PollingObserver
+        snapshot threads GIL-wedged the loop into a LoopDeadman kill.
+        ``_hard_coalesce_schedule`` makes the budget UNCONDITIONALLY
+        hard: when venv-coalescing is insufficient, the collapsible
+        depth-1 siblings are folded into a single ``(watch_dir, True)``
+        recursive root (their only common ancestor). Pattern-descent
+        groups are NEVER folded and BLOCK the watch-root collapse when
+        present (a recursive root would re-walk the protected 56K-file
+        subtree) — in that case the cap is floored + a WARNING fires,
+        honouring Slice 12I over the 12J/12K cap. ``hard_coalesced_count``
+        surfaces the fold to the boot log.
+
         Missing root → empty schedule (caller's observer.start()
         still succeeds; health loop will notice and recreate).
         """
@@ -1325,12 +1409,13 @@ class FileWatchGuard:
                     kind=_SCHEDULE_GROUP_KIND_SIMPLE_RECURSIVE,
                 ))
 
-        # Slice 12J — Phase 2: enforce schedule budget by coalescing
+        # Slice 12J — Phase 2a: enforce schedule budget by coalescing
         # NESTED_VENV_SPLIT groups (largest savings first). The
         # candidate count is fixed BEFORE coalescing for telemetry;
         # ``current`` tracks the live count as we coalesce.
         candidate_count = sum(len(g.entries) for g in groups)
         coalesced_count = 0
+        hard_coalesced_count = 0
         # ``max_scheduled_roots <= 0`` is the operator escape hatch
         # (legacy unbounded behavior; opt-out of the cap entirely).
         if max_scheduled_roots > 0 and candidate_count > max_scheduled_roots:
@@ -1361,6 +1446,20 @@ class FileWatchGuard:
                 current -= savings
                 coalesced_count += 1
 
+            # Slice 12K — Phase 2b: the UNCONDITIONALLY hard tier.
+            # Venv-coalescing only shrinks fat NESTED_VENV_SPLIT
+            # groups; it has no lever for a plan dominated by many
+            # distinct depth-1 recursive schedules (the live
+            # bt-iso-1783137488 failure: 51 > 30 after every venv
+            # split was collapsed). If we are STILL over budget,
+            # collapse the collapsible siblings into a single
+            # ``(watch_dir, True)`` root — never touching the
+            # PATTERN_DESCENT groups (Slice 12I). Runs at most once.
+            if current > max_scheduled_roots:
+                groups, hard_coalesced_count = self._hard_coalesce_schedule(
+                    groups, max_scheduled_roots, current,
+                )
+
         # Slice 12J — Phase 3: flatten groups into the final
         # ``observer.schedule()`` plan, preserving depth-1 order so
         # operator log lines stay alphabetical.
@@ -1373,7 +1472,93 @@ class FileWatchGuard:
             skipped_by_pattern=skipped_by_pattern,
             candidate_count=candidate_count,
             coalesced_count=coalesced_count,
+            hard_coalesced_count=hard_coalesced_count,
         )
+
+    def _hard_coalesce_schedule(
+        self,
+        groups: List["_ScheduleGroup"],
+        max_scheduled_roots: int,
+        current: int,
+    ) -> Tuple[List["_ScheduleGroup"], int]:
+        """Slice 12K — the UNCONDITIONALLY hard tier of the schedule
+        budget. Called only when Slice 12J venv-coalescing left the
+        plan over ``max_scheduled_roots``.
+
+        Depth-1 siblings share only ``watch_dir`` as a common
+        recursive ancestor, so the only sub-cap collapse is a SINGLE
+        ``(watch_dir, True)`` root — the "in the limit: one recursive
+        root schedule of the watch root" the operator binding
+        authorises. The legacy ``ignore_patterns`` post-event filter
+        still drops the re-included excluded-subtree (venv/cache)
+        events; per the LoopDeadman evidence one slow-but-alive poll
+        thread strictly beats N GIL-contending ones.
+
+        ABSOLUTE CONSTRAINT (Slice 12I): ``PATTERN_DESCENT`` groups are
+        NEVER folded, AND we never create a ``watch_dir`` root while
+        one is present — a recursive watch-root schedule would drag
+        the protected ``.jarvis/swe_bench_pro/worktrees`` subtree (56K
+        -file element-web clone) back into the poll walk and resurrect
+        the exact wedge Slice 12I closed. When pattern-descent groups
+        exist the collapsible depth-1 siblings are already one
+        schedule each and have no safe common ancestor, so the cap is
+        FLOORED: we return the groups UNCHANGED (pattern-descent +
+        irreducible siblings) and WARN. We honour 12I over the 12J/12K
+        cap ("never violate 12I to satisfy 12J").
+
+        Returns ``(new_groups, hard_coalesced_count)`` where
+        ``hard_coalesced_count`` is the number of collapsible groups
+        folded into the hard root (``0`` when the cap was floored or
+        the plan was already a single root).
+        """
+        pattern_groups = [
+            g for g in groups
+            if g.kind == _SCHEDULE_GROUP_KIND_PATTERN_DESCENT
+        ]
+        collapsible = [
+            g for g in groups
+            if g.kind != _SCHEDULE_GROUP_KIND_PATTERN_DESCENT
+        ]
+
+        if pattern_groups:
+            # Cap floored by the pattern-descent count + irreducible
+            # siblings. Collapsing to a watch-root would re-include the
+            # protected 56K-file subtree — forbidden. Honour 12I, warn,
+            # leave the plan as-is.
+            pattern_entry_count = sum(len(g.entries) for g in pattern_groups)
+            logger.warning(
+                "[FileWatchGuard] schedule_budget_floored_by_pattern_descent "
+                "cap=%d pattern_descent_schedules=%d collapsible_groups=%d "
+                "scheduled=%d — collapsible depth-1 siblings share only the "
+                "watch root as a recursive ancestor, and a recursive "
+                "watch-root schedule would re-include the protected "
+                ".jarvis/swe_bench_pro/worktrees subtree (Slice 12I). "
+                "Honouring 12I over the 12J/12K cap: pattern-descent "
+                "schedules kept, no watch-root collapse. Reduce "
+                "candidate roots via exclude_top_level_dirs / "
+                "exclude_path_patterns to lower the floor.",
+                max_scheduled_roots, pattern_entry_count,
+                len(collapsible), current,
+            )
+            return groups, 0
+
+        # No protected subtree — safe to collapse ALL collapsible
+        # groups into a single recursive watch-root schedule. (With no
+        # pattern-descent groups present, ``collapsible`` == ``groups``.)
+        watch_root_entry: Tuple[Path, bool] = (self.watch_dir, True)
+        already_single_root = (
+            len(collapsible) == 1
+            and collapsible[0].entries == (watch_root_entry,)
+        )
+        if not collapsible or already_single_root:
+            return groups, 0
+
+        hard_group = _ScheduleGroup(
+            parent=self.watch_dir,
+            entries=(watch_root_entry,),
+            kind=_SCHEDULE_GROUP_KIND_HARD_COALESCED,
+        )
+        return [hard_group], len(collapsible)
 
     # ---- Slice 12A — loop-thread enqueue wrapper -----------------
     #

--- a/backend/core/resilience/file_watch_guard.py
+++ b/backend/core/resilience/file_watch_guard.py
@@ -257,11 +257,18 @@ _SCHEDULE_GROUP_KIND_COALESCED = "nested_venv_split_coalesced"
 # so the ONLY sub-cap collapse is a single ``(watch_dir, True)`` root
 # — the "in the limit: one recursive root schedule of the watch root"
 # the operator binding authorises ("fewer observer schedules beats
-# perfect nested-dir exclusion"). The legacy ``ignore_patterns``
-# post-event filter still drops the re-included excluded-subtree
-# (venv/cache) events; one slow-but-alive poll thread strictly beats
-# N GIL-contending ones. This kind is a TERMINAL collapse target — it
-# is never itself coalesced further.
+# perfect nested-dir exclusion"). Safety comes from THREAD-COUNT, not
+# event filtering: ONE poll thread releases the GIL on every
+# scandir/stat syscall and cannot aggregate-GIL-wedge the loop the
+# way 51 contending walkers did. Re-included subtrees (venv/cache) DO
+# emit events — ``ignore_patterns`` fnmatches BASENAME only against
+# *.tmp/*.swp/*.bak/*~ and does NOT drop venv/.../foo.py; downstream
+# dedup + debounce absorb them — and ARE walked by the single poller:
+# an accepted operator-authorized tradeoff (12J binding: fewer
+# schedules beats perfect exclusion). The catastrophic 56K-file SWE
+# worktree stays pattern-descent-protected (never collapsed). This
+# kind is a TERMINAL collapse target — it is never itself coalesced
+# further.
 #
 # ABSOLUTE CONSTRAINT: a ``watch_dir`` root is created ONLY when NO
 # ``_SCHEDULE_GROUP_KIND_PATTERN_DESCENT`` group is present. A
@@ -270,7 +277,10 @@ _SCHEDULE_GROUP_KIND_COALESCED = "nested_venv_split_coalesced"
 # clone) back into the poll walk and resurrect the exact wedge Slice
 # 12I closed. When pattern-descent groups exist the cap is FLOORED —
 # we honour 12I over the 12J/12K cap and WARN (never violate 12I to
-# satisfy 12J).
+# satisfy 12J). Documented mixed-case gap: when pattern-descent
+# groups coexist with many irreducible siblings the cap floors to
+# warn-only (schedule_budget_floored_by_pattern_descent) — follow-up
+# slice required before SWE-bench-worktree soaks.
 _SCHEDULE_GROUP_KIND_HARD_COALESCED = "hard_coalesced_root"
 
 
@@ -911,10 +921,16 @@ class FileWatchGuard:
         # alone could not fit the cap, so the collapsible depth-1
         # siblings were folded into a single recursive watch-root
         # schedule). This is a stronger signal than the venv-tier
-        # WARNING: per-subtree event granularity is gone; the whole
-        # watch root is now one poll thread and ignore_patterns is the
-        # only excluded-subtree filter. It is still strictly better
-        # than the polling-thread storm that wedged the loop.
+        # WARNING: per-subtree schedule granularity is gone. Safety
+        # comes from THREAD-COUNT, not event filtering — ONE poll
+        # thread releases the GIL on every scandir/stat syscall and
+        # cannot aggregate-GIL-wedge the loop the way 51 contending
+        # walkers did. Re-included subtrees DO emit events (deduped
+        # downstream; ignore_patterns only fnmatches basenames like
+        # *.tmp) and ARE walked by the single poller — the accepted
+        # operator-authorized tradeoff (12J binding: fewer schedules
+        # beats perfect exclusion). The 56K-file SWE worktree stays
+        # pattern-descent-protected (never collapsed).
         if hard_coalesced_count > 0:
             logger.warning(
                 "[FileWatchGuard] schedule_budget_hard_coalesced "
@@ -922,8 +938,9 @@ class FileWatchGuard:
                 "venv-split coalescing was insufficient; %d collapsible "
                 "depth-1 group(s) folded into a single recursive watch-root "
                 "schedule to stay under the polling-thread budget "
-                "(bt-iso-1783137488 class: 51>30 loop-wedge). Excluded "
-                "subtrees still drop events via ignore_patterns; "
+                "(bt-iso-1783137488 class: 51>30 loop-wedge). Re-included "
+                "subtrees are walked by the single poller and DO emit "
+                "events (deduped downstream) — accepted 12J tradeoff; "
                 "pattern-descent groups (Slice 12I) are never folded.",
                 candidate_count, len(scheduled_ok),
                 max_scheduled_roots, hard_coalesced_count,
@@ -1489,10 +1506,18 @@ class FileWatchGuard:
         recursive ancestor, so the only sub-cap collapse is a SINGLE
         ``(watch_dir, True)`` root — the "in the limit: one recursive
         root schedule of the watch root" the operator binding
-        authorises. The legacy ``ignore_patterns`` post-event filter
-        still drops the re-included excluded-subtree (venv/cache)
-        events; per the LoopDeadman evidence one slow-but-alive poll
-        thread strictly beats N GIL-contending ones.
+        authorises. Safety comes from THREAD-COUNT, not event
+        filtering: ONE poll thread releases the GIL on every
+        scandir/stat syscall and cannot aggregate-GIL-wedge the loop
+        the way 51 contending walkers did (the LoopDeadman evidence).
+        Re-included subtrees (venv/cache) DO emit events —
+        ``ignore_patterns`` fnmatches BASENAME only against
+        *.tmp/*.swp/*.bak/*~, so venv/.../foo.py is NOT dropped;
+        downstream dedup + debounce absorb them — and ARE walked by
+        the single poller: an accepted operator-authorized tradeoff
+        (12J binding: fewer schedules beats perfect exclusion). The
+        catastrophic 56K-file SWE worktree stays pattern-descent-
+        protected (never collapsed).
 
         ABSOLUTE CONSTRAINT (Slice 12I): ``PATTERN_DESCENT`` groups are
         NEVER folded, AND we never create a ``watch_dir`` root while

--- a/tests/core/resilience/test_file_watch_guard_hard_budget.py
+++ b/tests/core/resilience/test_file_watch_guard_hard_budget.py
@@ -1,0 +1,524 @@
+"""Slice 12K — FileWatchGuard UNCONDITIONALLY-hard schedule budget.
+=================================================================
+
+Root-cause fix for the live session bt-iso-1783137488 census:
+
+    [FileWatchGuard] candidate_roots=168 scheduled_roots=51
+                     max_scheduled_roots=30
+
+Slice 12J's schedule budget was SOFT: its coalescer only collapses
+``NESTED_VENV_SPLIT`` groups (fat depth-2 splits). It has no lever for
+a plan dominated by many *distinct* depth-1 recursive schedules, so a
+large candidate set landed 70% OVER cap (51 > 30). Each scheduled root
+is one ``PollingObserver`` snapshot-walk thread on macOS; 51 of them
+aggregate-GIL-wedged the asyncio loop (34.9 s starvation → LoopDeadman
+kill). The file's own Slice-12J comments document the same failure at
+99 threads (bt-2026-05-22-232553).
+
+Slice 12K makes the budget UNCONDITIONALLY hard in the scheduling
+resolver: when venv-coalescing is insufficient, the collapsible
+depth-1 siblings are folded into a single ``(watch_dir, True)``
+recursive root (their only common recursive ancestor — the operator's
+"in the limit: one recursive root schedule of the watch root"). The
+legacy ``ignore_patterns`` post-event filter still drops re-included
+excluded-subtree events.
+
+ABSOLUTE CONSTRAINT (Slice 12I): ``PATTERN_DESCENT`` groups are NEVER
+folded, and a ``watch_dir`` root is NEVER created while one is present
+— a recursive root would drag the protected
+``.jarvis/swe_bench_pro/worktrees`` subtree (56K-file element-web
+clone) back into the poll walk. When the pattern-descent count alone
+floors the cap, the pattern schedules are kept + a WARNING fires
+(never violate 12I to satisfy 12J).
+
+These tests unit-test the RESOLVER's output-set properties — they do
+NOT spin real observers (per the existing narrow-scope test doctrine),
+except one boot-telemetry test that drives ``_start_watchdog`` with a
+spy Observer exactly as the Slice 12J suite does.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import List, Tuple
+from unittest.mock import patch
+
+import pytest
+
+from backend.core.resilience.file_watch_guard import (
+    FileWatchConfig,
+    FileWatchGuard,
+    _SCHEDULE_GROUP_KIND_HARD_COALESCED,
+    _SCHEDULE_GROUP_KIND_PATTERN_DESCENT,
+    _ResolvedSchedule,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _guard(tmp_path: Path, **config_overrides) -> FileWatchGuard:
+    cfg = FileWatchConfig(**config_overrides)
+    return FileWatchGuard(watch_dir=tmp_path, on_event=lambda _ev: None, config=cfg)
+
+
+def _mk_venv_split(root: Path, name: str, grandchildren: int) -> int:
+    """Create a depth-1 dir with a nested ``venv`` (→ NESTED_VENV_SPLIT)
+    plus ``grandchildren`` non-excluded grandchildren. Returns the number
+    of candidate entries this dir contributes: 1 non-recursive parent +
+    ``grandchildren`` recursive grandchildren."""
+    d = root / name
+    d.mkdir()
+    (d / "venv").mkdir()
+    (d / "venv" / "bin").mkdir()
+    for j in range(grandchildren):
+        (d / f"mod_{j:03d}").mkdir()
+    return 1 + grandchildren
+
+
+def _mk_plain(root: Path, name: str) -> int:
+    """Create a plain depth-1 dir (→ SIMPLE_RECURSIVE, 1 candidate)."""
+    (root / name).mkdir()
+    return 1
+
+
+def _mk_pattern_descent(root: Path, name: str, worktree_rel: str) -> None:
+    """Create a depth-1 dir that carries a pattern-excluded worktree
+    subtree (→ PATTERN_DESCENT) plus a couple of normal children.
+
+    ``worktree_rel`` is the repo-relative pattern that must be present in
+    ``exclude_path_patterns`` (default or env-added) so the walker routes
+    around it.
+    """
+    wt = root / worktree_rel / "instance_element-web-1234" / "src" / "deep"
+    wt.mkdir(parents=True)
+    (root / name / "sessions").mkdir(parents=True, exist_ok=True)
+    (root / name / "logs").mkdir(parents=True, exist_ok=True)
+
+
+def _live_census_layout_no_pattern(root: Path) -> int:
+    """Replicate the bt-iso-1783137488 census SHAPE without any
+    pattern-descent group (the real repo had ``skipped_by_pattern=0``):
+    a handful of fat venv-splits + ~45 plain depth-1 siblings. After
+    venv-coalescing this leaves (num_venv + num_plain) distinct depth-1
+    recursive schedules — the 51-over-30 defect.
+
+    Returns the candidate count.
+    """
+    total = 0
+    total += _mk_venv_split(root, "backend", 40)   # 41
+    total += _mk_venv_split(root, "tests", 40)     # 41
+    total += _mk_venv_split(root, "scripts", 40)   # 41
+    for i in range(45):
+        total += _mk_plain(root, f"plain_{i:02d}")  # +45
+    return total  # 168
+
+
+# ---------------------------------------------------------------------------
+# Test 1 — the live-census defect: fail-first vs fixed, NO pattern-descent
+# ---------------------------------------------------------------------------
+
+
+def test_live_census_168_no_pattern_collapses_under_cap(tmp_path: Path) -> None:
+    """The exact bt-iso-1783137488 defect shape (168 candidates, no
+    pattern-descent). Slice 12J venv-coalescing alone leaves 48 distinct
+    depth-1 recursive schedules — OVER the cap of 30 (the defect). Slice
+    12K's hard tier MUST fold them into a single recursive watch-root so
+    ``scheduled <= cap``.
+    """
+    candidate = _live_census_layout_no_pattern(tmp_path)
+    assert candidate == 168
+
+    guard = _guard(tmp_path, max_scheduled_roots=30)
+    result = guard._resolve_watch_paths(
+        guard._resolve_excluded_dirs(),
+        guard._resolve_excluded_path_patterns(),
+        max_scheduled_roots=30,
+    )
+    assert isinstance(result, _ResolvedSchedule)
+    assert result.candidate_count == 168
+    # Venv tier coalesced all 3 fat splits ...
+    assert result.coalesced_count == 3
+    # ... which alone would leave 45 plain + 3 coalesced-venv = 48
+    # distinct depth-1 recursive schedules. THAT is the pre-12K
+    # scheduled floor, and it is > cap — the defect the hard tier fixes.
+    assert result.hard_coalesced_count == 48, (
+        "hard_coalesced_count reflects the collapsible groups the pre-12K "
+        "resolver would have scheduled"
+    )
+    assert result.hard_coalesced_count > 30, (
+        "pre-12K floor must exceed the cap, else the test does not "
+        "reproduce the 51>30 defect"
+    )
+    # POST-FIX: the budget is now HARD.
+    assert len(result.paths) <= 30
+    assert len(result.paths) == 1
+
+
+def test_hard_coalesced_root_is_watch_dir_recursive(tmp_path: Path) -> None:
+    """The single hard-coalesced entry MUST be the watch root scheduled
+    RECURSIVELY — that is what preserves event coverage: a file under any
+    (now un-scheduled) source subtree still produces events via the
+    recursive parent schedule (post-condition iv)."""
+    _live_census_layout_no_pattern(tmp_path)
+    guard = _guard(tmp_path, max_scheduled_roots=30)
+    result = guard._resolve_watch_paths(
+        guard._resolve_excluded_dirs(),
+        guard._resolve_excluded_path_patterns(),
+        max_scheduled_roots=30,
+    )
+    assert result.paths == [(guard.watch_dir, True)], (
+        f"hard-coalesced plan must be a single recursive watch root; got "
+        f"{result.paths}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 2 — cap=0 legacy unbounded escape hatch preserved
+# ---------------------------------------------------------------------------
+
+
+def test_cap_zero_disables_hard_coalesce_legacy_unbounded(tmp_path: Path) -> None:
+    """``max_scheduled_roots=0`` is the operator escape hatch — no
+    coalescing at ALL, neither venv nor hard tier. The candidate plan is
+    the final plan (legacy unbounded behaviour)."""
+    candidate = _live_census_layout_no_pattern(tmp_path)
+    guard = _guard(tmp_path, max_scheduled_roots=0)
+    result = guard._resolve_watch_paths(
+        guard._resolve_excluded_dirs(),
+        guard._resolve_excluded_path_patterns(),
+        max_scheduled_roots=0,
+    )
+    assert result.coalesced_count == 0
+    assert result.hard_coalesced_count == 0
+    assert len(result.paths) == candidate
+
+
+# ---------------------------------------------------------------------------
+# Test 3 — pattern-descent floors the cap (cap < pattern-descent count)
+# ---------------------------------------------------------------------------
+
+
+def test_pattern_descent_floors_cap_and_warns(
+    tmp_path: Path, caplog,
+) -> None:
+    """When the pattern-descent-mandated schedule count alone exceeds the
+    cap, Slice 12K MUST keep the pattern-descent schedules (never fold
+    them, never create a watch-root that would re-walk the 56K subtree),
+    exceed the cap, and log the ``schedule_budget_floored_by_pattern_descent``
+    WARNING. This is the "never violate 12I to satisfy 12J" contract.
+    """
+    # Two pattern-descent groups, no venv, no plain siblings.
+    _mk_pattern_descent(
+        tmp_path, ".jarvis", ".jarvis/swe_bench_pro/worktrees",
+    )
+    _mk_pattern_descent(
+        tmp_path, ".data", ".data/big/worktrees",
+    )
+
+    caplog.set_level(
+        logging.WARNING, logger="backend.core.resilience.file_watch_guard",
+    )
+    with patch.dict(
+        os.environ,
+        {
+            "JARVIS_FILE_WATCH_EXCLUDE_DIRS": "venv",
+            "JARVIS_FILE_WATCH_EXCLUDE_PATH_PATTERNS": ".data/big/worktrees",
+        },
+        clear=False,
+    ):
+        guard = _guard(tmp_path, max_scheduled_roots=3)
+        excluded = guard._resolve_excluded_dirs()
+        patterns = guard._resolve_excluded_path_patterns()
+        result = guard._resolve_watch_paths(
+            excluded, patterns, max_scheduled_roots=3,
+        )
+
+    # pattern-descent entries dominate: with 2 groups × (~4 entries) the
+    # pattern floor exceeds cap=3.
+    pattern_floor = len(result.paths)
+    assert pattern_floor > 3, "test needs the pattern floor to exceed cap"
+    # No safe collapse happened; hard tier declined to fold.
+    assert result.hard_coalesced_count == 0
+    # Post-condition (i): scheduled <= max(cap, pattern_descent_count).
+    assert len(result.paths) <= max(3, pattern_floor)
+    # The protected worktree subtrees stay OUT of the schedule.
+    for path, _rec in result.paths:
+        rel = path.relative_to(guard.watch_dir).parts
+        if len(rel) >= 3:
+            assert rel[:3] != (".jarvis", "swe_bench_pro", "worktrees")
+            assert rel[:3] != (".data", "big", "worktrees")
+    # Both pattern parents survived.
+    top = {p.relative_to(guard.watch_dir).parts[0] for p, _ in result.paths}
+    assert ".jarvis" in top and ".data" in top
+    # The floored WARNING fired.
+    floored = [
+        r.message for r in caplog.records
+        if r.levelname == "WARNING"
+        and "schedule_budget_floored_by_pattern_descent" in r.message
+    ]
+    assert floored, (
+        "expected schedule_budget_floored_by_pattern_descent WARNING; "
+        f"got {[r.message for r in caplog.records]}"
+    )
+
+
+def test_pattern_descent_present_never_folded_even_with_collapsible(
+    tmp_path: Path, caplog,
+) -> None:
+    """Pattern-descent present AND many plain collapsible siblings, cap
+    tight. Slice 12K MUST NOT fold the collapsible siblings into a
+    watch-root (that would re-walk the protected subtree). The plain
+    siblings stay as individual recursive schedules; the pattern-descent
+    entries stay intact; the floored WARNING fires."""
+    _mk_pattern_descent(
+        tmp_path, ".jarvis", ".jarvis/swe_bench_pro/worktrees",
+    )
+    for i in range(20):
+        _mk_plain(tmp_path, f"src_{i:02d}")
+
+    caplog.set_level(
+        logging.WARNING, logger="backend.core.resilience.file_watch_guard",
+    )
+    with patch.dict(
+        os.environ,
+        {"JARVIS_FILE_WATCH_EXCLUDE_DIRS": "venv"},
+        clear=False,
+    ):
+        os.environ.pop("JARVIS_FILE_WATCH_EXCLUDE_PATH_PATTERNS", None)
+        guard = _guard(tmp_path, max_scheduled_roots=5)
+        result = guard._resolve_watch_paths(
+            guard._resolve_excluded_dirs(),
+            guard._resolve_excluded_path_patterns(),
+            max_scheduled_roots=5,
+        )
+
+    # No watch-root fold happened.
+    assert result.hard_coalesced_count == 0
+    assert (guard.watch_dir, True) not in result.paths, (
+        "a recursive watch-root must NOT be created while a "
+        "pattern-descent group is present"
+    )
+    # The 20 plain siblings are all still individually scheduled.
+    top = [p.relative_to(guard.watch_dir).parts[0] for p, _ in result.paths]
+    assert sum(1 for t in top if t.startswith("src_")) == 20
+    # Worktree subtree stays out.
+    for path, _rec in result.paths:
+        rel = path.relative_to(guard.watch_dir).parts
+        if len(rel) >= 3:
+            assert rel[:3] != (".jarvis", "swe_bench_pro", "worktrees")
+    floored = [
+        r.message for r in caplog.records
+        if "schedule_budget_floored_by_pattern_descent" in r.message
+    ]
+    assert floored
+
+
+# ---------------------------------------------------------------------------
+# Test 4 — synthetic 168 WITH pattern-descent that DOES fit under cap
+# ---------------------------------------------------------------------------
+
+
+def test_census_168_with_pattern_descent_fits_and_stays_intact(
+    tmp_path: Path,
+) -> None:
+    """A ~168-candidate plan mixing plain top-level splits, >=2
+    pattern-descent groups, and fat venv-split groups. Here the bulk is
+    venv-splits, so venv-coalescing fits the plan under cap WITHOUT
+    needing a watch-root fold — proving the two tiers compose and that
+    pattern-descent groups survive fully intact and under budget.
+    """
+    total = 0
+    total += _mk_venv_split(tmp_path, "backend", 100)  # 101
+    total += _mk_venv_split(tmp_path, "tests", 40)     # 41
+    total += _mk_venv_split(tmp_path, "scripts", 12)   # 13
+    _mk_pattern_descent(
+        tmp_path, ".jarvis", ".jarvis/swe_bench_pro/worktrees",
+    )  # 4 entries
+    _mk_pattern_descent(
+        tmp_path, ".data", ".data/big/worktrees",
+    )  # 4 entries
+    for i in range(3):
+        total += _mk_plain(tmp_path, f"plain_{i}")     # 3
+
+    with patch.dict(
+        os.environ,
+        {
+            "JARVIS_FILE_WATCH_EXCLUDE_DIRS": "venv",
+            "JARVIS_FILE_WATCH_EXCLUDE_PATH_PATTERNS": ".data/big/worktrees",
+        },
+        clear=False,
+    ):
+        guard = _guard(tmp_path, max_scheduled_roots=30)
+        result = guard._resolve_watch_paths(
+            guard._resolve_excluded_dirs(),
+            guard._resolve_excluded_path_patterns(),
+            max_scheduled_roots=30,
+        )
+
+    assert result.candidate_count > 150, "expected a ~168-candidate plan"
+    # venv-coalescing was enough — no hard fold, so pattern-descent
+    # groups keep their fine-grained routing.
+    assert result.coalesced_count >= 2
+    assert result.hard_coalesced_count == 0
+    assert len(result.paths) <= 30, (
+        f"scheduled {len(result.paths)} must be within cap 30"
+    )
+    # Both pattern parents present; worktrees excluded.
+    top = {p.relative_to(guard.watch_dir).parts[0] for p, _ in result.paths}
+    assert ".jarvis" in top and ".data" in top
+    for path, _rec in result.paths:
+        rel = path.relative_to(guard.watch_dir).parts
+        if len(rel) >= 3:
+            assert rel[:3] != (".jarvis", "swe_bench_pro", "worktrees")
+            assert rel[:3] != (".data", "big", "worktrees")
+
+
+# ---------------------------------------------------------------------------
+# Test 5 — post-condition (i) property across caps (no pattern-descent)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("cap", [1, 5, 10, 25, 30, 47])
+def test_scheduled_never_exceeds_cap_no_pattern(tmp_path: Path, cap: int) -> None:
+    """Post-condition (i) for the no-pattern case: for EVERY cap >= 1,
+    ``scheduled <= cap`` (== max(cap, pattern_descent_count=0))."""
+    _live_census_layout_no_pattern(tmp_path)
+    guard = _guard(tmp_path, max_scheduled_roots=cap)
+    result = guard._resolve_watch_paths(
+        guard._resolve_excluded_dirs(),
+        guard._resolve_excluded_path_patterns(),
+        max_scheduled_roots=cap,
+    )
+    assert len(result.paths) <= cap, (
+        f"cap={cap} but scheduled={len(result.paths)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Test 6 — boot telemetry: hard_coalesced_roots census + WARNING
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_startup_telemetry_reports_hard_coalesced_roots(
+    tmp_path: Path, caplog,
+) -> None:
+    """``_start_watchdog`` MUST extend the census INFO line with
+    ``hard_coalesced_roots=`` and emit the ``schedule_budget_hard_coalesced``
+    WARNING when the hard tier engages."""
+    caplog.set_level(
+        logging.INFO, logger="backend.core.resilience.file_watch_guard",
+    )
+    _live_census_layout_no_pattern(tmp_path)
+
+    class _SpyObserver:
+        def schedule(self, *a, **k):
+            return None
+
+        def start(self):
+            return None
+
+        def stop(self):
+            return None
+
+        def join(self, timeout=None):
+            return None
+
+    with patch(
+        "watchdog.observers.Observer", return_value=_SpyObserver(),
+    ), patch(
+        "watchdog.observers.polling.PollingObserver",
+        return_value=_SpyObserver(),
+    ):
+        with patch.dict(
+            os.environ,
+            {"JARVIS_FILE_WATCH_MAX_SCHEDULED_ROOTS": "30"},
+            clear=False,
+        ):
+            os.environ.pop("JARVIS_FILE_WATCH_EXCLUDE_DIRS", None)
+            os.environ.pop("JARVIS_FILE_WATCH_EXCLUDE_PATH_PATTERNS", None)
+            guard = _guard(tmp_path, max_scheduled_roots=30)
+            await guard._start_watchdog()
+
+    info_msgs = [r.message for r in caplog.records if r.levelname == "INFO"]
+    census = [
+        m for m in info_msgs
+        if "candidate_roots=" in m
+        and "scheduled_roots=" in m
+        and "hard_coalesced_roots=" in m
+    ]
+    assert census, (
+        f"census INFO line missing hard_coalesced_roots=: {info_msgs[-2:]}"
+    )
+    warn_msgs = [r.message for r in caplog.records if r.levelname == "WARNING"]
+    hard_warns = [
+        m for m in warn_msgs if "schedule_budget_hard_coalesced" in m
+    ]
+    assert hard_warns, (
+        f"schedule_budget_hard_coalesced WARNING not emitted: {warn_msgs}"
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_quiet_when_no_hard_coalesce(
+    tmp_path: Path, caplog,
+) -> None:
+    """A layout that fits under the cap MUST NOT emit the
+    ``schedule_budget_hard_coalesced`` WARNING."""
+    caplog.set_level(
+        logging.INFO, logger="backend.core.resilience.file_watch_guard",
+    )
+    (tmp_path / "a").mkdir()
+    (tmp_path / "b").mkdir()
+
+    class _SpyObserver:
+        def schedule(self, *a, **k):
+            return None
+
+        def start(self):
+            return None
+
+        def stop(self):
+            return None
+
+        def join(self, timeout=None):
+            return None
+
+    with patch(
+        "watchdog.observers.Observer", return_value=_SpyObserver(),
+    ), patch(
+        "watchdog.observers.polling.PollingObserver",
+        return_value=_SpyObserver(),
+    ):
+        guard = _guard(tmp_path)
+        await guard._start_watchdog()
+
+    hard_warns = [
+        r.message for r in caplog.records
+        if r.levelname == "WARNING"
+        and "schedule_budget_hard_coalesced" in r.message
+    ]
+    assert not hard_warns
+
+
+# ---------------------------------------------------------------------------
+# Test 7 — the new group kind + telemetry field exist
+# ---------------------------------------------------------------------------
+
+
+def test_hard_coalesced_group_kind_constant() -> None:
+    """Slice 12K adds a fifth group kind for the terminal collapse
+    target. It must be a distinct string literal."""
+    assert _SCHEDULE_GROUP_KIND_HARD_COALESCED == "hard_coalesced_root"
+    assert _SCHEDULE_GROUP_KIND_HARD_COALESCED != _SCHEDULE_GROUP_KIND_PATTERN_DESCENT
+
+
+def test_resolved_schedule_carries_hard_coalesced_count() -> None:
+    """The ``_ResolvedSchedule`` NamedTuple exposes the 12K telemetry
+    field with a default of 0 (so legacy early-return sites stay valid)."""
+    assert "hard_coalesced_count" in _ResolvedSchedule._fields
+    assert _ResolvedSchedule._field_defaults.get("hard_coalesced_count") == 0

--- a/tests/governance/test_loop_deadman_dump_order.py
+++ b/tests/governance/test_loop_deadman_dump_order.py
@@ -1,0 +1,288 @@
+"""Tombstone dump ordering -- MainThread-first (fix/watch-budget-deadman-dump).
+
+Defect (live session bt-iso-1783137488): when the LoopDeadman fired on a
+34.9s wedge, it dumped 76 thread tombstones -- but the MainThread
+tombstone was MISSING (cut off by ``os._exit(75)`` before it could be
+written). The MainThread stack IS the diagnostic payload -- it names the
+loop's exact block location -- so losing it defeats the instrument's
+purpose.
+
+Fix: the wedge-dump sequence now serializes + FLUSHES the MainThread
+tombstone FIRST, then dumps the remaining threads, flushing again before
+``os._exit(75)``. This is proven at two levels:
+
+  1. Unit-level -- ``_dump_tombstones(frames, main_ident, emit, flush)``
+     is a pure, injectable helper: MainThread first + tagged, remaining
+     threads still all emitted, a raising emit for one thread never
+     skips the rest, and ``flush`` fires both before and after the
+     remainder.
+  2. Source-level -- a static pin proves the real wedge branch
+     (``_fire_wedge``) calls the main-first dump + flush sequence
+     strictly BEFORE ``os._exit(75)``.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from backend.core.ouroboros.governance import loop_deadman as ld
+
+_REPO = Path(__file__).resolve().parents[2]
+_GOV = _REPO / "backend/core/ouroboros/governance"
+
+
+# -- fixtures -------------------------------------------------------------
+
+
+class _FakeFrame:
+    """Stand-in for a real frame object -- ``_dump_tombstones`` never
+    inspects the frame itself (that's the injected ``emit``'s job), so a
+    sentinel is sufficient and keeps these tests fast + frame-shape
+    independent."""
+
+    def __init__(self, tag: str) -> None:
+        self.tag = tag
+
+
+def _make_frames(main_ident: int = 1) -> dict:
+    return {
+        main_ident: _FakeFrame("main"),
+        2001: _FakeFrame("worker-a"),
+        2002: _FakeFrame("worker-b"),
+        2003: _FakeFrame("worker-c"),
+    }
+
+
+# -- (a) MainThread emitted FIRST and tagged MAIN ------------------------
+
+
+def test_main_thread_dumped_first_and_tagged():
+    frames = _make_frames(main_ident=1)
+    calls = []
+
+    def emit(tid, frame, is_main):
+        calls.append((tid, is_main))
+
+    ld._dump_tombstones(frames, main_ident=1, emit=emit)
+
+    assert calls[0] == (1, True), (
+        f"MainThread (ident=1) must be the first emitted call, got {calls[0]}"
+    )
+    # every other emitted call must be tagged is_main=False
+    assert all(is_main is False for _, is_main in calls[1:])
+
+
+# -- (b) all other threads are still emitted after MainThread -----------
+
+
+def test_all_remaining_threads_emitted_after_main():
+    frames = _make_frames(main_ident=1)
+    calls = []
+
+    def emit(tid, frame, is_main):
+        calls.append(tid)
+
+    ld._dump_tombstones(frames, main_ident=1, emit=emit)
+
+    # main + 3 workers == 4 total emissions, no thread dropped.
+    assert set(calls) == set(frames.keys())
+    assert len(calls) == len(frames)
+    assert calls[0] == 1
+    assert set(calls[1:]) == {2001, 2002, 2003}
+
+
+# -- (c) a raising emit for one thread must not skip the rest -----------
+
+
+def test_raising_emit_does_not_abort_remaining_dumps():
+    frames = _make_frames(main_ident=1)
+    calls = []
+
+    def emit(tid, frame, is_main):
+        calls.append(tid)
+        if tid == 2001:
+            raise RuntimeError("boom -- simulated per-thread dump failure")
+
+    # must not raise out of _dump_tombstones itself
+    ld._dump_tombstones(frames, main_ident=1, emit=emit)
+
+    # all 4 threads were still attempted despite 2001 raising mid-dump.
+    assert set(calls) == set(frames.keys())
+
+
+def test_raising_main_emit_does_not_abort_remaining_dumps():
+    """Even if the MOST important dump (MainThread) itself raises, the
+    remaining threads must still be attempted -- the dump path must
+    NEVER raise or short-circuit."""
+    frames = _make_frames(main_ident=1)
+    calls = []
+
+    def emit(tid, frame, is_main):
+        calls.append(tid)
+        if is_main:
+            raise RuntimeError("boom -- main dump failed")
+
+    ld._dump_tombstones(frames, main_ident=1, emit=emit)
+
+    assert set(calls) == set(frames.keys())
+
+
+# -- (d) flush called before AND after the remainder ---------------------
+
+
+def test_flush_called_before_and_after_remainder():
+    frames = _make_frames(main_ident=1)
+    order = []
+
+    def emit(tid, frame, is_main):
+        order.append(("emit", tid, is_main))
+
+    def flush():
+        order.append(("flush",))
+
+    ld._dump_tombstones(frames, main_ident=1, emit=emit, flush=flush)
+
+    flush_indices = [i for i, ev in enumerate(order) if ev == ("flush",)]
+    assert len(flush_indices) == 2, f"flush must fire exactly twice, got {order}"
+
+    main_index = order.index(("emit", 1, True))
+    remainder_indices = [
+        i for i, ev in enumerate(order)
+        if ev[0] == "emit" and ev[1] != 1
+    ]
+
+    first_flush, second_flush = flush_indices
+    # flush #1 sits between the main dump and the remainder.
+    assert main_index < first_flush, "flush must come AFTER the main dump"
+    assert all(first_flush < i for i in remainder_indices), (
+        "flush must come BEFORE the remainder dump"
+    )
+    # flush #2 sits after every remainder emission.
+    assert all(i < second_flush for i in remainder_indices), (
+        "second flush must come AFTER the remainder dump"
+    )
+
+
+def test_flush_is_optional_and_never_required():
+    """When no flush callable is supplied (e.g. legacy callers), the dump
+    must still complete without raising."""
+    frames = _make_frames(main_ident=1)
+    calls = []
+    ld._dump_tombstones(frames, main_ident=1, emit=lambda t, f, m: calls.append(t))
+    assert set(calls) == set(frames.keys())
+
+
+def test_raising_flush_does_not_abort_dump():
+    frames = _make_frames(main_ident=1)
+    calls = []
+
+    def emit(tid, frame, is_main):
+        calls.append(tid)
+
+    def bad_flush():
+        raise OSError("flush failed -- simulated disk-full")
+
+    ld._dump_tombstones(frames, main_ident=1, emit=emit, flush=bad_flush)
+    assert set(calls) == set(frames.keys())
+
+
+# -- missing MainThread frame (defensive edge case) ----------------------
+
+
+def test_missing_main_frame_does_not_prevent_remainder_dump():
+    """If ``main_ident`` isn't present in ``frames`` (should not happen in
+    practice -- sys._current_frames() always includes MainThread -- but
+    the dump path must be defensive), the remaining threads are still
+    dumped and nothing raises."""
+    frames = {2001: _FakeFrame("worker-a"), 2002: _FakeFrame("worker-b")}
+    calls = []
+
+    def emit(tid, frame, is_main):
+        calls.append((tid, is_main))
+
+    ld._dump_tombstones(frames, main_ident=1, emit=emit)
+    assert set(calls) == {(2001, False), (2002, False)}
+
+
+# -- real _emit_tombstone + _flush_all_logging smoke (not fakes) ---------
+
+
+def test_emit_tombstone_tags_main_vs_worker(caplog):
+    import sys as _sys
+
+    caplog.set_level("CRITICAL", logger="Ouroboros.LoopDeadman")
+    frame = _sys._getframe()
+    ld._emit_tombstone(999, frame, True)
+    ld._emit_tombstone(1000, frame, False)
+
+    records = [r.message for r in caplog.records]
+    assert any("[LoopDeadman.TOMBSTONE.MAIN]" in m and "999" in m for m in records)
+    assert any(
+        "[LoopDeadman.TOMBSTONE]" in m
+        and "[LoopDeadman.TOMBSTONE.MAIN]" not in m
+        and "1000" in m
+        for m in records
+    )
+
+
+def test_flush_all_logging_never_raises(monkeypatch):
+    """``_flush_all_logging`` must be best-effort: even if a handler's
+    flush() raises, the call must not propagate."""
+
+    class _BadHandler:
+        def flush(self):
+            raise OSError("disk full")
+
+    root = ld.logging.getLogger()
+    root.addHandler(_BadHandler())
+    try:
+        ld._flush_all_logging()  # must not raise
+    finally:
+        root.removeHandler(root.handlers[-1])
+
+
+# -- source-level pin: main-first dump + flush precede os._exit(75) -----
+
+
+def test_fire_wedge_dumps_main_first_and_flushes_before_exit():
+    src = (_GOV / "loop_deadman.py").read_text(encoding="utf-8")
+
+    fire_start = src.index("def _fire_wedge")
+    next_def = src.find("\n    def ", fire_start + 1)
+    body = src[fire_start:next_def] if next_def != -1 else src[fire_start:]
+
+    dump_call_idx = body.index("_dump_tombstones(")
+    # The real (unindented-in-string, executable) call is the LAST
+    # occurrence -- earlier occurrences are docstring/comment mentions
+    # describing the behavior.
+    exit_idx = body.rindex("os._exit(75)")
+    assert dump_call_idx < exit_idx, (
+        "_fire_wedge must call _dump_tombstones (main-first dump) BEFORE "
+        "os._exit(75)"
+    )
+
+    # The dump call must be wired to pass threading.main_thread().ident so
+    # MainThread is identified structurally, not by convention.
+    assert "threading.main_thread().ident" in body, (
+        "the real wedge branch must resolve MainThread via "
+        "threading.main_thread().ident"
+    )
+
+    # The flush helper must be wired into the dump call (passed as the
+    # injectable ``flush=`` callback) so the MainThread tombstone --
+    # and the remainder -- are flushed before os._exit(75) can cut off
+    # buffered I/O. It's passed by reference (not called directly) so
+    # _dump_tombstones controls the before/after-remainder timing.
+    flush_idx = body.index("_flush_all_logging")
+    assert dump_call_idx <= flush_idx < exit_idx, (
+        "_flush_all_logging must be wired into the dump call, before "
+        "os._exit(75)"
+    )
+
+
+def test_module_defines_dump_helpers():
+    assert hasattr(ld, "_dump_tombstones")
+    assert hasattr(ld, "_emit_tombstone")
+    assert hasattr(ld, "_flush_all_logging")
+    assert callable(ld._dump_tombstones)
+    assert callable(ld._emit_tombstone)
+    assert callable(ld._flush_all_logging)

--- a/tests/governance/test_slice12i_filewatchguard_exclusions.py
+++ b/tests/governance/test_slice12i_filewatchguard_exclusions.py
@@ -549,14 +549,15 @@ def test_path_pattern_empty_patterns_returns_false(tmp_path: Path) -> None:
 def test_resolve_watch_paths_returns_resolved_schedule_named_tuple(
     tmp_path: Path,
 ) -> None:
-    """Slice 12J: ``_resolve_watch_paths`` now returns a
-    ``_ResolvedSchedule`` NamedTuple with 4 fields:
+    """Slice 12J/12K: ``_resolve_watch_paths`` returns a
+    ``_ResolvedSchedule`` NamedTuple with 5 fields:
     ``paths`` / ``skipped_by_pattern`` / ``candidate_count`` /
-    ``coalesced_count``. NamedTuples are tuples (positional access
-    works) AND carry field names (``.paths`` etc.). The Slice 12I
-    field ``skipped_by_pattern`` remains semantically identical;
-    candidate_count + coalesced_count are Slice 12J additions for
-    budget telemetry.
+    ``coalesced_count`` / ``hard_coalesced_count``. NamedTuples are
+    tuples (positional access works) AND carry field names
+    (``.paths`` etc.). The Slice 12I field ``skipped_by_pattern``
+    remains semantically identical; candidate_count + coalesced_count
+    are Slice 12J additions and hard_coalesced_count is the Slice 12K
+    addition for budget telemetry.
     """
     _make_worktree_layout(tmp_path)
     guard = _build_guard(tmp_path)
@@ -566,12 +567,13 @@ def test_resolve_watch_paths_returns_resolved_schedule_named_tuple(
     )
     # NamedTuple is a tuple
     assert isinstance(result, tuple)
-    assert len(result) == 4
-    # Named field access (Slice 12J surface)
+    assert len(result) == 5
+    # Named field access (Slice 12J/12K surface)
     assert isinstance(result.paths, list)
     assert isinstance(result.skipped_by_pattern, int)
     assert isinstance(result.candidate_count, int)
     assert isinstance(result.coalesced_count, int)
+    assert isinstance(result.hard_coalesced_count, int)
     # Slice 12I semantic preserved: pattern hits counted
     assert result.skipped_by_pattern >= 1
     # Slice 12J invariant: candidate_count >= len(paths)


### PR DESCRIPTION
## Root-cause fix for the 6th starvation class (aggregate-GIL PollingObserver wedge)

Live evidence (bt-iso-1783137488): candidate_roots=168 -> scheduled_roots=51 vs cap=30 — the Slice-12J budget only coalesced nested-venv groups, so 51 snapshot-walk threads wedged the loop 34.9s (LoopDeadman kill; same class as run 1's 48.7s spike).

- **Slice 12K**: the schedule budget is now structurally enforced — progressive coalescing beyond venv groups (live shape collapses to 1 recursive schedule); Slice-12I pattern-descent groups NEVER collapsed (floored + WARN); cap=0 legacy escape hatch intact. 16 new tests; 6 pre-existing 12J AST pins green.
- **LoopDeadman**: MainThread tombstone serialized + flushed FIRST before os._exit(75) (the live run lost the main stack to the exit race). 12 tests. Timeout/clamp/arming untouched.
- Review: APPROVED for quiet-loop ignition; ledgered follow-up (mixed pattern-descent case floors to warn-only — gates SWE-bench-worktree soaks only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the file watcher’s schedule budget hard to prevent event-loop starvation from too many polling threads, and guarantees LoopDeadman logs the MainThread stack first so the key traceback is never lost on exit.

- **Bug Fixes**
  - File watching (Slice 12K): when venv coalescing can’t fit the cap, collapse collapsible depth‑1 siblings into a single recursive `watch_dir` root so `scheduled <= max_scheduled_roots`. Pattern‑descent groups are never folded; if present, the cap is floored and a `schedule_budget_floored_by_pattern_descent` warning is emitted. `JARVIS_FILE_WATCH_MAX_SCHEDULED_ROOTS=0` still disables the cap.
  - Telemetry: census line now includes `hard_coalesced_roots`, and a `schedule_budget_hard_coalesced` warning is logged when the hard tier engages.
  - LoopDeadman: MainThread tombstone is emitted and flushed first, then the rest, then exit. Factored `_dump_tombstones()` with per‑thread isolation and `_flush_all_logging()`; timeouts/arming unchanged.

<sup>Written for commit ca1eaf4fcfc7f268ac9bdaf66324b48961ac9d02. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69832?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

