### PR TITLE
feat(sovereignty): Multimodal Gaze + VBIA→PAVA handoff + Ignition Reporter

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/pava_handoff.py
+++ b/backend/core/ouroboros/governance/comms/duplex/pava_handoff.py
@@ -1,0 +1,182 @@
+"""VBIA → PAVA handoff + Autonomous Ignition Reporter.
+
+Operator authorization 2026-07-19 (reuse-not-duplicate directive).
+
+**VBIA → PAVA (mandate 2):** the x-vector cosine (``biometric_scorer``)
+is the ABSOLUTE gate. On a pass the payload hands off to the EXISTING
+PAVA drift matrix — ``backend.voice.advanced_biometric_verification.
+AdvancedBiometricVerifier`` (Bayesian + Mahalanobis + physics + anti-
+spoof) — which probabilistically tracks background acoustic
+degradation. Its confidence MODULATES the Rolling-Evolution EMA alpha:
+a physics-plausible, spoof-clean sample teaches the profile faster;
+a drifting/suspect one teaches slower or not at all. PAVA never
+overrides VBIA's gate — it only shapes how much the profile learns.
+
+**Autonomous Ignition Reporter (mandate 2):** the supervisor captures
+its OWN boot telemetry (encoder load ms, first cosine scores,
+threshold tunes, thermal state) and, on successful init, Daniel emits
+a silent ``SYSTEM_BOOT_REPORT`` frame over the attach pub/sub — the
+jarvis topology map renders it with no manual extraction.
+"""
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Awaitable, Callable, Dict, List, Optional
+
+import numpy as np
+
+logger = logging.getLogger("Ouroboros.PavaHandoff")
+
+
+class PavaDriftModulator:
+    """Wraps the EXISTING AdvancedBiometricVerifier as the drift lane.
+
+    ``pava_scorer(window) -> (plausibility: float, spoof_clean: bool)``
+    is the injected seam; the production default composes the existing
+    verifier. NEVER raises."""
+
+    def __init__(
+        self,
+        *,
+        pava_scorer: Optional[Callable[[Any], Awaitable[tuple]]] = None,
+    ) -> None:
+        self._pava = pava_scorer or self._default_pava
+        self._history: List[float] = []
+        self.stats: Dict[str, int] = {
+            "handoffs": 0, "spoof_rejected": 0, "drift_slowed": 0,
+        }
+
+    @staticmethod
+    async def _default_pava(window: Any) -> tuple:
+        # EXISTING organ (operator directive): the physics + anti-spoof
+        # verifier. Degrades to a neutral plausibility if unmountable
+        # (VBIA already gated — PAVA only shapes learning rate).
+        try:
+            from backend.voice.advanced_biometric_verification import (  # noqa: E501,PLC0415
+                AdvancedBiometricVerifier,
+            )
+            v = AdvancedBiometricVerifier(enable_adaptive_learning=False)
+            res = await v.verify_speaker(
+                np.asarray(window, dtype=np.float32),
+            )
+            plausibility = float(getattr(res, "physics_plausibility", 0.8))
+            spoof_clean = bool(getattr(res, "anti_spoofing_passed", True))
+            return plausibility, spoof_clean
+        except Exception:  # noqa: BLE001
+            return 0.8, True                   # neutral — VBIA already passed
+
+    async def modulated_alpha(
+        self, window: Any, base_alpha: float,
+    ) -> float:
+        """The handoff: PAVA drift → an evolution-alpha multiplier.
+        Spoof-suspect → 0 (never teach); low physics plausibility →
+        damped; clean + stable → full. NEVER raises."""
+        try:
+            self.stats["handoffs"] += 1
+            plausibility, spoof_clean = await self._pava(window)
+            if not spoof_clean:
+                self.stats["spoof_rejected"] += 1
+                return 0.0                     # anti-spoof veto on LEARNING
+            self._history.append(float(plausibility))
+            if len(self._history) > 100:
+                self._history.pop(0)
+            # Drift term: variance of recent plausibility widens →
+            # acoustics unstable → slow the EMA.
+            drift = float(np.std(self._history[-20:])) if len(
+                self._history,
+            ) >= 3 else 0.0
+            factor = max(0.0, min(1.0, plausibility * (1.0 - min(1.0, drift * 3))))
+            if factor < 0.9:
+                self.stats["drift_slowed"] += 1
+            return base_alpha * factor
+        except Exception:  # noqa: BLE001
+            return base_alpha
+
+
+# ---------------------------------------------------------------------------
+# Autonomous Ignition Reporter
+# ---------------------------------------------------------------------------
+
+
+class IgnitionReporter:
+    """Accumulates boot telemetry; on ``finalize`` emits the silent
+    SYSTEM_BOOT_REPORT over the injected publisher (the attach pub/sub
+    ``publish_line`` / a thermal-style frame). NEVER raises."""
+
+    def __init__(
+        self,
+        *,
+        publish: Optional[Callable[[str], None]] = None,
+        speak: Optional[Callable[..., Awaitable[bool]]] = None,
+    ) -> None:
+        self._publish = publish or (lambda _s: None)
+        self._speak = speak
+        self._t0 = time.monotonic()
+        self.telemetry: Dict[str, Any] = {
+            "encoder_load_ms": None, "first_cosines": [],
+            "threshold": None, "thermal": "nominal", "sentry_capture": None,
+        }
+
+    def record_encoder_load(self, seconds: float) -> None:
+        self.telemetry["encoder_load_ms"] = round(seconds * 1000.0, 1)
+
+    def record_cosine(self, score: float) -> None:
+        try:
+            if len(self.telemetry["first_cosines"]) < 5:
+                self.telemetry["first_cosines"].append(round(float(score), 3))
+        except Exception:  # noqa: BLE001
+            pass
+
+    def record_threshold(self, thr: float) -> None:
+        self.telemetry["threshold"] = round(float(thr), 3)
+
+    def record_thermal(self, state: str) -> None:
+        self.telemetry["thermal"] = str(state)
+
+    def record_capture_state(self, state: str) -> None:
+        self.telemetry["sentry_capture"] = str(state)
+
+    def compose(self) -> str:
+        t = self.telemetry
+        boot_ms = round((time.monotonic() - self._t0) * 1000.0)
+        enc = (
+            f"{t['encoder_load_ms']}ms" if t["encoder_load_ms"] is not None
+            else "deferred"
+        )
+        cos = (
+            "/".join(str(c) for c in t["first_cosines"])
+            if t["first_cosines"] else "none yet"
+        )
+        return (
+            f"SYSTEM_BOOT_REPORT · boot {boot_ms}ms · encoder {enc} · "
+            f"capture {t['sentry_capture'] or '?'} · thermal {t['thermal']} "
+            f"· threshold {t['threshold'] if t['threshold'] is not None else '0.70'} "
+            f"· first cosines {cos}"
+        )
+
+    async def finalize(self, *, spoken: bool = False) -> str:
+        """Emit the report. ``spoken=True`` also delivers a short
+        spoken digest through Daniel. NEVER raises."""
+        report = self.compose()
+        try:
+            self._publish(report)
+        except Exception:  # noqa: BLE001
+            pass
+        if spoken and self._speak is not None:
+            try:
+                digest = (
+                    "Boot complete. "
+                    + (
+                        "Voice recognition is online."
+                        if self.telemetry["encoder_load_ms"] is not None
+                        else "Voice recognition is still warming up."
+                    )
+                )
+                await self._speak(digest, "daniel")
+            except Exception:  # noqa: BLE001
+                pass
+        return report
+
+
+__all__ = ["IgnitionReporter", "PavaDriftModulator"]

--- a/backend/core/ouroboros/governance/comms/duplex/semantic_gaze.py
+++ b/backend/core/ouroboros/governance/comms/duplex/semantic_gaze.py
@@ -1,0 +1,227 @@
+"""Semantic Gaze — foveated vision that is DORMANT by construction.
+
+Multimodal Vision Plane (operator authorization 2026-07-19). This is
+an ORCHESTRATOR over existing organs — zero new capture code:
+
+  * capture   → ``backend.vision.screen_vision.ScreenVisionSystem.
+    capture_screen`` (async; native ``CGWindowListCreateImage`` /
+    ``CGDisplayCreateImage``; injectable seam)
+  * VLM       → ``backend.vision.claude_vision_analyzer_main.
+    ClaudeVisionAnalyzer.analyze_image_with_prompt`` (existing organ)
+  * delta     → the VisionSensor's dhash discipline (buffer-hash
+    delta pruning; unchanged screen → the VLM is NEVER invoked, the
+    cached semantic state answers)
+  * thermal   → the SAME SovereignGovernor verdict as the audio plane
+    (mandate 3): SERIOUS/CRITICAL hard-aborts BEFORE capture and
+    Daniel verbally reports the degradation instead.
+
+Gating law (mandate 2 — no while-True frame pumps, ever):
+
+    capture ⇐ lease ACTIVE ∧ semantic-visual intent ∧ thermal OK
+    VLM     ⇐ capture ∧ dhash delta changed
+
+Everything injectable; NEVER raises on any path.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import time
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.SemanticGaze")
+
+VERDICT_DORMANT = "dormant"                # no lease / no visual intent
+VERDICT_THERMAL_LOCKED = "thermal_locked"
+VERDICT_CACHED = "cached_semantic_state"
+VERDICT_ANALYZED = "analyzed"
+
+_THERMAL_WARNING = (
+    "I can't look at the screen right now — the system is thermally "
+    "degraded and vision processing is paused to protect the hardware."
+)
+
+
+def _visual_vocabulary() -> tuple:
+    raw = os.environ.get(
+        "JARVIS_GAZE_SEMANTIC_TRIGGERS",
+        "this,look,screen,code,see,showing,display,window,error here",
+    )
+    return tuple(w.strip().lower() for w in raw.split(",") if w.strip())
+
+
+def has_visual_intent(command: str) -> bool:
+    """Semantic requirement detector — closed trigger vocabulary,
+    env-extendable. NEVER raises."""
+    try:
+        import re  # noqa: PLC0415
+        # Word tokens only (strip punctuation) so "screen?" matches
+        # "screen" — a trigger followed by punctuation is still a
+        # trigger; substring false-hits ("scanner"⊅"scan") are avoided.
+        tokens = set(re.findall(r"[a-z']+", str(command or "").lower()))
+        low = str(command or "").lower()
+        for w in _visual_vocabulary():
+            if " " in w:                       # multi-word trigger
+                if w in low:
+                    return True
+            elif w in tokens:
+                return True
+        return False
+    except Exception:  # noqa: BLE001
+        return False
+
+
+class SemanticGaze:
+    """Collaborators (all injected; production defaults resolve the
+    EXISTING organs lazily):
+
+    * ``lease_active``  — () → bool (sentry LEASED?)
+    * ``thermal_ok``    — () → bool (SovereignGovernor verdict)
+    * ``capture``       — () → frame-bytes | None (CGWindowList seam)
+    * ``frame_hash``    — (frame) → str (dhash discipline)
+    * ``vlm``           — async (frame, command) → str (semantic state)
+    * ``speak``         — async (text, persona) → bool (Daniel's voice)
+    """
+
+    def __init__(
+        self,
+        *,
+        lease_active: Optional[Callable[[], bool]] = None,
+        thermal_ok: Optional[Callable[[], bool]] = None,
+        capture: Optional[Callable[[], Any]] = None,
+        frame_hash: Optional[Callable[[Any], str]] = None,
+        vlm: Optional[Callable[..., Awaitable[str]]] = None,
+        speak: Optional[Callable[..., Awaitable[bool]]] = None,
+    ) -> None:
+        self._lease_active = lease_active or (lambda: False)
+        self._thermal_ok = thermal_ok or self._default_thermal_ok
+        self._capture = capture or self._default_capture
+        self._hash = frame_hash or self._default_hash
+        self._vlm = vlm if vlm is not None else self._default_vlm
+        self._speak = speak or self._default_speak
+        self._last_hash: Optional[str] = None
+        self._cached_state: str = ""
+        self._cached_at: float = 0.0
+        self.stats: Dict[str, int] = {
+            "dormant": 0, "thermal_locks": 0, "cache_hits": 0,
+            "vlm_calls": 0, "captures": 0,
+        }
+
+    # ---- production defaults (existing organs, lazily) ----
+
+    @staticmethod
+    def _default_thermal_ok() -> bool:
+        # DRY mandate 3: the SAME governor verdict the audio plane
+        # obeys — one thermal truth for every modality.
+        try:
+            from .sovereign_governor import evolution_permitted  # noqa: E501,PLC0415
+            return evolution_permitted()
+        except Exception:  # noqa: BLE001
+            return False                       # unreadable = locked
+
+    @staticmethod
+    async def _default_capture() -> Any:
+        # EXISTING organ (operator directive: reuse, never duplicate):
+        # ScreenVisionSystem.capture_screen is async + native Quartz.
+        from backend.vision.screen_vision import (  # noqa: PLC0415
+            ScreenVisionSystem,
+        )
+        return await ScreenVisionSystem().capture_screen()
+
+    @staticmethod
+    def _default_hash(frame: Any) -> str:
+        try:
+            import hashlib  # noqa: PLC0415
+            data = frame if isinstance(frame, (bytes, bytearray)) else bytes(
+                getattr(frame, "tobytes", lambda: repr(frame).encode())(),
+            )
+            # Coarse structural hash on a strided sample — the delta
+            # gate needs CHANGE detection, not cryptography.
+            return hashlib.sha256(data[::max(1, len(data) // 65536)]).hexdigest()[:16]
+        except Exception:  # noqa: BLE001
+            return str(time.time())            # unhashable → always-changed
+
+    @staticmethod
+    async def _default_vlm(frame: Any, command: str) -> str:
+        # EXISTING organ: ClaudeVisionAnalyzer.analyze_image_with_prompt.
+        from backend.vision.claude_vision_analyzer_main import (  # noqa: E501,PLC0415
+            ClaudeVisionAnalyzer,
+        )
+        try:
+            analyzer = ClaudeVisionAnalyzer(
+                api_key=os.environ.get("ANTHROPIC_API_KEY"),
+            )
+        except TypeError:
+            analyzer = ClaudeVisionAnalyzer()  # older ctor signatures
+        result = await analyzer.analyze_image_with_prompt(frame, command)
+        if isinstance(result, dict):
+            return str(result.get("content", "") or "")
+        return str(result or "")
+
+    @staticmethod
+    async def _default_speak(text: str, persona: str = "daniel") -> bool:
+        from .ambient import say_with_persona  # noqa: PLC0415
+        return await say_with_persona(text, persona)
+
+    # ---- the gaze ----
+
+    async def request(self, command: str) -> Dict[str, Any]:
+        """One gaze request. Returns
+        ``{"verdict": ..., "semantic_state": ...}``. NEVER raises."""
+        try:
+            if not self._lease_active() or not has_visual_intent(command):
+                self.stats["dormant"] += 1
+                return {"verdict": VERDICT_DORMANT, "semantic_state": ""}
+            if not self._thermal_ok():
+                # Mandate 4: the lock is caught BEFORE capture and
+                # Daniel says WHY — silence would read as deafness.
+                self.stats["thermal_locks"] += 1
+                try:
+                    await self._speak(_THERMAL_WARNING, "daniel")
+                except Exception:  # noqa: BLE001
+                    pass
+                return {
+                    "verdict": VERDICT_THERMAL_LOCKED,
+                    "semantic_state": _THERMAL_WARNING,
+                }
+            import inspect  # noqa: PLC0415
+            frame = self._capture()
+            if inspect.isawaitable(frame):
+                frame = await frame            # ScreenVisionSystem is async
+            if frame is None:
+                self.stats["dormant"] += 1
+                return {"verdict": VERDICT_DORMANT, "semantic_state": ""}
+            self.stats["captures"] += 1
+            h = self._hash(frame)
+            if h == self._last_hash and self._cached_state:
+                # Delta pruning: the screen did not structurally
+                # change — the VLM is bypassed entirely.
+                self.stats["cache_hits"] += 1
+                return {
+                    "verdict": VERDICT_CACHED,
+                    "semantic_state": self._cached_state,
+                }
+            self._last_hash = h
+            if self._vlm is None:
+                return {"verdict": VERDICT_DORMANT, "semantic_state": ""}
+            state = await self._vlm(frame, command)
+            self._cached_state = str(state or "")
+            self._cached_at = time.time()
+            self.stats["vlm_calls"] += 1
+            return {
+                "verdict": VERDICT_ANALYZED,
+                "semantic_state": self._cached_state,
+            }
+        except Exception:  # noqa: BLE001
+            logger.debug("[SemanticGaze] request degraded", exc_info=True)
+            return {"verdict": VERDICT_DORMANT, "semantic_state": ""}
+
+
+__all__ = [
+    "VERDICT_ANALYZED",
+    "VERDICT_CACHED",
+    "VERDICT_DORMANT",
+    "VERDICT_THERMAL_LOCKED",
+    "SemanticGaze",
+    "has_visual_intent",
+]

--- a/backend/core/ouroboros/governance/comms/duplex/sentry_bootstrap.py
+++ b/backend/core/ouroboros/governance/comms/duplex/sentry_bootstrap.py
@@ -282,6 +282,17 @@ class BiometricGateAdapter:
                         return True             # verified; no hot-die math
                     from .biometric_evolution import evolve_if_confident  # noqa: E501,PLC0415
                     emb = getattr(getattr(self, "scorer_ref", None), "last_embedding", None) or getattr(self, "last_embedding", None)
+                    # VBIA→PAVA handoff: the drift matrix shapes HOW
+                    # MUCH this clean-passing sample teaches (never
+                    # whether it gates — VBIA already decided that).
+                    _pava = getattr(self, "pava", None)
+                    if _pava is not None and emb is not None:
+                        import os as _os  # noqa: PLC0415
+                        _base = float(_os.environ.get("JARVIS_BIOMETRIC_EVOLUTION_ALPHA", "0.02"))
+                        _alpha = await _pava.modulated_alpha(window, _base)
+                        if _alpha <= 0.0:
+                            return True         # spoof/drift veto on learning
+                        _os.environ["JARVIS_BIOMETRIC_EVOLUTION_ALPHA"] = str(_alpha)
                     if emb is not None and evolve_if_confident(conf, emb):
                         self.stats["evolutions"] = (
                             self.stats.get("evolutions", 0) + 1

--- a/tests/governance/test_multimodal_gaze.py
+++ b/tests/governance/test_multimodal_gaze.py
@@ -1,0 +1,189 @@
+"""Multimodal Vision Plane + VBIA→PAVA + Ignition Reporter spine.
+
+Mandate 4 verbatim (2026-07-19): a semantic visual request ("Jarvis,
+what is on my screen?") while thermal state is forced SERIOUS →
+capture aborted, thermal lock caught, Daniel verbally warns.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex.semantic_gaze import (
+    VERDICT_ANALYZED,
+    VERDICT_CACHED,
+    VERDICT_DORMANT,
+    VERDICT_THERMAL_LOCKED,
+    SemanticGaze,
+    has_visual_intent,
+)
+from backend.core.ouroboros.governance.comms.duplex.pava_handoff import (
+    IgnitionReporter,
+    PavaDriftModulator,
+)
+
+
+class TestSemanticGating:
+    def test_visual_intent_vocabulary(self):
+        assert has_visual_intent("Jarvis, what is on my screen?")
+        assert has_visual_intent("look at this code")
+        assert has_visual_intent("what's this error")
+        assert not has_visual_intent("what time is it")
+        assert not has_visual_intent("play some music")
+
+    async def test_dormant_without_lease_or_intent(self):
+        captured = {"n": 0}
+        gaze = SemanticGaze(
+            lease_active=lambda: True, thermal_ok=lambda: True,
+            capture=lambda: captured.__setitem__("n", captured["n"] + 1),
+            vlm=None,
+        )
+        # visual intent but... has intent yet no VLM → still no capture
+        r = await gaze.request("what time is it")   # no visual intent
+        assert r["verdict"] == VERDICT_DORMANT
+        assert captured["n"] == 0                    # NEVER captured
+
+    async def test_no_lease_stays_dormant(self):
+        captured = {"n": 0}
+        gaze = SemanticGaze(
+            lease_active=lambda: False, thermal_ok=lambda: True,
+            capture=lambda: captured.__setitem__("n", captured["n"] + 1),
+        )
+        r = await gaze.request("look at my screen")
+        assert r["verdict"] == VERDICT_DORMANT
+        assert captured["n"] == 0
+
+
+class TestThermalLock:
+    async def test_serious_thermal_aborts_capture_daniel_warns(self):
+        """MANDATE 4 VERBATIM."""
+        captured = {"n": 0}
+        spoken = []
+
+        async def _speak(text, persona="daniel"):
+            spoken.append((text, persona))
+            return True
+
+        gaze = SemanticGaze(
+            lease_active=lambda: True,
+            thermal_ok=lambda: False,          # SERIOUS thermal forced
+            capture=lambda: captured.__setitem__("n", captured["n"] + 1),
+            vlm=None, speak=_speak,
+        )
+        r = await gaze.request("Jarvis, what is on my screen?")
+        assert r["verdict"] == VERDICT_THERMAL_LOCKED
+        assert captured["n"] == 0                     # capture ABORTED
+        assert len(spoken) == 1                       # Daniel spoke
+        text, persona = spoken[0]
+        assert persona == "daniel"
+        assert "thermally degraded" in text.lower()
+        assert gaze.stats["thermal_locks"] == 1
+
+    async def test_dry_thermal_hook_matches_audio_plane_pin(self):
+        from pathlib import Path
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/comms/duplex/semantic_gaze.py"
+        ).read_text()
+        # Same governor verdict the audio plane consumes (mandate 3).
+        assert "evolution_permitted" in src
+
+
+class TestDeltaPruning:
+    async def test_unchanged_screen_bypasses_vlm(self):
+        vlm_calls = {"n": 0}
+
+        async def _vlm(frame, cmd):
+            vlm_calls["n"] += 1
+            return f"analysis-{vlm_calls['n']}"
+
+        gaze = SemanticGaze(
+            lease_active=lambda: True, thermal_ok=lambda: True,
+            capture=lambda: b"static-frame-bytes",
+            frame_hash=lambda f: "STABLE", vlm=_vlm,
+        )
+        r1 = await gaze.request("look at the screen")
+        assert r1["verdict"] == VERDICT_ANALYZED
+        r2 = await gaze.request("look at the screen again")  # same hash
+        assert r2["verdict"] == VERDICT_CACHED
+        assert r2["semantic_state"] == r1["semantic_state"]
+        assert vlm_calls["n"] == 1                    # VLM bypassed
+
+    async def test_changed_screen_reanalyzes(self):
+        vlm_calls = {"n": 0}
+        hashes = iter(["A", "B"])
+
+        async def _vlm(frame, cmd):
+            vlm_calls["n"] += 1
+            return f"v{vlm_calls['n']}"
+
+        gaze = SemanticGaze(
+            lease_active=lambda: True, thermal_ok=lambda: True,
+            capture=lambda: b"x", frame_hash=lambda f: next(hashes),
+            vlm=_vlm,
+        )
+        await gaze.request("look")
+        await gaze.request("look")
+        assert vlm_calls["n"] == 2                    # changed → re-VLM
+
+
+class TestPavaHandoff:
+    async def test_clean_sample_full_alpha(self):
+        async def _pava(w):
+            return 0.95, True                         # plausible, clean
+        mod = PavaDriftModulator(pava_scorer=_pava)
+        a = await mod.modulated_alpha(np.ones(1000), 0.02)
+        assert a > 0.015                              # near-full teaching
+        assert mod.stats["handoffs"] == 1
+
+    async def test_spoof_vetoes_learning(self):
+        async def _pava(w):
+            return 0.9, False                         # anti-spoof FAILED
+        mod = PavaDriftModulator(pava_scorer=_pava)
+        a = await mod.modulated_alpha(np.ones(1000), 0.02)
+        assert a == 0.0                               # never teach a spoof
+        assert mod.stats["spoof_rejected"] == 1
+
+    async def test_drift_slows_learning(self):
+        scores = iter([(0.9, True), (0.4, True), (0.9, True), (0.3, True)])
+        async def _pava(w):
+            return next(scores)
+        mod = PavaDriftModulator(pava_scorer=_pava)
+        for _ in range(4):
+            a = await mod.modulated_alpha(np.ones(1000), 0.02)
+        assert mod.stats["drift_slowed"] >= 1         # variance damped alpha
+
+    def test_evolution_consults_pava_pin(self):
+        from pathlib import Path
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/comms/duplex/sentry_bootstrap.py"
+        ).read_text()
+        assert "modulated_alpha" in src
+
+
+class TestIgnitionReporter:
+    async def test_boot_report_composed_and_published(self):
+        published = []
+        rep = IgnitionReporter(publish=published.append)
+        rep.record_encoder_load(1.4)
+        rep.record_cosine(0.82)
+        rep.record_cosine(0.79)
+        rep.record_threshold(0.70)
+        rep.record_thermal("nominal")
+        rep.record_capture_state("ACTIVE")
+        report = await rep.finalize()
+        assert "SYSTEM_BOOT_REPORT" in report
+        assert "1400.0ms" in report and "0.82/0.79" in report
+        assert "capture ACTIVE" in report and "thermal nominal" in report
+        assert published == [report]                  # silent IPC delivered
+
+    async def test_spoken_digest_optional(self):
+        spoken = []
+        async def _speak(t, p="daniel"):
+            spoken.append((t, p)); return True
+        rep = IgnitionReporter(publish=lambda _s: None, speak=_speak)
+        rep.record_encoder_load(0.9)
+        await rep.finalize(spoken=True)
+        assert spoken and spoken[0][1] == "daniel"
+        assert "online" in spoken[0][0].lower()


### PR DESCRIPTION
## Summary
Reuse-not-duplicate: every organ already existed; this layer orchestrates.
- **Semantic Gaze** — foveated vision dormant by construction: `capture ⇐ lease ∧ visual-intent ∧ thermal-OK`, `VLM ⇐ capture ∧ dhash-delta`. Reuses the real `ScreenVisionSystem.capture_screen` (native Quartz — corrected after reading the actual files, not a guessed API) + `ClaudeVisionAnalyzer.analyze_image_with_prompt`. Unchanged frame → VLM bypassed, cached state answers. No while-True anywhere.
- **DRY thermal** — the gaze obeys the *same* `sovereign_governor` verdict as audio; SERIOUS/CRITICAL hard-aborts before capture and Daniel warns.
- **VBIA→PAVA** — x-vector cosine is the absolute gate; on pass the existing `AdvancedBiometricVerifier` (Bayesian+Mahalanobis+physics+anti-spoof) modulates the evolution EMA alpha — spoof vetoes learning, drift damps it, clean teaches full.
- **Ignition Reporter** — boot telemetry → silent `SYSTEM_BOOT_REPORT` to the jarvis topology; optional Daniel digest.

## Testing
13 tests incl. **mandate 4 verbatim**: semantic visual request under forced-SERIOUS thermal → capture aborted, lock caught, Daniel speaks the warning. Delta-pruning VLM bypass, spoof-veto, drift-damp, boot-report composition. Sentry/governor sweeps green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a multimodal Semantic Gaze that captures and analyzes the screen only when needed, plus a VBIA→PAVA handoff that makes biometric learning adaptive, and a boot Ignition Reporter. This reduces VLM calls, respects thermal limits, and improves startup telemetry.

- New Features
  - Semantic Gaze: dormant by default; runs only when lease active, visual intent present, and thermal OK. Reuses `ScreenVisionSystem.capture_screen` and `ClaudeVisionAnalyzer.analyze_image_with_prompt`. Uses a frame hash to skip the VLM on unchanged screens. Shares the audio plane’s thermal gate via `evolution_permitted`; on lock, aborts capture and speaks a clear warning.
  - VBIA→PAVA: VBIA x‑vector cosine remains the gate. On pass, `AdvancedBiometricVerifier` modulates the evolution EMA (`JARVIS_BIOMETRIC_EVOLUTION_ALPHA`); spoof → no learning, drift → slower learning, clean → full learning. Integrated in `sentry_bootstrap` via `PavaDriftModulator.modulated_alpha`.
  - Ignition Reporter: collects boot telemetry (encoder load, first cosines, threshold, thermal, capture state) and emits a silent `SYSTEM_BOOT_REPORT`, with optional Daniel spoken digest.

<sup>Written for commit e614ecdd782a932dfe48a7681a193bc003b3fd8c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69956?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

