### PR TITLE
feat(stage3): partition hardening -- ack lane, durable WAL, WAL-seeded replay, deliberate-partition suite

### DIFF
--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -48,6 +48,7 @@ class BusBridgeClient:
         url: Optional[str] = None,
         session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None,
         initial_last_sent_id: Optional[str] = None,
+        on_ack: Optional[Callable[[str], None]] = None,
     ) -> None:
         self._broker = broker
         self._cfg = cfg
@@ -63,6 +64,12 @@ class BusBridgeClient:
         # instance's cursor via ``initial_last_sent_id`` -- otherwise the
         # severed span is silently lost (live-fire attempt 2, 2026-07-04).
         self._last_sent_id: Optional[str] = initial_last_sent_id
+        self._on_ack = on_ack
+        # Stage 3 WAL-trim cursor: the last event_id the SERVER has
+        # confirmed ingesting on this connection. Monotonic -- only ever
+        # advances, so a stray regressive/duplicate ack (out-of-order
+        # delivery, replay) cannot rewind a later trim decision.
+        self._last_acked_id: Optional[str] = None
         self._high_water: int = 0
         self._degraded = False
         self._missed_hb = 0
@@ -87,6 +94,12 @@ class BusBridgeClient:
     @property
     def last_event_id(self) -> Optional[str]:
         return self._last_event_id
+
+    @property
+    def last_acked_id(self) -> Optional[str]:
+        """The last event_id the server has confirmed ingesting on this
+        connection (Stage 3 WAL-trim cursor). None until the first ack."""
+        return self._last_acked_id
 
     @property
     def degraded(self) -> bool:
@@ -245,9 +258,33 @@ class BusBridgeClient:
             self._missed_hb = 0
             self._degraded = False
             frame = bf.BusFrame.decode(msg.data)
-            if frame is None or frame.kind != bf.FRAME_EVENT:
+            if frame is None:
+                continue
+            if frame.kind == bf.FRAME_ACK:
+                self._apply_ack(frame)
+                continue
+            if frame.kind != bf.FRAME_EVENT:
                 continue
             self._apply_inbound(frame)
+
+    def _apply_ack(self, frame: bf.BusFrame) -> None:
+        """Advance the ack cursor monotonically. Zero-padded hex event ids
+        compare correctly as strings, so a plain ``<=`` comparison is the
+        regressive/duplicate guard -- no int parsing needed. Fail-soft: an
+        ``on_ack`` callback that raises must never take down the inbound
+        pump."""
+        new_id = frame.last_event_id
+        if not new_id:
+            return
+        current = self._last_acked_id
+        if current is not None and new_id <= current:
+            return  # regressive or duplicate -- ignored
+        self._last_acked_id = new_id
+        if self._on_ack is not None:
+            try:
+                self._on_ack(new_id)
+            except Exception:  # noqa: BLE001 -- fail-soft, never crash the pump
+                logger.debug("[BusBridgeClient] on_ack callback raised", exc_info=True)
 
     def _apply_inbound(self, frame: bf.BusFrame) -> None:
         ev_dict = frame.event or {}

--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -4,7 +4,8 @@ import asyncio
 import logging
 import random
 from collections import OrderedDict
-from typing import Callable, Optional
+from dataclasses import fields as dataclass_fields
+from typing import Any, Awaitable, Callable, Dict, Optional
 
 import aiohttp
 
@@ -13,6 +14,7 @@ from backend.core.ouroboros.governance.ide_observability_stream import (
     EVENT_TYPE_REPLAY_END,
     EVENT_TYPE_REPLAY_START,
     EVENT_TYPE_STREAM_LAG,
+    StreamEvent,
     StreamEventBroker,
 )
 from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
@@ -34,6 +36,32 @@ _DEDUP_MAX = 8192  # bounded seen-id memory (mirrors bus_bridge_server.py)
 # heartbeat frame kind rather than forwarded as a generic event.
 _CONTROL_EVENT_TYPES = frozenset({EVENT_TYPE_REPLAY_START, EVENT_TYPE_REPLAY_END, EVENT_TYPE_STREAM_LAG})
 
+# StreamEvent constructor surface, computed once. WAL envelopes are
+# StreamEvent.to_dict() outputs (whose keys match the dataclass fields
+# exactly today) -- the filter is defensive against a future to_dict()
+# gaining extra serialization-only keys.
+_STREAM_EVENT_FIELDS = frozenset(f.name for f in dataclass_fields(StreamEvent))
+
+
+def _rebuild_stream_event(envelope: Dict[str, Any]) -> Optional[StreamEvent]:
+    """Rebuild a StreamEvent from a journaled ``to_dict()`` envelope.
+
+    Extra keys are stripped defensively; a malformed envelope (missing
+    required fields, wrong types) returns None -- the caller skips it
+    (fail-soft per entry, Stage 3 Task 3)."""
+    try:
+        kwargs = {k: v for k, v in dict(envelope).items()
+                  if k in _STREAM_EVENT_FIELDS}
+        ev = StreamEvent(**kwargs)
+    except Exception:  # noqa: BLE001 -- malformed journal entry
+        logger.debug(
+            "[BusBridgeClient] malformed WAL envelope skipped: %r",
+            envelope, exc_info=True)
+        return None
+    if not ev.event_id or not ev.event_type:
+        return None
+    return ev
+
 
 class BusBridgeClient:
     """Connects to a BusBridgeServer, resumes via Last-Event-ID, and
@@ -49,6 +77,8 @@ class BusBridgeClient:
         session_factory: Optional[Callable[[], aiohttp.ClientSession]] = None,
         initial_last_sent_id: Optional[str] = None,
         on_ack: Optional[Callable[[str], None]] = None,
+        url_resolver: Optional[Callable[[], Awaitable[Optional[str]]]] = None,
+        durable: Optional[Any] = None,
     ) -> None:
         self._broker = broker
         self._cfg = cfg
@@ -70,6 +100,10 @@ class BusBridgeClient:
         # advances, so a stray regressive/duplicate ack (out-of-order
         # delivery, replay) cannot rewind a later trim decision.
         self._last_acked_id: Optional[str] = None
+        # Stage 3 Task 3: per-attempt discovery re-race + WAL-seeded replay.
+        # Both default None = Stage-2-identical behavior.
+        self._url_resolver = url_resolver
+        self._durable = durable
         self._high_water: int = 0
         self._degraded = False
         self._missed_hb = 0
@@ -157,11 +191,29 @@ class BusBridgeClient:
                 pass
         self._connected = False
 
+    async def _resolve_attempt_url(self) -> str:
+        """Per-attempt discovery re-race (Stage 3 Task 3): consult the
+        resolver on EVERY connect attempt -- a peer that came back on a
+        different address is found without restarting the client. A
+        resolver failure (or a None/empty answer) fails soft to the
+        static url; no resolver = legacy static behavior."""
+        if self._url_resolver is not None:
+            try:
+                resolved = await self._url_resolver()
+            except Exception:  # noqa: BLE001 -- discovery down != loop down
+                logger.debug(
+                    "[BusBridgeClient] url_resolver failed; falling back "
+                    "to static url", exc_info=True)
+                resolved = None
+            if resolved:
+                return resolved
+        return self._resolve_url()
+
     async def run(self) -> None:
         attempt = 0
         while not self._stopped:
             try:
-                await self._connect_once()
+                await self._connect_once(await self._resolve_attempt_url())
                 attempt = 0  # clean disconnect resets backoff
             except asyncio.CancelledError:
                 raise
@@ -173,7 +225,7 @@ class BusBridgeClient:
             attempt += 1
             await asyncio.sleep(delay)
 
-    async def _connect_once(self) -> None:
+    async def _connect_once(self, url: Optional[str] = None) -> None:
         ssl_ctx = build_client_ssl_context(self._cfg)
         session = (self._session_factory() if self._session_factory
                    else aiohttp.ClientSession())
@@ -185,13 +237,17 @@ class BusBridgeClient:
             connect_kwargs["server_hostname"] = self._cfg.tls_server_hostname
         try:
             async with session.ws_connect(
-                self._resolve_url(), ssl=ssl_ctx, heartbeat=None, **connect_kwargs,
+                url or self._resolve_url(), ssl=ssl_ctx, heartbeat=None, **connect_kwargs,
             ) as ws:
                 await ws.send_bytes(
                     bf.hello_frame(self._cfg.source_id, self._last_event_id).encode()
                 )
                 self._connected = True
                 self._active_ws = ws
+                # WAL-seeded replay FIRST (the oldest truth), then the live
+                # pump's broker-cursor replay -- overlap dedup is the
+                # SERVER's job (qualified-id _mark_seen).
+                await self._replay_durable(ws)
                 out_task = asyncio.ensure_future(self._pump_outbound(ws))
                 try:
                     await self._pump_inbound(ws)
@@ -205,6 +261,41 @@ class BusBridgeClient:
                         pass
         finally:
             await session.close()
+
+    async def _replay_durable(self, ws: aiohttp.ClientWebSocketResponse) -> None:
+        """WAL-seeded replay (Stage 3 Task 3): send every pending journal
+        entry (already id-ordered by ``durable.pending()``) BEFORE the live
+        outbound pump starts. The WAL outlives the broker's bounded history
+        ring, so this recovers spans the broker-cursor replay physically
+        cannot.
+
+        No trim on send -- trim is exclusively ack-driven (Task 1 ack lane
+        -> Task 2 ``on_ack``); an entry stays journaled until the server
+        confirms ingesting past it, so a mid-replay drop just resends on
+        the next attempt. Malformed entries are skipped per-entry
+        (fail-soft); a dead socket propagates to the reconnect loop."""
+        if self._durable is None:
+            return
+        try:
+            entries = self._durable.pending()
+        except Exception:  # noqa: BLE001 -- a broken WAL must not block connect
+            logger.debug(
+                "[BusBridgeClient] durable.pending() failed; skipping "
+                "WAL replay", exc_info=True)
+            return
+        if not entries:
+            return
+        sent = 0
+        for envelope in entries:
+            ev = _rebuild_stream_event(envelope)
+            if ev is None:
+                continue  # malformed journal entry -- skip, keep replaying
+            await ws.send_bytes(
+                bf.event_frame(ev, source_id=self._cfg.source_id).encode())
+            sent += 1
+        logger.debug(
+            "[BusBridgeClient] WAL replay: sent %d/%d pending entries",
+            sent, len(entries))
 
     async def _pump_outbound(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         """Subscribe to the local broker and stream events (with

--- a/backend/core/ouroboros/governance/transport/bus_bridge_server.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_server.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
+import time
 from collections import OrderedDict
 from typing import Callable, Optional
 
@@ -21,6 +23,27 @@ from backend.core.ouroboros.governance.transport import bus_frame as bf
 logger = logging.getLogger(__name__)
 
 _DEDUP_MAX = 8192  # bounded seen-id memory
+
+
+def _ack_every_n() -> int:
+    """Env-resolved ack cadence (event count). Read at call time, never
+    baked -- Stage 3 WAL trim tuning must not require a restart."""
+    raw = os.environ.get("JARVIS_BUS_ACK_EVERY_N", "")
+    try:
+        return int(raw.strip())
+    except (ValueError, AttributeError):
+        return 16
+
+
+def _ack_interval_s() -> float:
+    """Env-resolved ack cadence (wall-clock seconds). Whichever of this or
+    ``_ack_every_n`` trips first fires the ack."""
+    raw = os.environ.get("JARVIS_BUS_ACK_INTERVAL_S", "")
+    try:
+        return float(raw.strip())
+    except (ValueError, AttributeError):
+        return 5.0
+
 
 # Broker-internal bookkeeping event types. These are produced by
 # StreamEventBroker.subscribe()/stream_iter() for SSE-side replay
@@ -128,6 +151,13 @@ class BusBridgeServer:
         ws = web.WebSocketResponse(heartbeat=None)
         await ws.prepare(request)
         pump_task: Optional[asyncio.Task] = None
+        # Per-connection ingest cursor (Stage 3 Task 1): the id of the last
+        # EVENT frame ingested on THIS connection, plus the cadence state
+        # that decides when to ack it back to the peer. Reset implicitly on
+        # every new connection since these are locals, not instance state.
+        conn_last_eid: Optional[str] = None
+        ack_pending = 0
+        ack_deadline = time.monotonic() + _ack_interval_s()
         try:
             async for msg in ws:
                 if msg.type != WSMsgType.BINARY and msg.type != WSMsgType.TEXT:
@@ -143,9 +173,25 @@ class BusBridgeServer:
                     )
                 elif frame.kind == bf.FRAME_EVENT:
                     self._ingest(frame)
+                    event_id = (frame.event or {}).get("event_id")
+                    if event_id:
+                        conn_last_eid = event_id
+                        ack_pending += 1
+                        now = time.monotonic()
+                        if ack_pending >= _ack_every_n() or now >= ack_deadline:
+                            try:
+                                await ws.send_bytes(
+                                    bf.ack_frame(self._cfg.source_id, conn_last_eid).encode()
+                                )
+                            except Exception:  # noqa: BLE001 -- a failed ack send must never kill the WS loop
+                                logger.debug("[BusBridgeServer] ack send failed", exc_info=True)
+                            ack_pending = 0
+                            ack_deadline = now + _ack_interval_s()
                 elif frame.kind == bf.FRAME_HEARTBEAT:
                     await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
-                # FRAME_ACK is plumbed for Stage 3 WAL trim; no-op here.
+                # FRAME_ACK: the server only EMITS acks (above); it does not
+                # consume inbound acks from the peer in Stage 3 Task 1 -- a
+                # symmetric client->server ack lane is not part of this arc.
         finally:
             if pump_task is not None:
                 pump_task.cancel()

--- a/backend/core/ouroboros/governance/transport/distributed_event_bus.py
+++ b/backend/core/ouroboros/governance/transport/distributed_event_bus.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import logging
-from typing import Optional
+from typing import Any, Awaitable, Callable, Optional
 
 from aiohttp import web
 
@@ -19,12 +19,26 @@ class DistributedEventBus:
     across the socket. TrinityEventBus callers are unchanged -- they still
     publish/subscribe on the local broker."""
 
-    def __init__(self, broker: StreamEventBroker, cfg: TransportConfig, *, role: str) -> None:
+    def __init__(
+        self,
+        broker: StreamEventBroker,
+        cfg: TransportConfig,
+        *,
+        role: str,
+        durable_outbound: Optional[Any] = None,
+        url_resolver: Optional[Callable[[], Awaitable[Optional[str]]]] = None,
+    ) -> None:
         if role not in ("server", "client"):
             raise ValueError(f"role must be server|client, got {role!r}")
         self._broker = broker
         self._cfg = cfg
         self._role = role
+        # Stage 3 Task 3 passthroughs (client role). Defaults None =
+        # Stage-2-identical. The durable's on_ack is re-wired at EVERY
+        # client construction so acks keep trimming the WAL across
+        # client recreation (start_client builds a new instance per call).
+        self._durable_outbound = durable_outbound
+        self._url_resolver = url_resolver
         self._server: Optional[BusBridgeServer] = None
         self._client: Optional[BusBridgeClient] = None
         # Outbound last-sent cursor carried ACROSS client instances: stop() +
@@ -51,9 +65,16 @@ class DistributedEventBus:
     async def start_client(self, url: Optional[str] = None) -> None:
         if self._role != "client":
             raise RuntimeError("start_client requires role=client")
+        kwargs: dict = {}
+        if self._durable_outbound is not None:
+            kwargs["durable"] = self._durable_outbound
+            kwargs["on_ack"] = self._durable_outbound.on_ack
+        if self._url_resolver is not None:
+            kwargs["url_resolver"] = self._url_resolver
         self._client = BusBridgeClient(
             self._broker, self._cfg, url=url,
             initial_last_sent_id=self._last_sent_cursor,
+            **kwargs,
         )
         await self._client.run()
 

--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -25,7 +25,9 @@ Durability honesty (review round): an append that FAILS is NEVER
 reported as pending-durable. The event moves to an in-memory at-risk
 set -- surfaced via :attr:`DurableOutbound.journal_failures` plus one
 loud warning per episode -- and is re-attempted on every subsequent
-journal cycle until it lands (or the far side acks past it). Likewise
+journal cycle until it lands (a cumulative ack past it does NOT purge
+it: the ack cannot prove the gap was received; server dedup makes the
+resulting duplicate safe). Likewise
 a failed ack tombstone keeps its lease parked for retry on later
 flushes: redelivery after a crash is SAFE downstream (server dedup);
 a silent live-acked/disk-pending split-brain is not.
@@ -222,16 +224,21 @@ class DurableOutbound:
 
         Reflects acked-in-memory IMMEDIATELY: entries whose ack tombstone
         is still in flight to disk are already excluded.
+
+        Iterates a SNAPSHOT of the pending dict (Task-3 carry-forward):
+        the ack flush pops entries from an offload THREAD, and iterating
+        the live dict here races that mutation (RuntimeError: dict
+        changed size during iteration).
         """
         self._ensure_loaded()
-        live = [(lid, entry) for lid, entry in self._pending.items()
+        live = [(lid, entry) for lid, entry in list(self._pending.items())
                 if lid not in self._ack_inflight]
         live.sort(key=lambda pair: pair[0])
         return [dict(entry.envelope_dict) for _, entry in live]
 
     def pending_count(self) -> int:
         self._ensure_loaded()
-        return sum(1 for lid in self._pending
+        return sum(1 for lid in list(self._pending)
                    if lid not in self._ack_inflight)
 
     @property
@@ -261,11 +268,16 @@ class DurableOutbound:
                 return
             if self._ack_cursor is None or acked_event_id > self._ack_cursor:
                 self._ack_cursor = acked_event_id
-            # An acked at-risk event no longer needs journaling at all.
-            for lid in [l for l in self._at_risk if l <= acked_event_id]:
-                self._at_risk.pop(lid, None)
+            # Task-3 carry-forward (re-review): at-risk entries are NOT
+            # purged by the ack cursor. The server acks its last-ingested
+            # id -- a cumulative ack for Y cannot prove it ever RECEIVED
+            # an earlier gap X (X may be exactly what the failed append
+            # lost). Retention costs only a duplicate send, which the
+            # server's qualified-id dedup absorbs; a purge here loses X
+            # forever if the process dies before it lands in the WAL.
+            # _retry_at_risk keeps re-attempting until the append lands.
             ids = sorted(
-                lid for lid in self._pending
+                lid for lid in list(self._pending)
                 if lid <= acked_event_id and lid not in self._ack_inflight)
             if not ids and not self._ack_retry:
                 return
@@ -344,10 +356,11 @@ class DurableOutbound:
             entry = self._at_risk.get(event_id)
             if entry is None:
                 continue
-            if self._ack_cursor is not None and event_id <= self._ack_cursor:
-                # The far side acked past it -- journaling is moot.
-                self._at_risk.pop(event_id, None)
-                continue
+            # Task-3 carry-forward: no ack-cursor short-circuit here -- a
+            # cumulative ack past this id does not prove the far side
+            # received it (see on_ack). Retry until the append LANDS; the
+            # journaled entry then rides pending()/WAL replay, and server
+            # dedup makes any duplicate delivery safe.
             result = await offload(self._wal.append, entry)
             if is_offload_error(result):
                 continue  # still failing -- next cycle retries again
@@ -405,7 +418,7 @@ class DurableOutbound:
                 "cleared")
 
     def _drop_oldest_pending(self) -> None:
-        live = sorted(lid for lid in self._pending
+        live = sorted(lid for lid in list(self._pending)
                       if lid not in self._ack_inflight)
         if not live:
             return

--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -151,6 +151,10 @@ class DurableOutbound:
         # dedup and duplicates events. A filter that RAISES fails open
         # (journal anyway): durability bias over filtering precision.
         self._journal_filter = journal_filter
+        # Review round: fail-open must not be SILENT -- one warning per
+        # failure episode (the file's established warn-once pattern),
+        # reset when the filter evaluates cleanly again.
+        self._filter_fail_warned = False
         self._wal_path = Path(wal_path) if wal_path else _default_wal_path()
         self._wal = WAL(
             self._wal_path,
@@ -325,8 +329,21 @@ class DurableOutbound:
         if self._journal_filter is not None:
             try:
                 keep = bool(self._journal_filter(event))
-            except Exception:  # noqa: BLE001 -- fail OPEN: durability bias
+            except Exception as exc:  # noqa: BLE001 -- fail OPEN: durability bias
                 keep = True
+                if not self._filter_fail_warned:
+                    self._filter_fail_warned = True
+                    logger.warning(
+                        "[DurableOutbound] journal_filter raising -- "
+                        "peer-exclusion degraded to fail-open (journaling "
+                        "everything; duplicates absorbed by server dedup): "
+                        "%s", exc)
+            else:
+                if self._filter_fail_warned:
+                    self._filter_fail_warned = False
+                    logger.info(
+                        "[DurableOutbound] journal_filter recovered -- "
+                        "peer-exclusion back in force")
             if not keep:
                 return
         if (event_id in self._pending or event_id in self._ack_inflight

--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -2,11 +2,11 @@
 """DurableOutbound -- Stage-3 Task 2: the Body-side durable outbound WAL.
 
 Journals every bridgeable StreamEventBroker event (op_id matching
-``op_prefix``, default ``trinity:``) into an fsync'd write-ahead log AT
-PUBLISH TIME -- upstream of any connection state. A network partition or
-a Body crash can therefore never lose a signal that ``publish()``
-accepted: the WAL is the durable truth, the broker's bounded history
-ring (512 default) is merely a hot cache.
+``op_prefix``, default ``trinity:``) into a flock-journaled write-ahead
+log AT PUBLISH TIME -- upstream of any connection state. A network
+partition or a Body crash can therefore never lose a signal that
+``publish()`` accepted: the WAL is the durable truth, the broker's
+bounded history ring (512 default) is merely a hot cache.
 
 Trim is ack-driven: Task 1 armed the ack lane (``BusBridgeClient``'s
 ``on_ack`` constructor kwarg); wiring that callback to
@@ -16,18 +16,30 @@ plain string comparison is correct) and compacts the file every
 ``JARVIS_BODY_WAL_COMPACT_EVERY_N`` acks.
 
 Durability heavy-lifting is the intake WAL, reused verbatim (operator
-DRY mandate): flock+fsync per line, tombstone-applied crash recovery,
-atomic tmp+fsync+replace compaction.
+DRY mandate): flock-serialized append per line (fsync happens on
+compaction and on the no-flock fallback path -- the hot path is
+flock+flush), tombstone-applied crash recovery, atomic
+tmp+fsync+replace compaction.
+
+Durability honesty (review round): an append that FAILS is NEVER
+reported as pending-durable. The event moves to an in-memory at-risk
+set -- surfaced via :attr:`DurableOutbound.journal_failures` plus one
+loud warning per episode -- and is re-attempted on every subsequent
+journal cycle until it lands (or the far side acks past it). Likewise
+a failed ack tombstone keeps its lease parked for retry on later
+flushes: redelivery after a crash is SAFE downstream (server dedup);
+a silent live-acked/disk-pending split-brain is not.
 
 Capacity is DYNAMIC -- no hardcoded byte caps anywhere. The WAL file may
 occupy at most ``JARVIS_BODY_WAL_DISK_FRACTION`` (default 0.05) of the
 CURRENT free bytes on the WAL's filesystem, probed off-loop through the
 cooperative_fs_io offload substrate and cached for
 ``JARVIS_BODY_WAL_PROBE_INTERVAL_S`` between appends. Over budget ->
-compact first; still over -> ``degraded_capacity`` episode: drop the
-OLDEST pending entry (dead_letter tombstone) per append with exactly ONE
-``logger.warning`` per episode (mirroring the broker's ``stream_lag``
-single-signal pattern). Never raises, never blocks the event loop.
+compact ONCE at episode onset; still over -> ``degraded_capacity``
+episode: drop the OLDEST pending entry (dead_letter tombstone) per
+append with exactly ONE ``logger.warning`` per episode (mirroring the
+broker's ``stream_lag`` single-signal pattern). Never raises, never
+blocks the event loop.
 
 Env knobs:
     JARVIS_BODY_WAL_PATH             (default <repo>/.jarvis/body_outbound_wal.jsonl)
@@ -142,6 +154,16 @@ class DurableOutbound:
         self._degraded = False
         self._loaded = False
         self._probe_cache: Optional[Tuple[float, Optional[int], int]] = None
+        # Review CRITICAL: events whose WAL append FAILED -- accepted but
+        # NOT durable. Never counted as pending; retried each journal
+        # cycle until they land or the ack cursor passes them.
+        self._at_risk: Dict[str, WALEntry] = {}
+        self._journal_fail_warned = False
+        # Review IMPORTANT-1: leases whose ack tombstone write FAILED --
+        # kept in _ack_inflight (so pending() stays trimmed) and retried
+        # on every later flush until the tombstone lands.
+        self._ack_retry: Set[str] = set()
+        self._ack_fail_warned = False
 
         self._sub: Any = None
         self._consumer_task: Optional[asyncio.Task] = None
@@ -216,6 +238,13 @@ class DurableOutbound:
     def degraded_capacity(self) -> bool:
         return self._degraded
 
+    @property
+    def journal_failures(self) -> int:
+        """Count of accepted events currently at risk (memory-only --
+        their WAL append failed and has not yet been retried to
+        success). Zero means every accepted publish is on disk."""
+        return len(self._at_risk)
+
     # --- ack lane (Task-1 hook target) ---------------------------------------
 
     def on_ack(self, acked_event_id: str) -> None:
@@ -232,10 +261,13 @@ class DurableOutbound:
                 return
             if self._ack_cursor is None or acked_event_id > self._ack_cursor:
                 self._ack_cursor = acked_event_id
+            # An acked at-risk event no longer needs journaling at all.
+            for lid in [l for l in self._at_risk if l <= acked_event_id]:
+                self._at_risk.pop(lid, None)
             ids = sorted(
                 lid for lid in self._pending
                 if lid <= acked_event_id and lid not in self._ack_inflight)
-            if not ids:
+            if not ids and not self._ack_retry:
                 return
             self._ack_inflight.update(ids)
             self._fire_and_forget(self._flush_acks_sync, ids)
@@ -265,11 +297,15 @@ class DurableOutbound:
         # non-hex ids -- only real 012x-hex publishes are journaled.
         if not event_id or not set(event_id) <= _HEX_DIGITS:
             return
-        if event_id in self._pending or event_id in self._ack_inflight:
+        if (event_id in self._pending or event_id in self._ack_inflight
+                or event_id in self._at_risk):
             return
         if self._ack_cursor is not None and event_id <= self._ack_cursor:
             return  # the far side already acked past this id
         await self._enforce_capacity()
+        # Bounded at-risk retry: each journal cycle re-attempts every
+        # previously-failed append exactly once (review CRITICAL).
+        await self._retry_at_risk()
         entry = WALEntry(
             lease_id=event_id,
             envelope_dict=event.to_dict(),
@@ -279,12 +315,49 @@ class DurableOutbound:
         )
         result = await offload(self._wal.append, entry)
         if is_offload_error(result):
-            logger.debug(
-                "[DurableOutbound] WAL append failed (kept in memory): %s",
-                result)
-        # In-memory view tracks the accepted publish regardless -- the WAL
-        # append path itself never raises, so this is belt-and-braces.
+            # Durability honesty (review CRITICAL): the append did NOT
+            # land -- the event must NOT masquerade as pending-durable.
+            # Park it at-risk (memory-only), surface loudly ONCE per
+            # episode, retry on subsequent journal cycles.
+            self._at_risk[event_id] = entry
+            if not self._journal_fail_warned:
+                self._journal_fail_warned = True
+                logger.warning(
+                    "[DurableOutbound] journal append FAILED -- %d event(s) "
+                    "at risk (memory-only, NOT durable; will retry on "
+                    "subsequent journal cycles): %s",
+                    len(self._at_risk), result)
+            return
         self._pending[event_id] = entry
+
+    async def _retry_at_risk(self) -> None:
+        """Re-attempt every at-risk append once. Clears the failure
+        episode (and says so) when the at-risk set drains."""
+        if not self._at_risk:
+            if self._journal_fail_warned:
+                self._journal_fail_warned = False
+                logger.info(
+                    "[DurableOutbound] journal append recovered -- no "
+                    "events remain at risk")
+            return
+        for event_id in sorted(self._at_risk):
+            entry = self._at_risk.get(event_id)
+            if entry is None:
+                continue
+            if self._ack_cursor is not None and event_id <= self._ack_cursor:
+                # The far side acked past it -- journaling is moot.
+                self._at_risk.pop(event_id, None)
+                continue
+            result = await offload(self._wal.append, entry)
+            if is_offload_error(result):
+                continue  # still failing -- next cycle retries again
+            self._at_risk.pop(event_id, None)
+            self._pending[event_id] = entry
+        if not self._at_risk and self._journal_fail_warned:
+            self._journal_fail_warned = False
+            logger.info(
+                "[DurableOutbound] journal append recovered -- all at-risk "
+                "events landed durably")
 
     # --- internal: dynamic capacity ------------------------------------------
 
@@ -297,17 +370,20 @@ class DurableOutbound:
             if size <= self._disk_fraction * free:
                 self._clear_degraded()
                 return
-            # Over budget: compact first (drops aged terminal entries).
-            result = await offload(self._wal.compact)
-            if is_offload_error(result):
-                logger.debug(
-                    "[DurableOutbound] capacity compact failed: %s", result)
-            free, size = await self._probe(force=True)
-            if free is None or size <= self._disk_fraction * free:
-                self._clear_degraded()
-                return
-            # STILL over: degraded episode -- one warning, drop oldest.
             if not self._degraded:
+                # Episode ONSET only (review IMPORTANT-2): compact once
+                # (drops aged terminal entries), re-probe; only if STILL
+                # over does the degraded episode begin. While degraded,
+                # subsequent over-budget appends drop-oldest WITHOUT
+                # re-running a full compaction each time.
+                result = await offload(self._wal.compact)
+                if is_offload_error(result):
+                    logger.debug(
+                        "[DurableOutbound] capacity compact failed: %s",
+                        result)
+                free, size = await self._probe(force=True)
+                if free is None or size <= self._disk_fraction * free:
+                    return  # compact bought back the budget -- no episode
                 self._degraded = True
                 logger.warning(
                     "[DurableOutbound] degraded_capacity: wal_size=%d over "
@@ -356,10 +432,29 @@ class DurableOutbound:
     # --- internal: recovery + offload plumbing --------------------------------
 
     def _ensure_loaded(self) -> None:
-        """One-time lazy recovery read for never-started instances."""
+        """One-time lazy recovery read for never-started instances.
+
+        GUARD (review Minor-b): this is a SYNCHRONOUS disk read. It is
+        intended ONLY for never-started instances queried from sync
+        contexts (crash-recovery / replay callers); started instances
+        recover through the offloaded read in :meth:`start`. If a
+        running event loop is detected we still proceed -- it is a
+        one-time bounded read and pending()/pending_count() are sync
+        APIs -- but we flag the architectural-purity violation loudly
+        so the caller can switch to ``await start()`` first.
+        """
         if self._loaded:
             return
         self._loaded = True
+        try:
+            asyncio.get_running_loop()
+        except RuntimeError:
+            pass  # no loop -- the intended sync-context caller
+        else:
+            logger.warning(
+                "[DurableOutbound] _ensure_loaded performing a sync WAL "
+                "read ON a running event loop -- call 'await start()' "
+                "before pending()/pending_count() to keep the loop clean")
         try:
             for entry in self._wal.pending_entries():
                 self._pending.setdefault(entry.lease_id, entry)
@@ -368,20 +463,47 @@ class DurableOutbound:
                 "[DurableOutbound] lazy WAL recovery failed", exc_info=True)
 
     def _flush_acks_sync(self, ids: List[str]) -> None:
-        """Tombstone acked ids + cadence compaction. Runs OFF the event
-        loop (offload thread) or inline in the no-loop fallback -- the
-        WAL substrate is flock-safe either way."""
-        for lease_id in ids:
+        """Tombstone acked ids (plus any leases parked for retry) +
+        cadence compaction. Runs OFF the event loop (offload thread) or
+        inline in the no-loop fallback -- the WAL substrate is
+        flock-safe either way.
+
+        Review IMPORTANT-1: a tombstone write that fails must NOT be
+        forgotten (that would leave live-says-acked / disk-says-pending
+        split-brain silently). The lease stays in ``_ack_inflight`` (so
+        pending() remains trimmed) and is parked in ``_ack_retry`` for
+        the next flush; ONE distinguishing warning per episode.
+        Redelivery after a crash is SAFE downstream (server dedup)."""
+        to_flush = list(dict.fromkeys(list(ids) + sorted(self._ack_retry)))
+        landed = 0
+        failed = False
+        for lease_id in to_flush:
             try:
                 self._wal.update_status(lease_id, "acked")
-            except Exception:  # noqa: BLE001
+            except Exception:  # noqa: BLE001 -- park for retry
+                failed = True
+                self._ack_retry.add(lease_id)
                 logger.debug(
-                    "[DurableOutbound] ack tombstone failed lease=%s",
-                    lease_id, exc_info=True)
+                    "[DurableOutbound] ack tombstone failed lease=%s "
+                    "(parked for retry)", lease_id, exc_info=True)
+                continue
+            self._ack_retry.discard(lease_id)
             self._pending.pop(lease_id, None)
             self._ack_inflight.discard(lease_id)
-        self._acks_since_compact += len(ids)
-        if self._acks_since_compact >= self._compact_every_n:
+            landed += 1
+        if failed and not self._ack_fail_warned:
+            self._ack_fail_warned = True
+            logger.warning(
+                "[DurableOutbound] ack tombstone write failing -- "
+                "redelivery possible after crash (%d lease(s) parked "
+                "for retry)", len(self._ack_retry))
+        if not self._ack_retry and self._ack_fail_warned:
+            self._ack_fail_warned = False
+            logger.info(
+                "[DurableOutbound] ack tombstone writes recovered -- "
+                "retry park drained")
+        self._acks_since_compact += landed
+        if landed and self._acks_since_compact >= self._compact_every_n:
             self._acks_since_compact = 0
             try:
                 self._wal.compact()

--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -2,8 +2,11 @@
 """DurableOutbound -- Stage-3 Task 2: the Body-side durable outbound WAL.
 
 Journals every bridgeable StreamEventBroker event (op_id matching
-``op_prefix``, default ``trinity:``) into a flock-journaled write-ahead
-log AT PUBLISH TIME -- upstream of any connection state. A network
+``op_prefix``, default ``trinity:``; optionally narrowed further by the
+``journal_filter`` predicate -- the Body driver uses it to exclude
+peer-republished events whose client-local ids the server never issued)
+into a flock-journaled write-ahead log AT PUBLISH TIME -- upstream of
+any connection state. A network
 partition or a Body crash can therefore never lose a signal that
 ``publish()`` accepted: the WAL is the durable truth, the broker's
 bounded history ring (512 default) is merely a hot cache.
@@ -135,9 +138,19 @@ class DurableOutbound:
         *,
         wal_path: Optional[str] = None,
         op_prefix: str = "trinity:",
+        journal_filter: Optional[Callable[[Any], bool]] = None,
     ) -> None:
         self._broker = broker
         self._op_prefix = op_prefix
+        # Task-4 (Task-3 review carry-in): optional publish-side filter.
+        # When provided, only events where journal_filter(event) is True
+        # are journaled. The driver's live default excludes PEER-
+        # republished events (payload origin != local source_id): those
+        # carry client-local event ids the server has never seen --
+        # replaying them at reconnect defeats the server's qualified-id
+        # dedup and duplicates events. A filter that RAISES fails open
+        # (journal anyway): durability bias over filtering precision.
+        self._journal_filter = journal_filter
         self._wal_path = Path(wal_path) if wal_path else _default_wal_path()
         self._wal = WAL(
             self._wal_path,
@@ -309,6 +322,13 @@ class DurableOutbound:
         # non-hex ids -- only real 012x-hex publishes are journaled.
         if not event_id or not set(event_id) <= _HEX_DIGITS:
             return
+        if self._journal_filter is not None:
+            try:
+                keep = bool(self._journal_filter(event))
+            except Exception:  # noqa: BLE001 -- fail OPEN: durability bias
+                keep = True
+            if not keep:
+                return
         if (event_id in self._pending or event_id in self._ack_inflight
                 or event_id in self._at_risk):
             return

--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -1,0 +1,414 @@
+# -*- coding: utf-8 -*-
+"""DurableOutbound -- Stage-3 Task 2: the Body-side durable outbound WAL.
+
+Journals every bridgeable StreamEventBroker event (op_id matching
+``op_prefix``, default ``trinity:``) into an fsync'd write-ahead log AT
+PUBLISH TIME -- upstream of any connection state. A network partition or
+a Body crash can therefore never lose a signal that ``publish()``
+accepted: the WAL is the durable truth, the broker's bounded history
+ring (512 default) is merely a hot cache.
+
+Trim is ack-driven: Task 1 armed the ack lane (``BusBridgeClient``'s
+``on_ack`` constructor kwarg); wiring that callback to
+:meth:`DurableOutbound.on_ack` tombstones every journaled entry with
+``lease_id <= acked_event_id`` (event ids are zero-padded 012x hex, so
+plain string comparison is correct) and compacts the file every
+``JARVIS_BODY_WAL_COMPACT_EVERY_N`` acks.
+
+Durability heavy-lifting is the intake WAL, reused verbatim (operator
+DRY mandate): flock+fsync per line, tombstone-applied crash recovery,
+atomic tmp+fsync+replace compaction.
+
+Capacity is DYNAMIC -- no hardcoded byte caps anywhere. The WAL file may
+occupy at most ``JARVIS_BODY_WAL_DISK_FRACTION`` (default 0.05) of the
+CURRENT free bytes on the WAL's filesystem, probed off-loop through the
+cooperative_fs_io offload substrate and cached for
+``JARVIS_BODY_WAL_PROBE_INTERVAL_S`` between appends. Over budget ->
+compact first; still over -> ``degraded_capacity`` episode: drop the
+OLDEST pending entry (dead_letter tombstone) per append with exactly ONE
+``logger.warning`` per episode (mirroring the broker's ``stream_lag``
+single-signal pattern). Never raises, never blocks the event loop.
+
+Env knobs:
+    JARVIS_BODY_WAL_PATH             (default <repo>/.jarvis/body_outbound_wal.jsonl)
+    JARVIS_BODY_WAL_DISK_FRACTION    (default 0.05 -- the ONLY capacity knob)
+    JARVIS_BODY_WAL_MAX_AGE_DAYS     (default 7, passed to WAL)
+    JARVIS_BODY_WAL_COMPACT_EVERY_N  (default 256)
+    JARVIS_BODY_WAL_PROBE_INTERVAL_S (default 5.0)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import shutil
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+from backend.core.ouroboros.governance.cooperative_fs_io import (
+    is_offload_error,
+    offload,
+)
+from backend.core.ouroboros.governance.intake.wal import WAL, WALEntry
+
+logger = logging.getLogger(__name__)
+
+_HEX_DIGITS = frozenset("0123456789abcdef")
+
+
+def _repo_root() -> Path:
+    # .../backend/core/ouroboros/governance/transport/durable_outbound.py
+    # parents: [0]=transport [1]=governance [2]=ouroboros [3]=core
+    #          [4]=backend   [5]=<repo root>
+    return Path(__file__).resolve().parents[5]
+
+
+def _default_wal_path() -> Path:
+    raw = os.environ.get("JARVIS_BODY_WAL_PATH", "").strip()
+    if raw:
+        return Path(raw).expanduser()
+    return _repo_root() / ".jarvis" / "body_outbound_wal.jsonl"
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _probe_disk(wal_path_str: str) -> Tuple[Optional[int], int]:
+    """Sync probe worker -- ALWAYS dispatched off-loop via ``offload``.
+
+    Returns ``(free_bytes_or_None, wal_file_size)``. ``None`` free means
+    the probe itself failed -- capacity enforcement then fails OPEN
+    (journal everything) rather than dropping signals on a broken probe.
+    """
+    try:
+        parent = os.path.dirname(wal_path_str) or "."
+        free: Optional[int] = shutil.disk_usage(parent).free
+    except OSError:
+        free = None
+    try:
+        size = os.stat(wal_path_str).st_size
+    except OSError:
+        size = 0
+    return free, size
+
+
+class DurableOutbound:
+    """Durable journal for outbound bridgeable events + ack-driven trim.
+
+    Lifecycle: construct -> ``await start()`` (recovers pending set from
+    disk, subscribes the broker, arms the journaling consumer) ->
+    ``await stop()``. A NEVER-started instance still serves
+    :meth:`pending` / :meth:`pending_count` from disk (crash recovery /
+    replay callers).
+    """
+
+    def __init__(
+        self,
+        broker: Any,
+        *,
+        wal_path: Optional[str] = None,
+        op_prefix: str = "trinity:",
+    ) -> None:
+        self._broker = broker
+        self._op_prefix = op_prefix
+        self._wal_path = Path(wal_path) if wal_path else _default_wal_path()
+        self._wal = WAL(
+            self._wal_path,
+            max_age_days=_env_int("JARVIS_BODY_WAL_MAX_AGE_DAYS", 7),
+        )
+        self._disk_fraction = _env_float("JARVIS_BODY_WAL_DISK_FRACTION", 0.05)
+        self._probe_interval_s = _env_float(
+            "JARVIS_BODY_WAL_PROBE_INTERVAL_S", 5.0)
+        self._compact_every_n = max(
+            1, _env_int("JARVIS_BODY_WAL_COMPACT_EVERY_N", 256))
+
+        self._pending: Dict[str, WALEntry] = {}
+        self._ack_inflight: Set[str] = set()
+        self._ack_cursor: Optional[str] = None
+        self._acks_since_compact = 0
+        self._degraded = False
+        self._loaded = False
+        self._probe_cache: Optional[Tuple[float, Optional[int], int]] = None
+
+        self._sub: Any = None
+        self._consumer_task: Optional[asyncio.Task] = None
+        self._bg_tasks: Set[asyncio.Task] = set()
+
+    # --- lifecycle ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Arm the durable subscriber. Idempotent."""
+        if self._consumer_task is not None:
+            return
+        # Subscribe FIRST so events published during disk recovery queue up
+        # (fresh event ids can never collide with recovered ones).
+        self._sub = self._broker.subscribe()
+        if self._sub is None:
+            raise RuntimeError(
+                "DurableOutbound: broker subscriber cap exceeded")
+        if not self._loaded:
+            entries = await offload(self._wal.pending_entries)
+            if is_offload_error(entries):
+                logger.debug(
+                    "[DurableOutbound] WAL recovery read failed: %s", entries)
+            else:
+                for entry in entries:
+                    self._pending.setdefault(entry.lease_id, entry)
+            self._loaded = True
+        self._consumer_task = asyncio.ensure_future(self._consume())
+
+    async def stop(self) -> None:
+        """Disarm the consumer and drain in-flight WAL work. Idempotent."""
+        if self._consumer_task is not None:
+            self._consumer_task.cancel()
+            try:
+                await self._consumer_task
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001 -- fail-soft teardown
+                logger.debug(
+                    "[DurableOutbound] consumer teardown error", exc_info=True)
+            self._consumer_task = None
+        if self._sub is not None:
+            try:
+                self._broker.unsubscribe(self._sub)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[DurableOutbound] broker unsubscribe failed",
+                    exc_info=True)
+            self._sub = None
+        if self._bg_tasks:
+            await asyncio.gather(*list(self._bg_tasks), return_exceptions=True)
+
+    # --- public read surface -------------------------------------------------
+
+    def pending(self) -> List[Dict[str, Any]]:
+        """Pending envelopes ordered by event_id (monotonic hex).
+
+        Reflects acked-in-memory IMMEDIATELY: entries whose ack tombstone
+        is still in flight to disk are already excluded.
+        """
+        self._ensure_loaded()
+        live = [(lid, entry) for lid, entry in self._pending.items()
+                if lid not in self._ack_inflight]
+        live.sort(key=lambda pair: pair[0])
+        return [dict(entry.envelope_dict) for _, entry in live]
+
+    def pending_count(self) -> int:
+        self._ensure_loaded()
+        return sum(1 for lid in self._pending
+                   if lid not in self._ack_inflight)
+
+    @property
+    def degraded_capacity(self) -> bool:
+        return self._degraded
+
+    # --- ack lane (Task-1 hook target) ---------------------------------------
+
+    def on_ack(self, acked_event_id: str) -> None:
+        """Cumulative-cursor trim. Cheap + non-blocking -- safe to call
+        straight from BusBridgeClient's inbound loop.
+
+        Marks every pending entry with ``lease_id <= acked_event_id``
+        acked in memory immediately, then fires the disk tombstone work
+        through the offload substrate (fail-soft, fire-and-forget).
+        Never raises.
+        """
+        try:
+            if not acked_event_id:
+                return
+            if self._ack_cursor is None or acked_event_id > self._ack_cursor:
+                self._ack_cursor = acked_event_id
+            ids = sorted(
+                lid for lid in self._pending
+                if lid <= acked_event_id and lid not in self._ack_inflight)
+            if not ids:
+                return
+            self._ack_inflight.update(ids)
+            self._fire_and_forget(self._flush_acks_sync, ids)
+        except Exception:  # noqa: BLE001 -- must never take down the caller
+            logger.debug("[DurableOutbound] on_ack failed", exc_info=True)
+
+    # --- internal: journaling consumer ---------------------------------------
+
+    async def _consume(self) -> None:
+        while True:
+            event = await self._sub.queue.get()
+            try:
+                await self._journal_event(event)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 -- never kill the journal loop
+                logger.debug(
+                    "[DurableOutbound] journal failed for event",
+                    exc_info=True)
+
+    async def _journal_event(self, event: Any) -> None:
+        op_id = getattr(event, "op_id", "") or ""
+        if not op_id.startswith(self._op_prefix):
+            return
+        event_id = getattr(event, "event_id", "") or ""
+        # Control frames (heartbeat "hb:", "replay:", "<id>:lag") carry
+        # non-hex ids -- only real 012x-hex publishes are journaled.
+        if not event_id or not set(event_id) <= _HEX_DIGITS:
+            return
+        if event_id in self._pending or event_id in self._ack_inflight:
+            return
+        if self._ack_cursor is not None and event_id <= self._ack_cursor:
+            return  # the far side already acked past this id
+        await self._enforce_capacity()
+        entry = WALEntry(
+            lease_id=event_id,
+            envelope_dict=event.to_dict(),
+            status="pending",
+            ts_monotonic=time.monotonic(),
+            ts_utc=datetime.now(timezone.utc).isoformat(),
+        )
+        result = await offload(self._wal.append, entry)
+        if is_offload_error(result):
+            logger.debug(
+                "[DurableOutbound] WAL append failed (kept in memory): %s",
+                result)
+        # In-memory view tracks the accepted publish regardless -- the WAL
+        # append path itself never raises, so this is belt-and-braces.
+        self._pending[event_id] = entry
+
+    # --- internal: dynamic capacity ------------------------------------------
+
+    async def _enforce_capacity(self) -> None:
+        """Disk-fraction budget check, entirely off-loop, never raises."""
+        try:
+            free, size = await self._probe(force=False)
+            if free is None:
+                return  # probe broken -> fail OPEN, keep journaling
+            if size <= self._disk_fraction * free:
+                self._clear_degraded()
+                return
+            # Over budget: compact first (drops aged terminal entries).
+            result = await offload(self._wal.compact)
+            if is_offload_error(result):
+                logger.debug(
+                    "[DurableOutbound] capacity compact failed: %s", result)
+            free, size = await self._probe(force=True)
+            if free is None or size <= self._disk_fraction * free:
+                self._clear_degraded()
+                return
+            # STILL over: degraded episode -- one warning, drop oldest.
+            if not self._degraded:
+                self._degraded = True
+                logger.warning(
+                    "[DurableOutbound] degraded_capacity: wal_size=%d over "
+                    "budget=%d (fraction=%s of free=%d) -- dropping oldest "
+                    "pending per append until capacity clears",
+                    size, int(self._disk_fraction * free),
+                    self._disk_fraction, free)
+            self._drop_oldest_pending()
+        except Exception:  # noqa: BLE001 -- capacity must never break journal
+            logger.debug(
+                "[DurableOutbound] capacity enforcement failed",
+                exc_info=True)
+
+    def _clear_degraded(self) -> None:
+        if self._degraded:
+            self._degraded = False
+            logger.info(
+                "[DurableOutbound] capacity recovered -- degraded episode "
+                "cleared")
+
+    def _drop_oldest_pending(self) -> None:
+        live = sorted(lid for lid in self._pending
+                      if lid not in self._ack_inflight)
+        if not live:
+            return
+        oldest = live[0]
+        self._pending.pop(oldest, None)
+        self._fire_and_forget(self._wal.update_status, oldest, "dead_letter")
+
+    async def _probe(
+        self, force: bool,
+    ) -> Tuple[Optional[int], int]:
+        """Cached off-loop disk probe (free bytes + WAL file size)."""
+        now = time.monotonic()
+        if (not force and self._probe_cache is not None
+                and (now - self._probe_cache[0]) < self._probe_interval_s):
+            return self._probe_cache[1], self._probe_cache[2]
+        result = await offload(_probe_disk, str(self._wal_path))
+        if is_offload_error(result):
+            logger.debug("[DurableOutbound] disk probe failed: %s", result)
+            return None, 0
+        free, size = result
+        self._probe_cache = (time.monotonic(), free, size)
+        return free, size
+
+    # --- internal: recovery + offload plumbing --------------------------------
+
+    def _ensure_loaded(self) -> None:
+        """One-time lazy recovery read for never-started instances."""
+        if self._loaded:
+            return
+        self._loaded = True
+        try:
+            for entry in self._wal.pending_entries():
+                self._pending.setdefault(entry.lease_id, entry)
+        except Exception:  # noqa: BLE001 -- fail-soft
+            logger.debug(
+                "[DurableOutbound] lazy WAL recovery failed", exc_info=True)
+
+    def _flush_acks_sync(self, ids: List[str]) -> None:
+        """Tombstone acked ids + cadence compaction. Runs OFF the event
+        loop (offload thread) or inline in the no-loop fallback -- the
+        WAL substrate is flock-safe either way."""
+        for lease_id in ids:
+            try:
+                self._wal.update_status(lease_id, "acked")
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[DurableOutbound] ack tombstone failed lease=%s",
+                    lease_id, exc_info=True)
+            self._pending.pop(lease_id, None)
+            self._ack_inflight.discard(lease_id)
+        self._acks_since_compact += len(ids)
+        if self._acks_since_compact >= self._compact_every_n:
+            self._acks_since_compact = 0
+            try:
+                self._wal.compact()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[DurableOutbound] cadence compact failed", exc_info=True)
+
+    def _fire_and_forget(self, fn: Callable[..., Any], *args: Any) -> None:
+        """Schedule sync WAL work through the offload substrate as a
+        tracked fire-and-forget task; inline fail-soft fallback when no
+        loop is running (pure-sync callers/tests)."""
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                fn(*args)
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[DurableOutbound] inline WAL op failed", exc_info=True)
+            return
+
+        async def _run() -> None:
+            result = await offload(fn, *args)
+            if is_offload_error(result):
+                logger.debug(
+                    "[DurableOutbound] offloaded WAL op failed: %s", result)
+
+        task = loop.create_task(_run())
+        self._bg_tasks.add(task)
+        task.add_done_callback(self._bg_tasks.discard)

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -13,21 +13,38 @@ scripts/ignite_brain_vm.py); the live defaults are resolved lazily inside
 ``run()`` so the unit tests (tests/infra/test_run_body_mode.py) stay pure-logic
 with zero sockets.
 
+Stage-3 Task 4 -- durable degrade: the live default arms a ``DurableOutbound``
+WAL on the broker (journal-at-publish; peer-republished events excluded via
+``journal_filter``) and threads it plus ``url_resolver=discover_brain_endpoint``
+into the ``DistributedEventBus`` client, so a partition never loses a signal
+and reconnect re-races discovery per attempt. With the WAL armed, discovery
+failure at start NO LONGER exits 2 -- the driver degrades: signals journal
+durably, the client re-races forever with backoff, and the census surfaces
+``connected=False queued=N``. ``--require-brain`` restores the strict Stage-2
+exit-2 / exit-3 contract (acceptance runs). The "Brain offline" /
+"Brain reconnected" lines are DETERMINISTIC edge transitions derived ONLY from
+the bus client's ``connected`` property (set/cleared exactly at WS
+establishment/teardown -- the transport closure), polled once per census tick.
+No exception-driven state, no heartbeat-timeout heuristics (operator mandate).
+
 Exit codes:
     0  acceptance-clean (duration elapsed, clean stop)
-    2  discovery failed ("Brain offline")
-    3  connect-gate timeout (WS client never established)
+    2  discovery failed ("Brain offline") -- STRICT contract only
+       (--require-brain, or no durable WAL armed)
+    3  connect-gate timeout (WS client never established) -- strict contract
 
 Env knobs (all resolved at call time -- zero baked assumptions):
     JARVIS_BRAIN_CONNECT_GATE_S     connect-gate budget (default 30)
     JARVIS_BODY_MODE_CENSUS_S       census log cadence (default 10)
     JARVIS_BRAIN_WS_*               Stage-0 transport client family
     JARVIS_BRAIN_MTLS_DIR           client mTLS material (Stage-1 conventions)
+    JARVIS_BODY_WAL_*               DurableOutbound family (durable_outbound.py)
 
 Usage::
 
     python3 scripts/run_body_mode.py                       # run until signal
     python3 scripts/run_body_mode.py --inject-test-signal 5 --duration-s 60
+    python3 scripts/run_body_mode.py --require-brain       # strict exit 2/3
     python3 scripts/run_body_mode.py --dry-run             # plan only, no network
 """
 from __future__ import annotations
@@ -59,6 +76,30 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+# The Body's bus-bridge identity -- MUST match the TrinityBusBridge
+# source_id (``_do_bridge``): the durable journal_filter keys on it.
+_SOURCE_ID = "mac-body"
+
+
+def _journal_local_origin_only(event: Any) -> bool:
+    """DurableOutbound journal_filter (live default): journal ONLY
+    locally-originated bridgeable events.
+
+    Peer-republished events -- imported off the wire and reflected onto
+    the local broker -- carry client-local event ids the server has
+    never seen; replaying them at reconnect defeats the server's
+    qualified-id dedup and duplicates events on the far side.
+    TrinityBusBridge stamps every outbound payload with
+    ``origin=<source_id>``; peer imports carry the peer's id. An absent
+    or empty origin journals anyway (fail OPEN: durability bias).
+    """
+    try:
+        origin = (getattr(event, "payload", None) or {}).get("origin")
+    except Exception:  # noqa: BLE001 -- fail OPEN
+        return True
+    return origin in (None, "", _SOURCE_ID)
+
+
 # ---------------------------------------------------------------------------
 # The Body-mode driver.
 # ---------------------------------------------------------------------------
@@ -78,6 +119,7 @@ class BodyModeDriver:
         shim_factory       -> ``(trinity_bus) -> RemoteIntakeRouter``
         sensor_factory     -> ``(shim) -> Optional[sensor]`` (fail-soft)
         watchdog_factory   -> ``() -> ControlPlaneWatchdog``
+        durable_factory    -> ``(broker) -> DurableOutbound`` (Stage-3 WAL)
     """
 
     def __init__(
@@ -86,6 +128,7 @@ class BodyModeDriver:
         inject_test_signals: int = 0,
         duration_s: Optional[float] = None,
         dry_run: bool = False,
+        require_brain: bool = False,
         # Injectable seams (live defaults resolved lazily inside run()).
         discover_fn: Optional[Callable[[], Awaitable[Optional[str]]]] = None,
         bus_factory: Optional[Callable[[], Awaitable[Tuple[Any, Any, Any]]]] = None,
@@ -93,10 +136,12 @@ class BodyModeDriver:
         shim_factory: Optional[Callable[[Any], Any]] = None,
         sensor_factory: Optional[Callable[[Any], Any]] = None,
         watchdog_factory: Optional[Callable[[], Any]] = None,
+        durable_factory: Optional[Callable[[Any], Any]] = None,
     ) -> None:
         self.inject_test_signals = max(0, int(inject_test_signals))
         self.duration_s = duration_s
         self.dry_run = dry_run
+        self.require_brain = require_brain
 
         self._discover = discover_fn
         self._bus_factory = bus_factory
@@ -104,9 +149,16 @@ class BodyModeDriver:
         self._shim_factory = shim_factory
         self._sensor_factory = sensor_factory
         self._watchdog_factory = watchdog_factory
+        self._durable_factory = durable_factory
 
         self._signals_sent = 0
         self._worst_lag_ms = 0.0
+        self._durable: Optional[Any] = None
+        self._durable_built = False
+        # Deterministic degrade surfacing (operator mandate): the link
+        # state derives ONLY from the client's `connected` property.
+        # None = not yet observed; edge transitions log exactly once.
+        self._link_up: Optional[bool] = None
 
     # -- lazy live default resolvers ---------------------------------------
 
@@ -133,9 +185,49 @@ class BodyModeDriver:
         )
         trinity_bus = await get_trinity_event_bus()
         broker = StreamEventBroker()
+        # Stage-3: build the durable WAL FIRST so the client constructor
+        # receives it (WAL-seeded replay + on_ack trim, Task 3), and
+        # thread the discovery re-race resolver (per-attempt).
+        self._durable = self._build_durable(broker)
+        self._durable_built = True
         cfg = TransportConfig.from_env(role="mac-body")
-        dist_bus = DistributedEventBus(broker, cfg, role="client")
+        dist_bus = DistributedEventBus(
+            broker, cfg, role="client",
+            durable_outbound=self._durable,
+            url_resolver=self._do_discover,
+        )
         return trinity_bus, broker, dist_bus
+
+    def _wal_arming_intended(self) -> bool:
+        """Structural arming intent, decided BEFORE anything is built:
+        an injected durable_factory arms the WAL; the live default (no
+        injected bus stack) always arms it; an injected bus stack
+        WITHOUT a durable seam stays on the strict Stage-2 contract."""
+        return self._durable_factory is not None or self._bus_factory is None
+
+    def _build_durable(self, broker: Any) -> Optional[Any]:
+        """Resolve the durable WAL seam. Fail-soft: a durable that
+        cannot be built degrades to the strict (unarmed) behavior
+        rather than killing the driver."""
+        if self._durable_factory is not None:
+            try:
+                return self._durable_factory(broker)
+            except Exception as exc:  # noqa: BLE001
+                _log("durable outbound unavailable (fail-soft): %s" % exc)
+                return None
+        if self._bus_factory is not None:
+            # Injected bus stack without a durable seam: the live
+            # DurableOutbound needs a real broker -- stay unarmed.
+            return None
+        try:
+            from backend.core.ouroboros.governance.transport.durable_outbound import (  # noqa: PLC0415
+                DurableOutbound,
+            )
+            return DurableOutbound(
+                broker, journal_filter=_journal_local_origin_only)
+        except Exception as exc:  # noqa: BLE001
+            _log("durable outbound unavailable (fail-soft): %s" % exc)
+            return None
 
     def _do_bridge(self, trinity_bus: Any, broker: Any) -> Any:
         if self._bridge_factory is not None:
@@ -240,7 +332,42 @@ class BodyModeDriver:
             _log("injected dedup_key=%s verdict=%s"
                  % (envelope.dedup_key, verdict))
 
-    # -- census -------------------------------------------------------------
+    # -- census + deterministic degrade surfacing ----------------------------
+
+    def _queued(self) -> int:
+        """Durable queue depth (0 when the WAL is unarmed). Fail-soft."""
+        if self._durable is None:
+            return 0
+        try:
+            return int(self._durable.pending_count())
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def _update_link_state(self, connected: bool) -> None:
+        """EDGE-triggered degrade surfacing (operator mandate): the UI
+        state derives ONLY from the bus client's ``connected`` property
+        -- set/cleared exactly at WS establishment/teardown inside
+        ``_connect_once`` (the transport closure). Polled once per
+        census tick; each episode transition logs exactly once. NO
+        generalized try/except state, NO heartbeat-timeout heuristics.
+        """
+        if self._link_up is None:
+            # First observation. A run that BEGINS dark is an offline
+            # episode and must surface; a run that begins connected is
+            # the quiet steady state.
+            self._link_up = connected
+            if not connected:
+                _log("Brain offline -- %d signals queued (durable)"
+                     % self._queued())
+            return
+        if connected == self._link_up:
+            return  # steady state -- never repeat the episode line
+        self._link_up = connected
+        if connected:
+            _log("Brain reconnected -- draining %d queued" % self._queued())
+        else:
+            _log("Brain offline -- %d signals queued (durable)"
+                 % self._queued())
 
     def _census_tick(self, watchdog: Any, connected: bool) -> None:
         lag_events = int(getattr(watchdog, "lag_event_count", 0))
@@ -251,8 +378,8 @@ class BodyModeDriver:
         for r in records:
             self._worst_lag_ms = max(
                 self._worst_lag_ms, float(getattr(r, "lag_ms", 0.0)))
-        _log("lag_events=%d worst_ms=%.1f connected=%s"
-             % (lag_events, self._worst_lag_ms, connected))
+        _log("lag_events=%d worst_ms=%.1f connected=%s queued=%d"
+             % (lag_events, self._worst_lag_ms, connected, self._queued()))
 
     # -- the run FSM ---------------------------------------------------------
 
@@ -266,17 +393,36 @@ class BodyModeDriver:
                  % self.inject_test_signals)
             return 0
 
-        # 1. DISCOVER (stateless; fail-soft returns None).
+        # 1. DISCOVER (stateless; fail-soft returns None). With the
+        #    durable WAL armed (Stage 3), discovery failure DEGRADES
+        #    instead of exiting: signals journal durably and the client
+        #    re-races discovery per attempt. --require-brain (or an
+        #    unarmed WAL) keeps the strict Stage-2 exit-2 contract.
         url = await self._do_discover()
+        strict = self.require_brain or not self._wal_arming_intended()
         if not url:
-            _log("Brain offline -- discovery returned no endpoint (exit 2)")
-            return 2
-        _log("Brain discovered at %s" % url)
+            if strict:
+                _log("Brain offline -- discovery returned no endpoint "
+                     "(exit 2)")
+                return 2
+            _log("discovery returned no endpoint -- degrading durably "
+                 "(WAL armed, reconnect re-racing)")
+        else:
+            _log("Brain discovered at %s" % url)
 
-        # 2. Bus stack + connect gate (Stage-1 proven pattern: events published
-        #    before the first successful connect are live-only-lost -- never
-        #    proceed on a dark link).
+        # 2. Bus stack + durable WAL. The WAL arms BEFORE the client so
+        #    journal-at-publish covers every event from the first
+        #    publish (a partition can never lose an accepted signal).
         trinity_bus, broker, dist_bus = await self._do_bus_stack()
+        if not self._durable_built:
+            self._durable = self._build_durable(broker)
+            self._durable_built = True
+        if self._durable is not None:
+            try:
+                await self._durable.start()
+            except Exception as exc:  # noqa: BLE001 -- fail-soft
+                _log("durable WAL failed to arm (fail-soft): %s" % exc)
+                self._durable = None
         client_task = asyncio.ensure_future(dist_bus.start_client(url))
 
         def _client_getter() -> Any:
@@ -298,12 +444,27 @@ class BodyModeDriver:
         bridge = None
         watchdog = None
         try:
-            if not await _await_connected(
-                    _env_float("JARVIS_BRAIN_CONNECT_GATE_S", 30.0)):
-                _log("connect gate TIMEOUT -- WS client never established "
-                     "(exit 3)")
-                return 3
-            _log("bus client connected")
+            # Connect gate (Stage-1 proven pattern). Strict contract:
+            # never proceed on a dark link (exit 3). Degrade contract:
+            # a dark link is an OFFLINE EPISODE, not an exit -- the WAL
+            # is the sink and the client keeps re-racing. With no url at
+            # all there is nothing to gate on; skip straight to the
+            # degraded census.
+            if url:
+                if await _await_connected(
+                        _env_float("JARVIS_BRAIN_CONNECT_GATE_S", 30.0)):
+                    _log("bus client connected")
+                elif strict:
+                    _log("connect gate TIMEOUT -- WS client never "
+                         "established (exit 3)")
+                    return 3
+                else:
+                    _log("connect gate timeout -- degrading durably "
+                         "(WAL armed, reconnect re-racing)")
+
+            # Initial link-state observation: a run that begins dark
+            # surfaces the canonical offline line exactly once here.
+            self._update_link_state(_connected())
 
             # 3. Bridge the local trinity bus onto the wire.
             bridge = self._do_bridge(trinity_bus, broker)
@@ -318,6 +479,9 @@ class BodyModeDriver:
                 await self._inject_signals(shim)
 
             # 5. Starvation census (the Stage-2 payoff measurement).
+            #    Determinism contract: `connected` is polled EXACTLY once
+            #    per tick; that single read feeds BOTH the edge machine
+            #    and the census line (no re-read skew).
             watchdog = self._do_watchdog()
             watchdog.start()
             census_s = _env_float("JARVIS_BODY_MODE_CENSUS_S", 10.0)
@@ -331,14 +495,19 @@ class BodyModeDriver:
                     await asyncio.sleep(min(census_s, remaining))
                 else:
                     await asyncio.sleep(census_s)
-                self._census_tick(watchdog, _connected())
+                connected = _connected()
+                self._update_link_state(connected)
+                self._census_tick(watchdog, connected)
 
             # 6. Clean stop -> summary -> exit 0.
-            self._census_tick(watchdog, _connected())
+            connected = _connected()
+            self._update_link_state(connected)
+            self._census_tick(watchdog, connected)
             return 0
         finally:
             lag_events = int(getattr(watchdog, "lag_event_count", 0)) \
                 if watchdog is not None else 0
+            queued_at_exit = self._queued()
             if watchdog is not None:
                 try:
                     await watchdog.stop()
@@ -347,6 +516,11 @@ class BodyModeDriver:
             if bridge is not None:
                 try:
                     await bridge.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+            if self._durable is not None:
+                try:
+                    await self._durable.stop()
                 except Exception:  # noqa: BLE001
                     pass
             try:
@@ -358,8 +532,10 @@ class BodyModeDriver:
                 await client_task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
-            _log("SUMMARY lag_events=%d worst_ms=%.1f signals_sent=%d"
-                 % (lag_events, self._worst_lag_ms, self._signals_sent))
+            _log("SUMMARY lag_events=%d worst_ms=%.1f signals_sent=%d "
+                 "queued_at_exit=%d"
+                 % (lag_events, self._worst_lag_ms, self._signals_sent,
+                    queued_at_exit))
 
 
 # ---------------------------------------------------------------------------
@@ -386,6 +562,13 @@ def build_arg_parser() -> argparse.ArgumentParser:
         help="Run for S seconds then stop cleanly (default: until signal).",
     )
     p.add_argument(
+        "--require-brain", action="store_true",
+        help="Strict Stage-2 contract: exit 2 when discovery fails and "
+             "exit 3 on connect-gate timeout, even with the durable WAL "
+             "armed (acceptance runs). Default: degrade durably -- journal "
+             "signals to the WAL and keep re-racing discovery.",
+    )
+    p.add_argument(
         "--dry-run", action="store_true",
         help="Print the Body-mode plan and exit -- touches no network.",
     )
@@ -399,6 +582,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         inject_test_signals=args.inject_test_signal,
         duration_s=args.duration_s,
         dry_run=args.dry_run,
+        require_brain=args.require_brain,
     )
     try:
         return asyncio.run(driver.run())

--- a/tests/governance/transport/test_ack_lane.py
+++ b/tests/governance/transport/test_ack_lane.py
@@ -1,0 +1,224 @@
+# -*- coding: utf-8 -*-
+"""Stage 3 Task 1: arm the dormant ack lane (bus_frame.py FRAME_ACK, minted
+at Stage 0, was a documented no-op through Stage 2 -- see
+bus_bridge_server.py's former L148 comment).
+
+Server side: ``BusBridgeServer._handle_ws`` now tracks a per-connection
+ingest cursor (the event_id of the last EVENT frame ingested on THIS
+connection) and emits an ``ack_frame`` back to the peer on a cadence --
+every ``JARVIS_BUS_ACK_EVERY_N`` events OR every ``JARVIS_BUS_ACK_INTERVAL_S``
+seconds, whichever trips first.
+
+Client side: ``BusBridgeClient._pump_inbound`` routes FRAME_ACK to the new
+``_apply_ack`` method, which monotonically advances ``last_acked_id``
+(zero-padded hex event ids compare correctly as strings) and fires an
+optional ``on_ack`` callback, fail-soft.
+
+Real localhost WS pair, no mocks -- the in-proc fake bridge masked three
+live bugs earlier this stage (see test_bridge_reflection_and_cursor.py),
+so this suite proves the ack lane against an actual aiohttp server +
+aiohttp client socket pair.
+"""
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import List, Optional
+
+from aiohttp import web
+
+import backend.core.ouroboros.governance.transport.exchange_protocol as xp
+from backend.core.ouroboros.governance.ide_observability_stream import StreamEventBroker
+from backend.core.ouroboros.governance.transport import bus_frame as bf
+from backend.core.ouroboros.governance.transport.bus_bridge_client import BusBridgeClient
+from backend.core.ouroboros.governance.transport.bus_bridge_server import BusBridgeServer
+from backend.core.ouroboros.governance.transport.transport_config import TransportConfig
+
+OP = xp.EXCHANGE_OP_PREFIX + "ack-lane"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _cfg(**over) -> TransportConfig:
+    base = dict(
+        host="127.0.0.1", port=0, path="/ws/trinity-bus", heartbeat_s=0.0,
+        reconnect_base_s=0.05, reconnect_max_s=0.5, reconnect_jitter=0.0,
+        queue_maxsize=256, history_maxlen=1024, degrade_after_missed_hb=2,
+        tls_enabled=False, tls_cert=None, tls_key=None, tls_ca=None,
+        tls_ephemeral=False, source_id="brain",
+    )
+    base.update(over)
+    return TransportConfig(**base)
+
+
+class _ServerHarness:
+    """A REAL BusBridgeServer bound to localhost -- constructed directly
+    (not via DistributedEventBus) so the test can hand BusBridgeClient the
+    new ``on_ack`` kwarg, which DistributedEventBus does not forward yet."""
+
+    def __init__(self) -> None:
+        self.port = _free_port()
+        self.broker = StreamEventBroker(history_maxlen=1024)
+        self.server = BusBridgeServer(self.broker, _cfg(port=self.port))
+        self._runner: Optional[web.AppRunner] = None
+
+    @property
+    def url(self) -> str:
+        return f"ws://127.0.0.1:{self.port}/ws/trinity-bus"
+
+    async def start(self) -> None:
+        app = web.Application()
+        self.server.register_routes(app)
+        self._runner = web.AppRunner(app)
+        await self._runner.setup()
+        site = web.TCPSite(self._runner, host="127.0.0.1", port=self.port)
+        await site.start()
+
+    async def stop(self) -> None:
+        if self._runner:
+            await self._runner.cleanup()
+
+
+async def _await_connected(client: BusBridgeClient, timeout: float = 5.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if client.connected:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("client never reported connected")
+
+
+async def _stop_client(client: BusBridgeClient, run_task: "asyncio.Task") -> None:
+    await client.stop()
+    run_task.cancel()
+    try:
+        await run_task
+    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+        pass
+
+
+# --------------------------------------------------------------------------- #
+# (a) N=20 real client-side events -> within the ack cadence, the client's
+#     last_acked_id reaches the 20th event's id and on_ack fired >=1 time
+#     with monotonically increasing ids.
+# --------------------------------------------------------------------------- #
+def test_ack_cursor_advances_to_last_ingested_event(monkeypatch):
+    monkeypatch.setenv("JARVIS_BUS_ACK_EVERY_N", "5")
+    monkeypatch.setenv("JARVIS_BUS_ACK_INTERVAL_S", "0.2")
+
+    async def scenario():
+        harness = _ServerHarness()
+        await harness.start()
+
+        client_broker = StreamEventBroker(history_maxlen=1024)
+        acked: List[str] = []
+        client = BusBridgeClient(
+            client_broker, _cfg(port=harness.port), url=harness.url,
+            on_ack=acked.append,
+        )
+        run_task = asyncio.ensure_future(client.run())
+        try:
+            await _await_connected(client)
+
+            event_ids = []
+            for i in range(20):
+                eid = client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + f"-{i}", {"i": i})
+                assert eid, "publish must succeed for a valid exchange event"
+                event_ids.append(eid)
+
+            deadline = asyncio.get_event_loop().time() + 3.0
+            while (asyncio.get_event_loop().time() < deadline
+                   and client.last_acked_id != event_ids[-1]):
+                await asyncio.sleep(0.05)
+
+            last_acked = client.last_acked_id
+        finally:
+            await _stop_client(client, run_task)
+            await harness.stop()
+        return last_acked, list(acked), event_ids
+
+    last_acked, acked, event_ids = asyncio.get_event_loop().run_until_complete(scenario())
+    assert last_acked == event_ids[-1], (
+        f"client last_acked_id must reach the 20th event's id: "
+        f"got {last_acked!r}, want {event_ids[-1]!r}")
+    assert len(acked) >= 1, "on_ack callback must fire at least once"
+    assert acked == sorted(acked), f"on_ack ids must be monotonically increasing: {acked!r}"
+
+
+# --------------------------------------------------------------------------- #
+# (b) monotonic guard: a regressive/duplicate ack must not move the cursor
+#     or re-fire on_ack. Unit-level -- hand-deliver ack frames straight into
+#     _apply_ack, no network needed for this half of the contract.
+# --------------------------------------------------------------------------- #
+def test_apply_ack_ignores_regressive_and_duplicate():
+    broker = StreamEventBroker(history_maxlen=16)
+    acked: List[str] = []
+    client = BusBridgeClient(broker, _cfg(), on_ack=acked.append)
+
+    client._apply_ack(bf.ack_frame("brain", "000000000005"))
+    assert client.last_acked_id == "000000000005"
+    assert acked == ["000000000005"]
+
+    client._apply_ack(bf.ack_frame("brain", "000000000003"))  # regressive
+    assert client.last_acked_id == "000000000005", "regressive ack must not rewind the cursor"
+
+    client._apply_ack(bf.ack_frame("brain", "000000000005"))  # duplicate
+    assert client.last_acked_id == "000000000005"
+    assert acked == ["000000000005"], "on_ack must not re-fire for a regressive/duplicate ack"
+
+    client._apply_ack(bf.ack_frame("brain", "000000000009"))  # forward
+    assert client.last_acked_id == "000000000009"
+    assert acked == ["000000000005", "000000000009"]
+
+
+def test_apply_ack_on_ack_exception_is_fail_soft():
+    def _boom(_eid: str) -> None:
+        raise RuntimeError("boom")
+
+    broker = StreamEventBroker(history_maxlen=16)
+    client = BusBridgeClient(broker, _cfg(), on_ack=_boom)
+
+    client._apply_ack(bf.ack_frame("brain", "000000000001"))  # must not raise
+    assert client.last_acked_id == "000000000001"
+
+
+# --------------------------------------------------------------------------- #
+# (c) legacy shape: a client with NO on_ack keeps working (acks silently
+#     advance the cursor with nothing to invoke). Stage-2 behavior (event
+#     flow, reflection suppression, cursor-across-reconnect) is asserted
+#     unmodified by the existing suites in this directory -- see
+#     test_bridge_reflection_and_cursor.py, test_bus_bridge_client.py,
+#     test_two_process_loopback.py, run alongside this file.
+# --------------------------------------------------------------------------- #
+def test_client_without_on_ack_still_ingests_and_gets_acked(monkeypatch):
+    monkeypatch.setenv("JARVIS_BUS_ACK_EVERY_N", "1")
+    monkeypatch.setenv("JARVIS_BUS_ACK_INTERVAL_S", "0.2")
+
+    async def scenario():
+        harness = _ServerHarness()
+        await harness.start()
+        client_broker = StreamEventBroker(history_maxlen=1024)
+        client = BusBridgeClient(client_broker, _cfg(port=harness.port), url=harness.url)
+        run_task = asyncio.ensure_future(client.run())
+        try:
+            await _await_connected(client)
+
+            eid = client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-legacy", {"i": 0})
+            assert eid
+
+            deadline = asyncio.get_event_loop().time() + 3.0
+            while asyncio.get_event_loop().time() < deadline and client.last_acked_id != eid:
+                await asyncio.sleep(0.05)
+
+            last_acked = client.last_acked_id
+        finally:
+            await _stop_client(client, run_task)
+            await harness.stop()
+        return last_acked, eid
+
+    last_acked, eid = asyncio.get_event_loop().run_until_complete(scenario())
+    assert last_acked == eid, "a client with no on_ack must still consume acks (cursor advances)"

--- a/tests/governance/transport/test_deliberate_partition.py
+++ b/tests/governance/transport/test_deliberate_partition.py
@@ -1,0 +1,575 @@
+# -*- coding: utf-8 -*-
+"""Stage 3 Task 5: THE DELIBERATE-PARTITION SUITE (load-bearing).
+
+Operator mandate: prove MATHEMATICAL SET-EQUALITY on the replay
+synchronization. Four legs, all against REAL localhost WS pairs, REAL
+DurableOutbound WAL files, REAL brokers -- the ARMED-durable live
+default path, no injected fakes. No sleeps-as-logic: every wait is a
+condition poll with a bounded deadline; the only time-window primitive
+is a *stability* settle (counts unchanged for a continuous window,
+bounded) used to let would-be duplicates land before exactness is
+asserted.
+
+  Leg A -- kill mid-stream, exact replay: 30 events total. ~10 cross
+      live, the server is HARD-KILLED (runner.cleanup() = socket
+      death), 10 more are published during the partition (client
+      connected=False, WAL pending >= 10, zero at-risk), the server
+      is RESTARTED with a FRESH broker (fresh dedup state) on a NEW
+      port found via the url_resolver, and the final 10 cross live.
+      The destination broker must end with ALL 30 exactly once:
+      multiset equality on the full ordered id set + per-id
+      occurrence == 1 + count == 30. The client broker ring is
+      env-clamped to 4 so broker-cursor replay physically cannot
+      recover the severed span -- the WAL is the only full truth.
+
+  Leg B -- Body process death mid-partition: with N=8 pending during
+      a partition, every client-side object is destroyed; a NEW
+      broker + client + DurableOutbound are built from the SAME
+      wal_path; on reconnect the 8 cross exactly once. Durability is
+      disk-truth, not object-lifetime. The 3 pre-partition events
+      that were acked+trimmed must NOT resurrect.
+
+  Leg C -- Brain service death, HMAC suspend/resume: two synthetic
+      in-flight ops registered in the REAL in-flight registry, then
+      capture_inflight(reason="partition_test") -- the module's real
+      contract, unchanged. list_pending returns both HMAC-VERIFIED;
+      a ONE-BYTE payload tamper (valid JSON at both levels -- only
+      the crypto gate can catch it) is REJECTED fail-closed; the
+      untampered twin hydrates EXACTLY once (mark_resumed second
+      call False, second hydrate injects nothing).
+
+  Leg D -- no duplicated terminal state: the SAME WAL pending set is
+      delivered twice across two reconnects to the SAME server. The
+      worst-case race (acks processed, trim NOT persisted) is made
+      deterministic by snapshotting the pre-trim WAL bytes and
+      restoring them after the first delivery+trim -- the second
+      incarnation replays all 6 again. Server-side count for those
+      ids stays exactly 1: qualified-id dedup is the single dedup
+      authority. Receipt of the second delivery is positively proven
+      by the server's acks re-trimming the restored WAL to 0.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+import shutil
+import socket
+from typing import Any, Callable, Dict, List, Optional
+
+from aiohttp import web
+
+import backend.core.ouroboros.governance.fsm_checkpoint as fc
+import backend.core.ouroboros.governance.in_flight_registry as ifr
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import (
+    TransportConfig,
+)
+from backend.core.ouroboros.governance.transport.distributed_event_bus import (
+    DistributedEventBus,
+)
+from backend.core.ouroboros.governance.transport.durable_outbound import (
+    DurableOutbound,
+)
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _cfg(monkeypatch, port: int, role: str) -> TransportConfig:
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HOST", "127.0.0.1")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", str(port))
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "1.0")
+    # Fast deterministic reconnect cadence -- partition recovery must not
+    # wait out production backoff.
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_BASE_S", "0.05")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_MAX_S", "0.2")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_JITTER", "0")
+    return TransportConfig.from_env(role=role)
+
+
+async def _wait_for(cond: Callable[[], bool], timeout: float = 10.0,
+                    msg: str = "") -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if cond():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError(
+        "condition not met within %.1fs%s"
+        % (timeout, (": " + msg) if msg else ""))
+
+
+async def _await_connected(bus: DistributedEventBus,
+                           timeout: float = 10.0) -> None:
+    def _is_connected() -> bool:
+        client = getattr(bus, "_client", None)
+        return client is not None and getattr(client, "connected", False)
+    await _wait_for(_is_connected, timeout=timeout, msg="client not connected")
+
+
+async def _await_disconnected(bus: DistributedEventBus,
+                              timeout: float = 10.0) -> None:
+    def _is_disconnected() -> bool:
+        client = getattr(bus, "_client", None)
+        return client is not None and not getattr(client, "connected", True)
+    await _wait_for(_is_disconnected, timeout=timeout,
+                    msg="client did not observe the sever")
+
+
+async def _start_server(
+    broker: StreamEventBroker, cfg: TransportConfig, port: int,
+) -> web.AppRunner:
+    bus = DistributedEventBus(broker, cfg, role="server")
+    app = web.Application()
+    bus.register_server_routes(app)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    # Small shutdown_timeout: these legs KILL servers while a live WS is
+    # attached -- the default 60s drain would hang the suite.
+    site = web.TCPSite(runner, host="127.0.0.1", port=port,
+                       shutdown_timeout=0.5)
+    await site.start()
+    return runner
+
+
+async def _stop_client(bus: DistributedEventBus, task: asyncio.Task) -> None:
+    try:
+        await bus.stop()
+    except Exception:  # noqa: BLE001
+        pass
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+        pass
+
+
+def _counts(broker: StreamEventBroker, ops: List[str]) -> Dict[str, int]:
+    """Per-op-id occurrence count on a destination broker."""
+    universe = set(ops)
+    got = [ev.op_id for ev in broker.recent_history(limit=2000)
+           if ev.op_id in universe]
+    return {op: got.count(op) for op in ops}
+
+
+def _arrivals(broker: StreamEventBroker, ops: List[str]) -> List[str]:
+    """The full ordered arrival list of the tracked ids."""
+    universe = set(ops)
+    return [ev.op_id for ev in broker.recent_history(limit=2000)
+            if ev.op_id in universe]
+
+
+async def _stable_counts(
+    counts_fn: Callable[[], Dict[str, int]],
+    *, window_s: float = 0.5, timeout: float = 6.0,
+) -> Dict[str, int]:
+    """Duplicate-detection settle: poll until the counts are UNCHANGED
+    for a continuous window (bounded). Condition-based -- not a bare
+    sleep pretending to be synchronization."""
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    last = counts_fn()
+    stable_since = loop.time()
+    while loop.time() < deadline:
+        await asyncio.sleep(0.05)
+        now = counts_fn()
+        t = loop.time()
+        if now != last:
+            last = now
+            stable_since = t
+        elif t - stable_since >= window_s:
+            return last
+    return last
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# --------------------------------------------------------------------------- #
+# Leg A -- kill mid-stream, exact replay onto a FRESH broker.
+# --------------------------------------------------------------------------- #
+def test_leg_a_kill_mid_stream_exact_replay(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    # Client broker ring clamped to 4: broker-cursor replay physically
+    # cannot recover the severed span -- WAL dependence is forced.
+    monkeypatch.setenv("JARVIS_IDE_STREAM_HISTORY_MAXLEN", "4")
+    # Ack cadence pushed out of reach: nothing trims pre-kill, so the WAL
+    # still carries the FULL 30-event truth for the fresh broker. (A trim
+    # would be correct -- delivery to broker A already happened -- but the
+    # set-equality target here is the fresh broker B.)
+    monkeypatch.setenv("JARVIS_BUS_ACK_EVERY_N", "1000")
+    monkeypatch.setenv("JARVIS_BUS_ACK_INTERVAL_S", "600")
+    wal_path = str(tmp_path / "leg_a_wal.jsonl")
+    ops = ["trinity:legA-%02d" % i for i in range(30)]
+
+    async def scenario():
+        port_a, port_b, dead_port = _free_port(), _free_port(), _free_port()
+        cfg_a = _cfg(monkeypatch, port_a, "server")
+        cfg_b = _cfg(monkeypatch, port_b, "server")
+        # Static client url dials a DEAD port -- only the resolver connects.
+        client_cfg = _cfg(monkeypatch, dead_port, "client")
+        path = client_cfg.path
+        target: Dict[str, str] = {"url": "ws://127.0.0.1:%d%s" % (port_a, path)}
+
+        async def resolver() -> Optional[str]:
+            return target["url"]
+
+        client_broker = StreamEventBroker()  # env-clamped ring: 4 slots
+        broker_a = StreamEventBroker(history_maxlen=256)
+        broker_b = StreamEventBroker(history_maxlen=256)
+        durable = DurableOutbound(client_broker, wal_path=wal_path)
+        await durable.start()
+        runner_a = await _start_server(broker_a, cfg_a, port_a)
+        bus = DistributedEventBus(
+            client_broker, client_cfg, role="client",
+            durable_outbound=durable, url_resolver=resolver)
+        task = asyncio.ensure_future(bus.start_client())
+        runner_b = None
+        try:
+            await _await_connected(bus)
+
+            # Events 1..10 cross LIVE to server A.
+            for op in ops[:10]:
+                client_broker.publish("task_started", op, {"leg": "A"})
+            await _wait_for(
+                lambda: _counts(broker_a, ops[:10]) == {o: 1 for o in ops[:10]},
+                msg="first 10 events did not land live on server A")
+            await _wait_for(lambda: durable.pending_count() == 10,
+                            msg="WAL journal lagged the first 10 publishes")
+
+            # HARD KILL at event ~10: socket death, not a graceful close.
+            await runner_a.cleanup()
+            await _await_disconnected(bus)
+
+            # Events 11..20 published DURING the partition.
+            for op in ops[10:20]:
+                client_broker.publish("task_started", op, {"leg": "A"})
+            await _wait_for(lambda: durable.pending_count() == 20,
+                            msg="partition-time publishes not journaled")
+            assert bus._client.connected is False, (
+                "partition invariant broken: client claims connected")
+            assert durable.pending_count() >= 10, (
+                "WAL must hold at least the partition-time span")
+            assert durable.journal_failures == 0, (
+                "durability honesty: an accepted publish is NOT on disk")
+
+            # RESTART: fresh broker (fresh dedup state) on a NEW port; the
+            # resolver's answer flips -- rediscovery lands the reconnect.
+            runner_b = await _start_server(broker_b, cfg_b, port_b)
+            target["url"] = "ws://127.0.0.1:%d%s" % (port_b, path)
+            await _await_connected(bus)
+            await _wait_for(
+                lambda: sum(_counts(broker_b, ops[:20]).values()) >= 20,
+                msg="WAL replay did not deliver the severed span to B")
+
+            # Events 21..30 cross LIVE post-reconnect (pump proven running
+            # by the 20 arrivals above -- no ring-gap race).
+            for op in ops[20:]:
+                client_broker.publish("task_started", op, {"leg": "A"})
+            await _wait_for(
+                lambda: all(c >= 1 for c in _counts(broker_b, ops).values()),
+                msg="full 30-event universe never completed on B")
+            counts = await _stable_counts(lambda: _counts(broker_b, ops))
+            arrivals = _arrivals(broker_b, ops)
+        finally:
+            await _stop_client(bus, task)
+            await durable.stop()
+            if runner_b is not None:
+                await runner_b.cleanup()
+        return counts, arrivals
+
+    counts, arrivals = _run(scenario())
+    # THE MANDATE: mathematical set-equality on the replay synchronization.
+    assert set(arrivals) == set(ops), (
+        "id-set mismatch: missing=%r extra=%r"
+        % (sorted(set(ops) - set(arrivals)), sorted(set(arrivals) - set(ops))))
+    assert sorted(arrivals) == sorted(ops), (
+        "full ordered id multiset mismatch: %r" % (sorted(arrivals),))
+    assert all(counts[op] == 1 for op in ops), (
+        "per-id occurrence != 1: %r"
+        % ({op: c for op, c in counts.items() if c != 1},))
+    assert len(arrivals) == 30, "count != 30: %d" % len(arrivals)
+
+
+# --------------------------------------------------------------------------- #
+# Leg B -- Body process death mid-partition: disk-truth durability.
+# --------------------------------------------------------------------------- #
+def test_leg_b_body_process_death_mid_partition(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    # Fast acks: the pre-partition events are trimmed (persisted tombstones)
+    # BEFORE the partition, so exactly N=8 are pending at death.
+    monkeypatch.setenv("JARVIS_BUS_ACK_EVERY_N", "1")
+    monkeypatch.setenv("JARVIS_BUS_ACK_INTERVAL_S", "0.2")
+    wal_path = str(tmp_path / "leg_b_wal.jsonl")
+    pre_ops = ["trinity:legB-pre-%d" % i for i in range(3)]
+    part_ops = ["trinity:legB-part-%d" % i for i in range(8)]
+
+    async def scenario():
+        port_a, port_b = _free_port(), _free_port()
+        cfg_a = _cfg(monkeypatch, port_a, "server")
+        cfg_b = _cfg(monkeypatch, port_b, "server")
+        client_cfg = _cfg(monkeypatch, port_a, "client")
+        path = client_cfg.path
+
+        # ----- incarnation 1: deliver 3, then partition with 8 pending -----
+        broker1 = StreamEventBroker(history_maxlen=64)
+        broker_a = StreamEventBroker(history_maxlen=256)
+        durable1 = DurableOutbound(broker1, wal_path=wal_path)
+        await durable1.start()
+        # Journal the pre-partition events BEFORE connecting so their WAL
+        # entries exist before any ack can arrive. (A live publish's append
+        # is offloaded; an ack that lands inside that window legitimately
+        # strands the entry pending until the NEXT ack -- at-least-once by
+        # design, absorbed by server dedup. Pre-journaling keeps THIS leg's
+        # trim-persistence assertion deterministic.)
+        for op in pre_ops:
+            broker1.publish("task_started", op, {"leg": "B"})
+        await _wait_for(lambda: durable1.pending_count() == 3,
+                        msg="pre-partition publishes not journaled")
+        runner_a = await _start_server(broker_a, cfg_a, port_a)
+        bus1 = DistributedEventBus(
+            broker1, client_cfg, role="client", durable_outbound=durable1)
+        task1 = asyncio.ensure_future(
+            bus1.start_client("ws://127.0.0.1:%d%s" % (port_a, path)))
+        try:
+            await _await_connected(bus1)
+            await _wait_for(
+                lambda: _counts(broker_a, pre_ops) == {o: 1 for o in pre_ops},
+                msg="pre-partition events did not cross via WAL replay")
+            # Ack lane trims them; _ack_inflight empty == tombstones LANDED
+            # on disk (the flush pops only after update_status succeeds).
+            await _wait_for(
+                lambda: (durable1.pending_count() == 0
+                         and not durable1._ack_inflight),
+                msg="ack-driven trim did not persist pre-partition")
+
+            # Partition: hard-kill the server, then publish N=8.
+            await runner_a.cleanup()
+            await _await_disconnected(bus1)
+            for op in part_ops:
+                broker1.publish("task_started", op, {"leg": "B"})
+            await _wait_for(lambda: durable1.pending_count() == 8,
+                            msg="partition publishes not journaled")
+            assert durable1.journal_failures == 0, (
+                "durability honesty: an accepted publish is NOT on disk")
+        finally:
+            # Body death: destroy EVERY client-side object. (An in-proc test
+            # cannot SIGKILL itself; the durability property under test is
+            # already sealed on disk -- the 8 appends landed at publish time,
+            # upstream of anything stop() flushes.)
+            await _stop_client(bus1, task1)
+            await durable1.stop()
+        del bus1, durable1, broker1
+
+        # ----- incarnation 2: NEW objects, SAME wal_path -----------------
+        broker2 = StreamEventBroker(history_maxlen=64)
+        durable2 = DurableOutbound(broker2, wal_path=wal_path)
+        await durable2.start()
+        # Disk truth: exactly the 8 partition events are pending; the 3
+        # acked ones stay dead (their tombstones persisted).
+        assert durable2.pending_count() == 8, (
+            "disk recovery expected exactly 8 pending, got %d"
+            % durable2.pending_count())
+
+        broker_b = StreamEventBroker(history_maxlen=256)
+        runner_b = await _start_server(broker_b, cfg_b, port_b)
+        bus2 = DistributedEventBus(
+            broker2, client_cfg, role="client", durable_outbound=durable2)
+        task2 = asyncio.ensure_future(
+            bus2.start_client("ws://127.0.0.1:%d%s" % (port_b, path)))
+        try:
+            await _await_connected(bus2)
+            await _wait_for(
+                lambda: all(c >= 1 for c in _counts(broker_b, part_ops).values()),
+                msg="recovered WAL did not deliver the 8 pending")
+            counts = await _stable_counts(lambda: _counts(broker_b, part_ops))
+            resurrected = _counts(broker_b, pre_ops)
+        finally:
+            await _stop_client(bus2, task2)
+            await durable2.stop()
+            await runner_b.cleanup()
+        return counts, resurrected
+
+    counts, resurrected = _run(scenario())
+    assert counts == {op: 1 for op in part_ops}, (
+        "the N pending must cross EXACTLY once, got %r" % (counts,))
+    assert resurrected == {op: 0 for op in pre_ops}, (
+        "acked+trimmed events resurrected across the object boundary: %r"
+        % (resurrected,))
+
+
+# --------------------------------------------------------------------------- #
+# Leg C -- Brain service death: HMAC suspend/resume, fail-closed tamper gate.
+# --------------------------------------------------------------------------- #
+def test_leg_c_hmac_suspend_resume_fail_closed(tmp_path, monkeypatch):
+    # Deterministic signing key (no dependence on a persisted host key).
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET",
+                       "task5-deliberate-partition-secret")
+    monkeypatch.delenv("JARVIS_CHECKPOINT_TTL_S", raising=False)
+    base = str(tmp_path)
+
+    class _Ctx:
+        """Synthetic in-flight op context carrying exactly the attributes
+        capture_from_context reads (module API used UNCHANGED)."""
+
+        def __init__(self, op_id: str) -> None:
+            self.op_id = op_id
+            self.description = "deliberate-partition suspend/resume drill"
+            self.target_files = ["backend/core/ouroboros/example.py"]
+            self.intake_evidence_json = ""
+            self.provider_route = "STANDARD"
+            self.signal_source = "partition_test"
+
+    # SUSPEND: drive capture_inflight through its REAL contract -- the
+    # in-flight registry snapshot (registry data structure works master-off
+    # by design; capture_inflight does not gate on the master flag).
+    ifr.reset_default_registry()
+    try:
+        reg = ifr.get_default_registry()
+        assert reg.register("op-clean", ctx_ref=_Ctx("op-clean"),
+                            last_phase_name="GENERATE") is not None
+        assert reg.register("op-tampered", ctx_ref=_Ctx("op-tampered"),
+                            last_phase_name="VALIDATE") is not None
+        n = fc.capture_inflight(base_dir=base, reason="partition_test")
+        assert n == 2, "capture_inflight must checkpoint both in-flight ops"
+    finally:
+        ifr.reset_default_registry()
+
+    # Both come back HMAC-VERIFIED.
+    pending = fc.list_pending(base_dir=base)
+    assert sorted(cp.op_id for cp in pending) == ["op-clean", "op-tampered"]
+    by_id = {cp.op_id: cp for cp in pending}
+    assert by_id["op-clean"].phase == "GENERATE"
+    assert by_id["op-tampered"].phase == "VALIDATE"
+    assert all(cp.resume_reason == "partition_test" for cp in pending)
+
+    # TAMPER exactly ONE byte inside the signed payload -- the wrapper and
+    # the payload both stay VALID JSON, so only the crypto gate can reject.
+    path = os.path.join(fc.checkpoint_dir(base), "op-tampered.json")
+    with open(path, "r", encoding="utf-8") as fh:
+        wrapper = json.loads(fh.read())
+    payload = wrapper["payload"]
+    assert "partition_test" in payload
+    tampered = payload.replace("partition_test", "partition_tesX", 1)
+    assert len(tampered) == len(payload) and tampered != payload
+    wrapper["payload"] = tampered
+    with open(path, "w", encoding="utf-8") as fh:
+        fh.write(json.dumps(wrapper))
+
+    # Fail-closed: the tampered checkpoint is REJECTED, the twin survives.
+    pending_after = fc.list_pending(base_dir=base)
+    assert [cp.op_id for cp in pending_after] == ["op-clean"], (
+        "one-byte tamper must be rejected by the HMAC gate (zero torn "
+        "ledger), got %r" % [cp.op_id for cp in pending_after])
+
+    # RESUME: the untampered twin hydrates EXACTLY once.
+    ingested: List[Dict[str, Any]] = []
+    resumed = fc.hydrate_pending_checkpoints(ingested.append, base_dir=base)
+    assert resumed == 1
+    assert [env["op_id"] for env in ingested] == ["op-clean"]
+    assert ingested[0]["resume"] is True
+    assert ingested[0]["resume_phase"] == "GENERATE"
+    assert ingested[0]["source"] == "fsm_resume"
+    # Exactly-once proof: hydrate consumed the file, so a second
+    # mark_resumed finds nothing to consume...
+    assert fc.mark_resumed("op-clean", base_dir=base) is False
+    # ...and a second hydrate injects nothing.
+    assert fc.hydrate_pending_checkpoints(ingested.append, base_dir=base) == 0
+    assert len(ingested) == 1
+    # The tampered file stays on disk (rejected, never hydrated, never
+    # silently deleted) -- auditable, fail-closed.
+    assert os.path.isfile(path)
+    assert fc.list_pending(base_dir=base) == []
+
+
+# --------------------------------------------------------------------------- #
+# Leg D -- double-replay of the SAME WAL pending: no duplicated terminal state.
+# --------------------------------------------------------------------------- #
+def test_leg_d_double_replay_single_terminal_state(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    monkeypatch.setenv("JARVIS_BUS_ACK_EVERY_N", "1")
+    monkeypatch.setenv("JARVIS_BUS_ACK_INTERVAL_S", "0.2")
+    wal_path = tmp_path / "leg_d_wal.jsonl"
+    snapshot_path = tmp_path / "leg_d_wal.pre_trim_snapshot"
+    ops = ["trinity:legD-%d" % i for i in range(6)]
+
+    async def scenario():
+        port = _free_port()
+        server_cfg = _cfg(monkeypatch, port, "server")
+        client_cfg = _cfg(monkeypatch, port, "client")
+        url = "ws://127.0.0.1:%d%s" % (port, client_cfg.path)
+
+        # ONE server instance across both reconnects: its qualified-id
+        # dedup memory is the single authority under test.
+        server_broker = StreamEventBroker(history_maxlen=256)
+        runner = await _start_server(server_broker, server_cfg, port)
+
+        # ----- delivery 1 -------------------------------------------------
+        broker1 = StreamEventBroker(history_maxlen=64)
+        durable1 = DurableOutbound(broker1, wal_path=str(wal_path))
+        await durable1.start()
+        for op in ops:
+            broker1.publish("task_started", op, {"leg": "D"})
+        await _wait_for(lambda: durable1.pending_count() == 6,
+                        msg="publishes not journaled")
+        # Snapshot the PRE-TRIM disk bytes: this IS the worst-case race
+        # frozen deterministically -- "acks processed, trim never persisted".
+        shutil.copyfile(wal_path, snapshot_path)
+
+        bus1 = DistributedEventBus(
+            broker1, client_cfg, role="client", durable_outbound=durable1)
+        task1 = asyncio.ensure_future(bus1.start_client(url))
+        try:
+            await _await_connected(bus1)
+            await _wait_for(
+                lambda: all(c >= 1 for c in _counts(server_broker, ops).values()),
+                msg="first delivery incomplete")
+            # Acks processed + trim persisted in THIS incarnation.
+            await _wait_for(
+                lambda: (durable1.pending_count() == 0
+                         and not durable1._ack_inflight),
+                msg="first-delivery acks never trimmed the WAL")
+        finally:
+            await _stop_client(bus1, task1)
+            await durable1.stop()
+
+        # Crash-with-torn-trim: the persisted trim is LOST -- restore the
+        # pre-trim WAL bytes, so the next incarnation re-sends everything.
+        shutil.copyfile(snapshot_path, wal_path)
+
+        # ----- delivery 2 (same ids, second reconnect) --------------------
+        broker2 = StreamEventBroker(history_maxlen=64)
+        durable2 = DurableOutbound(broker2, wal_path=str(wal_path))
+        await durable2.start()
+        assert durable2.pending_count() == 6, (
+            "restored WAL must re-arm the SAME 6 for a second delivery")
+        bus2 = DistributedEventBus(
+            broker2, client_cfg, role="client", durable_outbound=durable2)
+        task2 = asyncio.ensure_future(bus2.start_client(url))
+        try:
+            await _await_connected(bus2)
+            # Positive receipt proof: the server acks the re-sent frames
+            # (its ack cadence counts every EVENT frame, deduped or not),
+            # so the restored WAL trims to 0 ONLY if the double-replay was
+            # actually received on the wire. No vacuous pass possible.
+            await _wait_for(lambda: durable2.pending_count() == 0,
+                            msg="second delivery never reached the server")
+            counts = await _stable_counts(lambda: _counts(server_broker, ops))
+        finally:
+            await _stop_client(bus2, task2)
+            await durable2.stop()
+            await runner.cleanup()
+        return counts
+
+    counts = _run(scenario())
+    assert counts == {op: 1 for op in ops}, (
+        "double-replay must NOT duplicate terminal state -- qualified-id "
+        "dedup is the single authority; got %r" % (counts,))

--- a/tests/governance/transport/test_durable_outbound.py
+++ b/tests/governance/transport/test_durable_outbound.py
@@ -423,3 +423,60 @@ def test_ack_tombstone_failure_parks_lease_for_retry(
     assert len(warnings) == 1, (
         "exactly ONE ack-tombstone-failure warning per episode, got %d"
         % len(warnings))
+
+
+# --------------------------------------------------------------------------- #
+# (h) Task-3 carry-forward (re-review): a cumulative ack for Y must NOT
+#     purge an at-risk entry X <= Y -- the ack proves the server's ingest
+#     cursor reached Y, not that it ever RECEIVED the gap X (X was never
+#     durably journaled; if the process dies now, X is lost forever).
+#     Retention costs only a duplicate send, which server-side qualified-id
+#     dedup makes safe. The entry must keep retrying until it lands in the
+#     WAL, and then surface via pending() for replay.
+# --------------------------------------------------------------------------- #
+def test_ack_past_at_risk_entry_retains_it_until_journaled(
+        tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            real_append = outbound._wal.append
+            fault = {"on": True}
+
+            def _flaky_append(entry):
+                if fault["on"]:
+                    raise OSError(28, "No space left on device")
+                return real_append(entry)
+
+            monkeypatch.setattr(outbound._wal, "append", _flaky_append)
+
+            e1 = broker.publish(_EVENT_TYPE, _PREFIX + "risk-0", {"i": 0})
+            await _wait_for(lambda: outbound.journal_failures == 1)
+
+            # A cumulative ack that passes e1 arrives while e1 is at risk.
+            outbound.on_ack(e1)
+            await asyncio.sleep(0.1)
+            assert outbound.journal_failures == 1, (
+                "an ack for Y must NOT purge the at-risk gap X<=Y -- the "
+                "ack cannot prove X was received")
+
+            # Fault clears -> the next journal cycle lands e1 durably.
+            fault["on"] = False
+            e2 = broker.publish(_EVENT_TYPE, _PREFIX + "risk-1", {"i": 1})
+            await _wait_for(lambda: (outbound.journal_failures == 0
+                                     and outbound.pending_count() == 2))
+            assert _pending_ids(outbound) == sorted([e1, e2]), (
+                "the retained entry must land in the WAL and surface via "
+                "pending() for replay")
+            return [e1, e2]
+        finally:
+            await outbound.stop()
+
+    ids = _run(scenario())
+    fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+    assert _pending_ids(fresh) == sorted(ids), (
+        "disk truth must retain the once-at-risk entry after the fault clears")

--- a/tests/governance/transport/test_durable_outbound.py
+++ b/tests/governance/transport/test_durable_outbound.py
@@ -7,17 +7,24 @@ crash can never lose a publish() the broker accepted. Trims on ack
 (Task 1's BusBridgeClient on_ack hook target), with a dynamic
 disk-fraction capacity guard (no hardcoded byte caps).
 
-Suite map (per the task brief):
+Suite map (task brief + review round):
   (a) journal-at-publish: only op_prefix events land, ordered by event_id
   (b) crash-survival: a fresh instance on the same wal_path recovers the
-      pending set from fsync'd disk truth, not memory
+      pending set from journaled disk truth, not memory
   (c) ack-trim: on_ack(<eid>) trims every pending id <= eid, in memory
       immediately and on disk durably (fresh instance agrees)
   (d) dynamic capacity: tiny disk free -> degraded_capacity flips True,
       oldest pending dropped (dead_letter), exactly ONE warning per
-      episode, newest survives; restored disk clears the flag
+      episode, newest survives; restored disk clears the flag; compact
+      fires ONLY at episode onset (review IMPORTANT-2)
   (e) zero hardcoded caps: module source contains no byte-size literals;
       JARVIS_BODY_WAL_DISK_FRACTION is the only capacity knob
+  (f) review CRITICAL: a failed WAL append is NEVER reported as
+      pending-durable -- surfaced via journal_failures, ONE warning per
+      episode, retried on later journal cycles, lands when fault clears
+  (g) review IMPORTANT-1: a failed ack tombstone keeps the lease parked
+      for retry (no live-acked/disk-pending split-brain loss), ONE
+      warning per episode, drains once the fault clears
 """
 from __future__ import annotations
 
@@ -119,7 +126,7 @@ def test_crash_survival_fresh_instance_recovers_from_disk(tmp_path, monkeypatch)
     ids = _run(scenario())
 
     # A NEW instance -- new broker, no start(), no shared memory -- must see
-    # the same 5 pending entries purely from the fsync'd WAL file.
+    # the same 5 pending entries purely from the flock-journaled WAL file.
     fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
     assert fresh.pending_count() == 5
     assert _pending_ids(fresh) == sorted(ids), (
@@ -185,9 +192,22 @@ def test_dynamic_capacity_degrades_and_recovers(tmp_path, monkeypatch, caplog):
 
     logger_name = "backend.core.ouroboros.governance.transport.durable_outbound"
 
+    # Review IMPORTANT-2: compact must fire ONLY at episode onset, not on
+    # every over-budget append while already degraded.
+    compact_calls = {"n": 0}
+
     async def scenario():
         broker = StreamEventBroker(history_maxlen=64)
         outbound = DurableOutbound(broker, wal_path=wal_path)
+
+        real_compact = outbound._wal.compact
+
+        def _counting_compact():
+            compact_calls["n"] += 1
+            return real_compact()
+
+        monkeypatch.setattr(outbound._wal, "compact", _counting_compact)
+
         await outbound.start()
         try:
             ids = [broker.publish(_EVENT_TYPE, _PREFIX + "t-%d" % i, {"i": i})
@@ -219,6 +239,10 @@ def test_dynamic_capacity_degrades_and_recovers(tmp_path, monkeypatch, caplog):
 
     with caplog.at_level(logging.WARNING, logger=logger_name):
         ids, final_ids = _run(scenario())
+
+    assert compact_calls["n"] == 1, (
+        "compact must run ONLY at degraded-episode onset, ran %d times"
+        % compact_calls["n"])
 
     warnings = [r for r in caplog.records
                 if r.name == logger_name and r.levelno == logging.WARNING
@@ -260,3 +284,142 @@ def test_no_hardcoded_byte_caps_in_module_source():
     assert capacity_knobs == {"JARVIS_BODY_WAL_DISK_FRACTION"}, (
         "JARVIS_BODY_WAL_DISK_FRACTION must be the ONLY capacity knob: %r"
         % capacity_knobs)
+
+
+# --------------------------------------------------------------------------- #
+# (f) review CRITICAL: WAL.append failure (the ENOSPC class this module
+#     exists to survive) must NOT be reported as pending-durable. The event
+#     is surfaced as at-risk (journal_failures), warned ONCE per episode,
+#     retried on subsequent journal cycles, and lands when the fault clears.
+# --------------------------------------------------------------------------- #
+def test_journal_append_failure_not_falsely_durable_then_retried(
+        tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+    logger_name = "backend.core.ouroboros.governance.transport.durable_outbound"
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            real_append = outbound._wal.append
+            fault = {"on": True}
+
+            def _flaky_append(entry):
+                if fault["on"]:
+                    raise OSError(28, "No space left on device")
+                return real_append(entry)
+
+            monkeypatch.setattr(outbound._wal, "append", _flaky_append)
+
+            e1 = broker.publish(_EVENT_TYPE, _PREFIX + "t-0", {"i": 0})
+            e2 = broker.publish(_EVENT_TYPE, _PREFIX + "t-1", {"i": 1})
+            await _wait_for(lambda: outbound.journal_failures == 2)
+
+            # The durability claim must be HONEST: nothing landed on disk,
+            # so nothing may be reported as pending-durable.
+            assert outbound.pending_count() == 0, (
+                "a failed append must NOT surface as pending-durable")
+            probe = DurableOutbound(
+                StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+            assert probe.pending_count() == 0, (
+                "disk must agree: nothing was journaled")
+
+            # Fault clears -> the next journal cycle retries the at-risk
+            # entries, then journals the new event. All three land.
+            fault["on"] = False
+            e3 = broker.publish(_EVENT_TYPE, _PREFIX + "t-2", {"i": 2})
+            await _wait_for(lambda: (outbound.pending_count() == 3
+                                     and outbound.journal_failures == 0))
+            assert _pending_ids(outbound) == sorted([e1, e2, e3])
+            return [e1, e2, e3]
+        finally:
+            await outbound.stop()
+
+    with caplog.at_level(logging.WARNING, logger=logger_name):
+        ids = _run(scenario())
+
+    fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+    assert _pending_ids(fresh) == sorted(ids), (
+        "retried at-risk events must be durably journaled once the fault clears")
+
+    warnings = [r for r in caplog.records
+                if r.name == logger_name and r.levelno == logging.WARNING
+                and "journal append FAILED" in r.getMessage()]
+    assert len(warnings) == 1, (
+        "exactly ONE journal-failure warning per episode, got %d"
+        % len(warnings))
+
+
+# --------------------------------------------------------------------------- #
+# (g) review IMPORTANT-1: ack tombstone write failure must not produce the
+#     live-says-acked / disk-says-pending split silently -- the lease stays
+#     parked for retry, ONE distinguishing warning per episode, and the
+#     tombstones land once the fault clears.
+# --------------------------------------------------------------------------- #
+def test_ack_tombstone_failure_parks_lease_for_retry(
+        tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+    logger_name = "backend.core.ouroboros.governance.transport.durable_outbound"
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            ids = [broker.publish(_EVENT_TYPE, _PREFIX + "t-%d" % i, {"i": i})
+                   for i in range(3)]
+            await _wait_for(lambda: outbound.pending_count() == 3)
+
+            real_update = outbound._wal.update_status
+            fault = {"on": True}
+
+            def _flaky_update(lease_id, status):
+                if fault["on"] and status == "acked":
+                    raise OSError(5, "injected tombstone write failure")
+                return real_update(lease_id, status)
+
+            monkeypatch.setattr(outbound._wal, "update_status", _flaky_update)
+
+            outbound.on_ack(ids[1])  # acks ids[0..1]
+            # Immediate in-memory ack semantics still hold (redelivery is
+            # SAFE downstream -- server dedup)...
+            assert outbound.pending_count() == 1
+
+            # ...but the failed tombstones park the leases for retry.
+            await _wait_for(lambda: len(outbound._ack_retry) == 2)
+            probe = DurableOutbound(
+                StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+            assert probe.pending_count() == 3, (
+                "disk truth must still show 3 pending -- no tombstone landed")
+
+            # Fault clears -> a later flush retries the parked leases.
+            fault["on"] = False
+            outbound.on_ack(ids[1])  # no new ids; drains the retry park
+            await _wait_for(lambda: not outbound._ack_retry)
+
+            def _disk_agrees() -> bool:
+                p = DurableOutbound(
+                    StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+                return p.pending_count() == 1
+            await _wait_for(_disk_agrees)
+            assert outbound.pending_count() == 1
+            return ids
+        finally:
+            await outbound.stop()
+
+    with caplog.at_level(logging.WARNING, logger=logger_name):
+        ids = _run(scenario())
+
+    fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+    assert _pending_ids(fresh) == [sorted(ids)[2]], (
+        "acked leases must be durably tombstoned once the fault clears")
+
+    warnings = [r for r in caplog.records
+                if r.name == logger_name and r.levelno == logging.WARNING
+                and "ack tombstone" in r.getMessage()]
+    assert len(warnings) == 1, (
+        "exactly ONE ack-tombstone-failure warning per episode, got %d"
+        % len(warnings))

--- a/tests/governance/transport/test_durable_outbound.py
+++ b/tests/governance/transport/test_durable_outbound.py
@@ -1,0 +1,262 @@
+# -*- coding: utf-8 -*-
+"""Stage 3 Task 2: DurableOutbound -- the Body-side durable WAL journal.
+
+Journals every bridgeable (op_prefix-matched) StreamEventBroker event at
+PUBLISH time -- upstream of connection state, so a partition or a Body
+crash can never lose a publish() the broker accepted. Trims on ack
+(Task 1's BusBridgeClient on_ack hook target), with a dynamic
+disk-fraction capacity guard (no hardcoded byte caps).
+
+Suite map (per the task brief):
+  (a) journal-at-publish: only op_prefix events land, ordered by event_id
+  (b) crash-survival: a fresh instance on the same wal_path recovers the
+      pending set from fsync'd disk truth, not memory
+  (c) ack-trim: on_ack(<eid>) trims every pending id <= eid, in memory
+      immediately and on disk durably (fresh instance agrees)
+  (d) dynamic capacity: tiny disk free -> degraded_capacity flips True,
+      oldest pending dropped (dead_letter), exactly ONE warning per
+      episode, newest survives; restored disk clears the flag
+  (e) zero hardcoded caps: module source contains no byte-size literals;
+      JARVIS_BODY_WAL_DISK_FRACTION is the only capacity knob
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import re
+import shutil
+import types
+from pathlib import Path
+from typing import Any, Callable, List
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.durable_outbound import (
+    DurableOutbound,
+)
+
+_EVENT_TYPE = "task_started"  # valid broker type (see trinity_bus_bridge)
+_PREFIX = "trinity:"
+
+_MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "backend" / "core" / "ouroboros" / "governance" / "transport"
+    / "durable_outbound.py"
+)
+
+
+async def _wait_for(cond: Callable[[], bool], timeout: float = 5.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if cond():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("condition not met within %.1fs" % timeout)
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _pending_ids(outbound: DurableOutbound) -> List[str]:
+    return [d["event_id"] for d in outbound.pending()]
+
+
+# --------------------------------------------------------------------------- #
+# (a) journal-at-publish: 5 trinity events + 2 non-prefix events -> exactly
+#     the 5 trinity events are journaled, ordered by event_id.
+# --------------------------------------------------------------------------- #
+def test_journal_at_publish_filters_and_orders(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            trinity_ids = []
+            for i in range(5):
+                eid = broker.publish(_EVENT_TYPE, _PREFIX + "topic-%d" % i, {"i": i})
+                assert eid
+                trinity_ids.append(eid)
+                if i == 2:  # interleave the non-prefix noise mid-stream
+                    assert broker.publish(_EVENT_TYPE, "other-op-a", {})
+                    assert broker.publish(_EVENT_TYPE, "other-op-b", {})
+            await _wait_for(lambda: outbound.pending_count() == 5)
+            return trinity_ids, _pending_ids(outbound), outbound.pending_count()
+        finally:
+            await outbound.stop()
+
+    trinity_ids, got_ids, count = _run(scenario())
+    assert count == 5, "exactly the 5 trinity-prefixed events must be journaled"
+    assert got_ids == sorted(trinity_ids), (
+        "pending() must be ordered by event_id: got %r want %r"
+        % (got_ids, sorted(trinity_ids)))
+
+
+# --------------------------------------------------------------------------- #
+# (b) crash-survival -- THE WAL point: tear down without acks; a brand-new
+#     instance on the same wal_path recovers all 5 from disk.
+# --------------------------------------------------------------------------- #
+def test_crash_survival_fresh_instance_recovers_from_disk(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            ids = [broker.publish(_EVENT_TYPE, _PREFIX + "t-%d" % i, {"i": i})
+                   for i in range(5)]
+            await _wait_for(lambda: outbound.pending_count() == 5)
+        finally:
+            await outbound.stop()  # simulated crash boundary: instance gone
+        return ids
+
+    ids = _run(scenario())
+
+    # A NEW instance -- new broker, no start(), no shared memory -- must see
+    # the same 5 pending entries purely from the fsync'd WAL file.
+    fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+    assert fresh.pending_count() == 5
+    assert _pending_ids(fresh) == sorted(ids), (
+        "recovered pending set must match the journaled publishes")
+
+
+# --------------------------------------------------------------------------- #
+# (c) ack-trim: on_ack(<3rd id>) trims ids 1..3 -> pending_count()==2,
+#     immediately in memory and durably on disk (fresh instance agrees).
+# --------------------------------------------------------------------------- #
+def test_ack_trim_immediate_and_durable(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            ids = [broker.publish(_EVENT_TYPE, _PREFIX + "t-%d" % i, {"i": i})
+                   for i in range(5)]
+            await _wait_for(lambda: outbound.pending_count() == 5)
+
+            outbound.on_ack(ids[2])  # cumulative cursor: acks ids[0..2]
+            # IMMEDIATE in-memory effect -- before any disk tombstone lands.
+            assert outbound.pending_count() == 2
+            assert _pending_ids(outbound) == sorted(ids)[3:]
+
+            # Durable effect: poll fresh instances until the tombstones land.
+            def _disk_agrees() -> bool:
+                probe = DurableOutbound(
+                    StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+                return probe.pending_count() == 2
+            await _wait_for(_disk_agrees)
+        finally:
+            await outbound.stop()
+        return ids
+
+    ids = _run(scenario())
+    fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+    assert _pending_ids(fresh) == sorted(ids)[3:], (
+        "disk truth must agree with the in-memory trim after the ack flush")
+
+
+# --------------------------------------------------------------------------- #
+# (d) dynamic capacity: tiny free disk -> degraded_capacity True, oldest
+#     pending dead-lettered with exactly ONE warning per episode, newest
+#     survives; restoring the disk clears the flag on the next append.
+# --------------------------------------------------------------------------- #
+def test_dynamic_capacity_degrades_and_recovers(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    fake_free = {"v": None}  # None -> real shutil.disk_usage
+    real_disk_usage = shutil.disk_usage
+
+    def _fake_disk_usage(path):
+        if fake_free["v"] is None:
+            return real_disk_usage(path)
+        return types.SimpleNamespace(total=1, used=1, free=fake_free["v"])
+
+    monkeypatch.setattr(shutil, "disk_usage", _fake_disk_usage)
+
+    logger_name = "backend.core.ouroboros.governance.transport.durable_outbound"
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            ids = [broker.publish(_EVENT_TYPE, _PREFIX + "t-%d" % i, {"i": i})
+                   for i in range(3)]
+            await _wait_for(lambda: outbound.pending_count() == 3)
+            assert outbound.degraded_capacity is False
+
+            fake_free["v"] = 0  # budget = fraction * 0 -> any WAL size is over
+            ids.append(broker.publish(_EVENT_TYPE, _PREFIX + "t-3", {"i": 3}))
+            await _wait_for(
+                lambda: _pending_ids(outbound) == sorted(ids)[1:])
+            assert outbound.degraded_capacity is True
+
+            # Second over-capacity append: drops next-oldest, NO second warning.
+            ids.append(broker.publish(_EVENT_TYPE, _PREFIX + "t-4", {"i": 4}))
+            await _wait_for(
+                lambda: _pending_ids(outbound) == sorted(ids)[2:])
+            assert outbound.degraded_capacity is True
+
+            fake_free["v"] = None  # disk restored
+            ids.append(broker.publish(_EVENT_TYPE, _PREFIX + "t-5", {"i": 5}))
+            await _wait_for(
+                lambda: _pending_ids(outbound) == sorted(ids)[2:])
+            assert outbound.degraded_capacity is False, (
+                "capacity clearing must reset the degraded episode")
+            return ids, _pending_ids(outbound)
+        finally:
+            await outbound.stop()
+
+    with caplog.at_level(logging.WARNING, logger=logger_name):
+        ids, final_ids = _run(scenario())
+
+    warnings = [r for r in caplog.records
+                if r.name == logger_name and r.levelno == logging.WARNING
+                and "degraded_capacity" in r.getMessage()]
+    assert len(warnings) == 1, (
+        "exactly ONE degraded_capacity warning per episode, got %d"
+        % len(warnings))
+    assert sorted(ids)[-1] in final_ids, "the newest publish must survive"
+    assert sorted(ids)[0] not in final_ids, "the oldest pending must be dropped"
+
+
+# --------------------------------------------------------------------------- #
+# (e) zero hardcoded caps: the capacity logic must carry no byte-size
+#     literals; JARVIS_BODY_WAL_DISK_FRACTION is the only capacity knob.
+# --------------------------------------------------------------------------- #
+def test_no_hardcoded_byte_caps_in_module_source():
+    src = _MODULE_PATH.read_text(encoding="utf-8")
+
+    byte_literals = re.findall(
+        r"\b(?:1024|2048|4096|8192|65536|1048576|1073741824)\b"
+        r"|<<\s*(?:10|20|30|40)\b"
+        r"|\b\d+(?:\.\d+)?[eE]\+?\d+\b",
+        src,
+    )
+    assert not byte_literals, (
+        "capacity logic must not hardcode byte sizes, found: %r" % byte_literals)
+
+    knobs = set(re.findall(r"JARVIS_BODY_WAL_[A-Z0-9_]+", src))
+    assert knobs == {
+        "JARVIS_BODY_WAL_PATH",
+        "JARVIS_BODY_WAL_DISK_FRACTION",
+        "JARVIS_BODY_WAL_MAX_AGE_DAYS",
+        "JARVIS_BODY_WAL_COMPACT_EVERY_N",
+        "JARVIS_BODY_WAL_PROBE_INTERVAL_S",
+    }, "unexpected env knob set: %r" % knobs
+
+    capacity_knobs = {k for k in knobs
+                     if any(w in k for w in ("FRACTION", "SIZE", "BYTES", "CAP"))}
+    assert capacity_knobs == {"JARVIS_BODY_WAL_DISK_FRACTION"}, (
+        "JARVIS_BODY_WAL_DISK_FRACTION must be the ONLY capacity knob: %r"
+        % capacity_knobs)

--- a/tests/governance/transport/test_durable_outbound.py
+++ b/tests/governance/transport/test_durable_outbound.py
@@ -534,3 +534,70 @@ def test_journal_filter_excludes_peer_origin(tmp_path, monkeypatch):
     fresh = DurableOutbound(
         StreamEventBroker(history_maxlen=4), wal_path=wal_path)
     assert _pending_ids(fresh) == sorted([local_id, bare_id])
+
+
+# --------------------------------------------------------------------------- #
+# (h2) review round: a RAISING journal_filter fails OPEN (journals anyway --
+#      durability over dedup) but must NOT be silent: one warning per
+#      episode, episode reset when the filter succeeds again (the file's
+#      established warn-once pattern: WAL append / ack tombstone / capacity).
+# --------------------------------------------------------------------------- #
+def test_journal_filter_failure_warns_once_and_fails_open(
+        tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+    fault = {"on": True}
+
+    def _flaky_filter(event: Any) -> bool:
+        if fault["on"]:
+            raise RuntimeError("filter boom")
+        return (getattr(event, "payload", None) or {}).get(
+            "origin") != "peer"
+
+    def _filter_warnings() -> List[Any]:
+        return [r for r in caplog.records
+                if r.levelno == logging.WARNING
+                and "journal_filter" in r.getMessage()]
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(
+            broker, wal_path=wal_path, journal_filter=_flaky_filter)
+        await outbound.start()
+        try:
+            with caplog.at_level(logging.INFO):
+                # Episode 1: two raising evaluations -> BOTH events still
+                # journal (fail open) but exactly ONE warning fires.
+                e1 = broker.publish(
+                    _EVENT_TYPE, _PREFIX + "f-0", {"origin": "peer"})
+                e2 = broker.publish(
+                    _EVENT_TYPE, _PREFIX + "f-1", {"origin": "peer"})
+                await _wait_for(lambda: outbound.pending_count() == 2)
+                assert _pending_ids(outbound) == sorted([e1, e2]), (
+                    "fail-open: a raising filter must journal anyway")
+                assert len(_filter_warnings()) == 1, (
+                    "exactly one warning per failure episode")
+
+                # Recovery: the filter works again -> episode resets and
+                # peer exclusion is back in force.
+                fault["on"] = False
+                e3 = broker.publish(
+                    _EVENT_TYPE, _PREFIX + "f-2", {"origin": "peer"})
+                e4 = broker.publish(
+                    _EVENT_TYPE, _PREFIX + "f-3", {"origin": "local"})
+                await _wait_for(lambda: outbound.pending_count() == 3)
+                got = _pending_ids(outbound)
+                assert e3 not in got, "recovered filter excludes peer again"
+                assert e4 in got
+
+                # Episode 2: a NEW fault warns again (episode was reset).
+                fault["on"] = True
+                broker.publish(
+                    _EVENT_TYPE, _PREFIX + "f-4", {"origin": "peer"})
+                await _wait_for(lambda: outbound.pending_count() == 4)
+                assert len(_filter_warnings()) == 2, (
+                    "a fresh failure episode must warn again")
+        finally:
+            await outbound.stop()
+
+    _run(scenario())

--- a/tests/governance/transport/test_durable_outbound.py
+++ b/tests/governance/transport/test_durable_outbound.py
@@ -25,6 +25,11 @@ Suite map (task brief + review round):
   (g) review IMPORTANT-1: a failed ack tombstone keeps the lease parked
       for retry (no live-acked/disk-pending split-brain loss), ONE
       warning per episode, drains once the fault clears
+  (h) Task-4 carry-in (Task-3 review): ``journal_filter`` -- when
+      provided, only events the filter accepts are journaled.
+      Peer-republished events (payload origin != local source_id)
+      carry client-local event ids the server has never seen;
+      replaying them defeats qualified-id dedup and duplicates events
 """
 from __future__ import annotations
 
@@ -480,3 +485,52 @@ def test_ack_past_at_risk_entry_retains_it_until_journaled(
     fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
     assert _pending_ids(fresh) == sorted(ids), (
         "disk truth must retain the once-at-risk entry after the fault clears")
+
+
+# --------------------------------------------------------------------------- #
+# (h) journal_filter: peer-origin events are NOT journaled; locally-
+#     originated events (and origin-less events -- fail-open durability
+#     bias) are. The driver's live default excludes peer republications:
+#     they carry client-local event ids the server has never seen, so
+#     replaying them at reconnect defeats qualified-id dedup.
+# --------------------------------------------------------------------------- #
+def test_journal_filter_excludes_peer_origin(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+    local_source = "mac-body"
+
+    def _local_only(event: Any) -> bool:
+        return (getattr(event, "payload", None) or {}).get(
+            "origin") in (None, "", local_source)
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(
+            broker, wal_path=wal_path, journal_filter=_local_only)
+        await outbound.start()
+        try:
+            local_id = broker.publish(
+                _EVENT_TYPE, _PREFIX + "topic-a",
+                {"origin": local_source, "i": 0})
+            peer_id = broker.publish(
+                _EVENT_TYPE, _PREFIX + "topic-b",
+                {"origin": "gcp-brain", "i": 1})
+            bare_id = broker.publish(
+                _EVENT_TYPE, _PREFIX + "topic-c", {"i": 2})
+            assert local_id and peer_id and bare_id
+            await _wait_for(lambda: outbound.pending_count() >= 2)
+            await asyncio.sleep(0.1)  # settle: catch a late (wrong) journal
+            return local_id, peer_id, bare_id, _pending_ids(outbound)
+        finally:
+            await outbound.stop()
+
+    local_id, peer_id, bare_id, got = _run(scenario())
+    assert got == sorted([local_id, bare_id]), (
+        "local-origin + origin-less events must journal; got %r" % (got,))
+    assert peer_id not in got, (
+        "peer-republished (origin=gcp-brain) event must NOT be journaled")
+
+    # Disk truth agrees: a fresh instance recovers exactly the two.
+    fresh = DurableOutbound(
+        StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+    assert _pending_ids(fresh) == sorted([local_id, bare_id])

--- a/tests/governance/transport/test_wal_replay_and_rediscovery.py
+++ b/tests/governance/transport/test_wal_replay_and_rediscovery.py
@@ -1,0 +1,300 @@
+# -*- coding: utf-8 -*-
+"""Stage 3 Task 3: WAL-seeded reconnect replay + per-attempt discovery
+re-race, proven against a REAL localhost client<->server WS pair.
+
+  (a) REDISCOVERY: the client re-races discovery on EVERY reconnect
+      attempt (spec line 69). A client whose STATIC url is dead but whose
+      ``url_resolver`` answers a live URL connects; after the server is
+      killed and restarted on a DIFFERENT port, flipping the resolver's
+      answer lands the reconnect on the new port. Redialing a static url
+      forever (the pre-Task-3 behavior) can never pass this.
+  (a2) RESOLVER FAIL-SOFT: a resolver that raises must not kill the
+      reconnect loop -- the attempt falls back to the static url.
+  (b) WAL-SEEDED REPLAY BEYOND BROKER HISTORY: 6 events published with NO
+      server up and the broker history ring clamped to 2
+      (JARVIS_IDE_STREAM_HISTORY_MAXLEN=2 -- broker replay alone CANNOT
+      recover more than 2). The DurableOutbound WAL carried all 6; on
+      connect the client seeds the link from ``durable.pending()`` and the
+      server broker ends holding ALL 6 exactly once (qualified-id dedup
+      absorbs any overlap -- no client-side dedup added).
+  (c) LEGACY SHAPE: no ``durable``, no ``url_resolver`` -> Stage-2
+      behavior byte-identical (existing suites stay authoritative; this
+      pins the default construction path still mirrors events).
+"""
+from __future__ import annotations
+
+import asyncio
+import socket
+from typing import Any, Callable, Dict, List, Optional
+
+from aiohttp import web
+
+import backend.core.ouroboros.governance.transport.exchange_protocol as xp
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import (
+    TransportConfig,
+)
+from backend.core.ouroboros.governance.transport.distributed_event_bus import (
+    DistributedEventBus,
+)
+from backend.core.ouroboros.governance.transport.durable_outbound import (
+    DurableOutbound,
+)
+
+OP = xp.EXCHANGE_OP_PREFIX + "task3"
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _cfg(monkeypatch, port: int, role: str) -> TransportConfig:
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HOST", "127.0.0.1")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", str(port))
+    monkeypatch.setenv("JARVIS_BRAIN_WS_HEARTBEAT_S", "1.0")
+    # Fast, deterministic reconnect cadence so re-race tests finish quickly.
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_BASE_S", "0.05")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_MAX_S", "0.2")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_RECONNECT_JITTER", "0")
+    return TransportConfig.from_env(role=role)
+
+
+async def _wait_for(cond: Callable[[], bool], timeout: float = 8.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if cond():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("condition not met within %.1fs" % timeout)
+
+
+async def _await_connected(bus: DistributedEventBus, timeout: float = 8.0) -> None:
+    def _is_connected() -> bool:
+        client = getattr(bus, "_client", None)
+        return client is not None and getattr(client, "connected", False)
+    await _wait_for(_is_connected, timeout=timeout)
+
+
+async def _start_server(
+    broker: StreamEventBroker, cfg: TransportConfig, port: int,
+) -> web.AppRunner:
+    bus = DistributedEventBus(broker, cfg, role="server")
+    app = web.Application()
+    bus.register_server_routes(app)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    # Small shutdown_timeout: the rediscovery test KILLS a server while a
+    # live WS is attached -- the default 60s drain would hang the test.
+    site = web.TCPSite(runner, host="127.0.0.1", port=port, shutdown_timeout=0.5)
+    await site.start()
+    return runner
+
+
+def _op_ids(broker: StreamEventBroker) -> List[str]:
+    return [ev.op_id for ev in broker.recent_history(limit=1000)
+            if xp.is_exchange_op(ev.op_id) or ev.op_id.startswith("trinity:")]
+
+
+async def _stop_client(bus: DistributedEventBus, task: asyncio.Task) -> None:
+    try:
+        await bus.stop()
+    except Exception:  # noqa: BLE001
+        pass
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):  # noqa: BLE001
+        pass
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+# --------------------------------------------------------------------------- #
+# (a) rediscovery: the resolver is consulted on EVERY attempt; a kill +
+#     restart on a DIFFERENT port is recovered by flipping the resolver's
+#     answer. The static url is a dead port throughout -- only re-raced
+#     discovery can connect at all.
+# --------------------------------------------------------------------------- #
+def test_rediscovery_reraces_resolver_each_attempt(monkeypatch):
+    async def scenario():
+        port_a, port_b, dead_port = _free_port(), _free_port(), _free_port()
+        server_cfg_a = _cfg(monkeypatch, port_a, "server")
+        server_cfg_b = _cfg(monkeypatch, port_b, "server")
+        # Static client cfg dials a DEAD port -- the resolver must win.
+        client_cfg = _cfg(monkeypatch, dead_port, "client")
+        path = client_cfg.path
+
+        target: Dict[str, str] = {"url": "ws://127.0.0.1:%d%s" % (port_a, path)}
+        calls = {"n": 0}
+
+        async def resolver() -> Optional[str]:
+            calls["n"] += 1
+            return target["url"]
+
+        client_broker = StreamEventBroker(history_maxlen=64)
+        broker_a = StreamEventBroker(history_maxlen=64)
+        broker_b = StreamEventBroker(history_maxlen=64)
+
+        runner_a = await _start_server(broker_a, server_cfg_a, port_a)
+        client_bus = DistributedEventBus(
+            client_broker, client_cfg, role="client", url_resolver=resolver)
+        task = asyncio.ensure_future(client_bus.start_client())
+        try:
+            await _await_connected(client_bus)
+            client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-a", {"p": 1})
+            await _wait_for(lambda: (OP + "-a") in _op_ids(broker_a))
+
+            # Kill A. The client's retries keep hitting the (now dead)
+            # resolver answer -- each attempt must RE-ASK the resolver.
+            await runner_a.cleanup()
+            calls_at_kill = calls["n"]
+            await asyncio.sleep(0.4)
+
+            # Restart on a DIFFERENT port and flip the resolver's answer.
+            runner_b = await _start_server(broker_b, server_cfg_b, port_b)
+            target["url"] = "ws://127.0.0.1:%d%s" % (port_b, path)
+            await _await_connected(client_bus)
+            assert calls["n"] > calls_at_kill, (
+                "resolver must be re-raced per reconnect attempt, not "
+                "consulted once: %d calls before kill, %d after"
+                % (calls_at_kill, calls["n"]))
+
+            client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-b", {"p": 2})
+            await _wait_for(lambda: (OP + "-b") in _op_ids(broker_b))
+            landed_on_b = (OP + "-b") in _op_ids(broker_b)
+            await runner_b.cleanup()
+            return landed_on_b
+        finally:
+            await _stop_client(client_bus, task)
+
+    assert _run(scenario()) is True, (
+        "reconnect must land on the resolver's NEW url (per-attempt re-race)")
+
+
+# --------------------------------------------------------------------------- #
+# (a2) resolver fail-soft: a raising resolver falls back to the static url.
+# --------------------------------------------------------------------------- #
+def test_resolver_failure_falls_back_to_static_url(monkeypatch):
+    async def scenario():
+        port = _free_port()
+        server_cfg = _cfg(monkeypatch, port, "server")
+        client_cfg = _cfg(monkeypatch, port, "client")
+
+        async def bad_resolver() -> Optional[str]:
+            raise RuntimeError("discovery service down")
+
+        client_broker = StreamEventBroker(history_maxlen=64)
+        server_broker = StreamEventBroker(history_maxlen=64)
+        runner = await _start_server(server_broker, server_cfg, port)
+        client_bus = DistributedEventBus(
+            client_broker, client_cfg, role="client", url_resolver=bad_resolver)
+        url = "ws://127.0.0.1:%d%s" % (port, client_cfg.path)
+        task = asyncio.ensure_future(client_bus.start_client(url))
+        try:
+            await _await_connected(client_bus)
+            client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-fs", {"p": 1})
+            await _wait_for(lambda: (OP + "-fs") in _op_ids(server_broker))
+            return True
+        finally:
+            await _stop_client(client_bus, task)
+            await runner.cleanup()
+
+    assert _run(scenario()) is True, (
+        "a raising resolver must fail-soft to the static url, not kill run()")
+
+
+# --------------------------------------------------------------------------- #
+# (b) WAL-seeded replay beyond broker history: 6 events published with NO
+#     server and the broker ring clamped to 2 -- broker replay alone CANNOT
+#     recover them. The WAL can. Server ends with ALL 6, exactly once each.
+# --------------------------------------------------------------------------- #
+def test_wal_seeded_replay_beyond_broker_history(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    monkeypatch.setenv("JARVIS_IDE_STREAM_HISTORY_MAXLEN", "2")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+    ops = ["trinity:wal-%d" % i for i in range(6)]
+
+    async def scenario():
+        port = _free_port()
+        server_cfg = _cfg(monkeypatch, port, "server")
+        client_cfg = _cfg(monkeypatch, port, "client")
+
+        client_broker = StreamEventBroker()  # env-clamped ring: 2 slots
+        server_broker = StreamEventBroker(history_maxlen=64)
+        durable = DurableOutbound(client_broker, wal_path=wal_path)
+        await durable.start()
+
+        # Publish ALL 6 while no server exists.
+        ids = [client_broker.publish("task_started", op, {"i": i})
+               for i, op in enumerate(ops)]
+        assert all(ids)
+        await _wait_for(lambda: durable.pending_count() == 6)
+        # Proof the ring CANNOT recover alone: only the last 2 survive it.
+        ring = [ev.op_id for ev in client_broker.recent_history(limit=100)]
+        assert len(ring) == 2, (
+            "precondition broken: broker ring must hold only 2, got %r" % ring)
+
+        # NOW the server comes up; the client connects with the WAL wired.
+        runner = await _start_server(server_broker, server_cfg, port)
+        client_bus = DistributedEventBus(
+            client_broker, client_cfg, role="client", durable_outbound=durable)
+        url = "ws://127.0.0.1:%d%s" % (port, client_cfg.path)
+        task = asyncio.ensure_future(client_bus.start_client(url))
+        try:
+            await _await_connected(client_bus)
+
+            def _counts() -> Dict[str, int]:
+                got = [ev.op_id for ev in server_broker.recent_history(limit=200)
+                       if ev.op_id in set(ops)]
+                return {op: got.count(op) for op in ops}
+
+            await _wait_for(lambda: all(c >= 1 for c in _counts().values()))
+            await asyncio.sleep(0.6)  # let any duplicate land before exactness
+            counts = _counts()
+        finally:
+            await _stop_client(client_bus, task)
+            await durable.stop()
+            await runner.cleanup()
+        return counts
+
+    counts = _run(scenario())
+    assert counts == {op: 1 for op in ops}, (
+        "server must hold ALL 6 WAL-carried events exactly once, got %r"
+        % counts)
+
+
+# --------------------------------------------------------------------------- #
+# (c) legacy shape: no durable, no resolver -> Stage-2 behavior intact
+#     (default construction path still connects + mirrors an event).
+# --------------------------------------------------------------------------- #
+def test_legacy_shape_no_durable_no_resolver(monkeypatch):
+    async def scenario():
+        port = _free_port()
+        server_cfg = _cfg(monkeypatch, port, "server")
+        client_cfg = _cfg(monkeypatch, port, "client")
+        client_broker = StreamEventBroker(history_maxlen=64)
+        server_broker = StreamEventBroker(history_maxlen=64)
+        runner = await _start_server(server_broker, server_cfg, port)
+        client_bus = DistributedEventBus(client_broker, client_cfg, role="client")
+        url = "ws://127.0.0.1:%d%s" % (port, client_cfg.path)
+        task = asyncio.ensure_future(client_bus.start_client(url))
+        try:
+            await _await_connected(client_bus)
+            client = client_bus._client
+            assert getattr(client, "_durable", "MISSING") is None
+            assert getattr(client, "_url_resolver", "MISSING") is None
+            client_broker.publish(xp.EXCHANGE_EVENT_TYPE, OP + "-legacy", {"p": 1})
+            await _wait_for(lambda: (OP + "-legacy") in _op_ids(server_broker))
+            return True
+        finally:
+            await _stop_client(client_bus, task)
+            await runner.cleanup()
+
+    assert _run(scenario()) is True

--- a/tests/infra/test_run_body_mode.py
+++ b/tests/infra/test_run_body_mode.py
@@ -10,11 +10,30 @@ driver's seams (the ``BrainIgnitionDriver`` seam pattern). The tests prove:
       clears against a fake client; ``--inject-test-signal 3`` produces exactly
       3 ``shim.ingest`` calls whose envelopes carry 3 DISTINCT dedup_keys; the
       run exits 0 and emits the ``[BodyMode] SUMMARY`` line.
-  (c) Discovery failure -> exit 2 with the "Brain offline" log.
-  (d) Connect-gate timeout -> exit 3.
+  (c) Discovery failure -> exit 2 with the "Brain offline" log (STRICT
+      contract: applies because these seams arm no durable WAL).
+  (d) Connect-gate timeout -> exit 3 (same strict contract).
 
-The live discovery/bus/bridge paths are proven by the Stage-2 live-fire
-acceptance, not here.
+Stage-3 Task 4 (durable degrade) additions:
+
+  (e) Census line includes ``queued=N`` from the injected durable's
+      ``pending_count()``; SUMMARY gains ``queued_at_exit=N``.
+  (f) Offline-at-start with the WAL armed -> NO exit 2: the driver
+      degrades, signals journal via the fake durable, and the canonical
+      "Brain offline" line is logged exactly once.
+  (g) --require-brain restores the strict exit-2 contract even with the
+      WAL armed.
+  (h) Edge-transition determinism: the degrade UI state derives ONLY
+      from the client's ``connected`` property, polled exactly once per
+      census tick -- one offline line + one reconnected line per
+      episode, no repeats while steady.
+
+The live discovery/bus/bridge/WAL paths are proven by the Stage-2/3
+live-fire acceptance and the real-component transport suites, not here.
+The fake shim->durable wiring below simulates the live journal chain
+(shim -> trinity bus -> bridge -> broker -> DurableOutbound), which is
+itself proven by test_trinity_bus_bridge.py + test_durable_outbound.py;
+these tests prove the DRIVER's composition and surfacing only.
 """
 from __future__ import annotations
 
@@ -66,17 +85,68 @@ class _FakeClient:
         self.connected = connected
 
 
+class _ScriptedClient:
+    """``connected`` consumes one scripted value per read and holds the
+    last value once the script is exhausted. Determinism contract with
+    the driver: the connect gate reads ``connected`` until True; the
+    census loop reads it EXACTLY once per tick (a single poll feeds both
+    the edge machine and the census line)."""
+
+    def __init__(self, script: List[bool]) -> None:
+        self._script = list(script)
+        self._last = self._script[-1] if self._script else False
+
+    @property
+    def connected(self) -> bool:
+        if self._script:
+            self._last = self._script.pop(0)
+        return self._last
+
+
+class _FakeDurable:
+    """Duck-types the DurableOutbound surface the driver composes:
+    ``start``/``stop`` lifecycle + ``pending_count`` (census / summary)
+    + ``on_ack`` (threaded by the real DistributedEventBus, unused by
+    the fakes). ``record`` is the fake journal-chain terminus."""
+
+    def __init__(self, queued: Optional[int] = None) -> None:
+        self.started = False
+        self.stopped = False
+        self.journaled: List[str] = []
+        self._queued = queued
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+    def record(self, dedup_key: str) -> None:
+        self.journaled.append(dedup_key)
+
+    def pending_count(self) -> int:
+        if self._queued is not None:
+            return self._queued
+        return len(self.journaled)
+
+    def on_ack(self, acked_event_id: str) -> None:  # pragma: no cover
+        pass
+
+
 class _FakeDistBus:
     """Duck-types the DistributedEventBus client surface the driver uses:
     ``start_client`` (long-running) + ``_client`` attr with ``connected``."""
 
-    def __init__(self, connect: bool = True) -> None:
-        self._client = _FakeClient(connected=True) if connect else None
-        self.started_urls: List[str] = []
+    def __init__(self, connect: bool = True, client: Any = None) -> None:
+        if client is not None:
+            self._client = client
+        else:
+            self._client = _FakeClient(connected=True) if connect else None
+        self.started_urls: List[Any] = []
         self.stopped = False
         self._forever = asyncio.Event()
 
-    async def start_client(self, url: str) -> None:
+    async def start_client(self, url: Optional[str]) -> None:
         self.started_urls.append(url)
         await self._forever.wait()  # long-running, like the real client task
 
@@ -106,11 +176,17 @@ class _FakeBridge:
 
 
 class _FakeShim:
-    def __init__(self) -> None:
+    def __init__(self, durable: Optional[_FakeDurable] = None) -> None:
         self.envelopes: List[Any] = []
+        # Simulates the live journal chain terminus (shim -> trinity bus
+        # -> bridge -> broker -> DurableOutbound); the real chain is
+        # proven by the transport suites -- here we test the driver.
+        self._durable = durable
 
     async def ingest(self, envelope: Any) -> str:
         self.envelopes.append(envelope)
+        if self._durable is not None:
+            self._durable.record(envelope.dedup_key)
         return "enqueued"
 
 
@@ -133,12 +209,19 @@ class _FakeWatchdog:
 
 
 def _seams(*, url: Optional[str] = "wss://10.0.0.5:8770/ws/trinity-bus",
-           connect: bool = True):
-    """A full fake seam kit; returns (kwargs, recorder namespace)."""
+           connect: bool = True,
+           durable: Optional[_FakeDurable] = None,
+           client: Any = None):
+    """A full fake seam kit; returns (kwargs, recorder namespace).
+
+    ``durable`` arms the WAL seam (Stage-3 degrade contract); without it
+    the driver stays on the strict Stage-2 exit-2/exit-3 contract.
+    ``client`` overrides the dist bus's ``_client`` (edge scripting).
+    """
     calls = {"discover": 0}
-    dist = _FakeDistBus(connect=connect)
+    dist = _FakeDistBus(connect=connect, client=client)
     bridge = _FakeBridge()
-    shim = _FakeShim()
+    shim = _FakeShim(durable=durable)
     wd = _FakeWatchdog()
 
     async def _discover() -> Optional[str]:
@@ -168,8 +251,10 @@ def _seams(*, url: Optional[str] = "wss://10.0.0.5:8770/ws/trinity-bus",
         sensor_factory=_sensor_factory,
         watchdog_factory=_watchdog_factory,
     )
+    if durable is not None:
+        kwargs["durable_factory"] = lambda broker: durable
     ns = type("NS", (), dict(calls=calls, dist=dist, bridge=bridge,
-                             shim=shim, wd=wd))
+                             shim=shim, wd=wd, durable=durable))
     return kwargs, ns
 
 
@@ -264,3 +349,112 @@ def test_connect_gate_timeout_exits_3(capsys, monkeypatch):
     assert rc == 3
     assert ns.shim.envelopes == [], "no signals on a dark link"
     assert not ns.bridge.started, "bridge must not start on a dark link"
+
+
+# ---------------------------------------------------------------------------
+# (e) Task 4: census line includes queued= from the injected durable;
+#     SUMMARY gains queued_at_exit=.
+# ---------------------------------------------------------------------------
+
+
+def test_census_includes_queued_from_fake_durable(capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    durable = _FakeDurable(queued=7)
+    kwargs, ns = _seams(durable=durable)
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert "queued=7" in out, "census must surface durable.pending_count()"
+    assert "connected=True" in out
+    assert "queued_at_exit=7" in out, "SUMMARY must carry the exit depth"
+    assert durable.started, "driver must arm the durable WAL"
+    assert durable.stopped, "driver must disarm the durable WAL on teardown"
+
+
+# ---------------------------------------------------------------------------
+# (f) Task 4: offline-at-start with the WAL armed -> NO exit 2. The driver
+#     degrades: signals journal via the (fake) durable chain, the client
+#     starts with no static url (re-racing via url_resolver), and the
+#     canonical "Brain offline" line is logged exactly once.
+# ---------------------------------------------------------------------------
+
+
+def test_offline_at_start_with_wal_armed_degrades_without_exit_2(
+        capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    durable = _FakeDurable()
+    kwargs, ns = _seams(url=None, connect=False, durable=durable)
+    driver = bm.BodyModeDriver(inject_test_signals=5, duration_s=0.1, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+
+    assert rc == 0, "WAL armed: discovery failure must NOT exit 2"
+    assert out.count("Brain offline") == 1, (
+        "the offline episode must surface exactly once: %r" % out)
+    assert "signals queued (durable)" in out
+    assert len(ns.shim.envelopes) == 5, "signals still flow while offline"
+    assert durable.journaled == [e.dedup_key for e in ns.shim.envelopes], (
+        "every accepted signal must journal durably")
+    assert "queued=5" in out and "connected=False" in out
+    assert "queued_at_exit=5" in out
+    # The client is started with no static url -- it re-races discovery
+    # via the url_resolver seam instead of the driver exiting.
+    assert ns.dist.started_urls == [None]
+    assert ns.bridge.started, "bridge runs in degraded mode (WAL is the sink)"
+
+
+# ---------------------------------------------------------------------------
+# (g) Task 4: --require-brain restores the strict exit-2 contract even
+#     with the WAL armed.
+# ---------------------------------------------------------------------------
+
+
+def test_require_brain_restores_exit_2(capsys):
+    durable = _FakeDurable()
+    kwargs, ns = _seams(url=None, durable=durable)
+    driver = bm.BodyModeDriver(require_brain=True, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 2
+    assert "Brain offline" in out and "(exit 2)" in out
+    assert ns.dist.started_urls == [], "strict contract: no connect attempt"
+    assert not durable.started, "strict exit precedes WAL arming"
+
+
+def test_require_brain_cli_flag_parses():
+    parser = bm.build_arg_parser()
+    assert parser.parse_args(["--require-brain"]).require_brain is True
+    assert parser.parse_args([]).require_brain is False
+
+
+# ---------------------------------------------------------------------------
+# (h) Task 4: edge-transition determinism. The degrade UI state derives
+#     ONLY from the client's `connected` property (set/cleared at WS
+#     establishment/teardown -- the transport closure), polled exactly
+#     once per census tick. True->False->True across ticks -> exactly one
+#     offline line + one reconnected line, no repeats while steady.
+# ---------------------------------------------------------------------------
+
+
+def test_edge_transitions_log_exactly_once_per_episode(capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    durable = _FakeDurable(queued=3)
+    # Read schedule: gate(True), initial(True), tick1(True: steady),
+    # tick2(False: offline edge), tick3(False: steady -- no repeat),
+    # tick4(True: reconnect edge), then holds True for remaining ticks.
+    client = _ScriptedClient([True, True, True, False, False, True])
+    kwargs, ns = _seams(durable=durable, client=client)
+    driver = bm.BodyModeDriver(duration_s=0.25, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    assert out.count("Brain offline") == 1, (
+        "exactly one offline line per episode: %r" % out)
+    assert out.count("Brain reconnected") == 1, (
+        "exactly one reconnected line per episode: %r" % out)
+    # Both census states were surfaced during the run.
+    assert "connected=False" in out and "connected=True" in out

--- a/tests/infra/test_run_body_mode.py
+++ b/tests/infra/test_run_body_mode.py
@@ -423,6 +423,26 @@ def test_require_brain_restores_exit_2(capsys):
     assert not durable.started, "strict exit precedes WAL arming"
 
 
+def test_require_brain_restores_exit_3_on_gate_timeout(capsys, monkeypatch):
+    """Symmetric strict pin (review round): WAL armed + --require-brain +
+    a never-connecting client -> the connect-gate timeout still exits 3
+    (no durable degrade)."""
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "0.2")
+    durable = _FakeDurable()
+    kwargs, ns = _seams(connect=False, durable=durable)  # _client never appears
+    driver = bm.BodyModeDriver(
+        require_brain=True, inject_test_signals=1, duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 3
+    assert "(exit 3)" in out
+    assert ns.shim.envelopes == [], "no signals on a dark link"
+    assert not ns.bridge.started, "bridge must not start on a dark link"
+    # The WAL arms before the gate (journal-at-publish coverage) and is
+    # disarmed on the exit-3 teardown path.
+    assert durable.started and durable.stopped
+
+
 def test_require_brain_cli_flag_parses():
     parser = bm.build_arg_parser()
     assert parser.parse_args(["--require-brain"]).require_brain is True


### PR DESCRIPTION
## Stage 3: the link survives failure (ships DARK)

- **Ack lane armed** — the Stage-0 codec's dormant FRAME_ACK (reserved for exactly this) now carries the server's per-connection ingest cursor; client consumes monotonically.
- **DurableOutbound** — journal-at-publish WAL (intake `WAL` class reused verbatim: flock-journaled, fsync on compaction), ack-driven trim, at-risk retry honesty (Critical false-durability hole found by review reproduction and closed), dynamic disk-fraction capacity with offloaded probes — zero byte literals (grep-enforced by test).
- **WAL-seeded reconnect replay + per-attempt discovery re-race** — replay proven past a deliberately 2-slot broker ring; the static-URL redial violation is dead.
- **Body-mode durable degrade** — deterministic connected-property edge transitions (operator mandate: zero try/except-driven UI state, single-poll-per-tick proven by scripted-client desync guard), `queued=` census, `--require-brain` strict mode.
- **The deliberate-partition suite** — 4 legs, opus-adjudicated non-vacuous: mid-stream kill with 4-conjoined set-equality on the full 30-id multiset; body-death disk-truth; real HMAC checkpoint one-byte-tamper fail-closed + exactly-once hydrate; same-server double-replay (the hard case). 3× flake-immune.

Final whole-branch review (opus): READY, 0 Critical / 0 Important; cumulative-ack honesty proven by TCP ordering; all four operator mandates verified. 35 branch tests + 70 transport suite green.

Next: Task 6 paid live-fire (firewall-close partition + mid-op systemctl restart) under the ledgered runbook constraints.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the event bus to survive partitions and restarts: adds a durable publish-time WAL with ack-driven trim, arms the ACK lane, seeds reconnect replay from the WAL, and makes body mode degrade deterministically with a queued census.

- **New Features**
  - ACK lane: server sends per-connection ingest-cursor acks; client advances monotonically and exposes an `on_ack` hook. Tune with `JARVIS_BUS_ACK_EVERY_N` or `JARVIS_BUS_ACK_INTERVAL_S`.
  - Durable outbound WAL (`DurableOutbound`): journal-at-publish with fsync; ack-driven tombstone/trim; retries at-risk entries until acked; disk-fraction capacity guard with offloaded probes and warn-once; `journal_filter` excludes peer-republished events (fail-open + warn-once).
  - Reconnect resilience: client re-races `url_resolver` on every attempt; after hello, replays WAL `pending()` in id order before live pump; resolver exceptions fall back to the static URL.
  - Body mode degrade: default wires the WAL and `url_resolver` into `DistributedEventBus`; offline-at-start no longer exits 2—signals journal and retry continues; `--require-brain` restores strict exits; census shows `connected` and `queued`.
  - Tests: adds ACK lane, WAL replay/rediscovery, durable WAL, and a deliberate-partition suite asserting exactness across kill/crash/suspend/double-replay scenarios.

- **Migration**
  - If you depend on exit 2 when the Brain is offline at start, run with `--require-brain`.
  - Optionally set `JARVIS_BUS_ACK_EVERY_N` and/or `JARVIS_BUS_ACK_INTERVAL_S` to tune ack cadence.
  - Custom `DistributedEventBus` clients can pass `durable_outbound` and `url_resolver`; defaults keep prior behavior.

<sup>Written for commit e95770d284f1bebedc1fff3517328877d7c16173. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

