### PR TITLE
feat(sovereignty): production x-vector scorer — async warmup queue, no_grad hygiene

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/biometric_scorer.py
+++ b/backend/core/ouroboros/governance/comms/duplex/biometric_scorer.py
@@ -1,0 +1,251 @@
+"""Production x-vector scorer — the sovereign loop's identity organ.
+
+Final integration (operator authorization 2026-07-19). Scores the
+sentry's stitched window against the operator's REAL 192-dim x-vector
+enrollment via the speechbrain encoder already mounted at
+``~/.jarvis/models/speaker_recognition`` (resolved dynamically — the
+same symlink farm the VBIA stack owns).
+
+**Startup Race (mandate 2, solved structurally):** the mic arms at
+ignition; the encoder loads ASYNCHRONOUSLY in an executor thread (no
+blocking sleeps, mandate 1). A wake-word arriving mid-load routes its
+payload into a bounded ``asyncio.Queue`` and the scorer reports state
+``BIOMETRIC_WARMUP_WAIT``; the moment the load completes, a drainer
+task processes the backlog IN ARRIVAL ORDER — zero payload loss, zero
+event-loop blocking. Load FAILURES follow the DeferredCaptureAllocator
+discipline (same state vocabulary, same bounded-retry shape, fault
+classified — a missing model dir is permanent, a transient OSError
+retries).
+
+**Memory hygiene (mandate 2):** the encoder is instantiated
+``.eval()`` and EVERY inference — verification and Rolling-Evolution
+extraction alike — runs under ``torch.no_grad()``: no gradient tape
+can accumulate across 24/7 resident uptime.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from pathlib import Path
+from typing import Any, Callable, Optional, Tuple
+
+import numpy as np
+
+logger = logging.getLogger("Ouroboros.BiometricScorer")
+
+STATE_LOADING = "BIOMETRIC_WARMUP_WAIT"
+STATE_READY = "READY"
+STATE_FAILED = "FAILED"
+
+
+def encoder_dir() -> Optional[Path]:
+    """Dynamic resolution: env override → the models namespace the
+    VBIA stack already populates. NEVER raises."""
+    try:
+        env = os.environ.get("JARVIS_SPEAKER_ENCODER_DIR", "").strip()
+        if env:
+            p = Path(os.path.expanduser(env))
+            return p if p.exists() else None
+        data = Path(os.path.expanduser(
+            os.environ.get("JARVIS_DATA_DIR", "~/.jarvis"),
+        ))
+        p = data / "models" / "speaker_recognition"
+        return p if p.exists() else None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _warmup_queue_cap() -> int:
+    try:
+        return max(1, int(os.environ.get("JARVIS_BIOMETRIC_WARMUP_QUEUE", "8")))
+    except (TypeError, ValueError):
+        return 8
+
+
+def _warmup_timeout_s() -> float:
+    try:
+        return max(5.0, float(os.environ.get(
+            "JARVIS_BIOMETRIC_WARMUP_TIMEOUT_S", "120",
+        )))
+    except (TypeError, ValueError):
+        return 120.0
+
+
+class XVectorScorer:
+    """Async-loading scorer with the Biometric Deferred-Evaluation
+    Queue. Injectable seams: ``load_fn`` (blocking, runs in executor;
+    returns the encoder) and ``embed_fn(encoder, window) → np.ndarray``
+    — production defaults use speechbrain+torch; tests inject fakes.
+
+    ``verify(window) → (confidence, is_owner)`` is the
+    BiometricGateAdapter scorer contract; ``last_embedding`` is the
+    Rolling-Evolution seam.
+    """
+
+    def __init__(
+        self,
+        *,
+        load_fn: Optional[Callable[[], Any]] = None,
+        embed_fn: Optional[Callable[[Any, Any], "np.ndarray"]] = None,
+        enrollment_loader: Optional[Callable[[], Any]] = None,
+    ) -> None:
+        self._load_fn = load_fn or self._default_load
+        self._embed_fn = embed_fn or self._default_embed
+        self._enrollment_loader = enrollment_loader or self._default_enrollment
+        self.state = STATE_LOADING
+        self._encoder: Any = None
+        self._loaded = asyncio.Event()
+        self._queue: "asyncio.Queue" = asyncio.Queue(
+            maxsize=_warmup_queue_cap(),
+        )
+        self._drainer: Optional[asyncio.Task] = None
+        self.last_embedding: Optional["np.ndarray"] = None
+        self.stats = {
+            "queued_during_warmup": 0, "drained": 0, "scored": 0,
+            "queue_overflow_dropped": 0,
+        }
+
+    # ---- production seams (import-guarded) ----
+
+    @staticmethod
+    def _default_load() -> Any:
+        d = encoder_dir()
+        if d is None:
+            raise FileNotFoundError("speaker encoder dir absent")
+        from speechbrain.pretrained import EncoderClassifier  # noqa: PLC0415
+        enc = EncoderClassifier.from_hparams(
+            source=str(d), savedir=str(d), run_opts={"device": "cpu"},
+        )
+        # eval mode — never training, never dropout jitter.
+        enc.eval()
+        return enc
+
+    @staticmethod
+    def _default_embed(encoder: Any, window: Any) -> "np.ndarray":
+        import torch  # noqa: PLC0415
+        x = torch.from_numpy(
+            np.asarray(window, dtype=np.float32).reshape(1, -1),
+        )
+        # STRICT no_grad: 24/7 residency must never accumulate tape.
+        with torch.no_grad():
+            emb = encoder.encode_batch(x)
+        return emb.squeeze().cpu().numpy().astype(np.float32)
+
+    @staticmethod
+    def _default_enrollment() -> Any:
+        from .biometric_evolution import load_enrollment  # noqa: PLC0415
+        return load_enrollment()
+
+    # ---- lifecycle ----
+
+    async def start_loading(self) -> None:
+        """Fire the executor load; returns IMMEDIATELY (the mic is
+        already live). NEVER raises."""
+        try:
+            loop = asyncio.get_running_loop()
+
+            async def _load() -> None:
+                try:
+                    self._encoder = await loop.run_in_executor(
+                        None, self._load_fn,
+                    )
+                    self.state = STATE_READY
+                    self._loaded.set()
+                    logger.info("[BioScorer] encoder READY — draining %d "
+                                "warmup payload(s)", self._queue.qsize())
+                except FileNotFoundError:
+                    self.state = STATE_FAILED     # permanent — no retry
+                    self._loaded.set()
+                except Exception:  # noqa: BLE001
+                    logger.warning("[BioScorer] load failed", exc_info=True)
+                    self.state = STATE_FAILED
+                    self._loaded.set()
+
+            loop.create_task(_load())
+            self._drainer = loop.create_task(self._drain_loop())
+        except RuntimeError:
+            self.state = STATE_FAILED
+
+    async def _drain_loop(self) -> None:
+        """The Deferred-Evaluation drainer: waits for READY, then
+        serves the backlog in arrival order, then live requests."""
+        try:
+            await self._loaded.wait()
+            while True:
+                window, fut = await self._queue.get()
+                if not fut.done():
+                    fut.set_result(self._score_now(window))
+                self.stats["drained"] += 1
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[BioScorer] drainer degraded", exc_info=True)
+
+    def _score_now(self, window: Any) -> Tuple[float, bool]:
+        """Synchronous scoring path (encoder is READY). Fail-closed."""
+        try:
+            if self.state != STATE_READY or self._encoder is None:
+                return 0.0, False
+            emb = self._embed_fn(self._encoder, window)
+            self.last_embedding = np.asarray(emb, dtype=np.float32).reshape(-1)
+            enrolled = self._enrollment_loader()
+            if enrolled is None:
+                return 0.0, False
+            _sid, _name, baseline = enrolled
+            b = np.asarray(baseline, dtype=np.float32).reshape(-1)
+            e = self.last_embedding
+            if b.shape != e.shape or b.size == 0:
+                return 0.0, False
+            cos = float(np.dot(b, e) / (
+                (np.linalg.norm(b) * np.linalg.norm(e)) + 1e-9
+            ))
+            conf = max(0.0, min(1.0, (cos + 1.0) / 2.0))
+            self.stats["scored"] += 1
+            return conf, cos > 0.0
+        except Exception:  # noqa: BLE001
+            return 0.0, False
+
+    async def verify(self, window: Any) -> Tuple[float, bool]:
+        """The BiometricGateAdapter scorer contract. Mid-warmup: the
+        payload is QUEUED (never dropped, never blocking) and the
+        caller's await resolves when the drainer reaches it — bounded
+        by the warmup timeout, fail-closed on expiry/overflow."""
+        try:
+            if self.state == STATE_READY:
+                return self._score_now(window)
+            if self.state == STATE_FAILED:
+                return 0.0, False
+            fut: "asyncio.Future" = asyncio.get_running_loop().create_future()
+            try:
+                self._queue.put_nowait((window, fut))
+                self.stats["queued_during_warmup"] += 1
+            except asyncio.QueueFull:
+                self.stats["queue_overflow_dropped"] += 1
+                return 0.0, False
+            return await asyncio.wait_for(fut, timeout=_warmup_timeout_s())
+        except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+            return 0.0, False
+
+    async def stop(self) -> None:
+        """Teardown. NEVER raises."""
+        try:
+            task = self._drainer
+            self._drainer = None
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+        except Exception:  # noqa: BLE001
+            pass
+
+
+__all__ = [
+    "STATE_FAILED",
+    "STATE_LOADING",
+    "STATE_READY",
+    "XVectorScorer",
+    "encoder_dir",
+]

--- a/backend/core/ouroboros/governance/comms/duplex/sentry_bootstrap.py
+++ b/backend/core/ouroboros/governance/comms/duplex/sentry_bootstrap.py
@@ -277,7 +277,7 @@ class BiometricGateAdapter:
                 # native x-vector space; strict tensor guards inside).
                 try:
                     from .biometric_evolution import evolve_if_confident  # noqa: E501,PLC0415
-                    emb = getattr(self, "last_embedding", None)
+                    emb = getattr(getattr(self, "scorer_ref", None), "last_embedding", None) or getattr(self, "last_embedding", None)
                     if emb is not None and evolve_if_confident(conf, emb):
                         self.stats["evolutions"] = (
                             self.stats.get("evolutions", 0) + 1
@@ -352,7 +352,35 @@ def mount_passive_sentry(
             RemoteAudioLease,
         )
 
+        # Production x-vector scorer (final integration 2026-07-19):
+        # async encoder load — the mic arms NOW, wake-words landing
+        # mid-warmup queue in the Deferred-Evaluation lane. Fail-soft
+        # to the injected scorer (tests) or fail-closed default.
+        _xvec = None
+        if scorer is None:
+            try:
+                from .biometric_scorer import XVectorScorer  # noqa: PLC0415
+                _xvec = XVectorScorer()
+                await_start = getattr(_xvec, "start_loading", None)
+                if await_start is not None:
+                    import asyncio as _aio  # noqa: PLC0415
+                    try:
+                        _aio.get_running_loop().create_task(await_start())
+                    except RuntimeError:
+                        _xvec = None
+                scorer = _xvec.verify if _xvec is not None else None
+            except Exception:  # noqa: BLE001
+                _xvec = None
         gate_adapter = BiometricGateAdapter(scorer)
+        if _xvec is not None:
+            # Rolling-Evolution seam: the adapter reads the scorer's
+            # freshest embedding after a clear pass.
+            gate_adapter.last_embedding = None
+
+            class _EmbeddingMirror:
+                def __get__(self, obj, owner=None):
+                    return _xvec.last_embedding
+            gate_adapter.scorer_ref = _xvec
 
         async def _lease() -> bool:
             # DRY: the EXACT CLI-wake pathway — the sentry is a

--- a/tests/governance/test_sentry_bootstrap.py
+++ b/tests/governance/test_sentry_bootstrap.py
@@ -308,3 +308,121 @@ class TestBiometricEvolution:
         _sid, name, emb = enrolled
         assert emb.dtype == np.float32 and emb.size in (192, 512)
         assert name                                        # a real human name
+
+
+# ---------------------------------------------------------------------------
+# Production scorer — startup-race concurrency proof (2026-07-19)
+# ---------------------------------------------------------------------------
+
+
+class TestBiometricWarmupQueue:
+    def _scorer(self, load_delay_s, dim=192):
+        import asyncio as aio
+        from backend.core.ouroboros.governance.comms.duplex.biometric_scorer import (  # noqa: E501
+            XVectorScorer,
+        )
+        import time as _t
+        base = np.linspace(0.1, 1.0, dim).astype(np.float32)
+
+        def _slow_load():
+            _t.sleep(load_delay_s)      # blocking IN THE EXECUTOR only
+            return "encoder"
+
+        def _embed(_enc, window):
+            # deterministic: embedding == baseline → cosine 1.0
+            return base.copy()
+
+        return XVectorScorer(
+            load_fn=_slow_load,
+            embed_fn=_embed,
+            enrollment_loader=lambda: (1, "Derek J. Russell", base),
+        )
+
+    async def test_wake_200ms_before_load_completes_queued_not_lost(self):
+        """MANDATE 4 VERBATIM: chunk arrives 200ms before the encoder
+        finishes loading → safely queued (BIOMETRIC_WARMUP_WAIT), the
+        event loop stays unblocked, the backlog drains on READY, and
+        the queued chunk scores — zero data loss."""
+        from backend.core.ouroboros.governance.comms.duplex.biometric_scorer import (  # noqa: E501
+            STATE_LOADING,
+            STATE_READY,
+        )
+        scorer = self._scorer(load_delay_s=0.4)
+        await scorer.start_loading()
+        await asyncio.sleep(0.2)                       # 200ms into the load
+        assert scorer.state == STATE_LOADING           # still warming
+        window = np.ones(24000, dtype=np.float32)
+        heartbeat = {"ticks": 0}
+
+        async def _pulse():
+            for _ in range(20):
+                heartbeat["ticks"] += 1
+                await asyncio.sleep(0.02)
+
+        pulse = asyncio.get_running_loop().create_task(_pulse())
+        conf, is_owner = await scorer.verify(window)   # the racing wake
+        await pulse
+        assert scorer.state == STATE_READY
+        assert scorer.stats["queued_during_warmup"] == 1
+        assert scorer.stats["drained"] == 1            # zero loss
+        assert conf > 0.99 and is_owner is True        # scored correctly
+        # The main loop was NEVER blocked while we waited:
+        assert heartbeat["ticks"] >= 10
+        await scorer.stop()
+
+    async def test_ready_path_scores_inline_no_queue(self):
+        scorer = self._scorer(load_delay_s=0.0)
+        await scorer.start_loading()
+        for _ in range(50):
+            if scorer.state == "READY":
+                break
+            await asyncio.sleep(0.02)
+        conf, owner = await scorer.verify(np.ones(1000, dtype=np.float32))
+        assert conf > 0.99 and owner
+        assert scorer.stats["queued_during_warmup"] == 0
+        assert scorer.last_embedding is not None       # evolution seam fed
+        await scorer.stop()
+
+    async def test_permanent_load_failure_fails_closed(self):
+        from backend.core.ouroboros.governance.comms.duplex.biometric_scorer import (  # noqa: E501
+            STATE_FAILED,
+            XVectorScorer,
+        )
+
+        def _boom():
+            raise FileNotFoundError("no encoder")
+
+        scorer = XVectorScorer(load_fn=_boom, embed_fn=lambda e, w: None,
+                               enrollment_loader=lambda: None)
+        await scorer.start_loading()
+        for _ in range(50):
+            if scorer.state == STATE_FAILED:
+                break
+            await asyncio.sleep(0.02)
+        assert await scorer.verify(np.ones(100)) == (0.0, False)
+        await scorer.stop()
+
+    async def test_queue_overflow_drops_closed_never_blocks(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_BIOMETRIC_WARMUP_QUEUE", "1")
+        scorer = self._scorer(load_delay_s=0.5)
+        await scorer.start_loading()
+        w = np.ones(100, dtype=np.float32)
+        t1 = asyncio.get_running_loop().create_task(scorer.verify(w))
+        await asyncio.sleep(0.05)
+        t2 = asyncio.get_running_loop().create_task(scorer.verify(w))
+        r2 = await asyncio.wait_for(t2, timeout=1.0)
+        assert r2 == (0.0, False)                      # overflow fail-closed
+        r1 = await asyncio.wait_for(t1, timeout=2.0)
+        assert r1[0] > 0.99                            # first still served
+        assert scorer.stats["queue_overflow_dropped"] == 1
+        await scorer.stop()
+
+    def test_production_seams_pin(self):
+        src = (
+            _REPO / "backend/core/ouroboros/governance/comms/duplex/"
+            "biometric_scorer.py"
+        ).read_text()
+        assert "enc.eval()" in src                     # eval mode
+        assert "torch.no_grad()" in src                # 24/7 tape hygiene
+        assert "run_in_executor" in src                # never a sleep-wait
+        assert "time.sleep" not in src.replace("_t.sleep", "")


### PR DESCRIPTION
## Summary
The sovereign loop's identity organ: speechbrain x-vector encoder loaded asynchronously in an executor (mic arms at ignition — no blocking waits), scoring the sentry's stitched window against the operator's real 192-dim enrollment. The **Biometric Deferred-Evaluation Queue** solves the startup race structurally: a wake-word mid-warmup queues its payload (`BIOMETRIC_WARMUP_WAIT`), the drainer serves the backlog in arrival order on READY — overflow and timeout fail closed. Encoder pinned `.eval()`, every inference under `torch.no_grad()` (24/7 tape hygiene). Auto-mounted in `mount_passive_sentry` when speechbrain is importable; the Rolling-Evolution hook reads the scorer's freshest embedding.

## Testing
Mandate-4 verbatim: chunk arrives **200ms before** load completion → queued, event loop provably unblocked (a heartbeat task keeps ticking during the wait), backlog drains, chunk scores conf>0.99 — zero loss. Plus inline-READY, permanent-failure fail-closed, overflow-never-blocks, and eval/no_grad source pins. 25/25 suite; cli+sentry+quarantine sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a production x-vector biometric scorer that loads the `speechbrain` encoder asynchronously and queues wake-word payloads during warmup so the mic never blocks or loses data. Integrates with the passive sentry and enforces `.eval()` + `torch.no_grad()` for safe 24/7 inference.

- **New Features**
  - Async encoder load in an executor; requests arriving pre-READY go into a bounded `asyncio.Queue` and drain on READY.
  - Fail-closed behavior: warmup timeout and queue overflow drop safely; permanent load failures do not retry.
  - Cosine scoring against the real 192‑dim enrollment; exposes `last_embedding` for Rolling Evolution.
  - Auto-mounted in `mount_passive_sentry` when `speechbrain` is available; falls back to injected scorer in tests.
  - Dynamic model dir resolution via `JARVIS_SPEAKER_ENCODER_DIR` or `JARVIS_DATA_DIR`; queue size and timeout via `JARVIS_BIOMETRIC_WARMUP_QUEUE` and `JARVIS_BIOMETRIC_WARMUP_TIMEOUT_S`.

<sup>Written for commit 8ee741563d5476f4e8c2a1c969af4e1435260f4f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69954?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

