### PR TITLE
feat(positioning): Claude-RT-first critical path (DreamEngine RT + 8 gates via unified rt_gate)

### DIFF
--- a/backend/core/ouroboros/architect/reasoning_agent.py
+++ b/backend/core/ouroboros/architect/reasoning_agent.py
@@ -242,17 +242,31 @@ class ArchitectureReasoningAgent:
             max_steps=self._config.max_steps,
         )
 
-        # --- 3. Call Doubleword ---
-        raw = await self._doubleword.prompt_only(
-            prompt=prompt,
-            caller_id="architecture_agent",
-            response_format=ARCHITECTURAL_PLAN_JSON_SCHEMA,
+        # --- 3. Call the unified RT gate router ---
+        # Phase 2 RT repositioning (2026-07-16): architectural planning sits on
+        # the COMPLEX route's blocking path ("Claude plans → DW executes") — it
+        # buys TIME. Claude-RT first, this agent's DW handle as the
+        # opportunistic fallback. Plan validation below is unchanged.
+        from backend.core.ouroboros.governance.rt_gate import (
+            GateProviderExhaustedError,
+            gate_completion,
         )
+
+        try:
+            raw = await gate_completion(
+                prompt,
+                caller_id="architecture_agent",
+                response_format=ARCHITECTURAL_PLAN_JSON_SCHEMA,
+                max_tokens=4096,
+                dw_provider=self._doubleword,
+            )
+        except GateProviderExhaustedError:
+            raw = ""
 
         if not raw:
             logger.warning(
-                "ArchitectureReasoningAgent: empty response from Doubleword "
-                "(hypothesis=%r)",
+                "ArchitectureReasoningAgent: empty response from RT gate "
+                "router (hypothesis=%r)",
                 getattr(hypothesis, "hypothesis_id", repr(hypothesis)),
             )
             return None

--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -55,6 +55,16 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 
 DREAM_MAX_PROMPT_CHARS: int = 2048
+
+
+class DreamProviderExhaustedError(RuntimeError):
+    """All RT inference tiers (DW → Claude → J-Prime) failed for a dream job.
+
+    Typed routing exception (RT migration, 2026-07-16): per-tier failures are
+    raised and caught at each tier boundary to drive the cascade; when the
+    whole cascade is exhausted THIS is raised so the caller makes an explicit
+    routing decision (emit DREAM_DORMANT + skip the cycle) instead of
+    interpreting an ambiguous ``None``."""
 """Hard cap on dream prompt text length (TC23)."""
 
 _DREAM_LOOP_INTERVAL_S: float = 30.0
@@ -553,8 +563,14 @@ class DreamEngine:
         prompt = self._build_dream_prompt(candidate)
         prompt = self._truncate_prompt(prompt)
 
-        # Send via DW (primary) → Claude (fallback) → J-Prime (legacy)
-        result = await self._call_inference(prompt)
+        # Send via the RT cascade: DW-RT → Claude-RT → J-Prime (legacy).
+        # Exhaustion is a TYPED routing exception, not an ambiguous None.
+        try:
+            result = await self._call_inference(prompt)
+        except DreamProviderExhaustedError as exc:
+            logger.warning("[DreamEngine] inference cascade exhausted: %s", exc)
+            await self._emit_dormant("provider_cascade_exhausted")
+            return None
 
         # Check preemption after HTTP (TC17)
         if self._check_preempted():
@@ -564,8 +580,7 @@ class DreamEngine:
             return None
 
         if result is None:
-            # J-Prime unavailable — emit dormant (TC24)
-            await self._emit_dormant("jprime_request_failed")
+            # Preempted mid-tier — no dormant emit, just skip the cycle.
             return None
 
         # Build blueprint from result
@@ -704,42 +719,79 @@ class DreamEngine:
         if self._check_preempted():
             return None
 
-        # Tier 1: Doubleword (35B for light dreaming — 30x cheaper than Claude)
-        if self._dw_provider is not None:
+        # ------------------------------------------------------------------
+        # RT migration (2026-07-16): dreaming is LATENCY-SENSITIVE (a soak or
+        # idle window waits on it), so every tier is a REAL-TIME call with a
+        # hard per-tier timeout and FAIL-FAST semantics — a tier that times
+        # out or errors RAISES at its boundary and the cascade moves on. The
+        # old Tier-1 used the DW 4-stage BATCH API (24h completion window),
+        # which is the token-cheap queue for volume work — architecturally
+        # wrong for a caller with minutes of patience (bt-2026-07-16-173540:
+        # 40 min soak, 5 dream jobs, 0 completions, 0 blueprints).
+        # ------------------------------------------------------------------
+        rt_timeout = self._dream_rt_timeout_s()
+
+        # Tier 1: Doubleword RT — complete_sync (stream-free
+        # /v1/chat/completions, the Functions-not-Agents primitive built
+        # because DW's SSE endpoint stalls post-accept; it raises
+        # DoublewordInfraError on HTTP errors and TimeoutError on expiry).
+        if self._dw_provider is not None and hasattr(self._dw_provider, "complete_sync"):
             try:
-                _dw_model = os.environ.get(
-                    "JARVIS_DREAM_DW_MODEL", "Qwen/Qwen3.5-35B-A3B-FP8"
-                )
-                raw = await self._dw_provider.prompt_only(
-                    prompt=prompt,
-                    model=_dw_model,
-                    caller_id="dream_engine",
-                    response_format={"type": "json_object"},
-                    max_tokens=DREAM_MAX_PROMPT_CHARS,
+                # Model: env override, else the provider's own default (the
+                # account's entitled model) — no hardcoded model names.
+                _dw_model = os.environ.get("JARVIS_DREAM_DW_MODEL", "").strip() or None
+                res = await asyncio.wait_for(
+                    self._dw_provider.complete_sync(
+                        prompt,
+                        system_prompt=(
+                            "You are a senior AI reasoning engine for the "
+                            "JARVIS Trinity ecosystem. Return well-structured "
+                            "JSON output."
+                        ),
+                        caller_id="dream_engine",
+                        model=_dw_model,
+                        max_tokens=DREAM_MAX_PROMPT_CHARS,
+                        timeout_s=rt_timeout,
+                        response_format={"type": "json_object"},
+                    ),
+                    timeout=rt_timeout + 5.0,
                 )
                 if self._check_preempted():
                     return None
+                raw = getattr(res, "content", "") or ""
                 if raw:
                     result = self._parse_json_response(raw)
                     if result is not None:
                         result["_inference_provider"] = "doubleword"
-                        result["_inference_model"] = _dw_model
-                        logger.debug("[DreamEngine] DW inference succeeded (model=%s)", _dw_model)
+                        result["_inference_model"] = getattr(res, "model", _dw_model or "")
+                        logger.info(
+                            "[DreamEngine] DW RT inference succeeded (model=%s, %.1fs)",
+                            getattr(res, "model", "?"), getattr(res, "latency_s", -1.0),
+                        )
                         return result
-                    logger.debug("[DreamEngine] DW returned non-JSON, trying next tier")
+                    logger.info("[DreamEngine] DW RT returned non-JSON, cascading")
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.debug("[DreamEngine] DW inference failed: %s", exc)
+                # Fail-fast boundary: timeout / HTTP error / infra fault →
+                # visible cascade, never a silent empty-string swallow.
+                logger.info(
+                    "[DreamEngine] DW RT tier failed (%s: %s) — cascading to Claude",
+                    type(exc).__name__, exc,
+                )
 
-        # Tier 2: Claude API (reliable, handles complex reasoning)
+        # Tier 2: Claude RT — prompt_only (resilient, Aegis-gated create path).
         if self._claude_provider is not None:
             try:
-                raw = await self._claude_provider.prompt_only(
-                    prompt=prompt,
-                    caller_id="dream_engine",
-                    response_format={"type": "json_object"},
-                    max_tokens=DREAM_MAX_PROMPT_CHARS,
+                raw = await asyncio.wait_for(
+                    self._claude_provider.prompt_only(
+                        prompt=prompt,
+                        caller_id="dream_engine",
+                        response_format={"type": "json_object"},
+                        max_tokens=DREAM_MAX_PROMPT_CHARS,
+                        timeout_s=rt_timeout,
+                    ),
+                    timeout=rt_timeout + 5.0,
                 )
                 if self._check_preempted():
                     return None
@@ -747,15 +799,33 @@ class DreamEngine:
                     result = self._parse_json_response(raw)
                     if result is not None:
                         result["_inference_provider"] = "claude"
-                        logger.debug("[DreamEngine] Claude inference succeeded")
+                        logger.info("[DreamEngine] Claude RT inference succeeded")
                         return result
+                    logger.info("[DreamEngine] Claude RT returned non-JSON, cascading")
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
-                logger.debug("[DreamEngine] Claude inference failed: %s", exc)
+                logger.info(
+                    "[DreamEngine] Claude RT tier failed (%s: %s) — cascading to J-Prime",
+                    type(exc).__name__, exc,
+                )
 
         # Tier 3: J-Prime direct HTTP (legacy fallback — TC29)
-        return await self._call_jprime_legacy(prompt)
+        result = await self._call_jprime_legacy(prompt)
+        if result is None:
+            raise DreamProviderExhaustedError(
+                "all RT inference tiers exhausted (dw_rt, claude_rt, jprime)"
+            )
+        return result
+
+    @staticmethod
+    def _dream_rt_timeout_s() -> float:
+        """Per-tier RT budget (``JARVIS_DREAM_RT_TIMEOUT_S``, default 90s —
+        sized to DW RT's measured ~67s p50 TTFT with headroom). Never raises."""
+        try:
+            return max(5.0, float(os.environ.get("JARVIS_DREAM_RT_TIMEOUT_S", "90")))
+        except (TypeError, ValueError):
+            return 90.0
 
     async def _call_jprime_legacy(self, prompt: str) -> Optional[Dict[str, Any]]:
         """Legacy J-Prime direct HTTP fallback (TC29).

--- a/backend/core/ouroboros/governance/comms/karen_synth/speech_provider.py
+++ b/backend/core/ouroboros/governance/comms/karen_synth/speech_provider.py
@@ -22,16 +22,22 @@ class DWSpeechProvider:
         self._max_tokens = max_tokens
 
     async def source(self, *, system_prompt: str, user_prompt: str) -> AsyncIterator[str]:
+        # Phase 2 RT repositioning (2026-07-16): a HUMAN is waiting on speech —
+        # the purest buy-time call in the codebase. Routes through the unified
+        # Claude-RT-first gate router (this provider's DW handle stays as the
+        # opportunistic fallback). Contract unchanged: one chunk, never raises.
         try:
-            res = await self._dw.complete_sync(
+            from backend.core.ouroboros.governance.rt_gate import gate_completion
+
+            content = await gate_completion(
                 user_prompt,
-                system_prompt=system_prompt,
                 caller_id="karen_synth",
+                system_prompt=system_prompt,
                 max_tokens=self._max_tokens,
+                dw_provider=self._dw,
             )
-            content = getattr(res, "content", "") or ""
             if content.strip():
                 yield content
-        except Exception:  # noqa: BLE001
-            logger.debug("[KarenSynth] DW completion failed", exc_info=True)
+        except Exception:  # noqa: BLE001 — incl. GateProviderExhaustedError
+            logger.debug("[KarenSynth] RT completion failed", exc_info=True)
             return

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -7713,10 +7713,40 @@ class DoublewordProvider:
         except Exception:  # noqa: BLE001 — model resolution must not block parse
             _model_id_for_drift = ""
 
+        # Phase 2 RT repositioning (2026-07-16): JSON healing blocks an
+        # in-flight generation parse — it buys TIME. Inject the unified
+        # Claude-RT-first gate router (DW-RT opportunistic) instead of the
+        # 4-stage batch prompt_only. The healer module itself is untouched;
+        # the adapter matches its HealCall shape (prompt/model/caller_id/
+        # max_tokens → str, "" on failure — the documented contract).
+        async def _rt_heal_call(
+            prompt: str,
+            *,
+            model: Optional[str] = None,
+            caller_id: str = "json_healer",
+            response_format: Optional[dict] = None,
+            max_tokens: Optional[int] = None,
+        ) -> str:
+            from backend.core.ouroboros.governance.rt_gate import (
+                GateProviderExhaustedError,
+                gate_completion,
+            )
+            try:
+                return await gate_completion(
+                    prompt,
+                    caller_id=caller_id,
+                    response_format=response_format or {"type": "json_object"},
+                    max_tokens=max_tokens or 2000,
+                    dw_provider=self,
+                    dw_model=model or None,
+                )
+            except GateProviderExhaustedError:
+                return ""  # the healer's documented failure contract
+
         return await heal_and_retry_parse(
             raw=raw,
             parse_fn=_do_parse,
-            heal_call=self.prompt_only,
+            heal_call=_rt_heal_call,
             op_id=getattr(ctx, "op_id", "") or "",
             provider_name=provider_name,
             model_id=_model_id_for_drift,

--- a/backend/core/ouroboros/governance/intent_prompter.py
+++ b/backend/core/ouroboros/governance/intent_prompter.py
@@ -258,41 +258,32 @@ async def request_intent(
     user_prompt = build_user_prompt(req)
 
     async def _call() -> str:
-        # Construct + invoke the provider. The exact API varies by
-        # provider; we use a defensive feature-detection pattern.
+        # Phase 2 RT repositioning (2026-07-16): narrative intent renders
+        # inline while the operator watches — it buys TIME. Routed through
+        # the unified Claude-RT-first gate router (DW-RT opportunistic,
+        # constructed lazily as the fallback handle). Outer timeout and
+        # IntentResult semantics unchanged.
+        from backend.core.ouroboros.governance.rt_gate import (
+            GateProviderExhaustedError,
+            gate_completion,
+        )
+
+        _dw = None
         try:
-            provider = DoublewordProvider()
-        except Exception as exc:  # noqa: BLE001
-            raise RuntimeError(f"provider construct failed: {exc}")
+            _dw = DoublewordProvider()
+        except Exception:  # noqa: BLE001 — DW handle is optional fallback
+            _dw = None
 
-        # Try the modern ``generate(messages, max_tokens=...)`` API
-        # first; fall back to a string-based ``completion(prompt)`` if
-        # the provider exposes it.
-        if hasattr(provider, "generate"):
-            messages = [
-                {"role": "system", "content": _SYSTEM_PROMPT},
-                {"role": "user", "content": user_prompt},
-            ]
-            try:
-                result = await provider.generate(  # type: ignore[attr-defined]
-                    messages=messages,
-                    max_tokens=eff_max_tokens,
-                )
-                return _extract_text(result)
-            except Exception as exc:  # noqa: BLE001
-                raise RuntimeError(f"generate raised: {exc}")
-
-        if hasattr(provider, "completion"):
-            try:
-                result = await provider.completion(  # type: ignore[attr-defined]
-                    prompt=user_prompt,
-                    max_tokens=eff_max_tokens,
-                )
-                return _extract_text(result)
-            except Exception as exc:  # noqa: BLE001
-                raise RuntimeError(f"completion raised: {exc}")
-
-        raise RuntimeError("provider exposes no generate/completion API")
+        try:
+            return await gate_completion(
+                user_prompt,
+                caller_id="intent_prompter",
+                system_prompt=_SYSTEM_PROMPT,
+                max_tokens=eff_max_tokens,
+                dw_provider=_dw,
+            )
+        except GateProviderExhaustedError as exc:
+            raise RuntimeError(f"rt gate exhausted: {exc}")
 
     try:
         prose = await asyncio.wait_for(_call(), timeout=eff_timeout)

--- a/backend/core/ouroboros/governance/pr_self_linter.py
+++ b/backend/core/ouroboros/governance/pr_self_linter.py
@@ -35,16 +35,24 @@ class LintRejected(RuntimeError):
 
 
 async def default_critique_fn(diff: str) -> dict:
-    """Bounded, structured one-shot critique via the cheapest existing provider."""
-    from .doubleword_provider import DoublewordProvider
+    """Bounded, structured one-shot critique.
+
+    Phase 2 RT repositioning (2026-07-16): this gate blocks PR creation — it
+    buys TIME, so it routes through the unified Claude-RT-first gate router
+    (DW-RT opportunistic fallback). Critique rules/threshold/fail-closed
+    semantics are unchanged."""
+    from .rt_gate import GateProviderExhaustedError, gate_completion
     from .self_critique import parse_critique_json
-    provider = DoublewordProvider()
-    raw = await provider.prompt_only(
-        prompt=f"{_RULES}\n\nDIFF:\n{diff}",
-        caller_id="pr_self_linter",
-        response_format={"type": "json_object"},
-        max_tokens=512,
-    )
+    try:
+        raw = await gate_completion(
+            f"{_RULES}\n\nDIFF:\n{diff}",
+            caller_id="pr_self_linter",
+            response_format={"type": "json_object"},
+            max_tokens=512,
+        )
+    except GateProviderExhaustedError:
+        logger.warning("[Gate3] pr_self_linter: all RT tiers exhausted; fail-closed rating=0")
+        return {"rating": 0, "concerns": ["provider_exhausted"]}
     parsed, ok = parse_critique_json(raw, op_id="pr_self_linter")
     if not ok:
         logger.warning("[Gate3] pr_self_linter: critique parse failed; fail-closed rating=0")

--- a/backend/core/ouroboros/governance/rt_gate.py
+++ b/backend/core/ouroboros/governance/rt_gate.py
@@ -1,0 +1,217 @@
+"""RT Gate Router — Claude-RT-first completion for synchronous pipeline gates.
+
+Phase 2 of the provider-positioning pivot (2026-07-16). The pipeline's
+synchronous GATES (triage, critique, lint, heal, narrate, plan, review) are
+LATENCY-SENSITIVE: an op the soak/human is waiting on blocks behind each one.
+They were historically pointed at DoubleWord's token-priced queue — buying a
+sub-cent discount with minutes of wall clock. This module is the ONE place
+that encodes the correct positioning:
+
+    Claude sells TIME  → gates buy time  → Claude-RT first.
+    DW sells TOKENS    → kept as the OPPORTUNISTIC fallback (its stream-free
+                         RT primitive ``complete_sync``), so a Claude outage
+                         degrades a gate to slower-but-alive instead of dead.
+
+Design contract (Mandate 3 — no duplicated fallback logic in gate classes):
+  * ``gate_completion()`` is the single entry point. Gates pass their prompt
+    and (optionally) their injected provider handles; ALL ordering, timeout,
+    and fallback policy lives here.
+  * Claude resolution is two-tier: an injected ``claude_provider`` (uses its
+    resilient ``prompt_only``) else the provider-less, Aegis-wrapped
+    ``claude_fallback.claude_inference`` — so gates that were constructed
+    with only a DW handle still reach Claude without rewiring constructors.
+  * Failures RAISE ``GateProviderExhaustedError`` (typed) only when every
+    tier is exhausted; each gate keeps its own fail-open/fail-closed
+    semantics around that exception — gate logic is NOT rewritten here
+    (Mandate 1).
+  * ``JARVIS_GATE_CLAUDE_FIRST_ENABLED`` (default TRUE) is the master; OFF
+    restores DW-first ordering (one-flip rollback, byte-equivalent priority).
+
+Env knobs:
+  * ``JARVIS_GATE_CLAUDE_FIRST_ENABLED``  (default true)
+  * ``JARVIS_GATE_RT_TIMEOUT_S``          (default 60; floor 5)
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+_DEFAULT_SYSTEM = (
+    "You are a senior AI reasoning engine for the JARVIS Trinity ecosystem. "
+    "Think step by step and return well-structured output."
+)
+
+
+class GateProviderExhaustedError(RuntimeError):
+    """Every RT tier (Claude injected → Claude fallback → DW-RT) failed for a
+    gate completion. Gates decide fail-open vs fail-closed on this."""
+
+
+def claude_first_enabled() -> bool:
+    """Master — ``JARVIS_GATE_CLAUDE_FIRST_ENABLED`` (default true)."""
+    return os.environ.get(
+        "JARVIS_GATE_CLAUDE_FIRST_ENABLED", "true",
+    ).strip().lower() in _TRUTHY
+
+
+def gate_rt_timeout_s() -> float:
+    """Per-tier RT budget (``JARVIS_GATE_RT_TIMEOUT_S``, default 60s)."""
+    try:
+        return max(5.0, float(os.environ.get("JARVIS_GATE_RT_TIMEOUT_S", "60")))
+    except (TypeError, ValueError):
+        return 60.0
+
+
+async def _try_claude(
+    prompt: str,
+    *,
+    caller_id: str,
+    max_tokens: int,
+    response_format: Optional[Dict[str, Any]],
+    timeout_s: float,
+    claude_provider: Any = None,
+) -> Optional[str]:
+    """Claude tier: injected provider's resilient ``prompt_only``, else the
+    provider-less Aegis-wrapped ``claude_inference``. Returns text or None
+    (this tier's failure is non-fatal — the caller cascades)."""
+    # 1a. Injected ClaudeProvider (the resilient, budget-gated path).
+    if claude_provider is not None and hasattr(claude_provider, "prompt_only"):
+        try:
+            raw = await asyncio.wait_for(
+                claude_provider.prompt_only(
+                    prompt=prompt,
+                    caller_id=caller_id,
+                    response_format=response_format,
+                    max_tokens=max_tokens,
+                    timeout_s=timeout_s,
+                ),
+                timeout=timeout_s + 5.0,
+            )
+            if raw:
+                return raw
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — tier boundary, cascade on
+            logger.info(
+                "[RTGate] claude(injected) tier failed for %s (%s: %s)",
+                caller_id, type(exc).__name__, exc,
+            )
+    # 1b. Provider-less Claude (constructs its own Aegis-wrapped client).
+    try:
+        from backend.core.ouroboros.claude_fallback import claude_inference
+
+        raw = await asyncio.wait_for(
+            claude_inference(
+                prompt,
+                caller_id=caller_id,
+                response_format=response_format,
+                max_tokens=max_tokens,
+            ),
+            timeout=timeout_s + 5.0,
+        )
+        if raw:
+            return raw
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.info(
+            "[RTGate] claude(fallback) tier failed for %s (%s: %s)",
+            caller_id, type(exc).__name__, exc,
+        )
+    return None
+
+
+async def _try_dw_rt(
+    prompt: str,
+    *,
+    caller_id: str,
+    system_prompt: str,
+    max_tokens: int,
+    response_format: Optional[Dict[str, Any]],
+    timeout_s: float,
+    dw_provider: Any = None,
+    dw_model: Optional[str] = None,
+) -> Optional[str]:
+    """DW tier — the stream-free RT primitive ``complete_sync`` ONLY (never
+    the 24h batch queue: a gate blocks an op, so a batch wait is forbidden
+    here by design). Returns text or None."""
+    if dw_provider is None or not hasattr(dw_provider, "complete_sync"):
+        return None
+    try:
+        res = await asyncio.wait_for(
+            dw_provider.complete_sync(
+                prompt,
+                system_prompt=system_prompt,
+                caller_id=caller_id,
+                model=dw_model,
+                max_tokens=max_tokens,
+                timeout_s=timeout_s,
+                response_format=response_format,
+            ),
+            timeout=timeout_s + 5.0,
+        )
+        raw = getattr(res, "content", "") or ""
+        if raw:
+            return raw
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        logger.info(
+            "[RTGate] dw_rt tier failed for %s (%s: %s)",
+            caller_id, type(exc).__name__, exc,
+        )
+    return None
+
+
+async def gate_completion(
+    prompt: str,
+    *,
+    caller_id: str,
+    system_prompt: Optional[str] = None,
+    max_tokens: int = 512,
+    response_format: Optional[Dict[str, Any]] = None,
+    timeout_s: Optional[float] = None,
+    claude_provider: Any = None,
+    dw_provider: Any = None,
+    dw_model: Optional[str] = None,
+) -> str:
+    """Single-turn RT completion for a synchronous pipeline gate.
+
+    Claude-RT first (buying time), DW-RT opportunistic fallback (availability),
+    per :mod:`rt_gate` module contract. Raises
+    :class:`GateProviderExhaustedError` when every tier fails — the caller's
+    own fail-open/fail-closed semantics take over from there. Never returns
+    an empty string.
+    """
+    t = timeout_s if timeout_s is not None else gate_rt_timeout_s()
+    sys_p = system_prompt or _DEFAULT_SYSTEM
+
+    async def _claude() -> Optional[str]:
+        return await _try_claude(
+            prompt, caller_id=caller_id, max_tokens=max_tokens,
+            response_format=response_format, timeout_s=t,
+            claude_provider=claude_provider,
+        )
+
+    async def _dw() -> Optional[str]:
+        return await _try_dw_rt(
+            prompt, caller_id=caller_id, system_prompt=sys_p,
+            max_tokens=max_tokens, response_format=response_format,
+            timeout_s=t, dw_provider=dw_provider, dw_model=dw_model,
+        )
+
+    tiers = (_claude, _dw) if claude_first_enabled() else (_dw, _claude)
+    for tier in tiers:
+        raw = await tier()
+        if raw:
+            return raw
+    raise GateProviderExhaustedError(
+        f"gate_completion exhausted all RT tiers (caller={caller_id}, "
+        f"order={'claude,dw' if claude_first_enabled() else 'dw,claude'})"
+    )

--- a/backend/core/ouroboros/governance/security_reviewer.py
+++ b/backend/core/ouroboros/governance/security_reviewer.py
@@ -146,22 +146,44 @@ class SecurityReviewer:
             prompt = self._build_review_prompt(candidate, target_files, description)
             system_prompt = self._build_system_prompt()
 
-            response = await self._client.generate(
-                prompt=prompt,
-                system_prompt=system_prompt,
-                max_tokens=4096,
-                temperature=0.1,  # low temperature for consistent judgment
-                model_name=self._brain,
-                task_profile=None,
-            )
+            # Phase 2 RT repositioning (2026-07-16): security review blocks
+            # APPLY — it buys TIME. Claude-RT first via the unified gate
+            # router; the injected brain client stays as the FINAL tier so a
+            # configured local/J-Prime brain still serves when the RT tiers
+            # are exhausted. Verdict parsing below is unchanged.
+            raw_text = ""
+            source = ""
+            try:
+                from backend.core.ouroboros.governance.rt_gate import (
+                    gate_completion,
+                )
 
-            result = self._parse_response(response.content, response.source)
+                raw_text = await gate_completion(
+                    prompt,
+                    caller_id="security_reviewer",
+                    system_prompt=system_prompt,
+                    max_tokens=4096,
+                )
+                source = "rt_gate"
+            except Exception:  # noqa: BLE001 — incl. GateProviderExhausted
+                response = await self._client.generate(
+                    prompt=prompt,
+                    system_prompt=system_prompt,
+                    max_tokens=4096,
+                    temperature=0.1,  # low temperature for consistent judgment
+                    model_name=self._brain,
+                    task_profile=None,
+                )
+                raw_text = response.content
+                source = response.source
+
+            result = self._parse_response(raw_text, source)
             elapsed = time.monotonic() - start
             return SecurityReviewResult(
                 verdict=result["verdict"],
                 findings=result["findings"],
                 summary=result["summary"],
-                reviewer_brain=response.source,
+                reviewer_brain=source,
                 review_duration_s=elapsed,
             )
 

--- a/backend/core/ouroboros/governance/self_critique.py
+++ b/backend/core/ouroboros/governance/self_critique.py
@@ -293,15 +293,21 @@ class DoublewordCritiqueProvider:
 
     async def critique(self, request: CritiqueRequest) -> str:
         prompt = build_critique_prompt(request)
-        # DoublewordProvider.prompt_only enforces its own budget/session.
-        # Wrap it in our deadline as a second layer of defense.
+        # Phase 2 RT repositioning (2026-07-16): critique blocks apply/PR — it
+        # buys TIME, so it routes through the unified Claude-RT-first gate
+        # router with this backend's DW handle as the opportunistic fallback.
+        # Engine-facing contract unchanged: returns raw text or raises (the
+        # engine handles swallowing).
+        from backend.core.ouroboros.governance.rt_gate import gate_completion
+
         try:
             return await asyncio.wait_for(
-                self._dw.prompt_only(
-                    prompt=prompt,
+                gate_completion(
+                    prompt,
                     caller_id=self._caller_id,
                     response_format={"type": "json_object"},
                     max_tokens=self._max_tokens,
+                    dw_provider=self._dw,
                 ),
                 timeout=request.deadline_s,
             )

--- a/backend/core/ouroboros/governance/semantic_triage.py
+++ b/backend/core/ouroboros/governance/semantic_triage.py
@@ -404,19 +404,27 @@ class SemanticTriageEngine:
             if not prompt:
                 return TriageResult(decision=TriageDecision.SKIP)
 
-            # Call DW with the cheap 35B model
-            raw_response = await asyncio.wait_for(
-                self._dw.prompt_only(
-                    prompt=prompt,
-                    model=self._effective_model,
+            # Phase 2 RT repositioning (2026-07-16): triage is a synchronous
+            # gate every op blocks on — it buys TIME, so it routes through the
+            # unified Claude-RT-first gate router (DW-RT opportunistic
+            # fallback). All ordering/timeout/fallback policy lives in
+            # rt_gate.gate_completion; the triage logic below is unchanged.
+            from backend.core.ouroboros.governance.rt_gate import (
+                GateProviderExhaustedError,
+                gate_completion,
+            )
+
+            try:
+                raw_response = await gate_completion(
+                    prompt,
                     caller_id=f"triage_{ctx.op_id[:12]}",
                     response_format={"type": "json_object"},
                     max_tokens=_TRIAGE_MAX_TOKENS,
-                ),
-                timeout=_TRIAGE_TIMEOUT_S,
-            )
-
-            if not raw_response:
+                    timeout_s=_TRIAGE_TIMEOUT_S,
+                    dw_provider=self._dw,
+                    dw_model=self._effective_model,
+                )
+            except GateProviderExhaustedError:
                 self._failures += 1
                 return TriageResult(decision=TriageDecision.SKIP)
 

--- a/tests/governance/test_rt_gate.py
+++ b/tests/governance/test_rt_gate.py
@@ -1,0 +1,155 @@
+"""RT Gate Router — Claude-RT-first gate completions (Phase 2 positioning).
+
+Proves the ONE unified wrapper the 8 synchronous gates route through:
+Claude-RT first (injected provider, then the provider-less Aegis fallback),
+DW-RT (complete_sync — never the batch queue) as the opportunistic fallback,
+typed GateProviderExhaustedError on full exhaustion, master-flag rollback to
+DW-first ordering, and hang-bounding via wait_for.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import backend.core.ouroboros.claude_fallback as cf
+import backend.core.ouroboros.governance.rt_gate as rtg
+
+
+class _SyncResult:
+    def __init__(self, content):
+        self.content = content
+        self.model = "dw-x"
+        self.latency_s = 0.2
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+def _dead_claude_fallback(monkeypatch):
+    monkeypatch.setattr(cf, "claude_inference",
+                        AsyncMock(side_effect=RuntimeError("claude down")))
+
+
+# ---------------------------------------------------------------------------
+# Ordering: Claude-RT first
+# ---------------------------------------------------------------------------
+
+
+def test_injected_claude_wins_dw_never_called(monkeypatch):
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value="claude says")
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult("dw says"))
+    out = _run(rtg.gate_completion(
+        "p", caller_id="t", claude_provider=claude, dw_provider=dw))
+    assert out == "claude says"
+    dw.complete_sync.assert_not_called()          # time bought, tokens saved
+
+
+def test_providerless_claude_fallback_used_when_no_injected(monkeypatch):
+    monkeypatch.setattr(cf, "claude_inference", AsyncMock(return_value="cf says"))
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult("dw says"))
+    out = _run(rtg.gate_completion("p", caller_id="t", dw_provider=dw))
+    assert out == "cf says"
+    dw.complete_sync.assert_not_called()
+
+
+def test_dw_rt_is_the_opportunistic_fallback(monkeypatch):
+    """Both Claude tiers down → the gate degrades to DW-RT, not dead."""
+    _dead_claude_fallback(monkeypatch)
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(side_effect=RuntimeError("529 overloaded"))
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult("dw says"))
+    out = _run(rtg.gate_completion(
+        "p", caller_id="t", claude_provider=claude, dw_provider=dw))
+    assert out == "dw says"
+    kwargs = dw.complete_sync.await_args.kwargs
+    assert "timeout_s" in kwargs                  # RT primitive, caller-timed
+
+
+def test_master_off_restores_dw_first(monkeypatch):
+    monkeypatch.setenv("JARVIS_GATE_CLAUDE_FIRST_ENABLED", "false")
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value="claude says")
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult("dw says"))
+    out = _run(rtg.gate_completion(
+        "p", caller_id="t", claude_provider=claude, dw_provider=dw))
+    assert out == "dw says"                       # one-flip rollback
+    claude.prompt_only.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Exhaustion + bounding
+# ---------------------------------------------------------------------------
+
+
+def test_full_exhaustion_raises_typed_error(monkeypatch):
+    _dead_claude_fallback(monkeypatch)
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(side_effect=RuntimeError("403"))
+    with pytest.raises(rtg.GateProviderExhaustedError):
+        _run(rtg.gate_completion("p", caller_id="t", dw_provider=dw))
+
+
+def test_no_providers_at_all_raises(monkeypatch):
+    _dead_claude_fallback(monkeypatch)
+    with pytest.raises(rtg.GateProviderExhaustedError):
+        _run(rtg.gate_completion("p", caller_id="t"))
+
+
+def test_hanging_tier_is_bounded(monkeypatch):
+    """A hung provider (the batch-stall class) cannot wedge a gate."""
+    _dead_claude_fallback(monkeypatch)
+
+    async def _hang(*a, **k):
+        await asyncio.sleep(3600)
+
+    claude = MagicMock()
+    claude.prompt_only = _hang
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult("dw says"))
+    out = _run(asyncio.wait_for(
+        rtg.gate_completion("p", caller_id="t", claude_provider=claude,
+                            dw_provider=dw, timeout_s=5.0),
+        timeout=30,
+    ))
+    assert out == "dw says"
+
+
+def test_empty_responses_cascade_not_return(monkeypatch):
+    """An empty completion is a tier failure, never a returned ''."""
+    monkeypatch.setattr(cf, "claude_inference", AsyncMock(return_value=""))
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value="")
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult("real content"))
+    out = _run(rtg.gate_completion(
+        "p", caller_id="t", claude_provider=claude, dw_provider=dw))
+    assert out == "real content"
+
+
+# ---------------------------------------------------------------------------
+# Env parsing
+# ---------------------------------------------------------------------------
+
+
+def test_timeout_env_parsing(monkeypatch):
+    monkeypatch.delenv("JARVIS_GATE_RT_TIMEOUT_S", raising=False)
+    assert rtg.gate_rt_timeout_s() == 60.0
+    monkeypatch.setenv("JARVIS_GATE_RT_TIMEOUT_S", "25")
+    assert rtg.gate_rt_timeout_s() == 25.0
+    monkeypatch.setenv("JARVIS_GATE_RT_TIMEOUT_S", "junk")
+    assert rtg.gate_rt_timeout_s() == 60.0
+    monkeypatch.setenv("JARVIS_GATE_RT_TIMEOUT_S", "1")
+    assert rtg.gate_rt_timeout_s() == 5.0         # floor
+
+
+def test_master_default_true(monkeypatch):
+    monkeypatch.delenv("JARVIS_GATE_CLAUDE_FIRST_ENABLED", raising=False)
+    assert rtg.claude_first_enabled() is True

--- a/tests/test_ouroboros_governance/test_dream_engine.py
+++ b/tests/test_ouroboros_governance/test_dream_engine.py
@@ -879,3 +879,153 @@ def test_hydrate_adaptive_picks_up_advanced_head(tmp_path, monkeypatch):
     assert eng._current_head == "head_one"
     eng._hydrate_repo_state()
     assert eng._current_head == "head_two"        # advanced HEAD honored
+
+
+# ============================================================================
+# RT migration + fail-fast cascade (Phase 1, 2026-07-16)
+#
+# Dreaming is latency-sensitive; the old Tier-1 used the DW 4-stage BATCH API
+# (24h window) and swallowed failures as "" so the Claude tier never fired
+# live (bt-2026-07-16-173540: 5 dream jobs, 0 completions). These pin:
+# DW-RT (complete_sync) primary, per-tier fail-fast RAISING boundaries,
+# Claude-RT fallback actually firing on primary timeout, and typed
+# DreamProviderExhaustedError when the whole cascade is down.
+# ============================================================================
+
+from backend.core.ouroboros.consciousness.dream_engine import (
+    DreamProviderExhaustedError,
+)
+
+
+class _SyncResult:
+    def __init__(self, content):
+        self.content = content
+        self.model = "dw-model-x"
+        self.latency_s = 0.5
+
+
+_BP_JSON = (
+    '{"title":"t","description":"d","category":"debt","priority_score":0.7,'
+    '"target_files":["a.py"],"estimated_effort":"small","estimated_cost_usd":0.01,'
+    '"suggested_approach":"x","risk_assessment":"low"}'
+)
+
+
+def _rt_engine(tmp_path, dw=None, claude=None, jprime_url=""):
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    d = tmp_path / "dreams"
+    d.mkdir(exist_ok=True)
+    eng = DreamEngine(
+        health_cortex=MagicMock(),
+        memory_engine=MagicMock(),
+        activity_monitor=MockActivityMonitor(idle_seconds=600.0),
+        resource_governor=MagicMock(),
+        metrics_tracker=DreamMetricsTracker(),
+        config=_make_config(),
+        jprime_url=jprime_url,
+        persistence_dir=d,
+    )
+    eng._dw_provider = dw
+    eng._claude_provider = claude
+    return eng
+
+
+async def test_dw_rt_primary_succeeds(tmp_path):
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult(_BP_JSON))
+    eng = _rt_engine(tmp_path, dw=dw, claude=MagicMock())
+    result = await eng._call_inference("dream prompt")
+    assert result["_inference_provider"] == "doubleword"
+    dw.complete_sync.assert_awaited_once()          # RT primitive, not batch
+    kwargs = dw.complete_sync.await_args.kwargs
+    assert "timeout_s" in kwargs and kwargs["response_format"] == {"type": "json_object"}
+
+
+async def test_primary_timeout_falls_back_to_claude_rt(tmp_path, monkeypatch):
+    """THE mandate-4 test: primary provider timeout → cascade catches it →
+    Claude RT tier fires and completes the dream."""
+    monkeypatch.setenv("JARVIS_DREAM_RT_TIMEOUT_S", "5")
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(side_effect=asyncio.TimeoutError("dw rt timeout"))
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value=_BP_JSON)
+    eng = _rt_engine(tmp_path, dw=dw, claude=claude)
+    result = await eng._call_inference("dream prompt")
+    assert result["_inference_provider"] == "claude"    # fallback FIRED
+    claude.prompt_only.assert_awaited_once()
+
+
+async def test_primary_infra_error_falls_back_to_claude_rt(tmp_path):
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(side_effect=RuntimeError("HTTP 403 entitlement"))
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value=_BP_JSON)
+    eng = _rt_engine(tmp_path, dw=dw, claude=claude)
+    result = await eng._call_inference("dream prompt")
+    assert result["_inference_provider"] == "claude"
+
+
+async def test_hanging_primary_is_bounded_by_wait_for(tmp_path, monkeypatch):
+    """A provider that HANGS (the batch-stall class) is cut by the outer
+    wait_for and the cascade proceeds — a dream cycle can never wedge."""
+    monkeypatch.setenv("JARVIS_DREAM_RT_TIMEOUT_S", "5")   # floor-clamped to 5s
+
+    async def _hang(*a, **k):
+        await asyncio.sleep(3600)
+
+    dw = MagicMock()
+    dw.complete_sync = _hang
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value=_BP_JSON)
+    eng = _rt_engine(tmp_path, dw=dw, claude=claude)
+    result = await asyncio.wait_for(eng._call_inference("p"), timeout=30)
+    assert result["_inference_provider"] == "claude"
+
+
+async def test_full_cascade_exhaustion_raises_typed_error(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_DREAM_RT_TIMEOUT_S", "5")
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(side_effect=RuntimeError("down"))
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(side_effect=RuntimeError("down too"))
+    eng = _rt_engine(tmp_path, dw=dw, claude=claude, jprime_url="")  # no tier 3
+    with pytest.raises(DreamProviderExhaustedError):
+        await eng._call_inference("p")
+
+
+async def test_run_dream_job_handles_exhaustion_with_dormant(tmp_path):
+    """_run_dream_job catches the typed exhaustion, emits DREAM_DORMANT, and
+    returns None — the dream loop survives a total provider outage."""
+    comm = MagicMock()
+    comm.emit_heartbeat = AsyncMock()
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(side_effect=RuntimeError("down"))
+    eng = _rt_engine(tmp_path, dw=dw, claude=None)
+    eng._comm = comm
+    eng._current_head = "h" * 12
+    eng._current_policy_hash = "p" * 16
+    result = await eng._run_dream_job()
+    assert result is None
+    comm.emit_heartbeat.assert_awaited()               # dormant surfaced
+
+
+async def test_no_batch_api_on_dream_path(tmp_path):
+    """Structural: the dream path never touches prompt_only/submit_batch on DW."""
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult(_BP_JSON))
+    eng = _rt_engine(tmp_path, dw=dw, claude=MagicMock())
+    await eng._call_inference("p")
+    dw.prompt_only.assert_not_called()
+    dw.submit_batch.assert_not_called()
+
+
+def test_rt_timeout_env_parsing(monkeypatch):
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    monkeypatch.delenv("JARVIS_DREAM_RT_TIMEOUT_S", raising=False)
+    assert DreamEngine._dream_rt_timeout_s() == 90.0
+    monkeypatch.setenv("JARVIS_DREAM_RT_TIMEOUT_S", "45")
+    assert DreamEngine._dream_rt_timeout_s() == 45.0
+    monkeypatch.setenv("JARVIS_DREAM_RT_TIMEOUT_S", "bogus")
+    assert DreamEngine._dream_rt_timeout_s() == 90.0
+    monkeypatch.setenv("JARVIS_DREAM_RT_TIMEOUT_S", "1")
+    assert DreamEngine._dream_rt_timeout_s() == 5.0    # floor

--- a/tests/test_ouroboros_governance/test_self_critique.py
+++ b/tests/test_ouroboros_governance/test_self_critique.py
@@ -726,29 +726,47 @@ class TestIsSelfCritiqueEnabled:
 
 
 class TestDoublewordCritiqueProvider:
+    """Phase 2 RT repositioning (2026-07-16): the backend now routes through
+    rt_gate.gate_completion (Claude-RT first, this DW handle as the
+    opportunistic fallback via complete_sync — the stream-free RT primitive,
+    never batch prompt_only). The fakes mirror the NEW real contract."""
+
+    @staticmethod
+    def _sync_result(content: str):
+        res = MagicMock()
+        res.content = content
+        res.model = "dw-x"
+        res.latency_s = 0.1
+        return res
+
     @pytest.mark.asyncio
-    async def test_provider_calls_prompt_only(self):
+    async def test_provider_routes_via_rt_gate_dw_complete_sync(self):
         mock_dw = MagicMock()
-        mock_dw.prompt_only = MagicMock()
-        async def _async_prompt_only(**kwargs):
-            return json.dumps({"rating": 4, "rationale": "ok"})
-        mock_dw.prompt_only = _async_prompt_only
+
+        async def _complete_sync(*args, **kwargs):
+            return self._sync_result(json.dumps({"rating": 4, "rationale": "ok"}))
+
+        mock_dw.complete_sync = _complete_sync
         provider = DoublewordCritiqueProvider(mock_dw, max_tokens=256)
         request = CritiqueRequest(
             op_id="op-1", goal="fix bug", diff="+ y",
             risk_tier="notify_apply", target_files=("foo.py",),
             test_summary="ok", deadline_s=30.0,
         )
+        # Claude tiers are absent in the test env (no key) → the gate
+        # cascades to the DW-RT opportunistic fallback.
         raw = await provider.critique(request)
         assert '"rating": 4' in raw
 
     @pytest.mark.asyncio
     async def test_provider_timeout_propagates(self):
         mock_dw = MagicMock()
-        async def _slow(**kwargs):
+
+        async def _slow(*args, **kwargs):
             await asyncio.sleep(5.0)
-            return "late"
-        mock_dw.prompt_only = _slow
+            return self._sync_result("late")
+
+        mock_dw.complete_sync = _slow
         provider = DoublewordCritiqueProvider(mock_dw)
         request = CritiqueRequest(
             op_id="op", goal="g", diff="+ x", risk_tier="low",


### PR DESCRIPTION
Provider-positioning pivot: **Claude sells time; DW sells tokens.** Everything an op blocks on now buys time; DW stays the opportunistic fallback + the volume layer.

**Phase 1 — DreamEngine RT migration:** Tier 1 → DW `complete_sync` (stream-free RT; fail-fast), Tier 2 → Claude RT `prompt_only`; every tier `wait_for`-bounded (`JARVIS_DREAM_RT_TIMEOUT_S`); typed `DreamProviderExhaustedError` on full exhaustion → `provider_cascade_exhausted` dormant. Kills the 24h-batch-queue wait that produced 0 blueprints in 40 min (bt-2026-07-16-173540) and the hardcoded un-entitled 35B slug.

**Phase 2 — 8 gates via new `rt_gate.gate_completion`:** one unified wrapper (Claude-RT first → provider-less Aegis Claude → DW-RT opportunistic; typed exhaustion; master `JARVIS_GATE_CLAUDE_FIRST_ENABLED` default TRUE with one-flip rollback). Repositioned: semantic_triage, json_healer (injection site), self_critique, pr_self_linter, karen_synth speech, architect reasoning_agent, intent_prompter, security_reviewer. Gate logic/validation unchanged.

19 new tests; 181/181 adjacent green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make synchronous gates and DreamEngine real-time and fail-fast: Claude RT is first, DW RT is the fallback, with per-tier timeouts and typed exhaustion. This removes batch waits and keeps pipelines responsive without changing gate logic.

- **New Features**
  - Unified `rt_gate.gate_completion` for all synchronous gates: Claude RT first (injected provider, then provider-less fallback), DW RT (`complete_sync`) as opportunistic fallback; per-tier timeout via `JARVIS_GATE_RT_TIMEOUT_S`; raises `GateProviderExhaustedError`. Master switch `JARVIS_GATE_CLAUDE_FIRST_ENABLED` (default true) controls ordering.
  - Added tests for ordering, fallback, timeouts, empty responses, and env parsing; all adjacent tests green.

- **Migration**
  - DreamEngine now uses an RT cascade with hard per-tier timeouts (`JARVIS_DREAM_RT_TIMEOUT_S`, default 90s): DW RT `complete_sync` → Claude RT; full exhaustion raises `DreamProviderExhaustedError` and emits `provider_cascade_exhausted` dormant; no DW batch API on this path. Optional DW model via `JARVIS_DREAM_DW_MODEL`.
  - Repointed to `rt_gate`: `semantic_triage`, `json_healer`, `self_critique`, `pr_self_linter`, `karen_synth` speech, `architect` reasoning agent, `intent_prompter`, `security_reviewer`.

<sup>Written for commit c18cc4f8b2fa3778d888d8bd7439a7ec8fd8f393. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69910?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

