### PR TITLE
fix(dream): decouple output budget from prompt cap + kill silent empty-tier fall-through

### DIFF
--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -56,6 +56,27 @@ logger = logging.getLogger(__name__)
 
 DREAM_MAX_PROMPT_CHARS: int = 2048
 
+# Output-token budget for a dream completion — DECOUPLED from the prompt-char
+# cap above (2026-07-17). The two were conflated: DREAM_MAX_PROMPT_CHARS (an
+# INPUT character limit, TC23) was passed as the provider's ``max_tokens``
+# (an OUTPUT token budget) — a type error with teeth. bt-2026-07-17-033933:
+# the only entitled DW model (Qwen3.5-397B) carries a per-model effort FLOOR of
+# "low", so it ALWAYS reasons; 2048 output tokens were consumed entirely by
+# chain-of-thought, yielding 0 chars of content in 30.25s. The default leaves
+# room for the think phase AND the answer; env-tunable per deployment.
+_DREAM_MAX_OUTPUT_TOKENS_DEFAULT: int = 8192
+
+
+def dream_max_output_tokens() -> int:
+    """``JARVIS_DREAM_MAX_OUTPUT_TOKENS`` (default 8192). Floor of 1024 keeps a
+    misconfiguration from re-creating the truncation class. Never raises."""
+    try:
+        return max(1024, int(os.environ.get(
+            "JARVIS_DREAM_MAX_OUTPUT_TOKENS", _DREAM_MAX_OUTPUT_TOKENS_DEFAULT,
+        )))
+    except (TypeError, ValueError):
+        return _DREAM_MAX_OUTPUT_TOKENS_DEFAULT
+
 # Candidate hydration vocabulary (2026-07-17). The KEYS are the MemoryEngine's
 # own closed insight-category vocabulary (types.MemoryInsight.category) — this
 # maps that existing taxonomy onto a dream focus rather than inventing a second
@@ -834,7 +855,7 @@ class DreamEngine:
                         ),
                         caller_id="dream_engine",
                         model=_dw_model,
-                        max_tokens=DREAM_MAX_PROMPT_CHARS,
+                        max_tokens=dream_max_output_tokens(),
                         timeout_s=rt_timeout,
                         response_format={"type": "json_object"},
                     ),
@@ -854,6 +875,19 @@ class DreamEngine:
                         )
                         return result
                     logger.info("[DreamEngine] DW RT returned non-JSON, cascading")
+                else:
+                    # Observability (2026-07-17): an EMPTY tier response must
+                    # never fall through silently. bt-2026-07-17-033933 burned a
+                    # whole soak here — DW returned 0 chars in 30.25s (the
+                    # chain-of-thought consumed the output budget) and this
+                    # branch logged NOTHING, so the cascade looked like the DW
+                    # tier was never attempted at all.
+                    logger.info(
+                        "[DreamEngine] DW RT generation exhausted/empty "
+                        "(model=%s, %.1fs, out_tokens=%s, budget=%d) — cascading to Claude",
+                        getattr(res, "model", "?"), getattr(res, "latency_s", -1.0),
+                        getattr(res, "output_tokens", "?"), dream_max_output_tokens(),
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:
@@ -872,7 +906,7 @@ class DreamEngine:
                         prompt=prompt,
                         caller_id="dream_engine",
                         response_format={"type": "json_object"},
-                        max_tokens=DREAM_MAX_PROMPT_CHARS,
+                        max_tokens=dream_max_output_tokens(),
                         timeout_s=rt_timeout,
                     ),
                     timeout=rt_timeout + 5.0,
@@ -886,6 +920,14 @@ class DreamEngine:
                         logger.info("[DreamEngine] Claude RT inference succeeded")
                         return result
                     logger.info("[DreamEngine] Claude RT returned non-JSON, cascading")
+                else:
+                    # Same observability contract as the DW tier — no silent
+                    # fall-through anywhere in the routing topology.
+                    logger.info(
+                        "[DreamEngine] Claude RT generation exhausted/empty "
+                        "(budget=%d) — cascading to J-Prime",
+                        dream_max_output_tokens(),
+                    )
             except asyncio.CancelledError:
                 raise
             except Exception as exc:

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -7517,7 +7517,16 @@ class DoublewordProvider:
                         status_code=0,
                     )
                 message = choices[0].get("message", {}) or {}
-                _content = message.get("content", "") or ""
+                # DRY (2026-07-17) — compose the Slice-54 reasoning-aware
+                # extractor instead of hand-rolling ``message["content"]``.
+                # bt-2026-07-17-033933 proved why: the only ENTITLED model
+                # (Qwen3.5-397B) has a per-model effort FLOOR of "low", so
+                # ``reasoning_effort="none"`` is clamped up and the model always
+                # thinks — leaving ``content`` empty while the real text sits in
+                # ``reasoning`` / ``reasoning_details[].text`` (the correct DW
+                # field names). The hand-rolled read returned "" and the caller
+                # silently cascaded: 30.25s, 0 chars, $0.0001, no blueprint.
+                _content = _extract_completion_text(message)
                 usage = data.get("usage", {}) or {}
                 _input_tokens = int(usage.get("prompt_tokens", 0) or 0)
                 _output_tokens = int(usage.get("completion_tokens", 0) or 0)

--- a/tests/test_ouroboros_governance/test_dream_engine.py
+++ b/tests/test_ouroboros_governance/test_dream_engine.py
@@ -1215,3 +1215,78 @@ def test_pick_candidate_still_none_without_repo_state(tmp_path):
     eng = _cand_engine(tmp_path)
     eng._current_head = ""
     assert eng._pick_candidate() is None
+
+
+# ============================================================================
+# Output-budget decoupling + empty-tier observability (2026-07-17)
+#
+# bt-2026-07-17-033933: DW returned "0 chars, 30.25s, $0.00010". Two defects:
+#   (1) DREAM_MAX_PROMPT_CHARS (an INPUT char cap, TC23) was passed as the
+#       provider's max_tokens (an OUTPUT budget) — a type error. The only
+#       entitled model (Qwen3.5-397B) has an effort FLOOR of "low" so it ALWAYS
+#       reasons; 2048 output tokens went entirely to chain-of-thought.
+#   (2) the empty response logged NOTHING and fell through silently, so the
+#       cascade looked like DW was never attempted.
+# ============================================================================
+
+import logging
+
+from backend.core.ouroboros.consciousness.dream_engine import (
+    DREAM_MAX_PROMPT_CHARS,
+    dream_max_output_tokens,
+)
+
+
+def test_output_budget_is_decoupled_from_prompt_char_cap(monkeypatch):
+    """The type error must not regrow: the OUTPUT budget is its own knob."""
+    monkeypatch.delenv("JARVIS_DREAM_MAX_OUTPUT_TOKENS", raising=False)
+    assert dream_max_output_tokens() == 8192
+    assert dream_max_output_tokens() != DREAM_MAX_PROMPT_CHARS   # never conflated
+    assert DREAM_MAX_PROMPT_CHARS == 2048                        # input cap unchanged (TC23)
+
+
+def test_output_budget_env_tunable_with_floor(monkeypatch):
+    monkeypatch.setenv("JARVIS_DREAM_MAX_OUTPUT_TOKENS", "16384")
+    assert dream_max_output_tokens() == 16384
+    monkeypatch.setenv("JARVIS_DREAM_MAX_OUTPUT_TOKENS", "64")   # would re-create truncation
+    assert dream_max_output_tokens() == 1024                     # floor protects
+    monkeypatch.setenv("JARVIS_DREAM_MAX_OUTPUT_TOKENS", "junk")
+    assert dream_max_output_tokens() == 8192
+
+
+async def test_dw_tier_sends_the_output_budget_not_prompt_chars(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_DREAM_MAX_OUTPUT_TOKENS", "8192")
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult(_BP_JSON))
+    eng = _rt_engine(tmp_path, dw=dw, claude=MagicMock())
+    await eng._call_inference("p")
+    sent = dw.complete_sync.await_args.kwargs["max_tokens"]
+    assert sent == 8192
+    assert sent != DREAM_MAX_PROMPT_CHARS      # the 2048 truncation is dead
+
+
+async def test_empty_dw_response_logs_and_still_cascades(tmp_path, caplog):
+    """Mandate 2: an empty tier response emits a DISTINCT diagnostic and the
+    fallback still fires — no silent fall-through."""
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult(""))   # the live defect
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value=_BP_JSON)
+    eng = _rt_engine(tmp_path, dw=dw, claude=claude)
+    with caplog.at_level(logging.INFO):
+        result = await eng._call_inference("p")
+    assert result["_inference_provider"] == "claude"             # cascade fired
+    assert any("exhausted/empty" in r.message or "exhausted/empty" in r.getMessage()
+               for r in caplog.records), "empty DW response must log a distinct diagnostic"
+
+
+async def test_empty_claude_response_also_logs(tmp_path, caplog):
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(side_effect=RuntimeError("dw down"))
+    claude = MagicMock()
+    claude.prompt_only = AsyncMock(return_value="")
+    eng = _rt_engine(tmp_path, dw=dw, claude=claude, jprime_url="")
+    with caplog.at_level(logging.INFO):
+        with pytest.raises(DreamProviderExhaustedError):
+            await eng._call_inference("p")
+    assert any("exhausted/empty" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
DW-RT returned `0 chars, 30.25s, $0.00010`. Three root causes: (1) **type error** — `DREAM_MAX_PROMPT_CHARS` (input char cap) passed as `max_tokens` (output budget); the entitled 397B has an effort **floor of low** so it always reasons and 2048 tokens went entirely to chain-of-thought → new `JARVIS_DREAM_MAX_OUTPUT_TOKENS` (default 8192, floor 1024). (2) **silent fall-through** — empty responses logged nothing, so a tier that ran and cost money looked un-attempted; both tiers now emit `generation exhausted/empty`. (3) **DRY** — `complete_sync` now composes the Slice-54 `_extract_completion_text` (reasoning models put text in `reasoning`/`reasoning_details`, not `content`). 6 new tests; 84/84 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes zero-content dream responses by decoupling the output-token budget from the prompt cap and adding clear logs when a tier returns an empty generation. Also reads content from reasoning fields so answers aren’t lost on reasoning models.

- **Bug Fixes**
  - Use `JARVIS_DREAM_MAX_OUTPUT_TOKENS` for `max_tokens` (default 8192, floor 1024) instead of `DREAM_MAX_PROMPT_CHARS`.
  - Log “generation exhausted/empty” for DW and Claude tiers and still cascade to the next tier.
  - Added tests for budget decoupling, env tunability, correct `max_tokens`, and empty-tier logging/cascade.

- **Refactors**
  - Compose `_extract_completion_text` in `doubleword_provider.complete_sync` to read from `reasoning`/`reasoning_details` when `content` is empty.

<sup>Written for commit de2df651115a4c66c6e3e33c0bc74d3fca7192d0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69914?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

