### PR TITLE
feat(cli): Split-Plane Multiplexer — ov attach persistent interactive cockpit

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -222,6 +222,114 @@ def _render_hydration(console: Any, payload: dict) -> None:
         pass
 
 
+def _can_run_split_plane() -> bool:
+    """Split-plane needs a real TTY on stdin AND prompt_toolkit — piped
+    / scripted attaches degrade to the legacy pump. NEVER raises."""
+    try:
+        if not sys.stdin.isatty():
+            return False
+        import prompt_toolkit  # noqa: F401
+        return True
+    except Exception:
+        return False
+
+
+async def _split_plane_loop(client: Any, console: Any) -> None:
+    """The Split-Plane Multiplexer (operator mandate 2026-07-18).
+
+    prompt_toolkit's ``PromptSession`` + ``patch_stdout`` IS the
+    thread-safe split-plane mux (DRY — the same solved mechanism
+    SerpentFlow's REPL trusts): the ``ov ›`` prompt permanently owns
+    the bottom of the TTY on an ASYNC loop (no sleep-blockers, no
+    blocking reads); a daemon telemetry line arriving MID-
+    KEYSTROKE is intercepted by patch_stdout, the stdin buffer is
+    hidden, the line renders on the scrolling plane above, and the
+    active input buffer is restored on the bottom line — keystrokes
+    can never be split or corrupted (pinned by the concurrent-I/O
+    test). The prompt task races a connection watch so a daemon death
+    mid-typing detaches instantly instead of hanging on the prompt.
+    """
+    import asyncio
+    from prompt_toolkit import PromptSession
+    from prompt_toolkit.patch_stdout import patch_stdout
+
+    # Persona-host moment: the persistent interactive surface opens
+    # with Karen as the host — the visual seam between the scrolling
+    # daemon history above and the command plane below.
+    console.print(
+        "\U0001f4ad Karen ▸ attached — I'm listening. verbs or plain "
+        "words both work · 'detach' leaves the organism running",
+        markup=False, highlight=False,
+    )
+
+    session: Any = PromptSession()
+
+    async def _watch_disconnect() -> None:
+        while client.connected:
+            await asyncio.sleep(0.25)
+
+    with patch_stdout(raw=True):
+        while client.connected:
+            prompt_task = asyncio.ensure_future(
+                session.prompt_async("ov › "),
+            )
+            watch_task = asyncio.ensure_future(_watch_disconnect())
+            done, _pending = await asyncio.wait(
+                {prompt_task, watch_task},
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+            if watch_task in done and prompt_task not in done:
+                # Daemon died mid-typing — never hang on the prompt.
+                prompt_task.cancel()
+                try:
+                    await prompt_task
+                except (asyncio.CancelledError, Exception):
+                    pass
+                break
+            watch_task.cancel()
+            try:
+                await watch_task
+            except (asyncio.CancelledError, Exception):
+                pass
+            try:
+                line = prompt_task.result()
+            except (EOFError, KeyboardInterrupt):
+                break
+            text = (line or "").strip()
+            if text.lower() in ("detach", "exit", "quit"):
+                break
+            if text:
+                client.send_input(text)
+
+
+async def _legacy_pump_loop(client: Any) -> None:
+    """Non-TTY fallback: the original blocking-read-off-loop pump."""
+    import asyncio
+
+    async def _stdin_pump() -> None:
+        while client.connected:
+            try:
+                line = await asyncio.to_thread(sys.stdin.readline)
+            except Exception:
+                break
+            if not line:                   # EOF — operator closed stdin
+                break
+            text = line.strip()
+            if text and not client.send_input(text):
+                break
+
+    pump = asyncio.get_running_loop().create_task(_stdin_pump())
+    try:
+        while client.connected:
+            await asyncio.sleep(0.25)
+    finally:
+        pump.cancel()
+        try:
+            await pump
+        except (asyncio.CancelledError, Exception):
+            pass
+
+
 def run_attach(console: Any) -> int:
     """``ov attach`` — hydrate, stream, and pipe stdin upstream.
 
@@ -236,8 +344,12 @@ def run_attach(console: Any) -> int:
         )
 
         def _print_line(text: str) -> None:
+            # Builtin print() resolves sys.stdout DYNAMICALLY — under the
+            # split-plane's patch_stdout this routes daemon telemetry
+            # above the pinned prompt; the pre-bound Rich console would
+            # bypass the patch and corrupt the input line.
             try:
-                console.print(text, markup=False, highlight=False)
+                print(text)
             except Exception:
                 pass
 
@@ -254,38 +366,22 @@ def run_attach(console: Any) -> int:
             console.print(_NO_ORGANISM_MESSAGE, markup=False, highlight=False)
             return 1
 
-        # stdin pump — blocking reads off-loop; EOF or detach ends it.
-        async def _stdin_pump() -> None:
-            while client.connected:
-                try:
-                    line = await asyncio.to_thread(sys.stdin.readline)
-                except Exception:
-                    break
-                if not line:               # EOF — operator closed stdin
-                    break
-                text = line.strip()
-                if text and not client.send_input(text):
-                    break
-
-        pump = asyncio.get_running_loop().create_task(_stdin_pump())
         try:
-            while client.connected:
-                await asyncio.sleep(0.25)
-            console.print(
-                "⎿ organism went away — detached", markup=False,
-                highlight=False,
-            )
+            if _can_run_split_plane():
+                await _split_plane_loop(client, console)
+            else:
+                await _legacy_pump_loop(client)
+            if not client.connected:
+                console.print(
+                    "⎿ organism went away — detached", markup=False,
+                    highlight=False,
+                )
         except KeyboardInterrupt:
             console.print(
                 "⎿ detached (the organism keeps running)", markup=False,
                 highlight=False,
             )
         finally:
-            pump.cancel()
-            try:
-                await pump
-            except (asyncio.CancelledError, Exception):
-                pass
             await client.close()
         return 0
 

--- a/tests/cli/test_split_plane_mux.py
+++ b/tests/cli/test_split_plane_mux.py
@@ -1,0 +1,144 @@
+"""Split-Plane Multiplexer — concurrent-I/O integrity spine.
+
+Operator mandate: an async daemon emit arriving at the exact moment an
+operator keystroke registers must not corrupt the line buffer, drop
+characters, or break the prompt boundary. The mux is prompt_toolkit's
+PromptSession + patch_stdout (DRY — SerpentFlow's proven mechanism);
+these tests drive it with a REAL pipe input + interleaved emits.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+pt = pytest.importorskip("prompt_toolkit")
+
+from prompt_toolkit import PromptSession               # noqa: E402
+from prompt_toolkit.input import create_pipe_input     # noqa: E402
+from prompt_toolkit.output import DummyOutput          # noqa: E402
+from prompt_toolkit.patch_stdout import patch_stdout   # noqa: E402
+from prompt_toolkit.application import create_app_session  # noqa: E402
+
+
+# ---------------------------------------------------------------------------
+# (1) THE mandated test — mid-keystroke emit, zero corruption
+# ---------------------------------------------------------------------------
+
+
+async def test_concurrent_emit_never_corrupts_keystrokes():
+    """Type 'hel' → daemon emits mid-buffer → type 'lo' → more emits →
+    Enter. The returned line must be EXACTLY 'hello' (no drops, no
+    splits, no telemetry bleeding into the buffer)."""
+    with create_pipe_input() as pipe, create_app_session(
+        input=pipe, output=DummyOutput(),
+    ):
+        session: PromptSession = PromptSession()
+        with patch_stdout():
+            task = asyncio.ensure_future(session.prompt_async("ov › "))
+            await asyncio.sleep(0.05)
+            pipe.send_text("hel")
+            print("⏺ GENERATE — op-019f progressing")     # mid-keystroke emit
+            await asyncio.sleep(0.02)
+            pipe.send_text("lo")
+            print("⎿ verify: 4/4 · cost $0.12")            # and another
+            pipe.send_text("\n")
+            line = await asyncio.wait_for(task, timeout=5)
+    assert line == "hello"
+    # (Emit delivery goes to the isolated app session's DummyOutput —
+    # the property under test is BUFFER INTEGRITY, asserted above.)
+
+
+async def test_burst_emits_between_every_keystroke(capsys):
+    """Adversarial cadence: a telemetry line between EVERY character."""
+    with create_pipe_input() as pipe, create_app_session(
+        input=pipe, output=DummyOutput(),
+    ):
+        session: PromptSession = PromptSession()
+        target = "cancel op-019f77"
+        with patch_stdout():
+            task = asyncio.ensure_future(session.prompt_async("ov › "))
+            await asyncio.sleep(0.05)
+            for ch in target:
+                pipe.send_text(ch)
+                print(f"⎿ telemetry burst around {ch!r}")
+            pipe.send_text("\n")
+            line = await asyncio.wait_for(task, timeout=5)
+    assert line == target                                  # every char survived
+
+
+async def test_unicode_emits_never_bleed_into_ascii_buffer(capsys):
+    """Unicode-hostile EMITS (glyphs, emoji) around plain keystrokes —
+    the buffer must stay byte-exact. (Multibyte KEYSTROKES through the
+    pipe-input harness are timing-flaky under pytest-asyncio; the
+    property is proven by a standalone probe — the production stdin
+    path is a real vt100 stream, not the pipe harness.)"""
+    with create_pipe_input() as pipe, create_app_session(
+        input=pipe, output=DummyOutput(),
+    ):
+        session: PromptSession = PromptSession()
+        with patch_stdout():
+            task = asyncio.ensure_future(session.prompt_async("ov › "))
+            await asyncio.sleep(0.05)
+            pipe.send_text("status")
+            print("⏺ unicode-hostile emit ▸ 💭 · ⚠ 🎙")
+            pipe.send_text("\n")
+            line = await asyncio.wait_for(task, timeout=5)
+    assert line == "status"
+
+
+# ---------------------------------------------------------------------------
+# (2) Structure pins — async loop, no blockers, fallback, host moment
+# ---------------------------------------------------------------------------
+
+
+def _src() -> str:
+    from pathlib import Path
+    return (
+        Path(__file__).resolve().parents[2]
+        / "backend/core/ouroboros/cli/ov.py"
+    ).read_text()
+
+
+def test_split_plane_uses_prompt_toolkit_mux():
+    src = _src()
+    body = src[src.index("async def _split_plane_loop"):]
+    body = body[:body.index("\nasync def _legacy_pump_loop")]
+    assert "PromptSession" in body
+    assert "patch_stdout(raw=True)" in body
+    assert "prompt_async" in body                  # async loop, not input()
+    assert "time.sleep" not in body                # zero UI blockers
+    import re
+    assert not re.search(r"(?<![\w.])input\(", body)   # no blocking input()
+
+
+def test_daemon_death_races_the_prompt():
+    src = _src()
+    body = src[src.index("async def _split_plane_loop"):]
+    body = body[:body.index("\nasync def _legacy_pump_loop")]
+    assert "_watch_disconnect" in body
+    assert "FIRST_COMPLETED" in body               # never hangs on a dead daemon
+    assert "prompt_task.cancel()" in body
+
+
+def test_persona_host_line_present():
+    src = _src()
+    assert "Karen ▸ attached" in src
+    assert "'detach' leaves the organism running" in src
+
+
+def test_non_tty_degrades_to_legacy_pump():
+    src = _src()
+    assert "_can_run_split_plane" in src
+    body = src[src.index("def _can_run_split_plane"):][:800]
+    assert "sys.stdin.isatty()" in body
+    assert "_legacy_pump_loop" in src
+
+
+def test_line_renderer_resolves_stdout_dynamically():
+    """The pre-bound Rich console would bypass patch_stdout and corrupt
+    the prompt — daemon lines must go through builtin print()."""
+    src = _src()
+    body = src[src.index("def _print_line"):][:700]
+    assert "print(text)" in body
+    assert "console.print" not in body


### PR DESCRIPTION
prompt_toolkit-composed split-plane TUI for ov attach: bottom-pinned async prompt, contention-safe telemetry interleave (mandated concurrency tests: byte-exact buffers under mid-keystroke emits), Karen persona host, daemon-death races the prompt, non-TTY fallback. 8 new tests, 26/26 cli suite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make ov attach a persistent split-plane TUI with a bottom-pinned async prompt and safe telemetry interleave. Prevents input corruption on mid-keystroke emits and degrades cleanly when TTY or `prompt_toolkit` isn’t available.

- **New Features**
  - Split-plane TUI for `ov attach` using `prompt_toolkit` (`PromptSession` + `patch_stdout(raw=True)`). Bottom-pinned "ov ›" prompt with Karen host line; telemetry never corrupts input.
  - On disconnect, the prompt is cancelled and detach happens instantly.
  - Daemon lines route through built-in print() so `patch_stdout` applies; avoids Rich console bypass.
  - Non-TTY or missing `prompt_toolkit` falls back to the legacy stdin pump.
  - 8 tests cover mid-keystroke integrity, burst/Unicode emits, and structural guards.

<sup>Written for commit e4e36a8ed37a6c26101fb04c88b569d183352c1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69933?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

