### PR TITLE
fix(a1-diag): adversary logger is _log not logger

### DIFF
--- a/scripts/synthetic_adversary.py
+++ b/scripts/synthetic_adversary.py
@@ -1680,7 +1680,7 @@ class SyntheticAdversary:
                 if "## TOOLS" in _dc_str or "2b.2-tool" in _dc_str or "schema_version" in _dc_str:
                     _diag_prompt_has_venom_tools = True
                     break
-            logger.warning(
+            _log.warning(
                 "[A1-DIAG-ADV-TOOL-SEAM] has_tools=%s "
                 "prompt_has_venom_tools=%s body_keys=%s "
                 "msg_count=%d tool_choice=%s",


### PR DESCRIPTION
Live-fire NameError crash fix. Single character: `logger.warning` → `_log.warning` in the A1-DIAG instrumentation block. Module uses `_log = logging.getLogger(__name__)` (L142).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a NameError crash in A1-DIAG adversary instrumentation by using `_log.warning` instead of `logger.warning` in `synthetic_adversary.py`. Aligns with `_log = logging.getLogger(__name__)` and prevents crashes during tool-seam diagnostics.

<sup>Written for commit aa7432621302bb16ffcb5e3c7ba2e66e1cc38cd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

