### PR TITLE
feat(audio): sentry final wiring — deferred capture, VBIA/PAVA gate, total env safeguard

### DIFF
--- a/backend/audio/audio_pipeline_bootstrap.py
+++ b/backend/audio/audio_pipeline_bootstrap.py
@@ -309,6 +309,23 @@ async def wire_conversation_pipeline(
                     "[Bootstrap] ambient wake observer skipped",
                     exc_info=True,
                 )
+            # PASSIVE_SENTRY final mount (2026-07-19): the total gate
+            # lives INSIDE mount_passive_sentry — when
+            # JARVIS_PASSIVE_SENTRY_ENABLED is down, zero sentry
+            # imports/threads/deques/runloops are instantiated.
+            try:
+                from backend.core.ouroboros.governance.comms.duplex.sentry_bootstrap import (  # noqa: E501
+                    mount_passive_sentry,
+                )
+                handle.passive_sentry = mount_passive_sentry(
+                    broadcaster=handle.audio_ipc,
+                    mic_register=lambda cb: audio_bus.register_mic_consumer(cb),
+                )
+            except Exception:
+                handle.passive_sentry = None
+                logger.debug(
+                    "[Bootstrap] passive sentry mount skipped", exc_info=True,
+                )
         else:
             handle.audio_ipc = None
     except Exception as e:

--- a/backend/core/ouroboros/governance/comms/duplex/sentry_bootstrap.py
+++ b/backend/core/ouroboros/governance/comms/duplex/sentry_bootstrap.py
@@ -1,0 +1,391 @@
+"""Sentry bootstrap — the three final wiring points of the ambient loop.
+
+Operator authorization 2026-07-19:
+
+  1. **Total fail-closed gate**: ``JARVIS_PASSIVE_SENTRY_ENABLED``
+     (default OFF) is checked BEFORE any sentry import — threads,
+     deques, and pyobjc runloops stay completely uninstantiated when
+     the flag is down.
+  2. **Shared-Channel Audio Concurrency**: capture allocation goes
+     through :class:`DeferredCaptureAllocator` — a device-busy
+     collision is classified DETERMINISTICALLY (PortAudio -9985/-9986
+     device errors, POSIX EBUSY/EACCES) and transitions the sentry to
+     ``DEFERRED_CAPTURE``: bounded async retries on the loop, the
+     primary FSM never blocks, never panics. Non-busy faults fail the
+     allocation permanently (no blind retry of a real bug).
+  3. **Biometric gate**: :class:`BiometricGateAdapter` wraps the
+     EXISTING ``voice_authentication_layer`` (VBIA) — zero rewritten
+     biometric code. The stitched pre-roll window is the primary
+     verification target; a score in the boundary band invokes the
+     PAVA drift matrix over the next three sub-frames. Sentry
+     semantics INVERT tier-1's permissive BYPASSED: no adapter mounted
+     means NOBODY wakes the organism.
+
+DRY: the wake lease is the EXACT ``RemoteAudioLease`` pathway the CLI
+``wake`` command uses — the sentry is a headless client of the same
+Tri-State broker.
+"""
+from __future__ import annotations
+
+import asyncio
+import errno
+import logging
+import os
+import time
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.SentryBootstrap")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+STATE_ACTIVE = "ACTIVE"
+STATE_DEFERRED_CAPTURE = "DEFERRED_CAPTURE"
+STATE_FAILED = "FAILED"
+
+
+def sentry_enabled() -> bool:
+    """The TOTAL gate — consulted before any sentry import. Default
+    OFF. NEVER raises."""
+    return os.environ.get(
+        "JARVIS_PASSIVE_SENTRY_ENABLED", "",
+    ).strip().lower() in _TRUTHY
+
+
+# ---------------------------------------------------------------------------
+# Shared-channel capture — deterministic device-busy handling
+# ---------------------------------------------------------------------------
+
+#: PortAudio device-contention codes (paDeviceUnavailable / paTimedOut
+#: family) + POSIX busy/permission errnos. A closed classification —
+#: anything else is a REAL fault and is not retried.
+_PA_BUSY_CODES = (-9985, -9986, -9988, -9996)
+_POSIX_BUSY = (errno.EBUSY, errno.EACCES, errno.EAGAIN)
+
+
+def classify_capture_error(exc: BaseException) -> str:
+    """``busy`` (another OS consumer holds the device — retryable) or
+    ``fault`` (a genuine bug — never blind-retried). Deterministic on
+    exception TYPE + code, no message pattern-matching where a code
+    exists. NEVER raises."""
+    try:
+        code = getattr(exc, "errno", None)
+        if code in _POSIX_BUSY:
+            return "busy"
+        pa = getattr(exc, "args", ())
+        for a in pa:
+            if isinstance(a, int) and a in _PA_BUSY_CODES:
+                return "busy"
+        name = type(exc).__name__
+        if name == "PortAudioError":
+            # PortAudio hides the code in args[1] sometimes; the
+            # device-contention family is the ONLY retryable class.
+            text = str(exc).lower()
+            if "busy" in text or "unavailable" in text or "timed out" in text:
+                return "busy"
+        return "fault"
+    except Exception:  # noqa: BLE001
+        return "fault"
+
+
+class DeferredCaptureAllocator:
+    """Owns the capture-allocation lifecycle. ``ensure()`` tries the
+    injected opener; a busy-classified failure transitions to
+    DEFERRED_CAPTURE and schedules bounded async retries — the caller
+    (the supervisor FSM) returns immediately and keeps orchestrating.
+    NEVER raises out of any public method."""
+
+    def __init__(
+        self,
+        opener: Callable[[], Any],
+        *,
+        retry_interval_s: Optional[float] = None,
+        max_retries: Optional[int] = None,
+    ) -> None:
+        self._opener = opener
+        try:
+            self._interval = retry_interval_s if retry_interval_s is not None \
+                else max(1.0, float(os.environ.get(
+                    "JARVIS_SENTRY_CAPTURE_RETRY_S", "10",
+                )))
+        except (TypeError, ValueError):
+            self._interval = 10.0
+        try:
+            self._max_retries = max_retries if max_retries is not None \
+                else max(1, int(os.environ.get(
+                    "JARVIS_SENTRY_CAPTURE_MAX_RETRIES", "30",
+                )))
+        except (TypeError, ValueError):
+            self._max_retries = 30
+        self.state = STATE_DEFERRED_CAPTURE
+        self.handle: Any = None
+        self._retry_task: Optional[asyncio.Task] = None
+        self.stats: Dict[str, int] = {"attempts": 0, "busy": 0, "faults": 0}
+
+    def ensure(self) -> str:
+        """One allocation attempt now; busy → schedule the deferred
+        loop. Returns the resulting state. NEVER raises, NEVER
+        blocks."""
+        state = self._attempt()
+        if state == STATE_DEFERRED_CAPTURE and self._retry_task is None:
+            try:
+                self._retry_task = asyncio.get_running_loop().create_task(
+                    self._retry_loop(),
+                )
+            except RuntimeError:
+                pass                    # no loop (sync probe) — caller re-ensures
+        return self.state
+
+    def _attempt(self) -> str:
+        self.stats["attempts"] += 1
+        try:
+            self.handle = self._opener()
+            self.state = STATE_ACTIVE
+            return self.state
+        except Exception as exc:  # noqa: BLE001 — classified, not padded
+            kind = classify_capture_error(exc)
+            if kind == "busy":
+                self.stats["busy"] += 1
+                self.state = STATE_DEFERRED_CAPTURE
+                logger.info(
+                    "[Sentry] capture device busy — DEFERRED_CAPTURE "
+                    "(retry every %.0fs)", self._interval,
+                )
+            else:
+                self.stats["faults"] += 1
+                self.state = STATE_FAILED
+                logger.warning("[Sentry] capture fault (no retry): %r", exc)
+            return self.state
+
+    async def _retry_loop(self) -> None:
+        try:
+            retries = 0
+            while self.state == STATE_DEFERRED_CAPTURE \
+                    and retries < self._max_retries:
+                await asyncio.sleep(self._interval)
+                retries += 1
+                if self._attempt() == STATE_ACTIVE:
+                    logger.info(
+                        "[Sentry] capture allocated after %d deferred "
+                        "retries", retries,
+                    )
+                    return
+            if self.state != STATE_ACTIVE:
+                self.state = STATE_FAILED
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            self.state = STATE_FAILED
+
+    async def stop(self) -> None:
+        task = self._retry_task
+        self._retry_task = None
+        if task is not None and not task.done():
+            task.cancel()
+            try:
+                await task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Biometric gate — VBIA primary + PAVA drift on the boundary band
+# ---------------------------------------------------------------------------
+
+
+def _boundary_margin() -> float:
+    try:
+        return max(0.0, min(0.5, float(os.environ.get(
+            "JARVIS_SENTRY_VBIA_BOUNDARY_MARGIN", "0.08",
+        ))))
+    except (TypeError, ValueError):
+        return 0.08
+
+
+def _vbia_threshold() -> float:
+    try:
+        return max(0.1, min(0.99, float(os.environ.get(
+            "JARVIS_TIER1_VBIA_THRESHOLD", "0.70",
+        ))))
+    except (TypeError, ValueError):
+        return 0.70
+
+
+class BiometricGateAdapter:
+    """Composes the EXISTING biometric stack — no rewritten scoring.
+
+    ``scorer(window) -> (confidence: float, is_owner: bool)`` is the
+    injected seam; production default routes through
+    ``VoiceAuthenticationLayer.verify_for_tier1`` with the stitched
+    window in context. Decision law:
+
+      * conf ≥ threshold + margin           → PASS (clear)
+      * conf <  threshold − margin          → FAIL (clear)
+      * boundary band                       → PAVA drift: score the
+        window's three trailing sub-frames; PASS only if the trend is
+        non-degrading AND the mean clears the threshold.
+      * scorer unavailable / error          → FAIL (sentry inverts
+        tier-1's permissive BYPASSED — fail CLOSED).
+    """
+
+    def __init__(
+        self,
+        scorer: Optional[
+            Callable[[Any], Awaitable[tuple]]
+        ] = None,
+    ) -> None:
+        self._scorer = scorer or self._default_scorer
+        self.stats: Dict[str, int] = {
+            "clear_pass": 0, "clear_fail": 0, "pava_evals": 0,
+            "pava_pass": 0, "pava_fail": 0, "errors": 0,
+        }
+
+    @staticmethod
+    async def _default_scorer(window: Any) -> tuple:
+        from backend.core.voice_authentication_layer import (  # noqa: PLC0415
+            AuthResult,
+            VoiceAuthenticationLayer,
+        )
+        layer = VoiceAuthenticationLayer()
+        result = await layer.verify_for_tier1(
+            "sentry_wake",
+            context={"audio_window": window, "source": "passive_sentry"},
+        )
+        if result.result != AuthResult.PASSED:
+            # BYPASSED / FAILED / ERROR all read as no-confidence in
+            # sentry semantics — fail closed.
+            return 0.0, False
+        return float(result.confidence), bool(result.is_owner)
+
+    async def verify(self, window: Any) -> bool:
+        """The sentry's injected verifier. NEVER raises."""
+        try:
+            conf, is_owner = await self._scorer(window)
+            thr, margin = _vbia_threshold(), _boundary_margin()
+            if conf >= thr + margin and is_owner:
+                self.stats["clear_pass"] += 1
+                return True
+            if conf < thr - margin or not is_owner:
+                self.stats["clear_fail"] += 1
+                return False
+            # Boundary band → PAVA acoustic-drift evaluation.
+            self.stats["pava_evals"] += 1
+            ok = await self._pava_drift(window, thr)
+            self.stats["pava_pass" if ok else "pava_fail"] += 1
+            return ok
+        except Exception:  # noqa: BLE001
+            self.stats["errors"] += 1
+            return False                       # biometric fault = closed
+
+    async def _pava_drift(self, window: Any, thr: float) -> bool:
+        """Score the three trailing sub-frames; a non-degrading trend
+        whose mean clears the threshold survives the band."""
+        try:
+            import numpy as np  # noqa: PLC0415
+            x = np.asarray(window, dtype=np.float32).reshape(-1)
+            if x.size < 3:
+                return False
+            thirds = np.array_split(x[-min(x.size, 3 * 8000):], 3)
+            scores = []
+            for frame in thirds:
+                conf, _owner = await self._scorer(frame)
+                scores.append(float(conf))
+            non_degrading = all(
+                scores[i + 1] >= scores[i] - 1e-3
+                for i in range(len(scores) - 1)
+            )
+            return non_degrading and (sum(scores) / len(scores)) >= thr
+        except Exception:  # noqa: BLE001
+            return False
+
+
+# ---------------------------------------------------------------------------
+# The mount — called from the supervisor's audio bootstrap
+# ---------------------------------------------------------------------------
+
+
+def mount_passive_sentry(
+    *,
+    broadcaster: Any,
+    mic_register: Callable[[Callable[[Any], None]], Any],
+    scorer: Optional[Callable[[Any], Awaitable[tuple]]] = None,
+) -> Optional[Any]:
+    """Wire the full ambient loop. Returns the sentry, or ``None``
+    when the total gate is down (NOTHING was imported or allocated).
+    NEVER raises.
+
+    * ``broadcaster``  — the AudioStateBroadcaster; its
+      ``publish_event`` is wrapped so ``AUDIO_PLAYING``/``AUDIO_IDLE``
+      drive the Acoustic-Mirage blanking (DRY — the same event the
+      attach plane already consumes).
+    * ``mic_register`` — audio-bus consumer registration (the SHARED
+      capture plane); wrapped in the DeferredCaptureAllocator.
+    """
+    if not sentry_enabled():
+        return None                            # total gate: zero imports
+    try:
+        from .passive_sentry import (  # noqa: PLC0415
+            PassiveSentry,
+            SFSpeechWindowSession,
+        )
+        from backend.core.ouroboros.battle_test.audio_synapse import (  # noqa: E501,PLC0415
+            RemoteAudioLease,
+        )
+
+        gate_adapter = BiometricGateAdapter(scorer)
+
+        async def _lease() -> bool:
+            # DRY: the EXACT CLI-wake pathway — the sentry is a
+            # headless Tri-State broker client.
+            lease = RemoteAudioLease(lambda _s: None)
+            return await lease.acquire()
+
+        def _session_factory() -> Any:
+            try:
+                return SFSpeechWindowSession()
+            except Exception:  # noqa: BLE001
+                return None
+
+        sentry = PassiveSentry(
+            session_factory=_session_factory,
+            verifier=gate_adapter.verify,
+            lease_acquirer=_lease,
+        )
+        sentry.biometrics = gate_adapter       # telemetry surface
+
+        # ---- Acoustic-Mirage wiring (wrap, don't rewrite) ----
+        original_publish = broadcaster.publish_event
+
+        def _publish_with_blanking(kind: str) -> None:
+            original_publish(kind)
+            if kind == "AUDIO_PLAYING":
+                sentry.notify_playback(True)
+            elif kind == "AUDIO_IDLE":
+                sentry.notify_playback(False)
+
+        broadcaster.publish_event = _publish_with_blanking
+
+        # ---- Shared-channel capture with deferral ----
+        def _open_capture() -> Any:
+            return mic_register(sentry.feed_chunk)
+
+        sentry.capture = DeferredCaptureAllocator(_open_capture)
+        sentry.capture.ensure()
+        logger.info(
+            "[Sentry] mounted (capture=%s)", sentry.capture.state,
+        )
+        return sentry
+    except Exception:  # noqa: BLE001
+        logger.warning("[Sentry] mount degraded", exc_info=True)
+        return None
+
+
+__all__ = [
+    "BiometricGateAdapter",
+    "DeferredCaptureAllocator",
+    "STATE_ACTIVE",
+    "STATE_DEFERRED_CAPTURE",
+    "STATE_FAILED",
+    "classify_capture_error",
+    "mount_passive_sentry",
+    "sentry_enabled",
+]

--- a/tests/governance/test_sentry_bootstrap.py
+++ b/tests/governance/test_sentry_bootstrap.py
@@ -1,0 +1,210 @@
+"""Sentry bootstrap spine — deferred capture, biometric gate, total gate.
+
+Mandate 4 verbatim (2026-07-19): a device-busy hardware capture
+failure at supervisor init must leave orchestration loops alive,
+transition to DEFERRED_CAPTURE gracefully, and retry the audio plane —
+no fatal panic.
+"""
+from __future__ import annotations
+
+import asyncio
+import errno
+from pathlib import Path
+
+import numpy as np
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex.sentry_bootstrap import (
+    STATE_ACTIVE,
+    STATE_DEFERRED_CAPTURE,
+    STATE_FAILED,
+    BiometricGateAdapter,
+    DeferredCaptureAllocator,
+    classify_capture_error,
+    mount_passive_sentry,
+)
+
+_REPO = Path(__file__).resolve().parents[2]
+
+
+class TestCaptureClassification:
+    def test_posix_busy_codes_are_retryable(self):
+        e = OSError(errno.EBUSY, "Device busy")
+        assert classify_capture_error(e) == "busy"
+        assert classify_capture_error(
+            OSError(errno.EACCES, "not permitted"),
+        ) == "busy"
+
+    def test_genuine_faults_never_retried(self):
+        assert classify_capture_error(ValueError("bad rate")) == "fault"
+        assert classify_capture_error(
+            OSError(errno.ENOENT, "no device"),
+        ) == "fault"
+
+
+class TestDeferredCapture:
+    async def test_device_busy_defers_then_recovers_no_panic(self):
+        """MANDATE 4 VERBATIM: busy at init → DEFERRED_CAPTURE, the
+        loop keeps running, retry succeeds, state → ACTIVE."""
+        attempts = {"n": 0}
+
+        def _opener():
+            attempts["n"] += 1
+            if attempts["n"] < 3:
+                raise OSError(errno.EBUSY, "Device busy (media link)")
+            return "capture-handle"
+
+        alloc = DeferredCaptureAllocator(
+            _opener, retry_interval_s=0.05, max_retries=10,
+        )
+        assert alloc.ensure() == STATE_DEFERRED_CAPTURE   # graceful
+        # The primary loop is provably alive — we're awaiting on it:
+        for _ in range(60):
+            if alloc.state == STATE_ACTIVE:
+                break
+            await asyncio.sleep(0.05)
+        assert alloc.state == STATE_ACTIVE
+        assert alloc.handle == "capture-handle"
+        assert alloc.stats["busy"] == 2
+        await alloc.stop()
+
+    async def test_real_fault_fails_permanently_no_blind_retry(self):
+        def _opener():
+            raise ValueError("format mismatch — a real bug")
+
+        alloc = DeferredCaptureAllocator(_opener, retry_interval_s=0.05)
+        assert alloc.ensure() == STATE_FAILED
+        await asyncio.sleep(0.2)
+        assert alloc.stats["attempts"] == 1               # never retried
+        await alloc.stop()
+
+    async def test_retry_budget_bounded(self):
+        def _opener():
+            raise OSError(errno.EBUSY, "busy forever")
+
+        alloc = DeferredCaptureAllocator(
+            _opener, retry_interval_s=0.02, max_retries=3,
+        )
+        alloc.ensure()
+        for _ in range(60):
+            if alloc.state == STATE_FAILED:
+                break
+            await asyncio.sleep(0.02)
+        assert alloc.state == STATE_FAILED
+        assert alloc.stats["attempts"] == 4               # 1 + 3 retries
+        await alloc.stop()
+
+
+class TestBiometricGate:
+    async def test_clear_pass_and_clear_fail(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TIER1_VBIA_THRESHOLD", "0.70")
+        monkeypatch.setenv("JARVIS_SENTRY_VBIA_BOUNDARY_MARGIN", "0.05")
+
+        async def _hi(_w): return 0.9, True
+        async def _lo(_w): return 0.2, True
+        assert await BiometricGateAdapter(_hi).verify(np.ones(100)) is True
+        assert await BiometricGateAdapter(_lo).verify(np.ones(100)) is False
+
+    async def test_boundary_band_invokes_pava_drift(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TIER1_VBIA_THRESHOLD", "0.70")
+        monkeypatch.setenv("JARVIS_SENTRY_VBIA_BOUNDARY_MARGIN", "0.05")
+        calls = {"n": 0}
+
+        async def _scorer(w):
+            calls["n"] += 1
+            if calls["n"] == 1:
+                return 0.71, True          # boundary → PAVA engages
+            return 0.72 + 0.01 * calls["n"], True   # non-degrading trend
+
+        gate = BiometricGateAdapter(_scorer)
+        assert await gate.verify(np.ones(48000, dtype=np.float32)) is True
+        assert gate.stats["pava_evals"] == 1
+        assert gate.stats["pava_pass"] == 1
+        assert calls["n"] == 4                            # 1 + 3 frames
+
+    async def test_boundary_with_degrading_drift_fails(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_TIER1_VBIA_THRESHOLD", "0.70")
+        monkeypatch.setenv("JARVIS_SENTRY_VBIA_BOUNDARY_MARGIN", "0.05")
+        seq = iter([(0.71, True), (0.8, True), (0.6, True), (0.5, True)])
+
+        async def _scorer(_w):
+            return next(seq)
+
+        gate = BiometricGateAdapter(_scorer)
+        assert await gate.verify(np.ones(48000, dtype=np.float32)) is False
+        assert gate.stats["pava_fail"] == 1
+
+    async def test_scorer_error_fails_closed(self):
+        async def _boom(_w):
+            raise RuntimeError("biometric stack offline")
+
+        assert await BiometricGateAdapter(_boom).verify(np.ones(10)) is False
+
+    def test_sentry_inverts_permissive_bypass_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/governance/comms/duplex/"
+            "sentry_bootstrap.py"
+        ).read_text()
+        assert "AuthResult.PASSED" in src
+        assert "fail closed" in src.lower() or "fail CLOSED" in src
+
+
+class TestTotalGate:
+    def test_gate_down_means_zero_instantiation(self, monkeypatch):
+        monkeypatch.delenv("JARVIS_PASSIVE_SENTRY_ENABLED", raising=False)
+        touched = {"broadcaster": 0, "mic": 0}
+
+        class _B:
+            def __getattr__(self, name):
+                touched["broadcaster"] += 1
+                raise AttributeError(name)
+
+        result = mount_passive_sentry(
+            broadcaster=_B(),
+            mic_register=lambda cb: touched.__setitem__("mic", 1),
+        )
+        assert result is None
+        assert touched == {"broadcaster": 0, "mic": 0}    # NOTHING touched
+
+    def test_gate_check_precedes_imports_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/governance/comms/duplex/"
+            "sentry_bootstrap.py"
+        ).read_text()
+        body = src[src.index("def mount_passive_sentry"):]
+        assert body.index("sentry_enabled()") < body.index(
+            "from .passive_sentry",
+        )
+
+    async def test_gate_up_full_mount_with_blanking_wrap(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_PASSIVE_SENTRY_ENABLED", "true")
+
+        class _Broadcaster:
+            def __init__(self):
+                self.events = []
+
+            def publish_event(self, kind):
+                self.events.append(kind)
+
+        b = _Broadcaster()
+        regs = []
+        sentry = mount_passive_sentry(
+            broadcaster=b, mic_register=lambda cb: regs.append(cb) or "h",
+        )
+        assert sentry is not None
+        assert regs, "mic consumer never registered"
+        assert sentry.capture.state == STATE_ACTIVE
+        # The blanking wrap: AUDIO_PLAYING blanks, event still flows.
+        b.publish_event("AUDIO_PLAYING")
+        assert b.events == ["AUDIO_PLAYING"]
+        assert sentry.blanked is True
+        b.publish_event("AUDIO_IDLE")
+        assert sentry.stats["mirage_suppressed"] == 0     # nothing fired yet
+
+    def test_dry_lease_pathway_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/governance/comms/duplex/"
+            "sentry_bootstrap.py"
+        ).read_text()
+        assert "RemoteAudioLease" in src                  # the CLI wake path
+        assert "acquire()" in src


### PR DESCRIPTION
## Summary
The three closing integration points of the ambient loop:

1. **Shared-Channel Audio Concurrency** — `DeferredCaptureAllocator`: device-busy classified deterministically (PortAudio contention family + POSIX `EBUSY`/`EACCES`/`EAGAIN`, closed vocabulary) → `DEFERRED_CAPTURE` with bounded async retries; the primary FSM never blocks. Real faults fail permanently — never blind-retried.
2. **VBIA/PAVA biometric gate** — wraps the existing `voice_authentication_layer` (zero rewritten biometric code). Stitched pre-roll window is the primary target; boundary-band scores invoke the PAVA drift matrix over three trailing sub-frames (non-degrading trend + mean over threshold). Sentry semantics invert tier-1's permissive `BYPASSED`: no adapter → nobody wakes it.
3. **Total fail-closed gate** — `JARVIS_PASSIVE_SENTRY_ENABLED` (default OFF) checked before any import: threads, deques, pyobjc runloops completely uninstantiated when down (pinned: gate-down mount touches neither broadcaster nor mic registrar).

DRY: the wake lease is the exact `RemoteAudioLease` CLI pathway; mirage blanking wraps `publish_event` on the same `AUDIO_PLAYING`/`AUDIO_IDLE` events the attach plane consumes.

## Testing
14 tests incl. **mandate 4 verbatim**: device-busy hardware failure at supervisor init → graceful `DEFERRED_CAPTURE`, orchestration loop provably alive (the test awaits on it), retry succeeds → `ACTIVE`, no fatal panic. Plus: fault-vs-busy classification, bounded retry budget, PAVA drift pass/fail, scorer-error fail-closed, blanking wrap. 71-test ambient/audio sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Wired passive sentry into the ambient audio loop with a fail-closed global gate, deterministic deferred capture, and a VBIA/PAVA biometric check. Prevents blocking on busy devices and only allows owner-triggered wake.

- **New Features**
  - Added `sentry_bootstrap.mount_passive_sentry` with a total fail-closed env gate `JARVIS_PASSIVE_SENTRY_ENABLED` (default off). The gate is checked before any sentry import; when off, nothing is instantiated. Mounted from `backend/audio/audio_pipeline_bootstrap.py`.
  - Shared-channel capture via `DeferredCaptureAllocator`: deterministic busy classification (PortAudio -9985/-9986/-9988/-9996, POSIX `EBUSY`/`EACCES`/`EAGAIN`) → `DEFERRED_CAPTURE` with bounded async retries (`JARVIS_SENTRY_CAPTURE_RETRY_S`, `JARVIS_SENTRY_CAPTURE_MAX_RETRIES`). Real faults fail once; the main FSM never blocks.
  - Biometric gate via `BiometricGateAdapter` wrapping `voice_authentication_layer`: clear pass/fail around `JARVIS_TIER1_VBIA_THRESHOLD` with `JARVIS_SENTRY_VBIA_BOUNDARY_MARGIN`. Boundary band triggers PAVA drift over 3 trailing sub-frames; BYPASSED/ERROR fail closed.
  - DRY wiring: uses `RemoteAudioLease` for wake. Wraps `broadcaster.publish_event` so `AUDIO_PLAYING`/`AUDIO_IDLE` drive Acoustic Mirage blanking.

- **Migration**
  - Enable with `JARVIS_PASSIVE_SENTRY_ENABLED=true`.
  - Optional tuning: `JARVIS_SENTRY_CAPTURE_RETRY_S`, `JARVIS_SENTRY_CAPTURE_MAX_RETRIES`, `JARVIS_TIER1_VBIA_THRESHOLD`, `JARVIS_SENTRY_VBIA_BOUNDARY_MARGIN`.

<sup>Written for commit e9a20682ebb911af5ecb5406a31e24502050c4f6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

