### PR TITLE
fix(a1-brain): full-clone bake + robust boot-sync + setsid (live-fire durable)

### DIFF
--- a/backend/core/ouroboros/governance/brain_lifecycle.py
+++ b/backend/core/ouroboros/governance/brain_lifecycle.py
@@ -283,10 +283,20 @@ def _brain_runtime_startup_script() -> str:
         + tls_fetch
         + "chmod 600 %s/%s 2>/dev/null || true\n" % (
             _NODE_TLS_DIR, _TLS_META_KEYS["server_key"][1])
-        # Refresh the baked clone (fail-soft): the golden image tracks main at
-        # ignition, so driver-shipped scripts (e.g. the bus sidecar) that landed
-        # AFTER the bake are present without a re-bake.
-        + "git -C /opt/trinity/jarvis pull --ff-only || true\n"
+        # Refresh the baked clone to CURRENT origin/main (fail-soft, signed-
+        # commit lineage). The golden image is a SHALLOW clone (`git clone
+        # --depth 1`), on which `git pull --ff-only` frequently CANNOT
+        # fast-forward and silently no-ops (`|| true`) -- stranding the node at
+        # the stale baked ref (live-fire a1-brain: the A1 vector's test was
+        # absent though it was on main). A shallow `fetch` + `reset --hard`
+        # deterministically lands the node on the exact current origin/main
+        # (works on shallow clones); the old pull remains as a last-ditch
+        # fallback. Mandate 1: native git, no rsync/un-versioned patch.
+        + "(GIT_TERMINAL_PROMPT=0 timeout 90 git -C /opt/trinity/jarvis fetch "
+          "origin main --depth 1 2>/dev/null "
+          "&& git -C /opt/trinity/jarvis reset --hard FETCH_HEAD 2>/dev/null) "
+          "|| GIT_TERMINAL_PROMPT=0 timeout 60 git -C /opt/trinity/jarvis pull "
+          "--ff-only 2>/dev/null || true\n"
         # Stage-0 bus + acceptance echo responder SIDECAR: the Brain-side WS
         # server the cross-host acceptance connects to. Same venv as the soak.
         + "cat > /etc/systemd/system/jarvis-brain-bus.service <<'UNIT'\n"

--- a/scripts/bake_brain_golden_image.py
+++ b/scripts/bake_brain_golden_image.py
@@ -207,7 +207,13 @@ echo "[brain-bake] phase=brain-env-done ts=$(_ts)"
 echo "[brain-bake] phase=clone-start repo={repo_url_q} ref={repo_ref_q} ts=$(_ts)"
 mkdir -p /opt/trinity
 rm -rf {_REPO_PATH}
-if git clone --branch {repo_ref_q} --depth 1 {repo_url_q} {_REPO_PATH}; then
+# FULL clone (no --depth 1): a shallow clone cannot reliably `git pull
+# --ff-only` at ignition -- it silently no-ops, stranding the node on the stale
+# baked ref (live-fire: the A1 vector's test was absent though it was on main).
+# A full clone lets the boot-time fetch/pull deterministically land current
+# origin/main. Costs a little bake-time disk; worth it for a mutation-target
+# repo the IsomorphicEnv + chaos injector actually exercise.
+if git clone --branch {repo_ref_q} {repo_url_q} {_REPO_PATH}; then
     echo "[brain-bake] phase=clone-done ts=$(_ts)"
 else
     echo "[brain-bake] ERROR: git clone failed -- NOT writing sentinel"

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -383,6 +383,38 @@ def _compose_remote_command(
             "%s -m pip install -q -r backend/requirements-brain.txt && "
             % (_REMOTE_PYTHON,)
         )
+    # Diagnostic block (env-gated JARVIS_A1_BRAIN_DIAG, default on): capture the
+    # node's ACTUAL pytest + chaos-injector candidate behavior into the dispatch
+    # log (which is pulled on failure), so a node-specific "no viable candidates"
+    # is rooted with data, not guessed. Non-fatal (`|| true`).
+    diag = ""
+    if _truthy(os.environ.get("JARVIS_A1_BRAIN_DIAG", "0")):
+        # NO single quotes anywhere in the diag: the whole remote command runs
+        # inside `nohup bash -c '...'` (single-quoted), so an inner single quote
+        # breaks the wrapper (dispatch hung, run8). Use hyphen tokens, no quotes.
+        diag = (
+            "echo ===A1DIAG-git-state=== && "
+            "git -C %s rev-parse HEAD 2>&1 | head -1 && "
+            "git -C %s log --oneline -1 2>&1 | head -1 && "
+            "ls %s/tests/governance/a1_ignition_vector/ 2>&1 | head -5 && "
+            "echo ===A1DIAG-pytest-vector=== && "
+            % (_REMOTE_REPO_ROOT, _REMOTE_REPO_ROOT, _REMOTE_REPO_ROOT)
+        ) + (
+            "%s -m pytest %s/test_leaf_predicates.py -p no:cacheprovider "
+            "--no-header 2>&1 | tail -20 || true; "
+            "echo ===A1DIAG-list-candidates=== && "
+            "JARVIS_CHAOS_TARGET_DIRS=%s %s scripts/chaos_injector_ast.py "
+            "--list-candidates --repo-root %s 2>&1 | tail -25 || true; "
+            "echo ===A1DIAG-end=== ; "
+            % (
+                _REMOTE_PYTHON,
+                "tests/governance/a1_ignition_vector",
+                _DEFAULT_CHAOS_TARGET_DIRS,
+                _REMOTE_PYTHON,
+                _REMOTE_REPO_ROOT,
+            )
+        )
+        pip_sync = pip_sync + diag
     return (
         "cd %s && "
         "%s"
@@ -415,8 +447,14 @@ def _compose_dispatch_wrapper(remote_cmd: str, remote_run_dir: str) -> str:
     done_file = remote_run_dir.rstrip("/") + "/ignite_dispatch.done"
     log_file = remote_run_dir.rstrip("/") + "/ignite_dispatch.log"
     inner = "%s; echo DONE_RC=$? > %s" % (remote_cmd, shlex.quote(done_file))
+    # `setsid` starts the soak in a NEW session (fully severed from the SSH
+    # session's process group + controlling terminal), so `sudo bash` returns
+    # immediately and the dispatch SSH command cannot hang on an inherited fd
+    # held open by pip/pytest subprocesses (run8/9: nohup+disown alone left the
+    # SSH channel open -> 60s dispatch timeout). All fds are redirected
+    # (>log 2>&1 </dev/null) and it is backgrounded (&) + disowned.
     return (
-        "mkdir -p %s && nohup bash -c %s > %s 2>&1 < /dev/null & disown; "
+        "mkdir -p %s && setsid nohup bash -c %s > %s 2>&1 < /dev/null & disown; "
         "echo DISPATCH_STARTED"
         % (shlex.quote(remote_run_dir), shlex.quote(inner), shlex.quote(log_file))
     )


### PR DESCRIPTION
Durable fixes from the A1-on-Brain live-fire: full-clone golden image (drop `--depth 1` so boot pull lands current main with the vector+test), robust bounded boot-sync (fetch+reset, can't hang on creds), setsid dispatch detachment, diagnostic opt-in. Enables a clean re-bake after which ignition needs no runtime pip-sync/boot-sync. 59 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes A1 Brain ignition reliable: bake a full repo clone, use a bounded fetch+reset at boot, detach dispatch with `setsid`, and add opt‑in diagnostics. Ensures nodes land on current main and avoids SSH hangs during dispatch.

- **Bug Fixes**
  - Bake with a full `git clone` (no `--depth 1`) so boot can fast‑forward to the latest `main` and include new tests.
  - At boot, replace `pull` with a bounded `git fetch origin main --depth 1 && git reset --hard FETCH_HEAD` (timeouts, no credential prompts), with `--ff-only pull` as fallback.
  - Run dispatch with `setsid nohup ... & disown` to fully detach and prevent SSH channel hangs.
  - Add opt‑in diagnostics (set `JARVIS_A1_BRAIN_DIAG=1`) to capture git state, vector test output, and chaos candidate listing in the dispatch log.

- **Migration**
  - Re-bake the golden image with this change.
  - Optionally enable diagnostics by setting `JARVIS_A1_BRAIN_DIAG=1` during ignition.

<sup>Written for commit 291aa85466f6b324a252d16a9620a525d187bad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

