### PR TITLE
chore(gitignore): session artifacts + ouroboros runtime secrets + personal docs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -430,3 +430,17 @@ proof_telemetry/
 .hypervisor_state.json
 A1_LAUNCH_MANIFEST.json
 autopsy_reports/
+
+# Session/run artifacts (2026-07-04 hygiene pass) -- never commit run logs or local run dirs
+logs/
+a1_iso_runs/
+
+# Ouroboros local runtime state incl. the HMAC checkpoint key (SECRET -- never commit)
+.ouroboros/checkpoint_key
+.ouroboros/checkpoints/
+.ouroboros/stream_heartbeat.epoch
+
+# Personal documents (operator-local, not project files)
+*_resume.html
+*resume*.html
+Derek J. Russell - Resume*.pdf


### PR DESCRIPTION
Hygiene pass: 77 untracked run logs (*.out gap), a1_iso_runs/, .ouroboros runtime state including the HMAC checkpoint_key (a secret that must never be committable), and personal resume files. Ignore-not-commit: session artifacts don't belong in history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update .gitignore to ignore session/run artifacts (`logs/`, `a1_iso_runs/`), Ouroboros runtime state including the HMAC key (`.ouroboros/checkpoint_key`, checkpoints, heartbeat), and personal resume files. This prevents committing secrets and noisy files.

<sup>Written for commit d2b8db4e00a46319d376d6fbd5efef65b12bc1da. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

