### PR TITLE
fix(governance): four-root fix for the bare-ov death spiral

### DIFF
--- a/backend/core/ouroboros/battle_test/shutdown_watchdog.py
+++ b/backend/core/ouroboros/battle_test/shutdown_watchdog.py
@@ -318,10 +318,23 @@ class BoundedShutdownWatchdog:
             #       [ShutdownWatchdog.TOMBSTONE] CRITICAL lines that
             #       land in debug.log via the harness file handler
             try:
-                import faulthandler as _fh
-                _fh.dump_traceback(file=sys.stderr)
+                # Cockpit hygiene (2026-07-18): the full-thread stderr
+                # dump belongs to soak forensics; on the product
+                # surface it buried the goodbye under 200 lines of
+                # tombstones. Sinks (2)+(3) keep EVERY byte in the
+                # tombstone file + session log regardless of mode.
+                from backend.core.ouroboros.ui.presentation_mode import (
+                    is_cockpit as _is_cockpit_dump,
+                )
+                if not _is_cockpit_dump():
+                    import faulthandler as _fh
+                    _fh.dump_traceback(file=sys.stderr)
             except Exception:  # noqa: BLE001
-                pass
+                try:
+                    import faulthandler as _fh
+                    _fh.dump_traceback(file=sys.stderr)
+                except Exception:  # noqa: BLE001
+                    pass
 
             try:
                 _tombstone_dir = os.environ.get(
@@ -372,10 +385,16 @@ class BoundedShutdownWatchdog:
                             _stack_str = "".join(
                                 _tb.format_list(_stack)
                             )
+                            # file_only: the cockpit console filter
+                            # (silent_boot._CockpitConsoleFilter) drops
+                            # these from the operator surface; the
+                            # session file handler + soak console keep
+                            # full fidelity (filter installed cockpit-only).
                             logger.critical(
                                 "[ShutdownWatchdog.TOMBSTONE] "
                                 "thread_id=%d\n%s",
                                 _tid, _stack_str,
+                                extra={"file_only": True},
                             )
                         except Exception:  # noqa: BLE001
                             continue

--- a/backend/core/ouroboros/governance/key_input.py
+++ b/backend/core/ouroboros/governance/key_input.py
@@ -114,6 +114,22 @@ from typing import (
 
 logger = logging.getLogger(__name__)
 
+#: Select timeout for the bounded stdin read (seconds). The teardown
+#: latency ceiling for the reader thread — env-tunable, clamped in use.
+def _resolve_read_select_timeout() -> float:
+    """Env-tunable, clamped [0.05, 2.0]; malformed values fall back to
+    0.5 — module import is NEVER blocked by a bad env string."""
+    try:
+        raw = float(os.environ.get(
+            "JARVIS_KEY_INPUT_SELECT_TIMEOUT_S", "0.5",
+        ))
+    except (TypeError, ValueError):
+        raw = 0.5
+    return max(0.05, min(2.0, raw))
+
+
+_READ_SELECT_TIMEOUT_S = _resolve_read_select_timeout()
+
 
 KEY_INPUT_SCHEMA_VERSION: str = "key_input.1"
 
@@ -880,11 +896,27 @@ class InputController:
             self._exit_raw_mode()
 
     def _blocking_read(self, n: int) -> bytes:
-        """Blocking read of up to ``n`` bytes from stdin. Runs in
-        executor thread. Returns empty bytes on EOF or error."""
+        """Bounded read of up to ``n`` bytes from stdin. Runs in an
+        executor thread. Returns empty bytes on EOF/error/timeout.
+
+        2026-07-18 teardown-wedge root cause: an UNBOUNDED ``os.read``
+        on the DEFAULT executor blocks until a keypress; task
+        cancellation cannot unblock it, so ``loop.shutdown_default_
+        executor()`` joined the thread forever → BoundedShutdownWatchdog
+        os._exit(75) + tombstone dump on the operator's terminal. The
+        read is now select-bounded: the thread wakes at most
+        ``_READ_SELECT_TIMEOUT_S`` after data-or-stop, the reader loop
+        re-checks its stop event, and the executor drains cleanly at
+        shutdown. No fd tricks, no daemon-thread leaks."""
         try:
             if self._fd < 0:
                 return b""
+            import select
+            ready, _w, _x = select.select(
+                [self._fd], [], [], _READ_SELECT_TIMEOUT_S,
+            )
+            if not ready:
+                return b""            # timeout — loop re-checks stop event
             return os.read(self._fd, n)
         except Exception:  # noqa: BLE001 — defensive
             return b""

--- a/backend/core/ouroboros/governance/providers.py
+++ b/backend/core/ouroboros/governance/providers.py
@@ -3040,6 +3040,54 @@ Rules:
     return "\n\n".join(parts)
 
 
+#: Complexity → reservation multiplier (upper-bound spend fractions of
+#: the per-op cap; env-tunable, unknown → 1.0 fail-closed). Calibrated
+#: from live per-op costs: trivial ops land $0.01–0.05, simple
+#: $0.03–0.10 — a flat worst-case reservation starved the cockpit.
+_RESERVATION_COMPLEXITY_MULT = {
+    "trivial": ("JARVIS_RESERVE_MULT_TRIVIAL", 0.15),
+    "simple": ("JARVIS_RESERVE_MULT_SIMPLE", 0.30),
+    "light": ("JARVIS_RESERVE_MULT_SIMPLE", 0.30),
+    "moderate": ("JARVIS_RESERVE_MULT_MODERATE", 0.60),
+    "standard": ("JARVIS_RESERVE_MULT_MODERATE", 0.60),
+    "complex": ("JARVIS_RESERVE_MULT_COMPLEX", 1.0),
+    "heavy_code": ("JARVIS_RESERVE_MULT_COMPLEX", 1.0),
+}
+
+#: Reservation floor — a scaled estimate never drops below this
+#: (actual-usage reconciliation still bills the true cost).
+_RESERVATION_FLOOR_ENV = "JARVIS_RESERVE_FLOOR_USD"
+
+
+def _scale_reservation_by_complexity(
+    reservation_usd: float, complexity: str,
+) -> float:
+    """Scale the per-op budget reservation by declared complexity.
+    Unknown/blank complexity keeps the full worst case (fail-closed —
+    misdeclared metadata can never under-reserve to zero, and the
+    session ledger reconciles to ACTUAL spend after the call). Pure;
+    NEVER raises."""
+    try:
+        row = _RESERVATION_COMPLEXITY_MULT.get(
+            str(complexity or "").strip().lower(),
+        )
+        if row is None:
+            return reservation_usd
+        env_name, default_mult = row
+        try:
+            mult = float(os.environ.get(env_name, str(default_mult)))
+        except (TypeError, ValueError):
+            mult = default_mult
+        mult = min(1.0, max(0.05, mult))
+        try:
+            floor = float(os.environ.get(_RESERVATION_FLOOR_ENV, "0.02"))
+        except (TypeError, ValueError):
+            floor = 0.02
+        return max(floor, reservation_usd * mult)
+    except Exception:  # noqa: BLE001
+        return reservation_usd
+
+
 async def _context_prune_gate(prompt: str, provider_hint: str) -> str:
     """CONTEXT_PRUNE gate at the Expansion→Generate assembly seam.
 
@@ -8941,6 +8989,19 @@ class ClaudeProvider:
                         )
                     else:
                         _reservation_usd = float(_cumulative_cap_usd)
+                    # Complexity-scaled reservation (2026-07-18 root
+                    # cause): a FLAT worst-case reservation made a
+                    # trivial one-file op demand the same $0.50 as a
+                    # heavy multi-file generation — structurally
+                    # unaffordable inside the default cockpit budget
+                    # (est=$0.5000 > remaining=$0.4995 → instant
+                    # session_exhausted). The estimate now scales with
+                    # the op's declared complexity; unknown complexity
+                    # keeps the conservative worst case (fail-closed).
+                    _reservation_usd = _scale_reservation_by_complexity(
+                        _reservation_usd,
+                        getattr(context, "task_complexity", "") or "",
+                    )
                     _sba_acquire(
                         op_id=_ctx_op_id_str,
                         signal_source=getattr(

--- a/backend/core/ouroboros/governance/silent_boot.py
+++ b/backend/core/ouroboros/governance/silent_boot.py
@@ -90,7 +90,8 @@ import os
 import sys
 import threading
 from pathlib import Path
-from typing import Any, List, Optional
+import time
+from typing import Any, Dict, Tuple, List, Optional
 
 from backend.core.ouroboros.ui.presentation_mode import (
     PresentationMode,
@@ -132,6 +133,66 @@ _CONFIG_LOCK = threading.Lock()
 # ---------------------------------------------------------------------------
 # Flag accessors
 # ---------------------------------------------------------------------------
+
+
+class _CockpitErrorFormatter(logging.Formatter):
+    """One conformed line per ERROR on the cockpit console.
+
+    ``⚠ <logger-tail> · <message first line, ≤160 chars> — detail in
+    session log``. The session file handler always carries the full
+    record; the operator surface never gets a telemetry wall."""
+
+    _MAX = 160
+
+    def format(self, record: logging.LogRecord) -> str:  # noqa: A003
+        try:
+            tail = (record.name or "").rsplit(".", 1)[-1] or "system"
+            msg = record.getMessage().splitlines()[0].strip()
+            if len(msg) > self._MAX:
+                msg = msg[: self._MAX - 1].rstrip() + "…"
+            return f"⚠ {tail} · {msg} — detail in session log"
+        except Exception:  # noqa: BLE001
+            try:
+                return f"⚠ {record.getMessage()[:160]}"
+            except Exception:  # noqa: BLE001
+                return "⚠ error (unformattable record)"
+
+
+class _CockpitConsoleFilter(logging.Filter):
+    """Two console protections for the cockpit:
+
+    * records marked ``file_only=True`` (via ``extra=``) never reach
+      the terminal — the sink for forensic walls (watchdog tombstones)
+      that belong in the session log;
+    * repeat-dedup: the same (logger, message-prefix) within the window
+      renders ONCE (the EXHAUSTION storms repeated near-identical walls
+      every few seconds). NEVER raises — a filter fault admits the
+      record (fail-open: losing dedup beats losing an error)."""
+
+    _WINDOW_S = 30.0
+
+    def __init__(self) -> None:
+        super().__init__()
+        self._seen: Dict[Tuple[str, str], float] = {}
+
+    def filter(self, record: logging.LogRecord) -> bool:  # noqa: A003
+        try:
+            if getattr(record, "file_only", False):
+                return False
+            key = (record.name, record.getMessage()[:80])
+            now = time.monotonic()
+            last = self._seen.get(key)
+            self._seen[key] = now
+            if last is not None and (now - last) < self._WINDOW_S:
+                return False
+            if len(self._seen) > 256:
+                cutoff = now - self._WINDOW_S
+                self._seen = {
+                    k: t for k, t in self._seen.items() if t >= cutoff
+                }
+            return True
+        except Exception:  # noqa: BLE001
+            return True
 
 
 def _get_registry() -> Any:
@@ -393,10 +454,22 @@ def _configure_locked(
         )
         term_handler = logging.StreamHandler(stream=sys.stderr)
         term_handler.setLevel(threshold)
-        term_handler.setFormatter(logging.Formatter(
-            # Terse format — matches CC's restraint
-            "%(levelname)s %(message)s",
-        ))
+        if str(_resolved_mode).lower().endswith("cockpit") or (
+            getattr(_resolved_mode, "value", "") == "cockpit"
+        ):
+            # Cockpit ERROR conformance (2026-07-18): an ERROR that
+            # legitimately reaches the operator must arrive as ONE
+            # design-language line, not a multi-KV telemetry wall (the
+            # EXHAUSTION dumps that stomped the ceremony). Compact
+            # formatter + repeat-dedup + file_only rejection; the FULL
+            # record always lands in the session file handler.
+            term_handler.setFormatter(_CockpitErrorFormatter())
+            term_handler.addFilter(_CockpitConsoleFilter())
+        else:
+            term_handler.setFormatter(logging.Formatter(
+                # Terse format — matches CC's restraint
+                "%(levelname)s %(message)s",
+            ))
         setattr(term_handler, _HANDLER_MARKER, True)
         root.addHandler(term_handler)
     except Exception:  # noqa: BLE001 — defensive

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -1329,12 +1329,30 @@ def main(argv: "list[str] | None" = None) -> None:
           Signed-off-by: JARVIS Ouroboros <ouroboros@jarvis.local>{_RESET}
         """),
     )
+    # Presentation-aware session budget default (2026-07-18 root cause:
+    # bare `ov` died in 4 minutes — the $0.50 SOAK default collided with
+    # the $0.50 worst-case per-op Claude reservation, so the FIRST op
+    # was structurally unaffordable → 3 refusals → hibernation →
+    # session_exhausted. A product cockpit must afford real work out of
+    # the box; soak/CI keeps the conservative cap.
+    _cockpit_boot = (os.environ.get(
+        "JARVIS_OV_PRESENTATION", "",
+    ).strip().lower() == "cockpit")
+    _default_cap = (
+        os.environ.get("JARVIS_COCKPIT_COST_CAP", "2.50")
+        if _cockpit_boot
+        else os.environ.get("OUROBOROS_BATTLE_COST_CAP", "0.50")
+    )
     parser.add_argument(
         "--cost-cap",
         type=float,
-        default=float(os.environ.get("OUROBOROS_BATTLE_COST_CAP", "0.50")),
+        default=float(_default_cap),
         metavar="USD",
-        help="Session budget in USD (env: OUROBOROS_BATTLE_COST_CAP, default: 0.50)",
+        help=(
+            "Session budget in USD (cockpit default 2.50 via "
+            "JARVIS_COCKPIT_COST_CAP; soak default 0.50 via "
+            "OUROBOROS_BATTLE_COST_CAP)"
+        ),
     )
     parser.add_argument(
         "--idle-timeout",

--- a/tests/governance/test_failure_bundle_hardening.py
+++ b/tests/governance/test_failure_bundle_hardening.py
@@ -1,0 +1,287 @@
+"""Failure-bundle hardening spine — the bare-``ov`` 4-minute death spiral.
+
+Session bt-2026-07-19-031750 postmortem, four roots:
+
+  1. **Budget economics** — flat $0.50 worst-case reservation vs the
+     $0.50 default session cap → every op structurally unaffordable →
+     3 preflight refusals → hibernation → ``session_exhausted`` in 4
+     minutes. Fix: complexity-scaled reservation
+     (``providers._scale_reservation_by_complexity``).
+  2. **Cockpit cost cap** — the product surface now defaults to
+     ``JARVIS_COCKPIT_COST_CAP`` (2.50) instead of the soak/CI 0.50.
+  3. **Teardown wedge** — unbounded ``os.read`` on the default
+     executor could never be joined → BoundedShutdownWatchdog
+     ``os._exit(75)``. Fix: select-bounded ``_blocking_read``.
+  4. **ERROR/tombstone conformance** — EXHAUSTION walls + watchdog
+     faulthandler dumps stomped the cockpit ceremony. Fix:
+     ``_CockpitErrorFormatter`` + ``_CockpitConsoleFilter`` in
+     silent_boot, cockpit-gated stderr dump + ``file_only`` tombstone
+     records in shutdown_watchdog.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import key_input, providers, silent_boot
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# Root 1 — complexity-scaled budget reservation
+# ---------------------------------------------------------------------------
+
+
+class TestReservationScaling:
+    def test_trivial_scales_down(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_RESERVE_MULT_TRIVIAL", raising=False)
+        assert providers._scale_reservation_by_complexity(
+            0.50, "trivial",
+        ) == pytest.approx(0.075)
+
+    def test_simple_and_light_share_a_mult(self):
+        a = providers._scale_reservation_by_complexity(0.50, "simple")
+        b = providers._scale_reservation_by_complexity(0.50, "light")
+        assert a == b == pytest.approx(0.15)
+
+    def test_unknown_complexity_keeps_worst_case_fail_closed(self):
+        assert providers._scale_reservation_by_complexity(
+            0.50, "quantum_banana",
+        ) == 0.50
+        assert providers._scale_reservation_by_complexity(0.50, "") == 0.50
+        assert providers._scale_reservation_by_complexity(0.50, None) == 0.50
+
+    def test_complex_keeps_full_reservation(self):
+        assert providers._scale_reservation_by_complexity(
+            0.50, "heavy_code",
+        ) == 0.50
+
+    def test_floor_holds(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_RESERVE_FLOOR_USD", raising=False)
+        # 0.05 * 0.15 = 0.0075 < the 0.02 floor
+        assert providers._scale_reservation_by_complexity(
+            0.05, "trivial",
+        ) == pytest.approx(0.02)
+
+    def test_env_mult_override_clamped(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_RESERVE_MULT_TRIVIAL", "5.0")
+        # Clamped to 1.0 — an env typo can never OVER-reserve.
+        assert providers._scale_reservation_by_complexity(
+            0.50, "trivial",
+        ) == 0.50
+        monkeypatch.setenv("JARVIS_RESERVE_MULT_TRIVIAL", "not-a-float")
+        assert providers._scale_reservation_by_complexity(
+            0.50, "trivial",
+        ) == pytest.approx(0.075)
+
+    def test_wired_at_the_sba_reservation_site_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/governance/providers.py"
+        ).read_text()
+        assert "_scale_reservation_by_complexity(" in src.split(
+            "def _scale_reservation_by_complexity", 1,
+        )[1], "helper defined but never called — wired-but-inert"
+
+
+# ---------------------------------------------------------------------------
+# Root 2 — cockpit-aware cost-cap default
+# ---------------------------------------------------------------------------
+
+
+class TestCockpitCostCap:
+    def test_cockpit_default_pin(self):
+        src = (_REPO / "scripts/ouroboros_battle_test.py").read_text()
+        assert 'os.environ.get("JARVIS_COCKPIT_COST_CAP", "2.50")' in src
+        assert 'os.environ.get("OUROBOROS_BATTLE_COST_CAP", "0.50")' in src
+        # The branch keys off the presentation env, not a new flag.
+        assert '"JARVIS_OV_PRESENTATION"' in src
+
+
+# ---------------------------------------------------------------------------
+# Root 3 — select-bounded stdin read
+# ---------------------------------------------------------------------------
+
+
+class _FdHolder:
+    def __init__(self, fd: int) -> None:
+        self._fd = fd
+
+
+class TestBoundedRead:
+    def test_timeout_returns_empty_not_blocks(self):
+        r, w = os.pipe()
+        try:
+            holder = _FdHolder(r)
+            t0 = time.monotonic()
+            out = key_input.InputController._blocking_read(holder, 1)
+            elapsed = time.monotonic() - t0
+            assert out == b""
+            # Woke on the select timeout, not a keypress.
+            assert elapsed < key_input._READ_SELECT_TIMEOUT_S + 1.0
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_ready_fd_delivers_bytes(self):
+        r, w = os.pipe()
+        try:
+            os.write(w, b"q")
+            out = key_input.InputController._blocking_read(_FdHolder(r), 1)
+            assert out == b"q"
+        finally:
+            os.close(r)
+            os.close(w)
+
+    def test_negative_fd_and_closed_fd_return_empty(self):
+        assert key_input.InputController._blocking_read(
+            _FdHolder(-1), 1,
+        ) == b""
+        r, w = os.pipe()
+        os.close(r)
+        os.close(w)
+        assert key_input.InputController._blocking_read(
+            _FdHolder(r), 1,
+        ) == b""
+
+    def test_timeout_env_clamped_and_malformed_safe(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_KEY_INPUT_SELECT_TIMEOUT_S", "99")
+        assert key_input._resolve_read_select_timeout() == 2.0
+        monkeypatch.setenv("JARVIS_KEY_INPUT_SELECT_TIMEOUT_S", "0.001")
+        assert key_input._resolve_read_select_timeout() == 0.05
+        monkeypatch.setenv("JARVIS_KEY_INPUT_SELECT_TIMEOUT_S", "banana")
+        assert key_input._resolve_read_select_timeout() == 0.5
+
+
+# ---------------------------------------------------------------------------
+# Root 4 — cockpit ERROR conformance + tombstone hygiene
+# ---------------------------------------------------------------------------
+
+
+def _record(
+    msg: str, *, name: str = "backend.core.ouroboros.x.exhaustion",
+    level: int = logging.ERROR, **extra: object,
+) -> logging.LogRecord:
+    rec = logging.LogRecord(
+        name=name, level=level, pathname=__file__, lineno=1,
+        msg=msg, args=(), exc_info=None,
+    )
+    for k, v in extra.items():
+        setattr(rec, k, v)
+    return rec
+
+
+class TestCockpitErrorFormatter:
+    def test_conformed_single_line(self):
+        fmt = silent_boot._CockpitErrorFormatter()
+        out = fmt.format(_record(
+            "EXHAUSTION est=$0.5000 remaining=$0.4995 route=STANDARD\n"
+            "op=abc provider=dw attempt=3\nmore kv walls here",
+        ))
+        assert out.startswith("⚠ exhaustion · ")
+        assert "\n" not in out
+        assert out.endswith("— detail in session log")
+
+    def test_truncates_long_messages(self):
+        fmt = silent_boot._CockpitErrorFormatter()
+        out = fmt.format(_record("x" * 900))
+        assert len(out) < 220
+        assert "…" in out
+
+    def test_never_raises_on_hostile_record(self):
+        fmt = silent_boot._CockpitErrorFormatter()
+        rec = _record("fine")
+        rec.getMessage = lambda: (_ for _ in ()).throw(RuntimeError())
+        assert fmt.format(rec).startswith("⚠")
+
+
+class TestCockpitConsoleFilter:
+    def test_file_only_records_rejected(self):
+        flt = silent_boot._CockpitConsoleFilter()
+        assert flt.filter(_record("tombstone wall", file_only=True)) is False
+        assert flt.filter(_record("real error")) is True
+
+    def test_repeat_storm_dedupes_within_window(self):
+        flt = silent_boot._CockpitConsoleFilter()
+        assert flt.filter(_record("EXHAUSTION est=$0.50")) is True
+        for _ in range(5):
+            assert flt.filter(_record("EXHAUSTION est=$0.50")) is False
+        # A DIFFERENT error still passes.
+        assert flt.filter(_record("worktree_create_failed")) is True
+
+    def test_dedup_expires_after_window(self, monkeypatch):
+        flt = silent_boot._CockpitConsoleFilter()
+        assert flt.filter(_record("boom")) is True
+        clock = time.monotonic() + silent_boot._CockpitConsoleFilter._WINDOW_S + 1
+        monkeypatch.setattr(silent_boot.time, "monotonic", lambda: clock)
+        assert flt.filter(_record("boom")) is True
+
+    def test_fail_open_admits_record(self):
+        flt = silent_boot._CockpitConsoleFilter()
+        rec = _record("fine")
+        rec.getMessage = lambda: (_ for _ in ()).throw(RuntimeError())
+        assert flt.filter(rec) is True
+
+    def test_seen_map_bounded(self):
+        flt = silent_boot._CockpitConsoleFilter()
+        for i in range(400):
+            flt.filter(_record(f"err-{i}"))
+        assert len(flt._seen) <= 400  # pruned opportunistically at >256
+
+
+class TestCockpitWiringPins:
+    def test_silent_boot_installs_formatter_and_filter_cockpit_only(self):
+        src = (
+            _REPO / "backend/core/ouroboros/governance/silent_boot.py"
+        ).read_text()
+        body = src[src.index("def _configure_locked"):]
+        assert "term_handler.setFormatter(_CockpitErrorFormatter())" in body
+        assert "term_handler.addFilter(_CockpitConsoleFilter())" in body
+
+    def test_watchdog_stderr_dump_cockpit_gated(self):
+        src = (
+            _REPO
+            / "backend/core/ouroboros/battle_test/shutdown_watchdog.py"
+        ).read_text()
+        assert "is_cockpit as _is_cockpit_dump" in src
+        assert "if not _is_cockpit_dump():" in src
+
+    def test_watchdog_tombstone_records_marked_file_only(self):
+        src = (
+            _REPO
+            / "backend/core/ouroboros/battle_test/shutdown_watchdog.py"
+        ).read_text()
+        block = src[src.index('"[ShutdownWatchdog.TOMBSTONE] "'):][:400]
+        assert 'extra={"file_only": True}' in block
+
+
+class TestCockpitConformanceEndToEnd:
+    def test_error_wall_renders_one_conformed_line(self):
+        """The integration property: formatter+filter on one handler →
+        a 6-repeat EXHAUSTION storm yields exactly ONE conformed line."""
+        import io
+
+        stream = io.StringIO()
+        h = logging.StreamHandler(stream)
+        h.setLevel(logging.ERROR)
+        h.setFormatter(silent_boot._CockpitErrorFormatter())
+        h.addFilter(silent_boot._CockpitConsoleFilter())
+        lg = logging.getLogger("test.cockpit.conformance")
+        lg.setLevel(logging.DEBUG)
+        lg.propagate = False
+        lg.handlers = [h]
+        try:
+            for _ in range(6):
+                lg.error(
+                    "EXHAUSTION est=$0.5000 > remaining=$0.4995\nkv wall",
+                )
+            lg.critical("tombstone", extra={"file_only": True})
+            out = stream.getvalue().strip().splitlines()
+            assert len(out) == 1
+            assert out[0].startswith("⚠ conformance · EXHAUSTION")
+        finally:
+            lg.handlers = []


### PR DESCRIPTION
## Summary
Session `bt-2026-07-19-031750` postmortem: bare `ov` hit `session_exhausted` in 4 minutes with EXHAUSTION walls stomping the cockpit and a tombstone dump burying the goodbye. Four independent roots, each fixed at its own layer:

1. **Budget economics** — flat \$0.50 worst-case per-op reservation vs the \$0.50 default session cap made every op structurally unaffordable (3 refusals → hibernation → exhaustion). New `_scale_reservation_by_complexity` (providers.py) scales the reservation by declared complexity (trivial 0.15× … complex 1.0×, env-tunable `JARVIS_RESERVE_MULT_*`, \$0.02 floor, unknown → full worst case fail-closed). Ledger still reconciles to actual spend.
2. **Cockpit cost cap** — `ov` (cockpit) now defaults `--cost-cap` from `JARVIS_COCKPIT_COST_CAP` (2.50); soak/CI keeps `OUROBOROS_BATTLE_COST_CAP` (0.50).
3. **Teardown wedge** — key_input's unbounded `os.read` on the default executor could never be joined → `BoundedShutdownWatchdog os._exit(75)`. `_blocking_read` is now select-bounded (`JARVIS_KEY_INPUT_SELECT_TIMEOUT_S`, clamped [0.05, 2.0], malformed-env-safe).
4. **ERROR/tombstone conformance** — cockpit console installs `_CockpitErrorFormatter` (one `⚠` line, ≤160 chars, "detail in session log") + `_CockpitConsoleFilter` (`file_only` rejection + 30s repeat dedup, fail-open); shutdown_watchdog's stderr faulthandler dump is cockpit-gated and TOMBSTONE CRITICAL records carry `extra={"file_only": True}`. Full forensic fidelity remains in the tombstone file + debug.log in every mode.

## Testing
- 24 new tests in `tests/governance/test_failure_bundle_hardening.py` — all green.
- Neighbor suites: `test_bounded_shutdown_watchdog.py` 26/26 solo; a 3-test failure in the combined 4-suite run is a **pre-existing order-dependent interaction** (identical head-to-head with this PR's watchdog edit stashed).

Known-unfixed rider: DW batch-lane `Qwen/Qwen3.5-35B-A3B-FP8` 403 (policy-card drift — separate fix).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops bare `ov` sessions from exhausting budget and hanging on shutdown. Fixes reservation math, sets a cockpit-friendly default cost cap, bounds key input reads, and cleans up cockpit error/tombstone output.

- **Bug Fixes**
  - Budget economics: `_scale_reservation_by_complexity` scales per-op reservation by declared complexity (trivial 0.15× … complex 1.0×), env-tunable (`JARVIS_RESERVE_MULT_*`), with a $0.02 floor; unknown keeps worst case. Applied at the `_sba_acquire` site; ledger still reconciles to actual spend.
  - Cockpit cost cap: `--cost-cap` now defaults to `JARVIS_COCKPIT_COST_CAP` (2.50) in cockpit; soak/CI remains `OUROBOROS_BATTLE_COST_CAP` (0.50).
  - Teardown wedge: `key_input._blocking_read` is select-bounded using `JARVIS_KEY_INPUT_SELECT_TIMEOUT_S` (clamped 0.05–2.0s) to allow the default executor to shut down cleanly.
  - Cockpit logging hygiene: `_CockpitErrorFormatter` (single ⚠ line ≤160 chars, “detail in session log”) and `_CockpitConsoleFilter` (`file_only` suppression + 30s repeat dedup). Watchdog stderr `faulthandler` dump is cockpit-gated; TOMBSTONE records use `extra={"file_only": True}`.

<sup>Written for commit 9489838b24ae81a444ef32b815bb4d15a97e8887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69937?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

