### PR TITLE
feat(stage2): distributed TrinityEventBus -- brain relocation wiring (Tasks 1-5 prep)

### DIFF
--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -1098,8 +1098,14 @@ class IntakeLayerService:
                     "JARVIS_DISTRIBUTED_BUS_ENABLED is off",
                 )
                 return
-            # ``router`` is reserved for Task 3 (remote intake signal
-            # ingestion); passing it now keeps the Task-3 wiring additive.
+            # Task 3 (live): the host wires this router into a
+            # RemoteIntakeBridge so Body signals arriving over the bus land
+            # in the local intake pipeline. ``self._router`` is ALWAYS
+            # non-None here -- _build_components constructs it before this
+            # seam runs. Pinned by test_organism_bus_host.py::
+            # test_intake_layer_seam_passes_its_router_to_the_host so a
+            # refactor cannot silently revert to router=None (the
+            # wired-but-inert class).
             host = OrganismBusHost(router=self._router)
             if await host.start():
                 self._organism_bus_host = host

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -258,6 +258,11 @@ class IntakeLayerService:
         # Slice 6 — PerformanceRegressionSensor handle for CI webhook route.
         self._performance_regression_sensor: Optional[Any] = None
         self._event_channel_server: Optional[Any] = None
+        # Stage-2 Task 2 -- organism-owned mTLS WS bus host. Populated in
+        # ``_maybe_start_organism_bus_host`` only when the
+        # JARVIS_DISTRIBUTED_BUS_ENABLED master flag is on; master-OFF the
+        # transport package is never imported (lazy import inside the guard).
+        self._organism_bus_host: Optional[Any] = None
 
     @property
     def state(self) -> IntakeServiceState:
@@ -312,6 +317,16 @@ class IntakeLayerService:
             except Exception as exc:
                 logger.warning("[IntakeLayer] EventChannelServer stop error: %s", exc)
             self._event_channel_server = None
+
+        # Stage-2 Task 2 -- stop the organism bus host (fail-soft, its own
+        # stop() never raises but guard anyway; never blocks intake stop).
+        if self._organism_bus_host is not None:
+            try:
+                await self._organism_bus_host.stop()
+                logger.info("[IntakeLayer] OrganismBusHost stopped")
+            except Exception as exc:
+                logger.warning("[IntakeLayer] OrganismBusHost stop error: %s", exc)
+            self._organism_bus_host = None
 
         # Stop reactor consumer
         if hasattr(self, "_reactor_consumer") and self._reactor_consumer is not None:
@@ -1044,6 +1059,69 @@ class IntakeLayerService:
         # activation failure is logged and the intake layer continues
         # operating in poll-only mode (same behavior as before the slice).
         await self._maybe_start_event_channel_server()
+
+        # Stage-2 Task 2 -- organism-owned mTLS WS bus host (replaces the
+        # Stage-1 standalone sidecar on Stage-2 nodes). Same fail-soft
+        # ownership style as the EventChannelServer block above.
+        await self._maybe_start_organism_bus_host()
+
+    async def _maybe_start_organism_bus_host(self) -> None:
+        """Start the ``OrganismBusHost`` when the distributed bus is on.
+
+        Stage-2 Task 2: makes the organism's own TrinityEventBus reachable
+        across hosts (Stage-0 ``DistributedEventBus`` server + Task-1
+        ``TrinityBusBridge``) without the standalone sidecar process.
+
+        Master flag ``JARVIS_DISTRIBUTED_BUS_ENABLED`` (default false):
+        the import is LAZY inside this guard, so master-OFF adds zero
+        imports to the intake hot path -- byte-identical boot. Any failure
+        (missing aiohttp, port in use, TLS material unresolvable) is logged
+        and intake continues; the cross-host bus is a reach upgrade, not a
+        correctness invariant, so failure-to-start must never take the
+        intake layer down.
+        """
+        try:
+            try:
+                from backend.core.ouroboros.governance.transport.organism_bus_host import (  # noqa: E501
+                    OrganismBusHost,
+                    bus_host_enabled,
+                )
+            except ImportError as exc:
+                logger.debug(
+                    "[IntakeLayer] OrganismBusHost skipped -- import failed: %s",
+                    exc,
+                )
+                return
+            if not bus_host_enabled():
+                logger.debug(
+                    "[IntakeLayer] OrganismBusHost skipped -- "
+                    "JARVIS_DISTRIBUTED_BUS_ENABLED is off",
+                )
+                return
+            # ``router`` is reserved for Task 3 (remote intake signal
+            # ingestion); passing it now keeps the Task-3 wiring additive.
+            host = OrganismBusHost(router=self._router)
+            if await host.start():
+                self._organism_bus_host = host
+                logger.info(
+                    "[IntakeLayer] OrganismBusHost activated -- organism "
+                    "trinity bus is now reachable over the distributed bus",
+                )
+            else:
+                # start() stayed dark (port 0 / plaintext refusal / failed
+                # setup already unwound) -- log at INFO so operators can see
+                # why the flag-on host did not serve.
+                logger.info(
+                    "[IntakeLayer] OrganismBusHost declined to start "
+                    "(port unset, TLS material missing, or setup failed -- "
+                    "see [OrganismBusHost] lines above)",
+                )
+        except Exception as exc:
+            # Never crash intake because the bus host failed to start.
+            logger.warning(
+                "[IntakeLayer] OrganismBusHost activation failed "
+                "(intake continues without cross-host bus): %s", exc,
+            )
 
     async def _maybe_start_event_channel_server(self) -> None:
         """Start the ``EventChannelServer`` when webhook-primary mode is on.

--- a/backend/core/ouroboros/governance/intake/remote_intake.py
+++ b/backend/core/ouroboros/governance/intake/remote_intake.py
@@ -1,0 +1,110 @@
+"""Remote intake path (Stage-2 Task 3): Body shim + Brain bridge.
+
+Both classes live in ONE file because they are the two halves of a single
+wire contract -- the topic constant and the payload shape
+(``IntentEnvelope.to_dict()``) must never drift apart:
+
+  * ``RemoteIntakeRouter`` (Body / Mac side): a router-shaped shim that
+    duck-types the ONE method sensors call -- ``async def ingest(envelope)``
+    -- and publishes the envelope dict onto the local TrinityEventBus.
+    Fire-and-forget: the Brain's REAL ``UnifiedIntakeRouter`` owns dedup,
+    ack-parking, and backpressure.
+  * ``RemoteIntakeBridge`` (Brain side): subscribes ``TOPIC_REMOTE_SIGNAL``
+    on the organism's TrinityEventBus, rehydrates ``IntentEnvelope`` from
+    each payload, and feeds it into the injected real router. Malformed
+    payloads are logged-and-dropped -- the bus loop must never crash.
+
+Boot seam: ``OrganismBusHost.start()`` constructs + starts the bridge when
+its ``router`` param is not None (Task-2 reserved it for exactly this).
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Optional
+
+from backend.core.ouroboros.governance.intake.intent_envelope import IntentEnvelope
+
+logger = logging.getLogger(__name__)
+
+#: One wire contract, one topic. Body sensors publish here; the Brain bridge
+#: subscribes here. Matches the ``intake.remote_signal.*`` outbound allowlist
+#: pattern on the Mac-side TrinityBusBridge.
+TOPIC_REMOTE_SIGNAL = "intake.remote_signal.body"
+
+
+class RemoteIntakeRouter:
+    """Body-side shim: looks like a router to sensors, publishes to the bus.
+
+    Duck-types ONLY ``async def ingest(envelope) -> str``. Fail-soft: a
+    publish failure returns ``"backpressure"`` (a valid router verdict --
+    surfaces degradation without crashing the calling sensor).
+    """
+
+    def __init__(self, trinity_bus: Any) -> None:
+        self._bus = trinity_bus
+
+    async def ingest(self, envelope: Any) -> str:
+        try:
+            await self._bus.publish_raw(TOPIC_REMOTE_SIGNAL, envelope.to_dict())
+        except Exception:  # noqa: BLE001 -- fail-soft, never crash the sensor
+            logger.warning(
+                "[RemoteIntakeRouter] publish failed -- returning backpressure",
+                exc_info=True,
+            )
+            return "backpressure"
+        return "enqueued"
+
+
+class RemoteIntakeBridge:
+    """Brain-side subscriber: remote envelope dicts -> the REAL router.
+
+    Deliberately does NOT dedup -- ``UnifiedIntakeRouter._is_duplicate``
+    owns replay suppression; re-implementing it here would mask the real
+    contract (and drift).
+    """
+
+    def __init__(self, trinity_bus: Any, router: Any) -> None:
+        self._bus = trinity_bus
+        self._router = router
+        self._sub_id: Optional[str] = None
+
+    async def start(self) -> None:
+        if self._sub_id is not None:
+            return
+        self._sub_id = await self._bus.subscribe(
+            TOPIC_REMOTE_SIGNAL, self._on_signal)
+
+    async def stop(self) -> None:
+        sid, self._sub_id = self._sub_id, None
+        if sid is None:
+            return
+        try:
+            await self._bus.unsubscribe(sid)
+        except Exception:  # noqa: BLE001 -- fail-soft teardown
+            logger.debug("[RemoteIntakeBridge] unsubscribe failed",
+                         exc_info=True)
+
+    async def _on_signal(self, event: Any) -> None:
+        payload = getattr(event, "payload", None)
+        if not isinstance(payload, dict):
+            logger.warning(
+                "[RemoteIntakeBridge] non-dict payload dropped: %r",
+                type(payload).__name__)
+            return
+        try:
+            envelope = IntentEnvelope.from_dict(payload)
+        except Exception:  # noqa: BLE001 -- malformed: log-and-drop
+            logger.warning(
+                "[RemoteIntakeBridge] malformed remote envelope dropped "
+                "(keys=%s)", sorted(payload.keys()), exc_info=True)
+            return
+        try:
+            verdict = await self._router.ingest(envelope)
+            logger.debug(
+                "[RemoteIntakeBridge] ingested remote signal source=%s "
+                "dedup_key=%s verdict=%s",
+                envelope.source, envelope.dedup_key, verdict)
+        except Exception:  # noqa: BLE001 -- never crash the bus loop
+            logger.warning(
+                "[RemoteIntakeBridge] router ingest failed (signal dropped)",
+                exc_info=True)

--- a/backend/core/ouroboros/governance/transport/organism_bus_host.py
+++ b/backend/core/ouroboros/governance/transport/organism_bus_host.py
@@ -1,0 +1,200 @@
+"""OrganismBusHost -- the Brain organism's in-process mTLS WS bus (Stage-2).
+
+Hosts the Stage-0 ``DistributedEventBus`` server endpoint INSIDE the organism
+process and wires the Task-1 ``TrinityBusBridge`` to the organism's own
+``TrinityEventBus`` -- so the trinity bus becomes reachable across hosts
+without the Stage-1 standalone sidecar (``scripts/brain_bus_echo_server.py``,
+which now early-exits on Stage-2 nodes via
+``JARVIS_BRAIN_BUS_SIDECAR_ENABLED=false``).
+
+Dark by default (Manifesto: env-gated, byte-identical off):
+
+  * ``JARVIS_DISTRIBUTED_BUS_ENABLED`` master flag off  -> ``start()`` is
+    False and touches nothing (no aiohttp import, no sockets, no bus).
+  * ``JARVIS_BRAIN_WS_PORT`` unset/0                    -> False, dark.
+  * TLS enabled (default) but no material resolvable    -> False -- REFUSES
+    to fall through to a plaintext listener.
+
+Env knobs: the existing ``JARVIS_BRAIN_WS_*`` family (port/host/TLS/identity,
+see ``transport_config.py``) plus ``JARVIS_BRAIN_OUTBOUND_TOPICS`` (comma
+list of TrinityEventBus patterns mirrored outbound; default
+``actuation.*,telemetry.posture.*``).
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, List, Optional
+
+from backend.core.ouroboros.governance.transport.transport_config import (
+    distributed_bus_enabled,
+)
+
+logger = logging.getLogger(__name__)
+
+_ENV_OUTBOUND_TOPICS = "JARVIS_BRAIN_OUTBOUND_TOPICS"
+_DEFAULT_OUTBOUND_TOPICS = "actuation.*,telemetry.posture.*"
+
+
+def bus_host_enabled() -> bool:
+    """Master switch for the organism-owned bus host.
+
+    Re-export seam over ``distributed_bus_enabled()`` so the intake layer
+    (and any future boot seam) imports exactly ONE module for both the
+    flag check and the host class.
+    """
+    return distributed_bus_enabled()
+
+
+def resolve_outbound_topics() -> List[str]:
+    """Comma-list env knob; whitespace-tolerant; empty/blank -> default."""
+    raw = (os.environ.get(_ENV_OUTBOUND_TOPICS) or "").strip()
+    if not raw:
+        raw = _DEFAULT_OUTBOUND_TOPICS
+    topics = [t.strip() for t in raw.split(",") if t.strip()]
+    return topics or [t.strip() for t in _DEFAULT_OUTBOUND_TOPICS.split(",")]
+
+
+class OrganismBusHost:
+    """Owns the WS listener + Stage-0 server bus + Task-1 trinity bridge.
+
+    Lifecycle: ``await start() -> bool`` (False = stayed dark / refused),
+    ``await stop()`` unwinds in reverse and never raises. All heavy imports
+    (aiohttp, trinity bus, transport internals) happen INSIDE ``start()``
+    after the flag/port/TLS gates -- master-OFF pays zero import cost.
+    """
+
+    def __init__(self, router: Any = None) -> None:
+        # ``router`` is the UnifiedIntakeRouter handle, reserved for Task 3
+        # (remote intake signals arriving over this bus get ingested into
+        # the local intake pipeline). Stored but deliberately unused in
+        # Task 2 so the Task-3 wiring lands without a constructor change.
+        self._router = router
+        self._broker: Optional[Any] = None
+        self._bus: Optional[Any] = None  # DistributedEventBus (server role)
+        self._bridge: Optional[Any] = None  # TrinityBusBridge
+        self._runner: Optional[Any] = None  # aiohttp AppRunner
+        self._site: Optional[Any] = None  # aiohttp TCPSite
+        self._started = False
+
+    @property
+    def started(self) -> bool:
+        return self._started
+
+    async def start(self) -> bool:
+        """Serve the organism bus. Returns False (dark, touches nothing)
+        when the master flag is off, no port is configured, or TLS is
+        enabled but material cannot be resolved (plaintext refusal)."""
+        if self._started:
+            return True
+        if not bus_host_enabled():
+            logger.debug("[OrganismBusHost] master flag off -- staying dark")
+            return False
+
+        from backend.core.ouroboros.governance.transport.transport_config import (
+            TransportConfig,
+        )
+
+        cfg = TransportConfig.from_env(role="brain-server")
+        if cfg.port <= 0:
+            logger.info(
+                "[OrganismBusHost] JARVIS_BRAIN_WS_PORT unset/0 -- staying dark")
+            return False
+
+        from backend.core.ouroboros.governance.transport.transport_security import (
+            build_server_ssl_context,
+        )
+
+        try:
+            ssl_ctx = build_server_ssl_context(cfg)
+        except Exception as exc:  # noqa: BLE001 -- material unresolvable
+            ssl_ctx = None
+            logger.error(
+                "[OrganismBusHost] TLS material could not be resolved: %s", exc)
+        if cfg.tls_enabled and ssl_ctx is None:
+            logger.error(
+                "[OrganismBusHost] TLS enabled but no server ssl context "
+                "(JARVIS_BRAIN_WS_TLS_CERT/_KEY/_CA?) -- refusing plaintext")
+            return False
+
+        try:
+            from aiohttp import web
+
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                StreamEventBroker,
+            )
+            from backend.core.ouroboros.governance.transport.distributed_event_bus import (
+                DistributedEventBus,
+            )
+            from backend.core.ouroboros.governance.transport.trinity_bus_bridge import (
+                TrinityBusBridge,
+            )
+            from backend.core.trinity_event_bus import get_trinity_event_bus
+
+            self._broker = StreamEventBroker()
+            self._bus = DistributedEventBus(self._broker, cfg, role="server")
+            app = web.Application()
+            self._bus.register_server_routes(app)
+
+            self._runner = web.AppRunner(app)
+            await self._runner.setup()
+            self._site = web.TCPSite(
+                self._runner,
+                host=cfg.host or "0.0.0.0",
+                port=cfg.port,
+                ssl_context=ssl_ctx,
+            )
+            await self._site.start()
+
+            trinity_bus = await get_trinity_event_bus()
+            self._bridge = TrinityBusBridge(
+                trinity_bus,
+                self._broker,
+                outbound_topics=resolve_outbound_topics(),
+                source_id=cfg.source_id,
+            )
+            await self._bridge.start()
+        except Exception as exc:  # noqa: BLE001 -- fail-soft: unwind + dark
+            logger.warning(
+                "[OrganismBusHost] start failed (staying dark): %s", exc,
+                exc_info=True,
+            )
+            await self.stop()
+            return False
+
+        self._started = True
+        logger.info(
+            "[OrganismBusHost] serving host=%s port=%d tls=%s path=%s "
+            "outbound=%s source_id=%s",
+            cfg.host or "0.0.0.0", cfg.port, bool(ssl_ctx), cfg.path,
+            ",".join(resolve_outbound_topics()), cfg.source_id,
+        )
+        return True
+
+    async def stop(self) -> None:
+        """Unwind in reverse order. Never raises (fail-soft teardown);
+        no-op on a never-started host."""
+        self._started = False
+        if self._bridge is not None:
+            try:
+                await self._bridge.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug("[OrganismBusHost] bridge stop failed",
+                             exc_info=True)
+            self._bridge = None
+        if self._site is not None:
+            try:
+                await self._site.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug("[OrganismBusHost] site stop failed",
+                             exc_info=True)
+            self._site = None
+        if self._runner is not None:
+            try:
+                await self._runner.cleanup()
+            except Exception:  # noqa: BLE001
+                logger.debug("[OrganismBusHost] runner cleanup failed",
+                             exc_info=True)
+            self._runner = None
+        self._bus = None
+        self._broker = None

--- a/backend/core/ouroboros/governance/transport/organism_bus_host.py
+++ b/backend/core/ouroboros/governance/transport/organism_bus_host.py
@@ -65,14 +65,15 @@ class OrganismBusHost:
     """
 
     def __init__(self, router: Any = None) -> None:
-        # ``router`` is the UnifiedIntakeRouter handle, reserved for Task 3
-        # (remote intake signals arriving over this bus get ingested into
-        # the local intake pipeline). Stored but deliberately unused in
-        # Task 2 so the Task-3 wiring lands without a constructor change.
+        # ``router`` is the UnifiedIntakeRouter handle (Task 3): remote
+        # intake signals arriving over this bus get ingested into the local
+        # intake pipeline via a RemoteIntakeBridge. None skips the wiring
+        # (Task-2 behavior, byte-identical).
         self._router = router
         self._broker: Optional[Any] = None
         self._bus: Optional[Any] = None  # DistributedEventBus (server role)
         self._bridge: Optional[Any] = None  # TrinityBusBridge
+        self._intake_bridge: Optional[Any] = None  # RemoteIntakeBridge (Task 3)
         self._runner: Optional[Any] = None  # aiohttp AppRunner
         self._site: Optional[Any] = None  # aiohttp TCPSite
         self._started = False
@@ -154,6 +155,18 @@ class OrganismBusHost:
                 source_id=cfg.source_id,
             )
             await self._bridge.start()
+
+            if self._router is not None:
+                # Task 3: land remote Body signals into the local intake
+                # pipeline. Lazy import keeps the router=None path (and
+                # master-OFF) free of any intake-package import cost.
+                from backend.core.ouroboros.governance.intake.remote_intake import (
+                    RemoteIntakeBridge,
+                )
+
+                self._intake_bridge = RemoteIntakeBridge(
+                    trinity_bus, self._router)
+                await self._intake_bridge.start()
         except Exception as exc:  # noqa: BLE001 -- fail-soft: unwind + dark
             logger.warning(
                 "[OrganismBusHost] start failed (staying dark): %s", exc,
@@ -175,6 +188,13 @@ class OrganismBusHost:
         """Unwind in reverse order. Never raises (fail-soft teardown);
         no-op on a never-started host."""
         self._started = False
+        if self._intake_bridge is not None:
+            try:
+                await self._intake_bridge.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug("[OrganismBusHost] intake bridge stop failed",
+                             exc_info=True)
+            self._intake_bridge = None
         if self._bridge is not None:
             try:
                 await self._bridge.stop()

--- a/backend/core/ouroboros/governance/transport/trinity_bus_bridge.py
+++ b/backend/core/ouroboros/governance/transport/trinity_bus_bridge.py
@@ -1,0 +1,113 @@
+"""TrinityBusBridge -- the Stage-2 adapter the Stage-0 docstring promised.
+
+Mirrors allowlisted TrinityEventBus topics onto a StreamEventBroker (which the
+Stage-0/1 DistributedEventBus carries across the mTLS WS) and republishes
+imported events into the local TrinityEventBus. Loop safety is ORIGIN-BASED:
+imported events carry ``metadata.bridge_origin`` and are never re-forwarded --
+the Stage-1 reflection-storm class, closed at this layer by construction.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+TRINITY_OP_PREFIX = "trinity:"
+_BROKER_EVENT_TYPE = "task_started"  # a valid StreamEventBroker type
+_META_ORIGIN = "bridge_origin"
+
+
+class TrinityBusBridge:
+    """Origin-tagged adapter between a real ``TrinityEventBus`` and a
+    ``StreamEventBroker``.
+
+    Outbound: subscribes the trinity bus for each pattern in
+    ``outbound_topics`` and mirrors matching events onto the broker (unless
+    the event was itself imported from the far side -- origin check).
+
+    Inbound: drains the broker's subscriber queue for ``trinity:``-prefixed
+    op_ids not originated locally, and republishes them into the local
+    trinity bus tagged with ``metadata.bridge_origin`` so the outbound side
+    never bounces them back.
+    """
+
+    def __init__(self, trinity_bus: Any, broker: Any, *,
+                 outbound_topics: List[str], source_id: str) -> None:
+        self._bus = trinity_bus
+        self._broker = broker
+        self._outbound_topics = list(outbound_topics)
+        self._source_id = source_id
+        self._sub_ids: List[str] = []
+        self._drain_task: Optional[asyncio.Task] = None
+        self._broker_sub = None
+
+    async def start(self) -> None:
+        for pattern in self._outbound_topics:
+            sid = await self._bus.subscribe(pattern, self._on_outbound)
+            self._sub_ids.append(sid)
+        self._broker_sub = self._broker.subscribe()
+        if self._broker_sub is None:
+            raise RuntimeError("broker subscriber cap exceeded")
+        self._drain_task = asyncio.ensure_future(self._drain_inbound())
+
+    async def stop(self) -> None:
+        for sid in self._sub_ids:
+            try:
+                await self._bus.unsubscribe(sid)
+            except Exception:  # noqa: BLE001 -- fail-soft, never crash on teardown
+                logger.debug("[TrinityBusBridge] unsubscribe failed", exc_info=True)
+        self._sub_ids.clear()
+        if self._drain_task is not None:
+            self._drain_task.cancel()
+            try:
+                await self._drain_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001
+                logger.debug("[TrinityBusBridge] drain task teardown error", exc_info=True)
+            self._drain_task = None
+        if self._broker_sub is not None:
+            try:
+                self._broker.unsubscribe(self._broker_sub)
+            except Exception:  # noqa: BLE001
+                logger.debug("[TrinityBusBridge] broker unsubscribe failed", exc_info=True)
+            self._broker_sub = None
+
+    async def _on_outbound(self, event: Any) -> None:
+        origin = (getattr(event, "metadata", None) or {}).get(_META_ORIGIN)
+        if origin and origin != self._source_id:
+            return  # imported -- NEVER re-forward (loop safety)
+        try:
+            self._broker.publish(
+                _BROKER_EVENT_TYPE,
+                TRINITY_OP_PREFIX + str(event.topic),
+                {"topic": str(event.topic),
+                 "data": dict(event.payload or {}),
+                 "origin": self._source_id},
+            )
+        except Exception:  # noqa: BLE001 -- fail-soft, never crash the bus loop
+            logger.debug("[TrinityBusBridge] outbound publish failed", exc_info=True)
+
+    async def _drain_inbound(self) -> None:
+        from backend.core.trinity_event_bus import TrinityEvent  # noqa: PLC0415
+
+        while True:
+            ev = await self._broker_sub.queue.get()
+            op_id = getattr(ev, "op_id", "") or ""
+            if not op_id.startswith(TRINITY_OP_PREFIX):
+                continue
+            payload: Dict[str, Any] = dict(getattr(ev, "payload", None) or {})
+            if payload.get("origin") == self._source_id:
+                continue  # our own outbound reflected by the broker -- skip
+            try:
+                tev = TrinityEvent(
+                    topic=str(payload.get("topic", "")),
+                    payload=dict(payload.get("data", {}) or {}),
+                    metadata={_META_ORIGIN: str(payload.get("origin", ""))},
+                )
+                await self._bus.publish(tev)
+            except Exception:  # noqa: BLE001 -- fail-soft, never crash the bus loop
+                logger.debug("[TrinityBusBridge] inbound republish failed",
+                             exc_info=True)

--- a/scripts/brain_bus_echo_server.py
+++ b/scripts/brain_bus_echo_server.py
@@ -17,6 +17,13 @@ It is the piece that makes the cross-host acceptance REAL:
 Config is 100% env-resolved (``/etc/jarvis/brain.env`` via systemd
 ``EnvironmentFile``): the ``JARVIS_BRAIN_WS_*`` family. No baked endpoints, no
 literals. SIGTERM/SIGINT -> clean shutdown.
+
+STAGE-2 HANDOFF: on Stage-2 nodes the Brain ORGANISM hosts this bus itself
+(``backend/core/ouroboros/governance/transport/organism_bus_host.py`` --
+``OrganismBusHost``), so this standalone sidecar must stand down there. Set
+``JARVIS_BRAIN_BUS_SIDECAR_ENABLED=false`` in ``brain.env`` and ``main()``
+early-exits with rc=0 (systemd sees a clean one-shot). Default ``true``
+keeps Stage-1 nodes byte-identical.
 """
 from __future__ import annotations
 
@@ -131,6 +138,19 @@ async def amain() -> int:
 
 
 def main() -> int:
+    # Stage-2 handoff: the organism's OrganismBusHost owns the bus on
+    # Stage-2 nodes -- the sidecar stands down cleanly (rc=0) when disabled.
+    if os.environ.get("JARVIS_BRAIN_BUS_SIDECAR_ENABLED", "true").strip().lower() in (
+        "0", "false", "no", "off",
+    ):
+        logging.basicConfig(
+            level=os.environ.get("JARVIS_BRAIN_BUS_LOG_LEVEL", "INFO"),
+            format="%(asctime)s %(name)s %(levelname)s %(message)s",
+        )
+        logger.info(
+            "JARVIS_BRAIN_BUS_SIDECAR_ENABLED=false -- Stage-2 node: the "
+            "organism's OrganismBusHost owns the bus; sidecar standing down")
+        return 0
     logging.basicConfig(
         level=os.environ.get("JARVIS_BRAIN_BUS_LOG_LEVEL", "INFO"),
         format="%(asctime)s %(name)s %(levelname)s %(message)s",

--- a/scripts/ignite_brain_vm.py
+++ b/scripts/ignite_brain_vm.py
@@ -775,6 +775,7 @@ class BrainIgnitionDriver:
             "JARVIS_BRAIN_WS_PORT", "JARVIS_BRAIN_WS_PATH", "JARVIS_BRAIN_WS_TLS_ENABLED",
             "JARVIS_BRAIN_WS_TLS_CERT", "JARVIS_BRAIN_WS_TLS_KEY", "JARVIS_BRAIN_WS_TLS_CA",
             "JARVIS_BRAIN_COST_CAP", "JARVIS_DISTRIBUTED_BUS_ENABLED",
+            "JARVIS_BRAIN_BUS_SIDECAR_ENABLED", "JARVIS_BRAIN_OUTBOUND_TOPICS",
         ):
             v = os.environ.get(key)
             if v is not None and v != "":

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -170,7 +170,7 @@ class BodyModeDriver:
             from backend.core.ouroboros.governance.intake.sensors.voice_command_sensor import (  # noqa: PLC0415
                 VoiceCommandSensor,
             )
-            # Construction pattern: intake_layer_service.py:563-566 --
+            # Construction pattern: intake_layer_service.py:578-583 --
             # event-driven, no start/stop lifecycle; store as attribute only.
             return VoiceCommandSensor(router=shim, repo="jarvis")
         except Exception as exc:  # noqa: BLE001
@@ -201,9 +201,16 @@ class BodyModeDriver:
             # source: ``cadence_synthetic`` is the whitelisted honest-source
             # token for synthetic test-workload injection (intent_envelope.py
             # _VALID_SOURCES, 2026-05-05 precedent -- synthetic traffic MUST
-            # NOT masquerade as a production source; routes BACKGROUND, never
-            # burns Claude budget). The Body-mode identity travels in
-            # ``evidence.origin`` for downstream filtering.
+            # NOT masquerade as a production source). Routing truth: the
+            # token is in NEITHER _BACKGROUND_SOURCES nor _SPECULATIVE_SOURCES
+            # (urgency_router.py:134-146), so with urgency="low" and default
+            # moderate complexity these envelopes fall through to the
+            # Priority-5 default = ProviderRoute.STANDARD
+            # (urgency_router.py:731-734): DW primary WITH Claude fallback --
+            # a small residual Claude-fallback cost is possible if DW is
+            # degraded during acceptance, bounded by the run's cost cap. The
+            # Body-mode identity travels in ``evidence.origin`` for
+            # downstream filtering.
             out.append(make_envelope(
                 source="cadence_synthetic",
                 description="stage2 acceptance signal %d" % i,

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -1,0 +1,404 @@
+"""run_body_mode.py -- Stage-2 Body-mode driver (the Mac side of the relocation).
+
+A thin, composition-only process: discovers the Brain's WS endpoint, connects a
+client ``DistributedEventBus`` over mTLS, bridges the local ``TrinityEventBus``
+onto the wire (``TrinityBusBridge``), points the Body sensors at the
+``RemoteIntakeRouter`` shim (which publishes IntentEnvelopes to the bus instead
+of a local orchestrator), and runs a starvation census against the
+``ControlPlaneWatchdog`` -- the Stage-2 payoff proof that with the Brain
+relocated off-box, the Mac's control-plane starvation is ~0.
+
+Every collaborator is an injectable seam (the ``BrainIgnitionDriver`` pattern,
+scripts/ignite_brain_vm.py); the live defaults are resolved lazily inside
+``run()`` so the unit tests (tests/infra/test_run_body_mode.py) stay pure-logic
+with zero sockets.
+
+Exit codes:
+    0  acceptance-clean (duration elapsed, clean stop)
+    2  discovery failed ("Brain offline")
+    3  connect-gate timeout (WS client never established)
+
+Env knobs (all resolved at call time -- zero baked assumptions):
+    JARVIS_BRAIN_CONNECT_GATE_S     connect-gate budget (default 30)
+    JARVIS_BODY_MODE_CENSUS_S       census log cadence (default 10)
+    JARVIS_BRAIN_WS_*               Stage-0 transport client family
+    JARVIS_BRAIN_MTLS_DIR           client mTLS material (Stage-1 conventions)
+
+Usage::
+
+    python3 scripts/run_body_mode.py                       # run until signal
+    python3 scripts/run_body_mode.py --inject-test-signal 5 --duration-s 60
+    python3 scripts/run_body_mode.py --dry-run             # plan only, no network
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import sys
+import time
+from typing import Any, Awaitable, Callable, List, Optional, Tuple
+
+# ---------------------------------------------------------------------------
+# Paths -- derived from this file's location; backend importable regardless of cwd.
+# ---------------------------------------------------------------------------
+_SCRIPTS_DIR: str = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT: str = os.path.dirname(_SCRIPTS_DIR)
+if _REPO_ROOT not in sys.path:
+    sys.path.insert(0, _REPO_ROOT)
+
+
+def _log(msg: str) -> None:
+    print("[BodyMode] %s" % (msg,), flush=True)
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# The Body-mode driver.
+# ---------------------------------------------------------------------------
+
+
+class BodyModeDriver:
+    """Discover -> connect -> bridge -> shim sensors -> starvation census.
+
+    Every collaborator is an injectable seam; live defaults resolve lazily
+    inside ``run()`` (Mandate: fakes only in tests, no simulation on the live
+    path).
+
+    Seams:
+        discover_fn        -> ``async () -> Optional[str]`` (Brain WS URL)
+        bus_factory        -> ``async () -> (trinity_bus, broker, dist_bus)``
+        bridge_factory     -> ``(trinity_bus, broker) -> TrinityBusBridge``
+        shim_factory       -> ``(trinity_bus) -> RemoteIntakeRouter``
+        sensor_factory     -> ``(shim) -> Optional[sensor]`` (fail-soft)
+        watchdog_factory   -> ``() -> ControlPlaneWatchdog``
+    """
+
+    def __init__(
+        self,
+        *,
+        inject_test_signals: int = 0,
+        duration_s: Optional[float] = None,
+        dry_run: bool = False,
+        # Injectable seams (live defaults resolved lazily inside run()).
+        discover_fn: Optional[Callable[[], Awaitable[Optional[str]]]] = None,
+        bus_factory: Optional[Callable[[], Awaitable[Tuple[Any, Any, Any]]]] = None,
+        bridge_factory: Optional[Callable[[Any, Any], Any]] = None,
+        shim_factory: Optional[Callable[[Any], Any]] = None,
+        sensor_factory: Optional[Callable[[Any], Any]] = None,
+        watchdog_factory: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        self.inject_test_signals = max(0, int(inject_test_signals))
+        self.duration_s = duration_s
+        self.dry_run = dry_run
+
+        self._discover = discover_fn
+        self._bus_factory = bus_factory
+        self._bridge_factory = bridge_factory
+        self._shim_factory = shim_factory
+        self._sensor_factory = sensor_factory
+        self._watchdog_factory = watchdog_factory
+
+        self._signals_sent = 0
+        self._worst_lag_ms = 0.0
+
+    # -- lazy live default resolvers ---------------------------------------
+
+    async def _do_discover(self) -> Optional[str]:
+        if self._discover is not None:
+            return await self._discover()
+        from backend.core.ouroboros.governance.brain_discovery import (  # noqa: PLC0415
+            discover_brain_endpoint,
+        )
+        return await discover_brain_endpoint()
+
+    async def _do_bus_stack(self) -> Tuple[Any, Any, Any]:
+        if self._bus_factory is not None:
+            return await self._bus_factory()
+        from backend.core.trinity_event_bus import get_trinity_event_bus  # noqa: PLC0415
+        from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: PLC0415
+            StreamEventBroker,
+        )
+        from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: PLC0415
+            DistributedEventBus,
+        )
+        from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: PLC0415
+            TransportConfig,
+        )
+        trinity_bus = await get_trinity_event_bus()
+        broker = StreamEventBroker()
+        cfg = TransportConfig.from_env(role="mac-body")
+        dist_bus = DistributedEventBus(broker, cfg, role="client")
+        return trinity_bus, broker, dist_bus
+
+    def _do_bridge(self, trinity_bus: Any, broker: Any) -> Any:
+        if self._bridge_factory is not None:
+            return self._bridge_factory(trinity_bus, broker)
+        from backend.core.ouroboros.governance.transport.trinity_bus_bridge import (  # noqa: PLC0415
+            TrinityBusBridge,
+        )
+        return TrinityBusBridge(
+            trinity_bus, broker,
+            outbound_topics=["intake.remote_signal.*", "console.*"],
+            source_id="mac-body",
+        )
+
+    def _do_shim(self, trinity_bus: Any) -> Any:
+        if self._shim_factory is not None:
+            return self._shim_factory(trinity_bus)
+        from backend.core.ouroboros.governance.intake.remote_intake import (  # noqa: PLC0415
+            RemoteIntakeRouter,
+        )
+        return RemoteIntakeRouter(trinity_bus)
+
+    def _do_sensor(self, shim: Any) -> Optional[Any]:
+        """Fail-soft: the Mac test env may lack voice infra entirely --
+        ``--inject-test-signal`` is the deterministic acceptance path."""
+        if self._sensor_factory is not None:
+            try:
+                return self._sensor_factory(shim)
+            except Exception as exc:  # noqa: BLE001
+                _log("voice sensor unavailable (fail-soft): %s" % exc)
+                return None
+        try:
+            from backend.core.ouroboros.governance.intake.sensors.voice_command_sensor import (  # noqa: PLC0415
+                VoiceCommandSensor,
+            )
+            # Construction pattern: intake_layer_service.py:563-566 --
+            # event-driven, no start/stop lifecycle; store as attribute only.
+            return VoiceCommandSensor(router=shim, repo="jarvis")
+        except Exception as exc:  # noqa: BLE001
+            _log("voice sensor unavailable (fail-soft): %s" % exc)
+            return None
+
+    def _do_watchdog(self) -> Any:
+        if self._watchdog_factory is not None:
+            return self._watchdog_factory()
+        from backend.core.ouroboros.governance.control_plane_watchdog import (  # noqa: PLC0415
+            get_default_watchdog,
+        )
+        return get_default_watchdog()
+
+    # -- test-signal injection (the deterministic acceptance path) ----------
+
+    @staticmethod
+    def _build_test_envelopes(n: int) -> List[Any]:
+        from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: PLC0415
+            make_envelope,
+        )
+        out: List[Any] = []
+        for i in range(n):
+            # dedup_key = sha256(source|files|evidence["signature"]) -- the
+            # per-i signature makes every envelope's dedup_key DISTINCT
+            # (description alone would NOT: it is not part of the key).
+            #
+            # source: ``cadence_synthetic`` is the whitelisted honest-source
+            # token for synthetic test-workload injection (intent_envelope.py
+            # _VALID_SOURCES, 2026-05-05 precedent -- synthetic traffic MUST
+            # NOT masquerade as a production source; routes BACKGROUND, never
+            # burns Claude budget). The Body-mode identity travels in
+            # ``evidence.origin`` for downstream filtering.
+            out.append(make_envelope(
+                source="cadence_synthetic",
+                description="stage2 acceptance signal %d" % i,
+                # Non-empty per envelope validation; "." is the established
+                # cadence_synthetic placeholder (phase_9_synthetic_workload.py).
+                target_files=(".",),
+                repo="jarvis",
+                confidence=0.5,
+                urgency="low",
+                evidence={
+                    "signature": "body_test_stage2:%d" % i,
+                    "origin": "body_test",
+                },
+                requires_human_ack=False,
+            ))
+        return out
+
+    async def _inject_signals(self, shim: Any) -> None:
+        for envelope in self._build_test_envelopes(self.inject_test_signals):
+            try:
+                verdict = await shim.ingest(envelope)
+            except Exception as exc:  # noqa: BLE001 -- fail-soft, keep injecting
+                _log("inject FAILED dedup_key=%s: %s"
+                     % (envelope.dedup_key, exc))
+                continue
+            self._signals_sent += 1
+            _log("injected dedup_key=%s verdict=%s"
+                 % (envelope.dedup_key, verdict))
+
+    # -- census -------------------------------------------------------------
+
+    def _census_tick(self, watchdog: Any, connected: bool) -> None:
+        lag_events = int(getattr(watchdog, "lag_event_count", 0))
+        try:
+            records = watchdog.recent_lag_records()
+        except Exception:  # noqa: BLE001
+            records = []
+        for r in records:
+            self._worst_lag_ms = max(
+                self._worst_lag_ms, float(getattr(r, "lag_ms", 0.0)))
+        _log("lag_events=%d worst_ms=%.1f connected=%s"
+             % (lag_events, self._worst_lag_ms, connected))
+
+    # -- the run FSM ---------------------------------------------------------
+
+    async def run(self) -> int:
+        if self.dry_run:
+            _log("[dry-run] would discover the Brain WS endpoint, connect the "
+                 "mTLS bus client (role=mac-body), bridge "
+                 "['intake.remote_signal.*', 'console.*'], point sensors at "
+                 "the RemoteIntakeRouter shim, inject %d test signal(s), and "
+                 "run the starvation census -- no network touched"
+                 % self.inject_test_signals)
+            return 0
+
+        # 1. DISCOVER (stateless; fail-soft returns None).
+        url = await self._do_discover()
+        if not url:
+            _log("Brain offline -- discovery returned no endpoint (exit 2)")
+            return 2
+        _log("Brain discovered at %s" % url)
+
+        # 2. Bus stack + connect gate (Stage-1 proven pattern: events published
+        #    before the first successful connect are live-only-lost -- never
+        #    proceed on a dark link).
+        trinity_bus, broker, dist_bus = await self._do_bus_stack()
+        client_task = asyncio.ensure_future(dist_bus.start_client(url))
+
+        def _client_getter() -> Any:
+            return getattr(dist_bus, "_client", None)
+
+        def _connected() -> bool:
+            client = _client_getter()
+            return bool(client is not None
+                        and getattr(client, "connected", False))
+
+        async def _await_connected(budget_s: float) -> bool:
+            deadline = time.monotonic() + budget_s
+            while time.monotonic() < deadline:
+                if _connected():
+                    return True
+                await asyncio.sleep(0.1)
+            return False
+
+        bridge = None
+        watchdog = None
+        try:
+            if not await _await_connected(
+                    _env_float("JARVIS_BRAIN_CONNECT_GATE_S", 30.0)):
+                _log("connect gate TIMEOUT -- WS client never established "
+                     "(exit 3)")
+                return 3
+            _log("bus client connected")
+
+            # 3. Bridge the local trinity bus onto the wire.
+            bridge = self._do_bridge(trinity_bus, broker)
+            await bridge.start()
+
+            # 4. Sensors against the remote-intake shim.
+            shim = self._do_shim(trinity_bus)
+            sensor = self._do_sensor(shim)  # noqa: F841 -- event-driven, held alive
+            if sensor is not None:
+                _log("voice sensor armed against the remote-intake shim")
+            if self.inject_test_signals:
+                await self._inject_signals(shim)
+
+            # 5. Starvation census (the Stage-2 payoff measurement).
+            watchdog = self._do_watchdog()
+            watchdog.start()
+            census_s = _env_float("JARVIS_BODY_MODE_CENSUS_S", 10.0)
+            deadline = (time.monotonic() + self.duration_s
+                        if self.duration_s is not None else None)
+            while True:
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        break
+                    await asyncio.sleep(min(census_s, remaining))
+                else:
+                    await asyncio.sleep(census_s)
+                self._census_tick(watchdog, _connected())
+
+            # 6. Clean stop -> summary -> exit 0.
+            self._census_tick(watchdog, _connected())
+            return 0
+        finally:
+            lag_events = int(getattr(watchdog, "lag_event_count", 0)) \
+                if watchdog is not None else 0
+            if watchdog is not None:
+                try:
+                    await watchdog.stop()
+                except Exception:  # noqa: BLE001 -- fail-soft teardown
+                    pass
+            if bridge is not None:
+                try:
+                    await bridge.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+            try:
+                await dist_bus.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            client_task.cancel()
+            try:
+                await client_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            _log("SUMMARY lag_events=%d worst_ms=%.1f signals_sent=%d"
+                 % (lag_events, self._worst_lag_ms, self._signals_sent))
+
+
+# ---------------------------------------------------------------------------
+# CLI.
+# ---------------------------------------------------------------------------
+
+
+def build_arg_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="run_body_mode.py",
+        description=(
+            "Stage-2 Body-mode driver. Discovers the relocated Brain, connects "
+            "the mTLS WS bus, runs Body sensors against the RemoteIntakeRouter "
+            "shim, and proves the Mac's control-plane starvation is ~0."
+        ),
+    )
+    p.add_argument(
+        "--inject-test-signal", type=int, default=0, metavar="N",
+        help="Inject N deterministic body_test IntentEnvelopes through the "
+             "shim (the acceptance path; default 0).",
+    )
+    p.add_argument(
+        "--duration-s", type=float, default=None, metavar="S",
+        help="Run for S seconds then stop cleanly (default: until signal).",
+    )
+    p.add_argument(
+        "--dry-run", action="store_true",
+        help="Print the Body-mode plan and exit -- touches no network.",
+    )
+    return p
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    parser = build_arg_parser()
+    args = parser.parse_args(argv)
+    driver = BodyModeDriver(
+        inject_test_signals=args.inject_test_signal,
+        duration_s=args.duration_s,
+        dry_run=args.dry_run,
+    )
+    try:
+        return asyncio.run(driver.run())
+    except KeyboardInterrupt:
+        _log("interrupted -- clean stop")
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/governance/intake/test_remote_intake.py
+++ b/tests/governance/intake/test_remote_intake.py
@@ -1,0 +1,199 @@
+# -*- coding: utf-8 -*-
+"""Remote intake path (Stage-2 Task 3): Body shim + Brain bridge.
+
+Proves the wire contract between ``RemoteIntakeRouter`` (the router-shaped
+shim Body sensors call on the Mac) and ``RemoteIntakeBridge`` (the Brain-side
+subscriber that feeds the real ``UnifiedIntakeRouter``):
+
+  (a) ROUND-TRIP: a real envelope published through the shim on the Mac-side
+      TrinityEventBus crosses the Task-1 TrinityBusBridge pair (in-proc pump)
+      and arrives at a recording fake router on the Brain side as an
+      ``IntentEnvelope`` whose ``to_dict()`` equals the original's.
+  (b) REPLAY-DEDUP HONESTY: the SAME payload delivered twice reaches the
+      router TWICE with equal ``dedup_key`` -- dedup is the REAL router's
+      job (``_is_duplicate``); the bridge documents, not re-implements, it.
+  (c) MALFORMED PAYLOAD: ``{"garbage": True}`` is logged-and-dropped --
+      never raises, router never called (fail-soft, never crash the bus).
+  (d) SHIM FAIL-SOFT: a publish failure surfaces as the valid router
+      verdict ``"backpressure"`` instead of crashing the sensor.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, List
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.intake.intent_envelope import (
+    IntentEnvelope,
+    make_envelope,
+)
+from backend.core.ouroboros.governance.intake.remote_intake import (
+    TOPIC_REMOTE_SIGNAL,
+    RemoteIntakeBridge,
+    RemoteIntakeRouter,
+)
+from backend.core.ouroboros.governance.transport.trinity_bus_bridge import (
+    TRINITY_OP_PREFIX,
+    TrinityBusBridge,
+)
+from backend.core.trinity_event_bus import RepoType, TrinityEvent, TrinityEventBus
+
+
+async def _mk_bus() -> TrinityEventBus:
+    # Deviation (deliberate, documented): two REAL TrinityEventBus instances
+    # in one process stand in for two genuinely separate hosts (Mac + Brain
+    # VM). Suppress the in-process UDP multicast shortcut so the buses can
+    # ONLY see each other through the TrinityBusBridge under test. Precedent
+    # + full rationale: tests/governance/transport/
+    # test_trinity_bus_bridge.py::_mk_bus.
+    prev = os.environ.get("TRINITY_MULTICAST_ENABLED")
+    os.environ["TRINITY_MULTICAST_ENABLED"] = "false"
+    try:
+        return await TrinityEventBus.create(local_repo=RepoType.JARVIS)
+    finally:
+        if prev is None:
+            os.environ.pop("TRINITY_MULTICAST_ENABLED", None)
+        else:
+            os.environ["TRINITY_MULTICAST_ENABLED"] = prev
+
+
+async def _pump(src: StreamEventBroker, dst: StreamEventBroker, stop: asyncio.Event,
+                 seen: set) -> None:
+    """In-proc stand-in for the WS pair -- lifted verbatim from Task 1's
+    test file (tests/governance/transport/test_trinity_bus_bridge.py::_pump,
+    see its docstring for the (op_id, origin) shared-seen-set rationale)."""
+    sub = src.subscribe()
+    while not stop.is_set():
+        try:
+            ev = await asyncio.wait_for(sub.queue.get(), timeout=0.2)
+        except asyncio.TimeoutError:
+            continue
+        if not ev.op_id.startswith(TRINITY_OP_PREFIX):
+            continue
+        key = (ev.op_id, ev.payload.get("origin"))
+        if key in seen:
+            continue
+        seen.add(key)
+        dst.publish(ev.event_type, ev.op_id, dict(ev.payload))
+
+
+def _mk_envelope() -> IntentEnvelope:
+    return make_envelope(
+        source="test_failure",
+        description="remote intake round-trip probe",
+        target_files=("backend/core/example.py",),
+        repo="jarvis",
+        confidence=0.9,
+        urgency="high",
+        evidence={"signature": "stage2-task3-remote-intake"},
+        requires_human_ack=False,
+    )
+
+
+class _RecordingRouter:
+    """Fake real-router: async def ingest(env) records and accepts."""
+
+    def __init__(self) -> None:
+        self.calls: List[Any] = []
+
+    async def ingest(self, envelope: Any) -> str:
+        self.calls.append(envelope)
+        return "enqueued"
+
+
+# --------------------------------------------------------------------------- #
+# (a) full round-trip over two real buses + Task-1 bridge pair + pump
+# --------------------------------------------------------------------------- #
+def test_round_trip_body_shim_to_brain_router():
+    async def scenario():
+        mac_bus, brain_bus = await _mk_bus(), await _mk_bus()
+        mac_broker, brain_broker = StreamEventBroker(), StreamEventBroker()
+        stop = asyncio.Event()
+        pump_seen: set = set()
+        pumps = [
+            asyncio.ensure_future(_pump(mac_broker, brain_broker, stop, pump_seen)),
+            asyncio.ensure_future(_pump(brain_broker, mac_broker, stop, pump_seen)),
+        ]
+        mac = TrinityBusBridge(mac_bus, mac_broker,
+                               outbound_topics=["intake.remote_signal.*"],
+                               source_id="mac")
+        brain = TrinityBusBridge(brain_bus, brain_broker,
+                                 outbound_topics=["actuation.*"],
+                                 source_id="brain")
+        await mac.start(); await brain.start()
+
+        router = _RecordingRouter()
+        bridge = RemoteIntakeBridge(brain_bus, router)
+        await bridge.start()
+
+        shim = RemoteIntakeRouter(mac_bus)
+        env = _mk_envelope()
+        verdict = await shim.ingest(env)
+        await asyncio.sleep(1.0)
+
+        stop.set()
+        for p in pumps:
+            p.cancel()
+        await bridge.stop()
+        await mac.stop(); await brain.stop()
+        return verdict, env, router.calls
+
+    verdict, env, calls = asyncio.get_event_loop().run_until_complete(scenario())
+    assert verdict == "enqueued"
+    assert len(calls) == 1, f"exactly one envelope must arrive: {calls!r}"
+    got = calls[0]
+    assert isinstance(got, IntentEnvelope)
+    assert got.to_dict() == env.to_dict()
+
+
+# --------------------------------------------------------------------------- #
+# (b) replay-dedup honesty: dedup belongs to the REAL router, not the bridge
+# --------------------------------------------------------------------------- #
+def test_same_payload_twice_reaches_router_twice_with_equal_dedup_key():
+    async def scenario():
+        router = _RecordingRouter()
+        bridge = RemoteIntakeBridge(trinity_bus=None, router=router)
+        payload = _mk_envelope().to_dict()
+        await bridge._on_signal(
+            TrinityEvent(topic=TOPIC_REMOTE_SIGNAL, payload=dict(payload)))
+        await bridge._on_signal(
+            TrinityEvent(topic=TOPIC_REMOTE_SIGNAL, payload=dict(payload)))
+        return router.calls
+
+    calls = asyncio.get_event_loop().run_until_complete(scenario())
+    assert len(calls) == 2, "bridge must NOT dedup -- the real router owns it"
+    assert calls[0].dedup_key == calls[1].dedup_key
+
+
+# --------------------------------------------------------------------------- #
+# (c) malformed payload: log-and-drop, never raise, router untouched
+# --------------------------------------------------------------------------- #
+def test_malformed_payload_dropped_without_raising():
+    async def scenario():
+        router = _RecordingRouter()
+        bridge = RemoteIntakeBridge(trinity_bus=None, router=router)
+        await bridge._on_signal(
+            TrinityEvent(topic=TOPIC_REMOTE_SIGNAL, payload={"garbage": True}))
+        return router.calls
+
+    calls = asyncio.get_event_loop().run_until_complete(scenario())
+    assert calls == []
+
+
+# --------------------------------------------------------------------------- #
+# (d) shim fail-soft: publish failure -> "backpressure", never a raise
+# --------------------------------------------------------------------------- #
+def test_shim_returns_backpressure_when_publish_fails():
+    class _ExplodingBus:
+        async def publish_raw(self, topic: str, data: dict) -> str:
+            raise RuntimeError("wire down")
+
+    async def scenario():
+        shim = RemoteIntakeRouter(_ExplodingBus())
+        return await shim.ingest(_mk_envelope())
+
+    verdict = asyncio.get_event_loop().run_until_complete(scenario())
+    assert verdict == "backpressure"

--- a/tests/governance/transport/test_organism_bus_host.py
+++ b/tests/governance/transport/test_organism_bus_host.py
@@ -210,6 +210,47 @@ def test_live_publish_crosses_to_stage0_client(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# Task 3 boot seam: IntakeLayerService passes its REAL router to the host
+# --------------------------------------------------------------------------- #
+def test_intake_layer_seam_passes_its_router_to_the_host(monkeypatch):
+    """Pin the router pass-through so a refactor cannot silently revert to
+    ``OrganismBusHost(router=None)`` -- the wired-but-inert class. The seam
+    lazy-imports OrganismBusHost from its module, so patching the module
+    attribute intercepts construction."""
+    import backend.core.ouroboros.governance.transport.organism_bus_host as obh
+    from backend.core.ouroboros.governance.intake.intake_layer_service import (
+        IntakeLayerService,
+    )
+
+    recorded: dict = {}
+
+    class _RecordingHost:
+        def __init__(self, router: Any = None) -> None:
+            recorded["router"] = router
+
+        async def start(self) -> bool:
+            return True
+
+        async def stop(self) -> None:
+            pass
+
+    monkeypatch.setattr(obh, "OrganismBusHost", _RecordingHost)
+    monkeypatch.setattr(obh, "bus_host_enabled", lambda: True)
+
+    svc = IntakeLayerService.__new__(IntakeLayerService)  # seam-only slice
+    svc._router = object()  # stands in for the layer's UnifiedIntakeRouter
+    svc._organism_bus_host = None
+    _run(svc._maybe_start_organism_bus_host())
+
+    assert "router" in recorded, "seam never constructed the host"
+    assert recorded["router"] is svc._router, (
+        "the host must receive the layer's OWN router instance, got %r"
+        % (recorded["router"],))
+    assert recorded["router"] is not None
+    assert isinstance(svc._organism_bus_host, _RecordingHost)
+
+
+# --------------------------------------------------------------------------- #
 # (c) sidecar handoff
 # --------------------------------------------------------------------------- #
 def _load_sidecar():

--- a/tests/governance/transport/test_organism_bus_host.py
+++ b/tests/governance/transport/test_organism_bus_host.py
@@ -1,0 +1,238 @@
+# -*- coding: utf-8 -*-
+"""OrganismBusHost (Stage-2 Task 2): the Brain organism's in-process mTLS WS
+bus server.
+
+Proves the three contracts from the task brief:
+
+  (a) DARK BY DEFAULT: with the master flag off (or port 0, or TLS material
+      missing), ``start()`` returns False and touches nothing -- no server,
+      no bridge, no trinity bus resolution.
+  (b) LIVE PATH: with the flag on + TLS disabled + an ephemeral port, a REAL
+      Stage-0 ``DistributedEventBus`` client connects over localhost and a
+      ``publish_raw("actuation.click", ...)`` on the organism's own
+      TrinityEventBus is observed on the client's broker (scaffolding lifted
+      from test_bridge_reflection_and_cursor.py, server side replaced by
+      OrganismBusHost). TRINITY_MULTICAST_ENABLED=false suppresses the
+      in-process UDP shortcut (see test_trinity_bus_bridge.py::_mk_bus).
+  (c) SIDECAR HANDOFF: scripts/brain_bus_echo_server.py ``main()`` returns 0
+      immediately when JARVIS_BRAIN_BUS_SIDECAR_ENABLED=false (the organism
+      host replaces the sidecar on Stage-2 nodes); default keeps Stage-1
+      behavior byte-identical.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import socket
+from typing import Any, List
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.distributed_event_bus import (
+    DistributedEventBus,
+)
+from backend.core.ouroboros.governance.transport.organism_bus_host import (
+    OrganismBusHost,
+    bus_host_enabled,
+    resolve_outbound_topics,
+)
+from backend.core.ouroboros.governance.transport.transport_config import (
+    TransportConfig,
+)
+from backend.core.ouroboros.governance.transport.trinity_bus_bridge import (
+    TRINITY_OP_PREFIX,
+)
+
+_REPO_ROOT = os.path.dirname(os.path.dirname(os.path.dirname(
+    os.path.dirname(os.path.abspath(__file__)))))
+
+_ALL_KNOBS = (
+    "JARVIS_DISTRIBUTED_BUS_ENABLED",
+    "JARVIS_BRAIN_WS_TLS_ENABLED",
+    "JARVIS_BRAIN_WS_TLS_CERT",
+    "JARVIS_BRAIN_WS_TLS_KEY",
+    "JARVIS_BRAIN_WS_TLS_CA",
+    "JARVIS_BRAIN_WS_TLS_EPHEMERAL",
+    "JARVIS_BRAIN_WS_HOST",
+    "JARVIS_BRAIN_WS_PORT",
+    "JARVIS_BRAIN_WS_HEARTBEAT_S",
+    "JARVIS_BRAIN_OUTBOUND_TOPICS",
+    "JARVIS_BRAIN_BUS_SIDECAR_ENABLED",
+)
+
+
+def _clean_env(monkeypatch) -> None:
+    for key in _ALL_KNOBS:
+        monkeypatch.delenv(key, raising=False)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# --------------------------------------------------------------------------- #
+# Env knob parsing
+# --------------------------------------------------------------------------- #
+def test_outbound_topics_default_and_override(monkeypatch):
+    _clean_env(monkeypatch)
+    assert resolve_outbound_topics() == ["actuation.*", "telemetry.posture.*"]
+    monkeypatch.setenv("JARVIS_BRAIN_OUTBOUND_TOPICS", " a.b , c.* ,, ")
+    assert resolve_outbound_topics() == ["a.b", "c.*"]
+    monkeypatch.setenv("JARVIS_BRAIN_OUTBOUND_TOPICS", "   ")
+    assert resolve_outbound_topics() == ["actuation.*", "telemetry.posture.*"]
+
+
+# --------------------------------------------------------------------------- #
+# (a) dark by default
+# --------------------------------------------------------------------------- #
+def test_bus_host_enabled_defaults_false(monkeypatch):
+    _clean_env(monkeypatch)
+    assert bus_host_enabled() is False
+
+
+def test_start_dark_when_master_flag_off(monkeypatch):
+    _clean_env(monkeypatch)
+    host = OrganismBusHost()
+    assert _run(host.start()) is False
+    assert host.started is False
+    # touches nothing: no runner, no bridge, no broker
+    assert host._runner is None
+    assert host._bridge is None
+    assert host._broker is None
+    _run(host.stop())  # stop on a never-started host must be a no-op
+
+
+def test_start_dark_when_port_zero(monkeypatch):
+    _clean_env(monkeypatch)
+    monkeypatch.setenv("JARVIS_DISTRIBUTED_BUS_ENABLED", "true")
+    # port stays at the TransportConfig default (0)
+    host = OrganismBusHost()
+    assert _run(host.start()) is False
+    assert host.started is False
+    assert host._runner is None
+
+
+def test_refuses_plaintext_when_tls_material_missing(monkeypatch):
+    _clean_env(monkeypatch)
+    monkeypatch.setenv("JARVIS_DISTRIBUTED_BUS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", str(_free_port()))
+    # tls_enabled defaults True; no cert/key/ephemeral -> must refuse, never
+    # fall through to a plaintext TCPSite.
+    host = OrganismBusHost()
+    assert _run(host.start()) is False
+    assert host.started is False
+    assert host._runner is None
+
+
+# --------------------------------------------------------------------------- #
+# (b) live path: real Stage-0 client observes the organism's trinity bus
+# --------------------------------------------------------------------------- #
+def test_live_publish_crosses_to_stage0_client(monkeypatch):
+    _clean_env(monkeypatch)
+    port = _free_port()
+    monkeypatch.setenv("JARVIS_DISTRIBUTED_BUS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HOST", "127.0.0.1")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", str(port))
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "1.0")
+    # Suppress the in-process UDP multicast shortcut -- precedent + rationale:
+    # tests/governance/transport/test_trinity_bus_bridge.py::_mk_bus.
+    monkeypatch.setenv("TRINITY_MULTICAST_ENABLED", "false")
+
+    async def scenario():
+        from backend.core.trinity_event_bus import (
+            get_trinity_event_bus,
+            shutdown_trinity_event_bus,
+        )
+
+        host = OrganismBusHost()
+        client_task = None
+        client_bus = None
+        try:
+            assert await host.start() is True
+            assert host.started is True
+
+            client_cfg = TransportConfig.from_env(role="client")
+            client_broker = StreamEventBroker()
+            client_bus = DistributedEventBus(
+                client_broker, client_cfg, role="client")
+            url = "ws://127.0.0.1:%d%s" % (port, client_cfg.path)
+            client_task = asyncio.ensure_future(client_bus.start_client(url))
+
+            deadline = asyncio.get_event_loop().time() + 5.0
+            while asyncio.get_event_loop().time() < deadline:
+                client = getattr(client_bus, "_client", None)
+                if client is not None and getattr(client, "connected", False):
+                    break
+                await asyncio.sleep(0.02)
+            else:
+                raise AssertionError("client never reported connected")
+
+            bus = await get_trinity_event_bus()
+            await bus.publish_raw("actuation.click", {"x": 1})
+            await bus.publish_raw("fs.changed.src", {"x": 2})  # NOT allowlisted
+            await asyncio.sleep(1.0)
+
+            return [
+                ev for ev in client_broker.recent_history(limit=500)
+                if ev.op_id.startswith(TRINITY_OP_PREFIX)
+            ]
+        finally:
+            if client_bus is not None:
+                try:
+                    await client_bus.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+            if client_task is not None:
+                client_task.cancel()
+                try:
+                    await client_task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            await host.stop()
+            await shutdown_trinity_event_bus()
+
+    got: List[Any] = _run(scenario())
+    assert len(got) == 1, (
+        "exactly the allowlisted default topic must cross: %r" % got)
+    assert got[0].op_id == TRINITY_OP_PREFIX + "actuation.click"
+    assert got[0].payload["topic"] == "actuation.click"
+    assert got[0].payload["data"]["x"] == 1
+    assert got[0].payload["origin"]  # stamped with the host's source_id
+
+
+# --------------------------------------------------------------------------- #
+# (c) sidecar handoff
+# --------------------------------------------------------------------------- #
+def _load_sidecar():
+    path = os.path.join(_REPO_ROOT, "scripts", "brain_bus_echo_server.py")
+    spec = importlib.util.spec_from_file_location(
+        "brain_bus_echo_server_under_test", path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_sidecar_early_exits_when_disabled(monkeypatch):
+    _clean_env(monkeypatch)
+    mod = _load_sidecar()
+    for falsy in ("0", "false", "no", "off", " FALSE "):
+        monkeypatch.setenv("JARVIS_BRAIN_BUS_SIDECAR_ENABLED", falsy)
+        # Returns 0 BEFORE any asyncio.run / server setup.
+        assert mod.main() == 0
+
+
+def test_sidecar_default_keeps_stage1_behavior(monkeypatch):
+    _clean_env(monkeypatch)
+    mod = _load_sidecar()
+    # Default (env unset) must still reach amain(); with no port configured
+    # the Stage-1 contract is rc=2, NOT the disabled-guard's rc=0.
+    assert _run(mod.amain()) == 2

--- a/tests/governance/transport/test_trinity_bus_bridge.py
+++ b/tests/governance/transport/test_trinity_bus_bridge.py
@@ -1,0 +1,155 @@
+# -*- coding: utf-8 -*-
+"""TrinityBusBridge: topic-allowlisted mirroring with origin-tagged loop safety.
+
+Two REAL TrinityEventBus instances linked through two REAL StreamEventBrokers
+and an in-proc pump (the WS bridge's proven contract) -- publish on one side
+is observed by subscribers on the other, exactly once, allowlist enforced.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, Dict, List
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.trinity_bus_bridge import (
+    TRINITY_OP_PREFIX,
+    TrinityBusBridge,
+)
+from backend.core.trinity_event_bus import TrinityEventBus, RepoType
+
+
+async def _mk_bus() -> TrinityEventBus:
+    # Deviation (deliberate, documented): two REAL TrinityEventBus instances
+    # constructed with the SAME local_repo in one process are, in this test,
+    # standing in for two genuinely separate hosts (Mac + Brain VM) that are
+    # NOT on a shared broadcast domain in the real Stage-2 topology. Without
+    # this, CrossRepoTransport's own UDP multicast (an existing, unrelated
+    # channel -- see backend/core/trinity_event_bus.py:551-560) lets the two
+    # buses see each other directly on localhost, bypassing the
+    # TrinityBusBridge under test entirely and producing a storm that has
+    # nothing to do with the bridge's origin-tag loop guard. Established
+    # precedent for suppressing this in-process artifact:
+    # backend/core/ouroboros/battle_test/ov_smoke.py:456-458
+    # ("TRINITY_MULTICAST_ENABLED=false  # suppress UDP socket").
+    prev = os.environ.get("TRINITY_MULTICAST_ENABLED")
+    os.environ["TRINITY_MULTICAST_ENABLED"] = "false"
+    try:
+        return await TrinityEventBus.create(local_repo=RepoType.JARVIS)
+    finally:
+        if prev is None:
+            os.environ.pop("TRINITY_MULTICAST_ENABLED", None)
+        else:
+            os.environ["TRINITY_MULTICAST_ENABLED"] = prev
+
+
+async def _pump(src: StreamEventBroker, dst: StreamEventBroker, stop: asyncio.Event,
+                 seen: set) -> None:
+    """In-proc stand-in for the WS pair: mirror trinity-prefixed broker events
+    once, by LOGICAL identity (the real wire dedups + suppresses reflections).
+
+    Deviation from the brief's literal sketch (documented): the original
+    keyed ``seen`` by ``ev.event_id`` and scoped it per-direction (one set
+    per one-way pump). ``StreamEventBroker.publish()`` mints a brand-new
+    sequential id on every hop (no way to preserve one across a relay -- see
+    its signature, no event_id parameter), so a per-direction event_id-keyed
+    set can NEVER catch a reflection: mac -> brain -> mac each leg gets a
+    fresh id and looks unseen forever, which is exactly the "Stage-1
+    reflection-storm class" this test's docstring names. The REAL WS bridge
+    (bus_bridge_client.py:216-220, bus_bridge_server.py:59-62/118-119, fixed
+    2026-07-04 for this identical failure mode) instead tracks ids it
+    RE-MINTED from an inbound peer event and has its OUTBOUND pump skip
+    exactly those ids. This is the in-proc analog: dedup by the STABLE
+    (op_id, origin) pair carried unchanged in the payload across every hop,
+    with ONE ``seen`` set SHARED by both directions of a bidirectional pump
+    pair -- so a logical event crosses the link at most once total, not once
+    per direction.
+    """
+    sub = src.subscribe()
+    while not stop.is_set():
+        try:
+            ev = await asyncio.wait_for(sub.queue.get(), timeout=0.2)
+        except asyncio.TimeoutError:
+            continue
+        if not ev.op_id.startswith(TRINITY_OP_PREFIX):
+            continue
+        key = (ev.op_id, ev.payload.get("origin"))
+        if key in seen:
+            continue
+        seen.add(key)
+        dst.publish(ev.event_type, ev.op_id, dict(ev.payload))
+
+
+def test_publish_crosses_once_and_only_allowlisted_topics():
+    async def scenario():
+        mac_bus, brain_bus = await _mk_bus(), await _mk_bus()
+        mac_broker, brain_broker = StreamEventBroker(), StreamEventBroker()
+        stop = asyncio.Event()
+        pump_seen: set = set()
+        pumps = [asyncio.ensure_future(_pump(mac_broker, brain_broker, stop, pump_seen)),
+                 asyncio.ensure_future(_pump(brain_broker, mac_broker, stop, pump_seen))]
+        mac = TrinityBusBridge(mac_bus, mac_broker,
+                               outbound_topics=["intake.remote_signal.*"],
+                               source_id="mac")
+        brain = TrinityBusBridge(brain_bus, brain_broker,
+                                 outbound_topics=["actuation.*"],
+                                 source_id="brain")
+        await mac.start(); await brain.start()
+
+        got: List[Dict[str, Any]] = []
+
+        async def handler(ev):
+            got.append({"topic": ev.topic, "payload": dict(ev.payload)})
+
+        await brain_bus.subscribe("intake.remote_signal.*", handler)
+        await mac_bus.publish_raw("intake.remote_signal.voice", {"k": 1})
+        await mac_bus.publish_raw("fs.changed.src", {"k": 2})  # NOT allowlisted
+        await asyncio.sleep(1.0)
+
+        stop.set()
+        for p in pumps:
+            p.cancel()
+        await mac.stop(); await brain.stop()
+        return got
+
+    got = asyncio.get_event_loop().run_until_complete(scenario())
+    assert len(got) == 1, f"exactly the allowlisted topic, exactly once: {got!r}"
+    assert got[0]["topic"] == "intake.remote_signal.voice"
+    assert got[0]["payload"]["k"] == 1
+
+
+def test_no_ping_pong_amplification_at_trinity_layer():
+    """An imported event must NEVER be re-forwarded even when its topic matches
+    the local outbound allowlist (the Stage-1 reflection-storm class)."""
+    async def scenario():
+        mac_bus, brain_bus = await _mk_bus(), await _mk_bus()
+        mac_broker, brain_broker = StreamEventBroker(), StreamEventBroker()
+        stop = asyncio.Event()
+        pump_seen: set = set()
+        pumps = [asyncio.ensure_future(_pump(mac_broker, brain_broker, stop, pump_seen)),
+                 asyncio.ensure_future(_pump(brain_broker, mac_broker, stop, pump_seen))]
+        # SAME topic allowlisted on BOTH sides -- the storm setup.
+        mac = TrinityBusBridge(mac_bus, mac_broker,
+                               outbound_topics=["shared.topic"], source_id="mac")
+        brain = TrinityBusBridge(brain_bus, brain_broker,
+                                 outbound_topics=["shared.topic"], source_id="brain")
+        await mac.start(); await brain.start()
+
+        await mac_bus.publish_raw("shared.topic", {"n": 1})
+        await asyncio.sleep(1.5)  # long enough for any storm
+
+        mac_n = len([e for e in mac_broker.recent_history(limit=500)
+                     if e.op_id.startswith(TRINITY_OP_PREFIX)])
+        brain_n = len([e for e in brain_broker.recent_history(limit=500)
+                       if e.op_id.startswith(TRINITY_OP_PREFIX)])
+        stop.set()
+        for p in pumps:
+            p.cancel()
+        await mac.stop(); await brain.stop()
+        return mac_n, brain_n
+
+    mac_n, brain_n = asyncio.get_event_loop().run_until_complete(scenario())
+    assert mac_n == 1, f"mac broker must hold exactly the original: {mac_n}"
+    assert brain_n == 1, f"brain broker must hold exactly the mirror: {brain_n}"

--- a/tests/infra/test_brain_tls_delivery.py
+++ b/tests/infra/test_brain_tls_delivery.py
@@ -162,3 +162,12 @@ def test_runtime_startup_script_writes_and_starts_bus_sidecar(ign):
     assert script.index("/etc/jarvis/tls/ca.pem") < script.index(
         "systemctl restart jarvis-brain-bus.service")
     script.encode("ascii")
+
+
+def test_brain_env_values_fold_stage2_bus_host_keys(ign, mtls_dir, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_BUS_SIDECAR_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_BRAIN_OUTBOUND_TOPICS", "actuation.*,telemetry.posture.*")
+    driver = ign.BrainIgnitionDriver(dry_run=True)
+    vals = driver._brain_env_values()
+    assert vals["JARVIS_BRAIN_BUS_SIDECAR_ENABLED"] == "false"
+    assert vals["JARVIS_BRAIN_OUTBOUND_TOPICS"] == "actuation.*,telemetry.posture.*"

--- a/tests/infra/test_run_body_mode.py
+++ b/tests/infra/test_run_body_mode.py
@@ -1,0 +1,266 @@
+"""Unit tests for scripts/run_body_mode.py (Stage-2 Body-mode driver).
+
+Pure-logic -- NO real sockets, buses, or GCP. Every collaborator (discover /
+bus stack / bridge / shim / sensor / watchdog) is a fake injected via the
+driver's seams (the ``BrainIgnitionDriver`` seam pattern). The tests prove:
+
+  (a) --dry-run prints the plan and touches NOTHING (injected discover seam is
+      never called).
+  (b) Injected-seam happy path: fake discover returns a URL; the connect gate
+      clears against a fake client; ``--inject-test-signal 3`` produces exactly
+      3 ``shim.ingest`` calls whose envelopes carry 3 DISTINCT dedup_keys; the
+      run exits 0 and emits the ``[BodyMode] SUMMARY`` line.
+  (c) Discovery failure -> exit 2 with the "Brain offline" log.
+  (d) Connect-gate timeout -> exit 3.
+
+The live discovery/bus/bridge paths are proven by the Stage-2 live-fire
+acceptance, not here.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+import os
+import sys
+from typing import Any, List, Optional
+
+import pytest
+
+_HERE = os.path.dirname(os.path.abspath(__file__))
+_REPO_ROOT = os.path.dirname(os.path.dirname(_HERE))
+_DRIVER_PATH = os.path.join(_REPO_ROOT, "scripts", "run_body_mode.py")
+
+
+def _load_driver() -> Any:
+    """Load the Body-mode driver as a module by path (script, not a package)."""
+    if _REPO_ROOT not in sys.path:
+        sys.path.insert(0, _REPO_ROOT)
+    if "run_body_mode" in sys.modules:
+        return sys.modules["run_body_mode"]
+    spec = importlib.util.spec_from_file_location("run_body_mode", _DRIVER_PATH)
+    assert spec and spec.loader, "cannot load run_body_mode"
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules["run_body_mode"] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+bm = _load_driver()
+
+
+@pytest.fixture(autouse=True)
+def _no_multicast(monkeypatch):
+    # Established precedent (tests/governance/transport/test_trinity_bus_bridge.py
+    # _mk_bus): suppress the in-process UDP multicast artifact. Belt-and-braces
+    # here -- every collaborator is a fake, so no real bus is ever constructed.
+    monkeypatch.setenv("TRINITY_MULTICAST_ENABLED", "false")
+
+
+# ---------------------------------------------------------------------------
+# Fakes (record-only; no I/O).
+# ---------------------------------------------------------------------------
+
+
+class _FakeClient:
+    def __init__(self, connected: bool = True) -> None:
+        self.connected = connected
+
+
+class _FakeDistBus:
+    """Duck-types the DistributedEventBus client surface the driver uses:
+    ``start_client`` (long-running) + ``_client`` attr with ``connected``."""
+
+    def __init__(self, connect: bool = True) -> None:
+        self._client = _FakeClient(connected=True) if connect else None
+        self.started_urls: List[str] = []
+        self.stopped = False
+        self._forever = asyncio.Event()
+
+    async def start_client(self, url: str) -> None:
+        self.started_urls.append(url)
+        await self._forever.wait()  # long-running, like the real client task
+
+    async def stop(self) -> None:
+        self.stopped = True
+        self._forever.set()
+
+
+class _FakeTrinityBus:
+    pass
+
+
+class _FakeBroker:
+    pass
+
+
+class _FakeBridge:
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+class _FakeShim:
+    def __init__(self) -> None:
+        self.envelopes: List[Any] = []
+
+    async def ingest(self, envelope: Any) -> str:
+        self.envelopes.append(envelope)
+        return "enqueued"
+
+
+class _FakeWatchdog:
+    def __init__(self) -> None:
+        self.started = False
+        self.stopped = False
+        self.lag_event_count = 0
+        self.threshold_ms = 200.0
+
+    def start(self) -> bool:
+        self.started = True
+        return True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def recent_lag_records(self, limit: Optional[int] = None) -> List[Any]:
+        return []
+
+
+def _seams(*, url: Optional[str] = "wss://10.0.0.5:8770/ws/trinity-bus",
+           connect: bool = True):
+    """A full fake seam kit; returns (kwargs, recorder namespace)."""
+    calls = {"discover": 0}
+    dist = _FakeDistBus(connect=connect)
+    bridge = _FakeBridge()
+    shim = _FakeShim()
+    wd = _FakeWatchdog()
+
+    async def _discover() -> Optional[str]:
+        calls["discover"] += 1
+        return url
+
+    async def _bus_factory():
+        return _FakeTrinityBus(), _FakeBroker(), dist
+
+    def _bridge_factory(trinity_bus: Any, broker: Any) -> _FakeBridge:
+        return bridge
+
+    def _shim_factory(trinity_bus: Any) -> _FakeShim:
+        return shim
+
+    def _sensor_factory(shim_: Any) -> Any:
+        return object()
+
+    def _watchdog_factory() -> _FakeWatchdog:
+        return wd
+
+    kwargs = dict(
+        discover_fn=_discover,
+        bus_factory=_bus_factory,
+        bridge_factory=_bridge_factory,
+        shim_factory=_shim_factory,
+        sensor_factory=_sensor_factory,
+        watchdog_factory=_watchdog_factory,
+    )
+    ns = type("NS", (), dict(calls=calls, dist=dist, bridge=bridge,
+                             shim=shim, wd=wd))
+    return kwargs, ns
+
+
+# ---------------------------------------------------------------------------
+# (a) --dry-run: plan printed, no seam touched.
+# ---------------------------------------------------------------------------
+
+
+def test_dry_run_prints_plan_and_touches_nothing(capsys):
+    kwargs, ns = _seams()
+    driver = bm.BodyModeDriver(dry_run=True, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "[dry-run]" in out
+    assert "[BodyMode]" in out
+    assert ns.calls["discover"] == 0, "dry-run must not discover"
+    assert ns.dist.started_urls == [], "dry-run must not connect"
+    assert not ns.bridge.started and not ns.wd.started
+
+
+def test_dry_run_via_cli_main(capsys):
+    rc = bm.main(["--dry-run"])
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "[dry-run]" in out
+
+
+# ---------------------------------------------------------------------------
+# (b) Injected-seam happy path: 3 signals -> 3 ingests, distinct dedup_keys.
+# ---------------------------------------------------------------------------
+
+
+def test_inject_three_signals_distinct_dedup_keys(capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    kwargs, ns = _seams()
+    driver = bm.BodyModeDriver(
+        inject_test_signals=3, duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert len(ns.shim.envelopes) == 3, "exactly 3 shim.ingest calls"
+    keys = [e.dedup_key for e in ns.shim.envelopes]
+    assert len(set(keys)) == 3, "dedup_keys must be DISTINCT: %r" % keys
+    for e in ns.shim.envelopes:
+        # ``cadence_synthetic`` is the whitelisted honest-source token for
+        # synthetic test workload (intent_envelope.py _VALID_SOURCES) -- the
+        # Body-mode identity travels in evidence.origin.
+        assert e.source == "cadence_synthetic"
+        assert e.evidence.get("origin") == "body_test"
+        assert "stage2 acceptance signal" in e.description
+
+    # Full lifecycle: connected + bridged + watched + cleanly stopped.
+    assert ns.dist.started_urls == ["wss://10.0.0.5:8770/ws/trinity-bus"]
+    assert ns.bridge.started and ns.bridge.stopped
+    assert ns.wd.started and ns.wd.stopped
+
+    # Census + summary lines.
+    assert "[BodyMode] SUMMARY" in out
+    assert "signals_sent=3" in out
+    assert "lag_events=0" in out
+
+
+# ---------------------------------------------------------------------------
+# (c) Discovery failure -> exit 2 + "Brain offline".
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_failure_exits_2_brain_offline(capsys):
+    kwargs, ns = _seams(url=None)
+    driver = bm.BodyModeDriver(**kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "Brain offline" in out
+    assert ns.calls["discover"] == 1
+    assert ns.dist.started_urls == [], "no connect attempt after failed discovery"
+    assert not ns.bridge.started
+
+
+# ---------------------------------------------------------------------------
+# (d) Connect-gate timeout -> exit 3.
+# ---------------------------------------------------------------------------
+
+
+def test_connect_gate_timeout_exits_3(capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "0.2")
+    kwargs, ns = _seams(connect=False)  # _client never materializes
+    driver = bm.BodyModeDriver(inject_test_signals=1, duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    assert rc == 3
+    assert ns.shim.envelopes == [], "no signals on a dark link"
+    assert not ns.bridge.started, "bridge must not start on a dark link"


### PR DESCRIPTION
## Stage 2: the organism's bus goes distributed (ships DARK)

- **TrinityBusBridge** — origin-tagged TrinityEventBus ↔ StreamEventBroker adapter (the Stage-0 docstring promise, delivered). Loop safety by construction; proven no-storm under the same-topic-both-sides setup.
- **OrganismBusHost** — the Brain organism hosts the mTLS WS bus in-process (own site; EventChannelServer stays loopback-only per invariant). Sidecar handoff via `JARVIS_BRAIN_BUS_SIDECAR_ENABLED`.
- **Remote intake path** — Body-side `RemoteIntakeRouter` shim (sensors unchanged) → wire → Brain-side `RemoteIntakeBridge` → real `UnifiedIntakeRouter` (dedup preserved). Router pass-through pinned by is-identity test.
- **Body-mode driver** (`scripts/run_body_mode.py`) — discovery + connect-gated WS client + sensor shim + ControlPlaneWatchdog census; deterministic `--inject-test-signal` acceptance path (routes STANDARD — comment corrected after review traced the router).
- Ignition folds the two Stage-2 env keys to the node.

Everything behind `JARVIS_DISTRIBUTED_BUS_ENABLED` (default false) — final review verified behaviorally byte-identical off on both Mac and node paths.

Final whole-branch review (opus): READY-TO-MERGE, 0 Critical / 0 Important; live path hand-traced end-to-end against real collaborators; loop safety verified under the real wire semantics. 31 Stage-2 tests + 48 transport suite green.

Next: paid live-fire acceptance (provision warm standby, body mode from the Mac, verify a Mac-originated signal reaches the Brain FSM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the organism’s `TrinityEventBus` distributed across hosts with an in-process mTLS WS server and an origin-tagged bridge, enabling Body→Brain signal flow without the sidecar. Adds a Body-mode driver and a remote intake path that routes Mac sensor events into the Brain’s real intake router.

- **New Features**
  - `OrganismBusHost`: hosts a WS server (`DistributedEventBus`) inside the Brain; lazy-start behind `JARVIS_DISTRIBUTED_BUS_ENABLED`; refuses plaintext when TLS is enabled; outbound topics via `JARVIS_BRAIN_OUTBOUND_TOPICS`.
  - `TrinityBusBridge`: mirrors allowlisted `TrinityEventBus` topics to/from a `StreamEventBroker` with origin tags to prevent reflection loops.
  - Remote intake: `RemoteIntakeRouter` (Body) publishes envelopes to `intake.remote_signal.body`; `RemoteIntakeBridge` (Brain) rehydrates and forwards to the real router; fail-soft on errors.
  - Intake integration: `IntakeLayerService` starts/stops the host and passes its router; master-off path remains byte-identical.
  - Body mode: `scripts/run_body_mode.py` discovers the Brain, connects the WS client, starts the bridge, points sensors at the shim, supports `--inject-test-signal` and a starvation census.
  - Sidecar handoff: `brain_bus_echo_server.py` exits early when `JARVIS_BRAIN_BUS_SIDECAR_ENABLED=false`; ignition folds new env keys.

- **Migration**
  - Brain: set `JARVIS_DISTRIBUTED_BUS_ENABLED=true`, configure `JARVIS_BRAIN_WS_PORT`, and provide TLS (`JARVIS_BRAIN_WS_TLS_CERT`, `JARVIS_BRAIN_WS_TLS_KEY`, `JARVIS_BRAIN_WS_TLS_CA`) or set `JARVIS_BRAIN_WS_TLS_ENABLED=false`.
  - Brain: set `JARVIS_BRAIN_BUS_SIDECAR_ENABLED=false` to disable the sidecar on nodes that host the bus in-process.
  - Optional: set `JARVIS_BRAIN_OUTBOUND_TOPICS` (default `actuation.*,telemetry.posture.*`).
  - Body/Mac: run `scripts/run_body_mode.py`; optionally tune `JARVIS_BRAIN_CONNECT_GATE_S` and `JARVIS_BODY_MODE_CENSUS_S`.

<sup>Written for commit 2aa7615268cfb4a817a8f641eb7e5b064a955b81. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69842?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

