### PR TITLE
fix(brain-bake): venv + brain-scoped requirements (PEP 668 + lean-Brain mandate)

### DIFF
--- a/backend/requirements-brain.txt
+++ b/backend/requirements-brain.txt
@@ -1,0 +1,47 @@
+# backend/requirements-brain.txt -- the Brain-VM (CPU orchestrator) runtime set.
+#
+# Consumed by scripts/bake_brain_golden_image.py: installed into /opt/trinity/venv
+# on the golden image (Debian 12 system pip is PEP 668 externally-managed; the
+# bake never uses system pip).
+#
+# SCOPE (design Non-Goals, docs/superpowers/specs/2026-07-03-gcp-orchestrator-
+# relocation-design.md): the Brain is a CPU orchestrator that calls DW/J-Prime
+# over the network. It must NEVER carry the Mac Body's voice/vision/local-ML
+# stack (torch, torchaudio, whisper, PyAudio, llama-cpp, ...) -- installing that
+# on bare debian-12 is what failed live-fire attempt 1 (2026-07-04).
+#
+# DERIVATION (empirical, debian:12 container, 2026-07-04):
+# - HARD deps: iterative import-probe over the service entry surface (transport
+#   sentinel, battle_test.harness, governed_loop_service, orchestrator,
+#   event_channel, providers, doubleword_provider, candidate_generator,
+#   gcp_compute_rest, brain_discovery, tool_executor, test_runner, serpent_flow,
+#   oracle) until green.
+# - ARMED deps: the codebase import-guards most third-party libs (fail-soft) --
+#   a missing lib silently disables the feature instead of crashing. These are
+#   the guarded libs whose features the Brain soak MUST have live, found by
+#   import-site census over backend/core/ouroboros + resilience.
+# Pins follow root requirements.txt where present.
+
+# --- HARD: import-proven required by the service entry surface ---------------
+aiohttp==3.13.2
+psutil==7.1.3
+uuid6==2025.0.1          # NOT pinned in root requirements.txt (Mac had it out-of-band)
+rich==14.2.0             # serpent_flow/TUI render layer (headless still imports)
+pytest>=9.0,<10          # TestRunner VERIFY phase runs pytest subprocesses
+
+# --- ARMED: import-guarded features the Brain must have live -----------------
+anthropic==0.75.0        # Tier-1 provider (Claude) -- silent-degrade without it
+httpx==0.28.1            # DW provider / HTTP clients
+PyYAML==6.0.3            # brain_selection_policy.yaml -- zero hardcoded models
+python-dotenv==1.2.1
+cryptography>=42.0.0     # mTLS chain (Stage 1) + Ed25519 roadmap authority
+prompt_toolkit>=3.0.43   # REPL (headless-safe)
+watchdog==6.0.0          # FileWatchGuard / fs sensors (Slice 12K budget runs on it)
+numpy>=1.26.4,<2.5       # semantic index / oracle math
+fastembed>=0.3.0         # Oracle LITE embeddings (graduated default-ON); pulls onnxruntime (CPU)
+aiosqlite==0.19.0        # Oracle SQLite persistence
+aiofiles==23.2.1
+pytest-timeout==2.4.0
+redis>=4.2.0             # cost_tracker streaming (inert without a server)
+fastapi==0.124.2         # MCP HTTP transport (guarded)
+uvicorn==0.38.0          # telemetry broker (guarded)

--- a/scripts/bake_brain_golden_image.py
+++ b/scripts/bake_brain_golden_image.py
@@ -18,7 +18,9 @@ J-Prime code-model image:
     image + python3.11 + git.
   * Clones the repo to ``/opt/trinity/jarvis`` (URL + ref env-resolved at bake
     time -- ``JARVIS_BRAIN_REPO_URL`` / ``JARVIS_BRAIN_REPO_REF``).
-  * ``pip install`` of the repo requirements.
+  * venv ``pip install`` of the brain-scoped requirements
+    (``backend/requirements-brain.txt`` -- Debian 12 system pip is PEP 668
+    externally-managed, and the Brain never carries the Mac voice/ML stack).
   * Bakes a systemd unit ``jarvis-brain.service`` (headless warm-standby soak)
     + an idle self-shutdown timer.
   * ``/etc/jarvis/brain.env`` is written AT BOOT from instance metadata (tokens /
@@ -136,12 +138,14 @@ def build_startup_script(
     """Return the metadata startup-script that bakes the Brain VM image.
 
     Steps (each with an ISO phase-timestamp echo for measurable per-phase time):
-      1. Install base deps: python3.11 + pip + git (NO Ollama / NO NVIDIA).
+      1. Install base deps: python3.11 + dev headers + build-essential + pip +
+         git (NO Ollama / NO NVIDIA).
       2. Populate ``/etc/jarvis/brain.env`` FROM INSTANCE METADATA (the J-Prime
          metadata pattern) -- BEFORE any unit is enabled, so per-instance
          tokens / cost-cap / endpoints are never baked into the image.
       3. Clone the repo to ``/opt/trinity/jarvis`` (the IsomorphicEnv path).
-      4. ``pip install -r requirements.txt``.
+      4. venv at ``/opt/trinity/venv`` (PEP 668) + ``pip install -r
+         backend/requirements-brain.txt`` (brain-scoped, no torch/voice/ML).
       5. Write + enable the ``jarvis-brain.service`` warm-standby unit
          (headless battle-test soak, ``--max-wall-seconds 0`` = no wall) and the
          ``jarvis-brain-idle`` self-shutdown timer.
@@ -182,7 +186,7 @@ rm -f {sentinel_q} || true
 echo "[brain-bake] phase=deps-start ts=$(_ts)"
 export DEBIAN_FRONTEND=noninteractive
 apt-get update -y
-apt-get install -y python3.11 python3.11-venv python3-pip git curl ca-certificates
+apt-get install -y python3.11 python3.11-venv python3.11-dev python3-pip git curl ca-certificates build-essential
 echo "[brain-bake] phase=deps-done ts=$(_ts)"
 
 # 2. Populate {brain_env_path} FROM INSTANCE METADATA -- BEFORE any unit is
@@ -210,12 +214,21 @@ else
     exit 1
 fi
 
-# 4. Install the repo requirements.
+# 4. Install the BRAIN-SCOPED requirements into a venv.
+#    - venv, never system pip: Debian 12 pip is PEP 668 externally-managed and
+#      refuses system-wide installs outright (live-fire attempt 1, 2026-07-04).
+#    - backend/requirements-brain.txt, never the root requirements.txt: the
+#      Brain is a CPU orchestrator (design Non-Goals) -- torch/voice/local-ML
+#      belong to the Mac Body / J-Prime, not this image.
+#    - The venv lives OUTSIDE the repo path (the clone step rm -rf's the repo).
 echo "[brain-bake] phase=pip-start ts=$(_ts)"
 cd {_REPO_PATH}
-python3.11 -m ensurepip --upgrade || true
-python3.11 -m pip install --upgrade pip || true
-if python3.11 -m pip install -r requirements.txt; then
+if ! python3.11 -m venv /opt/trinity/venv; then
+    echo "[brain-bake] ERROR: venv creation failed -- NOT writing sentinel"
+    exit 1
+fi
+/opt/trinity/venv/bin/pip install --upgrade pip || true
+if /opt/trinity/venv/bin/pip install -r backend/requirements-brain.txt; then
     echo "[brain-bake] phase=pip-done ts=$(_ts)"
 else
     echo "[brain-bake] ERROR: pip install failed -- NOT writing sentinel"
@@ -241,7 +254,7 @@ EnvironmentFile={brain_env_path}
 # nukes a freshly-booted node during the soak's boot window.
 RuntimeDirectory=jarvis
 ExecStartPre=/bin/touch /run/jarvis/brain_liveness
-ExecStart=/usr/bin/python3.11 scripts/ouroboros_battle_test.py --production-soak --headless --cost-cap ${{JARVIS_BRAIN_COST_CAP}} --max-wall-seconds 0
+ExecStart=/opt/trinity/venv/bin/python scripts/ouroboros_battle_test.py --production-soak --headless --cost-cap ${{JARVIS_BRAIN_COST_CAP}} --max-wall-seconds 0
 Restart=on-failure
 RestartSec=10
 
@@ -308,7 +321,7 @@ systemctl enable jarvis-brain-idle.timer || true
 #    Never a fixed sleep. Either fails -> no sentinel -> reaper rolls the node.
 echo "[brain-bake] phase=readiness-proof-start ts=$(_ts)"
 if [ -d {_REPO_PATH}/.git ] && \\
-   ( cd {_REPO_PATH} && python3.11 -c "import backend.core.ouroboros.governance.transport" ); then
+   ( cd {_REPO_PATH} && /opt/trinity/venv/bin/python -c "import backend.core.ouroboros.governance.transport" ); then
     echo "ready repo={repo_ref_q} path={_REPO_PATH} ts=$(_ts)" > {sentinel_q}
     echo "[brain-bake] phase=sentinel-written ts=$(_ts)"
     echo "[brain-bake] startup-script done $(_ts)"
@@ -580,8 +593,9 @@ def build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         description=(
             "One-time bake of the CPU Brain-VM golden image (provision -> "
-            "install python3.11+git -> clone /opt/trinity/jarvis -> pip install "
-            "-> systemd units -> git+transport readiness proof -> snapshot -> "
+            "install python3.11+build-essential+git -> clone /opt/trinity/jarvis "
+            "-> venv pip install backend/requirements-brain.txt -> systemd units "
+            "-> git+transport readiness proof -> snapshot -> "
             "delete-to-snapshot). Default is --dry-run."
         ),
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,

--- a/tests/infra/test_brain_bake_script.py
+++ b/tests/infra/test_brain_bake_script.py
@@ -140,7 +140,86 @@ def test_idle_shutdown_timeout_is_env_driven(bake):
 
 
 # --------------------------------------------------------------------------- #
-# (g) whole startup script is ASCII-only.
+# (g) PEP 668: Debian 12 system pip is externally-managed and refuses installs
+#     outright (live-fire attempt 1, 2026-07-04). ALL pip must run inside the
+#     venv; the service and the sentinel proof must use the SAME interpreter
+#     the deps were installed into.
+# --------------------------------------------------------------------------- #
+def test_pip_runs_in_venv_never_system_pip(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert "python3.11 -m venv /opt/trinity/venv" in script
+    assert "/opt/trinity/venv/bin/pip install" in script
+    # No system-pip install may remain anywhere (PEP 668 refuses it on debian-12).
+    assert "python3.11 -m pip install" not in script
+    assert "python3.11 -m ensurepip" not in script
+
+
+def test_pip_installs_brain_scoped_requirements_not_full_stack(bake):
+    """The Brain is a CPU orchestrator (design Non-Goals): it must install the
+    brain-scoped subset, never the root requirements.txt Mac/voice/ML stack."""
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert "backend/requirements-brain.txt" in script
+    assert "-r requirements.txt" not in script
+
+
+def test_apt_installs_build_prereqs_before_pip(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert "build-essential" in script
+    assert "python3.11-dev" in script
+    apt_idx = script.index("build-essential")
+    pip_idx = script.index("/opt/trinity/venv/bin/pip install")
+    assert apt_idx < pip_idx, "build prereqs must be installed before pip runs"
+
+
+def test_execstart_uses_venv_python(bake):
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert (
+        "ExecStart=/opt/trinity/venv/bin/python scripts/ouroboros_battle_test.py"
+        in script
+    )
+    assert "ExecStart=/usr/bin/python3.11" not in script
+
+
+def test_sentinel_proof_uses_venv_python(bake):
+    """The readiness proof must import under the venv interpreter -- proving the
+    system python imports would validate a DIFFERENT runtime than the service."""
+    script = bake.build_startup_script("https://example.invalid/repo.git")
+    assert (
+        '/opt/trinity/venv/bin/python -c "import backend.core.ouroboros.governance.transport"'
+        in script
+    )
+
+
+def test_brain_requirements_file_excludes_ml_voice_stack():
+    """backend/requirements-brain.txt is the lean CPU-orchestrator set: no local
+    inference, no voice I/O, no training stack (design Non-Goals)."""
+    req_path = _SCRIPT.parents[1] / "backend" / "requirements-brain.txt"
+    assert req_path.exists(), "backend/requirements-brain.txt must exist"
+    # Check requirement LINES only (comments may name the excluded stack).
+    req = "\n".join(
+        line.split("#", 1)[0].strip()
+        for line in req_path.read_text(encoding="utf-8").splitlines()
+        if line.split("#", 1)[0].strip()
+    ).lower()
+    for forbidden in (
+        "torch",  # also catches torchaudio
+        "whisper",
+        "pyaudio",
+        "llama-cpp",
+        "speechbrain",
+        "librosa",
+        "pvporcupine",
+        "webrtcvad",
+        "sounddevice",
+        "coremltools",
+        "transformers",
+        "bitsandbytes",
+    ):
+        assert forbidden not in req, f"brain requirements must not carry {forbidden!r}"
+
+
+# --------------------------------------------------------------------------- #
+# (h) whole startup script is ASCII-only.
 # --------------------------------------------------------------------------- #
 def test_startup_script_is_ascii(bake):
     bake.build_startup_script("https://example.invalid/repo.git").encode("ascii")


### PR DESCRIPTION
## Live-fire attempt 1 unblock

**Root cause (proven, not the ledgered theory):** Debian 12 system pip is PEP 668 externally-managed and refuses `pip install` outright. Reproduced faithfully in a debian:12 container at $0 — pip dies instantly with `error: externally-managed-environment`, matching the ~90s failure timing (apt + clone consumed the 90s). `build-essential` was never reached.

**Fix:**
- venv at `/opt/trinity/venv` (outside the `rm -rf`'d repo path); all three interpreter touchpoints move together: pip install, systemd `ExecStart`, readiness sentinel import proof
- NEW `backend/requirements-brain.txt` — empirically-derived brain-scoped set (import-probe loop over the service entry surface on debian:12 + armed-feature census over the fail-soft import guards). NO torch/voice/local-ML per design Non-Goals. `requirements-cloud.txt` disqualified (stale 2025 GPU stack). Venv: **304MB** vs 4GB+.
- apt preamble adds `python3.11-dev` + `build-essential`

**In-container verification (faithful bake context):** pip step green, 14 runtime import probes green, 15 armed libs green. `bash -n` clean. 20/20 bake + 38 ignite + 24 brain-spec/discovery tests.

**Sequencing:** must land on main BEFORE re-bake (the bake clones main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Brain VM bake on Debian 12 by installing into a venv and switching to a lean, brain-scoped requirements set to avoid PEP 668 system pip failures. Aligns runtime and readiness checks to the same venv python and cuts the image size.

- **Bug Fixes**
  - Install into `/opt/trinity/venv`; no system `pip` calls; use `backend/requirements-brain.txt`.
  - Add `backend/requirements-brain.txt`: CPU-orchestrator deps only (no torch/voice/local-ML); ~304MB venv.
  - Install `python3.11-dev` and `build-essential` before pip to satisfy build deps.
  - Run systemd `ExecStart` and readiness import with `/opt/trinity/venv/bin/python`.
  - Tests assert venv-only pip, brain-scoped install, apt-before-pip, and venv interpreter usage.

<sup>Written for commit cb35ec6e78f322a654599a9a75d48f770dcfdfaf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69837?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

