### PR TITLE
fix(transport): DurableOutbound honors WAL.append's honest durability bool

### DIFF
--- a/backend/core/ouroboros/governance/transport/durable_outbound.py
+++ b/backend/core/ouroboros/governance/transport/durable_outbound.py
@@ -575,11 +575,19 @@ class DurableOutbound:
             ts_utc=datetime.now(timezone.utc).isoformat(),
         )
         result = await offload(self._wal.append, entry)
-        if is_offload_error(result):
+        if is_offload_error(result) or not bool(result):
             # Durability honesty (review CRITICAL): the append did NOT
-            # land -- the event must NOT masquerade as pending-durable.
-            # Park it at-risk (memory-only), surface loudly ONCE per
-            # episode, retry on subsequent journal cycles.
+            # land -- either the offload itself errored, OR the REAL WAL
+            # write path completed and returned an honest False (wal.py's
+            # ``append``/``_write_line`` never raise; a lock-timeout or
+            # OSError is caught internally and surfaced as a plain bool).
+            # is_offload_error(False) is False -- a bare bool is not an
+            # OffloadError instance -- so both must be checked. Either way
+            # the event must NOT masquerade as pending-durable. Park it
+            # at-risk (memory-only), surface loudly ONCE per episode,
+            # retry on subsequent journal cycles. Append lands durably
+            # iff is_offload_error(result) is False AND bool(result) is
+            # True.
             self._at_risk[event_id] = entry
             if not self._journal_fail_warned:
                 self._journal_fail_warned = True
@@ -611,7 +619,13 @@ class DurableOutbound:
             # journaled entry then rides pending()/WAL replay, and server
             # dedup makes any duplicate delivery safe.
             result = await offload(self._wal.append, entry)
-            if is_offload_error(result):
+            if is_offload_error(result) or not bool(result):
+                # Same durability-honesty check as the initial append
+                # (review CRITICAL follow-up): an honest False from the
+                # real WAL write path is treated identically to an
+                # OffloadError -- append lands durably iff
+                # is_offload_error(result) is False AND bool(result) is
+                # True.
                 continue  # still failing -- next cycle retries again
             self._at_risk.pop(event_id, None)
             self._pending[event_id] = entry

--- a/tests/governance/transport/test_durable_outbound.py
+++ b/tests/governance/transport/test_durable_outbound.py
@@ -365,6 +365,105 @@ def test_journal_append_failure_not_falsely_durable_then_retried(
 
 
 # --------------------------------------------------------------------------- #
+# (f2) review CRITICAL follow-up: a WAL.append that returns a plain ``False``
+#      (no exception -- e.g. wal.py's honest-durability contract: a lock
+#      timeout / OSError is caught INSIDE flock_append_line and surfaced as
+#      a bool, never raised) must be treated identically to an OffloadError.
+#      ``is_offload_error(False)`` is False -- a bare bool is not an
+#      OffloadError instance -- so BOTH ``self._wal.append`` call sites must
+#      also check ``not bool(result)``. Force the REAL WAL write path to
+#      return an honest False by monkeypatching
+#      ``cross_process_jsonl.flock_append_line`` (wal.py's ``_write_line``
+#      imports it fresh on every call), mirroring the causal ingestor's
+#      regression test for the same durability contract.
+# --------------------------------------------------------------------------- #
+def test_append_false_parks_at_risk_not_pending(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    import backend.core.ouroboros.governance.cross_process_jsonl as cpj
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            # Real write-failure through the true durability path -- no
+            # exception, just an honest False (nothing landed on disk).
+            monkeypatch.setattr(cpj, "flock_append_line",
+                                 lambda *a, **k: False)
+            eid = broker.publish(_EVENT_TYPE, _PREFIX + "false-0", {"i": 0})
+            assert eid
+            await _wait_for(lambda: outbound.journal_failures == 1)
+
+            assert eid not in _pending_ids(outbound), (
+                "a plain False append result must NOT masquerade as "
+                "pending-durable")
+            assert outbound._journal_fail_warned is True
+            probe = DurableOutbound(
+                StreamEventBroker(history_maxlen=4), wal_path=wal_path)
+            assert probe.pending_count() == 0, (
+                "disk must agree: a False-returning append never landed")
+        finally:
+            await outbound.stop()
+
+    _run(scenario())
+
+
+def test_retry_stays_at_risk_while_append_false(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_BODY_WAL_PROBE_INTERVAL_S", "0")
+    wal_path = str(tmp_path / "body_wal.jsonl")
+
+    import time
+    from datetime import datetime, timezone
+
+    import backend.core.ouroboros.governance.cross_process_jsonl as cpj
+    from backend.core.ouroboros.governance.intake.wal import WALEntry
+
+    async def scenario():
+        broker = StreamEventBroker(history_maxlen=64)
+        outbound = DurableOutbound(broker, wal_path=wal_path)
+        await outbound.start()
+        try:
+            entry = WALEntry(
+                lease_id="at-risk-0",
+                envelope_dict={"event_id": "at-risk-0"},
+                status="pending",
+                ts_monotonic=time.monotonic(),
+                ts_utc=datetime.now(timezone.utc).isoformat(),
+            )
+            outbound._at_risk["at-risk-0"] = entry
+            outbound._journal_fail_warned = True
+
+            fault = {"on": True}
+            real_flock = cpj.flock_append_line
+
+            def _flaky_flock(path, line):
+                if fault["on"]:
+                    return False
+                return real_flock(path, line)
+
+            monkeypatch.setattr(cpj, "flock_append_line", _flaky_flock)
+
+            # Still failing -- the entry must remain at-risk, never pending.
+            await outbound._retry_at_risk()
+            assert "at-risk-0" in outbound._at_risk
+            assert "at-risk-0" not in outbound._pending
+            assert outbound._journal_fail_warned is True
+
+            # Fault clears -- the next retry cycle lands it durably.
+            fault["on"] = False
+            await outbound._retry_at_risk()
+            assert "at-risk-0" not in outbound._at_risk
+            assert "at-risk-0" in outbound._pending
+            assert outbound._journal_fail_warned is False
+        finally:
+            await outbound.stop()
+
+    _run(scenario())
+
+
+# --------------------------------------------------------------------------- #
 # (g) review IMPORTANT-1: ack tombstone write failure must not produce the
 #     live-says-acked / disk-says-pending split silently -- the lease stays
 #     parked for retry, ONE distinguishing warning per episode, and the


### PR DESCRIPTION
## Fast follow-up to Domain-1 Staging-2 (durability honesty)

The Staging-2 review closed a lying-durability-signal Critical in the causal ingestor by making `WAL.append` return an **honest bool** (`False` = the underlying `flock_append_line` reported a lock-timeout/OSError and nothing landed on disk; never raises). The whole-branch re-review then found the *same falsified-durability class* one call away in already-shipped **Stage-3 DurableOutbound**, which consumed `WAL.append`'s return but gated only on `is_offload_error(result)` — and `is_offload_error(False)` is `False`, so a genuinely failed append slipped through and the event was marked durably `pending`.

### Fix — two `self._wal.append` call sites
- **Initial journal append** and **`_retry_at_risk` re-append** now gate on `is_offload_error(result) or not bool(result)`. A failed append (`False`) parks the event **at-risk** (memory-only, surfaced once, retried on later journal cycles) instead of masquerading as pending-durable.
- The `self._wal.compact` calls are intentionally **untouched** — `compact()` returns a removed-count where `0` is a legitimate falsy success. Review confirmed no other durability-bool site was missed.

### Tests — `tests/governance/transport/test_durable_outbound.py`
- `test_append_false_parks_at_risk_not_pending` — RED-confirmed pre-fix (event went straight to `_pending`).
- `test_retry_stays_at_risk_while_append_false` — RED-confirmed pre-fix (retry promoted a still-failing entry to `_pending`); the success-flip half proves the recovery/drain path.
- Both monkeypatch `cross_process_jsonl.flock_append_line` so the **real** WAL write path returns an honest `False` (mirrors the causal-ingestor regression test).
- **16 passed** (14 pre-existing + 2 new).

Whole-branch review: APPROVED, no findings survived scrutiny.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DurableOutbound` to treat a `False` return from `WAL.append` as a failed write. Events now stay at-risk and are retried until the append truly lands, preventing false pending-durable states.

- **Bug Fixes**
  - Updated both `self._wal.append` call sites (initial append and `_retry_at_risk`) to gate on `is_offload_error(result) or not bool(result)`.
  - Left `self._wal.compact()` unchanged (`0` removals is a valid success).
  - Added tests that force the real write path to return `False` via `cross_process_jsonl.flock_append_line`, verifying at-risk behavior and recovery on success.

<sup>Written for commit 35e769717d2d5b58bd68ceba3386b31b29a62e7e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

