### PR TITLE
fix(gap3): wire conception bridge to DreamEngine via consciousness-bridge chain

### DIFF
--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -289,6 +289,35 @@ class IntakeLayerService:
             await self._teardown()
             raise
 
+    def _resolve_dream_engine(self) -> Any:
+        """Resolve the live DreamEngine through the canonical consciousness
+        handle chain, tolerant of how it was wired.
+
+        The TrinityConsciousness that owns ``_dream`` is attached to the GLS as
+        a ``ConsciousnessBridge`` (``gls._consciousness_bridge._consciousness``)
+        in the battle-test/production boot, but a direct ``gls._consciousness``
+        handle is also honored. Returns the first DreamEngine found exposing the
+        observer hook, else None. NEVER raises."""
+        gls = self._gls
+        candidates = []
+        try:
+            # 1. direct consciousness handle (if ever set)
+            candidates.append(getattr(gls, "_consciousness", None))
+            # 2. via the ConsciousnessBridge (the real battle-test wiring)
+            cb = getattr(gls, "_consciousness_bridge", None)
+            candidates.append(getattr(cb, "_consciousness", None))
+            # 3. a direct dream handle, if some boot path attaches one
+            direct = getattr(gls, "_dream_engine", None) or getattr(gls, "_dream", None)
+            for consciousness in candidates:
+                dream = getattr(consciousness, "_dream", None)
+                if dream is not None and hasattr(dream, "register_blueprint_observer"):
+                    return dream
+            if direct is not None and hasattr(direct, "register_blueprint_observer"):
+                return direct
+        except Exception:  # noqa: BLE001
+            logger.debug("[IntakeLayer] dream engine resolution faulted", exc_info=True)
+        return None
+
     def _start_conception_bridge(self, router: Any) -> None:
         """Gap 3 — register the conception proposal bridge as a DreamEngine
         blueprint observer, so ranked blueprints route themselves into the
@@ -296,9 +325,10 @@ class IntakeLayerService:
 
         Composition only: the bridge (translation), the value model (ranking),
         DreamEngine (production), and the router (queue) all pre-exist; this is
-        the missing production wiring. Resolution is best-effort down
-        ``gls._consciousness._dream`` — any missing handle or master-off flag
-        leaves the system byte-identical. NEVER raises."""
+        the missing production wiring. The DreamEngine is resolved through the
+        canonical consciousness handle chain (see ``_resolve_dream_engine``) —
+        any missing handle or master-off flag leaves the system byte-identical.
+        NEVER raises."""
         try:
             from backend.core.ouroboros.governance.conception_proposal_bridge import (
                 get_default_bridge,
@@ -310,8 +340,7 @@ class IntakeLayerService:
                     "stay unrouted (intent_discovery grounding still active)",
                 )
                 return
-            consciousness = getattr(self._gls, "_consciousness", None)
-            dream = getattr(consciousness, "_dream", None)
+            dream = self._resolve_dream_engine()
             if dream is None or not hasattr(dream, "register_blueprint_observer"):
                 logger.info(
                     "[IntakeLayer] Conception bridge enabled but no DreamEngine "

--- a/tests/governance/intake/test_conception_bridge_wiring.py
+++ b/tests/governance/intake/test_conception_bridge_wiring.py
@@ -1,0 +1,110 @@
+"""IntakeLayer → conception bridge wiring (Gap 3 live-soak fix).
+
+The DreamEngine that owns blueprint production is attached to the GLS as a
+ConsciousnessBridge (gls._consciousness_bridge._consciousness._dream), not a
+direct gls._consciousness handle — the first live soak proved the bridge went
+idle ("no DreamEngine reachable") because resolution only tried the direct
+handle. These tests pin the canonical handle-chain resolution + the arming
+path so the event source can never silently detach again.
+"""
+from __future__ import annotations
+
+import tempfile
+
+from backend.core.ouroboros.governance.intake.intake_layer_service import (
+    IntakeLayerConfig,
+    IntakeLayerService,
+)
+
+
+class _FakeDream:
+    def __init__(self):
+        self.observers = []
+
+    def register_blueprint_observer(self, cb):
+        self.observers.append(cb)
+
+    def get_blueprints(self, top_n=5):
+        return []
+
+
+class _Consciousness:
+    def __init__(self, dream):
+        self._dream = dream
+
+
+class _ConsciousnessBridge:
+    def __init__(self, consciousness):
+        self._consciousness = consciousness
+
+
+def _svc(gls):
+    with tempfile.TemporaryDirectory() as tmp:
+        return IntakeLayerService(
+            gls=gls, config=IntakeLayerConfig(project_root=tmp), say_fn=None,
+        )
+
+
+class _GLSViaBridge:
+    """Mirrors the real battle-test wiring."""
+    def __init__(self, dream):
+        self._consciousness_bridge = _ConsciousnessBridge(_Consciousness(dream))
+
+
+class _GLSDirect:
+    def __init__(self, dream):
+        self._consciousness = _Consciousness(dream)
+
+
+def test_resolves_dream_via_consciousness_bridge_chain():
+    d = _FakeDream()
+    assert _svc(_GLSViaBridge(d))._resolve_dream_engine() is d
+
+
+def test_resolves_dream_via_direct_consciousness_handle():
+    d = _FakeDream()
+    assert _svc(_GLSDirect(d))._resolve_dream_engine() is d
+
+
+def test_resolves_none_when_unreachable():
+    assert _svc(object())._resolve_dream_engine() is None
+
+
+def test_resolves_none_when_dream_lacks_observer_hook():
+    class _NoHook:
+        pass
+
+    class _GLS:
+        def __init__(self):
+            self._consciousness = _Consciousness(_NoHook())
+
+    assert _svc(_GLS())._resolve_dream_engine() is None
+
+
+def test_arming_registers_observer_when_enabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "true")
+    import backend.core.ouroboros.governance.conception_proposal_bridge as cpb
+    cpb.reset_bridge_for_tests()
+    d = _FakeDream()
+    svc = _svc(_GLSViaBridge(d))
+
+    class _Router:
+        async def ingest(self, e):
+            return "enqueued"
+
+    svc._start_conception_bridge(_Router())
+    assert len(d.observers) == 1        # the event source is now connected
+
+
+def test_arming_is_inert_when_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "false")
+    d = _FakeDream()
+    svc = _svc(_GLSViaBridge(d))
+    svc._start_conception_bridge(object())
+    assert d.observers == []             # default-off → no wiring
+
+
+def test_arming_never_raises_on_bad_gls(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "true")
+    svc = _svc(object())
+    svc._start_conception_bridge(object())   # no dream reachable → idle, no raise


### PR DESCRIPTION
The first Gap 3 live soak exposed the conception proposal bridge going idle — `Conception bridge enabled but no DreamEngine reachable`.

**Root cause:** the `TrinityConsciousness` that owns `_dream` is attached to the GLS as a `ConsciousnessBridge` (`gls._consciousness_bridge._consciousness._dream`), not the direct `gls._consciousness` handle the arming path assumed. The event source was never connected — a wired-but-inert bridge.

**Fix:** `_resolve_dream_engine()` walks the canonical consciousness handle chain and returns the first DreamEngine exposing the observer hook. Root-cause resolution through the real handle; never raises; unreachable → idle (byte-identical).

**Tests:** 7 focused wiring tests (bridge-chain + direct-handle resolution, None when unreachable/hook-less, arming registers the observer, inert when master-off, never-raises). In their own file to avoid the pre-existing hang in `test_service_start_idempotent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Gap 3 conception bridge going idle by resolving the DreamEngine through the consciousness-bridge chain and reliably registering the blueprint observer when enabled.

- **Bug Fixes**
  - Added `_resolve_dream_engine()` to walk `gls._consciousness`, `gls._consciousness_bridge._consciousness`, then `gls._dream_engine`/`_dream`, returning only engines with `register_blueprint_observer`; never raises.
  - Updated `_start_conception_bridge` to use the resolver; remains idle when no engine is reachable or when `JARVIS_CONCEPTION_BRIDGE_ENABLED` is off. Added focused wiring tests.

<sup>Written for commit ba32d1eae38ec415e340c4a3f1bee1e4d19ada66. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69907?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

