### PR TITLE
feat(health): surface-aware DW topology + Synthetic Tracer (multi-dimensional)

### DIFF
--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -67,6 +67,18 @@ DREAM_MAX_PROMPT_CHARS: int = 2048
 _DREAM_MAX_OUTPUT_TOKENS_DEFAULT: int = 8192
 
 
+def _dw_completion_degrade_streak() -> int:
+    """Consecutive DIRECT_COMPLETION failures before the DW-RT tier is bypassed
+    (``JARVIS_DW_COMPLETION_DEGRADE_STREAK``, default 2 — mirrors the
+    heartbeat's own degrade-streak convention). Floor of 1: a bypass must
+    always require at least one observed failure, never fire on a clean
+    surface. Never raises."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_DW_COMPLETION_DEGRADE_STREAK", "2")))
+    except (TypeError, ValueError):
+        return 2
+
+
 def dream_max_output_tokens() -> int:
     """``JARVIS_DREAM_MAX_OUTPUT_TOKENS`` (default 8192). Floor of 1024 keeps a
     misconfiguration from re-creating the truncation class. Never raises."""
@@ -566,6 +578,11 @@ class DreamEngine:
         # blueprints from the prior HEAD are correctly discarded downstream).
         self._hydrate_repo_state()
 
+        # Recovery probe: if DW's completion surface is bypassed, this is the
+        # ONLY traffic that can observe it healing (a bypass silences organic
+        # calls). Fires only while degraded — a healthy DW costs nothing.
+        await self._trace_dw_recovery_if_bypassed()
+
         # Build candidate info (in a real implementation this would
         # come from the oracle/memory engine analysis of the repo)
         candidate = self._pick_candidate()
@@ -953,38 +970,80 @@ class DreamEngine:
         """True when the DW-RT tier should be SKIPPED because the heartbeat
         already knows DW is unhealthy — eliminating the timeout tax.
 
-        Consumes the EXISTING ``DWHeartbeat.is_degrading()`` state emission
-        (the same surface the failover lifecycle's pre-warm gate reads) rather
-        than probing DW again at the call site: the heartbeat's deep-probe loop
-        is the single source of health truth, so this is a read, not a check.
+        SURFACE-AWARE (2026-07-17). Reads the EXISTING SurfaceHealthLedger
+        verdict for ``DIRECT_COMPLETION`` — the stream-free
+        /v1/chat/completions surface that ``complete_sync`` (this tier's ONLY
+        transport) actually uses — never the SSE surface.
 
-        bt-2026-07-17-074626 is the motivating cost: DW answered HTTP 502
-        (upstream_unreachable) and EVERY dream paid ~53s of dead-tier latency
-        before cascading to Claude — the worst of both providers (DW's latency
-        AND Claude's price). With the heartbeat armed, a degraded DW is skipped
-        instantly.
+        This decoupling is load-bearing. The first version of this bypass read
+        ``DWHeartbeat.is_degrading()``, which probes ``DIRECT_STREAMING``, and
+        bt-2026-07-17-080507 showed the cost: the tier was bypassed on
+        ``consecutive_failures=254`` from a surface it was PURPOSE-BUILT to
+        avoid (complete_sync exists precisely because DW's SSE endpoint stalls
+        post-accept — bt-2026-04-14-182446). Cross-contaminated telemetry
+        neutralizes the opportunistic tier: SSE can be broken forever while
+        completions serve fine.
 
-        Inert by construction: the heartbeat is default-OFF and its
-        ``is_degrading()`` returns False when disabled OR frozen (its Safety
-        Law — a misconfiguration must never steer routing), so this bypass
-        cannot fire on a config error. Fail-soft: any fault → False → attempt
-        DW normally (never strand the cheap tier on a telemetry bug)."""
+        Bypasses on either failure dimension of ITS OWN surface — transport
+        (502/timeout/auth) or inference (HTTP 200 with zero generated content,
+        the reasoning-budget exhaustion class) — once the streak reaches the
+        degrade threshold.
+
+        Fail-soft: any fault → False → attempt DW normally (a telemetry bug
+        must never strand the cheap tier)."""
         try:
-            from backend.core.ouroboros.governance.provider_heartbeat import (
-                get_dw_heartbeat,
+            from backend.core.ouroboros.governance.dw_surface_health import (
+                SurfaceKind,
+                SurfaceHealthLedger,
+                SurfaceVerdict,
             )
 
-            hb = get_dw_heartbeat()
-            if hb.is_degrading():
+            rec = SurfaceHealthLedger().verdict_for(SurfaceKind.DIRECT_COMPLETION)
+            if rec is None:
+                return False  # never probed → attempt DW (no verdict is not a verdict)
+            if rec.verdict is SurfaceVerdict.HEALTHY:
+                return False
+            if int(rec.consecutive_failures) >= _dw_completion_degrade_streak():
                 logger.info(
-                    "[DreamEngine] DW-RT tier BYPASSED — heartbeat reports DW "
-                    "degraded (consecutive_failures=%s); routing straight to "
-                    "Claude (no timeout tax)", hb.consecutive_failures(),
+                    "[DreamEngine] DW-RT tier BYPASSED — DIRECT_COMPLETION "
+                    "surface %s (consecutive_failures=%d, diag=%s); routing "
+                    "straight to Claude (no timeout tax)",
+                    rec.verdict.value, rec.consecutive_failures,
+                    (rec.diagnostic or "")[:80],
                 )
                 return True
         except Exception:  # noqa: BLE001 — health telemetry is advisory
             logger.debug("[DreamEngine] DW health bypass probe cold", exc_info=True)
         return False
+
+    async def _trace_dw_recovery_if_bypassed(self) -> None:
+        """Close the ONE-WAY DOOR: probe a bypassed DW surface for recovery.
+
+        A bypass suppresses organic ``complete_sync`` traffic, so the surface
+        would never earn a fresh HEALTHY record and the bypass would be
+        permanent. This fires the Synthetic Tracer ONLY while the surface is
+        degraded — a healthy DW is never probed, so the cost is strictly
+        proportional to the outage — and the tracer's generated-content
+        assertion re-opens the tier the moment DW can truly serve again.
+
+        Driven from the existing dream loop (no new daemon). NEVER raises."""
+        try:
+            if not self._dw_health_bypass():
+                return  # healthy (or unprobed) → no tracer cost
+            from backend.core.ouroboros.governance.dw_capacity_probe import (
+                trace_direct_completion,
+            )
+
+            verdict = await trace_direct_completion(
+                self._dw_provider,
+                model=os.environ.get("JARVIS_DREAM_DW_MODEL", "").strip() or None,
+            )
+            logger.info(
+                "[DreamEngine] DW recovery tracer → %s (bypass lifts "
+                "automatically once the surface reports healthy)", verdict,
+            )
+        except Exception:  # noqa: BLE001 — recovery probing is advisory
+            logger.debug("[DreamEngine] DW recovery tracer skipped", exc_info=True)
 
     @staticmethod
     def _dream_rt_timeout_s() -> float:

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -7298,6 +7298,55 @@ class DoublewordProvider:
     # Functions-not-Agents path: complete_sync()
     # ------------------------------------------------------------------
 
+    @staticmethod
+    def _record_completion_surface(
+        *,
+        healthy: bool,
+        latency_s: float,
+        model: str,
+        output_tokens: int = 0,
+        verdict: Optional[Any] = None,
+        diagnostic: str = "",
+    ) -> None:
+        """Inject a DIRECT_COMPLETION outcome into the EXISTING surface-health
+        ledger (no parallel data structure — mandate 3).
+
+        Multi-dimensional by construction:
+          * transport fault (502/timeout/auth) → caller passes an explicit
+            ``verdict`` (UPSTREAM_DEGRADED / TRANSPORT_DEGRADED / AUTH_FAILED),
+          * transport OK but ZERO generated content → INFERENCE_DEGRADED,
+          * content produced → HEALTHY (streak resets in the ledger).
+
+        NEVER raises: health telemetry must never break a live inference call.
+        """
+        try:
+            from backend.core.ouroboros.governance.dw_surface_health import (
+                SurfaceHealthLedger,
+                SurfaceKind,
+                SurfaceVerdict,
+            )
+
+            if verdict is None:
+                verdict = (
+                    SurfaceVerdict.HEALTHY if healthy
+                    else SurfaceVerdict.INFERENCE_DEGRADED
+                )
+                diagnostic = diagnostic or (
+                    "" if healthy else
+                    f"empty_generation:model={model}:out_tokens={output_tokens}"
+                )
+            SurfaceHealthLedger().record(
+                SurfaceKind.DIRECT_COMPLETION,
+                verdict,
+                latency_ms=int(max(0.0, latency_s) * 1000),
+                diagnostic=diagnostic[:200],
+            )
+        except Exception:  # noqa: BLE001 — telemetry is advisory, never fatal
+            logger.debug(
+                "[DoublewordProvider] DIRECT_COMPLETION health record skipped",
+                exc_info=True,
+            )
+
     async def complete_sync(
         self,
         prompt: str,
@@ -7503,6 +7552,28 @@ class DoublewordProvider:
                 if resp.status >= 300:
                     self._last_error_status = resp.status
                     err_body = await resp.text()
+                    # TRANSPORT dimension of DIRECT_COMPLETION health: classify
+                    # the fault so a 502 (DW's upstream unreachable — the live
+                    # bt-2026-07-17-074626 condition) is a DIFFERENT fact from
+                    # an auth failure or an empty generation. Without this the
+                    # surface would only ever hear about successes.
+                    try:
+                        from backend.core.ouroboros.governance.dw_surface_health import (
+                            SurfaceVerdict as _SV,
+                        )
+                        if resp.status in (401, 403):
+                            _v = _SV.AUTH_FAILED
+                        elif resp.status in (502, 503, 504):
+                            _v = _SV.UPSTREAM_DEGRADED
+                        else:
+                            _v = _SV.TRANSPORT_DEGRADED
+                        self._record_completion_surface(
+                            healthy=False, latency_s=0.0, model=effective_model,
+                            verdict=_v,
+                            diagnostic=f"http_{resp.status}:{err_body[:80]}",
+                        )
+                    except Exception:  # noqa: BLE001 — never mask the real error
+                        pass
                     raise DoublewordInfraError(
                         f"complete_sync[{caller_id}] HTTP {resp.status}: {err_body[:200]}",
                         status_code=resp.status,
@@ -7562,6 +7633,22 @@ class DoublewordProvider:
                 "[DoublewordProvider] complete_sync[%s] empty content (model=%s, %.2fs)",
                 caller_id, effective_model, elapsed,
             )
+
+        # DIRECT_COMPLETION surface health (2026-07-17). complete_sync is the
+        # ONLY consumer of DW's stream-free /v1/chat/completions surface and it
+        # recorded NOTHING, so consumers had to borrow the SSE verdict — which
+        # is chronically degraded BY DESIGN (that breakage is why this method
+        # exists). Recording here gives the surface its own health domain.
+        #
+        # TWO DIMENSIONS, not one: a 200 with zero generated content is an
+        # INFERENCE failure wearing a healthy transport's clothes
+        # (bt-2026-07-17-033933: "ok: 30.25s, 0 chars" — the reasoning budget
+        # consumed everything). Transport-only health would score that HEALTHY
+        # and keep routing dreams into a tier that cannot produce.
+        self._record_completion_surface(
+            healthy=bool(content), latency_s=elapsed, model=effective_model,
+            output_tokens=output_tokens,
+        )
 
         logger.info(
             "[DoublewordProvider] complete_sync[%s] ok: %.2fs, %d chars, $%.5f (model=%s)",

--- a/backend/core/ouroboros/governance/dw_capacity_probe.py
+++ b/backend/core/ouroboros/governance/dw_capacity_probe.py
@@ -564,3 +564,120 @@ __all__ = [
     "build_capacity_probe_from_default_provider",
     "classify_probe_results",
 ]
+
+
+# ===========================================================================
+# Synthetic Tracer — DIRECT_COMPLETION health (2026-07-17)
+#
+# Repurposes this module (previously 0 production importers — dead code) into
+# the active health source for DW's stream-free completions surface.
+#
+# WHY a tracer and not just passive instrumentation: complete_sync records its
+# own outcome on every ORGANIC call, but once the DW-RT tier is bypassed no
+# organic calls occur — the surface would never see a fresh HEALTHY record and
+# the bypass would become a ONE-WAY DOOR. The tracer is the only thing that can
+# observe recovery on a silent surface, which is what lets cheap tokens resume
+# automatically with no code change.
+#
+# WHY not an HTTP ping: DW proved (bt-2026-07-17-033933) that it returns
+# "ok: 30.25s, 0 chars" — a perfect transport carrying zero inference. A ping
+# would score that HEALTHY and keep routing dreams into a tier that cannot
+# produce. The tracer therefore demands GENERATED CONTENT, asserting two
+# dimensions at once:
+#     transport  → did the call complete without an HTTP/timeout fault?
+#     inference  → did the model actually emit tokens?
+# ===========================================================================
+
+_TRACER_PROMPT = "Reply with the single word: ok"
+_TRACER_SYSTEM = "You are a liveness probe. Reply with exactly one word."
+
+
+def tracer_enabled() -> bool:
+    """``JARVIS_DW_COMPLETION_TRACER_ENABLED`` (default true). The tracer only
+    ever fires when the surface is already degraded (recovery detection), so it
+    costs nothing on a healthy provider."""
+    return os.environ.get(
+        "JARVIS_DW_COMPLETION_TRACER_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _tracer_max_tokens() -> int:
+    """Output ceiling for the tracer. Must leave room for a reasoning model to
+    think AND still emit a token — the entitled 397B carries an effort FLOOR of
+    "low", so a tiny budget reproduces the very exhaustion this probe exists to
+    detect and would report a false INFERENCE_DEGRADED."""
+    try:
+        return max(64, int(os.environ.get("JARVIS_DW_TRACER_MAX_TOKENS", "2048")))
+    except (TypeError, ValueError):
+        return 2048
+
+
+def _tracer_timeout_s() -> float:
+    try:
+        return max(5.0, float(os.environ.get("JARVIS_DW_TRACER_TIMEOUT_S", "90")))
+    except (TypeError, ValueError):
+        return 90.0
+
+
+async def trace_direct_completion(provider: Any, *, model: Optional[str] = None) -> str:
+    """Fire one synthetic generation at DW's stream-free completions surface
+    and inject the verdict into the EXISTING SurfaceHealthLedger.
+
+    Returns the recorded ``SurfaceVerdict`` value (a plain str) — or
+    ``"skipped"`` when disabled / no usable provider. NEVER raises: a health
+    probe must not be able to break the loop that hosts it.
+
+    complete_sync self-records both dimensions internally, so this function
+    does NOT duplicate the recording logic (DRY) — it simply drives a call on a
+    surface that would otherwise be silent, and lets the provider's own
+    instrumentation speak.
+    """
+    if not tracer_enabled():
+        return "skipped"
+    if provider is None or not hasattr(provider, "complete_sync"):
+        return "skipped"
+    try:
+        res = await asyncio.wait_for(
+            provider.complete_sync(
+                _TRACER_PROMPT,
+                system_prompt=_TRACER_SYSTEM,
+                caller_id="completion_tracer",
+                model=model,
+                max_tokens=_tracer_max_tokens(),
+                timeout_s=_tracer_timeout_s(),
+            ),
+            timeout=_tracer_timeout_s() + 5.0,
+        )
+        content = (getattr(res, "content", "") or "").strip()
+        # complete_sync already recorded HEALTHY / INFERENCE_DEGRADED.
+        verdict = "healthy" if content else "inference_degraded"
+        logger.info(
+            "[DWTracer] DIRECT_COMPLETION %s (chars=%d, %.2fs, model=%s)",
+            verdict, len(content), getattr(res, "latency_s", -1.0),
+            getattr(res, "model", "?"),
+        )
+        return verdict
+    except asyncio.CancelledError:
+        raise
+    except Exception as exc:  # noqa: BLE001
+        # complete_sync's own HTTP branch recorded the transport verdict
+        # (AUTH_FAILED / UPSTREAM_DEGRADED / TRANSPORT_DEGRADED). A timeout
+        # never reaches that branch, so record it here — same ledger, same API.
+        if isinstance(exc, asyncio.TimeoutError):
+            try:
+                from backend.core.ouroboros.governance.dw_surface_health import (
+                    SurfaceHealthLedger,
+                    SurfaceKind,
+                    SurfaceVerdict,
+                )
+                SurfaceHealthLedger().record(
+                    SurfaceKind.DIRECT_COMPLETION,
+                    SurfaceVerdict.TRANSPORT_DEGRADED,
+                    latency_ms=int(_tracer_timeout_s() * 1000),
+                    diagnostic="tracer_timeout",
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        logger.info("[DWTracer] DIRECT_COMPLETION probe failed (%s: %s)",
+                    type(exc).__name__, exc)
+        return "transport_degraded"

--- a/backend/core/ouroboros/governance/dw_surface_health.py
+++ b/backend/core/ouroboros/governance/dw_surface_health.py
@@ -47,20 +47,42 @@ LEDGER_SCHEMA_VERSION = 1
 
 
 class SurfaceKind(str, Enum):
-    """The three DW transport surfaces JARVIS uses."""
+    """The DW transport surfaces JARVIS uses.
+
+    Surfaces are INDEPENDENT health domains — a verdict on one says nothing
+    about another. DIRECT_STREAMING (SSE) has been chronically degraded since
+    bt-2026-04-14-182446 ("stalls post-accept across Qwen 397B and Gemma 4
+    31B"), which is precisely why ``DoublewordProvider.complete_sync`` exists:
+    it reaches /v1/chat/completions with ``stream=False`` and never opens an
+    SSE stream. DIRECT_COMPLETION is that surface's own health domain (added
+    2026-07-17). Before it existed, complete_sync recorded NOTHING, so
+    consumers had to borrow the SSE verdict — and bt-2026-07-17-080507 shows
+    the cost: the dream's DW-RT tier was permanently bypassed on
+    ``consecutive_failures=254`` from a surface it was purpose-built to avoid.
+    """
 
     BATCH_STORAGE = "batch_storage"
     DIRECT_STREAMING = "direct_streaming"
+    DIRECT_COMPLETION = "direct_completion"
     AUTH_SYNC = "auth_sync"
 
 
 class SurfaceVerdict(str, Enum):
-    """Health verdict for a single surface probe outcome."""
+    """Health verdict for a single surface probe outcome.
+
+    TRANSPORT vs INFERENCE are distinct failure dimensions: DW can return a
+    perfectly healthy transport (HTTP 200, low latency) while generating ZERO
+    content — the reasoning-budget exhaustion class proven live in
+    bt-2026-07-17-033933 ("ok: 30.25s, 0 chars, $0.00010"). A 200 that produces
+    nothing is a LIE the transport layer cannot see, so it earns its own
+    verdict rather than counting as HEALTHY.
+    """
 
     HEALTHY = "healthy"
     TRANSPORT_DEGRADED = "transport_degraded"
     UPSTREAM_DEGRADED = "upstream_degraded"
     AUTH_FAILED = "auth_failed"
+    INFERENCE_DEGRADED = "inference_degraded"
     ERROR_OTHER = "error_other"
 
 

--- a/tests/governance/test_dw_surface_aware_health.py
+++ b/tests/governance/test_dw_surface_aware_health.py
@@ -1,0 +1,197 @@
+"""Multi-dimensional DW surface health (2026-07-17).
+
+bt-2026-07-17-080507 bypassed the DW-RT tier on consecutive_failures=254 from
+DIRECT_STREAMING — the SSE surface that complete_sync was PURPOSE-BUILT to
+avoid (it stalls post-accept; bt-2026-04-14-182446). Cross-contaminated
+telemetry neutralizes the opportunistic tier. These pin the isolation, the two
+failure DIMENSIONS (transport vs inference), and the recovery door.
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger, SurfaceKind, SurfaceVerdict,
+)
+
+
+@pytest.fixture
+def ledger(tmp_path, monkeypatch):
+    lg = SurfaceHealthLedger(path=tmp_path / "surf.json", autosave=False)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.dw_surface_health.SurfaceHealthLedger",
+        lambda *a, **k: lg,
+    )
+    return lg
+
+
+def _run(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+# ---- surface isolation (the core fix) -------------------------------------
+
+
+def test_surfaces_are_independent_health_domains(ledger):
+    """A broken SSE surface must NOT contaminate the completions verdict."""
+    for _ in range(254):
+        ledger.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+    ledger.record(SurfaceKind.DIRECT_COMPLETION, SurfaceVerdict.HEALTHY)
+
+    sse = ledger.verdict_for(SurfaceKind.DIRECT_STREAMING)
+    comp = ledger.verdict_for(SurfaceKind.DIRECT_COMPLETION)
+    assert sse.consecutive_failures == 254            # SSE chronically broken
+    assert comp.verdict is SurfaceVerdict.HEALTHY     # completions unaffected
+    assert comp.consecutive_failures == 0
+
+
+def test_direct_completion_surface_is_registered():
+    assert SurfaceKind.DIRECT_COMPLETION.value == "direct_completion"
+    assert SurfaceVerdict.INFERENCE_DEGRADED.value == "inference_degraded"
+
+
+def test_bypass_reads_completion_not_streaming(ledger, monkeypatch, tmp_path):
+    """THE decoupling: 254 SSE failures must not bypass the DW-RT tier."""
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    for _ in range(254):
+        ledger.record(SurfaceKind.DIRECT_STREAMING, SurfaceVerdict.UPSTREAM_DEGRADED)
+    ledger.record(SurfaceKind.DIRECT_COMPLETION, SurfaceVerdict.HEALTHY)
+    assert DreamEngine._dw_health_bypass() is False   # SSE no longer contaminates
+
+
+def test_bypass_fires_on_completion_degradation(ledger):
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    for _ in range(2):
+        ledger.record(SurfaceKind.DIRECT_COMPLETION, SurfaceVerdict.UPSTREAM_DEGRADED)
+    assert DreamEngine._dw_health_bypass() is True
+
+
+def test_no_verdict_is_not_a_verdict(ledger):
+    """Never probed → attempt DW (don't strand the tier on silence)."""
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    assert DreamEngine._dw_health_bypass() is False
+
+
+def test_single_failure_below_streak_does_not_bypass(ledger):
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    ledger.record(SurfaceKind.DIRECT_COMPLETION, SurfaceVerdict.UPSTREAM_DEGRADED)
+    assert DreamEngine._dw_health_bypass() is False   # streak=1 < 2
+
+
+def test_healthy_record_resets_and_lifts_bypass(ledger):
+    """Recovery: a HEALTHY record zeroes the streak → tier re-opens."""
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    for _ in range(5):
+        ledger.record(SurfaceKind.DIRECT_COMPLETION, SurfaceVerdict.UPSTREAM_DEGRADED)
+    assert DreamEngine._dw_health_bypass() is True
+    ledger.record(SurfaceKind.DIRECT_COMPLETION, SurfaceVerdict.HEALTHY)
+    assert DreamEngine._dw_health_bypass() is False   # cheap tokens resume
+
+
+# ---- the two failure DIMENSIONS -------------------------------------------
+
+
+def _provider():
+    from backend.core.ouroboros.governance.doubleword_provider import DoublewordProvider
+    return DoublewordProvider
+
+
+def test_empty_200_is_inference_not_healthy(ledger):
+    """A 200 with 0 chars is a LIE the transport can't see."""
+    _provider()._record_completion_surface(
+        healthy=False, latency_s=30.25, model="Qwen/Qwen3.5-397B-A17B-FP8",
+        output_tokens=2048,
+    )
+    rec = ledger.verdict_for(SurfaceKind.DIRECT_COMPLETION)
+    assert rec.verdict is SurfaceVerdict.INFERENCE_DEGRADED   # not HEALTHY
+    assert "empty_generation" in rec.diagnostic
+
+
+def test_content_records_healthy(ledger):
+    _provider()._record_completion_surface(
+        healthy=True, latency_s=1.2, model="m", output_tokens=12,
+    )
+    assert ledger.verdict_for(SurfaceKind.DIRECT_COMPLETION).verdict is SurfaceVerdict.HEALTHY
+
+
+def test_transport_verdicts_are_distinct(ledger):
+    """502 (upstream) vs 403 (auth) must be different facts."""
+    _provider()._record_completion_surface(
+        healthy=False, latency_s=0.0, model="m",
+        verdict=SurfaceVerdict.UPSTREAM_DEGRADED, diagnostic="http_502:unreachable")
+    assert ledger.verdict_for(SurfaceKind.DIRECT_COMPLETION).verdict is SurfaceVerdict.UPSTREAM_DEGRADED
+    _provider()._record_completion_surface(
+        healthy=False, latency_s=0.0, model="m",
+        verdict=SurfaceVerdict.AUTH_FAILED, diagnostic="http_403")
+    assert ledger.verdict_for(SurfaceKind.DIRECT_COMPLETION).verdict is SurfaceVerdict.AUTH_FAILED
+
+
+def test_health_record_never_raises(ledger, monkeypatch):
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.dw_surface_health.SurfaceHealthLedger",
+        MagicMock(side_effect=RuntimeError("ledger down")))
+    _provider()._record_completion_surface(healthy=True, latency_s=1.0, model="m")
+
+
+# ---- Synthetic Tracer -----------------------------------------------------
+
+
+class _Res:
+    def __init__(self, content):
+        self.content = content
+        self.model = "m"
+        self.latency_s = 0.4
+
+
+def test_tracer_demands_generated_content_not_just_200(ledger):
+    """Mandate 2: an empty 200 must NOT score healthy."""
+    from backend.core.ouroboros.governance.dw_capacity_probe import trace_direct_completion
+    p = MagicMock()
+    p.complete_sync = AsyncMock(return_value=_Res(""))     # perfect transport, no inference
+    assert _run(trace_direct_completion(p)) == "inference_degraded"
+
+
+def test_tracer_healthy_on_real_generation(ledger):
+    from backend.core.ouroboros.governance.dw_capacity_probe import trace_direct_completion
+    p = MagicMock()
+    p.complete_sync = AsyncMock(return_value=_Res("ok"))
+    assert _run(trace_direct_completion(p)) == "healthy"
+
+
+def test_tracer_handles_502_transport_failure(ledger):
+    from backend.core.ouroboros.governance.dw_capacity_probe import trace_direct_completion
+    p = MagicMock()
+    p.complete_sync = AsyncMock(side_effect=RuntimeError("HTTP 502 upstream_unreachable"))
+    assert _run(trace_direct_completion(p)) == "transport_degraded"
+
+
+def test_tracer_records_timeout_to_ledger(ledger):
+    from backend.core.ouroboros.governance.dw_capacity_probe import trace_direct_completion
+    p = MagicMock()
+    p.complete_sync = AsyncMock(side_effect=asyncio.TimeoutError())
+    assert _run(trace_direct_completion(p)) == "transport_degraded"
+    rec = ledger.verdict_for(SurfaceKind.DIRECT_COMPLETION)
+    assert rec.verdict is SurfaceVerdict.TRANSPORT_DEGRADED and rec.diagnostic == "tracer_timeout"
+
+
+def test_tracer_uses_a_reasoning_safe_budget():
+    """A tiny budget would reproduce the exhaustion the probe exists to detect
+    (the 397B effort FLOOR means it always thinks) → false INFERENCE_DEGRADED."""
+    from backend.core.ouroboros.governance.dw_capacity_probe import _tracer_max_tokens
+    assert _tracer_max_tokens() >= 64
+
+
+def test_tracer_skips_without_provider(ledger):
+    from backend.core.ouroboros.governance.dw_capacity_probe import trace_direct_completion
+    assert _run(trace_direct_completion(None)) == "skipped"
+
+
+def test_tracer_disabled_is_inert(ledger, monkeypatch):
+    from backend.core.ouroboros.governance.dw_capacity_probe import trace_direct_completion
+    monkeypatch.setenv("JARVIS_DW_COMPLETION_TRACER_ENABLED", "false")
+    p = MagicMock(); p.complete_sync = AsyncMock(return_value=_Res("ok"))
+    assert _run(trace_direct_completion(p)) == "skipped"
+    p.complete_sync.assert_not_called()

--- a/tests/test_ouroboros_governance/test_dream_engine.py
+++ b/tests/test_ouroboros_governance/test_dream_engine.py
@@ -1301,21 +1301,31 @@ async def test_empty_claude_response_also_logs(tmp_path, caplog):
 # health; the cascade must READ that state, not re-probe.
 # ============================================================================
 
-import backend.core.ouroboros.governance.provider_heartbeat as _hb_mod
+from backend.core.ouroboros.governance.dw_surface_health import (
+    SurfaceHealthLedger as _SHL,
+    SurfaceKind as _SK,
+    SurfaceVerdict as _SV,
+)
 
 
-def _fake_hb(*, degrading, failures=0, monkeypatch=None):
-    hb = MagicMock()
-    hb.is_degrading.return_value = degrading
-    hb.consecutive_failures.return_value = failures
-    monkeypatch.setattr(_hb_mod, "get_dw_heartbeat", lambda: hb)
-    return hb
+def _surface(monkeypatch, tmp_path, verdict, *, times=1):
+    """Drive the REAL ledger — the fake must mirror the real contract. The
+    bypass reads DIRECT_COMPLETION, NOT the SSE heartbeat (which is chronically
+    degraded by design and must never contaminate this tier)."""
+    lg = _SHL(path=tmp_path / "surf.json", autosave=False)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.dw_surface_health.SurfaceHealthLedger",
+        lambda *a, **k: lg,
+    )
+    for _ in range(times):
+        lg.record(_SK.DIRECT_COMPLETION, verdict)
+    return lg
 
 
 async def test_degraded_dw_is_bypassed_instantly_no_timeout_tax(tmp_path, monkeypatch):
-    """THE fix: heartbeat says DW degraded → DW-RT is never called → Claude
+    """THE fix: DIRECT_COMPLETION degraded -> DW-RT never called -> Claude
     serves with ZERO dead-tier latency."""
-    _fake_hb(degrading=True, failures=3, monkeypatch=monkeypatch)
+    _surface(monkeypatch, tmp_path, _SV.UPSTREAM_DEGRADED, times=3)
     dw = MagicMock()
     dw.complete_sync = AsyncMock(return_value=_SyncResult(_BP_JSON))
     claude = MagicMock()
@@ -1326,9 +1336,9 @@ async def test_degraded_dw_is_bypassed_instantly_no_timeout_tax(tmp_path, monkey
     dw.complete_sync.assert_not_called()          # the 53s tax is gone
 
 
-async def test_healthy_dw_is_still_attempted(tmp_path, monkeypatch):
-    """Bypass must not strand the cheap tier when DW is healthy."""
-    _fake_hb(degrading=False, monkeypatch=monkeypatch)
+async def test_healthy_completion_surface_still_attempts_dw(tmp_path, monkeypatch):
+    """Bypass must not strand the cheap tier when the surface is healthy."""
+    _surface(monkeypatch, tmp_path, _SV.HEALTHY)
     dw = MagicMock()
     dw.complete_sync = AsyncMock(return_value=_SyncResult(_BP_JSON))
     eng = _rt_engine(tmp_path, dw=dw, claude=MagicMock())
@@ -1337,26 +1347,44 @@ async def test_healthy_dw_is_still_attempted(tmp_path, monkeypatch):
     dw.complete_sync.assert_awaited_once()
 
 
-def test_bypass_reads_existing_state_not_a_new_probe(tmp_path, monkeypatch):
-    """DRY: consumes is_degrading()/consecutive_failures() — no re-probe."""
-    hb = _fake_hb(degrading=True, failures=2, monkeypatch=monkeypatch)
+def test_sse_degradation_never_contaminates_the_completion_tier(tmp_path, monkeypatch):
+    """The bug this replaced: 254 SSE failures bypassed a tier built to AVOID
+    SSE. Surfaces are independent health domains."""
     from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
-    assert DreamEngine._dw_health_bypass() is True
-    hb.is_degrading.assert_called()               # existing emission consumed
-
-
-def test_bypass_inert_when_heartbeat_disabled_or_frozen(tmp_path, monkeypatch):
-    """Safety Law: OFF/frozen heartbeats report is_degrading()=False, so a
-    misconfiguration can never steer routing."""
-    _fake_hb(degrading=False, monkeypatch=monkeypatch)   # OFF/frozen semantics
-    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    lg = _surface(monkeypatch, tmp_path, _SV.HEALTHY)
+    for _ in range(254):
+        lg.record(_SK.DIRECT_STREAMING, _SV.UPSTREAM_DEGRADED)
     assert DreamEngine._dw_health_bypass() is False
 
 
 def test_bypass_fail_soft_never_strands_dw(tmp_path, monkeypatch):
     """A telemetry fault must not permanently disable the cheap tier."""
-    def _boom():
-        raise RuntimeError("heartbeat module exploded")
-    monkeypatch.setattr(_hb_mod, "get_dw_heartbeat", _boom)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.dw_surface_health.SurfaceHealthLedger",
+        MagicMock(side_effect=RuntimeError("ledger exploded")),
+    )
     from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
     assert DreamEngine._dw_health_bypass() is False   # attempt DW normally
+
+
+async def test_recovery_tracer_fires_only_when_bypassed(tmp_path, monkeypatch):
+    """Closes the ONE-WAY DOOR: a bypass silences organic traffic, so the
+    tracer is the only thing that can observe DW healing. It must NOT probe a
+    healthy surface (cost proportional to the outage)."""
+    import backend.core.ouroboros.governance.dw_capacity_probe as _cap
+    calls = []
+
+    async def _fake_trace(provider, *, model=None):
+        calls.append(model)
+        return "healthy"
+
+    monkeypatch.setattr(_cap, "trace_direct_completion", _fake_trace)
+
+    _surface(monkeypatch, tmp_path, _SV.HEALTHY)
+    eng = _rt_engine(tmp_path, dw=MagicMock(), claude=MagicMock())
+    await eng._trace_dw_recovery_if_bypassed()
+    assert calls == []                              # healthy -> no probe cost
+
+    _surface(monkeypatch, tmp_path, _SV.UPSTREAM_DEGRADED, times=3)
+    await eng._trace_dw_recovery_if_bypassed()
+    assert len(calls) == 1                          # degraded -> probe for recovery


### PR DESCRIPTION
The bypass shipped an hour ago read **DIRECT_STREAMING** health to gate a tier that uses **stream-free completions** — the very surface `complete_sync` exists to avoid. 254 SSE failures permanently neutralized the opportunistic tier.

**Isolation:** `SurfaceKind.DIRECT_COMPLETION` registered; `complete_sync` self-records; bypass decoupled from SSE.
**Two dimensions:** `INFERENCE_DEGRADED` — a 200 with 0 chars is a lie transport can't see (the 397B reasoning-floor class). 502/auth/timeout classified distinctly.
**Synthetic Tracer:** repurposes dead `dw_capacity_probe.py` — demands generated content, not a ping; reasoning-safe budget; injects via existing ledger (DRY).
**One-way door closed:** a bypass silences organic traffic → surface could never recover. Tracer fires only while degraded; HEALTHY resets the streak and cheap tokens resume automatically.

18 new tests; 137/137 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make DW health routing surface-aware and add a recovery tracer. This stops SSE failures from disabling the `complete_sync` tier and re-opens the cheap path automatically when DW recovers.

- **New Features**
  - Registered `DIRECT_COMPLETION` in `dw_surface_health`; `DoublewordProvider.complete_sync` now records outcomes to the ledger.
  - Multi-dimensional verdicts: added `INFERENCE_DEGRADED`; transport faults classified (401/403 → `AUTH_FAILED`, 502/503/504 → `UPSTREAM_DEGRADED`, else `TRANSPORT_DEGRADED`); zero-content 200 → `INFERENCE_DEGRADED`.
  - Synthetic Tracer `dw_capacity_probe.trace_direct_completion`: fires only while degraded, requires generated content, uses reasoning-safe budgets; toggled by `JARVIS_DW_COMPLETION_TRACER_ENABLED`, `JARVIS_DW_TRACER_MAX_TOKENS`, `JARVIS_DW_TRACER_TIMEOUT_S`.

- **Bug Fixes**
  - DW-RT bypass now reads `DIRECT_COMPLETION` health, not `DIRECT_STREAMING`; degrade streak via `JARVIS_DW_COMPLETION_DEGRADE_STREAK` (default 2).
  - Fail-soft: no verdict → no bypass; telemetry errors never strand DW; healthy records reset streak. Recovery is probed from the dream loop to lift the bypass as soon as DW is truly healthy.

<sup>Written for commit b8d3d9f04b6840429d5ba5216e37bcd6fd9a39d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

