### PR TITLE
feat(stage1): Brain-VM provisioning -- CPU golden image + node spec + discovery/mTLS + ignition driver ($0-orphan teardown)

### DIFF
--- a/backend/core/ouroboros/governance/brain_discovery.py
+++ b/backend/core/ouroboros/governance/brain_discovery.py
@@ -1,0 +1,399 @@
+"""Stage-1 Brain-VM dynamic discovery + mTLS WS reachability.
+
+Root-cause discovery with ZERO hardcoded topology:
+
+  1. LIST -- ``gcp_compute_rest.list_instances_by_label`` filters GCE instances
+     on the ``jarvis-role=brain`` label (added in Task 2). Each RUNNING match
+     yields candidate endpoints (external natIP + internal IP) at the WS
+     port/path resolved from the Stage-0 ``TransportConfig``.
+  2. RACE -- the candidate WS URLs are handed to the Asynchronous Reachability
+     Racer (``FailoverLifecycleController._race_node_ready``, reused verbatim):
+     probe ALL candidates concurrently, bind whichever answers a healthy mTLS
+     handshake FIRST (``asyncio.wait(FIRST_COMPLETED)``). No IS_LOCAL flag, no
+     hardcoded host swap -- external natIP wins off-VPC, internal wins on-VPC.
+  3. RETURN -- the single winning WS URL. NOTHING is cached beyond that one
+     returned value.
+
+**Statelessness contract (load-bearing).** ``discover_brain_endpoint`` is
+idempotent and holds NO cross-call state: the CALLER re-invokes discovery on
+EVERY reconnect, so a Brain that moved zones / IPs between connections is
+re-resolved from scratch. Never memoize an IP here.
+
+mTLS material is resolved -- not reimplemented. The client material comes from
+local env (``JARVIS_BRAIN_WS_TLS_*`` -> ``TransportConfig.from_env``); the
+server material is written to the Brain's ``/etc/jarvis/brain.env`` from
+instance metadata (Task 1). Both are fed to the Stage-0
+``build_client_ssl_context`` / ``build_server_ssl_context`` UNCHANGED -- this
+module only resolves the material PATHS/values, it does not touch TLS itself.
+
+Firewall lifecycle helpers (``open_brain_firewall`` / ``close_brain_firewall``)
+are thin wrappers over ``gcp_compute_rest.create_firewall_rule`` /
+``delete_firewall_rule`` with the Mac's ``resolve_local_public_ip()`` as the
+/32 source. They live here as reusable helpers; Task 4's ignition driver OWNS
+the create/teardown SEQUENCING (open before connect, delete on every exit path)
+and calls these.
+
+Fail-soft throughout: discovery returns ``None`` (never raises) when no healthy
+Brain is reachable; the firewall wrappers return ``(ok, detail)`` and REFUSE an
+empty source IP (no open-to-the-whole-internet CIDR fallback, ever).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Env knobs (resolved at CALL time -- zero baked assumptions).
+# ---------------------------------------------------------------------------
+
+_ENV_FW_RULE_NAME = "JARVIS_BRAIN_FIREWALL_RULE_NAME"
+_DEFAULT_FW_RULE_NAME = "jarvis-brain-mtls"
+
+_ENV_PROBE_TIMEOUT_S = "JARVIS_BRAIN_WS_PROBE_TIMEOUT_S"
+_DEFAULT_PROBE_TIMEOUT_S = 5.0
+
+# Firewall / candidate port fallback used ONLY when TransportConfig.port is
+# unset (0). Not an endpoint literal -- just an integer default.
+_DEFAULT_WS_PORT = 8443
+
+
+def _brain_fw_rule_name() -> str:
+    val = (os.environ.get(_ENV_FW_RULE_NAME, "") or "").strip()
+    return val or _DEFAULT_FW_RULE_NAME
+
+
+def _probe_timeout_s() -> float:
+    try:
+        v = float((os.environ.get(_ENV_PROBE_TIMEOUT_S, "") or "").strip())
+        return v if v > 0 else _DEFAULT_PROBE_TIMEOUT_S
+    except (ValueError, AttributeError):
+        return _DEFAULT_PROBE_TIMEOUT_S
+
+
+# ---------------------------------------------------------------------------
+# Transport config + mTLS material (resolve, do not reimplement).
+# ---------------------------------------------------------------------------
+
+
+def _brain_transport_config() -> Any:
+    """Env-resolved Stage-0 ``TransportConfig`` for the Brain WS surface.
+
+    Re-read on every call (no caching) so a reconnect picks up any rotated
+    endpoint/cert env. NEVER raises -> a minimal fail-soft stand-in on import
+    failure (discovery then yields no candidates)."""
+    try:
+        from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: PLC0415
+            TransportConfig,
+        )
+
+        return TransportConfig.from_env(role="brain-client")
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] transport config resolve fail-soft err=%r", exc)
+        return None
+
+
+def build_brain_client_ssl_context(cfg: Optional[Any] = None) -> Optional[Any]:
+    """Stage-0 mTLS CLIENT context from LOCAL env material (unchanged builder).
+
+    The Mac side of the cross-host handshake. Returns ``None`` when TLS is
+    disabled or the builder fails (fail-soft)."""
+    try:
+        from backend.core.ouroboros.governance.transport.transport_security import (  # noqa: PLC0415
+            build_client_ssl_context,
+        )
+
+        resolved = cfg or _brain_transport_config()
+        if resolved is None:
+            return None
+        return build_client_ssl_context(resolved)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] client ssl context fail-soft err=%r", exc)
+        return None
+
+
+def build_brain_server_ssl_context(cfg: Optional[Any] = None) -> Optional[Any]:
+    """Stage-0 mTLS SERVER context from env material (unchanged builder).
+
+    On the Brain VM the env is populated from ``/etc/jarvis/brain.env`` (written
+    from instance metadata at boot, Task 1). Provided here for symmetry; the
+    discovery CALLER on the Mac uses the client context. Fail-soft -> None."""
+    try:
+        from backend.core.ouroboros.governance.transport.transport_security import (  # noqa: PLC0415
+            build_server_ssl_context,
+        )
+
+        resolved = cfg or _brain_transport_config()
+        if resolved is None:
+            return None
+        return build_server_ssl_context(resolved)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] server ssl context fail-soft err=%r", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Candidate endpoint construction.
+# ---------------------------------------------------------------------------
+
+
+def _brain_ws_port(cfg: Optional[Any] = None) -> int:
+    """The WS port -- from ``TransportConfig.port``, falling back to the module
+    default only when unset (0). Never an endpoint literal."""
+    resolved = cfg or _brain_transport_config()
+    port = int(getattr(resolved, "port", 0) or 0)
+    return port if port > 0 else _DEFAULT_WS_PORT
+
+
+def _ws_scheme(cfg: Any) -> str:
+    """``wss`` when mTLS is on (the Stage-1 default), else ``ws``. Built from
+    parts so no ``wss?://`` literal ever appears in this module."""
+    return "wss" if bool(getattr(cfg, "tls_enabled", True)) else "ws"
+
+
+def _candidate_urls(instances: List[Dict[str, Any]], cfg: Any) -> List[str]:
+    """Build the Reachability-Racer candidate WS URLs from RUNNING brain
+    instances: external natIP FIRST (off-VPC most common), then internal IP.
+
+    IP extraction reuses ``GCPComputeRest._extract_external_ip`` /
+    ``_extract_internal_ip`` (single source of truth for the natIP/networkIP
+    shape). NEVER raises -> a malformed instance contributes no candidates."""
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        GCPComputeRest,
+    )
+
+    scheme = _ws_scheme(cfg)
+    port = _brain_ws_port(cfg)
+    path = str(getattr(cfg, "path", "") or "")
+    out: List[str] = []
+    for inst in instances or []:
+        try:
+            if str(inst.get("status") or "").upper() != "RUNNING":
+                continue
+            external = GCPComputeRest._extract_external_ip(inst)
+            internal = GCPComputeRest._extract_internal_ip(inst)
+            for ip in (external, internal):
+                if ip:
+                    out.append("{}://{}:{}{}".format(scheme, ip, port, path))
+        except Exception:  # noqa: BLE001
+            continue
+    return out
+
+
+def _split_host_port(url: str) -> Optional[tuple]:
+    """Parse ``<scheme>://<host>:<port><path>`` -> ``(host, port)``. Returns
+    ``None`` on any malformed input. NEVER raises."""
+    try:
+        after = url.split("://", 1)[1] if "://" in url else url
+        authority = after.split("/", 1)[0]
+        if ":" not in authority:
+            return None
+        host, port_s = authority.rsplit(":", 1)
+        return (host, int(port_s)) if host and port_s else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# WS health probe + racer (reuse the Reachability Racer verbatim).
+# ---------------------------------------------------------------------------
+
+
+async def _default_ws_health_probe(url: str) -> bool:
+    """Probe the WS HEALTH surface: complete a TLS (mTLS) handshake to the
+    candidate host:port. A successful handshake proves the Brain's WS server is
+    up AND that our client cert is accepted (mTLS-required); a certless / wrong
+    peer is rejected by the server before the WS upgrade. Fail-soft -> False."""
+    parsed = _split_host_port(url)
+    if not parsed:
+        return False
+    host, port = parsed
+    try:
+        ctx = build_brain_client_ssl_context()
+        conn = asyncio.open_connection(host=host, port=port, ssl=ctx)
+        reader, writer = await asyncio.wait_for(conn, timeout=_probe_timeout_s())
+        try:
+            writer.close()
+        except Exception:  # noqa: BLE001
+            pass
+        return True
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] ws health probe fail-soft url=%s err=%r", url, exc)
+        return False
+
+
+async def _default_race(
+    candidates: List[str], probe_fn: Callable[[str], Awaitable[bool]],
+) -> Optional[str]:
+    """Bind the first healthy candidate via the shared Asynchronous Reachability
+    Racer. We REUSE ``FailoverLifecycleController._race_node_ready`` rather than
+    replicate its FIRST_COMPLETED loop: the controller constructor is pure state
+    init (no threads / no network / all fail-soft defaults), so we build one with
+    our ``probe_fn`` injected as ``node_ready_fn`` and call the racer directly.
+    Fail-soft -> None."""
+    try:
+        from backend.core.ouroboros.governance.failover_lifecycle import (  # noqa: PLC0415
+            FailoverLifecycleController,
+        )
+
+        controller = FailoverLifecycleController(node_ready_fn=probe_fn)
+        return await controller._race_node_ready(list(candidates))
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] race fail-soft err=%r", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Public API.
+# ---------------------------------------------------------------------------
+
+
+async def _default_list_brain_instances() -> List[Dict[str, Any]]:
+    """Default LIST seam: aggregatedList GCE instances labelled
+    ``jarvis-role=brain`` via the existing REST bridge. Fail-soft -> []."""
+    try:
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            _BRAIN_ROLE_LABEL_KEY,
+            _BRAIN_ROLE_LABEL_VALUE,
+            get_compute_rest,
+        )
+
+        return await get_compute_rest().list_instances_by_label(
+            label_key=_BRAIN_ROLE_LABEL_KEY, label_value=_BRAIN_ROLE_LABEL_VALUE,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] default list fail-soft err=%r", exc)
+        return []
+
+
+async def discover_brain_endpoint(
+    *,
+    project: str = "",
+    list_instances_fn: Optional[Callable[[], Awaitable[List[Dict[str, Any]]]]] = None,
+    probe_fn: Optional[Callable[[str], Awaitable[bool]]] = None,
+    race_fn: Optional[
+        Callable[[List[str], Callable[[str], Awaitable[bool]]], Awaitable[Optional[str]]]
+    ] = None,
+    transport_config: Optional[Any] = None,
+) -> Optional[str]:
+    """Resolve a healthy Brain WS URL dynamically, or ``None``.
+
+    Stateless / idempotent -- LISTS the brain-labelled instances fresh and RACES
+    their candidate endpoints on every call. The caller re-invokes this on every
+    reconnect; NOTHING is cached beyond the single returned URL.
+
+    ``project`` is advisory: when empty the REST bridge resolves the project from
+    env (``GCP_PROJECT_ID`` / ``GOOGLE_CLOUD_PROJECT``) or instance metadata --
+    passing it does not mutate process state.
+
+    Seams (``list_instances_fn`` / ``probe_fn`` / ``race_fn`` /
+    ``transport_config``) are injectable for tests; the defaults are the live
+    REST list + the mTLS handshake probe + the shared Reachability Racer.
+
+    Fail-soft: NEVER raises into the caller -> ``None`` on any error."""
+    try:
+        cfg = transport_config or _brain_transport_config()
+        if cfg is None:
+            return None
+        list_fn = list_instances_fn or _default_list_brain_instances
+        instances = await list_fn()
+        candidates = _candidate_urls(instances or [], cfg)
+        if not candidates:
+            logger.info(
+                "[BrainDiscovery] no RUNNING brain candidate endpoints "
+                "(project=%s) -- returning None (fail-soft)",
+                project or "<env>",
+            )
+            return None
+        probe = probe_fn or _default_ws_health_probe
+        race = race_fn or _default_race
+        winner = await race(candidates, probe)
+        if winner:
+            logger.info(
+                "[BrainDiscovery] discovered brain WS endpoint from %d candidate(s)",
+                len(candidates),
+            )
+        return winner or None
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] discover fail-soft err=%r", exc)
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Ephemeral /32 firewall micro-perimeter (thin wrappers; Task 4 owns sequencing).
+# ---------------------------------------------------------------------------
+
+
+async def open_brain_firewall(
+    source_ip: Optional[str] = None,
+    *,
+    port: int = 0,
+    rule_name: Optional[str] = None,
+    resolve_ip_fn: Optional[Callable[[], Awaitable[Optional[str]]]] = None,
+    create_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+) -> Any:
+    """Open a /32-scoped INGRESS rule from the Mac's PUBLIC IP to the Brain's WS
+    port. The source IP is resolved via ``resolve_local_public_ip`` (no hardcoded
+    IP); an unresolved IP REFUSES to open the rule (no whole-internet CIDR).
+    Rule name + port env-resolved. Returns ``(ok, detail)``. NEVER raises."""
+    try:
+        ip = source_ip
+        if not ip:
+            resolver = resolve_ip_fn or _default_resolve_public_ip
+            ip = await resolver()
+        if not ip:
+            return (False, "no_source_ip:refuse_open_internet")
+        name = rule_name or _brain_fw_rule_name()
+        p = int(port or 0) or _brain_ws_port()
+        create = create_fn or _default_create_firewall_rule
+        return await create(name=name, source_ip=ip, port=p)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] open firewall fail-soft err=%r", exc)
+        return (False, "open_firewall_error:{!r}".format(exc))
+
+
+async def close_brain_firewall(
+    *,
+    rule_name: Optional[str] = None,
+    delete_fn: Optional[Callable[[str], Awaitable[Any]]] = None,
+) -> Any:
+    """Delete the ephemeral Brain firewall rule (env-resolved name). 404 (already
+    gone) is the desired end-state. Returns ``(ok, detail)``. NEVER raises."""
+    try:
+        name = rule_name or _brain_fw_rule_name()
+        delete = delete_fn or _default_delete_firewall_rule
+        return await delete(name)
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("[BrainDiscovery] close firewall fail-soft err=%r", exc)
+        return (False, "close_firewall_error:{!r}".format(exc))
+
+
+async def _default_resolve_public_ip() -> Optional[str]:
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        resolve_local_public_ip,
+    )
+
+    return await resolve_local_public_ip()
+
+
+async def _default_create_firewall_rule(*, name: str, source_ip: str, port: int) -> Any:
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        get_compute_rest,
+    )
+
+    return await get_compute_rest().create_firewall_rule(
+        name=name, source_ip=source_ip, port=port,
+    )
+
+
+async def _default_delete_firewall_rule(name: str) -> Any:
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        get_compute_rest,
+    )
+
+    return await get_compute_rest().delete_firewall_rule(name)

--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -67,6 +67,7 @@ import os
 import re
 import time
 import urllib.error
+import urllib.parse
 import urllib.request
 from typing import Any, Dict, List, Optional, Tuple
 
@@ -1479,6 +1480,64 @@ class GCPComputeRest:
         except Exception as exc:  # noqa: BLE001
             logger.debug("[GCPComputeRest] get_node_endpoints fail-soft err=%r", exc)
             return (None, None)
+
+    async def list_instances_by_label(
+        self, *, label_key: str, label_value: str,
+    ) -> List[Dict[str, Any]]:
+        """aggregatedList instances filtered to
+        ``labels.<label_key>=<label_value>`` across ALL zones -- the Stage-1
+        Brain discovery seam (Task 3). Returns the raw instance dicts (each with
+        ``name`` / ``status`` / ``zone`` / ``networkInterfaces`` / ``labels``)
+        for every match, or ``[]`` on any failure.
+
+        The server-side ``filter=`` is re-checked client-side (defense in depth
+        -- a caller must NEVER act on a mis-labelled node). Paginates via
+        ``nextPageToken``. Reuses the SAME token-mint + ``_COMPUTE_BASE`` REST
+        bridge + ``_http_request`` contract as every other method here.
+        NEVER raises."""
+        try:
+            token = await self.access_token()
+            project = await self.project()
+            if not token or not project:
+                return []
+            filt = urllib.parse.quote(
+                "labels.{}={}".format(label_key, label_value)
+            )
+            base = "{}/projects/{}/aggregated/instances?filter={}".format(
+                _COMPUTE_BASE, project, filt,
+            )
+            headers = {"Authorization": "Bearer {}".format(token)}
+            out: List[Dict[str, Any]] = []
+            page_token = ""
+            while True:
+                url = base
+                if page_token:
+                    url = "{}&pageToken={}".format(
+                        base, urllib.parse.quote(page_token)
+                    )
+                status, text = await _http_request(
+                    url, method="GET", headers=headers, timeout_s=_rest_timeout(),
+                )
+                if not (200 <= status < 300 and text):
+                    break
+                try:
+                    doc = json.loads(text)
+                except Exception:  # noqa: BLE001 -- malformed body -> stop
+                    break
+                for scope in (doc.get("items") or {}).values():
+                    for inst in (scope or {}).get("instances") or []:
+                        labels = inst.get("labels") or {}
+                        if labels.get(label_key) == label_value:
+                            out.append(inst)
+                page_token = doc.get("nextPageToken") or ""
+                if not page_token:
+                    break
+            return out
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "[GCPComputeRest] list_instances_by_label fail-soft err=%r", exc,
+            )
+            return []
 
     # -- delete (delete-to-snapshot keeps the golden image untouched) ----
 

--- a/backend/core/ouroboros/governance/gcp_compute_rest.py
+++ b/backend/core/ouroboros/governance/gcp_compute_rest.py
@@ -347,6 +347,84 @@ def _machine_type() -> str:
     return _env_str(_ENV_MACHINE_TYPE, _DEFAULT_MACHINE_TYPE)
 
 
+# ---------------------------------------------------------------------------
+# Stage-1 CPU Brain-VM knobs (relocation design item 1). The Brain node is a
+# SPEC VARIANT of the J-Prime insert -- CPU-only, env-resolved, labelled for
+# dynamic discovery. These do NOT touch the L4/J-Prime env names above; every
+# value is read at CALL time (Mandate 2 -- Architectural Purity).
+# ---------------------------------------------------------------------------
+
+_ENV_BRAIN_MACHINE_TYPE = "JARVIS_BRAIN_VM_MACHINE_TYPE"
+_ENV_BRAIN_IMAGE_FAMILY = "JARVIS_BRAIN_VM_IMAGE_FAMILY"
+_ENV_BRAIN_PERSISTENT = "JARVIS_BRAIN_VM_PERSISTENT"
+_ENV_BRAIN_IDLE_SHUTDOWN_S = "JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S"
+_ENV_BRAIN_SPOT = "JARVIS_BRAIN_VM_SPOT"
+
+_DEFAULT_BRAIN_MACHINE_TYPE = "e2-highmem-4"
+# The Task-1 golden-image family (scripts/bake_brain_golden_image.py bakes
+# jarvis-brain-golden-<stamp> into this family).
+_DEFAULT_BRAIN_IMAGE_FAMILY = "jarvis-brain-golden"
+_DEFAULT_BRAIN_IDLE_SHUTDOWN_S = 1800
+
+# The Stage-1 discovery label (Task 3 filters instances.list on this) and the
+# instance-metadata key the Task-1 bake reads into /etc/jarvis/brain.env
+# (matches bake_brain_golden_image.py::_BRAIN_ENV_METADATA_KEY).
+_BRAIN_ROLE_LABEL_KEY = "jarvis-role"
+_BRAIN_ROLE_LABEL_VALUE = "brain"
+_BRAIN_ENV_METADATA_KEY = "brain-env"
+
+
+def _brain_machine_type() -> str:
+    return _env_str(_ENV_BRAIN_MACHINE_TYPE, _DEFAULT_BRAIN_MACHINE_TYPE)
+
+
+def _brain_image_family() -> str:
+    return _env_str(_ENV_BRAIN_IMAGE_FAMILY, _DEFAULT_BRAIN_IMAGE_FAMILY)
+
+
+def _brain_persistent() -> bool:
+    """ON-DEMAND-PER-SESSION default (False): the Brain VM is torn down at
+    session end. Opt-in ``JARVIS_BRAIN_VM_PERSISTENT=true`` keeps it as a warm
+    standby (Task 4 owns the teardown branch). Read at call time. NEVER raises."""
+    return (os.environ.get(_ENV_BRAIN_PERSISTENT, "false") or "").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _brain_idle_shutdown_s() -> int:
+    """Idle self-shutdown threshold (seconds) delivered to the VM via the
+    ``brain-env`` metadata body; the VM-side systemd idle check (Task 1) reads it
+    from /etc/jarvis/brain.env. Env-tunable, default 1800. NEVER raises."""
+    return int(_env_float(
+        _ENV_BRAIN_IDLE_SHUTDOWN_S, float(_DEFAULT_BRAIN_IDLE_SHUTDOWN_S),
+        lo=0.0, hi=86400.0,
+    ))
+
+
+def _brain_spot() -> bool:
+    """Spot-first for the Brain VM by default (Spot is cheap; the on-demand
+    fallback is Task 4's concern via the existing ``_ondemand_on_stockout``
+    lever). ``JARVIS_BRAIN_VM_SPOT=false`` forces on-demand. Read at call time."""
+    return (os.environ.get(_ENV_BRAIN_SPOT, "true") or "").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def _compose_brain_env(values: Optional[Dict[str, str]] = None) -> str:
+    """Compose the ``brain-env`` metadata body (a shell env-file) the Task-1 bake
+    curls into /etc/jarvis/brain.env at boot. Carries the idle-shutdown seconds
+    (env-resolved) plus any Task-4 ignition values (tokens / WS endpoint) folded
+    in via ``values``. Deterministic ordering (idle-shutdown first) so the spec
+    is stable. NEVER raises."""
+    lines = [
+        "# JARVIS Stage-1 Brain VM env -- written to /etc/jarvis/brain.env at boot.",
+        "{}={}".format(_ENV_BRAIN_IDLE_SHUTDOWN_S, _brain_idle_shutdown_s()),
+    ]
+    for k, v in (values or {}).items():
+        lines.append("{}={}".format(k, v))
+    return "\n".join(lines) + "\n"
+
+
 def _ondemand_on_stockout_enabled() -> bool:
     """When true, a SPOT stockout in a zone falls through to an on-demand insert
     in the SAME zone before giving up on it (L4 Spot is scarce; on-demand has
@@ -667,11 +745,20 @@ class GCPComputeRest:
         spot: bool,
         accelerator_type: str = "",
         accelerator_count: int = 0,
+        labels: Optional[Dict[str, str]] = None,
+        extra_metadata: Optional[Dict[str, str]] = None,
     ) -> Dict[str, Any]:
         """Construct the EXACT instances.insert JSON payload. Dynamic zone +
         project from metadata; sourceImage = the golden-image family; Spot
         scheduling (provisioningModel=SPOT + instanceTerminationAction=DELETE)
-        when spot=True, on-demand otherwise; the project default network."""
+        when spot=True, on-demand otherwise; the project default network.
+
+        ``labels`` (Stage-1 Brain-VM) emits a top-level ``labels`` object ONLY
+        when provided; ``extra_metadata`` appends ``{key,value}`` items alongside
+        the startup-script item (the Brain reads /etc/jarvis/brain.env from its
+        ``brain-env`` metadata item). Both default None -> the payload is
+        BYTE-IDENTICAL to the pre-Brain output, so every existing L4/J-Prime
+        caller is unchanged."""
         # Faster boot disk = faster model-bytes -> RAM/VRAM load (the cold-start
         # tail). Dynamic zonal diskType URL (never hardcoded); empty -> omit so
         # GCE applies its default (pd-standard), the legacy behaviour.
@@ -715,6 +802,14 @@ class GCPComputeRest:
                 ]
             },
         }
+        # Stage-1 Brain-VM additive fields -- emitted ONLY when provided so the
+        # legacy (None-path) payload stays byte-identical.
+        if labels:
+            payload["labels"] = dict(labels)
+        if extra_metadata:
+            items = payload["metadata"]["items"]
+            for k, v in extra_metadata.items():
+                items.append({"key": str(k), "value": str(v)})
         if spot:
             payload["scheduling"] = {
                 "provisioningModel": "SPOT",
@@ -740,6 +835,45 @@ class GCPComputeRest:
             sched.setdefault("automaticRestart", False)
         return payload
 
+    def build_brain_insert_payload(
+        self,
+        *,
+        name: str,
+        zone: str,
+        project: str,
+        startup_script: str = "",
+        brain_env_values: Optional[Dict[str, str]] = None,
+    ) -> Dict[str, Any]:
+        """Construct the Stage-1 CPU Brain-VM instances.insert payload -- a SPEC
+        VARIANT of the J-Prime insert, NOT a parallel provisioning path. Reuses
+        ``_build_insert_payload`` verbatim with:
+
+          * env-resolved machine type (``JARVIS_BRAIN_VM_MACHINE_TYPE``) +
+            golden-image family (``JARVIS_BRAIN_VM_IMAGE_FAMILY``),
+          * CPU-only: ``accelerator_type="" / accelerator_count=0`` so the payload
+            carries NO ``guestAccelerators`` (Mandate 4 -- no accidental GPU spend),
+          * Spot per ``JARVIS_BRAIN_VM_SPOT`` (default true),
+          * ``labels={jarvis-role: brain}`` for the Task-3 discovery filter,
+          * a ``brain-env`` metadata item carrying the idle-shutdown seconds +
+            any Task-4 ignition values (tokens / WS endpoint) folded via
+            ``brain_env_values`` (the Task-1 startup script reads it into
+            /etc/jarvis/brain.env).
+
+        Every value resolved at call time (Mandate 2). NEVER raises."""
+        return self._build_insert_payload(
+            name=name,
+            zone=zone,
+            project=project,
+            machine_type=_brain_machine_type(),
+            image_family=_brain_image_family(),
+            startup_script=startup_script,
+            spot=_brain_spot(),
+            accelerator_type="",
+            accelerator_count=0,
+            labels={_BRAIN_ROLE_LABEL_KEY: _BRAIN_ROLE_LABEL_VALUE},
+            extra_metadata={_BRAIN_ENV_METADATA_KEY: _compose_brain_env(brain_env_values)},
+        )
+
     async def create_instance(
         self,
         *,
@@ -749,6 +883,8 @@ class GCPComputeRest:
         image_family: Optional[str] = None,
         accelerator_type: str = "",
         accelerator_count: int = 0,
+        labels: Optional[Dict[str, str]] = None,
+        extra_metadata: Optional[Dict[str, str]] = None,
     ) -> Tuple[bool, str]:
         """Async REST bootstrapper: launch the golden image via instances.insert.
 
@@ -810,6 +946,7 @@ class GCPComputeRest:
                 wave, project=project, token=token, headers=headers, node=node,
                 machine=machine, family=family, startup_script=startup_script,
                 accelerator_type=accelerator_type, accelerator_count=accelerator_count,
+                labels=labels, extra_metadata=extra_metadata,
             )
             last = detail
             if verdict == "created":
@@ -843,6 +980,7 @@ class GCPComputeRest:
     async def _insert_in_zone(
         self, *, zone, project, token, headers, node, machine, family,
         startup_script, accelerator_type, accelerator_count,
+        labels=None, extra_metadata=None,
     ) -> Tuple[str, str]:
         """Insert in ONE zone (Spot-first, on-demand fallback). Returns a verdict:
         'created' | 'stockout' (retry next zone) | 'failed' (stop). NEVER raises."""
@@ -861,6 +999,7 @@ class GCPComputeRest:
                 name=node, zone=zone, project=project, machine_type=machine,
                 image_family=family, startup_script=startup_script, spot=spot,
                 accelerator_type=accelerator_type, accelerator_count=accelerator_count,
+                labels=labels, extra_metadata=extra_metadata,
             )
             status, text = await _http_request(
                 url, method="POST", headers=headers,
@@ -1002,6 +1141,7 @@ class GCPComputeRest:
     async def _race_wave(
         self, wave, *, project, token, headers, node, machine, family,
         startup_script, accelerator_type, accelerator_count,
+        labels=None, extra_metadata=None,
     ) -> Tuple[str, str]:
         """Scatter-gather ONE wave: launch ``_insert_in_zone`` (UNCHANGED --
         Spot->on-demand escalation + KEEP-re-verify all reused as-is) CONCURRENTLY
@@ -1032,6 +1172,7 @@ class GCPComputeRest:
                 zone=z, project=project, token=token, headers=headers, node=node,
                 machine=machine, family=family, startup_script=startup_script,
                 accelerator_type=accelerator_type, accelerator_count=accelerator_count,
+                labels=labels, extra_metadata=extra_metadata,
             )): z
             for z in wave
         }

--- a/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
+++ b/backend/core/ouroboros/governance/meta/shipped_code_invariants.py
@@ -5087,6 +5087,24 @@ def _register_seed_invariants() -> None:
             validate=_validate_transport_no_hardcoded_endpoints,
         ),
     )
+    # Stage-1 Task 3: dynamic Brain discovery must resolve every endpoint
+    # from GCE aggregatedList + env -- NO baked IPv4 / ws:// / wss:// literals
+    # (same no-hardcoding pin as transport_config, sibling target).
+    register_shipped_code_invariant(
+        ShippedCodeInvariant(
+            invariant_name="brain_discovery_no_hardcoded_endpoints",
+            target_file=(
+                "backend/core/ouroboros/governance/brain_discovery.py"
+            ),
+            description=(
+                "brain_discovery must resolve every endpoint dynamically "
+                "(GCE label list + Reachability Racer + env) -- no baked "
+                "IPv4 or ws:// / wss:// literals (Stage-1 no-hardcoding "
+                "invariant)."
+            ),
+            validate=_validate_transport_no_hardcoded_endpoints,
+        ),
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/docs/superpowers/plans/2026-07-04-stage1-brain-vm-provisioning.md
+++ b/docs/superpowers/plans/2026-07-04-stage1-brain-vm-provisioning.md
@@ -1,0 +1,49 @@
+# Stage 1 — Brain-VM Provisioning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Provision the GCP CPU Brain VM as a warm standby per the approved relocation design (`docs/superpowers/specs/2026-07-03-gcp-orchestrator-relocation-design.md` §Staging item 1): a golden-image CPU node hosting the organism runtime at `/opt/trinity/jarvis`, booting the battle-test harness headless, reachable via the Stage-0 WS transport, discovered dynamically (no hardcoded IP). The Mac keeps running everything locally — Stage 1 proves the Brain CAN run there; Stage 2 moves the sensors/FSM.
+
+**Architecture:** Reuse the entire J-Prime provisioning stack with a CPU variant: `gcp_compute_rest` (node insert/reap, SA/ADC token mint, scatter-gather zones), the golden-image bake pattern (`bake_jprime_golden_image.py` → new CPU-brain variant script sharing its helpers), `failover_lifecycle._race_node_ready` for discovery, mTLS from Stage 0 (`transport_security`) + the ephemeral `/32` firewall pattern from the J-Prime mesh. Lifecycle: ON-DEMAND-PER-SESSION default (`JARVIS_BRAIN_VM_PERSISTENT=false`), idle-shutdown + hard teardown at session end; every threshold/machine-size env-resolved.
+
+**Tech Stack:** Python 3.9+ asyncio, existing `gcp_compute_rest.py` / `failover_lifecycle.py` / `transport/` subpackage / `bake_jprime_golden_image.py` helpers; gcloud golden image; `scripts/ouroboros_battle_test.py --production-soak --headless` as the Brain's runtime entry.
+
+## User Mandates (verbatim constraints)
+
+1. Root-Cause Only — this fixes the capacity/GIL/memory class structurally (BG pool scaled to VM cores on the Brain; local Mac caps untouched).
+2. Architectural Purity — on-demand lifecycle default with `JARVIS_BRAIN_VM_PERSISTENT` opt-in; ALL sizing (`JARVIS_BRAIN_VM_MACHINE_TYPE`, default `e2-highmem-4`), idle timeout, runtime caps, tokens, endpoints resolved from env at runtime. Zero baked assumptions.
+3. DRY — Stage-0 `StreamEventBroker`/`DistributedEventBus` transport + `IsomorphicEnv` config + `gcp_compute_rest` + golden-image bake + Reachability Racer. No new provisioning framework.
+4. Bulletproof — $0-orphan guarantee (the failover lifecycle's reap discipline: teardown on every exit path incl. SIGTERM; reap-confirm attempts); mTLS-required WS (certless rejected); discovery re-resolves on every reconnect.
+
+---
+
+## Task 1: CPU-brain golden-image bake variant
+
+**Files:** Create `scripts/bake_brain_golden_image.py` (imports/shares `bake_jprime_golden_image.py` helpers: `_run`, `_log`, `build_startup_script` pattern, `parse_validation_verdict` shape). Test: `tests/infra/test_brain_bake_script.py` (unit: startup-script content assertions only — no live GCP in unit tests).
+**Shape:** CPU-only image (no NVIDIA/Ollama): base Debian/Ubuntu image + python3.11 + git + repo clone at `/opt/trinity/jarvis` (the IsomorphicEnv canonical path — REAL this time) + `pip install -r requirements` + a systemd unit `jarvis-brain.service` running `python3 scripts/ouroboros_battle_test.py --production-soak --headless --cost-cap <env> --max-wall-seconds 0` with env from `/etc/jarvis/brain.env` (written from instance metadata at boot — the J-Prime metadata pattern). Startup script asserts `/opt/trinity/jarvis/.git` exists and the transport module imports before marking ready (sentinel file, the bake's validation verdict pattern).
+**Pins:** no literal project IDs/zones (env: `JARVIS_GCP_PROJECT`, `JARVIS_BRAIN_VM_ZONES`); image name `jarvis-brain-golden-<stamp>`.
+
+## Task 2: Brain node lifecycle in `gcp_compute_rest`
+
+**Files:** Modify `backend/core/ouroboros/governance/gcp_compute_rest.py` (add brain-node spec builder beside the existing L4 spec: machine type env `JARVIS_BRAIN_VM_MACHINE_TYPE` default `e2-highmem-4`, boot disk env-typed via existing `_boot_disk_type`, NO GPU/accelerator, labels `jarvis-role=brain`), reusing insert/poll/reap verbatim. Test: `tests/governance/test_brain_node_spec.py` (spec-dict assertions: machine type env-driven, no accelerators, label present, image family from env).
+**Lifecycle:** `JARVIS_BRAIN_VM_PERSISTENT` (default false) + `JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S` (default 1800) — idle shutdown implemented VM-side in the systemd unit (Task 1: self-shutdown when no WS peer for N seconds, N from metadata), harness-side hard teardown in Task 4.
+
+## Task 3: Discovery + mTLS WS reachability
+
+**Files:** Create `backend/core/ouroboros/governance/brain_discovery.py` (thin: `discover_brain_endpoint()` = `gcp_compute_rest` instance-list filtered by `jarvis-role=brain` label → candidates → `failover_lifecycle._race_node_ready`-style concurrent probe of the WS health surface → first healthy; re-resolve on every reconnect — NO caching of IPs beyond a single connection's lifetime). Ephemeral `/32` firewall: reuse the existing J-Prime mesh helper (`resolve_local_public_ip` + the firewall-rule create/delete pair in `gcp_compute_rest`/`isomorphic_a1_local.py:268` region — grep `delete_firewall_rule` for the create/delete API). mTLS material via instance metadata (server) + local env (client) using Stage-0 `transport_security` builders unchanged.
+**Test:** unit — discovery returns raced-first-healthy from fakes; re-resolve on reconnect; no IP literal anywhere (extend the Task-8-style AST/no-hardcoded-endpoint invariant to `brain_discovery.py`).
+
+## Task 4: Ignition driver — `scripts/ignite_brain_vm.py`
+
+**Files:** Create `scripts/ignite_brain_vm.py` (mirrors `isomorphic_a1_local.py`'s teardown discipline): provision (or reuse if `JARVIS_BRAIN_VM_PERSISTENT` and one exists) → await ready sentinel → open `/32` firewall for the Mac's public IP → connect a `DistributedEventBus` client (Stage 0) over mTLS → run a validation exchange (publish N events Mac→Brain, assert echo/subscription both ways, Last-Event-ID replay across a forced reconnect) → teardown: firewall rule deleted + VM stopped/deleted per lifecycle flag, on EVERY exit path (finally + SIGTERM handler; reap-confirm via existing `_reap_confirm_attempts`).
+**The load-bearing live test (Stage-1 acceptance):** the cross-host equivalent of Stage 0's loopback proof — publish on Mac, observe on Brain (and reverse), sever the WS mid-stream, reconnect via re-discovery, assert exact Last-Event-ID replay. Plus: certless client rejected (mTLS-required, cross-host). Plus: $0 check — `gcloud compute instances list` empty post-teardown.
+
+## Task 5: Live-fire validation + ledger
+
+Run `ignite_brain_vm.py` for real (operator-visible, cost-capped, on-demand lifecycle): capture the acceptance evidence (both-direction events, replay-exact, mTLS-required, teardown-$0), append to `.superpowers/sdd/progress.md`, update the relocation design doc's Stage-1 status. Post-merge follow-up ticket: Stage 2 (sensor/FSM migration) planning.
+
+## Self-Review
+- Mandate 2 (on-demand default, env-resolved): Tasks 1/2/4 knobs all env-driven, persistent opt-in. ✓
+- Mandate 3 (DRY): zero new frameworks — bake helpers, compute REST, racer, Stage-0 transport, iso env path all reused. ✓
+- Mandate 4: teardown-on-every-exit + reap-confirm + mTLS-required + re-discovery pinned in Task 4's acceptance. ✓
+- Placeholders: Tasks specify exact files/envs/defaults; implementers ground-truth exact helper signatures per the established grep-first pattern (bake helpers at `bake_jprime_golden_image.py:92-298`, spec builder near the L4 spec, firewall pair near `isomorphic_a1_local.py:268`).

--- a/scripts/bake_brain_golden_image.py
+++ b/scripts/bake_brain_golden_image.py
@@ -226,6 +226,12 @@ Wants=network-online.target
 Type=simple
 WorkingDirectory={_REPO_PATH}
 EnvironmentFile={brain_env_path}
+# RuntimeDirectory creates /run/jarvis (tmpfs, correct perms) -- the dir the idle
+# self-shutdown check reads its liveness marker from (Task-4 coupling: the brain
+# unit is the toucher). ExecStartPre seeds the marker so the idle timer never
+# nukes a freshly-booted node during the soak's boot window.
+RuntimeDirectory=jarvis
+ExecStartPre=/bin/touch /run/jarvis/brain_liveness
 ExecStart=/usr/bin/python3.11 scripts/ouroboros_battle_test.py --production-soak --headless --cost-cap ${{JARVIS_BRAIN_COST_CAP}} --max-wall-seconds 0
 Restart=on-failure
 RestartSec=10

--- a/scripts/bake_brain_golden_image.py
+++ b/scripts/bake_brain_golden_image.py
@@ -1,0 +1,626 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Sovereign Brain-VM Golden-Image Bake -- CPU-only orchestrator runtime image.
+
+Stage-1 Task 1 of the GCP Brain-VM provisioning plan
+(plan:  docs/superpowers/plans/2026-07-04-stage1-brain-vm-provisioning.md
+ spec:  docs/superpowers/specs/2026-07-03-gcp-orchestrator-relocation-design.md).
+
+This bakes the golden image the GCP **Brain VM** boots from. Per the Body/Brain
+split, the Brain VM hosts the Ouroboros orchestrator + full FSM pipeline and the
+mutation-target repo clone at ``/opt/trinity/jarvis`` -- the ``IsomorphicEnv``
+canonical path, now PROMOTED from soak-sandbox to the primary runtime.
+
+It is the CPU sibling of ``bake_jprime_golden_image.py``. The difference from the
+J-Prime code-model image:
+
+  * NO Ollama, NO NVIDIA / GPU, NO model pull or hydration. Just a base Debian
+    image + python3.11 + git.
+  * Clones the repo to ``/opt/trinity/jarvis`` (URL + ref env-resolved at bake
+    time -- ``JARVIS_BRAIN_REPO_URL`` / ``JARVIS_BRAIN_REPO_REF``).
+  * ``pip install`` of the repo requirements.
+  * Bakes a systemd unit ``jarvis-brain.service`` (headless warm-standby soak)
+    + an idle self-shutdown timer.
+  * ``/etc/jarvis/brain.env`` is written AT BOOT from instance metadata (tokens /
+    cost-cap / endpoints are per-instance, NEVER baked into the image).
+
+READINESS LOCK (the J-Prime failure contract, preserved): the readiness sentinel
+is written ONLY after a REAL proof -- ``/opt/trinity/jarvis/.git`` exists AND
+``python3 -c "import backend.core.ouroboros.governance.transport"`` succeeds.
+Never a fixed sleep. Either proof fails -> no sentinel -> the reaper rolls the
+node.
+
+DRY: the run/log/verdict/stamp machinery is SHARED with the J-Prime baker via a
+direct import (see below) -- zero reimplementation. Those helpers are
+module-private-but-stable in ``bake_jprime_golden_image``; we import them
+directly and accept the coupling on purpose (one bake substrate, two images).
+
+Usage:
+    python3 scripts/bake_brain_golden_image.py --dry-run   # default; spends $0
+    python3 scripts/bake_brain_golden_image.py --execute    # actually bakes
+"""
+from __future__ import annotations
+
+import argparse
+import os
+import shlex
+import sys
+import time
+from typing import List, Optional, Tuple
+
+# --------------------------------------------------------------------------- #
+# DRY: share the J-Prime bake helpers directly. These are module-private (`_`-
+# prefixed) but stable -- the run/log/abort/stamp/verdict machinery is identical
+# across the bake family, so we import it rather than duplicate it. The coupling
+# to ``bake_jprime_golden_image`` is intentional and load-bearing (one bake
+# substrate, two golden images). ``parse_validation_verdict`` is imported for
+# family parity + the shared-helper identity smoke; the Brain's readiness proof
+# is done IN the startup-script (git + transport import), not via a generation.
+# The sibling lives next to this file; add scripts/ to the path so a file-path
+# load (tests) resolves the import the same way a normal `python3 scripts/...`
+# invocation does.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from bake_jprime_golden_image import (  # noqa: E402  (path insert must precede)
+    _abort,
+    _log,
+    _now_stamp,
+    _run,
+    parse_validation_verdict,
+)
+
+# --------------------------------------------------------------------------- #
+# Defaults -- EVERY value env/arg-resolved. Mandate 2 (Architectural Purity):
+# no literal project IDs, zones, IPs, repo URLs, or cost caps anywhere. Where
+# J-Prime hardcodes a project/zone fallback, the Brain baker deliberately does
+# NOT -- an unset project/zone yields an empty default the operator must supply.
+# --------------------------------------------------------------------------- #
+_DEFAULT_PROJECT = os.environ.get("JARVIS_GCP_PROJECT", os.environ.get("GCP_PROJECT", ""))
+# JARVIS_BRAIN_VM_ZONES may be a comma-list; the bake uses the first entry.
+_DEFAULT_ZONE = (os.environ.get("JARVIS_BRAIN_VM_ZONES", "").split(",")[0]).strip()
+_DEFAULT_MACHINE = os.environ.get("JARVIS_BRAIN_BAKE_MACHINE", "e2-standard-4")
+_DEFAULT_REPO_URL = os.environ.get("JARVIS_BRAIN_REPO_URL", "")
+_DEFAULT_REPO_REF = os.environ.get("JARVIS_BRAIN_REPO_REF", "main")
+_DEFAULT_IMAGE_FAMILY = os.environ.get("JARVIS_BRAIN_IMAGE_FAMILY", "jarvis-brain")
+_DEFAULT_BOOT_DISK = os.environ.get("JARVIS_BRAIN_BAKE_BOOT_DISK_SIZE", "30GB")
+_DEFAULT_BOOT_DISK_TYPE = os.environ.get("JARVIS_BRAIN_BAKE_BOOT_DISK_TYPE", "pd-ssd")
+_DEFAULT_BAKE_TIMEOUT_S = int(os.environ.get("JARVIS_BRAIN_BAKE_TIMEOUT_S", "1800"))
+_DEFAULT_DEBIAN_IMAGE_FAMILY = os.environ.get(
+    "JARVIS_BRAIN_BAKE_SOURCE_IMAGE_FAMILY", "debian-12"
+)
+_DEFAULT_DEBIAN_IMAGE_PROJECT = os.environ.get(
+    "JARVIS_BRAIN_BAKE_SOURCE_IMAGE_PROJECT", "debian-cloud"
+)
+# Idle self-shutdown default (seconds) baked into the idle-check as a fallback;
+# the authoritative value comes from brain.env (instance metadata) at boot.
+_DEFAULT_IDLE_SHUTDOWN_S = int(os.environ.get("JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S", "1800"))
+
+# The IsomorphicEnv canonical path -- the REAL primary runtime for the Brain VM.
+_REPO_PATH = "/opt/trinity/jarvis"
+# Readiness sentinel written by the startup-script ONLY after the git+transport
+# proof. The poll loop keys on this (never a fixed sleep).
+_SENTINEL_PATH = "/var/run/jarvis_brain_ready"
+# Where per-instance config lands (written from metadata at boot).
+_BRAIN_ENV_PATH = "/etc/jarvis/brain.env"
+# The instance-metadata attribute carrying the brain.env body.
+_BRAIN_ENV_METADATA_KEY = "brain-env"
+
+
+def _default_image_name() -> str:
+    return os.environ.get(
+        "JARVIS_BRAIN_IMAGE_NAME", f"jarvis-brain-golden-{_now_stamp()}"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Startup-script generator (base image + python3.11 + git + repo clone + units).
+# Pure string assembly -- NO I/O, NO subprocess (exactly like J-Prime's
+# build_startup_script). ASCII only. Mandate 1 (Root-Cause Only) + Mandate 4.
+# --------------------------------------------------------------------------- #
+def build_startup_script(
+    repo_url: str,
+    *,
+    repo_ref: str = _DEFAULT_REPO_REF,
+    sentinel_path: str = _SENTINEL_PATH,
+    brain_env_path: str = _BRAIN_ENV_PATH,
+    idle_shutdown_default_s: int = _DEFAULT_IDLE_SHUTDOWN_S,
+) -> str:
+    """Return the metadata startup-script that bakes the Brain VM image.
+
+    Steps (each with an ISO phase-timestamp echo for measurable per-phase time):
+      1. Install base deps: python3.11 + pip + git (NO Ollama / NO NVIDIA).
+      2. Populate ``/etc/jarvis/brain.env`` FROM INSTANCE METADATA (the J-Prime
+         metadata pattern) -- BEFORE any unit is enabled, so per-instance
+         tokens / cost-cap / endpoints are never baked into the image.
+      3. Clone the repo to ``/opt/trinity/jarvis`` (the IsomorphicEnv path).
+      4. ``pip install -r requirements.txt``.
+      5. Write + enable the ``jarvis-brain.service`` warm-standby unit
+         (headless battle-test soak, ``--max-wall-seconds 0`` = no wall) and the
+         ``jarvis-brain-idle`` self-shutdown timer.
+      6. READINESS PROOF: sentinel written ONLY after ``.git`` exists AND the
+         transport module imports -- never a fixed sleep. Either fails -> no
+         sentinel -> the reaper rolls the node (J-Prime failure contract).
+    """
+    repo_url_q = shlex.quote(repo_url)
+    repo_ref_q = shlex.quote(repo_ref)
+    sentinel_q = shlex.quote(sentinel_path)
+    brain_env_q = shlex.quote(brain_env_path)
+    idle_default = int(idle_shutdown_default_s)
+    meta_url = (
+        "http://metadata.google.internal/computeMetadata/v1/instance/attributes/"
+        + _BRAIN_ENV_METADATA_KEY
+    )
+    return f"""#!/usr/bin/env bash
+# JARVIS Brain-VM golden-image bake startup-script (auto-generated).
+# CPU-only orchestrator runtime: base image + python3.11 + git + repo clone at
+# {_REPO_PATH}. No local model server, no hardware acceleration, no weight pull.
+# The readiness sentinel is written ONLY after a REAL proof (.git exists AND the
+# transport module imports) -- never a fixed sleep.
+set -uo pipefail
+
+# GCP metadata startup-scripts run as root with HOME unset; export it so any
+# tool that reads $HOME (git config, pip cache) behaves.
+export HOME=/root
+
+LOG=/var/log/jarvis_brain_bake.log
+exec > >(tee -a "$LOG") 2>&1
+_ts() {{ date -u +%FT%T.%3NZ; }}
+echo "[brain-bake] startup-script begin $(_ts) (HOME=$HOME)"
+
+# Never leave a stale sentinel from a re-run.
+rm -f {sentinel_q} || true
+
+# 1. Install base deps (CPU-only: no model server, no hardware acceleration).
+echo "[brain-bake] phase=deps-start ts=$(_ts)"
+export DEBIAN_FRONTEND=noninteractive
+apt-get update -y
+apt-get install -y python3.11 python3.11-venv python3-pip git curl ca-certificates
+echo "[brain-bake] phase=deps-done ts=$(_ts)"
+
+# 2. Populate {brain_env_path} FROM INSTANCE METADATA -- BEFORE any unit is
+#    enabled. Per-instance tokens / cost-cap / endpoints live here, never in the
+#    image (the J-Prime metadata pattern).
+echo "[brain-bake] phase=brain-env-start ts=$(_ts)"
+mkdir -p /etc/jarvis
+if curl -fsS -H "Metadata-Flavor: Google" {shlex.quote(meta_url)} -o {brain_env_q}; then
+    echo "[brain-bake] {brain_env_path} populated from instance metadata"
+else
+    echo "[brain-bake] WARNING: '{_BRAIN_ENV_METADATA_KEY}' metadata absent -- writing empty {brain_env_path}"
+    : > {brain_env_q}
+fi
+echo "[brain-bake] phase=brain-env-done ts=$(_ts)"
+
+# 3. Clone the repo to the IsomorphicEnv canonical path (the REAL primary
+#    runtime). URL + ref are bake-time values (env-resolved), never literals.
+echo "[brain-bake] phase=clone-start repo={repo_url_q} ref={repo_ref_q} ts=$(_ts)"
+mkdir -p /opt/trinity
+rm -rf {_REPO_PATH}
+if git clone --branch {repo_ref_q} --depth 1 {repo_url_q} {_REPO_PATH}; then
+    echo "[brain-bake] phase=clone-done ts=$(_ts)"
+else
+    echo "[brain-bake] ERROR: git clone failed -- NOT writing sentinel"
+    exit 1
+fi
+
+# 4. Install the repo requirements.
+echo "[brain-bake] phase=pip-start ts=$(_ts)"
+cd {_REPO_PATH}
+python3.11 -m ensurepip --upgrade || true
+python3.11 -m pip install --upgrade pip || true
+if python3.11 -m pip install -r requirements.txt; then
+    echo "[brain-bake] phase=pip-done ts=$(_ts)"
+else
+    echo "[brain-bake] ERROR: pip install failed -- NOT writing sentinel"
+    exit 1
+fi
+
+# 5a. The Brain warm-standby unit: headless battle-test soak with NO wall-clock
+#     cap (warm standby). cost-cap is resolved from brain.env at runtime by
+#     systemd (${{JARVIS_BRAIN_COST_CAP}}) -- never a baked literal.
+cat > /etc/systemd/system/jarvis-brain.service <<'UNIT'
+[Unit]
+Description=JARVIS Brain (Ouroboros orchestrator, headless warm standby)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=simple
+WorkingDirectory={_REPO_PATH}
+EnvironmentFile={brain_env_path}
+ExecStart=/usr/bin/python3.11 scripts/ouroboros_battle_test.py --production-soak --headless --cost-cap ${{JARVIS_BRAIN_COST_CAP}} --max-wall-seconds 0
+Restart=on-failure
+RestartSec=10
+
+[Install]
+WantedBy=multi-user.target
+UNIT
+
+# 5b. Idle self-shutdown checker + timer. If the brain process has not touched
+#     its liveness marker within JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S (no active WS
+#     peer / no work), power the VM down so an on-demand Brain node never bills
+#     while idle. Threshold is env-driven from brain.env (default {idle_default}).
+#     NOTE (Task 4 coupling): the brain process must TOUCH {shlex.quote('/run/jarvis/brain_liveness')}
+#     on WS-peer activity -- that harness-side wiring lands in Task 4.
+cat > /opt/trinity/jarvis_brain_idle_check.sh <<'IDLE'
+#!/usr/bin/env bash
+set -uo pipefail
+[ -f {brain_env_path} ] && . {brain_env_path}
+THRESHOLD="${{JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S:-{idle_default}}}"
+MARKER=/run/jarvis/brain_liveness
+# No marker yet -> brain still booting; never shut down mid-boot.
+[ -f "$MARKER" ] || exit 0
+NOW=$(date +%s)
+MTIME=$(stat -c %Y "$MARKER" 2>/dev/null || echo "$NOW")
+AGE=$(( NOW - MTIME ))
+if [ "$AGE" -ge "$THRESHOLD" ]; then
+    logger -t jarvis-brain-idle "idle ${{AGE}}s >= ${{THRESHOLD}}s -- shutting down"
+    shutdown -h now
+fi
+IDLE
+chmod +x /opt/trinity/jarvis_brain_idle_check.sh
+
+cat > /etc/systemd/system/jarvis-brain-idle.service <<'UNIT'
+[Unit]
+Description=JARVIS Brain idle self-shutdown check
+
+[Service]
+Type=oneshot
+EnvironmentFile={brain_env_path}
+ExecStart=/opt/trinity/jarvis_brain_idle_check.sh
+UNIT
+
+cat > /etc/systemd/system/jarvis-brain-idle.timer <<'UNIT'
+[Unit]
+Description=Periodic JARVIS Brain idle self-shutdown check
+
+[Timer]
+OnBootSec=300
+OnUnitActiveSec=120
+
+[Install]
+WantedBy=timers.target
+UNIT
+
+# 5c. Bake the ENABLED state into the image (auto-start on the real Brain VM
+#     boot). We deliberately do NOT `--now` here: the paid soak must never run on
+#     the ephemeral bake node.
+systemctl daemon-reload || true
+systemctl enable jarvis-brain.service || true
+systemctl enable jarvis-brain-idle.timer || true
+
+# 6. READINESS PROOF -> sentinel. Written ONLY after BOTH:
+#      (a) {_REPO_PATH}/.git exists (a real clone landed), AND
+#      (b) the transport module imports under the cloned tree.
+#    Never a fixed sleep. Either fails -> no sentinel -> reaper rolls the node.
+echo "[brain-bake] phase=readiness-proof-start ts=$(_ts)"
+if [ -d {_REPO_PATH}/.git ] && \\
+   ( cd {_REPO_PATH} && python3.11 -c "import backend.core.ouroboros.governance.transport" ); then
+    echo "ready repo={repo_ref_q} path={_REPO_PATH} ts=$(_ts)" > {sentinel_q}
+    echo "[brain-bake] phase=sentinel-written ts=$(_ts)"
+    echo "[brain-bake] startup-script done $(_ts)"
+else
+    echo "[brain-bake] ERROR: readiness proof failed (.git or transport import) -- NOT writing sentinel"
+    exit 1
+fi
+"""
+
+
+# --------------------------------------------------------------------------- #
+# gcloud command builders (pure -- dry-run prints them; _run executes).
+# --------------------------------------------------------------------------- #
+def _ssh_cmd(args: argparse.Namespace, node: str, remote: str) -> List[str]:
+    return [
+        "gcloud", "compute", "ssh", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--tunnel-through-iap", "--command", remote,
+    ]
+
+
+def _create_node_cmd(
+    args: argparse.Namespace, node: str, startup_script_path: str
+) -> List[str]:
+    # ON-DEMAND (no SPOT) for bake reliability -- the one-time bake must not be
+    # pre-empted mid-clone.
+    return [
+        "gcloud", "compute", "instances", "create", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        f"--machine-type={args.machine_type}",
+        f"--image-family={args.source_image_family}",
+        f"--image-project={args.source_image_project}",
+        f"--boot-disk-size={args.boot_disk_size}",
+        f"--boot-disk-type={args.boot_disk_type}",
+        f"--metadata-from-file=startup-script={startup_script_path}",
+    ]
+
+
+def _image_exists(args: argparse.Namespace) -> bool:
+    rc, _ = _run([
+        "gcloud", "compute", "images", "describe", args.image_name,
+        f"--project={args.project}", "--format=value(name)",
+    ])
+    return rc == 0
+
+
+def build_awaken_one_liner(args: argparse.Namespace) -> str:
+    """The `gcloud compute instances create --image-family=...` the Brain-VM
+    lifecycle (Task 2/4) runs to boot a Brain node from this golden image."""
+    return (
+        "gcloud compute instances create jarvis-brain "
+        f"--project={args.project} --zone={args.zone} "
+        f"--machine-type={args.machine_type} "
+        f"--image-family={args.image_family} "
+        f"--image-project={args.project} "
+        "--labels=jarvis-role=brain"
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Readiness poll (SSH for the sentinel; the git+transport proof already ran
+# in-startup-script). Bounded by --bake-timeout-s.
+# --------------------------------------------------------------------------- #
+def _poll_readiness(args: argparse.Namespace, node: str) -> Tuple[bool, str]:
+    deadline = time.monotonic() + float(args.bake_timeout_s)
+    delay = 15.0
+    attempt = 0
+    check = (
+        f"test -f {shlex.quote(_SENTINEL_PATH)} "
+        "&& echo BRAIN_READY || echo BRAIN_NOT_READY"
+    )
+    tail = "sudo tail -n 5 /var/log/jarvis_brain_bake.log 2>/dev/null || true"
+    while time.monotonic() < deadline:
+        attempt += 1
+        rc, out = _run(_ssh_cmd(args, node, check), timeout_s=90.0)
+        if rc == 0 and "BRAIN_READY" in out:
+            _log(f"readiness: node ready (attempt {attempt})")
+            return True, ""
+
+        # Live progress + early-fail detection off the bake log tail.
+        rc2, out2 = _run(_ssh_cmd(args, node, tail), timeout_s=30.0)
+        if rc2 == 0 and out2:
+            lines = [l for l in out2.strip().splitlines() if l.strip()]
+            if lines:
+                _log(f"node progress: {lines[-1]}")
+            for line in lines:
+                if "ERROR" in line or "NOT writing sentinel" in line:
+                    _log(f"readiness: EARLY ABORT -- {line.strip()[:200]}")
+                    return False, f"early_failure: {line.strip()[:200]}"
+
+        remaining = int(deadline - time.monotonic())
+        _log(f"readiness: not ready (attempt {attempt}); {remaining}s left, "
+             f"sleeping {int(delay)}s")
+        if time.monotonic() + delay >= deadline:
+            break
+        time.sleep(delay)
+        delay = min(delay * 1.5, 120.0)
+    _log(f"readiness: TIMEOUT after {args.bake_timeout_s}s")
+    return False, "readiness_timeout"
+
+
+# --------------------------------------------------------------------------- #
+# Cleanup (ALWAYS attempted once the node exists -- no orphaned billing).
+# --------------------------------------------------------------------------- #
+def _cleanup_node(args: argparse.Namespace, node: str) -> None:
+    _log(f"cleanup: deleting bake node {node} + disk (no orphaned billing)")
+    rc, out = _run([
+        "gcloud", "compute", "instances", "delete", node,
+        f"--project={args.project}", f"--zone={args.zone}",
+        "--delete-disks=all", "--quiet",
+    ], timeout_s=300.0)
+    if rc == 0:
+        _log(f"cleanup: node {node} + disk deleted")
+    else:
+        _log(f"cleanup: WARNING node delete rc={rc}: {out.strip()[:300]}")
+
+
+# --------------------------------------------------------------------------- #
+# Dry-run plan printer.
+# --------------------------------------------------------------------------- #
+def _print_plan(args: argparse.Namespace, node: str, startup_script: str) -> None:
+    print("=" * 72)
+    print("BRAIN-VM GOLDEN-IMAGE BAKE -- PLAN (dry-run, spends nothing)")
+    print("=" * 72)
+    print(f"  project        : {args.project or '(unset -- pass --project / JARVIS_GCP_PROJECT)'}")
+    print(f"  zone           : {args.zone or '(unset -- pass --zone / JARVIS_BRAIN_VM_ZONES)'}")
+    print(f"  machine-type   : {args.machine_type}  (CPU-only orchestrator runtime)")
+    print(f"  repo url       : {args.repo_url or '(unset -- pass --repo-url / JARVIS_BRAIN_REPO_URL)'}")
+    print(f"  repo ref       : {args.repo_ref}")
+    print(f"  repo path      : {_REPO_PATH}  (IsomorphicEnv canonical, primary runtime)")
+    print(f"  bake node      : {node}  (ON-DEMAND for bake reliability)")
+    print(f"  source image   : {args.source_image_family}/{args.source_image_project}")
+    print(f"  boot disk      : {args.boot_disk_size} ({args.boot_disk_type})")
+    print(f"  bake timeout   : {args.bake_timeout_s}s")
+    print(f"  -> image name  : {args.image_name}")
+    print(f"  -> image family: {args.image_family}")
+    print("-" * 72)
+    print("STARTUP-SCRIPT (metadata startup-script):")
+    print(startup_script)
+    print("-" * 72)
+    print("GCLOUD COMMANDS THAT WOULD RUN (in order):")
+    print("  1. PROVISION:")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _create_node_cmd(args, node, "<startup-script-tmpfile>")))
+    print("  2. POLL READINESS (repeated; keys on the git+transport sentinel):")
+    print("     " + " ".join(shlex.quote(c) for c in
+                              _ssh_cmd(args, node, "test -f " + _SENTINEL_PATH + " ...")))
+    print("  3. STOP instance (consistent image):")
+    print(f"     gcloud compute instances stop {node} "
+          f"--project={args.project} --zone={args.zone} --quiet")
+    print("  4. CREATE GOLDEN IMAGE:")
+    print(f"     gcloud compute images create {args.image_name} "
+          f"--project={args.project} --source-disk={node} "
+          f"--source-disk-zone={args.zone} --family={args.image_family}")
+    print("  5. DELETE-TO-SNAPSHOT (node + disk; image is the durable artifact):")
+    print(f"     gcloud compute instances delete {node} "
+          f"--project={args.project} --zone={args.zone} --delete-disks=all --quiet")
+    print("-" * 72)
+    print("AWAKEN ONE-LINER (used by the Brain-VM lifecycle, Task 2/4):")
+    print("  " + build_awaken_one_liner(args))
+    print("=" * 72)
+    print("[BAKE] --dry-run: nothing executed, no money spent. Use --execute to bake.")
+
+
+# --------------------------------------------------------------------------- #
+# Execute pipeline.
+# --------------------------------------------------------------------------- #
+def _execute_bake(args: argparse.Namespace, node: str, startup_script: str) -> int:
+    if not args.repo_url:
+        _abort("no repo URL -- set JARVIS_BRAIN_REPO_URL or pass --repo-url")
+        return 2
+    if not args.project or not args.zone:
+        _abort("project/zone unset -- set JARVIS_GCP_PROJECT + JARVIS_BRAIN_VM_ZONES "
+               "(or pass --project/--zone)")
+        return 2
+
+    # Idempotency guard: refuse to clobber an existing image unless --force.
+    if _image_exists(args):
+        if not args.force:
+            _abort(
+                f"image '{args.image_name}' already exists -- "
+                "rerun with --force to replace, or pass a new --image-name"
+            )
+            return 3
+        _log(f"WARNING: image '{args.image_name}' exists -- --force given, "
+             "will delete + recreate after a clean bake")
+
+    import tempfile
+    fd, sp_path = tempfile.mkstemp(prefix="brain_startup_", suffix=".sh")
+    node_exists = False
+    try:
+        with os.fdopen(fd, "w") as fh:
+            fh.write(startup_script)
+
+        # 1. PROVISION (ON-DEMAND).
+        _log(f"provisioning bake node {node} (ON-DEMAND, {args.machine_type})")
+        rc, out = _run(_create_node_cmd(args, node, sp_path), timeout_s=300.0)
+        if rc != 0:
+            _abort(f"provision failed rc={rc}: {out.strip()[:400]}")
+            return 4
+        node_exists = True
+        _log(f"node {node} created; startup-script installing deps + cloning repo")
+
+        # 2. POLL READINESS (the git+transport sentinel).
+        ready, reason = _poll_readiness(args, node)
+        if not ready:
+            _abort(f"readiness abort: {reason}")
+            return 5
+
+        # 3. STOP for a consistent image.
+        _log(f"stopping {node} for a consistent image snapshot")
+        rc, out = _run([
+            "gcloud", "compute", "instances", "stop", node,
+            f"--project={args.project}", f"--zone={args.zone}", "--quiet",
+        ], timeout_s=300.0)
+        if rc != 0:
+            _abort(f"instance stop failed rc={rc}: {out.strip()[:300]}")
+            return 7
+
+        if args.force and _image_exists(args):
+            _log(f"--force: deleting existing image {args.image_name}")
+            _run([
+                "gcloud", "compute", "images", "delete", args.image_name,
+                f"--project={args.project}", "--quiet",
+            ], timeout_s=300.0)
+
+        # 4. CREATE GOLDEN IMAGE.
+        _log(f"creating golden image {args.image_name} (family={args.image_family})")
+        rc, out = _run([
+            "gcloud", "compute", "images", "create", args.image_name,
+            f"--project={args.project}", f"--source-disk={node}",
+            f"--source-disk-zone={args.zone}", f"--family={args.image_family}",
+        ], timeout_s=900.0)
+        if rc != 0:
+            _abort(f"image create failed rc={rc}: {out.strip()[:400]}")
+            return 8
+        _log(f"golden image created: {args.image_name}")
+
+        # 5. DELETE-TO-SNAPSHOT happens in the finally cleanup.
+        _report_success(args, node)
+        return 0
+    finally:
+        try:
+            os.unlink(sp_path)
+        except OSError:
+            pass
+        if node_exists:
+            _cleanup_node(args, node)
+
+
+def _report_success(args: argparse.Namespace, node: str) -> None:
+    print("=" * 72)
+    print("[BAKE] SUCCESS -- Brain-VM golden image baked")
+    print("=" * 72)
+    print(f"  image name   : {args.image_name}")
+    print(f"  image family : {args.image_family}")
+    print(f"  repo runtime : {_REPO_PATH} (cloned + transport-import proven)")
+    print("  readiness    : PASS (.git exists AND transport module imports)")
+    print("-" * 72)
+    print("  AWAKEN later (Brain-VM lifecycle, Task 2/4):")
+    print("    " + build_awaken_one_liner(args))
+    print("=" * 72)
+
+
+# --------------------------------------------------------------------------- #
+# CLI.
+# --------------------------------------------------------------------------- #
+def build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        description=(
+            "One-time bake of the CPU Brain-VM golden image (provision -> "
+            "install python3.11+git -> clone /opt/trinity/jarvis -> pip install "
+            "-> systemd units -> git+transport readiness proof -> snapshot -> "
+            "delete-to-snapshot). Default is --dry-run."
+        ),
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument("--project", default=_DEFAULT_PROJECT,
+                   help="GCP project (env JARVIS_GCP_PROJECT / GCP_PROJECT)")
+    p.add_argument("--zone", default=_DEFAULT_ZONE,
+                   help="GCP zone (env JARVIS_BRAIN_VM_ZONES, first entry)")
+    p.add_argument("--machine-type", default=_DEFAULT_MACHINE,
+                   help="bake machine type (CPU-only orchestrator runtime)")
+    p.add_argument("--repo-url", default=_DEFAULT_REPO_URL,
+                   help="repo URL cloned to /opt/trinity/jarvis "
+                        "(env JARVIS_BRAIN_REPO_URL)")
+    p.add_argument("--repo-ref", default=_DEFAULT_REPO_REF,
+                   help="repo ref/branch to clone (env JARVIS_BRAIN_REPO_REF)")
+    p.add_argument("--image-name", default=_default_image_name(),
+                   help="golden image name (env JARVIS_BRAIN_IMAGE_NAME)")
+    p.add_argument("--image-family", default=_DEFAULT_IMAGE_FAMILY,
+                   help="golden image family (env JARVIS_BRAIN_IMAGE_FAMILY)")
+    p.add_argument("--boot-disk-size", default=_DEFAULT_BOOT_DISK,
+                   help="bake node boot disk size")
+    p.add_argument("--boot-disk-type", default=_DEFAULT_BOOT_DISK_TYPE,
+                   help="bake node boot disk type")
+    p.add_argument("--bake-timeout-s", type=int, default=_DEFAULT_BAKE_TIMEOUT_S,
+                   help="readiness poll timeout (seconds)")
+    p.add_argument("--source-image-family", default=_DEFAULT_DEBIAN_IMAGE_FAMILY,
+                   help="base OS image family (Debian)")
+    p.add_argument("--source-image-project", default=_DEFAULT_DEBIAN_IMAGE_PROJECT,
+                   help="base OS image project")
+    p.add_argument("--node-name", default=None,
+                   help="bake node name (default jarvis-brain-bake-<stamp>)")
+    p.add_argument("--force", action="store_true",
+                   help="replace an existing image of the same name")
+    mode = p.add_mutually_exclusive_group()
+    mode.add_argument("--dry-run", dest="dry_run", action="store_true",
+                      help="print the plan + commands WITHOUT executing (default)")
+    mode.add_argument("--execute", dest="dry_run", action="store_false",
+                      help="actually run the bake (spends money)")
+    p.set_defaults(dry_run=True)
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    args = build_parser().parse_args(argv)
+    node = args.node_name or f"jarvis-brain-bake-{_now_stamp()}-{int(time.time()) % 100000}"
+    startup_script = build_startup_script(args.repo_url, repo_ref=args.repo_ref)
+
+    if args.dry_run:
+        _print_plan(args, node, startup_script)
+        return 0
+
+    _log("EXECUTE mode -- this WILL provision a GCP node and spend money")
+    return _execute_bake(args, node, startup_script)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ignite_brain_vm.py
+++ b/scripts/ignite_brain_vm.py
@@ -390,6 +390,7 @@ class ValidationExchange:
         mac: Any,
         brain: Any,
         reconnect: Callable[[], Awaitable[Any]],
+        sever: Optional[Callable[[], Awaitable[Any]]] = None,
         settle_s: float = 0.25,
         observe_timeout_s: float = 10.0,
         event_type: str = _EXCHANGE_EVENT_TYPE,
@@ -397,9 +398,16 @@ class ValidationExchange:
         self._mac = mac
         self._brain = brain
         self._reconnect = reconnect
+        self._sever = sever
         self._settle_s = max(0.0, settle_s)
         self._observe_timeout_s = max(0.0, observe_timeout_s)
         self._event_type = event_type
+        # LOOPBACK GUARD (Fix 3): when the Mac and Brain observation endpoints are
+        # the SAME object, the bidirectional "cross-host" proof is really a local
+        # loopback (no Brain echo subscriber) -- it proves nothing across the host
+        # boundary. Recorded so ``run_all`` can gate the ``proven`` flag: a
+        # loopback run can NEVER report cross-host-proven.
+        self._loopback = mac is brain
 
     async def _await_observed(
         self, endpoint: Any, expected_ids: List[str],
@@ -455,19 +463,27 @@ class ValidationExchange:
                 "ok": bool(m2b["ok"] and b2m["ok"])}
 
     async def run_reconnect_replay(self, n: int) -> Dict[str, Any]:
-        """Publish ``n`` Brain->Mac, record the Mac's last acked id, SEVER +
-        stateless re-discover/reconnect, publish ``n`` more, and assert the Mac
-        observes the exact contiguous span with zero gap / zero dup (Last-Event-ID
-        replay across a real reconnect)."""
+        """Prove Last-Event-ID replay is LOAD-BEARING: publish ``n`` Brain->Mac
+        live, record the Mac's last acked id, SEVER the link, publish ``n`` more
+        events WHILE SEVERED (buffered at the source -- NOT delivered live), then
+        stateless re-discover/reconnect so the reconnect's Last-Event-ID replay is
+        the ONLY delivery route for the severed span. Assert the Mac observes the
+        exact contiguous pre+post span with zero gap / zero dup."""
         _ops, pre_ids = await self._publish_batch(self._brain, n, "pre")
         await self._await_observed(self._mac, pre_ids)
         last_id = self._mac.last_event_id
 
-        # Sever + re-discover + reconnect (stateless -- the caller re-resolves the
-        # endpoint from scratch). The reconnected Mac endpoint replaces ours.
+        # SEVER before publishing the post span so those events cannot deliver
+        # live -- they can only arrive via the reconnect's Last-Event-ID replay.
+        if self._sever is not None:
+            await self._sever()
+        _ops2, post_ids = await self._publish_batch(self._brain, n, "post")
+
+        # Re-discover + reconnect (stateless -- the caller re-resolves the endpoint
+        # from scratch). The hello-frame's Last-Event-ID triggers the replay of the
+        # severed span. The reconnected Mac endpoint replaces ours.
         self._mac = await self._reconnect()
 
-        _ops2, post_ids = await self._publish_batch(self._brain, n, "post")
         expected = pre_ids + post_ids
         observed = await self._await_observed(self._mac, expected)
         gap, dup = _gap_dup(expected, observed)
@@ -483,8 +499,13 @@ class ValidationExchange:
     async def run_all(self, n: int) -> Dict[str, Any]:
         bidi = await self.run_bidirectional(n)
         replay = await self.run_reconnect_replay(n)
+        logic_ok = bool(bidi["ok"] and replay["ok"])
+        # Fix 3: a loopback run (mac is brain, no Brain echo) can NEVER be read as
+        # cross-host-proven. Gate ``proven`` on NOT loopback; surface loopback_only.
         return {
-            "proven": bool(bidi["ok"] and replay["ok"]),
+            "proven": bool(logic_ok and not self._loopback),
+            "loopback_only": self._loopback,
+            "logic_ok": logic_ok,
             "bidirectional": bidi,
             "reconnect_replay": replay,
         }
@@ -712,21 +733,34 @@ class BrainIgnitionDriver:
         mac = _LiveMacEndpoint(bus, broker, _client_getter)
         await mac.start()
 
+        _live_tasks: List[asyncio.Task] = [client_task]
+
+        async def _sever() -> Any:
+            # Drop the WS: stop the client bridge so events published next buffer in
+            # the local broker history and can only reach the peer via the reconnect
+            # hello-frame's Last-Event-ID replay.
+            try:
+                await bus.stop()
+            except Exception:  # noqa: BLE001
+                pass
+
         async def _reconnect() -> Any:
-            # Stateless re-discovery: stop the client, re-resolve the endpoint from
-            # scratch (a Brain that moved is re-found), reconnect a fresh client.
-            await bus.stop()
+            # Stateless re-discovery: re-resolve the endpoint from scratch (a Brain
+            # that moved is re-found), reconnect a fresh client -> Last-Event-ID
+            # replay fills the severed span.
             new_url = await self._do_discover() or url
             new_task = asyncio.ensure_future(bus.start_client(new_url))
             _live_tasks.append(new_task)
             return mac
 
-        _live_tasks: List[asyncio.Task] = [client_task]
-        # In the live run the "brain" observation endpoint is the same local broker
-        # (Brain echoes flow back as inbound republishes). The exchange LOGIC is
-        # identical to the unit-proven path.
+        # LOUD LOOPBACK GUARD (Fix 3): with no Brain-side echo subscriber (Task 5),
+        # the Brain observation endpoint is the SAME local broker as the Mac -- the
+        # bidirectional exchange is a LOCAL LOOPBACK, not a cross-host round-trip.
+        # ValidationExchange gates ``proven=False`` in this mode; make it visible.
+        _log("[BrainIgnite] bidirectional exchange is LOOPBACK (brain echo "
+             "subscriber not wired) -- cross-host round-trip UNPROVEN until Stage 2")
         exchange = ValidationExchange(
-            mac=mac, brain=mac, reconnect=_reconnect,
+            mac=mac, brain=mac, reconnect=_reconnect, sever=_sever,
             settle_s=_env_float("JARVIS_BRAIN_EXCHANGE_SETTLE_S", 1.0),
             observe_timeout_s=_env_float("JARVIS_BRAIN_EXCHANGE_OBSERVE_S", 15.0),
         )
@@ -801,7 +835,13 @@ class BrainIgnitionDriver:
             else:
                 result = await self._default_run_exchange(url)
             proven = bool(result.get("proven"))
-            _log("ACCEPTANCE %s: %r" % ("PROVEN" if proven else "NOT PROVEN", result))
+            if result.get("loopback_only"):
+                _log("ACCEPTANCE NOT PROVEN (LOOPBACK_ONLY) -- exchange logic_ok=%r "
+                     "but cross-host round-trip requires the Brain echo (Task 5): %r"
+                     % (result.get("logic_ok"), result))
+            else:
+                _log("ACCEPTANCE %s: %r"
+                     % ("PROVEN" if proven else "NOT PROVEN", result))
             return 0 if proven else 4
 
         except Exception as exc:  # noqa: BLE001

--- a/scripts/ignite_brain_vm.py
+++ b/scripts/ignite_brain_vm.py
@@ -1,0 +1,913 @@
+"""ignite_brain_vm.py -- Stage-1 Brain-VM ignition driver + cross-host acceptance.
+
+Provisions (or reuses) the GCP CPU Brain VM, opens an ephemeral /32 mTLS firewall
+for THIS Mac, connects a Stage-0 ``DistributedEventBus`` client over the Brain's
+WS transport, runs the LOAD-BEARING Stage-1 acceptance exchange, and tears
+EVERYTHING down on every exit path with a $0-orphan guarantee.
+
+Teardown discipline (mirrors ``scripts/isomorphic_a1_local.py``)
+--------------------------------------------------------------
+A module-level ``_ACTIVE_BRAIN_RESOURCES`` registry is drained by
+``_reap_brain_resources`` on ``finally`` + ``atexit`` + SIGINT/SIGTERM --
+whichever fires first; the rest are no-ops once drained (idempotent, never
+raises). Each entry is registered UP FRONT (before the VM even exists) so a
+crash mid-provision still reaps whatever got created. The firewall is ALWAYS
+closed; the VM is deleted only when ``JARVIS_BRAIN_VM_PERSISTENT`` is false
+(on-demand-per-session default). Delete is idempotent (404==already-gone) and is
+attempted across the whole ``zone_fallback_chain`` so a node the scatter-gather
+awaken landed in a fallback zone is never orphaned.
+
+The acceptance exchange (Stage-1 proof)
+---------------------------------------
+``ValidationExchange`` is transport-agnostic and unit-testable: it publishes N
+events Mac->Brain and asserts they are observed on the Brain, publishes
+Brain->Mac and asserts observed on the Mac (both bus directions), then severs the
+WS mid-stream, RE-DISCOVERS (stateless) + reconnects, and asserts exact
+Last-Event-ID replay (zero gap / zero dup -- the Stage-0 guarantee, now
+cross-host). mTLS-required is proven by the discovery probe itself (a certless
+handshake is rejected by the Brain before the WS upgrade). Post-run the driver
+verifies $0: no brain instance + no brain firewall rule remain.
+
+The live path hits real GCP (Mandate 1: no cloud simulation); the fakes live
+only in the unit test (``tests/infra/test_ignite_brain_vm.py``), which proves the
+exchange + provision + teardown LOGIC without spending a cent.
+
+Env knobs (all resolved at call time -- Mandate 2, zero baked assumptions):
+    JARVIS_BRAIN_VM_PERSISTENT        opt-in warm standby (default false)
+    JARVIS_BRAIN_VM_NODE_NAME         node name (default jarvis-brain-<stamp>)
+    JARVIS_BRAIN_FIREWALL_RULE_NAME   /32 rule name (default jarvis-brain-mtls)
+    JARVIS_BRAIN_READY_BUDGET_S       readiness-await budget (default 600)
+    JARVIS_BRAIN_READY_BASE_S/_CAP_S  readiness backoff base/cap
+    JARVIS_BRAIN_EXCHANGE_N           events per acceptance direction (default 5)
+    JARVIS_BRAIN_WS_*                 Stage-0 transport (host/port/path/TLS/certs)
+    JARVIS_BRAIN_VM_MACHINE_TYPE / _IMAGE_FAMILY / _IDLE_SHUTDOWN_S / _SPOT
+                                      (resolved inside gcp_compute_rest)
+
+Usage::
+
+    python3 scripts/ignite_brain_vm.py                 # on-demand: provision+reap
+    JARVIS_BRAIN_VM_PERSISTENT=true python3 scripts/ignite_brain_vm.py  # warm standby
+    python3 scripts/ignite_brain_vm.py --dry-run       # print the plan, no GCP
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import atexit
+import os
+import signal
+import sys
+import threading
+import time
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Paths -- derived from this file's location; backend importable regardless of cwd.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR: str = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT: str = os.path.dirname(_SCRIPTS_DIR)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _log(msg: str) -> None:
+    print("[BrainIgnite] %s" % (msg,), flush=True)
+
+
+def _truthy(val: Optional[str]) -> bool:
+    return str(val or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(float(os.environ.get(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Env knobs (resolved at call time).
+# ---------------------------------------------------------------------------
+
+_ENV_PERSISTENT = "JARVIS_BRAIN_VM_PERSISTENT"
+_ENV_NODE_NAME = "JARVIS_BRAIN_VM_NODE_NAME"
+_ENV_FW_RULE_NAME = "JARVIS_BRAIN_FIREWALL_RULE_NAME"
+_DEFAULT_FW_RULE_NAME = "jarvis-brain-mtls"
+_ENV_READY_BUDGET_S = "JARVIS_BRAIN_READY_BUDGET_S"
+_ENV_READY_BASE_S = "JARVIS_BRAIN_READY_BASE_S"
+_ENV_READY_CAP_S = "JARVIS_BRAIN_READY_CAP_S"
+_ENV_EXCHANGE_N = "JARVIS_BRAIN_EXCHANGE_N"
+
+
+def _persistent() -> bool:
+    return _truthy(os.environ.get(_ENV_PERSISTENT, "false"))
+
+
+def _node_name() -> str:
+    val = (os.environ.get(_ENV_NODE_NAME, "") or "").strip()
+    return val or ("jarvis-brain-%s" % time.strftime("%Y%m%d-%H%M%S"))
+
+
+def _fw_rule_name() -> str:
+    val = (os.environ.get(_ENV_FW_RULE_NAME, "") or "").strip()
+    return val or _DEFAULT_FW_RULE_NAME
+
+
+# ---------------------------------------------------------------------------
+# Teardown reaper -- the $0-orphan guarantee (mirrors _reap_failover_resources).
+#
+# Each entry: {"node": <name|None>, "fw_rule": <name|None>, "persistent": bool,
+#              "zone": <zone|None>}
+#   node=None      -> a REUSED persistent VM (never provisioned here -> never deleted)
+#   persistent=True-> LEAVE the VM running; still close the firewall
+# ---------------------------------------------------------------------------
+
+_ACTIVE_BRAIN_RESOURCES: List[Dict[str, Any]] = []
+
+# Collaborators the SYNC reaper (signal / atexit path) uses. Injected by the
+# driver (and by tests). Default None -> the reaper resolves the live GCP
+# firewall/instance functions lazily.
+_REAP_CLOSE_FW_FN: Optional[Callable[..., Awaitable[Any]]] = None
+_REAP_DELETE_FN: Optional[Callable[..., Awaitable[Any]]] = None
+
+
+def _set_reap_collaborators(
+    *,
+    close_firewall_fn: Optional[Callable[..., Awaitable[Any]]],
+    delete_instance_fn: Optional[Callable[..., Awaitable[Any]]],
+) -> None:
+    """Point the sync (signal/atexit) reaper at specific firewall/delete
+    callables. The driver sets these before it registers any resource so a
+    SIGTERM at ANY point reaps through the same path the ``finally`` uses."""
+    global _REAP_CLOSE_FW_FN, _REAP_DELETE_FN
+    _REAP_CLOSE_FW_FN = close_firewall_fn
+    _REAP_DELETE_FN = delete_instance_fn
+
+
+def _register_brain_resource(
+    *, node: Optional[str], fw_rule: Optional[str], persistent: bool,
+    zone: Optional[str] = None,
+) -> None:
+    """Register a Brain node + its ephemeral firewall for teardown UP FRONT
+    (before the node exists) so a crash mid-provision still reaps what landed."""
+    _ACTIVE_BRAIN_RESOURCES.append({
+        "node": node,
+        "fw_rule": fw_rule,
+        "persistent": bool(persistent),
+        "zone": zone or os.environ.get("GCP_ZONE"),
+    })
+
+
+def _reap_confirm_attempts() -> int:
+    """Bounded delete+recheck rounds -- reuses the same env lever the GCP reap
+    path uses so a wedged zone never blocks teardown forever."""
+    try:
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            _reap_confirm_attempts as _rca,
+        )
+
+        return int(_rca())
+    except Exception:  # noqa: BLE001
+        return _env_int("JARVIS_REAP_CONFIRM_ATTEMPTS", 6)
+
+
+async def _default_close_firewall(rule_name: str) -> Any:
+    from backend.core.ouroboros.governance.brain_discovery import (  # noqa: PLC0415
+        close_brain_firewall,
+    )
+
+    return await close_brain_firewall(rule_name=rule_name)
+
+
+async def _default_delete_instance(node: str, *, zone: Optional[str] = None) -> Any:
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        get_compute_rest,
+    )
+
+    return await get_compute_rest().delete_instance(node, zone=zone)
+
+
+async def _reap_brain_resources_async(
+    *,
+    close_firewall_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+    delete_instance_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+) -> None:
+    """Drain the resource registry: close every firewall + delete every
+    non-persistent VM across the whole zone fallback chain. Idempotent (drains
+    the registry so a second call is a no-op) + fail-soft (NEVER raises)."""
+    if not _ACTIVE_BRAIN_RESOURCES:
+        return
+    resources = list(_ACTIVE_BRAIN_RESOURCES)
+    _ACTIVE_BRAIN_RESOURCES.clear()
+
+    close_fw = close_firewall_fn or _REAP_CLOSE_FW_FN or _default_close_firewall
+    delete_vm = delete_instance_fn or _REAP_DELETE_FN or _default_delete_instance
+
+    try:
+        from backend.core.ouroboros.governance.zone_fallback import (  # noqa: PLC0415
+            zone_fallback_chain,
+        )
+
+        zones = zone_fallback_chain(os.environ.get("GCP_ZONE"))
+    except Exception:  # noqa: BLE001
+        zones = [os.environ.get("GCP_ZONE")] if os.environ.get("GCP_ZONE") else [None]
+    if not zones:
+        zones = [None]
+
+    attempts = max(1, _reap_confirm_attempts())
+
+    for r in resources:
+        fw_rule = r.get("fw_rule")
+        if fw_rule:
+            try:
+                await close_fw(rule_name=fw_rule)
+            except Exception as exc:  # noqa: BLE001 -- teardown must never raise
+                _log("firewall close warning (continuing): %r" % (exc,))
+        node = r.get("node")
+        if node and not r.get("persistent"):
+            # Reap-confirm: idempotent delete across every candidate zone. The
+            # bounded ``attempts`` loop guards a LATE async materialization (an
+            # 'unknown' insert op that surfaces a node after the first pass).
+            for _round in range(attempts):
+                any_alive = False
+                for z in zones:
+                    try:
+                        ok, detail = await delete_vm(node, zone=z)
+                        # A non-terminal delete (not deleted/404) means the node
+                        # may still be materializing -> another round.
+                        if not ok:
+                            any_alive = True
+                    except Exception as exc:  # noqa: BLE001
+                        _log("delete warning node=%s zone=%s (continuing): %r"
+                             % (node, z, exc))
+                        any_alive = True
+                if not any_alive:
+                    break
+    _log("reaped %d brain resource(s) -- firewall(s) closed + non-persistent "
+         "VM(s) deleted" % len(resources))
+
+
+def _reap_brain_resources() -> None:
+    """SYNC reaper for the ``finally`` / ``atexit`` / signal paths. Dispatches the
+    async reap on a dedicated thread when a loop is already running (a signal that
+    interrupted ``asyncio.run``), else runs it directly. Idempotent + NEVER
+    raises."""
+    if not _ACTIVE_BRAIN_RESOURCES:
+        return
+
+    def _run_blocking() -> None:
+        asyncio.run(_reap_brain_resources_async())
+
+    try:
+        try:
+            asyncio.get_running_loop()
+            t = threading.Thread(target=_run_blocking, name="brain-reap", daemon=True)
+            t.start()
+            t.join(timeout=_env_float("JARVIS_FAILOVER_REST_TIMEOUT_S", 30.0) + 15.0)
+        except RuntimeError:
+            _run_blocking()
+    except Exception as exc:  # noqa: BLE001 -- teardown must NEVER raise
+        _log("reap error (continuing): %r" % (exc,))
+
+
+def _install_teardown_signal_handlers() -> None:
+    """SIGINT/SIGTERM -> reap the Brain VM + firewall before exiting. The REST
+    delete is the process's last breath even on Ctrl+C."""
+    def _handler(signum: int, _frame: Any) -> None:
+        _log("signal %d received -- reaping brain resources before exit" % (signum,))
+        try:
+            _reap_brain_resources()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            signal.signal(signum, signal.SIG_DFL)
+        except Exception:  # noqa: BLE001
+            pass
+        os.kill(os.getpid(), signum)
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        try:
+            signal.signal(sig, _handler)
+        except (ValueError, OSError):
+            pass  # not in main thread (e.g. pytest workers) -- skip silently
+
+
+# ---------------------------------------------------------------------------
+# Post-teardown $0 verify.
+# ---------------------------------------------------------------------------
+
+
+async def _default_list_brain_instances() -> List[Dict[str, Any]]:
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        _BRAIN_ROLE_LABEL_KEY,
+        _BRAIN_ROLE_LABEL_VALUE,
+        get_compute_rest,
+    )
+
+    return await get_compute_rest().list_instances_by_label(
+        label_key=_BRAIN_ROLE_LABEL_KEY, label_value=_BRAIN_ROLE_LABEL_VALUE,
+    )
+
+
+async def _default_firewall_exists(rule_name: str) -> bool:
+    """Best-effort: a successful close returns deleted/404 which IS the $0 proof;
+    there is no cheap read API, so default to False (assume-closed) and let a
+    non-terminal close surface as a warning. Tests inject a real probe."""
+    return False
+
+
+async def _teardown_verify(
+    *,
+    persistent: bool,
+    list_brain_fn: Optional[Callable[[], Awaitable[List[Dict[str, Any]]]]] = None,
+    firewall_exists_fn: Optional[Callable[[str], Awaitable[bool]]] = None,
+    rule_name: Optional[str] = None,
+) -> Dict[str, Any]:
+    """The driver's OWN $0 proof: assert no brain instance (unless persistent) +
+    no brain firewall remain post-teardown. Returns
+    ``{"zero_cost": bool, "leaked": [str, ...]}``. NEVER raises."""
+    leaked: List[str] = []
+    list_fn = list_brain_fn or _default_list_brain_instances
+    fw_fn = firewall_exists_fn or _default_firewall_exists
+    name = rule_name or _fw_rule_name()
+
+    if not persistent:
+        try:
+            instances = await list_fn()
+            for inst in instances or []:
+                status = str(inst.get("status") or "").upper()
+                if status in ("RUNNING", "PROVISIONING", "STAGING", "REPAIRING"):
+                    leaked.append("instance:%s" % (inst.get("name") or "?"))
+        except Exception as exc:  # noqa: BLE001
+            _log("teardown-verify instance list warning: %r" % (exc,))
+    try:
+        if await fw_fn(name):
+            leaked.append("firewall:%s" % name)
+    except Exception as exc:  # noqa: BLE001
+        _log("teardown-verify firewall check warning: %r" % (exc,))
+
+    return {"zero_cost": not leaked, "leaked": leaked}
+
+
+# ---------------------------------------------------------------------------
+# The Stage-1 acceptance exchange (transport-agnostic + unit-testable).
+# ---------------------------------------------------------------------------
+
+# A BusEndpoint is any object with:
+#   publish(event_type: str, op_id: str, payload: dict) -> str (event_id)
+#   observed() -> List[Tuple[op_id, event_id]]  (receive order)
+#   last_event_id -> Optional[str]
+
+_EXCHANGE_EVENT_TYPE = "task_started"  # a valid StreamEventBroker event type
+
+
+def _gap_dup(published_ids: List[str], observed_ids: List[str]) -> Tuple[List[str], List[str]]:
+    """Compute the (gap, dup) of ``observed_ids`` vs ``published_ids``: a gap is a
+    published id never observed; a dup is an id observed more than once."""
+    obs_counts: Dict[str, int] = {}
+    for eid in observed_ids:
+        obs_counts[eid] = obs_counts.get(eid, 0) + 1
+    gap = [eid for eid in published_ids if obs_counts.get(eid, 0) == 0]
+    dup = [eid for eid, c in obs_counts.items() if c > 1]
+    return gap, dup
+
+
+class ValidationExchange:
+    """Cross-host acceptance exchange over two ``BusEndpoint``s + a stateless
+    ``reconnect`` callable. Every assertion is returned as structured data so the
+    driver logs it and the unit test asserts on it."""
+
+    def __init__(
+        self,
+        *,
+        mac: Any,
+        brain: Any,
+        reconnect: Callable[[], Awaitable[Any]],
+        settle_s: float = 0.25,
+        observe_timeout_s: float = 10.0,
+        event_type: str = _EXCHANGE_EVENT_TYPE,
+    ) -> None:
+        self._mac = mac
+        self._brain = brain
+        self._reconnect = reconnect
+        self._settle_s = max(0.0, settle_s)
+        self._observe_timeout_s = max(0.0, observe_timeout_s)
+        self._event_type = event_type
+
+    async def _await_observed(
+        self, endpoint: Any, expected_ids: List[str],
+    ) -> List[str]:
+        """Poll ``endpoint.observed()`` until every expected event_id is present
+        or the observe budget elapses. Returns the observed event_ids for the
+        expected op set (in receive order)."""
+        expected = set(expected_ids)
+        deadline = time.monotonic() + self._observe_timeout_s
+        while True:
+            observed_ids = [eid for _op, eid in endpoint.observed()
+                            if eid in expected]
+            if expected.issubset(set(observed_ids)):
+                return observed_ids
+            if time.monotonic() >= deadline:
+                return observed_ids
+            await asyncio.sleep(min(0.05, self._settle_s) if self._settle_s else 0.02)
+
+    async def _publish_batch(
+        self, source: Any, n: int, tag: str,
+    ) -> Tuple[List[str], List[str]]:
+        """Publish ``n`` events on ``source``; return (op_ids, event_ids)."""
+        op_ids: List[str] = []
+        event_ids: List[str] = []
+        for i in range(n):
+            op_id = "brain-accept-%s-%d-%d" % (tag, int(time.time() * 1000), i)
+            eid = source.publish(self._event_type, op_id, {"seq": i, "tag": tag})
+            op_ids.append(op_id)
+            if eid:
+                event_ids.append(eid)
+        if self._settle_s:
+            await asyncio.sleep(self._settle_s)
+        return op_ids, event_ids
+
+    async def run_bidirectional(self, n: int) -> Dict[str, Any]:
+        """Mac->Brain then Brain->Mac; each direction asserts zero gap / zero
+        dup on the DESTINATION endpoint."""
+        # Mac -> Brain
+        _ops, m2b_ids = await self._publish_batch(self._mac, n, "m2b")
+        observed = await self._await_observed(self._brain, m2b_ids)
+        gap, dup = _gap_dup(m2b_ids, observed)
+        m2b = {"ok": not gap and not dup, "published": len(m2b_ids),
+               "observed": len(observed), "gap": gap, "dup": dup}
+
+        # Brain -> Mac
+        _ops2, b2m_ids = await self._publish_batch(self._brain, n, "b2m")
+        observed2 = await self._await_observed(self._mac, b2m_ids)
+        gap2, dup2 = _gap_dup(b2m_ids, observed2)
+        b2m = {"ok": not gap2 and not dup2, "published": len(b2m_ids),
+               "observed": len(observed2), "gap": gap2, "dup": dup2}
+
+        return {"mac_to_brain": m2b, "brain_to_mac": b2m,
+                "ok": bool(m2b["ok"] and b2m["ok"])}
+
+    async def run_reconnect_replay(self, n: int) -> Dict[str, Any]:
+        """Publish ``n`` Brain->Mac, record the Mac's last acked id, SEVER +
+        stateless re-discover/reconnect, publish ``n`` more, and assert the Mac
+        observes the exact contiguous span with zero gap / zero dup (Last-Event-ID
+        replay across a real reconnect)."""
+        _ops, pre_ids = await self._publish_batch(self._brain, n, "pre")
+        await self._await_observed(self._mac, pre_ids)
+        last_id = self._mac.last_event_id
+
+        # Sever + re-discover + reconnect (stateless -- the caller re-resolves the
+        # endpoint from scratch). The reconnected Mac endpoint replaces ours.
+        self._mac = await self._reconnect()
+
+        _ops2, post_ids = await self._publish_batch(self._brain, n, "post")
+        expected = pre_ids + post_ids
+        observed = await self._await_observed(self._mac, expected)
+        gap, dup = _gap_dup(expected, observed)
+        return {
+            "ok": not gap and not dup,
+            "last_event_id_at_sever": last_id,
+            "published": len(expected),
+            "observed": len(observed),
+            "gap": gap,
+            "dup": dup,
+        }
+
+    async def run_all(self, n: int) -> Dict[str, Any]:
+        bidi = await self.run_bidirectional(n)
+        replay = await self.run_reconnect_replay(n)
+        return {
+            "proven": bool(bidi["ok"] and replay["ok"]),
+            "bidirectional": bidi,
+            "reconnect_replay": replay,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Live BusEndpoint over a StreamEventBroker + DistributedEventBus client.
+# ---------------------------------------------------------------------------
+
+
+class _LiveMacEndpoint:
+    """Live Mac-side endpoint: publishes onto a local ``StreamEventBroker`` (which
+    a client ``DistributedEventBus`` bridge pumps to the Brain) and observes every
+    event that lands in the local broker (Brain-originated events arrive via the
+    client's inbound republish). ``last_event_id`` tracks the client bridge's
+    contiguous high-water mark (the real Last-Event-ID replay cursor)."""
+
+    def __init__(self, bus: Any, broker: Any, client_getter: Callable[[], Any]) -> None:
+        self.name = "mac"
+        self._bus = bus
+        self._broker = broker
+        self._client_getter = client_getter
+        self._observed: List[Tuple[str, str]] = []
+        self._sub = None
+        self._task: Optional[asyncio.Task] = None
+
+    async def start(self) -> None:
+        sub = self._broker.subscribe(op_id_filter=None, last_event_id=None)
+        if sub is None:
+            return
+        self._sub = sub
+
+        async def _collect() -> None:
+            try:
+                async for ev in self._broker.stream_iter(sub, heartbeat_s=0):
+                    eid = getattr(ev, "event_id", "") or ""
+                    op = getattr(ev, "op_id", "") or ""
+                    if eid:
+                        self._observed.append((op, eid))
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                pass
+
+        self._task = asyncio.ensure_future(_collect())
+
+    async def stop(self) -> None:
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            self._task = None
+
+    def publish(self, event_type: str, op_id: str, payload: Dict[str, Any]) -> str:
+        return self._bus.publish(event_type, op_id, payload) or ""
+
+    def observed(self) -> List[Tuple[str, str]]:
+        return list(self._observed)
+
+    @property
+    def last_event_id(self) -> Optional[str]:
+        client = self._client_getter()
+        return getattr(client, "last_event_id", None) if client else None
+
+
+# ---------------------------------------------------------------------------
+# The ignition driver.
+# ---------------------------------------------------------------------------
+
+
+class BrainIgnitionDriver:
+    """Provision (or reuse) -> firewall -> connect -> acceptance exchange ->
+    teardown ($0). Every GCP/transport collaborator is an injectable seam; the
+    defaults are the live REST/discovery/transport functions. The unit test
+    injects fakes for all of them (Mandate 1: no cloud simulation in the LIVE
+    path; fakes only in tests)."""
+
+    def __init__(
+        self,
+        *,
+        persistent: Optional[bool] = None,
+        node_name: Optional[str] = None,
+        fw_rule_name: Optional[str] = None,
+        exchange_n: Optional[int] = None,
+        ready_budget_s: Optional[float] = None,
+        # Injectable seams (live defaults resolved lazily inside run()).
+        create_instance_fn: Optional[Callable[..., Awaitable[Tuple[bool, str]]]] = None,
+        discover_fn: Optional[Callable[..., Awaitable[Optional[str]]]] = None,
+        open_firewall_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+        close_firewall_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+        delete_instance_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+        list_brain_fn: Optional[Callable[[], Awaitable[List[Dict[str, Any]]]]] = None,
+        firewall_exists_fn: Optional[Callable[[str], Awaitable[bool]]] = None,
+        run_exchange_fn: Optional[Callable[[], Awaitable[Dict[str, Any]]]] = None,
+        dry_run: bool = False,
+    ) -> None:
+        self.persistent = _persistent() if persistent is None else bool(persistent)
+        self.node_name = node_name or _node_name()
+        self.fw_rule_name = fw_rule_name or _fw_rule_name()
+        self.exchange_n = exchange_n if exchange_n is not None else _env_int(_ENV_EXCHANGE_N, 5)
+        self.ready_budget_s = (ready_budget_s if ready_budget_s is not None
+                               else _env_float(_ENV_READY_BUDGET_S, 600.0))
+        self.dry_run = dry_run
+
+        self._create_instance = create_instance_fn
+        self._discover = discover_fn
+        self._open_firewall = open_firewall_fn
+        self._close_firewall = close_firewall_fn
+        self._delete_instance = delete_instance_fn
+        self._list_brain = list_brain_fn
+        self._firewall_exists = firewall_exists_fn
+        self._run_exchange = run_exchange_fn
+
+    # -- lazy live default resolvers ---------------------------------------
+
+    async def _do_create_instance(self) -> Tuple[bool, str]:
+        if self._create_instance is not None:
+            return await self._create_instance(name=self.node_name)
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            _BRAIN_ENV_METADATA_KEY,
+            _BRAIN_ROLE_LABEL_KEY,
+            _BRAIN_ROLE_LABEL_VALUE,
+            _brain_image_family,
+            _brain_machine_type,
+            _compose_brain_env,
+            get_compute_rest,
+        )
+
+        brain_env = _compose_brain_env(self._brain_env_values())
+        return await get_compute_rest().create_instance(
+            startup_script=_brain_runtime_startup_script(),
+            name=self.node_name,
+            machine_type=_brain_machine_type(),
+            image_family=_brain_image_family(),
+            accelerator_type="",
+            accelerator_count=0,
+            labels={_BRAIN_ROLE_LABEL_KEY: _BRAIN_ROLE_LABEL_VALUE},
+            extra_metadata={_BRAIN_ENV_METADATA_KEY: brain_env},
+        )
+
+    def _brain_env_values(self) -> Dict[str, str]:
+        """Fold the Task-4 ignition values into the brain-env metadata: the WS
+        port/path + TLS material references + the session cost cap, all
+        env-resolved (Mandate 2). The idle-shutdown seconds are added by
+        ``_compose_brain_env`` itself."""
+        vals: Dict[str, str] = {}
+        for key in (
+            "JARVIS_BRAIN_WS_PORT", "JARVIS_BRAIN_WS_PATH", "JARVIS_BRAIN_WS_TLS_ENABLED",
+            "JARVIS_BRAIN_WS_TLS_CERT", "JARVIS_BRAIN_WS_TLS_KEY", "JARVIS_BRAIN_WS_TLS_CA",
+            "JARVIS_BRAIN_COST_CAP", "JARVIS_DISTRIBUTED_BUS_ENABLED",
+        ):
+            v = os.environ.get(key)
+            if v is not None and v != "":
+                vals[key] = v
+        return vals
+
+    async def _do_discover(self) -> Optional[str]:
+        if self._discover is not None:
+            return await self._discover()
+        from backend.core.ouroboros.governance.brain_discovery import (  # noqa: PLC0415
+            discover_brain_endpoint,
+        )
+
+        return await discover_brain_endpoint()
+
+    async def _do_open_firewall(self) -> Any:
+        if self._open_firewall is not None:
+            return await self._open_firewall(rule_name=self.fw_rule_name)
+        from backend.core.ouroboros.governance.brain_discovery import (  # noqa: PLC0415
+            open_brain_firewall,
+        )
+        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+            resolve_local_public_ip,
+        )
+
+        ip = await resolve_local_public_ip()
+        return await open_brain_firewall(ip, rule_name=self.fw_rule_name)
+
+    async def _await_ready(self) -> Optional[str]:
+        """Await the Brain readiness sentinel by re-running discovery until it
+        binds a healthy mTLS endpoint (the same stateless probe a reconnect uses).
+        Exponential backoff bounded by ``ready_budget_s``. Returns the WS URL or
+        None on timeout."""
+        base = _env_float(_ENV_READY_BASE_S, 3.0)
+        cap = _env_float(_ENV_READY_CAP_S, 30.0)
+        deadline = time.monotonic() + self.ready_budget_s
+        delay = base
+        while time.monotonic() < deadline:
+            url = await self._do_discover()
+            if url:
+                return url
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            await asyncio.sleep(min(delay, remaining))
+            delay = min(delay * 2.0, cap)
+        return None
+
+    async def _default_run_exchange(self, url: str) -> Dict[str, Any]:
+        """LIVE acceptance exchange: connect a client ``DistributedEventBus`` over
+        mTLS to the discovered Brain URL, run the bidirectional + reconnect-replay
+        proof. The Brain side of the bidirectional proof requires the Brain
+        harness's echo subscriber (wired/validated in Task 5); this driver owns the
+        Mac side + the full exchange LOGIC (unit-proven)."""
+        from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: PLC0415
+            StreamEventBroker,
+        )
+        from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: PLC0415
+            DistributedEventBus,
+        )
+        from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: PLC0415
+            TransportConfig,
+        )
+
+        cfg = TransportConfig.from_env(role="brain-client")
+        broker = StreamEventBroker()
+        bus = DistributedEventBus(broker, cfg, role="client")
+        client_task = asyncio.ensure_future(bus.start_client(url))
+
+        def _client_getter() -> Any:
+            return getattr(bus, "_client", None)
+
+        mac = _LiveMacEndpoint(bus, broker, _client_getter)
+        await mac.start()
+
+        async def _reconnect() -> Any:
+            # Stateless re-discovery: stop the client, re-resolve the endpoint from
+            # scratch (a Brain that moved is re-found), reconnect a fresh client.
+            await bus.stop()
+            new_url = await self._do_discover() or url
+            new_task = asyncio.ensure_future(bus.start_client(new_url))
+            _live_tasks.append(new_task)
+            return mac
+
+        _live_tasks: List[asyncio.Task] = [client_task]
+        # In the live run the "brain" observation endpoint is the same local broker
+        # (Brain echoes flow back as inbound republishes). The exchange LOGIC is
+        # identical to the unit-proven path.
+        exchange = ValidationExchange(
+            mac=mac, brain=mac, reconnect=_reconnect,
+            settle_s=_env_float("JARVIS_BRAIN_EXCHANGE_SETTLE_S", 1.0),
+            observe_timeout_s=_env_float("JARVIS_BRAIN_EXCHANGE_OBSERVE_S", 15.0),
+        )
+        try:
+            result = await exchange.run_all(self.exchange_n)
+        finally:
+            await mac.stop()
+            try:
+                await bus.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            for t in _live_tasks:
+                t.cancel()
+        return result
+
+    # -- the run FSM -------------------------------------------------------
+
+    async def run(self) -> int:
+        # Point the sync (signal/atexit) reaper at THIS run's collaborators before
+        # registering any resource, so a SIGTERM at any point reaps identically.
+        _set_reap_collaborators(
+            close_firewall_fn=self._close_firewall,
+            delete_instance_fn=self._delete_instance,
+        )
+
+        if self.dry_run:
+            _log("[dry-run] would open firewall %s, provision/reuse node %s "
+                 "(persistent=%s) -- no GCP touched" % (self.fw_rule_name,
+                                                        self.node_name, self.persistent))
+            return 0
+
+        proven = False
+        try:
+            # 1. FIREWALL first (discovery's mTLS probe needs our /32 open).
+            _register_brain_resource(
+                node=None, fw_rule=self.fw_rule_name, persistent=self.persistent)
+            ok, detail = await self._do_open_firewall()
+            _log("firewall %s -> %s (%s)" % (self.fw_rule_name,
+                                             "OPEN" if ok else "FAILED", detail))
+
+            # 2. PROVISION or REUSE.
+            url: Optional[str] = None
+            if self.persistent:
+                url = await self._do_discover()
+            if url:
+                _log("REUSE running brain (persistent) -- no provision")
+                # A reused VM was not provisioned here -> never delete it. Update
+                # the registered entry's node to None (already None) -- firewall
+                # stays registered for close.
+            else:
+                # Register the node for teardown UP FRONT (orphan safety), then
+                # provision. Non-persistent -> the reaper will delete it.
+                _register_brain_resource(
+                    node=self.node_name, fw_rule=None, persistent=self.persistent)
+                _log("provisioning brain node=%s (persistent=%s)"
+                     % (self.node_name, self.persistent))
+                cok, cdetail = await self._do_create_instance()
+                _log("create_instance -> %s (%s)" % ("OK" if cok else "FAILED", cdetail))
+                if not cok:
+                    _log("provision FAILED -- aborting (teardown will reap)")
+                    return 2
+                url = await self._await_ready()
+                if not url:
+                    _log("readiness TIMEOUT after %.0fs -- aborting (teardown reaps)"
+                         % self.ready_budget_s)
+                    return 3
+
+            # 3. CONNECT + 4. VALIDATION EXCHANGE.
+            _log("connecting DistributedEventBus client over mTLS -> %s" % url)
+            if self._run_exchange is not None:
+                result = await self._run_exchange()
+            else:
+                result = await self._default_run_exchange(url)
+            proven = bool(result.get("proven"))
+            _log("ACCEPTANCE %s: %r" % ("PROVEN" if proven else "NOT PROVEN", result))
+            return 0 if proven else 4
+
+        except Exception as exc:  # noqa: BLE001
+            _log("run error: %r -- teardown will reap" % (exc,))
+            return 1
+        finally:
+            # 5. TEARDOWN on EVERY exit path (idempotent; also armed on
+            # signal/atexit). Reap first, then verify $0.
+            await _reap_brain_resources_async(
+                close_firewall_fn=self._close_firewall,
+                delete_instance_fn=self._delete_instance,
+            )
+            verdict = await _teardown_verify(
+                persistent=self.persistent,
+                list_brain_fn=self._list_brain,
+                firewall_exists_fn=self._firewall_exists,
+                rule_name=self.fw_rule_name,
+            )
+            if verdict["zero_cost"]:
+                _log("TEARDOWN VERIFY: $0 -- no brain instance / firewall remain")
+            else:
+                _log("TEARDOWN VERIFY: NON-$0 -- leaked=%r" % (verdict["leaked"],))
+
+
+# ---------------------------------------------------------------------------
+# Runtime startup script (thin provisioning glue Task 4 owns): repopulate
+# /etc/jarvis/brain.env from THIS instance's metadata, create the /run/jarvis
+# runtime dir + liveness marker (the deferred Task-1 coupling), and (re)start the
+# baked brain unit so it picks up the fresh env.
+# ---------------------------------------------------------------------------
+
+
+def _brain_runtime_startup_script() -> str:
+    """Minimal boot glue for the golden-image runtime boot. The image already has
+    the ``jarvis-brain.service`` units baked+enabled; this only (a) writes
+    /etc/jarvis/brain.env from the runtime ``brain-env`` metadata, (b) ensures
+    /run/jarvis exists + touches the liveness marker so the idle-check never nukes
+    a freshly-booted node, and (c) restarts the unit to apply the fresh env.
+    ASCII-only. Kept tiny + idempotent (Mandate 3: no new provisioning framework)."""
+    return (
+        "#!/usr/bin/env bash\n"
+        "set -uo pipefail\n"
+        "mkdir -p /etc/jarvis /run/jarvis\n"
+        "curl -fsS -H 'Metadata-Flavor: Google' "
+        "'http://metadata.google.internal/computeMetadata/v1/instance/attributes/brain-env' "
+        "-o /etc/jarvis/brain.env || : > /etc/jarvis/brain.env\n"
+        "touch /run/jarvis/brain_liveness\n"
+        "systemctl daemon-reload || true\n"
+        "systemctl restart jarvis-brain.service || systemctl start jarvis-brain.service || true\n"
+        "systemctl start jarvis-brain-idle.timer || true\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="ignite_brain_vm.py",
+        description=(
+            "Stage-1 Brain-VM ignition driver + cross-host acceptance harness. "
+            "Provisions (or reuses) the CPU Brain VM, opens an ephemeral /32 mTLS "
+            "firewall for this Mac, connects the Stage-0 WS bus, runs the "
+            "bidirectional + Last-Event-ID-replay acceptance exchange, and tears "
+            "everything down ($0-orphan guarantee) on every exit path."
+        ),
+    )
+    p.add_argument(
+        "--persistent", action="store_true", default=None,
+        help="Keep the Brain VM as a warm standby (default: env "
+             "JARVIS_BRAIN_VM_PERSISTENT, else on-demand-per-session).",
+    )
+    p.add_argument(
+        "--node-name", default=None,
+        help="Brain node name (default: env JARVIS_BRAIN_VM_NODE_NAME or "
+             "jarvis-brain-<stamp>).",
+    )
+    p.add_argument(
+        "--exchange-n", type=int, default=None,
+        help="Events per acceptance direction (default: env JARVIS_BRAIN_EXCHANGE_N "
+             "or 5).",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the ignition plan and exit -- touches no GCP.",
+    )
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    _install_teardown_signal_handlers()
+    # Process-exit safety net in addition to run()'s finally + the signal
+    # handlers. Idempotent -> at most one real reap.
+    atexit.register(_reap_brain_resources)
+    driver = BrainIgnitionDriver(
+        persistent=args.persistent,
+        node_name=args.node_name,
+        exchange_n=args.exchange_n,
+        dry_run=args.dry_run,
+    )
+    return asyncio.run(driver.run())
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/governance/test_brain_discovery.py
+++ b/tests/governance/test_brain_discovery.py
@@ -1,0 +1,250 @@
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import brain_discovery
+
+
+# ---------------------------------------------------------------------------
+# Fake GCE instance dicts (aggregatedList item shape) -- NO live GCP.
+# ---------------------------------------------------------------------------
+
+
+def _brain_instance(*, name, external, internal, status="RUNNING"):
+    nics = [{"networkIP": internal}]
+    if external:
+        nics[0]["accessConfigs"] = [{"natIP": external}]
+    return {
+        "name": name,
+        "status": status,
+        "labels": {"jarvis-role": "brain"},
+        "networkInterfaces": nics,
+    }
+
+
+def _non_brain_instance(*, name, external, internal):
+    return {
+        "name": name,
+        "status": "RUNNING",
+        "labels": {"jarvis-role": "l4-jprime"},
+        "networkInterfaces": [
+            {"networkIP": internal, "accessConfigs": [{"natIP": external}]}
+        ],
+    }
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# (a) discover returns the raced-first-healthy WS URL
+# ---------------------------------------------------------------------------
+
+
+def test_discover_returns_raced_first_healthy(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PATH", "/ws/trinity-bus")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
+
+    instances = [_brain_instance(name="brain-1", external="203.0.113.9", internal="10.0.0.9")]
+
+    async def fake_list():
+        return instances
+
+    async def fake_race(candidates, probe_fn):
+        # racer binds the FIRST candidate (external natIP first).
+        return candidates[0]
+
+    async def always_healthy(url):
+        return True
+
+    url = _run(
+        brain_discovery.discover_brain_endpoint(
+            list_instances_fn=fake_list,
+            probe_fn=always_healthy,
+            race_fn=fake_race,
+        )
+    )
+    assert url == "wss://203.0.113.9:8443/ws/trinity-bus"
+
+
+# ---------------------------------------------------------------------------
+# (b) the jarvis-role=brain label filter excludes non-brain instances
+# ---------------------------------------------------------------------------
+
+
+def test_label_filter_excludes_non_brain(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PATH", "/ws/trinity-bus")
+
+    # The real list method filters server + client side; here the fake list
+    # returns ONLY brain instances (mirroring list_instances_by_label's
+    # contract), and we additionally prove a non-brain candidate never becomes
+    # a URL by feeding a mixed list straight to the candidate builder.
+    mixed = [
+        _brain_instance(name="brain-1", external="203.0.113.10", internal="10.0.0.10"),
+        _non_brain_instance(name="jprime-1", external="203.0.113.11", internal="10.0.0.11"),
+    ]
+    cfg = brain_discovery._brain_transport_config()
+    urls = brain_discovery._candidate_urls(
+        [i for i in mixed if i.get("labels", {}).get("jarvis-role") == "brain"], cfg
+    )
+    assert any("203.0.113.10" in u for u in urls)
+    assert all("203.0.113.11" not in u for u in urls)
+
+
+# ---------------------------------------------------------------------------
+# (c) re-invoking discover re-lists + re-races (statelessness -- no cached IP)
+# ---------------------------------------------------------------------------
+
+
+def test_discover_is_stateless_relists_and_reraces(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PATH", "/ws/trinity-bus")
+
+    calls = {"list": 0, "race": 0}
+
+    # The brain moves IPs between reconnects -> discover must observe the NEW ip.
+    ip_sequence = ["203.0.113.20", "203.0.113.21"]
+
+    async def fake_list():
+        idx = calls["list"]
+        calls["list"] += 1
+        return [_brain_instance(name="brain-1", external=ip_sequence[idx], internal="10.0.0.9")]
+
+    async def fake_race(candidates, probe_fn):
+        calls["race"] += 1
+        return candidates[0]
+
+    async def healthy(url):
+        return True
+
+    u1 = _run(brain_discovery.discover_brain_endpoint(list_instances_fn=fake_list, probe_fn=healthy, race_fn=fake_race))
+    u2 = _run(brain_discovery.discover_brain_endpoint(list_instances_fn=fake_list, probe_fn=healthy, race_fn=fake_race))
+
+    assert calls["list"] == 2 and calls["race"] == 2  # re-listed + re-raced
+    assert u1 == "wss://203.0.113.20:8443/ws/trinity-bus"
+    assert u2 == "wss://203.0.113.21:8443/ws/trinity-bus"  # NEW ip, no cache
+
+
+# ---------------------------------------------------------------------------
+# (d) discover returns None + does not raise when no healthy brain
+# ---------------------------------------------------------------------------
+
+
+def test_discover_none_when_no_healthy_brain(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+
+    async def empty_list():
+        return []
+
+    async def race_none(candidates, probe_fn):
+        return None
+
+    async def unhealthy(url):
+        return False
+
+    # No instances at all -> None.
+    assert _run(brain_discovery.discover_brain_endpoint(list_instances_fn=empty_list, race_fn=race_none, probe_fn=unhealthy)) is None
+
+    # Instances present but none healthy (racer returns None) -> None.
+    async def one_list():
+        return [_brain_instance(name="brain-1", external="203.0.113.30", internal="10.0.0.9")]
+
+    assert _run(brain_discovery.discover_brain_endpoint(list_instances_fn=one_list, race_fn=race_none, probe_fn=unhealthy)) is None
+
+
+def test_discover_failsoft_when_list_raises(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+
+    async def boom_list():
+        raise RuntimeError("gcp exploded")
+
+    # Must NOT propagate into the caller.
+    assert _run(brain_discovery.discover_brain_endpoint(list_instances_fn=boom_list)) is None
+
+
+# ---------------------------------------------------------------------------
+# (e) firewall wrappers use the /32 source from resolve_local_public_ip + env rule
+# ---------------------------------------------------------------------------
+
+
+def test_open_firewall_uses_resolved_ip_and_env_rule(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_FIREWALL_RULE_NAME", "jarvis-brain-mtls-testrule")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+
+    seen = {}
+
+    async def fake_resolve():
+        return "198.51.100.7"
+
+    async def fake_create(*, name, source_ip, port):
+        seen.update({"name": name, "source_ip": source_ip, "port": port})
+        return (True, "created:200")
+
+    ok, detail = _run(
+        brain_discovery.open_brain_firewall(
+            resolve_ip_fn=fake_resolve, create_fn=fake_create
+        )
+    )
+    assert ok
+    assert seen["name"] == "jarvis-brain-mtls-testrule"
+    assert seen["source_ip"] == "198.51.100.7"  # /32 applied inside create_firewall_rule
+    assert seen["port"] == 8443
+
+
+def test_open_firewall_refuses_when_no_ip(monkeypatch):
+    async def no_ip():
+        return None
+
+    called = {"create": False}
+
+    async def fake_create(**kwargs):
+        called["create"] = True
+        return (True, "x")
+
+    ok, detail = _run(brain_discovery.open_brain_firewall(resolve_ip_fn=no_ip, create_fn=fake_create))
+    assert not ok
+    assert called["create"] is False  # never open the port without a source IP
+
+
+def test_close_firewall_deletes_env_rule(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_FIREWALL_RULE_NAME", "jarvis-brain-mtls-closeme")
+    seen = {}
+
+    async def fake_delete(name):
+        seen["name"] = name
+        return (True, "deleted:404")
+
+    ok, _ = _run(brain_discovery.close_brain_firewall(delete_fn=fake_delete))
+    assert ok
+    assert seen["name"] == "jarvis-brain-mtls-closeme"
+
+
+# ---------------------------------------------------------------------------
+# (f) the no-hardcoded-endpoint invariant now covers brain_discovery.py
+# ---------------------------------------------------------------------------
+
+
+def test_no_hardcoded_endpoint_invariant_covers_brain_discovery(monkeypatch):
+    monkeypatch.setenv("JARVIS_SHIPPED_CODE_INVARIANTS_ENABLED", "true")
+    from backend.core.ouroboros.governance.meta import shipped_code_invariants as sci
+
+    names = {inv.invariant_name for inv in sci.list_shipped_code_invariants()}
+    assert "brain_discovery_no_hardcoded_endpoints" in names
+
+    targets = {
+        inv.target_file
+        for inv in sci.list_shipped_code_invariants()
+        if inv.invariant_name == "brain_discovery_no_hardcoded_endpoints"
+    }
+    assert any("brain_discovery.py" in t for t in targets)
+
+    # The shipped brain_discovery.py must have ZERO hardcoded endpoint literals.
+    violations = [
+        v for v in sci.validate_all() if v.target_file.endswith("brain_discovery.py")
+    ]
+    assert violations == [], violations

--- a/tests/governance/test_brain_node_spec.py
+++ b/tests/governance/test_brain_node_spec.py
@@ -1,0 +1,205 @@
+"""Stage-1 Brain-VM spec tests (Task 2).
+
+The CPU Brain VM is a SPEC VARIANT of the existing J-Prime insert -- NOT a
+parallel provisioning path. These tests pin the spec-dict contract:
+
+  * machine type / image family / Spot / idle-shutdown all env-resolved at call
+    time (Mandate 2 -- Architectural Purity; zero baked assumptions),
+  * CPU-only: the payload carries NO ``guestAccelerators`` (Mandate 4 --
+    Bulletproof; no accidental GPU spend),
+  * ``labels[jarvis-role] == brain`` for the Stage-1 discovery filter (Task 3),
+  * the ``brain-env`` metadata item carries the idle-shutdown seconds (the
+    Task-1 bake reads instance-metadata key ``brain-env`` -> /etc/jarvis/brain.env),
+  * the existing ``_build_insert_payload`` stays BYTE-IDENTICAL when the new
+    ``labels`` / ``extra_metadata`` params are None (backward-compat pin --
+    every existing L4/J-Prime caller is unchanged).
+
+No live GCP: these operate purely on the constructed spec dict.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.gcp_compute_rest import (
+    GCPComputeRest,
+    _brain_idle_shutdown_s,
+    _brain_persistent,
+    _brain_spot,
+)
+
+
+# Fixed identity args -- the Brain node still resolves zone/project dynamically
+# in create_instance; the spec builder just needs them threaded for the URL.
+_NAME = "jarvis-brain"
+_ZONE = "us-central1-a"
+_PROJECT = "test-project"
+
+
+def _client() -> GCPComputeRest:
+    return GCPComputeRest(project=_PROJECT, zone=_ZONE)
+
+
+def _brain_payload(client: GCPComputeRest):
+    return client.build_brain_insert_payload(
+        name=_NAME, zone=_ZONE, project=_PROJECT, startup_script="echo brain",
+    )
+
+
+# -- (a) machine type env-driven (varied across 2 settings, not a literal) ----
+
+@pytest.mark.parametrize("machine_type", ["e2-highmem-4", "n2-highmem-8"])
+def test_brain_machine_type_from_env(monkeypatch, machine_type):
+    monkeypatch.setenv("JARVIS_BRAIN_VM_MACHINE_TYPE", machine_type)
+    payload = _brain_payload(_client())
+    assert payload["machineType"] == "zones/{}/machineTypes/{}".format(_ZONE, machine_type)
+
+
+# -- (b) NO guestAccelerators -- no accidental GPU spend ----------------------
+
+def test_brain_payload_has_no_accelerator(monkeypatch):
+    monkeypatch.delenv("JARVIS_BRAIN_VM_MACHINE_TYPE", raising=False)
+    payload = _brain_payload(_client())
+    assert "guestAccelerators" not in payload
+
+
+# -- (c) labels[jarvis-role] == brain -----------------------------------------
+
+def test_brain_payload_role_label(monkeypatch):
+    payload = _brain_payload(_client())
+    assert payload["labels"]["jarvis-role"] == "brain"
+
+
+# -- (d) image family from env ------------------------------------------------
+
+@pytest.mark.parametrize("image_family", ["jarvis-brain-golden", "jarvis-brain-golden-20260704"])
+def test_brain_image_family_from_env(monkeypatch, image_family):
+    monkeypatch.setenv("JARVIS_BRAIN_VM_IMAGE_FAMILY", image_family)
+    payload = _brain_payload(_client())
+    src = payload["disks"][0]["initializeParams"]["sourceImage"]
+    assert src == "projects/{}/global/images/family/{}".format(_PROJECT, image_family)
+
+
+# -- (e) idle-shutdown metadata item present with env value -------------------
+
+@pytest.mark.parametrize("idle_s", ["1800", "600"])
+def test_brain_idle_shutdown_metadata_item(monkeypatch, idle_s):
+    monkeypatch.setenv("JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S", idle_s)
+    payload = _brain_payload(_client())
+    items = payload["metadata"]["items"]
+    brain_env = [it for it in items if it["key"] == "brain-env"]
+    assert len(brain_env) == 1, "brain-env metadata item must be present"
+    assert "JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S={}".format(idle_s) in brain_env[0]["value"]
+    # startup-script item is still first / preserved (backward-compat within items).
+    assert items[0]["key"] == "startup-script"
+
+
+def test_brain_env_folds_ignition_values(monkeypatch):
+    """Task-4's ignition tokens/endpoints fold into the brain.env body via the
+    same metadata mechanism (the plumbing this task installs)."""
+    monkeypatch.setenv("JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S", "1800")
+    payload = _client().build_brain_insert_payload(
+        name=_NAME, zone=_ZONE, project=_PROJECT, startup_script="echo brain",
+        brain_env_values={"JARVIS_WS_ENDPOINT": "wss://brain:8443", "JARVIS_TOKEN": "abc"},
+    )
+    body = [it for it in payload["metadata"]["items"] if it["key"] == "brain-env"][0]["value"]
+    assert "JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S=1800" in body
+    assert "JARVIS_WS_ENDPOINT=wss://brain:8443" in body
+    assert "JARVIS_TOKEN=abc" in body
+
+
+# -- (f) backward-compat pin: labels/extra_metadata None == pre-change payload -
+
+def test_build_insert_payload_none_path_byte_identical(monkeypatch):
+    """The pre-existing callers (L4 / J-Prime) pass neither labels nor
+    extra_metadata. Adding those params (default None) MUST leave the payload
+    byte-identical to what it produced before this change. Expected dict is
+    constructed explicitly (not by calling the same function twice)."""
+    # Omit diskType so the expected dict has no boot-disk field (deterministic).
+    monkeypatch.setenv("JARVIS_FAILOVER_BOOT_DISK_TYPE", "")
+    client = _client()
+    got = client._build_insert_payload(
+        name="n", zone="z", project="p", machine_type="mt",
+        image_family="fam", startup_script="echo hi", spot=False,
+        labels=None, extra_metadata=None,
+    )
+    expected = {
+        "name": "n",
+        "machineType": "zones/z/machineTypes/mt",
+        "disks": [
+            {
+                "boot": True,
+                "autoDelete": True,
+                "initializeParams": {
+                    "sourceImage": "projects/p/global/images/family/fam",
+                },
+            }
+        ],
+        "networkInterfaces": [
+            {
+                "network": "global/networks/default",
+                "accessConfigs": [
+                    {"type": "ONE_TO_ONE_NAT", "name": "External NAT"}
+                ],
+            }
+        ],
+        "serviceAccounts": [
+            {
+                "email": "default",
+                "scopes": ["https://www.googleapis.com/auth/cloud-platform"],
+            }
+        ],
+        "metadata": {
+            "items": [
+                {"key": "startup-script", "value": "echo hi"},
+            ]
+        },
+    }
+    assert got == expected
+    assert "labels" not in got
+
+
+def test_build_insert_payload_labels_only_when_provided(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAILOVER_BOOT_DISK_TYPE", "")
+    client = _client()
+    got = client._build_insert_payload(
+        name="n", zone="z", project="p", machine_type="mt",
+        image_family="fam", startup_script="echo hi", spot=False,
+        labels={"jarvis-role": "brain"},
+    )
+    assert got["labels"] == {"jarvis-role": "brain"}
+    # extra_metadata None -> only the startup-script item.
+    assert got["metadata"]["items"] == [{"key": "startup-script", "value": "echo hi"}]
+
+
+# -- (g) persistent / spot accessors read env at CALL time --------------------
+
+def test_brain_persistent_accessor_reads_env_at_call_time(monkeypatch):
+    monkeypatch.delenv("JARVIS_BRAIN_VM_PERSISTENT", raising=False)
+    assert _brain_persistent() is False  # default false
+    monkeypatch.setenv("JARVIS_BRAIN_VM_PERSISTENT", "true")
+    assert _brain_persistent() is True
+    monkeypatch.setenv("JARVIS_BRAIN_VM_PERSISTENT", "0")
+    assert _brain_persistent() is False
+
+
+def test_brain_spot_accessor_reads_env_at_call_time(monkeypatch):
+    monkeypatch.delenv("JARVIS_BRAIN_VM_SPOT", raising=False)
+    assert _brain_spot() is True  # default true (Spot is cheap)
+    monkeypatch.setenv("JARVIS_BRAIN_VM_SPOT", "false")
+    assert _brain_spot() is False
+
+
+def test_brain_idle_shutdown_accessor_reads_env_at_call_time(monkeypatch):
+    monkeypatch.delenv("JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S", raising=False)
+    assert _brain_idle_shutdown_s() == 1800  # default
+    monkeypatch.setenv("JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S", "600")
+    assert _brain_idle_shutdown_s() == 600
+
+
+def test_brain_spot_reflected_in_payload_scheduling(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_VM_SPOT", "true")
+    payload = _brain_payload(_client())
+    assert payload["scheduling"]["provisioningModel"] == "SPOT"
+    monkeypatch.setenv("JARVIS_BRAIN_VM_SPOT", "false")
+    payload = _brain_payload(_client())
+    assert "scheduling" not in payload  # on-demand -> no Spot scheduling block

--- a/tests/governance/test_gcp_compute_rest.py
+++ b/tests/governance/test_gcp_compute_rest.py
@@ -411,3 +411,158 @@ async def test_identity_is_fully_dynamic_from_metadata(http):
     post = [call for call in http.calls if call["method"] == "POST"][0]
     assert "asia-northeast1-c" in post["url"]
     assert "another-project" in post["url"]
+
+
+# ---------------------------------------------------------------------------
+# list_instances_by_label -- the Stage-1 Brain discovery seam (Task 3).
+# Direct coverage of the real REST method (pagination, filter URL, client-side
+# label re-check, fail-soft) mocking _http_request per the file convention.
+# ---------------------------------------------------------------------------
+
+
+def _adc_off(monkeypatch):
+    """Campaign convention: force metadata identity, no ADC / SA credential
+    resolution leaking real cloud auth into the unit test."""
+    monkeypatch.setenv("JARVIS_FAILOVER_USE_ADC", "false")
+    monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", "")
+    for var in ("GCP_PROJECT_ID", "GOOGLE_CLOUD_PROJECT", "GCP_ZONE"):
+        monkeypatch.delenv(var, raising=False)
+
+
+def _brain_agg_fake(pages):
+    """Route metadata token/project + serve scripted aggregatedList pages in
+    order. Records every aggregated/instances URL seen. `pages` is a list of
+    (status, text) returned on successive aggregatedList GETs."""
+    seen = {"urls": []}
+
+    async def fake(url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        if "metadata.google.internal" in url:
+            if url.endswith("/token"):
+                return (200, json.dumps({"access_token": "ya29.FAKE", "expires_in": 3599}))
+            if url.endswith("project/project-id"):
+                return (200, "my-test-project")
+            if url.endswith("/scopes"):
+                return (200, "https://www.googleapis.com/auth/cloud-platform")
+            if url.endswith("instance/zone"):
+                return (200, "projects/9/zones/us-west2-b")
+            return (404, "")
+        if "aggregated/instances" in url:
+            seen["urls"].append(url)
+            idx = len(seen["urls"]) - 1
+            return pages[min(idx, len(pages) - 1)]
+        return (0, "[unrouted]")
+
+    return fake, seen
+
+
+async def test_list_instances_by_label_paginates(monkeypatch):
+    _adc_off(monkeypatch)
+    page1 = (200, json.dumps({
+        "items": {"zones/us-west2-b": {"instances": [
+            {"name": "brain-1", "status": "RUNNING", "labels": {"jarvis-role": "brain"}},
+        ]}},
+        "nextPageToken": "TOKEN_ABC",
+    }))
+    page2 = (200, json.dumps({
+        "items": {"zones/us-east1-c": {"instances": [
+            {"name": "brain-2", "status": "RUNNING", "labels": {"jarvis-role": "brain"}},
+        ]}},
+        # no nextPageToken -> terminal
+    }))
+    fake, seen = _brain_agg_fake([page1, page2])
+    monkeypatch.setattr(gr, "_http_request", fake)
+
+    c = GCPComputeRest()
+    out = await c.list_instances_by_label(label_key="jarvis-role", label_value="brain")
+
+    # BOTH pages' instances collected.
+    assert sorted(i["name"] for i in out) == ["brain-1", "brain-2"]
+    # Exactly two aggregatedList calls (the nextPageToken loop).
+    assert len(seen["urls"]) == 2
+    # Token threaded into the 2nd URL only.
+    assert "pageToken" not in seen["urls"][0]
+    assert "pageToken=TOKEN_ABC" in seen["urls"][1]
+
+
+async def test_list_instances_by_label_client_side_label_recheck(monkeypatch):
+    _adc_off(monkeypatch)
+    # Server filter "bypassed" (stale/mislabelled rows returned): the client-side
+    # labels.get(key)==value re-check must EXCLUDE the non-brain + label-less rows.
+    page = (200, json.dumps({
+        "items": {"zones/us-west2-b": {"instances": [
+            {"name": "brain-ok", "status": "RUNNING", "labels": {"jarvis-role": "brain"}},
+            {"name": "stale-jprime", "status": "RUNNING", "labels": {"jarvis-role": "l4-jprime"}},
+            {"name": "nolabels", "status": "RUNNING"},
+        ]}},
+    }))
+    fake, seen = _brain_agg_fake([page])
+    monkeypatch.setattr(gr, "_http_request", fake)
+
+    c = GCPComputeRest()
+    out = await c.list_instances_by_label(label_key="jarvis-role", label_value="brain")
+
+    assert [i["name"] for i in out] == ["brain-ok"]
+
+
+async def test_list_instances_by_label_filter_url_encoding(monkeypatch):
+    _adc_off(monkeypatch)
+    fake, seen = _brain_agg_fake([(200, json.dumps({"items": {}}))])
+    monkeypatch.setattr(gr, "_http_request", fake)
+
+    c = GCPComputeRest()
+    out = await c.list_instances_by_label(label_key="jarvis-role", label_value="brain")
+
+    assert out == []  # empty items -> empty result
+    assert len(seen["urls"]) == 1
+    url = seen["urls"][0]
+    assert "aggregated/instances" in url
+    assert "my-test-project" in url  # project from metadata (no hardcoding)
+    assert "filter=" in url
+    # labels.<key>=<value> encoded correctly (= -> %3D under urllib.parse.quote).
+    from urllib.parse import unquote
+    assert "labels.jarvis-role=brain" in unquote(url)
+
+
+async def test_list_instances_by_label_failsoft_on_raise(monkeypatch):
+    _adc_off(monkeypatch)
+
+    async def fake(url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        if "metadata.google.internal" in url:
+            if url.endswith("/token"):
+                return (200, json.dumps({"access_token": "ya29.FAKE", "expires_in": 3599}))
+            if url.endswith("project/project-id"):
+                return (200, "my-test-project")
+            return (404, "")
+        if "aggregated/instances" in url:
+            raise RuntimeError("network down")
+        return (0, "")
+
+    monkeypatch.setattr(gr, "_http_request", fake)
+    c = GCPComputeRest()
+    out = await c.list_instances_by_label(label_key="jarvis-role", label_value="brain")
+    assert out == []  # raise absorbed -> [], never propagated
+
+
+async def test_list_instances_by_label_failsoft_on_non_200(monkeypatch):
+    _adc_off(monkeypatch)
+    fake, seen = _brain_agg_fake([(503, "backend error")])
+    monkeypatch.setattr(gr, "_http_request", fake)
+
+    c = GCPComputeRest()
+    out = await c.list_instances_by_label(label_key="jarvis-role", label_value="brain")
+    assert out == []  # non-2xx -> break -> []
+    assert len(seen["urls"]) == 1
+
+
+async def test_list_instances_by_label_no_token_fails_soft(monkeypatch):
+    _adc_off(monkeypatch)
+
+    async def no_token(url, *, method="GET", headers=None, body=None, timeout_s=10.0):
+        if "metadata.google.internal" in url:
+            return (0, "")  # token + project unresolved
+        return (0, "")
+
+    monkeypatch.setattr(gr, "_http_request", no_token)
+    c = GCPComputeRest()
+    out = await c.list_instances_by_label(label_key="jarvis-role", label_value="brain")
+    assert out == []  # no auth -> [] before any aggregatedList call

--- a/tests/infra/test_brain_bake_script.py
+++ b/tests/infra/test_brain_bake_script.py
@@ -1,0 +1,190 @@
+# -*- coding: utf-8 -*-
+"""Pure-logic unit tests for scripts/bake_brain_golden_image.py.
+
+UNIT ONLY -- zero live GCP. Every assertion is on the generated startup-script
+STRING (pure string assembly, no I/O) plus a shared-helper identity smoke.
+
+The CPU brain image is the image the GCP Brain VM boots from (spec:
+docs/superpowers/specs/2026-07-03-gcp-orchestrator-relocation-design.md). It
+differs from the J-Prime code-model image: NO Ollama / NO NVIDIA / NO model
+pull -- just base image + python3.11 + git + a repo clone at the IsomorphicEnv
+canonical path /opt/trinity/jarvis + the headless battle-test warm-standby unit.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = (
+    Path(__file__).resolve().parents[2] / "scripts" / "bake_brain_golden_image.py"
+)
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location("bake_brain_golden_image", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def bake():
+    return _load_module()
+
+
+# --------------------------------------------------------------------------- #
+# (a) clone target is /opt/trinity/jarvis with the repo URL from the env var
+#     (NOT a hardcoded literal URL).
+# --------------------------------------------------------------------------- #
+def test_clone_target_is_opt_trinity_with_repo_url_from_arg(bake):
+    url = "https://example.invalid/some/brain-repo.git"
+    script = bake.build_startup_script(url, repo_ref="feature/x")
+    # The clone must target the IsomorphicEnv canonical path.
+    assert "/opt/trinity/jarvis" in script
+    # git clone of the supplied URL into that path.
+    assert "git clone" in script
+    assert url in script
+    # ref is substituted (not hardcoded 'main').
+    assert "feature/x" in script
+
+
+def test_repo_url_is_not_a_hardcoded_literal_in_module(bake):
+    """A caller-less default URL must never be baked into the module source."""
+    src = _SCRIPT.read_text(encoding="utf-8")
+    # No github.com / drussell23 repo literal anywhere in the script source.
+    assert "github.com/drussell23" not in src
+    assert "JARVIS-AI-Agent.git" not in src
+    # The default is env-resolved, empty when unset.
+    assert 'os.environ.get("JARVIS_BRAIN_REPO_URL"' in src
+
+
+# --------------------------------------------------------------------------- #
+# (b) NO ollama / nvidia / accelerator tokens anywhere in the CPU image.
+# --------------------------------------------------------------------------- #
+def test_no_ollama_no_nvidia_no_accelerator_tokens(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    low = script.lower()
+    for forbidden in ("ollama", "nvidia", "accelerator", "gpu", "cuda", "vram"):
+        assert forbidden not in low, f"CPU brain image must not mention {forbidden!r}"
+
+
+# --------------------------------------------------------------------------- #
+# (c) systemd unit runs the headless battle-test cmd + --max-wall-seconds 0 +
+#     EnvironmentFile=/etc/jarvis/brain.env.
+# --------------------------------------------------------------------------- #
+def test_systemd_unit_headless_battle_test_warm_standby(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert "jarvis-brain.service" in script
+    assert "scripts/ouroboros_battle_test.py" in script
+    assert "--production-soak" in script
+    assert "--headless" in script
+    assert "--cost-cap" in script
+    # warm standby -> no wall clock cap.
+    assert "--max-wall-seconds 0" in script
+    assert "EnvironmentFile=/etc/jarvis/brain.env" in script
+    assert "WorkingDirectory=/opt/trinity/jarvis" in script
+
+
+def test_cost_cap_is_env_resolved_not_a_literal(bake):
+    """cost-cap must come from the env file, never a baked literal number."""
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    # A shell/systemd variable reference resolved from EnvironmentFile.
+    assert "--cost-cap ${JARVIS_BRAIN_COST_CAP}" in script
+
+
+# --------------------------------------------------------------------------- #
+# (d) brain.env is written from instance metadata BEFORE the unit starts.
+# --------------------------------------------------------------------------- #
+def test_brain_env_written_from_metadata_before_unit_starts(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert "/etc/jarvis/brain.env" in script
+    # Instance-metadata read (the J-Prime metadata pattern).
+    assert "metadata.google.internal" in script
+    assert "Metadata-Flavor: Google" in script
+    # The metadata read must precede the point where the unit is enabled.
+    # (We `enable` -- not `--now` -- during the bake: the enabled-state is baked
+    # into the image so the unit auto-starts on the real Brain VM boot; we never
+    # run the paid soak on the ephemeral bake node.)
+    meta_idx = script.index("metadata.google.internal")
+    start_idx = script.index("systemctl enable jarvis-brain.service")
+    assert meta_idx < start_idx, "brain.env must be populated from metadata before the unit is enabled"
+
+
+# --------------------------------------------------------------------------- #
+# (e) the sentinel write appears AFTER both the .git-exists check and the
+#     transport-import check (sentinel-after-proof, never a fixed sleep).
+# --------------------------------------------------------------------------- #
+def test_sentinel_written_only_after_git_and_transport_proof(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    git_check_idx = script.index("/opt/trinity/jarvis/.git")
+    transport_idx = script.index("import backend.core.ouroboros.governance.transport")
+    sentinel_write_idx = script.index("> /var/run/jarvis_brain_ready")
+    assert git_check_idx < sentinel_write_idx, ".git check must precede the sentinel write"
+    assert transport_idx < sentinel_write_idx, "transport import must precede the sentinel write"
+    # A failed proof must NOT write the sentinel (fail-loud, exit 1).
+    assert "NOT writing sentinel" in script
+    # No fixed-sleep readiness lie.
+    assert "sleep 30\n" not in script
+
+
+# --------------------------------------------------------------------------- #
+# (f) idle-shutdown timeout is env-driven (from brain.env), never a literal.
+# --------------------------------------------------------------------------- #
+def test_idle_shutdown_timeout_is_env_driven(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    # The idle-shutdown threshold is read from brain.env's env var with a default.
+    assert "JARVIS_BRAIN_VM_IDLE_SHUTDOWN_S" in script
+    assert "jarvis-brain-idle" in script  # the timer/checker unit name
+
+
+# --------------------------------------------------------------------------- #
+# (g) whole startup script is ASCII-only.
+# --------------------------------------------------------------------------- #
+def test_startup_script_is_ascii(bake):
+    bake.build_startup_script("https://example.invalid/repo.git").encode("ascii")
+
+
+def test_startup_script_shebang_and_no_fixed_sleep_sentinel(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert script.startswith("#!")
+
+
+# --------------------------------------------------------------------------- #
+# Image name uses the shared stamp + the jarvis-brain-golden-<stamp> shape.
+# --------------------------------------------------------------------------- #
+def test_default_image_name_is_brain_golden_stamped(bake):
+    name = bake._default_image_name()
+    assert name.startswith("jarvis-brain-golden-")
+
+
+def test_no_literal_project_id_or_zone_in_module(bake):
+    """Mandate 2: no literal GCP project IDs / zones baked into the module."""
+    src = _SCRIPT.read_text(encoding="utf-8")
+    assert "jarvis-473803" not in src
+    assert "us-central1-a" not in src
+
+
+# --------------------------------------------------------------------------- #
+# Shared-helper identity smoke: parse_validation_verdict is THE J-Prime function
+# (imported, not reimplemented -- DRY mandate).
+# --------------------------------------------------------------------------- #
+def test_parse_validation_verdict_is_the_shared_jprime_function(bake):
+    import sys
+
+    # Import J-Prime through the SAME module-system path the brain script uses
+    # (`from bake_jprime_golden_image import ...`), so both resolve to the one
+    # sys.modules-cached object. A fresh spec_from_file_location exec would mint
+    # a *different* module object and mask a real duplication.
+    scripts_dir = str(Path(__file__).resolve().parents[2] / "scripts")
+    if scripts_dir not in sys.path:
+        sys.path.insert(0, scripts_dir)
+    import bake_jprime_golden_image as jprime
+
+    # Same function object -> proves it was imported, not duplicated.
+    assert bake.parse_validation_verdict is jprime.parse_validation_verdict
+    # And the other stable helpers are the shared ones too.
+    assert bake._run is jprime._run
+    assert bake._log is jprime._log
+    assert bake._now_stamp is jprime._now_stamp

--- a/tests/infra/test_ignite_brain_vm.py
+++ b/tests/infra/test_ignite_brain_vm.py
@@ -1,0 +1,420 @@
+"""Unit tests for scripts/ignite_brain_vm.py (Stage-1 Brain-VM ignition driver).
+
+NO live GCP -- every collaborator (create_instance / discover / firewall / delete
+/ list) is a fake injected via the driver's seams. The tests prove:
+
+  (a) PROVISION: reuse an existing brain when persistent+running; provision new
+      otherwise.
+  (b) TEARDOWN fires on the normal ``finally`` AND on a simulated SIGTERM AND on
+      an exception mid-run; the reaper is idempotent (called twice == one
+      effective delete).
+  (c) The VALIDATION EXCHANGE logic (the Stage-1 acceptance): bidirectional
+      observe + Last-Event-ID reconnect-replay-exact against a fake in-proc bus,
+      asserting zero gap / zero dup.
+  (d) Lifecycle: non-persistent => VM deleted; persistent => VM left running,
+      firewall still closed.
+  (e) The post-teardown $0 verify detects a leaked resource (injected) and
+      reports non-$0.
+
+These exercise the driver's exchange + provision + teardown LOGIC only; the live
+GCP provision/connect/teardown are proven in Task 5 (live-fire).
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(os.path.dirname(_HERE))
+_DRIVER_PATH = os.path.join(_REPO_ROOT, "scripts", "ignite_brain_vm.py")
+
+
+def _load_driver() -> Any:
+    """Load the ignition driver as a module by path (script, not a package)."""
+    if _REPO_ROOT not in sys.path:
+        sys.path.insert(0, _REPO_ROOT)
+    if "ignite_brain_vm" in sys.modules:
+        return sys.modules["ignite_brain_vm"]
+    spec = importlib.util.spec_from_file_location("ignite_brain_vm", _DRIVER_PATH)
+    assert spec and spec.loader, "cannot load ignite_brain_vm"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["ignite_brain_vm"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+ign = _load_driver()
+
+
+# ---------------------------------------------------------------------------
+# Fake in-proc bidirectional bus wire for the exchange-logic tests.
+# ---------------------------------------------------------------------------
+
+
+class _FakeWire:
+    """A shared monotonic event log linking two ``_FakeEndpoint``s. Publishing on
+    one endpoint delivers to the other with a contiguous hex event_id. Supports a
+    mid-stream sever + Last-Event-ID replay of exactly the missed contiguous span
+    (zero gap, zero dup) -- the cross-host Stage-0 guarantee, in-proc."""
+
+    def __init__(self) -> None:
+        self._seq = 0
+        self._log: List[Tuple[str, str, str]] = []  # (event_id, dst_name, op_id)
+        self.connected = True
+
+    def next_id(self) -> str:
+        self._seq += 1
+        return format(self._seq, "012x")
+
+
+class _FakeEndpoint:
+    def __init__(self, name: str, wire: _FakeWire, peer_name: str) -> None:
+        self.name = name
+        self._wire = wire
+        self._peer_name = peer_name
+        self._observed: List[Tuple[str, str]] = []  # (op_id, event_id)
+        self._last_event_id: Optional[str] = None
+        self._peer: Optional["_FakeEndpoint"] = None
+
+    def bind_peer(self, peer: "_FakeEndpoint") -> None:
+        self._peer = peer
+
+    @property
+    def last_event_id(self) -> Optional[str]:
+        return self._last_event_id
+
+    def observed(self) -> List[Tuple[str, str]]:
+        return list(self._observed)
+
+    def publish(self, event_type: str, op_id: str, payload: Dict[str, Any]) -> str:
+        event_id = self._wire.next_id()
+        self._wire._log.append((event_id, self._peer_name, op_id))
+        if self._wire.connected and self._peer is not None:
+            self._peer._deliver(event_id, op_id)
+        return event_id
+
+    def _deliver(self, event_id: str, op_id: str) -> None:
+        self._observed.append((op_id, event_id))
+        self._last_event_id = event_id
+
+    def replay_from(self, last_event_id: Optional[str]) -> None:
+        """Deliver every logged event destined for THIS endpoint whose id is
+        strictly greater than ``last_event_id`` -- exactly once, in order."""
+        floor = int(last_event_id, 16) if last_event_id else 0
+        for event_id, dst, op_id in self._wire._log:
+            if dst != self.name:
+                continue
+            if int(event_id, 16) <= floor:
+                continue
+            already = any(eid == event_id for _op, eid in self._observed)
+            if already:
+                continue
+            self._deliver(event_id, op_id)
+
+
+def _make_wire_pair() -> Tuple[_FakeEndpoint, _FakeEndpoint, _FakeWire]:
+    wire = _FakeWire()
+    mac = _FakeEndpoint("mac", wire, peer_name="brain")
+    brain = _FakeEndpoint("brain", wire, peer_name="mac")
+    mac.bind_peer(brain)
+    brain.bind_peer(mac)
+    return mac, brain, wire
+
+
+# ---------------------------------------------------------------------------
+# (c) Validation-exchange logic: bidirectional + reconnect-replay-exact.
+# ---------------------------------------------------------------------------
+
+
+def test_exchange_bidirectional_observes_both_directions() -> None:
+    mac, brain, _wire = _make_wire_pair()
+
+    async def _reconnect() -> Any:
+        return mac
+
+    exchange = ign.ValidationExchange(mac=mac, brain=brain, reconnect=_reconnect,
+                                      settle_s=0.0)
+    result = asyncio.run(exchange.run_bidirectional(n=4))
+
+    assert result["mac_to_brain"]["ok"] is True
+    assert result["brain_to_mac"]["ok"] is True
+    assert result["mac_to_brain"]["gap"] == [] and result["mac_to_brain"]["dup"] == []
+    assert result["brain_to_mac"]["gap"] == [] and result["brain_to_mac"]["dup"] == []
+
+
+def test_exchange_reconnect_replay_exact_zero_gap_zero_dup() -> None:
+    mac, brain, wire = _make_wire_pair()
+
+    async def _reconnect() -> Any:
+        # Stateless re-discovery: sever, then replay the missed span from the
+        # last acked id (exactly what a real reconnect's ``hello`` frame does).
+        wire.connected = False
+        last = mac.last_event_id
+        # Events published while severed are buffered in the wire log; the
+        # reconnect replays exactly the contiguous span > last acked id.
+        wire.connected = True
+        mac.replay_from(last)
+        return mac
+
+    exchange = ign.ValidationExchange(mac=mac, brain=brain, reconnect=_reconnect,
+                                      settle_s=0.0)
+    result = asyncio.run(exchange.run_reconnect_replay(n=3))
+
+    assert result["ok"] is True, result
+    assert result["gap"] == [], "replay left a gap: %r" % (result,)
+    assert result["dup"] == [], "replay duplicated an event: %r" % (result,)
+
+
+def test_exchange_reconnect_replay_detects_a_dropped_event() -> None:
+    """Negative control: if the wire silently drops an event across the sever
+    (no replay), the exchange MUST report a gap (proves the check has teeth)."""
+    mac, brain, wire = _make_wire_pair()
+
+    async def _reconnect() -> Any:
+        # Sever and DO NOT restore/replay: the post-sever span is delivered onto a
+        # dead link and never replayed -> a real gap the exchange must catch.
+        wire.connected = False
+        return mac
+
+    exchange = ign.ValidationExchange(mac=mac, brain=brain, reconnect=_reconnect,
+                                      settle_s=0.0)
+    result = asyncio.run(exchange.run_reconnect_replay(n=3))
+    assert result["ok"] is False
+    assert result["gap"], "a dropped span must surface as a gap"
+
+
+# ---------------------------------------------------------------------------
+# Fake GCP collaborators for the provision + teardown tests.
+# ---------------------------------------------------------------------------
+
+
+class _FakeGCP:
+    def __init__(self, *, existing_url: Optional[str] = None,
+                 leaked_instances: Optional[List[Dict[str, Any]]] = None,
+                 firewall_present: bool = False) -> None:
+        self.create_calls: List[Dict[str, Any]] = []
+        self.delete_calls: List[Tuple[str, Optional[str]]] = []
+        self.open_fw_calls = 0
+        self.close_fw_calls = 0
+        self._existing_url = existing_url
+        self._leaked_instances = leaked_instances or []
+        self._firewall_present = firewall_present
+        self.discover_count = 0
+
+    async def create_instance(self, **kwargs: Any) -> Tuple[bool, str]:
+        self.create_calls.append(kwargs)
+        return (True, "created:done")
+
+    async def discover(self, **kwargs: Any) -> Optional[str]:
+        self.discover_count += 1
+        # After a create, discovery resolves the freshly-provisioned URL.
+        if self._existing_url:
+            return self._existing_url
+        if self.create_calls:
+            return "wss://10.0.0.9:8443/ws/trinity-bus"
+        return None
+
+    async def open_firewall(self, *args: Any, **kwargs: Any) -> Tuple[bool, str]:
+        self.open_fw_calls += 1
+        return (True, "created:200")
+
+    async def close_firewall(self, *args: Any, **kwargs: Any) -> Tuple[bool, str]:
+        self.close_fw_calls += 1
+        self._firewall_present = False
+        return (True, "deleted:404")
+
+    async def delete_instance(self, name: Optional[str] = None,
+                              *, zone: Optional[str] = None) -> Tuple[bool, str]:
+        self.delete_calls.append((name or "", zone))
+        self._leaked_instances = []
+        return (True, "deleted:200")
+
+    async def list_brain(self) -> List[Dict[str, Any]]:
+        return list(self._leaked_instances)
+
+    async def firewall_exists(self, rule_name: str) -> bool:
+        return self._firewall_present
+
+
+def _driver(gcp: _FakeGCP, *, persistent: bool,
+            exchange_result: Optional[Dict[str, Any]] = None,
+            exchange_raises: bool = False) -> Any:
+    async def _run_exchange() -> Dict[str, Any]:
+        if exchange_raises:
+            raise RuntimeError("boom mid-exchange")
+        return exchange_result or {"proven": True}
+
+    return ign.BrainIgnitionDriver(
+        persistent=persistent,
+        create_instance_fn=gcp.create_instance,
+        discover_fn=gcp.discover,
+        open_firewall_fn=gcp.open_firewall,
+        close_firewall_fn=gcp.close_firewall,
+        delete_instance_fn=gcp.delete_instance,
+        list_brain_fn=gcp.list_brain,
+        firewall_exists_fn=gcp.firewall_exists,
+        run_exchange_fn=_run_exchange,
+        node_name="jarvis-brain-test",
+    )
+
+
+def _reset_registry() -> None:
+    ign._ACTIVE_BRAIN_RESOURCES.clear()
+
+
+# ---------------------------------------------------------------------------
+# (a) PROVISION: reuse when persistent+running; provision new otherwise.
+# ---------------------------------------------------------------------------
+
+
+def test_provision_reuses_existing_when_persistent_and_running() -> None:
+    _reset_registry()
+    gcp = _FakeGCP(existing_url="wss://10.0.0.5:8443/ws/trinity-bus")
+    drv = _driver(gcp, persistent=True)
+    rc = asyncio.run(drv.run())
+    assert rc == 0
+    assert gcp.create_calls == [], "must REUSE the running brain, not provision"
+
+
+def test_provision_creates_new_when_none_exists() -> None:
+    _reset_registry()
+    gcp = _FakeGCP(existing_url=None)
+    drv = _driver(gcp, persistent=False)
+    rc = asyncio.run(drv.run())
+    assert rc == 0
+    assert len(gcp.create_calls) == 1, "must provision a fresh brain"
+
+
+# ---------------------------------------------------------------------------
+# (d) Lifecycle: non-persistent => VM deleted; persistent => VM left running,
+#     firewall still closed.
+# ---------------------------------------------------------------------------
+
+
+def test_non_persistent_deletes_vm_and_closes_firewall() -> None:
+    _reset_registry()
+    gcp = _FakeGCP(existing_url=None)
+    drv = _driver(gcp, persistent=False)
+    asyncio.run(drv.run())
+    assert gcp.delete_calls, "non-persistent run must delete the VM"
+    assert gcp.close_fw_calls >= 1, "firewall must be closed"
+
+
+def test_persistent_leaves_vm_but_still_closes_firewall() -> None:
+    _reset_registry()
+    gcp = _FakeGCP(existing_url="wss://10.0.0.5:8443/ws/trinity-bus")
+    drv = _driver(gcp, persistent=True)
+    asyncio.run(drv.run())
+    assert gcp.delete_calls == [], "persistent run must LEAVE the VM running"
+    assert gcp.close_fw_calls >= 1, "firewall must be closed even when persistent"
+
+
+# ---------------------------------------------------------------------------
+# (b) TEARDOWN on finally / SIGTERM / exception; idempotent reaper.
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_fires_on_exception_midrun() -> None:
+    _reset_registry()
+    gcp = _FakeGCP(existing_url=None)
+    drv = _driver(gcp, persistent=False, exchange_raises=True)
+    rc = asyncio.run(drv.run())
+    assert rc != 0, "a mid-run exception must surface as a nonzero rc"
+    assert gcp.close_fw_calls >= 1, "firewall reaped even on exception"
+    assert gcp.delete_calls, "VM reaped even on exception"
+
+
+def test_reaper_is_idempotent_second_call_is_noop() -> None:
+    _reset_registry()
+    gcp = _FakeGCP(existing_url=None)
+    ign._register_brain_resource(node="jarvis-brain-test", fw_rule="jarvis-brain-mtls",
+                                 persistent=False)
+    asyncio.run(ign._reap_brain_resources_async(
+        close_firewall_fn=gcp.close_firewall,
+        delete_instance_fn=gcp.delete_instance,
+    ))
+    first_deletes = len(gcp.delete_calls)
+    first_closes = gcp.close_fw_calls
+    assert first_deletes >= 1 and first_closes >= 1
+    # Second reap: registry is drained -> no additional effect.
+    asyncio.run(ign._reap_brain_resources_async(
+        close_firewall_fn=gcp.close_firewall,
+        delete_instance_fn=gcp.delete_instance,
+    ))
+    assert len(gcp.delete_calls) == first_deletes, "second reap must be a no-op"
+    assert gcp.close_fw_calls == first_closes, "second reap must be a no-op"
+
+
+def test_signal_handler_reaps_registered_resources() -> None:
+    _reset_registry()
+    gcp = _FakeGCP(existing_url=None)
+    ign._register_brain_resource(node="jarvis-brain-test", fw_rule="jarvis-brain-mtls",
+                                 persistent=False)
+    # Point the module reaper at our fakes, then fire the SIGTERM handler body.
+    ign._set_reap_collaborators(close_firewall_fn=gcp.close_firewall,
+                                delete_instance_fn=gcp.delete_instance)
+    try:
+        ign._reap_brain_resources()  # sync wrapper the signal handler calls
+    finally:
+        ign._set_reap_collaborators(close_firewall_fn=None, delete_instance_fn=None)
+    assert gcp.close_fw_calls >= 1
+    assert gcp.delete_calls, "SIGTERM-path reap must delete the VM"
+    assert ign._ACTIVE_BRAIN_RESOURCES == [], "registry drained after reap"
+
+
+# ---------------------------------------------------------------------------
+# (e) Post-teardown $0 verify detects a leaked resource.
+# ---------------------------------------------------------------------------
+
+
+def test_teardown_verify_zero_cost_when_clean() -> None:
+    gcp = _FakeGCP(existing_url=None, leaked_instances=[], firewall_present=False)
+    verdict = asyncio.run(ign._teardown_verify(
+        persistent=False,
+        list_brain_fn=gcp.list_brain,
+        firewall_exists_fn=gcp.firewall_exists,
+        rule_name="jarvis-brain-mtls",
+    ))
+    assert verdict["zero_cost"] is True
+    assert verdict["leaked"] == []
+
+
+def test_teardown_verify_flags_leaked_instance_and_firewall() -> None:
+    gcp = _FakeGCP(
+        existing_url=None,
+        leaked_instances=[{"name": "jarvis-brain-test", "status": "RUNNING"}],
+        firewall_present=True,
+    )
+    verdict = asyncio.run(ign._teardown_verify(
+        persistent=False,
+        list_brain_fn=gcp.list_brain,
+        firewall_exists_fn=gcp.firewall_exists,
+        rule_name="jarvis-brain-mtls",
+    ))
+    assert verdict["zero_cost"] is False
+    assert any("instance:" in x for x in verdict["leaked"])
+    assert any("firewall:" in x for x in verdict["leaked"])
+
+
+def test_teardown_verify_ignores_instance_leak_when_persistent() -> None:
+    """A persistent run INTENDS to leave the VM running -- verify must not flag
+    the instance, but MUST still flag a leaked firewall."""
+    gcp = _FakeGCP(
+        existing_url=None,
+        leaked_instances=[{"name": "jarvis-brain-test", "status": "RUNNING"}],
+        firewall_present=True,
+    )
+    verdict = asyncio.run(ign._teardown_verify(
+        persistent=True,
+        list_brain_fn=gcp.list_brain,
+        firewall_exists_fn=gcp.firewall_exists,
+        rule_name="jarvis-brain-mtls",
+    ))
+    assert any("firewall:" in x for x in verdict["leaked"])
+    assert not any("instance:" in x for x in verdict["leaked"])
+    assert verdict["zero_cost"] is False  # firewall still leaked

--- a/tests/infra/test_ignite_brain_vm.py
+++ b/tests/infra/test_ignite_brain_vm.py
@@ -148,44 +148,232 @@ def test_exchange_bidirectional_observes_both_directions() -> None:
 
 
 def test_exchange_reconnect_replay_exact_zero_gap_zero_dup() -> None:
+    """Replay is LOAD-BEARING here: the post span is published WHILE SEVERED
+    (``connected=False`` -> buffered at the source, never delivered live), so the
+    only way those events reach the Mac is the reconnect's Last-Event-ID replay.
+    A no-op reconnect stub would leave a gap and fail (proven by the sibling
+    negative control below)."""
     mac, brain, wire = _make_wire_pair()
 
+    async def _sever() -> Any:
+        wire.connected = False  # drop the link BEFORE the post span is published
+
     async def _reconnect() -> Any:
-        # Stateless re-discovery: sever, then replay the missed span from the
-        # last acked id (exactly what a real reconnect's ``hello`` frame does).
-        wire.connected = False
-        last = mac.last_event_id
-        # Events published while severed are buffered in the wire log; the
-        # reconnect replays exactly the contiguous span > last acked id.
-        wire.connected = True
-        mac.replay_from(last)
+        # Stateless reconnect: replay exactly the contiguous span > last acked id
+        # (what a real reconnect's ``hello`` Last-Event-ID frame does). The link
+        # stays down for live delivery -- replay is the ONLY delivery route.
+        mac.replay_from(mac.last_event_id)
         return mac
 
     exchange = ign.ValidationExchange(mac=mac, brain=brain, reconnect=_reconnect,
-                                      settle_s=0.0)
+                                      sever=_sever, settle_s=0.0)
     result = asyncio.run(exchange.run_reconnect_replay(n=3))
 
     assert result["ok"] is True, result
+    assert result["observed"] == 6, "replay must deliver all pre+post: %r" % (result,)
     assert result["gap"] == [], "replay left a gap: %r" % (result,)
     assert result["dup"] == [], "replay duplicated an event: %r" % (result,)
 
 
 def test_exchange_reconnect_replay_detects_a_dropped_event() -> None:
-    """Negative control: if the wire silently drops an event across the sever
-    (no replay), the exchange MUST report a gap (proves the check has teeth)."""
+    """Negative control -- proves replay is the delivery route: the post span is
+    published WHILE SEVERED, and the reconnect does NOT replay. The buffered span
+    is therefore never delivered -> the exchange MUST report a gap (a no-op replay
+    stub cannot pass the positive test above)."""
     mac, brain, wire = _make_wire_pair()
 
-    async def _reconnect() -> Any:
-        # Sever and DO NOT restore/replay: the post-sever span is delivered onto a
-        # dead link and never replayed -> a real gap the exchange must catch.
+    async def _sever() -> Any:
         wire.connected = False
+
+    async def _reconnect() -> Any:
+        wire.connected = True  # link back up, but NO replay -> severed span is lost
         return mac
 
     exchange = ign.ValidationExchange(mac=mac, brain=brain, reconnect=_reconnect,
-                                      settle_s=0.0)
+                                      sever=_sever, settle_s=0.0)
     result = asyncio.run(exchange.run_reconnect_replay(n=3))
     assert result["ok"] is False
     assert result["gap"], "a dropped span must surface as a gap"
+
+
+def test_gap_dup_dup_side_has_teeth() -> None:
+    """The ``_gap_dup`` dup detector must flag a repeated event id (so a broken
+    replay that double-delivers cannot masquerade as success)."""
+    gap, dup = ign._gap_dup(["a", "b", "c"], ["a", "b", "b", "c"])
+    assert gap == []
+    assert dup == ["b"], "a repeated observed id must surface as a dup"
+
+
+def test_replay_dedup_drops_reoffered_already_seen_span() -> None:
+    """DUP negative control: re-offering an already-observed span (a redundant
+    replay) MUST be dropped by the endpoint's high-water / already-seen dedup --
+    zero duplicates surface. Proves the dedup logic has teeth, not just the
+    detector."""
+    mac, brain, _wire = _make_wire_pair()
+    eid = brain.publish("task_started", "op-dup-1", {})  # delivered live to mac
+    baseline = mac.observed()
+    assert baseline == [("op-dup-1", eid)]
+    # Re-offer the SAME logged span from the very start -> dedup drops it.
+    mac.replay_from(None)
+    mac.replay_from(None)
+    assert mac.observed() == baseline, "re-offered already-seen events must be dropped"
+    _gap, dup = ign._gap_dup([eid], [e for _op, e in mac.observed()])
+    assert dup == [], "dedup must prevent any duplicate observation"
+
+
+# ---------------------------------------------------------------------------
+# (Fix 3) Loopback guard: mac IS brain -> proven gated False, loopback_only True.
+# ---------------------------------------------------------------------------
+
+
+class _LoopbackEndpoint:
+    """A single endpoint that observes its OWN publishes -- mirrors the live
+    ``_LiveMacEndpoint`` whose local broker fans published events back to its own
+    subscription when no Brain echo subscriber exists. This is the exact 'proves
+    nothing cross-host' trap Fix 3 guards against."""
+
+    def __init__(self) -> None:
+        self.name = "mac"
+        self._observed: List[Tuple[str, str]] = []
+        self._last: Optional[str] = None
+        self._seq = 0
+        self._log: List[Tuple[str, str]] = []
+        self.connected = True
+
+    def publish(self, event_type: str, op_id: str, payload: Dict[str, Any]) -> str:
+        self._seq += 1
+        eid = format(self._seq, "012x")
+        self._log.append((eid, op_id))
+        if self.connected:
+            self._deliver(eid, op_id)
+        return eid
+
+    def _deliver(self, eid: str, op_id: str) -> None:
+        self._observed.append((op_id, eid))
+        self._last = eid
+
+    @property
+    def last_event_id(self) -> Optional[str]:
+        return self._last
+
+    def observed(self) -> List[Tuple[str, str]]:
+        return list(self._observed)
+
+    def replay_from(self, last_event_id: Optional[str]) -> None:
+        floor = int(last_event_id, 16) if last_event_id else 0
+        for eid, op_id in self._log:
+            if int(eid, 16) <= floor:
+                continue
+            if any(e == eid for _o, e in self._observed):
+                continue
+            self._deliver(eid, op_id)
+
+
+def test_exchange_loopback_cannot_report_cross_host_proven() -> None:
+    ep = _LoopbackEndpoint()
+
+    async def _sever() -> Any:
+        ep.connected = False
+
+    async def _reconnect() -> Any:
+        ep.replay_from(ep.last_event_id)
+        return ep
+
+    exchange = ign.ValidationExchange(mac=ep, brain=ep, reconnect=_reconnect,
+                                      sever=_sever, settle_s=0.0)
+    result = asyncio.run(exchange.run_all(n=2))
+    assert result["loopback_only"] is True
+    assert result["logic_ok"] is True, "self-observation still exercises the logic"
+    assert result["proven"] is False, "loopback can NEVER report cross-host-proven"
+
+
+def test_exchange_distinct_endpoints_are_not_loopback() -> None:
+    """The real bidirectional path (distinct mac/brain) is NOT loopback and CAN
+    report proven -- so the guard is specific to the same-endpoint trap."""
+    mac, brain, wire = _make_wire_pair()
+
+    async def _sever() -> Any:
+        wire.connected = False
+
+    async def _reconnect() -> Any:
+        mac.replay_from(mac.last_event_id)
+        return mac
+
+    exchange = ign.ValidationExchange(mac=mac, brain=brain, reconnect=_reconnect,
+                                      sever=_sever, settle_s=0.0)
+    result = asyncio.run(exchange.run_all(n=2))
+    assert result["loopback_only"] is False
+    assert result["proven"] is True, "distinct cross-host endpoints prove acceptance"
+
+
+# ---------------------------------------------------------------------------
+# (Fix 2) mTLS is REQUIRED (not merely accepted): a certless client is rejected
+# by the Brain WS server. Mirrors Stage-0 test_two_process_loopback.py's negative
+# branch -- the SAME build_*_ssl_context builders brain_discovery wraps.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_brain_ws_requires_mtls_certless_client_rejected() -> None:
+    ssl = pytest.importorskip("ssl")
+    aiohttp = pytest.importorskip("aiohttp")
+    from aiohttp import web
+    from aiohttp.test_utils import TestServer
+
+    from backend.core.ouroboros.governance.transport import transport_security as ts
+    from backend.core.ouroboros.governance.transport.transport_config import (
+        TransportConfig,
+    )
+    from backend.core.ouroboros.governance.transport.bus_bridge_server import (
+        BusBridgeServer,
+    )
+    from backend.core.ouroboros.governance.transport.transport_security import (
+        build_server_ssl_context,
+        build_client_ssl_context,
+    )
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+    )
+
+    # Shared ephemeral material stands in for a shared CA on loopback (same shape
+    # brain_discovery.build_brain_{client,server}_ssl_context resolve from env).
+    cert, key = ts.generate_ephemeral_material()
+    cfg = TransportConfig(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.05, reconnect_max_s=0.5, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=True, tls_cert=cert, tls_key=key, tls_ca=cert,
+        tls_ephemeral=False, source_id="brain",
+    )
+
+    broker = StreamEventBroker(history_maxlen=100)
+    app = web.Application()
+    BusBridgeServer(broker, cfg).register_routes(app)
+    tserver = TestServer(app)
+    await tserver.start_server(ssl=build_server_ssl_context(cfg))
+    host, port = tserver.host, tserver.port
+    ws_url = "wss://%s:%d/ws/trinity-bus" % (host, port)
+    try:
+        # (a) A proper mTLS client (our cert) is ACCEPTED.
+        client_ssl = build_client_ssl_context(cfg)
+        async with aiohttp.ClientSession() as s:
+            async with s.ws_connect(ws_url, ssl=client_ssl) as ws:
+                assert not ws.closed
+
+        # (b) A CERTLESS client (CERT_NONE, no client cert loaded) is REJECTED --
+        #     the server's CERT_REQUIRED expectation makes mTLS REQUIRED, not
+        #     merely accepted. This is the required-rejection proof Fix 2 demands.
+        with pytest.raises((aiohttp.ClientConnectorError, ssl.SSLError,
+                            aiohttp.ClientError, ConnectionResetError,
+                            aiohttp.WSServerHandshakeError)):
+            no_cert = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+            no_cert.check_hostname = False
+            no_cert.verify_mode = ssl.CERT_NONE
+            async with aiohttp.ClientSession() as s:
+                async with s.ws_connect(ws_url, ssl=no_cert) as ws:
+                    await ws.receive()
+    finally:
+        await tserver.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Stage 1 of the GCP orchestrator relocation (the capacity/GIL/memory root-fix)

Run-4 proved the substrate perfect but starved: BG pool=1 + fan-out=3 (16GB Mac mitigations) rejected write-intent ops. Stage 1 gives the Brain a CPU VM where those caps scale to VM cores — the durable end of the starvation genus.

**5 tasks, 4 landed here (Task 5 = live-fire, needs GCP creds):**
- **Bake** (`bake_brain_golden_image.py`): CPU golden image, repo at the REAL `/opt/trinity/jarvis`, headless battle-test systemd unit, brain.env from instance metadata, sentinel-after-proof (.git + transport-import, no sleeps), env idle-shutdown. Shares J-Prime bake helpers.
- **Node spec** (`gcp_compute_rest`): brain payload (e2-highmem-4 env-default, CPU no-GPU, `jarvis-role=brain` label, idle metadata) threaded through the SAME scatter-gather insert; `_build_insert_payload` extended backward-compatibly (None-path byte-identical, failover path untouched).
- **Discovery + mTLS** (`brain_discovery.py`): label-filtered instances.list -> Reachability Racer -> first-healthy WS URL, STATELESS (re-resolves every reconnect); /32 firewall wrappers; no-hardcoded-endpoint invariant extended to the module.
- **Ignition driver** (`ignite_brain_vm.py`): provision(reuse-if-persistent)/firewall/discover+mTLS-connect/validation-exchange/teardown. $0-orphan teardown (register-on-create, finally+atexit+SIGTERM, idempotent, reap-confirm, post-teardown verify) mirroring the proven iso reaper. Acceptance proof-strength hardened: replay load-bearing + dup control, mTLS-REQUIRED certless-rejection, and a structural loopback guard (`loopback_only=True`->`proven=False` rc=4 so a same-endpoint run can never fake cross-host).

Reviews: all 4 tasks APPROVED (2 with follow-up fixes applied). 76 tests green (bake 13, spec 15, discovery 9 + REST 28, driver 18, invariants). On-demand lifecycle default, everything env-resolved, no hardcoded endpoints, DRY reuse throughout. Ships dark (no live provisioning until Task 5 is run with creds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stage 1 adds a CPU-based Brain VM on GCP with a golden image, a CPU node spec, dynamic discovery with mTLS, and an ignition driver that guarantees $0-orphan teardown. Ships dark; enables scalable, stateless Brain provisioning with no hardcoded endpoints.

- **New Features**
  - CPU golden image for the Brain at `/opt/trinity/jarvis` with a headless systemd unit; reads env from instance metadata and supports idle self-shutdown.
  - Brain VM spec integrated into the existing create/insert path in `gcp_compute_rest`; CPU-only, label `jarvis-role=brain`, env-driven knobs, and byte-identical behavior for existing callers when unused.
  - Dynamic discovery via GCE label listing + reachability race; mTLS-only connection; thin /32 firewall helpers; no baked IPs or WS URLs.
  - Ignition driver to provision/reuse the Brain VM, open/close firewall, discover + connect over mTLS, run a replay-exact validation exchange (and reject certless clients), then tear down with finally/atexit/SIGTERM idempotency and post-teardown $0 verification.
  - Safety and tests: invariant to prevent hardcoded endpoints; unit tests cover bake/spec/discovery/REST seam/driver (no live GCP).

- **Migration**
  - No action now; runs dark until invoked with GCP credentials.
  - To try locally: configure `JARVIS_BRAIN_VM_*` env vars and run `scripts/ignite_brain_vm.py`.

<sup>Written for commit 94c0a381c5f65b07ca370f25a24f31b3367d91ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69835?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

