### PR TITLE
feat(ui,audio): crest geometry polish + Semantic Interruption Awareness

### DIFF
--- a/backend/audio/audio_pipeline_bootstrap.py
+++ b/backend/audio/audio_pipeline_bootstrap.py
@@ -215,6 +215,19 @@ async def wire_conversation_pipeline(
             # this) and lazy-builds over the SAME factory when voice
             # wasn't pre-mounted — sovereignty never leaves this
             # process; the broadcaster only relays the verb.
+            def _wire_interruption_reporter() -> None:
+                # Semantic Interruption Awareness: barge-in/flush cuts
+                # route the truncation estimate into ConversationBridge
+                # so the next GENERATE knows the narration was cut off.
+                try:
+                    from backend.core.ouroboros.governance.conversation_bridge import (  # noqa: E501
+                        record_barge_in,
+                    )
+                    if handle.karen is not None:
+                        handle.karen.arbiter.on_interruption = record_barge_in
+                except Exception:
+                    pass
+
             async def _on_lease_change(armed: bool) -> None:
                 try:
                     if armed:
@@ -241,6 +254,7 @@ async def wire_conversation_pipeline(
                                 )
                             except Exception:
                                 pass
+                            _wire_interruption_reporter()
                             await handle.karen.start()
                             logger.info("[Bootstrap] audio lease ARMED")
                     else:
@@ -303,6 +317,13 @@ async def wire_conversation_pipeline(
                         lambda exc: handle.audio_ipc.publish_hardware_fault(str(exc))  # noqa: E501
                         if handle.audio_ipc is not None else None
                     )
+            except Exception:
+                pass
+            try:
+                from backend.core.ouroboros.governance.conversation_bridge import (  # noqa: E501
+                    record_barge_in as _rbi,
+                )
+                handle.karen.arbiter.on_interruption = _rbi
             except Exception:
                 pass
             logger.info("[Bootstrap] Karen full-duplex control layer mounted")

--- a/backend/core/ouroboros/governance/comms/duplex/arbiter.py
+++ b/backend/core/ouroboros/governance/comms/duplex/arbiter.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from collections import deque
 from typing import Callable, Deque, Dict, Optional
 
@@ -44,6 +45,20 @@ class VoiceDuplexArbiter:
         #: draining). Sync callable; never awaited on the audio path.
         self.on_hardware_fault: Optional[Callable[[BaseException], None]] = None
         self.hardware_fault_count = 0
+        #: Semantic Interruption Awareness (operator-authorized
+        #: 2026-07-18): when a barge-in / flush cuts Karen off
+        #: mid-utterance, the injected reporter receives
+        #: ``(full_text, est_delivered_chars, cause)`` so the prompt
+        #: plane can tell the LLM it was CUT OFF — otherwise the model
+        #: hallucinates having delivered the full payload. Truncation
+        #: is estimated from elapsed speech time × chars/sec
+        #: (``JARVIS_TTS_CHARS_PER_S``, default 15.0 — human-paced
+        #: synthesis; no per-engine hardcoding).
+        self.on_interruption: Optional[
+            Callable[[str, int, str], None]
+        ] = None
+        self._active_text: str = ""
+        self._speak_started_mono: float = 0.0
 
     @property
     def state(self) -> VoiceState:
@@ -113,6 +128,8 @@ class VoiceDuplexArbiter:
     async def _speak(self, req: SpeechRequest) -> None:
         self._state = VoiceState.KAREN_SPEAKING
         self._active_priority = req.priority
+        self._active_text = req.text
+        self._speak_started_mono = asyncio.get_event_loop().time()
         self._play_task = asyncio.create_task(self._playback.play(req.text))
         try:
             await self._play_task
@@ -139,12 +156,40 @@ class VoiceDuplexArbiter:
                 self._state = VoiceState.LISTENING
             self._active_priority = None
 
+    def _report_interruption(self, cause: str) -> None:
+        """Estimate the truncation point of the active utterance and
+        report it (Semantic Interruption Awareness). NEVER raises."""
+        try:
+            text = self._active_text
+            if not text:
+                return
+            self._active_text = ""
+            try:
+                rate = float(os.environ.get("JARVIS_TTS_CHARS_PER_S", "15.0"))
+            except (TypeError, ValueError):
+                rate = 15.0
+            rate = max(1.0, min(60.0, rate))
+            try:
+                elapsed = max(
+                    0.0,
+                    asyncio.get_event_loop().time() - self._speak_started_mono,
+                )
+            except Exception:  # noqa: BLE001
+                elapsed = 0.0
+            delivered = max(0, min(len(text), int(elapsed * rate)))
+            cb = self.on_interruption
+            if cb is not None:
+                cb(text, delivered, cause)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Arbiter] interruption report degraded", exc_info=True)
+
     async def on_user_speech_start(self) -> None:
         """Barge-in trigger. Preempts Karen and holds the floor. Never raises."""
         if not self._config.barge_in_enabled:
             return
         try:
             if self._state == VoiceState.KAREN_SPEAKING:
+                self._report_interruption("vad_barge_in")
                 self._playback.preempt()          # kill playback (idempotent)
                 if self._play_task is not None:
                     self._play_task.cancel()
@@ -166,6 +211,8 @@ class VoiceDuplexArbiter:
         buffer, cancel the play task, drop EVERY queued utterance, and
         reset the FSM to LISTENING. Sync + non-blocking so the IPC
         lane can invoke it inline. Idempotent; NEVER raises."""
+        if self._state == VoiceState.KAREN_SPEAKING:
+            self._report_interruption("operator_flush")
         try:
             self._playback.preempt()
         except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/conversation_bridge.py
+++ b/backend/core/ouroboros/governance/conversation_bridge.py
@@ -73,6 +73,7 @@ SOURCE_ASK_HUMAN_Q = "ask_human_q"
 SOURCE_ASK_HUMAN_A = "ask_human_a"
 SOURCE_POSTMORTEM = "postmortem"
 SOURCE_VOICE = "voice"
+SOURCE_BARGE_IN = "barge_in"
 
 _ALLOWED_SOURCES = frozenset({
     SOURCE_TUI_USER,
@@ -80,6 +81,7 @@ _ALLOWED_SOURCES = frozenset({
     SOURCE_ASK_HUMAN_A,
     SOURCE_POSTMORTEM,
     SOURCE_VOICE,
+    SOURCE_BARGE_IN,
 })
 
 # Source-category groupings used by subheader rendering. Each group gets
@@ -90,7 +92,64 @@ _SUBHEADER_ORDER: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
     ("### TUI user intent", (SOURCE_TUI_USER, SOURCE_VOICE)),
     ("### Clarifications (recent)", (SOURCE_ASK_HUMAN_Q, SOURCE_ASK_HUMAN_A)),
     ("### Prior op closure (postmortem)", (SOURCE_POSTMORTEM,)),
+    ("### Delivery interruptions", (SOURCE_BARGE_IN,)),
 )
+
+def record_barge_in(
+    full_text: str,
+    delivered_chars: int,
+    cause: str = "barge_in",
+    *,
+    op_id: str = "",
+) -> bool:
+    """Semantic Interruption Awareness (operator-authorized 2026-07-18):
+    admit ONE structured barge-in marker so the model structurally
+    knows its spoken narration was CUT OFF — otherwise the next
+    GENERATE hallucinates having delivered the full payload.
+
+    The marker is a discrete system token carrying the approximate
+    truncation point and the undelivered tail (bounded), rendered into
+    the CONTEXT_EXPANSION prompt under ``### Delivery interruptions``.
+    Flows through the SAME sanitize → cap → ring path as every other
+    turn (Tier -1 sanitizer included — the undelivered tail is model-
+    authored text re-entering a prompt). Returns True iff recorded.
+    NEVER raises.
+    """
+    try:
+        if not _is_enabled():
+            return False
+        full_text = str(full_text or "")
+        if not full_text.strip():
+            return False
+        n = len(full_text)
+        delivered = max(0, min(n, int(delivered_chars)))
+        pct = int(round(100.0 * delivered / n)) if n else 0
+        tail = full_text[delivered:][:160]
+        marker = (
+            "[SYSTEM: OPERATOR_BARGE_IN_DETECTED — spoken narration "
+            f"truncated at ~{pct}% ({delivered}/{n} chars, "
+            f"cause={str(cause or 'barge_in')[:32]}). UNDELIVERED tail: "
+            f"“{tail}”. Do not assume the operator heard the "
+            "full message.]"
+        )
+        bridge = get_default_bridge()
+        # Closed role vocabulary is ("user", "assistant") — the marker
+        # describes the ASSISTANT's own truncated delivery; the
+        # [SYSTEM: …] prefix carries the semantic class.
+        bridge.record_turn(
+            role="assistant",
+            text=marker,
+            source=SOURCE_BARGE_IN,
+            op_id=str(op_id or ""),
+        )
+        return True
+    except Exception:  # pragma: no cover — defensive (NEVER raises)
+        logger.debug(
+            "[ConversationBridge] record_barge_in dropped by internal error",
+            exc_info=True,
+        )
+        return False
+
 
 # ---------------------------------------------------------------------------
 # Env configuration

--- a/backend/core/ouroboros/ui/awakening.py
+++ b/backend/core/ouroboros/ui/awakening.py
@@ -327,6 +327,25 @@ class AwakeningConductor:
         except Exception:  # noqa: BLE001
             self._last_size = None
 
+        # Viewport guard (operator paste 2026-07-18): Rich's transient
+        # Live can only ERASE rows still inside the viewport — when the
+        # animated frame (crest + header) is taller than the terminal,
+        # rows scroll out mid-ceremony and the erase leaves stale crest
+        # fragments duplicated in scrollback (the "floating ▀▀▀▀▄▄
+        # pairs" artifact). If the frame can't fit with margin, skip
+        # the animation structurally and print the static emblem once —
+        # never a raw-ANSI overwrite hack.
+        try:
+            if self._last_size is not None:
+                _rows_needed = frame.rows + 6      # crest + header lines
+                if self._last_size[1] < _rows_needed:
+                    from .crest import render_crest_auto as _rca
+                    self._console.print(_rca(frame, tier))
+                    self._print_cooled_header()
+                    return
+        except Exception:  # noqa: BLE001
+            pass
+
         reader_cm: Optional[_StdinKeyReader] = None
         poll = self._key_source
         if poll is None:

--- a/backend/core/ouroboros/ui/crest.py
+++ b/backend/core/ouroboros/ui/crest.py
@@ -559,6 +559,101 @@ def _sample_pixel(
     return kind, inside / n, theta
 
 
+def _min_component_px() -> int:
+    try:
+        return max(0, int(os.environ.get(
+            "JARVIS_OV_CREST_MIN_COMPONENT_PX", "12",
+        )))
+    except (TypeError, ValueError):
+        return 12
+
+
+def _min_apex_row_px() -> int:
+    try:
+        return max(0, int(os.environ.get(
+            "JARVIS_OV_CREST_MIN_ROW_PX", "3",
+        )))
+    except (TypeError, ValueError):
+        return 3
+
+
+def _prune_sparse_geometry(
+    pixels: "Dict[Tuple[int, int], Any]",
+) -> "Dict[Tuple[int, int], Any]":
+    """Geometry Polish (operator mandate 2026-07-18): two mathematical
+    density clips on the raster — no terminal overwrites, no per-glyph
+    hacks.
+
+    1. **Detached-component clip**: any 8-connected pixel cluster
+       smaller than ``JARVIS_OV_CREST_MIN_COMPONENT_PX`` is removed
+       (the largest component ALWAYS survives — the body can never
+       delete itself on a tiny terminal).
+    2. **Apex row-density clip**: walking inward from the top and
+       bottom edges, rows thinner than ``JARVIS_OV_CREST_MIN_ROW_PX``
+       are shed until the first dense row — the 1-pixel tail whisker
+       that read as floating debris. Interior thin rows are untouched
+       (gaps between coil arcs are design, not debris).
+
+    Pure; NEVER raises; returns the input on any fault.
+    """
+    try:
+        if not pixels:
+            return pixels
+        coords = set(pixels.keys())
+        # -- (1) connected components (8-neighbour) --
+        min_comp = _min_component_px()
+        seen: set = set()
+        components = []
+        for start in coords:
+            if start in seen:
+                continue
+            stack, comp = [start], set()
+            while stack:
+                p = stack.pop()
+                if p in seen:
+                    continue
+                seen.add(p)
+                comp.add(p)
+                x, y = p
+                for dx in (-1, 0, 1):
+                    for dy in (-1, 0, 1):
+                        q = (x + dx, y + dy)
+                        if q in coords and q not in seen:
+                            stack.append(q)
+            components.append(comp)
+        if components:
+            largest = max(components, key=len)
+            keep = set().union(*(
+                c for c in components
+                if c is largest or len(c) >= min_comp
+            ))
+        else:
+            keep = coords
+        # -- (2) apex row-density clip (edges inward only) --
+        min_row = _min_apex_row_px()
+        if min_row > 0 and keep:
+            rows_px: Dict[int, int] = {}
+            for (_x, y) in keep:
+                rows_px[y] = rows_px.get(y, 0) + 1
+            ys = sorted(rows_px)
+            shed: set = set()
+            for y in ys:                       # top edge inward
+                if rows_px[y] < min_row:
+                    shed.add(y)
+                else:
+                    break
+            for y in reversed(ys):             # bottom edge inward
+                if rows_px[y] < min_row:
+                    shed.add(y)
+                else:
+                    break
+            if len(shed) < len(ys):            # never shed the whole mark
+                keep = {p for p in keep if p[1] not in shed}
+        return {p: v for p, v in pixels.items() if p in keep}
+    except Exception:  # noqa: BLE001
+        return pixels
+
+
 @functools.lru_cache(maxsize=8)
 def _generate_pixels_cached(clamped_cols: int, rows: int) -> PixelFrame:
     geo = _Geometry.for_size(clamped_cols, rows)
@@ -583,6 +678,7 @@ def _generate_pixels_cached(clamped_cols: int, rows: int) -> PixelFrame:
             )
             pixels[(x, py)] = (rgb, delay)  # type: ignore[assignment]
             max_delay = max(max_delay, delay)
+    pixels = _prune_sparse_geometry(pixels)
     return PixelFrame(
         cols=clamped_cols, rows=rows, px_rows=px_rows,
         pixels=pixels, max_delay_s=max_delay,
@@ -616,7 +712,12 @@ def pixels_to_text(
         from rich.text import Text
         cutoff = float("inf") if elapsed is None else elapsed
         text = Text()
-        for cy in range(pf.rows):
+        # Trim rows emptied by the sparse-geometry clip (a leading
+        # blank line is dead space above the emblem, not margin).
+        occupied = [py // 2 for py in {p[1] for p in pf.pixels}]
+        cy_lo = min(occupied) if occupied else 0
+        cy_hi = max(occupied) if occupied else pf.rows - 1
+        for cy in range(cy_lo, cy_hi + 1):
             for x in range(pf.cols):
                 top = pf.pixels.get((x, cy * 2))
                 bot = pf.pixels.get((x, cy * 2 + 1))
@@ -642,7 +743,7 @@ def pixels_to_text(
                 else:
                     br, bg_, bb = bot[0]  # type: ignore[index]
                     text.append("▄", style=f"rgb({br},{bg_},{bb})")
-            if cy < pf.rows - 1:
+            if cy < cy_hi:
                 text.append("\n")
         return text
     except Exception:  # noqa: BLE001

--- a/tests/battle_test/test_audio_visual_synapse.py
+++ b/tests/battle_test/test_audio_visual_synapse.py
@@ -164,7 +164,14 @@ class _FakeHandle:
 
 
 class TestAudioVisualSynapse:
-    async def test_wake_without_duplex_answers_unavailable(self):
+    async def test_wake_without_duplex_answers_unavailable(
+        self, sock_dir, monkeypatch,
+    ):
+        # Isolate from any LIVE supervisor socket on this machine — the
+        # broker path (v2) would otherwise genuinely acquire a lease.
+        monkeypatch.setenv(
+            "JARVIS_AUDIO_IPC_SOCKET", str(sock_dir / "absent.sock"),
+        )
         out: list = []
         syn = AudioVisualSynapse(out.append, handle_resolver=lambda: None)
         await syn.handle_cmd("wake")

--- a/tests/governance/test_semantic_interruption.py
+++ b/tests/governance/test_semantic_interruption.py
@@ -1,0 +1,236 @@
+"""Semantic Interruption Awareness + Crest Geometry Polish spine.
+
+Operator authorization 2026-07-18:
+
+  * A barge-in / flush must not merely halt audio — the prompt plane
+    must structurally learn the narration was CUT OFF (marker with
+    approximate truncation) so the next GENERATE never hallucinates a
+    fully-delivered payload. Channel: ConversationBridge (the existing
+    sanitized dialogue→CONTEXT_EXPANSION lane; GapSignalBus was
+    evaluated and rejected — it is the typed CapabilityGapEvent intake
+    bus, and routing markers through it would forge gap signals).
+  * Crest raster gains mathematical density clips: detached
+    sub-threshold components pruned, apex whisker rows shed; the
+    ceremony skips animation entirely when the frame exceeds the
+    viewport (the stale-Live duplication artifact).
+"""
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex.arbiter import (
+    VoiceDuplexArbiter,
+)
+from backend.core.ouroboros.governance.comms.duplex.protocols import (
+    ArbiterConfig,
+    Priority,
+    SpeechRequest,
+    VoiceState,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+_CFG = ArbiterConfig(
+    enabled=True, barge_in_enabled=True, proactive_enabled=True,
+)
+
+
+class _SlowPlayback:
+    def __init__(self) -> None:
+        self.preempts = 0
+
+    def preempt(self) -> None:
+        self.preempts += 1
+
+    async def play(self, _text: str) -> None:
+        await asyncio.sleep(3600)
+
+
+async def _speaking_arbiter(text: str = "the full narration payload " * 4):
+    arb = VoiceDuplexArbiter(_SlowPlayback(), config=_CFG)
+    run = asyncio.get_running_loop().create_task(arb.run())
+    arb.submit(SpeechRequest(text, Priority.PROACTIVE_INFO))
+    for _ in range(100):
+        if arb.state == VoiceState.KAREN_SPEAKING:
+            break
+        await asyncio.sleep(0.01)
+    assert arb.state == VoiceState.KAREN_SPEAKING
+    return arb, run
+
+
+async def _teardown(arb, run):
+    await arb.stop()
+    run.cancel()
+    try:
+        await run
+    except (asyncio.CancelledError, Exception):
+        pass
+
+
+# ---------------------------------------------------------------------------
+# (1) The arbiter interruption seams
+# ---------------------------------------------------------------------------
+
+
+class TestArbiterInterruption:
+    async def test_flush_reports_truncation_and_halts_buffer(self):
+        arb, run = await _speaking_arbiter()
+        reports: list = []
+        arb.on_interruption = lambda t, d, c: reports.append((t, d, c))
+        try:
+            await asyncio.sleep(0.25)
+            arb.flush()
+            assert arb._playback.preempts == 1        # buffer halted
+            assert len(reports) == 1
+            text, delivered, cause = reports[0]
+            assert cause == "operator_flush"
+            assert 0 <= delivered < len(text)          # truncated, not full
+        finally:
+            await _teardown(arb, run)
+
+    async def test_vad_barge_in_reports_with_distinct_cause(self):
+        arb, run = await _speaking_arbiter()
+        reports: list = []
+        arb.on_interruption = lambda t, d, c: reports.append(c)
+        try:
+            await arb.on_user_speech_start()
+            assert reports == ["vad_barge_in"]
+        finally:
+            await _teardown(arb, run)
+
+    async def test_truncation_estimate_scales_with_rate(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TTS_CHARS_PER_S", "60")
+        arb, run = await _speaking_arbiter("x" * 400)
+        reports: list = []
+        arb.on_interruption = lambda t, d, c: reports.append(d)
+        try:
+            await asyncio.sleep(0.5)
+            arb.flush()
+            delivered = reports[0]
+            # ~0.5s at 60 chars/s ≈ 30 chars (generous CI bounds).
+            assert 5 <= delivered <= 120
+        finally:
+            await _teardown(arb, run)
+
+    async def test_no_report_when_idle_and_reporter_faults_contained(self):
+        arb = VoiceDuplexArbiter(_SlowPlayback(), config=_CFG)
+        calls: list = []
+        arb.on_interruption = lambda *a: calls.append(a)
+        arb.flush()                        # idle — nothing was speaking
+        assert calls == []
+        arb._active_text = "mid-flight"
+        arb._state = VoiceState.KAREN_SPEAKING
+        arb.on_interruption = lambda *a: (_ for _ in ()).throw(RuntimeError())
+        arb.flush()                        # hostile reporter: must not raise
+
+
+# ---------------------------------------------------------------------------
+# (2) MANDATE 4 VERBATIM — flush + marker lands before the next GENERATE
+# ---------------------------------------------------------------------------
+
+
+class TestBargeMarkerReachesPromptPlane:
+    async def test_tts_interruption_appends_marker_to_context_channel(
+        self, monkeypatch,
+    ):
+        """Mock a TTS interruption: audio buffer flushed AND the
+        barge-in semantic marker is present in the composed
+        CONTEXT_EXPANSION prompt (the prompt history the next GENERATE
+        consumes)."""
+        monkeypatch.setenv("JARVIS_CONVERSATION_BRIDGE_ENABLED", "true")
+        from backend.core.ouroboros.governance import conversation_bridge as cb
+        cb.reset_default_bridge()
+        try:
+            arb, run = await _speaking_arbiter(
+                "Deploying the fix now; three files will change and the "
+                "regression suite will re-run automatically afterwards.",
+            )
+            arb.on_interruption = cb.record_barge_in   # production wiring
+            try:
+                await asyncio.sleep(0.2)
+                arb.flush()
+                assert arb._playback.preempts == 1     # (a) buffer flushed
+            finally:
+                await _teardown(arb, run)
+            prompt = cb.get_default_bridge().format_for_prompt()
+            assert prompt is not None
+            assert "OPERATOR_BARGE_IN_DETECTED" in prompt      # (b) marker
+            assert "Do not assume the operator heard" in prompt
+            assert "Delivery interruptions" in prompt
+        finally:
+            cb.reset_default_bridge()
+
+    async def test_marker_disabled_bridge_is_silent_noop(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CONVERSATION_BRIDGE_ENABLED", "false")
+        from backend.core.ouroboros.governance import conversation_bridge as cb
+        assert cb.record_barge_in("some text", 3, "flush") is False
+
+    def test_marker_carries_truncation_math(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CONVERSATION_BRIDGE_ENABLED", "true")
+        from backend.core.ouroboros.governance import conversation_bridge as cb
+        cb.reset_default_bridge()
+        try:
+            assert cb.record_barge_in("a" * 100, 25, "vad_barge_in") is True
+            prompt = cb.get_default_bridge().format_for_prompt()
+            assert "~25%" in prompt and "25/100 chars" in prompt
+            assert "cause=vad_barge_in" in prompt
+        finally:
+            cb.reset_default_bridge()
+
+    def test_bootstrap_wires_reporter_pin(self):
+        src = (_REPO / "backend/audio/audio_pipeline_bootstrap.py").read_text()
+        assert src.count("on_interruption") >= 2   # lease + pre-mount paths
+        assert "record_barge_in" in src
+
+
+# ---------------------------------------------------------------------------
+# (3) Crest Geometry Polish
+# ---------------------------------------------------------------------------
+
+
+class TestCrestGeometryPolish:
+    def test_apex_whisker_rows_are_shed(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_OV_CREST_MIN_ROW_PX", raising=False)
+        from backend.core.ouroboros.ui import crest
+        crest._generate_pixels_cached.cache_clear()
+        pf = crest.generate_crest_pixels(89, 60)
+        rows: dict = {}
+        for (_x, y) in pf.pixels:
+            rows[y] = rows.get(y, 0) + 1
+        top = min(rows)
+        # The topmost surviving raster row is DENSE — the 1-pixel tail
+        # whisker that read as floating debris is mathematically shed.
+        assert rows[top] >= crest._min_apex_row_px()
+
+    def test_detached_subthreshold_component_clipped(self):
+        from backend.core.ouroboros.ui import crest
+        body = {(x, y): ((200, 80, 40), 0.0)
+                for x in range(10) for y in range(10)}
+        debris = {(40, 40): ((200, 80, 40), 0.0), (41, 40): ((200, 80, 40), 0.0)}
+        pruned = crest._prune_sparse_geometry({**body, **debris})
+        assert (40, 40) not in pruned and (41, 40) not in pruned
+        assert (5, 5) in pruned                      # body intact
+
+    def test_largest_component_always_survives(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_OV_CREST_MIN_COMPONENT_PX", "9999")
+        from backend.core.ouroboros.ui import crest
+        tiny = {(x, 5): ((10, 10, 10), 0.0) for x in range(5)}
+        pruned = crest._prune_sparse_geometry(dict(tiny))
+        assert len(pruned) == 5                      # body never self-deletes
+
+    def test_renderer_trims_emptied_leading_rows(self):
+        from backend.core.ouroboros.ui import crest
+        crest._generate_pixels_cached.cache_clear()
+        pf = crest.generate_crest_pixels(89, 60)
+        plain = crest.pixels_to_text(pf).plain
+        assert plain.split("\n")[0].strip() != ""    # no dead space on top
+
+    def test_ceremony_viewport_guard_pin(self):
+        src = (_REPO / "backend/core/ouroboros/ui/awakening.py").read_text()
+        body = src[src.index("async def _run_animated"):][:2400]
+        assert "_rows_needed" in body
+        # Undersized viewport → static emblem path, never a broken Live.
+        assert "self._print_cooled_header()" in body

--- a/tests/ui/test_crest_halfblock.py
+++ b/tests/ui/test_crest_halfblock.py
@@ -143,8 +143,11 @@ def test_ceremony_prints_persistent_emblem_pin():
     # After the Live (transient) closes, the FULL crest prints into
     # scrollback BEFORE the cooled header.
     assert "PERSISTENT EMBLEM" in body
+    # rindex: the viewport guard (2026-07-18) adds an EARLIER static
+    # emblem+header pair for undersized terminals; the pin protects the
+    # NORMAL ceremony ordering (emblem into scrollback, THEN header).
     assert body.index("self._console.print(self._render_crest_text(") < \
-        body.index("self._print_cooled_header()")
+        body.rindex("self._print_cooled_header()")
 
 
 def test_conductor_renders_via_auto_dispatch_pin():


### PR DESCRIPTION
## Summary
Two authorized workstreams:

**Crest Geometry Polish (root-caused — no terminal overwrites):** empirical diagnosis first: the raster is always exactly **2 connected components** at every size, so the "floating `▀▀▀▀▄▄`" artifact had two real causes — (a) a 1-pixel apex whisker row that reads as debris, (b) the ceremony's transient `Live` cannot erase rows that scrolled out of the viewport, leaving stale frame fragments duplicated in scrollback. Fixes: `_prune_sparse_geometry` (8-connected sub-threshold component clip, largest always survives + apex row-density shed, edges-inward only — interior coil gaps are design), renderer trims emptied rows, and a **viewport guard** in the ceremony: frame taller than the terminal → static emblem, no animation, no broken erase.

**Semantic Interruption Awareness:** the FSM now *knows* it was cut off. The arbiter tracks the active utterance + start instant; barge-in and flush seams estimate the truncation point (`elapsed × JARVIS_TTS_CHARS_PER_S`) and report through an injected `on_interruption`. `conversation_bridge.record_barge_in` mints a discrete `[SYSTEM: OPERATOR_BARGE_IN_DETECTED — truncated at ~N% … UNDELIVERED tail … Do not assume the operator heard the full message.]` turn under `### Delivery interruptions` in the CONTEXT_EXPANSION prompt the next GENERATE consumes — same Tier -1 sanitize path as every turn. Bootstrap wires the reporter on both duplex mount paths.

**DRY substitution, stated openly:** the authorization named `GapSignalBus` — verified and rejected: it is the typed `CapabilityGapEvent` intake bus feeding CapabilityGapSensor; routing markers through it would forge capability-gap op signals. `ConversationBridge` is the genuinely existing dialogue→prompt-history channel and is what ships.

## Testing
13 new tests, incl. **mandate 4 verbatim**: mocked TTS interruption → audio buffer flushed AND the barge-in marker present in the composed prompt before the next GENERATE. Crest spine: whisker shed, sub-threshold clip, body-never-self-deletes, leading-row trim, viewport-guard pin. 118-test sweep green. Two test-isolation fixes: a unit test was reaching a LIVE supervisor socket and genuinely acquiring a lease (an accidental live proof of the broker — now isolated), and the emblem-ordering pin updated for the guard's early path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polishes the crest renderer to remove “floating” half-block artifacts and adds Semantic Interruption Awareness so barge-ins/flushes mark truncated TTS in prompt history. Cleans up the UI and stops the model from assuming a message was fully delivered.

- New Features
  - Semantic Interruption Awareness: the `arbiter` tracks the active utterance and start time; on barge-in or flush it estimates delivered chars (elapsed × `JARVIS_TTS_CHARS_PER_S`) and calls `on_interruption`.
  - `audio_pipeline_bootstrap` wires `arbiter.on_interruption` to `conversation_bridge.record_barge_in`, which adds a structured marker under “Delivery interruptions” to the next prompt.

- Bug Fixes
  - Crest geometry polish: `_prune_sparse_geometry` removes 8-connected components below `JARVIS_OV_CREST_MIN_COMPONENT_PX` (largest always kept) and sheds thin edge rows below `JARVIS_OV_CREST_MIN_ROW_PX`.
  - Renderer trims emptied leading rows; a viewport guard skips animation when the frame exceeds the terminal to prevent stale scrollback fragments.

<sup>Written for commit c5e7b01d72ecdc5ba7dc0a83a6476133436eeea8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69942?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

