### PR TITLE
feat(stage1): Task-5 acceptance wiring -- TLS delivery, SNI, brain echo server, un-loopbacked exchange

### DIFF
--- a/backend/core/ouroboros/governance/brain_discovery.py
+++ b/backend/core/ouroboros/governance/brain_discovery.py
@@ -215,7 +215,14 @@ async def _default_ws_health_probe(url: str) -> bool:
     host, port = parsed
     try:
         ctx = build_brain_client_ssl_context()
-        conn = asyncio.open_connection(host=host, port=port, ssl=ctx)
+        # The server cert's SAN is the DNS identity (jarvis-brain), but discovery
+        # dials the raw instance IP -- verify against the configured identity or
+        # the handshake can never succeed on the CA path.
+        kwargs: Dict[str, Any] = {}
+        sni = os.environ.get("JARVIS_BRAIN_WS_TLS_SERVER_HOSTNAME", "").strip()
+        if sni:
+            kwargs["server_hostname"] = sni
+        conn = asyncio.open_connection(host=host, port=port, ssl=ctx, **kwargs)
         reader, writer = await asyncio.wait_for(conn, timeout=_probe_timeout_s())
         try:
             writer.close()

--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -54,6 +54,11 @@ class BusBridgeClient:
         self._session_factory = session_factory
         self._stopped = False
         self._last_event_id: Optional[str] = None
+        # Outbound replay cursor: the last local event actually SENT to the peer.
+        # A reconnect re-subscribes from here so events published while severed
+        # cross client->server via broker replay (the server dedups overlaps).
+        # None = first connect (live-only, legacy behavior).
+        self._last_sent_id: Optional[str] = None
         self._high_water: int = 0
         self._degraded = False
         self._missed_hb = 0
@@ -129,9 +134,15 @@ class BusBridgeClient:
         ssl_ctx = build_client_ssl_context(self._cfg)
         session = (self._session_factory() if self._session_factory
                    else aiohttp.ClientSession())
+        # When discovery dialed a raw IP, the server cert's SAN is the DNS
+        # identity (e.g. jarvis-brain) -- verify against it explicitly. None
+        # preserves the legacy call shape (verify against the dialed host).
+        connect_kwargs: dict = {}
+        if self._cfg.tls_server_hostname:
+            connect_kwargs["server_hostname"] = self._cfg.tls_server_hostname
         try:
             async with session.ws_connect(
-                self._resolve_url(), ssl=ssl_ctx, heartbeat=None,
+                self._resolve_url(), ssl=ssl_ctx, heartbeat=None, **connect_kwargs,
             ) as ws:
                 await ws.send_bytes(
                     bf.hello_frame(self._cfg.source_id, self._last_event_id).encode()
@@ -155,7 +166,7 @@ class BusBridgeClient:
         StreamEventBroker.subscribe()/stream_iter() -- this method
         only filters broker-internal control events and translates
         StreamEvent -> BusFrame, writing bytes to the socket."""
-        sub = self._broker.subscribe(op_id_filter=None, last_event_id=None)
+        sub = self._broker.subscribe(op_id_filter=None, last_event_id=self._last_sent_id)
         if sub is None:
             return
         try:
@@ -170,6 +181,7 @@ class BusBridgeClient:
                     continue
                 frame = bf.event_frame(event, source_id=self._cfg.source_id)
                 await ws.send_bytes(frame.encode())
+                self._last_sent_id = event.event_id
         except (asyncio.CancelledError, ConnectionResetError):
             raise
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/transport/exchange_protocol.py
+++ b/backend/core/ouroboros/governance/transport/exchange_protocol.py
@@ -1,0 +1,92 @@
+"""Stage-1 cross-host acceptance exchange protocol (Task-5 wiring, 2026-07-04).
+
+The ValidationExchange (driver-side, unit-proven) needs a REAL Brain-side
+counterpart to clear the loopback guard. This module is the shared, pure
+vocabulary between the Mac driver's endpoint adapters and the Brain's echo
+responder -- zero I/O, fully unit-testable.
+
+Round-trip semantics
+--------------------
+Mac -> Brain proof: the Mac publishes exchange events; the Brain's responder
+ECHOES each one back (``echo_of_op`` = the original op_id). An echo observed on
+the Mac proves the Brain OBSERVED the original -- strictly stronger than the
+loopback it replaces.
+
+Brain -> Mac proof: the Mac publishes a *command* (``cmd=publish`` + a nonce);
+the responder answers with a fresh BRAIN-ORIGIN event carrying the nonce. A
+nonce observed on the Mac is an event the Brain itself published.
+
+Loop safety: the responder never reacts to its own outputs (``origin`` set) nor
+to commands' echoes, and only ops with the exchange prefix are ever touched --
+the organism's real ``task_started`` traffic is left alone. The WS bridges
+additionally dedup by qualified event id.
+"""
+from __future__ import annotations
+
+from typing import Any, Dict, List, Mapping, Optional, Tuple
+
+# The exchange rides a VALID StreamEventBroker event type (broker rejects
+# unknown types); the op-id prefix is the load-bearing discriminator.
+EXCHANGE_EVENT_TYPE = "task_started"
+EXCHANGE_OP_PREFIX = "brain-accept-"
+
+K_TAG = "tag"
+K_CMD = "cmd"
+CMD_PUBLISH = "publish"
+K_NONCE = "nonce"
+K_ORIGIN = "origin"
+ORIGIN_BRAIN = "brain"
+ORIGIN_ECHO = "brain-echo"
+K_ECHO_OF_OP = "echo_of_op"
+
+
+def is_exchange_op(op_id: str) -> bool:
+    return isinstance(op_id, str) and op_id.startswith(EXCHANGE_OP_PREFIX)
+
+
+def make_publish_cmd(nonce: str) -> Dict[str, Any]:
+    """Payload asking the Brain to publish a brain-origin event with ``nonce``."""
+    return {K_CMD: CMD_PUBLISH, K_NONCE: nonce}
+
+
+def respond(
+    event_type: str, op_id: str, payload: Optional[Mapping[str, Any]],
+) -> List[Tuple[str, str, Dict[str, Any]]]:
+    """The Brain responder's pure decision: given one observed event, return the
+    list of ``(event_type, op_id, payload)`` publishes it must answer with.
+
+    - a publish-command -> one BRAIN-ORIGIN event carrying the nonce;
+    - a plain exchange event -> one ECHO carrying the original op_id;
+    - anything self-originated / already-echoed / non-exchange -> nothing.
+    """
+    if event_type != EXCHANGE_EVENT_TYPE or not is_exchange_op(op_id):
+        return []
+    p = dict(payload or {})
+    if p.get(K_ORIGIN) in (ORIGIN_BRAIN, ORIGIN_ECHO) or K_ECHO_OF_OP in p:
+        return []  # never react to our own outputs
+    if p.get(K_CMD) == CMD_PUBLISH:
+        nonce = str(p.get(K_NONCE, ""))
+        if not nonce:
+            return []
+        return [(EXCHANGE_EVENT_TYPE, op_id,
+                 {K_NONCE: nonce, K_ORIGIN: ORIGIN_BRAIN})]
+    if K_TAG in p:
+        return [(EXCHANGE_EVENT_TYPE, op_id,
+                 {K_ECHO_OF_OP: op_id, K_ORIGIN: ORIGIN_ECHO})]
+    return []
+
+
+def parse_observed(
+    event_type: str, op_id: str, payload: Optional[Mapping[str, Any]],
+) -> Optional[Tuple[str, str]]:
+    """Mac-side classification of an inbound event: returns
+    ``("echo", original_op_id)`` for a Brain echo, ``("nonce", nonce)`` for a
+    brain-origin nonce event, None for anything else."""
+    if event_type != EXCHANGE_EVENT_TYPE or not is_exchange_op(op_id):
+        return None
+    p = dict(payload or {})
+    if p.get(K_ORIGIN) == ORIGIN_ECHO and p.get(K_ECHO_OF_OP):
+        return ("echo", str(p[K_ECHO_OF_OP]))
+    if p.get(K_ORIGIN) == ORIGIN_BRAIN and p.get(K_NONCE):
+        return ("nonce", str(p[K_NONCE]))
+    return None

--- a/backend/core/ouroboros/governance/transport/transport_config.py
+++ b/backend/core/ouroboros/governance/transport/transport_config.py
@@ -62,6 +62,10 @@ class TransportConfig:
     tls_ca: Optional[str]
     tls_ephemeral: bool
     source_id: str
+    # The DNS identity to verify the server cert against (its SAN), for clients
+    # that dial a raw IP (GCE discovery). None = verify against the dialed host
+    # (legacy loopback behavior).
+    tls_server_hostname: Optional[str] = None
 
     @classmethod
     def from_env(cls, *, role: str) -> "TransportConfig":
@@ -86,4 +90,5 @@ class TransportConfig:
             tls_ca=_env_str("JARVIS_BRAIN_WS_TLS_CA", None),
             tls_ephemeral=_env_bool("JARVIS_BRAIN_WS_TLS_EPHEMERAL", False),
             source_id=default_source or f"{role}-unknown",
+            tls_server_hostname=_env_str("JARVIS_BRAIN_WS_TLS_SERVER_HOSTNAME", None),
         )

--- a/scripts/brain_bus_echo_server.py
+++ b/scripts/brain_bus_echo_server.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Brain-side Stage-0 bus server + acceptance echo responder (Task-5 wiring).
+
+Runs ON the Brain VM as the ``jarvis-brain-bus.service`` sidecar (written by the
+ignition driver's runtime startup script -- the golden image needs no re-bake).
+It is the piece that makes the cross-host acceptance REAL:
+
+  1. serves the Stage-0 ``BusBridgeServer`` WS endpoint over mTLS (server cert
+     SAN = the ``jarvis-brain`` DNS identity; certless clients are rejected
+     before the WS upgrade);
+  2. answers the driver's ValidationExchange via the pure
+     ``exchange_protocol.respond`` rules (echoes prove Mac->Brain observation;
+     nonce responses prove Brain->Mac publication);
+  3. touches the liveness marker on WS-peer activity so the idle self-shutdown
+     timer never reaps a node mid-acceptance (the deferred Task-1 coupling).
+
+Config is 100% env-resolved (``/etc/jarvis/brain.env`` via systemd
+``EnvironmentFile``): the ``JARVIS_BRAIN_WS_*`` family. No baked endpoints, no
+literals. SIGTERM/SIGINT -> clean shutdown.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+
+_SCRIPTS_DIR = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(_SCRIPTS_DIR)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+logger = logging.getLogger("brain_bus_echo_server")
+
+_ENV_LIVENESS_MARKER = "JARVIS_BRAIN_LIVENESS_MARKER"
+_DEFAULT_LIVENESS_MARKER = "/run/jarvis/brain_liveness"
+
+
+def _touch_liveness() -> None:
+    """Best-effort liveness touch -- the idle timer reads this marker's mtime."""
+    path = os.environ.get(_ENV_LIVENESS_MARKER, _DEFAULT_LIVENESS_MARKER)
+    try:
+        with open(path, "a", encoding="utf-8"):
+            pass
+        os.utime(path, None)
+    except OSError:
+        logger.debug("liveness touch failed path=%s", path, exc_info=True)
+
+
+async def run_responder(broker, *, touch_fn=None) -> None:
+    """Subscribe to the local broker and answer exchange traffic per the pure
+    protocol rules. Injectable ``touch_fn`` for tests."""
+    import backend.core.ouroboros.governance.transport.exchange_protocol as xp
+
+    touch = touch_fn or _touch_liveness
+    sub = broker.subscribe()
+    if sub is None:
+        raise RuntimeError("broker subscriber cap exceeded -- responder cannot run")
+    try:
+        while True:
+            event = await sub.queue.get()
+            touch()
+            for etype, op_id, payload in xp.respond(
+                event.event_type, event.op_id, event.payload,
+            ):
+                broker.publish(etype, op_id, payload)
+    finally:
+        broker.unsubscribe(sub)
+
+
+async def amain() -> int:
+    from aiohttp import web
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+    )
+    from backend.core.ouroboros.governance.transport.distributed_event_bus import (
+        DistributedEventBus,
+    )
+    from backend.core.ouroboros.governance.transport.transport_config import (
+        TransportConfig,
+    )
+    from backend.core.ouroboros.governance.transport.transport_security import (
+        build_server_ssl_context,
+    )
+
+    cfg = TransportConfig.from_env(role="brain-server")
+    if cfg.port <= 0:
+        logger.error("JARVIS_BRAIN_WS_PORT unset/0 -- nothing to serve")
+        return 2
+    ssl_ctx = build_server_ssl_context(cfg)
+    if cfg.tls_enabled and ssl_ctx is None:
+        logger.error("TLS enabled but server ssl context could not be built "
+                     "(cert/key/ca paths in brain.env?) -- refusing plaintext")
+        return 3
+
+    broker = StreamEventBroker()
+    bus = DistributedEventBus(broker, cfg, role="server")
+    app = web.Application()
+    bus.register_server_routes(app)
+
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, host=cfg.host or "0.0.0.0", port=cfg.port,
+                       ssl_context=ssl_ctx)
+    await site.start()
+    _touch_liveness()
+    logger.info("brain bus serving host=%s port=%d tls=%s path=%s",
+                cfg.host or "0.0.0.0", cfg.port, bool(ssl_ctx), cfg.path)
+
+    stop = asyncio.Event()
+    loop = asyncio.get_event_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except (NotImplementedError, RuntimeError):
+            pass
+
+    responder = asyncio.ensure_future(run_responder(broker))
+    try:
+        await stop.wait()
+    finally:
+        responder.cancel()
+        try:
+            await responder
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        await runner.cleanup()
+    return 0
+
+
+def main() -> int:
+    logging.basicConfig(
+        level=os.environ.get("JARVIS_BRAIN_BUS_LOG_LEVEL", "INFO"),
+        format="%(asctime)s %(name)s %(levelname)s %(message)s",
+    )
+    try:
+        return asyncio.run(amain())
+    except KeyboardInterrupt:
+        return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/ignite_brain_vm.py
+++ b/scripts/ignite_brain_vm.py
@@ -104,6 +104,55 @@ _ENV_READY_BUDGET_S = "JARVIS_BRAIN_READY_BUDGET_S"
 _ENV_READY_BASE_S = "JARVIS_BRAIN_READY_BASE_S"
 _ENV_READY_CAP_S = "JARVIS_BRAIN_READY_CAP_S"
 _ENV_EXCHANGE_N = "JARVIS_BRAIN_EXCHANGE_N"
+_ENV_MTLS_DIR = "JARVIS_BRAIN_MTLS_DIR"
+
+# The server-side TLS material travels from the Mac (gen_brain_mtls.py output)
+# to the node as instance metadata; the runtime startup script writes it to
+# these node-local paths BEFORE the units start, and brain.env points at them.
+_NODE_TLS_DIR = "/etc/jarvis/tls"
+_TLS_META_KEYS = {
+    "server_cert": ("brain-tls-server-cert", "server-cert.pem"),
+    "server_key": ("brain-tls-server-key", "server-key.pem"),
+    "ca": ("brain-tls-ca", "ca.pem"),
+}
+
+
+class TLSMaterialError(RuntimeError):
+    """TLS is enabled but the server material is absent/incomplete. Raised in the
+    driver preflight BEFORE any GCP call (fail-closed, $0)."""
+
+
+def _tls_material() -> Optional[Dict[str, str]]:
+    """Load the SERVER PEM material (server cert/key + CA) from
+    ``JARVIS_BRAIN_MTLS_DIR`` (the gen_brain_mtls.py output dir). Returns None
+    when TLS is disabled; raises ``TLSMaterialError`` when TLS is enabled and any
+    piece is missing -- the ignition must never spend on a node that can only
+    fail its mTLS probe."""
+    if not _truthy(os.environ.get("JARVIS_BRAIN_WS_TLS_ENABLED", "true")):
+        return None
+    raw_dir = (os.environ.get(_ENV_MTLS_DIR, "") or "").strip()
+    if not raw_dir:
+        raise TLSMaterialError(
+            "TLS enabled but %s is unset -- run scripts/gen_brain_mtls.py and "
+            "export the material dir" % _ENV_MTLS_DIR)
+    mat: Dict[str, str] = {}
+    for part, (_meta_key, filename) in _TLS_META_KEYS.items():
+        path = os.path.join(raw_dir, filename)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                mat[part] = fh.read()
+        except OSError as exc:
+            raise TLSMaterialError(
+                "TLS enabled but %s is missing/unreadable (%s) -- aborting "
+                "BEFORE any GCP spend" % (path, exc)) from exc
+    return mat
+
+
+def _tls_extra_metadata(mat: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Map the loaded PEM material onto its instance-metadata keys."""
+    if not mat:
+        return {}
+    return {meta_key: mat[part] for part, (meta_key, _fn) in _TLS_META_KEYS.items()}
 
 
 def _persistent() -> bool:
@@ -529,6 +578,10 @@ class _LiveMacEndpoint:
         self._broker = broker
         self._client_getter = client_getter
         self._observed: List[Tuple[str, str]] = []
+        # Task-9 wiring: (op -> our minted event_id) for the echo mapping, and
+        # the full observed stream (type/op/eid/payload) for protocol parsing.
+        self._published: Dict[str, str] = {}
+        self._observed_full: List[Tuple[str, str, str, Dict[str, Any]]] = []
         self._sub = None
         self._task: Optional[asyncio.Task] = None
 
@@ -544,7 +597,17 @@ class _LiveMacEndpoint:
                     eid = getattr(ev, "event_id", "") or ""
                     op = getattr(ev, "op_id", "") or ""
                     if eid:
-                        self._observed.append((op, eid))
+                        etype = getattr(ev, "event_type", "") or ""
+                        payload = dict(getattr(ev, "payload", None) or {})
+                        self._observed_full.append((etype, op, eid, payload))
+                        # Brain-origin nonce events surface AS their nonce so the
+                        # exchange's expected-id matching sees what brain.publish
+                        # returned (the nonce IS the cross-host correlation id).
+                        parsed = _xp().parse_observed(etype, op, payload)
+                        if parsed and parsed[0] == "nonce":
+                            self._observed.append((op, parsed[1]))
+                        else:
+                            self._observed.append((op, eid))
             except asyncio.CancelledError:
                 raise
             except Exception:  # noqa: BLE001
@@ -562,7 +625,10 @@ class _LiveMacEndpoint:
             self._task = None
 
     def publish(self, event_type: str, op_id: str, payload: Dict[str, Any]) -> str:
-        return self._bus.publish(event_type, op_id, payload) or ""
+        eid = self._bus.publish(event_type, op_id, payload) or ""
+        if eid:
+            self._published[op_id] = eid
+        return eid
 
     def observed(self) -> List[Tuple[str, str]]:
         return list(self._observed)
@@ -571,6 +637,48 @@ class _LiveMacEndpoint:
     def last_event_id(self) -> Optional[str]:
         client = self._client_getter()
         return getattr(client, "last_event_id", None) if client else None
+
+
+def _xp():
+    """Lazy exchange-protocol import (keeps module import light for --help)."""
+    import backend.core.ouroboros.governance.transport.exchange_protocol as xp
+    return xp
+
+
+class _LiveBrainEndpoint:
+    """The BRAIN endpoint as seen FROM the Mac (Task-9 un-loopback).
+
+    ``publish()`` asks the Brain to publish: a nonce'd command crosses the
+    bridge, the Brain's echo responder answers with a BRAIN-ORIGIN event
+    carrying the nonce -- so the returned "event id" (the nonce) is observed on
+    the Mac iff the Brain really published across the wire.
+
+    ``observed()`` is what the Brain has PROVEN to observe: its echoes, mapped
+    back to the Mac-side event ids of the original ops (an echo for op X arrived
+    <=> the Brain saw the event the Mac minted for op X)."""
+
+    def __init__(self, mac: "_LiveMacEndpoint") -> None:
+        self.name = "brain"
+        self._mac = mac
+        self._pub_seq = 0
+
+    def publish(self, event_type: str, op_id: str, payload: Dict[str, Any]) -> str:
+        self._pub_seq += 1
+        nonce = "bn-%s-%d" % (op_id, self._pub_seq)
+        self._mac.publish(event_type, op_id, _xp().make_publish_cmd(nonce))
+        return nonce
+
+    def observed(self) -> List[Tuple[str, str]]:
+        xp = _xp()
+        out: List[Tuple[str, str]] = []
+        for etype, op, _eid, payload in self._mac._observed_full:
+            parsed = xp.parse_observed(etype, op, payload)
+            if parsed and parsed[0] == "echo":
+                orig_op = parsed[1]
+                mac_eid = self._mac._published.get(orig_op)
+                if mac_eid:
+                    out.append((orig_op, mac_eid))
+        return out
 
 
 # ---------------------------------------------------------------------------
@@ -637,6 +745,10 @@ class BrainIgnitionDriver:
         )
 
         brain_env = _compose_brain_env(self._brain_env_values())
+        extra = {_BRAIN_ENV_METADATA_KEY: brain_env}
+        # Ship the SERVER PEM material as metadata; the runtime startup script
+        # writes it to /etc/jarvis/tls/* before the units start.
+        extra.update(_tls_extra_metadata(_tls_material()))
         return await get_compute_rest().create_instance(
             startup_script=_brain_runtime_startup_script(),
             name=self.node_name,
@@ -645,14 +757,19 @@ class BrainIgnitionDriver:
             accelerator_type="",
             accelerator_count=0,
             labels={_BRAIN_ROLE_LABEL_KEY: _BRAIN_ROLE_LABEL_VALUE},
-            extra_metadata={_BRAIN_ENV_METADATA_KEY: brain_env},
+            extra_metadata=extra,
         )
 
     def _brain_env_values(self) -> Dict[str, str]:
         """Fold the Task-4 ignition values into the brain-env metadata: the WS
         port/path + TLS material references + the session cost cap, all
         env-resolved (Mandate 2). The idle-shutdown seconds are added by
-        ``_compose_brain_env`` itself."""
+        ``_compose_brain_env`` itself.
+
+        TLS paths: when server material is shipped (TLS enabled), the node's
+        brain.env is OVERRIDDEN to the node-local /etc/jarvis/tls/* paths the
+        runtime startup script writes -- the Mac-side env holds the Mac's OWN
+        (client) paths, which must never leak into the node's config."""
         vals: Dict[str, str] = {}
         for key in (
             "JARVIS_BRAIN_WS_PORT", "JARVIS_BRAIN_WS_PATH", "JARVIS_BRAIN_WS_TLS_ENABLED",
@@ -662,6 +779,13 @@ class BrainIgnitionDriver:
             v = os.environ.get(key)
             if v is not None and v != "":
                 vals[key] = v
+        if _tls_material() is not None:
+            vals["JARVIS_BRAIN_WS_TLS_CERT"] = "%s/%s" % (
+                _NODE_TLS_DIR, _TLS_META_KEYS["server_cert"][1])
+            vals["JARVIS_BRAIN_WS_TLS_KEY"] = "%s/%s" % (
+                _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
+            vals["JARVIS_BRAIN_WS_TLS_CA"] = "%s/%s" % (
+                _NODE_TLS_DIR, _TLS_META_KEYS["ca"][1])
         return vals
 
     async def _do_discover(self) -> Optional[str]:
@@ -753,14 +877,14 @@ class BrainIgnitionDriver:
             _live_tasks.append(new_task)
             return mac
 
-        # LOUD LOOPBACK GUARD (Fix 3): with no Brain-side echo subscriber (Task 5),
-        # the Brain observation endpoint is the SAME local broker as the Mac -- the
-        # bidirectional exchange is a LOCAL LOOPBACK, not a cross-host round-trip.
-        # ValidationExchange gates ``proven=False`` in this mode; make it visible.
-        _log("[BrainIgnite] bidirectional exchange is LOOPBACK (brain echo "
-             "subscriber not wired) -- cross-host round-trip UNPROVEN until Stage 2")
+        # Task-9 un-loopback: the Brain endpoint is REAL -- publish() commands the
+        # Brain's echo responder over the wire, observed() reads its echoes. The
+        # loopback guard clears (mac is not brain) and ``proven`` is reachable.
+        brain = _LiveBrainEndpoint(mac)
+        _log("[BrainIgnite] cross-host exchange armed (echo responder protocol; "
+             "loopback mode retired)")
         exchange = ValidationExchange(
-            mac=mac, brain=mac, reconnect=_reconnect, sever=_sever,
+            mac=mac, brain=brain, reconnect=_reconnect, sever=_sever,
             settle_s=_env_float("JARVIS_BRAIN_EXCHANGE_SETTLE_S", 1.0),
             observe_timeout_s=_env_float("JARVIS_BRAIN_EXCHANGE_OBSERVE_S", 15.0),
         )
@@ -791,6 +915,14 @@ class BrainIgnitionDriver:
                  "(persistent=%s) -- no GCP touched" % (self.fw_rule_name,
                                                         self.node_name, self.persistent))
             return 0
+
+        # 0. TLS PREFLIGHT -- fail-closed BEFORE any GCP call: a node that cannot
+        #    pass its own mTLS probe must never be paid for.
+        try:
+            _tls_material()
+        except TLSMaterialError as exc:
+            _log("TLS preflight FAILED ($0, nothing provisioned): %s" % exc)
+            return 4
 
         proven = False
         try:
@@ -881,16 +1013,53 @@ def _brain_runtime_startup_script() -> str:
     /run/jarvis exists + touches the liveness marker so the idle-check never nukes
     a freshly-booted node, and (c) restarts the unit to apply the fresh env.
     ASCII-only. Kept tiny + idempotent (Mandate 3: no new provisioning framework)."""
+    meta_base = "http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+    tls_fetch = "".join(
+        "curl -fsS -H 'Metadata-Flavor: Google' '%s/%s' -o %s/%s || true\n"
+        % (meta_base, meta_key, _NODE_TLS_DIR, filename)
+        for meta_key, filename in _TLS_META_KEYS.values()
+    )
     return (
         "#!/usr/bin/env bash\n"
         "set -uo pipefail\n"
-        "mkdir -p /etc/jarvis /run/jarvis\n"
-        "curl -fsS -H 'Metadata-Flavor: Google' "
-        "'http://metadata.google.internal/computeMetadata/v1/instance/attributes/brain-env' "
-        "-o /etc/jarvis/brain.env || : > /etc/jarvis/brain.env\n"
-        "touch /run/jarvis/brain_liveness\n"
+        "mkdir -p /etc/jarvis /run/jarvis %s\n" % _NODE_TLS_DIR
+        + "curl -fsS -H 'Metadata-Flavor: Google' "
+        "'%s/brain-env' " % meta_base
+        + "-o /etc/jarvis/brain.env || : > /etc/jarvis/brain.env\n"
+        # SERVER TLS material (shipped as metadata by the driver) -> node files,
+        # BEFORE any unit starts. Fail-soft per file: TLS-disabled ignitions have
+        # no such metadata and must still boot.
+        + tls_fetch
+        + "chmod 600 %s/%s 2>/dev/null || true\n" % (
+            _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
+        # Refresh the baked clone (fail-soft): the golden image tracks main at
+        # ignition, so driver-shipped scripts (e.g. the bus sidecar) that landed
+        # AFTER the bake are present without a re-bake.
+        + "git -C /opt/trinity/jarvis pull --ff-only || true\n"
+        # Stage-0 bus + acceptance echo responder SIDECAR: the Brain-side WS
+        # server the cross-host acceptance connects to. Same venv as the soak.
+        + "cat > /etc/systemd/system/jarvis-brain-bus.service <<'UNIT'\n"
+        "[Unit]\n"
+        "Description=JARVIS Brain Stage-0 bus + acceptance echo responder\n"
+        "After=network-online.target\n"
+        "Wants=network-online.target\n"
+        "\n"
+        "[Service]\n"
+        "Type=simple\n"
+        "WorkingDirectory=/opt/trinity/jarvis\n"
+        "EnvironmentFile=/etc/jarvis/brain.env\n"
+        "RuntimeDirectory=jarvis\n"
+        "ExecStart=/opt/trinity/venv/bin/python scripts/brain_bus_echo_server.py\n"
+        "Restart=on-failure\n"
+        "RestartSec=5\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=multi-user.target\n"
+        "UNIT\n"
+        + "touch /run/jarvis/brain_liveness\n"
         "systemctl daemon-reload || true\n"
         "systemctl restart jarvis-brain.service || systemctl start jarvis-brain.service || true\n"
+        "systemctl restart jarvis-brain-bus.service || systemctl start jarvis-brain-bus.service || true\n"
         "systemctl start jarvis-brain-idle.timer || true\n"
     )
 

--- a/tests/governance/transport/test_exchange_protocol.py
+++ b/tests/governance/transport/test_exchange_protocol.py
@@ -1,0 +1,125 @@
+# -*- coding: utf-8 -*-
+"""Exchange protocol (pure) + Brain echo responder (in-proc broker) spine."""
+from __future__ import annotations
+
+import asyncio
+
+from backend.core.ouroboros.governance.transport import exchange_protocol as xp
+
+
+OP = xp.EXCHANGE_OP_PREFIX + "m2b-123-0"
+
+
+# --------------------------------------------------------------------------- #
+# respond(): the Brain-side pure decision table.
+# --------------------------------------------------------------------------- #
+def test_plain_exchange_event_is_echoed():
+    out = xp.respond(xp.EXCHANGE_EVENT_TYPE, OP, {"seq": 0, "tag": "m2b"})
+    assert out == [(xp.EXCHANGE_EVENT_TYPE, OP,
+                    {xp.K_ECHO_OF_OP: OP, xp.K_ORIGIN: xp.ORIGIN_ECHO})]
+
+
+def test_publish_cmd_yields_brain_origin_nonce_event():
+    out = xp.respond(xp.EXCHANGE_EVENT_TYPE, OP, xp.make_publish_cmd("n-42"))
+    assert out == [(xp.EXCHANGE_EVENT_TYPE, OP,
+                    {xp.K_NONCE: "n-42", xp.K_ORIGIN: xp.ORIGIN_BRAIN})]
+
+
+def test_own_outputs_are_never_reacted_to():
+    echo_payload = {xp.K_ECHO_OF_OP: OP, xp.K_ORIGIN: xp.ORIGIN_ECHO}
+    nonce_payload = {xp.K_NONCE: "n-1", xp.K_ORIGIN: xp.ORIGIN_BRAIN}
+    assert xp.respond(xp.EXCHANGE_EVENT_TYPE, OP, echo_payload) == []
+    assert xp.respond(xp.EXCHANGE_EVENT_TYPE, OP, nonce_payload) == []
+
+
+def test_non_exchange_ops_and_types_are_ignored():
+    # The organism's real task_started traffic (no exchange prefix) is sacred.
+    assert xp.respond(xp.EXCHANGE_EVENT_TYPE, "op-019f-real", {"tag": "x"}) == []
+    assert xp.respond("task_completed", OP, {"tag": "m2b"}) == []
+    assert xp.respond(xp.EXCHANGE_EVENT_TYPE, OP, {"no": "tag"}) == []
+
+
+def test_cmd_without_nonce_is_dropped():
+    assert xp.respond(xp.EXCHANGE_EVENT_TYPE, OP, {xp.K_CMD: xp.CMD_PUBLISH}) == []
+
+
+# --------------------------------------------------------------------------- #
+# parse_observed(): the Mac-side classification.
+# --------------------------------------------------------------------------- #
+def test_parse_observed_echo_and_nonce_and_noise():
+    assert xp.parse_observed(
+        xp.EXCHANGE_EVENT_TYPE, OP,
+        {xp.K_ECHO_OF_OP: OP, xp.K_ORIGIN: xp.ORIGIN_ECHO}) == ("echo", OP)
+    assert xp.parse_observed(
+        xp.EXCHANGE_EVENT_TYPE, OP,
+        {xp.K_NONCE: "n-7", xp.K_ORIGIN: xp.ORIGIN_BRAIN}) == ("nonce", "n-7")
+    assert xp.parse_observed(xp.EXCHANGE_EVENT_TYPE, OP, {"tag": "m2b"}) is None
+    assert xp.parse_observed(xp.EXCHANGE_EVENT_TYPE, "op-019f-real",
+                             {xp.K_NONCE: "n", xp.K_ORIGIN: "brain"}) is None
+
+
+# --------------------------------------------------------------------------- #
+# run_responder(): wired against a REAL in-proc StreamEventBroker.
+# --------------------------------------------------------------------------- #
+def test_responder_echoes_and_answers_cmds_on_real_broker():
+    import importlib.util
+    import sys
+    from pathlib import Path
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+    )
+
+    script = Path(__file__).resolve().parents[3] / "scripts" / "brain_bus_echo_server.py"
+    spec = importlib.util.spec_from_file_location("brain_bus_echo_server", script)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("brain_bus_echo_server", mod)
+    spec.loader.exec_module(mod)
+
+    async def scenario():
+        broker = StreamEventBroker()
+        touches = []
+        task = asyncio.ensure_future(
+            mod.run_responder(broker, touch_fn=lambda: touches.append(1)))
+        await asyncio.sleep(0.05)  # subscriber armed
+
+        broker.publish(xp.EXCHANGE_EVENT_TYPE, OP, {"seq": 0, "tag": "m2b"})
+        cmd_op = xp.EXCHANGE_OP_PREFIX + "b2m-123-0"
+        broker.publish(xp.EXCHANGE_EVENT_TYPE, cmd_op, xp.make_publish_cmd("n-9"))
+        await asyncio.sleep(0.2)
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return broker, touches
+
+    broker, touches = asyncio.get_event_loop().run_until_complete(scenario())
+    # History carries: original + echo + cmd + nonce response = 4 events.
+    assert broker.published_count == 4
+    assert touches, "liveness must be touched on WS-peer activity"
+
+
+def test_responder_does_not_echo_its_own_echo_no_storm():
+    import brain_bus_echo_server as mod  # loaded by the previous test
+
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+    )
+
+    async def scenario():
+        broker = StreamEventBroker()
+        task = asyncio.ensure_future(
+            mod.run_responder(broker, touch_fn=lambda: None))
+        await asyncio.sleep(0.05)
+        broker.publish(xp.EXCHANGE_EVENT_TYPE, OP, {"seq": 0, "tag": "m2b"})
+        await asyncio.sleep(0.3)  # long enough for any echo-of-echo storm
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        return broker
+
+    broker = asyncio.get_event_loop().run_until_complete(scenario())
+    assert broker.published_count == 2, "exactly original + one echo -- no storm"

--- a/tests/governance/transport/test_tls_server_hostname.py
+++ b/tests/governance/transport/test_tls_server_hostname.py
@@ -1,0 +1,157 @@
+# -*- coding: utf-8 -*-
+"""tls_server_hostname wiring: config field + client + discovery-probe passthrough.
+
+Live-fire attempt-1 pre-flight finding (2026-07-04): the Brain server cert's SAN
+is the DNS identity ``jarvis-brain`` (never an IP), but both the discovery
+health-probe and the WS client connect to a raw IP -- with ``check_hostname``
+enabled on the CA path the handshake can NEVER succeed unless the intended
+identity is passed as ``server_hostname``. Default None = legacy behavior
+(loopback tests connect by resolvable hostname and need no override).
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict
+
+import pytest
+
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+
+
+def _clear_ws_env(monkeypatch):
+    for key in list(os.environ):
+        if key.startswith("JARVIS_BRAIN_WS_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+# --------------------------------------------------------------------------- #
+# (a) config field: default None, env-overridable.
+# --------------------------------------------------------------------------- #
+def test_tls_server_hostname_defaults_none(monkeypatch):
+    _clear_ws_env(monkeypatch)
+    cfg = TransportConfig.from_env(role="client")
+    assert cfg.tls_server_hostname is None
+
+
+def test_tls_server_hostname_env_overridable(monkeypatch):
+    _clear_ws_env(monkeypatch)
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_SERVER_HOSTNAME", "jarvis-brain")
+    cfg = TransportConfig.from_env(role="client")
+    assert cfg.tls_server_hostname == "jarvis-brain"
+
+
+# --------------------------------------------------------------------------- #
+# (b) BusBridgeClient passes server_hostname to ws_connect when set (and omits
+#     it when unset -- legacy call shape preserved).
+# --------------------------------------------------------------------------- #
+class _CaptureSession:
+    """Fake aiohttp session: capture ws_connect kwargs, then abort the connect."""
+
+    def __init__(self, captured: Dict[str, Any]) -> None:
+        self._captured = captured
+
+    def ws_connect(self, url: str, **kwargs: Any):
+        self._captured["url"] = url
+        self._captured.update(kwargs)
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                raise RuntimeError("capture-abort")
+
+            async def __aexit__(self_inner, *exc: Any) -> bool:
+                return False
+
+        return _Ctx()
+
+    async def close(self) -> None:
+        return None
+
+
+def _mk_cfg(monkeypatch, hostname: str | None) -> TransportConfig:
+    _clear_ws_env(monkeypatch)
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    if hostname is not None:
+        monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_SERVER_HOSTNAME", hostname)
+    return TransportConfig.from_env(role="client")
+
+
+def test_client_passes_server_hostname_when_set(monkeypatch):
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+    )
+    from backend.core.ouroboros.governance.transport.bus_bridge_client import (
+        BusBridgeClient,
+    )
+
+    captured: Dict[str, Any] = {}
+    cfg = _mk_cfg(monkeypatch, "jarvis-brain")
+    client = BusBridgeClient(
+        StreamEventBroker(), cfg,
+        url="wss://203.0.113.7:8443/ws/trinity-bus",
+        session_factory=lambda: _CaptureSession(captured),
+    )
+    with pytest.raises(RuntimeError, match="capture-abort"):
+        asyncio.get_event_loop().run_until_complete(client._connect_once())
+    assert captured.get("server_hostname") == "jarvis-brain"
+
+
+def test_client_omits_server_hostname_when_unset(monkeypatch):
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        StreamEventBroker,
+    )
+    from backend.core.ouroboros.governance.transport.bus_bridge_client import (
+        BusBridgeClient,
+    )
+
+    captured: Dict[str, Any] = {}
+    cfg = _mk_cfg(monkeypatch, None)
+    client = BusBridgeClient(
+        StreamEventBroker(), cfg,
+        url="wss://203.0.113.7:8443/ws/trinity-bus",
+        session_factory=lambda: _CaptureSession(captured),
+    )
+    with pytest.raises(RuntimeError, match="capture-abort"):
+        asyncio.get_event_loop().run_until_complete(client._connect_once())
+    assert "server_hostname" not in captured, "legacy call shape must be preserved"
+
+
+# --------------------------------------------------------------------------- #
+# (c) discovery probe passes server_hostname to open_connection when set.
+# --------------------------------------------------------------------------- #
+def test_probe_passes_server_hostname_when_set(monkeypatch):
+    import backend.core.ouroboros.governance.brain_discovery as bd
+
+    _clear_ws_env(monkeypatch)
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_SERVER_HOSTNAME", "jarvis-brain")
+    captured: Dict[str, Any] = {}
+
+    async def _fake_open_connection(**kwargs: Any):
+        captured.update(kwargs)
+        raise ConnectionRefusedError("capture-abort")
+
+    monkeypatch.setattr(bd.asyncio, "open_connection", _fake_open_connection)
+    ok = asyncio.get_event_loop().run_until_complete(
+        bd._default_ws_health_probe("wss://203.0.113.7:8443/ws/trinity-bus")
+    )
+    assert ok is False  # fail-soft on refused connect
+    assert captured.get("server_hostname") == "jarvis-brain"
+    assert captured.get("host") == "203.0.113.7"
+
+
+def test_probe_omits_server_hostname_when_unset(monkeypatch):
+    import backend.core.ouroboros.governance.brain_discovery as bd
+
+    _clear_ws_env(monkeypatch)
+    captured: Dict[str, Any] = {}
+
+    async def _fake_open_connection(**kwargs: Any):
+        captured.update(kwargs)
+        raise ConnectionRefusedError("capture-abort")
+
+    monkeypatch.setattr(bd.asyncio, "open_connection", _fake_open_connection)
+    ok = asyncio.get_event_loop().run_until_complete(
+        bd._default_ws_health_probe("wss://203.0.113.7:8443/ws/trinity-bus")
+    )
+    assert ok is False
+    assert "server_hostname" not in captured

--- a/tests/infra/test_brain_live_endpoints.py
+++ b/tests/infra/test_brain_live_endpoints.py
@@ -1,0 +1,214 @@
+# -*- coding: utf-8 -*-
+"""Task-9 wiring: client outbound replay cursor + live endpoint adapters +
+un-loopbacked exchange over two REAL brokers with the REAL Brain responder.
+
+The loopback design masked a Stage-0 gap: the WS client's outbound pump
+re-subscribed with ``last_event_id=None`` on every reconnect, so events
+published while severed never crossed client->server (server->client replay
+worked via the hello). The cursor closes it; the adapters make the
+cross-host bidirectional proof real (ValidationExchange itself UNCHANGED).
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import sys
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+import backend.core.ouroboros.governance.transport.exchange_protocol as xp
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+
+_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load(name: str):
+    spec = importlib.util.spec_from_file_location(name, _ROOT / "scripts" / f"{name}.py")
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault(name, mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def ign():
+    return _load("ignite_brain_vm")
+
+
+@pytest.fixture()
+def echo_mod():
+    return _load("brain_bus_echo_server")
+
+
+# --------------------------------------------------------------------------- #
+# (a) client outbound pump resumes from its last-SENT cursor.
+# --------------------------------------------------------------------------- #
+def test_client_outbound_pump_resumes_from_last_sent_cursor(monkeypatch):
+    from backend.core.ouroboros.governance.transport.bus_bridge_client import (
+        BusBridgeClient,
+    )
+    from backend.core.ouroboros.governance.transport.transport_config import (
+        TransportConfig,
+    )
+
+    for key in ("JARVIS_BRAIN_WS_TLS_ENABLED",):
+        monkeypatch.setenv(key, "false")
+    cfg = TransportConfig.from_env(role="client")
+    broker = StreamEventBroker()
+    client = BusBridgeClient(broker, cfg, url="ws://localhost:1/ws")
+
+    captured: List[Optional[str]] = []
+    real_subscribe = broker.subscribe
+
+    def _spy(op_id_filter=None, last_event_id=None):
+        captured.append(last_event_id)
+        return real_subscribe(op_id_filter=op_id_filter, last_event_id=last_event_id)
+
+    monkeypatch.setattr(broker, "subscribe", _spy)
+
+    class _FakeWS:
+        closed = False
+        sent: List[bytes] = []
+
+        async def send_bytes(self, b: bytes) -> None:
+            self.sent.append(b)
+            self.closed = True  # one send then hang up
+
+    async def scenario():
+        ws = _FakeWS()
+        pump = asyncio.ensure_future(client._pump_outbound(ws))
+        await asyncio.sleep(0.1)  # live-only subscription armed
+        eid1 = broker.publish(xp.EXCHANGE_EVENT_TYPE, "op-1", {"n": 1})
+        await asyncio.sleep(0.2)
+        pump.cancel()
+        try:
+            await pump
+        except asyncio.CancelledError:
+            pass
+        return eid1
+
+    eid1 = asyncio.get_event_loop().run_until_complete(scenario())
+    # First connect: no cursor (None). After sending event 1, the cursor is set.
+    assert captured[0] is None
+    assert client._last_sent_id == eid1
+
+    async def reconnect():
+        ws = _FakeWS()
+        pump = asyncio.ensure_future(client._pump_outbound(ws))
+        await asyncio.sleep(0.1)
+        pump.cancel()
+        try:
+            await pump
+        except asyncio.CancelledError:
+            pass
+
+    asyncio.get_event_loop().run_until_complete(reconnect())
+    assert captured[1] == eid1, "reconnect must resume from the last-SENT cursor"
+
+
+# --------------------------------------------------------------------------- #
+# (b)+(c) adapters + REAL responder over two real brokers, bridged in-proc.
+# --------------------------------------------------------------------------- #
+class _InProcBridge:
+    """Mirror publishes between two real brokers (the WS bridge, in-proc), with
+    a severable link + buffered replay on reconnect -- op-prefixed exchange
+    traffic only, mimicking the wire's dedup-by-id."""
+
+    def __init__(self, mac: StreamEventBroker, brain: StreamEventBroker) -> None:
+        self.mac, self.brain = mac, brain
+        self.connected = True
+        self._seen: set = set()
+        self._buffered: List[Tuple[str, str, str, Dict[str, Any]]] = []
+        self._tasks: List[asyncio.Task] = []
+
+    async def start(self) -> None:
+        self._tasks = [
+            asyncio.ensure_future(self._pump(self.mac, self.brain, "m2b")),
+            asyncio.ensure_future(self._pump(self.brain, self.mac, "b2m")),
+        ]
+
+    async def stop(self) -> None:
+        for t in self._tasks:
+            t.cancel()
+        for t in self._tasks:
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+
+    def sever(self) -> None:
+        self.connected = False
+
+    def reconnect(self) -> None:
+        self.connected = True
+        for etype, op, eid, payload in self._buffered:
+            if eid not in self._seen:
+                self._seen.add(eid)
+                self._dst_for_buffer.publish(etype, op, payload)
+        self._buffered.clear()
+
+    async def _pump(self, src: StreamEventBroker, dst: StreamEventBroker,
+                    tag: str) -> None:
+        sub = src.subscribe()
+        assert sub is not None
+        if tag == "m2b":
+            self._dst_for_buffer = dst  # mac->brain is the severable direction
+        while True:
+            ev = await sub.queue.get()
+            if not xp.is_exchange_op(ev.op_id):
+                continue
+            if ev.event_id in self._seen:
+                continue
+            if not self.connected and tag == "m2b":
+                self._buffered.append(
+                    (ev.event_type, ev.op_id, ev.event_id, dict(ev.payload)))
+                continue
+            self._seen.add(ev.event_id)
+            dst.publish(ev.event_type, ev.op_id, dict(ev.payload))
+
+
+def test_exchange_cross_host_proven_with_real_responder(ign, echo_mod):
+    async def scenario():
+        mac_broker = StreamEventBroker()
+        brain_broker = StreamEventBroker()
+        bridge = _InProcBridge(mac_broker, brain_broker)
+        await bridge.start()
+        responder = asyncio.ensure_future(
+            echo_mod.run_responder(brain_broker, touch_fn=lambda: None))
+        await asyncio.sleep(0.05)
+
+        class _Bus:  # publish seam the mac endpoint uses
+            def publish(self, etype, op, payload):
+                return mac_broker.publish(etype, op, payload)
+
+        mac = ign._LiveMacEndpoint(_Bus(), mac_broker, lambda: None)
+        await mac.start()
+        brain = ign._LiveBrainEndpoint(mac)
+
+        async def _reconnect():
+            bridge.reconnect()
+            return mac
+
+        async def _sever():
+            bridge.sever()
+
+        exchange = ign.ValidationExchange(
+            mac=mac, brain=brain, reconnect=_reconnect, sever=_sever,
+            settle_s=0.15, observe_timeout_s=5.0,
+        )
+        result = await exchange.run_all(3)
+        responder.cancel()
+        await mac.stop()
+        await bridge.stop()
+        return result
+
+    result = asyncio.get_event_loop().run_until_complete(scenario())
+    assert result.get("loopback_only") in (False, None), (
+        "distinct endpoints must clear the loopback guard: %r" % result)
+    assert result["bidirectional"]["ok"], result
+    assert result["reconnect_replay"]["ok"], result
+    assert result["proven"] is True, result

--- a/tests/infra/test_brain_tls_delivery.py
+++ b/tests/infra/test_brain_tls_delivery.py
@@ -1,0 +1,164 @@
+# -*- coding: utf-8 -*-
+"""TLS material delivery: driver preflight + metadata + node files (Task-5 wiring).
+
+Live-fire pre-flight finding (2026-07-04): the driver folded Mac-local
+``JARVIS_BRAIN_WS_TLS_*`` PATHS into brain.env, but the SSL builders take file
+paths and nothing ever shipped the PEMs onto the node -- and the Mac's CLIENT
+cert paths would have masqueraded as the node's SERVER cert. This spine proves:
+
+  (a) fail-closed preflight: TLS enabled + material missing -> abort BEFORE any
+      GCP call ($0);
+  (b) the server PEMs + CA travel via instance metadata keys;
+  (c) brain.env TLS paths are OVERRIDDEN to the node-local /etc/jarvis/tls/*;
+  (d) the runtime startup script writes those files (key 0600) BEFORE the unit
+      (re)start.
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_SCRIPT = Path(__file__).resolve().parents[2] / "scripts" / "ignite_brain_vm.py"
+
+
+def _load():
+    spec = importlib.util.spec_from_file_location("ignite_brain_vm", _SCRIPT)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules.setdefault("ignite_brain_vm", mod)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+@pytest.fixture()
+def ign():
+    return _load()
+
+
+@pytest.fixture()
+def mtls_dir(tmp_path, monkeypatch):
+    d = tmp_path / "mtls"
+    d.mkdir()
+    (d / "server-cert.pem").write_text("PEM-SERVER-CERT")
+    (d / "server-key.pem").write_text("PEM-SERVER-KEY")
+    (d / "ca.pem").write_text("PEM-CA")
+    monkeypatch.setenv("JARVIS_BRAIN_MTLS_DIR", str(d))
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
+    return d
+
+
+# --------------------------------------------------------------------------- #
+# (a) fail-closed preflight.
+# --------------------------------------------------------------------------- #
+def test_tls_material_loads_from_mtls_dir(ign, mtls_dir):
+    mat = ign._tls_material()
+    assert mat == {
+        "server_cert": "PEM-SERVER-CERT",
+        "server_key": "PEM-SERVER-KEY",
+        "ca": "PEM-CA",
+    }
+
+
+def test_tls_material_missing_raises_before_any_gcp(ign, tmp_path, monkeypatch):
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("JARVIS_BRAIN_MTLS_DIR", str(empty))
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
+    with pytest.raises(ign.TLSMaterialError):
+        ign._tls_material()
+
+
+def test_tls_material_none_when_tls_disabled(ign, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_BRAIN_MTLS_DIR", raising=False)
+    assert ign._tls_material() is None
+
+
+def test_tls_material_unset_dir_raises_when_tls_enabled(ign, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_BRAIN_MTLS_DIR", raising=False)
+    with pytest.raises(ign.TLSMaterialError):
+        ign._tls_material()
+
+
+# --------------------------------------------------------------------------- #
+# (b)+(c) metadata keys + brain.env node-path override.
+# --------------------------------------------------------------------------- #
+def test_tls_metadata_keys_carry_pem_content(ign, mtls_dir):
+    meta = ign._tls_extra_metadata(ign._tls_material())
+    assert meta["brain-tls-server-cert"] == "PEM-SERVER-CERT"
+    assert meta["brain-tls-server-key"] == "PEM-SERVER-KEY"
+    assert meta["brain-tls-ca"] == "PEM-CA"
+
+
+def test_brain_env_values_override_tls_paths_to_node_local(ign, mtls_dir, monkeypatch):
+    # Mac-side env points at MAC paths (the client material) -- the node must
+    # NEVER see them.
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_CERT", "/Users/mac/client-cert.pem")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_KEY", "/Users/mac/client-key.pem")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_CA", "/Users/mac/ca.pem")
+    driver = ign.BrainIgnitionDriver(dry_run=True)
+    vals = driver._brain_env_values()
+    assert vals["JARVIS_BRAIN_WS_TLS_CERT"] == "/etc/jarvis/tls/server-cert.pem"
+    assert vals["JARVIS_BRAIN_WS_TLS_KEY"] == "/etc/jarvis/tls/server-key.pem"
+    assert vals["JARVIS_BRAIN_WS_TLS_CA"] == "/etc/jarvis/tls/ca.pem"
+    for v in vals.values():
+        assert "/Users/" not in v, "Mac-local paths must never reach brain.env"
+
+
+def test_brain_env_values_no_override_when_tls_disabled(ign, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_BRAIN_MTLS_DIR", raising=False)
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_CERT", "/tmp/x.pem")
+    driver = ign.BrainIgnitionDriver(dry_run=True)
+    vals = driver._brain_env_values()
+    # Legacy fold-through when no material is shipped.
+    assert vals.get("JARVIS_BRAIN_WS_TLS_CERT") == "/tmp/x.pem"
+
+
+# --------------------------------------------------------------------------- #
+# (d) runtime startup script writes the TLS files before the unit (re)start.
+# --------------------------------------------------------------------------- #
+def test_runtime_startup_script_writes_tls_files_before_restart(ign):
+    script = ign._brain_runtime_startup_script()
+    for key, path in (
+        ("brain-tls-server-cert", "/etc/jarvis/tls/server-cert.pem"),
+        ("brain-tls-server-key", "/etc/jarvis/tls/server-key.pem"),
+        ("brain-tls-ca", "/etc/jarvis/tls/ca.pem"),
+    ):
+        assert key in script, f"metadata key {key} must be fetched"
+        assert path in script, f"node file {path} must be written"
+        assert script.index(path) < script.index("systemctl restart jarvis-brain"), (
+            "TLS files must land before the unit restart")
+    assert "chmod 600 /etc/jarvis/tls/server-key.pem" in script
+    assert script.startswith("#!")
+    script.encode("ascii")
+
+
+# --------------------------------------------------------------------------- #
+# (e) runtime startup script refreshes the baked clone (fail-soft) and starts
+#     the Stage-0 bus + echo-responder SIDECAR -- the Brain-side server that
+#     makes the cross-host acceptance real (wired-but-inert finding #6: the
+#     transport package previously had no boot path on the node).
+# --------------------------------------------------------------------------- #
+def test_runtime_startup_script_pulls_repo_before_units(ign):
+    script = ign._brain_runtime_startup_script()
+    assert "git -C /opt/trinity/jarvis pull --ff-only || true" in script, (
+        "the baked clone must track main at ignition (fail-soft)")
+    assert script.index("git -C /opt/trinity/jarvis pull") < script.index(
+        "systemctl restart jarvis-brain"), "pull must precede unit (re)starts"
+
+
+def test_runtime_startup_script_writes_and_starts_bus_sidecar(ign):
+    script = ign._brain_runtime_startup_script()
+    assert "jarvis-brain-bus.service" in script
+    assert ("ExecStart=/opt/trinity/venv/bin/python scripts/brain_bus_echo_server.py"
+            in script), "sidecar must run under the SAME venv as the soak"
+    assert "EnvironmentFile=/etc/jarvis/brain.env" in script
+    assert "WorkingDirectory=/opt/trinity/jarvis" in script
+    # TLS files must land before the sidecar starts (it builds the server ctx).
+    assert script.index("/etc/jarvis/tls/ca.pem") < script.index(
+        "systemctl restart jarvis-brain-bus.service")
+    script.encode("ascii")

--- a/tests/infra/test_ignite_brain_vm.py
+++ b/tests/infra/test_ignite_brain_vm.py
@@ -51,6 +51,19 @@ def _load_driver() -> Any:
 ign = _load_driver()
 
 
+@pytest.fixture(autouse=True)
+def _tls_material_env(tmp_path, monkeypatch):
+    """The driver's TLS preflight is fail-closed BEFORE any GCP call (Task-5
+    wiring, 2026-07-04). These unit runs declare their TLS posture explicitly:
+    a real (tmp) server-material dir, so the preflight itself is exercised on
+    every run() path."""
+    d = tmp_path / "mtls"
+    d.mkdir()
+    for fn in ("server-cert.pem", "server-key.pem", "ca.pem"):
+        (d / fn).write_text("PEM-TEST-%s" % fn)
+    monkeypatch.setenv("JARVIS_BRAIN_MTLS_DIR", str(d))
+
+
 # ---------------------------------------------------------------------------
 # Fake in-proc bidirectional bus wire for the exchange-logic tests.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Four unit-green-fails-live gaps caught at $0 by the ignition pre-flight

Each would have burned a node mid-acceptance:

1. **No PEM delivery** — Mac-local TLS paths folded into brain.env; node never received material (and would've served the Mac's *client* cert). Fix: fail-closed preflight (abort BEFORE any GCP call), PEMs via instance metadata → `/etc/jarvis/tls/*` (key 0600) → brain.env node-path override.
2. **+3. Hostname verification** — probe + WS client dial raw IPs, server SAN is DNS `jarvis-brain` → handshake could never succeed. Fix: `TransportConfig.tls_server_hostname` (`JARVIS_BRAIN_WS_TLS_SERVER_HOSTNAME`, default None = legacy) at both connect sites.
4. **No Brain-side server boot** (wired-but-inert #6) — transport package had zero consumers on the node; live exchange ran loopback with `proven=False` gated. Fix: `scripts/brain_bus_echo_server.py` sidecar (mTLS bus server + pure `exchange_protocol` responder + liveness touch), written+started by the runtime startup script, which now also `git pull --ff-only` (fail-soft) so the golden image tracks main at ignition — **no re-bake needed**.

**Bonus real Stage-0 gap the loopback masked:** the WS client's outbound pump re-subscribed with `last_event_id=None` on reconnect — severed-span events never crossed client→server. Fixed with an outbound last-sent cursor (server dedups overlaps).

**ValidationExchange unchanged** — `_LiveBrainEndpoint` adapts publish→nonce'd commands / observed→echo-mapping; the loopback guard clears and `proven` is finally reachable. Proven in-proc over two real brokers with the real responder.

119 tests green (transport + infra + brain suites).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Task-5 acceptance wiring: ships TLS PEMs to the Brain, runs a real mTLS bus + echo responder, and removes the loopback so cross‑host exchange is proven. Also fixes TLS hostname verification and reconnect replay gaps.

- **New Features**
  - TLS PEM delivery: driver preflight requires `JARVIS_BRAIN_MTLS_DIR`; PEMs sent via instance metadata; startup writes `/etc/jarvis/tls/*` (key 0600) and overrides `brain.env` to node-local paths.
  - Brain bus sidecar: `scripts/brain_bus_echo_server.py` runs an mTLS WS server plus pure `transport.exchange_protocol` responder, and touches liveness. Added `jarvis-brain-bus.service`.
  - Startup refresh: `git pull --ff-only` on the node so the baked clone tracks main at ignition (no re-bake).
  - Un-loopbacked exchange: new pure `exchange_protocol` and a real Brain endpoint adapter make ValidationExchange cross-host while keeping its API unchanged.

- **Bug Fixes**
  - TLS SAN mismatch: added `tls_server_hostname` (`JARVIS_BRAIN_WS_TLS_SERVER_HOSTNAME`) and passed it to discovery and the `aiohttp` WS client to fix IP-dial + DNS-SAN handshakes.
  - Reconnect replay: WS client now resumes outbound from the last sent event id so severed-span events are delivered after reconnect (server dedups).

<sup>Written for commit e053988c74127bab8d8990bcae5a923b240e440f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69839?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

