### PR TITLE
feat(sovereignty): Unified Epistemic Memory Bus — the split-brain cure

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/epistemic_bus.py
+++ b/backend/core/ouroboros/governance/comms/duplex/epistemic_bus.py
@@ -1,0 +1,168 @@
+"""Unified Epistemic Memory Bus — the split-brain cure.
+
+Operator authorization 2026-07-19. Daniel and Karen previously held
+persona-local visual caches (Contextual Fragmentation): Daniel sees an
+error, the operator says "Karen, write a patch for that", and Karen's
+prompt had no idea what "that" was — or worse, re-triggered Quartz.
+
+This bus is the ONE centralized memory pointer at the orchestrator
+root (mandate 1 — no disk serialization, no giant string relays
+between persona prompts): the dhash footprint + the VLM semantic
+state live HERE; every persona FSM holds a reference, never a copy.
+
+Volatility is structural (mandate 2 — a stale gaze is a hallucination
+vector):
+
+  * **Temporal**: entries older than ``JARVIS_EPISTEMIC_VISUAL_TTL_S``
+    (60s) are flushed at read time — an expired pointer is never
+    served.
+  * **Spatial**: a catastrophic dhash delta on the next capture
+    (Space swap, IDE closed) flushes instantly via
+    :meth:`spatial_invalidate`.
+
+DRY (mandate 3): every deposit ALSO records a bounded turn into the
+EXISTING ConversationBridge under ``### Visual context`` — the
+ContextCompactor summarizes it into the LLM window exactly as it does
+every other dialogue lane. One memory, every consumer.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.EpistemicBus")
+
+
+def _visual_ttl_s() -> float:
+    try:
+        return max(5.0, min(600.0, float(os.environ.get(
+            "JARVIS_EPISTEMIC_VISUAL_TTL_S", "60",
+        ))))
+    except (TypeError, ValueError):
+        return 60.0
+
+
+class EpistemicMemoryBus:
+    """The shared short-term epistemic state. Thread-safe (personas
+    live on different tasks); NEVER raises anywhere."""
+
+    def __init__(self, *, clock: Callable[[], float] = time.monotonic) -> None:
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._visual: Optional[Dict[str, Any]] = None
+        self.stats: Dict[str, int] = {
+            "deposits": 0, "inherits": 0, "ttl_flushes": 0,
+            "spatial_flushes": 0, "manual_flushes": 0,
+        }
+
+    # ---- the visual lane ----
+
+    def deposit_visual(
+        self,
+        semantic_state: str,
+        frame_hash: str,
+        *,
+        persona: str = "daniel",
+    ) -> None:
+        """One gaze result in — becomes THE pointer every persona
+        inherits. Also bridges into ConversationBridge (DRY) so the
+        compactor carries it into the LLM window. NEVER raises."""
+        try:
+            with self._lock:
+                self._visual = {
+                    "semantic_state": str(semantic_state or ""),
+                    "frame_hash": str(frame_hash or ""),
+                    "persona": str(persona),
+                    "deposited_at": self._clock(),
+                }
+                self.stats["deposits"] += 1
+            try:
+                from backend.core.ouroboros.governance.conversation_bridge import (  # noqa: E501,PLC0415
+                    record_visual_state,
+                )
+                record_visual_state(semantic_state, persona=persona)
+            except Exception:  # noqa: BLE001
+                pass
+        except Exception:  # noqa: BLE001
+            pass
+
+    def inherit_visual(self) -> Optional[Dict[str, Any]]:
+        """The cross-persona read: the LIVE pointer, or None. TTL is
+        enforced AT READ — an expired state is flushed, never served
+        (hallucination guard). NEVER raises."""
+        try:
+            with self._lock:
+                v = self._visual
+                if v is None:
+                    return None
+                if (self._clock() - v["deposited_at"]) > _visual_ttl_s():
+                    self._visual = None
+                    self.stats["ttl_flushes"] += 1
+                    logger.info("[EpistemicBus] visual TTL expired — flushed")
+                    return None
+                self.stats["inherits"] += 1
+                return dict(v)
+        except Exception:  # noqa: BLE001
+            return None
+
+    def spatial_invalidate(self, new_frame_hash: str) -> bool:
+        """Catastrophic-delta hook: the operator swapped Spaces /
+        closed the IDE — the remembered screen no longer exists.
+        True when a flush happened. NEVER raises."""
+        try:
+            with self._lock:
+                v = self._visual
+                if v is None:
+                    return False
+                if str(new_frame_hash) != v["frame_hash"]:
+                    self._visual = None
+                    self.stats["spatial_flushes"] += 1
+                    logger.info(
+                        "[EpistemicBus] catastrophic dhash delta — "
+                        "visual state flushed",
+                    )
+                    return True
+                return False
+        except Exception:  # noqa: BLE001
+            return False
+
+    def flush(self) -> None:
+        try:
+            with self._lock:
+                if self._visual is not None:
+                    self.stats["manual_flushes"] += 1
+                self._visual = None
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Process-wide root pointer (the orchestrator-root singleton)
+# ---------------------------------------------------------------------------
+
+_DEFAULT: Optional[EpistemicMemoryBus] = None
+_DEFAULT_LOCK = threading.Lock()
+
+
+def get_default_bus() -> EpistemicMemoryBus:
+    global _DEFAULT
+    with _DEFAULT_LOCK:
+        if _DEFAULT is None:
+            _DEFAULT = EpistemicMemoryBus()
+        return _DEFAULT
+
+
+def reset_default_bus() -> None:
+    global _DEFAULT
+    with _DEFAULT_LOCK:
+        _DEFAULT = None
+
+
+__all__ = [
+    "EpistemicMemoryBus",
+    "get_default_bus",
+    "reset_default_bus",
+]

--- a/backend/core/ouroboros/governance/comms/duplex/semantic_gaze.py
+++ b/backend/core/ouroboros/governance/comms/duplex/semantic_gaze.py
@@ -99,9 +99,11 @@ class SemanticGaze:
         self._hash = frame_hash or self._default_hash
         self._vlm = vlm if vlm is not None else self._default_vlm
         self._speak = speak or self._default_speak
-        self._last_hash: Optional[str] = None
-        self._cached_state: str = ""
-        self._cached_at: float = 0.0
+        # Unified Epistemic Bus (2026-07-19): the cache lives at the
+        # orchestrator root, NOT in this persona FSM — every gaze
+        # instance shares one pointer (split-brain cure).
+        from .epistemic_bus import get_default_bus  # noqa: PLC0415
+        self._bus = get_default_bus()
         self.stats: Dict[str, int] = {
             "dormant": 0, "thermal_locks": 0, "cache_hits": 0,
             "vlm_calls": 0, "captures": 0,
@@ -163,6 +165,22 @@ class SemanticGaze:
         from .ambient import say_with_persona  # noqa: PLC0415
         return await say_with_persona(text, persona)
 
+    @staticmethod
+    def _referential(command: str) -> bool:
+        """True when the command REFERS to prior visual context rather
+        than requesting a fresh look ("that error", "patch this",
+        "fix it")."""
+        import re  # noqa: PLC0415
+        tokens = set(re.findall(r"[a-z']+", str(command or "").lower()))
+        return bool(tokens & {"that", "it", "this", "same", "those"})
+
+    @staticmethod
+    def _force_recapture(command: str) -> bool:
+        """Explicit re-look verbs override inheritance ("look AGAIN",
+        "refresh")."""
+        low = str(command or "").lower()
+        return any(w in low for w in ("again", "refresh", "re-look", "now"))
+
     # ---- the gaze ----
 
     async def request(self, command: str) -> Dict[str, Any]:
@@ -184,6 +202,22 @@ class SemanticGaze:
                     "verdict": VERDICT_THERMAL_LOCKED,
                     "semantic_state": _THERMAL_WARNING,
                 }
+            shared_pre = self._bus.inherit_visual()
+            if (
+                shared_pre is not None
+                and self._referential(command)
+                and not self._force_recapture(command)
+            ):
+                # Cross-persona inheritance: "Karen, patch THAT" — a
+                # REFERENTIAL command points at the shared memory; the
+                # pointer is fresh; Quartz is NOT re-triggered. Fresh-
+                # look commands ("look at the screen") always capture
+                # so spatial invalidation can see a Space swap.
+                self.stats["cache_hits"] += 1
+                return {
+                    "verdict": VERDICT_CACHED,
+                    "semantic_state": shared_pre["semantic_state"],
+                }
             import inspect  # noqa: PLC0415
             frame = self._capture()
             if inspect.isawaitable(frame):
@@ -193,24 +227,28 @@ class SemanticGaze:
                 return {"verdict": VERDICT_DORMANT, "semantic_state": ""}
             self.stats["captures"] += 1
             h = self._hash(frame)
-            if h == self._last_hash and self._cached_state:
-                # Delta pruning: the screen did not structurally
-                # change — the VLM is bypassed entirely.
+            shared = self._bus.inherit_visual()
+            if shared is not None and shared["frame_hash"] == h:
+                # Delta pruning against the SHARED pointer: unchanged
+                # screen → VLM bypassed, every persona answers from
+                # the same epistemic state.
                 self.stats["cache_hits"] += 1
                 return {
                     "verdict": VERDICT_CACHED,
-                    "semantic_state": self._cached_state,
+                    "semantic_state": shared["semantic_state"],
                 }
-            self._last_hash = h
+            if shared is not None:
+                # Catastrophic delta: Space swap / IDE closed — the
+                # remembered screen is gone; flush before re-looking.
+                self._bus.spatial_invalidate(h)
             if self._vlm is None:
                 return {"verdict": VERDICT_DORMANT, "semantic_state": ""}
             state = await self._vlm(frame, command)
-            self._cached_state = str(state or "")
-            self._cached_at = time.time()
+            self._bus.deposit_visual(str(state or ""), h)
             self.stats["vlm_calls"] += 1
             return {
                 "verdict": VERDICT_ANALYZED,
-                "semantic_state": self._cached_state,
+                "semantic_state": str(state or ""),
             }
         except Exception:  # noqa: BLE001
             logger.debug("[SemanticGaze] request degraded", exc_info=True)

--- a/backend/core/ouroboros/governance/conversation_bridge.py
+++ b/backend/core/ouroboros/governance/conversation_bridge.py
@@ -74,6 +74,7 @@ SOURCE_ASK_HUMAN_A = "ask_human_a"
 SOURCE_POSTMORTEM = "postmortem"
 SOURCE_VOICE = "voice"
 SOURCE_BARGE_IN = "barge_in"
+SOURCE_VISUAL = "visual"
 
 _ALLOWED_SOURCES = frozenset({
     SOURCE_TUI_USER,
@@ -82,6 +83,7 @@ _ALLOWED_SOURCES = frozenset({
     SOURCE_POSTMORTEM,
     SOURCE_VOICE,
     SOURCE_BARGE_IN,
+    SOURCE_VISUAL,
 })
 
 # Source-category groupings used by subheader rendering. Each group gets
@@ -93,6 +95,7 @@ _SUBHEADER_ORDER: Tuple[Tuple[str, Tuple[str, ...]], ...] = (
     ("### Clarifications (recent)", (SOURCE_ASK_HUMAN_Q, SOURCE_ASK_HUMAN_A)),
     ("### Prior op closure (postmortem)", (SOURCE_POSTMORTEM,)),
     ("### Delivery interruptions", (SOURCE_BARGE_IN,)),
+    ("### Visual context (shared gaze)", (SOURCE_VISUAL,)),
 )
 
 def record_barge_in(
@@ -148,6 +151,28 @@ def record_barge_in(
             "[ConversationBridge] record_barge_in dropped by internal error",
             exc_info=True,
         )
+        return False
+
+
+def record_visual_state(semantic_state: str, *, persona: str = "daniel",
+                        op_id: str = "") -> bool:
+    """Unified Epistemic Bus lane (2026-07-19): the shared gaze's VLM
+    semantic state, bridged so the ContextCompactor carries it into
+    the LLM window for WHICHEVER persona speaks next. Bounded; same
+    Tier -1 sanitize path. NEVER raises."""
+    try:
+        if not _is_enabled():
+            return False
+        text = str(semantic_state or "").strip()
+        if not text:
+            return False
+        marker = f"[VISUAL:{str(persona)[:12]}] {text[:600]}"
+        get_default_bridge().record_turn(
+            role="assistant", text=marker,
+            source=SOURCE_VISUAL, op_id=str(op_id or ""),
+        )
+        return True
+    except Exception:  # pragma: no cover
         return False
 
 

--- a/tests/governance/test_epistemic_bus.py
+++ b/tests/governance/test_epistemic_bus.py
@@ -1,0 +1,136 @@
+"""Unified Epistemic Memory Bus spine — the split-brain cure.
+
+Mandate 4 verbatim (2026-07-19): a Daniel visual command followed by
+a Karen codebase command → Karen inherits the EXACT cached VLM
+payload, Quartz capture_screen is called strictly ONCE, and a
+simulated TTL expiry flushes the bus.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex import epistemic_bus as eb
+from backend.core.ouroboros.governance.comms.duplex.epistemic_bus import (
+    EpistemicMemoryBus,
+)
+from backend.core.ouroboros.governance.comms.duplex.semantic_gaze import (
+    VERDICT_ANALYZED,
+    VERDICT_CACHED,
+    SemanticGaze,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_bus():
+    eb.reset_default_bus()
+    yield
+    eb.reset_default_bus()
+
+
+def _gaze(captures, vlm_calls, hash_value="H1"):
+    async def _vlm(frame, cmd):
+        vlm_calls.append(cmd)
+        return "error: NoneType in orchestrator.py line 42"
+
+    def _capture():
+        captures.append(1)
+        return b"frame-bytes"
+
+    return SemanticGaze(
+        lease_active=lambda: True, thermal_ok=lambda: True,
+        capture=_capture, frame_hash=lambda f: hash_value, vlm=_vlm,
+    )
+
+
+class TestCrossPersonaHandoff:
+    async def test_daniel_to_karen_single_capture_shared_payload(
+        self, monkeypatch,
+    ):
+        """MANDATE 4 VERBATIM."""
+        captures, vlm_calls = [], []
+        daniel_gaze = _gaze(captures, vlm_calls)
+        # Daniel: "what is this error on my screen?"
+        r1 = await daniel_gaze.request("what is this error on my screen")
+        assert r1["verdict"] == VERDICT_ANALYZED
+        assert len(captures) == 1
+        # Karen (a DIFFERENT gaze instance — different persona FSM):
+        karen_gaze = _gaze(captures, vlm_calls)
+        r2 = await karen_gaze.request("Karen, write a patch for this code")
+        assert r2["verdict"] == VERDICT_CACHED
+        assert r2["semantic_state"] == r1["semantic_state"]   # EXACT payload
+        assert len(captures) == 1                # Quartz called ONCE, total
+        assert len(vlm_calls) == 1               # VLM once, total
+        bus = eb.get_default_bus()
+        assert bus.stats["deposits"] == 1 and bus.stats["inherits"] >= 1
+
+    async def test_ttl_expiry_flushes_and_forces_fresh_capture(
+        self, monkeypatch,
+    ):
+        monkeypatch.setenv("JARVIS_EPISTEMIC_VISUAL_TTL_S", "60")
+        clock = [1000.0]
+        bus = EpistemicMemoryBus(clock=lambda: clock[0])
+        monkeypatch.setattr(eb, "_DEFAULT", bus)
+        captures, vlm_calls = [], []
+        g = _gaze(captures, vlm_calls)
+        g._bus = bus
+        await g.request("look at the screen")
+        assert len(captures) == 1
+        clock[0] += 61.0                          # simulated TTL expiry
+        assert bus.inherit_visual() is None       # flushed at read
+        assert bus.stats["ttl_flushes"] == 1
+        await g.request("look at the screen")
+        assert len(captures) == 2                 # fresh capture forced
+
+    async def test_spatial_invalidation_on_catastrophic_delta(self):
+        captures, vlm_calls = [], []
+        hashes = iter(["SPACE1", "SPACE2"])
+        async def _vlm(frame, cmd):
+            vlm_calls.append(cmd); return f"state-{len(vlm_calls)}"
+        g = SemanticGaze(
+            lease_active=lambda: True, thermal_ok=lambda: True,
+            capture=lambda: captures.append(1) or b"f",
+            frame_hash=lambda f: next(hashes), vlm=_vlm,
+        )
+        await g.request("look at my screen now")   # 'now' forces capture
+        bus = eb.get_default_bus()
+        await g.request("look at my screen now")   # Space swapped → SPACE2
+        assert bus.stats["spatial_flushes"] == 1   # old state flushed
+        assert len(vlm_calls) == 2                 # re-analyzed fresh
+
+    async def test_explicit_relook_overrides_inheritance(self):
+        captures, vlm_calls = [], []
+        g = _gaze(captures, vlm_calls)
+        await g.request("look at the screen")
+        await g.request("look again")              # operator demands fresh
+        assert len(captures) == 2
+
+    def test_bridge_and_compactor_integration_pins(self):
+        from pathlib import Path
+        cb_src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/conversation_bridge.py"
+        ).read_text()
+        assert "SOURCE_VISUAL" in cb_src
+        assert "def record_visual_state" in cb_src
+        assert "### Visual context (shared gaze)" in cb_src
+        gz_src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/comms/duplex/semantic_gaze.py"
+        ).read_text()
+        assert "get_default_bus" in gz_src
+        assert "_cached_state" not in gz_src       # persona-local cache GONE
+
+    async def test_visual_state_reaches_prompt_plane(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CONVERSATION_BRIDGE_ENABLED", "true")
+        from backend.core.ouroboros.governance import conversation_bridge as cb
+        cb.reset_default_bridge()
+        try:
+            captures, vlm_calls = [], []
+            g = _gaze(captures, vlm_calls)
+            await g.request("what is on my screen")
+            prompt = cb.get_default_bridge().format_for_prompt()
+            assert prompt is not None
+            assert "Visual context (shared gaze)" in prompt
+            assert "NoneType in orchestrator.py" in prompt
+        finally:
+            cb.reset_default_bridge()

--- a/tests/governance/test_multimodal_gaze.py
+++ b/tests/governance/test_multimodal_gaze.py
@@ -21,6 +21,16 @@ from backend.core.ouroboros.governance.comms.duplex.pava_handoff import (
     IgnitionReporter,
     PavaDriftModulator,
 )
+from backend.core.ouroboros.governance.comms.duplex import epistemic_bus as _eb
+
+
+@pytest.fixture(autouse=True)
+def _fresh_epistemic_bus():
+    # The bus is a process-wide root pointer (by design) — tests must
+    # never inherit a previous test's gaze.
+    _eb.reset_default_bus()
+    yield
+    _eb.reset_default_bus()
 
 
 class TestSemanticGating:


### PR DESCRIPTION
## Summary
Contextual Fragmentation resolved at the root: one centralized memory pointer (`EpistemicMemoryBus`) at the orchestrator root holds the dhash footprint + VLM semantic state; the persona-local gaze cache is deleted (pinned). Volatility is structural: TTL enforced **at read** (expired pointers are flushed, never served) and `spatial_invalidate` flushes on catastrophic dhash delta (Space swap / IDE closed). Cross-persona inheritance is **referentially gated** — "Karen, patch *that*" inherits the exact pointer with Quartz untriggered; fresh-look commands always capture so spatial invalidation can see a swapped Space; "again/refresh" forces re-analysis. Every deposit bridges into `ConversationBridge` under `### Visual context (shared gaze)`, so the existing `ContextCompactor` carries the shared memory into whichever persona speaks next.

## Testing
6 new tests incl. **mandate 4 verbatim**: Daniel visual command → Karen codebase command receives the exact cached VLM payload, `capture_screen` called strictly once, simulated TTL expiry flushes and forces fresh capture. Spatial invalidation, relook override, prompt-plane delivery, cache-deletion pin. The referential gate itself was forced by an honest failing regression (blanket inheritance served stale screens to fresh-look commands). 80-test sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized the visual memory into a single orchestrator-level `EpistemicMemoryBus` to stop cross-persona “split-brain” and duplicate captures. Referential commands now share the same fresh VLM result, with TTL and spatial invalidation to prevent staleness.

- New Features
  - Added `epistemic_bus.EpistemicMemoryBus` singleton that stores `frame_hash` + VLM semantic state; thread-safe and process-wide.
  - `SemanticGaze` now reads/writes the shared bus; persona-local cache removed.
  - TTL enforced at read via `JARVIS_EPISTEMIC_VISUAL_TTL_S` (default 60s); expired pointers are flushed, never served.
  - Spatial invalidation flushes when a new capture’s `frame_hash` differs (Space swap / IDE closed).
  - Referential commands (“that/this/it”) inherit the shared state; “again/refresh/now” force fresh capture; non-referential “fresh look” always captures.
  - Visual state is bridged into `ConversationBridge` under “### Visual context (shared gaze)” so the compactor carries it into the next prompt.

<sup>Written for commit 448dba4213e066a0bd5ab0b768419999e852540b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69957?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

