### PR TITLE
feat(dream): dynamic candidate hydration — hardcoded stub → live telemetry keying

### DIFF
--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -56,6 +56,21 @@ logger = logging.getLogger(__name__)
 
 DREAM_MAX_PROMPT_CHARS: int = 2048
 
+# Candidate hydration vocabulary (2026-07-17). The KEYS are the MemoryEngine's
+# own closed insight-category vocabulary (types.MemoryInsight.category) — this
+# maps that existing taxonomy onto a dream focus rather than inventing a second
+# one. An unmapped category passes through verbatim, so the MemoryEngine can
+# grow new categories without this dict silently swallowing them.
+_PROMPT_FAMILY_BY_INSIGHT: Dict[str, str] = {
+    "failure_pattern": "failure_repair",
+    "file_fragility": "fragility_hardening",
+    "success_pattern": "success_extension",
+}
+# Honest "nothing learned yet" focus for a cold memory — NOT a fabricated one.
+_PROMPT_FAMILY_NEUTRAL: str = "general_improvement"
+# No provider wired: the job is unkeyable to a serving model class.
+_MODEL_CLASS_UNKNOWN: str = "unwired"
+
 
 class DreamProviderExhaustedError(RuntimeError):
     """All RT inference tiers (DW → Claude → J-Prime) failed for a dream job.
@@ -681,17 +696,86 @@ class DreamEngine:
             logger.info("[DreamEngine] Resuming interrupted job %s", key[:16])
             return info
 
-        # Placeholder — real implementation would query oracle + memory
         if not self._current_head or not self._current_policy_hash:
             return None
 
+        # Dynamic candidate hydration (2026-07-17) — replaces the hardcoded
+        # ``prompt_family="general_improvement"`` / ``model_class="qwen2.5-7b"``
+        # stub (the latter was also a lie: no soak has ever served a dream on
+        # qwen2.5-7b). BOTH axes are now derived organically from live runtime
+        # telemetry, which is what gives ``compute_job_key`` genuine identity
+        # diversity WITHOUT touching the hash or the dedup registry: as the
+        # organism's memory shifts (a new failure family emerges) or its
+        # provider topology changes, the key changes with it and a fresh dream
+        # is legitimately warranted.
         return {
-            "repo": "jarvis",
+            "repo": self._repo_name(),
             "repo_sha": self._current_head,
             "policy_hash": self._current_policy_hash,
-            "prompt_family": "general_improvement",
-            "model_class": "qwen2.5-7b",
+            "prompt_family": self._derive_prompt_family(),
+            "model_class": self._derive_model_class(),
         }
+
+    def _repo_name(self) -> str:
+        """Repo identity from the live repo path (no hardcoded slug)."""
+        try:
+            if self._repo_path:
+                return Path(self._repo_path).name or "jarvis"
+        except Exception:  # noqa: BLE001
+            pass
+        return "jarvis"
+
+    def _derive_prompt_family(self) -> str:
+        """The dream's focus, derived from live MemoryEngine telemetry.
+
+        Composes the existing ``get_pattern_summary()`` API (no duplicated
+        telemetry parsing): the organism's dominant NON-EXPIRED insight
+        category — ranked by the engine's own evidence_count ordering — names
+        what it should speculate about. ``failure_pattern`` → repair the
+        recurring break; ``file_fragility`` → harden the brittle surface;
+        ``success_pattern`` → extend what works.
+
+        The category vocabulary is the MemoryEngine's own (types.MemoryInsight);
+        we map it to a family rather than inventing a taxonomy. A cold memory
+        (fresh organism, no ingested outcomes) has no insights and yields the
+        neutral family — an honest "nothing learned yet", not a fabricated
+        focus. NEVER raises."""
+        try:
+            summary = self._memory_engine.get_pattern_summary()
+            now_iso = datetime.now(timezone.utc).isoformat()
+            for insight in getattr(summary, "top_patterns", ()) or ():
+                try:
+                    if insight.is_expired(now_iso):
+                        continue
+                except Exception:  # noqa: BLE001 — malformed insight is not a focus
+                    continue
+                cat = str(getattr(insight, "category", "") or "").strip().lower()
+                if cat:
+                    return _PROMPT_FAMILY_BY_INSIGHT.get(cat, cat)
+        except Exception:  # noqa: BLE001 — telemetry is advisory, never fatal
+            logger.debug("[DreamEngine] prompt_family telemetry cold", exc_info=True)
+        return _PROMPT_FAMILY_NEUTRAL
+
+    def _derive_model_class(self) -> str:
+        """The model class that will actually serve, from the live provider
+        topology — mirroring ``_call_inference``'s real tier order (DW-RT
+        first, Claude-RT fallback). Reads each provider's own ``_model`` rather
+        than restating a slug, so a topology change (entitlement shift, model
+        pin, provider outage) organically re-keys the job. NEVER raises."""
+        for provider, tier in (
+            (self._dw_provider, "dw"),
+            (self._claude_provider, "claude"),
+        ):
+            if provider is None:
+                continue
+            try:
+                model = str(getattr(provider, "_model", "") or "").strip()
+            except Exception:  # noqa: BLE001
+                model = ""
+            if model:
+                return f"{tier}:{model}"
+            return tier
+        return _MODEL_CLASS_UNKNOWN
 
     def _build_dream_prompt(self, candidate: Dict[str, Any]) -> str:
         """Build the speculative analysis prompt for J-Prime."""

--- a/tests/test_ouroboros_governance/test_dream_engine.py
+++ b/tests/test_ouroboros_governance/test_dream_engine.py
@@ -1029,3 +1029,189 @@ def test_rt_timeout_env_parsing(monkeypatch):
     assert DreamEngine._dream_rt_timeout_s() == 90.0
     monkeypatch.setenv("JARVIS_DREAM_RT_TIMEOUT_S", "1")
     assert DreamEngine._dream_rt_timeout_s() == 5.0    # floor
+
+
+# ============================================================================
+# Dynamic candidate hydration (2026-07-17)
+#
+# The stub hardcoded prompt_family="general_improvement" / model_class=
+# "qwen2.5-7b" (the latter a lie — no soak ever served a dream on it), so
+# compute_job_key had exactly ONE possible identity per HEAD: dream once, then
+# correctly skip forever ("Job ... already completed, skipping" x N). The hash
+# and the dedup registry are SOUND and untouched; the fix is to give the key
+# genuine, organically-derived diversity.
+# ============================================================================
+
+from backend.core.ouroboros.consciousness.dream_engine import (
+    _MODEL_CLASS_UNKNOWN,
+    _PROMPT_FAMILY_NEUTRAL,
+)
+from backend.core.ouroboros.consciousness.types import compute_job_key
+
+
+def _insight(category, *, expired=False, evidence=5):
+    i = MagicMock()
+    i.category = category
+    i.evidence_count = evidence
+    i.is_expired = MagicMock(return_value=expired)
+    return i
+
+
+def _mem(*insights):
+    m = MagicMock()
+    s = MagicMock()
+    s.top_patterns = tuple(insights)
+    m.get_pattern_summary.return_value = s
+    return m
+
+
+def _cand_engine(tmp_path, *, memory=None, dw=None, claude=None, repo=None):
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    d = tmp_path / "dreams"
+    d.mkdir(exist_ok=True)
+    eng = DreamEngine(
+        health_cortex=MagicMock(),
+        memory_engine=memory if memory is not None else _mem(),
+        activity_monitor=MockActivityMonitor(idle_seconds=600.0),
+        resource_governor=MagicMock(),
+        metrics_tracker=DreamMetricsTracker(),
+        config=_make_config(),
+        persistence_dir=d,
+        repo_path=str(repo) if repo else None,
+    )
+    eng._dw_provider = dw
+    eng._claude_provider = claude
+    eng._current_head = "headsha1234"
+    eng._current_policy_hash = "policyhash01"
+    return eng
+
+
+def _provider(model):
+    p = MagicMock()
+    p._model = model
+    return p
+
+
+# ---- prompt_family derives from live memory telemetry ----------------------
+
+
+def test_prompt_family_tracks_dominant_failure_pattern(tmp_path):
+    eng = _cand_engine(tmp_path, memory=_mem(_insight("failure_pattern")))
+    assert eng._derive_prompt_family() == "failure_repair"
+
+
+def test_prompt_family_tracks_fragility(tmp_path):
+    eng = _cand_engine(tmp_path, memory=_mem(_insight("file_fragility")))
+    assert eng._derive_prompt_family() == "fragility_hardening"
+
+
+def test_prompt_family_tracks_success_pattern(tmp_path):
+    eng = _cand_engine(tmp_path, memory=_mem(_insight("success_pattern")))
+    assert eng._derive_prompt_family() == "success_extension"
+
+
+def test_prompt_family_skips_expired_insights(tmp_path):
+    """An expired insight is not a live focus — the engine's own TTL governs."""
+    eng = _cand_engine(tmp_path, memory=_mem(
+        _insight("failure_pattern", expired=True),
+        _insight("file_fragility", expired=False),
+    ))
+    assert eng._derive_prompt_family() == "fragility_hardening"
+
+
+def test_prompt_family_unknown_category_passes_through(tmp_path):
+    """A NEW MemoryEngine category isn't silently swallowed by our map."""
+    eng = _cand_engine(tmp_path, memory=_mem(_insight("perf_regression")))
+    assert eng._derive_prompt_family() == "perf_regression"
+
+
+def test_prompt_family_cold_memory_is_neutral(tmp_path):
+    """Fresh organism: no insights → honest neutral focus, not a fabrication."""
+    assert _cand_engine(tmp_path, memory=_mem())._derive_prompt_family() == _PROMPT_FAMILY_NEUTRAL
+
+
+def test_prompt_family_never_raises_on_broken_memory(tmp_path):
+    m = MagicMock()
+    m.get_pattern_summary.side_effect = RuntimeError("memory down")
+    assert _cand_engine(tmp_path, memory=m)._derive_prompt_family() == _PROMPT_FAMILY_NEUTRAL
+
+
+# ---- model_class derives from the live provider topology -------------------
+
+
+def test_model_class_reflects_dw_primary(tmp_path):
+    eng = _cand_engine(tmp_path, dw=_provider("Qwen/Qwen3.5-397B-A17B-FP8"),
+                       claude=_provider("claude-sonnet-4-6"))
+    assert eng._derive_model_class() == "dw:Qwen/Qwen3.5-397B-A17B-FP8"  # mirrors tier order
+
+
+def test_model_class_falls_to_claude_when_dw_absent(tmp_path):
+    eng = _cand_engine(tmp_path, dw=None, claude=_provider("claude-sonnet-4-6"))
+    assert eng._derive_model_class() == "claude:claude-sonnet-4-6"
+
+
+def test_model_class_unwired_when_no_providers(tmp_path):
+    assert _cand_engine(tmp_path)._derive_model_class() == _MODEL_CLASS_UNKNOWN
+
+
+def test_model_class_never_hardcodes_the_stub_slug(tmp_path):
+    """The stub's qwen2.5-7b lie must never reappear."""
+    eng = _cand_engine(tmp_path, dw=_provider("Qwen/Qwen3.5-397B-A17B-FP8"))
+    assert "qwen2.5-7b" not in eng._derive_model_class()
+
+
+# ---- the payoff: DIVERSE job keys, hash untouched --------------------------
+
+
+def test_candidate_carries_derived_axes(tmp_path):
+    eng = _cand_engine(tmp_path, memory=_mem(_insight("failure_pattern")),
+                       dw=_provider("dw-model-x"))
+    c = eng._pick_candidate()
+    assert c["prompt_family"] == "failure_repair"
+    assert c["model_class"] == "dw:dw-model-x"
+    assert c["repo_sha"] == "headsha1234" and c["policy_hash"] == "policyhash01"
+
+
+def test_shifting_memory_yields_DISTINCT_job_keys_on_static_head(tmp_path):
+    """THE fix: with HEAD frozen, a shift in live telemetry re-keys the job —
+    so a genuinely new dream is warranted and the (correct) dedup skip no
+    longer starves the DW-RT tier."""
+    keys = set()
+    for cat in ("failure_pattern", "file_fragility", "success_pattern"):
+        eng = _cand_engine(tmp_path, memory=_mem(_insight(cat)), dw=_provider("m"))
+        c = eng._pick_candidate()
+        keys.add(compute_job_key(c["repo_sha"], c["policy_hash"],
+                                 c["prompt_family"], c["model_class"]))
+    assert len(keys) == 3          # same HEAD, three distinct dreamable jobs
+
+
+def test_provider_topology_shift_rekeys_job(tmp_path):
+    """A topology change (entitlement/pin/outage) legitimately re-keys."""
+    a = _cand_engine(tmp_path, dw=_provider("model-a"))._pick_candidate()
+    b = _cand_engine(tmp_path, dw=_provider("model-b"))._pick_candidate()
+    ka = compute_job_key(a["repo_sha"], a["policy_hash"], a["prompt_family"], a["model_class"])
+    kb = compute_job_key(b["repo_sha"], b["policy_hash"], b["prompt_family"], b["model_class"])
+    assert ka != kb
+
+
+def test_identical_state_is_STILL_deduped(tmp_path):
+    """Bulletproof: unchanged state must remain idempotent — no runaway
+    re-dreaming (the OOM/cost failure mode)."""
+    k = []
+    for _ in range(3):
+        eng = _cand_engine(tmp_path, memory=_mem(_insight("failure_pattern")), dw=_provider("m"))
+        c = eng._pick_candidate()
+        k.append(compute_job_key(c["repo_sha"], c["policy_hash"],
+                                 c["prompt_family"], c["model_class"]))
+    assert len(set(k)) == 1        # stable identity — the cache still works
+
+
+def test_repo_name_from_live_path_not_hardcoded(tmp_path):
+    eng = _cand_engine(tmp_path, repo=tmp_path / "my-repo")
+    assert eng._pick_candidate()["repo"] == "my-repo"
+
+
+def test_pick_candidate_still_none_without_repo_state(tmp_path):
+    eng = _cand_engine(tmp_path)
+    eng._current_head = ""
+    assert eng._pick_candidate() is None


### PR DESCRIPTION
One dream then `Job ... already completed, skipping` forever. **The dedup hash was sound** — `_pick_candidate` was a stub with two hardcoded axes (`prompt_family="general_improvement"`, `model_class="qwen2.5-7b"` — the latter false), so there was exactly ONE job identity per HEAD.

A temporal salt was **rejected**: it defeats the cache by design (runaway re-dreaming). `compute_job_key` + registry **untouched**.

Both axes now derive from live telemetry: `prompt_family` ← `MemoryEngine.get_pattern_summary()` (existing API, engine's own category vocabulary, unmapped categories pass through, cold memory → honest neutral); `model_class` ← live provider topology mirroring the real tier order; `repo` ← live path.

Also: `JARVIS_DREAM_RT_TIMEOUT_S=150` (DW-RT timed out at 90s vs its ~67s p50 + variance).

17 new tests incl. **3 distinct job keys on a static HEAD** while identical state stays idempotent. 50/50 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the hardcoded dream candidate stub with live telemetry so job keys reflect memory and provider state, fixing the permanent “already completed, skipping” loop on static HEADs. Also increased realtime timeout to reduce false DW-RT timeouts.

- **New Features**
  - `prompt_family` now comes from `MemoryEngine.get_pattern_summary()`; maps known categories, passes unknown through, and uses a neutral family when memory is cold.
  - `model_class` mirrors the live provider topology (DW → Claude) using each provider’s `_model`; topology changes re-key jobs.
  - `repo` name is taken from the live `repo_path` basename (no hardcoded slug).
  - Default `JARVIS_DREAM_RT_TIMEOUT_S` raised to 150s.
  - Added 17 tests covering telemetry derivation, expiry handling, topology shifts, key diversity on a static HEAD, and idempotency.

<sup>Written for commit 6ab5b8211a2c3d3f3adb3a82863ff94c89b920f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

