### PR TITLE
fix(a1-brain): black-box bundle captures organism soak_stdout (root-read + dynamic + flush)

### DIFF
--- a/scripts/a1_black_box.py
+++ b/scripts/a1_black_box.py
@@ -46,6 +46,16 @@ in-archive ``MANIFEST.txt``, never an abort):
     verdict from -- fail-soft: if none is found it is simply NOTED absent,
     never an abort.
 
+  * SOAK-CHILD STDOUT/STDERR (rc=1 boot telemetry gap) -- the newest
+    ``soak_stdout.log`` discovered under the same iso-run tree (mirrors the
+    A1-verdict discovery exactly: env-tunable globs, newest-mtime wins), added
+    at the STABLE root arcname ``soak_stdout.log``. This is the organism's
+    (soak child's) captured stdout+stderr -- when the organism runs
+    root-wrapped its ``.ouroboros/sessions/bt-iso-*`` dir is ROOT-OWNED and
+    invisible to a non-root bundler, so a fast-crashing (rc=1) boot's
+    traceback would otherwise be lost entirely. Fail-soft: absent -> noted,
+    never an abort.
+
 Output: ``black_box_<run_id>.tar.gz`` + ``black_box_<run_id>.tar.gz.sha256`` in
 ``--out``. The archive path + sha256 are printed to stdout as structured
 ``BLACK_BOX_ARCHIVE=`` / ``BLACK_BOX_SHA256=`` lines the orchestrator parses.
@@ -119,6 +129,22 @@ _VERDICT_GLOB_PATTERNS = [
         "a1_iso_runs/**/iso-a1-*/a1_verdict.json,**/iso-a1-*/a1_verdict.json",
     ).split(",") if g.strip()
 ]
+
+# The soak-child stdout/stderr log (rc=1 boot telemetry gap): env-overridable
+# comma list of glob patterns, mirroring _VERDICT_GLOB_PATTERNS exactly (same
+# iso-run tree layout, `SoakRunner.launch()` writes `soak_stdout.log` into the
+# SAME run dir a1_verdict.json lands in). NOT a frozen `bt-iso-*`/`iso-a1-*`
+# special case -- just another tunable glob list, like the verdict one.
+_SOAK_STDOUT_GLOB_PATTERNS = [
+    g.strip() for g in os.environ.get(
+        "JARVIS_A1_BLACKBOX_SOAK_STDOUT_GLOBS",
+        "a1_iso_runs/**/iso-a1-*/soak_stdout.log,**/iso-a1-*/soak_stdout.log",
+    ).split(",") if g.strip()
+]
+
+# Stable in-archive arcname for the soak-child stdout/stderr log -- lockstep
+# sibling of _A1_VERDICT_ARCNAME (see below).
+_SOAK_STDOUT_ARCNAME = "soak_stdout.log"
 
 # Provider-telemetry grep tokens (env-overridable, comma list).
 _PROVIDER_TOKENS = [
@@ -205,6 +231,49 @@ def _discover_verdict_path(repo_root: str, iso_run_root: str = "") -> Optional[s
                     os.path.join(iso_run_root, "a1_verdict.json")]
     else:
         patterns = [os.path.join(repo_root, p) for p in _VERDICT_GLOB_PATTERNS]
+
+    cand: List[Tuple[float, str]] = []
+    seen = set()
+    for pattern in patterns:
+        try:
+            for hit in glob.glob(pattern, recursive=True):
+                if hit in seen:
+                    continue
+                seen.add(hit)
+                try:
+                    if os.path.isfile(hit):
+                        cand.append((os.path.getmtime(hit), hit))
+                except OSError:
+                    continue
+        except Exception:  # noqa: BLE001 -- discovery must never abort the bundle
+            continue
+    if not cand:
+        return None
+    cand.sort(reverse=True)
+    return cand[0][1]
+
+
+def _discover_soak_stdout(repo_root: str, iso_run_root: str = "") -> Optional[str]:
+    """Best-effort newest ``soak_stdout.log`` under the repo's iso-run tree --
+    the isomorphic soak-child's (the organism) captured stdout+stderr, written
+    by ``a1_live_fire_chaos_harness.py``'s ``SoakRunner.launch()`` into the SAME
+    iso-run dir ``a1_verdict.json`` lands in. This is the ONLY surviving
+    telemetry surface for a fast-crashing (rc=1) organism boot when the run's
+    ``.ouroboros/sessions/bt-iso-*`` session dir is ROOT-OWNED (the organism
+    runs root-wrapped) and this bundler runs as a non-root user -- the session
+    dir listing fails silently for that ONE dir, but the iso-run dir under
+    ``a1_iso_runs/`` (created by the orchestrator, not the root-wrapped child)
+    stays discoverable regardless.
+
+    Mirrors ``_discover_verdict_path`` exactly: fail-soft (`None` on absence),
+    newest-mtime wins, env-overridable glob list (`_SOAK_STDOUT_GLOB_PATTERNS`)
+    -- never a frozen `bt-iso-*` / `iso-a1-*` special case."""
+    patterns: List[str]
+    if iso_run_root:
+        patterns = [os.path.join(iso_run_root, "**", "soak_stdout.log"),
+                    os.path.join(iso_run_root, "soak_stdout.log")]
+    else:
+        patterns = [os.path.join(repo_root, p) for p in _SOAK_STDOUT_GLOB_PATTERNS]
 
     cand: List[Tuple[float, str]] = []
     seen = set()
@@ -476,6 +545,20 @@ def bundle(cfg: BundleConfig) -> BundleResult:
             captured.append(_A1_VERDICT_ARCNAME)
         else:
             absent.append(_A1_VERDICT_ARCNAME)
+
+        # 6b. SOAK-CHILD STDOUT/STDERR (rc=1 boot telemetry gap) -- the newest
+        # soak_stdout.log under the same iso-run tree, at a STABLE root
+        # arcname. Independent of whether the session dir itself was
+        # discoverable above (root-ownership is exactly the failure mode this
+        # closes): a fast-crashing organism boot's traceback survives here
+        # even when the whole .ouroboros/sessions/bt-iso-* dir was invisible.
+        soak_stdout_path = _discover_soak_stdout(cfg.repo_root, cfg.iso_run_root)
+        soak_stdout_text = _read_text_bounded(soak_stdout_path) if soak_stdout_path else None
+        if soak_stdout_text is not None:
+            _add_text(tf, _SOAK_STDOUT_ARCNAME, soak_stdout_text)
+            captured.append(_SOAK_STDOUT_ARCNAME)
+        else:
+            absent.append(_SOAK_STDOUT_ARCNAME)
 
         # 7. MANIFEST.txt: what was captured + what was absent (loud, never silent).
         manifest_lines = [

--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -431,6 +431,12 @@ class SoakRunner:
         self.cost_cap = cost_cap
         self.wall_seconds = wall_seconds
         self._proc: Optional[subprocess.Popen] = None
+        # The parent-owned soak_stdout.log fh (Popen's stdout=fh, stderr=STDOUT).
+        # Flushed+fsync'd+closed by flush_stdout() once the child has verifiably
+        # exited -- the durability barrier a fast-crashing (rc=1) child's boot
+        # traceback needs before any reader (audit, black-box bundler) opens the
+        # file. See flush_stdout()'s docstring for the full rationale.
+        self._stdout_fh: Optional[Any] = None
 
     def _sessions_root(self) -> str:
         return os.path.join(self.repo_root, ".ouroboros", "sessions")
@@ -467,6 +473,7 @@ class SoakRunner:
         stdout_path = os.path.join(run_dir, "soak_stdout.log")
         os.makedirs(run_dir, exist_ok=True)
         fh = open(stdout_path, "w", encoding="utf-8")
+        self._stdout_fh = fh
         self._proc = subprocess.Popen(
             argv, cwd=self.repo_root, env=env, stdout=fh, stderr=subprocess.STDOUT,
             # Process Group Leader Isolation: the organism becomes its OWN
@@ -501,47 +508,84 @@ class SoakRunner:
         # Fall back to a placeholder path under the sessions root.
         return os.path.join(root, "pending", "debug.log")
 
+    def flush_stdout(self) -> None:
+        """Durability barrier for the parent-owned ``soak_stdout.log`` fh
+        (rc=1 boot telemetry gap fix, 2026-07-05): ``flush()`` + ``os.fsync()``
+        + ``close()`` the fh this runner opened in ``launch()``, so a
+        fast-crashing child's traceback is guaranteed durably on disk BEFORE
+        any reader (the live audit in ``isomorphic_a1_local.py``, or the
+        node-side Black-Box bundler) opens the file. MUST be called only after
+        the child has verifiably exited (``proc.poll()``/``proc.wait()``
+        returned non-None) -- calling it while the child is still running
+        would race the child's own in-flight writes.
+
+        Idempotent (a `.closed` fh is a no-op) + fail-soft (NEVER raises) --
+        safe to call from multiple sites (the caller's post-termination step,
+        `stop()`'s own cascade, `_reap_soak_runners()`, atexit) without
+        double-close errors."""
+        fh = self._stdout_fh
+        if fh is None or fh.closed:
+            return
+        try:
+            fh.flush()
+            os.fsync(fh.fileno())
+        except (OSError, ValueError):  # noqa: BLE001 -- ValueError: closed fh race
+            pass
+        finally:
+            try:
+                fh.close()
+            except OSError:
+                pass
+
     def stop(self) -> None:
         """Autonomous SIGTERM cascade over the WHOLE process group -- guarantees
         zero orphaned multiprocessing workers. The organism was launched as its
         own session leader (start_new_session=True), so its pgid == its pid and
         the group holds the organism + every worker/resource_tracker it spawned.
         SIGTERM the group (lets atexit + pool.join cleanup run), wait a grace,
-        then escalate SIGKILL to the group. NEVER raises."""
-        proc = self._proc
-        if proc is None or proc.poll() is not None:
-            return
-        try:
-            grace = float(os.environ.get("JARVIS_A1_SOAK_STOP_GRACE_S", "15") or 15)
-        except (TypeError, ValueError):
-            grace = 15.0
-        try:
-            pgid = os.getpgid(proc.pid)
-        except Exception:  # noqa: BLE001
-            pgid = None
+        then escalate SIGKILL to the group. NEVER raises.
 
-        def _signal_group(sig: int) -> None:
+        The soak_stdout.log fh is ALWAYS flushed+fsync'd+closed before this
+        method returns (via `finally` -> `flush_stdout()`), on every exit path
+        -- including the common case where the child had already exited before
+        `stop()` was even called."""
+        proc = self._proc
+        try:
+            if proc is None or proc.poll() is not None:
+                return
             try:
-                if pgid is not None:
-                    os.killpg(pgid, sig)          # the ENTIRE group, not just parent
-                else:
-                    proc.send_signal(sig)         # fallback: parent only
-            except ProcessLookupError:
+                grace = float(os.environ.get("JARVIS_A1_SOAK_STOP_GRACE_S", "15") or 15)
+            except (TypeError, ValueError):
+                grace = 15.0
+            try:
+                pgid = os.getpgid(proc.pid)
+            except Exception:  # noqa: BLE001
+                pgid = None
+
+            def _signal_group(sig: int) -> None:
+                try:
+                    if pgid is not None:
+                        os.killpg(pgid, sig)          # the ENTIRE group, not just parent
+                    else:
+                        proc.send_signal(sig)         # fallback: parent only
+                except ProcessLookupError:
+                    pass
+                except Exception:  # noqa: BLE001
+                    pass
+
+            _signal_group(signal.SIGTERM)
+            try:
+                proc.wait(timeout=grace)
+                return                                # group yielded gracefully
+            except Exception:  # noqa: BLE001 -- TimeoutExpired (or any) -> escalate
                 pass
+            _signal_group(signal.SIGKILL)             # workers refused to yield
+            try:
+                proc.wait(timeout=5)
             except Exception:  # noqa: BLE001
                 pass
-
-        _signal_group(signal.SIGTERM)
-        try:
-            proc.wait(timeout=grace)
-            return                                # group yielded gracefully
-        except Exception:  # noqa: BLE001 -- TimeoutExpired (or any) -> escalate
-            pass
-        _signal_group(signal.SIGKILL)             # workers refused to yield
-        try:
-            proc.wait(timeout=5)
-        except Exception:  # noqa: BLE001
-            pass
+        finally:
+            self.flush_stdout()
 
 
 # ===========================================================================
@@ -739,11 +783,28 @@ class IapBlackBoxTransport:
         return self._hyper
 
     def bundle_on_node(self, *, run_id: str, out_dir: str) -> Optional[Dict[str, str]]:
-        """SSH-exec the node-side bundler; parse BLACK_BOX_ARCHIVE/SHA256."""
+        """SSH-exec the node-side bundler; parse BLACK_BOX_ARCHIVE/SHA256.
+
+        ROOT-WRAPPED (rc=1 telemetry-gap fix, 2026-07-05): the organism runs
+        root-wrapped on the node, so its ``.ouroboros/sessions/bt-iso-*`` dir
+        AND the isomorphic soak-child's ``soak_stdout.log`` are ROOT-OWNED.
+        This transport, though, SSHes in as the OS-Login user -- a plain
+        `python3` invocation cannot even `os.listdir()` the root-owned session
+        dir, so a fast-crashing (rc=1) organism's boot traceback was silently
+        never captured. GCE OS-Login admins get passwordless sudo, so the
+        bundler itself now runs under `sudo` (root read access, same as the
+        tree it reads). The archive it writes lands ROOT-OWNED under
+        `out_dir` -- the subsequent `pull_archive()` scp (runs as the SSH
+        user, NOT root) could not otherwise read it, so a `sudo chmod -R a+r`
+        over `out_dir` is chained in the SAME SSH session, before control
+        returns to the (non-root) puller. This is a general correctness fix
+        (session dirs are commonly root-owned in remote soaks), not an
+        A1-only special case -- `a1_live_fire --remote` shares this class too."""
         hyper = self._hypervisor()
         remote = (
-            "cd %s && python3 scripts/a1_black_box.py --bundle --run-id %s --out %s"
-            % (_BLACK_BOX_REMOTE_REPO, run_id, out_dir)
+            "cd %s && sudo python3 scripts/a1_black_box.py --bundle --run-id %s --out %s "
+            "&& sudo chmod -R a+r %s"
+            % (_BLACK_BOX_REMOTE_REPO, run_id, out_dir, out_dir)
         )
         argv = hyper._ssh_cmd(self.args, self.node, remote)
         cp = self._run(argv)

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1621,6 +1621,27 @@ class IsomorphicA1Driver:
                                      "cascade -- atexit process-group kill is "
                                      "the final backstop")
 
+                        # -- Durability barrier (rc=1 boot telemetry gap fix,
+                        # 2026-07-05) -- flush+fsync+close the parent-owned
+                        # soak_stdout.log fh HERE, before the audit (below)
+                        # reads it. The child has now VERIFIABLY exited (either
+                        # branch above), so this is not a race with its own
+                        # writes. `_reap_soak_runners()`/`SoakRunner.stop()`
+                        # aren't reached until much later (final teardown,
+                        # after the audit already ran) on the normal "exited"
+                        # path, so without this explicit call a fast-crashing
+                        # (rc=1) child's traceback would sit in an unflushed
+                        # fh while the audit -- and later the node-side
+                        # Black-Box bundler -- read the file. Idempotent +
+                        # fail-soft: a later stop()/_reap_soak_runners() call
+                        # on the same runner is a safe no-op (fh already
+                        # closed).
+                        try:
+                            soak_runner.flush_stdout()
+                        except Exception as exc:  # noqa: BLE001 -- never block audit
+                            _log("soak_stdout flush-barrier warning: %r "
+                                 "(proceeding to audit)" % (exc,))
+
                     # ── Fast-Fail short-circuit: a global L4 capacity wall means the
                     # cognitive loop can NEVER reach APPLIED this run. Skip the audit
                     # ceiling entirely, emit a capacity verdict, and flow to teardown

--- a/tests/scripts/test_a1_black_box.py
+++ b/tests/scripts/test_a1_black_box.py
@@ -338,6 +338,111 @@ def test_bundle_without_verdict_is_noted_absent_and_does_not_crash(tmp_path):
     assert "a1_verdict.json" in result.absent
 
 
+# ===========================================================================
+# 6. Soak-child stdout/stderr (rc=1 boot telemetry gap) -- mirrors the
+#    a1_verdict.json discovery/bundling tests exactly (5) above.
+# ===========================================================================
+
+
+def _make_iso_soak_stdout(root: Path, *, text: str, run_id="iso-a1-20260624-010101"):
+    run_dir = root / "a1_iso_runs" / "some-node" / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+    stdout_path = run_dir / "soak_stdout.log"
+    stdout_path.write_text(text)
+    return stdout_path
+
+
+def test_bundle_includes_soak_stdout_when_present(tmp_path):
+    _make_session_tree(tmp_path)
+    _make_iso_soak_stdout(
+        tmp_path, text="Traceback (most recent call last):\nZeroDivisionError: boot rc=1\n")
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+
+    with tarfile.open(result.archive_path, "r:gz") as tf:
+        names = tf.getnames()
+    assert "soak_stdout.log" in names, "soak_stdout.log must land at a stable root arcname"
+
+    text = _extract_text(result.archive_path, "soak_stdout.log")
+    assert text is not None
+    assert "ZeroDivisionError" in text
+    assert "boot rc=1" in text
+
+    manifest = _extract_text(result.archive_path, "MANIFEST.txt")
+    assert "soak_stdout.log" in manifest
+
+
+def test_bundle_picks_newest_soak_stdout_when_multiple_present(tmp_path):
+    _make_session_tree(tmp_path)
+    older = _make_iso_soak_stdout(
+        tmp_path, text="older boot log", run_id="iso-a1-20260101-000000")
+    newer = _make_iso_soak_stdout(
+        tmp_path, text="newer boot log", run_id="iso-a1-20260624-235959")
+    now = time.time()
+    os.utime(older, (now - 1000, now - 1000))
+    os.utime(newer, (now, now))
+
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+    text = _extract_text(result.archive_path, "soak_stdout.log")
+    assert text == "newer boot log"
+
+
+def test_bundle_without_soak_stdout_is_noted_absent_and_does_not_crash(tmp_path):
+    # No a1_iso_runs tree at all -> discovery finds nothing, bundle still succeeds.
+    _make_session_tree(tmp_path)
+    out = tmp_path / "out"
+    result = black_box.bundle(_make_args(tmp_path, out))
+
+    assert Path(result.archive_path).exists(), "bundle must still succeed without soak_stdout.log"
+    with tarfile.open(result.archive_path, "r:gz") as tf:
+        names = tf.getnames()
+    assert "soak_stdout.log" not in names
+    manifest = _extract_text(result.archive_path, "MANIFEST.txt")
+    assert "soak_stdout.log" in manifest  # noted absent, never silently dropped
+    assert "soak_stdout.log" in result.absent
+
+
+def test_soak_stdout_iso_run_root_override_scopes_discovery(tmp_path):
+    """An explicit --iso-run-root searches ONLY that root, same escape hatch
+    as the a1_verdict.json discovery."""
+    _make_session_tree(tmp_path)
+    run_root = tmp_path / "custom_run_root"
+    run_dir = run_root / "iso-a1-20260624-010101"
+    run_dir.mkdir(parents=True)
+    (run_dir / "soak_stdout.log").write_text("custom root boot log")
+
+    cfg = black_box.BundleConfig(
+        run_id="run-custom",
+        repo_root=str(tmp_path),
+        out_dir=str(tmp_path / "out"),
+        session_dir=str(tmp_path / ".ouroboros" / "sessions" / "bt-20260624-000000"),
+        iso_run_root=str(run_root),
+        git_diff_runner=lambda target: "diff --git stub",
+        env={},
+    )
+    result = black_box.bundle(cfg)
+    text = _extract_text(result.archive_path, "soak_stdout.log")
+    assert text == "custom root boot log"
+
+
+def test_discover_soak_stdout_env_glob_override(tmp_path, monkeypatch):
+    """The glob list is env-tunable, not a frozen bt-iso-*/iso-a1-* special
+    case -- an operator can point discovery at a differently-named run tree.
+    (Mirrors how _VERDICT_GLOB_PATTERNS is resolved once at import time --
+    patch the resolved module-level list directly, same as the env var would
+    on a fresh interpreter.)"""
+    weird_dir = tmp_path / "weird_run_layout" / "attempt-7"
+    weird_dir.mkdir(parents=True)
+    (weird_dir / "soak_stdout.log").write_text("weird layout boot log")
+    monkeypatch.setattr(
+        black_box, "_SOAK_STDOUT_GLOB_PATTERNS", ["weird_run_layout/**/soak_stdout.log"])
+    hit = black_box._discover_soak_stdout(str(tmp_path))
+    assert hit is not None
+    assert hit.endswith("soak_stdout.log")
+    assert Path(hit).read_text() == "weird layout boot log"
+
+
 def test_iso_run_root_override_scopes_discovery(tmp_path):
     """An explicit --iso-run-root searches ONLY that root (arg/knob escape
     hatch), still landing at the stable arcname."""

--- a/tests/scripts/test_a1_blackbox_teardown.py
+++ b/tests/scripts/test_a1_blackbox_teardown.py
@@ -273,3 +273,55 @@ def test_blackbox_failure_path_holds_on_mismatch_and_reverts(tmp_path, monkeypat
     assert ("teardown", "sovereign-node-RF") not in transport.calls
     # Chaos STILL reverted in finally regardless.
     assert "revert" in chaos.calls
+
+
+# ===========================================================================
+# IapBlackBoxTransport.bundle_on_node -- root-wrapped (rc=1 telemetry gap fix,
+# 2026-07-05): the bundler now runs under sudo (root read access to the
+# root-owned organism session dir / soak_stdout.log) and the produced archive
+# is chmod'd world-readable so the subsequent (non-root) scp pull can read it.
+# No real SSH/subprocess -- the runner is injected.
+# ===========================================================================
+
+
+class _HypervisorArgsStub:
+    """Minimal stand-in for the argparse.Namespace `_ssh_cmd` reads."""
+
+    def __init__(self, *, project="proj-x", zone="us-central1-a"):
+        self.project = project
+        self.zone = zone
+
+
+def test_bundle_on_node_runs_bundler_under_sudo_and_chmods_output(monkeypatch):
+    captured_argv = []
+
+    def _fake_runner(argv):
+        captured_argv.append(list(argv))
+        import subprocess as _sp
+        return _sp.CompletedProcess(
+            argv, 0,
+            stdout="BLACK_BOX_ARCHIVE=/tmp/a1_black_box/black_box_run-X.tar.gz\n"
+                   "BLACK_BOX_SHA256=" + ("a" * 64) + "\n",
+            stderr="",
+        )
+
+    transport = harness.IapBlackBoxTransport(
+        node="sovereign-node-1", hypervisor_args=_HypervisorArgsStub(), runner=_fake_runner,
+    )
+    result = transport.bundle_on_node(run_id="run-X", out_dir="/tmp/a1_black_box")
+
+    assert result is not None
+    assert captured_argv, "the runner must have been invoked"
+    # _ssh_cmd(...) -> [..., "--command", remote] -- the remote command is last.
+    remote = captured_argv[0][-1]
+    # The bundler itself runs as root (passwordless OS-Login sudo) so it can
+    # read the root-owned organism session dir + soak_stdout.log.
+    assert "sudo python3 scripts/a1_black_box.py --bundle" in remote
+    # The produced archive (root-owned) is made world-readable so the
+    # subsequent (non-root) scp pull can read it, in the SAME ssh session.
+    assert "sudo chmod -R a+r" in remote
+    assert "/tmp/a1_black_box" in remote
+    # Ordering: bundle first, chmod second (chained with &&).
+    bundle_idx = remote.index("sudo python3 scripts/a1_black_box.py")
+    chmod_idx = remote.index("sudo chmod -R a+r")
+    assert bundle_idx < chmod_idx

--- a/tests/scripts/test_a1_live_fire_harness.py
+++ b/tests/scripts/test_a1_live_fire_harness.py
@@ -533,3 +533,80 @@ def test_dry_run_local_leaves_tree_reverted(tmp_path, monkeypatch):
     monkeypatch.setattr(harness, "build_dry_run_local", _wrapped)
     harness.main(["--dry-run-local", "--stub-soak", "--lenient"])
     assert revert_marker["reverted"], "dry-run-local must revert chaos in finally"
+
+
+# ===========================================================================
+# SoakRunner.flush_stdout() -- durability barrier (rc=1 boot telemetry gap
+# fix, 2026-07-05). A real (tiny, non-organism) child process is launched so
+# the fh-open/Popen/exit lifecycle is exercised for real -- no mocked
+# subprocess -- proving soak_stdout.log is durably readable (not stuck
+# unflushed) once the child has exited.
+# ===========================================================================
+
+
+def _write_fake_crashing_soak_script(tmp_path) -> str:
+    """A tiny standalone script that mimics a fast rc=1 organism boot crash:
+    prints a traceback-shaped message to stdout, then exits 1. Ignores its
+    argv entirely (SoakRunner.launch() passes --production-soak/--headless/
+    --cost-cap/--max-wall-seconds -- this stub tolerates any argv)."""
+    script = tmp_path / "fake_crashing_soak.py"
+    script.write_text(
+        "import sys\n"
+        "print('Traceback (most recent call last):')\n"
+        "print('RuntimeError: simulated boot rc=1')\n"
+        "sys.exit(1)\n"
+    )
+    return str(script)
+
+
+def test_flush_stdout_is_noop_before_launch():
+    # Never launched -> _stdout_fh is None -> flush_stdout() is a safe no-op.
+    runner = harness.SoakRunner(repo_root="/tmp", cost_cap=0.0, wall_seconds=5)
+    runner.flush_stdout()  # must not raise
+
+
+def test_stop_flushes_soak_stdout_after_real_child_exits(tmp_path, monkeypatch):
+    """The common ("exited") path: by the time stop() is called the child has
+    ALREADY exited (proc.poll() is not None), which used to early-return
+    WITHOUT flushing -- proving the fh (and thus a fast-crashing child's
+    traceback) is now durably on disk + closed via the `finally` barrier."""
+    monkeypatch.setattr(harness, "_SOAK_SCRIPT", _write_fake_crashing_soak_script(tmp_path))
+    run_dir = tmp_path / "run"
+    runner = harness.SoakRunner(repo_root=str(tmp_path), cost_cap=0.0, wall_seconds=5)
+    env = dict(os.environ)
+    env.pop("JARVIS_ACTIVE_SESSION_LOG", None)
+    handle = runner.launch(env, str(run_dir))
+    handle.proc.wait(timeout=10)
+    assert handle.proc.returncode == 1, "the fake script must exit rc=1"
+
+    # stop() sees an already-exited child -> the early-return branch -- must
+    # STILL flush via the finally barrier.
+    runner.stop()
+
+    stdout_path = run_dir / "soak_stdout.log"
+    text = stdout_path.read_text()
+    assert "Traceback (most recent call last):" in text
+    assert "RuntimeError: simulated boot rc=1" in text
+    assert runner._stdout_fh is not None and runner._stdout_fh.closed
+
+
+def test_flush_stdout_called_directly_before_stop_is_idempotent(tmp_path, monkeypatch):
+    """Mirrors isomorphic_a1_local.py's call site: flush_stdout() is invoked
+    directly once the child's termination is confirmed (BEFORE stop()/
+    _reap_soak_runners() runs, much later, at final teardown). A subsequent
+    stop() call on the same runner must be a safe no-op (fh already closed)."""
+    monkeypatch.setattr(harness, "_SOAK_SCRIPT", _write_fake_crashing_soak_script(tmp_path))
+    run_dir = tmp_path / "run"
+    runner = harness.SoakRunner(repo_root=str(tmp_path), cost_cap=0.0, wall_seconds=5)
+    env = dict(os.environ)
+    env.pop("JARVIS_ACTIVE_SESSION_LOG", None)
+    handle = runner.launch(env, str(run_dir))
+    handle.proc.wait(timeout=10)
+
+    runner.flush_stdout()  # the isomorphic_a1_local.py call site
+    stdout_path = run_dir / "soak_stdout.log"
+    text = stdout_path.read_text()
+    assert "RuntimeError: simulated boot rc=1" in text
+    assert runner._stdout_fh.closed
+
+    runner.stop()  # later teardown call -- must not raise (idempotent no-op)


### PR DESCRIPTION
Close the rc=1 telemetry blindspot: the O+V organism runs as root so its session + soak_stdout are root-owned; bundle_on_node ran as the SSH user and missed them. Now: (1) a1_black_box dynamically discovers + bundles soak_stdout.log (env-tunable globs, no hardcoded prefix); (2) IapBlackBoxTransport runs the bundler under sudo + chmods the archive readable for the pull; (3) SoakRunner flushes+fsyncs the child's stdout fh on every reap path before the audit. 70 tests green. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Capture the organism’s boot stdout/stderr in the black-box bundle and make it durable and readable on remote nodes, closing the rc=1 telemetry gap. We now discover and bundle `soak_stdout.log`, run the bundler under `sudo`, and flush the log before audits.

- **Bug Fixes**
  - Discovery and bundling: find the newest `soak_stdout.log` via env-tunable globs (`JARVIS_A1_BLACKBOX_SOAK_STDOUT_GLOBS`), add it at a stable root arcname `soak_stdout.log`, respect `--iso-run-root`, and fail-soft if missing.
  - Remote bundling: `IapBlackBoxTransport` runs `sudo python3 scripts/a1_black_box.py ... && sudo chmod -R a+r <out_dir>` so root-owned session data are readable and the non-root scp pull succeeds.
  - Durability barrier: `SoakRunner.flush_stdout()` flushes+fsyncs+closes the parent-owned log after the child exits; invoked in `stop()` and by `isomorphic_a1_local` before the audit; idempotent and fail-soft.

<sup>Written for commit 3f9e66f24caea6ab4850b2730ca310a7412a12fd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

