### PR TITLE
fix(a1-brain): live-fire hardening (all-zone teardown, root exec, venv+plugins)

### DIFF
--- a/backend/requirements-brain.txt
+++ b/backend/requirements-brain.txt
@@ -42,6 +42,17 @@ fastembed>=0.3.0         # Oracle LITE embeddings (graduated default-ON); pulls 
 aiosqlite==0.19.0        # Oracle SQLite persistence
 aiofiles==23.2.1
 pytest-timeout==2.4.0
+# pytest.ini sets `asyncio_mode = auto` + json/metadata plugins -- WITHOUT these
+# the Brain's pytest subprocesses (TestRunner VERIFY + the A1 chaos-injector's
+# RED-verification `_run_pytest_node`) error on the repo config and collect 0
+# tests (rc=5), so a genuine bug reads as "test did not go RED". Live-fire
+# a1-brain-20260705-173831: the lean venv had pytest but not these -> the A1
+# isolated-vector injection could not go RED on the node. Pinned to the repo's
+# own versions.
+pytest-asyncio==1.3.0
+pytest-json-report==1.5.0
+pytest-metadata==3.1.1
+anyio==4.12.0
 redis>=4.2.0             # cost_tracker streaming (inert without a server)
 fastapi==0.124.2         # MCP HTTP transport (guarded)
 uvicorn==0.38.0          # telemetry broker (guarded)

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -63,15 +63,22 @@ wall. Ordering invariant: ``soak_wall_s < monitor_stop < lifetime_s``.
 
 Teardown defense-in-depth (mandate 4, $0 even on total Mac network loss)
 -------------------------------------------------------------------------
-  1. This script's own explicit ``get_compute_rest().delete_instance()`` on
-     clean finish (fastest).
+  1. This script's own explicit ``get_compute_rest().delete_instance()`` sweep
+     ACROSS THE FULL CANDIDATE ZONE CHAIN (``_candidate_teardown_zones`` --
+     mirrors ``zone_fallback_chain``) on clean finish (fastest). Live-fire fix:
+     scatter-gather can land the winner in ANY zone in the chain, so this no
+     longer trusts a single (possibly stale/wrong) resolved zone.
   2. An up-front-registered atexit/SIGINT/SIGTERM reaper (drains
-     ``_ACTIVE_IGNITIONS``) -- bypassed only by SIGKILL.
-  3. The node-side absolute self-destruct (Piece D) -- survives Mac SIGKILL /
+     ``_ACTIVE_IGNITIONS``, itself now an all-zone sweep for the SAME reason)
+     -- bypassed only by SIGKILL.
+  3. A post-sweep ``list_instances_by_label`` $0-verify: if the node is STILL
+     found (a zone outside the matrix, or an outright REST failure), re-delete
+     it at the zone the verify list actually discovered.
+  4. The node-side absolute self-destruct (Piece D) -- survives Mac SIGKILL /
      total network partition.
-  4. ``scripts/gcp_cleanup.py`` (Piece A, already extended to match
+  5. ``scripts/gcp_cleanup.py`` (Piece A, already extended to match
      ``jarvis-role=brain``) -- Mac-side sweep once network returns.
-  5. The existing idle-shutdown timer (clean-idle backstop).
+  6. The existing idle-shutdown timer (clean-idle backstop).
 
 ``--dry-run`` prints the FULL plan (provision params, remote command, SSH argv,
 Black-Box pull argv preview, teardown argv preview, absolute-lifetime) and
@@ -90,6 +97,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import atexit
+import base64
 import importlib.util
 import json
 import os
@@ -389,6 +397,116 @@ def _compose_dispatch_wrapper(remote_cmd: str, remote_run_dir: str) -> str:
     )
 
 
+def _compose_verify_head_command() -> str:
+    """The remote HEAD-verification script. `/opt/trinity/jarvis` is ROOT-owned
+    (golden-image bake; the boot-time git-pull runs as root), so the SSH
+    OS-Login user hits `fatal: detected dubious ownership` on a bare
+    `git rev-parse` -- the `safe.directory` exception is required BEFORE the
+    rev-parse, and (since we run the whole thing root-wrapped via
+    `_wrap_as_root`) both lines execute as root, matching the tree's owner."""
+    quoted_root = shlex.quote(_REMOTE_REPO_ROOT)
+    return (
+        "git config --global --add safe.directory %s >/dev/null 2>&1; "
+        "git -C %s rev-parse HEAD" % (quoted_root, quoted_root)
+    )
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 (live-fire): root-wrapped remote exec. `/opt/trinity/jarvis` is
+# ROOT-owned (golden-image bake) -- the SSH OS-Login user can neither
+# `git rev-parse` (dubious ownership) nor `mkdir`/write under it directly. GCE
+# OS Login admins get passwordless sudo, so every node-side command that
+# touches that tree runs as root via a SINGLE base64 | sudo bash pipe instead
+# of nesting `sudo bash -c '...'` around already-quoted payloads (the nested
+# quoting is what makes the complex nohup dispatch wrapper unmanageable) --
+# one clean layer of quoting, the whole script runs as root (so any
+# background/disowned child it forks inherits root too, which is what lets
+# the detached soak keep writing under the root-owned tree after the SSH
+# session that dispatched it closes).
+# ---------------------------------------------------------------------------
+def _wrap_as_root(remote_cmd: str) -> str:
+    """Root-wrap `remote_cmd` for a single clean layer of quoting: base64-encode
+    the whole script locally, and have the remote shell decode + execute it
+    under `sudo bash`. NEVER raises (base64-encoding a str is infallible)."""
+    encoded = base64.b64encode(remote_cmd.encode("utf-8")).decode("ascii")
+    return "printf %%s %s | base64 -d | sudo bash" % (shlex.quote(encoded),)
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 (live-fire, MONEY-CRITICAL): the full cross-region candidate zone
+# chain teardown must sweep. Scatter-gather provisioning can land the WINNER
+# in any zone in this chain (`gcp_compute_rest.create_instance` races
+# `zone_fallback_chain(...)` waves) -- a leak happens when teardown only
+# tries the ONE zone a (possibly-wrong) resolution picked. Mirrors
+# ignite_brain_vm.py's `_reap_brain_resources_async` reap-across-chain
+# pattern: EVERY exit path sweeps EVERY candidate zone, unconditionally.
+# ---------------------------------------------------------------------------
+def _candidate_teardown_zones(preferred: Optional[str] = None) -> List[str]:
+    """The full ordered zone chain teardown must attempt `delete_instance` in.
+    `preferred` (the pre-create/operator zone) leads the chain but the WHOLE
+    matrix (all regions) is always included -- so a scatter-gather winner
+    landing in ANY candidate zone still gets swept. Falls back to
+    `GCP_ZONE` env (the same preferred `create_instance` itself races from)
+    when `preferred` is not given. Fail-soft: any import/lookup error
+    degrades to a single-zone list (never raises, never blocks teardown)."""
+    pref = (preferred or os.environ.get("GCP_ZONE", "") or "").strip() or None
+    try:
+        from backend.core.ouroboros.governance.zone_fallback import (  # noqa: PLC0415
+            zone_fallback_chain,
+        )
+
+        chain = zone_fallback_chain(pref)
+        if chain:
+            return chain
+    except Exception as exc:  # noqa: BLE001 -- must never block teardown
+        _log("WARN zone_fallback_chain unavailable (%r) -- degrading to a "
+             "single-zone teardown sweep" % (exc,))
+    return [pref] if pref else [None]
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 (live-fire): resolve_actual_zone must pick the RUNNING winner, not a
+# being-deleted loser. Under scatter-gather, multiple same-named instances
+# can briefly coexist (winner RUNNING in one zone, losers STOPPING/
+# TERMINATED elsewhere mid-reap) -- a naive first-match pick can grab a loser.
+# ---------------------------------------------------------------------------
+_ZONE_STATUS_RANK: Dict[str, int] = {
+    "RUNNING": 0,
+    "PROVISIONING": 1,
+    "STAGING": 1,
+    "REPAIRING": 2,
+    "SUSPENDING": 3,
+    "SUSPENDED": 3,
+    "STOPPING": 4,
+    "TERMINATED": 5,
+}
+
+
+def _status_rank(status: Optional[str]) -> int:
+    """Lower is better (more likely the live winner). Unknown/missing status
+    ranks in the middle -- neither preferred over a confirmed RUNNING match
+    nor penalized below a confirmed STOPPING/TERMINATED one. NEVER raises."""
+    return _ZONE_STATUS_RANK.get(str(status or "").strip().upper(), 2)
+
+
+# Parses the AUTHORITATIVE winner zone out of provision_brain's detail string.
+# gcp_compute_rest.create_instance's scatter-gather winner reports
+# "created:zone=<z>:mode=<m>" (see GCPComputeRest._insert_in_zone) -- this is
+# the real create-time zone, straight from the REST call that materialized
+# the node, and is preferred over re-listing (which can observe a transient
+# multi-instance race).
+_PROVISION_ZONE_RE = re.compile(r"zone=([a-zA-Z0-9-]+)")
+
+
+def _parse_provision_zone(detail: str) -> Optional[str]:
+    """Parse the winner zone out of provision()'s `(ok, detail)` detail
+    string. Fail-soft -- returns None on any non-match, NEVER raises."""
+    if not detail:
+        return None
+    m = _PROVISION_ZONE_RE.search(str(detail))
+    return m.group(1) if m else None
+
+
 # ---------------------------------------------------------------------------
 # Up-front teardown registry -- mirrors ignite_brain_vm.py's
 # _ACTIVE_BRAIN_RESOURCES / _reap_brain_resources pattern (idempotent, NEVER
@@ -401,17 +519,29 @@ _SIGNAL_HANDLERS_INSTALLED = False
 
 
 def _register_ignition(
-    *, node: str, zone: Optional[str], compute_rest_factory: Callable[[], Any]
+    *, node: str, zones: Sequence[Optional[str]], compute_rest_factory: Callable[[], Any]
 ) -> None:
     """Register a Brain node for teardown UP FRONT (before/at create) so a
-    crash mid-provision still reaps it."""
+    crash mid-provision still reaps it. `zones` is the FULL candidate zone
+    chain (Bug 1) -- NOT a single (possibly-wrong) resolved zone -- so the
+    reaper always sweeps every zone the scatter-gather winner could have
+    landed in, regardless of which zone later resolution picks."""
     _ACTIVE_IGNITIONS.append(
-        {"node": node, "zone": zone, "compute_rest_factory": compute_rest_factory}
+        {
+            "node": node,
+            "zones": list(zones) if zones else [None],
+            "confirmed_zone": None,  # informational only; never gates teardown
+            "compute_rest_factory": compute_rest_factory,
+        }
     )
 
 
 async def _reap_ignitions_async() -> None:
-    """Drain the registry: delete every registered node. Idempotent (the
+    """Drain the registry: for every registered node, attempt
+    `delete_instance` across EVERY zone in its candidate chain (Bug 1) --
+    unconditionally, not stopping at the first success, since idempotent
+    404-is-success semantics mean sweeping the whole chain is cheap and
+    guarantees the node is gone wherever it actually landed. Idempotent (the
     registry is cleared before the loop runs, so re-entrant/second calls are a
     no-op) + fail-soft (NEVER raises -- teardown must always complete)."""
     if not _ACTIVE_IGNITIONS:
@@ -420,17 +550,22 @@ async def _reap_ignitions_async() -> None:
     _ACTIVE_IGNITIONS.clear()
     for entry in entries:
         node = entry.get("node")
-        zone = entry.get("zone")
+        zones = entry.get("zones") or [entry.get("zone")]  # tolerate legacy shape
         factory = entry.get("compute_rest_factory") or _default_compute_rest_factory
         if not node:
             continue
         try:
             rest = factory()
-            ok, detail = await rest.delete_instance(node, zone=zone)
-            _log("[Reap] delete_instance node=%s zone=%s -> ok=%s detail=%s"
-                 % (node, zone, ok, detail))
         except Exception as exc:  # noqa: BLE001 -- reap must NEVER raise
-            _log("[Reap] warning node=%s: %r" % (node, exc))
+            _log("[Reap] factory error node=%s: %r" % (node, exc))
+            continue
+        for zone in zones:
+            try:
+                ok, detail = await rest.delete_instance(node, zone=zone)
+                _log("[Reap] delete_instance node=%s zone=%s -> ok=%s detail=%s"
+                     % (node, zone, ok, detail))
+            except Exception as exc:  # noqa: BLE001 -- reap must NEVER raise
+                _log("[Reap] warning node=%s zone=%s: %r" % (node, zone, exc))
 
 
 def _reap_ignitions() -> None:
@@ -500,6 +635,9 @@ class IgnitionPlan:
     remote_run_dir: str
     remote_cmd: str
     dispatch_wrapper_cmd: str
+    dispatch_wrapper_root_cmd: str = ""
+    verify_head_cmd: str = ""
+    teardown_zones: List[str] = field(default_factory=list)
     ssh_argv: List[str] = field(default_factory=list)
     pull_argv: List[str] = field(default_factory=list)
     teardown_argv: List[str] = field(default_factory=list)
@@ -539,6 +677,16 @@ class A1BrainIgnition:
         self.node_name = node_name or _default_node_name()
         self.project = (project or "").strip()
         self.zone = (zone or "").strip()
+        # Bug 2: the AUTHORITATIVE winner zone parsed from provision()'s
+        # "created:zone=<z>:mode=<m>" detail string -- set by provision(),
+        # preferred by resolve_actual_zone() over re-listing (avoids a
+        # scatter-gather race where a same-named LOSER is briefly visible).
+        self._provision_zone: Optional[str] = None
+        # Bug 1: the full candidate zone chain teardown sweeps -- set by
+        # provision() (up front, before create); computed fresh from
+        # self.zone if teardown() is ever reached without provision() having
+        # run (e.g. a direct test call).
+        self._teardown_zones: List[str] = []
 
         # Coordinated soak-wall <-> node-lifetime budget (review fix): the
         # on-node soak wall and the node's absolute self-destruct lifetime
@@ -618,6 +766,35 @@ class A1BrainIgnition:
         return await loop.run_in_executor(
             None, lambda: self._ssh_exec(remote, timeout_s=timeout_s))
 
+    async def _await_ssh_ready(self) -> bool:
+        """Poll SSH-over-IAP until the freshly-provisioned node ANSWERS, before
+        verify_head/dispatch. A new node needs ~30-90s to reach RUNNING + boot
+        sshd + establish the IAP tunnel; the pre-readiness-gate driver SSHed
+        immediately after provision and got rc=255 (ssh exit 255 = tunnel/host
+        not ready). Bounded + backoff, off-loop, fail-soft. Budget env
+        ``JARVIS_A1_BRAIN_SSH_READY_BUDGET_S`` (default 300, floor 60). Returns
+        True once a trivial `echo` round-trips; False if the budget elapses."""
+        budget_s = max(60.0, _env_float("JARVIS_A1_BRAIN_SSH_READY_BUDGET_S", 300.0))
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + budget_s
+        attempt = 0
+        delay = 5.0
+        while loop.time() < deadline:
+            attempt += 1
+            rc, out = await self._ssh_exec_async(
+                "echo A1_SSH_READY", timeout_s=30.0)
+            if rc == 0 and "A1_SSH_READY" in (out or ""):
+                _log("[IgniteA1Brain] SSH-over-IAP ready after %d attempt(s)"
+                     % (attempt,))
+                return True
+            _log("[IgniteA1Brain] SSH not ready yet (attempt %d rc=%d) -- "
+                 "retry in %.0fs" % (attempt, rc, delay))
+            await asyncio.sleep(delay)
+            delay = min(30.0, delay * 1.5)
+        _log("[IgniteA1Brain] WARN SSH-over-IAP not ready within %.0fs budget"
+             % (budget_s,))
+        return False
+
     # -- plan (pure, dry-run-safe) --------------------------------------------
 
     def build_plan(self) -> IgnitionPlan:
@@ -627,13 +804,17 @@ class A1BrainIgnition:
             remote_run_dir=self.remote_run_dir, seed=self.seed, verbose=self.verbose,
             soak_wall_s=self.soak_wall_s)
         dispatch_wrapper = _compose_dispatch_wrapper(remote_cmd, self.remote_run_dir)
+        # Bug 3: the command actually sent over SSH is root-wrapped (single
+        # base64 | sudo bash pipe) -- /opt/trinity/jarvis is root-owned.
+        dispatch_wrapper_root = _wrap_as_root(dispatch_wrapper)
+        verify_head_cmd = _wrap_as_root(_compose_verify_head_command())
         ns = argparse.Namespace(project=project, zone=zone)
 
         ssh_argv: List[str] = []
         teardown_argv: List[str] = []
         try:
             hyper = self._hyper()
-            ssh_argv = hyper._ssh_cmd(ns, self.node_name, dispatch_wrapper)
+            ssh_argv = hyper._ssh_cmd(ns, self.node_name, dispatch_wrapper_root)
             teardown_argv = hyper._delete_node_cmd(ns, self.node_name)
         except Exception as exc:  # noqa: BLE001 -- planning must never raise
             _log("WARN plan preview: hypervisor argv builders unavailable: %r" % (exc,))
@@ -651,6 +832,10 @@ class A1BrainIgnition:
             "JARVIS_BRAIN_VM_PERSISTENT": "true",
             "JARVIS_BRAIN_ABSOLUTE_LIFETIME_S": str(self.lifetime_s),
         }
+        # Bug 1: the FULL candidate zone chain teardown will sweep -- shown so
+        # --dry-run makes the $0 guarantee legible (not just the pre-create
+        # zone, which scatter-gather may not even land in).
+        teardown_zones = _candidate_teardown_zones(zone or None)
         return IgnitionPlan(
             node_name=self.node_name,
             project=project,
@@ -661,6 +846,9 @@ class A1BrainIgnition:
             remote_run_dir=self.remote_run_dir,
             remote_cmd=remote_cmd,
             dispatch_wrapper_cmd=dispatch_wrapper,
+            dispatch_wrapper_root_cmd=dispatch_wrapper_root,
+            verify_head_cmd=verify_head_cmd,
+            teardown_zones=teardown_zones,
             ssh_argv=ssh_argv,
             pull_argv=pull_argv,
             teardown_argv=teardown_argv,
@@ -676,8 +864,9 @@ class A1BrainIgnition:
         print("=" * 78)
         print("  node_name         : %s" % plan.node_name)
         print("  project           : %s" % plan.project)
-        print("  zone (pre-create) : %s  (actual zone resolved post-create via "
-              "list_instances_by_label)" % plan.zone)
+        print("  zone (pre-create) : %s  (actual zone resolved post-create -- "
+              "PREFERS the provision-reported winner zone, falls back to a "
+              "RUNNING-preferring list_instances_by_label match)" % plan.zone)
         print("  soak_wall_s       : %d  (-> OUROBOROS_BATTLE_MAX_WALL_SECONDS, "
               "on-node soak hard wall)" % plan.soak_wall_s)
         print("  lifetime_s        : %d  (-> JARVIS_BRAIN_ABSOLUTE_LIFETIME_S, "
@@ -694,10 +883,17 @@ class A1BrainIgnition:
         print("REMOTE COMMAND (isomorphic_a1_local.py, co-located ON the node):")
         print("  " + plan.remote_cmd)
         print("-" * 78)
-        print("DISPATCH WRAPPER (detached nohup; monitor() polls the done-file):")
-        print("  " + plan.dispatch_wrapper_cmd)
+        print("VERIFY-HEAD COMMAND (root-wrapped: safe.directory + git rev-parse AS ROOT):")
+        print("  " + plan.verify_head_cmd)
         print("-" * 78)
-        print("SSH ARGV (reused sovereign_iac_hypervisor._ssh_cmd):")
+        print("DISPATCH WRAPPER, raw (detached nohup; monitor() polls the done-file):")
+        print("  " + plan.dispatch_wrapper_cmd)
+        print("DISPATCH WRAPPER, root-wrapped (what is ACTUALLY sent over SSH --"
+              " /opt/trinity/jarvis is root-owned):")
+        print("  " + plan.dispatch_wrapper_root_cmd)
+        print("-" * 78)
+        print("SSH ARGV (reused sovereign_iac_hypervisor._ssh_cmd; --command carries "
+              "the root-wrapped dispatch wrapper above):")
         print("  " + _argv(plan.ssh_argv))
         print("-" * 78)
         print("BLACK-BOX PULL ARGV preview (reused IapBlackBoxTransport._scp_pull_cmd):")
@@ -707,6 +903,12 @@ class A1BrainIgnition:
         print("  " + _argv(plan.teardown_argv))
         print("  (the REAL teardown executes get_compute_rest().delete_instance("
               "node, zone=...) directly -- this argv is informational only)")
+        print("-" * 78)
+        print("TEARDOWN ALL-ZONE SWEEP (Bug 1 fix -- every exit path, incl. the "
+              "SIGINT/SIGTERM reaper, deletes the node NAME across EVERY zone "
+              "below, idempotent + fail-soft, so the $0 guarantee does not "
+              "depend on which zone got resolved):")
+        print(("  " + ", ".join(plan.teardown_zones)) if plan.teardown_zones else "  <none>")
         print("=" * 78)
         print("DRY RUN: zero network / subprocess side effects. Exiting 0.")
 
@@ -714,9 +916,13 @@ class A1BrainIgnition:
 
     async def provision(self) -> Tuple[bool, str]:
         _install_signal_handlers()
-        # Register UP FRONT (before create) so a crash mid-provision still reaps.
+        # Bug 1: register UP FRONT (before create) with the FULL candidate
+        # zone chain -- NOT a single (possibly pre-create, possibly wrong)
+        # zone -- so a crash mid-provision (or a later SIGINT/SIGTERM) still
+        # reaps the node wherever the scatter-gather winner actually landed.
+        self._teardown_zones = _candidate_teardown_zones(self.zone or None)
         _register_ignition(
-            node=self.node_name, zone=self.zone or None,
+            node=self.node_name, zones=self._teardown_zones,
             compute_rest_factory=self._compute_rest_factory)
 
         prev_persistent = os.environ.get("JARVIS_BRAIN_VM_PERSISTENT")
@@ -739,6 +945,13 @@ class A1BrainIgnition:
             else:
                 os.environ["JARVIS_BRAIN_ABSOLUTE_LIFETIME_S"] = prev_lifetime
 
+        # Bug 2: capture the AUTHORITATIVE winner zone straight out of the
+        # create-time detail string ("created:zone=<z>:mode=<m>") -- this is
+        # the real create-time zone, preferred by resolve_actual_zone() over
+        # a post-hoc list_instances_by_label query that can observe a
+        # transient scatter-gather multi-instance race.
+        self._provision_zone = _parse_provision_zone(detail) if ok else None
+
         _log("provision -> ok=%s detail=%s" % (ok, detail))
         return ok, detail
 
@@ -760,7 +973,33 @@ class A1BrainIgnition:
              "downstream will be missing --project")
         return None
 
+    def _mark_confirmed_zone(self, zone: str) -> None:
+        """Record the confirmed SSH-target zone for logging/introspection
+        ONLY -- teardown no longer depends on this being right (Bug 1 sweeps
+        the whole candidate chain unconditionally); this just tells the
+        reaper log which zone to expect the node in."""
+        self.zone = zone
+        for entry in _ACTIVE_IGNITIONS:
+            if entry.get("node") == self.node_name:
+                entry["confirmed_zone"] = zone
+
     async def resolve_actual_zone(self) -> Optional[str]:
+        """Bug 2: prefer the AUTHORITATIVE zone provision() parsed straight
+        out of the create-time detail string over re-listing (the real
+        create-time zone the REST call materialized the node in). Only when
+        that isn't available does this fall back to list_instances_by_label
+        -- and even then, prefer a RUNNING/PROVISIONING/STAGING match over a
+        STOPPING/TERMINATED one, since scatter-gather can leave a same-named
+        LOSER briefly visible mid-reap in a different zone (the exact live-fire
+        bug: a STOPPING loser in zone A got picked over the RUNNING winner in
+        zone B). This zone feeds the SSH target (verify_head/dispatch/
+        monitor) -- teardown's $0 guarantee no longer depends on it (Bug 1)."""
+        if self._provision_zone:
+            self._mark_confirmed_zone(self._provision_zone)
+            _log("resolved actual zone=%s for node=%s (source=provision_detail)"
+                 % (self._provision_zone, self.node_name))
+            return self._provision_zone
+
         try:
             from backend.core.ouroboros.governance.gcp_compute_rest import (  # noqa: PLC0415
                 _BRAIN_ROLE_LABEL_KEY,
@@ -773,25 +1012,37 @@ class A1BrainIgnition:
         except Exception as exc:  # noqa: BLE001
             _log("WARN zone resolution error (continuing, fail-soft): %r" % (exc,))
             return None
-        for inst in instances or []:
-            if inst.get("name") == self.node_name:
-                raw_zone = str(inst.get("zone") or "")
-                zone = raw_zone.rsplit("/", 1)[-1] if raw_zone else None
-                if zone:
-                    self.zone = zone
-                    for entry in _ACTIVE_IGNITIONS:
-                        if entry.get("node") == self.node_name:
-                            entry["zone"] = zone
-                    _log("resolved actual zone=%s for node=%s" % (zone, self.node_name))
-                    return zone
-        _log("WARN could not find node=%s via list_instances_by_label -- zone "
-             "remains unresolved" % (self.node_name,))
+
+        matches = [inst for inst in (instances or []) if inst.get("name") == self.node_name]
+        if not matches:
+            _log("WARN could not find node=%s via list_instances_by_label -- zone "
+                 "remains unresolved" % (self.node_name,))
+            return None
+
+        # RUNNING-preferring pick: sort is STABLE, so ties keep the original
+        # (API) order -- only a strictly better status jumps the queue.
+        best = sorted(matches, key=lambda inst: _status_rank(inst.get("status")))[0]
+        raw_zone = str(best.get("zone") or "")
+        zone = raw_zone.rsplit("/", 1)[-1] if raw_zone else None
+        if zone:
+            self._mark_confirmed_zone(zone)
+            _log("resolved actual zone=%s status=%s for node=%s "
+                 "(source=list_running_preferred, %d match(es))"
+                 % (zone, best.get("status"), self.node_name, len(matches)))
+            return zone
+        _log("WARN matched instance(s) for node=%s but zone field was empty"
+             % (self.node_name,))
         return None
 
     # -- phase 3: verify HEAD ---------------------------------------------------
 
     async def verify_head(self) -> Optional[str]:
-        remote = "git -C %s rev-parse HEAD" % (_REMOTE_REPO_ROOT,)
+        # Bug 3: /opt/trinity/jarvis is ROOT-owned (golden-image bake; the
+        # boot-time git-pull runs as root) -- a bare `git rev-parse` as the
+        # SSH OS-Login user fails with "dubious ownership". Root-wrap the
+        # whole thing (safe.directory exception + rev-parse) via a single
+        # base64 | sudo bash pipe.
+        remote = _wrap_as_root(_compose_verify_head_command())
         rc, out = await self._ssh_exec_async(
             remote, timeout_s=_env_float("JARVIS_A1_BRAIN_SSH_TIMEOUT_S", 60.0))
         text = (out or "").strip()
@@ -812,8 +1063,13 @@ class A1BrainIgnition:
             remote_run_dir=self.remote_run_dir, seed=self.seed, verbose=self.verbose,
             soak_wall_s=self.soak_wall_s)
         wrapper = _compose_dispatch_wrapper(remote, self.remote_run_dir)
+        # Bug 3: the mkdir + nohup + isomorphic_a1_local.py invocation all
+        # write under the root-owned /opt/trinity/jarvis tree -- root-wrap the
+        # WHOLE detached wrapper so the disowned child it forks inherits root
+        # too (it keeps writing after this SSH session closes).
+        root_wrapper = _wrap_as_root(wrapper)
         rc, out = await self._ssh_exec_async(
-            wrapper, timeout_s=_env_float("JARVIS_A1_BRAIN_DISPATCH_TIMEOUT_S", 60.0))
+            root_wrapper, timeout_s=_env_float("JARVIS_A1_BRAIN_DISPATCH_TIMEOUT_S", 60.0))
         ok = rc == 0 and "DISPATCH_STARTED" in (out or "")
         _log("dispatch -> rc=%d ok=%s out=%r" % (rc, ok, (out or "")[-300:]))
         return ok
@@ -824,12 +1080,15 @@ class A1BrainIgnition:
         deadline = time.monotonic() + self._monitor_max_s
         tail_lines = _env_int("JARVIS_A1_BRAIN_MONITOR_TAIL_LINES", 40)
         last_tail = ""
-        remote = (
+        inner = (
             "if [ -f %s ]; then echo __IGNITE_DONE__; cat %s; else "
             "tail -n %d %s 2>/dev/null || true; fi"
             % (shlex.quote(self._done_file()), shlex.quote(self._done_file()),
                tail_lines, shlex.quote(self._log_file()))
         )
+        # Bug 3: the done-file/log-file live under the root-owned run dir --
+        # the SSH user may not have read access, so poll AS ROOT too.
+        remote = _wrap_as_root(inner)
         while time.monotonic() < deadline:
             rc, out = await self._ssh_exec_async(
                 remote, timeout_s=_env_float("JARVIS_A1_BRAIN_MONITOR_SSH_TIMEOUT_S", 30.0))
@@ -849,10 +1108,14 @@ class A1BrainIgnition:
     # -- phase 6: retrieve verdict (authoritative) --------------------------------
 
     def _discover_verdict_path(self) -> Optional[str]:
-        remote = (
+        # Bug 3: the verdict lives under the root-owned run dir -- `find` as
+        # the plain SSH user can hit permission-denied on root-owned
+        # subdirectories, so this runs AS ROOT too.
+        inner = (
             "find %s -maxdepth 2 -name a1_verdict.json 2>/dev/null | sort | tail -n1"
             % (shlex.quote(self.remote_run_dir),)
         )
+        remote = _wrap_as_root(inner)
         rc, out = self._ssh_exec(remote, timeout_s=30.0)
         if rc != 0 or not out:
             return None
@@ -860,10 +1123,12 @@ class A1BrainIgnition:
         return lines[-1] if lines else None
 
     def _fetch_verdict_json(self, path: str) -> Optional[Dict[str, Any]]:
-        """NON-AUTHORITATIVE fallback fetch: direct SSH ``cat`` of the verdict
-        path discovered by ``_discover_verdict_path``. Only reached when the
+        """NON-AUTHORITATIVE fallback fetch: direct SSH ``cat`` (root-wrapped
+        -- Bug 3, the verdict file is root-owned) of the verdict path
+        discovered by ``_discover_verdict_path``. Only reached when the
         checksum-gated Black-Box channel produced no verdict at all."""
-        rc, out = self._ssh_exec("cat %s" % (shlex.quote(path),), timeout_s=30.0)
+        remote = _wrap_as_root("cat %s" % (shlex.quote(path),))
+        rc, out = self._ssh_exec(remote, timeout_s=30.0)
         if rc != 0 or not out:
             return None
         text = out.strip()
@@ -1018,19 +1283,38 @@ class A1BrainIgnition:
     # -- phase 7: teardown ($0) ---------------------------------------------------
 
     async def teardown(self) -> Dict[str, Any]:
+        """Defense-in-depth layer 1: an explicit, zone-agnostic sweep. Bug 1
+        (MONEY-CRITICAL, live-fire): scatter-gather can land the winner in ANY
+        zone in the candidate chain, and whichever zone got resolved for SSH
+        purposes (``self.zone``) is NOT trusted here -- this deletes the node
+        NAME across EVERY zone in the chain, unconditionally, idempotent
+        (404/not-found counts as success at the REST layer) + fail-soft (a
+        single zone's error never aborts the sweep)."""
         result: Dict[str, Any] = {"deleted": False, "detail": "", "zero_cost": False}
+        zones = self._teardown_zones or _candidate_teardown_zones(self.zone or None)
         try:
             rest = self._compute_rest_factory()
-            ok, detail = await rest.delete_instance(self.node_name, zone=self.zone or None)
-            result["deleted"] = ok
-            result["detail"] = detail
-            _log("[Teardown] delete_instance node=%s zone=%s -> ok=%s detail=%s"
-                 % (self.node_name, self.zone, ok, detail))
+            any_ok = False
+            details: List[str] = []
+            for zone in zones:
+                try:
+                    ok, detail = await rest.delete_instance(self.node_name, zone=zone)
+                except Exception as exc:  # noqa: BLE001 -- one zone's error never aborts the sweep
+                    ok, detail = False, "EXC:%r" % (exc,)
+                    _log("[Teardown] WARN delete_instance error zone=%s (continuing "
+                         "sweep): %r" % (zone, exc))
+                any_ok = any_ok or ok
+                details.append("zone=%s:ok=%s:%s" % (zone, ok, detail))
+                _log("[Teardown] delete_instance node=%s zone=%s -> ok=%s detail=%s"
+                     % (self.node_name, zone, ok, detail))
+            result["deleted"] = any_ok
+            result["detail"] = "; ".join(details)
         except Exception as exc:  # noqa: BLE001 -- teardown must never raise
-            _log("[Teardown] WARN delete_instance error (continuing to reaper): %r"
+            _log("[Teardown] WARN all-zone sweep error (continuing to reaper): %r"
                  % (exc,))
 
-        # Defense-in-depth layer 2: drain the up-front reaper registry. Run off
+        # Defense-in-depth layer 2: drain the up-front reaper registry (itself
+        # now an all-zone sweep, Bug 1 -- see _reap_ignitions_async). Run off
         # the event loop -- the sync reaper may block on a thread-join.
         loop = asyncio.get_running_loop()
         await loop.run_in_executor(None, _reap_ignitions)
@@ -1097,6 +1381,10 @@ class A1BrainIgnition:
                 _log("ABORT: provision failed (%s)" % (detail,))
                 return 1
             await self.resolve_actual_zone()
+            if not await self._await_ssh_ready():
+                _log("ABORT: node SSH-over-IAP not reachable within budget "
+                     "(teardown will $0 the node)")
+                return 1
             await self.verify_head()
             dispatched = await self.dispatch()
             if not dispatched:

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -368,8 +368,24 @@ def _compose_remote_command(
     so the node-side soak's hard wall and the node-side self-destruct
     (Piece D) never disagree."""
     verbose_flag = " --verbose" if verbose else ""
+    # Re-sync the golden-image venv to the GIT-PULLED (versioned, signed-commit
+    # lineage) requirements before the soak: the lean bake carries pytest but
+    # NOT the pytest.ini-required plugins (pytest-asyncio/json-report/metadata/
+    # anyio), so the A1 chaos-injector's RED-verification pytest collects 0
+    # tests (rc=5) and a real bug reads as "not RED" (live-fire
+    # a1-brain-20260705-173831). Idempotent + fast (already-satisfied deps are
+    # a no-op; only the few new pure-python plugins install). NOT an un-versioned
+    # patch (mandate 1) -- it installs exactly the committed, pinned
+    # requirements-brain.txt the node just pulled. Env-gated for override.
+    pip_sync = ""
+    if _truthy(os.environ.get("JARVIS_A1_BRAIN_PIP_SYNC", "1")):
+        pip_sync = (
+            "%s -m pip install -q -r backend/requirements-brain.txt && "
+            % (_REMOTE_PYTHON,)
+        )
     return (
         "cd %s && "
+        "%s"
         "JARVIS_CHAOS_TARGET_DIRS=%s "
         "JARVIS_BRAIN_OUTBOUND_TOPICS=%s "
         "OUROBOROS_BATTLE_HEADLESS=1 "
@@ -378,6 +394,7 @@ def _compose_remote_command(
         "--seed %d%s"
         % (
             _REMOTE_REPO_ROOT,
+            pip_sync,
             _DEFAULT_CHAOS_TARGET_DIRS,
             _DEFAULT_OUTBOUND_TOPICS,
             int(soak_wall_s),

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -123,6 +123,13 @@ _CHAOS_HARNESS_SCRIPT = os.path.join(_SCRIPTS_DIR, "a1_live_fire_chaos_harness.p
 
 # The remote jarvis repo root on the node (matches the golden image / IaC sync target).
 _REMOTE_REPO_ROOT = os.environ.get("JARVIS_A1_BRAIN_REMOTE_REPO", "/opt/trinity/jarvis")
+# The organism's deps live in the golden-image venv (PEP-668; the same
+# interpreter jarvis-brain.service uses), NOT system python3 -- bare `python3`
+# on the node has none of the org deps and dies with ModuleNotFoundError before
+# a session is ever created (live-fire bt a1-brain-20260705-173210: soak exited
+# RC=1, session_dir '<not discovered>'). Env-tunable.
+_REMOTE_PYTHON = os.environ.get(
+    "JARVIS_A1_BRAIN_PYTHON", "/opt/trinity/venv/bin/python3")
 
 # Piece C / B config baked into the remote command (facts-file authoritative values).
 _DEFAULT_CHAOS_TARGET_DIRS = "backend/core/ouroboros/a1_ignition_vector"
@@ -367,13 +374,14 @@ def _compose_remote_command(
         "JARVIS_BRAIN_OUTBOUND_TOPICS=%s "
         "OUROBOROS_BATTLE_HEADLESS=1 "
         "OUROBOROS_BATTLE_MAX_WALL_SECONDS=%d "
-        "python3 scripts/isomorphic_a1_local.py --mode process --run-root %s "
+        "%s scripts/isomorphic_a1_local.py --mode process --run-root %s "
         "--seed %d%s"
         % (
             _REMOTE_REPO_ROOT,
             _DEFAULT_CHAOS_TARGET_DIRS,
             _DEFAULT_OUTBOUND_TOPICS,
             int(soak_wall_s),
+            _REMOTE_PYTHON,
             remote_run_dir,
             seed,
             verbose_flag,
@@ -1272,6 +1280,23 @@ class A1BrainIgnition:
                 _log("  criterion %-32s %s" % (name, "PASS" if ok else "FAIL"))
         else:
             _log("A1 VERDICT: UNAVAILABLE (verdict_source=%s)" % (verdict_source,))
+            # Remote-failure visibility: the node-side dispatch log carries the
+            # soak's stdout/stderr (e.g. an early ModuleNotFoundError before any
+            # session exists). SSH is root-wrapped, so it can read the
+            # root-owned log. Bounded tail, fail-soft -- essential for
+            # diagnosing a remote soak that died before producing a verdict.
+            try:
+                rc, tail = await self._ssh_exec_async(
+                    "tail -n 60 %s 2>/dev/null || true"
+                    % (shlex.quote(self._log_file()),),
+                    timeout_s=30.0)
+                if tail and tail.strip():
+                    _log("[IgniteA1Brain] --- node ignite_dispatch.log (tail) ---")
+                    for ln in tail.strip().splitlines()[-60:]:
+                        _log("[node] %s" % (ln,))
+                    _log("[IgniteA1Brain] --- end dispatch log ---")
+            except Exception as exc:  # noqa: BLE001 -- diagnostic, never fatal
+                _log("[IgniteA1Brain] WARN could not pull dispatch log: %r" % (exc,))
 
         return {
             "verdict": verdict,

--- a/tests/scripts/test_ignite_a1_brain.py
+++ b/tests/scripts/test_ignite_a1_brain.py
@@ -1205,8 +1205,14 @@ def test_retrieve_verdict_ssh_fallback_disabled_by_env(tmp_path, monkeypatch):
 
     assert result["verdict"] is None
     assert result["verdict_source"] == "none"
-    # No SSH calls at all -- the fallback path was never entered.
-    assert runner.calls == []
+    # The SSH VERDICT FALLBACK was never entered -- no a1_verdict.json find/cat
+    # over SSH (mandate 3: authoritative retrieval is IapBlackBoxTransport-only,
+    # and the fallback is disabled). A diagnostic ignite_dispatch.log tail on the
+    # UNAVAILABLE branch is NOT verdict retrieval and is permitted.
+    assert not any(
+        "a1_verdict.json" in " ".join(str(a) for a in call[0])
+        for call in runner.calls), (
+        "the SSH verdict fallback must not run when disabled: %r" % (runner.calls,))
 
 
 def test_retrieve_verdict_bundle_without_verdict_member_falls_back(tmp_path, monkeypatch):

--- a/tests/scripts/test_ignite_a1_brain.py
+++ b/tests/scripts/test_ignite_a1_brain.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import argparse
 import asyncio
+import base64
 import importlib.util
 import io
 import json
@@ -248,6 +249,18 @@ def _real_hypervisor_loader():
 
 async def _exploding_provision_fn(*, node_name: str) -> Tuple[bool, str]:
     raise AssertionError("provision_fn was called -- --dry-run must never provision")
+
+
+def _extract_root_wrapped_payload(remote: str) -> str:
+    """Decode the base64 payload out of a `_wrap_as_root`-composed remote
+    command string (`printf %s <b64> | base64 -d | sudo bash`) -- used to
+    prove the ROOT-WRAPPED command actually carries the intended inner
+    script, not just that it LOOKS root-wrapped."""
+    prefix, suffix = "printf %s ", " | base64 -d | sudo bash"
+    assert remote.startswith(prefix), remote
+    assert remote.endswith(suffix), remote
+    encoded = remote[len(prefix): -len(suffix)]
+    return base64.b64decode(encoded.encode("ascii")).decode("utf-8")
 
 
 def _make_ignition(**overrides: Any):
@@ -516,9 +529,14 @@ def test_ssh_argv_built_by_reused_hypervisor_ssh_cmd():
     assert "--zone=us-central1-a" in argv
     assert "--tunnel-through-iap" in argv
     assert argv[-2] == "--command"
-    # The remote payload is the detached dispatch wrapper, which embeds the
-    # real isomorphic_a1_local.py invocation.
-    assert "isomorphic_a1_local.py" in argv[-1]
+    # Bug 3: the remote payload is now ROOT-WRAPPED (base64 | sudo bash) --
+    # decode it to confirm the real isomorphic_a1_local.py invocation (the
+    # detached dispatch wrapper) survives the round trip.
+    remote = argv[-1]
+    assert "sudo bash" in remote
+    assert "base64 -d" in remote
+    decoded = _extract_root_wrapped_payload(remote)
+    assert "isomorphic_a1_local.py" in decoded
 
 
 def test_ssh_exec_uses_ssh_cmd_and_injected_runner():
@@ -538,11 +556,274 @@ def test_ssh_exec_uses_ssh_cmd_and_injected_runner():
 
 
 # ===========================================================================
+# Bug 2 (live-fire): resolve_actual_zone must pick the RUNNING winner, not a
+# being-deleted loser -- and must PREFER the zone provision() parsed straight
+# out of the create-time detail string over re-listing at all.
+# ===========================================================================
+
+
+def test_status_rank_orders_running_before_stopping_and_terminated():
+    assert ignite._status_rank("RUNNING") < ignite._status_rank("STOPPING")
+    assert ignite._status_rank("RUNNING") < ignite._status_rank("TERMINATED")
+    assert ignite._status_rank("PROVISIONING") < ignite._status_rank("STOPPING")
+    # Unknown/missing status never raises and ranks in the middle (neither
+    # preferred over a confirmed RUNNING match nor penalized below a
+    # confirmed STOPPING/TERMINATED one).
+    assert ignite._status_rank(None) == ignite._status_rank("")
+    assert ignite._status_rank("RUNNING") < ignite._status_rank(None)
+    assert ignite._status_rank(None) < ignite._status_rank("TERMINATED")
+
+
+def test_parse_provision_zone_extracts_zone_from_create_instance_detail():
+    """gcp_compute_rest.GCPComputeRest._insert_in_zone's winner reports
+    "created:zone=<z>:mode=<m>" -- provision_brain forwards that detail
+    string verbatim as the (ok, detail) return."""
+    assert ignite._parse_provision_zone(
+        "created:zone=us-central1-b:mode=spot") == "us-central1-b"
+    assert ignite._parse_provision_zone(
+        "created:zone=us-east4-a:mode=on_demand") == "us-east4-a"
+    assert ignite._parse_provision_zone("ok") is None
+    assert ignite._parse_provision_zone("") is None
+    assert ignite._parse_provision_zone(None) is None  # fail-soft, never raises
+
+
+def test_resolve_actual_zone_prefers_provision_reported_zone_over_relisting():
+    """Bug 2 (primary source of truth): when provision() already parsed an
+    authoritative zone out of the create-time detail string,
+    resolve_actual_zone() must use it DIRECTLY -- list_instances_by_label is
+    never called at all."""
+    ignite._ACTIVE_IGNITIONS.clear()
+    rest = FakeComputeRest(instances=[
+        # A STOPPING same-named loser sitting in a DIFFERENT zone than the
+        # real winner -- proves the provision-zone path never even consults
+        # this list (a naive list-based resolver could still pick this).
+        {"name": "a1-brain-test", "zone": "projects/p/zones/us-central1-a", "status": "STOPPING"},
+    ])
+
+    async def _provision_fn(*, node_name: str) -> Tuple[bool, str]:
+        return True, "created:zone=us-central1-b:mode=spot"
+
+    ignition = _make_ignition(
+        compute_rest_factory=lambda: rest, zone="", provision_fn=_provision_fn)
+    asyncio.run(ignition.provision())
+
+    zone = asyncio.run(ignition.resolve_actual_zone())
+
+    assert zone == "us-central1-b"
+    assert ignition.zone == "us-central1-b"
+    assert rest.list_calls == 0  # never re-listed
+    ignite._ACTIVE_IGNITIONS.clear()
+
+
+def test_resolve_actual_zone_prefers_running_over_stopping_without_provision_zone():
+    """Bug 2 (fallback path): without a provision-reported zone, the exact
+    live-fire race -- a scatter-gather LOSER (STOPPING, mid-reap) in zone A
+    briefly coexists with the RUNNING winner in zone B -- must resolve to
+    the RUNNING zone, even though the STOPPING entry is listed FIRST (proves
+    rank-based selection, not first-match)."""
+    rest = FakeComputeRest(instances=[
+        {"name": "a1-brain-test", "zone": "projects/p/zones/us-central1-a", "status": "STOPPING"},
+        {"name": "a1-brain-test", "zone": "projects/p/zones/us-central1-b", "status": "RUNNING"},
+    ])
+    ignition = _make_ignition(compute_rest_factory=lambda: rest, zone="")
+    assert ignition._provision_zone is None  # exercises the list-fallback path
+
+    zone = asyncio.run(ignition.resolve_actual_zone())
+
+    assert zone == "us-central1-b"
+    assert ignition.zone == "us-central1-b"
+    assert rest.list_calls == 1
+
+
+def test_resolve_actual_zone_handles_missing_status_field_without_raising():
+    rest = FakeComputeRest(instances=[
+        {"name": "a1-brain-test", "zone": "projects/p/zones/us-central1-a"},  # no status key
+    ])
+    ignition = _make_ignition(compute_rest_factory=lambda: rest, zone="")
+
+    zone = asyncio.run(ignition.resolve_actual_zone())
+
+    assert zone == "us-central1-a"
+
+
+# ===========================================================================
+# Bug 3 (live-fire): remote commands must run as ROOT. /opt/trinity/jarvis is
+# ROOT-owned (golden-image bake; the boot-time git-pull runs as root) -- the
+# SSH OS-Login user can neither `git rev-parse` (dubious ownership) nor
+# `mkdir`/write under it. Every node-side command routes through
+# `_wrap_as_root` (base64 | sudo bash -- one clean layer of quoting).
+# ===========================================================================
+
+
+def test_wrap_as_root_round_trips_the_inner_command():
+    inner = "echo hello; mkdir -p /opt/trinity/jarvis/x && echo done"
+    wrapped = ignite._wrap_as_root(inner)
+
+    assert wrapped.startswith("printf %s ")
+    assert "sudo bash" in wrapped
+    assert "base64 -d" in wrapped
+    assert _extract_root_wrapped_payload(wrapped) == inner
+
+
+def test_wrap_as_root_handles_quotes_and_pipes_in_the_inner_command():
+    """The whole point of the base64 pattern is avoiding nested-quote hell --
+    prove a payload FULL of quotes/pipes/ampersands survives the round trip
+    byte-for-byte."""
+    inner = (
+        "mkdir -p '/opt/trinity/jarvis/a b' && nohup bash -c 'echo \"hi\" | cat' "
+        "> /tmp/x.log 2>&1 < /dev/null & disown; echo DISPATCH_STARTED"
+    )
+    wrapped = ignite._wrap_as_root(inner)
+    assert _extract_root_wrapped_payload(wrapped) == inner
+
+
+def test_compose_verify_head_command_adds_safe_directory_exception():
+    inner = ignite._compose_verify_head_command()
+    assert "safe.directory" in inner
+    assert "/opt/trinity/jarvis" in inner
+    assert "git -C /opt/trinity/jarvis rev-parse HEAD" in inner
+
+
+def test_verify_head_sends_root_wrapped_command():
+    runner = RecordingRunner(responses=[(0, "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef\n")])
+    ignition = _make_ignition(project="p", zone="z", runner=runner)
+
+    sha = asyncio.run(ignition.verify_head())
+
+    assert sha == "deadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
+    assert len(runner.calls) == 1
+    argv, _timeout_s = runner.calls[0]
+    remote = argv[-1]
+    assert "sudo bash" in remote
+    decoded = _extract_root_wrapped_payload(remote)
+    assert "safe.directory" in decoded
+    assert "git -C /opt/trinity/jarvis rev-parse HEAD" in decoded
+
+
+def test_dispatch_sends_root_wrapped_command():
+    runner = RecordingRunner(responses=[(0, "DISPATCH_STARTED\n")])
+    ignition = _make_ignition(project="p", zone="z", runner=runner)
+
+    ok = asyncio.run(ignition.dispatch())
+
+    assert ok is True
+    assert len(runner.calls) == 1
+    argv, _timeout_s = runner.calls[0]
+    remote = argv[-1]
+    assert "sudo bash" in remote
+    decoded = _extract_root_wrapped_payload(remote)
+    assert "mkdir -p" in decoded
+    assert "isomorphic_a1_local.py" in decoded
+    assert "DISPATCH_STARTED" in decoded
+
+
+def test_monitor_poll_command_is_root_wrapped():
+    """The done-file/log-file live under the root-owned run dir -- the poll
+    command must ALSO run as root (the SSH user may lack read access)."""
+    runner = RecordingRunner(responses=[(0, "__IGNITE_DONE__\nDONE_RC=0\n")])
+    ignition = _make_ignition(project="p", zone="z", runner=runner,
+                              monitor_poll_s=0.01, monitor_max_s=5.0)
+
+    result = asyncio.run(ignition.monitor())
+
+    assert result["completed"] is True
+    assert len(runner.calls) == 1
+    argv, _timeout_s = runner.calls[0]
+    remote = argv[-1]
+    assert "sudo bash" in remote
+    decoded = _extract_root_wrapped_payload(remote)
+    assert "ignite_dispatch.done" in decoded
+
+
+def test_discover_verdict_path_is_root_wrapped():
+    runner = RecordingRunner(responses=[
+        (0, "/opt/trinity/jarvis/a1_iso_runs/a1-brain-test/run1/a1_verdict.json\n"),
+    ])
+    ignition = _make_ignition(project="p", zone="z", runner=runner)
+
+    path = ignition._discover_verdict_path()
+
+    assert path == "/opt/trinity/jarvis/a1_iso_runs/a1-brain-test/run1/a1_verdict.json"
+    argv, _timeout_s = runner.calls[0]
+    remote = argv[-1]
+    assert "sudo bash" in remote
+    decoded = _extract_root_wrapped_payload(remote)
+    assert "find" in decoded
+    assert "a1_verdict.json" in decoded
+
+
+def test_fetch_verdict_json_is_root_wrapped():
+    verdict = {"proven": True, "criteria": {}}
+    runner = RecordingRunner(responses=[(0, json.dumps(verdict))])
+    ignition = _make_ignition(project="p", zone="z", runner=runner)
+
+    result = ignition._fetch_verdict_json("/opt/trinity/jarvis/x/a1_verdict.json")
+
+    assert result == verdict
+    argv, _timeout_s = runner.calls[0]
+    remote = argv[-1]
+    assert "sudo bash" in remote
+    decoded = _extract_root_wrapped_payload(remote)
+    assert decoded == "cat /opt/trinity/jarvis/x/a1_verdict.json"
+
+
+def test_dry_run_plan_shows_root_wrapped_commands_and_all_zone_sweep(capsys):
+    """--dry-run must show the ROOT-WRAPPED commands (Bug 3) and confirm the
+    all-zone teardown sweep (Bug 1) -- both fixes must be legible in the plan
+    preview, not just in the live-path code."""
+    ignition = _make_ignition(dry_run=True, project="demo-project", zone="us-central1-a")
+    plan = ignition.build_plan()
+    ignition.print_plan(plan)
+    out = capsys.readouterr().out
+
+    assert "root-wrapped" in out.lower()
+    assert "sudo bash" in out
+    assert "base64 -d" in out
+    assert "ALL-ZONE SWEEP" in out
+    assert "us-central1-a" in out  # the pre-create zone leads the printed chain
+
+    # The plan dataclass itself carries the root-wrapped forms + zone list.
+    assert plan.verify_head_cmd.startswith("printf %s ")
+    assert _extract_root_wrapped_payload(plan.verify_head_cmd) == (
+        ignite._compose_verify_head_command())
+    assert plan.dispatch_wrapper_root_cmd.startswith("printf %s ")
+    assert plan.teardown_zones  # non-empty
+    assert plan.teardown_zones[0] == "us-central1-a"
+
+
+def test_dry_run_still_zero_side_effect_with_root_wrapped_commands(capsys):
+    """Re-confirms the --dry-run zero-side-effect guarantee holds after the
+    Bug 3 root-wrapping rewrite (no SSH/subprocess call is ever made on the
+    dry-run path -- only the plan STRING preview changed)."""
+    exploding_rest = ExplodingComputeRest()
+    runner = RecordingRunner()
+
+    ignition = _make_ignition(
+        dry_run=True, project="demo-project", zone="us-central1-a",
+        compute_rest_factory=lambda: exploding_rest,
+        provision_fn=_exploding_provision_fn,
+        runner=runner,
+    )
+
+    rc = asyncio.run(ignition.run())
+
+    assert rc == 0
+    assert runner.calls == []
+    out = capsys.readouterr().out
+    assert "DRY RUN: zero network" in out
+
+
+# ===========================================================================
 # 4. Teardown targets the resolved node + zone.
 # ===========================================================================
 
 
-def test_teardown_deletes_resolved_node_and_zone():
+def test_teardown_deletes_resolved_node_and_zone(monkeypatch):
+    """Bug 1 (live-fire): teardown's explicit layer-1 delete sweeps EVERY zone
+    in the candidate chain -- not just the one zone resolve_actual_zone()
+    picked. Constrain the chain to a small deterministic pair via the env
+    override so the assertion doesn't depend on the full default matrix."""
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "us-east1-b,us-central1-a")
     rest = FakeComputeRest(instances=[{"name": "a1-brain-test", "zone": "projects/p/zones/us-east1-b"}])
     ignition = _make_ignition(compute_rest_factory=lambda: rest, zone="")
 
@@ -552,39 +833,145 @@ def test_teardown_deletes_resolved_node_and_zone():
     result = asyncio.run(ignition.teardown())
 
     assert result["deleted"] is True
-    assert rest.delete_calls == [("a1-brain-test", "us-east1-b")]
+    # Every zone in the (constrained) chain was attempted, in order.
+    assert rest.delete_calls == [
+        ("a1-brain-test", "us-east1-b"),
+        ("a1-brain-test", "us-central1-a"),
+    ]
+    assert result["zero_cost"] is True
 
 
-def test_teardown_reissues_delete_on_zone_mismatch():
-    """MINOR #4: when the all-zone label-based verify list detects the node
-    LEAKED in a DIFFERENT zone than the one the explicit delete targeted
-    (zone mismatch), teardown() must RE-ISSUE delete_instance with the
-    discovered zone rather than just logging LEAK."""
+def test_teardown_reissues_delete_on_zone_mismatch(monkeypatch):
+    """MINOR #4 (retained under Bug 1): when the all-zone label-based verify
+    list detects the node LEAKED in a zone OUTSIDE the swept candidate chain
+    (zone mismatch/drift), teardown() must RE-ISSUE delete_instance with the
+    discovered zone rather than just logging LEAK -- the $0-verify is the
+    final backstop for a zone the chain sweep didn't cover."""
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "us-central1-a,us-central1-b")
     rest = FakeComputeRest(
         instances=[{"name": "a1-brain-test", "zone": "projects/p/zones/us-east1-b"}])
     ignition = _make_ignition(compute_rest_factory=lambda: rest, zone="us-central1-a")
 
     result = asyncio.run(ignition.teardown())
 
-    # First call: the explicit delete, targeting the (wrong) pre-set zone.
+    # The chain sweep tried both configured zones -- neither matches the
+    # instance's real zone (us-east1-b), so both come back not_found.
     assert rest.delete_calls[0] == ("a1-brain-test", "us-central1-a")
-    # Second call: the zone-mismatch re-delete, targeting the zone DISCOVERED
-    # from the verify list.
+    assert rest.delete_calls[1] == ("a1-brain-test", "us-central1-b")
+    # The $0-verify then discovers the real zone and RE-ISSUES the delete.
     assert rest.delete_calls[-1] == ("a1-brain-test", "us-east1-b")
-    assert len(rest.delete_calls) == 2
+    assert len(rest.delete_calls) == 3
     # Re-delete succeeded (FakeComputeRest always returns ok=True) -> no leak.
     assert result["zero_cost"] is True
 
 
-def test_teardown_no_reissue_when_verify_list_clean():
-    """No leaked instance in the verify list -> no re-delete is issued."""
+def test_teardown_no_reissue_when_verify_list_clean(monkeypatch):
+    """No leaked instance in the verify list -> no re-delete is issued (but
+    the full constrained chain is still swept)."""
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "us-central1-a,us-central1-b")
     rest = FakeComputeRest(instances=[])
     ignition = _make_ignition(compute_rest_factory=lambda: rest, zone="us-central1-a")
 
     result = asyncio.run(ignition.teardown())
 
-    assert len(rest.delete_calls) == 1  # only the explicit delete
+    assert len(rest.delete_calls) == 2  # the full (constrained) chain sweep
     assert result["zero_cost"] is True
+
+
+# ===========================================================================
+# Bug 1 (live-fire, MONEY-CRITICAL): teardown + the signal-path reaper must
+# both sweep EVERY zone in the candidate chain, unconditionally, idempotent +
+# never-raising -- proven directly against `_reap_ignitions_async` /
+# `_reap_ignitions` (the sync wrapper the SIGINT/SIGTERM handler drains) and
+# against `A1BrainIgnition.teardown()`'s explicit layer-1 sweep.
+# ===========================================================================
+
+
+def test_teardown_sweeps_full_candidate_zone_chain_before_any_match(monkeypatch):
+    """Even when NOTHING matches in ANY swept zone, every zone in the chain
+    is still attempted (idempotent 404s) -- the sweep never short-circuits
+    early just because earlier zones came back not-found."""
+    monkeypatch.setenv(
+        "JARVIS_GCP_ZONE_FALLBACK", "us-central1-a,us-central1-b,us-central1-c")
+    rest = FakeComputeRest(instances=[])
+    ignition = _make_ignition(compute_rest_factory=lambda: rest, zone="us-central1-a")
+
+    result = asyncio.run(ignition.teardown())
+
+    assert rest.delete_calls == [
+        ("a1-brain-test", "us-central1-a"),
+        ("a1-brain-test", "us-central1-b"),
+        ("a1-brain-test", "us-central1-c"),
+    ]
+    assert result["deleted"] is False  # nothing actually matched anywhere
+    assert result["zero_cost"] is True  # but the $0-verify still confirms clean
+
+
+def test_reap_ignitions_sweeps_full_zone_chain_for_registered_node():
+    """`_register_ignition` now takes the FULL candidate chain (as
+    `provision()` computes it up front) -- draining the registry must issue
+    `delete_instance` for the node across EVERY zone in that chain."""
+    ignite._ACTIVE_IGNITIONS.clear()
+    rest = FakeComputeRest()
+    chain = ["us-central1-b", "us-central1-a", "us-central1-c", "us-central1-f"]
+    ignite._register_ignition(node="a1-brain-chain-test", zones=chain,
+                              compute_rest_factory=lambda: rest)
+
+    asyncio.run(ignite._reap_ignitions_async())
+
+    assert ignite._ACTIVE_IGNITIONS == []
+    assert rest.delete_calls == [("a1-brain-chain-test", z) for z in chain]
+
+
+def test_reap_ignitions_never_raises_when_one_zone_explodes():
+    """A single zone's delete_instance raising must NOT abort the sweep of
+    the remaining zones in the chain -- proves the per-zone try/except."""
+    ignite._ACTIVE_IGNITIONS.clear()
+
+    class HalfBoomComputeRest:
+        def __init__(self) -> None:
+            self.delete_calls: List[Tuple[str, Optional[str]]] = []
+
+        async def delete_instance(self, name: Optional[str] = None, *, zone: Optional[str] = None):
+            self.delete_calls.append((name or "", zone))
+            if zone == "us-central1-b":
+                raise RuntimeError("simulated GCP failure in this zone only")
+            return (True, "deleted:404")
+
+    rest = HalfBoomComputeRest()
+    chain = ["us-central1-a", "us-central1-b", "us-central1-c"]
+    ignite._register_ignition(node="a1-brain-half-boom", zones=chain,
+                              compute_rest_factory=lambda: rest)
+
+    asyncio.run(ignite._reap_ignitions_async())
+
+    assert ignite._ACTIVE_IGNITIONS == []
+    # ALL three zones were attempted despite the middle one raising.
+    assert rest.delete_calls == [
+        ("a1-brain-half-boom", "us-central1-a"),
+        ("a1-brain-half-boom", "us-central1-b"),
+        ("a1-brain-half-boom", "us-central1-c"),
+    ]
+
+
+def test_signal_path_sync_reaper_sweeps_full_zone_chain():
+    """The SYNC reaper (`_reap_ignitions`) is what the SIGINT/SIGTERM
+    `_handler` and `atexit` actually drain -- this is the exact live-fire
+    regression: the signal path must ALSO sweep every zone in the chain, not
+    just whichever single zone resolve_actual_zone() happened to pick."""
+    ignite._ACTIVE_IGNITIONS.clear()
+    rest = FakeComputeRest()
+    chain = ["us-central1-b", "us-central1-a"]
+    ignite._register_ignition(node="a1-brain-signal-test", zones=chain,
+                              compute_rest_factory=lambda: rest)
+
+    ignite._reap_ignitions()  # the sync path the signal handler calls
+
+    assert ignite._ACTIVE_IGNITIONS == []
+    assert rest.delete_calls == [
+        ("a1-brain-signal-test", "us-central1-b"),
+        ("a1-brain-signal-test", "us-central1-a"),
+    ]
 
 
 def test_teardown_argv_preview_targets_node_and_zone():
@@ -633,46 +1020,57 @@ def test_provision_env_carries_persistent_and_lifetime(monkeypatch):
     assert os.environ.get("JARVIS_BRAIN_ABSOLUTE_LIFETIME_S") is None
 
 
-def test_provision_registers_node_up_front_for_teardown():
+def test_provision_registers_node_up_front_for_teardown(monkeypatch):
+    """Bug 1: provision() registers with the FULL candidate zone chain, not a
+    single zone -- proven by constraining the chain via env override and
+    checking the registered entry's `zones` list matches it exactly."""
+    monkeypatch.setenv("JARVIS_GCP_ZONE_FALLBACK", "us-central1-b,us-central1-a")
     ignite._ACTIVE_IGNITIONS.clear()
 
     async def _ok_provision_fn(*, node_name: str) -> Tuple[bool, str]:
-        # Assert the registration already happened BEFORE the "create" call.
-        assert any(e["node"] == node_name for e in ignite._ACTIVE_IGNITIONS)
-        return True, "ok"
+        # Assert the registration already happened BEFORE the "create" call,
+        # and that it carries the FULL chain (not a single zone).
+        entry = next((e for e in ignite._ACTIVE_IGNITIONS if e["node"] == node_name), None)
+        assert entry is not None
+        assert entry["zones"] == ["us-central1-b", "us-central1-a"]
+        return True, "created:zone=us-central1-b:mode=spot"
 
     ignition = _make_ignition(node_name="a1-brain-upfront", provision_fn=_ok_provision_fn)
     ok, _ = asyncio.run(ignition.provision())
     assert ok is True
-    assert any(e["node"] == "a1-brain-upfront" for e in ignite._ACTIVE_IGNITIONS)
+    entry = next(e for e in ignite._ACTIVE_IGNITIONS if e["node"] == "a1-brain-upfront")
+    assert entry["zones"] == ["us-central1-b", "us-central1-a"]
     ignite._ACTIVE_IGNITIONS.clear()
 
 
 # ===========================================================================
-# 6. Reaper registry: idempotent + never raises when drained twice.
+# 6. Reaper registry: idempotent + never raises when drained twice. Bug 1:
+#    registration now carries the FULL candidate zone chain (`zones=[...]`),
+#    and draining sweeps EVERY zone for each registered node.
 # ===========================================================================
 
 
 def test_reap_registry_idempotent_and_never_raises():
     ignite._ACTIVE_IGNITIONS.clear()
     rest = FakeComputeRest()
-    ignite._register_ignition(node="a1-brain-reap-1", zone="us-central1-a",
+    ignite._register_ignition(node="a1-brain-reap-1", zones=["us-central1-a", "us-central1-b"],
                               compute_rest_factory=lambda: rest)
-    ignite._register_ignition(node="a1-brain-reap-2", zone=None,
+    ignite._register_ignition(node="a1-brain-reap-2", zones=[None],
                               compute_rest_factory=lambda: rest)
     assert len(ignite._ACTIVE_IGNITIONS) == 2
 
     asyncio.run(ignite._reap_ignitions_async())
     assert ignite._ACTIVE_IGNITIONS == []
-    assert sorted(rest.delete_calls) == [
+    assert sorted(rest.delete_calls) == sorted([
         ("a1-brain-reap-1", "us-central1-a"),
+        ("a1-brain-reap-1", "us-central1-b"),
         ("a1-brain-reap-2", None),
-    ]
+    ])
 
     # Second drain: registry already empty -- must be a silent no-op, no raise.
     asyncio.run(ignite._reap_ignitions_async())
     assert ignite._ACTIVE_IGNITIONS == []
-    assert len(rest.delete_calls) == 2  # unchanged -- nothing re-deleted
+    assert len(rest.delete_calls) == 3  # unchanged -- nothing re-deleted
 
 
 def test_reap_registry_never_raises_on_deleter_exception():
@@ -682,10 +1080,10 @@ def test_reap_registry_never_raises_on_deleter_exception():
         async def delete_instance(self, name: Optional[str] = None, *, zone: Optional[str] = None):
             raise RuntimeError("simulated GCP failure")
 
-    ignite._register_ignition(node="a1-brain-boom", zone=None,
+    ignite._register_ignition(node="a1-brain-boom", zones=[None, "us-central1-a"],
                               compute_rest_factory=lambda: BoomComputeRest())
 
-    # Must not raise, despite the deleter blowing up.
+    # Must not raise, despite the deleter blowing up on EVERY zone.
     asyncio.run(ignite._reap_ignitions_async())
     assert ignite._ACTIVE_IGNITIONS == []
 
@@ -693,7 +1091,7 @@ def test_reap_registry_never_raises_on_deleter_exception():
 def test_reap_sync_wrapper_idempotent_and_never_raises():
     ignite._ACTIVE_IGNITIONS.clear()
     rest = FakeComputeRest()
-    ignite._register_ignition(node="a1-brain-sync-reap", zone="us-central1-a",
+    ignite._register_ignition(node="a1-brain-sync-reap", zones=["us-central1-a"],
                               compute_rest_factory=lambda: rest)
 
     ignite._reap_ignitions()  # drains via the sync path (no running loop here)


### PR DESCRIPTION
Live-fire fixes from the first GCP Brain A1 ignition attempts (each `$0`, teardown proved bulletproof):

- **All-zone teardown on every exit path** — scatter-gather can create the node in a winner zone while resolution briefly sees a loser; the signal-path reaper now sweeps the node name across the full zone-fallback chain (a SIGTERM had leaked a node in a different zone). Zone resolution prefers the RUNNING winner via the authoritative provision zone.
- **Root-wrapped remote exec** — the SSH login user can't write the root-owned `/opt/trinity/jarvis`; commands now run via `base64 → sudo bash` (git safe.directory + the soak's session writes).
- **SSH-readiness gate** — poll SSH-over-IAP until the fresh node answers before dispatch (was rc=255 racing boot).
- **Venv Python + plugins** — run the soak under `/opt/trinity/venv/bin/python3`; add `pytest-asyncio`/`json-report`/`metadata`/`anyio` (pinned) to `requirements-brain.txt` — the lean venv lacked the pytest.ini-required plugins, so the injector's RED-verification collected 0 tests (rc=5) and a real bug read as "not RED". Dispatch re-syncs the venv from the git-pulled pinned requirements.
- **Dispatch-log visibility** — pull the node-side `ignite_dispatch.log` tail on an unavailable verdict (surfaced the plugin gap).

51 tests green; dry-run zero-side-effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens A1 Brain ignition to prevent node leaks and flaky runs. Adds all‑zone teardown, root‑wrapped SSH exec with the golden venv, RUNNING‑winner zone resolve, SSH readiness gating, and better failure visibility.

- **Bug Fixes**
  - Teardown sweeps all candidate zones on every exit; idempotent and fail‑soft.
  - Resolves the actual zone from the provision winner; falls back to a RUNNING‑preferred list so we don’t pick a STOPPING loser.
  - Runs all remote commands as root via a single base64 | sudo bash; wraps verify, dispatch, monitor, and verdict fallback to work under the root‑owned repo.
  - Uses the golden venv Python (/opt/trinity/venv/bin/python3) and waits for SSH‑over‑IAP to be ready before dispatch to stop rc=255 races.
  - Pulls `ignite_dispatch.log` tail when the verdict is unavailable for faster diagnosis.

- **Dependencies**
  - Adds `pytest-asyncio==1.3.0`, `pytest-json-report==1.5.0`, `pytest-metadata==3.1.1`, `anyio==4.12.0` to `backend/requirements-brain.txt`.
  - Dispatch re-syncs the venv from `backend/requirements-brain.txt` by default (env knob `JARVIS_A1_BRAIN_PIP_SYNC`).

<sup>Written for commit ca41699ac8486f716f8ee9ce998a1781d4285181. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69860?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

