### PR TITLE
feat(audio): lease preemption + PTT + hardware topology survival + TTS flush

### DIFF
--- a/backend/audio/audio_pipeline_bootstrap.py
+++ b/backend/audio/audio_pipeline_bootstrap.py
@@ -229,6 +229,18 @@ async def wire_conversation_pipeline(
                                 "[Bootstrap] Karen duplex lazy-mounted on lease",
                             )
                         if handle.karen is not None:
+                            # Hardware Topology Survival: the arbiter's
+                            # stream-fault reporter routes into the
+                            # broker's fail-safe (revoke + disarm +
+                            # HW_FAULT broadcast). Late-bound so a
+                            # lazy-mounted duplex is covered too.
+                            try:
+                                handle.karen.arbiter.on_hardware_fault = (
+                                    lambda exc: handle.audio_ipc.publish_hardware_fault(str(exc))  # noqa: E501
+                                    if handle.audio_ipc is not None else None
+                                )
+                            except Exception:
+                                pass
                             await handle.karen.start()
                             logger.info("[Bootstrap] audio lease ARMED")
                     else:
@@ -242,8 +254,20 @@ async def wire_conversation_pipeline(
                         "[Bootstrap] lease arm/disarm degraded", exc_info=True,
                     )
 
+            def _on_flush() -> None:
+                # TTS interruption (ducking): instantaneous outbound
+                # halt on the arbiter's own flush seam. Sync + inline.
+                try:
+                    if handle.karen is not None:
+                        handle.karen.arbiter.flush()
+                except Exception:
+                    logger.debug(
+                        "[Bootstrap] lease flush degraded", exc_info=True,
+                    )
+
             handle.audio_ipc = AudioStateBroadcaster(
                 on_lease_change=_on_lease_change,
+                on_flush=_on_flush,
             )
             if not await handle.audio_ipc.start():
                 handle.audio_ipc = None
@@ -270,6 +294,17 @@ async def wire_conversation_pipeline(
             handle.karen = build_karen_duplex(handle.tts_engine)
             await handle.karen.start()
             set_default_karen(handle.karen)
+            # Hardware Topology Survival — same fault route as the
+            # lease-armed path (a pre-mounted duplex is equally exposed
+            # to device vanish).
+            try:
+                if handle.audio_ipc is not None:
+                    handle.karen.arbiter.on_hardware_fault = (
+                        lambda exc: handle.audio_ipc.publish_hardware_fault(str(exc))  # noqa: E501
+                        if handle.audio_ipc is not None else None
+                    )
+            except Exception:
+                pass
             logger.info("[Bootstrap] Karen full-duplex control layer mounted")
         except Exception as e:
             handle.karen = None

--- a/backend/core/ouroboros/battle_test/audio_synapse.py
+++ b/backend/core/ouroboros/battle_test/audio_synapse.py
@@ -95,9 +95,12 @@ class RemoteAudioLease:
         self._denied_reason: Optional[str] = None
         self.active: bool = False
 
-    async def acquire(self) -> bool:
-        """Connect + negotiate. False (with UNAVAILABLE published by
-        the CALLER, keeping one honesty seam) when the supervisor is
+    async def acquire(self, *, preempt: bool = False, ptt: bool = False) -> bool:
+        """Connect + negotiate. ``preempt`` sends ``acquire_preempt``
+        (FORCE_WAKE — revokes an incumbent terminal); ``ptt`` opens an
+        ephemeral push-to-talk hold (always preempting; closed by
+        :meth:`ptt_end`). False (with UNAVAILABLE published by the
+        CALLER, keeping one honesty seam) when the supervisor is
         absent, refuses, or times out. NEVER raises."""
         try:
             from backend.core.ouroboros.governance.comms.duplex.audio_state_ipc import (  # noqa: E501,PLC0415
@@ -109,7 +112,10 @@ class RemoteAudioLease:
             if not await client.connect():
                 return False
             self._client = client
-            if not client.send_lease("acquire"):
+            cmd = "ptt_start" if ptt else (
+                "acquire_preempt" if preempt else "acquire"
+            )
+            if not client.send_lease(cmd):
                 await client.close()
                 self._client = None
                 return False
@@ -154,8 +160,25 @@ class RemoteAudioLease:
                         # stalled) — mirror its fail-safe honestly.
                         self.active = False
                         self._publish_safe("OFFLINE")
+                    elif reason == "preempted" and self.active:
+                        # Revoked over the heartbeat return channel:
+                        # another terminal asserted FORCE_WAKE/PTT.
+                        # Morph honestly; do NOT auto-re-acquire (that
+                        # would be two terminals fighting a mic war).
+                        self.active = False
+                        self._publish_safe("HELD")
+                    elif reason == "hw_fault" and self.active:
+                        # The audio device vanished under the lease —
+                        # supervisor already disarmed; render truth.
+                        self.active = False
+                        self._publish_safe("UNAVAILABLE")
             elif mtype == "event" and self.active:
-                state = _EVENT_MAP.get(str(msg.get("kind", "")))
+                kind = str(msg.get("kind", ""))
+                if kind == "HW_FAULT":
+                    self.active = False
+                    self._publish_safe("UNAVAILABLE")
+                    return
+                state = _EVENT_MAP.get(kind)
                 if state is not None:
                     self._publish_safe(state)
         except Exception:  # noqa: BLE001
@@ -180,6 +203,28 @@ class RemoteAudioLease:
             if self.active:
                 self.active = False
                 self._publish_safe("OFFLINE")
+
+    def flush(self) -> bool:
+        """Ducking: halt the supervisor's outbound audio NOW (holder-
+        only server-side). Non-blocking. NEVER raises."""
+        try:
+            client = self._client
+            if client is None or not self.active:
+                return False
+            return bool(client.send_lease("flush"))
+        except Exception:  # noqa: BLE001
+            return False
+
+    def ptt_end(self) -> bool:
+        """Close an ephemeral push-to-talk hold (full release server-
+        side). NEVER raises."""
+        try:
+            client = self._client
+            if client is None:
+                return False
+            return bool(client.send_lease("ptt_end"))
+        except Exception:  # noqa: BLE001
+            return False
 
     async def release(self) -> None:
         """Release + teardown. Idempotent; NEVER raises."""
@@ -254,29 +299,46 @@ class AudioVisualSynapse:
             cmd = str(cmd or "").strip().lower()
             if cmd == "wake":
                 await self._wake()
+            elif cmd == "force_wake":
+                await self._wake(preempt=True)
             elif cmd == "sleep":
                 await self._sleep()
             elif cmd == "barge":
                 await self._barge()
+            elif cmd == "ptt":
+                await self._wake(preempt=True, ptt=True)
+            elif cmd == "ptt_stop":
+                remote = self._remote
+                if remote is not None and remote.ptt_end():
+                    self._remote = None
+                    self._armed = False
+                    self._safe_publish("OFFLINE")
+            elif cmd == "flush":
+                await self._flush()
         except Exception:  # noqa: BLE001
             logger.debug("[AudioSynapse] cmd degraded", exc_info=True)
 
-    async def _wake(self) -> None:
+    async def _wake(self, *, preempt: bool = False, ptt: bool = False) -> None:
         handle = self._resolve()
-        if handle is None:
+        if handle is None or preempt or ptt:
             # No LOCAL duplex — the supervisor owns the hardware plane.
             # Tri-State broker path: negotiate a cross-process audio
-            # lease over audio_state_ipc. Only when the supervisor is
+            # lease over audio_state_ipc (preempt/ptt are inherently
+            # cross-process verbs — floor arbitration lives at the
+            # supervisor's lease table). Only when the supervisor is
             # absent/refusing does the TUI see UNAVAILABLE — honesty,
             # never a fake LISTENING.
             if broker_enabled():
                 remote = RemoteAudioLease(self._publish)
-                if await remote.acquire():
+                if await remote.acquire(preempt=preempt, ptt=ptt):
                     self._remote = remote
                     self._armed = True
                     return
-            self._safe_publish("UNAVAILABLE")
-            return
+            if handle is None:
+                self._safe_publish("UNAVAILABLE")
+                return
+            # Preempt/ptt asked but no supervisor: fall through to the
+            # local handle (single-terminal case — nothing to preempt).
         try:
             await handle.start()
         except Exception:  # noqa: BLE001
@@ -305,6 +367,23 @@ class AudioVisualSynapse:
                     "[AudioSynapse] duplex stop degraded", exc_info=True,
                 )
         self._safe_publish("OFFLINE")
+
+    async def _flush(self) -> None:
+        """Ducking — halt outbound audio wherever the lease lives:
+        remote lease → wire flush; local handle → the arbiter's own
+        flush seam. NEVER raises."""
+        remote = self._remote
+        if remote is not None:
+            remote.flush()
+            return
+        handle = self._resolve()
+        arbiter = getattr(handle, "arbiter", None)
+        flush = getattr(arbiter, "flush", None)
+        if callable(flush):
+            try:
+                flush()
+            except Exception:  # noqa: BLE001
+                logger.debug("[AudioSynapse] local flush degraded", exc_info=True)
 
     async def _barge(self) -> None:
         """Operator barge-in from the TUI — the text-plane equivalent

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -60,11 +60,15 @@ COCKPIT_ATTACH_SCHEMA_VERSION = "cockpit_attach.v2"
 #: requested but no duplex handle mounted in this process.
 AUDIO_STATES = (
     "OFFLINE", "UNAVAILABLE", "LISTENING", "HEARING", "THINKING",
-    "SPEAKING",
+    "SPEAKING", "HELD",
 )
 
-#: Closed taxonomy of TUI→daemon audio commands.
-AUDIO_CMDS = ("wake", "sleep", "barge")
+#: Closed taxonomy of TUI→daemon audio commands. v2.1: force_wake
+#: preempts an incumbent terminal; ptt/ptt_stop bracket an ephemeral
+#: push-to-talk hold; flush halts outbound audio (ducking).
+AUDIO_CMDS = (
+    "wake", "sleep", "barge", "force_wake", "ptt", "ptt_stop", "flush",
+)
 
 _TRUTHY = ("1", "true", "yes", "on")
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -277,10 +277,16 @@ class AttachUI:
     _PROMPTS = {
         "OFFLINE": "ov › ",
         "UNAVAILABLE": "ov › ",
+        "HELD": "ov › ",
         "LISTENING": "🎙 Karen › ",
         "HEARING": "🎙 Karen (hearing you) › ",
         "THINKING": "💭 Karen (thinking) › ",
         "SPEAKING": "🗣 Karen (speaking) › ",
+    }
+
+    _TOOLBAR_NOTES = {
+        "HELD": "voice: held by another terminal ('wake!' to take it)",
+        "UNAVAILABLE": "voice: unavailable (no audio plane)",
     }
 
     def __init__(self) -> None:
@@ -294,11 +300,20 @@ class AttachUI:
         return self._PROMPTS.get(self.audio_state, "ov › ")
 
     def toolbar(self) -> str:
-        audio = (
-            f" · voice: {self.audio_state.lower()}"
-            if self.audio_state != "OFFLINE" else " · voice: off ('wake')"
-        )
+        note = self._TOOLBAR_NOTES.get(self.audio_state)
+        if note is not None:
+            audio = f" · {note}"
+        elif self.audio_state == "OFFLINE":
+            audio = " · voice: off ('wake')"
+        else:
+            audio = f" · voice: {self.audio_state.lower()}"
         return f" ov attach — organism live{audio} · 'detach' to leave"
+
+    def should_flush_on_input(self) -> bool:
+        """Ducking predicate: the operator typed a NEW command while
+        Karen is composing or speaking — outbound audio yields to the
+        human instantly. NEVER raises."""
+        return self.audio_state in ("THINKING", "SPEAKING")
 
     def on_audio_state(self, state: str) -> None:
         """The synapse landing point — morph + repaint. NEVER raises."""
@@ -399,6 +414,18 @@ async def _split_plane_loop(
             if low in ("wake", "voice", "listen"):
                 client.send_audio("wake")
                 continue
+            if low in ("wake!", "force-wake", "force wake"):
+                client.send_audio("force_wake")
+                continue
+            if low == "ptt":
+                client.send_audio("ptt")
+                continue
+            if low in ("ptt stop", "ptt-stop", "ptt off"):
+                client.send_audio("ptt_stop")
+                continue
+            if low in ("flush", "shh", "hush"):
+                client.send_audio("flush")
+                continue
             if low in ("mute", "sleep"):
                 client.send_audio("sleep")
                 continue
@@ -406,6 +433,12 @@ async def _split_plane_loop(
                 client.send_audio("barge")
                 continue
             if text:
+                # TTS interruption (ducking): a new operator command
+                # while Karen is composing/speaking flushes her
+                # outbound buffer FIRST — the human always owns the
+                # floor.
+                if ui.should_flush_on_input():
+                    client.send_audio("flush")
                 client.send_input(text)
 
 

--- a/backend/core/ouroboros/governance/comms/duplex/arbiter.py
+++ b/backend/core/ouroboros/governance/comms/duplex/arbiter.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections import deque
-from typing import Deque, Dict, Optional
+from typing import Callable, Deque, Dict, Optional
 
 from .protocols import (
     ArbiterConfig, PlaybackHandle, Priority, SpeechRequest, VoiceState,
@@ -35,6 +35,15 @@ class VoiceDuplexArbiter:
         self.shed_count = 0
         self.coalesced_count = 0
         self._filler_idx = 0
+        #: Hardware Topology Survival seam (operator-authorized
+        #: 2026-07-18): playback stream faults (CoreAudio device
+        #: vanished, Bluetooth drop) were swallowed by _speak's
+        #: except — the fault EXISTED but died silently. The bootstrap
+        #: injects a reporter here; the arbiter loop itself always
+        #: survives the fault (state resets in finally, run() keeps
+        #: draining). Sync callable; never awaited on the audio path.
+        self.on_hardware_fault: Optional[Callable[[BaseException], None]] = None
+        self.hardware_fault_count = 0
 
     @property
     def state(self) -> VoiceState:
@@ -109,8 +118,21 @@ class VoiceDuplexArbiter:
             await self._play_task
         except asyncio.CancelledError:
             pass
-        except Exception:  # noqa: BLE001
-            logger.debug("[Arbiter] playback failed", exc_info=True)
+        except Exception as exc:  # noqa: BLE001
+            # Stream-layer fault (device vanished mid-play). Report to
+            # the injected sentinel — NEVER let the reporter's own
+            # fault kill the audio loop (the finally below always
+            # resets the FSM; the arbiter keeps running).
+            self.hardware_fault_count += 1
+            logger.warning("[Arbiter] playback stream fault: %s", exc)
+            cb = self.on_hardware_fault
+            if cb is not None:
+                try:
+                    cb(exc)
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "[Arbiter] fault reporter degraded", exc_info=True,
+                    )
         finally:
             self._play_task = None
             if self._state == VoiceState.KAREN_SPEAKING:
@@ -137,6 +159,29 @@ class VoiceDuplexArbiter:
                 self._wake.set()                  # resume draining the queue
         except Exception:  # noqa: BLE001
             logger.debug("[Arbiter] on_user_speech_end failed", exc_info=True)
+
+    def flush(self) -> None:
+        """Instantaneous outbound-audio halt (TTS interruption /
+        ducking, operator-authorized 2026-07-18): preempt the playback
+        buffer, cancel the play task, drop EVERY queued utterance, and
+        reset the FSM to LISTENING. Sync + non-blocking so the IPC
+        lane can invoke it inline. Idempotent; NEVER raises."""
+        try:
+            self._playback.preempt()
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            if self._play_task is not None:
+                self._play_task.cancel()
+            for p in self._queues:
+                self._queues[p].clear()
+            if self._state in (
+                VoiceState.KAREN_SPEAKING, VoiceState.THINKING,
+            ):
+                self._state = VoiceState.LISTENING
+            self._active_priority = None
+        except Exception:  # noqa: BLE001
+            logger.debug("[Arbiter] flush degraded", exc_info=True)
 
     async def stop(self) -> None:
         # Clean shutdown: cancel any active playback so no blocked play task

--- a/backend/core/ouroboros/governance/comms/duplex/audio_state_ipc.py
+++ b/backend/core/ouroboros/governance/comms/duplex/audio_state_ipc.py
@@ -71,7 +71,13 @@ logger = logging.getLogger(__name__)
 AUDIO_IPC_SCHEMA_VERSION = "audio_ipc.v2"
 
 #: Closed lease-command vocabulary (the upstream control lane).
-LEASE_CMDS = ("acquire", "release", "heartbeat")
+#: v2.1 (operator-authorized 2026-07-18): ``acquire_preempt`` revokes
+#: the incumbent (FORCE_WAKE); ``ptt_start``/``ptt_end`` bracket an
+#: ephemeral push-to-talk hold; ``flush`` halts outbound audio.
+LEASE_CMDS = (
+    "acquire", "release", "heartbeat",
+    "acquire_preempt", "ptt_start", "ptt_end", "flush",
+)
 
 
 def lease_ttl_s() -> float:
@@ -92,9 +98,10 @@ EVENT_VAD_INACTIVE = "VAD_INACTIVE"
 EVENT_TTS_GENERATING = "TTS_GENERATING"
 EVENT_AUDIO_PLAYING = "AUDIO_PLAYING"
 EVENT_AUDIO_IDLE = "AUDIO_IDLE"
+EVENT_HW_FAULT = "HW_FAULT"
 EVENT_KINDS = (
     EVENT_VAD_ACTIVE, EVENT_VAD_INACTIVE, EVENT_TTS_GENERATING,
-    EVENT_AUDIO_PLAYING, EVENT_AUDIO_IDLE,
+    EVENT_AUDIO_PLAYING, EVENT_AUDIO_IDLE, EVENT_HW_FAULT,
 )
 
 
@@ -147,6 +154,7 @@ class AudioStateBroadcaster:
         *,
         path: Optional[Path] = None,
         on_lease_change: Optional[Callable[[bool], Any]] = None,
+        on_flush: Optional[Callable[[], Any]] = None,
     ) -> None:
         self._path = Path(path) if path is not None else socket_path()
         self._server: Optional[asyncio.AbstractServer] = None
@@ -165,12 +173,16 @@ class AudioStateBroadcaster:
         # holder is identified by its StreamWriter; the deadline is a
         # raw ``time.monotonic()`` instant (watchdog isolation).
         self._on_lease_change = on_lease_change
+        self._on_flush = on_flush
         self._lease_holder: Optional[asyncio.StreamWriter] = None
         self._lease_deadline: float = 0.0
         self._lease_watchdog: Optional[asyncio.Task] = None
+        self._lease_is_ptt = False
         self.lease_stats: Dict[str, int] = {
             "acquires": 0, "denials": 0, "releases": 0,
             "expiries": 0, "drop_releases": 0, "heartbeats": 0,
+            "preempts": 0, "ptt_sessions": 0, "flushes": 0,
+            "hw_faults": 0,
         }
 
     # ---- lifecycle ----
@@ -324,6 +336,11 @@ class AudioStateBroadcaster:
         elif kind == EVENT_AUDIO_IDLE:
             self._state["tts_generating"] = False
             self._state["audio_playing"] = False
+        elif kind == EVENT_HW_FAULT:
+            # Device vanished — every presentation boolean is a lie now.
+            self._state["vad_active"] = False
+            self._state["tts_generating"] = False
+            self._state["audio_playing"] = False
 
     def _enqueue(self, msg: Dict[str, Any]) -> None:
         self._recent.append(msg)
@@ -394,6 +411,7 @@ class AudioStateBroadcaster:
             return
         self._lease_holder = None
         self._lease_deadline = 0.0
+        self._lease_is_ptt = False
         logger.info("[AudioIPC] lease released (%s) — audio disarmed", reason)
         await self._invoke_lease_change(False)
 
@@ -437,23 +455,96 @@ class AudioStateBroadcaster:
                     "type": "lease", "granted": False, "reason": "released",
                 })
             return
-        # acquire
-        if self._lease_holder is not None and self._lease_holder is not writer:
-            self.lease_stats["denials"] += 1
-            self._reply(writer, {
-                "type": "lease", "granted": False, "reason": "held",
-            })
+        if cmd == "flush":
+            # TTS interruption / ducking — holder-only (a bystander
+            # terminal must not silence Karen for the operator who
+            # holds the floor).
+            if writer is self._lease_holder:
+                self.lease_stats["flushes"] += 1
+                await self._invoke_flush()
+                self.publish_event(EVENT_AUDIO_IDLE)
             return
-        first_acquire = self._lease_holder is None
+        if cmd == "ptt_end":
+            # Ephemeral hold ends → FULL release (disarm). A non-PTT
+            # lease ignores ptt_end (defensive: mismatched brackets
+            # never disarm a standing lease).
+            if writer is self._lease_holder and self._lease_is_ptt:
+                self.lease_stats["releases"] += 1
+                await self._release_lease(reason="ptt_end")
+                self._reply(writer, {
+                    "type": "lease", "granted": False, "reason": "released",
+                })
+            return
+        # acquire / acquire_preempt / ptt_start
+        preempting = cmd in ("acquire_preempt", "ptt_start")
+        incumbent = self._lease_holder
+        if incumbent is not None and incumbent is not writer:
+            if not preempting:
+                self.lease_stats["denials"] += 1
+                self._reply(writer, {
+                    "type": "lease", "granted": False, "reason": "held",
+                })
+                return
+            # Graceful revocation over the return channel: the
+            # incumbent's TUI morphs to "held by another terminal".
+            # The hardware stays ARMED through the transfer — one
+            # continuous stream, no disarm/re-arm glitch.
+            self.lease_stats["preempts"] += 1
+            self._reply(incumbent, {
+                "type": "lease", "granted": False, "reason": "preempted",
+            })
+        first_arm = incumbent is None
         self._lease_holder = writer
         self._lease_deadline = time.monotonic() + ttl
+        self._lease_is_ptt = cmd == "ptt_start"
+        if self._lease_is_ptt:
+            self.lease_stats["ptt_sessions"] += 1
         self.lease_stats["acquires"] += 1
-        if first_acquire:
+        if first_arm:
             await self._invoke_lease_change(True)
             self._start_lease_watchdog()
         self._reply(writer, {
             "type": "lease", "granted": True, "ttl_s": ttl,
+            "ptt": self._lease_is_ptt,
         })
+
+    async def _invoke_flush(self) -> None:
+        """Fused invoke of the supervisor's outbound-audio halt seam.
+        NEVER raises."""
+        cb = self._on_flush
+        if cb is None:
+            return
+        try:
+            result = cb()
+            if asyncio.iscoroutine(result):
+                await asyncio.wait_for(result, timeout=lease_ttl_s())
+        except asyncio.TimeoutError:
+            logger.warning("[AudioIPC] flush callback timed out")
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioIPC] flush callback degraded", exc_info=True)
+
+    def publish_hardware_fault(self, detail: str = "") -> None:
+        """Hardware Topology Survival: the active audio device vanished
+        mid-lease (Bluetooth drop, CoreAudio stream death). Fail-safe
+        sequence — revoke the holder over the return channel (reason
+        ``hw_fault``), disarm via the lease seam (the bootstrap's
+        closure tears down the dead stream), and broadcast the fault
+        event so EVERY subscriber renders the truth. Thread-safe
+        (callable from the arbiter's fault reporter on any task);
+        NEVER raises — the supervisor loop must survive any device
+        topology change."""
+        try:
+            self.lease_stats["hw_faults"] += 1
+            holder = self._lease_holder
+            if holder is not None:
+                self._reply(holder, {
+                    "type": "lease", "granted": False, "reason": "hw_fault",
+                    "detail": str(detail or "")[:200],
+                })
+                self._schedule_lease_release(reason="hardware_fault")
+            self.publish_event(EVENT_HW_FAULT)
+        except Exception:  # noqa: BLE001
+            logger.debug("[AudioIPC] hw-fault publish degraded", exc_info=True)
 
     def _start_lease_watchdog(self) -> None:
         if self._lease_watchdog is not None and not self._lease_watchdog.done():
@@ -682,6 +773,7 @@ __all__ = [
     "AudioStateClient",
     "EVENT_AUDIO_IDLE",
     "EVENT_AUDIO_PLAYING",
+    "EVENT_HW_FAULT",
     "EVENT_KINDS",
     "EVENT_TTS_GENERATING",
     "EVENT_VAD_ACTIVE",

--- a/tests/governance/test_audio_lease_broker.py
+++ b/tests/governance/test_audio_lease_broker.py
@@ -361,3 +361,303 @@ class TestRemoteAudioLease:
         finally:
             await syn.stop()
             await b.stop()
+
+
+# ---------------------------------------------------------------------------
+# (4) Lease Preemption + Push-to-Talk (operator-authorized 2026-07-18)
+# ---------------------------------------------------------------------------
+
+
+class TestLeasePreemption:
+    async def test_force_wake_revokes_incumbent_gracefully(
+        self, sock_dir, fast_ttl,
+    ):
+        """Second terminal asserts acquire_preempt: incumbent gets
+        reason=preempted over the return channel, challenger is
+        granted, and the hardware stays ARMED through the transfer
+        (single continuous stream — no disarm/re-arm glitch)."""
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        f1: list = []
+        f2: list = []
+        c1 = AudioStateClient(path=sock_dir / "a.sock", on_message=f1.append)
+        c2 = AudioStateClient(path=sock_dir / "a.sock", on_message=f2.append)
+        try:
+            assert await c1.connect() and await c2.connect()
+            c1.send_lease("acquire")
+            await _wait_for(lambda: spy.armed)
+            c2.send_lease("acquire_preempt")
+            assert await _wait_for(lambda: any(
+                f.get("reason") == "preempted" for f in f1
+            ))
+            assert await _wait_for(lambda: any(
+                f.get("granted") is True for f in f2
+            ))
+            assert spy.calls == [True]           # armed ONCE, continuous
+            assert b.lease_stats["preempts"] == 1
+        finally:
+            await c1.close()
+            await c2.close()
+            await b.stop()
+
+    async def test_ptt_is_ephemeral_full_cycle(self, sock_dir, fast_ttl):
+        """ptt_start preempts + arms; ptt_end fully releases (disarm).
+        A standing lease never disarms on a stray ptt_end."""
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        frames: list = []
+        c = AudioStateClient(path=sock_dir / "a.sock", on_message=frames.append)
+        try:
+            assert await c.connect()
+            c.send_lease("ptt_start")
+            assert await _wait_for(lambda: spy.armed)
+            grant = [f for f in frames if f.get("granted")][0]
+            assert grant["ptt"] is True
+            c.send_lease("ptt_end")
+            assert await _wait_for(lambda: not spy.armed)
+            assert spy.calls == [True, False]
+            assert b.lease_stats["ptt_sessions"] == 1
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_stray_ptt_end_never_disarms_standing_lease(
+        self, sock_dir, fast_ttl,
+    ):
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        c = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c.connect()
+            c.send_lease("acquire")              # standing, not PTT
+            assert await _wait_for(lambda: spy.armed)
+            c.send_lease("ptt_end")
+            await asyncio.sleep(0.4)
+            assert spy.armed is True             # defensive bracket
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_remote_lease_maps_preempted_to_held(
+        self, sock_dir, fast_ttl, monkeypatch,
+    ):
+        """The revoked terminal's presentation truth: HELD (the ov
+        toolbar renders 'held by another terminal') and NO auto-
+        re-acquire mic war."""
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "a.sock"),
+        )
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        s1: list = []
+        s2: list = []
+        lease1 = RemoteAudioLease(s1.append)
+        lease2 = RemoteAudioLease(s2.append)
+        try:
+            assert await lease1.acquire()
+            assert await lease2.acquire(preempt=True)
+            assert await _wait_for(lambda: "HELD" in s1)
+            assert lease1.active is False        # no mic war
+            assert lease2.active is True
+        finally:
+            await lease1.release()
+            await lease2.release()
+            await b.stop()
+
+
+# ---------------------------------------------------------------------------
+# (5) TTS interruption — FLUSH / ducking
+# ---------------------------------------------------------------------------
+
+
+class TestFlush:
+    async def test_holder_flush_invokes_seam_and_broadcasts_idle(
+        self, sock_dir, fast_ttl,
+    ):
+        spy = _ArmSpy()
+        flushes: list = []
+        b = AudioStateBroadcaster(
+            path=sock_dir / "a.sock", on_lease_change=spy,
+            on_flush=lambda: flushes.append(1),
+        )
+        assert await b.start()
+        frames: list = []
+        c = AudioStateClient(path=sock_dir / "a.sock", on_message=frames.append)
+        try:
+            assert await c.connect()
+            c.send_lease("acquire")
+            await _wait_for(lambda: spy.armed)
+            c.send_lease("flush")
+            assert await _wait_for(lambda: flushes)
+            assert await _wait_for(lambda: any(
+                f.get("kind") == "AUDIO_IDLE" for f in frames
+            ))
+            assert b.lease_stats["flushes"] == 1
+        finally:
+            await c.close()
+            await b.stop()
+
+    async def test_bystander_flush_ignored(self, sock_dir, fast_ttl):
+        spy = _ArmSpy()
+        flushes: list = []
+        b = AudioStateBroadcaster(
+            path=sock_dir / "a.sock", on_lease_change=spy,
+            on_flush=lambda: flushes.append(1),
+        )
+        assert await b.start()
+        c1 = AudioStateClient(path=sock_dir / "a.sock")
+        c2 = AudioStateClient(path=sock_dir / "a.sock")
+        try:
+            assert await c1.connect() and await c2.connect()
+            c1.send_lease("acquire")
+            await _wait_for(lambda: spy.armed)
+            c2.send_lease("flush")               # NOT the holder
+            await asyncio.sleep(0.4)
+            assert flushes == []
+        finally:
+            await c1.close()
+            await c2.close()
+            await b.stop()
+
+    def test_arbiter_flush_halts_everything(self):
+        from backend.core.ouroboros.governance.comms.duplex.arbiter import (
+            VoiceDuplexArbiter,
+        )
+        from backend.core.ouroboros.governance.comms.duplex.protocols import (
+            Priority,
+            SpeechRequest,
+            VoiceState,
+        )
+
+        class _Playback:
+            def __init__(self) -> None:
+                self.preempts = 0
+
+            def preempt(self) -> None:
+                self.preempts += 1
+
+            async def play(self, _text: str) -> None:
+                await asyncio.sleep(3600)
+
+        pb = _Playback()
+        arb = VoiceDuplexArbiter(pb)
+        arb.submit(SpeechRequest("queued line", Priority.PROACTIVE_INFO))
+        arb._state = VoiceState.KAREN_SPEAKING
+        arb.flush()
+        assert pb.preempts == 1
+        assert arb.state == VoiceState.LISTENING
+        assert all(len(q) == 0 for q in arb._queues.values())
+
+    def test_attach_ui_ducking_predicate_and_held_toolbar(self):
+        from backend.core.ouroboros.cli.ov import AttachUI
+        ui = AttachUI()
+        for state, ducks in (
+            ("LISTENING", False), ("THINKING", True),
+            ("SPEAKING", True), ("OFFLINE", False),
+        ):
+            ui.on_audio_state(state)
+            assert ui.should_flush_on_input() is ducks
+        ui.on_audio_state("HELD")
+        assert "held by another terminal" in ui.toolbar()
+        assert ui.prompt() == "ov › "
+
+
+# ---------------------------------------------------------------------------
+# (6) Hardware Topology Survival — MANDATE 4 VERBATIM
+# ---------------------------------------------------------------------------
+
+
+class TestHardwareTopologySurvival:
+    def _arbiter_with_dying_stream(self):
+        from backend.core.ouroboros.governance.comms.duplex.arbiter import (
+            VoiceDuplexArbiter,
+        )
+
+        class _DyingPlayback:
+            def preempt(self) -> None:
+                pass
+
+            async def play(self, _text: str) -> None:
+                raise OSError("CoreAudio: device vanished (-10851)")
+
+        from backend.core.ouroboros.governance.comms.duplex.protocols import (
+            ArbiterConfig,
+        )
+        cfg = ArbiterConfig(
+            enabled=True, barge_in_enabled=True, proactive_enabled=True,
+        )
+        return VoiceDuplexArbiter(_DyingPlayback(), config=cfg)
+
+    async def test_stream_read_failure_reports_fault_and_loop_survives(self):
+        """Mock an audio stream failure during playback: the arbiter
+        reports through on_hardware_fault, resets its FSM, and its run
+        loop keeps draining — no crash, no wedge."""
+        from backend.core.ouroboros.governance.comms.duplex.protocols import (
+            Priority,
+            SpeechRequest,
+            VoiceState,
+        )
+        arb = self._arbiter_with_dying_stream()
+        faults: list = []
+        arb.on_hardware_fault = faults.append
+        run = asyncio.get_running_loop().create_task(arb.run())
+        try:
+            arb.submit(SpeechRequest("hello", Priority.PROACTIVE_INFO))
+            assert await _wait_for(lambda: faults, timeout=3.0)
+            assert "vanished" in str(faults[0])
+            assert arb.state == VoiceState.LISTENING   # FSM reset
+            assert arb.hardware_fault_count == 1
+            # Loop alive: a second submit is processed (faults again).
+            arb.submit(SpeechRequest("again", Priority.PROACTIVE_INFO))
+            assert await _wait_for(lambda: len(faults) == 2, timeout=3.0)
+        finally:
+            await arb.stop()
+            run.cancel()
+            try:
+                await run
+            except (asyncio.CancelledError, Exception):
+                pass
+
+    async def test_device_vanish_mid_lease_fails_safe_end_to_end(
+        self, sock_dir, fast_ttl, monkeypatch,
+    ):
+        """The full survival chain: active remote lease + supervisor
+        stream fault → holder revoked (reason=hw_fault), hardware seam
+        disarmed, HW_FAULT broadcast, TUI renders UNAVAILABLE, and the
+        supervisor's loop keeps serving new clients."""
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "a.sock"),
+        )
+        spy = _ArmSpy()
+        b = await _server(sock_dir, spy)
+        states: list = []
+        lease = RemoteAudioLease(states.append)
+        try:
+            assert await lease.acquire()
+            assert await _wait_for(lambda: spy.armed)
+            # The arbiter's fault reporter fires (Bluetooth dropped):
+            b.publish_hardware_fault("CoreAudio: device vanished (-10851)")
+            assert await _wait_for(
+                lambda: states and states[-1] == "UNAVAILABLE", timeout=3.0,
+            )
+            assert await _wait_for(lambda: not spy.armed, timeout=3.0)
+            assert lease.active is False
+            assert b.lease_stats["hw_faults"] == 1
+            # Supervisor loop alive — serves a fresh client.
+            c2 = AudioStateClient(path=sock_dir / "a.sock")
+            assert await c2.connect()
+            await c2.close()
+        finally:
+            await lease.release()
+            await b.stop()
+
+    def test_bootstrap_wires_fault_reporter_pin(self):
+        src = (
+            _REPO / "backend/audio/audio_pipeline_bootstrap.py"
+        ).read_text()
+        assert src.count("on_hardware_fault") >= 2   # lease + pre-mount paths
+        assert "publish_hardware_fault" in src
+        assert "on_flush=_on_flush" in src
+
+
+_REPO = Path(__file__).resolve().parents[2]


### PR DESCRIPTION
## Summary
Three authorized edge-case layers, all extending the existing lease vocabulary (no new transport):

1. **Lease Preemption + PTT** — `LEASE_CMDS += acquire_preempt / ptt_start / ptt_end / flush`. FORCE_WAKE revokes the incumbent over the heartbeat return channel (`reason:"preempted"` → its footer morphs to `voice: held by another terminal`, state `HELD`, no auto-re-acquire mic war). Hardware stays **armed through the transfer** — one continuous stream, arm invoked exactly once. PTT is an ephemeral preempting hold; `ptt_end` fully releases; a stray `ptt_end` never disarms a standing lease. TUI verbs: `wake!`, `ptt`, `ptt stop`.
2. **Hardware Topology Survival** — root cause found at `arbiter._speak`: a CoreAudio device-vanish exception *already existed* and was silently swallowed. The arbiter gains an injected `on_hardware_fault` reporter (loop always survives; FSM resets in `finally`). Bootstrap wires it on both mount paths → `publish_hardware_fault`: revoke holder (`reason:"hw_fault"`), disarm via the lease seam (tears down the dead stream), broadcast `HW_FAULT` (clears every presentation boolean). TUI renders `UNAVAILABLE`. No process restart needed — the supervisor survives any device topology change.
3. **TTS Interruption (ducking)** — `arbiter.flush()`: sync instantaneous halt (preempt playback, cancel play task, clear all queues, FSM → LISTENING). Holder-only `flush` cmd + `AUDIO_IDLE` broadcast; bystanders can't silence the holder. `ov attach` auto-flushes when the operator submits a command while Karen is THINKING/SPEAKING — the human always owns the floor.

## Testing
24 tests in `test_audio_lease_broker.py` (11 new), including **mandate 4 verbatim**: mocked audio stream read failure during an active lease → fault reported, lease gracefully dropped, daemon broker alerted, supervisor event loop keeps serving new clients. Plus: preemption continuity (`arm called once`), PTT full cycle, stray-`ptt_end` defense, holder-only flush, HELD mapping, ducking predicate. 104-test sweep green; 1 pre-existing unrelated red (narrator module-deletion pin, fails at baseline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add lease preemption and push-to-talk to the audio lease, add a holder-only TTS flush (ducking), and make the supervisor survive hardware device changes without restarts. Operators can take the floor instantly, and the system stays stable across device topology changes.

- New Features
  - Lease preemption and PTT: added `acquire_preempt`, `ptt_start`, `ptt_end`, `flush`. Incumbent gets `reason:"preempted"` and morphs to `HELD` (no auto re-acquire); hardware stays armed through transfer. PTT fully releases on `ptt_end`; stray `ptt_end` never disarms a standing lease.
  - TTS flush: holder-only `flush` halts playback now, cancels queued speech, and broadcasts `AUDIO_IDLE`. `ov attach` auto-flushes when the operator types during THINKING/SPEAKING. New TUI verbs: `wake!`/`force-wake`, `ptt`, `ptt stop`, `flush`. Toolbar notes “held by another terminal” on `HELD`.
  - Hardware topology survival: arbiter exposes `on_hardware_fault`; bootstrap wires it to `publish_hardware_fault`. On device vanish, revoke holder with `reason:"hw_fault"`, disarm via the lease seam, broadcast `HW_FAULT`, and render `UNAVAILABLE`. Supervisor loop keeps running.

- Bug Fixes
  - Fixed swallowed playback stream errors in the arbiter so hardware faults are reported, the FSM resets to LISTENING, and the loop continues; added basic fault telemetry.

<sup>Written for commit b7ab38608e490ea893b2c5cdd8a6e5f041780a2d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69940?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

