### PR TITLE
feat(a1): GCS verdict transport — decouple verdict from IAP tunnel

### DIFF
--- a/scripts/ignite_a1_brain.py
+++ b/scripts/ignite_a1_brain.py
@@ -163,6 +163,7 @@ _A1_VERDICT_ARCNAME = "a1_verdict.json"
 # doesn't lose all verdict visibility. Default-on (fail-soft over silence);
 # set to false to make IapBlackBoxTransport the ONLY verdict source, full stop.
 _ENV_VERDICT_SSH_FALLBACK_ENABLED = "JARVIS_A1_BRAIN_VERDICT_SSH_FALLBACK_ENABLED"
+_ENV_GCS_TELEMETRY_TARGET = "JARVIS_A1_GCS_TELEMETRY_TARGET"
 
 
 def _log(msg: str) -> None:
@@ -1332,6 +1333,67 @@ class A1BrainIgnition:
             _log("[BlackBox] WARN verdict JSON parse error: %r" % (exc,))
             return None
 
+    def _pull_verdict_from_gcs(self) -> Optional[Dict[str, Any]]:
+        """TIER 1.5: pull ``a1_verdict.json`` from GCS (IAP-decoupled).
+
+        Reads the ``JARVIS_A1_GCS_TELEMETRY_TARGET`` env-var for the
+        ``gs://bucket/prefix`` target.  The blob path is
+        ``<prefix>/<run_id>/a1_verdict.json`` -- the same layout that the
+        telemetry sidecar uses for uploads.
+
+        This is a **synchronous** helper (blocking I/O) intended to be called
+        via ``loop.run_in_executor``.  It is fully fail-soft: any exception
+        is logged and swallowed; returns ``None`` on failure."""
+        target = os.environ.get(_ENV_GCS_TELEMETRY_TARGET, "").strip()
+        if not target:
+            return None
+        try:
+            # -- lazy imports: neither the SDK nor the URI parser are
+            # needed unless GCS telemetry is actually configured. --
+            from google.cloud import storage as gcs_storage  # type: ignore[import-untyped]
+            from backend.core.ouroboros.governance.state_persistence_daemon import (
+                _parse_gs_uri,
+            )
+
+            parsed = _parse_gs_uri(target)
+            if parsed is None:
+                _log("[GcsVerdict] WARN env %s is not a valid gs:// URI: %s"
+                     % (_ENV_GCS_TELEMETRY_TARGET, target))
+                return None
+            bucket_name, prefix = parsed
+            run_id = "a1-brain-%s" % (self.node_name,)
+            blob_path = "%s/%s/%s" % (prefix, run_id, _A1_VERDICT_ARCNAME) if prefix else \
+                        "%s/%s" % (run_id, _A1_VERDICT_ARCNAME)
+
+            # 30 s hard deadline: guard against an unexpectedly slow GCS
+            # round-trip (DNS, metadata-server ADC refresh, etc.).
+            deadline = time.monotonic() + 30
+
+            client = gcs_storage.Client()
+            bucket = client.bucket(bucket_name)
+            blob = bucket.blob(blob_path)
+            if not blob.exists():
+                _log("[GcsVerdict] blob gs://%s/%s does not exist"
+                     % (bucket_name, blob_path))
+                return None
+
+            if time.monotonic() > deadline:
+                _log("[GcsVerdict] WARN 30 s timeout exceeded during GCS pull")
+                return None
+
+            text = blob.download_as_text(encoding="utf-8")
+            start = text.find("{")
+            if start == -1:
+                _log("[GcsVerdict] WARN blob contained no JSON object")
+                return None
+            verdict = json.loads(text[start:])
+            _log("[GcsVerdict] pulled a1_verdict.json from gs://%s/%s "
+                 "(GCS_AUTHORITATIVE)" % (bucket_name, blob_path))
+            return verdict
+        except Exception as exc:  # noqa: BLE001 -- GCS pull must never crash
+            _log("[GcsVerdict] pull failed (fail-soft): %r" % (exc,))
+            return None
+
     async def retrieve_verdict(self) -> Dict[str, Any]:
         """Mandate 3: verdict retrieval is 100% via ``IapBlackBoxTransport``.
 
@@ -1401,6 +1463,17 @@ class A1BrainIgnition:
             else:
                 _log("[BlackBox] WARN checksum-verified archive did not yield a "
                      "parseable a1_verdict.json")
+
+        # -- TIER 1.5: GCS verdict pull (IAP-decoupled, preemption-proof) --
+        if verdict is None:
+            try:
+                verdict = await loop.run_in_executor(None, self._pull_verdict_from_gcs)
+                if verdict is not None:
+                    verdict_source = "gcs"
+                    _log("[GcsVerdict] A1 verdict parsed from GCS "
+                         "(IAP-decoupled, AUTHORITATIVE)")
+            except Exception as exc:  # noqa: BLE001 -- GCS must never crash the driver
+                _log("[GcsVerdict] WARN pull error: %r" % (exc,))
 
         # -- FAIL-SOFT, NON-AUTHORITATIVE fallback: only when the Black-Box
         # channel produced NO verdict at all. --

--- a/scripts/isomorphic_a1_local.py
+++ b/scripts/isomorphic_a1_local.py
@@ -1202,6 +1202,54 @@ def _launch_iso_soak(
 
 
 # ---------------------------------------------------------------------------
+# GCS verdict push (fail-soft, 30s hard timeout)
+# ---------------------------------------------------------------------------
+
+def _push_verdict_to_gcs(verdict_out: str, run_id: str) -> None:
+    """Upload ``a1_verdict.json`` + ``dispatch_done.marker`` to the GCS target
+    used by the telemetry sidecar.  Entirely fail-soft: any error is logged and
+    swallowed so that a GCS outage never blocks teardown or alters the exit code.
+
+    The target URI comes from ``JARVIS_A1_GCS_TELEMETRY_TARGET`` (the same env
+    var the sidecar reads).  If unset/empty the function returns silently — the
+    sidecar was not enabled for this run, so there is no bucket to push to.
+    """
+    target_uri = (os.environ.get("JARVIS_A1_GCS_TELEMETRY_TARGET", "") or "").strip()
+    if not target_uri:
+        return  # sidecar not enabled — nothing to push
+
+    async def _upload() -> None:
+        # Lazy import: the sidecar module + google-cloud-storage SDK are
+        # optional; we only pay the import cost when GCS push is active.
+        from scripts.a1_gcs_telemetry_sidecar import make_gcs_chunk_sink  # type: ignore[import-untyped]
+
+        sink = make_gcs_chunk_sink(target_uri)
+        if sink is None:
+            _log("[a1-gcs-verdict] sink creation returned None — skipping push")
+            return
+
+        # Read the verdict file written by the auditor.
+        with open(verdict_out, "rb") as fh:
+            verdict_bytes = fh.read()
+
+        object_name = "%s/a1_verdict.json" % run_id
+        sink(object_name, verdict_bytes)
+
+        # Write the sentinel marker so the local side can detect completion.
+        marker_name = "%s/dispatch_done.marker" % run_id
+        sink(marker_name, b"\x00")
+
+        _log("[a1-gcs-verdict] pushed a1_verdict.json -> %s/%s" % (target_uri.rstrip("/"), object_name))
+
+    try:
+        asyncio.get_event_loop().run_until_complete(
+            asyncio.wait_for(_upload(), timeout=30.0)
+        )
+    except Exception as exc:  # noqa: BLE001 — fail-soft mandate
+        _log("[a1-gcs-verdict] push failed (fail-soft): %r" % (exc,))
+
+
+# ---------------------------------------------------------------------------
 # IsomorphicA1Driver -- the full-chain local E2E driver
 # ---------------------------------------------------------------------------
 
@@ -1751,6 +1799,7 @@ class IsomorphicA1Driver:
                         }
                         proven = False
                         _log("STEP audit VERDICT: SKIPPED (hardware_capacity_exhausted)")
+                        _push_verdict_to_gcs(verdict_out, run_id)
                     else:
                         # ── e. LAUNCH AUDITOR ────────────────────────────────
                         _log("STEP audit: sse=%s log=%s" % (self.sse_base, debug_log))
@@ -1787,6 +1836,7 @@ class IsomorphicA1Driver:
                              % ("A1_DISPATCH_PROVEN" if proven else "FAILED",
                                 " (log truncated: child force-reaped)"
                                 if _soak_force_reaped else ""))
+                        _push_verdict_to_gcs(verdict_out, run_id)
 
                     # ── f. FAILURE PATH: T5 telemetry + local autopsy ────────
                     if not proven:


### PR DESCRIPTION
Closes IAP tunnel degradation blindspot. 3-tier verdict retrieval: IAP BlackBox → GCS → SSH. 95 tests green. 7-day lifecycle auto-expiry on telemetry bucket.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds GCS verdict transport to decouple verdict retrieval from the IAP tunnel. A1 now resolves verdicts via IAP BlackBox, then GCS, with SSH as a last resort to close the tunnel degradation blindspot.

- New Features
  - Node: `_push_verdict_to_gcs` uploads `a1_verdict.json` and `dispatch_done.marker` to `gs://<target>/<run_id>/` (30s timeout, fail-soft; reuses the sidecar sink).
  - Local: `_pull_verdict_from_gcs` fetches `<run_id>/a1_verdict.json` from `gs://` using ADC and `google-cloud-storage` (authoritative Tier 1.5, fail-soft).
  - Retrieval order: IAP BlackBox → GCS (authoritative) → SSH fallback.

- Migration
  - Set `JARVIS_A1_GCS_TELEMETRY_TARGET` to `gs://bucket/prefix` to enable GCS transport; leave unset to keep current behavior.
  - Ensure the executing SA can write/read objects (e.g., objectCreator + objectViewer) in the target bucket.

<sup>Written for commit ce08dc43f891793ee21b4a12488f673ef1146941. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

