### PR TITLE
feat(providers): complete the capability scout — reasoning-effort compliance dimension

### DIFF
--- a/backend/core/ouroboros/governance/dw_discovery_runner.py
+++ b/backend/core/ouroboros/governance/dw_discovery_runner.py
@@ -209,6 +209,39 @@ async def run_discovery(
                 exc_info=True,
             )
 
+        # Step 1.4b: REASONING-EFFORT COMPLIANCE (2026-07-18).
+        # The entitlement probe maps WHETHER a model is callable (403/2xx); it
+        # sends a bare payload and so leaves the third capability dimension
+        # blank — whether the model honors reasoning_effort="none" or floors it
+        # (the gpt-oss-120b class that returns empty content when told not to
+        # think). That was learned only REACTIVELY, by burning a real op. This
+        # proactively probes it for the newly-catalogued (unprofiled) models —
+        # skipping any the entitlement probe just DENIED (a 403 model isn't
+        # callable to test) — and records floors into the EXISTING reasoning
+        # profile so the provider never sends effort=none to a model that
+        # rejects it. Bounded, fail-soft; never crashes discovery.
+        try:
+            _denied_set = set(_denied)
+            _rc_targets = [
+                str(getattr(m, "model_id", "") or "")
+                for m in snapshot.models
+                if str(getattr(m, "model_id", "") or "") not in _denied_set
+            ]
+            _floored, _rc_clean = await probe_reasoning_compliance(
+                session=session, base_url=base_url, api_key=api_key,
+                model_ids=_rc_targets,
+            )
+            if _floored or _rc_clean:
+                diagnostics.append(
+                    f"reasoning_compliance:floored={len(_floored)}"
+                    f":clean={len(_rc_clean)}"
+                )
+        except Exception:  # noqa: BLE001 — never crash discovery
+            logger.debug(
+                "[DiscoveryRunner] reasoning-compliance probe failed",
+                exc_info=True,
+            )
+
     # Step 1.5: Slice G — modality verification (metadata + probes)
     # Runs BEFORE classify so the ledger is populated with verdicts
     # the classifier can consult. Gated by master flag — when off,
@@ -545,6 +578,136 @@ async def probe_rt_entitlement(
         len(model_ids) - len(cleared) - len(denied), len(model_ids),
     )
     return denied, cleared
+
+
+def _reasoning_compliance_probe_enabled() -> bool:
+    """Master — ``JARVIS_DW_REASONING_COMPLIANCE_PROBE_ENABLED`` (default true)."""
+    return (
+        os.environ.get("JARVIS_DW_REASONING_COMPLIANCE_PROBE_ENABLED", "true") or ""
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+async def probe_reasoning_compliance(
+    *,
+    session: Any,
+    base_url: str,
+    api_key: str,
+    model_ids: Sequence[str],
+) -> Tuple[List[str], List[str]]:
+    """Map each model's ``reasoning_effort`` compliance — the third capability
+    dimension the entitlement probe leaves blank.
+
+    A reasoning model that CANNOT disable its chain-of-thought (the
+    ``gpt-oss-120b`` class) errors when sent ``reasoning_effort="none"`` and
+    then returns empty content on real ops. This sends ONE minimal completion
+    composed via the provider's own ``_reasoning_request_params(effort="none")``
+    (DRY — the single source of truth for the wire schema) and, on an
+    unambiguous reasoning-rejection error, records a floor into the EXISTING
+    ``ReasoningProfile`` so the provider stops under-spending effort on it.
+
+    Discipline mirrors ``probe_rt_entitlement`` — only UNAMBIGUOUS evidence is
+    written; a transient / 5xx / non-reasoning 4xx records NOTHING. Probes only
+    models NOT already profiled (the reasoning profile persists, so this is a
+    one-time cost per newly-catalogued model). Returns ``(floored, clean)``.
+    NEVER raises.
+    """
+    floored: List[str] = []
+    clean: List[str] = []
+    if not _reasoning_compliance_probe_enabled() or not model_ids or not api_key:
+        return floored, clean
+    try:
+        from backend.core.ouroboros.governance.dw_reasoning_profile import (
+            error_indicates_reasoning_rejection,
+            get_reasoning_profile,
+            reasoning_profile_enabled,
+        )
+    except Exception:  # noqa: BLE001
+        return floored, clean
+    if not reasoning_profile_enabled():
+        return floored, clean
+    profile = get_reasoning_profile()
+    # One-time per model: skip anything already carrying a learned floor.
+    targets = [
+        str(m) for m in model_ids
+        if str(m) and profile.learned_min_effort(str(m)) is None
+    ]
+    if not targets:
+        return floored, clean
+    # Lazy import of the wire-schema helper (avoids a provider import cycle at
+    # module load; the probe path can afford the one-time import).
+    try:
+        from backend.core.ouroboros.governance.doubleword_provider import (
+            _reasoning_request_params,
+        )
+    except Exception:  # noqa: BLE001
+        return floored, clean
+
+    timeout_s = _envf_probe("JARVIS_DW_REASONING_PROBE_TIMEOUT_S", 20.0)
+    max_conc = int(_envf_probe("JARVIS_DW_REASONING_PROBE_CONCURRENCY", 4.0))
+    sem = asyncio.Semaphore(max(1, max_conc))
+    url = f"{(base_url or '').rstrip('/')}/chat/completions"
+
+    async def _probe(model_id: str) -> None:
+        if not model_id:
+            return
+        # DRY: the exact wire schema the provider composes; carry only the
+        # wire-valid knob (extra_body/SDK-only keys would 400 on a raw POST).
+        _params = _reasoning_request_params(effort="none", model=model_id)
+        _wire = {k: v for k, v in _params.items() if k == "reasoning_effort"}
+        payload = {
+            "model": model_id,
+            "messages": [{"role": "user", "content": "ok"}],
+            "max_tokens": 1,
+            **_wire,
+        }
+        try:
+            async with sem:
+                async with session.post(
+                    url,
+                    headers={
+                        "Authorization": f"Bearer {api_key}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                    timeout=timeout_s,
+                ) as resp:
+                    status = int(resp.status)
+                    body = await resp.text()
+        except Exception:  # noqa: BLE001 — ambiguous → record NOTHING
+            logger.debug(
+                "[ReasoningProbe] model=%s inconclusive — no floor", model_id,
+                exc_info=True,
+            )
+            return
+        if status >= 400 and error_indicates_reasoning_rejection(body):
+            # The model rejected effort=none → it CANNOT run reasoning-free.
+            profile.record_reasoning_floor(model_id)
+            floored.append(model_id)
+        elif 200 <= status < 300:
+            # Honored effort=none → no floor needed (reasoning-free capable).
+            clean.append(model_id)
+        # else: 403 (entitlement's job), 5xx/429/timeout, or a non-reasoning
+        # 4xx → ambiguous for THIS dimension; record nothing.
+
+    try:
+        await asyncio.gather(
+            *(_probe(str(m)) for m in targets), return_exceptions=True,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[ReasoningProbe] gather failed", exc_info=True)
+        return floored, clean
+
+    if floored:
+        logger.info(
+            "[ReasoningProbe] %d model(s) require a reasoning floor (reject "
+            "effort=none): %s", len(floored), floored,
+        )
+    logger.info(
+        "[ReasoningProbe] reasoning-effort compliance mapped: %d floored, "
+        "%d reasoning-free-capable (of %d newly probed)",
+        len(floored), len(clean), len(targets),
+    )
+    return floored, clean
 
 
 def _failed_result(
@@ -1271,6 +1434,8 @@ __all__ = [
     "catalog_discovery_enabled",
     "get_heavy_probe_budget",
     "get_ttft_observer",
+    "probe_reasoning_compliance",
+    "probe_rt_entitlement",
     "reset_boot_state_for_tests",
     "run_discovery",
 ]

--- a/tests/governance/test_dw_reasoning_compliance_probe.py
+++ b/tests/governance/test_dw_reasoning_compliance_probe.py
@@ -1,0 +1,222 @@
+"""Autonomous capability scout — reasoning-effort compliance dimension.
+
+The Phase-12 discovery mesh (periodic /v1/models scan → minimal-token entitlement
+probe → transport-profile / EntitlementCatalogCache injection) already exists and
+is driven by the GovernedLoopService "Autonomic Pacemaker" + 30-min refresh loop.
+It mapped two of the three capability dimensions — RBAC entitlement (403) and
+batch-only — but left the THIRD blank: whether a model honors
+``reasoning_effort="none"`` or floors it (the gpt-oss-120b class that returns
+empty content when told not to think), which was only ever learned reactively by
+burning a real op.
+
+``probe_reasoning_compliance`` completes the mesh: it rides the SAME discovery
+cycle, composes the provider's own ``_reasoning_request_params`` (DRY), and
+records floors into the EXISTING ReasoningProfile. These tests pin both mandated
+scenarios — an unentitled model → cached 403 state, and a new reasoning model →
+floor recorded — plus the asymmetric never-mis-learn discipline.
+"""
+from __future__ import annotations
+
+import asyncio
+import pathlib
+import tempfile
+
+import pytest
+
+from backend.core.ouroboros.governance import dw_discovery_runner as D
+from backend.core.ouroboros.governance import dw_reasoning_profile as RP
+from backend.core.ouroboros.governance import dw_transport_profile as TP
+
+
+# ---------------------------------------------------------------------------
+# Fakes — a mocked DW endpoint keyed by model id
+# ---------------------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status, body=""):
+        self.status = status
+        self._body = body
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def text(self):
+        return self._body
+
+    async def read(self):
+        return b""
+
+
+class _FakeSession:
+    """Routes each POST to a scripted response by the payload's model id."""
+
+    def __init__(self, script):
+        self._script = script          # model_id -> (status, body)
+        self.calls = []                # observed payloads
+
+    def post(self, url, *, headers=None, json=None, timeout=None):
+        model = json["model"]
+        self.calls.append(json)
+        status, body = self._script.get(model, (500, "unmapped"))
+        return _Resp(status, body)
+
+
+def _run(coro):
+    return asyncio.new_event_loop().run_until_complete(coro)
+
+
+@pytest.fixture()
+def fresh_reasoning_profile(monkeypatch):
+    prof = RP.ReasoningProfile(
+        path=pathlib.Path(tempfile.mktemp(prefix="rp_")), autosave=False,
+    )
+    monkeypatch.setattr(RP, "_DEFAULT_PROFILE", prof)
+    monkeypatch.setenv("JARVIS_DW_REASONING_PROFILE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_REASONING_COMPLIANCE_PROBE_ENABLED", "true")
+    return prof
+
+
+# ---------------------------------------------------------------------------
+# Scenario 2 (mandate) — a NEW reasoning model → floor recorded
+# ---------------------------------------------------------------------------
+
+
+def test_new_reasoning_model_rejecting_none_records_floor(fresh_reasoning_profile):
+    prof = fresh_reasoning_profile
+    session = _FakeSession({
+        # A reasoning model that CANNOT disable thinking → 400 rejection.
+        "inkling": (400, "reasoning_effort cannot be disabled for this model"),
+        # A reasoning-free-capable model honors effort=none → 200.
+        "qwen-397b": (200, "ok"),
+    })
+    floored, clean = _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="k",
+        model_ids=["inkling", "qwen-397b"],
+    ))
+    assert floored == ["inkling"]
+    assert clean == ["qwen-397b"]
+    # The floor is persisted in the EXISTING reasoning profile (election-time
+    # call params now know to raise effort for this model).
+    assert prof.learned_min_effort("inkling") is not None
+    assert prof.learned_min_effort("qwen-397b") is None
+
+
+def test_probe_uses_reasoning_request_params_wire_schema(fresh_reasoning_profile):
+    # DRY: the probe composes the provider's own _reasoning_request_params, so
+    # the payload carries the compliant reasoning_effort knob.
+    session = _FakeSession({"m": (200, "ok")})
+    _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="k", model_ids=["m"],
+    ))
+    assert len(session.calls) == 1
+    assert session.calls[0].get("reasoning_effort") == "none"
+    assert session.calls[0]["max_tokens"] == 1        # minimal token generation
+
+
+# ---------------------------------------------------------------------------
+# Asymmetric discipline — never mis-learn from ambiguous evidence
+# ---------------------------------------------------------------------------
+
+
+def test_403_is_skipped_by_reasoning_probe(fresh_reasoning_profile):
+    prof = fresh_reasoning_profile
+    session = _FakeSession({"blocked": (403, "blocked by a routing rule")})
+    floored, clean = _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="k",
+        model_ids=["blocked"],
+    ))
+    # 403 is the entitlement probe's dimension — reasoning probe records NOTHING.
+    assert floored == [] and clean == []
+    assert prof.learned_min_effort("blocked") is None
+
+
+def test_transient_5xx_records_nothing(fresh_reasoning_profile):
+    prof = fresh_reasoning_profile
+    session = _FakeSession({"m": (503, "service unavailable")})
+    floored, clean = _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="k", model_ids=["m"],
+    ))
+    assert floored == [] and clean == []
+    assert prof.learned_min_effort("m") is None
+
+
+def test_non_reasoning_400_records_nothing(fresh_reasoning_profile):
+    # A 400 that is NOT a reasoning-rejection (e.g. a schema error) must not be
+    # mistaken for a reasoning floor.
+    prof = fresh_reasoning_profile
+    session = _FakeSession({"m": (400, "invalid 'foo' parameter")})
+    floored, _ = _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="k", model_ids=["m"],
+    ))
+    assert floored == []
+    assert prof.learned_min_effort("m") is None
+
+
+def test_already_profiled_model_is_not_reprobed(fresh_reasoning_profile):
+    prof = fresh_reasoning_profile
+    prof.record_reasoning_floor("known", "low")       # already learned
+    session = _FakeSession({"known": (400, "reasoning cannot be disabled")})
+    floored, clean = _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="k", model_ids=["known"],
+    ))
+    # Skipped — the reasoning profile persists, so this is a one-time cost.
+    assert session.calls == []
+    assert floored == [] and clean == []
+
+
+def test_master_off_is_noop(fresh_reasoning_profile, monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_REASONING_COMPLIANCE_PROBE_ENABLED", "false")
+    session = _FakeSession({"m": (400, "reasoning cannot be disabled")})
+    floored, clean = _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="k", model_ids=["m"],
+    ))
+    assert session.calls == [] and floored == [] and clean == []
+
+
+def test_no_api_key_is_noop(fresh_reasoning_profile):
+    session = _FakeSession({"m": (200, "ok")})
+    floored, clean = _run(D.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="", model_ids=["m"],
+    ))
+    assert session.calls == [] and floored == [] and clean == []
+
+
+def test_probe_never_raises_on_session_fault(fresh_reasoning_profile):
+    class _BoomSession:
+        def post(self, *a, **k):
+            raise RuntimeError("network exploded")
+    # Must degrade to (no floor) rather than propagate.
+    floored, clean = _run(D.probe_reasoning_compliance(
+        session=_BoomSession(), base_url="http://dw", api_key="k",
+        model_ids=["m"],
+    ))
+    assert floored == [] and clean == []
+
+
+# ---------------------------------------------------------------------------
+# Scenario 1 (mandate) — an UNENTITLED model → cached 403 state
+# (existing entitlement probe; pinned here so the two dimensions compose)
+# ---------------------------------------------------------------------------
+
+
+def test_unentitled_model_yields_cached_403_state(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_ENTITLEMENT_PROBE_ENABLED", "true")
+    prof = TP.get_transport_profile()
+    prof.clear("unentitled-xyz")
+    session = _FakeSession({
+        "unentitled-xyz": (403, "blocked by a routing rule"),
+        "entitled-397b": (200, "ok"),
+    })
+    denied, cleared = _run(D.probe_rt_entitlement(
+        session=session, base_url="http://dw", api_key="k",
+        model_ids=["unentitled-xyz", "entitled-397b"],
+    ))
+    assert "unentitled-xyz" in denied
+    assert "entitled-397b" in cleared
+    # The 403 is now cached in the election matrix (transport profile): the RT
+    # ladder skips it without re-burning a probe within the TTL window.
+    assert prof.is_unavailable("unentitled-xyz", TP.TRANSPORT_REALTIME) is True


### PR DESCRIPTION
## The scout already exists — this completes its third dimension

The periodic capability-discovery mesh the mandate describes is **already built and driven**: `GovernedLoopService.start()` → "Autonomic Pacemaker" `create_task(boot_discovery_once)` → `_discovery_refresh_loop` (re-runs `run_discovery` every ~30 min / on force-refresh). Each cycle fetches `/v1/models`, probes every model's RT entitlement with a minimal `max_tokens:1` request (403→`record_unavailable`, 2xx→`record_rt_success` into the transport-profile **election matrix** + `EntitlementCatalogCache` **TTL**), maps modalities, populates the dynamic catalog. Building a new scout would be pure duplication.

Two of the three capability dimensions were already mapped (RBAC entitlement + batch-only). The **missing third** was `reasoning_effort` compliance — the entitlement probe sends a *bare* payload, so a model that floors `reasoning_effort="none"` (the gpt-oss-120b class returning empty content) was only learned **reactively**, by burning a real op.

### What this adds
`probe_reasoning_compliance` rides the **same** discovery cycle (Step 1.4b, after entitlement, skipping any model just DENIED). It composes the provider's own `_reasoning_request_params(effort="none")` (**DRY** — one wire-schema source), sends one minimal completion, and on an unambiguous reasoning-rejection records a floor into the **existing** `ReasoningProfile` (`error_indicates_reasoning_rejection` + `record_reasoning_floor`). Same asymmetric never-mis-learn discipline (403/5xx/non-reasoning-4xx/transient → **nothing**). Probes only not-yet-profiled models (profile persists → one-time cost per new model, e.g. Inkling). Master `JARVIS_DW_REASONING_COMPLIANCE_PROBE_ENABLED` (default on); bounded, fail-soft.

**No new scout, no new scheduler, no new data structures** — one probe into the existing mesh + the existing reasoning ledger.

### Tests (10 new)
Both mandated scenarios — new reasoning model rejecting `none` → floor recorded; unentitled model → cached 403 in the election matrix — plus asymmetric discipline, already-profiled skip, master-off, no-key, never-raise, DRY wire-schema check. 58 existing discovery/reasoning/entitlement tests green (the 1 red is pre-existing classifier drift, confirmed via stash).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reasoning-effort compliance probe to the existing discovery cycle to detect models that reject `reasoning_effort="none"` and record a floor in the `ReasoningProfile` so we avoid sending reasoning-free requests to them. Runs right after entitlement; no new scout or scheduler.

- **New Features**
  - Added `probe_reasoning_compliance` to `run_discovery` after entitlement; skips denied models.
  - Uses provider `_reasoning_request_params(effort="none")` to send a minimal completion.
  - Records floors via `ReasoningProfile.record_reasoning_floor` on clear rejection; marks 2xx as clean.
  - Ignores ambiguous results (403, 5xx, non-reasoning 4xx); never raises; bounded by timeout and concurrency envs.
  - Probes only unprofiled models; gated by `JARVIS_DW_REASONING_COMPLIANCE_PROBE_ENABLED` (default on).

<sup>Written for commit 03f50bee1db3e730d6d183ff42380c942c5b5b7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69924?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

