### PR TITLE
Domain-1 Staging-2: cross-repo causal graph fold (Brain-side)

### DIFF
--- a/backend/core/ouroboros/governance/causal/blast_radius_oracle.py
+++ b/backend/core/ouroboros/governance/causal/blast_radius_oracle.py
@@ -1,0 +1,122 @@
+"""Intra-repo BlastRadiusOracle -- strict TheOracle delegation.
+
+Domain-1 Staging-2 Task 2.
+
+Answers "given a symbol change, what is the *intra-repo* blast radius?" by
+STRICTLY DELEGATING to the existing per-repo :class:`TheOracle`. This module
+re-derives ZERO import resolution (Mandate 3): it does not parse ASTs, build
+import graphs, or walk dependency edges itself. Its ONLY dependency-source is
+``TheOracle.get_blast_radius`` (which internally owns the graph walk).
+
+Cross-repo traversal (widest-path max-product, cycle detection) is Staging 3 --
+explicitly NOT implemented here.
+
+Mandate 2 (non-blocking): ``TheOracle.get_blast_radius`` is a *synchronous*
+graph walk (``oracle.py`` -> ``compute_blast_radius``). We offload it via the
+unified ``cooperative_fs_io.offload`` substrate so a large intra-repo traversal
+never starves the event loop. There is no timeout constant -- offload is
+cooperative, not deadline-bounded.
+
+Fail-soft: an Oracle miss, an offloaded exception, or a ``None`` result yields
+an empty :class:`IntraRepoImpact` (source symbol only, ``risk_level="low"``).
+``intra_repo`` never raises.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Callable, Optional, Tuple
+
+from backend.core.ouroboros.governance.causal.causal_graph import CausalGraph
+from backend.core.ouroboros.governance.cooperative_fs_io import (
+    is_offload_error,
+    offload,
+)
+from backend.core.ouroboros.oracle import get_oracle
+
+
+@dataclass(frozen=True)
+class IntraRepoImpact:
+    """Intra-repo blast radius of a symbol change (deterministic, sorted).
+
+    ``directly_affected`` / ``transitively_affected`` are sorted tuples of
+    ``"repo:file:name"`` node identities, projected from the Oracle's
+    ``BlastRadius``. Sorting makes the impact deterministic across runs.
+    """
+
+    source_symbol: str
+    directly_affected: Tuple[str, ...]
+    transitively_affected: Tuple[str, ...]
+    risk_level: str
+
+
+class BlastRadiusOracle:
+    """Intra-repo blast-radius resolver -- a thin delegator over TheOracle.
+
+    Parameters
+    ----------
+    graph:
+        The folded in-memory :class:`CausalGraph` (Task 1). Held for
+        Staging-3 cross-repo traversal; the intra-repo path delegates
+        entirely to the per-repo Oracle and does not read the graph.
+    oracle_fn:
+        Injectable zero-arg factory returning a TheOracle-shaped object
+        (must expose ``get_blast_radius(target) -> BlastRadius``). Defaults
+        to :func:`backend.core.ouroboros.oracle.get_oracle`. A ``None``
+        value is treated as "use the default resolver".
+    """
+
+    def __init__(
+        self,
+        graph: CausalGraph,
+        *,
+        oracle_fn: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        self._graph = graph
+        self._oracle_fn = oracle_fn
+
+    def _empty(self, symbol_id: str) -> IntraRepoImpact:
+        return IntraRepoImpact(
+            source_symbol=symbol_id,
+            directly_affected=(),
+            transitively_affected=(),
+            risk_level="low",
+        )
+
+    async def intra_repo(self, symbol_id: str) -> IntraRepoImpact:
+        """Resolve the intra-repo blast radius of ``symbol_id``.
+
+        Delegates entirely to ``get_oracle().get_blast_radius(symbol_id)``,
+        offloaded off the event loop (the walk is sync). Maps the resulting
+        ``BlastRadius`` (``directly_affected`` / ``transitively_affected``
+        NodeIDs -> sorted ``str`` tuples, ``risk_level``) into an
+        :class:`IntraRepoImpact`. Never raises -- any fault yields an empty
+        impact (source symbol only).
+        """
+        try:
+            resolver = self._oracle_fn or get_oracle
+            oracle = resolver()
+            if oracle is None:
+                return self._empty(symbol_id)
+
+            # Mandate 2: the Oracle graph walk is synchronous -- offload it so
+            # the traversal never blocks the loop. offload() is fail-soft: it
+            # returns an OffloadError instead of re-raising the fn's exception.
+            br = await offload(oracle.get_blast_radius, symbol_id)
+
+            if br is None or is_offload_error(br):
+                return self._empty(symbol_id)
+
+            directly = tuple(sorted(str(n) for n in br.directly_affected))
+            transitively = tuple(
+                sorted(str(n) for n in br.transitively_affected)
+            )
+            return IntraRepoImpact(
+                source_symbol=symbol_id,
+                directly_affected=directly,
+                transitively_affected=transitively,
+                risk_level=br.risk_level,
+            )
+        except Exception:
+            # Fail-soft: Oracle miss / resolver fault / mapping fault -> empty.
+            return self._empty(symbol_id)

--- a/backend/core/ouroboros/governance/causal/causal_graph.py
+++ b/backend/core/ouroboros/governance/causal/causal_graph.py
@@ -1,0 +1,320 @@
+"""Domain-1 Staging-2 Task 1 -- the in-memory cross-repo causal graph + fold.
+
+THE GRAPH FOLD. One stamped structural-delta envelope (as Staging-1 delivers
+it: ``{"delta": StructuralDelta.to_dict(), "lineage": {...}}``) is folded into a
+native-adjacency causal graph in ``apply_delta`` -- O(1) in the delta's symbol
+count, with NO traversal on write.
+
+Two load-bearing invariants make Task 4's crash-recovery determinism proof
+possible:
+
+  * **Mandate 1 (O(1) fold):** every mutation is a dict upsert / pop against
+    ``self._nodes`` plus the two adjacency indexes. ``file_level_churn`` touches
+    only the ONE file's node set (``self._by_file``), never a global scan.
+
+  * **Mandate 4 (emit_seq-MONOTONIC, order-independent):** a symbol's state is a
+    last-writer-wins register keyed by the per-repo monotonic ``emit_seq``. A
+    delta applies to a node ONLY IF the node is new OR ``emit_seq`` strictly
+    exceeds the node's ``last_emit_seq``; a stale (lower/equal) delta is a
+    no-op. Because ``emit_seq`` is unique-per-repo and a ``symbol_id`` encodes
+    its repo, no two distinct deltas can tie on the same symbol -- so folding
+    any permutation of a delta SET converges to one canonical state, witnessed
+    by ``state_fingerprint()``.
+
+NO intra-repo edges (Oracle owns those -- Task 2). NO WAL (Task 3). This module
+is a pure in-memory data structure + fold + deterministic snapshot. Fail-soft: a
+malformed envelope returns 0 and is logged, never raised.
+"""
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass, field
+from typing import Dict, FrozenSet, List, Optional, Set, Tuple
+
+from backend.core.ouroboros.governance.causal.structural_delta import (
+    StructuralDelta,
+)
+
+logger = logging.getLogger(__name__)
+
+_SNAPSHOT_VERSION = 1
+
+
+@dataclass
+class CausalNode:
+    """One symbol in the cross-repo causal graph.
+
+    ``imports`` are the declared-import FACTS (dotted names) folded from the
+    delta's import edges whose ``src_id`` is this node -- stored, not resolved
+    (Staging-3 resolves them cross-repo). ``last_emit_seq`` / ``last_head_sha``
+    are the lineage of the newest delta that wrote this node -- the monotonic
+    guard's comparison key.
+    """
+
+    symbol_id: str
+    repo: str
+    file_path: str
+    kind: str
+    signature_hash: str
+    imports: FrozenSet[str] = field(default_factory=frozenset)
+    last_emit_seq: int = 0
+    last_head_sha: str = ""
+
+
+class CausalGraph:
+    """Native-adjacency in-memory causal graph with an O(1) monotonic fold."""
+
+    def __init__(self) -> None:
+        self._nodes: Dict[str, CausalNode] = {}
+        self._by_repo: Dict[str, Set[str]] = {}
+        self._by_file: Dict[Tuple[str, str], Set[str]] = {}
+
+    # ------------------------------------------------------------------ #
+    # read surface
+    # ------------------------------------------------------------------ #
+    def node(self, symbol_id: str) -> Optional[CausalNode]:
+        return self._nodes.get(symbol_id)
+
+    def nodes_in_repo(self, repo: str) -> List[CausalNode]:
+        ids = self._by_repo.get(repo, set())
+        return [self._nodes[s] for s in sorted(ids) if s in self._nodes]
+
+    def node_count(self) -> int:
+        return len(self._nodes)
+
+    # ------------------------------------------------------------------ #
+    # index-preserving mutation primitives (all O(1))
+    # ------------------------------------------------------------------ #
+    def _index_add(self, node: CausalNode) -> None:
+        self._by_repo.setdefault(node.repo, set()).add(node.symbol_id)
+        self._by_file.setdefault((node.repo, node.file_path), set()).add(node.symbol_id)
+
+    def _index_remove(self, node: CausalNode) -> None:
+        repo_set = self._by_repo.get(node.repo)
+        if repo_set is not None:
+            repo_set.discard(node.symbol_id)
+            if not repo_set:
+                del self._by_repo[node.repo]
+        file_key = (node.repo, node.file_path)
+        file_set = self._by_file.get(file_key)
+        if file_set is not None:
+            file_set.discard(node.symbol_id)
+            if not file_set:
+                del self._by_file[file_key]
+
+    def _put(self, node: CausalNode) -> None:
+        """Upsert a node, reconciling adjacency indexes if identity keys moved
+        (defensive -- ``symbol_id`` normally pins repo/file)."""
+        existing = self._nodes.get(node.symbol_id)
+        if existing is not None and (
+            existing.repo != node.repo or existing.file_path != node.file_path
+        ):
+            self._index_remove(existing)
+        self._nodes[node.symbol_id] = node
+        self._index_add(node)
+
+    def _delete(self, symbol_id: str) -> bool:
+        node = self._nodes.pop(symbol_id, None)
+        if node is None:
+            return False
+        self._index_remove(node)
+        return True
+
+    # ------------------------------------------------------------------ #
+    # the fold
+    # ------------------------------------------------------------------ #
+    def apply_delta(self, envelope: dict) -> int:
+        """Fold one stamped delta envelope. Returns the count of nodes actually
+        mutated. O(1) in the delta's symbol count; emit_seq-monotonic per
+        symbol; NEVER raises (malformed -> 0, logged)."""
+        try:
+            if not isinstance(envelope, dict):
+                raise TypeError("envelope is not a dict")
+            delta = StructuralDelta.from_dict(envelope["delta"])
+            lineage = envelope["lineage"]
+            if not isinstance(lineage, dict):
+                raise TypeError("lineage is not a dict")
+            emit_seq = int(lineage["emit_seq"])
+            head_sha = str(lineage.get("head_sha", ""))
+        except Exception as exc:  # noqa: BLE001 -- fail-soft by contract
+            logger.warning("[CausalGraph] malformed envelope (%r) -- ignored", exc)
+            return 0
+
+        repo = delta.repo
+        file_path = delta.file_path
+
+        # Pre-delta emit_seq per node captured lazily on first touch, so every
+        # operation in THIS delta is authorized against the node's state BEFORE
+        # the delta started -- keeps a multi-touch delta internally consistent
+        # and the whole fold order-independent.
+        pre_seq: Dict[str, Optional[int]] = {}
+
+        def _prev(symbol_id: str) -> Optional[int]:
+            if symbol_id not in pre_seq:
+                node = self._nodes.get(symbol_id)
+                pre_seq[symbol_id] = node.last_emit_seq if node is not None else None
+            return pre_seq[symbol_id]
+
+        def _wins(symbol_id: str) -> bool:
+            prev = _prev(symbol_id)
+            return prev is None or emit_seq > prev
+
+        mutated: Set[str] = set()
+
+        # --- symbols_added: full upsert (merge any existing imports) ---------
+        for rec in delta.symbols_added:
+            sid = rec.symbol_id
+            if not _wins(sid):
+                continue
+            existing = self._nodes.get(sid)
+            imports = existing.imports if existing is not None else frozenset()
+            self._put(
+                CausalNode(
+                    symbol_id=sid,
+                    repo=repo,
+                    file_path=file_path,
+                    kind=rec.kind,
+                    signature_hash=rec.signature_hash,
+                    imports=imports,
+                    last_emit_seq=emit_seq,
+                    last_head_sha=head_sha,
+                )
+            )
+            mutated.add(sid)
+
+        # --- symbols_resignatured: signature-only update on an existing node -
+        # No kind travels with a resignature; if the node is unknown (an
+        # out-of-order resignature that precedes its add) we skip -- the
+        # highest-seq full add remains the authority, preserving determinism.
+        for entry in delta.symbols_resignatured:
+            sid, _old_h, new_h = entry
+            existing = self._nodes.get(sid)
+            if existing is None:
+                continue
+            if not _wins(sid):
+                continue
+            self._put(
+                CausalNode(
+                    symbol_id=sid,
+                    repo=repo,
+                    file_path=file_path,
+                    kind=existing.kind,
+                    signature_hash=new_h,
+                    imports=existing.imports,
+                    last_emit_seq=emit_seq,
+                    last_head_sha=head_sha,
+                )
+            )
+            mutated.add(sid)
+
+        # --- symbols_removed: remove only if present AND newer ---------------
+        for rec in delta.symbols_removed:
+            sid = rec.symbol_id
+            if self._nodes.get(sid) is None:
+                continue
+            if not _wins(sid):
+                continue
+            if self._delete(sid):
+                mutated.add(sid)
+
+        # --- import edges: fold declared-import facts onto the src node ------
+        imp_by_src: Dict[str, Tuple[Set[str], Set[str]]] = {}
+        for edge in delta.import_edges_added:
+            add_names, _ = imp_by_src.setdefault(edge.src_id, (set(), set()))
+            add_names.add(edge.dst_name)
+        for edge in delta.import_edges_removed:
+            _, rem_names = imp_by_src.setdefault(edge.src_id, (set(), set()))
+            rem_names.add(edge.dst_name)
+
+        for src_id, (add_names, rem_names) in imp_by_src.items():
+            node = self._nodes.get(src_id)
+            if node is None:
+                continue  # no home node for these import facts yet
+            if not _wins(src_id):
+                continue
+            new_imports = (set(node.imports) | add_names) - rem_names
+            self._put(
+                CausalNode(
+                    symbol_id=node.symbol_id,
+                    repo=node.repo,
+                    file_path=node.file_path,
+                    kind=node.kind,
+                    signature_hash=node.signature_hash,
+                    imports=frozenset(new_imports),
+                    last_emit_seq=emit_seq,
+                    last_head_sha=head_sha,
+                )
+            )
+            mutated.add(src_id)
+
+        # --- file_level_churn: coarse lineage bump, THIS file's nodes only ---
+        if delta.file_level_churn:
+            for sid in list(self._by_file.get((repo, file_path), ())):
+                node = self._nodes.get(sid)
+                if node is None:
+                    continue
+                if emit_seq <= node.last_emit_seq:
+                    continue
+                self._put(
+                    CausalNode(
+                        symbol_id=node.symbol_id,
+                        repo=node.repo,
+                        file_path=node.file_path,
+                        kind=node.kind,
+                        signature_hash=node.signature_hash,
+                        imports=node.imports,
+                        last_emit_seq=emit_seq,
+                        last_head_sha=head_sha,
+                    )
+                )
+                mutated.add(sid)
+
+        return len(mutated)
+
+    # ------------------------------------------------------------------ #
+    # deterministic serialization -- the equality witness
+    # ------------------------------------------------------------------ #
+    def snapshot(self) -> dict:
+        """Fully deterministic canonical serialization: every node with every
+        field, node list sorted by ``symbol_id``, imports as sorted lists."""
+        nodes = []
+        for sid in sorted(self._nodes):
+            n = self._nodes[sid]
+            nodes.append(
+                {
+                    "symbol_id": n.symbol_id,
+                    "repo": n.repo,
+                    "file_path": n.file_path,
+                    "kind": n.kind,
+                    "signature_hash": n.signature_hash,
+                    "imports": sorted(n.imports),
+                    "last_emit_seq": n.last_emit_seq,
+                    "last_head_sha": n.last_head_sha,
+                }
+            )
+        return {"version": _SNAPSHOT_VERSION, "nodes": nodes}
+
+    @classmethod
+    def from_snapshot(cls, snap: dict) -> "CausalGraph":
+        graph = cls()
+        for entry in (snap or {}).get("nodes", []):
+            node = CausalNode(
+                symbol_id=entry["symbol_id"],
+                repo=entry["repo"],
+                file_path=entry["file_path"],
+                kind=entry["kind"],
+                signature_hash=entry["signature_hash"],
+                imports=frozenset(entry.get("imports", [])),
+                last_emit_seq=int(entry.get("last_emit_seq", 0)),
+                last_head_sha=str(entry.get("last_head_sha", "")),
+            )
+            graph._nodes[node.symbol_id] = node
+            graph._index_add(node)
+        return graph
+
+    def state_fingerprint(self) -> str:
+        """sha256 of the canonical snapshot -- the Mandate-4 equality primitive."""
+        payload = json.dumps(self.snapshot(), sort_keys=True)
+        return hashlib.sha256(payload.encode("utf-8")).hexdigest()

--- a/backend/core/ouroboros/governance/causal/causal_graph.py
+++ b/backend/core/ouroboros/governance/causal/causal_graph.py
@@ -70,6 +70,13 @@ class CausalGraph:
         self._nodes: Dict[str, CausalNode] = {}
         self._by_repo: Dict[str, Set[str]] = {}
         self._by_file: Dict[Tuple[str, str], Set[str]] = {}
+        # Per-symbol Lamport high-water mark: the highest emit_seq EVER applied
+        # to a symbol_id via add / resignature / remove. It OUTLIVES the node
+        # (an event-sourced tombstone) so a stale, later-arriving lower-seq add
+        # cannot resurrect a removed symbol -- making the fold fully commutative
+        # regardless of WAL append vs live-ingest order (Task 3 offloads appends,
+        # so those orders can diverge under concurrency).
+        self._seq_hwm: Dict[str, int] = {}
 
     # ------------------------------------------------------------------ #
     # read surface
@@ -145,21 +152,25 @@ class CausalGraph:
         repo = delta.repo
         file_path = delta.file_path
 
-        # Pre-delta emit_seq per node captured lazily on first touch, so every
-        # operation in THIS delta is authorized against the node's state BEFORE
-        # the delta started -- keeps a multi-touch delta internally consistent
-        # and the whole fold order-independent.
-        pre_seq: Dict[str, Optional[int]] = {}
+        # Per-symbol Lamport high-water captured lazily at its PRE-delta value on
+        # first touch, so every operation in THIS delta is authorized against the
+        # symbol's watermark BEFORE the delta started -- a multi-touch delta stays
+        # internally consistent AND the whole fold is order-independent (max over
+        # emit_seq is commutative; the tombstone watermark blocks stale resurrection).
+        pre_hwm: Dict[str, int] = {}
 
-        def _prev(symbol_id: str) -> Optional[int]:
-            if symbol_id not in pre_seq:
-                node = self._nodes.get(symbol_id)
-                pre_seq[symbol_id] = node.last_emit_seq if node is not None else None
-            return pre_seq[symbol_id]
+        def _hwm_before(symbol_id: str) -> int:
+            if symbol_id not in pre_hwm:
+                pre_hwm[symbol_id] = self._seq_hwm.get(symbol_id, -1)
+            return pre_hwm[symbol_id]
 
         def _wins(symbol_id: str) -> bool:
-            prev = _prev(symbol_id)
-            return prev is None or emit_seq > prev
+            return emit_seq > _hwm_before(symbol_id)
+
+        def _bump_hwm(symbol_id: str) -> None:
+            cur = self._seq_hwm.get(symbol_id, -1)
+            if emit_seq > cur:
+                self._seq_hwm[symbol_id] = emit_seq
 
         mutated: Set[str] = set()
 
@@ -182,18 +193,21 @@ class CausalGraph:
                     last_head_sha=head_sha,
                 )
             )
+            _bump_hwm(sid)
             mutated.add(sid)
 
         # --- symbols_resignatured: signature-only update on an existing node -
-        # No kind travels with a resignature; if the node is unknown (an
-        # out-of-order resignature that precedes its add) we skip -- the
-        # highest-seq full add remains the authority, preserving determinism.
+        # No kind travels with a resignature. We still advance the watermark
+        # when we win (so a later lower-seq op is correctly skipped), but if the
+        # node is unknown (an out-of-order resignature preceding its add) there
+        # is no kind to materialize -> record the watermark, mutate no node.
         for entry in delta.symbols_resignatured:
             sid, _old_h, new_h = entry
+            if not _wins(sid):
+                continue
+            _bump_hwm(sid)
             existing = self._nodes.get(sid)
             if existing is None:
-                continue
-            if not _wins(sid):
                 continue
             self._put(
                 CausalNode(
@@ -209,13 +223,15 @@ class CausalGraph:
             )
             mutated.add(sid)
 
-        # --- symbols_removed: remove only if present AND newer ---------------
+        # --- symbols_removed: tombstone the watermark (EVEN IF the node is not
+        # present yet) so a later-arriving stale lower-seq add cannot resurrect
+        # the symbol; delete the node if it exists. This is the event-sourced
+        # tombstone that makes remove-before-add order-independent.
         for rec in delta.symbols_removed:
             sid = rec.symbol_id
-            if self._nodes.get(sid) is None:
-                continue
             if not _wins(sid):
                 continue
+            _bump_hwm(sid)
             if self._delete(sid):
                 mutated.add(sid)
 
@@ -247,6 +263,7 @@ class CausalGraph:
                     last_head_sha=head_sha,
                 )
             )
+            _bump_hwm(src_id)
             mutated.add(src_id)
 
         # --- file_level_churn: coarse lineage bump, THIS file's nodes only ---
@@ -255,7 +272,7 @@ class CausalGraph:
                 node = self._nodes.get(sid)
                 if node is None:
                     continue
-                if emit_seq <= node.last_emit_seq:
+                if not _wins(sid):
                     continue
                 self._put(
                     CausalNode(
@@ -269,6 +286,7 @@ class CausalGraph:
                         last_head_sha=head_sha,
                     )
                 )
+                _bump_hwm(sid)
                 mutated.add(sid)
 
         return len(mutated)
@@ -278,7 +296,9 @@ class CausalGraph:
     # ------------------------------------------------------------------ #
     def snapshot(self) -> dict:
         """Fully deterministic canonical serialization: every node with every
-        field, node list sorted by ``symbol_id``, imports as sorted lists."""
+        field, node list sorted by ``symbol_id``, imports as sorted lists, plus
+        the FULL per-symbol Lamport high-water map (live AND tombstoned symbols)
+        so crash-recovery / compaction preserves the monotonic guard."""
         nodes = []
         for sid in sorted(self._nodes):
             n = self._nodes[sid]
@@ -294,7 +314,8 @@ class CausalGraph:
                     "last_head_sha": n.last_head_sha,
                 }
             )
-        return {"version": _SNAPSHOT_VERSION, "nodes": nodes}
+        seq_hwm = {sid: self._seq_hwm[sid] for sid in sorted(self._seq_hwm)}
+        return {"version": _SNAPSHOT_VERSION, "nodes": nodes, "seq_hwm": seq_hwm}
 
     @classmethod
     def from_snapshot(cls, snap: dict) -> "CausalGraph":
@@ -312,6 +333,10 @@ class CausalGraph:
             )
             graph._nodes[node.symbol_id] = node
             graph._index_add(node)
+        graph._seq_hwm = {
+            str(sid): int(seq)
+            for sid, seq in (snap or {}).get("seq_hwm", {}).items()
+        }
         return graph
 
     def state_fingerprint(self) -> str:

--- a/backend/core/ouroboros/governance/causal/causal_graph.py
+++ b/backend/core/ouroboros/governance/causal/causal_graph.py
@@ -134,8 +134,19 @@ class CausalGraph:
     # ------------------------------------------------------------------ #
     def apply_delta(self, envelope: dict) -> int:
         """Fold one stamped delta envelope. Returns the count of nodes actually
-        mutated. O(1) in the delta's symbol count; emit_seq-monotonic per
-        symbol; NEVER raises (malformed -> 0, logged)."""
+        mutated. O(1) in the delta's symbol count; NEVER raises (malformed -> 0,
+        logged).
+
+        emit_seq-monotonic per symbol. FULL-WRITE ops (symbols_added,
+        symbols_removed) are fully order-independent (verified: any-order shuffle
+        converges). PARTIAL-WRITE fields -- a resignature-only signature update,
+        or an import-only edge fold (and the `imports` MERGE that symbols_added
+        performs) -- are last-writer-wins by emit_seq PER FIELD-SOURCE and are
+        order-independent ONLY under per-repo emit_seq order. This is guaranteed
+        by the event model (emit_seq is a per-repo Lamport clock; one source repo
+        emits its deltas in emit_seq order) and preserved by the ingestor's
+        per-repo-ordered WAL append (Task 3 binding invariant). Cross-repo folds
+        always commute (disjoint symbol_ids)."""
         try:
             if not isinstance(envelope, dict):
                 raise TypeError("envelope is not a dict")
@@ -152,11 +163,18 @@ class CausalGraph:
         repo = delta.repo
         file_path = delta.file_path
 
+        # INVARIANT: per-repo emit_seq order preserved by the ingestor (Task 3).
+        # emit_seq is a per-repo Lamport clock and one source repo emits its
+        # deltas in emit_seq order; the WAL append is per-repo-ordered. FULL-WRITE
+        # ops (add/remove) commute under ANY shuffle; PARTIAL-WRITE fields
+        # (resignature-only signature, import-only edge merge) are last-writer-wins
+        # per field-source and converge ONLY under that per-repo order. See the
+        # apply_delta docstring for the precise model.
+        #
         # Per-symbol Lamport high-water captured lazily at its PRE-delta value on
         # first touch, so every operation in THIS delta is authorized against the
         # symbol's watermark BEFORE the delta started -- a multi-touch delta stays
-        # internally consistent AND the whole fold is order-independent (max over
-        # emit_seq is commutative; the tombstone watermark blocks stale resurrection).
+        # internally consistent; the tombstone watermark blocks stale resurrection.
         pre_hwm: Dict[str, int] = {}
 
         def _hwm_before(symbol_id: str) -> int:
@@ -174,7 +192,11 @@ class CausalGraph:
 
         mutated: Set[str] = set()
 
-        # --- symbols_added: full upsert (merge any existing imports) ---------
+        # --- symbols_added: upsert. NOTE this is a FULL write for kind/signature
+        # but a PARTIAL write for `imports` -- it MERGES the node's existing
+        # imports (an import-only delta may have folded facts onto the node
+        # first). That merge is last-writer-wins per field-source and so is only
+        # order-independent under per-repo emit_seq order (see docstring). -------
         for rec in delta.symbols_added:
             sid = rec.symbol_id
             if not _wins(sid):

--- a/backend/core/ouroboros/governance/causal/causal_graph_ingestor.py
+++ b/backend/core/ouroboros/governance/causal/causal_graph_ingestor.py
@@ -361,7 +361,13 @@ class CausalGraphIngestor:
         ``lease_id`` is a unique uuid (never updated -> the entry stays
         'pending' -> replay reads the full ordered log); ``ts_*`` are metadata
         only and do NOT affect the fold. A failed append is logged loudly and
-        returns False so the non-durable delta is dropped from the live graph."""
+        returns False so the non-durable delta is dropped from the live graph.
+
+        Durability is gated on ``WAL.append``'s HONEST bool return, NOT merely
+        on the absence of an exception: ``flock_append_line`` returns False on
+        lock-timeout / write-error (no bytes on disk) while still returning
+        normally, so a falsy return must be treated as NOT durable:
+        ``durable = (not is_offload_error(res)) and bool(res)``."""
         try:
             entry = WALEntry(
                 lease_id=uuid.uuid4().hex,
@@ -379,8 +385,16 @@ class CausalGraphIngestor:
             return False
         if is_offload_error(res):
             logger.error(
-                "[CausalGraphIngestor] WAL append failed (%s) -- delta NOT "
-                "folded (non-durable, dropped from live graph)", res)
+                "[CausalGraphIngestor] WAL append offload failed (%s) -- delta "
+                "NOT folded (non-durable, dropped from live graph)", res)
+            return False
+        # WAL.append returns True iff bytes durably landed on disk. A False
+        # (lock timeout / OSError inside flock_append_line) returns normally
+        # but is a NON-DURABLE write -- it must NOT be folded.
+        if not bool(res):
+            logger.error(
+                "[CausalGraphIngestor] WAL append reported NOT durable "
+                "(write failed) -- delta NOT folded (dropped from live graph)")
             return False
         return True
 

--- a/backend/core/ouroboros/governance/causal/causal_graph_ingestor.py
+++ b/backend/core/ouroboros/governance/causal/causal_graph_ingestor.py
@@ -1,9 +1,26 @@
 """Domain-1 Staging-2 Task 3 -- the EVENT-SOURCED graph ingestor.
 
 The sink for the Staging-1 ``CausalDeltaSubscriber.on_delta`` callback. One
-stamped structural-delta envelope arrives, is folded into the in-memory
-``CausalGraph`` (Task 1, O(1) synchronous fold), and is durably appended to an
-intake WAL so the graph is deterministically RE-FOLDABLE after a Brain crash.
+stamped structural-delta envelope arrives; it is durably appended to an intake
+WAL FIRST, and only AFTER that append lands is it folded into the in-memory
+``CausalGraph`` (Task 1, O(1) fold). This is a genuine write-AHEAD log: the
+live graph never reflects a delta that is not already on disk, so the graph is
+deterministically RE-FOLDABLE after a Brain crash with ``recovered == live``.
+
+*** WRITE-AHEAD ORDERING (append-before-fold) -- the durability contract ***
+
+``ingest`` is a PURE non-blocking enqueue: it validates the envelope and pushes
+it onto the single ordered queue -- it does NOT fold. The SINGLE append worker
+then, per envelope, IN THIS ORDER: (a) ``await offload(WAL.append)`` -- DURABLE
+first; (b) only if that append succeeded, ``graph.apply_delta`` -- fold into the
+live graph. If the append FAILS, the delta is NOT folded (a non-durable delta
+must never enter the live graph) -- logged loudly, worker continues (fail-soft).
+
+Consequence: the WAL on disk is ALWAYS a superset-or-equal of the live graph.
+The live graph is EVENTUALLY-consistent with ingest -- it lags by the worker's
+append latency -- which is correct for an advisory graph (a reader only ever
+observes durable state). At quiescence (queue drained, worker idle): live graph
+== fold(WAL). ``flush()`` awaits that quiescence.
 
 Two durability surfaces compose into a loss-free, deterministic recovery:
 
@@ -38,13 +55,15 @@ commute); only the per-repo subsequence order is load-bearing.
 
 Determinism note: the fold depends ONLY on envelope content + ``emit_seq``,
 NEVER on the WAL's ``ts_monotonic`` / ``ts_utc`` metadata (those are wall-clock
-bookkeeping and do not touch graph state). The ``emit_seq``-monotonic guard
-makes re-folding the WAL tail after a snapshot idempotent, so the periodic
-compaction is loss-free even when the snapshot captured envelopes still queued
-(not yet appended) at compaction time.
+bookkeeping and do not touch graph state). Because the worker folds ONLY what
+it has already appended, ``graph.snapshot()`` at compaction time == the durable
+log state exactly (no queued-ahead divergence); the ``emit_seq``-monotonic
+guard additionally makes any WAL-tail re-fold after a snapshot idempotent, so
+compaction is loss-free across a crash.
 
 Fail-soft throughout: ``ingest`` never raises into the bus loop, a malformed
-envelope is dropped (touching neither graph nor WAL), and every offloaded
+envelope is dropped (never enqueued -> never appended, never folded), a failed
+append drops its delta from the live graph (non-durable), and every offloaded
 filesystem op degrades to a logged no-op rather than propagating.
 """
 from __future__ import annotations
@@ -253,26 +272,26 @@ class CausalGraphIngestor:
     # the sink -- CausalDeltaSubscriber.on_delta target
     # ------------------------------------------------------------------ #
     def ingest(self, envelope: dict) -> None:
-        """Fold ``envelope`` into the graph (O(1), synchronous, in-memory) and
-        enqueue it for the SINGLE ordered offloaded WAL append. NON-BLOCKING:
-        returns immediately -- the durable write happens on the append worker.
-        Malformed envelopes are dropped (graph + WAL untouched). NEVER raises
-        (this runs inside the bus delivery loop)."""
+        """PURE non-blocking enqueue onto the SINGLE ordered append queue -- the
+        write-AHEAD contract. ingest does NOT fold: the durable WAL append AND
+        the subsequent graph fold both happen on the append worker (append
+        FIRST, then fold), so a delta enters the live graph ONLY AFTER it is
+        durable on disk. Malformed envelopes are dropped (never enqueued ->
+        never appended, never folded). NEVER blocks, NEVER raises (this runs
+        inside the bus delivery loop)."""
         if not _looks_valid(envelope):
             logger.debug("[CausalGraphIngestor] dropping malformed envelope")
             return
-        try:
-            self.graph.apply_delta(envelope)
-        except Exception:  # noqa: BLE001 -- apply_delta is fail-soft; belt+braces
-            logger.debug("[CausalGraphIngestor] apply_delta raised (swallowed)",
-                         exc_info=True)
         # Push onto the single ordered queue. put_nowait on an unbounded queue
-        # is non-blocking; FIFO ordering + the single worker preserve per-repo
-        # emit_seq order in the WAL (the binding invariant).
+        # is non-blocking; FIFO ordering + the single worker's append-then-fold
+        # discipline preserve per-repo emit_seq order in the WAL (the binding
+        # invariant) AND the write-ahead guarantee.
         q = self._queue
         if q is None:
+            # Not started -> no durable path -> we MUST NOT fold (write-ahead:
+            # nothing enters the graph that isn't durable). Drop it.
             logger.debug("[CausalGraphIngestor] ingest before start() -- "
-                         "envelope folded but not durably logged")
+                         "envelope dropped (no durable path, not folded)")
             return
         try:
             q.put_nowait(envelope)
@@ -284,12 +303,15 @@ class CausalGraphIngestor:
     # the single ordered append worker (the serialization pin)
     # ------------------------------------------------------------------ #
     async def _append_worker(self) -> None:
-        """Drain the ordered queue, appending each envelope to the WAL in FIFO
-        order -- ONE at a time (``await`` each append before the next). This
-        single-flight discipline is what preserves per-repo emit_seq order in
-        the WAL. Every ``JARVIS_CAUSAL_SNAPSHOT_EVERY_N`` appends OR after
-        ``JARVIS_CAUSAL_SNAPSHOT_IDLE_S`` idle, folds to a snapshot + truncates
-        the WAL."""
+        """Drain the ordered queue ONE envelope at a time (``await`` each item's
+        durable append before pulling the next). Per envelope, in ORDER:
+        (a) durably append to the WAL; (b) ONLY if the append landed, fold into
+        the live graph via ``apply_delta`` (write-AHEAD -- a non-durable delta
+        never enters the graph). This single-flight, append-then-fold discipline
+        preserves per-repo emit_seq order in the WAL AND the durability
+        contract. Every ``JARVIS_CAUSAL_SNAPSHOT_EVERY_N`` durable folds OR
+        after ``JARVIS_CAUSAL_SNAPSHOT_IDLE_S`` idle, folds to a snapshot +
+        truncates the WAL."""
         idle_timeout: Optional[float] = (
             float(self._snapshot_idle_s) if self._snapshot_idle_s > 0 else None
         )
@@ -311,36 +333,56 @@ class CausalGraphIngestor:
             except asyncio.CancelledError:
                 raise
             try:
-                await self._append_one(envelope)
-                self._appends_since_snapshot += 1
-                if self._appends_since_snapshot >= self._snapshot_every_n:
-                    await self._compact()
+                durable = await self._append_one(envelope)
+                if durable:
+                    # WRITE-AHEAD: fold ONLY after the append landed durably.
+                    try:
+                        self.graph.apply_delta(envelope)
+                    except Exception:  # noqa: BLE001 -- apply_delta is fail-soft
+                        logger.debug(
+                            "[CausalGraphIngestor] apply_delta raised "
+                            "(swallowed)", exc_info=True)
+                    self._appends_since_snapshot += 1
+                    if self._appends_since_snapshot >= self._snapshot_every_n:
+                        await self._compact()
+                # not durable -> NOT folded (already logged loudly in _append_one)
             except Exception:  # noqa: BLE001 -- fail-soft per item
                 logger.warning(
-                    "[CausalGraphIngestor] append/compact failed (swallowed)",
-                    exc_info=True,
-                )
+                    "[CausalGraphIngestor] append/fold/compact failed "
+                    "(swallowed)", exc_info=True)
             finally:
                 q.task_done()
 
-    async def _append_one(self, envelope: dict) -> None:
-        """Offload ONE WAL append under the file lock. The lock only prevents
-        byte-interleave with an out-of-band snapshot_now(); ordering is already
-        pinned by the single FIFO worker. ``lease_id`` is a unique uuid (never
-        updated -> the entry stays 'pending' -> replay reads the full ordered
-        log); ``ts_*`` are metadata only and do NOT affect the fold."""
-        entry = WALEntry(
-            lease_id=uuid.uuid4().hex,
-            envelope_dict=envelope,
-            status="pending",
-            ts_monotonic=time.monotonic(),
-            ts_utc=datetime.now(timezone.utc).isoformat(),
-        )
-        async with self._file_lock:
-            res = await offload(self._wal.append, entry)
+    async def _append_one(self, envelope: dict) -> bool:
+        """Offload ONE WAL append under the file lock. Returns True iff the
+        append landed durably (the worker folds ONLY on True -- the write-ahead
+        gate). The lock only prevents byte-interleave with an out-of-band
+        snapshot_now(); ordering is already pinned by the single FIFO worker.
+        ``lease_id`` is a unique uuid (never updated -> the entry stays
+        'pending' -> replay reads the full ordered log); ``ts_*`` are metadata
+        only and do NOT affect the fold. A failed append is logged loudly and
+        returns False so the non-durable delta is dropped from the live graph."""
+        try:
+            entry = WALEntry(
+                lease_id=uuid.uuid4().hex,
+                envelope_dict=envelope,
+                status="pending",
+                ts_monotonic=time.monotonic(),
+                ts_utc=datetime.now(timezone.utc).isoformat(),
+            )
+            async with self._file_lock:
+                res = await offload(self._wal.append, entry)
+        except Exception as exc:  # noqa: BLE001 -- never fold a non-durable delta
+            logger.error(
+                "[CausalGraphIngestor] WAL append raised (%s) -- delta NOT "
+                "folded (non-durable)", exc, exc_info=True)
+            return False
         if is_offload_error(res):
-            logger.warning(
-                "[CausalGraphIngestor] WAL append offload failed: %s", res)
+            logger.error(
+                "[CausalGraphIngestor] WAL append failed (%s) -- delta NOT "
+                "folded (non-durable, dropped from live graph)", res)
+            return False
+        return True
 
     async def snapshot_now(self) -> None:
         """Force a fold-to-snapshot + WAL truncation now (deterministic
@@ -349,13 +391,15 @@ class CausalGraphIngestor:
 
     async def _compact(self) -> None:
         """Deterministic fold-to-snapshot (spec Q4): write ``graph.snapshot()``
-        durably, THEN truncate the WAL. The snapshot is computed synchronously
-        on the loop (a detached dict -- no shared mutable state) and only its
-        serialization/write is offloaded, so it never races a concurrent fold.
-        Truncation happens ONLY after the snapshot lands durably -- a failed
-        snapshot leaves the WAL intact (no data loss). Re-folding the WAL tail
-        after replay is idempotent (emit_seq guard), so a snapshot that
-        captured still-queued envelopes stays loss-free."""
+        durably, THEN truncate the WAL. Under write-ahead the worker folds ONLY
+        what it has already appended, so the live graph at this point == the
+        durable log exactly -- the snapshot IS the durable state (no queued-ahead
+        divergence). The snapshot is computed synchronously on the loop (a
+        detached dict -- no shared mutable state) and only its serialization/
+        write is offloaded, so it never races a concurrent fold. Truncation
+        happens ONLY after the snapshot lands durably -- a failed snapshot leaves
+        the WAL intact (no data loss); any WAL-tail re-fold after replay is
+        idempotent (emit_seq guard)."""
         try:
             snap = self.graph.snapshot()
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/causal/causal_graph_ingestor.py
+++ b/backend/core/ouroboros/governance/causal/causal_graph_ingestor.py
@@ -1,0 +1,432 @@
+"""Domain-1 Staging-2 Task 3 -- the EVENT-SOURCED graph ingestor.
+
+The sink for the Staging-1 ``CausalDeltaSubscriber.on_delta`` callback. One
+stamped structural-delta envelope arrives, is folded into the in-memory
+``CausalGraph`` (Task 1, O(1) synchronous fold), and is durably appended to an
+intake WAL so the graph is deterministically RE-FOLDABLE after a Brain crash.
+
+Two durability surfaces compose into a loss-free, deterministic recovery:
+
+  * **WAL** (``JARVIS_CAUSAL_WAL_PATH``): an append-only JSONL log of every
+    accepted envelope, in ingest order. Replayed by folding each entry through
+    ``graph.apply_delta`` in FILE ORDER.
+
+  * **Snapshot** (``JARVIS_CAUSAL_SNAPSHOT_PATH``): a periodic
+    ``graph.snapshot()`` (DETERMINISTIC fold-to-snapshot -- NOT heuristic GC).
+    Written every ``JARVIS_CAUSAL_SNAPSHOT_EVERY_N`` appends OR after
+    ``JARVIS_CAUSAL_SNAPSHOT_IDLE_S`` of no ingest. After a snapshot lands
+    durably the WAL is truncated to empty: recovery = ``from_snapshot`` + fold
+    the WAL tail.
+
+*** THE BINDING INVARIANT (per-repo emit_seq order) ***
+
+The ``CausalGraph`` fold is fully order-independent for FULL-WRITE ops
+(symbols_added / symbols_removed commute under any shuffle), but PARTIAL-WRITE
+fields (a resignature-only signature update, an import-only edge merge, the
+``imports`` merge symbols_added performs) are last-writer-wins per field-source
+and converge ONLY under per-repo ``emit_seq`` order. THEREFORE the WAL append
+MUST preserve per-repo emit_seq order: for any one repo, WAL append order ==
+ingest order == emit_seq order.
+
+This is guaranteed here by a SINGLE serialized append path -- NOT N racing
+fire-and-forget offload tasks (which could reorder same-repo appends). Every
+accepted envelope is pushed onto ONE ordered ``asyncio.Queue`` (FIFO) that a
+SINGLE append worker drains, ``await``-ing each offloaded append before it
+pulls the next item. FIFO queue + single-flight worker => append order == push
+order == ingest order. Cross-repo interleave is fine (disjoint ``symbol_id``s
+commute); only the per-repo subsequence order is load-bearing.
+
+Determinism note: the fold depends ONLY on envelope content + ``emit_seq``,
+NEVER on the WAL's ``ts_monotonic`` / ``ts_utc`` metadata (those are wall-clock
+bookkeeping and do not touch graph state). The ``emit_seq``-monotonic guard
+makes re-folding the WAL tail after a snapshot idempotent, so the periodic
+compaction is loss-free even when the snapshot captured envelopes still queued
+(not yet appended) at compaction time.
+
+Fail-soft throughout: ``ingest`` never raises into the bus loop, a malformed
+envelope is dropped (touching neither graph nor WAL), and every offloaded
+filesystem op degrades to a logged no-op rather than propagating.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Optional
+
+from backend.core.ouroboros.governance.causal.causal_graph import CausalGraph
+from backend.core.ouroboros.governance.cooperative_fs_io import (
+    is_offload_error,
+    offload,
+)
+from backend.core.ouroboros.governance.intake.wal import WAL, WALEntry
+
+logger = logging.getLogger(__name__)
+
+_ENV_WAL_PATH = "JARVIS_CAUSAL_WAL_PATH"
+_ENV_SNAPSHOT_PATH = "JARVIS_CAUSAL_SNAPSHOT_PATH"
+_ENV_SNAPSHOT_EVERY_N = "JARVIS_CAUSAL_SNAPSHOT_EVERY_N"
+_ENV_SNAPSHOT_IDLE_S = "JARVIS_CAUSAL_SNAPSHOT_IDLE_S"
+
+_DEFAULT_SNAPSHOT_EVERY_N = 500
+_DEFAULT_SNAPSHOT_IDLE_S = 3600
+
+
+def _repo_root() -> Path:
+    """<repo_root>, derived from this file's location: causal_graph_ingestor.py
+    -> causal -> governance -> ouroboros -> core -> backend -> <repo_root>
+    (parents[5]). Mirrors ``structural_delta._default_emit_seq_path``."""
+    return Path(__file__).resolve().parents[5]
+
+
+def _default_wal_path() -> Path:
+    return _repo_root() / ".jarvis" / "causal_graph_wal.jsonl"
+
+
+def _default_snapshot_path() -> Path:
+    return _repo_root() / ".jarvis" / "causal_graph_snapshot.json"
+
+
+def _env_int(name: str, default: int) -> int:
+    """Env-resolved positive int; unset/blank/unparseable/<=0 -> default.
+    NEVER raises."""
+    raw = (os.environ.get(name) or "").strip()
+    if not raw:
+        return default
+    try:
+        value = int(raw)
+    except (TypeError, ValueError):
+        return default
+    return value if value > 0 else default
+
+
+# --------------------------------------------------------------------------- #
+# module-level offload workers (detached -- safe to hand to the executor)
+# --------------------------------------------------------------------------- #
+def _write_json_atomic(path_str: str, payload: dict) -> bool:
+    """Atomically write ``payload`` as JSON to ``path_str`` (temp + os.replace).
+    Returns True on success; raises on failure so ``offload`` wraps it in an
+    OffloadError (never truncates the WAL on a failed snapshot)."""
+    p = Path(path_str)
+    p.parent.mkdir(parents=True, exist_ok=True)
+    tmp = p.with_suffix(p.suffix + ".tmp")
+    with tmp.open("w", encoding="utf-8") as f:
+        json.dump(payload, f, sort_keys=True)
+        f.flush()
+        os.fsync(f.fileno())
+    os.replace(tmp, p)
+    return True
+
+
+def _truncate_file(path_str: str) -> bool:
+    """Truncate ``path_str`` to empty (durably). No-op if absent."""
+    p = Path(path_str)
+    if p.exists():
+        with p.open("w", encoding="utf-8") as f:
+            f.flush()
+            os.fsync(f.fileno())
+    return True
+
+
+def _read_json(path_str: str) -> Optional[dict]:
+    """Read + parse a JSON object from ``path_str``. Absent/corrupt -> None."""
+    p = Path(path_str)
+    if not p.exists():
+        return None
+    try:
+        with p.open("r", encoding="utf-8") as f:
+            data = json.load(f)
+        return data if isinstance(data, dict) else None
+    except Exception:  # noqa: BLE001 -- corrupt snapshot -> cold replay
+        return None
+
+
+class CausalGraphIngestor:
+    """Event-sourced fold: subscriber callback -> graph fold + ordered WAL.
+
+    Parameters
+    ----------
+    graph:
+        The in-memory :class:`CausalGraph` (Task 1). Folded synchronously in
+        :meth:`ingest`; rebuilt from a snapshot during :meth:`replay_from_wal`.
+    wal_path / snapshot_path:
+        Override the durable paths (defaults from
+        ``JARVIS_CAUSAL_WAL_PATH`` / ``JARVIS_CAUSAL_SNAPSHOT_PATH``, then the
+        repo-local ``.jarvis`` defaults). ``None`` -> resolve from env.
+    """
+
+    def __init__(
+        self,
+        graph: CausalGraph,
+        *,
+        wal_path: Optional[str] = None,
+        snapshot_path: Optional[str] = None,
+    ) -> None:
+        self.graph = graph
+
+        wp = wal_path or os.environ.get(_ENV_WAL_PATH) or str(_default_wal_path())
+        sp = (
+            snapshot_path
+            or os.environ.get(_ENV_SNAPSHOT_PATH)
+            or str(_default_snapshot_path())
+        )
+        self._wal_path = Path(wp)
+        self._snapshot_path = Path(sp)
+        self._wal = WAL(self._wal_path)
+
+        self._snapshot_every_n = _env_int(
+            _ENV_SNAPSHOT_EVERY_N, _DEFAULT_SNAPSHOT_EVERY_N
+        )
+        self._snapshot_idle_s = _env_int(
+            _ENV_SNAPSHOT_IDLE_S, _DEFAULT_SNAPSHOT_IDLE_S
+        )
+
+        # SINGLE serialized append path (the binding invariant): one ordered
+        # FIFO queue drained by one worker. Created in start() so the queue
+        # binds to the running loop (py3.9-safe).
+        self._queue: Optional[asyncio.Queue] = None
+        self._worker: Optional[asyncio.Task] = None
+        # Serializes WAL file ops (append vs compact) so an out-of-band
+        # snapshot_now() cannot interleave bytes with an in-flight append.
+        self._file_lock = asyncio.Lock()
+        self._appends_since_snapshot = 0
+        self._started = False
+
+    # ------------------------------------------------------------------ #
+    # lifecycle
+    # ------------------------------------------------------------------ #
+    async def start(self) -> None:
+        """Replay the durable log into ``self.graph`` then arm the single
+        ordered append worker. Idempotent; fail-soft."""
+        if self._started:
+            return
+        try:
+            await self.replay_from_wal()
+        except Exception:  # noqa: BLE001 -- replay is best-effort
+            logger.warning(
+                "[CausalGraphIngestor] replay_from_wal failed (cold start)",
+                exc_info=True,
+            )
+        self._queue = asyncio.Queue()
+        self._worker = asyncio.ensure_future(self._append_worker())
+        self._started = True
+
+    async def stop(self) -> None:
+        """Flush pending appends then stop the worker. Never raises."""
+        self._started = False
+        try:
+            await self.flush()
+        except Exception:  # noqa: BLE001 -- best-effort flush
+            logger.debug("[CausalGraphIngestor] flush on stop failed",
+                         exc_info=True)
+        worker = self._worker
+        self._worker = None
+        if worker is not None:
+            worker.cancel()
+            try:
+                await worker
+            except asyncio.CancelledError:
+                pass
+            except Exception:  # noqa: BLE001 -- fail-soft teardown
+                logger.debug("[CausalGraphIngestor] worker teardown raised",
+                             exc_info=True)
+        self._queue = None
+
+    async def flush(self) -> None:
+        """Block until every queued append (and any compaction it triggered)
+        has drained. Fail-soft."""
+        q = self._queue
+        if q is None:
+            return
+        try:
+            await q.join()
+        except Exception:  # noqa: BLE001
+            logger.debug("[CausalGraphIngestor] queue.join failed",
+                         exc_info=True)
+
+    # ------------------------------------------------------------------ #
+    # the sink -- CausalDeltaSubscriber.on_delta target
+    # ------------------------------------------------------------------ #
+    def ingest(self, envelope: dict) -> None:
+        """Fold ``envelope`` into the graph (O(1), synchronous, in-memory) and
+        enqueue it for the SINGLE ordered offloaded WAL append. NON-BLOCKING:
+        returns immediately -- the durable write happens on the append worker.
+        Malformed envelopes are dropped (graph + WAL untouched). NEVER raises
+        (this runs inside the bus delivery loop)."""
+        if not _looks_valid(envelope):
+            logger.debug("[CausalGraphIngestor] dropping malformed envelope")
+            return
+        try:
+            self.graph.apply_delta(envelope)
+        except Exception:  # noqa: BLE001 -- apply_delta is fail-soft; belt+braces
+            logger.debug("[CausalGraphIngestor] apply_delta raised (swallowed)",
+                         exc_info=True)
+        # Push onto the single ordered queue. put_nowait on an unbounded queue
+        # is non-blocking; FIFO ordering + the single worker preserve per-repo
+        # emit_seq order in the WAL (the binding invariant).
+        q = self._queue
+        if q is None:
+            logger.debug("[CausalGraphIngestor] ingest before start() -- "
+                         "envelope folded but not durably logged")
+            return
+        try:
+            q.put_nowait(envelope)
+        except Exception:  # noqa: BLE001 -- never raise into the bus loop
+            logger.debug("[CausalGraphIngestor] enqueue failed (swallowed)",
+                         exc_info=True)
+
+    # ------------------------------------------------------------------ #
+    # the single ordered append worker (the serialization pin)
+    # ------------------------------------------------------------------ #
+    async def _append_worker(self) -> None:
+        """Drain the ordered queue, appending each envelope to the WAL in FIFO
+        order -- ONE at a time (``await`` each append before the next). This
+        single-flight discipline is what preserves per-repo emit_seq order in
+        the WAL. Every ``JARVIS_CAUSAL_SNAPSHOT_EVERY_N`` appends OR after
+        ``JARVIS_CAUSAL_SNAPSHOT_IDLE_S`` idle, folds to a snapshot + truncates
+        the WAL."""
+        idle_timeout: Optional[float] = (
+            float(self._snapshot_idle_s) if self._snapshot_idle_s > 0 else None
+        )
+        while True:
+            q = self._queue
+            if q is None:
+                return
+            try:
+                if idle_timeout is None:
+                    envelope = await q.get()
+                else:
+                    envelope = await asyncio.wait_for(q.get(), timeout=idle_timeout)
+            except asyncio.TimeoutError:
+                # Idle compaction: fold-to-snapshot if anything accrued since
+                # the last snapshot.
+                if self._appends_since_snapshot > 0:
+                    await self._compact()
+                continue
+            except asyncio.CancelledError:
+                raise
+            try:
+                await self._append_one(envelope)
+                self._appends_since_snapshot += 1
+                if self._appends_since_snapshot >= self._snapshot_every_n:
+                    await self._compact()
+            except Exception:  # noqa: BLE001 -- fail-soft per item
+                logger.warning(
+                    "[CausalGraphIngestor] append/compact failed (swallowed)",
+                    exc_info=True,
+                )
+            finally:
+                q.task_done()
+
+    async def _append_one(self, envelope: dict) -> None:
+        """Offload ONE WAL append under the file lock. The lock only prevents
+        byte-interleave with an out-of-band snapshot_now(); ordering is already
+        pinned by the single FIFO worker. ``lease_id`` is a unique uuid (never
+        updated -> the entry stays 'pending' -> replay reads the full ordered
+        log); ``ts_*`` are metadata only and do NOT affect the fold."""
+        entry = WALEntry(
+            lease_id=uuid.uuid4().hex,
+            envelope_dict=envelope,
+            status="pending",
+            ts_monotonic=time.monotonic(),
+            ts_utc=datetime.now(timezone.utc).isoformat(),
+        )
+        async with self._file_lock:
+            res = await offload(self._wal.append, entry)
+        if is_offload_error(res):
+            logger.warning(
+                "[CausalGraphIngestor] WAL append offload failed: %s", res)
+
+    async def snapshot_now(self) -> None:
+        """Force a fold-to-snapshot + WAL truncation now (deterministic
+        compaction). Serialized against the append worker via the file lock."""
+        await self._compact()
+
+    async def _compact(self) -> None:
+        """Deterministic fold-to-snapshot (spec Q4): write ``graph.snapshot()``
+        durably, THEN truncate the WAL. The snapshot is computed synchronously
+        on the loop (a detached dict -- no shared mutable state) and only its
+        serialization/write is offloaded, so it never races a concurrent fold.
+        Truncation happens ONLY after the snapshot lands durably -- a failed
+        snapshot leaves the WAL intact (no data loss). Re-folding the WAL tail
+        after replay is idempotent (emit_seq guard), so a snapshot that
+        captured still-queued envelopes stays loss-free."""
+        try:
+            snap = self.graph.snapshot()
+        except Exception:  # noqa: BLE001
+            logger.warning("[CausalGraphIngestor] snapshot() failed -- "
+                           "WAL left intact", exc_info=True)
+            return
+        async with self._file_lock:
+            wrote = await offload(
+                _write_json_atomic, str(self._snapshot_path), snap)
+            if is_offload_error(wrote):
+                logger.warning(
+                    "[CausalGraphIngestor] snapshot write failed (%s) -- "
+                    "WAL left intact, no truncation", wrote)
+                return
+            truncated = await offload(_truncate_file, str(self._wal_path))
+            if is_offload_error(truncated):
+                logger.warning(
+                    "[CausalGraphIngestor] WAL truncate failed (%s) -- "
+                    "snapshot durable, WAL tail will re-fold idempotently",
+                    truncated)
+                return
+        self._appends_since_snapshot = 0
+
+    # ------------------------------------------------------------------ #
+    # crash recovery
+    # ------------------------------------------------------------------ #
+    async def replay_from_wal(self) -> None:
+        """Deterministically re-fold the durable log into ``self.graph``:
+        load the snapshot (if present) via ``from_snapshot``, then fold every
+        WAL entry through ``apply_delta`` in FILE ORDER (== per-repo emit_seq
+        order by the append invariant). The emit_seq-monotonic fold makes this
+        idempotent, so a WAL tail that overlaps the snapshot re-folds to the
+        same state. After replay, ``state_fingerprint()`` equals the live
+        graph's. Fail-soft."""
+        snap = await offload(_read_json, str(self._snapshot_path))
+        if not is_offload_error(snap) and isinstance(snap, dict) and (
+            "nodes" in snap
+        ):
+            try:
+                self.graph = CausalGraph.from_snapshot(snap)
+            except Exception:  # noqa: BLE001 -- corrupt snapshot -> cold fold
+                logger.warning(
+                    "[CausalGraphIngestor] from_snapshot failed -- folding WAL "
+                    "onto the existing graph", exc_info=True)
+
+        entries = await offload(self._wal.pending_entries)
+        if is_offload_error(entries) or not isinstance(entries, list):
+            return
+        for entry in entries:
+            try:
+                self.graph.apply_delta(entry.envelope_dict)
+            except Exception:  # noqa: BLE001 -- apply_delta is already fail-soft
+                logger.debug("[CausalGraphIngestor] replay fold raised "
+                             "(swallowed)", exc_info=True)
+
+
+def _looks_valid(envelope: Any) -> bool:
+    """Cheap structural gate mirroring ``apply_delta``'s parse contract: a dict
+    with a dict ``delta`` and a dict ``lineage`` carrying an int-able
+    ``emit_seq``. Malformed -> dropped from BOTH graph and WAL; a well-formed
+    envelope that folds zero nodes (a lost emit_seq race, a resignature ahead
+    of its add) is STILL logged so replay determinism is preserved."""
+    if not isinstance(envelope, dict):
+        return False
+    if not isinstance(envelope.get("delta"), dict):
+        return False
+    lineage = envelope.get("lineage")
+    if not isinstance(lineage, dict):
+        return False
+    try:
+        int(lineage["emit_seq"])
+    except (KeyError, TypeError, ValueError):
+        return False
+    return True

--- a/backend/core/ouroboros/governance/intake/wal.py
+++ b/backend/core/ouroboros/governance/intake/wal.py
@@ -50,8 +50,17 @@ class WAL:
         self._max_age_days = max_age_days
         path.parent.mkdir(parents=True, exist_ok=True)
 
-    def append(self, entry: WALEntry) -> None:
-        """Append an entry and fsync."""
+    def append(self, entry: WALEntry) -> bool:
+        """Append an entry and fsync. Returns True iff the line was durably
+        written to disk, False on any write failure (lock timeout, OSError,
+        serialization failure). NEVER raises -- the intake WAL's fail-soft
+        contract holds for every consumer.
+
+        The bool return is an HONEST durability signal (a False means nothing
+        landed on disk). Existing callers that write ``wal.append(x)`` as a
+        statement are unaffected (None -> bool is transparent); durability-
+        sensitive callers (the CausalGraphIngestor's write-ahead gate) inspect
+        it and MUST NOT treat a False as durable."""
         record = {
             "v": _WAL_VERSION,
             "lease_id": entry.lease_id,
@@ -60,7 +69,7 @@ class WAL:
             "ts_monotonic": entry.ts_monotonic,
             "ts_utc": entry.ts_utc,
         }
-        self._write_line(record)
+        return self._write_line(record)
 
     def update_status(self, lease_id: str, status: str) -> None:
         """Append a status-update tombstone for the given lease_id."""
@@ -207,16 +216,24 @@ class WAL:
     # Internal
     # ------------------------------------------------------------------
 
-    def _write_line(self, record: Dict[str, Any]) -> None:
+    def _write_line(self, record: Dict[str, Any]) -> bool:
         """Append one WAL line cross-process safe via the canonical
         ``cross_process_jsonl.flock_append_line`` substrate
         (Wave 3 v2.26). Multiple sensors may concurrently append to
         the same WAL during a session — without flock, two processes
-        could interleave bytes mid-line. NEVER raises."""
+        could interleave bytes mid-line. NEVER raises.
+
+        Returns an HONEST durability bool: True iff the line landed on
+        disk, False on any failure. ``flock_append_line`` already returns
+        True/False (lock timeout / write error / fcntl unavailable) — that
+        signal used to be DISCARDED here, letting a lock-timeout look like a
+        success. It is now propagated so the write-ahead ingestor never folds
+        a non-durable delta. The ImportError fallback path returns True on a
+        clean fsync and False on any OSError (caught, never raised)."""
         try:
             line = json.dumps(record, default=str)
         except (TypeError, ValueError):
-            return
+            return False
         try:
             from backend.core.ouroboros.governance.cross_process_jsonl import (  # noqa: E501
                 flock_append_line,
@@ -224,10 +241,15 @@ class WAL:
         except ImportError:
             # Substrate-unavailable rollback — preserve legacy
             # within-process behavior; cross-process race remains
-            # but never raises into caller.
-            with self._path.open("a", encoding="utf-8") as f:
-                f.write(line + "\n")
-                f.flush()
-                os.fsync(f.fileno())
-            return
-        flock_append_line(self._path, line)
+            # but never raises into caller. Report honest durability.
+            try:
+                with self._path.open("a", encoding="utf-8") as f:
+                    f.write(line + "\n")
+                    f.flush()
+                    os.fsync(f.fileno())
+                return True
+            except OSError:
+                logger.warning("WAL: fallback append failed", exc_info=True)
+                return False
+        # Propagate flock_append_line's honest success/failure bool.
+        return bool(flock_append_line(self._path, line))

--- a/backend/core/ouroboros/governance/transport/organism_bus_host.py
+++ b/backend/core/ouroboros/governance/transport/organism_bus_host.py
@@ -95,6 +95,7 @@ class OrganismBusHost:
         self._bridge: Optional[Any] = None  # TrinityBusBridge
         self._intake_bridge: Optional[Any] = None  # RemoteIntakeBridge (Task 3)
         self._causal_subscriber: Optional[Any] = None  # CausalDeltaSubscriber (D1S1 Task 2)
+        self._causal_ingestor: Optional[Any] = None  # CausalGraphIngestor (D1S2 Task 3)
         self._generation_fence: Optional[Any] = None  # GenerationFence (Stage-4 Task 4)
         self._runner: Optional[Any] = None  # aiohttp AppRunner
         self._site: Optional[Any] = None  # aiohttp TCPSite
@@ -218,14 +219,31 @@ class OrganismBusHost:
         return True
 
     async def _start_causal_subscriber(self, trinity_bus: Any) -> None:
-        """Construct + start the Domain-1 Staging-1 CausalDeltaSubscriber
-        (Brain receiver). Lazy import inside the start-guard keeps master-OFF
+        """Construct + start the Domain-1 Staging-2 causal fold pipeline: an
+        in-memory ``CausalGraph`` + the event-sourced ``CausalGraphIngestor``
+        (Task 3), then the Staging-1 ``CausalDeltaSubscriber`` wired so its
+        ``on_delta`` sink IS ``ingestor.ingest`` (folds each delta into the
+        graph + durably logs it to the ordered WAL). The ingestor is started
+        FIRST (replay_from_wal + arm the ordered append worker) so it is a live
+        sink before any delta can arrive; teardown stops in reverse (subscriber
+        then ingestor). Lazy import inside the start-guard keeps master-OFF
         byte-identical (no causal-package import cost)."""
         from backend.core.ouroboros.governance.causal.causal_delta_subscriber import (  # noqa: PLC0415
             CausalDeltaSubscriber,
         )
+        from backend.core.ouroboros.governance.causal.causal_graph import (  # noqa: PLC0415
+            CausalGraph,
+        )
+        from backend.core.ouroboros.governance.causal.causal_graph_ingestor import (  # noqa: PLC0415
+            CausalGraphIngestor,
+        )
 
-        self._causal_subscriber = CausalDeltaSubscriber(trinity_bus)
+        graph = CausalGraph()
+        self._causal_ingestor = CausalGraphIngestor(graph)
+        await self._causal_ingestor.start()
+
+        self._causal_subscriber = CausalDeltaSubscriber(
+            trinity_bus, on_delta=self._causal_ingestor.ingest)
         await self._causal_subscriber.start()
 
     async def _maybe_start_generation_fence(self, trinity_bus: Any) -> None:
@@ -260,6 +278,16 @@ class OrganismBusHost:
                 logger.debug("[OrganismBusHost] causal subscriber stop failed",
                              exc_info=True)
             self._causal_subscriber = None
+        if self._causal_ingestor is not None:
+            # Reverse order: the subscriber (delta source) is already stopped,
+            # so flushing the ingestor's ordered append worker cannot race a
+            # late ingest. Fail-soft.
+            try:
+                await self._causal_ingestor.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug("[OrganismBusHost] causal ingestor stop failed",
+                             exc_info=True)
+            self._causal_ingestor = None
         if self._intake_bridge is not None:
             try:
                 await self._intake_bridge.stop()

--- a/docs/superpowers/plans/2026-07-05-domain1-staging2-graph-fold.md
+++ b/docs/superpowers/plans/2026-07-05-domain1-staging2-graph-fold.md
@@ -1,0 +1,161 @@
+# Domain 1 — Staging 2: The Graph Fold (Brain-side CausalGraph + Ingestor)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development. Steps use checkbox (`- [ ]`) syntax.
+
+**Goal:** A Brain-side in-memory `CausalGraph` folded from `StructuralDelta` events (O(1) per delta), an event-sourced `CausalGraphIngestor` (intake-WAL durable, deterministically re-foldable after a crash), and a `BlastRadiusOracle` whose intra-repo answer strictly delegates to `TheOracle`.
+
+**Architecture:** `CausalGraph` is a native in-memory node registry keyed by `str(NodeID)` — each `CausalNode` carries `signature_hash`, `kind`, its declared import dotted-names, and its `last_emit_seq`/`last_head_sha` lineage. The fold is **emit_seq-monotonic per symbol** (last-writer-wins by the Staging-0 Lamport seq), which makes it **commutative and order-independent** — the mathematical foundation of the crash-recovery determinism proof (live-fold ≡ any-order WAL-replay). Intra-repo dependency edges/blast-radius are NEVER stored or re-derived — they delegate to `get_oracle()`. The `CausalGraphIngestor` consumes the Staging-1 `CausalDeltaSubscriber.on_delta` callback, folds into the graph, and durably appends each delta envelope to an intake `WAL` (off-loop via `offload`). Cross-repo edges + dynamic weighting are Staging 3; the merge-base reconciler is Staging 4.
+
+**Tech Stack:** Staging-0 `StructuralDelta`; Staging-1 `CausalDeltaSubscriber`; `oracle.py` `get_oracle`/`get_blast_radius`/`get_dependents`/`NodeID`/`BlastRadius`; intake `WAL`/`WALEntry`; `cooperative_fs_io.offload`.
+
+## Global Constraints (Staging-2 mandates, binding)
+
+- **MANDATE 1 (O(1) event-driven fold):** ingesting a `StructuralDelta` mutates ONLY the directly-affected nodes/edges — O(1) in the delta's symbol count. NO periodic full-graph recalculation, NO sweep-and-prune GC. Nodes are removed ONLY by an explicit `symbols_removed` entry; the graph never garbage-collects heuristically.
+- **MANDATE 2 (async non-blocking, no timeout fallbacks):** the graph is native in-memory adjacency (dicts/sets) that the future `BlastRadiusOracle` traverses without starving the loop; every FS touch (WAL append, snapshot) is `await offload(...)` — never a blocking write on the loop. NO hardcoded timeout-fallback constants anywhere.
+- **MANDATE 3 (DRY intra-repo delegation):** all intra-repo dependency edges + blast radius come from `get_oracle().get_blast_radius(target)` / `.get_dependents(target)`. ZERO re-implemented Python import resolution in the causal graph. (The graph stores each node's DECLARED import dotted-names — a fact folded from the delta, used by Staging 3 for cross-repo edges — but never derives intra-repo dependency traversal itself.)
+- **MANDATE 4 (deterministic event-sourced fold):** the tear-down/spin-up proof — an arbitrary live delta sequence yields a graph mathematically identical (node-set + every node field, snapshot-equal) to one rebuilt purely from the intake WAL after a simulated crash. The emit_seq-monotonic fold is what guarantees this regardless of replay order.
+- Standing: dark behind existing masters (ingestor wired only inside the OrganismBusHost start-guard); single-writer (the Brain writes the graph; the Mac only publishes — unchanged); `from __future__ import annotations`; py3.9 (`asyncio.wait_for`, never `asyncio.timeout`); async-first; ASCII; fail-soft (a malformed delta is logged-and-dropped, never crashes the fold or the bus). TDD; named-files commits.
+
+## Key facts (scouted, verified)
+
+- Intake WAL: `WAL(path: Path, max_age_days=7)`; `append(WALEntry(lease_id, envelope_dict, status, ts_monotonic, ts_utc))`; `pending_entries() -> List[WALEntry]` (never call `update_status` on causal deltas → they stay `"pending"` → `pending_entries()` returns the FULL ordered event log). Flock/fsync durable. `intake/wal.py:29/37/53/81`.
+- Oracle: `get_oracle() -> TheOracle` (`oracle.py:4574`); `get_blast_radius(target: str) -> BlastRadius` (`:4004`); `get_dependents(target: str) -> List[NodeID]` (`:4029`). `BlastRadius` fields: `source_node`, `directly_affected: Set[NodeID]`, `transitively_affected: Set[NodeID]`, `broken_imports`, `broken_calls`, `risk_level` + `.to_dict()` (`:420`).
+- Offload: `async def offload(fn, ...)` (`cooperative_fs_io.py:619`) — the off-loop FS substrate (reused by DurableOutbound/ResourceManifest/EmitSequence).
+- Staging-1: `CausalDeltaSubscriber(trinity_bus, *, on_delta: Callable[[dict], None])`; the `on_delta` receives the envelope `{"delta": {...}, "lineage": {"repo","head_sha","parent_sha","merge_base","emit_seq"}}`. `StructuralDelta.from_dict(d)` reconstructs the Staging-0 delta.
+
+---
+
+### Task 1: `CausalGraph` + `CausalNode` + O(1) emit_seq-monotonic fold + snapshot
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/causal/causal_graph.py`
+- Test: `tests/governance/causal/test_causal_graph.py`
+
+**Interfaces (Produces):**
+```python
+@dataclass
+class CausalNode:
+    symbol_id: str            # "repo:file:name"
+    repo: str                 # RepoType.value
+    file_path: str
+    kind: str                 # class|function|method
+    signature_hash: str
+    imports: FrozenSet[str]   # declared import dotted-names (for Staging-3 cross-repo)
+    last_emit_seq: int
+    last_head_sha: str
+
+class CausalGraph:
+    def apply_delta(self, envelope: dict) -> int:
+        """Fold one stamped delta envelope. O(1) in the delta's symbol count.
+        emit_seq-MONOTONIC per symbol: a symbols_added/resignatured/import change
+        applies ONLY if delta.emit_seq > node.last_emit_seq (or the node is new);
+        symbols_removed removes ONLY if delta.emit_seq > last_emit_seq. A stale
+        (lower/equal emit_seq) delta is a no-op -> commutative + order-independent.
+        file_level_churn: mark all known nodes of that file with the new lineage
+        (coarse -- the structural detail was elided at the bound) WITHOUT touching
+        other files' nodes. Returns count of nodes mutated. NEVER raises (malformed
+        envelope -> 0, logged)."""
+    def node(self, symbol_id: str) -> Optional[CausalNode]
+    def nodes_in_repo(self, repo: str) -> List[CausalNode]
+    def node_count(self) -> int
+    def snapshot(self) -> dict:        # deterministic, fully-ordered serialization of every node+field
+    @classmethod
+    def from_snapshot(cls, snap: dict) -> "CausalGraph"
+    def state_fingerprint(self) -> str:  # sha256 of the canonical snapshot -- the equality primitive for Mandate 4
+```
+- Adjacency is native dicts: `self._nodes: Dict[str, CausalNode]`, `self._by_repo: Dict[str, Set[str]]`, `self._by_file: Dict[Tuple[str,str], Set[str]]` — all O(1) mutation, no traversal on write. NO intra-repo edge storage (Oracle owns that).
+
+- [ ] **Step 1: Write failing tests** — (a) apply a delta with `symbols_added` → nodes present with correct fields; (b) resignature (higher emit_seq) → signature_hash updated; (c) STALE delta (lower/equal emit_seq than the node's last) → NO-OP (node unchanged) — the commutativity pin; (d) symbols_removed (higher emit_seq) → node gone; a stale remove → node stays; (e) file_level_churn → that file's nodes get the new lineage, OTHER files untouched (O(1)-scope pin: assert an unrelated repo/file node is byte-identical before/after); (f) `apply_delta` on two orderings of the same delta set → identical `state_fingerprint()` (order-independence — the Mandate-4 foundation); (g) snapshot → from_snapshot → identical `state_fingerprint()`; (h) malformed envelope → returns 0, no raise.
+- [ ] **Step 2: RED.** **Step 3: Implement.** **Step 4: GREEN.** **Step 5: Commit** — `feat(domain1): CausalGraph -- O(1) emit_seq-monotonic fold + deterministic snapshot (Staging 2 Task 1)`.
+
+---
+
+### Task 2: `BlastRadiusOracle` intra-repo path (strict Oracle delegation)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/causal/blast_radius_oracle.py`
+- Test: `tests/governance/causal/test_blast_radius_oracle.py`
+
+**Interfaces (Produces):**
+```python
+@dataclass(frozen=True)
+class IntraRepoImpact:
+    source_symbol: str
+    directly_affected: Tuple[str, ...]
+    transitively_affected: Tuple[str, ...]
+    risk_level: str
+
+class BlastRadiusOracle:
+    def __init__(self, graph: CausalGraph, *, oracle_fn: Optional[Callable[[], Any]] = None) -> None:
+        # oracle_fn defaults to get_oracle (injectable for tests)
+    async def intra_repo(self, symbol_id: str) -> IntraRepoImpact:
+        """Delegate ENTIRELY to get_oracle().get_blast_radius(symbol_id) -> map the
+        BlastRadius (directly/transitively_affected NodeIDs -> str, risk_level) into
+        IntraRepoImpact. ZERO re-derived import resolution. Oracle call offloaded if
+        it does sync FS/graph work (await offload). Fail-soft: Oracle miss/exception
+        -> empty impact (source only), never raises. NON-BLOCKING (no timeout const)."""
+```
+- The cross-repo traversal (widest-path max-product, cycle-detected) is Staging 3 — NOT here. Staging 2 is the intra-repo delegation only.
+
+- [ ] **Step 1: Write failing tests** — inject a fake `oracle_fn` returning a `BlastRadius` with known directly/transitively/risk → `intra_repo` maps them exactly (NodeID→str); Oracle raising → empty impact, no raise; assert the impl calls `get_blast_radius` (delegation pin — a recording fake) and does NOT itself walk imports (grep/AST: no `ast.parse` / import-graph building in the module).
+- [ ] **Step 2: RED.** **Step 3: Implement.** **Step 4: GREEN.** **Step 5: Commit** — `feat(domain1): BlastRadiusOracle intra-repo -- strict TheOracle delegation (Staging 2 Task 2)`.
+
+---
+
+### Task 3: `CausalGraphIngestor` — fold + event-sourced WAL + snapshot compaction + wiring
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/causal/causal_graph_ingestor.py`
+- Modify: `backend/core/ouroboros/governance/transport/organism_bus_host.py` (wire the ingestor to the subscriber)
+- Test: `tests/governance/causal/test_causal_graph_ingestor.py`
+
+**Interfaces (Produces):**
+```python
+class CausalGraphIngestor:
+    def __init__(self, graph: CausalGraph, *, wal_path: Optional[str] = None,
+                 snapshot_path: Optional[str] = None) -> None:
+        # env: JARVIS_CAUSAL_WAL_PATH (default <repo>/.jarvis/causal_graph_wal.jsonl),
+        #      JARVIS_CAUSAL_SNAPSHOT_PATH (default <repo>/.jarvis/causal_graph_snapshot.json),
+        #      JARVIS_CAUSAL_SNAPSHOT_EVERY_N (default 500), JARVIS_CAUSAL_SNAPSHOT_IDLE_S (default 3600).
+    def ingest(self, envelope: dict) -> None:
+        """The CausalDeltaSubscriber.on_delta target. Fold into the graph (O(1)), then
+        schedule an offloaded WAL append of the envelope (fire-and-forget, fail-soft).
+        NON-BLOCKING: the fold is an in-memory dict op; the durable write is offloaded.
+        Every JARVIS_CAUSAL_SNAPSHOT_EVERY_N ingests OR after IDLE_S of no ingest ->
+        fold-to-snapshot compaction (write graph.snapshot() offloaded, truncate the WAL
+        to empty). This is DETERMINISTIC fold-to-snapshot (spec Q4), NOT heuristic GC."""
+    async def replay_from_wal(self) -> None:
+        """Crash recovery: load snapshot (if present) into the graph via from_snapshot,
+        then fold every WAL entry (offloaded read) through graph.apply_delta. The
+        emit_seq-monotonic fold makes this order-independent + idempotent. After replay,
+        graph.state_fingerprint() == the live graph's."""
+    async def start(self) -> None   # replay_from_wal + arm
+    async def stop(self) -> None
+```
+- Wire in `organism_bus_host`: construct the graph + ingestor, `await ingestor.start()` (replay), then construct `CausalDeltaSubscriber(trinity_bus, on_delta=ingestor.ingest)` (REPLACING the Staging-1 bare subscriber — the ingestor is now the on_delta sink). Lazy import inside the start-guard; master-off byte-identical. Stop in reverse.
+
+- [ ] **Step 1: Write failing tests** — (a) `ingest(envelope)` → graph folded + a WAL entry appended (read the WAL back); (b) non-blocking: `ingest` returns immediately, the offloaded WAL write lands (condition-poll); (c) compaction: after `SNAPSHOT_EVERY_N` ingests a snapshot file exists and the WAL is truncated; (d) snapshot+tail == full-replay: ingest N, force a snapshot at N/2, ingest N/2 more, then `replay_from_wal` on a fresh graph → `state_fingerprint()` equals the live graph (compaction is loss-free); (e) organism_bus_host wires ingestor+subscriber when armed (recording fake), byte-identical off; (f) malformed envelope → dropped, graph + WAL unaffected, no raise.
+- [ ] **Step 2: RED.** **Step 3: Implement.** **Step 4: GREEN.** **Step 5: Commit** — `feat(domain1): CausalGraphIngestor -- event-sourced fold + WAL + snapshot compaction + wiring (Staging 2 Task 3)`.
+
+---
+
+### Task 4: The tear-down/spin-up determinism proof (Mandate 4 — load-bearing)
+
+**Files:**
+- Test: `tests/governance/causal/test_causal_fold_determinism.py`
+
+- [ ] **Step 1: The crash-recovery determinism test:**
+  - Build a graph + ingestor on a tmp WAL. Ingest an ARBITRARY sequence of deltas (mix of add/resignature/remove/file_churn across all three repos, INCLUDING out-of-order emit_seq and duplicate replays and stale updates). Capture `live_fingerprint = graph.state_fingerprint()`.
+  - **Simulate a Brain VM crash:** destroy the graph + ingestor objects entirely (no graceful stop — the durable truth is the WAL + snapshot on disk).
+  - Reconstruct: fresh `CausalGraph` + `CausalGraphIngestor` on the SAME wal_path/snapshot_path; `await replay_from_wal()`. Capture `recovered_fingerprint`.
+  - **Assert MATHEMATICALLY: `recovered_fingerprint == live_fingerprint`** — node-set equal, every node field equal (the snapshot canonical form is the equality witness). Also assert `graph.snapshot() == recovered.snapshot()` for a second independent equality.
+  - **Order-independence corollary:** replay the SAME WAL entries in a SHUFFLED order → identical fingerprint (the emit_seq-monotonic commutativity, end-to-end).
+  - Run 3× (with different arbitrary sequences) for flake-immunity; stream the fingerprints.
+- [ ] **Step 2: Run** `python3 -m pytest tests/governance/causal/test_causal_fold_determinism.py -v -s` (unsandboxed if WAL writes ~/.jarvis; use a tmp_path WAL to avoid it). **Step 3: Commit** — `test(domain1): tear-down/spin-up fold determinism -- live graph == WAL-reconstructed after crash (Staging 2 Task 4)`.
+
+---
+
+## Self-Review
+1. **Spec coverage (Staging 2 = spec Staging 2 "graph + intra-repo blast radius"):** CausalGraph fold (T1), CausalGraphIngestor event-sourced (T3), BlastRadiusOracle intra-repo Oracle-delegated (T2), determinism/crash proof (T4). Cross-repo edges/weighting → Staging 3; reconciler → Staging 4. Correctly out.
+2. **Placeholder scan:** exact signatures/envs; the `state_fingerprint` is the concrete equality witness for Mandate 4; snapshot compaction is spec-Q4's deterministic fold-to-snapshot, explicitly NOT the heuristic GC Mandate 1 bans.
+3. **Type consistency:** `apply_delta(envelope: dict)` consumes the Staging-1 `on_delta` envelope verbatim; `state_fingerprint()` used identically in T1/T3/T4; `IntraRepoImpact` maps `BlastRadius` fields (directly/transitively_affected, risk_level) exactly.

--- a/tests/governance/causal/test_blast_radius_oracle.py
+++ b/tests/governance/causal/test_blast_radius_oracle.py
@@ -98,13 +98,32 @@ def test_delegation_pin_calls_get_blast_radius_with_exact_symbol() -> None:
     assert oracle.calls == ["jarvis:mod.py:target_symbol"]
 
 
-def test_default_oracle_fn_is_get_oracle() -> None:
-    # When no oracle_fn injected, the default resolver is oracle.get_oracle.
-    from backend.core.ouroboros import oracle as oracle_mod
+def test_default_resolver_calls_get_oracle() -> None:
+    # When no oracle_fn is injected, the intra_repo path must resolve the
+    # per-repo Oracle via ``blast_radius_oracle.get_oracle`` (the module-level
+    # import the code actually calls). Patch that symbol with a recording fake
+    # and assert the default path invoked it -- a real behavioral pin, not the
+    # tautological ``_oracle_fn is None`` identity check it replaces.
+    import backend.core.ouroboros.governance.causal.blast_radius_oracle as mod
 
-    graph = CausalGraph()
-    bro = BlastRadiusOracle(graph)
-    assert bro._oracle_fn is None or bro._oracle_fn is oracle_mod.get_oracle
+    called = {"n": 0}
+    recording = _RecordingOracle(_FakeBlastRadius([], [], "low"))
+
+    def _fake_get_oracle():
+        called["n"] += 1
+        return recording
+
+    orig = mod.get_oracle
+    mod.get_oracle = _fake_get_oracle
+    try:
+        graph = CausalGraph()
+        bro = BlastRadiusOracle(graph)  # no oracle_fn -> default resolver
+        asyncio.run(bro.intra_repo("jarvis:mod.py:sym"))
+    finally:
+        mod.get_oracle = orig
+
+    assert called["n"] == 1, "default path must call blast_radius_oracle.get_oracle"
+    assert recording.calls == ["jarvis:mod.py:sym"]
 
 
 # --------------------------------------------------------------------------

--- a/tests/governance/causal/test_blast_radius_oracle.py
+++ b/tests/governance/causal/test_blast_radius_oracle.py
@@ -1,0 +1,178 @@
+"""Tests for BlastRadiusOracle intra-repo path (Domain-1 Staging-2 Task 2).
+
+Strict TheOracle delegation: the BlastRadiusOracle re-derives NOTHING about
+import resolution -- it forwards to ``get_oracle().get_blast_radius(symbol)``
+and maps the resulting ``BlastRadius`` into an ``IntraRepoImpact``. These
+tests pin: exact mapping, delegation (recording fake), fail-soft on
+raise/None, no re-derived import walking (Mandate 3), and determinism.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from typing import Any, List
+
+import pytest
+
+from backend.core.ouroboros.governance.causal.blast_radius_oracle import (
+    BlastRadiusOracle,
+    IntraRepoImpact,
+)
+from backend.core.ouroboros.governance.causal.causal_graph import CausalGraph
+
+
+# --------------------------------------------------------------------------
+# Test doubles
+# --------------------------------------------------------------------------
+class _FakeNodeID:
+    """Stands in for oracle.NodeID -- str() -> "repo:file:name"."""
+
+    def __init__(self, s: str) -> None:
+        self._s = s
+
+    def __str__(self) -> str:  # noqa: D401 - trivial
+        return self._s
+
+
+class _FakeBlastRadius:
+    """BlastRadius-shaped: the only fields the mapper reads."""
+
+    def __init__(self, directly, transitively, risk_level: str) -> None:
+        self.source_node = _FakeNodeID("jarvis:x.py:src")
+        self.directly_affected = set(directly)
+        self.transitively_affected = set(transitively)
+        self.broken_imports: List[Any] = []
+        self.broken_calls: List[Any] = []
+        self.risk_level = risk_level
+
+
+class _RecordingOracle:
+    """Records the exact target passed to get_blast_radius."""
+
+    def __init__(self, result: Any) -> None:
+        self._result = result
+        self.calls: List[str] = []
+
+    def get_blast_radius(self, target: str) -> Any:
+        self.calls.append(target)
+        return self._result
+
+
+class _RaisingOracle:
+    def get_blast_radius(self, target: str) -> Any:
+        raise RuntimeError("oracle exploded during graph walk")
+
+
+def _make_oracle(graph: CausalGraph, oracle_obj: Any) -> BlastRadiusOracle:
+    return BlastRadiusOracle(graph, oracle_fn=lambda: oracle_obj)
+
+
+# --------------------------------------------------------------------------
+# Mapping + delegation
+# --------------------------------------------------------------------------
+def test_maps_blast_radius_fields_exactly_sorted() -> None:
+    graph = CausalGraph()
+    directly = [_FakeNodeID("jarvis:b.py:b"), _FakeNodeID("jarvis:a.py:a")]
+    transitively = [_FakeNodeID("jarvis:z.py:z"), _FakeNodeID("jarvis:m.py:m")]
+    br = _FakeBlastRadius(directly, transitively, "high")
+    oracle = _RecordingOracle(br)
+    bro = _make_oracle(graph, oracle)
+
+    impact = asyncio.run(bro.intra_repo("jarvis:x.py:src"))
+
+    assert isinstance(impact, IntraRepoImpact)
+    assert impact.source_symbol == "jarvis:x.py:src"
+    assert impact.directly_affected == ("jarvis:a.py:a", "jarvis:b.py:b")
+    assert impact.transitively_affected == ("jarvis:m.py:m", "jarvis:z.py:z")
+    assert impact.risk_level == "high"
+
+
+def test_delegation_pin_calls_get_blast_radius_with_exact_symbol() -> None:
+    graph = CausalGraph()
+    oracle = _RecordingOracle(_FakeBlastRadius([], [], "low"))
+    bro = _make_oracle(graph, oracle)
+
+    asyncio.run(bro.intra_repo("jarvis:mod.py:target_symbol"))
+
+    assert oracle.calls == ["jarvis:mod.py:target_symbol"]
+
+
+def test_default_oracle_fn_is_get_oracle() -> None:
+    # When no oracle_fn injected, the default resolver is oracle.get_oracle.
+    from backend.core.ouroboros import oracle as oracle_mod
+
+    graph = CausalGraph()
+    bro = BlastRadiusOracle(graph)
+    assert bro._oracle_fn is None or bro._oracle_fn is oracle_mod.get_oracle
+
+
+# --------------------------------------------------------------------------
+# Fail-soft
+# --------------------------------------------------------------------------
+def test_oracle_raising_yields_empty_impact_no_raise() -> None:
+    graph = CausalGraph()
+    bro = _make_oracle(graph, _RaisingOracle())
+
+    impact = asyncio.run(bro.intra_repo("jarvis:x.py:src"))
+
+    assert impact == IntraRepoImpact("jarvis:x.py:src", (), (), "low")
+
+
+def test_oracle_returning_none_yields_empty_impact() -> None:
+    graph = CausalGraph()
+    bro = _make_oracle(graph, _RecordingOracle(None))
+
+    impact = asyncio.run(bro.intra_repo("jarvis:x.py:src"))
+
+    assert impact == IntraRepoImpact("jarvis:x.py:src", (), (), "low")
+
+
+def test_oracle_fn_itself_raising_yields_empty_impact() -> None:
+    def _boom():
+        raise RuntimeError("get_oracle failed to build")
+
+    graph = CausalGraph()
+    bro = BlastRadiusOracle(graph, oracle_fn=_boom)
+
+    impact = asyncio.run(bro.intra_repo("jarvis:x.py:src"))
+
+    assert impact == IntraRepoImpact("jarvis:x.py:src", (), (), "low")
+
+
+# --------------------------------------------------------------------------
+# Determinism
+# --------------------------------------------------------------------------
+def test_determinism_identical_impact_for_same_input() -> None:
+    graph = CausalGraph()
+    directly = [_FakeNodeID("jarvis:b.py:b"), _FakeNodeID("jarvis:a.py:a")]
+    br = _FakeBlastRadius(directly, [], "medium")
+    bro = _make_oracle(graph, _RecordingOracle(br))
+
+    first = asyncio.run(bro.intra_repo("jarvis:x.py:src"))
+    second = asyncio.run(bro.intra_repo("jarvis:x.py:src"))
+
+    assert first == second
+
+
+# --------------------------------------------------------------------------
+# Mandate 3: NO re-derived import resolution in the module
+# --------------------------------------------------------------------------
+def test_module_contains_no_import_resolution() -> None:
+    import backend.core.ouroboros.governance.causal.blast_radius_oracle as mod
+
+    src = inspect.getsource(mod)
+    assert "ast.parse" not in src
+    assert "import ast" not in src
+    assert "_build_forward_import_graph" not in src
+    # The ONLY dependency-source is the Oracle's get_blast_radius / get_dependents.
+    assert "get_blast_radius" in src
+
+
+def test_result_type_is_frozen_dataclass() -> None:
+    import dataclasses
+
+    assert dataclasses.is_dataclass(IntraRepoImpact)
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        impact = IntraRepoImpact("s", (), (), "low")
+        impact.risk_level = "high"  # type: ignore[misc]

--- a/tests/governance/causal/test_causal_fold_determinism.py
+++ b/tests/governance/causal/test_causal_fold_determinism.py
@@ -1,0 +1,328 @@
+"""Domain-1 Staging-2 Task 4 -- the tear-down/spin-up determinism PROOF.
+
+MANDATE-4, load-bearing: a live ``CausalGraph`` (folded through the
+``CausalGraphIngestor``) is byte-for-byte reconstructible from the durable
+truth on disk (WAL + snapshot) after a simulated Brain-VM crash that destroys
+ALL in-memory state.
+
+    live_fingerprint  ==  WAL/snapshot-reconstructed fingerprint
+
+The equality witness is ``graph.state_fingerprint()`` (sha256 over the canonical
+snapshot: every node field + the full per-symbol Lamport high-water map),
+cross-checked by a second independent witness ``graph.snapshot() == ...``.
+
+*** THE BINDING CONSTRAINT (from the Task-1 opus review -- honored here) ***
+
+The fold is order-independent for FULL-WRITE ops (add / remove -- disjoint or
+tombstoned, they commute under ANY shuffle) but PARTIAL-WRITE fields
+(resignature-only signature, import-only edge merge, the ``imports`` merge a
+subsequent add performs) are last-writer-wins PER field-source and converge
+ONLY under per-repo ``emit_seq`` order (the ingestor's WAL-append invariant).
+
+THEREFORE every determinism/order-independence claim in this file shuffles the
+CROSS-REPO interleaving ONLY -- the three repos' delta streams (disjoint
+``symbol_id`` namespaces) genuinely commute against each other -- while PRESERVING
+each single repo's internal ``emit_seq`` order. Free-shuffling same-repo deltas
+would step outside the event model: it would either flake or FALSELY pass. A
+genuine same-symbol "stale lower-seq" delta CANNOT occur inside a per-repo-ordered
+live stream (a symbol's hwm is only ever set by strictly-earlier, lower-seq
+deltas), so the honest "stale/duplicate" coverage here is (1) an equal-seq
+DUPLICATE replay (strict-``>`` guard makes it a no-op) and (2) the idempotent
+WAL-tail re-fold after compaction -- both fully inside the event model.
+"""
+from __future__ import annotations
+
+import asyncio
+import copy
+import random
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.causal.causal_graph import CausalGraph
+from backend.core.ouroboros.governance.causal.causal_graph_ingestor import (
+    CausalGraphIngestor,
+)
+from backend.core.ouroboros.governance.causal.structural_delta import (
+    ImportEdge,
+    StructuralDelta,
+    SymbolRecord,
+)
+
+REPOS = ("jarvis", "prime", "reactor")
+
+
+# --------------------------------------------------------------------------- #
+# builders (real StructuralDelta / envelope shape -- no fold mocks)
+# --------------------------------------------------------------------------- #
+def _sym(symbol_id: str, kind: str, sig: str) -> SymbolRecord:
+    return SymbolRecord(symbol_id=symbol_id, kind=kind, signature_hash=sig)
+
+
+def _delta(repo, file_path, *, added=(), removed=(), resig=(), imp_added=(),
+           imp_removed=(), churn=False) -> StructuralDelta:
+    return StructuralDelta(
+        repo=repo,
+        file_path=file_path,
+        symbols_added=tuple(added),
+        symbols_removed=tuple(removed),
+        symbols_resignatured=tuple(resig),
+        import_edges_added=tuple(imp_added),
+        import_edges_removed=tuple(imp_removed),
+        file_level_churn=churn,
+        churn_counts={},
+    )
+
+
+def _env(delta: StructuralDelta, repo: str, emit_seq: int) -> dict:
+    """The publish-ready Staging-1 envelope: content-free delta dict + lineage.
+    ``head_sha`` is deterministic in (repo, seq) so it folds into a stable
+    ``last_head_sha`` -- part of the fingerprint."""
+    return {
+        "delta": delta.to_dict(),
+        "lineage": {
+            "repo": repo,
+            "head_sha": "%sh%d" % (repo, emit_seq),
+            "parent_sha": "%sp%d" % (repo, emit_seq),
+            "merge_base": "%sbase" % repo,
+            "emit_seq": emit_seq,
+        },
+    }
+
+
+def _build_repo_stream(repo: str, rng: random.Random) -> list:
+    """ONE repo's ordered (emit_seq 1..N, strictly increasing) envelope stream.
+
+    Mixes EVERY op the graph fold supports: add / resignature (partial) /
+    remove / import-edge (partial) / file_level_churn / re-add-after-tombstone /
+    no-home resignature (bumps hwm, materializes no node) / equal-seq
+    duplicate-replay. Content (sigs, extra-symbol count) is seed-varied so the
+    three test iterations fold DIFFERENT arbitrary sequences, but the per-repo
+    emit_seq order is ALWAYS monotonic (the binding invariant)."""
+    file_a = "core.py"
+    file_b = "util.py"
+    A = "%s:%s:alpha" % (repo, file_a)
+    B = "%s:%s:beta" % (repo, file_a)
+    C = "%s:%s:gamma" % (repo, file_b)
+
+    envs: list = []
+    seq = 0
+
+    def push(delta: StructuralDelta) -> None:
+        nonlocal seq
+        seq += 1
+        envs.append(_env(delta, repo, seq))
+
+    s = lambda tag: "%s_%s_%d" % (repo, tag, rng.randint(0, 1 << 30))  # noqa: E731
+
+    # 1 add A (function)
+    push(_delta(repo, file_a, added=(_sym(A, "function", s("a")),)))
+    # 2 add B (class)
+    push(_delta(repo, file_a, added=(_sym(B, "class", s("b")),)))
+    # 3 import-ONLY on A (partial write; merges onto A's node)
+    push(_delta(repo, file_a,
+                imp_added=(ImportEdge(A, "os.path", "imports"),)))
+    # 4 resignature-ONLY A (partial write)
+    push(_delta(repo, file_a, resig=((A, "old", s("a2")),)))
+    # 5 add C (function) in the second file
+    push(_delta(repo, file_b, added=(_sym(C, "function", s("c")),)))
+    # 6 remove B (tombstones B's hwm)
+    push(_delta(repo, file_a, removed=(_sym(B, "class", "old"),)))
+    # 7 re-add B at a higher seq -> beats the tombstone hwm (re-add proof)
+    push(_delta(repo, file_a, added=(_sym(B, "class", s("b2")),)))
+    # 8 import-ONLY on C (partial write, imports_from)
+    push(_delta(repo, file_b,
+                imp_added=(ImportEdge(C, "typing.List", "imports_from"),)))
+    # 9 file_level_churn on file_a -> bumps ONLY A + B lineage (never C)
+    push(_delta(repo, file_a, churn=True))
+    # 10 resignature C
+    push(_delta(repo, file_b, resig=((C, "old", s("c2")),)))
+
+    # seed-varied extra symbols (different delta mix per iteration)
+    for i in range(rng.randint(0, 3)):
+        X = "%s:%s:x%d" % (repo, file_b, i)
+        push(_delta(repo, file_b, added=(_sym(X, "function", s("x%d" % i)),)))
+        if rng.random() < 0.5:
+            push(_delta(repo, file_b, resig=((X, "old", s("x%dr" % i)),)))
+
+    # 11 remove C, then 12 a NO-HOME resignature of C at a still-higher seq:
+    # wins the hwm guard (bumps the tombstone watermark) yet materializes no
+    # node -- the fold records the watermark deterministically, live or replay.
+    push(_delta(repo, file_b, removed=(_sym(C, "function", "old"),)))
+    push(_delta(repo, file_b, resig=((C, "old", s("c3")),)))
+
+    # equal-seq DUPLICATE replay of the tail envelope -> strict-`>` guard makes
+    # it a pure no-op. Keeps the per-repo stream monotonic NON-decreasing.
+    envs.append(copy.deepcopy(envs[-1]))
+
+    return envs
+
+
+def _build_streams(seed: int) -> list:
+    """Three per-repo ordered streams for one iteration (seed-varied content)."""
+    rng = random.Random(seed)
+    return [_build_repo_stream(repo, rng) for repo in REPOS]
+
+
+def _interleave(streams: list, rng: random.Random) -> list:
+    """Merge the per-repo ordered streams into ONE cross-repo-interleaved
+    sequence, PRESERVING each stream's internal order (cursor pop) while
+    randomizing WHICH stream advances next. Non-mutating (index cursors).
+
+    This is the ONLY legal shuffle: it randomizes the cross-repo interleave
+    (disjoint symbol namespaces commute) but never reorders a single repo's
+    emit_seq subsequence (partial-writes are order-sensitive there)."""
+    cursors = [0] * len(streams)
+    total = sum(len(s) for s in streams)
+    out: list = []
+    for _ in range(total):
+        live = [i for i, s in enumerate(streams) if cursors[i] < len(s)]
+        i = rng.choice(live)
+        out.append(streams[i][cursors[i]])
+        cursors[i] += 1
+    return out
+
+
+async def _drain(cond, *, timeout_s: float = 5.0, interval_s: float = 0.01):
+    """Bounded condition-poll (no bare sleep-as-sync)."""
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        await asyncio.sleep(interval_s)
+    return cond()
+
+
+def _paths(tmp_path):
+    return str(tmp_path / "causal_wal.jsonl"), str(tmp_path / "causal_snap.json")
+
+
+# --------------------------------------------------------------------------- #
+# THE PROOF -- 3x, different arbitrary sequences, streamed fingerprints
+# --------------------------------------------------------------------------- #
+@pytest.mark.parametrize("seed", [1, 7, 42])
+def test_teardown_spinup_fold_determinism(tmp_path, seed):
+    """Live graph == WAL-reconstructed graph after a simulated Brain crash,
+    PLUS the cross-repo order-independence corollary. Mathematically asserted
+    on both the fingerprint AND the raw snapshot dict."""
+    wal_path, snap_path = _paths(tmp_path)
+    streams = _build_streams(seed)
+
+    async def scenario():
+        # -- LIVE ingest (cross-repo-interleaved, per-repo order preserved) ----
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        live_order = _interleave(streams, random.Random(seed * 31 + 1))
+        for env in live_order:
+            ing.ingest(env)
+        await ing.flush()                     # all durable appends land
+        live_fp = graph.state_fingerprint()
+        live_snap = graph.snapshot()
+
+        # -- SIMULATE BRAIN VM CRASH -------------------------------------------
+        # Flush/drain the queue so the WAL on disk is the durable truth, THEN
+        # annihilate ALL in-memory state. Nothing but the WAL file survives.
+        await ing.stop()
+        del ing, graph                        # no in-memory state survives
+
+        n_wal = await _drain(
+            lambda: Path(wal_path).exists()
+            and Path(wal_path).stat().st_size > 0)
+        assert n_wal, "WAL must be durable on disk after the crash"
+
+        # -- RECONSTRUCT from the durable log (fresh objects, SAME paths) -------
+        recovered_graph = CausalGraph()
+        ing2 = CausalGraphIngestor(
+            recovered_graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing2.replay_from_wal()
+        # replay_from_wal may REASSIGN ing2.graph (from_snapshot path); the
+        # authoritative reconstructed graph is ALWAYS ing2.graph.
+        recovered = ing2.graph
+        recovered_fp = recovered.state_fingerprint()
+        recovered_snap = recovered.snapshot()
+
+        # -- CROSS-REPO ORDER-INDEPENDENCE COROLLARY ---------------------------
+        # Re-fold the SAME per-repo-ordered entries in a DIFFERENT cross-repo
+        # interleaving (per-repo order still preserved) directly via apply_delta
+        # -> identical fingerprint. Proves the fold commutes across repos.
+        shuffled_graph = CausalGraph()
+        shuffle_order = _interleave(streams, random.Random(seed * 97 + 5))
+        assert [id(e) for e in shuffle_order] != [id(e) for e in live_order], (
+            "the corollary must use a DIFFERENT cross-repo interleaving")
+        for env in shuffle_order:
+            shuffled_graph.apply_delta(env)
+        shuffle_fp = shuffled_graph.state_fingerprint()
+
+        return live_fp, recovered_fp, live_snap, recovered_snap, shuffle_fp
+
+    live_fp, recovered_fp, live_snap, recovered_snap, shuffle_fp = asyncio.run(
+        scenario())
+
+    print(
+        "[determinism seed=%2d] live=%s recovered=%s %s" % (
+            seed, live_fp[:16], recovered_fp[:16],
+            "MATCH" if live_fp == recovered_fp else "MISMATCH"),
+        flush=True)
+
+    # MANDATE-4 primary witness: fingerprint equality.
+    assert recovered_fp == live_fp, (
+        "WAL-reconstructed fingerprint must equal the live fingerprint")
+    # Second INDEPENDENT witness: the raw canonical snapshot dict.
+    assert recovered_snap == live_snap, (
+        "WAL-reconstructed snapshot must equal the live snapshot")
+    # Non-triviality: the sequence actually built graph state.
+    assert live_snap["nodes"], "the arbitrary sequence must fold real nodes"
+    # Cross-repo order-independence corollary.
+    assert shuffle_fp == live_fp, (
+        "a DIFFERENT cross-repo interleaving (per-repo order preserved) must "
+        "fold to the identical fingerprint")
+
+
+# --------------------------------------------------------------------------- #
+# COMPACTION CROSS-CHECK -- snapshot fires mid-sequence, crash, replay still ==
+# --------------------------------------------------------------------------- #
+def test_compaction_lossless_under_crash(tmp_path, monkeypatch):
+    """A tiny SNAPSHOT_EVERY_N forces fold-to-snapshot compaction mid-sequence.
+    After the crash, recovery loads snapshot + re-folds the WAL tail (idempotent
+    under the emit_seq guard) and STILL reconstructs the exact live fingerprint
+    -- compaction is loss-free across a crash."""
+    monkeypatch.setenv("JARVIS_CAUSAL_SNAPSHOT_EVERY_N", "4")
+    wal_path, snap_path = _paths(tmp_path)
+    streams = _build_streams(seed=1234)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        for env in _interleave(streams, random.Random(3)):
+            ing.ingest(env)
+        await ing.flush()
+        # compaction must have fired at least once (snapshot file on disk)
+        snapshotted = await _drain(lambda: Path(snap_path).exists())
+        assert snapshotted, "small EVERY_N must trigger a mid-sequence snapshot"
+        live_fp = graph.state_fingerprint()
+
+        # crash
+        await ing.stop()
+        del ing, graph
+
+        # recover from snapshot + WAL tail
+        recovered_graph = CausalGraph()
+        ing2 = CausalGraphIngestor(
+            recovered_graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing2.replay_from_wal()
+        return live_fp, ing2.graph.state_fingerprint()
+
+    live_fp, recovered_fp = asyncio.run(scenario())
+    print(
+        "[compaction     ] live=%s recovered=%s %s" % (
+            live_fp[:16], recovered_fp[:16],
+            "MATCH" if live_fp == recovered_fp else "MISMATCH"),
+        flush=True)
+    assert recovered_fp == live_fp, (
+        "snapshot + WAL-tail recovery must equal the live fingerprint "
+        "(compaction is loss-free under crash)")

--- a/tests/governance/causal/test_causal_fold_determinism.py
+++ b/tests/governance/causal/test_causal_fold_determinism.py
@@ -7,6 +7,17 @@ ALL in-memory state.
 
     live_fingerprint  ==  WAL/snapshot-reconstructed fingerprint
 
+WHY THIS IS A TRUE-CRASH PROOF (write-ahead): the ingestor is append-BEFORE-fold
+-- the single worker durably appends each envelope to the WAL FIRST and folds it
+into the live graph ONLY after that append lands. So the live graph reflects
+ONLY durably-appended deltas: at quiescence (``flush()`` drained) the WAL on disk
+is exactly ``fold(WAL) == live graph``. Therefore capturing ``live_fp`` at
+quiescence and then annihilating all in-memory state loses NOTHING that isn't
+already on disk -- ``recovered == live`` is a genuine crash-determinism result,
+not an artifact of a graceful pre-crash flush. (Under the old write-BEHIND design
+a delta could be folded-but-not-yet-appended, so a true crash would yield
+recovered != live; append-before-fold closes that gap.)
+
 The equality witness is ``graph.state_fingerprint()`` (sha256 over the canonical
 snapshot: every node field + the full per-symbol Lamport high-water map),
 cross-checked by a second independent witness ``graph.snapshot() == ...``.
@@ -218,13 +229,18 @@ def test_teardown_spinup_fold_determinism(tmp_path, seed):
         live_order = _interleave(streams, random.Random(seed * 31 + 1))
         for env in live_order:
             ing.ingest(env)
-        await ing.flush()                     # all durable appends land
+        await ing.flush()                     # quiesce: append-then-fold drained
+        # write-AHEAD invariant: at quiescence the live graph reflects ONLY
+        # durably-appended deltas, so fold(WAL) == this live graph exactly.
         live_fp = graph.state_fingerprint()
         live_snap = graph.snapshot()
 
         # -- SIMULATE BRAIN VM CRASH -------------------------------------------
-        # Flush/drain the queue so the WAL on disk is the durable truth, THEN
-        # annihilate ALL in-memory state. Nothing but the WAL file survives.
+        # Quiesce reached above => the WAL on disk is the durable truth and is
+        # byte-equal to the live graph. Annihilate ALL in-memory state. stop()
+        # here only unwinds the (already-idle) worker task cleanly; it adds NO
+        # durability a hard kill wouldn't have -- everything folded was already
+        # appended (write-ahead). Nothing but the WAL/snapshot files survive.
         await ing.stop()
         del ing, graph                        # no in-memory state survives
 

--- a/tests/governance/causal/test_causal_graph.py
+++ b/tests/governance/causal/test_causal_graph.py
@@ -239,6 +239,101 @@ def test_two_orderings_same_fingerprint():
 
 
 # ---------------------------------------------------------------------------
+# (f2) order-independence WITH removes, re-adds, tombstones (Task 1 review)
+# ---------------------------------------------------------------------------
+
+def _tombstone_envelopes():
+    # Every symbol's TERMINAL (highest-seq) op is a FULL write (add or remove),
+    # so the fold is provably commutative under any permutation -- including
+    # remove-before-add and a resignature interleaved mid-history.
+    return [
+        # A: add@1 then remove@3  -> terminal remove -> ABSENT, hwm 3
+        _env(_delta("brain", "a.py", added=(_sym("brain:a.py:A", "class", "a1"),)), "brain", 1),
+        _env(_delta("brain", "a.py", removed=(_sym("brain:a.py:A", "class", "a1"),)), "brain", 3),
+        # B: add@2, resignature@5, re-add@8 -> terminal full add@8 -> PRESENT s8, hwm 8
+        _env(_delta("prime", "b.py", added=(_sym("prime:b.py:B", "function", "b2"),)), "prime", 2),
+        _env(_delta("prime", "b.py", resig=(("prime:b.py:B", "b2", "b5"),)), "prime", 5),
+        _env(_delta("prime", "b.py", added=(_sym("prime:b.py:B", "function", "b8"),)), "prime", 8),
+        # C: remove@4 with a STALE add@2 -> terminal remove -> ABSENT, hwm 4 (no resurrection)
+        _env(_delta("reactor", "c.py", removed=(_sym("reactor:c.py:C", "method", "c0"),)), "reactor", 4),
+        _env(_delta("reactor", "c.py", added=(_sym("reactor:c.py:C", "method", "c2"),)), "reactor", 2),
+        # D: lone add@6 -> PRESENT, hwm 6
+        _env(_delta("brain", "d.py", added=(_sym("brain:d.py:D", "class", "d6"),)), "brain", 6),
+    ]
+
+
+def test_order_independence_with_removes_and_tombstones():
+    import random
+
+    envs = _tombstone_envelopes()
+
+    def _fold(order):
+        g = CausalGraph()
+        for e in order:
+            g.apply_delta(e)
+        return g
+
+    base = _fold(envs)
+
+    for seed in (1, 7, 42, 2026):
+        shuffled = list(envs)
+        random.Random(seed).shuffle(shuffled)
+        g = _fold(shuffled)
+        assert g.state_fingerprint() == base.state_fingerprint(), f"seed={seed}"
+
+    # the converged truth
+    assert base.node("brain:a.py:A") is None          # removed
+    assert base.node("reactor:c.py:C") is None         # stale add never resurrected
+    b = base.node("prime:b.py:B")
+    assert b is not None and b.signature_hash == "b8" and b.last_emit_seq == 8
+    assert base.node("brain:d.py:D") is not None
+    assert base.node_count() == 2
+
+
+# ---------------------------------------------------------------------------
+# remove-before-add: the tombstone blocks resurrection (Task 1 review)
+# ---------------------------------------------------------------------------
+
+def test_out_of_order_remove_before_add_no_resurrection():
+    # out-of-order: remove(3) before add(1)  vs  in-order: add(1) then remove(3).
+    # Both must converge to ABSENT with an identical fingerprint (hwm[X]=3 both).
+    ooo = CausalGraph()
+    ooo.apply_delta(_env(_delta("brain", "x.py", removed=(_sym("brain:x.py:X", "class", "hx"),)), "brain", 3))
+    ooo.apply_delta(_env(_delta("brain", "x.py", added=(_sym("brain:x.py:X", "class", "hx1"),)), "brain", 1))
+
+    ordered = CausalGraph()
+    ordered.apply_delta(_env(_delta("brain", "x.py", added=(_sym("brain:x.py:X", "class", "hx1"),)), "brain", 1))
+    ordered.apply_delta(_env(_delta("brain", "x.py", removed=(_sym("brain:x.py:X", "class", "hx"),)), "brain", 3))
+
+    assert ooo.node("brain:x.py:X") is None
+    assert ordered.node("brain:x.py:X") is None
+    assert ooo.state_fingerprint() == ordered.state_fingerprint()
+
+    g = CausalGraph()
+
+    # a remove arrives for a symbol never yet seen -> records the tombstone hwm
+    n = g.apply_delta(_env(_delta("brain", "x.py", removed=(_sym("brain:x.py:X", "class", "hx"),)), "brain", 3))
+    assert n == 0                       # no node existed to delete
+    assert g.node("brain:x.py:X") is None
+
+    # a STALE lower-seq add must NOT resurrect the symbol
+    n = g.apply_delta(_env(_delta("brain", "x.py", added=(_sym("brain:x.py:X", "class", "hx1"),)), "brain", 1))
+    assert n == 0
+    assert g.node("brain:x.py:X") is None
+
+    # equal-seq add is also stale -> still absent
+    assert g.apply_delta(_env(_delta("brain", "x.py", added=(_sym("brain:x.py:X", "class", "hx3"),)), "brain", 3)) == 0
+    assert g.node("brain:x.py:X") is None
+
+    # a genuinely NEWER add (seq > tombstone) DOES resurrect it -- the guard is
+    # monotonic, not a permanent gravestone
+    n = g.apply_delta(_env(_delta("brain", "x.py", added=(_sym("brain:x.py:X", "class", "hx9"),)), "brain", 9))
+    assert n == 1
+    x = g.node("brain:x.py:X")
+    assert x is not None and x.signature_hash == "hx9" and x.last_emit_seq == 9
+
+
+# ---------------------------------------------------------------------------
 # import edges fold onto the src node
 # ---------------------------------------------------------------------------
 
@@ -267,6 +362,45 @@ def test_import_edges_update_src_node_imports():
         _env(_delta("brain", "mod.py", imp_removed=(ImportEdge("brain:mod.py:mod", "sys", "imports"),)), "brain", 3)
     )
     assert g.node("brain:mod.py:mod").imports == frozenset({"os.path"})
+
+
+# ---------------------------------------------------------------------------
+# snapshot / fingerprint carry the FULL hwm map (live + tombstoned) -- review
+# ---------------------------------------------------------------------------
+
+def test_snapshot_includes_hwm():
+    # (1) same LIVE node-set reached two ways, SAME hwm -> identical fingerprint.
+    gc = CausalGraph()  # added -> removed -> re-added at higher seq
+    gc.apply_delta(_env(_delta("brain", "m.py", added=(_sym("brain:m.py:X", "class", "s1"),)), "brain", 1))
+    gc.apply_delta(_env(_delta("brain", "m.py", removed=(_sym("brain:m.py:X", "class", "s1"),)), "brain", 3))
+    gc.apply_delta(_env(_delta("brain", "m.py", added=(_sym("brain:m.py:X", "class", "s5"),)), "brain", 5))
+
+    gd = CausalGraph()  # direct add at seq 5
+    gd.apply_delta(_env(_delta("brain", "m.py", added=(_sym("brain:m.py:X", "class", "s5"),)), "brain", 5))
+
+    assert gc.node("brain:m.py:X") == gd.node("brain:m.py:X")
+    assert gc.snapshot()["seq_hwm"] == gd.snapshot()["seq_hwm"] == {"brain:m.py:X": 5}
+    assert gc.state_fingerprint() == gd.state_fingerprint()
+
+    # (2) IDENTICAL live node-set (empty) but DIFFERENT hwm -> fingerprints DIFFER,
+    # proving the tombstone hwm is part of the equality witness.
+    ge = CausalGraph()  # add then remove -> empty live, hwm[Y]=3 tombstone
+    ge.apply_delta(_env(_delta("brain", "n.py", added=(_sym("brain:n.py:Y", "class", "y1"),)), "brain", 1))
+    ge.apply_delta(_env(_delta("brain", "n.py", removed=(_sym("brain:n.py:Y", "class", "y1"),)), "brain", 3))
+    gf = CausalGraph()  # empty, no hwm
+
+    assert ge.node_count() == gf.node_count() == 0
+    assert ge.snapshot()["seq_hwm"] == {"brain:n.py:Y": 3}
+    assert gf.snapshot()["seq_hwm"] == {}
+    assert ge.state_fingerprint() != gf.state_fingerprint()
+
+    # (3) roundtrip is stable WITH a tombstoned (removed) symbol in the hwm.
+    rebuilt = CausalGraph.from_snapshot(ge.snapshot())
+    assert rebuilt.state_fingerprint() == ge.state_fingerprint()
+    assert rebuilt.snapshot()["seq_hwm"] == {"brain:n.py:Y": 3}
+    # the tombstone survives the roundtrip: a stale add still cannot resurrect Y
+    assert rebuilt.apply_delta(_env(_delta("brain", "n.py", added=(_sym("brain:n.py:Y", "class", "y2"),)), "brain", 2)) == 0
+    assert rebuilt.node("brain:n.py:Y") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/governance/causal/test_causal_graph.py
+++ b/tests/governance/causal/test_causal_graph.py
@@ -1,0 +1,312 @@
+"""TDD spine for Domain-1 Staging-2 Task 1 -- the in-memory CausalGraph fold.
+
+Eight brief cases proving the O(1) emit_seq-monotonic fold and the fully
+deterministic snapshot / fingerprint that Task 4's crash-recovery determinism
+proof depends on:
+
+  (a) symbols_added        -> nodes present with correct fields
+  (b) resignature (higher) -> signature_hash updated
+  (c) STALE (lower/equal)  -> NO-OP  (the commutativity pin)
+  (d) removed (higher)     -> node gone; stale remove -> node stays
+  (e) file_level_churn     -> that file's nodes re-stamped; OTHER files untouched
+  (f) two orderings        -> identical state_fingerprint (Mandate-4 foundation)
+  (g) snapshot roundtrip   -> identical state_fingerprint
+  (h) malformed envelope   -> returns 0, never raises
+
+Real ``StructuralDelta`` from Staging-0 -- no mocks. Envelopes are built the
+way Staging-1 delivers them: ``{"delta": delta.to_dict(), "lineage": {...}}``.
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.causal.causal_graph import (
+    CausalGraph,
+    CausalNode,
+)
+from backend.core.ouroboros.governance.causal.structural_delta import (
+    ImportEdge,
+    StructuralDelta,
+    SymbolRecord,
+)
+
+
+# ---------------------------------------------------------------------------
+# builders
+# ---------------------------------------------------------------------------
+
+def _delta(
+    repo: str,
+    file_path: str,
+    *,
+    added=(),
+    removed=(),
+    resig=(),
+    imp_added=(),
+    imp_removed=(),
+    churn: bool = False,
+) -> StructuralDelta:
+    return StructuralDelta(
+        repo=repo,
+        file_path=file_path,
+        symbols_added=tuple(added),
+        symbols_removed=tuple(removed),
+        symbols_resignatured=tuple(resig),
+        import_edges_added=tuple(imp_added),
+        import_edges_removed=tuple(imp_removed),
+        file_level_churn=churn,
+        churn_counts={},
+    )
+
+
+def _env(delta: StructuralDelta, repo: str, emit_seq: int, head_sha: str = "sha") -> dict:
+    return {
+        "delta": delta.to_dict(),
+        "lineage": {
+            "repo": repo,
+            "head_sha": head_sha,
+            "parent_sha": "parent",
+            "merge_base": "base",
+            "emit_seq": emit_seq,
+        },
+    }
+
+
+def _sym(symbol_id: str, kind: str, sig: str) -> SymbolRecord:
+    return SymbolRecord(symbol_id=symbol_id, kind=kind, signature_hash=sig)
+
+
+# ---------------------------------------------------------------------------
+# (a) symbols_added -> nodes present with correct fields
+# ---------------------------------------------------------------------------
+
+def test_symbols_added_creates_nodes():
+    g = CausalGraph()
+    d = _delta(
+        "brain",
+        "mod.py",
+        added=(_sym("brain:mod.py:A", "class", "h1"), _sym("brain:mod.py:f", "function", "h2")),
+    )
+    n = g.apply_delta(_env(d, "brain", 5, head_sha="deadbeef"))
+    assert n == 2
+    assert g.node_count() == 2
+
+    a = g.node("brain:mod.py:A")
+    assert isinstance(a, CausalNode)
+    assert a.repo == "brain"
+    assert a.file_path == "mod.py"
+    assert a.kind == "class"
+    assert a.signature_hash == "h1"
+    assert a.last_emit_seq == 5
+    assert a.last_head_sha == "deadbeef"
+    assert a.imports == frozenset()
+
+    repo_nodes = g.nodes_in_repo("brain")
+    assert {x.symbol_id for x in repo_nodes} == {"brain:mod.py:A", "brain:mod.py:f"}
+
+
+# ---------------------------------------------------------------------------
+# (b) resignature (higher emit_seq) -> signature_hash updated
+# ---------------------------------------------------------------------------
+
+def test_resignature_higher_seq_updates_signature():
+    g = CausalGraph()
+    g.apply_delta(_env(_delta("brain", "mod.py", added=(_sym("brain:mod.py:A", "class", "h1"),)), "brain", 1))
+
+    n = g.apply_delta(
+        _env(_delta("brain", "mod.py", resig=(("brain:mod.py:A", "h1", "h2"),)), "brain", 2)
+    )
+    assert n == 1
+    a = g.node("brain:mod.py:A")
+    assert a.signature_hash == "h2"
+    assert a.kind == "class"           # kind preserved across resignature
+    assert a.last_emit_seq == 2
+
+
+# ---------------------------------------------------------------------------
+# (c) STALE (lower / equal emit_seq) -> NO-OP  (commutativity pin)
+# ---------------------------------------------------------------------------
+
+def test_stale_delta_is_noop():
+    g = CausalGraph()
+    g.apply_delta(_env(_delta("brain", "mod.py", added=(_sym("brain:mod.py:A", "class", "h1"),)), "brain", 5))
+    g.apply_delta(_env(_delta("brain", "mod.py", resig=(("brain:mod.py:A", "h1", "hNEW"),)), "brain", 9))
+    fp_before = g.state_fingerprint()
+    assert g.node("brain:mod.py:A").signature_hash == "hNEW"
+    assert g.node("brain:mod.py:A").last_emit_seq == 9
+
+    # lower emit_seq -> ignored
+    low = g.apply_delta(_env(_delta("brain", "mod.py", resig=(("brain:mod.py:A", "hNEW", "hLOW"),)), "brain", 3))
+    # equal emit_seq -> ignored
+    eq = g.apply_delta(_env(_delta("brain", "mod.py", resig=(("brain:mod.py:A", "hNEW", "hEQ"),)), "brain", 9))
+
+    assert low == 0
+    assert eq == 0
+    assert g.node("brain:mod.py:A").signature_hash == "hNEW"
+    assert g.state_fingerprint() == fp_before
+
+
+# ---------------------------------------------------------------------------
+# (d) removed (higher) -> gone; stale remove -> stays
+# ---------------------------------------------------------------------------
+
+def test_remove_higher_then_stale_remove_stays():
+    g = CausalGraph()
+    g.apply_delta(_env(_delta("brain", "mod.py", added=(_sym("brain:mod.py:A", "class", "h1"),)), "brain", 4))
+
+    n = g.apply_delta(_env(_delta("brain", "mod.py", removed=(_sym("brain:mod.py:A", "class", "h1"),)), "brain", 7))
+    assert n == 1
+    assert g.node("brain:mod.py:A") is None
+    assert g.node_count() == 0
+
+    # re-add at seq 10, then a stale remove at seq 6 must NOT delete it
+    g.apply_delta(_env(_delta("brain", "mod.py", added=(_sym("brain:mod.py:A", "class", "h9"),)), "brain", 10))
+    stale = g.apply_delta(_env(_delta("brain", "mod.py", removed=(_sym("brain:mod.py:A", "class", "h9"),)), "brain", 6))
+    assert stale == 0
+    assert g.node("brain:mod.py:A") is not None
+    assert g.node("brain:mod.py:A").last_emit_seq == 10
+
+
+# ---------------------------------------------------------------------------
+# (e) file_level_churn -> that file's nodes re-stamped; OTHER files untouched
+# ---------------------------------------------------------------------------
+
+def test_file_level_churn_scopes_to_one_file():
+    g = CausalGraph()
+    g.apply_delta(_env(_delta("brain", "a.py", added=(_sym("brain:a.py:A", "class", "ha"),)), "brain", 1))
+    g.apply_delta(_env(_delta("brain", "b.py", added=(_sym("brain:b.py:B", "class", "hb"),)), "brain", 2))
+    g.apply_delta(_env(_delta("prime", "c.py", added=(_sym("prime:c.py:C", "class", "hc"),)), "prime", 3))
+
+    unrelated_before = g.node("prime:c.py:C")
+    b_before = g.node("brain:b.py:B")
+
+    # churn on brain/a.py at a newer seq
+    n = g.apply_delta(_env(_delta("brain", "a.py", churn=True), "brain", 8, head_sha="churnsha"))
+    assert n == 1
+
+    a = g.node("brain:a.py:A")
+    assert a.last_emit_seq == 8
+    assert a.last_head_sha == "churnsha"
+    assert a.signature_hash == "ha"     # structure elided -> unchanged
+
+    # OTHER files byte-identical
+    assert g.node("prime:c.py:C") == unrelated_before
+    assert g.node("brain:b.py:B") == b_before
+
+    # churn on a file with no known nodes -> no-op
+    assert g.apply_delta(_env(_delta("prime", "nope.py", churn=True), "prime", 99)) == 0
+
+
+# ---------------------------------------------------------------------------
+# (f) two orderings -> identical fingerprint (Mandate-4 foundation)
+# ---------------------------------------------------------------------------
+
+def _order_independence_envelopes():
+    # F1 in brain is touched by add@3, resig@4, and a WINNING full add@7.
+    # Every other symbol is touched by exactly one delta. Out-of-order emit_seqs.
+    return [
+        _env(_delta("brain", "f.py", added=(_sym("brain:f.py:F1", "function", "s3"),)), "brain", 3, "c3"),
+        _env(_delta("prime", "g.py", added=(_sym("prime:g.py:G1", "class", "sg"),)), "prime", 1, "cg"),
+        _env(_delta("brain", "f.py", resig=(("brain:f.py:F1", "s3", "s4"),)), "brain", 4, "c4"),
+        _env(_delta("reactor", "h.py", added=(_sym("reactor:h.py:H1", "method", "sh"),)), "reactor", 5, "ch"),
+        _env(_delta("brain", "f.py", added=(_sym("brain:f.py:F1", "function", "s7"),)), "brain", 7, "c7"),
+        _env(_delta("prime", "g.py", added=(_sym("prime:g.py:G2", "function", "sg2"),)), "prime", 2, "cg2"),
+    ]
+
+
+def test_two_orderings_same_fingerprint():
+    import random
+
+    envs = _order_independence_envelopes()
+
+    g1 = CausalGraph()
+    for e in envs:
+        g1.apply_delta(e)
+
+    shuffled = list(envs)
+    random.Random(1234).shuffle(shuffled)
+    assert [e["lineage"]["emit_seq"] for e in shuffled] != [e["lineage"]["emit_seq"] for e in envs]
+
+    g2 = CausalGraph()
+    for e in shuffled:
+        g2.apply_delta(e)
+
+    assert g1.state_fingerprint() == g2.state_fingerprint()
+
+    # sanity: the WINNING full add@7 determines F1
+    f1 = g1.node("brain:f.py:F1")
+    assert f1.signature_hash == "s7"
+    assert f1.last_emit_seq == 7
+    assert g1.node_count() == 4
+
+
+# ---------------------------------------------------------------------------
+# import edges fold onto the src node
+# ---------------------------------------------------------------------------
+
+def test_import_edges_update_src_node_imports():
+    g = CausalGraph()
+    # a node whose symbol_id is the import src
+    g.apply_delta(_env(_delta("brain", "mod.py", added=(_sym("brain:mod.py:mod", "function", "h1"),)), "brain", 1))
+    g.apply_delta(
+        _env(
+            _delta(
+                "brain",
+                "mod.py",
+                imp_added=(
+                    ImportEdge("brain:mod.py:mod", "os.path", "imports_from"),
+                    ImportEdge("brain:mod.py:mod", "sys", "imports"),
+                ),
+            ),
+            "brain",
+            2,
+        )
+    )
+    assert g.node("brain:mod.py:mod").imports == frozenset({"os.path", "sys"})
+
+    # remove one at a newer seq
+    g.apply_delta(
+        _env(_delta("brain", "mod.py", imp_removed=(ImportEdge("brain:mod.py:mod", "sys", "imports"),)), "brain", 3)
+    )
+    assert g.node("brain:mod.py:mod").imports == frozenset({"os.path"})
+
+
+# ---------------------------------------------------------------------------
+# (g) snapshot -> from_snapshot -> identical fingerprint
+# ---------------------------------------------------------------------------
+
+def test_snapshot_roundtrip_identical_fingerprint():
+    g = CausalGraph()
+    for e in _order_independence_envelopes():
+        g.apply_delta(e)
+    # add an import fact for good measure
+    g.apply_delta(
+        _env(_delta("brain", "f.py", imp_added=(ImportEdge("brain:f.py:F1", "collections.abc", "imports_from"),)), "brain", 11)
+    )
+
+    snap = g.snapshot()
+    fp = g.state_fingerprint()
+
+    g2 = CausalGraph.from_snapshot(snap)
+    assert g2.state_fingerprint() == fp
+    assert g2.node_count() == g.node_count()
+    assert g2.node("brain:f.py:F1").imports == g.node("brain:f.py:F1").imports
+
+    # snapshot is deterministic across calls
+    assert g.snapshot() == snap
+
+
+# ---------------------------------------------------------------------------
+# (h) malformed envelope -> 0, no raise
+# ---------------------------------------------------------------------------
+
+def test_malformed_envelope_returns_zero_no_raise():
+    g = CausalGraph()
+    assert g.apply_delta(None) == 0
+    assert g.apply_delta({}) == 0
+    assert g.apply_delta({"delta": {}}) == 0                      # missing lineage
+    assert g.apply_delta({"delta": {}, "lineage": {}}) == 0       # missing emit_seq / bad delta
+    assert g.apply_delta({"lineage": {"emit_seq": 1}}) == 0       # missing delta
+    assert g.apply_delta(
+        {"delta": {}, "lineage": {"emit_seq": "notint", "head_sha": "x", "repo": "brain"}}
+    ) == 0
+    assert g.apply_delta("garbage") == 0
+    assert g.node_count() == 0

--- a/tests/governance/causal/test_causal_graph.py
+++ b/tests/governance/causal/test_causal_graph.py
@@ -334,6 +334,70 @@ def test_out_of_order_remove_before_add_no_resurrection():
 
 
 # ---------------------------------------------------------------------------
+# partial-write fields are deterministic under per-repo emit_seq order, and the
+# boundary (arbitrary same-repo reorder) is PINNED as a known divergence -- review
+# ---------------------------------------------------------------------------
+
+def test_partial_write_deterministic_under_per_repo_order():
+    # A single source repo emits its deltas in emit_seq order (emit_seq is that
+    # repo's Lamport clock). Folded in emit_seq order, the partial-write fields
+    # (resignature-sig, import-merge) converge deterministically.
+    seq_ordered = [
+        _env(_delta("brain", "m.py", added=(_sym("brain:m.py:X", "function", "a"),)), "brain", 1),
+        _env(_delta("brain", "m.py", imp_added=(ImportEdge("brain:m.py:X", "os", "imports"),)), "brain", 2),
+        _env(_delta("brain", "m.py", resig=(("brain:m.py:X", "a", "b"),)), "brain", 3),
+        _env(_delta("brain", "m.py", removed=(_sym("brain:m.py:X", "function", "b"),)), "brain", 4),
+        _env(_delta("brain", "m.py", added=(_sym("brain:m.py:X", "function", "c"),)), "brain", 5),
+    ]
+
+    def _fold(order):
+        g = CausalGraph()
+        for e in order:
+            g.apply_delta(e)
+        return g
+
+    # The ingestor delivers per-repo-ordered; two independent emit_seq-ordered
+    # replays are identical (determinism the WAL reconstruction relies on).
+    g1 = _fold(seq_ordered)
+    g2 = _fold(list(seq_ordered))
+    assert g1.state_fingerprint() == g2.state_fingerprint()
+
+    # converged truth: terminal full add@5 -> X present, sig=c, imports dropped
+    # by the remove@4 tombstone/re-add. hwm[X]=5.
+    x = g1.node("brain:m.py:X")
+    assert x is not None and x.signature_hash == "c" and x.last_emit_seq == 5
+    assert x.imports == frozenset()
+    assert g1.snapshot()["seq_hwm"] == {"brain:m.py:X": 5}
+
+    # BOUNDARY PIN (honest): swapping an import-only delta BEFORE the add that
+    # creates its node violates per-repo emit_seq order -- an ingest the event
+    # model never produces (one repo emits in emit_seq order; the WAL preserves
+    # it). Under that illegal shuffle the import fact lands on no node (the add
+    # hasn't run yet) and is lost, so the fold DIVERGES. We assert the divergence
+    # to document the boundary rather than hide it; per-field CRDT clocks would
+    # be over-engineering for a shuffle that cannot occur.
+    imp_pair = [
+        _env(_delta("brain", "p.py", added=(_sym("brain:p.py:Z", "function", "z"),)), "brain", 1),
+        _env(_delta("brain", "p.py", imp_added=(ImportEdge("brain:p.py:Z", "sys", "imports"),)), "brain", 2),
+    ]
+    good_imp = _fold(imp_pair)                          # per-repo order: Z imports={sys}
+    bad_imp = _fold(list(reversed(imp_pair)))           # illegal: import@2 before add@1
+    assert good_imp.node("brain:p.py:Z").imports == frozenset({"sys"})
+    assert bad_imp.node("brain:p.py:Z").imports == frozenset()          # fact lost
+    assert good_imp.state_fingerprint() != bad_imp.state_fingerprint()  # KNOWN, pinned
+
+    # Same boundary via a resignature-terminal partial write:
+    resig_terminal = [
+        _env(_delta("brain", "n.py", added=(_sym("brain:n.py:Y", "function", "p"),)), "brain", 1),
+        _env(_delta("brain", "n.py", resig=(("brain:n.py:Y", "p", "q"),)), "brain", 2),
+    ]
+    good = _fold(resig_terminal)                       # per-repo order: Y sig=q
+    bad = _fold(list(reversed(resig_terminal)))        # illegal reorder: resig before add
+    assert good.node("brain:n.py:Y").signature_hash == "q"
+    assert good.state_fingerprint() != bad.state_fingerprint()  # KNOWN, pinned boundary
+
+
+# ---------------------------------------------------------------------------
 # import edges fold onto the src node
 # ---------------------------------------------------------------------------
 

--- a/tests/governance/causal/test_causal_graph_ingestor.py
+++ b/tests/governance/causal/test_causal_graph_ingestor.py
@@ -151,6 +151,76 @@ def test_ingest_is_non_blocking_and_fold_is_deferred_write_ahead(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
+# (b2) WRITE-AHEAD honesty: a REAL WAL write-failure (flock_append_line -> False,
+#      the true durability layer) must NOT fold the delta -- it is non-durable.
+# --------------------------------------------------------------------------- #
+def test_append_failure_does_not_fold(tmp_path, monkeypatch):
+    """The write-ahead gate must trust an HONEST durability signal. Force a real
+    WAL write-failure at the TRUE layer: monkeypatch
+    ``cross_process_jsonl.flock_append_line`` to return False (lock timeout /
+    write error -- nothing lands on disk). The worker must skip the fold, leave
+    the graph empty, and a fresh replay must find nothing (never durable)."""
+    import backend.core.ouroboros.governance.cross_process_jsonl as cpj
+    wal_path, snap_path = _paths(tmp_path)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            # Real write-failure through the true durability path.
+            monkeypatch.setattr(cpj, "flock_append_line",
+                                lambda *a, **k: False)
+            ing.ingest(_add_env("brain", "f", 1))
+            await ing.flush()
+            # NON-DURABLE -> must NOT be folded into the live graph.
+            assert graph.node("brain:mod.py:f") is None, (
+                "a non-durable delta (WAL write failed) must never fold")
+        finally:
+            await ing.stop()
+
+        # And it is absent from a fresh reconstruction (never hit disk).
+        fresh = CausalGraph()
+        ing2 = CausalGraphIngestor(
+            fresh, wal_path=wal_path, snapshot_path=snap_path)
+        await ing2.replay_from_wal()
+        return ing2.graph.node("brain:mod.py:f")
+
+    recovered_node = asyncio.run(scenario())
+    assert recovered_node is None, (
+        "a non-durable delta must be absent from a fresh replay")
+
+
+def test_append_success_folds_positive_control(tmp_path):
+    """Positive control: with the real (unpatched) durable path, the same delta
+    IS folded and IS present on replay -- proving the failure test above isolates
+    the durability signal, not some unrelated drop."""
+    wal_path, snap_path = _paths(tmp_path)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            ing.ingest(_add_env("brain", "f", 1))
+            await ing.flush()
+            assert graph.node("brain:mod.py:f") is not None
+        finally:
+            await ing.stop()
+
+        fresh = CausalGraph()
+        ing2 = CausalGraphIngestor(
+            fresh, wal_path=wal_path, snapshot_path=snap_path)
+        await ing2.replay_from_wal()
+        return ing2.graph.node("brain:mod.py:f")
+
+    recovered_node = asyncio.run(scenario())
+    assert recovered_node is not None, "a durable delta must survive replay"
+
+
+# --------------------------------------------------------------------------- #
 # (c) PER-REPO-ORDER invariant (the load-bearing pin)
 # --------------------------------------------------------------------------- #
 def test_wal_preserves_per_repo_emit_seq_order(tmp_path):

--- a/tests/governance/causal/test_causal_graph_ingestor.py
+++ b/tests/governance/causal/test_causal_graph_ingestor.py
@@ -1,0 +1,346 @@
+"""TDD spine for Domain-1 Staging-2 Task 3 -- the CausalGraphIngestor.
+
+Event-sourced fold: subscriber callback -> O(1) graph fold + a single
+per-repo-ordered offloaded WAL append + deterministic snapshot compaction.
+
+Cases:
+  (a) ingest -> graph folded + a WAL entry appended (read the WAL back)
+  (b) NON-BLOCKING: ingest returns immediately; the offloaded append lands
+  (c) PER-REPO-ORDER invariant: [add@1, import@2, resig@3] rapid -> WAL entries
+      for that repo are in emit_seq order (the load-bearing pin)
+  (d) compaction: after SNAPSHOT_EVERY_N ingests a snapshot exists + WAL empty
+  (e) snapshot+tail == full-replay (compaction loss-free)
+  (f) organism_bus_host wires ingestor+subscriber when armed; byte-identical off
+  (g) malformed envelope -> dropped, graph + WAL unaffected, no raise
+
+Real ``StructuralDelta`` / ``CausalGraph`` -- no fold mocks. Uses tmp_path WALs.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance.causal.causal_graph import CausalGraph
+from backend.core.ouroboros.governance.causal.causal_graph_ingestor import (
+    CausalGraphIngestor,
+)
+from backend.core.ouroboros.governance.intake.wal import WAL
+from backend.core.ouroboros.governance.causal.structural_delta import (
+    ImportEdge,
+    StructuralDelta,
+    SymbolRecord,
+)
+
+
+# --------------------------------------------------------------------------- #
+# builders
+# --------------------------------------------------------------------------- #
+def _delta(repo, file_path, *, added=(), removed=(), resig=(), imp_added=(),
+           imp_removed=(), churn=False):
+    return StructuralDelta(
+        repo=repo,
+        file_path=file_path,
+        symbols_added=tuple(added),
+        symbols_removed=tuple(removed),
+        symbols_resignatured=tuple(resig),
+        import_edges_added=tuple(imp_added),
+        import_edges_removed=tuple(imp_removed),
+        file_level_churn=churn,
+        churn_counts={},
+    )
+
+
+def _env(delta, repo, emit_seq, head_sha="sha"):
+    return {
+        "delta": delta.to_dict(),
+        "lineage": {
+            "repo": repo,
+            "head_sha": head_sha,
+            "parent_sha": "parent",
+            "merge_base": "base",
+            "emit_seq": emit_seq,
+        },
+    }
+
+
+def _sym(symbol_id, kind, sig):
+    return SymbolRecord(symbol_id=symbol_id, kind=kind, signature_hash=sig)
+
+
+def _add_env(repo, name, emit_seq, sig="h1"):
+    sid = "%s:mod.py:%s" % (repo, name)
+    d = _delta(repo, "mod.py", added=(_sym(sid, "function", sig),))
+    return _env(d, repo, emit_seq)
+
+
+def _paths(tmp_path):
+    return str(tmp_path / "wal.jsonl"), str(tmp_path / "snap.json")
+
+
+async def _poll_until(cond, *, timeout_s=5.0, interval_s=0.01):
+    deadline = time.monotonic() + timeout_s
+    while time.monotonic() < deadline:
+        if cond():
+            return True
+        await asyncio.sleep(interval_s)
+    return cond()
+
+
+# --------------------------------------------------------------------------- #
+# (a) ingest -> graph folded + WAL entry appended
+# --------------------------------------------------------------------------- #
+def test_ingest_folds_graph_and_appends_wal(tmp_path):
+    wal_path, snap_path = _paths(tmp_path)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            ing.ingest(_add_env("brain", "f", 1))
+            await ing.flush()
+        finally:
+            await ing.stop()
+        # graph folded
+        assert graph.node("brain:mod.py:f") is not None
+        # WAL entry appended + readable back
+        entries = WAL(tmp_path / "wal.jsonl").pending_entries()
+        return entries
+
+    entries = asyncio.run(scenario())
+    assert len(entries) == 1
+    assert entries[0].envelope_dict["lineage"]["emit_seq"] == 1
+
+
+# --------------------------------------------------------------------------- #
+# (b) NON-BLOCKING: ingest returns immediately, offloaded write lands
+# --------------------------------------------------------------------------- #
+def test_ingest_is_non_blocking_and_write_lands(tmp_path):
+    wal_path, snap_path = _paths(tmp_path)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            t0 = time.monotonic()
+            ing.ingest(_add_env("brain", "f", 1))
+            elapsed = time.monotonic() - t0
+            # ingest itself does not block on the durable write
+            assert elapsed < 0.25, "ingest blocked on the offloaded append"
+            # graph is folded synchronously (immediately)
+            assert graph.node("brain:mod.py:f") is not None
+            # the durable write lands asynchronously (condition-poll)
+            landed = await _poll_until(
+                lambda: len(WAL(tmp_path / "wal.jsonl").pending_entries()) == 1)
+            assert landed
+        finally:
+            await ing.stop()
+
+    asyncio.run(scenario())
+
+
+# --------------------------------------------------------------------------- #
+# (c) PER-REPO-ORDER invariant (the load-bearing pin)
+# --------------------------------------------------------------------------- #
+def test_wal_preserves_per_repo_emit_seq_order(tmp_path):
+    wal_path, snap_path = _paths(tmp_path)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            sid = "brain:mod.py:f"
+            # add@1, import@2, resig@3 -- same repo, rapid, in emit_seq order.
+            add = _delta("brain", "mod.py",
+                         added=(_sym(sid, "function", "h1"),))
+            imp = _delta("brain", "mod.py",
+                         imp_added=(ImportEdge(sid, "os.path", "imports"),))
+            resig = _delta("brain", "mod.py", resig=((sid, "h1", "h2"),))
+            ing.ingest(_env(add, "brain", 1))
+            ing.ingest(_env(imp, "brain", 2))
+            ing.ingest(_env(resig, "brain", 3))
+            await ing.flush()
+        finally:
+            await ing.stop()
+        entries = WAL(tmp_path / "wal.jsonl").pending_entries()
+        return [e.envelope_dict["lineage"]["emit_seq"] for e in entries]
+
+    seqs = asyncio.run(scenario())
+    assert seqs == [1, 2, 3], (
+        "per-repo WAL append order must equal emit_seq order, got %r" % seqs)
+
+
+# --------------------------------------------------------------------------- #
+# (d) compaction: snapshot exists + WAL truncated after SNAPSHOT_EVERY_N
+# --------------------------------------------------------------------------- #
+def test_compaction_snapshots_and_truncates(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CAUSAL_SNAPSHOT_EVERY_N", "5")
+    wal_path, snap_path = _paths(tmp_path)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            for i in range(5):
+                ing.ingest(_add_env("brain", "f%d" % i, i + 1))
+            await ing.flush()
+        finally:
+            await ing.stop()
+
+    asyncio.run(scenario())
+    from pathlib import Path
+    # snapshot written
+    assert Path(snap_path).exists()
+    # WAL truncated to empty after the fold-to-snapshot
+    assert WAL(tmp_path / "wal.jsonl").pending_entries() == []
+
+
+# --------------------------------------------------------------------------- #
+# (e) snapshot + tail == full-replay (compaction loss-free)
+# --------------------------------------------------------------------------- #
+def test_snapshot_plus_tail_equals_full_replay(tmp_path):
+    wal_path, snap_path = _paths(tmp_path)
+    N = 8
+
+    async def scenario():
+        graph = CausalGraph()
+        # every_n large -> only the explicit snapshot_now() compacts.
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            for i in range(N // 2):
+                ing.ingest(_add_env("brain", "f%d" % i, i + 1))
+            await ing.flush()
+            await ing.snapshot_now()  # force snapshot at N/2 + truncate WAL
+            for i in range(N // 2, N):
+                ing.ingest(_add_env("brain", "f%d" % i, i + 1))
+            await ing.flush()
+            live_fp = graph.state_fingerprint()
+        finally:
+            await ing.stop()
+
+        # fresh graph + fresh ingestor on the SAME paths -> replay
+        fresh = CausalGraph()
+        ing2 = CausalGraphIngestor(
+            fresh, wal_path=wal_path, snapshot_path=snap_path)
+        await ing2.replay_from_wal()
+        return live_fp, ing2.graph.state_fingerprint(), ing2.graph.node_count()
+
+    live_fp, replay_fp, count = asyncio.run(scenario())
+    assert count == N, "replay must reconstruct all N nodes"
+    assert replay_fp == live_fp, (
+        "snapshot + WAL-tail replay must equal the live fingerprint")
+
+
+# --------------------------------------------------------------------------- #
+# (f) organism_bus_host wires ingestor+subscriber when armed; off byte-identical
+# --------------------------------------------------------------------------- #
+def test_organism_host_wires_ingestor_and_subscriber(monkeypatch):
+    import backend.core.ouroboros.governance.transport.organism_bus_host as obh
+
+    recorded = {}
+
+    class _RecordingSubscriber:
+        def __init__(self, bus, *, on_delta=None):
+            recorded["bus"] = bus
+            recorded["on_delta"] = on_delta
+
+        async def start(self):
+            recorded["subscriber_started"] = True
+
+        async def stop(self):
+            recorded["subscriber_stopped"] = True
+
+    class _RecordingIngestor:
+        def __init__(self, graph, **kwargs):
+            recorded["graph"] = graph
+            recorded["ingestor_kwargs"] = kwargs
+
+        def ingest(self, envelope):
+            recorded.setdefault("ingested", []).append(envelope)
+
+        async def start(self):
+            recorded["ingestor_started"] = True
+
+        async def stop(self):
+            recorded["ingestor_stopped"] = True
+
+    import backend.core.ouroboros.governance.causal.causal_delta_subscriber as cds
+    import backend.core.ouroboros.governance.causal.causal_graph_ingestor as cgi
+    monkeypatch.setattr(cds, "CausalDeltaSubscriber", _RecordingSubscriber)
+    monkeypatch.setattr(cgi, "CausalGraphIngestor", _RecordingIngestor)
+
+    host = obh.OrganismBusHost()
+
+    async def scenario():
+        await host._start_causal_subscriber(object())
+
+    asyncio.run(scenario())
+
+    # ingestor constructed + started (replay), subscriber wired to ingest sink
+    assert recorded.get("ingestor_started") is True
+    assert recorded.get("subscriber_started") is True
+    assert recorded.get("on_delta") is not None, (
+        "the subscriber must receive the ingestor.ingest sink as on_delta")
+    # the on_delta is the ingestor's ingest bound method
+    assert callable(recorded["on_delta"])
+
+    # stop in reverse: subscriber then ingestor
+    asyncio.run(host.stop())
+    assert recorded.get("subscriber_stopped") is True
+    assert recorded.get("ingestor_stopped") is True
+
+
+def test_organism_host_causal_wiring_dark_when_master_off(monkeypatch):
+    """Master-off: start() returns False and constructs NOTHING (no causal
+    subscriber, no ingestor). Byte-identical to pre-Task-3."""
+    import backend.core.ouroboros.governance.transport.organism_bus_host as obh
+
+    for key in ("JARVIS_DISTRIBUTED_BUS_ENABLED", "JARVIS_BRAIN_WS_PORT"):
+        monkeypatch.delenv(key, raising=False)
+
+    host = obh.OrganismBusHost()
+    assert asyncio.run(host.start()) is False
+    assert host.started is False
+    assert host._causal_subscriber is None
+    assert getattr(host, "_causal_ingestor", None) is None
+
+
+# --------------------------------------------------------------------------- #
+# (g) malformed envelope -> dropped, graph + WAL unaffected, no raise
+# --------------------------------------------------------------------------- #
+def test_malformed_envelope_dropped_no_raise(tmp_path):
+    wal_path, snap_path = _paths(tmp_path)
+
+    async def scenario():
+        graph = CausalGraph()
+        ing = CausalGraphIngestor(
+            graph, wal_path=wal_path, snapshot_path=snap_path)
+        await ing.start()
+        try:
+            # a grab-bag of malformed shapes -- none may raise, fold, or append
+            ing.ingest(None)  # type: ignore[arg-type]
+            ing.ingest({})
+            ing.ingest({"delta": "not-a-dict", "lineage": {}})
+            ing.ingest({"delta": {}, "lineage": "not-a-dict"})
+            ing.ingest({"delta": {}, "lineage": {"emit_seq": "not-int"}})
+            ing.ingest({"delta": {}})  # missing lineage
+            await ing.flush()
+        finally:
+            await ing.stop()
+        return graph.node_count()
+
+    count = asyncio.run(scenario())
+    assert count == 0, "malformed envelopes must not mutate the graph"
+    assert WAL(tmp_path / "wal.jsonl").pending_entries() == [], (
+        "malformed envelopes must not be appended to the WAL")

--- a/tests/governance/causal/test_causal_graph_ingestor.py
+++ b/tests/governance/causal/test_causal_graph_ingestor.py
@@ -116,9 +116,10 @@ def test_ingest_folds_graph_and_appends_wal(tmp_path):
 
 
 # --------------------------------------------------------------------------- #
-# (b) NON-BLOCKING: ingest returns immediately, offloaded write lands
+# (b) NON-BLOCKING + WRITE-AHEAD: ingest returns immediately; the durable
+#     append lands FIRST, and the graph fold is DEFERRED until after it.
 # --------------------------------------------------------------------------- #
-def test_ingest_is_non_blocking_and_write_lands(tmp_path):
+def test_ingest_is_non_blocking_and_fold_is_deferred_write_ahead(tmp_path):
     wal_path, snap_path = _paths(tmp_path)
 
     async def scenario():
@@ -130,14 +131,19 @@ def test_ingest_is_non_blocking_and_write_lands(tmp_path):
             t0 = time.monotonic()
             ing.ingest(_add_env("brain", "f", 1))
             elapsed = time.monotonic() - t0
-            # ingest itself does not block on the durable write
-            assert elapsed < 0.25, "ingest blocked on the offloaded append"
-            # graph is folded synchronously (immediately)
-            assert graph.node("brain:mod.py:f") is not None
-            # the durable write lands asynchronously (condition-poll)
+            # ingest itself does not block: it is a pure enqueue.
+            assert elapsed < 0.25, "ingest blocked (should be a pure enqueue)"
+            # WRITE-AHEAD: the fold is DEFERRED to the append worker (runs only
+            # after the durable append lands). No await has occurred since
+            # ingest returned, so the worker has NOT yet folded -> graph empty.
+            assert graph.node("brain:mod.py:f") is None, (
+                "fold must be deferred until AFTER the durable append "
+                "(write-ahead), not applied inside ingest")
+            # Both the durable append AND the deferred fold land asynchronously.
             landed = await _poll_until(
-                lambda: len(WAL(tmp_path / "wal.jsonl").pending_entries()) == 1)
-            assert landed
+                lambda: len(WAL(tmp_path / "wal.jsonl").pending_entries()) == 1
+                and graph.node("brain:mod.py:f") is not None)
+            assert landed, "the durable append + deferred fold must both land"
         finally:
             await ing.stop()
 


### PR DESCRIPTION
## Domain-1 Staging-2 — the graph fold

The Brain-side fold of the cross-repo causal sensory organ. Content-free structural deltas arriving over the proven Stage-1 transport hop are woven into a single-writer, event-sourced causal graph with crash-recovery determinism.

### What landed (4 tasks)
- **T1 `CausalGraph`** — O(1) `emit_seq`-monotonic fold; **per-symbol Lamport high-water clock** (`_seq_hwm`) that outlives the node so a stale add can't resurrect a removed symbol; deterministic `snapshot()`/`from_snapshot()`/`state_fingerprint()`. Fold is order-independent for full-writes; partial-writes require per-repo `emit_seq` order (documented invariant + boundary-pinned test).
- **T2 `BlastRadiusOracle`** — intra-repo blast radius via **strict `TheOracle` delegation** (`await offload(oracle.get_blast_radius, …)`), zero re-implemented import resolution. Fail-soft.
- **T3 `CausalGraphIngestor`** — event-sourced **write-AHEAD** fold: a delta is durably appended to the WAL *before* it folds into the live graph. Single `asyncio.Queue` + single `_append_worker` preserves per-repo `emit_seq` order; snapshot compaction on count/idle triggers.
- **T4 crash-recovery determinism** — live graph == WAL-reconstructed graph after tear-down/spin-up; fingerprints MATCH across seeds and across a compaction boundary.

### Review trail (whole-branch + fix re-reviews)
- Partial-write **commutativity boundary** — made the per-repo-order invariant explicit, documented, boundary-pinned (declined per-field CRDT as over-engineering).
- **Write-behind → write-ahead** — ingestor folded-then-appended; a true crash could lose a delta. Fixed to append-durably-first, fold-only-if-durable.
- **Lying durability signal (Critical)** — `WAL.append` swallowed `flock_append_line`'s `False` (lock-timeout/OSError) and returned a success-looking `None`, so a non-durable delta could still fold. Fixed: `WAL.append -> bool` propagates the honest write-failure signal; `_append_one` gates the fold on `(not is_offload_error(res)) and bool(res)`. Regression test monkeypatches `flock_append_line -> False` at the true durability layer and asserts the delta is neither folded nor present on a fresh `replay_from_wal`; positive control proves the bool is load-bearing.

### Tests
97 passed — full causal suite + shared-WAL (`test_wal.py`) + the DurableOutbound consumer (`test_durable_outbound.py`). Determinism fingerprints stable.

### Known follow-up (pre-existing, not this branch)
`transport/durable_outbound.py:570` consumes `WAL.append`'s now-honest bool but only checks `is_offload_error(result)`, never `bool(result)` — the same falsified-durability class one call away in shipped Stage-3 code. Fast follow-up PR incoming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Brain-side causal graph with a true write-ahead fold. Incoming structural changes are durably logged, folded in O(1), and fully recoverable after a crash. Also adds delegated intra-repo impact analysis and fixes WAL durability so non-durable writes never reach the graph.

- **New Features**
  - `CausalGraph` — in-memory fold with per-symbol sequence (last-writer-wins), safe removes, and deterministic `snapshot()`/`from_snapshot()`/`state_fingerprint()`.
  - `CausalGraphIngestor` — event-sourced pipeline: append to WAL first, then fold; single queue/worker preserves per-repo `emit_seq` order; offloaded IO; snapshot compaction and replay-based recovery; wired in `organism_bus_host.py`.
  - `BlastRadiusOracle` — strict delegation to `TheOracle.get_blast_radius` for intra-repo impact; offloaded and fail-soft.

- **Bug Fixes**
  - `wal.append()` now returns a truthful bool; failures no longer look like success. The ingestor folds only on True. Durability-sensitive callers should check the return value.
  - Fixed ordering from fold-then-append to append-then-fold to close the crash window.

<sup>Written for commit a9cead1608dba7b27ba72a08806e35d38368418c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69855?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

