### PR TITLE
fix(aegis): shape-aware upstream read budget — kill the non-streaming false-502

### DIFF
--- a/backend/core/ouroboros/aegis/forwarding.py
+++ b/backend/core/ouroboros/aegis/forwarding.py
@@ -126,6 +126,113 @@ def _upstream_sock_read_timeout_s() -> float:
 
 
 # ---------------------------------------------------------------------------
+# Shape-aware upstream read budget — kills the non-streaming false-502 class
+# (bt-2026-07-17: the DreamEngine DW-RT tier, and every stream:false op).
+#
+# The ``sock_read`` above is an INTER-CHUNK stall bound: correct for SSE, where
+# tokens arrive continuously and a 30s silence means a stalled stream. It is
+# WRONG for a non-streaming (``stream:false``) request — DW generates the ENTIRE
+# body before writing a single byte, so the socket is legitimately silent for
+# the whole generation (Qwen3.5-397B reasoning TTFT p50 ~66s per the DW client's
+# own STAGE_RT_HTTP_POST calibration). A 30s sock_read then fires mid-generation
+# and this proxy synthesizes a 502 ``upstream_unreachable`` BEFORE the client's
+# own 120s budget — a false outage manufactured by the proxy, not DW.
+#
+# The DW *client* deliberately sets NO sock_read (doubleword_provider
+# ``_request_timeout`` — total only) precisely because it owns a smarter,
+# phase-aware rupture watchdog (120s/360s TTFT then lag-compensated inter-chunk).
+# This proxy must not re-impose a cruder, tighter guard that pre-empts it.
+#
+# Two orthogonal, authority-preserving corrections:
+#   1. Shape default — a non-streaming request gets a generation-sized read
+#      budget (env ``JARVIS_AEGIS_NONSTREAM_READ_S``, default 120s = the DW
+#      client's own total). Streaming is UNCHANGED (30s inter-chunk).
+#   2. Client hint — the trusted local client MAY declare its per-request budget
+#      via the ``X-JARVIS-Upstream-Read-Budget-S`` header (sourced from its own
+#      rupture window / caller timeout). Aegis HONORS it but CLAMPS to
+#      ``[floor, ceiling]`` so a buggy/compromised client can never set an
+#      unbounded upstream read — Aegis stays the authority on the maximum.
+# Absent/invalid header → the shape default (byte-identical for any non-JARVIS
+# caller, e.g. an Anthropic passthrough that never sets the header).
+# ---------------------------------------------------------------------------
+
+_UPSTREAM_READ_BUDGET_HEADER: str = "X-JARVIS-Upstream-Read-Budget-S"
+_NONSTREAM_READ_ENV_VAR: str = "JARVIS_AEGIS_NONSTREAM_READ_S"
+_DEFAULT_NONSTREAM_READ_S: float = 120.0
+_READ_BUDGET_CEILING_ENV_VAR: str = "JARVIS_AEGIS_UPSTREAM_READ_CEILING_S"
+_DEFAULT_READ_BUDGET_CEILING_S: float = 600.0
+_READ_BUDGET_FLOOR_S: float = 5.0
+
+
+def _nonstream_read_default_s() -> float:
+    """Default upstream read budget for a NON-streaming request — there are no
+    inter-chunk semantics (the whole generation arrives as one silent-then-burst
+    read), so the inter-chunk bound does not apply. Env
+    ``JARVIS_AEGIS_NONSTREAM_READ_S``; invalid / non-positive → 120s. NEVER
+    raises."""
+    raw = os.environ.get(_NONSTREAM_READ_ENV_VAR, "").strip()
+    if raw:
+        try:
+            val = float(raw)
+            if val > 0:
+                return val
+        except (ValueError, TypeError):
+            pass
+    return _DEFAULT_NONSTREAM_READ_S
+
+
+def _read_budget_ceiling_s() -> float:
+    """Hard upper clamp on ANY resolved upstream read budget — Aegis stays the
+    authority on the maximum a client can request. Env
+    ``JARVIS_AEGIS_UPSTREAM_READ_CEILING_S``; invalid / non-positive → 600s.
+    NEVER raises."""
+    raw = os.environ.get(_READ_BUDGET_CEILING_ENV_VAR, "").strip()
+    if raw:
+        try:
+            val = float(raw)
+            if val > 0:
+                return val
+        except (ValueError, TypeError):
+            pass
+    return _DEFAULT_READ_BUDGET_CEILING_S
+
+
+def _resolve_upstream_read_budget_s(
+    request: "web.Request", *, is_streaming: bool,
+) -> float:
+    """Resolve the aiohttp ``sock_read`` budget for THIS upstream request.
+
+    Precedence:
+      1. A valid ``X-JARVIS-Upstream-Read-Budget-S`` header from the trusted
+         local client → clamped to ``[floor, ceiling]``.
+      2. No / invalid header → the shape default: the inter-chunk 30s bound for a
+         streaming request (UNCHANGED), or the generation-sized non-streaming
+         default for ``stream:false``.
+
+    Every branch is ceiling-bounded (defends a mis-set env too). NEVER raises —
+    any parse / header-access failure degrades to the shape default.
+    """
+    ceiling = _read_budget_ceiling_s()
+    raw = ""
+    try:
+        raw = (request.headers.get(_UPSTREAM_READ_BUDGET_HEADER, "") or "").strip()
+    except Exception:  # noqa: BLE001 — header access must never break forwarding
+        raw = ""
+    if raw:
+        try:
+            declared = float(raw)
+            if declared > 0:
+                return max(_READ_BUDGET_FLOOR_S, min(declared, ceiling))
+        except (ValueError, TypeError):
+            pass
+    shape_default = (
+        _upstream_sock_read_timeout_s() if is_streaming
+        else _nonstream_read_default_s()
+    )
+    return max(_READ_BUDGET_FLOOR_S, min(shape_default, ceiling))
+
+
+# ---------------------------------------------------------------------------
 # Wire-family usage parsers — closed dispatch
 # ---------------------------------------------------------------------------
 
@@ -526,7 +633,10 @@ async def forward_request(
     for name, value in request.headers.items():
         lname = name.lower()
         if lname in ("host", "authorization", "x-jarvis-lease",
-                     "content-length", endpoint.auth_header.lower()):
+                     "content-length", _UPSTREAM_READ_BUDGET_HEADER.lower(),
+                     endpoint.auth_header.lower()):
+            # X-JARVIS-Upstream-Read-Budget-S is a JARVIS↔Aegis control header —
+            # consumed here for the timeout decision, never leaked to upstream.
             continue
         outbound_headers[name] = value
     if endpoint.auth_scheme is AuthScheme.HEADER_RAW:
@@ -539,7 +649,12 @@ async def forward_request(
     )
     timeout = aiohttp.ClientTimeout(
         connect=_DEFAULT_CONNECT_TIMEOUT_S,
-        sock_read=_upstream_sock_read_timeout_s(),
+        # Shape-aware, client-hint-honoring, ceiling-clamped upstream read
+        # budget — NOT the blind 30s inter-chunk bound (which false-502'd every
+        # stream:false completion whose generation ran past 30s).
+        sock_read=_resolve_upstream_read_budget_s(
+            request, is_streaming=is_streaming,
+        ),
     )
 
     # 4. Open upstream + stream pass-through ---------------------------------

--- a/backend/core/ouroboros/governance/aegis_provider_bridge.py
+++ b/backend/core/ouroboros/governance/aegis_provider_bridge.py
@@ -389,6 +389,15 @@ async def acquire_call_lease(
 # AST pins + Aegis daemon stay in sync on the exact spelling.
 LEASE_HEADER_NAME: str = "X-JARVIS-Lease"
 
+# Canonical header a JARVIS client uses to DECLARE its per-request upstream read
+# budget (seconds) to the Aegis forwarding proxy. The proxy honors it (clamped
+# to its own ceiling) instead of imposing a blind inter-chunk sock_read that
+# would cut a legitimately-silent non-streaming generation before the client's
+# own budget. MUST byte-match ``aegis.forwarding._UPSTREAM_READ_BUDGET_HEADER``
+# — pinned by tests/aegis/test_upstream_read_budget.py so the two ends can never
+# drift. Single source of truth on the client side.
+UPSTREAM_READ_BUDGET_HEADER_NAME: str = "X-JARVIS-Upstream-Read-Budget-S"
+
 
 def merge_lease_header(
     extra_headers: Optional[Dict[str, str]],
@@ -439,4 +448,5 @@ __all__ = [
     "merge_lease_header",
     "merge_lease_into_session_headers",
     "LEASE_HEADER_NAME",
+    "UPSTREAM_READ_BUDGET_HEADER_NAME",
 ]

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -65,6 +65,7 @@ from backend.core.ouroboros.governance.aegis_provider_bridge import (
     dw_authorization_header as _aegis_dw_auth_header,
     dw_session_auth_header as _aegis_dw_session_auth_header,
     merge_lease_into_session_headers as _aegis_merge_lease_headers,
+    UPSTREAM_READ_BUDGET_HEADER_NAME as _AEGIS_READ_BUDGET_HEADER,
 )
 from backend.core.ouroboros.governance.stream_rupture import (
     CognitiveStallError,
@@ -512,6 +513,32 @@ _DW_REQUEST_TIMEOUT_S = float(os.environ.get("DOUBLEWORD_REQUEST_TIMEOUT_S", "12
 # JARVIS_TOPOLOGY_TTFT_TRACKING_ENABLED) that elects the faster lane when DW RT
 # p95 degrades. Both already exist; the throughput fix is arming them, not a
 # new socket timeout.
+#
+# 2026-07-17 — the Aegis forwarding PROXY (a separate process between this client
+# and DW) DID impose a blind 30s sock_read, which the client never wanted: on a
+# stream:false completion DW is silent for the whole generation, so the proxy
+# fired mid-generation and synthesized a 502 upstream_unreachable before this
+# client's 120s budget (the DreamEngine DW-RT tier failure class). The proxy is
+# now shape-aware AND honors a per-request budget this client DECLARES via the
+# X-JARVIS-Upstream-Read-Budget-S header. ``_dw_declare_read_budget`` stamps it
+# from the same rupture/timeout values this client already trusts (DRY) — the
+# proxy clamps it to its own ceiling, so this is a hint, never an authority.
+
+
+def _dw_declare_read_budget(
+    headers: Dict[str, str], budget_s: float,
+) -> Dict[str, str]:
+    """Stamp the Aegis upstream-read-budget header so the forwarding proxy does
+    not cut the upstream read before OUR budget. Mutates + returns *headers*.
+    Non-positive / invalid budget → header omitted (proxy falls back to its
+    shape default). NEVER raises."""
+    try:
+        b = float(budget_s)
+        if b > 0:
+            headers[_AEGIS_READ_BUDGET_HEADER] = f"{b:.3f}"
+    except (TypeError, ValueError):
+        pass
+    return headers
 
 
 _NATIVE_TC_SENTINEL = "\n__NTC__:"  # appended to content string when DW returns native tool_calls
@@ -4454,6 +4481,17 @@ class DoublewordProvider:
                         # missing_session_bearer 401 wedge on RT streaming).
                         _call_auth = await _aegis_dw_session_auth_header()
                         _call_auth["Content-Type"] = "application/json"
+                        # 2026-07-17 — declare our Phase-1 TTFT window to the
+                        # Aegis proxy so it does not cut the upstream read while
+                        # a reasoning model is legitimately silent before its
+                        # first token (the proxy's blind 30s inter-chunk bound
+                        # would pre-empt our own rupture watchdog). Same value
+                        # our Phase-1 breaker uses below (DRY); the proxy clamps
+                        # to its ceiling, and our inter-chunk watchdog stays the
+                        # authority on real mid-stream stalls.
+                        _dw_declare_read_budget(
+                            _call_auth, _stream_rupture_timeout_s(),
+                        )
                         # Slice 2B-ii — per-call Aegis lease (None when disabled
                         # → header is skipped via merge helper).
                         _aegis_lease = await _aegis_acquire_call_lease(
@@ -4956,6 +4994,12 @@ class DoublewordProvider:
                         # missing_session_bearer 401 wedge).
                         _call_auth = await _aegis_dw_session_auth_header()
                         _call_auth["Content-Type"] = "application/json"
+                        # 2026-07-17 — stream:false agent path: DW is silent for
+                        # the whole generation, so declare our transport budget
+                        # to the Aegis proxy (else its inter-chunk sock_read
+                        # false-502s mid-generation). Matches our own aiohttp
+                        # total (_request_timeout) — the bound we already impose.
+                        _dw_declare_read_budget(_call_auth, _DW_REQUEST_TIMEOUT_S)
                         # Slice 2B-ii — per-call Aegis lease.
                         _aegis_lease = await _aegis_acquire_call_lease(
                             op_id=context.op_id,
@@ -7637,6 +7681,12 @@ class DoublewordProvider:
             # Slice 31 — Aegis session bearer for sync complete().
             _call_auth = await _aegis_dw_session_auth_header()
             _call_auth["Content-Type"] = "application/json"
+            # 2026-07-17 — declare OUR patience to the Aegis proxy. complete_sync
+            # is stream:false: DW is silent on the socket for the whole
+            # generation, so without this the proxy's inter-chunk sock_read fires
+            # mid-generation and 502s. ``timeout_s`` is the caller's hard
+            # wait_for bound — the exact maximum we will wait on this socket.
+            _dw_declare_read_budget(_call_auth, timeout_s)
             # Slice 2B-ii — per-call Aegis lease bound to caller_id.
             _aegis_lease = await _aegis_acquire_call_lease(
                 op_id=f"dw-complete-sync:{caller_id}",

--- a/tests/aegis/test_upstream_read_budget.py
+++ b/tests/aegis/test_upstream_read_budget.py
@@ -1,0 +1,203 @@
+"""Shape-aware upstream read budget — kills the non-streaming false-502 class.
+
+The Aegis forwarding proxy used to impose a blind 30s inter-chunk ``sock_read``
+on every upstream request. That is correct for SSE (a 30s gap = a stalled
+stream) but WRONG for a ``stream:false`` completion: DW generates the entire
+body before writing a byte, so the socket is legitimately silent for the whole
+generation (Qwen3.5-397B reasoning TTFT p50 ~66s). The proxy fired mid-
+generation and synthesized a 502 ``upstream_unreachable`` before the client's
+own 120s budget — the bt-2026-07-17 DreamEngine DW-RT failure class.
+
+These tests pin the fix: shape-aware defaults, a client-declared per-request
+budget honored + ceiling-clamped, the control header stripped from upstream,
+and cross-module agreement on the header spelling so the two ends can't drift.
+"""
+from __future__ import annotations
+
+from typing import Dict, Optional
+
+import pytest
+
+from backend.core.ouroboros.aegis import forwarding as F
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeRequest:
+    """Minimal stand-in exposing only ``.headers`` (a case-insensitive-ish map)."""
+
+    def __init__(self, headers: Optional[Dict[str, str]] = None, *, raise_on_access=False):
+        self._headers = headers or {}
+        self._raise = raise_on_access
+
+    @property
+    def headers(self):
+        if self._raise:
+            raise RuntimeError("header access boom")
+        return self._headers
+
+
+def _clear_env(monkeypatch):
+    for k in (
+        F._AEGIS_SOCK_READ_ENV_VAR, F._NONSTREAM_READ_ENV_VAR,
+        F._READ_BUDGET_CEILING_ENV_VAR,
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+# ---------------------------------------------------------------------------
+# Shape defaults — the heart of the fix
+# ---------------------------------------------------------------------------
+
+
+def test_streaming_default_is_unchanged_30s(monkeypatch):
+    _clear_env(monkeypatch)
+    r = _FakeRequest()
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=True) == 30.0
+
+
+def test_nonstreaming_default_is_generation_sized_not_30s(monkeypatch):
+    _clear_env(monkeypatch)
+    r = _FakeRequest()
+    # The whole point: a stream:false request must NOT get the 30s inter-chunk
+    # bound — it gets the generation-sized default (120s).
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 120.0
+
+
+def test_nonstreaming_default_env_tunable(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(F._NONSTREAM_READ_ENV_VAR, "180")
+    r = _FakeRequest()
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 180.0
+
+
+def test_nonstreaming_invalid_env_falls_back(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(F._NONSTREAM_READ_ENV_VAR, "not-a-number")
+    assert F._nonstream_read_default_s() == 120.0
+    monkeypatch.setenv(F._NONSTREAM_READ_ENV_VAR, "-5")
+    assert F._nonstream_read_default_s() == 120.0
+
+
+# ---------------------------------------------------------------------------
+# Client-declared budget honored + clamped (authority stays server-side)
+# ---------------------------------------------------------------------------
+
+
+def test_client_hint_honored(monkeypatch):
+    _clear_env(monkeypatch)
+    r = _FakeRequest({F._UPSTREAM_READ_BUDGET_HEADER: "150"})
+    # Non-streaming shape but the client asked for 150 → honored (below ceiling).
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 150.0
+    # Even a streaming request honors an explicit client hint (a slow-TTFT
+    # reasoning stream declaring its 360s window).
+    r2 = _FakeRequest({F._UPSTREAM_READ_BUDGET_HEADER: "360"})
+    assert F._resolve_upstream_read_budget_s(r2, is_streaming=True) == 360.0
+
+
+def test_client_hint_clamped_to_ceiling(monkeypatch):
+    _clear_env(monkeypatch)
+    # A buggy/compromised client asking for 99999s is clamped — Aegis stays the
+    # authority on the maximum upstream read.
+    r = _FakeRequest({F._UPSTREAM_READ_BUDGET_HEADER: "99999"})
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 600.0
+
+
+def test_client_hint_clamped_to_floor(monkeypatch):
+    _clear_env(monkeypatch)
+    r = _FakeRequest({F._UPSTREAM_READ_BUDGET_HEADER: "0.5"})
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == F._READ_BUDGET_FLOOR_S
+
+
+def test_ceiling_env_tunable(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(F._READ_BUDGET_CEILING_ENV_VAR, "300")
+    r = _FakeRequest({F._UPSTREAM_READ_BUDGET_HEADER: "500"})
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 300.0
+
+
+def test_ceiling_also_bounds_a_misset_shape_default(monkeypatch):
+    _clear_env(monkeypatch)
+    monkeypatch.setenv(F._NONSTREAM_READ_ENV_VAR, "900")   # operator over-set
+    monkeypatch.setenv(F._READ_BUDGET_CEILING_ENV_VAR, "600")
+    r = _FakeRequest()
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 600.0
+
+
+# ---------------------------------------------------------------------------
+# Robustness — never raises, always degrades to a shape default
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize("bad", ["", "  ", "abc", "0", "-1", "nan", "inf"])
+def test_invalid_hint_degrades_to_shape_default(monkeypatch, bad):
+    _clear_env(monkeypatch)
+    r = _FakeRequest({F._UPSTREAM_READ_BUDGET_HEADER: bad})
+    val = F._resolve_upstream_read_budget_s(r, is_streaming=False)
+    # 'inf' parses to float('inf') > 0 → clamped to ceiling; everything else
+    # falls through to the non-streaming shape default. Both are bounded + sane.
+    assert val in (120.0, 600.0)
+    assert F._READ_BUDGET_FLOOR_S <= val <= 600.0
+
+
+def test_header_access_failure_never_raises(monkeypatch):
+    _clear_env(monkeypatch)
+    r = _FakeRequest(raise_on_access=True)
+    # A broken request object must not break forwarding — degrade to default.
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 120.0
+
+
+# ---------------------------------------------------------------------------
+# Control header is stripped from the outbound (never leaks to upstream)
+# ---------------------------------------------------------------------------
+
+
+def test_control_header_in_forwarding_strip_set():
+    # The forwarding handler strips a fixed set of JARVIS↔Aegis control headers
+    # before composing the outbound request. Assert our header is lowercased
+    # into that discipline (the actual strip happens inline in forward_request;
+    # this pins the invariant that the name is treated as strip-eligible).
+    import inspect
+    src = inspect.getsource(F.forward_request)
+    # The outbound-header strip loop drops this control header by its lowercased
+    # name so it never reaches upstream (DW/Anthropic).
+    assert "_UPSTREAM_READ_BUDGET_HEADER.lower()" in src
+
+
+# ---------------------------------------------------------------------------
+# Cross-module contract — the two ends can never drift on the spelling
+# ---------------------------------------------------------------------------
+
+
+def test_header_name_agrees_across_client_and_daemon():
+    from backend.core.ouroboros.governance.aegis_provider_bridge import (
+        UPSTREAM_READ_BUDGET_HEADER_NAME as client_name,
+    )
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _AEGIS_READ_BUDGET_HEADER as provider_alias,
+    )
+    assert F._UPSTREAM_READ_BUDGET_HEADER == client_name == provider_alias
+    assert client_name == "X-JARVIS-Upstream-Read-Budget-S"
+
+
+# ---------------------------------------------------------------------------
+# Client-side helper — stamps a valid budget, omits an invalid one
+# ---------------------------------------------------------------------------
+
+
+def test_client_helper_stamps_and_omits():
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _dw_declare_read_budget, _AEGIS_READ_BUDGET_HEADER,
+    )
+    assert _dw_declare_read_budget({}, 150.0) == {_AEGIS_READ_BUDGET_HEADER: "150.000"}
+    # Non-positive / invalid → header omitted (proxy uses its shape default).
+    assert _dw_declare_read_budget({}, 0) == {}
+    assert _dw_declare_read_budget({}, -3) == {}
+    assert _dw_declare_read_budget({}, float("nan")) == {}
+    # A declared budget round-trips through the resolver to the same clamp band.
+    hdrs = _dw_declare_read_budget({}, 150.0)
+    r = _FakeRequest(dict(hdrs))
+    assert F._resolve_upstream_read_budget_s(r, is_streaming=False) == 150.0


### PR DESCRIPTION
## Root cause

The DW 502 storm (soak \`bt-2026-07-17-205642\`) was **not DW's cloud going down** — the \`502 upstream_unreachable\` was synthesized by the **local Aegis forwarding proxy**. Aegis imposed a blind **30s aiohttp \`sock_read\`** — an *inter-chunk* stall bound (correct for SSE) — on **every** upstream request.

For a \`stream:false\` completion (the DreamEngine DW-RT tier, and every non-streaming op), DW generates the entire body **before writing a single byte**, so the socket is legitimately silent for the whole generation (Qwen3.5-397B reasoning TTFT p50 ~66s). The 30s sock_read fired mid-generation and the proxy returned 502 **before the client's own 120s budget**. The DW client deliberately sets *no* sock_read — it owns a smarter phase-aware rupture watchdog — and the proxy was re-imposing a cruder guard that pre-empted it.

This is why the earlier dream succeeded at 30.25s/32.96s (right at the edge) but 502'd whenever generation ran longer.

## Fix (root, adaptive, no hardcoding, DRY)

**Proxy** (\`forwarding.py\`) — two orthogonal, authority-preserving corrections:
1. **Shape-aware default**: streaming keeps the 30s inter-chunk bound (unchanged); non-streaming gets a generation-sized budget (\`JARVIS_AEGIS_NONSTREAM_READ_S\`, default 120s = the DW client's own total). \`is_streaming\` was already computed one block above — no new parsing.
2. **Client-declared budget**: the trusted local client may send \`X-JARVIS-Upstream-Read-Budget-S\`; Aegis honors it **clamped to \`[5s, JARVIS_AEGIS_UPSTREAM_READ_CEILING_S=600s]\`** so a buggy/compromised client can never set an unbounded read. Absent/invalid → shape default (byte-identical for any non-JARVIS caller). Control header is **stripped from the outbound** — never reaches upstream.

**Client** (\`doubleword_provider.py\`) declares the budget from values it *already trusts*, via one DRY helper \`_dw_declare_read_budget\` at the 3 POST sites:
- \`complete_sync\` → the caller's \`timeout_s\`
- RT streaming → its own \`_stream_rupture_timeout_s()\` Phase-1 TTFT window (also stops the proxy pre-empting a slow-first-token reasoning stream)
- non-streaming agent path → \`_request_timeout\` total

Header name is single-sourced (\`UPSTREAM_READ_BUDGET_HEADER_NAME\`) and **drift-pinned** to the daemon constant by a test.

### Why this is safe
Aegis reads only the request **shape** + a **clamped client hint** — never DW's latency ledgers — so the watchdog stays decoupled and can't deadlock with the system it guards (the same principle behind the wall-clock watchdog isolation invariant). The client's rupture watchdog remains the authority on real stalls; Aegis is now a correctly-sized backstop, not a competing tighter cut. We do **not** mask genuine outages — a real unreachable DW still fails fast on the 10s \`connect\` timeout.

## Tests
\`tests/aegis/test_upstream_read_budget.py\` (20): shape defaults, honor + ceiling/floor clamp, env-tunability, never-raise degradation (broken request, bad header values), outbound strip, cross-module header agreement, client-helper stamp/omit + round-trip. Existing forwarding regression green (the one red — a route-list assertion — is pre-existing drift on main, confirmed via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop false 502s from the Aegis proxy on non‑streaming DW calls by making the `aiohttp` upstream read timeout shape‑aware and honoring a client‑declared per‑request budget. Streaming stays at 30s inter‑chunk; non‑streaming uses a generation‑sized budget (default 120s) to match real TTFT.

- **Bug Fixes**
  - Proxy: resolve `sock_read` per request shape; honor `X-JARVIS-Upstream-Read-Budget-S` clamped to [5s, ceiling]; strip header upstream.
  - Tunables: `JARVIS_AEGIS_NONSTREAM_READ_S` (non‑stream default, 120s) and `JARVIS_AEGIS_UPSTREAM_READ_CEILING_S` (ceiling, 600s); safe fallbacks.
  - Client: add `_dw_declare_read_budget` and stamp header in 3 POST paths using existing budgets (`timeout_s`, `_stream_rupture_timeout_s()`, `_DW_REQUEST_TIMEOUT_S`); header name single‑sourced.
  - Tests: new `tests/aegis/test_upstream_read_budget.py` pins defaults, clamping, env tuning, header strip, and cross‑module header spelling.

<sup>Written for commit 0849ef49cfad10f1a59c328c943f185cda476f69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

