### PR TITLE
fix(cli): clean detach reaper + the emblem always greets ov

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -234,6 +234,33 @@ def _can_run_split_plane() -> bool:
         return False
 
 
+async def _reap_task(task: Any) -> None:
+    """Retrieve a task's outcome on EVERY exit path — the 2026-07-18
+    dirty-detach class: an abandoned prompt task finishing with its own
+    KeyboardInterrupt made asyncio dump 'Task exception was never
+    retrieved' over the clean goodbye. Cancel if pending, then consume
+    the result/exception so nothing is left for the GC to complain
+    about. NEVER raises."""
+    import asyncio
+    try:
+        if task is None:
+            return
+        if not task.done():
+            task.cancel()
+        try:
+            await task
+        except BaseException:  # noqa: BLE001 — incl. KeyboardInterrupt
+            pass
+        # Belt: mark a completed task's exception as retrieved.
+        if task.done() and not task.cancelled():
+            try:
+                task.exception()
+            except BaseException:  # noqa: BLE001
+                pass
+    except Exception:
+        pass
+
+
 async def _split_plane_loop(client: Any, console: Any) -> None:
     """The Split-Plane Multiplexer (operator mandate 2026-07-18).
 
@@ -274,26 +301,29 @@ async def _split_plane_loop(client: Any, console: Any) -> None:
                 session.prompt_async("ov › "),
             )
             watch_task = asyncio.ensure_future(_watch_disconnect())
-            done, _pending = await asyncio.wait(
-                {prompt_task, watch_task},
-                return_when=asyncio.FIRST_COMPLETED,
-            )
+            try:
+                done, _pending = await asyncio.wait(
+                    {prompt_task, watch_task},
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+            except (KeyboardInterrupt, asyncio.CancelledError):
+                # Ctrl+C landed in the WAIT itself — reap BOTH tasks
+                # (retrieving any KeyboardInterrupt the prompt task
+                # finished with) so the goodbye stays clean: no
+                # 'Task exception was never retrieved' ever again.
+                await _reap_task(prompt_task)
+                await _reap_task(watch_task)
+                break
             if watch_task in done and prompt_task not in done:
                 # Daemon died mid-typing — never hang on the prompt.
-                prompt_task.cancel()
-                try:
-                    await prompt_task
-                except (asyncio.CancelledError, Exception):
-                    pass
+                await _reap_task(prompt_task)
+                await _reap_task(watch_task)
                 break
-            watch_task.cancel()
-            try:
-                await watch_task
-            except (asyncio.CancelledError, Exception):
-                pass
+            await _reap_task(watch_task)
             try:
                 line = prompt_task.result()
             except (EOFError, KeyboardInterrupt):
+                await _reap_task(prompt_task)
                 break
             text = (line or "").strip()
             if text.lower() in ("detach", "exit", "quit"):

--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -404,26 +404,11 @@ class AwakeningConductor:
         """Render the crest as revealed so far -- cells whose ``delay_s``
         has elapsed draw solid; everything else is blank space. Draws
         tail-to-head purely as a function of the (test-injectable) clock."""
-        if not frame.cells or frame.cols <= 0 or frame.rows <= 0:
-            return Text("")
-        grid = {(c.x, c.y): c for c in frame.cells if c.delay_s <= elapsed}
-        text = Text()
-        for y in range(frame.rows):
-            for x in range(frame.cols):
-                cell = grid.get((x, y))
-                if cell is None:
-                    text.append(" ")
-                else:
-                    # Fill-mode-aware cell resolution (crest.render_cell):
-                    # interior full blocks paint as BACKGROUND-colored
-                    # spaces — solid across terminal line-spacing gaps
-                    # (the 2026-07-18 "brick wall" report); edge quadrants
-                    # keep foreground glyphs for the silhouette.
-                    ch, style = render_cell(cell, tier)
-                    text.append(ch, style=style)
-            if y < frame.rows - 1:
-                text.append("\n")
-        return text
+        # DRY (2026-07-18): THE one frame→Text renderer lives in
+        # crest.frame_to_text — this ceremony passes the reveal clock;
+        # static consumers (collision emblem) pass elapsed=None.
+        from .crest import frame_to_text
+        return frame_to_text(frame, tier, elapsed=elapsed)
 
     def _poll_keys(self, poll: Callable[[], bytes]) -> None:
         """Read whatever is available this tick. Esc/CR/LF request a skip;

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -20,7 +20,7 @@ import functools
 import math
 import os
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional, Tuple
 
 from .theme import ColorTier, Token, style_for
 
@@ -451,6 +451,68 @@ def generate_crest(
         return _generate_cached(clamped, needed_rows, int(tier))
     except Exception:  # noqa: BLE001 -- never raise into a render path
         return CrestFrame(0, 0, (), 0.0, "generation error")
+
+
+def frame_to_text(
+    frame: "CrestFrame", tier: ColorTier, *, elapsed: Optional[float] = None,
+) -> "Any":
+    """Render a crest frame to a Rich ``Text`` (fill-mode + feather
+    aware). ``elapsed=None`` renders the FULL crest (the static emblem
+    — collision surfaces, banners); a float renders the partial reveal
+    (the animated ceremony). THE one frame→Text renderer — the
+    AwakeningConductor and every static consumer compose it (DRY).
+    NEVER raises; degrades to an empty Text."""
+    try:
+        from rich.text import Text
+        if not frame.cells or frame.cols <= 0 or frame.rows <= 0:
+            return Text("")
+        cutoff = float("inf") if elapsed is None else elapsed
+        grid = {
+            (c.x, c.y): c for c in frame.cells if c.delay_s <= cutoff
+        }
+        text = Text()
+        for y in range(frame.rows):
+            for x in range(frame.cols):
+                cell = grid.get((x, y))
+                if cell is None:
+                    text.append(" ")
+                else:
+                    ch, style = render_cell(cell, tier)
+                    text.append(ch, style=style)
+            if y < frame.rows - 1:
+                text.append("\n")
+        return text
+    except Exception:  # noqa: BLE001
+        try:
+            from rich.text import Text
+            return Text("")
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+def print_static_crest(console: "Any") -> bool:
+    """The static emblem — the mark that ALWAYS greets ``ov`` (operator
+    law, 2026-07-18), including on the already-awake collision surface.
+    Full crest, no animation (animation is the BIRTH; the static mark
+    is the EMBLEM). Returns True when rendered; degrades silently on
+    non-TTY / NONE tier / tiny terminals. NEVER raises."""
+    try:
+        from .theme import detect_tier, supports_unicode
+        if not supports_unicode():
+            return False
+        tier = detect_tier(console)
+        if tier <= ColorTier.NONE:
+            return False
+        size = console.size
+        frame = generate_crest(
+            size.width, size.height, tier=tier, unicode_ok=True,
+        )
+        if frame.unavailable_reason:
+            return False
+        console.print(frame_to_text(frame, tier))
+        return True
+    except Exception:  # noqa: BLE001
+        return False
 
 
 def crest_fill_mode() -> str:

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -818,6 +818,17 @@ def _single_flight_preflight(*, quiet: bool = False) -> None:
                 release_boot_mux()
             except Exception:  # noqa: BLE001
                 pass
+            # THE EMBLEM ALWAYS GREETS `ov` (operator law 2026-07-18):
+            # the static crest renders above the already-awake card too
+            # — animation is the birth; the mark is the identity.
+            try:
+                from backend.core.ouroboros.ui.crest import (
+                    print_static_crest,
+                )
+                from backend.core.ouroboros.ui.theme import build_console
+                print_static_crest(build_console())
+            except Exception:  # noqa: BLE001 — emblem never blocks the card
+                pass
             _pid = violators[0][1]
             _held = ""
             _h = _read_lock_holder(_PROJECT_ROOT)

--- a/tests/cli/test_split_plane_mux.py
+++ b/tests/cli/test_split_plane_mux.py
@@ -118,7 +118,7 @@ def test_daemon_death_races_the_prompt():
     body = body[:body.index("\nasync def _legacy_pump_loop")]
     assert "_watch_disconnect" in body
     assert "FIRST_COMPLETED" in body               # never hangs on a dead daemon
-    assert "prompt_task.cancel()" in body
+    assert "_reap_task(prompt_task)" in body   # reaper cancels + retrieves
 
 
 def test_persona_host_line_present():
@@ -142,3 +142,79 @@ def test_line_renderer_resolves_stdout_dynamically():
     body = src[src.index("def _print_line"):][:700]
     assert "print(text)" in body
     assert "console.print" not in body
+
+
+# ---------------------------------------------------------------------------
+# (3) Clean detach — the dirty-KeyboardInterrupt class is dead
+# ---------------------------------------------------------------------------
+
+
+async def test_reap_consumes_keyboard_interrupt_task():
+    """The 2026-07-18 report: an abandoned prompt task finished with
+    KeyboardInterrupt → asyncio dumped 'Task exception was never
+    retrieved' over the clean goodbye. _reap_task must consume it so
+    the GC has nothing to complain about."""
+    import gc
+    from backend.core.ouroboros.cli.ov import _reap_task
+
+    complaints = []
+    loop = asyncio.get_running_loop()
+    old_handler = loop.get_exception_handler()
+    loop.set_exception_handler(lambda _l, ctx: complaints.append(ctx))
+    try:
+        class _FakeKI(BaseException):
+            """KeyboardInterrupt-shaped (BaseException, not Exception) —
+            a REAL KI in a task nukes the test runner itself, which is
+            precisely the sharpness of the original bug. Retrieval
+            semantics are identical for any BaseException."""
+
+        async def _boom():
+            raise _FakeKI
+
+        task = asyncio.ensure_future(_boom())
+        await asyncio.sleep(0.05)              # let it finish dirty
+        await _reap_task(task)                 # consume the corpse
+        del task
+        gc.collect()
+        await asyncio.sleep(0.05)
+        assert not any(
+            "never retrieved" in str(c.get("message", "")) for c in complaints
+        )
+    finally:
+        loop.set_exception_handler(old_handler)
+
+
+async def test_reap_cancels_pending_task():
+    from backend.core.ouroboros.cli.ov import _reap_task
+    task = asyncio.ensure_future(asyncio.sleep(30))
+    await _reap_task(task)
+    assert task.cancelled()
+
+
+def test_split_plane_reaps_on_every_exit_path():
+    src = _src()
+    body = src[src.index("async def _split_plane_loop"):]
+    body = body[:body.index("\nasync def _legacy_pump_loop")]
+    assert body.count("_reap_task(") >= 4          # KI-wait, daemon-death, EOF paths
+    assert "except (KeyboardInterrupt, asyncio.CancelledError):" in body
+
+
+def test_collision_surface_renders_the_emblem():
+    """Operator law: the crest ALWAYS greets `ov` — including the
+    already-awake collision card (static emblem, no animation)."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    src = (root / "scripts/ouroboros_battle_test.py").read_text()
+    idx = src.index("⏺ the organism is already awake")
+    region = src[max(0, idx - 3000):idx]
+    assert "print_static_crest" in region
+
+
+def test_static_emblem_renders_full_crest():
+    from backend.core.ouroboros.ui.crest import frame_to_text, generate_crest
+    from backend.core.ouroboros.ui.theme import ColorTier
+    f = generate_crest(80, 30, tier=ColorTier.TRUECOLOR, unicode_ok=True)
+    text = frame_to_text(f, ColorTier.TRUECOLOR)          # elapsed=None = FULL
+    assert len(text.plain.strip()) > 200                  # the whole mark
+    partial = frame_to_text(f, ColorTier.TRUECOLOR, elapsed=0.01)
+    assert len(partial.plain.strip()) < len(text.plain.strip())


### PR DESCRIPTION
Ctrl+C detach leaves zero asyncio corpses (task reaper on every exit path, KI caught in the race itself); the static crest emblem now renders on the already-awake collision surface (frame_to_text extracted as THE one renderer, conductor delegates). 6 new tests; 151 cli+ui green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clean Ctrl+C detach in `ov` by reaping prompt/watch tasks on every exit path, eliminating `asyncio` “Task exception was never retrieved”. Also shows the static crest emblem on the already-awake collision screen so `ov` always greets with the mark.

- Bug Fixes
  - Added `_reap_task` and handled `KeyboardInterrupt`/`CancelledError` in the wait; all tasks are cancelled, awaited, and exceptions consumed to prevent `asyncio` complaints.
  - Reap on daemon-death and EOF paths in the split-plane loop for a consistent, clean detach.

- New Features
  - Static crest now renders on the collision surface via `print_static_crest`; guarded by TTY/color tier and never blocks.
  - Extracted `frame_to_text` as the single crest renderer; `awakening` delegates to it. `elapsed=None` renders the full emblem; a float renders the partial reveal. Added 6 tests covering the reaper and emblem behavior.

<sup>Written for commit 2e8594680f68ef8fb68e368ce2e1771ba7671638. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

