### PR TITLE
feat(dw): wire the severed resilience owners into the RT completion path

### DIFF
--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -1974,6 +1974,10 @@ class DoublewordProvider:
         # and never rebound, so an alias onto the state dataclass is
         # alias-safe — no property indirection needed.
         self._stats = self._state.stats
+        # Slice 39 transport-pool flush policy owner (lazily constructed on the
+        # first RT transport failure). Holds the 60s anti-thrash cooldown state
+        # across calls, so it must be per-provider and not per-failure.
+        self._client_lifecycle: Any = None
         self._rate_limiter = rate_limiter
         self._tool_loop = tool_loop
         self._batch_registry = batch_registry
@@ -7298,6 +7302,104 @@ class DoublewordProvider:
     # Functions-not-Agents path: complete_sync()
     # ------------------------------------------------------------------
 
+    async def _handle_rt_http_failure(
+        self, *, status: int, body: str, model: str, caller_id: str,
+    ) -> None:
+        """Route an RT-completion HTTP failure to the EXISTING resilience
+        owners. Composition only — no backoff, TTL, or catalog logic here.
+
+        Until now these modules were reachable only from the batch/_upload_file
+        and probe paths, so the RT completion surface (the one the DreamEngine
+        and every rt_gate consumer use) had NO resilience owner at all:
+          * 502 storms never flushed the poisoned aiohttp pool
+            (``dw_client_lifecycle`` had ZERO production callers — severed),
+          * a 403 never pruned the unentitled model from the election matrix on
+            this path, so the organism could cycle 403s forever.
+
+        502/503/504 → ``ClientLifecycleManager.flush_transport_pool`` (Slice 39):
+        it owns the flush POLICY — master switch + a 60s cooldown that stops a
+        storm from thrashing the pool — and calls this provider's own
+        ``force_session_reset``. The jittered exponential recovery window lives
+        in ``dw_transport_recovery`` (Slice 127 Phase 3) and is consulted by the
+        surface-health/breaker consumers; the DIRECT_COMPLETION verdict recorded
+        just above is what the Tier-1 cascade reads to route around us with zero
+        latency.
+
+        401/403 → ``dw_entitlement_fallback`` (LIVE, default-on, TTL-cached via
+        ``JARVIS_DW_ENTITLEMENT_CACHE_TTL_S``, default 1800s): classify the
+        denial and refresh the entitled catalog so the blocked model is pruned
+        dynamically and re-probed only after the TTL expires — RBAC learned at
+        runtime, never hardcoded.
+
+        NEVER raises: resilience handling must not mask the real provider error
+        that the caller is about to receive.
+        """
+        try:
+            if status in (502, 503, 504):
+                from backend.core.ouroboros.governance.dw_client_lifecycle import (
+                    ClientLifecycleManager,
+                )
+
+                mgr = self._client_lifecycle
+                if mgr is None:
+                    mgr = self._client_lifecycle = ClientLifecycleManager()
+                flushed = await mgr.flush_transport_pool(
+                    self, reason=f"rt_http_{status}:{caller_id}",
+                )
+                logger.info(
+                    "[DoublewordProvider] RT %s → transport pool flush %s "
+                    "(model=%s); DIRECT_COMPLETION marked upstream_degraded — "
+                    "cascade routes around DW until it recovers",
+                    status, "APPLIED" if flushed else "suppressed(cooldown/off)",
+                    model,
+                )
+            elif status in (401, 403):
+                from backend.core.ouroboros.governance.dw_entitlement_fallback import (
+                    entitlement_fallback_enabled,
+                    is_entitlement_blocked,
+                )
+
+                if entitlement_fallback_enabled() and is_entitlement_blocked(
+                    status, body or "",
+                ):
+                    logger.info(
+                        "[DoublewordProvider] RT %s entitlement-blocked "
+                        "(model=%s) → pruning from the election matrix; "
+                        "re-probe after the TTL window", status, model,
+                    )
+                    self._prune_unentitled_model(model)
+        except Exception:  # noqa: BLE001 — never mask the caller's real error
+            logger.debug(
+                "[DoublewordProvider] RT failure handler skipped (status=%s)",
+                status, exc_info=True,
+            )
+
+    def _prune_unentitled_model(self, model: str) -> None:
+        """Prune a 403-blocked model from the live entitled set.
+
+        Delegates to the EXISTING process-wide ``EntitlementCatalogCache``
+        (``get_process_entitlement_cache``) — no second cache, no parallel RBAC
+        state. Its only mutation verb is ``reset()``, which invalidates the
+        cached entitled set so the NEXT ``get_entitled_ids`` re-fetches the
+        truth from DW's own /v1/models rather than trusting a stale local
+        guess. That is deliberately better than us subtracting the model
+        ourselves: DW remains the authority on its own RBAC, and the module's
+        TTL (``JARVIS_DW_ENTITLEMENT_CACHE_TTL_S``, default 1800s) still governs
+        re-probing if entitlements are provisioned later. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.dw_entitlement_fallback import (
+                get_process_entitlement_cache,
+            )
+
+            get_process_entitlement_cache().reset()
+            logger.info(
+                "[DoublewordProvider] entitled-catalog cache reset after 403 "
+                "(model=%s) — next election re-derives the entitled set from "
+                "DW itself", model,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[DoublewordProvider] entitlement prune skipped", exc_info=True)
+
     @staticmethod
     def _record_completion_surface(
         *,
@@ -7574,6 +7676,13 @@ class DoublewordProvider:
                         )
                     except Exception:  # noqa: BLE001 — never mask the real error
                         pass
+                    # RT-path resilience wiring (2026-07-17). Both handlers are
+                    # EXISTING modules — this composes them, it does not
+                    # reimplement backoff, TTL, or catalog logic (DRY).
+                    await self._handle_rt_http_failure(
+                        status=resp.status, body=err_body, model=effective_model,
+                        caller_id=caller_id,
+                    )
                     raise DoublewordInfraError(
                         f"complete_sync[{caller_id}] HTTP {resp.status}: {err_body[:200]}",
                         status_code=resp.status,

--- a/tests/governance/test_dw_rt_resilience_wiring.py
+++ b/tests/governance/test_dw_rt_resilience_wiring.py
@@ -1,0 +1,146 @@
+"""RT-completion resilience wiring (2026-07-17).
+
+Both handlers already EXISTED but were reachable only from batch/_upload_file
+and probe paths, so the RT completion surface — the one the DreamEngine and
+every rt_gate consumer use — had NO resilience owner:
+  * dw_client_lifecycle had ZERO production callers (severed): a 502 storm
+    (bt-2026-07-17-082144: "upstream_unreachable") never flushed the poisoned
+    aiohttp pool.
+  * a 403 never pruned the unentitled model on this path → cyclic 403s.
+
+These pin the WIRING. They deliberately do NOT re-test backoff/TTL internals —
+those belong to the modules that own them (DRY).
+"""
+from __future__ import annotations
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+import backend.core.ouroboros.governance.dw_client_lifecycle as lifecycle
+import backend.core.ouroboros.governance.dw_entitlement_fallback as ef
+from backend.core.ouroboros.governance.doubleword_provider import DoublewordProvider
+
+
+def _run(c):
+    return asyncio.new_event_loop().run_until_complete(c)
+
+
+def _provider():
+    p = DoublewordProvider.__new__(DoublewordProvider)
+    p._client_lifecycle = None
+    p.force_session_reset = AsyncMock()
+    return p
+
+
+# ---- 502 → the severed lifecycle owner is now driven -----------------------
+
+
+def test_502_triggers_transport_pool_flush(monkeypatch):
+    p = _provider()
+    _run(p._handle_rt_http_failure(
+        status=502, body='{"error":"upstream_unreachable"}',
+        model="Qwen/Qwen3.5-397B-A17B-FP8", caller_id="dream_engine"))
+    p.force_session_reset.assert_awaited_once()      # poisoned pool flushed
+
+
+@pytest.mark.parametrize("status", [502, 503, 504])
+def test_all_upstream_5xx_flush(monkeypatch, status):
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=status, body="", model="m", caller_id="c"))
+    p.force_session_reset.assert_awaited_once()
+
+
+def test_flush_respects_the_modules_own_cooldown(monkeypatch):
+    """DRY: the 60s anti-thrash cooldown is the lifecycle module's policy —
+    a 502 STORM must not thrash the pool. State persists per-provider."""
+    p = _provider()
+    for _ in range(5):
+        _run(p._handle_rt_http_failure(status=502, body="", model="m", caller_id="c"))
+    assert p.force_session_reset.await_count == 1    # storm → ONE flush
+
+
+def test_flush_master_switch_honored(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_TRANSPORT_FLUSH_ENABLED", "false")
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=502, body="", model="m", caller_id="c"))
+    p.force_session_reset.assert_not_called()
+
+
+def test_non_5xx_does_not_flush():
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=400, body="bad param", model="m", caller_id="c"))
+    p.force_session_reset.assert_not_called()
+
+
+# ---- 403 → entitlement prune (TTL-governed re-probe) ----------------------
+
+
+def test_403_entitlement_blocked_prunes_catalog(monkeypatch):
+    cache = MagicMock()
+    monkeypatch.setattr(ef, "get_process_entitlement_cache", lambda: cache)
+    monkeypatch.setattr(ef, "is_entitlement_blocked", lambda s, b: True)
+    p = _provider()
+    _run(p._handle_rt_http_failure(
+        status=403, body="blocked by a routing rule",
+        model="Qwen/Qwen3.5-35B-A3B-FP8", caller_id="dream_engine"))
+    cache.reset.assert_called_once()   # next election re-derives from DW itself
+
+
+def test_403_that_is_not_entitlement_does_not_prune(monkeypatch):
+    """A generic 403 (not the entitlement marker) must not nuke the catalog."""
+    cache = MagicMock()
+    monkeypatch.setattr(ef, "get_process_entitlement_cache", lambda: cache)
+    monkeypatch.setattr(ef, "is_entitlement_blocked", lambda s, b: False)
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=403, body="forbidden", model="m", caller_id="c"))
+    cache.reset.assert_not_called()
+
+
+def test_403_respects_fallback_master_switch(monkeypatch):
+    cache = MagicMock()
+    monkeypatch.setattr(ef, "get_process_entitlement_cache", lambda: cache)
+    monkeypatch.setattr(ef, "entitlement_fallback_enabled", lambda: False)
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=403, body="blocked by a routing rule",
+                                   model="m", caller_id="c"))
+    cache.reset.assert_not_called()
+
+
+def test_403_does_not_flush_the_pool():
+    """403 != 502: an entitlement denial must not thrash the transport."""
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=403, body="blocked by a routing rule",
+                                   model="m", caller_id="c"))
+    p.force_session_reset.assert_not_called()
+
+
+# ---- never mask the caller's real error -----------------------------------
+
+
+def test_handler_never_raises_on_broken_lifecycle(monkeypatch):
+    monkeypatch.setattr(
+        lifecycle, "ClientLifecycleManager",
+        MagicMock(side_effect=RuntimeError("lifecycle exploded")))
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=502, body="", model="m", caller_id="c"))
+
+
+def test_handler_never_raises_on_broken_entitlement(monkeypatch):
+    monkeypatch.setattr(
+        ef, "get_process_entitlement_cache",
+        MagicMock(side_effect=RuntimeError("cache exploded")))
+    monkeypatch.setattr(ef, "is_entitlement_blocked", lambda s, b: True)
+    p = _provider()
+    _run(p._handle_rt_http_failure(status=403, body="blocked by a routing rule",
+                                   model="m", caller_id="c"))
+
+
+def test_rt_failure_handler_is_wired_into_complete_sync():
+    """Structural: the RT path must actually call the handler (the whole point
+    — these modules were unreachable from RT before)."""
+    import inspect
+    src = inspect.getsource(DoublewordProvider.complete_sync)
+    code = "\n".join(l for l in src.splitlines() if not l.strip().startswith("#"))
+    assert "_handle_rt_http_failure(" in code


### PR DESCRIPTION
The RT completion surface (DreamEngine + every rt_gate consumer) had **no resilience owner**. Both handlers existed but were reachable only from batch/probe paths: `dw_client_lifecycle` had **zero production callers** (severed) so tonight's 502 storm never flushed the poisoned pool; `dw_entitlement_fallback` is live but never saw an RT 403.

**One handler, one call site (DRY):** `_handle_rt_http_failure` routes to the existing owners. 502/503/504 → `flush_transport_pool` (that module owns the policy + 60s anti-thrash cooldown); backoff stays in `dw_transport_recovery`, breaker stays in `circuit_breaker.py` — **neither reimplemented**. 401/403 → classify + reset the `EntitlementCatalogCache` so DW re-asserts its own RBAC (TTL governs re-probe) — never a local hardcode.

**Rejected on evidence:** the MIN_EFFORT 397B entry — Slice 169 resolves the floor dynamically from DW's catalog and already returns `low`; adding it would hardcode what the system discovers. The floor isn't the defect; the budget was (#69914).

14 tests incl. a 5×502 storm → exactly **one** flush. 151/151 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Connects the RT completion path to existing resilience owners so 5xx storms flush the transport pool and 401/403 entitlements prune the catalog. Reduces repeated RT failures without changing backoff or breaker logic.

- **Bug Fixes**
  - Added `_handle_rt_http_failure` and call it from `complete_sync`; composes existing modules (no new backoff/breaker logic).
  - 502/503/504 → `dw_client_lifecycle` (`ClientLifecycleManager.flush_transport_pool`) with 60s cooldown and master switch; per-provider state prevents thrash.
  - 401/403 → `dw_entitlement_fallback`: classify and reset the process `EntitlementCatalogCache` to prune unentitled models and re-probe by TTL; handler never raises. Tests cover storm=one flush, switches respected, non-5xx no flush, 403 prune, and wiring present.

<sup>Written for commit 528fe37c6f0822256919b84b74f00533a09f2d03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69917?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

