### PR TITLE
fix(transport): reflection suppression + connect gate + cursor-across-reconnect (live-fire attempt 2)

### DIFF
--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -47,6 +47,7 @@ class BusBridgeClient:
         *,
         url: Optional[str] = None,
         session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None,
+        initial_last_sent_id: Optional[str] = None,
     ) -> None:
         self._broker = broker
         self._cfg = cfg
@@ -57,12 +58,31 @@ class BusBridgeClient:
         # Outbound replay cursor: the last local event actually SENT to the peer.
         # A reconnect re-subscribes from here so events published while severed
         # cross client->server via broker replay (the server dedups overlaps).
-        # None = first connect (live-only, legacy behavior).
-        self._last_sent_id: Optional[str] = None
+        # None = first connect (live-only, legacy behavior). A recreated client
+        # (DistributedEventBus.start_client after stop) inherits the previous
+        # instance's cursor via ``initial_last_sent_id`` -- otherwise the
+        # severed span is silently lost (live-fire attempt 2, 2026-07-04).
+        self._last_sent_id: Optional[str] = initial_last_sent_id
         self._high_water: int = 0
         self._degraded = False
         self._missed_hb = 0
+        self._connected = False
+        self._active_ws: Optional[aiohttp.ClientWebSocketResponse] = None
         self._seen: "OrderedDict[str, None]" = OrderedDict()
+        # Local event ids WE minted by republishing peer events. The outbound
+        # pump must skip these or they bounce back with fresh ids forever
+        # (reflection storm: 408x amplification observed live).
+        self._republished: "OrderedDict[str, None]" = OrderedDict()
+
+    @property
+    def connected(self) -> bool:
+        """True while a WS link is established (hello sent, pumps running)."""
+        return self._connected
+
+    def _mark_republished(self, eid: str) -> None:
+        self._republished[eid] = None
+        if len(self._republished) > _DEDUP_MAX:
+            self._republished.popitem(last=False)
 
     @property
     def last_event_id(self) -> Optional[str]:
@@ -112,7 +132,17 @@ class BusBridgeClient:
         return f"{scheme}://{host}:{self._cfg.port}{self._cfg.path}"
 
     async def stop(self) -> None:
+        """Stop AND sever promptly: close the live WS so the pumps end now --
+        a flag-only stop leaves the link flushing until the next receive
+        timeout, which is not a sever (live-fire honesty gate, 2026-07-04)."""
         self._stopped = True
+        ws = self._active_ws
+        if ws is not None:
+            try:
+                await ws.close()
+            except Exception:  # noqa: BLE001
+                pass
+        self._connected = False
 
     async def run(self) -> None:
         attempt = 0
@@ -147,10 +177,14 @@ class BusBridgeClient:
                 await ws.send_bytes(
                     bf.hello_frame(self._cfg.source_id, self._last_event_id).encode()
                 )
+                self._connected = True
+                self._active_ws = ws
                 out_task = asyncio.ensure_future(self._pump_outbound(ws))
                 try:
                     await self._pump_inbound(ws)
                 finally:
+                    self._connected = False
+                    self._active_ws = None
                     out_task.cancel()
                     try:
                         await out_task
@@ -178,6 +212,11 @@ class BusBridgeClient:
                     continue  # broker-internal replay/lag bookkeeping, not on-wire
                 if event.event_type == EVENT_TYPE_HEARTBEAT:
                     await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
+                    continue
+                if event.event_id in self._republished:
+                    # An event WE republished from the peer -- sending it back
+                    # would re-mint ids on their side forever (reflection storm).
+                    self._last_sent_id = event.event_id
                     continue
                 frame = bf.event_frame(event, source_id=self._cfg.source_id)
                 await ws.send_bytes(frame.encode())
@@ -226,11 +265,13 @@ class BusBridgeClient:
             self._advance_contiguous(event_id)
             return
         try:
-            self._broker.publish(
+            local_eid = self._broker.publish(
                 ev_dict.get("event_type", ""),
                 ev_dict.get("op_id", ""),
                 ev_dict.get("payload", {}) or {},
             )
+            if local_eid:
+                self._mark_republished(local_eid)
         except Exception:  # noqa: BLE001
             logger.debug("[BusBridgeClient] local republish failed", exc_info=True)
         self._advance_contiguous(event_id)

--- a/backend/core/ouroboros/governance/transport/bus_bridge_server.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_server.py
@@ -48,9 +48,18 @@ class BusBridgeServer:
         self._cfg = cfg
         self._on_inbound = on_inbound
         self._seen: "OrderedDict[str, None]" = OrderedDict()
+        # Local event ids minted by the inbound republish (on_inbound returns the
+        # broker.publish id). The outbound pump must skip them or peer events
+        # bounce back with fresh ids forever (reflection storm, live-fire 2026-07-04).
+        self._republished: "OrderedDict[str, None]" = OrderedDict()
 
     def seen_count(self) -> int:
         return len(self._seen)
+
+    def _mark_republished(self, eid: str) -> None:
+        self._republished[eid] = None
+        if len(self._republished) > _DEDUP_MAX:
+            self._republished.popitem(last=False)
 
     def register_routes(self, app: web.Application) -> None:
         app.router.add_get(self._cfg.path, self._handle_ws)
@@ -79,7 +88,11 @@ class BusBridgeServer:
         )
         try:
             if self._on_inbound is not None:
-                self._on_inbound(ev)
+                local_eid = self._on_inbound(ev)
+                # DistributedEventBus's on_inbound returns the republish's local
+                # event id -- record it so the outbound pump never reflects it.
+                if isinstance(local_eid, str) and local_eid:
+                    self._mark_republished(local_eid)
         except Exception:  # noqa: BLE001 -- never crash the WS loop
             logger.debug("[BusBridgeServer] on_inbound raised", exc_info=True)
 
@@ -102,6 +115,8 @@ class BusBridgeServer:
                 if event.event_type == EVENT_TYPE_HEARTBEAT:
                     await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
                     continue
+                if event.event_id in self._republished:
+                    continue  # never reflect a peer's own event back at it
                 frame = bf.event_frame(event, source_id=self._cfg.source_id)
                 await ws.send_bytes(frame.encode())
         except (asyncio.CancelledError, ConnectionResetError):

--- a/backend/core/ouroboros/governance/transport/distributed_event_bus.py
+++ b/backend/core/ouroboros/governance/transport/distributed_event_bus.py
@@ -27,6 +27,10 @@ class DistributedEventBus:
         self._role = role
         self._server: Optional[BusBridgeServer] = None
         self._client: Optional[BusBridgeClient] = None
+        # Outbound last-sent cursor carried ACROSS client instances: stop() +
+        # start_client() builds a NEW BusBridgeClient, and without the carry
+        # the severed span is silently lost (live-fire 2026-07-04).
+        self._last_sent_cursor: Optional[str] = None
 
     def publish(self, event_type: str, op_id: str, payload: dict) -> Optional[str]:
         return self._broker.publish(event_type, op_id, payload)
@@ -47,9 +51,15 @@ class DistributedEventBus:
     async def start_client(self, url: Optional[str] = None) -> None:
         if self._role != "client":
             raise RuntimeError("start_client requires role=client")
-        self._client = BusBridgeClient(self._broker, self._cfg, url=url)
+        self._client = BusBridgeClient(
+            self._broker, self._cfg, url=url,
+            initial_last_sent_id=self._last_sent_cursor,
+        )
         await self._client.run()
 
     async def stop(self) -> None:
         if self._client is not None:
+            self._last_sent_cursor = (
+                getattr(self._client, "_last_sent_id", None) or self._last_sent_cursor
+            )
             await self._client.stop()

--- a/scripts/ignite_brain_vm.py
+++ b/scripts/ignite_brain_vm.py
@@ -854,8 +854,26 @@ class BrainIgnitionDriver:
         def _client_getter() -> Any:
             return getattr(bus, "_client", None)
 
+        async def _await_connected(budget_s: float) -> bool:
+            # CONNECT GATE (live-fire attempt 2): events published before the
+            # first successful connect are live-only-lost. Never start the
+            # exchange on a dark link.
+            deadline = time.monotonic() + budget_s
+            while time.monotonic() < deadline:
+                client = _client_getter()
+                if client is not None and getattr(client, "connected", False):
+                    return True
+                await asyncio.sleep(0.1)
+            return False
+
         mac = _LiveMacEndpoint(bus, broker, _client_getter)
         await mac.start()
+        if not await _await_connected(_env_float("JARVIS_BRAIN_CONNECT_GATE_S", 30.0)):
+            _log("[BrainIgnite] connect gate TIMEOUT -- WS client never established")
+            await mac.stop()
+            client_task.cancel()
+            return {"proven": False, "logic_ok": False,
+                    "error": "connect_gate_timeout"}
 
         _live_tasks: List[asyncio.Task] = [client_task]
 
@@ -871,10 +889,12 @@ class BrainIgnitionDriver:
         async def _reconnect() -> Any:
             # Stateless re-discovery: re-resolve the endpoint from scratch (a Brain
             # that moved is re-found), reconnect a fresh client -> Last-Event-ID
-            # replay fills the severed span.
+            # replay fills the severed span (the bus carries the outbound cursor
+            # across client instances).
             new_url = await self._do_discover() or url
             new_task = asyncio.ensure_future(bus.start_client(new_url))
             _live_tasks.append(new_task)
+            await _await_connected(_env_float("JARVIS_BRAIN_CONNECT_GATE_S", 30.0))
             return mac
 
         # Task-9 un-loopback: the Brain endpoint is REAL -- publish() commands the

--- a/tests/governance/transport/test_bridge_reflection_and_cursor.py
+++ b/tests/governance/transport/test_bridge_reflection_and_cursor.py
@@ -1,0 +1,202 @@
+# -*- coding: utf-8 -*-
+"""Live-fire attempt-2 defects (2026-07-04), proven against a REAL localhost
+client<->server WS pair with EXACT-count assertions (the in-proc fake bridge
+had modeled dedup-by-original-id; the real bridges re-mint ids on republish,
+so the fake masked all three):
+
+  (A) REFLECTION SUPPRESSION: a bridge must never re-send an event it itself
+      republished from the peer -- republish mints a NEW local event id, so
+      qualified-id dedup never fires and events ping-pong forever (observed
+      408x amplification of 5 events, live).
+  (B) CONNECT GATE: events published before the client's first successful
+      connect are lost (live-only first subscribe); the client must expose
+      ``connected`` so callers can gate.
+  (C) CURSOR ACROSS RECONNECT: DistributedEventBus builds a NEW BusBridgeClient
+      per start_client(); the outbound last-sent cursor must carry over or the
+      severed span is lost (all 5 post-sever events gapped, live).
+"""
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any, List, Optional
+
+import pytest
+from aiohttp import web
+
+import backend.core.ouroboros.governance.transport.exchange_protocol as xp
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import (
+    TransportConfig,
+)
+from backend.core.ouroboros.governance.transport.distributed_event_bus import (
+    DistributedEventBus,
+)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _cfg(monkeypatch, port: int, role: str) -> TransportConfig:
+    for key in ("JARVIS_BRAIN_WS_TLS_ENABLED", "JARVIS_BRAIN_WS_HOST",
+                "JARVIS_BRAIN_WS_PORT", "JARVIS_BRAIN_WS_HEARTBEAT_S"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HOST", "127.0.0.1")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", str(port))
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "1.0")
+    return TransportConfig.from_env(role=role)
+
+
+class _Pair:
+    """A REAL server + client DistributedEventBus pair on localhost."""
+
+    def __init__(self, monkeypatch) -> None:
+        self.port = _free_port()
+        self.server_cfg = _cfg(monkeypatch, self.port, "server")
+        self.client_cfg = _cfg(monkeypatch, self.port, "client")
+        self.server_broker = StreamEventBroker()
+        self.client_broker = StreamEventBroker()
+        self.server_bus = DistributedEventBus(
+            self.server_broker, self.server_cfg, role="server")
+        self.client_bus = DistributedEventBus(
+            self.client_broker, self.client_cfg, role="client")
+        self._runner: Optional[web.AppRunner] = None
+        self._client_task: Optional[asyncio.Task] = None
+
+    @property
+    def url(self) -> str:
+        return "ws://127.0.0.1:%d%s" % (self.port, self.client_cfg.path)
+
+    async def start(self) -> None:
+        app = web.Application()
+        self.server_bus.register_server_routes(app)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, host="127.0.0.1", port=self.port)
+        await site.start()
+        self._client_task = asyncio.ensure_future(
+            self.client_bus.start_client(self.url))
+
+    async def await_connected(self, timeout: float = 5.0) -> None:
+        deadline = asyncio.get_event_loop().time() + timeout
+        while asyncio.get_event_loop().time() < deadline:
+            client = getattr(self.client_bus, "_client", None)
+            if client is not None and getattr(client, "connected", False):
+                return
+            await asyncio.sleep(0.02)
+        raise AssertionError("client never reported connected")
+
+    async def stop(self) -> None:
+        try:
+            await self.client_bus.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        if self._client_task:
+            self._client_task.cancel()
+            try:
+                await self._client_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        if self._runner:
+            await self._runner.cleanup()
+
+
+def _exchange_events(broker: StreamEventBroker) -> List[Any]:
+    return [ev for ev in broker.recent_history(limit=1000)
+            if xp.is_exchange_op(ev.op_id)]
+
+
+OP = xp.EXCHANGE_OP_PREFIX + "reflect-1"
+
+
+# --------------------------------------------------------------------------- #
+# (A) no ping-pong: publish 1 event each side; each broker ends with EXACTLY 2.
+# --------------------------------------------------------------------------- #
+def test_no_reflection_storm_exact_counts(monkeypatch):
+    async def scenario():
+        pair = _Pair(monkeypatch)
+        await pair.start()
+        await pair.await_connected()
+
+        pair.client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-c", {"n": 1})
+        pair.server_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-s", {"n": 2})
+        await asyncio.sleep(1.5)  # plenty of time for any storm to develop
+
+        client_n = len(_exchange_events(pair.client_broker))
+        server_n = len(_exchange_events(pair.server_broker))
+        await pair.stop()
+        return client_n, server_n
+
+    client_n, server_n = asyncio.get_event_loop().run_until_complete(scenario())
+    assert client_n == 2, f"client broker must hold exactly 2 (own + peer), got {client_n}"
+    assert server_n == 2, f"server broker must hold exactly 2 (own + peer), got {server_n}"
+
+
+# --------------------------------------------------------------------------- #
+# (B) connected property gates publishes.
+# --------------------------------------------------------------------------- #
+def test_client_connected_property_reflects_link(monkeypatch):
+    async def scenario():
+        pair = _Pair(monkeypatch)
+        await pair.start()
+        await pair.await_connected()  # asserts the property flips True
+        client = pair.client_bus._client
+        await pair.stop()
+        return getattr(client, "connected", True)
+
+    connected_after_stop = asyncio.get_event_loop().run_until_complete(scenario())
+    assert connected_after_stop is False, "stop must clear connected"
+
+
+# --------------------------------------------------------------------------- #
+# (C) the outbound cursor survives client recreation: sever (bus.stop),
+#     publish while severed, start_client again -> severed span crosses.
+# --------------------------------------------------------------------------- #
+def test_severed_span_crosses_after_client_recreation(monkeypatch):
+    async def scenario():
+        pair = _Pair(monkeypatch)
+        await pair.start()
+        await pair.await_connected()
+
+        pair.client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-pre", {"i": 0})
+        await asyncio.sleep(0.5)
+
+        await pair.client_bus.stop()  # SEVER (kills the client instance)
+        await asyncio.sleep(0.3)  # let the link fully die -- no flush race
+        severed_ids = [
+            pair.client_broker.publish(
+                xp.EXCHANGE_EVENT_TYPE, OP + "-sev-%d" % i, {"i": i})
+            for i in range(3)
+        ]
+        assert all(severed_ids)
+        await asyncio.sleep(0.3)
+        # HONESTY GATE: while severed, the span must NOT have crossed -- if it
+        # did, the "sever" is a flush race and this test proves nothing.
+        mid_ops = {ev.op_id for ev in _exchange_events(pair.server_broker)}
+        assert not any((OP + "-sev-%d" % i) in mid_ops for i in range(3)), (
+            "severed events crossed BEFORE reconnect -- sever is not real")
+
+        task = asyncio.ensure_future(pair.client_bus.start_client(pair.url))
+        await pair.await_connected()
+        await asyncio.sleep(1.0)
+
+        server_ops = {ev.op_id for ev in _exchange_events(pair.server_broker)}
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+        await pair.stop()
+        return server_ops
+
+    server_ops = asyncio.get_event_loop().run_until_complete(scenario())
+    for i in range(3):
+        assert (OP + "-sev-%d" % i) in server_ops, (
+            "severed-span event %d must cross via the carried cursor: %r"
+            % (i, server_ops))


### PR DESCRIPTION
Acceptance attempt 2 ran CROSS-HOST (mTLS+SNI discovery bound, sidecar up,
round trips proven) but NOT PROVEN with three protocol defects, all invisible
to the in-proc fake bridge (it modeled dedup-by-original-id; the real bridges
re-mint ids on republish):

1. REFLECTION STORM (408 observations of 5 events): a bridge republish mints
   a NEW local event id, so qualified-id dedup never fires and events bounce
   Mac<->Brain forever. Fix: each bridge records the local ids it minted via
   inbound-republish (bounded LRU, server captures on_inbound's return) and
   its outbound pump never reflects them back.
2. LOST FIRST BATCH (m2b observed 0): events published before the WS client's
   first successful connect are live-only-lost. Fix: BusBridgeClient.connected
   property + driver connect gate (JARVIS_BRAIN_CONNECT_GATE_S, default 30s)
   before the exchange and after reconnect.
3. SEVERED SPAN LOST (all 5 post-sever nonces gapped): the driver's reconnect
   builds a NEW BusBridgeClient, so the outbound last-sent cursor died with
   the old instance. Fix: DistributedEventBus carries the cursor across
   start_client() calls.

Plus: BusBridgeClient.stop() now actually severs (closes the live WS) instead
of flag-only -- a lingering pump kept flushing after "stop", caught by the new
test's honesty gate (severed events must NOT cross before reconnect).

Spine: REAL localhost client<->server WS pair, EXACT-count assertions
(no amplification), honest sever, cursor-across-recreation. 98 tests green.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>

[integrity-verified: 257c903360a5]


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents reflection storms and event loss around connect/reconnect in the WebSocket bridge. Suppresses re-reflection, gates the first connect, and carries the outbound cursor across reconnect; stop now closes the live socket.

- **Bug Fixes**
  - Reflection suppression: record local IDs minted by inbound republish and skip them on outbound (client and server) to stop ping‑pong loops.
  - Connect gate: expose a `connected` property and gate the exchange with `JARVIS_BRAIN_CONNECT_GATE_S` (default 30s) so events published before first connect aren’t dropped.
  - Cursor across reconnect: `DistributedEventBus` carries the last sent ID into new client instances so severed spans replay after reconnect.
  - stop() severs: actively closes the WS to halt pumps immediately.

<sup>Written for commit 8b822bdd1e2bdafd93f49ef3b5e0108987685337. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

