### PR TITLE
feat(stage1): native Brain-VM mTLS cert-chain generator (CA + server + client)

### DIFF
--- a/scripts/gen_brain_mtls.py
+++ b/scripts/gen_brain_mtls.py
@@ -1,0 +1,430 @@
+#!/usr/bin/env python3
+"""gen_brain_mtls.py -- Stage-1 Brain-VM mTLS cert-chain generator.
+
+Emits a proper CA-signed 3-cert chain for the cross-host Brain<->Mac mTLS
+WebSocket boundary that Stage-1 Task-5 ignition (``scripts/ignite_brain_vm.py``)
+brings up:
+
+    ca.pem            self-signed root (CA=True, keyCertSign+cRLSign)
+    server-cert.pem   SERVER leaf (serverAuth EKU) -> injected into the Brain VM
+                      via instance metadata by the ignition driver
+    server-key.pem    SERVER private key            (0600)
+    client-cert.pem   CLIENT leaf (clientAuth EKU) -> stays on THIS Mac
+    client-key.pem    CLIENT private key            (0600)
+
+These files are consumed UNCHANGED by the Stage-0
+``transport_security.build_server_ssl_context`` / ``build_client_ssl_context``
+loaders (they read ``JARVIS_BRAIN_WS_TLS_CERT``/``_KEY``/``_CA`` from the env and
+enforce ``CERT_REQUIRED`` mutual auth). We feed those loaders -- we do NOT
+reimplement TLS context construction.
+
+Root-Cause / Mandate 1: native ``cryptography`` primitives ONLY. No ``subprocess``,
+no ``openssl`` shell.
+
+Architectural purity / Mandate 2: the SERVER cert SAN is NEVER a literal IP. The
+Brain's external IP is ephemeral (per-session GCE node + /32 firewall), so the
+cert is bound to a STABLE DNS-style RUNTIME IDENTITY instead:
+
+  * a canonical ``jarvis-brain`` DNSName is always present -- the client verifies
+    THIS name (``server_hostname="jarvis-brain"``) against the SAN, so a changing
+    external IP never has to appear in the cert;
+  * when ``server_identity`` is provided it is added as a DNSName, and -- if the
+    GCE zone + project are resolvable -- the GCE metadata-internal DNS pattern
+    ``<instance>.<zone>.c.<project>.internal`` is added as an additional SAN.
+
+Authentication is by CA-trust (shared ``ca.pem`` + ``CERT_REQUIRED``); the
+network-identity boundary is the ephemeral /32 firewall. No IP in any cert.
+
+Bulletproof / Mandate 4: private keys are written 0600; the generator refuses to
+silently overwrite an existing chain without ``--force``; it never emits a cert
+with a literal-IP SAN (an IP-literal ``server_identity`` is rejected up front).
+"""
+from __future__ import annotations
+
+import argparse
+import datetime
+import ipaddress
+import os
+import sys
+import tempfile
+from typing import Dict, List, Optional
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes, serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.x509.oid import ExtendedKeyUsageOID, NameOID
+
+# The canonical, stable identity the Brain server is always reachable AS. A
+# dynamic external IP is authenticated by CA-trust, not by being in the cert;
+# the client uses this name as its server_hostname over the CA-trust path.
+CANONICAL_BRAIN_IDENTITY = "jarvis-brain"
+
+_FILENAMES = {
+    "ca": "ca.pem",
+    "server_cert": "server-cert.pem",
+    "server_key": "server-key.pem",
+    "client_cert": "client-cert.pem",
+    "client_key": "client-key.pem",
+}
+
+_KEY_SIZE = 2048
+_PUBLIC_EXPONENT = 65537
+
+
+def _is_ip_literal(value: str) -> bool:
+    try:
+        ipaddress.ip_address(value)
+        return True
+    except ValueError:
+        return False
+
+
+def _new_rsa_key() -> rsa.RSAPrivateKey:
+    return rsa.generate_private_key(
+        public_exponent=_PUBLIC_EXPONENT, key_size=_KEY_SIZE
+    )
+
+
+def _server_dns_names(
+    server_identity: str,
+    *,
+    gce_zone: Optional[str],
+    gce_project: Optional[str],
+) -> List[str]:
+    """Build the ordered, de-duplicated DNSName SAN list for the server leaf.
+
+    Never contains a literal IP -- an IP-literal identity is rejected by the
+    caller before we get here.
+    """
+    names: List[str] = [CANONICAL_BRAIN_IDENTITY]
+    ident = (server_identity or "").strip()
+    if ident and ident != CANONICAL_BRAIN_IDENTITY:
+        names.append(ident)
+        # GCE metadata-internal DNS: <instance>.<zone>.c.<project>.internal --
+        # only when both coordinates resolve AND the identity is a bare instance
+        # name (not already a FQDN we should not decorate).
+        if gce_zone and gce_project and "." not in ident:
+            names.append("%s.%s.c.%s.internal" % (ident, gce_zone, gce_project))
+    # De-dupe, preserve order.
+    seen: Dict[str, None] = {}
+    for n in names:
+        seen.setdefault(n, None)
+    return list(seen.keys())
+
+
+def _build_ca(ca_cn: str, not_before, not_after):
+    ca_key = _new_rsa_key()
+    ca_name = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, ca_cn)])
+    ca_cert = (
+        x509.CertificateBuilder()
+        .subject_name(ca_name)
+        .issuer_name(ca_name)
+        .public_key(ca_key.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=True, path_length=0), critical=True)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=False,
+                content_commitment=False,
+                key_encipherment=False,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=True,
+                crl_sign=True,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(ca_key.public_key()),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    return ca_key, ca_cert
+
+
+def _sign_leaf(
+    *,
+    ca_key,
+    ca_cert,
+    subject_cn: str,
+    san: x509.SubjectAlternativeName,
+    eku_oid,
+    not_before,
+    not_after,
+):
+    """Generate a leaf key, build a CSR, and have the CA sign it into a cert."""
+    leaf_key = _new_rsa_key()
+    subject = x509.Name([x509.NameAttribute(NameOID.COMMON_NAME, subject_cn)])
+    # CSR (Mandate: "key + CSR signed by the CA").
+    csr = (
+        x509.CertificateSigningRequestBuilder()
+        .subject_name(subject)
+        .add_extension(san, critical=False)
+        .sign(leaf_key, hashes.SHA256())
+    )
+    leaf_cert = (
+        x509.CertificateBuilder()
+        .subject_name(csr.subject)
+        .issuer_name(ca_cert.subject)
+        .public_key(csr.public_key())
+        .serial_number(x509.random_serial_number())
+        .not_valid_before(not_before)
+        .not_valid_after(not_after)
+        .add_extension(x509.BasicConstraints(ca=False, path_length=None), critical=True)
+        .add_extension(san, critical=False)
+        .add_extension(
+            x509.KeyUsage(
+                digital_signature=True,
+                content_commitment=False,
+                key_encipherment=True,
+                data_encipherment=False,
+                key_agreement=False,
+                key_cert_sign=False,
+                crl_sign=False,
+                encipher_only=False,
+                decipher_only=False,
+            ),
+            critical=True,
+        )
+        .add_extension(x509.ExtendedKeyUsage([eku_oid]), critical=False)
+        .add_extension(
+            x509.AuthorityKeyIdentifier.from_issuer_public_key(ca_key.public_key()),
+            critical=False,
+        )
+        .add_extension(
+            x509.SubjectKeyIdentifier.from_public_key(leaf_key.public_key()),
+            critical=False,
+        )
+        .sign(ca_key, hashes.SHA256())
+    )
+    return leaf_key, leaf_cert
+
+
+def _write_cert(path: str, cert: x509.Certificate) -> None:
+    with open(path, "wb") as fh:
+        fh.write(cert.public_bytes(serialization.Encoding.PEM))
+    os.chmod(path, 0o644)
+
+
+def _write_key(path: str, key: rsa.RSAPrivateKey) -> None:
+    # Create with 0600 up front (umask-independent), then re-assert perms.
+    fd = os.open(path, os.O_WRONLY | os.O_CREAT | os.O_TRUNC, 0o600)
+    try:
+        with os.fdopen(fd, "wb") as fh:
+            fh.write(
+                key.private_bytes(
+                    serialization.Encoding.PEM,
+                    serialization.PrivateFormat.TraditionalOpenSSL,
+                    serialization.NoEncryption(),
+                )
+            )
+    finally:
+        os.chmod(path, 0o600)
+
+
+def generate_brain_mtls_chain(
+    *,
+    out_dir: str,
+    ca_cn: str = "jarvis-brain-ca",
+    server_identity: str = "",
+    client_cn: str = "jarvis-brain-client",
+    validity_days: int = 7,
+    gce_zone: Optional[str] = None,
+    gce_project: Optional[str] = None,
+    force: bool = False,
+) -> Dict[str, str]:
+    """Generate a CA + SERVER leaf + CLIENT leaf PEM chain under ``out_dir``.
+
+    Returns a dict of the 5 written paths keyed
+    ``ca``/``server_cert``/``server_key``/``client_cert``/``client_key``.
+
+    Raises ``ValueError`` if ``server_identity`` is a literal IP (Mandate 2/4:
+    no IP ever lands in a SAN). Raises ``FileExistsError`` if any target file
+    already exists and ``force`` is False (Mandate 4: no silent overwrite).
+    """
+    ident = (server_identity or "").strip()
+    if ident and _is_ip_literal(ident):
+        raise ValueError(
+            "server_identity must be a DNS-style identity, not a literal IP "
+            "(got %r) -- the cert binds to a stable name, never the ephemeral IP"
+            % ident
+        )
+    if validity_days <= 0:
+        raise ValueError("validity_days must be positive (got %r)" % validity_days)
+
+    gce_zone = gce_zone if gce_zone is not None else _resolve_env("JARVIS_BRAIN_GCE_ZONE")
+    gce_project = (
+        gce_project if gce_project is not None
+        else _resolve_env("JARVIS_BRAIN_GCE_PROJECT")
+    )
+
+    os.makedirs(out_dir, exist_ok=True)
+    paths = {k: os.path.join(out_dir, v) for k, v in _FILENAMES.items()}
+    if not force:
+        existing = [p for p in paths.values() if os.path.exists(p)]
+        if existing:
+            raise FileExistsError(
+                "refusing to overwrite existing mTLS material without force=True: "
+                + ", ".join(sorted(existing))
+            )
+
+    now = datetime.datetime.now(datetime.timezone.utc)
+    not_before = now - datetime.timedelta(minutes=1)
+    not_after = now + datetime.timedelta(days=validity_days)
+
+    ca_key, ca_cert = _build_ca(ca_cn, not_before, not_after)
+
+    # SERVER leaf: stable-DNS SAN, serverAuth. Subject CN mirrors the primary
+    # DNS identity so tooling that reads CN still sees a name, never an IP.
+    server_dns = _server_dns_names(ident, gce_zone=gce_zone, gce_project=gce_project)
+    server_san = x509.SubjectAlternativeName([x509.DNSName(n) for n in server_dns])
+    server_key, server_cert = _sign_leaf(
+        ca_key=ca_key,
+        ca_cert=ca_cert,
+        subject_cn=server_dns[0],
+        san=server_san,
+        eku_oid=ExtendedKeyUsageOID.SERVER_AUTH,
+        not_before=not_before,
+        not_after=not_after,
+    )
+
+    # CLIENT leaf: SAN/CN == client_cn, clientAuth.
+    client_cn = (client_cn or "jarvis-brain-client").strip()
+    if _is_ip_literal(client_cn):
+        raise ValueError("client_cn must not be a literal IP (got %r)" % client_cn)
+    client_san = x509.SubjectAlternativeName([x509.DNSName(client_cn)])
+    client_key, client_cert = _sign_leaf(
+        ca_key=ca_key,
+        ca_cert=ca_cert,
+        subject_cn=client_cn,
+        san=client_san,
+        eku_oid=ExtendedKeyUsageOID.CLIENT_AUTH,
+        not_before=not_before,
+        not_after=not_after,
+    )
+
+    _write_cert(paths["ca"], ca_cert)
+    _write_cert(paths["server_cert"], server_cert)
+    _write_key(paths["server_key"], server_key)
+    _write_cert(paths["client_cert"], client_cert)
+    _write_key(paths["client_key"], client_key)
+
+    return paths
+
+
+def _resolve_env(key: str) -> Optional[str]:
+    raw = os.environ.get(key)
+    if raw is None:
+        return None
+    raw = raw.strip()
+    return raw or None
+
+
+def _default_out_dir() -> str:
+    env = _resolve_env("JARVIS_BRAIN_MTLS_DIR")
+    if env:
+        return env
+    return tempfile.mkdtemp(prefix="jarvis-brain-mtls-")
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.environ.get(key, "")
+    try:
+        return int(raw.strip())
+    except (ValueError, AttributeError):
+        return default
+
+
+def _print_env_block(paths: Dict[str, str]) -> None:
+    """Print the operator/ignition env-export block.
+
+    Client-side vars (``JARVIS_BRAIN_WS_TLS_*``) point at the MAC's material and
+    are what ``build_client_ssl_context`` reads. The SERVER material paths are
+    surfaced separately -- the ignition driver injects server-cert/key into the
+    Brain VM's instance metadata.
+    """
+    lines = [
+        "# --- JARVIS Brain mTLS chain (source this) ---",
+        "# Client side (this Mac): consumed by build_client_ssl_context",
+        "export JARVIS_BRAIN_WS_TLS_CA=%s" % paths["ca"],
+        "export JARVIS_BRAIN_WS_TLS_CERT=%s" % paths["client_cert"],
+        "export JARVIS_BRAIN_WS_TLS_KEY=%s" % paths["client_key"],
+        "export JARVIS_BRAIN_WS_TLS_ENABLED=true",
+        "export JARVIS_BRAIN_WS_TLS_EPHEMERAL=false",
+        "# Server side (injected into the Brain VM metadata by the ignition driver)",
+        "export JARVIS_BRAIN_SERVER_TLS_CA=%s" % paths["ca"],
+        "export JARVIS_BRAIN_SERVER_TLS_CERT=%s" % paths["server_cert"],
+        "export JARVIS_BRAIN_SERVER_TLS_KEY=%s" % paths["server_key"],
+        "# ---------------------------------------------",
+    ]
+    print("\n".join(lines))
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = argparse.ArgumentParser(
+        description="Generate the Brain-VM mTLS CA + server + client cert chain "
+        "(native cryptography, no openssl).",
+    )
+    parser.add_argument(
+        "--out-dir",
+        default=None,
+        help="output dir for the 5 PEMs (default: env JARVIS_BRAIN_MTLS_DIR, "
+        "else a per-run tmp dir)",
+    )
+    parser.add_argument(
+        "--server-identity",
+        default=_resolve_env("JARVIS_BRAIN_VM_NODE_NAME") or "",
+        help="stable DNS-style SERVER identity for the SAN (a GCE instance name "
+        "/ jarvis-brain DNSName). NEVER an IP. Empty => canonical 'jarvis-brain'.",
+    )
+    parser.add_argument(
+        "--client-cn",
+        default="jarvis-brain-client",
+        help="client leaf CN/SAN (default jarvis-brain-client)",
+    )
+    parser.add_argument(
+        "--ca-cn", default="jarvis-brain-ca", help="CA common name",
+    )
+    parser.add_argument(
+        "--validity-days",
+        type=int,
+        default=_env_int("JARVIS_BRAIN_MTLS_VALIDITY_DAYS", 7),
+        help="cert validity window in days (env JARVIS_BRAIN_MTLS_VALIDITY_DAYS, "
+        "default 7)",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="overwrite an existing chain in --out-dir (default: refuse)",
+    )
+    args = parser.parse_args(argv)
+
+    out_dir = args.out_dir or _default_out_dir()
+    try:
+        paths = generate_brain_mtls_chain(
+            out_dir=out_dir,
+            ca_cn=args.ca_cn,
+            server_identity=args.server_identity,
+            client_cn=args.client_cn,
+            validity_days=args.validity_days,
+            force=args.force,
+        )
+    except FileExistsError as exc:
+        sys.stderr.write("error: %s\n(use --force to overwrite)\n" % exc)
+        return 2
+    except ValueError as exc:
+        sys.stderr.write("error: %s\n" % exc)
+        return 2
+
+    sys.stderr.write("wrote mTLS chain to %s\n" % out_dir)
+    _print_env_block(paths)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/infra/test_gen_brain_mtls.py
+++ b/tests/infra/test_gen_brain_mtls.py
@@ -1,0 +1,288 @@
+"""Unit tests for scripts/gen_brain_mtls.py (Stage-1 Brain-VM mTLS chain gen).
+
+NO network, NO GCP, NO openssl subprocess. Every assertion is a native
+``cryptography`` / ``ssl`` check against the 3-cert chain the generator emits:
+
+  (a) all 5 PEMs land and parse via ``x509.load_pem_x509_certificate``;
+  (b) server + client leaves are SIGNED BY the CA (signature chains to the CA
+      public key);
+  (c) server carries ``serverAuth`` EKU + a DNSName SAN and NO literal-IP
+      IPAddress SAN; client carries ``clientAuth`` EKU;
+  (d) THE LOAD PROOF: the generated files load cleanly through the UNCHANGED
+      Stage-0 ``build_server_ssl_context`` / ``build_client_ssl_context`` and
+      yield real ``ssl.SSLContext`` with ``verify_mode == CERT_REQUIRED``;
+  (e) a real in-memory mutual handshake over a loopback socket SUCCEEDS with the
+      generated chain and a CERTLESS client is REJECTED (mirrors Stage-0
+      ``test_two_process_loopback.py::test_mtls_handshake_succeeds_and_is_required``);
+  (f) key files are 0600.
+
+The handshake test binds a loopback socket -> run with the sandbox disabled.
+"""
+from __future__ import annotations
+
+import importlib.util
+import ipaddress
+import os
+import socket
+import ssl
+import stat
+import sys
+import threading
+from typing import Any, Dict
+
+import pytest
+
+from cryptography import x509
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.asymmetric import padding
+from cryptography.x509.oid import ExtensionOID, ExtendedKeyUsageOID
+
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+from backend.core.ouroboros.governance.transport.transport_security import (
+    build_server_ssl_context,
+    build_client_ssl_context,
+)
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(os.path.dirname(_HERE))
+_GEN_PATH = os.path.join(_REPO_ROOT, "scripts", "gen_brain_mtls.py")
+
+
+def _load_gen() -> Any:
+    if _REPO_ROOT not in sys.path:
+        sys.path.insert(0, _REPO_ROOT)
+    spec = importlib.util.spec_from_file_location("gen_brain_mtls", _GEN_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _load_cert(path: str) -> x509.Certificate:
+    with open(path, "rb") as fh:
+        return x509.load_pem_x509_certificate(fh.read())
+
+
+def _tls_cfg(**over) -> TransportConfig:
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.05, reconnect_max_s=0.5, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=True, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+@pytest.fixture()
+def chain(tmp_path) -> Dict[str, str]:
+    gen = _load_gen()
+    return gen.generate_brain_mtls_chain(
+        out_dir=str(tmp_path / "mtls"),
+        server_identity="jarvis-brain-vm",
+        validity_days=7,
+    )
+
+
+# --- (a) all 5 PEMs land + parse -----------------------------------------
+def test_all_five_pems_generated_and_parse(chain):
+    for key in ("ca", "server_cert", "server_key", "client_cert", "client_key"):
+        assert key in chain, "missing return key %s" % key
+        assert os.path.exists(chain[key]), "missing file for %s" % key
+    for key in ("ca", "server_cert", "client_cert"):
+        cert = _load_cert(chain[key])
+        assert isinstance(cert, x509.Certificate)
+
+
+# --- (b) leaves signed by the CA -----------------------------------------
+def test_server_and_client_signed_by_ca(chain):
+    ca = _load_cert(chain["ca"])
+    ca_pub = ca.public_key()
+    for leaf_key in ("server_cert", "client_cert"):
+        leaf = _load_cert(chain[leaf_key])
+        assert leaf.issuer == ca.subject
+        # Verifies the leaf signature chains to the CA public key. Raises on
+        # mismatch -> a failed chain fails the test.
+        ca_pub.verify(
+            leaf.signature,
+            leaf.tbs_certificate_bytes,
+            padding.PKCS1v15(),
+            leaf.signature_hash_algorithm,
+        )
+
+
+# --- (c) EKUs + DNSName SAN, no literal-IP SAN ---------------------------
+def test_server_eku_and_dns_san_no_ip(chain):
+    server = _load_cert(chain["server_cert"])
+    eku = server.extensions.get_extension_for_oid(
+        ExtensionOID.EXTENDED_KEY_USAGE
+    ).value
+    assert ExtendedKeyUsageOID.SERVER_AUTH in eku
+    san = server.extensions.get_extension_for_oid(
+        ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+    ).value
+    dns_names = san.get_values_for_type(x509.DNSName)
+    assert dns_names, "server SAN must carry at least one DNSName"
+    # Architectural purity: NO literal-IP SAN. IPAddress SANs must be empty,
+    # and no DNSName may itself be an IP literal.
+    ip_sans = san.get_values_for_type(x509.IPAddress)
+    assert ip_sans == [], "server SAN must not contain a literal IPAddress"
+    for name in dns_names:
+        with pytest.raises(ValueError):
+            ipaddress.ip_address(name)
+
+
+def test_client_eku_client_auth(chain):
+    client = _load_cert(chain["client_cert"])
+    eku = client.extensions.get_extension_for_oid(
+        ExtensionOID.EXTENDED_KEY_USAGE
+    ).value
+    assert ExtendedKeyUsageOID.CLIENT_AUTH in eku
+
+
+def test_ca_is_a_ca(chain):
+    ca = _load_cert(chain["ca"])
+    bc = ca.extensions.get_extension_for_oid(ExtensionOID.BASIC_CONSTRAINTS).value
+    assert bc.ca is True
+
+
+# --- (d) THE LOAD PROOF via the UNCHANGED Stage-0 builders ----------------
+def test_load_proof_through_unchanged_builders(chain):
+    server_cfg = _tls_cfg(
+        tls_cert=chain["server_cert"], tls_key=chain["server_key"], tls_ca=chain["ca"],
+    )
+    client_cfg = _tls_cfg(
+        tls_cert=chain["client_cert"], tls_key=chain["client_key"], tls_ca=chain["ca"],
+    )
+    sctx = build_server_ssl_context(server_cfg)
+    cctx = build_client_ssl_context(client_cfg)
+    assert isinstance(sctx, ssl.SSLContext)
+    assert isinstance(cctx, ssl.SSLContext)
+    assert sctx.verify_mode == ssl.CERT_REQUIRED
+    assert cctx.verify_mode == ssl.CERT_REQUIRED
+
+
+# --- (e) real loopback mutual handshake + certless reject ----------------
+def _server_thread(listener: socket.socket, sctx: ssl.SSLContext, out: dict):
+    try:
+        conn, _ = listener.accept()
+        conn.settimeout(5.0)
+        try:
+            tls = sctx.wrap_socket(conn, server_side=True)
+            out["peercert"] = tls.getpeercert()
+            try:
+                tls.close()
+            except OSError:
+                pass
+        except Exception as exc:  # noqa: BLE001 - reject path is a pass
+            out["server_error"] = exc
+    except Exception as exc:  # noqa: BLE001
+        out["accept_error"] = exc
+
+
+def test_mutual_handshake_succeeds_and_certless_rejected(chain):
+    server_cfg = _tls_cfg(
+        tls_cert=chain["server_cert"], tls_key=chain["server_key"], tls_ca=chain["ca"],
+    )
+    client_cfg = _tls_cfg(
+        tls_cert=chain["client_cert"], tls_key=chain["client_key"], tls_ca=chain["ca"],
+    )
+    sctx = build_server_ssl_context(server_cfg)
+    cctx = build_client_ssl_context(client_cfg)
+
+    # The stable DNS identity the SERVER cert is bound to (no IP). The client
+    # verifies THIS name against the SAN -- proving identity-by-DNS, not by IP.
+    server = _load_cert(chain["server_cert"])
+    san = server.extensions.get_extension_for_oid(
+        ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+    ).value
+    identity = san.get_values_for_type(x509.DNSName)[0]
+
+    # (e.1) mTLS mutual handshake succeeds.
+    listener = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener.bind(("127.0.0.1", 0))
+    listener.listen(1)
+    port = listener.getsockname()[1]
+    out: dict = {}
+    t = threading.Thread(target=_server_thread, args=(listener, sctx, out), daemon=True)
+    t.start()
+    raw = socket.create_connection(("127.0.0.1", port), timeout=5.0)
+    tls = cctx.wrap_socket(raw, server_hostname=identity)
+    try:
+        assert tls.cipher() is not None
+    finally:
+        try:
+            tls.close()
+        except OSError:
+            pass
+        t.join(timeout=5.0)
+    assert "server_error" not in out, "handshake failed: %r" % out.get("server_error")
+    # Server saw the client's cert (mutual auth actually happened).
+    assert out.get("peercert"), "server did not receive a client cert"
+    listener.close()
+
+    # (e.2) a CERTLESS client is REJECTED (server CERT_REQUIRED).
+    listener2 = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+    listener2.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+    listener2.bind(("127.0.0.1", 0))
+    listener2.listen(1)
+    port2 = listener2.getsockname()[1]
+    out2: dict = {}
+    t2 = threading.Thread(target=_server_thread, args=(listener2, sctx, out2), daemon=True)
+    t2.start()
+    bare = ssl.SSLContext(ssl.PROTOCOL_TLS_CLIENT)
+    bare.check_hostname = False
+    bare.verify_mode = ssl.CERT_NONE  # accept server cert, present NO client cert
+    raw2 = socket.create_connection(("127.0.0.1", port2), timeout=5.0)
+    with pytest.raises((ssl.SSLError, OSError)):
+        cless = bare.wrap_socket(raw2, server_hostname=identity)
+        # If the handshake somehow returns, force I/O so the reject surfaces.
+        cless.send(b"x")
+        cless.recv(1)
+    t2.join(timeout=5.0)
+    assert "server_error" in out2, "certless client was NOT rejected by the server"
+    listener2.close()
+
+
+# --- (f) key perms 0600 ---------------------------------------------------
+def test_key_files_are_0600(chain):
+    for key in ("server_key", "client_key"):
+        mode = stat.S_IMODE(os.stat(chain[key]).st_mode)
+        assert mode == 0o600, "%s perms are %o, expected 600" % (key, mode)
+
+
+# --- extra: never a literal-IP SAN even when identity is empty -----------
+def test_default_identity_is_dns_no_ip(tmp_path):
+    gen = _load_gen()
+    chain = gen.generate_brain_mtls_chain(out_dir=str(tmp_path / "d"), server_identity="")
+    server = _load_cert(chain["server_cert"])
+    san = server.extensions.get_extension_for_oid(
+        ExtensionOID.SUBJECT_ALTERNATIVE_NAME
+    ).value
+    assert san.get_values_for_type(x509.IPAddress) == []
+    assert "jarvis-brain" in san.get_values_for_type(x509.DNSName)
+
+
+# --- extra: idempotent-safe (no silent overwrite without --force) --------
+def test_refuses_overwrite_without_force(tmp_path):
+    gen = _load_gen()
+    out = str(tmp_path / "once")
+    gen.generate_brain_mtls_chain(out_dir=out, server_identity="jarvis-brain-vm")
+    with pytest.raises(FileExistsError):
+        gen.generate_brain_mtls_chain(out_dir=out, server_identity="jarvis-brain-vm")
+    # force=True overwrites cleanly.
+    again = gen.generate_brain_mtls_chain(
+        out_dir=out, server_identity="jarvis-brain-vm", force=True,
+    )
+    assert os.path.exists(again["ca"])
+
+
+# --- extra: an IP-literal server_identity is refused ---------------------
+def test_ip_literal_identity_refused(tmp_path):
+    gen = _load_gen()
+    with pytest.raises(ValueError):
+        gen.generate_brain_mtls_chain(
+            out_dir=str(tmp_path / "ip"), server_identity="10.128.0.7",
+        )


### PR DESCRIPTION
Task-5 live-fire prerequisite, banked 2026-07-04 and now landing for the ignition step.

- Native `cryptography` CA + server + client chain generator (`scripts/gen_brain_mtls.py`)
- SAN bound to the `jarvis-brain` DNS identity — zero IP literals
- Loads through the UNCHANGED Stage-0 `build_*_ssl_context` builders
- Mutual-handshake + certless-reject proven in tests (11 passed)

Wiring note for the ignition probe (ledgered): the client verifies hostname on the CA path — the probe must pass `server_hostname="jarvis-brain"`, never the raw IP.

Purely additive: 2 new files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a native mTLS cert-chain generator for the Brain VM (CA + server + client) using `cryptography` only, with server identity bound to DNS (`jarvis-brain`) instead of IPs. Integrates with existing `build_server_ssl_context`/`build_client_ssl_context` and includes tests proving mutual auth and certless-client rejection.

- New Features
  - Added `scripts/gen_brain_mtls.py` to emit `ca.pem`, `server-cert.pem`/`server-key.pem`, and `client-cert.pem`/`client-key.pem`.
  - Server SAN uses DNS only: always `jarvis-brain`, plus optional instance name and `<instance>.<zone>.c.<project>.internal`; IP literals are refused.
  - Safe defaults: keys 0600; no overwrite unless `--force`; configurable validity (`JARVIS_BRAIN_MTLS_VALIDITY_DAYS`).
  - Tests verify CA signature chain, EKUs, no-IP SANs, load via existing builders, real mutual handshake, and certless-client reject.

- Migration
  - Client env: set `JARVIS_BRAIN_WS_TLS_CA`, `JARVIS_BRAIN_WS_TLS_CERT`, `JARVIS_BRAIN_WS_TLS_KEY` (server material injected separately via `JARVIS_BRAIN_SERVER_TLS_*`).
  - When connecting, pass `server_hostname="jarvis-brain"` (never the raw IP).
  - Optional: choose output dir via `--out-dir` or `JARVIS_BRAIN_MTLS_DIR`.

<sup>Written for commit eff310bf5059a6eadfbeb6e8a99c9eeb8ec4a1dc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

