### PR TITLE
fix(a1): detect prompt-embedded Venom tool catalogs in adversary has_tools

### DIFF
--- a/scripts/synthetic_adversary.py
+++ b/scripts/synthetic_adversary.py
@@ -1666,6 +1666,19 @@ class SyntheticAdversary:
 
         # Early diagnostic fields for logging
         has_tools = bool(body.get("tools"))
+        # H2 structural fix: the Venom tool loop embeds the tool catalog in
+        # the prompt text (DW-proprietary 2b.2-tool schema) on the final
+        # generation round — body["tools"] is only populated during explicit
+        # tool-loop rounds where tool_choice=required. Detect prompt-embedded
+        # tools so has_tools accurately reflects the payload state regardless
+        # of which Venom round this request represents.
+        if not has_tools:
+            for _msg in messages:
+                _c = _msg.get("content", "")
+                _cs = _c if isinstance(_c, str) else str(_c)
+                if "## TOOLS" in _cs or "2b.2-tool" in _cs:
+                    has_tools = True
+                    break
         # A1-DIAG: stateless wire-side tool-coercion telemetry.
         # Detects the prompt-embedded Venom tool catalog (the DW-proprietary
         # 2b.2-tool format) independently of body["tools"] (the OpenAI-compat


### PR DESCRIPTION
## H2 Structural Fix — A1 APPLIED Milestone Blocker

**Root cause** (302 telemetry samples, 2 GCP Brain runs): Venom tool loop final generation drops `body['tools']`. Adversary checks only `body.get('tools')` → `False` → serves direct candidate → Iron Gate rejects `exploration_insufficient: 0/1`.

**Fix**: After `has_tools = bool(body.get('tools'))`, scan message content for prompt-embedded Venom markers (`## TOOLS`, `2b.2-tool`). 7 lines, same markers proven by diagnostic telemetry.

84/84 tests green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Detects Venom tool catalogs embedded in prompt text so the adversary correctly sets has_tools even when body.tools is missing. Prevents serving direct candidates and avoids Iron Gate exploration_insufficient rejects in A1 H2 flows.

- **Bug Fixes**
  - Scan message content for Venom markers ("## TOOLS", "2b.2-tool") and set has_tools to true when found.
  - Change limited to scripts/synthetic_adversary.py (13 LOC); all tests pass.

<sup>Written for commit d032a2cffa93e6ace077d2f8a69a3ea550cbe7a6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

