### PR TITLE
fix(audio): native in-memory PCM marshal + main-runloop pump — ambient loop proven live

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/passive_sentry.py
+++ b/backend/core/ouroboros/governance/comms/duplex/passive_sentry.py
@@ -304,6 +304,21 @@ class PassiveSentry:
 # ---------------------------------------------------------------------------
 
 
+def numpy_to_pcm_buffer(x: "np.ndarray", fmt: Any, pcm_buffer_cls: Any) -> Any:
+    """float32 numpy → AVAudioPCMBuffer via the SAFE pyobjc bridge:
+    ``floatChannelData()[0].as_buffer(n)`` yields a WRITABLE
+    memoryview over the buffer's own channel storage — no ctypes, no
+    address arithmetic, byte-exact. Caller owns the autorelease pool."""
+    buf = pcm_buffer_cls.alloc().initWithPCMFormat_frameCapacity_(
+        fmt, x.size,
+    )
+    buf.setFrameLength_(x.size)
+    channel = buf.floatChannelData()[0]
+    view = channel.as_buffer(x.size)
+    memoryview(view).cast("B")[: x.nbytes] = x.tobytes()
+    return buf
+
+
 class SFSpeechWindowSession:
     """One windowed on-device recognition burst. Wraps the three
     scout-proven mechanics: buffer-append streaming, an NSRunLoop pump
@@ -323,6 +338,12 @@ class SFSpeechWindowSession:
         self._AVAudioFormat = AVAudioFormat
         self._AVAudioPCMBuffer = AVAudioPCMBuffer
         self._rate = rate
+        # ONE format object for the session (bit depth / rate /
+        # interleaving fixed): pcmFormatFloat32, mono, deinterleaved —
+        # exactly what SFSpeechAudioBufferRecognitionRequest accepts.
+        self._fmt = AVAudioFormat.alloc().initWithCommonFormat_sampleRate_channels_interleaved_(  # noqa: E501
+            1, float(rate), 1, False,
+        )
         rec = Speech.SFSpeechRecognizer.alloc().init()
         if rec is None or not rec.isAvailable():
             raise RuntimeError("SFSpeechRecognizer unavailable")
@@ -337,20 +358,25 @@ class SFSpeechWindowSession:
         self._task = rec.recognitionTaskWithRequest_resultHandler_(
             req, self._result_cb,
         )
+        # Callback delivery contract (2026-07-19 dual-root fix):
+        # pyobjc schedules these result blocks onto the MAIN runloop —
+        # a secondary pump thread pumps ITS OWN loop and hears nothing
+        # (16 silent windows). The HOST owns the pump: call
+        # pump_main_runloop() from the MAIN thread each capture tick.
         self._pump_alive = True
-        import threading  # noqa: PLC0415
 
-        def _pump() -> None:
+    @staticmethod
+    def pump_main_runloop(seconds: float = 0.0) -> None:
+        """Drain pending main-runloop callbacks. MUST be called from
+        the main thread (the capture loop's natural cadence — one call
+        per 30ms chunk is ample). NEVER raises."""
+        try:
             from Foundation import NSDate, NSRunLoop  # noqa: PLC0415
-            while self._pump_alive:
-                NSRunLoop.currentRunLoop().runUntilDate_(
-                    NSDate.dateWithTimeIntervalSinceNow_(0.05),
-                )
-
-        self._pump_thread = threading.Thread(
-            target=_pump, name="sentry-runloop-pump", daemon=True,
-        )
-        self._pump_thread.start()
+            NSRunLoop.currentRunLoop().runUntilDate_(
+                NSDate.dateWithTimeIntervalSinceNow_(max(0.0, seconds)),
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
     def _result_cb(self, result: Any, error: Any) -> None:
         try:
@@ -366,23 +392,25 @@ class SFSpeechWindowSession:
         self._on_partial = cb
 
     def append(self, chunk: "np.ndarray") -> None:
-        fmt = self._AVAudioFormat.alloc().initWithCommonFormat_sampleRate_channels_interleaved_(  # noqa: E501
-            1, float(self._rate), 1, False,   # 1 == pcmFormatFloat32
-        )
-        x = np.ascontiguousarray(chunk, dtype=np.float32)
-        buf = self._AVAudioPCMBuffer.alloc().initWithPCMFormat_frameCapacity_(
-            fmt, x.size,
-        )
-        buf.setFrameLength_(x.size)
-        import ctypes  # noqa: PLC0415
-        dst = buf.floatChannelData()[0]
-        ctypes.memmove(
-            ctypes.c_void_p(int(ctypes.cast(
-                dst, ctypes.c_void_p,
-            ).value or 0)),
-            x.ctypes.data, x.nbytes,
-        )
-        self._req.appendAudioPCMBuffer_(buf)
+        """Native in-memory marshal (2026-07-19 root fix): the ctypes
+        memmove pointer-cast silently wrote to a WRONG address on
+        ARM64 (16 live windows, zero partials — garbage buffers). The
+        architecturally safe bridge is pyobjc's ``varlist.as_buffer``:
+        a WRITABLE memoryview over the buffer's own float channel —
+        zero address arithmetic, byte-exact (probe-proven round-trip).
+        The whole append runs inside an ``objc.autorelease_pool`` so a
+        24/7 sentry's transient ObjC buffers are destroyed instantly —
+        ARC and Python GC can never drift apart (leak-tested 10k
+        iterations flat)."""
+        import objc  # noqa: PLC0415
+        x = np.ascontiguousarray(chunk, dtype=np.float32).reshape(-1)
+        if x.size == 0:
+            return
+        with objc.autorelease_pool():
+            buf = numpy_to_pcm_buffer(
+                x, self._fmt, self._AVAudioPCMBuffer,
+            )
+            self._req.appendAudioPCMBuffer_(buf)
 
     def close(self) -> None:
         try:

--- a/tests/governance/test_passive_sentry.py
+++ b/tests/governance/test_passive_sentry.py
@@ -242,3 +242,66 @@ class TestBiometricGate:
         assert sentry.state == STATE_LEASED
         sentry.on_lease_released()
         assert sentry.state == STATE_PASSIVE          # the ear re-ajars
+
+
+# ---------------------------------------------------------------------------
+# Native in-memory marshal + ARC leak proof (2026-07-19)
+# ---------------------------------------------------------------------------
+
+
+class TestNativeMarshalARC:
+    def _av(self):
+        pytest.importorskip("objc")
+        from AVFoundation import AVAudioFormat, AVAudioPCMBuffer
+        fmt = AVAudioFormat.alloc().initWithCommonFormat_sampleRate_channels_interleaved_(  # noqa: E501
+            1, 16000.0, 1, False,
+        )
+        return fmt, AVAudioPCMBuffer
+
+    def test_marshal_is_byte_exact(self):
+        from backend.core.ouroboros.governance.comms.duplex.passive_sentry import (  # noqa: E501
+            numpy_to_pcm_buffer,
+        )
+        fmt, cls = self._av()
+        x = (0.5 * np.sin(np.arange(4800) * 0.05)).astype(np.float32)
+        buf = numpy_to_pcm_buffer(x, fmt, cls)
+        view = buf.floatChannelData()[0].as_buffer(x.size)
+        back = np.frombuffer(
+            memoryview(view).cast("B")[: x.nbytes], dtype=np.float32,
+        )
+        assert np.array_equal(back, x)
+        assert int(buf.frameLength()) == x.size
+
+    def test_10k_iterations_memory_flat_under_arc_pool(self):
+        """MANDATE 4: 10,000 create+marshal iterations inside
+        objc.autorelease_pool → RSS absolutely flat (the 24/7-sentry
+        leak class is dead)."""
+        import objc
+        import psutil
+        from backend.core.ouroboros.governance.comms.duplex.passive_sentry import (  # noqa: E501
+            numpy_to_pcm_buffer,
+        )
+        fmt, cls = self._av()
+        x = np.zeros(480, dtype=np.float32)
+        proc = psutil.Process()
+        # Warm-up (allocator pools, pyobjc caches):
+        with objc.autorelease_pool():
+            for _ in range(500):
+                numpy_to_pcm_buffer(x, fmt, cls)
+        rss0 = proc.memory_info().rss
+        for _ in range(100):
+            with objc.autorelease_pool():
+                for _ in range(100):
+                    numpy_to_pcm_buffer(x, fmt, cls)
+        delta_mb = (proc.memory_info().rss - rss0) / 1e6
+        assert delta_mb < 8.0, f"leak: RSS grew {delta_mb:.1f}MB over 10k"
+
+    def test_session_pump_contract_pin(self):
+        from pathlib import Path
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/comms/duplex/passive_sentry.py"
+        ).read_text()
+        assert "pump_main_runloop" in src
+        assert "import ctypes" not in src       # the wrong bridge is GONE
+        assert "autorelease_pool" in src


### PR DESCRIPTION
## Summary
Dual root of the silent recognition windows, both fixed strictly in-memory (disk-I/O fallback rejected per mandate): (1) the ctypes `memmove` pointer-cast wrote to a wrong ARM64 address — replaced with pyobjc's safe `as_buffer()` writable-memoryview bridge, byte-exact, zero address arithmetic; (2) the pump thread drained its own runloop while pyobjc delivers recognition callbacks on the **main** runloop — pump thread deleted, `pump_main_runloop()` is now an explicit host contract per capture tick. Every append runs inside `objc.autorelease_pool`.

## Testing
Mandate-4 ARC leak spine: 10,000 buffer creations, RSS flat. 13/13 sentry suite. **Live-fire round 2, operator's real voice:** `'Ja' → 'Jarvis'` partial → verify → lease armed +2ms → Daniel answered through the speakers → Daniel's own voice mirage-suppressed (the organism did not wake itself) → clean disarm. `answered: true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent recognition windows by switching to a safe in-memory PCM marshal and handling callbacks on the main runloop. Restores reliable partials and prevents ARC leaks during long runs.

- **Bug Fixes**
  - Replaced unsafe `ctypes.memmove` with `pyobjc` channel `as_buffer()` for byte-exact writes; added `numpy_to_pcm_buffer`; reuse one `AVAudioFormat` per session.
  - Removed background pump thread; callbacks are processed via the main runloop using `SFSpeechWindowSession.pump_main_runloop()`.
  - Wrapped appends in `objc.autorelease_pool()` to prevent ARC leaks; tests cover byte-exact marshal and 10k-iteration RSS stability.

- **Migration**
  - Call `SFSpeechWindowSession.pump_main_runloop()` from the main thread once per capture tick (~30 ms). Remove any local pump thread.

<sup>Written for commit 8cbcb4a3a3d295f4f395fe461062ee435e52fc55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

