### PR TITLE
fix(governance): activate in-flight registration so FSM suspend/resume actually fires

### DIFF
--- a/backend/core/ouroboros/governance/in_flight_registry.py
+++ b/backend/core/ouroboros/governance/in_flight_registry.py
@@ -88,6 +88,41 @@ def master_enabled() -> bool:
     return os.environ.get(_MASTER_FLAG, "false").lower() == "true"
 
 
+# The registry has TWO independent consumers:
+#   * the ConvergenceReaper (gated by master_enabled() / §33.1 default-FALSE — it
+#     reads the registry as authoritative only when explicitly graduated), and
+#   * FSM suspend-checkpointing (fsm_checkpoint.capture_inflight), which reads
+#     this registry as its DATA SOURCE to serialize in-flight ops at a graceful
+#     stop, and is default-ON via JARVIS_FSM_CHECKPOINT_ENABLED.
+#
+# Coupling registry POPULATION to the reaper's flag transitively disabled the
+# default-ON suspend feature: bt-2026-07-17-234137 hit session exhaustion with 7
+# ops mid-GENERATE, but every register_op_safely() had no-op'd, so
+# capture_inflight() read an EMPTY registry and checkpointed 0 ops -- nothing to
+# resume next boot. Population must therefore be active whenever EITHER consumer
+# needs it. The reaper still independently self-gates on reaper_enabled() before
+# any action, so populating the registry never makes it load-bearing.
+_FSM_CHECKPOINT_FLAG = "JARVIS_FSM_CHECKPOINT_ENABLED"
+
+
+def _checkpoint_wants_registry() -> bool:
+    """True iff FSM suspend-checkpointing (default-ON) needs the registry
+    populated so ``capture_inflight`` can serialize in-flight ops at a graceful
+    stop. NEVER raises."""
+    return os.environ.get(_FSM_CHECKPOINT_FLAG, "true").strip().lower() not in (
+        "0", "false", "no", "off",
+    )
+
+
+def registration_active() -> bool:
+    """Register/unregister/update ops when EITHER consumer needs the registry —
+    the reaper (``master_enabled``) OR FSM suspend-checkpointing
+    (``_checkpoint_wants_registry``). Decouples population from the reaper's
+    advisory-by-default flag so the default-ON suspend feature is actually fed.
+    """
+    return master_enabled() or _checkpoint_wants_registry()
+
+
 # ---------------------------------------------------------------------------
 # Phase enum (descriptive — not authoritative)
 # ---------------------------------------------------------------------------
@@ -690,7 +725,7 @@ def register_op_safely(
     ``GovernedLoopService`` — the loop's hot path stays
     one-liner-readable.
     """
-    if not master_enabled():
+    if not registration_active():
         return False
     try:
         result = get_default_registry().register(
@@ -720,7 +755,7 @@ def unregister_op_safely(op_id: str) -> bool:
     Drop-in for the four ``_active_ops.discard`` sites in
     ``GovernedLoopService``.
     """
-    if not master_enabled():
+    if not registration_active():
         return False
     try:
         return get_default_registry().unregister(op_id)
@@ -739,7 +774,7 @@ def update_phase_safely(op_id: str, *, phase_name: str) -> bool:
     Master-FALSE → silent no-op. Master-ON → composes default
     registry. NEVER raises. Returns ``True`` if the op was
     registered (and the phase swapped)."""
-    if not master_enabled():
+    if not registration_active():
         return False
     try:
         return get_default_registry().update_phase(

--- a/tests/governance/test_checkpoint_resume_registration_activation.py
+++ b/tests/governance/test_checkpoint_resume_registration_activation.py
@@ -1,0 +1,176 @@
+"""Stateful pipeline suspend/resume — the registration-activation root-cause fix.
+
+The FSM suspend/resume machinery (fsm_checkpoint: capture_inflight → signed
+checkpoint → list_pending → build_resume_envelope → hydrate) was fully built and
+wired (harness suspend both paths; intake-router _hydrate_fsm_checkpoints on
+boot), but INERT: its data source, the in_flight_registry, is populated only when
+JARVIS_IN_FLIGHT_REGISTRY_ENABLED is on — and that defaults FALSE (§33.1, the
+*reaper's* flag). So a default-ON suspend feature was transitively starved:
+bt-2026-07-17-234137 hit session exhaustion with 7 ops mid-GENERATE and
+capture_inflight checkpointed 0 ("in-flight registry empty").
+
+The fix decouples registry POPULATION from the reaper flag: register whenever
+EITHER consumer needs it (reaper OR FSM checkpointing, default-on). These tests
+pin the decoupling AND the full serialize→(second boot)→hydrate cycle.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import fsm_checkpoint as ckpt
+from backend.core.ouroboros.governance import in_flight_registry as R
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    R.reset_default_registry()
+    yield
+    R.reset_default_registry()
+
+
+class _FakeCtx:
+    """Minimal op context mirroring what capture_from_context reads."""
+
+    def __init__(self, op_id, phase="GENERATE"):
+        self.op_id = op_id
+        self.description = "optimize the hot loop"
+        self.target_files = ["backend/a.py"]
+        self.provider_route = "complex"
+        self.intake_evidence_json = '{"sensor": "opportunity_miner"}'
+        self.phase = phase
+
+
+# ---------------------------------------------------------------------------
+# Part A — the decoupling: registration active when EITHER consumer wants it
+# ---------------------------------------------------------------------------
+
+
+def test_both_consumers_off_is_inert(monkeypatch):
+    monkeypatch.setenv("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "false")
+    assert R.registration_active() is False
+    assert R.register_op_safely("op-1", ctx_ref=_FakeCtx("op-1")) is False
+    assert len(R.get_default_registry().snapshot()) == 0
+
+
+def test_checkpoint_on_activates_registration_even_with_reaper_off(monkeypatch):
+    # THE fix: the reaper stays advisory-off (§33.1) but the default-ON suspend
+    # feature now populates the registry.
+    monkeypatch.setenv("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    assert R.master_enabled() is False          # reaper NOT made load-bearing
+    assert R.registration_active() is True
+    assert R.register_op_safely("op-1", ctx_ref=_FakeCtx("op-1"),
+                                last_phase_name="GENERATE") is True
+    assert len(R.get_default_registry().snapshot()) == 1
+
+
+def test_reaper_on_also_activates(monkeypatch):
+    monkeypatch.setenv("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "false")
+    assert R.registration_active() is True
+    assert R.register_op_safely("op-1", ctx_ref=_FakeCtx("op-1")) is True
+
+
+def test_checkpoint_default_is_on(monkeypatch):
+    # Prove the real production default: with NOTHING set, checkpointing (and thus
+    # registration) is active — this is the state the soak actually runs in.
+    monkeypatch.delenv("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_FSM_CHECKPOINT_ENABLED", raising=False)
+    assert R.registration_active() is True
+
+
+# ---------------------------------------------------------------------------
+# Part B — SUSPEND: capture_inflight now checkpoints registered ops
+# (the exact path that captured 0 in the soak)
+# ---------------------------------------------------------------------------
+
+
+def test_capture_inflight_checkpoints_registered_ops(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "false")
+    base = str(tmp_path)
+
+    # Two ops mid-pipeline, registered as the live loop would.
+    R.register_op_safely("op-aaa", ctx_ref=_FakeCtx("op-aaa"),
+                         last_phase_name="GENERATE")
+    R.register_op_safely("op-bbb", ctx_ref=_FakeCtx("op-bbb", phase="VALIDATE"),
+                         last_phase_name="VALIDATE")
+
+    n = ckpt.capture_inflight(base_dir=base, reason="session_exhausted")
+    assert n == 2                                   # was 0 in the soak
+    pending = {cp.op_id: cp for cp in ckpt.list_pending(base_dir=base)}
+    assert set(pending) == {"op-aaa", "op-bbb"}
+    assert pending["op-aaa"].phase == "GENERATE"    # halted phase preserved
+    assert pending["op-bbb"].phase == "VALIDATE"
+    assert pending["op-aaa"].resume_reason == "session_exhausted"
+
+
+def test_empty_registry_still_captures_zero_gracefully(monkeypatch, tmp_path):
+    # The pre-fix behavior is still correct when there genuinely is nothing.
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    assert ckpt.capture_inflight(base_dir=str(tmp_path), reason="idle") == 0
+
+
+# ---------------------------------------------------------------------------
+# Part C — RESUME: a SECOND boot hydrates + resumes at the halted phase
+# ---------------------------------------------------------------------------
+
+
+def test_second_boot_hydrates_and_resumes_at_halted_phase(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    base = str(tmp_path)
+
+    # ---- BOOT 1: op runs to mid-GENERATE, session exhausts, suspend ----
+    R.register_op_safely("op-resume", ctx_ref=_FakeCtx("op-resume"),
+                         last_phase_name="GENERATE")
+    assert ckpt.capture_inflight(base_dir=base, reason="wall_clock_cap") == 1
+
+    # ---- BOOT 2: fresh process — registry empty, checkpoint on disk ----
+    R.reset_default_registry()
+    assert len(R.get_default_registry().snapshot()) == 0   # nothing in memory
+
+    pending = ckpt.list_pending(base_dir=base)             # HMAC verifies (same key)
+    assert len(pending) == 1
+    cp = pending[0]
+
+    env = ckpt.build_resume_envelope(cp)
+    # The resume envelope re-enters intake carrying the halted phase, so the
+    # pipeline FAST-FORWARDS past already-completed steps (Triage/Plan) instead
+    # of restarting clean.
+    assert env["op_id"] == "op-resume"
+    assert env["resume"] is True
+    assert env["resume_phase"] == "GENERATE"
+    assert env["source"] == "fsm_resume"
+    assert env["target_files"] == ["backend/a.py"]
+    assert env["provider_route"] == "complex"
+    # intake_evidence_json is preserved across the boot (the known WAL-resume gap
+    # this path does NOT have).
+    assert "opportunity_miner" in env["intake_evidence_json"]
+
+
+def test_hmac_key_stable_across_boots_same_base(monkeypatch, tmp_path):
+    # Same base_dir → same persisted key → resume verifies. This is why a normal
+    # host resumes: .ouroboros/checkpoint_key persists across ignitions.
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    monkeypatch.delenv("JARVIS_CHECKPOINT_HMAC_SECRET", raising=False)
+    base = str(tmp_path)
+    R.register_op_safely("op-k", ctx_ref=_FakeCtx("op-k"), last_phase_name="GENERATE")
+    assert ckpt.capture_inflight(base_dir=base, reason="wall_clock_cap") == 1
+    assert len(ckpt.list_pending(base_dir=base)) == 1      # verifies
+
+
+def test_checkpoint_written_under_a_different_key_is_rejected(monkeypatch, tmp_path):
+    # Explains the soak's Jul-3 orphan REJECTs: a checkpoint signed with one key
+    # (e.g. a driver-provisioned JARVIS_CHECKPOINT_HMAC_SECRET) fails verify under
+    # a different key → clean boot, never a silent corrupt resume.
+    base = str(tmp_path)
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "key-from-session-1")
+    R.register_op_safely("op-x", ctx_ref=_FakeCtx("op-x"), last_phase_name="GENERATE")
+    assert ckpt.capture_inflight(base_dir=base, reason="wall_clock_cap") == 1
+    assert len(ckpt.list_pending(base_dir=base)) == 1      # verifies with same key
+
+    monkeypatch.setenv("JARVIS_CHECKPOINT_HMAC_SECRET", "key-from-session-2")
+    # Different key → HMAC verify fails → excluded from resume (clean boot).
+    assert len(ckpt.list_pending(base_dir=base)) == 0

--- a/tests/governance/test_convergence_reaper_wiring.py
+++ b/tests/governance/test_convergence_reaper_wiring.py
@@ -95,7 +95,13 @@ def _isolate() -> Iterator[None]:
 
 
 class TestRegistrySafeWireHelpers:
-    def test_register_master_off_is_noop(self):
+    def test_register_master_off_is_noop(self, monkeypatch):
+        # Registration is inert only when NEITHER consumer wants the registry:
+        # the reaper (master, §33.1 default-off) AND FSM suspend-checkpointing
+        # (default-ON, disabled here to isolate the pure no-op). The decoupled
+        # activation — checkpoint-on populates the registry even with master off
+        # — is proven in test_checkpoint_resume_registration_activation.py.
+        monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "false")
         assert register_op_safely("op-x") is False
         assert get_default_registry().size() == 0
 
@@ -112,13 +118,12 @@ class TestRegistrySafeWireHelpers:
         assert rec is not None
         assert ("provider", "claude") in rec.metadata
 
-    def test_unregister_master_off_is_noop(self):
-        # Populate via the underlying registry directly.
+    def test_unregister_master_off_is_noop(self, monkeypatch):
+        # Both consumers off → the safe wrapper short-circuits, BUT the entry is
+        # still there because the bare register WAS called directly.
+        monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "false")
         r = get_default_registry()
         r.register("op-x")
-        # Master OFF — the safe wrapper short-circuits, BUT the
-        # entry is still there because the bare register WAS
-        # called.
         assert unregister_op_safely("op-x") is False
         assert r.size() == 1
 
@@ -216,10 +221,11 @@ class TestWiringPresence:
             )
             assert callable(getattr(gls_mod, name))
 
-    def test_module_helpers_are_master_off_byte_identical(self):
-        """The helpers MUST return False under master-OFF
-        without touching the registry — the live loop's hot
-        path must not depend on the registry being available."""
+    def test_module_helpers_are_master_off_byte_identical(self, monkeypatch):
+        """The helpers MUST return False when NEITHER consumer wants the registry
+        (reaper master-off AND FSM checkpointing off) without touching it — the
+        live loop's hot path must not depend on the registry being available."""
+        monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "false")
         assert (
             gls_mod._register_op_in_flight_safely("op-x") is False
         )


### PR DESCRIPTION
Root cause: the full stateful suspend/resume pipeline already exists and is wired (harness capture_inflight both paths + intake-router _hydrate_fsm_checkpoints, both default-ON), but INERT — its data source (in_flight_registry) is populated only when JARVIS_IN_FLIGHT_REGISTRY_ENABLED is on, which defaults FALSE (§33.1, the reaper's flag). So a default-ON suspend feature was transitively starved: bt-2026-07-17-234137 captured 0 in-flight ops at exhaustion despite 7 mid-GENERATE.

Fix (DRY, no new system): decouple registry population from the reaper flag — registration_active() = master_enabled() OR checkpoint-wants-registry (default-on). Reaper untouched (self-gates on reaper_enabled() at every action site).

10 new tests (decoupling + SUSPEND captures registered ops + full serialize→second-boot→hydrate cycle + HMAC key semantics) + 3 updated coupling tests. 119 across the registry/reaper/checkpoint spine green.

Two-soak empirical proof running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples in‑flight registry population from the reaper flag so `fsm_checkpoint` suspend/resume reliably captures and restores in‑flight ops. Default‑ON checkpointing now populates the registry even when the reaper is off, preserving advisory‑by‑default behavior.

- **Bug Fixes**
  - Introduced `registration_active()` to activate registry updates when either `master_enabled()` (reaper) or `_checkpoint_wants_registry()` (FSM checkpointing via `JARVIS_FSM_CHECKPOINT_ENABLED`) is on.
  - Updated `register_op_safely`, `unregister_op_safely`, and `update_phase_safely` to gate on `registration_active()`; reaper remains self‑gated and unchanged.
  - Verified end‑to‑end: suspend now checkpoints registered ops (was 0), second boot hydrates and resumes at the halted phase, and HMAC key stability/rejection works as expected.

<sup>Written for commit 81d82824a48d7d0d9ae20a976e375a3c31acc32e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69922?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

