### PR TITLE
feat(stage4): Sovereign Brain Resurrection + Priority-Aware WAL Replay

### DIFF
--- a/backend/core/ouroboros/governance/auto_committer.py
+++ b/backend/core/ouroboros/governance/auto_committer.py
@@ -321,6 +321,35 @@ class AutoCommitter:
 
         Returns a :class:`CommitResult`. Never raises.
         """
+        # Stage-4 GenerationFence chokepoint (split-brain defense). FAIL-CLOSED
+        # and FIRST: a process that observed a HIGHER Brain generation is a
+        # superseded twin -- its commits must never land, mid-flight ops
+        # included. Sibling gate to the one at ChangeEngine.execute (the two
+        # universal mutation chokepoints). This method's contract is "never
+        # raises", so an unreadable latch REFUSES the commit (fail-closed:
+        # cannot prove unfenced -> do not commit) instead of raising or
+        # silently proceeding.
+        _fenced = True
+        try:
+            from backend.core.ouroboros.governance import (  # noqa: PLC0415
+                generation_fence as _generation_fence,
+            )
+            _fenced = bool(_generation_fence.is_fenced())
+        except Exception:  # noqa: BLE001 -- fail-closed, never raises
+            logger.error(
+                "[GenerationFence] latch unavailable at AutoCommitter -- "
+                "refusing commit (fail-closed) op=%s", op_id, exc_info=True,
+            )
+        if _fenced:
+            logger.warning(
+                "[GenerationFence] commit DENIED at AutoCommitter "
+                "(generation_fenced) op=%s", op_id,
+            )
+            return CommitResult(
+                committed=False,
+                skipped_reason="generation_fenced",
+            )
+
         if not _ENABLED:
             return CommitResult(
                 committed=False,

--- a/backend/core/ouroboros/governance/brain_discovery.py
+++ b/backend/core/ouroboros/governance/brain_discovery.py
@@ -138,6 +138,74 @@ def build_brain_server_ssl_context(cfg: Optional[Any] = None) -> Optional[Any]:
 
 
 # ---------------------------------------------------------------------------
+# Generation filter (Stage-4 Task 3).
+# ---------------------------------------------------------------------------
+
+_ENV_CURRENT_GEN = "JARVIS_BRAIN_CURRENT_GEN"
+
+
+def _current_gen_floor() -> int:
+    """The keeper-exported generation floor, or 0 when the filter is inactive.
+
+    BACKWARD COMPAT (load-bearing): unset / empty / malformed / non-positive
+    values all resolve to 0 = ZERO behavior change -- discovery stays exactly
+    the pre-Stage-4 role-label-only path."""
+    raw = (os.environ.get(_ENV_CURRENT_GEN, "") or "").strip()
+    if not raw:
+        return 0
+    try:
+        val = int(raw)
+    except ValueError:
+        return 0
+    return val if val > 0 else 0
+
+
+def _filter_stale_generations(
+    instances: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    """Exclude candidates from generations OLDER than the keeper's current one,
+    BEFORE any probe is attempted.
+
+    When ``JARVIS_BRAIN_CURRENT_GEN`` is set (the Body driver exports it from
+    ``BrainKeeper.current_gen()``), a role-labelled instance whose
+    ``jarvis-brain-gen`` label is < current is a superseded generation --
+    never probed, never raced. An instance LACKING the gen label is excluded
+    too: an unlabeled brain is pre-Stage-4 = obsolete by definition when a
+    gen'd keeper runs (it predates the ownership substrate, so the keeper
+    cannot reason about it). Equal/higher generations pass through.
+
+    Fail-soft: with the env unset (or the lineage constants unimportable) the
+    input list is returned unchanged -- zero behavior change."""
+    floor = _current_gen_floor()
+    if floor <= 0:
+        return list(instances or [])
+    try:
+        from backend.core.ouroboros.governance.brain_lifecycle import (  # noqa: PLC0415
+            LABEL_GEN,
+        )
+    except Exception as exc:  # noqa: BLE001 -- fail-soft: no filter, no break
+        logger.debug("[BrainDiscovery] gen filter unavailable err=%r", exc)
+        return list(instances or [])
+    out: List[Dict[str, Any]] = []
+    for inst in instances or []:
+        raw_gen: Any = None
+        try:
+            raw_gen = (inst.get("labels") or {}).get(LABEL_GEN)
+            gen: Optional[int] = int(str(raw_gen).strip())
+        except (TypeError, ValueError, AttributeError):
+            gen = None
+        if gen is None or gen < floor:
+            logger.info(
+                "[BrainDiscovery] excluding stale-generation candidate "
+                "name=%s gen=%s current_gen=%d (never probed)",
+                (inst or {}).get("name"), raw_gen, floor,
+            )
+            continue
+        out.append(inst)
+    return out
+
+
+# ---------------------------------------------------------------------------
 # Candidate endpoint construction.
 # ---------------------------------------------------------------------------
 
@@ -309,6 +377,10 @@ async def discover_brain_endpoint(
             return None
         list_fn = list_instances_fn or _default_list_brain_instances
         instances = await list_fn()
+        # Stage-4 gen filter: superseded generations (and pre-Stage-4
+        # unlabeled brains) never become candidates when the keeper has
+        # exported JARVIS_BRAIN_CURRENT_GEN; env unset = zero change.
+        instances = _filter_stale_generations(instances or [])
         candidates = _candidate_urls(instances or [], cfg)
         if not candidates:
             logger.info(

--- a/backend/core/ouroboros/governance/brain_keeper.py
+++ b/backend/core/ouroboros/governance/brain_keeper.py
@@ -1,0 +1,399 @@
+"""brain_keeper.py -- Stage-4 Task 3: the Body-side Brain KEEPER.
+
+The keeper is the Body's answer to a dead Brain: it watches the driver's
+existing discovery/census outcomes (``note_discovery_result``), detects
+SUSTAINED absence (a continuous window with no healthy Brain endpoint), and
+resurrects a new Brain GENERATION under a persistent token-bucket rate cap.
+
+Components
+----------
+* ``PersistentTokenBucket``: a flock-journaled take ledger. The journal IS the
+  state -- ``try_take`` replays the JSONL file and counts takes inside the
+  rolling window, so the cap is deterministic across process restarts
+  (Mandate 1). NO sleeps, NO retry/backoff logic lives here: the bucket only
+  answers "may I spend a VM right now" from the on-disk record.
+* ``BrainKeeper``: the absence-window state machine. States:
+  ``healthy`` | ``absent`` | ``resurrecting`` | ``resurrected`` |
+  ``cap_exhausted`` (TERMINAL). A refused take is a deterministic terminal
+  state -- ``tick`` NEVER retries past it; only a NEW keeper process with
+  restored bucket capacity can resurrect again (Mandate 1: no endless retry).
+
+Wall-clock choice (documented, load-bearing)
+--------------------------------------------
+The bucket window uses ``time.time()`` (wall clock), NOT ``time.monotonic()``:
+the window is a human-scale BILLING guard ("at most N VM creates per hour of
+real time") and must survive process restarts -- monotonic clocks reset per
+process, so a restart would forget every prior take. A wall-clock step
+(NTP/DST) can widen or narrow one window edge; that is acceptable for a
+billing guard and irreparable any other way without external state.
+
+Failed attempts consume capacity BY DESIGN: the token is taken BEFORE the
+provision call, and a failed provision does not refund it. The bucket guards
+the VM FACTORY (attempts that can spend money), not successful births -- a
+crash-looping provision path must exhaust the cap, not spin the factory.
+
+Record-at-birth (closes Task-1 concern #3): the manifest ``record_create``
+is appended BEFORE the provision await -- exactly the semantics
+``ResourceManifest.record_create`` documents ("called AT BIRTH, right when
+the resource is requested") -- so a keeper death mid-provision still leaves
+the child on the manifest for the next teardown walk. A cleanly-failed
+provision leaves the record in place (conservative: a partial create is
+reaped by the walk; a never-created node's delete is a 404 no-op).
+
+Env knobs (all resolved at call time -- zero baked assumptions):
+    JARVIS_RESURRECT_BUCKET_PATH     bucket journal path
+                                     (default <repo>/.jarvis/manifests/resurrect_bucket.jsonl)
+    JARVIS_BRAIN_RESURRECT_WINDOW_S  rolling window seconds (default 3600.0)
+    JARVIS_BRAIN_RESURRECT_MAX_PER_H takes allowed per window (default 2)
+    JARVIS_BRAIN_RESURRECT_AFTER_S   sustained-absence threshold (default 900.0)
+    JARVIS_KEEPER_ID                 keeper identity (default "mac-body-keeper")
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+from backend.core.ouroboros.governance.brain_lifecycle import (
+    LABEL_GEN,
+    LABEL_OWNER,
+    LABEL_PARENT,
+    ResourceManifest,
+    sanitize_label_value,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Env knobs.
+# ---------------------------------------------------------------------------
+
+_ENV_BUCKET_PATH = "JARVIS_RESURRECT_BUCKET_PATH"
+_ENV_WINDOW_S = "JARVIS_BRAIN_RESURRECT_WINDOW_S"
+_DEFAULT_WINDOW_S = 3600.0
+_ENV_CAPACITY = "JARVIS_BRAIN_RESURRECT_MAX_PER_H"
+_DEFAULT_CAPACITY = 2
+_ENV_RESURRECT_AFTER_S = "JARVIS_BRAIN_RESURRECT_AFTER_S"
+_DEFAULT_RESURRECT_AFTER_S = 900.0
+_ENV_KEEPER_ID = "JARVIS_KEEPER_ID"
+_DEFAULT_KEEPER_ID = "mac-body-keeper"
+
+
+def _default_bucket_path() -> Path:
+    # backend/core/ouroboros/governance/brain_keeper.py -> repo root is 4 up.
+    repo_root = Path(__file__).resolve().parents[4]
+    return repo_root / ".jarvis" / "manifests" / "resurrect_bucket.jsonl"
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        v = float((os.environ.get(name, "") or "").strip())
+        return v if v > 0 else default
+    except (ValueError, AttributeError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        raw = (os.environ.get(name, "") or "").strip()
+        return int(raw) if raw else default
+    except (ValueError, AttributeError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# PersistentTokenBucket -- the journal IS the state.
+# ---------------------------------------------------------------------------
+
+
+class PersistentTokenBucket:
+    """Flock-journaled rate cap for Brain resurrections.
+
+    Each successful take appends one JSONL record
+    ``{"ts_utc": ..., "ts_wall": <time.time()>, "gen": N}`` through the SAME
+    intake-WAL ``_write_line`` substrate ``ResourceManifest`` reuses (flock
+    cross-process append -- imported, never copied). ``try_take`` replays the
+    journal fresh on every call: takes whose ``ts_wall`` falls inside the
+    rolling window count against the capacity; at/over capacity the take is
+    REFUSED WITHOUT APPENDING. Deterministic across process restarts
+    (Mandate 1) -- and deliberately free of sleeps/retries/backoff: rate
+    POLICY lives in the keeper's terminal state, not here.
+
+    Wall clock (``time.time()``) is intentional -- see the module docstring.
+    """
+
+    def __init__(self, path: Optional[Any] = None) -> None:
+        if path is not None:
+            resolved = Path(path)
+        else:
+            raw = (os.environ.get(_ENV_BUCKET_PATH, "") or "").strip()
+            resolved = Path(raw) if raw else _default_bucket_path()
+        self._path = resolved
+        # REUSE the intake-WAL primitives exactly as ResourceManifest does:
+        # WAL.__init__ mkdirs parents; WAL._write_line is the flock append.
+        from backend.core.ouroboros.governance.intake.wal import WAL  # noqa: PLC0415
+
+        self._wal = WAL(self._path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    def _replay(self) -> List[Dict[str, Any]]:
+        """Tolerant journal replay (WAL semantics: corrupt lines skipped)."""
+        records: List[Dict[str, Any]] = []
+        if not self._path.exists():
+            return records
+        try:
+            with self._path.open("r", encoding="utf-8") as fh:
+                for line_no, line in enumerate(fh, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "[ResurrectBucket] corrupt line %d in %s -- skipping",
+                            line_no, self._path,
+                        )
+                        continue
+                    if isinstance(rec, dict):
+                        records.append(rec)
+        except OSError as exc:
+            logger.warning("[ResurrectBucket] read failed (%r) -- empty replay", exc)
+        return records
+
+    def taken_in_window(self, now_wall: Optional[float] = None) -> int:
+        """Count of takes whose ``ts_wall`` is inside the rolling window."""
+        now = time.time() if now_wall is None else float(now_wall)
+        window_s = _env_float(_ENV_WINDOW_S, _DEFAULT_WINDOW_S)
+        count = 0
+        for rec in self._replay():
+            try:
+                ts_wall = float(rec.get("ts_wall"))
+            except (TypeError, ValueError):
+                continue
+            if (now - ts_wall) <= window_s:
+                count += 1
+        return count
+
+    def capacity(self) -> int:
+        return _env_int(_ENV_CAPACITY, _DEFAULT_CAPACITY)
+
+    def try_take(self, gen: Optional[int] = None) -> bool:
+        """Spend one resurrection token, or refuse.
+
+        Replays the journal, counts in-window takes; at/over capacity the
+        refusal appends NOTHING (a refused caller must leave no trace). On a
+        grant, appends the take record and returns True. No sleeps, no
+        retries, no backoff -- ever (Mandate 1)."""
+        now = time.time()
+        if self.taken_in_window(now) >= self.capacity():
+            return False
+        record: Dict[str, Any] = {
+            "ts_utc": datetime.now(timezone.utc).isoformat(),
+            "ts_wall": now,
+            "gen": gen,
+        }
+        self._wal._write_line(record)  # noqa: SLF001 -- private-but-stable WAL substrate
+        return True
+
+
+# ---------------------------------------------------------------------------
+# BrainKeeper -- the sustained-absence resurrection state machine.
+# ---------------------------------------------------------------------------
+
+_STATE_HEALTHY = "healthy"
+_STATE_ABSENT = "absent"
+_STATE_RESURRECTING = "resurrecting"
+_STATE_RESURRECTED = "resurrected"
+_STATE_CAP_EXHAUSTED = "cap_exhausted"  # TERMINAL
+
+
+class BrainKeeper:
+    """Detect sustained Brain absence; resurrect a new generation, capped.
+
+    The Body driver feeds every discovery outcome into
+    ``note_discovery_result`` (truthy url resets the absence window; falsy
+    starts/continues it) and awaits ``tick`` once per census tick. When the
+    absence window has continuously exceeded ``resurrect_after_s`` and no
+    resurrection is in flight, one bucket token is spent and ONE provision is
+    issued (single-flight). A refused token is the deterministic TERMINAL
+    ``cap_exhausted`` state: loud ``logger.error`` exactly once, then every
+    subsequent ``tick`` returns the terminal state without retrying -- only a
+    NEW keeper process with restored bucket capacity can resurrect (Mandate 1).
+
+    ``discover_fn`` is used by ``tick`` ONLY in the ``resurrected`` state (no
+    fresh discovery feed yet): one confirmation probe per tick closes the
+    resurrected -> healthy loop; a falsy probe starts a fresh absence window
+    for the NEW node (a still-dark resurrection re-arms the machine, bounded
+    by the bucket).
+    """
+
+    def __init__(
+        self,
+        *,
+        discover_fn: Callable[[], Awaitable[Optional[str]]],
+        provision_fn: Callable[..., Awaitable[Any]],
+        manifest: ResourceManifest,
+        bucket: PersistentTokenBucket,
+        resurrect_after_s: Optional[float] = None,
+        keeper_id: Optional[str] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._discover_fn = discover_fn
+        self._provision_fn = provision_fn
+        self._manifest = manifest
+        self._bucket = bucket
+        self._resurrect_after_s = (
+            float(resurrect_after_s) if resurrect_after_s is not None
+            else _env_float(_ENV_RESURRECT_AFTER_S, _DEFAULT_RESURRECT_AFTER_S)
+        )
+        if keeper_id is not None:
+            self._keeper_id = str(keeper_id)
+        else:
+            raw = (os.environ.get(_ENV_KEEPER_ID, "") or "").strip()
+            self._keeper_id = raw or _DEFAULT_KEEPER_ID
+        self._clock = clock
+
+        self._state = _STATE_HEALTHY
+        self._absence_started: Optional[float] = None
+        self._inflight = False
+
+    # -- read surface ---------------------------------------------------------
+
+    @property
+    def state(self) -> str:
+        return self._state
+
+    def current_gen(self) -> int:
+        """The highest generation ever minted (manifest replay)."""
+        return self._manifest.max_gen()
+
+    # -- discovery feed -------------------------------------------------------
+
+    def note_discovery_result(self, url: Optional[str]) -> None:
+        """The Body driver calls this from its existing discovery/census path.
+
+        Truthy url: the Brain answered -- the absence window resets; a
+        non-terminal, non-inflight keeper returns to ``healthy``. Falsy: the
+        window starts (first miss) or continues (already running -- the start
+        timestamp is NEVER refreshed by later misses: 'continuously absent').
+
+        ``cap_exhausted`` is terminal BY MANDATE: even a recovered Brain never
+        un-exhausts this keeper (the state persists as the audit trail)."""
+        if url:
+            self._absence_started = None
+            if self._state != _STATE_CAP_EXHAUSTED and not self._inflight:
+                self._state = _STATE_HEALTHY
+            return
+        if self._absence_started is None:
+            self._absence_started = self._clock()
+
+    # -- the tick FSM ---------------------------------------------------------
+
+    async def tick(self) -> str:
+        """Advance the state machine once; returns the current state."""
+        if self._state == _STATE_CAP_EXHAUSTED:
+            return self._state  # TERMINAL -- never retries, never re-logs
+        if self._inflight:
+            return _STATE_RESURRECTING  # single-flight: one provision at a time
+
+        if self._state == _STATE_RESURRECTED and self._absence_started is None:
+            # Confirmation probe for the freshly-minted node (fail-soft).
+            url: Optional[str] = None
+            try:
+                url = await self._discover_fn()
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("[BrainKeeper] confirm probe fail-soft err=%r", exc)
+            self.note_discovery_result(url)
+            if url:
+                return self._state  # -> healthy via note_discovery_result
+
+        if self._absence_started is None:
+            return self._state  # healthy / resurrected steady state
+
+        elapsed = self._clock() - self._absence_started
+        if elapsed <= self._resurrect_after_s:
+            self._state = _STATE_ABSENT
+            return self._state
+
+        # Sustained absence -> spend a token, then single-flight resurrect.
+        gen = self._manifest.max_gen() + 1
+        if not self._bucket.try_take(gen=gen):
+            self._state = _STATE_CAP_EXHAUSTED
+            logger.error(
+                "[BrainKeeper] resurrection cap EXHAUSTED (%d takes / %.0fs "
+                "window) -- TERMINAL: this keeper will NEVER retry; a new "
+                "keeper process with restored bucket capacity is required "
+                "(keeper_id=%s absence_s=%.0f)",
+                self._bucket.capacity(),
+                _env_float(_ENV_WINDOW_S, _DEFAULT_WINDOW_S),
+                self._keeper_id, elapsed,
+            )
+            return self._state
+
+        self._inflight = True
+        self._state = _STATE_RESURRECTING
+        try:
+            return await self._resurrect(gen)
+        finally:
+            self._inflight = False
+
+    async def _resurrect(self, gen: int) -> str:
+        stamp = datetime.now(timezone.utc).strftime("%Y%m%d-%H%M%S")
+        node_name = "jarvis-brain-gen%d-%s" % (gen, stamp)
+        labels = {
+            LABEL_OWNER: self._keeper_id,
+            LABEL_PARENT: sanitize_label_value(self._keeper_id),
+            LABEL_GEN: str(gen),
+        }
+        extra_env = {
+            "JARVIS_BRAIN_GENERATION": str(gen),
+            "JARVIS_BRAIN_PARENT_NODE": node_name,
+        }
+        # RECORD-AT-BIRTH (Task-1 concern #3): append BEFORE the provision
+        # await, so a keeper death mid-provision still leaves the child on the
+        # manifest for the next teardown walk. A cleanly-failed provision
+        # leaves the record in place (conservative -- see module docstring).
+        self._manifest.record_create(
+            kind="instance", name=node_name, labels=dict(labels),
+            parent=self._keeper_id, gen=gen, keeper_id=self._keeper_id,
+        )
+        logger.info(
+            "[BrainKeeper] resurrecting gen=%d node=%s keeper=%s",
+            gen, node_name, self._keeper_id,
+        )
+        try:
+            result = await self._provision_fn(
+                node_name=node_name, labels=labels, extra_env=extra_env,
+            )
+            ok = bool(result[0]) if isinstance(result, tuple) else bool(result)
+            detail = str(result[1]) if isinstance(result, tuple) and len(result) > 1 else ""
+        except Exception as exc:  # noqa: BLE001 -- fail-soft; token stays SPENT
+            ok, detail = False, repr(exc)
+        if ok:
+            self._state = _STATE_RESURRECTED
+            self._absence_started = None  # window resets; probe re-arms it
+            logger.info(
+                "[BrainKeeper] resurrection SUCCEEDED gen=%d node=%s",
+                gen, node_name,
+            )
+        else:
+            # The token is SPENT by design (VM-factory guard: attempts that
+            # can spend money count against the cap, refunds would let a
+            # crash-looping provision path spin the factory). The absence
+            # window keeps running -> the next tick may retry until the
+            # bucket refuses -> deterministic cap_exhausted.
+            self._state = _STATE_ABSENT
+            logger.warning(
+                "[BrainKeeper] resurrection FAILED gen=%d node=%s detail=%s "
+                "(token spent by design)", gen, node_name, detail,
+            )
+        return self._state

--- a/backend/core/ouroboros/governance/brain_keeper.py
+++ b/backend/core/ouroboros/governance/brain_keeper.py
@@ -50,6 +50,7 @@ Env knobs (all resolved at call time -- zero baked assumptions):
 """
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
@@ -82,6 +83,13 @@ _ENV_RESURRECT_AFTER_S = "JARVIS_BRAIN_RESURRECT_AFTER_S"
 _DEFAULT_RESURRECT_AFTER_S = 900.0
 _ENV_KEEPER_ID = "JARVIS_KEEPER_ID"
 _DEFAULT_KEEPER_ID = "mac-body-keeper"
+# Stage-4 Task-4 (IMPORTANT-2): the bounded grace between DELIVERING the fence
+# heartbeat to a superseded node (its deterministic self-fence + capture_inflight
+# window) and REAPING it. Env-tunable; the keeper never blocks past this.
+_ENV_FENCE_GRACE_S = "JARVIS_BRAIN_FENCE_GRACE_S"
+_DEFAULT_FENCE_GRACE_S = 20.0
+_ENV_FENCE_DELIVER_TIMEOUT_S = "JARVIS_BRAIN_FENCE_DELIVER_TIMEOUT_S"
+_DEFAULT_FENCE_DELIVER_TIMEOUT_S = 15.0
 
 
 def _default_bucket_path() -> Path:
@@ -279,6 +287,98 @@ _STATE_RESURRECTED = "resurrected"
 _STATE_CAP_EXHAUSTED = "cap_exhausted"  # TERMINAL
 
 
+# ---------------------------------------------------------------------------
+# Live-default fence delivery (IMPORTANT-2). The keeper ACTIVELY delivers the
+# fence heartbeat to a known superseded node -- a single-bridge Body only binds
+# the newest gen, so the old node would otherwise never receive the signal that
+# triggers its deterministic self-fence + capture_inflight.
+# ---------------------------------------------------------------------------
+
+
+async def _fence_deliver_impl(node_name: str, gen: int) -> bool:
+    """Open a SHORT-LIVED heartbeat-only client to the old node's bus and
+    publish ``console.keeper_heartbeat{gen}`` -- the run_body_mode idiom
+    (DistributedEventBus client role + TrinityBusBridge outbound ``console.*``)
+    but pointed at ONE known endpoint. Returns True iff the publish was issued."""
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        get_compute_rest,
+    )
+    from backend.core.ouroboros.governance.transport.transport_config import (  # noqa: PLC0415
+        TransportConfig,
+    )
+    from backend.core.ouroboros.governance.transport.distributed_event_bus import (  # noqa: PLC0415
+        DistributedEventBus,
+    )
+    from backend.core.ouroboros.governance.transport.trinity_bus_bridge import (  # noqa: PLC0415
+        TrinityBusBridge,
+    )
+    from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: PLC0415
+        StreamEventBroker,
+    )
+    from backend.core.trinity_event_bus import get_trinity_event_bus  # noqa: PLC0415
+
+    internal_ip, external_ip = await get_compute_rest().get_node_endpoints(
+        node_name)
+    host = external_ip or internal_ip
+    if not host:
+        return False
+    cfg = TransportConfig.from_env(role="mac-body")
+    scheme = "wss" if getattr(cfg, "tls_enabled", False) else "ws"
+    url = "%s://%s:%d%s" % (scheme, host, cfg.port, cfg.path)
+    trinity_bus = await get_trinity_event_bus()
+    broker = StreamEventBroker()
+    dist = DistributedEventBus(broker, cfg, role="client")
+    bridge = TrinityBusBridge(
+        trinity_bus, broker, outbound_topics=["console.*"],
+        source_id="mac-body-keeper",
+    )
+    task = asyncio.ensure_future(dist.start_client(url))
+    try:
+        deadline = time.monotonic() + 5.0
+        while time.monotonic() < deadline:
+            client = getattr(dist, "_client", None)
+            if client is not None and getattr(client, "connected", False):
+                break
+            await asyncio.sleep(0.1)
+        await bridge.start()
+        await trinity_bus.publish_raw(
+            "console.keeper_heartbeat", {"gen": int(gen)}, persist=False)
+        # Let the frame flush + the old node observe it and self-fence.
+        await asyncio.sleep(1.0)
+        return True
+    finally:
+        try:
+            await bridge.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            await dist.stop()
+        except Exception:  # noqa: BLE001
+            pass
+        task.cancel()
+        try:
+            await task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+
+
+async def _default_fence_deliver_fn(node_name: str, gen: int) -> bool:
+    """Bounded, fail-soft wrapper: deliver the fence heartbeat under a hard
+    timeout so an unreachable node can NEVER block the keeper. On any failure
+    the caller falls through to the reap backstop after the grace."""
+    import asyncio as _asyncio  # noqa: PLC0415
+    budget = _env_float(_ENV_FENCE_DELIVER_TIMEOUT_S, _DEFAULT_FENCE_DELIVER_TIMEOUT_S)
+    try:
+        return bool(await _asyncio.wait_for(
+            _fence_deliver_impl(node_name, gen), timeout=budget))
+    except Exception as exc:  # noqa: BLE001 -- delivery is best-effort; reap backstops
+        logger.warning(
+            "[BrainKeeper] fence delivery to %s fail-soft (falling through to "
+            "reap): %r", node_name, exc,
+        )
+        return False
+
+
 class BrainKeeper:
     """Detect sustained Brain absence; resurrect a new generation, capped.
 
@@ -309,11 +409,27 @@ class BrainKeeper:
         resurrect_after_s: Optional[float] = None,
         keeper_id: Optional[str] = None,
         clock: Callable[[], float] = time.monotonic,
+        # Stage-4 Task-4 (IMPORTANT-2/4): fence-supersession seams. All None ->
+        # the live defaults (real fence delivery + real GCP reap) resolve
+        # lazily; tests inject recorders.
+        fence_deliver_fn: Optional[Callable[[str, int], Awaitable[bool]]] = None,
+        delete_instance_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+        delete_firewall_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+        label_query_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+        fence_grace_s: Optional[float] = None,
     ) -> None:
         self._discover_fn = discover_fn
         self._provision_fn = provision_fn
         self._manifest = manifest
         self._bucket = bucket
+        self._fence_deliver_fn = fence_deliver_fn
+        self._delete_instance_fn = delete_instance_fn
+        self._delete_firewall_fn = delete_firewall_fn
+        self._label_query_fn = label_query_fn
+        self._fence_grace_s = (
+            float(fence_grace_s) if fence_grace_s is not None
+            else _env_float(_ENV_FENCE_GRACE_S, _DEFAULT_FENCE_GRACE_S)
+        )
         self._resurrect_after_s = (
             float(resurrect_after_s) if resurrect_after_s is not None
             else _env_float(_ENV_RESURRECT_AFTER_S, _DEFAULT_RESURRECT_AFTER_S)
@@ -420,6 +536,13 @@ class BrainKeeper:
         extra_env = {
             "JARVIS_BRAIN_GENERATION": str(gen),
             "JARVIS_BRAIN_PARENT_NODE": node_name,
+            # Stage-4 CRITICAL-1: ship the keeper id onto the Brain so any
+            # node ITS failover path awakens (the grandchild) can stamp the
+            # LABEL_OWNER=keeper_id family label + record-at-birth into the
+            # manifest -- otherwise the grandchild is invisible to both the
+            # family walk (teardown_family) AND the keeper-keyed drift
+            # detector (the orphan class Stage 4 exists to kill).
+            "JARVIS_KEEPER_ID": self._keeper_id,
         }
         # RECORD-AT-BIRTH (Task-1 concern #3): append BEFORE the provision
         # await, so a keeper death mid-provision still leaves the child on the
@@ -448,6 +571,17 @@ class BrainKeeper:
                 "[BrainKeeper] resurrection SUCCEEDED gen=%d node=%s",
                 gen, node_name,
             )
+            # Stage-4 IMPORTANT-2: a NEW generation is now live -- actively
+            # deliver the fence signal to every OLDER live node (its
+            # self-fence + capture_inflight window), then reap it. Fail-soft:
+            # supersession must never undo a successful resurrection.
+            try:
+                await self.supersede_old_generations(gen)
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "[BrainKeeper] supersession fail-soft (resurrection stands): "
+                    "%r", exc,
+                )
         else:
             # The token is SPENT by design (VM-factory guard: attempts that
             # can spend money count against the cap, refunds would let a
@@ -460,3 +594,136 @@ class BrainKeeper:
                 "(token spent by design)", gen, node_name, detail,
             )
         return self._state
+
+    # -- fence supersession (Stage-4 Task-4, IMPORTANT-2/4) -------------------
+
+    def _resolve_fence_deliver(self) -> Callable[[str, int], Awaitable[bool]]:
+        return self._fence_deliver_fn or _default_fence_deliver_fn
+
+    def _resolve_delete_instance(self) -> Callable[..., Awaitable[Any]]:
+        if self._delete_instance_fn is not None:
+            return self._delete_instance_fn
+
+        async def _live(name: str, *, zone: Optional[str] = None) -> Any:
+            from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                get_compute_rest,
+            )
+            return await get_compute_rest().delete_instance(name, zone=zone)
+
+        return _live
+
+    def _resolve_delete_firewall(self) -> Callable[..., Awaitable[Any]]:
+        if self._delete_firewall_fn is not None:
+            return self._delete_firewall_fn
+
+        async def _live(*, rule_name: str) -> Any:
+            from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                get_compute_rest,
+            )
+            return await get_compute_rest().delete_firewall_rule(rule_name)
+
+        return _live
+
+    def _resolve_label_query(self) -> Callable[..., Awaitable[Any]]:
+        if self._label_query_fn is not None:
+            return self._label_query_fn
+
+        async def _live(*, label_key: str, label_value: str) -> Any:
+            from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                get_compute_rest,
+            )
+            return await get_compute_rest().list_instances_by_label(
+                label_key=label_key, label_value=label_value)
+
+        return _live
+
+    async def supersede_old_generations(self, current_gen: int) -> Dict[str, Any]:
+        """Deliver the fence signal to every LIVE node older than
+        ``current_gen``, then (after the bounded grace) reap it.
+
+        The keeper OWNS the family (every resurrected node is recorded with
+        ``parent=keeper_id``), so ``live_family(keeper_id)`` is the complete
+        live set. For each ``gen < current_gen`` node: deliver
+        ``console.keeper_heartbeat{gen:current_gen}`` to its endpoint (its
+        deterministic self-fence + capture_inflight window). After ALL
+        deliveries, sleep the bounded grace ONCE, then reap each old node via
+        :meth:`reap_generation`. Delivery is best-effort -- an unreachable node
+        falls through to the reap backstop (never blocks). Fail-soft
+        throughout: returns a structured summary, never raises."""
+        try:
+            live = self._manifest.live_family(self._keeper_id)
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[BrainKeeper] supersede: live_family failed: %r", exc)
+            return {"superseded": [], "delivered": {}, "reaped": {}}
+
+        old_nodes: List[str] = []
+        for rec in live:
+            if str(rec.get("kind") or "instance") != "instance":
+                continue
+            g = rec.get("gen")
+            try:
+                g_int = int(g)
+            except (TypeError, ValueError):
+                continue
+            if g_int >= int(current_gen):
+                continue  # the new gen (and any equal/higher) is not superseded
+            name = str(rec.get("name") or "")
+            if name:
+                old_nodes.append(name)
+
+        if not old_nodes:
+            return {"superseded": [], "delivered": {}, "reaped": {}}
+
+        logger.warning(
+            "[BrainKeeper] SUPERSEDING %d old generation(s) after gen=%d: %s",
+            len(old_nodes), current_gen, ", ".join(old_nodes),
+        )
+        deliver = self._resolve_fence_deliver()
+        delivered: Dict[str, bool] = {}
+        for name in old_nodes:
+            try:
+                delivered[name] = bool(await deliver(name, int(current_gen)))
+            except Exception as exc:  # noqa: BLE001 -- delivery never blocks reap
+                logger.warning(
+                    "[BrainKeeper] fence delivery raised for %s (reap backstops): "
+                    "%r", name, exc,
+                )
+                delivered[name] = False
+
+        # ONE bounded grace: each delivered node gets its self-fence +
+        # capture_inflight window before the reap. Then reap regardless of
+        # delivery outcome (reap is the backstop).
+        if self._fence_grace_s > 0:
+            await asyncio.sleep(self._fence_grace_s)
+
+        reaped: Dict[str, Any] = {}
+        for name in old_nodes:
+            reaped[name] = await self.reap_generation(name)
+
+        return {
+            "superseded": old_nodes,
+            "delivered": delivered,
+            "reaped": reaped,
+        }
+
+    async def reap_generation(self, node_name: str) -> Dict[str, Any]:
+        """Reap a superseded node's family via the manifest walk. Passes
+        ``owner_id=keeper_id`` so the drift detector queries the label the
+        keeper actually stamps (``LABEL_OWNER=keeper_id``) -- IMPORTANT-4.
+        Fail-soft: any failure returns an ``error`` dict, never raises."""
+        try:
+            from backend.core.ouroboros.governance.brain_lifecycle import (  # noqa: PLC0415
+                teardown_family,
+            )
+            return await teardown_family(
+                node_name,
+                manifest=self._manifest,
+                owner_id=self._keeper_id,
+                delete_instance_fn=self._resolve_delete_instance(),
+                delete_firewall_fn=self._resolve_delete_firewall(),
+                label_query_fn=self._resolve_label_query(),
+            )
+        except Exception as exc:  # noqa: BLE001 -- reap is fail-soft
+            logger.warning(
+                "[BrainKeeper] reap_generation(%s) fail-soft: %r", node_name, exc)
+            return {"root": node_name, "error": repr(exc)}

--- a/backend/core/ouroboros/governance/brain_keeper.py
+++ b/backend/core/ouroboros/governance/brain_keeper.py
@@ -115,14 +115,26 @@ class PersistentTokenBucket:
     """Flock-journaled rate cap for Brain resurrections.
 
     Each successful take appends one JSONL record
-    ``{"ts_utc": ..., "ts_wall": <time.time()>, "gen": N}`` through the SAME
-    intake-WAL ``_write_line`` substrate ``ResourceManifest`` reuses (flock
-    cross-process append -- imported, never copied). ``try_take`` replays the
-    journal fresh on every call: takes whose ``ts_wall`` falls inside the
-    rolling window count against the capacity; at/over capacity the take is
-    REFUSED WITHOUT APPENDING. Deterministic across process restarts
-    (Mandate 1) -- and deliberately free of sleeps/retries/backoff: rate
-    POLICY lives in the keeper's terminal state, not here.
+    ``{"ts_utc": ..., "ts_wall": <time.time()>, "gen": N}``. ``try_take``
+    replays the journal fresh on every call: takes whose ``ts_wall`` falls
+    inside the rolling window count against the capacity; at/over capacity
+    the take is REFUSED WITHOUT APPENDING. Deterministic across process
+    restarts (Mandate 1) -- and deliberately free of sleeps/retries/backoff:
+    rate POLICY lives in the keeper's terminal state, not here.
+
+    Atomicity (review fix, IMPORTANT-1): the ENTIRE read-count-decide-append
+    runs inside ONE ``flock_critical_section`` acquisition (the canonical
+    ``cross_process_jsonl`` read-modify-write helper, the InvariantDriftStore
+    precedent -- never hand-rolled locking). An unlocked decide followed by a
+    locked append is a cross-process TOCTOU: two racing processes (a zombie
+    driver overlapping a fresh one) could both count capacity-1 and both
+    append, exceeding the cap by one. The append inside the section is
+    caller-owned direct I/O per that helper's documented contract -- the lock
+    is NON-reentrant (in-process ``threading.Lock`` + ``LOCK_NB`` poll), so
+    nesting ``flock_append_line`` (the intake-WAL ``_write_line`` path) inside
+    it would self-deadlock until timeout. Fail-CLOSED: a take that cannot
+    acquire the lock is REFUSED -- a billing guard that cannot prove capacity
+    must never spend.
 
     Wall clock (``time.time()``) is intentional -- see the module docstring.
     """
@@ -134,23 +146,37 @@ class PersistentTokenBucket:
             raw = (os.environ.get(_ENV_BUCKET_PATH, "") or "").strip()
             resolved = Path(raw) if raw else _default_bucket_path()
         self._path = resolved
-        # REUSE the intake-WAL primitives exactly as ResourceManifest does:
-        # WAL.__init__ mkdirs parents; WAL._write_line is the flock append.
-        from backend.core.ouroboros.governance.intake.wal import WAL  # noqa: PLC0415
-
-        self._wal = WAL(self._path)
+        try:
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass  # fail-soft: flock_critical_section re-mkdirs on the take path
 
     @property
     def path(self) -> Path:
         return self._path
 
+    def _durable_path(self) -> Path:
+        """The overlay-rerooted journal path (identity on plain hosts) --
+        resolved at CALL time so replay reads and the locked append always
+        target the SAME file ``flock_critical_section`` locks. Fail-soft to
+        the raw path."""
+        try:
+            from backend.core.ouroboros.governance.workspace_resolver import (  # noqa: PLC0415
+                resolve_durable_path,
+            )
+
+            return Path(resolve_durable_path(self._path))
+        except Exception:  # noqa: BLE001
+            return self._path
+
     def _replay(self) -> List[Dict[str, Any]]:
         """Tolerant journal replay (WAL semantics: corrupt lines skipped)."""
         records: List[Dict[str, Any]] = []
-        if not self._path.exists():
+        journal = self._durable_path()
+        if not journal.exists():
             return records
         try:
-            with self._path.open("r", encoding="utf-8") as fh:
+            with journal.open("r", encoding="utf-8") as fh:
                 for line_no, line in enumerate(fh, 1):
                     line = line.strip()
                     if not line:
@@ -189,19 +215,56 @@ class PersistentTokenBucket:
     def try_take(self, gen: Optional[int] = None) -> bool:
         """Spend one resurrection token, or refuse.
 
-        Replays the journal, counts in-window takes; at/over capacity the
-        refusal appends NOTHING (a refused caller must leave no trace). On a
-        grant, appends the take record and returns True. No sleeps, no
-        retries, no backoff -- ever (Mandate 1)."""
-        now = time.time()
-        if self.taken_in_window(now) >= self.capacity():
-            return False
+        The WHOLE read-count-decide-append runs under one
+        ``flock_critical_section`` acquisition (no cross-process TOCTOU --
+        see the class docstring). At/over capacity the refusal appends
+        NOTHING (a refused caller must leave no trace); a lock that cannot
+        be acquired REFUSES (fail-closed billing guard). On a grant, the
+        take record is appended inside the held section (caller-owned
+        direct I/O -- the lock is non-reentrant) and True is returned.
+        No sleeps, no retries, no backoff -- ever (Mandate 1)."""
         record: Dict[str, Any] = {
             "ts_utc": datetime.now(timezone.utc).isoformat(),
-            "ts_wall": now,
+            "ts_wall": time.time(),
             "gen": gen,
         }
-        self._wal._write_line(record)  # noqa: SLF001 -- private-but-stable WAL substrate
+        try:
+            line = json.dumps(record, default=str)
+        except (TypeError, ValueError):
+            return False
+        try:
+            from backend.core.ouroboros.governance.cross_process_jsonl import (  # noqa: PLC0415
+                flock_critical_section,
+            )
+        except Exception as exc:  # noqa: BLE001 -- fail-CLOSED, loudly
+            logger.error(
+                "[ResurrectBucket] locking substrate unavailable (%r) -- "
+                "REFUSING take (fail-closed billing guard)", exc,
+            )
+            return False
+        with flock_critical_section(self._path) as locked:
+            if not locked:
+                logger.error(
+                    "[ResurrectBucket] could not acquire the bucket lock for "
+                    "%s -- REFUSING take (fail-closed: cannot prove capacity)",
+                    self._path,
+                )
+                return False
+            if self.taken_in_window(float(record["ts_wall"])) >= self.capacity():
+                return False
+            try:
+                journal = self._durable_path()
+                journal.parent.mkdir(parents=True, exist_ok=True)
+                with journal.open("a", encoding="utf-8") as fh:
+                    fh.write(line + "\n")
+                    fh.flush()
+                    os.fsync(fh.fileno())
+            except OSError as exc:
+                logger.error(
+                    "[ResurrectBucket] take append failed (%r) -- REFUSING "
+                    "(no journal record, no grant)", exc,
+                )
+                return False
         return True
 
 

--- a/backend/core/ouroboros/governance/brain_lifecycle.py
+++ b/backend/core/ouroboros/governance/brain_lifecycle.py
@@ -540,6 +540,7 @@ async def teardown_family(
     delete_instance_fn: Callable[..., Awaitable[Any]],
     delete_firewall_fn: Optional[Callable[..., Awaitable[Any]]] = None,
     label_query_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+    owner_id: Optional[str] = None,
 ) -> Dict[str, Any]:
     """Tear down every live resource owned (transitively) by ``root_name``.
 
@@ -551,6 +552,15 @@ async def teardown_family(
     did not know is LOUD-warned and returned as ``drift`` (a structural
     invariant violation: something was born unrecorded), never silently
     deleted.
+
+    ``owner_id`` (Stage-4 Task-4 re-review, IMPORTANT-4): the value the drift
+    detector queries the ``LABEL_OWNER`` label for. The FAMILY WALK still keys
+    on ``root_name`` (the parent-chain root), but the keeper stamps the
+    ``LABEL_OWNER`` label with its KEEPER ID -- which is NOT the family-walk
+    root (a child's ``parent`` is its node/keeper). Without this the drift
+    query for a keeper-owned family used ``root_name`` and matched nothing
+    (inert detector). ``None`` -> the value defaults to ``root_name``
+    (byte-identical legacy behavior for callers that own by root name).
 
     Fail-soft per item: one failing delete is recorded in ``failed`` and the
     walk continues (a wedged child must not orphan its siblings). Successful
@@ -603,10 +613,11 @@ async def teardown_family(
             for rec in manifest._replay_records()  # noqa: SLF001 -- own module
             if rec.get("op") == "create" and rec.get("name")
         }
+        drift_owner = sanitize_label_value(owner_id if owner_id else root_name)
         try:
             found = await label_query_fn(
                 label_key=LABEL_OWNER,
-                label_value=sanitize_label_value(root_name),
+                label_value=drift_owner,
             )
             for item in found or []:
                 item_name = str((item or {}).get("name") or "")
@@ -617,7 +628,7 @@ async def teardown_family(
                         "%s=%s but the manifest never recorded it -- a resource "
                         "was born OUTSIDE the ownership substrate (structural "
                         "invariant violation; NOT auto-deleted)",
-                        item_name, LABEL_OWNER, sanitize_label_value(root_name),
+                        item_name, LABEL_OWNER, drift_owner,
                     )
         except Exception as exc:  # noqa: BLE001 -- detector is advisory
             logger.warning(

--- a/backend/core/ouroboros/governance/brain_lifecycle.py
+++ b/backend/core/ouroboros/governance/brain_lifecycle.py
@@ -1,0 +1,633 @@
+"""brain_lifecycle.py -- Stage-4 Task 1: the reusable Brain provisioning core
++ the hierarchical-ownership substrate (lineage labels + Resource Manifest).
+
+Extraction
+----------
+The create-instance composition that lived inline in the Stage-1 CLI driver
+(``scripts/ignite_brain_vm.py``) -- brain-env compose, TLS metadata delivery,
+the runtime startup script, machine/image resolution -- now lives here as
+``provision_brain``. The driver consumes this function (its injected-seam
+behavior unchanged; the live default delegates). BYTE-EQUIVALENT: the driver's
+existing regression suites (tests/infra/test_ignite_brain_vm.py,
+test_brain_tls_delivery.py) pin the behavior unmodified; the driver re-exports
+the helpers extracted here so its module surface stays back-compatible.
+
+Hierarchical ownership (the Stage-4 foundation)
+-----------------------------------------------
+Live incident that motivates this: an orphaned ``jarvis-prime-failover`` node
+(spawned by a Brain whose controller died) was found by AD-HOC listing. That
+class must be structurally impossible: every cloud resource is OWNED AT BIRTH
+(lineage labels stamped on create) and recorded in an append-only Resource
+Manifest, so teardown is a MANIFEST WALK (children first), never a discovery
+grep. The label-family query exists ONLY as a drift DETECTOR -- it is never
+the deletion source (see ``teardown_family``).
+
+Components
+----------
+* Label constants: ``LABEL_OWNER`` / ``LABEL_PARENT`` / ``LABEL_GEN`` +
+  ``sanitize_label_value`` (GCP label charset: lowercase [a-z0-9_-], <=63).
+* ``ResourceManifest``: append-only JSONL at ``JARVIS_RESOURCE_MANIFEST_PATH``
+  (default ``<repo>/.jarvis/manifests/resource_manifest.jsonl``). Reuses the
+  intake-WAL write primitive (flock cross-process append) -- imported, never
+  copied. Tolerant replay (corrupt lines skipped, mirroring WAL semantics).
+* ``teardown_family``: children-first manifest walk, fail-soft per item,
+  ``record_delete`` on success, optional label-family drift detector.
+* ``provision_brain``: the extracted Stage-1 Brain-VM create composition, with
+  additive ``labels`` / ``extra_env`` seams for Stage-4 lineage stamping.
+
+Env knobs (all resolved at call time -- zero baked assumptions):
+    JARVIS_RESOURCE_MANIFEST_PATH   manifest JSONL path (default repo-local)
+    JARVIS_KEEPER_ID                keeper identity stamped on create records
+    JARVIS_BRAIN_MTLS_DIR           server TLS material dir (gen_brain_mtls.py)
+    JARVIS_BRAIN_WS_* / JARVIS_BRAIN_VM_*  (resolved here + in gcp_compute_rest)
+"""
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import socket
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+def _truthy(val: Optional[str]) -> bool:
+    return str(val or "").strip().lower() in ("1", "true", "yes", "on")
+
+
+# ---------------------------------------------------------------------------
+# Lineage labels -- ownership stamped at BIRTH.
+# ---------------------------------------------------------------------------
+
+LABEL_OWNER = "jarvis-owner"
+LABEL_PARENT = "jarvis-parent"
+LABEL_GEN = "jarvis-brain-gen"
+
+_LABEL_SAFE_RE = re.compile(r"[^a-z0-9_-]")
+_LABEL_MAX_LEN = 63
+
+
+def sanitize_label_value(value: Any) -> str:
+    """Coerce an arbitrary value into a GCP-label-safe value: lowercase,
+    charset [a-z0-9_-], max 63 chars. Unsafe codepoints become ``-``.
+    NEVER raises."""
+    try:
+        raw = "" if value is None else str(value)
+    except Exception:  # noqa: BLE001
+        return ""
+    safe = _LABEL_SAFE_RE.sub("-", raw.strip().lower())
+    return safe[:_LABEL_MAX_LEN]
+
+
+# ---------------------------------------------------------------------------
+# TLS material delivery (extracted VERBATIM from scripts/ignite_brain_vm.py;
+# the driver re-exports these names -- its test suites pin the behavior).
+# ---------------------------------------------------------------------------
+
+_ENV_MTLS_DIR = "JARVIS_BRAIN_MTLS_DIR"
+
+# The server-side TLS material travels from the Mac (gen_brain_mtls.py output)
+# to the node as instance metadata; the runtime startup script writes it to
+# these node-local paths BEFORE the units start, and brain.env points at them.
+_NODE_TLS_DIR = "/etc/jarvis/tls"
+_TLS_META_KEYS = {
+    "server_cert": ("brain-tls-server-cert", "server-cert.pem"),
+    "server_key": ("brain-tls-server-key", "server-key.pem"),
+    "ca": ("brain-tls-ca", "ca.pem"),
+}
+
+
+class TLSMaterialError(RuntimeError):
+    """TLS is enabled but the server material is absent/incomplete. Raised in the
+    driver preflight BEFORE any GCP call (fail-closed, $0)."""
+
+
+def _tls_material() -> Optional[Dict[str, str]]:
+    """Load the SERVER PEM material (server cert/key + CA) from
+    ``JARVIS_BRAIN_MTLS_DIR`` (the gen_brain_mtls.py output dir). Returns None
+    when TLS is disabled; raises ``TLSMaterialError`` when TLS is enabled and any
+    piece is missing -- the ignition must never spend on a node that can only
+    fail its mTLS probe."""
+    if not _truthy(os.environ.get("JARVIS_BRAIN_WS_TLS_ENABLED", "true")):
+        return None
+    raw_dir = (os.environ.get(_ENV_MTLS_DIR, "") or "").strip()
+    if not raw_dir:
+        raise TLSMaterialError(
+            "TLS enabled but %s is unset -- run scripts/gen_brain_mtls.py and "
+            "export the material dir" % _ENV_MTLS_DIR)
+    mat: Dict[str, str] = {}
+    for part, (_meta_key, filename) in _TLS_META_KEYS.items():
+        path = os.path.join(raw_dir, filename)
+        try:
+            with open(path, "r", encoding="utf-8") as fh:
+                mat[part] = fh.read()
+        except OSError as exc:
+            raise TLSMaterialError(
+                "TLS enabled but %s is missing/unreadable (%s) -- aborting "
+                "BEFORE any GCP spend" % (path, exc)) from exc
+    return mat
+
+
+def _tls_extra_metadata(mat: Optional[Dict[str, str]]) -> Dict[str, str]:
+    """Map the loaded PEM material onto its instance-metadata keys."""
+    if not mat:
+        return {}
+    return {meta_key: mat[part] for part, (meta_key, _fn) in _TLS_META_KEYS.items()}
+
+
+# ---------------------------------------------------------------------------
+# Brain-env composition (extracted from BrainIgnitionDriver._brain_env_values;
+# the driver method now delegates here -- byte-equivalent when extra_env=None).
+# ---------------------------------------------------------------------------
+
+
+def brain_env_values(extra_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
+    """Fold the Task-4 ignition values into the brain-env metadata: the WS
+    port/path + TLS material references + the session cost cap, all
+    env-resolved (Mandate 2). The idle-shutdown seconds are added by
+    ``_compose_brain_env`` itself.
+
+    TLS paths: when server material is shipped (TLS enabled), the node's
+    brain.env is OVERRIDDEN to the node-local /etc/jarvis/tls/* paths the
+    runtime startup script writes -- the Mac-side env holds the Mac's OWN
+    (client) paths, which must never leak into the node's config.
+
+    ``extra_env`` (Stage-4, additive): caller-supplied values folded LAST so a
+    keeper can ship lineage env (e.g. JARVIS_BRAIN_PARENT_NODE /
+    JARVIS_BRAIN_GENERATION) onto the node. ``extra_env=None`` is
+    byte-identical to the pre-extraction composition."""
+    vals: Dict[str, str] = {}
+    for key in (
+        "JARVIS_BRAIN_WS_PORT", "JARVIS_BRAIN_WS_PATH", "JARVIS_BRAIN_WS_TLS_ENABLED",
+        "JARVIS_BRAIN_WS_TLS_CERT", "JARVIS_BRAIN_WS_TLS_KEY", "JARVIS_BRAIN_WS_TLS_CA",
+        "JARVIS_BRAIN_COST_CAP", "JARVIS_DISTRIBUTED_BUS_ENABLED",
+        "JARVIS_BRAIN_BUS_SIDECAR_ENABLED", "JARVIS_BRAIN_OUTBOUND_TOPICS",
+    ):
+        v = os.environ.get(key)
+        if v is not None and v != "":
+            vals[key] = v
+    if _tls_material() is not None:
+        vals["JARVIS_BRAIN_WS_TLS_CERT"] = "%s/%s" % (
+            _NODE_TLS_DIR, _TLS_META_KEYS["server_cert"][1])
+        vals["JARVIS_BRAIN_WS_TLS_KEY"] = "%s/%s" % (
+            _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
+        vals["JARVIS_BRAIN_WS_TLS_CA"] = "%s/%s" % (
+            _NODE_TLS_DIR, _TLS_META_KEYS["ca"][1])
+    # Opt-in provider-key fold (live-fire 2026-07-04 Stage-2 acceptance: the
+    # soak crash-looped 54x with "No API keys set" because these were never
+    # shipped). Keys travel as instance metadata (project-scoped
+    # visibility) -- the established J-Prime pattern per the relocation
+    # design's open risk #4. Opt-in so default ignitions never ship
+    # secrets.
+    if _truthy(os.environ.get("JARVIS_BRAIN_SHIP_PROVIDER_KEYS")):
+        for key in ("DOUBLEWORD_API_KEY", "ANTHROPIC_API_KEY"):
+            v = os.environ.get(key)
+            if v is not None and v != "":
+                vals[key] = v
+    if extra_env:
+        for k, v in extra_env.items():
+            if v is not None and v != "":
+                vals[str(k)] = str(v)
+    return vals
+
+
+# ---------------------------------------------------------------------------
+# Runtime startup script (extracted VERBATIM from scripts/ignite_brain_vm.py:
+# thin provisioning glue -- repopulate /etc/jarvis/brain.env from THIS
+# instance's metadata, create the /run/jarvis runtime dir + liveness marker,
+# and (re)start the baked brain unit so it picks up the fresh env).
+# ---------------------------------------------------------------------------
+
+
+def _brain_runtime_startup_script() -> str:
+    """Minimal boot glue for the golden-image runtime boot. The image already has
+    the ``jarvis-brain.service`` units baked+enabled; this only (a) writes
+    /etc/jarvis/brain.env from the runtime ``brain-env`` metadata, (b) ensures
+    /run/jarvis exists + touches the liveness marker so the idle-check never nukes
+    a freshly-booted node, and (c) restarts the unit to apply the fresh env.
+    ASCII-only. Kept tiny + idempotent (Mandate 3: no new provisioning framework)."""
+    meta_base = "http://metadata.google.internal/computeMetadata/v1/instance/attributes"
+    tls_fetch = "".join(
+        "curl -fsS -H 'Metadata-Flavor: Google' '%s/%s' -o %s/%s || true\n"
+        % (meta_base, meta_key, _NODE_TLS_DIR, filename)
+        for meta_key, filename in _TLS_META_KEYS.values()
+    )
+    return (
+        "#!/usr/bin/env bash\n"
+        "set -uo pipefail\n"
+        "mkdir -p /etc/jarvis /run/jarvis %s\n" % _NODE_TLS_DIR
+        + "curl -fsS -H 'Metadata-Flavor: Google' "
+        "'%s/brain-env' " % meta_base
+        + "-o /etc/jarvis/brain.env || : > /etc/jarvis/brain.env\n"
+        # SERVER TLS material (shipped as metadata by the driver) -> node files,
+        # BEFORE any unit starts. Fail-soft per file: TLS-disabled ignitions have
+        # no such metadata and must still boot.
+        + tls_fetch
+        + "chmod 600 %s/%s 2>/dev/null || true\n" % (
+            _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
+        # Refresh the baked clone (fail-soft): the golden image tracks main at
+        # ignition, so driver-shipped scripts (e.g. the bus sidecar) that landed
+        # AFTER the bake are present without a re-bake.
+        + "git -C /opt/trinity/jarvis pull --ff-only || true\n"
+        # Stage-0 bus + acceptance echo responder SIDECAR: the Brain-side WS
+        # server the cross-host acceptance connects to. Same venv as the soak.
+        + "cat > /etc/systemd/system/jarvis-brain-bus.service <<'UNIT'\n"
+        "[Unit]\n"
+        "Description=JARVIS Brain Stage-0 bus + acceptance echo responder\n"
+        "After=network-online.target\n"
+        "Wants=network-online.target\n"
+        "\n"
+        "[Service]\n"
+        "Type=simple\n"
+        "WorkingDirectory=/opt/trinity/jarvis\n"
+        "EnvironmentFile=/etc/jarvis/brain.env\n"
+        "RuntimeDirectory=jarvis\n"
+        "ExecStart=/opt/trinity/venv/bin/python scripts/brain_bus_echo_server.py\n"
+        "Restart=on-failure\n"
+        "RestartSec=5\n"
+        "\n"
+        "[Install]\n"
+        "WantedBy=multi-user.target\n"
+        "UNIT\n"
+        + "touch /run/jarvis/brain_liveness\n"
+        "systemctl daemon-reload || true\n"
+        "systemctl restart jarvis-brain.service || systemctl start jarvis-brain.service || true\n"
+        "systemctl restart jarvis-brain-bus.service || systemctl start jarvis-brain-bus.service || true\n"
+        "systemctl start jarvis-brain-idle.timer || true\n"
+    )
+
+
+# ---------------------------------------------------------------------------
+# provision_brain -- the extracted create-instance composition.
+# ---------------------------------------------------------------------------
+
+
+async def provision_brain(
+    *,
+    node_name: str,
+    labels: Optional[Dict[str, str]] = None,
+    extra_env: Optional[Dict[str, str]] = None,
+    create_instance_fn: Optional[Callable[..., Awaitable[Tuple[bool, str]]]] = None,
+) -> Tuple[bool, str]:
+    """Provision the Stage-1 CPU Brain VM: compose brain-env metadata + TLS
+    material delivery + the runtime startup script + env-resolved machine/image,
+    then issue the create. EXTRACTED from the ignition driver's live
+    ``_do_create_instance`` default -- byte-equivalent create_instance kwargs
+    when ``labels``/``extra_env`` are None.
+
+    Stage-4 additive seams:
+      * ``labels``: extra lineage labels (values sanitized to the GCP charset)
+        merged OVER the base ``{jarvis-role: brain}`` discovery label.
+      * ``extra_env``: extra brain-env values folded into the node's
+        /etc/jarvis/brain.env (e.g. parent/generation lineage env).
+      * ``create_instance_fn``: injectable seam for tests; the live default is
+        ``get_compute_rest().create_instance`` (real GCP REST -- Mandate 1: no
+        cloud simulation on the live path).
+
+    Raises ``TLSMaterialError`` when TLS is enabled and the server material is
+    incomplete (fail-closed, $0 -- never spend on a node that cannot pass its
+    own mTLS probe)."""
+    from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+        _BRAIN_ENV_METADATA_KEY,
+        _BRAIN_ROLE_LABEL_KEY,
+        _BRAIN_ROLE_LABEL_VALUE,
+        _brain_image_family,
+        _brain_machine_type,
+        _compose_brain_env,
+        get_compute_rest,
+    )
+
+    brain_env = _compose_brain_env(brain_env_values(extra_env))
+    extra = {_BRAIN_ENV_METADATA_KEY: brain_env}
+    # Ship the SERVER PEM material as metadata; the runtime startup script
+    # writes it to /etc/jarvis/tls/* before the units start.
+    extra.update(_tls_extra_metadata(_tls_material()))
+
+    merged_labels: Dict[str, str] = {_BRAIN_ROLE_LABEL_KEY: _BRAIN_ROLE_LABEL_VALUE}
+    for k, v in (labels or {}).items():
+        merged_labels[str(k)] = sanitize_label_value(v)
+
+    create = create_instance_fn or get_compute_rest().create_instance
+    return await create(
+        startup_script=_brain_runtime_startup_script(),
+        name=node_name,
+        machine_type=_brain_machine_type(),
+        image_family=_brain_image_family(),
+        accelerator_type="",
+        accelerator_count=0,
+        labels=merged_labels,
+        extra_metadata=extra,
+    )
+
+
+# ---------------------------------------------------------------------------
+# ResourceManifest -- append-only ownership ledger (JSONL).
+# ---------------------------------------------------------------------------
+
+_ENV_MANIFEST_PATH = "JARVIS_RESOURCE_MANIFEST_PATH"
+
+
+def _default_manifest_path() -> Path:
+    # backend/core/ouroboros/governance/brain_lifecycle.py -> repo root is 4 up.
+    repo_root = Path(__file__).resolve().parents[4]
+    return repo_root / ".jarvis" / "manifests" / "resource_manifest.jsonl"
+
+
+def _keeper_id() -> str:
+    val = (os.environ.get("JARVIS_KEEPER_ID", "") or "").strip()
+    if val:
+        return val
+    try:
+        return socket.gethostname()
+    except Exception:  # noqa: BLE001
+        return "unknown-keeper"
+
+
+class ResourceManifest:
+    """Append-only JSONL ledger of every cloud resource this keeper family has
+    created or deleted. The manifest IS the teardown walk (never a discovery
+    grep): ``live_family`` replays the file, applies delete tombstones, and
+    returns the surviving family CHILDREN FIRST so teardown deletes leaves
+    before their parents.
+
+    Writes reuse the intake-WAL flock append substrate (imported via the WAL
+    class -- private-but-stable, same precedent as bake_brain_golden_image's
+    helper reuse; the flock logic is NEVER copied). Replay mirrors the WAL's
+    corrupt-line tolerance: a torn/garbled line is skipped with a warning,
+    never a crash."""
+
+    def __init__(self, path: Optional[Any] = None) -> None:
+        if path is not None:
+            resolved = Path(path)
+        else:
+            raw = (os.environ.get(_ENV_MANIFEST_PATH, "") or "").strip()
+            resolved = Path(raw) if raw else _default_manifest_path()
+        self._path = resolved
+        # REUSE the intake-WAL primitives: WAL.__init__ mkdirs parents;
+        # WAL._write_line is the flock cross-process append (never raises).
+        from backend.core.ouroboros.governance.intake.wal import WAL  # noqa: PLC0415
+
+        self._wal = WAL(self._path)
+
+    @property
+    def path(self) -> Path:
+        return self._path
+
+    # -- append surface -----------------------------------------------------
+
+    def record_create(
+        self,
+        *,
+        kind: str,
+        name: str,
+        zone: Optional[str] = None,
+        labels: Optional[Dict[str, str]] = None,
+        parent: Optional[str] = None,
+        gen: Optional[int] = None,
+        keeper_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        """Append a create record. Called AT BIRTH (right when the resource is
+        requested) so a controller death mid-provision still leaves the child on
+        the manifest for the next teardown walk."""
+        record: Dict[str, Any] = {
+            "op": "create",
+            "kind": str(kind),
+            "name": str(name),
+            "zone": zone,
+            "labels": dict(labels or {}),
+            "parent": parent,
+            "gen": gen,
+            "keeper_id": keeper_id or _keeper_id(),
+            "ts_utc": datetime.now(timezone.utc).isoformat(),
+        }
+        self._wal._write_line(record)  # noqa: SLF001 -- private-but-stable WAL substrate
+        return record
+
+    def record_delete(self, name: str) -> Dict[str, Any]:
+        """Append a delete tombstone for ``name``."""
+        record: Dict[str, Any] = {
+            "op": "delete",
+            "name": str(name),
+            "keeper_id": _keeper_id(),
+            "ts_utc": datetime.now(timezone.utc).isoformat(),
+        }
+        self._wal._write_line(record)  # noqa: SLF001 -- private-but-stable WAL substrate
+        return record
+
+    # -- replay surface -----------------------------------------------------
+
+    def _replay_records(self) -> List[Dict[str, Any]]:
+        """Tolerant full-file replay: every parseable record, in append order.
+        Corrupt lines are skipped with a warning (WAL semantics)."""
+        records: List[Dict[str, Any]] = []
+        if not self._path.exists():
+            return records
+        try:
+            with self._path.open("r", encoding="utf-8") as fh:
+                for line_no, line in enumerate(fh, 1):
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        rec = json.loads(line)
+                    except json.JSONDecodeError:
+                        logger.warning(
+                            "[ResourceManifest] corrupt line %d in %s -- skipping",
+                            line_no, self._path,
+                        )
+                        continue
+                    if isinstance(rec, dict):
+                        records.append(rec)
+        except OSError as exc:
+            logger.warning("[ResourceManifest] read failed (%r) -- empty replay", exc)
+        return records
+
+    def _live_records(self) -> Dict[str, Dict[str, Any]]:
+        """Replay -> live set: creates keyed by name, delete tombstones applied.
+        A re-create after a delete resurrects the name (append order wins)."""
+        live: Dict[str, Dict[str, Any]] = {}
+        for rec in self._replay_records():
+            name = rec.get("name")
+            if not name:
+                continue
+            op = rec.get("op")
+            if op == "create":
+                live.pop(name, None)  # re-insert to refresh append ordering
+                live[name] = rec
+            elif op == "delete":
+                live.pop(name, None)
+        return live
+
+    def live_family(self, root_name: str) -> List[Dict[str, Any]]:
+        """Return the LIVE records whose parent-chain reaches ``root_name``,
+        ordered CHILDREN FIRST (deepest descendants first, the root record --
+        when present -- last) so a teardown walk deletes leaves before the
+        parents that own them."""
+        live = self._live_records()
+        children: Dict[str, List[Dict[str, Any]]] = {}
+        for rec in live.values():
+            parent = rec.get("parent")
+            if parent:
+                children.setdefault(str(parent), []).append(rec)
+
+        # BFS by depth from the root; cycle-guarded via the seen set.
+        levels: List[List[Dict[str, Any]]] = []
+        seen = {str(root_name)}
+        frontier = [str(root_name)]
+        while frontier:
+            level: List[Dict[str, Any]] = []
+            nxt: List[str] = []
+            for parent_name in frontier:
+                for rec in children.get(parent_name, []):
+                    name = str(rec.get("name"))
+                    if name in seen:
+                        continue
+                    seen.add(name)
+                    level.append(rec)
+                    nxt.append(name)
+            if level:
+                levels.append(level)
+            frontier = nxt
+
+        ordered: List[Dict[str, Any]] = []
+        for level in reversed(levels):
+            ordered.extend(level)
+        root_rec = live.get(str(root_name))
+        if root_rec is not None:
+            ordered.append(root_rec)
+        return ordered
+
+    def max_gen(self) -> int:
+        """Highest ``gen`` across ALL create records ever appended (delete
+        tombstones do NOT regress the counter -- a generation number is never
+        reused even after its node is gone)."""
+        best = 0
+        for rec in self._replay_records():
+            if rec.get("op") != "create":
+                continue
+            try:
+                gen = int(rec.get("gen"))
+            except (TypeError, ValueError):
+                continue
+            best = max(best, gen)
+        return best
+
+
+# ---------------------------------------------------------------------------
+# teardown_family -- the manifest IS the walk; the label query is ONLY a
+# drift detector.
+# ---------------------------------------------------------------------------
+
+
+def _delete_ok(result: Any) -> Tuple[bool, str]:
+    """Normalize a delete callable's result to (ok, detail). Accepts the
+    codebase's ``(ok, detail)`` tuple convention or a bare truthy."""
+    if isinstance(result, tuple):
+        ok = bool(result[0])
+        detail = str(result[1]) if len(result) > 1 else ""
+        return ok, detail
+    return bool(result), str(result)
+
+
+async def teardown_family(
+    root_name: str,
+    *,
+    manifest: ResourceManifest,
+    delete_instance_fn: Callable[..., Awaitable[Any]],
+    delete_firewall_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+    label_query_fn: Optional[Callable[..., Awaitable[Any]]] = None,
+) -> Dict[str, Any]:
+    """Tear down every live resource owned (transitively) by ``root_name``.
+
+    # INVARIANT: manifest-walk-only teardown
+    The deletion source is EXCLUSIVELY ``manifest.live_family`` (children
+    first). No list/aggregatedList discovery ever feeds the delete loop -- the
+    optional ``label_query_fn`` runs AFTER the walk purely as a drift DETECTOR:
+    any resource carrying our ``LABEL_OWNER`` family label that the manifest
+    did not know is LOUD-warned and returned as ``drift`` (a structural
+    invariant violation: something was born unrecorded), never silently
+    deleted.
+
+    Fail-soft per item: one failing delete is recorded in ``failed`` and the
+    walk continues (a wedged child must not orphan its siblings). Successful
+    deletes append a ``record_delete`` tombstone so the manifest converges.
+
+    Callable contracts:
+      * ``delete_instance_fn(name, zone=...)`` -> (ok, detail) or truthy
+      * ``delete_firewall_fn(rule_name=...)``  -> (ok, detail) or truthy
+      * ``label_query_fn(label_key=..., label_value=...)`` -> list of dicts
+        with at least ``name`` (e.g. ``list_instances_by_label``)
+    """
+    family = manifest.live_family(root_name)
+    deleted: List[str] = []
+    failed: List[Dict[str, str]] = []
+
+    for rec in family:
+        name = str(rec.get("name"))
+        kind = str(rec.get("kind") or "instance")
+        zone = rec.get("zone")
+        try:
+            if kind == "firewall":
+                if delete_firewall_fn is None:
+                    failed.append({
+                        "name": name, "kind": kind,
+                        "error": "no_delete_firewall_fn",
+                    })
+                    continue
+                ok, detail = _delete_ok(await delete_firewall_fn(rule_name=name))
+            else:
+                ok, detail = _delete_ok(await delete_instance_fn(name, zone=zone))
+            if ok:
+                manifest.record_delete(name)
+                deleted.append(name)
+            else:
+                failed.append({"name": name, "kind": kind, "error": detail})
+        except Exception as exc:  # noqa: BLE001 -- teardown is fail-soft per item
+            logger.warning(
+                "[BrainLifecycle] teardown delete failed name=%s kind=%s "
+                "(continuing): %r", name, kind, exc,
+            )
+            failed.append({"name": name, "kind": kind, "error": repr(exc)})
+
+    # Drift DETECTOR (never a deletion source): compare the label family
+    # against everything the manifest has EVER known (creates, live or
+    # tombstoned) -- an unknown member means a resource was born unrecorded.
+    drift: List[Dict[str, Any]] = []
+    if label_query_fn is not None:
+        known = {
+            str(rec.get("name"))
+            for rec in manifest._replay_records()  # noqa: SLF001 -- own module
+            if rec.get("op") == "create" and rec.get("name")
+        }
+        try:
+            found = await label_query_fn(
+                label_key=LABEL_OWNER,
+                label_value=sanitize_label_value(root_name),
+            )
+            for item in found or []:
+                item_name = str((item or {}).get("name") or "")
+                if item_name and item_name not in known:
+                    drift.append(dict(item))
+                    logger.warning(
+                        "[BrainLifecycle] OWNERSHIP DRIFT: resource %r carries "
+                        "%s=%s but the manifest never recorded it -- a resource "
+                        "was born OUTSIDE the ownership substrate (structural "
+                        "invariant violation; NOT auto-deleted)",
+                        item_name, LABEL_OWNER, sanitize_label_value(root_name),
+                    )
+        except Exception as exc:  # noqa: BLE001 -- detector is advisory
+            logger.warning(
+                "[BrainLifecycle] drift detector failed (advisory only): %r", exc,
+            )
+
+    return {
+        "root": str(root_name),
+        "family_size": len(family),
+        "deleted": deleted,
+        "failed": failed,
+        "drift": drift,
+    }

--- a/backend/core/ouroboros/governance/change_engine.py
+++ b/backend/core/ouroboros/governance/change_engine.py
@@ -703,6 +703,31 @@ class ChangeEngine:
         """
         op_id = request.op_id or generate_operation_id(repo_origin="jarvis")
 
+        # Stage-4 GenerationFence chokepoint (split-brain defense). FAIL-CLOSED:
+        # once this process observed a HIGHER Brain generation on the bus, it is
+        # a superseded twin and MUST NOT mutate -- including ops already
+        # mid-flight past GENERATE. This is the universal mutation chokepoint
+        # (every governed disk write funnels through execute -- the anti-venom
+        # _pre_write_gate doctrine), so the single boolean here structurally
+        # terminates the APPLY pathway. Deliberately NOT wrapped in try/except:
+        # generation_fence is stdlib-only + colocated; a broken import must
+        # fail the mutation loudly, never silently proceed unfenced.
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            generation_fence as _generation_fence,
+        )
+        if _generation_fence.is_fenced():
+            logger.warning(
+                "[GenerationFence] mutation DENIED at ChangeEngine "
+                "(generation_fenced) op=%s target=%s",
+                op_id, request.target_file,
+            )
+            return ChangeResult(
+                op_id=op_id,
+                success=False,
+                phase_reached=ChangePhase.PLAN,
+                error="POLICY_DENIED reason=generation_fenced",
+            )
+
         try:
             # Phase 1: PLAN -- classify risk, record in ledger
             classification = self._risk_engine.classify(request.profile)

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -555,24 +555,33 @@ def _gcloud_run(cmd: List[str], *, timeout_s: float = 180.0):
 
 def _lineage_labels() -> Optional[Dict[str, str]]:
     """Stage-4 hierarchical ownership: when THIS process runs ON a Brain node
-    (brain-env ships ``JARVIS_BRAIN_PARENT_NODE`` / ``JARVIS_BRAIN_GENERATION``),
-    every node ITS awaken path creates is labeled with its parent + generation
-    at BIRTH -- so an orphan whose controller died is still owned (findable by
-    the manifest/label family walk, never an ad-hoc listing).
+    (brain-env ships ``JARVIS_BRAIN_PARENT_NODE`` / ``JARVIS_BRAIN_GENERATION``
+    / ``JARVIS_KEEPER_ID``), every node ITS awaken path creates is labeled with
+    its owner + parent + generation at BIRTH -- so an orphan whose controller
+    died is still owned (findable by the manifest/label family walk AND the
+    keeper-keyed drift detector, never an ad-hoc listing).
+
+    CRITICAL-1 fix: also folds ``LABEL_OWNER`` from ``JARVIS_KEEPER_ID`` --
+    without it the grandchild carried only PARENT+GEN, so the keeper-keyed
+    drift detector (which queries ``LABEL_OWNER=keeper_id``) never flagged it.
 
     Additive: env absent -> None -> the create_instance payload is
     byte-identical to the pre-Stage-4 behavior. Fail-soft, never raises."""
     try:
         parent = (os.environ.get("JARVIS_BRAIN_PARENT_NODE", "") or "").strip()
         gen = (os.environ.get("JARVIS_BRAIN_GENERATION", "") or "").strip()
-        if not parent and not gen:
+        owner = (os.environ.get("JARVIS_KEEPER_ID", "") or "").strip()
+        if not parent and not gen and not owner:
             return None
         from backend.core.ouroboros.governance.brain_lifecycle import (  # noqa: PLC0415
             LABEL_GEN,
+            LABEL_OWNER,
             LABEL_PARENT,
             sanitize_label_value,
         )
         labels: Dict[str, str] = {}
+        if owner:
+            labels[LABEL_OWNER] = sanitize_label_value(owner)
         if parent:
             labels[LABEL_PARENT] = sanitize_label_value(parent)
         if gen:
@@ -580,6 +589,48 @@ def _lineage_labels() -> Optional[Dict[str, str]]:
         return labels or None
     except Exception:  # noqa: BLE001 -- lineage stamping must never block awaken
         return None
+
+
+def _record_failover_child(node_name: str, *, kind: str = "instance") -> None:
+    """Stage-4 CRITICAL-1: record-at-birth for a failover child (the
+    grandchild). When THIS process runs ON a Brain node (lineage env present),
+    every node its awaken path creates is appended to the SHARED
+    ``ResourceManifest`` -- so the grandchild is in ``live_family`` (reaped by
+    ``teardown_family``) AND carries the owner label the drift detector keys on.
+
+    Env-absent (``_lineage_labels()`` is None -> not on a labeled Brain node) ->
+    no-op (byte-identical: a plain failover run never touches the manifest).
+
+    Fail-soft: a manifest write failure MUST NOT break failover -- log +
+    continue. Same default-path env resolution ``brain_lifecycle`` uses."""
+    labels = _lineage_labels()
+    if not labels:
+        return  # not on a labeled Brain node -> byte-identical no-op
+    try:
+        from backend.core.ouroboros.governance.brain_lifecycle import (  # noqa: PLC0415
+            ResourceManifest,
+        )
+        parent = (os.environ.get("JARVIS_BRAIN_PARENT_NODE", "") or "").strip() or None
+        keeper = (os.environ.get("JARVIS_KEEPER_ID", "") or "").strip() or None
+        gen_raw = (os.environ.get("JARVIS_BRAIN_GENERATION", "") or "").strip()
+        try:
+            gen: Optional[int] = int(gen_raw) if gen_raw else None
+        except ValueError:
+            gen = None
+        ResourceManifest().record_create(
+            kind=kind, name=node_name, labels=dict(labels),
+            parent=parent, gen=gen, keeper_id=keeper,
+        )
+        logger.info(
+            "[FailoverLifecycle] record-at-birth: failover child %s recorded "
+            "into the manifest (parent=%s gen=%s keeper=%s)",
+            node_name, parent, gen, keeper,
+        )
+    except Exception as exc:  # noqa: BLE001 -- a manifest miss must NOT block failover
+        logger.warning(
+            "[FailoverLifecycle] record-at-birth failed for %s (continuing): %r",
+            node_name, exc,
+        )
 
 
 async def _default_vm_awaken_fn(*, startup_script: str) -> bool:
@@ -646,6 +697,12 @@ async def _default_vm_awaken_fn(*, startup_script: str) -> bool:
             labels=_lineage_labels(),
         )
         if ok_create:
+            # Stage-4 CRITICAL-1: record the grandchild at birth (no-op unless
+            # running on a labeled Brain node). Fail-soft -- never blocks awaken.
+            from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
+                _node_name as _failover_node_name,
+            )
+            _record_failover_child(_failover_node_name())
             logger.info(
                 "[FailoverLifecycle] awaken: %s-tier node created via native "
                 "Compute REST (%s, model=%s, gpu=%s) -- zero gcloud",
@@ -1125,6 +1182,9 @@ class FailoverLifecycleController:
             if not ok:
                 logger.warning("[FailoverLifecycle] GPU provision insert failed: %s", detail)
                 return None
+            # Stage-4 CRITICAL-1: record the grandchild at birth (no-op unless
+            # running on a labeled Brain node). Fail-soft -- never blocks awaken.
+            _record_failover_child(gpu_vm)
             # Own /32 firewall rule (crypto-namespaced -> no collision with cpu).
             if _ephemeral_fw_enabled():
                 ip = await resolve_local_public_ip()

--- a/backend/core/ouroboros/governance/failover_lifecycle.py
+++ b/backend/core/ouroboros/governance/failover_lifecycle.py
@@ -553,6 +553,35 @@ def _gcloud_run(cmd: List[str], *, timeout_s: float = 180.0):
         return 1, "[gcloud run failed: {!r}]".format(exc)
 
 
+def _lineage_labels() -> Optional[Dict[str, str]]:
+    """Stage-4 hierarchical ownership: when THIS process runs ON a Brain node
+    (brain-env ships ``JARVIS_BRAIN_PARENT_NODE`` / ``JARVIS_BRAIN_GENERATION``),
+    every node ITS awaken path creates is labeled with its parent + generation
+    at BIRTH -- so an orphan whose controller died is still owned (findable by
+    the manifest/label family walk, never an ad-hoc listing).
+
+    Additive: env absent -> None -> the create_instance payload is
+    byte-identical to the pre-Stage-4 behavior. Fail-soft, never raises."""
+    try:
+        parent = (os.environ.get("JARVIS_BRAIN_PARENT_NODE", "") or "").strip()
+        gen = (os.environ.get("JARVIS_BRAIN_GENERATION", "") or "").strip()
+        if not parent and not gen:
+            return None
+        from backend.core.ouroboros.governance.brain_lifecycle import (  # noqa: PLC0415
+            LABEL_GEN,
+            LABEL_PARENT,
+            sanitize_label_value,
+        )
+        labels: Dict[str, str] = {}
+        if parent:
+            labels[LABEL_PARENT] = sanitize_label_value(parent)
+        if gen:
+            labels[LABEL_GEN] = sanitize_label_value(gen)
+        return labels or None
+    except Exception:  # noqa: BLE001 -- lineage stamping must never block awaken
+        return None
+
+
 async def _default_vm_awaken_fn(*, startup_script: str) -> bool:
     """Create the J-Prime failover node from the golden image (Spot-first).
 
@@ -612,6 +641,9 @@ async def _default_vm_awaken_fn(*, startup_script: str) -> bool:
             image_family=_tier.image_family,
             accelerator_type=_tier.accelerator_type,
             accelerator_count=_tier.accelerator_count,
+            # Stage-4 lineage: parent/gen labels when running ON a Brain node
+            # (env-absent -> None -> byte-identical payload).
+            labels=_lineage_labels(),
         )
         if ok_create:
             logger.info(
@@ -1086,6 +1118,9 @@ class FailoverLifecycleController:
                 image_family=tier.image_family,
                 accelerator_type=tier.accelerator_type,
                 accelerator_count=tier.accelerator_count,
+                # Stage-4 lineage: parent/gen labels when running ON a Brain
+                # node (env-absent -> None -> byte-identical payload).
+                labels=_lineage_labels(),
             )
             if not ok:
                 logger.warning("[FailoverLifecycle] GPU provision insert failed: %s", detail)

--- a/backend/core/ouroboros/governance/generation_fence.py
+++ b/backend/core/ouroboros/governance/generation_fence.py
@@ -1,0 +1,225 @@
+"""GenerationFence -- the Brain-side ACTIVE fence (Stage-4 Task 4, split-brain).
+
+The keeper (Stage-4 Task 3, ``brain_keeper.py``) mints monotonic Brain
+generations and the Body publishes them as ``console.keeper_heartbeat`` on the
+trinity bus (``scripts/run_body_mode.py`` census tick, transiting the mac-side
+``TrinityBusBridge`` outbound allowlist ``console.*``). A Brain that observes a
+HIGHER current generation than its own is, by definition, a superseded twin: a
+newer Brain has been resurrected in its place and THIS node's mutations are no
+longer sovereign. On that observation this fence structurally terminates the
+node's mutation pathways -- deterministically, pure code, no LLM.
+
+Operator Mandate 2 (verbatim): the transition "must not just set an
+``is_fenced=True`` flag; it must structurally terminate the mutation execution
+pathways." We COMPOSE the existing, proven termination machinery rather than
+inventing a new one:
+
+  1. BOUNDARY ARM -- ``autonomous_workspace._arm_boundary_flags()`` (the LR-A
+     deterministic-lock force-arm of the Async Yield Matrix Sovereign Execution
+     Boundary, PRD s51.11.35 / PR #69638). It arms the flag PAIR
+     ``JARVIS_FILE_ISOLATION_ENABLED`` + ``JARVIS_EXECUTION_BOUNDARY_ENABLED``
+     in-process -- exactly the way its own regression spine arms it
+     (``tests/governance/test_deterministic_isolation_lock.py``) -- so Stage A
+     (commit denial: AutoCommit refuses the primary checkout) and Stage B
+     (file isolation: APPLY routes to a quarantine worktree, never the shared
+     tree) both read armed EVEN IF the flags were explicitly false. This is the
+     physical decoupling of the AutoCommit and APPLY pathways.
+  2. SHUTDOWN REQUEST -- ``cooperative_shutdown.request()``: the process-global
+     wind-down signal the harness itself uses at graceful shutdown. In-flight
+     coroutines yield at their next safe boundary; no new work starts.
+  3. CHECKPOINT CAPTURE -- ``fsm_checkpoint.capture_inflight(reason=
+     "generation_fenced")``: SUSPEND every in-flight op into a signed
+     checkpoint so the SUCCESSOR generation resumes the thought (Mandate 3:
+     crypto/payload untouched -- only a new reason STRING flows through the
+     existing signer).
+  4. IDLE TOUCH -- ``stream_heartbeat.pulse()``: best-effort beat on the
+     idle fast-path marker (the Move-2-v4 staleness watchdog input, with an
+     optional cross-process file mirror) so the idle machinery observes the
+     fence transition as fresh activity at a deterministic timestamp instead
+     of misreading the wind-down as a stall.
+
+Each step is fail-soft INDIVIDUALLY (one failing arm never stops the others)
+but the transition is deterministic: all four are ALWAYS attempted, in order,
+exactly once per process (idempotent -- a second higher-gen observation
+no-ops). Structured evidence line::
+
+    [GenerationFence] FENCED own_gen=%d observed_gen=%d arms=...
+
+Authority posture: this module is a pure-code consumer of a bus signal. It
+imports NO LLM/provider machinery (AST-pinned by
+``tests/governance/test_generation_fence.py``) and never mints authority --
+it only revokes this node's own.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+# The keeper-heartbeat topic. The Body publishes it on its local trinity bus;
+# the mac-side TrinityBusBridge outbound allowlist ("console.*",
+# scripts/run_body_mode.py::_do_bridge) carries it across the WS link onto the
+# Brain organism's trinity bus, where this fence subscribes.
+HEARTBEAT_TOPIC = "console.keeper_heartbeat"
+
+_FENCE_REASON = "generation_fenced"
+
+
+# --------------------------------------------------------------------------- #
+# Live default arms -- each a lazy import so constructing a fence with injected
+# seams (tests) never pays for (or trips over) the governance stack.
+# --------------------------------------------------------------------------- #
+def _default_boundary_arm() -> None:
+    """Force-arm the Sovereign Execution Boundary flag pair (LR-A)."""
+    from backend.core.ouroboros.governance.autonomous_workspace import (  # noqa: PLC0415
+        _arm_boundary_flags,
+    )
+    _arm_boundary_flags()
+
+
+def _default_shutdown() -> None:
+    """Request the process-global cooperative wind-down."""
+    from backend.core.ouroboros.governance import cooperative_shutdown  # noqa: PLC0415
+    cooperative_shutdown.request(reason=_FENCE_REASON)
+
+
+def _default_capture() -> None:
+    """SUSPEND in-flight ops into signed checkpoints for the successor.
+
+    Mandate 3: crypto and payload untouched -- ``reason`` is a plain string
+    threaded through the EXISTING capture path (it defaults to
+    ``wall_clock_cap``; this just names the new cause)."""
+    from backend.core.ouroboros.governance.fsm_checkpoint import (  # noqa: PLC0415
+        capture_inflight,
+    )
+    capture_inflight(reason=_FENCE_REASON)
+
+
+def _default_idle_touch() -> None:
+    """Best-effort touch of the idle fast-path marker.
+
+    ``stream_heartbeat.pulse()`` is the simple existing marker: it stamps the
+    idle/staleness watchdog input (plus the optional cross-process mirror
+    file) so the fence transition itself is the last recorded activity."""
+    from backend.core.ouroboros.governance import stream_heartbeat  # noqa: PLC0415
+    stream_heartbeat.pulse()
+
+
+class GenerationFence:
+    """Subscribe to keeper heartbeats; fence on a higher observed generation.
+
+    All four action seams are injectable (tests use recorders); ``None``
+    resolves to the live default lazily AT FENCE TIME (never at construction).
+
+    Args:
+        bus: the organism's ``TrinityEventBus`` (``subscribe``/``unsubscribe``).
+        own_gen: THIS Brain's minted generation (``JARVIS_BRAIN_GENERATION``).
+        boundary_arm_fn: seam for step 1 (Sovereign Execution Boundary arm).
+        shutdown_fn: seam for step 2 (cooperative shutdown request).
+        capture_fn: seam for step 3 (in-flight checkpoint capture).
+        idle_touch_fn: seam for step 4 (idle fast-path marker touch).
+    """
+
+    def __init__(
+        self,
+        bus: Any,
+        own_gen: int,
+        *,
+        boundary_arm_fn: Optional[Callable[[], Any]] = None,
+        shutdown_fn: Optional[Callable[[], Any]] = None,
+        capture_fn: Optional[Callable[[], Any]] = None,
+        idle_touch_fn: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        self._bus = bus
+        self._own_gen = int(own_gen)
+        self._boundary_arm_fn = boundary_arm_fn
+        self._shutdown_fn = shutdown_fn
+        self._capture_fn = capture_fn
+        self._idle_touch_fn = idle_touch_fn
+        self._sub_id: Optional[str] = None
+        self._fenced = False
+
+    @property
+    def own_gen(self) -> int:
+        return self._own_gen
+
+    @property
+    def fenced(self) -> bool:
+        return self._fenced
+
+    async def start(self) -> None:
+        """Subscribe the heartbeat topic on the organism trinity bus."""
+        if self._sub_id is not None:
+            return
+        self._sub_id = await self._bus.subscribe(
+            HEARTBEAT_TOPIC, self._on_heartbeat)
+        logger.info(
+            "[GenerationFence] armed own_gen=%d topic=%s",
+            self._own_gen, HEARTBEAT_TOPIC,
+        )
+
+    async def stop(self) -> None:
+        """Unsubscribe. Never raises (fail-soft teardown)."""
+        sub_id, self._sub_id = self._sub_id, None
+        if sub_id is None:
+            return
+        try:
+            await self._bus.unsubscribe(sub_id)
+        except Exception:  # noqa: BLE001 -- teardown is best-effort
+            logger.debug("[GenerationFence] unsubscribe failed", exc_info=True)
+
+    async def _on_heartbeat(self, event: Any) -> None:
+        """TrinityEvent handler: parse gen; fence EXACTLY ONCE on higher."""
+        payload = getattr(event, "payload", None) or {}
+        raw = payload.get("gen")
+        try:
+            gen = int(raw)
+        except (TypeError, ValueError):
+            logger.debug(
+                "[GenerationFence] ignoring malformed heartbeat gen=%r", raw)
+            return
+        if gen <= self._own_gen:
+            return
+        if self._fenced:
+            return  # idempotent -- the transition already ran
+        # Latch BEFORE the first await inside _fence so a concurrent second
+        # observation can never start a duplicate transition.
+        self._fenced = True
+        await self._fence(gen)
+
+    async def _fence(self, observed_gen: int) -> None:
+        """The deterministic ordered transition -- see the module docstring.
+
+        Each step is fail-soft individually, but ALL are attempted, in order.
+        """
+        steps = (
+            ("boundary", self._boundary_arm_fn or _default_boundary_arm),
+            ("shutdown", self._shutdown_fn or _default_shutdown),
+            ("capture", self._capture_fn or _default_capture),
+            ("idle", self._idle_touch_fn or _default_idle_touch),
+        )
+        results = []
+        for name, fn in steps:
+            ok = False
+            try:
+                result = fn()
+                if inspect.isawaitable(result):
+                    await result
+                ok = True
+            except Exception:  # noqa: BLE001 -- one arm must not stop the rest
+                logger.warning(
+                    "[GenerationFence] arm %s FAILED (continuing)", name,
+                    exc_info=True,
+                )
+            results.append((name, ok))
+        logger.warning(
+            "[GenerationFence] FENCED own_gen=%d observed_gen=%d arms=%s",
+            self._own_gen,
+            observed_gen,
+            ",".join("%s=%s" % (n, o) for n, o in results),
+        )
+
+
+__all__ = ["GenerationFence", "HEARTBEAT_TOPIC"]

--- a/backend/core/ouroboros/governance/generation_fence.py
+++ b/backend/core/ouroboros/governance/generation_fence.py
@@ -11,36 +11,49 @@ node's mutation pathways -- deterministically, pure code, no LLM.
 
 Operator Mandate 2 (verbatim): the transition "must not just set an
 ``is_fenced=True`` flag; it must structurally terminate the mutation execution
-pathways." We COMPOSE the existing, proven termination machinery rather than
-inventing a new one:
+pathways." The LOAD-BEARING terminators (review-corrected, 2026-07-04):
 
-  1. BOUNDARY ARM -- ``autonomous_workspace._arm_boundary_flags()`` (the LR-A
-     deterministic-lock force-arm of the Async Yield Matrix Sovereign Execution
-     Boundary, PRD s51.11.35 / PR #69638). It arms the flag PAIR
-     ``JARVIS_FILE_ISOLATION_ENABLED`` + ``JARVIS_EXECUTION_BOUNDARY_ENABLED``
-     in-process -- exactly the way its own regression spine arms it
-     (``tests/governance/test_deterministic_isolation_lock.py``) -- so Stage A
-     (commit denial: AutoCommit refuses the primary checkout) and Stage B
-     (file isolation: APPLY routes to a quarantine worktree, never the shared
-     tree) both read armed EVEN IF the flags were explicitly false. This is the
-     physical decoupling of the AutoCommit and APPLY pathways.
-  2. SHUTDOWN REQUEST -- ``cooperative_shutdown.request()``: the process-global
+  0. CHOKEPOINT LATCH (arm 0 -- the hard gate, set FIRST, before the graceful
+     arms): the process-global :func:`is_fenced` latch, consumed FAIL-CLOSED
+     at the two universal mutation chokepoints -- ``ChangeEngine.execute``
+     (every governed disk write funnels through it; the anti-venom
+     ``_pre_write_gate`` chokepoint doctrine) and ``AutoCommitter.commit``
+     (every autonomous commit). A fenced process therefore CANNOT complete an
+     APPLY write or a commit -- including ops already mid-flight past
+     GENERATE, the gap the flag-arm alone left open.
+  1. SHUTDOWN REQUEST -- ``cooperative_shutdown.request()``: the process-global
      wind-down signal the harness itself uses at graceful shutdown. In-flight
      coroutines yield at their next safe boundary; no new work starts.
+
+Composed defense-in-depth (real machinery, but NOT load-bearing for the
+current process in default config -- review finding Important-2):
+
+  2. BOUNDARY ARM -- ``autonomous_workspace._arm_boundary_flags()`` (the LR-A
+     deterministic-lock force-arm of the Async Yield Matrix Sovereign Execution
+     Boundary, PRD s51.11.35 / PR #69638). Arms the flag PAIR
+     ``JARVIS_FILE_ISOLATION_ENABLED`` + ``JARVIS_EXECUTION_BOUNDARY_ENABLED``
+     in-process, exactly the way its own regression spine arms it
+     (``tests/governance/test_deterministic_isolation_lock.py``). CAVEAT: the
+     Stage-B file-isolation consult is BOOT-TIME only
+     (``resolve_loop_project_root`` runs at harness config-construction), and
+     Stage-A commit denial is gated behind
+     ``JARVIS_OPERATOR_COMMIT_AUTHORITY_ENABLED`` (default false) and scopes
+     primary/main -- so on an already-booted default-config node the pair
+     hardens the NEXT boot and OCA-armed setups; arms 0-1 fence the CURRENT
+     process.
   3. CHECKPOINT CAPTURE -- ``fsm_checkpoint.capture_inflight(reason=
      "generation_fenced")``: SUSPEND every in-flight op into a signed
      checkpoint so the SUCCESSOR generation resumes the thought (Mandate 3:
      crypto/payload untouched -- only a new reason STRING flows through the
      existing signer).
-  4. IDLE TOUCH -- ``stream_heartbeat.pulse()``: best-effort beat on the
-     idle fast-path marker (the Move-2-v4 staleness watchdog input, with an
-     optional cross-process file mirror) so the idle machinery observes the
-     fence transition as fresh activity at a deterministic timestamp instead
-     of misreading the wind-down as a stall.
+  4. IDLE TOUCH -- deliberate no-op by default (Minor-4: the only simple idle
+     marker, ``stream_heartbeat.pulse()``, marks FRESH activity -- arguably
+     DELAYING idle-kill of a superseded node; the keeper reaps by manifest
+     regardless). The seam stays injectable for a future genuine surface.
 
 Each step is fail-soft INDIVIDUALLY (one failing arm never stops the others)
-but the transition is deterministic: all four are ALWAYS attempted, in order,
-exactly once per process (idempotent -- a second higher-gen observation
+but the transition is deterministic: latch first, then all four attempted, in
+order, exactly once per process (idempotent -- a second higher-gen observation
 no-ops). Structured evidence line::
 
     [GenerationFence] FENCED own_gen=%d observed_gen=%d arms=...
@@ -54,6 +67,7 @@ from __future__ import annotations
 
 import inspect
 import logging
+import threading
 from typing import Any, Callable, Optional
 
 logger = logging.getLogger(__name__)
@@ -65,6 +79,48 @@ logger = logging.getLogger(__name__)
 HEARTBEAT_TOPIC = "console.keeper_heartbeat"
 
 _FENCE_REASON = "generation_fenced"
+
+
+# --------------------------------------------------------------------------- #
+# Process-global chokepoint latch (arm 0 -- the hard gate).
+#
+# Module-level, thread-safe, ZERO asyncio dependency (the cooperative_shutdown
+# idiom): consumable from any thread/loop, including the synchronous top of
+# ChangeEngine.execute and AutoCommitter.commit. One-way in production; tests
+# reset via _reset_for_tests().
+# --------------------------------------------------------------------------- #
+_latch_lock = threading.Lock()
+_latch_fenced: bool = False
+_latch_reason: str = ""
+
+
+def _mark_fenced(reason: str = _FENCE_REASON) -> None:
+    """Set the process-global fence latch. Idempotent; first reason sticks."""
+    global _latch_fenced, _latch_reason
+    with _latch_lock:
+        if not _latch_fenced:
+            _latch_reason = str(reason or _FENCE_REASON)
+        _latch_fenced = True
+
+
+def is_fenced() -> bool:
+    """True once this process observed a higher Brain generation. Consumed
+    FAIL-CLOSED at the mutation chokepoints (ChangeEngine / AutoCommitter)."""
+    with _latch_lock:
+        return _latch_fenced
+
+
+def fence_reason() -> str:
+    with _latch_lock:
+        return _latch_reason
+
+
+def _reset_for_tests() -> None:
+    """Test hook -- clear the latch (production never unfences a process)."""
+    global _latch_fenced, _latch_reason
+    with _latch_lock:
+        _latch_fenced = False
+        _latch_reason = ""
 
 
 # --------------------------------------------------------------------------- #
@@ -98,28 +154,33 @@ def _default_capture() -> None:
 
 
 def _default_idle_touch() -> None:
-    """Best-effort touch of the idle fast-path marker.
+    """Deliberate no-op (Minor-4, review-corrected).
 
-    ``stream_heartbeat.pulse()`` is the simple existing marker: it stamps the
-    idle/staleness watchdog input (plus the optional cross-process mirror
-    file) so the fence transition itself is the last recorded activity."""
-    from backend.core.ouroboros.governance import stream_heartbeat  # noqa: PLC0415
-    stream_heartbeat.pulse()
+    The only simple idle fast-path marker is ``stream_heartbeat.pulse()``,
+    but pulsing marks FRESH activity -- which arguably DELAYS the idle-kill
+    of a node we want gone. No existing marker accelerates idle-kill, and
+    the keeper reaps superseded nodes by manifest regardless, so the
+    truthful default is: do nothing. The ``idle_touch_fn`` seam stays
+    injectable should a genuine surface appear."""
+    return None
 
 
 class GenerationFence:
     """Subscribe to keeper heartbeats; fence on a higher observed generation.
 
-    All four action seams are injectable (tests use recorders); ``None``
-    resolves to the live default lazily AT FENCE TIME (never at construction).
+    All four graceful action seams are injectable (tests use recorders);
+    ``None`` resolves to the live default lazily AT FENCE TIME (never at
+    construction). Arm 0 -- the process-global chokepoint latch
+    (:func:`is_fenced`) -- is intrinsic, not a seam: it fires first on every
+    fence transition regardless of injected arms.
 
     Args:
         bus: the organism's ``TrinityEventBus`` (``subscribe``/``unsubscribe``).
         own_gen: THIS Brain's minted generation (``JARVIS_BRAIN_GENERATION``).
-        boundary_arm_fn: seam for step 1 (Sovereign Execution Boundary arm).
-        shutdown_fn: seam for step 2 (cooperative shutdown request).
-        capture_fn: seam for step 3 (in-flight checkpoint capture).
-        idle_touch_fn: seam for step 4 (idle fast-path marker touch).
+        boundary_arm_fn: seam for the Sovereign Execution Boundary arm.
+        shutdown_fn: seam for the cooperative shutdown request.
+        capture_fn: seam for the in-flight checkpoint capture.
+        idle_touch_fn: seam for the idle touch (default: truthful no-op).
     """
 
     def __init__(
@@ -192,8 +253,14 @@ class GenerationFence:
     async def _fence(self, observed_gen: int) -> None:
         """The deterministic ordered transition -- see the module docstring.
 
-        Each step is fail-soft individually, but ALL are attempted, in order.
+        Arm 0 (the hard gate) fires FIRST: the process-global chokepoint
+        latch, pure assignment, cannot fail. Then the four graceful arms,
+        each fail-soft individually, ALL attempted, in order.
         """
+        # Arm 0 -- the chokepoint latch. From this line on, ChangeEngine
+        # refuses every APPLY write and AutoCommitter refuses every commit
+        # in this process, mid-flight ops included.
+        _mark_fenced(_FENCE_REASON)
         steps = (
             ("boundary", self._boundary_arm_fn or _default_boundary_arm),
             ("shutdown", self._shutdown_fn or _default_shutdown),
@@ -215,11 +282,17 @@ class GenerationFence:
                 )
             results.append((name, ok))
         logger.warning(
-            "[GenerationFence] FENCED own_gen=%d observed_gen=%d arms=%s",
+            "[GenerationFence] FENCED own_gen=%d observed_gen=%d "
+            "latch=True arms=%s",
             self._own_gen,
             observed_gen,
             ",".join("%s=%s" % (n, o) for n, o in results),
         )
 
 
-__all__ = ["GenerationFence", "HEARTBEAT_TOPIC"]
+__all__ = [
+    "GenerationFence",
+    "HEARTBEAT_TOPIC",
+    "fence_reason",
+    "is_fenced",
+]

--- a/backend/core/ouroboros/governance/saga/saga_apply_strategy.py
+++ b/backend/core/ouroboros/governance/saga/saga_apply_strategy.py
@@ -66,14 +66,39 @@ except ImportError:
     _ANTI_VENOM_GATE_AVAILABLE = False
 
 
-def _gate_path(full_path: Path, repo_root: Path) -> None:
+def _gate_path(full_path: Path, repo_root: Path, *, forward: bool = True) -> None:
     """Anti-Venom pre-write gate for saga write sites. FAIL-CLOSED.
 
     Calls :func:`assert_write_path_allowed` (containment + immutable-
     governance + protected-path) before any raw ``write_bytes`` in a saga
     apply or compensation step.  Raises ``RuntimeError`` if the gate module
     is unavailable so that an import failure never silently opens the gate.
+
+    ``forward`` (Stage-4 GenerationFence, Task-4 re-review): FORWARD writes
+    (apply-phase CREATE/MODIFY/DELETE -- the cross_repo mutation path) also
+    consult the process-global :func:`generation_fence.is_fenced` latch and
+    are DENIED on a fenced node (a superseded twin must not mutate any repo).
+    Compensation/ROLLBACK writes pass ``forward=False`` and are EXEMPT --
+    a fenced node may still restore preimages (rolling back is how it
+    honors the fence, not a violation of it). The fence import is
+    deliberately unguarded: this gate's doctrine is that an import failure
+    never silently opens it. ``forward`` defaults to True so any FUTURE
+    call site is fence-covered unless it explicitly claims the
+    compensation exemption.
     """
+    if forward:
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            generation_fence as _generation_fence,
+        )
+        if _generation_fence.is_fenced():
+            logger.warning(
+                "[GenerationFence] saga forward-write DENIED "
+                "(generation_fenced) path=%s", full_path,
+            )
+            raise RuntimeError(
+                "POLICY_DENIED reason=generation_fenced -- saga forward-write "
+                f"refused on a fenced node: {full_path}"
+            )
     if not _ANTI_VENOM_GATE_AVAILABLE or _assert_write_path_allowed is None:
         raise RuntimeError(
             f"Anti-Venom gate unavailable — fail-closed write to {full_path}"
@@ -509,12 +534,14 @@ class SagaApplyStrategy:
             full_path = repo_root / pf.path
             if pf.op == FileOp.CREATE:
                 if full_path.exists():
-                    _gate_path(full_path, repo_root)  # Anti-Venom: gate compensation unlink — phantom-file deletion vector
+                    # forward=False: ROLLBACK is exempt from the GenerationFence
+                    # (a fenced node may still restore preimages).
+                    _gate_path(full_path, repo_root, forward=False)  # Anti-Venom: gate compensation unlink -- phantom-file deletion vector
                     full_path.unlink()
             elif pf.op in (FileOp.MODIFY, FileOp.DELETE):
                 # preimage is guaranteed non-None for MODIFY/DELETE by PatchedFile.__post_init__
                 full_path.parent.mkdir(parents=True, exist_ok=True)
-                _gate_path(full_path, repo_root)  # Anti-Venom: gate compensation write too
+                _gate_path(full_path, repo_root, forward=False)  # Anti-Venom: gate compensation write too (fence-exempt: rollback)
                 full_path.write_bytes(pf.preimage)  # type: ignore[arg-type]
             to_unstage.append(pf.path)
 

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -1680,6 +1680,41 @@ def _maybe_observe_tool_confidence(
         )
 
 
+def _generation_fence_denial(tool_name: str, path: object) -> Optional[str]:
+    """Stage-4 GenerationFence chokepoint for the venom tool-loop write
+    surface (Task-4 re-review Important-2).
+
+    ``write_file``/``edit_file`` mutate disk DIRECTLY during GENERATE, so a
+    heartbeat that fences the node mid-tool-loop could otherwise land writes
+    in the window before the arm-1 cooperative shutdown bites. FAIL-CLOSED:
+    an unreadable latch DENIES the write (cannot prove unfenced -> do not
+    mutate); handlers never raise, so the denial is the handlers' established
+    error-string shape. Returns None when unfenced (zero behavior change).
+    """
+    fenced = True
+    try:
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            generation_fence as _generation_fence,
+        )
+        fenced = bool(_generation_fence.is_fenced())
+    except Exception:  # noqa: BLE001 -- fail-closed, never raises
+        logger.error(
+            "[GenerationFence] latch unavailable at tool_executor -- "
+            "refusing %s (fail-closed)", tool_name, exc_info=True,
+        )
+    if not fenced:
+        return None
+    logger.warning(
+        "[GenerationFence] tool write DENIED at tool_executor "
+        "(generation_fenced) tool=%s path=%s", tool_name, path,
+    )
+    return (
+        "(%s: POLICY_DENIED reason=generation_fenced -- this node observed "
+        "a higher Brain generation; its mutation pathways are structurally "
+        "fenced. Do not retry writes.)" % tool_name
+    )
+
+
 class ToolExecutor:
     """Dispatch ToolCall objects to read-only introspection handlers.
 
@@ -2506,6 +2541,11 @@ class ToolExecutor:
             BEFORE disk write — failures never reach the filesystem.
           * Post-write hash mismatch triggers automatic rollback.
         """
+        # --- Layer 0: GenerationFence (Stage-4 split-brain) -----------
+        _fence_denial = _generation_fence_denial("edit_file", args.get("path"))
+        if _fence_denial is not None:
+            return _fence_denial
+
         path_str: str = args["path"]
         old_text: str = args["old_text"]
         new_text: str = args["new_text"]
@@ -2699,6 +2739,11 @@ class ToolExecutor:
           * Post-write hash mismatch triggers rollback (restore snapshot
             for overwrites, unlink for new files).
         """
+        # --- Layer 0: GenerationFence (Stage-4 split-brain) -----------
+        _fence_denial = _generation_fence_denial("write_file", args.get("path"))
+        if _fence_denial is not None:
+            return _fence_denial
+
         path_str: str = args["path"]
         file_content: str = args["content"]
 

--- a/backend/core/ouroboros/governance/transport/bus_bridge_client.py
+++ b/backend/core/ouroboros/governance/transport/bus_bridge_client.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 import asyncio
 import logging
 import random
-from collections import OrderedDict
+from collections import OrderedDict, deque
 from dataclasses import fields as dataclass_fields
-from typing import Any, Awaitable, Callable, Dict, Optional
+from typing import Any, Awaitable, Callable, Deque, Dict, List, Optional, Tuple
 
 import aiohttp
 
@@ -96,10 +96,34 @@ class BusBridgeClient:
         self._last_sent_id: Optional[str] = initial_last_sent_id
         self._on_ack = on_ack
         # Stage 3 WAL-trim cursor: the last event_id the SERVER has
-        # confirmed ingesting on this connection. Monotonic -- only ever
-        # advances, so a stray regressive/duplicate ack (out-of-order
-        # delivery, replay) cannot rewind a later trim decision.
+        # confirmed ingesting on this connection. Stage-4 Task 2:
+        # monotonicity is tracked by SEND-SEQUENCE POSITION (below), not
+        # numeric id -- priority replay sends ids out of numeric order,
+        # so a numerically-lower id acked LATER is forward progress.
         self._last_acked_id: Optional[str] = None
+        # Stage-4 Task 2: per-connection SEND SEQUENCE -- event ids in
+        # the order actually sent (WAL-seeded replay first, then the
+        # live pump). The server's ack names its last-INGESTED id on
+        # this TCP-ordered connection; locating it in this sequence
+        # confirms EVERY id sent at or before that position
+        # (send-order-cumulative). Reset on every new connection.
+        #   _send_index: id -> FIRST-send position (conservative when a
+        #       replay/live overlap re-sends an id: mapping the ack to
+        #       the earliest position can only under-confirm, never
+        #       over-confirm -- a later ack or the idle-flush catches
+        #       the tail).
+        #   _send_unconfirmed: (position, id) FIFO of not-yet-confirmed
+        #       sends; confirmation always consumes a send-order prefix.
+        #   _acked_pos: high-water confirmed position (send-space
+        #       monotonic guard).
+        # Bounded: past _DEDUP_MAX unconfirmed sends the oldest entry is
+        # evicted; its eventual ack degrades to the exact-single-id
+        # fallback path in _apply_ack (safe: the durable trim is
+        # exact-set).
+        self._send_index: Dict[str, int] = {}
+        self._send_unconfirmed: Deque[Tuple[int, str]] = deque()
+        self._send_count = 0
+        self._acked_pos = -1
         # Stage 3 Task 3: per-attempt discovery re-race + WAL-seeded replay.
         # Both default None = Stage-2-identical behavior.
         self._url_resolver = url_resolver
@@ -124,6 +148,48 @@ class BusBridgeClient:
         self._republished[eid] = None
         if len(self._republished) > _DEDUP_MAX:
             self._republished.popitem(last=False)
+
+    # --- Stage-4 Task 2: per-connection send sequence ----------------------
+
+    def _reset_send_sequence(self) -> None:
+        """New connection = new send sequence. The server's ingest cursor
+        (and therefore its acks) is per-connection state; positions from
+        a previous link must never confirm sends on this one."""
+        self._send_index = {}
+        self._send_unconfirmed = deque()
+        self._send_count = 0
+        self._acked_pos = -1
+
+    def _record_sent(self, event_id: str) -> None:
+        """Record an event frame actually WRITTEN to the socket, in send
+        order. First-send position wins for duplicates (see __init__
+        comment: conservative -- under-confirmation is safe, over-
+        confirmation is the over-trim class)."""
+        if not event_id or event_id in self._send_index:
+            return
+        pos = self._send_count
+        self._send_count += 1
+        self._send_index[event_id] = pos
+        self._send_unconfirmed.append((pos, event_id))
+        if len(self._send_unconfirmed) > _DEDUP_MAX:
+            old_pos, old_id = self._send_unconfirmed.popleft()
+            self._send_index.pop(old_id, None)
+            logger.debug(
+                "[BusBridgeClient] send-sequence bound reached; evicted "
+                "oldest unconfirmed send pos=%d id=%s (its ack degrades "
+                "to exact-single-id confirmation)", old_pos, old_id)
+
+    def _fire_on_ack(self, event_id: str) -> None:
+        """Invoke the on_ack callback fail-soft -- a raising callback
+        must never take down the inbound pump (nor abort the remaining
+        ids of a cumulative confirmation)."""
+        if self._on_ack is None:
+            return
+        try:
+            self._on_ack(event_id)
+        except Exception:  # noqa: BLE001 -- fail-soft, never crash the pump
+            logger.debug(
+                "[BusBridgeClient] on_ack callback raised", exc_info=True)
 
     @property
     def last_event_id(self) -> Optional[str]:
@@ -244,6 +310,10 @@ class BusBridgeClient:
                 )
                 self._connected = True
                 self._active_ws = ws
+                # Fresh connection -> fresh send sequence (Stage-4 Task 2):
+                # ack positions are only meaningful against the sends of
+                # THIS link.
+                self._reset_send_sequence()
                 # WAL-seeded replay FIRST (the oldest truth), then the live
                 # pump's broker-cursor replay -- overlap dedup is the
                 # SERVER's job (qualified-id _mark_seen).
@@ -263,24 +333,34 @@ class BusBridgeClient:
             await session.close()
 
     async def _replay_durable(self, ws: aiohttp.ClientWebSocketResponse) -> None:
-        """WAL-seeded replay (Stage 3 Task 3): send every pending journal
-        entry (already id-ordered by ``durable.pending()``) BEFORE the live
+        """WAL-seeded replay (Stage 3 Task 3; PRIORITY-ordered by Stage-4
+        Task 2): send every pending journal entry BEFORE the live
         outbound pump starts. The WAL outlives the broker's bounded history
         ring, so this recovers spans the broker-cursor replay physically
-        cannot.
+        cannot. When the durable exposes ``pending_prioritized`` the
+        backlog is replayed in ``(urgency_rank, event_id)`` order --
+        IMMEDIATE-class signals cross the reborn link first -- with the
+        sort computed off-loop; older durables fall back to the
+        id-ordered ``pending()`` (backward compatible).
 
         No trim on send -- trim is exclusively ack-driven (Task 1 ack lane
-        -> Task 2 ``on_ack``); an entry stays journaled until the server
-        confirms ingesting past it, so a mid-replay drop just resends on
-        the next attempt. Malformed entries are skipped per-entry
+        -> exact-set ``on_ack``); an entry stays journaled until the server
+        confirms ingesting it, so a mid-replay drop just resends on
+        the next attempt. Every sent id is recorded in the per-connection
+        send sequence, which is what makes the server's acks cumulative
+        in SEND order. Malformed entries are skipped per-entry
         (fail-soft); a dead socket propagates to the reconnect loop."""
         if self._durable is None:
             return
         try:
-            entries = self._durable.pending()
+            prioritized = getattr(self._durable, "pending_prioritized", None)
+            if prioritized is not None:
+                entries = await prioritized()
+            else:
+                entries = self._durable.pending()
         except Exception:  # noqa: BLE001 -- a broken WAL must not block connect
             logger.debug(
-                "[BusBridgeClient] durable.pending() failed; skipping "
+                "[BusBridgeClient] durable pending read failed; skipping "
                 "WAL replay", exc_info=True)
             return
         if not entries:
@@ -292,10 +372,12 @@ class BusBridgeClient:
                 continue  # malformed journal entry -- skip, keep replaying
             await ws.send_bytes(
                 bf.event_frame(ev, source_id=self._cfg.source_id).encode())
+            self._record_sent(ev.event_id)
             sent += 1
         logger.debug(
-            "[BusBridgeClient] WAL replay: sent %d/%d pending entries",
-            sent, len(entries))
+            "[BusBridgeClient] WAL replay: sent %d/%d pending entries "
+            "(priority order: %s)", sent, len(entries),
+            prioritized is not None)
 
     async def _pump_outbound(self, ws: aiohttp.ClientWebSocketResponse) -> None:
         """Subscribe to the local broker and stream events (with
@@ -324,6 +406,7 @@ class BusBridgeClient:
                     continue
                 frame = bf.event_frame(event, source_id=self._cfg.source_id)
                 await ws.send_bytes(frame.encode())
+                self._record_sent(event.event_id)
                 self._last_sent_id = event.event_id
         except (asyncio.CancelledError, ConnectionResetError):
             raise
@@ -359,23 +442,51 @@ class BusBridgeClient:
             self._apply_inbound(frame)
 
     def _apply_ack(self, frame: bf.BusFrame) -> None:
-        """Advance the ack cursor monotonically. Zero-padded hex event ids
-        compare correctly as strings, so a plain ``<=`` comparison is the
-        regressive/duplicate guard -- no int parsing needed. Fail-soft: an
-        ``on_ack`` callback that raises must never take down the inbound
-        pump."""
+        """SEND-ORDER-CUMULATIVE ack application (Stage-4 Task 2).
+
+        The server acks the last event id it INGESTED on this connection
+        (unchanged, TCP-ordered). Replay is priority-ordered now, so the
+        old numeric-id cumulation is wrong: an ack for a high IMMEDIATE
+        id sent FIRST must not imply anything about numerically-lower
+        ids that were never sent. New interpretation: locate the acked
+        id in this connection's SEND sequence -- TCP ordering guarantees
+        every frame sent at or before that position was received -- and
+        confirm each not-yet-confirmed id in that prefix, in send order,
+        via ``on_ack`` (fail-soft per id; the durable's trim is
+        exact-set). ``last_acked_id`` monotonicity is positional
+        (send-space), not numeric.
+
+        An acked id NOT in this connection's send sequence (nothing was
+        sent on this link yet, a pre-reconnect ack raced the sever, or
+        the bounded index evicted it) never expands cumulatively --
+        that would be the over-trim class. It degrades to a SINGLE
+        exact-id confirmation under the legacy numeric-monotonic guard,
+        which is safe by construction: the server attested ingesting
+        exactly that id, and the durable's exact-set ``on_ack`` trims
+        only it."""
         new_id = frame.last_event_id
         if not new_id:
             return
-        current = self._last_acked_id
-        if current is not None and new_id <= current:
-            return  # regressive or duplicate -- ignored
+        pos = self._send_index.get(new_id)
+        if pos is None:
+            current = self._last_acked_id
+            if current is not None and new_id <= current:
+                return  # regressive or duplicate -- ignored
+            logger.debug(
+                "[BusBridgeClient] ack for id outside this connection's "
+                "send sequence: %s -- exact-single-id confirmation only",
+                new_id)
+            self._last_acked_id = new_id
+            self._fire_on_ack(new_id)
+            return
+        if pos <= self._acked_pos:
+            return  # regressive or duplicate in send-space -- ignored
+        self._acked_pos = pos
         self._last_acked_id = new_id
-        if self._on_ack is not None:
-            try:
-                self._on_ack(new_id)
-            except Exception:  # noqa: BLE001 -- fail-soft, never crash the pump
-                logger.debug("[BusBridgeClient] on_ack callback raised", exc_info=True)
+        while self._send_unconfirmed and self._send_unconfirmed[0][0] <= pos:
+            _, eid = self._send_unconfirmed.popleft()
+            self._send_index.pop(eid, None)
+            self._fire_on_ack(eid)
 
     def _apply_inbound(self, frame: bf.BusFrame) -> None:
         ev_dict = frame.event or {}

--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -13,10 +13,21 @@ bounded history ring (512 default) is merely a hot cache.
 
 Trim is ack-driven: Task 1 armed the ack lane (``BusBridgeClient``'s
 ``on_ack`` constructor kwarg); wiring that callback to
-:meth:`DurableOutbound.on_ack` tombstones every journaled entry with
-``lease_id <= acked_event_id`` (event ids are zero-padded 012x hex, so
-plain string comparison is correct) and compacts the file every
-``JARVIS_BODY_WAL_COMPACT_EVERY_N`` acks.
+:meth:`DurableOutbound.on_ack` tombstones journaled entries and compacts
+the file every ``JARVIS_BODY_WAL_COMPACT_EVERY_N`` acks.
+
+Stage-4 Task 2 -- EXACT-SET trim + priority replay. Replay is now
+PRIORITY-ordered (:meth:`pending_prioritized` /
+``pending(order="priority")``, sorted by ``(urgency_rank, event_id)``
+with ranks imported from the UrgencyRouter vocabulary -- never
+re-declared here), which breaks the Stage-3 id-order assumption that
+made a cumulative ``lease_id <= acked_event_id`` sweep correct: an ack
+for a high IMMEDIATE id sent FIRST must not sweep numerically-lower ids
+that were never sent. :meth:`on_ack` therefore trims EXACTLY the acked
+id (idempotent against replays of the same id); cumulation moved to the
+CLIENT, whose send-order-cumulative ``_apply_ack`` fires ``on_ack`` once
+per confirmed id in send order. This also retires the Stage-3 strand
+class where an ack racing an offloaded append could sweep unsent ids.
 
 Durability heavy-lifting is the intake WAL, reused verbatim (operator
 DRY mandate): flock-serialized append per line (fsync happens on
@@ -65,15 +76,101 @@ from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
+from backend.core.ouroboros.governance.background_agent_pool import (
+    _ROUTE_PRIORITY,
+)
 from backend.core.ouroboros.governance.cooperative_fs_io import (
     is_offload_error,
     offload,
 )
 from backend.core.ouroboros.governance.intake.wal import WAL, WALEntry
+from backend.core.ouroboros.governance.urgency_router import (
+    ProviderRoute,
+    _BACKGROUND_SOURCES,
+    _BACKGROUND_URGENCIES,
+    _IMMEDIATE_SOURCES,
+    _IMMEDIATE_URGENCIES,
+    _SPECULATIVE_SOURCES,
+)
 
 logger = logging.getLogger(__name__)
 
 _HEX_DIGITS = frozenset("0123456789abcdef")
+
+# ---------------------------------------------------------------------------
+# Stage-4 Task 2: urgency -> replay rank, derived ENTIRELY from the
+# UrgencyRouter vocabulary (operator mandate: no re-declared rank table).
+# The priority ints come from the pool's canonical _ROUTE_PRIORITY map
+# (IMMEDIATE=1 ... SPECULATIVE=7, keyed by ProviderRoute values); the
+# urgency/source affinity sets are the router's own frozensets.
+# ---------------------------------------------------------------------------
+
+_STANDARD_RANK = _ROUTE_PRIORITY[ProviderRoute.STANDARD.value]
+
+
+def _route_rank(route: ProviderRoute) -> int:
+    """Priority int for a route, from the imported canonical table.
+    Routes absent from the table (INFORMATIONAL / WIRING_VALIDATION)
+    rank STANDARD -- the default cascade."""
+    return _ROUTE_PRIORITY.get(route.value, _STANDARD_RANK)
+
+
+def urgency_rank(envelope_dict: Dict[str, Any]) -> int:
+    """Replay rank for a journaled WAL entry's StreamEvent dict.
+
+    Trinity-bridged intake signals carry the IntentEnvelope at
+    ``envelope_dict["payload"]["data"]`` (RemoteIntakeSubmitter publishes
+    ``envelope.to_dict()`` as the TrinityEvent payload;
+    ``TrinityBusBridge._on_outbound`` wraps it as
+    ``{"topic": ..., "data": <envelope dict>, "origin": ...}``). The
+    envelope's ``urgency`` (critical/high/normal/low) plus ``source``
+    map onto the UrgencyRouter's Priority 1-3 matrix (the deterministic
+    subset a WAL entry can know -- complexity/file-count classification
+    needs the live ROUTE phase and is unavailable here):
+
+      * urgency in _IMMEDIATE_URGENCIES            -> IMMEDIATE
+      * urgency == "high" + source immediate-class -> IMMEDIATE
+      * source speculative-class + low/normal      -> SPECULATIVE
+      * low urgency + source background-class      -> BACKGROUND
+      * everything else / missing / garbage        -> STANDARD
+
+    Tolerant by mandate: any shape violation ranks STANDARD. NEVER
+    raises. Lower rank replays first.
+    """
+    try:
+        payload = envelope_dict.get("payload") if isinstance(
+            envelope_dict, dict) else None
+        data = payload.get("data") if isinstance(payload, dict) else None
+        if not isinstance(data, dict):
+            return _STANDARD_RANK
+        urgency_raw = data.get("urgency")
+        source_raw = data.get("source")
+        urgency = urgency_raw.strip().lower() if isinstance(
+            urgency_raw, str) else ""
+        source = source_raw.strip().lower() if isinstance(
+            source_raw, str) else ""
+        if urgency in _IMMEDIATE_URGENCIES:
+            return _route_rank(ProviderRoute.IMMEDIATE)
+        if urgency == "high" and source in _IMMEDIATE_SOURCES:
+            return _route_rank(ProviderRoute.IMMEDIATE)
+        if source in _SPECULATIVE_SOURCES and urgency in ("low", "normal"):
+            return _route_rank(ProviderRoute.SPECULATIVE)
+        if urgency in _BACKGROUND_URGENCIES and source in _BACKGROUND_SOURCES:
+            return _route_rank(ProviderRoute.BACKGROUND)
+        return _STANDARD_RANK
+    except Exception:  # noqa: BLE001 -- shape tolerance is the contract
+        return _STANDARD_RANK
+
+
+def _sorted_priority_envelopes(
+    snapshot: List[Tuple[str, WALEntry]],
+) -> List[Dict[str, Any]]:
+    """Sync sort worker for :meth:`DurableOutbound.pending_prioritized`
+    -- ALWAYS dispatched off-loop via ``offload`` (operator mandate: no
+    blocking sort of a large backlog on the event loop)."""
+    snapshot.sort(
+        key=lambda pair: (urgency_rank(pair[1].envelope_dict), pair[0]))
+    return [dict(entry.envelope_dict) for _, entry in snapshot]
 
 
 def _repo_root() -> Path:
@@ -294,8 +391,11 @@ class DurableOutbound:
 
     # --- public read surface -------------------------------------------------
 
-    def pending(self) -> List[Dict[str, Any]]:
-        """Pending envelopes ordered by event_id (monotonic hex).
+    def pending(self, order: str = "id") -> List[Dict[str, Any]]:
+        """Pending envelopes, ordered by event_id (monotonic hex) by
+        default. ``order="priority"`` (Stage-4 Task 2) sorts by
+        ``(urgency_rank(entry), event_id)`` instead -- IMMEDIATE-class
+        entries first, id-ordered within each class.
 
         Reflects acked-in-memory IMMEDIATELY: entries whose ack tombstone
         is still in flight to disk are already excluded.
@@ -304,12 +404,47 @@ class DurableOutbound:
         the ack flush pops entries from an offload THREAD, and iterating
         the live dict here races that mutation (RuntimeError: dict
         changed size during iteration).
+
+        SYNC api -- legacy callers unchanged. Async callers replaying a
+        large backlog should use :meth:`pending_prioritized`, which
+        computes the sort off-loop.
         """
         self._ensure_loaded()
         live = [(lid, entry) for lid, entry in list(self._pending.items())
                 if lid not in self._ack_inflight]
+        if order == "priority":
+            return _sorted_priority_envelopes(live)
         live.sort(key=lambda pair: pair[0])
         return [dict(entry.envelope_dict) for _, entry in live]
+
+    async def pending_prioritized(self) -> List[Dict[str, Any]]:
+        """Priority-ordered pending snapshot with the sort computed
+        OFF-LOOP (Stage-4 Task 2 operator mandate: ``_replay_durable``
+        is async and must never block the event loop sorting a large
+        backlog). The snapshot itself is a cheap on-loop list copy; the
+        ``(urgency_rank, event_id)`` sort + envelope materialization run
+        through the offload substrate. A broken offload fails soft to
+        the legacy id-ordered snapshot (same cost class as the sync
+        :meth:`pending` every legacy caller already pays)."""
+        if not self._loaded:
+            self._loaded = True
+            entries = await offload(self._wal.pending_entries)
+            if is_offload_error(entries):
+                logger.debug(
+                    "[DurableOutbound] WAL recovery read failed: %s", entries)
+            else:
+                for entry in entries:
+                    self._pending.setdefault(entry.lease_id, entry)
+        snapshot = [(lid, entry) for lid, entry in list(self._pending.items())
+                    if lid not in self._ack_inflight]
+        result = await offload(_sorted_priority_envelopes, snapshot)
+        if is_offload_error(result):
+            logger.debug(
+                "[DurableOutbound] offloaded priority sort failed: %s -- "
+                "falling back to id order", result)
+            snapshot.sort(key=lambda pair: pair[0])
+            return [dict(entry.envelope_dict) for _, entry in snapshot]
+        return result
 
     def pending_count(self) -> int:
         self._ensure_loaded()
@@ -330,30 +465,43 @@ class DurableOutbound:
     # --- ack lane (Task-1 hook target) ---------------------------------------
 
     def on_ack(self, acked_event_id: str) -> None:
-        """Cumulative-cursor trim. Cheap + non-blocking -- safe to call
-        straight from BusBridgeClient's inbound loop.
+        """EXACT-SET trim (Stage-4 Task 2). Cheap + non-blocking -- safe
+        to call straight from BusBridgeClient's inbound loop.
 
-        Marks every pending entry with ``lease_id <= acked_event_id``
-        acked in memory immediately, then fires the disk tombstone work
-        through the offload substrate (fail-soft, fire-and-forget).
-        Never raises.
+        Trims EXACTLY ``acked_event_id`` -- never a ``<=`` sweep. Replay
+        is priority-ordered now, so an ack for a high IMMEDIATE id sent
+        FIRST proves nothing about numerically-lower ids that may never
+        have been sent (the Stage-3 over-trim strand class; it also
+        covered an ack racing an offloaded append). Cumulation is the
+        CLIENT's job: its send-order-cumulative ``_apply_ack`` calls
+        this once per confirmed id, in send order.
+
+        Idempotent against replays of the same id (already trimmed /
+        already in-flight -> no-op, modulo draining any parked ack
+        retries). Marks the entry acked in memory immediately, then
+        fires the disk tombstone work through the offload substrate
+        (fail-soft, fire-and-forget). Never raises.
         """
         try:
             if not acked_event_id:
                 return
+            # Observability cursor: highest id ever exact-acked. No longer
+            # a cumulative sweep boundary -- see _journal_event for why the
+            # <= duplicate-guard there remains sound (broker ids are
+            # strictly monotonic within a lifetime).
             if self._ack_cursor is None or acked_event_id > self._ack_cursor:
                 self._ack_cursor = acked_event_id
-            # Task-3 carry-forward (re-review): at-risk entries are NOT
-            # purged by the ack cursor. The server acks its last-ingested
-            # id -- a cumulative ack for Y cannot prove it ever RECEIVED
-            # an earlier gap X (X may be exactly what the failed append
-            # lost). Retention costs only a duplicate send, which the
-            # server's qualified-id dedup absorbs; a purge here loses X
-            # forever if the process dies before it lands in the WAL.
-            # _retry_at_risk keeps re-attempting until the append lands.
-            ids = sorted(
-                lid for lid in list(self._pending)
-                if lid <= acked_event_id and lid not in self._ack_inflight)
+            # Task-3 carry-forward (re-review): an at-risk entry (failed
+            # append, memory-only) is NOT purged by its ack -- the ack
+            # proves the server INGESTED the live send, not that the entry
+            # is durably journaled; purging it here loses it forever if
+            # the process dies before the append lands. _retry_at_risk
+            # keeps re-attempting; the eventual duplicate delivery is
+            # absorbed by server-side qualified-id dedup.
+            ids: List[str] = []
+            if (acked_event_id in self._pending
+                    and acked_event_id not in self._ack_inflight):
+                ids.append(acked_event_id)
             if not ids and not self._ack_retry:
                 return
             self._ack_inflight.update(ids)
@@ -408,7 +556,13 @@ class DurableOutbound:
                 or event_id in self._at_risk):
             return
         if self._ack_cursor is not None and event_id <= self._ack_cursor:
-            return  # the far side already acked past this id
+            # Duplicate guard, still sound under exact-set acks (Stage-4
+            # Task 2): broker ids are strictly monotonic within a
+            # lifetime and _consume sees publishes in id order, so any
+            # id at-or-below the highest EXACT-acked id can only be a
+            # replay of a publish this journal already processed --
+            # never a fresh event.
+            return
         await self._enforce_capacity()
         # Bounded at-risk retry: each journal cycle re-attempts every
         # previously-failed append exactly once (review CRITICAL).

--- a/backend/core/ouroboros/governance/transport/organism_bus_host.py
+++ b/backend/core/ouroboros/governance/transport/organism_bus_host.py
@@ -34,6 +34,26 @@ logger = logging.getLogger(__name__)
 
 _ENV_OUTBOUND_TOPICS = "JARVIS_BRAIN_OUTBOUND_TOPICS"
 _DEFAULT_OUTBOUND_TOPICS = "actuation.*,telemetry.posture.*"
+_ENV_BRAIN_GENERATION = "JARVIS_BRAIN_GENERATION"
+
+
+def _brain_generation() -> int:
+    """This Brain's minted generation (Stage-4 Task 4).
+
+    ``JARVIS_BRAIN_GENERATION`` is folded onto the node by the keeper's
+    provision path (``brain_keeper.py`` extra_env -> ``brain_lifecycle.
+    brain_env_values``). Unset / blank / unparseable / <=0 -> 0 (no fence
+    -- byte-identical pre-Stage-4 behavior)."""
+    raw = (os.environ.get(_ENV_BRAIN_GENERATION) or "").strip()
+    if not raw:
+        return 0
+    try:
+        return max(0, int(raw))
+    except ValueError:
+        logger.warning(
+            "[OrganismBusHost] unparseable %s=%r -- generation fence stays "
+            "dark", _ENV_BRAIN_GENERATION, raw)
+        return 0
 
 
 def bus_host_enabled() -> bool:
@@ -74,6 +94,7 @@ class OrganismBusHost:
         self._bus: Optional[Any] = None  # DistributedEventBus (server role)
         self._bridge: Optional[Any] = None  # TrinityBusBridge
         self._intake_bridge: Optional[Any] = None  # RemoteIntakeBridge (Task 3)
+        self._generation_fence: Optional[Any] = None  # GenerationFence (Stage-4 Task 4)
         self._runner: Optional[Any] = None  # aiohttp AppRunner
         self._site: Optional[Any] = None  # aiohttp TCPSite
         self._started = False
@@ -167,6 +188,11 @@ class OrganismBusHost:
                 self._intake_bridge = RemoteIntakeBridge(
                     trinity_bus, self._router)
                 await self._intake_bridge.start()
+
+            # Stage-4 Task 4: the Brain-side ACTIVE fence. Only on nodes
+            # the keeper stamped with a generation (env absent -> byte-
+            # identical, no import).
+            await self._maybe_start_generation_fence(trinity_bus)
         except Exception as exc:  # noqa: BLE001 -- fail-soft: unwind + dark
             logger.warning(
                 "[OrganismBusHost] start failed (staying dark): %s", exc,
@@ -184,10 +210,31 @@ class OrganismBusHost:
         )
         return True
 
+    async def _maybe_start_generation_fence(self, trinity_bus: Any) -> None:
+        """Construct + start the split-brain GenerationFence (Stage-4 Task 4)
+        when ``JARVIS_BRAIN_GENERATION`` is set (>0). Env absent/invalid ->
+        nothing constructed, nothing imported (byte-identical -- the file's
+        established lazy-import-inside-guard pattern)."""
+        own_gen = _brain_generation()
+        if own_gen <= 0:
+            return
+        from backend.core.ouroboros.governance import generation_fence  # noqa: PLC0415
+
+        self._generation_fence = generation_fence.GenerationFence(
+            trinity_bus, own_gen)
+        await self._generation_fence.start()
+
     async def stop(self) -> None:
         """Unwind in reverse order. Never raises (fail-soft teardown);
         no-op on a never-started host."""
         self._started = False
+        if self._generation_fence is not None:
+            try:
+                await self._generation_fence.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug("[OrganismBusHost] generation fence stop failed",
+                             exc_info=True)
+            self._generation_fence = None
         if self._intake_bridge is not None:
             try:
                 await self._intake_bridge.stop()

--- a/scripts/ignite_brain_vm.py
+++ b/scripts/ignite_brain_vm.py
@@ -69,6 +69,22 @@ _REPO_ROOT: str = os.path.dirname(_SCRIPTS_DIR)
 if _REPO_ROOT not in sys.path:
     sys.path.insert(0, _REPO_ROOT)
 
+# Stage-4 Task 1: the provisioning core (brain-env compose, TLS metadata
+# delivery, runtime startup script, create composition) is EXTRACTED into the
+# reusable ``brain_lifecycle`` module; this driver consumes it. The helpers are
+# re-exported here so existing consumers/tests keep importing them from the
+# driver (back-compat surface, byte-equivalent behavior).
+from backend.core.ouroboros.governance.brain_lifecycle import (  # noqa: E402
+    _NODE_TLS_DIR,
+    _TLS_META_KEYS,
+    TLSMaterialError,
+    _brain_runtime_startup_script,
+    _tls_extra_metadata,
+    _tls_material,
+    brain_env_values,
+    provision_brain,
+)
+
 
 def _log(msg: str) -> None:
     print("[BrainIgnite] %s" % (msg,), flush=True)
@@ -106,53 +122,10 @@ _ENV_READY_CAP_S = "JARVIS_BRAIN_READY_CAP_S"
 _ENV_EXCHANGE_N = "JARVIS_BRAIN_EXCHANGE_N"
 _ENV_MTLS_DIR = "JARVIS_BRAIN_MTLS_DIR"
 
-# The server-side TLS material travels from the Mac (gen_brain_mtls.py output)
-# to the node as instance metadata; the runtime startup script writes it to
-# these node-local paths BEFORE the units start, and brain.env points at them.
-_NODE_TLS_DIR = "/etc/jarvis/tls"
-_TLS_META_KEYS = {
-    "server_cert": ("brain-tls-server-cert", "server-cert.pem"),
-    "server_key": ("brain-tls-server-key", "server-key.pem"),
-    "ca": ("brain-tls-ca", "ca.pem"),
-}
-
-
-class TLSMaterialError(RuntimeError):
-    """TLS is enabled but the server material is absent/incomplete. Raised in the
-    driver preflight BEFORE any GCP call (fail-closed, $0)."""
-
-
-def _tls_material() -> Optional[Dict[str, str]]:
-    """Load the SERVER PEM material (server cert/key + CA) from
-    ``JARVIS_BRAIN_MTLS_DIR`` (the gen_brain_mtls.py output dir). Returns None
-    when TLS is disabled; raises ``TLSMaterialError`` when TLS is enabled and any
-    piece is missing -- the ignition must never spend on a node that can only
-    fail its mTLS probe."""
-    if not _truthy(os.environ.get("JARVIS_BRAIN_WS_TLS_ENABLED", "true")):
-        return None
-    raw_dir = (os.environ.get(_ENV_MTLS_DIR, "") or "").strip()
-    if not raw_dir:
-        raise TLSMaterialError(
-            "TLS enabled but %s is unset -- run scripts/gen_brain_mtls.py and "
-            "export the material dir" % _ENV_MTLS_DIR)
-    mat: Dict[str, str] = {}
-    for part, (_meta_key, filename) in _TLS_META_KEYS.items():
-        path = os.path.join(raw_dir, filename)
-        try:
-            with open(path, "r", encoding="utf-8") as fh:
-                mat[part] = fh.read()
-        except OSError as exc:
-            raise TLSMaterialError(
-                "TLS enabled but %s is missing/unreadable (%s) -- aborting "
-                "BEFORE any GCP spend" % (path, exc)) from exc
-    return mat
-
-
-def _tls_extra_metadata(mat: Optional[Dict[str, str]]) -> Dict[str, str]:
-    """Map the loaded PEM material onto its instance-metadata keys."""
-    if not mat:
-        return {}
-    return {meta_key: mat[part] for part, (meta_key, _fn) in _TLS_META_KEYS.items()}
+# TLS material delivery (``TLSMaterialError`` / ``_tls_material`` /
+# ``_tls_extra_metadata`` / ``_NODE_TLS_DIR`` / ``_TLS_META_KEYS``) is EXTRACTED
+# into ``backend.core.ouroboros.governance.brain_lifecycle`` (Stage-4 Task 1)
+# and re-exported at the top of this module -- byte-equivalent behavior.
 
 
 def _persistent() -> bool:
@@ -734,71 +707,15 @@ class BrainIgnitionDriver:
     async def _do_create_instance(self) -> Tuple[bool, str]:
         if self._create_instance is not None:
             return await self._create_instance(name=self.node_name)
-        from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
-            _BRAIN_ENV_METADATA_KEY,
-            _BRAIN_ROLE_LABEL_KEY,
-            _BRAIN_ROLE_LABEL_VALUE,
-            _brain_image_family,
-            _brain_machine_type,
-            _compose_brain_env,
-            get_compute_rest,
-        )
-
-        brain_env = _compose_brain_env(self._brain_env_values())
-        extra = {_BRAIN_ENV_METADATA_KEY: brain_env}
-        # Ship the SERVER PEM material as metadata; the runtime startup script
-        # writes it to /etc/jarvis/tls/* before the units start.
-        extra.update(_tls_extra_metadata(_tls_material()))
-        return await get_compute_rest().create_instance(
-            startup_script=_brain_runtime_startup_script(),
-            name=self.node_name,
-            machine_type=_brain_machine_type(),
-            image_family=_brain_image_family(),
-            accelerator_type="",
-            accelerator_count=0,
-            labels={_BRAIN_ROLE_LABEL_KEY: _BRAIN_ROLE_LABEL_VALUE},
-            extra_metadata=extra,
-        )
+        # Live default: the EXTRACTED provisioning core (brain_lifecycle,
+        # Stage-4 Task 1) -- byte-equivalent create composition.
+        return await provision_brain(node_name=self.node_name)
 
     def _brain_env_values(self) -> Dict[str, str]:
-        """Fold the Task-4 ignition values into the brain-env metadata: the WS
-        port/path + TLS material references + the session cost cap, all
-        env-resolved (Mandate 2). The idle-shutdown seconds are added by
-        ``_compose_brain_env`` itself.
-
-        TLS paths: when server material is shipped (TLS enabled), the node's
-        brain.env is OVERRIDDEN to the node-local /etc/jarvis/tls/* paths the
-        runtime startup script writes -- the Mac-side env holds the Mac's OWN
-        (client) paths, which must never leak into the node's config."""
-        vals: Dict[str, str] = {}
-        for key in (
-            "JARVIS_BRAIN_WS_PORT", "JARVIS_BRAIN_WS_PATH", "JARVIS_BRAIN_WS_TLS_ENABLED",
-            "JARVIS_BRAIN_WS_TLS_CERT", "JARVIS_BRAIN_WS_TLS_KEY", "JARVIS_BRAIN_WS_TLS_CA",
-            "JARVIS_BRAIN_COST_CAP", "JARVIS_DISTRIBUTED_BUS_ENABLED",
-            "JARVIS_BRAIN_BUS_SIDECAR_ENABLED", "JARVIS_BRAIN_OUTBOUND_TOPICS",
-        ):
-            v = os.environ.get(key)
-            if v is not None and v != "":
-                vals[key] = v
-        if _tls_material() is not None:
-            vals["JARVIS_BRAIN_WS_TLS_CERT"] = "%s/%s" % (
-                _NODE_TLS_DIR, _TLS_META_KEYS["server_cert"][1])
-            vals["JARVIS_BRAIN_WS_TLS_KEY"] = "%s/%s" % (
-                _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
-            vals["JARVIS_BRAIN_WS_TLS_CA"] = "%s/%s" % (
-                _NODE_TLS_DIR, _TLS_META_KEYS["ca"][1])
-        # Opt-in provider-key fold (live-fire 2026-07-04 Stage-2 acceptance: the
-        # soak crash-looped 54x with "No API keys set" because these were never
-        # shipped). Keys travel as instance metadata (project-scoped
-        # visibility) -- the established J-Prime pattern per the relocation
-        # design's open risk #4. Opt-in so default ignitions never ship
-        # secrets.
-        if _truthy(os.environ.get("JARVIS_BRAIN_SHIP_PROVIDER_KEYS")):
-            for key in ("DOUBLEWORD_API_KEY", "ANTHROPIC_API_KEY"):
-                v = os.environ.get(key)
-                if v is not None and v != "":
-                    vals[key] = v
-        return vals
+        """Fold the Task-4 ignition values into the brain-env metadata.
+        EXTRACTED to ``brain_lifecycle.brain_env_values`` (Stage-4 Task 1);
+        this method delegates -- byte-equivalent composition."""
+        return brain_env_values()
 
     async def _do_discover(self) -> Optional[str]:
         if self._discover is not None:
@@ -1031,69 +948,10 @@ class BrainIgnitionDriver:
 
 
 # ---------------------------------------------------------------------------
-# Runtime startup script (thin provisioning glue Task 4 owns): repopulate
-# /etc/jarvis/brain.env from THIS instance's metadata, create the /run/jarvis
-# runtime dir + liveness marker (the deferred Task-1 coupling), and (re)start the
-# baked brain unit so it picks up the fresh env.
+# Runtime startup script: EXTRACTED to ``brain_lifecycle._brain_runtime_
+# startup_script`` (Stage-4 Task 1) and re-exported at the top of this module
+# -- byte-equivalent script body.
 # ---------------------------------------------------------------------------
-
-
-def _brain_runtime_startup_script() -> str:
-    """Minimal boot glue for the golden-image runtime boot. The image already has
-    the ``jarvis-brain.service`` units baked+enabled; this only (a) writes
-    /etc/jarvis/brain.env from the runtime ``brain-env`` metadata, (b) ensures
-    /run/jarvis exists + touches the liveness marker so the idle-check never nukes
-    a freshly-booted node, and (c) restarts the unit to apply the fresh env.
-    ASCII-only. Kept tiny + idempotent (Mandate 3: no new provisioning framework)."""
-    meta_base = "http://metadata.google.internal/computeMetadata/v1/instance/attributes"
-    tls_fetch = "".join(
-        "curl -fsS -H 'Metadata-Flavor: Google' '%s/%s' -o %s/%s || true\n"
-        % (meta_base, meta_key, _NODE_TLS_DIR, filename)
-        for meta_key, filename in _TLS_META_KEYS.values()
-    )
-    return (
-        "#!/usr/bin/env bash\n"
-        "set -uo pipefail\n"
-        "mkdir -p /etc/jarvis /run/jarvis %s\n" % _NODE_TLS_DIR
-        + "curl -fsS -H 'Metadata-Flavor: Google' "
-        "'%s/brain-env' " % meta_base
-        + "-o /etc/jarvis/brain.env || : > /etc/jarvis/brain.env\n"
-        # SERVER TLS material (shipped as metadata by the driver) -> node files,
-        # BEFORE any unit starts. Fail-soft per file: TLS-disabled ignitions have
-        # no such metadata and must still boot.
-        + tls_fetch
-        + "chmod 600 %s/%s 2>/dev/null || true\n" % (
-            _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
-        # Refresh the baked clone (fail-soft): the golden image tracks main at
-        # ignition, so driver-shipped scripts (e.g. the bus sidecar) that landed
-        # AFTER the bake are present without a re-bake.
-        + "git -C /opt/trinity/jarvis pull --ff-only || true\n"
-        # Stage-0 bus + acceptance echo responder SIDECAR: the Brain-side WS
-        # server the cross-host acceptance connects to. Same venv as the soak.
-        + "cat > /etc/systemd/system/jarvis-brain-bus.service <<'UNIT'\n"
-        "[Unit]\n"
-        "Description=JARVIS Brain Stage-0 bus + acceptance echo responder\n"
-        "After=network-online.target\n"
-        "Wants=network-online.target\n"
-        "\n"
-        "[Service]\n"
-        "Type=simple\n"
-        "WorkingDirectory=/opt/trinity/jarvis\n"
-        "EnvironmentFile=/etc/jarvis/brain.env\n"
-        "RuntimeDirectory=jarvis\n"
-        "ExecStart=/opt/trinity/venv/bin/python scripts/brain_bus_echo_server.py\n"
-        "Restart=on-failure\n"
-        "RestartSec=5\n"
-        "\n"
-        "[Install]\n"
-        "WantedBy=multi-user.target\n"
-        "UNIT\n"
-        + "touch /run/jarvis/brain_liveness\n"
-        "systemctl daemon-reload || true\n"
-        "systemctl restart jarvis-brain.service || systemctl start jarvis-brain.service || true\n"
-        "systemctl restart jarvis-brain-bus.service || systemctl start jarvis-brain-bus.service || true\n"
-        "systemctl start jarvis-brain-idle.timer || true\n"
-    )
 
 
 # ---------------------------------------------------------------------------

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -39,6 +39,8 @@ Env knobs (all resolved at call time -- zero baked assumptions):
     JARVIS_BRAIN_WS_*               Stage-0 transport client family
     JARVIS_BRAIN_MTLS_DIR           client mTLS material (Stage-1 conventions)
     JARVIS_BODY_WAL_*               DurableOutbound family (durable_outbound.py)
+    JARVIS_BRAIN_RESURRECT_*        BrainKeeper family (brain_keeper.py, Stage-4)
+    JARVIS_KEEPER_ID                keeper identity (default mac-body-keeper)
 
 Usage::
 
@@ -120,6 +122,9 @@ class BodyModeDriver:
         sensor_factory     -> ``(shim) -> Optional[sensor]`` (fail-soft)
         watchdog_factory   -> ``() -> ControlPlaneWatchdog``
         durable_factory    -> ``(broker) -> DurableOutbound`` (Stage-3 WAL)
+        keeper_factory     -> ``() -> BrainKeeper`` (Stage-4 resurrection;
+                              live default arms the real keeper with
+                              provision_brain imported IN-PROCESS)
     """
 
     def __init__(
@@ -137,6 +142,7 @@ class BodyModeDriver:
         sensor_factory: Optional[Callable[[Any], Any]] = None,
         watchdog_factory: Optional[Callable[[], Any]] = None,
         durable_factory: Optional[Callable[[Any], Any]] = None,
+        keeper_factory: Optional[Callable[[], Any]] = None,
     ) -> None:
         self.inject_test_signals = max(0, int(inject_test_signals))
         self.duration_s = duration_s
@@ -150,11 +156,15 @@ class BodyModeDriver:
         self._sensor_factory = sensor_factory
         self._watchdog_factory = watchdog_factory
         self._durable_factory = durable_factory
+        self._keeper_factory = keeper_factory
 
         self._signals_sent = 0
         self._worst_lag_ms = 0.0
         self._durable: Optional[Any] = None
         self._durable_built = False
+        # Stage-4 Task 3: the Brain KEEPER (sustained-absence resurrection).
+        self._keeper: Optional[Any] = None
+        self._exported_gen: Optional[int] = None
         # Deterministic degrade surfacing (operator mandate): the link
         # state derives ONLY from the client's `connected` property.
         # None = not yet observed; edge transitions log exactly once.
@@ -163,12 +173,90 @@ class BodyModeDriver:
     # -- lazy live default resolvers ---------------------------------------
 
     async def _do_discover(self) -> Optional[str]:
+        """Discovery seam, WRAPPED so every result also feeds the keeper
+        (Stage-4 Task 3): the initial discovery, every url_resolver
+        reconnect re-race, and the keeper's own confirmation probe all
+        flow through here -- one honest wiring, no second census path."""
         if self._discover is not None:
-            return await self._discover()
-        from backend.core.ouroboros.governance.brain_discovery import (  # noqa: PLC0415
-            discover_brain_endpoint,
-        )
-        return await discover_brain_endpoint()
+            url = await self._discover()
+        else:
+            from backend.core.ouroboros.governance.brain_discovery import (  # noqa: PLC0415
+                discover_brain_endpoint,
+            )
+            url = await discover_brain_endpoint()
+        if self._keeper is not None:
+            try:
+                self._keeper.note_discovery_result(url)
+            except Exception:  # noqa: BLE001 -- keeper feed is fail-soft
+                pass
+        return url
+
+    def _do_keeper(self) -> Optional[Any]:
+        """Resolve the Brain-keeper seam (Stage-4 Task 3).
+
+        Live default (no injected bus stack) ARMS the keeper:
+        ``provision_fn`` is ``brain_lifecycle.provision_brain`` imported
+        IN-PROCESS (the resource ledger and the provisioner share one
+        process -- never a shell-out per resurrect), the manifest is the
+        live ``ResourceManifest``, and the bucket is the persistent
+        flock-journaled ``PersistentTokenBucket``. An injected bus stack
+        WITHOUT a keeper seam stays keeper-less (the ``_build_durable``
+        precedent: injected-seam tests must never touch the real repo
+        ledger). Fail-soft: a keeper that cannot be built degrades to
+        the keeper-less census rather than killing the driver."""
+        if self._keeper_factory is not None:
+            try:
+                return self._keeper_factory()
+            except Exception as exc:  # noqa: BLE001
+                _log("brain keeper unavailable (fail-soft): %s" % exc)
+                return None
+        if self._bus_factory is not None:
+            return None
+        try:
+            from backend.core.ouroboros.governance import brain_lifecycle  # noqa: PLC0415
+            from backend.core.ouroboros.governance.brain_keeper import (  # noqa: PLC0415
+                BrainKeeper,
+                PersistentTokenBucket,
+            )
+            return BrainKeeper(
+                discover_fn=self._do_discover,
+                provision_fn=brain_lifecycle.provision_brain,
+                manifest=brain_lifecycle.ResourceManifest(),
+                bucket=PersistentTokenBucket(),
+            )
+        except Exception as exc:  # noqa: BLE001
+            _log("brain keeper unavailable (fail-soft): %s" % exc)
+            return None
+
+    def _export_current_gen(self) -> int:
+        """Export ``JARVIS_BRAIN_CURRENT_GEN`` for the discovery gen-filter
+        (set at keeper construction + refreshed after each tick, which
+        covers every resurrection). Gen 0 (no generation ever minted) is
+        NOT exported -- exporting it would arm the filter and exclude a
+        pre-Stage-4 unlabeled Brain before this keeper has minted
+        anything. Returns the current gen (0 on any failure)."""
+        if self._keeper is None:
+            return 0
+        try:
+            gen = int(self._keeper.current_gen())
+        except Exception:  # noqa: BLE001 -- fail-soft
+            return self._exported_gen or 0
+        if gen >= 1 and gen != self._exported_gen:
+            os.environ["JARVIS_BRAIN_CURRENT_GEN"] = str(gen)
+            self._exported_gen = gen
+        return gen
+
+    async def _keeper_tick(self) -> Optional[Tuple[str, int]]:
+        """One keeper advance per census tick -> ``(state, gen)`` for the
+        census line, or None (keeper-less / failed tick). Fail-soft."""
+        if self._keeper is None:
+            return None
+        try:
+            state = str(await self._keeper.tick())
+        except Exception as exc:  # noqa: BLE001
+            _log("keeper tick failed (fail-soft): %s" % exc)
+            return None
+        return (state, self._export_current_gen())
 
     async def _do_bus_stack(self) -> Tuple[Any, Any, Any]:
         if self._bus_factory is not None:
@@ -412,7 +500,8 @@ class BodyModeDriver:
             _log("Brain offline -- %d signals queued (durable)"
                  % self._queued())
 
-    def _census_tick(self, watchdog: Any, connected: bool) -> None:
+    def _census_tick(self, watchdog: Any, connected: bool,
+                     keeper_info: Optional[Tuple[str, int]] = None) -> None:
         lag_events = int(getattr(watchdog, "lag_event_count", 0))
         try:
             records = watchdog.recent_lag_records()
@@ -421,8 +510,13 @@ class BodyModeDriver:
         for r in records:
             self._worst_lag_ms = max(
                 self._worst_lag_ms, float(getattr(r, "lag_ms", 0.0)))
-        _log("lag_events=%d worst_ms=%.1f connected=%s queued=%d"
-             % (lag_events, self._worst_lag_ms, connected, self._queued()))
+        keeper_part = ""
+        if keeper_info is not None:
+            state, gen = keeper_info
+            keeper_part = " gen=%d keeper=%s" % (gen, state)
+        _log("lag_events=%d worst_ms=%.1f connected=%s queued=%d%s"
+             % (lag_events, self._worst_lag_ms, connected, self._queued(),
+                keeper_part))
 
     # -- the run FSM ---------------------------------------------------------
 
@@ -435,6 +529,13 @@ class BodyModeDriver:
                  "run the starvation census -- no network touched"
                  % self.inject_test_signals)
             return 0
+
+        # 0. Brain KEEPER (Stage-4 Task 3) -- built BEFORE the first
+        #    discovery so the initial result already feeds its absence
+        #    window, and the discovery gen-filter env is exported from
+        #    the persisted manifest at construction.
+        self._keeper = self._do_keeper()
+        self._export_current_gen()
 
         # 1. DISCOVER (stateless; fail-soft returns None). With the
         #    durable WAL armed (Stage 3), discovery failure DEGRADES
@@ -540,12 +641,13 @@ class BodyModeDriver:
                     await asyncio.sleep(census_s)
                 connected = _connected()
                 self._update_link_state(connected)
-                self._census_tick(watchdog, connected)
+                self._census_tick(watchdog, connected,
+                                  await self._keeper_tick())
 
             # 6. Clean stop -> summary -> exit 0.
             connected = _connected()
             self._update_link_state(connected)
-            self._census_tick(watchdog, connected)
+            self._census_tick(watchdog, connected, await self._keeper_tick())
             return 0
         finally:
             lag_events = int(getattr(watchdog, "lag_event_count", 0)) \

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -258,6 +258,34 @@ class BodyModeDriver:
             return None
         return (state, self._export_current_gen())
 
+    async def _publish_keeper_heartbeat(
+        self, trinity_bus: Any, keeper_info: Optional[Tuple[str, int]],
+    ) -> None:
+        """Stage-4 Task 4 (split-brain fence, Body side): publish the keeper's
+        CURRENT generation as ``console.keeper_heartbeat`` on the local trinity
+        bus every census tick. ``console.*`` is already on the mac-side
+        TrinityBusBridge outbound allowlist (``_do_bridge``), so the beat
+        transits the WS link onto the Brain organism's bus, where a superseded
+        twin's GenerationFence observes a HIGHER gen and structurally fences
+        itself. Gen 0 (nothing ever minted) is never published -- it would say
+        nothing a fence could act on. ``persist=False``: a ~10s liveness beat
+        must not accrete in the event store WAL. Fail-soft: a bus that cannot
+        publish (or lacks publish_raw -- injected fakes) never kills the
+        census."""
+        if keeper_info is None:
+            return
+        _state, gen = keeper_info
+        if gen < 1:
+            return
+        publish_raw = getattr(trinity_bus, "publish_raw", None)
+        if publish_raw is None:
+            return
+        try:
+            await publish_raw(
+                "console.keeper_heartbeat", {"gen": int(gen)}, persist=False)
+        except Exception as exc:  # noqa: BLE001 -- fail-soft
+            _log("keeper heartbeat publish failed (fail-soft): %s" % exc)
+
     async def _do_bus_stack(self) -> Tuple[Any, Any, Any]:
         if self._bus_factory is not None:
             return await self._bus_factory()
@@ -641,13 +669,16 @@ class BodyModeDriver:
                     await asyncio.sleep(census_s)
                 connected = _connected()
                 self._update_link_state(connected)
-                self._census_tick(watchdog, connected,
-                                  await self._keeper_tick())
+                keeper_info = await self._keeper_tick()
+                await self._publish_keeper_heartbeat(trinity_bus, keeper_info)
+                self._census_tick(watchdog, connected, keeper_info)
 
             # 6. Clean stop -> summary -> exit 0.
             connected = _connected()
             self._update_link_state(connected)
-            self._census_tick(watchdog, connected, await self._keeper_tick())
+            keeper_info = await self._keeper_tick()
+            await self._publish_keeper_heartbeat(trinity_bus, keeper_info)
+            self._census_tick(watchdog, connected, keeper_info)
             return 0
         finally:
             lag_events = int(getattr(watchdog, "lag_event_count", 0)) \

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -134,6 +134,10 @@ class BodyModeDriver:
         duration_s: Optional[float] = None,
         dry_run: bool = False,
         require_brain: bool = False,
+        # Stage-4 IMPORTANT-3: keeper master. None -> consult
+        # JARVIS_BRAIN_KEEPER_ENABLED (default false); True -> force on
+        # (--keeper); False -> force off (--no-keeper, wins over everything).
+        keeper_mode: Optional[bool] = None,
         # Injectable seams (live defaults resolved lazily inside run()).
         discover_fn: Optional[Callable[[], Awaitable[Optional[str]]]] = None,
         bus_factory: Optional[Callable[[], Awaitable[Tuple[Any, Any, Any]]]] = None,
@@ -148,6 +152,7 @@ class BodyModeDriver:
         self.duration_s = duration_s
         self.dry_run = dry_run
         self.require_brain = require_brain
+        self.keeper_mode = keeper_mode
 
         self._discover = discover_fn
         self._bus_factory = bus_factory
@@ -191,6 +196,19 @@ class BodyModeDriver:
                 pass
         return url
 
+    def _keeper_enabled(self) -> bool:
+        """Stage-4 IMPORTANT-3 master resolution. ``--no-keeper`` (keeper_mode
+        False) wins over everything; ``--keeper`` (True) forces on; None ->
+        consult ``JARVIS_BRAIN_KEEPER_ENABLED`` (default FALSE -- SAFE default:
+        the drill / live runs opt in explicitly, pre-Stage-4 degrade-and-wait
+        is byte-identical)."""
+        if self.keeper_mode is False:
+            return False
+        if self.keeper_mode is True:
+            return True
+        return (os.environ.get("JARVIS_BRAIN_KEEPER_ENABLED", "false")
+                or "").strip().lower() in ("1", "true", "yes", "on")
+
     def _do_keeper(self) -> Optional[Any]:
         """Resolve the Brain-keeper seam (Stage-4 Task 3).
 
@@ -204,6 +222,10 @@ class BodyModeDriver:
         precedent: injected-seam tests must never touch the real repo
         ledger). Fail-soft: a keeper that cannot be built degrades to
         the keeper-less census rather than killing the driver."""
+        # Stage-4 IMPORTANT-3: --no-keeper wins over an injected factory too.
+        if self.keeper_mode is False:
+            _log("brain keeper disabled (--no-keeper)")
+            return None
         if self._keeper_factory is not None:
             try:
                 return self._keeper_factory()
@@ -211,6 +233,10 @@ class BodyModeDriver:
                 _log("brain keeper unavailable (fail-soft): %s" % exc)
                 return None
         if self._bus_factory is not None:
+            return None
+        if not self._keeper_enabled():
+            _log("brain keeper disabled (JARVIS_BRAIN_KEEPER_ENABLED=false) "
+                 "-- pre-Stage-4 degrade-and-wait")
             return None
         try:
             from backend.core.ouroboros.governance import brain_lifecycle  # noqa: PLC0415
@@ -748,6 +774,19 @@ def build_arg_parser() -> argparse.ArgumentParser:
         "--dry-run", action="store_true",
         help="Print the Body-mode plan and exit -- touches no network.",
     )
+    # Stage-4 IMPORTANT-3: keeper master flag overrides. dest defaults to None
+    # (neither given -> consult JARVIS_BRAIN_KEEPER_ENABLED, default false).
+    p.add_argument(
+        "--keeper", dest="keeper", action="store_true", default=None,
+        help="Force-arm the Brain KEEPER (overrides "
+             "JARVIS_BRAIN_KEEPER_ENABLED). Default: consult the env flag "
+             "(off).",
+    )
+    p.add_argument(
+        "--no-keeper", dest="keeper", action="store_false",
+        help="Force the keeper OFF (wins over env + --keeper): pre-Stage-4 "
+             "degrade-and-wait behavior.",
+    )
     return p
 
 
@@ -759,6 +798,7 @@ def main(argv: Optional[List[str]] = None) -> int:
         duration_s=args.duration_s,
         dry_run=args.dry_run,
         require_brain=args.require_brain,
+        keeper_mode=args.keeper,
     )
     try:
         return asyncio.run(driver.run())

--- a/tests/governance/test_brain_discovery.py
+++ b/tests/governance/test_brain_discovery.py
@@ -12,14 +12,17 @@ from backend.core.ouroboros.governance import brain_discovery
 # ---------------------------------------------------------------------------
 
 
-def _brain_instance(*, name, external, internal, status="RUNNING"):
+def _brain_instance(*, name, external, internal, status="RUNNING", gen=None):
     nics = [{"networkIP": internal}]
     if external:
         nics[0]["accessConfigs"] = [{"natIP": external}]
+    labels = {"jarvis-role": "brain"}
+    if gen is not None:
+        labels["jarvis-brain-gen"] = str(gen)
     return {
         "name": name,
         "status": status,
-        "labels": {"jarvis-role": "brain"},
+        "labels": labels,
         "networkInterfaces": nics,
     }
 
@@ -165,6 +168,78 @@ def test_discover_failsoft_when_list_raises(monkeypatch):
 
     # Must NOT propagate into the caller.
     assert _run(brain_discovery.discover_brain_endpoint(list_instances_fn=boom_list)) is None
+
+
+# ---------------------------------------------------------------------------
+# (d2) Stage-4 Task 3: generation filter (JARVIS_BRAIN_CURRENT_GEN).
+# ---------------------------------------------------------------------------
+
+
+def test_gen_filter_env_unset_zero_behavior_change(monkeypatch):
+    monkeypatch.delenv("JARVIS_BRAIN_CURRENT_GEN", raising=False)
+    mixed = [
+        _brain_instance(name="brain-old", external="203.0.113.40", internal="10.0.0.40"),
+        _brain_instance(name="brain-g1", external="203.0.113.41", internal="10.0.0.41", gen=1),
+    ]
+    out = brain_discovery._filter_stale_generations(mixed)
+    assert out == mixed, "env unset: the filter must be a byte-level no-op"
+
+
+def test_gen_filter_malformed_or_zero_env_is_inactive(monkeypatch):
+    mixed = [_brain_instance(name="brain-old", external="203.0.113.40", internal="10.0.0.40")]
+    for raw in ("not-a-number", "0", "-3", "  "):
+        monkeypatch.setenv("JARVIS_BRAIN_CURRENT_GEN", raw)
+        assert brain_discovery._filter_stale_generations(mixed) == mixed, (
+            "malformed/non-positive env must stay fail-soft inactive: %r" % raw)
+
+
+def test_gen_filter_excludes_lower_and_unlabeled_keeps_equal_higher(monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_CURRENT_GEN", "2")
+    instances = [
+        _brain_instance(name="brain-g1", external="203.0.113.51", internal="10.0.0.51", gen=1),
+        _brain_instance(name="brain-g2", external="203.0.113.52", internal="10.0.0.52", gen=2),
+        _brain_instance(name="brain-g3", external="203.0.113.53", internal="10.0.0.53", gen=3),
+        # Pre-Stage-4 unlabeled brain: obsolete by definition once a gen'd
+        # keeper runs.
+        _brain_instance(name="brain-prestage4", external="203.0.113.54", internal="10.0.0.54"),
+    ]
+    out = brain_discovery._filter_stale_generations(instances)
+    assert [i["name"] for i in out] == ["brain-g2", "brain-g3"]
+
+
+def test_gen_filter_applies_before_probing(monkeypatch):
+    """End-to-end through discover_brain_endpoint: excluded generations never
+    become candidates -- they are never probed, never raced."""
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PATH", "/ws/trinity-bus")
+    monkeypatch.setenv("JARVIS_BRAIN_CURRENT_GEN", "2")
+
+    async def fake_list():
+        return [
+            _brain_instance(name="brain-g1", external="203.0.113.61", internal="10.0.0.61", gen=1),
+            _brain_instance(name="brain-old", external="203.0.113.62", internal="10.0.0.62"),
+            _brain_instance(name="brain-g2", external="203.0.113.63", internal="10.0.0.63", gen=2),
+        ]
+
+    seen = {"candidates": None, "probed": []}
+
+    async def probe(url):
+        seen["probed"].append(url)
+        return True
+
+    async def fake_race(candidates, probe_fn):
+        seen["candidates"] = list(candidates)
+        for u in candidates:
+            await probe_fn(u)
+        return candidates[0]
+
+    url = _run(brain_discovery.discover_brain_endpoint(
+        list_instances_fn=fake_list, probe_fn=probe, race_fn=fake_race))
+
+    assert url == "wss://203.0.113.63:8443/ws/trinity-bus"
+    joined = " ".join(seen["candidates"]) + " " + " ".join(seen["probed"])
+    assert "203.0.113.61" not in joined, "lower gen excluded PRE-probe"
+    assert "203.0.113.62" not in joined, "unlabeled excluded PRE-probe"
 
 
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_brain_keeper.py
+++ b/tests/governance/test_brain_keeper.py
@@ -1,0 +1,445 @@
+"""Tests for backend/core/ouroboros/governance/brain_keeper.py (Stage-4 Task 3).
+
+The Body-side KEEPER: persistent token bucket + sustained-absence resurrection
+state machine. NO live GCP, NO sleeps -- the clock is injected and the
+provision collaborator is a fake.
+
+Proves:
+  bucket:
+    (a) persistence across instances -- the journal IS the state (2 takes,
+        a NEW instance refuses within the window);
+    (b) a record OUTSIDE the rolling window is ignored (injected old ts_wall);
+    (c) refusal appends NOTHING (deterministic: replaying the same journal
+        yields the same refusal, no growth);
+  keeper:
+    (d) absence-window arithmetic against a fake clock (<= threshold stays
+        absent; > threshold resurrects);
+    (e) reset-on-discovery (a truthy url clears the window; no provision);
+    (f) single-flight (concurrent ticks -> exactly one provision);
+    (g) cap_exhausted is TERMINAL (never provisions/retries past it; the
+        error is logged exactly once);
+    (h) gen minting is monotonic from the manifest;
+    (i) record-at-birth (the manifest gains the create record with
+        labels+gen BEFORE the provision resolves -- a keeper death
+        mid-provision leaves the child on the manifest);
+    (j) a failed provision SPENDS the token (VM-factory guard) and returns
+        the machine to absent.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance import brain_keeper as bk
+from backend.core.ouroboros.governance import brain_lifecycle as bl
+
+
+@pytest.fixture()
+def bucket_path(tmp_path, monkeypatch):
+    path = tmp_path / "manifests" / "resurrect_bucket.jsonl"
+    monkeypatch.setenv("JARVIS_RESURRECT_BUCKET_PATH", str(path))
+    return path
+
+
+@pytest.fixture()
+def manifest(tmp_path, monkeypatch):
+    path = tmp_path / "manifests" / "resource_manifest.jsonl"
+    monkeypatch.setenv("JARVIS_RESOURCE_MANIFEST_PATH", str(path))
+    return bl.ResourceManifest()
+
+
+class _FakeClock:
+    def __init__(self, start: float = 1000.0) -> None:
+        self.t = start
+
+    def __call__(self) -> float:
+        return self.t
+
+    def advance(self, s: float) -> None:
+        self.t += s
+
+
+class _FakeProvisioner:
+    """Records every provision call; scriptable result / exception / block."""
+
+    def __init__(self, ok: bool = True, raise_exc: bool = False) -> None:
+        self.calls: List[Dict[str, Any]] = []
+        self.ok = ok
+        self.raise_exc = raise_exc
+        self.started = asyncio.Event()
+        self.release: Optional[asyncio.Event] = None
+
+    async def __call__(self, *, node_name: str, labels: Dict[str, str],
+                       extra_env: Dict[str, str]) -> Tuple[bool, str]:
+        self.calls.append({
+            "node_name": node_name, "labels": dict(labels),
+            "extra_env": dict(extra_env),
+        })
+        self.started.set()
+        if self.release is not None:
+            await self.release.wait()
+        if self.raise_exc:
+            raise RuntimeError("gcp exploded mid-create")
+        return (self.ok, "created:done" if self.ok else "QUOTA_EXCEEDED")
+
+
+async def _no_brain() -> Optional[str]:
+    return None
+
+
+def _mk_keeper(manifest: Any, bucket: Any, clock: Any,
+               provision: Any, *, discover: Any = _no_brain,
+               after_s: float = 900.0) -> Any:
+    return bk.BrainKeeper(
+        discover_fn=discover, provision_fn=provision, manifest=manifest,
+        bucket=bucket, resurrect_after_s=after_s, keeper_id="mac-body-keeper",
+        clock=clock,
+    )
+
+
+def _journal_lines(path) -> List[Dict[str, Any]]:
+    if not path.exists():
+        return []
+    return [json.loads(ln) for ln in path.read_text().splitlines() if ln.strip()]
+
+
+# ---------------------------------------------------------------------------
+# (a) Bucket persistence across instances -- the journal IS the state.
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_persists_across_instances(bucket_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "2")
+    b1 = bk.PersistentTokenBucket()
+    assert b1.try_take(gen=1) is True
+    assert b1.try_take(gen=2) is True
+
+    # A brand-new instance (a restarted process) replays the SAME journal.
+    b2 = bk.PersistentTokenBucket()
+    assert b2.try_take(gen=3) is False, (
+        "the cap must be deterministic across process restarts")
+    assert len(_journal_lines(bucket_path)) == 2
+
+
+def test_bucket_take_record_shape(bucket_path) -> None:
+    before = time.time()
+    bk.PersistentTokenBucket().try_take(gen=7)
+    (rec,) = _journal_lines(bucket_path)
+    assert rec["gen"] == 7
+    assert "ts_utc" in rec
+    assert before <= float(rec["ts_wall"]) <= time.time(), (
+        "ts_wall must be wall-clock time.time() (survives restarts)")
+
+
+# ---------------------------------------------------------------------------
+# (b) Records outside the rolling window are ignored.
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_ignores_takes_outside_window(bucket_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "2")
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_WINDOW_S", "3600")
+    bucket = bk.PersistentTokenBucket()
+    # Two OLD takes (2h ago) injected straight into the journal.
+    bucket_path.parent.mkdir(parents=True, exist_ok=True)
+    old = time.time() - 7200.0
+    with bucket_path.open("a", encoding="utf-8") as fh:
+        for gen in (1, 2):
+            fh.write(json.dumps(
+                {"ts_utc": "old", "ts_wall": old, "gen": gen}) + "\n")
+
+    assert bucket.taken_in_window() == 0, "expired takes must not count"
+    assert bucket.try_take(gen=3) is True
+    assert bucket.try_take(gen=4) is True
+    assert bucket.try_take(gen=5) is False, "in-window takes hit the cap"
+
+
+# ---------------------------------------------------------------------------
+# (c) Refusal appends NOTHING (determinism; no retry/backoff state).
+# ---------------------------------------------------------------------------
+
+
+def test_bucket_refusal_appends_nothing(bucket_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "1")
+    bucket = bk.PersistentTokenBucket()
+    assert bucket.try_take(gen=1) is True
+    for _ in range(5):
+        assert bucket.try_take(gen=99) is False
+    lines = _journal_lines(bucket_path)
+    assert len(lines) == 1, "a refused take must leave NO trace"
+    assert lines[0]["gen"] == 1
+
+
+def test_bucket_tolerates_corrupt_lines(bucket_path) -> None:
+    bucket = bk.PersistentTokenBucket()
+    assert bucket.try_take(gen=1) is True
+    with bucket_path.open("a", encoding="utf-8") as fh:
+        fh.write("{not json!!\n\n")
+    assert bucket.taken_in_window() == 1, "corrupt lines skipped, not fatal"
+
+
+# ---------------------------------------------------------------------------
+# (d) Absence-window arithmetic (fake clock; no sleeps).
+# ---------------------------------------------------------------------------
+
+
+def test_absence_window_arithmetic(manifest, bucket_path) -> None:
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov,
+                        after_s=900.0)
+
+    assert asyncio.run(keeper.tick()) == "healthy", "no observation yet"
+    keeper.note_discovery_result(None)          # absence starts at t
+    clock.advance(899.0)
+    assert asyncio.run(keeper.tick()) == "absent"
+    assert prov.calls == [], "below the threshold: never provision"
+
+    clock.advance(2.0)                          # 901s > 900s: sustained
+    assert asyncio.run(keeper.tick()) == "resurrected"
+    assert len(prov.calls) == 1
+
+    # Later misses must NOT refresh the start timestamp ('continuously').
+    keeper2 = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock,
+                         _FakeProvisioner(), after_s=900.0)
+    keeper2.note_discovery_result(None)
+    clock.advance(500.0)
+    keeper2.note_discovery_result(None)         # continue, not restart
+    clock.advance(401.0)                        # 901s from the FIRST miss
+    assert asyncio.run(keeper2.tick()) == "resurrected"
+
+
+def test_resurrect_after_s_env_default(manifest, bucket_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_AFTER_S", "60")
+    keeper = bk.BrainKeeper(
+        discover_fn=_no_brain, provision_fn=_FakeProvisioner(),
+        manifest=manifest, bucket=bk.PersistentTokenBucket(),
+    )
+    assert keeper._resurrect_after_s == 60.0
+    assert keeper._keeper_id == "mac-body-keeper", "spec default keeper id"
+
+
+# ---------------------------------------------------------------------------
+# (e) Reset-on-discovery.
+# ---------------------------------------------------------------------------
+
+
+def test_discovery_resets_absence_window(manifest, bucket_path) -> None:
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov)
+
+    keeper.note_discovery_result(None)
+    clock.advance(800.0)
+    keeper.note_discovery_result("wss://10.0.0.5:8443/ws")   # brain answered
+    clock.advance(5000.0)
+    assert asyncio.run(keeper.tick()) == "healthy"
+    assert prov.calls == [], "a reset window must never provision"
+
+    # A fresh absence after the reset starts a NEW window.
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+    assert asyncio.run(keeper.tick()) == "resurrected"
+    assert len(prov.calls) == 1
+
+
+# ---------------------------------------------------------------------------
+# (f) Single-flight: concurrent ticks -> exactly one provision.
+# ---------------------------------------------------------------------------
+
+
+def test_single_flight_concurrent_ticks(manifest, bucket_path) -> None:
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    prov.release = asyncio.Event()
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov)
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+
+    async def scenario() -> None:
+        t1 = asyncio.ensure_future(keeper.tick())
+        await prov.started.wait()               # first tick is inside provision
+        assert await keeper.tick() == "resurrecting", (
+            "a concurrent tick must observe the in-flight resurrection")
+        assert await keeper.tick() == "resurrecting"
+        prov.release.set()
+        assert await t1 == "resurrected"
+
+    asyncio.run(scenario())
+    assert len(prov.calls) == 1, "single-flight: exactly ONE provision"
+
+
+# ---------------------------------------------------------------------------
+# (g) cap_exhausted is TERMINAL: never retries, error logged exactly once.
+# ---------------------------------------------------------------------------
+
+
+def test_cap_exhausted_terminal_and_logs_once(
+        manifest, bucket_path, monkeypatch, caplog) -> None:
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "0")  # always refuse
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov)
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+
+    with caplog.at_level(logging.ERROR):
+        assert asyncio.run(keeper.tick()) == "cap_exhausted"
+        for _ in range(5):
+            clock.advance(10000.0)
+            assert asyncio.run(keeper.tick()) == "cap_exhausted", (
+                "TERMINAL: tick must NEVER retry past cap_exhausted")
+
+    assert prov.calls == [], "no provision may follow a refused token"
+    errors = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(errors) == 1, "the terminal transition logs ERROR exactly once"
+    assert "EXHAUSTED" in errors[0].getMessage()
+
+    # Even a recovered brain does not un-exhaust this keeper (state persists;
+    # only a NEW keeper process with restored capacity can resurrect).
+    keeper.note_discovery_result("wss://10.0.0.5:8443/ws")
+    assert asyncio.run(keeper.tick()) == "cap_exhausted"
+
+
+# ---------------------------------------------------------------------------
+# (h) Gen minting is monotonic from the manifest.
+# ---------------------------------------------------------------------------
+
+
+def test_gen_monotonic_from_manifest(manifest, bucket_path) -> None:
+    manifest.record_create(kind="instance", name="jarvis-brain-gen3-old",
+                           gen=3, keeper_id="mac-body-keeper")
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov)
+    assert keeper.current_gen() == 3
+
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+    assert asyncio.run(keeper.tick()) == "resurrected"
+
+    call = prov.calls[0]
+    assert call["node_name"].startswith("jarvis-brain-gen4-")
+    assert call["labels"][bl.LABEL_GEN] == "4"
+    assert call["extra_env"]["JARVIS_BRAIN_GENERATION"] == "4"
+    assert call["extra_env"]["JARVIS_BRAIN_PARENT_NODE"] == call["node_name"]
+    assert keeper.current_gen() == 4
+
+
+# ---------------------------------------------------------------------------
+# (i) Record-at-birth: the manifest gains the record with labels+gen.
+# ---------------------------------------------------------------------------
+
+
+def test_record_at_birth_with_labels_and_gen(manifest, bucket_path) -> None:
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov)
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+    asyncio.run(keeper.tick())
+
+    node_name = prov.calls[0]["node_name"]
+    fam = manifest.live_family("mac-body-keeper")
+    assert [r["name"] for r in fam] == [node_name]
+    rec = fam[0]
+    assert rec["gen"] == 1
+    assert rec["kind"] == "instance"
+    assert rec["keeper_id"] == "mac-body-keeper"
+    assert rec["labels"][bl.LABEL_OWNER] == "mac-body-keeper"
+    assert rec["labels"][bl.LABEL_PARENT] == "mac-body-keeper"
+    assert rec["labels"][bl.LABEL_GEN] == "1"
+
+
+def test_record_at_birth_survives_provision_death(manifest, bucket_path) -> None:
+    """A provision that RAISES mid-create (keeper-death proxy) must still
+    leave the child on the manifest -- the record is appended BEFORE the
+    provision await (the Task-1 record_create semantics)."""
+    clock = _FakeClock()
+    prov = _FakeProvisioner(raise_exc=True)
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov)
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+    state = asyncio.run(keeper.tick())
+
+    assert state == "absent", "a failed provision returns the machine to absent"
+    names = [r["name"] for r in manifest.live_family("mac-body-keeper")]
+    assert len(names) == 1 and names[0].startswith("jarvis-brain-gen1-"), (
+        "record-at-birth: the child is on the manifest for the next walk")
+
+
+# ---------------------------------------------------------------------------
+# (j) A failed provision SPENDS the token (VM-factory guard).
+# ---------------------------------------------------------------------------
+
+
+def test_failed_provision_spends_token(manifest, bucket_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "2")
+    clock = _FakeClock()
+    prov = _FakeProvisioner(ok=False)           # clean (False, detail) failure
+    bucket = bk.PersistentTokenBucket()
+    keeper = _mk_keeper(manifest, bucket, clock, prov)
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+
+    assert asyncio.run(keeper.tick()) == "absent"     # attempt 1: token spent
+    assert bucket.taken_in_window() == 1
+    assert asyncio.run(keeper.tick()) == "absent"     # attempt 2: token spent
+    assert bucket.taken_in_window() == 2
+    assert asyncio.run(keeper.tick()) == "cap_exhausted", (
+        "failed attempts consume capacity by design (VM-factory guard)")
+    assert len(prov.calls) == 2
+
+
+# ---------------------------------------------------------------------------
+# resurrected -> healthy closure via the confirmation probe.
+# ---------------------------------------------------------------------------
+
+
+def test_resurrected_confirms_via_discover_fn(manifest, bucket_path) -> None:
+    """The tick after a successful resurrection issues ONE confirmation
+    probe through discover_fn; a truthy answer closes resurrected->healthy."""
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    probes = {"n": 0}
+
+    async def discover() -> Optional[str]:
+        probes["n"] += 1
+        return "wss://10.0.0.9:8443/ws"
+
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov,
+                        discover=discover)
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+    assert asyncio.run(keeper.tick()) == "resurrected"
+    assert probes["n"] == 0, "the resurrection tick itself never probes"
+    assert asyncio.run(keeper.tick()) == "healthy"
+    assert probes["n"] == 1
+    assert len(prov.calls) == 1, "confirmation probing never re-provisions"
+
+
+def test_resurrected_missed_probe_rearms_absence_window(
+        manifest, bucket_path) -> None:
+    """A MISSED confirmation probe (new node still dark) starts a FRESH
+    absence window for the new generation -- the machine re-arms and a
+    still-dark resurrection can escalate to the next gen, bounded by the
+    bucket. The driver's discovery feed can still flip it healthy."""
+    clock = _FakeClock()
+    prov = _FakeProvisioner()
+    keeper = _mk_keeper(manifest, bk.PersistentTokenBucket(), clock, prov,
+                        discover=_no_brain)
+    keeper.note_discovery_result(None)
+    clock.advance(901.0)
+    assert asyncio.run(keeper.tick()) == "resurrected"
+    assert asyncio.run(keeper.tick()) == "absent", (
+        "missed confirm probe -> fresh window, honest absent state")
+    assert len(prov.calls) == 1, "the fresh window must not instantly re-fire"
+
+    # The driver's own discovery feed finds the new node -> healthy.
+    keeper.note_discovery_result("wss://10.0.0.9:8443/ws")
+    assert asyncio.run(keeper.tick()) == "healthy"

--- a/tests/governance/test_brain_keeper.py
+++ b/tests/governance/test_brain_keeper.py
@@ -576,3 +576,180 @@ def test_gen_minter_uniqueness_invariant() -> None:
     assert hits == [
         "backend/core/ouroboros/governance/brain_keeper.py",
     ], "gen minting must have exactly ONE home: %r" % hits
+
+
+# ---------------------------------------------------------------------------
+# Stage-4 Task-4 (IMPORTANT-2/4): keeper-delivered fence supersession + reap.
+# ---------------------------------------------------------------------------
+
+
+def _record_gen_node(manifest: Any, keeper_id: str, gen: int) -> str:
+    """Record a live Brain node owned by the keeper (parent=keeper_id), as
+    _resurrect's record-at-birth does."""
+    name = "jarvis-brain-gen%d-node" % gen
+    manifest.record_create(
+        kind="instance", name=name,
+        labels={bl.LABEL_OWNER: keeper_id, bl.LABEL_GEN: str(gen)},
+        parent=keeper_id, gen=gen, keeper_id=keeper_id,
+    )
+    return name
+
+
+def test_supersede_delivers_fence_then_reaps_lower_gens(manifest) -> None:
+    """After a new gen N, the keeper delivers console.keeper_heartbeat{gen:N}
+    to every LIVE node with gen < N (its self-fence + capture_inflight window),
+    then reaps it. The just-minted gen N is NOT superseded."""
+    kid = "mac-body-keeper"
+    g1 = _record_gen_node(manifest, kid, 1)
+    g2 = _record_gen_node(manifest, kid, 2)
+    g3 = _record_gen_node(manifest, kid, 3)  # the NEW gen -- must NOT be reaped
+
+    delivered: List[Tuple[str, int]] = []
+    reaped: List[str] = []
+
+    async def fake_deliver(node_name: str, gen: int) -> bool:
+        delivered.append((node_name, gen))
+        return True
+
+    async def fake_delete(name: str, *, zone: Any = None) -> Tuple[bool, str]:
+        reaped.append(name)
+        return (True, "deleted:200")
+
+    keeper = bk.BrainKeeper(
+        discover_fn=_no_brain,
+        provision_fn=_FakeProvisioner(),
+        manifest=manifest, bucket=bk.PersistentTokenBucket(),
+        keeper_id=kid,
+        fence_deliver_fn=fake_deliver,
+        delete_instance_fn=fake_delete,
+        fence_grace_s=0.0,  # no real sleep in tests
+    )
+
+    result = asyncio.run(keeper.supersede_old_generations(3))
+
+    assert set(result["superseded"]) == {g1, g2}
+    assert g3 not in result["superseded"], "the new gen must never self-reap"
+    # The fence heartbeat carries the NEW gen so the old node observes gen>own.
+    assert set(delivered) == {(g1, 3), (g2, 3)}
+    # Both old nodes reaped after the grace.
+    assert set(reaped) == {g1, g2}
+    # Manifest converged: the reaped nodes are tombstoned, only g3 remains live.
+    live = {r["name"] for r in manifest.live_family(kid)}
+    assert live == {g3}
+
+
+def test_supersede_delivery_failure_falls_through_to_reap(manifest) -> None:
+    """An unreachable node (delivery raises/False) MUST still be reaped -- the
+    reap is the backstop; delivery never blocks it."""
+    kid = "mac-body-keeper"
+    g1 = _record_gen_node(manifest, kid, 1)
+    _record_gen_node(manifest, kid, 2)  # new gen
+
+    reaped: List[str] = []
+
+    async def failing_deliver(node_name: str, gen: int) -> bool:
+        raise RuntimeError("node unreachable")
+
+    async def fake_delete(name: str, *, zone: Any = None) -> Tuple[bool, str]:
+        reaped.append(name)
+        return (True, "deleted:200")
+
+    keeper = bk.BrainKeeper(
+        discover_fn=_no_brain, provision_fn=_FakeProvisioner(),
+        manifest=manifest, bucket=bk.PersistentTokenBucket(), keeper_id=kid,
+        fence_deliver_fn=failing_deliver, delete_instance_fn=fake_delete,
+        fence_grace_s=0.0,
+    )
+
+    result = asyncio.run(keeper.supersede_old_generations(2))
+    assert result["delivered"] == {g1: False}
+    assert reaped == [g1], "a failed delivery must still fall through to reap"
+
+
+def test_reap_generation_passes_owner_id_for_drift_query(manifest) -> None:
+    """IMPORTANT-4 wiring: reap_generation calls teardown_family with
+    owner_id=keeper_id so the drift detector queries the keeper-owner label."""
+    kid = "mac-body-keeper"
+    node = _record_gen_node(manifest, kid, 1)
+    query_calls: List[Dict[str, Any]] = []
+
+    async def fake_delete(name: str, *, zone: Any = None) -> Tuple[bool, str]:
+        return (True, "deleted:200")
+
+    async def label_query(**kwargs: Any) -> List[Dict[str, Any]]:
+        query_calls.append(kwargs)
+        return []
+
+    keeper = bk.BrainKeeper(
+        discover_fn=_no_brain, provision_fn=_FakeProvisioner(),
+        manifest=manifest, bucket=bk.PersistentTokenBucket(), keeper_id=kid,
+        delete_instance_fn=fake_delete, label_query_fn=label_query,
+    )
+
+    result = asyncio.run(keeper.reap_generation(node))
+    assert node in result["deleted"]
+    assert query_calls == [
+        {"label_key": bl.LABEL_OWNER, "label_value": kid},
+    ], "the drift query must key on the keeper-owner label, not the node name"
+
+
+def test_reap_generation_drift_flags_unowned_grandchild(manifest) -> None:
+    """The failover grandchild -- now carrying LABEL_OWNER=keeper -- shows up
+    in the keeper-keyed drift query. If the local manifest never recorded it
+    (cross-host birth), it is flagged as drift (NOT auto-deleted)."""
+    kid = "mac-body-keeper"
+    node = _record_gen_node(manifest, kid, 1)
+
+    async def fake_delete(name: str, *, zone: Any = None) -> Tuple[bool, str]:
+        return (True, "deleted:200")
+
+    async def label_query(**kwargs: Any) -> List[Dict[str, Any]]:
+        return [{"name": "jarvis-prime-failover"}]  # owner=keeper, unrecorded here
+
+    keeper = bk.BrainKeeper(
+        discover_fn=_no_brain, provision_fn=_FakeProvisioner(),
+        manifest=manifest, bucket=bk.PersistentTokenBucket(), keeper_id=kid,
+        delete_instance_fn=fake_delete, label_query_fn=label_query,
+    )
+    result = asyncio.run(keeper.reap_generation(node))
+    assert [d["name"] for d in result["drift"]] == ["jarvis-prime-failover"]
+
+
+def test_resurrect_success_triggers_supersession(manifest, bucket_path,
+                                                  monkeypatch) -> None:
+    """End-to-end: a successful resurrection to gen N supersedes the prior
+    live gen (delivers the fence + reaps). Proves supersede is wired into
+    _resurrect's success branch."""
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "5")
+    kid = "mac-body-keeper"
+    # A prior live gen-1 node exists on the manifest.
+    g1 = _record_gen_node(manifest, kid, 1)
+
+    delivered: List[Tuple[str, int]] = []
+    reaped: List[str] = []
+
+    async def fake_deliver(node_name: str, gen: int) -> bool:
+        delivered.append((node_name, gen))
+        return True
+
+    async def fake_delete(name: str, *, zone: Any = None) -> Tuple[bool, str]:
+        reaped.append(name)
+        return (True, "deleted:200")
+
+    clock = _FakeClock()
+    keeper = bk.BrainKeeper(
+        discover_fn=_no_brain, provision_fn=_FakeProvisioner(ok=True),
+        manifest=manifest, bucket=bk.PersistentTokenBucket(),
+        resurrect_after_s=900.0, keeper_id=kid, clock=clock,
+        fence_deliver_fn=fake_deliver, delete_instance_fn=fake_delete,
+        fence_grace_s=0.0,
+    )
+    # Drive the FSM into sustained absence -> resurrection (gen 2).
+    keeper.note_discovery_result(None)  # window starts
+    clock.advance(901.0)                # exceed resurrect_after_s
+    state = asyncio.run(keeper.tick())
+
+    assert state == "resurrected"
+    # gen 2 was minted (max_gen was 1) and the old gen-1 node was superseded.
+    assert delivered == [(g1, 2)]
+    assert reaped == [g1]

--- a/tests/governance/test_brain_keeper.py
+++ b/tests/governance/test_brain_keeper.py
@@ -443,3 +443,136 @@ def test_resurrected_missed_probe_rearms_absence_window(
     # The driver's own discovery feed finds the new node -> healthy.
     keeper.note_discovery_result("wss://10.0.0.9:8443/ws")
     assert asyncio.run(keeper.tick()) == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# Review fix IMPORTANT-1: the ENTIRE read-count-decide-append of try_take
+# runs inside ONE flock_critical_section acquisition (no cross-process
+# TOCTOU), and a lock that cannot be acquired REFUSES (fail-closed).
+# ---------------------------------------------------------------------------
+
+
+def test_try_take_decides_and_appends_under_the_lock(
+        bucket_path, monkeypatch) -> None:
+    """Recording monkeypatch of flock_critical_section: EVERY try_take
+    (grants AND refusals) acquires the section, and the grant's journal
+    append happens strictly BETWEEN enter and exit -- i.e. while the real
+    lock is held (an unlocked decide + locked append is the TOCTOU the
+    review flagged)."""
+    from contextlib import contextmanager
+
+    from backend.core.ouroboros.governance import cross_process_jsonl as cpj
+
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "1")
+    real_section = cpj.flock_critical_section
+    events: List[Dict[str, Any]] = []
+
+    def _lines() -> int:
+        return len(_journal_lines(bucket_path))
+
+    @contextmanager
+    def recording_section(path, **kwargs):
+        entry = {"path": str(path), "lines_at_enter": _lines()}
+        with real_section(path, **kwargs) as acquired:
+            yield acquired
+            # Still INSIDE the real lock: the caller's decide+append body
+            # has run by now (contextmanager resumes after the with-body).
+            entry["lines_before_exit"] = _lines()
+        events.append(entry)
+
+    monkeypatch.setattr(cpj, "flock_critical_section", recording_section)
+    bucket = bk.PersistentTokenBucket()
+
+    assert bucket.try_take(gen=1) is True
+    assert bucket.try_take(gen=2) is False    # refusal path
+    assert len(events) == 2, (
+        "EVERY take decision (grant and refusal) must run under the section")
+    for e in events:
+        assert str(bucket_path) in e["path"]
+    grant, refusal = events[0], events[1]
+    assert grant["lines_at_enter"] == 0 and grant["lines_before_exit"] == 1, (
+        "the grant append must land INSIDE the held section")
+    assert refusal["lines_at_enter"] == 1 and refusal["lines_before_exit"] == 1, (
+        "a refusal must append NOTHING inside the section")
+
+
+def test_try_take_fail_closed_when_lock_unavailable(
+        bucket_path, monkeypatch, caplog) -> None:
+    """A take that cannot acquire the lock REFUSES and appends nothing --
+    a billing guard that cannot prove capacity must never spend."""
+    from contextlib import contextmanager
+
+    from backend.core.ouroboros.governance import cross_process_jsonl as cpj
+
+    @contextmanager
+    def never_acquires(path, **kwargs):
+        yield False
+
+    monkeypatch.setattr(cpj, "flock_critical_section", never_acquires)
+    bucket = bk.PersistentTokenBucket()
+    with caplog.at_level(logging.ERROR):
+        assert bucket.try_take(gen=1) is False
+    assert _journal_lines(bucket_path) == [], "no lock -> no trace"
+    assert any("fail-closed" in r.getMessage() for r in caplog.records), (
+        "the refused-by-lock path must be LOUD")
+
+
+def test_try_take_concurrent_instances_never_exceed_capacity(
+        bucket_path, monkeypatch) -> None:
+    """Two bucket INSTANCES (the zombie-driver-overlapping-fresh-driver
+    shape, serialized here by the section's in-process lock tier) racing
+    try_take on one journal: exactly ONE grant at capacity 1, exactly one
+    journal line -- the decide can never run against a stale count."""
+    import threading
+
+    monkeypatch.setenv("JARVIS_BRAIN_RESURRECT_MAX_PER_H", "1")
+    b1 = bk.PersistentTokenBucket()
+    b2 = bk.PersistentTokenBucket()
+    barrier = threading.Barrier(2)
+    results: List[bool] = []
+    lock = threading.Lock()
+
+    def race(bucket: Any, gen: int) -> None:
+        barrier.wait()
+        got = bucket.try_take(gen=gen)
+        with lock:
+            results.append(got)
+
+    t1 = threading.Thread(target=race, args=(b1, 1))
+    t2 = threading.Thread(target=race, args=(b2, 2))
+    t1.start(); t2.start(); t1.join(timeout=30); t2.join(timeout=30)
+
+    assert sorted(results) == [False, True], (
+        "exactly one racer may win the last token: %r" % results)
+    assert len(_journal_lines(bucket_path)) == 1, (
+        "the cap must never be exceeded by a race")
+
+
+# ---------------------------------------------------------------------------
+# Review fix IMPORTANT-2: grep-enforced gen-minter uniqueness invariant.
+# ---------------------------------------------------------------------------
+
+
+def test_gen_minter_uniqueness_invariant() -> None:
+    """Exactly ONE shipped source file may mint generations
+    (``max_gen() + 1``), and it must be brain_keeper.py. Two independent
+    minters racing the same manifest could stamp duplicate generation
+    numbers -- the gen sequence is only monotonic because there is a
+    single minter."""
+    import re
+    from pathlib import Path
+
+    repo_root = Path(__file__).resolve().parents[2]
+    pattern = re.compile(r"max_gen\(\)\s*\+\s*1")
+    hits: List[str] = []
+    for base in ("backend", "scripts"):
+        for py in sorted((repo_root / base).rglob("*.py")):
+            try:
+                text = py.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            if pattern.search(text):
+                hits.append(str(py.relative_to(repo_root)))
+    assert hits == [
+        "backend/core/ouroboros/governance/brain_keeper.py",
+    ], "gen minting must have exactly ONE home: %r" % hits

--- a/tests/governance/test_brain_lifecycle.py
+++ b/tests/governance/test_brain_lifecycle.py
@@ -133,6 +133,26 @@ def test_live_family_empty_for_unknown_root(manifest) -> None:
     assert manifest.live_family("never-recorded") == []
 
 
+def test_live_family_terminates_on_parent_cycle(manifest) -> None:
+    """Cycle-safety pin (Task-3 fold-in from the Task-1 review): a 2-node
+    parent CYCLE (a->b->a) must terminate, return both nodes, and never hang.
+    Bounded by a hard deadline -- a regression that reintroduces an unbounded
+    walk fails the test instead of wedging the suite."""
+    from concurrent.futures import ThreadPoolExecutor  # noqa: PLC0415
+
+    _create(manifest, "node-a", parent="node-b")
+    _create(manifest, "node-b", parent="node-a")
+
+    with ThreadPoolExecutor(max_workers=1) as pool:
+        # .result(timeout=...) is the bounded deadline: raises TimeoutError
+        # instead of hanging if the BFS cycle guard ever regresses.
+        fam = pool.submit(manifest.live_family, "node-a").result(timeout=10)
+
+    names = [r["name"] for r in fam]
+    assert set(names) == {"node-a", "node-b"}, "both cycle members returned"
+    assert names[-1] == "node-a", "the root still comes last (children first)"
+
+
 # ---------------------------------------------------------------------------
 # (c) teardown_family: order + tombstones + fail-soft per item.
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_brain_lifecycle.py
+++ b/tests/governance/test_brain_lifecycle.py
@@ -1,0 +1,432 @@
+"""Tests for backend/core/ouroboros/governance/brain_lifecycle.py (Stage-4 Task 1).
+
+The hierarchical-ownership substrate: lineage labels + append-only Resource
+Manifest + manifest-walk-only family teardown + the extracted Brain
+provisioning core. NO live GCP -- every delete/create/query collaborator is an
+injected fake. The existing driver suites (tests/infra/test_ignite_brain_vm.py,
+test_brain_tls_delivery.py) pin the extraction's byte-equivalence UNMODIFIED.
+
+Proves:
+  (a) manifest append/replay round-trip incl. delete tombstones + corrupt-line
+      tolerance;
+  (b) ``live_family`` children-first ordering across a 3-level tree;
+  (c) ``teardown_family`` deletes children before the parent, records delete
+      tombstones, and is fail-soft on a single failing delete (continues +
+      reports);
+  (d) the drift detector: a label-query hit the manifest never recorded is
+      LOUD-warned + returned as ``drift`` -- and NEVER deleted (the manifest is
+      the only deletion source);
+  (e) ``max_gen`` across records (delete tombstones never regress it);
+  (f) ``sanitize_label_value`` edge cases (GCP label charset);
+  (g) ``provision_brain`` composes labels + brain-env via an injected fake
+      create fn;
+  (h) failover_lifecycle lineage-label fold from brain-env (additive,
+      env-absent -> None).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from typing import Any, Dict, List, Optional, Tuple
+
+import pytest
+
+from backend.core.ouroboros.governance import brain_lifecycle as bl
+
+
+@pytest.fixture()
+def manifest(tmp_path, monkeypatch):
+    path = tmp_path / "manifests" / "resource_manifest.jsonl"
+    monkeypatch.setenv("JARVIS_RESOURCE_MANIFEST_PATH", str(path))
+    monkeypatch.setenv("JARVIS_KEEPER_ID", "keeper-test")
+    return bl.ResourceManifest()
+
+
+def _create(m: bl.ResourceManifest, name: str, *, parent: Optional[str] = None,
+            kind: str = "instance", zone: str = "us-central1-a",
+            gen: Optional[int] = None) -> Dict[str, Any]:
+    return m.record_create(
+        kind=kind, name=name, zone=zone,
+        labels={bl.LABEL_OWNER: "root-brain"}, parent=parent, gen=gen,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (a) Append/replay round-trip + tombstones + corrupt-line tolerance.
+# ---------------------------------------------------------------------------
+
+
+def test_manifest_append_replay_round_trip(manifest) -> None:
+    rec = _create(manifest, "brain-root", gen=1)
+    _create(manifest, "child-a", parent="brain-root")
+
+    assert manifest.path.exists(), "append must materialize the JSONL"
+    fam = manifest.live_family("brain-root")
+    names = [r["name"] for r in fam]
+    assert names == ["child-a", "brain-root"]
+
+    # Every record field survives the round trip.
+    replayed_root = fam[-1]
+    for key in ("op", "kind", "name", "zone", "labels", "parent", "gen",
+                "keeper_id", "ts_utc"):
+        assert key in replayed_root, "record must carry %s" % key
+    assert replayed_root["kind"] == rec["kind"]
+    assert replayed_root["keeper_id"] == "keeper-test"
+    assert replayed_root["labels"] == {bl.LABEL_OWNER: "root-brain"}
+
+
+def test_manifest_delete_tombstone_removes_from_live_set(manifest) -> None:
+    _create(manifest, "brain-root")
+    _create(manifest, "child-a", parent="brain-root")
+    manifest.record_delete("child-a")
+
+    names = [r["name"] for r in manifest.live_family("brain-root")]
+    assert "child-a" not in names, "a tombstoned resource must not replay live"
+    assert names == ["brain-root"]
+
+
+def test_manifest_corrupt_line_is_skipped_not_fatal(manifest) -> None:
+    _create(manifest, "brain-root")
+    with manifest.path.open("a", encoding="utf-8") as fh:
+        fh.write("{this is not json!!\n")
+        fh.write("\n")  # blank line
+    _create(manifest, "child-a", parent="brain-root")
+
+    names = [r["name"] for r in manifest.live_family("brain-root")]
+    assert names == ["child-a", "brain-root"], (
+        "corrupt/blank lines must be skipped, records around them preserved")
+
+
+def test_manifest_default_path_is_repo_local(monkeypatch) -> None:
+    monkeypatch.delenv("JARVIS_RESOURCE_MANIFEST_PATH", raising=False)
+    p = bl._default_manifest_path()
+    assert p.parts[-3:] == (".jarvis", "manifests", "resource_manifest.jsonl")
+
+
+# ---------------------------------------------------------------------------
+# (b) live_family: children-first ordering across a 3-level tree.
+# ---------------------------------------------------------------------------
+
+
+def test_live_family_children_first_three_level_tree(manifest) -> None:
+    #   root
+    #   +-- child-1 --- grand-1
+    #   +-- child-2
+    _create(manifest, "root", gen=1)
+    _create(manifest, "child-1", parent="root")
+    _create(manifest, "child-2", parent="root")
+    _create(manifest, "grand-1", parent="child-1")
+    _create(manifest, "unrelated")  # different family -- must not appear
+
+    names = [r["name"] for r in manifest.live_family("root")]
+    assert "unrelated" not in names
+    assert set(names) == {"root", "child-1", "child-2", "grand-1"}
+    # CHILDREN FIRST: deepest level first, root strictly last.
+    assert names[0] == "grand-1", "the deepest descendant must come first"
+    assert names[-1] == "root", "the root must come last (deleted after children)"
+    assert names.index("grand-1") < names.index("child-1")
+
+
+def test_live_family_empty_for_unknown_root(manifest) -> None:
+    _create(manifest, "some-node")
+    assert manifest.live_family("never-recorded") == []
+
+
+# ---------------------------------------------------------------------------
+# (c) teardown_family: order + tombstones + fail-soft per item.
+# ---------------------------------------------------------------------------
+
+
+class _FakeDeleter:
+    def __init__(self, fail_names: Optional[set] = None,
+                 raise_names: Optional[set] = None) -> None:
+        self.calls: List[Tuple[str, Optional[str]]] = []
+        self.fw_calls: List[str] = []
+        self._fail = fail_names or set()
+        self._raise = raise_names or set()
+
+    async def delete_instance(self, name: str, *, zone: Optional[str] = None
+                              ) -> Tuple[bool, str]:
+        self.calls.append((name, zone))
+        if name in self._raise:
+            raise RuntimeError("boom deleting %s" % name)
+        if name in self._fail:
+            return (False, "INSERT_STILL_RUNNING")
+        return (True, "deleted:200")
+
+    async def delete_firewall(self, *, rule_name: str) -> Tuple[bool, str]:
+        self.fw_calls.append(rule_name)
+        return (True, "deleted:404")
+
+
+def test_teardown_family_deletes_children_before_parent(manifest) -> None:
+    _create(manifest, "root")
+    _create(manifest, "child-1", parent="root")
+    _create(manifest, "grand-1", parent="child-1")
+    fake = _FakeDeleter()
+
+    result = asyncio.run(bl.teardown_family(
+        "root", manifest=manifest, delete_instance_fn=fake.delete_instance,
+    ))
+
+    order = [n for n, _z in fake.calls]
+    assert order == ["grand-1", "child-1", "root"]
+    assert result["deleted"] == ["grand-1", "child-1", "root"]
+    assert result["failed"] == []
+    # Deletes are tombstoned -> the family has converged to empty.
+    assert manifest.live_family("root") == []
+
+
+def test_teardown_family_routes_firewall_kind_to_firewall_fn(manifest) -> None:
+    _create(manifest, "root")
+    _create(manifest, "root-mtls-fw", parent="root", kind="firewall")
+    fake = _FakeDeleter()
+
+    result = asyncio.run(bl.teardown_family(
+        "root", manifest=manifest,
+        delete_instance_fn=fake.delete_instance,
+        delete_firewall_fn=fake.delete_firewall,
+    ))
+    assert fake.fw_calls == ["root-mtls-fw"]
+    assert [n for n, _z in fake.calls] == ["root"], (
+        "the firewall record must never hit the instance deleter")
+    assert set(result["deleted"]) == {"root-mtls-fw", "root"}
+
+
+def test_teardown_family_fail_soft_continues_and_reports(manifest) -> None:
+    _create(manifest, "root")
+    _create(manifest, "child-ok", parent="root")
+    _create(manifest, "child-bad", parent="root")
+    fake = _FakeDeleter(raise_names={"child-bad"})
+
+    result = asyncio.run(bl.teardown_family(
+        "root", manifest=manifest, delete_instance_fn=fake.delete_instance,
+    ))
+
+    attempted = {n for n, _z in fake.calls}
+    assert attempted == {"child-ok", "child-bad", "root"}, (
+        "one failing delete must not stop the walk")
+    assert "child-ok" in result["deleted"] and "root" in result["deleted"]
+    assert [f["name"] for f in result["failed"]] == ["child-bad"]
+    # The failed child stays LIVE on the manifest (no tombstone) so the next
+    # walk retries it.
+    live = [r["name"] for r in manifest.live_family("root")]
+    assert live == ["child-bad"]
+
+
+def test_teardown_family_nonok_delete_reported_not_tombstoned(manifest) -> None:
+    _create(manifest, "root")
+    fake = _FakeDeleter(fail_names={"root"})
+    result = asyncio.run(bl.teardown_family(
+        "root", manifest=manifest, delete_instance_fn=fake.delete_instance,
+    ))
+    assert result["deleted"] == []
+    assert [f["name"] for f in result["failed"]] == ["root"]
+    assert [r["name"] for r in manifest.live_family("root")] == ["root"]
+
+
+# ---------------------------------------------------------------------------
+# (d) Drift detector: unknown label-family member -> loud warn + returned,
+#     NEVER deleted (the manifest is the only deletion source).
+# ---------------------------------------------------------------------------
+
+
+def test_drift_detector_flags_unknown_resource_loudly(manifest, caplog) -> None:
+    _create(manifest, "root")
+    _create(manifest, "child-1", parent="root")
+    fake = _FakeDeleter()
+    query_calls: List[Dict[str, Any]] = []
+
+    async def label_query(**kwargs: Any) -> List[Dict[str, Any]]:
+        query_calls.append(kwargs)
+        return [
+            {"name": "child-1", "zone": "us-central1-a"},   # known -- no drift
+            {"name": "jarvis-prime-failover-orphan", "zone": "us-west1-b"},
+        ]
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(bl.teardown_family(
+            "root", manifest=manifest,
+            delete_instance_fn=fake.delete_instance,
+            label_query_fn=label_query,
+        ))
+
+    assert [d["name"] for d in result["drift"]] == ["jarvis-prime-failover-orphan"]
+    assert any("DRIFT" in r.message for r in caplog.records), (
+        "an unrecorded family member must be LOUD-warned")
+    # The query fed the detector, not the deleter: the orphan is NOT deleted.
+    assert "jarvis-prime-failover-orphan" not in [n for n, _z in fake.calls]
+    # The detector queries by the OWNER label, sanitized.
+    assert query_calls == [
+        {"label_key": bl.LABEL_OWNER, "label_value": "root"},
+    ]
+
+
+def test_drift_detector_absent_by_default(manifest) -> None:
+    _create(manifest, "root")
+    fake = _FakeDeleter()
+    result = asyncio.run(bl.teardown_family(
+        "root", manifest=manifest, delete_instance_fn=fake.delete_instance,
+    ))
+    assert result["drift"] == []
+
+
+def test_manifest_walk_only_invariant_marker_present() -> None:
+    """Grep-enforceable structural invariant: the teardown must be marked as
+    manifest-walk-only (no list-style discovery as a deletion source)."""
+    import inspect
+
+    src = inspect.getsource(bl)
+    assert "# INVARIANT: manifest-walk-only teardown" in src
+
+
+# ---------------------------------------------------------------------------
+# (e) max_gen across records.
+# ---------------------------------------------------------------------------
+
+
+def test_max_gen_across_records_ignoring_tombstones(manifest) -> None:
+    assert manifest.max_gen() == 0, "empty manifest -> gen 0"
+    _create(manifest, "brain-g1", gen=1)
+    _create(manifest, "brain-g3", gen=3)
+    _create(manifest, "brain-g2", gen=2)
+    _create(manifest, "no-gen")            # gen=None tolerated
+    manifest.record_delete("brain-g3")     # tombstone must NOT regress max_gen
+    assert manifest.max_gen() == 3
+
+
+# ---------------------------------------------------------------------------
+# (f) sanitize_label_value edge cases.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("already-safe_1", "already-safe_1"),
+    ("MyNode.01", "mynode-01"),
+    ("Brain Node (v2)", "brain-node--v2-"),
+    ("", ""),
+    (None, ""),
+    (42, "42"),
+])
+def test_sanitize_label_value_edge_cases(raw, expected) -> None:
+    assert bl.sanitize_label_value(raw) == expected
+
+
+def test_sanitize_label_value_truncates_to_63() -> None:
+    out = bl.sanitize_label_value("A" * 100)
+    assert len(out) == 63
+    assert out == "a" * 63
+
+
+def test_label_constants_are_gcp_safe() -> None:
+    for const in (bl.LABEL_OWNER, bl.LABEL_PARENT, bl.LABEL_GEN):
+        assert const == bl.sanitize_label_value(const), (
+            "label KEYS must already satisfy the GCP charset")
+
+
+# ---------------------------------------------------------------------------
+# (g) provision_brain composes labels + brain-env via injected fake create fn.
+# ---------------------------------------------------------------------------
+
+
+def test_provision_brain_composes_labels_and_env(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_BRAIN_MTLS_DIR", raising=False)
+    monkeypatch.setenv("JARVIS_BRAIN_WS_PORT", "8443")
+    captured: Dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> Tuple[bool, str]:
+        captured.update(kwargs)
+        return (True, "created:done")
+
+    ok, detail = asyncio.run(bl.provision_brain(
+        node_name="jarvis-brain-gen2",
+        labels={bl.LABEL_OWNER: "Root.Brain", bl.LABEL_GEN: 2},
+        extra_env={"JARVIS_BRAIN_PARENT_NODE": "jarvis-brain-gen1",
+                   "JARVIS_BRAIN_GENERATION": "2"},
+        create_instance_fn=fake_create,
+    ))
+    assert ok is True and detail == "created:done"
+    assert captured["name"] == "jarvis-brain-gen2"
+
+    # Lineage labels arrive SANITIZED, merged over the base discovery label.
+    labels = captured["labels"]
+    assert labels["jarvis-role"] == "brain"
+    assert labels[bl.LABEL_OWNER] == "root-brain"
+    assert labels[bl.LABEL_GEN] == "2"
+
+    # brain-env metadata carries the env-resolved values AND the extra_env fold.
+    brain_env = captured["extra_metadata"]["brain-env"]
+    assert "JARVIS_BRAIN_WS_PORT=8443" in brain_env
+    assert "JARVIS_BRAIN_PARENT_NODE=jarvis-brain-gen1" in brain_env
+    assert "JARVIS_BRAIN_GENERATION=2" in brain_env
+
+    # The extracted composition still ships the CPU-only + startup contract.
+    assert captured["accelerator_type"] == ""
+    assert captured["accelerator_count"] == 0
+    assert captured["startup_script"].startswith("#!")
+    assert captured["machine_type"] and captured["image_family"]
+
+
+def test_provision_brain_defaults_are_byte_equivalent_shape(monkeypatch) -> None:
+    """labels=None / extra_env=None -> the exact legacy driver composition:
+    only the discovery label, no lineage keys in brain-env."""
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_BRAIN_MTLS_DIR", raising=False)
+    captured: Dict[str, Any] = {}
+
+    async def fake_create(**kwargs: Any) -> Tuple[bool, str]:
+        captured.update(kwargs)
+        return (True, "created:done")
+
+    asyncio.run(bl.provision_brain(
+        node_name="jarvis-brain-legacy", create_instance_fn=fake_create,
+    ))
+    assert captured["labels"] == {"jarvis-role": "brain"}
+    assert "JARVIS_BRAIN_PARENT_NODE" not in captured["extra_metadata"]["brain-env"]
+
+
+def test_provision_brain_tls_failclosed_before_create(monkeypatch, tmp_path) -> None:
+    """TLS enabled + material missing -> TLSMaterialError BEFORE the create fn
+    is ever called ($0 fail-closed, preserved through the extraction)."""
+    empty = tmp_path / "empty"
+    empty.mkdir()
+    monkeypatch.setenv("JARVIS_BRAIN_WS_TLS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_BRAIN_MTLS_DIR", str(empty))
+    calls: List[Dict[str, Any]] = []
+
+    async def fake_create(**kwargs: Any) -> Tuple[bool, str]:
+        calls.append(kwargs)
+        return (True, "created:done")
+
+    with pytest.raises(bl.TLSMaterialError):
+        asyncio.run(bl.provision_brain(
+            node_name="jarvis-brain-x", create_instance_fn=fake_create,
+        ))
+    assert calls == [], "no create may be attempted on a failed TLS preflight"
+
+
+# ---------------------------------------------------------------------------
+# (h) failover_lifecycle lineage fold from brain-env (additive).
+# ---------------------------------------------------------------------------
+
+
+def test_failover_lineage_labels_from_env(monkeypatch) -> None:
+    from backend.core.ouroboros.governance import failover_lifecycle as fl
+
+    monkeypatch.setenv("JARVIS_BRAIN_PARENT_NODE", "Jarvis-Brain-Gen1")
+    monkeypatch.setenv("JARVIS_BRAIN_GENERATION", "2")
+    assert fl._lineage_labels() == {
+        bl.LABEL_PARENT: "jarvis-brain-gen1",
+        bl.LABEL_GEN: "2",
+    }
+
+
+def test_failover_lineage_labels_absent_env_is_none(monkeypatch) -> None:
+    from backend.core.ouroboros.governance import failover_lifecycle as fl
+
+    monkeypatch.delenv("JARVIS_BRAIN_PARENT_NODE", raising=False)
+    monkeypatch.delenv("JARVIS_BRAIN_GENERATION", raising=False)
+    assert fl._lineage_labels() is None, (
+        "env-absent must stay byte-identical (labels=None)")

--- a/tests/governance/test_brain_lifecycle.py
+++ b/tests/governance/test_brain_lifecycle.py
@@ -292,6 +292,63 @@ def test_drift_detector_absent_by_default(manifest) -> None:
     assert result["drift"] == []
 
 
+def test_teardown_owner_id_keys_drift_query_to_the_owner_label(
+        manifest, caplog) -> None:
+    """Stage-4 IMPORTANT-4: the family walk keys on ``root_name`` (the
+    parent-chain root, here the Brain NODE), but the keeper stamps
+    ``LABEL_OWNER=keeper_id``. ``owner_id`` re-keys ONLY the drift query so
+    the detector actually matches the family's owner label -- WITHOUT it the
+    query used the node name and matched nothing (inert detector)."""
+    _create(manifest, "brain-node")
+    _create(manifest, "child-1", parent="brain-node")
+    fake = _FakeDeleter()
+    query_calls: List[Dict[str, Any]] = []
+
+    async def label_query(**kwargs: Any) -> List[Dict[str, Any]]:
+        query_calls.append(kwargs)
+        return [
+            {"name": "child-1"},                             # known -> no drift
+            {"name": "jarvis-prime-failover-orphan"},        # unrecorded -> drift
+        ]
+
+    with caplog.at_level(logging.WARNING):
+        result = asyncio.run(bl.teardown_family(
+            "brain-node", manifest=manifest,
+            delete_instance_fn=fake.delete_instance,
+            label_query_fn=label_query,
+            owner_id="mac-body-keeper",
+        ))
+
+    # The drift query keyed on the KEEPER-owner label, NOT the walk root.
+    assert query_calls == [
+        {"label_key": bl.LABEL_OWNER, "label_value": "mac-body-keeper"},
+    ]
+    assert [d["name"] for d in result["drift"]] == [
+        "jarvis-prime-failover-orphan"]
+    # Never a deletion source: the drifted orphan is not deleted.
+    assert "jarvis-prime-failover-orphan" not in [n for n, _z in fake.calls]
+
+
+def test_teardown_owner_id_none_defaults_to_root_name(manifest) -> None:
+    """``owner_id=None`` -> the drift query defaults to ``root_name``
+    (byte-identical legacy behavior)."""
+    _create(manifest, "root")
+    fake = _FakeDeleter()
+    query_calls: List[Dict[str, Any]] = []
+
+    async def label_query(**kwargs: Any) -> List[Dict[str, Any]]:
+        query_calls.append(kwargs)
+        return []
+
+    asyncio.run(bl.teardown_family(
+        "root", manifest=manifest, delete_instance_fn=fake.delete_instance,
+        label_query_fn=label_query,
+    ))
+    assert query_calls == [
+        {"label_key": bl.LABEL_OWNER, "label_value": "root"},
+    ]
+
+
 def test_manifest_walk_only_invariant_marker_present() -> None:
     """Grep-enforceable structural invariant: the teardown must be marked as
     manifest-walk-only (no list-style discovery as a deletion source)."""

--- a/tests/governance/test_failover_lifecycle.py
+++ b/tests/governance/test_failover_lifecycle.py
@@ -309,6 +309,83 @@ async def test_default_delete_uses_native_rest_zero_gcloud(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
+# Stage-4 CRITICAL-1: failover child record-at-birth + LABEL_OWNER on labels.
+# ---------------------------------------------------------------------------
+
+
+async def test_failover_child_recorded_at_birth_with_owner(monkeypatch, tmp_path):
+    """A failover awaken that runs ON a labeled Brain node (lineage env present)
+    records the grandchild into the SHARED manifest with LABEL_OWNER=keeper_id
+    -- so it is IN the family walk AND flagged by the keeper-keyed drift
+    detector (the orphan class Stage 4 exists to kill)."""
+    import backend.core.ouroboros.governance.gcp_compute_rest as gr
+    from backend.core.ouroboros.governance import brain_lifecycle as bl
+
+    manifest_path = tmp_path / "manifests" / "resource_manifest.jsonl"
+    monkeypatch.setenv("JARVIS_RESOURCE_MANIFEST_PATH", str(manifest_path))
+    # Lineage env: THIS failover controller runs on a gen-2 Brain node.
+    monkeypatch.setenv("JARVIS_KEEPER_ID", "mac-body-keeper")
+    monkeypatch.setenv("JARVIS_BRAIN_PARENT_NODE", "jarvis-brain-gen2-xyz")
+    monkeypatch.setenv("JARVIS_BRAIN_GENERATION", "2")
+    monkeypatch.setenv("JARVIS_FAILOVER_NODE_NAME", "jarvis-prime-failover")
+
+    class FakeRest:
+        async def verify_compute_scopes(self):
+            return (True, "compute_scope_present")
+
+        async def create_instance(self, *, startup_script, labels=None, **kw):
+            # The lineage labels MUST carry the owner (CRITICAL-1(b)).
+            assert labels is not None
+            assert labels.get(bl.LABEL_OWNER) == "mac-body-keeper"
+            return (True, "created:SPOT:200")
+
+    monkeypatch.setattr(gr, "get_compute_rest", lambda: FakeRest())
+    ok = await fl._default_vm_awaken_fn(startup_script="#!/bin/bash\n")
+    assert ok is True
+
+    # The grandchild is now IN the manifest family walk, keyed under its
+    # PARENT (the Brain node it was born on) -- so a teardown_family walk of
+    # the parent's subtree reaps it. Before CRITICAL-1 there was NO record at
+    # all (nor a LABEL_OWNER for the keeper-keyed drift detector).
+    manifest = bl.ResourceManifest()
+    fam = [r["name"] for r in manifest.live_family("jarvis-brain-gen2-xyz")]
+    assert "jarvis-prime-failover" in fam, (
+        "the failover child must be recorded at birth under its parent node")
+    rec = next(r for r in manifest.live_family("jarvis-brain-gen2-xyz")
+               if r["name"] == "jarvis-prime-failover")
+    assert rec["labels"].get(bl.LABEL_OWNER) == "mac-body-keeper"
+    assert rec["parent"] == "jarvis-brain-gen2-xyz"
+    assert rec["gen"] == 2
+    assert rec["keeper_id"] == "mac-body-keeper"
+
+
+async def test_failover_child_no_manifest_write_when_env_absent(monkeypatch, tmp_path):
+    """Env-absent (a plain failover run, NOT on a Brain node) -> the manifest
+    is never touched (byte-identical pre-Stage-4 behavior)."""
+    import backend.core.ouroboros.governance.gcp_compute_rest as gr
+
+    manifest_path = tmp_path / "manifests" / "resource_manifest.jsonl"
+    monkeypatch.setenv("JARVIS_RESOURCE_MANIFEST_PATH", str(manifest_path))
+    monkeypatch.delenv("JARVIS_KEEPER_ID", raising=False)
+    monkeypatch.delenv("JARVIS_BRAIN_PARENT_NODE", raising=False)
+    monkeypatch.delenv("JARVIS_BRAIN_GENERATION", raising=False)
+
+    class FakeRest:
+        async def verify_compute_scopes(self):
+            return (True, "compute_scope_present")
+
+        async def create_instance(self, *, startup_script, labels=None, **kw):
+            assert labels is None  # no lineage -> byte-identical payload
+            return (True, "created:SPOT:200")
+
+    monkeypatch.setattr(gr, "get_compute_rest", lambda: FakeRest())
+    ok = await fl._default_vm_awaken_fn(startup_script="x")
+    assert ok is True
+    assert not manifest_path.exists(), (
+        "a non-Brain-node failover run must never touch the manifest")
+
+
+# ---------------------------------------------------------------------------
 # AWAKENING -> SERVING gated by observed ensure-ready probe
 # ---------------------------------------------------------------------------
 

--- a/tests/governance/test_generation_fence.py
+++ b/tests/governance/test_generation_fence.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+"""GenerationFence (Stage-4 Task 4): the Brain-side split-brain ACTIVE fence.
+
+Contract under proof:
+
+  (a) A ``console.keeper_heartbeat`` carrying a HIGHER gen than the fence's
+      own triggers the deterministic ordered transition -- boundary arm ->
+      shutdown request -> checkpoint capture -> idle touch -- EXACTLY ONCE
+      (a second higher-gen observation no-ops: idempotent latch).
+  (b) Equal / lower gen -> zero arms.
+  (c) Malformed payload (missing gen, non-int gen) -> ignored, no raise.
+  (d) One arm raising -> the remaining arms are STILL attempted (fail-soft
+      per step, deterministic transition).
+  (e) AST pin: generation_fence.py imports no LLM/provider machinery --
+      pure code, no model in the fence path.
+  (f) organism_bus_host wiring: JARVIS_BRAIN_GENERATION set (>0) -> a fence
+      is constructed with own_gen and started (and stopped in stop());
+      env absent/invalid -> nothing constructed (byte-identical).
+
+(a)-(d) run against a REAL TrinityEventBus (the fence's subscribe path is
+real); TRINITY_MULTICAST_ENABLED=false suppresses the in-process UDP
+shortcut (precedent: test_trinity_bus_bridge.py::_mk_bus). Delivery waits
+poll ``bus._metrics.events_delivered`` -- incremented only AFTER every
+matching handler completed (trinity_event_bus._process_queue), so the
+waits are deterministic, not sleep-guesses. All publishes use
+``persist=False`` (no event-store WAL writes from a test).
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import os
+from typing import Any, List
+
+from backend.core.ouroboros.governance.generation_fence import (
+    HEARTBEAT_TOPIC,
+    GenerationFence,
+)
+from backend.core.trinity_event_bus import RepoType, TrinityEventBus
+
+_FENCE_SOURCE = os.path.join(
+    os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
+    "backend", "core", "ouroboros", "governance", "generation_fence.py",
+)
+
+
+async def _mk_bus() -> TrinityEventBus:
+    """A REAL bus with the in-process UDP multicast artifact suppressed
+    (rationale + precedent: test_trinity_bus_bridge.py::_mk_bus)."""
+    prev = os.environ.get("TRINITY_MULTICAST_ENABLED")
+    os.environ["TRINITY_MULTICAST_ENABLED"] = "false"
+    try:
+        return await TrinityEventBus.create(local_repo=RepoType.JARVIS)
+    finally:
+        if prev is None:
+            os.environ.pop("TRINITY_MULTICAST_ENABLED", None)
+        else:
+            os.environ["TRINITY_MULTICAST_ENABLED"] = prev
+
+
+async def _await_delivered(bus: TrinityEventBus, count: int,
+                           timeout_s: float = 5.0) -> None:
+    """Wait until the bus has fully delivered ``count`` events (every
+    matching handler awaited -- the counter increments after the gather)."""
+    deadline = asyncio.get_event_loop().time() + timeout_s
+    while asyncio.get_event_loop().time() < deadline:
+        if bus._metrics.events_delivered >= count:
+            return
+        await asyncio.sleep(0.01)
+    raise AssertionError(
+        "bus never delivered %d event(s) (delivered=%d)"
+        % (count, bus._metrics.events_delivered))
+
+
+def _recorders(order: List[str], *, boom: str = ""):
+    """Four recording arm seams appending their name to ``order``; the one
+    named by ``boom`` raises AFTER recording (fail-soft proof)."""
+    def _mk(name: str):
+        def _arm() -> None:
+            order.append(name)
+            if name == boom:
+                raise RuntimeError("%s arm exploded" % name)
+        return _arm
+    return dict(
+        boundary_arm_fn=_mk("boundary"),
+        shutdown_fn=_mk("shutdown"),
+        capture_fn=_mk("capture"),
+        idle_touch_fn=_mk("idle"),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# (a) higher gen -> ordered transition, exactly once
+# --------------------------------------------------------------------------- #
+def test_higher_gen_fences_all_four_arms_in_order_exactly_once():
+    async def scenario() -> List[str]:
+        bus = await _mk_bus()
+        try:
+            order: List[str] = []
+            fence = GenerationFence(bus, 2, **_recorders(order))
+            await fence.start()
+
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"gen": 3}, persist=False)
+            await _await_delivered(bus, 1)
+            assert fence.fenced is True
+
+            # Second higher-gen observation (distinct payload -- the bus
+            # dedups identical fingerprints) MUST no-op: idempotent latch.
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"gen": 4}, persist=False)
+            await _await_delivered(bus, 2)
+
+            await fence.stop()
+            return order
+        finally:
+            await bus.stop()
+
+    order = asyncio.run(scenario())
+    assert order == ["boundary", "shutdown", "capture", "idle"], (
+        "the transition must run all four arms IN ORDER exactly once: %r"
+        % order)
+
+
+# --------------------------------------------------------------------------- #
+# (b) equal / lower gen -> zero arms
+# --------------------------------------------------------------------------- #
+def test_equal_and_lower_gen_never_fence():
+    async def scenario() -> List[str]:
+        bus = await _mk_bus()
+        try:
+            order: List[str] = []
+            fence = GenerationFence(bus, 3, **_recorders(order))
+            await fence.start()
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"gen": 3}, persist=False)  # equal
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"gen": 1}, persist=False)  # lower
+            await _await_delivered(bus, 2)
+            assert fence.fenced is False
+            await fence.stop()
+            return order
+        finally:
+            await bus.stop()
+
+    assert asyncio.run(scenario()) == []
+
+
+# --------------------------------------------------------------------------- #
+# (c) malformed payloads -> ignored, no raise
+# --------------------------------------------------------------------------- #
+def test_malformed_heartbeats_are_ignored():
+    async def scenario() -> List[str]:
+        bus = await _mk_bus()
+        try:
+            order: List[str] = []
+            fence = GenerationFence(bus, 1, **_recorders(order))
+            await fence.start()
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"note": "no gen key"}, persist=False)
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"gen": "not-an-int"}, persist=False)
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"gen": None}, persist=False)
+            await _await_delivered(bus, 3)
+            assert fence.fenced is False
+            await fence.stop()
+            return order
+        finally:
+            await bus.stop()
+
+    assert asyncio.run(scenario()) == []
+
+
+# --------------------------------------------------------------------------- #
+# (d) one arm raising -> the rest still attempted
+# --------------------------------------------------------------------------- #
+def test_failing_arm_does_not_stop_the_remaining_arms():
+    async def scenario() -> List[str]:
+        bus = await _mk_bus()
+        try:
+            order: List[str] = []
+            fence = GenerationFence(bus, 2, **_recorders(order, boom="boundary"))
+            await fence.start()
+            await bus.publish_raw(
+                HEARTBEAT_TOPIC, {"gen": 9}, persist=False)
+            await _await_delivered(bus, 1)
+            assert fence.fenced is True
+            await fence.stop()
+            return order
+        finally:
+            await bus.stop()
+
+    order = asyncio.run(scenario())
+    assert order == ["boundary", "shutdown", "capture", "idle"], (
+        "a raising arm must not stop the remaining arms: %r" % order)
+
+
+# --------------------------------------------------------------------------- #
+# (e) AST pin: no LLM/provider imports in the fence module
+# --------------------------------------------------------------------------- #
+def test_ast_pin_no_llm_or_provider_imports():
+    """The fence is pure code -- Mandate: deterministic, no LLM. Any import
+    (top-level OR function-local) of provider/LLM machinery fails this pin."""
+    forbidden = (
+        "providers", "doubleword", "candidate_generator", "anthropic",
+        "openai", "llm", "tool_executor", "plan_generator",
+    )
+    with open(_FENCE_SOURCE, "r", encoding="utf-8") as fh:
+        tree = ast.parse(fh.read())
+    imported: List[str] = []
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            imported.extend(alias.name for alias in node.names)
+        elif isinstance(node, ast.ImportFrom):
+            mod = node.module or ""
+            imported.append(mod)
+            imported.extend("%s.%s" % (mod, alias.name) for alias in node.names)
+    bad = [name for name in imported
+           if any(f in name.lower() for f in forbidden)]
+    assert not bad, (
+        "generation_fence.py must import no LLM/provider machinery: %r" % bad)
+
+
+# --------------------------------------------------------------------------- #
+# (f) organism_bus_host wiring: env-gated construction
+# --------------------------------------------------------------------------- #
+class _RecordingFence:
+    instances: List["_RecordingFence"] = []
+
+    def __init__(self, bus: Any, own_gen: int, **kwargs: Any) -> None:
+        self.bus = bus
+        self.own_gen = own_gen
+        self.started = False
+        self.stopped = False
+        _RecordingFence.instances.append(self)
+
+    async def start(self) -> None:
+        self.started = True
+
+    async def stop(self) -> None:
+        self.stopped = True
+
+
+def _patched_host_module(monkeypatch):
+    """Patch the lazy-import target: organism_bus_host does
+    ``from ... import generation_fence`` then ``generation_fence.
+    GenerationFence`` -- patching the module attribute intercepts
+    construction (the test_organism_bus_host.py router-seam precedent)."""
+    import backend.core.ouroboros.governance.generation_fence as gf
+    monkeypatch.setattr(gf, "GenerationFence", _RecordingFence)
+    _RecordingFence.instances = []
+    from backend.core.ouroboros.governance.transport.organism_bus_host import (
+        OrganismBusHost,
+    )
+    return OrganismBusHost
+
+
+def test_host_arms_fence_when_generation_env_set(monkeypatch):
+    OrganismBusHost = _patched_host_module(monkeypatch)
+    monkeypatch.setenv("JARVIS_BRAIN_GENERATION", "7")
+    host = OrganismBusHost()
+    fake_bus = object()
+
+    async def scenario() -> None:
+        await host._maybe_start_generation_fence(fake_bus)
+        assert len(_RecordingFence.instances) == 1
+        fence = _RecordingFence.instances[0]
+        assert fence.bus is fake_bus, "the fence must ride the ORGANISM bus"
+        assert fence.own_gen == 7
+        assert fence.started is True
+        # stop() must unwind the fence.
+        await host.stop()
+        assert fence.stopped is True
+        assert host._generation_fence is None
+
+    asyncio.run(scenario())
+
+
+def test_host_stays_dark_when_generation_env_absent_or_invalid(monkeypatch):
+    OrganismBusHost = _patched_host_module(monkeypatch)
+    host = OrganismBusHost()
+
+    async def scenario() -> None:
+        for value in (None, "", "  ", "0", "-3", "abc"):
+            if value is None:
+                monkeypatch.delenv("JARVIS_BRAIN_GENERATION", raising=False)
+            else:
+                monkeypatch.setenv("JARVIS_BRAIN_GENERATION", value)
+            await host._maybe_start_generation_fence(object())
+            assert host._generation_fence is None, (
+                "env %r must not arm a fence" % (value,))
+        assert _RecordingFence.instances == [], (
+            "no fence may be constructed without a positive generation")
+
+    asyncio.run(scenario())

--- a/tests/governance/test_generation_fence.py
+++ b/tests/governance/test_generation_fence.py
@@ -412,3 +412,103 @@ def test_real_fence_trip_denies_change_engine_and_auto_committer(
             "auto_commit_disabled", "no_target_files")
 
     asyncio.run(scenario())
+
+
+# --------------------------------------------------------------------------- #
+# (h) saga: fenced -> forward-write refused, compensation still succeeds
+# --------------------------------------------------------------------------- #
+def test_fenced_saga_forward_write_refused_but_compensation_exempt(tmp_path):
+    """Re-review Important-1: the saga's raw write_bytes forward-writes
+    (cross_repo path) must consult the latch; compensation/ROLLBACK writes
+    MUST stay exempt -- a fenced node may still restore preimages."""
+    from backend.core.ouroboros.governance.saga.saga_apply_strategy import (
+        SagaApplyStrategy,
+    )
+    from backend.core.ouroboros.governance.saga.saga_types import (
+        FileOp,
+        PatchedFile,
+        RepoPatch,
+    )
+
+    import subprocess
+
+    # A real git repo so the unfenced apply's `git add` succeeds (the
+    # tests/governance/saga/test_saga_apply_strategy.py precedent).
+    subprocess.run(["git", "init"], cwd=tmp_path,
+                   capture_output=True, check=True)
+    (tmp_path / "src").mkdir()
+    target = tmp_path / "src" / "mod.py"
+    target.write_bytes(b"old = 1\n")
+
+    patch_obj = RepoPatch(
+        repo="jarvis",
+        files=(PatchedFile(
+            path="src/mod.py", op=FileOp.MODIFY, preimage=b"old = 1\n"),),
+        new_content=(("src/mod.py", b"new = 2\n"),),
+    )
+    strategy = SagaApplyStrategy(
+        repo_roots={"jarvis": tmp_path}, ledger=None)
+
+    async def scenario() -> None:
+        gf._mark_fenced()
+
+        # FORWARD write: refused via the saga's own failure pattern (raise
+        # out of _apply_patch -> Phase B failure -> compensation), file
+        # untouched.
+        with pytest.raises(RuntimeError, match="generation_fenced"):
+            await strategy._apply_patch("jarvis", patch_obj)
+        assert target.read_bytes() == b"old = 1\n", (
+            "a fenced saga forward-write must never touch disk")
+
+        # COMPENSATION write: exempt -- preimage restore still lands.
+        target.write_bytes(b"half-applied garbage")
+        await strategy._compensate_patch("jarvis", patch_obj)
+        assert target.read_bytes() == b"old = 1\n", (
+            "a fenced node must still be able to roll back (compensation "
+            "writes are fence-exempt)")
+
+        # Unfenced: the same forward write applies normally.
+        gf._reset_for_tests()
+        await strategy._apply_patch("jarvis", patch_obj)
+        assert target.read_bytes() == b"new = 2\n"
+
+    asyncio.run(scenario())
+
+
+# --------------------------------------------------------------------------- #
+# (i) venom tool loop: fenced -> write_file / edit_file refuse
+# --------------------------------------------------------------------------- #
+def test_fenced_tool_executor_write_and_edit_refused(tmp_path):
+    """Re-review Important-2: write_file/edit_file mutate disk directly
+    during GENERATE -- the post-fence window before arm-1 shutdown bites
+    must be closed at the handler top (the handlers' established
+    error-string denial shape)."""
+    import backend.core.ouroboros.governance.tool_executor as te_mod
+
+    te = te_mod.ToolExecutor(tmp_path)
+    existing = tmp_path / "mod.py"
+    existing.write_text("x = 1\n", encoding="utf-8")
+    te._files_read.add("mod.py")  # bypass must-have-read (test precedent)
+
+    gf._mark_fenced()
+
+    res_w = te._write_file({"path": "newfile.py", "content": "y = 2\n"})
+    assert "POLICY_DENIED reason=generation_fenced" in res_w, res_w
+    assert not (tmp_path / "newfile.py").exists(), (
+        "a fenced write_file must never touch disk")
+
+    res_e = te._edit_file(
+        {"path": "mod.py", "old_text": "x = 1\n", "new_text": "x = 3\n"})
+    assert "POLICY_DENIED reason=generation_fenced" in res_e, res_e
+    assert existing.read_text(encoding="utf-8") == "x = 1\n", (
+        "a fenced edit_file must never touch disk")
+
+    # Unfenced: both handlers work normally (zero change).
+    gf._reset_for_tests()
+    res_w2 = te._write_file({"path": "newfile.py", "content": "y = 2\n"})
+    assert "POLICY_DENIED" not in res_w2, res_w2
+    assert (tmp_path / "newfile.py").exists()
+    res_e2 = te._edit_file(
+        {"path": "mod.py", "old_text": "x = 1\n", "new_text": "x = 3\n"})
+    assert "POLICY_DENIED" not in res_e2, res_e2
+    assert existing.read_text(encoding="utf-8") == "x = 3\n"

--- a/tests/governance/test_generation_fence.py
+++ b/tests/governance/test_generation_fence.py
@@ -16,9 +16,15 @@ Contract under proof:
   (f) organism_bus_host wiring: JARVIS_BRAIN_GENERATION set (>0) -> a fence
       is constructed with own_gen and started (and stopped in stop());
       env absent/invalid -> nothing constructed (byte-identical).
+  (g) CHOKEPOINT INTEGRATION (review Critical fix): a REAL fence trip
+      (real-bus heartbeat) sets the process-global latch, after which the
+      REAL ``ChangeEngine.execute`` refuses a tmp-file mutation with
+      ``POLICY_DENIED reason=generation_fenced`` and the REAL
+      ``AutoCommitter.commit`` skips with ``generation_fenced`` -- and an
+      unfenced (reset) engine mutates normally.
 
-(a)-(d) run against a REAL TrinityEventBus (the fence's subscribe path is
-real); TRINITY_MULTICAST_ENABLED=false suppresses the in-process UDP
+(a)-(d),(g) run against a REAL TrinityEventBus (the fence's subscribe path
+is real); TRINITY_MULTICAST_ENABLED=false suppresses the in-process UDP
 shortcut (precedent: test_trinity_bus_bridge.py::_mk_bus). Delivery waits
 poll ``bus._metrics.events_delivered`` -- incremented only AFTER every
 matching handler completed (trinity_event_bus._process_queue), so the
@@ -30,13 +36,26 @@ from __future__ import annotations
 import ast
 import asyncio
 import os
+from pathlib import Path
 from typing import Any, List
 
+import pytest
+
+import backend.core.ouroboros.governance.generation_fence as gf
 from backend.core.ouroboros.governance.generation_fence import (
     HEARTBEAT_TOPIC,
     GenerationFence,
 )
 from backend.core.trinity_event_bus import RepoType, TrinityEventBus
+
+
+@pytest.fixture(autouse=True)
+def _clean_latch():
+    """The chokepoint latch is process-global (one-way in production) --
+    every test starts and ends unfenced so a trip never leaks across tests."""
+    gf._reset_for_tests()
+    yield
+    gf._reset_for_tests()
 
 _FENCE_SOURCE = os.path.join(
     os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))),
@@ -104,6 +123,10 @@ def test_higher_gen_fences_all_four_arms_in_order_exactly_once():
                 HEARTBEAT_TOPIC, {"gen": 3}, persist=False)
             await _await_delivered(bus, 1)
             assert fence.fenced is True
+            # Arm 0 -- the process-global chokepoint latch -- is intrinsic:
+            # it fires even with all four graceful arms injected.
+            assert gf.is_fenced() is True
+            assert gf.fence_reason() == "generation_fenced"
 
             # Second higher-gen observation (distinct payload -- the bus
             # dedups identical fingerprints) MUST no-op: idempotent latch.
@@ -138,6 +161,8 @@ def test_equal_and_lower_gen_never_fence():
                 HEARTBEAT_TOPIC, {"gen": 1}, persist=False)  # lower
             await _await_delivered(bus, 2)
             assert fence.fenced is False
+            assert gf.is_fenced() is False, (
+                "equal/lower gen must never set the chokepoint latch")
             await fence.stop()
             return order
         finally:
@@ -292,5 +317,98 @@ def test_host_stays_dark_when_generation_env_absent_or_invalid(monkeypatch):
                 "env %r must not arm a fence" % (value,))
         assert _RecordingFence.instances == [], (
             "no fence may be constructed without a positive generation")
+
+    asyncio.run(scenario())
+
+
+# --------------------------------------------------------------------------- #
+# (g) chokepoint integration: a REAL trip denies the REAL mutation surfaces
+# --------------------------------------------------------------------------- #
+def test_real_fence_trip_denies_change_engine_and_auto_committer(
+        tmp_path, monkeypatch):
+    """The test the review demanded: after a REAL fence trip (real-bus
+    heartbeat -> arm-0 latch), the REAL ChangeEngine refuses an APPLY write
+    and the REAL AutoCommitter refuses a commit -- proving the fence
+    structurally terminates the mutation pathways for a CURRENT process,
+    mid-flight ops included (Mandate 2). Reset -> the same engine mutates
+    normally (zero behavior change unfenced)."""
+    from backend.core.ouroboros.governance.auto_committer import AutoCommitter
+    from backend.core.ouroboros.governance.change_engine import (
+        ChangeEngine,
+        ChangeRequest,
+    )
+    from backend.core.ouroboros.governance.ledger import OperationLedger
+    from backend.core.ouroboros.governance.risk_engine import (
+        ChangeType,
+        OperationProfile,
+    )
+
+    # Writes must land under tmp_path, not a leaked harness workspace.
+    monkeypatch.delenv("JARVIS_AUTO_COMMIT_WORKSPACE", raising=False)
+    (tmp_path / "src").mkdir()
+    target = tmp_path / "src" / "app.py"
+
+    def _request(op_id: str) -> ChangeRequest:
+        # SAFE_AUTO profile so an UNfenced op reaches the APPLY write
+        # (the test_change_engine_chokepoint.py construction precedent).
+        return ChangeRequest(
+            goal="generation fence chokepoint integration",
+            target_file=target,
+            proposed_content="x = 1\n",
+            profile=OperationProfile(
+                files_affected=[target],
+                change_type=ChangeType.MODIFY,
+                blast_radius=1,
+                crosses_repo_boundary=False,
+                touches_security_surface=False,
+                touches_supervisor=False,
+                test_scope_confidence=1.0,
+            ),
+            op_id=op_id,
+        )
+
+    async def scenario() -> None:
+        # 1. REAL fence trip: real bus, real subscribe path, real heartbeat.
+        bus = await _mk_bus()
+        try:
+            order: List[str] = []
+            fence = GenerationFence(bus, 1, **_recorders(order))
+            await fence.start()
+            await bus.publish_raw(HEARTBEAT_TOPIC, {"gen": 2}, persist=False)
+            await _await_delivered(bus, 1)
+            assert gf.is_fenced() is True, "the trip must set the arm-0 latch"
+            await fence.stop()
+        finally:
+            await bus.stop()
+
+        # 2. REAL ChangeEngine refuses the mutation at its chokepoint.
+        engine = ChangeEngine(
+            project_root=tmp_path,
+            ledger=OperationLedger(storage_dir=tmp_path / "ledger"),
+        )
+        res = await engine.execute(_request("op-fenced"))
+        assert res.success is False
+        assert res.error == "POLICY_DENIED reason=generation_fenced"
+        assert not target.exists(), "a fenced APPLY must never touch disk"
+
+        # 3. REAL AutoCommitter refuses at its entry -- FIRST, even before
+        #    the no_target_files / disabled guards (gate precedence pin).
+        committer = AutoCommitter(tmp_path)
+        cres = await committer.commit(
+            op_id="op-fenced", description="fenced", target_files=())
+        assert cres.committed is False
+        assert cres.skipped_reason == "generation_fenced"
+
+        # 4. Unfenced (latch reset) -> the SAME engine mutates normally.
+        gf._reset_for_tests()
+        res2 = await engine.execute(_request("op-ok"))
+        assert res2.success is True, res2.error
+        assert target.exists() and "x = 1" in target.read_text()
+        # ... and the commit gate is passed cleanly: the NEXT guard answers
+        # (env-dependent disabled/no-files), never the fence denial.
+        cres2 = await committer.commit(
+            op_id="op-ok", description="unfenced", target_files=())
+        assert cres2.skipped_reason in (
+            "auto_commit_disabled", "no_target_files")
 
     asyncio.run(scenario())

--- a/tests/governance/transport/test_durable_outbound.py
+++ b/tests/governance/transport/test_durable_outbound.py
@@ -11,8 +11,10 @@ Suite map (task brief + review round):
   (a) journal-at-publish: only op_prefix events land, ordered by event_id
   (b) crash-survival: a fresh instance on the same wal_path recovers the
       pending set from journaled disk truth, not memory
-  (c) ack-trim: on_ack(<eid>) trims every pending id <= eid, in memory
-      immediately and on disk durably (fresh instance agrees)
+  (c) ack-trim (Stage-4 Task 2 redefinition): on_ack(<eid>) trims EXACTLY
+      that id -- cumulation is now the CLIENT's job (send-order-cumulative
+      _apply_ack fires on_ack per confirmed id). In memory immediately and
+      on disk durably (fresh instance agrees)
   (d) dynamic capacity: tiny disk free -> degraded_capacity flips True,
       oldest pending dropped (dead_letter), exactly ONE warning per
       episode, newest survives; restored disk clears the flag; compact
@@ -139,8 +141,10 @@ def test_crash_survival_fresh_instance_recovers_from_disk(tmp_path, monkeypatch)
 
 
 # --------------------------------------------------------------------------- #
-# (c) ack-trim: on_ack(<3rd id>) trims ids 1..3 -> pending_count()==2,
-#     immediately in memory and durably on disk (fresh instance agrees).
+# (c) ack-trim: exact-set semantics (Stage-4 Task 2) -- one on_ack per
+#     confirmed id (the client's send-order-cumulative _apply_ack drives
+#     the fan-out). Trimmed immediately in memory and durably on disk
+#     (fresh instance agrees).
 # --------------------------------------------------------------------------- #
 def test_ack_trim_immediate_and_durable(tmp_path, monkeypatch):
     monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
@@ -155,7 +159,10 @@ def test_ack_trim_immediate_and_durable(tmp_path, monkeypatch):
                    for i in range(5)]
             await _wait_for(lambda: outbound.pending_count() == 5)
 
-            outbound.on_ack(ids[2])  # cumulative cursor: acks ids[0..2]
+            # The client confirms ids[0..2] one by one (send-order-
+            # cumulative _apply_ack fires on_ack per confirmed id).
+            for eid in sorted(ids)[:3]:
+                outbound.on_ack(eid)
             # IMMEDIATE in-memory effect -- before any disk tombstone lands.
             assert outbound.pending_count() == 2
             assert _pending_ids(outbound) == sorted(ids)[3:]
@@ -388,7 +395,8 @@ def test_ack_tombstone_failure_parks_lease_for_retry(
 
             monkeypatch.setattr(outbound._wal, "update_status", _flaky_update)
 
-            outbound.on_ack(ids[1])  # acks ids[0..1]
+            for eid in sorted(ids)[:2]:  # exact-set: one ack per id
+                outbound.on_ack(eid)
             # Immediate in-memory ack semantics still hold (redelivery is
             # SAFE downstream -- server dedup)...
             assert outbound.pending_count() == 1
@@ -601,3 +609,220 @@ def test_journal_filter_failure_warns_once_and_fails_open(
             await outbound.stop()
 
     _run(scenario())
+
+
+# =========================================================================== #
+# Stage-4 Task 2: priority-aware replay + exact-set trim.
+#
+#   (i) urgency_rank: extracts the intake envelope's urgency from a WAL
+#       entry's StreamEvent dict (trinity-bridged shape:
+#       payload.data.urgency) and maps it to the UrgencyRouter's route
+#       priority ints (imported, never re-declared). Tolerant: missing /
+#       garbage shapes rank STANDARD.
+#   (j) pending("priority") + pending_prioritized(): entries sorted by
+#       (urgency_rank, event_id); default pending() stays id-ordered;
+#       the async variant computes the sort OFF-LOOP (offload substrate).
+#   (k) exact-set on_ack: ack for id X trims ONLY X -- an unsent lower id
+#       SURVIVES (the Stage-3 over-trim strand class, regression-pinned).
+# =========================================================================== #
+
+from backend.core.ouroboros.governance.background_agent_pool import (  # noqa: E402
+    _ROUTE_PRIORITY,
+)
+from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: E402
+    make_envelope,
+)
+from backend.core.ouroboros.governance.urgency_router import (  # noqa: E402
+    ProviderRoute,
+)
+from backend.core.ouroboros.governance.transport.durable_outbound import (  # noqa: E402
+    urgency_rank,
+)
+
+_RANK_IMMEDIATE = _ROUTE_PRIORITY[ProviderRoute.IMMEDIATE.value]
+_RANK_STANDARD = _ROUTE_PRIORITY[ProviderRoute.STANDARD.value]
+_RANK_SPECULATIVE = _ROUTE_PRIORITY[ProviderRoute.SPECULATIVE.value]
+
+
+def _trinity_payload(urgency: str, source: str = "capability_gap") -> dict:
+    """The REAL trinity-bridged broker payload shape: RemoteIntakeSubmitter
+    publishes envelope.to_dict() as a TrinityEvent payload, and
+    TrinityBusBridge._on_outbound wraps it as
+    {"topic": ..., "data": <envelope dict>, "origin": <source_id>}."""
+    env = make_envelope(
+        source=source,
+        description="stage4 task2 fixture",
+        target_files=("README.md",),
+        repo="jarvis",
+        confidence=0.9,
+        urgency=urgency,
+        evidence={"signature": "s4t2-%s-%s" % (urgency, source)},
+        requires_human_ack=False,
+    )
+    return {"topic": "intake.remote_signal.body",
+            "data": env.to_dict(),
+            "origin": "mac-body"}
+
+
+def _envelope_dict(urgency: str, source: str = "capability_gap") -> dict:
+    """A full journaled envelope_dict (StreamEvent.to_dict shape)."""
+    return {
+        "schema_version": "1.0",
+        "event_id": "000000000001",
+        "event_type": _EVENT_TYPE,
+        "op_id": _PREFIX + "intake.remote_signal.body",
+        "timestamp": "2026-07-04T00:00:00+00:00",
+        "payload": _trinity_payload(urgency, source),
+    }
+
+
+# --------------------------------------------------------------------------- #
+# (i) urgency_rank: real trinity-encoded envelope + shape tolerance.
+# --------------------------------------------------------------------------- #
+def test_urgency_rank_real_trinity_shape():
+    assert urgency_rank(_envelope_dict("critical", "test_failure")) == _RANK_IMMEDIATE
+    assert urgency_rank(_envelope_dict("high", "test_failure")) == _RANK_IMMEDIATE
+    assert urgency_rank(_envelope_dict("normal")) == _RANK_STANDARD
+    assert urgency_rank(
+        _envelope_dict("low", "intent_discovery")) == _RANK_SPECULATIVE
+    # Rank ordering sanity straight from the imported router table.
+    assert _RANK_IMMEDIATE < _RANK_STANDARD < _RANK_SPECULATIVE
+
+
+def test_urgency_rank_tolerates_missing_and_garbage():
+    # Missing urgency key -> STANDARD.
+    d = _envelope_dict("normal")
+    del d["payload"]["data"]["urgency"]
+    assert urgency_rank(d) == _RANK_STANDARD
+    # Unknown urgency vocabulary -> STANDARD.
+    d2 = _envelope_dict("normal")
+    d2["payload"]["data"]["urgency"] = "warp-speed"
+    assert urgency_rank(d2) == _RANK_STANDARD
+    # Garbage shapes -> STANDARD, never raises.
+    assert urgency_rank({}) == _RANK_STANDARD
+    assert urgency_rank({"payload": None}) == _RANK_STANDARD
+    assert urgency_rank({"payload": "nope"}) == _RANK_STANDARD
+    assert urgency_rank({"payload": {"data": None}}) == _RANK_STANDARD
+    assert urgency_rank({"payload": {"data": {"urgency": 42}}}) == _RANK_STANDARD
+    assert urgency_rank({"payload": {"data": []}}) == _RANK_STANDARD
+    assert urgency_rank(None) == _RANK_STANDARD  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# (j) priority ordering: mixed IMMEDIATE/STANDARD/SPECULATIVE x2, published
+#     interleaved -> pending("priority") and pending_prioritized() return
+#     the IMMEDIATE pair first (by id within class), then STANDARD, then
+#     SPECULATIVE. Default pending() stays id-ordered (legacy untouched).
+#     The async variant's sort runs through the offload substrate.
+# --------------------------------------------------------------------------- #
+def test_pending_priority_order_and_offloaded_sort(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    import backend.core.ouroboros.governance.transport.durable_outbound as dob
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            # Interleaved publish order: STD, SPEC, IMM, STD, SPEC, IMM.
+            specs = [("normal", "capability_gap"),
+                     ("low", "intent_discovery"),
+                     ("critical", "test_failure"),
+                     ("normal", "capability_gap"),
+                     ("low", "intent_discovery"),
+                     ("critical", "test_failure")]
+            ids = []
+            for urgency, source in specs:
+                eid = broker.publish(
+                    _EVENT_TYPE, _PREFIX + "intake.remote_signal.body",
+                    _trinity_payload(urgency, source))
+                assert eid
+                ids.append(eid)
+            await _wait_for(lambda: outbound.pending_count() == 6)
+
+            want_priority = [ids[2], ids[5],  # IMMEDIATE pair, id-ordered
+                             ids[0], ids[3],  # STANDARD pair
+                             ids[1], ids[4]]  # SPECULATIVE pair
+
+            # Legacy default stays byte-identical: id order.
+            assert _pending_ids(outbound) == sorted(ids)
+            # Sync priority order.
+            got_sync = [d["event_id"] for d in outbound.pending("priority")]
+            assert got_sync == want_priority, (
+                "pending('priority') must sort by (urgency_rank, event_id): "
+                "got %r want %r" % (got_sync, want_priority))
+
+            # Async variant: same order, sort dispatched via offload.
+            real_offload = dob.offload
+            offload_calls = {"n": 0}
+
+            async def _counting_offload(fn, *args, **kwargs):
+                offload_calls["n"] += 1
+                return await real_offload(fn, *args, **kwargs)
+
+            monkeypatch.setattr(dob, "offload", _counting_offload)
+            try:
+                got_async = [d["event_id"]
+                             for d in await outbound.pending_prioritized()]
+            finally:
+                monkeypatch.setattr(dob, "offload", real_offload)
+            assert got_async == want_priority
+            assert offload_calls["n"] >= 1, (
+                "pending_prioritized must compute the sort through the "
+                "offload substrate, not on the event loop")
+        finally:
+            await outbound.stop()
+
+    _run(scenario())
+
+
+# --------------------------------------------------------------------------- #
+# (k) exact-set on_ack: ack for id X trims ONLY X. An UNSENT lower id
+#     survives -- the Stage-3 strand class (priority replay sends a high
+#     IMMEDIATE id first; its ack must not sweep unsent lower ids).
+# --------------------------------------------------------------------------- #
+def test_exact_set_ack_trims_only_the_acked_id(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            ids = sorted(
+                broker.publish(_EVENT_TYPE, _PREFIX + "x-%d" % i, {"i": i})
+                for i in range(3))
+            await _wait_for(lambda: outbound.pending_count() == 3)
+
+            # Priority replay sent the HIGHEST id first; the server acks it.
+            outbound.on_ack(ids[2])
+            assert _pending_ids(outbound) == ids[:2], (
+                "exact-set trim: ONLY the acked id may be trimmed -- the "
+                "unsent lower ids must survive (over-trim regression)")
+
+            # Replay of the SAME ack id is an idempotent no-op.
+            outbound.on_ack(ids[2])
+            assert _pending_ids(outbound) == ids[:2]
+
+            # Disk truth agrees once the tombstone lands.
+            def _disk_agrees() -> bool:
+                probe = DurableOutbound(
+                    StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+                return _pending_ids(probe) == ids[:2]
+            await _wait_for(_disk_agrees)
+
+            # The remaining ids drain only via their OWN acks.
+            outbound.on_ack(ids[0])
+            outbound.on_ack(ids[1])
+            assert outbound.pending_count() == 0
+            return ids
+        finally:
+            await outbound.stop()
+
+    ids = _run(scenario())
+    fresh = DurableOutbound(StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+    assert fresh.pending_count() == 0, (
+        "disk truth must drain to 0 after per-id exact-set acks")

--- a/tests/governance/transport/test_wal_replay_and_rediscovery.py
+++ b/tests/governance/transport/test_wal_replay_and_rediscovery.py
@@ -298,3 +298,109 @@ def test_legacy_shape_no_durable_no_resolver(monkeypatch):
             await runner.cleanup()
 
     assert _run(scenario()) is True
+
+
+# --------------------------------------------------------------------------- #
+# (d) Stage-4 Task 2: PRIORITY-ordered WAL replay + send-order-cumulative
+#     trim, against a REAL localhost pair. A mixed-urgency backlog (2x
+#     IMMEDIATE / 2x STANDARD / 2x SPECULATIVE, interleaved publish order)
+#     is journaled during a partition (no server). On reconnect the server
+#     must receive the IMMEDIATE entries FIRST (arrival-order prefix) and
+#     the FULL set exactly once; the server's per-connection acks must
+#     trim the entire backlog (send-order-cumulative on the client +
+#     exact-set on the durable) -- end state pending_count()==0 via
+#     condition poll. Deliberate out-of-id-order sending (that is what
+#     priority replay IS) must not over-trim: set-equality + drain-to-0
+#     prove it live; the exact-set unit pin covers it structurally.
+# --------------------------------------------------------------------------- #
+def test_priority_replay_immediate_first_and_full_trim(tmp_path, monkeypatch):
+    from backend.core.ouroboros.governance.intake.intent_envelope import (
+        make_envelope,
+    )
+
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    monkeypatch.setenv("JARVIS_BUS_ACK_EVERY_N", "1")
+    monkeypatch.setenv("JARVIS_BUS_ACK_INTERVAL_S", "0.2")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    # Interleaved publish order: STD, SPEC, IMM, STD, SPEC, IMM.
+    specs = [("std-0", "normal", "capability_gap"),
+             ("spec-0", "low", "intent_discovery"),
+             ("imm-0", "critical", "test_failure"),
+             ("std-1", "normal", "capability_gap"),
+             ("spec-1", "low", "intent_discovery"),
+             ("imm-1", "critical", "test_failure")]
+    ops = ["trinity:s4-%s" % name for name, _, _ in specs]
+
+    def _payload(name: str, urgency: str, source: str) -> Dict[str, Any]:
+        env = make_envelope(
+            source=source,
+            description="stage4 task2 live fixture %s" % name,
+            target_files=("README.md",),
+            repo="jarvis",
+            confidence=0.9,
+            urgency=urgency,
+            evidence={"signature": "s4t2-%s" % name},
+            requires_human_ack=False,
+        )
+        return {"topic": "intake.remote_signal.body",
+                "data": env.to_dict(),
+                "origin": "mac-body"}
+
+    async def scenario():
+        port = _free_port()
+        server_cfg = _cfg(monkeypatch, port, "server")
+        client_cfg = _cfg(monkeypatch, port, "client")
+
+        client_broker = StreamEventBroker(history_maxlen=64)
+        server_broker = StreamEventBroker(history_maxlen=64)
+        durable = DurableOutbound(client_broker, wal_path=wal_path)
+        await durable.start()
+
+        # Journal the whole mixed-urgency backlog while NO server exists.
+        for (name, urgency, source), op in zip(specs, ops):
+            eid = client_broker.publish(
+                "task_started", op, _payload(name, urgency, source))
+            assert eid
+        await _wait_for(lambda: durable.pending_count() == 6)
+
+        runner = await _start_server(server_broker, server_cfg, port)
+        client_bus = DistributedEventBus(
+            client_broker, client_cfg, role="client", durable_outbound=durable)
+        url = "ws://127.0.0.1:%d%s" % (port, client_cfg.path)
+        task = asyncio.ensure_future(client_bus.start_client(url))
+        try:
+            await _await_connected(client_bus)
+
+            op_set = set(ops)
+
+            def _arrivals() -> List[str]:
+                return [ev.op_id
+                        for ev in server_broker.recent_history(limit=200)
+                        if ev.op_id in op_set]
+
+            await _wait_for(lambda: len(set(_arrivals())) == 6)
+            await asyncio.sleep(0.6)  # settle: let any duplicate land
+            arrivals = _arrivals()
+
+            # Send-order-cumulative acks must drain the WHOLE backlog --
+            # including the numerically-lowest ids that were sent LAST.
+            await _wait_for(lambda: durable.pending_count() == 0)
+        finally:
+            await _stop_client(client_bus, task)
+            await durable.stop()
+            await runner.cleanup()
+        return arrivals
+
+    arrivals = _run(scenario())
+    # Full set-equality, exactly once each.
+    assert sorted(arrivals) == sorted(ops), (
+        "server must hold ALL 6 exactly once, got %r" % (arrivals,))
+    # IMMEDIATE entries arrive FIRST, id-ordered within the class; then
+    # STANDARD, then SPECULATIVE (the (urgency_rank, event_id) sort).
+    want_order = ["trinity:s4-imm-0", "trinity:s4-imm-1",
+                  "trinity:s4-std-0", "trinity:s4-std-1",
+                  "trinity:s4-spec-0", "trinity:s4-spec-1"]
+    assert arrivals == want_order, (
+        "priority replay must deliver IMMEDIATE first: got %r want %r"
+        % (arrivals, want_order))

--- a/tests/infra/test_run_body_mode.py
+++ b/tests/infra/test_run_body_mode.py
@@ -680,3 +680,69 @@ def test_keeperless_run_publishes_no_heartbeat_and_survives_plain_fake_bus(
     driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
     rc = asyncio.run(driver.run())
     assert rc == 0
+
+
+# ---------------------------------------------------------------------------
+# Stage-4 IMPORTANT-3: keeper master flag (JARVIS_BRAIN_KEEPER_ENABLED) + CLI.
+# ---------------------------------------------------------------------------
+
+
+def test_keeper_master_off_by_default_no_keeper(monkeypatch):
+    """Env unset -> master defaults FALSE -> no keeper is armed on the live
+    default path (pre-Stage-4 degrade-and-wait, byte-identical)."""
+    monkeypatch.delenv("JARVIS_BRAIN_KEEPER_ENABLED", raising=False)
+    driver = bm.BodyModeDriver()  # no seams -> live default path
+    assert driver._do_keeper() is None
+
+
+def test_keeper_master_on_arms_the_live_keeper(monkeypatch, tmp_path):
+    """Env on -> the live default keeper is built (no injected seams)."""
+    monkeypatch.setenv("JARVIS_BRAIN_KEEPER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_RESOURCE_MANIFEST_PATH",
+                       str(tmp_path / "manifest.jsonl"))
+    monkeypatch.setenv("JARVIS_RESURRECT_BUCKET_PATH",
+                       str(tmp_path / "bucket.jsonl"))
+    from backend.core.ouroboros.governance.brain_keeper import BrainKeeper
+    driver = bm.BodyModeDriver()
+    keeper = driver._do_keeper()
+    assert isinstance(keeper, BrainKeeper), "master ON must arm the real keeper"
+
+
+def test_no_keeper_flag_wins_over_injected_factory(monkeypatch):
+    """--no-keeper (keeper_mode False) wins over EVERYTHING -- even an
+    explicitly injected keeper_factory."""
+    monkeypatch.setenv("JARVIS_BRAIN_KEEPER_ENABLED", "true")
+    sentinel = object()
+    driver = bm.BodyModeDriver(
+        keeper_mode=False, keeper_factory=lambda: sentinel)
+    assert driver._do_keeper() is None
+
+
+def test_keeper_flag_forces_on_despite_env_off(monkeypatch, tmp_path):
+    """--keeper (keeper_mode True) forces the keeper on even when the env
+    master is off."""
+    monkeypatch.setenv("JARVIS_BRAIN_KEEPER_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_RESOURCE_MANIFEST_PATH",
+                       str(tmp_path / "manifest.jsonl"))
+    monkeypatch.setenv("JARVIS_RESURRECT_BUCKET_PATH",
+                       str(tmp_path / "bucket.jsonl"))
+    from backend.core.ouroboros.governance.brain_keeper import BrainKeeper
+    driver = bm.BodyModeDriver(keeper_mode=True)
+    assert isinstance(driver._do_keeper(), BrainKeeper)
+
+
+def test_keeper_cli_flags_parse():
+    """--keeper -> True, --no-keeper -> False, neither -> None."""
+    p = bm.build_arg_parser()
+    assert p.parse_args([]).keeper is None
+    assert p.parse_args(["--keeper"]).keeper is True
+    assert p.parse_args(["--no-keeper"]).keeper is False
+
+
+def test_injected_factory_still_armed_when_mode_none(monkeypatch):
+    """Byte-identical seam path: keeper_mode None + injected factory -> the
+    factory is used (master flag not consulted for an explicit seam)."""
+    monkeypatch.delenv("JARVIS_BRAIN_KEEPER_ENABLED", raising=False)
+    sentinel = object()
+    driver = bm.BodyModeDriver(keeper_factory=lambda: sentinel)
+    assert driver._do_keeper() is sentinel

--- a/tests/infra/test_run_body_mode.py
+++ b/tests/infra/test_run_body_mode.py
@@ -478,3 +478,121 @@ def test_edge_transitions_log_exactly_once_per_episode(capsys, monkeypatch):
         "exactly one reconnected line per episode: %r" % out)
     # Both census states were surfaced during the run.
     assert "connected=False" in out and "connected=True" in out
+
+
+# ---------------------------------------------------------------------------
+# (i) Stage-4 Task 3: the BrainKeeper seam. A fake keeper injected via
+#     keeper_factory receives every discovery result (the wrapped discover
+#     seam), is ticked once per census tick, surfaces `gen=/keeper=` on the
+#     census line, and its current_gen is exported as
+#     JARVIS_BRAIN_CURRENT_GEN for the discovery gen-filter.
+# ---------------------------------------------------------------------------
+
+
+class _FakeKeeper:
+    def __init__(self, gen: int = 3, state: str = "healthy") -> None:
+        self.notes: List[Any] = []
+        self.ticks = 0
+        self._gen = gen
+        self._state = state
+
+    def note_discovery_result(self, url: Any) -> None:
+        self.notes.append(url)
+
+    async def tick(self) -> str:
+        self.ticks += 1
+        return self._state
+
+    def current_gen(self) -> int:
+        return self._gen
+
+
+def test_keeper_seam_receives_discovery_ticks_and_census(capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    # Pre-seed so monkeypatch restores the var after the driver mutates it.
+    monkeypatch.setenv("JARVIS_BRAIN_CURRENT_GEN", "")
+    keeper = _FakeKeeper(gen=3, state="healthy")
+    kwargs, ns = _seams()
+    kwargs["keeper_factory"] = lambda: keeper
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+
+    assert rc == 0
+    # The wrapped discover seam feeds the keeper the initial discovery result.
+    assert keeper.notes == ["wss://10.0.0.5:8770/ws/trinity-bus"], (
+        "every discovery outcome must feed the keeper: %r" % keeper.notes)
+    assert keeper.ticks >= 1, "the census loop must tick the keeper"
+    # Census line gains ` gen=%d keeper=%s`.
+    assert "gen=3 keeper=healthy" in out, out
+    # The gen-filter export: set at keeper construction (current_gen >= 1).
+    assert os.environ.get("JARVIS_BRAIN_CURRENT_GEN") == "3"
+
+
+def test_keeper_seam_offline_discovery_feeds_none(capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    monkeypatch.setenv("JARVIS_BRAIN_CURRENT_GEN", "")
+    keeper = _FakeKeeper(gen=2, state="absent")
+    durable = _FakeDurable()
+    kwargs, ns = _seams(url=None, connect=False, durable=durable)
+    kwargs["keeper_factory"] = lambda: keeper
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+
+    assert rc == 0, "WAL armed: degrade, not exit 2"
+    assert keeper.notes == [None], "a failed discovery feeds the keeper falsy"
+    assert keeper.ticks >= 1
+    assert "gen=2 keeper=absent" in out, out
+
+
+def test_keeper_gen_zero_is_not_exported(capsys, monkeypatch):
+    """A keeper that has never minted a generation (gen 0) must NOT arm the
+    discovery gen-filter -- exporting 0 would exclude a pre-Stage-4
+    unlabeled Brain before the keeper has ever resurrected anything."""
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    monkeypatch.delenv("JARVIS_BRAIN_CURRENT_GEN", raising=False)
+    keeper = _FakeKeeper(gen=0, state="healthy")
+    kwargs, ns = _seams()
+    kwargs["keeper_factory"] = lambda: keeper
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert os.environ.get("JARVIS_BRAIN_CURRENT_GEN") is None, (
+        "gen 0 must never arm the discovery filter")
+    assert "gen=0 keeper=healthy" in out, "census still surfaces the state"
+
+
+def test_no_keeper_seam_with_injected_stack_stays_keeperless(capsys, monkeypatch):
+    """Back-compat: an injected bus stack WITHOUT a keeper seam must stay
+    keeper-less (the _build_durable precedent) -- no gen=/keeper= census
+    fields, no real ResourceManifest/bucket touched."""
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    kwargs, ns = _seams()
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 0
+    assert " keeper=" not in out and " gen=" not in out, (
+        "keeper-less runs must keep the census line byte-compatible")
+
+
+def test_keeper_factory_failure_is_fail_soft(capsys, monkeypatch):
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+
+    def boom_factory():
+        raise RuntimeError("keeper exploded at build")
+
+    kwargs, ns = _seams()
+    kwargs["keeper_factory"] = boom_factory
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    out = capsys.readouterr().out
+    assert rc == 0, "a keeper that cannot be built must not kill the driver"
+    assert "brain keeper unavailable (fail-soft)" in out
+    assert " keeper=" not in out

--- a/tests/infra/test_run_body_mode.py
+++ b/tests/infra/test_run_body_mode.py
@@ -596,3 +596,87 @@ def test_keeper_factory_failure_is_fail_soft(capsys, monkeypatch):
     assert rc == 0, "a keeper that cannot be built must not kill the driver"
     assert "brain keeper unavailable (fail-soft)" in out
     assert " keeper=" not in out
+
+
+# ---------------------------------------------------------------------------
+# Stage-4 Task 4: keeper-heartbeat publish (the split-brain fence, Body side).
+# ---------------------------------------------------------------------------
+
+
+class _RecordingTrinityBus(_FakeTrinityBus):
+    """_FakeTrinityBus + a publish_raw recorder (the driver's heartbeat
+    surface)."""
+
+    def __init__(self) -> None:
+        self.published: List[Any] = []
+
+    async def publish_raw(self, topic: str, data: Any, **kwargs: Any) -> str:
+        self.published.append((topic, data, kwargs))
+        return "ev-%d" % len(self.published)
+
+
+def test_census_tick_publishes_keeper_heartbeat_with_gen(capsys, monkeypatch):
+    """Every census tick with a keeper holding gen >= 1 publishes
+    ``console.keeper_heartbeat`` carrying that gen on the LOCAL trinity bus
+    (``console.*`` is on the mac-side bridge outbound allowlist, so the beat
+    transits to the Brain organism's GenerationFence). persist=False: a ~10s
+    liveness beat must never accrete in the event-store WAL."""
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    monkeypatch.setenv("JARVIS_BRAIN_CURRENT_GEN", "")
+    keeper = _FakeKeeper(gen=3, state="healthy")
+    bus = _RecordingTrinityBus()
+    kwargs, ns = _seams()
+
+    async def _bus_factory():
+        return bus, _FakeBroker(), ns.dist
+
+    kwargs["bus_factory"] = _bus_factory
+    kwargs["keeper_factory"] = lambda: keeper
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+
+    assert rc == 0
+    assert keeper.ticks >= 1
+    assert bus.published, "the census loop must publish the keeper heartbeat"
+    for topic, data, pub_kwargs in bus.published:
+        assert topic == "console.keeper_heartbeat"
+        assert data == {"gen": 3}
+        assert pub_kwargs.get("persist") is False, (
+            "heartbeats must not persist to the event store")
+    # One heartbeat per keeper tick (the census cadence).
+    assert len(bus.published) == keeper.ticks
+
+
+def test_keeper_gen_zero_publishes_no_heartbeat(capsys, monkeypatch):
+    """Gen 0 (nothing ever minted) says nothing a fence could act on --
+    it must never be published (symmetric with the gen-filter export)."""
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    monkeypatch.delenv("JARVIS_BRAIN_CURRENT_GEN", raising=False)
+    keeper = _FakeKeeper(gen=0, state="healthy")
+    bus = _RecordingTrinityBus()
+    kwargs, ns = _seams()
+
+    async def _bus_factory():
+        return bus, _FakeBroker(), ns.dist
+
+    kwargs["bus_factory"] = _bus_factory
+    kwargs["keeper_factory"] = lambda: keeper
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    assert rc == 0
+    assert bus.published == [], "gen 0 must never be broadcast"
+
+
+def test_keeperless_run_publishes_no_heartbeat_and_survives_plain_fake_bus(
+        capsys, monkeypatch):
+    """Keeper-less: no heartbeat. Also pins the fail-soft contract for a
+    bus without publish_raw (the pre-existing _FakeTrinityBus): the census
+    must not die on the heartbeat surface."""
+    monkeypatch.setenv("JARVIS_BRAIN_CONNECT_GATE_S", "2")
+    monkeypatch.setenv("JARVIS_BODY_MODE_CENSUS_S", "0.01")
+    kwargs, ns = _seams()  # plain _FakeTrinityBus, no keeper seam
+    driver = bm.BodyModeDriver(duration_s=0.05, **kwargs)
+    rc = asyncio.run(driver.run())
+    assert rc == 0


### PR DESCRIPTION
## Stage 4: the Body keeps its Brain alive (ships DARK; keeper opt-in)

- **Lineage substrate** (T1): `brain_lifecycle.py` extraction (byte-equivalent driver) + cascading GCP labels + append-only `ResourceManifest` (intake-WAL flock primitives) — ownership recorded at BIRTH, teardown is a manifest walk, never a discovery grep.
- **Priority-aware WAL replay** (T2): `UrgencyRouter` ranks imported (no tables), off-loop sort, and the **send-order-cumulative ack redefinition** — proven sound across four adversarial interleavings; retires the Stage-3 strand class.
- **BrainKeeper** (T3): flock-critical-section persistent token bucket (deterministic `RESURRECT_CAP_EXHAUSTED` terminal, no sleeps/retry), gen minting, discovery gen-filter, record-at-birth.
- **Generation fence** (T4): process-global latch consulted fail-closed at **every** mutation chokepoint — `ChangeEngine.execute`, `AutoCommitter.commit`, saga forward-writes, Venom write tools — composing the Async Yield Matrix boundary + `cooperative_shutdown` + `capture_inflight(reason="generation_fenced")`. **Mandate-2 PASS** (structural termination, not a flag).
- **Keeper-delivered fence supersession**: the keeper actively delivers the gen-heartbeat to superseded nodes (deterministic self-fence + capture window) then reaps — closing the split-brain window a passive filter alone left open.

Two review waves (per-task + two whole-branch passes) found and closed a Critical false-durability-adjacent gap, the failover-grandchild orphan class, and the self-fence delivery gap. `fsm_checkpoint` untouched (zero lines). Ships dark: `JARVIS_DISTRIBUTED_BUS_ENABLED` + `JARVIS_BRAIN_KEEPER_ENABLED` (default false) + `JARVIS_BRAIN_GENERATION`.

Next: the split-brain live drill (Task 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds generation-based Brain resurrection and split-brain fencing, plus priority-ordered WAL replay for reliable delivery. Extracts a reusable Brain provisioning core with lineage labels and manifest-based teardown; ships dark and is fully opt‑in.

- **New Features**
  - Body-side `BrainKeeper`: resurrects on sustained absence using a persistent token bucket; mints generations, exports `JARVIS_BRAIN_CURRENT_GEN`, and records ownership at birth (labels: owner/parent/gen).
  - Brain-side generation fence: on higher-gen heartbeat, denies writes at `ChangeEngine`, `AutoCommitter`, saga forward-writes, and venom write tools; requests cooperative shutdown and checkpoint capture; wired via `organism_bus_host` using `JARVIS_BRAIN_GENERATION`.
  - Priority WAL replay: `DurableOutbound` replays by urgency; `BusBridgeClient` tracks send-order and applies cumulative acks by send position; `on_ack` trims the exact acked id to prevent over-trim.
  - Provisioning core: `brain_lifecycle.py` extracted and consumed by the driver; lineage labels and an append-only `ResourceManifest` enable manifest-walk family teardown; `failover_lifecycle` folds `LABEL_OWNER`.

- **Migration**
  - Default off. To enable: set `JARVIS_BRAIN_KEEPER_ENABLED=true` and `JARVIS_DISTRIBUTED_BUS_ENABLED=true` on the Body, and provide `JARVIS_KEEPER_ID`. Brain nodes receive `JARVIS_BRAIN_GENERATION` from the keeper; the bus host reads it automatically. Unset envs keep pre-Stage‑4 behavior.

<sup>Written for commit f73980be8e8ed6ca473bb356803b178deec25ebe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

