### PR TITLE
feat(domain1): Staging 1 -- the transport hop (causal.delta.* over the Stage-2/3/4 bridge)

### DIFF
--- a/backend/core/ouroboros/governance/causal/causal_delta_subscriber.py
+++ b/backend/core/ouroboros/governance/causal/causal_delta_subscriber.py
@@ -11,10 +11,16 @@ causality DAG -- is Staging 2 (single-writer; no graph is built here).
 
 Design commitments:
 
-* **Reflective source.** The origin repo is read from ``event.source`` (a
-  ``RepoType``), never parsed from ``event.topic``. A non-``RepoType`` source,
-  or ``RepoType.BROADCAST`` (a TARGET semantic, never a valid causal origin),
-  is logged and dropped -- a causal delta must name ONE concrete source.
+* **Reflective source (Mandate 2 -- in-payload identity).** The origin repo is
+  read from the IN-PAYLOAD ``lineage.repo`` via ``RepoType(...)`` reflection,
+  never from ``event.source`` and never parsed from ``event.topic``. Mandate 2
+  rides the RepoType as reflective metadata INSIDE the data payload, not typed
+  on the transport -- and this is the identity that survives the cross-host WS
+  hop verbatim (the generic ``TrinityBusBridge`` re-mints ``event.source`` to
+  the receiver bus's ``local_repo``, so it MUST NOT be trusted). A
+  non-``RepoType`` ``lineage.repo``, or ``RepoType.BROADCAST`` (a TARGET
+  semantic, never a valid causal origin), is logged and dropped -- a causal
+  delta must name ONE concrete source.
 * **No new dedup.** The bus's OWN 60s fingerprint dedup
   (``TrinityEvent.fingerprint``) drops exact duplicates BEFORE the handler
   fires. The subscriber adds NO dedup algorithm; its ``(repo, emit_seq,
@@ -100,14 +106,6 @@ class CausalDeltaSubscriber:
         """Record one causal delta. NEVER raises into the bus (fail-soft) and
         is a fast append (non-blocking -- no sleeps, no heavy work)."""
         try:
-            # Reflective source: the enum IS the repo. Never parse the topic.
-            repo = getattr(event, "source", None)
-            if not isinstance(repo, RepoType) or repo == RepoType.BROADCAST:
-                logger.debug(
-                    "[CausalDeltaSubscriber] dropping delta with non-concrete "
-                    "source %r (topic=%s)", repo, getattr(event, "topic", None))
-                return
-
             payload = getattr(event, "payload", None)
             if not isinstance(payload, dict):
                 logger.debug("[CausalDeltaSubscriber] dropping non-dict payload")
@@ -122,6 +120,29 @@ class CausalDeltaSubscriber:
             ):
                 logger.debug("[CausalDeltaSubscriber] dropping envelope with "
                              "missing/malformed lineage: %r", lineage)
+                return
+
+            # Reflective source read from the IN-PAYLOAD lineage.repo (Mandate 2:
+            # the RepoType rides as reflective metadata INSIDE the data payload,
+            # never typed on the transport). This is the identity that survives
+            # the WS hop verbatim -- ``event.source`` is re-minted to the
+            # receiver bus's local_repo by the generic bridge and MUST NOT be
+            # trusted here. ``RepoType(...)`` reflection IS the validation (no
+            # string-matching / if-chain, no topic parsing); an unknown repo
+            # raises -> log-and-drop. BROADCAST is a TARGET semantic, never a
+            # valid causal origin, so it is dropped too.
+            try:
+                repo = RepoType(lineage["repo"])
+            except (ValueError, TypeError):
+                logger.debug(
+                    "[CausalDeltaSubscriber] dropping delta with non-RepoType "
+                    "lineage.repo %r (topic=%s)", lineage.get("repo"),
+                    getattr(event, "topic", None))
+                return
+            if repo == RepoType.BROADCAST:
+                logger.debug(
+                    "[CausalDeltaSubscriber] dropping delta with BROADCAST "
+                    "lineage.repo (a causal delta needs a concrete source)")
                 return
 
             try:

--- a/backend/core/ouroboros/governance/causal/causal_delta_subscriber.py
+++ b/backend/core/ouroboros/governance/causal/causal_delta_subscriber.py
@@ -1,0 +1,183 @@
+"""Domain-1 Staging-1 Task 2 -- CausalDeltaSubscriber (Brain receiver).
+
+The other end of the Task-1 transport hop. The Body's ``StructuralDeltaSensor``
+publishes content-free ``causal.delta.<repo>`` events over the proven
+``TrinityEventBus`` bridge; this subscriber is the Brain-side RECEIVER. It
+subscribes ``causal.delta.*`` and RECORDS receipt of each delta in causal
+order.
+
+It only records receipt. The graph fold -- weaving the deltas into a cross-repo
+causality DAG -- is Staging 2 (single-writer; no graph is built here).
+
+Design commitments:
+
+* **Reflective source.** The origin repo is read from ``event.source`` (a
+  ``RepoType``), never parsed from ``event.topic``. A non-``RepoType`` source,
+  or ``RepoType.BROADCAST`` (a TARGET semantic, never a valid causal origin),
+  is logged and dropped -- a causal delta must name ONE concrete source.
+* **No new dedup.** The bus's OWN 60s fingerprint dedup
+  (``TrinityEvent.fingerprint``) drops exact duplicates BEFORE the handler
+  fires. The subscriber adds NO dedup algorithm; its ``(repo, emit_seq,
+  head_sha)`` seen-set is only belt-and-suspenders for a REPLAY outside the
+  60s window.
+* **Causal order.** Deltas are ordered by ``emit_seq`` WITHIN each repo (the
+  Lamport guarantee from Staging 0). Cross-repo interleave is preserved via a
+  global receive-order index; the per-repo subsequence is the guarantee.
+* **Fail-soft, non-blocking.** The handler NEVER raises into the bus delivery
+  loop (any error is logged and swallowed) and is a fast append -- no sleeps,
+  no heavy work. Heavy work (the Staging-2 graph fold) is deferred there.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+from backend.core.trinity_event_bus import RepoType, TrinityEvent
+
+logger = logging.getLogger(__name__)
+
+CAUSAL_DELTA_PATTERN = "causal.delta.*"
+
+# The lineage keys a well-formed causal-delta envelope MUST carry (shape of the
+# Staging-0 ``stamp_delta`` output).
+_REQUIRED_LINEAGE_KEYS = (
+    "repo",
+    "head_sha",
+    "parent_sha",
+    "merge_base",
+    "emit_seq",
+)
+
+
+class CausalDeltaSubscriber:
+    """Subscribe ``causal.delta.*`` and record deltas in causal order.
+
+    RECORDS receipt only -- no graph, no fold (Staging 2). ``on_delta`` is an
+    optional fast, fail-soft sink for the raw envelope; it MUST NOT block the
+    bus loop.
+    """
+
+    def __init__(
+        self,
+        trinity_bus: Any,
+        *,
+        on_delta: Optional[Callable[[dict], None]] = None,
+    ) -> None:
+        self._bus = trinity_bus
+        self._on_delta_cb = on_delta
+        self._sid: Optional[str] = None
+        # Belt-and-suspenders idempotency for replays OUTSIDE the bus's 60s
+        # fingerprint window. NOT a dedup algorithm -- the bus owns that.
+        self._seen: set = set()
+        # Per-repo log of (emit_seq, head_sha), ordered on read by emit_seq.
+        self._per_repo: Dict[str, List[Tuple[int, str]]] = {}
+        # Global receive order (one repo.value per accepted delta) -- preserves
+        # cross-repo interleave for observed().
+        self._receive_order: List[str] = []
+
+    # -- lifecycle ---------------------------------------------------------
+
+    async def start(self) -> None:
+        """Subscribe ``causal.delta.*``. The bus fingerprint-dedups before the
+        handler fires; ``event.source`` carries the authoritative repo."""
+        self._sid = await self._bus.subscribe(CAUSAL_DELTA_PATTERN, self._on_delta)
+
+    async def stop(self) -> None:
+        """Unsubscribe. Fail-soft: never raises."""
+        if self._sid is None:
+            return
+        try:
+            await self._bus.unsubscribe(self._sid)
+        except Exception:  # noqa: BLE001 -- fail-soft teardown
+            logger.debug("[CausalDeltaSubscriber] unsubscribe failed",
+                         exc_info=True)
+        finally:
+            self._sid = None
+
+    # -- handler -----------------------------------------------------------
+
+    async def _on_delta(self, event: TrinityEvent) -> None:
+        """Record one causal delta. NEVER raises into the bus (fail-soft) and
+        is a fast append (non-blocking -- no sleeps, no heavy work)."""
+        try:
+            # Reflective source: the enum IS the repo. Never parse the topic.
+            repo = getattr(event, "source", None)
+            if not isinstance(repo, RepoType) or repo == RepoType.BROADCAST:
+                logger.debug(
+                    "[CausalDeltaSubscriber] dropping delta with non-concrete "
+                    "source %r (topic=%s)", repo, getattr(event, "topic", None))
+                return
+
+            payload = getattr(event, "payload", None)
+            if not isinstance(payload, dict):
+                logger.debug("[CausalDeltaSubscriber] dropping non-dict payload")
+                return
+            if "delta" not in payload:
+                logger.debug("[CausalDeltaSubscriber] dropping envelope with no "
+                             "'delta' block")
+                return
+            lineage = payload.get("lineage")
+            if not isinstance(lineage, dict) or any(
+                k not in lineage for k in _REQUIRED_LINEAGE_KEYS
+            ):
+                logger.debug("[CausalDeltaSubscriber] dropping envelope with "
+                             "missing/malformed lineage: %r", lineage)
+                return
+
+            try:
+                emit_seq = int(lineage["emit_seq"])
+            except (TypeError, ValueError):
+                logger.debug("[CausalDeltaSubscriber] dropping envelope with "
+                             "non-int emit_seq: %r", lineage.get("emit_seq"))
+                return
+            head_sha = lineage["head_sha"]
+            if not isinstance(head_sha, str) or not head_sha:
+                logger.debug("[CausalDeltaSubscriber] dropping envelope with "
+                             "empty/non-str head_sha: %r", head_sha)
+                return
+
+            key = (repo.value, emit_seq, head_sha)
+            if key in self._seen:
+                # Replay outside the bus's 60s window -- idempotent skip.
+                logger.debug("[CausalDeltaSubscriber] already-seen delta %r", key)
+                return
+            self._seen.add(key)
+
+            self._per_repo.setdefault(repo.value, []).append((emit_seq, head_sha))
+            self._receive_order.append(repo.value)
+
+            if self._on_delta_cb is not None:
+                try:
+                    self._on_delta_cb(payload)
+                except Exception:  # noqa: BLE001 -- callback is fail-soft
+                    logger.debug("[CausalDeltaSubscriber] on_delta callback "
+                                 "raised (swallowed)", exc_info=True)
+        except Exception:  # noqa: BLE001 -- handler MUST never raise into bus
+            logger.warning("[CausalDeltaSubscriber] _on_delta failed "
+                           "(swallowed, fail-soft)", exc_info=True)
+
+    # -- read surface ------------------------------------------------------
+
+    def observed(self) -> List[Tuple[str, int, str]]:
+        """All observed ``(repo, emit_seq, head_sha)``.
+
+        Cross-repo interleave follows global receive order; WITHIN each repo the
+        subsequence is ``emit_seq``-ordered (the Lamport causal guarantee). We
+        assign each repo's emit_seq-sorted items into that repo's receive-order
+        slots, so both invariants hold simultaneously.
+        """
+        sorted_by_repo: Dict[str, List[Tuple[int, str]]] = {
+            repo: sorted(items) for repo, items in self._per_repo.items()
+        }
+        cursors: Dict[str, int] = {repo: 0 for repo in sorted_by_repo}
+        out: List[Tuple[str, int, str]] = []
+        for repo in self._receive_order:
+            idx = cursors[repo]
+            emit_seq, head_sha = sorted_by_repo[repo][idx]
+            cursors[repo] = idx + 1
+            out.append((repo, emit_seq, head_sha))
+        return out
+
+    def observed_count(self) -> int:
+        """Number of distinct deltas recorded."""
+        return len(self._receive_order)

--- a/backend/core/ouroboros/governance/causal/causal_delta_subscriber.py
+++ b/backend/core/ouroboros/governance/causal/causal_delta_subscriber.py
@@ -85,7 +85,8 @@ class CausalDeltaSubscriber:
 
     async def start(self) -> None:
         """Subscribe ``causal.delta.*``. The bus fingerprint-dedups before the
-        handler fires; ``event.source`` carries the authoritative repo."""
+        handler fires; the authoritative repo is the in-payload ``lineage.repo``
+        (``event.source`` collapses over the bridge -- never read here)."""
         self._sid = await self._bus.subscribe(CAUSAL_DELTA_PATTERN, self._on_delta)
 
     async def stop(self) -> None:

--- a/backend/core/ouroboros/governance/causal/structural_delta_sensor.py
+++ b/backend/core/ouroboros/governance/causal/structural_delta_sensor.py
@@ -1,0 +1,168 @@
+"""Domain-1 Staging-1 Task 1 -- StructuralDeltaSensor (Body publisher).
+
+The transport hop. Staging-0 built the Body-local AST structural-delta engine
+(``structural_delta.py``); this sensor is the PUBLISHER: it computes a
+content-free structural delta, stamps it with git lineage + the durable emit
+sequence, and publishes it as ``causal.delta.<repo>`` over the proven
+Stage-2/3/4 ``TrinityEventBus`` bridge.
+
+Design commitments:
+
+* **No new durability code.** The sensor only publishes; the Stage-3
+  ``DurableOutbound`` WAL on the same broker journals the event across a severed
+  link. Durability is INHERITED (proven by the ``_journal_local_origin_only``
+  test), not re-coded here.
+* **Reflective repo validation.** ``repo`` is validated at construction via
+  ``RepoType(repo)`` -- the enum IS the allowlist. A non-trinity repo raises at
+  construction time; there is NO hardcoded string allowlist.
+* **Explicit source identity.** The event is built with ``source=RepoType(repo)``
+  and published via ``publish(event)`` (NOT ``publish_raw``): ``publish_raw``
+  has no ``source`` kwarg -- it derives source from ``data["source"]`` and would
+  force us to pollute the content-free envelope. Building the ``TrinityEvent``
+  directly is the only path that yields ``event.source == RepoType(repo)`` while
+  keeping ``event.payload`` byte-identical to the ``stamp_delta`` envelope, so
+  the fingerprint + the Brain's reflective read see the authoritative repo.
+* **Fail-soft, non-blocking.** ``emit_file_change`` never raises (log + return
+  ``None`` on any error) and awaits exactly one ``publish`` -- no sleeps, no
+  retries.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Callable, Optional
+
+from backend.core.trinity_event_bus import RepoType, TrinityEvent
+from backend.core.ouroboros.governance.causal.structural_delta import (
+    DeltaLineage,
+    EmitSequence,
+    StructuralDelta,
+    compute_file_delta,
+    stamp_delta,
+)
+
+logger = logging.getLogger(__name__)
+
+CAUSAL_DELTA_TOPIC_PREFIX = "causal.delta."
+
+# Lazily-constructed module-level emit sequence -- used only when the caller
+# does not inject one. Never touched under test (tests inject a fake).
+_MODULE_EMIT_SEQ: Optional[EmitSequence] = None
+
+
+def _module_emit_seq() -> EmitSequence:
+    global _MODULE_EMIT_SEQ
+    if _MODULE_EMIT_SEQ is None:
+        _MODULE_EMIT_SEQ = EmitSequence()
+    return _MODULE_EMIT_SEQ
+
+
+@dataclass(frozen=True)
+class GitLineage:
+    """The git-read SHAs, injectable so unit tests need no real repo.
+
+    Staging 1 does NOT read git -- the sensor accepts these already-resolved
+    SHAs. The actual git reader is a later concern.
+    """
+
+    head_sha: str
+    parent_sha: str
+    merge_base: str
+
+
+class StructuralDeltaSensor:
+    """Compute a structural delta and publish it as ``causal.delta.<repo>``."""
+
+    def __init__(
+        self,
+        trinity_bus: Any,
+        *,
+        repo: str,
+        emit_seq: Optional[EmitSequence] = None,
+        sha_reader: Optional[Callable[[str], "GitLineage"]] = None,
+    ) -> None:
+        # Reflective validation: RepoType(repo) raises ValueError on an unknown
+        # repo -- the enum IS the allowlist. Re-raise with a clear message so a
+        # non-trinity repo can never construct a sensor.
+        try:
+            self._repo_enum = RepoType(repo)
+        except ValueError as exc:
+            raise ValueError(
+                "StructuralDeltaSensor: refusing to construct for non-trinity "
+                "repo %r (not a RepoType)" % (repo,)
+            ) from exc
+
+        self._bus = trinity_bus
+        self._repo = repo
+        self._emit_seq = emit_seq
+        self._sha_reader = sha_reader
+
+    # -- helpers -----------------------------------------------------------
+
+    def _seq(self) -> EmitSequence:
+        return self._emit_seq if self._emit_seq is not None else _module_emit_seq()
+
+    @staticmethod
+    def _has_structural_change(delta: StructuralDelta) -> bool:
+        """True iff there is something to publish: a file-level churn collapse
+        OR any non-empty per-symbol/per-edge tuple."""
+        if delta.file_level_churn:
+            return True
+        return bool(
+            delta.symbols_added
+            or delta.symbols_removed
+            or delta.symbols_resignatured
+            or delta.import_edges_added
+            or delta.import_edges_removed
+        )
+
+    # -- publish -----------------------------------------------------------
+
+    async def emit_file_change(
+        self,
+        file_path: str,
+        before_source: str,
+        after_source: str,
+        *,
+        lineage: "GitLineage",
+    ) -> Optional[str]:
+        """Compute -> stamp -> publish. Returns the event_id, or ``None`` when
+        nothing structural changed. Fail-soft: never raises."""
+        try:
+            delta = compute_file_delta(
+                self._repo, file_path, before_source, after_source
+            )
+            if not self._has_structural_change(delta):
+                # Nothing structural crossed -- do not publish noise.
+                return None
+
+            seq = self._seq().next(self._repo)
+            envelope = stamp_delta(
+                delta,
+                DeltaLineage(
+                    repo=self._repo,
+                    head_sha=lineage.head_sha,
+                    parent_sha=lineage.parent_sha,
+                    merge_base=lineage.merge_base,
+                    emit_seq=seq,
+                ),
+            )
+
+            # Build the event explicitly so source == RepoType(repo) and the
+            # payload stays byte-identical to the content-free envelope.
+            event = TrinityEvent(
+                topic=CAUSAL_DELTA_TOPIC_PREFIX + self._repo,
+                source=self._repo_enum,
+                payload=envelope,
+                correlation_id=lineage.head_sha,
+                causation_id=lineage.parent_sha,
+            )
+            return await self._bus.publish(event)
+        except Exception as exc:  # noqa: BLE001 -- fail-soft by contract
+            logger.error(
+                "[StructuralDeltaSensor] emit_file_change failed for %s (%r) "
+                "-- fail-soft, no publish",
+                file_path,
+                exc,
+            )
+            return None

--- a/backend/core/ouroboros/governance/causal/structural_delta_sensor.py
+++ b/backend/core/ouroboros/governance/causal/structural_delta_sensor.py
@@ -92,6 +92,15 @@ class StructuralDeltaSensor:
                 "repo %r (not a RepoType)" % (repo,)
             ) from exc
 
+        # BROADCAST is a TARGET semantic, not a valid SOURCE identity: a causal
+        # delta must originate from ONE concrete repo. Reflective enum-member
+        # check (no hardcoded string set).
+        if self._repo_enum == RepoType.BROADCAST:
+            raise ValueError(
+                "StructuralDeltaSensor requires a concrete source repo, not "
+                "BROADCAST"
+            )
+
         self._bus = trinity_bus
         self._repo = repo
         self._emit_seq = emit_seq

--- a/backend/core/ouroboros/governance/transport/organism_bus_host.py
+++ b/backend/core/ouroboros/governance/transport/organism_bus_host.py
@@ -94,6 +94,7 @@ class OrganismBusHost:
         self._bus: Optional[Any] = None  # DistributedEventBus (server role)
         self._bridge: Optional[Any] = None  # TrinityBusBridge
         self._intake_bridge: Optional[Any] = None  # RemoteIntakeBridge (Task 3)
+        self._causal_subscriber: Optional[Any] = None  # CausalDeltaSubscriber (D1S1 Task 2)
         self._generation_fence: Optional[Any] = None  # GenerationFence (Stage-4 Task 4)
         self._runner: Optional[Any] = None  # aiohttp AppRunner
         self._site: Optional[Any] = None  # aiohttp TCPSite
@@ -189,6 +190,12 @@ class OrganismBusHost:
                     trinity_bus, self._router)
                 await self._intake_bridge.start()
 
+            # Domain-1 Staging-1 Task 2: the Brain-side RECEIVER. Records
+            # causal.delta.<repo> deltas in causal order (reflective RepoType;
+            # the bus's own fingerprint dedup fires first). Lazy import keeps
+            # master-OFF free of the causal-package import cost.
+            await self._start_causal_subscriber(trinity_bus)
+
             # Stage-4 Task 4: the Brain-side ACTIVE fence. Only on nodes
             # the keeper stamped with a generation (env absent -> byte-
             # identical, no import).
@@ -209,6 +216,17 @@ class OrganismBusHost:
             ",".join(resolve_outbound_topics()), cfg.source_id,
         )
         return True
+
+    async def _start_causal_subscriber(self, trinity_bus: Any) -> None:
+        """Construct + start the Domain-1 Staging-1 CausalDeltaSubscriber
+        (Brain receiver). Lazy import inside the start-guard keeps master-OFF
+        byte-identical (no causal-package import cost)."""
+        from backend.core.ouroboros.governance.causal.causal_delta_subscriber import (  # noqa: PLC0415
+            CausalDeltaSubscriber,
+        )
+
+        self._causal_subscriber = CausalDeltaSubscriber(trinity_bus)
+        await self._causal_subscriber.start()
 
     async def _maybe_start_generation_fence(self, trinity_bus: Any) -> None:
         """Construct + start the split-brain GenerationFence (Stage-4 Task 4)
@@ -235,6 +253,13 @@ class OrganismBusHost:
                 logger.debug("[OrganismBusHost] generation fence stop failed",
                              exc_info=True)
             self._generation_fence = None
+        if self._causal_subscriber is not None:
+            try:
+                await self._causal_subscriber.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug("[OrganismBusHost] causal subscriber stop failed",
+                             exc_info=True)
+            self._causal_subscriber = None
         if self._intake_bridge is not None:
             try:
                 await self._intake_bridge.stop()

--- a/docs/superpowers/plans/2026-07-05-domain1-staging1-transport-hop.md
+++ b/docs/superpowers/plans/2026-07-05-domain1-staging1-transport-hop.md
@@ -1,0 +1,111 @@
+# Domain 1 — Staging 1: The Transport Hop
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A Body-side `StructuralDeltaSensor` publishes bounded structural deltas as `causal.delta.<repo>` over the proven Stage-2/3/4 bridge; a Brain-side `CausalDeltaSubscriber` receives them, dedups by `TrinityEvent.fingerprint`, and orders them causally — all riding existing transport, with Stage-3 WAL durability inherited on a severed link.
+
+**Architecture:** The sensor computes a delta (Staging-0 `compute_file_delta` + `stamp_delta`) and `publish_raw(topic=f"causal.delta.{repo}", data=envelope, source=RepoType, correlation_id=head_sha, causation_id=parent_sha)` onto the Body's local `TrinityEventBus`. The Body `TrinityBusBridge` (allowlist gains `causal.delta.*`) mirrors it to the broker; the Stage-3 `DurableOutbound` journals it at publish (local-origin passes `_journal_local_origin_only`), so a mid-transit partition queues it on disk and replays on mTLS restore — **no new durability code, no retry loop**. On the Brain, the inbound `TrinityBusBridge` republishes onto the Brain's `TrinityEventBus`; `CausalDeltaSubscriber` subscribes `causal.delta.*`, reads `RepoType` **reflectively from the payload** (never the topic string), and records deltas in causal order. Nothing net-new in transport/dedup/routing.
+
+**Tech Stack:** Staging-0 `structural_delta` engine; `TrinityEventBus.publish_raw`/`subscribe`; the Stage-2/3/4 `TrinityBusBridge`/`DistributedEventBus`/`DurableOutbound`; `RepoType`.
+
+## Global Constraints (Staging-1 mandates, binding)
+
+- **MANDATE 1 (root-cause durability):** a severed bridge mid-transit queues the payload on disk via the EXISTING Stage-3 `DurableOutbound` FS-WAL (journal-at-publish → replay on reconnect). NO retry loops, NO `sleep`, NO heuristic back-off anywhere in the sensor or subscriber.
+- **MANDATE 2 (reflective RepoType, no string-match routing):** the subscriber determines the source repo by reading the `RepoType` enum from the payload/`TrinityEvent.source` — NEVER by parsing the topic string or `if repo == "jarvis"` case-switching. Subscribe the wildcard `causal.delta.*`; branch on the reflected enum only for tagging, never for routing logic.
+- **MANDATE 3 (DRY, zero new transport):** `publish_raw` + add `causal.delta.*` to the `TrinityBusBridge` outbound allowlist + `TrinityEvent.fingerprint` 60s-window dedup ONLY. No new socket, dedup algorithm, or wire-routing handler.
+- **MANDATE 4 (adversarial loopback):** the two-process loopback test fires concurrent interleaved deltas from all three repos (jarvis/prime/reactor) simultaneously; proves the Brain subscriber drops exact fingerprint-duplicates while processing distinct deltas in causal order, non-blocking.
+- Standing: dark behind `JARVIS_DISTRIBUTED_BUS_ENABLED` (existing master); `from __future__ import annotations`; py3.9 (`asyncio.wait_for`, never `asyncio.timeout`); async-first, no blocking on the loop; ASCII; fail-soft (a malformed inbound delta is logged-and-dropped, never crashes the bus); single-writer (the Body only publishes; the graph write is Staging 2 — the subscriber here only RECORDS receipt, no graph). TDD; named-files commits.
+
+## Key facts (scouted, verified)
+
+- Body bridge allowlist: `scripts/run_body_mode.py:425` `outbound_topics=["intake.remote_signal.*", "console.*"]` → add `"causal.delta.*"`.
+- `_journal_local_origin_only` (`run_body_mode.py:86`): passes local-origin trinity events → causal deltas (origin `mac-body`) are journaled by `DurableOutbound` automatically (inherited durability).
+- Brain attach point: `organism_bus_host.py:171` `trinity_bus = await get_trinity_event_bus()`; construct the subscriber and `await sub.start()` right where `RemoteIntakeBridge` is wired (`:184-189`), lazy-imported inside the guard (master-off byte-identical).
+- `TrinityEvent.fingerprint` (`trinity_event_bus.py:291`) = `sha256(topic:source.value:sorted(payload))[:16]`; dedup window `TRINITY_DEDUP_WINDOW` default 60s (`trinity_event_bus.py:971-982`). Reuse — no new dedup.
+- `publish_raw(topic, data, priority=NORMAL, target=BROADCAST, persist=True, correlation_id=None, causation_id=None) -> str` (`trinity_event_bus.py:1006`); `RepoType.{JARVIS,PRIME,REACTOR,BROADCAST}` values `jarvis/prime/reactor/broadcast` (`trinity_event_bus.py:181`).
+- Staging-0: `compute_file_delta(repo, file_path, before, after) -> StructuralDelta`; `stamp_delta(delta, DeltaLineage) -> Dict`; `EmitSequence.next(repo) -> int` (all in `governance/causal/structural_delta.py`).
+
+---
+
+### Task 1: `StructuralDeltaSensor` (Body publisher) + allowlist
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/causal/structural_delta_sensor.py`
+- Modify: `scripts/run_body_mode.py` (allowlist `causal.delta.*`)
+- Test: `tests/governance/causal/test_structural_delta_sensor.py`
+
+**Interfaces (Produces):**
+```python
+CAUSAL_DELTA_TOPIC_PREFIX = "causal.delta."
+
+class StructuralDeltaSensor:
+    def __init__(self, trinity_bus, *, repo: str,
+                 emit_seq: Optional[EmitSequence] = None,
+                 sha_reader: Optional[Callable[[str], "GitLineage"]] = None) -> None: ...
+    async def emit_file_change(self, file_path: str, before_source: str,
+                               after_source: str, *, lineage: "GitLineage") -> Optional[str]:
+        """Compute delta (Staging-0) -> stamp lineage (repo from RepoType, head/parent/merge_base
+        from `lineage`, emit_seq from the durable counter) -> publish_raw(
+        topic=CAUSAL_DELTA_TOPIC_PREFIX + repo, data=envelope,
+        source=RepoType(repo), correlation_id=head_sha, causation_id=parent_sha).
+        Returns the event_id, or None if the delta is empty AND not file_level_churn
+        (nothing structural changed -> nothing to publish). Fail-soft: never raises."""
+
+@dataclass(frozen=True)
+class GitLineage:   # the git-read SHAs, injectable so unit tests need no real repo
+    head_sha: str
+    parent_sha: str
+    merge_base: str
+```
+- `repo` is validated to a `RepoType` at construction (reflective — `RepoType(repo)` raises on unknown, caught → the sensor refuses to construct for a non-trinity repo; NO string allowlist). The topic embeds `repo` for human-readable routing but the SOURCE enum is the authoritative identity.
+- Durability note (Mandate 1): the sensor only `publish_raw`s; the Stage-3 `DurableOutbound` on the same broker journals it. A test asserts a causal-delta event passes `_journal_local_origin_only` (so it IS journaled) — the durability is inherited, not re-coded.
+
+- [ ] **Step 1: Write failing tests** — injected fake `trinity_bus` recording `publish_raw` calls: (a) a real before/after pair → one `publish_raw` with `topic=="causal.delta.jarvis"`, `source==RepoType.JARVIS`, `correlation_id==head_sha`, `causation_id==parent_sha`, and `data` == the `stamp_delta` envelope (no content — magic-token absent); (b) empty structural change (identical source) → no publish, returns None; (c) `file_level_churn` (overflow) → publishes; (d) unknown repo → sensor construction refuses (ValueError caught → documented); (e) `_journal_local_origin_only` returns True for a synthesized causal-delta trinity event (durability inheritance pin).
+- [ ] **Step 2: RED.** **Step 3: Implement.** **Step 4: GREEN** + `causal.delta.*` added to the Body allowlist (verified by a one-line assertion test on `run_body_mode`'s outbound list, or a grep-test). **Step 5: Commit** — `feat(domain1): StructuralDeltaSensor publishes causal.delta.<repo> + bridge allowlist (Staging 1 Task 1)`.
+
+---
+
+### Task 2: `CausalDeltaSubscriber` (Brain receiver) — reflective, dedup, causal order
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/causal/causal_delta_subscriber.py`
+- Modify: `backend/core/ouroboros/governance/transport/organism_bus_host.py` (wire it beside `RemoteIntakeBridge`)
+- Test: `tests/governance/causal/test_causal_delta_subscriber.py`
+
+**Interfaces (Produces):**
+```python
+class CausalDeltaSubscriber:
+    def __init__(self, trinity_bus, *, on_delta: Optional[Callable[[dict], None]] = None) -> None: ...
+    async def start(self) -> None:   # subscribe "causal.delta.*"
+    async def stop(self) -> None:
+    def observed(self) -> List[Tuple[str, int, str]]:  # (repo, emit_seq, head_sha) in causal order
+    def observed_count(self) -> int
+```
+- Handler: parse the envelope; read the source repo REFLECTIVELY — `RepoType(event.source)` (or `RepoType(envelope["lineage"]["repo"])`), never the topic string; validate the lineage block; append `(repo, emit_seq, head_sha)` to a per-repo causal-ordered log (ordered by `emit_seq` within a repo — the Lamport guarantee from Staging 0; cross-repo interleave is recorded with a global receive index too). `TrinityEvent.fingerprint` dedup at the bus handles exact duplicates BEFORE the handler fires (reuse — the subscriber adds NO dedup); an idempotency guard on `(repo, emit_seq)` is the belt-and-suspenders for a replay outside the 60s window. Malformed envelope → log-and-drop (fail-soft). NON-BLOCKING: any non-trivial work (e.g. the `on_delta` callback) must not block the bus loop — the handler is a fast append; heavy work (Staging 2 graph fold) is deferred/offloaded there, not here.
+- Wire in `organism_bus_host`: lazy import inside the existing start-guard, `await sub.start()` after the intake bridge; `await sub.stop()` in stop. Master-off byte-identical.
+
+- [ ] **Step 1: Write failing tests** — real `TrinityEventBus` (TRINITY_MULTICAST_ENABLED=false): (a) publish 3 causal deltas (jarvis/prime/reactor) → `observed()` has all 3, repo read reflectively (test a delta whose TOPIC says one repo but SOURCE enum says another → the SOURCE wins — proves no topic-string routing); (b) publish the SAME delta twice within 60s → observed once (fingerprint dedup); (c) out-of-order emit_seq within one repo → `observed()` for that repo is in emit_seq order; (d) malformed envelope (missing lineage) → dropped, no raise; (e) organism_bus_host constructs the subscriber when gen/bus armed (recording fake), byte-identical off.
+- [ ] **Step 2: RED.** **Step 3: Implement.** **Step 4: GREEN.** **Step 5: Commit** — `feat(domain1): CausalDeltaSubscriber -- reflective RepoType, fingerprint dedup, causal order (Staging 1 Task 2)`.
+
+---
+
+### Task 3: The adversarial two-process loopback (Mandate 4)
+
+**Files:**
+- Test: `tests/governance/causal/test_causal_transport_loopback.py`
+
+Real localhost WS pair (reuse `test_bridge_reflection_and_cursor.py` `_Pair`/`_cfg`/`_free_port` + `organism_bus_host` patterns): a Body-side `TrinityEventBus`+bridge+`StructuralDeltaSensor`(×3 repos) and a Brain-side `TrinityEventBus`+host+`CausalDeltaSubscriber`, linked over a real mTLS-disabled WS.
+
+- [ ] **Step 1: The adversarial test:**
+  - Three `StructuralDeltaSensor`s (repo=jarvis/prime/reactor) publish `N` deltas each **concurrently** (`asyncio.gather`) with **interleaved** emit — rapid-fire, simultaneous.
+  - Inject a fraction as **exact duplicates** (same topic+source+payload within 60s).
+  - **Assert (mathematically):** the Brain subscriber's `observed_count()` == `3·N` distinct (duplicates dropped — `set` equality on `(repo, emit_seq, head_sha)`); every duplicate's fingerprint collided and was dropped (assert `bus.events_deduplicated` advanced by exactly the injected-dup count); each repo's observed sub-sequence is in `emit_seq` order (causal chronological within source); the Brain loop never blocked (a concurrent heartbeat/counter task kept ticking through the storm — assert its tick count is within expected band, i.e. the ingest didn't starve it).
+  - Condition-polled to a bounded deadline; run 3× for flake-immunity.
+- [ ] **Step 2: Run** `python3 -m pytest tests/governance/causal/test_causal_transport_loopback.py -v` (unsandboxed — real sockets). **Step 3: Commit** — `test(domain1): adversarial 3-repo concurrent transport loopback -- dedup + causal order + non-blocking (Staging 1 Task 3)`.
+
+---
+
+## Self-Review
+1. **Spec coverage (Staging 1 = spec Staging 1 "the transport hop"):** publish `causal.delta.*` (T1), Brain subscriber echo (T2), two-process loopback + dup-fingerprint dedup (T3), RepoType round-trips (T1/T2). Durability inherited from Stage-3 (T1 pin). Graph fold is Staging 2 — correctly out.
+2. **Placeholder scan:** exact topics/signatures/envs; the `_Pair` reuse is a named scaffold, not a TBD.
+3. **Type consistency:** `stamp_delta` envelope (Staging-0) is the `data` payload verbatim; `RepoType` is the reflected identity in both T1 (publish source) and T2 (read source); `(repo, emit_seq, head_sha)` tuple identical in T2/T3.

--- a/scripts/run_body_mode.py
+++ b/scripts/run_body_mode.py
@@ -422,7 +422,7 @@ class BodyModeDriver:
         )
         return TrinityBusBridge(
             trinity_bus, broker,
-            outbound_topics=["intake.remote_signal.*", "console.*"],
+            outbound_topics=["intake.remote_signal.*", "console.*", "causal.delta.*"],
             source_id="mac-body",
         )
 

--- a/tests/governance/causal/test_causal_delta_subscriber.py
+++ b/tests/governance/causal/test_causal_delta_subscriber.py
@@ -6,16 +6,19 @@ Proves the five brief contracts against a REAL ``TrinityEventBus``
 precedent: tests/governance/transport/test_trinity_bus_bridge.py::_mk_bus):
 
   (a) three deltas (jarvis/prime/reactor) are observed, and the source repo is
-      read REFLECTIVELY from ``event.source`` -- an event whose TOPIC says
-      ``causal.delta.jarvis`` but whose SOURCE enum is ``RepoType.PRIME`` is
-      recorded as PRIME (no topic-string routing);
+      read REFLECTIVELY from the IN-PAYLOAD ``lineage.repo`` (Mandate 2: the
+      RepoType rides as reflective metadata inside the data payload, NOT typed
+      on the transport) -- an event whose TOPIC says ``causal.delta.jarvis`` AND
+      whose ``event.source`` enum is ``RepoType.REACTOR`` but whose payload
+      ``lineage.repo`` is ``"prime"`` is recorded as PRIME (payload is
+      authoritative; neither topic-string nor event.source routing);
   (b) the SAME delta published twice within the 60s window is observed once
       (the bus's own fingerprint dedup -- the subscriber adds no dedup algo);
   (c) out-of-order ``emit_seq`` within one repo -> ``observed()`` for that repo
       is in ``emit_seq`` order (the Lamport guarantee);
   (d) a malformed envelope (missing lineage) is dropped, no raise into the bus;
-      a BROADCAST-sourced delta is dropped (a causal delta needs a concrete
-      source);
+      a delta whose in-payload ``lineage.repo`` is BROADCAST is dropped (a
+      causal delta needs a concrete source);
   (e) organism_bus_host constructs + starts the subscriber when the host serves
       (recording fake via monkeypatched lazy import) and is byte-identical
       (subscriber never constructed) when the master flag is off.
@@ -116,14 +119,16 @@ def test_three_deltas_observed_repo_read_reflectively():
         sub = CausalDeltaSubscriber(bus)
         await sub.start()
         try:
-            # jarvis + reactor: honest topic/source.
+            # jarvis + reactor: honest topic/source/payload.
             await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS,
                            _envelope("jarvis", 1, head_sha="jh"))
             await _publish(bus, "causal.delta.reactor", RepoType.REACTOR,
                            _envelope("reactor", 1, head_sha="rh"))
-            # LIE: topic says jarvis, but source enum says PRIME. The SOURCE
-            # wins -> recorded as prime. Proves no topic-string routing.
-            await _publish(bus, "causal.delta.jarvis", RepoType.PRIME,
+            # DOUBLE LIE: topic says jarvis AND event.source says REACTOR, but
+            # the in-payload lineage.repo says "prime". The PAYLOAD wins ->
+            # recorded as prime. Proves neither topic-string nor event.source
+            # routing -- Mandate-2 in-payload identity is authoritative.
+            await _publish(bus, "causal.delta.jarvis", RepoType.REACTOR,
                            _envelope("prime", 1, head_sha="ph"))
             await _settle(sub, 3)
             return sub.observed()
@@ -134,7 +139,7 @@ def test_three_deltas_observed_repo_read_reflectively():
     observed = _run(scenario())
     repos = {repo for (repo, _seq, _sha) in observed}
     assert repos == {"jarvis", "prime", "reactor"}, observed
-    # the lying-topic event is recorded under its SOURCE repo (prime), and its
+    # the double-lying event is recorded under its PAYLOAD repo (prime), and its
     # head_sha proves it is the same event.
     prime = [rec for rec in observed if rec[0] == "prime"]
     assert prime == [("prime", 1, "ph")], observed
@@ -225,9 +230,14 @@ def test_malformed_and_broadcast_dropped_no_raise():
             # lineage present but missing required keys
             await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS,
                            {"delta": {}, "lineage": {"repo": "jarvis"}})
-            # BROADCAST is a TARGET semantic, never a valid causal SOURCE
-            await _publish(bus, "causal.delta.jarvis", RepoType.BROADCAST,
-                           _envelope("jarvis", 3))
+            # in-payload lineage.repo == BROADCAST: a TARGET semantic, never a
+            # valid causal SOURCE (concrete event.source is irrelevant now --
+            # the payload is authoritative).
+            await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS,
+                           _envelope(RepoType.BROADCAST.value, 3))
+            # in-payload lineage.repo not a RepoType at all -> reflection drops
+            await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS,
+                           _envelope("not-a-trinity-repo", 4))
             # a good one to prove the bus + handler are still alive after drops
             await _publish(bus, "causal.delta.reactor", RepoType.REACTOR,
                            _envelope("reactor", 1, head_sha="ok"))
@@ -257,11 +267,12 @@ def test_handler_never_raises_on_garbage_payload():
         bad["lineage"]["emit_seq"] = "not-an-int"
         await sub._on_delta(TrinityEvent(topic="causal.delta.jarvis",
                                          source=RepoType.JARVIS, payload=bad))
-        # source not a RepoType at all
-        ev = TrinityEvent(topic="causal.delta.jarvis", source=RepoType.JARVIS,
-                          payload=_envelope("jarvis", 1))
-        ev.source = "jarvis"  # type: ignore[assignment]
-        await sub._on_delta(ev)
+        # in-payload lineage.repo not a RepoType at all -> reflection drops it
+        # (event.source is a perfectly valid RepoType.JARVIS -- irrelevant now)
+        bad_repo = _envelope("jarvis", 1)
+        bad_repo["lineage"]["repo"] = 12345  # non-str, non-RepoType
+        await sub._on_delta(TrinityEvent(topic="causal.delta.jarvis",
+                                         source=RepoType.JARVIS, payload=bad_repo))
         return sub.observed_count()
 
     assert _run(scenario()) == 0

--- a/tests/governance/causal/test_causal_delta_subscriber.py
+++ b/tests/governance/causal/test_causal_delta_subscriber.py
@@ -1,0 +1,342 @@
+# -*- coding: utf-8 -*-
+"""Domain-1 Staging-1 Task 2 -- CausalDeltaSubscriber (Brain receiver).
+
+Proves the five brief contracts against a REAL ``TrinityEventBus``
+(``TRINITY_MULTICAST_ENABLED=false`` to suppress the in-process UDP shortcut;
+precedent: tests/governance/transport/test_trinity_bus_bridge.py::_mk_bus):
+
+  (a) three deltas (jarvis/prime/reactor) are observed, and the source repo is
+      read REFLECTIVELY from ``event.source`` -- an event whose TOPIC says
+      ``causal.delta.jarvis`` but whose SOURCE enum is ``RepoType.PRIME`` is
+      recorded as PRIME (no topic-string routing);
+  (b) the SAME delta published twice within the 60s window is observed once
+      (the bus's own fingerprint dedup -- the subscriber adds no dedup algo);
+  (c) out-of-order ``emit_seq`` within one repo -> ``observed()`` for that repo
+      is in ``emit_seq`` order (the Lamport guarantee);
+  (d) a malformed envelope (missing lineage) is dropped, no raise into the bus;
+      a BROADCAST-sourced delta is dropped (a causal delta needs a concrete
+      source);
+  (e) organism_bus_host constructs + starts the subscriber when the host serves
+      (recording fake via monkeypatched lazy import) and is byte-identical
+      (subscriber never constructed) when the master flag is off.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+from typing import Any, List, Optional
+
+from backend.core.trinity_event_bus import RepoType, TrinityEvent, TrinityEventBus
+
+
+# ---------------------------------------------------------------------------
+# Real-bus fixture (multicast suppressed) -- precedent: _mk_bus in
+# tests/governance/transport/test_trinity_bus_bridge.py.
+# ---------------------------------------------------------------------------
+
+async def _mk_bus() -> TrinityEventBus:
+    prev = os.environ.get("TRINITY_MULTICAST_ENABLED")
+    os.environ["TRINITY_MULTICAST_ENABLED"] = "false"
+    try:
+        bus = await TrinityEventBus.create(local_repo=RepoType.JARVIS)
+    finally:
+        if prev is None:
+            os.environ.pop("TRINITY_MULTICAST_ENABLED", None)
+        else:
+            os.environ["TRINITY_MULTICAST_ENABLED"] = prev
+    # The real transport file-syncs non-local-source events to a shared
+    # ~/.jarvis/trinity/bus_sync/<source>_events.jsonl and a fresh bus REPLAYS
+    # them on boot (it skips only the local repo). Since these tests publish
+    # PRIME/REACTOR-sourced deltas, clear any stale sync files so one test's
+    # events never bleed into the next. (Publishing with target=local_repo --
+    # see _publish -- also skips the write, so this only self-heals leftovers.)
+    try:
+        for stale in bus._transport._sync_dir.glob("*_events.jsonl"):
+            stale.unlink()
+    except Exception:  # noqa: BLE001 -- best-effort isolation
+        pass
+    return bus
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _envelope(repo: str, emit_seq: int, head_sha: str = "h",
+              parent_sha: str = "p", merge_base: str = "m") -> dict:
+    """A content-free causal-delta envelope (shape of ``stamp_delta``)."""
+    return {
+        "delta": {"repo": repo, "file_level_churn": True},
+        "lineage": {
+            "repo": repo,
+            "head_sha": head_sha,
+            "parent_sha": parent_sha,
+            "merge_base": merge_base,
+            "emit_seq": emit_seq,
+        },
+    }
+
+
+async def _publish(bus: TrinityEventBus, topic: str, source: RepoType,
+                   envelope: dict) -> None:
+    # target=local_repo (JARVIS) keeps publish() from writing the event to the
+    # shared file-sync transport (publish only calls transport.send when
+    # target is BROADCAST or != local_repo) -- so cross-instance/cross-test
+    # replay can't happen. Local delivery is unaffected (the event still lands
+    # on the local queue and reaches subscribers). ``source`` is independent of
+    # ``target`` -- the reflective read under test is of ``event.source``.
+    await bus.publish(TrinityEvent(
+        topic=topic, source=source, target=RepoType.JARVIS, payload=envelope))
+
+
+async def _settle(sub: Any, expected: int, timeout: float = 3.0) -> None:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if sub.observed_count() >= expected:
+            return
+        await asyncio.sleep(0.02)
+
+
+def _import_subscriber():
+    from backend.core.ouroboros.governance.causal.causal_delta_subscriber import (
+        CausalDeltaSubscriber,
+    )
+    return CausalDeltaSubscriber
+
+
+# ---------------------------------------------------------------------------
+# (a) three deltas observed; repo read reflectively from event.source
+# ---------------------------------------------------------------------------
+def test_three_deltas_observed_repo_read_reflectively():
+    CausalDeltaSubscriber = _import_subscriber()
+
+    async def scenario():
+        bus = await _mk_bus()
+        sub = CausalDeltaSubscriber(bus)
+        await sub.start()
+        try:
+            # jarvis + reactor: honest topic/source.
+            await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS,
+                           _envelope("jarvis", 1, head_sha="jh"))
+            await _publish(bus, "causal.delta.reactor", RepoType.REACTOR,
+                           _envelope("reactor", 1, head_sha="rh"))
+            # LIE: topic says jarvis, but source enum says PRIME. The SOURCE
+            # wins -> recorded as prime. Proves no topic-string routing.
+            await _publish(bus, "causal.delta.jarvis", RepoType.PRIME,
+                           _envelope("prime", 1, head_sha="ph"))
+            await _settle(sub, 3)
+            return sub.observed()
+        finally:
+            await sub.stop()
+            await bus.stop()
+
+    observed = _run(scenario())
+    repos = {repo for (repo, _seq, _sha) in observed}
+    assert repos == {"jarvis", "prime", "reactor"}, observed
+    # the lying-topic event is recorded under its SOURCE repo (prime), and its
+    # head_sha proves it is the same event.
+    prime = [rec for rec in observed if rec[0] == "prime"]
+    assert prime == [("prime", 1, "ph")], observed
+
+
+# ---------------------------------------------------------------------------
+# (b) same delta twice within 60s -> observed once (bus fingerprint dedup)
+# ---------------------------------------------------------------------------
+def test_duplicate_within_window_observed_once():
+    CausalDeltaSubscriber = _import_subscriber()
+
+    async def scenario():
+        bus = await _mk_bus()
+        sub = CausalDeltaSubscriber(bus)
+        await sub.start()
+        try:
+            env = _envelope("jarvis", 5, head_sha="dup")
+            await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS, env)
+            await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS, env)
+            await _settle(sub, 1)
+            await asyncio.sleep(0.2)  # give any second delivery a chance
+            return sub.observed()
+        finally:
+            await sub.stop()
+            await bus.stop()
+
+    observed = _run(scenario())
+    assert observed == [("jarvis", 5, "dup")], observed
+
+
+def test_belt_and_suspenders_idempotency_outside_window():
+    """The seen-set guards a REPLAY outside the bus's 60s window (the bus dedup
+    would have expired). Drive the handler directly to simulate that replay."""
+    CausalDeltaSubscriber = _import_subscriber()
+
+    async def scenario():
+        sub = CausalDeltaSubscriber(trinity_bus=object())
+        ev = TrinityEvent(topic="causal.delta.jarvis", source=RepoType.JARVIS,
+                          payload=_envelope("jarvis", 9, head_sha="rep"))
+        await sub._on_delta(ev)
+        await sub._on_delta(ev)  # replay -- seen-set must drop it
+        return sub.observed()
+
+    observed = _run(scenario())
+    assert observed == [("jarvis", 9, "rep")], observed
+
+
+# ---------------------------------------------------------------------------
+# (c) out-of-order emit_seq within one repo -> observed() is emit_seq-ordered
+# ---------------------------------------------------------------------------
+def test_out_of_order_emit_seq_ordered_per_repo():
+    CausalDeltaSubscriber = _import_subscriber()
+
+    async def scenario():
+        bus = await _mk_bus()
+        sub = CausalDeltaSubscriber(bus)
+        await sub.start()
+        try:
+            # arrive out of order: 5 then 2 then 8 then 1
+            for seq, sha in ((5, "s5"), (2, "s2"), (8, "s8"), (1, "s1")):
+                await _publish(bus, "causal.delta.prime", RepoType.PRIME,
+                               _envelope("prime", seq, head_sha=sha))
+            await _settle(sub, 4)
+            return sub.observed()
+        finally:
+            await sub.stop()
+            await bus.stop()
+
+    observed = _run(scenario())
+    prime_seqs = [seq for (repo, seq, _sha) in observed if repo == "prime"]
+    assert prime_seqs == [1, 2, 5, 8], observed
+
+
+# ---------------------------------------------------------------------------
+# (d) malformed envelope dropped; BROADCAST source dropped -- no raise
+# ---------------------------------------------------------------------------
+def test_malformed_and_broadcast_dropped_no_raise():
+    CausalDeltaSubscriber = _import_subscriber()
+
+    async def scenario():
+        bus = await _mk_bus()
+        sub = CausalDeltaSubscriber(bus)
+        await sub.start()
+        try:
+            # missing lineage entirely
+            await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS,
+                           {"delta": {"repo": "jarvis"}})
+            # lineage present but missing required keys
+            await _publish(bus, "causal.delta.jarvis", RepoType.JARVIS,
+                           {"delta": {}, "lineage": {"repo": "jarvis"}})
+            # BROADCAST is a TARGET semantic, never a valid causal SOURCE
+            await _publish(bus, "causal.delta.jarvis", RepoType.BROADCAST,
+                           _envelope("jarvis", 3))
+            # a good one to prove the bus + handler are still alive after drops
+            await _publish(bus, "causal.delta.reactor", RepoType.REACTOR,
+                           _envelope("reactor", 1, head_sha="ok"))
+            await _settle(sub, 1)
+            await asyncio.sleep(0.2)
+            return sub.observed()
+        finally:
+            await sub.stop()
+            await bus.stop()
+
+    observed = _run(scenario())
+    assert observed == [("reactor", 1, "ok")], observed
+
+
+def test_handler_never_raises_on_garbage_payload():
+    """Direct-drive the handler with hostile payloads -- it must swallow every
+    error (fail-soft: never raise into the bus delivery loop)."""
+    CausalDeltaSubscriber = _import_subscriber()
+
+    async def scenario():
+        sub = CausalDeltaSubscriber(trinity_bus=object())
+        # payload not a dict
+        await sub._on_delta(TrinityEvent(topic="causal.delta.jarvis",
+                                         source=RepoType.JARVIS, payload=None))  # type: ignore[arg-type]
+        # emit_seq not an int
+        bad = _envelope("jarvis", 1)
+        bad["lineage"]["emit_seq"] = "not-an-int"
+        await sub._on_delta(TrinityEvent(topic="causal.delta.jarvis",
+                                         source=RepoType.JARVIS, payload=bad))
+        # source not a RepoType at all
+        ev = TrinityEvent(topic="causal.delta.jarvis", source=RepoType.JARVIS,
+                          payload=_envelope("jarvis", 1))
+        ev.source = "jarvis"  # type: ignore[assignment]
+        await sub._on_delta(ev)
+        return sub.observed_count()
+
+    assert _run(scenario()) == 0
+
+
+def test_on_delta_callback_fires_and_is_failsoft():
+    CausalDeltaSubscriber = _import_subscriber()
+    seen: List[dict] = []
+
+    def _cb(payload: dict) -> None:
+        seen.append(payload)
+        raise RuntimeError("callback boom -- must not propagate")
+
+    async def scenario():
+        sub = CausalDeltaSubscriber(trinity_bus=object(), on_delta=_cb)
+        await sub._on_delta(TrinityEvent(
+            topic="causal.delta.jarvis", source=RepoType.JARVIS,
+            payload=_envelope("jarvis", 1, head_sha="cb")))
+        return sub.observed()
+
+    observed = _run(scenario())
+    assert observed == [("jarvis", 1, "cb")], observed
+    assert len(seen) == 1  # callback fired despite raising
+
+
+# ---------------------------------------------------------------------------
+# (e) organism_bus_host wiring: constructed when armed, byte-identical off
+# ---------------------------------------------------------------------------
+def test_organism_bus_host_constructs_subscriber_when_armed(monkeypatch):
+    import backend.core.ouroboros.governance.causal.causal_delta_subscriber as mod
+    from backend.core.ouroboros.governance.transport.organism_bus_host import (
+        OrganismBusHost,
+    )
+
+    recorded: dict = {}
+
+    class _RecordingSubscriber:
+        def __init__(self, trinity_bus: Any,
+                     *, on_delta: Optional[Any] = None) -> None:
+            recorded["bus"] = trinity_bus
+            recorded["started"] = False
+
+        async def start(self) -> None:
+            recorded["started"] = True
+
+        async def stop(self) -> None:
+            recorded["stopped"] = True
+
+    monkeypatch.setattr(mod, "CausalDeltaSubscriber", _RecordingSubscriber)
+
+    host = OrganismBusHost()
+    sentinel_bus = object()
+    _run(host._start_causal_subscriber(sentinel_bus))
+
+    assert recorded.get("bus") is sentinel_bus
+    assert recorded.get("started") is True
+    assert isinstance(host._causal_subscriber, _RecordingSubscriber)
+
+    _run(host.stop())
+    assert recorded.get("stopped") is True
+    assert host._causal_subscriber is None
+
+
+def test_organism_bus_host_byte_identical_when_master_off(monkeypatch):
+    from backend.core.ouroboros.governance.transport import organism_bus_host as obh
+    from backend.core.ouroboros.governance.transport.organism_bus_host import (
+        OrganismBusHost,
+    )
+
+    for key in ("JARVIS_DISTRIBUTED_BUS_ENABLED", "JARVIS_BRAIN_WS_PORT"):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.setattr(obh, "bus_host_enabled", lambda: False)
+
+    host = OrganismBusHost()
+    assert _run(host.start()) is False
+    assert host._causal_subscriber is None
+    _run(host.stop())  # no-op teardown, never raises
+    assert host._causal_subscriber is None

--- a/tests/governance/causal/test_causal_transport_loopback.py
+++ b/tests/governance/causal/test_causal_transport_loopback.py
@@ -11,38 +11,31 @@ DISTINCT deltas simultaneously via ``asyncio.gather``, with a fraction re-emitte
 as EXACT duplicates, while a concurrent ticker proves the Brain loop never
 starved.
 
-WHAT SURVIVES THE HOP (empirically pinned, see the two identity surfaces below):
+MANDATE-2 IN-PAYLOAD IDENTITY (the design this test proves survives the hop):
 
-* The bridge (``TrinityBusBridge``) carries ``{topic, data, origin}`` across the
-  WS -- it does NOT carry the ``TrinityEvent.source`` enum. So on the Brain side
-  ``event.source`` COLLAPSES to the receiver bus's ``local_repo`` for every
-  delta (a real property of the Stage-2 generic bridge, not a bug this test
-  hides). The AUTHORITATIVE origin repo survives faithfully in the envelope
-  (``payload["lineage"]["repo"]`` == ``delta["repo"]``) and in the topic
-  (``causal.delta.<repo>``). This test therefore keys per-origin identity off
-  the transport-carried ENVELOPE (via the subscriber's ``on_delta`` sink) and
-  off a repo-encoding ``head_sha`` -- never off the collapsed ``event.source``.
-
-* Because ``event.source`` collapses to a single ``local_repo``, the
-  subscriber's ``observed()`` places all deltas in ONE per-repo bucket and
-  returns them GLOBALLY ordered by ``(emit_seq, head_sha)``. Filtering that
-  global order to one origin (by the repo-encoding ``head_sha``) yields that
-  origin's ``emit_seq`` subsequence -- which MUST be the strict ascending
-  ``1..N`` if causal order was preserved end-to-end across the WS.
+* The RepoType origin rides as REFLECTIVE METADATA INSIDE the data payload
+  (``payload["lineage"]["repo"]`` == ``delta["repo"]``), NOT typed on the
+  transport. The generic ``TrinityBusBridge`` carries ``{topic, data, origin}``
+  verbatim across the WS but re-mints ``TrinityEvent.source`` to the receiver
+  bus's ``local_repo`` -- so ``event.source`` is NOT a reliable origin over a
+  cross-host hop and is deliberately never read. The Brain
+  ``CausalDeltaSubscriber`` reflects the origin from the surviving in-payload
+  ``lineage.repo`` (``RepoType(...)``), so its ``observed()`` carries the TRUE
+  per-repo identity end-to-end. This test asserts MANDATE-4 DIRECTLY against
+  ``observed()`` -- no head_sha / event.source workaround.
 
 The MANDATE-4 assertions (all condition-polled to a bounded deadline; NO bare
 sleep-as-sync):
 
   1. ``observed_count() == 3*N`` -- every distinct delta crossed; duplicates
-     dropped. The faithful envelope set ``{(lineage.repo, emit_seq, head_sha)}``
-     captured on the Brain side has exactly ``3*N`` unique tuples.
+     dropped. ``set(observed())`` has exactly ``3*N`` unique
+     ``(repo, emit_seq, head_sha)`` tuples with the CORRECT (in-payload) repo.
   2. The BODY bus's ``events_deduplicated`` advanced by EXACTLY the injected
      duplicate count (same topic+source+payload within the 60s fingerprint
      window collided and was dropped at publish -- the dups never left the Body).
-  3. For EACH origin repo, the ``emit_seq`` subsequence (recovered from the
-     Brain's ``observed()`` via the repo-encoding ``head_sha``) is the strict
-     ascending ``1..N`` -- causal chronological order within source, preserved
-     end-to-end.
+  3. For EACH origin repo, the ``emit_seq`` subsequence of ``observed()``
+     filtered to that repo is the strict ascending ``1..N`` -- causal
+     chronological order within source, preserved end-to-end.
   4. NON-BLOCKING: a concurrent ~5ms ticker task kept ticking THROUGH the storm;
      its tick count sits within a band tied to the measured wall-clock -- the
      Brain ingest never starved the loop.
@@ -52,9 +45,9 @@ Run 3x consecutively for flake-immunity.
 Isolation notes: ``TRINITY_MULTICAST_ENABLED=false`` suppresses the in-process
 UDP shortcut (precedent: test_trinity_bus_bridge.py::_mk_bus). The disk file-sync
 transport (``CrossRepoTransport._file_sync_loop``, 1s poll) would otherwise
-double-deliver (and, via the on-disk ``to_dict``, resurrect ``source``) and bleed
-state across iterations, so each bus's ``_sync_dir`` is repointed to a UNIQUE
-temp dir -- the WS is then the ONLY cross-bus path, which is the hop under test.
+double-deliver and bleed state across iterations, so each bus's ``_sync_dir`` is
+repointed to a UNIQUE temp dir -- the WS is then the ONLY cross-bus path, which is
+the hop under test.
 """
 from __future__ import annotations
 
@@ -222,18 +215,6 @@ async def _one_iteration(iteration: int) -> str:
     runner = None
     ticker = _Ticker()
 
-    # Faithful origin identity, captured off the transport-carried ENVELOPE
-    # (NOT event.source, which collapses across the bridge).
-    captured_env: List[Tuple[str, int, str]] = []
-
-    def _on_delta(payload: Dict[str, Any]) -> None:
-        lineage = payload.get("lineage") or {}
-        captured_env.append((
-            str(lineage.get("repo")),
-            int(lineage.get("emit_seq")),
-            str(lineage.get("head_sha")),
-        ))
-
     try:
         # -- buses (repoint sync dirs to isolated temp dirs: WS-only crossing) -
         body_bus = await TrinityEventBus.create(local_repo=RepoType.JARVIS)
@@ -259,8 +240,8 @@ async def _one_iteration(iteration: int) -> str:
         await body_bridge.start()
         await brain_bridge.start()
 
-        # -- Brain subscriber ---------------------------------------------- #
-        sub = CausalDeltaSubscriber(brain_bus, on_delta=_on_delta)
+        # -- Brain subscriber (reads the in-payload lineage.repo identity) -- #
+        sub = CausalDeltaSubscriber(brain_bus)
         await sub.start()
 
         # -- real localhost WS server + client ----------------------------- #
@@ -332,21 +313,18 @@ async def _one_iteration(iteration: int) -> str:
         dedup_after = body_bus._metrics.events_deduplicated
 
         # ================= MANDATE-4 ASSERTIONS ========================= #
-        # (1) exactly 3*N distinct crossed; dups dropped.
+        # (1) exactly 3*N distinct crossed; dups dropped. observed() carries the
+        #     TRUE in-payload (repo, emit_seq, head_sha) identity.
         assert sub.observed_count() == 3 * N, (
             "iter %d: observed_count %d != %d"
             % (iteration, sub.observed_count(), 3 * N))
-        expected_env = {
+        expected = {
             (repo, i, "%ssha%d" % (repo, i))
             for repo in REPOS for i in range(1, N + 1)
         }
-        assert len(captured_env) == 3 * N, (
-            "iter %d: envelope sink saw %d, expected %d"
-            % (iteration, len(captured_env), 3 * N))
-        assert set(captured_env) == expected_env, (
-            "iter %d: faithful envelope set mismatch (lost/extra deltas)"
-            % iteration)
-        # observed() tuples are unique across the collapsed bucket (head_sha).
+        assert set(observed) == expected, (
+            "iter %d: observed() identity set mismatch (lost/extra deltas or "
+            "wrong repo): %r" % (iteration, sorted(set(observed) ^ expected)))
         assert len(set(observed)) == 3 * N, (
             "iter %d: observed() has non-unique tuples: %r"
             % (iteration, observed))
@@ -360,14 +338,11 @@ async def _one_iteration(iteration: int) -> str:
             "iter %d: brain deduped %d (expected 0)"
             % (iteration, brain_bus._metrics.events_deduplicated))
 
-        # (3) per-origin causal order preserved end-to-end: filter the Brain's
-        #     globally-ordered observed() to each origin (by repo-encoding
-        #     head_sha) -> strict ascending 1..N.
+        # (3) per-origin causal order preserved end-to-end: filter observed() to
+        #     each origin repo (the TRUE in-payload identity) -> strict
+        #     ascending 1..N.
         for repo in REPOS:
-            seqs = [
-                seq for (_r, seq, sha) in observed
-                if sha.startswith("%ssha" % repo)
-            ]
+            seqs = [seq for (r, seq, _sha) in observed if r == repo]
             assert seqs == list(range(1, N + 1)), (
                 "iter %d: repo %s emit_seq order %r != %r"
                 % (iteration, repo, seqs, list(range(1, N + 1))))

--- a/tests/governance/causal/test_causal_transport_loopback.py
+++ b/tests/governance/causal/test_causal_transport_loopback.py
@@ -1,0 +1,447 @@
+# -*- coding: utf-8 -*-
+"""Domain-1 Staging-1 Task 3 -- the adversarial two-process loopback (MANDATE 4).
+
+The load-bearing proof of the transport hop. Task 1 built the Body
+``StructuralDeltaSensor`` (publishes ``causal.delta.<repo>``); Task 2 built the
+Brain ``CausalDeltaSubscriber`` (reflective RepoType, fingerprint dedup, causal
+order). This test drives them TOGETHER over a REAL localhost WS pair
+(``DistributedEventBus`` client <-> server, TLS disabled via env) under
+adversarial concurrent load: three sensors (jarvis/prime/reactor) fire N
+DISTINCT deltas simultaneously via ``asyncio.gather``, with a fraction re-emitted
+as EXACT duplicates, while a concurrent ticker proves the Brain loop never
+starved.
+
+WHAT SURVIVES THE HOP (empirically pinned, see the two identity surfaces below):
+
+* The bridge (``TrinityBusBridge``) carries ``{topic, data, origin}`` across the
+  WS -- it does NOT carry the ``TrinityEvent.source`` enum. So on the Brain side
+  ``event.source`` COLLAPSES to the receiver bus's ``local_repo`` for every
+  delta (a real property of the Stage-2 generic bridge, not a bug this test
+  hides). The AUTHORITATIVE origin repo survives faithfully in the envelope
+  (``payload["lineage"]["repo"]`` == ``delta["repo"]``) and in the topic
+  (``causal.delta.<repo>``). This test therefore keys per-origin identity off
+  the transport-carried ENVELOPE (via the subscriber's ``on_delta`` sink) and
+  off a repo-encoding ``head_sha`` -- never off the collapsed ``event.source``.
+
+* Because ``event.source`` collapses to a single ``local_repo``, the
+  subscriber's ``observed()`` places all deltas in ONE per-repo bucket and
+  returns them GLOBALLY ordered by ``(emit_seq, head_sha)``. Filtering that
+  global order to one origin (by the repo-encoding ``head_sha``) yields that
+  origin's ``emit_seq`` subsequence -- which MUST be the strict ascending
+  ``1..N`` if causal order was preserved end-to-end across the WS.
+
+The MANDATE-4 assertions (all condition-polled to a bounded deadline; NO bare
+sleep-as-sync):
+
+  1. ``observed_count() == 3*N`` -- every distinct delta crossed; duplicates
+     dropped. The faithful envelope set ``{(lineage.repo, emit_seq, head_sha)}``
+     captured on the Brain side has exactly ``3*N`` unique tuples.
+  2. The BODY bus's ``events_deduplicated`` advanced by EXACTLY the injected
+     duplicate count (same topic+source+payload within the 60s fingerprint
+     window collided and was dropped at publish -- the dups never left the Body).
+  3. For EACH origin repo, the ``emit_seq`` subsequence (recovered from the
+     Brain's ``observed()`` via the repo-encoding ``head_sha``) is the strict
+     ascending ``1..N`` -- causal chronological order within source, preserved
+     end-to-end.
+  4. NON-BLOCKING: a concurrent ~5ms ticker task kept ticking THROUGH the storm;
+     its tick count sits within a band tied to the measured wall-clock -- the
+     Brain ingest never starved the loop.
+
+Run 3x consecutively for flake-immunity.
+
+Isolation notes: ``TRINITY_MULTICAST_ENABLED=false`` suppresses the in-process
+UDP shortcut (precedent: test_trinity_bus_bridge.py::_mk_bus). The disk file-sync
+transport (``CrossRepoTransport._file_sync_loop``, 1s poll) would otherwise
+double-deliver (and, via the on-disk ``to_dict``, resurrect ``source``) and bleed
+state across iterations, so each bus's ``_sync_dir`` is repointed to a UNIQUE
+temp dir -- the WS is then the ONLY cross-bus path, which is the hop under test.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import shutil
+import socket
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+from aiohttp import web
+
+from backend.core.trinity_event_bus import RepoType, TrinityEventBus
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    StreamEventBroker,
+)
+from backend.core.ouroboros.governance.transport.transport_config import (
+    TransportConfig,
+)
+from backend.core.ouroboros.governance.transport.distributed_event_bus import (
+    DistributedEventBus,
+)
+from backend.core.ouroboros.governance.transport.trinity_bus_bridge import (
+    TrinityBusBridge,
+)
+from backend.core.ouroboros.governance.causal.causal_delta_subscriber import (
+    CausalDeltaSubscriber,
+)
+from backend.core.ouroboros.governance.causal.structural_delta_sensor import (
+    GitLineage,
+    StructuralDeltaSensor,
+)
+from backend.core.ouroboros.governance.causal.structural_delta import EmitSequence
+
+# --------------------------------------------------------------------------- #
+# Adversarial parameters
+# --------------------------------------------------------------------------- #
+REPOS: Tuple[str, ...] = ("jarvis", "prime", "reactor")
+N = 8                       # distinct deltas PER repo -> 3*N total
+DUP_INDICES: Tuple[int, ...] = (0, 5, 10, 15, 20, 23)  # which captured events to
+#                                                       re-emit as EXACT dups
+DUP_COUNT = len(DUP_INDICES)
+ITERATIONS = 3              # flake-immunity
+
+
+def _free_port() -> int:
+    with socket.socket() as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+def _run(coro):
+    return asyncio.get_event_loop().run_until_complete(coro)
+
+
+def _before_after(repo: str, i: int) -> Tuple[str, str]:
+    """A structurally-distinct before/after pair for (repo, i): the AFTER adds a
+    uniquely-named function, so every delta has a distinct fingerprint."""
+    before = "def base():\n    return 0\n"
+    after = (
+        "def base():\n    return 0\n\n"
+        "def g_%s_%d():\n    return %d\n" % (repo, i, i)
+    )
+    return before, after
+
+
+def _real_sync_dir() -> Path:
+    """The bus's real sync dir (sandbox_fallback-resolved), so a pre-create
+    clean removes any stale ``*_events.jsonl`` before the transport's first poll
+    can replay it."""
+    from backend.core.ouroboros.governance.sandbox_paths import sandbox_fallback
+    return sandbox_fallback(Path.home() / ".jarvis" / "trinity" / "bus_sync")
+
+
+def _clean_real_sync_dir() -> None:
+    try:
+        for stale in _real_sync_dir().glob("*_events.jsonl"):
+            stale.unlink()
+    except Exception:  # noqa: BLE001 -- best-effort isolation
+        pass
+
+
+async def _await_connected(client_bus: Any, timeout: float = 5.0) -> None:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        client = getattr(client_bus, "_client", None)
+        if client is not None and getattr(client, "connected", False):
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError("client never reported connected")
+
+
+async def _settle_count(sub: Any, expected: int, timeout: float = 20.0) -> None:
+    loop = asyncio.get_event_loop()
+    deadline = loop.time() + timeout
+    while loop.time() < deadline:
+        if sub.observed_count() >= expected:
+            return
+        await asyncio.sleep(0.02)
+    raise AssertionError(
+        "brain never observed %d deltas (stuck at %d)"
+        % (expected, sub.observed_count()))
+
+
+class _Ticker:
+    """A ~5ms heartbeat proving the event loop kept turning under the storm."""
+
+    def __init__(self, interval: float = 0.005) -> None:
+        self._interval = interval
+        self.ticks = 0
+        self._stop = False
+        self._task: Optional[asyncio.Task] = None
+        self._started_at = 0.0
+        self._stopped_at = 0.0
+
+    async def _loop(self) -> None:
+        while not self._stop:
+            self.ticks += 1
+            await asyncio.sleep(self._interval)
+
+    def start(self) -> None:
+        self._started_at = asyncio.get_event_loop().time()
+        self._task = asyncio.ensure_future(self._loop())
+
+    async def stop(self) -> None:
+        self._stop = True
+        self._stopped_at = asyncio.get_event_loop().time()
+        if self._task is not None:
+            try:
+                await self._task
+            except Exception:  # noqa: BLE001
+                pass
+
+    @property
+    def elapsed(self) -> float:
+        return max(1e-6, self._stopped_at - self._started_at)
+
+
+async def _one_iteration(iteration: int) -> str:
+    """Build a REAL Body<->Brain WS pair, run the adversarial storm, assert the
+    four MANDATE-4 invariants, tear everything down. Returns a one-line summary.
+    """
+    _clean_real_sync_dir()
+
+    port = _free_port()
+    os.environ["JARVIS_BRAIN_WS_TLS_ENABLED"] = "false"
+    os.environ["JARVIS_BRAIN_WS_HOST"] = "127.0.0.1"
+    os.environ["JARVIS_BRAIN_WS_PORT"] = str(port)
+    os.environ["JARVIS_BRAIN_WS_HEARTBEAT_S"] = "1.0"
+    os.environ["TRINITY_MULTICAST_ENABLED"] = "false"
+
+    server_cfg = TransportConfig.from_env(role="server")
+    client_cfg = TransportConfig.from_env(role="client")
+
+    tmp_dirs: List[str] = []
+    body_bus = None
+    brain_bus = None
+    body_bridge = None
+    brain_bridge = None
+    sub = None
+    client_bus = None
+    client_task = None
+    runner = None
+    ticker = _Ticker()
+
+    # Faithful origin identity, captured off the transport-carried ENVELOPE
+    # (NOT event.source, which collapses across the bridge).
+    captured_env: List[Tuple[str, int, str]] = []
+
+    def _on_delta(payload: Dict[str, Any]) -> None:
+        lineage = payload.get("lineage") or {}
+        captured_env.append((
+            str(lineage.get("repo")),
+            int(lineage.get("emit_seq")),
+            str(lineage.get("head_sha")),
+        ))
+
+    try:
+        # -- buses (repoint sync dirs to isolated temp dirs: WS-only crossing) -
+        body_bus = await TrinityEventBus.create(local_repo=RepoType.JARVIS)
+        brain_bus = await TrinityEventBus.create(local_repo=RepoType.JARVIS)
+        for bus in (body_bus, brain_bus):
+            d = tempfile.mkdtemp(prefix="causal_loopback_")
+            tmp_dirs.append(d)
+            bus._transport._sync_dir = Path(d)
+
+        # -- brokers + Stage-0 distributed buses ---------------------------- #
+        server_broker = StreamEventBroker()
+        client_broker = StreamEventBroker()
+        server_bus = DistributedEventBus(server_broker, server_cfg, role="server")
+        client_bus = DistributedEventBus(client_broker, client_cfg, role="client")
+
+        # -- bridges: Body mirrors causal.delta.* outbound; Brain drains inbound
+        body_bridge = TrinityBusBridge(
+            body_bus, client_broker,
+            outbound_topics=["causal.delta.*"], source_id="mac-body")
+        brain_bridge = TrinityBusBridge(
+            brain_bus, server_broker,
+            outbound_topics=[], source_id="brain")
+        await body_bridge.start()
+        await brain_bridge.start()
+
+        # -- Brain subscriber ---------------------------------------------- #
+        sub = CausalDeltaSubscriber(brain_bus, on_delta=_on_delta)
+        await sub.start()
+
+        # -- real localhost WS server + client ----------------------------- #
+        app = web.Application()
+        server_bus.register_server_routes(app)
+        runner = web.AppRunner(app)
+        await runner.setup()
+        site = web.TCPSite(runner, host="127.0.0.1", port=port)
+        await site.start()
+        url = "ws://127.0.0.1:%d%s" % (port, client_cfg.path)
+        client_task = asyncio.ensure_future(client_bus.start_client(url))
+        await _await_connected(client_bus)
+
+        # -- three sensors, distinct durable emit sequences per repo -------- #
+        sensors: Dict[str, StructuralDeltaSensor] = {}
+        for repo in REPOS:
+            seq_path = tempfile.mkdtemp(prefix="emit_seq_%s_" % repo)
+            tmp_dirs.append(seq_path)
+            seq = EmitSequence(path=os.path.join(seq_path, "seq.jsonl"))
+            sensors[repo] = StructuralDeltaSensor(body_bus, repo=repo, emit_seq=seq)
+
+        # -- capture the exact TrinityEvents the sensors publish (so a dup is a
+        #    byte-identical re-publish -> same fingerprint). --------------- #
+        published: List[Any] = []
+        _orig_publish = body_bus.publish
+
+        async def _spy_publish(event):
+            published.append(event)
+            return await _orig_publish(event)
+
+        body_bus.publish = _spy_publish  # type: ignore[assignment]
+
+        # -- THE STORM: all 3 repos x N deltas, fully concurrent ----------- #
+        ticker.start()
+
+        async def _emit(repo: str, i: int):
+            before, after = _before_after(repo, i)
+            return await sensors[repo].emit_file_change(
+                "%s/f%d.py" % (repo, i), before, after,
+                lineage=GitLineage(
+                    head_sha="%ssha%d" % (repo, i),
+                    parent_sha="%spar%d" % (repo, i),
+                    merge_base="%smb" % repo,
+                ),
+            )
+
+        storm = [_emit(repo, i) for repo in REPOS for i in range(1, N + 1)]
+        emit_ids = await asyncio.gather(*storm)
+        # every distinct emit produced a real publish (structural change present)
+        assert all(eid for eid in emit_ids), (
+            "iter %d: a sensor emit returned None (no publish)" % iteration)
+        assert len(published) == 3 * N, (
+            "iter %d: expected %d captured publishes, got %d"
+            % (iteration, 3 * N, len(published)))
+
+        # -- INJECT EXACT DUPLICATES: re-publish captured events (bypass spy so
+        #    published[] stays the distinct set). Same topic+source+payload
+        #    within the 60s window -> the Body bus fingerprint-dedups each. --
+        dedup_before = body_bus._metrics.events_deduplicated
+        dups = [_orig_publish(published[k]) for k in DUP_INDICES]
+        await asyncio.gather(*dups)
+
+        # -- settle: brain must observe exactly the 3*N distinct deltas ----- #
+        await _settle_count(sub, 3 * N)
+        await asyncio.sleep(0.3)  # drain window (NOT a sync): catch any straggler
+        await ticker.stop()
+
+        observed = sub.observed()
+        dedup_after = body_bus._metrics.events_deduplicated
+
+        # ================= MANDATE-4 ASSERTIONS ========================= #
+        # (1) exactly 3*N distinct crossed; dups dropped.
+        assert sub.observed_count() == 3 * N, (
+            "iter %d: observed_count %d != %d"
+            % (iteration, sub.observed_count(), 3 * N))
+        expected_env = {
+            (repo, i, "%ssha%d" % (repo, i))
+            for repo in REPOS for i in range(1, N + 1)
+        }
+        assert len(captured_env) == 3 * N, (
+            "iter %d: envelope sink saw %d, expected %d"
+            % (iteration, len(captured_env), 3 * N))
+        assert set(captured_env) == expected_env, (
+            "iter %d: faithful envelope set mismatch (lost/extra deltas)"
+            % iteration)
+        # observed() tuples are unique across the collapsed bucket (head_sha).
+        assert len(set(observed)) == 3 * N, (
+            "iter %d: observed() has non-unique tuples: %r"
+            % (iteration, observed))
+
+        # (2) the BODY bus deduplicated EXACTLY the injected dup count.
+        assert dedup_after - dedup_before == DUP_COUNT, (
+            "iter %d: body dedup advanced by %d, expected %d"
+            % (iteration, dedup_after - dedup_before, DUP_COUNT))
+        # nothing was deduped on the Brain (every crossing delta was distinct).
+        assert brain_bus._metrics.events_deduplicated == 0, (
+            "iter %d: brain deduped %d (expected 0)"
+            % (iteration, brain_bus._metrics.events_deduplicated))
+
+        # (3) per-origin causal order preserved end-to-end: filter the Brain's
+        #     globally-ordered observed() to each origin (by repo-encoding
+        #     head_sha) -> strict ascending 1..N.
+        for repo in REPOS:
+            seqs = [
+                seq for (_r, seq, sha) in observed
+                if sha.startswith("%ssha" % repo)
+            ]
+            assert seqs == list(range(1, N + 1)), (
+                "iter %d: repo %s emit_seq order %r != %r"
+                % (iteration, repo, seqs, list(range(1, N + 1))))
+
+        # (4) NON-BLOCKING: the ticker kept turning through the storm.
+        expected_ticks = ticker.elapsed / 0.005
+        floor = max(10, int(expected_ticks * 0.25))
+        assert ticker.ticks >= floor, (
+            "iter %d: ticker starved -- %d ticks over %.3fs (floor %d)"
+            % (iteration, ticker.ticks, ticker.elapsed, floor))
+
+        return (
+            "iter %d OK: observed=%d dups_dropped=%d/%d "
+            "ticks=%d/%.0f(elapsed=%.2fs) per_repo_order=strict[1..%d]"
+            % (iteration, sub.observed_count(), dedup_after - dedup_before,
+               DUP_COUNT, ticker.ticks, expected_ticks, ticker.elapsed, N))
+    finally:
+        # restore the patched method (defensive; bus is discarded anyway)
+        if body_bus is not None and hasattr(body_bus, "publish"):
+            try:
+                del body_bus.publish  # type: ignore[misc]
+            except Exception:  # noqa: BLE001
+                pass
+        if ticker._task is not None and not ticker._stop:
+            await ticker.stop()
+        if sub is not None:
+            try:
+                await sub.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        for bridge in (body_bridge, brain_bridge):
+            if bridge is not None:
+                try:
+                    await bridge.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+        if client_bus is not None:
+            try:
+                await client_bus.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        if client_task is not None:
+            client_task.cancel()
+            try:
+                await client_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        if runner is not None:
+            try:
+                await runner.cleanup()
+            except Exception:  # noqa: BLE001
+                pass
+        for bus in (body_bus, brain_bus):
+            if bus is not None:
+                try:
+                    await bus.stop()
+                except Exception:  # noqa: BLE001
+                    pass
+        for d in tmp_dirs:
+            shutil.rmtree(d, ignore_errors=True)
+        _clean_real_sync_dir()
+
+
+# --------------------------------------------------------------------------- #
+# The 3x flake-immunity driver.
+# --------------------------------------------------------------------------- #
+def test_adversarial_concurrent_transport_loopback():
+    async def driver():
+        summaries: List[str] = []
+        for it in range(1, ITERATIONS + 1):
+            summaries.append(await _one_iteration(it))
+        return summaries
+
+    summaries = _run(driver())
+    # surface the per-run evidence (visible with -s / on failure).
+    print("\n".join(summaries))
+    assert len(summaries) == ITERATIONS

--- a/tests/governance/causal/test_structural_delta_sensor.py
+++ b/tests/governance/causal/test_structural_delta_sensor.py
@@ -1,0 +1,215 @@
+"""Domain-1 Staging-1 Task 1 -- StructuralDeltaSensor (Body publisher).
+
+Proves the sensor computes a Staging-0 structural delta and publishes it as a
+content-free ``causal.delta.<repo>`` TrinityEvent over the injected bus, that a
+no-op change publishes nothing, that an over-bound change still publishes (as
+``file_level_churn``), that construction refuses a non-trinity repo, and that a
+causal-delta event passes the Body's ``_journal_local_origin_only`` filter (so
+the Stage-3 DurableOutbound WAL journals it -- durability is INHERITED, not
+re-coded). Also pins the Body bus-bridge allowlist to include ``causal.delta.*``.
+"""
+from __future__ import annotations
+
+import inspect
+import json
+
+import pytest
+
+from backend.core.trinity_event_bus import RepoType, TrinityEvent
+from backend.core.ouroboros.governance.causal.structural_delta_sensor import (
+    CAUSAL_DELTA_TOPIC_PREFIX,
+    GitLineage,
+    StructuralDeltaSensor,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fakes -- zero real bus, zero real durable emit-seq.
+# ---------------------------------------------------------------------------
+
+class _FakeBus:
+    """Records publish()/publish_raw() calls without touching a real broker."""
+
+    def __init__(self) -> None:
+        self.published = []          # list[TrinityEvent] via publish()
+        self.published_raw = []      # list[dict] via publish_raw()
+        self.local_repo = RepoType.JARVIS
+
+    async def publish(self, event, persist=True):
+        self.published.append(event)
+        return event.event_id
+
+    async def publish_raw(self, topic, data, priority=None, target=None,
+                          persist=True, correlation_id=None, causation_id=None):
+        self.published_raw.append(
+            {
+                "topic": topic,
+                "data": data,
+                "correlation_id": correlation_id,
+                "causation_id": causation_id,
+            }
+        )
+        return "raw-event-id"
+
+
+class _FakeEmitSeq:
+    def __init__(self, value: int = 7) -> None:
+        self.value = value
+        self.calls = []
+
+    def next(self, repo: str) -> int:
+        self.calls.append(repo)
+        return self.value
+
+
+_LINEAGE = GitLineage(head_sha="head123", parent_sha="parent456", merge_base="mb789")
+
+_BEFORE = "def foo():\n    return 1\n"
+# after adds a brand-new function whose BODY carries a distinctive token that
+# must never leak into the published (content-free) envelope.
+_AFTER = (
+    "def foo():\n    return 1\n\n\n"
+    "def bar():\n    MAGIC_TOKEN_XYZ = 42\n    return MAGIC_TOKEN_XYZ\n"
+)
+
+
+def _all_published_events(bus: _FakeBus):
+    return list(bus.published) + list(bus.published_raw)
+
+
+# ---------------------------------------------------------------------------
+# (a) real before/after -> one content-free publish with correct provenance.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_real_change_publishes_content_free_causal_delta():
+    bus = _FakeBus()
+    seq = _FakeEmitSeq(value=7)
+    sensor = StructuralDeltaSensor(bus, repo="jarvis", emit_seq=seq)
+
+    event_id = await sensor.emit_file_change(
+        "backend/x.py", _BEFORE, _AFTER, lineage=_LINEAGE
+    )
+
+    assert event_id is not None
+    assert len(_all_published_events(bus)) == 1
+    assert len(bus.published) == 1, "expected publish() with an explicit source"
+    event: TrinityEvent = bus.published[0]
+
+    assert event.topic == CAUSAL_DELTA_TOPIC_PREFIX + "jarvis" == "causal.delta.jarvis"
+    assert event.source == RepoType.JARVIS
+    assert event.correlation_id == "head123"
+    assert event.causation_id == "parent456"
+
+    # envelope == stamp_delta output shape: {"delta": ..., "lineage": ...}
+    payload = event.payload
+    assert set(payload.keys()) == {"delta", "lineage"}
+    assert payload["lineage"]["repo"] == "jarvis"
+    assert payload["lineage"]["head_sha"] == "head123"
+    assert payload["lineage"]["parent_sha"] == "parent456"
+    assert payload["lineage"]["merge_base"] == "mb789"
+    assert payload["lineage"]["emit_seq"] == 7
+    assert seq.calls == ["jarvis"]
+
+    # bar() was added structurally...
+    added_ids = [s["symbol_id"] for s in payload["delta"]["symbols_added"]]
+    assert any(sid.endswith(":bar") for sid in added_ids)
+
+    # ...but NO source content ever crosses the boundary (Mandate 1).
+    assert "MAGIC_TOKEN_XYZ" not in json.dumps(payload)
+
+
+# ---------------------------------------------------------------------------
+# (b) empty structural change -> nothing published, returns None.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_no_structural_change_publishes_nothing():
+    bus = _FakeBus()
+    sensor = StructuralDeltaSensor(bus, repo="jarvis", emit_seq=_FakeEmitSeq())
+
+    event_id = await sensor.emit_file_change(
+        "backend/x.py", _BEFORE, _BEFORE, lineage=_LINEAGE
+    )
+
+    assert event_id is None
+    assert _all_published_events(bus) == []
+
+
+# ---------------------------------------------------------------------------
+# (c) over-bound / unparseable revision -> file_level_churn -> still publishes.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_file_level_churn_publishes():
+    bus = _FakeBus()
+    sensor = StructuralDeltaSensor(bus, repo="jarvis", emit_seq=_FakeEmitSeq())
+
+    # before is unparseable -> parse_failure -> file_level_churn True even though
+    # the per-symbol tuples collapse to empty.
+    event_id = await sensor.emit_file_change(
+        "backend/x.py", "this is not python (((", _AFTER, lineage=_LINEAGE
+    )
+
+    assert event_id is not None
+    assert len(bus.published) == 1
+    delta = bus.published[0].payload["delta"]
+    assert delta["file_level_churn"] is True
+    assert delta["symbols_added"] == []
+
+
+# ---------------------------------------------------------------------------
+# (d) unknown repo -> construction refuses (reflective RepoType validation).
+# ---------------------------------------------------------------------------
+
+def test_unknown_repo_refuses_construction():
+    bus = _FakeBus()
+    with pytest.raises(ValueError):
+        StructuralDeltaSensor(bus, repo="not-a-trinity-repo")
+
+
+# ---------------------------------------------------------------------------
+# (e) durability inheritance: a causal-delta trinity event passes the Body's
+#     _journal_local_origin_only filter, so DurableOutbound WILL journal it.
+# ---------------------------------------------------------------------------
+
+def test_causal_delta_event_passes_durable_journal_filter():
+    from scripts.run_body_mode import _journal_local_origin_only
+
+    # A locally-originated causal-delta event (no peer ``origin`` stamped yet --
+    # the bridge stamps origin on the OUTBOUND payload; at publish time it is
+    # absent -> fail-OPEN -> journaled).
+    event = TrinityEvent(
+        topic=CAUSAL_DELTA_TOPIC_PREFIX + "jarvis",
+        source=RepoType.JARVIS,
+        payload={"delta": {"file_level_churn": False}, "lineage": {"repo": "jarvis"}},
+    )
+    assert _journal_local_origin_only(event) is True
+
+
+# ---------------------------------------------------------------------------
+# Body bus-bridge allowlist pin: causal.delta.* is bridged onto the wire.
+# ---------------------------------------------------------------------------
+
+def test_body_bridge_allowlist_includes_causal_delta():
+    from scripts.run_body_mode import BodyModeDriver
+
+    src = inspect.getsource(BodyModeDriver._do_bridge)
+    assert "causal.delta.*" in src
+
+
+# ---------------------------------------------------------------------------
+# Fail-soft: an exploding bus never raises out of emit_file_change.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_emit_is_fail_soft_on_bus_error():
+    class _BoomBus(_FakeBus):
+        async def publish(self, event, persist=True):
+            raise RuntimeError("bus down")
+
+    sensor = StructuralDeltaSensor(_BoomBus(), repo="jarvis", emit_seq=_FakeEmitSeq())
+    result = await sensor.emit_file_change(
+        "backend/x.py", _BEFORE, _AFTER, lineage=_LINEAGE
+    )
+    assert result is None

--- a/tests/governance/causal/test_structural_delta_sensor.py
+++ b/tests/governance/causal/test_structural_delta_sensor.py
@@ -168,6 +168,14 @@ def test_unknown_repo_refuses_construction():
         StructuralDeltaSensor(bus, repo="not-a-trinity-repo")
 
 
+def test_broadcast_repo_refuses_construction():
+    # BROADCAST is a TARGET semantic, not a valid SOURCE identity -- a causal
+    # delta must originate from ONE concrete repo.
+    bus = _FakeBus()
+    with pytest.raises(ValueError):
+        StructuralDeltaSensor(bus, repo="broadcast")
+
+
 # ---------------------------------------------------------------------------
 # (e) durability inheritance: a causal-delta trinity event passes the Body's
 #     _journal_local_origin_only filter, so DurableOutbound WILL journal it.


### PR DESCRIPTION
## Domain 1 Staging 1: the transport hop (ships dark)

The Body publishes bounded structural deltas as `causal.delta.<repo>` over the proven Stage-2/3/4 bridge; the Brain receives, dedups, and orders them causally.

- **`StructuralDeltaSensor`** (Body) — `publish`es the Staging-0 delta envelope with `source=RepoType(repo)`, rejects BROADCAST; `causal.delta.*` added to the bridge outbound allowlist. Durability inherited from the Stage-3 `DurableOutbound` WAL (no retry/sleep — a severed link queues on disk and replays; Mandate 1).
- **`CausalDeltaSubscriber`** (Brain) — reads the source repo **reflectively from the in-payload `lineage.repo`** (Mandate 2 / spec Q5), never `event.source` (which collapses over the bridge) nor the topic string; reuses `TrinityEvent.fingerprint` 60s dedup (Mandate 3, no new algorithm); records causal order; wired in `OrganismBusHost`, records-only (single-writer — the graph fold is Staging 2).
- **The adversarial loopback** (Mandate 4) — a real localhost WS pair, 3 repos firing 8 deltas each concurrently via one `gather` with 6 exact-dup injections. Proven 3× flake-immune:
  ```
  observed=24  dups_dropped=6/6 (exact fingerprint)  per_repo_order=strict[1..8]  ticks~73/78 (non-blocking)
  ```

**The adversarial test earned its keep** — it caught a real cross-host bug (the bridge collapses `event.source`), and the root fix aligned the reflective read with the in-payload identity you mandated. Two per-task reviews + a whole-branch review, all spec-clean. 40/40 causal suite. Merges dark — masters off = byte-identical, sensor has no production caller until Staging 2.

Next: Staging 2 (the graph fold — `CausalGraphIngestor` on the Brain).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Domain-1 Staging-1 “transport hop”: the Body publishes content-free structural deltas as `causal.delta.<repo>` over the existing bridge, and the Brain subscribes, deduplicates via bus fingerprinting, and records per-repo causal order. Ships dark and inherits durability from Stage-3 `DurableOutbound`.

- **New Features**
  - Added `StructuralDeltaSensor` to compute/stamp and publish deltas to `causal.delta.<repo>` via `TrinityEventBus`; validates `RepoType`, rejects `BROADCAST`, and fails soft; durability is inherited (no retries).
  - Added `CausalDeltaSubscriber` to subscribe `causal.delta.*`, read the source repo reflectively from `payload.lineage.repo` (survives cross-host), rely on bus fingerprint dedup, and record `(repo, emit_seq, head_sha)` in causal order; non-blocking.
  - Wired the subscriber in `OrganismBusHost`; added `causal.delta.*` to the Body `TrinityBusBridge` allowlist.
  - Adversarial loopback test (3 repos × 8 deltas with exact dup injections): observed 24 distinct, all dups dropped, strict per-repo order, and no event-loop starvation.
  - Added plan docs under `docs/superpowers/plans/2026-07-05-domain1-staging1-transport-hop.md`.

- **Migration**
  - No action required; feature is behind the existing distributed bus flag and merges dark.
  - No API or schema changes.

<sup>Written for commit 4a9d0df29bf8ec871949286d38ee822286006f10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69854?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

