### PR TITLE
fix(cli): Stateful KeepAlive Handoff + Circadian Log Janitor

### DIFF
--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -152,6 +152,60 @@ def daemon_log_path() -> Path:
     return repo_root() / ".jarvis" / "logs" / "ov-daemon.log"
 
 
+def _log_max_bytes() -> int:
+    try:
+        return max(1024, int(os.environ.get(
+            "JARVIS_OV_DAEMON_LOG_MAX_BYTES", str(50 * 1024 * 1024),
+        )))
+    except (TypeError, ValueError):
+        return 50 * 1024 * 1024
+
+
+def _log_backups() -> int:
+    try:
+        return max(1, int(os.environ.get(
+            "JARVIS_OV_DAEMON_LOG_BACKUPS", "3",
+        )))
+    except (TypeError, ValueError):
+        return 3
+
+
+def rollover_daemon_log(path: Optional[Path] = None) -> bool:
+    """Circadian Log Janitor for the RAW daemon sinks (the streams
+    launchd / Popen capture BELOW the logging layer). Uses the
+    standard ``RotatingFileHandler`` machinery (``shouldRollover`` /
+    ``doRollover`` — never manual byte manipulation) at each
+    spawn/boot boundary: oversized logs shift to ``.1``/``.2``/``.3``
+    and the oldest falls off. Caveat, stated honestly: a stream fd
+    HELD OPEN by launchd keeps writing to the rotated inode until the
+    next daemon start — the bound is therefore max_bytes × (backups+2)
+    per sink, never unbounded. NEVER raises."""
+    import logging as _logging
+    import logging.handlers as _lh
+    target = path or daemon_log_path()
+    try:
+        target.parent.mkdir(parents=True, exist_ok=True)
+        handler = _lh.RotatingFileHandler(
+            str(target),
+            maxBytes=_log_max_bytes(),
+            backupCount=_log_backups(),
+            encoding="utf-8",
+            delay=True,                    # never touches a healthy file
+        )
+        probe = _logging.LogRecord(
+            "ov.janitor", _logging.INFO, __file__, 0, "", (), None,
+        )
+        try:
+            if handler.shouldRollover(probe):
+                handler.doRollover()
+                return True
+            return False
+        finally:
+            handler.close()
+    except Exception:  # noqa: BLE001
+        return False
+
+
 def spawn_daemon(
     *, spawner: Callable[..., Any] = subprocess.Popen,
 ) -> Optional[int]:
@@ -161,6 +215,7 @@ def spawn_daemon(
     try:
         log = daemon_log_path()
         log.parent.mkdir(parents=True, exist_ok=True)
+        rollover_daemon_log(log)           # janitor at every ignition
         env = dict(os.environ)
         # The resident organism serves cockpits — give it the cockpit
         # session economics unless the operator overrode them.
@@ -311,7 +366,12 @@ def install_agent(
     try:
         path = agent_plist_path(agents_dir)
         path.parent.mkdir(parents=True, exist_ok=True)
-        (repo_root() / ".jarvis" / "logs").mkdir(parents=True, exist_ok=True)
+        log_dir = repo_root() / ".jarvis" / "logs"
+        log_dir.mkdir(parents=True, exist_ok=True)
+        # Janitor the launchd sinks at (re)install so an accumulated
+        # history never rides into the resident era unbounded.
+        rollover_daemon_log(log_dir / "ov-daemon.out.log")
+        rollover_daemon_log(log_dir / "ov-daemon.err.log")
         with open(path, "wb") as fh:
             plistlib.dump(build_agent_plist(), fh)
         try:

--- a/backend/core/ouroboros/governance/silent_boot.py
+++ b/backend/core/ouroboros/governance/silent_boot.py
@@ -409,8 +409,23 @@ def _configure_locked(
         file_handler = None
     if file_handler is None:
         try:
-            file_handler = logging.FileHandler(
-                str(log_path), encoding="utf-8",
+            # Circadian Log Janitor (2026-07-18): the legacy fallback
+            # now rotates too — a resident organism must NEVER write
+            # unbounded logs (same env knobs as the primary pipeline:
+            # JARVIS_TELEMETRY_LOG_MAX_BYTES / _BACKUPS).
+            import logging.handlers as _lh
+            from backend.core.ouroboros.governance.headless_telemetry import (
+                _DEFAULT_BACKUPS,
+                _DEFAULT_MAX_BYTES,
+                _FLAG_BACKUPS,
+                _FLAG_MAX_BYTES,
+                _env_int,
+            )
+            file_handler = _lh.RotatingFileHandler(
+                str(log_path),
+                maxBytes=_env_int(_FLAG_MAX_BYTES, _DEFAULT_MAX_BYTES),
+                backupCount=_env_int(_FLAG_BACKUPS, _DEFAULT_BACKUPS),
+                encoding="utf-8",
             )
             file_handler.setLevel(logging.DEBUG)
             file_handler.setFormatter(_formatter)

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -2233,6 +2233,16 @@ def main(argv: "list[str] | None" = None) -> None:
         # argv[0] is the interpreter, argv[1] is this script, then the original CLI flags.
         os.execv(sys.executable, [sys.executable, *sys.argv])
 
+    # Stateful KeepAlive Handoff (operator-authorized 2026-07-18): every
+    # CLEAN completion — idle_timeout, budget_exhausted, wall_clock_cap,
+    # operator shutdown — exits 0 EXPLICITLY. Under the resident
+    # launchd agent (KeepAlive.SuccessfulExit=false) this lets the
+    # organism SLEEP on intentional exit instead of entering a
+    # CPU-burning restart loop against the host OS; the thin client's
+    # cold-boot path revives it on the next operator touch. Crashes
+    # (tracebacks, os._exit(75) wedges) exit nonzero and ARE revived.
+    sys.exit(0)
+
 
 if __name__ == "__main__":
     main()

--- a/tests/cli/test_ov_dispatch.py
+++ b/tests/cli/test_ov_dispatch.py
@@ -6,8 +6,19 @@ re-parsing), status/attach/help are handled without booting the organism.
 """
 from __future__ import annotations
 
+import pytest
+
 from backend.core.ouroboros.cli import ov
 from backend.core.ouroboros.cli.ov import resolve
+
+
+@pytest.fixture(autouse=True)
+def _restore_presentation_env():
+    # ov.main() writes JARVIS_OV_PRESENTATION during boot-action tests;
+    # restore process env so later suites never inherit a leaked mode.
+    yield
+    import os as _os
+    _os.environ.pop("JARVIS_OV_PRESENTATION", None)
 
 
 class TestResolveSubcommands:

--- a/tests/cli/test_ov_presentation.py
+++ b/tests/cli/test_ov_presentation.py
@@ -12,6 +12,13 @@ from backend.core.ouroboros.cli import ov as ov_cli
 @pytest.fixture(autouse=True)
 def _clean_env(monkeypatch):
     monkeypatch.delenv("JARVIS_OV_PRESENTATION", raising=False)
+    yield
+    # ov.main() mutates os.environ DURING the test (mode declaration) —
+    # monkeypatch can't see that write, so restore explicitly or the
+    # mode leaks into every later suite in the process (the silent_boot
+    # cockpit-threshold cross-pollution, 2026-07-18).
+    import os as _os
+    _os.environ.pop("JARVIS_OV_PRESENTATION", None)
 
 
 def _capture_delegation(monkeypatch):

--- a/tests/cli/test_thin_client.py
+++ b/tests/cli/test_thin_client.py
@@ -291,3 +291,87 @@ class TestRouting:
         assert "run_cockpit_thin(console)" in src
         assert "thin_client_enabled()" in src
         assert '"--legacy-boot" not in inv.delegate_argv' in src
+
+
+# ---------------------------------------------------------------------------
+# (6) Stateful KeepAlive Handoff + Circadian Log Janitor (2026-07-18)
+# ---------------------------------------------------------------------------
+
+
+class TestStatefulKeepAlive:
+    def test_keepalive_is_the_successful_exit_dict_never_a_boolean(self):
+        """MANDATE 4: the plist's KeepAlive MUST be the dict form —
+        {'SuccessfulExit': False} — so a clean idle exit(0) SLEEPS
+        while a crash is revived. A blind boolean would pin the
+        organism in a restart loop against the host OS."""
+        plist = thin_client.build_agent_plist()
+        ka = plist["KeepAlive"]
+        assert isinstance(ka, dict) and not isinstance(ka, bool)
+        assert ka == {"SuccessfulExit": False}
+
+    def test_plist_serialization_preserves_dict_structure(self, sock_dir):
+        import plistlib
+        thin_client.install_agent(
+            agents_dir=sock_dir, runner=lambda *a, **k: None,
+        )
+        raw = thin_client.agent_plist_path(sock_dir).read_bytes()
+        loaded = plistlib.loads(raw)
+        assert loaded["KeepAlive"] == {"SuccessfulExit": False}
+        # XML sanity: the dict serialized as <dict>, not <true/>.
+        assert b"<dict>" in raw and b"SuccessfulExit" in raw
+
+    def test_clean_completion_exits_zero_pin(self):
+        src = (_REPO / "scripts/ouroboros_battle_test.py").read_text()
+        tail = src[src.rindex("os.execv(sys.executable"):]
+        assert "sys.exit(0)" in tail       # explicit launchd handoff
+
+
+class TestCircadianLogJanitor:
+    def test_oversized_log_rotates_via_stdlib_machinery(
+        self, sock_dir, monkeypatch,
+    ):
+        monkeypatch.setenv("JARVIS_OV_DAEMON_LOG_MAX_BYTES", "2048")
+        monkeypatch.setenv("JARVIS_OV_DAEMON_LOG_BACKUPS", "3")
+        log = sock_dir / "ov-daemon.log"
+        log.write_bytes(b"x" * 4096)
+        assert thin_client.rollover_daemon_log(log) is True
+        assert (sock_dir / "ov-daemon.log.1").exists()
+        assert (sock_dir / "ov-daemon.log.1").stat().st_size == 4096
+        assert not log.exists() or log.stat().st_size == 0
+
+    def test_healthy_log_untouched(self, sock_dir, monkeypatch):
+        monkeypatch.setenv("JARVIS_OV_DAEMON_LOG_MAX_BYTES", "2048")
+        log = sock_dir / "ov-daemon.log"
+        log.write_bytes(b"y" * 100)
+        assert thin_client.rollover_daemon_log(log) is False
+        assert log.read_bytes() == b"y" * 100
+        assert not (sock_dir / "ov-daemon.log.1").exists()
+
+    def test_backup_count_bounds_total_disk(self, sock_dir, monkeypatch):
+        monkeypatch.setenv("JARVIS_OV_DAEMON_LOG_MAX_BYTES", "1024")
+        monkeypatch.setenv("JARVIS_OV_DAEMON_LOG_BACKUPS", "2")
+        log = sock_dir / "ov-daemon.log"
+        for _ in range(5):                 # five oversized generations
+            log.write_bytes(b"z" * 2048)
+            thin_client.rollover_daemon_log(log)
+        survivors = sorted(p.name for p in sock_dir.iterdir())
+        assert "ov-daemon.log.3" not in survivors     # oldest fell off
+        assert len([s for s in survivors if s.startswith("ov-daemon")]) <= 3
+
+    def test_spawn_and_install_invoke_the_janitor_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/cli/thin_client.py"
+        ).read_text()
+        spawn = src[src.index("def spawn_daemon"):][:1200]
+        install = src[src.index("def install_agent"):][:1500]
+        assert "rollover_daemon_log(" in spawn
+        assert src[src.index("def install_agent"):].count(
+            "rollover_daemon_log(",
+        ) >= 2                              # both launchd sinks
+        assert "rollover_daemon_log" in install
+
+    def test_silent_boot_fallback_rotates_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/governance/silent_boot.py"
+        ).read_text()
+        assert "RotatingFileHandler(" in src


### PR DESCRIPTION
## Summary
The two pre-install safety mandates for the resident organism:

1. **Stateful KeepAlive Handoff** — the `KeepAlive: {SuccessfulExit: false}` dict form shipped in #69943 (now pinned as *dict-never-boolean* + XML round-trip). The missing half was the contract's other side: the bootstrap now calls `sys.exit(0)` **explicitly** on every clean completion, so launchd lets an idle-exited organism sleep (thin-client cold boot revives it on next touch) while crashes exit nonzero and are revived. No restart loops against the host OS.
2. **Circadian Log Janitor** — standard `logging.handlers` only. The primary non-blocking pipeline already rotated (`RotatingFileHandler`, env knobs); the legacy silent_boot fallback now matches it. The raw daemon sinks (Popen log + launchd out/err — below the logging layer) get `rollover_daemon_log()`: stdlib `shouldRollover`/`doRollover` at every ignition and every (re)install (50MB × 3 backups, env-tunable). Honest bound documented: a launchd-held fd writes to the rotated inode until the next daemon start → ceiling is `max_bytes × (backups+2)` per sink — bounded, never disk exhaustion.

Rider: sealed a pre-existing cross-suite env leak (`ov.main()` writes `JARVIS_OV_PRESENTATION` mid-test; the leaked cockpit mode flipped silent_boot's terminal threshold in later suites).

## Testing
8 new tests (KeepAlive dict structure + serialization, explicit exit-0 pin, rotation via stdlib machinery incl. backup-count disk bound + healthy-file-untouched, janitor wiring pins, silent_boot fallback pin). **112/112** combined cli + silent_boot sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensures clean shutdowns sleep instead of restart looping by explicitly exiting 0 with `launchd` `KeepAlive: {'SuccessfulExit': false}`. Adds safe, stdlib-based log rotation for raw daemon logs and the `silent_boot` fallback to cap disk usage.

- New Features
  - Explicit `sys.exit(0)` on clean completion to match `KeepAlive: {'SuccessfulExit': False}`; crashes exit nonzero and are revived.
  - `rollover_daemon_log()` uses stdlib `RotatingFileHandler` for raw daemon sinks; runs on daemon spawn and agent (re)install. Tunable via `JARVIS_OV_DAEMON_LOG_MAX_BYTES` (default 50MB) and `JARVIS_OV_DAEMON_LOG_BACKUPS` (default 3). Bound: max_bytes × (backups+2) per sink.
  - `silent_boot` fallback switches to `RotatingFileHandler` with `JARVIS_TELEMETRY_LOG_MAX_BYTES` and `JARVIS_TELEMETRY_LOG_BACKUPS`.

- Bug Fixes
  - Stops cross-suite env leakage by restoring `JARVIS_OV_PRESENTATION` in tests.

<sup>Written for commit 6aa7e214e3616a72b6ba37d881bb6565a3994999. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69944?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

