### PR TITLE
fix(brain-bake): single-source image family (kill drift before Task-5 live-fire)

### DIFF
--- a/scripts/bake_brain_golden_image.py
+++ b/scripts/bake_brain_golden_image.py
@@ -80,7 +80,16 @@ _DEFAULT_ZONE = (os.environ.get("JARVIS_BRAIN_VM_ZONES", "").split(",")[0]).stri
 _DEFAULT_MACHINE = os.environ.get("JARVIS_BRAIN_BAKE_MACHINE", "e2-standard-4")
 _DEFAULT_REPO_URL = os.environ.get("JARVIS_BRAIN_REPO_URL", "")
 _DEFAULT_REPO_REF = os.environ.get("JARVIS_BRAIN_REPO_REF", "main")
-_DEFAULT_IMAGE_FAMILY = os.environ.get("JARVIS_BRAIN_IMAGE_FAMILY", "jarvis-brain")
+# SINGLE SOURCE OF TRUTH with the provisioner: the bake MUST create the same
+# image family that gcp_compute_rest._brain_image_family() provisions FROM,
+# or Task-5 ignition finds no image. Both read JARVIS_BRAIN_VM_IMAGE_FAMILY and
+# default to "jarvis-brain-golden" -- structurally coupled, cannot drift.
+# (The legacy JARVIS_BRAIN_IMAGE_FAMILY name is honored as a fallback so an
+# operator who set the old var is not silently ignored.)
+_DEFAULT_IMAGE_FAMILY = os.environ.get(
+    "JARVIS_BRAIN_VM_IMAGE_FAMILY",
+    os.environ.get("JARVIS_BRAIN_IMAGE_FAMILY", "jarvis-brain-golden"),
+)
 _DEFAULT_BOOT_DISK = os.environ.get("JARVIS_BRAIN_BAKE_BOOT_DISK_SIZE", "30GB")
 _DEFAULT_BOOT_DISK_TYPE = os.environ.get("JARVIS_BRAIN_BAKE_BOOT_DISK_TYPE", "pd-ssd")
 _DEFAULT_BAKE_TIMEOUT_S = int(os.environ.get("JARVIS_BRAIN_BAKE_TIMEOUT_S", "1800"))

--- a/tests/infra/test_brain_bake_script.py
+++ b/tests/infra/test_brain_bake_script.py
@@ -188,3 +188,29 @@ def test_parse_validation_verdict_is_the_shared_jprime_function(bake):
     assert bake._run is jprime._run
     assert bake._log is jprime._log
     assert bake._now_stamp is jprime._now_stamp
+
+
+def test_bake_family_matches_provisioner_single_source_of_truth(monkeypatch):
+    """Cross-component pin: the bake MUST create the exact image family the
+    Task-2 provisioner (_brain_image_family) provisions FROM, else Task-5
+    ignition finds no image. Both must read JARVIS_BRAIN_VM_IMAGE_FAMILY and
+    share a default. Regression guard for the drift caught pre-live-fire
+    (bake was JARVIS_BRAIN_IMAGE_FAMILY/jarvis-brain vs provisioner
+    JARVIS_BRAIN_VM_IMAGE_FAMILY/jarvis-brain-golden)."""
+    import importlib.util as _u
+    monkeypatch.delenv("JARVIS_BRAIN_VM_IMAGE_FAMILY", raising=False)
+    monkeypatch.delenv("JARVIS_BRAIN_IMAGE_FAMILY", raising=False)
+    _s = _u.spec_from_file_location("_bb_pin", "scripts/bake_brain_golden_image.py")
+    _m = _u.module_from_spec(_s)
+    _s.loader.exec_module(_m)
+    from backend.core.ouroboros.governance.gcp_compute_rest import _brain_image_family
+    assert _m._DEFAULT_IMAGE_FAMILY == _brain_image_family(), (
+        "bake image family must match the provisioner's -- Task 5 provisions "
+        "from _brain_image_family(); a mismatch means no image found"
+    )
+    # And the shared env var drives BOTH:
+    monkeypatch.setenv("JARVIS_BRAIN_VM_IMAGE_FAMILY", "jarvis-brain-custom-fam")
+    _m2 = _u.module_from_spec(_s)
+    _s.loader.exec_module(_m2)
+    assert _m2._DEFAULT_IMAGE_FAMILY == "jarvis-brain-custom-fam"
+    assert _brain_image_family() == "jarvis-brain-custom-fam"


### PR DESCRIPTION
Pre-live-fire integration fix: the bake created family jarvis-brain but the provisioner reads jarvis-brain-golden -> Task 5 would find no image. Both now read JARVIS_BRAIN_VM_IMAGE_FAMILY with a shared default; cross-component pin test added. 14/14 green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the brain image family between the bake script and the GCP provisioner to prevent Task-5 from failing to find an image. Both now read JARVIS_BRAIN_VM_IMAGE_FAMILY with a shared default of jarvis-brain-golden.

- Bug Fixes
  - Bake script honors legacy JARVIS_BRAIN_IMAGE_FAMILY as a fallback to avoid breaking existing configs.
  - Added cross-component test to pin bake default to backend.core.ouroboros.governance.gcp_compute_rest._brain_image_family() and verify the shared env var drives both.

<sup>Written for commit 0bfafbb129f8b343794b2463b944f9a63b5f97d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69836?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

