### PR TITLE
fix(stage2): opt-in provider-key fold into brain.env metadata (live-fire: soak crash-looped keyless)

### DIFF
--- a/scripts/ignite_brain_vm.py
+++ b/scripts/ignite_brain_vm.py
@@ -787,6 +787,17 @@ class BrainIgnitionDriver:
                 _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
             vals["JARVIS_BRAIN_WS_TLS_CA"] = "%s/%s" % (
                 _NODE_TLS_DIR, _TLS_META_KEYS["ca"][1])
+        # Opt-in provider-key fold (live-fire 2026-07-04 Stage-2 acceptance: the
+        # soak crash-looped 54x with "No API keys set" because these were never
+        # shipped). Keys travel as instance metadata (project-scoped
+        # visibility) -- the established J-Prime pattern per the relocation
+        # design's open risk #4. Opt-in so default ignitions never ship
+        # secrets.
+        if _truthy(os.environ.get("JARVIS_BRAIN_SHIP_PROVIDER_KEYS")):
+            for key in ("DOUBLEWORD_API_KEY", "ANTHROPIC_API_KEY"):
+                v = os.environ.get(key)
+                if v is not None and v != "":
+                    vals[key] = v
         return vals
 
     async def _do_discover(self) -> Optional[str]:

--- a/tests/infra/test_brain_tls_delivery.py
+++ b/tests/infra/test_brain_tls_delivery.py
@@ -171,3 +171,37 @@ def test_brain_env_values_fold_stage2_bus_host_keys(ign, mtls_dir, monkeypatch):
     vals = driver._brain_env_values()
     assert vals["JARVIS_BRAIN_BUS_SIDECAR_ENABLED"] == "false"
     assert vals["JARVIS_BRAIN_OUTBOUND_TOPICS"] == "actuation.*,telemetry.posture.*"
+
+
+# --------------------------------------------------------------------------- #
+# (f) opt-in provider-key fold (live-fire 2026-07-04: soak crash-looped 54x
+#     with "No API keys set" -- the keys were never shipped to the node).
+# --------------------------------------------------------------------------- #
+def test_brain_env_values_provider_keys_not_folded_by_default(ign, mtls_dir, monkeypatch):
+    monkeypatch.delenv("JARVIS_BRAIN_SHIP_PROVIDER_KEYS", raising=False)
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", "test-dw-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+    driver = ign.BrainIgnitionDriver(dry_run=True)
+    vals = driver._brain_env_values()
+    assert "DOUBLEWORD_API_KEY" not in vals
+    assert "ANTHROPIC_API_KEY" not in vals
+
+
+def test_brain_env_values_provider_keys_folded_when_opted_in(ign, mtls_dir, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_SHIP_PROVIDER_KEYS", "true")
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", "test-dw-key")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "test-anthropic-key")
+    driver = ign.BrainIgnitionDriver(dry_run=True)
+    vals = driver._brain_env_values()
+    assert vals["DOUBLEWORD_API_KEY"] == "test-dw-key"
+    assert vals["ANTHROPIC_API_KEY"] == "test-anthropic-key"
+
+
+def test_brain_env_values_provider_keys_empty_skipped_when_opted_in(ign, mtls_dir, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_SHIP_PROVIDER_KEYS", "true")
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", "")
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    driver = ign.BrainIgnitionDriver(dry_run=True)
+    vals = driver._brain_env_values()
+    assert "DOUBLEWORD_API_KEY" not in vals
+    assert "ANTHROPIC_API_KEY" not in vals


### PR DESCRIPTION
## Summary

- **Live-fire finding (2026-07-04 Stage-2 acceptance):** the Brain VM's soak crash-looped 54 times with `ERROR: No API keys set. Export DOUBLEWORD_API_KEY or ANTHROPIC_API_KEY.` `scripts/ignite_brain_vm.py::_brain_env_values()` folds config env into the node's `/etc/jarvis/brain.env` metadata but never shipped provider keys — the design spec's open risk #4 ("secrets on the VM — the golden-image + metadata pattern already handles this for J-Prime; confirm reuse") was never actually closed.
- **Fix:** `_brain_env_values()` now folds `DOUBLEWORD_API_KEY` and `ANTHROPIC_API_KEY` into the node's brain.env metadata, but **only when opted in** via `JARVIS_BRAIN_SHIP_PROVIDER_KEYS` (truthy per the module's existing `_truthy` helper). Empty/unset keys are skipped even when opted in. Default ignitions never ship secrets.
- **Precedent:** keys travel as instance metadata (project-scoped visibility) — the same pattern already established for J-Prime.

## Test plan

- [x] Added 3 new tests to `tests/infra/test_brain_tls_delivery.py` matching the existing `_brain_env_values` test style (`ign` + `mtls_dir` fixtures):
  - keys NOT folded by default even when set in env
  - folded when `JARVIS_BRAIN_SHIP_PROVIDER_KEYS=true` and set
  - empty-valued key skipped even when opted in
- [x] RED confirmed: reverted the implementation, ran the suite — 1 new test failed (`KeyError: 'DOUBLEWORD_API_KEY'`), 13 passed.
- [x] GREEN: `python3 -m pytest tests/infra/test_brain_tls_delivery.py -q` → 14 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Opt-in shipping of provider API keys to the Brain VM to prevent keyless crash loops seen in stage-2 soak. When `JARVIS_BRAIN_SHIP_PROVIDER_KEYS` is truthy, `DOUBLEWORD_API_KEY` and `ANTHROPIC_API_KEY` are folded into `/etc/jarvis/brain.env`; empty or unset keys are skipped.

- **Bug Fixes**
  - Default stays: no secrets shipped via metadata.
  - Reuses the J-Prime instance metadata pattern.
  - Added 3 tests in `tests/infra/test_brain_tls_delivery.py` for default skip, opt-in include, and empty skip (all passing).

- **Migration**
  - Set `JARVIS_BRAIN_SHIP_PROVIDER_KEYS=true` during ignition to ship keys.
  - Ensure `DOUBLEWORD_API_KEY` and/or `ANTHROPIC_API_KEY` are set to non-empty values.

<sup>Written for commit 31134b3beac458b659c1b1787b5cd7fbb9fa287a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

