### PR TITLE
feat(ov): ov awakening — terminal-native boot ceremony + Karen live-state briefing

### DIFF
--- a/backend/audio/audio_pipeline_bootstrap.py
+++ b/backend/audio/audio_pipeline_bootstrap.py
@@ -194,12 +194,21 @@ async def wire_conversation_pipeline(
         try:
             from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (
                 build_karen_duplex,
+                set_default_karen,
             )
             handle.karen = build_karen_duplex(handle.tts_engine)
             await handle.karen.start()
+            set_default_karen(handle.karen)
             logger.info("[Bootstrap] Karen full-duplex control layer mounted")
         except Exception as e:
             handle.karen = None
+            try:
+                from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (
+                    set_default_karen,
+                )
+                set_default_karen(None)
+            except Exception:
+                pass
             logger.warning(f"[Bootstrap] Karen duplex mount skipped: {e}")
 
     # 4. ConversationPipeline
@@ -319,6 +328,13 @@ async def shutdown(handle: PipelineHandle) -> None:
             await asyncio.wait_for(handle.karen.stop(), timeout=_timeout)
         except Exception as e:
             logger.debug(f"[Bootstrap] Karen duplex stop error: {e}")
+        try:
+            from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (
+                set_default_karen,
+            )
+            set_default_karen(None)
+        except Exception:
+            pass
 
     # 0b. Karen voice->build bridge (Sprint 4) — drop the ref, no async teardown needed.
     handle.voice_build = None

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -385,6 +385,99 @@ def _resolve_active_session_dir(default_dir: Path) -> Path:
         return default_dir
 
 
+def build_awakening_for_cockpit(
+    console: Any,
+    *,
+    intake_probe: Optional[Callable[[], Optional[int]]] = None,
+    approvals_probe: Optional[Callable[[], Optional[int]]] = None,
+) -> Optional[Any]:
+    """COCKPIT boot skin factory (ov awakening Task 8). Returns ``None`` in
+    SOAK (spec §3.5) -- the legacy compact boot banner stays byte-identical.
+
+    Orchestrates existing Task 3-7 pieces only (DRY mandate #3): the
+    conductor (Task 5), the Karen boot briefing composer (Task 7), and the
+    process-wide default-Karen handle (this task). No boot-ordering logic is
+    duplicated here.
+
+    The briefing rides ``on_ignition`` fire-and-forget -- its own breaker +
+    NEVER-raises contract (karen_boot_briefing.BootBriefing) means a
+    synthesis failure can never touch boot. ``_speak_sink`` prefers the live
+    mounted Karen duplex handle; when voice is off (no handle mounted) it
+    degrades to a muted console line -- still observable (spec: "voice-off
+    degrades to console print").
+    """
+    from backend.core.ouroboros.ui.presentation_mode import is_cockpit
+
+    if not is_cockpit():
+        return None
+
+    from backend.core.ouroboros.battle_test.boot_timing import get_default_timer
+    from backend.core.ouroboros.governance.comms.karen_boot_briefing import (
+        BootBriefing,
+        build_default_synthesizer,
+        gather_vectors,
+    )
+    from backend.core.ouroboros.ui.awakening import AwakeningConductor
+
+    briefing_tasks: List[Any] = []
+
+    def _speak_sink(line: str) -> None:
+        try:
+            from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (
+                get_default_karen,
+            )
+            karen = get_default_karen()
+            if karen is not None:
+                karen.submit_speech(line)
+                return
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            console.print(
+                f"  \U0001f4ad Karen ▸ “{line}”",
+                style="muted", markup=False,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _on_ignition() -> None:
+        async def _deliver() -> None:
+            try:
+                vectors = await gather_vectors(
+                    intake_probe=intake_probe, approvals_probe=approvals_probe,
+                )
+            except Exception:  # noqa: BLE001
+                vectors = None
+            briefing = BootBriefing(
+                synthesizer=build_default_synthesizer(),
+                speak_sink=_speak_sink,
+                vectors_override=vectors,
+            )
+            await briefing.run()
+        try:
+            briefing_tasks.append(asyncio.get_event_loop().create_task(_deliver()))
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _context_line() -> str:
+        import datetime
+        parts = [f"awakened {datetime.datetime.now().strftime('%H:%M')}"]
+        try:
+            n = intake_probe() if intake_probe else None
+            if n:
+                parts.append(f"{n} ops queued")
+        except Exception:  # noqa: BLE001
+            pass
+        return " · ".join(parts)
+
+    conductor = AwakeningConductor(
+        console, timer=get_default_timer(),
+        on_ignition=_on_ignition, context_provider=_context_line,
+    )
+    conductor._briefing_tasks = briefing_tasks  # keep references (no GC)
+    return conductor
+
+
 class BattleTestHarness:
     """Orchestrates the full Ouroboros boot, event-driven session loop, and shutdown.
 
@@ -1255,12 +1348,31 @@ class BattleTestHarness:
 
             _log_path = getattr(self, "_log_file_path", "")
 
+            self._awakening = None
             if hasattr(self, "_serpent_flow") and self._serpent_flow is not None:
-                self._serpent_flow.boot_banner(
-                    layers=_layers,
-                    n_sensors=0,  # Updated below after intake boot
-                    log_path=_log_path,
+                self._awakening = build_awakening_for_cockpit(
+                    self._serpent_flow.console,
+                    intake_probe=self._intake_pending_probe,
+                    approvals_probe=None,
                 )
+                if self._awakening is not None:
+                    # COCKPIT: play the boot ceremony now, serialized against
+                    # the rest of boot -- it owns a Rich Live region on the
+                    # same console, and its animate-vs-plain decision reads
+                    # console.is_terminal, which is only reliable BEFORE the
+                    # REPL's patch_stdout(raw=True) wraps stdout (Task 5
+                    # review's load-bearing ordering invariant). Awaited to
+                    # completion here so no later boot-path console.print()
+                    # (e.g. SerpentFlow.start()'s ribbon) can interleave with
+                    # the Live-owned ceremony.
+                    await self._awakening.run()
+                else:
+                    # legacy SOAK banner path -- UNCHANGED
+                    self._serpent_flow.boot_banner(
+                        layers=_layers,
+                        n_sensors=0,  # Updated below after intake boot
+                        log_path=_log_path,
+                    )
             else:
                 # Fallback: basic Rich console output
                 from rich.console import Console as _C
@@ -1363,9 +1475,20 @@ class BattleTestHarness:
                 else:
                     try:
                         from backend.core.ouroboros.battle_test.serpent_flow import SerpentREPL
+                        # ov awakening Task 8 — hand off keys typed during
+                        # the boot ceremony (self._awakening is None in
+                        # SOAK / when the ceremony fell back to plain
+                        # before any keys were buffered) into the first
+                        # prompt instead of dropping them.
+                        _awakening_prefix = (
+                            self._awakening.typed_prefix
+                            if getattr(self, "_awakening", None) is not None
+                            else ""
+                        )
                         self._serpent_repl = SerpentREPL(
                             flow=self._serpent_flow,
                             on_command=self._handle_repl_command,
+                            initial_text=_awakening_prefix,
                         )
                         await self._serpent_repl.start()
                     except Exception as _repl_exc:
@@ -3152,6 +3275,27 @@ class BattleTestHarness:
         except Exception as exc:
             logger.warning("Branch creation failed: %s", exc)
             return f"{self._config.branch_prefix}/failed"
+
+    def _intake_pending_probe(self) -> Optional[int]:
+        """Best-effort live intake-queue depth for the Karen boot briefing
+        context line (ov awakening Task 8). Mirrors the router-resolution
+        walk used for plugin sensor wiring / ``/resume`` (harness.py's
+        ``_intake_router``/``intake_router``/``_router``/``router`` probe on
+        ``self._governed_loop_service`` -- DRY reuse of the existing idiom,
+        not a new router-lookup mechanism). NEVER raises."""
+        try:
+            gls = getattr(self, "_governed_loop_service", None)
+            router = None
+            for _attr in ("_intake_router", "intake_router", "_router", "router"):
+                _cand = getattr(gls, _attr, None)
+                if _cand is not None:
+                    router = _cand
+                    break
+            if router is not None and hasattr(router, "pending_ack_count"):
+                return int(router.pending_ack_count())
+        except Exception:  # noqa: BLE001
+            pass
+        return None
 
     async def boot_intake(self) -> None:
         """Create IntakeLayerConfig, IntakeLayerService, and start()."""

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4567,6 +4567,7 @@ class SerpentREPL:
         on_command: Optional[Callable[[str], Any]] = None,
         prompt_str: str = "🐍 ouroboros > ",
         gls: Any = None,
+        initial_text: str = "",
     ) -> None:
         self._flow = flow
         self._on_command = on_command
@@ -4577,6 +4578,11 @@ class SerpentREPL:
         self._gls = gls  # GovernedLoopService reference for /cancel
         # Slice 253 — live shadow-trap breadcrumb listener task.
         self._shadow_breadcrumb_task: Optional[asyncio.Task[None]] = None
+        # ov awakening Task 8 — non-skip keys typed during the boot ceremony
+        # are buffered into AwakeningConductor.typed_prefix and handed off
+        # here so the first prompt pre-fills instead of dropping the input.
+        # Consumed (not re-applied) after the first prompt_async call.
+        self._initial_text: str = initial_text
 
     async def start(self) -> None:
         """Start the REPL loop as a background task."""
@@ -5125,9 +5131,18 @@ class SerpentREPL:
                         )
                     except Exception:
                         prompt_html = HTML(f"<b>{self._prompt_str}</b>")
+                    # ov awakening Task 8 — pre-fill the FIRST prompt only
+                    # with keys buffered during the boot ceremony; consumed
+                    # immediately so later iterations never re-apply it.
+                    _prompt_kwargs: Dict[str, Any] = {
+                        "set_exception_handler": False,
+                    }
+                    if self._initial_text:
+                        _prompt_kwargs["default"] = self._initial_text
+                        self._initial_text = ""
                     line = await self._session.prompt_async(
                         prompt_html,
-                        set_exception_handler=False,
+                        **_prompt_kwargs,
                     )
                     line = line.strip()
                     if not line:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -20,6 +20,7 @@ Everything after the verb forwards verbatim to the bootstrap, e.g.
 """
 from __future__ import annotations
 
+import os
 import sys
 from dataclasses import dataclass, field
 from typing import Callable, List, Optional, Sequence
@@ -156,7 +157,14 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         console.print(status_digest(), markup=False, highlight=False)
         return 0
 
-    # cockpit / headless -> the one shared bootstrap (DRY).
+    # cockpit / headless -> the one shared bootstrap (DRY). The facade's ONLY
+    # added responsibility: declare the presentation skin (spec §3.4).
+    from backend.core.ouroboros.ui.presentation_mode import ENV_KEY, PresentationMode
+
+    os.environ[ENV_KEY] = (
+        PresentationMode.COCKPIT.value if inv.action == "cockpit"
+        else PresentationMode.SOAK.value
+    )
     try:
         from scripts.ouroboros_battle_test import main as battle_main
     except Exception as exc:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -6529,7 +6529,7 @@ class CandidateGenerator:
                     )
                     _sx_b = _get_sx_batch()
                     _sx_b.record_attempt(
-                        op_id=_op_id or "",
+                        op_id=getattr(context, "op_id", "") or _op_id or "",
                         error_msg=_poll_err,
                         candidate_preview=getattr(
                             _poll_exc, "candidate_preview", "",

--- a/backend/core/ouroboros/governance/comms/duplex/karen_duplex_factory.py
+++ b/backend/core/ouroboros/governance/comms/duplex/karen_duplex_factory.py
@@ -97,4 +97,32 @@ def build_karen_duplex(
     return KarenDuplexHandle(arbiter=arbiter, playback=playback, bridge=bridge)
 
 
-__all__ = ["KarenDuplexHandle", "build_karen_duplex"]
+# ---------------------------------------------------------------------------
+# Process-wide default singleton (ov awakening Task 8)
+# ---------------------------------------------------------------------------
+# Mirrors voice_command_sensor.set_default_voice_sensor /
+# get_default_voice_sensor: the handle is mounted inside
+# audio_pipeline_bootstrap, but late-binding consumers (the Karen boot
+# briefing) need a handle to the live instance without threading it through
+# every call site. Last-write-wins; NEVER raises.
+
+_DEFAULT_KAREN: Optional[KarenDuplexHandle] = None
+
+
+def set_default_karen(handle: Optional[KarenDuplexHandle]) -> None:
+    """Publish the mounted duplex handle for late-binding consumers (boot
+    briefing). Same pattern as intake's set_default_voice_sensor."""
+    global _DEFAULT_KAREN
+    _DEFAULT_KAREN = handle
+
+
+def get_default_karen() -> Optional[KarenDuplexHandle]:
+    return _DEFAULT_KAREN
+
+
+__all__ = [
+    "KarenDuplexHandle",
+    "build_karen_duplex",
+    "set_default_karen",
+    "get_default_karen",
+]

--- a/backend/core/ouroboros/governance/comms/karen_boot_briefing.py
+++ b/backend/core/ouroboros/governance/comms/karen_boot_briefing.py
@@ -161,7 +161,11 @@ class BootBriefing:
                 sink(line)
             except Exception:  # noqa: BLE001
                 logger.debug("[briefing] sink failed", exc_info=True)
-            return                        # speak wins; text is the fallback
+            # Deliver to the FIRST configured sink only, then stop: speak_sink
+            # is the cockpit path; text_sink is the voice-off alternative used
+            # when speak_sink is None. (Not a speak-failure fallback -- a
+            # raising speak_sink is logged and swallowed, not retried on text.)
+            return
 
 
 def build_default_synthesizer() -> Optional[object]:

--- a/backend/core/ouroboros/governance/comms/karen_boot_briefing.py
+++ b/backend/core/ouroboros/governance/comms/karen_boot_briefing.py
@@ -1,0 +1,178 @@
+# backend/core/ouroboros/governance/comms/karen_boot_briefing.py
+"""Karen's boot briefing -- the awakening's voice (spec §3.3).
+
+Live vectors -> Sprint-2 speech pipeline (LedgerView filters -> persona ->
+DW -> sentence chunks -> arbiter) behind a hard asyncio.wait_for breaker.
+Fallback is a LOCAL deterministic composition over the SAME vectors --
+state-driven prose, never canned boilerplate. Fire-and-forget by contract:
+run() NEVER raises and never blocks boot beyond its own awaited deadline.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from .karen_synth.ledger_view import LedgerView, strip_code
+
+logger = logging.getLogger("Ouroboros.Karen.BootBriefing")
+
+_TIMEOUT_ENV = "JARVIS_KAREN_BOOT_BRIEF_TIMEOUT_S"
+
+
+@dataclass
+class BriefingVectors:
+    last_session: Optional[str] = None
+    queued_ops: Optional[int] = None
+    posture: Optional[str] = None
+    pending_approvals: Optional[int] = None
+
+    @property
+    def empty(self) -> bool:
+        return all(v is None for v in
+                   (self.last_session, self.queued_ops, self.posture,
+                    self.pending_approvals))
+
+
+async def gather_vectors(*, intake_probe: Optional[Callable[[], Optional[int]]] = None,
+                         approvals_probe: Optional[Callable[[], Optional[int]]] = None,
+                         ) -> BriefingVectors:
+    """Best-effort, read-only, per-vector fault isolation. NEVER raises."""
+    v = BriefingVectors()
+    loop = asyncio.get_event_loop()
+    try:
+        from backend.core.ouroboros.governance.last_session_summary import (
+            get_default_summary,
+        )
+        v.last_session = await loop.run_in_executor(
+            None, get_default_summary().format_for_prompt_sync)
+    except Exception:  # noqa: BLE001
+        logger.debug("[briefing] last_session vector unavailable", exc_info=True)
+    try:
+        from backend.core.ouroboros.governance.posture_palette import (
+            read_current_posture_safe,
+        )
+        reading = await loop.run_in_executor(None, read_current_posture_safe)
+        if reading is not None:
+            value = getattr(reading, "value", reading)
+            v.posture = str(value or "") or None
+    except Exception:  # noqa: BLE001
+        logger.debug("[briefing] posture vector unavailable", exc_info=True)
+    for probe, attr in ((intake_probe, "queued_ops"),
+                        (approvals_probe, "pending_approvals")):
+        if probe is None:
+            continue
+        try:
+            setattr(v, attr, probe())
+        except Exception:  # noqa: BLE001
+            logger.debug("[briefing] %s vector unavailable", attr, exc_info=True)
+    return v
+
+
+def compose_local(v: BriefingVectors) -> str:
+    """Deterministic prose over LIVE vectors (the breaker's landing pad).
+    Never a canned greeting: every clause carries real state."""
+    if v.empty:
+        return "Awake. First session on this repo."
+    parts: List[str] = ["Awake."]
+    if v.queued_ops:
+        plural = "s" if v.queued_ops != 1 else ""
+        parts.append(f"{v.queued_ops} op{plural} queued overnight.")
+    if v.pending_approvals:
+        plural = "s" if v.pending_approvals != 1 else ""
+        parts.append(f"{v.pending_approvals} awaiting your sign-off.")
+    if v.posture:
+        parts.append(f"Posture {v.posture}.")
+    if v.last_session and len(parts) == 1:
+        parts.append(f"Last session: {strip_code(v.last_session)[:120]}.")
+    return " ".join(parts)
+
+
+class BootBriefing:
+    def __init__(self, *, synthesizer: Optional[object] = None,
+                 speak_sink: Optional[Callable[[str], None]] = None,
+                 text_sink: Optional[Callable[[str], None]] = None,
+                 timeout_s: Optional[float] = None,
+                 vectors_override: Optional[BriefingVectors] = None) -> None:
+        self._synth = synthesizer
+        self._speak = speak_sink
+        self._text = text_sink
+        self._timeout = timeout_s if timeout_s is not None else float(
+            os.environ.get(_TIMEOUT_ENV, "4.0"))
+        self._vectors_override = vectors_override
+
+    async def run(self) -> str:
+        """Deliver the briefing. NEVER raises. Bounded by the breaker."""
+        try:
+            v = self._vectors_override if self._vectors_override is not None \
+                else await gather_vectors()
+            line = ""
+            if self._synth is not None:
+                line = await self._primary(v)
+            if not line:
+                line = compose_local(v)
+                self._deliver(line)
+            return line
+        except Exception:  # noqa: BLE001
+            logger.debug("[briefing] run failed", exc_info=True)
+            return ""
+
+    async def _primary(self, v: BriefingVectors) -> str:
+        """DW path under the breaker. Returns "" on any failure/timeout."""
+        payload = {"goal": compose_local(v)}
+        view = LedgerView.from_payload("boot", payload)
+        spoken: List[str] = []
+
+        async def _consume() -> None:
+            async for sentence in self._synth.synthesize(view):
+                safe = strip_code(sentence).strip()
+                if safe:
+                    spoken.append(safe)
+                    self._deliver(safe)
+
+        task = asyncio.get_event_loop().create_task(_consume())
+        try:
+            await asyncio.wait_for(task, timeout=self._timeout)
+        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            if not spoken:
+                logger.debug("[briefing] breaker tripped -> local fallback")
+                return ""
+        return " ".join(spoken)
+
+    def _deliver(self, line: str) -> None:
+        for sink in (self._speak, self._text):
+            if sink is None:
+                continue
+            try:
+                sink(line)
+            except Exception:  # noqa: BLE001
+                logger.debug("[briefing] sink failed", exc_info=True)
+            return                        # speak wins; text is the fallback
+
+
+def build_default_synthesizer() -> Optional[object]:
+    """Best-effort production synthesizer (DW -> Karen). None on any failure
+    -- the breaker's local path covers it."""
+    try:
+        from backend.core.ouroboros.governance.doubleword_provider import (
+            DoublewordProvider,
+        )
+        from .karen_synth.speech_provider import DWSpeechProvider
+        from .karen_synth.synthesizer import KarenSpeechSynthesizer
+        if not os.environ.get("DOUBLEWORD_API_KEY"):
+            return None
+        return KarenSpeechSynthesizer(DWSpeechProvider(DoublewordProvider()))
+    except Exception:  # noqa: BLE001
+        logger.debug("[briefing] default synthesizer unavailable", exc_info=True)
+        return None
+
+
+__all__ = ["BriefingVectors", "BootBriefing", "gather_vectors",
+           "compose_local", "build_default_synthesizer"]

--- a/backend/core/ouroboros/governance/comms/karen_boot_briefing.py
+++ b/backend/core/ouroboros/governance/comms/karen_boot_briefing.py
@@ -134,10 +134,17 @@ class BootBriefing:
 
         task = asyncio.get_event_loop().create_task(_consume())
         try:
+            # asyncio.wait_for raises asyncio.TimeoutError (an Exception) on its
+            # own deadline — NEVER CancelledError. So we deliberately do NOT
+            # catch CancelledError here: a genuine OUTER cancellation (boot
+            # shutdown while we await DW) MUST propagate out of run(), not be
+            # eaten by the breaker's local-fallback path.
             await asyncio.wait_for(task, timeout=self._timeout)
-        except (asyncio.TimeoutError, asyncio.CancelledError, Exception):  # noqa: BLE001
+        except Exception:  # noqa: BLE001  (asyncio.TimeoutError is a subclass)
             task.cancel()
             try:
+                # Awaiting the child we just cancelled legitimately raises
+                # CancelledError HERE — it is ours to absorb, not the caller's.
                 await task
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -2563,7 +2563,7 @@ class DoublewordProvider:
                     )
                     _sx_p = _get_sx_poll()
                     _sx_p.record_attempt(
-                        op_id=getattr(pending, "op_id", "") or "",
+                        op_id=getattr(ctx, "op_id", "") or getattr(pending, "op_id", "") or "",
                         error_msg=_exc_msg,
                         candidate_preview=(
                             content[:800] if content else ""

--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -1,0 +1,431 @@
+"""backend/core/ouroboros/ui/awakening.py -- the ov boot ceremony conductor.
+
+:class:`AwakeningConductor` owns a Rich ``Live`` region that plays the boot
+ceremony: the procedural crest (``ui.crest``) draws itself tail-to-head while
+the *real* boot-phase readiness renders beneath it via a MOUNTED
+:class:`~backend.core.ouroboros.ui.wake_sequence.WakeSequenceRenderer` --
+this module never reimplements phase tracking (Mandate 3 / DRY). When the
+crest finishes drawing it fires an ``on_ignition`` callback exactly once,
+then holds/breathes until boot is genuinely "live" (never faked), cools down
+to a one-line header, and supports Esc/Enter skip while buffering any other
+typed keys so they are handed off to the REPL rather than swallowed.
+
+Dependency rule (leaf UI layer): stdlib + Rich + ``.theme`` + ``.crest`` +
+``.wake_sequence`` only. No ``governance``/``battle_test`` imports -- the
+``on_ignition``/``context_provider`` callbacks are injected by the caller so
+governance concerns stay out of the presentation layer.
+
+NEVER raises: :meth:`AwakeningConductor.run` wraps the entire ceremony and
+falls back to the plain (no ``Live``) path on any exception, logging DEBUG
+to ``logging.getLogger("Ouroboros.UI.Awakening")``.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import select
+import sys
+import time
+from typing import Callable, Optional
+
+from rich.console import Console, Group, RenderableType
+from rich.live import Live
+from rich.text import Text
+
+from .crest import CrestFrame, generate_crest, style_for_cell
+from .theme import (
+    ColorTier,
+    Token,
+    detect_tier,
+    ensure_theme,
+    style_for,
+    supports_unicode,
+)
+from .wake_sequence import WakeSequenceRenderer
+
+logger = logging.getLogger("Ouroboros.UI.Awakening")
+
+#: Kill switch -- default ON. Flip to a falsy value to skip the ceremony
+#: entirely and go straight to the plain (no ``Live``) boot path.
+_ENABLED_ENV_VAR = "JARVIS_OV_AWAKENING_ENABLED"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+
+#: Bytes that request a skip -- Esc, CR, LF. Every other byte is buffered
+#: into ``typed_prefix`` for REPL handoff (never swallowed, never a skip).
+_SKIP_CHARS = frozenset({"\x1b", "\r", "\n"})
+
+#: Wall-clock (or injected-clock) ceiling on the pre-ignition reveal and the
+#: post-ignition hold -- honesty guard so a stuck sensor can never wedge the
+#: ceremony forever (spec §3.2 item 4).
+_HOLD_GUARD_S = 20.0
+
+#: Animation cadence -- mirrors the 16ms batched-refresh pattern used by
+#: ``battle_test/stream_renderer.py`` (~60fps).
+_ANIMATION_TICK_S = 0.016
+
+#: Cool-down sub-frame hold, real wall-clock -- ~0.4s total across 2 frames.
+_COOLDOWN_SUBFRAME_S = 0.2
+
+
+def _awakening_enabled() -> bool:
+    """Env gate read fresh on every call (tests monkeypatch the env var)."""
+    return os.environ.get(_ENABLED_ENV_VAR, "true").strip().lower() in _TRUTHY
+
+
+class _StdinKeyReader:
+    """Non-blocking raw-stdin reader for skip detection (production only).
+
+    Only actually engages when BOTH ``sys.__stdout__`` and ``sys.stdin`` are
+    real ttys -- checked via ``sys.__stdout__`` (not ``sys.stdout``, which
+    can be wrapped by prompt_toolkit's ``patch_stdout`` and report ``False``
+    even on a real terminal). Under any other condition (tests, headless,
+    CI, piped output) this degrades to an inert no-op reader: ``read()``
+    always returns ``b""``. Restores termios settings in ``__exit__``, and
+    NEVER raises -- every termios call is wrapped defensively.
+    """
+
+    def __init__(self) -> None:
+        self._fd: Optional[int] = None
+        self._old_settings = None
+        self._active = False
+
+    def __enter__(self) -> "_StdinKeyReader":
+        try:
+            stdout = sys.__stdout__
+            if stdout is None or not stdout.isatty():
+                return self
+            stdin = sys.stdin
+            if stdin is None or not stdin.isatty():
+                return self
+            import termios
+            import tty
+
+            self._fd = stdin.fileno()
+            self._old_settings = termios.tcgetattr(self._fd)
+            tty.setcbreak(self._fd)
+            self._active = True
+        except Exception:  # noqa: BLE001 -- terminal setup must never be fatal
+            logger.debug("[awakening] cbreak setup failed", exc_info=True)
+            self._active = False
+        return self
+
+    def __exit__(self, *exc_info: object) -> None:
+        if self._active and self._fd is not None and self._old_settings is not None:
+            try:
+                import termios
+
+                termios.tcsetattr(self._fd, termios.TCSADRAIN, self._old_settings)
+            except Exception:  # noqa: BLE001
+                logger.debug("[awakening] termios restore failed", exc_info=True)
+        self._active = False
+
+    def read(self) -> bytes:
+        if not self._active or self._fd is None:
+            return b""
+        try:
+            ready, _, _ = select.select([self._fd], [], [], 0)
+            if not ready:
+                return b""
+            return os.read(self._fd, 64)
+        except Exception:  # noqa: BLE001
+            logger.debug("[awakening] stdin read failed", exc_info=True)
+            return b""
+
+
+class AwakeningConductor:
+    """Plays the boot ceremony: crest reveal + mounted wake sequence.
+
+    Consumes (never rebuilds) :class:`~.wake_sequence.WakeSequenceRenderer`
+    for real phase readiness, and :func:`~.crest.generate_crest` for the
+    procedural crest geometry. See module docstring for the full contract.
+    """
+
+    def __init__(
+        self,
+        console: Console,
+        *,
+        timer: object = None,
+        on_ignition: Optional[Callable[[], None]] = None,
+        context_provider: Optional[Callable[[], str]] = None,
+        clock: Callable[[], float] = time.monotonic,
+        key_source: Optional[Callable[[], bytes]] = None,
+    ) -> None:
+        self._console = console
+        ensure_theme(console)
+        self._wake = WakeSequenceRenderer(console)
+        if timer is not None:
+            self._wake.attach(timer)  # existing observer API -- MOUNTED, not rebuilt
+
+        self._on_ignition = on_ignition
+        self._context_provider = context_provider
+        self._clock = clock
+        self._key_source = key_source
+
+        self.typed_prefix: str = ""
+        self.used_plain_path: bool = False
+
+        self._skip_requested = False
+        self._ignited = False
+        self._header_printed = False
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def request_skip(self) -> None:
+        """Request an immediate jump to cool-down. Idempotent."""
+        self._skip_requested = True
+
+    async def run(self) -> None:
+        """Play the whole ceremony. NEVER raises -- falls back to the plain
+        path on any exception encountered anywhere in the animated path."""
+        try:
+            frame = self._generate_frame()
+            if self._should_go_plain(frame):
+                await self._run_plain()
+                return
+            await self._run_animated(frame)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[awakening] animated ceremony failed; falling back to plain",
+                exc_info=True,
+            )
+            try:
+                await self._run_plain()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[awakening] plain fallback also failed", exc_info=True,
+                )
+
+    # ------------------------------------------------------------------
+    # Guards
+    # ------------------------------------------------------------------
+
+    def _generate_frame(self) -> CrestFrame:
+        try:
+            size = self._console.size
+            tier = detect_tier(self._console)
+            unicode_ok = supports_unicode()
+            return generate_crest(
+                size.width, size.height, tier=tier, unicode_ok=unicode_ok,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[awakening] frame generation failed", exc_info=True)
+            return CrestFrame(0, 0, (), 0.0, "generation error")
+
+    def _should_go_plain(self, frame: CrestFrame) -> bool:
+        """True when any guard forces the plain (no ``Live``) path.
+
+        Guards: the master env kill switch, a non-interactive console (via
+        ``console.is_terminal`` -- honors ``force_terminal`` for injected
+        test consoles the same way Rich's own renderers do), or an
+        unavailable crest frame (unsupported unicode/color/size).
+        """
+        if not _awakening_enabled():
+            return True
+        try:
+            if not getattr(self._console, "is_terminal", False):
+                return True
+        except Exception:  # noqa: BLE001
+            return True
+        if frame.unavailable_reason is not None:
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    # Animated path
+    # ------------------------------------------------------------------
+
+    async def _run_animated(self, frame: CrestFrame) -> None:
+        tier = detect_tier(self._console)
+        start = self._clock()
+        ignite_elapsed: Optional[float] = None
+
+        reader_cm: Optional[_StdinKeyReader] = None
+        poll = self._key_source
+        if poll is None:
+            reader_cm = _StdinKeyReader()
+            reader_cm.__enter__()
+            poll = reader_cm.read
+
+        try:
+            with Live(console=self._console, auto_refresh=False, transient=True) as live:
+                while True:
+                    now = self._clock()
+                    elapsed = now - start
+
+                    self._poll_keys(poll)
+
+                    # Deliberately NOT wrapped in try/except: a rendering
+                    # failure must propagate out to run()'s outer handler
+                    # so the WHOLE ceremony falls back to the plain path
+                    # (spec §3.2 item 7) rather than spinning forever on a
+                    # tick that can never succeed.
+                    crest_text = self._render_crest_text(frame, elapsed, tier)
+                    live.update(
+                        Group(crest_text, self._wake.render_frame()), refresh=True,
+                    )
+
+                    if not self._ignited and elapsed >= frame.max_delay_s:
+                        self._ignited = True
+                        ignite_elapsed = elapsed
+                        if self._on_ignition is not None:
+                            try:
+                                self._on_ignition()
+                            except Exception:  # noqa: BLE001
+                                logger.debug(
+                                    "[awakening] on_ignition callback failed",
+                                    exc_info=True,
+                                )
+
+                    if self._skip_requested:
+                        break
+                    if self._ignited:
+                        anchor = ignite_elapsed if ignite_elapsed is not None else elapsed
+                        holding_for = elapsed - anchor
+                        if self._wake.model.is_live or holding_for >= _HOLD_GUARD_S:
+                            break
+
+                    await asyncio.sleep(_ANIMATION_TICK_S)
+
+                await self._cool_down(frame, tier, live)
+        finally:
+            if reader_cm is not None:
+                reader_cm.__exit__(None, None, None)
+
+        self._print_cooled_header()
+
+    async def _cool_down(self, frame: CrestFrame, tier: ColorTier, live: Live) -> None:
+        """A couple of tint sub-frames (~0.4s) before the ``Live`` region
+        closes (``transient=True`` erases it -- the cooled header below is
+        the only thing left on screen)."""
+        accent_style = style_for(Token.ACCENT, tier) or "accent"
+
+        # Sub-frame 1: hold the fully-revealed gradient crest.
+        full = self._render_crest_text(frame, frame.max_delay_s + 1.0, tier)
+        live.update(Group(full, self._wake.render_frame()), refresh=True)
+        await asyncio.sleep(_COOLDOWN_SUBFRAME_S)
+
+        # Sub-frame 2: collapse to a single accent-tinted mark.
+        tint = Text("ov · ouroboros", style=accent_style)
+        live.update(Group(tint), refresh=True)
+        await asyncio.sleep(_COOLDOWN_SUBFRAME_S)
+
+    def _render_crest_text(
+        self, frame: CrestFrame, elapsed: float, tier: ColorTier,
+    ) -> RenderableType:
+        """Render the crest as revealed so far -- cells whose ``delay_s``
+        has elapsed draw solid; everything else is blank space. Draws
+        tail-to-head purely as a function of the (test-injectable) clock."""
+        if not frame.cells or frame.cols <= 0 or frame.rows <= 0:
+            return Text("")
+        grid = {(c.x, c.y): c for c in frame.cells if c.delay_s <= elapsed}
+        text = Text()
+        for y in range(frame.rows):
+            for x in range(frame.cols):
+                cell = grid.get((x, y))
+                if cell is None:
+                    text.append(" ")
+                else:
+                    text.append(cell.glyph, style=style_for_cell(cell, tier))
+            if y < frame.rows - 1:
+                text.append("\n")
+        return text
+
+    def _poll_keys(self, poll: Callable[[], bytes]) -> None:
+        """Read whatever is available this tick. Esc/CR/LF request a skip;
+        every other decoded char is appended to ``typed_prefix`` -- NEVER
+        swallowed (load-bearing anti-corruption rule for REPL handoff)."""
+        try:
+            data = poll()
+        except Exception:  # noqa: BLE001
+            logger.debug("[awakening] key_source failed", exc_info=True)
+            return
+        if not data:
+            return
+        try:
+            text = data.decode("utf-8", errors="replace")
+        except Exception:  # noqa: BLE001
+            text = ""
+        for ch in text:
+            if ch in _SKIP_CHARS:
+                self.request_skip()
+                return
+            self.typed_prefix += ch
+
+    # ------------------------------------------------------------------
+    # Plain path (no Live) -- attaches to the SAME mounted renderer
+    # ------------------------------------------------------------------
+
+    async def _run_plain(self) -> None:
+        self.used_plain_path = True
+        start = self._clock()
+        while True:
+            now = self._clock()
+            self._wake.flush(now)
+            if self._skip_requested:
+                break
+            if self._wake.model.is_live:
+                break
+            if (now - start) >= _HOLD_GUARD_S:
+                break
+            if self._key_source is not None:
+                self._poll_keys(self._key_source)
+                if self._skip_requested:
+                    break
+            await asyncio.sleep(_ANIMATION_TICK_S)
+        self._print_cooled_header()
+
+    # ------------------------------------------------------------------
+    # Cooled header -- printed exactly once, whichever path completes
+    # ------------------------------------------------------------------
+
+    def _print_cooled_header(self) -> None:
+        if self._header_printed:
+            return
+        self._header_printed = True
+        try:
+            header = Text()
+            header.append("ov", style="accent")
+            header.append(" · ", style="muted")
+            header.append("ouroboros", style="heading")
+            header.append("   ")
+            header.append("live", style="success")
+            self._console.print(header)
+            if self._context_provider is not None:
+                try:
+                    ctx = self._context_provider()
+                except Exception:  # noqa: BLE001
+                    ctx = ""
+                if ctx:
+                    self._console.print(Text(str(ctx), style="muted"))
+        except Exception:  # noqa: BLE001
+            logger.debug("[awakening] cooled header print failed", exc_info=True)
+
+
+async def run_awakening(console: Optional[Console] = None, **kwargs: object) -> "AwakeningConductor":
+    """Build a console (if not given) and play the ceremony end-to-end.
+
+    NEVER raises -- ``AwakeningConductor.run`` already guards its whole
+    body, and any failure constructing the console falls back to a bare
+    :class:`~rich.console.Console`.
+    """
+    if console is None:
+        try:
+            from .theme import build_console
+
+            console = build_console()
+        except Exception:  # noqa: BLE001
+            logger.debug("[awakening] build_console failed; bare Console", exc_info=True)
+            console = Console()
+
+    conductor = AwakeningConductor(console, **kwargs)  # type: ignore[arg-type]
+    try:
+        await conductor.run()
+    except Exception:  # noqa: BLE001 -- conductor.run() already never raises; stay defensive
+        logger.debug("[awakening] run_awakening failed unexpectedly", exc_info=True)
+    return conductor
+
+
+__all__ = ["AwakeningConductor", "run_awakening"]

--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -169,6 +169,13 @@ class AwakeningConductor:
         self._ignited = False
         self._header_printed = False
 
+        #: Resize proof (Mandate 4 / SIGWINCH): count of in-flight crest
+        #: regenerations triggered by a mid-trace console size change, and
+        #: the last size measured by the animated tick loop. ``None`` until
+        #: the first tick establishes a baseline.
+        self.regenerations: int = 0
+        self._last_size: Optional[tuple] = None
+
     # ------------------------------------------------------------------
     # Public API
     # ------------------------------------------------------------------
@@ -233,6 +240,43 @@ class AwakeningConductor:
             return True
         return False
 
+    def _check_resize(self, frame: CrestFrame, tier: ColorTier) -> CrestFrame:
+        """Per-tick SIGWINCH proof (Mandate 4): if the measured console size
+        changed since the last tick, regenerate the crest at the new size.
+
+        Crest cell ``delay_s`` values are derived purely from arc-angle
+        (tail=0 -> head=1), the SAME fractional schedule regardless of
+        width -- so the same ``elapsed`` reveals the same arc fraction on
+        the regenerated frame and the reveal stays monotonic by
+        construction; no remapping is needed, only adoption of the new
+        frame. If the console shrank below the crest minimum, the new
+        frame comes back ``unavailable_reason``-set -- request a skip so
+        the ceremony degrades gracefully to cool-down instead of trying to
+        render a frame with no cells. NEVER raises: any failure to measure
+        or regenerate just keeps the current frame for this tick.
+        """
+        try:
+            size = self._console.size
+            current = (size.width, size.height)
+        except Exception:  # noqa: BLE001
+            logger.debug("[awakening] resize measurement failed", exc_info=True)
+            return frame
+        if current == self._last_size:
+            return frame
+        self._last_size = current
+        try:
+            new_frame = self._generate_frame()
+        except Exception:  # noqa: BLE001
+            logger.debug("[awakening] resize regeneration failed", exc_info=True)
+            return frame
+        if new_frame.unavailable_reason is None:
+            self.regenerations += 1
+            return new_frame
+        # Too small now -- degrade gracefully to cool-down rather than
+        # crashing or spinning on an empty frame.
+        self.request_skip()
+        return frame
+
     # ------------------------------------------------------------------
     # Animated path
     # ------------------------------------------------------------------
@@ -241,6 +285,12 @@ class AwakeningConductor:
         tier = detect_tier(self._console)
         start = self._clock()
         ignite_elapsed: Optional[float] = None
+
+        try:
+            size0 = self._console.size
+            self._last_size = (size0.width, size0.height)
+        except Exception:  # noqa: BLE001
+            self._last_size = None
 
         reader_cm: Optional[_StdinKeyReader] = None
         poll = self._key_source
@@ -256,6 +306,7 @@ class AwakeningConductor:
                     elapsed = now - start
 
                     self._poll_keys(poll)
+                    frame = self._check_resize(frame, tier)
 
                     # Deliberately NOT wrapped in try/except: a rendering
                     # failure must propagate out to run()'s outer handler

--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -240,7 +240,7 @@ class AwakeningConductor:
             return True
         return False
 
-    def _check_resize(self, frame: CrestFrame, tier: ColorTier) -> CrestFrame:
+    def _check_resize(self, frame: CrestFrame) -> CrestFrame:
         """Per-tick SIGWINCH proof (Mandate 4): if the measured console size
         changed since the last tick, regenerate the crest at the new size.
 
@@ -306,7 +306,7 @@ class AwakeningConductor:
                     elapsed = now - start
 
                     self._poll_keys(poll)
-                    frame = self._check_resize(frame, tier)
+                    frame = self._check_resize(frame)
 
                     # Deliberately NOT wrapped in try/except: a rendering
                     # failure must propagate out to run()'s outer handler

--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -455,28 +455,4 @@ class AwakeningConductor:
             logger.debug("[awakening] cooled header print failed", exc_info=True)
 
 
-async def run_awakening(console: Optional[Console] = None, **kwargs: object) -> "AwakeningConductor":
-    """Build a console (if not given) and play the ceremony end-to-end.
-
-    NEVER raises -- ``AwakeningConductor.run`` already guards its whole
-    body, and any failure constructing the console falls back to a bare
-    :class:`~rich.console.Console`.
-    """
-    if console is None:
-        try:
-            from .theme import build_console
-
-            console = build_console()
-        except Exception:  # noqa: BLE001
-            logger.debug("[awakening] build_console failed; bare Console", exc_info=True)
-            console = Console()
-
-    conductor = AwakeningConductor(console, **kwargs)  # type: ignore[arg-type]
-    try:
-        await conductor.run()
-    except Exception:  # noqa: BLE001 -- conductor.run() already never raises; stay defensive
-        logger.debug("[awakening] run_awakening failed unexpectedly", exc_info=True)
-    return conductor
-
-
-__all__ = ["AwakeningConductor", "run_awakening"]
+__all__ = ["AwakeningConductor"]

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -1,0 +1,396 @@
+"""Procedural ouroboros crest (v5) -- reactive, hard-edge, tier-resolved.
+
+Ports docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py into
+a reactive generator: every metric scales from the measured terminal width
+(Mandate 2 -- zero absolute canvas dimensions), clamped to
+[JARVIS_OV_CREST_MIN_COLS, JARVIS_OV_CREST_MAX_COLS]. Rendering is
+hard-threshold quadrant rasterization -- solid fill, no anti-aliasing.
+
+The asset is the geometry source of truth; this module reproduces its math
+verbatim (same sampling functions, same quadrant table, same gradient, same
+v5 tuning) with every absolute metric replaced by ``scale * reference``
+where ``scale = clamped_cols / _REF_COLS``.
+
+Leaf module: stdlib + ui.theme only. NEVER raises: impossible conditions
+return CrestFrame(unavailable_reason=...).
+"""
+from __future__ import annotations
+
+import functools
+import math
+import os
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from .theme import ColorTier
+
+# ---- reference geometry (verbatim from the approved v5 asset) -------------
+# docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py
+_REF_COLS = 58.0
+_REF_ROWS = 17.0
+_REF_ASPECT = 1.083
+
+_REF = dict(
+    r_mid=11.6,
+    thick=3.5,
+    gap_half=math.radians(20),
+    taper_sweep=math.radians(52),
+    taper_min=0.34,
+    tail_intrude=math.radians(15),
+    head_len=5.6,
+    head_w=2.5,
+    eye_r=0.95,
+    v_top=4.9,
+    v_bot=5.6,
+    v_half_span=4.8,
+    v_stroke=2.7,
+)
+_GAP_CENTER = math.radians(90)
+_SS = 3
+
+_STOPS = [
+    (0, (125, 255, 106)), (60, (91, 227, 75)), (150, (139, 92, 246)),
+    (210, (177, 108, 234)), (285, (212, 192, 74)), (360, (125, 255, 106)),
+]
+_HEAD_RGB = (125, 255, 106)
+_EYE_RGB = (234, 255, 208)
+_V_TOP_RGB, _V_BOT_RGB = (192, 132, 252), (157, 78, 220)
+
+_QUAD = {
+    0b0000: " ", 0b1000: "▘", 0b0100: "▝", 0b1100: "▀",
+    0b0010: "▖", 0b1010: "▌", 0b0110: "▞", 0b1110: "▛",
+    0b0001: "▗", 0b1001: "▚", 0b0101: "▐", 0b1101: "▜",
+    0b0011: "▄", 0b1011: "▙", 0b0111: "▟", 0b1111: "█",
+}
+_PRIORITY = ("eye", "head", "coil", "v")
+_DOTS = set("▘▝▖▗")  # ▘▝▖▗
+
+
+@dataclass(frozen=True)
+class CrestCell:
+    x: int
+    y: int
+    glyph: str
+    kind: str
+    rgb: Tuple[int, int, int]
+    delay_s: float
+
+
+@dataclass(frozen=True)
+class CrestFrame:
+    cols: int
+    rows: int
+    cells: Tuple[CrestCell, ...]
+    max_delay_s: float
+    unavailable_reason: Optional[str] = None
+
+
+def _clamp_cols(measured: int) -> Tuple[int, int, int]:
+    """Return (lo, hi, clamped) column bounds for a measured width.
+
+    ``clamped`` is only meaningful when ``measured >= lo`` -- callers must
+    check the low bound against ``measured`` directly (not ``clamped``,
+    which is floored at ``lo`` by construction and so can never itself
+    read as "below minimum").
+    """
+    lo = int(os.environ.get("JARVIS_OV_CREST_MIN_COLS", "46"))
+    hi = int(os.environ.get("JARVIS_OV_CREST_MAX_COLS", "72"))
+    clamped = max(lo, min(measured, hi))
+    return lo, hi, clamped
+
+
+# ===========================================================================
+# Scaled geometry
+# ===========================================================================
+
+
+class _Geometry:
+    """Every reference metric scaled by ``cols / _REF_COLS``.
+
+    Mirrors the asset's module-level constants + derived CX/CY, but as
+    instance attributes parameterized by the measured (clamped) width --
+    zero absolute canvas dimensions (Mandate 2).
+    """
+
+    def __init__(self, cols: int, rows: int) -> None:
+        self.cols = cols
+        self.rows = rows
+        scale = cols / _REF_COLS
+        self.scale = scale
+
+        self.r_mid = _REF["r_mid"] * scale
+        self.thick = _REF["thick"] * scale
+        self.gap_center = _GAP_CENTER
+        self.gap_half = _REF["gap_half"]
+        self.taper_sweep = _REF["taper_sweep"]
+        self.taper_min = _REF["taper_min"]
+        self.tail_intrude = _REF["tail_intrude"]
+        self.head_len = _REF["head_len"] * scale
+        self.head_w = _REF["head_w"] * scale
+        self.eye_r = _REF["eye_r"] * scale
+        self.v_top = _REF["v_top"] * scale
+        self.v_bot = _REF["v_bot"] * scale
+        self.v_half_span = _REF["v_half_span"] * scale
+        self.v_stroke = _REF["v_stroke"] * scale
+
+        # Physical pixel canvas: 1 cell = 1px wide x 2px tall (aspect corrected).
+        self.px_w = float(cols)
+        self.px_h = float(rows) * 2.0
+        self.cx = self.px_w / 2.0
+        self.cy = (self.px_h / 2.0) * _REF_ASPECT
+
+        self.tail_tip = _ang_norm(self.gap_center + self.gap_half)
+        self.head_theta = _ang_norm(self.gap_center - self.gap_half)
+
+    @staticmethod
+    def rows_needed(cols: int) -> int:
+        """Cell rows required to fit the coil's scaled diameter + margin."""
+        scale = cols / _REF_COLS
+        r_mid = _REF["r_mid"] * scale
+        thick = _REF["thick"] * scale
+        diameter_px = 2.0 * (r_mid + thick / 2.0)
+        cell_rows = math.ceil(diameter_px / (2.0 * _REF_ASPECT))
+        return cell_rows + 2
+
+    @classmethod
+    def for_size(cls, cols: int, rows: int) -> "_Geometry":
+        return cls(cols, rows)
+
+
+# ===========================================================================
+# Sampling functions -- ported verbatim from the asset, parameterized by geo
+# ===========================================================================
+
+
+def _ang_norm(a: float) -> float:
+    while a < 0:
+        a += 2 * math.pi
+    while a >= 2 * math.pi:
+        a -= 2 * math.pi
+    return a
+
+
+def _in_gap(theta: float, geo: _Geometry) -> bool:
+    d = abs(_ang_norm(theta - geo.gap_center))
+    if d > math.pi:
+        d = 2 * math.pi - d
+    return d < geo.gap_half
+
+
+def _body_half(theta: float, geo: _Geometry) -> float:
+    d = _ang_norm(theta - geo.tail_tip)          # 0 at tail tip, grows CCW
+    if d < geo.taper_sweep:
+        t = d / geo.taper_sweep
+        return (geo.thick * (geo.taper_min + (1.0 - geo.taper_min) * t)) / 2.0
+    return geo.thick / 2.0
+
+
+def _sample_coil(px: float, py: float, geo: _Geometry) -> bool:
+    dx, dy = px - geo.cx, py - geo.cy
+    r = math.hypot(dx, dy)
+    theta = math.atan2(-dy, dx)
+    if _in_gap(theta, geo):
+        # tail tip intrudes into the mouth as a thin point
+        d_from_tail_edge = _ang_norm(geo.tail_tip - theta)
+        if d_from_tail_edge < geo.tail_intrude:
+            t = d_from_tail_edge / geo.tail_intrude   # 0 at gap edge -> 1 deep
+            half = (geo.thick * geo.taper_min / 2.0) * (1.0 - 0.72 * t)
+            return abs(r - geo.r_mid) <= half
+        return False
+    return abs(r - geo.r_mid) <= _body_half(theta, geo)
+
+
+def _head_frame(geo: _Geometry) -> Tuple[float, float, float, float]:
+    hx = geo.cx + geo.r_mid * math.cos(geo.head_theta)
+    hy = geo.cy - geo.r_mid * math.sin(geo.head_theta)
+    # snout points CCW along the tangent (toward the gap / tail tip)
+    tx = math.sin(geo.head_theta)
+    ty = math.cos(geo.head_theta)
+    return hx, hy, tx, ty
+
+
+def _sample_head(px: float, py: float, geo: _Geometry) -> bool:
+    hx, hy, tx, ty = _head_frame(geo)
+    dx, dy = px - hx, py - hy
+    lon = dx * tx + dy * ty
+    lat = -dx * ty + dy * tx
+    if lon < -1.6 * geo.scale or lon > geo.head_len:
+        return False
+    w = geo.head_w * (1.0 - 0.62 * max(0.0, lon / geo.head_len))
+    # open mouth: notch at the snout half
+    if lon > geo.head_len * 0.52 and abs(lat) < w * 0.34:
+        return False
+    return abs(lat) <= w
+
+
+def _eye_center(geo: _Geometry) -> Tuple[float, float]:
+    hx, hy, tx, ty = _head_frame(geo)
+    return (
+        hx + tx * 0.7 * geo.scale - ty * 1.05 * geo.scale,
+        hy + ty * 0.7 * geo.scale + tx * 1.05 * geo.scale,
+    )
+
+
+def _sample_eye(px: float, py: float, geo: _Geometry) -> bool:
+    ex, ey = _eye_center(geo)
+    return math.hypot(px - ex, py - ey) <= geo.eye_r
+
+
+def _seg_dist(px, py, ax, ay, bx, by) -> float:
+    vx, vy = bx - ax, by - ay
+    wx, wy = px - ax, py - ay
+    denom = vx * vx + vy * vy
+    t = 0.0 if denom == 0 else max(0.0, min(1.0, (wx * vx + wy * vy) / denom))
+    return math.hypot(px - (ax + t * vx), py - (ay + t * vy))
+
+
+def _sample_v(px: float, py: float, geo: _Geometry) -> bool:
+    if py < geo.cy - geo.v_top:                # flat, machined top edge
+        return False
+    top_inset = 0.8 * geo.scale
+    d1 = _seg_dist(px, py, geo.cx - geo.v_half_span, geo.cy - geo.v_top - top_inset,
+                    geo.cx, geo.cy + geo.v_bot)
+    d2 = _seg_dist(px, py, geo.cx + geo.v_half_span, geo.cy - geo.v_top - top_inset,
+                    geo.cx, geo.cy + geo.v_bot)
+    return min(d1, d2) <= geo.v_stroke / 2.0
+
+
+# ---- gradient ---------------------------------------------------------------
+
+
+def _grad(frac: float) -> Tuple[float, float, float]:
+    deg = frac * 360.0
+    for (a0, c0), (a1, c1) in zip(_STOPS, _STOPS[1:]):
+        if a0 <= deg <= a1:
+            t = (deg - a0) / (a1 - a0) if a1 > a0 else 0
+            return tuple(c0[k] + t * (c1[k] - c0[k]) for k in range(3))  # type: ignore[return-value]
+    return _STOPS[-1][1]
+
+
+# ---- classification + rasterization -----------------------------------------
+
+
+def _classify(px: float, py: float, geo: _Geometry) -> Tuple[Optional[str], Optional[float]]:
+    """Hard classification of one subpixel center-region (majority of SSxSS)."""
+    votes = {"eye": 0, "head": 0, "coil": 0, "v": 0}
+    theta: Optional[float] = None
+    for sy in range(_SS):
+        for sx in range(_SS):
+            spx = px + (sx + 0.5) / _SS * 0.5
+            spy = py + ((sy + 0.5) / _SS * 0.5) * _REF_ASPECT
+            if _sample_eye(spx, spy, geo):
+                votes["eye"] += 1
+            elif _sample_head(spx, spy, geo):
+                votes["head"] += 1
+            elif _sample_coil(spx, spy, geo):
+                votes["coil"] += 1
+                theta = math.atan2(-(spy - geo.cy), spx - geo.cx)
+            elif _sample_v(spx, spy, geo):
+                votes["v"] += 1
+    n = _SS * _SS
+    inside = sum(votes.values()) >= n / 2.0       # 0.5 coverage threshold
+    if not inside:
+        return None, None
+    k = max(_PRIORITY, key=lambda kk: votes[kk])
+    return k, theta
+
+
+def _render_cells(geo: _Geometry) -> List[CrestCell]:
+    """cell -> CrestCell. Quadrant bit order: TL,TR,BL,BR."""
+    raw: Dict[Tuple[int, int], Tuple[str, str, Tuple[float, float, float], float]] = {}
+    for cy_ in range(geo.rows):
+        for cx_ in range(geo.cols):
+            bits = 0
+            kinds: List[str] = []
+            thetas: List[float] = []
+            for i, (sx, sy) in enumerate([(0, 0), (1, 0), (0, 1), (1, 1)]):
+                # subpixel origin in physical units (cell 1.0 wide, 2*ASPECT tall)
+                px = cx_ + sx * 0.5
+                py = (cy_ * 2 + sy) * _REF_ASPECT
+                k, th = _classify(px, py, geo)
+                if k is not None:
+                    bits |= 1 << (3 - i)
+                    kinds.append(k)
+                    if th is not None:
+                        thetas.append(th)
+            if not bits:
+                continue
+            kind = max(_PRIORITY, key=lambda kk: kinds.count(kk)) if kinds else "coil"
+            if kind == "eye":
+                color, delay = _EYE_RGB, 1.55
+            elif kind == "head":
+                color, delay = _HEAD_RGB, 1.42
+            elif kind == "coil":
+                th = thetas[len(thetas) // 2] if thetas else 0.0
+                frac = _ang_norm(th - geo.tail_tip) / (2 * math.pi)
+                color = tuple(round(c) for c in _grad(frac))
+                delay = 0.05 + 1.30 * frac
+            else:  # v
+                t = max(0.0, min(1.0, (cy_ * 2 * _REF_ASPECT - (geo.cy - geo.v_top))
+                                  / (geo.v_top + geo.v_bot)))
+                color = tuple(round(_V_TOP_RGB[k2] + t * (_V_BOT_RGB[k2] - _V_TOP_RGB[k2]))
+                              for k2 in range(3))
+                delay = 1.78 + 0.5 * t
+            raw[(cx_, cy_)] = (_QUAD[bits], kind, color, delay)  # type: ignore[assignment]
+
+    # cleanup: drop isolated single-quadrant crumbs (no orthogonal neighbor)
+    for (x, y) in [k for k, v in raw.items() if v[0] in _DOTS]:
+        if not any((x + dx, y + dy) in raw for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))):
+            del raw[(x, y)]
+
+    return [
+        CrestCell(x=x, y=y, glyph=glyph, kind=kind, rgb=color, delay_s=delay)
+        for (x, y), (glyph, kind, color, delay) in raw.items()
+    ]
+
+
+# ===========================================================================
+# Public entry point
+# ===========================================================================
+
+
+@functools.lru_cache(maxsize=8)
+def _generate_cached(clamped_cols: int, rows: int, tier: int) -> CrestFrame:
+    geo = _Geometry.for_size(clamped_cols, rows)
+    cells = _render_cells(geo)
+    max_delay = max((c.delay_s for c in cells), default=0.0)
+    return CrestFrame(
+        cols=clamped_cols,
+        rows=rows,
+        cells=tuple(cells),
+        max_delay_s=max(max_delay, 1.55),
+    )
+
+
+def generate_crest(
+    measured_cols: int,
+    measured_rows: int,
+    *,
+    tier: ColorTier,
+    unicode_ok: bool,
+) -> CrestFrame:
+    """Generate a reactive crest frame sized to the measured terminal.
+
+    NEVER raises. Returns an unavailable frame (``unavailable_reason`` set)
+    when: unicode is unsupported, the color tier is NONE, the measured width
+    is below the configured minimum, or there are not enough rows to fit the
+    scaled geometry. Frames are cached per (clamped_cols, rows, tier).
+    """
+    try:
+        if not unicode_ok:
+            return CrestFrame(0, 0, (), 0.0, "unicode required")
+        if tier is ColorTier.NONE:
+            return CrestFrame(0, 0, (), 0.0, "color tier NONE")
+        lo, _hi, clamped = _clamp_cols(measured_cols)
+        if measured_cols < lo:
+            return CrestFrame(0, 0, (), 0.0, f"width {measured_cols} < min {lo}")
+        needed_rows = _Geometry.rows_needed(clamped)
+        if measured_rows < needed_rows:
+            return CrestFrame(0, 0, (), 0.0,
+                               f"rows {measured_rows} < needed {needed_rows}")
+        return _generate_cached(clamped, needed_rows, int(tier))
+    except Exception:  # noqa: BLE001 -- never raise into a render path
+        return CrestFrame(0, 0, (), 0.0, "generation error")
+
+
+__all__ = ["CrestCell", "CrestFrame", "generate_crest"]

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -22,7 +22,7 @@ import os
 from dataclasses import dataclass
 from typing import Dict, List, Optional, Tuple
 
-from .theme import ColorTier
+from .theme import ColorTier, Token, style_for
 
 # ---- reference geometry (verbatim from the approved v5 asset) -------------
 # docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py
@@ -393,4 +393,17 @@ def generate_crest(
         return CrestFrame(0, 0, (), 0.0, "generation error")
 
 
-__all__ = ["CrestCell", "CrestFrame", "generate_crest"]
+def style_for_cell(cell: CrestCell, tier: ColorTier) -> str:
+    """Resolve one cell's Rich style for the tier. TRUECOLOR/C256 carry the
+    per-cell gradient (Rich downgrades 24-bit for 256 terminals); STANDARD
+    collapses to the single accent (geometry + trace unchanged)."""
+    if tier >= ColorTier.C256:
+        r, g, b = cell.rgb
+        return f"rgb({r},{g},{b})"
+    accent = style_for(Token.ACCENT, tier)
+    if cell.kind == "v":
+        return f"bold {accent}"
+    return accent
+
+
+__all__ = ["CrestCell", "CrestFrame", "generate_crest", "style_for_cell"]

--- a/backend/core/ouroboros/ui/presentation_mode.py
+++ b/backend/core/ouroboros/ui/presentation_mode.py
@@ -1,0 +1,41 @@
+"""backend/core/ouroboros/ui/presentation_mode.py -- COCKPIT vs SOAK skin.
+
+One resolution point for the ov presentation split (spec §3.5). SOAK is the
+fail-safe default: every legacy launch path (the battle-test script, ov run,
+CI, daemons) keeps byte-identical output unless `ov` cockpit explicitly opts
+in via JARVIS_OV_PRESENTATION=cockpit.
+
+Leaf module: stdlib only. The gate this feeds NEVER carries fatal telemetry
+(Mandate 1) -- ERROR/CRITICAL paths are emitted unconditionally at their
+sources and do not consult this module.
+"""
+from __future__ import annotations
+
+import enum
+import os
+from typing import Mapping, Optional
+
+ENV_KEY = "JARVIS_OV_PRESENTATION"
+
+
+class PresentationMode(str, enum.Enum):
+    COCKPIT = "cockpit"   # ov awakening: banners withheld, WARNING logging
+    SOAK = "soak"         # legacy verbose harness output (default)
+
+
+def resolve_presentation_mode(
+    env: Optional[Mapping[str, str]] = None,
+) -> PresentationMode:
+    """Resolve the mode. Unknown/absent values fail safe to SOAK."""
+    source = os.environ if env is None else env
+    raw = (source.get(ENV_KEY) or "").strip().lower()
+    if raw == PresentationMode.COCKPIT.value:
+        return PresentationMode.COCKPIT
+    return PresentationMode.SOAK
+
+
+def is_cockpit() -> bool:
+    return resolve_presentation_mode() is PresentationMode.COCKPIT
+
+
+__all__ = ["ENV_KEY", "PresentationMode", "resolve_presentation_mode", "is_cockpit"]

--- a/docs/superpowers/plans/2026-07-07-ov-awakening-implementation.md
+++ b/docs/superpowers/plans/2026-07-07-ov-awakening-implementation.md
@@ -1,0 +1,1825 @@
+# The `ov` Awakening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** `ov` boots as a terminal-native awakening — procedural ouroboros crest animation + Karen live-state boot briefing — cooling into the restrained working surface, while soak/CI output stays byte-identical.
+
+**Architecture:** Presentation-layer split: a `PresentationMode` gate at every harness banner emission source (COCKPIT withholds, SOAK unchanged, fatal paths structurally bypass); a reactive procedural crest (`ui/crest.py`) + thin conductor (`ui/awakening.py`) that mounts the existing `WakeSequenceRenderer`; a boot-briefing composer reusing the Sprint-2 Karen speech pipeline behind a 4s circuit breaker.
+
+**Tech Stack:** Python 3.9+, Rich (Live/Theme), asyncio, pytest + pytest-asyncio, existing `ui/theme.py` tier ladder, existing `karen_synth`/duplex stack.
+
+**Spec:** `docs/superpowers/specs/2026-07-07-ov-awakening-cli-design.md` (approved, §10 resolved). Crest geometry source of truth: `docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py`.
+
+## Global Constraints
+
+- CLI/terminal only; all rendering through `ui/theme.py`; zero escape leakage at `ColorTier.NONE`; TTY checks via `sys.__stdout__` (`real_stdout_isatty` pattern), never `sys.stdout.isatty()`.
+- **Mandate 1 (root-cause):** banner suppression by conditional logic at each emission source in `scripts/ouroboros_battle_test.py` / `harness.py`. NO stdout redirect/wrapper/regex filter anywhere. ERROR/CRITICAL + fatal prints must not route through the gate at all.
+- **Mandate 2 (reactive geometry):** `ui/crest.py` scales all metrics proportionally from measured console size; clamp cols to `[JARVIS_OV_CREST_MIN_COLS=46, JARVIS_OV_CREST_MAX_COLS=72]`; zero absolute canvas dimensions.
+- **Mandate 3 (DRY):** `ui/awakening.py` embeds `WakeSequenceRenderer`/`WakeModel` (`ui/wake_sequence.py`) and subscribes via `BootTimer.add_observer` — no new phase tracker. `cli/ov.py` stays a facade (sets mode env, delegates to `battle_main`).
+- **Mandate 4 (bulletproof):** SIGWINCH mid-animation resize test required; briefing breaker (`JARVIS_KAREN_BOOT_BRIEF_TIMEOUT_S`, default 4.0) proven to fall back to the local live-state line without stalling.
+- Skip keys: `Esc`/`Enter` ONLY; any other typed bytes are buffered and handed to the REPL untouched (never swallowed, never trigger skip).
+- Crest requires unicode + tier ≥ STANDARD; otherwise the awakening degrades to plain wake lines.
+- `ui/` modules import only stdlib + Rich + `ui.theme` (leaf rule); governance callbacks reach `ui/` via injection.
+- `from __future__ import annotations` in every new file; `asyncio.wait_for` (3.9), never `asyncio.timeout`.
+- Env flags (exact names): `JARVIS_OV_PRESENTATION`, `JARVIS_OV_AWAKENING_ENABLED` (default true), `JARVIS_KAREN_BOOT_BRIEF_TIMEOUT_S` (4.0), `JARVIS_OV_CREST_MIN_COLS` (46), `JARVIS_OV_CREST_MAX_COLS` (72).
+- Commit after every task; `git add` only named files (never `-A`/`.`); commit trailer: `Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>`.
+- Run tests with `python3 -m pytest` from the repo root.
+
+---
+
+### Task 1: PresentationMode + gate the harness banner sources (root cause first)
+
+**Files:**
+- Create: `backend/core/ouroboros/ui/presentation_mode.py`
+- Create: `tests/ui/test_presentation_mode.py`
+- Modify: `scripts/ouroboros_battle_test.py` (emission sites: zombie reaper call ~line 1315, single-flight ~1392, `_print_preflight()` call ~1397, `logging.basicConfig` level ~1402; fatal API-key check extraction from `_print_preflight` ~lines 589–594 and ~630–634)
+- Test: `tests/battle_test/test_presentation_gate.py`
+
+**Interfaces:**
+- Consumes: nothing new.
+- Produces: `PresentationMode(str, Enum)` with `.COCKPIT`/`.SOAK`; `resolve_presentation_mode(env: Optional[Mapping[str,str]] = None) -> PresentationMode`; `is_cockpit() -> bool`; script-level `_check_api_keys_or_die() -> None` (unconditional fatal check). Later tasks read `resolve_presentation_mode()` and rely on `JARVIS_OV_PRESENTATION=cockpit`.
+
+- [ ] **Step 1: Write the failing mode tests**
+
+```python
+# tests/ui/test_presentation_mode.py
+"""PresentationMode: default-SOAK fail-safe resolution (spec §3.5)."""
+from __future__ import annotations
+
+from backend.core.ouroboros.ui.presentation_mode import (
+    PresentationMode, resolve_presentation_mode, is_cockpit,
+)
+
+
+def test_default_is_soak():
+    assert resolve_presentation_mode(env={}) is PresentationMode.SOAK
+
+
+def test_cockpit_value_resolves():
+    env = {"JARVIS_OV_PRESENTATION": "cockpit"}
+    assert resolve_presentation_mode(env=env) is PresentationMode.COCKPIT
+
+
+def test_garbage_fails_safe_to_soak():
+    env = {"JARVIS_OV_PRESENTATION": "PARTY_MODE"}
+    assert resolve_presentation_mode(env=env) is PresentationMode.SOAK
+
+
+def test_case_and_whitespace_tolerant():
+    env = {"JARVIS_OV_PRESENTATION": "  Cockpit "}
+    assert resolve_presentation_mode(env=env) is PresentationMode.COCKPIT
+
+
+def test_is_cockpit_reads_process_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_PRESENTATION", "cockpit")
+    assert is_cockpit() is True
+    monkeypatch.delenv("JARVIS_OV_PRESENTATION")
+    assert is_cockpit() is False
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ui/test_presentation_mode.py -v`
+Expected: FAIL — `ModuleNotFoundError: ...presentation_mode`
+
+- [ ] **Step 3: Implement the module**
+
+```python
+# backend/core/ouroboros/ui/presentation_mode.py
+"""backend/core/ouroboros/ui/presentation_mode.py -- COCKPIT vs SOAK skin.
+
+One resolution point for the ov presentation split (spec §3.5). SOAK is the
+fail-safe default: every legacy launch path (the battle-test script, ov run,
+CI, daemons) keeps byte-identical output unless `ov` cockpit explicitly opts
+in via JARVIS_OV_PRESENTATION=cockpit.
+
+Leaf module: stdlib only. The gate this feeds NEVER carries fatal telemetry
+(Mandate 1) -- ERROR/CRITICAL paths are emitted unconditionally at their
+sources and do not consult this module.
+"""
+from __future__ import annotations
+
+import enum
+import os
+from typing import Mapping, Optional
+
+ENV_KEY = "JARVIS_OV_PRESENTATION"
+
+
+class PresentationMode(str, enum.Enum):
+    COCKPIT = "cockpit"   # ov awakening: banners withheld, WARNING logging
+    SOAK = "soak"         # legacy verbose harness output (default)
+
+
+def resolve_presentation_mode(
+    env: Optional[Mapping[str, str]] = None,
+) -> PresentationMode:
+    """Resolve the mode. Unknown/absent values fail safe to SOAK."""
+    source = os.environ if env is None else env
+    raw = (source.get(ENV_KEY) or "").strip().lower()
+    if raw == PresentationMode.COCKPIT.value:
+        return PresentationMode.COCKPIT
+    return PresentationMode.SOAK
+
+
+def is_cockpit() -> bool:
+    return resolve_presentation_mode() is PresentationMode.COCKPIT
+
+
+__all__ = ["ENV_KEY", "PresentationMode", "resolve_presentation_mode", "is_cockpit"]
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/ui/test_presentation_mode.py -v`
+Expected: 5 PASS
+
+- [ ] **Step 5: Write the failing gate tests (bypass proof + withholding proof)**
+
+Read `scripts/ouroboros_battle_test.py` around lines 558–644 first: `_print_preflight()` currently contains the fatal No-API-keys check (prints `ERROR: No API keys set.` and `sys.exit(1)`). The gate must NOT be able to suppress that — it gets extracted to `_check_api_keys_or_die()` called unconditionally.
+
+```python
+# tests/battle_test/test_presentation_gate.py
+"""Presentation gate: COCKPIT withholds banners at the SOURCE; fatal paths
+structurally bypass (Mandate 1). SOAK is call-through (legacy regression)."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import scripts.ouroboros_battle_test as bt
+from backend.core.ouroboros.ui.presentation_mode import PresentationMode
+
+
+def test_check_api_keys_or_die_exists_and_is_fatal(monkeypatch):
+    """The fatal check is its own function -- physically outside the gate."""
+    monkeypatch.delenv("DOUBLEWORD_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(SystemExit):
+        bt._check_api_keys_or_die()
+
+
+def test_check_api_keys_passes_with_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    bt._check_api_keys_or_die()   # no raise
+
+
+def test_print_preflight_no_longer_contains_fatal_exit(monkeypatch, capsys):
+    """_print_preflight is pure presentation now: with no keys it must NOT
+    exit -- the fatal lives in _check_api_keys_or_die (bypass proof)."""
+    monkeypatch.delenv("DOUBLEWORD_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    bt._print_preflight()          # must not raise SystemExit
+
+
+def test_gated_banner_helpers_skip_in_cockpit(monkeypatch):
+    """The boot path calls banners through _run_gated_boot_banners(mode);
+    COCKPIT skips them, SOAK calls through."""
+    calls = []
+    monkeypatch.setattr(bt, "_reap_zombies", lambda: calls.append("reap") or set())
+    monkeypatch.setattr(bt, "_single_flight_preflight", lambda: calls.append("sf"))
+    monkeypatch.setattr(bt, "_print_preflight", lambda: calls.append("pf"))
+
+    bt._run_gated_boot_banners(PresentationMode.COCKPIT, single_flight_enabled=True,
+                               reap_enabled=True)
+    assert calls == []             # all withheld at the source
+
+    bt._run_gated_boot_banners(PresentationMode.SOAK, single_flight_enabled=True,
+                               reap_enabled=True)
+    assert calls == ["reap", "sf", "pf"]   # legacy order preserved
+
+
+def test_resolve_boot_log_level_cockpit_is_warning():
+    assert bt._resolve_boot_log_level(PresentationMode.COCKPIT, verbose=False) == logging.WARNING
+    assert bt._resolve_boot_log_level(PresentationMode.SOAK, verbose=False) == logging.INFO
+    # verbose ALWAYS wins -- an operator asking for -v is never silenced
+    assert bt._resolve_boot_log_level(PresentationMode.COCKPIT, verbose=True) == logging.DEBUG
+
+
+def test_error_records_pass_in_cockpit(caplog):
+    """WARNING root level still delivers ERROR/CRITICAL -- the bypass is
+    structural: the gate only lowers verbosity, it filters nothing."""
+    level = bt._resolve_boot_log_level(PresentationMode.COCKPIT, verbose=False)
+    logger = logging.getLogger("test.cockpit.fatal")
+    with caplog.at_level(level, logger="test.cockpit.fatal"):
+        logger.error("initialization collapse")
+        logger.critical("fatal")
+    messages = [r.message for r in caplog.records]
+    assert "initialization collapse" in messages
+    assert "fatal" in messages
+```
+
+- [ ] **Step 6: Run to verify failure**
+
+Run: `python3 -m pytest tests/battle_test/test_presentation_gate.py -v`
+Expected: FAIL — `AttributeError: ... has no attribute '_check_api_keys_or_die'` (and `_run_gated_boot_banners`, `_resolve_boot_log_level`)
+
+- [ ] **Step 7: Implement the gate in `scripts/ouroboros_battle_test.py`**
+
+7a. Add near the top (after the existing imports):
+
+```python
+from backend.core.ouroboros.ui.presentation_mode import (
+    PresentationMode, resolve_presentation_mode,
+)
+```
+
+7b. Extract the fatal check. Find the No-API-keys block inside `_print_preflight()` (it checks `DOUBLEWORD_API_KEY` / `ANTHROPIC_API_KEY`, prints the red ERROR lines, and calls `sys.exit(1)`). Move the check+exit into a new top-level function directly above `_print_preflight`, keeping the exact print strings:
+
+```python
+def _check_api_keys_or_die() -> None:
+    """FATAL preflight: no provider keys -> die loudly. Deliberately OUTSIDE
+    the presentation gate (Mandate 1): no mode can suppress this."""
+    if not os.environ.get("DOUBLEWORD_API_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+        print(f"\n  {_RED}{_BOLD}ERROR: No API keys set.{_RESET}")
+        print(f"  {_RED}Export DOUBLEWORD_API_KEY or ANTHROPIC_API_KEY.{_RESET}\n")
+        sys.exit(1)
+```
+
+Inside `_print_preflight()`, replace the moved block with nothing (delete it); if a second key-check/exit exists near the end of `_print_preflight` (~630–634), delete that too. `_print_preflight` becomes pure presentation.
+
+> Note: match the EXACT existing strings/conditions when extracting — read the current function body first; the snippet above shows the shape, the source is authoritative.
+
+7c. Add the two gate helpers (top-level, near `_print_preflight`):
+
+```python
+def _run_gated_boot_banners(
+    mode: PresentationMode, *, single_flight_enabled: bool, reap_enabled: bool,
+) -> None:
+    """Nominal boot banners, gated AT THE SOURCE (Mandate 1). COCKPIT
+    withholds; detail stays reachable via the /preflight + /organism verbs.
+    Fatal telemetry never routes through here."""
+    if mode is PresentationMode.COCKPIT:
+        return
+    if reap_enabled:
+        _reap_zombies()
+    if single_flight_enabled:
+        _single_flight_preflight()
+    _print_preflight()
+
+
+def _resolve_boot_log_level(mode: PresentationMode, *, verbose: bool = False) -> int:
+    """COCKPIT quiets the INFO flood to WARNING. -v always wins. ERROR and
+    CRITICAL pass at every level -- the gate lowers verbosity, filters nothing."""
+    if verbose:
+        return logging.DEBUG
+    if mode is PresentationMode.COCKPIT:
+        return logging.WARNING
+    return logging.INFO
+```
+
+7d. Rewire `main()`'s boot section. Locate the existing calls (`_reaped = _reap_zombies()` ~1315 with its enable-env check, `_single_flight_preflight()` ~1392 with its enable-env check, `_print_preflight()` ~1397, `log_level = logging.DEBUG if args.verbose else logging.INFO` ~1402) and replace with:
+
+```python
+    _mode = resolve_presentation_mode()
+    _check_api_keys_or_die()          # fatal path: unconditional, both modes
+    _run_gated_boot_banners(
+        _mode,
+        single_flight_enabled=os.environ.get(
+            "JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", "true"
+        ).lower() not in ("false", "0", "no", "off"),
+        reap_enabled=_reap_enabled,   # reuse the existing JARVIS_BATTLE_REAP_ZOMBIES resolution
+    )
+    log_level = _resolve_boot_log_level(_mode, verbose=args.verbose)
+```
+
+Important integration details (read the surrounding code and preserve behavior):
+- The zombie-reaper block currently also calls `_cleanup_stale_router_lock` / `_reap_stale_jarvis_locks` and keeps the reaped-PID set. Keep the lock-cleanup **functional** work OUTSIDE the gate (it is hygiene, not presentation) — only the banner-printing reaper path is gated. If `_reap_zombies()` mixes both, split: gate its `print(...)` lines on `mode is not COCKPIT` via a new `quiet: bool = False` parameter instead of skipping the reap (zombie reaping must still HAPPEN in cockpit — it is functional). In that case `_run_gated_boot_banners` calls `_reap_zombies(quiet=False)` and `main()` calls `_reap_zombies(quiet=True)` directly in cockpit mode. Choose based on what the code actually does at the call site; the invariant is: **functional side effects always run; only stdout ceremony is gated.**
+- Keep the existing noisy-logger suppression list and `JARVIS_LOG_LEVEL` override exactly as-is (they run after `basicConfig` in both modes).
+
+- [ ] **Step 8: Run to verify pass + no regressions**
+
+Run: `python3 -m pytest tests/battle_test/test_presentation_gate.py tests/ui/test_presentation_mode.py -v`
+Expected: all PASS
+Run: `python3 -m pytest tests/battle_test/ -x -q 2>&1 | tail -5`
+Expected: existing battle_test suite green
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add backend/core/ouroboros/ui/presentation_mode.py tests/ui/test_presentation_mode.py scripts/ouroboros_battle_test.py tests/battle_test/test_presentation_gate.py
+git commit -m "feat(ov): presentation-mode gate at harness banner sources + structural fatal bypass
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 2: `ov` cockpit facade sets the mode
+
+**Files:**
+- Modify: `backend/core/ouroboros/cli/ov.py` (the `main()` cockpit/headless dispatch, lines ~139-166)
+- Test: `tests/cli/test_ov_presentation.py` (create; `tests/cli/` may already exist from Sprint 1 — check for existing `test_ov*.py` and add alongside)
+
+**Interfaces:**
+- Consumes: `ENV_KEY`, `PresentationMode` from Task 1.
+- Produces: `ov` cockpit ⇒ `os.environ["JARVIS_OV_PRESENTATION"]="cockpit"` before delegation; `ov run`/`daemon` ⇒ forces `"soak"`.
+
+- [ ] **Step 1: Write the failing test**
+
+```python
+# tests/cli/test_ov_presentation.py
+"""ov facade: cockpit action opts into COCKPIT presentation; run/daemon
+force SOAK; the facade never does more than set env + delegate (Mandate 3)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.core.ouroboros.cli import ov as ov_cli
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("JARVIS_OV_PRESENTATION", raising=False)
+
+
+def _capture_delegation(monkeypatch):
+    seen = {}
+
+    def fake_battle_main(argv):
+        seen["argv"] = list(argv)
+        seen["mode_env"] = os.environ.get("JARVIS_OV_PRESENTATION")
+
+    import scripts.ouroboros_battle_test as bt
+    monkeypatch.setattr(bt, "main", fake_battle_main)
+    return seen
+
+
+def test_cockpit_sets_cockpit_mode_before_delegating(monkeypatch):
+    seen = _capture_delegation(monkeypatch)
+    assert ov_cli.main([]) == 0
+    assert seen["mode_env"] == "cockpit"
+    assert seen["argv"] == []
+
+
+def test_run_forces_soak(monkeypatch):
+    seen = _capture_delegation(monkeypatch)
+    assert ov_cli.main(["run", "--cost-cap", "1.00"]) == 0
+    assert seen["mode_env"] == "soak"
+    assert seen["argv"] == ["--headless", "--cost-cap", "1.00"]
+
+
+def test_daemon_forces_soak(monkeypatch):
+    seen = _capture_delegation(monkeypatch)
+    assert ov_cli.main(["daemon"]) == 0
+    assert seen["mode_env"] == "soak"
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/cli/test_ov_presentation.py -v`
+Expected: FAIL — `seen["mode_env"]` is `None`
+
+- [ ] **Step 3: Implement in `cli/ov.py`**
+
+In `main()`, replace the final dispatch block:
+
+```python
+    # cockpit / headless -> the one shared bootstrap (DRY). The facade's ONLY
+    # added responsibility: declare the presentation skin (spec §3.4).
+    from backend.core.ouroboros.ui.presentation_mode import ENV_KEY, PresentationMode
+
+    os.environ[ENV_KEY] = (
+        PresentationMode.COCKPIT.value if inv.action == "cockpit"
+        else PresentationMode.SOAK.value
+    )
+    try:
+        from scripts.ouroboros_battle_test import main as battle_main
+    except Exception as exc:  # noqa: BLE001
+        console.print(f"ov: failed to load bootstrap: {exc}", markup=False)
+        return 1
+    battle_main(inv.delegate_argv)
+    return 0
+```
+
+Add `import os` to the module imports.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/cli/ -v`
+Expected: PASS (new + any existing ov dispatch tests)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/cli/ov.py tests/cli/test_ov_presentation.py
+git commit -m "feat(ov): cockpit facade declares presentation mode, run/daemon force soak
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 3: `ui/crest.py` — reactive procedural geometry (TDD)
+
+**Files:**
+- Create: `backend/core/ouroboros/ui/crest.py`
+- Test: `tests/ui/test_crest.py`
+- Read first (geometry source of truth — port, do not invent): `docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py`
+
+**Interfaces:**
+- Consumes: `ui.theme` (`ColorTier`, `style_for`, `Token`, `supports_unicode`).
+- Produces (Tasks 4–6 rely on these exact names):
+
+```python
+@dataclass(frozen=True)
+class CrestCell:
+    x: int; y: int; glyph: str; kind: str          # kind in {"coil","head","eye","v"}
+    rgb: Tuple[int, int, int]; delay_s: float
+
+@dataclass(frozen=True)
+class CrestFrame:
+    cols: int; rows: int
+    cells: Tuple[CrestCell, ...]
+    max_delay_s: float
+    unavailable_reason: Optional[str] = None       # non-None => do not animate
+
+def generate_crest(measured_cols: int, measured_rows: int, *,
+                   tier: ColorTier, unicode_ok: bool) -> CrestFrame
+```
+
+**Porting rule (Mandate 2 applied to the asset):** the asset uses fixed
+`CELL_W, CELL_H = 58, 19` and absolute radii. The port replaces every
+absolute metric with `scale = clamped_cols / 58.0` applied to the reference
+values, where `clamped_cols = max(MIN_COLS, min(measured_cols, MAX_COLS))`
+from `JARVIS_OV_CREST_MIN_COLS` (46) / `JARVIS_OV_CREST_MAX_COLS` (72).
+Reference metrics (from the asset, verbatim): `R_MID=12.6`, `THICK=2.9`,
+`GAP_HALF=20°`, `TAPER_SWEEP=52°` with min-thickness factor `0.34`,
+`TAIL_INTRUDE=15°`, `HEAD_LEN=5.4`, `HEAD_W=2.05`, `V_TOP=5.0`, `V_BOT=5.4`,
+`V_HALF_SPAN=4.9`, `V_STROKE=2.65`, `ASPECT=1.08`, supersample `SS=3`,
+threshold ≥ 0.5 per subpixel, quadrant lookup table, flat-V-top rejection,
+isolated-crumb cleanup, eye disc `EYE_R≈0.95` offset inside the head.
+Copy the sampling functions (`ang_norm`, `in_gap`, `body_half`/taper with
+intrusion, `head_frame`, `sample_head`, `sample_eye`, `seg_dist`, `sample_v`
+with the flat top, the quadrant `QUAD` table, `classify`, cleanup pass, and
+the gradient `STOPS`/`grad`) from the asset, adapting names/params to the
+scaled-geometry dataclass. Delays: `coil = 0.05 + 1.30*frac` (frac = arc
+angle from tail tip, 0→1), `head = 1.42`, `eye = 1.55`, `v = 1.78 + 0.5*t`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/ui/test_crest.py
+"""Crest v5 invariants: solid, crisp, anatomically complete, REACTIVE.
+These are the professional-art regression net (spec §9.1)."""
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+from backend.core.ouroboros.ui.crest import CrestFrame, generate_crest
+from backend.core.ouroboros.ui.theme import ColorTier
+
+T = ColorTier.TRUECOLOR
+
+
+def gen(cols=60, rows=24, tier=T, unicode_ok=True) -> CrestFrame:
+    return generate_crest(cols, rows, tier=tier, unicode_ok=unicode_ok)
+
+
+def cells_by_kind(frame, kind):
+    return [c for c in frame.cells if c.kind == kind]
+
+
+# ---- anatomy invariants ----------------------------------------------------
+
+def test_all_kinds_present():
+    f = gen()
+    assert f.unavailable_reason is None
+    for kind in ("coil", "head", "eye", "v"):
+        assert cells_by_kind(f, kind), f"missing {kind} cells"
+
+
+def test_no_isolated_crumb_cells():
+    f = gen()
+    occupied = {(c.x, c.y) for c in f.cells}
+    dots = set("▘▝▖▗")   # single-quadrant glyphs
+    for c in f.cells:
+        if c.glyph in dots:
+            assert any((c.x + dx, c.y + dy) in occupied
+                       for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))), \
+                f"isolated crumb at {(c.x, c.y)}"
+
+
+def test_v_has_flat_top():
+    f = gen()
+    v = cells_by_kind(f, "v")
+    top_y = min(c.y for c in v)
+    top_row = [c for c in v if c.y == top_y]
+    assert len(top_row) >= 4          # two stroke caps, each >=2 cells wide
+
+
+def test_coil_is_solid_no_full_block_holes():
+    """Between the leftmost and rightmost coil cell of each row band that
+    contains full blocks, interior full-block runs are contiguous per flank
+    (annulus: at most 2 runs per row -- left flank + right flank)."""
+    f = gen()
+    coil_rows = {}
+    for c in cells_by_kind(f, "coil"):
+        if c.glyph == "█":
+            coil_rows.setdefault(c.y, []).append(c.x)
+    assert coil_rows, "no solid coil interior at all"
+    for y, xs in coil_rows.items():
+        xs = sorted(xs)
+        runs = 1
+        for a, b in zip(xs, xs[1:]):
+            if b - a > 1:
+                runs += 1
+        assert runs <= 2, f"row {y}: {runs} solid runs (holes in the body)"
+
+
+def test_delays_monotonic_tail_to_head_and_bounded():
+    f = gen()
+    coil = cells_by_kind(f, "coil")
+    assert all(0.0 <= c.delay_s <= 1.40 for c in coil)
+    assert min(c.delay_s for c in coil) < 0.2       # trace starts at the tail
+    head = cells_by_kind(f, "head")
+    assert all(c.delay_s > max(c2.delay_s for c2 in coil) - 0.3 for c in head)
+    assert f.max_delay_s >= 1.55                     # eye ignition is last
+
+
+# ---- reactivity + clamping (Mandate 2) --------------------------------------
+
+def test_geometry_scales_with_width():
+    small, large = gen(cols=46), gen(cols=72)
+    assert small.cols == 46 and large.cols == 72
+    assert len(large.cells) > len(small.cells) * 1.5
+
+
+def test_hard_clamp_at_72():
+    f = gen(cols=200)
+    assert f.cols == 72
+    assert max(c.x for c in f.cells) < 72
+
+
+def test_env_min_clamp(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_CREST_MIN_COLS", "50")
+    f = generate_crest(48, 24, tier=T, unicode_ok=True)
+    assert f.unavailable_reason is not None          # below min -> unavailable
+
+
+def test_below_default_min_unavailable():
+    f = gen(cols=40)
+    assert f.unavailable_reason is not None
+
+
+def test_insufficient_rows_unavailable():
+    f = gen(cols=60, rows=8)
+    assert f.unavailable_reason is not None
+
+
+# ---- tier / unicode degradation ---------------------------------------------
+
+def test_no_unicode_unavailable():
+    f = gen(unicode_ok=False)
+    assert f.unavailable_reason is not None
+
+
+def test_none_tier_unavailable():
+    f = gen(tier=ColorTier.NONE)
+    assert f.unavailable_reason is not None
+
+
+def test_standard_tier_renders_geometry():
+    f = gen(tier=ColorTier.STANDARD)
+    assert f.unavailable_reason is None
+    assert cells_by_kind(f, "coil")
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ui/test_crest.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `ui/crest.py`**
+
+Module skeleton (port the listed functions from the asset into `_Geometry`-parameterized forms; the asset file is in-repo and authoritative for the math):
+
+```python
+# backend/core/ouroboros/ui/crest.py
+"""Procedural ouroboros crest (v5) -- reactive, hard-edge, tier-resolved.
+
+Ports docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py
+into a reactive generator: every metric scales from the measured terminal
+width (Mandate 2 -- zero absolute canvas dimensions), clamped to
+[JARVIS_OV_CREST_MIN_COLS, JARVIS_OV_CREST_MAX_COLS]. Rendering is
+hard-threshold quadrant rasterization -- solid fill, no anti-aliasing.
+Leaf module: stdlib + ui.theme only. NEVER raises: impossible conditions
+return CrestFrame(unavailable_reason=...).
+"""
+from __future__ import annotations
+
+import functools
+import math
+import os
+from dataclasses import dataclass
+from typing import Optional, Tuple
+
+from .theme import ColorTier
+
+_REF_COLS = 58.0        # the asset's reference canvas width
+
+# reference metrics -- verbatim from the approved v5 asset
+_REF = dict(
+    r_mid=12.6, thick=2.9, gap_half=math.radians(20),
+    taper_sweep=math.radians(52), taper_min=0.34,
+    tail_intrude=math.radians(15),
+    head_len=5.4, head_w=2.05, eye_r=0.95,
+    v_top=5.0, v_bot=5.4, v_half_span=4.9, v_stroke=2.65,
+)
+_ASPECT = 1.08
+_SS = 3
+_GAP_CENTER = math.radians(90)
+
+_STOPS = [
+    (0, (125, 255, 106)), (60, (91, 227, 75)), (150, (139, 92, 246)),
+    (210, (177, 108, 234)), (285, (212, 192, 74)), (360, (125, 255, 106)),
+]
+_HEAD_RGB = (125, 255, 106)
+_EYE_RGB = (234, 255, 208)
+_V_TOP_RGB, _V_BOT_RGB = (192, 132, 252), (157, 78, 220)
+
+_QUAD = {
+    0b0000: " ", 0b1000: "▘", 0b0100: "▝", 0b1100: "▀",
+    0b0010: "▖", 0b1010: "▌", 0b0110: "▞", 0b1110: "▛",
+    0b0001: "▗", 0b1001: "▚", 0b0101: "▐", 0b1101: "▜",
+    0b0011: "▄", 0b1011: "▙", 0b0111: "▟", 0b1111: "█",
+}
+
+
+@dataclass(frozen=True)
+class CrestCell:
+    x: int
+    y: int
+    glyph: str
+    kind: str
+    rgb: Tuple[int, int, int]
+    delay_s: float
+
+
+@dataclass(frozen=True)
+class CrestFrame:
+    cols: int
+    rows: int
+    cells: Tuple[CrestCell, ...]
+    max_delay_s: float
+    unavailable_reason: Optional[str] = None
+
+
+def _clamp_cols(measured: int) -> Tuple[int, int]:
+    lo = int(os.environ.get("JARVIS_OV_CREST_MIN_COLS", "46"))
+    hi = int(os.environ.get("JARVIS_OV_CREST_MAX_COLS", "72"))
+    return lo, min(measured, hi)
+
+
+# ... [_Geometry dataclass: every _REF metric * scale; center at
+#      (cols/2, rows*ASPECT); required_rows derived from scaled radius] ...
+# ... [port: _ang_norm, _in_gap, _body_half (taper + taper_min), tail
+#      intrusion, _head_frame, _sample_head (wedge + mouth notch),
+#      _sample_eye, _seg_dist, _sample_v (flat top), _classify (priority
+#      eye>head>coil>v, SS*SS majority >= 0.5), _grad(frac)] ...
+# ... [_render_cells: per cell 2x2 subpixels -> QUAD bits; kind from
+#      majority; rgb + delay from kind/frac; isolated-crumb cleanup] ...
+
+
+@functools.lru_cache(maxsize=8)
+def _generate_cached(clamped_cols: int, rows: int, tier: int) -> CrestFrame:
+    geo = _Geometry.for_size(clamped_cols, rows)
+    cells = _render_cells(geo)
+    max_delay = max((c.delay_s for c in cells), default=0.0)
+    return CrestFrame(cols=clamped_cols, rows=geo.rows_used,
+                      cells=tuple(cells), max_delay_s=max(max_delay, 1.55))
+
+
+def generate_crest(measured_cols: int, measured_rows: int, *,
+                   tier: ColorTier, unicode_ok: bool) -> CrestFrame:
+    """NEVER raises. Unavailable => plain-wake-lines degradation upstream."""
+    try:
+        if not unicode_ok:
+            return CrestFrame(0, 0, (), 0.0, "unicode required")
+        if tier is ColorTier.NONE:
+            return CrestFrame(0, 0, (), 0.0, "color tier NONE")
+        lo, clamped = _clamp_cols(measured_cols)
+        if clamped < lo:
+            return CrestFrame(0, 0, (), 0.0, f"width {measured_cols} < min {lo}")
+        needed_rows = _Geometry.rows_needed(clamped)
+        if measured_rows < needed_rows:
+            return CrestFrame(0, 0, (), 0.0,
+                              f"rows {measured_rows} < needed {needed_rows}")
+        return _generate_cached(clamped, needed_rows, int(tier))
+    except Exception:  # noqa: BLE001
+        return CrestFrame(0, 0, (), 0.0, "generation error")
+```
+
+The `# ... [port: ...] ...` blocks above name every function to port; transcribe
+each from the asset (same math, `geo.` parameters instead of module constants).
+`_Geometry.for_size(cols, rows)` computes `scale = cols / _REF_COLS` and
+multiplies every `_REF` metric; `rows_needed(cols)` returns
+`ceil((2*(r_mid+thick/2)*scale) / (2*_ASPECT)) + 2` (the coil's cell height
+plus one row of margin top/bottom).
+
+- [ ] **Step 4: Run to verify pass; iterate the port until the invariants hold**
+
+Run: `python3 -m pytest tests/ui/test_crest.py -v`
+Expected: 13 PASS. If an anatomy invariant fails, print the silhouette
+(`"".join(...)` by rows) in a debug session and compare against the asset's
+`preview_cells` output — the port must reproduce the approved v5 silhouette
+at cols=58.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/ui/crest.py tests/ui/test_crest.py
+git commit -m "feat(ov): reactive procedural crest v5 (hard-edge quadrants, clamped 46-72)
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 4: crest style resolution per tier
+
+**Files:**
+- Modify: `backend/core/ouroboros/ui/crest.py`
+- Test: `tests/ui/test_crest.py` (append)
+
+**Interfaces:**
+- Produces: `style_for_cell(cell: CrestCell, tier: ColorTier) -> str` — Rich style string per cell; TRUECOLOR/C256 ⇒ `f"rgb({r},{g},{b})"` (Rich downgrades for 256 automatically); STANDARD ⇒ coil/head/eye = `style_for(Token.ACCENT, tier)`, v = `"bold " + style_for(Token.ACCENT, tier)`. Task 5 consumes this.
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+# append to tests/ui/test_crest.py
+from backend.core.ouroboros.ui.crest import style_for_cell
+from backend.core.ouroboros.ui.theme import Token, style_for
+
+
+def test_truecolor_styles_are_rgb():
+    f = gen()
+    c = cells_by_kind(f, "coil")[0]
+    assert style_for_cell(c, ColorTier.TRUECOLOR).startswith("rgb(")
+
+
+def test_standard_styles_are_accent_mono():
+    f = gen(tier=ColorTier.STANDARD)
+    accent = style_for(Token.ACCENT, ColorTier.STANDARD)
+    coil = cells_by_kind(f, "coil")[0]
+    v = cells_by_kind(f, "v")[0]
+    assert style_for_cell(coil, ColorTier.STANDARD) == accent
+    assert style_for_cell(v, ColorTier.STANDARD) == f"bold {accent}"
+
+
+def test_cache_hit_same_object():
+    a = gen(cols=60)
+    b = gen(cols=60)
+    assert a is b        # lru_cache identity
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ui/test_crest.py -k "style or cache" -v`
+Expected: FAIL — `style_for_cell` not found
+
+- [ ] **Step 3: Implement**
+
+```python
+# in ui/crest.py
+from .theme import ColorTier, Token, style_for   # extend existing import
+
+
+def style_for_cell(cell: CrestCell, tier: ColorTier) -> str:
+    """Resolve one cell's Rich style for the tier. TRUECOLOR/C256 carry the
+    per-cell gradient (Rich downgrades 24-bit for 256 terminals); STANDARD
+    collapses to the single accent (geometry + trace unchanged)."""
+    if tier >= ColorTier.C256:
+        r, g, b = cell.rgb
+        return f"rgb({r},{g},{b})"
+    accent = style_for(Token.ACCENT, tier)
+    if cell.kind == "v":
+        return f"bold {accent}"
+    return accent
+```
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/ui/test_crest.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/ui/crest.py tests/ui/test_crest.py
+git commit -m "feat(ov): tier-resolved crest cell styles
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 5: `ui/awakening.py` — the conductor (mounts WakeSequenceRenderer)
+
+**Files:**
+- Create: `backend/core/ouroboros/ui/awakening.py`
+- Test: `tests/ui/test_awakening.py`
+- Read first: `backend/core/ouroboros/ui/wake_sequence.py` (the renderer being mounted — Mandate 3), `backend/core/ouroboros/battle_test/stream_renderer.py` (16ms cadence pattern).
+
+**Interfaces:**
+- Consumes: `generate_crest`/`style_for_cell`/`CrestFrame` (Tasks 3-4), `WakeSequenceRenderer` (existing), `theme.build_console`/`detect_tier`/`supports_unicode`/`active_tier`.
+- Produces (Task 6 and Task 8 rely on these):
+
+```python
+class AwakeningConductor:
+    def __init__(self, console, *, timer=None,
+                 on_ignition: Optional[Callable[[], None]] = None,
+                 context_provider: Optional[Callable[[], str]] = None,
+                 clock: Callable[[], float] = time.monotonic,
+                 key_source: Optional[Callable[[], bytes]] = None) -> None
+    typed_prefix: str            # non-skip bytes typed during the ceremony
+    async def run(self) -> None  # whole ceremony; NEVER raises; returns after cool-down
+    def request_skip(self) -> None
+
+async def run_awakening(console=None, **kwargs) -> "AwakeningConductor"
+```
+
+**Behavior contract (from spec §3.2 + §10):**
+1. Guards: `JARVIS_OV_AWAKENING_ENABLED` false, non-TTY (`sys.__stdout__` isatty), crest `unavailable_reason` ⇒ plain path: attach `WakeSequenceRenderer` to the timer and flush plain frames until `model.is_live` or a 20s guard timeout, then print the cooled header. No Live.
+2. Animated path: Rich `Live` at ≤16ms refresh; frame = `Group(crest_text(elapsed), wake.render_frame())` where `crest_text` reveals cells with `delay_s <= elapsed`.
+3. `on_ignition` fires exactly once when `elapsed >= frame.max_delay_s`.
+4. After ignition: eye-pulse tick (alternate eye style bright/brighter each ~0.8s) + hold until `wake.model.is_live` (or 20s guard).
+5. Cool-down: 3 sub-frames over ~0.4s (full gradient → all-accent tint → collapse), then Live closes and the cooled header prints once: `ov · ouroboros   live` styled line + one muted context line from `context_provider()` (fallback: `""` → header only, but production always passes a provider).
+6. Skip: `key_source` (injectable; production reads stdin raw non-blocking via `select` + `os.read` in cbreak mode, restoring termios in `finally`): bytes `\x1b` (Esc) or `\r`/`\n` (Enter) ⇒ `request_skip()` ⇒ jump to cool-down; ALL other bytes append to `typed_prefix` (never swallowed, never skip).
+7. NEVER raises; any exception ⇒ plain path fallback; logs DEBUG to `logging.getLogger("Ouroboros.UI.Awakening")`.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/ui/test_awakening.py
+"""AwakeningConductor: mounts the EXISTING WakeSequenceRenderer (Mandate 3),
+ignites exactly once, skips only on Esc/Enter, buffers typed input, cools
+down exactly once, and NEVER raises (spec §3.2, §9.5)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from rich.console import Console
+
+from backend.core.ouroboros.ui.awakening import AwakeningConductor
+from backend.core.ouroboros.ui import theme
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+    def __call__(self):
+        return self.t
+
+
+class FakeTimer:
+    """Duck-typed BootTimer: captures the observer for manual driving."""
+    def __init__(self):
+        self.observers = []
+    def add_observer(self, cb):
+        self.observers.append(cb)
+    def emit(self, name, in_flight):
+        class R:  # PhaseRecord duck
+            pass
+        r = R(); r.name = name; r.is_in_flight = in_flight
+        for cb in self.observers:
+            cb(r)
+
+
+def make_conductor(**kw):
+    console = Console(file=open("/dev/null", "w"), force_terminal=True,
+                      width=80, color_system="truecolor")
+    theme.ensure_theme(console)
+    clock = kw.pop("clock", FakeClock())
+    timer = kw.pop("timer", FakeTimer())
+    c = AwakeningConductor(console, timer=timer, clock=clock, **kw)
+    return c, clock, timer
+
+
+@pytest.mark.asyncio
+async def test_ignition_fires_exactly_once():
+    fired = []
+    c, clock, timer = make_conductor(on_ignition=lambda: fired.append(1))
+    timer.emit("sensors online", False)
+    task = asyncio.create_task(c.run())
+    for _ in range(400):
+        clock.t += 0.05
+        await asyncio.sleep(0.001)
+        if fired:
+            break
+    clock.t += 30.0                      # blow past hold guard + cool-down
+    await asyncio.wait_for(task, timeout=5.0)
+    assert fired == [1]
+
+
+@pytest.mark.asyncio
+async def test_esc_skips_and_enter_skips_but_other_keys_buffer():
+    for skip_byte in (b"\x1b", b"\r", b"\n"):
+        feed = [b"g", b"i", skip_byte]
+        c, clock, timer = make_conductor(
+            key_source=lambda f=feed: f.pop(0) if f else b"")
+        timer.emit("loop armed", False)
+        task = asyncio.create_task(c.run())
+        for _ in range(200):
+            clock.t += 0.05
+            await asyncio.sleep(0.001)
+            if task.done():
+                break
+        clock.t += 30.0
+        await asyncio.wait_for(task, timeout=5.0)
+        assert c.typed_prefix == "gi"     # buffered, not swallowed
+
+
+@pytest.mark.asyncio
+async def test_live_honesty_holds_until_model_live():
+    c, clock, timer = make_conductor()
+    timer.emit("venom priming", True)     # still in flight
+    task = asyncio.create_task(c.run())
+    clock.t += 3.0                        # trace done, but NOT live
+    await asyncio.sleep(0.01)
+    assert not task.done()                # holding (breathing)
+    timer.emit("venom priming", False)    # now live
+    clock.t += 30.0
+    await asyncio.wait_for(task, timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_render_failure_never_raises(monkeypatch):
+    c, clock, timer = make_conductor()
+    monkeypatch.setattr(c, "_render_crest_text",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    timer.emit("sensors online", False)
+    clock.t += 60.0
+    await asyncio.wait_for(c.run(), timeout=5.0)   # must complete silently
+
+
+@pytest.mark.asyncio
+async def test_awakening_disabled_env_goes_plain(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_AWAKENING_ENABLED", "false")
+    c, clock, timer = make_conductor()
+    timer.emit("sensors online", False)
+    clock.t += 60.0
+    await asyncio.wait_for(c.run(), timeout=5.0)
+    assert c.used_plain_path is True
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ui/test_awakening.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement `ui/awakening.py`** per the behavior contract above. Key structure:
+
+```python
+# backend/core/ouroboros/ui/awakening.py  (skeleton -- implement fully)
+class AwakeningConductor:
+    def __init__(self, console, *, timer=None, on_ignition=None,
+                 context_provider=None, clock=time.monotonic, key_source=None):
+        self._console = console
+        self._wake = WakeSequenceRenderer(console)      # MOUNTED, not rebuilt
+        if timer is not None:
+            self._wake.attach(timer)                    # existing observer API
+        ...
+        self.typed_prefix = ""
+        self.used_plain_path = False
+
+    async def run(self) -> None:
+        try:
+            frame = self._generate_frame()
+            if self._should_go_plain(frame):
+                await self._run_plain()
+                return
+            await self._run_animated(frame)
+        except Exception:
+            logger.debug("[awakening] falling back to plain", exc_info=True)
+            try:
+                await self._run_plain()
+            except Exception:
+                pass
+```
+
+Implementation notes:
+- `_generate_frame()` measures `self._console.size` and calls
+  `generate_crest(size.width, size.height, tier=detect_tier(self._console), unicode_ok=supports_unicode())`.
+- `_run_animated`: `with Live(console=..., auto_refresh=False, transient=True) as live:` loop at `await asyncio.sleep(0.016)`; poll `key_source` each tick; compose crest Text (per-cell `Text.append(glyph, style=style_for_cell(cell, tier))` positioned via row assembly) + `self._wake.render_frame()`; ignition when `elapsed >= frame.max_delay_s` (guard `self._ignited` bool; call `on_ignition` in try/except).
+- Hold: `while not self._wake.model.is_live and elapsed < ignition_time + 20.0 and not self._skip:` breathe.
+- Cool-down: render 2 tint frames then exit Live (transient erases it), then `console.print` the cooled header (accent `ov` · heading `ouroboros` · success `live`) and the muted `context_provider()` line.
+- Production `key_source=None` ⇒ construct the termios/cbreak reader ONLY when `sys.__stdout__ is not None and sys.__stdout__.isatty()` and stdin is a tty; wrap all termios calls in try/except (never fatal); restore settings in `finally`.
+- `_run_plain`: `self.used_plain_path = True`; loop `flush(now)` on the wake renderer (it prints plain frames) until `model.is_live` or 20s; print cooled header once.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/ui/test_awakening.py -v`
+Expected: 5 PASS (parametrized skip = 7 asserts total)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/ui/awakening.py tests/ui/test_awakening.py
+git commit -m "feat(ov): awakening conductor -- crest trace + mounted wake sequence + Esc/Enter skip
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 6: SIGWINCH / resize mid-animation (Mandate 4 proof)
+
+**Files:**
+- Modify: `backend/core/ouroboros/ui/awakening.py` (per-tick size check + regeneration)
+- Test: `tests/ui/test_awakening_resize.py`
+
+**Interfaces:**
+- Consumes: Task 5's conductor internals.
+- Produces: resize-safe animation; `conductor.regenerations: int` counter for tests.
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/ui/test_awakening_resize.py
+"""SIGWINCH proof (spec §9.2): mid-trace resize regenerates the crest at the
+new measurement, reveal stays monotonic, cool-down intact. Plus a real
+POSIX SIGWINCH delivery against a pty-backed console."""
+from __future__ import annotations
+
+import asyncio
+import os
+import signal
+import sys
+
+import pytest
+from rich.console import Console
+
+from backend.core.ouroboros.ui.awakening import AwakeningConductor
+from backend.core.ouroboros.ui import theme
+from tests.ui.test_awakening import FakeClock, FakeTimer
+
+
+class ResizableConsole(Console):
+    """Console whose reported size we mutate mid-run."""
+    _forced = (80, 30)
+    @property
+    def size(self):
+        from rich.console import ConsoleDimensions
+        return ConsoleDimensions(*self._forced)
+
+
+@pytest.mark.asyncio
+async def test_mid_trace_resize_regenerates_and_stays_monotonic():
+    console = ResizableConsole(file=open("/dev/null", "w"),
+                               force_terminal=True, color_system="truecolor")
+    theme.ensure_theme(console)
+    clock, timer = FakeClock(), FakeTimer()
+    c = AwakeningConductor(console, timer=timer, clock=clock)
+    timer.emit("sensors online", False)
+
+    revealed_counts = []
+    orig = c._render_crest_text
+    def spy(frame, elapsed, tier):
+        revealed = sum(1 for cell in frame.cells if cell.delay_s <= elapsed)
+        revealed_counts.append((frame.cols, revealed / max(1, len(frame.cells))))
+        return orig(frame, elapsed, tier)
+    c._render_crest_text = spy
+
+    task = asyncio.create_task(c.run())
+    for i in range(120):
+        clock.t += 0.02
+        await asyncio.sleep(0.001)
+        if i == 40:
+            ResizableConsole._forced = (50, 30)     # SIGWINCH effect
+    clock.t += 60.0
+    await asyncio.wait_for(task, timeout=5.0)
+
+    assert c.regenerations >= 1
+    cols_seen = {cols for cols, _ in revealed_counts}
+    assert 50 in cols_seen                            # regenerated at new width
+    # monotonic reveal FRACTION across the resize boundary (no flash-back)
+    fracs = [f for _, f in revealed_counts]
+    assert all(b >= a - 1e-9 for a, b in zip(fracs, fracs[1:]))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal test")
+def test_real_sigwinch_does_not_crash_animation():
+    """Deliver a real SIGWINCH while the conductor animates on a pty."""
+    import pty
+    pid, fd = pty.fork()
+    if pid == 0:  # child: run a short awakening against the pty
+        try:
+            import asyncio as aio
+            from rich.console import Console as C
+            from backend.core.ouroboros.ui.awakening import AwakeningConductor as A
+            from backend.core.ouroboros.ui import theme as th
+            console = C(force_terminal=True, color_system="truecolor")
+            th.ensure_theme(console)
+            from tests.ui.test_awakening import FakeTimer as FT
+            t = FT()
+            c = A(console, timer=t)
+            t.emit("sensors online", False)
+            aio.get_event_loop().run_until_complete(
+                aio.wait_for(c.run(), timeout=15.0))
+            os._exit(0)
+        except BaseException:
+            os._exit(3)
+    else:
+        import time as _t
+        _t.sleep(0.4)
+        os.kill(pid, signal.SIGWINCH)                 # the real signal
+        _, status = os.waitpid(pid, 0)
+        assert os.WEXITSTATUS(status) == 0
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/ui/test_awakening_resize.py -v`
+Expected: FAIL — no `regenerations` attribute / resize not handled
+
+- [ ] **Step 3: Implement resize handling in the animated loop**
+
+```python
+# inside AwakeningConductor._run_animated tick loop:
+size = self._console.size
+if (size.width, size.height) != self._last_size:
+    self._last_size = (size.width, size.height)
+    new_frame = self._generate_frame()
+    if new_frame.unavailable_reason is None:
+        # remap: delays are angle-derived, so identical elapsed reveals the
+        # same arc fraction on the new frame -- monotonic by construction
+        frame = new_frame
+        self.regenerations += 1
+    else:
+        self._skip = True          # too small now -> graceful cool-down
+```
+
+Initialize `self.regenerations = 0` and `self._last_size` in `__init__`.
+(No signal handler needed: Rich re-reads the size, and per-tick measurement is
+signal-free and thread-safe; the pty test proves real-SIGWINCH safety.)
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/ui/test_awakening_resize.py tests/ui/test_awakening.py -v`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/ui/awakening.py tests/ui/test_awakening_resize.py
+git commit -m "feat(ov): resize-reactive awakening -- regeneration + monotonic reveal + SIGWINCH proof
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 7: Karen boot briefing + circuit breaker (mathematically proven)
+
+**Files:**
+- Create: `backend/core/ouroboros/governance/comms/karen_boot_briefing.py`
+- Test: `tests/voice/test_karen_boot_briefing.py`
+- Read first: `backend/core/ouroboros/governance/comms/karen_synth/synthesizer.py` (the `synthesize(view) -> AsyncIterator[str]` contract), `ledger_view.py` (`LedgerView.from_payload`, `strip_code`).
+
+**Interfaces:**
+- Consumes: `KarenSpeechSynthesizer` duck (injected), `LedgerView.from_payload(phase, payload)`, `strip_code`.
+- Produces (Task 8 wires these):
+
+```python
+@dataclass
+class BriefingVectors:
+    last_session: Optional[str] = None
+    queued_ops: Optional[int] = None
+    posture: Optional[str] = None
+    pending_approvals: Optional[int] = None
+    @property
+    def empty(self) -> bool: ...
+
+async def gather_vectors(*, intake_probe=None, approvals_probe=None) -> BriefingVectors
+def compose_local(v: BriefingVectors) -> str
+class BootBriefing:
+    def __init__(self, *, synthesizer=None, speak_sink=None, text_sink=None,
+                 timeout_s: Optional[float] = None,
+                 vectors_override: Optional[BriefingVectors] = None) -> None
+    async def run(self) -> str        # returns the delivered line; NEVER raises
+def build_default_synthesizer() -> Optional[object]
+```
+
+- [ ] **Step 1: Write the failing tests**
+
+```python
+# tests/voice/test_karen_boot_briefing.py
+"""Boot briefing: live-state composition, DW primary, 4s breaker that
+provably falls back to the LOCAL live-state line without stalling (spec
+§3.3, Mandate 4). No canned strings: every output embeds real vectors."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.karen_boot_briefing import (
+    BootBriefing, BriefingVectors, compose_local, gather_vectors,
+)
+
+
+V = BriefingVectors(last_session="apply=AUTO/3 verify=4/4 commit=9f3c21ab",
+                    queued_ops=2, posture="EXPLORE", pending_approvals=1)
+
+
+class SlowSynth:
+    """Synthesizer that never completes inside the deadline."""
+    def __init__(self):
+        self.cancelled = False
+    async def synthesize(self, view):
+        try:
+            await asyncio.sleep(30)
+            yield "never"
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class GoodSynth:
+    async def synthesize(self, view):
+        yield "Right then -- awake."
+        yield "Two ops queued overnight."
+
+
+def test_compose_local_embeds_live_vectors():
+    line = compose_local(V)
+    assert "2" in line and "EXPLORE".lower() in line.lower()
+    assert "1" in line                       # pending approval surfaced
+
+
+def test_compose_local_empty_state_is_factual_not_boilerplate():
+    line = compose_local(BriefingVectors())
+    assert "first session" in line.lower()
+
+
+@pytest.mark.asyncio
+async def test_breaker_falls_back_fast_without_stalling():
+    """MATHEMATICAL PROOF (Mandate 4): wall-clock bound. timeout=0.2s; a
+    30s-hanging LLM must yield the local fallback in < 1.0s."""
+    spoken = []
+    synth = SlowSynth()
+    b = BootBriefing(synthesizer=synth, speak_sink=spoken.append,
+                     timeout_s=0.2, vectors_override=V)
+    loop = asyncio.get_event_loop()
+    t0 = loop.time()
+    line = await b.run()
+    elapsed = loop.time() - t0
+    assert elapsed < 1.0                     # CLI init NOT stalled
+    assert "2" in line                       # fallback is the LIVE-state line
+    assert spoken and spoken[-1] == line
+    await asyncio.sleep(0.05)
+    assert synth.cancelled is True           # hung task actually cancelled
+
+
+@pytest.mark.asyncio
+async def test_primary_path_speaks_sentences():
+    spoken = []
+    b = BootBriefing(synthesizer=GoodSynth(), speak_sink=spoken.append,
+                     timeout_s=2.0, vectors_override=V)
+    line = await b.run()
+    assert spoken == ["Right then -- awake.", "Two ops queued overnight."]
+    assert "awake" in line.lower()
+
+
+@pytest.mark.asyncio
+async def test_no_synthesizer_goes_straight_to_local():
+    spoken = []
+    b = BootBriefing(synthesizer=None, speak_sink=spoken.append,
+                     vectors_override=V)
+    line = await b.run()
+    assert "2" in line and spoken == [line]
+
+
+@pytest.mark.asyncio
+async def test_voice_off_text_sink_only():
+    texts = []
+    b = BootBriefing(synthesizer=None, speak_sink=None, text_sink=texts.append,
+                     vectors_override=V)
+    line = await b.run()
+    assert texts == [line]
+
+
+@pytest.mark.asyncio
+async def test_run_never_raises(monkeypatch):
+    class ExplodingSynth:
+        async def synthesize(self, view):
+            raise RuntimeError("provider exploded")
+            yield  # pragma: no cover
+    b = BootBriefing(synthesizer=ExplodingSynth(),
+                     speak_sink=lambda s: (_ for _ in ()).throw(RuntimeError("sink!")),
+                     vectors_override=V)
+    line = await b.run()                     # absolutely must not raise
+    assert isinstance(line, str)
+
+
+@pytest.mark.asyncio
+async def test_gather_vectors_is_fault_isolated(monkeypatch):
+    def bad_probe():
+        raise RuntimeError("intake exploded")
+    v = await gather_vectors(intake_probe=bad_probe, approvals_probe=None)
+    assert v.queued_ops is None              # absent, not raised
+```
+
+- [ ] **Step 2: Run to verify failure**
+
+Run: `python3 -m pytest tests/voice/test_karen_boot_briefing.py -v`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the module**
+
+```python
+# backend/core/ouroboros/governance/comms/karen_boot_briefing.py
+"""Karen's boot briefing -- the awakening's voice (spec §3.3).
+
+Live vectors -> Sprint-2 speech pipeline (LedgerView filters -> persona ->
+DW -> sentence chunks -> arbiter) behind a hard asyncio.wait_for breaker.
+Fallback is a LOCAL deterministic composition over the SAME vectors --
+state-driven prose, never canned boilerplate. Fire-and-forget by contract:
+run() NEVER raises and never blocks boot beyond its own awaited deadline.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass
+from typing import Callable, List, Optional
+
+from .karen_synth.ledger_view import LedgerView, strip_code
+
+logger = logging.getLogger("Ouroboros.Karen.BootBriefing")
+
+_TIMEOUT_ENV = "JARVIS_KAREN_BOOT_BRIEF_TIMEOUT_S"
+
+
+@dataclass
+class BriefingVectors:
+    last_session: Optional[str] = None
+    queued_ops: Optional[int] = None
+    posture: Optional[str] = None
+    pending_approvals: Optional[int] = None
+
+    @property
+    def empty(self) -> bool:
+        return all(v is None for v in
+                   (self.last_session, self.queued_ops, self.posture,
+                    self.pending_approvals))
+
+
+async def gather_vectors(*, intake_probe: Optional[Callable[[], Optional[int]]] = None,
+                         approvals_probe: Optional[Callable[[], Optional[int]]] = None,
+                         ) -> BriefingVectors:
+    """Best-effort, read-only, per-vector fault isolation. NEVER raises."""
+    v = BriefingVectors()
+    loop = asyncio.get_event_loop()
+    try:
+        from backend.core.ouroboros.governance.last_session_summary import (
+            get_default_summary,
+        )
+        v.last_session = await loop.run_in_executor(
+            None, get_default_summary().format_for_prompt_sync)
+    except Exception:  # noqa: BLE001
+        logger.debug("[briefing] last_session vector unavailable", exc_info=True)
+    try:
+        from backend.core.ouroboros.governance.posture_palette import (
+            read_current_posture_safe,
+        )
+        reading = await loop.run_in_executor(None, read_current_posture_safe)
+        if reading is not None:
+            v.posture = str(getattr(reading, "posture", "") or "") or None
+    except Exception:  # noqa: BLE001
+        logger.debug("[briefing] posture vector unavailable", exc_info=True)
+    for probe, attr in ((intake_probe, "queued_ops"),
+                        (approvals_probe, "pending_approvals")):
+        if probe is None:
+            continue
+        try:
+            setattr(v, attr, probe())
+        except Exception:  # noqa: BLE001
+            logger.debug("[briefing] %s vector unavailable", attr, exc_info=True)
+    return v
+
+
+def compose_local(v: BriefingVectors) -> str:
+    """Deterministic prose over LIVE vectors (the breaker's landing pad).
+    Never a canned greeting: every clause carries real state."""
+    if v.empty:
+        return "Awake. First session on this repo."
+    parts: List[str] = ["Awake."]
+    if v.queued_ops:
+        plural = "s" if v.queued_ops != 1 else ""
+        parts.append(f"{v.queued_ops} op{plural} queued overnight.")
+    if v.pending_approvals:
+        plural = "s" if v.pending_approvals != 1 else ""
+        parts.append(f"{v.pending_approvals} awaiting your sign-off.")
+    if v.posture:
+        parts.append(f"Posture {v.posture}.")
+    if v.last_session and len(parts) == 1:
+        parts.append(f"Last session: {strip_code(v.last_session)[:120]}.")
+    return " ".join(parts)
+
+
+class BootBriefing:
+    def __init__(self, *, synthesizer: Optional[object] = None,
+                 speak_sink: Optional[Callable[[str], None]] = None,
+                 text_sink: Optional[Callable[[str], None]] = None,
+                 timeout_s: Optional[float] = None,
+                 vectors_override: Optional[BriefingVectors] = None) -> None:
+        self._synth = synthesizer
+        self._speak = speak_sink
+        self._text = text_sink
+        self._timeout = timeout_s if timeout_s is not None else float(
+            os.environ.get(_TIMEOUT_ENV, "4.0"))
+        self._vectors_override = vectors_override
+
+    async def run(self) -> str:
+        """Deliver the briefing. NEVER raises. Bounded by the breaker."""
+        try:
+            v = self._vectors_override or await gather_vectors()
+            line = ""
+            if self._synth is not None:
+                line = await self._primary(v)
+            if not line:
+                line = compose_local(v)
+                self._deliver(line)
+            return line
+        except Exception:  # noqa: BLE001
+            logger.debug("[briefing] run failed", exc_info=True)
+            return ""
+
+    async def _primary(self, v: BriefingVectors) -> str:
+        """DW path under the breaker. Returns "" on any failure/timeout."""
+        payload = {
+            "summary": compose_local(v),
+            "queued_ops": v.queued_ops, "posture": v.posture,
+            "pending_approvals": v.pending_approvals,
+            "last_session": v.last_session,
+        }
+        view = LedgerView.from_payload("boot", payload)
+        spoken: List[str] = []
+
+        async def _consume() -> None:
+            async for sentence in self._synth.synthesize(view):
+                safe = strip_code(sentence).strip()
+                if safe:
+                    spoken.append(safe)
+                    self._deliver(safe)
+
+        task = asyncio.get_event_loop().create_task(_consume())
+        try:
+            await asyncio.wait_for(task, timeout=self._timeout)
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+            if not spoken:
+                logger.debug("[briefing] breaker tripped -> local fallback")
+                return ""
+        return " ".join(spoken)
+
+    def _deliver(self, line: str) -> None:
+        for sink in (self._speak, self._text):
+            if sink is None:
+                continue
+            try:
+                sink(line)
+            except Exception:  # noqa: BLE001
+                logger.debug("[briefing] sink failed", exc_info=True)
+            return                        # speak wins; text is the fallback
+
+
+def build_default_synthesizer() -> Optional[object]:
+    """Best-effort production synthesizer (DW -> Karen). None on any failure
+    -- the breaker's local path covers it."""
+    try:
+        from backend.core.ouroboros.governance.doubleword_provider import (
+            DoublewordProvider,
+        )
+        from .karen_synth.speech_provider import DWSpeechProvider
+        from .karen_synth.synthesizer import KarenSpeechSynthesizer
+        if not os.environ.get("DOUBLEWORD_API_KEY"):
+            return None
+        return KarenSpeechSynthesizer(DWSpeechProvider(DoublewordProvider()))
+    except Exception:  # noqa: BLE001
+        logger.debug("[briefing] default synthesizer unavailable", exc_info=True)
+        return None
+
+
+__all__ = ["BriefingVectors", "BootBriefing", "gather_vectors",
+           "compose_local", "build_default_synthesizer"]
+```
+
+> Check `KarenSpeechSynthesizer.__init__` (synthesizer.py:20) for its exact
+> parameters before wiring `build_default_synthesizer` — pass the provider
+> as it expects (positional `provider` or keyword). Adjust the one call site.
+
+- [ ] **Step 4: Run to verify pass**
+
+Run: `python3 -m pytest tests/voice/test_karen_boot_briefing.py -v`
+Expected: 8 PASS — including the wall-clock breaker proof (< 1.0s with a 30s-hanging synth) and the cancellation assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/comms/karen_boot_briefing.py tests/voice/test_karen_boot_briefing.py
+git commit -m "feat(karen): boot briefing -- live vectors, DW primary, proven 4s breaker fallback
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 8: production wiring — default Karen sink + harness cockpit hook
+
+**Files:**
+- Modify: `backend/core/ouroboros/governance/comms/duplex/karen_duplex_factory.py` (default-handle singleton, mirroring `voice_command_sensor.set_default_voice_sensor`)
+- Modify: `backend/audio/audio_pipeline_bootstrap.py` (register/clear the default handle at Karen mount/stop, ~lines 195-202 and the shutdown path)
+- Modify: `backend/core/ouroboros/battle_test/harness.py` (cockpit branch at the boot-banner block, ~lines 1212-1259; REPL `initial_text` handoff at ~1366)
+- Test: `tests/voice/duplex/test_default_karen_handle.py`, `tests/battle_test/test_awakening_hook.py`
+
+**Interfaces:**
+- Consumes: everything from Tasks 1-7.
+- Produces: `set_default_karen(handle) / get_default_karen()` in `karen_duplex_factory`; harness helper `build_awakening_for_cockpit(console, *, intake_probe, approvals_probe) -> AwakeningConductor` (module-level in `harness.py`, unit-testable).
+
+- [ ] **Step 1: Write the failing singleton tests**
+
+```python
+# tests/voice/duplex/test_default_karen_handle.py
+"""Default-Karen singleton -- the same late-binding pattern as
+voice_command_sensor.set_default_voice_sensor (Sprint 4)."""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.comms.duplex import karen_duplex_factory as kdf
+
+
+def test_default_handle_roundtrip():
+    sentinel = object()
+    kdf.set_default_karen(sentinel)
+    try:
+        assert kdf.get_default_karen() is sentinel
+    finally:
+        kdf.set_default_karen(None)
+    assert kdf.get_default_karen() is None
+```
+
+- [ ] **Step 2: Run to verify failure, then implement**
+
+Run: `python3 -m pytest tests/voice/duplex/test_default_karen_handle.py -v` → FAIL.
+
+In `karen_duplex_factory.py` add (module level, bottom):
+
+```python
+_DEFAULT_KAREN: Optional[KarenDuplexHandle] = None
+
+
+def set_default_karen(handle: Optional["KarenDuplexHandle"]) -> None:
+    """Publish the mounted duplex handle for late-binding consumers (boot
+    briefing). Same pattern as intake's set_default_voice_sensor."""
+    global _DEFAULT_KAREN
+    _DEFAULT_KAREN = handle
+
+
+def get_default_karen() -> Optional["KarenDuplexHandle"]:
+    return _DEFAULT_KAREN
+```
+
+In `audio_pipeline_bootstrap.py`: after `handle.karen = build_karen_duplex(handle.tts_engine)` + `await handle.karen.start()` add `set_default_karen(handle.karen)` (import alongside `build_karen_duplex`); in the `except` that sets `handle.karen = None` and in `shutdown()` where Karen stops, call `set_default_karen(None)`.
+
+Run: `python3 -m pytest tests/voice/duplex/test_default_karen_handle.py tests/voice/duplex/ -q` → PASS (existing duplex suite still green).
+
+- [ ] **Step 3: Write the failing harness-hook test**
+
+```python
+# tests/battle_test/test_awakening_hook.py
+"""Cockpit hook: harness builds the conductor with briefing wired to
+on_ignition; SOAK builds nothing (spec §3.5)."""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.harness import build_awakening_for_cockpit
+from backend.core.ouroboros.ui.awakening import AwakeningConductor
+from rich.console import Console
+from backend.core.ouroboros.ui import theme
+
+
+def test_builder_returns_wired_conductor(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_PRESENTATION", "cockpit")
+    console = Console(file=open("/dev/null", "w"), force_terminal=True,
+                      width=80, color_system="truecolor")
+    theme.ensure_theme(console)
+    conductor = build_awakening_for_cockpit(
+        console, intake_probe=lambda: 2, approvals_probe=lambda: 0)
+    assert isinstance(conductor, AwakeningConductor)
+    assert conductor._on_ignition is not None      # briefing wired
+
+
+def test_builder_returns_none_in_soak(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_PRESENTATION", "soak")
+    console = Console(file=open("/dev/null", "w"))
+    assert build_awakening_for_cockpit(console, intake_probe=None,
+                                       approvals_probe=None) is None
+```
+
+- [ ] **Step 4: Run to verify failure, then implement the harness hook**
+
+Run: `python3 -m pytest tests/battle_test/test_awakening_hook.py -v` → FAIL.
+
+4a. Add to `harness.py` (module level, near the top-level helpers):
+
+```python
+def build_awakening_for_cockpit(console, *, intake_probe=None, approvals_probe=None):
+    """COCKPIT boot skin factory. Returns None in SOAK (spec §3.5). The
+    briefing rides on_ignition fire-and-forget; its failure can never
+    touch boot (breaker + NEVER-raises contract in the composer)."""
+    from backend.core.ouroboros.ui.presentation_mode import is_cockpit
+    if not is_cockpit():
+        return None
+    import asyncio
+    from backend.core.ouroboros.ui.awakening import AwakeningConductor
+    from backend.core.ouroboros.battle_test.boot_timing import get_default_timer
+    from backend.core.ouroboros.governance.comms.karen_boot_briefing import (
+        BootBriefing, build_default_synthesizer, compose_local, gather_vectors,
+    )
+
+    briefing_tasks = []
+
+    def _speak_sink(line: str) -> None:
+        try:
+            from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (
+                get_default_karen,
+            )
+            karen = get_default_karen()
+            if karen is not None:
+                karen.submit_speech(line)
+                return
+        except Exception:
+            pass
+        console.print(f"  \U0001f4ad Karen ▸ “{line}”",
+                      style="muted", markup=False)
+
+    def _on_ignition() -> None:
+        briefing = BootBriefing(
+            synthesizer=build_default_synthesizer(),
+            speak_sink=_speak_sink,
+        )
+        briefing_tasks.append(asyncio.get_event_loop().create_task(briefing.run()))
+
+    def _context_line() -> str:
+        import datetime
+        parts = [f"awakened {datetime.datetime.now().strftime('%H:%M')}"]
+        try:
+            n = intake_probe() if intake_probe else None
+            if n:
+                parts.append(f"{n} ops queued")
+        except Exception:
+            pass
+        return " · ".join(parts)
+
+    conductor = AwakeningConductor(
+        console, timer=get_default_timer(),
+        on_ignition=_on_ignition, context_provider=_context_line,
+    )
+    conductor._briefing_tasks = briefing_tasks     # keep references (no GC)
+    return conductor
+```
+
+4b. In `harness.run()` locate the compact-boot-banner block (~1212-1259,
+`self._serpent_flow.boot_banner(...)`). Branch (SerpentFlow owns the themed
+console — `self._serpent_flow.console`, built via `theme.build_console` at
+serpent_flow.py:679):
+
+```python
+    _awakening = build_awakening_for_cockpit(
+        self._serpent_flow.console,
+        intake_probe=self._intake_pending_probe,      # see 4c
+        approvals_probe=None,
+    )
+    if _awakening is not None:
+        self._awakening_task = asyncio.create_task(_awakening.run())
+        self._awakening = _awakening
+    else:
+        # legacy SOAK banner path -- UNCHANGED
+        self._serpent_flow.boot_banner(...)
+```
+
+4c. Add a small probe method on the harness class (it owns the intake layer):
+
+```python
+    def _intake_pending_probe(self) -> Optional[int]:
+        try:
+            router = getattr(self, "_intake_router", None)
+            if router is not None and hasattr(router, "pending_ack_count"):
+                return int(router.pending_ack_count())
+        except Exception:
+            pass
+        return None
+```
+
+(Read the harness to find the real attribute holding the intake router /
+layer — grep `intake` in `boot_intake()` (~line 3156) and use the actual
+attribute name; `pending_ack_count` exists on `unified_intake_router`.)
+
+4d. REPL handoff: where `SerpentREPL(` is constructed (~1366), pass
+`initial_text=getattr(self, "_awakening", None) and self._awakening.typed_prefix or ""`
+— add an `initial_text: str = ""` parameter to `SerpentREPL.__init__` that
+pre-fills the first `prompt_async(default=initial_text)` call. Before the
+REPL starts, `await self._awakening_task` if set (the ceremony must finish
+before the prompt appears; it self-bounds at ~20s worst case).
+
+- [ ] **Step 5: Run the tests + full affected suites**
+
+Run: `python3 -m pytest tests/battle_test/test_awakening_hook.py tests/voice/ tests/ui/ -q 2>&1 | tail -5`
+Expected: all PASS
+Run: `python3 -m pytest tests/battle_test/ -q 2>&1 | tail -5`
+Expected: green (SOAK regression intact)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add backend/core/ouroboros/governance/comms/duplex/karen_duplex_factory.py backend/audio/audio_pipeline_bootstrap.py backend/core/ouroboros/battle_test/harness.py tests/voice/duplex/test_default_karen_handle.py tests/battle_test/test_awakening_hook.py
+git commit -m "feat(ov): cockpit awakening wired into harness boot -- briefing on ignition, REPL prefix handoff
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+### Task 9: guard extensions + full regression + ledger
+
+**Files:**
+- Modify: `tests/ui/test_theme_guard.py` (extend the banned-pattern net)
+- Modify: `.superpowers/sdd/progress.md` (ledger entry at execution time)
+
+- [ ] **Step 1: Extend the guard test**
+
+Append to the guard's banned-pattern scan (matching its existing structure —
+read it first) a check over `scripts/ouroboros_battle_test.py`:
+
+```python
+def test_boot_banners_only_called_via_gate():
+    """The three banner functions may be CALLED only inside
+    _run_gated_boot_banners (Mandate 1 made permanent)."""
+    import pathlib, re
+    src = pathlib.Path("scripts/ouroboros_battle_test.py").read_text()
+    gate_body = src.split("def _run_gated_boot_banners", 1)[1].split("\ndef ", 1)[0]
+    for fn in ("_print_preflight()", "_single_flight_preflight()"):
+        calls_outside = src.count(fn) - gate_body.count(fn)
+        assert calls_outside == 0, f"{fn} called outside the gate"
+```
+
+(If `_reap_zombies` took the `quiet=` route in Task 1, assert instead that
+every call site passes an explicit `quiet=` argument.)
+
+- [ ] **Step 2: Run everything**
+
+Run: `python3 -m pytest tests/ui/ tests/cli/ tests/voice/ tests/battle_test/ -q 2>&1 | tail -8`
+Expected: full green.
+
+- [ ] **Step 3: Manual smoke (cockpit + soak skins)**
+
+```bash
+JARVIS_OV_PRESENTATION=cockpit python3 -c "
+from backend.core.ouroboros.ui.crest import generate_crest
+from backend.core.ouroboros.ui.theme import ColorTier
+f = generate_crest(60, 24, tier=ColorTier.TRUECOLOR, unicode_ok=True)
+print('crest cells:', len(f.cells), 'max_delay:', f.max_delay_s)"
+```
+Expected: a cell count > 200 and max_delay ≥ 1.55.
+Then eyeball `ov run --help`-level SOAK output unchanged (no code path change).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/ui/test_theme_guard.py
+git commit -m "test(ov): guard -- banner calls locked inside the presentation gate
+
+Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>"
+```
+
+---
+
+## Acceptance (after all tasks): the live-mic gate
+
+Local, interactive, on real hardware (spec §9.8) — this is the sprint's
+finish line, run by the human:
+
+1. `ov` → crest animates (trace → eye → V), cools to header + prompt.
+2. Karen speaks a briefing referencing real state (queued ops / last session).
+3. Speak over her mid-briefing → she stops (barge-in preemption).
+4. Speak a build command → a real op appears in the governed loop.
+5. Karen's own voice does not retrigger VAD (AEC holds).
+6. `ov run` in a second terminal → full SOAK banners, byte-familiar.
+7. `Esc` during a fresh `ov` boot → instant cooled prompt; typing `sta` during
+   the animation leaves `sta` in the first prompt.

--- a/docs/superpowers/specs/2026-07-07-ov-awakening-cli-design.md
+++ b/docs/superpowers/specs/2026-07-07-ov-awakening-cli-design.md
@@ -1,0 +1,372 @@
+# Spec: The `ov` Awakening — Product Boot Experience + Karen Boot Briefing
+
+**Date:** 2026-07-07
+**Author:** Derek J. Russell (design conducted with Claude)
+**Status:** Design — approved in session; awaiting written-spec review before implementation plan
+**Scope tag:** UX Polish · Sprint 2 of the "O+V as a product" program
+**Predecessor:** `2026-07-06-ov-theme-and-boot-cockpit-design.md` (Sprint 1 — theme engine, `ov` binary, wake-sequence renderer)
+
+---
+
+## 1. Context & problem statement
+
+Sprint 1 shipped the Restrained Mono theme engine, the packaged `ov` binary,
+and the `WakeSequenceRenderer` — but the renderer was **never wired into the
+boot** (zero importers; wired-but-inert), and bare `ov` still delegates
+straight into the battle-test soak harness, whose boot output is a debugging
+surface: Zombie Reaper banner, single-flight report, full Preflight Checklist,
+and an INFO-level log flood — much of it raw ANSI that predates the theme.
+
+**Category mismatch:** a soak-debug harness is the product's front door.
+`claude` opens with a quiet branded canvas; `ov` opens with a wall of
+diagnostics.
+
+This sprint makes `ov` boot as an **awakening**: the organism's ouroboros
+crest draws itself alive, Karen speaks a live-state briefing, real boot
+readiness renders honestly beneath, and the whole ceremony cools into the
+restrained teal working surface. The soak workflow keeps its verbose output
+untouched.
+
+### Approved design decisions (from session iteration)
+
+| Decision | Outcome |
+|---|---|
+| Brand vs. restraint | **Threshold ritual**: full-chroma crest at boot only → cools to Restrained Mono. Evolves Sprint 1 §2's "no logomark" — consciously superseded for the boot moment only. |
+| The mark | **Crest v5**: procedurally generated serpent — solid fill, hard-edge quadrant rendering (no anti-aliasing/blur), scale-free gradient, tail tapering into the open mouth, wedge head with ignited eye, thick flat-topped block V. |
+| Static assets | **None.** The crest is generated at runtime from geometry (pure math, <50ms, cached). One geometry source, tier-resolved. |
+| Karen at boot | **Dynamic briefing** composed from live system vectors via the shipped Sprint-2 speech pipeline, with a local live-state fallback breaker. |
+| Working surface | **Option A — frameless flow.** After cool-down: one cooled header line, then the existing themed REPL surfaces. The serpent lives only in the awakening. |
+| Clean-boot architecture | **Option 1 — presentation-layer split.** `ov` conducts presentation; the harness keeps the one 6-layer boot ordering; banner emission sites gate at the source. |
+
+### Non-goals
+
+- `ov attach` / daemon transport (still a follow-up sprint).
+- First-run onboarding wizard.
+- Any new authority surface. The awakening is presentation + voice only.
+- Changing soak/CI/graduation-run output (SOAK mode is byte-identical).
+- Serpent-framed `/split` cockpit (Option C was declined — may revisit later).
+- iTerm2/kitty inline-image logo blit (optional garnish, explicitly cut).
+
+---
+
+## 2. Global constraints (every task inherits these)
+
+1. **CLI/terminal only.** Text cells + ANSI truecolor inside the existing
+   prompt_toolkit REPL and `patch_stdout(raw=True)` model. No GUI, no web.
+2. **Theme-tier degradable.** All rendering routes through `ui/theme.py`'s
+   ladder (TRUECOLOR → C256 → STANDARD → NONE). Zero escape leakage at NONE.
+   TTY detection uses `real_stdout_isatty` (`sys.__stdout__`) — never
+   `sys.stdout.isatty()` (fails under `patch_stdout`).
+3. **REPL-safe.** The awakening must not block the event loop, corrupt
+   scrollback, or delay fatal-error visibility. NEVER-raises contract on all
+   render paths.
+4. **Root-cause only (Mandate 1).** Harness banner suppression happens by
+   conditional logic **at each emission source**. No global stdout redirect,
+   no stream wrapper, no regex filter in `ov.py`. The ERROR/CRITICAL bypass
+   is **structural**: fatal telemetry does not route through the gate at all,
+   so no gate state can suppress it.
+5. **Reactive geometry (Mandate 2).** `ui/crest.py` scales proportionally
+   from `console.size` measured at execution time, clamped to sane bounds.
+   No hardcoded padding, no fixed canvas dimensions.
+6. **Thin conductor (Mandate 3).** `ui/awakening.py` orchestrates existing
+   components — it embeds `WakeSequenceRenderer` + `WakeModel` and subscribes
+   via `BootTimer.add_observer`. It must not invent a redundant phase-tracking
+   loop. `cli/ov.py` stays a facade: it sets presentation mode and delegates
+   to the one shared bootstrap; zero boot-ordering logic.
+7. **Bulletproof (Mandate 4).** The test strategy MUST include a SIGWINCH
+   mid-animation resize proof (§9.2) and the ERROR-bypass proof (§9.3).
+8. **Env-var driven config**, `from __future__ import annotations`,
+   Python 3.9+ (`asyncio.wait_for`, not `asyncio.timeout`) — repo standards.
+9. **Karen reuse (Sprint-2 DRY).** Boot briefing reuses `LedgerView`-shaped
+   payload filtering (`strip_code`), persona prompt, `DWSpeechProvider`,
+   `KarenSpeechSynthesizer`, and the `VoiceDuplexArbiter` — no parallel
+   speech path.
+
+---
+
+## 3. Architecture — components
+
+### 3.1 New: `backend/core/ouroboros/ui/crest.py`
+
+Procedural crest generator. Imports: stdlib + `ui.theme` only (leaf module,
+same dependency rule as `theme.py`).
+
+**Geometry (ported from the approved v5 generator):**
+- Annulus (coil) with mouth gap at the top; body thickness tapers over the
+  final ~52° of arc and the tail tip **intrudes ~15° into the gap**, thinning
+  between the jaws.
+- Wedge head (capsule, narrowing to snout) at the gap's clockwise edge,
+  open-mouth notch cut from the snout half; eye disc offset inside the head.
+- Thick V: two stroke capsules meeting at a point, **flat machined top**
+  (samples above the top line rejected).
+- Hard-edge rendering: each cell = 2×2 subpixels; each subpixel supersampled
+  (3×3) and **thresholded at 0.5 coverage** — no anti-aliasing, no blending
+  (the approved fix for v4's blur). Quadrant glyph lookup (16 patterns).
+  Isolated single-quadrant crumb cells (no orthogonal neighbor) are removed.
+- Pixel aspect correction (~1.08 vertical) so the coil renders circular.
+
+**Reactivity (Mandate 2 — normative):** the generator takes the measured
+console width/height at call time and derives ALL radii/thickness/V metrics
+proportionally from a single scale factor, clamped to
+`[CREST_MIN_COLS, min(measured, CREST_MAX_COLS)]` (defaults 46/72, env
+overridable). Below `CREST_MIN_COLS` or insufficient height the crest reports
+`unavailable` and the awakening degrades (§6). Zero absolute dimensions.
+
+**Output:** `CrestFrame` — per-cell `(x, y, glyph, style_or_rgb, kind,
+trace_delay_s)` where `kind ∈ {coil, head, eye, v}`; gradient color and
+trace delay both derived from arc angle (tail=0 → head=1). Tier resolution:
+
+| Tier | Color treatment |
+|---|---|
+| TRUECOLOR | Per-cell RGB gradient (green → gold → purple circulation) |
+| C256 | Same RGB, Rich color downgrade |
+| STANDARD | Single `accent` style for coil/head, bold for V — geometry + trace identical |
+| NONE / no-unicode | Crest unavailable — caller degrades to plain wake lines |
+
+Result cached per `(cols-bucket, rows-bucket, tier)`; regeneration on
+resize is cheap (<50ms budget, pure math).
+
+### 3.2 New: `backend/core/ouroboros/ui/awakening.py`
+
+The awakening conductor — a **thin orchestrator** (Mandate 3):
+
+- Owns one Rich `Live` region (16ms max refresh, mirroring
+  `stream_renderer.py` cadence) rendering: crest (animated by revealing cells
+  whose `trace_delay ≤ elapsed`) above the **embedded**
+  `WakeSequenceRenderer` output (real `BootTimer` phases via `add_observer`
+  — the Sprint-1 module finally wired, not reimplemented).
+- **Eye-ignition callback:** when the trace completes (elapsed ≥ max delay),
+  invokes the injected `on_ignition` callable exactly once — production wires
+  this to the Karen briefing submission (§4). Injection keeps `ui/` free of
+  governance imports (dependency rule preserved).
+- **Breathing:** post-trace, a slow brightness modulation on coil styles
+  (style-table swap per pulse tick, bounded) until boot phases complete.
+- **"live" honesty:** the final state renders only when `WakeModel.is_live`
+  — animation completion NEVER fakes readiness (Sprint-1 §5 principle).
+- **Cool-down:** ~400ms staged recolor of crest cells toward `accent`/muted →
+  Live region replaced by the single cooled header line
+  (`ov · ouroboros   live` + one muted context line) → returns control; the
+  REPL proceeds exactly as today.
+- **Skip:** any keypress (raw, non-blocking read while Live is active) jumps
+  straight to cool-down completion. Headless/non-TTY/NONE-tier/no-unicode/
+  narrow terminal → no Live at all: plain sequential wake lines (existing
+  fallback path).
+- **Resize (SIGWINCH):** on console size change mid-animation, the conductor
+  regenerates the crest for the new measurement (cache miss → recompute),
+  remaps elapsed trace time onto the new frame, and continues — no crash, no
+  fractured cells (proven by §9.2).
+- NEVER-raises: every callback and render wrapped; failure degrades to plain
+  wake lines and logs at DEBUG.
+
+### 3.3 New: `backend/core/ouroboros/governance/comms/karen_boot_briefing.py`
+
+`BootBriefingComposer` — gathers live vectors, composes speech, one breaker:
+
+- **Vectors (all read-only, each optional, gathered concurrently at boot
+  start):** LastSessionSummary tokens (`apply=…/N verify=P/T commit=…`),
+  queued-op count + top intent from intake, posture + confidence from the
+  DirectionInferrer triplet files, pending-approval count. A vector that
+  fails to read is simply absent — no exceptions escape the gather.
+- **Primary path (DRY, Sprint-2 pipeline):** vectors → briefing payload →
+  `strip_code`/`first_line` filters → persona prompt (Karen: Australian,
+  dry, high-SNR) → `DWSpeechProvider` → `KarenSpeechSynthesizer` →
+  `VoiceDuplexArbiter.submit` at `PROACTIVE_INFO`.
+- **Circuit breaker (Mandate 4 of the briefing decision):**
+  `asyncio.wait_for(…, timeout=JARVIS_KAREN_BOOT_BRIEF_TIMEOUT_S)` (default
+  4.0s). On timeout / provider error / empty result → **local deterministic
+  composition over the SAME gathered vectors** — state-driven prose, not a
+  canned greeting ("Awake. Two ops queued overnight; one awaiting your
+  sign-off."). Truly-empty state (fresh install) degrades to the still-
+  factual minimal line ("Awake. First session on this repo."). No generic
+  boilerplate strings disconnected from state (approved mandate).
+- **Voice-off** (`JARVIS_KAREN_VOICE_ENABLED` false): the composed line still
+  renders as the `💭` narrative line under the cooled header — silent but
+  observable (philosophy §7).
+- Entire briefing is a fire-and-forget task (reference retained); it can
+  never block, delay, or crash the boot. Karen speaking does not gate the
+  prompt; barge-in works from her first word (shipped duplex stack).
+
+### 3.4 Modified: `backend/core/ouroboros/cli/ov.py`
+
+Facade only. `cockpit` action: resolve presentation mode → set
+`JARVIS_OV_PRESENTATION=cockpit` (process-local env) → delegate to
+`scripts.ouroboros_battle_test.main(argv)` exactly as today. `run`/`daemon`
+continue to imply SOAK. No boot logic, no output manipulation (Mandate 1),
+no duplicated initialization (Mandate 3).
+
+### 3.5 Modified: harness presentation gate (root cause)
+
+`battle_test/harness.py` + `scripts/ouroboros_battle_test.py`:
+
+- `PresentationMode` enum {`COCKPIT`, `SOAK`} resolved once from
+  `JARVIS_OV_PRESENTATION` (default `SOAK` — legacy script and `ov run`
+  unchanged by construction).
+- **Each banner emission site branches at the source** (Mandate 1): zombie
+  reaper banner, single-flight report, `_print_preflight`, boot-timing
+  emit_summary chrome. COCKPIT: the content is withheld from stdout and
+  remains available via the existing `/preflight` + `/organism` verbs
+  (already designed to hold detail). SOAK: byte-identical current output
+  (golden-tested, §9.4).
+- Logging: COCKPIT sets root level WARNING (INFO flood gone).
+  **Structural ERROR/CRITICAL bypass:** fatal paths — the No-API-keys error,
+  single-flight conflict report, and any `logger.error/critical` — do not
+  pass through the gate's conditionals at all; they print/log unconditionally
+  in both modes. The gate can only ever withhold nominal-detail output.
+- The awakening hook: in COCKPIT mode the harness invokes
+  `ui.awakening.run_awakening(...)` (injected `on_ignition` → briefing) at
+  the point where SOAK prints its banners. One boot ordering, two skins.
+
+### 3.6 Working surface (after cool-down)
+
+Frameless flow (approved Option A): cooled header once, then today's themed
+surfaces — `live_status_line` bottom toolbar, narrative channel, op blocks,
+`ov ›` prompt. No persistent brand chrome. No changes required beyond the
+cooled-header print.
+
+---
+
+## 4. The awakening timeline (normative sequence)
+
+```
+t0      ov (cockpit) → PresentationMode=COCKPIT → shared bootstrap starts
+        briefing vector-gather task starts (concurrent, read-only)
+t0..    crest traces tail→body→head (~1.4s nominal) in the Live region;
+        real BootTimer phases render beneath via embedded WakeSequenceRenderer
+ignite  trace complete → eye pulse begins → on_ignition fires ONCE →
+        briefing submitted (DW primary / 4s breaker → local live-state line)
+hold    crest breathes until WakeModel.is_live (real readiness gates "live")
+cool    ~400ms recolor sweep → Live replaced by cooled header → REPL prompt
+after   Karen may still be speaking (independent audio plane; barge-in live)
+```
+
+Skip: keypress at any point → immediate cool-down completion (briefing still
+delivered). Headless / `ov run` / `ov daemon` / non-TTY / NONE tier /
+no-unicode / narrow terminal: no Live, plain wake lines; SOAK output where
+SOAK mode applies.
+
+---
+
+## 5. Flags & configuration
+
+| Flag | Default | Meaning |
+|---|---|---|
+| `JARVIS_OV_PRESENTATION` | `soak` | `cockpit` set by `ov` cockpit action; everything else soaks |
+| `JARVIS_OV_AWAKENING_ENABLED` | `true` | Master for the crest animation (cockpit only); `false` → cooled header directly |
+| `JARVIS_KAREN_BOOT_BRIEF_TIMEOUT_S` | `4.0` | DW breaker deadline for the boot briefing |
+| `JARVIS_KAREN_VOICE_ENABLED` | existing | Voice-off → briefing renders as text line only |
+| `JARVIS_OV_CREST_MIN_COLS` / `_MAX_COLS` | `46` / `72` | Reactive-geometry clamp bounds |
+| `JARVIS_UI_THEME_FORCE_TIER` | existing | Debug/test tier override (Sprint 1) |
+
+No rollback flag for the presentation gate itself: SOAK mode **is** the
+legacy renderer (mode default preserves it), mirroring Sprint 1's
+no-old-look-flag decision.
+
+---
+
+## 6. Degradation matrix
+
+| Condition | Behavior |
+|---|---|
+| TRUECOLOR + unicode + TTY + width ≥ min | Full crest: per-cell gradient, trace, eye pulse, breathing, cool-down |
+| C256 | Same geometry/animation, palette downgraded |
+| STANDARD (16) | Same geometry/trace, single accent color, bold V |
+| NONE / `NO_COLOR` / pipe | No crest; plain wake lines; zero escapes |
+| No unicode | Crest unavailable (quadrant glyphs required); plain wake lines |
+| Non-TTY / headless / `ov run` | No Live; plain lines; SOAK banners per mode |
+| Width < min or height insufficient | Crest skipped; cooled header only |
+| SIGWINCH mid-animation | Regenerate at new measurement; remap elapsed trace; continue (§9.2) |
+| DW down at boot | 4s breaker → local live-state briefing line |
+| Awakening render failure | NEVER-raises → plain wake lines, DEBUG log |
+| Fatal init failure | ERROR/CRITICAL bypass — full visibility in both modes |
+
+---
+
+## 7. What this sprint deliberately reuses (DRY ledger)
+
+| Existing asset | Role here |
+|---|---|
+| `ui/theme.py` | Tier detection, styles, console factory — untouched, consumed |
+| `ui/wake_sequence.py` | Embedded verbatim as the phase view (finally wired) |
+| `battle_test/boot_timing.py::add_observer` | Real-phase feed (Sprint 1 addition) |
+| `stream_renderer.py` 16ms cadence pattern | Live refresh discipline |
+| Sprint-2 Karen stack (`karen_synth/*`, duplex arbiter) | Entire speech path |
+| `LastSessionSummary`, intake queue, posture triplet | Briefing vectors |
+| `/preflight`, `/organism` verbs | Home for withheld banner detail |
+| Harness bootstrap + `battle_main(argv)` | The one boot ordering (facade delegation) |
+
+---
+
+## 8. Component/file map
+
+**New:**
+- `backend/core/ouroboros/ui/crest.py`
+- `backend/core/ouroboros/ui/awakening.py`
+- `backend/core/ouroboros/governance/comms/karen_boot_briefing.py`
+
+**Modified:**
+- `backend/core/ouroboros/cli/ov.py` (presentation-mode env + delegation only)
+- `backend/core/ouroboros/battle_test/harness.py` (PresentationMode + gated emission sites + awakening hook)
+- `scripts/ouroboros_battle_test.py` (gate at its banner sites: reaper, preflight, logging level)
+
+**Tests:**
+- `tests/ui/test_crest.py`, `tests/ui/test_awakening.py`
+- `tests/voice/test_karen_boot_briefing.py`
+- `tests/battle_test/test_presentation_gate.py`
+- `tests/ui/test_theme_guard.py` (extended)
+
+---
+
+## 9. Testing strategy (normative)
+
+1. **Crest invariants** — for widths {46, 60, 72, 100→clamped} × tiers
+   {TRUECOLOR, C256, STANDARD} (forced): solid interior (every coil cell's
+   ring-interior neighbors filled — no holes), zero isolated crumb cells,
+   tail-tip cells present inside the gap arc, eye cells present, V cells
+   present with flat top row; NONE tier / no-unicode → generator reports
+   unavailable; rendered NONE output contains no `\x1b[`. Geometry derived
+   values must differ across widths (proves reactivity — Mandate 2).
+2. **SIGWINCH resize proof (Mandate 4)** — drive the conductor with a fake
+   clock mid-trace, deliver a console-size change (direct resize injection
+   plus, on POSIX, a real `os.kill(os.getpid(), signal.SIGWINCH)` against a
+   pty-backed console), assert: no exception, crest regenerated at the new
+   measurement, elapsed-trace remap keeps monotonic reveal (no cell flashes
+   back to hidden), final cool-down header renders intact at the new width.
+3. **ERROR bypass proof (Mandate 1)** — in COCKPIT mode with the gate active:
+   inject `logger.error` + `logger.critical` records and the No-API-keys
+   fatal path; assert all reach the terminal stream; assert reaper/preflight
+   banners do NOT; assert `/preflight` verb still serves the withheld detail.
+4. **SOAK golden regression** — SOAK-mode boot banner output byte-identical
+   to pre-change capture (reaper text, preflight checklist, log level).
+5. **Conductor** — synthetic BootTimer feed → phases render beneath crest;
+   `on_ignition` fires exactly once; keypress skip → immediate cooled state;
+   "live" withheld until `WakeModel.is_live`; render-failure injection →
+   plain-lines fallback, no raise; headless → no Live.
+6. **Briefing** — synthetic vectors → composed text contains the live values;
+   forced DW timeout/error → fallback line contains the same live values
+   (proves state-driven fallback, not boilerplate); gather-failure per vector
+   → vector absent, no exception; voice-off → text-only render; whole task
+   time-boxed (never blocks the boot task).
+7. **Guard test extension** — grep-enforce: no banner `print(` outside the
+   gate in the touched harness regions; no raw ANSI constants reintroduced.
+8. **Live-mic acceptance gate (local, interactive — the finish line):**
+   1. `ov` on real hardware: crest animates, cools, prompt arrives.
+   2. Karen speaks a briefing that references real state (queued ops /
+      last session).
+   3. **Barge-in:** speak over her mid-briefing → she stops within the
+      arbiter's preemption latency.
+   4. **Spoken build command** → VoiceCommandSensor → a real op enters the
+      governed loop (visible in the op blocks).
+   5. **AEC:** Karen's own speech does not retrigger VAD/barge-in (no
+      self-echo loop).
+   6. `ov run` in a second terminal → full SOAK banners (regression eyeball).
+
+---
+
+## 10. Open questions for review
+
+1. **Cool-down destination line** — cooled header currently specced as
+   `ov · ouroboros   live` + one muted context line (`awakened HH:MM ·
+   N ops queued`). Keep the context line, or header only?
+2. **Skip key scope** — any keypress vs. Esc/Enter only? (Specced: any key.)
+3. **Crest max width 72** — bump for ultra-wide terminals, or keep the crest
+   intimate? (Specced: 72.)

--- a/docs/superpowers/specs/2026-07-07-ov-awakening-cli-design.md
+++ b/docs/superpowers/specs/2026-07-07-ov-awakening-cli-design.md
@@ -147,10 +147,13 @@ The awakening conductor — a **thin orchestrator** (Mandate 3):
   Live region replaced by the single cooled header line
   (`ov · ouroboros   live` + one muted context line) → returns control; the
   REPL proceeds exactly as today.
-- **Skip:** any keypress (raw, non-blocking read while Live is active) jumps
-  straight to cool-down completion. Headless/non-TTY/NONE-tier/no-unicode/
-  narrow terminal → no Live at all: plain sequential wake lines (existing
-  fallback path).
+- **Skip:** `Esc` or `Enter` ONLY (raw, non-blocking read while Live is
+  active) jumps straight to cool-down completion. Any other key is passed
+  through untouched — "any keypress" would swallow the first character of a
+  command typed during the wake phase and corrupt the REPL's stdin buffer
+  (approved §10 resolution 2). Headless/non-TTY/NONE-tier/no-unicode/narrow
+  terminal → no Live at all: plain sequential wake lines (existing fallback
+  path).
 - **Resize (SIGWINCH):** on console size change mid-animation, the conductor
   regenerates the crest for the new measurement (cache miss → recompute),
   remaps elapsed trace time onto the new frame, and continues — no crash, no
@@ -362,11 +365,17 @@ no-old-look-flag decision.
 
 ---
 
-## 10. Open questions for review
+## 10. Review resolutions (approved 2026-07-07)
 
-1. **Cool-down destination line** — cooled header currently specced as
-   `ov · ouroboros   live` + one muted context line (`awakened HH:MM ·
-   N ops queued`). Keep the context line, or header only?
-2. **Skip key scope** — any keypress vs. Esc/Enter only? (Specced: any key.)
-3. **Crest max width 72** — bump for ultra-wide terminals, or keep the crest
-   intimate? (Specced: 72.)
+1. **Cool-down destination line — RESOLVED: keep the context line.** The
+   cooled header is `ov · ouroboros   live` plus one muted context line
+   (`awakened HH:MM · N ops queued`), its values sourced from the same
+   briefing vector gather (LedgerView-shaped telemetry — DRY, high-SNR).
+   The header is never empty.
+2. **Skip key scope — RESOLVED: `Esc`/`Enter` only.** "Any keypress" would
+   swallow the first character of a command typed during the wake phase and
+   corrupt the REPL's stdin buffer (Bulletproof violation). All other keys
+   pass through untouched.
+3. **Crest max width — RESOLVED: hard clamp at 72 columns.** Generation
+   stays dynamic below the clamp; unbounded scalar growth on ultra-wide
+   viewports would disperse visual density and break Restrained Mono.

--- a/docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py
+++ b/docs/superpowers/specs/assets/2026-07-07-ov-crest-v5-generator.py
@@ -1,0 +1,242 @@
+#!/usr/bin/env python3
+"""Ouroboros crest v4 — fully-painted half-block rendering with anti-aliasing.
+
+Every cell is a ▀/▄ with fg+bg truecolor: the coil body is SOLID color,
+edges blend smoothly into the terminal background via supersampled coverage.
+This is the same technique terminal image renderers (chafa/timg) use, and it
+translates 1:1 to ANSI in the real CLI.
+
+Pixel grid: 1 cell = 1px wide x 2px tall. Pixel aspect corrected (x1.083).
+"""
+from __future__ import annotations
+import math
+import sys
+
+# ---- canvas ---------------------------------------------------------------
+CELL_W, CELL_H = 58, 17
+PX_W, PX_H = CELL_W, CELL_H * 2
+ASPECT = 1.083                    # physical height of one pixel / its width
+BG = (11, 14, 20)                 # #0b0e14 terminal background
+
+CX = PX_W / 2.0
+CY = (PX_H / 2.0) * ASPECT
+
+# ---- anatomy --------------------------------------------------------------
+R_MID = 11.6
+THICK = 3.5
+GAP_CENTER = math.radians(90)
+GAP_HALF = math.radians(20)
+TAPER_SWEEP = math.radians(52)
+TAIL_INTRUDE = math.radians(15)   # tail tip continues INTO the mouth
+
+HEAD_LEN = 5.6
+HEAD_W = 2.5
+
+V_TOP = 4.9
+V_BOT = 5.6
+V_HALF_SPAN = 4.8
+V_STROKE = 2.7
+
+SS = 3                            # supersample factor per pixel axis
+
+def ang_norm(a: float) -> float:
+    while a < 0: a += 2 * math.pi
+    while a >= 2 * math.pi: a -= 2 * math.pi
+    return a
+
+TAIL_TIP = ang_norm(GAP_CENTER + GAP_HALF)
+HEAD_THETA = ang_norm(GAP_CENTER - GAP_HALF)
+
+def in_gap(theta: float) -> bool:
+    d = abs(ang_norm(theta - GAP_CENTER))
+    if d > math.pi: d = 2 * math.pi - d
+    return d < GAP_HALF
+
+def body_half(theta: float) -> float:
+    d = ang_norm(theta - TAIL_TIP)          # 0 at tail tip, grows CCW along body
+    if d < TAPER_SWEEP:
+        t = d / TAPER_SWEEP
+        return (THICK * (0.34 + 0.66 * t)) / 2.0
+    return THICK / 2.0
+
+def sample_coil(px: float, py: float) -> bool:
+    dx, dy = px - CX, py - CY
+    r = math.hypot(dx, dy)
+    theta = math.atan2(-dy, dx)
+    if in_gap(theta):
+        # tail tip intrudes into the mouth as a thin point
+        d_from_tail_edge = ang_norm(TAIL_TIP - theta)
+        if d_from_tail_edge < TAIL_INTRUDE:
+            t = d_from_tail_edge / TAIL_INTRUDE          # 0 at gap edge -> 1 deep
+            half = (THICK * 0.34 / 2.0) * (1.0 - 0.72 * t)
+            return abs(r - R_MID) <= half
+        return False
+    return abs(r - R_MID) <= body_half(theta)
+
+def head_frame():
+    hx = CX + R_MID * math.cos(HEAD_THETA)
+    hy = CY - R_MID * math.sin(HEAD_THETA)
+    # snout points CCW along the tangent (toward the gap / tail tip)
+    tx = math.sin(HEAD_THETA)
+    ty = math.cos(HEAD_THETA)
+    return hx, hy, tx, ty
+
+def sample_head(px: float, py: float) -> bool:
+    hx, hy, tx, ty = head_frame()
+    dx, dy = px - hx, py - hy
+    lon = dx * tx + dy * ty
+    lat = -dx * ty + dy * tx
+    if lon < -1.6 or lon > HEAD_LEN:
+        return False
+    w = HEAD_W * (1.0 - 0.62 * max(0.0, lon / HEAD_LEN))
+    # open mouth: notch at the snout half
+    if lon > HEAD_LEN * 0.52 and abs(lat) < w * 0.34:
+        return False
+    return abs(lat) <= w
+
+def eye_center():
+    hx, hy, tx, ty = head_frame()
+    return hx + tx * 0.7 - ty * 1.05, hy + ty * 0.7 + tx * 1.05
+
+EYE_R = 0.95
+
+def sample_eye(px: float, py: float) -> bool:
+    ex, ey = eye_center()
+    return math.hypot(px - ex, py - ey) <= EYE_R
+
+def seg_dist(px, py, ax, ay, bx, by):
+    vx, vy = bx - ax, by - ay
+    wx, wy = px - ax, py - ay
+    t = max(0.0, min(1.0, (wx * vx + wy * vy) / (vx * vx + vy * vy)))
+    return math.hypot(px - (ax + t * vx), py - (ay + t * vy))
+
+def sample_v(px, py) -> bool:
+    if py < CY - V_TOP:                      # flat, machined top edge
+        return False
+    d1 = seg_dist(px, py, CX - V_HALF_SPAN, CY - V_TOP - 0.8, CX, CY + V_BOT)
+    d2 = seg_dist(px, py, CX + V_HALF_SPAN, CY - V_TOP - 0.8, CX, CY + V_BOT)
+    return min(d1, d2) <= V_STROKE / 2.0
+
+# ---- gradient ---------------------------------------------------------------
+STOPS = [
+    (0,   (125, 255, 106)),
+    (60,  (91, 227, 75)),
+    (150, (139, 92, 246)),
+    (210, (177, 108, 234)),
+    (285, (212, 192, 74)),
+    (360, (125, 255, 106)),
+]
+HEAD_COLOR = (125, 255, 106)
+EYE_COLOR = (234, 255, 208)
+V_TOP_C = (192, 132, 252)
+V_BOT_C = (157, 78, 220)
+
+def grad(frac: float):
+    deg = frac * 360.0
+    for (a0, c0), (a1, c1) in zip(STOPS, STOPS[1:]):
+        if a0 <= deg <= a1:
+            t = (deg - a0) / (a1 - a0) if a1 > a0 else 0
+            return tuple(c0[k] + t * (c1[k] - c0[k]) for k in range(3))
+    return STOPS[-1][1]
+
+# ---- render: hard-edge quadrants (2x2 subpixels per cell, no AA) -----------
+QUAD = {
+    0b0000: ' ', 0b1000: '▘', 0b0100: '▝', 0b1100: '▀',
+    0b0010: '▖', 0b1010: '▌', 0b0110: '▞', 0b1110: '▛',
+    0b0001: '▗', 0b1001: '▚', 0b0101: '▐', 0b1101: '▜',
+    0b0011: '▄', 0b1011: '▙', 0b0111: '▟', 0b1111: '█',
+}
+PRIORITY = ('eye', 'head', 'coil', 'v')
+
+def classify(px: float, py: float):
+    """Hard classification of one subpixel center-region (majority of SSxSS)."""
+    votes = {'eye': 0, 'head': 0, 'coil': 0, 'v': 0}
+    theta = None
+    for sy in range(SS):
+        for sx in range(SS):
+            spx = px + (sx + 0.5) / SS * 0.5
+            spy = py + ((sy + 0.5) / SS * 0.5) * ASPECT
+            if sample_eye(spx, spy):
+                votes['eye'] += 1
+            elif sample_head(spx, spy):
+                votes['head'] += 1
+            elif sample_coil(spx, spy):
+                votes['coil'] += 1
+                theta = math.atan2(-(spy - CY), spx - CX)
+            elif sample_v(spx, spy):
+                votes['v'] += 1
+    n = SS * SS
+    inside = sum(votes.values()) >= n / 2.0          # 0.5 coverage threshold
+    if not inside:
+        return None, None
+    k = max(PRIORITY, key=lambda kk: votes[kk])
+    return k, theta
+
+def render_cells():
+    """cell -> (glyph, kind, color, delay). Quadrant bit order: TL,TR,BL,BR."""
+    cells = {}
+    for cy_ in range(CELL_H):
+        for cx_ in range(CELL_W):
+            bits = 0
+            kinds, thetas = [], []
+            for i, (sx, sy) in enumerate([(0, 0), (1, 0), (0, 1), (1, 1)]):
+                # subpixel origin in physical units (cell is 1.0 wide, 2*ASPECT tall)
+                px = cx_ + sx * 0.5
+                py = (cy_ * 2 + sy) * ASPECT
+                k, th = classify(px, py)
+                if k is not None:
+                    bits |= 1 << (3 - i)
+                    kinds.append(k)
+                    if th is not None:
+                        thetas.append(th)
+            if not bits:
+                continue
+            kind = max(PRIORITY, key=lambda kk: kinds.count(kk)) if kinds else 'coil'
+            if kind == 'eye':
+                color, delay = EYE_COLOR, 1.55
+            elif kind == 'head':
+                color, delay = HEAD_COLOR, 1.42
+            elif kind == 'coil':
+                th = thetas[len(thetas) // 2] if thetas else 0.0
+                frac = ang_norm(th - TAIL_TIP) / (2 * math.pi)
+                color = tuple(round(c) for c in grad(frac))
+                delay = 0.05 + 1.30 * frac
+            else:
+                t = max(0.0, min(1.0, (cy_ * 2 * ASPECT - (CY - V_TOP)) / (V_TOP + V_BOT)))
+                color = tuple(round(V_TOP_C[k2] + t * (V_BOT_C[k2] - V_TOP_C[k2])) for k2 in range(3))
+                delay = 1.78 + 0.5 * t
+            cells[(cx_, cy_)] = (QUAD[bits], kind, color, delay)
+    # cleanup: drop isolated single-quadrant crumbs (no orthogonal neighbor)
+    dots = set('\u2598\u259d\u2596\u2597')
+    for (x, y) in [k for k, v in cells.items() if v[0] in dots]:
+        if not any((x + dx, y + dy) in cells for dx, dy in ((1,0),(-1,0),(0,1),(0,-1))):
+            del cells[(x, y)]
+    return cells
+
+def preview_cells(cells):
+    for y in range(CELL_H):
+        print(''.join(cells.get((x, y), (' ',))[0] for x in range(CELL_W)).rstrip())
+
+def html_cells(cells):
+    lines = []
+    for y in range(CELL_H):
+        parts, spaces = [], 0
+        for x in range(CELL_W):
+            cell = cells.get((x, y))
+            if cell is None:
+                spaces += 1
+                continue
+            if spaces:
+                parts.append(' ' * spaces); spaces = 0
+            ch, kind, c, d = cell
+            cls = 'px eyepx' if kind == 'eye' else 'px'
+            parts.append(f'<span class="{cls}" style="color:rgb({c[0]},{c[1]},{c[2]});animation-delay:{d:.2f}s">{ch}</span>')
+        lines.append(''.join(parts))
+    print('\n'.join(lines))
+
+if __name__ == '__main__':
+    cells = render_cells()
+    if '--html' in sys.argv:
+        html_cells(cells)
+    else:
+        preview_cells(cells)

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -447,7 +447,7 @@ def _reap_stale_jarvis_locks(
     return reaped
 
 
-def _single_flight_preflight() -> None:
+def _single_flight_preflight(*, quiet: bool = False) -> None:
     """Harness Epic Slice 2 — single-flight launcher enforcement.
 
     Rejects concurrent battle-test runs at the process level. Two checks:
@@ -481,6 +481,13 @@ def _single_flight_preflight() -> None:
 
     Disable via ``JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED=false`` (operator
     escape hatch — useful for diagnostics or recovery).
+
+    ov awakening Task 1 (Mandate 1): this guard is FUNCTIONAL (prevents two
+    sessions competing for budget/locks/branches) and runs in BOTH
+    presentation modes. ``quiet`` withholds only the happy-path diagnostic
+    chatter (the wedged-lock adoption note below, where the launch
+    proceeds). The conflict-path REJECTED block is ERROR-class telemetry
+    and prints unconditionally — no mode can suppress it.
     """
     from pathlib import Path as _Path
     import json as _json
@@ -546,12 +553,15 @@ def _single_flight_preflight() -> None:
                 if alive and fresh:
                     violators.append(("lock", holder_pid))
                 elif alive and not fresh:
-                    print(
-                        f"  {_DIM}[single-flight] adopting wedged lock "
-                        f"(PID={holder_pid} alive, age={age_s:.0f}s > "
-                        f"TTL={_stale_ttl:.0f}s — Py_FinalizeEx-class "
-                        f"zombie pattern){_RESET}"
-                    )
+                    # Happy-path chatter (launch proceeds) — the only
+                    # print this guard gates on ``quiet``.
+                    if not quiet:
+                        print(
+                            f"  {_DIM}[single-flight] adopting wedged lock "
+                            f"(PID={holder_pid} alive, age={age_s:.0f}s > "
+                            f"TTL={_stale_ttl:.0f}s — Py_FinalizeEx-class "
+                            f"zombie pattern){_RESET}"
+                        )
         except (ValueError, OSError, KeyError):
             pass  # corrupt lock — IntakeRouter._cleanup_stale_lock will handle
 
@@ -661,17 +671,21 @@ def _print_preflight() -> None:
 
 
 def _run_gated_boot_banners(
-    mode: PresentationMode, *, single_flight_enabled: bool, reap_enabled: bool,
+    mode: PresentationMode, *, reap_enabled: bool,
 ) -> None:
     """Nominal boot banners, gated AT THE SOURCE (Mandate 1). COCKPIT
     withholds; detail stays reachable via the /preflight + /organism verbs.
-    Fatal telemetry never routes through here."""
+    Fatal telemetry never routes through here.
+
+    Only pure ceremony belongs in this helper. FUNCTIONAL boot steps —
+    _check_api_keys_or_die, _single_flight_preflight (concurrent-launch
+    guard), and the zombie reap in main() — run unconditionally in both
+    modes at their own call sites; they must never be added back here.
+    """
     if mode is PresentationMode.COCKPIT:
         return
     if reap_enabled:
         _reap_zombies()
-    if single_flight_enabled:
-        _single_flight_preflight()
     _print_preflight()
 
 
@@ -1441,28 +1455,33 @@ def main(argv: "list[str] | None" = None) -> None:
     atexit.register(_lock_stack.close)
 
     # ------------------------------------------------------------------
-    # Harness Epic Slice 2 — single-flight preflight + preflight
-    # checklist. Reject concurrent battle-test runs at the process
-    # level; the zombie reap above kills DEAD lingering processes, this
-    # check rejects ALIVE concurrent processes (operator launched twice
-    # by accident, etc.). Exit 75 (EX_TEMPFAIL) signals "try again
-    # later" to wrappers — distinct from generic error code 1.
+    # Harness Epic Slice 2 — single-flight preflight. Reject concurrent
+    # battle-test runs at the process level; the zombie reap above kills
+    # DEAD lingering processes, this check rejects ALIVE concurrent
+    # processes (operator launched twice by accident, etc.). Exit 75
+    # (EX_TEMPFAIL) signals "try again later" to wrappers — distinct
+    # from generic error code 1.
     # Master flag: JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED (default true).
     #
-    # ov awakening Task 1 — gated at the source via
-    # _run_gated_boot_banners: COCKPIT withholds both the single-flight
-    # diagnostic prints and the preflight checklist banner; SOAK calls
-    # through in the legacy order. Reap already ran (functionally) above,
-    # so reap_enabled=False here — this call handles single-flight +
-    # preflight only.
+    # ov awakening Task 1 fix — this guard is FUNCTIONAL (prevents two
+    # sessions competing for budget), so it runs unconditionally in BOTH
+    # presentation modes, structurally outside _run_gated_boot_banners.
+    # COCKPIT gates only the happy-path chatter (quiet=True); the
+    # conflict-path REJECTED block prints in every mode (same Mandate 1
+    # rationale as _check_api_keys_or_die). It stays at this position —
+    # after the reap (dead-PID locks must be cleaned first, or this
+    # check false-positives on them) and after the singleton lock
+    # (structural defense fires before the pgrep diagnostic).
     # ------------------------------------------------------------------
-    _run_gated_boot_banners(
-        _mode,
-        single_flight_enabled=os.environ.get(
-            "JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", "true"
-        ).lower() not in ("false", "0", "no", "off"),
-        reap_enabled=False,
-    )
+    if os.environ.get("JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", "true").lower() not in ("false", "0", "no", "off"):
+        _single_flight_preflight(quiet=(_mode is PresentationMode.COCKPIT))
+
+    # ------------------------------------------------------------------
+    # Preflight checklist — pure ceremony, gated at the source: COCKPIT
+    # withholds, SOAK calls through. Reap already ran (functionally)
+    # above, so reap_enabled=False here.
+    # ------------------------------------------------------------------
+    _run_gated_boot_banners(_mode, reap_enabled=False)
 
     # ------------------------------------------------------------------
     # Logging

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -157,6 +157,13 @@ _PROJECT_ROOT = Path(__file__).resolve().parent.parent
 if str(_PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(_PROJECT_ROOT))
 
+# ov awakening Task 1 — presentation-mode gate (COCKPIT vs SOAK). Leaf
+# module: stdlib only, safe to import at top level now that _PROJECT_ROOT
+# is on sys.path. See backend/core/ouroboros/ui/presentation_mode.py.
+from backend.core.ouroboros.ui.presentation_mode import (  # noqa: E402
+    PresentationMode, resolve_presentation_mode,
+)
+
 # ANSI color codes
 _CYAN = "\033[96m"
 _GREEN = "\033[92m"
@@ -212,7 +219,7 @@ def _check_env_val(key: str, default: str = "") -> str:
     return os.environ.get(key, default)
 
 
-def _reap_zombies() -> "set[int]":
+def _reap_zombies(*, quiet: bool = False) -> "set[int]":
     """Detect and reap any lingering ouroboros_battle_test.py processes.
 
     A terminal disconnect or crashed session can leave the battle test
@@ -234,6 +241,12 @@ def _reap_zombies() -> "set[int]":
     PID between SIGKILL and the probe, making a just-killed PID look
     "alive" again under a fresh unrelated occupant. Closes the boot
     coordination gap between reaper and lock cleanup (2026-05-03).
+
+    ``quiet`` (ov awakening Task 1, Mandate 1) withholds the stdout
+    banner ceremony only — the scan/terminate/kill side effects below
+    are functional and run unconditionally in either mode. Callers in
+    COCKPIT presentation mode pass ``quiet=True`` so lingering
+    processes are still reaped without flooding the clean boot.
     """
     try:
         import psutil  # type: ignore[import-untyped]
@@ -291,19 +304,23 @@ def _reap_zombies() -> "set[int]":
 
     reaped_pids: "set[int]" = {p.pid for p in victims}
 
-    print(f"\n{_BOLD}{_YELLOW}  Zombie Reaper{_RESET}")
-    print(f"{_DIM}  {'─' * 52}{_RESET}")
+    # Mandate 1: gate the banner ceremony at the source, not the
+    # scan/terminate/kill side effects below (those always run).
+    _emit = (lambda *_a, **_k: None) if quiet else print
+
+    _emit(f"\n{_BOLD}{_YELLOW}  Zombie Reaper{_RESET}")
+    _emit(f"{_DIM}  {'─' * 52}{_RESET}")
     for p in victims:
         try:
             age_s = time.time() - p.create_time()
             m, s = int(age_s) // 60, int(age_s) % 60
-            print(
+            _emit(
                 f"  {_YELLOW}→{_RESET} reaping PID {p.pid} "
                 f"{_DIM}(age {m}m{s:02d}s){_RESET}"
             )
             p.terminate()
         except (psutil.NoSuchProcess, psutil.AccessDenied) as exc:
-            print(f"  {_DIM}  skipped PID {p.pid}: {type(exc).__name__}{_RESET}")
+            _emit(f"  {_DIM}  skipped PID {p.pid}: {type(exc).__name__}{_RESET}")
 
     # Wait up to 3s for graceful shutdown, then SIGKILL holdouts.
     try:
@@ -313,13 +330,13 @@ def _reap_zombies() -> "set[int]":
     for p in alive:
         try:
             p.kill()
-            print(f"  {_RED}→{_RESET} SIGKILL PID {p.pid} {_DIM}(ignored SIGTERM){_RESET}")
+            _emit(f"  {_RED}→{_RESET} SIGKILL PID {p.pid} {_DIM}(ignored SIGTERM){_RESET}")
         except (psutil.NoSuchProcess, psutil.AccessDenied):
             pass
 
     count = len(victims)
     plural = "s" if count != 1 else ""
-    print(f"  {_GREEN}✓ reaped {count} zombie{plural}{_RESET}\n")
+    _emit(f"  {_GREEN}✓ reaped {count} zombie{plural}{_RESET}\n")
     return reaped_pids
 
 
@@ -555,18 +572,29 @@ def _single_flight_preflight() -> None:
         sys.exit(75)
 
 
+def _check_api_keys_or_die() -> None:
+    """FATAL preflight: no provider keys -> die loudly. Deliberately OUTSIDE
+    the presentation gate (Mandate 1): no mode can suppress this."""
+    if not os.environ.get("DOUBLEWORD_API_KEY") and not os.environ.get("ANTHROPIC_API_KEY"):
+        print(f"\n  {_RED}{_BOLD}ERROR: No API keys set.{_RESET}")
+        print(f"  {_RED}Export DOUBLEWORD_API_KEY or ANTHROPIC_API_KEY.{_RESET}\n")
+        sys.exit(1)
+
+
 def _print_preflight() -> None:
     """Print a preflight checklist showing what's enabled.
 
     Gap #7 Slice 1 — when ``JARVIS_PRESENTATION_RESTRAINT_ENABLED``
     is on, the verbose multi-line checklist is suppressed at boot.
     Operators retrieve the same content on demand via the ``/preflight``
-    REPL verb. The deeper API-key fail-fast (no providers set at all)
-    still happens — that's a hard error operators MUST see.
+    REPL verb.
+
+    ov awakening Task 1 — this is now pure presentation. The API-key
+    fail-fast lives in ``_check_api_keys_or_die()`` and is called
+    unconditionally by ``main()`` before this function runs, so this
+    function itself never exits the process.
     """
-    # Restraint mode: skip the verbose render, but still enforce the
-    # API-key fail-fast (the script exits with code 1 below if neither
-    # provider is configured — that's not chrome, it's a hard error).
+    # Restraint mode: skip the verbose render.
     try:
         from backend.core.ouroboros.battle_test.presentation_restraint import (
             is_restraint_enabled, suppress_diagnostic_logs,
@@ -582,13 +610,6 @@ def _print_preflight() -> None:
             suppress_diagnostic_logs()
         except Exception:
             pass
-        # Hard-fail check still runs (API keys must be present).
-        has_dw = bool(os.environ.get("DOUBLEWORD_API_KEY"))
-        has_claude = bool(os.environ.get("ANTHROPIC_API_KEY"))
-        if not has_dw and not has_claude:
-            print(f"\n  {_RED}{_BOLD}ERROR: No API keys set.{_RESET}")
-            print(f"  {_RED}Export DOUBLEWORD_API_KEY or ANTHROPIC_API_KEY.{_RESET}\n")
-            sys.exit(1)
         return
 
     print(f"\n{_BOLD}{_CYAN}  Preflight Checklist{_RESET}")
@@ -626,20 +647,42 @@ def _print_preflight() -> None:
     rounds = _check_env_val("JARVIS_GOVERNED_TOOL_MAX_ROUNDS", "10")
     print(f"\n{_DIM}  Tool rounds: {rounds} (deadline-based, safety ceiling){_RESET}")
 
-    # Check at least one provider
+    # Single-provider warnings (non-fatal; the "no keys at all" case is a
+    # hard error and lives in _check_api_keys_or_die, called before this
+    # function ever runs).
     has_dw = bool(os.environ.get("DOUBLEWORD_API_KEY"))
     has_claude = bool(os.environ.get("ANTHROPIC_API_KEY"))
-    if not has_dw and not has_claude:
-        print(f"\n  {_RED}{_BOLD}ERROR: No API keys set.{_RESET}")
-        print(f"  {_RED}Export DOUBLEWORD_API_KEY or ANTHROPIC_API_KEY.{_RESET}\n")
-        sys.exit(1)
-
     if not has_claude:
         print(f"\n  {_YELLOW}WARNING: ANTHROPIC_API_KEY not set — no Claude fallback.{_RESET}")
     if not has_dw:
         print(f"\n  {_YELLOW}WARNING: DOUBLEWORD_API_KEY not set — Claude only (expensive).{_RESET}")
 
     print()
+
+
+def _run_gated_boot_banners(
+    mode: PresentationMode, *, single_flight_enabled: bool, reap_enabled: bool,
+) -> None:
+    """Nominal boot banners, gated AT THE SOURCE (Mandate 1). COCKPIT
+    withholds; detail stays reachable via the /preflight + /organism verbs.
+    Fatal telemetry never routes through here."""
+    if mode is PresentationMode.COCKPIT:
+        return
+    if reap_enabled:
+        _reap_zombies()
+    if single_flight_enabled:
+        _single_flight_preflight()
+    _print_preflight()
+
+
+def _resolve_boot_log_level(mode: PresentationMode, *, verbose: bool = False) -> int:
+    """COCKPIT quiets the INFO flood to WARNING. -v always wins. ERROR and
+    CRITICAL pass at every level -- the gate lowers verbosity, filters nothing."""
+    if verbose:
+        return logging.DEBUG
+    if mode is PresentationMode.COCKPIT:
+        return logging.WARNING
+    return logging.INFO
 
 
 def _render_multi_op_and_exit(arg: str, *, color: bool) -> None:
@@ -1307,12 +1350,30 @@ def main(argv: "list[str] | None" = None) -> None:
     os.environ.setdefault("JARVIS_GOVERNANCE_MODE", "governed")
 
     # ------------------------------------------------------------------
+    # ov awakening Task 1 — resolve presentation mode + the structural
+    # fatal bypass (Mandate 1). Both read env populated by _load_env_files
+    # above, so this must come after it. _check_api_keys_or_die is
+    # deliberately unconditional and outside every gate below — no mode
+    # can suppress it.
+    # ------------------------------------------------------------------
+    _mode = resolve_presentation_mode()
+    _check_api_keys_or_die()
+
+    # ------------------------------------------------------------------
     # Zombie reaper — kill lingering battle tests from prior sessions
     # before they race us on API budget, git branches, and the intake
     # router lock. Opt-out with JARVIS_BATTLE_REAP_ZOMBIES=false.
+    #
+    # ov awakening Task 1: reaping + lock hygiene are FUNCTIONAL side
+    # effects and always run in both presentation modes — only the
+    # reaper's stdout banner is gated (quiet=True in COCKPIT). This is
+    # handled here rather than inside _run_gated_boot_banners below
+    # because _cleanup_stale_router_lock needs the reaped-PID set that
+    # helper's contract doesn't expose.
     # ------------------------------------------------------------------
-    if os.environ.get("JARVIS_BATTLE_REAP_ZOMBIES", "true").lower() not in ("false", "0", "no", "off"):
-        _reaped = _reap_zombies()
+    _reap_enabled = os.environ.get("JARVIS_BATTLE_REAP_ZOMBIES", "true").lower() not in ("false", "0", "no", "off")
+    if _reap_enabled:
+        _reaped = _reap_zombies(quiet=(_mode is PresentationMode.COCKPIT))
         _cleanup_stale_router_lock(reaped_pids=_reaped)
         # Slice 48 — sweep multi-day stale .jarvis/*.lock debris (flock
         # auto-releases on death; these are inert crumbs that accumulate).
@@ -1380,26 +1441,33 @@ def main(argv: "list[str] | None" = None) -> None:
     atexit.register(_lock_stack.close)
 
     # ------------------------------------------------------------------
-    # Harness Epic Slice 2 — single-flight preflight.
-    # Reject concurrent battle-test runs at the process level. The
-    # zombie reap above kills DEAD lingering processes; this check
-    # rejects ALIVE concurrent processes (operator launched twice by
-    # accident, etc.). Exit 75 (EX_TEMPFAIL) signals "try again later"
-    # to wrappers — distinct from generic error code 1.
+    # Harness Epic Slice 2 — single-flight preflight + preflight
+    # checklist. Reject concurrent battle-test runs at the process
+    # level; the zombie reap above kills DEAD lingering processes, this
+    # check rejects ALIVE concurrent processes (operator launched twice
+    # by accident, etc.). Exit 75 (EX_TEMPFAIL) signals "try again
+    # later" to wrappers — distinct from generic error code 1.
     # Master flag: JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED (default true).
+    #
+    # ov awakening Task 1 — gated at the source via
+    # _run_gated_boot_banners: COCKPIT withholds both the single-flight
+    # diagnostic prints and the preflight checklist banner; SOAK calls
+    # through in the legacy order. Reap already ran (functionally) above,
+    # so reap_enabled=False here — this call handles single-flight +
+    # preflight only.
     # ------------------------------------------------------------------
-    if os.environ.get("JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", "true").lower() not in ("false", "0", "no", "off"):
-        _single_flight_preflight()
-
-    # ------------------------------------------------------------------
-    # Preflight checklist
-    # ------------------------------------------------------------------
-    _print_preflight()
+    _run_gated_boot_banners(
+        _mode,
+        single_flight_enabled=os.environ.get(
+            "JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", "true"
+        ).lower() not in ("false", "0", "no", "off"),
+        reap_enabled=False,
+    )
 
     # ------------------------------------------------------------------
     # Logging
     # ------------------------------------------------------------------
-    log_level = logging.DEBUG if args.verbose else logging.INFO
+    log_level = _resolve_boot_log_level(_mode, verbose=args.verbose)
     logging.basicConfig(
         level=log_level,
         format=(

--- a/tests/battle_test/test_awakening_hook.py
+++ b/tests/battle_test/test_awakening_hook.py
@@ -1,0 +1,28 @@
+"""Cockpit hook: harness builds the conductor with briefing wired to
+on_ignition; SOAK builds nothing (spec §3.5)."""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.battle_test.harness import build_awakening_for_cockpit
+from backend.core.ouroboros.ui.awakening import AwakeningConductor
+from rich.console import Console
+from backend.core.ouroboros.ui import theme
+
+
+def test_builder_returns_wired_conductor(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_PRESENTATION", "cockpit")
+    console = Console(file=open("/dev/null", "w"), force_terminal=True,
+                      width=80, color_system="truecolor")
+    theme.ensure_theme(console)
+    conductor = build_awakening_for_cockpit(
+        console, intake_probe=lambda: 2, approvals_probe=lambda: 0)
+    assert isinstance(conductor, AwakeningConductor)
+    assert conductor._on_ignition is not None      # briefing wired
+
+
+def test_builder_returns_none_in_soak(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_PRESENTATION", "soak")
+    console = Console(file=open("/dev/null", "w"))
+    assert build_awakening_for_cockpit(console, intake_probe=None,
+                                       approvals_probe=None) is None

--- a/tests/battle_test/test_harness_epic_graduation_pins_slice4.py
+++ b/tests/battle_test/test_harness_epic_graduation_pins_slice4.py
@@ -241,17 +241,28 @@ def test_slice_2_pin_single_flight_helper_exists():
     rationale.  This pin accepts the new shape so we don't fight
     ourselves; the anchor-specific test is the load-bearing one."""
     src = _read("scripts/ouroboros_battle_test.py")
-    assert "def _single_flight_preflight()" in src
+    # ov awakening Task 1: signature gained a keyword-only ``quiet`` param
+    # (COCKPIT gates only happy-path chatter; the guard + its REJECTED
+    # conflict output run in both presentation modes) — pin the def-line
+    # prefix, not the exact zero-arg shape.
+    assert "def _single_flight_preflight(" in src
     assert r'"^python3? scripts/ouroboros_battle_test\.py"' in src
     assert "sys.exit(75)" in src
 
 
 def test_slice_2_pin_single_flight_runs_after_zombie_reap():
     """Slice 2 — single-flight check runs AFTER the zombie reap so it
-    doesn't false-trip on dead-PID lockholders the reaper can clean."""
+    doesn't false-trip on dead-PID lockholders the reaper can clean.
+
+    ov awakening Task 1: both are direct mode-independent calls in
+    main() (each takes ``quiet=...`` in COCKPIT), so the search is
+    scoped to main()'s body and matches the call prefix."""
     src = _read("scripts/ouroboros_battle_test.py")
-    reap_idx = src.find("_reap_zombies()")
-    sf_idx = src.find("_single_flight_preflight()")
+    main_start = src.find("def main(")
+    assert main_start > 0
+    body = src[main_start:]
+    reap_idx = body.find("_reap_zombies(")
+    sf_idx = body.find("_single_flight_preflight(")
     assert reap_idx > 0
     assert sf_idx > reap_idx
 

--- a/tests/battle_test/test_presentation_gate.py
+++ b/tests/battle_test/test_presentation_gate.py
@@ -1,0 +1,68 @@
+"""Presentation gate: COCKPIT withholds banners at the SOURCE; fatal paths
+structurally bypass (Mandate 1). SOAK is call-through (legacy regression)."""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+import scripts.ouroboros_battle_test as bt
+from backend.core.ouroboros.ui.presentation_mode import PresentationMode
+
+
+def test_check_api_keys_or_die_exists_and_is_fatal(monkeypatch):
+    """The fatal check is its own function -- physically outside the gate."""
+    monkeypatch.delenv("DOUBLEWORD_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    with pytest.raises(SystemExit):
+        bt._check_api_keys_or_die()
+
+
+def test_check_api_keys_passes_with_key(monkeypatch):
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    bt._check_api_keys_or_die()   # no raise
+
+
+def test_print_preflight_no_longer_contains_fatal_exit(monkeypatch, capsys):
+    """_print_preflight is pure presentation now: with no keys it must NOT
+    exit -- the fatal lives in _check_api_keys_or_die (bypass proof)."""
+    monkeypatch.delenv("DOUBLEWORD_API_KEY", raising=False)
+    monkeypatch.delenv("ANTHROPIC_API_KEY", raising=False)
+    bt._print_preflight()          # must not raise SystemExit
+
+
+def test_gated_banner_helpers_skip_in_cockpit(monkeypatch):
+    """The boot path calls banners through _run_gated_boot_banners(mode);
+    COCKPIT skips them, SOAK calls through."""
+    calls = []
+    monkeypatch.setattr(bt, "_reap_zombies", lambda: calls.append("reap") or set())
+    monkeypatch.setattr(bt, "_single_flight_preflight", lambda: calls.append("sf"))
+    monkeypatch.setattr(bt, "_print_preflight", lambda: calls.append("pf"))
+
+    bt._run_gated_boot_banners(PresentationMode.COCKPIT, single_flight_enabled=True,
+                               reap_enabled=True)
+    assert calls == []             # all withheld at the source
+
+    bt._run_gated_boot_banners(PresentationMode.SOAK, single_flight_enabled=True,
+                               reap_enabled=True)
+    assert calls == ["reap", "sf", "pf"]   # legacy order preserved
+
+
+def test_resolve_boot_log_level_cockpit_is_warning():
+    assert bt._resolve_boot_log_level(PresentationMode.COCKPIT, verbose=False) == logging.WARNING
+    assert bt._resolve_boot_log_level(PresentationMode.SOAK, verbose=False) == logging.INFO
+    # verbose ALWAYS wins -- an operator asking for -v is never silenced
+    assert bt._resolve_boot_log_level(PresentationMode.COCKPIT, verbose=True) == logging.DEBUG
+
+
+def test_error_records_pass_in_cockpit(caplog):
+    """WARNING root level still delivers ERROR/CRITICAL -- the bypass is
+    structural: the gate only lowers verbosity, it filters nothing."""
+    level = bt._resolve_boot_log_level(PresentationMode.COCKPIT, verbose=False)
+    logger = logging.getLogger("test.cockpit.fatal")
+    with caplog.at_level(level, logger="test.cockpit.fatal"):
+        logger.error("initialization collapse")
+        logger.critical("fatal")
+    messages = [r.message for r in caplog.records]
+    assert "initialization collapse" in messages
+    assert "fatal" in messages

--- a/tests/battle_test/test_presentation_gate.py
+++ b/tests/battle_test/test_presentation_gate.py
@@ -33,19 +33,68 @@ def test_print_preflight_no_longer_contains_fatal_exit(monkeypatch, capsys):
 
 def test_gated_banner_helpers_skip_in_cockpit(monkeypatch):
     """The boot path calls banners through _run_gated_boot_banners(mode);
-    COCKPIT skips them, SOAK calls through."""
+    COCKPIT skips them, SOAK calls through. Single-flight is NOT in this
+    helper — it is a FUNCTIONAL guard invoked unconditionally by main()
+    (see the cockpit boot-path test below)."""
     calls = []
     monkeypatch.setattr(bt, "_reap_zombies", lambda: calls.append("reap") or set())
-    monkeypatch.setattr(bt, "_single_flight_preflight", lambda: calls.append("sf"))
     monkeypatch.setattr(bt, "_print_preflight", lambda: calls.append("pf"))
 
-    bt._run_gated_boot_banners(PresentationMode.COCKPIT, single_flight_enabled=True,
-                               reap_enabled=True)
+    bt._run_gated_boot_banners(PresentationMode.COCKPIT, reap_enabled=True)
     assert calls == []             # all withheld at the source
 
-    bt._run_gated_boot_banners(PresentationMode.SOAK, single_flight_enabled=True,
-                               reap_enabled=True)
-    assert calls == ["reap", "sf", "pf"]   # legacy order preserved
+    bt._run_gated_boot_banners(PresentationMode.SOAK, reap_enabled=True)
+    assert calls == ["reap", "pf"]   # legacy order preserved
+
+
+class _BootSentinel(Exception):
+    """Raised by the single-flight spy to halt main() before stack boot."""
+
+
+def test_single_flight_invoked_in_cockpit_boot_path(monkeypatch):
+    """Mandate 1 invariant: single-flight is a FUNCTIONAL concurrent-launch
+    guard (budget competition), not ceremony — main() must invoke it in
+    COCKPIT mode too, with quiet=True (chatter gated, guard live)."""
+    monkeypatch.setenv("JARVIS_OV_PRESENTATION", "cockpit")
+    monkeypatch.setenv("ANTHROPIC_API_KEY", "sk-test")
+    monkeypatch.delenv("JARVIS_BATTLE_SINGLE_FLIGHT_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_BATTLE_TEST_SINGLETON_LOCK_ENABLED", raising=False)
+    # Neutralize earlier boot steps (functional, but not under test here).
+    monkeypatch.setattr(bt, "_load_env_files", lambda: None)
+    monkeypatch.setattr(bt, "_reap_zombies", lambda quiet=False: set())
+    monkeypatch.setattr(bt, "_cleanup_stale_router_lock", lambda reaped_pids=None: None)
+    monkeypatch.setattr(bt, "_reap_stale_jarvis_locks", lambda *a, **k: 0)
+
+    calls = []
+
+    def _spy(*, quiet=False):
+        calls.append(("sf", quiet))
+        raise _BootSentinel  # stop main() before it boots the full stack
+
+    monkeypatch.setattr(bt, "_single_flight_preflight", _spy)
+
+    with pytest.raises(_BootSentinel):
+        bt.main([])
+    assert calls == [("sf", True)]   # invoked in COCKPIT, chatter-quiet
+
+
+def test_single_flight_conflict_output_not_suppressed(monkeypatch, capsys):
+    """The conflict path is ERROR-class telemetry: even with quiet=True
+    (COCKPIT), a detected concurrent run prints the REJECTED block and
+    exits 75 — the gate never carries fatal telemetry."""
+    import subprocess
+
+    class _FakePgrep:
+        returncode = 0
+        stdout = "99999999\n"   # a PID that is not this process
+
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: _FakePgrep())
+    with pytest.raises(SystemExit) as excinfo:
+        bt._single_flight_preflight(quiet=True)
+    assert excinfo.value.code == 75
+    out = capsys.readouterr().out
+    assert "REJECTED" in out
+    assert "99999999" in out
 
 
 def test_resolve_boot_log_level_cockpit_is_warning():

--- a/tests/battle_test/test_presentation_restraint_slice1.py
+++ b/tests/battle_test/test_presentation_restraint_slice1.py
@@ -446,14 +446,22 @@ def test_script_print_preflight_short_circuits_under_restraint():
 
 def test_script_still_enforces_api_key_fail_fast():
     """The hard-fail check (no providers configured) MUST run even
-    under restraint — that's not chrome, it's a structural error."""
+    under restraint — that's not chrome, it's a structural error.
+
+    ov awakening Task 1 (Mandate 1) extracted this check out of
+    ``_print_preflight`` into ``_check_api_keys_or_die`` -- a dedicated
+    function called unconditionally by ``main()`` before any
+    presentation-gated banner (restraint, COCKPIT, or SOAK). That's a
+    *stronger* guarantee than living inside ``_print_preflight`` (which
+    only ran under some launch paths) -- so this test now pins the new,
+    always-invoked location instead of the old one.
+    """
     src = (_REPO / "scripts/ouroboros_battle_test.py").read_text()
     tree = ast.parse(src)
     for node in ast.walk(tree):
-        if isinstance(node, ast.FunctionDef) and node.name == "_print_preflight":
+        if isinstance(node, ast.FunctionDef) and node.name == "_check_api_keys_or_die":
             body = ast.unparse(node)
-            # The restraint branch must still call sys.exit on missing keys
             assert "sys.exit(1)" in body
             assert "No API keys" in body
             return
-    pytest.fail("_print_preflight not found")
+    pytest.fail("_check_api_keys_or_die not found")

--- a/tests/cli/test_ov_presentation.py
+++ b/tests/cli/test_ov_presentation.py
@@ -1,0 +1,46 @@
+"""ov facade: cockpit action opts into COCKPIT presentation; run/daemon
+force SOAK; the facade never does more than set env + delegate (Mandate 3)."""
+from __future__ import annotations
+
+import os
+
+import pytest
+
+from backend.core.ouroboros.cli import ov as ov_cli
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("JARVIS_OV_PRESENTATION", raising=False)
+
+
+def _capture_delegation(monkeypatch):
+    seen = {}
+
+    def fake_battle_main(argv):
+        seen["argv"] = list(argv)
+        seen["mode_env"] = os.environ.get("JARVIS_OV_PRESENTATION")
+
+    import scripts.ouroboros_battle_test as bt
+    monkeypatch.setattr(bt, "main", fake_battle_main)
+    return seen
+
+
+def test_cockpit_sets_cockpit_mode_before_delegating(monkeypatch):
+    seen = _capture_delegation(monkeypatch)
+    assert ov_cli.main([]) == 0
+    assert seen["mode_env"] == "cockpit"
+    assert seen["argv"] == []
+
+
+def test_run_forces_soak(monkeypatch):
+    seen = _capture_delegation(monkeypatch)
+    assert ov_cli.main(["run", "--cost-cap", "1.00"]) == 0
+    assert seen["mode_env"] == "soak"
+    assert seen["argv"] == ["--headless", "--cost-cap", "1.00"]
+
+
+def test_daemon_forces_soak(monkeypatch):
+    seen = _capture_delegation(monkeypatch)
+    assert ov_cli.main(["daemon"]) == 0
+    assert seen["mode_env"] == "soak"

--- a/tests/governance/test_intake_lock_lifecycle_slice2.py
+++ b/tests/governance/test_intake_lock_lifecycle_slice2.py
@@ -203,15 +203,30 @@ def test_single_flight_gated_by_env_var():
 
 def test_single_flight_called_after_zombie_reap():
     """The single-flight check runs AFTER the zombie reaper so it doesn't
-    falsely trip on dead-PID lockholders the reaper can clean."""
+    falsely trip on dead-PID lockholders the reaper can clean.
+
+    ov awakening Task 1 restructured main()'s boot sequence: zombie
+    reaping is now a mode-independent functional step (quiet=True in
+    COCKPIT) invoked directly in main(), BEFORE the call to
+    ``_run_gated_boot_banners`` -- which is what actually invokes
+    ``_single_flight_preflight()`` from inside its own gated body. This
+    pins the ordering at the new call site (main() -> _reap_zombies,
+    then main() -> _run_gated_boot_banners); the runtime proof that
+    _run_gated_boot_banners itself calls reap before single-flight
+    before preflight (when all are enabled) lives in
+    tests/battle_test/test_presentation_gate.py.
+    """
     src = Path("scripts/ouroboros_battle_test.py").read_text()
-    # Both must exist; single-flight check string must appear after the
-    # zombie reap call in the main() flow.
-    reap_idx = src.find("_reap_zombies()")
-    sf_idx = src.find("_single_flight_preflight()")
-    assert reap_idx > 0
-    assert sf_idx > reap_idx, (
-        "single-flight must be invoked AFTER _reap_zombies in main() flow"
+    main_start = src.find("def main(")
+    assert main_start > 0, "main() entry point missing"
+    body = src[main_start:]
+    reap_idx = body.find("_reap_zombies(")
+    banners_idx = body.find("_run_gated_boot_banners(")
+    assert reap_idx > 0, "_reap_zombies call missing in main()"
+    assert banners_idx > 0, "_run_gated_boot_banners call missing in main()"
+    assert banners_idx > reap_idx, (
+        "single-flight (invoked inside _run_gated_boot_banners) must be "
+        "invoked AFTER _reap_zombies in main() flow"
     )
 
 

--- a/tests/governance/test_intake_lock_lifecycle_slice2.py
+++ b/tests/governance/test_intake_lock_lifecycle_slice2.py
@@ -173,16 +173,31 @@ def test_corrupt_lock_removed(tmp_path) -> None:
 
 
 def test_single_flight_helper_exists():
-    """Helper function `_single_flight_preflight` must exist in launcher."""
+    """Helper function `_single_flight_preflight` must exist in launcher.
+
+    ov awakening Task 1 gave it a keyword-only ``quiet`` param (COCKPIT
+    gates only the happy-path chatter; the guard itself and its
+    conflict-path REJECTED output run in both presentation modes), so
+    the pin matches the def line prefix rather than the exact
+    zero-arg signature.
+    """
     src = Path("scripts/ouroboros_battle_test.py").read_text()
-    assert "def _single_flight_preflight()" in src
+    assert "def _single_flight_preflight(" in src
 
 
 def test_single_flight_uses_pgrep_canonical_pattern():
     """Pgrep pattern must be the operator-runbook canonical form
-    (avoids matching zsh wrapper eval text — addressed in Slice 3 too)."""
+    (avoids matching zsh wrapper eval text — addressed in Slice 3 too).
+
+    Pattern evolution 2026-05-13: the canonical form gained a leading
+    ``^`` anchor so wrappers like ``caffeinate -dimsu python3 ...``
+    (whose cmdline contains the python invocation as later argv
+    elements) don't self-match. This pin was stale against that change;
+    it now pins the anchored canonical form, matching the load-bearing
+    anchor test in test_harness_epic_graduation_pins_slice4.py.
+    """
     src = Path("scripts/ouroboros_battle_test.py").read_text()
-    assert r'"python3? scripts/ouroboros_battle_test\.py"' in src
+    assert r'"^python3? scripts/ouroboros_battle_test\.py"' in src
 
 
 def test_single_flight_exits_75_on_violation():
@@ -205,28 +220,22 @@ def test_single_flight_called_after_zombie_reap():
     """The single-flight check runs AFTER the zombie reaper so it doesn't
     falsely trip on dead-PID lockholders the reaper can clean.
 
-    ov awakening Task 1 restructured main()'s boot sequence: zombie
-    reaping is now a mode-independent functional step (quiet=True in
-    COCKPIT) invoked directly in main(), BEFORE the call to
-    ``_run_gated_boot_banners`` -- which is what actually invokes
-    ``_single_flight_preflight()`` from inside its own gated body. This
-    pins the ordering at the new call site (main() -> _reap_zombies,
-    then main() -> _run_gated_boot_banners); the runtime proof that
-    _run_gated_boot_banners itself calls reap before single-flight
-    before preflight (when all are enabled) lives in
-    tests/battle_test/test_presentation_gate.py.
+    ov awakening Task 1: both steps are mode-independent FUNCTIONAL boot
+    work invoked directly in main() (each with quiet=True in COCKPIT —
+    only their chatter is presentation-gated, never the side effects).
+    The search is scoped to main()'s body so the function *definitions*
+    above main() can't satisfy it.
     """
     src = Path("scripts/ouroboros_battle_test.py").read_text()
     main_start = src.find("def main(")
     assert main_start > 0, "main() entry point missing"
     body = src[main_start:]
     reap_idx = body.find("_reap_zombies(")
-    banners_idx = body.find("_run_gated_boot_banners(")
+    sf_idx = body.find("_single_flight_preflight(")
     assert reap_idx > 0, "_reap_zombies call missing in main()"
-    assert banners_idx > 0, "_run_gated_boot_banners call missing in main()"
-    assert banners_idx > reap_idx, (
-        "single-flight (invoked inside _run_gated_boot_banners) must be "
-        "invoked AFTER _reap_zombies in main() flow"
+    assert sf_idx > 0, "_single_flight_preflight call missing in main()"
+    assert sf_idx > reap_idx, (
+        "single-flight must be invoked AFTER _reap_zombies in main() flow"
     )
 
 

--- a/tests/ui/test_awakening.py
+++ b/tests/ui/test_awakening.py
@@ -1,0 +1,110 @@
+"""AwakeningConductor: mounts the EXISTING WakeSequenceRenderer (Mandate 3),
+ignites exactly once, skips only on Esc/Enter, buffers typed input, cools
+down exactly once, and NEVER raises (spec §3.2, §9.5)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from rich.console import Console
+
+from backend.core.ouroboros.ui.awakening import AwakeningConductor
+from backend.core.ouroboros.ui import theme
+
+
+class FakeClock:
+    def __init__(self):
+        self.t = 0.0
+    def __call__(self):
+        return self.t
+
+
+class FakeTimer:
+    """Duck-typed BootTimer: captures the observer for manual driving."""
+    def __init__(self):
+        self.observers = []
+    def add_observer(self, cb):
+        self.observers.append(cb)
+    def emit(self, name, in_flight):
+        class R:  # PhaseRecord duck
+            pass
+        r = R(); r.name = name; r.is_in_flight = in_flight
+        for cb in self.observers:
+            cb(r)
+
+
+def make_conductor(**kw):
+    console = Console(file=open("/dev/null", "w"), force_terminal=True,
+                      width=80, color_system="truecolor")
+    theme.ensure_theme(console)
+    clock = kw.pop("clock", FakeClock())
+    timer = kw.pop("timer", FakeTimer())
+    c = AwakeningConductor(console, timer=timer, clock=clock, **kw)
+    return c, clock, timer
+
+
+@pytest.mark.asyncio
+async def test_ignition_fires_exactly_once():
+    fired = []
+    c, clock, timer = make_conductor(on_ignition=lambda: fired.append(1))
+    timer.emit("sensors online", False)
+    task = asyncio.create_task(c.run())
+    for _ in range(400):
+        clock.t += 0.05
+        await asyncio.sleep(0.001)
+        if fired:
+            break
+    clock.t += 30.0                      # blow past hold guard + cool-down
+    await asyncio.wait_for(task, timeout=5.0)
+    assert fired == [1]
+
+
+@pytest.mark.asyncio
+async def test_esc_skips_and_enter_skips_but_other_keys_buffer():
+    for skip_byte in (b"\x1b", b"\r", b"\n"):
+        feed = [b"g", b"i", skip_byte]
+        c, clock, timer = make_conductor(
+            key_source=lambda f=feed: f.pop(0) if f else b"")
+        timer.emit("loop armed", False)
+        task = asyncio.create_task(c.run())
+        for _ in range(200):
+            clock.t += 0.05
+            await asyncio.sleep(0.001)
+            if task.done():
+                break
+        clock.t += 30.0
+        await asyncio.wait_for(task, timeout=5.0)
+        assert c.typed_prefix == "gi"     # buffered, not swallowed
+
+
+@pytest.mark.asyncio
+async def test_live_honesty_holds_until_model_live():
+    c, clock, timer = make_conductor()
+    timer.emit("venom priming", True)     # still in flight
+    task = asyncio.create_task(c.run())
+    clock.t += 3.0                        # trace done, but NOT live
+    await asyncio.sleep(0.01)
+    assert not task.done()                # holding (breathing)
+    timer.emit("venom priming", False)    # now live
+    clock.t += 30.0
+    await asyncio.wait_for(task, timeout=5.0)
+
+
+@pytest.mark.asyncio
+async def test_render_failure_never_raises(monkeypatch):
+    c, clock, timer = make_conductor()
+    monkeypatch.setattr(c, "_render_crest_text",
+                        lambda *a, **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    timer.emit("sensors online", False)
+    clock.t += 60.0
+    await asyncio.wait_for(c.run(), timeout=5.0)   # must complete silently
+
+
+@pytest.mark.asyncio
+async def test_awakening_disabled_env_goes_plain(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_AWAKENING_ENABLED", "false")
+    c, clock, timer = make_conductor()
+    timer.emit("sensors online", False)
+    clock.t += 60.0
+    await asyncio.wait_for(c.run(), timeout=5.0)
+    assert c.used_plain_path is True

--- a/tests/ui/test_awakening_resize.py
+++ b/tests/ui/test_awakening_resize.py
@@ -1,0 +1,145 @@
+"""SIGWINCH proof (spec §9.2): mid-trace resize regenerates the crest at the
+new measurement, reveal stays monotonic, cool-down intact. Plus a real
+POSIX SIGWINCH delivery against a pty-backed console."""
+from __future__ import annotations
+
+import asyncio
+import os
+import select
+import signal
+import sys
+import threading
+
+import pytest
+from rich.console import Console
+
+from backend.core.ouroboros.ui.awakening import AwakeningConductor
+from backend.core.ouroboros.ui import theme
+from tests.ui.test_awakening import FakeClock, FakeTimer
+
+
+class ResizableConsole(Console):
+    """Console whose reported size we mutate mid-run."""
+    _forced = (80, 30)
+    @property
+    def size(self):
+        from rich.console import ConsoleDimensions
+        return ConsoleDimensions(*self._forced)
+
+
+@pytest.mark.asyncio
+async def test_mid_trace_resize_regenerates_and_stays_monotonic():
+    console = ResizableConsole(file=open("/dev/null", "w"),
+                               force_terminal=True, color_system="truecolor")
+    theme.ensure_theme(console)
+    clock, timer = FakeClock(), FakeTimer()
+    c = AwakeningConductor(console, timer=timer, clock=clock)
+    timer.emit("sensors online", False)
+
+    revealed_counts = []
+    orig = c._render_crest_text
+    def spy(frame, elapsed, tier):
+        revealed = sum(1 for cell in frame.cells if cell.delay_s <= elapsed)
+        revealed_counts.append((frame.cols, revealed / max(1, len(frame.cells))))
+        return orig(frame, elapsed, tier)
+    c._render_crest_text = spy
+
+    task = asyncio.create_task(c.run())
+    for i in range(120):
+        clock.t += 0.02
+        await asyncio.sleep(0.001)
+        if i == 40:
+            ResizableConsole._forced = (50, 30)     # SIGWINCH effect
+    clock.t += 60.0
+    await asyncio.wait_for(task, timeout=5.0)
+
+    assert c.regenerations >= 1
+    cols_seen = {cols for cols, _ in revealed_counts}
+    assert 50 in cols_seen                            # regenerated at new width
+    # monotonic reveal FRACTION across the resize boundary (no flash-back)
+    fracs = [f for _, f in revealed_counts]
+    assert all(b >= a - 1e-9 for a, b in zip(fracs, fracs[1:]))
+
+
+@pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal test")
+def test_real_sigwinch_does_not_crash_animation():
+    """Deliver a real SIGWINCH while the conductor animates on a pty.
+
+    The child's ``Live`` output must be drained from the pty master side,
+    or the kernel tty output buffer fills within a second or two of 60fps
+    frames and the child's ``write(2)`` blocks forever -- a blocking OS
+    call is NOT an asyncio await point, so ``asyncio.wait_for``'s
+    cancellation can never interrupt it. A real terminal emulator drains
+    continuously; here the parent runs a tiny reader thread that does the
+    same (discarding bytes), and bounds the final wait so a genuine hang
+    fails loudly instead of wedging the suite.
+    """
+    import pty
+    pid, fd = pty.fork()
+    if pid == 0:  # child: run a short awakening against the pty
+        try:
+            import asyncio as aio
+            from rich.console import Console as C
+            from backend.core.ouroboros.ui.awakening import AwakeningConductor as A
+            from backend.core.ouroboros.ui import theme as th
+            console = C(force_terminal=True, color_system="truecolor")
+            th.ensure_theme(console)
+            from tests.ui.test_awakening import FakeTimer as FT
+            t = FT()
+            c = A(console, timer=t)
+            t.emit("sensors online", False)
+            # A prior async test in this pytest session may have left a
+            # "current" event loop registered on this thread, backed by a
+            # kqueue/epoll selector fd -- fork() does NOT preserve
+            # kqueue/epoll fds (BSD/macOS semantics), so reusing that
+            # stale loop in the child crashes. Always build a fresh loop
+            # here rather than trusting ``get_event_loop()``.
+            loop = aio.new_event_loop()
+            aio.set_event_loop(loop)
+            loop.run_until_complete(
+                aio.wait_for(c.run(), timeout=15.0))
+            os._exit(0)
+        except BaseException:
+            os._exit(3)
+    else:
+        stop = threading.Event()
+
+        def _drain() -> None:
+            while not stop.is_set():
+                try:
+                    ready, _, _ = select.select([fd], [], [], 0.1)
+                except (OSError, ValueError):
+                    return
+                if fd in ready:
+                    try:
+                        if not os.read(fd, 65536):
+                            return
+                    except OSError:
+                        return
+
+        reader = threading.Thread(target=_drain, daemon=True)
+        reader.start()
+
+        import time as _t
+        _t.sleep(0.4)
+        os.kill(pid, signal.SIGWINCH)                 # the real signal
+
+        deadline = _t.time() + 20.0
+        exited = False
+        status = None
+        while _t.time() < deadline:
+            wpid, status = os.waitpid(pid, os.WNOHANG)
+            if wpid != 0:
+                exited = True
+                break
+            _t.sleep(0.05)
+
+        stop.set()
+        reader.join(timeout=1.0)
+
+        if not exited:
+            os.kill(pid, signal.SIGKILL)
+            os.waitpid(pid, 0)
+            pytest.fail("child did not exit within the bounded wait (20s)")
+
+        assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0

--- a/tests/ui/test_awakening_resize.py
+++ b/tests/ui/test_awakening_resize.py
@@ -1,12 +1,14 @@
 """SIGWINCH proof (spec §9.2): mid-trace resize regenerates the crest at the
 new measurement, reveal stays monotonic, cool-down intact. Plus a real
-POSIX SIGWINCH delivery against a pty-backed console."""
+POSIX SIGWINCH delivery -- via ``TIOCSWINSZ`` ioctl -- against a pty-backed
+console, which is load-bearing: the child proves it observed the resize
+(``regenerations >= 1``) or exits non-zero, so the test goes red without the
+feature."""
 from __future__ import annotations
 
 import asyncio
 import os
 import select
-import signal
 import sys
 import threading
 
@@ -27,8 +29,20 @@ class ResizableConsole(Console):
         return ConsoleDimensions(*self._forced)
 
 
+class ShrinkConsole(Console):
+    """Console with a per-instance forced size (no shared class state)."""
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._forced_size = (80, 40)
+    @property
+    def size(self):
+        from rich.console import ConsoleDimensions
+        return ConsoleDimensions(*self._forced_size)
+
+
 @pytest.mark.asyncio
 async def test_mid_trace_resize_regenerates_and_stays_monotonic():
+    ResizableConsole._forced = (80, 30)               # reset shared class state
     console = ResizableConsole(file=open("/dev/null", "w"),
                                force_terminal=True, color_system="truecolor")
     theme.ensure_theme(console)
@@ -61,23 +75,77 @@ async def test_mid_trace_resize_regenerates_and_stays_monotonic():
     assert all(b >= a - 1e-9 for a, b in zip(fracs, fracs[1:]))
 
 
+@pytest.mark.asyncio
+async def test_mid_trace_shrink_below_minimum_degrades_to_cooldown():
+    """Terminal shrinks below the crest minimum mid-trace: the conductor must
+    degrade gracefully (request skip -> cool-down) WITHOUT adopting the
+    unavailable frame and WITHOUT crashing. ``regenerations`` stays 0."""
+    console = ShrinkConsole(file=open("/dev/null", "w"),
+                            force_terminal=True, color_system="truecolor")
+    theme.ensure_theme(console)
+    clock, timer = FakeClock(), FakeTimer()
+    c = AwakeningConductor(console, timer=timer, clock=clock)
+    timer.emit("sensors online", False)
+
+    task = asyncio.create_task(c.run())
+    for i in range(120):
+        clock.t += 0.02
+        await asyncio.sleep(0.001)
+        if i == 30:
+            console._forced_size = (30, 40)          # below crest min (46)
+    clock.t += 60.0
+    await asyncio.wait_for(task, timeout=5.0)         # completes, never raises
+
+    assert c.regenerations == 0                       # never adopted unavailable
+    assert c._skip_requested is True                  # degraded to cool-down
+
+
 @pytest.mark.skipif(sys.platform == "win32", reason="POSIX signal test")
 def test_real_sigwinch_does_not_crash_animation():
-    """Deliver a real SIGWINCH while the conductor animates on a pty.
+    """Deliver a REAL, kernel-originated SIGWINCH mid-trace by resizing the
+    child's controlling pty via ``TIOCSWINSZ`` -- and prove the child
+    observed it (load-bearing).
 
-    The child's ``Live`` output must be drained from the pty master side,
-    or the kernel tty output buffer fills within a second or two of 60fps
-    frames and the child's ``write(2)`` blocks forever -- a blocking OS
-    call is NOT an asyncio await point, so ``asyncio.wait_for``'s
-    cancellation can never interrupt it. A real terminal emulator drains
-    continuously; here the parent runs a tiny reader thread that does the
-    same (discarding bytes), and bounds the final wait so a genuine hang
-    fails loudly instead of wedging the suite.
+    Why the ioctl (not a bare ``os.kill(pid, SIGWINCH)``): Python's default
+    disposition for SIGWINCH is *ignore* with no handler installed, so a
+    plain ``kill`` is dropped by the kernel and, crucially, changes nothing
+    the child measures -- such a test passes with OR without the feature and
+    proves nothing. ``TIOCSWINSZ`` on the pty master both delivers a genuine
+    kernel SIGWINCH to the child (session leader on that controlling tty)
+    AND actually changes what the child's ``console.size`` reports, finally
+    exercising ``_check_resize`` under real signal delivery.
+
+    Load-bearing exit-code contract (child):
+      * real crash / hang / missing attribute -> ``os._exit(3)``  (fail)
+      * feature present but never fired (``regenerations == 0``) -> ``4``  (fail)
+      * feature worked under real SIGWINCH (``regenerations >= 1``) -> ``0``
+    Only the real, working feature yields exit 0.
+
+    The child's ``Live`` output must be drained from the pty master side, or
+    the kernel tty output buffer fills within a second or two of 60fps frames
+    and the child's ``write(2)`` blocks forever -- a blocking OS call is NOT
+    an asyncio await point, so ``asyncio.wait_for``'s cancellation can never
+    interrupt it. A real terminal emulator drains continuously; here the
+    parent runs a tiny reader thread that does the same.
     """
+    import fcntl
     import pty
-    pid, fd = pty.fork()
-    if pid == 0:  # child: run a short awakening against the pty
+    import struct
+    import termios
+    import time as _t
+
+    pid, master_fd = pty.fork()
+    if pid == 0:  # child: run a real awakening on the pty and prove the resize
         try:
+            # COLUMNS/LINES in the env would short-circuit Rich's live pty
+            # measurement -- drop them so console.size reflects TIOCSWINSZ.
+            os.environ.pop("COLUMNS", None)
+            os.environ.pop("LINES", None)
+            # Establish a known-good initial size on our controlling pty
+            # (race-free: we own fd 1 before the parent can touch it), so the
+            # first frame is available and we take the animated path.
+            fcntl.ioctl(1, termios.TIOCSWINSZ, struct.pack("HHHH", 40, 80, 0, 0))
+
             import asyncio as aio
             from rich.console import Console as C
             from backend.core.ouroboros.ui.awakening import AwakeningConductor as A
@@ -90,15 +158,15 @@ def test_real_sigwinch_does_not_crash_animation():
             t.emit("sensors online", False)
             # A prior async test in this pytest session may have left a
             # "current" event loop registered on this thread, backed by a
-            # kqueue/epoll selector fd -- fork() does NOT preserve
-            # kqueue/epoll fds (BSD/macOS semantics), so reusing that
-            # stale loop in the child crashes. Always build a fresh loop
-            # here rather than trusting ``get_event_loop()``.
+            # kqueue/epoll selector fd -- fork() does NOT preserve those fds
+            # (BSD/macOS semantics), so reusing that stale loop crashes.
+            # Always build a fresh loop rather than trusting get_event_loop().
             loop = aio.new_event_loop()
             aio.set_event_loop(loop)
-            loop.run_until_complete(
-                aio.wait_for(c.run(), timeout=15.0))
-            os._exit(0)
+            loop.run_until_complete(aio.wait_for(c.run(), timeout=15.0))
+            # Load-bearing proof: did the animated loop actually observe the
+            # parent's mid-trace resize and regenerate the crest?
+            os._exit(0 if c.regenerations >= 1 else 4)
         except BaseException:
             os._exit(3)
     else:
@@ -107,12 +175,12 @@ def test_real_sigwinch_does_not_crash_animation():
         def _drain() -> None:
             while not stop.is_set():
                 try:
-                    ready, _, _ = select.select([fd], [], [], 0.1)
+                    ready, _, _ = select.select([master_fd], [], [], 0.1)
                 except (OSError, ValueError):
                     return
-                if fd in ready:
+                if master_fd in ready:
                     try:
-                        if not os.read(fd, 65536):
+                        if not os.read(master_fd, 65536):
                             return
                     except OSError:
                         return
@@ -120,11 +188,22 @@ def test_real_sigwinch_does_not_crash_animation():
         reader = threading.Thread(target=_drain, daemon=True)
         reader.start()
 
-        import time as _t
-        _t.sleep(0.4)
-        os.kill(pid, signal.SIGWINCH)                 # the real signal
+        def _set_size(cols: int, rows: int) -> None:
+            try:
+                fcntl.ioctl(master_fd, termios.TIOCSWINSZ,
+                            struct.pack("HHHH", rows, cols, 0, 0))
+            except OSError:
+                pass
 
-        deadline = _t.time() + 20.0
+        # Toggle between two valid widths (both >= 46 min) across the whole
+        # animation window. The child's crest reveal runs ~2.3s real-time; by
+        # continuously toggling every 0.25s from 0.4s onward we guarantee at
+        # least one genuine mid-trace size change lands inside the tick loop
+        # regardless of the child's (variable) import time -- robust, not racy.
+        widths = [(60, 40), (80, 40)]
+        deadline = _t.time() + 25.0
+        next_resize = _t.time() + 0.4
+        toggle = 0
         exited = False
         status = None
         while _t.time() < deadline:
@@ -132,14 +211,26 @@ def test_real_sigwinch_does_not_crash_animation():
             if wpid != 0:
                 exited = True
                 break
-            _t.sleep(0.05)
+            if _t.time() >= next_resize:
+                cols, rows = widths[toggle % 2]
+                toggle += 1
+                _set_size(cols, rows)
+                next_resize = _t.time() + 0.25
+            _t.sleep(0.02)
 
         stop.set()
         reader.join(timeout=1.0)
 
         if not exited:
-            os.kill(pid, signal.SIGKILL)
+            os.kill(pid, __import__("signal").SIGKILL)
             os.waitpid(pid, 0)
-            pytest.fail("child did not exit within the bounded wait (20s)")
+            pytest.fail("child did not exit within the bounded wait (25s)")
 
-        assert os.WIFEXITED(status) and os.WEXITSTATUS(status) == 0
+        # exit 0 == feature observed a real resize; 3 == crash/hang/missing
+        # attribute; 4 == feature present but never fired.
+        assert os.WIFEXITED(status), f"child killed by signal: {status}"
+        code = os.WEXITSTATUS(status)
+        assert code == 0, (
+            f"child exit {code} "
+            f"({'crash/missing-attr' if code == 3 else 'regenerations==0' if code == 4 else 'unexpected'})"
+        )

--- a/tests/ui/test_crest.py
+++ b/tests/ui/test_crest.py
@@ -124,3 +124,30 @@ def test_standard_tier_renders_geometry():
     f = gen(tier=ColorTier.STANDARD)
     assert f.unavailable_reason is None
     assert cells_by_kind(f, "coil")
+
+
+# ---- style resolution --------------------------------------------------------
+
+from backend.core.ouroboros.ui.crest import style_for_cell
+from backend.core.ouroboros.ui.theme import Token, style_for
+
+
+def test_truecolor_styles_are_rgb():
+    f = gen()
+    c = cells_by_kind(f, "coil")[0]
+    assert style_for_cell(c, ColorTier.TRUECOLOR).startswith("rgb(")
+
+
+def test_standard_styles_are_accent_mono():
+    f = gen(tier=ColorTier.STANDARD)
+    accent = style_for(Token.ACCENT, ColorTier.STANDARD)
+    coil = cells_by_kind(f, "coil")[0]
+    v = cells_by_kind(f, "v")[0]
+    assert style_for_cell(coil, ColorTier.STANDARD) == accent
+    assert style_for_cell(v, ColorTier.STANDARD) == f"bold {accent}"
+
+
+def test_cache_hit_same_object():
+    a = gen(cols=60)
+    b = gen(cols=60)
+    assert a is b        # lru_cache identity

--- a/tests/ui/test_crest.py
+++ b/tests/ui/test_crest.py
@@ -1,0 +1,126 @@
+"""Crest v5 invariants: solid, crisp, anatomically complete, REACTIVE.
+These are the professional-art regression net (spec §9.1)."""
+from __future__ import annotations
+
+import math
+import os
+
+import pytest
+
+from backend.core.ouroboros.ui.crest import CrestFrame, generate_crest
+from backend.core.ouroboros.ui.theme import ColorTier
+
+T = ColorTier.TRUECOLOR
+
+
+def gen(cols=60, rows=24, tier=T, unicode_ok=True) -> CrestFrame:
+    return generate_crest(cols, rows, tier=tier, unicode_ok=unicode_ok)
+
+
+def cells_by_kind(frame, kind):
+    return [c for c in frame.cells if c.kind == kind]
+
+
+# ---- anatomy invariants ----------------------------------------------------
+
+def test_all_kinds_present():
+    f = gen()
+    assert f.unavailable_reason is None
+    for kind in ("coil", "head", "eye", "v"):
+        assert cells_by_kind(f, kind), f"missing {kind} cells"
+
+
+def test_no_isolated_crumb_cells():
+    f = gen()
+    occupied = {(c.x, c.y) for c in f.cells}
+    dots = set("▘▝▖▗")   # single-quadrant glyphs
+    for c in f.cells:
+        if c.glyph in dots:
+            assert any((c.x + dx, c.y + dy) in occupied
+                       for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))), \
+                f"isolated crumb at {(c.x, c.y)}"
+
+
+def test_v_has_flat_top():
+    f = gen()
+    v = cells_by_kind(f, "v")
+    top_y = min(c.y for c in v)
+    top_row = [c for c in v if c.y == top_y]
+    assert len(top_row) >= 4          # two stroke caps, each >=2 cells wide
+
+
+def test_coil_is_solid_no_full_block_holes():
+    """Between the leftmost and rightmost coil cell of each row band that
+    contains full blocks, interior full-block runs are contiguous per flank
+    (annulus: at most 2 runs per row -- left flank + right flank)."""
+    f = gen()
+    coil_rows = {}
+    for c in cells_by_kind(f, "coil"):
+        if c.glyph == "█":
+            coil_rows.setdefault(c.y, []).append(c.x)
+    assert coil_rows, "no solid coil interior at all"
+    for y, xs in coil_rows.items():
+        xs = sorted(xs)
+        runs = 1
+        for a, b in zip(xs, xs[1:]):
+            if b - a > 1:
+                runs += 1
+        assert runs <= 2, f"row {y}: {runs} solid runs (holes in the body)"
+
+
+def test_delays_monotonic_tail_to_head_and_bounded():
+    f = gen()
+    coil = cells_by_kind(f, "coil")
+    assert all(0.0 <= c.delay_s <= 1.40 for c in coil)
+    assert min(c.delay_s for c in coil) < 0.2       # trace starts at the tail
+    head = cells_by_kind(f, "head")
+    assert all(c.delay_s > max(c2.delay_s for c2 in coil) - 0.3 for c in head)
+    assert f.max_delay_s >= 1.55                     # eye ignition is last
+
+
+# ---- reactivity + clamping (Mandate 2) --------------------------------------
+
+def test_geometry_scales_with_width():
+    small, large = gen(cols=46), gen(cols=72)
+    assert small.cols == 46 and large.cols == 72
+    assert len(large.cells) > len(small.cells) * 1.5
+
+
+def test_hard_clamp_at_72():
+    f = gen(cols=200)
+    assert f.cols == 72
+    assert max(c.x for c in f.cells) < 72
+
+
+def test_env_min_clamp(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_CREST_MIN_COLS", "50")
+    f = generate_crest(48, 24, tier=T, unicode_ok=True)
+    assert f.unavailable_reason is not None          # below min -> unavailable
+
+
+def test_below_default_min_unavailable():
+    f = gen(cols=40)
+    assert f.unavailable_reason is not None
+
+
+def test_insufficient_rows_unavailable():
+    f = gen(cols=60, rows=8)
+    assert f.unavailable_reason is not None
+
+
+# ---- tier / unicode degradation ---------------------------------------------
+
+def test_no_unicode_unavailable():
+    f = gen(unicode_ok=False)
+    assert f.unavailable_reason is not None
+
+
+def test_none_tier_unavailable():
+    f = gen(tier=ColorTier.NONE)
+    assert f.unavailable_reason is not None
+
+
+def test_standard_tier_renders_geometry():
+    f = gen(tier=ColorTier.STANDARD)
+    assert f.unavailable_reason is None
+    assert cells_by_kind(f, "coil")

--- a/tests/ui/test_presentation_mode.py
+++ b/tests/ui/test_presentation_mode.py
@@ -1,0 +1,32 @@
+"""PresentationMode: default-SOAK fail-safe resolution (spec §3.5)."""
+from __future__ import annotations
+
+from backend.core.ouroboros.ui.presentation_mode import (
+    PresentationMode, resolve_presentation_mode, is_cockpit,
+)
+
+
+def test_default_is_soak():
+    assert resolve_presentation_mode(env={}) is PresentationMode.SOAK
+
+
+def test_cockpit_value_resolves():
+    env = {"JARVIS_OV_PRESENTATION": "cockpit"}
+    assert resolve_presentation_mode(env=env) is PresentationMode.COCKPIT
+
+
+def test_garbage_fails_safe_to_soak():
+    env = {"JARVIS_OV_PRESENTATION": "PARTY_MODE"}
+    assert resolve_presentation_mode(env=env) is PresentationMode.SOAK
+
+
+def test_case_and_whitespace_tolerant():
+    env = {"JARVIS_OV_PRESENTATION": "  Cockpit "}
+    assert resolve_presentation_mode(env=env) is PresentationMode.COCKPIT
+
+
+def test_is_cockpit_reads_process_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_PRESENTATION", "cockpit")
+    assert is_cockpit() is True
+    monkeypatch.delenv("JARVIS_OV_PRESENTATION")
+    assert is_cockpit() is False

--- a/tests/ui/test_theme_guard.py
+++ b/tests/ui/test_theme_guard.py
@@ -115,3 +115,100 @@ def test_boot_banner_active_path_log_line_migrated() -> None:
     """
     sf = (_BATTLE / "serpent_flow.py").read_text(encoding="utf-8")
     assert "[muted]{log_path}[/muted]" in sf
+
+
+# --- ov awakening Task 9: Mandate 1 made permanent ----------------------
+#
+# Task 1 split boot-time behavior in scripts/ouroboros_battle_test.py into
+# two classes:
+#
+#   * PURE CEREMONY (``_print_preflight``, the zombie-reap banner) --
+#     withheld entirely in COCKPIT mode by being called ONLY from inside
+#     ``_run_gated_boot_banners``.
+#   * FUNCTIONAL side effects (``_check_api_keys_or_die`` fatal check,
+#     ``_reap_zombies`` scan/kill, ``_single_flight_preflight`` conflict
+#     rejection) -- these must run unconditionally in BOTH presentation
+#     modes, so they live OUTSIDE the gate at their own call sites.
+#     ``_reap_zombies``/``_single_flight_preflight`` additionally gate
+#     only their own happy-path banner chatter via an explicit ``quiet=``
+#     keyword passed at the (ungated) call site -- not via the gate helper.
+#
+# The brief's literal test (``_single_flight_preflight()`` bare-call count
+# outside the gate == 0) does not hold for the real Task 1 shape: that
+# function is *never* called from inside the gate at all -- it always runs
+# outside it, distinguished instead by requiring an explicit ``quiet=``
+# argument. The guard below asserts the invariant that actually holds:
+# ceremony-only functions are gate-exclusive; functional-but-gated-banner
+# functions always pass ``quiet=`` when called outside the gate; and the
+# fatal API-key check is never reachable only from inside the gate.
+_SCRIPT = _REPO / "scripts" / "ouroboros_battle_test.py"
+
+
+def _gate_span(src: str) -> Tuple[int, int]:
+    """Return the (start, end) char offsets of _run_gated_boot_banners'
+    body within ``src`` -- from its ``def`` line up to (not including)
+    the next top-level ``def``."""
+    start = src.index("def _run_gated_boot_banners")
+    end = src.index("\ndef ", start)
+    return start, end
+
+
+def test_boot_banner_ceremony_only_called_via_gate() -> None:
+    """Mandate 1, made permanent: pure-ceremony banners are gate-exclusive;
+    functional/fatal boot steps are never gated.
+
+    Would go red if someone re-added an ungated ``_print_preflight()`` call
+    to ``main()``'s hot path, or stripped the ``quiet=`` kwarg from an
+    outside-the-gate ``_reap_zombies``/``_single_flight_preflight`` call
+    (both of which would let COCKPIT's banner-suppression contract leak),
+    or moved ``_check_api_keys_or_die()`` inside the gate (which would let
+    a presentation mode suppress the no-API-keys fatal exit).
+    """
+    src = _SCRIPT.read_text(encoding="utf-8")
+    gate_start, gate_end = _gate_span(src)
+
+    # 1. _print_preflight() is pure ceremony -- every call site in the
+    # file must fall inside the gate body.
+    print_preflight_calls = [
+        m for m in re.finditer(r"(?<!def )_print_preflight\(\)", src)
+    ]
+    assert print_preflight_calls, "_print_preflight() is never called at all"
+    outside = [
+        m for m in print_preflight_calls
+        if not (gate_start <= m.start() < gate_end)
+    ]
+    assert not outside, (
+        "_print_preflight() called outside _run_gated_boot_banners at "
+        f"offset(s) {[m.start() for m in outside]} -- Mandate 1 violation: "
+        "COCKPIT can no longer withhold this banner at the source"
+    )
+
+    # 2. _reap_zombies / _single_flight_preflight are FUNCTIONAL and run
+    # unconditionally; every call site OUTSIDE the gate body must pass an
+    # explicit quiet= kwarg, so only the happy-path banner is suppressed
+    # in COCKPIT -- never the scan/kill or conflict-rejection side effects.
+    for fn_name in ("_reap_zombies", "_single_flight_preflight"):
+        call_rx = re.compile(rf"(?<!def ){re.escape(fn_name)}\(([^)]*)\)")
+        outside_calls = [
+            m for m in call_rx.finditer(src)
+            if not (gate_start <= m.start() < gate_end)
+        ]
+        assert outside_calls, f"{fn_name} is never called outside the gate"
+        for m in outside_calls:
+            assert "quiet=" in m.group(1), (
+                f"{fn_name} called outside the gate without an explicit "
+                f"quiet= kwarg ({m.group(0)!r} at offset {m.start()}) -- "
+                "its banner ceremony would leak past Mandate 1"
+            )
+
+    # 3. _check_api_keys_or_die is the FATAL preflight -- it must never be
+    # reachable only from inside the gate (no presentation mode may
+    # suppress the no-API-keys exit).
+    assert "_check_api_keys_or_die()" in src
+    fatal_calls = [
+        m for m in re.finditer(r"(?<!def )_check_api_keys_or_die\(\)", src)
+    ]
+    assert fatal_calls, "_check_api_keys_or_die() is never called at all"
+    assert all(
+        not (gate_start <= m.start() < gate_end) for m in fatal_calls
+    ), "_check_api_keys_or_die() called from inside the presentation gate"

--- a/tests/voice/duplex/test_default_karen_handle.py
+++ b/tests/voice/duplex/test_default_karen_handle.py
@@ -1,0 +1,15 @@
+"""Default-Karen singleton -- the same late-binding pattern as
+voice_command_sensor.set_default_voice_sensor (Sprint 4)."""
+from __future__ import annotations
+
+from backend.core.ouroboros.governance.comms.duplex import karen_duplex_factory as kdf
+
+
+def test_default_handle_roundtrip():
+    sentinel = object()
+    kdf.set_default_karen(sentinel)
+    try:
+        assert kdf.get_default_karen() is sentinel
+    finally:
+        kdf.set_default_karen(None)
+    assert kdf.get_default_karen() is None

--- a/tests/voice/test_karen_boot_briefing.py
+++ b/tests/voice/test_karen_boot_briefing.py
@@ -1,0 +1,115 @@
+# tests/voice/test_karen_boot_briefing.py
+"""Boot briefing: live-state composition, DW primary, 4s breaker that
+provably falls back to the LOCAL live-state line without stalling (spec
+§3.3, Mandate 4). No canned strings: every output embeds real vectors."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.karen_boot_briefing import (
+    BootBriefing, BriefingVectors, compose_local, gather_vectors,
+)
+
+
+V = BriefingVectors(last_session="apply=AUTO/3 verify=4/4 commit=9f3c21ab",
+                    queued_ops=2, posture="EXPLORE", pending_approvals=1)
+
+
+class SlowSynth:
+    """Synthesizer that never completes inside the deadline."""
+    def __init__(self):
+        self.cancelled = False
+    async def synthesize(self, view):
+        try:
+            await asyncio.sleep(30)
+            yield "never"
+        except asyncio.CancelledError:
+            self.cancelled = True
+            raise
+
+
+class GoodSynth:
+    async def synthesize(self, view):
+        yield "Right then -- awake."
+        yield "Two ops queued overnight."
+
+
+def test_compose_local_embeds_live_vectors():
+    line = compose_local(V)
+    assert "2" in line and "EXPLORE".lower() in line.lower()
+    assert "1" in line                       # pending approval surfaced
+
+
+def test_compose_local_empty_state_is_factual_not_boilerplate():
+    line = compose_local(BriefingVectors())
+    assert "first session" in line.lower()
+
+
+@pytest.mark.asyncio
+async def test_breaker_falls_back_fast_without_stalling():
+    """MATHEMATICAL PROOF (Mandate 4): wall-clock bound. timeout=0.2s; a
+    30s-hanging LLM must yield the local fallback in < 1.0s."""
+    spoken = []
+    synth = SlowSynth()
+    b = BootBriefing(synthesizer=synth, speak_sink=spoken.append,
+                     timeout_s=0.2, vectors_override=V)
+    loop = asyncio.get_event_loop()
+    t0 = loop.time()
+    line = await b.run()
+    elapsed = loop.time() - t0
+    assert elapsed < 1.0                     # CLI init NOT stalled
+    assert "2" in line                       # fallback is the LIVE-state line
+    assert spoken and spoken[-1] == line
+    await asyncio.sleep(0.05)
+    assert synth.cancelled is True           # hung task actually cancelled
+
+
+@pytest.mark.asyncio
+async def test_primary_path_speaks_sentences():
+    spoken = []
+    b = BootBriefing(synthesizer=GoodSynth(), speak_sink=spoken.append,
+                     timeout_s=2.0, vectors_override=V)
+    line = await b.run()
+    assert spoken == ["Right then -- awake.", "Two ops queued overnight."]
+    assert "awake" in line.lower()
+
+
+@pytest.mark.asyncio
+async def test_no_synthesizer_goes_straight_to_local():
+    spoken = []
+    b = BootBriefing(synthesizer=None, speak_sink=spoken.append,
+                     vectors_override=V)
+    line = await b.run()
+    assert "2" in line and spoken == [line]
+
+
+@pytest.mark.asyncio
+async def test_voice_off_text_sink_only():
+    texts = []
+    b = BootBriefing(synthesizer=None, speak_sink=None, text_sink=texts.append,
+                     vectors_override=V)
+    line = await b.run()
+    assert texts == [line]
+
+
+@pytest.mark.asyncio
+async def test_run_never_raises(monkeypatch):
+    class ExplodingSynth:
+        async def synthesize(self, view):
+            raise RuntimeError("provider exploded")
+            yield  # pragma: no cover
+    b = BootBriefing(synthesizer=ExplodingSynth(),
+                     speak_sink=lambda s: (_ for _ in ()).throw(RuntimeError("sink!")),
+                     vectors_override=V)
+    line = await b.run()                     # absolutely must not raise
+    assert isinstance(line, str)
+
+
+@pytest.mark.asyncio
+async def test_gather_vectors_is_fault_isolated(monkeypatch):
+    def bad_probe():
+        raise RuntimeError("intake exploded")
+    v = await gather_vectors(intake_probe=bad_probe, approvals_probe=None)
+    assert v.queued_ops is None              # absent, not raised

--- a/tests/voice/test_karen_boot_briefing.py
+++ b/tests/voice/test_karen_boot_briefing.py
@@ -67,6 +67,26 @@ async def test_breaker_falls_back_fast_without_stalling():
 
 
 @pytest.mark.asyncio
+async def test_outer_cancellation_propagates_not_swallowed():
+    """SHUTDOWN SAFETY: asyncio.wait_for raises TimeoutError (not
+    CancelledError) on its OWN deadline, so run() must NOT catch
+    CancelledError at the breaker site. A genuine outer cancellation (boot
+    shutdown while awaiting DW) MUST propagate out of run() — never be eaten
+    by the local-fallback path. Task 8 runs run() inside a cancellable boot."""
+    spoken = []
+    synth = SlowSynth()
+    # Long timeout so the breaker CANNOT trip first — only outer cancel acts.
+    b = BootBriefing(synthesizer=synth, speak_sink=spoken.append,
+                     timeout_s=5.0, vectors_override=V)
+    task = asyncio.ensure_future(b.run())
+    await asyncio.sleep(0.1)                  # let it reach the DW await
+    task.cancel()
+    with pytest.raises(asyncio.CancelledError):
+        await task                           # propagates, NOT swallowed
+    assert spoken == []                      # nothing delivered on shutdown
+
+
+@pytest.mark.asyncio
 async def test_primary_path_speaks_sentences():
     spoken = []
     b = BootBriefing(synthesizer=GoodSynth(), speak_sink=spoken.append,


### PR DESCRIPTION
## The `ov` awakening

Running `ov` now boots as a terminal-native **awakening**: a runtime-generated ouroboros crest (v5, hard-edge quadrant, reactive 46–72 cols) draws itself tail-to-head, real boot phases resolve beneath it, the eye ignites and **Karen speaks a live-state briefing** (DoubleWord primary + a proven 4s circuit breaker → deterministic local fallback), then it cools into the restrained working prompt. `ov run` / soak / CI output stays **byte-identical** (COCKPIT/SOAK presentation gate at the emission sources; fatal paths structurally bypass).

Sprint 2 of the "O+V as a product" program. Spec: `docs/superpowers/specs/2026-07-07-ov-awakening-cli-design.md`. Plan: `docs/superpowers/plans/2026-07-07-ov-awakening-implementation.md`.

### 9-task TDD build (each per-task reviewed; final whole-branch review = MERGE-READY, 0 Critical/Important)
- Presentation-mode gate at harness banner sources + structural ERROR/CRITICAL bypass
- `ov` cockpit facade (declares mode, delegates — thin facade)
- Reactive procedural crest `ui/crest.py` + tier-resolved styles
- Awakening conductor `ui/awakening.py` (mounts the existing `WakeSequenceRenderer`; Esc/Enter skip buffers other keys)
- Genuine SIGWINCH resize proof (real `TIOCSWINSZ` + child exit-code assertion)
- Karen boot briefing `karen_boot_briefing.py` (Sprint-2 pipeline reuse + 4s breaker)
- Harness wiring (awakening awaited before `patch_stdout`; briefing fire-and-forget on ignition)
- Theme guard locks Mandate 1 permanently

### Mandates
- **Root-cause:** no stdout redirect/wrapper/filter; gates are conditionals at emission sources.
- **Reactive geometry:** crest scales from measured `console.size`, clamped, no absolute dims.
- **DRY:** mounts existing WakeSequenceRenderer; reuses the harness bootstrap + Sprint-2 Karen pipeline; clean ff-merge (linear, no reconciliation).
- **Bulletproof:** NEVER-raises on UI/briefing paths; proven breaker; genuine SIGWINCH; tier degradation TRUECOLOR→256→16→none→plain.

Remaining acceptance: live-mic hardware gate (barge-in / spoken build / AEC), run locally on `main` post-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a terminal‑native boot ceremony to `ov`: a reactive ouroboros crest, real boot‑phase readouts, and a short Karen briefing that cools into the prompt. Cockpit‑only; `run`/soak/CI output remains unchanged.

- **New Features**
  - Presentation gate (`cockpit` vs `soak`) via `JARVIS_OV_PRESENTATION` with fail‑safe default `soak`; fatal/functional checks run unconditionally.
  - Terminal awakening: procedural crest v5 with tiered colors, mounts the existing phase renderer, Esc/Enter skip, typed input handed to the first REPL prompt, and resize‑safe regeneration.
  - Karen boot briefing on ignition: DoubleWord primary with a 4s breaker and deterministic local fallback; fire‑and‑forget; process‑wide default Karen handle wired during audio bootstrap.
  - `ov` sets presentation mode and delegates: `cockpit` → `cockpit`, `run`/`daemon` → `soak`; legacy soak/CI output stays byte‑identical.

- **Bug Fixes**
  - Escalator uses the orchestrator FSM `op_id` to accumulate failures correctly across DW retries.
  - Boot briefing preserves outer cancellation by narrowing exception handling.

<sup>Written for commit 6616e1f46753b2c17ffd2013591659837fc3d3eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

