### PR TITLE
fix(a1): operator-explicit soak wall wins over overlay default (node-side unblock)

### DIFF
--- a/scripts/a1_live_fire_chaos_harness.py
+++ b/scripts/a1_live_fire_chaos_harness.py
@@ -224,12 +224,36 @@ def _parse_env_overlay(path: str) -> Dict[str, str]:
     return out
 
 
+# Keys whose operator/ignition-supplied value is AUTHORITATIVE over the static
+# overlay default -- the overlay provides a FALLBACK for these, never an
+# override. The soak-child wall is coordination-critical: ignite_a1_brain.py
+# sizes the node's absolute lifetime + the monitor budget from --soak-wall-s and
+# bakes the SAME value into the remote command as OUROBOROS_BATTLE_MAX_WALL_SECONDS
+# (ordering invariant: soak_wall_s < monitor_stop < lifetime_s). If the overlay's
+# static 3600 clobbers that explicit value, the soak child outlives the outer
+# budget -- the node self-destructs / the monitor gives up mid-soak and no verdict
+# is ever produced (live-fire a1-brain-20260705-213419). This is the SAME
+# "operator env ALWAYS wins" invariant that _composed_soak_wall_s
+# (isomorphic_a1_local.py, bt-iso-1783036735) documents one layer down; the fix
+# there never fired because compose_env overwrote the operator value BEFORE
+# _composed_soak_wall_s could read it.
+_OPERATOR_AUTHORITATIVE_KEYS = frozenset({"OUROBOROS_BATTLE_MAX_WALL_SECONDS"})
+
+
 def compose_env(*, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
     """Compose the soak env: the derived cognitive flags ON + the orchestration
     flags + the Linux production overlay. The result is printed for audit by the
-    caller. Precedence (lowest->highest): process env -> linux overlay -> derived
-    cognitive flags -> orchestration-required flags."""
+    caller. Precedence (lowest->highest): linux overlay -> derived cognitive
+    flags -> orchestration-required flags -> operator-authoritative process env
+    (``_OPERATOR_AUTHORITATIVE_KEYS`` -- explicit operator values win over every
+    static default for coordination-critical keys)."""
     env: Dict[str, str] = dict(base_env if base_env is not None else os.environ)
+    # Snapshot operator-explicit authoritative values BEFORE any overlay/manifest
+    # layering so a static default can never clobber an explicit operator value.
+    # Re-asserted as the LAST step below so they win over EVERYTHING composed here.
+    _operator_pins = {
+        k: env[k] for k in _OPERATOR_AUTHORITATIVE_KEYS if k in env
+    }
     # 1. Production overlay. Always layer the linux base FIRST (pytest caps, AST
     #    pool, Claude-disabled autarky) -- the omni env `source`s it in bash, which
     #    the line-based parser cannot follow, so we compose the inheritance here.
@@ -280,6 +304,9 @@ def compose_env(*, base_env: Optional[Dict[str, str]] = None) -> Dict[str, str]:
         file_isolation=False,
     )
     apply_manifest(_a1_manifest, env)
+    # 6. Operator-authoritative process env wins over every static default above.
+    #    (Empty when the operator pinned nothing -> overlay default stands.)
+    env.update(_operator_pins)
     return env
 
 

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -300,6 +300,16 @@ _ENV_BOOT_OFFSET_S = "JARVIS_A1_BRAIN_BOOT_OFFSET_S"
 _DEFAULT_BOOT_OFFSET_S = 180  # observed ~168s cold boot, rounded up w/ margin
 _ENV_VERDICT_PULL_MARGIN_S = "JARVIS_A1_BRAIN_VERDICT_PULL_MARGIN_S"
 _DEFAULT_VERDICT_PULL_MARGIN_S = 180  # headroom for the checksum-gated pull
+# Time the isomorphic run needs AFTER the soak_wall fires, before its done-file
+# lands: the organism's own wall-clock kill ladder (grace + margin + the
+# external sentinel ~90-150s) + the isomorphic driver's audit (~30-60s). WITHOUT
+# this, monitor_max_s (= lifetime - verdict_pull_margin = boot+soak_wall) gives
+# up ~120s BEFORE the done-file appears (live-fire a1-brain-20260705-204359:
+# "monitor budget exhausted (1980s) without a done-file" while the soak was
+# mid-kill-ladder). Folded into lifetime so the monitor waits long enough AND
+# the verdict pull still finishes before Piece D's self-destruct.
+_ENV_POST_WALL_MARGIN_S = "JARVIS_A1_BRAIN_POST_WALL_MARGIN_S"
+_DEFAULT_POST_WALL_MARGIN_S = 300
 
 
 def _resolve_soak_wall_s(explicit: Optional[int]) -> int:
@@ -310,7 +320,7 @@ def _resolve_soak_wall_s(explicit: Optional[int]) -> int:
 
 def _resolve_lifetime_s(
     *, explicit: Optional[int], soak_wall_s: int, boot_offset_s: int,
-    verdict_pull_margin_s: int,
+    verdict_pull_margin_s: int, post_wall_margin_s: int = 0,
 ) -> int:
     """DERIVE the node's absolute lifetime from the coordinated soak wall
     (+ margins) so the two budgets can never drift apart. `explicit` (an
@@ -332,7 +342,8 @@ def _resolve_lifetime_s(
     keeps the ordering invariant `soak_wall_s < monitor_stop < lifetime_s`
     true after resolution in every case. An explicit lifetime >= the floor
     is honored as-is (an operator may deliberately extend it further)."""
-    floor = int(soak_wall_s) + int(boot_offset_s) + int(verdict_pull_margin_s)
+    floor = (int(soak_wall_s) + int(boot_offset_s) + int(post_wall_margin_s)
+             + int(verdict_pull_margin_s))
 
     def _clamp_to_floor(value: int, *, source: str) -> int:
         if value >= floor:
@@ -786,12 +797,15 @@ class A1BrainIgnition:
         self.boot_offset_s = int(_env_int(_ENV_BOOT_OFFSET_S, _DEFAULT_BOOT_OFFSET_S))
         self.verdict_pull_margin_s = int(
             _env_int(_ENV_VERDICT_PULL_MARGIN_S, _DEFAULT_VERDICT_PULL_MARGIN_S))
+        self.post_wall_margin_s = int(
+            _env_int(_ENV_POST_WALL_MARGIN_S, _DEFAULT_POST_WALL_MARGIN_S))
         self.soak_wall_s = _resolve_soak_wall_s(soak_wall_s)
         self.lifetime_s = _resolve_lifetime_s(
             explicit=lifetime_s,
             soak_wall_s=self.soak_wall_s,
             boot_offset_s=self.boot_offset_s,
             verdict_pull_margin_s=self.verdict_pull_margin_s,
+            post_wall_margin_s=self.post_wall_margin_s,
         )
         self.seed = int(seed)
         self.remote_run_dir = remote_run_dir or _default_remote_run_dir(self.node_name)

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -134,6 +134,17 @@ _REMOTE_PYTHON = os.environ.get(
 # Piece C / B config baked into the remote command (facts-file authoritative values).
 _DEFAULT_CHAOS_TARGET_DIRS = "backend/core/ouroboros/a1_ignition_vector"
 _DEFAULT_OUTBOUND_TOPICS = "actuation.*,telemetry.posture.*,autonomy.*"
+# The O+V production-soak boot HARD-GATES on a provider key (ouroboros_battle_
+# test.py: exits 1 if neither DOUBLEWORD_API_KEY nor ANTHROPIC_API_KEY is set).
+# The A1 drill runs against the SYNTHETIC ADVERSARY (which owns DOUBLEWORD_BASE_
+# URL), so a synthetic key satisfies the gate while the adversary stubs every
+# request. Locally the gate passes only because a dev shell already exports a
+# key; the GCP node's env has none -> the organism died rc=1 (live-fire
+# a1-brain-20260705-194856). Setting it in the dispatch env makes the drill
+# self-contained on the immutable node WITHOUT a re-bake (the durable twin is
+# synthetic_adversary._build_env_overrides, which now also emits this key).
+_SYNTHETIC_DW_API_KEY = os.environ.get(
+    "JARVIS_ADVERSARY_SYNTHETIC_API_KEY", "synthetic-adversary-dw-key")
 
 # The node-side Black Box bundler's default staging dir (matches a1_black_box.py /
 # a1_live_fire_chaos_harness.py's JARVIS_A1_BLACKBOX_NODE_OUT default).
@@ -420,6 +431,7 @@ def _compose_remote_command(
         "%s"
         "JARVIS_CHAOS_TARGET_DIRS=%s "
         "JARVIS_BRAIN_OUTBOUND_TOPICS=%s "
+        "DOUBLEWORD_API_KEY=%s "
         "OUROBOROS_BATTLE_HEADLESS=1 "
         "OUROBOROS_BATTLE_MAX_WALL_SECONDS=%d "
         "%s scripts/isomorphic_a1_local.py --mode process --run-root %s "
@@ -429,6 +441,7 @@ def _compose_remote_command(
             pip_sync,
             _DEFAULT_CHAOS_TARGET_DIRS,
             _DEFAULT_OUTBOUND_TOPICS,
+            _SYNTHETIC_DW_API_KEY,
             int(soak_wall_s),
             _REMOTE_PYTHON,
             remote_run_dir,

--- a/scripts/synthetic_adversary.py
+++ b/scripts/synthetic_adversary.py
@@ -442,6 +442,17 @@ def _build_env_overrides(port: int) -> Dict[str, str]:
         "JARVIS_PRIME_URL": f"{base}/prime",
         "JARVIS_REACTOR_URL": f"{base}/reactor",
         "REACTOR_CORE_API_URL": f"{base}/reactor",
+        # The adversary IS the DoubleWord provider (it owns DOUBLEWORD_BASE_URL),
+        # so it must ALSO supply the key that the production-soak boot gate
+        # requires (ouroboros_battle_test.py: exits 1 if neither DOUBLEWORD_API_KEY
+        # nor ANTHROPIC_API_KEY is set). This makes the drill SELF-CONTAINED on
+        # ANY host -- no dependence on the operator's real shell key (the exact
+        # gap that failed the GCP node, whose env has no key while a dev laptop
+        # does). The mock never validates the key; setdefault-style callers
+        # (env.update(env_overrides())) let a real operator key still win if they
+        # set one, since env_overrides is applied over the composed base env.
+        "DOUBLEWORD_API_KEY": os.environ.get(
+            "JARVIS_ADVERSARY_SYNTHETIC_API_KEY", "synthetic-adversary-dw-key"),
     }
 
 

--- a/tests/scripts/test_a1_live_fire_harness.py
+++ b/tests/scripts/test_a1_live_fire_harness.py
@@ -132,6 +132,38 @@ def test_compose_env_sources_linux_overlay(monkeypatch):
     assert "OUROBOROS_BATTLE_MAX_WALL_SECONDS" in env
 
 
+def test_compose_env_operator_wall_wins_over_overlay(monkeypatch):
+    """The ignition/operator-supplied OUROBOROS_BATTLE_MAX_WALL_SECONDS is
+    AUTHORITATIVE over the linux_prod overlay's static default (3600).
+
+    Root cause (live-fire a1-brain-20260705-213419): ignite_a1_brain.py sizes the
+    node lifetime + monitor budget from --soak-wall-s and bakes the SAME value as
+    OUROBOROS_BATTLE_MAX_WALL_SECONDS in the remote command. compose_env layered
+    the overlay via env.update(), clobbering the baked 1200 with the overlay's
+    3600 -- so the soak child outlived the outer budget (node self-destructed /
+    monitor gave up mid-soak -> no verdict). The operator's explicit wall must
+    survive overlay layering (the SAME "operator env ALWAYS wins" invariant
+    _composed_soak_wall_s documents one layer down)."""
+    monkeypatch.delenv("JARVIS_A1_AUDIT_FLAGS", raising=False)
+    monkeypatch.setenv("OUROBOROS_BATTLE_MAX_WALL_SECONDS", "1200")
+    env = harness.compose_env()
+    assert env["OUROBOROS_BATTLE_MAX_WALL_SECONDS"] == "1200", (
+        "operator-explicit soak wall must win over the overlay's static 3600 default"
+    )
+
+
+def test_compose_env_overlay_wall_default_when_operator_unset(monkeypatch):
+    """When the operator does NOT pin the wall, the overlay default (3600) is
+    still sourced -- the fix preserves the fallback, it only stops the clobber
+    of an EXPLICIT operator value."""
+    monkeypatch.delenv("JARVIS_A1_AUDIT_FLAGS", raising=False)
+    monkeypatch.delenv("OUROBOROS_BATTLE_MAX_WALL_SECONDS", raising=False)
+    env = harness.compose_env()
+    assert env["OUROBOROS_BATTLE_MAX_WALL_SECONDS"] == "3600", (
+        "overlay default must still apply when the operator leaves the wall unset"
+    )
+
+
 # ===========================================================================
 # 1b. compose_env: A1-harness opt-in flags (Fix #1 + Fix #2 regression spine)
 # ===========================================================================

--- a/tests/scripts/test_ignite_a1_brain.py
+++ b/tests/scripts/test_ignite_a1_brain.py
@@ -385,9 +385,12 @@ def test_lifetime_is_derived_from_soak_wall_plus_margins():
         dry_run=True, project="p", zone="z",
         soak_wall_s=1000, lifetime_s=None,
     )
-    assert ignition.lifetime_s == 1000 + ignition.boot_offset_s + ignition.verdict_pull_margin_s
+    assert ignition.lifetime_s == (
+        1000 + ignition.boot_offset_s + ignition.post_wall_margin_s
+        + ignition.verdict_pull_margin_s)
     assert ignition.lifetime_s >= (
-        ignition.soak_wall_s + ignition.boot_offset_s + ignition.verdict_pull_margin_s
+        ignition.soak_wall_s + ignition.boot_offset_s
+        + ignition.post_wall_margin_s + ignition.verdict_pull_margin_s
     )
 
 
@@ -480,16 +483,17 @@ def test_ignition_clamps_reported_regression_case(capsys):
     """End-to-end regression pin for the EXACT reported failure:
     `--soak-wall-s 2400 --lifetime-s 1800` used to yield lifetime_s=1800 <
     wall=2400 -- a $0-kill mid-verdict. It must now clamp lifetime_s up to
-    the floor (2400 + 180 + 180 = 2760) and the full ordering invariant
-    (soak_wall_s < monitor_stop < lifetime_s) must hold."""
+    the floor (2400 + boot 180 + post_wall 300 + verdict 180 = 3060) and the
+    full ordering invariant (soak_wall_s < monitor_stop < lifetime_s) must hold."""
     ignition = _make_ignition(
         dry_run=True, project="p", zone="z", soak_wall_s=2400, lifetime_s=1800,
         monitor_max_s=None,  # let monitor_max_s DERIVE from lifetime_s (fixture
         # default overrides it to a tiny test value otherwise, which would
         # trivially satisfy any ordering check).
     )
-    expected_floor = 2400 + ignition.boot_offset_s + ignition.verdict_pull_margin_s
-    assert expected_floor == 2760
+    expected_floor = (2400 + ignition.boot_offset_s
+                      + ignition.post_wall_margin_s + ignition.verdict_pull_margin_s)
+    assert expected_floor == 3060
     assert ignition.lifetime_s == expected_floor
     assert ignition.lifetime_s >= 2400  # never $0-killed before the soak wall
 
@@ -1109,11 +1113,13 @@ def test_reap_sync_wrapper_idempotent_and_never_raises():
 
 
 def test_plan_includes_absolute_lifetime_and_provision_env():
-    ignition = _make_ignition(dry_run=True, lifetime_s=2400, project="p", zone="z")
+    # Explicit lifetime ABOVE the coordination floor (soak_wall 1800 + boot 180 +
+    # post_wall 300 + verdict 180 = 2460) so it is honored as-is, not clamped up.
+    ignition = _make_ignition(dry_run=True, lifetime_s=3000, project="p", zone="z")
     plan = ignition.build_plan()
-    assert plan.lifetime_s == 2400
+    assert plan.lifetime_s == 3000
     assert plan.provision_env["JARVIS_BRAIN_VM_PERSISTENT"] == "true"
-    assert plan.provision_env["JARVIS_BRAIN_ABSOLUTE_LIFETIME_S"] == "2400"
+    assert plan.provision_env["JARVIS_BRAIN_ABSOLUTE_LIFETIME_S"] == "3000"
 
 
 # ===========================================================================


### PR DESCRIPTION
## Why

The A1 Brain ignition drill reached the furthest point yet on `a1-brain-20260705-213419`: the organism **booted, injected the red signal, and ran the fix loop** on the un-starvable GCP Brain. But no verdict was produced — root-caused with hard evidence from the live node.

## Root cause (node-side)

`deploy/ouroboros_linux_prod.env:32` sets `OUROBOROS_BATTLE_MAX_WALL_SECONDS=3600`. `compose_env()` (a1_live_fire_chaos_harness.py) layered that overlay via `env.update()`, whose documented precedence is `process env -> linux overlay` — so the overlay's static `3600` **clobbered** the `1200` that `ignite_a1_brain.py` bakes from `--soak-wall-s` into the remote command.

Proven on the running node:
- isomorphic driver (pid 1055): `OUROBOROS_BATTLE_MAX_WALL_SECONDS=1200` ✓
- soak child (pid 1060): `ouroboros_battle_test --production-soak --max-wall-seconds 3600` + env `=3600` ✗

The 3600s child outlived the outer driver's budget (node absolute lifetime + monitor sized for ~1860s from `--soak-wall-s 1200`) → the monitor/VM gave up mid-soak → no verdict. This defeated the SAME "operator env ALWAYS wins" invariant that `_composed_soak_wall_s` (bt-iso-1783036735) documents one layer down — that fix never fired because `compose_env` overwrote the operator value before it could be read.

## Fix

`_OPERATOR_AUTHORITATIVE_KEYS` snapshot: `compose_env()` captures coordination-critical operator-explicit keys from the base process env before overlay/manifest layering and re-asserts them as the final step. An explicit operator wall now wins over every static default; an **unset** wall still falls back to the overlay's 3600.

## Commits
- `b251938b74` — operator-explicit soak wall wins over the linux overlay default (**the node-side unblock**)
- `2f348a0294` — post_wall_margin so the monitor waits for the organism kill-ladder + audit
- `5fa6945cf3` — synthetic adversary supplies DOUBLEWORD_API_KEY so the organism boots on a keyless node

## Tests
- `tests/scripts/test_a1_live_fire_harness.py` — 30/30 green, incl. 2 new: operator-wall-wins + overlay-default-when-unset
- `tests/scripts/test_ignite_a1_brain.py` — 51/51 green

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes soak wall precedence so the operator value always wins over the overlay default, preventing the soak child from outliving the monitor and restoring verdicts on A1 live-fire. Adds a small post-wall margin and a synthetic `DOUBLEWORD_API_KEY` so the organism boots on keyless nodes.

- **Bug Fixes**
  - `compose_env()` now snapshots operator-authoritative keys (e.g., `OUROBOROS_BATTLE_MAX_WALL_SECONDS`) and reapplies them last, so an explicit wall wins; when unset, the overlay’s 3600 default still applies.
  - Added `JARVIS_A1_BRAIN_POST_WALL_MARGIN_S` (default 300s) to the lifetime floor in `ignite_a1_brain.py` so the monitor waits through the kill ladder and audit; preserves soak_wall < monitor_stop < lifetime.
  - Sets a synthetic `DOUBLEWORD_API_KEY` in the dispatch env and in `synthetic_adversary._build_env_overrides` (configurable via `JARVIS_ADVERSARY_SYNTHETIC_API_KEY`) to satisfy the O+V boot gate on keyless nodes.

<sup>Written for commit b251938b741c4db796f12cf5b7a73d9c0858db4e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

