### PR TITLE
feat(ui): Unified Boot/Exit Polish Pass — reflection labels, exit cinematics, edge feathering, versioned identity

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -13,6 +13,7 @@ dependencies.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import atexit
 import logging
 import os
@@ -29,6 +30,8 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 from backend.core.ouroboros.battle_test.cost_tracker import CostTracker
 from backend.core.ouroboros.battle_test.idle_watchdog import IdleWatchdog
 from backend.core.ouroboros.battle_test.session_recorder import SessionRecorder
+
+from backend.core.ouroboros.ui.boot_labels import ui_label as _ui_label
 
 logger = logging.getLogger(__name__)
 
@@ -1044,8 +1047,71 @@ class BattleTestHarness:
     # Main lifecycle
     # ------------------------------------------------------------------
 
+    @contextlib.asynccontextmanager
+    async def _exit_cinematic_scope(self):
+        """Teardown lifecycle handler (Unified Boot/Exit Polish, 2026-07-18).
+
+        ONE scope over the whole run: every termination sequence —
+        clean shutdown, SIGINT/SIGTERM (the Ticket-B handlers set the
+        shutdown event, so run() unwinds through this same finally; no
+        second signal handler is installed, preserving watchdog purity)
+        — exits through a single conformed presentation line via the
+        _repl_print chokepoint (PresentationRouter + attach mirror
+        inherit it automatically). Missing/abnormal data degrades to
+        the professional default with zero secondary tracebacks.
+        COCKPIT-only; SOAK teardown is byte-identical.
+        """
+        try:
+            yield
+        finally:
+            self._emit_exit_cinematic()
+
+    def _emit_exit_cinematic(self) -> None:
+        """`organism rests · N changes landed · $X · Ym` — composed from
+        the session's own live counters (the same sources the summary
+        writer reads). NEVER raises; missing data → the default line."""
+        try:
+            from backend.core.ouroboros.ui.presentation_mode import is_cockpit
+            if not is_cockpit():
+                return
+        except Exception:  # noqa: BLE001
+            return
+        line = "⏺ organism rests · session closed"
+        try:
+            parts = ["⏺ organism rests"]
+            gls = getattr(self, "_governed_loop_service", None)
+            completed = len(getattr(gls, "_completed_ops", {}) or {})
+            if completed:
+                parts.append(
+                    f"{completed} change{'s' if completed != 1 else ''} landed"
+                )
+            cost = getattr(
+                getattr(self, "_cost_tracker", None), "total_cost", None,
+            )
+            if isinstance(cost, (int, float)) and cost > 0:
+                parts.append(f"${cost:.2f}")
+            started = getattr(self, "_started_at", None)
+            if started:
+                mins = max(0.0, (time.time() - float(started)) / 60.0)
+                parts.append(f"{mins:.0f}m" if mins >= 1 else "<1m")
+            if len(parts) > 1:
+                line = " · ".join(parts)
+        except Exception:  # noqa: BLE001 — the default line stands
+            pass
+        try:
+            self._repl_print(line)
+        except Exception:  # noqa: BLE001
+            pass
+
     async def run(self) -> None:
-        """Main lifecycle method: boot, wait for stop signal, shutdown, report."""
+        """Main lifecycle: the whole session inside the exit-cinematic
+        lifecycle scope — clean exits, SIGINT/SIGTERM unwinds, and
+        fatals all leave through one conformed goodbye line."""
+        async with self._exit_cinematic_scope():
+            await self._run_inner()
+
+    async def _run_inner(self) -> None:
+        """Boot, wait for stop signal, shutdown, report."""
         self._started_at = time.time()
 
         # D1 silent boot — route INFO/DEBUG to session_dir/debug.log,
@@ -2559,6 +2625,7 @@ class BattleTestHarness:
     # Boot methods (all overridable for test mocking)
     # ------------------------------------------------------------------
 
+    @_ui_label("oracle · codebase index")
     async def boot_oracle(self) -> None:
         """Import + construct TheOracle, defer ``initialize()`` to a
         background task by default.
@@ -2611,6 +2678,7 @@ class BattleTestHarness:
         except Exception as exc:
             logger.warning("Oracle failed to boot: %s", exc)
 
+    @_ui_label("governance stack")
     async def boot_governance_stack(self) -> None:
         """Create GovernanceConfig and call create_governance_stack()."""
         try:
@@ -2955,6 +3023,7 @@ class BattleTestHarness:
         except Exception as exc:
             logger.warning("Governance stack failed to boot: %s", exc)
 
+    @_ui_label("governed loop · the organism")
     async def boot_governed_loop_service(self) -> None:
         """Create GovernedLoopConfig, GovernedLoopService, and start()."""
         try:
@@ -3651,6 +3720,7 @@ class BattleTestHarness:
             wt_path, branch_name, self._session_id,
         )
 
+    @_ui_label("provider tiers")
     async def boot_jarvis_tiers(self) -> None:
         """Import and start PredictiveRegressionEngine (Tier 3).
 
@@ -3707,6 +3777,7 @@ class BattleTestHarness:
             pass
         return None
 
+    @_ui_label("intake · 17 senses")
     async def boot_intake(self) -> None:
         """Create IntakeLayerConfig, IntakeLayerService, and start()."""
         try:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -27,8 +27,43 @@ from typing import Any, Callable, List, Optional, Sequence
 
 from backend.core.ouroboros.ui.theme import build_console
 
-_VERBS = {"cockpit", "run", "daemon", "status", "attach"}
+_VERBS = {"cockpit", "run", "daemon", "status", "attach", "version"}
 _HELP_TOKENS = {"help", "--help", "-h"}
+_VERSION_TOKENS = {"version", "--version", "-V"}
+
+#: Milestone name — paired with the pyproject version at render time.
+#: Minted per release; the number itself is NEVER duplicated here.
+RELEASE_NAME = "unchained"
+
+
+def resolve_version() -> str:
+    """``0.1.0`` — dynamically from installed metadata, falling back to
+    the repo's pyproject.toml (editable/dev checkouts), then to the
+    honest ``0.0.0+unknown``. NEVER raises."""
+    try:
+        from importlib.metadata import version as _dist_version
+        return _dist_version("ouroboros-ov")
+    except Exception:
+        pass
+    try:
+        import tomllib
+        from pathlib import Path
+        root = Path(__file__).resolve().parents[4]
+        data = tomllib.loads((root / "pyproject.toml").read_text())
+        v = str(data.get("project", {}).get("version", "")).strip()
+        if v:
+            return v
+    except Exception:
+        pass
+    return "0.0.0+unknown"
+
+
+def version_line() -> str:
+    """``ov 0.1.0 “unchained” — ouroboros + venom``. NEVER raises."""
+    try:
+        return f"ov {resolve_version()} “{RELEASE_NAME}” — ouroboros + venom"
+    except Exception:
+        return "ov — ouroboros + venom"
 
 _NO_ORGANISM_MESSAGE = (
     "no organism awake — nothing to attach to. Start one with `ov` "
@@ -42,6 +77,7 @@ _HELP_TEXT = """ov -- Ouroboros + Venom, autonomous engineering organism
   ov daemon [flags]   alias for a headless run
   ov status           last-session digest (no boot)
   ov attach           attach this terminal to the running organism
+  ov version          version + milestone
   ov help             this message
 
 All flags after the verb forward to the battle-test bootstrap, e.g.
@@ -75,6 +111,9 @@ def resolve(argv: Optional[Sequence[str]] = None) -> Invocation:
 
     if tokens and tokens[0] in _HELP_TOKENS:
         return Invocation("help")
+
+    if tokens and tokens[0] in _VERSION_TOKENS:
+        return Invocation("version")
 
     if tokens and tokens[0] in _VERBS:
         verb, rest = tokens[0], list(tokens[1:])
@@ -286,6 +325,9 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
 
     if inv.action == "help":
         console.print(_HELP_TEXT, markup=False, highlight=False)
+        return 0
+    if inv.action == "version":
+        console.print(version_line(), markup=False, highlight=False)
         return 0
     if inv.action == "attach":
         return run_attach(console)

--- a/backend/core/ouroboros/ui/boot_labels.py
+++ b/backend/core/ouroboros/ui/boot_labels.py
@@ -1,0 +1,110 @@
+"""Reflection-based boot-phase labels — no dict rot, no raw symbols.
+
+Design language §3 ("never show a field name"): the wake checklist was
+rendering internal timer marks (``boot_governed_loop_service``) verbatim
+on the product surface. A static translation dictionary inside the UI
+loop would rot the moment a boot phase is renamed; the root mechanism is
+REFLECTION with an algorithmic floor:
+
+  1. **``@ui_label("…")``** — boot-phase methods declare their own
+     presentation token as ``__ui_label__``; :func:`resolve_label` finds
+     the attribute by walking the harness class for a callable named
+     exactly like the mark. Rename the method → the lookup follows for
+     free; delete it → the humanizer floor takes over. Presentation
+     stays declared AT the lifecycle site, yet the layers remain
+     decoupled (the UI only ever reads an attribute).
+  2. **Humanizer floor** — marks without a method (sub-marks like
+     ``oracle_load_cache``) degrade to an algorithmic prettification:
+     structural prefix tokens drop, snake_case becomes spaces. Always
+     produces SOMETHING human; never raises.
+
+Pure presentation module: reads attributes, never calls anything.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Callable, Dict, Optional
+
+logger = logging.getLogger(__name__)
+
+#: Structural tokens the humanizer floor drops from the FRONT of a mark
+#: (they describe plumbing, not meaning). Order matters — longest first.
+_STRUCTURAL_PREFIXES = ("harness_run_", "boot_")
+
+
+def ui_label(label: str) -> Callable:
+    """Declare a boot phase's presentation token at its lifecycle site.
+
+    Usage::
+
+        @ui_label("governed loop")
+        async def boot_governed_loop_service(self) -> None: ...
+    """
+    def _decorate(fn: Callable) -> Callable:
+        try:
+            fn.__ui_label__ = str(label)  # type: ignore[attr-defined]
+        except Exception:  # noqa: BLE001
+            pass
+        return fn
+    return _decorate
+
+
+def humanize_mark(name: str) -> str:
+    """Algorithmic floor: ``boot_governed_loop_service`` →
+    ``governed loop service``. Pure; NEVER raises."""
+    try:
+        n = str(name or "").strip()
+        for prefix in _STRUCTURAL_PREFIXES:
+            if n.startswith(prefix):
+                n = n[len(prefix):]
+                break
+        n = n.replace("_", " ").strip()
+        return n or str(name)
+    except Exception:  # noqa: BLE001
+        return str(name)
+
+
+_CACHE: Dict[str, str] = {}
+
+
+def _reflect_label(mark: str) -> Optional[str]:
+    """Walk the harness class for a callable named exactly like *mark*
+    and read its ``__ui_label__``. Lazy import — the UI layer never
+    holds a lifecycle reference. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.harness import (
+            BattleTestHarness,
+        )
+        fn = getattr(BattleTestHarness, mark, None)
+        if fn is None:
+            return None
+        label = getattr(fn, "__ui_label__", None)
+        return str(label) if label else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def resolve_label(mark: str) -> str:
+    """The wake checklist's ONE label source: reflection first,
+    humanizer floor always. Cached per mark. NEVER raises."""
+    try:
+        cached = _CACHE.get(mark)
+        if cached is not None:
+            return cached
+        label = _reflect_label(mark) or humanize_mark(mark)
+        _CACHE[mark] = label
+        return label
+    except Exception:  # noqa: BLE001
+        return str(mark)
+
+
+def reset_label_cache_for_tests() -> None:
+    _CACHE.clear()
+
+
+__all__ = [
+    "humanize_mark",
+    "reset_label_cache_for_tests",
+    "resolve_label",
+    "ui_label",
+]

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -73,6 +73,18 @@ def _coverage_threshold() -> float:
 
 _SS = 5   # legacy alias — sampling reads _ss() at render time
 
+
+def _edge_feather() -> float:
+    """Boundary-cell luminance factor (``JARVIS_OV_CREST_FEATHER``,
+    default 0.65 — dimmed edges read as native terminal anti-aliasing).
+    ``1.0`` disables. Clamped [0.2, 1.0]; NEVER raises."""
+    try:
+        return min(1.0, max(0.2, float(
+            os.environ.get("JARVIS_OV_CREST_FEATHER", "0.65"),
+        )))
+    except (TypeError, ValueError):
+        return 0.65
+
 _STOPS = [
     (0, (125, 255, 106)), (60, (91, 227, 75)), (150, (139, 92, 246)),
     (210, (177, 108, 234)), (285, (212, 192, 74)), (360, (125, 255, 106)),
@@ -363,6 +375,28 @@ def _render_cells(geo: _Geometry) -> List[CrestCell]:
     for (x, y) in [k for k, v in raw.items() if v[0] in _DOTS]:
         if not any((x + dx, y + dy) in raw for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))):
             del raw[(x, y)]
+
+    # Topological edge feathering (2026-07-18): boundary cells — fewer
+    # than 4 populated orthogonal neighbors — scale their luminance by
+    # the feather factor. Dimmed edges read as anti-aliasing on the
+    # terminal grid; interior cells keep the full gradient. Clip-safe
+    # by construction (round of a [0,1]-scaled channel never exceeds
+    # the source, never drops below 0).
+    feather = _edge_feather()
+    if feather < 1.0:
+        boundary = [
+            key for key in raw
+            if sum(
+                (key[0] + dx, key[1] + dy) in raw
+                for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))
+            ) < 4
+        ]
+        for key in boundary:
+            glyph, kind, color, delay = raw[key]
+            dimmed = tuple(
+                max(0, min(255, round(c * feather))) for c in color
+            )
+            raw[key] = (glyph, kind, dimmed, delay)  # type: ignore[assignment]
 
     return [
         CrestCell(x=x, y=y, glyph=glyph, kind=kind, rgb=color, delay_s=delay)

--- a/backend/core/ouroboros/ui/wake_sequence.py
+++ b/backend/core/ouroboros/ui/wake_sequence.py
@@ -173,14 +173,18 @@ class WakeSequenceRenderer:
 
             check = theme.mark("check")
             dot = theme.mark("dot")
+            from .boot_labels import resolve_label
             for name, active in self._model.phases():
+                # Design language §3 — the product surface renders the
+                # reflected human label, never the raw timer mark.
+                label = resolve_label(name)
                 line = Text()
                 if active:
                     line.append(f"{dot} ", style="accent")
-                    line.append(name, style="body")
+                    line.append(label, style="body")
                 else:
                     line.append(f"{check} ", style="muted")
-                    line.append(name, style="muted")
+                    line.append(label, style="muted")
                 parts.append(line)
 
             if self._model.is_live:

--- a/tests/ui/test_boot_exit_polish.py
+++ b/tests/ui/test_boot_exit_polish.py
@@ -1,0 +1,216 @@
+"""Unified Boot/Exit Polish Pass — labels, cinematics, feathering, version.
+
+Operator mandates: reflection-based labels (no dict rot), a lifecycle
+scope whose exit line degrades cleanly on missing data, feathering math
+that can never clip negative, and TOML-sourced versioning.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import boot_labels as bl
+from backend.core.ouroboros.ui import crest
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    monkeypatch.delenv("JARVIS_OV_CREST_FEATHER", raising=False)
+    bl.reset_label_cache_for_tests()
+    yield
+    bl.reset_label_cache_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# (1) Reflection labels — declared at the lifecycle site, no dict in the UI
+# ---------------------------------------------------------------------------
+
+
+def test_decorated_boot_method_reflects_its_label():
+    assert bl.resolve_label("boot_governed_loop_service") == (
+        "governed loop · the organism"
+    )
+    assert bl.resolve_label("boot_oracle") == "oracle · codebase index"
+
+
+def test_undecorated_mark_humanizes():
+    # Sub-marks with no harness method degrade algorithmically.
+    assert bl.resolve_label("oracle_load_cache") == "oracle load cache"
+    assert bl.humanize_mark("boot_git_index_guard") == "git index guard"
+    assert bl.humanize_mark("harness_run_pre_boot_done") == "pre boot done"
+
+
+def test_rename_follows_for_free():
+    """The rot-proof property: an unknown mark NEVER renders raw
+    plumbing prefixes; the floor always produces something human."""
+    assert bl.resolve_label("boot_some_future_phase") == "some future phase"
+    assert isinstance(bl.resolve_label(""), str)   # degenerate never raises
+
+
+def test_wake_renderer_consumes_resolver_pin():
+    from pathlib import Path
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "backend/core/ouroboros/ui/wake_sequence.py"
+    ).read_text()
+    assert "resolve_label" in src
+    body = src[src.index("def render_frame"):][:2000]
+    assert "resolve_label(name)" in body
+
+
+def test_no_static_label_dict_in_ui_pin():
+    from pathlib import Path
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "backend/core/ouroboros/ui/wake_sequence.py"
+    ).read_text()
+    assert "boot_governed_loop_service" not in src   # no dict rot in the UI
+
+
+# ---------------------------------------------------------------------------
+# (2) Exit cinematics — one conformed goodbye, null-safe
+# ---------------------------------------------------------------------------
+
+
+class _H:
+    """Minimal harness duck for _emit_exit_cinematic."""
+
+    def __init__(self) -> None:
+        self.lines = []
+        self._started_at = None
+        self._governed_loop_service = None
+        self._cost_tracker = None
+
+    def _repl_print(self, msg: str) -> None:
+        self.lines.append(msg)
+
+
+def _emit(h, monkeypatch, cockpit=True):
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+    monkeypatch.setenv(
+        "JARVIS_OV_PRESENTATION", "cockpit" if cockpit else "soak",
+    )
+    BattleTestHarness._emit_exit_cinematic(h)
+
+
+def test_exit_line_with_full_data(monkeypatch):
+    import time as _t
+
+    class _Cost:
+        total_cost = 0.42
+
+    class _GLS:
+        _completed_ops = {"a": 1, "b": 2}
+
+    h = _H()
+    h._started_at = _t.time() - 34 * 60
+    h._cost_tracker = _Cost()
+    h._governed_loop_service = _GLS()
+    _emit(h, monkeypatch)
+    assert len(h.lines) == 1
+    line = h.lines[0]
+    assert line.startswith("⏺ organism rests")
+    assert "2 changes landed" in line
+    assert "$0.42" in line
+    assert "34m" in line
+
+
+def test_exit_line_null_data_falls_back_clean(monkeypatch):
+    h = _H()                                   # everything missing/None
+    _emit(h, monkeypatch)
+    assert h.lines == ["⏺ organism rests · session closed"]
+
+
+def test_exit_line_soak_is_silent(monkeypatch):
+    h = _H()
+    _emit(h, monkeypatch, cockpit=False)
+    assert h.lines == []                       # SOAK teardown byte-identical
+
+
+def test_run_wrapped_in_lifecycle_scope_pin():
+    from pathlib import Path
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "backend/core/ouroboros/battle_test/harness.py"
+    ).read_text()
+    body = src[src.index("    async def run(self)"):][:900]
+    assert "async with self._exit_cinematic_scope():" in body
+    scope = src[src.index("def _exit_cinematic_scope"):][:1600]
+    assert "finally:" in scope
+    assert "_emit_exit_cinematic()" in scope
+
+
+# ---------------------------------------------------------------------------
+# (3) Edge feathering — dimmed boundaries, clip-safe
+# ---------------------------------------------------------------------------
+
+
+def _frame(cols=80, rows=30):
+    from backend.core.ouroboros.ui.theme import ColorTier
+    crest._generate_cached.cache_clear()
+    return crest.generate_crest(
+        cols, rows, tier=ColorTier.TRUECOLOR, unicode_ok=True,
+    )
+
+
+def test_feathering_dims_boundary_not_interior():
+    f = _frame()
+    cells = {(c.x, c.y): c for c in f.cells}
+
+    def neighbors(x, y):
+        return sum(
+            (x + dx, y + dy) in cells
+            for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1))
+        )
+
+    boundary = [c for c in f.cells if neighbors(c.x, c.y) < 4]
+    interior = [c for c in f.cells if neighbors(c.x, c.y) == 4]
+    assert boundary and interior
+    b_lum = sum(sum(c.rgb) for c in boundary) / len(boundary)
+    i_lum = sum(sum(c.rgb) for c in interior) / len(interior)
+    assert b_lum < i_lum * 0.85                # edges measurably dimmer
+
+
+def test_feathering_never_clips_negative_or_overflows():
+    f = _frame()
+    for c in f.cells:
+        for ch in c.rgb:
+            assert 0 <= ch <= 255
+
+
+def test_feather_disable_and_clamp(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_CREST_FEATHER", "1.0")
+    f_off = _frame()
+    lum_off = sum(sum(c.rgb) for c in f_off.cells)
+    monkeypatch.setenv("JARVIS_OV_CREST_FEATHER", "0.65")
+    f_on = _frame(cols=80, rows=30)
+    lum_on = sum(sum(c.rgb) for c in f_on.cells)
+    assert lum_on < lum_off                    # feathering removes light
+    monkeypatch.setenv("JARVIS_OV_CREST_FEATHER", "-3")
+    assert crest._edge_feather() == 0.2        # clamped, never negative
+
+
+# ---------------------------------------------------------------------------
+# (4) Versioning — TOML-sourced, milestone-paired
+# ---------------------------------------------------------------------------
+
+
+def test_version_resolves_dynamically():
+    from backend.core.ouroboros.cli.ov import resolve_version
+    v = resolve_version()
+    assert v and v != "0.0.0+unknown"
+    assert v.count(".") >= 1                   # semver-ish, not hardcoded
+
+
+def test_version_line_carries_milestone():
+    from backend.core.ouroboros.cli.ov import RELEASE_NAME, version_line
+    line = version_line()
+    assert line.startswith("ov ")
+    assert RELEASE_NAME in line
+
+
+def test_version_verb_routes_and_exits_zero(capsys):
+    from backend.core.ouroboros.cli import ov
+    for argv in (["version"], ["--version"], ["-V"]):
+        assert ov.resolve(argv).action == "version"
+    assert ov.main(["--version"]) == 0
+    assert "ov " in capsys.readouterr().out


### PR DESCRIPTION
Operator-authorized product pass: reflection-based wake-checklist labels (no dict rot — \`@ui_label\` at the lifecycle site + algorithmic humanizer floor), exit-cinematic lifecycle scope (one conformed goodbye line through the PresentationRouter chokepoint, null-safe, SOAK byte-identical), topological crest edge feathering (clip-safe 0.65 luminance on boundary cells), and \`ov version\` with TOML-sourced versioning + milestone name. 15 new tests; 138 ui+cli green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the boot and exit UX: human-readable wake labels, a single exit line on shutdown, dimmed crest edges, and a new `ov version` command with dynamic version and milestone.

- **New Features**
  - Wake checklist shows reflected labels from `@ui_label`; unknown marks fall back to a humanized name.
  - Exit cinematic: one null-safe goodbye line from a single scope; cockpit-only, no extra tracebacks on failure.
  - Crest edge feathering: dims boundary cells via `JARVIS_OV_CREST_FEATHER` (default 0.65, 1.0 disables; clamped 0.2–1.0).
  - `ov version`/`--version`/`-V`: resolves version from installed metadata or `pyproject.toml`, and prints the milestone “unchained”.

<sup>Written for commit 7ace75a87d02b2cf96a21bc5bc3621d4b4b33146. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

