### PR TITLE
feat(audio): Ears-Ajar Gate — pre-roll stitching kills wake-word truncation

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/ears_ajar.py
+++ b/backend/core/ouroboros/governance/comms/duplex/ears_ajar.py
@@ -1,0 +1,151 @@
+"""Ears-Ajar Gate — the Passive Sentry's low-power acoustic pre-filter.
+
+Operator authorization 2026-07-19, scout-validated (246µs/chunk DSP,
+0.82% of one core). The gate solves the primary physical flaw of
+energy-gated listeners at its ROOT — **Wake-Word Truncation**: by the
+time RMS breaches the threshold, the initial plosive ("J-arvis",
+"K-aren") is already in the past. No threshold-lowering, no wildcard
+parsing: the gate keeps a strict rolling FIFO **pre-roll ring** of the
+last ~500ms of RAW chunks and, on breach, STITCHES that pre-roll to
+the front of the live stream — the recognizer and the VBIA/PAVA
+biometric layer both receive the complete acoustic envelope.
+
+Dynamic Noise-Floor Recalibration: the trigger threshold rides a slow
+EMA of the room baseline (fast EMA for the signal), so an HVAC fan
+engaging RAISES the floor instead of causing runaway triggers, and a
+quieting room lowers it again. Both time constants env-tunable.
+
+Pure DSP; ``collections.deque(maxlen=…)`` ring (memory-safe rotation,
+zero explicit GC); no audio-capture authority — callers own the mic.
+"""
+from __future__ import annotations
+
+import os
+from collections import deque
+from typing import Any, Deque, Dict, Optional
+
+import numpy as np
+
+_RATE_DEFAULT = 16000
+_CHUNK_DEFAULT = 480          # 30ms @16k — the scout's proven geometry
+
+
+def _env_f(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return max(lo, min(hi, float(os.environ.get(name, str(default)))))
+    except (TypeError, ValueError):
+        return default
+
+
+class EarsAjarGate:
+    """Feed 30ms chunks; receive ``None`` (stay cold) or a stitched
+    payload (pre-roll + breach chunk) the moment speech-like energy
+    crosses the adaptive gate.
+
+    After a trigger the gate stays OPEN (``in_window``) and every
+    subsequent chunk should be forwarded raw by the caller until it
+    calls :meth:`close_window` — stitching is only for the FIRST
+    chunk, where the truncation physics live.
+    """
+
+    def __init__(
+        self,
+        *,
+        rate: int = _RATE_DEFAULT,
+        chunk: int = _CHUNK_DEFAULT,
+    ) -> None:
+        self.rate = rate
+        self.chunk = chunk
+        preroll_ms = _env_f("JARVIS_SENTRY_PREROLL_MS", 500.0, 60.0, 2000.0)
+        n_chunks = max(1, int(round((preroll_ms / 1000.0) * rate / chunk)))
+        #: strict FIFO ring — deque(maxlen) rotates in O(1), no GC churn.
+        self._preroll: Deque[np.ndarray] = deque(maxlen=n_chunks)
+        self._noise_floor = _env_f(
+            "JARVIS_SENTRY_FLOOR_SEED", 1e-4, 1e-6, 1.0,
+        )
+        #: slow baseline EMA — HVAC engagement takes ~seconds to absorb.
+        self._floor_alpha = _env_f(
+            "JARVIS_SENTRY_FLOOR_ALPHA", 0.005, 0.0001, 0.2,
+        )
+        self._ratio_min = _env_f("JARVIS_SENTRY_VOICE_RATIO", 0.55, 0.1, 0.95)
+        self._floor_mult = _env_f("JARVIS_SENTRY_FLOOR_MULT", 3.0, 1.2, 10.0)
+        self._abs_min = _env_f("JARVIS_SENTRY_ABS_MIN_RMS", 0.01, 0.0, 0.5)
+        freqs = np.fft.rfftfreq(chunk, 1.0 / rate)
+        self._band = (freqs >= 85.0) & (freqs <= 3000.0)
+        self.in_window = False
+        self.stats: Dict[str, Any] = {
+            "chunks": 0, "triggers": 0, "floor": self._noise_floor,
+            "floor_min": self._noise_floor, "floor_max": self._noise_floor,
+        }
+
+    @property
+    def noise_floor(self) -> float:
+        return self._noise_floor
+
+    @property
+    def preroll_chunks(self) -> int:
+        return int(self._preroll.maxlen or 0)
+
+    def feed(self, chunk: "np.ndarray") -> Optional["np.ndarray"]:
+        """One 30ms chunk in. Returns the STITCHED payload
+        (pre-roll ‖ breach chunk — the complete acoustic envelope,
+        initial plosive preserved) on gate breach; ``None`` otherwise.
+        While a window is open, returns ``None`` (caller forwards the
+        live stream itself). NEVER raises; a malformed chunk is
+        swallowed cold."""
+        try:
+            x = np.asarray(chunk, dtype=np.float32).reshape(-1)
+            if x.size == 0:
+                return None
+            self.stats["chunks"] += 1
+            rms = float(np.sqrt(np.mean(x * x)))
+            # Dynamic floor: the SLOW room-baseline EMA. Deliberately
+            # updated from every chunk INCLUDING speech (speech is
+            # transient; alpha makes hours of fan dominate seconds of
+            # words), preventing runaway triggers on ambience shifts.
+            self._noise_floor = (
+                (1.0 - self._floor_alpha) * self._noise_floor
+                + self._floor_alpha * rms
+            )
+            self.stats["floor"] = self._noise_floor
+            self.stats["floor_min"] = min(
+                self.stats["floor_min"], self._noise_floor,
+            )
+            self.stats["floor_max"] = max(
+                self.stats["floor_max"], self._noise_floor,
+            )
+            if self.in_window:
+                # Caller streams live audio during an open window; the
+                # ring keeps rolling so the NEXT trigger has pre-roll.
+                self._preroll.append(x)
+                return None
+            threshold = max(
+                self._floor_mult * self._noise_floor, self._abs_min,
+            )
+            breach = rms > threshold
+            if breach:
+                spec = np.abs(np.fft.rfft(x))
+                voice_ratio = float(
+                    spec[self._band].sum() / (spec.sum() + 1e-9),
+                )
+                breach = voice_ratio > self._ratio_min
+            if not breach:
+                self._preroll.append(x)
+                return None
+            # ---- Pre-Roll Stitching (the truncation root fix) ----
+            payload = np.concatenate([*self._preroll, x]) if self._preroll \
+                else x.copy()
+            self._preroll.append(x)
+            self.in_window = True
+            self.stats["triggers"] += 1
+            return payload
+        except Exception:  # noqa: BLE001 — sentry DSP never crashes audio
+            return None
+
+    def close_window(self) -> None:
+        """Recognition window ended (utterance finished / timeout) —
+        the gate goes back to sleep with its ring warm. NEVER raises."""
+        self.in_window = False
+
+
+__all__ = ["EarsAjarGate"]

--- a/scripts/scouts/sentry_live_leg.py
+++ b/scripts/scouts/sentry_live_leg.py
@@ -1,0 +1,78 @@
+"""Interactive accuracy + 30-min soak legs (2026-07-19).
+Uses the PRODUCTION EarsAjarGate + on-device SFSpeechRecognizer.
+argv[1]: 'interactive' (600s, log wake-word hits) | 'soak' (1800s)."""
+from __future__ import annotations
+import json, sys, time
+import numpy as np, psutil, sounddevice as sd
+from backend.core.ouroboros.governance.comms.duplex.ears_ajar import EarsAjarGate
+
+MODE = sys.argv[1] if len(sys.argv) > 1 else "interactive"
+SECONDS = 1800 if MODE == "soak" else 600
+RATE, CHUNK = 16000, 480
+PROC = psutil.Process()
+
+import Speech
+from AVFoundation import AVAudioEngine
+
+def recognize_window(seconds=4.0):
+    """One windowed on-device recognition burst; returns transcripts."""
+    hits = []
+    try:
+        rec = Speech.SFSpeechRecognizer.alloc().init()
+        if rec is None or not rec.isAvailable():
+            return hits
+        req = Speech.SFSpeechAudioBufferRecognitionRequest.alloc().init()
+        try: req.setRequiresOnDeviceRecognition_(True)
+        except Exception: pass
+        eng = AVAudioEngine.alloc().init()
+        node = eng.inputNode()
+        fmt = node.outputFormatForBus_(0)
+        def _cb(result, error):
+            if result is not None:
+                hits.append(str(result.bestTranscription().formattedString()))
+        task = rec.recognitionTaskWithRequest_resultHandler_(req, _cb)
+        node.installTapOnBus_bufferSize_format_block_(
+            0, 1024, fmt, lambda b, w: req.appendAudioPCMBuffer_(b))
+        eng.prepare(); eng.startAndReturnError_(None)
+        time.sleep(seconds)
+        eng.stop(); node.removeTapOnBus_(0)
+        req.endAudio(); task.cancel()
+    except Exception as e:
+        hits.append(f"<err {type(e).__name__}>")
+    return hits
+
+def main():
+    gate = EarsAjarGate(rate=RATE, chunk=CHUNK)
+    events = []
+    floor_log = []
+    PROC.cpu_percent(None)
+    t0 = time.monotonic()
+    with sd.InputStream(samplerate=RATE, channels=1, blocksize=CHUNK, dtype="float32") as stream:
+        while time.monotonic() - t0 < SECONDS:
+            data, _ = stream.read(CHUNK)
+            payload = gate.feed(data[:, 0])
+            now = round(time.monotonic() - t0, 1)
+            if int(now) % 60 == 0 and (not floor_log or floor_log[-1]["t"] != int(now)):
+                floor_log.append({"t": int(now), "floor": round(gate.noise_floor, 6),
+                                  "cpu": PROC.cpu_percent(None)})
+            if payload is not None and MODE == "interactive":
+                # gate fired → windowed recognizer (stream released first)
+                stream.stop()
+                text = recognize_window(4.0)
+                stream.start()
+                gate.close_window()
+                low = " ".join(text).lower()
+                events.append({"t": now, "heard": text[-1] if text else "",
+                               "jarvis": "jarvis" in low, "karen": "karen" in low})
+            elif payload is not None:
+                gate.close_window()
+    print(json.dumps({
+        "mode": MODE, "seconds": SECONDS,
+        "gate_stats": {k: (round(v, 6) if isinstance(v, float) else v)
+                        for k, v in gate.stats.items()},
+        "floor_drift": floor_log[:35],
+        "events": events[-40:],
+        "wake_hits": sum(1 for e in events if e.get("jarvis") or e.get("karen")),
+    }, indent=1))
+
+main()

--- a/tests/governance/test_ears_ajar_gate.py
+++ b/tests/governance/test_ears_ajar_gate.py
@@ -1,0 +1,140 @@
+"""Ears-Ajar Gate spine — pre-roll stitching + adaptive noise floor.
+
+Mandate 4 verbatim (2026-07-19): a wake word whose acoustic envelope
+begins 200ms BEFORE the RMS breach must arrive at the recognizer FSM
+complete — the pre-roll stitch prepends the missing 200ms.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex.ears_ajar import (
+    EarsAjarGate,
+)
+
+RATE, CHUNK = 16000, 480          # 30ms chunks
+CHUNK_S = CHUNK / RATE
+
+
+def _tone(freq: float, amp: float, chunks: int = 1) -> list:
+    t = np.arange(chunks * CHUNK) / RATE
+    x = (amp * np.sin(2 * np.pi * freq * t)).astype(np.float32)
+    return [x[i * CHUNK:(i + 1) * CHUNK] for i in range(chunks)]
+
+
+def _noise(amp: float, chunks: int = 1, seed: int = 7) -> list:
+    rng = np.random.default_rng(seed)
+    return [
+        (amp * rng.standard_normal(CHUNK)).astype(np.float32)
+        for _ in range(chunks)
+    ]
+
+
+@pytest.fixture()
+def gate(monkeypatch):
+    for k in (
+        "JARVIS_SENTRY_PREROLL_MS", "JARVIS_SENTRY_FLOOR_ALPHA",
+        "JARVIS_SENTRY_ABS_MIN_RMS", "JARVIS_SENTRY_FLOOR_MULT",
+    ):
+        monkeypatch.delenv(k, raising=False)
+    return EarsAjarGate(rate=RATE, chunk=CHUNK)
+
+
+class TestPreRollStitch:
+    def test_wake_word_starting_200ms_before_breach_is_prepended(self, gate):
+        """MANDATE 4 VERBATIM. Timeline:
+        quiet noise → 200ms of SOFT voice-band onset (below threshold —
+        the leading consonant) → LOUD voice-band chunk (breach). The
+        stitched payload must contain the soft 200ms onset."""
+        for c in _noise(0.001, chunks=30):        # settle the floor
+            assert gate.feed(c) is None
+        # The wake word's soft onset: 200ms ≈ 7 chunks at 300Hz, quiet
+        # enough to stay under 3×floor... use amp below abs_min too.
+        onset = _tone(300.0, 0.004, chunks=7)     # sub-threshold voice
+        for c in onset:
+            assert gate.feed(c) is None            # gate stays cold
+        loud = _tone(300.0, 0.2, chunks=1)[0]      # the stressed vowel
+        payload = gate.feed(loud)
+        assert payload is not None                 # gate fired
+        # The payload ends with the breach chunk...
+        assert np.array_equal(payload[-CHUNK:], loud)
+        # ...and STRUCTURALLY CONTAINS the full 200ms onset immediately
+        # before it (byte-identical samples — nothing truncated).
+        onset_cat = np.concatenate(onset)
+        n = onset_cat.size
+        assert np.array_equal(payload[-CHUNK - n:-CHUNK], onset_cat)
+        # Total pre-roll ≈ 500ms: payload spans breach + ring.
+        assert payload.size == CHUNK * (gate.preroll_chunks + 1)
+
+    def test_first_chunk_breach_without_history_still_fires(self, gate):
+        loud = _tone(300.0, 0.3, chunks=1)[0]
+        payload = gate.feed(loud)
+        assert payload is not None
+        assert np.array_equal(payload, loud)       # nothing to stitch yet
+
+    def test_ring_is_bounded_fifo(self, gate):
+        for c in _noise(0.001, chunks=200):        # 6s >> 500ms ring
+            gate.feed(c)
+        assert len(gate._preroll) == gate.preroll_chunks
+        assert gate.preroll_chunks == round(0.5 * RATE / CHUNK)  # ~500ms
+
+    def test_open_window_streams_raw_not_restitched(self, gate):
+        for c in _noise(0.001, chunks=30):
+            gate.feed(c)
+        assert gate.feed(_tone(300.0, 0.3)[0]) is not None
+        assert gate.in_window is True
+        # While the window is open, feed returns None (caller forwards
+        # the live stream); ring keeps rolling for the NEXT trigger.
+        assert gate.feed(_tone(300.0, 0.3)[0]) is None
+        gate.close_window()
+        assert gate.in_window is False
+
+
+class TestDynamicNoiseFloor:
+    def test_hvac_engagement_raises_floor_no_runaway_triggers(
+        self, gate, monkeypatch,
+    ):
+        for c in _noise(0.001, chunks=50):
+            gate.feed(c)
+        floor_before = gate.noise_floor
+        # HVAC engages: sustained broadband noise well above the old
+        # floor. First moments may trigger (legitimately loud), but the
+        # floor absorbs it and triggers STOP.
+        fan = _noise(0.02, chunks=1200, seed=11)   # ~36s of fan
+        triggers = 0
+        for c in fan:
+            if gate.feed(c) is not None:
+                triggers += 1
+                gate.close_window()
+        assert gate.noise_floor > floor_before * 4  # recalibrated
+        # Runaway = triggering on a large fraction of fan chunks.
+        assert triggers < 60                        # <5% of 1200
+        # Late fan chunks are absorbed silently:
+        late = 0
+        for c in _noise(0.02, chunks=100, seed=12):
+            if gate.feed(c) is not None:
+                late += 1
+                gate.close_window()
+        assert late == 0                            # fully adapted
+
+    def test_floor_drift_telemetry_recorded(self, gate):
+        for c in _noise(0.001, chunks=20):
+            gate.feed(c)
+        for c in _noise(0.05, chunks=200, seed=3):
+            gate.feed(c)
+            if gate.in_window:
+                gate.close_window()
+        assert gate.stats["floor_max"] > gate.stats["floor_min"]
+        assert gate.stats["chunks"] == 220
+
+    def test_non_voice_broadband_transient_rejected(self, gate):
+        """A door slam: loud but spectrally flat → voice-ratio veto."""
+        for c in _noise(0.001, chunks=30):
+            gate.feed(c)
+        slam = _noise(0.4, chunks=1, seed=99)[0]   # white = flat spectrum
+        assert gate.feed(slam) is None
+
+    def test_hostile_chunk_never_raises(self, gate):
+        assert gate.feed(np.array([])) is None
+        assert gate.feed("not audio") is None      # type: ignore[arg-type]


### PR DESCRIPTION
## Summary
The Passive Sentry's low-power pre-filter (scout-validated DSP: 246µs/30ms chunk). Wake-word truncation fixed at the root: a `deque(maxlen)` FIFO ring holds ~500ms of raw chunks; on breach the gate stitches the pre-roll to the payload front — the initial plosive reaches SFSpeech **and** VBIA/PAVA byte-identical. Dynamic noise floor (slow EMA) absorbs HVAC engagement with zero runaway triggers after adaptation; spectrally-flat transients (door slams) are vetoed by the voice-band ratio. Stitch-first-chunk / stream-open-window / re-arm-warm semantics.

## Testing
8 tests incl. **mandate 4 verbatim**: a wake word starting 200ms before the RMS breach arrives with the missing 200ms prepended byte-identically. HVAC recalibration (<5% triggers during onset, 0 after adaptation), bounded FIFO, first-chunk-no-history, hostile-input containment. Live-hardware interactive + 30-min soak legs running via the rider harness.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the Ears‑Ajar Gate to eliminate wake‑word truncation by stitching ~500 ms of pre‑roll onto the first triggered chunk. Also adds adaptive noise‑floor tracking to avoid false triggers, plus tests and a live soak harness.

- **New Features**
  - Pre‑roll stitching via `collections.deque(maxlen)` (~500 ms) so initial consonants reach the recognizer and biometric layers.
  - Adaptive floor with slow EMA, floor multiplier, and absolute min; voice‑band ratio (85–3000 Hz) rejects flat transients.
  - Windowing: stitch only the first breach; stream subsequent chunks; call `close_window()` to re‑arm.
  - Tests for mandate‑4 and edge cases; live hardware harness at `scripts/scouts/sentry_live_leg.py`.

- **Migration**
  - Feed 30 ms mono float32 chunks at 16 kHz into `EarsAjarGate.feed`; it returns the stitched payload on first breach, else `None`.
  - On payload, start recognition and forward live audio yourself until done, then call `close_window()`.
  - Optional tuning via `JARVIS_SENTRY_PREROLL_MS`, `JARVIS_SENTRY_FLOOR_ALPHA`, `JARVIS_SENTRY_FLOOR_MULT`, `JARVIS_SENTRY_ABS_MIN_RMS`. Defaults are safe.

<sup>Written for commit c0a608ed8f1bb05b743d5182c26e7aae68f18923. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69947?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

