### PR TITLE
fix(gap3): repair DreamEngine inference-path API contracts (DW enable_thinking + ClaudeProvider.prompt_only)

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -459,13 +459,19 @@ def _reasoning_request_params(effort: str = "", *, complexity: str = "", model: 
     if eff == "none":
         # Slice 192 Phase 2 — DW honors enable_thinking ONLY nested in extra_body (Seb @
         # Doubleword). Inject it there DYNAMICALLY for catalog-confirmed reasoning models (no
-        # hardcoded names) to cut stream length → fewer ruptures at the source. When the catalog
-        # can't confirm, fall back to the legacy top-level flag (DW-ignored but harmless).
+        # hardcoded names) to cut stream length → fewer ruptures at the source.
+        #
+        # API-contract decay (2026-07-16, bt-2026-07-16-095428): DW now HARD-REJECTS the
+        # legacy TOP-LEVEL ``chat_template_kwargs.enable_thinking`` with a 400
+        # ("Unsupported parameter 'chat_template_kwargs.enable_thinking'; use 'reasoning_effort'")
+        # — it is no longer "ignored but harmless". ``reasoning_effort=none`` is the compliant,
+        # DW-honored signal and is ALWAYS present in ``params`` above, so when the catalog can't
+        # confirm the nested extra_body form we send reasoning_effort ALONE. The deprecated
+        # top-level flag is removed entirely (restores every prompt_only caller: DreamEngine,
+        # IntentDiscovery, SemanticTriage).
         _eb = _dw_thinking_extra_body(model)
         if _eb:
             params["extra_body"] = _eb
-        else:
-            params["chat_template_kwargs"] = {"enable_thinking": False}
     return params
 
 

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -29,7 +29,7 @@ import os
 import re
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Awaitable, Callable, Dict, List, Optional, Sequence, Set, Tuple
 
@@ -8053,6 +8053,67 @@ class ClaudeProvider:
             label="claude_create",
             deadline=deadline,
         )
+
+    async def prompt_only(
+        self,
+        prompt: str,
+        *,
+        model: Optional[str] = None,
+        caller_id: str = "ouroboros_cognition",
+        response_format: Optional[Dict[str, Any]] = None,
+        max_tokens: Optional[int] = None,
+        system: Optional[str] = None,
+        timeout_s: float = 60.0,
+    ) -> str:
+        """Direct single-turn Claude completion returning raw text.
+
+        Symmetric with :meth:`DoublewordProvider.prompt_only` — the raw-text
+        fast-path for cognition layers (DreamEngine, SemanticTriage,
+        IntentDiscovery) that need Claude inference WITHOUT the OperationContext
+        generation pipeline (which produces code-candidates for declared
+        target_files, not free-form text). Composes the existing resilient,
+        Aegis-gated, backoff-wrapped create path
+        (:meth:`_claude_create_with_resilience`, self-acquiring its client via
+        ``_ensure_client``) and extracts text with the same block-walk the
+        generation path uses.
+
+        ``response_format`` is accepted for call-site symmetry with the DW
+        provider but is inapplicable to Claude (no OpenAI-style JSON mode) —
+        callers embed the JSON-shape instruction in ``prompt``. Errors
+        PROPAGATE (no catch-all swallow) so the caller's tier-fallback governs;
+        returns ``""`` only when the model genuinely emits no text block.
+        """
+        _model = model or self._model
+        _max = max_tokens if max_tokens is not None else self._max_tokens
+        _timeout = float(timeout_s or 60.0)
+        _system = system or (
+            "You are a senior AI reasoning engine for the JARVIS Trinity "
+            "ecosystem. Think step by step and return well-structured output."
+        )
+        _messages: List[Dict[str, Any]] = [{"role": "user", "content": prompt}]
+        _create_kwargs: Dict[str, Any] = {
+            "model": _model,
+            "max_tokens": _max,
+            "system": _system,
+            "messages": _messages,
+        }
+        deadline = datetime.now(timezone.utc) + timedelta(seconds=_timeout)
+        msg = await self._claude_create_with_resilience(
+            create_kwargs=_create_kwargs,
+            messages=_messages,
+            use_prefill=False,
+            deadline=deadline,
+            timeout_s=_timeout,
+        )
+        # Text-only extraction (skip thinking blocks) — identical to the
+        # generation path's block walk.
+        raw = ""
+        for _block in (getattr(msg, "content", None) or []):
+            if getattr(_block, "type", None) == "text":
+                raw += getattr(_block, "text", "")
+        if not raw and getattr(msg, "content", None):
+            raw = getattr(msg.content[0], "text", "")
+        return raw or ""
 
     # ---------------------------------------------------------------------
     # Slice 2B-iii — paired extraction from _generate_raw closure

--- a/tests/governance/test_gap3_inference_path_fixes.py
+++ b/tests/governance/test_gap3_inference_path_fixes.py
@@ -1,0 +1,157 @@
+"""Gap 3 inference-path API-contract fixes (re-soak bt-2026-07-16-095428).
+
+The organic DreamEngine conception loop reached inference but failed on every
+provider tier:
+  A. DW hard-rejected the deprecated top-level ``chat_template_kwargs.enable_thinking``
+     with a 400 ("use 'reasoning_effort'").
+  B. the DreamEngine's Claude fallback called ``ClaudeProvider.prompt_only`` — a
+     method that did not exist (ClaudeProvider's real API is context-based
+     ``generate``, which produces code-candidates, not free-form text).
+
+These pin both API contracts so they cannot silently drift again.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Bug A — DW reasoning params never send the deprecated enable_thinking flag
+# ---------------------------------------------------------------------------
+
+import backend.core.ouroboros.governance.doubleword_provider as dwp
+
+
+def test_reasoning_params_never_send_top_level_enable_thinking(monkeypatch):
+    """The deprecated top-level chat_template_kwargs (DW 400) is gone; the
+    compliant reasoning_effort is always present."""
+    # Force the eff=="none" branch with no catalog-confirmed extra_body.
+    monkeypatch.setattr(dwp, "_dw_model_min_effort", lambda model: "none")
+    monkeypatch.setattr(dwp, "_dw_thinking_extra_body", lambda model="": {})
+    p = dwp._reasoning_request_params(effort="none", model="some/model")
+    assert p.get("reasoning_effort") == "none"
+    assert "chat_template_kwargs" not in p          # the deprecated 400-trigger
+    assert "extra_body" not in p                    # unconfirmed → effort alone
+
+
+def test_reasoning_params_use_extra_body_when_catalog_confirms(monkeypatch):
+    """When the catalog confirms reasoning control, the COMPLIANT nested
+    extra_body form is used (never the top-level flag)."""
+    monkeypatch.setattr(dwp, "_dw_model_min_effort", lambda model: "none")
+    monkeypatch.setattr(
+        dwp, "_dw_thinking_extra_body",
+        lambda model="": {"chat_template_kwargs": {"enable_thinking": False}},
+    )
+    p = dwp._reasoning_request_params(effort="none", model="reasoning/model")
+    assert p.get("reasoning_effort") == "none"
+    assert "extra_body" in p                         # nested, compliant
+    assert "chat_template_kwargs" not in p           # never top-level
+
+
+def test_reasoning_params_nonzero_effort_has_no_thinking_keys(monkeypatch):
+    monkeypatch.setattr(dwp, "_dw_model_min_effort", lambda model: "none")
+    p = dwp._reasoning_request_params(effort="low", model="m")
+    assert p["reasoning_effort"] == "low"
+    assert "chat_template_kwargs" not in p and "extra_body" not in p
+
+
+# ---------------------------------------------------------------------------
+# Bug B — ClaudeProvider.prompt_only (raw text, symmetric with DW)
+# ---------------------------------------------------------------------------
+
+from backend.core.ouroboros.governance.providers import ClaudeProvider
+
+
+class _Blk:
+    def __init__(self, type_, text):
+        self.type = type_
+        self.text = text
+
+
+class _Msg:
+    def __init__(self, blocks):
+        self.content = blocks
+
+
+def _bare_claude():
+    inst = ClaudeProvider.__new__(ClaudeProvider)   # skip live-client __init__
+    inst._model = "claude-sonnet-4-6"
+    inst._max_tokens = 2000
+    return inst
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def test_prompt_only_exists_and_is_async():
+    assert hasattr(ClaudeProvider, "prompt_only")
+    assert asyncio.iscoroutinefunction(ClaudeProvider.prompt_only)
+
+
+def test_prompt_only_composes_clean_create_kwargs():
+    inst = _bare_claude()
+    seen = {}
+
+    async def _fake(**kw):
+        seen.update(kw)
+        return _Msg([_Blk("text", "hello")])
+
+    inst._claude_create_with_resilience = _fake
+    out = _run(inst.prompt_only(
+        "dream prompt", model="claude-x", max_tokens=1500,
+        response_format={"type": "json_object"},
+    ))
+    ck = seen["create_kwargs"]
+    assert out == "hello"
+    assert ck["model"] == "claude-x" and ck["max_tokens"] == 1500
+    assert ck["messages"][0] == {"role": "user", "content": "dream prompt"}
+    assert "system" in ck
+    # response_format is inapplicable to Claude and must NOT leak into the body,
+    # nor may any deprecated DW-style key.
+    assert "response_format" not in ck and "chat_template_kwargs" not in ck
+
+
+def test_prompt_only_skips_thinking_blocks():
+    inst = _bare_claude()
+
+    async def _fake(**kw):
+        return _Msg([_Blk("thinking", "internal reasoning"), _Blk("text", "ANSWER")])
+
+    inst._claude_create_with_resilience = _fake
+    assert _run(inst.prompt_only("p")) == "ANSWER"
+
+
+def test_prompt_only_falls_back_to_first_block_text():
+    inst = _bare_claude()
+
+    async def _fake(**kw):
+        return _Msg([_Blk("other", "only block")])   # no 'text'-typed block
+
+    inst._claude_create_with_resilience = _fake
+    assert _run(inst.prompt_only("p")) == "only block"
+
+
+def test_prompt_only_empty_content_returns_empty_string():
+    inst = _bare_claude()
+
+    async def _fake(**kw):
+        return _Msg([])
+
+    inst._claude_create_with_resilience = _fake
+    assert _run(inst.prompt_only("p")) == ""
+
+
+def test_prompt_only_propagates_errors_no_swallow():
+    """Mandate 1: no catch-all swallow — a create error propagates to the
+    caller's tier-fallback logic."""
+    inst = _bare_claude()
+
+    async def _boom(**kw):
+        raise RuntimeError("anthropic 529 overloaded")
+
+    inst._claude_create_with_resilience = _boom
+    with pytest.raises(RuntimeError, match="overloaded"):
+        _run(inst.prompt_only("p"))


### PR DESCRIPTION
The organic conception loop (repo-state hydration merged) reached inference but `DREAM_DORMANT`'d on every provider tier. Two root-caused API-contract fixes:

**A. DW payload schema** — DW now hard-rejects the legacy top-level `chat_template_kwargs.enable_thinking` with a 400 (`use 'reasoning_effort'`). `reasoning_effort` is already present and is the honored signal, so the deprecated top-level fallback is removed (compliant nested `extra_body` kept when the catalog confirms it). DRY — restores DreamEngine + IntentDiscovery + SemanticTriage.

**B. `ClaudeProvider.prompt_only` was missing** — the DreamEngine's Claude fallback correctly called `prompt_only` (symmetric with `DoublewordProvider.prompt_only`), but ClaudeProvider only exposed context-based `generate()`, which emits patch-candidates for declared `target_files` — unfit for target-less dream speculation. Added a raw single-turn completion reusing the existing resilient, Aegis-gated create path; errors propagate (no swallow).

9 new regression tests. Adjacent green: slice168+169, dream_engine (25), providers (63 pass; the 2 reds are pre-existing — a hardcoded `2026-03-07` deadline now in the past + an unrelated codegen-flag assertion).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes DreamEngine inference by repairing provider API contracts: DW now relies on `reasoning_effort` only, and Claude gets a raw `prompt_only` path. Restores dream runs for DreamEngine, IntentDiscovery, and SemanticTriage.

- **Bug Fixes**
  - Doubleword requests: remove deprecated top‑level `chat_template_kwargs.enable_thinking`; always send `reasoning_effort`; use nested `extra_body` only when the catalog confirms reasoning models (prevents 400s).
  - Claude provider: add `ClaudeProvider.prompt_only(prompt, ...)` for single‑turn completions via `_claude_create_with_resilience`; returns text only (skips thinking blocks) and propagates errors.

<sup>Written for commit 06ab29d658e51f2412cbacfe40d140295d82a91d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69909?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

