### PR TITLE
fix(stratification): index-backed file_has_test_coverage -- retires the loop-wedge inline AST build (MainThread-tombstone root cause)

### DIFF
--- a/backend/core/ouroboros/governance/target_stratification.py
+++ b/backend/core/ouroboros/governance/target_stratification.py
@@ -495,6 +495,39 @@ def file_has_test_coverage(
 
     Non-``.py`` and ``test_*`` inputs are treated as covered (no penalty).
 
+    **Index-backed, off-loop by construction (sixth starvation-class kill).**
+    This function is STRUCTURALLY incapable of walking or ``ast.parse``-ing
+    on the caller's thread — the trap that wedged the asyncio loop for 30.1 s
+    in session bt-iso-1783142866 (OpportunityMiner.scan_once → this function
+    → inline ``_strat_build_ast_map`` over ~3000 test files, GIL-held). It
+    answers only from the pre-built off-loop :class:`_CoverageIndex`:
+
+      * **WARM** (index present for the scan root) — Strategy 1 collapses to a
+        set lookup + one bisect prefix probe, Strategy 2 to a dict lookup. NO
+        filesystem traversal; today's exact matching semantics are preserved.
+      * **COLD** (no warm index) — fire the single-flight, idempotent
+        :func:`trigger_coverage_index_build` (which self-gates: builds off the
+        loop via ``cooperative_fs_io.offload`` when a loop is running, else
+        returns a no-op sentinel) and return the **NEUTRAL degrade** ``True``
+        (treated-as-covered = zero penalty). This mirrors the Tier-4 ingest
+        cold convention exactly (``unified_intake_router.py``: "cold → PROCEED
+        DEGRADED (override 0 — no penalty, no evidence)"): a covered answer
+        feeds ``stratification_penalty_multiplier``/``ingest_priority_penalty``
+        as zero penalty, so ops flow unbiased while the index warms — the
+        advisory prior is priority-ordering only, never authority.
+
+    Consumer consistency while cold: ``dw_transport_hedge.resolve_hedge_arm``
+    already gates on ``coverage_index_ready() and not file_has_test_coverage``
+    → cold (not ready) short-circuits, so returning ``True`` here keeps
+    ``+uncovered_target`` un-appended; ``OperationAdvisor._compute_test_coverage``
+    and the OpportunityMiner get a neutral 1.0 ratio while cold — exactly the
+    Tier-4 ingest semantics. The inline directory walk and inline
+    ``_strat_build_ast_map`` cold fallback are DELETED from this path; the
+    builder remains worker-only (invoked solely inside the off-loop index
+    build). Disabling the index (``JARVIS_STRATIFICATION_INDEX_ENABLED=false``)
+    therefore leaves sync callers permanently neutral (no walk) — the signal
+    is advisory, so this is a safe opt-out, not a regression.
+
     ``repo_root`` is automatically translated via
     :func:`execution_context.authoritative_repo_root` so that a
     ``.worktrees/<name>/`` path (an L3 isolation worktree that may be empty
@@ -502,37 +535,50 @@ def file_has_test_coverage(
     where test files actually live. READS stay authoritative; WRITES still
     target the worktree.
     """
-    # Defense-in-depth: translate .worktrees/<name> paths to the real repo
-    # root so coverage detection never returns 0 due to an empty worktree.
-    try:
-        from backend.core.ouroboros.governance.execution_context import (
-            authoritative_repo_root as _auth_root,
-        )
+    # LoopSink instrumentation — proves this callsite no longer blocks the
+    # asyncio thread (the whole point of the fix). Cheap + fail-soft; a no-op
+    # when JARVIS_LOOP_SINK_ENABLED is off.
+    from backend.core.ouroboros.telemetry.loop_sink import (
+        sink_sync as _ls_sink_sync,
+    )
 
-        _scan_root = _auth_root(Path(repo_root))
-    except Exception:  # noqa: BLE001 — fail-soft, never breaks coverage
-        _scan_root = Path(repo_root)
+    with _ls_sink_sync("target_stratification.file_has_test_coverage"):
+        # Defense-in-depth: translate .worktrees/<name> paths to the real repo
+        # root so coverage detection never returns 0 due to an empty worktree.
+        try:
+            from backend.core.ouroboros.governance.execution_context import (
+                authoritative_repo_root as _auth_root,
+            )
 
-    name = Path(file_path).name
-    if not name.endswith(".py") or "test_" in name:
-        return True
-    stem = Path(file_path).stem
-    dir_names = _strat_test_dir_names()
-    exact_name = f"test_{stem}.py"
-    suffix_prefix = f"test_{stem}_"
+            _scan_root = _auth_root(Path(repo_root))
+        except Exception:  # noqa: BLE001 — fail-soft, never breaks coverage
+            _scan_root = Path(repo_root)
 
-    # Tier-4 fast path — when the off-loop coverage index is warm, answer
-    # from memory: Strategy 1 collapses to a set lookup + one bisect prefix
-    # probe, Strategy 2 to a dict lookup. NO filesystem traversal. This is
-    # what makes the function safe to call from latency-sensitive contexts
-    # once the index is built (the intake hot path additionally never calls
-    # it on the loop at all — see UnifiedIntakeRouter._ingest_impl).
-    try:
-        _idx_key = _scan_root.resolve()
-    except OSError:  # noqa: PERF203 — circular symlink, keep syntactic form
-        _idx_key = _scan_root
-    _idx = _coverage_index_lookup(_idx_key)
-    if _idx is not None:
+        name = Path(file_path).name
+        if not name.endswith(".py") or "test_" in name:
+            return True
+        stem = Path(file_path).stem
+        exact_name = f"test_{stem}.py"
+        suffix_prefix = f"test_{stem}_"
+
+        try:
+            _idx_key = _scan_root.resolve()
+        except OSError:  # circular symlink, keep syntactic form
+            _idx_key = _scan_root
+        _idx = _coverage_index_lookup(_idx_key)
+
+        if _idx is None:
+            # COLD — NEVER walk/parse on the caller's thread. Request the
+            # single-flight off-loop build (idempotent; self-gates on the
+            # "building" set / TTL / failure cooldown / no-loop) and return
+            # the neutral degrade (treated-as-covered = zero penalty).
+            trigger_coverage_index_build(_scan_root)
+            return True
+
+        # WARM — answer both strategies from the in-memory index.
+        # Strategy 1: suffix-aware name match (set lookup + bisect prefix probe;
+        # subsumes the old exact-match). Strategy 2: AST-import dict lookup,
+        # env-opt-out. Preserves today's exact matching semantics.
         if exact_name in _idx.names_set:
             return True
         _i = bisect.bisect_left(_idx.names_sorted, suffix_prefix)
@@ -551,43 +597,6 @@ def file_has_test_coverage(
             except Exception:  # noqa: BLE001 — fail-soft, mirror Strategy 2
                 pass
         return False
-
-    # Strategy 1: suffix-aware recursive search across all test roots.
-    # Finds test_<stem>.py (exact) AND test_<stem>_*.py (suffix variants).
-    # This subsumes the old single-path tests/test_{stem}.py existence check.
-    # Uses _scan_root (translated from .worktrees/<name> to the real repo root
-    # via authoritative_repo_root) so coverage detection never returns 0 due
-    # to an empty isolation worktree.
-    for tdn in sorted(dir_names):
-        top = _scan_root / tdn
-        if not top.is_dir():
-            continue
-        for match in sorted(top.rglob("test_*.py")):
-            if not match.is_file():
-                continue
-            mname = match.name
-            if mname == exact_name or (mname.startswith(suffix_prefix) and mname.endswith(".py")):
-                return True
-
-    # Strategy 2: AST-import scan (lazy cached per _scan_root, env-opt-out).
-    # Uses _scan_root (authoritative repo root) so the import map is built
-    # from real test files, never from an empty isolation worktree.
-    if _strat_ast_import_enabled():
-        try:
-            fp = Path(file_path)
-            if not fp.is_absolute():
-                fp = _scan_root / fp
-            module_path = _strat_path_to_module(fp, _scan_root)
-            if module_path:
-                resolved_root = _scan_root.resolve()
-                if resolved_root not in _strat_ast_cache:
-                    _strat_ast_cache[resolved_root] = _strat_build_ast_map(resolved_root, dir_names)
-                if _strat_ast_cache[resolved_root].get(module_path):
-                    return True
-        except Exception:  # noqa: BLE001 — fail-soft, never raises
-            pass
-
-    return False
 
 
 def stratification_penalty_multiplier(

--- a/tests/governance/test_coverage_sync_index_backed.py
+++ b/tests/governance/test_coverage_sync_index_backed.py
@@ -1,0 +1,224 @@
+"""Sixth starvation class kill — the SYNC coverage API becomes index-backed.
+
+Root-cause pins for ``fix/coverage-sync-inline-ast``.
+
+Live smoking gun (session bt-iso-1783142866, MainThread tombstone, loop
+wedged 30.1 s → LoopDeadman kill):
+
+    opportunity_miner_sensor.py:1146 _poll_loop → await scan_once()
+    opportunity_miner_sensor.py:686  scan_once → file_has_test_coverage(...)
+    target_stratification.py:584     _strat_ast_cache[root] = _strat_build_ast_map(root)
+    target_stratification.py:429     ast.parse(source)   ← ~3000 test files, GIL-held
+
+``file_has_test_coverage`` kept the legacy inline walk (Strategy 1) + inline
+``_strat_build_ast_map`` cold fallback (Strategy 2). OpportunityMiner and
+OperationAdvisor call it straight off the asyncio loop thread, so the cold
+AST build blocked the loop for tens of seconds.
+
+The fix makes ``file_has_test_coverage`` STRUCTURALLY incapable of walking or
+parsing on the caller's thread: it answers from the off-loop ``_CoverageIndex``
+when WARM, and when COLD fires the single-flight ``trigger_coverage_index_build``
+and returns the NEUTRAL degrade (``True`` = treated-as-covered = zero penalty),
+matching the Tier-4 ingest cold convention (``unified_intake_router.py``:
+"cold → PROCEED DEGRADED (override 0 — no penalty, no evidence)").
+
+Pins:
+  §a  COLD call NEVER invokes ``_strat_build_ast_map`` / ``_iter_test_files`` /
+      ``Path.rglob`` — it requests the off-loop build instead.
+  §b  WARM call answers BOTH strategies (suffix-name + AST-import), positive
+      and negative, correctly from the index.
+  §c  COLD returns the neutral ``True`` even for a genuinely-untested file.
+  §d  Early-``True`` cases (non-``.py`` / ``test_*`` input) are unchanged and
+      short-circuit before any build trigger.
+  §e  Source-level: the function body contains no ``_strat_build_ast_map(``
+      call and no rglob / walk / ``_iter_test_files`` traversal token.
+"""
+
+from __future__ import annotations
+
+import inspect
+from pathlib import Path
+
+import pytest
+
+import backend.core.ouroboros.governance.target_stratification as _ts
+from backend.core.ouroboros.governance.target_stratification import (
+    file_has_test_coverage,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_index_state():
+    _ts.reset_coverage_index()
+    _ts._strat_ast_cache.clear()
+    yield
+    _ts.reset_coverage_index()
+    _ts._strat_ast_cache.clear()
+
+
+def _install_index(root: Path) -> None:
+    """Build + install the coverage index synchronously (test-only shortcut)."""
+    idx = _ts._build_coverage_index_sync(
+        _ts._resolve_scan_root(root),
+        _ts._strat_test_dir_names(),
+    )
+    with _ts._COVERAGE_IDX_LOCK:
+        _ts._coverage_index[_ts._resolve_scan_root(root)] = idx
+
+
+def _sever_all_traversal(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Make ANY on-thread walk / parse blow up loudly."""
+
+    def _boom(*a, **k):  # noqa: ANN002, ANN003
+        raise AssertionError(
+            "SYNC file_has_test_coverage walked/parsed on the caller thread"
+        )
+
+    monkeypatch.setattr(_ts, "_strat_build_ast_map", _boom)
+    monkeypatch.setattr(_ts, "_iter_test_files", _boom)
+    monkeypatch.setattr(Path, "rglob", _boom)
+
+
+# ── §a COLD never walks/parses; it requests the off-loop build ──────────
+def test_cold_call_never_walks_and_requests_offload_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # A real (untested) tree exists — but the SYNC API must NOT touch it.
+    (tmp_path / "tests").mkdir()
+    _sever_all_traversal(monkeypatch)
+
+    calls: list[object] = []
+    real_trigger = _ts.trigger_coverage_index_build
+
+    def _spy(repo_root):  # noqa: ANN001
+        calls.append(repo_root)
+        # Return a sentinel WITHOUT scheduling (no loop in this sync test).
+        return "skipped_no_loop"
+
+    monkeypatch.setattr(_ts, "trigger_coverage_index_build", _spy)
+
+    result = file_has_test_coverage("backend/core/orphan.py", tmp_path)
+
+    assert result is True  # neutral degrade — never blocks, never False cold
+    assert calls, "cold path must request the single-flight off-loop build"
+    # Sanity: the real trigger is single-flight (idempotent) — importable.
+    assert callable(real_trigger)
+
+
+# ── §c COLD returns the neutral True even for a genuinely-untested file ──
+def test_cold_returns_neutral_true_for_untested(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_other.py").write_text(
+        "from backend.core.other import foo\ndef test_foo(): pass\n"
+    )
+    # Index cold (reset by fixture) — untested file must degrade neutral, not
+    # walk the tree to resolve False.
+    assert file_has_test_coverage("backend/core/orphan.py", tmp_path) is True
+
+
+# ── §b WARM answers both strategies — suffix name match (positive) ──────
+def test_warm_suffix_name_match_positive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "false")
+    (tmp_path / "tests" / "battle_test").mkdir(parents=True)
+    (tmp_path / "tests" / "battle_test" / "test_widget_slice4.py").write_text(
+        "def test_x(): pass\n"
+    )
+    _install_index(tmp_path)
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+
+
+# ── §b WARM suffix / name — no match (negative) ─────────────────────────
+def test_warm_name_no_match_negative(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "false")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)
+    # AST off + name doesn't match → genuinely uncovered (warm index answers).
+    assert file_has_test_coverage("backend/core/orphan.py", tmp_path) is False
+
+
+# ── §b WARM answers both strategies — AST import match (positive) ───────
+def test_warm_ast_import_match_positive(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    (tmp_path / "tests").mkdir()
+    # A test that imports the module by dotted path (no name-convention match).
+    (tmp_path / "tests" / "test_integration_suite.py").write_text(
+        "from backend.core.special_util import some_func\n"
+        "def test_it(): assert some_func() is not None\n"
+    )
+    _install_index(tmp_path)
+    assert file_has_test_coverage("backend/core/special_util.py", tmp_path) is True
+
+
+# ── §b WARM AST import — no match (negative) ────────────────────────────
+def test_warm_ast_import_no_match_negative(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_integration_suite.py").write_text(
+        "from backend.core.other_module import foo\n"
+        "def test_it(): assert foo() is not None\n"
+    )
+    _install_index(tmp_path)
+    assert file_has_test_coverage("backend/core/special_util.py", tmp_path) is False
+
+
+# ── §b WARM must not walk even to answer (severed traversal) ────────────
+def test_warm_answers_without_any_filesystem_walk(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    (tmp_path / "tests").mkdir()
+    (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)
+    _sever_all_traversal(monkeypatch)
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+    assert file_has_test_coverage("backend/core/nope.py", tmp_path) is False
+
+
+# ── §d early-True: non-.py input, unchanged, no build trigger ───────────
+def test_non_py_input_is_early_true_without_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _sever_all_traversal(monkeypatch)
+    calls: list[object] = []
+    monkeypatch.setattr(
+        _ts, "trigger_coverage_index_build", lambda r: calls.append(r)
+    )
+    assert file_has_test_coverage("README.md", tmp_path) is True
+    assert not calls, "non-.py input must short-circuit before any build trigger"
+
+
+# ── §d early-True: test_* input, unchanged, no build trigger ────────────
+def test_test_prefixed_input_is_early_true_without_build(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    _sever_all_traversal(monkeypatch)
+    calls: list[object] = []
+    monkeypatch.setattr(
+        _ts, "trigger_coverage_index_build", lambda r: calls.append(r)
+    )
+    assert file_has_test_coverage("tests/test_widget.py", tmp_path) is True
+    assert not calls, "test_* input must short-circuit before any build trigger"
+
+
+# ── §e source-level: no inline build call, no rglob/walk token ──────────
+def test_source_has_no_inline_build_or_walk() -> None:
+    src = inspect.getsource(file_has_test_coverage)
+    assert "_strat_build_ast_map(" not in src, (
+        "SYNC path must not call the inline AST builder"
+    )
+    assert "rglob" not in src, "SYNC path must not rglob-walk the tree"
+    assert ".walk(" not in src, "SYNC path must not os.walk the tree"
+    assert "_iter_test_files(" not in src, (
+        "SYNC path must not iterate the test tree on the caller thread"
+    )

--- a/tests/governance/test_slice48_target_stratification.py
+++ b/tests/governance/test_slice48_target_stratification.py
@@ -1,5 +1,14 @@
 """Slice 48 — Semantic Target Stratification regression spine.
 
+Contract update (fix/coverage-sync-inline-ast — sixth starvation class):
+``file_has_test_coverage`` is INDEX-BACKED — the inline legacy scan (rglob
+walk + cold ``_strat_build_ast_map``) was retired because it wedged the
+asyncio loop 30.1 s (bt-iso-1783142866). COLD now degrades NEUTRAL (True,
+zero penalty, fires the single-flight off-loop build); real verdicts require
+a WARM index. All §1 detection/negative pins below therefore warm the index
+via ``_install_index`` first. The cold never-walk/neutral guarantees are
+pinned in ``test_coverage_sync_index_backed.py``.
+
 Pins (shared scoring substrate + OpportunityMiner wiring):
   §1  file_has_test_coverage — global AST-aware resolver (suffix + AST-import)
   §1a  exact test_<stem>.py still detected
@@ -36,16 +45,18 @@ from backend.core.ouroboros.governance.target_stratification import (
 )
 
 
-# ── §1a exact test_<stem>.py detected (unchanged behavior) ──────────────
+# ── §1a exact test_<stem>.py detected (warm index) ──────────────────────
 def test_file_has_test_coverage_detects_test_file(tmp_path: Path) -> None:
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)
     assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
 
 
-# ── §1e genuinely-untested file → False ─────────────────────────────────
+# ── §1e genuinely-untested file → False (warm index) ────────────────────
 def test_file_has_test_coverage_false_when_absent(tmp_path: Path) -> None:
     (tmp_path / "tests").mkdir()
+    _install_index(tmp_path)  # cold would degrade neutral (True) by design
     assert file_has_test_coverage("backend/core/widget.py", tmp_path) is False
 
 
@@ -59,6 +70,7 @@ def test_file_has_test_coverage_suffix_variant(
     (tmp_path / "tests" / "battle_test" / "test_repl_input_polish_slice4.py").write_text(
         "def test_x(): pass\n"
     )
+    _install_index(tmp_path)
     assert (
         file_has_test_coverage("backend/core/ouroboros/battle_test/repl_input_polish.py", tmp_path)
         is True
@@ -75,6 +87,7 @@ def test_file_has_test_coverage_nested_subdir(
     (tmp_path / "tests" / "governance" / "autonomy" / "test_widget.py").write_text(
         "def test_y(): pass\n"
     )
+    _install_index(tmp_path)
     assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
 
 
@@ -92,11 +105,9 @@ def test_file_has_test_coverage_ast_import_detects(
         "def test_it(): assert some_func() is not None\n"
     )
     (tmp_path / "tests" / "test_integration_suite.py").write_text(test_content)
-    # Clear cache for this tmp_path so Strategy 2 rebuilds fresh.
-    _strat_ast_cache.pop(tmp_path.resolve(), None)
-    result = file_has_test_coverage("backend/core/special_util.py", tmp_path)
-    _strat_ast_cache.pop(tmp_path.resolve(), None)  # cleanup
-    assert result is True
+    # Index-backed: Strategy 2's AST map lives inside the warm index.
+    _install_index(tmp_path)
+    assert file_has_test_coverage("backend/core/special_util.py", tmp_path) is True
 
 
 # ── §1e genuinely-untested file → False (explicit named case) ───────────
@@ -110,10 +121,8 @@ def test_file_has_test_coverage_genuinely_untested(
     (tmp_path / "tests" / "test_other.py").write_text(
         "from backend.core.other import foo\ndef test_foo(): pass\n"
     )
-    _strat_ast_cache.pop(tmp_path.resolve(), None)
-    result = file_has_test_coverage("backend/core/orphan.py", tmp_path)
-    _strat_ast_cache.pop(tmp_path.resolve(), None)  # cleanup
-    assert result is False
+    _install_index(tmp_path)  # cold would degrade neutral (True) by design
+    assert file_has_test_coverage("backend/core/orphan.py", tmp_path) is False
 
 
 # ── §1f Advisor _compute_test_coverage returns 1.0 for suffix-tested file ─
@@ -129,6 +138,7 @@ def test_advisor_compute_coverage_suffix_variant(
     (tmp_path / "tests" / "battle_test" / "test_repl_input_polish_slice4.py").write_text(
         "def test_x(): pass\n"
     )
+    _install_index(tmp_path)
     adv = OperationAdvisor.__new__(OperationAdvisor)
     adv._project_root = tmp_path  # type: ignore[attr-defined]
     cov = adv._compute_test_coverage(
@@ -226,6 +236,7 @@ def test_advisor_coverage_matches_shared_definition(tmp_path: Path) -> None:
 
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_covered.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)  # warm — cold degrades every file to covered
     adv = OperationAdvisor.__new__(OperationAdvisor)  # avoid heavy __init__
     adv._project_root = tmp_path  # type: ignore[attr-defined]
     cov = adv._compute_test_coverage(("covered.py", "uncovered.py"), root=tmp_path)
@@ -276,6 +287,7 @@ def test_analyze_file_stamps_coverage(tmp_path: Path) -> None:
     tree = _ast.parse(src)
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_thing.py").write_text("def test_x(): pass\n")
+    _install_index(tmp_path)  # warm — cold stamps every file covered (neutral)
     covered = _analyze_file("pkg/thing.py", src, tree, repo_root=tmp_path)
     uncovered = _analyze_file("pkg/other.py", src, tree, repo_root=tmp_path)
     none_root = _analyze_file("pkg/thing.py", src, tree)  # repo_root None → safe
@@ -285,10 +297,11 @@ def test_analyze_file_stamps_coverage(tmp_path: Path) -> None:
 
 
 # ═══════════════════════════════════════════════════════════════════════
-# Tier-4 — off-loop coverage index (warm fast path parity + lifecycle).
+# Tier-4 — off-loop coverage index (warm correctness + lifecycle).
 # The index answers Strategy 1 via set/bisect lookups and Strategy 2 via
-# the prebuilt AST map — it must be semantically identical to the legacy
-# filesystem scan for every case above.
+# the prebuilt AST map. It is the ONLY answer path for the sync API now —
+# the legacy inline filesystem scan was retired by the loop-wedge fix
+# (fix/coverage-sync-inline-ast); cold degrades neutral (True).
 # ═══════════════════════════════════════════════════════════════════════
 import time as _time
 
@@ -315,11 +328,15 @@ def _install_index(root: Path) -> None:
 
 
 @pytest.mark.parametrize("covered_case", ["exact", "suffix", "ast", "none"])
-def test_warm_index_parity_with_legacy_scan(
+def test_warm_index_correctness_per_strategy(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
     covered_case: str,
 ) -> None:
+    """Formerly ``test_warm_index_parity_with_legacy_scan`` — the legacy
+    cold-scan leg is retired (there is no inline scan to be at parity with;
+    cold now degrades neutral True). The warm index remains pinned to the
+    ground-truth verdict for every strategy case."""
     monkeypatch.setenv("JARVIS_STRATIFICATION_AST_IMPORT_ENABLED", "true")
     src = tmp_path / "backend" / "core" / "widget.py"
     src.parent.mkdir(parents=True)
@@ -335,13 +352,13 @@ def test_warm_index_parity_with_legacy_scan(
             "def test_it(): assert some_func() is not None\n"
         )
 
-    legacy = file_has_test_coverage("backend/core/widget.py", tmp_path)
-    _strat_ast_cache.clear()  # legacy run may have warmed it — isolate
+    # COLD — neutral degrade for every case (never walks, never False).
+    assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
 
     _install_index(tmp_path)
     warm = file_has_test_coverage("backend/core/widget.py", tmp_path)
 
-    assert warm == legacy == (covered_case != "none")
+    assert warm == (covered_case != "none")
 
 
 def test_warm_index_answers_without_filesystem_scan(
@@ -364,18 +381,23 @@ def test_warm_index_answers_without_filesystem_scan(
     assert file_has_test_coverage("backend/core/nope.py", tmp_path) is False
 
 
-def test_index_master_switch_off_restores_legacy_path(
+def test_index_master_switch_off_sync_stays_neutral(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
+    """Formerly ``test_index_master_switch_off_restores_legacy_path`` — the
+    legacy scan no longer exists. Master off → lookup always None → the sync
+    API stays permanently NEUTRAL (True, zero penalty), and it must still
+    never walk (the signal is advisory, so this is a safe opt-out)."""
     (tmp_path / "tests").mkdir()
     (tmp_path / "tests" / "test_widget.py").write_text("def test_x(): pass\n")
     _install_index(tmp_path)
     monkeypatch.setenv("JARVIS_STRATIFICATION_INDEX_ENABLED", "false")
-    # Index ignored (lookup returns None) → legacy scan still answers.
     assert _ts.coverage_index_ready(tmp_path) is False
     assert _ts.trigger_coverage_index_build(tmp_path) == "skipped_disabled"
+    # Neutral for covered AND uncovered alike — a degrade, not a scan verdict.
     assert file_has_test_coverage("backend/core/widget.py", tmp_path) is True
+    assert file_has_test_coverage("backend/core/orphan.py", tmp_path) is True
 
 
 def test_trigger_sentinels_lifecycle(tmp_path: Path) -> None:

--- a/tests/governance/test_slice49_ingest_stratification.py
+++ b/tests/governance/test_slice49_ingest_stratification.py
@@ -35,16 +35,34 @@ def _mk(root: Path, rel: str, lines: int, *, covered: bool) -> str:
     return rel
 
 
+def _install_index(root: Path) -> None:
+    """Build + install the coverage index synchronously (test-only shortcut).
+
+    ``file_has_test_coverage`` is index-backed (fix/coverage-sync-inline-ast):
+    COLD degrades neutral (every file treated covered → penalty 0), so any pin
+    that needs a real uncovered verdict must warm the index first. Mirrors the
+    slice48 helper. (``ts`` is the module import below — resolved at call time.)
+    """
+    idx = ts._build_coverage_index_sync(
+        ts._resolve_scan_root(root),
+        ts._strat_test_dir_names(),
+    )
+    with ts._COVERAGE_IDX_LOCK:
+        ts._coverage_index[ts._resolve_scan_root(root)] = idx
+
+
 # ── §1 ─────────────────────────────────────────────────────────────────
 def test_no_files_or_covered_is_zero(tmp_path: Path) -> None:
     assert ingest_priority_penalty([], tmp_path) == 0
     rel = _mk(tmp_path, "backend/big.py", 5000, covered=True)
+    _install_index(tmp_path)  # warm so "covered → 0" is a real verdict
     assert ingest_priority_penalty([rel], tmp_path) == 0
 
 
 # ── §2 ─────────────────────────────────────────────────────────────────
 def test_huge_uncovered_gets_penalty(tmp_path: Path) -> None:
     rel = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
+    _install_index(tmp_path)  # cold degrades neutral (penalty 0) by design
     assert ingest_priority_penalty([rel], tmp_path) > 0
 
 
@@ -57,6 +75,7 @@ def test_suppress_escape_hatch(tmp_path: Path) -> None:
 # ── §4 ─────────────────────────────────────────────────────────────────
 def test_penalty_is_bounded(tmp_path: Path) -> None:
     rels = [_mk(tmp_path, f"backend/h{i}.py", 9000, covered=False) for i in range(5)]
+    _install_index(tmp_path)  # cold degrades neutral (penalty 0) by design
     pen = ingest_priority_penalty(rels, tmp_path)
     assert 0 < pen <= 5  # bounded — cannot swamp base priorities (1..99)
 
@@ -70,6 +89,7 @@ def test_compute_priority_deprioritizes_huge_uncovered(tmp_path: Path) -> None:
 
     huge = _mk(tmp_path, "backend/huge.py", 5000, covered=False)
     small = _mk(tmp_path, "backend/small.py", 40, covered=True)
+    _install_index(tmp_path)  # cold degrades neutral → both would rank equal
 
     common = dict(
         source="ai_miner",


### PR DESCRIPTION
## The true 6th starvation class, killed at the root

MainThread-first tombstone (bt-iso-1783142866, instrument 1 run old) named it line-exactly: OpportunityMiner.scan_once -> file_has_test_coverage -> INLINE _strat_build_ast_map -> ast.parse of the whole tests tree ON the asyncio loop (30.1s GIL-held; the cause of all three runs' wedges — SemanticIndex adjacency was coincidental).

- Sync API now index-backed via the existing Tier-4 _CoverageIndex: WARM -> set/bisect/ast-map lookups (semantic parity both strategies, proven); COLD -> trigger_coverage_index_build (existing process pool, single-flight, 600s failed-build retry) + documented neutral degrade (ingest cold semantics). Inline walk + AST build DELETED from the caller-thread path (source-pinned).
- LoopSink instrumentation wired (the callsite was previously invisible).
- 16 spine tests migrated to the index-backed contract (incl. 6 previously-vacuous positives re-armed); 0 deleted; 10 new never-walk/neutral-cold tests. Combined: 55 passed.
- Operator note: JARVIS_STRATIFICATION_INDEX_ENABLED=false now means 'coverage prior disabled (all neutral)' — no inline-scan fallback exists anymore (advisory-only signal; documented + test-pinned).

Review: APPROVED (never-walk structural for every input incl. master-off; cold blast radius bounded; migration honesty sampled).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make `file_has_test_coverage` index-backed and off-loop to stop event-loop wedges and long GIL stalls. Cold calls now trigger a background index build and return a neutral covered result (zero penalty); warm calls answer from memory.

- Bug Fixes
  - Replaced inline scanning with `_CoverageIndex` lookups (warm); cold path calls `trigger_coverage_index_build` and returns `True` (treated-as-covered).
  - Removed inline `_strat_build_ast_map` and filesystem walks from the sync path; added LoopSink instrumentation to verify no loop blocking.
  - Preserved existing matching semantics (exact/suffix name, optional AST-import) when the index is warm; added a new test suite and migrated slice48/49 tests to warm the index where needed.

- Migration
  - No inline-scan fallback remains. With `JARVIS_STRATIFICATION_INDEX_ENABLED=false`, sync callers stay neutral (all files treated as covered).
  - Code/tests that need uncovered verdicts must ensure the index is warm (use the `_install_index` helper in tests or wait for the builder).
  - Early-True behavior for non-.py and `test_*` inputs is unchanged.

<sup>Written for commit 6d0de8fd00ac52444062d1a0dc153a27222c5be3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69833?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

