### PR TITLE
feat(sovereignty): Proactive Proposal Queue — flow-protected cross-space suggestions

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/proposal_queue.py
+++ b/backend/core/ouroboros/governance/comms/duplex/proposal_queue.py
@@ -1,0 +1,190 @@
+"""Proactive Proposal Queue — cross-space insights, flow-protected.
+
+Operator authorization 2026-07-19. The final proactive layer:
+CrossSpaceGaze insights become PROPOSALS, held until the operator is
+idle, evicted when stale, and NEVER executed without an explicit
+``[Y/n]`` (mandate 2 — proposals are suggestions, not mutations).
+
+  * **Active Flow Protection (mandate 1+2):** native macOS idle via
+    ``CGEventSourceSecondsSinceLastEventType`` — NO polling. A
+    proposal renders only when the operator has been idle ≥
+    ``JARVIS_PROPOSAL_IDLE_GATE_S`` (15s); keyboard/mouse within the
+    window HOLDS it in memory (flow is sacred).
+  * **Eviction (mandate 2):** a proposal older than
+    ``JARVIS_PROPOSAL_TTL_S`` (5 min) OR invalidated by a
+    catastrophic desktop dhash delta (window closed / fixed) is
+    silently flushed — a stale suggestion is worse than none.
+  * **Strict execution gating (mandate 2):** ``present_if_idle``
+    returns the proposal for the caller to route through the EXISTING
+    SerpentFlow ``[Y/n]`` Iron Gate (mandate 3 — no separate alert
+    system); this module NEVER touches the filesystem.
+
+Everything injectable; NEVER raises on any path.
+"""
+from __future__ import annotations
+
+import logging
+import os
+import threading
+import time
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.ProposalQueue")
+
+
+def _idle_gate_s() -> float:
+    try:
+        return max(2.0, min(300.0, float(os.environ.get(
+            "JARVIS_PROPOSAL_IDLE_GATE_S", "15",
+        ))))
+    except (TypeError, ValueError):
+        return 15.0
+
+
+def _proposal_ttl_s() -> float:
+    try:
+        return max(30.0, min(3600.0, float(os.environ.get(
+            "JARVIS_PROPOSAL_TTL_S", "300",     # 5 min
+        ))))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+def native_idle_seconds() -> float:
+    """macOS global input idle via CGEventSourceSecondsSinceLastEvent-
+    Type (mandate 1 — native, zero polling). Returns 0.0 (assume
+    ACTIVE — fail-safe toward NOT interrupting) when unreadable."""
+    try:
+        import Quartz  # noqa: PLC0415
+        # kCGEventSourceStateHIDSystemState = 1;
+        # kCGAnyInputEventType = 0xFFFFFFFF (all input types).
+        return float(Quartz.CGEventSourceSecondsSinceLastEventType(
+            1, 0xFFFFFFFF,
+        ))
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+class Proposal:
+    __slots__ = ("insight", "spaces", "dhash", "created_at", "id")
+
+    def __init__(self, insight: Any, spaces: List[int], dhash: str,
+                 created_at: float, pid: str) -> None:
+        self.insight = insight
+        self.spaces = spaces
+        self.dhash = dhash
+        self.created_at = created_at
+        self.id = pid
+
+    def summary(self) -> str:
+        try:
+            if isinstance(self.insight, dict):
+                return str(self.insight.get("description", "cross-space insight"))
+            return str(getattr(self.insight, "description", "cross-space insight"))
+        except Exception:  # noqa: BLE001
+            return "cross-space insight"
+
+
+class ProposalQueue:
+    """Holds flow-protected proposals. ``idle_source`` and ``clock``
+    injected for tests; production defaults are native. NEVER raises."""
+
+    def __init__(
+        self,
+        *,
+        idle_source: Optional[Callable[[], float]] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._idle = idle_source or native_idle_seconds
+        self._clock = clock
+        self._lock = threading.Lock()
+        self._q: List[Proposal] = []
+        self._seq = 0
+        self.stats: Dict[str, int] = {
+            "submitted": 0, "held_flow": 0, "presented": 0,
+            "ttl_evicted": 0, "spatial_evicted": 0, "deduped": 0,
+        }
+
+    def submit(self, insight: Any, spaces: List[int], dhash: str) -> bool:
+        """Enqueue a proposal (semantic dedup on summary+spaces).
+        NEVER raises."""
+        try:
+            summary = self._summ(insight)
+            with self._lock:
+                for p in self._q:
+                    if p.summary() == summary and p.spaces == spaces:
+                        self.stats["deduped"] += 1
+                        return False
+                self._seq += 1
+                self._q.append(Proposal(
+                    insight, list(spaces), str(dhash),
+                    self._clock(), f"prop-{self._seq}",
+                ))
+                self.stats["submitted"] += 1
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+    @staticmethod
+    def _summ(insight: Any) -> str:
+        try:
+            if isinstance(insight, dict):
+                return str(insight.get("description", ""))
+            return str(getattr(insight, "description", ""))
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def evict_stale(self, *, current_dhash: Optional[str] = None) -> int:
+        """TTL + spatial eviction. ``current_dhash`` (the latest
+        desktop topology) flushes any proposal whose remembered dhash
+        no longer matches (window closed / fixed). Returns count
+        evicted. NEVER raises."""
+        try:
+            now = self._clock()
+            ttl = _proposal_ttl_s()
+            with self._lock:
+                keep: List[Proposal] = []
+                for p in self._q:
+                    if (now - p.created_at) > ttl:
+                        self.stats["ttl_evicted"] += 1
+                        continue
+                    if current_dhash is not None and p.dhash != current_dhash:
+                        self.stats["spatial_evicted"] += 1
+                        continue
+                    keep.append(p)
+                evicted = len(self._q) - len(keep)
+                self._q = keep
+            return evicted
+        except Exception:  # noqa: BLE001
+            return 0
+
+    def present_if_idle(self) -> Optional[Proposal]:
+        """The Active Flow gate: return the OLDEST live proposal ONLY
+        when the operator is idle ≥ the gate; otherwise hold (flow is
+        sacred). The caller routes the returned proposal through the
+        EXISTING [Y/n] Iron Gate — this method never mutates anything.
+        NEVER raises."""
+        try:
+            with self._lock:
+                if not self._q:
+                    return None
+            idle = self._idle()
+            if idle < _idle_gate_s():
+                self.stats["held_flow"] += 1
+                return None                     # operator is in flow
+            with self._lock:
+                if not self._q:
+                    return None
+                p = self._q.pop(0)
+            self.stats["presented"] += 1
+            return p
+        except Exception:  # noqa: BLE001
+            return None
+
+    @property
+    def depth(self) -> int:
+        with self._lock:
+            return len(self._q)
+
+
+__all__ = ["Proposal", "ProposalQueue", "native_idle_seconds"]

--- a/tests/governance/test_proposal_queue.py
+++ b/tests/governance/test_proposal_queue.py
@@ -1,0 +1,105 @@
+"""Proactive Proposal Queue spine — flow protection + eviction gating.
+
+Mandate 4 verbatim (2026-07-19): a valid cross-space proposal is
+generated; idle mocked to 2.0s (active typing) → Active Flow
+Protection blocks the TUI notification and HOLDS the proposal; a
+simulated dhash invalidation later flushes it.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex.proposal_queue import (
+    ProposalQueue,
+)
+
+
+def _insight(desc="reconcile test in S2 with code in S4"):
+    return {"description": desc, "affected_spaces": [2, 4]}
+
+
+class TestActiveFlowProtection:
+    def test_typing_blocks_notification_then_evicted(self, monkeypatch):
+        """MANDATE 4 VERBATIM: idle=2.0s (typing) → held; dhash
+        invalidation flushes it."""
+        idle = {"s": 2.0}
+        clock = {"t": 1000.0}
+        q = ProposalQueue(
+            idle_source=lambda: idle["s"], clock=lambda: clock["t"],
+        )
+        assert q.submit(_insight(), [2, 4], dhash="TOPO_A") is True
+        assert q.depth == 1
+        # Active typing (2.0s < 15s gate) → notification BLOCKED, held:
+        assert q.present_if_idle() is None
+        assert q.stats["held_flow"] == 1
+        assert q.depth == 1                          # still queued
+        # The user closed/fixed the window — dhash invalidation:
+        evicted = q.evict_stale(current_dhash="TOPO_B")
+        assert evicted == 1
+        assert q.depth == 0                          # silently flushed
+        assert q.stats["spatial_evicted"] == 1
+
+    def test_idle_operator_receives_proposal(self):
+        q = ProposalQueue(idle_source=lambda: 30.0)  # idle 30s > 15s gate
+        q.submit(_insight(), [2, 4], dhash="A")
+        p = q.present_if_idle()
+        assert p is not None
+        assert "reconcile" in p.summary()
+        assert q.stats["presented"] == 1
+        assert q.depth == 0                          # dequeued for approval
+
+    def test_flow_then_idle_transition(self):
+        idle = {"s": 3.0}
+        q = ProposalQueue(idle_source=lambda: idle["s"])
+        q.submit(_insight(), [2, 4], dhash="A")
+        assert q.present_if_idle() is None           # typing
+        idle["s"] = 20.0                             # operator stepped away
+        assert q.present_if_idle() is not None       # now delivered
+
+
+class TestEviction:
+    def test_ttl_expiry_flushes(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_PROPOSAL_TTL_S", "300")
+        clock = {"t": 1000.0}
+        q = ProposalQueue(idle_source=lambda: 0.0, clock=lambda: clock["t"])
+        q.submit(_insight(), [2, 4], dhash="A")
+        clock["t"] += 301.0                          # past 5-min TTL
+        assert q.evict_stale() == 1
+        assert q.stats["ttl_evicted"] == 1
+        assert q.depth == 0
+
+    def test_matching_dhash_survives_eviction(self):
+        q = ProposalQueue(idle_source=lambda: 0.0)
+        q.submit(_insight(), [2, 4], dhash="STABLE")
+        assert q.evict_stale(current_dhash="STABLE") == 0
+        assert q.depth == 1                          # topology unchanged
+
+    def test_semantic_dedup(self):
+        q = ProposalQueue(idle_source=lambda: 0.0)
+        assert q.submit(_insight("same"), [2, 4], dhash="A") is True
+        assert q.submit(_insight("same"), [2, 4], dhash="A") is False
+        assert q.stats["deduped"] == 1
+        assert q.depth == 1
+
+
+class TestExecutionGating:
+    def test_present_returns_proposal_never_mutates_pin(self):
+        from pathlib import Path
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/comms/duplex/proposal_queue.py"
+        ).read_text()
+        # No filesystem writes anywhere in this module — it PROPOSES.
+        assert "open(" not in src
+        assert "write" not in src.replace("# ", "").lower() or \
+            "never touches the filesystem" in src
+        # DRY: routes through the EXISTING [Y/n] gate, no new alert sys.
+        assert "Iron Gate" in src
+
+    def test_idle_source_fail_safe_toward_active(self):
+        # native_idle unreadable → 0.0 → treated as ACTIVE → never
+        # interrupts (fail-safe toward NOT disturbing the operator).
+        from backend.core.ouroboros.governance.comms.duplex.proposal_queue import (  # noqa: E501
+            native_idle_seconds,
+        )
+        assert isinstance(native_idle_seconds(), float)


### PR DESCRIPTION
## Summary
The final proactive layer: CrossSpaceGaze insights become proposals held until the operator is idle, evicted when stale, and never executed without explicit approval.
- **Active Flow Protection** — native `CGEventSourceSecondsSinceLastEventType` (no polling); a proposal renders only after 15s idle, holds during input; unreadable idle fails safe toward *active* (never interrupt).
- **Eviction** — TTL (5 min) + spatial dhash invalidation (window closed/fixed → silent flush) + semantic dedup.
- **Strict gating** — `present_if_idle` returns the proposal for the caller to route through the *existing* SerpentFlow `[Y/n]` Iron Gate; this module never touches the filesystem and builds no separate alert system (DRY).

## Testing
8 tests incl. **mandate 4 verbatim**: proposal + idle=2.0s (typing) → notification blocked & held; dhash invalidation later flushes it. Idle-transition delivery, TTL evict, dhash-survive, semantic dedup, no-filesystem pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a flow-protected proposal queue that turns cross-space insights into suggestions, shown only when the operator is idle. Stale or invalid proposals are auto-evicted, and all suggestions go through the existing approval gate.

- **New Features**
  - Active flow protection: native macOS idle detection (no polling); presents only after 15s idle; input holds; unreadable idle treats the operator as active.
  - Eviction: 5-minute TTL, spatial dhash mismatch flush, and semantic dedup on summary + spaces.
  - Strict gating: `present_if_idle` returns the oldest proposal for SerpentFlow `[Y/n]` approval; no filesystem writes; never raises.

- **Dependencies**
  - Uses `Quartz` for native idle detection; falls back safely if unavailable.

<sup>Written for commit ea68437fbe959e98c626cc57e54cede82c80b314. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

