### PR TITLE
fix(dw): one source of truth for the reasoning payload — purge the deprecated enable_thinking twin

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -7359,15 +7359,18 @@ class DoublewordProvider:
         temperature:
             Override sampling temperature. Defaults to ``_DW_TEMPERATURE``.
         enable_thinking:
-            Optional override for the per-request ``chat_template_kwargs``
-            ``enable_thinking`` flag. ``None`` (default) preserves the
-            legacy behavior of disabling DW's reasoning mode for
-            short structured-function callers (CompactionCaller,
-            BlastRadius, FailureClustering, DreamSeed). The heavy
-            codegen non-streaming lane passes ``True`` to unlock
-            DW reasoning over a stream-free transport. Existing
-            callers that omit this parameter remain byte-identical
-            to pre-extension behavior.
+            Optional override for DW's reasoning mode. ``None`` (default)
+            preserves the legacy behavior of suppressing reasoning for short
+            structured-function callers (CompactionCaller, BlastRadius,
+            FailureClustering, DreamSeed); the heavy codegen non-streaming
+            lane passes ``True`` to unlock DW reasoning over a stream-free
+            transport. The caller contract is unchanged, but as of 2026-07-16
+            the flag is TRANSLATED into the compliant ``reasoning_effort``
+            schema via :func:`_reasoning_request_params` (the single source of
+            truth, shared with ``prompt_only``) rather than emitting the
+            deprecated top-level ``chat_template_kwargs.enable_thinking``,
+            which DW now hard-rejects with a 400. False/None → effort
+            ``"none"``; True → effort derives from the model/complexity.
 
         Returns
         -------
@@ -7415,14 +7418,39 @@ class DoublewordProvider:
             temperature if temperature is not None else _DW_TEMPERATURE
         )
 
-        # Heavy-codegen non-streaming lane needs DW reasoning; legacy
-        # Functions callers (CompactionCaller, BlastRadius, etc.) call
-        # with enable_thinking=None and get the byte-identical legacy
-        # behavior (False). The new heavy lane explicitly passes True.
-        _effective_enable_thinking: bool = (
-            bool(enable_thinking) if enable_thinking is not None
-            else False
+        # DRY (2026-07-16) — ONE source of truth for the DW reasoning payload
+        # schema: ``_reasoning_request_params``, the same helper ``prompt_only``
+        # composes. complete_sync previously hand-rolled a deprecated top-level
+        # ``chat_template_kwargs.enable_thinking``, which DW now HARD-REJECTS
+        # with a 400 ("Unsupported parameter … use 'reasoning_effort'"). Proven
+        # live in bt-2026-07-16-200920: the DreamEngine's DW-RT tier 400'd on
+        # every call while prompt_only's path (already migrated in the earlier
+        # contract fix) was healthy — the duplication WAS the defect.
+        #
+        # The caller-facing ``enable_thinking`` contract is preserved and
+        # TRANSLATED into the compliant schema (no signature change):
+        #   * None/False — legacy Functions callers (CompactionCaller,
+        #     BlastRadius, FailureClustering, DreamSeed) — suppress reasoning
+        #     → effort "none". The helper still applies the Slice-168 per-model
+        #     floor (a model that rejects "none" is clamped up) and the
+        #     Slice-192 nested ``extra_body`` form when the catalog confirms
+        #     reasoning control.
+        #   * True — the heavy non-streaming codegen lane — effort DERIVES from
+        #     the model/complexity instead of being pinned to "none".
+        _reasoning_params = _reasoning_request_params(
+            effort="" if enable_thinking else "none",
+            model=effective_model,
         )
+        # complete_sync POSTs a RAW json body (no OpenAI SDK in this path).
+        # ``extra_body`` is an SDK *client* kwarg whose contents the SDK merges
+        # into the request — it is NOT itself a wire parameter, so forwarding it
+        # raw would introduce a fresh "unsupported parameter" 400. Carry only
+        # the wire-valid knob; the helper remains the single source of truth for
+        # WHICH effort applies (incl. the Slice-168 per-model floor).
+        _wire_reasoning = {
+            k: v for k, v in _reasoning_params.items()
+            if k == "reasoning_effort"
+        }
         body: Dict[str, Any] = {
             "model": effective_model,
             "messages": [
@@ -7432,9 +7460,7 @@ class DoublewordProvider:
             "max_tokens": max_tokens,
             "temperature": effective_temperature,
             "stream": False,
-            "chat_template_kwargs": {
-                "enable_thinking": _effective_enable_thinking,
-            },
+            **_wire_reasoning,
         }
         if response_format is not None:
             body["response_format"] = response_format

--- a/backend/core/ouroboros/governance/dw_heavy_probe.py
+++ b/backend/core/ouroboros/governance/dw_heavy_probe.py
@@ -656,8 +656,16 @@ class HeavyProber:
             # knob makes the probe go straight to content (verified Slice 54).
             # The probe is a liveness check, so always "none" regardless of the
             # generation-path effort.
+            #
+            # API-contract decay purge (2026-07-16): the deprecated top-level
+            # ``chat_template_kwargs={"enable_thinking": False}`` companion was
+            # removed — DW now HARD-REJECTS it with a 400 ("Unsupported
+            # parameter … use 'reasoning_effort'"), which would make this
+            # liveness probe report transport faults that are really our own
+            # malformed payload (poisoning the capability verdict it exists to
+            # produce). ``reasoning_effort`` above is the DW-honored knob and
+            # already carries the full intent.
             "reasoning_effort": "none",
-            "chat_template_kwargs": {"enable_thinking": False},
         }
         url = f"{base_url.rstrip('/')}/chat/completions"
         # Slice 2B-ii.2 — Aegis Provider Bridge wire. When

--- a/scripts/ouroboros_v34_gatekick.py
+++ b/scripts/ouroboros_v34_gatekick.py
@@ -118,7 +118,13 @@ def _build_smoke_entry(
             ],
             "max_tokens": 16,
             "temperature": 0.0,
-            "chat_template_kwargs": {"enable_thinking": False},
+            # API-contract decay purge (2026-07-16): the deprecated top-level
+            # ``chat_template_kwargs={"enable_thinking": False}`` is now HARD-
+            # REJECTED by DW with a 400 ("Unsupported parameter … use
+            # 'reasoning_effort'"). ``reasoning_effort="none"`` is the honored
+            # knob and carries the same intent (suppress chain-of-thought so a
+            # 16-token ping returns content, not reasoning).
+            "reasoning_effort": "none",
         },
     }
 

--- a/tests/governance/test_gap3_inference_path_fixes.py
+++ b/tests/governance/test_gap3_inference_path_fixes.py
@@ -233,3 +233,115 @@ def test_complete_sync_gate_defensive_on_aegis_probe_error(monkeypatch):
         asyncio.new_event_loop().run_until_complete(
             p.complete_sync("hi", system_prompt="s", caller_id="test")
         )
+
+
+# ---------------------------------------------------------------------------
+# complete_sync payload schema — DRY vs the deprecated twin
+#
+# bt-2026-07-16-200920: the DreamEngine's DW-RT tier 400'd on EVERY call —
+# "Unsupported parameter 'chat_template_kwargs.enable_thinking'; use
+# 'reasoning_effort'" — because complete_sync hand-rolled its own payload and
+# never composed _reasoning_request_params (the helper the earlier contract fix
+# corrected for prompt_only). The duplication WAS the defect. These pin the
+# wire schema so the twin cannot regrow.
+# ---------------------------------------------------------------------------
+
+
+class _CapturedBody(BaseException):
+    """Carries the composed request body out of complete_sync before any HTTP.
+
+    Subclasses BaseException deliberately: the egress block inside
+    complete_sync wraps sanitation in ``except Exception: pass`` (fail-soft by
+    design), which would swallow a normal Exception and let the call proceed to
+    transport."""
+    def __init__(self, body):
+        self.body = body
+
+
+def _payload_provider(monkeypatch, *, model="some/model"):
+    """A REAL DoublewordProvider (not a skeleton — the fake must mirror the
+    real contract) whose composed body is captured at the egress boundary
+    before any transport. Legacy direct-key credential path (Aegis off) —
+    the gate is orthogonal to payload composition."""
+    from unittest.mock import AsyncMock
+
+    monkeypatch.setattr(aegis_client, "is_enabled", lambda: False)
+    monkeypatch.setenv("DOUBLEWORD_API_KEY", "dw-test-key")
+    p = DoublewordProvider()                     # real __init__, real defaults
+    p._api_key = "dw-test-key"                   # satisfies the legacy gate
+    p._model = model
+    p._check_budget = MagicMock()
+    p._get_session = AsyncMock(return_value=MagicMock())   # no real transport
+
+    # Capture exactly where the body is finished: egress sanitation runs on the
+    # composed dict, so intercept there and abort before the request leaves.
+    import backend.core.ouroboros.governance.doubleword_provider as dwp_mod
+    monkeypatch.setattr(dwp_mod, "egress_interceptor_enabled", lambda: True)
+
+    def _capture(body, model_id):
+        raise _CapturedBody(body)
+
+    monkeypatch.setattr(dwp_mod, "sanitize_egress_body", _capture)
+    return p
+
+
+def _compose(monkeypatch, **kw):
+    p = _payload_provider(monkeypatch, model=kw.pop("model", "some/model"))
+    try:
+        asyncio.new_event_loop().run_until_complete(
+            p.complete_sync("hi", system_prompt="s", caller_id="test", **kw)
+        )
+    except _CapturedBody as c:
+        return c.body
+    raise AssertionError("body was never composed/captured")
+
+
+def test_complete_sync_payload_has_reasoning_effort_never_deprecated_key(monkeypatch):
+    """THE pin: compliant reasoning_effort present, deprecated top-level key
+    absolutely absent (the 400 trigger)."""
+    body = _compose(monkeypatch)
+    assert "reasoning_effort" in body
+    assert "chat_template_kwargs" not in body     # the DW 400 trigger
+    assert "extra_body" not in body               # SDK-only kwarg, never raw
+
+
+def test_complete_sync_legacy_none_suppresses_reasoning(monkeypatch):
+    """enable_thinking=None (legacy Functions callers) → effort 'none'."""
+    monkeypatch.setattr(dwp, "_dw_model_min_effort", lambda model: "none")
+    body = _compose(monkeypatch, enable_thinking=None)
+    assert body["reasoning_effort"] == "none"
+    assert "chat_template_kwargs" not in body
+
+
+def test_complete_sync_explicit_false_suppresses_reasoning(monkeypatch):
+    monkeypatch.setattr(dwp, "_dw_model_min_effort", lambda model: "none")
+    body = _compose(monkeypatch, enable_thinking=False)
+    assert body["reasoning_effort"] == "none"
+
+
+def test_complete_sync_true_unlocks_reasoning_not_pinned_none(monkeypatch):
+    """enable_thinking=True (heavy lane) → effort DERIVES, never forced 'none'."""
+    monkeypatch.setattr(dwp, "_dw_model_min_effort", lambda model: "none")
+    monkeypatch.setattr(dwp, "_reasoning_effort_for", lambda c, model="": "medium")
+    body = _compose(monkeypatch, enable_thinking=True)
+    assert body["reasoning_effort"] == "medium"
+    assert "chat_template_kwargs" not in body
+
+
+def test_complete_sync_honors_per_model_effort_floor(monkeypatch):
+    """DRY payoff: the Slice-168 per-model floor now applies to complete_sync
+    for free, because it composes the shared helper."""
+    monkeypatch.setattr(dwp, "_dw_model_min_effort", lambda model: "low")
+    body = _compose(monkeypatch, enable_thinking=False)   # asks for "none"
+    assert body["reasoning_effort"] == "low"              # clamped up by the floor
+
+
+def test_complete_sync_composes_the_single_source_of_truth(monkeypatch):
+    """Structural: complete_sync must call _reasoning_request_params, not
+    hand-roll a payload (the duplication that caused the outage)."""
+    import inspect
+    src = inspect.getsource(DoublewordProvider.complete_sync)
+    assert "_reasoning_request_params(" in src
+    # no hand-rolled deprecated construction anywhere in the method body
+    code = "\n".join(l for l in src.splitlines() if not l.strip().startswith("#"))
+    assert '"chat_template_kwargs"' not in code


### PR DESCRIPTION
`bt-2026-07-16-200920` proved the Aegis gate fix (0 old-gate errors) but DW-RT still 400'd every dream: *"Unsupported parameter 'chat_template_kwargs.enable_thinking'; use 'reasoning_effort'"*.

**Root cause:** the earlier contract fix corrected only `_reasoning_request_params` (prompt_only's path); `complete_sync` hand-rolled its own payload and never composed it — so the RT migration routed dreaming onto the unfixed twin. **The duplication was the defect.**

**DRY:** `complete_sync` now composes `_reasoning_request_params` (one source of truth). The `enable_thinking` contract is preserved and translated (None/False → `"none"`; True → derives). Earns the Slice-168 per-model floor for free. Only `reasoning_effort` goes on the raw wire — `extra_body` is an SDK client kwarg and would cause a fresh 400.

**Repo-wide sweep:** two twins purged (`dw_heavy_probe` — its deprecated companion would poison the capability verdict it exists to produce; `ouroboros_v34_gatekick`). Only `_dw_thinking_extra_body` remains — the compliant nested form.

6 payload-pinning tests; 143/143 adjacent green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Unifies DW reasoning payload to stop 400 errors by translating `enable_thinking` to `reasoning_effort` and removing the deprecated `chat_template_kwargs` key.

- **Bug Fixes**
  - `complete_sync` now composes `_reasoning_request_params` and sends only `reasoning_effort` on the wire (no raw `extra_body`).
  - Removed `chat_template_kwargs.enable_thinking` from `dw_heavy_probe` and `scripts/ouroboros_v34_gatekick.py`; use `reasoning_effort: "none"` instead.
  - Added tests that pin the payload schema, cover legacy `enable_thinking` behavior, and enforce the per-model effort floor.

<sup>Written for commit 9a29cc02bae3db23ee4e13a047b157991cf0aab8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69912?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

