### PR TITLE
feat(soak): Residency Telemetry ring-buffer + verified lazy ML isolation

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -2161,6 +2161,32 @@ class GovernedLoopService:
                     self._chronos_task = _aio_chr.create_task(
                         _chronos_heartbeat_loop(),
                     )
+
+                    # Residency Telemetry (2026-07-19, pre-soak): the
+                    # loop instruments ITSELF — RSS / UDS conns / loop
+                    # lag every 5 min → bounded rotating JSONL. Own
+                    # task on the Orchestrator lifecycle; a leak shows
+                    # as monotone rss_delta over the 24h soak.
+                    try:
+                        from backend.core.ouroboros.governance.residency_telemetry import (  # noqa: E501
+                            ResidencyTelemetry,
+                        )
+
+                        def _uds_conns() -> int:
+                            n = 0
+                            for _attr in (
+                                "_cockpit_attach_bridge", "audio_ipc",
+                            ):
+                                _b = getattr(self, _attr, None)
+                                n += int(getattr(_b, "client_count", 0) or 0)
+                            return n
+
+                        self._residency_telemetry = ResidencyTelemetry(
+                            conn_source=_uds_conns,
+                        )
+                        self._residency_telemetry.start()
+                    except Exception:  # noqa: BLE001
+                        self._residency_telemetry = None
                     logger.info(
                         "[GovernedLoop] Chronos heartbeat scheduled (%.0fs; "
                         "non-volatile uptime ledger active)", _chronos_hb_s(),

--- a/backend/core/ouroboros/governance/residency_telemetry.py
+++ b/backend/core/ouroboros/governance/residency_telemetry.py
@@ -1,0 +1,228 @@
+"""Residency Telemetry — the organism instruments its OWN loop.
+
+Pre-soak hardening (operator authorization 2026-07-19) for the 24/7
+Continuous Residency Validation. Mandate 1: no bash, no cron, no
+psutil scraping — the async loop measures ITSELF.
+
+Every ``JARVIS_RESIDENCY_SNAPSHOT_S`` (300s) a non-blocking task
+appends one JSON line:
+
+  * ``rss_mb``       — stdlib ``resource.getrusage`` (native, no
+    psutil; macOS bytes / Linux KiB normalized).
+  * ``uds_conns``    — live attach/audio subscriber count (pulled from
+    the injected bridge — the organism's own connection ledgers).
+  * ``loop_lag_ms``  — event-loop scheduling latency: the round-trip
+    of a ``call_soon`` future (the honest "is the loop starving?"
+    probe — a zero-work callback that should return in microseconds;
+    a fat number means the loop is congested).
+  * deltas vs the first snapshot → a leak shows as monotone rss growth.
+
+DRY (mandate 3): the bounded ``.jsonl`` rides the EXISTING
+``headless_telemetry`` RotatingFileHandler (same
+``JARVIS_TELEMETRY_LOG_MAX_BYTES`` rotation the FSM log janitor uses).
+The task registers on the Orchestrator lifecycle (GovernedLoop) — one
+coroutine, cancelled cleanly at teardown.
+
+NEVER raises on the sampling path — a telemetry fault must never
+perturb the system it measures.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import logging.handlers
+import os
+import resource
+import sys
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.ResidencyTelemetry")
+
+
+def _snapshot_interval_s() -> float:
+    try:
+        return max(5.0, min(3600.0, float(os.environ.get(
+            "JARVIS_RESIDENCY_SNAPSHOT_S", "300",
+        ))))
+    except (TypeError, ValueError):
+        return 300.0
+
+
+def _log_path() -> Path:
+    return Path(os.environ.get(
+        "JARVIS_RESIDENCY_LOG",
+        ".jarvis/logs/residency_telemetry.jsonl",
+    ))
+
+
+def rss_mb() -> float:
+    """Resident set size in MiB via stdlib ``resource`` — NO psutil.
+    ru_maxrss is bytes on macOS, KiB on Linux. NEVER raises."""
+    try:
+        raw = resource.getrusage(resource.RUSAGE_SELF).ru_maxrss
+        # Normalize: Darwin reports bytes, Linux KiB.
+        if sys.platform == "darwin":
+            return round(raw / (1024.0 * 1024.0), 2)
+        return round(raw / 1024.0, 2)
+    except Exception:  # noqa: BLE001
+        return 0.0
+
+
+async def loop_lag_ms(loop: Optional[asyncio.AbstractEventLoop] = None) -> float:
+    """Event-loop scheduling latency: the round-trip of a zero-work
+    ``call_soon`` callback. A healthy loop returns in µs; congestion
+    (a blocking call hogging the loop) inflates it — the honest
+    starvation probe. NEVER raises."""
+    try:
+        loop = loop or asyncio.get_running_loop()
+        fut: "asyncio.Future" = loop.create_future()
+        t0 = loop.time()
+        loop.call_soon(lambda: fut.done() or fut.set_result(loop.time()))
+        t1 = await fut
+        return round((t1 - t0) * 1000.0, 3)
+    except Exception:  # noqa: BLE001
+        return -1.0
+
+
+class ResidencyTelemetry:
+    """Owns the bounded JSONL sink + the snapshot loop. ``conn_source``
+    returns the live UDS subscriber count (injected — the bridges'
+    own client ledgers); ``clock`` injected for the fast-forward
+    test."""
+
+    def __init__(
+        self,
+        *,
+        conn_source: Optional[Callable[[], int]] = None,
+        log_path: Optional[Path] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._conns = conn_source or (lambda: 0)
+        self._path = log_path or _log_path()
+        self._clock = clock
+        self._handler: Optional[logging.handlers.RotatingFileHandler] = None
+        self._task: Optional[asyncio.Task] = None
+        self._first_rss: Optional[float] = None
+        self._samples = 0
+        self.last: Dict[str, Any] = {}
+
+    def _get_handler(self) -> Optional[logging.handlers.RotatingFileHandler]:
+        if self._handler is not None:
+            return self._handler
+        try:
+            # DRY: the SAME rotation knobs as the FSM log janitor.
+            from backend.core.ouroboros.governance.headless_telemetry import (  # noqa: E501
+                _DEFAULT_BACKUPS,
+                _DEFAULT_MAX_BYTES,
+                _FLAG_BACKUPS,
+                _FLAG_MAX_BYTES,
+                _env_int,
+            )
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            self._handler = logging.handlers.RotatingFileHandler(
+                str(self._path),
+                maxBytes=_env_int(_FLAG_MAX_BYTES, _DEFAULT_MAX_BYTES),
+                backupCount=_env_int(_FLAG_BACKUPS, _DEFAULT_BACKUPS),
+                encoding="utf-8",
+            )
+            self._handler.setFormatter(logging.Formatter("%(message)s"))
+            return self._handler
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def snapshot(self) -> Dict[str, Any]:
+        """One measurement → one bounded JSONL line. Returns the row.
+        NEVER raises; NEVER blocks the loop."""
+        try:
+            r = rss_mb()
+            if self._first_rss is None:
+                self._first_rss = r
+            row = {
+                "ts": time.time(),
+                "rss_mb": r,
+                "rss_delta_mb": round(r - (self._first_rss or r), 2),
+                "uds_conns": self._safe_conns(),
+                "loop_lag_ms": await loop_lag_ms(),
+                "sample": self._samples,
+            }
+            self._samples += 1
+            self.last = row
+            h = self._get_handler()
+            if h is not None:
+                # Emit through the rotating handler (bounded on disk).
+                rec = logging.LogRecord(
+                    "residency", logging.INFO, __file__, 0,
+                    json.dumps(row, separators=(",", ":")), (), None,
+                )
+                h.emit(rec)
+            return row
+        except Exception:  # noqa: BLE001
+            logger.debug("[Residency] snapshot degraded", exc_info=True)
+            return {}
+
+    def _safe_conns(self) -> int:
+        try:
+            return int(self._conns())
+        except Exception:  # noqa: BLE001
+            return -1
+
+    def start(self) -> bool:
+        """Register the snapshot loop on the running loop. Gated
+        ``JARVIS_RESIDENCY_TELEMETRY_ENABLED`` (default ON — cheap and
+        the soak needs it). NEVER raises."""
+        try:
+            if os.environ.get(
+                "JARVIS_RESIDENCY_TELEMETRY_ENABLED", "1",
+            ).strip().lower() not in ("1", "true", "yes", "on"):
+                return False
+            loop = asyncio.get_running_loop()
+            self._task = loop.create_task(self._loop())
+            logger.info(
+                "[Residency] telemetry armed (every %.0fs → %s)",
+                _snapshot_interval_s(), self._path,
+            )
+            return True
+        except RuntimeError:
+            return False
+        except Exception:  # noqa: BLE001
+            return False
+
+    async def _loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(_snapshot_interval_s())
+                await self.snapshot()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[Residency] loop degraded", exc_info=True)
+
+    async def stop(self) -> None:
+        """Cancel the loop + flush the handler. NEVER raises."""
+        try:
+            task = self._task
+            self._task = None
+            if task is not None and not task.done():
+                task.cancel()
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            if self._handler is not None:
+                try:
+                    self._handler.close()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._handler = None
+        except Exception:  # noqa: BLE001
+            pass
+
+
+__all__ = [
+    "ResidencyTelemetry",
+    "loop_lag_ms",
+    "rss_mb",
+]

--- a/tests/governance/test_residency_telemetry.py
+++ b/tests/governance/test_residency_telemetry.py
@@ -1,0 +1,165 @@
+"""Residency Telemetry spine — self-instrumented loop + lazy ML.
+
+Mandate 4 verbatim (2026-07-19): a fast-forwarded 24h event loop where
+the snapshot fires repeatedly. Assert the telemetry queue footprint
+stays flat and the RotatingFileHandler prunes the .jsonl to its max
+byte size WITHOUT halting the primary event loop.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.residency_telemetry import (
+    ResidencyTelemetry,
+    loop_lag_ms,
+    rss_mb,
+)
+
+
+class TestNativeProbes:
+    def test_rss_native_no_psutil(self):
+        v = rss_mb()
+        assert isinstance(v, float) and v > 0        # real process RSS
+        # No psutil import anywhere in the module:
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/residency_telemetry.py"
+        ).read_text()
+        # No psutil IMPORT (the docstring may mention it as the thing
+        # we deliberately avoid — check imports, not prose):
+        import ast
+        for node in ast.walk(ast.parse(src)):
+            if isinstance(node, ast.Import):
+                assert all("psutil" not in a.name for a in node.names)
+            elif isinstance(node, ast.ImportFrom):
+                assert "psutil" not in (node.module or "")
+        assert "import resource" in src              # stdlib native
+
+    async def test_loop_lag_measures_scheduling(self):
+        lag = await loop_lag_ms()
+        assert lag >= 0.0 and lag < 500.0           # healthy idle loop
+
+    async def test_congested_loop_shows_higher_lag(self):
+        import time
+        healthy = await loop_lag_ms()
+        # A blocking call hogs the loop between the call_soon and its
+        # callback — lag inflates (the honest starvation signal).
+        import asyncio
+        loop = asyncio.get_running_loop()
+        fut = loop.create_future()
+        t0 = loop.time()
+        loop.call_soon(lambda: fut.set_result(loop.time()))
+        time.sleep(0.05)                             # BLOCK the loop 50ms
+        t1 = await fut
+        congested = round((t1 - t0) * 1000, 3)
+        assert congested > healthy                   # detected congestion
+
+
+class TestMandate4:
+    async def test_24h_fastforward_flat_footprint_bounded_file(
+        self, tmp_path, monkeypatch,
+    ):
+        """MANDATE 4 VERBATIM: 288 snapshots (24h @ 5min) → queue
+        footprint flat, .jsonl rotated to max bytes, loop never
+        halted."""
+        # Tiny rotation so the prune is exercised within the test.
+        monkeypatch.setenv("JARVIS_TELEMETRY_LOG_MAX_BYTES", "4096")
+        monkeypatch.setenv("JARVIS_TELEMETRY_LOG_BACKUPS", "2")
+        log = tmp_path / "residency.jsonl"
+        tel = ResidencyTelemetry(
+            conn_source=lambda: 2, log_path=log,
+        )
+        # Prove the loop stays alive throughout: a concurrent heartbeat.
+        import asyncio
+        beats = {"n": 0}
+        async def _beat():
+            for _ in range(50):
+                beats["n"] += 1
+                await asyncio.sleep(0)
+        beat_task = asyncio.get_running_loop().create_task(_beat())
+
+        SNAPSHOTS = 288                              # 24h at 5-min cadence
+        for _ in range(SNAPSHOTS):
+            row = await tel.snapshot()
+            assert "rss_mb" in row and "loop_lag_ms" in row
+
+        await beat_task
+        assert beats["n"] == 50                      # loop NEVER halted
+
+        # Footprint flat: the telemetry holds only `last` + counters,
+        # not 288 rows in memory (bounded by construction).
+        assert tel._samples == SNAPSHOTS
+        assert isinstance(tel.last, dict)            # single latest row
+        # File pruned to max bytes (+ backups), NOT 288 unbounded lines:
+        assert log.exists()
+        assert log.stat().st_size <= 4096 + 512      # rotated, bounded
+        survivors = sorted(p.name for p in tmp_path.iterdir()
+                           if p.name.startswith("residency"))
+        assert len(survivors) <= 3                   # main + 2 backups
+        # Every surviving line is valid JSON (bounded ring integrity):
+        for line in log.read_text().splitlines():
+            if line.strip():
+                json.loads(line)
+        await tel.stop()
+
+    async def test_snapshot_records_leak_as_rss_delta(self, tmp_path):
+        tel = ResidencyTelemetry(log_path=tmp_path / "r.jsonl")
+        r1 = await tel.snapshot()
+        r2 = await tel.snapshot()
+        assert "rss_delta_mb" in r2                  # leak-detection field
+        assert r1["sample"] == 0 and r2["sample"] == 1
+
+    async def test_conn_source_fault_never_breaks_snapshot(self, tmp_path):
+        def _boom():
+            raise RuntimeError("bridge gone")
+        tel = ResidencyTelemetry(
+            conn_source=_boom, log_path=tmp_path / "r.jsonl",
+        )
+        row = await tel.snapshot()
+        assert row["uds_conns"] == -1               # degraded, not crashed
+
+
+class TestLazyMLSubstrates:
+    def test_no_module_level_ml_imports_in_duplex(self):
+        """Dependency Isolation (mandate 2): torch/speechbrain/Speech/
+        AVFoundation/Quartz must be RUNTIME imports (PLC0415), never
+        module-level — text-only residency keeps them out of memory."""
+        import ast
+        duplex = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/comms/duplex"
+        )
+        heavy = {"torch", "speechbrain", "Speech", "AVFoundation", "Quartz"}
+        offenders = []
+        for py in duplex.glob("*.py"):
+            tree = ast.parse(py.read_text())
+            for node in tree.body:                   # MODULE LEVEL only
+                if isinstance(node, ast.Import):
+                    for a in node.names:
+                        if a.name.split(".")[0] in heavy:
+                            offenders.append(f"{py.name}: import {a.name}")
+                elif isinstance(node, ast.ImportFrom) and node.module:
+                    if node.module.split(".")[0] in heavy:
+                        offenders.append(f"{py.name}: from {node.module}")
+        assert not offenders, f"module-level ML imports: {offenders}"
+
+    def test_text_only_import_stays_light(self):
+        """Importing the sentry/scorer modules must NOT drag torch in
+        (text-only residency contract)."""
+        import subprocess, sys
+        code = (
+            "import sys;"
+            "import backend.core.ouroboros.governance.comms.duplex."
+            "passive_sentry;"
+            "import backend.core.ouroboros.governance.comms.duplex."
+            "biometric_scorer;"
+            "print('torch' in sys.modules)"
+        )
+        out = subprocess.run(
+            [sys.executable, "-c", code], capture_output=True, text=True,
+            timeout=60,
+        ).stdout.strip()
+        assert out.endswith("False"), f"torch loaded on text-only import: {out}"


### PR DESCRIPTION
## Summary
Pre-soak instrumentation for the 24/7 Continuous Residency Validation.
- **Self-instrumented telemetry** — the async loop measures itself (no bash/cron/psutil). Every 5 min a non-blocking task snapshots `rss_mb` (stdlib `resource.getrusage`, platform-normalized), `uds_conns` (the bridges' own `client_count`), and `loop_lag_ms` (`call_soon` round-trip — the honest starvation probe), plus `rss_delta_mb` so a leak reads as monotone growth. Bounded `.jsonl` rides the *existing* `headless_telemetry` RotatingFileHandler (same rotation as the FSM janitor). Registered on the GovernedLoop lifecycle beside the Chronos heartbeat.
- **Lazy ML isolation, verified** — an AST test proves zero module-level `torch`/`speechbrain`/`Speech`/`AVFoundation`/`Quartz` imports across the duplex namespace; a subprocess test proves text-only import of the sentry + scorer leaves torch out of `sys.modules`. Text-only residency keeps the heavy substrates out of memory.

## Testing
8 tests incl. **mandate 4 verbatim**: 288-snapshot 24h fast-forward → in-memory footprint flat (only `last` + counters), `.jsonl` rotated to max bytes (main + 2 backups), a concurrent heartbeat proves the loop is never halted. Native-RSS/loop-lag probes, congestion detection, leak-delta field, conn-source-fault containment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds self-instrumented residency telemetry to the governed loop and verifies lazy ML isolation for text-only residency. Enables 24/7 soak validation with bounded metrics and no heavy ML modules loaded.

- New Features
  - `ResidencyTelemetry`: snapshots `rss_mb`, `uds_conns`, `loop_lag_ms`, and `rss_delta_mb` every 5 min (config via `JARVIS_RESIDENCY_SNAPSHOT_S`); writes JSONL via the existing `headless_telemetry` rotating handler; gated by `JARVIS_RESIDENCY_TELEMETRY_ENABLED`; non-blocking and never raises.
  - Integrated into `GovernedLoop` startup; UDS connection count aggregated from `_cockpit_attach_bridge` and `audio_ipc`.
  - Lazy ML isolation verified: AST and subprocess tests confirm no module-level imports of `torch`/`speechbrain`/`Speech`/`AVFoundation`/`Quartz` in duplex and that importing `passive_sentry` + `biometric_scorer` doesn’t load `torch`. A 24h fast-forward test ensures bounded rotation, flat memory, and a responsive loop.

<sup>Written for commit a4c213628fcbd84ba28b11aec59ddc9db649990f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69963?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

