### PR TITLE
feat(governance): deterministic Poison-Pill quarantine + fix Kimi classifier drift

### DIFF
--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -184,6 +184,12 @@ class FSMCheckpoint:
     # context, so the resume is demoted to PLAN to re-plan against current source
     # rather than fast-forwarding into corruption. Empty = drift-check skipped.
     repo_sha: str = ""
+    # Poison-Pill guard: how many times this checkpoint has been hydrated (a
+    # resume ATTEMPTED). Incremented + re-signed on disk BEFORE each re-inject,
+    # so a checkpoint that deterministically crashes the pipeline on resume can't
+    # loop forever — after the attempt ceiling it is shunted to the quarantine
+    # DLQ. Rides inside the HMAC-signed payload → the count is tamper-evident.
+    hydration_attempt_count: int = 0
     schema_version: int = _SCHEMA_VERSION
 
     def to_json(self) -> str:
@@ -381,6 +387,132 @@ def write_checkpoint(cp: FSMCheckpoint, *, base_dir: "Optional[str]" = None) -> 
         return path
     except Exception:  # noqa: BLE001
         return None
+
+
+# ---------------------------------------------------------------------------
+# Poison-Pill quarantine (2026-07-18)
+#
+# A checkpoint that deterministically CRASHES the pipeline on resume would loop
+# forever: hydrate → crash → reboot → hydrate the same checkpoint → crash …
+# This is NOT solved by a generic try/except (which would silently swallow the
+# fault and re-attempt anyway) but by a DETERMINISTIC counter: each hydration
+# increments hydration_attempt_count on disk (re-signed) BEFORE the re-inject, so
+# the increment survives even a hard crash mid-attempt. Past the ceiling the
+# checkpoint is shunted to a quarantine/ DLQ (the SAME move-to-subdir + HMAC-
+# signed-envelope pattern as expired/) and the loop proceeds to the next op —
+# pipeline survival over a single poisoned operation.
+# ---------------------------------------------------------------------------
+
+
+def hydration_max_attempts() -> int:
+    """Resume attempts before a checkpoint is quarantined as a poison pill
+    (env ``JARVIS_FSM_HYDRATION_MAX_ATTEMPTS``, default 3). NEVER raises."""
+    try:
+        raw = os.environ.get("JARVIS_FSM_HYDRATION_MAX_ATTEMPTS", "").strip()
+        n = int(raw) if raw else 3
+        return n if n >= 1 else 3
+    except Exception:  # noqa: BLE001
+        return 3
+
+
+def record_hydration_attempt(
+    cp: "FSMCheckpoint", *, base_dir: "Optional[str]" = None,
+) -> int:
+    """Increment ``hydration_attempt_count`` and PERSIST it (re-signed) before a
+    resume is attempted, so a crash mid-attempt cannot reset the count. Mutates
+    *cp* in place and returns the new count. On a write failure returns the
+    in-memory incremented count (still monotonic within the process). NEVER
+    raises."""
+    try:
+        cp.hydration_attempt_count = int(cp.hydration_attempt_count or 0) + 1
+    except Exception:  # noqa: BLE001
+        cp.hydration_attempt_count = 1
+    try:
+        write_checkpoint(cp, base_dir=base_dir)
+    except Exception:  # noqa: BLE001
+        pass
+    return cp.hydration_attempt_count
+
+
+def quarantine_dir(base_dir: "Optional[str]" = None) -> str:
+    """The poison-pill DLQ dir (``<checkpoints>/quarantine``). Created on demand.
+    NEVER raises."""
+    try:
+        d = os.path.join(checkpoint_dir(base_dir), "quarantine")
+        os.makedirs(d, exist_ok=True)
+        return d
+    except Exception:  # noqa: BLE001
+        return os.path.join(".ouroboros", "checkpoints", "quarantine")
+
+
+def quarantine_checkpoint(
+    cp: "FSMCheckpoint", *, reason: str, base_dir: "Optional[str]" = None,
+) -> "Optional[str]":
+    """Shunt a poison-pill checkpoint to the quarantine DLQ: re-sign it tagged
+    with the quarantine reason (inside the HMAC payload) into ``quarantine/`` and
+    remove it from the pending set, so it is never resumed again but stays
+    auditable (§8). Returns the quarantine path, or None on failure. NEVER
+    raises."""
+    try:
+        # Tag the state vector — carried inside the HMAC-signed payload (DRY:
+        # reuses the checkpoint envelope + signing; no separate DLQ schema).
+        try:
+            _lin = dict(cp.trace_lineage or {})
+            _lin["quarantined"] = True
+            _lin["quarantine_reason"] = str(reason)
+            _lin["quarantine_attempts"] = int(cp.hydration_attempt_count or 0)
+            cp.trace_lineage = _lin
+        except Exception:  # noqa: BLE001
+            pass
+        d = quarantine_dir(base_dir)
+        payload_json = cp.to_json()
+        sig = _sign(payload_json, _checkpoint_key(base_dir))
+        wrapper = json.dumps(
+            {"schema": _SCHEMA_VERSION, "payload": payload_json, "hmac": sig}
+        )
+        path = os.path.join(d, "%s.json" % cp.op_id)
+        tmp = path + ".tmp"
+        with open(tmp, "w", encoding="utf-8") as fh:
+            fh.write(wrapper)
+        os.replace(tmp, path)
+        # Remove from the pending set (best-effort) so it is not re-hydrated.
+        try:
+            pending_path = os.path.join(checkpoint_dir(base_dir), "%s.json" % cp.op_id)
+            if os.path.isfile(pending_path):
+                os.remove(pending_path)
+        except Exception:  # noqa: BLE001
+            pass
+        logger.warning(
+            "[fsm_checkpoint] QUARANTINED op=%s attempts=%d reason=%s -> "
+            "poison-pill DLQ (quarantine/); pipeline proceeds to the next op",
+            cp.op_id, int(cp.hydration_attempt_count or 0), reason,
+        )
+        return path
+    except Exception:  # noqa: BLE001
+        logger.debug("[fsm_checkpoint] quarantine write failed", exc_info=True)
+        return None
+
+
+def list_quarantined(*, base_dir: "Optional[str]" = None) -> List[FSMCheckpoint]:
+    """Read the quarantine DLQ (HMAC-verified). Observability only — these are
+    NEVER resumed. NEVER raises."""
+    out: List[FSMCheckpoint] = []
+    try:
+        d = quarantine_dir(base_dir)
+        key = _checkpoint_key(base_dir)
+        for name in sorted(os.listdir(d)):
+            if not name.endswith(".json"):
+                continue
+            try:
+                raw = json.loads(open(os.path.join(d, name), encoding="utf-8").read())
+                payload = raw.get("payload", "")
+                if _verify(payload, raw.get("hmac", ""), key):
+                    out.append(FSMCheckpoint.from_json(payload))
+            except Exception:  # noqa: BLE001
+                continue
+    except Exception:  # noqa: BLE001
+        pass
+    return out
 
 
 def _checkpoint_ttl_s() -> float:

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -1265,6 +1265,28 @@ class UnifiedIntakeRouter:
             # scheduling each re-inject and consuming the checkpoint on success.
             _pending = _ckpt.list_pending()
             for _cp in _pending:
+                # Poison-Pill guard (DETERMINISTIC, not a swallow): persist the
+                # incremented hydration count BEFORE attempting the resume, so a
+                # checkpoint that crashes the pipeline on resume can't loop
+                # forever. Past the ceiling it is shunted to the quarantine DLQ
+                # and the loop proceeds to the next op — pipeline survival.
+                try:
+                    _attempt = _ckpt.record_hydration_attempt(_cp)
+                    if _attempt > _ckpt.hydration_max_attempts():
+                        _ckpt.quarantine_checkpoint(
+                            _cp, reason="hydration_attempts_exhausted",
+                        )
+                        logger.warning(
+                            "Router: QUARANTINED poison-pill op=%s after %d "
+                            "resume attempts -> DLQ; proceeding to next op",
+                            _cp.op_id, _attempt - 1,
+                        )
+                        continue
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "Router: hydration-attempt guard faulted op=%s",
+                        getattr(_cp, "op_id", "?"), exc_info=True,
+                    )
                 try:
                     _env = _ckpt.build_resume_envelope(_cp)
                     await _reinject(_env)

--- a/tests/governance/test_dw_discovery_runner.py
+++ b/tests/governance/test_dw_discovery_runner.py
@@ -262,10 +262,16 @@ async def test_run_discovery_registers_newly_quarantined(
 ) -> None:
     """Models with both param_count_b AND pricing missing → ambiguous
     → registered as quarantined in the ledger."""
+    # NOTE (2026-07-18): the earlier fixture used ``moonshotai/Kimi-K2.6`` as an
+    # "ambiguous" example, but Slice 82's curated ``_KNOWN_MODEL_PARAMS_B`` now
+    # resolves ``kimi-k2`` → 1000B (Kimi K2 genuinely is a ~1T MoE), so it is
+    # correctly NON-ambiguous and NOT quarantined. Use ids that carry NO
+    # parseable size token AND are not in the curated known-params list.
     body = {"data": [
-        {"id": "moonshotai/Kimi-K2.6"},                # ambiguous
+        {"id": "acme/mystery-model"},                  # ambiguous (unknown vendor)
         {"id": "vendor/no-suffix-id"},                 # ambiguous
         {"id": "Qwen/Qwen3.5-397B-A17B"},              # has params
+        {"id": "moonshotai/Kimi-K2.6"},                # curated → NOT ambiguous
     ]}
     session = _mock_session(body)
     result = await run_discovery(
@@ -275,13 +281,14 @@ async def test_run_discovery_registers_newly_quarantined(
         ledger=isolated_ledger,
         cache_path=isolated_cache,
     )
-    assert "moonshotai/Kimi-K2.6" in result.newly_quarantined
+    assert "acme/mystery-model" in result.newly_quarantined
     assert "vendor/no-suffix-id" in result.newly_quarantined
     # Ledger now knows about them
-    assert isolated_ledger.is_quarantined("moonshotai/Kimi-K2.6") is True
+    assert isolated_ledger.is_quarantined("acme/mystery-model") is True
     assert isolated_ledger.is_quarantined("vendor/no-suffix-id") is True
-    # Non-ambiguous model NOT in newly_quarantined
+    # Models with a resolvable param count (parsed OR curated) are NOT ambiguous.
     assert "Qwen/Qwen3.5-397B-A17B" not in result.newly_quarantined
+    assert "moonshotai/Kimi-K2.6" not in result.newly_quarantined
 
 
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_fsm_poison_pill_quarantine.py
+++ b/tests/governance/test_fsm_poison_pill_quarantine.py
@@ -1,0 +1,176 @@
+"""Poison-Pill Quarantine — deterministic survival of a crash-on-resume checkpoint.
+
+A checkpoint that deterministically crashes the pipeline when hydrated would loop
+forever (hydrate → crash → reboot → hydrate the SAME checkpoint → crash …). This
+is NOT solved by a generic try/except (which swallows the fault and re-attempts
+anyway) but by a DETERMINISTIC counter: ``hydration_attempt_count`` is incremented
++ re-signed on disk BEFORE each resume, so the increment survives a hard crash
+mid-attempt. Past the ceiling (default 3) the checkpoint is shunted to a
+quarantine DLQ — reusing the SAME move-to-subdir + HMAC-signed-envelope pattern
+as ``expired/`` (no novel DLQ schema) — and the loop proceeds to the next op.
+
+These tests pin: the count rides inside the HMAC payload (tamper-evident), it
+increments across simulated reboots (re-read from disk), a poison pill that
+raises during processing is quarantined on the threshold breach, and the DLQ is
+tagged with the ``quarantined`` state vector while the pending set is cleared.
+"""
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from backend.core.ouroboros.governance import fsm_checkpoint as CK
+
+
+@pytest.fixture()
+def base(tmp_path, monkeypatch):
+    monkeypatch.delenv("JARVIS_FSM_HYDRATION_MAX_ATTEMPTS", raising=False)
+    monkeypatch.delenv("JARVIS_CHECKPOINT_HMAC_SECRET", raising=False)
+    return str(tmp_path)
+
+
+def _write(base, op_id="op-x", phase="GENERATE", count=0):
+    cp = CK.FSMCheckpoint(
+        op_id=op_id, phase=phase, goal_description="g", target_files=["a.py"],
+        hydration_attempt_count=count,
+    )
+    CK.write_checkpoint(cp, base_dir=base)
+    return cp
+
+
+# ---------------------------------------------------------------------------
+# The counter rides inside the HMAC-signed payload (tamper-evident)
+# ---------------------------------------------------------------------------
+
+
+def test_hydration_count_persists_and_is_hmac_signed(base):
+    _write(base, count=0)
+    cp = CK.list_pending(base_dir=base)[0]
+    assert cp.hydration_attempt_count == 0
+    CK.record_hydration_attempt(cp, base_dir=base)
+    # Re-read from disk (a fresh "reboot") — the count survived.
+    cp2 = CK.list_pending(base_dir=base)[0]
+    assert cp2.hydration_attempt_count == 1
+    # It is inside the signed payload: hand-tamper the count → HMAC verify fails
+    # → the checkpoint is dropped from pending (never resumed with a forged count).
+    path = os.path.join(CK.checkpoint_dir(base), "op-x.json")
+    raw = json.loads(open(path).read())
+    payload = json.loads(raw["payload"])
+    payload["hydration_attempt_count"] = 0            # forge the count back down
+    raw["payload"] = json.dumps(payload, sort_keys=True)
+    open(path, "w").write(json.dumps(raw))            # same hmac, tampered payload
+    assert CK.list_pending(base_dir=base) == []       # HMAC rejects the forgery
+
+
+def test_count_increments_across_simulated_reboots(base):
+    _write(base, count=0)
+    for expected in (1, 2, 3):
+        cp = CK.list_pending(base_dir=base)[0]        # fresh read each "boot"
+        assert CK.record_hydration_attempt(cp, base_dir=base) == expected
+
+
+# ---------------------------------------------------------------------------
+# THE poison pill — corrupted payload raises during processing → quarantine
+# ---------------------------------------------------------------------------
+
+
+def _router_hydrate_pass(base, *, reinject):
+    """Mirror the router's per-checkpoint hydrate decision: increment BEFORE the
+    attempt; quarantine past the ceiling; else re-inject (which may raise)."""
+    resumed, quarantined = [], []
+    for cp in CK.list_pending(base_dir=base):
+        attempt = CK.record_hydration_attempt(cp, base_dir=base)
+        if attempt > CK.hydration_max_attempts():
+            CK.quarantine_checkpoint(cp, reason="hydration_attempts_exhausted", base_dir=base)
+            quarantined.append(cp.op_id)
+            continue
+        try:
+            reinject(cp)                              # the "processing" step
+            CK.mark_resumed(cp.op_id, base_dir=base)
+            resumed.append(cp.op_id)
+        except Exception:                             # noqa: BLE001 — left pending, retried next boot
+            pass
+    return resumed, quarantined
+
+
+def test_poison_pill_quarantined_on_threshold_breach(base):
+    _write(base, op_id="op-poison", count=0)
+
+    def _always_crashes(cp):
+        raise RuntimeError("deterministic crash on resume (poison pill)")
+
+    # 3 reboots each re-attempt and crash (left pending); the 4th quarantines.
+    for boot in (1, 2, 3):
+        resumed, quarantined = _router_hydrate_pass(base, reinject=_always_crashes)
+        assert resumed == [] and quarantined == []
+        assert len(CK.list_pending(base_dir=base)) == 1   # still pending
+
+    resumed, quarantined = _router_hydrate_pass(base, reinject=_always_crashes)
+    assert quarantined == ["op-poison"]               # shunted to DLQ
+    assert CK.list_pending(base_dir=base) == []        # no longer resumed
+
+    dlq = CK.list_quarantined(base_dir=base)
+    assert [c.op_id for c in dlq] == ["op-poison"]
+    tag = dlq[0].trace_lineage
+    assert tag.get("quarantined") is True
+    assert tag.get("quarantine_reason") == "hydration_attempts_exhausted"
+
+
+def test_healthy_op_resumes_and_never_quarantines(base):
+    _write(base, op_id="op-ok", count=0)
+    resumed, quarantined = _router_hydrate_pass(base, reinject=lambda cp: None)
+    assert resumed == ["op-ok"] and quarantined == []
+    assert CK.list_pending(base_dir=base) == []        # consumed on success
+    assert CK.list_quarantined(base_dir=base) == []
+
+
+def test_one_poison_pill_does_not_block_the_next_op(base):
+    # Pipeline survival: a poisoned op is quarantined while a healthy one resumes.
+    _write(base, op_id="op-poison", count=CK.hydration_max_attempts())  # one more = breach
+    _write(base, op_id="op-healthy", count=0)
+
+    def _selective(cp):
+        if cp.op_id == "op-poison":
+            raise RuntimeError("crash")
+
+    resumed, quarantined = _router_hydrate_pass(base, reinject=_selective)
+    assert "op-poison" in quarantined                  # DLQ'd
+    assert "op-healthy" in resumed                      # NOT blocked
+    assert CK.list_quarantined(base_dir=base)[0].op_id == "op-poison"
+
+
+# ---------------------------------------------------------------------------
+# Config + robustness
+# ---------------------------------------------------------------------------
+
+
+def test_max_attempts_env_tunable(base, monkeypatch):
+    monkeypatch.setenv("JARVIS_FSM_HYDRATION_MAX_ATTEMPTS", "1")
+    assert CK.hydration_max_attempts() == 1
+    _write(base, op_id="op-strict", count=0)
+    # attempt 1 (<=1 → re-inject), attempt 2 (>1 → quarantine)
+    _router_hydrate_pass(base, reinject=lambda cp: (_ for _ in ()).throw(RuntimeError()))
+    _, quarantined = _router_hydrate_pass(base, reinject=lambda cp: None)
+    assert quarantined == ["op-strict"]
+
+
+@pytest.mark.parametrize("bad", ["", "0", "-3", "abc"])
+def test_max_attempts_invalid_falls_back_to_3(base, monkeypatch, bad):
+    monkeypatch.setenv("JARVIS_FSM_HYDRATION_MAX_ATTEMPTS", bad)
+    assert CK.hydration_max_attempts() == 3
+
+
+def test_quarantine_never_raises_on_bad_dir(monkeypatch):
+    # A write failure must degrade, not raise into the hydrate loop.
+    cp = CK.FSMCheckpoint(op_id="op-x", phase="GENERATE")
+    monkeypatch.setattr(CK, "quarantine_dir", lambda base_dir=None: "/proc/nonexistent/x")
+    assert CK.quarantine_checkpoint(cp, reason="x", base_dir=None) is None
+
+
+def test_record_attempt_never_raises_on_write_failure(monkeypatch):
+    cp = CK.FSMCheckpoint(op_id="op-x", phase="GENERATE", hydration_attempt_count=2)
+    monkeypatch.setattr(CK, "write_checkpoint", lambda *a, **k: (_ for _ in ()).throw(OSError()))
+    # In-memory increment still monotonic even if persistence fails.
+    assert CK.record_hydration_attempt(cp) == 3


### PR DESCRIPTION
## Poison-Pill quarantine — FSM hydration crash-loop guard

A checkpoint that deterministically crashes the pipeline on resume would loop forever (hydrate → crash → reboot → hydrate the SAME checkpoint → crash). Solved **not** with a generic try/except (which swallows + re-attempts anyway) but with a **deterministic counter**:

- `FSMCheckpoint.hydration_attempt_count` — inside the **HMAC-signed payload**, so the count is tamper-evident (a forged count fails verify → dropped from pending).
- The router's `_hydrate_fsm_checkpoints` loop calls `record_hydration_attempt` (increment + re-sign + **persist**) **before** each re-inject, so the increment survives a hard crash mid-attempt.
- Past `JARVIS_FSM_HYDRATION_MAX_ATTEMPTS` (default 3), the checkpoint is `quarantine_checkpoint`-ed to a DLQ and the loop `continue`s to the next op — **pipeline survival** over one poisoned operation.

**DRY:** the DLQ reuses the **existing** checkpoint envelope — same move-to-subdir + HMAC-signed `{schema,payload,hmac}` pattern as `expired/` (no novel DLQ database), and the `quarantined` state vector rides inside `trace_lineage` in the signed payload (the tag-and-preserve pattern applied to FSM state). `list_quarantined` reads it back HMAC-verified for audit; quarantined ops are never resumed.

## Kimi classifier-drift test — fixed at root

The test used `moonshotai/Kimi-K2.6` as an "ambiguous" model, but Slice 82's curated `_KNOWN_MODEL_PARAMS_B` now resolves `kimi-k2` → 1000B (Kimi K2 genuinely is a ~1T MoE), so it's correctly non-ambiguous. The classifier is right; the test's example was stale (an assertion mismatch against the now-dynamic catalog). Replaced with genuinely-ambiguous ids + a positive assertion that Kimi is NOT quarantined.

## Tests (12 new)
Count rides the HMAC payload (forge → rejected), increments across simulated reboots, poison pill quarantined on the 4th hydrate, healthy op resumes + never quarantines, **one poison pill does not block the next op**, env-tunable + invalid→3, never-raise on bad DLQ dir / write failure. **61 across the checkpoint + discovery spine green** (the previously-red Kimi test now passes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a deterministic poison‑pill quarantine to stop infinite crash loops when hydrating FSM checkpoints. Also updates discovery tests to reflect the curated Kimi model so ambiguous classification stays accurate.

- **New Features**
  - Added `hydration_attempt_count` to the HMAC‑signed checkpoint payload (tamper‑evident).
  - Router persists the increment before each resume; survives hard crashes.
  - Exceeding `JARVIS_FSM_HYDRATION_MAX_ATTEMPTS` (default 3) moves the checkpoint to a `quarantine/` DLQ and removes it from pending; processing continues with the next op.
  - DLQ reuses the signed checkpoint envelope and tags `trace_lineage` with quarantine metadata; `list_quarantined` provides audit-only reads.

- **Bug Fixes**
  - Replaced `moonshotai/Kimi-K2.6` in discovery tests with truly ambiguous model IDs and added a positive check that Kimi is not quarantined.

<sup>Written for commit 648e64461385d6f67d66c13dc129cd5e7c1acea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

