### PR TITLE
feat(governance): Atomic Workspace Checkpointing — resume a mid-mutation op across the FSM boundary

### DIFF
--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -190,6 +190,13 @@ class FSMCheckpoint:
     # loop forever — after the attempt ceiling it is shunted to the quarantine
     # DLQ. Rides inside the HMAC-signed payload → the count is tamper-evident.
     hydration_attempt_count: int = 0
+    # Atomic Workspace Checkpoint: raw ``git stash create`` SHA of the dirty
+    # working-tree delta at suspend time. Bound INSIDE the HMAC payload (tamper-
+    # evident). On hydration the delta is re-applied by this SHA, so an op
+    # suspended MID-MUTATION resumes against its own uncommitted changes even if
+    # the tree was cleaned across the boundary (rollback / worktree teardown /
+    # a cloud node's fresh checkout). Empty = the tree was clean at suspend.
+    workspace_stash_ref: str = ""
     schema_version: int = _SCHEMA_VERSION
 
     def to_json(self) -> str:
@@ -591,6 +598,72 @@ def list_pending(*, base_dir: "Optional[str]" = None) -> List[FSMCheckpoint]:
     return out
 
 
+def workspace_stash_enabled() -> bool:
+    """``JARVIS_FSM_WORKSPACE_STASH_ENABLED`` (default ON). When on, a dirty
+    working tree is snapshotted (``git stash create``) at suspend and re-applied
+    at hydration — Atomic Workspace Checkpointing. NEVER raises."""
+    return os.environ.get(
+        "JARVIS_FSM_WORKSPACE_STASH_ENABLED", "true",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def workspace_root() -> str:
+    """The git working-tree root the in-flight ops mutate. Env
+    ``JARVIS_FSM_WORKSPACE_ROOT`` (for tests) else the process cwd. NEVER
+    raises."""
+    try:
+        raw = os.environ.get("JARVIS_FSM_WORKSPACE_ROOT", "").strip()
+        return raw or os.getcwd()
+    except Exception:  # noqa: BLE001
+        return "."
+
+
+def restore_workspace_stash(stash_ref: str) -> bool:
+    """HYDRATE: re-apply a suspended op's dirty working-tree delta by its raw
+    ``git stash`` SHA (from the checkpoint payload) via the shared sync helper
+    (DRY). Returns True on a clean apply; False (fail-soft) if stashing is
+    disabled, the ref is empty/invalid, or the apply conflicts (e.g. the delta
+    is already present because the tree was never cleaned) — the op resumes
+    regardless. NEVER raises."""
+    if not workspace_stash_enabled() or not stash_ref:
+        return False
+    try:
+        from backend.core.ouroboros.governance.workspace_checkpoint import (  # noqa: PLC0415
+            apply_stash_ref,
+        )
+        ok = apply_stash_ref(workspace_root(), stash_ref)
+        if ok:
+            logger.warning(
+                "[fsm_checkpoint] atomic workspace RESTORED stash=%s "
+                "(dirty-tree delta re-applied — op resumes mid-mutation)",
+                str(stash_ref)[:12],
+            )
+        return ok
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _capture_workspace_stash() -> str:
+    """Snapshot the dirty working tree ONCE per suspend via the shared sync
+    stash helper (DRY — no VC logic here). Returns the raw SHA, or "" when the
+    tree is clean / stashing disabled / git fails. NEVER raises."""
+    if not workspace_stash_enabled():
+        return ""
+    try:
+        from backend.core.ouroboros.governance.workspace_checkpoint import (  # noqa: PLC0415
+            create_stash_ref,
+        )
+        ref = create_stash_ref(workspace_root()) or ""
+        if ref:
+            logger.info(
+                "[fsm_checkpoint] atomic workspace stash created sha=%s "
+                "(dirty working-tree delta snapshotted for resume)", ref[:12],
+            )
+        return ref
+    except Exception:  # noqa: BLE001
+        return ""
+
+
 def capture_inflight(*, base_dir: "Optional[str]" = None, reason: str = "wall_clock_cap") -> int:
     """SUSPEND: on graceful shutdown (wall-clock cap / SIGTERM preemption), read the
     in-flight registry and serialize a signed checkpoint for each active op (from its
@@ -602,7 +675,12 @@ def capture_inflight(*, base_dir: "Optional[str]" = None, reason: str = "wall_cl
         from backend.core.ouroboros.governance.in_flight_registry import (  # noqa: PLC0415
             get_default_registry,
         )
-        for rec in get_default_registry().snapshot():
+        _records = list(get_default_registry().snapshot())
+        # Atomic Workspace Checkpoint: snapshot the dirty tree ONCE (session-wide,
+        # not per-op) and stamp the same ref on every in-flight checkpoint. Only
+        # bother if there IS something to suspend.
+        _workspace_stash = _capture_workspace_stash() if _records else ""
+        for rec in _records:
             try:
                 ctx = getattr(rec, "ctx_ref", None)
                 if ctx is None:
@@ -611,6 +689,8 @@ def capture_inflight(*, base_dir: "Optional[str]" = None, reason: str = "wall_cl
                     ctx, phase=getattr(rec, "last_phase_name", "") or "GENERATE",
                     resume_reason=reason,
                 )
+                if cp is not None:
+                    cp.workspace_stash_ref = _workspace_stash
                 if cp is not None and write_checkpoint(cp, base_dir=base_dir):
                     n += 1
                     logger.info(

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -1264,6 +1264,23 @@ class UnifiedIntakeRouter:
             # hydrate_pending_checkpoints wants a sync ingest_fn; bridge to async by
             # scheduling each re-inject and consuming the checkpoint on success.
             _pending = _ckpt.list_pending()
+            # Atomic Workspace Checkpoint restore (before any re-inject): re-apply
+            # each distinct dirty-tree stash ONCE, so an op suspended mid-mutation
+            # resumes against its own uncommitted delta even if the tree was
+            # cleaned across the boundary. Fail-soft (already-present/conflict is
+            # fine — the op resumes regardless).
+            _applied_stashes: set = set()
+            for _cp in _pending:
+                _ws_ref = getattr(_cp, "workspace_stash_ref", "") or ""
+                if _ws_ref and _ws_ref not in _applied_stashes:
+                    _applied_stashes.add(_ws_ref)
+                    try:
+                        _ckpt.restore_workspace_stash(_ws_ref)
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "Router: workspace stash restore faulted ref=%s",
+                            _ws_ref[:12], exc_info=True,
+                        )
             for _cp in _pending:
                 # Poison-Pill guard (DETERMINISTIC, not a swallow): persist the
                 # incremented hydration count BEFORE attempting the resume, so a

--- a/backend/core/ouroboros/governance/workspace_checkpoint.py
+++ b/backend/core/ouroboros/governance/workspace_checkpoint.py
@@ -69,6 +69,62 @@ _MAX_CHECKPOINTS = _env_int("JARVIS_MAX_CHECKPOINTS", 20)
 _SHA_RE = re.compile(r"^[0-9a-f]{40}$")
 
 
+# ---------------------------------------------------------------------------
+# Synchronous stash helpers (2026-07-18) — the SYNC siblings of the async
+# WorkspaceCheckpointManager, for the sync signal-handler suspend path
+# (fsm_checkpoint.capture_inflight) and the cross-reboot restore path (which
+# applies a RAW SHA from the FSM payload — the async manager's restore_checkpoint
+# only knows in-memory checkpoint_ids and cannot survive a reboot). ALL git-stash
+# version-control logic lives here in ONE module (no VC logic in fsm_checkpoint).
+# ---------------------------------------------------------------------------
+
+
+def create_stash_ref(
+    project_root: "os.PathLike | str", *, timeout_s: Optional[float] = None,
+) -> Optional[str]:
+    """``git stash create -u`` — a NON-DESTRUCTIVE snapshot of the dirty working
+    tree (index + untracked). Returns the raw stash-commit SHA, or None when the
+    tree is CLEAN (nothing to snapshot) or git fails/times out. The delta stays
+    in the working tree (create, not push), so this only SNAPSHOTS — it never
+    reverts. NEVER raises."""
+    import subprocess  # noqa: PLC0415
+    to = timeout_s if timeout_s is not None else _env_float("JARVIS_CHECKPOINT_TIMEOUT_S", 8.0)
+    try:
+        proc = subprocess.run(
+            ["git", "stash", "create", "-u"],
+            cwd=str(project_root), capture_output=True, text=True, timeout=to,
+        )
+        if proc.returncode != 0:
+            return None
+        sha = (proc.stdout or "").strip()
+        return sha if sha and _SHA_RE.fullmatch(sha) else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def apply_stash_ref(
+    project_root: "os.PathLike | str", stash_ref: str,
+    *, timeout_s: Optional[float] = None,
+) -> bool:
+    """``git stash apply <sha>`` — re-apply a stash-create snapshot's delta onto
+    the working tree by RAW SHA (survives a reboot; no in-memory stash list
+    needed, per the module docstring). Returns True on a clean apply. NEVER
+    raises. A conflict / already-applied delta returns False (the caller treats
+    that as fail-soft — the op resumes regardless)."""
+    if not stash_ref or not _SHA_RE.fullmatch(str(stash_ref)):
+        return False
+    import subprocess  # noqa: PLC0415
+    to = timeout_s if timeout_s is not None else _env_float("JARVIS_CHECKPOINT_TIMEOUT_S", 8.0)
+    try:
+        proc = subprocess.run(
+            ["git", "stash", "apply", str(stash_ref)],
+            cwd=str(project_root), capture_output=True, text=True, timeout=to,
+        )
+        return proc.returncode == 0
+    except Exception:  # noqa: BLE001
+        return False
+
+
 @dataclass
 class Checkpoint:
     checkpoint_id: str

--- a/tests/governance/test_fsm_workspace_stash.py
+++ b/tests/governance/test_fsm_workspace_stash.py
@@ -1,0 +1,185 @@
+"""Atomic Workspace Checkpointing — a mid-mutation op survives the FSM boundary.
+
+When a graceful shutdown traps an op mid-mutation with a dirty git index, the
+suspend serializer snapshots the working-tree delta (``git stash create -u``,
+non-destructive) and binds the raw stash SHA INSIDE the HMAC-signed FSM payload.
+On hydration the delta is re-applied by that SHA — so the op resumes against its
+own uncommitted changes even if the tree was cleaned across the boundary
+(rollback / worktree teardown / a cloud node's fresh checkout).
+
+These tests use a REAL throwaway git repo (no mock VC) to pin: the stash/apply
+round-trip restores a cleaned delta, a clean tree produces no ref, capture_inflight
+stamps the ref onto the checkpoint and it survives the HMAC envelope, and a
+disabled master / bad ref degrade fail-soft.
+"""
+from __future__ import annotations
+
+import os
+import subprocess
+
+import pytest
+
+from backend.core.ouroboros.governance import fsm_checkpoint as CK
+from backend.core.ouroboros.governance import in_flight_registry as R
+from backend.core.ouroboros.governance import workspace_checkpoint as WC
+
+
+def _git(repo, *args):
+    return subprocess.run(
+        ["git", *args], cwd=repo, capture_output=True, text=True,
+    )
+
+
+@pytest.fixture()
+def repo(tmp_path):
+    d = str(tmp_path / "wt")
+    os.makedirs(d)
+    _git(d, "init", "-q")
+    _git(d, "config", "user.email", "t@t")
+    _git(d, "config", "user.name", "t")
+    (tmp_path / "wt" / "code.py").write_text("def foo():\n    return 1\n")
+    _git(d, "add", "-A")
+    _git(d, "commit", "-qm", "base")
+    return d
+
+
+def _dirty(repo, content="def foo():\n    return 42  # EDIT\n"):
+    with open(os.path.join(repo, "code.py"), "w") as fh:
+        fh.write(content)
+
+
+def _clean(repo):
+    _git(repo, "checkout", "--", "code.py")
+
+
+def _read(repo):
+    return open(os.path.join(repo, "code.py")).read()
+
+
+# ---------------------------------------------------------------------------
+# Core mechanism — stash create (non-destructive) + apply by raw SHA
+# ---------------------------------------------------------------------------
+
+
+def test_stash_create_apply_round_trip_restores_cleaned_delta(repo):
+    _dirty(repo)
+    ref = WC.create_stash_ref(repo)
+    assert ref and len(ref) == 40
+    # create is NON-destructive — the delta is still in the tree.
+    assert "EDIT" in _read(repo)
+    # Simulate the tree being cleaned across the boundary.
+    _clean(repo)
+    assert "EDIT" not in _read(repo)
+    # Hydrate: re-apply by raw SHA.
+    assert WC.apply_stash_ref(repo, ref) is True
+    assert "EDIT" in _read(repo)
+
+
+def test_clean_tree_produces_no_stash(repo):
+    assert WC.create_stash_ref(repo) is None
+
+
+@pytest.mark.parametrize("bad", ["", "not-a-sha", "z" * 40, "abc123"])
+def test_apply_bad_ref_is_failsoft(repo, bad):
+    assert WC.apply_stash_ref(repo, bad) is False
+
+
+def test_apply_dangling_but_unknown_sha_returns_false(repo):
+    # A well-formed but non-existent SHA → git errors → False, never raises.
+    assert WC.apply_stash_ref(repo, "0" * 40) is False
+
+
+# ---------------------------------------------------------------------------
+# Suspend integration — capture_inflight stamps the ref; HMAC round-trip
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def wired(monkeypatch, repo):
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FSM_WORKSPACE_STASH_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FSM_WORKSPACE_ROOT", repo)
+    R.reset_default_registry()
+    yield
+    R.reset_default_registry()
+
+
+class _Ctx:
+    def __init__(self, op_id):
+        self.op_id = op_id
+        self.description = "mutate code.py"
+        self.target_files = ["code.py"]
+        self.phase = "GENERATE"
+
+
+def test_capture_inflight_stamps_stash_ref_and_survives_hmac(wired, repo, tmp_path):
+    base = str(tmp_path / "ck")
+    _dirty(repo)
+    R.register_op_safely("op-mut", ctx_ref=_Ctx("op-mut"), last_phase_name="GENERATE")
+
+    n = CK.capture_inflight(base_dir=base, reason="wall_clock_cap")
+    assert n == 1
+    cp = CK.list_pending(base_dir=base)[0]        # re-read from disk (HMAC-verified)
+    assert cp.workspace_stash_ref and len(cp.workspace_stash_ref) == 40
+
+    # END-TO-END: clean the tree, then hydrate-restore by the checkpoint's ref.
+    _clean(repo)
+    assert "EDIT" not in _read(repo)
+    assert CK.restore_workspace_stash(cp.workspace_stash_ref) is True
+    assert "EDIT" in _read(repo)
+
+
+def test_clean_tree_stamps_empty_ref(wired, repo, tmp_path):
+    base = str(tmp_path / "ck")
+    # tree is clean (no _dirty)
+    R.register_op_safely("op-clean", ctx_ref=_Ctx("op-clean"), last_phase_name="GENERATE")
+    CK.capture_inflight(base_dir=base, reason="wall_clock_cap")
+    cp = CK.list_pending(base_dir=base)[0]
+    assert cp.workspace_stash_ref == ""
+
+
+def test_stash_ref_is_hmac_bound(wired, repo, tmp_path):
+    import json
+    base = str(tmp_path / "ck")
+    _dirty(repo)
+    R.register_op_safely("op-h", ctx_ref=_Ctx("op-h"), last_phase_name="GENERATE")
+    CK.capture_inflight(base_dir=base, reason="wall_clock_cap")
+    # Forge the stash ref in the payload without re-signing → HMAC verify fails.
+    path = os.path.join(CK.checkpoint_dir(base), "op-h.json")
+    raw = json.loads(open(path).read())
+    payload = json.loads(raw["payload"])
+    payload["workspace_stash_ref"] = "f" * 40          # forged
+    raw["payload"] = json.dumps(payload, sort_keys=True)
+    open(path, "w").write(json.dumps(raw))
+    assert CK.list_pending(base_dir=base) == []          # rejected
+
+
+# ---------------------------------------------------------------------------
+# Master switch + robustness
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_captures_no_stash(monkeypatch, repo, tmp_path):
+    monkeypatch.setenv("JARVIS_FSM_CHECKPOINT_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_FSM_WORKSPACE_STASH_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_FSM_WORKSPACE_ROOT", repo)
+    R.reset_default_registry()
+    base = str(tmp_path / "ck")
+    _dirty(repo)
+    R.register_op_safely("op-off", ctx_ref=_Ctx("op-off"), last_phase_name="GENERATE")
+    CK.capture_inflight(base_dir=base, reason="wall_clock_cap")
+    cp = CK.list_pending(base_dir=base)[0]
+    assert cp.workspace_stash_ref == ""
+    # restore is a no-op when disabled
+    assert CK.restore_workspace_stash("a" * 40) is False
+    R.reset_default_registry()
+
+
+def test_restore_empty_ref_is_noop(monkeypatch):
+    monkeypatch.setenv("JARVIS_FSM_WORKSPACE_STASH_ENABLED", "true")
+    assert CK.restore_workspace_stash("") is False
+
+
+def test_helpers_never_raise_on_bad_root():
+    assert WC.create_stash_ref("/proc/nonexistent/xyz") is None
+    assert WC.apply_stash_ref("/proc/nonexistent/xyz", "a" * 40) is False


### PR DESCRIPTION
Closes the Dirty Workspace edge case: an op suspended MID-MUTATION previously resumed against a clean/reverted tree, losing its uncommitted code changes.

**DRY:** the git-stash machinery already exists (`workspace_checkpoint.WorkspaceCheckpointManager`: `git stash create -u` / `apply`), but its restore is an in-memory `checkpoint_id` lookup that can't survive a reboot. So I added **sync** module siblings `create_stash_ref`/`apply_stash_ref` (all VC logic stays in `workspace_checkpoint.py`) — sync because `capture_inflight` runs in the signal handler, and cross-reboot restore applies the **raw SHA from the FSM payload**.

- **Suspend** (`capture_inflight`): once per shutdown, a dirty tree is snapshotted non-destructively; the raw SHA is stamped on every checkpoint's new `FSMCheckpoint.workspace_stash_ref` — **inside the HMAC payload** (forge → verify fails → dropped).
- **Resume** (`_hydrate_fsm_checkpoints`): before any re-inject, each distinct stash ref is re-applied via `git stash apply <sha>`, so the op resumes against its own delta even if the tree was **cleaned across the boundary** (rollback / worktree teardown / cloud fresh-checkout). Fail-soft throughout. Master `JARVIS_FSM_WORKSPACE_STASH_ENABLED` (default on).

**Tests (13, real throwaway git repo, no mock VC):** stash/apply round-trip restores a *cleaned* delta; clean tree → no ref; `capture_inflight` stamps the ref + survives the HMAC envelope end-to-end (dirty→suspend→clean→hydrate-restore→delta back); ref is HMAC-bound; disabled/empty/bad-root fail-soft. **49 across the checkpoint spine green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Atomic Workspace Checkpointing to let mid-mutation ops resume with their uncommitted changes across FSM restarts. Prevents losing in-progress edits when the repo is cleaned or a node reboots.

- **New Features**
  - Added sync helpers `create_stash_ref` and `apply_stash_ref` using `git stash create -u` and `git stash apply <sha>`.
  - Suspend: snapshot the dirty tree once and stamp the raw SHA into the HMAC-signed `FSMCheckpoint.workspace_stash_ref` for each in-flight op.
  - Resume: before reinject, de-duplicate and re-apply each stash by SHA; fail-soft on conflicts or no-op cases.
  - Env controls: `JARVIS_FSM_WORKSPACE_STASH_ENABLED` (default on), `JARVIS_FSM_WORKSPACE_ROOT` (for tests).

<sup>Written for commit 147c1bc5d80900b1f00630184d90405295dfed82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

