### PR TITLE
fix(stage3): cross-lifetime event identity (WAL-seeded broker seq) + heartbeat-driven ack cadence (live-fire findings)

### DIFF
--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -1819,6 +1819,7 @@ class StreamEventBroker:
         history_maxlen: Optional[int] = None,
         max_subscribers: Optional[int] = None,
         queue_maxsize: Optional[int] = None,
+        initial_event_seq: int = 0,
     ) -> None:
         self._history_maxlen = history_maxlen or _history_maxlen()
         self._max_subscribers = max_subscribers or _max_subscribers()
@@ -1828,7 +1829,20 @@ class StreamEventBroker:
         self._history: Deque[StreamEvent] = deque(maxlen=self._history_maxlen)
         self._subscribers: Dict[int, _Subscriber] = {}
         self._next_sub_id: int = 0
-        self._next_event_seq: int = 0
+        # Stage-3 Task 7 (cross-lifetime identity, live-fire finding A):
+        # a fresh broker in a restarted process minted the SAME 012x ids
+        # a previous lifetime already journaled into the durable outbound
+        # WAL -- new publishes were skipped as already-pending (silent
+        # loss during a partition) and would poison the far side's
+        # qualified-id dedup. Callers that persist event ids across
+        # lifetimes seed this with the WAL high-water mark
+        # (durable_outbound.wal_high_water) so every new lifetime mints
+        # strictly-greater ids. Purely additive: default 0 is the
+        # legacy in-memory behavior; non-int / negative fails soft to 0.
+        try:
+            self._next_event_seq: int = max(0, int(initial_event_seq))
+        except (TypeError, ValueError):
+            self._next_event_seq = 0
         self._lock = threading.Lock()
         self._published_count: int = 0
         self._dropped_count: int = 0

--- a/backend/core/ouroboros/governance/transport/bus_bridge_server.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_server.py
@@ -189,6 +189,27 @@ class BusBridgeServer:
                             ack_deadline = now + _ack_interval_s()
                 elif frame.kind == bf.FRAME_HEARTBEAT:
                     await ws.send_bytes(bf.heartbeat_frame(self._cfg.source_id).encode())
+                    # Stage-3 Task 7, live-fire finding B (ack starvation):
+                    # the interval cadence used to be evaluated ONLY in the
+                    # FRAME_EVENT branch -- a burst below EVERY_N followed by
+                    # silence never re-entered that branch, so the pending
+                    # ack never fired and the peer's durable WAL never
+                    # trimmed. Heartbeats flow continuously (the client sends
+                    # them on its heartbeat_s cadence), so evaluating the
+                    # SAME interval check here bounds ack latency to
+                    # ~JARVIS_BUS_ACK_INTERVAL_S even on an idle-after-burst
+                    # connection. Fires ONLY when un-acked ingest state
+                    # exists (cursor set + events pending since last ack).
+                    if (conn_last_eid and ack_pending
+                            and time.monotonic() >= ack_deadline):
+                        try:
+                            await ws.send_bytes(
+                                bf.ack_frame(self._cfg.source_id, conn_last_eid).encode()
+                            )
+                        except Exception:  # noqa: BLE001 -- a failed ack send must never kill the WS loop
+                            logger.debug("[BusBridgeServer] ack send failed", exc_info=True)
+                        ack_pending = 0
+                        ack_deadline = time.monotonic() + _ack_interval_s()
                 # FRAME_ACK: the server only EMITS acks (above); it does not
                 # consume inbound acks from the peer in Stage 3 Task 1 -- a
                 # symmetric client->server ack lane is not part of this arc.

--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -56,6 +56,7 @@ Env knobs:
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import shutil
@@ -101,6 +102,63 @@ def _env_int(name: str, default: int) -> int:
         return int(os.environ.get(name, str(default)))
     except (TypeError, ValueError):
         return default
+
+
+def wal_high_water(wal_path: Any) -> int:
+    """Highest event-id sequence EVER journaled into the WAL at ``wal_path``.
+
+    Stage-3 Task 7 (cross-lifetime identity, live-fire finding A): the
+    broker's event-id sequence is in-memory and restarts at 0 every
+    process lifetime, while the WAL (and the far side's qualified-id
+    dedup) remember ids across lifetimes. A restarted Body re-minted ids
+    a previous lifetime had already journaled -- new publishes were
+    skipped by ``_journal_event`` as already-pending (published but
+    UNJOURNALED: silent loss during a partition). Seeding
+    ``StreamEventBroker(initial_event_seq=wal_high_water(path))`` makes
+    every new lifetime mint ids strictly above every id ever journaled.
+
+    Scans ALL records regardless of status -- acked / dead_letter
+    tombstones included: an id that was EVER minted must never be minted
+    again, trimmed or not. Parses ``lease_id`` as base-16 (event ids are
+    zero-padded 012x hex). Tolerant line-by-line parse mirroring
+    ``WAL.pending_entries``: blank / corrupt / non-hex lines are skipped.
+    Returns 0 for a missing or empty file. NEVER raises (fail-soft:
+    an unreadable WAL degrades to the legacy 0 seed).
+    """
+    high = 0
+    try:
+        path = Path(wal_path)
+        if not path.exists():
+            return 0
+        with path.open("r", encoding="utf-8") as f:
+            for line_no, line in enumerate(f, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    record = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.debug(
+                        "[wal_high_water] corrupt entry at line %d, "
+                        "skipping", line_no)
+                    continue
+                if not isinstance(record, dict):
+                    continue
+                lease_id = record.get("lease_id", "")
+                if not isinstance(lease_id, str) or not lease_id:
+                    continue
+                if not set(lease_id) <= _HEX_DIGITS:
+                    continue  # non-hex control ids never seed the broker
+                try:
+                    value = int(lease_id, 16)
+                except ValueError:
+                    continue
+                if value > high:
+                    high = value
+    except Exception:  # noqa: BLE001 -- fail-soft: seed degrades to 0
+        logger.debug("[wal_high_water] scan failed for %r", wal_path,
+                     exc_info=True)
+    return high
 
 
 def _probe_disk(wal_path_str: str) -> Tuple[Optional[int], int]:

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -184,7 +184,18 @@ class BodyModeDriver:
             TransportConfig,
         )
         trinity_bus = await get_trinity_event_bus()
-        broker = StreamEventBroker()
+        # Stage-3 Task 7 (cross-lifetime identity, live-fire finding A):
+        # resolve the WAL path FIRST and seed the broker's event-id
+        # sequence at the WAL high-water mark, so a restarted Body never
+        # re-mints an id a previous lifetime already journaled (re-minted
+        # ids were skipped as already-pending -- published-but-unjournaled
+        # signals were silently lost during a partition, and the far
+        # side's qualified-id dedup would drop the new events as
+        # replays). Scan runs OFF-loop through the cooperative_fs_io
+        # substrate; a broken offload falls back to the one-time inline
+        # boot read (wal_high_water is itself fail-soft -> 0).
+        broker = StreamEventBroker(
+            initial_event_seq=await self._wal_high_water_seed())
         # Stage-3: build the durable WAL FIRST so the client constructor
         # receives it (WAL-seeded replay + on_ack trim, Task 3), and
         # thread the discovery re-race resolver (per-attempt).
@@ -197,6 +208,38 @@ class BodyModeDriver:
             url_resolver=self._do_discover,
         )
         return trinity_bus, broker, dist_bus
+
+    async def _wal_high_water_seed(self) -> int:
+        """Live-default broker seed (Stage-3 Task 7): the max event id
+        EVER journaled into the durable outbound WAL -- tombstoned
+        entries included. Resolves the SAME default WAL path the live
+        DurableOutbound uses (``_default_wal_path``), so the seed and
+        the journal always agree. Fail-soft: any failure degrades to 0
+        (the legacy in-memory seed) rather than killing the driver."""
+        try:
+            from backend.core.ouroboros.governance.transport.durable_outbound import (  # noqa: PLC0415
+                _default_wal_path,
+                wal_high_water,
+            )
+        except Exception as exc:  # noqa: BLE001 -- fail-soft
+            _log("WAL high-water seed unavailable (fail-soft): %s" % exc)
+            return 0
+        wal_path = _default_wal_path()
+        try:
+            from backend.core.ouroboros.governance.cooperative_fs_io import (  # noqa: PLC0415
+                is_offload_error,
+                offload,
+            )
+            result = await offload(wal_high_water, str(wal_path))
+            seed = wal_high_water(wal_path) if is_offload_error(result) \
+                else int(result)
+        except Exception:  # noqa: BLE001 -- offload substrate unavailable:
+            # one-time bounded boot read inline (wal_high_water never raises)
+            seed = wal_high_water(wal_path)
+        if seed:
+            _log("broker event-seq seeded at %d (WAL high-water -- "
+                 "cross-lifetime identity)" % seed)
+        return seed
 
     def _wal_arming_intended(self) -> bool:
         """Structural arming intent, decided BEFORE anything is built:

--- a/tests/governance/transport/test_ack_lane.py
+++ b/tests/governance/transport/test_ack_lane.py
@@ -150,6 +150,69 @@ def test_ack_cursor_advances_to_last_ingested_event(monkeypatch):
 
 
 # --------------------------------------------------------------------------- #
+# (a2) Stage 3 Task 7, live-fire finding B (ack starvation): a burst BELOW
+#      the counter cadence followed by silence never re-enters the
+#      FRAME_EVENT branch, so the interval cadence never fired and the
+#      client's WAL never trimmed. The fix evaluates the same interval
+#      check in the FRAME_HEARTBEAT branch -- heartbeats flow continuously
+#      on the client's heartbeat_s cadence, so an idle-after-burst
+#      connection acks within ~JARVIS_BUS_ACK_INTERVAL_S. WITHOUT the fix
+#      this test times out: at most one interval ack can fire inside the
+#      3-event burst itself, and it can never cover the 3rd id.
+# --------------------------------------------------------------------------- #
+def test_heartbeat_drives_interval_ack_after_idle_burst(monkeypatch):
+    monkeypatch.setenv("JARVIS_BUS_ACK_EVERY_N", "16")  # burst of 3 << 16
+    monkeypatch.setenv("JARVIS_BUS_ACK_INTERVAL_S", "0.3")
+
+    async def scenario():
+        harness = _ServerHarness()
+        await harness.start()
+
+        client_broker = StreamEventBroker(history_maxlen=1024)
+        acked: List[str] = []
+        client = BusBridgeClient(
+            client_broker,
+            # Small client heartbeat cadence: the client's idle outbound
+            # pump keeps sending FRAME_HEARTBEATs, which now carry the
+            # server's interval-cadence ack evaluation.
+            _cfg(port=harness.port, heartbeat_s=0.1),
+            url=harness.url, on_ack=acked.append,
+        )
+        run_task = asyncio.ensure_future(client.run())
+        try:
+            await _await_connected(client)
+
+            event_ids = []
+            for i in range(3):  # burst-then-idle: NO further events
+                eid = client_broker.publish(
+                    xp.EXCHANGE_EVENT_TYPE, OP + f"-hb-{i}", {"i": i})
+                assert eid
+                event_ids.append(eid)
+
+            # Bounded condition-poll: the 3rd id must be acked with NO
+            # further event traffic -- heartbeats alone must trip the
+            # interval cadence.
+            deadline = asyncio.get_event_loop().time() + 3.0
+            while (asyncio.get_event_loop().time() < deadline
+                   and client.last_acked_id != event_ids[-1]):
+                await asyncio.sleep(0.05)
+
+            last_acked = client.last_acked_id
+        finally:
+            await _stop_client(client, run_task)
+            await harness.stop()
+        return last_acked, list(acked), event_ids
+
+    last_acked, acked, event_ids = asyncio.get_event_loop().run_until_complete(scenario())
+    assert last_acked == event_ids[-1], (
+        f"burst-then-idle must still ack the last ingested id via the "
+        f"heartbeat-driven interval cadence: got {last_acked!r}, "
+        f"want {event_ids[-1]!r}")
+    assert len(acked) >= 1, "on_ack must fire without any post-burst events"
+    assert acked == sorted(acked), f"ack ids must stay monotonic: {acked!r}"
+
+
+# --------------------------------------------------------------------------- #
 # (b) monotonic guard: a regressive/duplicate ack must not move the cursor
 #     or re-fire on_ack. Unit-level -- hand-deliver ack frames straight into
 #     _apply_ack, no network needed for this half of the contract.

--- a/tests/governance/transport/test_cross_lifetime_identity.py
+++ b/tests/governance/transport/test_cross_lifetime_identity.py
@@ -1,0 +1,247 @@
+# -*- coding: utf-8 -*-
+"""Stage 3 Task 7, live-fire finding A: CROSS-LIFETIME EVENT-ID COLLISION.
+
+StreamEventBroker mints event ids from an in-memory sequence that
+restarts at 0 every process lifetime, while the durable outbound WAL
+(and the far side's qualified-id dedup) remember ids ACROSS lifetimes.
+Live fire proved the failure: Body-mode process 1 journaled events
+000000000001..03 and exited; process 2 on the same WAL path recovered
+those 3 as pending, then its fresh broker minted the SAME ids for 3
+brand-new events -- ``DurableOutbound._journal_event`` skipped them as
+already-pending, so they were published-but-unjournaled: silent loss
+during a partition.
+
+The fix is monotonic identity across lifetimes:
+  * ``durable_outbound.wal_high_water(path)`` -- the max id EVER
+    journaled (any status, tombstones included), base-16 parse,
+    corrupt-line tolerant, 0 for missing/empty (fail-soft).
+  * ``StreamEventBroker(initial_event_seq=...)`` -- additive seed.
+  * scripts/run_body_mode.py live default seeds the broker with the
+    WAL high-water BEFORE constructing the durable outbound.
+
+Suite map:
+  (a) wal_high_water: max-ever incl. tombstoned; missing file -> 0;
+      corrupt / non-hex lines skipped
+  (b) THE COLLISION REPRO (RED proof): an UNSEEDED lifetime-2 broker
+      re-mints lifetime-1's exact ids and the journal silently skips
+      the new events (pending stays 3)
+  (c) THE FIX (GREEN): a lifetime-2 broker seeded via wal_high_water
+      journals 3 NEW events -> pending_count()==6, all 6 lease ids
+      distinct
+  (d) a seeded broker mints strictly-greater ids, 012x format preserved
+
+Real broker + real DurableOutbound + real WAL file, no mocks -- the
+in-proc fakes masked exactly this class of bug earlier this stage.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Callable, List
+
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.intake.wal import WAL, WALEntry
+from backend.core.ouroboros.governance.transport.durable_outbound import (
+    DurableOutbound,
+    wal_high_water,
+)
+
+_EVENT_TYPE = "task_started"  # valid broker type (see trinity_bus_bridge)
+_PREFIX = "trinity:"
+
+
+async def _wait_for(cond: Callable[[], bool], timeout: float = 5.0) -> None:
+    deadline = asyncio.get_event_loop().time() + timeout
+    while asyncio.get_event_loop().time() < deadline:
+        if cond():
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("condition not met within %.1fs" % timeout)
+
+
+def _run(coro: Any) -> Any:
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _pending_ids(outbound: DurableOutbound) -> List[str]:
+    return [d["event_id"] for d in outbound.pending()]
+
+
+def _append(wal: WAL, event_id: str) -> None:
+    wal.append(WALEntry(
+        lease_id=event_id,
+        envelope_dict={"event_id": event_id},
+        status="pending",
+        ts_monotonic=time.monotonic(),
+        ts_utc=datetime.now(timezone.utc).isoformat(),
+    ))
+
+
+async def _lifetime_publish(
+    wal_path: str, n: int, *, initial_event_seq: int = 0,
+) -> List[str]:
+    """One full process lifetime: fresh broker (optionally seeded) +
+    fresh DurableOutbound on ``wal_path``; publish ``n`` bridgeable
+    events; wait for the journal consumer to settle; tear down."""
+    broker = StreamEventBroker(
+        history_maxlen=64, initial_event_seq=initial_event_seq)
+    outbound = DurableOutbound(broker, wal_path=wal_path)
+    await outbound.start()
+    try:
+        ids = []
+        for i in range(n):
+            eid = broker.publish(_EVENT_TYPE, _PREFIX + "t-%d" % i, {"i": i})
+            assert eid, "publish must accept a valid bridgeable event"
+            ids.append(eid)
+        # Settle: drain the journal consumer past the last publish. A
+        # count-based wait cannot be used here -- the COLLISION case is
+        # precisely the one where the count does NOT advance.
+        await _wait_for(lambda: outbound._sub.queue.qsize() == 0)
+        await asyncio.sleep(0.1)
+        return ids
+    finally:
+        await outbound.stop()  # simulated crash/exit boundary
+
+
+# --------------------------------------------------------------------------- #
+# (a) wal_high_water: the max id EVER journaled -- ANY status. Tombstoned
+#     (acked / dead_letter) ids count: an id that was ever minted must never
+#     be minted again, trimmed or not.
+# --------------------------------------------------------------------------- #
+def test_wal_high_water_is_max_ever_including_tombstoned(tmp_path):
+    wal_path = tmp_path / "body_wal.jsonl"
+    wal = WAL(wal_path)
+    _append(wal, "000000000001")
+    _append(wal, "00000000000a")  # 10 -- hex parse, not lexical/decimal
+    _append(wal, "000000000003")
+    wal.update_status("00000000000a", "acked")       # tombstone the max
+    wal.update_status("000000000003", "dead_letter")  # and another
+
+    assert wal_high_water(wal_path) == 10, (
+        "high-water must be the max id EVER seen (base-16), tombstoned "
+        "entries included")
+    # Sanity: the tombstoned max is invisible to pending-based recovery --
+    # exactly why the seed must scan ALL records, not the pending set.
+    assert "00000000000a" not in [e.lease_id for e in wal.pending_entries()]
+
+
+def test_wal_high_water_missing_and_empty_file_return_zero(tmp_path):
+    assert wal_high_water(tmp_path / "does_not_exist.jsonl") == 0
+    empty = tmp_path / "empty.jsonl"
+    empty.write_text("", encoding="utf-8")
+    assert wal_high_water(empty) == 0
+    assert wal_high_water(str(empty)) == 0, "str paths must work too"
+
+
+def test_wal_high_water_skips_corrupt_and_non_hex_lines(tmp_path):
+    wal_path = tmp_path / "body_wal.jsonl"
+    good = {
+        "v": 1, "lease_id": "000000000005", "envelope": {},
+        "status": "pending", "ts_monotonic": 0.0, "ts_utc": "",
+    }
+    lines = [
+        "{not json at all",                                   # corrupt
+        json.dumps({"v": 1, "status": "pending"}),            # no lease_id
+        json.dumps(dict(good, lease_id="hb:not-hex")),        # non-hex id
+        json.dumps(dict(good, lease_id="ZZZZ")),              # non-hex id
+        json.dumps(good),                                     # the real max
+        "",                                                   # blank
+        json.dumps(dict(good, lease_id="000000000002")),
+        json.dumps([1, 2, 3]),                                # non-dict record
+    ]
+    wal_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+    assert wal_high_water(wal_path) == 5, (
+        "corrupt / non-hex / malformed lines must be skipped, valid max kept")
+
+
+# --------------------------------------------------------------------------- #
+# (b) THE COLLISION REPRO (RED proof -- the bug exists without the seed):
+#     lifetime 1 journals 3; lifetime 2 with an UNSEEDED broker re-mints the
+#     SAME ids 01..03 for 3 brand-new events -> the journal skips them as
+#     already-pending. pending stays 3 = published-but-unjournaled during a
+#     partition = SILENT LOSS.
+# --------------------------------------------------------------------------- #
+def test_unseeded_second_lifetime_collides_and_silently_drops(
+        tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    async def scenario():
+        first_ids = await _lifetime_publish(wal_path, 3)
+        # Lifetime 2: same WAL path, fresh UNSEEDED broker (seq back at 0).
+        second_ids = await _lifetime_publish(wal_path, 3)
+        probe = DurableOutbound(
+            StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+        return first_ids, second_ids, probe.pending_count()
+
+    first_ids, second_ids, count = _run(scenario())
+    assert second_ids == first_ids, (
+        "RED proof: the unseeded lifetime-2 broker re-mints lifetime-1's "
+        "exact ids -- the cross-lifetime collision is real")
+    assert count == 3, (
+        "RED proof: 6 accepted publishes but only 3 journaled -- the 3 "
+        "colliding NEW events were silently skipped as already-pending "
+        "(the live-fire silent-loss failure)")
+
+
+# --------------------------------------------------------------------------- #
+# (c) THE FIX (GREEN): lifetime 2 seeds its broker at wal_high_water(path)
+#     -> 3 NEW events journal alongside the 3 recovered ones:
+#     pending_count()==6 and all 6 lease ids DISTINCT.
+# --------------------------------------------------------------------------- #
+def test_seeded_second_lifetime_journals_six_distinct(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    async def scenario():
+        first_ids = await _lifetime_publish(wal_path, 3)
+        seed = wal_high_water(Path(wal_path))
+        second_ids = await _lifetime_publish(
+            wal_path, 3, initial_event_seq=seed)
+        probe = DurableOutbound(
+            StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+        return first_ids, seed, second_ids, _pending_ids(probe)
+
+    first_ids, seed, second_ids, pending = _run(scenario())
+    assert seed == max(int(eid, 16) for eid in first_ids)
+    assert len(pending) == 6, (
+        "both lifetimes' publishes must be journaled: got %d" % len(pending))
+    assert len(set(pending)) == 6, (
+        "all 6 journaled lease ids must be DISTINCT: %r" % (pending,))
+    assert sorted(pending) == sorted(first_ids + second_ids)
+    assert min(int(eid, 16) for eid in second_ids) > seed, (
+        "every lifetime-2 id must be strictly above the WAL high-water")
+
+
+# --------------------------------------------------------------------------- #
+# (d) seeded broker mints strictly-greater ids; 012x wire format preserved
+#     (zero-padded 12-hex -- plain string comparison stays correct for the
+#     cumulative ack cursor and the WAL trim).
+# --------------------------------------------------------------------------- #
+def test_seeded_broker_mints_strictly_greater_012x_ids():
+    seed = 0x2A
+    broker = StreamEventBroker(history_maxlen=16, initial_event_seq=seed)
+    ids = [broker.publish(_EVENT_TYPE, _PREFIX + "fmt-%d" % i, {})
+           for i in range(3)]
+    assert ids == [format(seed + 1 + i, "012x") for i in range(3)], (
+        "seeded broker must continue the 012x sequence strictly above the "
+        "seed: %r" % (ids,))
+    for eid in ids:
+        assert len(eid) == 12 and int(eid, 16) > seed
+    assert ids == sorted(ids), "zero-padded hex must stay string-sortable"
+
+
+def test_initial_event_seq_default_and_garbage_fail_soft():
+    # Default: byte-identical legacy behavior (first id is 000000000001).
+    legacy = StreamEventBroker(history_maxlen=16)
+    assert legacy.publish(_EVENT_TYPE, _PREFIX + "d", {}) == format(1, "012x")
+    # Garbage seeds degrade to the legacy 0, never raise (fail-soft).
+    for bad in ("not-an-int", None, -7):
+        broker = StreamEventBroker(history_maxlen=16, initial_event_seq=bad)
+        assert broker.publish(_EVENT_TYPE, _PREFIX + "g", {}) == format(1, "012x"), (
+            "seed %r must fail soft to the legacy sequence" % (bad,))


### PR DESCRIPTION
## Stage-3 partition hardening -- Task 7 (unplanned, mandated by two live-fire findings)

### Finding A (CRITICAL, silent loss): cross-lifetime event-id collision
`StreamEventBroker` mints event ids from an in-memory sequence starting at 0, while the WS client's `source_id` is hostname-stable across restarts. Live fire proved it: Body-mode process 1 journaled events `000000000001..03` into the durable outbound WAL and exited; process 2 on the same WAL path recovered those 3 as pending, then its FRESH broker minted the SAME ids for 3 brand-new events -- `DurableOutbound._journal_event` skipped them as already-pending. Published-but-unjournaled during a partition = SILENT LOSS, and the same collision would poison the server's qualified-id dedup (new events dropped as replays).

**Root-cause fix (monotonic Last-Event-ID across lifetimes):**
- `StreamEventBroker.__init__` gains additive kwarg `initial_event_seq: int = 0` (default byte-identical legacy behavior; garbage seeds fail soft to 0).
- `durable_outbound.wal_high_water(wal_path) -> int`: max id EVER journaled -- ANY status, tombstoned included -- base-16 parse, corrupt/non-hex/blank lines skipped (mirrors `WAL.pending_entries` tolerance), 0 for missing/empty, never raises.
- `scripts/run_body_mode.py` live default resolves the WAL path FIRST, computes `seed = wal_high_water(path)` off-loop via the `cooperative_fs_io` offload substrate (inline fail-soft fallback), and constructs `StreamEventBroker(initial_event_seq=seed)` -- every new lifetime mints ids strictly above every id ever journaled. Injectable seams untouched.

### Finding B (ack starvation): burst-then-idle never acks
`bus_bridge_server._handle_ws` evaluated the ack cadence (`JARVIS_BUS_ACK_EVERY_N` / `JARVIS_BUS_ACK_INTERVAL_S`) ONLY in the FRAME_EVENT branch -- a 3-event burst below EVERY_N followed by silence never tripped the interval, so the client's WAL never trimmed. **Fix:** the FRAME_HEARTBEAT branch now evaluates the same interval cadence (heartbeats flow continuously on the client's `heartbeat_s` cadence), firing ONLY when un-acked ingest state exists (`conn_last_eid` set + `ack_pending`). Idle-after-burst connections now ack within ~interval.

### TDD (RED -> GREEN proven for both)
- `tests/governance/transport/test_cross_lifetime_identity.py` (7 tests): `wal_high_water` max-ever/missing/corrupt; THE COLLISION REPRO (unseeded lifetime-2 re-mints lifetime-1's exact ids, pending stays 3 = the silent skip); seeded lifetime-2 -> `pending_count()==6`, all 6 lease ids distinct; strictly-greater 012x minting; default/garbage-seed fail-soft. Suite fails at import + collision against pre-fix sources.
- `tests/governance/transport/test_ack_lane.py` + burst-then-idle test (3 events << EVERY_N, INTERVAL_S=0.3, client heartbeat_s=0.1): `last_acked_id` reaches the 3rd id with NO post-burst events. Verified FAILED against pre-fix `bus_bridge_server.py`, passes with the fix.
- Regression: full `tests/governance/transport/` + `tests/infra/test_run_body_mode.py` (89 passed, deliberate-partition suite included) + `tests/governance/test_ide_observability_stream.py` (49 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent event loss by seeding event IDs from the WAL high‑water mark and ensures acks are sent during idle periods via heartbeat. This keeps event identity monotonic across restarts and trims the WAL reliably.

- **Bug Fixes**
  - Cross‑lifetime event‑id collision: added `initial_event_seq` to `StreamEventBroker` and `wal_high_water(path)` to read the max-ever ID (incl. tombstones); `scripts/run_body_mode.py` now seeds the broker from this value via cooperative FS offload.
  - Ack starvation after burst‑then‑idle: `bus_bridge_server.py` now evaluates the interval ack cadence on heartbeat frames when unacked events exist, bounding ack latency without further events.
  - Tests: new `test_cross_lifetime_identity.py` and updates to `test_ack_lane.py` cover both fixes.

<sup>Written for commit a6d8faec1e68e141f45e4cc2825ada7d288b8252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69846?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

