### PR TITLE
feat(ui): half-block pixel crest — 2× resolution, true AA, scale banding, persistent emblem

### DIFF
--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -380,6 +380,18 @@ class AwakeningConductor:
             if reader_cm is not None:
                 reader_cm.__exit__(None, None, None)
 
+        # PERSISTENT EMBLEM (2026-07-18 operator report): transient=True
+        # erased the crest at ceremony end — the mark vanished, leaving
+        # partial-erase artifacts. The final full crest now prints INTO
+        # SCROLLBACK once, deterministically, before the cooled header:
+        # the identity stays on screen for the whole session.
+        try:
+            self._console.print(self._render_crest_text(
+                frame, frame.max_delay_s + 1.0, tier,
+            ))
+        except Exception:  # noqa: BLE001
+            pass
+
         self._print_cooled_header()
 
     async def _cool_down(self, frame: CrestFrame, tier: ColorTier, live: Live) -> None:
@@ -404,11 +416,12 @@ class AwakeningConductor:
         """Render the crest as revealed so far -- cells whose ``delay_s``
         has elapsed draw solid; everything else is blank space. Draws
         tail-to-head purely as a function of the (test-injectable) clock."""
-        # DRY (2026-07-18): THE one frame→Text renderer lives in
-        # crest.frame_to_text — this ceremony passes the reveal clock;
-        # static consumers (collision emblem) pass elapsed=None.
-        from .crest import frame_to_text
-        return frame_to_text(frame, tier, elapsed=elapsed)
+        # DRY (2026-07-18): renderer dispatch lives in
+        # crest.render_crest_auto — half-block pixels on capable
+        # terminals, quadrant fallback; the reveal clock threads
+        # through either path.
+        from .crest import render_crest_auto
+        return render_crest_auto(frame, tier, elapsed=elapsed)
 
     def _poll_keys(self, poll: Callable[[], bytes]) -> None:
         """Read whatever is available this tick. Esc/CR/LF request a skip;

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -453,6 +453,217 @@ def generate_crest(
         return CrestFrame(0, 0, (), 0.0, "generation error")
 
 
+def crest_renderer() -> str:
+    """``JARVIS_OV_CREST_RENDERER`` — ``halfblock`` (default, 2026-07-18
+    fidelity pass) or ``quadrant`` (legacy).
+
+    HALFBLOCK is a renderer-class upgrade: each terminal cell renders
+    ``▀`` with INDEPENDENT foreground (upper pixel) and background
+    (lower pixel) colors — 1×2 true pixels per cell with full per-pixel
+    color (the chafa/timg technique). That enables genuine coverage-
+    based alpha anti-aliasing (edge pixels blend toward the dark
+    canvas — real AA, not luminance smearing) and per-pixel gradient +
+    scale banding so the coil reads as a snake's body, not a lumpy
+    ring. Quadrant glyphs give 2×2 binary subcells but only ONE color
+    per cell — the structural ceiling the operator's screenshots hit."""
+    mode = os.environ.get(
+        "JARVIS_OV_CREST_RENDERER", "halfblock",
+    ).strip().lower()
+    return mode if mode in ("halfblock", "quadrant") else "halfblock"
+
+
+def _band_strength() -> float:
+    """Scale-banding amplitude along the coil (``JARVIS_OV_CREST_BANDS``
+    amplitude, default 0.10 — subtle segmentation that reads as scales).
+    0 disables. Clamped [0, 0.3]."""
+    try:
+        return min(0.3, max(0.0, float(
+            os.environ.get("JARVIS_OV_CREST_BAND_AMP", "0.10"),
+        )))
+    except (TypeError, ValueError):
+        return 0.10
+
+
+_BAND_COUNT = 26   # bands around the full coil — segment cadence
+
+
+@dataclass(frozen=True)
+class PixelFrame:
+    """Half-block pixel raster: ``cols`` cell columns × ``px_rows``
+    (= cell rows × 2) pixel rows. ``pixels[(x, py)] = (rgb, delay_s)``."""
+
+    cols: int
+    rows: int                 # CELL rows (px_rows == rows * 2)
+    px_rows: int
+    pixels: Dict[Tuple[int, int], Tuple[Tuple[int, int, int], float]]
+    max_delay_s: float
+
+
+def _pixel_color_and_delay(
+    kind: str, theta: Optional[float], py_frac: float, geo: _Geometry,
+) -> Tuple[Tuple[float, float, float], float]:
+    """Base color + reveal delay for one pixel — the SAME palette,
+    gradient and delay formulas as the cell path, plus coil scale
+    banding. Pure."""
+    if kind == "eye":
+        return tuple(float(c) for c in _EYE_RGB), 1.55
+    if kind == "head":
+        return tuple(float(c) for c in _HEAD_RGB), 1.42
+    if kind == "v":
+        t = max(0.0, min(1.0, py_frac))
+        color = tuple(
+            float(_V_TOP_RGB[k] + t * (_V_BOT_RGB[k] - _V_TOP_RGB[k]))
+            for k in range(3)
+        )
+        return color, 1.78 + 0.5 * t
+    # coil
+    th = theta if theta is not None else 0.0
+    frac = _ang_norm(th - geo.tail_tip) / (2 * math.pi)
+    color = _grad(frac)
+    amp = _band_strength()
+    if amp > 0.0:
+        band = 1.0 + amp * math.sin(th * _BAND_COUNT)
+        color = tuple(min(255.0, c * band) for c in color)
+    return tuple(float(c) for c in color), 0.05 + 1.30 * frac
+
+
+def _sample_pixel(
+    px0: float, py0: float, geo: _Geometry, ss: int,
+) -> Tuple[Optional[str], float, Optional[float]]:
+    """Sample ONE half-block pixel (1.0 cell wide × 1 physical-px tall)
+    with ss×ss subsamples. Returns (kind, coverage 0..1, theta)."""
+    votes = {"eye": 0, "head": 0, "coil": 0, "v": 0}
+    theta: Optional[float] = None
+    for sy in range(ss):
+        for sx in range(ss):
+            spx = px0 + (sx + 0.5) / ss
+            spy = py0 + ((sy + 0.5) / ss) * _REF_ASPECT
+            if _sample_eye(spx, spy, geo):
+                votes["eye"] += 1
+            elif _sample_head(spx, spy, geo):
+                votes["head"] += 1
+            elif _sample_coil(spx, spy, geo):
+                votes["coil"] += 1
+                theta = math.atan2(-(spy - geo.cy), spx - geo.cx)
+            elif _sample_v(spx, spy, geo):
+                votes["v"] += 1
+    n = ss * ss
+    inside = sum(votes.values())
+    if inside == 0:
+        return None, 0.0, None
+    kind = max(_PRIORITY, key=lambda kk: votes[kk])
+    return kind, inside / n, theta
+
+
+@functools.lru_cache(maxsize=8)
+def _generate_pixels_cached(clamped_cols: int, rows: int) -> PixelFrame:
+    geo = _Geometry.for_size(clamped_cols, rows)
+    ss = _ss()
+    pixels: Dict[Tuple[int, int], Tuple[Tuple[int, int, int], float]] = {}
+    max_delay = 0.0
+    px_rows = rows * 2
+    v_span = max(1e-6, geo.v_top + geo.v_bot)
+    for py in range(px_rows):
+        py0 = float(py) * _REF_ASPECT
+        for x in range(clamped_cols):
+            kind, coverage, theta = _sample_pixel(float(x), py0, geo, ss)
+            if kind is None or coverage < 0.06:
+                continue
+            py_frac = (py * _REF_ASPECT - (geo.cy - geo.v_top)) / v_span
+            base, delay = _pixel_color_and_delay(kind, theta, py_frac, geo)
+            # TRUE anti-aliasing: coverage-alpha blend toward the dark
+            # canvas (gamma-softened so edges taper, not smear).
+            alpha = coverage ** 0.75
+            rgb = tuple(
+                max(0, min(255, round(c * alpha))) for c in base
+            )
+            pixels[(x, py)] = (rgb, delay)  # type: ignore[assignment]
+            max_delay = max(max_delay, delay)
+    return PixelFrame(
+        cols=clamped_cols, rows=rows, px_rows=px_rows,
+        pixels=pixels, max_delay_s=max_delay,
+    )
+
+
+def generate_crest_pixels(
+    measured_cols: int, measured_rows: int,
+) -> Optional[PixelFrame]:
+    """Half-block raster sized like :func:`generate_crest` (same clamps
+    + row fit). None when the terminal can't fit it. NEVER raises."""
+    try:
+        lo, _hi, clamped = _clamp_cols(measured_cols)
+        if measured_cols < lo:
+            return None
+        rows = _Geometry.rows_needed(clamped)
+        if measured_rows < rows + 2:
+            return None
+        return _generate_pixels_cached(clamped, rows)
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def pixels_to_text(
+    pf: "PixelFrame", *, elapsed: Optional[float] = None,
+) -> "Any":
+    """PixelFrame → Rich Text of ``▀`` cells (fg=upper px, bg=lower px).
+    ``elapsed=None`` = the full emblem; float = partial reveal. NEVER
+    raises; degrades to empty Text."""
+    try:
+        from rich.text import Text
+        cutoff = float("inf") if elapsed is None else elapsed
+        text = Text()
+        for cy in range(pf.rows):
+            for x in range(pf.cols):
+                top = pf.pixels.get((x, cy * 2))
+                bot = pf.pixels.get((x, cy * 2 + 1))
+                if top is not None and top[1] > cutoff:
+                    top = None
+                if bot is not None and bot[1] > cutoff:
+                    bot = None
+                if top is None and bot is None:
+                    text.append(" ")
+                elif top is not None and bot is not None:
+                    tr, tg, tb = top[0]
+                    br, bg_, bb = bot[0]
+                    text.append(
+                        "▀",
+                        style=(
+                            f"rgb({tr},{tg},{tb}) on "
+                            f"rgb({br},{bg_},{bb})"
+                        ),
+                    )
+                elif top is not None:
+                    tr, tg, tb = top[0]
+                    text.append("▀", style=f"rgb({tr},{tg},{tb})")
+                else:
+                    br, bg_, bb = bot[0]  # type: ignore[index]
+                    text.append("▄", style=f"rgb({br},{bg_},{bb})")
+            if cy < pf.rows - 1:
+                text.append("\n")
+        return text
+    except Exception:  # noqa: BLE001
+        try:
+            from rich.text import Text
+            return Text("")
+        except Exception:  # noqa: BLE001
+            return ""
+
+
+def render_crest_auto(
+    frame: "CrestFrame", tier: ColorTier, *, elapsed: Optional[float] = None,
+) -> "Any":
+    """THE renderer dispatch: half-block pixels on capable terminals
+    (C256+ and renderer=halfblock), quadrant glyphs otherwise. Both
+    paths honor the reveal clock. NEVER raises."""
+    try:
+        if crest_renderer() == "halfblock" and tier >= ColorTier.C256:
+            pf = _generate_pixels_cached(frame.cols, frame.rows)
+            return pixels_to_text(pf, elapsed=elapsed)
+    except Exception:  # noqa: BLE001
+        pass
+    return frame_to_text(frame, tier, elapsed=elapsed)
+
+
 def frame_to_text(
     frame: "CrestFrame", tier: ColorTier, *, elapsed: Optional[float] = None,
 ) -> "Any":
@@ -509,7 +720,7 @@ def print_static_crest(console: "Any") -> bool:
         )
         if frame.unavailable_reason:
             return False
-        console.print(frame_to_text(frame, tier))
+        console.print(render_crest_auto(frame, tier))
         return True
     except Exception:  # noqa: BLE001
         return False

--- a/tests/ui/test_crest_halfblock.py
+++ b/tests/ui/test_crest_halfblock.py
@@ -1,0 +1,166 @@
+"""Half-block pixel renderer — the fidelity-class upgrade spine.
+
+Operator verdict on the quadrant renderer: lumpy, smeary, "amateur".
+Root cause was structural — one color per cell. The half-block path
+renders ``▀`` with independent fg (upper pixel) + bg (lower pixel):
+1×2 true pixels per cell, per-pixel gradient, coverage-alpha
+anti-aliasing, and coil scale banding so the mark reads as a snake.
+Plus: the ceremony now leaves the PERSISTENT emblem in scrollback
+instead of erasing it (the shot-1 vanishing-crest glitch).
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import crest
+from backend.core.ouroboros.ui.theme import ColorTier
+
+
+@pytest.fixture(autouse=True)
+def _clean(monkeypatch):
+    for k in (
+        "JARVIS_OV_CREST_RENDERER", "JARVIS_OV_CREST_BAND_AMP",
+        "JARVIS_OV_CREST_FEATHER",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    crest._generate_pixels_cached.cache_clear()
+    crest._generate_cached.cache_clear()
+    yield
+    crest._generate_pixels_cached.cache_clear()
+    crest._generate_cached.cache_clear()
+
+
+def _pf():
+    pf = crest.generate_crest_pixels(80, 40)
+    assert pf is not None
+    return pf
+
+
+# ---------------------------------------------------------------------------
+# (1) The pixel raster — 2× vertical resolution, AA, banding
+# ---------------------------------------------------------------------------
+
+
+def test_pixel_frame_doubles_vertical_resolution():
+    pf = _pf()
+    assert pf.px_rows == pf.rows * 2
+    assert len(pf.pixels) > 400                   # a real raster, not a sketch
+
+
+def test_coverage_alpha_antialiasing_edges_darker_than_core():
+    """True AA: edge pixels (partial coverage) carry dimmer color than
+    full-coverage interior pixels of the same region."""
+    pf = _pf()
+    lums = sorted(sum(rgb) for rgb, _d in pf.pixels.values())
+    # A healthy AA distribution has a real spread: the dimmest edge
+    # pixels are well below the brightest interior pixels.
+    assert lums[0] < lums[-1] * 0.55
+
+
+def test_no_channel_clipping():
+    pf = _pf()
+    for rgb, _d in pf.pixels.values():
+        for ch in rgb:
+            assert 0 <= ch <= 255
+
+
+def test_scale_banding_modulates_coil(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_CREST_BAND_AMP", "0.0")
+    crest._generate_pixels_cached.cache_clear()
+    flat = crest.generate_crest_pixels(80, 40)
+    monkeypatch.setenv("JARVIS_OV_CREST_BAND_AMP", "0.2")
+    crest._generate_pixels_cached.cache_clear()
+    banded = crest.generate_crest_pixels(80, 40)
+    assert flat is not None and banded is not None
+    flat_lum = [sum(rgb) for rgb, _ in flat.pixels.values()]
+    band_lum = [sum(rgb) for rgb, _ in banded.pixels.values()]
+    import statistics
+    # Banding widens luminance variance along the coil.
+    assert statistics.pstdev(band_lum) > statistics.pstdev(flat_lum)
+
+
+def test_reveal_clock_threads_through_pixels():
+    pf = _pf()
+    full = crest.pixels_to_text(pf).plain
+    early = crest.pixels_to_text(pf, elapsed=0.05).plain
+    assert len(early.strip()) < len(full.strip())
+
+
+def test_halfblock_text_uses_dual_color_cells():
+    pf = _pf()
+    from rich.text import Text
+    text = crest.pixels_to_text(pf)
+    assert isinstance(text, Text)
+    dual = [
+        sp for sp in text.spans
+        if " on rgb(" in str(sp.style)
+    ]
+    assert dual                                    # fg+bg pixels exist
+
+
+# ---------------------------------------------------------------------------
+# (2) Renderer dispatch — capability-aware, env-tunable
+# ---------------------------------------------------------------------------
+
+
+def _frame():
+    f = crest.generate_crest(80, 40, tier=ColorTier.TRUECOLOR, unicode_ok=True)
+    assert f.unavailable_reason is None
+    return f
+
+
+def test_auto_dispatch_prefers_halfblock_on_truecolor():
+    text = crest.render_crest_auto(_frame(), ColorTier.TRUECOLOR)
+    assert "▀" in text.plain                       # pixel path
+
+
+def test_auto_dispatch_falls_back_on_16_color():
+    text = crest.render_crest_auto(_frame(), ColorTier.STANDARD)
+    assert "▀" not in text.plain or "█" in text.plain  # quadrant path
+
+
+def test_renderer_env_forces_quadrant(monkeypatch):
+    monkeypatch.setenv("JARVIS_OV_CREST_RENDERER", "quadrant")
+    f = _frame()
+    auto = crest.render_crest_auto(f, ColorTier.TRUECOLOR)
+    legacy = crest.frame_to_text(f, ColorTier.TRUECOLOR)
+    assert auto.plain == legacy.plain              # byte-identical fallback
+
+
+# ---------------------------------------------------------------------------
+# (3) Persistent emblem — the vanishing-crest glitch is dead
+# ---------------------------------------------------------------------------
+
+
+def test_ceremony_prints_persistent_emblem_pin():
+    from pathlib import Path
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "backend/core/ouroboros/ui/awakening.py"
+    ).read_text()
+    body = src[src.index("async def _run_animated"):]
+    body = body[:body.index("async def _cool_down")]
+    # After the Live (transient) closes, the FULL crest prints into
+    # scrollback BEFORE the cooled header.
+    assert "PERSISTENT EMBLEM" in body
+    assert body.index("self._console.print(self._render_crest_text(") < \
+        body.index("self._print_cooled_header()")
+
+
+def test_conductor_renders_via_auto_dispatch_pin():
+    from pathlib import Path
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "backend/core/ouroboros/ui/awakening.py"
+    ).read_text()
+    assert "render_crest_auto" in src
+
+
+def test_static_emblem_uses_auto_dispatch_pin():
+    from pathlib import Path
+    src = (
+        Path(__file__).resolve().parents[2]
+        / "backend/core/ouroboros/ui/crest.py"
+    ).read_text()
+    body = src[src.index("def print_static_crest"):][:1600]
+    assert "render_crest_auto(frame, tier)" in body


### PR DESCRIPTION
Renderer-class upgrade: ▀ dual-color pixels (1×2 per cell), coverage-alpha anti-aliasing, coil scale banding, capability-aware dispatch with byte-identical quadrant fallback, and the ceremony now leaves the full emblem in scrollback instead of erasing it. 12 new tests; 132/132 ui.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded the crest renderer to half-block pixels with 2× vertical resolution, true coverage-based AA, and coil scale banding; added capability-aware dispatch and kept the final emblem in scrollback. This makes the crest sharp on truecolor terminals, with a byte-identical quadrant fallback otherwise.

- **New Features**
  - Half-block pixel renderer: dual-color `▀` cells (1×2 pixels), per-pixel gradient, true AA, and coil scale banding.
  - Auto dispatch: uses half-block on C256+; falls back to quadrant on low color or when `JARVIS_OV_CREST_RENDERER=quadrant`. Reveal clock works on both paths. `render_crest_auto` is now the single entry point.

- **Bug Fixes**
  - Persistent emblem: prints the full crest into scrollback before the cooled header, fixing the vanishing-crest/partial-erase glitch.

<sup>Written for commit 0e6460c1dd866b3f7cd5e8e19fd92097499af533. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69936?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

