### PR TITLE
fix(dw): Slice-27-parity Aegis credential gate for complete_sync

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -7383,9 +7383,30 @@ class DoublewordProvider:
         DoublewordInfraError
             On HTTP errors, empty choices, or cost-budget violations.
         """
-        if not self._api_key:
+        # Slice 27-parity Aegis-unified auth bridge (2026-07-16, caught live
+        # by bt-2026-07-16-185947: the dream RT tier failed with
+        # "DOUBLEWORD_API_KEY is not set — cannot call complete_sync()").
+        # ``self._api_key`` may be empty post-Aegis env_scrub — Aegis is the
+        # secure credential broker that injects the real DOUBLEWORD_API_KEY
+        # server-side at the daemon's forwarding handler, and this method's
+        # transport is ALREADY Aegis-bridged (``_get_session()`` +
+        # ``_aegis_merge_lease_headers``). Either credential source is valid —
+        # the EXACT gate ``prompt_only`` received in Slice 27; pre-fix this
+        # raised even when Aegis was the active broker, silently killing every
+        # complete_sync caller (DreamEngine RT tier, CompactionCaller,
+        # BlastRadius, karen_synth) post-scrub.
+        try:
+            from backend.core.ouroboros.aegis.client import (
+                is_enabled as _aegis_enabled,
+            )
+            _aegis_active = _aegis_enabled()
+        except Exception:  # noqa: BLE001 — defensive
+            _aegis_active = False
+        if not self._api_key and not _aegis_active:
             raise ValueError(
-                "DOUBLEWORD_API_KEY is not set — cannot call complete_sync()"
+                "DOUBLEWORD_API_KEY is not set AND Aegis is not "
+                "enabled — cannot call complete_sync() without a "
+                "credential source"
             )
         self._check_budget()
 

--- a/tests/governance/test_gap3_inference_path_fixes.py
+++ b/tests/governance/test_gap3_inference_path_fixes.py
@@ -155,3 +155,81 @@ def test_prompt_only_propagates_errors_no_swallow():
     inst._claude_create_with_resilience = _boom
     with pytest.raises(RuntimeError, match="overloaded"):
         _run(inst.prompt_only("p"))
+
+
+# ---------------------------------------------------------------------------
+# complete_sync Aegis credential gate (Slice-27 parity, bt-2026-07-16-185947)
+#
+# Under Aegis env_scrub, DOUBLEWORD_API_KEY is absent from os.environ and
+# self._api_key is empty — but Aegis injects the real key server-side at the
+# daemon's forwarding handler (complete_sync's transport is already
+# Aegis-bridged). The gate must accept EITHER credential source, exactly like
+# prompt_only post-Slice-27.
+# ---------------------------------------------------------------------------
+
+from unittest.mock import MagicMock
+
+import backend.core.ouroboros.aegis.client as aegis_client
+from backend.core.ouroboros.governance.doubleword_provider import DoublewordProvider
+
+
+class _GatePassed(Exception):
+    """Sentinel raised by the mocked budget check — proves the credential
+    gate ADMITTED the call (budget is the very next statement)."""
+
+
+def _scrubbed_provider(monkeypatch):
+    """A provider skeleton in an Aegis-scrubbed world: no env key, empty
+    _api_key. No live HTTP is possible — _check_budget raises the sentinel."""
+    monkeypatch.delenv("DOUBLEWORD_API_KEY", raising=False)
+    p = DoublewordProvider.__new__(DoublewordProvider)
+    p._api_key = ""                       # post-scrub state
+    p._model = "some/model"
+    p._check_budget = MagicMock(side_effect=_GatePassed())
+    return p
+
+
+def test_complete_sync_admits_when_aegis_active(monkeypatch):
+    """Scrubbed env + Aegis broker active → the gate passes and execution
+    reaches payload construction (sentinel fires)."""
+    monkeypatch.setattr(aegis_client, "is_enabled", lambda: True)
+    p = _scrubbed_provider(monkeypatch)
+    with pytest.raises(_GatePassed):
+        asyncio.new_event_loop().run_until_complete(
+            p.complete_sync("hi", system_prompt="s", caller_id="test")
+        )
+
+
+def test_complete_sync_rejects_when_no_credential_source(monkeypatch):
+    """Scrubbed env + Aegis OFF → fail-closed ValueError (no silent no-auth
+    call, no hardcoded fallback)."""
+    monkeypatch.setattr(aegis_client, "is_enabled", lambda: False)
+    p = _scrubbed_provider(monkeypatch)
+    with pytest.raises(ValueError, match="Aegis is not"):
+        asyncio.new_event_loop().run_until_complete(
+            p.complete_sync("hi", system_prompt="s", caller_id="test")
+        )
+
+
+def test_complete_sync_admits_with_direct_key_aegis_off(monkeypatch):
+    """Legacy path unchanged: a directly-configured key admits without Aegis."""
+    monkeypatch.setattr(aegis_client, "is_enabled", lambda: False)
+    p = _scrubbed_provider(monkeypatch)
+    p._api_key = "dw-legacy-key"
+    with pytest.raises(_GatePassed):
+        asyncio.new_event_loop().run_until_complete(
+            p.complete_sync("hi", system_prompt="s", caller_id="test")
+        )
+
+
+def test_complete_sync_gate_defensive_on_aegis_probe_error(monkeypatch):
+    """An erroring Aegis probe degrades to 'not active' (defensive), so
+    scrubbed + broken-probe still fail-closes rather than crashing oddly."""
+    def _boom():
+        raise RuntimeError("aegis probe failed")
+    monkeypatch.setattr(aegis_client, "is_enabled", _boom)
+    p = _scrubbed_provider(monkeypatch)
+    with pytest.raises(ValueError, match="cannot call complete_sync"):
+        asyncio.new_event_loop().run_until_complete(
+            p.complete_sync("hi", system_prompt="s", caller_id="test")
+        )


### PR DESCRIPTION
`complete_sync` kept the pre-Slice-27 client-side key requirement even though its transport is already Aegis-bridged (daemon injects the key at forward time) — so under Aegis env_scrub it failed every caller (DreamEngine RT tier, CompactionCaller, BlastRadius, karen_synth) before the broker could serve. Caught live in bt-2026-07-16-185947.

Fix mirrors `prompt_only`'s Slice-27 gate exactly: admit on direct key OR active Aegis broker; fail-closed otherwise. 4 new scrubbed-env tests; 56/56 adjacent green. Restores the DW-RT opportunistic tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the credential check in `complete_sync` to match the Slice-27 Aegis gate and stop failures under env scrub. Calls now proceed with either a direct `DOUBLEWORD_API_KEY` or an active Aegis broker; otherwise they fail closed.

- **Bug Fixes**
  - Updated `complete_sync` to admit on direct key or active Aegis; fail-closed when neither. Handles a failing Aegis probe defensively.
  - Added 4 tests for scrubbed env pass/fail, legacy direct-key path, and probe-error behavior.
  - Restores the DW real-time opportunistic tier in Aegis environments.

<sup>Written for commit 5e314d38620b92ca27bbce0ea3632a12012cab8d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69911?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

