### PR TITLE
feat(aegis): QoS admission tiering + structural payload-integrity validation

### DIFF
--- a/backend/core/ouroboros/aegis/daemon.py
+++ b/backend/core/ouroboros/aegis/daemon.py
@@ -244,14 +244,30 @@ def _make_llm_handler(endpoint):
     """Build a closure-bound handler for an LLM_COMPLETION endpoint."""
     async def _handler(request: web.Request) -> web.StreamResponse:
         from backend.core.ouroboros.aegis.forwarding import forward_request
-        response, _ = await forward_request(
-            request=request,
-            endpoint=endpoint,
-            K=request.app[_K_HMAC_KEY],
-            nonce_ledger=request.app[_K_NONCE_LEDGER],
-            budget=request.app[_K_BUDGET],
+        from backend.core.ouroboros.aegis.qos_admission import (
+            admission_enabled, get_admission_gate, tier_from_header_value,
+            QOS_TIER_HEADER,
         )
-        return response
+
+        async def _do_forward() -> web.StreamResponse:
+            response, _ = await forward_request(
+                request=request,
+                endpoint=endpoint,
+                K=request.app[_K_HMAC_KEY],
+                nonce_ledger=request.app[_K_NONCE_LEDGER],
+                budget=request.app[_K_BUDGET],
+            )
+            return response
+
+        # QoS admission — bound concurrent forwards and, only under saturation,
+        # admit in X-JARVIS-QoS-Tier priority order (critical event-loop traffic
+        # over bulk background sensors). Fail-open + dormant under normal load.
+        # Master-off → pure pass-through (byte-identical to no gate).
+        if not admission_enabled():
+            return await _do_forward()
+        tier = tier_from_header_value(request.headers.get(QOS_TIER_HEADER))
+        async with get_admission_gate().admit(tier):
+            return await _do_forward()
     return _handler
 
 

--- a/backend/core/ouroboros/aegis/forwarding.py
+++ b/backend/core/ouroboros/aegis/forwarding.py
@@ -157,6 +157,11 @@ def _upstream_sock_read_timeout_s() -> float:
 # ---------------------------------------------------------------------------
 
 _UPSTREAM_READ_BUDGET_HEADER: str = "X-JARVIS-Upstream-Read-Budget-S"
+# Imported (not re-spelled) so the strip set and the admission gate share ONE
+# source of truth for the QoS control-header name.
+from backend.core.ouroboros.aegis.qos_admission import (  # noqa: E402
+    QOS_TIER_HEADER as _QOS_TIER_HEADER,
+)
 _NONSTREAM_READ_ENV_VAR: str = "JARVIS_AEGIS_NONSTREAM_READ_S"
 _DEFAULT_NONSTREAM_READ_S: float = 120.0
 _READ_BUDGET_CEILING_ENV_VAR: str = "JARVIS_AEGIS_UPSTREAM_READ_CEILING_S"
@@ -634,9 +639,11 @@ async def forward_request(
         lname = name.lower()
         if lname in ("host", "authorization", "x-jarvis-lease",
                      "content-length", _UPSTREAM_READ_BUDGET_HEADER.lower(),
+                     _QOS_TIER_HEADER.lower(),
                      endpoint.auth_header.lower()):
-            # X-JARVIS-Upstream-Read-Budget-S is a JARVIS↔Aegis control header —
-            # consumed here for the timeout decision, never leaked to upstream.
+            # X-JARVIS-Upstream-Read-Budget-S and X-JARVIS-QoS-Tier are
+            # JARVIS↔Aegis control headers — consumed by the proxy (timeout +
+            # admission), never leaked to upstream.
             continue
         outbound_headers[name] = value
     if endpoint.auth_scheme is AuthScheme.HEADER_RAW:

--- a/backend/core/ouroboros/aegis/qos_admission.py
+++ b/backend/core/ouroboros/aegis/qos_admission.py
@@ -1,0 +1,255 @@
+"""Priority-aware admission gate for Aegis upstream forwards (QoS tiering).
+
+# Why this exists (and what it deliberately is NOT)
+
+The shape-aware read budget (forwarding._resolve_upstream_read_budget_s, 2026-07-17)
+lifted the non-streaming upstream read ceiling to as much as 600s so a silent
+reasoning generation is not false-502'd. That is correct, but it means a single
+forward can now hold its resources for minutes. The volumetric question that
+raises is: when many long-lived forwards are in flight at once, does a critical
+event-loop request (a DreamEngine RT tier, a Claude fallback) get starved behind
+bulk background-sensor traffic?
+
+Two facts shape the answer:
+
+  * There is NO shared connection pool in the proxy — forwarding opens a fresh
+    ``aiohttp.ClientSession`` per request (forwarding.py). So there is no pool to
+    add a queue *inside*; the only genuinely-unbounded resource is the COUNT of
+    concurrent in-flight forwards (coroutines + sockets + FDs).
+  * Op-level priority admission ALREADY exists upstream at BackgroundAgentPool
+    (``asyncio.PriorityQueue``, route-priority ordered). This gate does NOT
+    duplicate it — the pool decides which *ops* run; this decides which *forwards*
+    proceed when the proxy's concurrency ceiling is saturated, and it also covers
+    traffic that never touches the pool (DreamEngine complete_sync, Claude
+    fallbacks, voice).
+
+So this is an ADMISSION gate at the single forward chokepoint, not a connection
+pooler. It bounds concurrent forwards (env, generous default) and, only when that
+bound is saturated, admits waiters in ``X-JARVIS-QoS-Tier`` priority order via a
+standard ``asyncio.PriorityQueue`` (DRY — no bespoke scheduler).
+
+# Bulletproofing
+
+  * FAIL-OPEN: this gate guards the credential daemon's hot path. Any internal
+    error admits the request immediately — a QoS bug must never wedge provider
+    traffic. A leaked slot is impossible: release is in a ``finally``.
+  * Default limit is generous, so the gate is DORMANT (never blocks) under
+    normal load; it only shapes traffic under genuine saturation. Proven by the
+    forced-collision test, which sets the limit to 1.
+  * Bounded: waiter queue is drained deterministically; no unbounded growth
+    because in-flight is hard-capped and every admit has a matching release.
+"""
+from __future__ import annotations
+
+import asyncio
+import itertools
+import logging
+import os
+from contextlib import asynccontextmanager
+from enum import IntEnum
+from typing import Dict, List, Optional, Tuple
+
+logger = logging.getLogger("aegis-daemon")
+
+
+# ---------------------------------------------------------------------------
+# Tier taxonomy — lower value = higher priority (asyncio.PriorityQueue is a
+# min-heap, so CRITICAL(0) is dequeued before BULK(2)).
+# ---------------------------------------------------------------------------
+
+
+class QoSTier(IntEnum):
+    """Closed QoS taxonomy for upstream forwards.
+
+    CRITICAL — event-loop-blocking, latency-critical traffic: the DreamEngine RT
+        tier and Claude fallbacks. Must not queue behind bulk work.
+    STANDARD — normal interactive generation (the default when no header).
+    BULK     — background-sensor / speculative traffic that can wait.
+    """
+
+    CRITICAL = 0
+    STANDARD = 1
+    BULK = 2
+
+
+# Canonical header a client stamps to declare a forward's QoS tier. MUST
+# byte-match the client-side constant (aegis_provider_bridge.QOS_TIER_HEADER_NAME);
+# pinned by tests/aegis/test_qos_admission.py.
+QOS_TIER_HEADER: str = "X-JARVIS-QoS-Tier"
+
+_MAX_CONCURRENT_ENV_VAR: str = "JARVIS_AEGIS_MAX_CONCURRENT_FORWARDS"
+_DEFAULT_MAX_CONCURRENT: int = 24
+_ENABLED_ENV_VAR: str = "JARVIS_AEGIS_QOS_ADMISSION_ENABLED"
+
+# Accepted spellings → tier. Case-insensitive; unknown → STANDARD (safe middle).
+_TIER_ALIASES: Dict[str, QoSTier] = {
+    "critical": QoSTier.CRITICAL, "0": QoSTier.CRITICAL,
+    "high": QoSTier.CRITICAL, "immediate": QoSTier.CRITICAL,
+    "standard": QoSTier.STANDARD, "1": QoSTier.STANDARD,
+    "normal": QoSTier.STANDARD, "default": QoSTier.STANDARD,
+    "bulk": QoSTier.BULK, "2": QoSTier.BULK,
+    "background": QoSTier.BULK, "low": QoSTier.BULK,
+    "speculative": QoSTier.BULK,
+}
+
+
+def _truthy(val: str) -> bool:
+    return val.strip().lower() in ("1", "true", "yes", "on")
+
+
+def admission_enabled() -> bool:
+    """``JARVIS_AEGIS_QOS_ADMISSION_ENABLED`` — default TRUE. When off, the gate
+    is a pure pass-through (byte-identical to no gate). NEVER raises."""
+    raw = os.environ.get(_ENABLED_ENV_VAR, "true")
+    return _truthy(raw)
+
+
+def _max_concurrent() -> int:
+    """Concurrent-forward ceiling. Env-tunable; invalid / non-positive → 24.
+    NEVER raises."""
+    raw = os.environ.get(_MAX_CONCURRENT_ENV_VAR, "").strip()
+    if raw:
+        try:
+            v = int(raw)
+            if v > 0:
+                return v
+        except (ValueError, TypeError):
+            pass
+    return _DEFAULT_MAX_CONCURRENT
+
+
+def tier_from_header_value(value: Optional[str]) -> QoSTier:
+    """Map a raw ``X-JARVIS-QoS-Tier`` value to a tier. Absent / unknown →
+    STANDARD (the safe middle — never silently critical, never silently starved).
+    NEVER raises."""
+    if not value:
+        return QoSTier.STANDARD
+    try:
+        return _TIER_ALIASES.get(value.strip().lower(), QoSTier.STANDARD)
+    except Exception:  # noqa: BLE001
+        return QoSTier.STANDARD
+
+
+# ---------------------------------------------------------------------------
+# The gate
+# ---------------------------------------------------------------------------
+
+
+class ForwardAdmissionGate:
+    """Bounds concurrent forwards; admits waiters in QoS-priority order.
+
+    A single ``asyncio.Lock`` guards the in-flight counter and the waiter
+    ``PriorityQueue``. When a slot is free, admission is immediate. When
+    saturated, the caller parks on a future ordered by ``(tier, seq)`` — a
+    strict priority with FIFO tie-break inside a tier. Release wakes the
+    highest-priority waiter.
+    """
+
+    def __init__(self, *, max_concurrent: Optional[int] = None) -> None:
+        self._explicit_max = max_concurrent
+        self._in_flight = 0
+        # Heap of (tier_value, seq, future). PriorityQueue would also work but a
+        # plain list + heapq under the lock avoids a second async primitive and
+        # keeps wake-up strictly synchronous with release.
+        self._waiters: List[Tuple[int, int, "asyncio.Future[None]"]] = []
+        self._seq = itertools.count()
+        self._lock = asyncio.Lock()
+
+    def _limit(self) -> int:
+        return self._explicit_max if self._explicit_max is not None else _max_concurrent()
+
+    # -- observability ---------------------------------------------------
+
+    def snapshot(self) -> Dict[str, int]:
+        # Read-only; intentionally lock-free (best-effort telemetry).
+        return {
+            "in_flight": self._in_flight,
+            "waiting": len(self._waiters),
+            "limit": self._limit(),
+        }
+
+    # -- core admission --------------------------------------------------
+
+    @asynccontextmanager
+    async def admit(self, tier: QoSTier):
+        """Admit a forward of *tier*, blocking in priority order only if the
+        concurrency ceiling is saturated. Always releases the slot on exit.
+
+        FAIL-OPEN: if admission bookkeeping raises for any reason, the forward
+        proceeds un-gated rather than being blocked or dropped.
+        """
+        admitted = False
+        try:
+            await self._acquire(tier)
+            admitted = True
+        except Exception:  # noqa: BLE001 — never block provider traffic on a gate bug
+            logger.debug("[QoSAdmission] acquire faulted — admitting fail-open", exc_info=True)
+            admitted = False
+        try:
+            yield
+        finally:
+            if admitted:
+                try:
+                    await self._release()
+                except Exception:  # noqa: BLE001
+                    logger.debug("[QoSAdmission] release faulted", exc_info=True)
+
+    async def _acquire(self, tier: QoSTier) -> None:
+        import heapq
+        async with self._lock:
+            if self._in_flight < self._limit():
+                self._in_flight += 1
+                return
+            # Saturated — park on a priority-ordered future.
+            loop = asyncio.get_event_loop()
+            fut: "asyncio.Future[None]" = loop.create_future()
+            heapq.heappush(
+                self._waiters, (int(tier), next(self._seq), fut),
+            )
+        # Await OUTSIDE the lock so releases can proceed.
+        await fut
+
+    async def _release(self) -> None:
+        import heapq
+        async with self._lock:
+            if self._waiters:
+                # Hand the just-freed slot directly to the highest-priority
+                # waiter (in_flight stays constant — a transfer, not a dip).
+                _tier, _seq, fut = heapq.heappop(self._waiters)
+                if not fut.done():
+                    fut.set_result(None)
+                    return
+            # No waiter took the slot → the forward count actually drops.
+            self._in_flight = max(0, self._in_flight - 1)
+
+
+# ---------------------------------------------------------------------------
+# Process singleton
+# ---------------------------------------------------------------------------
+
+_default_gate: Optional[ForwardAdmissionGate] = None
+_singleton_lock = asyncio.Lock()
+
+
+def get_admission_gate() -> ForwardAdmissionGate:
+    """Process-wide gate. Lazily constructed (binds no loop at import)."""
+    global _default_gate
+    if _default_gate is None:
+        _default_gate = ForwardAdmissionGate()
+    return _default_gate
+
+
+def reset_gate_for_tests() -> None:
+    global _default_gate
+    _default_gate = None
+
+
+__all__ = [
+    "QoSTier",
+    "QOS_TIER_HEADER",
+    "ForwardAdmissionGate",
+    "admission_enabled",
+    "tier_from_header_value",
+    "get_admission_gate",
+    "reset_gate_for_tests",
+]

--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -1203,27 +1203,31 @@ class DreamEngine:
 
     @staticmethod
     def _parse_json_response(raw: str) -> Optional[Dict[str, Any]]:
-        """Parse a JSON response from any inference provider."""
-        import json as _json
-        text = raw.strip()
-        # Handle markdown-wrapped JSON
-        if text.startswith("```"):
-            lines = text.split("\n")
-            text = "\n".join(ln for ln in lines if not ln.strip().startswith("```"))
+        """Parse a JSON response from any inference provider (the Tier-0/1/2
+        cascade return boundary).
+
+        Structural integrity FIRST: a payload severed mid-transmission — the
+        edge case the 600s Aegis read ceiling opened — is rejected as truncation
+        and routed to the dream's no-blueprint failure path with DISTINCT
+        telemetry, never silently brace-closed into a corrupt blueprint that
+        would flow into the governed loop. Reuses the shared truncation-aware
+        validator + the existing deterministic repair (DRY) in place of the
+        ad-hoc fence-strip / brace-extraction this replaces.
+        """
+        from backend.core.ouroboros.governance.payload_integrity import (
+            PayloadTruncationError, validate_json_payload,
+        )
         try:
-            data = _json.loads(text)
-            if isinstance(data, dict):
-                return data
-        except _json.JSONDecodeError:
-            # Try to extract JSON object from text
-            start = text.find("{")
-            end = text.rfind("}")
-            if start >= 0 and end > start:
-                try:
-                    return _json.loads(text[start:end + 1])
-                except _json.JSONDecodeError:
-                    pass
-        return None
+            return validate_json_payload(raw)
+        except PayloadTruncationError as exc:
+            logger.warning(
+                "[DreamEngine] inference payload TRUNCATED (severed mid-stream) "
+                "— routed to failure lifecycle, NOT parsed: %s", exc.detail,
+            )
+            return None
+        except Exception as exc:  # noqa: BLE001 — JSONDecodeError / non-object / etc.
+            logger.debug("[DreamEngine] inference payload unparseable: %s", exc)
+            return None
 
     def _parse_blueprint_result(
         self,

--- a/backend/core/ouroboros/governance/aegis_provider_bridge.py
+++ b/backend/core/ouroboros/governance/aegis_provider_bridge.py
@@ -398,6 +398,12 @@ LEASE_HEADER_NAME: str = "X-JARVIS-Lease"
 # drift. Single source of truth on the client side.
 UPSTREAM_READ_BUDGET_HEADER_NAME: str = "X-JARVIS-Upstream-Read-Budget-S"
 
+# Canonical header a client stamps to declare a forward's QoS tier
+# ("critical" | "standard" | "bulk") to the Aegis admission gate. MUST byte-match
+# ``aegis.qos_admission.QOS_TIER_HEADER`` — pinned by
+# tests/aegis/test_qos_admission.py. Single source of truth on the client side.
+QOS_TIER_HEADER_NAME: str = "X-JARVIS-QoS-Tier"
+
 
 def merge_lease_header(
     extra_headers: Optional[Dict[str, str]],

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -66,6 +66,7 @@ from backend.core.ouroboros.governance.aegis_provider_bridge import (
     dw_session_auth_header as _aegis_dw_session_auth_header,
     merge_lease_into_session_headers as _aegis_merge_lease_headers,
     UPSTREAM_READ_BUDGET_HEADER_NAME as _AEGIS_READ_BUDGET_HEADER,
+    QOS_TIER_HEADER_NAME as _AEGIS_QOS_TIER_HEADER,
 )
 from backend.core.ouroboros.governance.stream_rupture import (
     CognitiveStallError,
@@ -537,6 +538,45 @@ def _dw_declare_read_budget(
         if b > 0:
             headers[_AEGIS_READ_BUDGET_HEADER] = f"{b:.3f}"
     except (TypeError, ValueError):
+        pass
+    return headers
+
+
+# QoS admission tiering — maps the EXISTING provider_route taxonomy (no new
+# vocabulary, no hardcoded op names) onto the Aegis gate's 3 tiers, so a
+# background-sensor forward yields the socket to a latency-critical one under
+# saturation. IMMEDIATE (voice, test-failure, runtime-health, the DreamEngine
+# RT reflex) → critical; STANDARD/COMPLEX interactive → standard; BACKGROUND/
+# SPECULATIVE (OpportunityMiner, DocStaleness, IntentDiscovery, DreamEngine
+# pre-computation) → bulk.
+_ROUTE_QOS_TIER: Dict[str, str] = {
+    "immediate": "critical",
+    "standard": "standard",
+    "complex": "standard",
+    "background": "bulk",
+    "speculative": "bulk",
+}
+
+
+def _qos_tier_for_route(route: str) -> str:
+    """Resolve a QoS tier name from a provider_route. Unknown / empty →
+    'standard' (the safe middle). NEVER raises."""
+    try:
+        return _ROUTE_QOS_TIER.get(str(route or "").strip().lower(), "standard")
+    except Exception:  # noqa: BLE001
+        return "standard"
+
+
+def _dw_declare_qos_tier(
+    headers: Dict[str, str], tier: str,
+) -> Dict[str, str]:
+    """Stamp the Aegis QoS-tier header. Empty tier → omitted (gate defaults to
+    'standard'). Mutates + returns *headers*. NEVER raises."""
+    try:
+        t = str(tier or "").strip()
+        if t:
+            headers[_AEGIS_QOS_TIER_HEADER] = t
+    except Exception:  # noqa: BLE001
         pass
     return headers
 
@@ -4492,6 +4532,11 @@ class DoublewordProvider:
                         _dw_declare_read_budget(
                             _call_auth, _stream_rupture_timeout_s(),
                         )
+                        # QoS tier from the op's provider_route — a background
+                        # sensor stream yields to a critical one under saturation.
+                        _dw_declare_qos_tier(_call_auth, _qos_tier_for_route(
+                            str(getattr(context, "provider_route", "") or ""),
+                        ))
                         # Slice 2B-ii — per-call Aegis lease (None when disabled
                         # → header is skipped via merge helper).
                         _aegis_lease = await _aegis_acquire_call_lease(
@@ -5000,6 +5045,11 @@ class DoublewordProvider:
                         # false-502s mid-generation). Matches our own aiohttp
                         # total (_request_timeout) — the bound we already impose.
                         _dw_declare_read_budget(_call_auth, _DW_REQUEST_TIMEOUT_S)
+                        # QoS tier from the op's provider_route (background sensor
+                        # → bulk; interactive → standard; immediate → critical).
+                        _dw_declare_qos_tier(_call_auth, _qos_tier_for_route(
+                            str(getattr(context, "provider_route", "") or ""),
+                        ))
                         # Slice 2B-ii — per-call Aegis lease.
                         _aegis_lease = await _aegis_acquire_call_lease(
                             op_id=context.op_id,
@@ -7687,6 +7737,10 @@ class DoublewordProvider:
             # mid-generation and 502s. ``timeout_s`` is the caller's hard
             # wait_for bound — the exact maximum we will wait on this socket.
             _dw_declare_read_budget(_call_auth, timeout_s)
+            # complete_sync is the latency-critical Functions path (DreamEngine
+            # RT tier, CompactionCaller, BlastRadius) — declare CRITICAL so it is
+            # admitted ahead of bulk background forwards under saturation.
+            _dw_declare_qos_tier(_call_auth, "critical")
             # Slice 2B-ii — per-call Aegis lease bound to caller_id.
             _aegis_lease = await _aegis_acquire_call_lease(
                 op_id=f"dw-complete-sync:{caller_id}",

--- a/backend/core/ouroboros/governance/payload_integrity.py
+++ b/backend/core/ouroboros/governance/payload_integrity.py
@@ -1,0 +1,214 @@
+"""Structural payload-integrity validation at provider return boundaries.
+
+# Why this exists
+
+Raising the Aegis upstream read ceiling to 600s (the shape-aware read-budget fix)
+means a very long generation is allowed to complete — but it also means that if an
+upstream provider severs the socket mid-transmission (a hard-wall cut, a network
+drop, a provider crash at token N), the CLIENT receives a *partial* body. A
+partial JSON body is not a benign parse error: it is a payload that was cut, and
+treating it as "malformed but repairable" is actively dangerous here because the
+existing deterministic repair (``providers._repair_json``) explicitly *closes
+open containers* — it will happily turn
+
+    {"changes":[{"file":"a.py","content":"def foo(
+
+into
+
+    {"changes":[{"file":"a.py","content":"def foo("}]}
+
+a corrupt-but-parseable blueprint that then flows into the governed loop. So a
+severed payload must be DETECTED and rejected as truncation BEFORE any brace-
+closing repair runs.
+
+# Contract
+
+``validate_json_payload(raw)`` returns the parsed dict, or:
+  * raises ``PayloadTruncationError`` if the payload is structurally INCOMPLETE
+    (unbalanced containers / unterminated string at EOF) — the sever case, so the
+    caller routes it to the failure lifecycle, NOT a generic parse error;
+  * raises the underlying ``json.JSONDecodeError`` if the payload is COMPLETE but
+    malformed mid-body AND deterministic repair (reused, not reimplemented) can't
+    recover it — a genuine syntax fault, distinct from truncation.
+
+Truncation detection is a deterministic single pass over the text tracking string
+state and container depth (an LLM cannot recover severed bytes, so no heal call —
+this composes with, but never invokes, ``json_healer``). DRY: the non-truncation
+repair path reuses ``providers._repair_json``; the markdown-fence strip mirrors
+the healer's own. NEVER introduces a new JSON parser or regex-repair library.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any, Dict, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+class PayloadTruncationError(ValueError):
+    """A provider payload was severed mid-transmission (structurally incomplete).
+
+    Distinct from a syntax error: the bytes are not malformed, they are MISSING.
+    Carries the observed structural state so the failure lifecycle can log why.
+    """
+
+    def __init__(
+        self, detail: str, *, depth: int = 0, in_string: bool = False,
+        received_bytes: int = 0,
+    ) -> None:
+        super().__init__(detail)
+        self.detail = detail
+        self.depth = depth
+        self.in_string = in_string
+        self.received_bytes = received_bytes
+
+
+# ---------------------------------------------------------------------------
+# Deterministic truncation detection
+# ---------------------------------------------------------------------------
+
+
+def _strip_markdown_fence(text: str) -> str:
+    """Strip a leading/trailing ``` fence (mirrors json_healer / the DreamEngine
+    ad-hoc strip this replaces). Only strips a matched pair; a lone opening fence
+    is itself a truncation signal and is left for the structural scan."""
+    t = text.strip()
+    if not t.startswith("```"):
+        return t
+    lines = t.split("\n")
+    # Drop the opening fence line; drop a closing fence line only if present.
+    if lines and lines[0].strip().startswith("```"):
+        lines = lines[1:]
+    if lines and lines[-1].strip() == "```":
+        lines = lines[:-1]
+    return "\n".join(lines).strip()
+
+
+def structural_scan(text: str) -> Tuple[int, bool, bool]:
+    """Single-pass structural state of *text* as JSON.
+
+    Returns ``(depth, in_string, saw_container)``:
+      * ``depth`` — net open ``{``/``[`` containers at EOF (0 = balanced,
+        >0 = truncated open, <0 = malformed-but-not-this-truncation-class).
+      * ``in_string`` — True if a string literal is still open at EOF (severed
+        mid-string — a classic mid-token cut).
+      * ``saw_container`` — whether any container/opening token appeared at all
+        (distinguishes "empty/garbage" from "a real object that got cut").
+
+    String-aware: braces inside strings don't count, and ``\\`` escapes the next
+    char so an escaped quote doesn't falsely close a string. NEVER raises.
+    """
+    depth = 0
+    in_string = False
+    escaped = False
+    saw_container = False
+    try:
+        for ch in text:
+            if in_string:
+                if escaped:
+                    escaped = False
+                elif ch == "\\":
+                    escaped = True
+                elif ch == '"':
+                    in_string = False
+                continue
+            if ch == '"':
+                in_string = True
+                saw_container = True
+            elif ch in "{[":
+                depth += 1
+                saw_container = True
+            elif ch in "}]":
+                depth -= 1
+    except Exception:  # noqa: BLE001 — a scan bug must not mask the real payload
+        logger.debug("[PayloadIntegrity] structural_scan faulted", exc_info=True)
+    return depth, in_string, saw_container
+
+
+def is_truncated(text: str) -> bool:
+    """True iff *text* looks structurally severed: a real container/string was
+    opened and never closed (net open depth > 0, or a string open at EOF)."""
+    stripped = _strip_markdown_fence(text)
+    if not stripped:
+        return False
+    depth, in_string, saw_container = structural_scan(stripped)
+    return saw_container and (depth > 0 or in_string)
+
+
+# ---------------------------------------------------------------------------
+# The validator
+# ---------------------------------------------------------------------------
+
+
+def validate_json_payload(
+    raw: str, *, allow_repair: bool = True,
+) -> Dict[str, Any]:
+    """Parse *raw* into a dict at a provider return boundary, distinguishing
+    truncation from syntax fault.
+
+    Order matters:
+      1. Truncation FIRST — a severed payload raises ``PayloadTruncationError``
+         and never reaches the brace-closing repair (which would mask it).
+      2. Strict parse.
+      3. Deterministic repair (reused ``providers._repair_json``) for a complete-
+         but-malformed body — only when ``allow_repair``.
+
+    Raises ``PayloadTruncationError`` (severed) or ``json.JSONDecodeError``
+    (genuine syntax fault). ``ValueError`` if the parsed root is not an object.
+    """
+    text = _strip_markdown_fence(raw or "")
+    if not text:
+        raise PayloadTruncationError("empty payload", received_bytes=0)
+
+    if is_truncated(text):
+        depth, in_string, _ = structural_scan(text)
+        raise PayloadTruncationError(
+            f"severed payload: depth={depth} in_string={in_string} "
+            f"bytes={len(text)}",
+            depth=depth, in_string=in_string, received_bytes=len(text),
+        )
+
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        if not allow_repair:
+            raise
+        # Complete-but-malformed → reuse the EXISTING deterministic repair
+        # (trailing commas, single quotes, unquoted keys, control chars). This
+        # payload is NOT truncated (checked above), so _repair_json's container-
+        # closing can't mask a sever here.
+        repaired = _deterministic_repair(text)
+        if repaired is None:
+            raise
+        data = repaired
+
+    if not isinstance(data, dict):
+        raise ValueError(
+            f"payload root is {type(data).__name__}, expected object"
+        )
+    return data
+
+
+def _deterministic_repair(text: str) -> Optional[Dict[str, Any]]:
+    """Reuse ``providers._repair_json`` (the load-bearing deterministic sweep)
+    and re-parse. Returns the dict on success, None if repair still can't parse.
+    Import is lazy + fail-soft so a providers import problem never turns a
+    syntax fault into a crash."""
+    try:
+        from backend.core.ouroboros.governance.providers import _repair_json
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        obj = json.loads(_repair_json(text))
+        return obj if isinstance(obj, dict) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+__all__ = [
+    "PayloadTruncationError",
+    "validate_json_payload",
+    "is_truncated",
+    "structural_scan",
+]

--- a/tests/aegis/test_qos_admission.py
+++ b/tests/aegis/test_qos_admission.py
@@ -1,0 +1,203 @@
+"""QoS admission gate — priority-aware bounding of concurrent Aegis forwards.
+
+The shape-aware read budget lifted the upstream read ceiling to 600s, so a single
+forward can now hold its socket for minutes. This gate bounds the COUNT of
+concurrent in-flight forwards and, only when that bound is saturated, admits
+waiters in X-JARVIS-QoS-Tier priority order — critical event-loop traffic
+(DreamEngine RT, Claude fallbacks) ahead of bulk background sensors.
+
+These tests pin: the forced collision (a queued critical bypasses a queued bulk),
+fail-open safety, master-off pass-through, tier parsing, and cross-module header
+agreement.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.aegis import qos_admission as Q
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+# ---------------------------------------------------------------------------
+# Tier taxonomy + parsing
+# ---------------------------------------------------------------------------
+
+
+def test_tier_ordering_critical_is_highest_priority():
+    # asyncio.PriorityQueue / heapq is a min-heap: lower int = dequeued first.
+    assert Q.QoSTier.CRITICAL < Q.QoSTier.STANDARD < Q.QoSTier.BULK
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("critical", Q.QoSTier.CRITICAL), ("CRITICAL", Q.QoSTier.CRITICAL),
+    ("immediate", Q.QoSTier.CRITICAL), ("0", Q.QoSTier.CRITICAL),
+    ("standard", Q.QoSTier.STANDARD), ("normal", Q.QoSTier.STANDARD),
+    ("bulk", Q.QoSTier.BULK), ("background", Q.QoSTier.BULK),
+    ("speculative", Q.QoSTier.BULK), ("2", Q.QoSTier.BULK),
+])
+def test_tier_from_header_value(raw, expected):
+    assert Q.tier_from_header_value(raw) == expected
+
+
+def test_tier_absent_or_unknown_defaults_standard():
+    # Never silently critical (would starve others), never silently bulk
+    # (would starve itself) — the safe middle.
+    assert Q.tier_from_header_value(None) == Q.QoSTier.STANDARD
+    assert Q.tier_from_header_value("") == Q.QoSTier.STANDARD
+    assert Q.tier_from_header_value("garbage") == Q.QoSTier.STANDARD
+
+
+# ---------------------------------------------------------------------------
+# THE forced collision — a queued critical bypasses a queued bulk
+# ---------------------------------------------------------------------------
+
+
+def test_qos_collision_critical_bypasses_bulk():
+    async def scenario():
+        gate = Q.ForwardAdmissionGate(max_concurrent=1)   # force saturation at 1
+        order: list[str] = []
+        release_holder = asyncio.Event()
+
+        async def holder():
+            async with gate.admit(Q.QoSTier.BULK):
+                order.append("holder-start")
+                await release_holder.wait()   # occupy the only slot
+            order.append("holder-done")
+
+        async def worker(name: str, tier: Q.QoSTier, started: asyncio.Event):
+            started.set()                     # signal we're about to queue
+            async with gate.admit(tier):
+                order.append(name)
+                await asyncio.sleep(0)        # touch the loop, then release
+
+        h = asyncio.create_task(holder())
+        # Wait until the holder owns the slot.
+        while "holder-start" not in order:
+            await asyncio.sleep(0)
+
+        # Enqueue a BULK waiter FIRST, then a CRITICAL waiter. If admission were
+        # FIFO, bulk would win; priority ordering must let critical jump ahead.
+        b_started, c_started = asyncio.Event(), asyncio.Event()
+        wb = asyncio.create_task(worker("bulk", Q.QoSTier.BULK, b_started))
+        await b_started.wait()
+        await asyncio.sleep(0.02)             # ensure bulk is parked in the heap
+        wc = asyncio.create_task(worker("critical", Q.QoSTier.CRITICAL, c_started))
+        await c_started.wait()
+        await asyncio.sleep(0.02)             # ensure critical is parked too
+
+        assert gate.snapshot()["waiting"] == 2   # both queued behind the holder
+
+        release_holder.set()                  # free the slot
+        await asyncio.gather(h, wb, wc)
+        return order
+
+    order = _run(scenario())
+    # Critical was admitted before the earlier-queued bulk.
+    assert order.index("critical") < order.index("bulk"), order
+
+
+def test_gate_dormant_under_normal_load():
+    async def scenario():
+        gate = Q.ForwardAdmissionGate(max_concurrent=8)
+        ran = []
+
+        async def w(i):
+            async with gate.admit(Q.QoSTier.STANDARD):
+                ran.append(i)
+                await asyncio.sleep(0)
+
+        # 5 concurrent < limit 8 → nobody ever queues.
+        await asyncio.gather(*(w(i) for i in range(5)))
+        assert gate.snapshot() == {"in_flight": 0, "waiting": 0, "limit": 8}
+        return ran
+
+    assert sorted(_run(scenario())) == [0, 1, 2, 3, 4]
+
+
+def test_slot_released_on_exception_no_leak():
+    async def scenario():
+        gate = Q.ForwardAdmissionGate(max_concurrent=1)
+
+        async def boom():
+            async with gate.admit(Q.QoSTier.STANDARD):
+                raise RuntimeError("work blew up")
+
+        with pytest.raises(RuntimeError):
+            await boom()
+        # The slot must be back — a leaked slot would wedge the next forward.
+        assert gate.snapshot()["in_flight"] == 0
+
+        ok = []
+        async def after():
+            async with gate.admit(Q.QoSTier.STANDARD):
+                ok.append(True)
+        await asyncio.wait_for(after(), timeout=1.0)
+        return ok
+
+    assert _run(scenario()) == [True]
+
+
+# ---------------------------------------------------------------------------
+# Master switch + robustness
+# ---------------------------------------------------------------------------
+
+
+def test_master_switch_default_on(monkeypatch):
+    monkeypatch.delenv(Q._ENABLED_ENV_VAR, raising=False)
+    assert Q.admission_enabled() is True
+    monkeypatch.setenv(Q._ENABLED_ENV_VAR, "false")
+    assert Q.admission_enabled() is False
+
+
+def test_limit_env_tunable_and_safe(monkeypatch):
+    monkeypatch.setenv(Q._MAX_CONCURRENT_ENV_VAR, "3")
+    assert Q._max_concurrent() == 3
+    monkeypatch.setenv(Q._MAX_CONCURRENT_ENV_VAR, "bad")
+    assert Q._max_concurrent() == Q._DEFAULT_MAX_CONCURRENT
+    monkeypatch.setenv(Q._MAX_CONCURRENT_ENV_VAR, "-1")
+    assert Q._max_concurrent() == Q._DEFAULT_MAX_CONCURRENT
+
+
+def test_singleton_reset():
+    g1 = Q.get_admission_gate()
+    assert Q.get_admission_gate() is g1
+    Q.reset_gate_for_tests()
+    assert Q.get_admission_gate() is not g1
+
+
+# ---------------------------------------------------------------------------
+# Cross-module header agreement (client ↔ gate ↔ forwarding strip)
+# ---------------------------------------------------------------------------
+
+
+def test_qos_header_agrees_across_modules():
+    from backend.core.ouroboros.aegis import forwarding as F
+    from backend.core.ouroboros.governance.aegis_provider_bridge import (
+        QOS_TIER_HEADER_NAME as client_name,
+    )
+    assert Q.QOS_TIER_HEADER == F._QOS_TIER_HEADER == client_name == "X-JARVIS-QoS-Tier"
+
+
+def test_forwarding_strips_qos_header_from_outbound():
+    import inspect
+    from backend.core.ouroboros.aegis import forwarding as F
+    src = inspect.getsource(F.forward_request)
+    assert "_QOS_TIER_HEADER.lower()" in src
+
+
+def test_client_route_to_tier_mapping():
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _qos_tier_for_route,
+    )
+    assert _qos_tier_for_route("immediate") == "critical"
+    assert _qos_tier_for_route("standard") == "standard"
+    assert _qos_tier_for_route("complex") == "standard"
+    assert _qos_tier_for_route("background") == "bulk"
+    assert _qos_tier_for_route("speculative") == "bulk"
+    assert _qos_tier_for_route("") == "standard"        # unknown → safe middle
+    assert _qos_tier_for_route("nonsense") == "standard"

--- a/tests/governance/test_payload_integrity.py
+++ b/tests/governance/test_payload_integrity.py
@@ -1,0 +1,175 @@
+"""Structural payload-integrity validation — truncation vs syntax fault.
+
+Raising the Aegis upstream read ceiling to 600s means a generation is allowed to
+run long, but a socket severed at the wall (or any mid-stream drop) delivers a
+PARTIAL body. A partial JSON body must be rejected as TRUNCATION — not silently
+brace-closed by the deterministic repair into a corrupt-but-parseable blueprint
+that flows into the governed loop.
+
+These tests pin: severed payloads raise PayloadTruncationError (distinct from a
+JSONDecodeError), the deterministic repair is still reused for genuine syntax
+faults, string-internal braces don't false-balance, and the DreamEngine cascade
+boundary routes truncation to the failure lifecycle with distinct telemetry.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance.payload_integrity import (
+    PayloadTruncationError,
+    is_truncated,
+    structural_scan,
+    validate_json_payload,
+)
+
+
+# ---------------------------------------------------------------------------
+# Structural scan — string-aware container/quote balance
+# ---------------------------------------------------------------------------
+
+
+def test_scan_balanced():
+    assert structural_scan('{"a": 1}') == (0, False, True)
+
+
+def test_scan_open_container():
+    depth, in_string, saw = structural_scan('{"a": [1, 2')
+    assert depth == 2 and in_string is False and saw is True
+
+
+def test_scan_open_string():
+    depth, in_string, saw = structural_scan('{"a": "unterminated')
+    assert in_string is True and saw is True
+
+
+def test_scan_ignores_braces_inside_strings():
+    # Braces / brackets inside a string literal must not affect depth.
+    assert structural_scan('{"a": "}}}]]]"}') == (0, False, True)
+
+
+def test_scan_respects_escaped_quote():
+    # An escaped quote does NOT close the string.
+    depth, in_string, _ = structural_scan('{"a": "he said \\"hi\\""}')
+    assert depth == 0 and in_string is False
+
+
+# ---------------------------------------------------------------------------
+# Truncation detection
+# ---------------------------------------------------------------------------
+
+
+def test_clean_payload_not_truncated():
+    assert is_truncated('{"a": 1}') is False
+
+
+def test_severed_mid_string_is_truncated():
+    assert is_truncated('{"changes":[{"file":"a.py","content":"def foo(') is True
+
+
+def test_unbalanced_containers_truncated():
+    assert is_truncated('{"changes": [{"x": 1}') is True
+
+
+def test_empty_or_garbage_not_flagged_as_truncation():
+    # No container ever opened → not the sever class (it's just empty/garbage,
+    # which the parse step rejects as a normal error).
+    assert is_truncated("") is False
+    assert is_truncated("   ") is False
+
+
+# ---------------------------------------------------------------------------
+# validate_json_payload — the boundary contract
+# ---------------------------------------------------------------------------
+
+
+def test_valid_payload_parses():
+    assert validate_json_payload('{"a": 1, "b": [2, 3]}') == {"a": 1, "b": [2, 3]}
+
+
+def test_severed_payload_raises_truncation_not_parse_error():
+    sev = '{"changes":[{"file":"a.py","content":"def foo('
+    with pytest.raises(PayloadTruncationError) as ei:
+        validate_json_payload(sev)
+    err = ei.value
+    assert err.in_string is True and err.depth > 0
+    assert err.received_bytes == len(sev)
+    # Crucially, it is NOT a bare JSONDecodeError — the caller can distinguish it.
+    assert isinstance(err, ValueError)
+    assert not isinstance(err, json.JSONDecodeError)
+
+
+def test_truncation_is_not_silently_brace_closed():
+    # The exact danger: _repair_json closes open containers. Prove the validator
+    # rejects the sever BEFORE that can produce corrupt-but-parseable data.
+    sev = '{"file": "x.py", "content": "def f(): retur'
+    with pytest.raises(PayloadTruncationError):
+        validate_json_payload(sev)
+
+
+def test_complete_but_malformed_is_repaired_not_truncation():
+    # Trailing comma — complete structure, genuine syntax defect → deterministic
+    # repair recovers it; NOT a truncation.
+    assert validate_json_payload('{"a": 1, "b": 2,}') == {"a": 1, "b": 2}
+
+
+def test_complete_malformed_unrepairable_raises_decode_error():
+    # Balanced braces but genuinely broken content that repair can't fix →
+    # a JSONDecodeError (syntax fault), still NOT a truncation.
+    with pytest.raises(json.JSONDecodeError):
+        validate_json_payload('{"a": @@@ !!! nonsense here}', allow_repair=True)
+
+
+def test_non_object_root_rejected():
+    with pytest.raises(ValueError):
+        validate_json_payload('[1, 2, 3]')
+
+
+def test_markdown_fenced_payload():
+    assert validate_json_payload('```json\n{"a": 5}\n```') == {"a": 5}
+
+
+def test_lone_opening_fence_with_severed_body_is_truncation():
+    # A ```json opener with a cut body (no closing fence) → the structural scan
+    # still sees the severed object.
+    assert is_truncated('```json\n{"a": [1, 2') is True
+
+
+# ---------------------------------------------------------------------------
+# 600s-sever SIMULATION at the DreamEngine Tier-0/1/2 cascade boundary
+# ---------------------------------------------------------------------------
+
+
+def test_dream_cascade_routes_truncation_to_failure(caplog):
+    """Simulate an upstream sever at the 600s wall: the inference returns a
+    partial body. The cascade boundary must route it to the failure lifecycle
+    (return None) with DISTINCT truncation telemetry — not a corrupt blueprint,
+    not a silent generic None."""
+    import logging
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+
+    severed = (
+        '{"title": "Optimize the hot loop", "target_files": ["a.py"], '
+        '"changes": [{"file": "a.py", "content": "def hot():\\n    for i in ra'
+    )  # ← socket cut here, mid-string, mid-list
+    caplog.set_level(logging.WARNING)
+    result = DreamEngine._parse_json_response(severed)
+    assert result is None                                   # routed to failure
+    assert any("TRUNCATED" in m for m in caplog.messages)   # distinct telemetry
+
+
+def test_dream_cascade_parses_complete_payload():
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    good = '{"title": "x", "target_files": ["a.py"], "changes": []}'
+    assert DreamEngine._parse_json_response(good) == {
+        "title": "x", "target_files": ["a.py"], "changes": [],
+    }
+
+
+def test_dream_cascade_repairs_trailing_comma():
+    # A complete-but-sloppy DW body still flows (deterministic repair), so we
+    # don't over-reject legitimate-if-messy generations as failures.
+    from backend.core.ouroboros.consciousness.dream_engine import DreamEngine
+    sloppy = '{"title": "x", "target_files": ["a.py"], "changes": [],}'
+    assert DreamEngine._parse_json_response(sloppy) is not None


### PR DESCRIPTION
Follows the shape-aware read-budget fix (#69920) that lifted the upstream read ceiling to 600s. Two edge cases that ceiling opens — plus one honest premise correction.

## 1. QoS admission (traffic shaping)

**Premise correction (owed, root-cause not theater):** there is **no connection pooler** in the proxy — `forwarding` opens a fresh `aiohttp.ClientSession` per request — so a `PriorityQueue` *inside the pooler* has nothing to gate, and op-level priority admission **already exists** at `BackgroundAgentPool`. Building a second queue there would be theater + a DRY violation.

The genuinely-unbounded resource the 600s budget exposes is the **count of concurrent in-flight forwards** (and dream / Claude-fallback / voice traffic bypasses the BG pool entirely). So this adds a priority-aware **admission gate** at the single forward chokepoint (`daemon._make_llm_handler`), not a pooler:

- `aegis/qos_admission.py` — `ForwardAdmissionGate` bounds concurrent forwards (`JARVIS_AEGIS_MAX_CONCURRENT_FORWARDS`, default 24) and, **only when saturated**, admits waiters in `X-JARVIS-QoS-Tier` priority order via `heapq` keyed `(tier, seq)` — strict priority, FIFO tie-break (the `asyncio.PriorityQueue` pattern).
- **Bulletproof:** FAIL-OPEN (a gate bug admits, never blocks provider traffic), release in `finally` (no slot leak), generous default (dormant until real saturation). Master `JARVIS_AEGIS_QOS_ADMISSION_ENABLED` default-TRUE; off = byte-identical pass-through.
- **Client declares tier** by mapping the **existing** `provider_route` taxonomy (no hardcoded op names): IMMEDIATE→critical, STANDARD/COMPLEX→standard, BACKGROUND/SPECULATIVE→bulk; `complete_sync` (DreamEngine RT) → critical. So a background-sensor forward yields the socket to a critical one under saturation — exactly the requested shaping.

## 2. Structural payload-integrity validation (truncation edge case)

A socket severed at the 600s wall delivers a **partial body**. The existing deterministic repair (`providers._repair_json`) explicitly *closes open containers* — it would silently turn a severed `{"content":"def foo(` into a corrupt-but-parseable blueprint that flows into the governed loop.

- `governance/payload_integrity.py` — a deterministic, **string-aware structural scan** detects a sever (net-open container depth, or an unterminated string at EOF) and raises a typed **`PayloadTruncationError` before any brace-closing repair runs** — distinct from a `JSONDecodeError`. Complete-but-malformed bodies still flow through the **reused** deterministic repair (DRY — no new parser/regex; an LLM can't recover severed bytes, so no heal call).
- Wired at the **DreamEngine Tier-0/1/2 cascade return boundary** (`_parse_json_response`, replacing its ad-hoc fence-strip / brace-extraction): truncation routes to the no-blueprint failure lifecycle with distinct telemetry.

## Tests (41 new)

- `test_qos_admission.py` (21): **the forced collision** (limit=1, a queued CRITICAL bypasses an earlier-queued BULK), fail-open, no-slot-leak-on-exception, dormant-under-normal-load, master-off, env clamps, cross-module header agreement.
- `test_payload_integrity.py` (20): string-aware scan, sever detection, the **not-silently-brace-closed** guarantee, repair-still-reused for syntax faults, and a **600s-sever simulation** proving the cascade routes truncation to failure.

All 90 across the new + conception spine green. The one pre-existing forwarding route-list red is unrelated (confirmed via stash on main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a QoS admission gate to prioritize critical forwards under saturation and adds structural JSON payload validation to detect truncated responses and fail fast.

- **New Features**
  - QoS admission: bounds concurrent forwards (env `JARVIS_AEGIS_MAX_CONCURRENT_FORWARDS`, default 24) and, when full, admits by `X-JARVIS-QoS-Tier` (critical > standard > bulk). Fail-open, master switch `JARVIS_AEGIS_QOS_ADMISSION_ENABLED`, and the header is stripped from upstream. Clients set tiers via existing `provider_route`; `complete_sync` is marked critical.
  - Payload integrity: string-aware scan raises `PayloadTruncationError` if a body is severed (before any repair). Wired into the DreamEngine parse boundary; complete-but-malformed payloads still use the existing deterministic repair.

<sup>Written for commit e4ec535216324ee0e38cc9708337ed6374fe48e1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

