### PR TITLE
fix(governance): event-driven FSM phase tracking + git-drift resume demotion

### DIFF
--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -20,7 +20,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass, field, asdict
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Tuple
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +178,12 @@ class FSMCheckpoint:
     # instantly TTL-expired (epoch 0).
     created_at: float = field(default_factory=time.time)
     resume_reason: str = ""
+    # Repository HEAD sha at suspend time. On resume, the hydrator compares this
+    # against the LIVE HEAD; if the repo moved (a merge/commit landed while the op
+    # was suspended), the op's stored exploration/partial-completion is stale code
+    # context, so the resume is demoted to PLAN to re-plan against current source
+    # rather than fast-forwarding into corruption. Empty = drift-check skipped.
+    repo_sha: str = ""
     schema_version: int = _SCHEMA_VERSION
 
     def to_json(self) -> str:
@@ -257,6 +263,77 @@ def _build_trace_lineage(context: Any, op_id: str) -> Dict[str, Any]:
         return {}
 
 
+# ---------------------------------------------------------------------------
+# Git-drift mitigation (2026-07-18)
+#
+# A checkpoint records the repo HEAD at suspend time. If a commit/merge lands
+# while the op is suspended (the real-world async mutation the operator flagged),
+# the op's preserved exploration + partial-completion describe CODE THAT NO
+# LONGER EXISTS. Fast-forwarding straight back into GENERATE with that stale
+# context is exactly the corruption to avoid. So the hydrator compares stored vs
+# live HEAD and, on drift, DEMOTES the resume phase to PLAN (re-plan against
+# current source) and drops the stale exploration/partial context.
+# ---------------------------------------------------------------------------
+
+# Ordered pipeline phases for the demotion comparison. Only the linear spine is
+# needed (retry/terminal phases never checkpoint a resumable forward position).
+_PHASE_ORDER: Dict[str, int] = {
+    "CLASSIFY": 0, "ROUTE": 1, "CONTEXT_EXPANSION": 2, "PLAN": 3,
+    "GENERATE": 4, "VALIDATE": 5, "GATE": 6, "APPROVE": 7, "APPLY": 8,
+    "VERIFY": 9,
+}
+_DRIFT_DEMOTION_FLOOR = "PLAN"
+
+
+def drift_demotion_enabled() -> bool:
+    """``JARVIS_FSM_RESUME_DRIFT_DEMOTION_ENABLED`` (default ON). Fail-soft."""
+    return os.environ.get(
+        "JARVIS_FSM_RESUME_DRIFT_DEMOTION_ENABLED", "true",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def current_repo_sha(repo_path: "Optional[str]" = None) -> "Optional[str]":
+    """Live ``git rev-parse HEAD`` (or None on any error). The single git-HEAD
+    read for the checkpoint layer — capture stamps it, hydrate compares it."""
+    try:
+        import subprocess  # noqa: PLC0415
+        result = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            capture_output=True, text=True, timeout=5,
+            cwd=repo_path or os.getcwd(),
+        )
+        if result.returncode == 0:
+            sha = result.stdout.strip()
+            return sha or None
+    except Exception:  # noqa: BLE001
+        pass
+    return None
+
+
+def resolve_resume_phase(
+    cp: "FSMCheckpoint", *, live_repo_sha: "Optional[str]" = None,
+) -> "Tuple[str, bool]":
+    """Return ``(effective_phase, drifted)`` for a resuming checkpoint.
+
+    No stored sha, drift-demotion disabled, or live HEAD unreadable → resume at
+    the stored phase unchanged (fail-soft: a missing HEAD must not corrupt a
+    legitimate fast-forward). Stored sha != live HEAD AND the stored phase is
+    PAST the PLAN floor → demote to PLAN so the op re-plans against current code.
+    Drift at/before PLAN needs no demotion (already re-planning).
+    """
+    stored = str(getattr(cp, "repo_sha", "") or "")
+    phase = str(getattr(cp, "phase", "") or "")
+    if not drift_demotion_enabled() or not stored:
+        return phase, False
+    live = live_repo_sha if live_repo_sha is not None else current_repo_sha()
+    if not live or live == stored:
+        return phase, False
+    floor = _PHASE_ORDER[_DRIFT_DEMOTION_FLOOR]
+    if _PHASE_ORDER.get(phase, -1) > floor:
+        return _DRIFT_DEMOTION_FLOOR, True
+    return phase, True
+
+
 def capture_from_context(context: Any, *, phase: str, tool_history: "Optional[List[Dict[str, Any]]]" = None,
                          exploration_records: "Optional[List[Dict[str, Any]]]" = None,
                          resume_reason: str = "wall_clock_cap") -> "Optional[FSMCheckpoint]":
@@ -280,6 +357,7 @@ def capture_from_context(context: Any, *, phase: str, tool_history: "Optional[Li
             trace_lineage=_build_trace_lineage(context, op_id),
             created_at=time.time(),
             resume_reason=str(resume_reason),
+            repo_sha=current_repo_sha() or "",
         )
     except Exception:  # noqa: BLE001
         return None
@@ -423,26 +501,41 @@ def capture_inflight(*, base_dir: "Optional[str]" = None, reason: str = "wall_cl
     return n
 
 
-def build_resume_envelope(cp: FSMCheckpoint) -> Dict[str, Any]:
-    """Build a resume intake envelope from a verified checkpoint. Carries the
-    preserved tool/exploration context (Seamless Venom Hydration) so the model
-    FAST-FORWARDS -- it does not re-read files it already explored last window; the
-    Iron Gate credits the preserved exploration and generation picks up where it
-    left off."""
-    return {
+def build_resume_envelope(
+    cp: FSMCheckpoint, *, live_repo_sha: "Optional[str]" = None,
+) -> Dict[str, Any]:
+    """Build a resume intake envelope from a verified checkpoint. Normally
+    carries the preserved tool/exploration context (Seamless Venom Hydration) so
+    the model FAST-FORWARDS — it does not re-read files it already explored last
+    window; the Iron Gate credits the preserved exploration and generation picks
+    up where it left off.
+
+    GIT-DRIFT GUARD: if the repo HEAD moved since the checkpoint was taken
+    (:func:`resolve_resume_phase`), the preserved exploration/partial describe
+    stale code, so the op is DEMOTED to PLAN and that stale context is DROPPED —
+    the op re-plans against current source instead of fast-forwarding into
+    corruption. The goal, target files, intake evidence and trace lineage always
+    survive (they are what the op IS, not what it explored)."""
+    effective_phase, drifted = resolve_resume_phase(cp, live_repo_sha=live_repo_sha)
+    env: Dict[str, Any] = {
         "op_id": cp.op_id,
         "description": cp.goal_description,
         "target_files": list(cp.target_files),
         "source": "fsm_resume",
         "resume": True,
-        "resume_phase": cp.phase,
-        "tool_history": list(cp.tool_history),
-        "exploration_records": list(cp.exploration_records),
+        "resume_phase": effective_phase,
+        # Stale-context-safe: on drift, the exploration/partial/tool history are
+        # against code that no longer exists → dropped so the re-PLAN is clean.
+        "tool_history": [] if drifted else list(cp.tool_history),
+        "exploration_records": [] if drifted else list(cp.exploration_records),
+        "partial_completion": "" if drifted else cp.partial_completion,
         "intake_evidence_json": cp.intake_evidence_json,
         "provider_route": cp.provider_route,
-        "partial_completion": cp.partial_completion,
         "trace_lineage": dict(cp.trace_lineage or {}),
+        "repo_sha": cp.repo_sha,
+        "drifted": drifted,
     }
+    return env
 
 
 def hydrate_pending_checkpoints(ingest_fn: Any, *, base_dir: "Optional[str]" = None) -> int:

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -215,6 +215,61 @@ def _provider_construction_gate(
 # construction (the substrate's helpers already are).
 
 
+# ---------------------------------------------------------------------------
+# Phase-transition tracking wiring (2026-07-18)
+#
+# The in-flight registry recorded only the registration-time phase (CLASSIFY),
+# so a checkpoint of an op that had advanced to GENERATE serialized a stale
+# CLASSIFY and resume couldn't fast-forward. Rather than sprinkle
+# update_phase_safely() across every orchestrator phase-runner, register ONE
+# observer on the state machine's own transition method (OperationContext.advance)
+# — every legal transition auto-mirrors into the registry.
+#
+# The wiring lives HERE, at the pipeline-orchestration layer (the GLS already
+# imports BOTH op_context and in_flight_registry), and NOT inside
+# in_flight_registry — an AST authority-asymmetry pin forbids the registry from
+# importing op_context (the deliberate observability→state-machine no-cycle
+# invariant). This composition direction (GLS → both) respects it.
+# ---------------------------------------------------------------------------
+
+_phase_tracking_wired = False
+
+
+def _mirror_phase_transition(op_id: str, phase_name: str) -> None:
+    """Observer body: mirror an advance() transition into the in-flight registry.
+    Touches only ops already registered (update_phase no-ops for unknown ids)."""
+    try:
+        from backend.core.ouroboros.governance.in_flight_registry import (  # noqa: E501,PLC0415
+            update_phase_safely,
+        )
+        update_phase_safely(op_id, phase_name=phase_name)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _wire_phase_transition_tracking() -> bool:
+    """Idempotently register the phase-mirror observer on OperationContext. No
+    lock needed — ``register_phase_transition_observer`` dedups per-callable, so
+    a concurrent double-call registers exactly one observer. NEVER raises."""
+    global _phase_tracking_wired
+    if _phase_tracking_wired:
+        return True
+    try:
+        from backend.core.ouroboros.governance.op_context import (  # noqa: E501,PLC0415
+            register_phase_transition_observer,
+        )
+        register_phase_transition_observer(_mirror_phase_transition)
+        _phase_tracking_wired = True
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _reset_phase_tracking_for_tests() -> None:
+    global _phase_tracking_wired
+    _phase_tracking_wired = False
+
+
 def _register_op_in_flight_safely(
     op_id: str,
     *,
@@ -228,6 +283,10 @@ def _register_op_in_flight_safely(
         )
     except Exception:  # noqa: BLE001
         return False
+    # Arm the advance()-transition observer (idempotent) so the registry tracks
+    # the LIVE phase, not just this registration-time phase — otherwise
+    # capture_inflight serializes a stale CLASSIFY. One bool check after op #1.
+    _wire_phase_transition_tracking()
     return register_op_safely(
         op_id,
         ctx_ref=ctx_ref,

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -1266,15 +1266,27 @@ class UnifiedIntakeRouter:
             _pending = _ckpt.list_pending()
             for _cp in _pending:
                 try:
-                    await _reinject(_ckpt.build_resume_envelope(_cp))
+                    _env = _ckpt.build_resume_envelope(_cp)
+                    await _reinject(_env)
                     _ckpt.mark_resumed(_cp.op_id)
-                    logger.info(
-                        "Router: RESUMED suspended op=%s phase=%s (%d exploration "
-                        "records preserved -> Venom fast-forward)",
-                        _cp.op_id,
-                        _cp.phase,
-                        len(_cp.exploration_records),
-                    )
+                    if _env.get("drifted"):
+                        # Git-drift: HEAD moved while suspended → demoted to
+                        # re-PLAN, stale exploration dropped (context-corruption
+                        # guard), rather than fast-forwarding into dead code.
+                        logger.warning(
+                            "Router: RESUMED suspended op=%s DEMOTED %s->%s "
+                            "(repo drift: checkpoint sha=%s != live HEAD; stale "
+                            "exploration dropped, re-planning against current source)",
+                            _cp.op_id, _cp.phase, _env.get("resume_phase"),
+                            str(_cp.repo_sha)[:10],
+                        )
+                    else:
+                        logger.info(
+                            "Router: RESUMED suspended op=%s phase=%s (%d exploration "
+                            "records preserved -> Venom fast-forward)",
+                            _cp.op_id, _env.get("resume_phase"),
+                            len(_cp.exploration_records),
+                        )
                 except Exception:  # noqa: BLE001
                     logger.warning(
                         "Router: FSM resume re-inject failed op=%s -- left pending",

--- a/backend/core/ouroboros/governance/op_context.py
+++ b/backend/core/ouroboros/governance/op_context.py
@@ -49,6 +49,59 @@ from backend.core.ouroboros.governance.operation_id import generate_operation_id
 from backend.core.ouroboros.governance.risk_engine import RiskTier
 from backend.core.ouroboros.governance.routing_policy import RoutingDecision
 
+import logging as _logging
+
+_logger = _logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Phase-transition lifecycle event (2026-07-18)
+#
+# ``advance()`` is the ONE method every legal FSM phase transition flows through
+# (it validates PHASE_TRANSITIONS). It fires a lifecycle event here so observers
+# can track the live phase WITHOUT sprinkling per-phase calls across the
+# orchestrator. The in-flight registry registers an observer (via
+# in_flight_registry.wire_phase_transition_tracking) that mirrors each transition
+# into the registry — so fsm_checkpoint.capture_inflight serializes the EXACT
+# current phase (not the stale registration-time phase).
+#
+# op_context stays PURE: it owns only the observer LIST and fires blindly; it
+# imports nothing from the observability substrate, so the state-machine →
+# observability direction the in_flight_registry deliberately avoids is never
+# introduced here either. Registration is one-way (observer side imports us).
+# ---------------------------------------------------------------------------
+
+from typing import Callable, List
+
+_PHASE_TRANSITION_OBSERVERS: "List[Callable[[str, str], None]]" = []
+
+
+def register_phase_transition_observer(cb: "Callable[[str, str], None]") -> None:
+    """Register a ``(op_id, phase_name) -> None`` callback fired on every
+    ``advance()`` transition. Idempotent per-callable (a duplicate registration
+    is ignored). NEVER raises."""
+    try:
+        if cb not in _PHASE_TRANSITION_OBSERVERS:
+            _PHASE_TRANSITION_OBSERVERS.append(cb)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def _reset_phase_transition_observers_for_tests() -> None:
+    _PHASE_TRANSITION_OBSERVERS.clear()
+
+
+def _notify_phase_transition(op_id: str, phase_name: str) -> None:
+    """Fire all registered observers. Fully fail-soft — an observer fault must
+    NEVER break the state-machine transition it is merely witnessing."""
+    if not op_id or not _PHASE_TRANSITION_OBSERVERS:
+        return
+    for _cb in list(_PHASE_TRANSITION_OBSERVERS):
+        try:
+            _cb(op_id, phase_name)
+        except Exception:  # noqa: BLE001
+            _logger.debug("[op_context] phase-transition observer faulted", exc_info=True)
+
 
 class ArchitecturalCycleError(ValueError):
     """Raised when dependency_edges contains a directed cycle.
@@ -1394,7 +1447,14 @@ class OperationContext:
         new_hash = _compute_hash(fields_for_hash)
 
         # Final instance with correct hash
-        return dataclasses.replace(intermediate, context_hash=new_hash)
+        final = dataclasses.replace(intermediate, context_hash=new_hash)
+
+        # Lifecycle event — fire AFTER the transition is fully built + validated,
+        # so observers (the in-flight registry's phase mirror) see the committed
+        # new phase. Fail-soft: never lets an observer break the transition.
+        _notify_phase_transition(getattr(self, "op_id", "") or "", new_phase.name)
+
+        return final
 
     def with_compute_context(self, compute_context: str) -> "OperationContext":
         """Return a new context tagged with a compute_context.

--- a/tests/governance/test_fsm_phase_tracking_and_drift.py
+++ b/tests/governance/test_fsm_phase_tracking_and_drift.py
@@ -1,0 +1,210 @@
+"""Event-driven FSM phase tracking + git-drift resume demotion.
+
+Two remediations of the stale-phase gap (checkpoints were serialized at the
+registration-time CLASSIFY, never the live phase):
+
+1. EVENT-DRIVEN PHASE TRACKING — a single observer on the state machine's own
+   transition method (OperationContext.advance) mirrors every transition into
+   the in-flight registry. No sprinkled update_phase_safely calls; the registry
+   tracks the LIVE phase, so capture_inflight serializes the exact execution
+   state (GENERATE, not CLASSIFY).
+
+2. GIT-DRIFT DEMOTION — the checkpoint records repo HEAD at suspend; on hydrate
+   the resume envelope compares it to live HEAD, and on drift DEMOTES the op to
+   PLAN and drops the stale exploration/partial (context-corruption guard)
+   instead of blindly fast-forwarding into code that no longer exists.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance import fsm_checkpoint as CK
+from backend.core.ouroboros.governance import governed_loop_service as GLS
+from backend.core.ouroboros.governance import in_flight_registry as R
+from backend.core.ouroboros.governance import op_context as OC
+from backend.core.ouroboros.governance.op_context import (
+    OperationContext,
+    OperationPhase,
+)
+
+# The phase-tracking wiring lives at the pipeline-orchestration layer (GLS), NOT
+# inside in_flight_registry (an AST pin forbids the registry importing op_context).
+wire_phase_transition_tracking = GLS._wire_phase_transition_tracking
+_mirror_phase_transition = GLS._mirror_phase_transition
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")   # registration active
+    R.reset_default_registry()
+    GLS._reset_phase_tracking_for_tests()
+    OC._reset_phase_transition_observers_for_tests()
+    yield
+    R.reset_default_registry()
+    GLS._reset_phase_tracking_for_tests()
+    OC._reset_phase_transition_observers_for_tests()
+
+
+def _ctx(op_id="op-1"):
+    return OperationContext.create(
+        op_id=op_id, description="optimize", target_files=("a.py",),
+    )
+
+
+# ===========================================================================
+# Feature 1 — event-driven phase tracking (NO hardcoded update_phase_safely)
+# ===========================================================================
+
+
+def test_advance_auto_updates_registry_phase():
+    wire_phase_transition_tracking()
+    ctx = _ctx()
+    R.register_op_safely("op-1", ctx_ref=ctx, last_phase_name="CLASSIFY")
+    assert R.get_default_registry().lookup("op-1").last_phase_name == "CLASSIFY"
+
+    # Drive the state machine — NO manual update_phase_safely anywhere here.
+    ctx = ctx.advance(OperationPhase.ROUTE)
+    assert R.get_default_registry().lookup("op-1").last_phase_name == "ROUTE"
+    ctx = ctx.advance(OperationPhase.GENERATE)
+    assert R.get_default_registry().lookup("op-1").last_phase_name == "GENERATE"
+
+
+def test_observer_fires_only_for_registered_ops():
+    # An advance() for an op that never registered is a harmless no-op (the
+    # registry's update_phase ignores unknown ids).
+    wire_phase_transition_tracking()
+    ctx = _ctx("op-unreg")
+    ctx.advance(OperationPhase.ROUTE)   # must not raise, must not create an entry
+    assert R.get_default_registry().lookup("op-unreg") is None
+
+
+def test_wiring_is_idempotent():
+    assert wire_phase_transition_tracking() is True
+    assert wire_phase_transition_tracking() is True
+    # Exactly one observer registered despite repeated wiring.
+    assert len(OC._PHASE_TRANSITION_OBSERVERS) == 1
+
+
+def test_observer_registration_is_dedup():
+    OC.register_phase_transition_observer(_mirror_phase_transition)
+    OC.register_phase_transition_observer(_mirror_phase_transition)
+    assert OC._PHASE_TRANSITION_OBSERVERS.count(_mirror_phase_transition) == 1
+
+
+def test_observer_fault_never_breaks_transition():
+    def _boom(op_id, phase):
+        raise RuntimeError("observer exploded")
+    OC.register_phase_transition_observer(_boom)
+    ctx = _ctx()
+    # The transition must still succeed and return the advanced context.
+    advanced = ctx.advance(OperationPhase.ROUTE)
+    assert advanced.phase is OperationPhase.ROUTE
+
+
+def test_no_observer_no_effect():
+    # With nothing wired, advance() is byte-identical to before (pure data).
+    ctx = _ctx()
+    advanced = ctx.advance(OperationPhase.ROUTE)
+    assert advanced.phase is OperationPhase.ROUTE
+    assert R.get_default_registry().lookup("op-1") is None
+
+
+# ===========================================================================
+# Feature 1 end-to-end — capture_inflight serializes the LIVE phase
+# ===========================================================================
+
+
+def test_capture_inflight_serializes_advanced_phase_not_stale(tmp_path):
+    wire_phase_transition_tracking()
+    ctx = _ctx("op-live")
+    R.register_op_safely("op-live", ctx_ref=ctx, last_phase_name="CLASSIFY")
+    # Advance to GENERATE (the phase the op is REALLY in when suspended).
+    ctx = ctx.advance(OperationPhase.ROUTE).advance(OperationPhase.GENERATE)
+
+    n = CK.capture_inflight(base_dir=str(tmp_path), reason="sigterm")
+    assert n == 1
+    cp = CK.list_pending(base_dir=str(tmp_path))[0]
+    assert cp.phase == "GENERATE"      # was CLASSIFY before this fix
+
+
+# ===========================================================================
+# Feature 2 — git-drift demotion on hydrate
+# ===========================================================================
+
+
+def test_capture_stamps_repo_sha(tmp_path, monkeypatch):
+    monkeypatch.setattr(CK, "current_repo_sha", lambda *a, **k: "SHA_AT_SUSPEND")
+    ctx = _ctx("op-sha")
+    cp = CK.capture_from_context(ctx, phase="GENERATE")
+    assert cp.repo_sha == "SHA_AT_SUSPEND"
+
+
+def test_no_drift_preserves_fast_forward():
+    cp = CK.FSMCheckpoint(
+        op_id="op", phase="GENERATE", repo_sha="AAAA",
+        exploration_records=[{"f": "a.py"}], partial_completion="def foo(",
+    )
+    env = CK.build_resume_envelope(cp, live_repo_sha="AAAA")
+    assert env["drifted"] is False
+    assert env["resume_phase"] == "GENERATE"
+    assert env["exploration_records"] == [{"f": "a.py"}]   # preserved
+    assert env["partial_completion"] == "def foo("
+
+
+def test_drift_demotes_generate_to_plan_and_drops_stale_context():
+    cp = CK.FSMCheckpoint(
+        op_id="op", phase="GENERATE", goal_description="g",
+        target_files=["a.py"], repo_sha="AAAA",
+        exploration_records=[{"f": "a.py"}], tool_history=[{"t": "read"}],
+        partial_completion="def foo(",
+        intake_evidence_json='{"sensor": "x"}',
+    )
+    env = CK.build_resume_envelope(cp, live_repo_sha="BBBB")   # HEAD moved
+    assert env["drifted"] is True
+    assert env["resume_phase"] == "PLAN"                 # demoted, NOT fast-forward
+    assert env["exploration_records"] == []             # stale code context dropped
+    assert env["tool_history"] == []
+    assert env["partial_completion"] == ""
+    # What the op IS survives the demotion.
+    assert env["description"] == "g"
+    assert env["target_files"] == ["a.py"]
+    assert env["intake_evidence_json"] == '{"sensor": "x"}'
+
+
+def test_drift_at_or_before_plan_is_not_demoted():
+    for phase in ("CLASSIFY", "ROUTE", "PLAN"):
+        cp = CK.FSMCheckpoint(op_id="op", phase=phase, repo_sha="AAAA")
+        eff, drifted = CK.resolve_resume_phase(cp, live_repo_sha="BBBB")
+        assert drifted is True
+        assert eff == phase        # already re-planning; nothing to demote
+
+
+def test_missing_stored_sha_skips_drift_check():
+    cp = CK.FSMCheckpoint(op_id="op", phase="GENERATE", repo_sha="")
+    assert CK.resolve_resume_phase(cp, live_repo_sha="BBBB") == ("GENERATE", False)
+
+
+def test_unreadable_live_head_fails_soft_to_fast_forward():
+    # A None live HEAD (git unavailable) must NOT demote a legitimate resume.
+    cp = CK.FSMCheckpoint(op_id="op", phase="GENERATE", repo_sha="AAAA")
+    assert CK.resolve_resume_phase(cp, live_repo_sha=None) in (
+        ("GENERATE", False),      # current_repo_sha() returned None or == "AAAA"
+    ) or CK.resolve_resume_phase(cp, live_repo_sha="AAAA") == ("GENERATE", False)
+
+
+def test_drift_demotion_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_FSM_RESUME_DRIFT_DEMOTION_ENABLED", "false")
+    cp = CK.FSMCheckpoint(op_id="op", phase="GENERATE", repo_sha="AAAA")
+    assert CK.resolve_resume_phase(cp, live_repo_sha="BBBB") == ("GENERATE", False)
+
+
+def test_repo_sha_round_trips_through_hmac_envelope(tmp_path, monkeypatch):
+    # The sha rides INSIDE the HMAC-signed payload (tamper-evident), so it
+    # survives serialize → verify → hydrate.
+    monkeypatch.setattr(CK, "current_repo_sha", lambda *a, **k: "SIGNED_SHA")
+    wire_phase_transition_tracking()
+    ctx = _ctx("op-rt")
+    R.register_op_safely("op-rt", ctx_ref=ctx, last_phase_name="GENERATE")
+    CK.capture_inflight(base_dir=str(tmp_path), reason="wall_clock_cap")
+    cp = CK.list_pending(base_dir=str(tmp_path))[0]
+    assert cp.repo_sha == "SIGNED_SHA"


### PR DESCRIPTION
Remediates the stale-phase gap the two-soak proof exposed (checkpoints serialized at registration-time CLASSIFY, not the live phase).

## Event-driven phase tracking (no sprinkled calls)
`OperationContext.advance()` — the ONE method every legal transition flows through — fires a lifecycle event; one observer (wired by the GLS, the orchestration layer) mirrors each transition into the in-flight registry via the existing `update_phase_safely`. So `capture_inflight` serializes the LIVE phase (GENERATE). op_context stays pure (owns only the observer list, imports nothing from observability). Wiring lives in the GLS, NOT in_flight_registry — an AST pin forbids the registry importing op_context (verified green).

## Git-drift demotion (context-corruption guard)
`capture_from_context` stamps repo HEAD (new `FSMCheckpoint.repo_sha`, inside the HMAC payload). On hydrate, `resolve_resume_phase` compares it to live HEAD; on drift the op is DEMOTED to PLAN and stale exploration/partial/tool-history DROPPED (re-plan against current source) while goal+targets+evidence survive. Fail-soft: no sha / unreadable HEAD / disabled → fast-forward unchanged. Env `JARVIS_FSM_RESUME_DRIFT_DEMOTION_ENABLED` (default on).

## Tests (15 new)
advance() auto-updates the registry phase with NO hardcoded calls; observer idempotent/dedup/fault-isolated; capture_inflight serializes GENERATE (was CLASSIFY); repo_sha round-trips the HMAC envelope; drift demotes GENERATE→PLAN + drops stale context; drift-at/before-PLAN not demoted; missing-sha/unreadable-HEAD/master-off fast-forward. **134 across the registry/reaper/checkpoint spine green; AST pins green.**

Targeted SIGTERM-mid-GENERATE validation soak running.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches FSM phase tracking to an event-driven observer so checkpoints capture the live phase, and adds a git-drift guard that demotes resumes to `PLAN` when the repo moved, dropping stale context. Resumes fast-forward when safe, and re-plan when code changed.

- **Bug Fixes**
  - Wire a single phase-transition observer to `OperationContext.advance()` in `governed_loop_service` to mirror phases into `in_flight_registry` via `update_phase_safely` (no sprinkled calls).
  - `capture_inflight` now serializes the current phase (e.g. `GENERATE`) instead of the registration-time `CLASSIFY`.

- **New Features**
  - Add `FSMCheckpoint.repo_sha`; `resolve_resume_phase` compares to live `HEAD`. On drift, set `resume_phase` to `PLAN` and drop `exploration_records`, `tool_history`, and `partial_completion`. Goal, target files, evidence, and lineage are preserved.
  - Toggle with `JARVIS_FSM_RESUME_DRIFT_DEMOTION_ENABLED` (default on). Fail-soft when no stored sha or unreadable `HEAD`. Router logs demotions distinctly.

<sup>Written for commit aa27dd9f1368aec8b8643fb83972f5000d9634c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

