### PR TITLE
fix(a1): coordinate soak-child audit to the child's PUBLISHED wall deadline

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1445,6 +1445,32 @@ class BattleTestHarness:
                 os.environ["OUROBOROS_BATTLE_WALL_DEADLINE_MONOTONIC"] = (
                     repr(time.monotonic() + float(_wall_cap))
                 )
+                # Cross-process deadline seam (A1 exit-wait coordination,
+                # bt-iso-1783144982). The env var above is per-process; an
+                # OUT-OF-PROCESS supervisor (the isomorphic A1 driver's
+                # exit-wait) needs the child's TRUE wall anchor to size its
+                # wait, instead of GUESSING a boot ceiling — the observed
+                # boot→arm skew was 168s, not the assumed 90s (a ~72s
+                # ShippedCodeInvariants boot validation on this monolith armed
+                # the watchdog long after boot-READY). So ALSO publish the
+                # absolute WALL deadline to a session-dir file the parent can
+                # read. Wall-clock (not monotonic) so it is comparable across
+                # processes; Principle #7 (absolute observability). Best-effort
+                # — a write failure never breaks boot.
+                try:
+                    import json as _json_wd  # noqa: PLC0415
+                    _now_wall = time.time()
+                    (self._session_dir / "wall_deadline.json").write_text(
+                        _json_wd.dumps({
+                            "armed_wall": _now_wall,
+                            "cap_s": float(_wall_cap),
+                            "deadline_wall": _now_wall + float(_wall_cap),
+                        })
+                    )
+                except Exception:  # noqa: BLE001 -- observability seam; never break boot
+                    logger.debug(
+                        "[WallClockWatchdog] wall_deadline.json publish failed "
+                        "(non-fatal)", exc_info=True)
                 # Defect #1 Slice B (2026-05-03) — thread-based safety
                 # net immune to asyncio starvation. The asyncio task
                 # above is the primary path (handles normal termination

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -463,6 +463,172 @@ def _env_float(name: str, default: float) -> float:
         return default
 
 
+# ---------------------------------------------------------------------------
+# Soak-child termination coordination (root cause bt-iso-1783144982)
+# ---------------------------------------------------------------------------
+# The parent must wait for the soak child's OWN guaranteed self-termination
+# before it audits debug.log -- else it audits a TRUNCATED log and scores a
+# spurious FAILED (the incident: 5/6 real autonomy criteria had passed; the
+# child's watchdog heartbeat read remaining=53s at audit time).
+#
+# The child dies at ``wall_anchor + cap + max_kill_margin``. The DEFEATED
+# approaches both tried to GUESS ``wall_anchor``:
+#   * v1: flat ``cap + 30`` anchored at exit-wait START (missed the whole
+#     kill ladder AND the boot skew).
+#   * v2: ``launch + boot_ceiling(90) + cap + max_margin`` -- but the boot->arm
+#     skew is NOT bounded by 90s: the observed skew was 168s (a ~72s
+#     ShippedCodeInvariants boot validation armed the watchdog long after
+#     boot-READY). ``_await_soak_boot`` never enforces its poll ceiling -- it
+#     just stops polling -- so nothing bounds the anchor.
+#
+# ROOT-CAUSE FIX: stop guessing. The harness PUBLISHES its absolute wall
+# deadline to ``<session_dir>/wall_deadline.json`` at arm time (Principle #7 --
+# absolute observability); the parent CONSUMES it. Fully adaptive to any boot
+# duration -- the anchor is the child's OWN published deadline, not an
+# assumption. All margins still come from the harness's own env knobs (single
+# source of truth; no hardcoding).
+
+# How long the parent polls debug.log for the boot-READY marker before it
+# proceeds to inject chaos. This is the boot-READY poll ONLY -- it does NOT (and
+# never did) bound the child's wall anchor; the published deadline does.
+_SOAK_BOOT_READY_POLL_S: float = 90.0
+
+
+def _child_hard_deadline_grace_s() -> float:
+    """The child harness WallClockHardDeadlineThread's graceful-fire grace
+    (``JARVIS_WALL_CLOCK_HARD_DEADLINE_GRACE_S``; floor 5, ceiling 600, default
+    30) -- read from the SAME env knob the harness reads so parent and child
+    share ONE source of truth for the escalation ladder. NEVER raises."""
+    raw = os.environ.get("JARVIS_WALL_CLOCK_HARD_DEADLINE_GRACE_S", "").strip()
+    try:
+        return max(5.0, min(600.0, float(raw) if raw else 30.0))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _child_hard_kill_margin_s() -> float:
+    """The child harness's resource-zero SIGKILL margin
+    (``JARVIS_WALL_CLOCK_HARD_KILL_MARGIN_S``; floor 5, ceiling 300, default
+    30) -- the bounded window after the graceful nudge before the unblockable
+    ``os._exit(137)`` fires. Read from the harness's own knob. NEVER raises."""
+    raw = os.environ.get("JARVIS_WALL_CLOCK_HARD_KILL_MARGIN_S", "").strip()
+    try:
+        return max(5.0, min(300.0, float(raw) if raw else 30.0))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _child_external_watchdog_margin_s() -> float:
+    """The child harness's Slice-49 external subprocess watchdog margin
+    (``JARVIS_EXTERNAL_WATCHDOG_MARGIN_S``; floor 30, default 90). The
+    out-of-process, GIL-immune sentinel SIGKILLs the child WALL-authoritatively
+    at ``cap + this margin`` (``evaluate_kill`` fires unconditionally once
+    ``now - armed >= budget``), so it is the child's LATEST guaranteed
+    self-termination layer -- it exists precisely because the in-process
+    resource-zero thread was proven GIL-starvable (v44: 73min > 40min cap,
+    never fired). Returns 0.0 when the sentinel is disabled
+    (``JARVIS_EXTERNAL_WATCHDOG_ENABLED=false``) -- MUST mirror
+    ``harness._arm_external_watchdog`` exactly. NEVER raises."""
+    if os.environ.get(
+        "JARVIS_EXTERNAL_WATCHDOG_ENABLED", "true",
+    ).strip().lower() in ("false", "0", "no", "off"):
+        return 0.0
+    raw = os.environ.get("JARVIS_EXTERNAL_WATCHDOG_MARGIN_S", "").strip()
+    try:
+        return max(30.0, float(raw) if raw else 90.0)
+    except (TypeError, ValueError):
+        return 90.0
+
+
+def _child_max_kill_margin_s() -> float:
+    """The child's LATEST terminal margin AFTER its wall cap: the MAX of the two
+    independent terminal layers, so the parent waits for whichever kills the
+    child LAST -- the in-process ladder (``grace + margin``) OR the external
+    sentinel (``external_margin``, wall-authoritative + GIL-immune, which
+    dominates under default knobs: 90 > 30+30). All from the harness's OWN env
+    knobs (single source of truth). NEVER raises."""
+    return max(
+        _child_hard_deadline_grace_s() + _child_hard_kill_margin_s(),
+        _child_external_watchdog_margin_s(),
+    )
+
+
+def _parent_exit_deadline_wall(child_deadline_wall: float) -> float:
+    """Absolute WALL time (epoch seconds) the parent must wait until for the
+    child's GUARANTEED self-termination, given the child's OWN published
+    wall-cap deadline (``wall_deadline.json`` ``deadline_wall``). The child dies
+    by ``child_deadline_wall + max_kill_margin`` (whichever terminal layer fires
+    last); ``slack`` (``JARVIS_A1_SOAK_EXIT_SLACK_S``, default 15, floor 5)
+    covers the sentinel's 1s poll + the in-process <=5s poll + IPC latency. This
+    is anchored to the child's OWN published deadline, so it is correct for ANY
+    boot duration -- no boot-ceiling assumption. NEVER raises."""
+    slack = max(5.0, _env_float("JARVIS_A1_SOAK_EXIT_SLACK_S", 15.0))
+    return float(child_deadline_wall) + _child_max_kill_margin_s() + slack
+
+
+def _read_published_wall_deadline(session_dir: str) -> "Optional[float]":
+    """Read the child harness's published absolute wall deadline
+    (``<session_dir>/wall_deadline.json`` ``deadline_wall``, epoch seconds).
+    Returns ``None`` until the child has armed its wall watchdog (the file
+    appears at arm time -- the TRUE anchor, whenever boot actually finishes) or
+    on any read/parse error. NEVER raises."""
+    try:
+        import json as _json_rd  # noqa: PLC0415
+        with open(os.path.join(session_dir, "wall_deadline.json")) as f:
+            data = _json_rd.load(f)
+        dl = data.get("deadline_wall")
+        return float(dl) if dl is not None else None
+    except (OSError, ValueError, TypeError, AttributeError):
+        return None
+
+
+async def _await_soak_child_termination(
+    soak_proc: "Any",
+    debug_log: str,
+    launch_monotonic: "Optional[float]",
+) -> str:
+    """Wait for the soak child's ACTUAL termination, coordinated to its OWN
+    published wall deadline -- adaptive to any boot duration, not a guessed
+    ceiling. Returns ``"exited"`` (the child self-terminated cleanly; audit will
+    see a COMPLETE log) or ``"force_reaped"`` (pathological -- the child
+    outlived its own guaranteed self-kill, or never armed; caller reaps).
+
+    Condition-based (Principle: no arbitrary fixed timeout): the loop's exit
+    conditions are the child's real exit OR its own published deadline elapsing,
+    NOT a magic number. Every blocking read is off-loop (``run_in_executor``) so
+    the co-located SyntheticAdversary aiohttp server keeps serving the child's
+    provider requests throughout. NEVER raises."""
+    loop = asyncio.get_event_loop()
+    session_dir = os.path.dirname(os.path.abspath(debug_log))
+    # Bounds ONLY a genuine pre-arm boot hang (the child never published a
+    # deadline at all). Generous + env-tunable; it is NOT the anchor bound.
+    arm_ceiling_s = max(120.0, _env_float("JARVIS_A1_SOAK_ARM_CEILING_S", 600.0))
+    poll_s = max(1.0, _env_float("JARVIS_A1_SOAK_TERM_POLL_S", 5.0))
+    deadline_wall: "Optional[float]" = None
+    while True:
+        if soak_proc.poll() is not None:
+            return "exited"
+        if deadline_wall is None:
+            deadline_wall = await loop.run_in_executor(
+                None, _read_published_wall_deadline, session_dir)
+            if deadline_wall is None:
+                # Not armed yet -> boot still in progress. Bounded ONLY by the
+                # generous arm ceiling; fires solely on a real pre-arm hang.
+                if launch_monotonic is not None and (
+                        time.monotonic() - launch_monotonic) > arm_ceiling_s:
+                    _log("WARN soak-child never published a wall deadline "
+                         "within arm ceiling (%.0fs) -- pre-arm boot hang; "
+                         "force-reaping" % arm_ceiling_s)
+                    return "force_reaped"
+        else:
+            if time.time() >= _parent_exit_deadline_wall(deadline_wall):
+                _log("WARN soak-child outlived its OWN published wall deadline "
+                     "+ kill margins (deadline_wall=%.0f) -- force-reaping "
+                     "(zero-orphan)" % deadline_wall)
+                return "force_reaped"
+        await asyncio.sleep(poll_s)
+
+
 def _a1_audit_ceiling_s(debug_log: "Optional[str]" = None) -> float:
     """Dynamic Global Audit Ceiling (no hardcoded window). The auditor early-exits
     the moment the verdict is proven; this is the SAFETY ceiling.
@@ -1292,6 +1458,7 @@ class IsomorphicA1Driver:
                         harness_mod.write_stub_soak_log(
                             debug_log, goal_id="GOAL-ISO-A1")
                         soak_proc = None
+                        _soak_launch_monotonic = None
                     else:
                         _log("STEP soak: launching production O+V (pre-inject boot) "
                              "iso_cwd=%s" % iso_cwd)
@@ -1328,8 +1495,14 @@ class IsomorphicA1Driver:
                         handle = _launch_iso_soak(soak_runner, env, run_dir, iso_cwd)
                         debug_log = handle.debug_log
                         soak_proc = handle.proc
+                        # Record launch time for the pre-arm-hang ceiling in
+                        # _await_soak_child_termination (NOT an anchor guess --
+                        # the child publishes its true wall deadline).
+                        _soak_launch_monotonic = time.monotonic()
                         _log("STEP await boot READY (TestWatcher fs.changed.* sub)")
-                        _await_soak_boot(soak_proc, debug_log, timeout_s=90.0)
+                        _await_soak_boot(
+                            soak_proc, debug_log,
+                            timeout_s=_SOAK_BOOT_READY_POLL_S)
 
                     _log("STEP soak boot OK: debug_log=%s" % debug_log)
 
@@ -1395,28 +1568,58 @@ class IsomorphicA1Driver:
                     # the co-located SyntheticAdversary aiohttp server runs on
                     # that SAME loop and must keep serving the child's requests
                     # throughout the wait.
+                    _soak_force_reaped = False
                     if soak_proc is not None:
-                        import subprocess as _subprocess_mod  # noqa: PLC0415
-                        _wait_budget_s = float(_soak_wall_s) + 30.0
-                        _log("STEP await soak-child exit (bind audit to ACTUAL "
-                             "completion, budget=%.0fs) -- no more stale FAILED "
-                             "verdicts from a fixed post-boot audit window"
-                             % _wait_budget_s)
+                        # Wait for the child's ACTUAL termination, coordinated
+                        # to its OWN published wall deadline (wall_deadline.json)
+                        # -- adaptive to any boot duration, so the audit only
+                        # ever sees a COMPLETE debug.log. Replaces the pre-fix
+                        # boot-ceiling GUESS that expired before the child's
+                        # self-kill and audited a truncated log
+                        # (bt-iso-1783144982).
+                        _log("STEP await soak-child termination (coordinated to "
+                             "the child's published wall deadline -- adaptive, "
+                             "no boot-ceiling guess) so the audit sees a "
+                             "COMPLETE log")
                         try:
-                            await asyncio.get_event_loop().run_in_executor(
-                                None,
-                                lambda: soak_proc.wait(timeout=_wait_budget_s),
-                            )
+                            _term_status = await _await_soak_child_termination(
+                                soak_proc, debug_log, _soak_launch_monotonic)
+                        except Exception as exc:  # noqa: BLE001 -- never block audit
+                            _term_status = "exited"
+                            _log("soak-child termination-wait warning: %r "
+                                 "(proceeding to audit)" % (exc,))
+                        if _term_status == "exited":
                             _log("STEP soak-child exited (rc=%s)"
                                  % (soak_proc.returncode,))
-                        except _subprocess_mod.TimeoutExpired:
-                            _log("WARN soak-child did not exit within "
-                                 "wall(%.0fs)+30s grace -- auditing whatever the "
-                                 "log currently holds (should not happen; the "
-                                 "child's own wall-clock watchdog guarantees "
-                                 "exit)" % (_soak_wall_s,))
-                        except Exception as exc:  # noqa: BLE001
-                            _log("soak-child wait warning: %r" % (exc,))
+                        else:
+                            # PATHOLOGICAL: the child outlived its OWN published
+                            # deadline + all kill margins (near-impossible), or
+                            # never armed. Do NOT audit a truncated log as if
+                            # complete: deterministically reap the whole process
+                            # GROUP (SIGTERM->SIGKILL cascade via the existing
+                            # runner primitive -- DRY, off-loop so the adversary
+                            # keeps serving) + waitpid so zero orphans/zombies
+                            # survive, and flag the verdict truncated so it is
+                            # never mistaken for a genuine cognitive FAILED.
+                            _soak_force_reaped = True
+                            _reap_join_s = max(
+                                5.0, _env_float("JARVIS_A1_SOAK_REAP_JOIN_S", 30.0))
+                            _log("WARN soak-child force-reap: process-group "
+                                 "SIGTERM->SIGKILL + waitpid (zero-orphan) "
+                                 "before audit; verdict will be marked truncated")
+                            _loop = asyncio.get_event_loop()
+                            try:
+                                await _loop.run_in_executor(None, _reap_soak_runners)
+                                await _loop.run_in_executor(
+                                    None,
+                                    lambda: soak_proc.wait(timeout=_reap_join_s),
+                                )
+                                _log("STEP soak-child force-reaped (rc=%s)"
+                                     % (soak_proc.returncode,))
+                            except Exception:  # noqa: BLE001 -- best-effort join
+                                _log("WARN soak-child still unreaped after force "
+                                     "cascade -- atexit process-group kill is "
+                                     "the final backstop")
 
                     # ── Fast-Fail short-circuit: a global L4 capacity wall means the
                     # cognitive loop can NEVER reach APPLIED this run. Skip the audit
@@ -1458,8 +1661,19 @@ class IsomorphicA1Driver:
                         )
 
                         proven = bool(verdict.get("proven"))
-                        _log("STEP audit VERDICT: %s"
-                             % ("A1_DISPATCH_PROVEN" if proven else "FAILED"))
+                        # A force-reaped child means the audit ran on a log the
+                        # child never got to finish flushing -- tag it so a
+                        # truncated FAILED is never read as a genuine cognitive
+                        # failure (the child outlived its own resource-zero
+                        # envelope, an infra pathology, not an autonomy verdict).
+                        if _soak_force_reaped and isinstance(verdict, dict):
+                            verdict["soak_child_force_reaped"] = True
+                            verdict.setdefault(
+                                "audit_log_truncated", not proven)
+                        _log("STEP audit VERDICT: %s%s"
+                             % ("A1_DISPATCH_PROVEN" if proven else "FAILED",
+                                " (log truncated: child force-reaped)"
+                                if _soak_force_reaped else ""))
 
                     # ── f. FAILURE PATH: T5 telemetry + local autopsy ────────
                     if not proven:

--- a/tests/scripts/test_soak_exit_wait_budget.py
+++ b/tests/scripts/test_soak_exit_wait_budget.py
@@ -1,0 +1,189 @@
+"""Regression spine for the A1 soak-child termination coordination.
+
+Root cause (bt-iso-1783144982, 2026-07-04): the isomorphic A1 driver audited
+the soak child's debug.log BEFORE the child had actually terminated, scoring a
+spurious FAILED while 5/6 real autonomy criteria had passed (the child's own
+watchdog heartbeat read remaining=53s at audit time).
+
+Two defeated approaches both tried to GUESS the child's wall anchor:
+  * v1: flat ``cap + 30`` anchored at exit-wait START.
+  * v2: ``launch + boot_ceiling(90) + cap + max_margin`` -- but the boot->arm
+    skew is unbounded (observed 168s: a ~72s ShippedCodeInvariants boot
+    validation armed the watchdog long after boot-READY), so a hardcoded 90s
+    ceiling is empirically false.
+
+ROOT-CAUSE FIX: the harness PUBLISHES its absolute wall deadline to
+``<session_dir>/wall_deadline.json`` at arm time; the parent CONSUMES it. The
+parent's exit deadline = ``published_deadline_wall + max_kill_margin + slack``,
+which is correct for ANY boot duration because it is anchored to the child's
+OWN published deadline -- no boot-ceiling assumption. These tests pin that
+invariant (incl. the boot-time-INDEPENDENCE the v2 ceiling lacked), the
+env-knob single-source-of-truth, the file read, and the adaptive
+termination-wait coroutine.
+"""
+from __future__ import annotations
+
+import asyncio
+import importlib
+import json
+
+iso = importlib.import_module("scripts.isomorphic_a1_local")
+
+
+# Harness defaults (backend/core/ouroboros/battle_test/harness.py):
+#  - in-process ladder (_start_wall_clock_hard_deadline_thread): grace 5..600
+#    default 30; margin 5..300 default 30.
+#  - external sentinel (_arm_external_watchdog): margin floor 30 / default 90,
+#    WALL-authoritative -- the LATEST guaranteed kill (90 > 30+30 by default).
+_HARNESS_GRACE_DEFAULT = 30.0
+_HARNESS_MARGIN_DEFAULT = 30.0
+_HARNESS_EXTERNAL_MARGIN_DEFAULT = 90.0
+
+
+def _clear_all_knobs(monkeypatch):
+    for k in (
+        "JARVIS_WALL_CLOCK_HARD_DEADLINE_GRACE_S",
+        "JARVIS_WALL_CLOCK_HARD_KILL_MARGIN_S",
+        "JARVIS_EXTERNAL_WATCHDOG_MARGIN_S",
+        "JARVIS_EXTERNAL_WATCHDOG_ENABLED",
+        "JARVIS_A1_SOAK_EXIT_SLACK_S",
+        "JARVIS_A1_SOAK_ARM_CEILING_S",
+        "JARVIS_A1_SOAK_TERM_POLL_S",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+# ── margin helpers: single source of truth with the harness ──────────────
+
+def test_shared_env_knob_readers_match_harness_defaults_and_bounds(monkeypatch):
+    _clear_all_knobs(monkeypatch)
+    assert iso._child_hard_deadline_grace_s() == _HARNESS_GRACE_DEFAULT
+    assert iso._child_hard_kill_margin_s() == _HARNESS_MARGIN_DEFAULT
+    assert iso._child_external_watchdog_margin_s() == _HARNESS_EXTERNAL_MARGIN_DEFAULT
+    # max_kill_margin picks the LATER layer (external 90 > in-process 60).
+    assert iso._child_max_kill_margin_s() == 90.0
+    # Floor/ceiling clamps mirror the harness.
+    monkeypatch.setenv("JARVIS_WALL_CLOCK_HARD_DEADLINE_GRACE_S", "1")
+    monkeypatch.setenv("JARVIS_WALL_CLOCK_HARD_KILL_MARGIN_S", "9999")
+    monkeypatch.setenv("JARVIS_EXTERNAL_WATCHDOG_MARGIN_S", "1")
+    assert iso._child_hard_deadline_grace_s() == 5.0
+    assert iso._child_hard_kill_margin_s() == 300.0
+    assert iso._child_external_watchdog_margin_s() == 30.0
+    # in-process ladder now dominates (5+300=305 > external 30).
+    assert iso._child_max_kill_margin_s() == 305.0
+    # External sentinel disabled -> 0 contribution (mirrors _arm_external_watchdog).
+    monkeypatch.setenv("JARVIS_EXTERNAL_WATCHDOG_ENABLED", "false")
+    assert iso._child_external_watchdog_margin_s() == 0.0
+    # Garbage -> default, never raises.
+    monkeypatch.setenv("JARVIS_WALL_CLOCK_HARD_DEADLINE_GRACE_S", "not-a-number")
+    assert iso._child_hard_deadline_grace_s() == _HARNESS_GRACE_DEFAULT
+
+
+# ── the core invariant: parent deadline covers the child's guaranteed kill ─
+
+def test_parent_deadline_covers_child_guaranteed_kill(monkeypatch):
+    _clear_all_knobs(monkeypatch)
+    # Child published its wall-cap deadline (armed_wall + cap). Its guaranteed
+    # death is that + max_kill_margin (the external sentinel at +90 by default).
+    child_deadline_wall = 1_000_000.0
+    child_guaranteed_death = child_deadline_wall + _HARNESS_EXTERNAL_MARGIN_DEFAULT
+    parent_deadline = iso._parent_exit_deadline_wall(child_deadline_wall)
+    assert parent_deadline >= child_guaranteed_death + 5.0, (
+        "parent must outlast the child's guaranteed death, with slack")
+
+
+def test_parent_deadline_is_boot_time_INDEPENDENT(monkeypatch):
+    # THE crux the v2 boot-ceiling missed: because the parent anchors to the
+    # child's OWN published deadline (not a launch+ceiling guess), the invariant
+    # holds for ANY boot->arm skew -- including the 168s that broke v2, and a
+    # pathological 900s cold boot. armed_wall = launch + boot_skew; the child
+    # publishes deadline_wall = armed_wall + cap; parent covers it regardless.
+    _clear_all_knobs(monkeypatch)
+    launch_wall = 1_000_000.0
+    cap = 3600.0
+    for boot_skew in (5.0, 90.0, 168.0, 500.0, 900.0):
+        armed_wall = launch_wall + boot_skew
+        published_deadline_wall = armed_wall + cap
+        child_guaranteed_death = (
+            published_deadline_wall + _HARNESS_EXTERNAL_MARGIN_DEFAULT)
+        parent_deadline = iso._parent_exit_deadline_wall(published_deadline_wall)
+        assert parent_deadline >= child_guaranteed_death + 5.0, (
+            "invariant must hold at boot_skew=%.0fs (v2's 90s ceiling failed "
+            "at 168s)" % boot_skew)
+
+
+def test_parent_deadline_tracks_env_knobs(monkeypatch):
+    # Widen EITHER ladder -> the parent's deadline grows with the max.
+    _clear_all_knobs(monkeypatch)
+    monkeypatch.setenv("JARVIS_WALL_CLOCK_HARD_DEADLINE_GRACE_S", "120")
+    monkeypatch.setenv("JARVIS_WALL_CLOCK_HARD_KILL_MARGIN_S", "90")   # in-proc 210
+    monkeypatch.setenv("JARVIS_EXTERNAL_WATCHDOG_MARGIN_S", "150")     # external 150
+    monkeypatch.setenv("JARVIS_A1_SOAK_EXIT_SLACK_S", "20")
+    child_deadline_wall = 1_000_000.0
+    # max(210, 150) = 210; parent = deadline + 210 + 20.
+    assert iso._parent_exit_deadline_wall(child_deadline_wall) == (
+        child_deadline_wall + 210.0 + 20.0)
+
+
+# ── the published-deadline file read ─────────────────────────────────────
+
+def test_read_published_wall_deadline_roundtrip(tmp_path):
+    (tmp_path / "wall_deadline.json").write_text(json.dumps({
+        "armed_wall": 1_000_000.0, "cap_s": 3600.0,
+        "deadline_wall": 1_003_600.0}))
+    assert iso._read_published_wall_deadline(str(tmp_path)) == 1_003_600.0
+
+
+def test_read_published_wall_deadline_missing_or_garbage(tmp_path):
+    # Missing file -> None (child not armed yet).
+    assert iso._read_published_wall_deadline(str(tmp_path)) is None
+    # Garbage -> None, never raises.
+    (tmp_path / "wall_deadline.json").write_text("{not json")
+    assert iso._read_published_wall_deadline(str(tmp_path)) is None
+    # Present but no deadline_wall key -> None.
+    (tmp_path / "wall_deadline.json").write_text(json.dumps({"cap_s": 10}))
+    assert iso._read_published_wall_deadline(str(tmp_path)) is None
+
+
+# ── the adaptive termination-wait coroutine ──────────────────────────────
+
+class _FakeProc:
+    """Minimal Popen stand-in: alive for `alive_polls` poll() calls, then rc."""
+    def __init__(self, alive_polls: int, rc: int = 0):
+        self._alive_polls = alive_polls
+        self._rc = rc
+        self.returncode = None
+
+    def poll(self):
+        if self._alive_polls > 0:
+            self._alive_polls -= 1
+            return None
+        self.returncode = self._rc
+        return self._rc
+
+
+def test_termination_wait_returns_exited_when_child_exits(tmp_path, monkeypatch):
+    _clear_all_knobs(monkeypatch)
+    monkeypatch.setenv("JARVIS_A1_SOAK_TERM_POLL_S", "1")  # floored to 1s
+    debug_log = str(tmp_path / "debug.log")
+    open(debug_log, "w").close()
+    proc = _FakeProc(alive_polls=2, rc=0)  # exits on the 3rd poll
+    status = asyncio.get_event_loop().run_until_complete(
+        iso._await_soak_child_termination(proc, debug_log, launch_monotonic=None))
+    assert status == "exited"
+
+
+def test_termination_wait_force_reaps_past_published_deadline(tmp_path, monkeypatch):
+    # Child NEVER exits, and its published deadline is already in the past ->
+    # the coroutine must force-reap (not hang, not audit-truncated-silently).
+    _clear_all_knobs(monkeypatch)
+    monkeypatch.setenv("JARVIS_A1_SOAK_TERM_POLL_S", "1")
+    debug_log = str(tmp_path / "debug.log")
+    open(debug_log, "w").close()
+    # deadline_wall far in the past -> _parent_exit_deadline_wall already elapsed.
+    (tmp_path / "wall_deadline.json").write_text(json.dumps({
+        "deadline_wall": 1.0}))  # epoch 1970 -> long past
+    proc = _FakeProc(alive_polls=10_000, rc=0)  # never exits within the test
+    status = asyncio.get_event_loop().run_until_complete(
+        iso._await_soak_child_termination(proc, debug_log, launch_monotonic=None))
+    assert status == "force_reaped"


### PR DESCRIPTION
## Root cause (bt-iso-1783144982)

The isomorphic A1 driver audited the soak child's debug.log **before the child terminated**, scoring a spurious FAILED while 5/6 real autonomy criteria had passed. Proof: the child's own WallClockWatchdog heartbeat read `remaining=53s` at audit time — it was still 53s from its cap, running healthily. The parent had abandoned it.

Two guessing approaches were defeated (both anchored the parent's wait on an *assumed* child wall-anchor):
- flat `cap + 30` at exit-wait start;
- `launch + boot_ceiling(90) + cap + max_margin` — but the boot→arm skew is **unbounded** (observed **168s**: a ~72s ShippedCodeInvariants boot validation armed the watchdog long after boot-READY). Bumping the ceiling is the hardcoded-bypass the mandate forbids.

## Root-cause fix — published-deadline IPC contract (Principle #7)

- **`harness.py`**: at wall-watchdog arm time, publish the absolute wall deadline to `<session_dir>/wall_deadline.json` (`armed_wall`, `cap_s`, `deadline_wall`). Mirrors the existing `OUROBOROS_BATTLE_WALL_DEADLINE_MONOTONIC` env seam, but as a **cross-process file** the out-of-process parent can read. Best-effort; never breaks boot.
- **`isomorphic_a1_local.py`**: the parent **consumes** that deadline and waits until `deadline_wall + max_kill_margin + slack` — adaptive to **any** boot duration because it's anchored to the child's *own* published deadline, not a guess. `max_kill_margin = max(in-process grace+margin, external Slice-49 sentinel margin)` — the sentinel dominates by default (90 > 30+30) and is the latest guaranteed kill. All margins read from the harness's own env knobs (single source of truth).
- Condition-based off-loop termination wait (`run_in_executor` so the co-located adversary keeps serving); deterministic process-group reap + `waitpid` on the pathological path (zero-orphan); verdict tagged `soak_child_force_reaped` so a truncated FAILED is never misread.

## Review trail

Two independent review rounds caught **two real defects**, both closed: (1) the external GIL-immune sentinel outlasting the in-process ladder → `max()`; (2) the boot-ceiling assumption empirically false (168s observed) → replaced with the published-deadline contract. Final re-review **APPROVED** — verified the harness `_session_dir` == parent `dirname(debug_log)` byte-identically (no wired-but-inert trap).

## Live proof

Full faithful local run (`cap=3600s`, process mode, `$0`): `soak-child exited (rc=0)` on a **COMPLETE** log (`force_reaped=None`, `audit_log_truncated=None`) — through the same 90s cold-boot timeout that broke the old approach. The truncation fog is gone; the run now cleanly attributes the *real* autonomy blocker (`fsm:did_not_reach_state_applied` — Advisor correctly blocking high-blast-radius/zero-coverage targets under host memory pressure).

Tests: `tests/scripts/test_soak_exit_wait_budget.py` — margin single-source-of-truth, the parent-deadline invariant, boot-time-**independence** across skews 5..900s, file read, async termination coroutine. 8 new + 12 adjacent green; harness wall-clock-cap suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coordinates the soak-child audit to the child’s published wall deadline to stop auditing truncated logs and prevent spurious FAILED results. The harness now writes the absolute wall deadline and the parent waits against it with correct margins and slack.

- **Bug Fixes**
  - Harness writes `<session_dir>/wall_deadline.json` with `armed_wall`, `cap_s`, and `deadline_wall`.
  - Parent reads that file and waits until `deadline + max_kill_margin + slack`; margins come from the same env knobs and account for the external watchdog (no boot-ceiling guess).
  - Async, condition-based wait keeps the adversary server responsive; on deadline overrun or missing arm, force-reaps the process group and tags the verdict with `soak_child_force_reaped` and `audit_log_truncated`.
  - Added regression tests for env-knob parity, boot-skew independence, file read, and the termination-wait coroutine.

<sup>Written for commit 492d82a3df14a811e76697966d53cba0d18ca724. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69857?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

