### PR TITLE
fix(gap3): hydrate DreamEngine repo-state so native conception can fire

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -3204,6 +3204,7 @@ class BattleTestHarness:
                         comm=_comm,
                         dw_provider=_dw_ref,
                         claude_provider=_claude_ref,
+                        repo_path=str(self._config.repo_path),
                     )
                     logger.info(
                         "DreamEngine booted (dw=%s, claude=%s, jprime=%s)",

--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -30,6 +30,7 @@ Thread-safety:
 from __future__ import annotations
 
 import asyncio
+import hashlib
 import json
 import logging
 import os
@@ -166,6 +167,7 @@ class DreamEngine:
         comm: Any = None,
         dw_provider: Any = None,
         claude_provider: Any = None,
+        repo_path: Optional[str] = None,
     ) -> None:
         self._health_cortex = health_cortex
         self._memory_engine = memory_engine
@@ -175,6 +177,10 @@ class DreamEngine:
         self._config = config
         self._jprime_url: str = jprime_url
         self._comm = comm
+        # Repo root for truthful repo-state hydration (git HEAD + policy hash).
+        # None → _get_git_head falls back to cwd (correct when the process runs
+        # from the repo root, e.g. the battle test).
+        self._repo_path: Optional[str] = repo_path
 
         # DW + Claude providers (preferred over raw J-Prime HTTP)
         self._dw_provider = dw_provider
@@ -245,16 +251,21 @@ class DreamEngine:
     async def start(self) -> None:
         """Load persisted state from disk and start the background dream loop."""
         self._load_state()
+        # Hydrate truthful repo-state at boot so the FIRST idle cycle can
+        # already derive a candidate (no wait for a later refresh).
+        self._hydrate_repo_state()
         self._loop_task = asyncio.create_task(
             self._dream_loop(), name="dream_engine_loop",
         )
         logger.info(
             "[DreamEngine] Started (idle_threshold=%.0fs, max_min/day=%.0f, "
-            "blueprints=%d, keys=%d)",
+            "blueprints=%d, keys=%d, head=%s, policy=%s)",
             self._config.dream_idle_threshold_s,
             self._config.dream_max_minutes_per_day,
             len(self._blueprints),
             len(self._completed_keys),
+            (self._current_head or "unset")[:10],
+            (self._current_policy_hash or "unset"),
         )
 
     async def stop(self) -> None:
@@ -504,6 +515,11 @@ class DreamEngine:
         """
         start_mono = time.monotonic()
 
+        # Adaptive refresh: re-hydrate truthful repo-state before selecting a
+        # candidate so a HEAD advanced since boot is honored (and stale
+        # blueprints from the prior HEAD are correctly discarded downstream).
+        self._hydrate_repo_state()
+
         # Build candidate info (in a real implementation this would
         # come from the oracle/memory engine analysis of the repo)
         candidate = self._pick_candidate()
@@ -575,6 +591,66 @@ class DreamEngine:
         self._metrics_tracker.record_compute_time(elapsed_min)
 
         return blueprint
+
+    def _hydrate_repo_state(self) -> None:
+        """Hydrate ``_current_head`` + ``_current_policy_hash`` from truthful
+        repository state so ``_pick_candidate`` can derive a candidate.
+
+        Dynamic + adaptive: called at boot and before each dream job, so a HEAD
+        that advances between cycles is picked up and older blueprints correctly
+        go stale. **Fail-safe** (Mandate 2): reuses ``memory_engine._get_git_head``
+        (5s-timeout subprocess that returns None on a locked/absent/erroring
+        index — DRY, Mandate 3) and only OVERWRITES the fields on a truthful
+        read. A None read leaves the prior value intact; on first boot that
+        keeps ``_current_head`` empty and ``_pick_candidate`` returns None (no
+        candidate, no crash) rather than dreaming about a phantom SHA. NEVER
+        raises — the dream loop and the primary governed loop are never
+        disturbed by a git hiccup."""
+        try:
+            from backend.core.ouroboros.consciousness.memory_engine import (
+                _get_git_head,
+            )
+
+            head = _get_git_head(self._repo_path)
+            if head:
+                self._current_head = head
+            policy_hash = self._compute_policy_hash()
+            if policy_hash:
+                self._current_policy_hash = policy_hash
+        except Exception:  # noqa: BLE001 — hydration is best-effort, fail-safe
+            logger.debug(
+                "[DreamEngine] repo-state hydration skipped", exc_info=True,
+            )
+
+    def _compute_policy_hash(self) -> str:
+        """Truthful, stable fingerprint of the active brain-selection policy.
+
+        sha256[:16] of ``brain_selection_policy.yaml`` (the canonical model
+        policy per CLAUDE.md), searched by env override then repo-relative
+        candidates. Returns the stable sentinel ``"nopolicy"`` when the file is
+        unreadable/absent — non-empty so the candidate guard passes, and stable
+        so staleness detection stays consistent. NEVER raises."""
+        try:
+            candidates = []
+            env_p = os.environ.get("JARVIS_BRAIN_POLICY_PATH", "").strip()
+            if env_p:
+                candidates.append(Path(env_p))
+            root = Path(self._repo_path) if self._repo_path else Path.cwd()
+            candidates += [
+                root / "brain_selection_policy.yaml",
+                root / "config" / "brain_selection_policy.yaml",
+                root / "backend" / "core" / "ouroboros" / "governance"
+                / "brain_selection_policy.yaml",
+            ]
+            for p in candidates:
+                try:
+                    if p.is_file():
+                        return hashlib.sha256(p.read_bytes()).hexdigest()[:16]
+                except OSError:
+                    continue
+        except Exception:  # noqa: BLE001
+            pass
+        return "nopolicy"
 
     def _pick_candidate(self) -> Optional[Dict[str, Any]]:
         """Select the next candidate for speculative analysis.

--- a/tests/test_ouroboros_governance/test_dream_engine.py
+++ b/tests/test_ouroboros_governance/test_dream_engine.py
@@ -765,3 +765,117 @@ async def test_start_loads_state(
 
     # Clean up the dream loop task
     await engine.stop()
+
+
+# ============================================================================
+# Repo-state hydration → candidate picker (Gap 3 live-soak fix)
+#
+# The live soak proved _pick_candidate was structurally unreachable: it is
+# gated on _current_head/_current_policy_hash, which nothing ever populated, so
+# DreamEngine produced 0 blueprints and the conception bridge had no event to
+# route. These pin the truthful hydration + the guard both ways.
+# ============================================================================
+
+
+def _hydration_engine(tmp_path: Path, repo_path: Any = None):
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    d = tmp_path / "dreams"
+    d.mkdir(exist_ok=True)
+    return DreamEngine(
+        health_cortex=MagicMock(),
+        memory_engine=MagicMock(),
+        activity_monitor=MockActivityMonitor(idle_seconds=600.0),
+        resource_governor=MagicMock(),
+        metrics_tracker=DreamMetricsTracker(),
+        config=_make_config(),
+        persistence_dir=d,
+        repo_path=repo_path,
+    )
+
+
+def test_pick_candidate_none_when_state_unhydrated(tmp_path):
+    """Mandate 4: missing repo-state → no candidate (the guard clause holds)."""
+    eng = _hydration_engine(tmp_path)
+    assert eng._current_head == "" and eng._current_policy_hash == ""
+    assert eng._pick_candidate() is None
+
+
+def test_pick_candidate_returns_candidate_when_hydrated(tmp_path):
+    """Mandate 4: hydrated repo-state → a native candidate derived from it."""
+    eng = _hydration_engine(tmp_path)
+    eng._current_head = "deadbeefcafe"
+    eng._current_policy_hash = "abc123def4567890"
+    cand = eng._pick_candidate()
+    assert cand is not None
+    assert cand["repo_sha"] == "deadbeefcafe"
+    assert cand["policy_hash"] == "abc123def4567890"
+    assert cand["repo"] == "jarvis"
+
+
+def test_hydrate_populates_head_and_policy(tmp_path, monkeypatch):
+    """Truthful hydration: real git HEAD via the reused _get_git_head util."""
+    import backend.core.ouroboros.consciousness.memory_engine as me
+    monkeypatch.setattr(me, "_get_git_head", lambda repo_path=None: "1234abcd5678")
+    eng = _hydration_engine(tmp_path)
+    eng._hydrate_repo_state()
+    assert eng._current_head == "1234abcd5678"
+    assert eng._current_policy_hash != ""       # a policy fingerprint was set
+    assert eng._pick_candidate() is not None     # end-to-end: guard now passes
+
+
+def test_hydrate_failsafe_when_git_unavailable(tmp_path, monkeypatch):
+    """Mandate 2: git locked/absent (head=None) → prior state kept, no crash,
+    candidate stays None (no phantom SHA dreamed about)."""
+    import backend.core.ouroboros.consciousness.memory_engine as me
+    monkeypatch.setattr(me, "_get_git_head", lambda repo_path=None: None)
+    eng = _hydration_engine(tmp_path)
+    eng._hydrate_repo_state()                     # must not raise
+    assert eng._current_head == ""                # untouched
+    assert eng._pick_candidate() is None          # still safe
+
+
+def test_hydrate_never_raises_on_git_exception(tmp_path, monkeypatch):
+    import backend.core.ouroboros.consciousness.memory_engine as me
+
+    def _boom(repo_path=None):
+        raise RuntimeError("git index locked")
+
+    monkeypatch.setattr(me, "_get_git_head", _boom)
+    eng = _hydration_engine(tmp_path)
+    eng._hydrate_repo_state()                     # swallowed, fail-safe
+    assert eng._current_head == ""
+
+
+def test_compute_policy_hash_reads_file(tmp_path):
+    (tmp_path / "brain_selection_policy.yaml").write_text("models:\n  a: b\n")
+    eng = _hydration_engine(tmp_path, repo_path=str(tmp_path))
+    h = eng._compute_policy_hash()
+    assert h != "nopolicy" and len(h) == 16       # sha256[:16] of the file
+
+
+def test_compute_policy_hash_sentinel_when_absent(tmp_path):
+    empty = tmp_path / "empty_repo"
+    empty.mkdir()                                     # exists but has no policy file
+    eng = _hydration_engine(tmp_path, repo_path=str(empty))
+    assert eng._compute_policy_hash() == "nopolicy"   # stable, non-empty
+
+
+def test_compute_policy_hash_honors_env_override(tmp_path, monkeypatch):
+    pol = tmp_path / "custom_policy.yaml"
+    pol.write_text("x: 1\n")
+    monkeypatch.setenv("JARVIS_BRAIN_POLICY_PATH", str(pol))
+    eng = _hydration_engine(tmp_path)
+    import hashlib as _h
+    assert eng._compute_policy_hash() == _h.sha256(pol.read_bytes()).hexdigest()[:16]
+
+
+def test_hydrate_adaptive_picks_up_advanced_head(tmp_path, monkeypatch):
+    """Adaptive: a HEAD that advances between cycles is re-hydrated."""
+    import backend.core.ouroboros.consciousness.memory_engine as me
+    heads = iter(["head_one", "head_two"])
+    monkeypatch.setattr(me, "_get_git_head", lambda repo_path=None: next(heads))
+    eng = _hydration_engine(tmp_path)
+    eng._hydrate_repo_state()
+    assert eng._current_head == "head_one"
+    eng._hydrate_repo_state()
+    assert eng._current_head == "head_two"        # advanced HEAD honored


### PR DESCRIPTION
The Gap 3 live soak proved the conception loop was blocked one layer *above* the (correctly-armed) bridge: DreamEngine's `_pick_candidate` is gated on `_current_head`/`_current_policy_hash`, which were initialized to `""` and **never populated anywhere** — so the picker returned `None` every cycle, produced 0 blueprints, and gave the bridge nothing to route.

**Root-cause fix** (no injected candidate, no guard bypass, no idle-threshold change): `_hydrate_repo_state()` populates both fields from truthful repository state — git HEAD via the reused `memory_engine._get_git_head` (DRY), and `_compute_policy_hash()` = sha256[:16] of `brain_selection_policy.yaml`. Called at boot and before each dream job (dynamic + adaptive). Fail-safe: a None/erroring git read leaves prior state intact and never raises.

Verified on the real repo — hydration yields the actual HEAD + policy hash and `_pick_candidate` fires (was `None`). 9 new tests; 25/25 dream_engine green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hydrates DreamEngine repo state so `_pick_candidate` can run natively and produce blueprints. Populates `_current_head` and `_current_policy_hash` from git HEAD and the policy file at boot and before each dream job, with fail‑safe behavior.

- **Bug Fixes**
  - Implemented `_hydrate_repo_state()` to set `_current_head` via `memory_engine._get_git_head` and `_current_policy_hash` as sha256[:16] of `brain_selection_policy.yaml` (env override supported; `"nopolicy"` sentinel when absent).
  - Invoked hydration in `start()` and before each dream job to honor HEAD changes and unblock `_pick_candidate`.
  - Added optional `repo_path` to DreamEngine and passed it from the battle test harness for correct repo resolution.
  - Made hydration non-throwing and state-preserving on git errors/None; added tests for guard behavior, hydration paths, env override, and adaptive HEAD changes.

<sup>Written for commit 9495e4671f06507e02ffca7fe751e7ea76279b90. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69908?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

