### PR TITLE
feat(governance): Karen Answer Engine — grounded narrated Q&A + voice tap

### DIFF
--- a/backend/core/ouroboros/governance/chat_text_bridge.py
+++ b/backend/core/ouroboros/governance/chat_text_bridge.py
@@ -356,9 +356,7 @@ class ChatTextMultiplexer:
                 self._safe_print(self._CANCEL_LINE)
                 return None
             result = await work
-            rendered = getattr(result, "rendered_text", None)
-            if rendered:
-                self._safe_print(str(rendered))
+            self._render_result(result)
             return result
         except asyncio.CancelledError:
             # drain()/shutdown cancelled us — propagate after tidying.
@@ -375,6 +373,42 @@ class ChatTextMultiplexer:
                     await token_wait
                 except (asyncio.CancelledError, Exception):  # noqa: BLE001
                     pass
+
+    def _render_result(self, result: Any) -> None:
+        """Answer-first rendering (design language §3, 2026-07-18).
+
+        A REAL executor answer renders as Karen's voice line + speaks
+        through the mounted duplex; the routing-decision telemetry stays
+        available via ``/chat why`` instead of dumping on the surface.
+        Sentinel responses (the logging safe-default's ``logged-…`` /
+        bounded-failure ``error-…`` tokens) keep the legacy decision
+        render — in dev mode the telemetry IS the product. NEVER raises."""
+        try:
+            response = getattr(result, "executor_response", None)
+            status = getattr(
+                getattr(result, "status", None), "value", "",
+            )
+            is_real_answer = (
+                status == "EXECUTOR_OK"
+                and isinstance(response, str)
+                and response.strip()
+                and not response.startswith(("logged-", "error-"))
+            )
+            if is_real_answer:
+                self._safe_print(f"\U0001f4ad Karen ▸ {response.strip()}")
+                try:
+                    from backend.core.ouroboros.governance.karen_answer_engine import (  # noqa: E501
+                        speak_answer,
+                    )
+                    speak_answer(response)
+                except Exception:  # noqa: BLE001
+                    pass
+                return
+            rendered = getattr(result, "rendered_text", None)
+            if rendered:
+                self._safe_print(str(rendered))
+        except Exception:  # noqa: BLE001
+            logger.debug("[ChatTextBridge] render degraded", exc_info=True)
 
     def _safe_print(self, line: str) -> None:
         try:
@@ -412,8 +446,24 @@ def build_chat_text_multiplexer(
             from backend.core.ouroboros.governance.chat_repl_claude_executor import (  # noqa: E501
                 build_chat_repl_dispatcher_with_claude,
             )
+            # Karen Answer Engine (2026-07-18): the REAL provider —
+            # grounded in organism state, narrated through the print
+            # sink, routed via the rt_gate policy lane. Only consulted
+            # when JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED arms the Claude
+            # leg; the safe-default logging chain is untouched otherwise.
+            _karen_provider = None
+            try:
+                from backend.core.ouroboros.governance.karen_answer_engine import (  # noqa: E501
+                    KarenQueryProvider,
+                )
+                _karen_provider = KarenQueryProvider(
+                    progress_sink=print_sink,
+                )
+            except Exception:  # noqa: BLE001
+                _karen_provider = None
             d = build_chat_repl_dispatcher_with_claude(
                 project_root=project_root,
+                claude_provider=_karen_provider,
             )
         if d is None:
             return None

--- a/backend/core/ouroboros/governance/karen_answer_engine.py
+++ b/backend/core/ouroboros/governance/karen_answer_engine.py
@@ -1,0 +1,233 @@
+"""Karen Answer Engine — grounded, narrated, policy-routed Q&A.
+
+Operator mandate 2026-07-18: "not simulation crap." When the operator
+asks *"what was the last thing I worked on?"* Karen must (1) SHOW her
+thinking live in the CLI (Gemini-style progress, in our glyph grammar),
+(2) ground the answer in the ACTUAL codebase/session state — not
+model imagination — and (3) answer through the same provider policy
+lane everything else uses.
+
+Three organs, all composition:
+
+* **Grounding pack** — a bounded organism-state digest composed from
+  EXISTING read-only surfaces: the LastSessionSummary operator plane
+  (what actually happened last sessions), recent git subjects (what
+  actually landed), live posture + phase. "What did I last work on"
+  is answered from evidence.
+* **KarenQueryProvider** — a ``ClaudeQueryProvider`` implementation
+  that plugs into the EXISTING ClaudeChatActionExecutor (its cost caps
+  + audit ride along untouched). Routing rides ``rt_gate.gate_completion``
+  — Claude-RT first, DW fallback — the SAME lane Karen's boot-briefing
+  synthesis uses. One policy brain for everything Karen says.
+* **Progress narration** — every stage emits one design-language line
+  through the injected sink (the ``_repl_print`` chokepoint → router
+  conformance + attach-terminal mirror for free): the operator is
+  never left in the dark between Enter and the answer.
+* **speak_answer** — the voice tap: first spoken-sized sentence to the
+  mounted Karen duplex (supervisor-owned speakers); silent no-op when
+  voice isn't mounted. Deterministic compression for v1 — zero extra
+  LLM spend to talk.
+
+NEVER raises anywhere; a failed stage degrades to an honest
+"couldn't reach a provider" answer, never a traceback.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import re
+from typing import Callable, Optional
+
+logger = logging.getLogger(__name__)
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+_SYSTEM_PROMPT = (
+    "You are Karen, the voice of O+V (Ouroboros + Venom) — an autonomous "
+    "self-developing engineering organism. You are a terse, senior "
+    "Australian engineer: plain words, no filler, no bullet spam. "
+    "Answer ONLY from the organism-state context provided and general "
+    "engineering knowledge; if the context doesn't contain the answer, "
+    "say so plainly. Two to five sentences."
+)
+
+
+def _answer_max_tokens() -> int:
+    try:
+        return max(64, int(os.environ.get(
+            "JARVIS_KAREN_ANSWER_MAX_TOKENS", "400",
+        )))
+    except (TypeError, ValueError):
+        return 400
+
+
+def _grounding_cap_chars() -> int:
+    try:
+        return max(400, int(os.environ.get(
+            "JARVIS_KAREN_GROUNDING_CAP_CHARS", "2400",
+        )))
+    except (TypeError, ValueError):
+        return 2400
+
+
+# ---------------------------------------------------------------------------
+# Grounding pack — evidence, not imagination
+# ---------------------------------------------------------------------------
+
+
+def build_grounding_pack() -> str:
+    """Bounded organism-state digest from existing read-only surfaces.
+    Every source is independently defensive; a dead source contributes
+    nothing rather than an error. NEVER raises."""
+    sections = []
+    # (1) What the last sessions actually did — the LSS operator plane.
+    try:
+        from backend.core.ouroboros.governance.last_session_summary import (
+            get_default_summary,
+        )
+        digest = get_default_summary().operator_digest_sync()
+        if digest:
+            sections.append("recent sessions:\n" + digest)
+    except Exception:  # noqa: BLE001
+        pass
+    # (2) What actually landed — recent git subjects.
+    try:
+        import subprocess
+        out = subprocess.run(
+            ["git", "log", "--oneline", "-6", "--no-decorate"],
+            capture_output=True, text=True, timeout=5,
+        )
+        if out.returncode == 0 and out.stdout.strip():
+            sections.append("recent commits:\n" + out.stdout.strip())
+    except Exception:  # noqa: BLE001
+        pass
+    # (3) Live stance — posture + phase + liquidity headline.
+    try:
+        from backend.core.ouroboros.battle_test.status_line import (
+            get_status_line_builder,
+        )
+        b = get_status_line_builder()
+        if b is not None:
+            snap = b.snapshot()
+            sections.append(
+                f"live state: phase={snap.phase} "
+                f"cost=${snap.cost_spent_usd:.2f}/"
+                f"${snap.cost_budget_usd:.2f}"
+            )
+    except Exception:  # noqa: BLE001
+        pass
+    pack = "\n\n".join(sections)
+    return pack[: _grounding_cap_chars()]
+
+
+# ---------------------------------------------------------------------------
+# The provider — plugs into ClaudeChatActionExecutor's seam
+# ---------------------------------------------------------------------------
+
+
+class KarenQueryProvider:
+    """``ClaudeQueryProvider`` impl: narrated + grounded + rt_gate-routed.
+
+    Runs inside the chat multiplexer's worker thread (no running loop),
+    so the async rt_gate lane executes on a thread-local loop via
+    ``asyncio.run`` — the REPL event loop is never touched."""
+
+    def __init__(
+        self,
+        progress_sink: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._progress = progress_sink or (lambda _s: None)
+
+    def _emit(self, line: str) -> None:
+        try:
+            self._progress(line)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def query(self, prompt: str, max_tokens: int = 0) -> str:
+        """The executor hands us its composed prompt (message + recent
+        turns); we prepend evidence and route through the policy lane,
+        narrating each stage. NEVER raises — degrades to an honest
+        can't-reach-provider answer."""
+        try:
+            self._emit("⎿ thinking · gathering organism context")
+            pack = build_grounding_pack()
+            grounded = (
+                ("## Organism state (evidence — answer from this)\n"
+                 f"{pack}\n\n" if pack else "")
+                + prompt
+            )
+            self._emit("⎿ thinking · asking claude (doubleword fallback)")
+            from backend.core.ouroboros.governance.rt_gate import (
+                gate_completion,
+            )
+            answer = asyncio.run(gate_completion(
+                grounded,
+                caller_id="karen_chat_answer",
+                system_prompt=_SYSTEM_PROMPT,
+                max_tokens=max_tokens or _answer_max_tokens(),
+            ))
+            if isinstance(answer, str) and answer.strip():
+                return answer.strip()
+            return (
+                "I got an empty reply from every provider — ask me again "
+                "in a moment."
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("[KarenAnswer] query degraded", exc_info=True)
+            self._emit("⎿ providers unreachable")
+            return (
+                "I couldn't reach a provider just now "
+                f"({type(exc).__name__}) — my windows may be dry. "
+                "Try again shortly."
+            )
+
+
+# ---------------------------------------------------------------------------
+# Voice tap — speak the short version, never block, never break
+# ---------------------------------------------------------------------------
+
+
+_SENTENCE_END = re.compile(r"(?<=[.!?])\s")
+
+
+def spoken_digest(answer: str, *, cap: int = 140) -> str:
+    """First spoken-sized sentence of *answer* — deterministic
+    compression, zero LLM spend. Pure; NEVER raises."""
+    try:
+        text = " ".join(str(answer or "").split())
+        if not text:
+            return ""
+        first = _SENTENCE_END.split(text, 1)[0]
+        return first[:cap].rstrip()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def speak_answer(answer: str) -> bool:
+    """Hand the spoken digest to the mounted Karen duplex. True when a
+    line was actually submitted; silent False when voice isn't mounted
+    (no supervisor / voice master off). NEVER raises."""
+    try:
+        digest = spoken_digest(answer)
+        if not digest:
+            return False
+        from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (  # noqa: E501
+            get_default_karen,
+        )
+        karen = get_default_karen()
+        if karen is None:
+            return False
+        karen.submit_speech(digest)
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+__all__ = [
+    "KarenQueryProvider",
+    "build_grounding_pack",
+    "speak_answer",
+    "spoken_digest",
+]

--- a/tests/governance/test_karen_answer_engine.py
+++ b/tests/governance/test_karen_answer_engine.py
@@ -1,0 +1,183 @@
+"""Karen Answer Engine — grounded, narrated, policy-routed Q&A spine.
+
+Operator mandate: real answers grounded in the codebase (not
+"simulation crap"), live thinking narration in the CLI, and Karen's
+voice on top. Tests drive the REAL executor + dispatcher + multiplexer
+with the rt_gate lane mocked at its seam.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance import karen_answer_engine as kae
+
+
+# ---------------------------------------------------------------------------
+# (1) Grounding pack — evidence, not imagination
+# ---------------------------------------------------------------------------
+
+
+def test_grounding_pack_carries_real_commits():
+    pack = kae.build_grounding_pack()
+    assert "recent commits:" in pack
+    # Real repo evidence — a hash-prefixed oneline subject is present.
+    assert any(
+        len(ln.split()[0]) >= 7 for ln in pack.splitlines()
+        if ln and ln[0].isalnum() and " " in ln
+    )
+
+
+def test_grounding_pack_bounded(monkeypatch):
+    monkeypatch.setenv("JARVIS_KAREN_GROUNDING_CAP_CHARS", "500")
+    assert len(kae.build_grounding_pack()) <= 500
+
+
+def test_grounding_pack_never_raises(monkeypatch):
+    # Kill every source — pack degrades to empty, never an error.
+    monkeypatch.setattr(
+        "subprocess.run",
+        lambda *a, **k: (_ for _ in ()).throw(OSError("no git")),
+    )
+    assert isinstance(kae.build_grounding_pack(), str)
+
+
+# ---------------------------------------------------------------------------
+# (2) The provider — narration order + grounding + degrade
+# ---------------------------------------------------------------------------
+
+
+def test_provider_narrates_and_grounds(monkeypatch):
+    seen = {}
+
+    async def _fake_gate(prompt, **kw):
+        seen["prompt"] = prompt
+        seen["kw"] = kw
+        return "You last worked on the split-plane attach cockpit."
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.rt_gate.gate_completion",
+        _fake_gate,
+    )
+    progress = []
+    p = kae.KarenQueryProvider(progress_sink=progress.append)
+    answer = p.query("what did I last work on?")
+
+    assert answer == "You last worked on the split-plane attach cockpit."
+    # Thinking narration, in order, in the glyph grammar.
+    assert progress[0].startswith("⎿ thinking · gathering")
+    assert progress[1].startswith("⎿ thinking · asking claude")
+    # The prompt reaching the provider lane is GROUNDED.
+    assert "## Organism state (evidence" in seen["prompt"]
+    assert "recent commits:" in seen["prompt"]
+    assert seen["kw"]["caller_id"] == "karen_chat_answer"
+
+
+def test_provider_degrades_honestly(monkeypatch):
+    async def _dead_gate(prompt, **kw):
+        raise RuntimeError("all tiers down")
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.rt_gate.gate_completion",
+        _dead_gate,
+    )
+    p = kae.KarenQueryProvider()
+    answer = p.query("hello?")
+    assert "couldn't reach a provider" in answer
+    assert "RuntimeError" in answer               # honest, not a traceback
+
+
+# ---------------------------------------------------------------------------
+# (3) Voice tap — deterministic spoken digest, mounted-only
+# ---------------------------------------------------------------------------
+
+
+def test_spoken_digest_first_sentence_capped():
+    long = (
+        "O+V is your self-evolving engineering organism. It has eleven "
+        "phases and seventeen senses. " + "x" * 300
+    )
+    d = kae.spoken_digest(long)
+    assert d == "O+V is your self-evolving engineering organism."
+    assert len(kae.spoken_digest("word " * 200)) <= 140
+
+
+def test_speak_answer_silent_when_no_duplex():
+    # No supervisor / no mounted karen — False, zero noise, zero raise.
+    assert kae.speak_answer("anything") is False
+
+
+def test_speak_answer_submits_when_mounted(monkeypatch):
+    spoken = []
+
+    class _Karen:
+        def submit_speech(self, line, *a, **k):
+            spoken.append(line)
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.comms.duplex."
+        "karen_duplex_factory.get_default_karen",
+        lambda: _Karen(),
+    )
+    assert kae.speak_answer("Short answer. Longer detail follows.") is True
+    assert spoken == ["Short answer."]
+
+
+# ---------------------------------------------------------------------------
+# (4) End-to-end: mux renders the ANSWER, telemetry stays off the surface
+# ---------------------------------------------------------------------------
+
+
+async def test_full_loop_answer_first_render(monkeypatch):
+    monkeypatch.setenv("JARVIS_CONVERSATIONAL_MODE_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_CHAT_TEXT_BRIDGE_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED", "true")
+
+    async def _fake_gate(prompt, **kw):
+        return "The attach cockpit was the most recent work."
+
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.rt_gate.gate_completion",
+        _fake_gate,
+    )
+    from backend.core.ouroboros.governance.chat_text_bridge import (
+        build_chat_text_multiplexer,
+    )
+    lines = []
+    mux = build_chat_text_multiplexer(print_sink=lines.append)
+    assert mux is not None
+    task = mux.submit("what was the last thing I worked on?")
+    assert task is not None
+    result = await task
+    assert result is not None
+
+    joined = "\n".join(lines)
+    # The ANSWER renders in Karen's voice…
+    assert "💭 Karen ▸ The attach cockpit was the most recent work." in joined
+    # …the thinking narration streamed live…
+    assert "⎿ thinking · gathering organism context" in joined
+    assert "⎿ thinking · asking claude" in joined
+    # …and the routing telemetry stayed OFF the surface.
+    assert "conf=" not in joined
+    assert "turn: chat-" not in joined
+
+
+async def test_logging_stub_keeps_dev_render(monkeypatch):
+    """Executor flags OFF → the safe-default logging chain → the legacy
+    decision render survives (dev mode: telemetry IS the product)."""
+    monkeypatch.setenv("JARVIS_CONVERSATIONAL_MODE_ENABLED", "1")
+    monkeypatch.delenv("JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CHAT_EXECUTOR_SUBAGENT_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_CHAT_EXECUTOR_BACKLOG_ENABLED", raising=False)
+    from backend.core.ouroboros.governance.chat_text_bridge import (
+        build_chat_text_multiplexer,
+    )
+    lines = []
+    mux = build_chat_text_multiplexer(print_sink=lines.append)
+    assert mux is not None
+    task = mux.submit("what is O+V?")
+    await task
+    joined = "\n".join(lines)
+    assert "logged-claude" in joined               # stub visible in dev mode
+    assert "💭 Karen ▸ logged-" not in joined      # never voiced as an answer


### PR DESCRIPTION
Evidence-grounded chat answers (LSS + git + live state), Gemini-style thinking narration through the router chokepoint, rt_gate policy routing (Claude-first/DW-fallback), answer-first render with /chat-why telemetry tuck, deterministic voice tap to the mounted duplex. 10 new tests, 253 chat-family green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Karen Answer Engine: evidence-grounded chat answers with live thinking narration and a deterministic voice tap, routed through `rt_gate`. Integrates with the Claude chat path to render answers first and keep routing telemetry behind `/chat why`.

- New Features
  - Grounding pack from Last Session Summary, recent git subjects, and live status; bounded and resilient; never raises.
  - `KarenQueryProvider` plugs into the Claude executor and routes via `rt_gate.gate_completion` (Claude-RT first, DW fallback); emits two progress lines.
  - Voice tap: `spoken_digest` + `speak_answer` send the first sentence (≤140 chars) to the mounted Karen duplex; silent no-op if not mounted.
  - `chat_text_bridge.py` injects the provider when `JARVIS_CHAT_EXECUTOR_CLAUDE_ENABLED` is true and adds `_render_result` for answer-first print ("Karen ▸ <answer>") and voice; `logged-*`/`error-*` keep legacy dev render and are never voiced.
  - Tests: `tests/governance/test_karen_answer_engine.py` covers grounding, narration, honest degrade paths, voice, and end-to-end answer-first rendering.

<sup>Written for commit 595e8531975c7c175d6d762c80b880b2dc4327f7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69934?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

