### PR TITLE
feat(sovereignty): SkyLight true-Space attribution + Amortized Presentation Slot

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/proactive_coordinator.py
+++ b/backend/core/ouroboros/governance/comms/duplex/proactive_coordinator.py
@@ -142,6 +142,17 @@ def native_windows_by_space() -> Dict[int, List[dict]]:
         wins = Quartz.CGWindowListCopyWindowInfo(
             Quartz.kCGWindowListOptionAll, Quartz.kCGNullWindowID,
         ) or []
+        # SkyLight true-Space attribution FIRST (2026-07-19): native
+        # Mission-Control Space IDs. Returns None when the private API
+        # is unavailable/vanished → the PID heuristic below runs
+        # (Dynamic Symbol Resolution degradation, mandate 2).
+        try:
+            from .skylight_spaces import true_windows_by_space  # noqa: PLC0415
+            true = true_windows_by_space(list(wins))
+            if true:
+                return true
+        except Exception:  # noqa: BLE001
+            pass
         by_space: Dict[int, List[dict]] = {}
         pid_space: Dict[Any, int] = {}
         next_space = 2

--- a/backend/core/ouroboros/governance/comms/duplex/proposal_queue.py
+++ b/backend/core/ouroboros/governance/comms/duplex/proposal_queue.py
@@ -103,10 +103,17 @@ class ProposalQueue:
         self.stats: Dict[str, int] = {
             "submitted": 0, "held_flow": 0, "presented": 0,
             "ttl_evicted": 0, "spatial_evicted": 0, "deduped": 0,
+            "slot_evicted": 0,
         }
 
     def submit(self, insight: Any, spaces: List[int], dhash: str) -> bool:
-        """Enqueue a proposal (semantic dedup on summary+spaces).
+        """Enqueue a proposal. Semantic dedup on summary+spaces.
+
+        Amortized Presentation Slot (mandate 2 — the Alert Avalanche
+        Guard): at most ONE proposal is ever held. A FRESHER insight
+        arriving while the slot is occupied SILENTLY EVICTS the older
+        one and takes its place — a returning operator faces exactly
+        one current prompt, never a stacked backlog of stale [Y/n]s.
         NEVER raises."""
         try:
             summary = self._summ(insight)
@@ -115,6 +122,10 @@ class ProposalQueue:
                     if p.summary() == summary and p.spaces == spaces:
                         self.stats["deduped"] += 1
                         return False
+                # Single-slot amortization: newest wins.
+                if self._q:
+                    self._q.clear()
+                    self.stats["slot_evicted"] += 1
                 self._seq += 1
                 self._q.append(Proposal(
                     insight, list(spaces), str(dhash),

--- a/backend/core/ouroboros/governance/comms/duplex/skylight_spaces.py
+++ b/backend/core/ouroboros/governance/comms/duplex/skylight_spaces.py
@@ -1,0 +1,129 @@
+"""SkyLight true-Space attribution — native, dynamically resolved.
+
+Operator authorization 2026-07-19. Replaces the coarse PID-bucketing
+heuristic ("17 pseudo-Spaces from 71 windows") with the operator's
+TRUE Mission-Control Space IDs, via Apple's private
+CoreGraphics/SkyLight symbols.
+
+Mandate 1+2 — Dynamic Symbol Resolution with graceful degradation:
+``CGSCopySpacesForWindows`` / ``CGSGetActiveSpace`` are private
+undocumented symbols that CAN vanish in a macOS update. They are
+resolved at RUNTIME (never a static import) — this module reuses the
+EXISTING ``MacOSSpaceDetector`` (which already dynamically loads the
+CoreGraphics bundle + resolves the CGS symbol map with its own
+``_private_api_available`` capability flag). If resolution fails or
+throws, :func:`true_windows_by_space` returns ``None`` and the caller
+falls back to PID bucketing — the FSM never crashes.
+
+DRY (mandate 3): zero new ctypes/bundle-load code; the detector's
+resolved symbol map IS the binding.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.SkyLightSpaces")
+
+_DETECTOR: Any = None
+_RESOLUTION_FAILED = False
+
+
+def _get_detector() -> Any:
+    """Lazily build (once) the existing MacOSSpaceDetector — it does
+    the dynamic bundle load + CGS symbol resolution internally. A
+    resolution fault is remembered so we never re-pay it. NEVER
+    raises; returns None on any failure (→ caller degrades)."""
+    global _DETECTOR, _RESOLUTION_FAILED
+    if _RESOLUTION_FAILED:
+        return None
+    if _DETECTOR is not None:
+        return _DETECTOR
+    try:
+        from backend.vision.macos_space_detector import (  # noqa: PLC0415
+            MacOSSpaceDetector,
+        )
+        det = MacOSSpaceDetector()
+        # The detector sets _private_api_available after its own
+        # dynamic resolution — the honest capability signal.
+        if not getattr(det, "_private_api_available", False):
+            _RESOLUTION_FAILED = True
+            logger.info(
+                "[SkyLight] private Space API unavailable — degrading "
+                "to PID-bucketing heuristic",
+            )
+            return None
+        _DETECTOR = det
+        return det
+    except Exception as exc:  # noqa: BLE001 — missing symbol / bundle / import
+        _RESOLUTION_FAILED = True
+        logger.warning(
+            "[SkyLight] symbol resolution failed (%s) — degrading to "
+            "PID heuristic", exc,
+        )
+        return None
+
+
+def _reset_for_tests() -> None:
+    global _DETECTOR, _RESOLUTION_FAILED
+    _DETECTOR = None
+    _RESOLUTION_FAILED = False
+
+
+def skylight_available() -> bool:
+    """True iff the true-Space API resolved. NEVER raises."""
+    return _get_detector() is not None
+
+
+def true_windows_by_space(
+    raw_windows: List[dict],
+) -> Optional[Dict[int, List[dict]]]:
+    """Attribute each raw CGWindow to its TRUE Mission-Control Space
+    via the resolved private API. Returns ``None`` when the API is
+    unavailable (caller falls back to PID bucketing) — NEVER raises,
+    NEVER a partial/garbage map.
+
+    ``raw_windows`` are the ``CGWindowListCopyWindowInfo`` dicts; each
+    carries ``kCGWindowNumber``. We ask the detector for the
+    window→space mapping through its already-resolved
+    ``CGSCopySpacesForWindows`` symbol; a per-window resolution gap
+    routes that window to the active Space (never dropped)."""
+    det = _get_detector()
+    if det is None:
+        return None
+    try:
+        conn = getattr(det, "cgs_connection", None)
+        copy_for_windows = getattr(det, "_cgs_copy_spaces_for_windows", None)
+        get_active = getattr(det, "_cgs_get_active_space", None)
+        if conn is None:
+            return None
+        active_space = 1
+        if callable(get_active):
+            try:
+                active_space = int(get_active(conn))
+            except Exception:  # noqa: BLE001
+                active_space = 1
+        by_space: Dict[int, List[dict]] = {}
+        for w in raw_windows:
+            if w.get("kCGWindowLayer", 0) != 0:
+                continue
+            wid = w.get("kCGWindowNumber")
+            space_id = active_space
+            if callable(copy_for_windows) and wid is not None:
+                try:
+                    spaces = copy_for_windows(conn, 0x7, [wid])  # all-space mask
+                    if spaces:
+                        space_id = int(spaces[0])
+                except Exception:  # noqa: BLE001
+                    space_id = active_space
+            by_space.setdefault(space_id, []).append(dict(w))
+        return by_space or None
+    except Exception:  # noqa: BLE001
+        logger.debug("[SkyLight] attribution degraded", exc_info=True)
+        return None
+
+
+__all__ = [
+    "skylight_available",
+    "true_windows_by_space",
+]

--- a/tests/governance/test_skylight_and_amortize.py
+++ b/tests/governance/test_skylight_and_amortize.py
@@ -1,0 +1,120 @@
+"""SkyLight true-Space attribution + Amortized Presentation Slot spine.
+
+Mandate 4 verbatim (2026-07-19): a mocked SkyLight symbol resolution
+failure (AttributeError on the CDLL/bundle load) → the fault-handler
+catches the missing symbol, logs the degradation, falls back to PID
+bucketing, and the primary loop survives.
+"""
+from __future__ import annotations
+
+import logging
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex import skylight_spaces as sl
+from backend.core.ouroboros.governance.comms.duplex.proposal_queue import (
+    ProposalQueue,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_skylight():
+    sl._reset_for_tests()
+    yield
+    sl._reset_for_tests()
+
+
+class TestDynamicSymbolResolution:
+    def test_symbol_resolution_failure_degrades_no_crash(
+        self, monkeypatch, caplog,
+    ):
+        """MANDATE 4 VERBATIM: AttributeError on bundle/CDLL load →
+        caught, logged, falls back to PID (None), loop survives."""
+        import backend.vision.macos_space_detector as msd
+
+        class _BoomDetector:
+            def __init__(self):
+                raise AttributeError(
+                    "dlsym(CGSCopySpacesForWindows): symbol not found",
+                )
+
+        monkeypatch.setattr(msd, "MacOSSpaceDetector", _BoomDetector)
+        with caplog.at_level(logging.WARNING, logger="Ouroboros.SkyLightSpaces"):
+            result = sl.true_windows_by_space([{"kCGWindowNumber": 1}])
+        assert result is None                       # → PID fallback
+        assert sl.skylight_available() is False
+        assert any("symbol resolution failed" in r.message
+                   for r in caplog.records)         # logged degradation
+        # The primary loop is unharmed — a second call is a fast no-op:
+        assert sl.true_windows_by_space([{"kCGWindowNumber": 2}]) is None
+
+    def test_private_api_unavailable_degrades(self, monkeypatch):
+        import backend.vision.macos_space_detector as msd
+
+        class _NoPrivateAPI:
+            _private_api_available = False
+
+        monkeypatch.setattr(msd, "MacOSSpaceDetector", lambda: _NoPrivateAPI())
+        assert sl.true_windows_by_space([{"kCGWindowNumber": 1}]) is None
+        assert sl.skylight_available() is False
+
+    def test_resolution_failure_remembered_not_repaid(self, monkeypatch):
+        import backend.vision.macos_space_detector as msd
+        calls = {"n": 0}
+
+        def _boom():
+            calls["n"] += 1
+            raise AttributeError("gone")
+
+        monkeypatch.setattr(msd, "MacOSSpaceDetector", _boom)
+        sl.true_windows_by_space([])
+        sl.true_windows_by_space([])
+        sl.true_windows_by_space([])
+        assert calls["n"] == 1                       # resolved-fault cached
+
+    def test_provider_falls_back_when_skylight_none(self, monkeypatch):
+        # native_windows_by_space must still yield the PID-bucket map
+        # when SkyLight returns None (the real degraded path).
+        from backend.core.ouroboros.governance.comms.duplex import (
+            proactive_coordinator as pc,
+        )
+        monkeypatch.setattr(
+            "backend.core.ouroboros.governance.comms.duplex.skylight_spaces."
+            "true_windows_by_space", lambda w: None,
+        )
+        # No Quartz on CI → {} (still no crash); on macOS → PID map.
+        result = pc.native_windows_by_space()
+        assert isinstance(result, dict)
+
+
+class TestAmortizedPresentationSlot:
+    def test_fresher_insight_evicts_older_single_slot(self):
+        """The Alert Avalanche Guard: max ONE proposal; a newer one
+        silently replaces the older."""
+        q = ProposalQueue(idle_source=lambda: 30.0)  # idle → will present
+        q.submit({"description": "old insight"}, [1], dhash="A")
+        assert q.depth == 1
+        q.submit({"description": "FRESH insight"}, [2], dhash="B")
+        assert q.depth == 1                          # STILL one slot
+        assert q.stats["slot_evicted"] == 1
+        # The one held proposal is the FRESH one:
+        p = q.present_if_idle()
+        assert p is not None and "FRESH" in p.summary()
+
+    def test_returning_operator_faces_one_prompt(self):
+        q = ProposalQueue(idle_source=lambda: 30.0)  # idle (stepped away)
+        # A long idle period generates several insights:
+        for i in range(5):
+            q.submit({"description": f"insight-{i}"}, [i], dhash=f"H{i}")
+        assert q.depth == 1                          # never stacked
+        p = q.present_if_idle()
+        assert "insight-4" in p.summary()            # the newest
+        assert q.present_if_idle() is None           # no avalanche behind it
+
+    def test_identical_insight_still_deduped_not_evicted(self):
+        q = ProposalQueue(idle_source=lambda: 0.0)
+        q.submit({"description": "same"}, [1], dhash="A")
+        assert q.submit({"description": "same"}, [1], dhash="A") is False
+        assert q.stats["deduped"] == 1
+        assert q.stats["slot_evicted"] == 0          # dedup ≠ eviction
+        assert q.depth == 1


### PR DESCRIPTION
## Summary
- **SkyLight true-Space attribution** — replaces the coarse PID heuristic ("17 pseudo-Spaces from 71 windows") with the operator's real Mission-Control Space IDs. Dynamic Symbol Resolution reuses the *existing* `MacOSSpaceDetector`'s runtime CGS symbol map (`CGSCopySpacesForWindows`/`CGSGetActiveSpace`, dynamically loaded via its own bundle load + `_private_api_available` flag — zero new ctypes code). A vanished symbol or bundle fault → `None` → `native_windows_by_space` falls back to PID bucketing; the fault is cached so it's never re-paid. SkyLight is tried first, degrades cleanly.
- **Amortized Presentation Slot** — the queue holds at most one proposal; a fresher insight silently evicts the older and takes its place. After a long idle the operator faces exactly one current `[Y/n]`, never a stacked avalanche. Semantic dedup unchanged (dedup ≠ eviction).

## Testing
7 tests incl. **mandate 4 verbatim**: mocked SkyLight `AttributeError` on the detector load → caught, degradation logged, PID fallback, loop survives, fault cached. Private-API-unavailable degrade, provider fallback, single-slot eviction, returning-operator-one-prompt, dedup-not-eviction. 27-test queue/coordinator/skylight sweep green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add SkyLight true Mission Control Space attribution and a single-slot proposal queue to reduce noisy prompts and improve attribution accuracy. SkyLight is tried first and cleanly falls back to PID bucketing when the private API isn’t available.

- **New Features**
  - True Space attribution: `native_windows_by_space` prefers `true_windows_by_space`, which reuses `MacOSSpaceDetector` to resolve `CGSCopySpacesForWindows` and `CGSGetActiveSpace`. No new ctypes; resolution faults are cached and return `None` to trigger PID fallback.
  - Amortized presentation slot: `ProposalQueue` holds at most one proposal; a newer insight evicts the older. Semantic dedup remains unchanged. Tracks `slot_evicted` stats.

<sup>Written for commit e33626c5807b1181c1f2bf375782869625559661. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69962?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

