### PR TITLE
feat(audio): Tri-State IPC Audio Broker — cross-process lease + orphaned-mic protection

### DIFF
--- a/backend/audio/audio_pipeline_bootstrap.py
+++ b/backend/audio/audio_pipeline_bootstrap.py
@@ -208,7 +208,43 @@ async def wire_conversation_pipeline(
             audio_ipc_enabled,
         )
         if audio_ipc_enabled():
-            handle.audio_ipc = AudioStateBroadcaster()
+            # Tri-State broker lease seam (operator-authorized
+            # 2026-07-18): a remote `wake` (ov attach → daemon broker)
+            # arms the SUPERVISOR-owned duplex; disarm stops it. The
+            # closure late-binds `handle` (karen mounts at 3b, AFTER
+            # this) and lazy-builds over the SAME factory when voice
+            # wasn't pre-mounted — sovereignty never leaves this
+            # process; the broadcaster only relays the verb.
+            async def _on_lease_change(armed: bool) -> None:
+                try:
+                    if armed:
+                        if handle.karen is None and handle.tts_engine is not None:
+                            from backend.core.ouroboros.governance.comms.duplex.karen_duplex_factory import (  # noqa: E501
+                                build_karen_duplex,
+                                set_default_karen,
+                            )
+                            handle.karen = build_karen_duplex(handle.tts_engine)
+                            set_default_karen(handle.karen)
+                            logger.info(
+                                "[Bootstrap] Karen duplex lazy-mounted on lease",
+                            )
+                        if handle.karen is not None:
+                            await handle.karen.start()
+                            logger.info("[Bootstrap] audio lease ARMED")
+                    else:
+                        if handle.karen is not None:
+                            await handle.karen.stop()
+                            logger.info(
+                                "[Bootstrap] audio lease DISARMED (fail-safe)",
+                            )
+                except Exception:
+                    logger.warning(
+                        "[Bootstrap] lease arm/disarm degraded", exc_info=True,
+                    )
+
+            handle.audio_ipc = AudioStateBroadcaster(
+                on_lease_change=_on_lease_change,
+            )
             if not await handle.audio_ipc.start():
                 handle.audio_ipc = None
             else:

--- a/backend/core/ouroboros/battle_test/audio_synapse.py
+++ b/backend/core/ouroboros/battle_test/audio_synapse.py
@@ -46,12 +46,169 @@ _FSM_MAP = {
 }
 
 
+#: Supervisor event kinds → attach-protocol AUDIO_STATES (the remote
+#: lane's morphing vocabulary; IDLE while armed reads LISTENING).
+_EVENT_MAP = {
+    "VAD_ACTIVE": "HEARING",
+    "VAD_INACTIVE": "LISTENING",
+    "TTS_GENERATING": "THINKING",
+    "AUDIO_PLAYING": "SPEAKING",
+    "AUDIO_IDLE": "LISTENING",
+}
+
+
 def _poll_interval_s() -> float:
     try:
         raw = float(os.environ.get("JARVIS_AUDIO_SYNAPSE_POLL_S", "0.15"))
     except (TypeError, ValueError):
         raw = 0.15
     return max(0.05, min(1.0, raw))
+
+
+def broker_enabled() -> bool:
+    """``JARVIS_AUDIO_BROKER_ENABLED`` (default on) — the cross-process
+    lane is fail-soft: no supervisor socket → honest UNAVAILABLE, same
+    as before the broker existed. NEVER raises."""
+    return os.environ.get(
+        "JARVIS_AUDIO_BROKER_ENABLED", "1",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+class RemoteAudioLease:
+    """Daemon-side half of the Tri-State broker: negotiate the audio
+    lease with the supervisor over the EXISTING ``audio_state_ipc``
+    transport, heartbeat while armed, and map the supervisor's
+    hardware FSM events into attach-protocol states.
+
+    Strictly a broker (mandate 1): no audio bytes, no hardware, no
+    duplex import. If the supervisor vanishes mid-conversation the
+    read loop ends → ``OFFLINE`` is published and the heartbeat task
+    reaps itself; the supervisor's own drop-release disarms the mic.
+    """
+
+    def __init__(self, publish: Callable[[str], None]) -> None:
+        self._publish = publish
+        self._client: Any = None
+        self._hb_task: Optional[asyncio.Task] = None
+        self._ttl_s: float = 5.0
+        self._granted = asyncio.Event()
+        self._denied_reason: Optional[str] = None
+        self.active: bool = False
+
+    async def acquire(self) -> bool:
+        """Connect + negotiate. False (with UNAVAILABLE published by
+        the CALLER, keeping one honesty seam) when the supervisor is
+        absent, refuses, or times out. NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.comms.duplex.audio_state_ipc import (  # noqa: E501,PLC0415
+                AudioStateClient,
+                lease_ttl_s,
+            )
+            self._ttl_s = lease_ttl_s()
+            client = AudioStateClient(on_message=self._on_message)
+            if not await client.connect():
+                return False
+            self._client = client
+            if not client.send_lease("acquire"):
+                await client.close()
+                self._client = None
+                return False
+            try:
+                await asyncio.wait_for(
+                    self._granted.wait(), timeout=self._ttl_s,
+                )
+            except asyncio.TimeoutError:
+                await self.release()
+                return False
+            if self._denied_reason is not None:
+                await self.release()
+                return False
+            self.active = True
+            self._hb_task = asyncio.get_running_loop().create_task(
+                self._heartbeat_loop(),
+            )
+            self._publish_safe("LISTENING")
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioSynapse] remote acquire degraded", exc_info=True)
+            await self.release()
+            return False
+
+    def _on_message(self, msg: dict) -> None:
+        try:
+            mtype = msg.get("type")
+            if mtype == "lease":
+                if msg.get("granted"):
+                    ttl = msg.get("ttl_s")
+                    if isinstance(ttl, (int, float)) and ttl > 0:
+                        self._ttl_s = float(ttl)
+                    self._denied_reason = None
+                    self._granted.set()
+                else:
+                    reason = str(msg.get("reason", "denied"))
+                    if reason in ("expired", "held"):
+                        self._denied_reason = reason
+                        self._granted.set()
+                    if reason == "expired" and self.active:
+                        # Supervisor expired us (our heartbeats
+                        # stalled) — mirror its fail-safe honestly.
+                        self.active = False
+                        self._publish_safe("OFFLINE")
+            elif mtype == "event" and self.active:
+                state = _EVENT_MAP.get(str(msg.get("kind", "")))
+                if state is not None:
+                    self._publish_safe(state)
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def _heartbeat_loop(self) -> None:
+        """TTL/3 cadence — three misses inside one deadline window
+        would be needed to lose a healthy lease. Ends itself (and
+        reports OFFLINE) the moment the transport dies."""
+        try:
+            while self.active:
+                client = self._client
+                if client is None or not client.connected:
+                    break
+                client.send_lease("heartbeat")
+                await asyncio.sleep(self._ttl_s / 3.0)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            pass
+        finally:
+            if self.active:
+                self.active = False
+                self._publish_safe("OFFLINE")
+
+    async def release(self) -> None:
+        """Release + teardown. Idempotent; NEVER raises."""
+        self.active = False
+        task = self._hb_task
+        self._hb_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        client = self._client
+        self._client = None
+        if client is not None:
+            try:
+                client.send_lease("release")
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await client.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _publish_safe(self, state: str) -> None:
+        try:
+            self._publish(state)
+        except Exception:  # noqa: BLE001
+            pass
 
 
 class AudioVisualSynapse:
@@ -73,6 +230,7 @@ class AudioVisualSynapse:
         self._resolve = handle_resolver or self._default_resolver
         self._watch_task: Optional[asyncio.Task] = None
         self._armed = False
+        self._remote: Optional[RemoteAudioLease] = None
 
     @staticmethod
     def _default_resolver() -> Any:
@@ -106,9 +264,17 @@ class AudioVisualSynapse:
     async def _wake(self) -> None:
         handle = self._resolve()
         if handle is None:
-            # Honest surface: this process has no mounted duplex (the
-            # supervisor owns the hardware plane) — the TUI must render
-            # that truth, never a fake LISTENING.
+            # No LOCAL duplex — the supervisor owns the hardware plane.
+            # Tri-State broker path: negotiate a cross-process audio
+            # lease over audio_state_ipc. Only when the supervisor is
+            # absent/refusing does the TUI see UNAVAILABLE — honesty,
+            # never a fake LISTENING.
+            if broker_enabled():
+                remote = RemoteAudioLease(self._publish)
+                if await remote.acquire():
+                    self._remote = remote
+                    self._armed = True
+                    return
             self._safe_publish("UNAVAILABLE")
             return
         try:
@@ -124,6 +290,12 @@ class AudioVisualSynapse:
     async def _sleep(self) -> None:
         self._armed = False
         await self._stop_watch()
+        remote = self._remote
+        self._remote = None
+        if remote is not None:
+            await remote.release()
+            self._safe_publish("OFFLINE")
+            return
         handle = self._resolve()
         if handle is not None:
             try:
@@ -197,10 +369,16 @@ class AudioVisualSynapse:
                 pass
 
     async def stop(self) -> None:
-        """Teardown — disarm + reap the watch. NEVER raises."""
+        """Teardown — disarm + reap watch AND remote lease (the
+        supervisor's drop-release is the backstop, but a clean daemon
+        exit releases explicitly). NEVER raises."""
         try:
             self._armed = False
             await self._stop_watch()
+            remote = self._remote
+            self._remote = None
+            if remote is not None:
+                await remote.release()
         except Exception:  # noqa: BLE001
             pass
 
@@ -211,4 +389,4 @@ class AudioVisualSynapse:
             logger.debug("[AudioSynapse] publish degraded", exc_info=True)
 
 
-__all__ = ["AudioVisualSynapse"]
+__all__ = ["AudioVisualSynapse", "RemoteAudioLease", "broker_enabled"]

--- a/backend/core/ouroboros/governance/comms/duplex/audio_state_ipc.py
+++ b/backend/core/ouroboros/governance/comms/duplex/audio_state_ipc.py
@@ -30,6 +30,29 @@ Authority invariant: pure presentation telemetry. No audio capture, no
 mutation surface, no policy imports. Socket is chmod 0600 (same-user
 only). Master ``JARVIS_AUDIO_IPC_ENABLED`` (default on — §7 Absolute
 Observability; the socket exports state, never grants control).
+
+Tri-State IPC Audio Broker (v2, operator-authorized 2026-07-18): the
+transport gains an upstream **lease lane** — the ONE narrow control
+surface, and it still never moves audio bytes:
+
+  * ``{"type":"lease","cmd":"acquire"|"release"|"heartbeat"}`` from a
+    client negotiates the audio-arming lease. Single-holder; a second
+    client is answered ``{"type":"lease","granted":false,
+    "reason":"held"}``. Grants carry ``ttl_s`` so the client derives
+    its own heartbeat cadence (no hardcoded numbers on the wire's far
+    side).
+  * **Orphaned-mic protection**: the lease DIES two independent ways —
+    (a) the holder's socket drops (daemon SIGKILL = broken pipe →
+    instant release), and (b) heartbeats stop while the socket wedges
+    open (a monotonic-deadline watchdog sweeps at TTL/2 and expires
+    the lease). Either path invokes the injected ``on_lease_change
+    (False)`` so the supervisor disarms the hardware and fails safe.
+    The watchdog reads ONLY ``time.monotonic()`` + its own deadline —
+    never pipeline state (the Slice-47 watchdog-isolation invariant).
+  * The supervisor stays sovereign: ``on_lease_change`` is an injected
+    callable the BOOTSTRAP owns; this module never imports or touches
+    karen_duplex / hardware. Lease grant ≠ hardware promise — the
+    supervisor may still refuse in its callback.
 """
 from __future__ import annotations
 
@@ -45,7 +68,21 @@ from typing import Any, Callable, Deque, Dict, Optional, Set
 
 logger = logging.getLogger(__name__)
 
-AUDIO_IPC_SCHEMA_VERSION = "audio_ipc.v1"
+AUDIO_IPC_SCHEMA_VERSION = "audio_ipc.v2"
+
+#: Closed lease-command vocabulary (the upstream control lane).
+LEASE_CMDS = ("acquire", "release", "heartbeat")
+
+
+def lease_ttl_s() -> float:
+    """``JARVIS_AUDIO_LEASE_TTL_S`` (default 5.0, clamped [1, 60]) —
+    the heartbeat deadline. A dead daemon releases the mic within one
+    TTL. NEVER raises."""
+    try:
+        raw = float(os.environ.get("JARVIS_AUDIO_LEASE_TTL_S", "5.0"))
+    except (TypeError, ValueError):
+        raw = 5.0
+    return max(1.0, min(60.0, raw))
 
 _TRUTHY = ("1", "true", "yes", "on")
 
@@ -105,7 +142,12 @@ class AudioStateBroadcaster:
     a slow or dead client is dropped, never awaited inline.
     """
 
-    def __init__(self, *, path: Optional[Path] = None) -> None:
+    def __init__(
+        self,
+        *,
+        path: Optional[Path] = None,
+        on_lease_change: Optional[Callable[[bool], Any]] = None,
+    ) -> None:
         self._path = Path(path) if path is not None else socket_path()
         self._server: Optional[asyncio.AbstractServer] = None
         self._clients: Set[asyncio.StreamWriter] = set()
@@ -117,6 +159,19 @@ class AudioStateBroadcaster:
         }
         self._utterance: Optional[Dict[str, Any]] = None
         self._loop: Optional[asyncio.AbstractEventLoop] = None
+        # ---- lease lane (v2) ----
+        # ``on_lease_change(armed)`` is the supervisor's injected
+        # arm/disarm seam (sync or async — both awaited safely). The
+        # holder is identified by its StreamWriter; the deadline is a
+        # raw ``time.monotonic()`` instant (watchdog isolation).
+        self._on_lease_change = on_lease_change
+        self._lease_holder: Optional[asyncio.StreamWriter] = None
+        self._lease_deadline: float = 0.0
+        self._lease_watchdog: Optional[asyncio.Task] = None
+        self.lease_stats: Dict[str, int] = {
+            "acquires": 0, "denials": 0, "releases": 0,
+            "expiries": 0, "drop_releases": 0, "heartbeats": 0,
+        }
 
     # ---- lifecycle ----
 
@@ -149,6 +204,15 @@ class AudioStateBroadcaster:
     async def stop(self) -> None:
         """Close server + clients, unlink the socket. NEVER raises."""
         try:
+            await self._release_lease(reason="server_stop")
+            wd = self._lease_watchdog
+            self._lease_watchdog = None
+            if wd is not None and not wd.done():
+                wd.cancel()
+                try:
+                    await wd
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
             if self._server is not None:
                 self._server.close()
                 try:
@@ -292,10 +356,150 @@ class AudioStateBroadcaster:
 
     def _drop_client(self, w: asyncio.StreamWriter) -> None:
         self._clients.discard(w)
+        # Orphaned-mic protection path (a): the holder's socket died —
+        # SIGKILL'd daemon, broken pipe, hard reset. Release the
+        # hardware IMMEDIATELY; never wait for the heartbeat expiry.
+        if w is self._lease_holder:
+            self.lease_stats["drop_releases"] += 1
+            self._schedule_lease_release(reason="holder_dropped")
         try:
             w.close()
         except Exception:  # noqa: BLE001
             pass
+
+    # ---- lease lane (v2) --------------------------------------------------
+
+    @property
+    def lease_held(self) -> bool:
+        return self._lease_holder is not None
+
+    def _schedule_lease_release(self, *, reason: str) -> None:
+        """Fire-and-forget release from sync contexts (client drop).
+        NEVER raises."""
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            self._lease_holder = None
+            return
+        try:
+            loop.create_task(self._release_lease(reason=reason))
+        except RuntimeError:
+            self._lease_holder = None
+
+    async def _release_lease(self, *, reason: str) -> None:
+        """Disarm the supervisor's audio plane + clear the holder.
+        Idempotent; NEVER raises — the supervisor process must survive
+        ANY fault in the disarm callback (mandate 4: no hang, no
+        crash, mic never left hot)."""
+        if self._lease_holder is None:
+            return
+        self._lease_holder = None
+        self._lease_deadline = 0.0
+        logger.info("[AudioIPC] lease released (%s) — audio disarmed", reason)
+        await self._invoke_lease_change(False)
+
+    async def _invoke_lease_change(self, armed: bool) -> None:
+        cb = self._on_lease_change
+        if cb is None:
+            return
+        try:
+            result = cb(armed)
+            if asyncio.iscoroutine(result):
+                # Bounded: a wedged arm/disarm callback must never hang
+                # the broadcaster loop (the supervisor's own timeout
+                # discipline applies inside; this is the outer fuse).
+                await asyncio.wait_for(result, timeout=lease_ttl_s())
+        except asyncio.TimeoutError:
+            logger.warning(
+                "[AudioIPC] lease callback timed out (armed=%s)", armed,
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "[AudioIPC] lease callback degraded (armed=%s)",
+                armed, exc_info=True,
+            )
+
+    async def _handle_lease_frame(
+        self, cmd: str, writer: asyncio.StreamWriter,
+    ) -> None:
+        """One lease negotiation step. Replies only to the requesting
+        client (grants are private; STATE stays broadcast)."""
+        ttl = lease_ttl_s()
+        if cmd == "heartbeat":
+            if writer is self._lease_holder:
+                self._lease_deadline = time.monotonic() + ttl
+                self.lease_stats["heartbeats"] += 1
+            return
+        if cmd == "release":
+            if writer is self._lease_holder:
+                self.lease_stats["releases"] += 1
+                await self._release_lease(reason="client_release")
+                self._reply(writer, {
+                    "type": "lease", "granted": False, "reason": "released",
+                })
+            return
+        # acquire
+        if self._lease_holder is not None and self._lease_holder is not writer:
+            self.lease_stats["denials"] += 1
+            self._reply(writer, {
+                "type": "lease", "granted": False, "reason": "held",
+            })
+            return
+        first_acquire = self._lease_holder is None
+        self._lease_holder = writer
+        self._lease_deadline = time.monotonic() + ttl
+        self.lease_stats["acquires"] += 1
+        if first_acquire:
+            await self._invoke_lease_change(True)
+            self._start_lease_watchdog()
+        self._reply(writer, {
+            "type": "lease", "granted": True, "ttl_s": ttl,
+        })
+
+    def _start_lease_watchdog(self) -> None:
+        if self._lease_watchdog is not None and not self._lease_watchdog.done():
+            return
+        loop = self._loop
+        if loop is None or loop.is_closed():
+            return
+        self._lease_watchdog = loop.create_task(self._lease_watchdog_loop())
+
+    async def _lease_watchdog_loop(self) -> None:
+        """Orphaned-mic protection path (b): heartbeats stopped while
+        the socket wedged open. Sweeps at TTL/2; reads ONLY
+        ``time.monotonic()`` + the deadline — never pipeline state
+        (Slice-47 watchdog isolation: a watchdog coupled to the system
+        it guards deadlocks with it)."""
+        try:
+            while self._lease_holder is not None:
+                await asyncio.sleep(lease_ttl_s() / 2.0)
+                if (
+                    self._lease_holder is not None
+                    and time.monotonic() > self._lease_deadline
+                ):
+                    self.lease_stats["expiries"] += 1
+                    holder = self._lease_holder
+                    await self._release_lease(reason="heartbeat_expired")
+                    self._reply(holder, {
+                        "type": "lease", "granted": False,
+                        "reason": "expired",
+                    })
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioIPC] lease watchdog degraded", exc_info=True)
+
+    def _reply(self, writer: asyncio.StreamWriter, msg: Dict[str, Any]) -> None:
+        """Best-effort unicast to one client. NEVER raises."""
+        try:
+            if writer.is_closing():
+                return
+            writer.write(
+                (json.dumps(msg, separators=(",", ":")) + "\n").encode(),
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+    # ----------------------------------------------------------------------
 
     def _handshake_payload(self) -> Dict[str, Any]:
         return {
@@ -307,6 +511,7 @@ class AudioStateBroadcaster:
                 dict(self._utterance) if self._utterance is not None else None
             ),
             "recent": list(self._recent),
+            "lease": {"held": self.lease_held},
         }
 
     async def _on_client(
@@ -320,11 +525,22 @@ class AudioStateBroadcaster:
             writer.write(handshake)
             await writer.drain()
             self._clients.add(writer)
-            # Hold the connection open; EOF (client gone) unregisters.
+            # Upstream lane: newline-JSON lease frames. Anything
+            # malformed or off-vocabulary is IGNORED (the export lane
+            # stays authority-free; lease is the one narrow verb set).
+            # EOF (client gone) unregisters + drop-releases the lease.
             while True:
-                data = await reader.read(4096)
-                if not data:
+                line = await reader.readline()
+                if not line:
                     break
+                try:
+                    frame = json.loads(line)
+                except (ValueError, TypeError):
+                    continue
+                if frame.get("type") == "lease":
+                    cmd = str(frame.get("cmd", "")).strip().lower()
+                    if cmd in LEASE_CMDS:
+                        await self._handle_lease_frame(cmd, writer)
         except Exception:  # noqa: BLE001
             pass
         finally:
@@ -415,6 +631,23 @@ class AudioStateClient:
         finally:
             self.connected = False
 
+    def send_lease(self, cmd: str) -> bool:
+        """Pipe one lease frame upstream (``acquire`` / ``release`` /
+        ``heartbeat``). Non-blocking; False when detached or the
+        command is off-vocabulary. NEVER raises."""
+        try:
+            cmd = str(cmd or "").strip().lower()
+            if cmd not in LEASE_CMDS:
+                return False
+            w = self._writer
+            if not self.connected or w is None or w.is_closing():
+                return False
+            frame = {"type": "lease", "cmd": cmd}
+            w.write((json.dumps(frame, separators=(",", ":")) + "\n").encode())
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
     async def close(self) -> None:
         """Idempotent teardown. NEVER raises."""
         self.connected = False
@@ -453,6 +686,8 @@ __all__ = [
     "EVENT_TTS_GENERATING",
     "EVENT_VAD_ACTIVE",
     "EVENT_VAD_INACTIVE",
+    "LEASE_CMDS",
     "audio_ipc_enabled",
+    "lease_ttl_s",
     "socket_path",
 ]

--- a/tests/governance/test_audio_lease_broker.py
+++ b/tests/governance/test_audio_lease_broker.py
@@ -1,0 +1,363 @@
+"""Tri-State IPC Audio Broker — lease negotiation + orphaned-mic spine.
+
+Operator authorization 2026-07-18. The supervisor's ``audio_state_ipc``
+transport gains an upstream lease lane; the daemon's synapse brokers
+``wake`` cross-process instead of mounting hardware. The load-bearing
+edge case (mandate 4, verbatim): a daemon crash mid-conversation must
+disarm the supervisor's hardware locks WITHOUT hanging the supervisor —
+two independent paths: broken-pipe drop-release + heartbeat expiry.
+
+UDS tests need short socket paths (macOS sun_path) + sandbox off.
+"""
+from __future__ import annotations
+
+import asyncio
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test.audio_synapse import (
+    AudioVisualSynapse,
+    RemoteAudioLease,
+)
+from backend.core.ouroboros.governance.comms.duplex.audio_state_ipc import (
+    AudioStateBroadcaster,
+    AudioStateClient,
+)
+
+
+@pytest.fixture()
+def sock_dir():
+    d = Path(tempfile.mkdtemp(prefix="lease-"))
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+@pytest.fixture()
+def fast_ttl(monkeypatch):
+    monkeypatch.setenv("JARVIS_AUDIO_LEASE_TTL_S", "1.0")
+
+
+class _ArmSpy:
+    """The supervisor's injected arm/disarm seam."""
+
+    def __init__(self) -> None:
+        self.calls: list = []
+        self.armed = False
+
+    async def __call__(self, armed: bool) -> None:
+        self.armed = armed
+        self.calls.append(armed)
+
+
+async def _server(sock_dir, spy):
+    b = AudioStateBroadcaster(
+        path=sock_dir / "a.sock", on_lease_change=spy,
+    )
+    assert await b.start()
+    return b
+
+
+async def _wait_for(cond, timeout=5.0):
+    deadline = asyncio.get_running_loop().time() + timeout
+    while not cond():
+        if asyncio.get_running_loop().time() > deadline:
+            return False
+        await asyncio.sleep(0.05)
+    return True
+
+
+# ---------------------------------------------------------------------------
+# (1) Lease negotiation over the EXISTING transport
+# ---------------------------------------------------------------------------
+
+
+class TestLeaseNegotiation:
+    async def test_acquire_arms_and_grants_with_ttl(self, sock_dir, fast_ttl):
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        frames: list = []
+        c = AudioStateClient(path=sock_dir / "a.sock", on_message=frames.append)
+        try:
+            assert await c.connect()
+            assert c.send_lease("acquire")
+            assert await _wait_for(lambda: any(
+                f.get("type") == "lease" for f in frames
+            ))
+            grant = [f for f in frames if f.get("type") == "lease"][0]
+            assert grant["granted"] is True
+            assert grant["ttl_s"] == pytest.approx(1.0)
+            assert spy.calls == [True]
+            assert b.lease_held is True
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_second_client_denied_while_held(self, sock_dir, fast_ttl):
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        f1: list = []
+        f2: list = []
+        c1 = AudioStateClient(path=sock_dir / "a.sock", on_message=f1.append)
+        c2 = AudioStateClient(path=sock_dir / "a.sock", on_message=f2.append)
+        try:
+            assert await c1.connect() and await c2.connect()
+            c1.send_lease("acquire")
+            await _wait_for(lambda: any(f.get("type") == "lease" for f in f1))
+            c2.send_lease("acquire")
+            assert await _wait_for(lambda: any(
+                f.get("type") == "lease" for f in f2
+            ))
+            deny = [f for f in f2 if f.get("type") == "lease"][0]
+            assert deny["granted"] is False and deny["reason"] == "held"
+            assert spy.calls == [True]          # single arm, no re-arm
+        finally:
+            await c1.close()
+            await c2.close()
+            await b.stop()
+
+    async def test_explicit_release_disarms(self, sock_dir, fast_ttl):
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        c = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c.connect()
+            c.send_lease("acquire")
+            await _wait_for(lambda: spy.armed)
+            c.send_lease("release")
+            assert await _wait_for(lambda: not spy.armed)
+            assert spy.calls == [True, False]
+            assert b.lease_held is False
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_handshake_advertises_lease_state(self, sock_dir, fast_ttl):
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        hs: list = []
+        c1 = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c1.connect()
+            c1.send_lease("acquire")
+            await _wait_for(lambda: spy.armed)
+            c2 = AudioStateClient(
+                path=sock_dir / "a.sock", on_handshake=hs.append,
+            )
+            assert await c2.connect()
+            assert hs and hs[0]["lease"]["held"] is True
+            assert hs[0]["schema_version"] == "audio_ipc.v2"
+            await c2.close()
+        finally:
+            await c1.close()
+            await b.stop()
+
+
+# ---------------------------------------------------------------------------
+# (2) Orphaned-mic protection — MANDATE 4 VERBATIM
+# ---------------------------------------------------------------------------
+
+
+class TestOrphanedMicProtection:
+    async def test_daemon_crash_mid_conversation_disarms_without_hang(
+        self, sock_dir, fast_ttl,
+    ):
+        """Daemon crash mid-conversation: the client socket dies with
+        NO release frame (SIGKILL shape). The supervisor must detect
+        the broken pipe, disarm the hardware seam, and keep serving —
+        the whole recovery bounded well under one TTL."""
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        c = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c.connect()
+            c.send_lease("acquire")
+            assert await _wait_for(lambda: spy.armed)
+            # Mid-conversation: supervisor is speaking.
+            b.publish_event("TTS_GENERATING")
+            # CRASH — abrupt transport death, no release, no goodbye.
+            c._writer.transport.abort()
+            assert await _wait_for(lambda: not spy.armed, timeout=3.0)
+            assert spy.calls == [True, False]
+            assert b.lease_held is False
+            assert b.lease_stats["drop_releases"] == 1
+            # The supervisor did NOT hang: it still serves new clients.
+            c2 = AudioStateClient(path=sock_dir / "a.sock")
+            assert await c2.connect()
+            await c2.close()
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_missed_heartbeats_expire_the_lease(
+        self, sock_dir, fast_ttl,
+    ):
+        """Path (b): socket wedges OPEN but heartbeats stop (daemon
+        event loop frozen). The monotonic watchdog expires the lease
+        within ~1.5×TTL and disarms."""
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        c = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c.connect()
+            c.send_lease("acquire")
+            assert await _wait_for(lambda: spy.armed)
+            # Send NO heartbeats; socket stays open.
+            assert await _wait_for(lambda: not spy.armed, timeout=4.0)
+            assert b.lease_stats["expiries"] == 1
+            assert b.lease_held is False
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_heartbeats_keep_the_lease_alive(self, sock_dir, fast_ttl):
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        c = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c.connect()
+            c.send_lease("acquire")
+            assert await _wait_for(lambda: spy.armed)
+            for _ in range(6):                  # 1.8s > TTL, kept alive
+                c.send_lease("heartbeat")
+                await asyncio.sleep(0.3)
+            assert spy.armed is True
+            assert b.lease_stats["expiries"] == 0
+            assert b.lease_stats["heartbeats"] >= 4
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_wedged_disarm_callback_never_hangs_supervisor(
+        self, sock_dir, fast_ttl,
+    ):
+        """A pathological arm/disarm callback that blocks forever is
+        fused by the outer wait_for — the broadcaster loop survives."""
+        async def _wedged(_armed: bool) -> None:
+            await asyncio.sleep(3600)
+
+        b = AudioStateBroadcaster(
+            path=sock_dir / "a.sock", on_lease_change=_wedged,
+        )
+        assert await b.start()
+        c = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c.connect()
+            c.send_lease("acquire")
+            # Grant still arrives (callback fuse = TTL) and the server
+            # keeps accepting connections afterwards.
+            await asyncio.sleep(1.5)
+            c2 = AudioStateClient(path=sock_dir / "a.sock")
+            assert await c2.connect()
+            await c2.close()
+        finally:
+            await c.close()
+            await b.stop()
+
+
+# ---------------------------------------------------------------------------
+# (3) Daemon-side broker — RemoteAudioLease + synapse composition
+# ---------------------------------------------------------------------------
+
+
+class TestRemoteAudioLease:
+    async def test_acquire_streams_fsm_states_to_tui(
+        self, sock_dir, fast_ttl, monkeypatch,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "a.sock"),
+        )
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        states: list = []
+        lease = RemoteAudioLease(states.append)
+        try:
+            assert await lease.acquire()
+            assert states[0] == "LISTENING"     # armed baseline
+            b.publish_event("VAD_ACTIVE")
+            await _wait_for(lambda: "HEARING" in states)
+            b.publish_event("TTS_GENERATING")
+            await _wait_for(lambda: "THINKING" in states)
+            b.publish_event("AUDIO_PLAYING")
+            await _wait_for(lambda: "SPEAKING" in states)
+            b.publish_event("AUDIO_IDLE")
+            assert await _wait_for(lambda: states[-1] == "LISTENING")
+        finally:
+            await lease.release()
+            await b.stop()
+
+    async def test_supervisor_absent_is_honest_failure(
+        self, sock_dir, monkeypatch,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "missing.sock"),
+        )
+        states: list = []
+        lease = RemoteAudioLease(states.append)
+        assert await lease.acquire() is False
+        assert states == []                     # caller owns UNAVAILABLE
+
+    async def test_supervisor_death_mid_lease_reports_offline(
+        self, sock_dir, fast_ttl, monkeypatch,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "a.sock"),
+        )
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        states: list = []
+        lease = RemoteAudioLease(states.append)
+        try:
+            assert await lease.acquire()
+            await b.stop()                      # supervisor dies
+            assert await _wait_for(
+                lambda: states and states[-1] == "OFFLINE", timeout=3.0,
+            )
+        finally:
+            await lease.release()
+
+    async def test_synapse_wake_brokers_cross_process(
+        self, sock_dir, fast_ttl, monkeypatch,
+    ):
+        """The full daemon seam: no local handle + live supervisor →
+        wake acquires the remote lease (LISTENING); sleep releases it
+        (OFFLINE) and the supervisor disarms."""
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "a.sock"),
+        )
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        states: list = []
+        syn = AudioVisualSynapse(states.append, handle_resolver=lambda: None)
+        try:
+            await syn.handle_cmd("wake")
+            assert syn.armed is True
+            assert states == ["LISTENING"]
+            assert await _wait_for(lambda: spy.armed)
+            await syn.handle_cmd("sleep")
+            assert states[-1] == "OFFLINE"
+            assert await _wait_for(lambda: not spy.armed, timeout=3.0)
+        finally:
+            await syn.stop()
+            await b.stop()
+
+    async def test_synapse_wake_broker_disabled_stays_unavailable(
+        self, sock_dir, fast_ttl, monkeypatch,
+    ):
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "a.sock"),
+        )
+        monkeypatch.setenv("JARVIS_AUDIO_BROKER_ENABLED", "false")
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        states: list = []
+        syn = AudioVisualSynapse(states.append, handle_resolver=lambda: None)
+        try:
+            await syn.handle_cmd("wake")
+            assert states == ["UNAVAILABLE"]
+            assert spy.calls == []              # supervisor untouched
+        finally:
+            await syn.stop()
+            await b.stop()


### PR DESCRIPTION
## Summary
The final cross-process bridge: `ov attach` → `wake` → daemon broker → supervisor audio FSM — with the daemon never touching hardware.

- **DRY (mandate 3)**: no new transport. `audio_state_ipc` gains an upstream lease lane on the SAME UDS — `{"type":"lease","cmd":"acquire"|"release"|"heartbeat"}`. Single-holder, contention answered `{"granted":false,"reason":"held"}`, grants carry `ttl_s` so clients derive heartbeat cadence from the wire (no hardcoded numbers on the far side). Schema → `audio_ipc.v2`; handshake advertises `lease.held`.
- **Sovereignty (mandate 1)**: the arm/disarm seam is an injected closure owned by `audio_pipeline_bootstrap` — starts the mounted `karen_duplex`, or lazy-builds it via the same `build_karen_duplex` factory when voice wasn't pre-mounted. Hardware locks never leave the supervisor process; the broker relays the verb.
- **Orphaned-mic protection (mandate 2)** — two independent kill paths: (a) holder socket drop (SIGKILL'd daemon) → instant drop-release; (b) heartbeat expiry via a monotonic-deadline watchdog at TTL/2 that reads only `time.monotonic()` + its own deadline (Slice-47 watchdog isolation). Either path disarms via `on_lease_change(False)`; the callback itself is fused with `wait_for` so a wedged disarm can never hang the supervisor.
- **Daemon broker**: `RemoteAudioLease` in `audio_synapse` — acquire, TTL/3 heartbeats, supervisor FSM→attach-state mapping (`VAD_ACTIVE→HEARING`, `TTS_GENERATING→THINKING`, `AUDIO_PLAYING→SPEAKING`, `IDLE→LISTENING`). The synapse's `wake` tries local handle → remote lease → honest `UNAVAILABLE` (`JARVIS_AUDIO_BROKER_ENABLED` default on, fail-soft). Supervisor death mid-lease → `OFFLINE` morph on the TUI.

## Testing
13 tests in `tests/governance/test_audio_lease_broker.py`, all green, including **mandate 4 verbatim**: daemon crash mid-conversation (`transport.abort()`, no release frame, supervisor mid-`TTS_GENERATING`) → broken pipe detected, hardware seam disarmed, supervisor keeps serving new clients — no hang. Plus: missed-heartbeat expiry (~1.5×TTL), heartbeat keepalive, second-client denial, wedged-callback fuse, and the full synapse `wake`→`sleep` cross-process round-trip. 66-test sweep across broker/synapse/IPC/attach green. One pre-existing unrelated red (`test_narrator_script_module_is_deleted`, fails at baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Tri-State IPC Audio Broker so the daemon acquires an audio lease from the supervisor over the existing IPC, with strong orphaned-mic protection. The supervisor keeps hardware control; the daemon never touches audio devices.

- New Features
  - IPC v2 lease lane on the same UDS: `{"type":"lease","cmd":"acquire"|"release"|"heartbeat"}`. Single-holder; denials include `{"reason":"held"}`. Grants include `ttl_s`. Handshake advertises `lease.held`.
  - Orphaned-mic protection: drop-release on socket close and a TTL watchdog (sweeps at TTL/2 using `time.monotonic()`). Both paths disarm via injected `on_lease_change(False)`. The callback is fused with a timeout to avoid hangs.
  - Supervisor sovereignty: `audio_pipeline_bootstrap` injects `on_lease_change` to arm/disarm `karen_duplex` (lazy-built via `build_karen_duplex` when needed). Hardware stays in the supervisor process.
  - Daemon broker: `RemoteAudioLease` in `audio_synapse` handles acquire, TTL/3 heartbeats, and maps supervisor events to attach states (`VAD_ACTIVE→HEARING`, `TTS_GENERATING→THINKING`, `AUDIO_PLAYING→SPEAKING`, `AUDIO_IDLE→LISTENING`). `wake` tries local handle → remote lease → publishes `UNAVAILABLE` if absent; supervisor death → `OFFLINE`.
  - Config and schema: `JARVIS_AUDIO_LEASE_TTL_S` (default 5s, clamp [1,60]), `JARVIS_AUDIO_BROKER_ENABLED` (default on), schema `audio_ipc.v2`. 13 tests added in `tests/governance/test_audio_lease_broker.py` cover crash mid-convo, heartbeat expiry/keepalive, contention, wedged-callback fuse, and full wake→sleep.

<sup>Written for commit a3bf5995cc64c77c2d145855200c332ced241569. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69939?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

