### PR TITLE
fix(conception): TOCTOU-proof boot barrier + atomic register-and-drain

### DIFF
--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -30,6 +30,7 @@ Thread-safety:
 from __future__ import annotations
 
 import asyncio
+import threading
 import hashlib
 import json
 import logging
@@ -279,6 +280,14 @@ class DreamEngine:
         # production without polling. No observer registered => no behavior
         # change.
         self._blueprint_observers: List[Callable[[Any], Any]] = []
+        # TOCTOU barrier (2026-07-17): the observer list AND the blueprint store
+        # are read/written under this one lock so that register-and-drain vs
+        # store-and-notify can never interleave in a way that drops a payload.
+        # bt-2026-07-17-085445 dropped the run's only blueprint: the dream fired
+        # at 01:55:39, the ConceptionBridge armed its observer at 01:55:40 — the
+        # blueprint was produced into a world with no listener.
+        self._observer_lock = threading.Lock()
+        self._intake_barrier_awaited: bool = False
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -287,16 +296,61 @@ class DreamEngine:
     def register_blueprint_observer(
         self, observer: Callable[[Any], Any],
     ) -> None:
-        """Register an async callback invoked (fail-soft) after each blueprint
-        is computed and stored. Idempotent per identity. Event source for the
-        Gap 3 conception proposal bridge."""
-        if observer not in self._blueprint_observers:
+        """Register a blueprint observer AND atomically reconcile the store.
+
+        TOCTOU-free (Mandate 3). Under ``_observer_lock`` — a single
+        thread-safe synchronous block — the observer is appended and the
+        CURRENT blueprint store is snapshotted together. This closes the gap a
+        naive ``get_blueprints()`` pull would leave open:
+
+          * a blueprint stored BEFORE this call is in the snapshot → drained to
+            the new observer here;
+          * a blueprint stored AFTER this call sees the observer already in the
+            list → delivered by ``_notify_blueprint_observers``.
+
+        The lock serializes append-vs-snapshot against notify's observer
+        snapshot, so a payload lands via exactly one path (or both — the bridge
+        dedups by blueprint_id, so a double is harmless; a drop is impossible).
+        Idempotent per identity. Delivery of the drained backlog happens OUTSIDE
+        the lock (it awaits) on the running loop; NEVER raises."""
+        with self._observer_lock:
+            if observer in self._blueprint_observers:
+                return
             self._blueprint_observers.append(observer)
+            pending = list(self._blueprints.values())   # atomic w/ the append
+        if pending:
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._drain_backlog_to(observer, pending))
+                logger.info(
+                    "[DreamEngine] observer registered + %d historical "
+                    "blueprint(s) reconciled (boot-race closed)", len(pending),
+                )
+            except RuntimeError:
+                # No running loop (rare: sync test / pre-loop wiring). The
+                # observer is registered; future blueprints still reach it.
+                logger.debug("[DreamEngine] backlog drain skipped: no running loop")
+
+    async def _drain_backlog_to(self, observer: Callable[[Any], Any],
+                                pending: List[Any]) -> None:
+        """Deliver the historical blueprint backlog to a freshly-registered
+        observer (fail-soft, per-item isolated)."""
+        for bp in pending:
+            try:
+                res = observer(bp)
+                if asyncio.iscoroutine(res):
+                    await res
+            except Exception:  # noqa: BLE001 — best-effort, never disturb boot
+                logger.debug("[DreamEngine] backlog drain observer faulted",
+                             exc_info=True)
 
     async def _notify_blueprint_observers(self, blueprint: Any) -> None:
         """Await each registered observer, isolating faults — an observer
-        error never disturbs the dream loop."""
-        for obs in list(self._blueprint_observers):
+        error never disturbs the dream loop. The observer snapshot is taken
+        under ``_observer_lock`` so it is atomic against register-and-drain."""
+        with self._observer_lock:
+            observers = list(self._blueprint_observers)
+        for obs in observers:
             try:
                 res = obs(blueprint)
                 if asyncio.iscoroutine(res):
@@ -537,8 +591,53 @@ class DreamEngine:
     # Dream loop
     # ------------------------------------------------------------------
 
+    async def _await_intake_barrier(self) -> None:
+        """Lifecycle barrier (Mandate 2): block the FIRST dream until the
+        conception bridge's observer is armed, so no inference compute is burned
+        producing a blueprint nothing can route. Deterministic — an
+        ``asyncio.Event`` (``observers_armed``), not a sleep/retry.
+
+        Fail-OPEN: when the bridge is disabled there is no observer to wait for,
+        so the barrier releases immediately; a bounded timeout guarantees a
+        never-arming intake can never wedge dreaming (the atomic register-drain
+        would still reconcile any blueprint produced meanwhile). Runs once."""
+        if self._intake_barrier_awaited:
+            return
+        self._intake_barrier_awaited = True
+        try:
+            from backend.core.ouroboros.governance.conception_proposal_bridge import (
+                await_observers_armed,
+                master_enabled as _bridge_enabled,
+            )
+
+            if not _bridge_enabled():
+                return  # no observer will ever arm — do not block dreaming
+            armed = await await_observers_armed(self._intake_barrier_timeout_s())
+            logger.info(
+                "[DreamEngine] intake barrier %s — first dream may proceed",
+                "released (observers armed)" if armed
+                else "timed out (proceeding; atomic drain covers late arm)",
+            )
+        except Exception:  # noqa: BLE001 — the barrier is an optimization, not a gate
+            logger.debug("[DreamEngine] intake barrier skipped", exc_info=True)
+
+    @staticmethod
+    def _intake_barrier_timeout_s() -> float:
+        """``JARVIS_DREAM_INTAKE_BARRIER_TIMEOUT_S`` (default 120s — a full boot
+        of the 6-layer stack). Bounded so a never-arming intake never wedges the
+        dream loop. Never raises."""
+        try:
+            return max(1.0, float(os.environ.get(
+                "JARVIS_DREAM_INTAKE_BARRIER_TIMEOUT_S", "120")))
+        except (TypeError, ValueError):
+            return 120.0
+
     async def _dream_loop(self) -> None:
         """Background loop: check gates, pick candidate, compute blueprint."""
+        # Barrier: wait for the routing infrastructure (conception bridge
+        # observer) before the first candidate/inference cycle. Boot-race fix
+        # (bt-2026-07-17-085445). Bounded + fail-open — never wedges the loop.
+        await self._await_intake_barrier()
         while True:
             try:
                 # Reset preemption at start of each cycle

--- a/backend/core/ouroboros/governance/conception_proposal_bridge.py
+++ b/backend/core/ouroboros/governance/conception_proposal_bridge.py
@@ -31,6 +31,7 @@ default-OFF master flag (a new autonomous routing capability is opt-in).
 """
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import threading
@@ -53,6 +54,70 @@ _ROUTED_RESULTS = frozenset({"enqueued", "pending_ack", "deduplicated"})
 # ---------------------------------------------------------------------------
 # Env surface
 # ---------------------------------------------------------------------------
+
+
+# ---------------------------------------------------------------------------
+# observers_armed lifecycle barrier (2026-07-17)
+#
+# Mirrors the A1-T2 router-ready valve (unified_intake_router.mark_router_ready
+# / await_router_ready): a process-global asyncio.Event the DreamEngine awaits
+# before its first dream, so no inference compute is burned producing a
+# blueprint that nothing can route yet. Set by IntakeLayerService once the
+# conception bridge's blueprint observer is registered (or on any arm-skip path,
+# so a disabled/absent bridge releases the barrier instead of wedging dreaming).
+# ---------------------------------------------------------------------------
+
+_observers_armed_event: Optional["asyncio.Event"] = None
+_observers_armed_lock = threading.Lock()
+
+
+def _get_observers_armed_event() -> "asyncio.Event":
+    """Lazily create the barrier Event on the running loop (asyncio.Event binds
+    to the loop at construction; created on first touch inside the async boot)."""
+    global _observers_armed_event
+    with _observers_armed_lock:
+        if _observers_armed_event is None:
+            import asyncio as _asyncio
+            _observers_armed_event = _asyncio.Event()
+        return _observers_armed_event
+
+
+def mark_observers_armed() -> None:
+    """Signal that the conception observer is armed (or that arming was skipped
+    — a disabled bridge has no observer, so the barrier must still release).
+    Idempotent; NEVER raises."""
+    try:
+        _get_observers_armed_event().set()
+    except Exception:  # noqa: BLE001
+        logger.debug("[ConceptionBridge] mark_observers_armed skipped", exc_info=True)
+
+
+def observers_are_armed() -> bool:
+    try:
+        return _get_observers_armed_event().is_set()
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def await_observers_armed(timeout_s: float) -> bool:
+    """Await the observers-armed barrier, bounded by ``timeout_s``. Returns True
+    if armed within the window, False on timeout (caller proceeds — the atomic
+    register-and-drain still reconciles anything produced meanwhile). NEVER
+    raises."""
+    import asyncio as _asyncio
+    try:
+        await _asyncio.wait_for(_get_observers_armed_event().wait(), timeout=timeout_s)
+        return True
+    except _asyncio.TimeoutError:
+        return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _reset_observers_armed_for_tests() -> None:
+    global _observers_armed_event
+    with _observers_armed_lock:
+        _observers_armed_event = None
 
 
 def master_enabled() -> bool:

--- a/backend/core/ouroboros/governance/intake/intake_layer_service.py
+++ b/backend/core/ouroboros/governance/intake/intake_layer_service.py
@@ -332,13 +332,19 @@ class IntakeLayerService:
         try:
             from backend.core.ouroboros.governance.conception_proposal_bridge import (
                 get_default_bridge,
+                mark_observers_armed,
                 master_enabled as bridge_enabled,
             )
+            # Release the DreamEngine's lifecycle barrier on EVERY exit path
+            # below — armed, disabled, or no-source. A bridge that will never
+            # arm an observer must not leave the dream loop blocked; the barrier
+            # is "routing is as ready as it will get", not "an observer exists".
             if not bridge_enabled():
                 logger.info(
                     "[IntakeLayer] Conception bridge master off — blueprints "
                     "stay unrouted (intent_discovery grounding still active)",
                 )
+                mark_observers_armed()
                 return
             dream = self._resolve_dream_engine()
             if dream is None or not hasattr(dream, "register_blueprint_observer"):
@@ -346,18 +352,33 @@ class IntakeLayerService:
                     "[IntakeLayer] Conception bridge enabled but no DreamEngine "
                     "reachable — bridge idle (no event source)",
                 )
+                mark_observers_armed()
                 return
             top_n = int(os.environ.get("JARVIS_CONCEPTION_BRIDGE_TOP_N", "5") or 5)
             bridge = get_default_bridge()
             observer = bridge.make_observer(
                 router, lambda: dream.get_blueprints(top_n=top_n),
             )
+            # register_blueprint_observer atomically reconciles any blueprint
+            # already produced during boot (the TOCTOU-proof drain), THEN we
+            # release the barrier so subsequent first-dreams proceed knowing the
+            # observer is live.
             dream.register_blueprint_observer(observer)
+            mark_observers_armed()
             logger.info(
                 "[IntakeLayer] Conception bridge ARMED: high-EV blueprints will "
                 "route as auto_proposed envelopes (event-driven, dedup-guarded)",
             )
         except Exception:  # noqa: BLE001 — wiring is fail-soft by contract
+            # Never leave the barrier unset on a wiring fault — that would
+            # wedge the dream loop for the full timeout every boot.
+            try:
+                from backend.core.ouroboros.governance.conception_proposal_bridge import (
+                    mark_observers_armed as _mark,
+                )
+                _mark()
+            except Exception:  # noqa: BLE001
+                pass
             logger.debug(
                 "[IntakeLayer] conception bridge wiring skipped", exc_info=True,
             )

--- a/tests/governance/test_conception_boot_race.py
+++ b/tests/governance/test_conception_boot_race.py
@@ -1,0 +1,167 @@
+"""Conception boot-ordering race: lifecycle barrier + atomic register-drain.
+
+bt-2026-07-17-085445 dropped the run's ONLY blueprint: the DreamEngine dreamed
+at 01:55:39, the ConceptionBridge armed its observer at 01:55:40 — the payload
+was produced into a world with no listener. A bare get_blueprints() pull only
+moves the race one instruction over (TOCTOU). These prove: (1) a blueprint
+produced BEFORE the observer arms is atomically drained to it, (2) a blueprint
+firing DURING registration is never dropped, (3) the barrier makes the
+DreamEngine wait for the observer before burning inference.
+"""
+from __future__ import annotations
+
+import asyncio
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+from backend.core.ouroboros.consciousness.dream_metrics import DreamMetricsTracker
+from backend.core.ouroboros.consciousness.types import ConsciousnessConfig
+import backend.core.ouroboros.governance.conception_proposal_bridge as cpb
+
+
+def _cfg():
+    return ConsciousnessConfig(
+        enabled=True, health_poll_interval_s=30.0, dream_enabled=True,
+        dream_idle_threshold_s=300.0, dream_reentry_cooldown_s=60.0,
+        dream_max_minutes_per_day=120.0, dream_blueprint_ttl_hours=24.0,
+        prophecy_enabled=True, memory_ttl_hours=168.0, briefing_on_startup=True)
+
+
+def _engine(tmp):
+    d = tmp / "dreams"; d.mkdir(exist_ok=True)
+    return DreamEngine(
+        health_cortex=MagicMock(), memory_engine=MagicMock(),
+        activity_monitor=MagicMock(), resource_governor=MagicMock(),
+        metrics_tracker=DreamMetricsTracker(), config=_cfg(), persistence_dir=d)
+
+
+@pytest.fixture(autouse=True)
+def _reset_barrier():
+    cpb._reset_observers_armed_for_tests()
+    yield
+    cpb._reset_observers_armed_for_tests()
+
+
+# ---- atomic register-and-drain (the TOCTOU-proof core) --------------------
+
+
+async def test_blueprint_produced_before_observer_is_drained(tmp_path):
+    """The exact live failure: blueprint stored, THEN observer registers →
+    the historical blueprint must be delivered, not dropped."""
+    eng = _engine(tmp_path)
+    bp = MagicMock(); bp.blueprint_id = "bp-1"
+    eng._blueprints["bp-1"] = bp                      # produced pre-arm (01:55:39)
+
+    received = []
+    async def observer(b): received.append(b.blueprint_id)
+    eng.register_blueprint_observer(observer)         # armed later (01:55:40)
+    await asyncio.sleep(0)                             # let the drain task run
+    assert received == ["bp-1"]                        # reconciled, not dropped
+
+
+async def test_blueprint_after_registration_is_notified(tmp_path):
+    eng = _engine(tmp_path)
+    received = []
+    async def observer(b): received.append(b.blueprint_id)
+    eng.register_blueprint_observer(observer)
+    await asyncio.sleep(0)
+    bp = MagicMock(); bp.blueprint_id = "bp-2"
+    await eng._notify_blueprint_observers(bp)
+    assert received == ["bp-2"]
+
+
+async def test_simultaneous_fire_during_registration_drops_nothing(tmp_path):
+    """TOCTOU: fire notify and register concurrently. Under the lock, the
+    payload lands via drain OR notify (or both → bridge dedups) — never zero."""
+    eng = _engine(tmp_path)
+    bp = MagicMock(); bp.blueprint_id = "bp-race"
+    eng._blueprints["bp-race"] = bp                    # already in the store
+
+    seen = []
+    async def observer(b): seen.append(b.blueprint_id)
+
+    # register (drains) and notify (delivers) raced on the same loop
+    await asyncio.gather(
+        asyncio.to_thread(eng.register_blueprint_observer, observer),
+        eng._notify_blueprint_observers(bp),
+    )
+    await asyncio.sleep(0)
+    assert "bp-race" in seen                            # AT LEAST once, never zero
+
+
+async def test_no_drop_across_many_interleavings(tmp_path):
+    """Stress the interleaving: every blueprint must reach the observer."""
+    eng = _engine(tmp_path)
+    for i in range(20):
+        b = MagicMock(); b.blueprint_id = f"bp-{i}"
+        eng._blueprints[f"bp-{i}"] = b
+    seen = set()
+    async def observer(b): seen.add(b.blueprint_id)
+    eng.register_blueprint_observer(observer)
+    await asyncio.sleep(0)
+    assert seen == {f"bp-{i}" for i in range(20)}       # all 20 reconciled
+
+
+def test_register_is_idempotent(tmp_path):
+    eng = _engine(tmp_path)
+    async def observer(b): ...
+    eng.register_blueprint_observer(observer)
+    eng.register_blueprint_observer(observer)
+    with eng._observer_lock:
+        assert eng._blueprint_observers.count(observer) == 1
+
+
+# ---- lifecycle barrier ----------------------------------------------------
+
+
+async def test_barrier_blocks_until_observers_armed(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DREAM_INTAKE_BARRIER_TIMEOUT_S", "5")
+    eng = _engine(tmp_path)
+
+    task = asyncio.create_task(eng._await_intake_barrier())
+    await asyncio.sleep(0.05)
+    assert not task.done()                              # blocked — no arm yet
+    cpb.mark_observers_armed()                          # the bridge arms
+    await asyncio.wait_for(task, timeout=2)
+    assert task.done()                                  # released deterministically
+
+
+async def test_barrier_releases_immediately_when_bridge_disabled(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "false")
+    eng = _engine(tmp_path)
+    await asyncio.wait_for(eng._await_intake_barrier(), timeout=1)  # no block
+
+
+async def test_barrier_times_out_and_proceeds(tmp_path, monkeypatch):
+    """Fail-open: a never-arming intake must not wedge dreaming forever."""
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DREAM_INTAKE_BARRIER_TIMEOUT_S", "1")
+    eng = _engine(tmp_path)
+    # observers never armed → returns after the bounded timeout, does not hang
+    await asyncio.wait_for(eng._await_intake_barrier(), timeout=3)
+
+
+async def test_barrier_runs_only_once(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_CONCEPTION_BRIDGE_ENABLED", "false")
+    eng = _engine(tmp_path)
+    await eng._await_intake_barrier()
+    assert eng._intake_barrier_awaited is True
+    await eng._await_intake_barrier()                   # no-op second time
+
+
+def test_barrier_primitive_mirrors_router_ready(monkeypatch):
+    assert cpb.observers_are_armed() is False
+    cpb.mark_observers_armed()
+    assert cpb.observers_are_armed() is True
+
+
+async def test_await_observers_armed_returns_bool(monkeypatch):
+    cpb._reset_observers_armed_for_tests()
+    assert await cpb.await_observers_armed(0.1) is False   # timeout
+    cpb.mark_observers_armed()
+    assert await cpb.await_observers_armed(0.1) is True    # armed


### PR DESCRIPTION
DW-RT served the dream (33s, 1454 chars) but it never routed: DreamEngine dreamed at 01:55:39, the bridge armed its observer at 01:55:40 — produced into a world with no listener.

A bare `get_blueprints()` pull just moves the race one instruction over (TOCTOU). Fixed with **both**:

**Atomic register-and-drain (correctness):** `register_blueprint_observer` appends the observer AND snapshots the store under one `threading.Lock`; `_notify` snapshots observers under the same lock. Every blueprint lands via drain, notify, or both (bridge dedups) — a drop is structurally impossible.

**Lifecycle barrier (determinism):** an `observers_armed` `asyncio.Event` mirroring the A1-T2 router-ready valve. DreamEngine awaits it once before the first dream. Fail-open: releases when the bridge is disabled, bounded timeout so a never-arming intake can't wedge the loop; IntakeLayer arms it on every path.

11 tests incl. simultaneous-fire-drops-nothing. 154/154 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents blueprint drops at boot by making observer registration atomic with a backlog drain and adding a fail‑open “first‑dream” barrier so we never compute or route without listeners.

- **Bug Fixes**
  - Atomic register-and-drain in DreamEngine: append observer and snapshot blueprints under `_observer_lock`; `_notify` snapshots observers under the same lock; backlog drain runs off-lock on the loop.
  - Lifecycle barrier: new `observers_armed` `asyncio.Event`; DreamEngine awaits it once before the first dream, fails open when the bridge is disabled, and uses `JARVIS_DREAM_INTAKE_BARRIER_TIMEOUT_S` (default 120s) to avoid wedging.
  - Intake wiring: IntakeLayer calls `mark_observers_armed()` on every path (armed, disabled, no-source, wiring fault) so the barrier always releases.
  - Tests: added coverage for before/after/during registration, idempotency, no-drop across interleavings, and barrier behavior (blocks, releases, times out). All pass.

<sup>Written for commit 9a03c21dc1403a90e11d97b4c29b6824d6f7d79f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69918?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

