### PR TITLE
fix(a1): add schema_version to has_tools prompt detection markers

### DIFF
--- a/scripts/synthetic_adversary.py
+++ b/scripts/synthetic_adversary.py
@@ -1676,7 +1676,7 @@ class SyntheticAdversary:
             for _msg in messages:
                 _c = _msg.get("content", "")
                 _cs = _c if isinstance(_c, str) else str(_c)
-                if "## TOOLS" in _cs or "2b.2-tool" in _cs:
+                if "## TOOLS" in _cs or "2b.2-tool" in _cs or "schema_version" in _cs:
                     has_tools = True
                     break
         # A1-DIAG: stateless wire-side tool-coercion telemetry.


### PR DESCRIPTION
Live-fire showed fix marker set incomplete — `schema_version` missing. Now matches diagnostic marker set exactly. 84/84 green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix has_tools prompt detection by also checking for 'schema_version', matching the diagnostic markers and correctly recognizing Venom schema blocks to prevent false negatives.

<sup>Written for commit 936077f12e1a70f9373878794470b139e196b211. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69887?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

