### PR TITLE
feat(ui): Rigid TUI Cockpit + Audio-Visual Synapse IPC bridge

### DIFF
--- a/backend/core/ouroboros/battle_test/audio_synapse.py
+++ b/backend/core/ouroboros/battle_test/audio_synapse.py
@@ -1,0 +1,214 @@
+"""Audio-Visual Synapse — IPC remote control for the karen_duplex plane.
+
+Operator authorization 2026-07-18: the ``karen_duplex`` audio engine was
+isolated in the daemon with no orchestration bridge — the attached TUI
+could neither arm the VAD/mic loop nor see the audio FSM. This module is
+the missing synapse, and it is strictly an ADAPTER (mandate 3, DRY): it
+holds NO audio logic. It composes two solved mechanisms:
+
+  * :func:`~backend.core.ouroboros.governance.comms.duplex.
+    karen_duplex_factory.get_default_karen` — the process-wide duplex
+    handle mounted by ``audio_pipeline_bootstrap`` (start / stop /
+    barge-in are ITS methods; we only call them).
+  * ``CockpitAttachBridge.publish_audio_state`` — the v2 attach-protocol
+    downstream lane (edge-coalesced broadcast + hydration retention).
+
+State mapping (arbiter ``VoiceState`` → attach ``AUDIO_STATES``)::
+
+    listening       → LISTENING     karen_speaking → SPEAKING
+    user_speaking   → HEARING       thinking       → THINKING
+
+The arbiter exposes no observer hook, so the synapse watches the FSM
+with a bounded edge-coalescing poll (``JARVIS_AUDIO_SYNAPSE_POLL_S``,
+default 0.15s — instant to a human eye) rather than rewriting the
+arbiter to push. Only EDGES are published; a steady state costs zero
+frames on the wire.
+
+Bulletproof contract (mandate 4): every public method is fail-soft. A
+missing duplex handle answers ``UNAVAILABLE`` (the TUI renders honesty,
+not a hang); a dead watch task is contained; ``stop()`` never raises.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.AudioSynapse")
+
+#: VoiceState.value → attach-protocol AUDIO_STATES member.
+_FSM_MAP = {
+    "listening": "LISTENING",
+    "user_speaking": "HEARING",
+    "karen_speaking": "SPEAKING",
+    "thinking": "THINKING",
+}
+
+
+def _poll_interval_s() -> float:
+    try:
+        raw = float(os.environ.get("JARVIS_AUDIO_SYNAPSE_POLL_S", "0.15"))
+    except (TypeError, ValueError):
+        raw = 0.15
+    return max(0.05, min(1.0, raw))
+
+
+class AudioVisualSynapse:
+    """Remote-control adapter: attach-protocol audio commands in,
+    audio-FSM state frames out.
+
+    ``publish`` is the injected downstream lane (production:
+    ``bridge.publish_audio_state``). ``handle_resolver`` is injected for
+    tests; production default is ``get_default_karen``.
+    """
+
+    def __init__(
+        self,
+        publish: Callable[[str], None],
+        *,
+        handle_resolver: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        self._publish = publish
+        self._resolve = handle_resolver or self._default_resolver
+        self._watch_task: Optional[asyncio.Task] = None
+        self._armed = False
+
+    @staticmethod
+    def _default_resolver() -> Any:
+        try:
+            from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (  # noqa: E501,PLC0415
+                get_default_karen,
+            )
+            return get_default_karen()
+        except Exception:  # noqa: BLE001
+            return None
+
+    @property
+    def armed(self) -> bool:
+        return self._armed
+
+    # ---- the upstream command surface (bridge on_audio sink) ----
+
+    async def handle_cmd(self, cmd: str) -> None:
+        """Execute one attach-protocol audio command. NEVER raises."""
+        try:
+            cmd = str(cmd or "").strip().lower()
+            if cmd == "wake":
+                await self._wake()
+            elif cmd == "sleep":
+                await self._sleep()
+            elif cmd == "barge":
+                await self._barge()
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioSynapse] cmd degraded", exc_info=True)
+
+    async def _wake(self) -> None:
+        handle = self._resolve()
+        if handle is None:
+            # Honest surface: this process has no mounted duplex (the
+            # supervisor owns the hardware plane) — the TUI must render
+            # that truth, never a fake LISTENING.
+            self._safe_publish("UNAVAILABLE")
+            return
+        try:
+            await handle.start()
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioSynapse] duplex start degraded", exc_info=True)
+            self._safe_publish("UNAVAILABLE")
+            return
+        self._armed = True
+        self._safe_publish(self._current_state(handle) or "LISTENING")
+        self._start_watch()
+
+    async def _sleep(self) -> None:
+        self._armed = False
+        await self._stop_watch()
+        handle = self._resolve()
+        if handle is not None:
+            try:
+                await handle.stop()
+            except Exception:  # noqa: BLE001
+                logger.debug(
+                    "[AudioSynapse] duplex stop degraded", exc_info=True,
+                )
+        self._safe_publish("OFFLINE")
+
+    async def _barge(self) -> None:
+        """Operator barge-in from the TUI — the text-plane equivalent
+        of speaking over Karen; routes to the arbiter's OWN interrupt
+        seam (no new interrupt logic)."""
+        handle = self._resolve()
+        arbiter = getattr(handle, "arbiter", None)
+        if arbiter is None:
+            return
+        try:
+            await arbiter.on_user_speech_start()
+            await arbiter.on_user_speech_end()
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioSynapse] barge degraded", exc_info=True)
+
+    # ---- the downstream FSM watch (edge-coalesced poll) ----
+
+    def _current_state(self, handle: Any) -> Optional[str]:
+        try:
+            raw = getattr(getattr(handle, "arbiter", None), "state", None)
+            value = getattr(raw, "value", raw)
+            return _FSM_MAP.get(str(value or "").strip().lower())
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _start_watch(self) -> None:
+        if self._watch_task is not None and not self._watch_task.done():
+            return
+        try:
+            self._watch_task = asyncio.get_running_loop().create_task(
+                self._watch_loop(),
+            )
+        except RuntimeError:
+            self._watch_task = None
+
+    async def _watch_loop(self) -> None:
+        interval = _poll_interval_s()
+        last: Optional[str] = None
+        try:
+            while self._armed:
+                handle = self._resolve()
+                if handle is None:
+                    break
+                state = self._current_state(handle)
+                if state is not None and state != last:
+                    last = state
+                    self._safe_publish(state)
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioSynapse] watch degraded", exc_info=True)
+
+    async def _stop_watch(self) -> None:
+        task = self._watch_task
+        self._watch_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+
+    async def stop(self) -> None:
+        """Teardown — disarm + reap the watch. NEVER raises."""
+        try:
+            self._armed = False
+            await self._stop_watch()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _safe_publish(self, state: str) -> None:
+        try:
+            self._publish(state)
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioSynapse] publish degraded", exc_info=True)
+
+
+__all__ = ["AudioVisualSynapse"]

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -22,6 +22,14 @@ Protocol (newline-delimited JSON, schema ``cockpit_attach.v1``):
     stdin from the attached terminal, routed into the harness's
     ``_handle_repl_command`` — the FULL verb set plus the bare-text
     chat bridge, not a chat-only side channel.
+  * **Audio orchestration (v2, the Audio-Visual Synapse)** — upstream
+    ``{"type":"audio","cmd":"wake"|"sleep"|"barge"}`` arms / disarms /
+    interrupts the daemon's karen_duplex voice plane; downstream
+    ``{"type":"audio_state","state":...}`` streams the audio FSM
+    (``OFFLINE`` / ``UNAVAILABLE`` / ``LISTENING`` / ``HEARING`` /
+    ``THINKING`` / ``SPEAKING``) so the attached TUI can morph its
+    prompt in real time. The hydration payload carries the CURRENT
+    audio state (late joiners never render a stale footer).
 
 Bulletproof contract (mandate 4): the daemon-side publisher is strictly
 non-blocking and per-client fail-drop — ``BrokenPipeError`` /
@@ -45,7 +53,18 @@ from typing import Any, Callable, Dict, Optional, Set
 
 logger = logging.getLogger("Ouroboros.CockpitAttach")
 
-COCKPIT_ATTACH_SCHEMA_VERSION = "cockpit_attach.v1"
+COCKPIT_ATTACH_SCHEMA_VERSION = "cockpit_attach.v2"
+
+#: Closed taxonomy of daemon→TUI audio FSM states (the morphing
+#: vocabulary). OFFLINE = voice plane not armed; UNAVAILABLE = wake
+#: requested but no duplex handle mounted in this process.
+AUDIO_STATES = (
+    "OFFLINE", "UNAVAILABLE", "LISTENING", "HEARING", "THINKING",
+    "SPEAKING",
+)
+
+#: Closed taxonomy of TUI→daemon audio commands.
+AUDIO_CMDS = ("wake", "sleep", "barge")
 
 _TRUTHY = ("1", "true", "yes", "on")
 
@@ -94,19 +113,23 @@ class CockpitAttachBridge:
         ops_provider: Optional[Callable[[], Any]] = None,
         liquidity_provider: Optional[Callable[[], Dict[str, Any]]] = None,
         on_input: Optional[Callable[[str], None]] = None,
+        on_audio: Optional[Callable[[str], None]] = None,
         path: Optional[Path] = None,
     ) -> None:
         self._status = status_provider or (lambda: {})
         self._ops = ops_provider or (lambda: [])
         self._liquidity = liquidity_provider or (lambda: {})
         self._on_input = on_input or (lambda _t: None)
+        self._on_audio = on_audio or (lambda _c: None)
         self._path = Path(path) if path is not None else attach_socket_path()
         self._server: Optional[asyncio.AbstractServer] = None
         self._clients: Set[asyncio.StreamWriter] = set()
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        self._audio_state: str = "OFFLINE"
         self.stats: Dict[str, int] = {
             "connects": 0, "dropped": 0, "lines_published": 0,
-            "inputs_received": 0,
+            "inputs_received": 0, "audio_cmds": 0,
+            "audio_states_published": 0,
         }
 
     # ---- lifecycle ----
@@ -178,6 +201,7 @@ class CockpitAttachBridge:
             "status": _safe(self._status, {}),
             "ops": _safe(self._ops, []),
             "liquidity": _safe(self._liquidity, {}),
+            "audio": {"state": self._audio_state},
         }
 
     # ---- publish (the harness _repl_print mirror) ----
@@ -205,6 +229,32 @@ class CockpitAttachBridge:
                 loop.call_soon_threadsafe(self._broadcast, msg)
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] publish degraded", exc_info=True)
+
+    def publish_audio_state(self, state: str) -> None:
+        """Stream one audio-FSM state to every attached terminal
+        (edge-coalesced: republishing the current state is a no-op).
+        The state is also retained for hydration so a late joiner's
+        footer is never stale. Thread-safe; NEVER raises."""
+        try:
+            state = str(state or "").strip().upper()
+            if state not in AUDIO_STATES or state == self._audio_state:
+                return
+            self._audio_state = state
+            self.stats["audio_states_published"] += 1
+            msg = {"type": "audio_state", "state": state, "ts": time.time()}
+            loop = self._loop
+            if loop is None or loop.is_closed() or not self._clients:
+                return
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                self._broadcast(msg)
+            else:
+                loop.call_soon_threadsafe(self._broadcast, msg)
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] audio publish degraded", exc_info=True)
 
     def _broadcast(self, msg: Dict[str, Any]) -> None:
         data = (json.dumps(msg, separators=(",", ":")) + "\n").encode()
@@ -256,7 +306,8 @@ class CockpitAttachBridge:
                     frame = json.loads(line)
                 except (ValueError, TypeError):
                     continue
-                if frame.get("type") == "input":
+                ftype = frame.get("type")
+                if ftype == "input":
                     text = str(frame.get("text", "")).strip()
                     if text:
                         self.stats["inputs_received"] += 1
@@ -265,6 +316,17 @@ class CockpitAttachBridge:
                         except Exception:  # noqa: BLE001
                             logger.debug(
                                 "[CockpitAttach] input sink degraded",
+                                exc_info=True,
+                            )
+                elif ftype == "audio":
+                    cmd = str(frame.get("cmd", "")).strip().lower()
+                    if cmd in AUDIO_CMDS:
+                        self.stats["audio_cmds"] += 1
+                        try:
+                            self._on_audio(cmd)
+                        except Exception:  # noqa: BLE001
+                            logger.debug(
+                                "[CockpitAttach] audio sink degraded",
                                 exc_info=True,
                             )
         except (BrokenPipeError, ConnectionResetError, OSError):
@@ -296,11 +358,13 @@ class CockpitAttachClient:
         *,
         on_hydration: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_line: Optional[Callable[[str], None]] = None,
+        on_audio_state: Optional[Callable[[str], None]] = None,
         path: Optional[Path] = None,
     ) -> None:
         self._path = Path(path) if path is not None else attach_socket_path()
         self._on_hydration = on_hydration or (lambda _m: None)
         self._on_line = on_line or (lambda _t: None)
+        self._on_audio_state = on_audio_state or (lambda _s: None)
         self._reader: Optional[asyncio.StreamReader] = None
         self._writer: Optional[asyncio.StreamWriter] = None
         self._read_task: Optional[asyncio.Task] = None
@@ -329,6 +393,23 @@ class CockpitAttachClient:
             return True
         except Exception:  # noqa: BLE001
             await self.close()
+            return False
+
+    def send_audio(self, cmd: str) -> bool:
+        """Pipe one audio-orchestration command upstream (``wake`` /
+        ``sleep`` / ``barge``). Non-blocking; False when detached or
+        the command is outside the closed taxonomy. NEVER raises."""
+        try:
+            cmd = str(cmd or "").strip().lower()
+            if cmd not in AUDIO_CMDS:
+                return False
+            w = self._writer
+            if not self.connected or w is None or w.is_closing():
+                return False
+            frame = {"type": "audio", "cmd": cmd}
+            w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
+            return True
+        except Exception:  # noqa: BLE001
             return False
 
     def send_input(self, text: str) -> bool:
@@ -360,8 +441,13 @@ class CockpitAttachClient:
                     frame = json.loads(line)
                 except (ValueError, TypeError):
                     continue
-                if frame.get("type") == "line":
+                ftype = frame.get("type")
+                if ftype == "line":
                     self._safe_cb_text(self._on_line, str(frame.get("text", "")))
+                elif ftype == "audio_state":
+                    self._safe_cb_text(
+                        self._on_audio_state, str(frame.get("state", "")),
+                    )
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001
@@ -404,6 +490,8 @@ class CockpitAttachClient:
 
 
 __all__ = [
+    "AUDIO_CMDS",
+    "AUDIO_STATES",
     "COCKPIT_ATTACH_SCHEMA_VERSION",
     "CockpitAttachBridge",
     "CockpitAttachClient",

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4339,11 +4339,21 @@ class BattleTestHarness:
                     return
                 loop.create_task(self._handle_repl_command(text))
 
+            # Audio-Visual Synapse (v2): attached terminals arm/disarm
+            # the karen_duplex plane and receive the audio FSM. Pure
+            # adapter — the duplex handle keeps sole audio authority.
+            from backend.core.ouroboros.battle_test.audio_synapse import (
+                AudioVisualSynapse,
+            )
             bridge = CockpitAttachBridge(
                 status_provider=_status_provider,
                 ops_provider=_ops_provider,
                 liquidity_provider=_liquidity_provider,
                 on_input=_on_input,
+                on_audio=lambda cmd: self._dispatch_audio_cmd(cmd),
+            )
+            self._audio_synapse = AudioVisualSynapse(
+                bridge.publish_audio_state,
             )
             if await bridge.start():
                 self._cockpit_attach_bridge = bridge
@@ -4352,6 +4362,18 @@ class BattleTestHarness:
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] mount degraded", exc_info=True)
             self._cockpit_attach_bridge = None
+
+    def _dispatch_audio_cmd(self, cmd: str) -> None:
+        """Bridge on_audio sink → synapse coroutine. Scheduled, never
+        inline in the read loop. NEVER raises."""
+        try:
+            synapse = getattr(self, "_audio_synapse", None)
+            if synapse is None:
+                return
+            loop = asyncio.get_running_loop()
+            loop.create_task(synapse.handle_cmd(cmd))
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioSynapse] dispatch degraded", exc_info=True)
 
     # -- Audio-state IPC subscriber (cockpit render plane) -----------------
 
@@ -8112,6 +8134,12 @@ class BattleTestHarness:
             ipc_client = getattr(self, "_audio_ipc_client", None)
             if ipc_client is not None:
                 await ipc_client.close()
+        except Exception:
+            pass
+        try:
+            synapse = getattr(self, "_audio_synapse", None)
+            if synapse is not None:
+                await synapse.stop()
         except Exception:
             pass
         try:

--- a/backend/core/ouroboros/battle_test/presentation_router.py
+++ b/backend/core/ouroboros/battle_test/presentation_router.py
@@ -80,7 +80,11 @@ def canonical_glyph_chars() -> frozenset:
 
 
 #: Structure/typography set — allowed everywhere, not rationed (§2).
-TYPOGRAPHIC_CHARS = frozenset("·✓✗›─")
+# ``▸`` is the Karen speaker mark (``💭 Karen ▸ …``) — registered
+# typography since 2026-07-18 (it renders on the chat bridge, the
+# attach persona-host line, and the answer engine; the sentinel was
+# right to flag it unregistered).
+TYPOGRAPHIC_CHARS = frozenset("·✓✗›─▸")
 
 #: Legacy semantic marks → their canonical meaning. Aliased, not merely
 #: stripped — the SIGNAL survives the sweep even where old emitters

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -261,7 +261,62 @@ async def _reap_task(task: Any) -> None:
         pass
 
 
-async def _split_plane_loop(client: Any, console: Any) -> None:
+class AttachUI:
+    """The rigid Footer/Header state of the attached TUI.
+
+    Owns the audio-FSM presentation binding (operator mandate: Dynamic
+    UI Morphing). ``prompt()`` and ``toolbar()`` are the dynamic
+    callables handed to the ONE persistent ``PromptSession`` — prompt
+    duplication died with per-iteration prompt construction; the
+    session re-evaluates these on every repaint, so a state change
+    repaints the footer WITHOUT touching the active keystroke buffer.
+    ``on_audio_state`` is loop-safe: it mutates state then invalidates
+    the app so prompt_toolkit repaints on its own schedule.
+    """
+
+    _PROMPTS = {
+        "OFFLINE": "ov › ",
+        "UNAVAILABLE": "ov › ",
+        "LISTENING": "🎙 Karen › ",
+        "HEARING": "🎙 Karen (hearing you) › ",
+        "THINKING": "💭 Karen (thinking) › ",
+        "SPEAKING": "🗣 Karen (speaking) › ",
+    }
+
+    def __init__(self) -> None:
+        self.audio_state: str = "OFFLINE"
+        self._app_ref: Any = None
+
+    def bind_app(self, app: Any) -> None:
+        self._app_ref = app
+
+    def prompt(self) -> str:
+        return self._PROMPTS.get(self.audio_state, "ov › ")
+
+    def toolbar(self) -> str:
+        audio = (
+            f" · voice: {self.audio_state.lower()}"
+            if self.audio_state != "OFFLINE" else " · voice: off ('wake')"
+        )
+        return f" ov attach — organism live{audio} · 'detach' to leave"
+
+    def on_audio_state(self, state: str) -> None:
+        """The synapse landing point — morph + repaint. NEVER raises."""
+        try:
+            state = str(state or "").strip().upper()
+            if not state or state == self.audio_state:
+                return
+            self.audio_state = state
+            app = self._app_ref
+            if app is not None:
+                app.invalidate()
+        except Exception:
+            pass
+
+
+async def _split_plane_loop(
+    client: Any, console: Any, ui: Optional["AttachUI"] = None,
+) -> None:
     """The Split-Plane Multiplexer (operator mandate 2026-07-18).
 
     prompt_toolkit's ``PromptSession`` + ``patch_stdout`` IS the
@@ -285,11 +340,21 @@ async def _split_plane_loop(client: Any, console: Any) -> None:
     # daemon history above and the command plane below.
     console.print(
         "\U0001f4ad Karen ▸ attached — I'm listening. verbs or plain "
-        "words both work · 'detach' leaves the organism running",
+        "words both work · 'wake' arms my voice · "
+        "'detach' leaves the organism running",
         markup=False, highlight=False,
     )
 
-    session: Any = PromptSession()
+    ui = ui or AttachUI()
+    # ONE persistent session, dynamic prompt + rigid footer toolbar:
+    # both are callables re-evaluated on every repaint, so an
+    # audio_state frame morphs the footer via app.invalidate() while
+    # the active keystroke buffer stays untouched (mandate 4).
+    session: Any = PromptSession(
+        message=lambda: ui.prompt(),
+        bottom_toolbar=lambda: ui.toolbar(),
+    )
+    ui.bind_app(session.app)
 
     async def _watch_disconnect() -> None:
         while client.connected:
@@ -298,7 +363,7 @@ async def _split_plane_loop(client: Any, console: Any) -> None:
     with patch_stdout(raw=True):
         while client.connected:
             prompt_task = asyncio.ensure_future(
-                session.prompt_async("ov › "),
+                session.prompt_async(),
             )
             watch_task = asyncio.ensure_future(_watch_disconnect())
             try:
@@ -326,8 +391,20 @@ async def _split_plane_loop(client: Any, console: Any) -> None:
                 await _reap_task(prompt_task)
                 break
             text = (line or "").strip()
-            if text.lower() in ("detach", "exit", "quit"):
+            low = text.lower()
+            if low in ("detach", "exit", "quit"):
                 break
+            # Audio Control Plane verbs — routed on the audio lane,
+            # never as chat text (the daemon synapse owns the duplex).
+            if low in ("wake", "voice", "listen"):
+                client.send_audio("wake")
+                continue
+            if low in ("mute", "sleep"):
+                client.send_audio("sleep")
+                continue
+            if low == "barge":
+                client.send_audio("barge")
+                continue
             if text:
                 client.send_input(text)
 
@@ -384,13 +461,21 @@ def run_attach(console: Any) -> int:
                 pass
 
         hydrated = asyncio.Event()
+        ui = AttachUI()
 
         def _on_hydration(payload: dict) -> None:
             _render_hydration(console, payload)
+            try:
+                state = (payload.get("audio") or {}).get("state", "")
+                if state:
+                    ui.on_audio_state(str(state))
+            except Exception:
+                pass
             hydrated.set()
 
         client = CockpitAttachClient(
             on_hydration=_on_hydration, on_line=_print_line,
+            on_audio_state=ui.on_audio_state,
         )
         if not await client.connect():
             console.print(_NO_ORGANISM_MESSAGE, markup=False, highlight=False)
@@ -398,7 +483,7 @@ def run_attach(console: Any) -> int:
 
         try:
             if _can_run_split_plane():
-                await _split_plane_loop(client, console)
+                await _split_plane_loop(client, console, ui)
             else:
                 await _legacy_pump_loop(client)
             if not client.connected:

--- a/backend/core/ouroboros/governance/fsm_checkpoint.py
+++ b/backend/core/ouroboros/governance/fsm_checkpoint.py
@@ -87,12 +87,26 @@ def _verify(payload_json: str, signature: str, key: bytes) -> bool:
 # thought that re-enters the LLM). Observability only -- authority-free, never raises.
 
 def emit_handshake(line: str) -> None:
-    """Emit one Atomic Hydration Handshake line to BOTH the logger and stdout.
-    Best-effort on every leg -- observability never breaks suspend/resume."""
+    """Emit one Atomic Hydration Handshake line — logger ALWAYS (the
+    session debug.log carries full crypto-forensic fidelity); raw stdout
+    ONLY outside cockpit mode. The raw-write leg deliberately bypasses
+    every logging layer for soak forensics, which is exactly why it was
+    bleeding un-conformed ``[HYDRATION-HANDSHAKE]`` telemetry into the
+    operator presentation plane (operator finding 2026-07-18): zero raw
+    telemetry may hit the cockpit Body. Best-effort on every leg --
+    observability never breaks suspend/resume."""
     try:
         logger.info(line)
     except Exception:  # noqa: BLE001
         pass
+    try:
+        from backend.core.ouroboros.ui.presentation_mode import (  # noqa: PLC0415
+            is_cockpit,
+        )
+        if is_cockpit():
+            return
+    except Exception:  # noqa: BLE001
+        pass                    # mode unresolvable → legacy raw write
     try:
         import sys  # noqa: PLC0415
         sys.stdout.write(line + "\n")

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -132,7 +132,11 @@ def _clamp_cols(measured: int) -> Tuple[int, int, int]:
     """
     lo = int(os.environ.get("JARVIS_OV_CREST_MIN_COLS", "46"))
     hi = int(os.environ.get("JARVIS_OV_CREST_MAX_COLS", "88"))
-    clamped = max(lo, min(measured, hi))
+    # Strict bounding-box margin (operator finding 2026-07-18): a crest
+    # exactly as wide as the terminal auto-wraps its last cell onto the
+    # next line — every row sheds one detached artifact block. One
+    # column of right margin kills the whole off-by-one wrap class.
+    clamped = max(lo, min(measured - 1, hi))
     return lo, hi, clamped
 
 
@@ -701,6 +705,38 @@ def frame_to_text(
             return ""
 
 
+def blit_text(console: "Any", text: "Any") -> bool:
+    """Double-buffered blit: render ``text`` to an OFF-SCREEN ANSI
+    buffer first, then write the whole frame to the TTY in a single
+    ``write`` + flush. Eliminates tearing/flicker from incremental
+    segment writes (mandate: no raw cursor-jump hacks — one atomic
+    frame). Coordinates are already bounded by :func:`_clamp_cols`'s
+    terminal-size margin. Returns False (no partial output) on any
+    fault. NEVER raises."""
+    try:
+        from rich.console import Console
+        import io
+        size = console.size
+        buf = io.StringIO()
+        offscreen = Console(
+            file=buf,
+            width=size.width,
+            force_terminal=True,
+            color_system=getattr(console, "_color_system_name", None)
+            or "truecolor",
+            highlight=False,
+        )
+        offscreen.print(text)
+        frame = buf.getvalue()
+        if not frame:
+            return False
+        console.file.write(frame)
+        console.file.flush()
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def print_static_crest(console: "Any") -> bool:
     """The static emblem — the mark that ALWAYS greets ``ov`` (operator
     law, 2026-07-18), including on the already-awake collision surface.
@@ -720,7 +756,12 @@ def print_static_crest(console: "Any") -> bool:
         )
         if frame.unavailable_reason:
             return False
-        console.print(render_crest_auto(frame, tier))
+        emblem = render_crest_auto(frame, tier)
+        # Single-frame blit (double-buffered); Rich print fallback keeps
+        # the emblem law ("the mark ALWAYS greets ov") even when the
+        # console's file surface is exotic.
+        if not blit_text(console, emblem):
+            console.print(emblem)
         return True
     except Exception:  # noqa: BLE001
         return False

--- a/tests/battle_test/test_audio_visual_synapse.py
+++ b/tests/battle_test/test_audio_visual_synapse.py
@@ -1,0 +1,366 @@
+"""Audio-Visual Synapse + Rigid TUI Cockpit spine (operator mandate 2026-07-18).
+
+Covers the four authorized roots:
+
+  1. attach-protocol v2 audio lane — upstream ``{"type":"audio"}``
+     command frames, downstream ``{"type":"audio_state"}`` FSM frames,
+     hydration retention for late joiners;
+  2. ``AudioVisualSynapse`` — the DRY remote-control adapter over the
+     EXISTING karen_duplex handle (no audio logic of its own);
+  3. Dynamic UI Morphing — a mocked incoming ``AUDIO_STATE: LISTENING``
+     frame repaints the Footer prompt asynchronously WITHOUT touching
+     the active keystroke buffer (mandate 4, verbatim);
+  4. leak class kills — ``emit_handshake`` raw-stdout silenced in
+     cockpit; crest off-by-one bounding margin + single-frame blit.
+
+UDS tests use short ``tempfile.mkdtemp`` roots (macOS ~104-char
+``sun_path``) and need the sandbox disabled (UDS bind).
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test.audio_synapse import AudioVisualSynapse
+from backend.core.ouroboros.battle_test.cockpit_attach import (
+    AUDIO_STATES,
+    CockpitAttachBridge,
+    CockpitAttachClient,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+@pytest.fixture()
+def sock_dir():
+    d = Path(tempfile.mkdtemp(prefix="avs-"))
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+async def _pair(sock_dir, **bridge_kw):
+    path = sock_dir / "a.sock"
+    bridge = CockpitAttachBridge(path=path, **bridge_kw)
+    assert await bridge.start()
+    return bridge, path
+
+
+# ---------------------------------------------------------------------------
+# (1) Protocol v2 — the audio lane
+# ---------------------------------------------------------------------------
+
+
+class TestAttachProtocolV2:
+    async def test_upstream_audio_frame_reaches_on_audio(self, sock_dir):
+        got: list = []
+        bridge, path = await _pair(sock_dir, on_audio=got.append)
+        client = CockpitAttachClient(path=path)
+        try:
+            assert await client.connect()
+            assert client.send_audio("wake")
+            for _ in range(40):
+                if got:
+                    break
+                await asyncio.sleep(0.05)
+            assert got == ["wake"]
+        finally:
+            await client.close()
+            await bridge.stop()
+
+    async def test_bogus_audio_cmd_refused_client_side(self, sock_dir):
+        bridge, path = await _pair(sock_dir)
+        client = CockpitAttachClient(path=path)
+        try:
+            assert await client.connect()
+            assert client.send_audio("rm -rf /") is False
+            assert client.send_audio("") is False
+        finally:
+            await client.close()
+            await bridge.stop()
+
+    async def test_downstream_audio_state_reaches_client(self, sock_dir):
+        states: list = []
+        bridge, path = await _pair(sock_dir)
+        client = CockpitAttachClient(
+            path=path, on_audio_state=states.append,
+        )
+        try:
+            assert await client.connect()
+            bridge.publish_audio_state("LISTENING")
+            for _ in range(40):
+                if states:
+                    break
+                await asyncio.sleep(0.05)
+            assert states == ["LISTENING"]
+        finally:
+            await client.close()
+            await bridge.stop()
+
+    async def test_publish_is_edge_coalesced(self, sock_dir):
+        bridge, path = await _pair(sock_dir)
+        try:
+            bridge.publish_audio_state("LISTENING")
+            bridge.publish_audio_state("LISTENING")
+            bridge.publish_audio_state("SPEAKING")
+            bridge.publish_audio_state("not-a-state")
+            assert bridge.stats["audio_states_published"] == 2
+        finally:
+            await bridge.stop()
+
+    async def test_hydration_carries_current_audio_state(self, sock_dir):
+        bridge, path = await _pair(sock_dir)
+        bridge.publish_audio_state("THINKING")
+        payloads: list = []
+        client = CockpitAttachClient(
+            path=path, on_hydration=payloads.append,
+        )
+        try:
+            assert await client.connect()
+            assert payloads and payloads[0]["audio"]["state"] == "THINKING"
+            assert payloads[0]["schema_version"] == "cockpit_attach.v2"
+        finally:
+            await client.close()
+            await bridge.stop()
+
+
+# ---------------------------------------------------------------------------
+# (2) The synapse adapter — DRY remote control of the existing duplex
+# ---------------------------------------------------------------------------
+
+
+class _FakeState:
+    def __init__(self, value: str) -> None:
+        self.value = value
+
+
+class _FakeArbiter:
+    def __init__(self) -> None:
+        self.state = _FakeState("listening")
+        self.barges = 0
+
+    async def on_user_speech_start(self) -> None:
+        self.barges += 1
+
+    async def on_user_speech_end(self) -> None:
+        pass
+
+
+class _FakeHandle:
+    def __init__(self) -> None:
+        self.arbiter = _FakeArbiter()
+        self.started = 0
+        self.stopped = 0
+
+    async def start(self) -> None:
+        self.started += 1
+
+    async def stop(self) -> None:
+        self.stopped += 1
+
+
+class TestAudioVisualSynapse:
+    async def test_wake_without_duplex_answers_unavailable(self):
+        out: list = []
+        syn = AudioVisualSynapse(out.append, handle_resolver=lambda: None)
+        await syn.handle_cmd("wake")
+        assert out == ["UNAVAILABLE"]
+        assert syn.armed is False
+
+    async def test_wake_starts_existing_handle_and_publishes_listening(self):
+        out: list = []
+        handle = _FakeHandle()
+        syn = AudioVisualSynapse(out.append, handle_resolver=lambda: handle)
+        await syn.handle_cmd("wake")
+        try:
+            assert handle.started == 1          # DRY: ITS start, not ours
+            assert out[0] == "LISTENING"
+            assert syn.armed is True
+        finally:
+            await syn.stop()
+
+    async def test_fsm_edges_stream_through_watch(self):
+        out: list = []
+        handle = _FakeHandle()
+        syn = AudioVisualSynapse(out.append, handle_resolver=lambda: handle)
+        await syn.handle_cmd("wake")
+        try:
+            handle.arbiter.state = _FakeState("thinking")
+            await asyncio.sleep(0.4)
+            handle.arbiter.state = _FakeState("karen_speaking")
+            await asyncio.sleep(0.4)
+            assert "THINKING" in out and "SPEAKING" in out
+            # Edge-coalesced: steady states don't repeat.
+            assert len(out) == len(set(out))
+        finally:
+            await syn.stop()
+
+    async def test_sleep_stops_handle_and_goes_offline(self):
+        out: list = []
+        handle = _FakeHandle()
+        syn = AudioVisualSynapse(out.append, handle_resolver=lambda: handle)
+        await syn.handle_cmd("wake")
+        await syn.handle_cmd("sleep")
+        assert handle.stopped == 1
+        assert out[-1] == "OFFLINE"
+        assert syn.armed is False
+
+    async def test_barge_routes_to_arbiter_interrupt_seam(self):
+        out: list = []
+        handle = _FakeHandle()
+        syn = AudioVisualSynapse(out.append, handle_resolver=lambda: handle)
+        await syn.handle_cmd("barge")
+        assert handle.arbiter.barges == 1
+
+    async def test_publish_fault_never_raises(self):
+        def _boom(_s: str) -> None:
+            raise RuntimeError("sink died")
+        syn = AudioVisualSynapse(_boom, handle_resolver=lambda: None)
+        await syn.handle_cmd("wake")           # must not raise
+
+    def test_all_published_states_are_in_the_closed_taxonomy(self):
+        from backend.core.ouroboros.battle_test import audio_synapse
+        for mapped in audio_synapse._FSM_MAP.values():
+            assert mapped in AUDIO_STATES
+
+
+# ---------------------------------------------------------------------------
+# (3) Dynamic UI Morphing — mandate 4 verbatim
+# ---------------------------------------------------------------------------
+
+
+class TestFooterMorphing:
+    def _session(self):
+        from prompt_toolkit import PromptSession
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        session = PromptSession(
+            message=lambda: ui.prompt(),
+            bottom_toolbar=lambda: ui.toolbar(),
+        )
+        ui.bind_app(session.app)
+        return ui, session
+
+    async def test_listening_frame_morphs_prompt_without_touching_buffer(self):
+        """Mock an incoming ``AUDIO_STATE: LISTENING`` IPC frame; the
+        Footer prompt repaints while the active keystroke buffer is
+        preserved byte-for-byte."""
+        from prompt_toolkit.application import create_app_session
+        from prompt_toolkit.input.defaults import create_pipe_input
+        from prompt_toolkit.output import DummyOutput
+
+        with create_pipe_input() as pipe:
+            with create_app_session(input=pipe, output=DummyOutput()):
+                ui, session = self._session()
+                # Operator mid-keystroke:
+                session.default_buffer.insert_text("deploy the fix")
+                assert ui.prompt() == "ov › "
+                # The mocked IPC frame lands (exactly what
+                # CockpitAttachClient's read loop dispatches):
+                ui.on_audio_state("LISTENING")
+                assert ui.prompt() == "🎙 Karen › "
+                assert "listening" in ui.toolbar()
+                # Keystroke integrity: the buffer was never interrupted.
+                assert session.default_buffer.text == "deploy the fix"
+
+    def test_full_fsm_cycle_prompts(self):
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        seen = []
+        for state in ("LISTENING", "HEARING", "THINKING", "SPEAKING"):
+            ui.on_audio_state(state)
+            seen.append(ui.prompt())
+        assert len(set(seen)) == 4              # every state is distinct
+        ui.on_audio_state("OFFLINE")
+        assert ui.prompt() == "ov › "
+
+    def test_unknown_state_is_inert(self):
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        ui.on_audio_state("QUANTUM")
+        assert ui.prompt() == "ov › "           # graceful: default prompt
+
+    def test_invalidate_called_on_morph(self):
+        from backend.core.ouroboros.cli.ov import AttachUI
+
+        class _App:
+            def __init__(self) -> None:
+                self.invalidations = 0
+
+            def invalidate(self) -> None:
+                self.invalidations += 1
+
+        ui = AttachUI()
+        app = _App()
+        ui.bind_app(app)
+        ui.on_audio_state("LISTENING")
+        ui.on_audio_state("LISTENING")          # same state = no repaint
+        assert app.invalidations == 1
+
+
+# ---------------------------------------------------------------------------
+# (4) Leak-class kills — handshake silencing + crest bounding/blit
+# ---------------------------------------------------------------------------
+
+
+class TestHandshakeSilencing:
+    def test_cockpit_suppresses_raw_stdout(self, monkeypatch, capsys):
+        monkeypatch.setenv("JARVIS_OV_PRESENTATION", "cockpit")
+        from backend.core.ouroboros.governance import fsm_checkpoint
+        fsm_checkpoint.emit_handshake("[HYDRATION-HANDSHAKE] test-line")
+        assert "[HYDRATION-HANDSHAKE]" not in capsys.readouterr().out
+
+    def test_soak_keeps_raw_stdout_forensics(self, monkeypatch, capsys):
+        monkeypatch.setenv("JARVIS_OV_PRESENTATION", "soak")
+        from backend.core.ouroboros.governance import fsm_checkpoint
+        fsm_checkpoint.emit_handshake("[HYDRATION-HANDSHAKE] test-line")
+        assert "[HYDRATION-HANDSHAKE] test-line" in capsys.readouterr().out
+
+
+class TestCrestBoundingAndBlit:
+    def test_clamp_reserves_one_column_margin(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_OV_CREST_MIN_COLS", raising=False)
+        monkeypatch.delenv("JARVIS_OV_CREST_MAX_COLS", raising=False)
+        from backend.core.ouroboros.ui import crest
+        # A crest exactly as wide as the terminal wraps its last cell —
+        # the off-by-one detached-artifact class. One column of margin.
+        _lo, _hi, clamped = crest._clamp_cols(80)
+        assert clamped == 79
+        _lo, _hi, clamped = crest._clamp_cols(200)
+        assert clamped == 88                    # cap still wins when roomy
+
+    def test_blit_writes_one_atomic_frame(self):
+        from backend.core.ouroboros.ui import crest
+        from rich.text import Text
+
+        class _CountingFile:
+            def __init__(self) -> None:
+                self.writes: list = []
+
+            def write(self, s: str) -> None:
+                self.writes.append(s)
+
+            def flush(self) -> None:
+                pass
+
+        class _Size:
+            width, height = 100, 50
+
+        class _Console:
+            size = _Size()
+            file = _CountingFile()
+
+        console = _Console()
+        assert crest.blit_text(console, Text("▀▀▀\n▀▀▀"))
+        # Double-buffered: the whole frame arrived in a SINGLE write.
+        assert len(console.file.writes) == 1
+        assert "▀▀▀" in console.file.writes[0]
+
+    def test_print_static_crest_routes_through_blit_pin(self):
+        src = (_REPO / "backend/core/ouroboros/ui/crest.py").read_text()
+        body = src[src.index("def print_static_crest"):]
+        assert "blit_text(console, emblem)" in body


### PR DESCRIPTION
## Summary
Operator-authorized structural pass on the attach TUI + audio plane, four roots:

1. **Rigid layout (challenged + refined)** — a full-screen `prompt_toolkit.Application` was rejected: alternate-screen apps kill scrollback/copy, and Claude Code (the stated bar) is scrolling-body + pinned-footer, not a rigid app. Root cause of prompt duplication was per-iteration prompt construction → now ONE persistent `PromptSession` with **dynamic `message` + `bottom_toolbar` callables** (`AttachUI`): rigid Footer/Header, scrolling Body, scrollback intact.
2. **Double-buffered crest** — `blit_text` renders to an off-screen ANSI buffer and writes the TTY in one atomic frame (no tearing); `_clamp_cols` reserves a 1-column right margin, killing the off-by-one wrap class that shed a detached artifact block per row on exact-width terminals.
3. **Handshake silenced** — `emit_handshake`'s raw-stdout leg is cockpit-gated; `debug.log` keeps full `[HYDRATION-HANDSHAKE]` crypto fidelity; zero raw telemetry reaches the Body.
4. **Audio Control Plane** — attach protocol **v2**: upstream `{"type":"audio","cmd":"wake"|"sleep"|"barge"}`, downstream `{"type":"audio_state"}` (OFFLINE/UNAVAILABLE/LISTENING/HEARING/THINKING/SPEAKING), hydration retains current state for late joiners. `AudioVisualSynapse` is a **pure adapter** over the existing `karen_duplex` handle (DRY — its start/stop/interrupt seams, zero new audio logic) with an edge-coalesced FSM watch. Footer morphs per state (`ov ›` → `🎙 Karen ›` → `💭 Karen (thinking) ›` …) via `app.invalidate()` — the active keystroke buffer is never touched (pinned by test).

Rider: `▸` (Karen speaker mark) registered in `TYPOGRAPHIC_CHARS` — the design-language sentinel was correctly flagging it on main (pre-existing red).

## Testing
- 21 new tests (`tests/battle_test/test_audio_visual_synapse.py`), incl. mandate-4 verbatim: mock `AUDIO_STATE: LISTENING` frame → footer repaints, buffer preserved byte-for-byte.
- 145-test sweep green: attach, split-plane mux, crest (halfblock/fill/postlude), boot mux, console hygiene, AST-parity sentinel, failure-bundle hardening.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a rigid TUI cockpit and an Audio‑Visual Synapse IPC bridge. Ships attach protocol v2 with upstream audio commands and live audio state driving the footer, plus fixes for crest flicker and handshake noise.

- New Features
  - Attach protocol v2: upstream `{"type":"audio","cmd":"wake"|"sleep"|"barge"}` and downstream `{"type":"audio_state"}` with hydration of current state; schema `cockpit_attach.v2`.
  - `AudioVisualSynapse`: pure adapter over `karen_duplex`; edge‑coalesced FSM polling; fail‑soft on all paths.
  - Rigid TUI: one persistent `prompt_toolkit.PromptSession` via `AttachUI`; dynamic prompt/toolbar; footer morphs by audio state without losing keystrokes.
  - CLI verbs: `wake`, `sleep`, and `barge` route over the audio lane (not chat).
  - Bridge/client APIs: `publish_audio_state`, `send_audio`, and `AUDIO_STATES`/`AUDIO_CMDS`.
  - Tests: 21 new cases covering IPC, synapse behavior, UI morphing, and crest pins.

- Bug Fixes
  - Crest rendering: double‑buffered `blit_text` and a 1‑column right margin to prevent wrap artifacts and flicker.
  - Handshake gating: raw stdout silenced in cockpit; logs keep full handshake details.
  - Typography: register `▸` to stop false warnings.

<sup>Written for commit 14a2a47ef58df97ce9b8165e02bfd21722fcb865. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

