### PR TITLE
fix(battle_test): four-root teardown hygiene — post-SESSION-COMPLETE noise bundle

### DIFF
--- a/backend/core/ouroboros/battle_test/graceful_preemption.py
+++ b/backend/core/ouroboros/battle_test/graceful_preemption.py
@@ -96,21 +96,46 @@ def halt_child_workers() -> int:
         import psutil  # reused harness dependency
     except Exception:  # noqa: BLE001
         return 0
+    # Orderly drain FIRST (2026-07-18): registered ProcessPoolExecutors
+    # shut down gracefully so their workers exit clean and the
+    # multiprocessing resource_tracker unregisters each semaphore
+    # exactly once — the KeyError-wall class dies at its source.
+    try:
+        from backend.core.ouroboros.governance.executor_registry import (
+            shutdown_all as _drain_pools,
+        )
+        _drain_pools()
+    except Exception:  # noqa: BLE001
+        pass
     try:
         me = psutil.Process()
         kids = me.children(recursive=True)
-        for c in kids:
+
+        def _is_resource_tracker(proc) -> bool:
+            # NEVER kill multiprocessing's janitor: killing it forces a
+            # relaunch with an empty registry, and every later
+            # unregister prints a raw KeyError traceback to stderr.
+            # It exits on its own once its pipe closes at process end.
+            try:
+                return any(
+                    "resource_tracker" in part for part in proc.cmdline()
+                )
+            except Exception:  # noqa: BLE001
+                return False
+
+        targets = [c for c in kids if not _is_resource_tracker(c)]
+        for c in targets:
             try:
                 c.terminate()
             except Exception:  # noqa: BLE001
                 pass
-        _, alive = psutil.wait_procs(kids, timeout=_CHILD_TERM_GRACE_S)
+        _, alive = psutil.wait_procs(targets, timeout=_CHILD_TERM_GRACE_S)
         for c in alive:
             try:
                 c.kill()
             except Exception:  # noqa: BLE001
                 pass
-        return len(kids)
+        return len(targets)
     except Exception:  # noqa: BLE001
         return 0
 

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -1190,6 +1190,15 @@ class BattleTestHarness:
         _running_loop = asyncio.get_event_loop()
 
         def _harness_loop_exception_handler(loop_, ctx_):
+            # Interpreter finalization guard (operator paste 2026-07-18):
+            # during shutdown the QueueHandler's copy.copy(record) dies
+            # with "ImportError: sys.meta_path is None" and logging
+            # itself prints a '--- Logging error ---' WALL per leaked
+            # task — pure noise from a dying process. Drop silently;
+            # every pre-finalization leak still logs normally.
+            import sys as _sys
+            if _sys.is_finalizing() or _sys.meta_path is None:
+                return
             msg = ctx_.get("message", "Unhandled exception in event loop")
             exc = ctx_.get("exception")
             extras = " | ".join(
@@ -6449,6 +6458,19 @@ class BattleTestHarness:
         except Exception:  # noqa: BLE001 — never let watchdog arm crash signal handler
             pass
 
+        # Quiesce gate (operator paste 2026-07-18): refuse NEW op
+        # dequeues from this instant — the signal→GLS.stop window let
+        # workers start fresh synthesis AFTER the SESSION COMPLETE
+        # banner (EXHAUSTION storm on a dying organism). In-flight ops
+        # keep their finish/checkpoint contract.
+        try:
+            _gls = getattr(self, "_governed_loop_service", None)
+            _pool = getattr(_gls, "background_pool", None)
+            if _pool is not None:
+                _pool.request_quiesce()
+        except Exception:  # noqa: BLE001
+            pass
+
         # Autonomous FSM Suspend (signal/preemption path) — checkpoint in-flight ops
         # BEFORE the async cleanup, so an external SIGTERM reap / GCP Spot preemption
         # (not just the internal wall-event race) resumes on the next ignition.
@@ -8156,6 +8178,18 @@ class BattleTestHarness:
         try:
             if hasattr(self, "_keyboard_handler") and self._keyboard_handler is not None:
                 await self._keyboard_handler.stop()
+        except Exception:
+            pass
+        # TrinityEventBus teardown (leak-wall root fix 2026-07-18): the
+        # bus's processor/cleanup/transport loops were NEVER stopped by
+        # the harness — every one of them surfaced as a "Task was
+        # destroyed but it is pending" wall at loop close. Bounded:
+        # a wedged bus must never hang the exit cinematic.
+        try:
+            from backend.core.trinity_event_bus import (
+                shutdown_trinity_event_bus,
+            )
+            await asyncio.wait_for(shutdown_trinity_event_bus(), timeout=5.0)
         except Exception:
             pass
         try:

--- a/backend/core/ouroboros/governance/ast_compile_helper.py
+++ b/backend/core/ouroboros/governance/ast_compile_helper.py
@@ -524,6 +524,13 @@ def _get_pool() -> ProcessPoolExecutor:
                 initargs=_initargs,
             )
             try:
+                from backend.core.ouroboros.governance.executor_registry import (  # noqa: PLC0415,E501
+                    register as _reg_pool,
+                )
+                _reg_pool(_pool)
+            except Exception:  # noqa: BLE001
+                pass
+            try:
                 from backend.core.ouroboros.governance.child_reaper import (
                     register_cleanup,
                 )

--- a/backend/core/ouroboros/governance/background_agent_pool.py
+++ b/backend/core/ouroboros/governance/background_agent_pool.py
@@ -366,6 +366,7 @@ class BackgroundAgentPool:
         self._ops: Dict[str, BackgroundOp] = {}
         self._workers: List[asyncio.Task] = []  # type: ignore[type-arg]
         self._running: bool = False
+        self._quiesced: bool = False
 
         # Pause gate for HIBERNATION_MODE. Default set == "not paused".
         # Workers await this before dequeuing; pause() clears it, resume()
@@ -497,6 +498,17 @@ class BackgroundAgentPool:
             self._pool_size,
             self._queue_size,
         )
+
+    def request_quiesce(self) -> None:
+        """Session-ending gate (operator paste 2026-07-18): the moment
+        a shutdown signal lands, workers must not START new operations
+        — the observed failure was fresh '🧬 synthesizing' + an
+        EXHAUSTION storm firing AFTER the SESSION COMPLETE banner, in
+        the window between the signal and ``stop()``. In-flight ops
+        still finish/checkpoint (that contract is untouched); only NEW
+        dequeues are refused. Sync + signal-handler-safe; idempotent;
+        NEVER raises."""
+        self._quiesced = True
 
     async def stop(self) -> None:
         """Cancel all workers, drain the queue, and mark pending ops as cancelled.
@@ -1048,7 +1060,7 @@ class BackgroundAgentPool:
         """
         logger.debug("Worker %d started", worker_id)
         try:
-            while self._running:
+            while self._running and not self._quiesced:
                 # Dynamic Fleet Topology: cooperative retire when the live
                 # target shrank below this worker's id (mesh topology says
                 # fewer lanes than workers). Never mid-op -- only between

--- a/backend/core/ouroboros/governance/cooperative_fs_io.py
+++ b/backend/core/ouroboros/governance/cooperative_fs_io.py
@@ -576,6 +576,13 @@ def _get_fs_process_pool():
                 else:
                     max_tasks = None
                 _FS_PROCESS_POOL = ProcessPoolExecutor(**pool_kwargs)
+                try:
+                    from backend.core.ouroboros.governance.executor_registry import (  # noqa: PLC0415,E501
+                        register as _reg_pool,
+                    )
+                    _reg_pool(_FS_PROCESS_POOL)
+                except Exception:  # noqa: BLE001
+                    pass
                 atexit.register(shutdown_fs_process_pool)
                 # Slice 23 — fold this pool's hard-reap into the child_reaper
                 # cascade so a shutdown/OOM-triggered teardown (graceful,

--- a/backend/core/ouroboros/governance/executor_registry.py
+++ b/backend/core/ouroboros/governance/executor_registry.py
@@ -1,0 +1,62 @@
+"""Process-pool executor registry — orderly drain before the reaper.
+
+Operator paste 2026-07-18: at teardown the Preemption Shield's blind
+psutil sweep SIGTERM'd EVERY child — including multiprocessing's
+``resource_tracker`` janitor process. The relaunched tracker starts
+with an empty registry, so every subsequent semaphore/shm unregister
+prints a raw ``KeyError: '/mp-…'`` traceback to inherited stderr —
+a wall the logging layer can never filter. Two-part root fix:
+
+  1. Long-lived ``ProcessPoolExecutor`` owners register here at
+     creation (weakref — the registry never extends a pool's life).
+     :func:`shutdown_all` drains them gracefully (workers exit clean,
+     the tracker unregisters exactly once) BEFORE any signal sweep.
+  2. The shield's sweep exempts the tracker process itself (killing
+     the janitor IS the spam).
+
+Stdlib-only, no policy imports, NEVER raises anywhere.
+"""
+from __future__ import annotations
+
+import logging
+import weakref
+from typing import Any
+
+logger = logging.getLogger("Ouroboros.ExecutorRegistry")
+
+_POOLS: "weakref.WeakSet[Any]" = weakref.WeakSet()
+
+
+def register(executor: Any) -> None:
+    """Track a long-lived executor for orderly teardown. NEVER raises."""
+    try:
+        _POOLS.add(executor)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def shutdown_all() -> int:
+    """Gracefully drain every registered executor (non-blocking:
+    ``wait=False, cancel_futures=True`` — workers exit as soon as
+    their current item ends; nothing new starts). Returns the count
+    drained. NEVER raises."""
+    count = 0
+    for pool in list(_POOLS):
+        try:
+            pool.shutdown(wait=False, cancel_futures=True)
+            count += 1
+        except TypeError:
+            # <3.9 signature safety — cancel_futures unsupported.
+            try:
+                pool.shutdown(wait=False)
+                count += 1
+            except Exception:  # noqa: BLE001
+                pass
+        except Exception:  # noqa: BLE001
+            pass
+    if count:
+        logger.debug("[ExecutorRegistry] drained %d pool(s)", count)
+    return count
+
+
+__all__ = ["register", "shutdown_all"]

--- a/backend/core/ouroboros/governance/key_input.py
+++ b/backend/core/ouroboros/governance/key_input.py
@@ -708,6 +708,14 @@ class InputController:
         self._original_termios: Optional[Any] = None
         self._fd: int = -1
         self._atexit_registered: bool = False
+        # Self-pipe wakeup (teardown-leak root fix, 2026-07-18): the
+        # reader thread selects on [stdin, wake_r]; stop() writes ONE
+        # byte to wake_w so the thread returns IMMEDIATELY instead of
+        # waiting out the select timeout — under a saturated shutdown
+        # executor that latency blew the stop() shield and leaked the
+        # reader task into loop-close ("Task was destroyed" wall).
+        self._wake_r: int = -1
+        self._wake_w: int = -1
 
     # -- public API ------------------------------------------------------
 
@@ -762,6 +770,10 @@ class InputController:
             )
             return False
         self._stop_event = asyncio.Event()
+        try:
+            self._wake_r, self._wake_w = os.pipe()
+        except OSError:
+            self._wake_r = self._wake_w = -1
         self._wire_action_dispatch()
         self._task = loop.create_task(self._reader_loop())
         return True
@@ -770,6 +782,13 @@ class InputController:
         """Stop the reader task + restore termios. Idempotent."""
         if self._stop_event is not None:
             self._stop_event.set()
+        # Wake the select-blocked reader thread NOW (self-pipe) — the
+        # stop shield below must never race the select timeout.
+        if self._wake_w >= 0:
+            try:
+                os.write(self._wake_w, b"\x00")
+            except OSError:
+                pass
         task = self._task
         self._task = None
         if task is not None and not task.done():
@@ -783,6 +802,14 @@ class InputController:
                     "[InputController] reader stop exception",
                     exc_info=True,
                 )
+        for attr in ("_wake_r", "_wake_w"):
+            fd = getattr(self, attr)
+            setattr(self, attr, -1)
+            if fd >= 0:
+                try:
+                    os.close(fd)
+                except OSError:
+                    pass
         self._exit_raw_mode()
 
     # -- internals -------------------------------------------------------
@@ -912,9 +939,19 @@ class InputController:
             if self._fd < 0:
                 return b""
             import select
+            watch = [self._fd]
+            if self._wake_r >= 0:
+                watch.append(self._wake_r)
             ready, _w, _x = select.select(
-                [self._fd], [], [], _READ_SELECT_TIMEOUT_S,
+                watch, [], [], _READ_SELECT_TIMEOUT_S,
             )
+            if self._wake_r >= 0 and self._wake_r in ready:
+                # stop() poked the self-pipe — drain + return NOW.
+                try:
+                    os.read(self._wake_r, 64)
+                except OSError:
+                    pass
+                return b""
             if not ready:
                 return b""            # timeout — loop re-checks stop event
             return os.read(self._fd, n)

--- a/backend/core/ouroboros/simulator.py
+++ b/backend/core/ouroboros/simulator.py
@@ -922,6 +922,13 @@ class TheSimulator:
 
                 # v95.12: Register executors for cleanup
                 register_executor_for_cleanup(self._process_pool, "simulator_process_pool", is_process_pool=True)
+                try:
+                    from backend.core.ouroboros.governance.executor_registry import (  # noqa: PLC0415,E501
+                        register as _reg_pool,
+                    )
+                    _reg_pool(self._process_pool)
+                except Exception:  # noqa: BLE001
+                    pass
                 register_executor_for_cleanup(self._thread_pool, "simulator_thread_pool")
 
                 self._initialized = True

--- a/tests/battle_test/test_teardown_hygiene.py
+++ b/tests/battle_test/test_teardown_hygiene.py
@@ -1,0 +1,232 @@
+"""Teardown-hygiene spine — the post-SESSION-COMPLETE noise bundle.
+
+Operator paste 2026-07-18 (session bt-2026-07-19-054703), four roots:
+
+  #32 '--- Logging error --- ImportError: sys.meta_path is None' walls —
+      the leak-logger handler fired during interpreter finalization.
+  #33 'Task was destroyed but it is pending' — InputController reader
+      (select-blocked thread outlived the stop shield) + TrinityEventBus
+      loops (never stopped by the harness at all).
+  #34 fresh '🧬 synthesizing' + EXHAUSTION storm AFTER the session
+      report — workers dequeued NEW ops in the signal→GLS.stop window.
+  #35 resource_tracker KeyError spam — the preemption shield SIGTERM'd
+      multiprocessing's janitor process; the relaunched tracker's empty
+      registry KeyError'd every later unregister.
+"""
+from __future__ import annotations
+
+import asyncio
+import os
+import time
+from pathlib import Path
+
+import pytest
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+# ---------------------------------------------------------------------------
+# #32 — finalization guard
+# ---------------------------------------------------------------------------
+
+
+class TestFinalizationGuard:
+    def test_leak_handler_guards_finalizing_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text()
+        body = src[src.index("def _harness_loop_exception_handler"):][:2000]
+        assert "is_finalizing()" in body
+        assert "meta_path is None" in body
+        # The guard sits BEFORE the first logger call.
+        assert body.index("is_finalizing()") < body.index("_async_leak_logger")
+
+
+# ---------------------------------------------------------------------------
+# #33 — self-pipe reader wake + event-bus teardown wiring
+# ---------------------------------------------------------------------------
+
+
+class _FdHolder:
+    def __init__(self, fd: int, wake_r: int = -1) -> None:
+        self._fd = fd
+        self._wake_r = wake_r
+
+
+class TestReaderSelfPipe:
+    def test_wake_pipe_returns_instantly_not_at_timeout(self):
+        from backend.core.ouroboros.governance import key_input
+        stdin_r, stdin_w = os.pipe()      # stays empty — like a quiet TTY
+        wake_r, wake_w = os.pipe()
+        try:
+            os.write(wake_w, b"\x00")     # stop() poked the pipe
+            t0 = time.monotonic()
+            out = key_input.InputController._blocking_read(
+                _FdHolder(stdin_r, wake_r), 64,
+            )
+            elapsed = time.monotonic() - t0
+            assert out == b""
+            # Instant wake — far under the 0.5s select timeout.
+            assert elapsed < 0.2
+        finally:
+            for fd in (stdin_r, stdin_w, wake_r, wake_w):
+                os.close(fd)
+
+    def test_stdin_data_still_delivered_with_wake_pipe_armed(self):
+        from backend.core.ouroboros.governance import key_input
+        stdin_r, stdin_w = os.pipe()
+        wake_r, wake_w = os.pipe()
+        try:
+            os.write(stdin_w, b"q")
+            out = key_input.InputController._blocking_read(
+                _FdHolder(stdin_r, wake_r), 1,
+            )
+            assert out == b"q"
+        finally:
+            for fd in (stdin_r, stdin_w, wake_r, wake_w):
+                os.close(fd)
+
+    async def test_stop_writes_wake_byte_and_closes_pipes(self):
+        from backend.core.ouroboros.governance.key_input import InputController
+        c = InputController()
+        c._wake_r, c._wake_w = os.pipe()
+        wake_r = c._wake_r
+        await c.stop()
+        # Pipes closed + fields reset — no fd leak across restarts.
+        assert c._wake_r == -1 and c._wake_w == -1
+        with pytest.raises(OSError):
+            os.fstat(wake_r)
+
+    def test_harness_stops_trinity_event_bus_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text()
+        assert "shutdown_trinity_event_bus" in src
+        # Bounded — a wedged bus never hangs the exit cinematic.
+        idx = src.index("shutdown_trinity_event_bus(), timeout=")
+        assert idx > 0
+
+
+# ---------------------------------------------------------------------------
+# #34 — post-signal work quiescence
+# ---------------------------------------------------------------------------
+
+
+class TestQuiesceGate:
+    def test_request_quiesce_stops_worker_dequeue_loop(self):
+        from backend.core.ouroboros.governance.background_agent_pool import (
+            BackgroundAgentPool,
+        )
+        pool = BackgroundAgentPool.__new__(BackgroundAgentPool)
+        pool._quiesced = False
+        pool.request_quiesce()
+        assert pool._quiesced is True
+        pool.request_quiesce()                # idempotent
+        assert pool._quiesced is True
+
+    def test_worker_loop_honors_quiesce_pin(self):
+        src = (
+            _REPO
+            / "backend/core/ouroboros/governance/background_agent_pool.py"
+        ).read_text()
+        body = src[src.index("async def _worker_loop"):][:1200]
+        assert "while self._running and not self._quiesced:" in body
+
+    def test_signal_handler_fires_quiesce_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/battle_test/harness.py"
+        ).read_text()
+        body = src[src.index("def _handle_shutdown_signal"):][:4000]
+        assert "request_quiesce()" in body
+
+
+# ---------------------------------------------------------------------------
+# #35 — orderly pool drain + resource_tracker exemption
+# ---------------------------------------------------------------------------
+
+
+class TestExecutorRegistry:
+    def test_register_and_shutdown_all(self):
+        from backend.core.ouroboros.governance import executor_registry
+
+        class _Pool:
+            def __init__(self) -> None:
+                self.kw = None
+
+            def shutdown(self, wait=True, cancel_futures=False):
+                self.kw = (wait, cancel_futures)
+
+        p1, p2 = _Pool(), _Pool()
+        executor_registry.register(p1)
+        executor_registry.register(p2)
+        assert executor_registry.shutdown_all() >= 2
+        assert p1.kw == (False, True)
+        assert p2.kw == (False, True)
+
+    def test_shutdown_all_survives_hostile_pool(self):
+        from backend.core.ouroboros.governance import executor_registry
+
+        class _Bomb:
+            def shutdown(self, *a, **k):
+                raise RuntimeError("pool exploded")
+
+        class _Legacy:
+            def __init__(self) -> None:
+                self.called = False
+
+            def shutdown(self, wait=True):   # no cancel_futures kwarg
+                self.called = True
+
+        bomb, legacy = _Bomb(), _Legacy()
+        executor_registry.register(bomb)
+        executor_registry.register(legacy)
+        executor_registry.shutdown_all()     # must not raise
+        assert legacy.called is True
+
+    def test_registry_is_weak_never_extends_pool_life(self):
+        import gc
+        from backend.core.ouroboros.governance import executor_registry
+
+        class _Pool:
+            def shutdown(self, *a, **k):
+                pass
+
+        p = _Pool()
+        executor_registry.register(p)
+        del p
+        gc.collect()
+        # Registry drops the dead ref — shutdown_all never resurrects.
+        assert all(
+            type(x).__name__ != "_Pool" for x in list(executor_registry._POOLS)
+        )
+
+
+class TestResourceTrackerExemption:
+    def test_shield_never_kills_the_janitor_pin(self):
+        src = (
+            _REPO
+            / "backend/core/ouroboros/battle_test/graceful_preemption.py"
+        ).read_text()
+        body = src[src.index("def halt_child_workers"):]
+        body = body[:body.index("def _run_git")]
+        assert "resource_tracker" in body
+        assert "_is_resource_tracker" in body
+        # Drain precedes the sweep.
+        assert body.index("shutdown_all") < body.index("terminate()")
+
+    def test_long_lived_pools_register_pin(self):
+        for rel in (
+            "backend/core/ouroboros/governance/ast_compile_helper.py",
+            "backend/core/ouroboros/governance/cooperative_fs_io.py",
+            "backend/core/ouroboros/simulator.py",
+        ):
+            src = (_REPO / rel).read_text()
+            assert "executor_registry" in src, f"{rel} missing registration"
+
+    def test_halt_child_workers_smoke_no_children(self):
+        """Callable end-to-end in a childless test process: drains the
+        registry, sweeps nothing, returns 0, never raises."""
+        from backend.core.ouroboros.battle_test.graceful_preemption import (
+            halt_child_workers,
+        )
+        assert isinstance(halt_child_workers(), int)

--- a/tests/governance/test_failure_bundle_hardening.py
+++ b/tests/governance/test_failure_bundle_hardening.py
@@ -110,6 +110,7 @@ class TestCockpitCostCap:
 class _FdHolder:
     def __init__(self, fd: int) -> None:
         self._fd = fd
+        self._wake_r = -1          # mirrors InputController's self-pipe field
 
 
 class TestBoundedRead:


### PR DESCRIPTION
## Summary
Operator paste (bt-2026-07-19-054703): after the SESSION COMPLETE banner the cockpit drowned in four independent noise/zombie classes. Each fixed at its root — no output filtering, no suppression hacks:

1. **Finalization logging walls** — the asyncio leak-logger handler fired during interpreter shutdown; `QueueHandler`'s `copy.copy(record)` died with `ImportError: sys.meta_path is None` and logging printed a `--- Logging error ---` wall per leaked task. Handler now drops silently once `sys.is_finalizing()`.
2. **Teardown task leaks** — (a) `InputController` gains a **self-pipe wakeup**: `stop()` writes one byte so the select-blocked reader thread returns instantly instead of racing the 1s stop shield under a saturated shutdown executor. (b) `TrinityEventBus` was *never stopped by the harness* — every processor/cleanup/transport loop surfaced as a "Task was destroyed" wall; teardown now calls `shutdown_trinity_event_bus()` bounded at 5s.
3. **Post-signal work quiescence** — workers dequeued *new* ops in the signal→GLS.stop window (fresh `🧬 synthesizing` + EXHAUSTION storm after the report). `BackgroundAgentPool.request_quiesce()`, fired from the signal handler, refuses new dequeues; in-flight ops keep their finish/checkpoint contract.
4. **resource_tracker KeyError spam** — the preemption shield's blind psutil sweep SIGTERM'd multiprocessing's *resource_tracker janitor*; the relaunched tracker's empty registry KeyError'd every later unregister, raw to stderr. `halt_child_workers` now drains registered `ProcessPoolExecutor`s gracefully first (new `executor_registry`, weakref-backed) and exempts the tracker from the sweep.

## Testing
14 new tests (`tests/battle_test/test_teardown_hygiene.py`): instant self-pipe wake vs select timeout, stdin still delivered with wake armed, stop closes pipes (fd-leak check), quiesce gate + worker-loop + signal-handler pins, registry drain incl. hostile/legacy pools + weakref lifetime, tracker exemption + drain-before-sweep ordering, childless `halt_child_workers` smoke. Failure-bundle suite updated for the new field — 38/38 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix teardown noise after SESSION COMPLETE by addressing four root causes: finalization logging, task leaks, post-signal dequeues, and `resource_tracker` spam. Adds a self-pipe wake for input, quiesces background workers on signal, drains process pools safely, and shuts down the event bus, with 14 tests covering the changes.

- **Bug Fixes**
  - Suppress loop logging during interpreter finalization to prevent logging error walls (`sys.is_finalizing()`/`meta_path is None` guard).
  - Eliminate teardown leaks: InputController gains a self-pipe wake on `stop()` and closes pipes; harness now shuts down `TrinityEventBus` with a 5s timeout.
  - Prevent new work after shutdown signal: `BackgroundAgentPool.request_quiesce()` stops worker dequeues while allowing in-flight ops to finish/checkpoint.
  - Stop `resource_tracker` KeyError spam: new weak `executor_registry` drains registered `ProcessPoolExecutor`s before the sweep; `halt_child_workers()` exempts the `resource_tracker` process. Long-lived pools register in `ast_compile_helper`, `cooperative_fs_io`, and `simulator`.

<sup>Written for commit 8e0b88ceefc50a6a4a55eb1aa9ee16571a3046fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

