### PR TITLE
fix(intake): zero-loss submit boundary -- capacity rejections park in the intake WAL, dispatcher stays async

### DIFF
--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -897,6 +897,20 @@ class BackgroundAgentPool:
         """
         return self._queue.qsize()
 
+    def has_capacity(self) -> bool:
+        """True when the queue has a free slot (``submit`` would not raise
+        :class:`QueueFullError`).
+
+        Consumed by the no-loss submit boundary: the intake router gates its
+        capacity-deferred WAL replay on this so parked envelopes are re-drained
+        only once a slot actually frees — never a hot re-submit spin against a
+        saturated pool. NEVER raises (fail-open to ``True`` so a probe fault can
+        never wedge the drain path)."""
+        try:
+            return self._queue.qsize() < self._queue_size
+        except Exception:  # noqa: BLE001
+            return True
+
     def _clear_resume_mark(self, ctx_op_id: str) -> None:
         """Drop the resume mark.  Called by the worker loop's finally
         block AFTER a resumed dispatch reaches terminal.

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3021,6 +3021,12 @@ class GovernedLoopService:
             )
 
         if self._bg_pool is not None:
+            # Import the capacity-rejection class locally to keep the module
+            # import graph flat (background_agent_pool imports op_context; a
+            # top-level import here risks a cycle).
+            from backend.core.ouroboros.governance.background_agent_pool import (
+                QueueFullError,
+            )
             try:
                 op_id = await self._bg_pool.submit(ctx)
                 logger.info(
@@ -3028,13 +3034,53 @@ class GovernedLoopService:
                     op_id, trigger_source,
                 )
                 return op_id
-            except Exception as exc:
-                logger.warning(
-                    "[GovernedLoop] Background submit failed, falling back to sync: %s", exc
+            except QueueFullError:
+                # NO-LOSS SUBMIT BOUNDARY. A capacity rejection is NOT a broken
+                # pool — it is transient backpressure. The legacy behavior ran
+                # ``await self.submit(ctx)`` here: a ~2-minute op executed
+                # SYNCHRONOUSLY INLINE on the dispatch path, serializing the
+                # UnifiedIntakeRouter's dequeue loop so low-priority write-intent
+                # signals never drained for 60+ min (live bt-iso-1783144982, 45x).
+                # Instead we RE-RAISE: the router's intake WAL already holds this
+                # envelope as a ``status="pending"`` row, so declining to ack it
+                # parks it durably. The router catches QueueFullError, keeps the
+                # WAL row pending, and re-drains it via _replay_wal once the pool
+                # reports free capacity. The dispatcher stays fully async.
+                logger.info(
+                    "[GovernedLoop] Background submit deferred (capacity) — "
+                    "parking in intake WAL: op=%s (trigger=%s)",
+                    getattr(ctx, "op_id", "") or "?", trigger_source,
                 )
-        # Fallback: run synchronously
+                raise
+            except Exception as exc:
+                # Genuinely broken pool (not-started, worker crash, etc.) — the
+                # legacy sync fallback still applies. This is a real failure, not
+                # backpressure, so serializing one op inline is acceptable.
+                logger.warning(
+                    "[GovernedLoop] Background submit failed (non-capacity), "
+                    "falling back to sync: %s", exc
+                )
+        # Fallback: run synchronously (no pool, or a non-capacity pool fault).
         result = await self.submit(ctx, trigger_source)
         return result.op_id
+
+    def has_background_capacity(self) -> bool:
+        """True when the background pool can accept a submit without raising
+        ``QueueFullError`` (or when there is no pool — nothing to gate on).
+
+        Consumed by the intake router's capacity-deferred WAL drain: parked
+        envelopes are replayed only when a slot is actually free. NEVER raises
+        (fail-open to ``True``)."""
+        pool = self._bg_pool
+        if pool is None:
+            return True
+        try:
+            probe = getattr(pool, "has_capacity", None)
+            if callable(probe):
+                return bool(probe())
+        except Exception:  # noqa: BLE001
+            pass
+        return True
 
     def get_background_result(self, op_id: str) -> Any:
         """Poll for a background operation result. Returns None if not ready."""

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -852,6 +852,13 @@ class UnifiedIntakeRouter:
         # _replay_wal once the pool reports capacity. Self-clearing after a
         # drain; re-set by any subsequent capacity deferral.
         self._capacity_deferred_pending: bool = False
+        # Single-flight guard for _drain_capacity_deferred: the drain's WAL
+        # read is offloaded through cooperative_fs_io (a real suspension
+        # point), which makes reentry possible if a second caller reaches the
+        # drain while the first is parked on the thread hop. True while a
+        # drain cycle is in flight; overlapping callers return immediately
+        # (the in-flight cycle covers them).
+        self._capacity_drain_in_flight: bool = False
         self._pending_ack = PendingAckStore()
         self._dead_letter: List[IntentEnvelope] = []
         self._dispatch_task: Optional[asyncio.Task] = None
@@ -2243,17 +2250,31 @@ class UnifiedIntakeRouter:
 
         * ``_capacity_deferred_pending`` — cheap flag; skip the full WAL read
           entirely when nothing is parked.
+        * ``_capacity_drain_in_flight`` — single-flight: the offloaded WAL
+          read is a real suspension point, so a concurrent second drain call
+          is possible; it returns immediately (the in-flight cycle covers it).
         * pool capacity — only replay when the pool reports a free slot
           (``has_background_capacity``); otherwise the parked rows sit idle
           in the WAL (no re-submit spin against a saturated pool).
-        * in-memory queue + coalesce buffers empty — the dispatch loop is a
-          single coroutine, so when both are empty NO pending envelope is
-          already in flight; re-enqueuing the pending WAL rows therefore
-          cannot double-enqueue one that is still queued/buffered.
+        * in-memory queue + coalesce buffers empty — checked BEFORE the
+          offloaded read and RE-CHECKED after it resolves (an ``ingest()``
+          on another coroutine may have enqueued a fresh — and WAL-pending —
+          envelope during the thread hop; replaying then would double-enqueue
+          it). The re-enqueue itself runs on-loop with no true suspension
+          point after the re-check, so it is atomic w.r.t. other coroutines.
+
+        The WAL read (whole-file read + JSON parse) is routed through the
+        ``cooperative_fs_io.offload`` substrate — this method runs on the
+        dispatch loop's idle branch repeatedly, and a synchronous
+        ``pending_entries()`` here would be a new instance of the
+        sync-FS-on-loop class. Fail-soft: an OffloadError skips this cycle
+        (flag stays set → retried next idle tick).
 
         NEVER raises.
         """
         if not self._capacity_deferred_pending:
+            return
+        if self._capacity_drain_in_flight:
             return
         # Capacity gate — fail-open (drain) if the GLS can't be probed.
         try:
@@ -2265,19 +2286,58 @@ class UnifiedIntakeRouter:
         # Only drain when nothing pending is already in flight (see docstring).
         if self._queue.qsize() > 0 or self._coalesce_buffer:
             return
-        # Reuse the existing pending-WAL replay to re-enqueue the parked rows.
-        await self._replay_wal()
-        # Cleared optimistically; any row that hits QueueFullError again on the
-        # re-dispatch re-sets the flag, so a partial drain self-continues.
-        self._capacity_deferred_pending = False
+        self._capacity_drain_in_flight = True
+        try:
+            # Sync-FS-on-loop guard: the whole-WAL read + JSON parse happens
+            # on the shared cooperative_fs_io thread pool, not the loop.
+            from backend.core.ouroboros.governance.cooperative_fs_io import (
+                is_offload_error,
+                offload,
+            )
+
+            pending = await offload(self._wal.pending_entries, cpu_bound=False)
+            if is_offload_error(pending):
+                # Flag stays set — retried on the next idle tick.
+                logger.debug(
+                    "[Router] capacity-deferred drain skipped (OffloadError): %r",
+                    pending,
+                )
+                return
+            # Re-check the idle gate: ingest() may have enqueued a fresh
+            # (WAL-pending) envelope while we were parked on the thread hop.
+            # Replaying now would double-enqueue it — defer to the next tick.
+            if self._queue.qsize() > 0 or self._coalesce_buffer:
+                return
+            # Cleared optimistically; any row that hits QueueFullError again
+            # on the re-dispatch re-sets the flag, so a partial drain
+            # self-continues.
+            self._capacity_deferred_pending = False
+            if pending:
+                # Reuse the existing replay machinery for the re-enqueue
+                # (on-loop, cheap — the expensive read already happened).
+                await self._replay_wal(pending=pending)
+        except Exception:  # noqa: BLE001 — the drain must never kill the loop
+            logger.exception("[Router] capacity-deferred drain failed")
+        finally:
+            self._capacity_drain_in_flight = False
 
     # ------------------------------------------------------------------
     # WAL crash recovery
     # ------------------------------------------------------------------
 
-    async def _replay_wal(self) -> None:
-        """Re-enqueue all pending WAL entries from a previous run."""
-        pending = self._wal.pending_entries()
+    async def _replay_wal(
+        self, pending: Optional[List[WALEntry]] = None
+    ) -> None:
+        """Re-enqueue all pending WAL entries from a previous run.
+
+        ``pending`` (no-loss submit boundary): pre-fetched entries from an
+        already-offloaded ``pending_entries()`` read — the capacity-deferred
+        drain passes these so the whole-WAL file read + JSON parse never runs
+        synchronously on the dispatch loop. ``None`` (the once-at-``start()``
+        crash-recovery call) preserves the legacy inline read.
+        """
+        if pending is None:
+            pending = self._wal.pending_entries()
         if not pending:
             return
         logger.info("Router: replaying %d pending WAL entries", len(pending))
@@ -2300,6 +2360,14 @@ class UnifiedIntakeRouter:
                         envelope,
                     )
                 )
+                # F1 mirror — same guard as the ingest site: in primary mode
+                # the IntakePriorityQueue is the dispatch source of truth, so
+                # a replayed row that only lands on the legacy _queue would
+                # never dequeue. Mirror-enqueue exactly like ingest step 6.
+                # None when both F1 flags are off → default-off behavior is
+                # byte-identical.
+                if self._priority_queue is not None:
+                    self._priority_queue.enqueue(envelope)
                 logger.debug(
                     "Router: replayed lease_id=%s source=%s",
                     entry.lease_id,

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -845,6 +845,13 @@ class UnifiedIntakeRouter:
         )
         self._dedup: Dict[str, float] = {}
         self._retry_count: Dict[str, int] = {}
+        # No-loss submit boundary: set True whenever a dispatch is deferred by
+        # a background-pool QueueFullError (the envelope stays a pending WAL
+        # row — durably parked). The dispatch loop's idle branch consults this
+        # cheap flag to decide whether to re-drain the parked rows via
+        # _replay_wal once the pool reports capacity. Self-clearing after a
+        # drain; re-set by any subsequent capacity deferral.
+        self._capacity_deferred_pending: bool = False
         self._pending_ack = PendingAckStore()
         self._dead_letter: List[IntentEnvelope] = []
         self._dispatch_task: Optional[asyncio.Task] = None
@@ -1748,6 +1755,9 @@ class UnifiedIntakeRouter:
                     except asyncio.CancelledError:
                         break
                     await self._flush_expired_coalesce_buffers()
+                    # No-loss submit boundary: re-drain capacity-parked WAL rows
+                    # now the queue is idle and (maybe) the pool freed a slot.
+                    await self._drain_capacity_deferred()
                     continue
                 envelope = decision.envelope
                 # Drain the matching entry from the legacy queue so
@@ -1778,6 +1788,9 @@ class UnifiedIntakeRouter:
                 except asyncio.TimeoutError:
                     # Flush any expired coalescing buffers
                     await self._flush_expired_coalesce_buffers()
+                    # No-loss submit boundary: re-drain capacity-parked WAL rows
+                    # now the queue is idle and (maybe) the pool freed a slot.
+                    await self._drain_capacity_deferred()
                     continue
                 except asyncio.CancelledError:
                     break
@@ -1896,6 +1909,14 @@ class UnifiedIntakeRouter:
         no code-change signals), dispatch to RuntimeTaskOrchestrator.
         Otherwise, dispatch to GovernedLoopService for code changes.
         """
+        # No-loss submit boundary — the background pool's capacity-rejection
+        # class. Handled distinctly from genuine dispatch failures below (park
+        # durably in the WAL, never dead-letter). Local import keeps the
+        # module import graph flat.
+        from backend.core.ouroboros.governance.background_agent_pool import (
+            QueueFullError,
+        )
+
         ikey = envelope.idempotency_key
 
         # A1-T4 — hop 3/5 (dequeue): the dispatch loop has pulled this
@@ -2144,6 +2165,23 @@ class UnifiedIntakeRouter:
                 )
             self._wal.update_status(envelope.lease_id, "acked")
             self._retry_count.pop(ikey, None)
+        except QueueFullError:
+            # NO-LOSS SUBMIT BOUNDARY. The background pool is at capacity. This
+            # is NOT a dispatch failure — do NOT increment the retry counter and
+            # do NOT dead-letter (either would eventually LOSE the op). The WAL
+            # already holds this envelope as a status="pending" row (durable
+            # park); we simply decline to ack it. It is re-drained by
+            # _drain_capacity_deferred() -> _replay_wal() once the pool reports
+            # free capacity. The dispatcher stays fully async — no sync-inline
+            # execution serializes the queue (the live bt-iso-1783144982 defect).
+            self._capacity_deferred_pending = True
+            logger.info(
+                "[Router] bg_submit_deferred lease_id=%s source=%s "
+                "reason=pool_capacity_full wal=pending (durably parked, no loss)",
+                envelope.lease_id,
+                envelope.source,
+            )
+            return
         except Exception as exc:
             retries = self._retry_count.get(ikey, 0) + 1
             self._retry_count[ikey] = retries
@@ -2185,6 +2223,53 @@ class UnifiedIntakeRouter:
                     self._wal.update_status(envelope.lease_id, "dead_letter")
                     self._dead_letter.append(envelope)
                     self._retry_count.pop(ikey, None)
+
+    # ------------------------------------------------------------------
+    # No-loss submit boundary — capacity-deferred WAL drain
+    # ------------------------------------------------------------------
+
+    async def _drain_capacity_deferred(self) -> None:
+        """Re-drain envelopes parked by a background-pool ``QueueFullError``.
+
+        The no-loss submit boundary keeps a capacity-rejected envelope as a
+        ``status="pending"`` WAL row (durable park) instead of running it
+        synchronously inline. This method re-enqueues those parked rows for
+        another dispatch attempt — reusing the EXISTING replay machinery
+        (:meth:`_replay_wal`); no new queue, no custom retry loop.
+
+        Called from the dispatch loop's idle branch, so it is the natural
+        drain cadence with zero extra tasks. Guarded three ways to guarantee
+        no double-dispatch and no hot spin:
+
+        * ``_capacity_deferred_pending`` — cheap flag; skip the full WAL read
+          entirely when nothing is parked.
+        * pool capacity — only replay when the pool reports a free slot
+          (``has_background_capacity``); otherwise the parked rows sit idle
+          in the WAL (no re-submit spin against a saturated pool).
+        * in-memory queue + coalesce buffers empty — the dispatch loop is a
+          single coroutine, so when both are empty NO pending envelope is
+          already in flight; re-enqueuing the pending WAL rows therefore
+          cannot double-enqueue one that is still queued/buffered.
+
+        NEVER raises.
+        """
+        if not self._capacity_deferred_pending:
+            return
+        # Capacity gate — fail-open (drain) if the GLS can't be probed.
+        try:
+            probe = getattr(self._gls, "has_background_capacity", None)
+            if callable(probe) and not probe():
+                return
+        except Exception:  # noqa: BLE001
+            pass
+        # Only drain when nothing pending is already in flight (see docstring).
+        if self._queue.qsize() > 0 or self._coalesce_buffer:
+            return
+        # Reuse the existing pending-WAL replay to re-enqueue the parked rows.
+        await self._replay_wal()
+        # Cleared optimistically; any row that hits QueueFullError again on the
+        # re-dispatch re-sets the flag, so a partial drain self-continues.
+        self._capacity_deferred_pending = False
 
     # ------------------------------------------------------------------
     # WAL crash recovery

--- a/tests/governance/test_no_loss_submit_boundary.py
+++ b/tests/governance/test_no_loss_submit_boundary.py
@@ -126,10 +126,13 @@ class _StubGLS:
         return _R()
 
 
-def _make_router(tmp_path, pool, monkeypatch):
+def _make_router(tmp_path, pool, monkeypatch, f1_master: bool = False):
     # Keep intake side-channels quiet + deterministic.
     monkeypatch.setenv("JARVIS_SEMANTIC_INFERENCE_ENABLED", "false")
-    monkeypatch.setenv("JARVIS_INTAKE_PRIORITY_SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv(
+        "JARVIS_INTAKE_PRIORITY_SCHEDULER_ENABLED",
+        "true" if f1_master else "false",
+    )
     monkeypatch.setenv("JARVIS_INTAKE_PRIORITY_SCHEDULER_SHADOW", "false")
     cfg = IntakeRouterConfig(
         project_root=tmp_path,
@@ -362,3 +365,163 @@ async def test_non_capacity_exception_still_takes_sync_fallback(
     assert deferred_logs == []
     # The op ran (sync) → acked, not parked.
     assert router._wal.pending_entries() == []
+
+
+# ---------------------------------------------------------------------------
+# Sync-FS-on-loop guard — the drain's WAL read runs via cooperative_fs_io
+# offload (off the event-loop thread), never synchronously on the loop.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_drain_wal_read_routed_through_offload_substrate(
+    tmp_path, monkeypatch
+):
+    import threading
+
+    import backend.core.ouroboros.governance.cooperative_fs_io as cfs
+
+    monkeypatch.setenv("JARVIS_COOPERATIVE_FS_IO_ENABLED", "true")
+    pool = _GatedPool(capacity=16)
+    router, _ = _make_router(tmp_path, pool, monkeypatch)
+
+    envs = [_lease_and_wal(router, e) for e in _envelopes(20)]
+    for env in envs:
+        await router._dispatch_one(env)
+    assert router._capacity_deferred_pending
+
+    # Spy 1 — every offload() call records the fn it was handed.
+    real_offload = cfs.offload
+    offloaded_fns: list = []
+
+    async def spy_offload(fn, *args, **kwargs):
+        offloaded_fns.append(fn)
+        return await real_offload(fn, *args, **kwargs)
+
+    monkeypatch.setattr(cfs, "offload", spy_offload)
+
+    # Spy 2 — pending_entries records the thread it executes on, and RAISES
+    # if it ever runs on the event-loop thread during the drain.
+    loop_thread = threading.current_thread()
+    real_pending = router._wal.pending_entries
+    read_threads: list = []
+
+    def spy_pending():
+        read_threads.append(threading.current_thread())
+        if threading.current_thread() is loop_thread:
+            raise AssertionError(
+                "sync-FS-on-loop: pending_entries ran ON the event-loop "
+                "thread during the drain path"
+            )
+        return real_pending()
+
+    monkeypatch.setattr(router._wal, "pending_entries", spy_pending)
+
+    while pool.queue_depth() > 0:
+        pool.release_one()
+    await router._drain_capacity_deferred()
+
+    # The WAL read went through the offload substrate...
+    assert spy_pending in offloaded_fns, (
+        "drain did not route the WAL read through cooperative_fs_io.offload"
+    )
+    # ...and actually executed off the loop thread.
+    assert read_threads, "pending_entries never ran"
+    assert all(t is not loop_thread for t in read_threads)
+    # And the drain still worked: parked rows were re-enqueued.
+    assert router._queue.qsize() == 4  # 20 - 16 accepted
+
+
+# ---------------------------------------------------------------------------
+# Single-flight — overlapping drain calls perform exactly ONE WAL read.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_overlapping_drains_are_single_flight(tmp_path, monkeypatch):
+    import asyncio as _asyncio
+
+    import backend.core.ouroboros.governance.cooperative_fs_io as cfs
+
+    pool = _GatedPool(capacity=16)
+    router, _ = _make_router(tmp_path, pool, monkeypatch)
+
+    envs = [_lease_and_wal(router, e) for e in _envelopes(20)]
+    for env in envs:
+        await router._dispatch_one(env)
+    assert router._capacity_deferred_pending
+    while pool.queue_depth() > 0:
+        pool.release_one()
+
+    # Slow offload: first drain parks on `release`; reads are counted.
+    read_count = 0
+    first_read_started = _asyncio.Event()
+    release = _asyncio.Event()
+
+    async def slow_offload(fn, *args, **kwargs):
+        nonlocal read_count
+        kwargs.pop("cpu_bound", None)  # offload-only kwarg, not fn's
+        read_count += 1
+        first_read_started.set()
+        await release.wait()
+        return fn(*args, **kwargs)
+
+    monkeypatch.setattr(cfs, "offload", slow_offload)
+
+    t1 = _asyncio.create_task(router._drain_capacity_deferred())
+    await first_read_started.wait()
+    # Second drain while the first is suspended mid-offload: must return
+    # immediately WITHOUT a second WAL read (single-flight guard).
+    await router._drain_capacity_deferred()
+    assert read_count == 1, "overlapping drain performed a second WAL read"
+
+    release.set()
+    await t1
+    assert read_count == 1
+    # The single in-flight drain completed the re-enqueue.
+    assert router._queue.qsize() == 4  # 20 - 16 accepted
+    assert router._capacity_drain_in_flight is False
+
+
+# ---------------------------------------------------------------------------
+# F1 mirror — replayed rows land in the IntakePriorityQueue when the
+# scheduler master flag is on; default-off behavior is byte-identical.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replay_mirror_enqueues_priority_queue_when_f1_on(
+    tmp_path, monkeypatch
+):
+    pool = _GatedPool(capacity=16)
+    router, _ = _make_router(tmp_path, pool, monkeypatch, f1_master=True)
+    assert router._priority_queue is not None  # F1 primary mode wired
+
+    # Park 5 rows durably (pending WAL rows, nothing in the queues).
+    for env in _envelopes(5):
+        _lease_and_wal(router, env)
+    router._capacity_deferred_pending = True
+
+    await router._drain_capacity_deferred()
+
+    # Replayed rows land on BOTH queues — the priority queue is the dispatch
+    # source of truth in F1 primary mode, so missing the mirror means the
+    # replayed rows would never dequeue.
+    assert router._queue.qsize() == 5
+    assert len(router._priority_queue) == 5
+
+
+@pytest.mark.asyncio
+async def test_replay_no_priority_queue_when_f1_off(tmp_path, monkeypatch):
+    pool = _GatedPool(capacity=16)
+    router, _ = _make_router(tmp_path, pool, monkeypatch, f1_master=False)
+    assert router._priority_queue is None  # default-off: no mirror target
+
+    for env in _envelopes(5):
+        _lease_and_wal(router, env)
+    router._capacity_deferred_pending = True
+
+    await router._drain_capacity_deferred()
+
+    # Byte-identical default-off behavior: legacy queue only, no errors.
+    assert router._queue.qsize() == 5

--- a/tests/governance/test_no_loss_submit_boundary.py
+++ b/tests/governance/test_no_loss_submit_boundary.py
@@ -1,0 +1,364 @@
+"""No-loss submit boundary — capacity rejections park durably in the intake WAL.
+
+THE EVIDENCED DEFECT (live session bt-iso-1783144982, 45 occurrences):
+    ``[GovernedLoop] Background submit failed, falling back to sync:
+      Background queue is full (16 items)...``
+``GovernedLoopService.submit_background`` caught the ``QueueFullError`` from
+``BackgroundAgentPool.submit`` and ran ``await self.submit(ctx)`` — a
+SYNCHRONOUS INLINE ~2-minute op ON THE DISPATCH PATH. The dispatcher
+serialized, the intake queue backed up behind it, and low-priority
+write-intent signals (TodoScanner, priority 5) never dequeued for 60+ min.
+Effective loss.
+
+THE FIX (no-loss submit boundary):
+    A capacity rejection (``QueueFullError``) is NOT a broken pool. It must
+    park DURABLY in the EXISTING intake WAL (the envelope is already a
+    ``status="pending"`` WAL row — parking = simply never acking it) and
+    drain via the EXISTING replay machinery (``_replay_wal``) once the pool
+    reports free capacity. The dispatcher stays fully async. Genuinely broken
+    (non-capacity) submit exceptions still take the legacy sync fallback.
+
+THE GATE TEST (deterministic): burst 100 envelopes into a simulated
+16-slot / 1-worker pool with the worker GATED (zero consumption during the
+burst) → EXACTLY 84 durably parked in the WAL (84 pending rows), 16 accepted
+(acked / pool-owned), ZERO lost, ZERO sync-inline fallbacks; then release the
+worker → ALL 100 reach accepted/terminal states (bounded drain, no loss).
+"""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import pytest
+
+from backend.core.ouroboros.governance.background_agent_pool import QueueFullError
+from backend.core.ouroboros.governance.governed_loop_service import (
+    GovernedLoopService,
+)
+from backend.core.ouroboros.governance.operation_id import generate_operation_id
+from backend.core.ouroboros.governance.intake.intent_envelope import (
+    IntentEnvelope,
+    make_envelope,
+)
+from backend.core.ouroboros.governance.intake.unified_intake_router import (
+    IntakeRouterConfig,
+    UnifiedIntakeRouter,
+)
+from backend.core.ouroboros.governance.intake.wal import WALEntry
+import time
+
+
+# ---------------------------------------------------------------------------
+# Test doubles — a faithful 16-slot / 1-worker gated pool + a stub GLS that
+# binds the REAL submit_background / has_background_capacity boundary methods.
+# ---------------------------------------------------------------------------
+
+
+class _GatedPool:
+    """Faithful 16-slot / 1-worker BackgroundAgentPool.
+
+    ``submit`` raises the REAL ``QueueFullError`` once ``capacity`` slots are
+    occupied. The single worker is GATED: slots free only via ``release_one``
+    (simulating a worker consuming one op), so the test controls consumption
+    deterministically. Records every accepted ctx.op_id for loss accounting.
+    """
+
+    def __init__(self, capacity: int = 16) -> None:
+        self._cap = capacity
+        self._queued: list = []  # accepted, not yet consumed by the worker
+        self.accepted_ctx_ids: list = []  # ctx.op_id of every accepted op
+        self._counter = 0
+
+    async def submit(self, ctx) -> str:
+        if len(self._queued) >= self._cap:
+            raise QueueFullError(
+                f"Background queue is full ({self._cap} items). "
+                f"Operation rejected."
+            )
+        self._counter += 1
+        op_id = f"bgop-{self._counter:05d}"
+        self._queued.append((op_id, ctx))
+        self.accepted_ctx_ids.append(str(getattr(ctx, "op_id", "") or op_id))
+        return op_id
+
+    def has_capacity(self) -> bool:
+        return len(self._queued) < self._cap
+
+    def queue_depth(self) -> int:
+        return len(self._queued)
+
+    def release_one(self) -> None:
+        """Simulate the single worker draining one occupied slot."""
+        if self._queued:
+            self._queued.pop(0)
+
+
+class _StubGLS:
+    """Minimal GLS that binds the REAL boundary methods under test.
+
+    ``submit_background`` + ``has_background_capacity`` are the production
+    methods bound onto a lightweight object carrying only ``_bg_pool`` and the
+    sync fallback ``submit``. Using ``getattr`` fallback for
+    ``has_background_capacity`` keeps the test importable BEFORE the method is
+    implemented (fail-first cleanliness).
+    """
+
+    submit_background = GovernedLoopService.submit_background
+    has_background_capacity = getattr(
+        GovernedLoopService, "has_background_capacity", lambda self: True
+    )
+
+    def __init__(self, pool: _GatedPool) -> None:
+        self._bg_pool = pool
+        self.sync_fallback_calls = 0
+        self.sync_fallback_ctx_ids: list = []
+
+    async def submit(self, ctx, trigger_source: str = "unknown"):
+        # THE sync-inline fallback. For a CAPACITY rejection this MUST NOT run
+        # (that is the exact defect: a ~2-min op serialized on the dispatch
+        # path). Only a genuinely-broken (non-capacity) pool may reach here.
+        self.sync_fallback_calls += 1
+        self.sync_fallback_ctx_ids.append(str(getattr(ctx, "op_id", "") or ""))
+
+        class _R:
+            op_id = str(getattr(ctx, "op_id", "") or "sync")
+
+        return _R()
+
+
+def _make_router(tmp_path, pool, monkeypatch):
+    # Keep intake side-channels quiet + deterministic.
+    monkeypatch.setenv("JARVIS_SEMANTIC_INFERENCE_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_INTAKE_PRIORITY_SCHEDULER_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_INTAKE_PRIORITY_SCHEDULER_SHADOW", "false")
+    cfg = IntakeRouterConfig(
+        project_root=tmp_path,
+        wal_path=tmp_path / "intake_wal.jsonl",
+        max_queue_size=512,
+        dispatch_timeout_s=30.0,
+    )
+    gls = _StubGLS(pool)
+    router = UnifiedIntakeRouter(gls, cfg)
+    return router, gls
+
+
+def _envelopes(n: int):
+    out = []
+    for i in range(n):
+        out.append(
+            make_envelope(
+                source="todo_scanner",
+                description=f"fix bug in module_{i}",
+                target_files=(f"pkg/mod_{i}.py",),
+                repo="jarvis",
+                confidence=0.9,
+                urgency="high",  # bypass coalescing → 1:1 dispatch
+                evidence={"signature": f"sig-{i}"},
+                requires_human_ack=False,
+            )
+        )
+    return out
+
+
+def _lease_and_wal(router, env):
+    """Mimic ingest step 4 — durable WAL append (status=pending) before
+    the envelope is handed to dispatch. Returns the leased envelope."""
+    lease_id = generate_operation_id("lse")
+    env = env.with_lease(lease_id)
+    router._wal.append(
+        WALEntry(
+            lease_id=lease_id,
+            envelope_dict=env.to_dict(),
+            status="pending",
+            ts_monotonic=time.monotonic(),
+            ts_utc=datetime.now(timezone.utc).isoformat(),
+        )
+    )
+    return env
+
+
+# ---------------------------------------------------------------------------
+# THE GATE TEST — 84 parked / 16 accepted / 0 lost / 0 sync-inline.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_gate_burst_100_parks_84_in_wal_zero_loss_zero_sync(
+    tmp_path, monkeypatch, caplog
+):
+    pool = _GatedPool(capacity=16)
+    router, gls = _make_router(tmp_path, pool, monkeypatch)
+
+    envs = [_lease_and_wal(router, e) for e in _envelopes(100)]
+
+    caplog.set_level(logging.INFO)
+    # Burst: dispatch all 100 with the worker GATED (zero consumption).
+    for env in envs:
+        await router._dispatch_one(env)
+
+    # --- 16 accepted (pool-owned / acked), 84 durably parked (pending) ---
+    pending = router._wal.pending_entries()
+    assert len(pending) == 84, f"expected 84 parked, got {len(pending)}"
+    assert len(pool.accepted_ctx_ids) == 16, (
+        f"expected 16 accepted, got {len(pool.accepted_ctx_ids)}"
+    )
+
+    # --- ZERO sync-inline fallback for capacity rejections ---
+    assert gls.sync_fallback_calls == 0, (
+        f"capacity rejection must NOT serialize on the dispatch path; "
+        f"sync fallback ran {gls.sync_fallback_calls}x"
+    )
+
+    # --- ZERO loss: 16 accepted + 84 pending == 100, disjoint sets ---
+    parked_ids = {e.envelope_dict["causal_id"] for e in pending}
+    accepted_ids = set(pool.accepted_ctx_ids)
+    assert len(parked_ids) == 84
+    assert len(accepted_ids) == 16
+    assert parked_ids.isdisjoint(accepted_ids)
+    assert len(parked_ids | accepted_ids) == 100, "envelope loss detected"
+
+    # --- structured telemetry fires once per parked envelope ---
+    deferred_logs = [
+        r for r in caplog.records if "bg_submit_deferred" in r.getMessage()
+    ]
+    assert len(deferred_logs) == 84, (
+        f"expected 84 bg_submit_deferred telemetry lines, got {len(deferred_logs)}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Byte-fidelity — parked envelopes round-trip through the WAL exactly.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_wal_parking_preserves_envelope_byte_fidelity(
+    tmp_path, monkeypatch
+):
+    pool = _GatedPool(capacity=16)
+    router, _ = _make_router(tmp_path, pool, monkeypatch)
+
+    originals = _envelopes(40)
+    leased = [_lease_and_wal(router, e) for e in originals]
+    for env in leased:
+        await router._dispatch_one(env)
+
+    pending = router._wal.pending_entries()
+    assert len(pending) == 24  # 40 - 16
+
+    by_cid = {e.envelope_dict["causal_id"]: e for e in pending}
+    for env in leased:
+        entry = by_cid.get(env.causal_id)
+        if entry is None:
+            continue  # this one was accepted, not parked
+        # Round-trip: from_dict(to_dict) == to_dict, and matches the leased env.
+        rehydrated = IntentEnvelope.from_dict(entry.envelope_dict)
+        assert rehydrated.to_dict() == entry.envelope_dict
+        assert rehydrated.to_dict() == env.to_dict()
+
+
+# ---------------------------------------------------------------------------
+# Drain proof — release the worker, ALL 100 reach accepted, bounded, no loss.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_released_worker_drains_all_parked(tmp_path, monkeypatch):
+    pool = _GatedPool(capacity=16)
+    router, gls = _make_router(tmp_path, pool, monkeypatch)
+
+    envs = [_lease_and_wal(router, e) for e in _envelopes(100)]
+    for env in envs:
+        await router._dispatch_one(env)
+
+    assert len(router._wal.pending_entries()) == 84
+
+    # Release the worker: drain everything via the EXISTING replay machinery.
+    # Bounded loop — each round consumes the pool then re-drains parked WAL rows.
+    rounds = 0
+    while router._wal.pending_entries():
+        rounds += 1
+        assert rounds < 50, "drain did not converge (unbounded)"
+        # Worker consumes all currently-occupied slots.
+        while pool.queue_depth() > 0:
+            pool.release_one()
+        # Capacity-gated replay of the parked WAL rows onto the queue.
+        await router._drain_capacity_deferred()
+        # Dispatch whatever the replay re-enqueued.
+        while not router._queue.empty():
+            item = router._queue.get_nowait()
+            await router._dispatch_one(item[-1])
+
+    # ALL 100 accepted exactly once, zero lost, zero sync-inline.
+    assert len(pool.accepted_ctx_ids) == 100
+    assert len(set(pool.accepted_ctx_ids)) == 100, "double-dispatch detected"
+    assert gls.sync_fallback_calls == 0
+    assert router._wal.pending_entries() == []
+
+
+# ---------------------------------------------------------------------------
+# Idempotency — replay after full drain dispatches nothing (no double-dispatch).
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replay_is_idempotent_after_drain(tmp_path, monkeypatch):
+    pool = _GatedPool(capacity=16)
+    router, _ = _make_router(tmp_path, pool, monkeypatch)
+
+    envs = [_lease_and_wal(router, e) for e in _envelopes(20)]
+    for env in envs:
+        await router._dispatch_one(env)
+
+    # Drain fully (pool big enough after release).
+    while router._wal.pending_entries():
+        while pool.queue_depth() > 0:
+            pool.release_one()
+        await router._drain_capacity_deferred()
+        while not router._queue.empty():
+            item = router._queue.get_nowait()
+            await router._dispatch_one(item[-1])
+
+    accepted_after_drain = len(pool.accepted_ctx_ids)
+    assert accepted_after_drain == 20
+
+    # Re-run replay: no pending rows remain → nothing re-enqueued, no re-dispatch.
+    await router._replay_wal()
+    dispatched_extra = 0
+    while not router._queue.empty():
+        item = router._queue.get_nowait()
+        await router._dispatch_one(item[-1])
+        dispatched_extra += 1
+    assert dispatched_extra == 0
+    assert len(pool.accepted_ctx_ids) == accepted_after_drain  # no growth
+
+
+# ---------------------------------------------------------------------------
+# Distinguish — a genuinely broken (non-capacity) pool STILL uses sync fallback.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_non_capacity_exception_still_takes_sync_fallback(
+    tmp_path, monkeypatch, caplog
+):
+    class _BrokenPool(_GatedPool):
+        async def submit(self, ctx):
+            raise RuntimeError("pool worker crashed — not a capacity condition")
+
+    pool = _BrokenPool(capacity=16)
+    router, gls = _make_router(tmp_path, pool, monkeypatch)
+
+    env = _lease_and_wal(router, _envelopes(1)[0])
+    caplog.set_level(logging.INFO)
+    await router._dispatch_one(env)
+
+    # Non-capacity exception → legacy sync fallback preserved (broken pool).
+    assert gls.sync_fallback_calls == 1
+    # Non-capacity failures are NOT capacity deferrals.
+    deferred_logs = [
+        r for r in caplog.records if "bg_submit_deferred" in r.getMessage()
+    ]
+    assert deferred_logs == []
+    # The op ran (sync) → acked, not parked.
+    assert router._wal.pending_entries() == []


### PR DESCRIPTION
## Unblocks the mutation pipeline (run-4 finding)

Live evidence (bt-iso-1783144982): 45x 'Background queue is full (16)' -> the legacy handler ran ops SYNC-INLINE on the dispatch path, serializing the router; low-priority write-intent signals never dequeued in 60+ min (effective loss). Root cause of zero mutations on a perfect substrate.

- GLS re-raises the pool's QueueFullError (capacity class ONLY — genuine pool faults keep the legacy sync fallback); the router parks the envelope as its still-pending intake-WAL row (no new queue/retry/file) and drains via the existing _replay_wal from the idle branch when the pool reports real capacity.
- Deterministic gate proof: 100-envelope burst at 16-slot/gated-worker -> EXACTLY 84 durably parked / 16 accepted / 0 lost / 0 sync-inline; release -> all 100 dispatched, no double-dispatch; byte-fidelity + replay idempotency pinned.
- Drain WAL read offloaded via cooperative_fs_io (spy test raises if it ever touches the loop thread); single-flight + post-offload re-check closes the thread-hop double-enqueue race; F1 priority-queue mirror added behind its default-off flag.
- JARVIS_BG_QUEUE_SIZE / JARVIS_BG_POOL_SIZE untouched (the Mac mitigations stand; capacity itself is Stage-1 GCP's job).

Review: APPROVED (semantic split, ack lifecycle, capacity probe, happy-path byte-identical all verified).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops sync-inline execution on background queue capacity errors by parking envelopes in the intake WAL and draining them when capacity frees, preventing dispatcher serialization and lost low-priority signals.

- **Bug Fixes**
  - `GovernedLoopService.submit_background` distinguishes `QueueFullError` from real pool errors; re-raises capacity rejections so the router parks them.
  - `UnifiedIntakeRouter` catches `QueueFullError`, leaves the WAL row pending (no retry increment, no dead-letter), and emits `bg_submit_deferred` telemetry.
  - Parked rows drain via the existing `_replay_wal` from idle branches, gated by `has_background_capacity`; dispatcher stays fully async.
  - Added `BackgroundAgentPool.has_capacity()` and `GovernedLoopService.has_background_capacity()` probes (fail-open).

- **Refactors**
  - Offloaded the drain’s WAL read through `cooperative_fs_io.offload`; added a single-flight guard and a post-offload idle re-check to avoid double-enqueue.
  - `_replay_wal` accepts pre-fetched entries; mirrors into the priority queue in F1 primary mode (default-off remains byte-identical).
  - Added comprehensive tests for the gate behavior, byte-fidelity, bounded drain, idempotent replay, non-capacity fallback, offload routing, single-flight, and F1 mirror.

<sup>Written for commit 8b662486805bec680661e08a6bdb8ae4c7ae8205. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69834?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

