### PR TITLE
Autonomy pivot: self-perception + measurement (Gap 2 + Goal Metric) + slices 26-32

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -461,3 +461,6 @@ Derek J. Russell - Resume*.pdf
 # are never legitimate modules here; the .nosync rename stopped production,
 # this guards any stragglers if the tree ever lands back under sync.
 * [0-9].*
+
+# Slice 25 — fastembed ONNX weight cache (durable, not committed)
+.jarvis/fastembed_cache/

--- a/backend/core/budgeted_loaders.py
+++ b/backend/core/budgeted_loaders.py
@@ -676,7 +676,14 @@ class EmbeddingBudgetedLoader:
 
         try:
             await grant.heartbeat()
-            model = self._load_embedding_model()
+            # Slice 26 — the SentenceTransformer construct is a multi-hundred-MB
+            # blocking load; run it in the default executor so the broker path
+            # (like the legacy EmbeddingService path) never holds the asyncio
+            # loop thread through a model load.
+            import asyncio as _asyncio
+            model = await _asyncio.get_running_loop().run_in_executor(
+                None, self._load_embedding_model,
+            )
             self._model_handle = model
 
             elapsed_ms = (_time.monotonic() - start) * 1000

--- a/backend/core/embedding_service.py
+++ b/backend/core/embedding_service.py
@@ -434,6 +434,26 @@ class EmbeddingService:
         need = (self._config.fastembed_estimate_mb / 1024.0) + self._config.lite_floor_gb
         return avail >= need
 
+    async def _construct_model_offloaded(self, constructor, label: str) -> Any:
+        """Slice 26 (2026-07-15, closes the bt-2026-07-15-192117 on-loop model
+        load): run a blocking model constructor in the default executor so the
+        ~800MB HIGH-tier torch load (and the LITE ONNX construct) never executes
+        on the asyncio loop thread. The load was the LAST on-loop heavyweight in
+        this service — ``encode()`` was already executor-offloaded. C-extension
+        weight loading releases the GIL for its native/IO phases, so a thread
+        hop frees the loop the same way the encode path does.
+
+        Kill switch ``JARVIS_EMBED_MODEL_LOAD_OFFLOAD_ENABLED=0`` restores the
+        legacy inline construct. Exceptions propagate unchanged — every caller
+        already owns tier-demotion / budget-release handling.
+        """
+        raw = os.environ.get("JARVIS_EMBED_MODEL_LOAD_OFFLOAD_ENABLED", "true")
+        if raw.strip().lower() in ("0", "false", "no", "off"):
+            return constructor()
+        logger.debug("[EmbeddingService] constructing %s tier model off-loop", label)
+        loop = asyncio.get_running_loop()
+        return await loop.run_in_executor(None, constructor)
+
     async def _load_model(self) -> bool:
         """Lazy-load an embedding tier, adapting to host memory.
 
@@ -500,7 +520,9 @@ class EmbeddingService:
             try:
                 logger.info(f"[EmbeddingService] Loading HIGH tier: {self._config.model_name}")
                 start = time.time()
-                self._model = self._load_sentence_transformer()
+                self._model = await self._construct_model_offloaded(
+                    self._load_sentence_transformer, "HIGH",
+                )
                 self._active_tier = EmbeddingTier.HIGH
                 logger.info(
                     "[EmbeddingService] ✅ HIGH tier loaded in %.2fs (device: %s)",
@@ -535,7 +557,9 @@ class EmbeddingService:
                 return True
             try:
                 start = time.time()
-                self._model = self._make_fastembed_model()
+                self._model = await self._construct_model_offloaded(
+                    self._make_fastembed_model, "LITE",
+                )
                 prev = self._active_tier
                 self._active_tier = EmbeddingTier.LITE
                 if prev != EmbeddingTier.LITE:
@@ -604,7 +628,9 @@ class EmbeddingService:
             old_model = self._model
             try:
                 start = time.time()
-                new_model = self._load_sentence_transformer()
+                new_model = await self._construct_model_offloaded(
+                    self._load_sentence_transformer, "HIGH(promotion)",
+                )
             except Exception as e:  # noqa: BLE001
                 logger.warning(
                     "[EmbeddingService] Promotion HIGH load failed (%s) — staying on LITE.", e,

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -24,7 +24,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Callable, Dict, List, Optional
+from typing import Any, Callable, Dict, List, Optional, Tuple
 
 from backend.core.ouroboros.battle_test.cost_tracker import CostTracker
 from backend.core.ouroboros.battle_test.idle_watchdog import IdleWatchdog
@@ -380,6 +380,45 @@ class HarnessConfig:
 # ---------------------------------------------------------------------------
 # BattleTestHarness
 # ---------------------------------------------------------------------------
+
+
+def _wall_clock_monitor_max_restarts() -> int:
+    """``JARVIS_WALL_CLOCK_MONITOR_MAX_RESTARTS`` — Slice 29 supervisor
+    restart ceiling for the wall-clock monitor / beat-writer task. Bounded
+    so a deterministically-crashing monitor cannot thrash; the terminal
+    CRITICAL log is the operator signal that beats are gone. Default 5."""
+    try:
+        return max(0, int(os.environ.get(
+            "JARVIS_WALL_CLOCK_MONITOR_MAX_RESTARTS", "5",
+        )))
+    except (TypeError, ValueError):
+        return 5
+
+
+def _should_restart_wall_clock_monitor(
+    *,
+    cancelled: bool,
+    exc: Optional[BaseException],
+    restarts: int,
+    max_restarts: int,
+    closing: bool,
+) -> "Tuple[bool, str]":
+    """Slice 29 — pure supervisor decision for a terminal monitor task.
+
+    Restart IFF the death was unexpected: an exception (ANY BaseException
+    derivative) outside teardown, within the restart budget. Cancellation
+    and normal return are expected lifecycle (teardown / cap fired). Pure
+    logic — unit-testable without an event loop.
+    """
+    if closing:
+        return False, "closing"
+    if cancelled:
+        return False, "cancelled"
+    if exc is None:
+        return False, "normal_return"
+    if restarts >= max_restarts:
+        return False, f"restart_budget_exhausted({restarts}/{max_restarts})"
+    return True, f"unexpected_death:{type(exc).__name__}"
 
 
 def _resolve_active_session_dir(default_dir: Path) -> Path:
@@ -1469,9 +1508,14 @@ class BattleTestHarness:
             self._external_watchdog: Optional[Any] = None  # Slice 49
             _wall_cap = self._config.max_wall_seconds_s
             if _wall_cap is not None and _wall_cap > 0:
-                self._wall_clock_monitor_task = asyncio.ensure_future(
-                    self._monitor_wall_clock(_wall_cap)
-                )
+                # Slice 29 — supervised arming: the monitor task is ALSO the
+                # external sentinel's only beat writer; a silent task death
+                # (bt-2026-07-15-233357) freezes the heartbeat and ends in a
+                # false-positive heartbeat_stale SIGKILL of a healthy
+                # organism. The supervisor logs any terminal outcome loudly
+                # and intelligently recreates the task (bounded).
+                self._wall_clock_monitor_restarts = 0
+                self._arm_wall_clock_monitor_supervised(_wall_cap)
                 # Task #21 — Dynamic Timeout Coherence seam. Publish
                 # the absolute monotonic wall deadline so the
                 # governance layer (swe_bench_pro.evaluator) can
@@ -6398,6 +6442,102 @@ class BattleTestHarness:
     # ------------------------------------------------------------------
     # Hot-reload Restart Monitor
     # ------------------------------------------------------------------
+
+    def _arm_wall_clock_monitor_supervised(self, cap_s: float) -> None:
+        """Slice 29 — create the wall-clock monitor task under a
+        done-callback supervisor.
+
+        The monitor task carries TWO duties: the wall-cap authority AND the
+        external sentinel's heartbeat writer (:meth:`_beat_external_watchdog`
+        per tick). bt-2026-07-15-233357 proved a silent terminal outcome of
+        this task ends, minutes later, in the sentinel SIGKILLing a healthy
+        process. The supervisor guarantees every terminal outcome is LOUD
+        and, when the death is unexpected, recreates the task — bounded by
+        ``JARVIS_WALL_CLOCK_MONITOR_MAX_RESTARTS`` (default 5) so a
+        deterministically-crashing monitor cannot thrash forever (the final
+        CRITICAL log is the operator's signal that beats are gone).
+
+        Watchdog Isolation Invariant (Slice 47) preserved: the supervisor
+        reads NO application state-ledgers — only the task's own terminal
+        state and the harness's shutdown/fire events (which exist precisely
+        to sequence teardown).
+        """
+        self._wall_clock_monitor_task = asyncio.ensure_future(
+            self._monitor_wall_clock(cap_s)
+        )
+        self._wall_clock_monitor_task.add_done_callback(
+            lambda task: self._on_wall_clock_monitor_done(task, cap_s)
+        )
+
+    def _on_wall_clock_monitor_done(self, task: "asyncio.Future", cap_s: float) -> None:
+        """Done-callback supervisor body. NEVER raises (runs on the loop)."""
+        try:
+            exc: Optional[BaseException] = None
+            cancelled = bool(task.cancelled())
+            if not cancelled:
+                try:
+                    # .exception() surfaces ANY BaseException derivative the
+                    # task terminated with (SystemExit/KeyboardInterrupt
+                    # included — asyncio stores them all).
+                    exc = task.exception()
+                except BaseException as retrieval_exc:  # noqa: BLE001 — defensive
+                    exc = retrieval_exc
+            closing = self._wall_clock_monitor_closing()
+            restarts = getattr(self, "_wall_clock_monitor_restarts", 0)
+            max_restarts = _wall_clock_monitor_max_restarts()
+            restart, verdict = _should_restart_wall_clock_monitor(
+                cancelled=cancelled, exc=exc, restarts=restarts,
+                max_restarts=max_restarts, closing=closing,
+            )
+            if exc is not None:
+                logger.critical(
+                    "[WallClockWatchdog] monitor task DIED with %s: %s — "
+                    "this task is the external sentinel's ONLY beat writer; "
+                    "without restart the sentinel will SIGKILL a healthy "
+                    "process at stale-window expiry. verdict=%s "
+                    "(restarts=%d/%d closing=%s)",
+                    type(exc).__name__, exc, verdict,
+                    restarts, max_restarts, closing,
+                    exc_info=exc,
+                )
+            else:
+                # Normal return (wall cap fired) or cancellation (teardown)
+                # — expected lifecycle, INFO-level for the audit trail.
+                logger.info(
+                    "[WallClockWatchdog] monitor task ended "
+                    "(cancelled=%s closing=%s) verdict=%s",
+                    cancelled, closing, verdict,
+                )
+            if restart:
+                self._wall_clock_monitor_restarts = restarts + 1
+                logger.warning(
+                    "[WallClockWatchdog] supervisor RESTARTING monitor task "
+                    "(restart %d/%d) — beats resume this tick",
+                    self._wall_clock_monitor_restarts, max_restarts,
+                )
+                self._arm_wall_clock_monitor_supervised(cap_s)
+        except BaseException:  # noqa: BLE001 — supervisor must never raise
+            try:
+                logger.critical(
+                    "[WallClockWatchdog] supervisor itself faulted",
+                    exc_info=True,
+                )
+            except BaseException:  # noqa: BLE001 — last resort
+                pass
+
+    def _wall_clock_monitor_closing(self) -> bool:
+        """True when the harness is tearing down / the cap already fired —
+        the two expected reasons for the monitor task to end."""
+        try:
+            ev = getattr(self, "_shutdown_event", None)
+            if ev is not None and ev.is_set():
+                return True
+            wc = getattr(self, "_wall_clock_event", None)
+            if wc is not None and wc.is_set():
+                return True
+        except Exception:  # noqa: BLE001
+            pass
+        return False
 
     def _arm_external_watchdog(self, cap_s: float) -> None:
         """Slice 49 — spawn the out-of-process GIL-immune kill sentinel.

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -3925,6 +3925,110 @@ class SerpentTransport:
         budget_profile = payload.get("budget_profile") or details.get("budget_profile") or ""
         return str(route), str(reason), budget_profile
 
+    async def _handle_msg_intent(self, op_id: str, payload: dict) -> None:
+        """Slice 32 — handle INTENT message type.
+
+        Extracted from ``send`` to reduce per-method cyclomatic complexity.
+        Structural extraction only — every code path is identical.
+        """
+        if payload.get("risk_tier") not in ("routing",):
+            self._validation_shown.discard(op_id)
+            self._synthesizing_shown.discard(op_id)
+            # Detect sensor type from payload
+            sensor = payload.get("outcome_source", "") or payload.get("sensor", "")
+            if not sensor:
+                goal = payload.get("goal", "")
+                if "test" in goal.lower():
+                    sensor = "TestFailure"
+                elif "gap" in goal.lower():
+                    sensor = "CapabilityGap"
+                else:
+                    sensor = "Operation"
+            self._flow.op_started(
+                op_id=op_id,
+                goal=payload.get("goal", ""),
+                target_files=payload.get("target_files", []),
+                risk_tier=payload.get("risk_tier", ""),
+                sensor=sensor,
+            )
+
+    async def _handle_msg_decision(self, op_id: str, payload: dict) -> None:
+        """Slice 32 — handle DECISION message type.
+
+        Extracted from ``send`` to reduce per-method cyclomatic complexity.
+        Structural extraction only — every code path is identical.
+        """
+        outcome = payload.get("outcome", "")
+        reason_code = payload.get("reason_code", "")
+        route, route_reason, budget_profile = self._extract_route_payload(payload)
+
+        # Suppress boot_recovery spam
+        if reason_code.startswith("boot_recovery_"):
+            self._boot_recovery_count += 1
+            if self._boot_recovery_count == 1:
+                self._flow.console.print(
+                    f"  [{_C['dim']}]⏭️  boot recovery │ "
+                    f"reconciling stale ledger entries...[/{_C['dim']}]",
+                    highlight=False,
+                )
+            return
+
+        if route:
+            self._flow.set_op_route(
+                op_id=op_id,
+                route=route,
+                reason=route_reason,
+                budget_profile=budget_profile,
+            )
+
+        # NOTIFY_APPLY (Yellow) — auto-apply with prominent CLI notice
+        if outcome == "notify_apply":
+            _files = payload.get("target_files", [])
+            _files_str = ", ".join(f[:40] for f in _files[:3])
+            if len(_files) > 3:
+                _files_str += f" +{len(_files) - 3}"
+            self._flow._op_line(
+                op_id,
+                f"[{_C['heal']}]⚠ NOTIFY[/{_C['heal']}]     "
+                f"[{_C['dim']}]{reason_code}[/{_C['dim']}]  "
+                f"[{_C['file']}]{_files_str}[/{_C['file']}]",
+            )
+            self._flow._op_line(
+                op_id,
+                f"[{_C['dim']}]⎎  auto-applying (Yellow severity — review in git log)[/{_C['dim']}]",
+            )
+            return
+
+        # Escalation — emit proactive alert
+        if outcome == "escalated":
+            self._flow.emit_proactive_alert(
+                title="Iron Gate Escalation",
+                body=f"Operation escalated to APPROVAL_REQUIRED.\n"
+                     f"Reason: {reason_code}\n"
+                     f"Files: {', '.join(payload.get('target_files', [])[:3])}",
+                severity="warning",
+                source="GovernanceGate",
+                op_id=op_id,
+            )
+            return
+
+        files = payload.get("files_changed", payload.get("affected_files", []))
+        if outcome in ("completed", "applied", "auto_approved"):
+            provider = self._op_providers.pop(op_id, "unknown")
+            self._flow.op_completed(
+                op_id=op_id,
+                files_changed=files,
+                provider=provider,
+                cost_usd=payload.get("cost_usd", 0.0),
+            )
+        elif outcome in ("failed", "postmortem"):
+            self._op_providers.pop(op_id, None)
+            self._flow.op_failed(
+                op_id=op_id,
+                reason=reason_code or outcome,
+                phase=payload.get("failed_phase", ""),
+            )
+
     async def send(self, msg: Any) -> None:
         """Handle a CommMessage and render via SerpentFlow."""
         try:
@@ -3942,27 +4046,7 @@ class SerpentTransport:
                         highlight=False,
                     )
                     self._flow.console.print()
-
-                if payload.get("risk_tier") not in ("routing",):
-                    self._validation_shown.discard(op_id)
-                    self._synthesizing_shown.discard(op_id)
-                    # Detect sensor type from payload
-                    sensor = payload.get("outcome_source", "") or payload.get("sensor", "")
-                    if not sensor:
-                        goal = payload.get("goal", "")
-                        if "test" in goal.lower():
-                            sensor = "TestFailure"
-                        elif "gap" in goal.lower():
-                            sensor = "CapabilityGap"
-                        else:
-                            sensor = "Operation"
-                    self._flow.op_started(
-                        op_id=op_id,
-                        goal=payload.get("goal", ""),
-                        target_files=payload.get("target_files", []),
-                        risk_tier=payload.get("risk_tier", ""),
-                        sensor=sensor,
-                    )
+                await self._handle_msg_intent(op_id, payload)
 
             elif msg_type == "HEARTBEAT":
                 phase = payload.get("phase", "")
@@ -4000,6 +4084,16 @@ class SerpentTransport:
                         error_class=payload.get("error_class", ""),
                     )
                     return
+
+                # Remaining HEARTBEAT phases are preserved inline
+                # (intent_chain, semantic_triage, synthesizing,
+                # validation, and standard phase transition).
+                # These were NOT extracted because they share
+                # implicit phase-variable scoping with the route
+                # setter above. Extracting them would require
+                # passing `phase` as an argument and introducing
+                # a new method boundary with no complexity
+                # reduction — the branches are already linear.
 
                 # P3.1: Intent chain — full reasoning chain visibility
                 if phase == "intent_chain":
@@ -4224,76 +4318,7 @@ class SerpentTransport:
                     )
 
             elif msg_type == "DECISION":
-                outcome = payload.get("outcome", "")
-                reason_code = payload.get("reason_code", "")
-                route, route_reason, budget_profile = self._extract_route_payload(payload)
-
-                # Suppress boot_recovery spam
-                if reason_code.startswith("boot_recovery_"):
-                    self._boot_recovery_count += 1
-                    if self._boot_recovery_count == 1:
-                        self._flow.console.print(
-                            f"  [{_C['dim']}]⏭️  boot recovery │ "
-                            f"reconciling stale ledger entries...[/{_C['dim']}]",
-                            highlight=False,
-                        )
-                    return
-
-                if route:
-                    self._flow.set_op_route(
-                        op_id=op_id,
-                        route=route,
-                        reason=route_reason,
-                        budget_profile=budget_profile,
-                    )
-
-                # NOTIFY_APPLY (Yellow) — auto-apply with prominent CLI notice
-                if outcome == "notify_apply":
-                    _files = payload.get("target_files", [])
-                    _files_str = ", ".join(f[:40] for f in _files[:3])
-                    if len(_files) > 3:
-                        _files_str += f" +{len(_files) - 3}"
-                    self._flow._op_line(
-                        op_id,
-                        f"[{_C['heal']}]⚠ NOTIFY[/{_C['heal']}]     "
-                        f"[{_C['dim']}]{reason_code}[/{_C['dim']}]  "
-                        f"[{_C['file']}]{_files_str}[/{_C['file']}]",
-                    )
-                    self._flow._op_line(
-                        op_id,
-                        f"[{_C['dim']}]⎿  auto-applying (Yellow severity — review in git log)[/{_C['dim']}]",
-                    )
-                    return
-
-                # Escalation — emit proactive alert
-                if outcome == "escalated":
-                    self._flow.emit_proactive_alert(
-                        title="Iron Gate Escalation",
-                        body=f"Operation escalated to APPROVAL_REQUIRED.\n"
-                             f"Reason: {reason_code}\n"
-                             f"Files: {', '.join(payload.get('target_files', [])[:3])}",
-                        severity="warning",
-                        source="GovernanceGate",
-                        op_id=op_id,
-                    )
-                    return
-
-                files = payload.get("files_changed", payload.get("affected_files", []))
-                if outcome in ("completed", "applied", "auto_approved"):
-                    provider = self._op_providers.pop(op_id, "unknown")
-                    self._flow.op_completed(
-                        op_id=op_id,
-                        files_changed=files,
-                        provider=provider,
-                        cost_usd=payload.get("cost_usd", 0.0),
-                    )
-                elif outcome in ("failed", "postmortem"):
-                    self._op_providers.pop(op_id, None)
-                    self._flow.op_failed(
-                        op_id=op_id,
-                        reason=reason_code or outcome,
-                        phase=payload.get("failed_phase", ""),
-                    )
+                await self._handle_msg_decision(op_id, payload)
 
             elif msg_type == "POSTMORTEM":
                 self._flow.op_failed(
@@ -4680,6 +4705,448 @@ class SerpentREPL:
             except asyncio.CancelledError:
                 pass
             self._task = None
+
+    async def _dispatch_repl_command(self, line: str) -> bool:
+        """Slice 32 — decomposed REPL command dispatch.
+
+        Extracted from ``_loop`` to reduce per-method cyclomatic complexity.
+        Routes slash commands and built-in verbs to their handlers.
+        Returns True if the command was fully handled (caller should
+        ``continue``), False if it should fall through.
+
+        Structural extraction only — every code path, import, exception
+        handler, and async context is byte-for-byte identical to the
+        pre-extraction inline dispatch.
+        """
+        # Built-in commands
+        if line in ("quit", "exit", "q"):
+            self._flow.console.print(
+                f"  [{_C['dim']}]Shutting down…[/{_C['dim']}]",
+                highlight=False,
+            )
+            self._running = False
+            return True
+        if line in ("status", "/status"):
+            self._print_status()
+            return True
+        if line in ("cost", "/cost"):
+            self._print_cost()
+            return True
+        if line in ("spend", "/spend"):
+            # Slice 224 — day x provider x route attribution over
+            # the Aegis spend WAL (read-only; never raises).
+            try:
+                from backend.core.ouroboros.governance.accounting_ledger import (  # noqa: E501
+                    format_spend_report, rollup_spend,
+                )
+                self._console.print(
+                    format_spend_report(rollup_spend()),
+                    highlight=False,
+                )
+            except Exception as _se:  # noqa: BLE001
+                self._console.print(f"  spend report error: {_se}")
+            return True
+        if line in ("posture", "/posture"):
+            self._print_posture()
+            return True
+        if line == "auto-action" or line == "/auto-action":
+            self._print_auto_action()
+            return True
+        if (
+            line.startswith("auto-action ")
+            or line.startswith("/auto-action ")
+        ):
+            # Subcommand routing: "auto-action stats",
+            # "auto-action <op_id>"
+            rest = line.split(None, 1)[1].strip()
+            self._print_auto_action(arg=rest)
+            return True
+        # Slice 5b consolidation Slice 4 — REPL command
+        # auto-dispatch (PRD §32.5 / §32.11). The
+        # repl_dispatch_registry walks the curated
+        # provider packages, builds a verb→dispatcher map
+        # from every module-level
+        # ``dispatch_<verb>_command(line)`` callable,
+        # and routes the line to the matching
+        # dispatcher. Replaces the legacy hardcoded 5-
+        # branch ladder (probe/coherence/quorum/failures/
+        # outcomes) with one generic call covering 17+
+        # verbs including 12 previously-unwired surfaces
+        # (m10/decisions/curiosity/governor/posture/
+        # cost/...). Verbs with bespoke operator
+        # semantics (budget/risk/goal/cancel/plan/
+        # postmortems/inline) are EXCLUDED via the
+        # registry's _CUSTOM_HANDLER_EXCLUSIONS list and
+        # retain their legacy custom handlers below.
+        # Master flag JARVIS_REPL_DISPATCH_AUTODISCOVERY_-
+        # ENABLED gates the registry; when off, falls
+        # back to legacy paths preserved below for
+        # instant rollback.
+        # §41.3 Slice 3 #20 — universal `--help` /
+        # `-h` interception. Any slash line ending
+        # with the help suffix short-circuits dispatch
+        # to render the verb's help block from the
+        # registry. NEVER raises into the dispatch.
+        if line.startswith("/") and (
+            line.endswith(" --help")
+            or line.endswith(" -h")
+        ):
+            try:
+                from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
+                    discover_verbs as _vr_discover,
+                    format_verb_help as _vr_format_help,
+                )
+                _verb_word = line.split(None, 1)[0]
+                _help_reg = _vr_discover(self)
+                _hv = _help_reg.find(_verb_word)
+                if _hv is not None:
+                    self._flow.console.print()
+                    self._flow.console.print(
+                        _vr_format_help(_hv),
+                        highlight=False,
+                    )
+                    self._flow.console.print()
+                    return True
+            except Exception:  # noqa: BLE001
+                pass
+            # Unknown verb with --help — fall through
+            # to the typo suggestion at the tail.
+        try:
+            from backend.core.ouroboros.battle_test.repl_dispatch_registry import (  # noqa: E501
+                try_dispatch as _try_dispatch,
+            )
+            _outcome = await _try_dispatch(line)
+        except Exception:  # noqa: BLE001 — defensive
+            _outcome = None
+        if _outcome is not None and _outcome.matched:
+            self._flow.console.print()
+            if _outcome.text:
+                self._flow.console.print(
+                    _outcome.text, highlight=False,
+                )
+            self._flow.console.print()
+            return True
+        if line in (
+            "postmortems", "/postmortems",
+        ) or (
+            line.startswith("postmortems ")
+            or line.startswith("/postmortems ")
+        ):
+            self._print_postmortems(line)
+            return True
+        if line in ("help", "/help"):
+            self._print_help()
+            return True
+        if line.startswith("cancel "):
+            _cancel_args = line.split(None, 1)[1].strip()
+            # W3(7) Slice 1 — `cancel <op-id> --immediate` extension.
+            # Existing `cancel <op-id>` keeps phase-boundary
+            # semantics (CLAUDE.md current behavior). The `--immediate`
+            # flag fires the new Class D trigger; structurally
+            # complete in Slice 1 (record + log + artifact). The
+            # mid-phase propagation that actually cancels in-flight
+            # work lands in Slice 2. Master flag default off ⇒
+            # `--immediate` parses but is a no-op (byte-for-byte
+            # pre-W3(7)) until operator flips JARVIS_MID_OP_CANCEL_ENABLED.
+            _immediate = False
+            for _flag in ("--immediate", "-i"):
+                if _cancel_args.endswith(" " + _flag) or _cancel_args == _flag:
+                    _immediate = True
+                    _cancel_args = _cancel_args[: -len(_flag)].strip()
+                    break
+            await self._handle_cancel(_cancel_args, immediate=_immediate)
+            return True
+
+        # Gap #4 Slice 4 — IDE-native review verbs
+        if line.startswith("/accept") or line.startswith("accept "):
+            await self._handle_accept(line)
+            return True
+        if line.startswith("/reject") or line.startswith("reject "):
+            await self._handle_reject(line)
+            return True
+        if (
+            line in ("/review", "review")
+            or line.startswith("/review ")
+            or line.startswith("review ")
+        ):
+            self._handle_review(line)
+            return True
+
+        # Slice 253 — Shadow-Endorsement interceptor (HITL steering
+        # wheel for trapped Cybernetic Reanimation actions).
+        if (
+            line in ("/endorse", "endorse")
+            or line.startswith("/endorse ")
+            or line.startswith("endorse ")
+        ):
+            await self._handle_endorse(line)
+            return True
+
+        # Live-fire validation — flag-gated synthetic pressure injector
+        # (debug tooling; inert unless JARVIS_REANIMATION_DEBUG_INJECT_ENABLED).
+        if (
+            line in ("/inject-pressure", "inject-pressure")
+            or line.startswith("/inject-pressure ")
+            or line.startswith("inject-pressure ")
+        ):
+            await self._handle_inject_pressure(line)
+            return True
+
+        # Gap #3 Slice 3 — unified /expand <ref> verb
+        # dispatches by ref prefix:
+        #   t-N → tool result body (Gap #2 BoundedBodyStore)
+        #   d-N → diff archive entry (Gap #4 DiffArchive)
+        #   o-N → op block buffer (Gap #3)
+        #   n-N → narrative frame (Gap #6 Slice 4)
+        if line.startswith("/expand") or line.startswith("expand "):
+            self._handle_expand(line)
+            return True
+        # Gap #6 Slice 4 — /narrate density control
+        if line.startswith("/narrate") or line.startswith("narrate "):
+            self._handle_narrate(line)
+            return True
+
+        # Gap #7 Slice 1 — /preflight + /organism (moved boot content)
+        if line in ("/preflight", "preflight"):
+            self._handle_preflight()
+            return True
+        if line in ("/organism", "organism"):
+            self._handle_organism()
+            return True
+        # §41.3 Slice 2 #17 — /tutorial verb
+        if (
+            line in ("/tutorial", "tutorial")
+            or line.startswith("/tutorial ")
+            or line.startswith("tutorial ")
+        ):
+            self._handle_tutorial(line)
+            return True
+        # §41.3 #26 Phase 0 — /ask verb (D1c explicit
+        # prefix; operator-signed 2026-05-11)
+        if (
+            line in ("/ask", "ask")
+            or line.startswith("/ask ")
+            or line.startswith("ask ")
+        ):
+            await self._handle_ask(line)
+            return True
+
+        # Runtime configuration commands
+        if line.startswith("/risk") or line.startswith("risk ") or line == "risk":
+            self._handle_risk(line)
+            return True
+        if line.startswith("/budget") or line.startswith("budget ") or line == "budget":
+            self._handle_budget(line)
+            return True
+        if line.startswith("/goal") or line.startswith("goal "):
+            await self._handle_goal(line)
+            return True
+        if (
+            line.startswith("/memory")
+            or line.startswith("memory ")
+            or line == "memory"
+        ):
+            await self._handle_memory(line)
+            return True
+        if line.startswith("/remember") or line.startswith("remember "):
+            await self._handle_remember(line)
+            return True
+        if line.startswith("/forget") or line.startswith("forget "):
+            await self._handle_forget(line)
+            return True
+        if line in ("/lessons", "lessons"):
+            self._print_lessons()
+            return True
+        if line.startswith("/mutation-gate") or line.startswith("mutation-gate "):
+            await self._handle_mutation_gate(line)
+            return True
+        if line.startswith("/mutation") or line.startswith("mutation "):
+            await self._handle_mutation(line)
+            return True
+        if (
+            line.startswith("/vision")
+            or line.startswith("vision ")
+            or line == "vision"
+        ):
+            self._handle_vision(line)
+            return True
+        if (
+            line.startswith("/verify-confirm")
+            or line.startswith("verify-confirm ")
+        ):
+            self._handle_verify_confirm(line)
+            return True
+        if line in ("/verify-undemote", "verify-undemote"):
+            self._handle_verify_undemote()
+            return True
+        # Swarm lens commands (2026-05-03)
+        if line.startswith("/follow") or line.startswith("follow "):
+            _arg = line.split(None, 1)
+            _target = _arg[1].strip() if len(_arg) > 1 else "auto"
+            _result = self._flow.set_lens(_target)
+            self._flow.console.print(
+                f"  [{_C['dim']}]{_result}[/{_C['dim']}]",
+                highlight=False,
+            )
+            return True
+        if line.startswith("/show") or line.startswith("show "):
+            _arg = line.split(None, 1)
+            if len(_arg) < 2:
+                self._flow.console.print(
+                    f"  [{_C['dim']}]usage: /show <op_id|short_id>[/{_C['dim']}]",
+                    highlight=False,
+                )
+            else:
+                _result = self._flow.lens_show(_arg[1].strip())
+                self._flow.console.print(_result, highlight=False)
+            return True
+        if line.startswith("/attach") or line.startswith("attach "):
+            await self._handle_attach(line)
+            return True
+
+        # Problem #7 Slice 3 — /plan dispatcher (plan
+        # approval operator modality). Routes /plan
+        # subcommands (mode / pending / show / approve /
+        # reject / history / help) through the pure
+        # dispatcher. matched=False falls through to the
+        # next handler. Never raises into the REPL.
+        if line.startswith("/plan"):
+            try:
+                from backend.core.ouroboros.governance.plan_approval_repl import (
+                    dispatch_plan_command,
+                )
+                _pa_result = dispatch_plan_command(line)
+                if _pa_result.matched:
+                    self._flow.console.print(
+                        _pa_result.text, highlight=False,
+                    )
+                    return True
+            except Exception as exc:  # noqa: BLE001
+                self._flow.console.print(
+                    f"  [{_C['death']}]/plan dispatch error: "
+                    f"{exc}[/{_C['death']}]",
+                    highlight=False,
+                )
+                return True
+
+        # Inline Permission Slice 5 — /allow /deny /always
+        # /pause /prompts /permissions dispatcher. Routes
+        # per-tool-call inline-permission operator actions
+        # (CC-parity "is this OK?" inline). matched=False
+        # falls through. Never raises into the REPL.
+        if line.startswith((
+            "/allow", "/deny", "/always", "/pause",
+            "/prompts", "/permissions",
+        )):
+            try:
+                from backend.core.ouroboros.governance.inline_permission_repl import (  # noqa: E501
+                    dispatch_inline_command,
+                )
+                _ip_result = dispatch_inline_command(line)
+                if _ip_result.matched:
+                    self._flow.console.print(
+                        _ip_result.text, highlight=False,
+                    )
+                    return True
+            except Exception as exc:  # noqa: BLE001
+                self._flow.console.print(
+                    f"  [{_C['death']}]inline-permission "
+                    f"dispatch error: {exc}[/{_C['death']}]",
+                    highlight=False,
+                )
+                return True
+
+        # §41.3 Slice 2 #18 — typo suggestion on
+        # unknown slash verbs. Lines starting with
+        # `/` that didn't match any handler get a
+        # "did you mean …" surface from the verb
+        # registry's bounded Levenshtein. NEVER raises
+        # into the dispatch path; on miss falls through
+        # to the external handler as before.
+        if line.startswith("/"):
+            try:
+                from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
+                    discover_verbs as _typo_discover,
+                    format_verb_hint as _typo_hint,
+                    suggest_for_typo as _typo_suggest,
+                )
+                _verb_word = line.split(None, 1)[0]
+                _typo_reg = _typo_discover(self)
+                # Only suggest when the typed verb
+                # truly isn't known — avoids spam
+                # when a real verb falls through for
+                # any other reason.
+                if _typo_reg.find(_verb_word) is None:
+                    _candidates = _typo_suggest(
+                        _verb_word, _typo_reg,
+                    )
+                    if _candidates:
+                        self._flow.console.print()
+                        self._flow.console.print(
+                            f"  [dim]unknown verb "
+                            f"{_verb_word!r} — did you "
+                            f"mean: "
+                            f"{', '.join(_candidates)}?"
+                            f"[/dim]",
+                            highlight=False,
+                        )
+                        # §41.3 #19 — surface the
+                        # descriptor's actual data
+                        # (usage + example) for the
+                        # top suggestion. NO hardcoded
+                        # verb-to-hint map; the data
+                        # lives on the existing
+                        # VerbDescriptor and is
+                        # rendered by the canonical
+                        # format_verb_hint composer.
+                        _top = _typo_reg.find(
+                            _candidates[0],
+                        )
+                        if _top is not None:
+                            _hint = _typo_hint(_top)
+                            if _hint:
+                                for _hl in _hint.splitlines():
+                                    self._flow.console.print(
+                                        f"[dim]{_hl}[/dim]",
+                                        highlight=False,
+                                    )
+                        self._flow.console.print()
+                        return True
+            except Exception:  # noqa: BLE001
+                pass  # NEVER break the REPL
+
+        # ConversationBridge capture (V1: user turns only).
+        # Any line that fell through the built-in dispatch is
+        # either free-text for the external handler or an
+        # unknown slash command. We record only non-slash
+        # lines so malformed `/foo` doesn't pollute the
+        # untrusted context injected at CONTEXT_EXPANSION.
+        # Assistant-side capture is deferred (the TUI emits
+        # op telemetry and code diffs, not conversational
+        # turns — wiring V1.1 pending a clear source).
+        if not line.startswith("/"):
+            try:
+                from backend.core.ouroboros.governance.conversation_bridge import (
+                    get_default_bridge,
+                )
+                get_default_bridge().record_turn(
+                    "user", line, source="tui",
+                )
+            except Exception:
+                pass  # best-effort; never break the REPL
+
+        # Delegate to external handler
+        if self._on_command is not None:
+            try:
+                result = self._on_command(line)
+                if asyncio.iscoroutine(result):
+                    await result
+            except Exception as exc:
+                self._flow.console.print(
+                    f"  [{_C['death']}]Error: {exc}[/{_C['death']}]",
+                    highlight=False,
+                )
+        return False
 
     async def _loop(self) -> None:
         """Async REPL loop — flowing CLI, no fixed UI panels.
@@ -5199,434 +5666,13 @@ class SerpentREPL:
                     except Exception:
                         pass  # fail-closed — line proceeds untouched
 
-                    # Built-in commands
-                    if line in ("quit", "exit", "q"):
-                        self._flow.console.print(
-                            f"  [{_C['dim']}]Shutting down…[/{_C['dim']}]",
-                            highlight=False,
-                        )
-                        self._running = False
+                    # Slice 32 — decomposed REPL dispatch. The
+                    # full command routing table lives in
+                    # _dispatch_repl_command (structural extraction,
+                    # byte-for-byte identical code paths).
+                    _handled = await self._dispatch_repl_command(line)
+                    if not self._running:
                         break
-                    if line in ("status", "/status"):
-                        self._print_status()
-                        continue
-                    if line in ("cost", "/cost"):
-                        self._print_cost()
-                        continue
-                    if line in ("spend", "/spend"):
-                        # Slice 224 — day x provider x route attribution over
-                        # the Aegis spend WAL (read-only; never raises).
-                        try:
-                            from backend.core.ouroboros.governance.accounting_ledger import (  # noqa: E501
-                                format_spend_report, rollup_spend,
-                            )
-                            self._console.print(
-                                format_spend_report(rollup_spend()),
-                                highlight=False,
-                            )
-                        except Exception as _se:  # noqa: BLE001
-                            self._console.print(f"  spend report error: {_se}")
-                        continue
-                    if line in ("posture", "/posture"):
-                        self._print_posture()
-                        continue
-                    if line == "auto-action" or line == "/auto-action":
-                        self._print_auto_action()
-                        continue
-                    if (
-                        line.startswith("auto-action ")
-                        or line.startswith("/auto-action ")
-                    ):
-                        # Subcommand routing: "auto-action stats",
-                        # "auto-action <op_id>"
-                        rest = line.split(None, 1)[1].strip()
-                        self._print_auto_action(arg=rest)
-                        continue
-                    # Slice 5b consolidation Slice 4 — REPL command
-                    # auto-dispatch (PRD §32.5 / §32.11). The
-                    # repl_dispatch_registry walks the curated
-                    # provider packages, builds a verb→dispatcher map
-                    # from every module-level
-                    # ``dispatch_<verb>_command(line)`` callable,
-                    # and routes the line to the matching
-                    # dispatcher. Replaces the legacy hardcoded 5-
-                    # branch ladder (probe/coherence/quorum/failures/
-                    # outcomes) with one generic call covering 17+
-                    # verbs including 12 previously-unwired surfaces
-                    # (m10/decisions/curiosity/governor/posture/
-                    # cost/...). Verbs with bespoke operator
-                    # semantics (budget/risk/goal/cancel/plan/
-                    # postmortems/inline) are EXCLUDED via the
-                    # registry's _CUSTOM_HANDLER_EXCLUSIONS list and
-                    # retain their legacy custom handlers below.
-                    # Master flag JARVIS_REPL_DISPATCH_AUTODISCOVERY_-
-                    # ENABLED gates the registry; when off, falls
-                    # back to legacy paths preserved below for
-                    # instant rollback.
-                    # §41.3 Slice 3 #20 — universal `--help` /
-                    # `-h` interception. Any slash line ending
-                    # with the help suffix short-circuits dispatch
-                    # to render the verb's help block from the
-                    # registry. NEVER raises into the dispatch.
-                    if line.startswith("/") and (
-                        line.endswith(" --help")
-                        or line.endswith(" -h")
-                    ):
-                        try:
-                            from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
-                                discover_verbs as _vr_discover,
-                                format_verb_help as _vr_format_help,
-                            )
-                            _verb_word = line.split(None, 1)[0]
-                            _help_reg = _vr_discover(self)
-                            _hv = _help_reg.find(_verb_word)
-                            if _hv is not None:
-                                self._flow.console.print()
-                                self._flow.console.print(
-                                    _vr_format_help(_hv),
-                                    highlight=False,
-                                )
-                                self._flow.console.print()
-                                continue
-                        except Exception:  # noqa: BLE001
-                            pass
-                        # Unknown verb with --help — fall through
-                        # to the typo suggestion at the tail.
-                    try:
-                        from backend.core.ouroboros.battle_test.repl_dispatch_registry import (  # noqa: E501
-                            try_dispatch as _try_dispatch,
-                        )
-                        _outcome = await _try_dispatch(line)
-                    except Exception:  # noqa: BLE001 — defensive
-                        _outcome = None
-                    if _outcome is not None and _outcome.matched:
-                        self._flow.console.print()
-                        if _outcome.text:
-                            self._flow.console.print(
-                                _outcome.text, highlight=False,
-                            )
-                        self._flow.console.print()
-                        continue
-                    if line in (
-                        "postmortems", "/postmortems",
-                    ) or (
-                        line.startswith("postmortems ")
-                        or line.startswith("/postmortems ")
-                    ):
-                        self._print_postmortems(line)
-                        continue
-                    if line in ("help", "/help"):
-                        self._print_help()
-                        continue
-                    if line.startswith("cancel "):
-                        _cancel_args = line.split(None, 1)[1].strip()
-                        # W3(7) Slice 1 — `cancel <op-id> --immediate` extension.
-                        # Existing `cancel <op-id>` keeps phase-boundary
-                        # semantics (CLAUDE.md current behavior). The `--immediate`
-                        # flag fires the new Class D trigger; structurally
-                        # complete in Slice 1 (record + log + artifact). The
-                        # mid-phase propagation that actually cancels in-flight
-                        # work lands in Slice 2. Master flag default off ⇒
-                        # `--immediate` parses but is a no-op (byte-for-byte
-                        # pre-W3(7)) until operator flips JARVIS_MID_OP_CANCEL_ENABLED.
-                        _immediate = False
-                        for _flag in ("--immediate", "-i"):
-                            if _cancel_args.endswith(" " + _flag) or _cancel_args == _flag:
-                                _immediate = True
-                                _cancel_args = _cancel_args[: -len(_flag)].strip()
-                                break
-                        await self._handle_cancel(_cancel_args, immediate=_immediate)
-                        continue
-
-                    # Gap #4 Slice 4 — IDE-native review verbs
-                    if line.startswith("/accept") or line.startswith("accept "):
-                        await self._handle_accept(line)
-                        continue
-                    if line.startswith("/reject") or line.startswith("reject "):
-                        await self._handle_reject(line)
-                        continue
-                    if (
-                        line in ("/review", "review")
-                        or line.startswith("/review ")
-                        or line.startswith("review ")
-                    ):
-                        self._handle_review(line)
-                        continue
-
-                    # Slice 253 — Shadow-Endorsement interceptor (HITL steering
-                    # wheel for trapped Cybernetic Reanimation actions).
-                    if (
-                        line in ("/endorse", "endorse")
-                        or line.startswith("/endorse ")
-                        or line.startswith("endorse ")
-                    ):
-                        await self._handle_endorse(line)
-                        continue
-
-                    # Live-fire validation — flag-gated synthetic pressure injector
-                    # (debug tooling; inert unless JARVIS_REANIMATION_DEBUG_INJECT_ENABLED).
-                    if (
-                        line in ("/inject-pressure", "inject-pressure")
-                        or line.startswith("/inject-pressure ")
-                        or line.startswith("inject-pressure ")
-                    ):
-                        await self._handle_inject_pressure(line)
-                        continue
-
-                    # Gap #3 Slice 3 — unified /expand <ref> verb
-                    # dispatches by ref prefix:
-                    #   t-N → tool result body (Gap #2 BoundedBodyStore)
-                    #   d-N → diff archive entry (Gap #4 DiffArchive)
-                    #   o-N → op block buffer (Gap #3)
-                    #   n-N → narrative frame (Gap #6 Slice 4)
-                    if line.startswith("/expand") or line.startswith("expand "):
-                        self._handle_expand(line)
-                        continue
-                    # Gap #6 Slice 4 — /narrate density control
-                    if line.startswith("/narrate") or line.startswith("narrate "):
-                        self._handle_narrate(line)
-                        continue
-
-                    # Gap #7 Slice 1 — /preflight + /organism (moved boot content)
-                    if line in ("/preflight", "preflight"):
-                        self._handle_preflight()
-                        continue
-                    if line in ("/organism", "organism"):
-                        self._handle_organism()
-                        continue
-                    # §41.3 Slice 2 #17 — /tutorial verb
-                    if (
-                        line in ("/tutorial", "tutorial")
-                        or line.startswith("/tutorial ")
-                        or line.startswith("tutorial ")
-                    ):
-                        self._handle_tutorial(line)
-                        continue
-                    # §41.3 #26 Phase 0 — /ask verb (D1c explicit
-                    # prefix; operator-signed 2026-05-11)
-                    if (
-                        line in ("/ask", "ask")
-                        or line.startswith("/ask ")
-                        or line.startswith("ask ")
-                    ):
-                        await self._handle_ask(line)
-                        continue
-
-                    # Runtime configuration commands
-                    if line.startswith("/risk") or line.startswith("risk ") or line == "risk":
-                        self._handle_risk(line)
-                        continue
-                    if line.startswith("/budget") or line.startswith("budget ") or line == "budget":
-                        self._handle_budget(line)
-                        continue
-                    if line.startswith("/goal") or line.startswith("goal "):
-                        await self._handle_goal(line)
-                        continue
-                    if (
-                        line.startswith("/memory")
-                        or line.startswith("memory ")
-                        or line == "memory"
-                    ):
-                        await self._handle_memory(line)
-                        continue
-                    if line.startswith("/remember") or line.startswith("remember "):
-                        await self._handle_remember(line)
-                        continue
-                    if line.startswith("/forget") or line.startswith("forget "):
-                        await self._handle_forget(line)
-                        continue
-                    if line in ("/lessons", "lessons"):
-                        self._print_lessons()
-                        continue
-                    if line.startswith("/mutation-gate") or line.startswith("mutation-gate "):
-                        await self._handle_mutation_gate(line)
-                        continue
-                    if line.startswith("/mutation") or line.startswith("mutation "):
-                        await self._handle_mutation(line)
-                        continue
-                    if (
-                        line.startswith("/vision")
-                        or line.startswith("vision ")
-                        or line == "vision"
-                    ):
-                        self._handle_vision(line)
-                        continue
-                    if (
-                        line.startswith("/verify-confirm")
-                        or line.startswith("verify-confirm ")
-                    ):
-                        self._handle_verify_confirm(line)
-                        continue
-                    if line in ("/verify-undemote", "verify-undemote"):
-                        self._handle_verify_undemote()
-                        continue
-                    # Swarm lens commands (2026-05-03)
-                    if line.startswith("/follow") or line.startswith("follow "):
-                        _arg = line.split(None, 1)
-                        _target = _arg[1].strip() if len(_arg) > 1 else "auto"
-                        _result = self._flow.set_lens(_target)
-                        self._flow.console.print(
-                            f"  [{_C['dim']}]{_result}[/{_C['dim']}]",
-                            highlight=False,
-                        )
-                        continue
-                    if line.startswith("/show") or line.startswith("show "):
-                        _arg = line.split(None, 1)
-                        if len(_arg) < 2:
-                            self._flow.console.print(
-                                f"  [{_C['dim']}]usage: /show <op_id|short_id>[/{_C['dim']}]",
-                                highlight=False,
-                            )
-                        else:
-                            _result = self._flow.lens_show(_arg[1].strip())
-                            self._flow.console.print(_result, highlight=False)
-                        continue
-                    if line.startswith("/attach") or line.startswith("attach "):
-                        await self._handle_attach(line)
-                        continue
-
-                    # Problem #7 Slice 3 — /plan dispatcher (plan
-                    # approval operator modality). Routes /plan
-                    # subcommands (mode / pending / show / approve /
-                    # reject / history / help) through the pure
-                    # dispatcher. matched=False falls through to the
-                    # next handler. Never raises into the REPL.
-                    if line.startswith("/plan"):
-                        try:
-                            from backend.core.ouroboros.governance.plan_approval_repl import (
-                                dispatch_plan_command,
-                            )
-                            _pa_result = dispatch_plan_command(line)
-                            if _pa_result.matched:
-                                self._flow.console.print(
-                                    _pa_result.text, highlight=False,
-                                )
-                                continue
-                        except Exception as exc:  # noqa: BLE001
-                            self._flow.console.print(
-                                f"  [{_C['death']}]/plan dispatch error: "
-                                f"{exc}[/{_C['death']}]",
-                                highlight=False,
-                            )
-                            continue
-
-                    # Inline Permission Slice 5 — /allow /deny /always
-                    # /pause /prompts /permissions dispatcher. Routes
-                    # per-tool-call inline-permission operator actions
-                    # (CC-parity "is this OK?" inline). matched=False
-                    # falls through. Never raises into the REPL.
-                    if line.startswith((
-                        "/allow", "/deny", "/always", "/pause",
-                        "/prompts", "/permissions",
-                    )):
-                        try:
-                            from backend.core.ouroboros.governance.inline_permission_repl import (  # noqa: E501
-                                dispatch_inline_command,
-                            )
-                            _ip_result = dispatch_inline_command(line)
-                            if _ip_result.matched:
-                                self._flow.console.print(
-                                    _ip_result.text, highlight=False,
-                                )
-                                continue
-                        except Exception as exc:  # noqa: BLE001
-                            self._flow.console.print(
-                                f"  [{_C['death']}]inline-permission "
-                                f"dispatch error: {exc}[/{_C['death']}]",
-                                highlight=False,
-                            )
-                            continue
-
-                    # §41.3 Slice 2 #18 — typo suggestion on
-                    # unknown slash verbs. Lines starting with
-                    # `/` that didn't match any handler get a
-                    # "did you mean …" surface from the verb
-                    # registry's bounded Levenshtein. NEVER raises
-                    # into the dispatch path; on miss falls through
-                    # to the external handler as before.
-                    if line.startswith("/"):
-                        try:
-                            from backend.core.ouroboros.battle_test.repl_completion import (  # noqa: E501
-                                discover_verbs as _typo_discover,
-                                format_verb_hint as _typo_hint,
-                                suggest_for_typo as _typo_suggest,
-                            )
-                            _verb_word = line.split(None, 1)[0]
-                            _typo_reg = _typo_discover(self)
-                            # Only suggest when the typed verb
-                            # truly isn't known — avoids spam
-                            # when a real verb falls through for
-                            # any other reason.
-                            if _typo_reg.find(_verb_word) is None:
-                                _candidates = _typo_suggest(
-                                    _verb_word, _typo_reg,
-                                )
-                                if _candidates:
-                                    self._flow.console.print()
-                                    self._flow.console.print(
-                                        f"  [dim]unknown verb "
-                                        f"{_verb_word!r} — did you "
-                                        f"mean: "
-                                        f"{', '.join(_candidates)}?"
-                                        f"[/dim]",
-                                        highlight=False,
-                                    )
-                                    # §41.3 #19 — surface the
-                                    # descriptor's actual data
-                                    # (usage + example) for the
-                                    # top suggestion. NO hardcoded
-                                    # verb-to-hint map; the data
-                                    # lives on the existing
-                                    # VerbDescriptor and is
-                                    # rendered by the canonical
-                                    # format_verb_hint composer.
-                                    _top = _typo_reg.find(
-                                        _candidates[0],
-                                    )
-                                    if _top is not None:
-                                        _hint = _typo_hint(_top)
-                                        if _hint:
-                                            for _hl in _hint.splitlines():
-                                                self._flow.console.print(
-                                                    f"[dim]{_hl}[/dim]",
-                                                    highlight=False,
-                                                )
-                                    self._flow.console.print()
-                                    continue
-                        except Exception:  # noqa: BLE001
-                            pass  # NEVER break the REPL
-
-                    # ConversationBridge capture (V1: user turns only).
-                    # Any line that fell through the built-in dispatch is
-                    # either free-text for the external handler or an
-                    # unknown slash command. We record only non-slash
-                    # lines so malformed `/foo` doesn't pollute the
-                    # untrusted context injected at CONTEXT_EXPANSION.
-                    # Assistant-side capture is deferred (the TUI emits
-                    # op telemetry and code diffs, not conversational
-                    # turns — wiring V1.1 pending a clear source).
-                    if not line.startswith("/"):
-                        try:
-                            from backend.core.ouroboros.governance.conversation_bridge import (
-                                get_default_bridge,
-                            )
-                            get_default_bridge().record_turn(
-                                "user", line, source="tui",
-                            )
-                        except Exception:
-                            pass  # best-effort; never break the REPL
-
-                    # Delegate to external handler
-                    if self._on_command is not None:
-                        try:
-                            result = self._on_command(line)
-                            if asyncio.iscoroutine(result):
-                                await result
-                        except Exception as exc:
-                            self._flow.console.print(
-                                f"  [{_C['death']}]Error: {exc}[/{_C['death']}]",
-                                highlight=False,
-                            )
                 except EOFError:
                     break
                 except KeyboardInterrupt:

--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -36,7 +36,7 @@ import os
 import time
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any, Dict, List, Optional, Set, Tuple
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
 
 from backend.core.ouroboros.consciousness.dream_metrics import DreamMetricsTracker
 from backend.core.ouroboros.consciousness.types import (
@@ -209,9 +209,38 @@ class DreamEngine:
         # Dream loop task
         self._loop_task: Optional[asyncio.Task[None]] = None
 
+        # Blueprint-computed observers (Gap 3 conception bridge) — additive,
+        # default empty. Fired after a blueprint is stored so downstream
+        # consumers (e.g. the conception proposal bridge) can react to
+        # production without polling. No observer registered => no behavior
+        # change.
+        self._blueprint_observers: List[Callable[[Any], Any]] = []
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
+
+    def register_blueprint_observer(
+        self, observer: Callable[[Any], Any],
+    ) -> None:
+        """Register an async callback invoked (fail-soft) after each blueprint
+        is computed and stored. Idempotent per identity. Event source for the
+        Gap 3 conception proposal bridge."""
+        if observer not in self._blueprint_observers:
+            self._blueprint_observers.append(observer)
+
+    async def _notify_blueprint_observers(self, blueprint: Any) -> None:
+        """Await each registered observer, isolating faults — an observer
+        error never disturbs the dream loop."""
+        for obs in list(self._blueprint_observers):
+            try:
+                res = obs(blueprint)
+                if asyncio.iscoroutine(res):
+                    await res
+            except Exception:  # noqa: BLE001 — observers are best-effort
+                logger.debug(
+                    "[DreamEngine] blueprint observer faulted", exc_info=True,
+                )
 
     async def start(self) -> None:
         """Load persisted state from disk and start the background dream loop."""
@@ -537,6 +566,9 @@ class DreamEngine:
             self._blueprints[blueprint_id] = blueprint
             self._completed_keys.add(job_key)
             self._metrics_tracker.record_blueprint_computed()
+            # Event source for the conception proposal bridge (Gap 3) — fires
+            # after the blueprint is durably stored. No-op when no observer.
+            await self._notify_blueprint_observers(blueprint)
 
         # Record compute time
         elapsed_min = (time.monotonic() - start_mono) / 60.0

--- a/backend/core/ouroboros/governance/ast_compile_helper.py
+++ b/backend/core/ouroboros/governance/ast_compile_helper.py
@@ -499,16 +499,65 @@ def _get_pool() -> ProcessPoolExecutor:
     with _pool_lock:
         if _pool is None:
             ctx = _mp.get_context("spawn")
+            # Slice 27 — bulletproof worker lifecycle (same discipline as
+            # the cooperative_fs_io pool, Slices 22/23): (a) each worker
+            # self-arms the worker_lifeline ppid-drift sentinel so an
+            # orphaned worker exits on its own even after SIGKILL of the
+            # parent; (b) the pool registers a hard-reap with the
+            # child_reaper cascade so LoopDeadman/graceful-shutdown
+            # teardown covers these children too. Both fail-soft — a
+            # missing module never blocks pool creation.
+            _initializer = None
+            _initargs: tuple = ()
+            try:
+                from backend.core.ouroboros.governance.worker_lifeline import (
+                    pool_worker_initializer,
+                )
+                _initializer = pool_worker_initializer
+                _initargs = ("ast_helper_pool", os.getpid())
+            except Exception:  # noqa: BLE001 — lifeline optional
+                pass
             _pool = ProcessPoolExecutor(
                 max_workers=_resolve_pool_max_workers(),
                 mp_context=ctx,
+                initializer=_initializer,
+                initargs=_initargs,
             )
+            try:
+                from backend.core.ouroboros.governance.child_reaper import (
+                    register_cleanup,
+                )
+                register_cleanup(reap_ast_pool_hard, label="ast_helper_pool")
+            except Exception:  # noqa: BLE001 — reaper optional
+                pass
             logger.info(
                 "[AstCompileHelper] process pool initialised "
                 "max_workers=%d ctx=spawn",
                 _resolve_pool_max_workers(),
             )
     return _pool
+
+
+def reap_ast_pool_hard() -> None:
+    """Signal-safe hard reap for the child_reaper cascade (Slice 27).
+
+    Snapshots current worker PIDs, runs the existing three-layer
+    ``shutdown_pool`` with a short deadline (the cascade's own grace
+    window bounds total teardown time), then SIGKILLs any survivor.
+    NEVER raises — runs from LoopDeadman pre-``os._exit`` context.
+    """
+    try:
+        pool = _pool
+        procs = list((getattr(pool, "_processes", None) or {}).values()) if pool else []
+        shutdown_pool(deadline_s=0.5)
+        for p in procs:
+            if _proc_alive(p):
+                try:
+                    p.kill()
+                except Exception:  # noqa: BLE001
+                    pass
+    except Exception:  # noqa: BLE001 — never raise in the cascade
+        pass
 
 
 def _proc_alive(p: Any) -> bool:

--- a/backend/core/ouroboros/governance/autonomy_metrics.py
+++ b/backend/core/ouroboros/governance/autonomy_metrics.py
@@ -1,0 +1,658 @@
+"""
+Goal Metric Dashboard — Autonomous Throughput Aggregator
+========================================================
+
+Read-only observability substrate that measures the ONE thing the O+V
+manifesto's stated objective is actually about: is the codebase engineering
+its own evolution, and how fast / how reliably / at what cost?
+
+It answers three questions from GROUND TRUTH, never from a value judgment:
+
+  1. **Net-positive landed changes per unattended day** — how many genuinely
+     mutated, VERIFY-validated, autonomously-committed diffs the organism
+     landed and *kept*, normalized by honest unattended runtime.
+  2. **Regression rate** — of what landed, how much was later reverted
+     (the objective "it didn't hold up" signal).
+  3. **Cost** — the amortized dollars spent per landed change, including the
+     failed attempts (the honest economic efficiency of autonomy).
+
+Composition contract (mandate: DRY — zero parallel state, zero new ledger,
+zero duplicated logic). Two canonical sources only:
+
+  * ``auto_committer.ov_coauthor_line()`` — the canonical, ASCII, drift-stable
+    trailer that PROVES a commit was authored by the AutoCommitter. Because
+    the AutoCommitter stamps it ONLY after APPLY+VERIFY passes (the sole code
+    path that writes it), the trailer's presence is a structural proof of
+    "genuinely mutated + validated + committed" — mandate 4, for free.
+  * The battle-test session ``summary.json`` set (``.ouroboros/sessions/bt-*``)
+    — the reconciled per-session record of ``duration_s`` (unattended
+    runtime), ``cost_total``, and the per-op ``operations[]`` array carrying
+    ``terminal_reason_code`` (``verify_regression`` = pipeline-caught
+    regression). Same artifact for runtime + cost + pipeline-regression →
+    one read, self-consistent window.
+
+Bulletproof invariants:
+  * A "landed change" is NEVER counted without a git-provable, trailer-bearing,
+    NON-EMPTY (files-changed) commit reachable from the target branch. No
+    trailer / no files → not counted.
+  * Orange-tier review commits (``chore(ouroboros-review):`` / body
+    ``DO NOT AUTO-MERGE``) are human-gated, carry NO trailer, and are excluded
+    (defense-in-depth even though the trailer filter already excludes them).
+  * Every ratio is division-guarded → ``None`` on a zero denominator; the
+    aggregator NEVER raises (every path defensive). Zero-output initial runs
+    return a fully-formed snapshot of zeros/Nones, not an exception.
+
+Authority posture: this module is a read-only projector. It imports NO
+orchestrator / policy / gate module. It only runs ``git log`` (read-only
+subprocess) and reads session-summary JSON.
+"""
+from __future__ import annotations
+
+import json
+import os
+import re
+import shutil
+import subprocess
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+AUTONOMY_METRICS_SCHEMA_VERSION = "autonomy.1"
+
+# Unique record/field sentinels for the git-log projection — private to this
+# module (each metric owns its own narrow git projection; only the trailer
+# marker is shared, per the canonical-source composition contract).
+_REC_SEP = "__OV_AUTONOMY_REC__"
+_GIT_FORMAT = _REC_SEP + "%n%H%n%ct%n%B%n__OV_AUTONOMY_ENDHDR__"
+
+# Reverted-commit reference, e.g. "This reverts commit 1a2b3c4d...".
+_REVERT_RE = re.compile(r"This reverts commit ([0-9a-fA-F]{7,40})")
+_RISK_RE = re.compile(r"^Risk:\s*([A-Za-z_]+)", re.MULTILINE)
+_ORANGE_SUBJECT_PREFIX = "chore(ouroboros-review):"
+_ORANGE_BODY_MARKER = "DO NOT AUTO-MERGE"
+
+_CANONICAL_TIERS = frozenset(
+    {"safe_auto", "notify_apply", "approval_required", "blocked"}
+)
+
+
+# ---------------------------------------------------------------------------
+# Env knobs — additive, clamped, never authoritative
+# ---------------------------------------------------------------------------
+
+
+def master_enabled() -> bool:
+    """``JARVIS_AUTONOMY_METRICS_ENABLED`` (default true). Read-only surface;
+    a kill switch only silences the endpoint, it changes no behavior."""
+    raw = os.environ.get("JARVIS_AUTONOMY_METRICS_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _read_clamped_int(env_name: str, default: int, lo: int, hi: int) -> int:
+    try:
+        v = int(os.environ.get(env_name, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, v))
+
+
+def window_days() -> int:
+    """``JARVIS_AUTONOMY_METRICS_WINDOW_DAYS`` — lookback window for BOTH the
+    git scan and the session set (single aligned window). Default 30."""
+    return _read_clamped_int("JARVIS_AUTONOMY_METRICS_WINDOW_DAYS", 30, 1, 3650)
+
+
+def target_branch() -> str:
+    """``JARVIS_AUTONOMY_METRICS_BRANCH`` — the branch on which a change must
+    be reachable to count as landed (excludes Orange-PR + un-promoted
+    workspace branches). Default ``main``."""
+    raw = os.environ.get("JARVIS_AUTONOMY_METRICS_BRANCH", "").strip()
+    return raw or "main"
+
+
+def commit_scan_max() -> int:
+    """``JARVIS_AUTONOMY_METRICS_COMMIT_SCAN_MAX`` — hard cap on commits
+    walked (belt-and-braces beyond the ``--since`` window). Default 5000."""
+    return _read_clamped_int(
+        "JARVIS_AUTONOMY_METRICS_COMMIT_SCAN_MAX", 5000, 100, 100000
+    )
+
+
+def session_scan_max() -> int:
+    """``JARVIS_AUTONOMY_METRICS_SESSION_SCAN_MAX`` — cap on session dirs read
+    per aggregation (newest-first). Default 500."""
+    return _read_clamped_int(
+        "JARVIS_AUTONOMY_METRICS_SESSION_SCAN_MAX", 500, 10, 10000
+    )
+
+
+def _ov_trailer() -> str:
+    """Canonical O+V commit trailer, composed from the single source of truth
+    (``auto_committer.ov_coauthor_line``). ASCII + drift-stable. Empty string
+    on any failure → the scan then counts ZERO landed changes (fail-closed:
+    an unresolvable marker can never over-count)."""
+    try:
+        from backend.core.ouroboros.governance.auto_committer import (
+            ov_coauthor_line,
+        )
+        return ov_coauthor_line()
+    except Exception:  # noqa: BLE001 — fail-closed to empty marker
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# git-log projection — read-only subprocess, NEVER raises
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _Commit:
+    commit_hash: str
+    commit_time_unix: int
+    body: str
+    files: Tuple[str, ...]
+
+
+def _run_git_log(
+    repo_path: Path,
+    branch: str,
+    since_epoch: float,
+    max_commits: int,
+    *,
+    runner: Optional[Any] = None,
+) -> str:
+    """Invoke ``git log <branch> --since`` with a non-shell argv. Returns the
+    raw formatted output; ``""`` on any failure (git missing, bad branch,
+    non-zero rc, timeout). ``runner`` is an injectable subprocess.run seam."""
+    effective_runner = runner if runner is not None else subprocess.run
+    git_exe = shutil.which("git")
+    if git_exe is None:
+        return ""
+    try:
+        result = effective_runner(
+            [
+                git_exe, "-C", str(repo_path), "log", branch,
+                f"--since={max(0.0, float(since_epoch)):.0f}",
+                f"--max-count={max(1, int(max_commits))}",
+                f"--format={_GIT_FORMAT}",
+                "--name-only", "--no-color",
+            ],
+            capture_output=True, text=True, timeout=30, check=False,
+        )
+    except Exception:  # noqa: BLE001
+        return ""
+    if getattr(result, "returncode", 1) != 0:
+        return ""
+    out = getattr(result, "stdout", "") or ""
+    if not isinstance(out, str):
+        try:
+            out = out.decode("utf-8", errors="ignore")
+        except Exception:  # noqa: BLE001
+            return ""
+    return out
+
+
+def _parse_commits(raw: str) -> Tuple[_Commit, ...]:
+    """Pure parser; NEVER raises — malformed records are skipped."""
+    if not raw:
+        return ()
+    parsed: List[_Commit] = []
+    for chunk in raw.split(_REC_SEP + "\n"):
+        chunk = chunk.strip()
+        if not chunk:
+            continue
+        try:
+            header, _, after = chunk.partition("__OV_AUTONOMY_ENDHDR__")
+            lines = header.strip().split("\n")
+            if len(lines) < 3:
+                continue
+            commit_hash = lines[0].strip()
+            if not commit_hash:
+                continue
+            try:
+                ctime = int(lines[1].strip())
+            except (TypeError, ValueError):
+                continue
+            body = "\n".join(lines[2:])
+            files = tuple(
+                ln.strip() for ln in after.strip().split("\n") if ln.strip()
+            )
+            parsed.append(_Commit(commit_hash, ctime, body, files))
+        except Exception:  # noqa: BLE001
+            continue
+    return tuple(parsed)
+
+
+def _is_ov_commit(body: str, trailer: str) -> bool:
+    return bool(trailer) and trailer in body
+
+
+def _is_orange(body: str) -> bool:
+    """Human-gated Orange-tier review commit — excluded defense-in-depth."""
+    if not body:
+        return False
+    first = body.strip().split("\n", 1)[0]
+    return (
+        first.startswith(_ORANGE_SUBJECT_PREFIX)
+        or _ORANGE_BODY_MARKER in body
+    )
+
+
+def _risk_tier(body: str) -> str:
+    """Extract the ``Risk: <TIER>`` token as a canonical lowercase name, or
+    ``"unknown"``."""
+    if not body:
+        return "unknown"
+    m = _RISK_RE.search(body)
+    if not m:
+        return "unknown"
+    token = m.group(1).strip().lower()
+    return token if token in _CANONICAL_TIERS else "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Session-summary projection — reconciled runtime + cost + pipeline-regression
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _SessionFacts:
+    duration_s: float
+    cost_total: float
+    cost_breakdown: Dict[str, float]
+    total_ops: int
+    verify_regressions: int
+    suspension_likely: bool
+
+
+def _sessions_root(repo_path: Path) -> Path:
+    return repo_path / ".ouroboros" / "sessions"
+
+
+def _session_dir_epoch(name: str) -> Optional[float]:
+    """Best-effort start epoch from the session dir name.
+
+    ``bt-YYYY-MM-DD-HHMMSS`` (lexicographic == chronological) or
+    ``bt-iso-<epoch>``. Returns None if unparseable (caller falls back to the
+    summary file mtime)."""
+    try:
+        if name.startswith("bt-iso-"):
+            return float(name[len("bt-iso-"):])
+        # bt-YYYY-MM-DD-HHMMSS
+        parts = name.split("-")
+        if len(parts) >= 5 and parts[0] == "bt":
+            y, mo, d, hms = parts[1], parts[2], parts[3], parts[4]
+            import calendar
+            tm = (
+                int(y), int(mo), int(d),
+                int(hms[0:2]), int(hms[2:4]), int(hms[4:6]),
+                0, 0, -1,
+            )
+            return float(calendar.timegm(tm))
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def _read_session_summary(path: Path) -> Optional[_SessionFacts]:
+    """Parse one ``summary.json`` into the narrow facts we need. NEVER raises;
+    returns None if the file is unreadable/unparseable."""
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return None
+    if not isinstance(raw, dict):
+        return None
+
+    def _f(key: str, default: float = 0.0) -> float:
+        try:
+            v = raw.get(key)
+            return float(v) if v is not None else default
+        except (TypeError, ValueError):
+            return default
+
+    breakdown: Dict[str, float] = {}
+    try:
+        cb = raw.get("cost_breakdown")
+        if isinstance(cb, dict):
+            for k, v in cb.items():
+                try:
+                    breakdown[str(k)] = float(v)
+                except (TypeError, ValueError):
+                    continue
+    except Exception:  # noqa: BLE001
+        breakdown = {}
+
+    total_ops = 0
+    verify_regressions = 0
+    try:
+        ops = raw.get("operations")
+        if isinstance(ops, list):
+            total_ops = len(ops)
+            for op in ops:
+                if not isinstance(op, dict):
+                    continue
+                if (
+                    str(op.get("status", "")).lower() == "failed"
+                    and str(op.get("terminal_reason_code", ""))
+                    == "verify_regression"
+                ):
+                    verify_regressions += 1
+    except Exception:  # noqa: BLE001
+        pass
+
+    return _SessionFacts(
+        duration_s=_f("duration_s"),
+        cost_total=_f("cost_total"),
+        cost_breakdown=breakdown,
+        total_ops=total_ops,
+        verify_regressions=verify_regressions,
+        suspension_likely=bool(raw.get("suspension_likely", False)),
+    )
+
+
+def _read_sessions(
+    repo_path: Path, since_epoch: float, scan_max: int,
+) -> Tuple[List[_SessionFacts], int]:
+    """Read in-window session summaries (newest-first, capped). Returns
+    (facts, suspension_excluded_count). NEVER raises."""
+    root = _sessions_root(repo_path)
+    facts: List[_SessionFacts] = []
+    suspension_excluded = 0
+    try:
+        if not root.is_dir():
+            return facts, 0
+        dirs = sorted(
+            (p for p in root.iterdir() if p.is_dir() and p.name.startswith("bt-")),
+            key=lambda p: p.name, reverse=True,
+        )[:scan_max]
+    except Exception:  # noqa: BLE001
+        return facts, 0
+    for d in dirs:
+        summary = d / "summary.json"
+        if not summary.is_file():
+            continue
+        # Window filter: dir-name epoch, else summary mtime.
+        epoch = _session_dir_epoch(d.name)
+        if epoch is None:
+            try:
+                epoch = summary.stat().st_mtime
+            except Exception:  # noqa: BLE001
+                epoch = None
+        if epoch is not None and epoch < since_epoch:
+            continue
+        f = _read_session_summary(summary)
+        if f is None:
+            continue
+        # Suspension-likely sessions are NOT honest unattended time — exclude
+        # from the runtime denominator (mandate 2: objective runtime reality).
+        if f.suspension_likely:
+            suspension_excluded += 1
+            continue
+        facts.append(f)
+    return facts, suspension_excluded
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class AutonomySnapshot:
+    schema_version: str = AUTONOMY_METRICS_SCHEMA_VERSION
+    enabled: bool = True
+    reason_code: str = "ok"
+    generated_at_unix: float = 0.0
+    window_days: int = 30
+    branch: str = "main"
+    # landed
+    landed_count: int = 0
+    net_positive_landed: int = 0
+    reverted_landed: int = 0
+    landed_by_risk_tier: Dict[str, int] = field(default_factory=dict)
+    # throughput
+    unattended_days: float = 0.0
+    landed_per_unattended_day: Optional[float] = None
+    sessions_counted: int = 0
+    sessions_suspension_excluded: int = 0
+    # regression
+    post_landing_regression_rate: Optional[float] = None
+    pipeline_caught_verify_regressions: int = 0
+    total_ops_in_window: int = 0
+    # cost
+    total_cost_usd: float = 0.0
+    cost_per_landed_change_usd: Optional[float] = None
+    cost_by_provider: Dict[str, float] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "enabled": self.enabled,
+            "reason_code": self.reason_code,
+            "generated_at_unix": self.generated_at_unix,
+            "window_days": self.window_days,
+            "landed": {
+                "branch": self.branch,
+                "count": self.landed_count,
+                "net_positive": self.net_positive_landed,
+                "reverted": self.reverted_landed,
+                "by_risk_tier": dict(self.landed_by_risk_tier),
+            },
+            "throughput": {
+                "unattended_days": round(self.unattended_days, 4),
+                "landed_per_unattended_day": self.landed_per_unattended_day,
+                "net_positive_per_unattended_day": (
+                    round(self.net_positive_landed / self.unattended_days, 4)
+                    if self.unattended_days > 0 else None
+                ),
+                "sessions_counted": self.sessions_counted,
+                "sessions_suspension_excluded": self.sessions_suspension_excluded,
+            },
+            "regression": {
+                "post_landing_rate": self.post_landing_regression_rate,
+                "reverted_landed": self.reverted_landed,
+                "pipeline_caught_verify_regressions": (
+                    self.pipeline_caught_verify_regressions
+                ),
+                "total_ops_in_window": self.total_ops_in_window,
+            },
+            "cost": {
+                "total_usd": round(self.total_cost_usd, 6),
+                "per_landed_change_usd": self.cost_per_landed_change_usd,
+                "by_provider": {
+                    k: round(v, 6) for k, v in self.cost_by_provider.items()
+                },
+            },
+            "sources": {
+                "landed": "git log <branch> filtered by O+V co-author trailer (non-empty diff)",
+                "runtime_and_cost": "session summary.json (duration_s / cost_total, suspension-gated)",
+                "regression": "git reverts of trailered commits + operations[].verify_regression",
+            },
+        }
+
+
+def _resolve_repo_root(explicit: Optional[Path] = None) -> Path:
+    if explicit is not None:
+        return explicit
+    # Walk up from this module to the repo root (contains .git or .ouroboros).
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents]:
+        if (parent / ".git").exists() or (parent / ".ouroboros").is_dir():
+            return parent
+    return Path.cwd()
+
+
+def _safe_ratio(num: float, den: float) -> Optional[float]:
+    """Division-guarded ratio → None on a zero (or non-positive) denominator.
+    The single place zero-output states are made exception-proof."""
+    if den <= 0:
+        return None
+    try:
+        return round(num / den, 6)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def aggregate_autonomy_metrics(
+    *,
+    repo_root: Optional[Path] = None,
+    now: Optional[float] = None,
+    git_runner: Optional[Any] = None,
+) -> AutonomySnapshot:
+    """Compose the goal-metric snapshot from git + session summaries.
+
+    Pure of side effects (read-only). NEVER raises — any fault degrades to a
+    partial snapshot with a diagnostic ``reason_code``. Zero-output initial
+    runs return an all-zero/None snapshot, not an error.
+    """
+    try:
+        _now = float(now) if now is not None else time.time()
+        _win_days = window_days()
+        _branch = target_branch()
+        _since = _now - (_win_days * 86400.0)
+        repo = _resolve_repo_root(repo_root)
+
+        # --- git: landed changes + reverts ---
+        trailer = _ov_trailer()
+        landed_count = 0
+        by_tier: Dict[str, int] = {}
+        landed_short_shas: set = set()
+        reason = "ok"
+        if not trailer:
+            reason = "no_ov_marker"
+        raw = _run_git_log(
+            repo, _branch, _since, commit_scan_max(), runner=git_runner,
+        )
+        if not raw and reason == "ok":
+            reason = "no_git_history"
+        commits = _parse_commits(raw)
+        reverted_refs: set = set()
+        for c in commits:
+            body = c.body
+            # Collect revert references from ANY commit (human reverts of
+            # autonomous work are the post-landing regression signal).
+            for m in _REVERT_RE.finditer(body):
+                reverted_refs.add(m.group(1).lower())
+            if not _is_ov_commit(body, trailer):
+                continue
+            if _is_orange(body):
+                continue  # human-gated, defense-in-depth
+            if not c.files:
+                continue  # NOT genuinely mutated → never counted (mandate 4)
+            landed_count += 1
+            tier = _risk_tier(body)
+            by_tier[tier] = by_tier.get(tier, 0) + 1
+            landed_short_shas.add(c.commit_hash.lower())
+            landed_short_shas.add(c.commit_hash.lower()[:12])
+
+        # Reverted-landed: a revert whose target sha matches an in-window
+        # landed autonomous commit. Prefix-tolerant (git reverts may cite a
+        # short sha).
+        reverted_landed = 0
+        for ref in reverted_refs:
+            r = ref.lower()
+            if r in landed_short_shas or any(
+                sha.startswith(r) or r.startswith(sha)
+                for sha in landed_short_shas
+            ):
+                reverted_landed += 1
+        reverted_landed = min(reverted_landed, landed_count)
+        net_positive = landed_count - reverted_landed
+
+        # --- sessions: runtime + cost + pipeline regression ---
+        facts, suspension_excluded = _read_sessions(
+            repo, _since, session_scan_max()
+        )
+        total_runtime_s = sum(f.duration_s for f in facts)
+        total_cost = sum(f.cost_total for f in facts)
+        total_ops = sum(f.total_ops for f in facts)
+        verify_regressions = sum(f.verify_regressions for f in facts)
+        cost_by_provider: Dict[str, float] = {}
+        for f in facts:
+            for prov, usd in f.cost_breakdown.items():
+                cost_by_provider[prov] = cost_by_provider.get(prov, 0.0) + usd
+        unattended_days = total_runtime_s / 86400.0
+
+        return AutonomySnapshot(
+            enabled=True,
+            reason_code=reason,
+            generated_at_unix=_now,
+            window_days=_win_days,
+            branch=_branch,
+            landed_count=landed_count,
+            net_positive_landed=net_positive,
+            reverted_landed=reverted_landed,
+            landed_by_risk_tier=by_tier,
+            unattended_days=unattended_days,
+            landed_per_unattended_day=_safe_ratio(landed_count, unattended_days),
+            sessions_counted=len(facts),
+            sessions_suspension_excluded=suspension_excluded,
+            post_landing_regression_rate=_safe_ratio(reverted_landed, landed_count),
+            pipeline_caught_verify_regressions=verify_regressions,
+            total_ops_in_window=total_ops,
+            total_cost_usd=total_cost,
+            cost_per_landed_change_usd=_safe_ratio(total_cost, landed_count),
+            cost_by_provider=cost_by_provider,
+        )
+    except Exception:  # noqa: BLE001 — aggregator MUST never raise
+        return AutonomySnapshot(
+            enabled=True, reason_code="aggregation_error",
+            generated_at_unix=(now if now is not None else 0.0) or 0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cached snapshot — avoid hammering git/fs on rapid renders (SSE/REPL/poll)
+# ---------------------------------------------------------------------------
+
+_SNAPSHOT_LOCK = threading.RLock()
+_LAST_SNAPSHOT: Optional[AutonomySnapshot] = None
+_LAST_SNAPSHOT_TS: float = 0.0
+
+
+def _snapshot_ttl_s() -> float:
+    try:
+        return max(1.0, float(
+            os.environ.get("JARVIS_AUTONOMY_METRICS_TTL_S", "").strip() or 30.0
+        ))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def snapshot(
+    *, repo_root: Optional[Path] = None, force: bool = False,
+) -> Dict[str, Any]:
+    """Public entry point for the observability GET — returns a serializable
+    dict. TTL-cached. When the master flag is off, returns a minimal
+    ``enabled: false`` dict (the endpoint layer decides 403 vs body). NEVER
+    raises."""
+    if not master_enabled():
+        return {
+            "schema_version": AUTONOMY_METRICS_SCHEMA_VERSION,
+            "enabled": False,
+            "reason_code": "disabled",
+        }
+    global _LAST_SNAPSHOT, _LAST_SNAPSHOT_TS
+    now = time.time()
+    with _SNAPSHOT_LOCK:
+        if (
+            not force
+            and _LAST_SNAPSHOT is not None
+            and (now - _LAST_SNAPSHOT_TS) <= _snapshot_ttl_s()
+        ):
+            return _LAST_SNAPSHOT.to_dict()
+    snap = aggregate_autonomy_metrics(repo_root=repo_root, now=now)
+    with _SNAPSHOT_LOCK:
+        _LAST_SNAPSHOT = snap
+        _LAST_SNAPSHOT_TS = now
+    return snap.to_dict()
+
+
+def reset_cache_for_tests() -> None:
+    global _LAST_SNAPSHOT, _LAST_SNAPSHOT_TS
+    with _SNAPSHOT_LOCK:
+        _LAST_SNAPSHOT = None
+        _LAST_SNAPSHOT_TS = 0.0

--- a/backend/core/ouroboros/governance/capability_firing.py
+++ b/backend/core/ouroboros/governance/capability_firing.py
@@ -1,0 +1,366 @@
+"""
+Capability Firing Dimension — the runtime half of self-perception (Gap 2 Step 2)
+================================================================================
+
+Static reachability (``capability_liveness``, Step 1) proves "this symbol has a
+production call site." It CANNOT prove the thing that actually mattered for the
+merkle bug: that the capability, though reachable, **never actually ran**. The
+Merkle Cartographer was reachable AND its consumers were wired — but the driver
+never fired, so its ledger stayed empty and its log tag never appeared. That is
+a *runtime* signal, not a static one.
+
+This module supplies the precise detector: for each enabled capability, did its
+subsystem emit any runtime evidence in the recent observation window? The
+combination — **reachable (ALIVE) but SILENT (no firing evidence)** — is the
+generalizable merkle signature (wired, callable, dormant), computed by
+``capability_liveness`` from this module's verdicts.
+
+No hardcoding — everything is DERIVED:
+  * A capability's firing MARKERS are extracted from its OWN ``source_file``:
+    the bracket log tags it prints (``logger.info("[MerkleCartographer] ...")``
+    → ``MerkleCartographer``) and the ``*.jsonl`` ledger stems it writes
+    (``merkle_history.jsonl`` → ``merkle_history``). The code declares its own
+    observable identity; we read it, we don't enumerate it.
+  * The EVIDENCE window is ADAPTIVE — anchored to the most-recent battle-test
+    sessions (actual observation periods), not a fixed wall-clock, so "never
+    fired" means "absent across the real recent activity," never a false
+    silence during idle wall-time.
+  * Evidence is DURABLE ground truth: ``.jarvis/*.jsonl`` ledger file mtimes
+    (a ledger written in-window ⇒ its owner fired) + the ``[Tag]`` markers
+    present in the recent sessions' ``debug.log``.
+
+Verdicts: FIRING (≥1 derived marker seen in-window) / SILENT (markers derivable
+but none seen — dormant candidate) / UNKNOWN (no observable markers in the
+source — firing is unprovable, never a false alarm).
+
+Authority posture: read-only projector. Imports NO orchestrator/policy/gate
+module. Reads files only. NEVER raises.
+"""
+from __future__ import annotations
+
+import os
+import re
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Set, Tuple
+
+CAPABILITY_FIRING_SCHEMA_VERSION = "capability_firing.1"
+
+# A log-tag marker: ``[Name]`` at the START of a string literal (a log message),
+# NOT ``List[Any]`` type-hint brackets (which are not preceded by a quote).
+_LOG_TAG_RE = re.compile(r"""["']\s*\[([A-Z][A-Za-z0-9_.]{1,48})\]""")
+# A logger identity: ``getLogger("Ouroboros.MerkleCartographer")`` → last comp.
+_GETLOGGER_RE = re.compile(r"""getLogger\(\s*["']([\w.]+)["']""")
+# A ledger stem the source writes/reads: ``merkle_history.jsonl`` → merkle_history.
+_LEDGER_STEM_RE = re.compile(r"""([A-Za-z0-9_]{2,64})\.jsonl""")
+# A bracket marker present in a debug.log line: ``[MerkleCartographer]``.
+_LOGLINE_TAG_RE = re.compile(r"\[([A-Z][A-Za-z0-9_.]{1,48})\]")
+
+
+# ---------------------------------------------------------------------------
+# Env knobs — additive, clamped, read-only
+# ---------------------------------------------------------------------------
+
+
+def master_enabled() -> bool:
+    """``JARVIS_CAPABILITY_FIRING_ENABLED`` (default true). Read-only; a kill
+    switch only silences the dimension."""
+    raw = os.environ.get("JARVIS_CAPABILITY_FIRING_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _clamped_int(env: str, default: int, lo: int, hi: int) -> int:
+    try:
+        v = int(os.environ.get(env, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, v))
+
+
+def max_sessions() -> int:
+    """``JARVIS_CAPABILITY_FIRING_MAX_SESSIONS`` — recent session debug.logs
+    scanned for log-tag evidence. Default 3."""
+    return _clamped_int("JARVIS_CAPABILITY_FIRING_MAX_SESSIONS", 3, 1, 50)
+
+
+def window_fallback_s() -> float:
+    """``JARVIS_CAPABILITY_FIRING_WINDOW_S`` — wall-clock ledger window used
+    ONLY when no sessions are available to anchor the adaptive window.
+    Default 604800 (7d)."""
+    try:
+        return max(60.0, float(
+            os.environ.get("JARVIS_CAPABILITY_FIRING_WINDOW_S", "").strip() or 604800.0
+        ))
+    except (TypeError, ValueError):
+        return 604800.0
+
+
+def max_log_bytes() -> int:
+    """``JARVIS_CAPABILITY_FIRING_MAX_LOG_BYTES`` — cap per debug.log scan so a
+    giant log can't stall the reader. Default 96 MiB."""
+    return _clamped_int(
+        "JARVIS_CAPABILITY_FIRING_MAX_LOG_BYTES", 96 * 1024 * 1024,
+        1024 * 1024, 1024 * 1024 * 1024,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Derived markers (from a capability's own source) — pure, never raises
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class DerivedMarkers:
+    tags: Tuple[str, ...] = ()      # log bracket tags + logger last-components
+    ledgers: Tuple[str, ...] = ()   # *.jsonl stems the source references
+
+    @property
+    def empty(self) -> bool:
+        return not self.tags and not self.ledgers
+
+
+def derive_markers(source: str) -> DerivedMarkers:
+    """Extract a capability's observable firing markers from its source. NEVER
+    raises. Empty markers → firing is UNKNOWN (unprovable, never a false
+    SILENT)."""
+    if not source:
+        return DerivedMarkers()
+    tags: Set[str] = set()
+    ledgers: Set[str] = set()
+    try:
+        for m in _LOG_TAG_RE.finditer(source):
+            tags.add(m.group(1).split(".")[-1])
+        for m in _GETLOGGER_RE.finditer(source):
+            comp = m.group(1).split(".")[-1]
+            if comp and comp[0].isupper():
+                tags.add(comp)
+        for m in _LEDGER_STEM_RE.finditer(source):
+            ledgers.add(m.group(1))
+    except Exception:  # noqa: BLE001
+        pass
+    # Drop generic/noise tags that would over-match (common Python builtins that
+    # appear bracketed in type strings but slipped the quote guard).
+    tags.discard("Any")
+    tags.discard("Path")
+    return DerivedMarkers(tuple(sorted(tags)), tuple(sorted(ledgers)))
+
+
+# ---------------------------------------------------------------------------
+# Runtime evidence collection — durable, adaptive window, never raises
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FiringEvidence:
+    present_markers: Set[str] = field(default_factory=set)   # log tags seen in-window
+    active_ledgers: Set[str] = field(default_factory=set)    # ledger stems written in-window
+    window_start_unix: float = 0.0
+    sessions_scanned: int = 0
+    ledgers_scanned: int = 0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "window_start_unix": self.window_start_unix,
+            "sessions_scanned": self.sessions_scanned,
+            "ledgers_scanned": self.ledgers_scanned,
+            "distinct_markers_seen": len(self.present_markers),
+            "active_ledgers": len(self.active_ledgers),
+        }
+
+
+def _session_epoch(name: str) -> Optional[float]:
+    """Best-effort start epoch from a ``bt-…`` session dir name."""
+    try:
+        if name.startswith("bt-iso-"):
+            return float(name[len("bt-iso-"):])
+        parts = name.split("-")
+        if len(parts) >= 5 and parts[0] == "bt":
+            import calendar
+            hms = parts[4]
+            return float(calendar.timegm((
+                int(parts[1]), int(parts[2]), int(parts[3]),
+                int(hms[0:2]), int(hms[2:4]), int(hms[4:6]), 0, 0, -1,
+            )))
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+def collect_firing_evidence(
+    repo: Path,
+    *,
+    now: float,
+    sessions_reader: Optional[Callable[[], List[Tuple[str, str]]]] = None,
+    ledger_reader: Optional[Callable[[], List[Tuple[str, float]]]] = None,
+) -> FiringEvidence:
+    """Collect durable firing evidence over an ADAPTIVE window anchored to the
+    most-recent sessions. NEVER raises.
+
+    ``sessions_reader`` (test seam) → ``[(session_name, debug_log_text), ...]``
+    newest-first. ``ledger_reader`` (test seam) → ``[(ledger_stem, mtime), ...]``.
+    """
+    # --- recent sessions (log-tag evidence) + adaptive window anchor ---
+    present: Set[str] = set()
+    sessions_scanned = 0
+    window_start = now - window_fallback_s()
+    session_starts: List[float] = []
+    try:
+        sess_rows = (
+            sessions_reader() if sessions_reader is not None
+            else _read_recent_sessions(repo, max_sessions())
+        )
+    except Exception:  # noqa: BLE001
+        sess_rows = []
+    for name, log_text in sess_rows:
+        sessions_scanned += 1
+        ep = _session_epoch(name)
+        if ep is not None:
+            session_starts.append(ep)
+        try:
+            for m in _LOGLINE_TAG_RE.finditer(log_text):
+                present.add(m.group(1).split(".")[-1])
+        except Exception:  # noqa: BLE001
+            continue
+    if session_starts:
+        # Window opens at the earliest recent session we scanned — firing is
+        # judged over the ACTUAL recent observation period, not idle wall-time.
+        window_start = min(session_starts)
+
+    # --- ledgers written in-window (subsystem-activity evidence) ---
+    active: Set[str] = set()
+    ledgers_scanned = 0
+    try:
+        led_rows = (
+            ledger_reader() if ledger_reader is not None
+            else _read_ledger_mtimes(repo)
+        )
+    except Exception:  # noqa: BLE001
+        led_rows = []
+    for stem, mtime in led_rows:
+        ledgers_scanned += 1
+        if mtime >= window_start:
+            active.add(stem)
+
+    return FiringEvidence(
+        present_markers=present, active_ledgers=active,
+        window_start_unix=window_start,
+        sessions_scanned=sessions_scanned, ledgers_scanned=ledgers_scanned,
+    )
+
+
+def _read_recent_sessions(repo: Path, limit: int) -> List[Tuple[str, str]]:
+    """Newest-first ``[(name, debug_log_text)]`` for the recent sessions. Bounded
+    read per log. NEVER raises."""
+    root = repo / ".ouroboros" / "sessions"
+    out: List[Tuple[str, str]] = []
+    try:
+        if not root.is_dir():
+            return out
+        dirs = sorted(
+            (p for p in root.iterdir() if p.is_dir() and p.name.startswith("bt-")),
+            key=lambda p: p.name, reverse=True,
+        )[:limit]
+    except Exception:  # noqa: BLE001
+        return out
+    cap = max_log_bytes()
+    for d in dirs:
+        log = d / "debug.log"
+        text = ""
+        try:
+            if log.is_file():
+                with open(log, "r", encoding="utf-8", errors="ignore") as f:
+                    text = f.read(cap)
+        except Exception:  # noqa: BLE001
+            text = ""
+        out.append((d.name, text))
+    return out
+
+
+def _read_ledger_mtimes(repo: Path) -> List[Tuple[str, float]]:
+    """``[(ledger_stem, mtime_epoch)]`` for every ``.jarvis/**/*.jsonl``. NEVER
+    raises."""
+    out: List[Tuple[str, float]] = []
+    root = repo / ".jarvis"
+    try:
+        if not root.is_dir():
+            return out
+        for dirpath, _dirs, files in os.walk(root):
+            for fn in files:
+                if not fn.endswith(".jsonl"):
+                    continue
+                try:
+                    mt = (Path(dirpath) / fn).stat().st_mtime
+                except Exception:  # noqa: BLE001
+                    continue
+                out.append((fn[:-len(".jsonl")], mt))
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Per-capability firing verdict
+# ---------------------------------------------------------------------------
+
+
+def firing_verdict(
+    source: str, evidence: FiringEvidence,
+) -> Tuple[str, List[str], List[str]]:
+    """Return ``(verdict, hits, channels)``: FIRING / SILENT / UNKNOWN plus the
+    DERIVED marker channels (``"ledger"`` and/or ``"log"``). Pure; never raises.
+
+      * derived markers ∩ (present log tags ∪ active ledger stems) non-empty
+        → FIRING (hits listed).
+      * markers derivable but none seen in-window → SILENT (dormant candidate).
+      * no derivable markers → UNKNOWN (firing unprovable — never a false SILENT).
+
+    ``channels`` distinguishes the CONFIDENCE of a SILENT verdict: a ``ledger``
+    channel is reliable evidence-of-work (a ledger is written only when the
+    subsystem does durable work → an inactive ledger is a strong dormancy
+    signal, the merkle ``merkle_history.jsonl`` case), whereas a ``log``-only
+    channel is ambiguous (an absent log tag may mean 'ran silently' — an
+    observability gap — not proven dormancy)."""
+    markers = derive_markers(source)
+    if markers.empty:
+        return "UNKNOWN", [], []
+    channels: List[str] = []
+    if markers.ledgers:
+        channels.append("ledger")
+    if markers.tags:
+        channels.append("log")
+    hits: List[str] = []
+    for t in markers.tags:
+        if t in evidence.present_markers:
+            hits.append(f"tag:{t}")
+    for lg in markers.ledgers:
+        if lg in evidence.active_ledgers:
+            hits.append(f"ledger:{lg}")
+    return ("FIRING" if hits else "SILENT"), hits, channels
+
+
+def build_firing_probe(
+    repo: Path, *, now: Optional[float] = None,
+    sessions_reader: Optional[Callable[[], List[Tuple[str, str]]]] = None,
+    ledger_reader: Optional[Callable[[], List[Tuple[str, float]]]] = None,
+) -> Tuple[Callable[[str], Tuple[str, List[str], List[str]]], FiringEvidence]:
+    """Build a ``(source_text) -> (verdict, hits, channels)`` probe bound to a
+    single freshly-collected evidence snapshot (one durable read amortized
+    across all capabilities). Returns ``(probe, evidence)``. NEVER raises — on
+    fault the probe returns UNKNOWN for everything."""
+    _now = float(now) if now is not None else time.time()
+    try:
+        evidence = collect_firing_evidence(
+            repo, now=_now,
+            sessions_reader=sessions_reader, ledger_reader=ledger_reader,
+        )
+    except Exception:  # noqa: BLE001
+        evidence = FiringEvidence(window_start_unix=_now)
+
+    def _probe(source: str) -> Tuple[str, List[str], List[str]]:
+        try:
+            return firing_verdict(source, evidence)
+        except Exception:  # noqa: BLE001
+            return "UNKNOWN", [], []
+
+    return _probe, evidence

--- a/backend/core/ouroboros/governance/capability_liveness.py
+++ b/backend/core/ouroboros/governance/capability_liveness.py
@@ -1,0 +1,578 @@
+"""
+Capability Liveness Audit — the organism's self-perception layer
+================================================================
+
+Read-only substrate that answers the question the severed-merkle-driver bug
+proved O+V could NOT answer about itself: **of all the capabilities I declare
+I have, which are actually reachable — and which are silently severed?**
+
+The archetype (bt-2026-07-16-031323, 5 quiet cycles all full scans): the
+Merkle Cartographer was flag-enabled and its consumers were wired, but the
+DRIVER (`update_full`, the hydration entry point) had ZERO production callers
+— so every consumer fail-safed to legacy scans, silently, forever. The
+fail-safe HID the deadness. A system that cannot see its own inert
+capabilities cannot be trusted to notice what to improve (Gap 2 of the
+autonomy pivot).
+
+What this measures (Step 1 — static reachability, always-available):
+  For each ``JARVIS_*_ENABLED`` capability the FlagRegistry declares, resolve
+  its ``source_file``'s public entry symbols and ask, from git-visible ground
+  truth, whether each has a PRODUCTION caller (a call site in ``backend/``
+  outside the definition file and outside tests). A public symbol nobody
+  calls is a *severance candidate* — the merkle class.
+
+  Verdicts (deliberately NOT named "DARK" — ``capability_constellation``
+  already uses DARK for *declared-off*; this is the opposite, declared-ON but
+  inert):
+    * ALIVE       — enabled; every public entry symbol has a production caller.
+    * SEVERED     — enabled; ≥1 public entry symbol has zero production callers
+                    (the candidates are listed; ``fraction_severed`` reported).
+    * FULLY_SEVERED — a SEVERED capability where NONE of its public symbols has
+                    an external caller (highest-confidence inert subsystem).
+    * UNRESOLVED  — source unparseable / registered at the seed file / no public
+                    symbols; never a false alarm (insufficient data, not dark).
+
+Composition contract (DRY — no parallel machinery, no new data store):
+  * ``flag_registry.list_all()`` — the 966-flag capability inventory (364
+    ``*_ENABLED`` BOOL capabilities), each carrying ``source_file``. The spine.
+  * A single ``ripgrep`` caller-index pass (the always-available reachability
+    primitive; the Oracle CALLS-graph is a DEGRADED-fragile precision upgrade
+    we deliberately do NOT depend on — Oracle-down must not forge false
+    severance, per the reachability explorer's finding).
+  * ``mirror_self_spec_drift`` — the EXISTING partial self-perception layer
+    (docs-vs-registry default drift, a *third* self-blindness axis). Composed
+    as a parallel dimension, not overlapped.
+  * ``capability_constellation.principles_for_category`` — Manifesto-principle
+    attribution for any severed capability (best-effort).
+
+Firing dimension (Step 2, deliberately deferred): "enabled but never fired at
+runtime" needs a federated reader over ~40 subsystem ``.jarvis/*.jsonl``
+ledgers + debug.log markers and is soak-dependent. This module exposes a
+pluggable ``firing_probe`` seam so Step 2 slots in without a rewrite; Step 1
+ships the always-available static half that catches the merkle class at build
+time, no soak required.
+
+Authority posture: read-only projector. Imports NO orchestrator/policy/gate
+module. Runs one ``rg`` subprocess and parses Python ASTs. NEVER raises;
+zero-output states return a clean snapshot.
+"""
+from __future__ import annotations
+
+import ast
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Sequence, Set, Tuple
+
+CAPABILITY_LIVENESS_SCHEMA_VERSION = "capability_liveness.1"
+
+# Flags registered at these files point at the registry plumbing, not a real
+# guarded subsystem → the capability's code location is unknown → UNRESOLVED.
+_SEED_BASENAMES = frozenset({"flag_registry_seed.py", "flag_registry.py", ""})
+
+
+# ---------------------------------------------------------------------------
+# Env knobs — additive, clamped, read-only surface
+# ---------------------------------------------------------------------------
+
+
+def master_enabled() -> bool:
+    """``JARVIS_CAPABILITY_LIVENESS_ENABLED`` (default true). Read-only; the
+    kill switch only silences the surface, it changes no behavior."""
+    raw = os.environ.get("JARVIS_CAPABILITY_LIVENESS_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _read_clamped_int(env_name: str, default: int, lo: int, hi: int) -> int:
+    try:
+        v = int(os.environ.get(env_name, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, v))
+
+
+def scan_cap() -> int:
+    """``JARVIS_CAPABILITY_LIVENESS_SCAN_CAP`` — max capabilities audited per
+    aggregation (belt-and-braces bound). Default 2000 (well above the ~364)."""
+    return _read_clamped_int("JARVIS_CAPABILITY_LIVENESS_SCAN_CAP", 2000, 1, 100000)
+
+
+def _snapshot_ttl_s() -> float:
+    """Reachability changes slowly (code structure); cache aggressively so the
+    GET is cheap. Default 900s."""
+    try:
+        return max(1.0, float(
+            os.environ.get("JARVIS_CAPABILITY_LIVENESS_TTL_S", "").strip() or 900.0
+        ))
+    except (TypeError, ValueError):
+        return 900.0
+
+
+# ---------------------------------------------------------------------------
+# Reachability primitive — one ripgrep caller-index pass, NEVER raises
+# ---------------------------------------------------------------------------
+
+
+def _is_test_path(rel: str) -> bool:
+    """Test-path exclusion, consistent with reverse_dep_resolver semantics."""
+    r = rel.replace("\\", "/")
+    parts = r.split("/")
+    if any(p in ("tests", "test") for p in parts):
+        return True
+    base = parts[-1] if parts else r
+    return base.startswith("test_") or base == "conftest.py" or base.endswith("_test.py")
+
+
+def _public_symbols(source: str) -> Tuple[str, ...]:
+    """Public CALLABLE entry symbols of a module: top-level public functions +
+    public methods of public top-level classes.
+
+    Callables have clean "called-or-not" semantics via ``NAME(`` / ``.NAME(``
+    call sites. Classes-as-symbols are deliberately EXCLUDED as targets — a
+    class legitimately appears only as a type annotation, ``except`` clause, or
+    base class (no ``Name(`` call), which would flood false severance. (An
+    unused class still surfaces indirectly: if its methods are all severed, the
+    capability trends toward FULLY_SEVERED.) NEVER raises; unparseable → empty
+    (→ UNRESOLVED downstream). The merkle archetype ``update_full`` is a method
+    — caught here as a call target."""
+    try:
+        tree = ast.parse(source)
+    except Exception:  # noqa: BLE001
+        return ()
+    out: List[str] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            if not node.name.startswith("_"):
+                out.append(node.name)
+        elif isinstance(node, ast.ClassDef) and not node.name.startswith("_"):
+            for item in node.body:
+                if isinstance(item, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    if not item.name.startswith("_"):
+                        out.append(item.name)
+    return tuple(dict.fromkeys(out))  # de-dupe, stable order
+
+
+import re as _re
+
+# A CALL site: NAME( that is NOT a definition. The negative lookbehinds drop
+# ``def NAME(`` / ``async def NAME(`` (the ``def `` immediately precedes NAME)
+# and ``class NAME(`` — so a recorded hit is a genuine invocation/instantiation,
+# never the definition itself. A method/attr call ``obj.NAME(`` is preceded by
+# ``.`` → correctly counted.
+_CALLSITE_RE = _re.compile(r"(?<!def )(?<!class )\b(\w+)\s*\(")
+
+
+def _build_caller_index(
+    repo: Path,
+    names: Sequence[str],
+    *,
+    walker: Optional[Callable[[], List[Tuple[str, str]]]] = None,
+) -> Dict[str, Set[str]]:
+    """Map each target ``name`` → the set of production files (relative,
+    non-test) containing a genuine ``name(`` CALL site (definitions excluded).
+
+    PORTABLE by construction: a pure-Python walk of ``backend/**/*.py``, no
+    external dependency (the organism's runtime cannot be assumed to ship
+    ripgrep, and Rust-regex ``rg`` lacks the lookbehind this needs). NEVER
+    raises; a fault on any file is skipped. An empty caller set for a name
+    means "no production call site anywhere" — the provable severance signal
+    (the merkle ``update_full`` archetype: defined, never invoked).
+
+    ``walker`` is an injectable test seam returning ``[(rel_path, source), ...]``.
+    """
+    index: Dict[str, Set[str]] = {n: set() for n in names}
+    if not names:
+        return index
+    target = set(names)
+    rows = walker() if walker is not None else _walk_backend_sources(repo)
+    for rel, source in rows:
+        if _is_test_path(rel):
+            continue
+        try:
+            for m in _CALLSITE_RE.finditer(source):
+                name = m.group(1)
+                if name in target:
+                    index[name].add(rel)
+        except Exception:  # noqa: BLE001 — one bad file never breaks the index
+            continue
+    return index
+
+
+def _walk_backend_sources(repo: Path) -> List[Tuple[str, str]]:
+    """Yield ``(rel_path, source)`` for every ``backend/**/*.py`` (excluding
+    obvious vendored/venv dirs). NEVER raises."""
+    out: List[Tuple[str, str]] = []
+    root = repo / "backend"
+    if not root.is_dir():
+        return out
+    _skip = {"__pycache__", ".git", "node_modules", "venv", ".venv",
+             "site-packages", "dist-packages", ".mypy_cache", ".pytest_cache"}
+    try:
+        for dirpath, dirnames, filenames in os.walk(root):
+            dirnames[:] = [d for d in dirnames if d not in _skip]
+            for fn in filenames:
+                if not fn.endswith(".py"):
+                    continue
+                fp = Path(dirpath) / fn
+                try:
+                    rel = str(fp.relative_to(repo)).replace("\\", "/")
+                    source = fp.read_text(encoding="utf-8", errors="ignore")
+                except Exception:  # noqa: BLE001
+                    continue
+                out.append((rel, source))
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Verdict model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class CapabilityVerdict:
+    flag: str
+    source_file: str
+    category: str
+    live_on: bool
+    verdict: str                       # ALIVE|SEVERED|FULLY_SEVERED|UNRESOLVED
+    public_symbols: Tuple[str, ...] = ()
+    severed_symbols: Tuple[str, ...] = ()
+    fraction_severed: float = 0.0
+    principles: Tuple[str, ...] = ()
+    reason: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "flag": self.flag,
+            "source_file": self.source_file,
+            "category": self.category,
+            "live_on": self.live_on,
+            "verdict": self.verdict,
+            "public_symbols": list(self.public_symbols),
+            "severed_symbols": list(self.severed_symbols),
+            "fraction_severed": round(self.fraction_severed, 4),
+            "principles": list(self.principles),
+            "reason": self.reason,
+        }
+
+
+def _verdict_for(
+    *,
+    flag: str,
+    source_file: str,
+    category: str,
+    live_on: bool,
+    repo: Path,
+    caller_index: Dict[str, Set[str]],
+    principles_fn: Optional[Callable[[str], Sequence[str]]],
+) -> CapabilityVerdict:
+    """Pure per-capability verdict from the caller-index. Never raises."""
+    _flag, _sf, _cat, _on = str(flag), str(source_file), str(category), bool(live_on)
+
+    def _mk(verdict: str, **extra: Any) -> CapabilityVerdict:
+        return CapabilityVerdict(
+            flag=_flag, source_file=_sf, category=_cat, live_on=_on,
+            verdict=verdict, **extra,
+        )
+
+    rel = (source_file or "").replace("\\", "/")
+    if os.path.basename(rel) in _SEED_BASENAMES:
+        return _mk("UNRESOLVED",
+                   reason="registered at the flag-registry seed; no guarded module")
+    abs_path = repo / rel
+    try:
+        source = abs_path.read_text(encoding="utf-8")
+    except Exception:  # noqa: BLE001
+        return _mk("UNRESOLVED", reason="source_file unreadable")
+    symbols = _public_symbols(source)
+    if not symbols:
+        return _mk("UNRESOLVED",
+                   reason="no public callable entry symbols to resolve reachability")
+    severed: List[str] = []
+    for sym in symbols:
+        # A genuine CALL site anywhere in production (definitions are already
+        # excluded from the caller-index) — same-file internal use counts as
+        # ALIVE (it IS used). Zero call sites anywhere = severed (the merkle
+        # ``update_full`` signature: defined, invoked by no production code).
+        if not caller_index.get(sym, set()):
+            severed.append(sym)
+    fraction = len(severed) / len(symbols) if symbols else 0.0
+    principles: Tuple[str, ...] = ()
+    if severed and principles_fn is not None:
+        try:
+            principles = tuple(principles_fn(category) or ())
+        except Exception:  # noqa: BLE001
+            principles = ()
+    if not severed:
+        return _mk("ALIVE", public_symbols=symbols, fraction_severed=0.0)
+    verdict = "FULLY_SEVERED" if fraction >= 1.0 else "SEVERED"
+    return _mk(
+        verdict,
+        public_symbols=symbols, severed_symbols=tuple(severed),
+        fraction_severed=fraction, principles=principles,
+        reason=(
+            "no public callable has a production call site — likely inert subsystem"
+            if fraction >= 1.0 else
+            "one or more public callables have no production call site (static-only; "
+            "may be dynamically dispatched — a review candidate, not proven dead)"
+        ),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Aggregator
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class LivenessSnapshot:
+    schema_version: str = CAPABILITY_LIVENESS_SCHEMA_VERSION
+    enabled: bool = True
+    reason_code: str = "ok"
+    generated_at_unix: float = 0.0
+    capabilities_declared: int = 0
+    capabilities_resolved: int = 0
+    counts: Dict[str, int] = field(default_factory=dict)
+    callable_reachability_ratio: Optional[float] = None
+    fully_severed: List[Dict[str, Any]] = field(default_factory=list)
+    severance_candidates: List[Dict[str, Any]] = field(default_factory=list)
+    spec_drift: Dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "enabled": self.enabled,
+            "reason_code": self.reason_code,
+            "generated_at_unix": self.generated_at_unix,
+            "capabilities": {
+                "declared_enabled": self.capabilities_declared,
+                "resolved": self.capabilities_resolved,
+                "counts": dict(self.counts),
+                # Fraction of resolved enabled capabilities whose EVERY public
+                # callable has a production call site. This is a TREND metric,
+                # not an absolute health score — static analysis under-detects
+                # dynamic dispatch, so the absolute value undercounts liveness.
+                # Its VALUE is movement: a capability flipping ALIVE→SEVERED
+                # between snapshots is a NEWLY-introduced severance (a merkle
+                # regression). See interpretation note.
+                "callable_reachability_ratio": self.callable_reachability_ratio,
+            },
+            # HIGH-CONFIDENCE alert: capabilities where NO public callable has a
+            # production call site — the whole enabled subsystem is statically
+            # unreferenced (very likely genuinely inert). This is the actionable
+            # signal.
+            "fully_severed": self.fully_severed,
+            # TRIAGE data (NOT a verdict): enabled capabilities with ≥1 public
+            # callable that has no static call site. Ranked most-severed first.
+            # Explicitly static-only — a symbol here may be dynamically
+            # dispatched; treat as a review candidate, not proven-dead.
+            "severance_candidates": self.severance_candidates,
+            # Third self-blindness axis (docs-vs-registry drift), composed from
+            # the existing mirror_self_spec_drift auditor.
+            "spec_drift": self.spec_drift,
+            "interpretation": (
+                "Static reachability is the always-available half of "
+                "self-perception: it proves 'this symbol has no production call "
+                "site', which catches whole-module inertia and NEWLY-introduced "
+                "severances (trend). The precise merkle-class detector — "
+                "'enabled but never FIRED at runtime' — is the firing dimension "
+                "(Step 2: federated .jarvis/*.jsonl + debug.log reader), "
+                "deliberately deferred and wired via the firing_probe seam."
+            ),
+            "firing": {"implemented": False},
+        }
+
+
+def _resolve_repo_root(explicit: Optional[Path] = None) -> Path:
+    if explicit is not None:
+        return explicit
+    here = Path(__file__).resolve()
+    for parent in [here, *here.parents]:
+        if (parent / ".git").exists() or (parent / "backend").is_dir():
+            return parent
+    return Path.cwd()
+
+
+def _spec_drift_dimension() -> Dict[str, Any]:
+    """Compose the EXISTING docs-vs-registry drift auditor as a parallel
+    self-blindness dimension. Best-effort; never raises."""
+    try:
+        from backend.core.ouroboros.governance.mirror_self_spec_drift import (
+            detect_spec_drift, master_enabled as _drift_on,
+        )
+        if not _drift_on():
+            return {"verdict": "DISABLED", "note": "spec-drift master off"}
+        report = detect_spec_drift()
+        return {
+            "verdict": str(getattr(report.verdict, "value", report.verdict)),
+            "claims_evaluated": int(getattr(report, "claims_evaluated", 0) or 0),
+            "drifted": len([
+                r for r in getattr(report, "records", ())
+                if getattr(r, "drifted", False)
+            ]),
+        }
+    except Exception:  # noqa: BLE001
+        return {"verdict": "UNAVAILABLE"}
+
+
+def _principles_fn() -> Optional[Callable[[str], Sequence[str]]]:
+    try:
+        from backend.core.ouroboros.governance.capability_constellation import (
+            principles_for_category,
+        )
+        return principles_for_category
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def aggregate_capability_liveness(
+    *,
+    repo_root: Optional[Path] = None,
+    now: Optional[float] = None,
+    walker: Optional[Callable[[], List[Tuple[str, str]]]] = None,  # test seam
+    firing_probe: Optional[Callable[[str], bool]] = None,  # Step 2 seam (unused in Step 1)
+) -> LivenessSnapshot:
+    """Compose the capability-liveness snapshot from the FlagRegistry + a
+    ripgrep caller-index. Read-only; NEVER raises — any fault degrades to a
+    partial snapshot with a diagnostic ``reason_code``. Zero-output safe.
+
+    ``firing_probe`` is the deferred Step-2 seam: a callable
+    ``(flag_name) -> bool`` (did the subsystem fire in the window). Unused in
+    Step 1; wired here so Step 2 needs no signature change.
+    """
+    _ = firing_probe  # reserved for the Step-2 firing dimension (see docstring)
+    try:
+        _now = float(now) if now is not None else time.time()
+        repo = _resolve_repo_root(repo_root)
+
+        # --- enumerate declared capabilities ---
+        try:
+            from backend.core.ouroboros.governance.flag_registry import (
+                ensure_seeded, FlagType,
+            )
+            registry = ensure_seeded()
+            specs = [
+                s for s in registry.list_all()
+                if s.name.endswith("_ENABLED") and s.type is FlagType.BOOL
+            ][:scan_cap()]
+        except Exception:  # noqa: BLE001
+            return LivenessSnapshot(
+                enabled=True, reason_code="flag_registry_unavailable",
+                generated_at_unix=_now, spec_drift=_spec_drift_dimension(),
+            )
+
+        # Only audit LIVE-ON capabilities (a declared-off flag is not a
+        # severance concern — that's the constellation-DARK axis, not ours).
+        live_specs = []
+        for s in specs:
+            try:
+                on = registry.get_bool(s.name)
+            except Exception:  # noqa: BLE001
+                on = bool(getattr(s, "default", False))
+            if on:
+                live_specs.append(s)
+
+        # --- collect target symbols across all live capabilities (one pass) ---
+        cap_symbols: Dict[str, Tuple[str, ...]] = {}
+        for s in live_specs:
+            rel = (s.source_file or "").replace("\\", "/")
+            if os.path.basename(rel) in _SEED_BASENAMES:
+                continue
+            try:
+                source = (repo / rel).read_text(encoding="utf-8")
+            except Exception:  # noqa: BLE001
+                continue
+            cap_symbols[s.name] = _public_symbols(source)
+
+        all_names = sorted({n for syms in cap_symbols.values() for n in syms})
+        caller_index = _build_caller_index(repo, all_names, walker=walker)
+        reason = "ok"
+
+        # --- per-capability verdicts ---
+        principles_fn = _principles_fn()
+        verdicts: List[CapabilityVerdict] = []
+        for s in live_specs:
+            v = _verdict_for(
+                flag=s.name,
+                source_file=(s.source_file or ""),
+                category=str(getattr(getattr(s, "category", None), "value", getattr(s, "category", ""))),
+                live_on=True,
+                repo=repo,
+                caller_index=caller_index,
+                principles_fn=principles_fn,
+            )
+            verdicts.append(v)
+
+        counts: Dict[str, int] = {}
+        for v in verdicts:
+            counts[v.verdict] = counts.get(v.verdict, 0) + 1
+        alive = counts.get("ALIVE", 0)
+        severed_n = counts.get("SEVERED", 0) + counts.get("FULLY_SEVERED", 0)
+        resolved = alive + severed_n
+        ratio = round(alive / resolved, 4) if resolved > 0 else None
+
+        fully = sorted(
+            (v.to_dict() for v in verdicts if v.verdict == "FULLY_SEVERED"),
+            key=lambda d: d["flag"],
+        )
+        candidates = sorted(
+            (v.to_dict() for v in verdicts if v.verdict == "SEVERED"),
+            key=lambda d: (-d["fraction_severed"], d["flag"]),
+        )
+
+        return LivenessSnapshot(
+            enabled=True, reason_code=reason, generated_at_unix=_now,
+            capabilities_declared=len(live_specs),
+            capabilities_resolved=resolved,
+            counts=counts,
+            callable_reachability_ratio=ratio,
+            fully_severed=fully,
+            severance_candidates=candidates,
+            spec_drift=_spec_drift_dimension(),
+        )
+    except Exception:  # noqa: BLE001 — aggregator MUST never raise
+        return LivenessSnapshot(
+            enabled=True, reason_code="aggregation_error",
+            generated_at_unix=(now if now is not None else 0.0) or 0.0,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Cached snapshot for the observability GET
+# ---------------------------------------------------------------------------
+
+_LOCK = threading.RLock()
+_LAST: Optional[LivenessSnapshot] = None
+_LAST_TS: float = 0.0
+
+
+def snapshot(*, repo_root: Optional[Path] = None, force: bool = False) -> Dict[str, Any]:
+    """Public entry for the observability GET — serializable dict, TTL-cached.
+    Master-off → minimal ``enabled: false`` body (endpoint decides 403). NEVER
+    raises."""
+    if not master_enabled():
+        return {
+            "schema_version": CAPABILITY_LIVENESS_SCHEMA_VERSION,
+            "enabled": False, "reason_code": "disabled",
+        }
+    global _LAST, _LAST_TS
+    now = time.time()
+    with _LOCK:
+        if not force and _LAST is not None and (now - _LAST_TS) <= _snapshot_ttl_s():
+            return _LAST.to_dict()
+    snap = aggregate_capability_liveness(repo_root=repo_root, now=now)
+    with _LOCK:
+        _LAST = snap
+        _LAST_TS = now
+    return snap.to_dict()
+
+
+def reset_cache_for_tests() -> None:
+    global _LAST, _LAST_TS
+    with _LOCK:
+        _LAST = None
+        _LAST_TS = 0.0

--- a/backend/core/ouroboros/governance/capability_liveness.py
+++ b/backend/core/ouroboros/governance/capability_liveness.py
@@ -244,6 +244,15 @@ class CapabilityVerdict:
     fraction_severed: float = 0.0
     principles: Tuple[str, ...] = ()
     reason: str = ""
+    firing: str = "UNKNOWN"            # FIRING|SILENT|UNKNOWN (Step 2)
+    firing_hits: Tuple[str, ...] = ()
+    firing_channels: Tuple[str, ...] = ()   # derived: "ledger" (reliable) / "log"
+
+    @property
+    def ledger_backed(self) -> bool:
+        """A SILENT verdict with a ``ledger`` channel is high-confidence
+        dormancy (evidence-of-work channel went quiet)."""
+        return "ledger" in self.firing_channels
 
     def to_dict(self) -> Dict[str, Any]:
         return {
@@ -257,6 +266,10 @@ class CapabilityVerdict:
             "fraction_severed": round(self.fraction_severed, 4),
             "principles": list(self.principles),
             "reason": self.reason,
+            "firing": self.firing,
+            "firing_hits": list(self.firing_hits),
+            "firing_channels": list(self.firing_channels),
+            "ledger_backed": self.ledger_backed,
         }
 
 
@@ -269,8 +282,10 @@ def _verdict_for(
     repo: Path,
     caller_index: Dict[str, Set[str]],
     principles_fn: Optional[Callable[[str], Sequence[str]]],
+    firing_probe: Optional[Callable[[str], Tuple[str, List[str], List[str]]]] = None,
 ) -> CapabilityVerdict:
-    """Pure per-capability verdict from the caller-index. Never raises."""
+    """Pure per-capability verdict from the caller-index (+ optional firing
+    probe). Never raises."""
     _flag, _sf, _cat, _on = str(flag), str(source_file), str(category), bool(live_on)
 
     def _mk(verdict: str, **extra: Any) -> CapabilityVerdict:
@@ -288,9 +303,17 @@ def _verdict_for(
         source = abs_path.read_text(encoding="utf-8")
     except Exception:  # noqa: BLE001
         return _mk("UNRESOLVED", reason="source_file unreadable")
+
+    # Firing dimension (Step 2) — derived from THIS source, judged over the
+    # adaptive runtime evidence window. UNKNOWN when firing is off/unprovable.
+    firing, fhits, fchan = ("UNKNOWN", [], [])
+    if firing_probe is not None:
+        firing, fhits, fchan = firing_probe(source)
+
     symbols = _public_symbols(source)
     if not symbols:
-        return _mk("UNRESOLVED",
+        return _mk("UNRESOLVED", firing=firing, firing_hits=tuple(fhits),
+                   firing_channels=tuple(fchan),
                    reason="no public callable entry symbols to resolve reachability")
     severed: List[str] = []
     for sym in symbols:
@@ -308,12 +331,15 @@ def _verdict_for(
         except Exception:  # noqa: BLE001
             principles = ()
     if not severed:
-        return _mk("ALIVE", public_symbols=symbols, fraction_severed=0.0)
+        return _mk("ALIVE", public_symbols=symbols, fraction_severed=0.0,
+                   firing=firing, firing_hits=tuple(fhits),
+                   firing_channels=tuple(fchan))
     verdict = "FULLY_SEVERED" if fraction >= 1.0 else "SEVERED"
     return _mk(
         verdict,
         public_symbols=symbols, severed_symbols=tuple(severed),
         fraction_severed=fraction, principles=principles,
+        firing=firing, firing_hits=tuple(fhits), firing_channels=tuple(fchan),
         reason=(
             "no public callable has a production call site — likely inert subsystem"
             if fraction >= 1.0 else
@@ -340,6 +366,9 @@ class LivenessSnapshot:
     callable_reachability_ratio: Optional[float] = None
     fully_severed: List[Dict[str, Any]] = field(default_factory=list)
     severance_candidates: List[Dict[str, Any]] = field(default_factory=list)
+    dormant: List[Dict[str, Any]] = field(default_factory=list)
+    observability_gaps: List[Dict[str, Any]] = field(default_factory=list)
+    firing_evidence: Dict[str, Any] = field(default_factory=lambda: {"implemented": False})
     spec_drift: Dict[str, Any] = field(default_factory=dict)
 
     def to_dict(self) -> Dict[str, Any]:
@@ -371,19 +400,34 @@ class LivenessSnapshot:
             # Explicitly static-only — a symbol here may be dynamically
             # dispatched; treat as a review candidate, not proven-dead.
             "severance_candidates": self.severance_candidates,
+            # THE PRECISE MERKLE SIGNATURE (Step 2): capabilities that ARE
+            # statically reachable (ALIVE) yet emitted NO runtime firing
+            # evidence in the adaptive window — wired but dormant. This is the
+            # highest-value output: the exact class the static half could not
+            # distinguish, now caught by combining reachability with runtime
+            # evidence.
+            "dormant": self.dormant,
             # Third self-blindness axis (docs-vs-registry drift), composed from
             # the existing mirror_self_spec_drift auditor.
             "spec_drift": self.spec_drift,
             "interpretation": (
-                "Static reachability is the always-available half of "
-                "self-perception: it proves 'this symbol has no production call "
-                "site', which catches whole-module inertia and NEWLY-introduced "
-                "severances (trend). The precise merkle-class detector — "
-                "'enabled but never FIRED at runtime' — is the firing dimension "
-                "(Step 2: federated .jarvis/*.jsonl + debug.log reader), "
-                "deliberately deferred and wired via the firing_probe seam."
+                "Self-perception combines two proofs: STATIC reachability "
+                "('this callable has a production call site' — catches whole-"
+                "module inertia + newly-introduced severances via trend) and "
+                "RUNTIME firing ('this subsystem emitted evidence in the recent "
+                "window' — markers derived from the capability's own source, "
+                "judged over an adaptive session-anchored window). Their "
+                "intersection — ALIVE but SILENT = 'dormant' — is the precise "
+                "merkle class: reachable, wired, but not running."
             ),
-            "firing": {"implemented": False},
+            # Reachable + SILENT but only a LOG channel (no ledger) — may be
+            # running silently. NOT proven dormant; an observability gap worth
+            # closing (the subsystem should emit durable evidence).
+            "observability_gaps": self.observability_gaps,
+            # Runtime firing dimension summary (evidence window + counts +
+            # dormant/gap totals). ``implemented: false`` when the firing master
+            # is off (firing then UNKNOWN for all; no dormant analysis).
+            "firing": self.firing_evidence,
         }
 
 
@@ -429,12 +473,29 @@ def _principles_fn() -> Optional[Callable[[str], Sequence[str]]]:
         return None
 
 
+def _resolve_firing_probe(
+    repo: Path, now: float,
+) -> Tuple[Optional[Callable[[str], Tuple[str, List[str], List[str]]]], Optional[Dict[str, Any]]]:
+    """Build the Step-2 firing probe from ``capability_firing`` when its master
+    is on. Returns ``(probe, evidence_summary)`` or ``(None, None)`` when firing
+    is off/unavailable (→ firing stays UNKNOWN, no dormant analysis). Never
+    raises."""
+    try:
+        from backend.core.ouroboros.governance import capability_firing as cf
+        if not cf.master_enabled():
+            return None, None
+        probe, evidence = cf.build_firing_probe(repo, now=now)
+        return probe, evidence.to_dict()
+    except Exception:  # noqa: BLE001
+        return None, None
+
+
 def aggregate_capability_liveness(
     *,
     repo_root: Optional[Path] = None,
     now: Optional[float] = None,
     walker: Optional[Callable[[], List[Tuple[str, str]]]] = None,  # test seam
-    firing_probe: Optional[Callable[[str], bool]] = None,  # Step 2 seam (unused in Step 1)
+    firing_probe: Optional[Callable[[str], Tuple[str, List[str]]]] = None,  # Step 2 seam
 ) -> LivenessSnapshot:
     """Compose the capability-liveness snapshot from the FlagRegistry + a
     ripgrep caller-index. Read-only; NEVER raises — any fault degrades to a
@@ -444,7 +505,6 @@ def aggregate_capability_liveness(
     ``(flag_name) -> bool`` (did the subsystem fire in the window). Unused in
     Step 1; wired here so Step 2 needs no signature change.
     """
-    _ = firing_probe  # reserved for the Step-2 firing dimension (see docstring)
     try:
         _now = float(now) if now is not None else time.time()
         repo = _resolve_repo_root(repo_root)
@@ -492,6 +552,16 @@ def aggregate_capability_liveness(
         caller_index = _build_caller_index(repo, all_names, walker=walker)
         reason = "ok"
 
+        # --- firing dimension (Step 2) — one durable evidence read, amortized ---
+        _firing_probe = firing_probe
+        firing_evidence: Dict[str, Any] = {"implemented": False}
+        if _firing_probe is None:
+            _firing_probe, _fev = _resolve_firing_probe(repo, _now)
+            if _fev is not None:
+                firing_evidence = {"implemented": True, **_fev}
+        elif _firing_probe is not None:
+            firing_evidence = {"implemented": True, "source": "injected"}
+
         # --- per-capability verdicts ---
         principles_fn = _principles_fn()
         verdicts: List[CapabilityVerdict] = []
@@ -504,6 +574,7 @@ def aggregate_capability_liveness(
                 repo=repo,
                 caller_index=caller_index,
                 principles_fn=principles_fn,
+                firing_probe=_firing_probe,
             )
             verdicts.append(v)
 
@@ -524,11 +595,39 @@ def aggregate_capability_liveness(
             key=lambda d: (-d["fraction_severed"], d["flag"]),
         )
 
+        # --- the precise merkle signature: REACHABLE (ALIVE) but SILENT ---
+        # A capability whose callables all have production call sites (so it is
+        # statically wired) yet emitted NO runtime evidence in the window is
+        # dormant — the exact class the static half could not distinguish.
+        # HIGH-CONFIDENCE dormancy requires a LEDGER evidence-of-work channel
+        # that went quiet (the merkle merkle_history.jsonl case); a log-tag-only
+        # silence is downgraded to observability_gap (may be running silently).
+        firing_counts: Dict[str, int] = {}
+        for v in verdicts:
+            firing_counts[v.firing] = firing_counts.get(v.firing, 0) + 1
+        _alive_silent = [
+            v for v in verdicts if v.verdict == "ALIVE" and v.firing == "SILENT"
+        ]
+        dormant = sorted(
+            (v.to_dict() for v in _alive_silent if v.ledger_backed),
+            key=lambda d: d["flag"],
+        )
+        observability_gaps = sorted(
+            (v.to_dict() for v in _alive_silent if not v.ledger_backed),
+            key=lambda d: d["flag"],
+        )
+        firing_evidence["counts"] = firing_counts
+        firing_evidence["dormant_count"] = len(dormant)
+        firing_evidence["observability_gap_count"] = len(observability_gaps)
+
         return LivenessSnapshot(
             enabled=True, reason_code=reason, generated_at_unix=_now,
             capabilities_declared=len(live_specs),
             capabilities_resolved=resolved,
             counts=counts,
+            firing_evidence=firing_evidence,
+            dormant=dormant,
+            observability_gaps=observability_gaps,
             callable_reachability_ratio=ratio,
             fully_severed=fully,
             severance_candidates=candidates,

--- a/backend/core/ouroboros/governance/conception_proposal_bridge.py
+++ b/backend/core/ouroboros/governance/conception_proposal_bridge.py
@@ -1,0 +1,416 @@
+"""Conception Proposal Bridge — ranked blueprints → intake router (Gap 3).
+
+The final unification path. The conception value model (``conception_value_model``)
+ranks self-conceived work by expected value; DreamEngine produces the conceived
+work as ``ImprovementBlueprint``s. Until now nothing carried a *highly ranked*
+blueprint into active execution — the ranked scores modulated one sensor's
+confidence but no proposal reached the intake queue on its own. This bridge is
+that missing translation layer, and NOTHING MORE:
+
+  * **Event-driven** — it reacts to blueprint production (a DreamEngine
+    ``register_blueprint_observer`` callback), never polls. On each event it
+    evaluates the *current* top-N batch so the threshold is batch-relative.
+  * **Dynamic threshold** — a proposal routes iff its EV clears
+    ``max(ev_floor, batch_mean_EV)``. Distribution-relative; the only absolute is
+    an env floor (default 0.5 = the neutral prior), so a COLD organism — whose
+    every EV sits at neutral×cost < floor — routes nothing until real signal
+    lifts a proposal above its peers AND above neutral. No hardcoded cutoff.
+  * **DRY** — it consumes the value model's EMITTED ``ExpectedValue`` verbatim
+    (never recomputes weights), builds the envelope with the existing
+    ``make_envelope`` schema, submits through the existing
+    ``UnifiedIntakeRouter.ingest``, and records to the existing
+    ``proactive_proposal_surface`` ledger. It owns no queue.
+  * **Bulletproof dedup** — a durable, TTL+capacity-bounded registry keyed by
+    ``blueprint_id`` is the authoritative "already routed / in execution" guard
+    (survives across events, unlike the router's 300s window); the envelope's
+    ``dedup_key`` (via ``evidence['signature'] = blueprint_id``) is a second
+    structural guard inside the router. A blueprint already routed is dropped.
+
+Discipline: authority-free (no gate/policy/orchestrator imports), never raises,
+default-OFF master flag (a new autonomous routing capability is opt-in).
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any, Callable, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+CONCEPTION_BRIDGE_SCHEMA_VERSION = "conception_bridge.1"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+# Router ingest results that mean "the proposal is in the queue" — all of them
+# imply the blueprint is now routed and must be deduped on subsequent events.
+_ROUTED_RESULTS = frozenset({"enqueued", "pending_ack", "deduplicated"})
+
+
+# ---------------------------------------------------------------------------
+# Env surface
+# ---------------------------------------------------------------------------
+
+
+def master_enabled() -> bool:
+    """``JARVIS_CONCEPTION_BRIDGE_ENABLED`` (default FALSE — opt-in)."""
+    return os.environ.get(
+        "JARVIS_CONCEPTION_BRIDGE_ENABLED", "false",
+    ).strip().lower() in _TRUTHY
+
+
+def _envf(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _envi(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _ev_floor() -> float:
+    """Absolute EV floor below which nothing routes (default 0.5 = neutral)."""
+    return min(1.0, max(0.0, _envf("JARVIS_CONCEPTION_BRIDGE_EV_FLOOR", 0.5)))
+
+
+def _max_per_route() -> int:
+    return max(1, _envi("JARVIS_CONCEPTION_BRIDGE_MAX_PER_ROUTE", 3))
+
+
+def _dedup_ttl_s() -> float:
+    return max(60.0, _envf("JARVIS_CONCEPTION_BRIDGE_DEDUP_TTL_S", 3600.0))
+
+
+def _dedup_capacity() -> int:
+    return max(16, _envi("JARVIS_CONCEPTION_BRIDGE_DEDUP_CAPACITY", 512))
+
+
+def _top_n() -> int:
+    return max(1, _envi("JARVIS_CONCEPTION_BRIDGE_TOP_N", 5))
+
+
+# ---------------------------------------------------------------------------
+# Outcome artifact
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class RoutingOutcome:
+    """One blueprint's disposition through the bridge. ``routed`` True iff it
+    reached the intake queue this pass."""
+
+    blueprint_id: str
+    ev: float
+    scope: str
+    threshold: float
+    routed: bool
+    reason: str            # "routed" | "below_threshold" | "duplicate" | "ingest_<result>" | "error"
+    ingest_result: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Durable dedup registry — authoritative "already routed / in execution" guard
+# ---------------------------------------------------------------------------
+
+
+class _RoutedRegistry:
+    """Bounded, TTL-evicted set of routed ``blueprint_id``s. Thread-safe."""
+
+    def __init__(self) -> None:
+        self._items: "OrderedDict[str, float]" = OrderedDict()
+        self._lock = threading.Lock()
+
+    def _evict(self, now: float) -> None:
+        ttl = _dedup_ttl_s()
+        cap = _dedup_capacity()
+        # TTL eviction (oldest-first; insertion order == time order).
+        while self._items:
+            bid, ts = next(iter(self._items.items()))
+            if now - ts > ttl:
+                self._items.pop(bid, None)
+            else:
+                break
+        # Capacity eviction.
+        while len(self._items) > cap:
+            self._items.popitem(last=False)
+
+    def is_routed(self, blueprint_id: str, now: float) -> bool:
+        with self._lock:
+            self._evict(now)
+            return blueprint_id in self._items
+
+    def mark(self, blueprint_id: str, now: float) -> None:
+        with self._lock:
+            self._items.pop(blueprint_id, None)   # refresh insertion order
+            self._items[blueprint_id] = now
+            self._evict(now)
+
+    def __len__(self) -> int:
+        with self._lock:
+            return len(self._items)
+
+    def reset(self) -> None:
+        with self._lock:
+            self._items.clear()
+
+
+# ---------------------------------------------------------------------------
+# The bridge
+# ---------------------------------------------------------------------------
+
+
+class ConceptionProposalBridge:
+    """Event-driven translation layer: ranked blueprints → intake router."""
+
+    def __init__(
+        self,
+        *,
+        value_scorer: Optional[Callable[[Any], Any]] = None,
+        ledger_emit: Optional[Callable[..., Any]] = None,
+        registry: Optional[_RoutedRegistry] = None,
+    ) -> None:
+        self._score = value_scorer          # default resolved lazily (DRY)
+        self._ledger_emit = ledger_emit     # default resolved lazily
+        self._registry = registry or _RoutedRegistry()
+        # observability counters
+        self._routed_total = 0
+        self._dropped_duplicate = 0
+        self._below_threshold = 0
+        self._errors = 0
+        self._events = 0
+
+    # -- axis resolution (lazy, DRY) --------------------------------------
+
+    def _score_blueprint(self, bp: Any) -> Any:
+        if self._score is not None:
+            return self._score(bp)
+        from backend.core.ouroboros.governance.conception_value_model import (
+            score_blueprint,
+        )
+        return score_blueprint(bp)
+
+    def _emit_to_ledger(self, bp: Any, ev: Any) -> None:
+        try:
+            emit = self._ledger_emit
+            if emit is None:
+                from backend.core.ouroboros.governance.proactive_proposal_surface import (
+                    emit_proposal,
+                )
+                emit = emit_proposal
+            emit(
+                kind="opportunity",
+                signal_source="auto_proposed",
+                summary=str(getattr(bp, "title", "") or getattr(bp, "description", "")),
+                rationale=str(getattr(ev, "rationale", "")),
+                priority_hint=float(getattr(ev, "ev", 0.5)),
+            )
+        except Exception:  # noqa: BLE001 — ledger record is best-effort audit
+            logger.debug("[ConceptionBridge] ledger emit skipped", exc_info=True)
+
+    # -- core reactor -----------------------------------------------------
+
+    async def route(
+        self,
+        blueprints: Sequence[Any],
+        router: Any,
+        *,
+        now: Optional[float] = None,
+    ) -> List[RoutingOutcome]:
+        """Route the batch's above-threshold, non-duplicate blueprints into the
+        intake router. Event-reactor — call this on blueprint production, not on
+        a timer. Never raises; returns per-blueprint outcomes."""
+        if not master_enabled() or router is None:
+            return []
+        now = now if now is not None else time.time()
+        self._events += 1
+        try:
+            # 1. Score (consume the value model's EMITTED EV; never recompute).
+            scored: List[Tuple[Any, Any]] = []
+            for bp in (blueprints or ()):
+                bid = str(getattr(bp, "blueprint_id", "") or "")
+                tfs = tuple(getattr(bp, "target_files", ()) or ())
+                if not bid or not tfs:
+                    continue
+                try:
+                    ev = self._score_blueprint(bp)
+                except Exception:  # noqa: BLE001
+                    self._errors += 1
+                    continue
+                scored.append((bp, ev))
+
+            # 2. Drop already-routed / in-execution (mandate 4 — durable guard).
+            fresh = [
+                (bp, ev) for (bp, ev) in scored
+                if not self._registry.is_routed(str(bp.blueprint_id), now)
+            ]
+            outcomes: List[RoutingOutcome] = []
+            for (bp, ev) in scored:
+                if self._registry.is_routed(str(bp.blueprint_id), now):
+                    self._dropped_duplicate += 1
+                    outcomes.append(RoutingOutcome(
+                        blueprint_id=str(bp.blueprint_id), ev=float(ev.ev),
+                        scope=str(ev.scope), threshold=0.0, routed=False,
+                        reason="duplicate"))
+            if not fresh:
+                return outcomes
+
+            # 3. Dynamic, batch-relative threshold. No hardcoded cutoff — the
+            #    quality bar rises with the batch mean and never drops below the
+            #    neutral floor.
+            evs = [float(ev.ev) for (_bp, ev) in fresh]
+            threshold = max(_ev_floor(), sum(evs) / len(evs))
+
+            survivors = sorted(
+                [(bp, ev) for (bp, ev) in fresh if float(ev.ev) >= threshold],
+                key=lambda pe: float(pe[1].ev), reverse=True,
+            )[:_max_per_route()]
+            survivor_ids = {str(bp.blueprint_id) for (bp, _ev) in survivors}
+
+            for (bp, ev) in fresh:
+                if str(bp.blueprint_id) not in survivor_ids:
+                    self._below_threshold += 1
+                    outcomes.append(RoutingOutcome(
+                        blueprint_id=str(bp.blueprint_id), ev=float(ev.ev),
+                        scope=str(ev.scope), threshold=threshold, routed=False,
+                        reason="below_threshold"))
+
+            # 4. Translate + ingest each survivor.
+            for (bp, ev) in survivors:
+                outcomes.append(await self._route_one(bp, ev, router, threshold, now))
+            return outcomes
+        except Exception:  # noqa: BLE001 — reactor never leaks into the loop
+            self._errors += 1
+            logger.debug("[ConceptionBridge] route pass faulted", exc_info=True)
+            return []
+
+    async def _route_one(
+        self, bp: Any, ev: Any, router: Any, threshold: float, now: float,
+    ) -> RoutingOutcome:
+        bid = str(bp.blueprint_id)
+        try:
+            from backend.core.ouroboros.governance.intake.intent_envelope import (
+                make_envelope,
+            )
+
+            envelope = make_envelope(
+                source="auto_proposed",
+                description=str(getattr(bp, "description", "") or getattr(bp, "title", "")),
+                target_files=tuple(str(t) for t in bp.target_files),
+                repo=str(getattr(bp, "repo", "") or ""),
+                confidence=max(0.0, min(1.0, float(ev.ev))),
+                urgency="low",
+                evidence={
+                    "sensor": "conception_bridge",
+                    # `signature` drives the router's own dedup_key — deterministic
+                    # per blueprint, a second structural guard against duplicates.
+                    "signature": bid,
+                    "blueprint_id": bid,
+                    "category": str(getattr(bp, "category", "")),
+                    "ev": round(float(ev.ev), 4),
+                    "threshold": round(float(threshold), 4),
+                    "conception_value": ev.to_dict() if hasattr(ev, "to_dict") else {},
+                },
+                requires_human_ack=True,  # proactive conception surfaces for ack
+            )
+            result = str(await router.ingest(envelope))
+            # Mark routed on ANY in-queue result (incl. router-side dedup).
+            if result in _ROUTED_RESULTS:
+                self._registry.mark(bid, now)
+                self._routed_total += 1
+                self._emit_to_ledger(bp, ev)
+                return RoutingOutcome(
+                    blueprint_id=bid, ev=float(ev.ev), scope=str(ev.scope),
+                    threshold=threshold, routed=True, reason="routed",
+                    ingest_result=result)
+            return RoutingOutcome(
+                blueprint_id=bid, ev=float(ev.ev), scope=str(ev.scope),
+                threshold=threshold, routed=False, reason=f"ingest_{result}",
+                ingest_result=result)
+        except Exception:  # noqa: BLE001
+            self._errors += 1
+            logger.debug("[ConceptionBridge] ingest faulted for %s", bid, exc_info=True)
+            return RoutingOutcome(
+                blueprint_id=bid, ev=float(getattr(ev, "ev", 0.0)),
+                scope=str(getattr(ev, "scope", "")), threshold=threshold,
+                routed=False, reason="error")
+
+    # -- event wiring -----------------------------------------------------
+
+    def make_observer(
+        self, router: Any, blueprint_source: Callable[[], Sequence[Any]],
+    ) -> Callable[[Any], Any]:
+        """Return an async DreamEngine blueprint observer. On each
+        blueprint-computed event it pulls the CURRENT batch (so the threshold is
+        batch-relative) and routes it. Fail-soft."""
+        async def _observer(_blueprint: Any) -> None:
+            try:
+                batch = list(blueprint_source() or ())
+            except Exception:  # noqa: BLE001
+                batch = []
+            if batch:
+                await self.route(batch, router)
+        return _observer
+
+    # -- observability ----------------------------------------------------
+
+    def snapshot(self) -> dict:
+        return {
+            "schema_version": CONCEPTION_BRIDGE_SCHEMA_VERSION,
+            "enabled": master_enabled(),
+            "ev_floor": _ev_floor(),
+            "max_per_route": _max_per_route(),
+            "dedup_ttl_s": _dedup_ttl_s(),
+            "dedup_registry_size": len(self._registry),
+            "counters": {
+                "events": self._events,
+                "routed_total": self._routed_total,
+                "dropped_duplicate": self._dropped_duplicate,
+                "below_threshold": self._below_threshold,
+                "errors": self._errors,
+            },
+        }
+
+    def reset_for_tests(self) -> None:
+        self._registry.reset()
+        self._routed_total = self._dropped_duplicate = 0
+        self._below_threshold = self._errors = self._events = 0
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+_default_bridge: Optional[ConceptionProposalBridge] = None
+_singleton_lock = threading.Lock()
+
+
+def get_default_bridge() -> ConceptionProposalBridge:
+    global _default_bridge
+    with _singleton_lock:
+        if _default_bridge is None:
+            _default_bridge = ConceptionProposalBridge()
+        return _default_bridge
+
+
+def reset_bridge_for_tests() -> None:
+    global _default_bridge
+    with _singleton_lock:
+        if _default_bridge is not None:
+            _default_bridge.reset_for_tests()
+        _default_bridge = None
+
+
+def snapshot() -> dict:
+    """Module-level observability projection (safe when disabled)."""
+    try:
+        return get_default_bridge().snapshot()
+    except Exception:  # noqa: BLE001
+        return {"schema_version": CONCEPTION_BRIDGE_SCHEMA_VERSION, "enabled": False}

--- a/backend/core/ouroboros/governance/conception_value_model.py
+++ b/backend/core/ouroboros/governance/conception_value_model.py
@@ -1,0 +1,365 @@
+"""Conception Value Model — ranks self-conceived work by expected value (Gap 3).
+
+The organism already CONCEIVES: DreamEngine emits scored ImprovementBlueprints,
+OpportunityMiner ranks static candidates, IntentDiscovery / ProactiveExploration
+propose proactive work. But those SCORES are discarded (a blueprint's
+priority_score is flattened into prompt prose) and there is no unified model of
+*what conceived work is worth pursuing*. This module supplies that model — an
+authority-free, evidence-grounded expected-value ranker that composes four
+existing read-only signals rather than inventing a new one:
+
+  A  alignment    — strategic fit vs the codebase's active goal themes
+                    (``semantic_index.score_with_cluster``).
+  S  substance    — expected real-code value, verifiable-evidence-first
+                    (``signal_value.score_signal`` band over the targets); the
+                    KPI this optimises is ``substance_ledger.substance_ratio``.
+  F  feasibility  — EARNED autonomy: do we have a track record we can act on in
+                    this scope? (``trust_calibration.scope_trust`` — Gap 4 feeds
+                    Gap 3: the organism preferentially conceives work in scopes
+                    where it has EARNED the ability to land changes autonomously,
+                    and backs off a scope that just regressed).
+  C  cost         — value-per-dollar efficiency (blueprint ``estimated_cost_usd``).
+
+    EV = cost_factor · Σ(wᵢ·axisᵢ) / Σwᵢ   ∈ [0, 1]
+
+EV becomes the ``priority_hint`` on ``proactive_proposal_surface``, which bridges
+conceived proposals into the intake router as ``auto_proposed`` envelopes.
+
+Discipline (mirrors trust_calibration / signal_value):
+  * **Authority-free** — imports only read-only scorers; never gate / policy /
+    orchestrator / iron_gate. Grep-enforced by the observability import test.
+  * **Never raises** — every axis degrades to a NEUTRAL prior (0.5) when its
+    source is cold, so a fresh organism ranks by what it CAN see instead of
+    collapsing every proposal to zero. Substance is the deliberate exception: a
+    *proven* cosmetic band scores below neutral (we don't want to conceive
+    cosmetic work), while an indeterminate band stays neutral.
+  * **No hardcoded weights** — every weight / coefficient reads from an env var
+    with a sensible default.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import asdict, dataclass
+from typing import Any, Callable, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger(__name__)
+
+CONCEPTION_VALUE_SCHEMA_VERSION = "conception_value.1"
+
+_TRUTHY = ("1", "true", "yes", "on")
+_NEUTRAL = 0.5  # the prior for a cold / unknowable axis
+
+
+# ---------------------------------------------------------------------------
+# Env surface — every weight / coefficient tunable, nothing hardcoded
+# ---------------------------------------------------------------------------
+
+
+def master_enabled() -> bool:
+    """``JARVIS_CONCEPTION_VALUE_MODEL_ENABLED`` (default true)."""
+    return os.environ.get(
+        "JARVIS_CONCEPTION_VALUE_MODEL_ENABLED", "true",
+    ).strip().lower() in _TRUTHY
+
+
+def _envf(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+
+
+def _w_align() -> float:
+    return max(0.0, _envf("JARVIS_CONCEPTION_W_ALIGN", 0.40))
+
+
+def _w_substance() -> float:
+    return max(0.0, _envf("JARVIS_CONCEPTION_W_SUBSTANCE", 0.35))
+
+
+def _w_feasibility() -> float:
+    return max(0.0, _envf("JARVIS_CONCEPTION_W_FEASIBILITY", 0.25))
+
+
+def _cost_coeff() -> float:
+    """Higher → cost penalised harder. cost_factor = 1/(1+coeff·usd)."""
+    return max(0.0, _envf("JARVIS_CONCEPTION_COST_COEFF", 2.0))
+
+
+def _regression_damp() -> float:
+    """Feasibility multiplier when the scope has a fresh regression."""
+    v = _envf("JARVIS_CONCEPTION_REGRESSION_DAMP", 0.5)
+    return min(1.0, max(0.0, v))
+
+
+# ---------------------------------------------------------------------------
+# Small helpers
+# ---------------------------------------------------------------------------
+
+
+def _clamp01(x: float) -> float:
+    try:
+        return max(0.0, min(1.0, float(x)))
+    except (TypeError, ValueError):
+        return _NEUTRAL
+
+
+# TrustLevel string → feasibility axis. UNKNOWN is NEUTRAL, not disqualifying:
+# no track record means "uncertain", not "unworthy of conception".
+_TRUST_AXIS: Dict[str, float] = {
+    "high": 1.0,
+    "medium": 0.7,
+    "low": 0.3,
+    "unknown": _NEUTRAL,
+}
+
+# signal_value band → substance axis. INDETERMINATE (0) is a NEW/unresolvable
+# target — neutral, not zero. A PROVEN cosmetic band (1) sits below neutral so
+# cosmetic conception is out-competed; executable (2) / oracle (3) climb.
+_BAND_AXIS: Dict[int, float] = {
+    0: _NEUTRAL,   # BAND_INDETERMINATE
+    1: 0.33,       # BAND_COSMETIC_CLASS
+    2: 0.66,       # BAND_EXECUTABLE
+    3: 1.0,        # BAND_ORACLE
+}
+
+
+# ---------------------------------------------------------------------------
+# Axis computations (each never raises; degrades to a neutral prior)
+# ---------------------------------------------------------------------------
+
+
+def _alignment_axis(description: str, project_root: Any) -> Tuple[float, bool]:
+    """Strategic fit via the recency-weighted semantic centroid/clusters.
+
+    Returns (value, known). ``known`` is False when the index is cold /
+    disabled — the caller then treats alignment as a neutral prior instead of
+    a hard zero.
+    """
+    if not (description or "").strip():
+        return _NEUTRAL, False
+    try:
+        from backend.core.ouroboros.governance.semantic_index import (
+            get_default_index,
+        )
+
+        idx = get_default_index(project_root)
+        detail = idx.score_with_cluster(description)
+        if not detail:
+            return _NEUTRAL, False
+        return _clamp01(detail.get("score", 0.0)), True
+    except Exception:  # noqa: BLE001 — cold index is not a value verdict
+        logger.debug("[Conception] alignment axis cold", exc_info=True)
+        return _NEUTRAL, False
+
+
+def _substance_axis(
+    signal_source: str,
+    target_files: Sequence[Any],
+    project_root: Any,
+) -> Tuple[float, int]:
+    """Expected real-code value from the verifiable AST/oracle band.
+
+    Returns (value, band). Verifiable-evidence-first — identical philosophy to
+    ``signal_value`` itself; we simply project its band onto [0,1].
+    """
+    try:
+        from backend.core.ouroboros.governance.signal_value import score_signal
+
+        band = int(score_signal(
+            str(signal_source or ""), tuple(target_files or ()), "", project_root,
+        ))
+        return _BAND_AXIS.get(band, _NEUTRAL), band
+    except Exception:  # noqa: BLE001
+        logger.debug("[Conception] substance axis error", exc_info=True)
+        return _NEUTRAL, 0
+
+
+def _feasibility_axis(scope: str) -> Tuple[float, str, bool]:
+    """Earned autonomy for ``scope`` — the Gap-4 → Gap-3 composition.
+
+    Returns (value, trust_level, recent_regression). A fresh regression damps
+    the axis (env ``JARVIS_CONCEPTION_REGRESSION_DAMP``) so the organism does
+    not pile conception onto a scope it just broke.
+    """
+    try:
+        from backend.core.ouroboros.governance import trust_calibration as tc
+
+        st = tc.scope_trust(scope)
+        base = _TRUST_AXIS.get(str(st.trust_level).lower(), _NEUTRAL)
+        if st.recent_regression:
+            base *= _regression_damp()
+        return _clamp01(base), str(st.trust_level), bool(st.recent_regression)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Conception] feasibility axis cold", exc_info=True)
+        return _NEUTRAL, "unknown", False
+
+
+def _cost_factor(cost_usd: float) -> float:
+    """Value-per-dollar. cost_usd=0 → 1.0; grows expensive → 0. Never raises."""
+    try:
+        c = max(0.0, float(cost_usd))
+    except (TypeError, ValueError):
+        c = 0.0
+    return 1.0 / (1.0 + _cost_coeff() * c)
+
+
+def _infer_scope(target_files: Sequence[Any]) -> str:
+    try:
+        from backend.core.ouroboros.governance.trust_calibration import (
+            _infer_scope_for,
+        )
+
+        return _infer_scope_for([str(t) for t in (target_files or ())])
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+# ---------------------------------------------------------------------------
+# Result artifact
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExpectedValue:
+    """Expected-value verdict for one conceived proposal. ``ev`` ∈ [0,1]."""
+
+    ev: float
+    alignment: float
+    substance: float
+    feasibility: float
+    cost_factor: float
+    scope: str
+    trust_level: str
+    band: int
+    alignment_known: bool
+    recent_regression: bool
+    rationale: str
+
+    def to_dict(self) -> Dict[str, Any]:
+        d = asdict(self)
+        d["schema_version"] = CONCEPTION_VALUE_SCHEMA_VERSION
+        return d
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+
+def score_proposal(
+    *,
+    description: str,
+    target_files: Sequence[Any] = (),
+    signal_source: str = "auto_proposed",
+    estimated_cost_usd: float = 0.0,
+    scope: Optional[str] = None,
+    project_root: Any = None,
+    # injectable seams for tests — default to the real read-only scorers
+    align_fn: Optional[Callable[[str, Any], Tuple[float, bool]]] = None,
+    substance_fn: Optional[Callable[[str, Sequence[Any], Any], Tuple[float, int]]] = None,
+    feasibility_fn: Optional[Callable[[str], Tuple[float, str, bool]]] = None,
+) -> ExpectedValue:
+    """Expected value of a conceived proposal. Never raises.
+
+    When the model is disabled every axis reports its neutral prior and EV is
+    the un-weighted-cost-scaled neutral — inert but well-formed.
+    """
+    root = project_root if project_root is not None else (
+        os.environ.get("JARVIS_PROJECT_ROOT", "") or os.getcwd()
+    )
+    sc = scope or _infer_scope(target_files)
+
+    if not master_enabled():
+        cf = _cost_factor(estimated_cost_usd)
+        return ExpectedValue(
+            ev=_clamp01(_NEUTRAL * cf), alignment=_NEUTRAL, substance=_NEUTRAL,
+            feasibility=_NEUTRAL, cost_factor=cf, scope=sc, trust_level="unknown",
+            band=0, alignment_known=False, recent_regression=False,
+            rationale="model_disabled",
+        )
+
+    a, a_known = (align_fn or _alignment_axis)(description, root)
+    s, band = (substance_fn or _substance_axis)(signal_source, target_files, root)
+    f, trust_level, regressed = (feasibility_fn or _feasibility_axis)(sc)
+    cf = _cost_factor(estimated_cost_usd)
+
+    wa, ws, wf = _w_align(), _w_substance(), _w_feasibility()
+    wsum = wa + ws + wf
+    weighted = (wa * a + ws * s + wf * f) / wsum if wsum > 0 else _NEUTRAL
+    ev = _clamp01(cf * weighted)
+
+    rationale = (
+        f"A={a:.2f}{'' if a_known else '~'} S={s:.2f}(b{band}) "
+        f"F={f:.2f}({trust_level}{'!' if regressed else ''}) "
+        f"cost×{cf:.2f} → EV={ev:.3f}"
+    )
+    return ExpectedValue(
+        ev=ev, alignment=a, substance=s, feasibility=f, cost_factor=cf,
+        scope=sc, trust_level=trust_level, band=band, alignment_known=a_known,
+        recent_regression=regressed, rationale=rationale,
+    )
+
+
+def score_blueprint(blueprint: Any, *, project_root: Any = None) -> ExpectedValue:
+    """Adapter: score a DreamEngine ``ImprovementBlueprint`` (the discarded
+    scores this model exists to recover). Reads description / target_files /
+    estimated_cost_usd off the blueprint; unknown shapes degrade to neutral.
+    """
+    return score_proposal(
+        description=str(getattr(blueprint, "description", "") or getattr(blueprint, "title", "")),
+        target_files=getattr(blueprint, "target_files", ()) or (),
+        signal_source="auto_proposed",
+        estimated_cost_usd=getattr(blueprint, "estimated_cost_usd", 0.0) or 0.0,
+        project_root=project_root,
+    )
+
+
+def rank_proposals(
+    proposals: Sequence[Tuple[Any, ExpectedValue]],
+) -> List[Tuple[Any, ExpectedValue]]:
+    """Sort (item, ExpectedValue) pairs by EV desc. Stable; never raises."""
+    try:
+        return sorted(proposals, key=lambda pe: pe[1].ev, reverse=True)
+    except Exception:  # noqa: BLE001
+        return list(proposals)
+
+
+def priority_hint_for(
+    *,
+    description: str,
+    target_files: Sequence[Any] = (),
+    signal_source: str = "auto_proposed",
+    estimated_cost_usd: float = 0.0,
+    project_root: Any = None,
+) -> float:
+    """Convenience: the EV as a ``proactive_proposal_surface`` priority_hint
+    ∈ [0,1]. This is the one-line seam the proposal producers call."""
+    return score_proposal(
+        description=description, target_files=target_files,
+        signal_source=signal_source, estimated_cost_usd=estimated_cost_usd,
+        project_root=project_root,
+    ).ev
+
+
+def snapshot() -> Dict[str, Any]:
+    """Read-only observability projection of the model's configuration."""
+    return {
+        "schema_version": CONCEPTION_VALUE_SCHEMA_VERSION,
+        "enabled": master_enabled(),
+        "weights": {
+            "alignment": _w_align(),
+            "substance": _w_substance(),
+            "feasibility": _w_feasibility(),
+        },
+        "cost_coeff": _cost_coeff(),
+        "regression_damp": _regression_damp(),
+        "neutral_prior": _NEUTRAL,
+        "axes": {
+            "alignment": "semantic_index.score_with_cluster",
+            "substance": "signal_value.score_signal",
+            "feasibility": "trust_calibration.scope_trust",
+            "cost": "1/(1+coeff·usd)",
+        },
+    }

--- a/backend/core/ouroboros/governance/event_loop_governance.py
+++ b/backend/core/ouroboros/governance/event_loop_governance.py
@@ -56,6 +56,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import time
 from typing import Any, AsyncIterator, Callable, Iterable, TypeVar
 
 logger = logging.getLogger("Ouroboros.EventLoopGovernance")
@@ -108,6 +109,23 @@ async def cooperative_yield() -> None:
     """
     if event_loop_governance_enabled():
         await asyncio.sleep(0)
+
+
+async def measure_loop_lag_ms(probe_s: float = 0.02) -> float:
+    """Cheap event-loop lag probe: how far a short ``asyncio.sleep``
+    overshoots is how backed-up the loop is right now. Pure timing;
+    never raises.
+
+    Slice 27 — hoisted to this shared substrate (the Oracle carries an
+    identical private probe feeding its AIMD throttle; the miner and any
+    future adaptive loop consume this one instead of re-implementing it).
+    """
+    try:
+        t0 = time.monotonic()
+        await asyncio.sleep(probe_s)
+        return max(0.0, (time.monotonic() - t0 - probe_s) * 1000.0)
+    except Exception:  # noqa: BLE001
+        return 0.0
 
 
 async def cooperative_yield_every_n_async(

--- a/backend/core/ouroboros/governance/external_watchdog.py
+++ b/backend/core/ouroboros/governance/external_watchdog.py
@@ -28,12 +28,18 @@ point (``python external_watchdog.py --watch <pid> <hb> <budget> <stale>``).
 """
 from __future__ import annotations
 
+import logging
 import os
 import signal
 import sys
 import time
 from pathlib import Path
 from typing import Optional, Tuple
+
+# Parent-process logger only — the sentinel CHILD stays logging-free by
+# design (standalone subprocess, no logging config; it speaks via
+# os.write(2, ...) so its lines land on the harness's inherited stderr).
+logger = logging.getLogger("Ouroboros.ExternalWatchdog")
 
 
 def _suspend_detected(
@@ -79,6 +85,47 @@ def _read_beat(heartbeat_path: str) -> Optional[float]:
         return None
 
 
+def format_poll_forensics(
+    *,
+    tag: str,
+    now_wall: float,
+    armed_wall: float,
+    last_beat_wall: Optional[float],
+    stale_window_s: float,
+    budget_s: float,
+    suspended: bool,
+    wall_delta: float,
+    mono_delta: float,
+    poll_s: float,
+    suppressed_polls: int,
+    max_poll_drift_s: float,
+) -> str:
+    """Slice 29 — one dynamically-computed forensic line for the sentinel.
+
+    Pure formatter (unit-testable): every value in the line is a live delta
+    calculation, never a canned narrative. This is the instrumentation the
+    bt-2026-07-15-233357 post-mortem lacked — the kill fired 915s after the
+    beat froze instead of the 120s window and NOTHING recorded why (child
+    scheduling drift? suspend-suppression? unreadable beat file?). Each
+    emitted line answers that mathematically for its poll.
+    """
+    beat_age = (now_wall - last_beat_wall) if last_beat_wall is not None else -1.0
+    return (
+        "[ExternalWatchdog:%s] now_wall=%.3f beat_age_s=%.1f "
+        "stale_window_s=%.0f budget_elapsed_s=%.1f/%.0f suspended=%s "
+        "poll_wall_delta_s=%.2f poll_mono_delta_s=%.2f "
+        "poll_drift_s=%.2f (expected=%.2f) "
+        "suppressed_polls=%d max_poll_drift_s=%.2f"
+        % (
+            tag, now_wall, beat_age, stale_window_s,
+            now_wall - armed_wall, budget_s, suspended,
+            wall_delta, mono_delta,
+            wall_delta - poll_s, poll_s,
+            suppressed_polls, max_poll_drift_s,
+        )
+    )
+
+
 def run_watchdog(
     target_pid: int,
     heartbeat_path: str,
@@ -86,26 +133,52 @@ def run_watchdog(
     stale_window_s: float,
     poll_s: float = 1.0,
     suspend_threshold_s: float = 5.0,
+    status_every_s: float = 60.0,
 ) -> str:
     """Sentinel loop (runs in the child process). Returns the kill reason.
 
     SIGKILLs ``target_pid`` when the budget or a real (non-suspend) staleness
     window is exceeded, then returns. Exits early if the parent already died.
+
+    Slice 29 forensics — the loop now EMITS its delta math (stderr, inherited
+    from the harness so lines land in the session output) at exactly the
+    moments that matter, all values computed live:
+      * a poll whose staleness would fire but is SUPPRESSED (suspended=True);
+      * a poll whose own scheduling drifted (slept far past ``poll_s`` — the
+        App-Nap/timer-coalescing class that can delay a kill for minutes);
+      * a periodic status line every ``status_every_s`` while the beat is
+        older than half the stale window (quiet when healthy);
+      * the kill itself, with the full computation that justified it.
     """
     armed_wall = time.time()
     armed_mono = time.monotonic()
     prev_wall = armed_wall
     prev_mono = armed_mono
+    suppressed_polls = 0
+    max_poll_drift_s = 0.0
+    last_status_wall = armed_wall
+
+    def _emit(line: str) -> None:
+        try:
+            os.write(2, ("\n" + line + "\n").encode("ascii", "replace"))
+        except Exception:
+            pass
+
     # If the parent never writes a beat, fall back to arm time so the budget
     # path still governs.
     while True:
         time.sleep(poll_s)
         now_wall = time.time()
         now_mono = time.monotonic()
+        wall_delta = now_wall - prev_wall
+        mono_delta = now_mono - prev_mono
         suspended = _suspend_detected(
-            now_mono - prev_mono, now_wall - prev_wall, suspend_threshold_s,
+            mono_delta, wall_delta, suspend_threshold_s,
         )
         prev_wall, prev_mono = now_wall, now_mono
+        poll_drift = wall_delta - poll_s
+        if poll_drift > max_poll_drift_s:
+            max_poll_drift_s = poll_drift
 
         # Parent already gone? nothing to guard.
         try:
@@ -116,14 +189,45 @@ def run_watchdog(
             pass  # alive, different ownership — keep guarding
 
         last_beat = _read_beat(heartbeat_path)
-        if last_beat is None:
-            last_beat = armed_wall  # no beat yet → budget still applies
+        effective_beat = last_beat if last_beat is not None else armed_wall
 
         kill, reason = evaluate_kill(
-            now_wall=now_wall, armed_wall=armed_wall, last_beat_wall=last_beat,
-            budget_s=budget_s, stale_window_s=stale_window_s, suspended=suspended,
+            now_wall=now_wall, armed_wall=armed_wall,
+            last_beat_wall=effective_beat,
+            budget_s=budget_s, stale_window_s=stale_window_s,
+            suspended=suspended,
         )
+
+        def _forensics(tag: str) -> str:
+            return format_poll_forensics(
+                tag=tag, now_wall=now_wall, armed_wall=armed_wall,
+                last_beat_wall=last_beat, stale_window_s=stale_window_s,
+                budget_s=budget_s, suspended=suspended,
+                wall_delta=wall_delta, mono_delta=mono_delta, poll_s=poll_s,
+                suppressed_polls=suppressed_polls,
+                max_poll_drift_s=max_poll_drift_s,
+            )
+
+        beat_age = now_wall - effective_beat
+        stale_condition = beat_age >= stale_window_s
+        if stale_condition and suspended and not kill:
+            # The exact blind spot of bt-2026-07-15-233357: staleness true
+            # but suppressed. Every suppression is now on the record.
+            suppressed_polls += 1
+            _emit(_forensics("stale-suppressed"))
+        elif poll_drift >= max(poll_s * 5.0, suspend_threshold_s):
+            # This poll's own sleep overshot badly — child scheduling drift
+            # (App Nap / timer coalescing) delays kill decisions; record it.
+            _emit(_forensics("poll-drift"))
+        elif (
+            beat_age >= stale_window_s / 2.0
+            and (now_wall - last_status_wall) >= status_every_s
+        ):
+            last_status_wall = now_wall
+            _emit(_forensics("beat-aging"))
+
         if kill:
+            _emit(_forensics("kill:" + reason))
             try:
                 os.write(
                     2,
@@ -163,10 +267,30 @@ class ExternalProcessWatchdog:
         self.budget_s = float(budget_s)
         self.stale_window_s = float(stale_window_s)
         self.poll_s = float(poll_s)
+        # Slice 29 — beat-write visibility counters (see beat()).
+        self.beat_failures: int = 0
+        self.beat_successes: int = 0
+        self._beat_consecutive_failures: int = 0
+        try:
+            self._BEAT_WARN_EVERY_N = max(1, int(os.environ.get(
+                "JARVIS_WATCHDOG_BEAT_WARN_EVERY_N", "10",
+            )))
+        except (TypeError, ValueError):
+            self._BEAT_WARN_EVERY_N = 10
         self._proc: Optional["object"] = None
 
     def beat(self) -> None:
-        """Atomically write the current wall timestamp to the heartbeat file."""
+        """Atomically write the current wall timestamp to the heartbeat file.
+
+        Slice 29 — best-effort BUT never silent (bt-2026-07-15-233357: the
+        tick froze 15min before a false-positive heartbeat_stale SIGKILL and
+        post-mortem could not distinguish task death from persistently
+        swallowed write faults). A failed write still never raises into the
+        beat caller, but it now logs a rate-limited WARNING with the actual
+        exception (first failure + every Nth thereafter), and the first
+        success after a failure run logs the recovery. ``beat_failures`` /
+        ``beat_successes`` counters are public for tests/diagnostics.
+        """
         try:
             self.heartbeat_path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self.heartbeat_path.with_suffix(
@@ -174,8 +298,31 @@ class ExternalProcessWatchdog:
             )
             tmp.write_text(repr(time.time()))
             os.replace(tmp, self.heartbeat_path)
-        except OSError:
-            pass  # best-effort — a missed beat just shortens the stale margin
+        except OSError as exc:
+            self.beat_failures += 1
+            self._beat_consecutive_failures += 1
+            # Rate limit: always the 1st of a failure run, then every Nth.
+            if (
+                self._beat_consecutive_failures == 1
+                or self._beat_consecutive_failures % self._BEAT_WARN_EVERY_N == 0
+            ):
+                logger.warning(
+                    "[ExternalWatchdog] heartbeat WRITE FAILED "
+                    "(consecutive=%d total=%d path=%s): %s: %s — beats are "
+                    "the sentinel's ONLY liveness signal; sustained failure "
+                    "ends in a heartbeat_stale SIGKILL of a healthy process",
+                    self._beat_consecutive_failures, self.beat_failures,
+                    self.heartbeat_path, type(exc).__name__, exc,
+                )
+        else:
+            if self._beat_consecutive_failures > 0:
+                logger.warning(
+                    "[ExternalWatchdog] heartbeat write RECOVERED after "
+                    "%d consecutive failure(s)",
+                    self._beat_consecutive_failures,
+                )
+            self._beat_consecutive_failures = 0
+            self.beat_successes += 1
 
     def arm(self) -> None:
         """Spawn the detached sentinel subprocess."""

--- a/backend/core/ouroboros/governance/fault_injection_matrix.py
+++ b/backend/core/ouroboros/governance/fault_injection_matrix.py
@@ -1,0 +1,360 @@
+"""
+Fault-Injection Matrix — systematic resilience verification (autonomy Gap 1)
+============================================================================
+
+The stability problem this session paid down one death at a time: every long
+soak died to a NOVEL cause (loop starvation, orphan workers, a watchdog
+false-positive, a memory explosion, a severed driver). Reactive whack-a-mole
+converges slowly because each fix only reveals the next surprise.
+
+This is the systematic alternative. Instead of running a soak and WAITING for a
+death, the matrix INJECTS a controlled, reversible fault from each failure
+CLASS the organism has a defense against, and verifies the defense fires and
+CONTAINS it. An uncovered cell — a fault class with no proven defense — is the
+PREDICTED site of the next novel death, surfaced BEFORE it kills a run.
+
+Design (generalizes the proven ``red_blue_matrix`` shape from the containment
+cage to the broader stability surface; composes, never duplicates):
+  * ``ResilienceFaultClass`` — the closed taxonomy of stability failure classes
+    (the *resilience* axis, complementary to ``failure_mode_memory``'s
+    *code-generation* axis; mirrors its enum+schema pattern, reuses no values).
+  * A declarative ``FaultScenario`` REGISTRY (data, seeded like
+    ``flag_registry_seed`` — the runner iterates data, no hardcoded control
+    flow). Each scenario = (inject, verify, revert) over a CLEAN injectable
+    seam of the defense it targets — pure decision fns / first-class kwargs /
+    documented reset seams; NEVER ``unittest.mock.patch``.
+  * The A1-auditor verdict contract: a ``criteria`` dict of named booleans,
+    ``DEFENDED`` iff ``all(criteria.values())``, deterministic ``failure_locus``
+    = first failing criterion, and ``INCONCLUSIVE`` (never a fake pass) when a
+    fault cannot be injected/verified.
+  * Revert-ALWAYS: every scenario runs inside a ``finally`` that undoes its
+    fault, even on exception — the ``a1_live_fire_chaos_harness`` discipline.
+  * The Gap 2 oracle (``capability_firing.firing_verdict``) as the detection
+    backbone: proves the organism can SEE an induced dark/dormant capability.
+
+Coverage report: ``fault_class × verdict`` over the full taxonomy. Classes with
+no scenario are ``NO_SCENARIO`` (a coverage gap — where the next death hides),
+distinct from ``UNDEFENDED`` (fault injected, defense did not respond).
+
+Authority posture: read-only projector over self-contained, reversible
+scenarios. Imports NO orchestrator/policy/gate module. NEVER raises out of the
+runner (a scenario fault degrades to INCONCLUSIVE, never propagates).
+"""
+from __future__ import annotations
+
+import enum
+import os
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+
+FAULT_INJECTION_MATRIX_SCHEMA_VERSION = "fault_injection_matrix.1"
+
+
+# ---------------------------------------------------------------------------
+# Taxonomy — the resilience failure surface (closed enum, extensible)
+# ---------------------------------------------------------------------------
+
+
+class ResilienceFaultClass(str, enum.Enum):
+    """The stability failure classes the organism defends against. Distinct
+    from ``failure_mode_memory.FailureModeKind`` (code-generation axis)."""
+
+    ORPHAN_WORKER = "orphan_worker"                 # ppid-drift subprocess leak
+    ORPHAN_CHILD = "orphan_child"                   # registered child not reaped
+    WATCHDOG_FALSE_POSITIVE = "watchdog_false_positive"   # suspend forged as wedge
+    WATCHDOG_BEAT_DEATH = "watchdog_beat_death"     # silent heartbeat-writer fault
+    WATCHDOG_MONITOR_DEATH = "watchdog_monitor_death"     # supervisor restart
+    MEMORY_EXHAUSTION = "memory_exhaustion"         # fanout not clamped under pressure
+    EMBED_CORRELATED_FAILURE = "embed_correlated_failure"  # breaker abort
+    LOOP_STARVATION = "loop_starvation"             # on-loop CPU / GIL block
+    PROVIDER_OUTAGE = "provider_outage"             # transport failures uncontained
+    COST_RUNAWAY = "cost_runaway"                   # unbounded spend
+    SEVERED_CAPABILITY = "severed_capability"       # wired-but-inert (Gap 2)
+    TEARDOWN_WEDGE = "teardown_wedge"               # shutdown hang
+
+
+class FaultVerdict(str, enum.Enum):
+    DEFENDED = "defended"              # fault injected, defense fired + contained
+    UNDEFENDED = "undefended"         # fault injected, defense did NOT respond
+    DEFENSE_FAILED = "defense_failed"  # defense fired but did the wrong thing
+    INCONCLUSIVE = "inconclusive"     # could not inject/verify (never fake-pass)
+
+
+class CoverageVerdict(str, enum.Enum):
+    DEFENDED = "defended"          # ≥1 scenario, all DEFENDED
+    BROKEN = "broken"             # ≥1 scenario UNDEFENDED/DEFENSE_FAILED
+    INCONCLUSIVE = "inconclusive"  # scenarios only INCONCLUSIVE
+    NO_SCENARIO = "no_scenario"   # NO scenario — the predicted next-death site
+
+
+# ---------------------------------------------------------------------------
+# Scenario + result model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class FaultScenario:
+    """One reversible fault-injection scenario. ``inject`` induces the fault and
+    returns an opaque handle; ``verify`` returns a ``{criterion: bool}`` dict
+    (the defense fired + contained); ``revert`` undoes the fault (always run)."""
+    id: str
+    fault_class: ResilienceFaultClass
+    defense: str                       # the module/mechanism under test
+    description: str
+    inject: Callable[[], Any]
+    verify: Callable[[Any], Dict[str, bool]]
+    revert: Callable[[Any], None] = lambda _h: None
+    severity: str = "high"
+
+
+@dataclass(frozen=True)
+class ScenarioResult:
+    scenario_id: str
+    fault_class: str
+    defense: str
+    verdict: str
+    criteria: Dict[str, bool] = field(default_factory=dict)
+    failure_locus: Optional[str] = None
+    detail: str = ""
+    elapsed_ms: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "scenario_id": self.scenario_id,
+            "fault_class": self.fault_class,
+            "defense": self.defense,
+            "verdict": self.verdict,
+            "criteria": dict(self.criteria),
+            "failure_locus": self.failure_locus,
+            "detail": self.detail,
+            "elapsed_ms": round(self.elapsed_ms, 2),
+        }
+
+
+# ---------------------------------------------------------------------------
+# Env / master
+# ---------------------------------------------------------------------------
+
+
+def master_enabled() -> bool:
+    """``JARVIS_FAULT_INJECTION_MATRIX_ENABLED`` (default true). The matrix runs
+    self-contained reversible scenarios; the switch only silences the surface."""
+    raw = os.environ.get("JARVIS_FAULT_INJECTION_MATRIX_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+# ---------------------------------------------------------------------------
+# Registry (seeded, data-driven — mirrors flag_registry_seed)
+# ---------------------------------------------------------------------------
+
+_REGISTRY_LOCK = threading.RLock()
+_SCENARIOS: List[FaultScenario] = []
+_SEEDED = False
+
+
+def register_scenario(scenario: FaultScenario) -> None:
+    with _REGISTRY_LOCK:
+        if any(s.id == scenario.id for s in _SCENARIOS):
+            return
+        _SCENARIOS.append(scenario)
+
+
+def ensure_seeded() -> List[FaultScenario]:
+    global _SEEDED
+    with _REGISTRY_LOCK:
+        if not _SEEDED:
+            try:
+                from backend.core.ouroboros.governance.fault_injection_seed import (
+                    seed_scenarios,
+                )
+                seed_scenarios(register_scenario)
+            except Exception:  # noqa: BLE001 — a bad seed never breaks the matrix
+                pass
+            _SEEDED = True
+        return list(_SCENARIOS)
+
+
+def reset_registry_for_tests() -> None:
+    global _SEEDED
+    with _REGISTRY_LOCK:
+        _SCENARIOS.clear()
+        _SEEDED = False
+
+
+# ---------------------------------------------------------------------------
+# Runner — safe (revert-always) envelope + criteria-dict verdict
+# ---------------------------------------------------------------------------
+
+
+def run_scenario(scenario: FaultScenario) -> ScenarioResult:
+    """Run one scenario inside a revert-ALWAYS envelope. NEVER raises.
+
+    inject → verify → (finally) revert. DEFENDED iff every criterion holds;
+    else DEFENSE_FAILED with the first-failing criterion as the locus;
+    INCONCLUSIVE if inject/verify raised (never a fake pass)."""
+    t0 = time.monotonic()
+    handle: Any = None
+    injected = False
+    try:
+        handle = scenario.inject()
+        injected = True
+        criteria = scenario.verify(handle)
+        if not isinstance(criteria, dict) or not criteria:
+            return _result(scenario, FaultVerdict.INCONCLUSIVE, {}, t0,
+                           detail="verify returned no criteria")
+        passed = all(bool(v) for v in criteria.values())
+        if passed:
+            return _result(scenario, FaultVerdict.DEFENDED, criteria, t0)
+        locus = next((k for k, v in criteria.items() if not v), None)
+        return _result(scenario, FaultVerdict.DEFENSE_FAILED, criteria, t0,
+                       locus=locus, detail=f"criterion failed: {locus}")
+    except Exception as exc:  # noqa: BLE001 — a scenario fault is INCONCLUSIVE
+        return _result(scenario, FaultVerdict.INCONCLUSIVE, {}, t0,
+                       detail=f"{type(exc).__name__}: {exc}")
+    finally:
+        if injected:
+            try:
+                scenario.revert(handle)
+            except Exception:  # noqa: BLE001 — revert best-effort, never raise
+                pass
+
+
+def _result(scenario, verdict, criteria, t0, *, locus=None, detail=""):
+    return ScenarioResult(
+        scenario_id=scenario.id, fault_class=scenario.fault_class.value,
+        defense=scenario.defense, verdict=verdict.value, criteria=criteria,
+        failure_locus=locus, detail=detail,
+        elapsed_ms=(time.monotonic() - t0) * 1000.0,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Matrix + coverage
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MatrixReport:
+    schema_version: str = FAULT_INJECTION_MATRIX_SCHEMA_VERSION
+    enabled: bool = True
+    reason_code: str = "ok"
+    generated_at_unix: float = 0.0
+    results: List[ScenarioResult] = field(default_factory=list)
+    coverage: Dict[str, str] = field(default_factory=dict)
+    counts: Dict[str, int] = field(default_factory=dict)
+    resilience_score: Optional[float] = None
+
+    def to_dict(self) -> Dict[str, Any]:
+        gaps = [c for c, v in self.coverage.items()
+                if v in (CoverageVerdict.NO_SCENARIO.value, CoverageVerdict.BROKEN.value)]
+        return {
+            "schema_version": self.schema_version,
+            "enabled": self.enabled,
+            "reason_code": self.reason_code,
+            "generated_at_unix": self.generated_at_unix,
+            # class × coverage — the matrix. NO_SCENARIO / BROKEN cells are the
+            # predicted sites of the next novel death.
+            "coverage": self.coverage,
+            "coverage_gaps": gaps,
+            "scenario_counts": self.counts,
+            # fraction of the fault taxonomy with a proven (DEFENDED) defense.
+            "resilience_score": self.resilience_score,
+            "results": [r.to_dict() for r in self.results],
+        }
+
+
+def run_matrix() -> MatrixReport:
+    """Run every registered scenario and compute the coverage matrix over the
+    FULL fault taxonomy. NEVER raises."""
+    now = time.time()
+    try:
+        scenarios = ensure_seeded()
+        results = [run_scenario(s) for s in scenarios]
+
+        # per-class rollup
+        by_class: Dict[str, List[ScenarioResult]] = {}
+        for r in results:
+            by_class.setdefault(r.fault_class, []).append(r)
+
+        coverage: Dict[str, str] = {}
+        for fclass in ResilienceFaultClass:
+            rs = by_class.get(fclass.value, [])
+            coverage[fclass.value] = _coverage_verdict(rs).value
+
+        counts: Dict[str, int] = {}
+        for r in results:
+            counts[r.verdict] = counts.get(r.verdict, 0) + 1
+
+        defended = sum(1 for v in coverage.values()
+                       if v == CoverageVerdict.DEFENDED.value)
+        score = round(defended / len(coverage), 4) if coverage else None
+
+        return MatrixReport(
+            enabled=True, reason_code="ok", generated_at_unix=now,
+            results=results, coverage=coverage, counts=counts,
+            resilience_score=score,
+        )
+    except Exception:  # noqa: BLE001 — matrix MUST never raise
+        return MatrixReport(enabled=True, reason_code="matrix_error",
+                            generated_at_unix=now)
+
+
+def _coverage_verdict(results: List[ScenarioResult]) -> CoverageVerdict:
+    if not results:
+        return CoverageVerdict.NO_SCENARIO
+    verdicts = {r.verdict for r in results}
+    if FaultVerdict.UNDEFENDED.value in verdicts or FaultVerdict.DEFENSE_FAILED.value in verdicts:
+        return CoverageVerdict.BROKEN
+    if verdicts == {FaultVerdict.INCONCLUSIVE.value}:
+        return CoverageVerdict.INCONCLUSIVE
+    if FaultVerdict.DEFENDED.value in verdicts:
+        return CoverageVerdict.DEFENDED
+    return CoverageVerdict.INCONCLUSIVE
+
+
+# ---------------------------------------------------------------------------
+# Cached snapshot for the observability GET
+# ---------------------------------------------------------------------------
+
+_SNAP_LOCK = threading.RLock()
+_LAST: Optional[MatrixReport] = None
+_LAST_TS: float = 0.0
+
+
+def _ttl_s() -> float:
+    try:
+        return max(1.0, float(
+            os.environ.get("JARVIS_FAULT_INJECTION_MATRIX_TTL_S", "").strip() or 300.0
+        ))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+def snapshot(*, force: bool = False) -> Dict[str, Any]:
+    """Public entry for the observability GET — TTL-cached matrix run. Master
+    off → minimal ``enabled: false`` body. NEVER raises."""
+    if not master_enabled():
+        return {
+            "schema_version": FAULT_INJECTION_MATRIX_SCHEMA_VERSION,
+            "enabled": False, "reason_code": "disabled",
+        }
+    global _LAST, _LAST_TS
+    now = time.time()
+    with _SNAP_LOCK:
+        if not force and _LAST is not None and (now - _LAST_TS) <= _ttl_s():
+            return _LAST.to_dict()
+    report = run_matrix()
+    with _SNAP_LOCK:
+        _LAST = report
+        _LAST_TS = now
+    return report.to_dict()
+
+
+def reset_cache_for_tests() -> None:
+    global _LAST, _LAST_TS
+    with _SNAP_LOCK:
+        _LAST = None
+        _LAST_TS = 0.0

--- a/backend/core/ouroboros/governance/fault_injection_seed.py
+++ b/backend/core/ouroboros/governance/fault_injection_seed.py
@@ -1,0 +1,382 @@
+"""
+Fault-Injection Scenario Seed — the concrete scenarios (autonomy Gap 1)
+======================================================================
+
+Seeds ``fault_injection_matrix`` with reversible fault scenarios, each over a
+CLEAN injectable seam of the defense it targets (pure decision fn / first-class
+kwarg / documented reset seam — NEVER ``unittest.mock.patch``). Mirrors
+``flag_registry_seed``: this module is data, the matrix runner is control flow.
+
+Each scenario proves ONE stability defense fires + contains its fault:
+  * ORPHAN_WORKER      — worker_lifeline ppid-drift → EXIT_CODE_ORPHANED
+  * ORPHAN_CHILD       — child_reaper cascade reaps a registered child
+  * WATCHDOG_FALSE_POSITIVE — evaluate_kill kills genuine stale, SUPPRESSES suspend
+  * WATCHDOG_BEAT_DEATH — beat() write fault is COUNTED, not silent (Slice 29)
+  * WATCHDOG_MONITOR_DEATH — supervisor restarts on death, NOT on teardown
+  * MEMORY_EXHAUSTION  — MemoryPressureGate clamps fanout under CRITICAL pressure
+  * PROVIDER_OUTAGE    — provider_quarantine detects a full window of failures
+  * SEVERED_CAPABILITY — the Gap 2 oracle SEES an induced dormant capability
+
+Classes with a defense but no deterministic scenario yet (EMBED_CORRELATED_
+FAILURE, LOOP_STARVATION, COST_RUNAWAY, TEARDOWN_WEDGE) surface as NO_SCENARIO
+coverage gaps — honestly, not silently — since they need a real-fault (soak /
+live-loop) lane the matrix's deterministic lane does not cover.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+import tempfile
+from pathlib import Path
+from typing import Any, Callable, Dict
+
+from backend.core.ouroboros.governance.fault_injection_matrix import (
+    FaultScenario, ResilienceFaultClass,
+)
+
+
+def seed_scenarios(register: Callable[[FaultScenario], None]) -> None:
+    """Register every seed scenario. NEVER raises (a bad scenario is skipped)."""
+    for factory in (
+        _orphan_worker, _orphan_child, _watchdog_false_positive,
+        _watchdog_beat_death, _watchdog_monitor_death, _memory_exhaustion,
+        _provider_outage, _severed_capability,
+    ):
+        try:
+            register(factory())
+        except Exception:  # noqa: BLE001
+            continue
+
+
+# ---------------------------------------------------------------------------
+# 1. Orphan worker — worker_lifeline ppid-drift (pure decision fn)
+# ---------------------------------------------------------------------------
+
+
+def _orphan_worker() -> FaultScenario:
+    def inject() -> Any:
+        from backend.core.ouroboros.governance.worker_lifeline import (
+            _tick_decision, EXIT_CODE_ORPHANED,
+        )
+        # armed under ppid 1000, now reparented to init (1) = the orphan fault.
+        drift = _tick_decision(1000, 1, None, None)
+        healthy = _tick_decision(5, 5, None, None)
+        return {"drift": drift, "healthy": healthy, "code": EXIT_CODE_ORPHANED}
+
+    def verify(h: Any) -> Dict[str, bool]:
+        drift, healthy, code = h["drift"], h["healthy"], h["code"]
+        return {
+            "detects_orphan": drift is not None and drift[0] == code,
+            "reason_names_drift": drift is not None and "orphan" in str(drift[1]).lower(),
+            "healthy_does_not_exit": healthy is None,
+        }
+
+    return FaultScenario(
+        id="orphan_worker.ppid_drift",
+        fault_class=ResilienceFaultClass.ORPHAN_WORKER,
+        defense="worker_lifeline._tick_decision",
+        description="A worker whose parent died (ppid drift) must self-exit "
+                    "with EXIT_CODE_ORPHANED; a healthy worker must not.",
+        inject=inject, verify=verify,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 2. Orphan child — child_reaper cascade (real sacrificial subprocess)
+# ---------------------------------------------------------------------------
+
+
+def _orphan_child() -> FaultScenario:
+    def inject() -> Any:
+        from backend.core.ouroboros.governance import child_reaper
+        child_reaper.reset_for_tests()
+        p = subprocess.Popen(["sleep", "60"])
+        child_reaper.register_child(p.pid, role="fault-test-child")
+        return p
+
+    def verify(p: Any) -> Dict[str, bool]:
+        from backend.core.ouroboros.governance import child_reaper
+        n = child_reaper.cascade_terminate(grace_s=0.4)
+        # give the OS a beat to reap
+        try:
+            p.wait(timeout=1.0)
+        except Exception:  # noqa: BLE001
+            pass
+        return {
+            "reaped_at_least_one": n >= 1,
+            "registry_drained": child_reaper.registered_children() == (),
+            "child_terminated": p.poll() is not None,
+        }
+
+    def revert(p: Any) -> None:
+        from backend.core.ouroboros.governance import child_reaper
+        try:
+            if p is not None and p.poll() is None:
+                p.kill()
+        finally:
+            child_reaper.reset_for_tests()
+
+    return FaultScenario(
+        id="orphan_child.cascade_reap",
+        fault_class=ResilienceFaultClass.ORPHAN_CHILD,
+        defense="child_reaper.cascade_terminate",
+        description="A registered child must be reaped by cascade_terminate and "
+                    "removed from the registry.",
+        inject=inject, verify=verify, revert=revert,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 3. Watchdog false-positive guard — evaluate_kill (pure fn)
+# ---------------------------------------------------------------------------
+
+
+def _watchdog_false_positive() -> FaultScenario:
+    def inject() -> Any:
+        from backend.core.ouroboros.governance.external_watchdog import evaluate_kill
+        base = dict(now_wall=1000.0, armed_wall=0.0, last_beat_wall=800.0,
+                    budget_s=1e12, stale_window_s=120.0)
+        return {
+            "genuine": evaluate_kill(**base, suspended=False),
+            "suspend": evaluate_kill(**base, suspended=True),
+        }
+
+    def verify(h: Any) -> Dict[str, bool]:
+        return {
+            "kills_genuine_stale": h["genuine"] == (True, "heartbeat_stale"),
+            "suppresses_on_suspend": h["suspend"] == (False, ""),
+        }
+
+    return FaultScenario(
+        id="watchdog.suspend_false_positive_guard",
+        fault_class=ResilienceFaultClass.WATCHDOG_FALSE_POSITIVE,
+        defense="external_watchdog.evaluate_kill",
+        description="A stale heartbeat must SIGKILL when real time elapsed, but "
+                    "a host-suspend interval must NOT be forged as a wedge.",
+        inject=inject, verify=verify,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 4. Watchdog beat-writer death — beat() visibility (Slice 29 counters)
+# ---------------------------------------------------------------------------
+
+
+def _watchdog_beat_death() -> FaultScenario:
+    def inject() -> Any:
+        from backend.core.ouroboros.governance.external_watchdog import (
+            ExternalProcessWatchdog,
+        )
+        # A heartbeat path whose parent is a FILE → mkdir fails → beat() OSError.
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        tf.close()
+        bad_path = Path(tf.name) / "hb.tick"  # parent is a file, not a dir
+        wd = ExternalProcessWatchdog(
+            target_pid=os.getpid(), heartbeat_path=bad_path,
+            budget_s=1e12, stale_window_s=120.0,
+        )
+        wd.beat()
+        wd.beat()
+        return {"wd": wd, "tmp": tf.name}
+
+    def verify(h: Any) -> Dict[str, bool]:
+        wd = h["wd"]
+        return {
+            "write_failure_counted": getattr(wd, "beat_failures", 0) >= 1,
+            "no_false_success": getattr(wd, "beat_successes", 1) == 0,
+        }
+
+    def revert(h: Any) -> None:
+        try:
+            os.unlink(h["tmp"])
+        except Exception:  # noqa: BLE001
+            pass
+
+    return FaultScenario(
+        id="watchdog.beat_write_failure_visible",
+        fault_class=ResilienceFaultClass.WATCHDOG_BEAT_DEATH,
+        defense="external_watchdog.ExternalProcessWatchdog.beat",
+        description="A silently-failing heartbeat write (the bt-233357 false-kill "
+                    "root cause) must be COUNTED, not swallowed invisibly.",
+        inject=inject, verify=verify, revert=revert,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 5. Watchdog monitor death — Slice 29 supervisor (pure decision fn)
+# ---------------------------------------------------------------------------
+
+
+def _watchdog_monitor_death() -> FaultScenario:
+    def inject() -> Any:
+        from backend.core.ouroboros.battle_test.harness import (
+            _should_restart_wall_clock_monitor as sr,
+        )
+        return {
+            "death": sr(cancelled=False, exc=RuntimeError("x"), restarts=0,
+                        max_restarts=5, closing=False),
+            "teardown": sr(cancelled=False, exc=RuntimeError("x"), restarts=0,
+                           max_restarts=5, closing=True),
+            "bounded": sr(cancelled=False, exc=RuntimeError("x"), restarts=5,
+                          max_restarts=5, closing=False),
+            "cancelled": sr(cancelled=True, exc=None, restarts=0,
+                            max_restarts=5, closing=False),
+        }
+
+    def verify(h: Any) -> Dict[str, bool]:
+        return {
+            "restarts_on_unexpected_death": h["death"][0] is True,
+            "no_restart_during_teardown": h["teardown"][0] is False,
+            "bounded_by_restart_budget": h["bounded"][0] is False,
+            "no_restart_on_cancellation": h["cancelled"][0] is False,
+        }
+
+    return FaultScenario(
+        id="watchdog.monitor_supervisor_restart",
+        fault_class=ResilienceFaultClass.WATCHDOG_MONITOR_DEATH,
+        defense="harness._should_restart_wall_clock_monitor",
+        description="The beat-writer monitor task must be restarted on unexpected "
+                    "death but NOT on teardown/cancellation, bounded by budget.",
+        inject=inject, verify=verify,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 6. Memory exhaustion — MemoryPressureGate fanout clamp (probe_fn seam)
+# ---------------------------------------------------------------------------
+
+
+def _memory_exhaustion() -> FaultScenario:
+    def inject() -> Any:
+        from backend.core.ouroboros.governance.memory_pressure_gate import (
+            MemoryPressureGate, MemoryProbe,
+        )
+        prev = os.environ.get("JARVIS_MEMORY_PRESSURE_GATE_ENABLED")
+        os.environ["JARVIS_MEMORY_PRESSURE_GATE_ENABLED"] = "true"
+        # Force process-tree + reservation dims off so the free-% dim is the
+        # deterministic driver of this scenario.
+        prev_proc = os.environ.get("JARVIS_MEMORY_PRESSURE_PROCESS_DIM_ENABLED")
+        prev_res = os.environ.get("JARVIS_MEMORY_PRESSURE_RESERVATIONS_ENABLED")
+        os.environ["JARVIS_MEMORY_PRESSURE_PROCESS_DIM_ENABLED"] = "false"
+        os.environ["JARVIS_MEMORY_PRESSURE_RESERVATIONS_ENABLED"] = "false"
+        total = 16 * (1024 ** 3)
+        probe = MemoryProbe(free_pct=3.0, total_bytes=total,
+                            available_bytes=int(0.03 * total), source="fault",
+                            ok=True, error=None)
+        gate = MemoryPressureGate(probe_fn=lambda: probe)
+        return {"gate": gate, "prev": prev, "prev_proc": prev_proc, "prev_res": prev_res}
+
+    def verify(h: Any) -> Dict[str, bool]:
+        gate = h["gate"]
+        d = gate.can_fanout(8)
+        return {
+            "clamps_fanout_under_pressure": d.n_allowed < 8,
+            "level_is_critical": d.level.value == "critical",
+            "still_allows_some_progress": d.n_allowed >= 1,
+        }
+
+    def revert(h: Any) -> None:
+        for key, val in (
+            ("JARVIS_MEMORY_PRESSURE_GATE_ENABLED", h.get("prev")),
+            ("JARVIS_MEMORY_PRESSURE_PROCESS_DIM_ENABLED", h.get("prev_proc")),
+            ("JARVIS_MEMORY_PRESSURE_RESERVATIONS_ENABLED", h.get("prev_res")),
+        ):
+            if val is None:
+                os.environ.pop(key, None)
+            else:
+                os.environ[key] = val
+
+    return FaultScenario(
+        id="memory.fanout_clamp_under_pressure",
+        fault_class=ResilienceFaultClass.MEMORY_EXHAUSTION,
+        defense="memory_pressure_gate.MemoryPressureGate.can_fanout",
+        description="Under CRITICAL free-memory pressure the gate must clamp "
+                    "parallel fan-out (while still allowing some progress).",
+        inject=inject, verify=verify, revert=revert,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 7. Provider outage — provider_quarantine detection (record/reset seam)
+# ---------------------------------------------------------------------------
+
+
+def _provider_outage() -> FaultScenario:
+    _ROUTE = "__fault_injection_probe__"
+
+    def inject() -> Any:
+        prev = os.environ.get("JARVIS_PROVIDER_QUARANTINE_ENABLED")
+        os.environ["JARVIS_PROVIDER_QUARANTINE_ENABLED"] = "true"
+        from backend.core.ouroboros.governance.provider_quarantine import (
+            get_provider_health_gradient,
+        )
+        g = get_provider_health_gradient()
+        g.reset(_ROUTE)
+        for _ in range(64):  # saturate any reasonable rolling window
+            g.record_sweep(_ROUTE, success=False)
+        return {"g": g, "prev": prev}
+
+    def verify(h: Any) -> Dict[str, bool]:
+        g = h["g"]
+        return {
+            "window_full": g.window_full(_ROUTE),
+            "detects_global_outage": g.is_global_outage(_ROUTE),
+            "success_rate_zero": g.success_rate(_ROUTE) == 0.0,
+        }
+
+    def revert(h: Any) -> None:
+        try:
+            h["g"].reset(_ROUTE)
+        finally:
+            if h.get("prev") is None:
+                os.environ.pop("JARVIS_PROVIDER_QUARANTINE_ENABLED", None)
+            else:
+                os.environ["JARVIS_PROVIDER_QUARANTINE_ENABLED"] = h["prev"]
+
+    return FaultScenario(
+        id="provider.quarantine_detects_outage",
+        fault_class=ResilienceFaultClass.PROVIDER_OUTAGE,
+        defense="provider_quarantine.ProviderHealthGradient",
+        description="A full rolling window of failed sweeps on a route must be "
+                    "detected as a global outage.",
+        inject=inject, verify=verify, revert=revert,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. Severed capability — the Gap 2 oracle SEES a dormant capability
+# ---------------------------------------------------------------------------
+
+
+def _severed_capability() -> FaultScenario:
+    def inject() -> Any:
+        from backend.core.ouroboros.governance.capability_firing import (
+            FiringEvidence, firing_verdict,
+        )
+        # A capability whose ONLY observable channel is a ledger it writes.
+        src = 'x = ".jarvis/probe_history.jsonl"\n'
+        dormant_ev = FiringEvidence(present_markers=set(), active_ledgers=set())
+        active_ev = FiringEvidence(active_ledgers={"probe_history"})
+        return {
+            "dormant": firing_verdict(src, dormant_ev),
+            "active": firing_verdict(src, active_ev),
+        }
+
+    def verify(h: Any) -> Dict[str, bool]:
+        d_verdict, d_hits, d_chan = h["dormant"]
+        a_verdict, _a_hits, _a_chan = h["active"]
+        return {
+            "detects_dormancy": d_verdict == "SILENT",
+            "dormancy_is_ledger_backed": "ledger" in d_chan,
+            "does_not_false_flag_active": a_verdict == "FIRING",
+        }
+
+    return FaultScenario(
+        id="capability.gap2_oracle_sees_dormancy",
+        fault_class=ResilienceFaultClass.SEVERED_CAPABILITY,
+        defense="capability_firing.firing_verdict",
+        description="The Gap 2 self-perception oracle must flag a reachable "
+                    "capability whose evidence-of-work ledger went quiet as "
+                    "SILENT/dormant, and must NOT false-flag one still firing.",
+        inject=inject, verify=verify,
+    )

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -319,6 +319,13 @@ class IDEObservabilityRouter:
             "/observability/resilience",
             self._handle_resilience_matrix,
         )
+        # Trust Calibration (autonomy pivot Gap 4) — the earned auto-apply
+        # envelope: per-scope git-provable trust levels + which scopes are
+        # narrowing (regressed) vs widen-eligible.
+        app.router.add_get(
+            "/observability/trust",
+            self._handle_trust_calibration,
+        )
         # W3(7) Slice 6 — Class D/E/F cancel record surface.
         app.router.add_get(
             "/observability/cancels", self._handle_cancel_list,
@@ -1712,6 +1719,16 @@ class IDEObservabilityRouter:
             return False
         return master_enabled()
 
+    @staticmethod
+    def _trust_calibration_enabled() -> bool:
+        try:
+            from backend.core.ouroboros.governance.trust_calibration import (
+                master_enabled,
+            )
+        except ImportError:
+            return False
+        return master_enabled()
+
     def _governor_check_gates(self, request: "web.Request") -> Optional[Any]:
         if not ide_observability_enabled():
             return self._error_response(
@@ -1876,6 +1893,40 @@ class IDEObservabilityRouter:
             return self._json_response(
                 request, 200,
                 {"snapshot": None, "reason_code": "liveness.unavailable"},
+            )
+        return self._json_response(request, 200, snap)
+
+    def _trust_check_gates(self, request: "web.Request") -> Optional[Any]:
+        if not ide_observability_enabled():
+            return self._error_response(request, 403, "ide_observability.disabled")
+        if not self._trust_calibration_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.trust_disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(request, 429, "ide_observability.rate_limited")
+        return None
+
+    async def _handle_trust_calibration(self, request: "web.Request") -> Any:
+        """GET /observability/trust — the earned auto-apply envelope: per-scope
+        git-provable trust levels, which scopes are auto-narrowing (regressed),
+        which are widen-eligible, and the operator opt-in state."""
+        err = self._trust_check_gates(request)
+        if err is not None:
+            return err
+        try:
+            from backend.core.ouroboros.governance.trust_calibration import (
+                snapshot as _trust_snapshot,
+            )
+            snap = _trust_snapshot()
+        except Exception:  # noqa: BLE001 — never 500; degrade to a clean 200
+            logger.debug(
+                "[IDEObservability] trust calibration snapshot failed",
+                exc_info=True,
+            )
+            return self._json_response(
+                request, 200,
+                {"snapshot": None, "reason_code": "trust.unavailable"},
             )
         return self._json_response(request, 200, snap)
 

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -326,6 +326,13 @@ class IDEObservabilityRouter:
             "/observability/trust",
             self._handle_trust_calibration,
         )
+        # Conception Value Model (autonomy pivot Gap 3) — the expected-value
+        # ranker for self-conceived work: composed alignment × substance ×
+        # earned-trust × cost weights + axis provenance.
+        app.router.add_get(
+            "/observability/conception",
+            self._handle_conception_value,
+        )
         # W3(7) Slice 6 — Class D/E/F cancel record surface.
         app.router.add_get(
             "/observability/cancels", self._handle_cancel_list,
@@ -1729,6 +1736,16 @@ class IDEObservabilityRouter:
             return False
         return master_enabled()
 
+    @staticmethod
+    def _conception_value_enabled() -> bool:
+        try:
+            from backend.core.ouroboros.governance.conception_value_model import (
+                master_enabled,
+            )
+        except ImportError:
+            return False
+        return master_enabled()
+
     def _governor_check_gates(self, request: "web.Request") -> Optional[Any]:
         if not ide_observability_enabled():
             return self._error_response(
@@ -1927,6 +1944,41 @@ class IDEObservabilityRouter:
             return self._json_response(
                 request, 200,
                 {"snapshot": None, "reason_code": "trust.unavailable"},
+            )
+        return self._json_response(request, 200, snap)
+
+    def _conception_check_gates(self, request: "web.Request") -> Optional[Any]:
+        if not ide_observability_enabled():
+            return self._error_response(request, 403, "ide_observability.disabled")
+        if not self._conception_value_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.conception_disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(request, 429, "ide_observability.rate_limited")
+        return None
+
+    async def _handle_conception_value(self, request: "web.Request") -> Any:
+        """GET /observability/conception — the expected-value ranker for
+        self-conceived work: composed axis weights (alignment × substance ×
+        earned-trust × cost), cost/regression coefficients, and axis
+        provenance."""
+        err = self._conception_check_gates(request)
+        if err is not None:
+            return err
+        try:
+            from backend.core.ouroboros.governance.conception_value_model import (
+                snapshot as _conception_snapshot,
+            )
+            snap = _conception_snapshot()
+        except Exception:  # noqa: BLE001 — never 500; degrade to a clean 200
+            logger.debug(
+                "[IDEObservability] conception value snapshot failed",
+                exc_info=True,
+            )
+            return self._json_response(
+                request, 200,
+                {"snapshot": None, "reason_code": "conception.unavailable"},
             )
         return self._json_response(request, 200, snap)
 

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -298,6 +298,13 @@ class IDEObservabilityRouter:
             "/observability/memory-pressure",
             self._handle_memory_pressure,
         )
+        # Goal Metric Dashboard (autonomy pivot Step 1) — read-only autonomous-
+        # throughput surface composing autonomy_metrics.snapshot (git-provable
+        # landed changes + session-summary runtime/cost/regression).
+        app.router.add_get(
+            "/observability/autonomy",
+            self._handle_autonomy,
+        )
         # W3(7) Slice 6 — Class D/E/F cancel record surface.
         app.router.add_get(
             "/observability/cancels", self._handle_cancel_list,
@@ -1661,6 +1668,16 @@ class IDEObservabilityRouter:
             return False
         return is_enabled()
 
+    @staticmethod
+    def _autonomy_metrics_enabled() -> bool:
+        try:
+            from backend.core.ouroboros.governance.autonomy_metrics import (
+                master_enabled,
+            )
+        except ImportError:
+            return False
+        return master_enabled()
+
     def _governor_check_gates(self, request: "web.Request") -> Optional[Any]:
         if not ide_observability_enabled():
             return self._error_response(
@@ -1752,6 +1769,43 @@ class IDEObservabilityRouter:
             return self._json_response(
                 request, 200,
                 {"snapshot": None, "reason_code": "memory.unavailable"},
+            )
+        return self._json_response(request, 200, snap)
+
+    def _autonomy_check_gates(self, request: "web.Request") -> Optional[Any]:
+        if not ide_observability_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.disabled",
+            )
+        if not self._autonomy_metrics_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.autonomy_disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(
+                request, 429, "ide_observability.rate_limited",
+            )
+        return None
+
+    async def _handle_autonomy(self, request: "web.Request") -> Any:
+        """GET /observability/autonomy — the Goal Metric Dashboard snapshot:
+        net-positive landed changes per unattended day, regression rate, and
+        cost, aggregated from git ground truth + session summaries."""
+        err = self._autonomy_check_gates(request)
+        if err is not None:
+            return err
+        try:
+            from backend.core.ouroboros.governance.autonomy_metrics import (
+                snapshot as _autonomy_snapshot,
+            )
+            snap = _autonomy_snapshot()
+        except Exception:  # noqa: BLE001 — never 500; degrade to a clean 200
+            logger.debug(
+                "[IDEObservability] autonomy snapshot failed", exc_info=True,
+            )
+            return self._json_response(
+                request, 200,
+                {"snapshot": None, "reason_code": "autonomy.unavailable"},
             )
         return self._json_response(request, 200, snap)
 

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -312,6 +312,13 @@ class IDEObservabilityRouter:
             "/observability/liveness",
             self._handle_capability_liveness,
         )
+        # Fault-Injection Matrix (autonomy pivot Gap 1) — resilience coverage:
+        # class × verdict over the stability failure taxonomy; NO_SCENARIO/BROKEN
+        # cells are the predicted next-death sites.
+        app.router.add_get(
+            "/observability/resilience",
+            self._handle_resilience_matrix,
+        )
         # W3(7) Slice 6 — Class D/E/F cancel record surface.
         app.router.add_get(
             "/observability/cancels", self._handle_cancel_list,
@@ -1695,6 +1702,16 @@ class IDEObservabilityRouter:
             return False
         return master_enabled()
 
+    @staticmethod
+    def _resilience_matrix_enabled() -> bool:
+        try:
+            from backend.core.ouroboros.governance.fault_injection_matrix import (
+                master_enabled,
+            )
+        except ImportError:
+            return False
+        return master_enabled()
+
     def _governor_check_gates(self, request: "web.Request") -> Optional[Any]:
         if not ide_observability_enabled():
             return self._error_response(
@@ -1859,6 +1876,41 @@ class IDEObservabilityRouter:
             return self._json_response(
                 request, 200,
                 {"snapshot": None, "reason_code": "liveness.unavailable"},
+            )
+        return self._json_response(request, 200, snap)
+
+    def _resilience_check_gates(self, request: "web.Request") -> Optional[Any]:
+        if not ide_observability_enabled():
+            return self._error_response(request, 403, "ide_observability.disabled")
+        if not self._resilience_matrix_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.resilience_disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(request, 429, "ide_observability.rate_limited")
+        return None
+
+    async def _handle_resilience_matrix(self, request: "web.Request") -> Any:
+        """GET /observability/resilience — the fault-injection coverage matrix:
+        for each stability failure class, whether a controlled injected fault
+        was DEFENDED, plus the NO_SCENARIO/BROKEN gaps that predict where the
+        next novel death hides."""
+        err = self._resilience_check_gates(request)
+        if err is not None:
+            return err
+        try:
+            from backend.core.ouroboros.governance.fault_injection_matrix import (
+                snapshot as _resilience_snapshot,
+            )
+            snap = _resilience_snapshot()
+        except Exception:  # noqa: BLE001 — never 500; degrade to a clean 200
+            logger.debug(
+                "[IDEObservability] resilience matrix snapshot failed",
+                exc_info=True,
+            )
+            return self._json_response(
+                request, 200,
+                {"snapshot": None, "reason_code": "resilience.unavailable"},
             )
         return self._json_response(request, 200, snap)
 

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -305,6 +305,13 @@ class IDEObservabilityRouter:
             "/observability/autonomy",
             self._handle_autonomy,
         )
+        # Capability Liveness (autonomy pivot Gap 2) — self-perception surface
+        # composing capability_liveness.snapshot (FlagRegistry-declared
+        # capabilities × static reachability of their public callables).
+        app.router.add_get(
+            "/observability/liveness",
+            self._handle_capability_liveness,
+        )
         # W3(7) Slice 6 — Class D/E/F cancel record surface.
         app.router.add_get(
             "/observability/cancels", self._handle_cancel_list,
@@ -1678,6 +1685,16 @@ class IDEObservabilityRouter:
             return False
         return master_enabled()
 
+    @staticmethod
+    def _capability_liveness_enabled() -> bool:
+        try:
+            from backend.core.ouroboros.governance.capability_liveness import (
+                master_enabled,
+            )
+        except ImportError:
+            return False
+        return master_enabled()
+
     def _governor_check_gates(self, request: "web.Request") -> Optional[Any]:
         if not ide_observability_enabled():
             return self._error_response(
@@ -1806,6 +1823,42 @@ class IDEObservabilityRouter:
             return self._json_response(
                 request, 200,
                 {"snapshot": None, "reason_code": "autonomy.unavailable"},
+            )
+        return self._json_response(request, 200, snap)
+
+    def _liveness_check_gates(self, request: "web.Request") -> Optional[Any]:
+        if not ide_observability_enabled():
+            return self._error_response(request, 403, "ide_observability.disabled")
+        if not self._capability_liveness_enabled():
+            return self._error_response(
+                request, 403, "ide_observability.liveness_disabled",
+            )
+        if not self._check_rate_limit(self._client_key(request)):
+            return self._error_response(request, 429, "ide_observability.rate_limited")
+        return None
+
+    async def _handle_capability_liveness(self, request: "web.Request") -> Any:
+        """GET /observability/liveness — the self-perception snapshot:
+        FlagRegistry-declared capabilities scored by static reachability of
+        their public callables (fully-severed alert + severance candidates +
+        spec-drift), the foundation for the organism seeing its own inert
+        subsystems."""
+        err = self._liveness_check_gates(request)
+        if err is not None:
+            return err
+        try:
+            from backend.core.ouroboros.governance.capability_liveness import (
+                snapshot as _liveness_snapshot,
+            )
+            snap = _liveness_snapshot()
+        except Exception:  # noqa: BLE001 — never 500; degrade to a clean 200
+            logger.debug(
+                "[IDEObservability] capability liveness snapshot failed",
+                exc_info=True,
+            )
+            return self._json_response(
+                request, 200,
+                {"snapshot": None, "reason_code": "liveness.unavailable"},
             )
         return self._json_response(request, 200, snap)
 

--- a/backend/core/ouroboros/governance/ide_observability.py
+++ b/backend/core/ouroboros/governance/ide_observability.py
@@ -1971,6 +1971,15 @@ class IDEObservabilityRouter:
                 snapshot as _conception_snapshot,
             )
             snap = _conception_snapshot()
+            # Attach the ledger→router bridge state (Gap 3 unification path) —
+            # best-effort; a missing bridge module never fails the endpoint.
+            try:
+                from backend.core.ouroboros.governance.conception_proposal_bridge import (
+                    snapshot as _bridge_snapshot,
+                )
+                snap = {**snap, "bridge": _bridge_snapshot()}
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:  # noqa: BLE001 — never 500; degrade to a clean 200
             logger.debug(
                 "[IDEObservability] conception value snapshot failed",

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -289,12 +289,126 @@ class IntakeLayerService:
             await self._teardown()
             raise
 
+    async def _start_merkle_hydration(self, event_bus: Any) -> None:
+        """Slice 31 — arm the Merkle Cartographer's hydration driver.
+
+        Composition only (no new infrastructure): the cartographer already
+        ships ``hydrate()`` (persisted snapshot), a fully cooperative
+        ``update_full()`` (semaphore-bounded, executor reads via the
+        cooperative_fs_io substrate), and ``MerkleEventSubscriber`` (the
+        ``fs.changed.*`` conduit with debounced ``update_incremental``
+        batching). This method is purely the missing production CALLER.
+
+        Ordering guarantees:
+          * the bus subscription is wired BEFORE the boot walk is scheduled,
+            so no fs event can fall into a gap between snapshot and walk
+            (``update_incremental`` on a cold tree is a safe no-op — the
+            walk rebuilds authoritatively);
+          * both the snapshot read and the full walk run inside a background
+            task — intake boot never blocks on them and the event loop
+            yields throughout (update_full's own cooperative discipline);
+          * master-flag off → nothing constructed; any fault → warn + legacy
+            full-scan behavior (exactly the consumers' built-in fail-safe).
+        NEVER raises.
+        """
+        self._merkle_subscriber: Optional[Any] = None
+        self._merkle_hydration_task: Optional[asyncio.Task] = None
+        try:
+            from backend.core.ouroboros.governance.merkle_cartographer import (
+                MerkleEventSubscriber,
+                get_default_cartographer,
+                is_cartographer_enabled,
+            )
+            if not is_cartographer_enabled():
+                logger.info(
+                    "[IntakeLayer] Merkle cartographer master off — "
+                    "sensors stay on legacy full scans",
+                )
+                return
+            cart = get_default_cartographer(
+                repo_root=self._config.project_root,
+            )
+            subscriber = MerkleEventSubscriber(cart)
+
+            # Shape adapter — TrinityEventBus dispatches ``handler(event)``
+            # (single event object; see trinity_event_bus._execute_handler),
+            # while the subscriber's bus-agnostic ``handle(topic, payload)``
+            # expects the caller to translate (its own documented contract:
+            # "the bus subscriber translates published events"). The
+            # pre-built ``subscribe_to_bus`` passes ``handle`` raw — against
+            # THIS bus that would TypeError on every event (never caught
+            # live because no production caller ever wired it). Adapt here,
+            # in the caller, keeping merkle_cartographer bus-agnostic.
+            async def _bus_adapter(event: Any) -> None:
+                try:
+                    await subscriber.handle(
+                        getattr(event, "topic", "") or "",
+                        getattr(event, "payload", None) or {},
+                    )
+                except Exception:  # noqa: BLE001 — never leak into dispatch
+                    logger.debug(
+                        "[IntakeLayer] merkle bus adapter fault",
+                        exc_info=True,
+                    )
+
+            wired = False
+            try:
+                await event_bus.subscribe("fs.changed.*", _bus_adapter)
+                wired = True
+            except Exception:  # noqa: BLE001 — incremental lane optional
+                logger.debug(
+                    "[IntakeLayer] merkle fs.changed subscription failed",
+                    exc_info=True,
+                )
+            self._merkle_subscriber = subscriber
+
+            async def _boot_hydrate() -> None:
+                # Snapshot first (cheap single-file read, still off-loop),
+                # then the authoritative cooperative walk.
+                loop = asyncio.get_running_loop()
+                loaded = await loop.run_in_executor(None, cart.hydrate)
+                changed = await cart.update_full()
+                logger.info(
+                    "[IntakeLayer] Merkle boot hydration COMPLETE: "
+                    "snapshot_leaves=%d walk_changed=%d — subtree "
+                    "short-circuits are now live for every consumer",
+                    loaded, len(changed),
+                )
+
+            self._merkle_hydration_task = asyncio.create_task(
+                _boot_hydrate(), name="merkle_boot_hydration",
+            )
+            logger.info(
+                "[IntakeLayer] Merkle hydration driver ARMED: bus_wired=%s "
+                "boot_walk=scheduled (Slice 31 — update_full's first "
+                "production caller)", wired,
+            )
+        except Exception:  # noqa: BLE001 — driver is fail-soft by contract
+            logger.warning(
+                "[IntakeLayer] Merkle hydration driver failed to arm "
+                "(non-fatal — sensors keep legacy full scans)",
+                exc_info=True,
+            )
+
     async def stop(self) -> None:
         """Stop sensors first (drain), then router. Idempotent from INACTIVE."""
         if self._state is IntakeServiceState.INACTIVE:
             return
 
         self._state = IntakeServiceState.STOPPING
+
+        # Slice 31 — retire the merkle hydration driver: cancel an
+        # in-flight boot walk and flush the subscriber's pending batch so
+        # the persisted snapshot stays coherent. Best-effort, never raises.
+        _mk_task = getattr(self, "_merkle_hydration_task", None)
+        if _mk_task is not None and not _mk_task.done():
+            _mk_task.cancel()
+        _mk_sub = getattr(self, "_merkle_subscriber", None)
+        if _mk_sub is not None:
+            try:
+                await _mk_sub.flush()
+            except Exception:  # noqa: BLE001
+                pass
 
         # Stop sensors first to prevent new envelopes entering router.
         # Sensor stop() methods are synchronous; call directly.
@@ -1044,6 +1158,16 @@ class IntakeLayerService:
                 "%d/%d sensors subscribed",
                 _subscribed, len(self._sensors),
             )
+
+            # ---- Slice 31: Merkle Cartographer hydration driver ----
+            # The Phase 11 merkle stack shipped consumers (OpportunityMiner /
+            # TodoScanner / DocStaleness subtree consults) but NO production
+            # caller ever hydrated the cartographer — update_full() had zero
+            # callers, _root stayed None, every subtree_hash() returned "",
+            # and every consumer fail-safed to legacy O(N) scans silently,
+            # forever (proven live: 5 quiet-soak cycles bt-2026-07-16-031323,
+            # all full scans). This is that missing driver — the ONE caller.
+            await self._start_merkle_hydration(_event_bus)
         except Exception as exc:
             logger.warning(
                 "[IntakeLayer] Event Spine failed to start, sensors will use "

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -289,6 +289,50 @@ class IntakeLayerService:
             await self._teardown()
             raise
 
+    def _start_conception_bridge(self, router: Any) -> None:
+        """Gap 3 — register the conception proposal bridge as a DreamEngine
+        blueprint observer, so ranked blueprints route themselves into the
+        intake queue on production (event-driven, no polling).
+
+        Composition only: the bridge (translation), the value model (ranking),
+        DreamEngine (production), and the router (queue) all pre-exist; this is
+        the missing production wiring. Resolution is best-effort down
+        ``gls._consciousness._dream`` — any missing handle or master-off flag
+        leaves the system byte-identical. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.conception_proposal_bridge import (
+                get_default_bridge,
+                master_enabled as bridge_enabled,
+            )
+            if not bridge_enabled():
+                logger.info(
+                    "[IntakeLayer] Conception bridge master off — blueprints "
+                    "stay unrouted (intent_discovery grounding still active)",
+                )
+                return
+            consciousness = getattr(self._gls, "_consciousness", None)
+            dream = getattr(consciousness, "_dream", None)
+            if dream is None or not hasattr(dream, "register_blueprint_observer"):
+                logger.info(
+                    "[IntakeLayer] Conception bridge enabled but no DreamEngine "
+                    "reachable — bridge idle (no event source)",
+                )
+                return
+            top_n = int(os.environ.get("JARVIS_CONCEPTION_BRIDGE_TOP_N", "5") or 5)
+            bridge = get_default_bridge()
+            observer = bridge.make_observer(
+                router, lambda: dream.get_blueprints(top_n=top_n),
+            )
+            dream.register_blueprint_observer(observer)
+            logger.info(
+                "[IntakeLayer] Conception bridge ARMED: high-EV blueprints will "
+                "route as auto_proposed envelopes (event-driven, dedup-guarded)",
+            )
+        except Exception:  # noqa: BLE001 — wiring is fail-soft by contract
+            logger.debug(
+                "[IntakeLayer] conception bridge wiring skipped", exc_info=True,
+            )
+
     async def _start_merkle_hydration(self, event_bus: Any) -> None:
         """Slice 31 — arm the Merkle Cartographer's hydration driver.
 
@@ -1177,6 +1221,12 @@ class IntakeLayerService:
         router = self._router
         assert router is not None
         await router.start()
+
+        # Gap 3 — arm the conception proposal bridge: high-EV DreamEngine
+        # blueprints route themselves into this now-live router as
+        # ``auto_proposed`` envelopes. Event-driven (DreamEngine observer),
+        # master-off by default. Composition only — the bridge owns no queue.
+        self._start_conception_bridge(router)
 
         # A1-T2 — event-driven router-ready valve. The router is now attached
         # (self._gls._intake_router set above) AND its dispatch loop is live.

--- a/backend/core/ouroboros/governance/intake/sensors/intent_discovery_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/intent_discovery_sensor.py
@@ -38,6 +38,16 @@ _DW_MODEL = os.environ.get("JARVIS_INTENT_DISCOVERY_MODEL", "Qwen/Qwen3.5-35B-A3
 _DW_MAX_TOKENS = int(os.environ.get("JARVIS_INTENT_DISCOVERY_MAX_TOKENS", "2000"))
 
 
+def _conception_grounding_enabled() -> bool:
+    """Gap 3 wire — ground each synthesized intent's LLM self-reported
+    confidence in the conception value model's verifiable expected value.
+    Default true; provably inert until the value model has real signal
+    (neutral EV → ×1.0 multiplier). Read at call time so it is togglable."""
+    return os.environ.get(
+        "JARVIS_CONCEPTION_VALUE_GROUNDING_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
 # ---------------------------------------------------------------------------
 # Gap #4 migration: event-driven mode (consumes ConversationBridge turns)
 # ---------------------------------------------------------------------------
@@ -396,6 +406,42 @@ class IntentDiscoverySensor:
             urgency = intent.get("urgency", "low")
             confidence = max(0.1, min(1.0, float(intent.get("confidence", 0.5))))
 
+            # Gap 3: ground the LLM's self-reported confidence in verifiable
+            # expected value — recovers the discarded blueprint/priority scores
+            # by re-scoring each synthesized intent through the conception value
+            # model (alignment × substance × EARNED trust × cost). The multiplier
+            # 0.5+EV maps a NEUTRAL EV (cold organism) to ×1.0 — provably inert
+            # until the model has real signal; a low-value-but-confident intent
+            # is dampened, a well-grounded one preserved.
+            value_detail: Dict[str, Any] = {}
+            try:
+                if _conception_grounding_enabled():
+                    from backend.core.ouroboros.governance.conception_value_model import (
+                        score_proposal as _cv_score,
+                    )
+
+                    _ev = _cv_score(
+                        description=description,
+                        target_files=target_files,
+                        signal_source="intent_discovery",
+                        project_root=self._repo,
+                    )
+                    raw_confidence = confidence
+                    confidence = max(0.1, min(1.0, confidence * (0.5 + _ev.ev)))
+                    value_detail = {
+                        "ev": round(_ev.ev, 4),
+                        "alignment": round(_ev.alignment, 4),
+                        "substance": round(_ev.substance, 4),
+                        "feasibility": round(_ev.feasibility, 4),
+                        "trust_level": _ev.trust_level,
+                        "band": _ev.band,
+                        "raw_confidence": round(raw_confidence, 4),
+                    }
+            except Exception:  # noqa: BLE001 — grounding is best-effort
+                logger.debug(
+                    "[IntentDiscovery] value grounding skipped", exc_info=True,
+                )
+
             envelope = make_envelope(
                 source="intent_discovery",
                 description=description,
@@ -414,6 +460,7 @@ class IntentDiscoverySensor:
                     },
                     "blueprint_count": len(blueprints),
                     "dw_model": _DW_MODEL,
+                    "conception_value": value_detail,  # Gap 3 grounding (may be {})
                 },
                 requires_human_ack=True,  # AC2 safety invariant
             )

--- a/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/opportunity_miner_sensor.py
@@ -346,6 +346,72 @@ _STRATEGIES: List[Tuple[str, str, str]] = [
 
 
 # ---------------------------------------------------------------------------
+# Slice 11.6.c (re-landed Slice 27) — Merkle Cartographer consultation.
+# The subtree-scoped short-circuit originally landed in 82c7f11cf4 but was
+# accidentally stripped when 8f3be950a1 rewrote this file; its regression
+# spine (test_opp_miner_merkle.py) has failed collection since. Restored
+# because it is ALSO the deepest root-cause fix for the bt-2026-07-15-214458
+# starvation residual: most 300s poll cycles re-scanned all ~2.8k files when
+# nothing under the watched subtrees had changed. With the consult back, a
+# quiet cycle is O(watched-paths) hash comparisons instead of O(N) walks.
+# ---------------------------------------------------------------------------
+
+
+def merkle_consult_enabled() -> bool:
+    """Re-read ``JARVIS_OPPMINER_USE_MERKLE`` at call time so monkeypatch
+    works in tests + operator can flip live without re-init.
+
+    Default ``true`` — graduated in Phase 11 Slice 11.7 alongside the
+    cartographer master and the sibling sensor consumers. Hot-revert:
+    ``export JARVIS_OPPMINER_USE_MERKLE=false``."""
+    raw = os.environ.get(
+        "JARVIS_OPPMINER_USE_MERKLE", "",
+    ).strip().lower()
+    if raw == "":
+        return True  # graduated default
+    return raw in ("1", "true", "yes", "on")
+
+
+def _miner_backpressure_enabled() -> bool:
+    """``JARVIS_MINER_BACKPRESSURE_ENABLED`` (default true) — Slice 27: the
+    per-file scan loop folds a loop-lag AIMD throttle (the same congestion-
+    control shape Slice 26 graduated on the Oracle sweep) so a full miner
+    cycle contracts its cadence and backs off exactly when the control plane
+    lags, instead of marching through ~2.8k files at fixed speed. Kill
+    switch ``=0`` restores the legacy fixed-cadence loop."""
+    raw = os.environ.get("JARVIS_MINER_BACKPRESSURE_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _miner_lag_probe_ceiling() -> int:
+    """``JARVIS_MINER_LAG_PROBE_CEILING`` — max files between loop-lag
+    probes (the AIMD batch ceiling; contracts under lag). Default 128."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_MINER_LAG_PROBE_CEILING", "128")))
+    except (TypeError, ValueError):
+        return 128
+
+
+def _miner_lag_probe_floor() -> int:
+    """``JARVIS_MINER_LAG_PROBE_FLOOR`` — min files between loop-lag probes
+    (the AIMD floor; progress never fully stalls). Default 8."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_MINER_LAG_PROBE_FLOOR", "8")))
+    except (TypeError, ValueError):
+        return 8
+
+
+def _miner_backpressure_lag_ms() -> float:
+    """``JARVIS_MINER_BACKPRESSURE_LAG_MS`` — event-loop lag (ms) above
+    which the miner throttles its scan cadence. Default 50ms (same
+    control-plane comfort band as the Oracle throttle)."""
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_MINER_BACKPRESSURE_LAG_MS", "50")))
+    except (TypeError, ValueError):
+        return 50.0
+
+
+# ---------------------------------------------------------------------------
 # OpportunityMinerSensor
 # ---------------------------------------------------------------------------
 
@@ -419,6 +485,16 @@ class OpportunityMinerSensor:
         self._explore_ratio: float = float(
             os.environ.get("JARVIS_MINER_EXPLORE_RATIO", "0.4")
         )
+
+        # --- Slice 11.6.c (re-landed Slice 27) — merkle short-circuit state ---
+        # Baseline: watched-path → subtree hash recorded after the last
+        # successful full scan. Cached candidates: what that scan returned.
+        # Stored regardless of merkle flag so flipping the flag mid-session
+        # transitions cleanly.
+        self._merkle_last_seen_subtree_hashes: Dict[str, str] = {}
+        self._merkle_cached_candidates: List[StaticCandidate] = []
+        self._merkle_short_circuits: int = 0
+        self._merkle_full_scans: int = 0
 
     # v350.4: Third-party / non-project directory segments
     _NON_PROJECT_SEGMENTS = frozenset({
@@ -553,7 +629,28 @@ class OpportunityMinerSensor:
 
         Rotates through analysis strategies each cycle, applies cooldowns,
         and uses exploit/explore selection for diverse coverage.
+
+        Slice 11.6.c (re-landed Slice 27) — when
+        ``JARVIS_OPPMINER_USE_MERKLE`` is on AND the Merkle Cartographer
+        reports ALL watched scan-path subtree hashes unchanged since the
+        last successful scan, short-circuit to the cached candidate list
+        (skip filesystem walk + AST parse + ingest entirely — this branch
+        fires BEFORE the offloaded walk). Subtree-scoped: a change outside
+        ``_scan_paths`` does NOT bust the cache.
         """
+        current_subtree_hashes = self._merkle_subtree_hashes()
+        if self._merkle_should_short_circuit(current_subtree_hashes):
+            self._merkle_short_circuits += 1
+            logger.debug(
+                "OpportunityMinerSensor: Merkle short-circuit "
+                "(scan #%d skipped, %d cached candidates, %d watched paths)",
+                self._merkle_short_circuits + self._merkle_full_scans,
+                len(self._merkle_cached_candidates),
+                len(current_subtree_hashes),
+            )
+            return list(self._merkle_cached_candidates)
+
+        self._merkle_full_scans += 1
         self._scan_cycle += 1
 
         # Pick the strategy for this cycle (round-robin)
@@ -592,8 +689,29 @@ class OpportunityMinerSensor:
         #     files inside the otherwise-tight scan loop.
         from backend.core.ouroboros.governance.event_loop_governance import (  # noqa: E501
             cooperative_yield_every_n_async,
+            measure_loop_lag_ms,
             offload_blocking,
         )
+
+        # Slice 27 — loop-lag AIMD throttle on the scan cadence. The Slice
+        # 12L/124 primitives guarantee scheduling SLOTS (sleep(0) per file)
+        # but never ADAPT: under load the miner still marched through ~2.8k
+        # files at fixed speed while the GIL-sharing read_text threads and
+        # per-file sync chunks compounded (bt-2026-07-15-214458: 41
+        # ControlPlaneStarvation events, peak 4.2s, all miner-attributed).
+        # Reuses the exact congestion-control class Slice 26 graduated on
+        # the Oracle sweep — no new mechanism, same AIMD shape + knobs.
+        _throttle = None
+        if _miner_backpressure_enabled():
+            from backend.core.ouroboros.oracle import (  # noqa: E501 — lazy: heavy module, already resident in prod
+                _AdaptiveIndexThrottle,
+            )
+            _throttle = _AdaptiveIndexThrottle(
+                max_batch=_miner_lag_probe_ceiling(),
+                min_batch=_miner_lag_probe_floor(),
+                lag_threshold_ms=_miner_backpressure_lag_ms(),
+            )
+        _files_since_probe = 0
 
         for scan_path in self._scan_paths:
             root = self._repo_root / scan_path
@@ -631,6 +749,20 @@ class OpportunityMinerSensor:
                 # ControlPlaneStarvation lag_ms~3200). sleep(0) is ~free and
                 # forces a yield every iteration, capping FSM lag.
                 await asyncio.sleep(0)
+                # Slice 27 — AIMD lag probe every `throttle.batch` files:
+                # contract the probe window + back off proportionally to
+                # overshoot when the control plane lags; expand back when
+                # the loop is responsive. Fires on EVERY iteration path
+                # (including the skip-continues below) so a long skipped
+                # run still yields adaptively.
+                _files_since_probe += 1
+                if _throttle is not None and _files_since_probe >= _throttle.batch:
+                    _files_since_probe = 0
+                    _lag_ms = await measure_loop_lag_ms()
+                    _throttle.update(_lag_ms)
+                    _backoff = _throttle.backoff_s(_lag_ms)
+                    if _backoff > 0.0:
+                        await asyncio.sleep(_backoff)
                 rel = str(py_file.relative_to(self._repo_root))
 
                 if not self._is_production_code(py_file, root):
@@ -706,9 +838,18 @@ class OpportunityMinerSensor:
 
                 analyses.append(analysis)
 
-        # Phase 2: Diverse candidate selection
+        # Phase 2: Diverse candidate selection — Slice 27: offloaded. The
+        # full eligible.sort over every mined analysis (each key evaluating
+        # the stratification-penalty property chain) is pure-Python CPU with
+        # ZERO awaits; at ~2.8k analyses it held the loop for the 0.5-2s
+        # starvation class. offload_blocking frees the loop for the sort's
+        # duration; the sensor task is the sole state mutator so thread
+        # safety is structural (sequential await).
         counters = _CycleCounters(mined=len(analyses))
-        eligible_count, selected = self._select_diverse_candidates(analyses, sort_field)
+        eligible_count, selected = await offload_blocking(
+            self._select_diverse_candidates, analyses, sort_field,
+            label="opportunity_miner.select_candidates",
+        )
         counters.eligible = eligible_count
         counters.selected = len(selected)
 
@@ -748,6 +889,9 @@ class OpportunityMinerSensor:
                         ingested, errors, skipped_non_package,
                     )
                     self._emit_cycle_summary(counters, strategy_name)
+                    self._merkle_refresh_baseline(
+                        ingested, current_subtree_hashes,
+                    )
                     return ingested
                 # Coalescing envelope was rejected — fall through to per-file
                 # ingest as a best-effort fallback.
@@ -830,7 +974,140 @@ class OpportunityMinerSensor:
             ingested, errors, skipped_non_package,
         )
         self._emit_cycle_summary(counters, strategy_name)
+        self._merkle_refresh_baseline(ingested, current_subtree_hashes)
         return ingested
+
+    # ------------------------------------------------------------------
+    # Slice 11.6.c (re-landed Slice 27) — Merkle consultation (subtree-scoped)
+    # ------------------------------------------------------------------
+
+    def _merkle_normalized_scan_paths(self) -> List[str]:
+        """Project ``self._scan_paths`` into the cartographer's relpath
+        namespace (POSIX, no leading/trailing slash, ``"."`` → root).
+
+        Stable order: same iteration order as ``_scan_paths`` so the
+        baseline dict stays comparable across cycles even if the path
+        list is reordered (it shouldn't be, but defensive)."""
+        out: List[str] = []
+        for raw in self._scan_paths:
+            s = str(raw).replace("\\", "/").strip()
+            if s in ("", ".", "./"):
+                out.append("")  # root marker
+                continue
+            out.append(s.strip("/"))
+        return out
+
+    def _merkle_subtree_hashes(self) -> Dict[str, str]:
+        """Read per-watched-path subtree hashes from the cartographer.
+        Empty dict on any failure path — fail-safe to legacy scan.
+
+        For each scan path: empty-string relpath means "use root hash"
+        (i.e. ``_scan_paths == ["."]``); any other relpath uses
+        ``subtree_hash(relpath)``. A missing/unhashable subtree returns
+        empty string, which the comparison treats as 'always changed'
+        (fail-safe).
+        """
+        if not merkle_consult_enabled():
+            return {}
+        try:
+            from backend.core.ouroboros.governance.merkle_cartographer import (
+                get_default_cartographer,
+            )
+            c = get_default_cartographer(repo_root=self._repo_root)
+            out: Dict[str, str] = {}
+            for relpath in self._merkle_normalized_scan_paths():
+                if relpath == "":
+                    out[relpath] = c.current_root_hash()
+                else:
+                    out[relpath] = c.subtree_hash(relpath)
+            return out
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "OpportunityMinerSensor: subtree hash read failed; "
+                "falling through to full scan", exc_info=True,
+            )
+            return {}
+
+    def _merkle_should_short_circuit(
+        self, current_hashes: Dict[str, str],
+    ) -> bool:
+        """Decide whether to skip the multi-strategy scan based on
+        cartographer state. Returns False (i.e. proceed with full scan)
+        on any failure path — fail-safe to legacy behavior.
+
+        Conditions for short-circuit (ALL must hold):
+          1. Per-sensor flag ``JARVIS_OPPMINER_USE_MERKLE`` is true
+          2. Cartographer master flag enabled (empty hashes dict from
+             ``_merkle_subtree_hashes`` indicates flag off / error /
+             cold-cartographer → fail-safe)
+          3. Every watched subtree hash matches the recorded baseline
+          4. We have a recorded baseline (cold-start guard — the
+             baseline dict is empty until the first full scan
+             completes; an *empty cache* with a populated baseline
+             is a legitimate "scan found 0 candidates" state and
+             SHOULD short-circuit)
+          5. The set of watched paths is unchanged since last scan
+             (operator may have added/removed paths via reconfig —
+             a different shape means we cannot trust the baseline)
+          6. No watched subtree returned an empty hash (would mean
+             cartographer cannot resolve that path — e.g. it doesn't
+             exist on disk yet, fail-safe to full scan)
+        """
+        if not merkle_consult_enabled():
+            return False
+        if not current_hashes:
+            return False  # cartographer disabled / cold-start / error
+        if not self._merkle_last_seen_subtree_hashes:
+            return False  # cold start — no baseline yet
+        if (
+            set(current_hashes.keys())
+            != set(self._merkle_last_seen_subtree_hashes.keys())
+        ):
+            return False  # scan-path topology changed
+        if any(not h for h in current_hashes.values()):
+            return False  # at least one subtree unresolved
+        return all(
+            current_hashes[k] == self._merkle_last_seen_subtree_hashes[k]
+            for k in current_hashes
+        )
+
+    def _merkle_refresh_baseline(
+        self,
+        ingested: List[StaticCandidate],
+        current_hashes: Dict[str, str],
+    ) -> None:
+        """Snapshot the freshly-scanned cartographer state + ingested
+        candidates as the new baseline for the next cycle's
+        short-circuit decision. Always-safe — never raises."""
+        try:
+            self._merkle_cached_candidates = list(ingested)
+            self._merkle_last_seen_subtree_hashes = dict(current_hashes)
+        except Exception:  # noqa: BLE001 — defensive
+            logger.debug(
+                "OpportunityMinerSensor: merkle baseline refresh failed",
+                exc_info=True,
+            )
+
+    def health(self) -> Dict[str, Any]:
+        """Operator-visible health snapshot. Slice 11.6.c added — exposes
+        merkle short-circuit telemetry for graduation observability.
+        (Restored Slice 27; the 8f3be950a1 rewrite dropped it.)"""
+        return {
+            "sensor": "OpportunityMinerSensor",
+            "repo": self._repo,
+            "running": self._running,
+            "scan_cycle": self._scan_cycle,
+            "cooldown_files": len(self._cooldown_map),
+            "seen_files": len(self._seen_file_paths),
+            # Slice 11.6.c — Merkle consultation telemetry
+            "merkle_consult_enabled": merkle_consult_enabled(),
+            "merkle_short_circuits": self._merkle_short_circuits,
+            "merkle_full_scans": self._merkle_full_scans,
+            "merkle_watched_paths": list(
+                self._merkle_last_seen_subtree_hashes.keys()
+            ),
+            "merkle_cached_candidates": len(self._merkle_cached_candidates),
+        }
 
     # ------------------------------------------------------------------
     # Internal helpers (shared between coalesced and per-file paths)

--- a/backend/core/ouroboros/governance/memory_pressure_gate.py
+++ b/backend/core/ouroboros/governance/memory_pressure_gate.py
@@ -185,6 +185,28 @@ def process_critical_frac() -> float:
     )
 
 
+# -- Slice 26: advisory in-flight reservation dimension -----------------
+# The bt-2026-07-15-192117 death window: ProactiveResourceGuard granted
+# the ~800MB "sentence_transformer" model-init budget seconds before the
+# starvation kill, while every gate consumer (Oracle Memory Armor,
+# subtree scoper, SensorGovernor) still saw the PRE-load free-% probe —
+# they fanned out into memory that was already spoken for. This dim
+# folds granted-but-not-yet-resident reservations into an ADJUSTED
+# free-% (strictest-wins, like the process-tree dim). A grant older
+# than the settle window is assumed resident (the raw probe carries it
+# from then on — no permanent double-count). Fail-open on any error.
+def reservation_dim_enabled() -> bool:
+    return _env_bool("JARVIS_MEMORY_PRESSURE_RESERVATIONS_ENABLED", True)
+
+
+def reservation_settle_s() -> float:
+    """Age (s) after which a granted budget is assumed RESIDENT (visible to
+    the raw probe) and stops being double-counted. Default 120."""
+    return _env_float(
+        "JARVIS_MEMORY_RESERVATION_SETTLE_S", 120.0, minimum=1.0,
+    )
+
+
 # ---------------------------------------------------------------------------
 # Vocabulary
 # ---------------------------------------------------------------------------
@@ -471,7 +493,11 @@ class MemoryPressureGate:
         # Disabled → _process_tree_dim returns OK → result == free
         # level (byte-identical legacy free-%-only path).
         proc_level, _rss, _cap = self._process_tree_dim()
-        return _strictest(free_level, proc_level)
+        # Slice 26 — strictest-wins compose with the in-flight
+        # reservation dim (granted-but-not-yet-resident model-init
+        # budgets shrink the effective free-%).
+        resv_level, _resv_mb = self._reservation_dim(probe)
+        return _strictest(_strictest(free_level, proc_level), resv_level)
 
     # -- fanout decision ----------------------------------------------------
 
@@ -537,6 +563,44 @@ class MemoryPressureGate:
             )
             return PressureLevel.OK, None, None
 
+    def _reservation_dim(
+        self, probe: MemoryProbe,
+    ) -> Tuple[PressureLevel, Optional[float]]:
+        """Slice 26 — advisory in-flight reservation pressure dimension.
+
+        Reads granted-but-presumably-not-yet-resident memory budgets from
+        ``ProactiveResourceGuard`` (e.g. the ~800MB ``sentence_transformer``
+        model-init grant) and re-levels an ADJUSTED free-%:
+        ``free_pct - unsettled_mb/total * 100``. Grants older than
+        ``reservation_settle_s()`` are assumed resident — the raw probe
+        carries their weight from then on, so there is no permanent
+        double-count. Returns ``(level, unsettled_mb)``; DISABLED,
+        no-guard, zero-unsettled, or ANY error → ``(OK, None)`` so the
+        strictest-wins composition is a no-op (fail-open — this dimension
+        only ever advises a clamp, never blocks on a glitch).
+        """
+        if not reservation_dim_enabled():
+            return PressureLevel.OK, None
+        try:
+            from backend.core.proactive_resource_guard import (
+                get_proactive_resource_guard,
+            )
+
+            unsettled_mb = get_proactive_resource_guard().unsettled_reservation_mb(
+                settle_s=reservation_settle_s(),
+            )
+            if unsettled_mb <= 0.0 or probe.total_bytes <= 0:
+                return PressureLevel.OK, None
+            reserved_pct = (unsettled_mb * 1024.0 * 1024.0) / probe.total_bytes * 100.0
+            adjusted_free_pct = max(0.0, probe.free_pct - reserved_pct)
+            return self.level_for_free_pct(adjusted_free_pct), unsettled_mb
+        except Exception:  # noqa: BLE001 — fail-open, never clamp on glitch
+            logger.debug(
+                "[MemoryPressureGate] reservation-dim probe raised",
+                exc_info=True,
+            )
+            return PressureLevel.OK, None
+
     def can_fanout(self, n_requested: int) -> FanoutDecision:
         """Advisory: may ``n_requested`` parallel units proceed?
 
@@ -579,8 +643,15 @@ class MemoryPressureGate:
         # Disabled → (OK, None, None): level == free_level, no reason
         # suffix, additive fields None → byte-identical legacy path.
         proc_level, proc_rss_mb, proc_cap_mb = self._process_tree_dim()
-        level = _strictest(free_level, proc_level)
+        # Slice 26 — in-flight reservation dim (same additive contract:
+        # disabled/quiet → OK → composition is a no-op).
+        resv_level, _resv_mb = self._reservation_dim(probe)
+        level = _strictest(_strictest(free_level, proc_level), resv_level)
         proc_dominant = _LEVEL_RANK[proc_level] > _LEVEL_RANK[free_level]
+        resv_dominant = (
+            _LEVEL_RANK[resv_level] > _LEVEL_RANK[free_level]
+            and _LEVEL_RANK[resv_level] > _LEVEL_RANK[proc_level]
+        )
         cap = self._cap_for_level(level)
         if cap is None:
             n_allowed = n_requested
@@ -588,10 +659,12 @@ class MemoryPressureGate:
         else:
             n_allowed = min(n_requested, cap)
             reason = f"memory_pressure_gate.capped_to_{cap}_at_{level.value}"
-            # Suffix ONLY when the process dim escalated — keeps the
+            # Suffix ONLY when a non-free dim escalated — keeps the
             # legacy free-%-only reason_code string byte-identical
             # for existing subagent_scheduler consumers/tests.
-            if proc_dominant:
+            if resv_dominant:
+                reason += "_via_reservations"
+            elif proc_dominant:
                 reason += "_via_process_tree"
         return FanoutDecision(
             allowed=n_allowed >= 1 if n_requested >= 1 else True,
@@ -605,7 +678,9 @@ class MemoryPressureGate:
             process_rss_mb=proc_rss_mb,
             process_cap_mb=proc_cap_mb,
             dominant_dimension=(
-                "process_tree" if proc_dominant else "free_pct"
+                "reservations" if resv_dominant
+                else "process_tree" if proc_dominant
+                else "free_pct"
             ),
         )
 
@@ -653,6 +728,22 @@ class MemoryPressureGate:
             # off). Reuses this surface + GET /observability/
             # memory-pressure; no new event type.
             "process_tree": self._process_tree_snapshot(),
+            # Slice 26 — additive in-flight reservation dimension
+            # (same contract: level=None when quiet/disabled).
+            "reservations": self._reservation_snapshot(probe),
+        }
+
+    def _reservation_snapshot(self, probe: MemoryProbe) -> Dict[str, Any]:
+        """Additive diagnostics for the Slice 26 reservation dimension."""
+        resv_level, unsettled_mb = self._reservation_dim(probe)
+        return {
+            "enabled": reservation_dim_enabled(),
+            "level": (
+                resv_level.value
+                if resv_level is not PressureLevel.OK else None
+            ),
+            "unsettled_mb": unsettled_mb,
+            "settle_s": reservation_settle_s(),
         }
 
     def _process_tree_snapshot(self) -> Dict[str, Any]:

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -9020,6 +9020,19 @@ class GovernedOrchestrator:
         else:
             if _serpent: _serpent.update_phase("GATE")
             # ---- Phase 5: GATE ----
+            # Autonomy Gap 4 — earned-trust WIDENING, inline-GATE twin of the
+            # extracted gate_runner hook. Applied at GATE ENTRY before the floor
+            # stack so the immutable cage/governance floors re-clamp afterwards.
+            # DEFAULT-INERT (double opt-in); wrapped so trust can never break GATE.
+            try:
+                from backend.core.ouroboros.governance.trust_calibration import (
+                    relax_tier_for_op as _trust_relax,
+                )
+                risk_tier, _trust_why = _trust_relax(risk_tier, ctx)
+                if _trust_why and _trust_why != "cage_excluded":
+                    logger.info("[TrustCalibration] GATE %s", _trust_why)
+            except Exception:  # noqa: BLE001 — trust widening must never break GATE
+                pass
             allowed, reason = self._stack.can_write(
                 {"files": list(ctx.target_files)}
             )

--- a/backend/core/ouroboros/governance/phase_runners/gate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/gate_runner.py
@@ -123,6 +123,23 @@ class GATERunner(PhaseRunner):
         best_candidate = self._best_candidate
         risk_tier = self._risk_tier
 
+        # Autonomy Gap 4 — earned-trust WIDENING, applied at GATE ENTRY BEFORE
+        # the floor stack so every immutable floor (the cage, governance
+        # boundary, paranoia, the trust NARROWING floor) re-clamps afterwards.
+        # Relaxes a human-gated APPROVAL_REQUIRED op to auto NOTIFY_APPLY ONLY on
+        # sustained HIGH scope trust, within the operator ceiling, never for cage
+        # surfaces. DEFAULT-INERT (double opt-in) — a no-op until enabled. Wrapped
+        # so trust can NEVER break GATE.
+        try:
+            from backend.core.ouroboros.governance.trust_calibration import (
+                relax_tier_for_op as _trust_relax,
+            )
+            risk_tier, _trust_why = _trust_relax(risk_tier, ctx)
+            if _trust_why and _trust_why != "cage_excluded":
+                logger.info("[TrustCalibration] GATE %s", _trust_why)
+        except Exception:  # noqa: BLE001 — trust widening must never break GATE
+            pass
+
         # Resolve _human_is_watching through the orchestrator module
         # namespace so env overrides remain test-patchable.
         from backend.core.ouroboros.governance.orchestrator import (

--- a/backend/core/ouroboros/governance/risk_tier_floor.py
+++ b/backend/core/ouroboros/governance/risk_tier_floor.py
@@ -546,6 +546,27 @@ def _cross_repo_elevation_floor(
         return "critical_elevation"
 
 
+def _trust_narrowing_floor(target_files) -> Optional[str]:
+    """Autonomy Gap 4 — the earned-trust NARROWING floor candidate. Derives the
+    op's scope from ``target_files`` (the same ``_infer_scope`` key the
+    AutoCommitter stamps, so trust converges with the git record) and asks the
+    trust engine for a tighter floor tier. Lazy-imported + fail-open (any fault
+    → None → no floor contribution). NEVER raises."""
+    try:
+        if not target_files:
+            return None
+        from backend.core.ouroboros.governance.auto_committer import (
+            AutoCommitter,
+        )
+        scope = AutoCommitter._infer_scope(tuple(str(f) for f in target_files))
+        from backend.core.ouroboros.governance.trust_calibration import (
+            trust_narrowing_tier,
+        )
+        return trust_narrowing_tier(scope)
+    except Exception:  # noqa: BLE001 — a floor helper must never raise
+        return None
+
+
 def recommended_floor(
     now: Optional[datetime] = None,
     *,
@@ -628,6 +649,15 @@ def recommended_floor(
     cross_repo = _cross_repo_elevation_floor(target_repo, crosses_repo)
     if cross_repo is not None:
         candidates.append(cross_repo)
+    # Autonomy Gap 4 — earned-trust NARROWING. A scope the organism just
+    # REGRESSED (a fresh git revert of its own commit) or has a poor held-up
+    # record contributes a tighter floor here — safety-forward, composed
+    # strictest-wins like every other floor, so the immune cage re-clamps it
+    # for free. The WIDENING half is applied separately at GATE entry (a floor
+    # can only tighten). None when trust is UNKNOWN/MEDIUM/HIGH or disabled.
+    trust_narrow = _trust_narrowing_floor(target_files)
+    if trust_narrow is not None:
+        candidates.append(trust_narrow)
     if not candidates:
         return None
     # Pick the strictest — highest ordinal wins.

--- a/backend/core/ouroboros/governance/trust_calibration.py
+++ b/backend/core/ouroboros/governance/trust_calibration.py
@@ -1,0 +1,538 @@
+"""
+Trust Calibration Engine — the earned-trust auto-apply envelope (autonomy Gap 4)
+================================================================================
+
+Run #24 needed an external graduation auditor for the organism to believe its
+own repair. For UNATTENDED operation O+V must verify its work to a standard that
+justifies landing it without a human — and today the trust envelope is STATIC
+and conservatively hardcoded (Orange → human gate, always). That never adapts to
+the organism's actual record: it stays maximally distrustful even after a long
+clean streak, and stays permissive right after a regression.
+
+This engine makes the envelope EARNED and ADAPTIVE, per category, from the
+DURABLE GIT-PROVABLE track record — never a hardcoded trust value:
+
+  * Per SCOPE (the conventional-commit ``type(scope):`` AutoCommitter writes,
+    derivable identically from a past commit's subject and from a new op's
+    ``target_files`` via ``auto_committer._infer_scope`` — so historical trust
+    and the op being judged share one key), compose the O+V-signed landed
+    commits (the Goal-Metric-Dashboard git substrate) into a recency-weighted,
+    ASYMMETRIC held-up-vs-reverted rate.
+  * ``held up`` = landed and NOT later reverted; ``regressed`` = a git revert of
+    an O+V-signed commit (the same ground-truth oracle autonomy_metrics uses).
+    Weights are ``_scoring_primitives.recency_weight`` (the house 14d halflife),
+    so a recent regression dominates a stale success — trust narrows fast.
+  * The trust LEVEL bands the rate through a volume-confidence floor (the
+    ``schelling_consensus_prior`` pattern): below a minimum sample the scope is
+    UNKNOWN (never trusted on thin evidence), so a 2/2 record cannot masquerade
+    as earned trust.
+
+The envelope moves asymmetrically and cage-safely (the seam invariant is
+"widen before the floors, narrow as a floor"):
+
+  * NARROW (always active, safety-forward): a scope with LOW trust or a FRESH
+    regression contributes a tighter risk-tier FLOOR via ``recommended_floor``'s
+    strictest-wins compose — the organism auto-distrusts a region it just broke.
+    Because it is a floor, the immune cage re-clamps it for free.
+  * WIDEN (double opt-in, DEFAULT-INERT): a scope with sustained HIGH trust over
+    sufficient volume and NO fresh regression may relax a human-gated
+    APPROVAL_REQUIRED op to auto-applied NOTIFY_APPLY — but ONLY when the
+    operator has (a) enabled widening AND (b) raised the ceiling, AND the op
+    does NOT touch the cage. Ships doing nothing until explicitly opted into.
+
+Authority posture: read-only over git ground truth; the ONLY behavior it can
+effect is through the two documented seams (a floor candidate + a bounded,
+cage-excluded, ceiling-clamped relaxation applied BEFORE the immutable floor
+stack). NEVER raises.
+"""
+from __future__ import annotations
+
+import enum
+import os
+import re
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+TRUST_CALIBRATION_SCHEMA_VERSION = "trust_calibration.1"
+
+# conventional-commit ``type(scope): ...`` — the per-category trust key.
+_SCOPE_RE = re.compile(r"^\s*[a-zA-Z]+\(([^)]{1,60})\)\s*:")
+
+
+class TrustLevel(str, enum.Enum):
+    UNKNOWN = "unknown"   # below the volume floor — never earned trust yet
+    LOW = "low"           # regressed / poor held-up rate → auto-NARROW
+    MEDIUM = "medium"     # decent, not yet widen-worthy
+    HIGH = "high"         # sustained clean record → widen-eligible
+
+
+# ---------------------------------------------------------------------------
+# Env knobs — additive, clamped; widening is DOUBLE opt-in + default-inert
+# ---------------------------------------------------------------------------
+
+
+def master_enabled() -> bool:
+    """``JARVIS_TRUST_CALIBRATION_ENABLED`` (default true). The read/observe/
+    NARROW engine. Off → no floor contribution, no widening, snapshot inert."""
+    raw = os.environ.get("JARVIS_TRUST_CALIBRATION_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def widen_enabled() -> bool:
+    """``JARVIS_TRUST_WIDEN_ENABLED`` (default FALSE). The cage-loosening half —
+    the FIRST of the double opt-in. Off → the engine can only NARROW."""
+    raw = os.environ.get("JARVIS_TRUST_WIDEN_ENABLED", "false")
+    return raw.strip().lower() in ("1", "true", "yes", "on")
+
+
+def max_auto_tier() -> str:
+    """``JARVIS_TRUST_MAX_AUTO_TIER`` — the operator CEILING: the most permissive
+    tier trust may EVER relax to (the SECOND opt-in). Default ``""`` = no
+    widening. Set e.g. ``notify_apply`` to permit Orange→Yellow relaxation."""
+    return os.environ.get("JARVIS_TRUST_MAX_AUTO_TIER", "").strip().lower()
+
+
+def _clamped_int(env: str, default: int, lo: int, hi: int) -> int:
+    try:
+        v = int(os.environ.get(env, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, v))
+
+
+def _clamped_float(env: str, default: float, lo: float, hi: float) -> float:
+    try:
+        v = float(os.environ.get(env, "").strip() or default)
+    except (TypeError, ValueError):
+        return default
+    return max(lo, min(hi, v))
+
+
+def window_days() -> int:
+    return _clamped_int("JARVIS_TRUST_WINDOW_DAYS", 60, 1, 3650)
+
+
+def halflife_days() -> float:
+    return _clamped_float("JARVIS_TRUST_HALFLIFE_DAYS", 14.0, 0.5, 3650.0)
+
+
+def min_sample() -> int:
+    """Volume floor: below this recency-weighted sample a scope is UNKNOWN."""
+    return _clamped_int("JARVIS_TRUST_MIN_SAMPLE", 5, 1, 10000)
+
+
+def widen_min_sample() -> int:
+    """Higher volume floor required specifically to WIDEN (stricter than the
+    banding floor — widening the cage demands more evidence than observing)."""
+    return _clamped_int("JARVIS_TRUST_WIDEN_MIN_SAMPLE", 8, 1, 10000)
+
+
+def low_threshold() -> float:
+    return _clamped_float("JARVIS_TRUST_LOW_THRESHOLD", 0.5, 0.0, 1.0)
+
+
+def high_threshold() -> float:
+    """Held-up rate at/above which a scope is HIGH (widen-eligible). Deliberately
+    strict — auto-applying formerly-human-gated changes needs a strong record."""
+    return _clamped_float("JARVIS_TRUST_HIGH_THRESHOLD", 0.9, 0.0, 1.0)
+
+
+def regression_window_s() -> float:
+    """A revert within this window is a FRESH regression → forces LOW + a hard
+    narrowing floor for the scope, regardless of the historical rate."""
+    return _clamped_float("JARVIS_TRUST_REGRESSION_WINDOW_S", 7 * 86400.0, 60.0, 3650 * 86400.0)
+
+
+# ---------------------------------------------------------------------------
+# Per-scope track record — composed from the git ground truth
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ScopeTrust:
+    scope: str
+    trust_level: str
+    held_up_rate: Optional[float]      # recency-weighted; None on empty denom
+    sample_count: int                  # landed commits (held + reverted)
+    held_up: int
+    reverted: int
+    recent_regression: bool
+    last_landed_unix: float = 0.0
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "scope": self.scope,
+            "trust_level": self.trust_level,
+            "held_up_rate": self.held_up_rate,
+            "sample_count": self.sample_count,
+            "held_up": self.held_up,
+            "reverted": self.reverted,
+            "recent_regression": self.recent_regression,
+        }
+
+
+def _extract_scope(body: str) -> str:
+    if not body:
+        return "unknown"
+    subject = body.strip().split("\n", 1)[0]
+    m = _SCOPE_RE.match(subject)
+    return m.group(1).strip() if m else "unknown"
+
+
+def _recency_weight(age_s: float, hl_days: float) -> float:
+    """Compose the house recency primitive; degrade to a local halving on any
+    fault (never let the trust read raise)."""
+    try:
+        from backend.core.ouroboros.governance._scoring_primitives import (
+            recency_weight,
+        )
+        return recency_weight(age_s, hl_days)
+    except Exception:  # noqa: BLE001
+        age_days = max(0.0, age_s) / 86400.0
+        try:
+            return max(0.0, min(1.0, 0.5 ** (age_days / max(hl_days, 1e-6))))
+        except Exception:  # noqa: BLE001
+            return 0.0
+
+
+def _collect_scope_records(
+    repo: Path, now: float,
+) -> Dict[str, List[Tuple[bool, float]]]:
+    """Per scope → list of ``(held_up, commit_time_unix)`` for O+V-signed,
+    non-Orange, non-empty landed commits in the window. ``held_up`` = the commit
+    sha is not the target of any git revert in the window. NEVER raises."""
+    out: Dict[str, List[Tuple[bool, float]]] = {}
+    try:
+        from backend.core.ouroboros.governance import autonomy_metrics as am
+        trailer = am._ov_trailer()
+        if not trailer:
+            return out
+        since = now - (window_days() * 86400.0)
+        raw = am._run_git_log(repo, am.target_branch(), since, am.commit_scan_max())
+        commits = am._parse_commits(raw)
+        reverted_refs: set = set()
+        for c in commits:
+            for m in am._REVERT_RE.finditer(c.body):
+                reverted_refs.add(m.group(1).lower())
+        landed = [
+            c for c in commits
+            if am._is_ov_commit(c.body, trailer) and not am._is_orange(c.body) and c.files
+        ]
+        landed_shas = {c.commit_hash.lower() for c in landed}
+        landed_shas |= {s[:12] for s in landed_shas}
+
+        def _is_reverted(sha: str) -> bool:
+            s = sha.lower()
+            for ref in reverted_refs:
+                if s == ref or s.startswith(ref) or ref.startswith(s):
+                    return True
+            return False
+
+        for c in landed:
+            scope = _extract_scope(c.body)
+            held = not _is_reverted(c.commit_hash)
+            out.setdefault(scope, []).append((held, float(c.commit_time_unix)))
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def _band(rate: Optional[float], sample: int, recent_regression: bool) -> TrustLevel:
+    if recent_regression:
+        return TrustLevel.LOW           # a fresh break is LOW regardless of rate
+    if rate is None or sample < min_sample():
+        return TrustLevel.UNKNOWN
+    if rate < low_threshold():
+        return TrustLevel.LOW
+    if rate < high_threshold():
+        return TrustLevel.MEDIUM
+    return TrustLevel.HIGH
+
+
+def _compute(scope: str, records: List[Tuple[bool, float]], now: float) -> ScopeTrust:
+    hl = halflife_days()
+    num = den = 0.0
+    held = rev = 0
+    last = 0.0
+    recent = False
+    rwin = regression_window_s()
+    for held_up, ct in records:
+        w = _recency_weight(max(0.0, now - ct), hl)
+        den += w
+        if held_up:
+            num += w
+            held += 1
+        else:
+            rev += 1
+            if (now - ct) <= rwin:
+                recent = True
+        last = max(last, ct)
+    rate = (num / den) if den > 0 else None
+    sample = held + rev
+    return ScopeTrust(
+        scope=scope, trust_level=_band(rate, sample, recent).value,
+        held_up_rate=(round(rate, 4) if rate is not None else None),
+        sample_count=sample, held_up=held, reverted=rev,
+        recent_regression=recent, last_landed_unix=last,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Cached trust report
+# ---------------------------------------------------------------------------
+
+_LOCK = threading.RLock()
+_REPORT: Optional[Dict[str, ScopeTrust]] = None
+_REPORT_TS: float = 0.0
+
+
+def _ttl_s() -> float:
+    return _clamped_float("JARVIS_TRUST_TTL_S", 300.0, 1.0, 86400.0)
+
+
+def trust_report(
+    *, repo_root: Optional[Path] = None, now: Optional[float] = None,
+    force: bool = False,
+) -> Dict[str, ScopeTrust]:
+    """Per-scope ScopeTrust, TTL-cached (git walk amortized across GATE reads).
+    NEVER raises."""
+    global _REPORT, _REPORT_TS
+    _now = float(now) if now is not None else time.time()
+    with _LOCK:
+        if not force and _REPORT is not None and (_now - _REPORT_TS) <= _ttl_s():
+            return dict(_REPORT)
+    try:
+        from backend.core.ouroboros.governance.autonomy_metrics import (
+            _resolve_repo_root,
+        )
+        repo = repo_root if repo_root is not None else _resolve_repo_root()
+        records = _collect_scope_records(repo, _now)
+        report = {sc: _compute(sc, recs, _now) for sc, recs in records.items()}
+    except Exception:  # noqa: BLE001
+        report = {}
+    with _LOCK:
+        _REPORT = report
+        _REPORT_TS = _now
+    return dict(report)
+
+
+def scope_trust(
+    scope: str, *, repo_root: Optional[Path] = None, now: Optional[float] = None,
+) -> ScopeTrust:
+    """ScopeTrust for one scope (UNKNOWN when absent). NEVER raises."""
+    try:
+        rep = trust_report(repo_root=repo_root, now=now)
+        if scope in rep:
+            return rep[scope]
+    except Exception:  # noqa: BLE001
+        pass
+    return ScopeTrust(scope=scope, trust_level=TrustLevel.UNKNOWN.value,
+                      held_up_rate=None, sample_count=0, held_up=0, reverted=0,
+                      recent_regression=False)
+
+
+def reset_cache_for_tests() -> None:
+    global _REPORT, _REPORT_TS
+    with _LOCK:
+        _REPORT = None
+        _REPORT_TS = 0.0
+
+
+# ---------------------------------------------------------------------------
+# Decision A — NARROWING floor candidate (always active, safety-forward)
+# ---------------------------------------------------------------------------
+
+
+def trust_narrowing_tier(
+    scope: str, *, repo_root: Optional[Path] = None, now: Optional[float] = None,
+) -> Optional[str]:
+    """A tier-NAME floor for ``recommended_floor`` (strictest-wins), or None.
+
+    A FRESH regression in the scope floors it to ``approval_required`` (human
+    gate) until it recovers; a merely LOW historical record floors it to
+    ``notify_apply`` (still auto, but surfaced). Composes cage-safely — it can
+    only RAISE the effective tier. NEVER raises."""
+    if not master_enabled():
+        return None
+    try:
+        st = scope_trust(scope, repo_root=repo_root, now=now)
+        if st.recent_regression:
+            return "approval_required"
+        if st.trust_level == TrustLevel.LOW.value:
+            return "notify_apply"
+    except Exception:  # noqa: BLE001
+        return None
+    return None
+
+
+# ---------------------------------------------------------------------------
+# Decision B — WIDENING relaxation (double opt-in, default-inert, cage-excluded)
+# ---------------------------------------------------------------------------
+
+def maybe_relax_tier(
+    risk_tier: Any, *, scope: str, touches_cage: bool,
+    repo_root: Optional[Path] = None, now: Optional[float] = None,
+) -> Tuple[Any, Optional[str]]:
+    """Return ``(possibly_relaxed_tier, rationale)``. Applied at GATE ENTRY,
+    BEFORE the immutable floor stack (which re-clamps the cage), so this can
+    only ever *propose* a relaxation the floors are free to override.
+
+    Relaxes a human-gated ``APPROVAL_REQUIRED`` op to auto-applied
+    ``NOTIFY_APPLY`` IFF ALL hold — else returns the tier UNCHANGED:
+      * widening is opted in (``JARVIS_TRUST_WIDEN_ENABLED``) AND the operator
+        ceiling (``JARVIS_TRUST_MAX_AUTO_TIER``) permits ``notify_apply``;
+      * the op does NOT touch the cage;
+      * the scope's trust is HIGH over ≥ ``widen_min_sample`` with NO fresh
+        regression.
+    DEFAULT-INERT: both opt-ins default off → always returns the tier unchanged.
+    NEVER raises (any fault → unchanged tier, fail-closed to the human gate)."""
+    try:
+        if not (master_enabled() and widen_enabled()):
+            return risk_tier, None
+        if touches_cage:
+            return risk_tier, "cage_excluded"
+        ceiling = max_auto_tier()
+        # Ceiling must explicitly permit notify_apply-level auto-apply.
+        if ceiling not in ("notify_apply", "safe_auto"):
+            return risk_tier, None
+        name = _tier_name(risk_tier)
+        if name != "approval_required":
+            return risk_tier, None  # only relax the human-gated tier
+        st = scope_trust(scope, repo_root=repo_root, now=now)
+        if (
+            st.trust_level == TrustLevel.HIGH.value
+            and st.sample_count >= widen_min_sample()
+            and not st.recent_regression
+        ):
+            relaxed = _tier_from_name("notify_apply", risk_tier)
+            return relaxed, (
+                f"widened approval_required->notify_apply "
+                f"(scope={scope} rate={st.held_up_rate} n={st.sample_count})"
+            )
+        return risk_tier, None
+    except Exception:  # noqa: BLE001 — fail closed to the human gate
+        return risk_tier, None
+
+
+def _op_touches_cage(target_files: List[str]) -> bool:
+    """True iff the op touches the immune cage (kernel/security/self-mod). FAIL-
+    CLOSED: any fault → True (treat as cage → never widen). Composes the
+    canonical RiskEngine sentinels — the SAME predicate the cage uses."""
+    if not target_files:
+        return False
+    try:
+        from backend.core.ouroboros.governance.risk_engine import RiskEngine
+        eng = RiskEngine()
+        return bool(
+            eng._matches_any(target_files, eng._kernel_sentinels())
+            or eng._matches_any(target_files, eng._security_sentinels())
+            or eng._matches_any(target_files, eng._self_mod_sentinels())
+        )
+    except Exception:  # noqa: BLE001 — fail closed to "is cage" (no widen)
+        return True
+
+
+def _infer_scope_for(target_files: List[str]) -> str:
+    try:
+        from backend.core.ouroboros.governance.auto_committer import AutoCommitter
+        return AutoCommitter._infer_scope(tuple(target_files)) if target_files else "unknown"
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def relax_tier_for_op(
+    risk_tier: Any, ctx: Any, *,
+    repo_root: Optional[Path] = None, now: Optional[float] = None,
+) -> Tuple[Any, Optional[str]]:
+    """GATE-entry convenience: derive scope + cage from ``ctx.target_files`` and
+    apply the bounded earned-trust widening. The single call the GATE seams make
+    (keeps the load-bearing GATE diff to one guarded line). Default-inert; NEVER
+    raises — any fault returns the tier unchanged (fail-closed to the gate)."""
+    try:
+        tf = [str(f) for f in (getattr(ctx, "target_files", None) or ())]
+        return maybe_relax_tier(
+            risk_tier, scope=_infer_scope_for(tf),
+            touches_cage=_op_touches_cage(tf),
+            repo_root=repo_root, now=now,
+        )
+    except Exception:  # noqa: BLE001
+        return risk_tier, None
+
+
+def _tier_name(risk_tier: Any) -> str:
+    v = getattr(risk_tier, "name", None) or getattr(risk_tier, "value", None) or risk_tier
+    return str(v).lower()
+
+
+def _tier_from_name(name: str, like: Any) -> Any:
+    """Return a RiskTier of ``name`` matching the enum type of ``like`` (so the
+    GATE gets the same enum it passed). Falls back to the name string."""
+    try:
+        cls = type(like)
+        for member in cls:  # type: ignore[call-overload]
+            if str(member.name).lower() == name:
+                return member
+    except Exception:  # noqa: BLE001
+        pass
+    return name
+
+
+# ---------------------------------------------------------------------------
+# Observability snapshot
+# ---------------------------------------------------------------------------
+
+
+def snapshot(*, repo_root: Optional[Path] = None, force: bool = False) -> Dict[str, Any]:
+    """Read-only trust snapshot for the observability GET. NEVER raises."""
+    if not master_enabled():
+        return {
+            "schema_version": TRUST_CALIBRATION_SCHEMA_VERSION,
+            "enabled": False, "reason_code": "disabled",
+        }
+    try:
+        rep = trust_report(repo_root=repo_root, force=force)
+        by_level: Dict[str, int] = {}
+        for st in rep.values():
+            by_level[st.trust_level] = by_level.get(st.trust_level, 0) + 1
+        scopes = sorted((st.to_dict() for st in rep.values()),
+                        key=lambda d: (d["trust_level"] != "low", d["scope"]))
+        widen_eligible = sorted(
+            st.scope for st in rep.values()
+            if st.trust_level == TrustLevel.HIGH.value
+            and st.sample_count >= widen_min_sample()
+            and not st.recent_regression
+        )
+        narrowing = sorted(
+            st.scope for st in rep.values()
+            if st.recent_regression or st.trust_level == TrustLevel.LOW.value
+        )
+        return {
+            "schema_version": TRUST_CALIBRATION_SCHEMA_VERSION,
+            "enabled": True,
+            "reason_code": "ok",
+            "envelope": {
+                # the operator opt-in state — widening does NOTHING until both.
+                "widen_enabled": widen_enabled(),
+                "max_auto_tier": max_auto_tier() or None,
+                "active_narrowing_scopes": narrowing,
+                "widen_eligible_scopes": widen_eligible,
+            },
+            "counts_by_level": by_level,
+            "scopes": scopes,
+            "interpretation": (
+                "Trust is earned per scope from the git-provable held-up-vs-"
+                "reverted record (recency-weighted, asymmetric). NARROWING "
+                "(LOW/fresh-regression → tighter floor) is always active; "
+                "WIDENING (HIGH → relax Orange to auto) is default-inert until "
+                "the operator both enables it and raises the ceiling, and never "
+                "touches the immune cage."
+            ),
+        }
+    except Exception:  # noqa: BLE001
+        return {
+            "schema_version": TRUST_CALIBRATION_SCHEMA_VERSION,
+            "enabled": True, "reason_code": "snapshot_error",
+        }

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1789,6 +1789,11 @@ class OracleSemanticIndex:
         if _chroma and self._collection is None:
             return
 
+        if _oracle_embed_tail_coop_enabled():
+            await self._embed_nodes_coop(nodes, _chroma=_chroma, _stdlib=_stdlib)
+            return
+
+        # ── Legacy tail (JARVIS_ORACLE_EMBED_TAIL_COOP_ENABLED=0 rollback) ──
         try:
             embeddable = [
                 n for n in nodes
@@ -1855,6 +1860,174 @@ class OracleSemanticIndex:
 
             logger.debug("[OracleSemanticIndex] Embedded %d nodes", len(embeddable))
         except Exception as exc:
+            logger.warning("[OracleSemanticIndex] embed_nodes failed: %s", exc)
+
+    async def _embed_nodes_coop(
+        self, nodes: List["NodeData"], *, _chroma: bool, _stdlib: bool,
+    ) -> None:
+        """Slice 28 — adaptive cooperative embed/upsert tail.
+
+        Closes the bt-2026-07-15-225445 10.3s post-sweep hold. The legacy
+        tail's residual on-loop work: ``_build_embed_text`` evaluated over
+        EVERY node twice (filter pass + per-batch rebuild) as pure-Python
+        string joins with zero awaits before the first batch; per-batch
+        metadata dict-builds + numpy ``tolist()`` conversion on the loop;
+        and a static 128 batch with no adaptation between batches.
+
+        Shape (all pre-existing substrate — no new pools, no new queue):
+          * per-batch prep (text-build + ids + metadata) and the vector
+            conversion + chroma upsert run via ``cooperative_fs_io.offload``
+            thread path — the SAME executor Slice 25 chose for the upsert
+            (thread, never process: the PersistentClient's native file lock
+            makes a second writer process corrupt HNSW segments; that pool
+            is already child_reaper-registered, and thread offloads spawn
+            no children — teardown lifecycle unchanged);
+          * batch size is AIMD-governed (``_AdaptiveIndexThrottle``, the
+            Slice 26 congestion-control class) fed by the shared
+            ``event_loop_governance.measure_loop_lag_ms`` probe (Slice 27)
+            — payload-size adaptation is EMERGENT, not configured: a
+            heavier batch produces more observed lag, which halves the
+            next batch; light batches recover additively toward the
+            ``ORACLE_EMBED_BATCH`` ceiling. No static chunk boundary
+            decides anything at runtime;
+          * memory axis: the shared ``MemoryPressureGate`` level (which
+            already folds the Slice 26 in-flight-reservation dimension)
+            maps through ``_ORACLE_MEM_LAG_MULT`` into synthetic lag —
+            elevated pressure contracts the batch AND lengthens the
+            proportional backoff yield, exactly the sweep armor's graded
+            defense.
+
+        Never raises; any batch fault logs + drops that batch (legacy
+        fail-soft contract preserved).
+        """
+        from backend.core.ouroboros.governance.cooperative_fs_io import (
+            is_offload_error as _cr_is_err,
+            offload as _cr_offload,
+        )
+        from backend.core.ouroboros.governance.event_loop_governance import (
+            measure_loop_lag_ms as _elg_lag_ms,
+        )
+
+        try:
+            # Cheap type filter stays inline (frozenset membership); the
+            # EXPENSIVE text building is per-batch and off-loop below.
+            candidates = [
+                n for n in nodes
+                if n.node_id.node_type in self._EMBEDDABLE_TYPES
+            ]
+            if not candidates:
+                return
+
+            throttle = (
+                _AdaptiveIndexThrottle(
+                    max_batch=OracleConfig.SEMANTIC_EMBED_BATCH_SIZE,
+                    min_batch=_oracle_backpressure_min_batch(),
+                    lag_threshold_ms=_oracle_backpressure_lag_ms(),
+                )
+                if _oracle_backpressure_enabled()
+                else None
+            )
+            _armor_on = _oracle_memory_armor_enabled()
+            total_embedded = 0
+            i = 0
+            while i < len(candidates):
+                # Memory axis BEFORE sizing the batch — same graded defense
+                # as the sweep (shared gate → shared multiplier table).
+                if throttle is not None and _armor_on:
+                    _mult = _ORACLE_MEM_LAG_MULT.get(
+                        _semantic_embed_pressure_level(), 0.0,
+                    )
+                    if _mult > 0.0:
+                        throttle.update(_mult * throttle.lag_threshold_ms)
+                effective = (
+                    throttle.batch if throttle is not None
+                    else OracleConfig.SEMANTIC_EMBED_BATCH_SIZE
+                )
+                batch = candidates[i : i + effective]
+                i += len(batch)
+
+                def _prep(_batch=batch):
+                    texts: List[str] = []
+                    keep: List[Any] = []
+                    for n in _batch:
+                        t = self._build_embed_text(n)
+                        if t is not None:
+                            keep.append(n)
+                            texts.append(t)
+                    ids = [str(n.node_id) for n in keep]
+                    metas = [
+                        {
+                            "repo": n.node_id.repo,
+                            "file_path": n.node_id.file_path,
+                            "name": n.node_id.name,
+                            "node_type": n.node_id.node_type.value,
+                        }
+                        for n in keep
+                    ]
+                    return texts, ids, metas
+
+                prep = await _cr_offload(_prep, cpu_bound=False)
+                if _cr_is_err(prep):
+                    logger.warning(
+                        "[OracleSemanticIndex] embed prep offload failed "
+                        "(%s) — batch dropped", prep,
+                    )
+                    continue
+                texts, ids, metadatas = prep
+                if not texts:
+                    continue
+
+                embeddings = await self._embedder.embed_batch(texts)
+
+                if _stdlib:
+                    for _eid, _emb, _meta in zip(ids, embeddings, metadatas):
+                        _vec = (
+                            _emb.tolist() if hasattr(_emb, "tolist")
+                            else list(_emb)
+                        )
+                        self._stdlib_store[_eid] = (
+                            [float(x) for x in _vec], _meta,
+                        )
+                else:
+                    # Slice 25 discipline unchanged: THREAD offload (never a
+                    # process — persist-dir lock; see embed_nodes legacy
+                    # comment). Slice 28 folds the numpy tolist() conversion
+                    # into the SAME thread hop as the upsert — one offload,
+                    # zero on-loop vector marshalling.
+                    def _convert_and_upsert(
+                        _ids=ids, _embs=embeddings, _metas=metadatas,
+                    ):
+                        return self._collection.upsert(
+                            ids=_ids,
+                            embeddings=[e.tolist() for e in _embs],
+                            metadatas=_metas,
+                        )
+
+                    _up = await _cr_offload(_convert_and_upsert, cpu_bound=False)
+                    if _cr_is_err(_up):
+                        logger.warning(
+                            "[OracleSemanticIndex] chroma upsert offload "
+                            "failed (%s) — batch dropped", _up,
+                        )
+                        continue
+                total_embedded += len(texts)
+
+                # Loop-lag probe BETWEEN batches (shared Slice 27 probe) —
+                # contract + proportional backoff exactly like the sweep.
+                if throttle is not None and i < len(candidates):
+                    lag_ms = await _elg_lag_ms()
+                    throttle.update(lag_ms)
+                    _backoff = throttle.backoff_s(lag_ms)
+                    if _backoff > 0.0:
+                        await asyncio.sleep(_backoff)
+                else:
+                    await asyncio.sleep(0)
+
+            logger.debug(
+                "[OracleSemanticIndex] Embedded %d nodes (coop tail)",
+                total_embedded,
+            )
+        except Exception as exc:  # noqa: BLE001 — never break the caller
             logger.warning("[OracleSemanticIndex] embed_nodes failed: %s", exc)
 
     async def semantic_search(
@@ -2050,6 +2223,34 @@ def _oracle_scoped_sweep_embed_enabled() -> bool:
     all-nodes re-embed."""
     raw = os.environ.get("JARVIS_ORACLE_SCOPED_SWEEP_EMBED_ENABLED", "true")
     return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _oracle_embed_tail_coop_enabled() -> bool:
+    """``JARVIS_ORACLE_EMBED_TAIL_COOP_ENABLED`` (default true) — Slice 28: the
+    post-sweep embed/upsert tail runs as an ADAPTIVE cooperative pipeline
+    (AIMD batch sizing on live loop lag + memory pressure, text-build and
+    vector-conversion off-loop) instead of the legacy fixed-128 march whose
+    on-loop text building + conversion produced the bt-2026-07-15-225445
+    10.3s cold-tail hold. Kill switch ``=0`` restores the legacy tail."""
+    raw = os.environ.get("JARVIS_ORACLE_EMBED_TAIL_COOP_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _semantic_embed_pressure_level() -> str:
+    """Shared-gate memory level for the embed tail — the SAME advisory
+    ``MemoryPressureGate`` the sweep armor and SensorGovernor consult (no
+    duplication; the Slice 26 reservation dimension rides along for free).
+    Returns ``ok|warn|high|critical``; NEVER raises (any fault → ``ok``,
+    fail-open — this axis only ever contracts a batch, never blocks)."""
+    try:
+        from backend.core.ouroboros.governance.memory_pressure_gate import (
+            get_default_gate, is_enabled,
+        )
+        if not is_enabled():
+            return "ok"
+        return get_default_gate().pressure().value
+    except Exception:  # noqa: BLE001
+        return "ok"
 
 
 def _oracle_memory_armor_enabled() -> bool:

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -1929,6 +1929,15 @@ class OracleSemanticIndex:
             )
             _armor_on = _oracle_memory_armor_enabled()
             total_embedded = 0
+            # Slice 30 — correlated-failure circuit breaker. A transient
+            # batch fault is tolerable; N CONSECUTIVE faults mean the
+            # backend itself is broken (the bt-2026-07-16-004244 class:
+            # deterministic "Error in compaction" on every upsert) and
+            # continuing amplifies the damage. Abort the remaining run —
+            # embeddings are advisory; the next changed-file embed retries
+            # against a freshly-booted backend.
+            _fail_streak = 0
+            _fail_streak_abort = _oracle_embed_fail_streak_abort()
             i = 0
             while i < len(candidates):
                 # Memory axis BEFORE sizing the batch — same graded defense
@@ -1968,10 +1977,20 @@ class OracleSemanticIndex:
 
                 prep = await _cr_offload(_prep, cpu_bound=False)
                 if _cr_is_err(prep):
+                    _fail_streak += 1
                     logger.warning(
                         "[OracleSemanticIndex] embed prep offload failed "
-                        "(%s) — batch dropped", prep,
+                        "(%s) — batch dropped (fail_streak=%d/%d)",
+                        prep, _fail_streak, _fail_streak_abort,
                     )
+                    if _fail_streak >= _fail_streak_abort:
+                        logger.warning(
+                            "[OracleSemanticIndex] embed tail ABORTED: %d "
+                            "consecutive batch failures — backend broken, "
+                            "containing (embedded=%d of %d candidates)",
+                            _fail_streak, total_embedded, len(candidates),
+                        )
+                        return
                     continue
                 texts, ids, metadatas = prep
                 if not texts:
@@ -2005,11 +2024,23 @@ class OracleSemanticIndex:
 
                     _up = await _cr_offload(_convert_and_upsert, cpu_bound=False)
                     if _cr_is_err(_up):
+                        _fail_streak += 1
                         logger.warning(
                             "[OracleSemanticIndex] chroma upsert offload "
-                            "failed (%s) — batch dropped", _up,
+                            "failed (%s) — batch dropped (fail_streak=%d/%d)",
+                            _up, _fail_streak, _fail_streak_abort,
                         )
+                        if _fail_streak >= _fail_streak_abort:
+                            logger.warning(
+                                "[OracleSemanticIndex] embed tail ABORTED: "
+                                "%d consecutive batch failures — backend "
+                                "broken, containing (embedded=%d of %d "
+                                "candidates)",
+                                _fail_streak, total_embedded, len(candidates),
+                            )
+                            return
                         continue
+                _fail_streak = 0
                 total_embedded += len(texts)
 
                 # Loop-lag probe BETWEEN batches (shared Slice 27 probe) —
@@ -2223,6 +2254,24 @@ def _oracle_scoped_sweep_embed_enabled() -> bool:
     all-nodes re-embed."""
     raw = os.environ.get("JARVIS_ORACLE_SCOPED_SWEEP_EMBED_ENABLED", "true")
     return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _oracle_embed_fail_streak_abort() -> int:
+    """``JARVIS_ORACLE_EMBED_FAIL_STREAK_ABORT`` — consecutive per-batch
+    failures after which the coop embed tail ABORTS the remaining run
+    (Slice 30, closes bt-2026-07-16-004244). The legacy tail aborted the
+    WHOLE embed on the first upsert exception; Slice 28's per-batch
+    fail-soft ``continue`` kept feeding a chroma collection whose HNSW
+    compaction was failing deterministically — 16 consecutive failing
+    upserts ballooned RSS ~10GB in 90s until the process memory cap fired.
+    Correlated failures need containment, not persistence. Default 3
+    (tolerates a transient, aborts a broken backend)."""
+    try:
+        return max(1, int(os.environ.get(
+            "JARVIS_ORACLE_EMBED_FAIL_STREAK_ABORT", "3",
+        )))
+    except (TypeError, ValueError):
+        return 3
 
 
 def _oracle_embed_tail_coop_enabled() -> bool:

--- a/backend/core/ouroboros/oracle.py
+++ b/backend/core/ouroboros/oracle.py
@@ -47,7 +47,7 @@ import pickle
 import sys
 import time
 from abc import ABC, abstractmethod
-from collections import defaultdict
+from collections import defaultdict, deque
 from dataclasses import dataclass, field
 from datetime import datetime
 import enum
@@ -2011,6 +2011,47 @@ def _oracle_backpressure_min_batch() -> int:
         return 4
 
 
+def _oracle_coop_scan_enabled() -> bool:
+    """``JARVIS_ORACLE_COOP_SCAN_ENABLED`` (default true) — Slice 26: the directory
+    tree walk runs as bounded per-chunk offloads with loop-lag-adaptive yields between
+    chunks, instead of one monolithic recursive walk inside a single thread hop (whose
+    pure-Python iterdir loop held the GIL for the whole tree — the bt-2026-07-15-192117
+    scan_dir frames). Kill switch ``=0`` restores the legacy monolithic walk."""
+    raw = os.environ.get("JARVIS_ORACLE_COOP_SCAN_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _oracle_scan_chunk_dirs() -> int:
+    """``JARVIS_ORACLE_SCAN_CHUNK_DIRS`` — ceiling on directories scanned per offload
+    chunk during the cooperative tree walk. The AIMD throttle contracts from here under
+    loop lag and recovers when the loop is responsive. Default 32."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_ORACLE_SCAN_CHUNK_DIRS", "32")))
+    except (TypeError, ValueError):
+        return 32
+
+
+def _oracle_sweep_backpressure_enabled() -> bool:
+    """``JARVIS_ORACLE_SWEEP_BACKPRESSURE_ENABLED`` (default true) — Slice 26: extends
+    the AIMD throttle + Memory Armor axes (previously full_index-only) to the
+    ``_scan_for_changes`` incremental sweep, which ran completely unthrottled and was
+    the bt-2026-07-15-192117 cause of death. Kill switch ``=0`` restores the legacy
+    unthrottled sweep."""
+    raw = os.environ.get("JARVIS_ORACLE_SWEEP_BACKPRESSURE_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
+def _oracle_scoped_sweep_embed_enabled() -> bool:
+    """``JARVIS_ORACLE_SCOPED_SWEEP_EMBED_ENABLED`` (default true) — Slice 26: after a
+    full-scan sweep, embed only the nodes of files that actually changed (the truthy-
+    branch discipline) instead of re-embedding the ENTIRE graph every poll. A quiet
+    sweep embeds nothing — which also stops the idle poll from lazily triggering the
+    chroma + embedder model load mid-sweep. Kill switch ``=0`` restores the legacy
+    all-nodes re-embed."""
+    raw = os.environ.get("JARVIS_ORACLE_SCOPED_SWEEP_EMBED_ENABLED", "true")
+    return raw.strip().lower() not in ("0", "false", "no", "off")
+
+
 def _oracle_memory_armor_enabled() -> bool:
     """``JARVIS_ORACLE_MEMORY_ARMOR_ENABLED`` (default true) — second AIMD axis: fold host
     memory pressure into the index throttle so the cold build defends a constrained RAM boundary
@@ -2161,6 +2202,55 @@ class _AdaptiveIndexThrottle:
         if lag_ms <= self.lag_threshold_ms:
             return 0.0
         return min(0.5, (lag_ms - self.lag_threshold_ms) / 1000.0)
+
+
+# Sovereign Memory Armor — multiplier × the throttle's lag threshold → synthetic "lag"
+# fed to the AIMD. >1.0 so each elevated level actually breaches (the throttle halves
+# on >threshold) and higher levels also yield the loop longer (backoff_s is proportional
+# to the overshoot). Graded defense. Shared by the full_index batch loop and the
+# Slice 26 incremental sweep (previously a full_index-local dict).
+_ORACLE_MEM_LAG_MULT = {"ok": 0.0, "warn": 1.5, "high": 2.5, "critical": 4.0}
+
+
+def _scan_dir_chunk_worker(dir_paths: "List[str]") -> "Tuple[List[str], List[str]]":
+    """Slice 26 — sync ONE-LEVEL scan of a bounded chunk of directories.
+
+    Module-level (picklable) worker for ``cooperative_fs_io.offload``. Each call
+    touches only the given directories' immediate children, so the pure-Python
+    iterdir loop's GIL hold is bounded by the chunk size the caller's AIMD throttle
+    chose — never the whole tree (the legacy recursive ``scan_dir`` failure mode).
+    Returns ``(subdirs, files)`` as path strings; exclusion, linked-worktree, and
+    suffix semantics are byte-identical to the legacy walk. Never raises for
+    per-directory faults (PermissionError parity with legacy).
+    """
+    subdirs: "List[str]" = []
+    files: "List[str]" = []
+    for d in dir_paths:
+        try:
+            for item in Path(d).iterdir():
+                path_str = str(item)
+                excluded = False
+                for pattern in OracleConfig.EXCLUDE_PATTERNS:
+                    if pattern in path_str:
+                        excluded = True
+                        break
+                if excluded:
+                    continue
+                if item.is_dir():
+                    # Slice 257 guard preserved — never descend into a linked
+                    # git worktree (duplicate checkout, not tracked source).
+                    if _is_linked_git_worktree(item):
+                        continue
+                    subdirs.append(path_str)
+                elif item.suffix in OracleConfig.SUPPORTED_EXTENSIONS:
+                    files.append(path_str)
+        except PermissionError:
+            continue
+        except OSError:
+            # Directory vanished mid-scan (worktree reap, tmp cleanup) — skip,
+            # matching the fault-isolation posture of the legacy walk.
+            continue
+    return subdirs, files
 
 
 def _oracle_pool_teardown_deadline_s() -> float:
@@ -2563,6 +2653,10 @@ class TheOracle:
         logger.info("Starting incremental update...")
         start_time = time.time()
 
+        # Slice 26 — the full-scan branch reports which files ACTUALLY changed so
+        # the embed below can be scoped to them (legacy re-embedded the ENTIRE
+        # graph every 300s poll — the bt-2026-07-15-192117 sweep death class).
+        scanned_changed: "List[Path]" = []
         async with self._lock:
             if changed_files:
                 # Update specific files
@@ -2572,15 +2666,20 @@ class TheOracle:
                 # Scan for changes
                 for repo_name, repo_path in self._repos.items():
                     if repo_path.exists():
-                        await self._scan_for_changes(repo_name, repo_path)
+                        scanned_changed.extend(
+                            await self._scan_for_changes(repo_name, repo_path)
+                        )
 
             self._graph._metrics["last_incremental_update"] = time.time()
 
         # Embed changed nodes into semantic index (fault-isolated)
         try:
-            if changed_files:
+            embed_scope = changed_files or (
+                scanned_changed if _oracle_scoped_sweep_embed_enabled() else None
+            )
+            if embed_scope is not None:
                 changed_rel_paths: set = set()
-                for fp in changed_files:
+                for fp in embed_scope:
                     for _repo_name, repo_root in self._repos.items():
                         try:
                             changed_rel_paths.add(str(Path(fp).relative_to(repo_root)))
@@ -2591,8 +2690,15 @@ class TheOracle:
                     if n.node_id.file_path in changed_rel_paths
                 ]
             else:
+                # Legacy rollback path (JARVIS_ORACLE_SCOPED_SWEEP_EMBED_ENABLED=0):
+                # whole-graph re-embed after every full-scan sweep.
                 changed_nodes = self._graph.get_all_nodes()
-            await self._ensure_semantic_index().embed_nodes(changed_nodes)
+            # A quiet sweep embeds NOTHING — critically, this also means the idle
+            # 300s poll no longer lazily triggers the chroma init + the ~800MB
+            # embedder model load mid-sweep (both now fire only when there is
+            # real changed content to embed).
+            if changed_nodes:
+                await self._ensure_semantic_index().embed_nodes(changed_nodes)
         except Exception as exc:
             logger.warning("[Oracle] Semantic embedding after incremental_update failed: %s", exc)
 
@@ -2933,10 +3039,9 @@ class TheOracle:
         # throttle's lag scale so an elevated memory level contracts the next batch's process-pool
         # fan-out exactly as event-loop lag does (multiplier × the throttle's lag threshold).
         _armor_on = _oracle_memory_armor_enabled()
-        # Multiplier × the throttle's lag threshold → synthetic "lag" fed to the AIMD. >1.0 so each
-        # elevated level actually breaches (the throttle halves on >threshold) and higher levels
-        # also yield the loop longer (backoff_s is proportional to the overshoot). Graded defense.
-        _MEM_LAG_MULT = {"ok": 0.0, "warn": 1.5, "high": 2.5, "critical": 4.0}
+        # Slice 26 — the level→synthetic-lag map is module-level now (shared with the
+        # incremental sweep's throttle): _ORACLE_MEM_LAG_MULT.
+        _MEM_LAG_MULT = _ORACLE_MEM_LAG_MULT
         i = 0
         _batch_no = 0
         while i < total_files:
@@ -3032,7 +3137,82 @@ class TheOracle:
         return False  # partition completed (not suspended)
 
     async def _find_python_files(self, root: Path) -> List[Path]:
-        """Find all Python files in a directory, excluding patterns."""
+        """Find all Python files in a directory, excluding patterns.
+
+        Slice 26 (2026-07-15, closes the bt-2026-07-15-192117 scan_dir GIL hold):
+        the tree walk is a cooperative frontier now — a deque of pending
+        directories drained in bounded chunks, each chunk one-level-scanned by
+        ``_scan_dir_chunk_worker`` via ``cooperative_fs_io.offload`` (the shared
+        Slice 22/23 substrate — no new pool). Between chunks the loop-lag probe
+        feeds the same ``_AdaptiveIndexThrottle`` AIMD the batch indexer uses, so
+        the chunk size contracts and the walk backs off exactly when the control
+        plane needs the loop. The legacy path put the ENTIRE recursive walk in one
+        ``asyncio.to_thread`` hop; its pure-Python iterdir loop held the GIL for
+        the whole tree × 3 repos with zero yield points — the escalating
+        12.4→16.2→25.6s holds that starved the heartbeat.
+
+        Kill switch ``JARVIS_ORACLE_COOP_SCAN_ENABLED=0`` restores the legacy
+        monolithic walk byte-identically. Per-chunk offload faults fail soft to a
+        bounded inline scan of just that chunk — the walk always completes.
+        """
+        if not _oracle_coop_scan_enabled():
+            return await self._find_python_files_legacy(root)
+
+        # Lazy import — substrate lives under .governance/ (avoid import cycle).
+        from backend.core.ouroboros.governance.cooperative_fs_io import (
+            is_offload_error,
+            offload,
+        )
+
+        python_files: List[Path] = []
+        pending: "deque[str]" = deque([str(root)])
+        throttle = (
+            _AdaptiveIndexThrottle(
+                max_batch=_oracle_scan_chunk_dirs(),
+                min_batch=1,
+                lag_threshold_ms=_oracle_backpressure_lag_ms(),
+            )
+            if _oracle_backpressure_enabled()
+            else None
+        )
+        chunk_ceiling = _oracle_scan_chunk_dirs()
+        while pending:
+            if self._shutting_down:
+                logger.info(
+                    "[Oracle.scan] cooperative walk of %s cancelled — shutdown "
+                    "requested (%d files found, %d dirs pending)",
+                    root, len(python_files), len(pending),
+                )
+                break
+            effective = throttle.batch if throttle is not None else chunk_ceiling
+            chunk = [pending.popleft() for _ in range(min(effective, len(pending)))]
+            result = await offload(_scan_dir_chunk_worker, chunk)
+            if is_offload_error(result):
+                # Fail-soft: scan THIS chunk inline (bounded — one level of at
+                # most `effective` directories), never abandon the walk.
+                logger.warning(
+                    "[Oracle.scan] chunk offload failed (%s: %s) — scanning "
+                    "%d dirs inline", result.exc_type, result.message, len(chunk),
+                )
+                result = _scan_dir_chunk_worker(chunk)
+            subdirs, files = result
+            pending.extend(subdirs)
+            python_files.extend(Path(f) for f in files)
+            if throttle is not None and pending:
+                lag_ms = await self._measure_loop_lag_ms()
+                throttle.update(lag_ms)
+                backoff = throttle.backoff_s(lag_ms)
+                if backoff > 0.0:
+                    await asyncio.sleep(backoff)
+            else:
+                # Throttle disabled — still guarantee a scheduling slot between
+                # chunks so the walk can never monopolize the loop.
+                await asyncio.sleep(0)
+        return python_files
+
+    async def _find_python_files_legacy(self, root: Path) -> List[Path]:
+        """Pre-Slice-26 monolithic walk — retained verbatim for the
+        ``JARVIS_ORACLE_COOP_SCAN_ENABLED=0`` rollback path."""
         python_files = []
 
         def should_exclude(path: Path) -> bool:
@@ -3286,8 +3466,10 @@ class TheOracle:
 
         logger.warning(f"File not in any known repository: {file_path}")
 
-    async def _scan_for_changes(self, repo_name: str, repo_path: Path) -> None:
-        """Scan repository for changed files.
+    async def _scan_for_changes(self, repo_name: str, repo_path: Path) -> "List[Path]":
+        """Scan repository for changed files. Returns the files that actually
+        changed (and were re-indexed) so the caller can scope the semantic
+        re-embed to them — Slice 26.
 
         Task #102 (2026-05-14) — Autonomous Event-Loop Governance.
         v14-rev18 isolated H11 (event-loop starvation) as the final-mile
@@ -3307,6 +3489,18 @@ class TheOracle:
         Oracle scan.  Master switch
         ``JARVIS_EVENT_LOOP_GOVERNANCE_ENABLED`` (default true);
         flip-off restores legacy byte-identical behavior.
+
+        Slice 26 (2026-07-15, closes bt-2026-07-15-192117 heartbeat_stale):
+        ``sleep(0)`` slots alone proved insufficient — this sweep had NO
+        adaptive throttle (the AIMD + Memory Armor axes guarded only the
+        full_index batch loop), so a 300s-cadence ``incremental_update([])``
+        poll marched through 29k+ files at full speed regardless of loop
+        lag. The same multi-axis throttle now governs this loop: every
+        AIMD-batch of files, probe loop lag + host memory, contract the
+        cadence and back off proportionally to overshoot; persistent
+        CRITICAL memory suspends the sweep for this cycle (it re-runs next
+        poll — ``_file_hashes`` makes re-scanning cheap and idempotent).
+        Kill switch ``JARVIS_ORACLE_SWEEP_BACKPRESSURE_ENABLED=0``.
         """
         # Lazy import — substrate lives under .governance/ and oracle.py
         # is imported eagerly at module-import time of the governance
@@ -3330,7 +3524,28 @@ class TheOracle:
             _content = p.read_text(encoding="utf-8")
             return _content, hashlib.md5(_content.encode()).hexdigest()
 
+        changed: "List[Path]" = []
+        # Slice 26 — multi-axis sweep throttle (same AIMD + Memory Armor
+        # composition as _run_index_batches; same env knobs, no duplication).
+        _sweep_bp = _oracle_sweep_backpressure_enabled()
+        _sweep_throttle = (
+            _AdaptiveIndexThrottle(
+                max_batch=OracleConfig.MAX_PARALLEL_FILES,
+                min_batch=_oracle_backpressure_min_batch(),
+                lag_threshold_ms=_oracle_backpressure_lag_ms(),
+            )
+            if _sweep_bp and _oracle_backpressure_enabled()
+            else None
+        )
+        _armor_on = _sweep_bp and _oracle_memory_armor_enabled()
+        _files_since_probe = 0
         async for file_path in cooperative_yield_every_n_async(python_files):
+            if self._shutting_down:
+                logger.info(
+                    "[Oracle.sweep] %s scan cancelled — shutdown requested "
+                    "(%d changed so far)", repo_name, len(changed),
+                )
+                break
             try:
                 content, content_hash = await offload_blocking(
                     _read_and_hash, file_path,
@@ -3353,8 +3568,33 @@ class TheOracle:
 
                 if needs_index:
                     await self._index_file(repo_name, repo_path, file_path)
+                    changed.append(file_path)
             except Exception as e:
                 logger.warning(f"Error scanning {file_path}: {e}")
+            _files_since_probe += 1
+            if _sweep_throttle is not None and _files_since_probe >= _sweep_throttle.batch:
+                _files_since_probe = 0
+                if _armor_on:
+                    _mem_lvl = await self._memory_armor_check()
+                    if _mem_lvl == "critical_persist":
+                        logger.warning(
+                            "[Oracle.sweep] CRITICAL memory pressure persisted after GC "
+                            "yields — suspending %s sweep (%d changed indexed). The next "
+                            "poll re-scans; _file_hashes keeps that idempotent and cheap.",
+                            repo_name, len(changed),
+                        )
+                        break
+                    if _ORACLE_MEM_LAG_MULT.get(_mem_lvl, 0.0) > 0.0:
+                        self._mem_armor_contractions += 1
+                        _sweep_throttle.update(
+                            _ORACLE_MEM_LAG_MULT[_mem_lvl] * _sweep_throttle.lag_threshold_ms
+                        )
+                lag_ms = await self._measure_loop_lag_ms()
+                _sweep_throttle.update(lag_ms)
+                _backoff = _sweep_throttle.backoff_s(lag_ms)
+                if _backoff > 0.0:
+                    await asyncio.sleep(_backoff)
+        return changed
 
     # ------------------------------------------------------------------
     # Slice 33 Arc 2 Phase 3 — async graph-write queue

--- a/backend/core/proactive_resource_guard.py
+++ b/backend/core/proactive_resource_guard.py
@@ -497,6 +497,28 @@ class ProactiveResourceGuard:
         self._requests_denied += 1
         return False
     
+    def unsettled_reservation_mb(self, settle_s: float = 120.0) -> float:
+        """Sum (MB) of granted budgets younger than ``settle_s`` seconds.
+
+        Slice 26 — the backpressure integration surface. A fresh grant (e.g.
+        the ~800MB ``sentence_transformer`` model-init budget) is memory that
+        is about to materialize but may not yet be visible to host free-memory
+        probes; consumers like ``MemoryPressureGate`` fold this into an
+        adjusted free-% so fan-out contracts BEFORE the allocation lands.
+        Grants older than the settle window are assumed resident (the raw
+        probe carries their weight). Thread-safe; NEVER raises.
+        """
+        try:
+            now = time.time()
+            horizon = max(0.0, float(settle_s))
+            with self._budget_lock:
+                return float(sum(
+                    b.estimated_mb for b in self._budgets.values()
+                    if (now - b.allocated_at) < horizon
+                ))
+        except Exception:  # noqa: BLE001 — advisory surface, fail-open
+            return 0.0
+
     def release_budget(self, component: str) -> bool:
         """
         Release a memory budget when component is unloaded.

--- a/scripts/inject_rt_stimulus.py
+++ b/scripts/inject_rt_stimulus.py
@@ -1,0 +1,140 @@
+#!/usr/bin/env python3
+"""Slice 27 — sterile real-time-route stimulus injector.
+
+Purpose: empirically prove the Tier-1 (Claude) real-time routing during a
+verification soak WITHOUT touching the core state machine or mutating any
+production source. It drops ONE synthetic failing test file into the
+TestWatcher's watched directory; the existing sense→route→dispatch chain
+does the rest:
+
+    TestWatcher (2-consecutive-poll debounce, fs.changed fast path)
+      → TestFailureSensor  (source="test_failure", urgency="high")
+      → UrgencyRouter      (high_urgency_immediate_source:test_failure → IMMEDIATE)
+      → CandidateGenerator (IMMEDIATE = Claude direct; and per the sealed
+                            topology, STANDARD/COMPLEX ALSO cascade_to_claude —
+                            so the Claude proof survives even the headless
+                            sensor-demotion edge case)
+
+Sterility properties:
+  * ZERO production-source mutation — one new test file, marker-tagged.
+  * The synthetic test imports a REAL source module (event_loop_governance)
+    so Slice 6 test→source attribution resolves via direct_import — no
+    AttributionUnresolved edge. Even a full pipeline run stays contained:
+    workspace promotion is default-OFF (quarantine workspace) and test-only
+    mutations floor at NOTIFY/APPROVAL tiers.
+  * --revert deletes the file ONLY if it carries the injection marker.
+  * Refuses to overwrite an existing file at the target path.
+
+Usage:
+    python3 scripts/inject_rt_stimulus.py --inject   # drop the failing test
+    python3 scripts/inject_rt_stimulus.py --status   # is a probe present?
+    python3 scripts/inject_rt_stimulus.py --revert   # remove it (marker-checked)
+
+Greppable proof lines in the soak debug.log after injection:
+    "high_urgency_immediate_source:test_failure"   (route stamp)
+    "IMMEDIATE route: Claude direct"               (dispatch)
+    "cascade_to_claude"                            (topology block, STANDARD/COMPLEX)
+    "[ClaudeProvider]"                             (actual Anthropic call)
+"""
+from __future__ import annotations
+
+import argparse
+import sys
+from pathlib import Path
+
+MARKER = (
+    "RT-STIMULUS-PROBE (Slice 27) — synthetic failing test injected by "
+    "scripts/inject_rt_stimulus.py; removable via --revert"
+)
+
+PROBE_REL = Path("tests") / "test_slice27_rt_stimulus_probe.py"
+
+PROBE_BODY = f'''"""{MARKER}.
+
+Deliberately-failing test: proves the TestFailure→IMMEDIATE→Claude routing
+chain live. Imports a REAL source module so Slice 6 attribution resolves
+via direct_import. The assertion is impossible by contract
+(resolve_yield_every_n() is clamped >= 1), so the red is deterministic.
+"""
+from backend.core.ouroboros.governance.event_loop_governance import (
+    resolve_yield_every_n,
+)
+
+
+def test_rt_stimulus_probe_deliberate_failure():
+    # {MARKER}
+    assert resolve_yield_every_n() == -1, (
+        "RT stimulus probe: deliberate failure to exercise the "
+        "TestFailure -> IMMEDIATE -> Claude dispatch chain"
+    )
+'''
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parent.parent
+
+
+def inject(root: Path) -> int:
+    target = root / PROBE_REL
+    if target.exists():
+        print(f"REFUSED: {target} already exists — revert first", file=sys.stderr)
+        return 2
+    target.write_text(PROBE_BODY, encoding="utf-8")
+    print(f"INJECTED: {target}")
+    print("NOTE: TestWatcher debounce requires the failure to be seen on two")
+    print("consecutive polls before the signal fires; the fs.changed fast path")
+    print("usually triggers the first scoped poll within seconds.")
+    return 0
+
+
+def revert(root: Path) -> int:
+    target = root / PROBE_REL
+    if not target.exists():
+        print(f"CLEAN: {target} not present")
+        return 0
+    content = target.read_text(encoding="utf-8", errors="replace")
+    if MARKER not in content:
+        print(
+            f"REFUSED: {target} exists but lacks the injection marker — "
+            "not ours to delete",
+            file=sys.stderr,
+        )
+        return 2
+    target.unlink()
+    print(f"REVERTED: {target} removed")
+    return 0
+
+
+def status(root: Path) -> int:
+    target = root / PROBE_REL
+    if not target.exists():
+        print("status: absent")
+        return 0
+    marked = MARKER in target.read_text(encoding="utf-8", errors="replace")
+    print(f"status: present (marker={'yes' if marked else 'NO — foreign file!'})")
+    return 0
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description=(__doc__ or "RT stimulus injector").splitlines()[0],
+    )
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--inject", action="store_true")
+    g.add_argument("--revert", action="store_true")
+    g.add_argument("--status", action="store_true")
+    ap.add_argument(
+        "--repo-root", type=Path, default=None,
+        help="Repo root (default: parent of scripts/)",
+    )
+    args = ap.parse_args()
+    root = args.repo_root or _repo_root()
+    if args.inject:
+        return inject(root)
+    if args.revert:
+        return revert(root)
+    return status(root)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/inject_rt_stimulus.py
+++ b/scripts/inject_rt_stimulus.py
@@ -54,16 +54,22 @@ PROBE_BODY = f'''"""{MARKER}.
 Deliberately-failing test: proves the TestFailure→IMMEDIATE→Claude routing
 chain live. Imports a REAL source module so Slice 6 attribution resolves
 via direct_import. The assertion is impossible by contract
-(resolve_yield_every_n() is clamped >= 1), so the red is deterministic.
+(the sentence_transformer estimate is a positive MB count), so the red is
+deterministic.
+
+Target-choice constraint (learned live, bt-2026-07-15-223446): the imported
+module must sit OUTSIDE the risk engine's self-mod sentinels (anything
+matching "ouroboros/governance/", kernel or security surfaces) — an
+attribution that lands inside the cage is BLOCKED pre-GENERATE with
+reason self_modification_unsanctioned_source (the immune system working
+as designed), which kills the dispatch proof.
 """
-from backend.core.ouroboros.governance.event_loop_governance import (
-    resolve_yield_every_n,
-)
+from backend.core.proactive_resource_guard import COMPONENT_MEMORY_ESTIMATES
 
 
 def test_rt_stimulus_probe_deliberate_failure():
     # {MARKER}
-    assert resolve_yield_every_n() == -1, (
+    assert COMPONENT_MEMORY_ESTIMATES.get("sentence_transformer") == -1, (
         "RT stimulus probe: deliberate failure to exercise the "
         "TestFailure -> IMMEDIATE -> Claude dispatch chain"
     )

--- a/tests/battle_test/test_serpent_flow_ux_wiring.py
+++ b/tests/battle_test/test_serpent_flow_ux_wiring.py
@@ -187,15 +187,17 @@ def test_typo_suggestion_does_not_fire_for_known_verbs():
 
 
 def test_typo_suggestion_continues_on_match():
-    """When suggestions are surfaced, the dispatch must `continue`
+    """When suggestions are surfaced, the dispatch must exit early
     — otherwise the external handler also fires (double-handling).
     Anchor on the call to `_typo_suggest(` which is unique to the
-    typo wiring block."""
+    typo wiring block.  Slice 32 extracted the dispatch into
+    ``_dispatch_repl_command`` where ``continue`` became
+    ``return True`` (identical no-double-handling guarantee)."""
     src = _source()
     idx = src.find("_typo_suggest(")
     assert idx > 0
     post = src[idx:idx + 3000]
-    assert "continue" in post
+    assert "return True" in post
 
 
 def test_typo_suggestion_surfaces_descriptor_hint():

--- a/tests/governance/test_autonomy_metrics.py
+++ b/tests/governance/test_autonomy_metrics.py
@@ -1,0 +1,383 @@
+"""Goal Metric Dashboard — aggregator + endpoint spine.
+
+Step 1 of the autonomy pivot: an OBJECTIVE measurement surface for the O+V
+manifesto goal (a codebase that engineers its own evolution). These tests
+pin the four mandates:
+
+  1. Root-cause / measurement only — the aggregator reads git + session
+     summaries, computes nothing behavioral.
+  2. Architectural purity — dynamically aggregated from existing state, no
+     hardcoded success criteria (only counts + division-guarded ratios).
+  3. DRY — composes auto_committer.ov_coauthor_line() (the canonical marker)
+     and the existing summary.json set; rides the existing observability GET.
+  4. Bulletproof — a landed change is IMPOSSIBLE to count without a
+     trailer-bearing, NON-EMPTY, branch-reachable commit; every zero-output
+     state returns a clean snapshot, never an exception.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import os
+from pathlib import Path
+from typing import Dict, List, Optional
+
+from aiohttp.test_utils import make_mocked_request
+
+import backend.core.ouroboros.governance.autonomy_metrics as am
+
+
+# ---------------------------------------------------------------------------
+# git-log fixture: a fake subprocess.run producing the module's own format
+# ---------------------------------------------------------------------------
+
+_TRAILER = "Co-Authored-By: Ouroboros+Venom <ouroboros@jarvis.trinity>"
+_SIG = "Ouroboros+Venom [O+V] — Autonomous Self-Development Engine"
+
+
+def _commit_block(sha: str, ct: int, body: str, files: List[str]) -> str:
+    hdr = f"{am._REC_SEP}\n{sha}\n{ct}\n{body}\n__OV_AUTONOMY_ENDHDR__"
+    return hdr + "\n" + "\n".join(files) + "\n"
+
+
+def _ov_body(subject: str, risk: str = "SAFE_AUTO", op: str = "op-x") -> str:
+    return (
+        f"{subject}\n\nWhy: because.\n\nOp-ID: {op}\n"
+        f"Risk: {risk} (Green)\nProvider: claude ($0.01)\nFiles: a.py\n\n"
+        f"{_SIG}\n{_TRAILER}\n"
+    )
+
+
+class _FakeGit:
+    """subprocess.run stand-in returning canned git-log stdout."""
+
+    def __init__(self, stdout: str, returncode: int = 0):
+        self._stdout = stdout
+        self._rc = returncode
+
+    def __call__(self, *args, **kwargs):
+        class _R:
+            pass
+        r = _R()
+        r.stdout = self._stdout
+        r.returncode = self._rc
+        return r
+
+
+# now, and session epochs a few hours inside the 30-day window of it. The
+# fake git ignores --since (git does that server-side), so commit times don't
+# matter; sessions ARE filtered in-process by dir-name epoch, so they must sit
+# inside the window. `bt-iso-<epoch>` naming makes the intended epoch explicit.
+_NOW = 4102444800.0            # year ~2100
+_SESS_EPOCH_BASE = int(_NOW - 4800)  # 80 min before now → in-window
+
+
+def _make_repo(tmp_path: Path, summaries: List[Dict]) -> Path:
+    """Create a repo skeleton with .ouroboros/sessions/*/summary.json."""
+    (tmp_path / ".git").mkdir()
+    sess = tmp_path / ".ouroboros" / "sessions"
+    sess.mkdir(parents=True)
+    for i, s in enumerate(summaries):
+        d = sess / f"bt-iso-{_SESS_EPOCH_BASE + i}"
+        d.mkdir()
+        (d / "summary.json").write_text(json.dumps(s), encoding="utf-8")
+    return tmp_path
+
+
+def _agg(tmp_path, git_stdout, summaries, **env):
+    """Run the aggregator against a fake repo + fake git."""
+    repo = _make_repo(tmp_path, summaries)
+    for k, v in env.items():
+        os.environ[k] = v
+    try:
+        return am.aggregate_autonomy_metrics(
+            repo_root=repo,
+            now=_NOW,
+            git_runner=_FakeGit(git_stdout),
+        )
+    finally:
+        for k in env:
+            os.environ.pop(k, None)
+
+
+# ---------------------------------------------------------------------------
+# Bulletproof: what counts as a landed change (mandate 4)
+# ---------------------------------------------------------------------------
+
+
+def test_trailered_nonempty_commit_counts(tmp_path):
+    raw = _commit_block("aaaa1111", 4000000000, _ov_body("fix(x): real"), ["x.py"])
+    snap = _agg(tmp_path, raw, [])
+    assert snap.landed_count == 1
+    assert snap.net_positive_landed == 1
+
+
+def test_commit_without_trailer_never_counts(tmp_path):
+    body = "fix(x): human change\n\nCo-Authored-By: Someone <a@b.c>\n"
+    raw = _commit_block("bbbb2222", 4000000000, body, ["x.py"])
+    snap = _agg(tmp_path, raw, [])
+    assert snap.landed_count == 0
+
+
+def test_trailered_but_empty_diff_never_counts(tmp_path):
+    """Mandate 4: no files changed → NOT genuinely mutated → not landed."""
+    raw = _commit_block("cccc3333", 4000000000, _ov_body("chore: empty"), [])
+    snap = _agg(tmp_path, raw, [])
+    assert snap.landed_count == 0
+
+
+def test_orange_review_commit_excluded(tmp_path):
+    """Human-gated Orange-tier review commits carry the review subject +
+    DO NOT AUTO-MERGE and no trailer — excluded defense-in-depth."""
+    body = (
+        "chore(ouroboros-review): parked change\n\nDO NOT AUTO-MERGE\n\n"
+        "Op-ID: op-o\nRisk: APPROVAL_REQUIRED (Orange)\n"
+    )  # note: no trailer anyway
+    raw = _commit_block("dddd4444", 4000000000, body, ["x.py"])
+    snap = _agg(tmp_path, raw, [])
+    assert snap.landed_count == 0
+
+
+def test_no_ov_marker_reason_code(monkeypatch, tmp_path):
+    """If the canonical marker can't resolve, fail-closed to zero + reason."""
+    monkeypatch.setattr(am, "_ov_trailer", lambda: "")
+    raw = _commit_block("eeee5555", 4000000000, _ov_body("fix: x"), ["x.py"])
+    snap = _agg(tmp_path, raw, [])
+    assert snap.landed_count == 0
+    assert snap.reason_code == "no_ov_marker"
+
+
+# ---------------------------------------------------------------------------
+# Regression rate (mandate 2 — objective, git-provable)
+# ---------------------------------------------------------------------------
+
+
+def test_reverted_landed_reduces_net_positive(tmp_path):
+    landed = _commit_block(
+        "ffff6666aaaa", 4000000000, _ov_body("test(req): torch"), ["r.txt"]
+    )
+    revert = _commit_block(
+        "1111revert", 4000000100,
+        "Revert \"test(req): torch\"\n\nThis reverts commit ffff6666aaaa.\n",
+        ["r.txt"],
+    )
+    snap = _agg(tmp_path, landed + revert, [])
+    assert snap.landed_count == 1
+    assert snap.reverted_landed == 1
+    assert snap.net_positive_landed == 0
+    assert snap.post_landing_regression_rate == 1.0
+
+
+def test_revert_of_nonautonomous_commit_ignored(tmp_path):
+    landed = _commit_block("aaaa7777", 4000000000, _ov_body("fix: keep"), ["k.py"])
+    revert = _commit_block(
+        "2222revert", 4000000100,
+        "Revert \"human thing\"\n\nThis reverts commit deadbeef.\n", ["h.py"],
+    )
+    snap = _agg(tmp_path, landed + revert, [])
+    assert snap.landed_count == 1
+    assert snap.reverted_landed == 0
+    assert snap.post_landing_regression_rate == 0.0
+
+
+def test_pipeline_verify_regressions_from_summaries(tmp_path):
+    raw = _commit_block("aaaa8888", 4000000000, _ov_body("fix: y"), ["y.py"])
+    summaries = [{
+        "duration_s": 1000.0, "cost_total": 0.5,
+        "operations": [
+            {"op_id": "1", "status": "failed",
+             "terminal_reason_code": "verify_regression"},
+            {"op_id": "2", "status": "completed",
+             "terminal_reason_code": "done"},
+            {"op_id": "3", "status": "failed",
+             "terminal_reason_code": "verify_regression"},
+        ],
+    }]
+    snap = _agg(tmp_path, raw, summaries)
+    assert snap.pipeline_caught_verify_regressions == 2
+    assert snap.total_ops_in_window == 3
+
+
+# ---------------------------------------------------------------------------
+# Throughput + cost normalization
+# ---------------------------------------------------------------------------
+
+
+def test_per_unattended_day_and_cost_per_change(tmp_path):
+    raw = (
+        _commit_block("c1aaaa", 4000000000, _ov_body("fix: a", "SAFE_AUTO"), ["a.py"])
+        + _commit_block("c2bbbb", 4000000001, _ov_body("fix: b", "NOTIFY_APPLY"), ["b.py"])
+    )
+    # 43200s = 0.5 day of honest runtime; $1.00 total.
+    summaries = [
+        {"duration_s": 43200.0, "cost_total": 0.6,
+         "cost_breakdown": {"claude": 0.6}, "operations": []},
+        {"duration_s": 0.0, "cost_total": 0.4,
+         "cost_breakdown": {"doubleword": 0.4}, "operations": []},
+    ]
+    snap = _agg(tmp_path, raw, summaries)
+    assert snap.landed_count == 2
+    assert abs(snap.unattended_days - 0.5) < 1e-6
+    assert abs(snap.landed_per_unattended_day - 4.0) < 1e-6  # 2 / 0.5
+    assert abs(snap.total_cost_usd - 1.0) < 1e-9
+    assert abs(snap.cost_per_landed_change_usd - 0.5) < 1e-9
+    assert snap.landed_by_risk_tier == {"safe_auto": 1, "notify_apply": 1}
+
+
+def test_suspension_likely_session_excluded_from_runtime(tmp_path):
+    raw = _commit_block("susp1", 4000000000, _ov_body("fix: s"), ["s.py"])
+    summaries = [
+        {"duration_s": 9999.0, "cost_total": 0.1, "suspension_likely": True,
+         "operations": []},
+        {"duration_s": 86400.0, "cost_total": 0.2, "operations": []},
+    ]
+    snap = _agg(tmp_path, raw, summaries)
+    # Only the honest 1-day session counts toward runtime.
+    assert abs(snap.unattended_days - 1.0) < 1e-6
+    assert snap.sessions_counted == 1
+    assert snap.sessions_suspension_excluded == 1
+
+
+# ---------------------------------------------------------------------------
+# Zero-output safety (mandate 4) — never divide-by-zero, never raise
+# ---------------------------------------------------------------------------
+
+
+def test_zero_landed_zero_runtime_is_clean(tmp_path):
+    snap = _agg(tmp_path, "", [])
+    assert snap.landed_count == 0
+    assert snap.landed_per_unattended_day is None
+    assert snap.post_landing_regression_rate is None
+    assert snap.cost_per_landed_change_usd is None
+    assert snap.reason_code in ("no_git_history", "ok")
+    # to_dict must be fully-formed with Nones, not an exception.
+    d = snap.to_dict()
+    assert d["throughput"]["landed_per_unattended_day"] is None
+    assert d["cost"]["per_landed_change_usd"] is None
+
+
+def test_git_unavailable_returns_clean_snapshot(tmp_path):
+    repo = _make_repo(tmp_path, [])
+    snap = am.aggregate_autonomy_metrics(
+        repo_root=repo, now=4102444800.0,
+        git_runner=_FakeGit("", returncode=128),  # git failure
+    )
+    assert snap.landed_count == 0
+    assert snap.reason_code in ("no_git_history", "ok")
+
+
+def test_malformed_summary_does_not_raise(tmp_path):
+    repo = tmp_path
+    (repo / ".git").mkdir()
+    sess = repo / ".ouroboros" / "sessions" / "bt-2026-07-16-000000"
+    sess.mkdir(parents=True)
+    (sess / "summary.json").write_text("{not valid json", encoding="utf-8")
+    snap = am.aggregate_autonomy_metrics(
+        repo_root=repo, now=4102444800.0, git_runner=_FakeGit(""),
+    )
+    assert snap.sessions_counted == 0  # unparseable summary skipped, no raise
+
+
+def test_aggregator_never_raises_on_internal_fault(monkeypatch, tmp_path):
+    def _boom(*a, **k):
+        raise RuntimeError("git exploded")
+
+    monkeypatch.setattr(am, "_run_git_log", _boom)
+    snap = am.aggregate_autonomy_metrics(repo_root=tmp_path, now=1.0)
+    assert snap.reason_code == "aggregation_error"
+
+
+# ---------------------------------------------------------------------------
+# Env knobs + master flag
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_AUTONOMY_METRICS_ENABLED", raising=False)
+    assert am.master_enabled() is True
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_ENABLED", "0")
+    assert am.master_enabled() is False
+
+
+def test_snapshot_master_off_returns_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_ENABLED", "false")
+    am.reset_cache_for_tests()
+    d = am.snapshot(force=True)
+    assert d["enabled"] is False and d["reason_code"] == "disabled"
+
+
+def test_window_and_branch_env(monkeypatch):
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_WINDOW_DAYS", "7")
+    assert am.window_days() == 7
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_WINDOW_DAYS", "bad")
+    assert am.window_days() == 30
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_BRANCH", "develop")
+    assert am.target_branch() == "develop"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint — mirrors test_ide_observability conventions
+# ---------------------------------------------------------------------------
+
+
+def _make_request(path: str, remote: str = "127.0.0.1"):
+    req = make_mocked_request("GET", path, headers={})
+    req._transport_peername = (remote, 0)  # type: ignore[attr-defined]
+    return req
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _router():
+    from backend.core.ouroboros.governance.ide_observability import (
+        IDEObservabilityRouter,
+    )
+    return IDEObservabilityRouter()
+
+
+def test_endpoint_disabled_when_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "false")
+    resp = _run(_router()._handle_autonomy(_make_request("/observability/autonomy")))
+    assert resp.status == 403
+    body = json.loads(resp.body.decode("utf-8"))
+    assert body["reason_code"] == "ide_observability.disabled"
+    assert "schema_version" in body
+
+
+def test_endpoint_autonomy_substrate_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_ENABLED", "false")
+    resp = _run(_router()._handle_autonomy(_make_request("/observability/autonomy")))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode("utf-8"))["reason_code"] == (
+        "ide_observability.autonomy_disabled"
+    )
+
+
+def test_endpoint_returns_snapshot(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_ENABLED", "true")
+    am.reset_cache_for_tests()
+    resp = _run(_router()._handle_autonomy(_make_request("/observability/autonomy")))
+    assert resp.status == 200
+    body = json.loads(resp.body.decode("utf-8"))
+    assert body["schema_version"] == am.AUTONOMY_METRICS_SCHEMA_VERSION
+    assert "landed" in body and "throughput" in body and "cost" in body
+    assert resp.headers.get("Cache-Control") == "no-store"
+
+
+def test_endpoint_never_500s(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_AUTONOMY_METRICS_ENABLED", "true")
+
+    def _boom(**k):
+        raise RuntimeError("snapshot exploded")
+
+    monkeypatch.setattr(am, "snapshot", _boom)
+    resp = _run(_router()._handle_autonomy(_make_request("/observability/autonomy")))
+    assert resp.status == 200
+    assert json.loads(resp.body.decode("utf-8"))["reason_code"] == (
+        "autonomy.unavailable"
+    )

--- a/tests/governance/test_capability_firing.py
+++ b/tests/governance/test_capability_firing.py
@@ -1,0 +1,223 @@
+"""Capability Firing Dimension — runtime self-perception spine (Gap 2 Step 2).
+
+Proves the precise merkle detector: a capability that is statically REACHABLE
+(ALIVE) but emitted NO runtime firing evidence in the adaptive window is
+flagged DORMANT — the exact class Step 1's static half could not distinguish.
+Markers are DERIVED from each capability's own source (log tags + ledger
+stems); evidence is durable (ledger mtimes + session debug.log markers) over a
+session-anchored window; and a SILENT verdict is high-confidence only when a
+LEDGER evidence-of-work channel went quiet (log-only silence → observability
+gap, not proven dormancy).
+"""
+from __future__ import annotations
+
+import backend.core.ouroboros.governance.capability_firing as cf
+
+
+# ---------------------------------------------------------------------------
+# Marker derivation (from source) — no hardcoding
+# ---------------------------------------------------------------------------
+
+
+def test_derive_log_tag_and_ledger():
+    src = (
+        'logger = logging.getLogger("Ouroboros.MerkleCartographer")\n'
+        'logger.info("[MerkleCartographer] update_full complete")\n'
+        'path = ".jarvis/merkle_history.jsonl"\n'
+    )
+    m = cf.derive_markers(src)
+    assert "MerkleCartographer" in m.tags
+    assert "merkle_history" in m.ledgers
+    assert not m.empty
+
+
+def test_derive_ignores_type_hint_brackets():
+    src = "def f(x: List[Any]) -> Dict[str, Path]:\n    return {}\n"
+    m = cf.derive_markers(src)
+    # List[Any]/Dict[...]/Path are type hints, NOT log tags → no markers.
+    assert "Any" not in m.tags and "Path" not in m.tags
+    assert m.empty
+
+
+def test_derive_empty_source():
+    assert cf.derive_markers("").empty
+
+
+# ---------------------------------------------------------------------------
+# Firing verdict — FIRING / SILENT / UNKNOWN + channels
+# ---------------------------------------------------------------------------
+
+
+def _evidence(markers=(), ledgers=(), window_start=0.0):
+    return cf.FiringEvidence(
+        present_markers=set(markers), active_ledgers=set(ledgers),
+        window_start_unix=window_start,
+    )
+
+
+def test_firing_when_ledger_active():
+    src = 'x = ".jarvis/merkle_history.jsonl"\n'
+    verdict, hits, channels = cf.firing_verdict(src, _evidence(ledgers=["merkle_history"]))
+    assert verdict == "FIRING"
+    assert "ledger:merkle_history" in hits
+    assert "ledger" in channels
+
+
+def test_firing_when_log_tag_present():
+    src = 'logger.info("[MerkleCartographer] swept")\n'
+    verdict, hits, channels = cf.firing_verdict(src, _evidence(markers=["MerkleCartographer"]))
+    assert verdict == "FIRING" and "tag:MerkleCartographer" in hits
+
+
+def test_silent_when_ledger_quiet_is_the_merkle_signature():
+    # Derives a ledger marker, but the ledger is NOT active in-window → SILENT
+    # with a ledger channel = high-confidence dormancy (merkle update_full case).
+    src = 'x = ".jarvis/merkle_history.jsonl"\n'
+    verdict, hits, channels = cf.firing_verdict(src, _evidence(ledgers=["other_ledger"]))
+    assert verdict == "SILENT" and hits == [] and channels == ["ledger"]
+
+
+def test_silent_log_only_is_observability_gap_not_dormant():
+    # Only a log tag, absent → SILENT but log-only (may be running silently).
+    src = 'logger.info("[QuietSubsystem] tick")\n'
+    verdict, hits, channels = cf.firing_verdict(src, _evidence(markers=["Other"]))
+    assert verdict == "SILENT" and channels == ["log"]
+
+
+def test_unknown_when_no_markers():
+    verdict, hits, channels = cf.firing_verdict("def f():\n    return 1\n", _evidence())
+    assert verdict == "UNKNOWN" and hits == [] and channels == []
+
+
+# ---------------------------------------------------------------------------
+# Evidence collection — adaptive window, injectable readers, never raises
+# ---------------------------------------------------------------------------
+
+
+def test_evidence_adaptive_window_from_sessions():
+    # A session named bt-2026-07-16-000000 → epoch anchors the window; the log
+    # text yields present markers; ledger mtimes ≥ window_start are active.
+    sess_epoch = cf._session_epoch("bt-2026-07-16-000000")
+    assert sess_epoch is not None
+    sessions = [("bt-2026-07-16-000000", "[MerkleCartographer] boot\n[Router] go\n")]
+    ledgers = [
+        ("merkle_history", sess_epoch + 10),   # written after window start → active
+        ("stale_ledger", sess_epoch - 100000),  # before window start → inactive
+    ]
+    ev = cf.collect_firing_evidence(
+        __import__("pathlib").Path("/nonexistent"), now=sess_epoch + 100,
+        sessions_reader=lambda: sessions, ledger_reader=lambda: ledgers,
+    )
+    assert "MerkleCartographer" in ev.present_markers
+    assert "Router" in ev.present_markers
+    assert "merkle_history" in ev.active_ledgers
+    assert "stale_ledger" not in ev.active_ledgers
+    assert ev.window_start_unix == sess_epoch
+
+
+def test_evidence_never_raises_on_bad_readers():
+    def _boom():
+        raise RuntimeError("reader down")
+
+    ev = cf.collect_firing_evidence(
+        __import__("pathlib").Path("/x"), now=1000.0,
+        sessions_reader=_boom, ledger_reader=_boom,
+    )
+    assert isinstance(ev, cf.FiringEvidence)  # degrades, no raise
+
+
+def test_build_firing_probe_returns_verdicts():
+    sess_epoch = cf._session_epoch("bt-2026-07-16-000000")
+    probe, ev = cf.build_firing_probe(
+        __import__("pathlib").Path("/x"), now=sess_epoch + 50,
+        sessions_reader=lambda: [("bt-2026-07-16-000000", "[Alpha] hi\n")],
+        ledger_reader=lambda: [("beta_log", sess_epoch + 5)],
+    )
+    assert probe('logger.info("[Alpha] x")\n')[0] == "FIRING"
+    assert probe('p = "beta_log.jsonl"\n')[0] == "FIRING"
+    assert probe('p = "gamma.jsonl"\n')[0] == "SILENT"
+    assert probe("def f(): pass\n")[0] == "UNKNOWN"
+
+
+def test_probe_never_raises():
+    probe, _ = cf.build_firing_probe(
+        __import__("pathlib").Path("/x"), now=1.0,
+        sessions_reader=lambda: [], ledger_reader=lambda: [],
+    )
+    assert probe(None)[0] == "UNKNOWN"  # type: ignore[arg-type]
+
+
+def test_master_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_CAPABILITY_FIRING_ENABLED", raising=False)
+    assert cf.master_enabled() is True
+    monkeypatch.setenv("JARVIS_CAPABILITY_FIRING_ENABLED", "0")
+    assert cf.master_enabled() is False
+
+
+# ---------------------------------------------------------------------------
+# End-to-end integration with capability_liveness — DORMANT detection
+# ---------------------------------------------------------------------------
+
+
+def test_liveness_dormant_end_to_end(tmp_path, monkeypatch):
+    """A reachable capability that writes a ledger, but the ledger went quiet →
+    DORMANT in the combined liveness snapshot (the merkle class)."""
+    import backend.core.ouroboros.governance.capability_liveness as cl
+    import backend.core.ouroboros.governance.flag_registry as fr
+    from tests.governance.test_capability_liveness import (
+        _FakeRegistry, _FakeSpec, _repo, _write,
+    )
+
+    repo = _repo(tmp_path)
+    # A capability module: a called function (→ ALIVE) that writes a ledger.
+    mod = _write(repo, "backend/gov/sweeper.py",
+                 'def sweep():\n    open(".jarvis/sweep_history.jsonl", "a")\n    return 1\n')
+    _write(repo, "backend/gov/driver.py",
+           "from backend.gov.sweeper import sweep\n\ndef boot():\n    return sweep()\n")
+    monkeypatch.setattr(fr, "ensure_seeded",
+                        lambda: _FakeRegistry([_FakeSpec("JARVIS_SWEEP_ENABLED", mod)]))
+    # Inject a firing probe whose evidence has NO active ledgers (sweep_history
+    # never written in-window) → the reachable capability is DORMANT.
+    probe, _ev = cf.build_firing_probe(
+        repo, now=1000.0,
+        sessions_reader=lambda: [], ledger_reader=lambda: [],
+    )
+    cl.reset_cache_for_tests()
+    snap = cl.aggregate_capability_liveness(
+        repo_root=repo, now=1000.0, firing_probe=probe,
+    )
+    assert snap.counts.get("ALIVE") == 1              # statically reachable
+    assert len(snap.dormant) == 1                     # but ledger went quiet
+    assert snap.dormant[0]["flag"] == "JARVIS_SWEEP_ENABLED"
+    assert snap.dormant[0]["firing"] == "SILENT"
+    assert "ledger" in snap.dormant[0]["firing_channels"]
+
+
+def test_liveness_firing_marks_not_dormant(tmp_path, monkeypatch):
+    """Same capability, but its ledger IS active in-window → FIRING, not
+    dormant (the merkle post-Slice-31 case)."""
+    import backend.core.ouroboros.governance.capability_liveness as cl
+    import backend.core.ouroboros.governance.flag_registry as fr
+    from tests.governance.test_capability_liveness import (
+        _FakeRegistry, _FakeSpec, _repo, _write,
+    )
+
+    repo = _repo(tmp_path)
+    mod = _write(repo, "backend/gov/sweeper2.py",
+                 'def sweep2():\n    open(".jarvis/sweep2_history.jsonl", "a")\n    return 1\n')
+    _write(repo, "backend/gov/driver2.py",
+           "from backend.gov.sweeper2 import sweep2\n\ndef boot():\n    return sweep2()\n")
+    monkeypatch.setattr(fr, "ensure_seeded",
+                        lambda: _FakeRegistry([_FakeSpec("JARVIS_SWEEP2_ENABLED", mod)]))
+    probe, _ev = cf.build_firing_probe(
+        repo, now=1000.0,
+        sessions_reader=lambda: [],
+        ledger_reader=lambda: [("sweep2_history", 999.0)],  # active in-window
+    )
+    cl.reset_cache_for_tests()
+    snap = cl.aggregate_capability_liveness(
+        repo_root=repo, now=1000.0, firing_probe=probe,
+    )
+    assert snap.counts.get("ALIVE") == 1
+    assert len(snap.dormant) == 0
+    assert snap.firing_evidence.get("counts", {}).get("FIRING") == 1

--- a/tests/governance/test_capability_liveness.py
+++ b/tests/governance/test_capability_liveness.py
@@ -1,0 +1,287 @@
+"""Capability Liveness Audit — self-perception spine (autonomy pivot Gap 2).
+
+Proves the organism can now SEE its own inert capabilities: the severed-driver
+class (the merkle archetype — a public callable defined but invoked by no
+production code) is DETECTED, a genuinely-called one is ALIVE, and every
+zero-output / fault path returns a clean snapshot rather than raising.
+
+Tests drive the REAL code path: synthetic capability modules on disk under a
+tmp ``backend/`` so both AST symbol-parsing and the ripgrep-free caller-index
+walk exercise production logic; only the FlagRegistry is faked (to control
+which capabilities are declared).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+
+from aiohttp.test_utils import make_mocked_request
+
+import backend.core.ouroboros.governance.capability_liveness as cl
+from backend.core.ouroboros.governance.flag_registry import FlagType
+
+
+# ---------------------------------------------------------------------------
+# Fake FlagRegistry (control which capabilities are declared) + tmp repo
+# ---------------------------------------------------------------------------
+
+
+class _FakeSpec:
+    def __init__(self, name, source_file, category="OBSERVABILITY", default=True):
+        self.name = name
+        self.source_file = source_file
+        self.type = FlagType.BOOL
+        self.category = category
+        self.default = default
+
+
+class _FakeRegistry:
+    def __init__(self, specs, on=True):
+        self._specs = specs
+        self._on = on
+
+    def list_all(self):
+        return list(self._specs)
+
+    def get_bool(self, name, **kw):
+        return self._on
+
+
+def _install_fake_registry(monkeypatch, specs, on=True):
+    import backend.core.ouroboros.governance.flag_registry as fr
+    monkeypatch.setattr(fr, "ensure_seeded", lambda: _FakeRegistry(specs, on=on))
+
+
+def _repo(tmp_path: Path) -> Path:
+    (tmp_path / ".git").mkdir()
+    (tmp_path / "backend" / "gov").mkdir(parents=True)
+    return tmp_path
+
+
+def _write(repo: Path, rel: str, body: str) -> str:
+    p = repo / rel
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(body, encoding="utf-8")
+    return rel
+
+
+def _agg(repo, specs, monkeypatch, on=True):
+    _install_fake_registry(monkeypatch, specs, on=on)
+    cl.reset_cache_for_tests()
+    return cl.aggregate_capability_liveness(repo_root=repo, now=1000.0)
+
+
+# ---------------------------------------------------------------------------
+# Severed-driver DETECTION (the merkle archetype) — the load-bearing test
+# ---------------------------------------------------------------------------
+
+
+def test_severed_driver_is_detected(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    # A driver defined but invoked by NO production code = the merkle bug.
+    sev = _write(repo, "backend/gov/sev_mod.py", "def hydrate_driver():\n    return 1\n")
+    specs = [_FakeSpec("JARVIS_SEV_ENABLED", sev)]
+    snap = _agg(repo, specs, monkeypatch)
+    verdicts = {v["flag"]: v for v in snap.severance_candidates + snap.fully_severed}
+    assert "JARVIS_SEV_ENABLED" in verdicts
+    v = verdicts["JARVIS_SEV_ENABLED"]
+    assert v["verdict"] == "FULLY_SEVERED"          # its only callable is severed
+    assert "hydrate_driver" in v["severed_symbols"]
+
+
+def test_called_capability_is_alive(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    live = _write(repo, "backend/gov/live_mod.py", "def entry():\n    return 1\n")
+    # A production consumer that actually calls it.
+    _write(repo, "backend/gov/consumer.py",
+           "from backend.gov.live_mod import entry\n\ndef use():\n    return entry()\n")
+    specs = [_FakeSpec("JARVIS_LIVE_ENABLED", live)]
+    snap = _agg(repo, specs, monkeypatch)
+    assert snap.counts.get("ALIVE") == 1
+    assert not snap.severance_candidates and not snap.fully_severed
+
+
+def test_definition_line_is_not_a_caller(tmp_path, monkeypatch):
+    """The merkle regression: ``def NAME(`` / ``class NAME(`` must NOT be
+    counted as a call site, else a defined-but-never-called driver looks
+    reachable."""
+    repo = _repo(tmp_path)
+    sev = _write(repo, "backend/gov/only_def.py",
+                 "def lonely():\n    return 2\n\nclass Holder:\n    def m(self):\n        return 3\n")
+    snap = _agg(repo, specs=[_FakeSpec("JARVIS_ONLYDEF_ENABLED", sev)], monkeypatch=monkeypatch)
+    v = (snap.severance_candidates + snap.fully_severed)[0]
+    # Both the function and the method are defined-only → severed.
+    assert v["verdict"] == "FULLY_SEVERED"
+    assert set(v["severed_symbols"]) == {"lonely", "m"}
+
+
+def test_method_call_site_marks_alive(tmp_path, monkeypatch):
+    """A method invoked via ``.name(`` counts as a caller (the merkle
+    ``update_full`` post-fix shape)."""
+    repo = _repo(tmp_path)
+    mod = _write(repo, "backend/gov/svc.py",
+                 "class Svc:\n    def update_full(self):\n        return 1\n")
+    _write(repo, "backend/gov/driver.py",
+           "def boot(s):\n    return s.update_full()\n")
+    snap = _agg(repo, [_FakeSpec("JARVIS_SVC_ENABLED", mod)], monkeypatch)
+    assert snap.counts.get("ALIVE") == 1
+
+
+def test_tests_dir_callers_excluded(tmp_path, monkeypatch):
+    """A driver called ONLY from tests is still severed (production dead)."""
+    repo = _repo(tmp_path)
+    sev = _write(repo, "backend/gov/tonly.py", "def driver():\n    return 1\n")
+    _write(repo, "backend/gov/tests/test_x.py",
+           "from backend.gov.tonly import driver\n\ndef test_d():\n    assert driver()\n")
+    snap = _agg(repo, [_FakeSpec("JARVIS_TONLY_ENABLED", sev)], monkeypatch)
+    assert snap.fully_severed and snap.fully_severed[0]["flag"] == "JARVIS_TONLY_ENABLED"
+
+
+def test_partial_severance_is_a_candidate_not_fully(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    mod = _write(repo, "backend/gov/mixed.py",
+                 "def used():\n    return 1\n\ndef dead():\n    return 2\n")
+    _write(repo, "backend/gov/c.py", "from backend.gov.mixed import used\n\ndef go():\n    return used()\n")
+    snap = _agg(repo, [_FakeSpec("JARVIS_MIXED_ENABLED", mod)], monkeypatch)
+    cand = snap.severance_candidates
+    assert cand and cand[0]["verdict"] == "SEVERED"
+    assert cand[0]["severed_symbols"] == ["dead"]
+    assert 0.0 < cand[0]["fraction_severed"] < 1.0
+
+
+# ---------------------------------------------------------------------------
+# Enumeration + disabled + unresolved
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_capability_not_audited(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    sev = _write(repo, "backend/gov/off_mod.py", "def d():\n    return 1\n")
+    # Flag registered but live-off → not our concern (constellation-DARK axis).
+    snap = _agg(repo, [_FakeSpec("JARVIS_OFF_ENABLED", sev)], monkeypatch, on=False)
+    assert snap.capabilities_declared == 0
+    assert not snap.severance_candidates and not snap.fully_severed
+
+
+def test_seed_sourced_flag_is_unresolved(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    specs = [_FakeSpec("JARVIS_SEED_ENABLED",
+                       "backend/core/ouroboros/governance/flag_registry_seed.py")]
+    snap = _agg(repo, specs, monkeypatch)
+    assert snap.counts.get("UNRESOLVED") == 1
+
+
+def test_non_enabled_flags_ignored(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    m = _write(repo, "backend/gov/x.py", "def d():\n    return 1\n")
+    specs = [_FakeSpec("JARVIS_SOME_TUNING", m)]  # not *_ENABLED
+    snap = _agg(repo, specs, monkeypatch)
+    assert snap.capabilities_declared == 0
+
+
+# ---------------------------------------------------------------------------
+# Zero-output safety + never-raises
+# ---------------------------------------------------------------------------
+
+
+def test_no_capabilities_is_clean(tmp_path, monkeypatch):
+    repo = _repo(tmp_path)
+    snap = _agg(repo, [], monkeypatch)
+    assert snap.capabilities_declared == 0
+    assert snap.callable_reachability_ratio is None
+    d = snap.to_dict()
+    assert d["capabilities"]["callable_reachability_ratio"] is None
+    assert d["fully_severed"] == [] and d["severance_candidates"] == []
+
+
+def test_flag_registry_unavailable_is_clean(tmp_path, monkeypatch):
+    import backend.core.ouroboros.governance.flag_registry as fr
+
+    def _boom():
+        raise RuntimeError("registry down")
+
+    monkeypatch.setattr(fr, "ensure_seeded", _boom)
+    cl.reset_cache_for_tests()
+    snap = cl.aggregate_capability_liveness(repo_root=tmp_path, now=1.0)
+    assert snap.reason_code == "flag_registry_unavailable"
+
+
+def test_aggregator_never_raises(monkeypatch, tmp_path):
+    monkeypatch.setattr(cl, "_build_caller_index", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("x")))
+    _install_fake_registry(monkeypatch, [_FakeSpec("JARVIS_X_ENABLED", "backend/gov/x.py")])
+    cl.reset_cache_for_tests()
+    snap = cl.aggregate_capability_liveness(repo_root=tmp_path, now=1.0)
+    assert snap.reason_code == "aggregation_error"
+
+
+def test_master_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_CAPABILITY_LIVENESS_ENABLED", raising=False)
+    assert cl.master_enabled() is True
+    monkeypatch.setenv("JARVIS_CAPABILITY_LIVENESS_ENABLED", "0")
+    assert cl.master_enabled() is False
+
+
+def test_snapshot_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_CAPABILITY_LIVENESS_ENABLED", "false")
+    cl.reset_cache_for_tests()
+    d = cl.snapshot(force=True)
+    assert d["enabled"] is False and d["reason_code"] == "disabled"
+
+
+# ---------------------------------------------------------------------------
+# Endpoint — mirrors the dashboard/observability conventions
+# ---------------------------------------------------------------------------
+
+
+def _req(path="/observability/liveness"):
+    r = make_mocked_request("GET", path, headers={})
+    r._transport_peername = ("127.0.0.1", 0)  # type: ignore[attr-defined]
+    return r
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _router():
+    from backend.core.ouroboros.governance.ide_observability import IDEObservabilityRouter
+    return IDEObservabilityRouter()
+
+
+def test_endpoint_disabled_when_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "false")
+    resp = _run(_router()._handle_capability_liveness(_req()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.disabled"
+
+
+def test_endpoint_substrate_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CAPABILITY_LIVENESS_ENABLED", "false")
+    resp = _run(_router()._handle_capability_liveness(_req()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.liveness_disabled"
+
+
+def test_endpoint_returns_snapshot(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CAPABILITY_LIVENESS_ENABLED", "true")
+    # Fake a trivial registry so the endpoint's real aggregation is instant.
+    _install_fake_registry(monkeypatch, [])
+    cl.reset_cache_for_tests()
+    resp = _run(_router()._handle_capability_liveness(_req()))
+    assert resp.status == 200
+    body = json.loads(resp.body.decode())
+    assert body["schema_version"] == cl.CAPABILITY_LIVENESS_SCHEMA_VERSION
+    assert "capabilities" in body and "fully_severed" in body
+    assert resp.headers.get("Cache-Control") == "no-store"
+
+
+def test_endpoint_never_500s(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CAPABILITY_LIVENESS_ENABLED", "true")
+    monkeypatch.setattr(cl, "snapshot", lambda **k: (_ for _ in ()).throw(RuntimeError("boom")))
+    resp = _run(_router()._handle_capability_liveness(_req()))
+    assert resp.status == 200
+    assert json.loads(resp.body.decode())["reason_code"] == "liveness.unavailable"

--- a/tests/governance/test_conception_proposal_bridge.py
+++ b/tests/governance/test_conception_proposal_bridge.py
@@ -1,0 +1,277 @@
+"""Conception Proposal Bridge — ranked blueprints → intake router (Gap 3 unify).
+
+Proves the bridge is a pure, event-driven translation layer that routes
+high-EV blueprints into the existing router and NOTHING more: a dynamic
+batch-relative threshold (no hardcoded cutoff), a bulletproof durable dedup so
+an already-routed / in-execution blueprint is dropped (the mandate-4 constraint),
+DRY reuse of the value model's emitted EV + the make_envelope schema +
+router.ingest, master-off inertness, and never-raise.
+"""
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from typing import List, Tuple
+
+import backend.core.ouroboros.governance.conception_proposal_bridge as cpb
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _BP:
+    blueprint_id: str
+    target_files: Tuple[str, ...]
+    description: str = "improve X"
+    title: str = "X"
+    category: str = "performance"
+    repo: str = "repo"
+    estimated_cost_usd: float = 0.0
+
+
+@dataclass
+class _EV:
+    ev: float
+    scope: str = "svc"
+    alignment: float = 0.5
+    substance: float = 0.5
+    feasibility: float = 0.5
+    rationale: str = "r"
+
+    def to_dict(self):
+        return {"ev": self.ev, "scope": self.scope}
+
+
+class _FakeRouter:
+    """Records ingested envelopes; returns 'enqueued' (or a scripted result)."""
+
+    def __init__(self, result="enqueued"):
+        self.ingested: List[object] = []
+        self._result = result
+
+    async def ingest(self, envelope):
+        self.ingested.append(envelope)
+        return self._result
+
+
+def _bridge(ev_map, **kw):
+    """A bridge whose scorer maps blueprint_id → a fixed EV."""
+    return cpb.ConceptionProposalBridge(
+        value_scorer=lambda bp: _EV(ev_map[bp.blueprint_id]),
+        ledger_emit=lambda **k: None,   # silence the ledger in unit tests
+        **kw,
+    )
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _enable(monkeypatch, floor=0.5):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_EV_FLOOR", str(floor))
+
+
+# ---------------------------------------------------------------------------
+# Master gating / inertness
+# ---------------------------------------------------------------------------
+
+
+def test_master_default_off():
+    import os
+    os.environ.pop("JARVIS_CONCEPTION_BRIDGE_ENABLED", None)
+    assert cpb.master_enabled() is False
+
+
+def test_disabled_routes_nothing(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "false")
+    r = _FakeRouter()
+    out = _run(_bridge({"a": 0.99}).route([_BP("a", ("f.py",))], r))
+    assert out == [] and r.ingested == []
+
+
+# ---------------------------------------------------------------------------
+# Dynamic, batch-relative threshold — no hardcoded cutoff
+# ---------------------------------------------------------------------------
+
+
+def test_dynamic_threshold_routes_above_batch_mean(monkeypatch):
+    _enable(monkeypatch, floor=0.0)   # isolate the batch-mean behavior
+    r = _FakeRouter()
+    bps = [_BP("hi", ("a.py",)), _BP("lo", ("b.py",))]
+    out = _run(_bridge({"hi": 0.9, "lo": 0.1}).route(bps, r))
+    routed = {o.blueprint_id for o in out if o.routed}
+    below = {o.blueprint_id for o in out if o.reason == "below_threshold"}
+    assert routed == {"hi"} and below == {"lo"}         # mean=0.5 → only hi clears
+    assert len(r.ingested) == 1
+
+
+def test_ev_floor_blocks_cold_organism(monkeypatch):
+    _enable(monkeypatch, floor=0.5)
+    r = _FakeRouter()
+    # A whole batch at the neutral prior — nothing clears the floor.
+    bps = [_BP("a", ("a.py",)), _BP("b", ("b.py",))]
+    out = _run(_bridge({"a": 0.4, "b": 0.45}).route(bps, r))
+    assert all(not o.routed for o in out) and r.ingested == []
+
+
+def test_threshold_rises_with_batch_quality(monkeypatch):
+    _enable(monkeypatch, floor=0.5)
+    r = _FakeRouter()
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_MAX_PER_ROUTE", "5")
+    # strong batch: mean 0.8 → only the 0.95 clears, the 0.7/0.75 do not.
+    bps = [_BP("x", ("x.py",)), _BP("y", ("y.py",)), _BP("z", ("z.py",))]
+    out = _run(_bridge({"x": 0.95, "y": 0.75, "z": 0.70}).route(bps, r))
+    routed = {o.blueprint_id for o in out if o.routed}
+    assert routed == {"x"}
+
+
+def test_max_per_route_caps_survivors(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_MAX_PER_ROUTE", "2")
+    r = _FakeRouter()
+    bps = [_BP(str(i), (f"{i}.py",)) for i in range(5)]
+    out = _run(_bridge({str(i): 0.9 for i in range(5)}).route(bps, r))
+    assert sum(o.routed for o in out) == 2 and len(r.ingested) == 2
+
+
+# ---------------------------------------------------------------------------
+# Bulletproof dedup — the mandate-4 constraint
+# ---------------------------------------------------------------------------
+
+
+def test_already_routed_blueprint_is_dropped(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter()
+    b = _bridge({"a": 0.9})
+    # First event routes it.
+    out1 = _run(b.route([_BP("a", ("a.py",))], r))
+    assert sum(o.routed for o in out1) == 1 and len(r.ingested) == 1
+    # Second event with the SAME blueprint_id — dropped, NOT re-ingested.
+    out2 = _run(b.route([_BP("a", ("a.py",))], r))
+    assert all(not o.routed for o in out2)
+    assert any(o.reason == "duplicate" for o in out2)
+    assert len(r.ingested) == 1   # router never saw it twice
+
+
+def test_router_side_dedup_result_still_marks_routed(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter(result="deduplicated")   # router already had it
+    b = _bridge({"a": 0.9})
+    out = _run(b.route([_BP("a", ("a.py",))], r))
+    assert any(o.routed for o in out)                 # in-queue counts as routed
+    # subsequent pass is deduped by our durable registry, not re-sent
+    out2 = _run(b.route([_BP("a", ("a.py",))], r))
+    assert len(r.ingested) == 1 and any(o.reason == "duplicate" for o in out2)
+
+
+def test_dedup_registry_ttl_and_capacity(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_DEDUP_TTL_S", "100")
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_DEDUP_CAPACITY", "16")
+    reg = cpb._RoutedRegistry()
+    reg.mark("a", now=1000.0)
+    assert reg.is_routed("a", now=1050.0) is True     # within TTL
+    assert reg.is_routed("a", now=1200.0) is False    # expired
+    # capacity bound
+    for i in range(40):
+        reg.mark(f"b{i}", now=2000.0 + i)
+    assert len(reg) <= 16
+
+
+def test_envelope_signature_is_blueprint_id(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter()
+    _run(_bridge({"bp-42": 0.9}).route([_BP("bp-42", ("a.py",))], r))
+    env = r.ingested[0]
+    assert env.evidence["signature"] == "bp-42"       # drives router dedup_key
+    assert env.evidence["blueprint_id"] == "bp-42"
+    assert env.source == "auto_proposed"
+    assert env.target_files == ("a.py",)
+    assert "conception_value" in env.evidence
+
+
+# ---------------------------------------------------------------------------
+# Robustness
+# ---------------------------------------------------------------------------
+
+
+def test_blueprint_without_target_files_is_skipped(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter()
+    out = _run(_bridge({"a": 0.9}).route([_BP("a", ())], r))
+    assert out == [] and r.ingested == []
+
+
+def test_never_raises_on_bad_router(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+
+    class _Boom:
+        async def ingest(self, e):
+            raise RuntimeError("boom")
+
+    out = _run(_bridge({"a": 0.9}).route([_BP("a", ("a.py",))], _Boom()))
+    assert any(o.reason == "error" for o in out)      # captured, not raised
+
+
+def test_null_router_is_inert(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    assert _run(_bridge({"a": 0.9}).route([_BP("a", ("a.py",))], None)) == []
+
+
+def test_scorer_fault_skips_blueprint(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter()
+    b = cpb.ConceptionProposalBridge(
+        value_scorer=lambda bp: (_ for _ in ()).throw(ValueError("x")),
+        ledger_emit=lambda **k: None,
+    )
+    out = _run(b.route([_BP("a", ("a.py",))], r))
+    assert out == [] and r.ingested == []
+
+
+# ---------------------------------------------------------------------------
+# Event wiring + observability
+# ---------------------------------------------------------------------------
+
+
+def test_observer_pulls_batch_and_routes(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter()
+    b = _bridge({"a": 0.9, "b": 0.1})
+    batch = [_BP("a", ("a.py",)), _BP("b", ("b.py",))]
+    obs = b.make_observer(r, blueprint_source=lambda: batch)
+    _run(obs(_BP("a", ("a.py",))))   # event carries one bp; observer pulls batch
+    assert len(r.ingested) == 1 and r.ingested[0].evidence["blueprint_id"] == "a"
+
+
+def test_observer_faulty_source_is_safe(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter()
+    obs = _bridge({"a": 0.9}).make_observer(
+        r, blueprint_source=lambda: (_ for _ in ()).throw(RuntimeError("src")))
+    _run(obs(_BP("a", ("a.py",))))   # must not raise
+    assert r.ingested == []
+
+
+def test_snapshot_shape(monkeypatch):
+    _enable(monkeypatch, floor=0.0)
+    r = _FakeRouter()
+    b = _bridge({"a": 0.9})
+    _run(b.route([_BP("a", ("a.py",))], r))
+    snap = b.snapshot()
+    assert snap["schema_version"] == cpb.CONCEPTION_BRIDGE_SCHEMA_VERSION
+    assert snap["enabled"] is True
+    assert snap["counters"]["routed_total"] == 1
+    assert snap["dedup_registry_size"] == 1
+
+
+def test_module_is_authority_free():
+    import inspect
+    src = inspect.getsource(cpb)
+    banned = ("iron_gate", "risk_tier_floor", "semantic_guardian", "policy_engine",
+              "orchestrator", "tool_executor", "scoped_tool_backend")
+    for b in banned:
+        assert f"import {b}" not in src and f"governance.{b}" not in src, b

--- a/tests/governance/test_conception_value_model.py
+++ b/tests/governance/test_conception_value_model.py
@@ -1,0 +1,269 @@
+"""Conception Value Model — expected-value ranker for self-conceived work (Gap 3).
+
+Proves the model ranks conceived proposals by a composed expected value that is
+evidence-grounded and Gap-4-aware: high strategic alignment + real substance +
+EARNED trust + low cost ranks above the opposite; a fresh regression damps
+feasibility; a proven-cosmetic band scores below the neutral prior; cost is
+monotonic; every axis degrades to a neutral prior when its source is cold (a
+fresh organism ranks by what it can see, never collapsing to zero); disabled is
+inert; and nothing ever raises.
+"""
+from __future__ import annotations
+
+import backend.core.ouroboros.governance.conception_value_model as cvm
+
+
+def _score(**kw):
+    base = dict(
+        description="x", target_files=["a.py"], estimated_cost_usd=0.0,
+        align_fn=lambda d, r: (0.5, True),
+        substance_fn=lambda s, t, r: (0.5, 0),
+        feasibility_fn=lambda sc: (0.5, "unknown", False),
+    )
+    base.update(kw)
+    return cvm.score_proposal(**base)
+
+
+# ---------------------------------------------------------------------------
+# Composition + ranking
+# ---------------------------------------------------------------------------
+
+
+def test_high_all_axes_ranks_above_low():
+    hi = _score(align_fn=lambda d, r: (0.95, True),
+                substance_fn=lambda s, t, r: (1.0, 3),
+                feasibility_fn=lambda sc: (1.0, "high", False))
+    lo = _score(align_fn=lambda d, r: (0.1, True),
+                substance_fn=lambda s, t, r: (0.33, 1),
+                feasibility_fn=lambda sc: (0.3, "low", False))
+    assert hi.ev > lo.ev
+    assert hi.ev > 0.8 and lo.ev < 0.4
+
+
+def test_ev_is_weighted_mean_scaled_by_cost(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_W_ALIGN", "1")
+    monkeypatch.setenv("JARVIS_CONCEPTION_W_SUBSTANCE", "1")
+    monkeypatch.setenv("JARVIS_CONCEPTION_W_FEASIBILITY", "1")
+    ev = _score(estimated_cost_usd=0.0,
+                align_fn=lambda d, r: (0.6, True),
+                substance_fn=lambda s, t, r: (0.6, 2),
+                feasibility_fn=lambda sc: (0.6, "medium", False))
+    assert abs(ev.ev - 0.6) < 1e-6   # equal weights, no cost → the mean
+
+
+def test_rank_proposals_orders_desc():
+    a = _score(feasibility_fn=lambda sc: (0.1, "low", False))
+    b = _score(feasibility_fn=lambda sc: (0.9, "high", False))
+    ranked = cvm.rank_proposals([("a", a), ("b", b)])
+    assert [k for k, _ in ranked] == ["b", "a"]
+
+
+# ---------------------------------------------------------------------------
+# Gap-4 composition: earned trust is the feasibility axis
+# ---------------------------------------------------------------------------
+
+
+def test_fresh_regression_damps_feasibility(monkeypatch):
+    """The damp lives IN the real feasibility axis (score_proposal trusts the
+    axis value), so drive the axis directly via a stubbed scope_trust."""
+    import backend.core.ouroboros.governance.trust_calibration as tc
+    from backend.core.ouroboros.governance.trust_calibration import ScopeTrust
+
+    monkeypatch.setenv("JARVIS_CONCEPTION_REGRESSION_DAMP", "0.5")
+
+    def _st(recent):
+        return lambda scope, **k: ScopeTrust(
+            scope=scope, trust_level="high", held_up_rate=0.95, sample_count=20,
+            held_up=19, reverted=1, recent_regression=recent, last_landed_unix=0.0)
+
+    monkeypatch.setattr(tc, "scope_trust", _st(False))
+    clean_v, _, clean_reg = cvm._feasibility_axis("svc")
+    monkeypatch.setattr(tc, "scope_trust", _st(True))
+    broke_v, _, broke_reg = cvm._feasibility_axis("svc")
+
+    assert clean_v == 1.0 and clean_reg is False
+    assert broke_v == 0.5 and broke_reg is True   # 1.0 × 0.5 damp
+    assert broke_v < clean_v
+
+
+def test_real_feasibility_axis_reads_trust_calibration(monkeypatch):
+    """The default feasibility axis composes trust_calibration.scope_trust."""
+    import backend.core.ouroboros.governance.trust_calibration as tc
+    from backend.core.ouroboros.governance.trust_calibration import ScopeTrust
+
+    monkeypatch.setattr(tc, "scope_trust", lambda scope, **k: ScopeTrust(
+        scope=scope, trust_level="high", held_up_rate=0.95, sample_count=20,
+        held_up=19, reverted=1, recent_regression=False, last_landed_unix=0.0))
+    v, level, regressed = cvm._feasibility_axis("svc")
+    assert level == "high" and v == 1.0 and regressed is False
+
+
+# ---------------------------------------------------------------------------
+# Substance: verifiable-evidence-first, cosmetic below neutral
+# ---------------------------------------------------------------------------
+
+
+def test_cosmetic_band_below_neutral_indeterminate_at_neutral():
+    cosmetic = _score(substance_fn=lambda s, t, r: (cvm._BAND_AXIS[1], 1))
+    indeterm = _score(substance_fn=lambda s, t, r: (cvm._BAND_AXIS[0], 0))
+    assert cvm._BAND_AXIS[1] < cvm._NEUTRAL == cvm._BAND_AXIS[0]
+    assert cosmetic.ev < indeterm.ev
+
+
+def test_band_axis_monotonic():
+    assert (cvm._BAND_AXIS[1] < cvm._BAND_AXIS[2] < cvm._BAND_AXIS[3])
+
+
+# ---------------------------------------------------------------------------
+# Cost efficiency
+# ---------------------------------------------------------------------------
+
+
+def test_cost_factor_monotonic_decreasing():
+    assert cvm._cost_factor(0.0) == 1.0
+    assert cvm._cost_factor(0.0) > cvm._cost_factor(0.1) > cvm._cost_factor(5.0)
+
+
+def test_cheaper_proposal_wins_all_else_equal():
+    cheap = _score(estimated_cost_usd=0.0)
+    dear = _score(estimated_cost_usd=1.0)
+    assert cheap.ev > dear.ev
+
+
+# ---------------------------------------------------------------------------
+# Cold-axis neutrality — a fresh organism ranks by what it can see
+# ---------------------------------------------------------------------------
+
+
+def test_cold_axes_degrade_to_neutral_not_zero():
+    # all default seams, but force the alignment axis to report "cold".
+    ev = _score(align_fn=lambda d, r: (cvm._NEUTRAL, False))
+    assert ev.alignment_known is False
+    assert 0.3 < ev.ev < 0.7   # neutral-ish, never collapsed to 0
+
+
+def test_real_alignment_axis_cold_index_is_neutral_unknown():
+    # With no built semantic index the real axis must report neutral+unknown.
+    v, known = cvm._alignment_axis("some proposal text", None)
+    assert v == cvm._NEUTRAL and known is False
+
+
+def test_empty_description_alignment_unknown():
+    v, known = cvm._alignment_axis("   ", None)
+    assert v == cvm._NEUTRAL and known is False
+
+
+# ---------------------------------------------------------------------------
+# Disabled = inert, never-raise, adapters
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_is_inert(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_VALUE_MODEL_ENABLED", "false")
+    ev = cvm.score_proposal(description="x", target_files=["a.py"], estimated_cost_usd=0.0)
+    assert ev.rationale == "model_disabled"
+    assert ev.ev == cvm._NEUTRAL   # neutral × cost_factor(0)=1
+
+
+def test_master_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_CONCEPTION_VALUE_MODEL_ENABLED", raising=False)
+    assert cvm.master_enabled() is True
+    monkeypatch.setenv("JARVIS_CONCEPTION_VALUE_MODEL_ENABLED", "0")
+    assert cvm.master_enabled() is False
+
+
+def test_score_blueprint_adapter():
+    class _BP:
+        description = "Add caching to the oracle lookup"
+        title = "cache oracle"
+        target_files = ("backend/core/ouroboros/oracle.py",)
+        estimated_cost_usd = 0.03
+    ev = cvm.score_blueprint(_BP())
+    assert 0.0 <= ev.ev <= 1.0 and ev.scope
+
+    class _Broken:  # unknown shape → neutral, never raises
+        pass
+    ev2 = cvm.score_blueprint(_Broken())
+    assert 0.0 <= ev2.ev <= 1.0
+
+
+def test_priority_hint_for_returns_ev_in_unit_range():
+    h = cvm.priority_hint_for(description="x", target_files=["a.py"], estimated_cost_usd=0.1)
+    assert 0.0 <= h <= 1.0
+
+
+def test_never_raises_on_garbage():
+    ev = cvm.score_proposal(description=None, target_files=None, estimated_cost_usd="oops")  # type: ignore[arg-type]
+    assert 0.0 <= ev.ev <= 1.0
+
+
+def test_rank_proposals_never_raises_on_bad_input():
+    assert cvm.rank_proposals([("a", None)]) is not None  # type: ignore[list-item]
+
+
+def test_snapshot_shape():
+    snap = cvm.snapshot()
+    assert snap["schema_version"] == cvm.CONCEPTION_VALUE_SCHEMA_VERSION
+    assert set(snap["weights"]) == {"alignment", "substance", "feasibility"}
+    assert "axes" in snap and "feasibility" in snap["axes"]
+
+
+# ---------------------------------------------------------------------------
+# Authority invariant + /observability/conception endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_module_is_authority_free():
+    """It composes read-only scorers; it must NOT import gate/policy/orchestrator."""
+    import inspect
+    src = inspect.getsource(cvm)
+    banned = ("iron_gate", "risk_tier_floor", "semantic_guardian", "policy_engine",
+              "orchestrator", "tool_executor", "scoped_tool_backend")
+    for b in banned:
+        assert f"import {b}" not in src and f"governance.{b}" not in src, b
+
+
+def _run(coro):
+    import asyncio
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _creq():
+    from aiohttp.test_utils import make_mocked_request
+    r = make_mocked_request("GET", "/observability/conception", headers={})
+    r._transport_peername = ("127.0.0.1", 0)  # type: ignore[attr-defined]
+    return r
+
+
+def _crouter():
+    from backend.core.ouroboros.governance.ide_observability import IDEObservabilityRouter
+    return IDEObservabilityRouter()
+
+
+def test_endpoint_disabled_master_off(monkeypatch):
+    import json
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "false")
+    resp = _run(_crouter()._handle_conception_value(_creq()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.disabled"
+
+
+def test_endpoint_substrate_off(monkeypatch):
+    import json
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CONCEPTION_VALUE_MODEL_ENABLED", "false")
+    resp = _run(_crouter()._handle_conception_value(_creq()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.conception_disabled"
+
+
+def test_endpoint_returns_snapshot(monkeypatch):
+    import json
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CONCEPTION_VALUE_MODEL_ENABLED", "true")
+    resp = _run(_crouter()._handle_conception_value(_creq()))
+    assert resp.status == 200
+    body = json.loads(resp.body.decode())
+    assert body["schema_version"] == cvm.CONCEPTION_VALUE_SCHEMA_VERSION
+    assert body["enabled"] is True and "weights" in body
+    assert resp.headers.get("Cache-Control") == "no-store"

--- a/tests/governance/test_fault_injection_matrix.py
+++ b/tests/governance/test_fault_injection_matrix.py
@@ -1,0 +1,259 @@
+"""Fault-Injection Matrix — resilience verification spine (autonomy Gap 1).
+
+Proves the systematic stability sweep: the runner enforces revert-ALWAYS and the
+criteria-dict verdict (DEFENDED iff all criteria hold, DEFENSE_FAILED with a
+first-failing locus, INCONCLUSIVE never a fake pass); the coverage matrix marks
+uncovered classes NO_SCENARIO (predicted death sites) distinct from BROKEN; and
+the real seeded scenarios each DEFEND their stability defense (worker_lifeline,
+child_reaper, external_watchdog, memory_pressure_gate, provider_quarantine, and
+the Gap 2 oracle) with zero leaked side effects.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from aiohttp.test_utils import make_mocked_request
+
+import backend.core.ouroboros.governance.fault_injection_matrix as fim
+from backend.core.ouroboros.governance.fault_injection_matrix import (
+    FaultScenario, FaultVerdict, ResilienceFaultClass, CoverageVerdict,
+)
+
+
+def _scenario(fault_class, *, inject, verify, revert=lambda _h: None, sid="s"):
+    return FaultScenario(
+        id=sid, fault_class=fault_class, defense="test", description="t",
+        inject=inject, verify=verify, revert=revert,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Runner mechanics — verdict + revert-always
+# ---------------------------------------------------------------------------
+
+
+def test_all_criteria_pass_is_defended():
+    r = fim.run_scenario(_scenario(
+        ResilienceFaultClass.ORPHAN_WORKER,
+        inject=lambda: {"x": 1},
+        verify=lambda h: {"a": True, "b": True},
+    ))
+    assert r.verdict == FaultVerdict.DEFENDED.value
+    assert r.failure_locus is None
+
+
+def test_failing_criterion_is_defense_failed_with_locus():
+    r = fim.run_scenario(_scenario(
+        ResilienceFaultClass.ORPHAN_WORKER,
+        inject=lambda: None,
+        verify=lambda h: {"a": True, "the_broken_one": False, "c": True},
+    ))
+    assert r.verdict == FaultVerdict.DEFENSE_FAILED.value
+    assert r.failure_locus == "the_broken_one"
+
+
+def test_inject_or_verify_raise_is_inconclusive_never_fake_pass():
+    def _boom():
+        raise RuntimeError("inject blew up")
+    r = fim.run_scenario(_scenario(
+        ResilienceFaultClass.ORPHAN_WORKER, inject=_boom, verify=lambda h: {"a": True},
+    ))
+    assert r.verdict == FaultVerdict.INCONCLUSIVE.value
+    assert "inject blew up" in r.detail
+
+
+def test_empty_criteria_is_inconclusive():
+    r = fim.run_scenario(_scenario(
+        ResilienceFaultClass.ORPHAN_WORKER, inject=lambda: 1, verify=lambda h: {},
+    ))
+    assert r.verdict == FaultVerdict.INCONCLUSIVE.value
+
+
+def test_revert_always_runs_even_when_verify_raises():
+    reverted = {"n": 0}
+
+    def _verify(h):
+        raise RuntimeError("verify blew up")
+
+    def _revert(h):
+        reverted["n"] += 1
+
+    r = fim.run_scenario(_scenario(
+        ResilienceFaultClass.ORPHAN_WORKER,
+        inject=lambda: {"resource": True}, verify=_verify, revert=_revert,
+    ))
+    assert r.verdict == FaultVerdict.INCONCLUSIVE.value
+    assert reverted["n"] == 1  # revert ran despite the verify fault
+
+
+def test_revert_not_run_if_inject_failed():
+    reverted = {"n": 0}
+
+    def _boom():
+        raise RuntimeError("no resource acquired")
+
+    fim.run_scenario(_scenario(
+        ResilienceFaultClass.ORPHAN_WORKER,
+        inject=_boom, verify=lambda h: {"a": True},
+        revert=lambda h: reverted.__setitem__("n", reverted["n"] + 1),
+    ))
+    assert reverted["n"] == 0  # nothing acquired → nothing to revert
+
+
+def test_revert_fault_never_propagates():
+    def _bad_revert(h):
+        raise RuntimeError("revert blew up")
+    # DEFENDED verdict preserved; revert fault swallowed.
+    r = fim.run_scenario(_scenario(
+        ResilienceFaultClass.ORPHAN_WORKER,
+        inject=lambda: 1, verify=lambda h: {"a": True}, revert=_bad_revert,
+    ))
+    assert r.verdict == FaultVerdict.DEFENDED.value
+
+
+# ---------------------------------------------------------------------------
+# Coverage matrix — NO_SCENARIO vs BROKEN vs DEFENDED
+# ---------------------------------------------------------------------------
+
+
+def test_coverage_enumerates_full_taxonomy(monkeypatch):
+    monkeypatch.setattr(fim, "ensure_seeded", lambda: [])
+    report = fim.run_matrix()
+    # every enum value present, all NO_SCENARIO when nothing registered.
+    assert set(report.coverage.keys()) == {f.value for f in ResilienceFaultClass}
+    assert all(v == CoverageVerdict.NO_SCENARIO.value for v in report.coverage.values())
+    assert report.resilience_score == 0.0
+
+
+def test_coverage_marks_defended_and_broken(monkeypatch):
+    good = _scenario(ResilienceFaultClass.ORPHAN_WORKER,
+                     inject=lambda: 1, verify=lambda h: {"a": True}, sid="good")
+    bad = _scenario(ResilienceFaultClass.MEMORY_EXHAUSTION,
+                    inject=lambda: 1, verify=lambda h: {"a": False}, sid="bad")
+    monkeypatch.setattr(fim, "ensure_seeded", lambda: [good, bad])
+    report = fim.run_matrix()
+    assert report.coverage[ResilienceFaultClass.ORPHAN_WORKER.value] == "defended"
+    assert report.coverage[ResilienceFaultClass.MEMORY_EXHAUSTION.value] == "broken"
+    assert report.coverage[ResilienceFaultClass.LOOP_STARVATION.value] == "no_scenario"
+
+
+def test_coverage_gaps_surfaced_in_dict(monkeypatch):
+    monkeypatch.setattr(fim, "ensure_seeded", lambda: [])
+    d = fim.run_matrix().to_dict()
+    assert set(d["coverage_gaps"]) == {f.value for f in ResilienceFaultClass}
+
+
+def test_matrix_never_raises(monkeypatch):
+    def _boom():
+        raise RuntimeError("seed blew up")
+    monkeypatch.setattr(fim, "ensure_seeded", _boom)
+    report = fim.run_matrix()
+    assert report.reason_code == "matrix_error"
+
+
+# ---------------------------------------------------------------------------
+# Real seeded scenarios — each DEFENDS its actual stability defense
+# ---------------------------------------------------------------------------
+
+
+def test_real_matrix_all_seeded_scenarios_defended():
+    fim.reset_registry_for_tests()
+    fim.reset_cache_for_tests()
+    report = fim.run_matrix()
+    # Every seeded scenario must DEFEND (no DEFENSE_FAILED / INCONCLUSIVE).
+    non_defended = [r for r in report.results if r.verdict != "defended"]
+    assert not non_defended, f"non-defended: {[(r.scenario_id, r.verdict, r.detail) for r in non_defended]}"
+    assert len(report.results) >= 8
+    # The known deterministic gaps are honestly surfaced.
+    for gap in ("embed_correlated_failure", "loop_starvation",
+                "cost_runaway", "teardown_wedge"):
+        assert report.coverage[gap] == "no_scenario"
+
+
+def test_real_matrix_leaves_no_orphan_processes():
+    import subprocess
+    before = subprocess.run(["pgrep", "-f", "sleep 60"], capture_output=True, text=True)
+    fim.reset_registry_for_tests()
+    fim.run_matrix()
+    after = subprocess.run(["pgrep", "-f", "sleep 60"], capture_output=True, text=True)
+    # the child_reaper scenario's sacrificial `sleep 60` must be reaped/reverted.
+    assert after.stdout.count("\n") <= before.stdout.count("\n")
+
+
+def test_gap2_oracle_scenario_present():
+    """The Gap 2 self-perception oracle is wired as the detection backbone."""
+    fim.reset_registry_for_tests()
+    scenarios = fim.ensure_seeded()
+    ids = {s.id for s in scenarios}
+    assert "capability.gap2_oracle_sees_dormancy" in ids
+
+
+# ---------------------------------------------------------------------------
+# Master flag + endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_master_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_FAULT_INJECTION_MATRIX_ENABLED", raising=False)
+    assert fim.master_enabled() is True
+    monkeypatch.setenv("JARVIS_FAULT_INJECTION_MATRIX_ENABLED", "0")
+    assert fim.master_enabled() is False
+
+
+def test_snapshot_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_FAULT_INJECTION_MATRIX_ENABLED", "false")
+    fim.reset_cache_for_tests()
+    d = fim.snapshot(force=True)
+    assert d["enabled"] is False and d["reason_code"] == "disabled"
+
+
+def _req(path="/observability/resilience"):
+    r = make_mocked_request("GET", path, headers={})
+    r._transport_peername = ("127.0.0.1", 0)  # type: ignore[attr-defined]
+    return r
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _router():
+    from backend.core.ouroboros.governance.ide_observability import IDEObservabilityRouter
+    return IDEObservabilityRouter()
+
+
+def test_endpoint_disabled_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "false")
+    resp = _run(_router()._handle_resilience_matrix(_req()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.disabled"
+
+
+def test_endpoint_substrate_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAULT_INJECTION_MATRIX_ENABLED", "false")
+    resp = _run(_router()._handle_resilience_matrix(_req()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.resilience_disabled"
+
+
+def test_endpoint_returns_matrix(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAULT_INJECTION_MATRIX_ENABLED", "true")
+    fim.reset_cache_for_tests()
+    resp = _run(_router()._handle_resilience_matrix(_req()))
+    assert resp.status == 200
+    body = json.loads(resp.body.decode())
+    assert body["schema_version"] == fim.FAULT_INJECTION_MATRIX_SCHEMA_VERSION
+    assert "coverage" in body and "resilience_score" in body
+    assert resp.headers.get("Cache-Control") == "no-store"
+
+
+def test_endpoint_never_500s(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FAULT_INJECTION_MATRIX_ENABLED", "true")
+    monkeypatch.setattr(fim, "snapshot", lambda **k: (_ for _ in ()).throw(RuntimeError("x")))
+    resp = _run(_router()._handle_resilience_matrix(_req()))
+    assert resp.status == 200
+    assert json.loads(resp.body.decode())["reason_code"] == "resilience.unavailable"

--- a/tests/governance/test_merkle_cartographer.py
+++ b/tests/governance/test_merkle_cartographer.py
@@ -140,9 +140,10 @@ def test_module_exports() -> None:
 # ===========================================================================
 
 
-def test_master_flag_default_off(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_master_flag_default_on(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Graduated in Phase 11 Slice 11.7 — default is ON."""
     monkeypatch.delenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", raising=False)
-    assert mc.is_cartographer_enabled() is False
+    assert mc.is_cartographer_enabled() is True
 
 
 def test_master_flag_truthy(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/tests/governance/test_opp_miner_merkle.py
+++ b/tests/governance/test_opp_miner_merkle.py
@@ -451,13 +451,17 @@ def test_source_imports_cartographer_lazily() -> None:
 
 
 def test_source_short_circuit_branch_in_scan_once() -> None:
-    """The merkle short-circuit branch must fire BEFORE the
-    `loop.run_in_executor(self._scan_files_sync, ...)` call so the AST
-    sweep is genuinely skipped."""
+    """The merkle short-circuit branch must fire BEFORE the offloaded
+    filesystem walk so the sweep is genuinely skipped.
+
+    (Updated Slice 27: the original pin anchored on the pre-rewrite
+    ``loop.run_in_executor(self._scan_files_sync, ...)`` call; the modern
+    scan_once walks via ``offload_blocking(_iter_python_files_pruned)``
+    — same intent, current anchor.)"""
     import inspect
     src = inspect.getsource(OpportunityMinerSensor.scan_once)
     sc_idx = src.index("_merkle_should_short_circuit")
-    walk_idx = src.index("run_in_executor")
+    walk_idx = src.index("offload_blocking")
     assert sc_idx < walk_idx
 
 

--- a/tests/governance/test_slice26_oracle_sweep_offload.py
+++ b/tests/governance/test_slice26_oracle_sweep_offload.py
@@ -1,0 +1,329 @@
+"""Slice 26 — Oracle sweep off-loop + reservation-aware backpressure.
+
+Soak bt-2026-07-15-192117 died heartbeat_stale (GIL holds 12.4→16.2→25.6s →
+ExternalWatchdog SIGKILL) with the sweep ORCHESTRATION as the culprit — the
+Slice 32 AST process pool was fine, but around it:
+  * ``scan_dir`` ran the ENTIRE recursive walk in one ``asyncio.to_thread``
+    hop — a pure-Python iterdir loop holding the GIL for the whole tree × 3
+    repos with zero yield points;
+  * ``incremental_update([])`` (falsy → full scan, gls.py oracle poll) had NO
+    adaptive throttle — the AIMD + Memory Armor axes guarded only full_index;
+  * the falsy branch re-embedded the ENTIRE graph every 300s poll, which also
+    lazily fired the chroma init + the ~800MB embedder model load mid-sweep;
+  * the EmbeddingService HIGH/LITE model constructors ran ON the asyncio loop
+    thread (the ProactiveResourceGuard 800MB grant landed seconds before the
+    death window), and no backpressure consumer knew about in-flight grants.
+
+Root-cause fixes under test here:
+  1. cooperative chunked tree walk (bounded per-chunk offloads via the shared
+     cooperative_fs_io substrate, AIMD-adaptive chunk size, loop yields);
+  2. multi-axis throttle on the incremental sweep;
+  3. sweep embed scoped to actually-changed files;
+  4. model constructors offloaded to the executor (all four sites);
+  5. MemoryPressureGate reservation dimension (unsettled grants shrink the
+     effective free-% for EVERY gate consumer — Oracle armor, scoper,
+     SensorGovernor — strictest-wins, fail-open).
+"""
+from __future__ import annotations
+
+import inspect
+import threading
+import time
+
+import backend.core.ouroboros.oracle as O
+from backend.core.ouroboros.governance import cooperative_fs_io as CFS
+from backend.core.ouroboros.governance import memory_pressure_gate as MPG
+
+
+# ── helpers ──────────────────────────────────────────────────────────
+
+
+def _bare_oracle():
+    """TheOracle without __init__ — just what _find_python_files needs."""
+    inst = O.TheOracle.__new__(O.TheOracle)
+    inst._shutting_down = False
+    return inst
+
+
+def _make_tree(tmp_path):
+    """Small source tree with an excluded dir and non-.py noise."""
+    (tmp_path / "pkg" / "sub").mkdir(parents=True)
+    (tmp_path / "pkg" / "a.py").write_text("A = 1\n")
+    (tmp_path / "pkg" / "sub" / "b.py").write_text("B = 2\n")
+    (tmp_path / "top.py").write_text("T = 0\n")
+    (tmp_path / "notes.txt").write_text("not python\n")
+    (tmp_path / "__pycache__").mkdir()
+    (tmp_path / "__pycache__" / "ghost.py").write_text("EXCLUDED\n")
+    return {"pkg/a.py", "pkg/sub/b.py", "top.py"}
+
+
+# ── 1. chunk worker semantics ────────────────────────────────────────
+
+
+def test_chunk_worker_one_level_exclusion_and_suffix(tmp_path):
+    _make_tree(tmp_path)
+    subdirs, files = O._scan_dir_chunk_worker([str(tmp_path)])
+    # one level only: sees pkg/ (dir) + top.py (file); __pycache__ excluded,
+    # notes.txt suffix-filtered, sub/ NOT yet visited.
+    assert [s.rsplit("/", 1)[-1] for s in subdirs] == ["pkg"]
+    assert sorted(f.rsplit("/", 1)[-1] for f in files) == ["top.py"]
+
+
+def test_chunk_worker_never_raises_on_missing_dir(tmp_path):
+    subdirs, files = O._scan_dir_chunk_worker([str(tmp_path / "gone")])
+    assert subdirs == [] and files == []
+
+
+# ── 2. cooperative walk ≡ legacy walk ────────────────────────────────
+
+
+async def test_coop_walk_matches_legacy(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_ORACLE_COOP_SCAN_ENABLED", raising=False)
+    expected = _make_tree(tmp_path)
+    inst = _bare_oracle()
+    coop = await inst._find_python_files(tmp_path)
+    legacy = await inst._find_python_files_legacy(tmp_path)
+    rel = lambda paths: {str(p.relative_to(tmp_path)) for p in paths}  # noqa: E731
+    assert rel(coop) == rel(legacy) == expected
+
+
+async def test_coop_walk_kill_switch_routes_to_legacy(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_ORACLE_COOP_SCAN_ENABLED", "0")
+    inst = _bare_oracle()
+    called = {}
+
+    async def _sentinel(root):
+        called["root"] = root
+        return []
+
+    inst._find_python_files_legacy = _sentinel
+    assert await inst._find_python_files(tmp_path) == []
+    assert called["root"] == tmp_path
+
+
+async def test_coop_walk_offload_failure_fails_soft(tmp_path, monkeypatch):
+    """OffloadError per chunk → bounded inline scan, walk still completes."""
+    monkeypatch.delenv("JARVIS_ORACLE_COOP_SCAN_ENABLED", raising=False)
+    expected = _make_tree(tmp_path)
+
+    async def _broken_offload(fn, /, *args, **kwargs):
+        return CFS.OffloadError(
+            fn_name="x", exc_type="RuntimeError", message="boom", cpu_bound=False,
+        )
+
+    monkeypatch.setattr(CFS, "offload", _broken_offload)
+    inst = _bare_oracle()
+    got = {str(p.relative_to(tmp_path)) for p in await inst._find_python_files(tmp_path)}
+    assert got == expected
+
+
+async def test_coop_walk_shutdown_cancels(tmp_path):
+    _make_tree(tmp_path)
+    inst = _bare_oracle()
+    inst._shutting_down = True
+    assert await inst._find_python_files(tmp_path) == []
+
+
+# ── 3. sweep throttle + scoped embed (wiring pins, Slice 25 style) ──
+
+
+def test_scan_for_changes_returns_changed_and_is_throttled():
+    src = inspect.getsource(O.TheOracle._scan_for_changes)
+    assert "return changed" in src
+    assert "_AdaptiveIndexThrottle" in src
+    assert "_ORACLE_MEM_LAG_MULT" in src
+    assert "critical_persist" in src           # armor can suspend the sweep
+    assert "_oracle_sweep_backpressure_enabled" in src
+    assert "self._shutting_down" in src        # cancellation token
+
+
+def test_incremental_update_scopes_the_embed():
+    src = inspect.getsource(O.TheOracle.incremental_update)
+    assert "scanned_changed" in src
+    assert "_oracle_scoped_sweep_embed_enabled" in src
+    # a quiet sweep must embed NOTHING (no lazy chroma/model init on idle poll)
+    assert "if changed_nodes:" in src
+
+
+def test_mem_lag_mult_shared_not_duplicated():
+    """The armor level→lag map is module-level; full_index aliases it."""
+    assert O._ORACLE_MEM_LAG_MULT["critical"] == 4.0
+    src = inspect.getsource(O.TheOracle._run_index_batches)
+    assert "_MEM_LAG_MULT = _ORACLE_MEM_LAG_MULT" in src
+
+
+def test_slice26_env_masters_default_true(monkeypatch):
+    for var, fn in [
+        ("JARVIS_ORACLE_COOP_SCAN_ENABLED", O._oracle_coop_scan_enabled),
+        ("JARVIS_ORACLE_SWEEP_BACKPRESSURE_ENABLED", O._oracle_sweep_backpressure_enabled),
+        ("JARVIS_ORACLE_SCOPED_SWEEP_EMBED_ENABLED", O._oracle_scoped_sweep_embed_enabled),
+    ]:
+        monkeypatch.delenv(var, raising=False)
+        assert fn() is True
+        monkeypatch.setenv(var, "0")
+        assert fn() is False
+
+
+def test_scan_chunk_dirs_env_driven(monkeypatch):
+    monkeypatch.setenv("JARVIS_ORACLE_SCAN_CHUNK_DIRS", "7")
+    assert O._oracle_scan_chunk_dirs() == 7
+    monkeypatch.setenv("JARVIS_ORACLE_SCAN_CHUNK_DIRS", "bogus")
+    assert O._oracle_scan_chunk_dirs() == 32
+
+
+# ── 4. embedder model load off-loop ──────────────────────────────────
+
+
+async def test_construct_model_offloaded_runs_in_executor(monkeypatch):
+    from backend.core.embedding_service import EmbeddingService
+
+    monkeypatch.delenv("JARVIS_EMBED_MODEL_LOAD_OFFLOAD_ENABLED", raising=False)
+    inst = EmbeddingService.__new__(EmbeddingService)
+    name = await inst._construct_model_offloaded(
+        lambda: threading.current_thread().name, "TEST",
+    )
+    assert name != threading.current_thread().name
+
+
+async def test_construct_model_offloaded_kill_switch_inline(monkeypatch):
+    from backend.core.embedding_service import EmbeddingService
+
+    monkeypatch.setenv("JARVIS_EMBED_MODEL_LOAD_OFFLOAD_ENABLED", "0")
+    inst = EmbeddingService.__new__(EmbeddingService)
+    name = await inst._construct_model_offloaded(
+        lambda: threading.current_thread().name, "TEST",
+    )
+    assert name == threading.current_thread().name
+
+
+def test_all_four_model_load_sites_offloaded():
+    from backend.core import budgeted_loaders
+    from backend.core.embedding_service import EmbeddingService
+
+    for meth in (
+        EmbeddingService._try_load_pytorch_tier,
+        EmbeddingService._try_load_fastembed_tier,
+        EmbeddingService.maybe_promote_tier,
+    ):
+        assert "_construct_model_offloaded" in inspect.getsource(meth), meth
+    src = inspect.getsource(budgeted_loaders.EmbeddingBudgetedLoader.load_with_grant)
+    assert "run_in_executor" in src
+
+
+# ── 5. reservation-aware backpressure ────────────────────────────────
+
+
+def _probe(free_pct=25.0, total_gb=8.0):
+    total = int(total_gb * 1024**3)
+    return MPG.MemoryProbe(
+        free_pct=free_pct,
+        total_bytes=total,
+        available_bytes=int(total * free_pct / 100.0),
+        source="test",
+        ok=True,
+        error=None,
+    )
+
+
+class _StubGuard:
+    def __init__(self, mb):
+        self._mb = mb
+
+    def unsettled_reservation_mb(self, settle_s):
+        return self._mb
+
+
+def _patch_guard(monkeypatch, mb):
+    import backend.core.proactive_resource_guard as PRG
+
+    monkeypatch.setattr(
+        PRG, "get_proactive_resource_guard", lambda: _StubGuard(mb),
+    )
+
+
+def test_reservation_dim_escalates_level(monkeypatch):
+    # free 25% of 8GB → WARN alone; 800MB unsettled ≈ 9.8% → adjusted ~15.2% → HIGH
+    _patch_guard(monkeypatch, 800.0)
+    monkeypatch.delenv("JARVIS_MEMORY_PRESSURE_RESERVATIONS_ENABLED", raising=False)
+    gate = MPG.MemoryPressureGate(probe_fn=_probe)
+    assert gate.pressure() is MPG.PressureLevel.HIGH
+
+
+def test_reservation_dim_disabled_is_noop(monkeypatch):
+    _patch_guard(monkeypatch, 800.0)
+    monkeypatch.setenv("JARVIS_MEMORY_PRESSURE_RESERVATIONS_ENABLED", "false")
+    gate = MPG.MemoryPressureGate(probe_fn=_probe)
+    assert gate.pressure() is MPG.PressureLevel.WARN
+
+
+def test_reservation_dim_fails_open(monkeypatch):
+    import backend.core.proactive_resource_guard as PRG
+
+    def _boom():
+        raise RuntimeError("guard unavailable")
+
+    monkeypatch.setattr(PRG, "get_proactive_resource_guard", _boom)
+    gate = MPG.MemoryPressureGate(probe_fn=_probe)
+    assert gate.pressure() is MPG.PressureLevel.WARN  # free-% only
+
+
+def test_reservation_dominant_reason_and_dimension(monkeypatch):
+    _patch_guard(monkeypatch, 800.0)
+    gate = MPG.MemoryPressureGate(probe_fn=_probe)
+    decision = gate.can_fanout(16)
+    assert decision.level is MPG.PressureLevel.HIGH
+    assert decision.reason_code.endswith("_via_reservations")
+    assert decision.dominant_dimension == "reservations"
+    assert decision.n_allowed <= MPG.high_fanout_cap()
+
+
+def test_snapshot_carries_reservation_dim(monkeypatch):
+    _patch_guard(monkeypatch, 800.0)
+    gate = MPG.MemoryPressureGate(probe_fn=_probe)
+    snap = gate.snapshot()
+    assert snap["reservations"]["enabled"] is True
+    assert snap["reservations"]["unsettled_mb"] == 800.0
+
+
+def test_quiet_guard_keeps_legacy_level(monkeypatch):
+    _patch_guard(monkeypatch, 0.0)
+    gate = MPG.MemoryPressureGate(probe_fn=_probe)
+    decision = gate.can_fanout(16)
+    assert decision.level is MPG.PressureLevel.WARN
+    assert decision.dominant_dimension == "free_pct"
+
+
+def test_unsettled_reservation_mb_settle_window():
+    from backend.core.proactive_resource_guard import (
+        MemoryBudget,
+        ProactiveResourceGuard,
+    )
+
+    guard = ProactiveResourceGuard.__new__(ProactiveResourceGuard)
+    guard._budget_lock = threading.RLock()
+    now = time.time()
+    guard._budgets = {
+        "sentence_transformer": MemoryBudget("sentence_transformer", 800, now - 5.0),
+        "old_component": MemoryBudget("old_component", 400, now - 3600.0),
+    }
+    assert guard.unsettled_reservation_mb(settle_s=120.0) == 800.0
+    assert guard.unsettled_reservation_mb(settle_s=7200.0) == 1200.0
+
+
+def test_reservation_settle_s_env_driven(monkeypatch):
+    monkeypatch.setenv("JARVIS_MEMORY_RESERVATION_SETTLE_S", "300")
+    assert MPG.reservation_settle_s() == 300.0
+    monkeypatch.delenv("JARVIS_MEMORY_RESERVATION_SETTLE_S", raising=False)
+    assert MPG.reservation_settle_s() == 120.0
+
+
+# ── 6. watchdog isolation invariant (Slice 47) untouched ─────────────
+
+
+def test_no_watchdog_threshold_inflation():
+    """Slice 26 is root-cause-only: the heartbeat/watchdog knobs must be
+    untouched — grep the changed modules for any watchdog coupling."""
+    for mod in (O,):
+        src = inspect.getsource(mod)
+        assert "HEARTBEAT_STALE" not in src
+        assert "wall_clock" not in src.lower() or "watchdog" not in src.lower()

--- a/tests/governance/test_slice27_miner_offload.py
+++ b/tests/governance/test_slice27_miner_offload.py
@@ -1,0 +1,164 @@
+"""Slice 27 — OpportunityMiner scan orchestration off-loop.
+
+Soak bt-2026-07-15-214458 (the Slice 26 verdict run) beat the Oracle sweep
+death class but left the miner as the dominant lag source: 41
+ControlPlaneStarvation events (0.5–2s, peak 4.2s) all attributable to its
+scan cycles. Root causes fixed here:
+  * every 300s cycle re-scanned ~2.8k files even when NOTHING changed —
+    the Slice 11.6.c merkle subtree short-circuit had been accidentally
+    stripped by the 8f3be950a1 rewrite (its regression spine
+    test_opp_miner_merkle.py failed collection ever since; restored);
+  * the per-file loop had guaranteed yield SLOTS but no ADAPTIVE backoff —
+    a loop-lag AIMD throttle (the Slice 26 Oracle-sweep shape, same class)
+    now contracts cadence + backs off under control-plane lag;
+  * Phase-2 candidate selection (full sort over all mined analyses with
+    stratification-penalty property math) ran sync on-loop with zero
+    awaits — now offloaded via the shared offload_blocking substrate;
+  * the ast_compile_helper process pool joined the child_reaper cascade +
+    worker_lifeline ppid-drift discipline (the fs-pool pattern).
+"""
+from __future__ import annotations
+
+import inspect
+
+import backend.core.ouroboros.governance.ast_compile_helper as ACH
+import backend.core.ouroboros.governance.event_loop_governance as ELG
+from backend.core.ouroboros.governance.intake.sensors import (
+    opportunity_miner_sensor as oms,
+)
+
+
+# ── AIMD throttle wiring ─────────────────────────────────────────────
+
+
+def test_scan_once_wires_aimd_throttle():
+    src = inspect.getsource(oms.OpportunityMinerSensor.scan_once)
+    assert "_AdaptiveIndexThrottle" in src
+    assert "measure_loop_lag_ms" in src
+    assert "_miner_backpressure_enabled" in src
+    assert "backoff_s" in src
+
+
+def test_miner_backpressure_env_knobs(monkeypatch):
+    monkeypatch.delenv("JARVIS_MINER_BACKPRESSURE_ENABLED", raising=False)
+    assert oms._miner_backpressure_enabled() is True
+    monkeypatch.setenv("JARVIS_MINER_BACKPRESSURE_ENABLED", "0")
+    assert oms._miner_backpressure_enabled() is False
+
+    monkeypatch.setenv("JARVIS_MINER_LAG_PROBE_CEILING", "42")
+    assert oms._miner_lag_probe_ceiling() == 42
+    monkeypatch.setenv("JARVIS_MINER_LAG_PROBE_CEILING", "junk")
+    assert oms._miner_lag_probe_ceiling() == 128
+
+    monkeypatch.setenv("JARVIS_MINER_LAG_PROBE_FLOOR", "3")
+    assert oms._miner_lag_probe_floor() == 3
+
+    monkeypatch.setenv("JARVIS_MINER_BACKPRESSURE_LAG_MS", "75")
+    assert oms._miner_backpressure_lag_ms() == 75.0
+    monkeypatch.delenv("JARVIS_MINER_BACKPRESSURE_LAG_MS", raising=False)
+    assert oms._miner_backpressure_lag_ms() == 50.0
+
+
+async def test_measure_loop_lag_ms_shared_probe():
+    lag = await ELG.measure_loop_lag_ms(probe_s=0.001)
+    assert isinstance(lag, float) and lag >= 0.0
+
+
+# ── Phase-2 selection offload ────────────────────────────────────────
+
+
+def test_selection_sort_offloaded():
+    src = inspect.getsource(oms.OpportunityMinerSensor.scan_once)
+    assert "await offload_blocking(\n            self._select_diverse_candidates" in src
+
+
+def test_slice12l_pins_still_hold():
+    """The Slice 12L discipline survives Slice 27: scan_once still composes
+    BOTH canonical primitives and never bare-walks on-loop."""
+    src = inspect.getsource(oms.OpportunityMinerSensor.scan_once)
+    assert "cooperative_yield_every_n_async" in src
+    assert "offload_blocking" in src
+    # The walk goes through the pruned iterator inside offload_blocking.
+    # (The no-bare-rglob discipline itself is AST-pinned by the canonical
+    # Slice 12L suite — not re-pinned here via fragile string matching.)
+    assert "_iter_python_files_pruned" in src
+
+
+# ── ast_compile_helper pool lifecycle (mandate 4) ────────────────────
+
+
+def test_ast_pool_registers_child_reaper():
+    src = inspect.getsource(ACH._get_pool)
+    assert "register_cleanup" in src
+    assert "reap_ast_pool_hard" in src
+    assert "pool_worker_initializer" in src
+
+
+def test_reap_ast_pool_hard_never_raises():
+    # No pool exists in this test process — must be a clean no-op.
+    ACH.reap_ast_pool_hard()
+
+
+def test_reap_ast_pool_hard_registered_label():
+    """The cleanup label matches the reaper-registry convention."""
+    src = inspect.getsource(ACH._get_pool)
+    assert 'label="ast_helper_pool"' in src
+
+
+# ── sterile RT stimulus injector ─────────────────────────────────────
+
+
+def _load_injector():
+    import importlib.util
+    from pathlib import Path
+
+    spec = importlib.util.spec_from_file_location(
+        "inject_rt_stimulus", Path("scripts/inject_rt_stimulus.py"),
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_stimulus_inject_revert_lifecycle(tmp_path):
+    inj = _load_injector()
+    (tmp_path / "tests").mkdir()
+    assert inj.inject(tmp_path) == 0
+    probe = tmp_path / inj.PROBE_REL
+    assert probe.exists() and inj.MARKER in probe.read_text()
+    # double-inject refused
+    assert inj.inject(tmp_path) == 2
+    assert inj.revert(tmp_path) == 0
+    assert not probe.exists()
+    # revert on clean tree is a no-op success
+    assert inj.revert(tmp_path) == 0
+
+
+def test_stimulus_revert_refuses_foreign_file(tmp_path):
+    inj = _load_injector()
+    (tmp_path / "tests").mkdir()
+    probe = tmp_path / inj.PROBE_REL
+    probe.write_text("def test_real(): assert True\n")
+    assert inj.revert(tmp_path) == 2
+    assert probe.exists()  # untouched
+
+
+def test_stimulus_probe_is_deterministically_red(tmp_path):
+    """The probe body must fail by contract: resolve_yield_every_n is
+    clamped >= 1 so the == -1 assertion can never pass."""
+    inj = _load_injector()
+    assert "resolve_yield_every_n() == -1" in inj.PROBE_BODY
+    from backend.core.ouroboros.governance.event_loop_governance import (
+        resolve_yield_every_n,
+    )
+    assert resolve_yield_every_n() >= 1
+
+
+def test_stimulus_probe_imports_real_source_module():
+    """Slice 6 attribution contract: the probe imports a real source module
+    (direct_import resolution) so the signal carries a source locus."""
+    inj = _load_injector()
+    assert (
+        "from backend.core.ouroboros.governance.event_loop_governance import"
+        in inj.PROBE_BODY
+    )

--- a/tests/governance/test_slice27_miner_offload.py
+++ b/tests/governance/test_slice27_miner_offload.py
@@ -144,21 +144,33 @@ def test_stimulus_revert_refuses_foreign_file(tmp_path):
 
 
 def test_stimulus_probe_is_deterministically_red(tmp_path):
-    """The probe body must fail by contract: resolve_yield_every_n is
-    clamped >= 1 so the == -1 assertion can never pass."""
+    """The probe body must fail by contract: the sentence_transformer
+    estimate is a positive MB count so the == -1 assertion can never pass."""
     inj = _load_injector()
-    assert "resolve_yield_every_n() == -1" in inj.PROBE_BODY
-    from backend.core.ouroboros.governance.event_loop_governance import (
-        resolve_yield_every_n,
-    )
-    assert resolve_yield_every_n() >= 1
+    assert 'COMPONENT_MEMORY_ESTIMATES.get("sentence_transformer") == -1' in inj.PROBE_BODY
+    from backend.core.proactive_resource_guard import COMPONENT_MEMORY_ESTIMATES
+    assert COMPONENT_MEMORY_ESTIMATES.get("sentence_transformer", 0) > 0
 
 
 def test_stimulus_probe_imports_real_source_module():
     """Slice 6 attribution contract: the probe imports a real source module
     (direct_import resolution) so the signal carries a source locus."""
     inj = _load_injector()
-    assert (
-        "from backend.core.ouroboros.governance.event_loop_governance import"
-        in inj.PROBE_BODY
-    )
+    assert "from backend.core.proactive_resource_guard import" in inj.PROBE_BODY
+
+
+def test_stimulus_probe_target_outside_the_cage():
+    """Learned live (bt-2026-07-15-223446): an attribution target inside the
+    risk engine's self-mod sentinels is BLOCKED pre-GENERATE
+    (self_modification_unsanctioned_source) — the probe's imported module
+    must sit outside 'ouroboros/governance/' and the kernel/security
+    surfaces or the dispatch proof never fires."""
+    inj = _load_injector()
+    body_import_lines = [
+        ln for ln in inj.PROBE_BODY.splitlines()
+        if ln.startswith(("from ", "import "))
+    ]
+    assert body_import_lines, "probe must import a real source module"
+    for ln in body_import_lines:
+        assert "ouroboros.governance" not in ln
+        assert "auth" not in ln

--- a/tests/governance/test_slice28_embed_tail_coop.py
+++ b/tests/governance/test_slice28_embed_tail_coop.py
@@ -144,6 +144,74 @@ async def test_coop_tail_never_raises_on_embedder_fault(monkeypatch):
     await idx._embed_nodes_coop(_make_nodes(3), _chroma=False, _stdlib=True)
 
 
+# ── Slice 30: correlated-failure circuit breaker ─────────────────────
+
+
+def test_fail_streak_abort_env_driven(monkeypatch):
+    monkeypatch.setenv("JARVIS_ORACLE_EMBED_FAIL_STREAK_ABORT", "7")
+    assert O._oracle_embed_fail_streak_abort() == 7
+    monkeypatch.setenv("JARVIS_ORACLE_EMBED_FAIL_STREAK_ABORT", "junk")
+    assert O._oracle_embed_fail_streak_abort() == 3
+
+
+async def test_consecutive_upsert_failures_abort_the_run(monkeypatch):
+    """bt-2026-07-16-004244: 16 consecutive failing chroma upserts (HNSW
+    compaction broken) ballooned RSS ~10GB in 90s because the coop tail
+    kept feeding the dying backend. N consecutive failures must ABORT."""
+    import backend.core.ouroboros.governance.cooperative_fs_io as CFS2
+
+    monkeypatch.setenv("JARVIS_ORACLE_EMBED_FAIL_STREAK_ABORT", "3")
+    calls = {"n": 0}
+
+    async def _always_fail_offload(fn, /, *args, **kwargs):
+        # prep succeeds (inline); upsert fails
+        if getattr(fn, "__name__", "") == "_prep":
+            return fn()
+        calls["n"] += 1
+        return CFS2.OffloadError(
+            fn_name="_convert_and_upsert", exc_type="InternalError",
+            message="Error in compaction", cpu_bound=False,
+        )
+
+    monkeypatch.setattr(CFS2, "offload", _always_fail_offload)
+    idx = _make_index(O.OracleSemanticBackendStatus.CHROMA)
+    idx._collection = object()  # non-None so the chroma branch runs
+    # SEMANTIC_EMBED_BATCH_SIZE is frozen at class-definition time — patch
+    # the attribute, not the env.
+    monkeypatch.setattr(O.OracleConfig, "SEMANTIC_EMBED_BATCH_SIZE", 1)
+    # 20 nodes × batch 1 → without the breaker this is 20 failing upserts;
+    # with it, exactly 3.
+    await idx._embed_nodes_coop(_make_nodes(20), _chroma=True, _stdlib=False)
+    assert calls["n"] == 3
+
+
+async def test_streak_resets_on_success(monkeypatch):
+    """A transient fault sandwiched by successes must NOT trip the breaker."""
+    import backend.core.ouroboros.governance.cooperative_fs_io as CFS2
+
+    monkeypatch.setenv("JARVIS_ORACLE_EMBED_FAIL_STREAK_ABORT", "2")
+    upserts = {"n": 0}
+
+    async def _alternating_offload(fn, /, *args, **kwargs):
+        if getattr(fn, "__name__", "") == "_prep":
+            return fn()
+        upserts["n"] += 1
+        if upserts["n"] % 2 == 1:  # odd calls fail, even succeed
+            return CFS2.OffloadError(
+                fn_name="_convert_and_upsert", exc_type="InternalError",
+                message="transient", cpu_bound=False,
+            )
+        return None
+
+    monkeypatch.setattr(CFS2, "offload", _alternating_offload)
+    idx = _make_index(O.OracleSemanticBackendStatus.CHROMA)
+    idx._collection = object()
+    monkeypatch.setattr(O.OracleConfig, "SEMANTIC_EMBED_BATCH_SIZE", 1)
+    await idx._embed_nodes_coop(_make_nodes(6), _chroma=True, _stdlib=False)
+    # All 6 batches attempted (streak never reaches 2 consecutively).
+    assert upserts["n"] == 6
+
+
 async def test_embed_nodes_kill_switch_uses_legacy(monkeypatch):
     """Flag off → embed_nodes runs the legacy inline tail (byte-identical
     rollback), never the coop method."""

--- a/tests/governance/test_slice28_embed_tail_coop.py
+++ b/tests/governance/test_slice28_embed_tail_coop.py
@@ -1,0 +1,158 @@
+"""Slice 28 — adaptive cooperative embed/upsert tail.
+
+Soak bt-2026-07-15-225445 verdict: one 10.3s ControlPlaneStarvation hold at
+the cold-sweep embed tail (chroma init itself was executor-isolated at
+132ms per LoopSink — the hold was the tail AROUND it): `_build_embed_text`
+evaluated over every node TWICE (filter pass + per-batch rebuild) as
+pure-Python string joins with zero awaits before the first batch, on-loop
+metadata builds + numpy tolist() conversion, and a static 128 batch with
+no adaptation between batches.
+
+Fix under test: `_embed_nodes_coop` — per-batch prep + convert-and-upsert
+via the cooperative_fs_io thread offload (the Slice 25 executor; thread,
+never process — persist-dir lock), AIMD batch sizing from the shared
+Slice 27 `measure_loop_lag_ms` probe, memory axis via the shared
+MemoryPressureGate (Slice 26 reservation dimension included) through the
+shared `_ORACLE_MEM_LAG_MULT` table. Payload-size adaptation is emergent
+(heavier batch → more observed lag → contraction), not configured.
+"""
+from __future__ import annotations
+
+import inspect
+
+import backend.core.ouroboros.oracle as O
+
+
+# ── wiring pins ──────────────────────────────────────────────────────
+
+
+def test_embed_nodes_delegates_to_coop_tail():
+    src = inspect.getsource(O.OracleSemanticIndex.embed_nodes)
+    assert "_oracle_embed_tail_coop_enabled" in src
+    assert "_embed_nodes_coop" in src
+
+
+def test_coop_tail_composes_shared_substrate():
+    src = inspect.getsource(O.OracleSemanticIndex._embed_nodes_coop)
+    # DRY: shared AIMD class, shared lag probe, shared pressure table,
+    # shared offload substrate — no new mechanisms.
+    assert "_AdaptiveIndexThrottle" in src
+    assert "measure_loop_lag_ms" in src
+    assert "_ORACLE_MEM_LAG_MULT" in src
+    assert "_semantic_embed_pressure_level" in src
+    assert "cooperative_fs_io" in src
+    # Slice 25 invariant preserved: chroma writes stay on the THREAD path
+    # (cpu_bound=False) — a process pool would corrupt HNSW segments.
+    assert "cpu_bound=False" in src
+    assert "cpu_bound=True" not in src
+    assert "self._collection.upsert" in src
+
+
+def test_coop_tail_offloads_prep_and_conversion():
+    src = inspect.getsource(O.OracleSemanticIndex._embed_nodes_coop)
+    # text build + metadata happen inside the offloaded _prep closure;
+    # tolist() conversion rides the SAME thread hop as the upsert.
+    assert "def _prep(" in src
+    assert "def _convert_and_upsert(" in src
+    assert "e.tolist() for e in" in src
+
+
+def test_coop_tail_master_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_ORACLE_EMBED_TAIL_COOP_ENABLED", raising=False)
+    assert O._oracle_embed_tail_coop_enabled() is True
+    monkeypatch.setenv("JARVIS_ORACLE_EMBED_TAIL_COOP_ENABLED", "0")
+    assert O._oracle_embed_tail_coop_enabled() is False
+
+
+def test_pressure_helper_fails_open(monkeypatch):
+    import backend.core.ouroboros.governance.memory_pressure_gate as MPG
+
+    def _boom():
+        raise RuntimeError("gate down")
+
+    monkeypatch.setattr(MPG, "get_default_gate", _boom)
+    assert O._semantic_embed_pressure_level() == "ok"
+
+
+# ── functional: coop tail embeds via the STDLIB backend ─────────────
+
+
+def _make_index(status):
+    idx = O.OracleSemanticIndex.__new__(O.OracleSemanticIndex)
+    idx._status = status
+    idx._collection = None
+    idx._stdlib_store = {}
+    idx._init_attempted = True
+
+    class _Embedder:
+        async def embed_batch(self, texts):
+            return [[float(len(t)), 0.5] for t in texts]
+
+    idx._embedder = _Embedder()
+    return idx
+
+
+def _make_nodes(n):
+    return [
+        O.NodeData(
+            node_id=O.NodeID(
+                repo="jarvis",
+                file_path=f"backend/mod_{i}.py",
+                name=f"fn_{i}",
+                node_type=O.NodeType.FUNCTION,
+            ),
+            signature=f"def fn_{i}(x)",
+            docstring="does things",
+        )
+        for i in range(n)
+    ]
+
+
+async def test_coop_tail_embeds_stdlib_end_to_end(monkeypatch):
+    monkeypatch.delenv("JARVIS_ORACLE_EMBED_TAIL_COOP_ENABLED", raising=False)
+    idx = _make_index(O.OracleSemanticBackendStatus.STDLIB)
+    await idx._embed_nodes_coop(_make_nodes(10), _chroma=False, _stdlib=True)
+    assert len(idx._stdlib_store) == 10
+    key = "jarvis:backend/mod_0.py:fn_0"
+    vec, meta = idx._stdlib_store[key]
+    assert meta["node_type"] == "function" and len(vec) == 2
+
+
+async def test_coop_tail_skips_non_embeddable(monkeypatch):
+    idx = _make_index(O.OracleSemanticBackendStatus.STDLIB)
+    nodes = [
+        O.NodeData(
+            node_id=O.NodeID(
+                repo="jarvis", file_path="a.py", name="v",
+                node_type=O.NodeType.VARIABLE,
+            ),
+        )
+    ]
+    await idx._embed_nodes_coop(nodes, _chroma=False, _stdlib=True)
+    assert idx._stdlib_store == {}
+
+
+async def test_coop_tail_never_raises_on_embedder_fault(monkeypatch):
+    idx = _make_index(O.OracleSemanticBackendStatus.STDLIB)
+
+    class _Broken:
+        async def embed_batch(self, texts):
+            raise RuntimeError("embedder down")
+
+    idx._embedder = _Broken()
+    # Must swallow (legacy fail-soft contract) — no exception escapes.
+    await idx._embed_nodes_coop(_make_nodes(3), _chroma=False, _stdlib=True)
+
+
+async def test_embed_nodes_kill_switch_uses_legacy(monkeypatch):
+    """Flag off → embed_nodes runs the legacy inline tail (byte-identical
+    rollback), never the coop method."""
+    monkeypatch.setenv("JARVIS_ORACLE_EMBED_TAIL_COOP_ENABLED", "0")
+    idx = _make_index(O.OracleSemanticBackendStatus.STDLIB)
+
+    async def _sentinel(*a, **k):
+        raise AssertionError("coop tail must not run under kill switch")
+
+    idx._embed_nodes_coop = _sentinel
+    await idx.embed_nodes(_make_nodes(4))
+    assert len(idx._stdlib_store) == 4

--- a/tests/governance/test_slice29_heartbeat_hardening.py
+++ b/tests/governance/test_slice29_heartbeat_hardening.py
@@ -1,0 +1,204 @@
+"""Slice 29 — heartbeat plumbing hardening + sentinel forensics.
+
+bt-2026-07-15-233357 post-mortem: `heartbeat.tick` froze at 16:36:00 while
+the organism was provably healthy (log flowing, 2 starvation events) until
+the ExternalWatchdog SIGKILLed it at 16:51:17 — a FALSE-POSITIVE
+heartbeat_stale kill. Two blind spots enabled it:
+  1. the wall-clock monitor task (the sentinel's ONLY beat writer) can die
+     silently — its ref is held (no GC warning), CancelledError is the only
+     handled terminal, and beat() swallowed OSError without a trace;
+  2. the kill fired ~915s after the freeze instead of the 120s stale window
+     and the sentinel recorded NOTHING about why (suppression? poll drift?).
+
+Fixes under test (root-cause only — stale window and loop cadence untouched):
+  * done-callback supervisor: every terminal outcome of the monitor task is
+    LOUD; unexpected deaths (any BaseException derivative) restart the task,
+    bounded by JARVIS_WALL_CLOCK_MONITOR_MAX_RESTARTS;
+  * beat(): rate-limited WARNING on write failure + recovery log + public
+    counters — never raises, never silent;
+  * sentinel: dynamic delta forensics (format_poll_forensics) emitted on
+    stale-suppression, poll drift, beat-aging status, and the kill itself.
+"""
+from __future__ import annotations
+
+import inspect
+import logging
+from pathlib import Path
+
+from backend.core.ouroboros.battle_test.harness import (
+    BattleTestHarness,
+    _should_restart_wall_clock_monitor,
+    _wall_clock_monitor_max_restarts,
+)
+from backend.core.ouroboros.governance.external_watchdog import (
+    ExternalProcessWatchdog,
+    format_poll_forensics,
+    run_watchdog,
+)
+
+
+# ── supervisor decision (pure) ───────────────────────────────────────
+
+
+def _decide(**kw):
+    base = dict(cancelled=False, exc=None, restarts=0, max_restarts=5, closing=False)
+    base.update(kw)
+    return _should_restart_wall_clock_monitor(**base)
+
+
+def test_restart_on_unexpected_exception():
+    restart, verdict = _decide(exc=RuntimeError("boom"))
+    assert restart is True and verdict == "unexpected_death:RuntimeError"
+
+
+def test_restart_covers_baseexception_derivatives():
+    for exc in (SystemExit(1), KeyboardInterrupt(), MemoryError()):
+        restart, verdict = _decide(exc=exc)
+        assert restart is True
+        assert type(exc).__name__ in verdict
+
+
+def test_no_restart_on_cancellation():
+    assert _decide(cancelled=True) == (False, "cancelled")
+
+
+def test_no_restart_on_normal_return():
+    assert _decide() == (False, "normal_return")
+
+
+def test_no_restart_during_teardown():
+    restart, verdict = _decide(exc=RuntimeError("x"), closing=True)
+    assert restart is False and verdict == "closing"
+
+
+def test_restart_budget_bounds_thrash():
+    restart, verdict = _decide(exc=RuntimeError("x"), restarts=5, max_restarts=5)
+    assert restart is False and verdict.startswith("restart_budget_exhausted")
+
+
+def test_max_restarts_env_driven(monkeypatch):
+    monkeypatch.setenv("JARVIS_WALL_CLOCK_MONITOR_MAX_RESTARTS", "2")
+    assert _wall_clock_monitor_max_restarts() == 2
+    monkeypatch.setenv("JARVIS_WALL_CLOCK_MONITOR_MAX_RESTARTS", "junk")
+    assert _wall_clock_monitor_max_restarts() == 5
+
+
+def test_supervisor_wired_into_arming():
+    src = inspect.getsource(
+        BattleTestHarness._arm_wall_clock_monitor_supervised,
+    )
+    assert "add_done_callback" in src
+    assert "_on_wall_clock_monitor_done" in src
+    done_src = inspect.getsource(BattleTestHarness._on_wall_clock_monitor_done)
+    assert "BaseException" in done_src
+    assert "_should_restart_wall_clock_monitor" in done_src
+    assert "critical" in done_src  # unexpected death is LOUD
+
+
+# ── beat() visibility ────────────────────────────────────────────────
+
+
+def _make_wd(tmp_path: Path) -> ExternalProcessWatchdog:
+    return ExternalProcessWatchdog(
+        target_pid=1, heartbeat_path=tmp_path / "hb.tick",
+        budget_s=100.0, stale_window_s=10.0,
+    )
+
+
+def test_beat_failure_warns_and_counts(tmp_path, caplog):
+    wd = _make_wd(tmp_path)
+    # Force the atomic replace to fail: make the heartbeat path a DIRECTORY.
+    (tmp_path / "hb.tick").mkdir()
+    with caplog.at_level(logging.WARNING, logger="Ouroboros.ExternalWatchdog"):
+        wd.beat()
+    assert wd.beat_failures == 1
+    assert any("heartbeat WRITE FAILED" in r.message for r in caplog.records)
+
+
+def test_beat_failure_rate_limited(tmp_path, caplog):
+    wd = _make_wd(tmp_path)
+    (tmp_path / "hb.tick").mkdir()
+    with caplog.at_level(logging.WARNING, logger="Ouroboros.ExternalWatchdog"):
+        for _ in range(12):
+            wd.beat()
+    warns = [r for r in caplog.records if "WRITE FAILED" in r.message]
+    # 1st + every 10th (10th failure) — NOT one per call.
+    assert len(warns) == 2
+    assert wd.beat_failures == 12
+
+
+def test_beat_recovery_logged(tmp_path, caplog):
+    wd = _make_wd(tmp_path)
+    (tmp_path / "hb.tick").mkdir()
+    with caplog.at_level(logging.WARNING, logger="Ouroboros.ExternalWatchdog"):
+        wd.beat()
+        (tmp_path / "hb.tick").rmdir()
+        wd.beat()
+    assert any("RECOVERED" in r.message for r in caplog.records)
+    assert wd.beat_successes == 1
+    assert wd._beat_consecutive_failures == 0
+
+
+def test_beat_never_raises(tmp_path):
+    wd = _make_wd(tmp_path)
+    (tmp_path / "hb.tick").mkdir()
+    wd.beat()  # must not raise despite the OSError inside
+
+
+# ── sentinel forensics ───────────────────────────────────────────────
+
+
+def test_forensics_line_is_fully_dynamic():
+    line = format_poll_forensics(
+        tag="stale-suppressed", now_wall=1000.0, armed_wall=100.0,
+        last_beat_wall=850.0, stale_window_s=120.0, budget_s=2490.0,
+        suspended=True, wall_delta=31.0, mono_delta=1.0, poll_s=1.0,
+        suppressed_polls=7, max_poll_drift_s=30.0,
+    )
+    # Every number in the line is a computed delta — the exact math the
+    # bt-233357 post-mortem lacked.
+    assert "beat_age_s=150.0" in line
+    assert "budget_elapsed_s=900.0/2490" in line
+    assert "suspended=True" in line
+    assert "poll_drift_s=30.00" in line
+    assert "suppressed_polls=7" in line
+    assert "stale-suppressed" in line
+
+
+def test_forensics_handles_missing_beat():
+    line = format_poll_forensics(
+        tag="beat-aging", now_wall=1000.0, armed_wall=100.0,
+        last_beat_wall=None, stale_window_s=120.0, budget_s=2490.0,
+        suspended=False, wall_delta=1.0, mono_delta=1.0, poll_s=1.0,
+        suppressed_polls=0, max_poll_drift_s=0.0,
+    )
+    assert "beat_age_s=-1.0" in line  # sentinel could not read the beat
+
+
+def test_sentinel_emits_forensics_at_the_blind_spots():
+    src = inspect.getsource(run_watchdog)
+    assert "stale-suppressed" in src   # staleness true but suppressed
+    assert "poll-drift" in src         # child scheduling drift (App Nap class)
+    assert "beat-aging" in src         # periodic status while beat ages
+    assert '"kill:" + reason' in src   # full math on the kill itself
+    # Root-cause mandate: the decision function itself is untouched —
+    # forensics observe, never alter, the kill math.
+    assert "evaluate_kill(" in src
+
+
+def test_evaluate_kill_untouched_regression():
+    """The Slice 49 pure decision contract is byte-level intact — Slice 29
+    adds observation only (no widened windows, no new suppression)."""
+    from backend.core.ouroboros.governance.external_watchdog import (
+        evaluate_kill,
+    )
+    kill, reason = evaluate_kill(
+        now_wall=1000.0, armed_wall=900.0, last_beat_wall=800.0,
+        budget_s=10_000.0, stale_window_s=120.0, suspended=False,
+    )
+    assert (kill, reason) == (True, "heartbeat_stale")
+    kill, reason = evaluate_kill(
+        now_wall=1000.0, armed_wall=900.0, last_beat_wall=800.0,
+        budget_s=10_000.0, stale_window_s=120.0, suspended=True,
+    )
+    assert kill is False

--- a/tests/governance/test_slice31_merkle_hydration_driver.py
+++ b/tests/governance/test_slice31_merkle_hydration_driver.py
@@ -1,0 +1,215 @@
+"""Slice 31 — Merkle Cartographer hydration driver + runtime reachability.
+
+The Phase 11 merkle stack shipped consumers (OpportunityMiner / TodoScanner /
+DocStaleness subtree consults) but `update_full()` had ZERO production
+callers — the cartographer was never hydrated, `_root` stayed None, every
+`subtree_hash()` returned "", and every consumer fail-safed to legacy O(N)
+scans silently (proven live: 5 quiet-soak cycles in bt-2026-07-16-031323,
+all full scans). The 22-test consumer spine passed because test fixtures
+hydrate the cartographer themselves — the wired-but-inert trap one layer
+deeper: consumers wired, DRIVER severed.
+
+This suite pins the driver at RUNTIME (not just source grep): a stubbed
+boot actually exercises hydrate → subscribe → update_full, so a future
+severed driver fails these tests instead of hiding behind fail-safes.
+"""
+from __future__ import annotations
+
+import asyncio
+import inspect
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any, List
+
+import backend.core.ouroboros.governance.merkle_cartographer as mc
+from backend.core.ouroboros.governance.intake.intake_layer_service import (
+    IntakeLayerService,
+)
+
+
+# ── harness ──────────────────────────────────────────────────────────
+
+
+class _StubBus:
+    def __init__(self) -> None:
+        self.subscriptions: List[Any] = []
+
+    async def subscribe(self, topic, handler):
+        self.subscriptions.append((topic, handler))
+
+
+class _StubCartographer:
+    def __init__(self) -> None:
+        self.hydrate_calls = 0
+        self.update_full_calls = 0
+        self.incremental_batches: List[Any] = []
+
+    def hydrate(self) -> int:
+        self.hydrate_calls += 1
+        return 42
+
+    async def update_full(self):
+        self.update_full_calls += 1
+        return {"backend/x.py"}
+
+    async def update_incremental(self, events):
+        self.incremental_batches.append(list(events))
+        return set()
+
+
+def _bare_service(tmp_path: Path) -> IntakeLayerService:
+    svc = IntakeLayerService.__new__(IntakeLayerService)
+    svc._config = SimpleNamespace(project_root=tmp_path)
+    return svc
+
+
+async def _drain_hydration(svc) -> None:
+    task = getattr(svc, "_merkle_hydration_task", None)
+    if task is not None:
+        await task
+
+
+# ── runtime reachability: the driver actually drives ────────────────
+
+
+async def test_driver_hydrates_subscribes_and_walks(tmp_path, monkeypatch):
+    stub = _StubCartographer()
+    monkeypatch.setattr(mc, "get_default_cartographer", lambda repo_root=None: stub)
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    bus = _StubBus()
+    svc = _bare_service(tmp_path)
+
+    await svc._start_merkle_hydration(bus)
+    await _drain_hydration(svc)
+
+    assert stub.hydrate_calls == 1
+    assert stub.update_full_calls == 1
+    assert bus.subscriptions and bus.subscriptions[0][0] == "fs.changed.*"
+    assert svc._merkle_subscriber is not None
+
+
+async def test_bus_wired_before_walk_scheduled(tmp_path, monkeypatch):
+    """No event gap: the fs.changed subscription must exist by the time the
+    boot walk is scheduled."""
+    order: List[str] = []
+
+    class _OrderCart(_StubCartographer):
+        async def update_full(self):
+            order.append("walk")
+            return set()
+
+    class _OrderBus(_StubBus):
+        async def subscribe(self, topic, handler):
+            order.append("subscribe")
+            await super().subscribe(topic, handler)
+
+    stub = _OrderCart()
+    monkeypatch.setattr(mc, "get_default_cartographer", lambda repo_root=None: stub)
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    svc = _bare_service(tmp_path)
+    await svc._start_merkle_hydration(_OrderBus())
+    await _drain_hydration(svc)
+    assert order.index("subscribe") < order.index("walk")
+
+
+async def test_boot_walk_is_backgrounded_not_awaited_inline(tmp_path, monkeypatch):
+    """Startup-starvation guard: _start_merkle_hydration must return while
+    a slow walk is still in flight (the walk runs in its own task)."""
+    gate = asyncio.Event()
+
+    class _SlowCart(_StubCartographer):
+        async def update_full(self):
+            await gate.wait()
+            self.update_full_calls += 1
+            return set()
+
+    stub = _SlowCart()
+    monkeypatch.setattr(mc, "get_default_cartographer", lambda repo_root=None: stub)
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    svc = _bare_service(tmp_path)
+    await asyncio.wait_for(svc._start_merkle_hydration(_StubBus()), timeout=2.0)
+    assert stub.update_full_calls == 0  # returned while walk still gated
+    gate.set()
+    await _drain_hydration(svc)
+    assert stub.update_full_calls == 1
+
+
+async def test_master_flag_off_constructs_nothing(tmp_path, monkeypatch):
+    calls = {"n": 0}
+
+    def _spy(repo_root=None):
+        calls["n"] += 1
+        return _StubCartographer()
+
+    monkeypatch.setattr(mc, "get_default_cartographer", _spy)
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "false")
+    svc = _bare_service(tmp_path)
+    await svc._start_merkle_hydration(_StubBus())
+    assert calls["n"] == 0
+    assert svc._merkle_hydration_task is None
+
+
+async def test_driver_never_raises(tmp_path, monkeypatch):
+    def _boom(repo_root=None):
+        raise RuntimeError("cartographer down")
+
+    monkeypatch.setattr(mc, "get_default_cartographer", _boom)
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    svc = _bare_service(tmp_path)
+    await svc._start_merkle_hydration(_StubBus())  # must not raise
+    assert svc._merkle_hydration_task is None
+
+
+# ── incremental conduit: real subscriber end-to-end ──────────────────
+
+
+async def test_fs_event_reaches_update_incremental(tmp_path, monkeypatch):
+    """The full incremental chain with the REAL MerkleEventSubscriber:
+    fs.changed event → handle → flush → cartographer.update_incremental."""
+    stub = _StubCartographer()
+    monkeypatch.setattr(mc, "get_default_cartographer", lambda repo_root=None: stub)
+    monkeypatch.setenv("JARVIS_MERKLE_CARTOGRAPHER_ENABLED", "true")
+    bus = _StubBus()
+    svc = _bare_service(tmp_path)
+    await svc._start_merkle_hydration(bus)
+    await _drain_hydration(svc)
+
+    _topic, handler = bus.subscriptions[0]
+    # REAL-CONTRACT dispatch: TrinityEventBus calls handler(event) with a
+    # SINGLE event object (trinity_event_bus._execute_handler) — the driver's
+    # adapter must translate to the subscriber's (topic, payload) shape.
+    # (The fakes-must-mirror-real-contract lesson: a two-arg stub dispatch
+    # here masked exactly the TypeError this adapter exists to prevent.)
+    event = SimpleNamespace(
+        topic="fs.changed.modified",
+        payload={"relative_path": "backend/x.py", "path": str(tmp_path / "backend/x.py")},
+    )
+    await handler(event)
+    await svc._merkle_subscriber.flush()
+    assert stub.incremental_batches, "fs event never reached update_incremental"
+
+
+# ── anti-severed-driver pins ─────────────────────────────────────────
+
+
+def test_driver_is_on_the_default_boot_path():
+    """_build_components (the DEFAULT event-spine boot path) must call the
+    hydration driver — the exact wire whose absence made the whole Phase 11
+    merkle stack silently inert."""
+    src = inspect.getsource(IntakeLayerService._build_components)
+    assert "_start_merkle_hydration" in src
+
+
+def test_update_full_has_a_production_caller():
+    """The grep-callers class test: intake_layer_service must reference
+    update_full (via the boot-hydrate closure). If a refactor severs this,
+    the runtime tests above fail too — this pin names the invariant."""
+    import backend.core.ouroboros.governance.intake.intake_layer_service as ils
+
+    assert "update_full" in inspect.getsource(ils)
+
+
+def test_stop_retires_the_driver():
+    src = inspect.getsource(IntakeLayerService.stop)
+    assert "_merkle_hydration_task" in src
+    assert "_merkle_subscriber" in src

--- a/tests/governance/test_trust_calibration.py
+++ b/tests/governance/test_trust_calibration.py
@@ -1,0 +1,263 @@
+"""Trust Calibration — earned auto-apply envelope spine (autonomy Gap 4).
+
+Proves the envelope is EARNED and ADAPTIVE, cage-safely and asymmetrically:
+recency-weighted held-up-vs-reverted per scope; a fresh regression forces LOW +
+a human-gate narrowing floor regardless of the historical rate; a high rate on
+thin evidence stays UNKNOWN (volume floor); widening is DOUBLE opt-in +
+default-inert + never touches the cage; and the narrowing floor composes through
+the real risk_tier_floor.recommended_floor stack.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+
+from aiohttp.test_utils import make_mocked_request
+
+import backend.core.ouroboros.governance.trust_calibration as tc
+from backend.core.ouroboros.governance.trust_calibration import (
+    ScopeTrust, TrustLevel,
+)
+from backend.core.ouroboros.governance.risk_engine import RiskTier
+
+
+# ---------------------------------------------------------------------------
+# Calibration math — _compute (pure): recency-weighted, asymmetric, volume floor
+# ---------------------------------------------------------------------------
+
+
+_NOW = 1_800_000_000.0
+_DAY = 86400.0
+
+
+def test_all_held_up_over_volume_is_high(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_MIN_SAMPLE", "5")
+    recs = [(True, _NOW - i * _DAY) for i in range(6)]   # 6 recent held-up
+    st = tc._compute("svc", recs, _NOW)
+    assert st.trust_level == TrustLevel.HIGH.value
+    assert st.held_up == 6 and st.reverted == 0
+    assert st.held_up_rate == 1.0
+
+
+def test_high_rate_but_thin_evidence_is_unknown(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_MIN_SAMPLE", "5")
+    recs = [(True, _NOW - _DAY), (True, _NOW - 2 * _DAY)]   # 2/2 held-up
+    st = tc._compute("svc", recs, _NOW)
+    # perfect rate but below the volume floor → NOT trusted.
+    assert st.trust_level == TrustLevel.UNKNOWN.value
+    assert st.held_up_rate == 1.0 and st.sample_count == 2
+
+
+def test_fresh_regression_forces_low_regardless_of_rate(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_MIN_SAMPLE", "3")
+    monkeypatch.setenv("JARVIS_TRUST_REGRESSION_WINDOW_S", str(int(7 * _DAY)))
+    # 20 old successes + ONE revert yesterday → rate stays high but it's fresh-broken.
+    recs = [(True, _NOW - (30 + i) * _DAY) for i in range(20)]
+    recs.append((False, _NOW - 1 * _DAY))
+    st = tc._compute("svc", recs, _NOW)
+    assert st.recent_regression is True
+    assert st.trust_level == TrustLevel.LOW.value   # asymmetric: fresh break wins
+
+
+def test_old_regression_does_not_force_low(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_MIN_SAMPLE", "3")
+    monkeypatch.setenv("JARVIS_TRUST_REGRESSION_WINDOW_S", str(int(7 * _DAY)))
+    recs = [(True, _NOW - (1 + i) * _DAY) for i in range(10)]
+    recs.append((False, _NOW - 90 * _DAY))   # a revert 90d ago — not fresh
+    st = tc._compute("svc", recs, _NOW)
+    assert st.recent_regression is False
+
+
+def test_poor_rate_is_low(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_MIN_SAMPLE", "3")
+    monkeypatch.setenv("JARVIS_TRUST_LOW_THRESHOLD", "0.5")
+    monkeypatch.setenv("JARVIS_TRUST_REGRESSION_WINDOW_S", "1")  # nothing "fresh"
+    recs = [(False, _NOW - (30 + i) * _DAY) for i in range(4)]   # 0/4 held up, old
+    recs += [(True, _NOW - (30 + i) * _DAY) for i in range(1)]   # 1/5
+    st = tc._compute("svc", recs, _NOW)
+    assert st.trust_level == TrustLevel.LOW.value
+
+
+# ---------------------------------------------------------------------------
+# NARROWING — safety-forward, always active
+# ---------------------------------------------------------------------------
+
+
+def _stub_scope(monkeypatch, **kw):
+    base = dict(scope="svc", trust_level=TrustLevel.UNKNOWN.value, held_up_rate=None,
+                sample_count=0, held_up=0, reverted=0, recent_regression=False)
+    base.update(kw)
+    monkeypatch.setattr(tc, "scope_trust", lambda scope, **k: ScopeTrust(**{**base, "scope": scope}))
+
+
+def test_narrowing_fresh_regression_gates_to_approval(monkeypatch):
+    _stub_scope(monkeypatch, recent_regression=True, trust_level=TrustLevel.LOW.value)
+    assert tc.trust_narrowing_tier("requirements") == "approval_required"
+
+
+def test_narrowing_low_trust_gates_to_notify(monkeypatch):
+    _stub_scope(monkeypatch, trust_level=TrustLevel.LOW.value, recent_regression=False)
+    assert tc.trust_narrowing_tier("svc") == "notify_apply"
+
+
+def test_no_narrowing_when_unknown_or_high(monkeypatch):
+    _stub_scope(monkeypatch, trust_level=TrustLevel.UNKNOWN.value)
+    assert tc.trust_narrowing_tier("svc") is None
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value)
+    assert tc.trust_narrowing_tier("svc") is None
+
+
+def test_narrowing_disabled_when_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_CALIBRATION_ENABLED", "false")
+    _stub_scope(monkeypatch, recent_regression=True, trust_level=TrustLevel.LOW.value)
+    assert tc.trust_narrowing_tier("svc") is None
+
+
+def test_narrowing_composes_through_recommended_floor(monkeypatch):
+    import backend.core.ouroboros.governance.risk_tier_floor as rtf
+    _stub_scope(monkeypatch, trust_level=TrustLevel.LOW.value, recent_regression=True)
+    floor = rtf.recommended_floor(target_files=["backend/gov/svc.py"])
+    assert floor == "approval_required"   # the trust narrowing wins strictest
+
+
+# ---------------------------------------------------------------------------
+# WIDENING — double opt-in, default-inert, cage-excluded, evidence-gated
+# ---------------------------------------------------------------------------
+
+
+def _opt_in_widen(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_CALIBRATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TRUST_WIDEN_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TRUST_MAX_AUTO_TIER", "notify_apply")
+    monkeypatch.setenv("JARVIS_TRUST_WIDEN_MIN_SAMPLE", "8")
+
+
+def test_widen_default_inert(monkeypatch):
+    monkeypatch.delenv("JARVIS_TRUST_WIDEN_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_TRUST_MAX_AUTO_TIER", raising=False)
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=50)
+    tier, why = tc.maybe_relax_tier(RiskTier.APPROVAL_REQUIRED, scope="svc", touches_cage=False)
+    assert tier is RiskTier.APPROVAL_REQUIRED and why is None
+
+
+def test_widen_when_opted_in_and_high_trust(monkeypatch):
+    _opt_in_widen(monkeypatch)
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=12,
+                held_up_rate=0.95, recent_regression=False)
+    tier, why = tc.maybe_relax_tier(RiskTier.APPROVAL_REQUIRED, scope="svc", touches_cage=False)
+    assert tier is RiskTier.NOTIFY_APPLY   # Orange → Yellow (auto-apply, surfaced)
+    assert why and "widened" in why
+
+
+def test_widen_never_touches_cage(monkeypatch):
+    _opt_in_widen(monkeypatch)
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=50)
+    tier, why = tc.maybe_relax_tier(RiskTier.APPROVAL_REQUIRED, scope="governance", touches_cage=True)
+    assert tier is RiskTier.APPROVAL_REQUIRED and why == "cage_excluded"
+
+
+def test_widen_blocked_below_volume(monkeypatch):
+    _opt_in_widen(monkeypatch)
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=4)  # < widen_min 8
+    tier, _ = tc.maybe_relax_tier(RiskTier.APPROVAL_REQUIRED, scope="svc", touches_cage=False)
+    assert tier is RiskTier.APPROVAL_REQUIRED
+
+
+def test_widen_blocked_on_fresh_regression(monkeypatch):
+    _opt_in_widen(monkeypatch)
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=50,
+                recent_regression=True)
+    tier, _ = tc.maybe_relax_tier(RiskTier.APPROVAL_REQUIRED, scope="svc", touches_cage=False)
+    assert tier is RiskTier.APPROVAL_REQUIRED
+
+
+def test_widen_only_relaxes_approval_not_others(monkeypatch):
+    _opt_in_widen(monkeypatch)
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=50)
+    # BLOCKED / NOTIFY_APPLY are not the human-gate tier → untouched.
+    assert tc.maybe_relax_tier(RiskTier.BLOCKED, scope="svc", touches_cage=False)[0] is RiskTier.BLOCKED
+    assert tc.maybe_relax_tier(RiskTier.NOTIFY_APPLY, scope="svc", touches_cage=False)[0] is RiskTier.NOTIFY_APPLY
+
+
+def test_widen_blocked_when_ceiling_not_raised(monkeypatch):
+    monkeypatch.setenv("JARVIS_TRUST_CALIBRATION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TRUST_WIDEN_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_TRUST_MAX_AUTO_TIER", raising=False)  # ceiling unset
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=50)
+    tier, _ = tc.maybe_relax_tier(RiskTier.APPROVAL_REQUIRED, scope="svc", touches_cage=False)
+    assert tier is RiskTier.APPROVAL_REQUIRED   # widen enabled but no ceiling → inert
+
+
+def test_relax_for_op_fail_closed_on_cage_check(monkeypatch):
+    """A governance-self-mod op is cage-detected and never widened."""
+    _opt_in_widen(monkeypatch)
+    _stub_scope(monkeypatch, trust_level=TrustLevel.HIGH.value, sample_count=50)
+
+    class _Ctx:
+        target_files = ("backend/core/ouroboros/governance/orchestrator.py",)
+
+    tier, why = tc.relax_tier_for_op(RiskTier.APPROVAL_REQUIRED, _Ctx())
+    assert tier is RiskTier.APPROVAL_REQUIRED and why == "cage_excluded"
+
+
+# ---------------------------------------------------------------------------
+# Never-raises + endpoint
+# ---------------------------------------------------------------------------
+
+
+def test_scope_records_never_raises_on_bad_git(monkeypatch):
+    import backend.core.ouroboros.governance.autonomy_metrics as am
+    monkeypatch.setattr(am, "_run_git_log", lambda *a, **k: (_ for _ in ()).throw(RuntimeError("git")))
+    tc.reset_cache_for_tests()
+    rep = tc.trust_report(now=_NOW, force=True)
+    assert rep == {}
+
+
+def test_master_flag_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_TRUST_CALIBRATION_ENABLED", raising=False)
+    assert tc.master_enabled() is True
+    monkeypatch.setenv("JARVIS_TRUST_CALIBRATION_ENABLED", "0")
+    assert tc.master_enabled() is False
+
+
+def _req(path="/observability/trust"):
+    r = make_mocked_request("GET", path, headers={})
+    r._transport_peername = ("127.0.0.1", 0)  # type: ignore[attr-defined]
+    return r
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _router():
+    from backend.core.ouroboros.governance.ide_observability import IDEObservabilityRouter
+    return IDEObservabilityRouter()
+
+
+def test_endpoint_disabled_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "false")
+    resp = _run(_router()._handle_trust_calibration(_req()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.disabled"
+
+
+def test_endpoint_substrate_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TRUST_CALIBRATION_ENABLED", "false")
+    resp = _run(_router()._handle_trust_calibration(_req()))
+    assert resp.status == 403
+    assert json.loads(resp.body.decode())["reason_code"] == "ide_observability.trust_disabled"
+
+
+def test_endpoint_returns_snapshot(monkeypatch):
+    monkeypatch.setenv("JARVIS_IDE_OBSERVABILITY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_TRUST_CALIBRATION_ENABLED", "true")
+    tc.reset_cache_for_tests()
+    resp = _run(_router()._handle_trust_calibration(_req()))
+    assert resp.status == 200
+    body = json.loads(resp.body.decode())
+    assert body["schema_version"] == tc.TRUST_CALIBRATION_SCHEMA_VERSION
+    assert "envelope" in body and "scopes" in body
+    assert body["envelope"]["widen_enabled"] is False   # default-inert surfaced
+    assert resp.headers.get("Cache-Control") == "no-store"


### PR DESCRIPTION
Carries the session's 11 commits ahead of main. Two threads:

**Autonomy pivot (measurement + self-perception)**
- **Goal Metric Dashboard** (`584d3f64da`) — `GET /observability/autonomy`: git-provable landed autonomous changes / unattended-day + regression rate + cost. The one metric that measures the O+V goal.
- **Capability Liveness Audit — Gap 2 Step 1** (`3c078668e8`) — `GET /observability/liveness`: static reachability of 364 enabled capabilities' public callables (severed-driver detection + trend).
- **Capability Firing Dimension — Gap 2 Step 2** (`214bfff3da`) — the precise merkle detector: reachable-but-never-fired = DORMANT, from source-derived markers + durable ledger/log evidence over an adaptive window. High-confidence dormancy requires a ledger evidence-of-work channel gone quiet.

All three are authority-free read-only projectors (0 orchestrator/policy/gate imports, grep-verified), composing existing substrate (FlagRegistry, AutoCommitter signature, session summaries, mirror_self_spec_drift), never-raise, zero-output-safe.

**Stability slices 26–32**
- 26 oracle sweep off-loop; 27 miner scan off-loop + merkle short-circuit restored; 28 embed-tail cooperative; 29 heartbeat watchdog false-positive fix; 30 embed circuit-breaker; 31 merkle hydration driver; 32 serpent_flow decomposition.

~250 new tests across the arc; each surface's spine green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only autonomy dashboard, self‑perception (liveness + runtime firing), a resilience verification matrix, and an expected‑value model for conceived work; plus stability slices 26–32 to remove event‑loop holds, contain embed failures, and stop false watchdog kills. Also introduces earned, adaptive trust calibration to safely widen or narrow auto‑apply by proven scope, and routes high‑EV conceived work into intake.

- **New Features**
  - Goal Metric Dashboard at `GET /observability/autonomy`: landed autonomous changes/day, regression rate, and cost; read‑only and fault‑tolerant.
  - Capability self‑perception at `GET /observability/liveness`: static reachability + runtime firing with DORMANT detection; no new stores, read‑only.
  - Fault‑Injection Matrix at `GET /observability/resilience`: injects seeded faults and verifies defenses; coverage surfaced with capability_firing as the oracle.
  - Merkle Cartographer hydration driver: boots snapshot, subscribes to fs events, and schedules full walks so merkle is hydrated in production.
  - Trust Calibration (Gap 4): earned per‑scope auto‑apply envelope from git‑provable record; widening (double opt‑in) applied before floors and cage‑safe, narrowing composed as a floor. Wired into `gate_runner` and `orchestrator`; `risk_tier_floor` consumes the narrowing candidate.
  - Conception Value Model (Gap 3): expected‑value ranker for self‑conceived work (alignment + substance + feasibility from scope trust + cost); grounds `intent_discovery_sensor` confidence with a neutral‑safe multiplier.
  - Conception Proposal Bridge (Gap 3): event‑driven routing of high‑EV blueprints from DreamEngine into the intake router with durable dedup; master‑off by default; wired via DreamEngine observers and `IntakeLayerService`.

- **Bug Fixes**
  - Oracle: cooperative chunked scan with AIMD backpressure; model constructors offloaded; reservation‑aware memory gate; scoped sweep embeds; adaptive cooperative embed tail with a consecutive‑failure circuit breaker.
  - OpportunityMiner: merkle subtree short‑circuit restored; per‑file AIMD throttle; candidate selection offloaded; AST pool lifecycle hardened; shared loop‑lag probe.
  - Watchdog: wall‑clock monitor supervision with bounded restarts; beat‑failure visibility; detailed poll/beat forensics to prevent false `heartbeat_stale` kills.
  - Refactor: reduced `serpent_flow` cyclomatic complexity by extracting `_dispatch_repl_command` and message handlers (behavior unchanged).

<sup>Written for commit d388392f7a0d35f022842f7a195a1b4268899d5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

