### PR TITLE
feat(cli+governance): CLI product wiring batch — chat bridge, flow streaming, ov status, liquidity surfaces, IPC audio bridge, design-language enforcement, curiosity observability

### DIFF
--- a/backend/audio/audio_pipeline_bootstrap.py
+++ b/backend/audio/audio_pipeline_bootstrap.py
@@ -61,6 +61,7 @@ class PipelineHandle:
     _bargein_vad_consumer: object = None  # stored for unregister on shutdown
     karen: object = None  # Sprint 3: full-duplex control layer (env-gated mount)
     voice_build: object = None  # Sprint 4: voice->build bridge (env-gated mount)
+    audio_ipc: object = None  # 2026-07-18: audio-state UDS broadcaster (ov CLI subscribes)
 
     def get_status(self) -> dict:
         """Aggregate status from all components."""
@@ -172,8 +173,19 @@ async def wire_conversation_pipeline(
                 # legacy barge-in controller and Karen's arbiter — no second loop.
                 # handle.karen resolves at frame-time (mounted just below).
                 karen_vad=lambda s: (
-                    handle.karen.on_vad(s) if handle.karen is not None else None
-                ),
+                    (
+                        handle.karen.on_vad(s)
+                        if handle.karen is not None else None
+                    ),
+                    # Same per-frame VAD decision feeds the audio-state
+                    # IPC (edge-coalesced inside publish_vad) — the ov
+                    # cockpit sees VAD_ACTIVE/INACTIVE with no second
+                    # VAD loop. Late-bound like handle.karen.
+                    (
+                        handle.audio_ipc.publish_vad(bool(s))
+                        if handle.audio_ipc is not None else None
+                    ),
+                )[0],
             )
             audio_bus.register_mic_consumer(handle._bargein_vad_consumer)
             logger.info("[Bootstrap] BargeInController registered on AudioBus")
@@ -183,6 +195,29 @@ async def wire_conversation_pipeline(
 
     except Exception as e:
         logger.warning(f"[Bootstrap] TurnDetector/BargeIn skipped: {e}")
+
+    # 3a-ipc. Audio-state IPC broadcaster (operator-signed 2026-07-18):
+    #     the supervisor owns the audio hardware plane; the ov cockpit
+    #     subscribes to STATE over this UDS instead of binding audio.
+    #     Read-only telemetry export — a bind failure never touches the
+    #     pipeline. VAD edges publish through the SAME per-frame decision
+    #     that drives barge-in + Karen (DRY — no second VAD loop).
+    try:
+        from backend.core.ouroboros.governance.comms.duplex.audio_state_ipc import (
+            AudioStateBroadcaster,
+            audio_ipc_enabled,
+        )
+        if audio_ipc_enabled():
+            handle.audio_ipc = AudioStateBroadcaster()
+            if not await handle.audio_ipc.start():
+                handle.audio_ipc = None
+            else:
+                logger.info("[Bootstrap] Audio-state IPC broadcaster mounted")
+        else:
+            handle.audio_ipc = None
+    except Exception as e:
+        handle.audio_ipc = None
+        logger.warning(f"[Bootstrap] audio-state IPC skipped: {e}")
 
     # 3b. Karen full-duplex control layer (Sprint 3) — env-gated adaptive mount.
     #     Default OFF: the pipeline pays zero voice-allocation overhead and its
@@ -246,6 +281,49 @@ async def wire_conversation_pipeline(
         except Exception as e:
             handle.voice_build = None
             logger.warning(f"[Bootstrap] voice->build mount skipped: {e}")
+
+    # 4c. Audio-state IPC transcript + speech hooks (2026-07-18).
+    #     Composes — never replaces — the existing forks:
+    #       * user turns: chained _on_turn_text wrapper publishes the
+    #         final transcript to the IPC THEN forwards to whatever fork
+    #         was already installed (voice->build stays untouched);
+    #       * Karen lines: submit_speech is wrapped to publish the line
+    #         (role=karen) + TTS_GENERATING before the arbiter enqueue.
+    #     Fault-isolated: hook failures degrade silently; the audio
+    #     pipeline is byte-identical when the broadcaster is absent.
+    if handle.audio_ipc is not None:
+        try:
+            _ipc = handle.audio_ipc
+            if handle.conversation_pipeline is not None:
+                _prev_fork = getattr(
+                    handle.conversation_pipeline, "_on_turn_text", None,
+                )
+
+                async def _ipc_turn_fork(text, *a, **kw):
+                    try:
+                        _ipc.publish_transcript("user", str(text), final=True)
+                    except Exception:  # noqa: BLE001
+                        pass
+                    if _prev_fork is not None:
+                        return await _prev_fork(text, *a, **kw)
+                    return None
+
+                handle.conversation_pipeline._on_turn_text = _ipc_turn_fork
+            if handle.karen is not None:
+                _prev_submit = handle.karen.submit_speech
+
+                def _ipc_submit_speech(text, *a, **kw):
+                    try:
+                        _ipc.publish_transcript("karen", str(text), final=True)
+                        _ipc.publish_event("TTS_GENERATING")
+                    except Exception:  # noqa: BLE001
+                        pass
+                    return _prev_submit(text, *a, **kw)
+
+                handle.karen.submit_speech = _ipc_submit_speech
+            logger.info("[Bootstrap] audio-state IPC transcript hooks wired")
+        except Exception as e:
+            logger.warning(f"[Bootstrap] audio-state IPC hooks skipped: {e}")
 
     # 5. ModeDispatcher
     try:
@@ -338,6 +416,15 @@ async def shutdown(handle: PipelineHandle) -> None:
 
     # 0b. Karen voice->build bridge (Sprint 4) — drop the ref, no async teardown needed.
     handle.voice_build = None
+
+    # 0c. Audio-state IPC broadcaster — close clients + unlink the socket
+    #     so a later boot never sees a stale sock file.
+    if getattr(handle, "audio_ipc", None) is not None:
+        try:
+            await asyncio.wait_for(handle.audio_ipc.stop(), timeout=_timeout)
+        except Exception as e:
+            logger.debug(f"[Bootstrap] audio-state IPC stop error: {e}")
+        handle.audio_ipc = None
 
     # 1. ModeDispatcher
     if handle.mode_dispatcher is not None:

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4137,13 +4137,13 @@ class BattleTestHarness:
                 )
                 lines.append(
                     f"  {name}: {tok_txt} · {reset_txt} · "
-                    f"last_status={status} · runway={verdict}"
+                    f"status: {status} · runway: {verdict}"
                 )
             lines.append(
-                f"  floor={min_tokens_floor():,} tokens · "
-                f"any_exhausted={any_runway_exhausted()}"
+                f"  floor: {min_tokens_floor():,} tokens · "
+                f"exhausted: {'yes' if any_runway_exhausted() else 'no'}"
                 + (
-                    f" · max_reset={int(max_seconds_to_reset() or 0)}s"
+                    f" · longest reset: {int(max_seconds_to_reset() or 0)}s"
                     if any_runway_exhausted() else ""
                 )
             )
@@ -4282,7 +4282,20 @@ class BattleTestHarness:
     # -- REPL sub-commands ------------------------------------------------
 
     def _repl_print(self, msg: str) -> None:
-        """Print to SerpentFlow console if available, else log."""
+        """Print to SerpentFlow console if available, else log.
+
+        THE design-language chokepoint (OV_DESIGN_LANGUAGE.md §6): every
+        REPL verb, chat turn, and IPC render funnels here, so routing
+        this one seam through the PresentationRouter conforms the whole
+        operator plane — glyph ration, telemetry recast, density. The
+        AST sentinel pins this wiring."""
+        try:
+            from backend.core.ouroboros.battle_test.presentation_router import (
+                get_default_router,
+            )
+            msg = get_default_router().route_block(msg)
+        except Exception:  # noqa: BLE001 — router must never eat output
+            pass
         sf = getattr(self, "_serpent_flow", None)
         if sf is not None:
             sf.console.print(msg, highlight=False)

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1457,6 +1457,16 @@ class BattleTestHarness:
                         await self._serpent_repl.start()
                     except Exception as _repl_exc:
                         logger.debug("SerpentREPL not available: %s", _repl_exc)
+                    # Audio-state IPC subscriber (cockpit-only): the
+                    # supervisor owns the audio plane; the cockpit
+                    # renders its state feed. Bounded connect — a dead
+                    # daemon degrades to text-only, no UI-loop impact.
+                    try:
+                        await self._start_audio_ipc_client()
+                    except Exception:  # noqa: BLE001 — optional surface
+                        logger.debug(
+                            "audio IPC client mount degraded", exc_info=True,
+                        )
             elif hasattr(self, "_tui_console") and self._tui_console is not None:
                 self._tui_console.show_controls_bar()
             if hasattr(self, "_keyboard_handler") and self._keyboard_handler is not None:
@@ -4065,6 +4075,12 @@ class BattleTestHarness:
             # /infer — Rich table of inferred directions;
             # /infer accept <id> / reject <id> / stats
             self._repl_cmd_infer(command.strip())
+        elif cmd == "/liquidity" or cmd.startswith("/liquidity "):
+            # /liquidity — circadian provider-runway dashboard (item #5):
+            # per-provider declared tokens + reset horizons from the
+            # ProviderLiquidityLedger, exhaustion verdicts, and the
+            # LiquidityPool lease economy.
+            self._repl_cmd_liquidity()
         elif await self._try_dispatch_plugin_command(command.strip()):
             # Plugin-registered slash commands: /greet, /<plugin_cmd>, etc.
             # Returns True iff a plugin handled the command.
@@ -4080,6 +4096,136 @@ class BattleTestHarness:
             pass
         else:
             logger.debug("Unknown REPL command: %s", cmd)
+
+    def _repl_cmd_liquidity(self) -> None:
+        """``/liquidity`` — circadian provider-runway dashboard.
+
+        Pure composition over the Circadian Resilience organs: the
+        file-backed ProviderLiquidityLedger (hydrated by Aegis on every
+        upstream response), its exhaustion verdicts, and the
+        LiquidityPool lease economy. Read-only; NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.provider_liquidity_ledger import (  # noqa: E501
+                _load,
+                any_runway_exhausted,
+                liquidity,
+                max_seconds_to_reset,
+                min_tokens_floor,
+                runway_exhausted,
+            )
+            providers = (_load().get("providers") or {})
+            lines = ["Provider liquidity (declared by upstream headers):"]
+            if not providers:
+                lines.append(
+                    "  (no telemetry recorded yet — the ledger fills on "
+                    "the first proxied provider response)"
+                )
+            for name in sorted(providers):
+                tokens, secs = liquidity(name)
+                entry = providers.get(name) or {}
+                status = entry.get("last_status", "?")
+                tok_txt = (
+                    f"{tokens:,} tokens" if tokens is not None
+                    else "tokens undeclared"
+                )
+                reset_txt = (
+                    f"reset in {int(secs)}s" if secs is not None
+                    else "no reset horizon"
+                )
+                verdict = (
+                    "DRY" if runway_exhausted(name) else "ok"
+                )
+                lines.append(
+                    f"  {name}: {tok_txt} · {reset_txt} · "
+                    f"last_status={status} · runway={verdict}"
+                )
+            lines.append(
+                f"  floor={min_tokens_floor():,} tokens · "
+                f"any_exhausted={any_runway_exhausted()}"
+                + (
+                    f" · max_reset={int(max_seconds_to_reset() or 0)}s"
+                    if any_runway_exhausted() else ""
+                )
+            )
+            # Lease economy — best-effort (pool may not be constructed).
+            try:
+                from backend.core.ouroboros.governance.liquidity_pool import (
+                    get_default_pool,
+                )
+                pool = get_default_pool()
+                snap = getattr(pool, "snapshot", None)
+                if callable(snap):
+                    s = snap()
+                    lines.append(f"  lease pool: {s}")
+            except Exception:  # noqa: BLE001 — optional surface
+                pass
+            for ln in lines:
+                self._repl_print(ln)
+        except Exception as exc:  # noqa: BLE001 — REPL must survive
+            self._repl_print(f"/liquidity: degraded ({exc})")
+
+    # -- Audio-state IPC subscriber (cockpit render plane) -----------------
+
+    async def _start_audio_ipc_client(self) -> None:
+        """Mount the audio-state UDS subscriber (COCKPIT only).
+
+        State-reconciliation contract: the handshake's
+        ``active_utterance`` renders IMMEDIATELY — opening a new ov
+        terminal while Karen is mid-sentence shows the ongoing
+        transcript without a fresh prompt. A missing/refused socket
+        (daemon offline) degrades silently to text-only mode; the
+        bounded connect never touches the UI loop. NEVER raises."""
+        try:
+            from backend.core.ouroboros.ui.presentation_mode import is_cockpit
+            if not is_cockpit():
+                return
+            from backend.core.ouroboros.governance.comms.duplex.audio_state_ipc import (  # noqa: E501
+                AudioStateClient,
+                audio_ipc_enabled,
+            )
+            if not audio_ipc_enabled():
+                return
+
+            def _on_handshake(msg: dict) -> None:
+                utt = msg.get("active_utterance") or None
+                if utt and str(utt.get("text_so_far", "")).strip():
+                    role = utt.get("role", "karen")
+                    glyph = "💭 Karen" if role == "karen" else "🗣 you"
+                    self._repl_print(
+                        f"{glyph} (mid-sentence) ▸ {utt['text_so_far']}"
+                    )
+                state = msg.get("state") or {}
+                if state.get("audio_playing") or state.get("tts_generating"):
+                    self._repl_print("🎙 Karen voice channel active")
+
+            def _on_message(msg: dict) -> None:
+                mtype = msg.get("type")
+                if mtype == "transcript":
+                    if not msg.get("final"):
+                        return                # partials stay off the scrollback
+                    role = msg.get("role", "")
+                    glyph = "💭 Karen" if role == "karen" else "🗣 you"
+                    chunk = str(msg.get("chunk", "")).strip()
+                    if chunk:
+                        self._repl_print(f"{glyph} ▸ {chunk}")
+                elif mtype == "event" and msg.get("kind") == "VAD_ACTIVE":
+                    self._repl_print("🎙 listening…")
+
+            client = AudioStateClient(
+                on_handshake=_on_handshake, on_message=_on_message,
+            )
+            if await client.connect():
+                self._audio_ipc_client = client
+                logger.info(
+                    "[AudioIPC] cockpit subscribed to supervisor audio state",
+                )
+            else:
+                self._audio_ipc_client = None
+                logger.debug(
+                    "[AudioIPC] supervisor socket unavailable — text-only",
+                )
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioIPC] client mount degraded", exc_info=True)
 
     # -- Chat text bridge (Heuristic Intent Multiplexer) -------------------
 
@@ -7750,6 +7896,12 @@ class BattleTestHarness:
             mux = getattr(self, "_chat_text_mux", None)
             if mux is not None:
                 await mux.drain()
+        except Exception:
+            pass
+        try:
+            ipc_client = getattr(self, "_audio_ipc_client", None)
+            if ipc_client is not None:
+                await ipc_client.close()
         except Exception:
             pass
         try:

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4069,8 +4069,69 @@ class BattleTestHarness:
             # Plugin-registered slash commands: /greet, /<plugin_cmd>, etc.
             # Returns True iff a plugin handled the command.
             pass
+        elif self._try_chat_text_bridge(command):
+            # Heuristic Intent Multiplexer (chat_text_bridge): bare
+            # operator text becomes a conversational turn through the
+            # canonical intent_classifier -> chat_repl_dispatcher ->
+            # executor chain. Non-blocking (the turn runs off-loop);
+            # Ctrl+C cancels via the REPL interrupt hook. Unknown
+            # SLASH commands still fall through to the debug log —
+            # a typo'd verb is not a conversation.
+            pass
         else:
             logger.debug("Unknown REPL command: %s", cmd)
+
+    # -- Chat text bridge (Heuristic Intent Multiplexer) -------------------
+
+    def _try_chat_text_bridge(self, command: str) -> bool:
+        """Route bare operator text into the conversational stack.
+
+        Returns True iff the multiplexer accepted the turn. Slash-
+        prefixed input NEVER routes here (an unknown ``/verb`` is a
+        typo for the did-you-mean surface, not a conversation). Sync +
+        O(1): ``submit()`` spawns the turn task and returns immediately
+        — the REPL prompt is never blocked on an LLM. NEVER raises."""
+        try:
+            text = (command or "").strip()
+            if not text or text.startswith("/"):
+                return False
+            mux = self._ensure_chat_text_mux()
+            if mux is None:
+                return False
+            return mux.submit(text) is not None
+        except Exception:  # noqa: BLE001 — REPL must survive anything
+            logger.debug("[ChatTextBridge] repl route degraded", exc_info=True)
+            return False
+
+    def _ensure_chat_text_mux(self):
+        """Lazily build + cache the ChatTextMultiplexer (None when the
+        bridge or chat master is off — cached either way so the flag
+        read happens once per session). Wires the REPL's Ctrl+C surface
+        to the cancellation token on first build. NEVER raises."""
+        if getattr(self, "_chat_text_mux_built", False):
+            return getattr(self, "_chat_text_mux", None)
+        mux = None
+        try:
+            from backend.core.ouroboros.governance.chat_text_bridge import (
+                build_chat_text_multiplexer,
+            )
+            mux = build_chat_text_multiplexer(
+                project_root=getattr(self, "project_root", None),
+                print_sink=self._repl_print,
+            )
+            if mux is not None:
+                repl = getattr(self, "_serpent_repl", None)
+                if repl is not None:
+                    # Additive hook: SerpentREPL invokes on_interrupt
+                    # on KeyboardInterrupt (Ctrl+C) — the token aborts
+                    # the in-flight generation, prompt comes back.
+                    repl.on_interrupt = mux.cancel_active
+        except Exception:  # noqa: BLE001
+            logger.debug("[ChatTextBridge] mux build degraded", exc_info=True)
+            mux = None
+        self._chat_text_mux = mux
+        self._chat_text_mux_built = True
+        return mux
 
     # -- REPL sub-commands ------------------------------------------------
 
@@ -7682,6 +7743,15 @@ class BattleTestHarness:
             pass
 
         # 0b. REPL + keyboard handler + SerpentFlow
+        try:
+            # Chat text bridge: cancel + await every in-flight
+            # conversational turn BEFORE the REPL stops — no orphaned
+            # tasks may outlive the bridge (chat_text_bridge mandate).
+            mux = getattr(self, "_chat_text_mux", None)
+            if mux is not None:
+                await mux.drain()
+        except Exception:
+            pass
         try:
             if hasattr(self, "_serpent_repl") and self._serpent_repl is not None:
                 await self._serpent_repl.stop()

--- a/backend/core/ouroboros/battle_test/presentation_router.py
+++ b/backend/core/ouroboros/battle_test/presentation_router.py
@@ -1,0 +1,271 @@
+"""PresentationRouter — the design-language gateway for the UI plane.
+
+OV_DESIGN_LANGUAGE.md §6, operator-authorized 2026-07-18. Root cause of
+aesthetic rot: disparate modules formatting their own output, each arc
+minting private glyph vocabularies and leaking ``key=value`` telemetry
+onto operator surfaces. The structural fix is a CHOKEPOINT: every
+CLI-facing line pipes through :meth:`PresentationRouter.route_line`,
+which
+
+  1. **Scrubs glyphs** against the closed six-mark semantic ration
+     (``theme._GLYPHS``: action/detail/voice/human/warn/audio) —
+     legacy marks are ALIASED to their canonical meaning (``⛲``→warn),
+     decorative emoji are stripped;
+  2. **Recasts telemetry dumps** — a line carrying ≥2 raw ``key=value``
+     pairs is re-voiced into the detail grammar (``key: value ·
+     key: value``), so serialization-boundary leaks render as designed
+     output instead of debug spew;
+  3. **Normalizes density** — blank-line runs collapse to one; trailing
+     whitespace dies;
+  4. **Stays tier-adaptive** — glyph geometry comes from
+     :func:`theme.mark`, so ASCII terminals get the same shape
+     (``*``/``-``/``!``) the truecolor tier gets.
+
+DRY: this module owns NO rendering — it composes ``theme.mark`` /
+``supports_unicode`` and hands styled text back to whatever SerpentFlow
+console the caller already writes to. Master
+``JARVIS_PRESENTATION_ROUTER_ENABLED`` (default on); off = byte-identical
+passthrough. Enforcement against bypass lives in
+``tests/battle_test/test_presentation_ast_parity.py`` (the sentinel).
+NEVER raises anywhere on the UI plane.
+"""
+from __future__ import annotations
+
+import enum
+import logging
+import os
+import re
+import unicodedata
+from typing import Optional
+
+logger = logging.getLogger("Ouroboros.PresentationRouter")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def router_enabled() -> bool:
+    """Master gate — default ON. Off = byte-identical passthrough."""
+    return os.environ.get(
+        "JARVIS_PRESENTATION_ROUTER_ENABLED", "1",
+    ).strip().lower() in _TRUTHY
+
+
+# ---------------------------------------------------------------------------
+# The semantic ration — closed enum over theme._GLYPHS names
+# ---------------------------------------------------------------------------
+
+
+class Glyph(str, enum.Enum):
+    """The SIX operator-plane semantic marks (OV_DESIGN_LANGUAGE §2)."""
+
+    ACTION = "action"
+    DETAIL = "detail"
+    VOICE = "voice"
+    HUMAN = "human"
+    WARN = "warn"
+    AUDIO = "audio"
+
+
+def _mark(g: "Glyph") -> str:
+    try:
+        from backend.core.ouroboros.ui.theme import mark
+        return mark(g.value)
+    except Exception:  # noqa: BLE001 — theme unavailable → bare text
+        return ""
+
+
+def canonical_glyph_chars() -> frozenset:
+    """The unicode characters of the six rationed marks."""
+    return frozenset("⏺⎿💭🗣⚠🎙")
+
+
+#: Structure/typography set — allowed everywhere, not rationed (§2).
+TYPOGRAPHIC_CHARS = frozenset("·✓✗›─")
+
+#: Legacy semantic marks → their canonical meaning. Aliased, not merely
+#: stripped — the SIGNAL survives the sweep even where old emitters
+#: haven't been re-voiced yet.
+LEGACY_GLYPH_ALIASES = {
+    "⛲": "⚠",
+}
+
+
+def _is_decorative_symbol(ch: str) -> bool:
+    """True for emoji / pictographs outside the ration. Pure; NEVER
+    raises. Uses codepoint ranges + unicode category — no hardcoded
+    denylist of individual emoji (the set is open-ended by nature)."""
+    try:
+        cp = ord(ch)
+        if ch in canonical_glyph_chars() or ch in TYPOGRAPHIC_CHARS:
+            return False
+        if ch in LEGACY_GLYPH_ALIASES:
+            return False              # aliased separately, never dropped
+        if 0x1F000 <= cp <= 0x1FAFF:  # emoji / symbols-extended planes
+            return True
+        if 0x2190 <= cp <= 0x2BFF and ch not in TYPOGRAPHIC_CHARS:
+            # arrows / misc symbols / dingbats blocks — decorative on
+            # the UI plane unless in the typographic set.
+            return unicodedata.category(ch) in ("So", "Sk")
+        if cp in (0xFE0F, 0x200D):    # variation selector / ZWJ debris
+            return True
+        return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def scrub_glyphs(text: str) -> str:
+    """Alias legacy marks to canonical; strip decorative emoji; drop
+    orphaned variation selectors. Pure; NEVER raises."""
+    try:
+        scrubbed_lines = []
+        for line in str(text).split("\n"):
+            stripped_lead = line.lstrip()
+            lead_was_symbol = bool(stripped_lead) and _is_decorative_symbol(
+                stripped_lead[0],
+            )
+            out = []
+            for ch in line:
+                if ch in LEGACY_GLYPH_ALIASES:
+                    out.append(LEGACY_GLYPH_ALIASES[ch])
+                elif _is_decorative_symbol(ch):
+                    continue
+                else:
+                    out.append(ch)
+            cleaned = "".join(out)
+            # Collapse doubled interior spaces a strip left behind;
+            # trailing residue always dies; LEADING space dies only when
+            # the line's first glyph was the thing we stripped —
+            # intentional indentation survives.
+            cleaned = re.sub(r"(?<=\S)  +(?=\S)", " ", cleaned).rstrip()
+            if lead_was_symbol:
+                cleaned = cleaned.lstrip()
+            scrubbed_lines.append(cleaned)
+        return "\n".join(scrubbed_lines)
+    except Exception:  # noqa: BLE001
+        return str(text)
+
+
+# ---------------------------------------------------------------------------
+# Telemetry recast — key=value leaks become detail-voice
+# ---------------------------------------------------------------------------
+
+
+_KV_PAIR = re.compile(r"\b([A-Za-z_][\w.-]*)=(\S+)")
+
+
+def looks_like_telemetry(line: str) -> bool:
+    """≥2 raw ``key=value`` pairs on one line = a serialization leak.
+    Pure; NEVER raises."""
+    try:
+        return len(_KV_PAIR.findall(str(line))) >= 2
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def recast_telemetry(line: str) -> str:
+    """Re-voice ``key=value`` pairs into the detail grammar
+    (``key: value`` joined by the middot). Words around the pairs are
+    preserved. Pure; NEVER raises (degrades to the input)."""
+    try:
+        if not looks_like_telemetry(line):
+            return line
+        recast = _KV_PAIR.sub(lambda m: f"{m.group(1)}: {m.group(2)}", line)
+        # Successive recast pairs separated by bare spaces read better
+        # middot-joined: "a: 1 b: 2" -> "a: 1 · b: 2".
+        recast = re.sub(
+            r"(?<=\S) (?=[A-Za-z_][\w.-]*: )", " · ", recast,
+        )
+        return recast
+    except Exception:  # noqa: BLE001
+        return line
+
+
+# ---------------------------------------------------------------------------
+# The router
+# ---------------------------------------------------------------------------
+
+
+class PresentationRouter:
+    """Chokepoint gateway — see module docstring. Stateless; cheap
+    enough for every line of every verb."""
+
+    def route_line(
+        self,
+        text: str,
+        *,
+        kind: Optional[Glyph] = None,
+    ) -> str:
+        """Return *text* conformed to the design language. ``kind``
+        (optional) prefixes the semantic mark when the line doesn't
+        already lead with one. Master-off = byte-identical passthrough.
+        NEVER raises."""
+        try:
+            if not router_enabled():
+                return text
+            line = str(text)
+            line = scrub_glyphs(line)
+            line = recast_telemetry(line)
+            line = line.rstrip()
+            if kind is not None and line.strip():
+                lead = line.lstrip()
+                if not any(
+                    lead.startswith(g) for g in canonical_glyph_chars()
+                ):
+                    m = _mark(kind)
+                    if m:
+                        line = f"{m} {line}"
+            return line
+        except Exception:  # noqa: BLE001 — UI plane never breaks
+            return str(text)
+
+    def route_block(self, text: str, *, kind: Optional[Glyph] = None) -> str:
+        """Multi-line variant: per-line conformance + density rule §5
+        (blank-line runs collapse to one). NEVER raises."""
+        try:
+            if not router_enabled():
+                return text
+            lines = [
+                self.route_line(ln, kind=None) for ln in str(text).split("\n")
+            ]
+            out = []
+            prev_blank = False
+            for ln in lines:
+                blank = not ln.strip()
+                if blank and prev_blank:
+                    continue
+                out.append(ln)
+                prev_blank = blank
+            joined = "\n".join(out)
+            if kind is not None:
+                joined = self.route_line(joined.split("\n", 1)[0], kind=kind) + (
+                    ("\n" + joined.split("\n", 1)[1]) if "\n" in joined else ""
+                )
+            return joined
+        except Exception:  # noqa: BLE001
+            return str(text)
+
+
+_DEFAULT_ROUTER: Optional[PresentationRouter] = None
+
+
+def get_default_router() -> PresentationRouter:
+    """Process-global router (stateless — the singleton is a
+    convenience, not shared state)."""
+    global _DEFAULT_ROUTER
+    if _DEFAULT_ROUTER is None:
+        _DEFAULT_ROUTER = PresentationRouter()
+    return _DEFAULT_ROUTER
+
+
+__all__ = [
+    "Glyph",
+    "LEGACY_GLYPH_ALIASES",
+    "PresentationRouter",
+    "TYPOGRAPHIC_CHARS",
+    "canonical_glyph_chars",
+    "get_default_router",
+    "looks_like_telemetry",
+    "recast_telemetry",
+    "router_enabled",
+    "scrub_glyphs",
+]

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -5676,6 +5676,19 @@ class SerpentREPL:
                 except EOFError:
                     break
                 except KeyboardInterrupt:
+                    # Chat text bridge: Ctrl+C is the operator's abort
+                    # gesture for an in-flight conversational turn. The
+                    # optional hook triggers the multiplexer's
+                    # cancellation token (set by the harness when the
+                    # bridge mounts); the prompt loop itself continues
+                    # exactly as before. Defensive: a hook failure can
+                    # never take down the REPL.
+                    _cb = getattr(self, "on_interrupt", None)
+                    if _cb is not None:
+                        try:
+                            _cb()
+                        except Exception:  # noqa: BLE001
+                            pass
                     continue
                 except asyncio.CancelledError:
                     break

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -118,6 +118,12 @@ class StatusSnapshot:
     # Route / provider badge
     route: str = ""                    # "complex" / "standard" / "background" / ...
     provider: str = ""                 # "claude" / "dw" / "prime" / ""
+    # Circadian liquidity (item #5) — populated ONLY when a provider's
+    # declared token runway is exhausted (presentation restraint: the
+    # healthy state renders nothing).
+    liquidity_exhausted: bool = False
+    liquidity_provider: str = ""       # first exhausted provider name
+    liquidity_reset_s: Optional[float] = None
 
 
 # ---------------------------------------------------------------------------
@@ -187,6 +193,7 @@ class StatusLineBuilder:
         idle_elapsed, idle_timeout = self._sample_idle()
         primary_op, extra_ops = self._sample_ops()
         route, provider = self._sample_route_and_provider(primary_op)
+        liq_exhausted, liq_provider, liq_reset = self._sample_liquidity()
 
         # §37 Slice 5 — feed cost-band-crossing observer.
         # Chatter-suppression is structural in the observer; this call
@@ -214,6 +221,9 @@ class StatusLineBuilder:
             extra_op_count=extra_ops,
             route=route,
             provider=provider,
+            liquidity_exhausted=liq_exhausted,
+            liquidity_provider=liq_provider,
+            liquidity_reset_s=liq_reset,
         )
 
     def render_plain(self) -> str:
@@ -399,6 +409,32 @@ class StatusLineBuilder:
 
         return (primary_phase, detail)
 
+    def _sample_liquidity(self) -> tuple:
+        """Circadian liquidity sample (item #5) — reads the file-backed
+        ProviderLiquidityLedger the Aegis proxy hydrates on every
+        upstream response. Restraint contract: returns the exhausted
+        triple ONLY when some provider's declared runway is dry; the
+        healthy state samples as (False, "", None) and renders nothing.
+        Master ``JARVIS_STATUS_LIQUIDITY_SEGMENT_ENABLED`` (default on).
+        NEVER raises."""
+        try:
+            if os.environ.get(
+                "JARVIS_STATUS_LIQUIDITY_SEGMENT_ENABLED", "1",
+            ).strip().lower() in ("0", "false", "no", "off"):
+                return (False, "", None)
+            from backend.core.ouroboros.governance.provider_liquidity_ledger import (  # noqa: E501
+                _load,
+                liquidity,
+                runway_exhausted,
+            )
+            for name in sorted((_load().get("providers") or {})):
+                if runway_exhausted(name):
+                    _tokens, secs = liquidity(name)
+                    return (True, str(name), secs)
+            return (False, "", None)
+        except Exception:  # noqa: BLE001 — status line never breaks
+            return (False, "", None)
+
     def _sample_route_and_provider(self, op_id: str) -> tuple:
         """Pull route + provider for the primary op. Both optional."""
         if not op_id or self._gls is None:
@@ -519,11 +555,23 @@ def _format_plain(snap: StatusSnapshot, *, compact: bool) -> str:
             and isinstance(snap.phase, str)
             and snap.phase.upper() in ("IDLE", "")
         ):
-            return format_idle_breadcrumb(
+            crumb = format_idle_breadcrumb(
                 cost_spent=snap.cost_spent_usd,
                 cost_budget=snap.cost_budget_usd,
                 op_id=snap.primary_op_id or "",
             )
+            # A dry provider runway is MOST relevant while idle — the
+            # organism may be idle BECAUSE it is dry. The one exception
+            # to the breadcrumb's minimalism.
+            if snap.liquidity_exhausted:
+                tok = f"⛲ {snap.liquidity_provider or 'provider'} dry"
+                if (
+                    snap.liquidity_reset_s is not None
+                    and snap.liquidity_reset_s > 0
+                ):
+                    tok += f" ~{max(1, int(snap.liquidity_reset_s / 60))}m"
+                crumb = f"{crumb} · {tok}" if crumb else tok
+            return crumb
     except Exception:  # noqa: BLE001 — defensive
         pass
 
@@ -575,6 +623,15 @@ def _format_plain(snap: StatusSnapshot, *, compact: bool) -> str:
     if idle_fr >= (warn_threshold_pct() / 100.0):
         idle_txt += " ⚠"
     parts.append(idle_txt)
+
+    # Circadian liquidity (item #5) — renders ONLY when a provider's
+    # declared runway is dry (restraint: healthy = invisible). Reset
+    # horizon in minutes when the provider declared one.
+    if snap.liquidity_exhausted:
+        liq_txt = f"⛲ {snap.liquidity_provider or 'provider'} dry"
+        if snap.liquidity_reset_s is not None and snap.liquidity_reset_s > 0:
+            liq_txt += f" ~{max(1, int(snap.liquidity_reset_s / 60))}m"
+        parts.append(liq_txt)
 
     if not compact and snap.primary_op_id:
         op_txt = f"Op: {_short_op_id(snap.primary_op_id)}"

--- a/backend/core/ouroboros/battle_test/status_line.py
+++ b/backend/core/ouroboros/battle_test/status_line.py
@@ -564,7 +564,7 @@ def _format_plain(snap: StatusSnapshot, *, compact: bool) -> str:
             # organism may be idle BECAUSE it is dry. The one exception
             # to the breadcrumb's minimalism.
             if snap.liquidity_exhausted:
-                tok = f"⛲ {snap.liquidity_provider or 'provider'} dry"
+                tok = f"⚠ {snap.liquidity_provider or 'provider'} dry"
                 if (
                     snap.liquidity_reset_s is not None
                     and snap.liquidity_reset_s > 0
@@ -628,7 +628,7 @@ def _format_plain(snap: StatusSnapshot, *, compact: bool) -> str:
     # declared runway is dry (restraint: healthy = invisible). Reset
     # horizon in minutes when the provider declared one.
     if snap.liquidity_exhausted:
-        liq_txt = f"⛲ {snap.liquidity_provider or 'provider'} dry"
+        liq_txt = f"⚠ {snap.liquidity_provider or 'provider'} dry"
         if snap.liquidity_reset_s is not None and snap.liquidity_reset_s > 0:
             liq_txt += f" ~{max(1, int(snap.liquidity_reset_s / 60))}m"
         parts.append(liq_txt)

--- a/backend/core/ouroboros/battle_test/stream_renderer.py
+++ b/backend/core/ouroboros/battle_test/stream_renderer.py
@@ -45,12 +45,59 @@ from typing import Any, Optional
 logger = logging.getLogger("Ouroboros.StreamRenderer")
 
 _STREAMING_ENV_VAR = "JARVIS_UI_STREAMING_ENABLED"
+_FLOW_MODE_ENV_VAR = "JARVIS_UI_STREAMING_FLOW_MODE_ENABLED"
 _TRUTHY = frozenset({"1", "true", "yes", "on"})
 
 
 def streaming_enabled() -> bool:
     """Env gate read. Default: ON (``1``). Flip to ``0`` for batch mode."""
     return os.environ.get(_STREAMING_ENV_VAR, "1").strip().lower() in _TRUTHY
+
+
+def flow_mode_enabled() -> bool:
+    """§41.3 #27 — progressive-streaming flow mode (unwrap the Live cage).
+
+    When ON, completed markdown blocks are committed ABOVE the Live region
+    into terminal scrollback as they stream (CC-style progressive flow);
+    the Live cage holds only the current in-progress block. When OFF
+    (default, §33.1), the legacy behavior is byte-identical: the whole
+    stream lives inside the tail-truncated Live region and long
+    generations scroll out of the cage without accumulating in scrollback.
+    """
+    return os.environ.get(_FLOW_MODE_ENV_VAR, "0").strip().lower() in _TRUTHY
+
+
+def find_commit_boundary(text: str, start: int = 0) -> int:
+    """Return the index up to which ``text`` can be safely committed to
+    scrollback: just past the LAST complete blank line that sits OUTSIDE
+    a fenced code block, at or after ``start``. Returns ``start`` when no
+    safe boundary exists yet.
+
+    Contract: ``start`` must be a previous return value of this function
+    (or 0) — boundaries are only ever emitted at closed-fence points, so
+    scanning ``text[start:]`` with fence-closed initial state is always
+    correct and the scan cost is O(new content), not O(stream length).
+
+    Pure, deterministic, NEVER raises. A trailing line without ``\\n`` is
+    still in flight and never a boundary; blank lines inside an open
+    ```` ``` ````/``~~~`` fence never split the block (a partial fenced
+    code block must stay whole in the Live region until it seals).
+    """
+    try:
+        fence_open = False
+        boundary = start
+        pos = start
+        for line in text[start:].splitlines(keepends=True):
+            end = pos + len(line)
+            stripped = line.strip()
+            if stripped.startswith("```") or stripped.startswith("~~~"):
+                fence_open = not fence_open
+            elif not fence_open and stripped == "" and line.endswith("\n"):
+                boundary = end
+            pos = end
+        return boundary
+    except Exception:  # noqa: BLE001 — presentation layer never raises
+        return start
 
 
 # ---------------------------------------------------------------------------
@@ -132,6 +179,11 @@ class StreamRenderer:
         self._first_token_mono: Optional[float] = None
         self._token_count: int = 0
         self._dropped_count: int = 0
+        # §41.3 #27 flow mode — offset of the buffer prefix already
+        # committed to scrollback above the Live region. Snapshotted from
+        # the env gate at start() so one op never splits across modes.
+        self._flow_mode: bool = False
+        self._committed_offset: int = 0
 
     # ------------------------------------------------------------------
     # Lifecycle
@@ -165,6 +217,8 @@ class StreamRenderer:
         self._dropped_count = 0
         self._first_token_mono = None
         self._start_mono = time.monotonic()
+        self._flow_mode = flow_mode_enabled()
+        self._committed_offset = 0
 
         # Obtain the running loop. The queue MUST be bound to the same
         # loop that will run the consumer, else put_nowait raises.
@@ -278,11 +332,22 @@ class StreamRenderer:
         if self._live is not None:
             try:
                 from rich.markdown import Markdown
-                # Final render: tail slice only. Rich Live's viewport shows
-                # at most the visible terminal area, so re-parsing the full
-                # buffer would pay O(N) cost to render content that never
-                # reaches pixels.
-                self._live.update(Markdown(self._buffer[-_RENDER_TAIL_CHARS:]))  # type: ignore[attr-defined]
+                if self._flow_mode:
+                    # §41.3 #27 — final commit: land the uncommitted
+                    # remainder in scrollback and clear the cage, so the
+                    # ENTIRE stream persists in terminal history with no
+                    # tail truncation.
+                    remainder = self._buffer[self._committed_offset:]
+                    if remainder.strip():
+                        self._live.console.print(Markdown(remainder))  # type: ignore[attr-defined]
+                    self._committed_offset = len(self._buffer)
+                    self._live.update(Markdown(""))  # type: ignore[attr-defined]
+                else:
+                    # Final render: tail slice only. Rich Live's viewport
+                    # shows at most the visible terminal area, so re-parsing
+                    # the full buffer would pay O(N) cost to render content
+                    # that never reaches pixels.
+                    self._live.update(Markdown(self._buffer[-_RENDER_TAIL_CHARS:]))  # type: ignore[attr-defined]
                 self._live.stop()  # type: ignore[attr-defined]
             except Exception:  # noqa: BLE001
                 logger.debug(
@@ -309,6 +374,8 @@ class StreamRenderer:
         # Clear state so the renderer instance is reusable across ops.
         self._queue = None
         self._buffer = ""
+        self._committed_offset = 0
+        self._flow_mode = False
         self._op_id = ""
         self._provider = ""
         self._first_token_mono = None
@@ -474,7 +541,24 @@ class StreamRenderer:
             return
         try:
             from rich.markdown import Markdown
-            self._live.update(Markdown(self._buffer[-_RENDER_TAIL_CHARS:]))  # type: ignore[attr-defined]
+            if self._flow_mode:
+                # §41.3 #27 — commit completed blocks ABOVE the Live region
+                # into scrollback (Rich routes console.print above an active
+                # Live display), then render only the in-progress tail in
+                # the cage. Long generations accumulate in scrollback
+                # instead of scrolling out of the tail-truncated widget.
+                boundary = find_commit_boundary(
+                    self._buffer, self._committed_offset,
+                )
+                if boundary > self._committed_offset:
+                    chunk = self._buffer[self._committed_offset:boundary]
+                    if chunk.strip():
+                        self._live.console.print(Markdown(chunk))  # type: ignore[attr-defined]
+                    self._committed_offset = boundary
+                tail = self._buffer[self._committed_offset:]
+                self._live.update(Markdown(tail[-_RENDER_TAIL_CHARS:]))  # type: ignore[attr-defined]
+            else:
+                self._live.update(Markdown(self._buffer[-_RENDER_TAIL_CHARS:]))  # type: ignore[attr-defined]
         except Exception:  # noqa: BLE001
             logger.debug(
                 "[StreamRender] Live.update failed", exc_info=True,

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -97,18 +97,23 @@ def resolve(argv: Optional[Sequence[str]] = None) -> Invocation:
 
 
 def _default_status_provider() -> Optional[str]:
-    """Best-effort one-line digest of the most recent session.
+    """Best-effort digest of recent sessions (authority-free, read-only).
 
-    Reads the existing :class:`LastSessionSummary` (authority-free, read-only).
-    Returns ``None`` when there is no prior session or the digest is
-    unavailable -- callers render a friendly fallback. NEVER raises.
+    Reads :meth:`LastSessionSummary.operator_digest_sync` — the
+    OPERATOR-plane surface, deliberately ungated by
+    ``JARVIS_LAST_SESSION_SUMMARY_ENABLED`` (that flag governs the
+    organism's prompt-injection authority, not a human's explicit query;
+    routing status through the autonomy gate was the wired-but-inert
+    root cause: sessions on disk, "no prior session found" on screen).
+    Returns ``None`` when no parseable prior session exists -- callers
+    render a friendly fallback. NEVER raises.
     """
     try:
         from backend.core.ouroboros.governance.last_session_summary import (
             get_default_summary,
         )
 
-        text = get_default_summary().format_for_prompt_sync()
+        text = get_default_summary().operator_digest_sync()
         if isinstance(text, str) and text.strip():
             return text.strip()
         return None

--- a/backend/core/ouroboros/governance/chat_repl_dispatcher.py
+++ b/backend/core/ouroboros/governance/chat_repl_dispatcher.py
@@ -54,7 +54,7 @@ import enum
 import logging
 import os
 from dataclasses import dataclass
-from typing import List, Optional, Protocol
+from typing import Any, List, Optional, Protocol
 
 from backend.core.ouroboros.governance.conversation_orchestrator import (
     ChatRoutingDecision,
@@ -296,6 +296,7 @@ class ChatReplDispatcher:
         self,
         line: str,
         session_id: Optional[str] = None,
+        verdict_override: Optional[Any] = None,
     ) -> ChatReplResult:
         """Dispatch a single operator input line.
 
@@ -303,6 +304,12 @@ class ChatReplDispatcher:
           * ``"/chat <message>"`` or ``"/chat history|why|clear|help"``
           * Bare ``"<message>"`` (treated as a new turn)
           * Empty / whitespace → :class:`ChatReplStatus.EMPTY`
+
+        ``verdict_override`` (additive seam, chat_text_bridge): a
+        pre-computed ``IntentClassification`` threaded verbatim to the
+        orchestrator's dispatch — the code-shape re-weighted verdict.
+        ``None`` (all legacy callers) is byte-identical. Applies only
+        to message dispatch, never to ``/chat`` subcommands.
         """
         sid = session_id or self.default_session_id
         if not line or not line.strip():
@@ -327,10 +334,14 @@ class ChatReplDispatcher:
             # Treat as the message body — falls through to dispatch so
             # natural-language "/chat why is X?" doesn't get misparsed
             # as the ``why`` subcommand.
-            return self._dispatch_message(tail, sid)
+            return self._dispatch_message(
+                tail, sid, verdict_override=verdict_override,
+            )
 
         # Bare text path.
-        return self._dispatch_message(stripped, sid)
+        return self._dispatch_message(
+            stripped, sid, verdict_override=verdict_override,
+        )
 
     @staticmethod
     def _args_match_subcommand(sub: str, args: str) -> bool:
@@ -369,7 +380,9 @@ class ChatReplDispatcher:
     ) -> ChatReplResult:
         """Convenience for SerpentFlow when the operator has explicitly
         opted into chat mode and types without the slash prefix."""
-        return self._dispatch_message(text or "", session_id)
+        return self._dispatch_message(
+            text or "", session_id or self.default_session_id,
+        )
 
     # ---- subcommands ----
 
@@ -438,10 +451,17 @@ class ChatReplDispatcher:
     # ---- message dispatch ----
 
     def _dispatch_message(
-        self, message: str, session_id: str,
+        self,
+        message: str,
+        session_id: str,
+        verdict_override: Optional[Any] = None,
     ) -> ChatReplResult:
         orch = self._orch()
-        turn, decision = orch.dispatch(message, session_id=session_id)
+        turn, decision = orch.dispatch(
+            message,
+            session_id=session_id,
+            verdict_override=verdict_override,
+        )
 
         rendered = render_decision(turn, decision)
 

--- a/backend/core/ouroboros/governance/chat_text_bridge.py
+++ b/backend/core/ouroboros/governance/chat_text_bridge.py
@@ -1,0 +1,438 @@
+"""Heuristic Intent Multiplexer — the REPL text plane's missing bridge.
+
+Closes the wired-but-inert gap where the complete conversational stack
+(``intent_classifier`` + ``chat_repl_dispatcher`` + the executor triplet)
+had ZERO callers on the ``ov`` REPL path: bare operator text fell through
+``_handle_repl_command`` to a debug log. This module supplies ONLY the
+missing I/O bridge — classification, routing, session state, decision
+rendering, and executor side-effects all stay in their canonical modules
+(DRY mandate: zero routing logic is duplicated here).
+
+Three pieces:
+
+1. **Code-shape pre-filter** (:func:`code_shape_signals` +
+   :func:`weighted_classify`) — pure, deterministic evidence the base
+   classifier cannot express: multiline fenced blocks and AST-parseable
+   payloads re-weight the verdict toward the TASK plane
+   (``ACTION_REQUEST``) over the CHAT plane (``EXPLANATION``). The base
+   :func:`intent_classifier.classify` remains the single classification
+   authority; this layer only re-weights its verdict on code evidence,
+   and the re-weighted verdict rides the additive ``verdict_override``
+   seam on the canonical dispatch path.
+
+2. **CancellationToken** — an asyncio-native, thread-safe abort signal.
+   The REPL's existing ``KeyboardInterrupt`` surface (prompt_toolkit
+   raises it INTO the input loop on Ctrl+C) triggers the token; no
+   process-level ``signal.signal`` handler is registered — the harness's
+   Ticket-B SIGINT handlers (partial-summary writes) stay untouched, per
+   the watchdog-isolation discipline.
+
+3. **ChatTextMultiplexer** — non-blocking submit: each turn runs the
+   sync dispatcher off-loop via ``asyncio.to_thread`` and RACES it
+   against the token (``asyncio.wait FIRST_COMPLETED``). Token fires →
+   the turn task is cancelled and the operator is back at the prompt
+   immediately; a late executor result is discarded on arrival.
+   Cooperative boundary (stated honestly): a sync provider mid-HTTP-call
+   cannot be hard-aborted — the wrapping task completes cancelled at
+   once, the worker thread drains in the background, and its result is
+   dropped. A cancel-aware ``ClaudeQueryProvider`` can tighten this
+   without touching the bridge.
+
+Authority invariant: presentation-plane only. Never imports orchestrator
+/ iron_gate / policy_engine / risk_engine. The default executor chain is
+the graduated safe-default (``LoggingChatActionExecutor`` unless the
+per-leg executor flags are armed) — mounting this bridge grants ZERO new
+mutation authority.
+
+Master flag: ``JARVIS_CHAT_TEXT_BRIDGE_ENABLED`` (default **true** —
+presentation-layer bridge over an already-graduated default-true chat
+master; the side-effecting executors keep their own default-FALSE
+flags per §33.1).
+"""
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+import os
+import re
+import textwrap
+from pathlib import Path
+from typing import Any, Callable, Optional, Set, Tuple
+
+from backend.core.ouroboros.governance.intent_classifier import (
+    ChatIntent,
+    IntentClassification,
+    classify,
+)
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+_BRIDGE_ENV_VAR = "JARVIS_CHAT_TEXT_BRIDGE_ENABLED"
+
+
+def bridge_enabled() -> bool:
+    """Master gate — default ON (pure presentation bridge; executor
+    authority is governed by the per-leg flags). NEVER raises."""
+    return os.environ.get(_BRIDGE_ENV_VAR, "1").strip().lower() in _TRUTHY
+
+
+# ---------------------------------------------------------------------------
+# Code-shape pre-filter — pure evidence functions
+# ---------------------------------------------------------------------------
+
+
+_FENCE_BLOCK = re.compile(r"```[^\n`]*\n(.*?)```", re.DOTALL)
+
+SIGNAL_FENCED = "fenced_code_block"
+SIGNAL_AST = "ast_parseable_body"
+BOOST_REASON = "code_shape_boost"
+
+
+def _looks_substantive(tree: "ast.Module") -> bool:
+    """A parse is code evidence only when it contains something a prose
+    sentence cannot: a def/class/import/assignment/compound statement,
+    or 2+ statements. Guards against ``"status"`` (a bare Name) or a
+    one-word message parsing as a trivial expression."""
+    if len(tree.body) >= 2:
+        return True
+    for node in ast.walk(tree):
+        if isinstance(node, (
+            ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef,
+            ast.Import, ast.ImportFrom, ast.Assign, ast.AnnAssign,
+            ast.AugAssign, ast.For, ast.While, ast.If, ast.With,
+            ast.Try, ast.Return, ast.Call,
+        )):
+            return True
+    return False
+
+
+def _ast_parses(src: str) -> bool:
+    """True iff *src* is a non-trivial AST-parseable body. NEVER raises."""
+    try:
+        cleaned = textwrap.dedent(src).strip()
+        if not cleaned or "\n" not in cleaned and len(cleaned) < 12:
+            # Single short token — never code evidence on its own.
+            return False
+        tree = ast.parse(cleaned)
+        return bool(tree.body) and _looks_substantive(tree)
+    except (SyntaxError, ValueError, RecursionError):
+        return False
+    except Exception:  # noqa: BLE001 — evidence must never break dispatch
+        return False
+
+
+def code_shape_signals(text: str) -> Tuple[str, ...]:
+    """Fired code-evidence signal names for *text*. Pure; NEVER raises.
+
+    * ``fenced_code_block`` — a ``` fence is present.
+    * ``ast_parseable_body`` — a fence interior OR the raw payload
+      parses as substantive Python (see :func:`_looks_substantive`).
+    """
+    try:
+        t = str(text or "")
+        if not t.strip():
+            return ()
+        signals = []
+        if "```" in t:
+            signals.append(SIGNAL_FENCED)
+        candidates = [m.group(1) for m in _FENCE_BLOCK.finditer(t)] or [t]
+        for cand in candidates:
+            if _ast_parses(cand):
+                signals.append(SIGNAL_AST)
+                break
+        return tuple(signals)
+    except Exception:  # noqa: BLE001
+        return ()
+
+
+def weighted_classify(text: str) -> IntentClassification:
+    """The heuristic pre-filter: base classifier verdict, re-weighted
+    toward the TASK plane on code-shape evidence. Pure; NEVER raises
+    (degrades to the base verdict).
+
+    Re-weight rules (deterministic, auditable via ``reasons``):
+      * ``EXPLANATION`` (chat) + any code signal → ``ACTION_REQUEST``.
+        A chat-shaped message carrying real code is a work order.
+      * ``CONTEXT_PASTE`` + ``ast_parseable_body`` → ``ACTION_REQUEST``.
+        Runnable code handed to an engineering organism is a task; a
+        paste that is only a stack trace / log fence (NOT parseable)
+        keeps the canonical paste-attach semantics — diagnostic context
+        belongs to the previous turn.
+      * ``ACTION_REQUEST`` + signals → confidence reinforcement only.
+      * ``EXPLORATION`` is already on the task plane — untouched.
+    """
+    base = classify(text)
+    try:
+        signals = code_shape_signals(text)
+        if not signals:
+            return base
+        boosted_conf = min(1.0, max(
+            base.confidence, 0.55 + 0.15 * len(signals),
+        ))
+        reasons = tuple(base.reasons) + signals + (BOOST_REASON,)
+        if base.intent == ChatIntent.EXPLANATION:
+            return IntentClassification(
+                intent=ChatIntent.ACTION_REQUEST,
+                confidence=boosted_conf,
+                reasons=reasons,
+                truncated=base.truncated,
+            )
+        if base.intent == ChatIntent.CONTEXT_PASTE and SIGNAL_AST in signals:
+            return IntentClassification(
+                intent=ChatIntent.ACTION_REQUEST,
+                confidence=boosted_conf,
+                reasons=reasons,
+                truncated=base.truncated,
+            )
+        if base.intent == ChatIntent.ACTION_REQUEST:
+            return IntentClassification(
+                intent=base.intent,
+                confidence=boosted_conf,
+                reasons=reasons,
+                truncated=base.truncated,
+            )
+        return base
+    except Exception:  # noqa: BLE001
+        return base
+
+
+# ---------------------------------------------------------------------------
+# CancellationToken — asyncio-native, thread-safe abort signal
+# ---------------------------------------------------------------------------
+
+
+class CancellationToken:
+    """One resettable abort signal shared by the REPL surface and the
+    multiplexer. ``trigger()`` is safe from any thread (marshalled via
+    ``call_soon_threadsafe`` when a loop is bound); NEVER raises."""
+
+    def __init__(self) -> None:
+        self._event = asyncio.Event()
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    def bind_loop(self, loop: asyncio.AbstractEventLoop) -> None:
+        self._loop = loop
+
+    @property
+    def triggered(self) -> bool:
+        return self._event.is_set()
+
+    def trigger(self) -> None:
+        try:
+            loop = self._loop
+            if loop is not None and not loop.is_closed():
+                try:
+                    running = asyncio.get_running_loop()
+                except RuntimeError:
+                    running = None
+                if running is not loop:
+                    loop.call_soon_threadsafe(self._event.set)
+                    return
+            self._event.set()
+        except Exception:  # noqa: BLE001
+            logger.debug("[ChatTextBridge] token trigger degraded", exc_info=True)
+
+    def reset(self) -> None:
+        try:
+            self._event.clear()
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def wait(self) -> None:
+        await self._event.wait()
+
+
+# ---------------------------------------------------------------------------
+# ChatTextMultiplexer — non-blocking turn execution with graceful abort
+# ---------------------------------------------------------------------------
+
+
+class ChatTextMultiplexer:
+    """Async multiplexer between the REPL text plane and the canonical
+    :class:`ChatReplDispatcher`.
+
+    ``submit()`` is O(1) and never blocks the REPL loop: the sync
+    dispatcher (whose executors may make blocking LLM calls) runs via
+    ``asyncio.to_thread``, raced against the cancellation token. Every
+    spawned task is tracked and self-discarding — ``drain()`` proves the
+    loop clean at shutdown.
+    """
+
+    _CANCEL_LINE = "[chat] ^C -- generation abandoned, back to prompt"
+
+    def __init__(
+        self,
+        dispatcher: Any,
+        *,
+        print_sink: Optional[Callable[[str], None]] = None,
+        session_id: str = "repl",
+        token: Optional[CancellationToken] = None,
+    ) -> None:
+        self._dispatcher = dispatcher
+        self._sink = print_sink or (lambda _s: None)
+        self._session_id = session_id
+        self._token = token or CancellationToken()
+        self._tasks: Set[asyncio.Task] = set()
+
+    # ---- introspection ----
+
+    @property
+    def token(self) -> CancellationToken:
+        return self._token
+
+    @property
+    def active_count(self) -> int:
+        return sum(1 for t in self._tasks if not t.done())
+
+    # ---- ingress ----
+
+    def submit(self, text: str) -> Optional[asyncio.Task]:
+        """Spawn one conversational turn. Non-blocking; returns the
+        tracked task, or ``None`` (empty input / no running loop).
+        NEVER raises."""
+        try:
+            if not text or not str(text).strip():
+                return None
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            logger.debug("[ChatTextBridge] submit without running loop — drop")
+            return None
+        except Exception:  # noqa: BLE001
+            return None
+        self._token.bind_loop(loop)
+        task = loop.create_task(self._run(str(text)))
+        self._tasks.add(task)
+        task.add_done_callback(self._tasks.discard)
+        return task
+
+    def cancel_active(self) -> None:
+        """The REPL's Ctrl+C surface. Thread-safe; NEVER raises."""
+        self._token.trigger()
+
+    async def drain(self, timeout: float = 5.0) -> None:
+        """Cancel + await every tracked task (shutdown hygiene: no
+        orphaned tasks may outlive the bridge). NEVER raises."""
+        tasks = [t for t in self._tasks if not t.done()]
+        for t in tasks:
+            t.cancel()
+        if tasks:
+            try:
+                await asyncio.wait_for(
+                    asyncio.gather(*tasks, return_exceptions=True),
+                    timeout=timeout,
+                )
+            except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+                pass
+
+    # ---- turn execution ----
+
+    async def _run(self, text: str) -> Optional[Any]:
+        verdict = weighted_classify(text)
+        work = asyncio.ensure_future(asyncio.to_thread(
+            self._dispatcher.handle,
+            text,
+            self._session_id,
+            verdict_override=verdict,
+        ))
+        token_wait = asyncio.ensure_future(self._token.wait())
+        try:
+            done, _pending = await asyncio.wait(
+                {work, token_wait},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if token_wait in done and work not in done:
+                # Graceful abort: cancel the turn, drop the late result,
+                # hand the prompt back. The token resets so the NEXT
+                # turn starts clean.
+                work.cancel()
+                try:
+                    await work
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+                self._token.reset()
+                self._safe_print(self._CANCEL_LINE)
+                return None
+            result = await work
+            rendered = getattr(result, "rendered_text", None)
+            if rendered:
+                self._safe_print(str(rendered))
+            return result
+        except asyncio.CancelledError:
+            # drain()/shutdown cancelled us — propagate after tidying.
+            work.cancel()
+            raise
+        except Exception as exc:  # noqa: BLE001 — REPL must survive anything
+            logger.warning("[ChatTextBridge] turn failed: %s", exc)
+            self._safe_print(f"[chat] turn failed: {exc}")
+            return None
+        finally:
+            if not token_wait.done():
+                token_wait.cancel()
+                try:
+                    await token_wait
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+
+    def _safe_print(self, line: str) -> None:
+        try:
+            self._sink(line)
+        except Exception:  # noqa: BLE001
+            logger.debug("[ChatTextBridge] print sink degraded", exc_info=True)
+
+
+# ---------------------------------------------------------------------------
+# Factory — composes the canonical top-of-chain dispatcher factory
+# ---------------------------------------------------------------------------
+
+
+def build_chat_text_multiplexer(
+    *,
+    project_root: Optional[Path] = None,
+    print_sink: Optional[Callable[[str], None]] = None,
+    session_id: str = "repl",
+    dispatcher: Optional[Any] = None,
+) -> Optional[ChatTextMultiplexer]:
+    """Build the bridge over the canonical executor chain.
+
+    Returns ``None`` when the bridge master OR the chat master
+    (``JARVIS_CONVERSATIONAL_MODE_ENABLED``, inside the chained factory)
+    is off — callers keep the legacy debug-log fall-through. The
+    dispatcher comes from ``build_chat_repl_dispatcher_with_claude``,
+    the TOP of the existing executor chain (Claude → Subagent → Backlog
+    → Logging, each leg behind its own flag) — zero chain logic is
+    re-implemented here. NEVER raises."""
+    try:
+        if not bridge_enabled():
+            return None
+        d = dispatcher
+        if d is None:
+            from backend.core.ouroboros.governance.chat_repl_claude_executor import (  # noqa: E501
+                build_chat_repl_dispatcher_with_claude,
+            )
+            d = build_chat_repl_dispatcher_with_claude(
+                project_root=project_root,
+            )
+        if d is None:
+            return None
+        return ChatTextMultiplexer(
+            d, print_sink=print_sink, session_id=session_id,
+        )
+    except Exception:  # noqa: BLE001
+        logger.debug("[ChatTextBridge] factory degraded", exc_info=True)
+        return None
+
+
+__all__ = [
+    "BOOST_REASON",
+    "CancellationToken",
+    "ChatTextMultiplexer",
+    "SIGNAL_AST",
+    "SIGNAL_FENCED",
+    "bridge_enabled",
+    "build_chat_text_multiplexer",
+    "code_shape_signals",
+    "weighted_classify",
+]

--- a/backend/core/ouroboros/governance/comms/duplex/audio_state_ipc.py
+++ b/backend/core/ouroboros/governance/comms/duplex/audio_state_ipc.py
@@ -1,0 +1,458 @@
+"""Stateful IPC Audio Pub/Sub Bridge — supervisor audio plane → ov CLI.
+
+Architecture decision (operator-signed 2026-07-18): the daemonized
+``unified_supervisor`` retains ABSOLUTE ownership of the audio hardware
+plane (mic, speakers, CoreAudio/ALSA locks). The ephemeral ``ov``
+cockpit never binds ``karen_duplex`` or VAD listeners — it subscribes to
+the supervisor's audio STATE over a Unix Domain Socket and renders.
+
+Protocol (newline-delimited JSON over UDS, schema ``audio_ipc.v1``):
+
+  * On accept, the server's FIRST line is the **state-reconciliation
+    handshake**: current voice-state booleans, the ACTIVE utterance
+    (id + accumulated ``text_so_far``) if Karen or the operator is
+    mid-sentence, and a bounded ring of recent events. A CLI opened
+    while Karen is mid-sentence renders the ongoing transcript
+    immediately — no ghosting, no fresh prompt required.
+  * Thereafter the server streams events:
+      ``{"type":"event","kind":"VAD_ACTIVE"|"VAD_INACTIVE"|
+         "TTS_GENERATING"|"AUDIO_PLAYING"|"AUDIO_IDLE","ts":...}``
+      ``{"type":"transcript","role":"user"|"karen","chunk":"...",
+         "final":bool,"utterance_id":"u-...","ts":...}``
+
+Degradation contract (mandate 4): the CLIENT side is strictly
+non-blocking — ``connect()`` is bounded by a short timeout and returns
+``False`` on a missing / refused / dead socket, so the ``ov`` UI loop
+cleanly stays in text-only mode. The SERVER side never lets one slow or
+dead subscriber block a publish (per-client fail-drop).
+
+Authority invariant: pure presentation telemetry. No audio capture, no
+mutation surface, no policy imports. Socket is chmod 0600 (same-user
+only). Master ``JARVIS_AUDIO_IPC_ENABLED`` (default on — §7 Absolute
+Observability; the socket exports state, never grants control).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import time
+import uuid
+from collections import deque
+from pathlib import Path
+from typing import Any, Callable, Deque, Dict, Optional, Set
+
+logger = logging.getLogger(__name__)
+
+AUDIO_IPC_SCHEMA_VERSION = "audio_ipc.v1"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: Closed event-kind vocabulary (state machine below keys off these).
+EVENT_VAD_ACTIVE = "VAD_ACTIVE"
+EVENT_VAD_INACTIVE = "VAD_INACTIVE"
+EVENT_TTS_GENERATING = "TTS_GENERATING"
+EVENT_AUDIO_PLAYING = "AUDIO_PLAYING"
+EVENT_AUDIO_IDLE = "AUDIO_IDLE"
+EVENT_KINDS = (
+    EVENT_VAD_ACTIVE, EVENT_VAD_INACTIVE, EVENT_TTS_GENERATING,
+    EVENT_AUDIO_PLAYING, EVENT_AUDIO_IDLE,
+)
+
+
+def audio_ipc_enabled() -> bool:
+    """Master gate — default ON (read-only state export). NEVER raises."""
+    return os.environ.get(
+        "JARVIS_AUDIO_IPC_ENABLED", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def socket_path() -> Path:
+    """``JARVIS_AUDIO_IPC_SOCKET`` (default ``.jarvis/audio_state.sock``)."""
+    return Path(os.environ.get(
+        "JARVIS_AUDIO_IPC_SOCKET", ".jarvis/audio_state.sock",
+    ))
+
+
+def _recent_cap() -> int:
+    try:
+        return max(8, int(os.environ.get("JARVIS_AUDIO_IPC_RECENT", "100")))
+    except (TypeError, ValueError):
+        return 100
+
+
+def _connect_timeout_s() -> float:
+    try:
+        return max(0.05, float(os.environ.get(
+            "JARVIS_AUDIO_IPC_CONNECT_TIMEOUT_S", "0.5",
+        )))
+    except (TypeError, ValueError):
+        return 0.5
+
+
+# ---------------------------------------------------------------------------
+# Server — lives in the unified_supervisor process (audio-plane owner)
+# ---------------------------------------------------------------------------
+
+
+class AudioStateBroadcaster:
+    """The supervisor-side pub/sub hub.
+
+    Holds the authoritative presentation-state (VAD / TTS / playback
+    booleans), the ACTIVE utterance accumulation, and a bounded ring of
+    recent messages for late-joiner replay. Every publish is O(clients);
+    a slow or dead client is dropped, never awaited inline.
+    """
+
+    def __init__(self, *, path: Optional[Path] = None) -> None:
+        self._path = Path(path) if path is not None else socket_path()
+        self._server: Optional[asyncio.AbstractServer] = None
+        self._clients: Set[asyncio.StreamWriter] = set()
+        self._recent: Deque[Dict[str, Any]] = deque(maxlen=_recent_cap())
+        self._state: Dict[str, bool] = {
+            "vad_active": False,
+            "tts_generating": False,
+            "audio_playing": False,
+        }
+        self._utterance: Optional[Dict[str, Any]] = None
+        self._loop: Optional[asyncio.AbstractEventLoop] = None
+
+    # ---- lifecycle ----
+
+    async def start(self) -> bool:
+        """Bind the UDS (removing any stale socket file). Returns False
+        (never raises) when binding fails — the supervisor keeps running
+        without the export surface."""
+        try:
+            self._loop = asyncio.get_running_loop()
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            try:
+                if self._path.exists():
+                    self._path.unlink()
+            except OSError:
+                pass
+            self._server = await asyncio.start_unix_server(
+                self._on_client, path=str(self._path),
+            )
+            try:
+                os.chmod(self._path, 0o600)
+            except OSError:
+                pass
+            logger.info("[AudioIPC] broadcaster bound at %s", self._path)
+            return True
+        except Exception as exc:  # noqa: BLE001 — export is optional
+            logger.warning("[AudioIPC] broadcaster bind failed: %s", exc)
+            self._server = None
+            return False
+
+    async def stop(self) -> None:
+        """Close server + clients, unlink the socket. NEVER raises."""
+        try:
+            if self._server is not None:
+                self._server.close()
+                try:
+                    await self._server.wait_closed()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._server = None
+            for w in list(self._clients):
+                self._drop_client(w)
+            try:
+                if self._path.exists():
+                    self._path.unlink()
+            except OSError:
+                pass
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioIPC] stop degraded", exc_info=True)
+
+    @property
+    def client_count(self) -> int:
+        return len(self._clients)
+
+    # ---- publish surface (supervisor-side hooks call these) ----
+
+    def publish_event(self, kind: str) -> None:
+        """Publish one state event + update the state machine. Safe from
+        any thread (marshalled to the bound loop). NEVER raises."""
+        try:
+            if kind not in EVENT_KINDS:
+                return
+            msg = {"type": "event", "kind": kind, "ts": time.time()}
+            self._apply_state(kind)
+            self._enqueue(msg)
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioIPC] publish_event degraded", exc_info=True)
+
+    def publish_vad(self, active: bool) -> None:
+        """Edge-coalesced VAD publisher — repeated same-state calls are
+        dropped (the per-frame consumer may fire at 50Hz). NEVER raises."""
+        try:
+            if bool(active) == self._state["vad_active"]:
+                return
+            self.publish_event(
+                EVENT_VAD_ACTIVE if active else EVENT_VAD_INACTIVE,
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    def publish_transcript(
+        self,
+        role: str,
+        chunk: str,
+        *,
+        final: bool = False,
+        utterance_id: Optional[str] = None,
+    ) -> str:
+        """Publish a transcript chunk, accumulating the ACTIVE utterance
+        for late-joiner reconciliation. Returns the utterance id. A
+        ``final`` chunk seals the utterance into the recent ring and
+        clears the active slot. NEVER raises."""
+        uid = utterance_id or ""
+        try:
+            role = str(role or "unknown")
+            chunk = str(chunk or "")
+            if (
+                self._utterance is not None
+                and (utterance_id in (None, self._utterance.get("utterance_id")))
+                and self._utterance.get("role") == role
+            ):
+                uid = str(self._utterance["utterance_id"])
+                self._utterance["text_so_far"] = (
+                    str(self._utterance.get("text_so_far", "")) + chunk
+                )
+            else:
+                uid = utterance_id or f"u-{uuid.uuid4().hex[:12]}"
+                self._utterance = {
+                    "utterance_id": uid,
+                    "role": role,
+                    "text_so_far": chunk,
+                    "started_unix": time.time(),
+                }
+            msg = {
+                "type": "transcript",
+                "role": role,
+                "chunk": chunk,
+                "final": bool(final),
+                "utterance_id": uid,
+                "ts": time.time(),
+            }
+            if final:
+                self._utterance = None
+            self._enqueue(msg)
+            return uid
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioIPC] publish_transcript degraded", exc_info=True)
+            return uid
+
+    # ---- internals ----
+
+    def _apply_state(self, kind: str) -> None:
+        if kind == EVENT_VAD_ACTIVE:
+            self._state["vad_active"] = True
+        elif kind == EVENT_VAD_INACTIVE:
+            self._state["vad_active"] = False
+        elif kind == EVENT_TTS_GENERATING:
+            self._state["tts_generating"] = True
+        elif kind == EVENT_AUDIO_PLAYING:
+            self._state["tts_generating"] = False
+            self._state["audio_playing"] = True
+        elif kind == EVENT_AUDIO_IDLE:
+            self._state["tts_generating"] = False
+            self._state["audio_playing"] = False
+
+    def _enqueue(self, msg: Dict[str, Any]) -> None:
+        self._recent.append(msg)
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        try:
+            running = asyncio.get_running_loop()
+        except RuntimeError:
+            running = None
+        if running is loop:
+            self._broadcast(msg)
+        else:
+            loop.call_soon_threadsafe(self._broadcast, msg)
+
+    def _broadcast(self, msg: Dict[str, Any]) -> None:
+        if not self._clients:
+            return
+        data = (json.dumps(msg, separators=(",", ":")) + "\n").encode()
+        for w in list(self._clients):
+            try:
+                if w.is_closing():
+                    self._drop_client(w)
+                    continue
+                w.write(data)
+                # No inline await — asyncio buffers; a client that never
+                # drains eventually errors on write and gets dropped.
+            except Exception:  # noqa: BLE001
+                self._drop_client(w)
+
+    def _drop_client(self, w: asyncio.StreamWriter) -> None:
+        self._clients.discard(w)
+        try:
+            w.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _handshake_payload(self) -> Dict[str, Any]:
+        return {
+            "type": "handshake",
+            "schema_version": AUDIO_IPC_SCHEMA_VERSION,
+            "ts": time.time(),
+            "state": dict(self._state),
+            "active_utterance": (
+                dict(self._utterance) if self._utterance is not None else None
+            ),
+            "recent": list(self._recent),
+        }
+
+    async def _on_client(
+        self, reader: asyncio.StreamReader, writer: asyncio.StreamWriter,
+    ) -> None:
+        try:
+            handshake = (
+                json.dumps(self._handshake_payload(), separators=(",", ":"))
+                + "\n"
+            ).encode()
+            writer.write(handshake)
+            await writer.drain()
+            self._clients.add(writer)
+            # Hold the connection open; EOF (client gone) unregisters.
+            while True:
+                data = await reader.read(4096)
+                if not data:
+                    break
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            self._drop_client(writer)
+
+
+# ---------------------------------------------------------------------------
+# Client — lives in the ov cockpit process (render-only subscriber)
+# ---------------------------------------------------------------------------
+
+
+class AudioStateClient:
+    """Non-blocking UDS subscriber for the ov cockpit.
+
+    ``connect()`` is bounded by a short timeout and NEVER raises — a
+    missing/refused/dead socket returns ``False`` and the CLI stays in
+    text-only mode with zero UI-loop impact. On success the FIRST frame
+    is the reconciliation handshake (delivered to ``on_handshake``);
+    subsequent frames stream to ``on_message``.
+    """
+
+    def __init__(
+        self,
+        *,
+        on_handshake: Optional[Callable[[Dict[str, Any]], None]] = None,
+        on_message: Optional[Callable[[Dict[str, Any]], None]] = None,
+        path: Optional[Path] = None,
+    ) -> None:
+        self._path = Path(path) if path is not None else socket_path()
+        self._on_handshake = on_handshake or (lambda _m: None)
+        self._on_message = on_message or (lambda _m: None)
+        self._reader: Optional[asyncio.StreamReader] = None
+        self._writer: Optional[asyncio.StreamWriter] = None
+        self._read_task: Optional[asyncio.Task] = None
+        self.connected: bool = False
+
+    async def connect(self) -> bool:
+        """Bounded connect + handshake consume. Returns False on ANY
+        failure (text-only degrade). NEVER raises, NEVER hangs — both
+        the connect and the handshake read share one deadline."""
+        timeout = _connect_timeout_s()
+        try:
+            self._reader, self._writer = await asyncio.wait_for(
+                asyncio.open_unix_connection(path=str(self._path)),
+                timeout=timeout,
+            )
+            line = await asyncio.wait_for(
+                self._reader.readline(), timeout=timeout,
+            )
+            if not line:
+                await self.close()
+                return False
+            handshake = json.loads(line)
+            if handshake.get("type") == "handshake":
+                self._safe(self._on_handshake, handshake)
+            else:
+                self._safe(self._on_message, handshake)
+            self._read_task = asyncio.get_running_loop().create_task(
+                self._read_loop(),
+            )
+            self.connected = True
+            return True
+        except Exception:  # noqa: BLE001 — dead daemon = text-only mode
+            logger.debug(
+                "[AudioIPC] connect degraded (text-only mode)", exc_info=True,
+            )
+            await self.close()
+            return False
+
+    async def _read_loop(self) -> None:
+        reader = self._reader
+        if reader is None:
+            return
+        try:
+            while True:
+                line = await reader.readline()
+                if not line:
+                    break
+                try:
+                    msg = json.loads(line)
+                except (ValueError, TypeError):
+                    continue          # one malformed frame never kills the feed
+                self._safe(self._on_message, msg)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            self.connected = False
+
+    async def close(self) -> None:
+        """Idempotent teardown. NEVER raises."""
+        self.connected = False
+        task = self._read_task
+        self._read_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        w = self._writer
+        self._writer = None
+        self._reader = None
+        if w is not None:
+            try:
+                w.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    @staticmethod
+    def _safe(cb: Callable[[Dict[str, Any]], None], msg: Dict[str, Any]) -> None:
+        try:
+            cb(msg)
+        except Exception:  # noqa: BLE001 — render sink never kills the feed
+            logger.debug("[AudioIPC] client callback degraded", exc_info=True)
+
+
+__all__ = [
+    "AUDIO_IPC_SCHEMA_VERSION",
+    "AudioStateBroadcaster",
+    "AudioStateClient",
+    "EVENT_AUDIO_IDLE",
+    "EVENT_AUDIO_PLAYING",
+    "EVENT_KINDS",
+    "EVENT_TTS_GENERATING",
+    "EVENT_VAD_ACTIVE",
+    "EVENT_VAD_INACTIVE",
+    "audio_ipc_enabled",
+    "socket_path",
+]

--- a/backend/core/ouroboros/governance/conversation_orchestrator.py
+++ b/backend/core/ouroboros/governance/conversation_orchestrator.py
@@ -222,6 +222,7 @@ class ConversationOrchestrator:
         self,
         message: str,
         session_id: str = "default",
+        verdict_override: Optional[IntentClassification] = None,
     ) -> Tuple[ChatTurn, ChatRoutingDecision]:
         """Classify ``message`` and emit a :class:`ChatRoutingDecision`.
 
@@ -234,8 +235,19 @@ class ConversationOrchestrator:
           * For empty / whitespace input, the decision is ``"noop"``
             so the renderer can short-circuit without consuming
             session capacity.
+
+        ``verdict_override`` (additive seam, chat_text_bridge): a
+        caller-supplied :class:`IntentClassification` — e.g. the
+        code-shape re-weighted verdict — replaces the inline
+        ``classify()`` call. ``None`` (every legacy caller) keeps the
+        pre-seam behavior byte-identical. The override travels the
+        SAME turn/decision path, so ``/chat why`` audits it verbatim
+        (its ``reasons`` carry the re-weight evidence).
         """
-        verdict = classify(message)
+        verdict = (
+            verdict_override if verdict_override is not None
+            else classify(message)
+        )
         now = self._clock()
         turn_id = self._mint_turn_id()
 

--- a/backend/core/ouroboros/governance/domain_entropy_engine.py
+++ b/backend/core/ouroboros/governance/domain_entropy_engine.py
@@ -116,7 +116,13 @@ class DomainEntropyReport:
 
 @dataclass(frozen=True)
 class CuriosityScanReport:
-    """Outcome of one proactive scan + governed-emission cycle."""
+    """Outcome of one proactive scan + governed-emission cycle.
+
+    ``zero_cause`` (additive, 2026-07-18 observability closure): when
+    ``emitted == 0`` this carries ONE value from the closed
+    :data:`SCAN_ZERO_CAUSES` taxonomy so a silent scan is a classified
+    verdict, not an absence of evidence. ``""`` when emitted > 0 (or on
+    pre-taxonomy records — the schema is additive)."""
 
     master_enabled: bool
     normalized_entropy: float
@@ -125,7 +131,27 @@ class CuriosityScanReport:
     emitted: int
     ingest_results: Tuple[str, ...]
     diagnostic: str
+    zero_cause: str = ""
     schema_version: str = DOMAIN_ENTROPY_SCHEMA_VERSION
+
+
+#: Closed zero-cause taxonomy — WHY a scan emitted nothing. Ordered by
+#: where the pipeline starved (data → budget → construction → transport
+#: → admission). A dashboard/test can rely on exactly these values.
+ZERO_CAUSE_DISABLED = "master_disabled"
+ZERO_CAUSE_NO_ZONES = "no_zones"                 # index empty / no sparse zones
+ZERO_CAUSE_BUDGET = "budget_zero"                # cognitive-load shed to 0
+ZERO_CAUSE_NO_ENVELOPES = "no_envelopes"         # zone→envelope construction dry
+ZERO_CAUSE_ROUTER_MISSING = "router_missing"     # no intake router wired
+ZERO_CAUSE_INGEST_REJECTED = "ingest_rejected"   # router refused every envelope
+SCAN_ZERO_CAUSES = (
+    ZERO_CAUSE_DISABLED,
+    ZERO_CAUSE_NO_ZONES,
+    ZERO_CAUSE_BUDGET,
+    ZERO_CAUSE_NO_ENVELOPES,
+    ZERO_CAUSE_ROUTER_MISSING,
+    ZERO_CAUSE_INGEST_REJECTED,
+)
 
 
 def _disabled_entropy_report() -> DomainEntropyReport:
@@ -345,6 +371,7 @@ async def run_curiosity_scan_once(
             master_enabled=False, normalized_entropy=0.0, zones_identified=0,
             budget=0, emitted=0, ingest_results=(),
             diagnostic="domain entropy engine disabled",
+            zero_cause=ZERO_CAUSE_DISABLED,
         )
     report = compute_domain_entropy(clusters=clusters, now_unix=now_unix)
     budget = exploration_budget(load_report=load_report)
@@ -361,12 +388,38 @@ async def run_curiosity_scan_once(
             except Exception as exc:  # noqa: BLE001 — one bad ingest never aborts the scan
                 logger.debug("[DomainEntropy] ingest failed: %s", exc)
                 results.append("error")
+
+    # Observability closure (2026-07-18): a zero-emission scan was
+    # SILENT — indistinguishable from the scan never running (the exact
+    # blind spot that cost a graduation soak). Classify WHY it emitted
+    # nothing (closed taxonomy, starvation-ordered: data → budget →
+    # construction → transport → admission) and log the verdict
+    # UNCONDITIONALLY when the master is on — one line per sensor
+    # cadence, structured + grep-able.
+    zero_cause = ""
+    if emitted == 0:
+        if not report.sparse_zones:
+            zero_cause = ZERO_CAUSE_NO_ZONES
+        elif budget <= 0:
+            zero_cause = ZERO_CAUSE_BUDGET
+        elif not envelopes:
+            zero_cause = ZERO_CAUSE_NO_ENVELOPES
+        elif router is None:
+            zero_cause = ZERO_CAUSE_ROUTER_MISSING
+        else:
+            zero_cause = ZERO_CAUSE_INGEST_REJECTED
+
+    ingest_hist: dict = {}
+    for r in results:
+        ingest_hist[r] = ingest_hist.get(r, 0) + 1
     diag = (
         f"entropy_norm={report.normalized_entropy:.3f} "
-        f"zones={len(report.sparse_zones)} budget={budget} emitted={emitted}"
+        f"zones={len(report.sparse_zones)} budget={budget} "
+        f"envelopes={len(envelopes)} emitted={emitted}"
+        + (f" zero_cause={zero_cause}" if zero_cause else "")
+        + (f" ingest={ingest_hist}" if ingest_hist else "")
     )
-    if emitted > 0:
-        logger.info("[DomainEntropy] proactive scan — %s", diag)
+    logger.info("[DomainEntropy] proactive scan — %s", diag)
     return CuriosityScanReport(
         master_enabled=True,
         normalized_entropy=report.normalized_entropy,
@@ -375,4 +428,5 @@ async def run_curiosity_scan_once(
         emitted=emitted,
         ingest_results=tuple(results),
         diagnostic=diag,
+        zero_cause=zero_cause,
     )

--- a/backend/core/ouroboros/governance/intake/sensors/proactive_exploration_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/proactive_exploration_sensor.py
@@ -563,6 +563,22 @@ class ProactiveExplorationSensor:
             )
             return emitted
 
+        # Observability closure (2026-07-18): the reader path was
+        # SILENT on every zero-emission outcome (empty collector,
+        # cooldown, below-floor), indistinguishable from never having
+        # run. One unconditional verdict line per scan when the reader
+        # is armed — decision histogram makes the starvation point
+        # legible without a debugger.
+        _decision_hist: dict = {}
+        for _r in rankings:
+            _key = str(getattr(_r.decision, "value", _r.decision))
+            _decision_hist[_key] = _decision_hist.get(_key, 0) + 1
+        logger.info(
+            "[ExplorationSensor] curiosity-reader scan — rankings=%d "
+            "decisions=%s",
+            len(rankings), _decision_hist or "{}",
+        )
+
         for ranking in rankings:
             if ranking.decision is not (
                 CuriosityRankingDecision.SURFACED

--- a/backend/core/ouroboros/governance/last_session_summary.py
+++ b/backend/core/ouroboros/governance/last_session_summary.py
@@ -356,6 +356,44 @@ def _parse_summary_impl(
 # ---------------------------------------------------------------------------
 
 
+def _render_operator_line(r: SessionRecord) -> str:
+    """One compact ``ov status`` line per session. Pure; NEVER raises.
+
+    Shape: ``bt-... — stop_reason after Xm · ops A/C/F · $T · apply=... ·
+    verify=P/T · commit=hash`` — apply/verify/commit segments render only
+    when the session carried them (v1.1a fields are optional)."""
+    try:
+        mins = r.duration_s / 60.0
+        dur = f"{mins:.0f}m" if mins >= 1.0 else f"{r.duration_s:.0f}s"
+        parts = [
+            f"{r.session_id} — {r.stop_reason or 'unknown'} after {dur}",
+            (
+                f"ops {r.stats_attempted} att / {r.stats_completed} done"
+                f" / {r.stats_failed} failed"
+            ),
+            f"${r.cost_total:.2f}",
+        ]
+        if r.last_apply_mode and r.last_apply_mode != "none":
+            files = (
+                f" ({r.last_apply_files} file(s))"
+                if r.last_apply_files is not None else ""
+            )
+            parts.append(f"apply={r.last_apply_mode}{files}")
+        if (
+            r.last_verify_tests_passed is not None
+            and r.last_verify_tests_total is not None
+        ):
+            parts.append(
+                f"verify={r.last_verify_tests_passed}"
+                f"/{r.last_verify_tests_total}"
+            )
+        if r.last_commit_hash:
+            parts.append(f"commit={r.last_commit_hash[:10]}")
+        return " · ".join(parts)
+    except Exception:  # noqa: BLE001
+        return f"{getattr(r, 'session_id', '?')} — (render degraded)"
+
+
 def _render_session(record: SessionRecord) -> str:
     """Render one SessionRecord as a dense one-line string + optional note.
 
@@ -462,6 +500,41 @@ def _lex_max_session_dirs_worker(
     return filtered[:n]
 
 
+def _mtime_max_session_dirs_worker(
+    sessions_root_str: str, active: Optional[str], n: int,
+) -> List[str]:
+    """Recency-ordered sibling of :func:`_lex_max_session_dirs_worker`
+    for the OPERATOR plane. Lex-max assumes homogeneous ``bt-<stamp>``
+    naming, but sandbox lineages (``bt-iso-*``) lexicographically shadow
+    newer ``bt-2026-*`` dirs (``i`` > ``2``) — an operator asking ``ov
+    status`` wants what ran MOST RECENTLY, so order by the
+    ``summary.json`` mtime (the moment the session actually closed).
+    The autonomy plane keeps lex-max untouched. Same self-skip +
+    summary-exists filter semantics."""
+    sessions_root = Path(sessions_root_str)
+    try:
+        candidates = [
+            p for p in sessions_root.iterdir()
+            if p.is_dir() and p.name.startswith("bt-")
+        ]
+    except OSError:
+        return []
+
+    stamped: List[Tuple[float, str]] = []
+    for p in candidates:
+        if active and p.name == active:
+            continue
+        summary = p / "summary.json"
+        try:
+            if not summary.is_file():
+                continue
+            stamped.append((summary.stat().st_mtime, str(p)))
+        except OSError:
+            continue
+    stamped.sort(key=lambda t: t[0], reverse=True)
+    return [path for _mt, path in stamped[:n]]
+
+
 # ---------------------------------------------------------------------------
 # LastSessionSummary
 # ---------------------------------------------------------------------------
@@ -537,6 +610,30 @@ class LastSessionSummary:
             return []
         return [Path(p) for p in result]
 
+    async def _mtime_max_session_dirs(self, n: int) -> List[Path]:
+        """Recency-ordered sibling of :meth:`_lex_max_session_dirs`
+        (operator plane — see :func:`_mtime_max_session_dirs_worker`).
+        Same offload + fail-soft discipline."""
+        sessions_root = self._sessions_dir()
+        if not sessions_root.exists() or not sessions_root.is_dir():
+            return []
+        active = get_active_session_id()
+        from backend.core.ouroboros.governance.cooperative_fs_io import (
+            offload,
+            is_offload_error,
+        )
+        result = await offload(
+            _mtime_max_session_dirs_worker,
+            str(sessions_root), active, max(0, n),
+        )
+        if is_offload_error(result):
+            logger.debug(
+                "[LastSessionSummary] _mtime_max_session_dirs offload "
+                "failed — degrading to empty list",
+            )
+            return []
+        return [Path(p) for p in result]
+
     async def load(self, n_sessions: Optional[int] = None) -> List[SessionRecord]:
         """Load up to ``n_sessions`` most-recent session summaries.
 
@@ -546,12 +643,32 @@ class LastSessionSummary:
         """
         if not _is_enabled():
             return []
+        return await self._load_ungated(n_sessions)
+
+    async def _load_ungated(
+        self,
+        n_sessions: Optional[int] = None,
+        *,
+        order: str = "lex",
+    ) -> List[SessionRecord]:
+        """The parse core of :meth:`load` WITHOUT the autonomy-plane
+        master gate. Two callers, two authorities: :meth:`load` (the
+        CONTEXT_EXPANSION injection path) applies ``_is_enabled()``
+        first — that flag governs what the ORGANISM may read into its
+        own prompt; :meth:`operator_digest` (the ``ov status`` path)
+        calls this directly — an explicit human query for session
+        history is operator-plane and needs no autonomy flag. Same
+        directories, same parser, same stats — zero duplicated logic.
+        """
         target_n = n_sessions if n_sessions is not None else _n_sessions()
         if target_n <= 0:
             return []
         target_n = min(target_n, _HARD_MAX_SESSIONS)
 
-        dirs = await self._lex_max_session_dirs(target_n)
+        if order == "mtime":
+            dirs = await self._mtime_max_session_dirs(target_n)
+        else:
+            dirs = await self._lex_max_session_dirs(target_n)
         if not dirs:
             return []
 
@@ -675,6 +792,61 @@ class LastSessionSummary:
             "[LastSessionSummary] format_for_prompt_sync called from "
             "within a running event loop — degrading to None",
         )
+        return None
+
+    # ------------------------------------------------------------------
+    # Operator-plane digest (ov status)
+    # ------------------------------------------------------------------
+
+    async def operator_digest(
+        self, n_sessions: Optional[int] = None,
+    ) -> Optional[str]:
+        """Compact human digest of recent sessions for ``ov status``.
+
+        OPERATOR-plane: bypasses the autonomy master gate by design —
+        ``JARVIS_LAST_SESSION_SUMMARY_ENABLED`` governs the organism's
+        prompt-injection authority, not a human's right to read their
+        own session history (the wired-but-inert ``ov status`` root
+        cause: 50+ session dirs on disk, "no prior session found" on
+        screen). Session count from ``JARVIS_OV_STATUS_SESSIONS``
+        (default 3, clamped to the hard max). Returns ``None`` when no
+        parseable session exists. NEVER raises."""
+        try:
+            if n_sessions is None:
+                try:
+                    n_sessions = max(1, int(os.environ.get(
+                        "JARVIS_OV_STATUS_SESSIONS", "3",
+                    )))
+                except (TypeError, ValueError):
+                    n_sessions = 3
+            records = await self._load_ungated(n_sessions, order="mtime")
+            if not records:
+                return None
+            return "\n".join(
+                _render_operator_line(r) for r in records
+            )
+        except Exception:  # noqa: BLE001 — status must never crash ov
+            logger.debug(
+                "[LastSessionSummary] operator_digest degraded",
+                exc_info=True,
+            )
+            return None
+
+    def operator_digest_sync(
+        self, n_sessions: Optional[int] = None,
+    ) -> Optional[str]:
+        """Synchronous bridge to :meth:`operator_digest` (``ov status``
+        runs before any event loop exists). NEVER raises; degrades to
+        ``None`` from within a running loop — mirrors
+        :meth:`format_for_prompt_sync`."""
+        import asyncio as _asyncio
+        try:
+            _asyncio.get_running_loop()
+        except RuntimeError:
+            try:
+                return _asyncio.run(self.operator_digest(n_sessions))
+            except Exception:  # noqa: BLE001
+                return None
         return None
 
     # ------------------------------------------------------------------

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -241,6 +241,15 @@ _GLYPHS: Mapping[str, tuple] = {
     "cross": ("✗", "X"),    # failed
     "arrow": ("›", ">"),    # prompt / pointer
     "rule": ("─", "-"),     # hairline
+    # Design-language semantic ration (OV_DESIGN_LANGUAGE.md §2) —
+    # the SIX operator-plane glyphs, each with an ASCII degradation
+    # so 16-color/none terminals keep identical geometry.
+    "action": ("⏺", "*"),   # an actor did/does something
+    "detail": ("⎿", "-"),   # continuation under an action
+    "voice": ("💭", "K:"),  # the organism speaking
+    "human": ("🗣", "you:"),  # the operator's words echoed
+    "warn": ("⚠", "!"),     # operator-notable degradation
+    "audio": ("🎙", "mic"),  # live audio-plane state
 }
 
 

--- a/docs/architecture/OV_DESIGN_LANGUAGE.md
+++ b/docs/architecture/OV_DESIGN_LANGUAGE.md
@@ -1,0 +1,104 @@
+# O+V Design Language — the Operator Surface Contract
+
+**Status**: operator-authorized 2026-07-18. Structurally enforced by
+`battle_test/presentation_router.py` (the middleware every CLI-facing
+line pipes through) and `tests/battle_test/test_presentation_ast_parity.py`
+(the AST sentinel that makes bypass a test failure, not a code review
+hope). This document is the *why*; the router is the *law*.
+
+## 1. Identity
+
+O+V's surface is **Restrained Mono with a pulse**: near-monochrome calm
+(single teal chrome, `chrome_color()` reserving green for outcomes),
+borderless flowing output, and a *rationed* set of semantic glyphs that
+give the organism a voice CC doesn't have. Ceremony at the door (the
+awakening crest is the ONE sanctioned moment of brand color), restraint
+at the desk.
+
+## 2. The Glyph Ration (closed set — six, plus typography)
+
+Every operator-facing glyph is one of SIX semantic marks, each with a
+meaning, an ASCII degradation (via `theme.mark()`), and a rule for when
+it may appear. Anything else is scrubbed by the router.
+
+| Glyph | Name | ASCII | Meaning — and the ONLY time it appears |
+|---|---|---|---|
+| `⏺` | `action` | `*` | An actor did/does something: op steps, tool calls, verb outputs' lead line |
+| `⎿` | `detail` | `-` | Continuation/detail under an action line; recast telemetry lands here |
+| `💭` | `voice` | `K:` | The organism speaking in its own voice (Karen, narrative intent) |
+| `🗣` | `human` | `you:` | The operator's words echoed back (transcripts, preambles) |
+| `⚠` | `warn` | `!` | Degradation the operator should notice (budget, dry runway, drift) |
+| `🎙` | `audio` | `mic` | Live audio-plane state (listening, voice channel active) |
+
+**Typographic set** (not rationed — structure, not semantics): `·`
+separator, `✓`/`✗` outcomes, `›` prompt, `─` rule. These come from the
+existing `theme._GLYPHS` table and degrade with it.
+
+Legacy glyphs are ALIASED, not tolerated: `⛲`→`⚠`, and decorative
+emoji (🔍 📊 🛤️ 💡 🧠 ⚡ 🔥 🎯 …) are stripped on the UI plane. Boot
+banners and log files are NOT the UI plane; they keep their grep
+anchors.
+
+## 3. Microcopy Voice
+
+1. **Never show a field name.** `runway=DRY` is telemetry; the operator
+   reads `runway: DRY` (recast) or, better, prose (`anthropic dry,
+   resets in ~5m`). The router recasts `key=value` dumps automatically;
+   surfaces SHOULD do better than the recast by hand.
+2. **Never show a raw enum or a truncated hash without meaning.**
+   `chat-02b3e8ce49ad` earns its place only as an `/expand`-able ref.
+3. **Sentence-case, no exclamation marks, no filler.** The organism is
+   calm. "generation abandoned, back to prompt" — not "Cancelled!!".
+4. **Outcomes are color, not adjectives.** Green text IS "success";
+   the word "successfully" is banned.
+
+## 4. Color Roles (composes `chrome_color()` + `theme.Token`)
+
+| Role | Rule |
+|---|---|
+| Chrome (labels, structure) | single teal; NEVER green |
+| Outcomes | green — reserved by `chrome_color()` discipline |
+| Failures | red, dim red for detail |
+| Warnings | yellow, only with `⚠` |
+| Brand chroma | the awakening crest ONLY |
+
+Tier degradation is owned by `ui/theme.py` (truecolor→256→16→none);
+surfaces never branch on `TERM` themselves — they ask the theme.
+
+## 5. Density & Spacing
+
+- One blank line maximum between blocks (router collapses runs).
+- A verb's output: one `action` lead line, `detail` lines beneath,
+  nothing else. If it needs more than ~8 lines, it needs an
+  `/expand` ref instead.
+- No boxes, no panels, no borders on flowing output (Sovereign
+  borderless render is the standard; Panels only for the boot summary
+  and diff previews).
+
+## 6. Enforcement (the part that survives without discipline)
+
+- **`PresentationRouter`** (`battle_test/presentation_router.py`): the
+  gateway. `route_line()` scrubs unregistered glyphs (alias → strip),
+  recasts `key=value` telemetry into detail-voice, normalizes spacing,
+  and prefixes the semantic glyph — composing `theme.mark()` so ASCII
+  terminals get the same geometry. Master
+  `JARVIS_PRESENTATION_ROUTER_ENABLED` (default on; off = byte-identical
+  legacy passthrough).
+- **Chokepoint wiring**: the harness's `_repl_print` — the funnel every
+  REPL verb, chat turn, and IPC render already flows through — pipes
+  through the router. New surfaces inherit the law by using the funnel.
+- **AST Sentinel** (`test_presentation_ast_parity.py`): walks the
+  declared UI-plane modules and fails on (a) raw `print()` calls,
+  (b) string literals carrying unregistered emoji, (c) a `_repl_print`
+  that no longer routes. The module list grows additively — sweeping a
+  surface means adding it to the sentinel so it can never rot back.
+
+## 7. Sweep Ledger
+
+| Surface | State |
+|---|---|
+| `_repl_print` funnel (all harness verbs, chat sink, IPC renders) | routed 2026-07-18 |
+| status-line liquidity token | canonical `⚠` 2026-07-18 |
+| `presentation_router.py` / `chat_text_bridge.py` / `audio_state_ipc.py` | sentinel-pinned |
+| SerpentFlow op blocks / diff renders | already speak the language (origin of it) |
+| boot preflight, `/help`, narrative renderer, legacy verb bodies | NOT yet swept — add to sentinel as each is swept |

--- a/tests/battle_test/test_liquidity_surfaces.py
+++ b/tests/battle_test/test_liquidity_surfaces.py
@@ -53,14 +53,14 @@ def test_segment_renders_when_dry(ledger):
     snap = StatusLineBuilder().snapshot()
     assert snap.liquidity_exhausted is True
     assert snap.liquidity_provider == "anthropic"
-    assert "⛲ anthropic dry" in _format_plain(snap, compact=False)
+    assert "⚠ anthropic dry" in _format_plain(snap, compact=False)
 
 
 def test_segment_silent_when_healthy(ledger):
     ledger(tokens=9_000_000)
     snap = StatusLineBuilder().snapshot()
     assert snap.liquidity_exhausted is False
-    assert "⛲" not in _format_plain(snap, compact=False)
+    assert "⚠" not in _format_plain(snap, compact=False)
 
 
 def test_segment_surfaces_on_idle_breadcrumb(ledger):
@@ -76,7 +76,7 @@ def test_segment_master_off(ledger, monkeypatch):
     monkeypatch.setenv("JARVIS_STATUS_LIQUIDITY_SEGMENT_ENABLED", "0")
     snap = StatusLineBuilder().snapshot()
     assert snap.liquidity_exhausted is False
-    assert "⛲" not in _format_plain(snap, compact=False)
+    assert "⚠" not in _format_plain(snap, compact=False)
 
 
 def test_segment_reset_minutes_render(ledger):
@@ -112,16 +112,16 @@ def test_verb_renders_provider_rows(ledger):
     joined = "\n".join(lines)
     assert "anthropic" in joined
     assert "12,000,000 tokens" in joined
-    assert "runway=ok" in joined
-    assert "any_exhausted=False" in joined
+    assert "runway: ok" in joined
+    assert "exhausted: no" in joined
 
 
 def test_verb_marks_dry_runway(ledger):
     ledger(tokens=100)
     lines = _run_verb()
     joined = "\n".join(lines)
-    assert "runway=DRY" in joined
-    assert "any_exhausted=True" in joined
+    assert "runway: DRY" in joined
+    assert "exhausted: yes" in joined
 
 
 def test_verb_survives_empty_ledger(tmp_path, monkeypatch):

--- a/tests/battle_test/test_liquidity_surfaces.py
+++ b/tests/battle_test/test_liquidity_surfaces.py
@@ -1,0 +1,141 @@
+"""Item #5 — circadian liquidity operator surfaces.
+
+Pins the ``/liquidity`` REPL verb + the status-line liquidity segment,
+both pure composition over the ProviderLiquidityLedger the Aegis proxy
+hydrates. Restraint contract: the segment renders ONLY when a runway is
+dry — the healthy state is invisible — EXCEPT that a dry runway also
+surfaces on the idle breadcrumb (the organism may be idle BECAUSE it is
+dry).
+"""
+from __future__ import annotations
+
+import json
+import time
+
+import pytest
+
+from backend.core.ouroboros.battle_test.status_line import (
+    StatusLineBuilder,
+    _format_plain,
+)
+from backend.core.ouroboros.governance import provider_liquidity_ledger as pl
+
+
+@pytest.fixture()
+def ledger(tmp_path, monkeypatch):
+    path = tmp_path / "liq.json"
+    monkeypatch.setenv("JARVIS_PROVIDER_LIQUIDITY_PATH", str(path))
+    pl._reset_for_tests()
+
+    def write(tokens: int, reset_s: float = 300.0, provider="anthropic"):
+        path.write_text(json.dumps({
+            "schema_version": pl.PROVIDER_LIQUIDITY_SCHEMA_VERSION,
+            "providers": {provider: {
+                "tokens_remaining": tokens,
+                "reset_delta_s": reset_s,
+                "recorded_unix": time.time(),
+                "last_status": 200,
+            }},
+        }))
+        pl._reset_for_tests()
+
+    yield write
+    pl._reset_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Status-line segment
+# ---------------------------------------------------------------------------
+
+
+def test_segment_renders_when_dry(ledger):
+    ledger(tokens=500)
+    snap = StatusLineBuilder().snapshot()
+    assert snap.liquidity_exhausted is True
+    assert snap.liquidity_provider == "anthropic"
+    assert "⛲ anthropic dry" in _format_plain(snap, compact=False)
+
+
+def test_segment_silent_when_healthy(ledger):
+    ledger(tokens=9_000_000)
+    snap = StatusLineBuilder().snapshot()
+    assert snap.liquidity_exhausted is False
+    assert "⛲" not in _format_plain(snap, compact=False)
+
+
+def test_segment_surfaces_on_idle_breadcrumb(ledger):
+    ledger(tokens=100)
+    snap = StatusLineBuilder().snapshot()
+    line = _format_plain(snap, compact=False)
+    # Whatever restraint mode renders, the dry token must be present.
+    assert "dry" in line
+
+
+def test_segment_master_off(ledger, monkeypatch):
+    ledger(tokens=100)
+    monkeypatch.setenv("JARVIS_STATUS_LIQUIDITY_SEGMENT_ENABLED", "0")
+    snap = StatusLineBuilder().snapshot()
+    assert snap.liquidity_exhausted is False
+    assert "⛲" not in _format_plain(snap, compact=False)
+
+
+def test_segment_reset_minutes_render(ledger):
+    ledger(tokens=100, reset_s=600.0)
+    snap = StatusLineBuilder().snapshot()
+    line = _format_plain(snap, compact=False)
+    assert "~" in line and "m" in line
+
+
+# ---------------------------------------------------------------------------
+# /liquidity verb (unbound-method probe — no harness boot)
+# ---------------------------------------------------------------------------
+
+
+class _FakeHarness:
+    def __init__(self) -> None:
+        self.lines = []
+
+    def _repl_print(self, msg: str) -> None:
+        self.lines.append(msg)
+
+
+def _run_verb() -> list:
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+    h = _FakeHarness()
+    BattleTestHarness._repl_cmd_liquidity(h)
+    return h.lines
+
+
+def test_verb_renders_provider_rows(ledger):
+    ledger(tokens=12_000_000)
+    lines = _run_verb()
+    joined = "\n".join(lines)
+    assert "anthropic" in joined
+    assert "12,000,000 tokens" in joined
+    assert "runway=ok" in joined
+    assert "any_exhausted=False" in joined
+
+
+def test_verb_marks_dry_runway(ledger):
+    ledger(tokens=100)
+    lines = _run_verb()
+    joined = "\n".join(lines)
+    assert "runway=DRY" in joined
+    assert "any_exhausted=True" in joined
+
+
+def test_verb_survives_empty_ledger(tmp_path, monkeypatch):
+    monkeypatch.setenv(
+        "JARVIS_PROVIDER_LIQUIDITY_PATH", str(tmp_path / "absent.json"),
+    )
+    pl._reset_for_tests()
+    lines = _run_verb()
+    assert any("no telemetry recorded yet" in ln for ln in lines)
+
+
+def test_verb_wired_into_repl_dispatch():
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    src = (root / "backend/core/ouroboros/battle_test/harness.py").read_text()
+    assert '"/liquidity"' in src
+    assert "_repl_cmd_liquidity" in src

--- a/tests/battle_test/test_presentation_ast_parity.py
+++ b/tests/battle_test/test_presentation_ast_parity.py
@@ -1,0 +1,208 @@
+"""Design-language enforcement — router behavior + the AST sentinel.
+
+OV_DESIGN_LANGUAGE.md §6: aesthetic consistency across a 1.45M-line
+codebase cannot rest on discipline. Part 1 pins the PresentationRouter's
+conformance behavior (glyph ration, telemetry recast, density, tier
+adaptivity, master-off passthrough). Part 2 is the SENTINEL: an AST
+walker over the declared UI-plane modules asserting that no module
+bypasses the router — raw ``print()`` calls and unregistered emoji
+literals are compile-level failures, not review hopes. The module list
+grows additively as surfaces are swept.
+"""
+from __future__ import annotations
+
+import ast
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test import presentation_router as pr
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+# ===========================================================================
+# Part 1 — router conformance behavior
+# ===========================================================================
+
+
+def test_glyph_ration_is_closed_six():
+    assert pr.canonical_glyph_chars() == frozenset("⏺⎿💭🗣⚠🎙")
+    assert set(g.value for g in pr.Glyph) == {
+        "action", "detail", "voice", "human", "warn", "audio",
+    }
+
+
+def test_scrub_strips_decorative_emoji():
+    assert pr.scrub_glyphs("🔥 deploy 🚀 done 🎯") == "deploy done"
+
+
+def test_scrub_aliases_legacy_liquidity_glyph():
+    assert pr.scrub_glyphs("⛲ anthropic dry ~5m") == "⚠ anthropic dry ~5m"
+
+
+def test_scrub_preserves_ration_and_typography():
+    line = "⏺ apply · ✓ verified ⎿ detail ─ 💭 thinking ⚠ hot 🎙 live 🗣 you"
+    assert pr.scrub_glyphs(line) == line
+
+
+def test_scrub_never_raises():
+    assert pr.scrub_glyphs(None) == "None"     # degrades to str()
+    assert pr.scrub_glyphs("") == ""
+
+
+def test_telemetry_leak_detection():
+    assert pr.looks_like_telemetry("turn=chat-x session=repl") is True
+    assert pr.looks_like_telemetry("a normal sentence = fine") is False
+    assert pr.looks_like_telemetry("one pair=only") is False
+
+
+def test_telemetry_recast_to_detail_voice():
+    out = pr.recast_telemetry("[chat] turn=chat-x session=repl")
+    assert "turn: chat-x" in out
+    assert "session: repl" in out
+    assert " · " in out
+    assert "=" not in out.replace("[chat]", "")
+
+
+def test_route_line_prefixes_semantic_glyph():
+    r = pr.PresentationRouter()
+    out = r.route_line("listening", kind=pr.Glyph.AUDIO)
+    assert out.startswith("🎙 ") or out.startswith("mic ")
+
+
+def test_route_line_does_not_double_prefix():
+    r = pr.PresentationRouter()
+    out = r.route_line("💭 already voiced", kind=pr.Glyph.VOICE)
+    assert out.count("💭") == 1
+
+
+def test_route_block_collapses_blank_runs():
+    r = pr.PresentationRouter()
+    out = r.route_block("a\n\n\n\nb")
+    assert out == "a\n\nb"
+
+
+def test_master_off_is_byte_identical(monkeypatch):
+    monkeypatch.setenv("JARVIS_PRESENTATION_ROUTER_ENABLED", "0")
+    r = pr.PresentationRouter()
+    raw = "🔥 x=1 y=2\n\n\n⛲ untouched"
+    assert r.route_block(raw) == raw
+    assert r.route_line(raw) == raw
+
+
+def test_ascii_tier_keeps_geometry(monkeypatch):
+    """Tier adaptivity: the semantic mark degrades to its ASCII pair
+    (theme.mark) — same shape, no unicode requirement."""
+    from backend.core.ouroboros.ui import theme
+    assert theme.mark("action", unicode=False) == "*"
+    assert theme.mark("warn", unicode=False) == "!"
+    assert theme.mark("audio", unicode=False) == "mic"
+    assert theme.mark("action", unicode=True) == "⏺"
+
+
+def test_router_never_raises_on_garbage():
+    r = pr.PresentationRouter()
+    for bad in (None, 42, b"bytes", object()):
+        assert isinstance(r.route_line(bad), str)   # type: ignore[arg-type]
+
+
+# ===========================================================================
+# Part 2 — the AST sentinel
+# ===========================================================================
+
+#: UI-plane modules under the design-language law. ADDITIVE — sweeping a
+#: surface means adding it here so it can never rot back (§7 ledger).
+SENTINEL_MODULES = (
+    "backend/core/ouroboros/battle_test/presentation_router.py",
+    "backend/core/ouroboros/governance/chat_text_bridge.py",
+    "backend/core/ouroboros/governance/comms/duplex/audio_state_ipc.py",
+    "backend/core/ouroboros/battle_test/status_line.py",
+)
+
+#: Per-module emoji grants for glyphs that are DATA (protocol payload,
+#: docstrings describing renders) rather than direct UI emission.
+_EMOJI_GRANTS = {
+    # none currently — grants require a comment in this table saying why
+}
+
+
+def _iter_module_asts():
+    for rel in SENTINEL_MODULES:
+        path = ROOT / rel
+        yield rel, ast.parse(path.read_text()), path.read_text()
+
+
+def _is_ui_plane_string(s: str) -> bool:
+    return any(pr._is_decorative_symbol(ch) for ch in s)
+
+
+def test_sentinel_no_raw_print_on_ui_plane():
+    """Raw ``print()`` bypasses every conformance layer — banned in the
+    sentinel modules (they must write through a console/logger/router)."""
+    offenders = []
+    for rel, tree, _src in _iter_module_asts():
+        for node in ast.walk(tree):
+            if (
+                isinstance(node, ast.Call)
+                and isinstance(node.func, ast.Name)
+                and node.func.id == "print"
+            ):
+                offenders.append(f"{rel}:{node.lineno}")
+    assert not offenders, f"raw print() on the UI plane: {offenders}"
+
+
+def test_sentinel_no_unregistered_emoji_literals():
+    """String literals in sentinel modules may carry ONLY the rationed
+    glyphs + typography (or an explicit grant). Docstrings are exempt
+    (they describe, they don't render)."""
+    offenders = []
+    for rel, tree, _src in _iter_module_asts():
+        grants = _EMOJI_GRANTS.get(rel, frozenset())
+        docstring_lines = set()
+        for node in ast.walk(tree):
+            if isinstance(node, (ast.Module, ast.ClassDef, ast.FunctionDef,
+                                 ast.AsyncFunctionDef)):
+                ds = ast.get_docstring(node, clean=False)
+                if ds and node.body:
+                    first = node.body[0]
+                    docstring_lines.update(
+                        range(first.lineno, (first.end_lineno or first.lineno) + 1)
+                    )
+        for node in ast.walk(tree):
+            if isinstance(node, ast.Constant) and isinstance(node.value, str):
+                if node.lineno in docstring_lines:
+                    continue
+                bad = [
+                    ch for ch in node.value
+                    if pr._is_decorative_symbol(ch) and ch not in grants
+                ]
+                if bad:
+                    offenders.append(f"{rel}:{node.lineno} {bad!r}")
+    assert not offenders, f"unregistered emoji on the UI plane: {offenders}"
+
+
+def test_sentinel_repl_print_routes_through_router():
+    """THE chokepoint pin: the harness funnel must pipe through the
+    PresentationRouter — every verb inherits the law through it."""
+    src = (ROOT / "backend/core/ouroboros/battle_test/harness.py").read_text()
+    body_start = src.index("def _repl_print")
+    body = src[body_start:body_start + 1200]
+    assert "presentation_router" in body
+    assert "route_block" in body
+
+
+def test_sentinel_status_line_uses_canonical_warn():
+    src = (ROOT / "backend/core/ouroboros/battle_test/status_line.py").read_text()
+    assert "⛲" not in src            # legacy glyph fully retired at source
+    assert "⚠" in src
+
+
+def test_sentinel_module_list_is_additive_documented():
+    """The sweep ledger contract: every sentinel module exists, and the
+    design doc references the sentinel by name."""
+    for rel in SENTINEL_MODULES:
+        assert (ROOT / rel).is_file(), rel
+    doc = (ROOT / "docs/architecture/OV_DESIGN_LANGUAGE.md").read_text()
+    assert "test_presentation_ast_parity.py" in doc
+    assert "PresentationRouter" in doc

--- a/tests/battle_test/test_stream_flow_mode.py
+++ b/tests/battle_test/test_stream_flow_mode.py
@@ -1,0 +1,207 @@
+"""§41.3 #27 — Progressive streaming flow mode (unwrap the Live cage).
+
+Pins the last remaining §41.3 engineering item: with
+``JARVIS_UI_STREAMING_FLOW_MODE_ENABLED=1``, completed markdown blocks are
+committed ABOVE the Rich Live region into terminal scrollback as they
+stream (CC-style progressive flow); the Live cage holds only the current
+in-progress block, and ``end()`` lands the remainder so the ENTIRE stream
+persists in scrollback with no tail truncation.
+
+Master flag default-FALSE per §33.1 — the legacy caged path must stay
+byte-identical when the flag is off.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test import stream_renderer as sr
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("JARVIS_UI_STREAMING_FLOW_MODE_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_UI_STREAMING_ENABLED", "1")
+    sr.reset_stream_renderer()
+    yield
+    sr.reset_stream_renderer()
+
+
+# ---------------------------------------------------------------------------
+# Fakes
+# ---------------------------------------------------------------------------
+
+
+class _FakeConsole:
+    def __init__(self) -> None:
+        self.printed = []
+
+    def print(self, renderable) -> None:
+        self.printed.append(getattr(renderable, "markup", renderable))
+
+
+class _FakeLive:
+    """Duck-typed Rich Live stand-in capturing update/commit traffic."""
+
+    def __init__(self) -> None:
+        self.console = _FakeConsole()
+        self.updates = []
+        self.stopped = False
+
+    def update(self, renderable) -> None:
+        self.updates.append(getattr(renderable, "markup", renderable))
+
+    def stop(self) -> None:
+        self.stopped = True
+
+
+# ---------------------------------------------------------------------------
+# (1) Env gate — §33.1 default-FALSE
+# ---------------------------------------------------------------------------
+
+
+def test_flow_mode_default_off():
+    assert sr.flow_mode_enabled() is False
+
+
+def test_flow_mode_env_on(monkeypatch):
+    monkeypatch.setenv("JARVIS_UI_STREAMING_FLOW_MODE_ENABLED", "1")
+    assert sr.flow_mode_enabled() is True
+
+
+# ---------------------------------------------------------------------------
+# (2) find_commit_boundary — pure fence-aware boundary math
+# ---------------------------------------------------------------------------
+
+
+def test_boundary_none_without_blank_line():
+    assert sr.find_commit_boundary("just one paragraph still typing") == 0
+
+
+def test_boundary_after_complete_paragraph():
+    text = "para one.\n\npara two still typ"
+    b = sr.find_commit_boundary(text)
+    assert b == len("para one.\n\n")
+    assert text[b:] == "para two still typ"
+
+
+def test_boundary_skips_blank_lines_inside_open_fence():
+    text = "intro\n\n```python\ncode\n\nmore code"
+    # Only the blank line BEFORE the fence opens is a safe boundary.
+    assert sr.find_commit_boundary(text) == len("intro\n\n")
+
+
+def test_boundary_advances_after_fence_closes():
+    text = "intro\n\n```python\ncode\n```\n\ntail typing"
+    b = sr.find_commit_boundary(text)
+    assert text[b:] == "tail typing"
+
+
+def test_partial_trailing_blank_line_not_a_boundary():
+    # A "\n" not yet followed by its blank line's terminator stays in flight.
+    assert sr.find_commit_boundary("para one.\n") == 0
+
+
+def test_boundary_incremental_scan_from_prior_boundary():
+    text = "a\n\nb\n\nc typing"
+    b1 = sr.find_commit_boundary(text[:4])       # "a\n\nb"
+    assert b1 == 3
+    b2 = sr.find_commit_boundary(text, b1)
+    assert text[b2:] == "c typing"
+
+
+def test_boundary_never_raises():
+    assert sr.find_commit_boundary("", 0) == 0
+    assert sr.find_commit_boundary("x", 99) == 99   # degenerate start
+
+
+# ---------------------------------------------------------------------------
+# (3) Renderer integration — flow commits above the cage
+# ---------------------------------------------------------------------------
+
+
+def _make_active_renderer(monkeypatch, flow: str) -> "tuple[sr.StreamRenderer, _FakeLive]":
+    """Build a renderer in an active session with a fake Live installed."""
+    monkeypatch.setenv("JARVIS_UI_STREAMING_FLOW_MODE_ENABLED", flow)
+    r = sr.StreamRenderer()
+    fake = _FakeLive()
+
+    async def _boot():
+        r.start("op-flow-test", "claude")
+
+    asyncio.run(_boot())
+    # start() under pytest is non-TTY → _live is None; install the fake and
+    # keep session state (this isolates the render path from real Rich).
+    r._live = fake
+    return r, fake
+
+
+def test_flow_mode_commits_completed_block_and_cages_tail(monkeypatch):
+    r, fake = _make_active_renderer(monkeypatch, "1")
+    r._buffer = "block one.\n\nblock two typ"
+    r._render_buffer_safe()
+    # Completed block landed in scrollback...
+    assert fake.console.printed == ["block one.\n\n"]
+    # ...and the cage renders ONLY the uncommitted tail.
+    assert fake.updates[-1] == "block two typ"
+    assert r._committed_offset == len("block one.\n\n")
+
+
+def test_flow_mode_does_not_recommit(monkeypatch):
+    r, fake = _make_active_renderer(monkeypatch, "1")
+    r._buffer = "block one.\n\nblock two typ"
+    r._render_buffer_safe()
+    r._buffer += "ing more"
+    r._render_buffer_safe()
+    # No new boundary → no second scrollback print.
+    assert len(fake.console.printed) == 1
+    assert fake.updates[-1] == "block two typing more"
+
+
+def test_legacy_mode_never_prints_above_cage(monkeypatch):
+    r, fake = _make_active_renderer(monkeypatch, "0")
+    r._buffer = "block one.\n\nblock two typ"
+    r._render_buffer_safe()
+    # Legacy: nothing committed; whole buffer (tail-sliced) in the cage.
+    assert fake.console.printed == []
+    assert fake.updates[-1] == "block one.\n\nblock two typ"
+    assert r._committed_offset == 0
+
+
+def test_flow_mode_end_lands_remainder_and_clears_cage(monkeypatch):
+    r, fake = _make_active_renderer(monkeypatch, "1")
+    r._buffer = "block one.\n\nfinal words"
+    r._render_buffer_safe()
+    r.end()
+    # end() committed the remainder + cleared the cage before stop.
+    assert fake.console.printed == ["block one.\n\n", "final words"]
+    assert fake.updates[-1] == ""
+    assert fake.stopped is True
+
+
+def test_legacy_mode_end_keeps_final_tail_render(monkeypatch):
+    r, fake = _make_active_renderer(monkeypatch, "0")
+    r._buffer = "block one.\n\nfinal words"
+    r.end()
+    assert fake.console.printed == []
+    assert fake.updates[-1] == "block one.\n\nfinal words"
+    assert fake.stopped is True
+
+
+def test_flow_state_reset_between_sessions(monkeypatch):
+    r, fake = _make_active_renderer(monkeypatch, "1")
+    r._buffer = "a\n\nb"
+    r._render_buffer_safe()
+    r.end()
+    assert r._committed_offset == 0
+    assert r._flow_mode is False
+
+
+def test_mode_snapshotted_at_start_not_per_render(monkeypatch):
+    """One op never splits across modes — the env flip mid-stream is inert."""
+    r, fake = _make_active_renderer(monkeypatch, "0")
+    monkeypatch.setenv("JARVIS_UI_STREAMING_FLOW_MODE_ENABLED", "1")
+    r._buffer = "block one.\n\ntail"
+    r._render_buffer_safe()
+    assert fake.console.printed == []       # still legacy for this op

--- a/tests/governance/test_audio_state_ipc.py
+++ b/tests/governance/test_audio_state_ipc.py
@@ -1,0 +1,344 @@
+"""Stateful IPC Audio Pub/Sub Bridge — reconciliation + degradation spine.
+
+Pins the operator-signed audio architecture (2026-07-18): the
+unified_supervisor owns the hardware plane; the ov cockpit subscribes to
+STATE over a UDS. Four mandates covered:
+
+  1. Root-cause: no audio binding here — pure state pub/sub over the
+     socket (the substrate imports no audio/hardware modules).
+  2. **State-reconciliation handshake** — a client that connects while
+     Karen is MID-SENTENCE receives the accumulated ``text_so_far`` in
+     the FIRST frame and renders it immediately (no ghosting, no fresh
+     prompt). THE headline telemetry of this suite.
+  3. DRY — event kinds are the closed module vocabulary; state machine
+     asserted through the same publish surface the supervisor hooks use.
+  4. Bulletproof degradation — missing socket / refused path / dead
+     server all return ``False`` from a BOUNDED connect (measured), and
+     a malformed frame never kills the feed.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import stat
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex import audio_state_ipc as ipc
+
+
+@pytest.fixture()
+def sock():
+    """A SHORT socket path — AF_UNIX caps sun_path at ~104 chars on
+    macOS and pytest's tmp_path breaches it. Production is unaffected
+    (the default is the repo-relative ``.jarvis/audio_state.sock``)."""
+    import shutil
+    import tempfile
+    d = tempfile.mkdtemp(prefix="aipc")
+    try:
+        yield __import__("pathlib").Path(d) / "a.sock"
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+async def _mk_server(sock):
+    b = ipc.AudioStateBroadcaster(path=sock)
+    assert await b.start() is True
+    return b
+
+
+class _Sink:
+    def __init__(self) -> None:
+        self.handshakes = []
+        self.messages = []
+        self.rendered = []
+
+    def on_handshake(self, msg):
+        self.handshakes.append(msg)
+        utt = msg.get("active_utterance")
+        if utt and utt.get("text_so_far"):
+            self.rendered.append(
+                f"{utt['role']} (mid-sentence) > {utt['text_so_far']}"
+            )
+
+    def on_message(self, msg):
+        self.messages.append(msg)
+
+
+async def _connect(sock, sink):
+    c = ipc.AudioStateClient(
+        on_handshake=sink.on_handshake, on_message=sink.on_message, path=sock,
+    )
+    ok = await c.connect()
+    return c, ok
+
+
+# ---------------------------------------------------------------------------
+# (1) THE reconciliation handshake — mid-sentence join renders immediately
+# ---------------------------------------------------------------------------
+
+
+async def test_mid_sentence_join_renders_ongoing_transcript(sock):
+    b = await _mk_server(sock)
+    try:
+        # Karen is mid-sentence: three chunks published, none final.
+        uid = b.publish_transcript("karen", "The validation gate ")
+        b.publish_transcript("karen", "is holding because ", utterance_id=uid)
+        b.publish_transcript("karen", "the sandbox drifted", utterance_id=uid)
+
+        # A NEW terminal opens now.
+        sink = _Sink()
+        c, ok = await _connect(sock, sink)
+        assert ok is True
+        # The FIRST frame carried the full accumulated text — the UI
+        # rendered it with zero further round-trips.
+        assert len(sink.handshakes) == 1
+        utt = sink.handshakes[0]["active_utterance"]
+        assert utt["utterance_id"] == uid
+        assert utt["role"] == "karen"
+        assert utt["text_so_far"] == (
+            "The validation gate is holding because the sandbox drifted"
+        )
+        assert sink.rendered == [
+            "karen (mid-sentence) > The validation gate is holding "
+            "because the sandbox drifted"
+        ]
+        await c.close()
+    finally:
+        await b.stop()
+
+
+async def test_handshake_state_snapshot_reflects_live_flags(sock):
+    b = await _mk_server(sock)
+    try:
+        b.publish_event(ipc.EVENT_TTS_GENERATING)
+        b.publish_event(ipc.EVENT_AUDIO_PLAYING)
+        sink = _Sink()
+        c, ok = await _connect(sock, sink)
+        assert ok
+        state = sink.handshakes[0]["state"]
+        assert state["audio_playing"] is True
+        assert state["tts_generating"] is False   # PLAYING supersedes
+        assert sink.handshakes[0]["schema_version"] == (
+            ipc.AUDIO_IPC_SCHEMA_VERSION
+        )
+        await c.close()
+    finally:
+        await b.stop()
+
+
+async def test_final_utterance_clears_active_slot(sock):
+    b = await _mk_server(sock)
+    try:
+        uid = b.publish_transcript("karen", "done now", final=True)
+        assert uid
+        sink = _Sink()
+        c, ok = await _connect(sock, sink)
+        assert ok
+        assert sink.handshakes[0]["active_utterance"] is None
+        # ...but the sealed line is replayable from the recent ring.
+        recent = sink.handshakes[0]["recent"]
+        assert any(
+            m.get("type") == "transcript" and m.get("final") for m in recent
+        )
+        await c.close()
+    finally:
+        await b.stop()
+
+
+# ---------------------------------------------------------------------------
+# (2) Live pub/sub after connect
+# ---------------------------------------------------------------------------
+
+
+async def test_events_stream_to_connected_clients(sock):
+    b = await _mk_server(sock)
+    try:
+        sink = _Sink()
+        c, ok = await _connect(sock, sink)
+        assert ok
+        b.publish_event(ipc.EVENT_VAD_ACTIVE)
+        b.publish_transcript("user", "run the tests", final=True)
+        for _ in range(50):
+            if len(sink.messages) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        kinds = [m.get("kind") or m.get("type") for m in sink.messages]
+        assert "VAD_ACTIVE" in kinds
+        assert "transcript" in kinds
+        await c.close()
+    finally:
+        await b.stop()
+
+
+async def test_vad_publisher_is_edge_coalesced(sock):
+    b = await _mk_server(sock)
+    try:
+        sink = _Sink()
+        c, ok = await _connect(sock, sink)
+        assert ok
+        for _ in range(25):
+            b.publish_vad(True)      # 50Hz frame spam — ONE edge
+        b.publish_vad(False)
+        for _ in range(50):
+            if len(sink.messages) >= 2:
+                break
+            await asyncio.sleep(0.02)
+        kinds = [m.get("kind") for m in sink.messages]
+        assert kinds.count("VAD_ACTIVE") == 1
+        assert kinds.count("VAD_INACTIVE") == 1
+        await c.close()
+    finally:
+        await b.stop()
+
+
+async def test_two_clients_both_receive(sock):
+    b = await _mk_server(sock)
+    try:
+        s1, s2 = _Sink(), _Sink()
+        c1, ok1 = await _connect(sock, s1)
+        c2, ok2 = await _connect(sock, s2)
+        assert ok1 and ok2 and b.client_count == 2
+        b.publish_event(ipc.EVENT_TTS_GENERATING)
+        for _ in range(50):
+            if s1.messages and s2.messages:
+                break
+            await asyncio.sleep(0.02)
+        assert s1.messages and s2.messages
+        await c1.close()
+        await c2.close()
+    finally:
+        await b.stop()
+
+
+# ---------------------------------------------------------------------------
+# (3) Bulletproof degradation — the dead-daemon contract
+# ---------------------------------------------------------------------------
+
+
+async def test_missing_socket_degrades_fast_and_false(sock):
+    c = ipc.AudioStateClient(path=sock.parent / "nope.sock")
+    t0 = time.monotonic()
+    ok = await c.connect()
+    elapsed = time.monotonic() - t0
+    assert ok is False
+    assert c.connected is False
+    assert elapsed < 1.5          # bounded — never hangs the UI loop
+
+
+async def test_refused_non_socket_path_degrades(sock):
+    bogus = sock.parent / "plainfile.sock"
+    bogus.write_text("plain file")
+    c = ipc.AudioStateClient(path=bogus)
+    assert await c.connect() is False
+
+
+async def test_server_gone_midstream_marks_disconnected(sock):
+    b = await _mk_server(sock)
+    sink = _Sink()
+    c, ok = await _connect(sock, sink)
+    assert ok and c.connected
+    await b.stop()
+    for _ in range(50):
+        if not c.connected:
+            break
+        await asyncio.sleep(0.02)
+    assert c.connected is False
+    await c.close()
+
+
+async def test_malformed_frame_never_kills_feed(sock):
+    b = await _mk_server(sock)
+    try:
+        sink = _Sink()
+        c, ok = await _connect(sock, sink)
+        assert ok
+        # Inject garbage directly to every connected writer.
+        for w in list(b._clients):
+            w.write(b"{not json}\n")
+        b.publish_event(ipc.EVENT_AUDIO_IDLE)
+        for _ in range(50):
+            if sink.messages:
+                break
+            await asyncio.sleep(0.02)
+        assert any(m.get("kind") == "AUDIO_IDLE" for m in sink.messages)
+        await c.close()
+    finally:
+        await b.stop()
+
+
+# ---------------------------------------------------------------------------
+# (4) Hygiene — perms, ring bounds, stale-socket rebind, teardown
+# ---------------------------------------------------------------------------
+
+
+async def test_socket_perms_owner_only(sock):
+    b = await _mk_server(sock)
+    try:
+        mode = stat.S_IMODE(os.stat(sock).st_mode)
+        assert mode == 0o600
+    finally:
+        await b.stop()
+
+
+async def test_recent_ring_is_bounded(sock, monkeypatch):
+    monkeypatch.setenv("JARVIS_AUDIO_IPC_RECENT", "10")
+    b = ipc.AudioStateBroadcaster(path=sock)
+    assert await b.start()
+    try:
+        for i in range(50):
+            b.publish_transcript("karen", f"line {i}", final=True)
+        sink = _Sink()
+        c, ok = await _connect(sock, sink)
+        assert ok
+        assert len(sink.handshakes[0]["recent"]) <= 10
+        await c.close()
+    finally:
+        await b.stop()
+
+
+async def test_stale_socket_file_is_rebindable(sock):
+    b1 = await _mk_server(sock)
+    # Simulate crash: no stop(), just drop the server object's bind by
+    # closing without unlink — then a fresh boot must still bind.
+    b1._server.close()
+    b2 = ipc.AudioStateBroadcaster(path=sock)
+    assert await b2.start() is True
+    await b2.stop()
+
+
+async def test_stop_unlinks_socket(sock):
+    b = await _mk_server(sock)
+    assert sock.exists()
+    await b.stop()
+    assert not sock.exists()
+
+
+# ---------------------------------------------------------------------------
+# (5) Wiring pins — supervisor + cockpit mounts (source-anchored)
+# ---------------------------------------------------------------------------
+
+
+def _read(rel: str) -> str:
+    from pathlib import Path
+    return (Path(__file__).resolve().parents[2] / rel).read_text()
+
+
+def test_supervisor_bootstrap_mounts_broadcaster_and_hooks():
+    src = _read("backend/audio/audio_pipeline_bootstrap.py")
+    assert "AudioStateBroadcaster" in src
+    assert "publish_vad" in src                  # shared VAD decision feeds IPC
+    assert "_ipc_turn_fork" in src               # user transcript fork
+    assert "_prev_fork" in src                   # ...CHAINS the voice->build fork
+    assert "_ipc_submit_speech" in src           # Karen line wrapper
+    assert "handle.audio_ipc.stop()" in src      # shutdown unlinks socket
+
+
+def test_cockpit_harness_mounts_bounded_client():
+    src = _read("backend/core/ouroboros/battle_test/harness.py")
+    assert "_start_audio_ipc_client" in src
+    assert "is_cockpit()" in src
+    body = src[src.index("async def _start_audio_ipc_client"):][:4000]
+    assert "mid-sentence" in body                # reconciliation render
+    assert "text-only" in body                   # degradation contract

--- a/tests/governance/test_chat_text_bridge.py
+++ b/tests/governance/test_chat_text_bridge.py
@@ -1,0 +1,354 @@
+"""Heuristic Intent Multiplexer — REPL text-plane bridge regression spine.
+
+Pins the four mandates of the chat_text_bridge authorization:
+
+1. Root-cause: the bridge composes the CANONICAL classifier/dispatcher —
+   the verdict_override seam is additive (None = byte-identical legacy).
+2. Async multiplexer: submit() never blocks; Ctrl+C (KeyboardInterrupt →
+   token trigger) aborts an in-flight turn and returns to the prompt.
+3. DRY: routing runs through the real ChatReplDispatcher +
+   ConversationOrchestrator — the tests below use a RECORDING executor
+   behind the real dispatch path, not a parallel router.
+4. Bulletproof: standard string → chat executor (query_claude); code
+   block → task executor (dispatch_backlog); injected interrupt →
+   cancellation with ZERO orphaned tasks left on the event loop.
+"""
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+
+from backend.core.ouroboros.governance import chat_text_bridge as ctb
+from backend.core.ouroboros.governance.chat_repl_dispatcher import (
+    ChatReplDispatcher,
+)
+from backend.core.ouroboros.governance.intent_classifier import ChatIntent
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    monkeypatch.delenv("JARVIS_CHAT_TEXT_BRIDGE_ENABLED", raising=False)
+    monkeypatch.setenv("JARVIS_CONVERSATIONAL_MODE_ENABLED", "1")
+    yield
+
+
+# ---------------------------------------------------------------------------
+# Recording executor — real Protocol, observable side
+# ---------------------------------------------------------------------------
+
+
+class _RecordingExecutor:
+    """ChatActionExecutor with an inspectable call log. ``block_event``
+    (optional) makes query/backlog calls park until released — the
+    cancellation tests use it to hold a 'generation' mid-flight."""
+
+    def __init__(self, block_event: "threading.Event | None" = None) -> None:
+        self.calls = []
+        self._block = block_event
+        self.entered = threading.Event()
+
+    def _maybe_block(self) -> None:
+        self.entered.set()
+        if self._block is not None:
+            self._block.wait(timeout=30)
+
+    def dispatch_backlog(self, message, turn):
+        self.calls.append(("dispatch_backlog", message))
+        self._maybe_block()
+        return "backlog-id-1"
+
+    def spawn_subagent(self, message, turn):
+        self.calls.append(("spawn_subagent", message))
+        self._maybe_block()
+        return "subagent-id-1"
+
+    def query_claude(self, message, turn, recent_turns):
+        self.calls.append(("query_claude", message))
+        self._maybe_block()
+        return "claude-answer"
+
+    def attach_context(self, message, turn, target_turn):
+        self.calls.append(("attach_context", message))
+        return "attached"
+
+
+def _mux(executor, **kw):
+    d = ChatReplDispatcher(executor=executor)
+    return ctb.ChatTextMultiplexer(d, **kw)
+
+
+CODE_BLOCK = (
+    "```python\n"
+    "def frobnicate(x):\n"
+    "    return x * 2\n"
+    "```"
+)
+
+
+# ---------------------------------------------------------------------------
+# (1) Code-shape pre-filter — pure evidence
+# ---------------------------------------------------------------------------
+
+
+def test_signals_empty_for_prose():
+    assert ctb.code_shape_signals("how does the intake router work?") == ()
+
+
+def test_signals_empty_for_single_word():
+    # "status" parses as a bare Name — must NOT count as code.
+    assert ctb.code_shape_signals("status") == ()
+
+
+def test_signals_fence_and_ast():
+    signals = ctb.code_shape_signals(CODE_BLOCK)
+    assert ctb.SIGNAL_FENCED in signals
+    assert ctb.SIGNAL_AST in signals
+
+
+def test_signals_raw_multiline_code_without_fence():
+    raw = "import os\nvalue = os.environ.get('X')\nprint(value)"
+    assert ctb.SIGNAL_AST in ctb.code_shape_signals(raw)
+
+
+def test_signals_never_raise():
+    assert ctb.code_shape_signals(None) == ()      # type: ignore[arg-type]
+    assert ctb.code_shape_signals("") == ()
+
+
+# ---------------------------------------------------------------------------
+# (2) weighted_classify — TASK-over-CHAT re-weighting
+# ---------------------------------------------------------------------------
+
+
+def test_prose_question_stays_chat():
+    v = ctb.weighted_classify("how does the intake router work?")
+    assert v.intent == ChatIntent.EXPLANATION
+    assert ctb.BOOST_REASON not in v.reasons
+
+
+def test_chat_shape_with_code_reweights_to_task():
+    v = ctb.weighted_classify(
+        "how should this behave?\n" + CODE_BLOCK,
+    )
+    assert v.intent == ChatIntent.ACTION_REQUEST
+    assert ctb.BOOST_REASON in v.reasons
+    assert v.confidence >= 0.55
+
+
+def test_pure_runnable_paste_reweights_to_task():
+    # Base classifier calls this CONTEXT_PASTE (fence fires first);
+    # runnable code handed to an engineering organism is a work order.
+    v = ctb.weighted_classify(CODE_BLOCK)
+    assert v.intent == ChatIntent.ACTION_REQUEST
+    assert ctb.SIGNAL_AST in v.reasons
+
+
+def test_stacktrace_paste_keeps_attach_semantics():
+    trace = (
+        "Traceback (most recent call last):\n"
+        '  File "x.py", line 3, in <module>\n'
+        "KeyError: 'missing'"
+    )
+    v = ctb.weighted_classify(trace)
+    # Diagnostic context (not AST-parseable) keeps canonical paste-attach.
+    assert v.intent == ChatIntent.CONTEXT_PASTE
+
+
+def test_action_request_with_code_gets_confidence_bump():
+    base_text = "fix this function:\n" + CODE_BLOCK
+    v = ctb.weighted_classify(base_text)
+    assert v.intent == ChatIntent.ACTION_REQUEST
+    assert ctb.BOOST_REASON in v.reasons
+
+
+# ---------------------------------------------------------------------------
+# (3) Multiplexer routing through the REAL dispatcher
+# ---------------------------------------------------------------------------
+
+
+async def test_standard_string_routes_to_chat_executor():
+    ex = _RecordingExecutor()
+    mux = _mux(ex)
+    task = mux.submit("what is the current posture of the organism?")
+    assert task is not None
+    result = await task
+    assert result is not None
+    assert [c[0] for c in ex.calls] == ["query_claude"]
+
+
+async def test_code_block_routes_to_task_executor():
+    ex = _RecordingExecutor()
+    mux = _mux(ex)
+    task = mux.submit("how should this behave?\n" + CODE_BLOCK)
+    assert task is not None
+    await task
+    assert [c[0] for c in ex.calls] == ["dispatch_backlog"]
+
+
+async def test_submit_is_nonblocking_and_renders_to_sink():
+    lines = []
+    ex = _RecordingExecutor()
+    mux = _mux(ex, print_sink=lines.append)
+    task = mux.submit("why did the last op fail?")
+    assert task is not None and not task.done()   # returned before work ran
+    await task
+    assert lines and "claude-answer" in lines[-1]
+
+
+async def test_empty_submit_is_noop():
+    mux = _mux(_RecordingExecutor())
+    assert mux.submit("") is None
+    assert mux.submit("   ") is None
+    assert mux.active_count == 0
+
+
+# ---------------------------------------------------------------------------
+# (4) Cancellation — KeyboardInterrupt → token → graceful abort, no orphans
+# ---------------------------------------------------------------------------
+
+
+async def test_keyboard_interrupt_cancels_without_orphans():
+    baseline = len(asyncio.all_tasks())
+    release = threading.Event()
+    ex = _RecordingExecutor(block_event=release)
+    lines = []
+    mux = _mux(ex, print_sink=lines.append)
+
+    task = mux.submit("what is blocking the pipeline right now?")
+    assert task is not None
+    # Wait for the 'generation' to actually be in flight.
+    await asyncio.to_thread(ex.entered.wait, 5)
+
+    # The REPL surface: prompt_toolkit raises KeyboardInterrupt into
+    # the input loop; the on_interrupt hook triggers the token.
+    try:
+        raise KeyboardInterrupt
+    except KeyboardInterrupt:
+        mux.cancel_active()
+
+    result = await task                     # returns promptly, cancelled
+    assert result is None
+    assert any("abandoned" in ln for ln in lines)
+
+    release.set()                           # let the worker thread drain
+    await mux.drain()
+    assert mux.active_count == 0
+    # No orphaned asyncio tasks may remain beyond the pre-test baseline.
+    await asyncio.sleep(0)
+    leaked = [
+        t for t in asyncio.all_tasks()
+        if not t.done() and t is not asyncio.current_task()
+    ]
+    assert len(leaked) <= baseline
+
+
+async def test_token_resets_for_next_turn_after_cancel():
+    release = threading.Event()
+    ex = _RecordingExecutor(block_event=release)
+    mux = _mux(ex)
+    t1 = mux.submit("what changed since the last soak?")
+    await asyncio.to_thread(ex.entered.wait, 5)
+    mux.cancel_active()
+    assert await t1 is None
+    release.set()
+
+    # Next turn must run to completion — the token cleared itself.
+    ex2_calls_before = len(ex.calls)
+    ex.entered.clear()
+    t2 = mux.submit("why is doubleword degraded?")
+    assert t2 is not None
+    result = await t2
+    assert result is not None
+    assert len(ex.calls) > ex2_calls_before
+
+
+async def test_drain_cancels_inflight_turns():
+    release = threading.Event()
+    ex = _RecordingExecutor(block_event=release)
+    mux = _mux(ex)
+    t = mux.submit("summarize the session so far")
+    await asyncio.to_thread(ex.entered.wait, 5)
+    release.set()
+    await mux.drain()
+    assert mux.active_count == 0
+    assert t is not None and t.done()
+
+
+# ---------------------------------------------------------------------------
+# (5) Factory + flag gates + additive-seam legacy parity
+# ---------------------------------------------------------------------------
+
+
+def test_factory_none_when_bridge_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_CHAT_TEXT_BRIDGE_ENABLED", "0")
+    assert ctb.build_chat_text_multiplexer() is None
+
+
+def test_factory_none_when_chat_master_off(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONVERSATIONAL_MODE_ENABLED", "false")
+    assert ctb.build_chat_text_multiplexer() is None
+
+
+def test_factory_builds_over_canonical_chain():
+    mux = ctb.build_chat_text_multiplexer()
+    assert isinstance(mux, ctb.ChatTextMultiplexer)
+
+
+def test_verdict_override_none_is_legacy_byte_identical():
+    """The additive seam: handle() without an override must produce the
+    same decision the pre-seam code produced (inline classify path)."""
+    ex_a, ex_b = _RecordingExecutor(), _RecordingExecutor()
+    d_legacy = ChatReplDispatcher(executor=ex_a)
+    d_seam = ChatReplDispatcher(executor=ex_b)
+    msg = "explain the risk ladder"
+    r1 = d_legacy.handle(msg)
+    r2 = d_seam.handle(msg, verdict_override=None)
+    assert r1.decision.action == r2.decision.action == "claude_query"
+
+
+def test_verdict_override_steers_the_route():
+    ex = _RecordingExecutor()
+    d = ChatReplDispatcher(executor=ex)
+    v = ctb.weighted_classify("how should this behave?\n" + CODE_BLOCK)
+    d.handle("how should this behave?\n" + CODE_BLOCK, verdict_override=v)
+    assert ex.calls[0][0] == "dispatch_backlog"
+
+
+# ---------------------------------------------------------------------------
+# (6) Harness + REPL wiring pins (source-anchored, refactor-detecting)
+# ---------------------------------------------------------------------------
+
+
+def _read(path: str) -> str:
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    return (root / path).read_text()
+
+
+def test_harness_fall_through_mounts_bridge():
+    src = _read("backend/core/ouroboros/battle_test/harness.py")
+    assert "_try_chat_text_bridge(command)" in src
+    assert "build_chat_text_multiplexer" in src
+    # The mount must live BEFORE the terminal unknown-command log.
+    mount = src.index("_try_chat_text_bridge(command)")
+    unknown = src.index('logger.debug("Unknown REPL command', mount)
+    assert unknown > mount
+
+
+def test_harness_slash_input_never_routes_to_chat():
+    src = _read("backend/core/ouroboros/battle_test/harness.py")
+    body_start = src.index("def _try_chat_text_bridge")
+    body = src[body_start:body_start + 2000]
+    assert 'text.startswith("/")' in body
+
+
+def test_serpent_repl_interrupt_hook_present():
+    src = _read("backend/core/ouroboros/battle_test/serpent_flow.py")
+    assert 'getattr(self, "on_interrupt", None)' in src
+
+
+def test_harness_drains_mux_at_shutdown():
+    src = _read("backend/core/ouroboros/battle_test/harness.py")
+    assert "await mux.drain()" in src

--- a/tests/governance/test_curiosity_scan_observability.py
+++ b/tests/governance/test_curiosity_scan_observability.py
@@ -1,0 +1,168 @@
+"""Curiosity-scan observability closure — silent zero-emission is dead.
+
+The bt-2026-07-18-231346 graduation soak produced ZERO curiosity log
+lines and the outcome was undiagnosable: ``run_curiosity_scan_once``
+logged only when ``emitted > 0``, and the sensor's reader path logged
+nothing at all on empty rankings. These tests pin the fix:
+
+  1. every armed scan logs ONE verdict line, emission or not;
+  2. ``zero_cause`` is a CLASSIFIED value from the closed taxonomy,
+     ordered by starvation point (data → budget → construction →
+     transport → admission);
+  3. the sensor's reader path logs its rankings/decision histogram;
+  4. the report schema stays additive (legacy fields untouched).
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+
+import pytest
+
+from backend.core.ouroboros.governance import domain_entropy_engine as dee
+
+
+@pytest.fixture(autouse=True)
+def _armed(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "true")
+    yield
+
+
+CLUSTERS = [
+    {"cluster_id": "a", "kind": "goal", "size": 3},
+    {"cluster_id": "b", "kind": "goal", "size": 30},
+]
+
+
+class _Router:
+    def __init__(self, verdict="enqueued"):
+        self.verdict = verdict
+        self.ingested = []
+
+    async def ingest(self, env):
+        self.ingested.append(env)
+        return self.verdict
+
+
+class _Load:
+    """Duck-typed cognitive-load report."""
+    def __init__(self, verdict_value):
+        class _V:  # noqa: D401
+            value = verdict_value
+        self.verdict = _V()
+
+
+def _scan(**kw):
+    return asyncio.run(dee.run_curiosity_scan_once(**kw))
+
+
+# ---------------------------------------------------------------------------
+# (1) Zero-cause taxonomy — each starvation point classified
+# ---------------------------------------------------------------------------
+
+
+def test_disabled_scan_carries_master_disabled(monkeypatch):
+    monkeypatch.setenv("JARVIS_DOMAIN_ENTROPY_ENGINE_ENABLED", "false")
+    rep = _scan(router=_Router())
+    assert rep.zero_cause == dee.ZERO_CAUSE_DISABLED
+    assert rep.master_enabled is False
+
+
+def test_no_zones_cause(caplog):
+    with caplog.at_level(logging.INFO):
+        rep = _scan(router=_Router(), clusters=[])
+    assert rep.zero_cause == dee.ZERO_CAUSE_NO_ZONES
+    assert "zero_cause=no_zones" in caplog.text
+
+
+def test_budget_zero_cause_when_overloaded(caplog):
+    with caplog.at_level(logging.INFO):
+        rep = _scan(
+            router=_Router(), clusters=CLUSTERS,
+            load_report=_Load("overloaded"),
+        )
+    assert rep.zero_cause == dee.ZERO_CAUSE_BUDGET
+    assert rep.zones_identified == 2
+    assert "zero_cause=budget_zero" in caplog.text
+
+
+def test_router_missing_cause():
+    rep = _scan(router=None, clusters=CLUSTERS, load_report=_Load("normal"))
+    assert rep.zero_cause == dee.ZERO_CAUSE_ROUTER_MISSING
+
+
+def test_ingest_rejected_cause_with_histogram(caplog):
+    with caplog.at_level(logging.INFO):
+        rep = _scan(
+            router=_Router(verdict="rejected_governor"),
+            clusters=CLUSTERS, load_report=_Load("normal"),
+        )
+    assert rep.zero_cause == dee.ZERO_CAUSE_INGEST_REJECTED
+    assert "rejected_governor" in caplog.text     # histogram surfaces WHY
+    assert rep.emitted == 0
+    assert len(rep.ingest_results) >= 1
+
+
+def test_taxonomy_is_closed_and_ordered():
+    assert dee.SCAN_ZERO_CAUSES == (
+        dee.ZERO_CAUSE_DISABLED, dee.ZERO_CAUSE_NO_ZONES,
+        dee.ZERO_CAUSE_BUDGET, dee.ZERO_CAUSE_NO_ENVELOPES,
+        dee.ZERO_CAUSE_ROUTER_MISSING, dee.ZERO_CAUSE_INGEST_REJECTED,
+    )
+
+
+# ---------------------------------------------------------------------------
+# (2) The verdict line is UNCONDITIONAL when armed
+# ---------------------------------------------------------------------------
+
+
+def test_zero_emission_scan_still_logs_verdict(caplog):
+    with caplog.at_level(logging.INFO):
+        _scan(router=None, clusters=[], load_report=_Load("normal"))
+    assert "[DomainEntropy] proactive scan" in caplog.text
+
+
+def test_successful_emission_logs_and_has_empty_zero_cause(caplog):
+    with caplog.at_level(logging.INFO):
+        rep = _scan(
+            router=_Router(), clusters=CLUSTERS, load_report=_Load("normal"),
+        )
+    assert rep.emitted >= 1
+    assert rep.zero_cause == ""
+    assert "emitted=" in caplog.text
+    assert "zero_cause" not in rep.diagnostic
+
+
+# ---------------------------------------------------------------------------
+# (3) Schema stays additive
+# ---------------------------------------------------------------------------
+
+
+def test_report_legacy_fields_unchanged():
+    rep = _scan(router=_Router(), clusters=CLUSTERS, load_report=_Load("normal"))
+    for field in (
+        "master_enabled", "normalized_entropy", "zones_identified",
+        "budget", "emitted", "ingest_results", "diagnostic",
+        "schema_version",
+    ):
+        assert hasattr(rep, field)
+    assert rep.schema_version == dee.DOMAIN_ENTROPY_SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# (4) Sensor reader-path verdict line (source-anchored pin + unit)
+# ---------------------------------------------------------------------------
+
+
+def test_sensor_reader_scan_line_is_unconditional():
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    src = (
+        root / "backend/core/ouroboros/governance/intake/sensors/"
+        "proactive_exploration_sensor.py"
+    ).read_text()
+    # The verdict line must sit BEFORE the per-ranking emission loop —
+    # i.e., it fires even when rankings is empty.
+    line = src.index("curiosity-reader scan")
+    loop = src.index("for ranking in rankings:", line)
+    assert loop > line

--- a/tests/governance/test_ov_status_operator_digest.py
+++ b/tests/governance/test_ov_status_operator_digest.py
@@ -1,0 +1,179 @@
+"""``ov status`` operator digest — the wired-but-inert fix.
+
+Root cause pinned: ``ov status`` read through
+``LastSessionSummary.format_for_prompt_sync`` — the AUTONOMY-plane
+surface gated by ``JARVIS_LAST_SESSION_SUMMARY_ENABLED`` (default
+FALSE, governing the organism's prompt-injection authority) — so an
+operator with 50+ session dirs on disk saw "no prior session found".
+
+The fix separates the planes on the SAME parse machinery:
+  * ``operator_digest`` / ``_sync`` — ungated, recency (mtime) ordered;
+  * ``load`` / ``format_for_prompt`` — untouched, still autonomy-gated,
+    still lex-max ordered.
+"""
+from __future__ import annotations
+
+import json
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.last_session_summary import (
+    LastSessionSummary,
+)
+
+
+@pytest.fixture(autouse=True)
+def _clean_env(monkeypatch):
+    for k in (
+        "JARVIS_LAST_SESSION_SUMMARY_ENABLED",
+        "JARVIS_OV_STATUS_SESSIONS",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    yield
+
+
+def _mk_session(root: Path, name: str, *, mtime: float, **overrides) -> None:
+    d = root / ".ouroboros" / "sessions" / name
+    d.mkdir(parents=True)
+    payload = {
+        "schema_version": 2,
+        "session_id": name,
+        "stop_reason": "idle_timeout",
+        "duration_s": 120.0,
+        "stats": {"attempted": 3, "completed": 1, "failed": 2,
+                  "cancelled": 0, "queued": 0},
+        "cost_total": 0.25,
+        "cost_breakdown": {"claude": 0.25},
+    }
+    payload.update(overrides)
+    p = d / "summary.json"
+    p.write_text(json.dumps(payload))
+    os.utime(p, (mtime, mtime))
+
+
+# ---------------------------------------------------------------------------
+# (1) The operator plane is UNGATED
+# ---------------------------------------------------------------------------
+
+
+def test_digest_works_without_autonomy_flag(tmp_path):
+    _mk_session(tmp_path, "bt-2026-07-18-000001", mtime=time.time())
+    lss = LastSessionSummary(tmp_path)
+    digest = lss.operator_digest_sync()
+    assert digest is not None
+    assert "bt-2026-07-18-000001" in digest
+    assert "idle_timeout" in digest
+
+
+def test_autonomy_plane_stays_gated(tmp_path):
+    """The SAME instance: operator digest renders, prompt injection
+    stays None while the master flag is unset (default FALSE)."""
+    _mk_session(tmp_path, "bt-2026-07-18-000001", mtime=time.time())
+    lss = LastSessionSummary(tmp_path)
+    assert lss.operator_digest_sync() is not None
+    assert lss.format_for_prompt_sync() is None
+
+
+def test_digest_none_when_no_sessions(tmp_path):
+    assert LastSessionSummary(tmp_path).operator_digest_sync() is None
+
+
+# ---------------------------------------------------------------------------
+# (2) Recency (mtime) ordering — bt-iso-* cannot shadow newer sessions
+# ---------------------------------------------------------------------------
+
+
+def test_mtime_order_beats_lex_shadowing(tmp_path):
+    now = time.time()
+    # Lexicographically bt-iso-* > bt-2026-* ("i" > "2") — but the
+    # bt-2026 session closed LATER and must render FIRST.
+    _mk_session(tmp_path, "bt-iso-1783990000", mtime=now - 3600)
+    _mk_session(tmp_path, "bt-2026-07-18-235959", mtime=now)
+    digest = LastSessionSummary(tmp_path).operator_digest_sync()
+    assert digest is not None
+    lines = digest.splitlines()
+    assert lines[0].startswith("bt-2026-07-18-235959")
+    assert lines[1].startswith("bt-iso-")
+
+
+def test_session_count_env_knob(tmp_path, monkeypatch):
+    now = time.time()
+    for i in range(5):
+        _mk_session(tmp_path, f"bt-2026-07-18-00000{i}", mtime=now - i)
+    monkeypatch.setenv("JARVIS_OV_STATUS_SESSIONS", "2")
+    digest = LastSessionSummary(tmp_path).operator_digest_sync()
+    assert digest is not None
+    assert len(digest.splitlines()) == 2
+
+
+# ---------------------------------------------------------------------------
+# (3) Render content — apply/verify/commit segments are conditional
+# ---------------------------------------------------------------------------
+
+
+def test_render_includes_apply_verify_commit_when_present(tmp_path):
+    # v1.1a fields nest under summary.json's "ops_digest" key — the
+    # fixture mirrors the REAL schema the harness writes.
+    _mk_session(
+        tmp_path, "bt-2026-07-18-000009", mtime=time.time(),
+        ops_digest={
+            "last_apply_mode": "multi", "last_apply_files": 2,
+            "last_verify_tests_passed": 4, "last_verify_tests_total": 4,
+            "last_commit_hash": "f6abcdbec5deadbeef",
+        },
+    )
+    digest = LastSessionSummary(tmp_path).operator_digest_sync()
+    assert digest is not None
+    assert "apply=multi (2 file(s))" in digest
+    assert "verify=4/4" in digest
+    assert "commit=f6abcdbec5" in digest
+
+
+def test_render_omits_segments_when_absent(tmp_path):
+    _mk_session(tmp_path, "bt-2026-07-18-000010", mtime=time.time())
+    digest = LastSessionSummary(tmp_path).operator_digest_sync()
+    assert digest is not None
+    assert "apply=" not in digest
+    assert "verify=" not in digest
+    assert "commit=" not in digest
+
+
+# ---------------------------------------------------------------------------
+# (4) ov status wiring — provider reads the operator plane
+# ---------------------------------------------------------------------------
+
+
+def test_ov_status_digest_uses_operator_plane(tmp_path, monkeypatch):
+    from backend.core.ouroboros.cli import ov
+
+    _mk_session(tmp_path, "bt-2026-07-18-000011", mtime=time.time())
+    lss = LastSessionSummary(tmp_path)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.last_session_summary."
+        "get_default_summary",
+        lambda *a, **k: lss,
+    )
+    out = ov.status_digest()
+    assert "bt-2026-07-18-000011" in out
+
+
+def test_ov_status_fallback_when_empty(tmp_path, monkeypatch):
+    from backend.core.ouroboros.cli import ov
+
+    lss = LastSessionSummary(tmp_path)
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.last_session_summary."
+        "get_default_summary",
+        lambda *a, **k: lss,
+    )
+    assert "no prior session" in ov.status_digest()
+
+
+def test_ov_source_reads_operator_digest():
+    root = Path(__file__).resolve().parents[2]
+    src = (root / "backend/core/ouroboros/cli/ov.py").read_text()
+    assert "operator_digest_sync" in src
+    assert "format_for_prompt_sync" not in src   # the inert path is gone


### PR DESCRIPTION
## Six-commit batch (operator-authorized)

| Commit | What |
|---|---|
| `fa882677e0` | §41.3 #27 progressive streaming flow mode (unwrap the Live cage) — LAST §41.3 engineering item; 16 tests |
| `5e04feb873` | Heuristic Intent Multiplexer — bare REPL text → canonical chat stack (classifier + executor chain), code-shape TASK re-weighting, Ctrl+C cancellation token, zero-orphan drain; 26 tests |
| `279d8d754a` | Curiosity-scan observability closure — classified zero-cause taxonomy + unconditional verdict lines (both silent paths dead); 10 tests. Paid off same-day: first live classified verdict `zero_cause=ingest_rejected ingest={governor_throttled: 2}` |
| `f2d7eb1d9c` | ov status operator-plane fix — autonomy gate no longer starves a human query; mtime ordering kills bt-iso lex shadowing; 10 tests |
| `79a72d70de` | /liquidity verb + circadian status segment + Stateful IPC Audio Pub/Sub Bridge (supervisor owns hardware; cockpit subscribes over UDS with mid-sentence reconciliation handshake + measured bounded degradation); 25 tests |
| `448b64000b` | Design Language spec + PresentationRouter chokepoint + AST Sentinel — six-glyph ration, telemetry recast, deterministic enforcement; 18 tests |

105 new tests; all neighboring baselines green throughout (chat family 194, LSS 47, status 90, entropy/Move-8 140, cli 18).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the CLI with a chat text bridge, progressive streaming, audio state IPC, and a unified design-language router. Adds liquidity and status surfaces and fixes missing status digest and silent curiosity scans.

- New Features
  - Chat text bridge: routes bare REPL text through the classifier and executors; Ctrl+C cancels in-flight turns; additive `verdict_override` seam.
  - Progressive streaming flow mode: `JARVIS_UI_STREAMING_FLOW_MODE_ENABLED=1` commits finished markdown blocks above the Live region; default off keeps legacy behavior.
  - Audio state IPC: supervisor broadcasts audio state over UDS; CLI subscribes with a reconciliation handshake for mid-sentence join; bounded, safe degradation when the server is absent.
  - Liquidity surfaces: `/liquidity` verb and a status-line segment that only renders when a provider is dry, including reset ETA.
  - Design-language enforcement: `PresentationRouter` chokepoint scrubs/aliases glyphs, recasts `key=value` dumps, and normalizes density; spec in `docs/architecture/OV_DESIGN_LANGUAGE.md`; AST sentinel guards router usage; six canonical glyphs added to `theme`.

- Bug Fixes
  - `ov status` reads the operator plane (ungated digest) and orders by file mtime, so recent sessions no longer get shadowed or hidden behind autonomy gates.
  - Curiosity scans: always emit a verdict line with a classified `zero_cause`, plus a reader-side decision histogram; silent zero-emission paths are gone.

<sup>Written for commit 448b64000be1156989066908b241c5bd8d178a86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69930?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

