### PR TITLE
feat(a1-diag): preemption-proof dispatch-level H3 diagnostic + stderr flush

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -2901,6 +2901,36 @@ class DoublewordProvider:
         if not _slice36_force_batch and self._s189_storm_forces_batch(context):
             _slice36_force_batch = True
 
+        # A1-DIAG: dispatch-level topology diagnostic (env-gated, preemption-proof).
+        # Captures the RT vs batch branch decision BEFORE it executes, so a SPOT
+        # preemption cannot lose the decisive H3a/H3b/H3c signal. Writes to stderr
+        # with immediate flush — the monitor's SSH stream captures it in real time.
+        if os.environ.get("JARVIS_A1_DIAG_TOOL_SEAM", "").strip().lower() in (
+            "1", "true", "yes", "on",
+        ):
+            _diag_dispatch_path = (
+                "BATCH(force)" if _slice36_force_batch
+                else "RT" if self._realtime_enabled
+                else "BATCH(rt_disabled)"
+            )
+            _diag_msg = (
+                "[A1-DIAG-DISPATCH] op=%s route=%s complexity=%s "
+                "force_batch=%s rt_enabled=%s tool_loop_present=%s "
+                "dispatch_path=%s repair_context=%s"
+                % (
+                    (getattr(context, "op_id", "?") or "?")[:24],
+                    getattr(context, "provider_route", "?"),
+                    getattr(context, "task_complexity", "?"),
+                    _slice36_force_batch, self._realtime_enabled,
+                    self._tool_loop is not None,
+                    _diag_dispatch_path,
+                    repair_context is not None,
+                )
+            )
+            logger.warning(_diag_msg)
+            import sys as _diag_sys
+            print(_diag_msg, file=_diag_sys.stderr, flush=True)
+
         # Real-time mode: /v1/chat/completions with SSE streaming + Venom tool loop
         # On 429/503, fall back to batch within DW (stay cheap) instead of
         # cascading to the 150x more expensive Claude fallback.
@@ -3575,19 +3605,24 @@ class DoublewordProvider:
         if os.environ.get("JARVIS_A1_DIAG_TOOL_SEAM", "").strip().lower() in (
             "1", "true", "yes", "on",
         ):
-            logger.warning(
+            _diag_rt_msg = (
                 "[A1-DIAG-TOOL-SEAM] op=%s route=%s complexity=%s "
                 "is_read_only=%s _will_skip_tools=%s _tools_available=%s "
                 "tool_loop_present=%s _s226_gate_demands=%s "
-                "native_tool_forcing=%s",
-                (getattr(context, "op_id", "?") or "?")[:24],
-                _route, _complexity,
-                getattr(context, "is_read_only", "?"),
-                _will_skip_tools, _tools_available,
-                self._tool_loop is not None,
-                _s226_gate_demands(str(_complexity)),
-                _dw_native_tool_forcing_enabled(),
+                "native_tool_forcing=%s"
+                % (
+                    (getattr(context, "op_id", "?") or "?")[:24],
+                    _route, _complexity,
+                    getattr(context, "is_read_only", "?"),
+                    _will_skip_tools, _tools_available,
+                    self._tool_loop is not None,
+                    _s226_gate_demands(str(_complexity)),
+                    _dw_native_tool_forcing_enabled(),
+                )
             )
+            logger.warning(_diag_rt_msg)
+            import sys as _diag_sys
+            print(_diag_rt_msg, file=_diag_sys.stderr, flush=True)
         _preloaded_files: List[str] = []
         # DW prompt caching (Slice-131 split): when the master flag is on, divert
         # the STABLE tool catalog + output schema into this sink so ONLY they are

--- a/scripts/synthetic_adversary.py
+++ b/scripts/synthetic_adversary.py
@@ -1680,15 +1680,20 @@ class SyntheticAdversary:
                 if "## TOOLS" in _dc_str or "2b.2-tool" in _dc_str or "schema_version" in _dc_str:
                     _diag_prompt_has_venom_tools = True
                     break
-            _log.warning(
+            _diag_adv_msg = (
                 "[A1-DIAG-ADV-TOOL-SEAM] has_tools=%s "
                 "prompt_has_venom_tools=%s body_keys=%s "
-                "msg_count=%d tool_choice=%s",
-                has_tools, _diag_prompt_has_venom_tools,
-                sorted(body.keys()),
-                len(messages),
-                body.get("tool_choice", "<absent>"),
+                "msg_count=%d tool_choice=%s"
+                % (
+                    has_tools, _diag_prompt_has_venom_tools,
+                    sorted(body.keys()),
+                    len(messages),
+                    body.get("tool_choice", "<absent>"),
+                )
             )
+            _log.warning(_diag_adv_msg)
+            import sys as _diag_sys
+            print(_diag_adv_msg, file=_diag_sys.stderr, flush=True)
         _manifest = _load_chaos_manifest()
         manifest_present = _manifest is not None
 


### PR DESCRIPTION
Mandate 4 (bulletproof): All diagnostics now flush to stderr immediately for preemption-proof capture. New [A1-DIAG-DISPATCH] at the RT/batch branch point captures force_batch, rt_enabled, tool_loop_present, dispatch_path — discriminates H3a/H3b/H3c before the branch executes. 84/84 tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a preemption-proof dispatch diagnostic and flush diagnostics to stderr for real-time capture. Prevents loss of H3 routing signals on preemption.

- **New Features**
  - Added [A1-DIAG-DISPATCH] in `_dispatch_internal` to record the RT vs batch decision before branching. Captures `force_batch`, `rt_enabled`, `tool_loop_present`, `dispatch_path`, and `repair_context` (discriminates H3a/H3b/H3c).
  - All A1 diagnostics now also `print(..., file=stderr, flush=True)` alongside `logger.warning()`, gated by `JARVIS_A1_DIAG_TOOL_SEAM`. Stateless; tests unchanged.

<sup>Written for commit 97ee70398bd8ff6e2dd6271b1b7eafca9a27fc8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69885?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

