### PR TITLE
fix(a1): run-233225 root causes — vector sensor python3, honest mutation gate, L2 storm breaker, HARDEN posture seed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -444,3 +444,6 @@ a1_iso_runs/
 *_resume.html
 *resume*.html
 Derek J. Russell - Resume*.pdf
+
+# Local AI-tool configs that may hold per-user credentials (never commit)
+.codex/

--- a/backend/core/ouroboros/governance/intent/test_watcher.py
+++ b/backend/core/ouroboros/governance/intent/test_watcher.py
@@ -180,14 +180,16 @@ class TestWatcher:
         soak). When *target_paths* is None / empty, the legacy
         whole-``test_dir`` behavior is byte-identical (back-compat).
         """
-        from backend.core.ouroboros.governance.test_subprocess_helper import (  # noqa: E501
-            run_pytest_subprocess,
-        )
+        from backend.core.ouroboros.governance import test_subprocess_helper as _tsh  # noqa: E501
         # Scoped targets (FS-driven primary) vs. legacy whole-suite.
         scoped = [str(p) for p in (target_paths or []) if str(p).strip()]
         pytest_targets = scoped if scoped else [str(self.test_dir)]
+        # resolve_python_bin — NEVER bare "python3": PATH-dependent argv[0]
+        # under a minimal-PATH node hit /usr/bin/python3 (no pytest) and
+        # blinded the TestFailure sensor for the whole a1-brain-20260705-
+        # 233225 session (the 41-byte "No module named pytest" class).
         argv = [
-            "python3",
+            _tsh.resolve_python_bin(),
             "-m",
             "pytest",
             *pytest_targets,
@@ -196,7 +198,7 @@ class TestWatcher:
             "--no-header",
             "--color=no",
         ]
-        result = await run_pytest_subprocess(
+        result = await _tsh.run_pytest_subprocess(
             argv,
             cwd=str(self.repo_path),
             timeout_s=float(self.pytest_timeout_s),

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -12180,6 +12180,15 @@ class GovernedOrchestrator:
                 "max_iterations_exhausted",
                 "max_validation_runs_exhausted",
                 "deadline_budget_exhausted",
+                # a1-brain-20260705-233225 storm root cause: a per-class
+                # retry exhaustion IS "genuinely exhausted" by this
+                # taxonomy's own definition, but was absent here →
+                # classified SOFT → futilely re-dispatched — 120/120
+                # identical class_retries_exhausted:env re-dispatches,
+                # each burning a fresh 120s timebox. The engine's
+                # per-run counter re-derives the same deterministic
+                # failure every dispatch.
+                "class_retries_exhausted",
             )
             _stop_reason_str = l2_result.stop_reason or ""
             _is_hard_stop = any(

--- a/backend/core/ouroboros/governance/phase_runners/validate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/validate_runner.py
@@ -93,6 +93,60 @@ if TYPE_CHECKING:  # pragma: no cover
 logger = logging.getLogger("Ouroboros.Orchestrator")
 
 
+# ---------------------------------------------------------------------------
+# L2 storm breaker (run a1-brain-20260705-233225): 60 background-route ops
+# each re-dispatched L2 on the IDENTICAL sticky stop reason
+# (class_retries_exhausted:env, 120/120 uniform), burning a fresh 120s
+# timebox per futile dispatch until the wall clock died. Two structural
+# guards, no sensor names, no global disables:
+#
+#   * resolve_l2_dispatch_budget — route-aware dispatch cap. BACKGROUND /
+#     SPECULATIVE routes default to a single dispatch (no re-dispatch),
+#     composing with the existing route-gating cost philosophy (the Venom
+#     tool loop is already skipped for those routes). Strictest-wins
+#     against the global knob, same composing philosophy as
+#     risk_tier_floor.
+#   * is_sticky_soft_stop — a re-dispatch that reproduces the identical
+#     stop reason has empirically falsified the SOFT premise ("transient
+#     — fresh dispatch could converge"); the failure is deterministic and
+#     further dispatches are storm fuel. Generic across ANY reason.
+# ---------------------------------------------------------------------------
+
+# The two cost-optimized provider routes (closed UrgencyRouter vocabulary).
+_L2_BG_ROUTES = frozenset({"background", "speculative"})
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        raw = os.environ.get(name, "").strip()
+        return int(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def resolve_l2_dispatch_budget(provider_route: Optional[str]) -> int:
+    """Max total L2 dispatches (1 initial + N re-dispatches) for this op.
+
+    Global: ``JARVIS_L2_DISPATCH_RETRIES`` (default 1 → 2 dispatches).
+    BACKGROUND/SPECULATIVE routes: ``JARVIS_L2_DISPATCH_RETRIES_BACKGROUND``
+    (default 0 → single dispatch), never exceeding the global cap.
+    """
+    base = _env_int("JARVIS_L2_DISPATCH_RETRIES", 1) + 1
+    route = (provider_route or "").strip().lower()
+    if route in _L2_BG_ROUTES:
+        bg = _env_int("JARVIS_L2_DISPATCH_RETRIES_BACKGROUND", 0) + 1
+        return min(base, bg)
+    return base
+
+
+def is_sticky_soft_stop(
+    prev_reason: Optional[str], new_reason: str
+) -> bool:
+    """True when a re-dispatch reproduced the identical soft-stop reason —
+    deterministic failure; re-dispatching again is definitionally futile."""
+    return bool(prev_reason) and prev_reason == new_reason
+
+
 class VALIDATERunner(PhaseRunner):
     """Verbatim transcription of orchestrator.py VALIDATE block (~4693-5440)."""
 
@@ -399,9 +453,11 @@ class VALIDATERunner(PhaseRunner):
                 # ADDITIONAL L2 dispatches after the first.
                 # ──────────────────────────────────────────────────
                 if orch._config.repair_engine is not None and best_validation is not None:
-                    _l2_max_dispatches = int(
-                        os.environ.get("JARVIS_L2_DISPATCH_RETRIES", "1"),
-                    ) + 1
+                    # Route-aware budget: BACKGROUND/SPECULATIVE default to a
+                    # single dispatch (storm breaker — see module docstring).
+                    _l2_max_dispatches = resolve_l2_dispatch_budget(
+                        getattr(ctx, "provider_route", ""),
+                    )
                 else:
                     _l2_max_dispatches = 0
                 _l2_dispatch_idx = 0
@@ -469,9 +525,54 @@ class VALIDATERunner(PhaseRunner):
                         break  # inner Slice 6 retry loop
                     elif directive[0] == "l2_retry":
                         # Slice 6 — re-dispatch L2 with fresh budget
-                        _l2_soft_stop_history.append(
+                        _new_stop_reason = (
                             directive[2] if len(directive) > 2 else "unknown"
                         )
+                        _prev_stop_reason = (
+                            _l2_soft_stop_history[-1]
+                            if _l2_soft_stop_history else None
+                        )
+                        _l2_soft_stop_history.append(_new_stop_reason)
+                        if is_sticky_soft_stop(
+                            _prev_stop_reason, _new_stop_reason
+                        ):
+                            # Storm breaker: the re-dispatch reproduced the
+                            # IDENTICAL stop reason — deterministic failure,
+                            # the SOFT premise is empirically falsified.
+                            # Burning another timebox is storm fuel
+                            # (a1-brain-20260705-233225: 120/120 identical
+                            # class_retries_exhausted:env re-dispatches).
+                            logger.info(
+                                "[Orchestrator] L2 sticky soft-stop op=%s "
+                                "reason=%s repeated identically — "
+                                "converting to cancel terminal "
+                                "(no-progress breaker)",
+                                ctx.op_id,
+                                _new_stop_reason,
+                            )
+                            ctx = ctx.advance(
+                                OperationPhase.CANCELLED,
+                                terminal_reason_code=(
+                                    f"l2_sticky_soft_stop:{_new_stop_reason}"
+                                ),
+                            )
+                            await orch._record_ledger(
+                                ctx,
+                                OperationState.FAILED,
+                                {
+                                    "reason": "l2_sticky_soft_stop",
+                                    "stop_reason": _new_stop_reason,
+                                    "attempts": _l2_dispatch_idx,
+                                    "soft_stop_history": _l2_soft_stop_history,
+                                },
+                            )
+                            _fsm_log(
+                                "l2_sticky_soft_stop",
+                                f"reason={_new_stop_reason} "
+                                f"attempts={_l2_dispatch_idx}",
+                            )
+                            _l2_retries_exhausted_ctx = ctx
+                            break  # inner Slice 6 retry loop
                         if _l2_dispatch_idx >= _l2_max_dispatches:
                             # Out of retries — convert soft stop to cancel.
                             logger.info(

--- a/backend/core/ouroboros/governance/test_runner.py
+++ b/backend/core/ouroboros/governance/test_runner.py
@@ -1307,8 +1307,13 @@ class TestRunner:
         streaming_on = _streaming_enabled()
         verbosity_flag = "-v" if streaming_on else "-q"
 
+        # resolve_python_bin — NEVER bare "python3" (PATH-dependent argv[0]
+        # blinded VERIFY on minimal-PATH nodes; see test_subprocess_helper).
+        from backend.core.ouroboros.governance.test_subprocess_helper import (
+            resolve_python_bin,
+        )
         cmd = [
-            "python3", "-m", "pytest",
+            resolve_python_bin(), "-m", "pytest",
             "-o", "addopts=",
             "--continue-on-collection-errors",
             "--timeout=" + str(_TEST_PER_TEST_TIMEOUT_S),

--- a/backend/core/ouroboros/governance/test_subprocess_helper.py
+++ b/backend/core/ouroboros/governance/test_subprocess_helper.py
@@ -90,6 +90,7 @@ import enum
 import logging
 import os
 import signal
+import sys
 import time
 from dataclasses import dataclass, field
 from typing import Any, List, Mapping, Optional, Sequence
@@ -155,6 +156,35 @@ _GRACE_S_MAX: float = 30.0
 
 _DEFAULT_OUTPUT_CAP_CHARS: int = 200_000
 _OUTPUT_CAP_MIN: int = 1_000
+
+# Interpreter override for every pytest spawn routed through this helper.
+# Same env precedent as hybrid_teammate_executor / isolated_agent_worker.
+_PYTHON_BIN_ENV: str = "JARVIS_PYTHON_BIN"
+
+
+def resolve_python_bin() -> str:
+    """Resolve the interpreter for pytest spawns — NEVER bare ``python3``.
+
+    Resolution order:
+
+    1. ``JARVIS_PYTHON_BIN`` env override (operator-explicit wins);
+    2. ``sys.executable`` — the running interpreter, structurally
+       guaranteed to carry the organism's own test deps;
+    3. bare ``"python3"`` only as a last resort for embedded/frozen
+       interpreters where ``sys.executable`` is empty.
+
+    Root cause this closes (run a1-brain-20260705-233225, GCP Brain node):
+    a bare ``"python3"`` argv[0] resolves PATH-dependently — under the
+    systemd-run unit's minimal PATH it hit ``/usr/bin/python3`` (no
+    pytest), so every TestWatcher run died at bootstrap with the 41-byte
+    ``No module named pytest`` and the organism was blind to test
+    failures for the whole session (the A1 injection vector never became
+    an op). Classic passes-local-fails-remote.
+    """
+    env = os.environ.get(_PYTHON_BIN_ENV, "").strip()
+    if env:
+        return env
+    return sys.executable or "python3"
 
 
 def _resolve_grace_s() -> float:

--- a/backend/core/ouroboros/governance/tool_executor.py
+++ b/backend/core/ouroboros/governance/tool_executor.py
@@ -4838,12 +4838,17 @@ class AsyncProcessToolBackend:
         branch, which SIGKILL-pgrp's the child before re-raising.
         """
         from backend.core.ouroboros.governance.test_subprocess_helper import (  # noqa: E501
+            resolve_python_bin,
             run_pytest_subprocess,
         )
         paths_arg = call.arguments.get("paths", [])
         if isinstance(paths_arg, str):
             paths_arg = [paths_arg]
-        cmd = ["python3", "-m", "pytest", "--tb=short", "-q"] + list(paths_arg)
+        # resolve_python_bin — NEVER bare "python3" (PATH-dependent argv[0]
+        # broke run_tests on minimal-PATH nodes; see test_subprocess_helper).
+        cmd = [resolve_python_bin(), "-m", "pytest", "--tb=short", "-q"] + list(
+            paths_arg
+        )
 
         try:
             result = await run_pytest_subprocess(

--- a/scripts/a1_graduation_auditor.py
+++ b/scripts/a1_graduation_auditor.py
@@ -73,6 +73,7 @@ from typing import (
     List,
     Optional,
     Sequence,
+    Set,
     Tuple,
 )
 
@@ -550,13 +551,19 @@ _LEDGER_TERMINAL_RE = re.compile(
 )
 # 'op=<op> is_noop=True (...) terminal_reason_code=<code> ... skipping APPLY'
 # -- a legitimate, BY-DESIGN FSM branch: a read-only/no-op op structurally
-# SKIPS the literal APPLY phase yet still reaches a genuine autonomous
-# terminal completion (LEDGER_TERMINAL state=applied). Counted as
-# APPLY-equivalent evidence (labelled distinctly -- never silently relabeled
-# as a literal "APPLY" phase observation) so a no-op autonomous completion is
-# not wrongly reported as "never reached APPLY".
+# SKIPS the literal APPLY phase and reaches an autonomous terminal
+# completion (LEDGER_TERMINAL state=applied) WITHOUT writing a byte.
+# Recorded distinctly as "APPLY_SKIPPED_NOOP" for observability AND the
+# op_id is registered in ``_noop_op_ids`` so its subsequent
+# ``state=applied`` ledger record can NEVER satisfy the autonomous-
+# MUTATION gate (``fsm_classify_to_applied``). This is the fix for the
+# run-a1-brain-20260705-233225 false positive where the old
+# "APPLY-equivalent evidence" semantics let two read_only_complete noops
+# flip the criterion true. written=True AND is_noop=False are absolute
+# prerequisites for a PASS.
 _NOOP_SKIP_APPLY_RE = re.compile(
-    r"is_noop=True.*?terminal_reason_code=\S+.*?skipping APPLY"
+    r"op=(?P<op>\S+)\s+is_noop=True.*?"
+    r"terminal_reason_code=(?P<code>\S+).*?skipping APPLY"
 )
 # '[HYDRATION-HANDSHAKE] HMAC-SHA256 VERIFIED op=<op> phase=<phase> digest=<hex>...'
 # -- fsm_checkpoint.list_pending() emits this ONLY after its own _verify()
@@ -1031,6 +1038,17 @@ _TERMINAL_MERGE_MARKERS: Tuple[str, ...] = (
 # FSM phases (from the 11-phase pipeline). state=applied is the win.
 _TERMINAL_APPLIED_STATES = frozenset({"applied"})
 
+# Terminal reason codes that mark a NO-MUTATION completion. An op that
+# terminates with one of these wrote zero bytes — its ``state=applied``
+# ledger record is an autonomous *completion*, never autonomous *mutation*
+# evidence. Mirrors the orchestrator's read-only APPLY short-circuit
+# (orchestrator.py ``terminal_reason_code="read_only_complete"`` emit sites)
+# — the parser twin of that contract, kept in lockstep the same way the
+# regexes above mirror their log emitters. Run a1-brain-20260705-233225
+# false-positive: two is_noop=True read_only_complete ops flipped
+# ``fsm_classify_to_applied`` true with zero bytes written.
+_NOOP_TERMINAL_REASON_CODES = frozenset({"read_only_complete"})
+
 
 @dataclass
 class A1Verdict:
@@ -1091,7 +1109,17 @@ class A1GraduationAuditor:
 
         self.trace = A1TraceTimeline()
         self.fsm_phases_seen: List[str] = []
-        self.state_applied = False
+        # Autonomous-MUTATION evidence (op-scoped). ``_applied_written_ops``
+        # holds ops with a ``state=applied`` terminal AND a durable write
+        # (log path: ``written=True`` literal; SSE path: publish happens
+        # only after a successful ledger.append per
+        # ``publish_operation_terminal``'s contract). ``_noop_op_ids``
+        # holds ops that terminated via a no-mutation reason code
+        # (read_only_complete) or the is_noop skip-APPLY branch. The gate
+        # is their set difference — written=True AND is_noop=False are
+        # absolute prerequisites (see ``state_applied`` property).
+        self._applied_written_ops: Set[str] = set()
+        self._noop_op_ids: Set[str] = set()
         self.pr_signal_observed = False
         self.terminal_merge_reached = False
         self.intervention_tripped = False
@@ -1417,11 +1445,24 @@ class A1GraduationAuditor:
                 self.fsm_phases_seen.append(phase)
                 self._last_fsm_phase = phase
 
-        # Terminal applied / PR signal.
+        # Terminal applied / PR signal. Op-scoped mutation evidence: a
+        # no-mutation reason code (read_only_complete) registers the op as
+        # noop; anything else with an op_id counts as applied evidence
+        # (publish fires only after a successful ledger append — see
+        # publish_operation_terminal). Anonymous events (no op_id) can't be
+        # correlated against noop markers and are never mutation proof.
         if event_type == "operation_terminal":
             state = str(payload.get("state", "")).strip().lower()
             if state in _TERMINAL_APPLIED_STATES:
-                self.state_applied = True
+                op = str(payload.get("op_id", "")).strip()
+                reason = str(
+                    payload.get("terminal_reason_code", "")
+                ).strip().lower()
+                if reason in _NOOP_TERMINAL_REASON_CODES:
+                    if op:
+                        self._noop_op_ids.add(op)
+                elif op:
+                    self._applied_written_ops.add(op)
         if self._is_pr_signal(event_type, payload, blob):
             self.pr_signal_observed = True
 
@@ -1512,17 +1553,24 @@ class A1GraduationAuditor:
                 self._last_fsm_phase = phase.upper()
 
         # LEDGER_TERMINAL state=applied (textual twin of operation_terminal).
+        # written=True is an ABSOLUTE prerequisite — written=False is a
+        # deduped/phantom record, never mutation proof. Op-scoped so a noop
+        # op's applied terminal is subtracted at verdict time.
         lt = _LEDGER_TERMINAL_RE.search(line)
         if lt is not None:
             state = lt.group("state").strip().lower()
-            if state in _TERMINAL_APPLIED_STATES:
-                self.state_applied = True
+            written = lt.group("written").strip().lower() == "true"
+            if state in _TERMINAL_APPLIED_STATES and written:
+                self._applied_written_ops.add(lt.group("op").strip())
 
         # A no-op/read-only op that structurally SKIPS the literal APPLY
-        # phase yet still reaches a genuine autonomous completion -- counted
-        # as APPLY-equivalent (see _NOOP_SKIP_APPLY_RE docstring above).
-        if _NOOP_SKIP_APPLY_RE.search(line) is not None:
+        # phase. Recorded for observability + the op is registered as noop
+        # so its applied terminal can never satisfy the mutation gate (see
+        # _NOOP_SKIP_APPLY_RE docstring above).
+        noop_m = _NOOP_SKIP_APPLY_RE.search(line)
+        if noop_m is not None:
             self.fsm_phases_seen.append("APPLY_SKIPPED_NOOP")
+            self._noop_op_ids.add(noop_m.group("op").strip())
 
         # HMAC-anchored resume-splice authentication record.
         hh = parse_hydration_handshake_verified(line)
@@ -1618,12 +1666,26 @@ class A1GraduationAuditor:
                 return False, "flag_audit:unverifiable:%s" % (st.flag,)
         return True, ""
 
+    @property
+    def state_applied(self) -> bool:
+        """True iff at least one op has a durable ``state=applied`` terminal
+        (``written=True``) AND is not a no-mutation completion. This is the
+        autonomous-MUTATION gate: written=True and is_noop=False are
+        absolute prerequisites — a ``read_only_complete`` no-op can never
+        satisfy it (run a1-brain-20260705-233225 false-positive fix)."""
+        return bool(self._applied_written_ops - self._noop_op_ids)
+
     def _fsm_reached_applied(self) -> bool:
-        # CLASSIFY...APPLY present + state=applied observed.
+        # CLASSIFY...APPLY present + a genuine (written, non-noop)
+        # state=applied observed. "APPLY_SKIPPED_NOOP" is observability
+        # labelling, NEVER mutation-gate evidence.
         saw_classify = any(
             p.upper().startswith("CLASSIFY") for p in self.fsm_phases_seen
         )
-        saw_apply = any(p.upper().startswith("APPLY") for p in self.fsm_phases_seen)
+        saw_apply = any(
+            p.upper().startswith("APPLY") and p.upper() != "APPLY_SKIPPED_NOOP"
+            for p in self.fsm_phases_seen
+        )
         return saw_classify and saw_apply and self.state_applied
 
     def verdict(self) -> A1Verdict:
@@ -1676,7 +1738,16 @@ class A1GraduationAuditor:
                 missing = self._missing_hops()
                 locus = "a1trace:missing_or_out_of_order:%s" % (",".join(missing) or "order",)
             elif not fsm_ok:
-                locus = "fsm:did_not_reach_state_applied"
+                if self._noop_op_ids and not (
+                    self._applied_written_ops - self._noop_op_ids
+                ):
+                    # Diagnosable, not generic: the ONLY applied evidence
+                    # was no-mutation (read_only_complete / is_noop)
+                    # completions — the exact false-positive class this
+                    # gate was tightened against.
+                    locus = "fsm:only_noop_read_only_completions_no_mutation"
+                else:
+                    locus = "fsm:did_not_reach_state_applied"
             elif not flag_pass:
                 locus = flag_locus
             elif not pr_ok:

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -296,6 +296,18 @@ def _default_remote_run_dir(node_name: str) -> str:
 # ---------------------------------------------------------------------------
 _ENV_SOAK_WALL_S = "JARVIS_A1_BRAIN_SOAK_WALL_S"
 _DEFAULT_SOAK_WALL_S = 1800  # matches the CLAUDE.md A1 happy-path (~850-1300s)
+# DW-rehearsal session budget for the on-node isomorphic soak. isomorphic_a1_local
+# defaults --dw-session-budget to 0.0 (the "starve" scenario for failover forcing);
+# with a $0 cap the SessionBudgetAuthority preflight REFUSES every DW dispatch
+# (est $0.10 > $0.00) so GENERATE never produces a candidate and no op reaches
+# APPLY (live-fire a1-brain-20260705-221612: 209 CLASSIFY / 106 GENERATE / 0
+# VALIDATE / 0 APPLIED). This driver EXISTS to prove the APPLIED threshold, so it
+# opts into the sanctioned DW-powered rehearsal lane by default -- the on-node DW
+# is the SyntheticAdversary stub (free: HeavyProbe cost_usd~$0.00002/call), so a
+# nonzero cap lets the budget preflight pass at ~$0 real cost. Set the env to 0 to
+# restore the legacy starve scenario.
+_ENV_DW_SESSION_BUDGET = "JARVIS_A1_BRAIN_DW_SESSION_BUDGET"
+_DEFAULT_DW_SESSION_BUDGET = 5.0  # ~50 ops at the $0.10 static estimate; free stub
 _ENV_BOOT_OFFSET_S = "JARVIS_A1_BRAIN_BOOT_OFFSET_S"
 _DEFAULT_BOOT_OFFSET_S = 180  # observed ~168s cold boot, rounded up w/ margin
 _ENV_VERDICT_PULL_MARGIN_S = "JARVIS_A1_BRAIN_VERDICT_PULL_MARGIN_S"
@@ -379,6 +391,7 @@ def _resolve_lifetime_s(
 # ---------------------------------------------------------------------------
 def _compose_remote_command(
     *, remote_run_dir: str, seed: int, verbose: bool, soak_wall_s: int,
+    dw_session_budget: float,
 ) -> str:
     """The actual isomorphic_a1_local.py invocation that runs ON the node.
     Co-located (parent driver's SSH session + the soak child it launches share
@@ -446,7 +459,7 @@ def _compose_remote_command(
         "OUROBOROS_BATTLE_HEADLESS=1 "
         "OUROBOROS_BATTLE_MAX_WALL_SECONDS=%d "
         "%s scripts/isomorphic_a1_local.py --mode process --run-root %s "
-        "--seed %d%s"
+        "--dw-session-budget %s --seed %d%s"
         % (
             _REMOTE_REPO_ROOT,
             pip_sync,
@@ -456,6 +469,7 @@ def _compose_remote_command(
             int(soak_wall_s),
             _REMOTE_PYTHON,
             remote_run_dir,
+            "%g" % float(dw_session_budget),
             seed,
             verbose_flag,
         )
@@ -800,6 +814,8 @@ class A1BrainIgnition:
         self.post_wall_margin_s = int(
             _env_int(_ENV_POST_WALL_MARGIN_S, _DEFAULT_POST_WALL_MARGIN_S))
         self.soak_wall_s = _resolve_soak_wall_s(soak_wall_s)
+        self.dw_session_budget = _env_float(
+            _ENV_DW_SESSION_BUDGET, _DEFAULT_DW_SESSION_BUDGET)
         self.lifetime_s = _resolve_lifetime_s(
             explicit=lifetime_s,
             soak_wall_s=self.soak_wall_s,
@@ -925,7 +941,7 @@ class A1BrainIgnition:
         zone = self.zone or _resolve_zone_for_plan()
         remote_cmd = _compose_remote_command(
             remote_run_dir=self.remote_run_dir, seed=self.seed, verbose=self.verbose,
-            soak_wall_s=self.soak_wall_s)
+            soak_wall_s=self.soak_wall_s, dw_session_budget=self.dw_session_budget)
         dispatch_wrapper = _compose_dispatch_wrapper(remote_cmd, self.remote_run_dir)
         # Bug 3: the command actually sent over SSH is root-wrapped (single
         # base64 | sudo bash pipe) -- /opt/trinity/jarvis is root-owned.
@@ -1184,7 +1200,7 @@ class A1BrainIgnition:
     async def dispatch(self) -> bool:
         remote = _compose_remote_command(
             remote_run_dir=self.remote_run_dir, seed=self.seed, verbose=self.verbose,
-            soak_wall_s=self.soak_wall_s)
+            soak_wall_s=self.soak_wall_s, dw_session_budget=self.dw_session_budget)
         wrapper = _compose_dispatch_wrapper(remote, self.remote_run_dir)
         # Bug 3: the mkdir + nohup + isomorphic_a1_local.py invocation all
         # write under the root-owned /opt/trinity/jarvis tree -- root-wrap the

--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -308,6 +308,14 @@ _DEFAULT_SOAK_WALL_S = 1800  # matches the CLAUDE.md A1 happy-path (~850-1300s)
 # restore the legacy starve scenario.
 _ENV_DW_SESSION_BUDGET = "JARVIS_A1_BRAIN_DW_SESSION_BUDGET"
 _DEFAULT_DW_SESSION_BUDGET = 5.0  # ~50 ops at the $0.10 static estimate; free stub
+# Posture-context seed forwarding: the isomorphic driver defaults to seeding
+# HARDEN into the overlay's posture triplet (organism boots context-aware,
+# background-sensor budgets reshape natively). Operators override/disable
+# Mac-side via this env; forwarded verbatim to the remote cmd when set.
+# Token-validated (alnum/underscore) because the remote cmd runs inside a
+# single-quoted bash -c wrapper.
+_ENV_POSTURE_SEED = "JARVIS_A1_POSTURE_SEED"
+_POSTURE_SEED_TOKEN_RE = re.compile(r"^[A-Za-z0-9_]+$")
 _ENV_BOOT_OFFSET_S = "JARVIS_A1_BRAIN_BOOT_OFFSET_S"
 _DEFAULT_BOOT_OFFSET_S = 180  # observed ~168s cold boot, rounded up w/ margin
 _ENV_VERDICT_PULL_MARGIN_S = "JARVIS_A1_BRAIN_VERDICT_PULL_MARGIN_S"
@@ -450,8 +458,17 @@ def _compose_remote_command(
             )
         )
         pip_sync = pip_sync + diag
+    # Operator-explicit posture-seed override rides along (default lives in
+    # the driver itself: HARDEN). Token-validated — the cmd runs inside a
+    # single-quoted bash -c wrapper; a non-token value is dropped, never
+    # quoted-through.
+    posture_seed = ""
+    _seed_raw = os.environ.get(_ENV_POSTURE_SEED, "").strip()
+    if _seed_raw and _POSTURE_SEED_TOKEN_RE.match(_seed_raw):
+        posture_seed = "%s=%s " % (_ENV_POSTURE_SEED, _seed_raw)
     return (
         "cd %s && "
+        "%s"
         "%s"
         "JARVIS_CHAOS_TARGET_DIRS=%s "
         "JARVIS_BRAIN_OUTBOUND_TOPICS=%s "
@@ -463,6 +480,7 @@ def _compose_remote_command(
         % (
             _REMOTE_REPO_ROOT,
             pip_sync,
+            posture_seed,
             _DEFAULT_CHAOS_TARGET_DIRS,
             _DEFAULT_OUTBOUND_TOPICS,
             _SYNTHETIC_DW_API_KEY,

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -943,6 +943,85 @@ def _install_revert_signal_handlers() -> None:
 
 
 # ---------------------------------------------------------------------------
+# A1 posture-context seed (run a1-brain-20260705-233225)
+# ---------------------------------------------------------------------------
+
+def _seed_posture_context(repo_root: str) -> bool:
+    """Seed the overlay's durable posture triplet so the organism boots
+    knowing its operating context — an A1 ignition rehearsal is
+    definitionally a HARDEN context (prove a repair loop against an
+    injected failure).
+
+    Why this and not a sensor-disable flag: 63 doc_staleness + 3
+    todo_scanner background signals swamped the a1-brain-20260705-233225
+    loop while the vector's lane sat idle. Disabling sensors is a
+    governance bypass; seeding posture routes the SAME intent through the
+    organism's existing metacognition — SensorGovernor weighted caps
+    (HARDEN: TestFailure 1.8x, discovery 0.3x, consolidation 0.6x via
+    sensor_governor_seed.py), posture prompt injection, and L3
+    direct-enforcement all consume it natively.
+
+    Contract:
+      * ``JARVIS_A1_POSTURE_SEED`` selects the posture (default HARDEN;
+        ``0/false/off/none/empty`` disables; invalid values fail soft).
+      * Round-trips through the REAL PostureStore serializer — never a
+        hand-rolled JSON shape that could drift from the schema.
+      * NEVER clobbers an existing reading (resumed overlay / operator
+        state wins — this is a cold-start default, not authority).
+      * The seed is a starting state, not a lock: PostureObserver's own
+        cadence + hysteresis may move off it if live signals demand.
+      * Fail-soft: any error logs and returns False; ignition proceeds.
+
+    Returns True iff a fresh reading was written.
+    """
+    raw = os.environ.get("JARVIS_A1_POSTURE_SEED", "HARDEN").strip()
+    if raw.lower() in ("", "0", "false", "off", "none"):
+        return False
+    try:
+        from backend.core.ouroboros.governance.posture import (
+            Posture,
+            PostureReading,
+        )
+        from backend.core.ouroboros.governance.posture_store import (
+            PostureStore,
+        )
+
+        try:
+            posture = Posture.from_str(raw)
+        except Exception:  # noqa: BLE001 — unknown vocabulary → fail soft
+            _log(
+                "[PostureSeed] unknown posture %r — seed skipped "
+                "(valid: %s)" % (raw, [p.value for p in Posture]),
+            )
+            return False
+
+        store = PostureStore(Path(repo_root) / ".jarvis")
+        if store.load_current() is not None:
+            _log("[PostureSeed] existing reading present — seed skipped")
+            return False
+        now = time.time()
+        store.write_current(
+            PostureReading(
+                posture=posture,
+                confidence=0.9,
+                evidence=(),
+                inferred_at=now,
+                signal_bundle_hash="a1-ignition-seed",
+                all_scores=((posture, 0.9),),
+            ),
+            change_marker_at=now,
+        )
+        _log(
+            "[PostureSeed] seeded posture=%s at %s/.jarvis — organism "
+            "boots context-aware" % (posture.value, repo_root),
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — never blocks ignition
+        _log("[PostureSeed] fail-soft: %s" % (exc,))
+        return False
+
+
+# ---------------------------------------------------------------------------
 # Run-#12 helpers: touch chaos files + derive scoped test targets
 # ---------------------------------------------------------------------------
 
@@ -999,12 +1078,18 @@ def _derive_scoped_test_targets(chaos_files: List[str], repo_root: str) -> List[
     return sorted(set(targets))
 
 
-def _await_soak_boot(
+async def _await_soak_boot(
     proc: Any,
     debug_log: str,
     timeout_s: float = 60.0,
 ) -> bool:
     """Poll the soak's debug.log for the TestWatcher READY marker.
+
+    ``async def`` is load-bearing (the e2e spine pins it): a synchronous
+    blocking-sleep poll here blocked the driver's event loop for up
+    to *timeout_s* — starving the SyntheticAdversary's aiohttp server
+    exactly while the booting organism runs its provider preflight, so
+    real preflight requests read as CONNECTION_ERROR.
 
     Returns True when the marker is found within *timeout_s*, False on timeout
     or premature process exit.  Stub-soak callers pass ``proc=None`` and this
@@ -1027,7 +1112,7 @@ def _await_soak_boot(
                         return True
         except OSError:
             pass
-        time.sleep(0.5)
+        await asyncio.sleep(0.5)
     _log("soak boot TIMEOUT after %.0fs (%d lines scanned)" % (timeout_s, seen_lines))
     return False  # timeout -- proceed anyway; sensor may still start
 
@@ -1232,6 +1317,13 @@ class IsomorphicA1Driver:
                 # Capture the disjoint cwd now (IsomorphicEnv chdir'd us here).
                 # Used later to run the organism subprocess under the same path.
                 iso_cwd: str = os.getcwd()
+
+                # Seed the overlay's durable posture triplet so the organism
+                # boots knowing this is a HARDEN-context rehearsal — the
+                # existing metacognitive stack (SensorGovernor weights,
+                # posture prompt injection, L3 enforcement) consumes it
+                # natively. Cold-start default only; never clobbers state.
+                _seed_posture_context(str(env_ctx.root))
 
                 # Compose env: node vars (from IsomorphicEnv via os.environ, which
                 # now includes JARVIS_SANDBOX_PREFIXES) + cognitive flags ON (from
@@ -1500,7 +1592,7 @@ class IsomorphicA1Driver:
                         # the child publishes its true wall deadline).
                         _soak_launch_monotonic = time.monotonic()
                         _log("STEP await boot READY (TestWatcher fs.changed.* sub)")
-                        _await_soak_boot(
+                        await _await_soak_boot(
                             soak_proc, debug_log,
                             timeout_s=_SOAK_BOOT_READY_POLL_S)
 

--- a/tests/governance/test_l2_storm_breaker.py
+++ b/tests/governance/test_l2_storm_breaker.py
@@ -1,0 +1,147 @@
+"""L2 VALIDATE_RETRY storm breaker — Slice 6 hardening.
+
+Empirical context (run a1-brain-20260705-233225, GCP Brain node):
+60 background-route doc_staleness ops each dispatched L2 twice, and
+120/120 re-dispatches returned the IDENTICAL stop reason
+``class_retries_exhausted:env`` — a monotonic exhaustion that cannot be
+un-exhausted by a fresh dispatch. Each futile re-dispatch burned a fresh
+120s timebox; the aggregate storm consumed the session wall clock and the
+worker pool while the queue's priority math sat idle. 720 VALIDATE_RETRY
+phase entries, zero repairs.
+
+Three composable fixes, all structural (no sensor names, no global
+disables):
+
+1. TAXONOMY ROOT CAUSE — ``class_retries_exhausted`` joins the HARD stop
+   prefixes in ``_l2_hook``. The taxonomy's own definition of HARD is
+   "genuinely exhausted — re-dispatch would gain nothing"; a per-class
+   retry exhaustion is literally that. Misclassified SOFT was the storm's
+   ignition.
+2. STICKY-REASON BREAKER — a re-dispatch that reproduces the identical
+   stop reason has empirically falsified the SOFT premise ("transient —
+   fresh dispatch could converge"). Generic: catches ANY deterministic
+   failure, not an enumerated reason list.
+3. ROUTE-AWARE DISPATCH BUDGET — BACKGROUND/SPECULATIVE ops default to a
+   single L2 dispatch (no re-dispatch), composing with the existing
+   route-gating cost philosophy (Venom tool loop is already skipped for
+   those routes). Env-tunable: JARVIS_L2_DISPATCH_RETRIES_BACKGROUND.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.phase_runners import validate_runner as vr
+
+_REPO = Path(__file__).resolve().parents[2]
+_ORCH = _REPO / "backend" / "core" / "ouroboros" / "governance" / "orchestrator.py"
+_ENGINE = _REPO / "backend" / "core" / "ouroboros" / "governance" / "repair_engine.py"
+_VR = (
+    _REPO / "backend" / "core" / "ouroboros" / "governance"
+    / "phase_runners" / "validate_runner.py"
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. resolve_l2_dispatch_budget — route-aware
+# ---------------------------------------------------------------------------
+
+
+class TestResolveL2DispatchBudget:
+    def test_default_routes_get_two_dispatches(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_L2_DISPATCH_RETRIES", raising=False)
+        monkeypatch.delenv("JARVIS_L2_DISPATCH_RETRIES_BACKGROUND", raising=False)
+        for route in ("immediate", "standard", "complex", "", None):
+            assert vr.resolve_l2_dispatch_budget(route) == 2
+
+    def test_background_and_speculative_get_single_dispatch(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_L2_DISPATCH_RETRIES", raising=False)
+        monkeypatch.delenv("JARVIS_L2_DISPATCH_RETRIES_BACKGROUND", raising=False)
+        for route in ("background", "speculative", "BACKGROUND", " speculative "):
+            assert vr.resolve_l2_dispatch_budget(route) == 1
+
+    def test_background_env_knob_raises_bg_budget(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_L2_DISPATCH_RETRIES", raising=False)
+        monkeypatch.setenv("JARVIS_L2_DISPATCH_RETRIES_BACKGROUND", "1")
+        assert vr.resolve_l2_dispatch_budget("background") == 2
+
+    def test_bg_budget_never_exceeds_global(self, monkeypatch):
+        # Operator caps the global at 0 retries: BG cannot exceed it even
+        # with a raised BG knob — strictest wins, same composing philosophy
+        # as risk_tier_floor.
+        monkeypatch.setenv("JARVIS_L2_DISPATCH_RETRIES", "0")
+        monkeypatch.setenv("JARVIS_L2_DISPATCH_RETRIES_BACKGROUND", "5")
+        assert vr.resolve_l2_dispatch_budget("background") == 1
+
+    def test_garbage_env_falls_back_to_defaults(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_L2_DISPATCH_RETRIES", "not-a-number")
+        monkeypatch.setenv("JARVIS_L2_DISPATCH_RETRIES_BACKGROUND", "nan!")
+        assert vr.resolve_l2_dispatch_budget("standard") == 2
+        assert vr.resolve_l2_dispatch_budget("background") == 1
+
+
+# ---------------------------------------------------------------------------
+# 2. is_sticky_soft_stop — no-progress detector
+# ---------------------------------------------------------------------------
+
+
+class TestIsStickySoftStop:
+    def test_identical_consecutive_reason_is_sticky(self):
+        assert vr.is_sticky_soft_stop(
+            "class_retries_exhausted:env", "class_retries_exhausted:env"
+        )
+
+    def test_different_reason_is_progress(self):
+        assert not vr.is_sticky_soft_stop(
+            "empty_candidates", "generate_error:TypeError"
+        )
+
+    def test_first_dispatch_has_no_prior(self):
+        assert not vr.is_sticky_soft_stop(None, "empty_candidates")
+        assert not vr.is_sticky_soft_stop("", "empty_candidates")
+
+
+# ---------------------------------------------------------------------------
+# 3. Spine pins — the wiring may not silently disappear
+# ---------------------------------------------------------------------------
+
+
+def test_spine_validate_runner_wires_sticky_breaker():
+    src = _VR.read_text(encoding="utf-8")
+    assert "is_sticky_soft_stop(" in src, (
+        "validate_runner no longer consults the sticky-reason breaker — "
+        "the 120/120-identical-reason storm class is live again"
+    )
+    assert "l2_sticky_soft_stop" in src, (
+        "validate_runner missing the l2_sticky_soft_stop terminal reason"
+    )
+
+
+def test_spine_validate_runner_wires_route_aware_budget():
+    src = _VR.read_text(encoding="utf-8")
+    assert "resolve_l2_dispatch_budget(" in src, (
+        "validate_runner computes the L2 dispatch budget inline again — "
+        "route-aware budgeting unwired"
+    )
+
+
+def test_spine_class_retries_exhausted_is_hard_stop():
+    """The taxonomy root cause: class_retries_exhausted IS an exhaustion.
+    It must sit in _l2_hook's HARD prefixes so the engine's own verdict
+    ('this failure class is out of retries') is honored instead of
+    re-dispatched."""
+    src = _ORCH.read_text(encoding="utf-8")
+    # The prefix must appear inside the hard-stop tuple.
+    tuple_start = src.find("_l2_hard_stop_prefixes = (")
+    assert tuple_start != -1, "hard-stop prefixes tuple missing from _l2_hook"
+    tuple_src = src[tuple_start : src.find(")", tuple_start)]
+    assert '"class_retries_exhausted"' in tuple_src, (
+        "class_retries_exhausted missing from _l2_hard_stop_prefixes — "
+        "a monotonic exhaustion is classified as transient and will be "
+        "futilely re-dispatched (the a1-brain-20260705-233225 storm)"
+    )
+    # And the engine really emits it (taxonomy lockstep, same as the
+    # existing Slice 6 spine test for the other four).
+    engine_src = _ENGINE.read_text(encoding="utf-8")
+    assert 'class_retries_exhausted' in engine_src

--- a/tests/governance/test_python_bin_resolution.py
+++ b/tests/governance/test_python_bin_resolution.py
@@ -1,0 +1,120 @@
+"""Interpreter-resolution spine — pytest spawns must NEVER use bare "python3".
+
+Root cause (run a1-brain-20260705-233225, GCP Brain node): TestWatcher's
+``run_pytest`` spawned ``argv=["python3", "-m", "pytest", ...]``. Under the
+systemd-run unit's minimal PATH, ``python3`` resolved to ``/usr/bin/python3``
+(no pytest) -> every run died at bootstrap with the 41-byte
+``/usr/bin/python3: No module named pytest`` -> ``parse_pytest_output`` found
+zero FAILED lines -> zero signals emitted -> the A1 blast=1 injection vector
+NEVER became an op. The organism was blind to test failures the entire
+session. Classic passes-local-fails-remote: the Mac's PATH python3 happens to
+carry pytest; the node's does not.
+
+Fix: ``resolve_python_bin()`` in the Slice-9 canonical pytest helper —
+``JARVIS_PYTHON_BIN`` env override wins (existing precedent:
+hybrid_teammate_executor / isolated_agent_worker), else ``sys.executable``
+(the running interpreter — structurally guaranteed to carry the organism's
+own test deps), bare "python3" only as a last resort for embedded/frozen
+interpreters where ``sys.executable`` is empty.
+
+Three A1-critical spawn sites are pinned here:
+  * intent/test_watcher.py  (TestFailure sensor detection)
+  * test_runner.py          (post-APPLY VERIFY)
+  * tool_executor.py        (Venom run_tests tool)
+"""
+from __future__ import annotations
+
+import asyncio
+import re
+import sys
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from backend.core.ouroboros.governance import test_subprocess_helper as tsh
+
+
+# ---------------------------------------------------------------------------
+# 1. resolve_python_bin() unit behavior
+# ---------------------------------------------------------------------------
+
+
+class TestResolvePythonBin:
+    def test_default_is_sys_executable(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_PYTHON_BIN", raising=False)
+        assert tsh.resolve_python_bin() == sys.executable
+
+    def test_env_override_wins(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_PYTHON_BIN", "/opt/custom/bin/python3")
+        assert tsh.resolve_python_bin() == "/opt/custom/bin/python3"
+
+    def test_blank_env_falls_through_to_sys_executable(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_PYTHON_BIN", "   ")
+        assert tsh.resolve_python_bin() == sys.executable
+
+    def test_empty_sys_executable_falls_back_to_python3(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_PYTHON_BIN", raising=False)
+        with mock.patch.object(tsh.sys, "executable", ""):
+            assert tsh.resolve_python_bin() == "python3"
+
+
+# ---------------------------------------------------------------------------
+# 2. TestWatcher.run_pytest spawns the RESOLVED interpreter
+# ---------------------------------------------------------------------------
+
+
+def test_test_watcher_run_pytest_uses_resolved_interpreter(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_PYTHON_BIN", raising=False)
+    from backend.core.ouroboros.governance.intent.test_watcher import TestWatcher
+
+    captured: dict = {}
+
+    async def _fake_run(argv, **kwargs):
+        captured["argv"] = list(argv)
+        result = mock.Mock()
+        result.timed_out = False
+        result.stdout = ""
+        result.returncode = 0
+        return result
+
+    monkeypatch.setattr(tsh, "run_pytest_subprocess", _fake_run)
+    w = TestWatcher(
+        repo="jarvis",
+        test_dir=str(tmp_path / "tests"),
+        repo_path=str(tmp_path),
+    )
+    asyncio.run(w.run_pytest())
+    assert captured["argv"][0] == sys.executable
+    assert captured["argv"][0] != "python3"
+    assert captured["argv"][1:3] == ["-m", "pytest"]
+
+
+# ---------------------------------------------------------------------------
+# 3. Source-level pin — the bug class may not reappear at the three
+#    A1-critical spawn sites. Bare "python3" adjacent to a pytest spawn is
+#    the exact 41-byte failure mode; new spawn sites must compose
+#    resolve_python_bin().
+# ---------------------------------------------------------------------------
+
+_GOV = Path(__file__).resolve().parents[2] / "backend" / "core" / "ouroboros" / "governance"
+
+_CRITICAL_MODULES = (
+    _GOV / "intent" / "test_watcher.py",
+    _GOV / "test_runner.py",
+    _GOV / "tool_executor.py",
+)
+
+# argv-list opening with the bare literal: ["python3", "-m", "pytest"
+_BARE_SPAWN_RE = re.compile(r"\[\s*\"python3\"\s*,\s*\"-m\"\s*,\s*\"pytest\"")
+
+
+@pytest.mark.parametrize("module_path", _CRITICAL_MODULES, ids=lambda p: p.name)
+def test_no_bare_python3_pytest_spawn(module_path):
+    source = module_path.read_text(encoding="utf-8")
+    hits = _BARE_SPAWN_RE.findall(source)
+    assert not hits, (
+        f"{module_path.name} spawns pytest via bare 'python3' — resolves "
+        "PATH-dependently (41-byte 'No module named pytest' on minimal-PATH "
+        "nodes). Use test_subprocess_helper.resolve_python_bin()."
+    )

--- a/tests/integration/test_a1_posture_seed.py
+++ b/tests/integration/test_a1_posture_seed.py
@@ -1,0 +1,153 @@
+"""A1 posture-context seeding — the organism natively understands its
+operating context.
+
+Run a1-brain-20260705-233225: 63 doc_staleness + 3 todo_scanner background
+signals swamped the loop during an A1 ignition rehearsal while the blast=1
+vector's lane sat idle. Rather than a hardcoded sensor-disable flag (a
+governance bypass), the driver seeds the EXISTING durable posture triplet
+(``.jarvis/posture_current.json``) with HARDEN before organism boot. The
+organism's own metacognitive stack then reshapes everything natively:
+
+  * SensorGovernor weighted caps — HARDEN starves discovery/consolidation
+    sensors (0.3-0.6x) and boosts TestFailure (1.8x) via the seed-spec
+    weight algebra (sensor_governor_seed.py);
+  * StrategicDirection / CONTEXT_EXPANSION posture prompt injection;
+  * L3 subagent_scheduler direct enforcement (Slice 5 Arc B).
+
+The seed is a *starting state*, not a lock: PostureObserver's own cadence +
+hysteresis may legitimately move off it if live signals demand — honest,
+dynamic, no authority bypass. Round-trips through the REAL PostureStore
+(fakes-mirror-real-contract).
+"""
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+import pytest
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+def _load_script(name: str):
+    path = _REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec and spec.loader, "Cannot load %s from %s" % (name, path)
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)  # type: ignore[union-attr]
+    return mod
+
+
+_driver_mod = _load_script("isomorphic_a1_local")
+_seed_posture_context = _driver_mod._seed_posture_context
+
+
+def _load_current(root: Path):
+    """Read back through the REAL store — the same code path the
+    organism's SensorGovernor + PostureObserver consume at boot."""
+    from backend.core.ouroboros.governance.posture_store import PostureStore
+
+    return PostureStore(root / ".jarvis").load_current()
+
+
+def test_seed_writes_harden_reading_real_store_roundtrip(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_A1_POSTURE_SEED", raising=False)
+    assert _seed_posture_context(str(tmp_path)) is True
+    reading = _load_current(tmp_path)
+    assert reading is not None, "seeded reading rejected by the real store"
+    assert reading.posture.value == "HARDEN"
+    # High-confidence starting state (>= the observer's 0.75 bypass tier).
+    assert reading.confidence >= 0.75
+
+
+def test_seed_env_selects_other_posture(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_POSTURE_SEED", "EXPLORE")
+    assert _seed_posture_context(str(tmp_path)) is True
+    reading = _load_current(tmp_path)
+    assert reading is not None
+    assert reading.posture.value == "EXPLORE"
+
+
+@pytest.mark.parametrize("off", ["", "0", "false", "off", "none", "OFF"])
+def test_seed_disabled_writes_nothing(tmp_path, monkeypatch, off):
+    monkeypatch.setenv("JARVIS_A1_POSTURE_SEED", off)
+    assert _seed_posture_context(str(tmp_path)) is False
+    assert not (tmp_path / ".jarvis" / "posture_current.json").exists()
+
+
+def test_seed_invalid_value_fails_soft(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_A1_POSTURE_SEED", "TURBO_MODE")
+    # Never raises, never writes garbage the organism would then trust.
+    assert _seed_posture_context(str(tmp_path)) is False
+    assert not (tmp_path / ".jarvis" / "posture_current.json").exists()
+
+
+def test_seed_never_clobbers_existing_reading(tmp_path, monkeypatch):
+    """A pre-existing posture state (resumed overlay, operator-set) is
+    NEVER overwritten — the seed is a cold-start default, not authority."""
+    monkeypatch.delenv("JARVIS_A1_POSTURE_SEED", raising=False)
+    assert _seed_posture_context(str(tmp_path)) is True
+    first = _load_current(tmp_path)
+    monkeypatch.setenv("JARVIS_A1_POSTURE_SEED", "EXPLORE")
+    assert _seed_posture_context(str(tmp_path)) is False
+    second = _load_current(tmp_path)
+    assert second is not None and second.posture == first.posture
+
+
+def test_spine_driver_seeds_inside_isomorphic_block():
+    """The seed call must live in the driver's IsomorphicEnv block —
+    before organism boot, against the overlay root."""
+    src = (_REPO_ROOT / "scripts" / "isomorphic_a1_local.py").read_text(
+        encoding="utf-8"
+    )
+    assert "_seed_posture_context(" in src.split("with IsomorphicEnv", 1)[1], (
+        "driver no longer seeds posture context inside the IsomorphicEnv "
+        "block — the organism boots context-blind and background sensors "
+        "swamp A1 rehearsals again"
+    )
+
+
+# ===========================================================================
+# Ignite forwarding — operator-explicit seed override reaches the node
+# ===========================================================================
+
+
+def _load_ignite():
+    return _load_script("ignite_a1_brain")
+
+
+def test_ignite_forwards_operator_posture_seed(monkeypatch):
+    ignite = _load_ignite()
+    monkeypatch.setenv("JARVIS_A1_POSTURE_SEED", "off")
+    cmd = ignite._compose_remote_command(
+        remote_run_dir="/opt/trinity/jarvis/a1_iso_runs/x", seed=0,
+        verbose=False, soak_wall_s=1800, dw_session_budget=5.0,
+    )
+    assert "JARVIS_A1_POSTURE_SEED=off " in cmd
+
+
+def test_ignite_omits_seed_when_unset(monkeypatch):
+    ignite = _load_ignite()
+    monkeypatch.delenv("JARVIS_A1_POSTURE_SEED", raising=False)
+    cmd = ignite._compose_remote_command(
+        remote_run_dir="/opt/trinity/jarvis/a1_iso_runs/x", seed=0,
+        verbose=False, soak_wall_s=1800, dw_session_budget=5.0,
+    )
+    # Default lives in the driver (HARDEN); ignite adds nothing.
+    assert "JARVIS_A1_POSTURE_SEED" not in cmd
+
+
+def test_ignite_drops_non_token_seed_value(monkeypatch):
+    """The remote cmd runs inside a single-quoted bash -c wrapper — a
+    non-token value must be dropped, never quoted-through (the run-8
+    inner-single-quote dispatch-hang class)."""
+    ignite = _load_ignite()
+    monkeypatch.setenv("JARVIS_A1_POSTURE_SEED", "HARDEN'; rm -rf /tmp; '")
+    cmd = ignite._compose_remote_command(
+        remote_run_dir="/opt/trinity/jarvis/a1_iso_runs/x", seed=0,
+        verbose=False, soak_wall_s=1800, dw_session_budget=5.0,
+    )
+    assert "JARVIS_A1_POSTURE_SEED" not in cmd
+    assert "rm -rf" not in cmd

--- a/tests/integration/test_isomorphic_a1_e2e.py
+++ b/tests/integration/test_isomorphic_a1_e2e.py
@@ -827,10 +827,18 @@ class TestSubprocessIsomorphismPropagation:
                 pass
 
         class _NoopEnv:
+            # Hermetic: honors the REAL IsomorphicEnv contract (disjoint
+            # cwd under tmp_path, restored on exit). The old no-chdir fake
+            # left cwd on the HOST repo -- the 2026-07-06 leak vector that
+            # let a cwd-anchored resolver chaos-inject production source.
             root = tmp_path
             def __enter__(self) -> "_NoopEnv":
+                self._prev_cwd = os.getcwd()
+                (tmp_path / "app").mkdir(parents=True, exist_ok=True)
+                os.chdir(tmp_path / "app")
                 return self
             def __exit__(self, *args: Any) -> bool:
+                os.chdir(self._prev_cwd)
                 return False
 
         class _CapturingChaos:
@@ -965,10 +973,18 @@ class TestSubprocessIsomorphismPropagation:
                 pass
 
         class _NoopEnv:
+            # Hermetic: honors the REAL IsomorphicEnv contract (disjoint
+            # cwd under tmp_path, restored on exit). The old no-chdir fake
+            # left cwd on the HOST repo -- the 2026-07-06 leak vector that
+            # let a cwd-anchored resolver chaos-inject production source.
             root = tmp_path
             def __enter__(self) -> "_NoopEnv":
+                self._prev_cwd = os.getcwd()
+                (tmp_path / "app").mkdir(parents=True, exist_ok=True)
+                os.chdir(tmp_path / "app")
                 return self
             def __exit__(self, *args: Any) -> bool:
+                os.chdir(self._prev_cwd)
                 return False
 
         class _CapturingChaos:
@@ -1047,10 +1063,18 @@ class TestSubprocessIsomorphismPropagation:
                 pass
 
         class _NoopEnv:
+            # Hermetic: honors the REAL IsomorphicEnv contract (disjoint
+            # cwd under tmp_path, restored on exit). The old no-chdir fake
+            # left cwd on the HOST repo -- the 2026-07-06 leak vector that
+            # let a cwd-anchored resolver chaos-inject production source.
             root = tmp_path
             def __enter__(self) -> "_NoopEnv":
+                self._prev_cwd = os.getcwd()
+                (tmp_path / "app").mkdir(parents=True, exist_ok=True)
+                os.chdir(tmp_path / "app")
                 return self
             def __exit__(self, *args: Any) -> bool:
+                os.chdir(self._prev_cwd)
                 return False
 
         class _CapturingChaos:
@@ -1160,10 +1184,18 @@ class TestSubprocessIsomorphismPropagation:
                 pass
 
         class _NoopEnv:
+            # Hermetic: honors the REAL IsomorphicEnv contract (disjoint
+            # cwd under tmp_path, restored on exit). The old no-chdir fake
+            # left cwd on the HOST repo -- the 2026-07-06 leak vector that
+            # let a cwd-anchored resolver chaos-inject production source.
             root = tmp_path
             def __enter__(self) -> "_NoopEnv":
+                self._prev_cwd = os.getcwd()
+                (tmp_path / "app").mkdir(parents=True, exist_ok=True)
+                os.chdir(tmp_path / "app")
                 return self
             def __exit__(self, *args: Any) -> bool:
+                os.chdir(self._prev_cwd)
                 return False
 
         class _CapturingChaos:
@@ -1247,10 +1279,18 @@ class TestSubprocessIsomorphismPropagation:
                 pass
 
         class _NoopEnv:
+            # Hermetic: honors the REAL IsomorphicEnv contract (disjoint
+            # cwd under tmp_path, restored on exit). The old no-chdir fake
+            # left cwd on the HOST repo -- the 2026-07-06 leak vector that
+            # let a cwd-anchored resolver chaos-inject production source.
             root = tmp_path
             def __enter__(self) -> "_NoopEnv":
+                self._prev_cwd = os.getcwd()
+                (tmp_path / "app").mkdir(parents=True, exist_ok=True)
+                os.chdir(tmp_path / "app")
                 return self
             def __exit__(self, *args: Any) -> bool:
+                os.chdir(self._prev_cwd)
                 return False
 
         class _CapturingChaos:
@@ -1765,12 +1805,24 @@ class TestAuditAtTeardownSequencing:
     ceiling (_a1_audit_ceiling_s) while the soak child was STILL RUNNING --
     stale FAILED verdicts, because the chain hadn't finished yet.
 
-    The fix: bind the audit invocation to the soak child's ACTUAL exit,
-    reusing the existing process-wait primitive (Popen.wait -- the SAME one
-    SoakRunner.stop()/_reap_soak_runners() already use in teardown), offloaded
-    via run_in_executor so it does not starve the co-located SyntheticAdversary
-    event loop. These tests prove: (1) the wait happens BEFORE the audit is
-    invoked, and (2) the completed-session audit runs in --replay mode.
+    The contract under test (updated for the wall-coordination rewrite,
+    bt-iso-1783144982): the audit fires ONLY after the soak-child
+    termination-wait (_await_soak_child_termination) completes -- never on
+    a fixed post-boot ceiling. These tests prove: (1) the termination-wait
+    happens BEFORE the audit is invoked, and (2) the completed-session
+    audit runs in --replay mode.
+
+    HERMETIC-ISOLATION NOTE (2026-07-06 leak postmortem): the original
+    scaffold was structurally un-passable AND unsafe -- (a) its fake proc's
+    only exit path was the pre-arm ceiling (floor 120s >= pytest.ini's
+    120s timeout, so pytest-timeout ALWAYS killed it first), and (b) its
+    _NoopEnv did not chdir, so any cwd-anchored repo-root fallback inside
+    the driver flow resolved to the REAL working tree -- a pytest run
+    mutated production source (leaf_predicates.py chaos-injected on the
+    host). Fixed structurally: _NoopEnv now honors the real IsomorphicEnv
+    contract (chdir into tmp_path, restore on exit) and the termination-
+    wait is an async spy that simulates the child's exit -- a unit test
+    mathematically cannot touch the host tree or the wall clock.
     """
 
     def _scaffold(self, tmp_path: Path, harness_mod: Any):
@@ -1790,10 +1842,18 @@ class TestAuditAtTeardownSequencing:
                 pass
 
         class _NoopEnv:
+            # Hermetic: honors the REAL IsomorphicEnv contract (disjoint
+            # cwd under tmp_path, restored on exit). The old no-chdir fake
+            # left cwd on the HOST repo -- the 2026-07-06 leak vector that
+            # let a cwd-anchored resolver chaos-inject production source.
             root = tmp_path
             def __enter__(self) -> "_NoopEnv":
+                self._prev_cwd = os.getcwd()
+                (tmp_path / "app").mkdir(parents=True, exist_ok=True)
+                os.chdir(tmp_path / "app")
                 return self
             def __exit__(self, *args: Any) -> bool:
+                os.chdir(self._prev_cwd)
                 return False
 
         class _CapturingChaos:
@@ -1850,6 +1910,19 @@ class TestAuditAtTeardownSequencing:
         async def _fake_await_soak_boot(proc: Any, log: str, timeout_s: float = 90.0) -> bool:
             return True
 
+        async def _spy_await_soak_child_termination(
+            soak_proc: Any, dbg_log: str, launch_monotonic: Any,
+        ) -> str:
+            # Simulates the child's clean self-termination: records the
+            # ordering event and stamps the exit code the way a real
+            # Popen.wait would. Removes the old scaffold's wall-clock
+            # dependence (fake proc's only real exit path was the >=120s
+            # pre-arm ceiling -- structurally unreachable under
+            # pytest.ini's 120s timeout).
+            call_order.append("term.wait")
+            soak_proc.returncode = 0
+            return "exited"
+
         driver = IsomorphicA1Driver(
             repo_root=str(tmp_path),
             stub_soak=False,
@@ -1869,27 +1942,39 @@ class TestAuditAtTeardownSequencing:
             patch.object(harness_mod, "SoakRunner", _FakeSoakRunner),
             patch.object(harness_mod, "AuditorRunner", _SpyAuditorRunner),
             patch.object(_driver_mod, "_await_soak_boot", _fake_await_soak_boot),
+            patch.object(
+                _driver_mod,
+                "_await_soak_child_termination",
+                _spy_await_soak_child_termination,
+            ),
         ]
         return driver, patches, call_order, _captured_auditor_kwargs, fake_proc
 
     async def test_soak_proc_wait_happens_before_audit_invocation(
         self, tmp_path: Path,
     ) -> None:
-        """Popen.wait() must be called BEFORE AuditorRunner.watch() -- the
-        audit must never fire while the soak child could still be running."""
+        """The termination-wait (_await_soak_child_termination) must
+        complete BEFORE AuditorRunner.watch() -- the audit must never fire
+        while the soak child could still be running. (Contract updated
+        from the stale 'Popen.wait' assertion: the wall-coordination
+        rewrite replaced the direct wait with the adaptive
+        deadline-coordinated wait.)"""
         harness_mod = _load_script("a1_live_fire_chaos_harness")
-        driver, patches, call_order, _auditor_kwargs, _proc = self._scaffold(
+        driver, patches, call_order, _auditor_kwargs, proc = self._scaffold(
             tmp_path, harness_mod,
         )
-        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
             rc = await driver.run()
 
-        assert "proc.wait" in call_order, "soak-child wait must have been invoked"
+        assert "term.wait" in call_order, (
+            "soak-child termination-wait must have been invoked"
+        )
         assert "auditor.watch" in call_order, "the auditor must still run"
-        assert call_order.index("proc.wait") < call_order.index("auditor.watch"), (
+        assert call_order.index("term.wait") < call_order.index("auditor.watch"), (
             "audit must be invoked AFTER the soak child exits, not on a fixed "
             "post-boot ceiling; got order=%r" % (call_order,)
         )
+        assert proc.returncode == 0, "child exit must be observed pre-audit"
         assert rc == 0
 
     async def test_audit_invoked_in_replay_mode_after_completion(
@@ -1902,7 +1987,7 @@ class TestAuditAtTeardownSequencing:
         driver, patches, _call_order, auditor_kwargs, _proc = self._scaffold(
             tmp_path, harness_mod,
         )
-        with patches[0], patches[1], patches[2], patches[3], patches[4]:
+        with patches[0], patches[1], patches[2], patches[3], patches[4], patches[5]:
             await driver.run()
 
         assert auditor_kwargs, "AuditorRunner must have been constructed"

--- a/tests/scripts/test_a1_graduation_auditor.py
+++ b/tests/scripts/test_a1_graduation_auditor.py
@@ -438,7 +438,11 @@ def test_run_watch_proven_via_injected_log(tmp_path):
             a.ingest_log_line("[SemanticGuard] findings=0")
             a.ingest_event("tool_exploration_start", {})
             a.ingest_event("decision_recorded", {})
-            a.ingest_event("operation_terminal", {"state": "applied"})
+            # op_id mirrors the real publisher contract —
+            # publish_operation_terminal refuses to publish without one.
+            a.ingest_event(
+                "operation_terminal", {"op_id": "op-watch", "state": "applied"}
+            )
             a.ingest_event("review_branch_created", {})
 
         writer = asyncio.ensure_future(_writer())
@@ -478,3 +482,122 @@ def test_run_watch_intervention_trips_and_fails(tmp_path):
     assert verdict.proven is False
     assert verdict.criteria["intervention_lock_clean"] is False
     assert "intervention_lock" in verdict.failure_locus
+
+
+# ===========================================================================
+# 10. Autonomous-mutation gate — noop/read-only completions MUST NOT satisfy
+#     fsm_classify_to_applied (run a1-brain-20260705-233225 false-positive:
+#     two is_noop=True read_only_complete ops flipped the criterion true
+#     with zero bytes written). written=True AND is_noop=False are absolute
+#     prerequisites for a PASS. Log lines below are byte-shaped on the real
+#     orchestrator output from that run's black-box bundle.
+# ===========================================================================
+
+
+def _feed_hops_and_classify(a, op="op-noop1"):
+    for hop in aud.A1TRACE_HOPS:
+        a.ingest_log_line(f"WARNING [A1Trace] {hop} goal=GOAL-N op={op}")
+    a.ingest_event("fsm_phase_changed", {"phase": "CLASSIFY", "op_id": op})
+    a.ingest_event("fsm_phase_changed", {"phase": "GENERATE", "op_id": op})
+
+
+def test_noop_read_only_applied_fails_mutation_gate():
+    """The exact live false-positive: noop skip-APPLY + LEDGER_TERMINAL
+    state=applied written=True for the SAME op -> criterion must be False."""
+    a = _make_auditor(strict=False)
+    _feed_hops_and_classify(a, op="op-noop1")
+    a.ingest_log_line(
+        "2026-07-06T06:35:20 [Ouroboros.Orchestrator] INFO [Orchestrator] "
+        "op=op-noop1 is_noop=True (provider=doubleword) "
+        "terminal_reason_code=read_only_complete — skipping APPLY"
+    )
+    a.ingest_log_line(
+        "2026-07-06T06:35:21 [Ouroboros.Orchestrator] INFO [Slice74Probe] "
+        "LEDGER_TERMINAL op_id=op-noop1 state=applied written=True"
+    )
+    v = a.verdict()
+    assert v.criteria["fsm_classify_to_applied"] is False
+    assert v.proven is False
+    assert "fsm" in v.failure_locus
+
+
+def test_ledger_terminal_written_false_fails_mutation_gate():
+    """state=applied with written=False is a deduped/phantom write -- not
+    mutation proof."""
+    a = _make_auditor(strict=False)
+    _feed_hops_and_classify(a, op="op-w0")
+    a.ingest_event("fsm_phase_changed", {"phase": "APPLY", "op_id": "op-w0"})
+    a.ingest_log_line(
+        "[Slice74Probe] LEDGER_TERMINAL op_id=op-w0 state=applied written=False"
+    )
+    v = a.verdict()
+    assert v.criteria["fsm_classify_to_applied"] is False
+
+
+def test_real_mutation_ledger_terminal_passes_log_only():
+    """A genuine APPLY phase + applied terminal written=True from a non-noop
+    op still passes (log-only path, no SSE)."""
+    a = _make_auditor(strict=False)
+    _feed_hops_and_classify(a, op="op-real")
+    a.ingest_event("fsm_phase_changed", {"phase": "APPLY", "op_id": "op-real"})
+    a.ingest_log_line(
+        "[Slice74Probe] LEDGER_TERMINAL op_id=op-real state=applied written=True"
+    )
+    v = a.verdict()
+    assert v.criteria["fsm_classify_to_applied"] is True
+
+
+def test_sse_applied_with_noop_reason_fails_mutation_gate():
+    """SSE operation_terminal carrying terminal_reason_code=read_only_complete
+    is a no-op completion, never mutation proof."""
+    a = _make_auditor(strict=False)
+    _feed_hops_and_classify(a, op="op-sse-noop")
+    a.ingest_event("fsm_phase_changed", {"phase": "APPLY", "op_id": "op-sse-noop"})
+    a.ingest_event(
+        "operation_terminal",
+        {
+            "op_id": "op-sse-noop",
+            "state": "applied",
+            "phase": "COMPLETE",
+            "terminal_reason_code": "read_only_complete",
+        },
+    )
+    v = a.verdict()
+    assert v.criteria["fsm_classify_to_applied"] is False
+
+
+def test_mixed_noop_and_real_mutation_passes():
+    """A noop completion alongside a genuine mutation: the real op carries
+    the gate."""
+    a = _make_auditor(strict=False)
+    _feed_hops_and_classify(a, op="op-mix")
+    a.ingest_log_line(
+        "[Orchestrator] op=op-mix-noop is_noop=True (provider=doubleword) "
+        "terminal_reason_code=read_only_complete — skipping APPLY"
+    )
+    a.ingest_log_line(
+        "[Slice74Probe] LEDGER_TERMINAL op_id=op-mix-noop state=applied written=True"
+    )
+    a.ingest_event("fsm_phase_changed", {"phase": "APPLY", "op_id": "op-mix"})
+    a.ingest_log_line(
+        "[Slice74Probe] LEDGER_TERMINAL op_id=op-mix state=applied written=True"
+    )
+    v = a.verdict()
+    assert v.criteria["fsm_classify_to_applied"] is True
+
+
+def test_noop_only_failure_locus_names_noop_class():
+    """When the ONLY applied evidence is noop read-only completions, the
+    failure locus must say so (diagnosable, not generic)."""
+    a = _make_auditor(strict=False)
+    _feed_hops_and_classify(a, op="op-noop2")
+    a.ingest_log_line(
+        "[Orchestrator] op=op-noop2 is_noop=True (provider=doubleword) "
+        "terminal_reason_code=read_only_complete — skipping APPLY"
+    )
+    a.ingest_log_line(
+        "[Slice74Probe] LEDGER_TERMINAL op_id=op-noop2 state=applied written=True"
+    )
+    v = a.verdict()
+    assert v.criteria["fsm_classify_to_applied"] is False
+    assert "noop" in v.failure_locus or "read_only" in v.failure_locus

--- a/tests/scripts/test_a1_lineage_stitching.py
+++ b/tests/scripts/test_a1_lineage_stitching.py
@@ -152,8 +152,14 @@ def test_stitching_makes_fsm_classify_to_applied_provable(tmp_path):
             "[A1Trace] dequeue goal=op-RESUME-1",
             "[A1Trace] submit goal=op-RESUME-1",
             "[A1Trace] accept goal=op-RESUME-1 phase=CLASSIFY",
-            "op=op-RESUME-1 is_noop=True (provider=doubleword) "
-            "terminal_reason_code=read_only_complete — skipping APPLY",
+            # Genuine mutation evidence (mutation-gate tightening,
+            # run a1-brain-20260705-233225): a real APPLY phase heartbeat +
+            # a written, NON-noop applied terminal. The old shape here (an
+            # is_noop=True read_only_complete skip-APPLY) is now correctly
+            # rejected by the gate — noop coverage lives in
+            # test_a1_graduation_auditor.py section 10.
+            "[CommProtocol] HEARTBEAT op=op-RESUME-1 seq=3 "
+            "payload={'phase': 'APPLY'}",
             "[Slice74Probe] LEDGER_TERMINAL op_id=op-RESUME-1 state=applied "
             "written=True",
         ],

--- a/tests/scripts/test_ignite_a1_brain.py
+++ b/tests/scripts/test_ignite_a1_brain.py
@@ -344,7 +344,7 @@ def test_dry_run_via_main_never_calls_asyncio_run(monkeypatch, capsys):
 def test_remote_command_contains_piece_b_and_c_config():
     remote_cmd = ignite._compose_remote_command(
         remote_run_dir="/opt/trinity/jarvis/a1_iso_runs/x", seed=0, verbose=True,
-        soak_wall_s=1800)
+        soak_wall_s=1800, dw_session_budget=5.0)
 
     assert "JARVIS_CHAOS_TARGET_DIRS=backend/core/ouroboros/a1_ignition_vector" in remote_cmd
     assert "autonomy.*" in remote_cmd
@@ -362,10 +362,40 @@ def test_plan_remote_cmd_matches_composer():
     plan = ignition.build_plan()
     expected = ignite._compose_remote_command(
         remote_run_dir=ignition.remote_run_dir, seed=ignition.seed, verbose=ignition.verbose,
-        soak_wall_s=ignition.soak_wall_s)
+        soak_wall_s=ignition.soak_wall_s, dw_session_budget=ignition.dw_session_budget)
     assert plan.remote_cmd == expected
     assert "autonomy.*" in plan.remote_cmd
     assert "backend/core/ouroboros/a1_ignition_vector" in plan.remote_cmd
+
+
+def test_remote_command_opts_into_dw_rehearsal_budget_by_default():
+    """The A1 Brain ignition drill EXISTS to prove the APPLIED threshold, so it
+    must pass a NONZERO --dw-session-budget to the on-node isomorphic soak.
+
+    Root cause (live-fire a1-brain-20260705-221612): isomorphic_a1_local defaults
+    --dw-session-budget to 0.0 (the failover "starve" scenario). With a $0 cap the
+    SessionBudgetAuthority preflight refuses every DW dispatch (est $0.10 > $0.00),
+    so GENERATE never produces a candidate and no op reaches APPLY (209 CLASSIFY /
+    106 GENERATE / 0 VALIDATE / 0 APPLIED). The on-node DW is the free
+    SyntheticAdversary stub, so a nonzero cap opts into the sanctioned rehearsal
+    lane at ~$0 real cost."""
+    ignition = _make_ignition(dry_run=True, project="p", zone="z")
+    plan = ignition.build_plan()
+    assert ignition.dw_session_budget > 0.0, "the drill must fund the DW rehearsal lane"
+    assert "--dw-session-budget %g" % ignition.dw_session_budget in plan.remote_cmd
+
+
+def test_dw_session_budget_env_override(monkeypatch):
+    """JARVIS_A1_BRAIN_DW_SESSION_BUDGET overrides the default -- incl. 0 to
+    restore the legacy starve scenario (no hardcoding)."""
+    monkeypatch.setenv("JARVIS_A1_BRAIN_DW_SESSION_BUDGET", "0")
+    starve = _make_ignition(dry_run=True, project="p", zone="z")
+    assert starve.dw_session_budget == 0.0
+    assert "--dw-session-budget 0 " in starve.build_plan().remote_cmd
+    monkeypatch.setenv("JARVIS_A1_BRAIN_DW_SESSION_BUDGET", "12.5")
+    funded = _make_ignition(dry_run=True, project="p", zone="z")
+    assert funded.dw_session_budget == 12.5
+    assert "--dw-session-budget 12.5 " in funded.build_plan().remote_cmd
 
 
 # ===========================================================================

--- a/tests/scripts/test_ignite_a1_soak.py
+++ b/tests/scripts/test_ignite_a1_soak.py
@@ -244,7 +244,9 @@ class TestLiveFailoverHelpers:
         assert env["JARVIS_FAILOVER_QUALITY_TIER_ENABLED"] == "true"
         assert env["JARVIS_FAILOVER_VIOLENT_TEARDOWN_ENABLED"] == "true"
         assert env["JARVIS_FAILOVER_QUALITY_IMAGE"] == "jarvis-prime-coder-32b"
-        assert env["JARVIS_FAILOVER_QUALITY_MACHINE"] == "g2-standard-4"
+        # g2-standard-8: deliberate host bump (6c46126e0c, RAM Pre-Flight
+        # Gate) — this assertion tracks the script's authoritative value.
+        assert env["JARVIS_FAILOVER_QUALITY_MACHINE"] == "g2-standard-8"
 
     def test_live_failover_argv_contains_enable_failover(self, tmp_path):
         """_build_soak_argv appends --enable-failover when live_failover=True."""


### PR DESCRIPTION
## Summary

Four root causes from A1 Brain run `a1-brain-20260705-233225` (first VALIDATE-reaching run, verdict retracted as auditor false positive), plus hermetic test isolation after a pytest run was found mutating the host tree.

1. **Vector death at sensor** (`07fe0a6366`): TestWatcher spawned bare `python3` → `/usr/bin/python3` (no pytest) under systemd-run's minimal PATH → 41-byte bootstrap error → zero FAILED lines → the blast=1 vector never became an op. Fix: `resolve_python_bin()` (`JARVIS_PYTHON_BIN` → `sys.executable`) in the Slice-9 canonical helper, adopted at sensor/VERIFY/Venom spawn sites + source-level pin.
2. **Auditor false positive** (`becfd0e882`): `read_only_complete` no-ops satisfied `fsm_classify_to_applied`. Now `written=True ∧ is_noop=False` are absolute prerequisites, op-scoped on both ingest paths. Criteria tightened, never lowered.
3. **VALIDATE_RETRY storm** (`3b1fce1f66`): 120/120 L2 re-dispatches on the identical sticky reason `class_retries_exhausted:env`. Fixes: exhaustion joins the HARD taxonomy; generic sticky-reason breaker; route-aware dispatch budget (BG/SPEC single-dispatch, strictest-wins).
4. **Context-blind boot** (`ae50411c83`): driver seeds HARDEN into the overlay's durable posture triplet via the real `PostureStore` — SensorGovernor weights, prompt injection, and L3 enforcement consume it natively. No sensor-disable flags. Also makes `_await_soak_boot` async (its e2e spine test was red on main — sync poll starved the adversary's aiohttp server during organism preflight).
5. **Hermetic scaffolds** (`1f16839d2a`): `TestAuditAtTeardownSequencing` was structurally un-passable (fake-proc exit floor ≥ pytest timeout) and leaked real chaos into the host tree (no-chdir `_NoopEnv`). All 6 fakes now honor the real IsomorphicEnv contract; termination-wait spied; stale `g2-standard-4` assertion tracks the deliberate `-8` bump.
6. `.codex/` gitignored (`83137ce809`) — untracked local tool config holds credentials; zero git history verified.

## Test plan
- 188 passed, 0 deselected across ignite/soak/driver-e2e/posture-seed/auditor/python-bin/L2-breaker suites
- Host-tree sentinel verified untouched post-sweep
- Next: re-ignite A1 Brain on GCP (node boot-syncs origin/main) → watch vector emit → VALIDATE>0 on the vector lane → APPLIED 6/6 under the tightened gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes A1 Brain run regressions: reliable pytest execution, honest mutation gate, L2 retry storm breaker, and posture‑aware boot. Also funds the DW rehearsal path and hardens test scaffolds.

- **New Features**
  - Seeds posture context via the real `PostureStore` before boot (`JARVIS_A1_POSTURE_SEED`, default `HARDEN`); ignite forwards operator overrides.
  - Funds on‑node rehearsal by passing `--dw-session-budget` from `ignite_a1_brain` (`JARVIS_A1_BRAIN_DW_SESSION_BUDGET`, default `5.0`).
  - Git‑ignore `.codex/` to prevent committing local tool configs.

- **Bug Fixes**
  - Pytest spawns resolve the interpreter via `resolve_python_bin()` (`JARVIS_PYTHON_BIN` → `sys.executable`) in TestWatcher, TestRunner, and ToolExecutor.
  - Auditor mutation gate now requires `written=True` and non‑noop; `read_only_complete` no‑ops never satisfy `fsm_classify_to_applied` and are labeled separately.
  - L2 storm breaker: classifies `class_retries_exhausted` as HARD; cancels on sticky identical soft‑stop reasons (`l2_sticky_soft_stop:<reason>`); adds route‑aware L2 dispatch budgets (`JARVIS_L2_DISPATCH_RETRIES*`, BG/SPEC default single dispatch).
  - `_await_soak_boot` is async to avoid starving the adversary’s server during preflight.
  - Hermetic test scaffolds: IsomorphicEnv fakes chdir and restore CWD; termination‑wait is spied (no wall‑clock dependence); failover machine assert updated to `g2-standard-8`.

<sup>Written for commit 1f16839d2aed4e87f09a7f01709901c0d90985f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69866?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

