### PR TITLE
fix(providers): make the capability-scout probes run under Aegis (were inert)

### DIFF
--- a/backend/core/ouroboros/governance/dw_discovery_runner.py
+++ b/backend/core/ouroboros/governance/dw_discovery_runner.py
@@ -468,6 +468,66 @@ def _entitlement_probe_enabled() -> bool:
     ).strip().lower() in ("1", "true", "yes", "on")
 
 
+async def _probe_request_headers(
+    *, api_key: str, op_tag: str,
+) -> "Optional[Dict[str, str]]":
+    """Auth headers for a probe POST to ``/v1/chat/completions``.
+
+    This endpoint is the Aegis FORWARDING path, which requires a per-call lease
+    (unlike the catalog's ``/v1/models`` passthrough that ``DwCatalogClient``
+    hits with session auth alone). Under Aegis the caller's direct ``api_key`` is
+    scrubbed server-side (=""), so a raw ``Bearer {api_key}`` is empty and the
+    guard ``if not api_key`` used to make BOTH probes silently INERT on the
+    production transport — the catalog got mapped but entitlement/reasoning never
+    did. This composes the SAME session-vault + per-call-lease flow
+    ``complete_sync`` uses (aegis_provider_bridge), so the probes actually run
+    under Aegis. Non-Aegis → raw Bearer. Returns None when no usable auth exists
+    (the caller then skips — never emits an unauthenticated/lease-less probe that
+    would 401 and pollute the signal). NEVER raises.
+    """
+    try:
+        from backend.core.ouroboros.aegis import client as _aegis_client
+        if _aegis_client.is_enabled():
+            from backend.core.ouroboros.governance.aegis_provider_bridge import (
+                acquire_call_lease as _acquire_lease,
+                dw_session_auth_header as _session_auth,
+                merge_lease_into_session_headers as _merge_lease,
+            )
+            headers = await _session_auth()
+            if not headers.get("Authorization"):
+                return None
+            headers["Content-Type"] = "application/json"
+            try:
+                lease = await _acquire_lease(
+                    op_id=f"dw-probe:{op_tag}", route="standard",
+                    estimated_cost_usd=0.0002,
+                )
+            except Exception:  # noqa: BLE001 — lease infra hiccup → skip, don't 401
+                return None
+            return _merge_lease(headers, lease)
+    except Exception:  # noqa: BLE001
+        pass
+    if api_key:
+        return {
+            "Authorization": f"Bearer {api_key}",
+            "Content-Type": "application/json",
+        }
+    return None
+
+
+def _probe_auth_available(api_key: str) -> bool:
+    """True iff SOME probe auth is obtainable — a direct key, or Aegis. Lets the
+    probe guards drop the ``not api_key`` short-circuit that made them inert
+    under Aegis (where the direct key is intentionally empty)."""
+    if api_key:
+        return True
+    try:
+        from backend.core.ouroboros.aegis import client as _aegis_client
+        return bool(_aegis_client.is_enabled())
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def _envf_probe(name: str, default: float) -> float:
     try:
         raw = (os.environ.get(name, "") or "").strip()
@@ -507,7 +567,7 @@ async def probe_rt_entitlement(
     """
     denied: List[str] = []
     cleared: List[str] = []
-    if not _entitlement_probe_enabled() or not model_ids or not api_key:
+    if not _entitlement_probe_enabled() or not model_ids or not _probe_auth_available(api_key):
         return denied, cleared
 
     timeout_s = _envf_probe("JARVIS_DW_ENTITLEMENT_PROBE_TIMEOUT_S", 20.0)
@@ -525,6 +585,11 @@ async def probe_rt_entitlement(
     async def _probe(model_id: str) -> None:
         if not model_id:
             return
+        headers = await _probe_request_headers(
+            api_key=api_key, op_tag=f"entitlement:{model_id}",
+        )
+        if headers is None:
+            return  # no usable auth (e.g. Aegis lease unavailable) → skip
         payload = {
             "model": model_id,
             "messages": [{"role": "user", "content": "ok"}],
@@ -533,13 +598,7 @@ async def probe_rt_entitlement(
         try:
             async with sem:
                 async with session.post(
-                    url,
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json=payload,
-                    timeout=timeout_s,
+                    url, headers=headers, json=payload, timeout=timeout_s,
                 ) as resp:
                     status = int(resp.status)
                     await resp.read()  # drain so the connection is reusable
@@ -613,7 +672,11 @@ async def probe_reasoning_compliance(
     """
     floored: List[str] = []
     clean: List[str] = []
-    if not _reasoning_compliance_probe_enabled() or not model_ids or not api_key:
+    if (
+        not _reasoning_compliance_probe_enabled()
+        or not model_ids
+        or not _probe_auth_available(api_key)
+    ):
         return floored, clean
     try:
         from backend.core.ouroboros.governance.dw_reasoning_profile import (
@@ -650,6 +713,11 @@ async def probe_reasoning_compliance(
     async def _probe(model_id: str) -> None:
         if not model_id:
             return
+        headers = await _probe_request_headers(
+            api_key=api_key, op_tag=f"reasoning:{model_id}",
+        )
+        if headers is None:
+            return  # no usable auth → skip
         # DRY: the exact wire schema the provider composes; carry only the
         # wire-valid knob (extra_body/SDK-only keys would 400 on a raw POST).
         _params = _reasoning_request_params(effort="none", model=model_id)
@@ -663,13 +731,7 @@ async def probe_reasoning_compliance(
         try:
             async with sem:
                 async with session.post(
-                    url,
-                    headers={
-                        "Authorization": f"Bearer {api_key}",
-                        "Content-Type": "application/json",
-                    },
-                    json=payload,
-                    timeout=timeout_s,
+                    url, headers=headers, json=payload, timeout=timeout_s,
                 ) as resp:
                     status = int(resp.status)
                     body = await resp.text()

--- a/tests/governance/test_dw_reasoning_compliance_probe.py
+++ b/tests/governance/test_dw_reasoning_compliance_probe.py
@@ -203,6 +203,53 @@ def test_probe_never_raises_on_session_fault(fresh_reasoning_profile):
 # ---------------------------------------------------------------------------
 
 
+# ---------------------------------------------------------------------------
+# Aegis edge case — the probes RUN when the direct api_key is scrubbed
+# (the wired-but-inert-under-production condition this fixes)
+# ---------------------------------------------------------------------------
+
+
+def test_probe_runs_under_aegis_with_empty_direct_key(fresh_reasoning_profile, monkeypatch):
+    # Under Aegis the caller's direct api_key is "" (scrubbed server-side). The
+    # probe must STILL run, authenticating via the Aegis session vault + lease —
+    # not silently no-op on the `not api_key` guard.
+    import backend.core.ouroboros.governance.dw_discovery_runner as DR
+
+    async def _fake_headers(*, api_key, op_tag):
+        # Simulate the Aegis path resolving real auth despite empty direct key.
+        return {"Authorization": "Bearer AEGIS_INJECTED", "X-JARVIS-Lease": "lease-tok"}
+    monkeypatch.setattr(DR, "_probe_request_headers", _fake_headers)
+    monkeypatch.setattr(DR, "_probe_auth_available", lambda api_key: True)
+
+    session = _FakeSession({"inkling": (400, "reasoning cannot be disabled")})
+    floored, _ = _run(DR.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="",   # <-- scrubbed
+        model_ids=["inkling"],
+    ))
+    assert floored == ["inkling"]                       # ran despite empty key
+    assert session.calls[0]  # a probe was actually issued
+    assert fresh_reasoning_profile.learned_min_effort("inkling") is not None
+
+
+def test_probe_skips_when_aegis_lease_unavailable(fresh_reasoning_profile, monkeypatch):
+    # If auth can't be assembled (e.g. Aegis lease infra hiccup), the probe
+    # SKIPS rather than firing a doomed lease-less request that 401s and
+    # pollutes the signal.
+    import backend.core.ouroboros.governance.dw_discovery_runner as DR
+
+    async def _no_headers(*, api_key, op_tag):
+        return None
+    monkeypatch.setattr(DR, "_probe_request_headers", _no_headers)
+    monkeypatch.setattr(DR, "_probe_auth_available", lambda api_key: True)
+
+    session = _FakeSession({"m": (400, "reasoning cannot be disabled")})
+    floored, clean = _run(DR.probe_reasoning_compliance(
+        session=session, base_url="http://dw", api_key="", model_ids=["m"],
+    ))
+    assert session.calls == []                          # nothing issued
+    assert floored == [] and clean == []
+
+
 def test_unentitled_model_yields_cached_403_state(monkeypatch):
     monkeypatch.setenv("JARVIS_DW_ENTITLEMENT_PROBE_ENABLED", "true")
     prof = TP.get_transport_profile()


### PR DESCRIPTION
Live soak `bt-2026-07-18-023350` caught a wired-but-inert condition: the scout's catalog fetch mapped **25 DW models**, but neither the entitlement probe nor the new reasoning-compliance probe ran. The Autonomic Pacemaker passes `api_key=tier0._api_key`, which under Aegis is coerced to `""` (key confiscated server-side), and both probes guarded on `not api_key` → silent early-return on the production transport. The catalog GET worked only because `DwCatalogClient` already authenticates via the Aegis session vault.

**Fix (DRY):** `_probe_request_headers` composes the same session-vault + per-call-lease flow `complete_sync`/`DwCatalogClient` use. The probes POST to `/v1/chat/completions` — the Aegis *forwarding* path, which needs a per-call lease (unlike the catalog's `/v1/models` passthrough). Non-Aegis keeps the raw Bearer. Guards drop `not api_key` for `_probe_auth_available` (direct key OR Aegis); if auth can't be assembled, the probe **skips** rather than firing a lease-less 401 that pollutes the asymmetric signal.

So the scout now maps all three dimensions **live under Aegis** — entitlement (election matrix), batch-only, and reasoning-effort compliance — not just the catalog.

Tests (+2 = 12): probe runs under Aegis with empty direct key; skips when lease unavailable. 36 discovery/entitlement green (1 red = pre-existing Kimi classifier drift, stash-confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes capability-scout entitlement and reasoning-compliance probes so they run under Aegis. Probes now use session-vault auth with a per-call lease and skip cleanly if auth can’t be assembled.

- **Bug Fixes**
  - Added `_probe_request_headers` to build Aegis session auth + lease for `/v1/chat/completions`; falls back to Bearer off-Aegis.
  - Replaced `not api_key` guards with `_probe_auth_available` (supports Aegis or direct key).
  - Skip probes when no lease/auth is available to avoid 401 noise.
  - Added tests for running with an empty direct key under Aegis and for skipping when a lease can’t be acquired.

<sup>Written for commit 53f93802c6cc095eafe8acb3f4739ee089e8886c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

