### PR TITLE
feat(a1): isolated pure-leaf ignition vector (blast radius 1, coverage 1.0)

### DIFF
--- a/backend/core/ouroboros/a1_ignition_vector/__init__.py
+++ b/backend/core/ouroboros/a1_ignition_vector/__init__.py
@@ -1,0 +1,26 @@
+"""A1 Ignition Vector -- a deliberately ISOLATED pure-leaf target package.
+
+Purpose
+-------
+This package exists solely as the surgical **isolated test vector** for the A1
+autonomy-gate ignition (GCP Brain drill, 2026-07-05). It is imported by NOTHING
+in the production graph (blast radius ~1) and is fully covered by its own test
+(coverage 1.0), so a synthetic failure injected here clears the
+``OperationAdvisor`` gate **legitimately** -- without lowering any governance
+threshold -- letting the organism drive a full CLASSIFY->...->APPLIED cycle on
+a change that is genuinely safe to auto-apply.
+
+Why this is not a shortcut
+--------------------------
+The Advisor blocks auto-apply when ``blast_radius >= 20 and coverage == 0`` (or
+``blast_radius >= 10`` under memory pressure). Real production files the chaos
+injector otherwise selects (e.g. ``repl_input_polish.py``) are widely imported
+(blast radius 50) and trip that gate -- correctly. This package is the opposite
+by construction: a leaf nothing depends on, with 100% test coverage. The gate
+still runs at full strictness; the target simply satisfies it honestly.
+
+The chaos injector is scoped to this package via
+``JARVIS_CHAOS_TARGET_DIRS=backend/core/ouroboros/a1_ignition_vector`` so it
+selects a pure-leaf function HERE rather than anywhere else in the tree.
+"""
+from __future__ import annotations

--- a/backend/core/ouroboros/a1_ignition_vector/leaf_predicates.py
+++ b/backend/core/ouroboros/a1_ignition_vector/leaf_predicates.py
@@ -1,0 +1,40 @@
+"""Isolated pure-leaf numeric predicates -- the A1 ignition target surface.
+
+Every function here is a STRUCTURALLY PURE LEAF (operators only, no calls, no
+I/O, no globals) so the AST chaos injector can select and mutate one, and each
+is exhaustively exercised by ``tests/.../test_leaf_predicates.py`` (coverage
+1.0). Nothing in the production graph imports this module (blast radius ~1).
+
+Do not add imports of this module elsewhere -- its isolation is load-bearing:
+it is what lets a synthetic failure here clear the OperationAdvisor gate
+honestly (blast_radius=1 + coverage=1.0), never by relaxing the gate.
+"""
+from __future__ import annotations
+
+
+def is_even(n: int) -> bool:
+    """Return True iff ``n`` is even. Pure leaf: modulo + comparison, no calls."""
+    return n % 2 == 0
+
+
+def sign(n: int) -> int:
+    """Return ``-1``, ``0`` or ``1`` for negative, zero, positive ``n``."""
+    if n > 0:
+        return 1
+    if n < 0:
+        return -1
+    return 0
+
+
+def in_closed_range(x: int, low: int, high: int) -> bool:
+    """Return True iff ``low <= x <= high`` (inclusive on both ends)."""
+    return low <= x <= high
+
+
+def clamp01(x: int) -> int:
+    """Clamp ``x`` into the closed interval ``[0, 1]`` (operators only)."""
+    if x < 0:
+        return 0
+    if x > 1:
+        return 1
+    return x

--- a/tests/governance/a1_ignition_vector/test_leaf_predicates.py
+++ b/tests/governance/a1_ignition_vector/test_leaf_predicates.py
@@ -1,0 +1,45 @@
+"""Exhaustive green tests for the isolated A1 ignition target (coverage 1.0).
+
+These are what make the target a LEGITIMATE auto-apply candidate: the chaos
+injector requires a green test exercising the function it mutates, and the
+OperationAdvisor's coverage signal reads ``test_leaf_predicates.py`` as full
+coverage of ``leaf_predicates.py``. A mutation that breaks one of these turns a
+test RED (the live-fire signal); the organism's fix must turn it GREEN again.
+"""
+from __future__ import annotations
+
+from backend.core.ouroboros.a1_ignition_vector.leaf_predicates import (
+    clamp01,
+    in_closed_range,
+    is_even,
+    sign,
+)
+
+
+def test_is_even():
+    assert is_even(0) is True
+    assert is_even(2) is True
+    assert is_even(-4) is True
+    assert is_even(1) is False
+    assert is_even(-3) is False
+
+
+def test_sign():
+    assert sign(5) == 1
+    assert sign(0) == 0
+    assert sign(-7) == -1
+
+
+def test_in_closed_range():
+    assert in_closed_range(5, 1, 10) is True
+    assert in_closed_range(1, 1, 10) is True   # inclusive low
+    assert in_closed_range(10, 1, 10) is True  # inclusive high
+    assert in_closed_range(0, 1, 10) is False
+    assert in_closed_range(11, 1, 10) is False
+
+
+def test_clamp01():
+    assert clamp01(-5) == 0
+    assert clamp01(0) == 0
+    assert clamp01(1) == 1
+    assert clamp01(7) == 1


### PR DESCRIPTION
The surgical **isolated test vector** for the A1 autonomy-gate GCP Brain drill (mandate 1: engineer a safe target, do not lower Advisor thresholds).

`backend/core/ouroboros/a1_ignition_vector/leaf_predicates.py` — pure-leaf numeric predicates imported by **nothing** in the production graph (blast radius ~1), fully covered by `tests/governance/a1_ignition_vector/test_leaf_predicates.py` (coverage 1.0).

**Why root-cause, not a shortcut:** the `OperationAdvisor` blocks auto-apply at `blast_radius>=20 & coverage==0` (or `>=10` under memory pressure) — real files the chaos injector otherwise picks (`repl_input_polish.py`, blast radius 50) trip that gate *correctly*. This target satisfies the **same full-strictness gate honestly** (blast 1 + coverage 1.0). Scoped via `JARVIS_CHAOS_TARGET_DIRS`.

**Validated locally:** injector selects `clamp01`/`is_even`/`sign` (pure leaves w/ green tests); real inject → test RED (`assert -5 == 0`) → `--revert` byte-identical GREEN; 4 tests pass.

The GCP Brain node inherits this via its boot-time `git pull --ff-only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an isolated A1 ignition vector. A tiny pure-leaf package with 100% test coverage gives the chaos injector a safe target (blast radius 1) that passes OperationAdvisor without lowering thresholds.

- **New Features**
  - Introduced `backend/core/ouroboros/a1_ignition_vector` with pure-leaf functions: `is_even`, `sign`, `in_closed_range`, `clamp01`.
  - Added exhaustive tests in `tests/governance/a1_ignition_vector/test_leaf_predicates.py` (coverage 1.0).
  - Scoped chaos selection via `JARVIS_CHAOS_TARGET_DIRS=backend/core/ouroboros/a1_ignition_vector` to keep blast radius ~1.

- **Migration**
  - Set `JARVIS_CHAOS_TARGET_DIRS` to `backend/core/ouroboros/a1_ignition_vector`.

<sup>Written for commit 4b9e573127dc8fb395644caf91875fc356ac1b2a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69858?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

