### PR TITLE
feat(multi-agent): QoS frustration sensor + depth-bounded peer consensus RPC

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/peer_consensus.py
+++ b/backend/core/ouroboros/governance/comms/duplex/peer_consensus.py
@@ -1,0 +1,153 @@
+"""Peer Consensus RPC — Daniel and Karen converse as reasoning agents.
+
+The second closing gap (operator authorization 2026-07-19). Until now
+the personas shared memory and split voices but never TALKED. This is
+the inter-agent handshake: JARVIS (Daniel) yields a hard coding query
+to O+V (Karen), awaits her diagnostic, and answers the user with it —
+over the EXISTING TrinityEventBus transport + the Claude/DW provider
+connections.
+
+**Depth-Bounded Consensus Lock (mandate 2 — the anti-loop guard):** a
+single user interaction may trigger AT MOST ONE round-trip. The lock
+is armed on the first yield; a SECOND yield within the same
+interaction is INTERCEPTED — no provider call, no token burn — and
+Daniel gracefully falls back to reporting the ambiguity to the
+operator. This makes an infinite Daniel↔Karen token-burn loop
+structurally impossible, not merely discouraged.
+
+``karen_diagnose`` is the injected reasoning seam (production: Karen's
+answer engine → rt_gate → Claude/DW). Every path is bounded + fail-
+soft; NEVER raises.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from typing import Any, Awaitable, Callable, Dict, Optional
+
+logger = logging.getLogger("Ouroboros.PeerConsensus")
+
+OUTCOME_RESOLVED = "resolved"
+OUTCOME_LOCK_INTERCEPTED = "lock_intercepted_fallback"
+OUTCOME_TIMEOUT = "timeout_fallback"
+OUTCOME_ERROR = "error_fallback"
+
+_FALLBACK_MESSAGE = (
+    "I looked into that with the engineering side but couldn't fully "
+    "resolve it in one pass — here's what I have, and I'd flag the "
+    "ambiguity rather than guess further."
+)
+
+
+def _consensus_timeout_s() -> float:
+    try:
+        return max(2.0, min(120.0, float(os.environ.get(
+            "JARVIS_CONSENSUS_TIMEOUT_S", "30",
+        )))
+        )
+    except (TypeError, ValueError):
+        return 30.0
+
+
+class ConsensusSession:
+    """One user interaction's consensus budget. The lock is per-
+    session so a NEW user interaction gets a fresh single round-trip
+    — the guard bounds a loop WITHIN one interaction, not across a
+    conversation."""
+
+    def __init__(self) -> None:
+        self._used = False
+
+    @property
+    def spent(self) -> bool:
+        return self._used
+
+    def try_claim(self) -> bool:
+        """Claim the single round-trip. Returns True the FIRST time,
+        False forever after (the second-yield interception point)."""
+        if self._used:
+            return False
+        self._used = True
+        return True
+
+
+class PeerConsensus:
+    """The inter-agent RPC. ``karen_diagnose(query, context) -> str``
+    is Karen's reasoning seam (routes to Claude/DW in production)."""
+
+    def __init__(
+        self,
+        *,
+        karen_diagnose: Optional[Callable[..., Awaitable[str]]] = None,
+    ) -> None:
+        self._diagnose = karen_diagnose or self._default_diagnose
+        self.stats: Dict[str, int] = {
+            "yields": 0, "resolved": 0, "lock_intercepted": 0,
+            "timeouts": 0, "errors": 0,
+        }
+
+    @staticmethod
+    async def _default_diagnose(query: str, context: Any) -> str:
+        # Production: Karen's answer engine → rt_gate → Claude/DW.
+        from backend.core.ouroboros.governance.karen_answer_engine import (  # noqa: E501,PLC0415
+            KarenQueryProvider,
+        )
+        return await KarenQueryProvider().query(query)
+
+    def new_session(self) -> ConsensusSession:
+        """A fresh single-round-trip budget for one user interaction."""
+        return ConsensusSession()
+
+    async def daniel_yields_to_karen(
+        self,
+        session: ConsensusSession,
+        query: str,
+        *,
+        context: Any = None,
+    ) -> Dict[str, Any]:
+        """Daniel yields ``query`` to Karen and awaits her diagnostic.
+
+        Depth-Bounded Lock: the FIRST yield in this session runs; a
+        SECOND is intercepted (no provider call) → graceful fallback.
+        Returns ``{"outcome", "payload"}``. NEVER raises."""
+        try:
+            self.stats["yields"] += 1
+            if not session.try_claim():
+                # SECOND yield in the same interaction — the anti-loop
+                # guard fires BEFORE any API call.
+                self.stats["lock_intercepted"] += 1
+                logger.warning(
+                    "[PeerConsensus] depth-bound lock intercepted a "
+                    "second yield — no provider call; graceful fallback",
+                )
+                return {
+                    "outcome": OUTCOME_LOCK_INTERCEPTED,
+                    "payload": _FALLBACK_MESSAGE,
+                }
+            try:
+                payload = await asyncio.wait_for(
+                    self._diagnose(query, context),
+                    timeout=_consensus_timeout_s(),
+                )
+            except asyncio.TimeoutError:
+                self.stats["timeouts"] += 1
+                return {"outcome": OUTCOME_TIMEOUT, "payload": _FALLBACK_MESSAGE}
+            except Exception:  # noqa: BLE001
+                self.stats["errors"] += 1
+                return {"outcome": OUTCOME_ERROR, "payload": _FALLBACK_MESSAGE}
+            self.stats["resolved"] += 1
+            return {"outcome": OUTCOME_RESOLVED, "payload": str(payload or "")}
+        except Exception:  # noqa: BLE001
+            self.stats["errors"] += 1
+            return {"outcome": OUTCOME_ERROR, "payload": _FALLBACK_MESSAGE}
+
+
+__all__ = [
+    "OUTCOME_ERROR",
+    "OUTCOME_LOCK_INTERCEPTED",
+    "OUTCOME_RESOLVED",
+    "OUTCOME_TIMEOUT",
+    "ConsensusSession",
+    "PeerConsensus",
+]

--- a/backend/core/ouroboros/governance/comms/duplex/qos_sensor.py
+++ b/backend/core/ouroboros/governance/comms/duplex/qos_sensor.py
@@ -1,0 +1,183 @@
+"""QoS Sensor — Daniel evaluates his OWN interaction quality.
+
+The first of the two closing gaps (operator authorization 2026-07-19):
+JARVIS (Daniel) watches where he STRUGGLES to assist the user, and
+hands the breakdown to O+V (Karen) as a fix signal — the loop that
+makes "O+V improves JARVIS from real usage" literally true.
+
+Mandate 1 — no explicit "you failed" feedback. Frustration is
+inferred from IMPLICIT operational deviations:
+
+  * **Rapid prompt repetition** — the user re-sends a
+    semantically-equivalent command within
+    ``JARVIS_QOS_REPEAT_WINDOW_S`` (30s). Re-asking = the first answer
+    missed.
+  * **Operational override** — a ``SIGINT`` mid-response, or the user
+    seizing an active terminal/audio lease. Interrupting = the
+    trajectory was wrong.
+
+On trigger, the preceding context window is bundled into a
+``UX_DEGRADATION_EVENT`` and routed — DRY, mandate 3 — through the
+EXISTING ``make_envelope(source="performance_regression", …)`` intake
+path, so Karen diagnoses a conversational breakdown with the EXACT
+logic she uses for a codebase test failure.
+
+Bounded + deduped (a frustration storm is ONE signal); NEVER raises.
+"""
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+import re
+import time
+from collections import deque
+from typing import Any, Callable, Deque, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.QoSSensor")
+
+UX_DEGRADATION_EVENT = "UX_DEGRADATION_EVENT"
+
+
+def _repeat_window_s() -> float:
+    try:
+        return max(3.0, min(300.0, float(os.environ.get(
+            "JARVIS_QOS_REPEAT_WINDOW_S", "30",
+        ))))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _cooldown_s() -> float:
+    try:
+        return max(10.0, float(os.environ.get(
+            "JARVIS_QOS_COOLDOWN_S", "120",
+        )))
+    except (TypeError, ValueError):
+        return 120.0
+
+
+def _semantic_key(command: str) -> str:
+    """Semantic-equivalence key: lowercased, punctuation-stripped,
+    stop-word-light token set. "fix the bug" ≈ "fix the bug please" ≈
+    "can you fix the bug". NEVER raises."""
+    try:
+        toks = re.findall(r"[a-z0-9]+", str(command or "").lower())
+        stop = {"the", "a", "an", "please", "can", "you", "could", "would",
+                "to", "for", "me", "my", "i", "it", "this", "that", "do"}
+        core = sorted(t for t in toks if t not in stop and len(t) > 1)
+        return hashlib.sha256(" ".join(core).encode()).hexdigest()[:16]
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+class QoSSensor:
+    """Daniel's self-evaluation. ``emit_signal(envelope)`` is the
+    injected intake sink (production: the unified intake router).
+    ``context_provider`` returns the recent dialogue for the bundle."""
+
+    def __init__(
+        self,
+        *,
+        emit_signal: Optional[Callable[[Any], None]] = None,
+        context_provider: Optional[Callable[[], List[str]]] = None,
+        clock: Callable[[], float] = time.monotonic,
+    ) -> None:
+        self._emit = emit_signal or (lambda _e: None)
+        self._context = context_provider or (lambda: [])
+        self._clock = clock
+        self._recent: Deque[Tuple[str, float]] = deque(maxlen=32)
+        self._last_emit = 0.0
+        self.stats: Dict[str, int] = {
+            "commands": 0, "repeat_triggers": 0, "override_triggers": 0,
+            "emitted": 0, "cooldown_suppressed": 0,
+        }
+
+    # ---- the two implicit signals ----
+
+    def observe_command(self, command: str) -> bool:
+        """One user command in. Detects rapid semantic repetition.
+        Returns True iff a UX_DEGRADATION_EVENT was emitted. NEVER
+        raises."""
+        try:
+            self.stats["commands"] += 1
+            key = _semantic_key(command)
+            now = self._clock()
+            window = _repeat_window_s()
+            repeated = any(
+                k == key and (now - t) <= window
+                for k, t in self._recent
+            )
+            self._recent.append((key, now))
+            if repeated and key:
+                self.stats["repeat_triggers"] += 1
+                return self._degrade(
+                    "rapid_repeat",
+                    f"User re-sent a semantically-equivalent command "
+                    f"within {int(window)}s — the prior response missed: "
+                    f"{str(command)[:120]}",
+                )
+            return False
+        except Exception:  # noqa: BLE001
+            return False
+
+    def observe_override(self, kind: str = "sigint") -> bool:
+        """An operational override (SIGINT mid-response / lease seizure).
+        Returns True iff emitted. NEVER raises."""
+        try:
+            self.stats["override_triggers"] += 1
+            return self._degrade(
+                f"override_{kind}",
+                f"User issued an operational override ({kind}) mid-"
+                f"assistance — the trajectory was wrong.",
+            )
+        except Exception:  # noqa: BLE001
+            return False
+
+    def _degrade(self, cause: str, summary: str) -> bool:
+        """Bundle context → UX_DEGRADATION_EVENT → the EXISTING perf-
+        regression intake path (mandate 3). Cooldown-guarded so a
+        frustration storm is ONE signal. NEVER raises."""
+        now = self._clock()
+        if (now - self._last_emit) < _cooldown_s():
+            self.stats["cooldown_suppressed"] += 1
+            return False
+        self._last_emit = now
+        try:
+            context = list(self._context() or [])[-8:]
+            from backend.core.ouroboros.governance.intake.intent_envelope import (  # noqa: E501,PLC0415
+                make_envelope,
+            )
+            # DRY: Karen processes a conversational breakdown as a
+            # performance_regression — same diagnostic logic as a
+            # codebase test failure.
+            envelope = make_envelope(
+                source="performance_regression",
+                description=f"[{UX_DEGRADATION_EVENT}:{cause}] {summary}",
+                target_files=(
+                    "backend/core/ouroboros/governance/orchestrator.py",
+                ),
+                repo=os.environ.get("JARVIS_REPO", "."),
+                confidence=0.75,
+                urgency="normal",
+                evidence={
+                    "ux_degradation": True,
+                    "cause": cause,
+                    "dialogue_context": context,
+                    "detector": "qos_sensor",
+                },
+                # A conversational breakdown is an autonomous fix
+                # signal — no human ack gate on the SIGNAL (the fix it
+                # produces still passes the full Iron Gate downstream).
+                requires_human_ack=False,
+            )
+            self._emit(envelope)
+            self.stats["emitted"] += 1
+            logger.info("[QoS] %s → UX_DEGRADATION_EVENT emitted", cause)
+            return True
+        except Exception:  # noqa: BLE001
+            logger.debug("[QoS] emit degraded", exc_info=True)
+            return False
+
+
+__all__ = ["QoSSensor", "UX_DEGRADATION_EVENT"]

--- a/tests/governance/test_peer_diagnostics.py
+++ b/tests/governance/test_peer_diagnostics.py
@@ -1,0 +1,157 @@
+"""Dual-Module Peer Review + QoS Diagnostic spine.
+
+Mandate 4 verbatim (2026-07-19): Daniel receives a technical prompt,
+yields to Karen via the RPC handshake, but Karen's response triggers a
+SECOND yield from Daniel → the Depth-Bounded Consensus Lock intercepts
+the second yield, PREVENTS the API call, and forces a graceful
+user-facing fallback.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex.peer_consensus import (
+    OUTCOME_LOCK_INTERCEPTED,
+    OUTCOME_RESOLVED,
+    OUTCOME_TIMEOUT,
+    PeerConsensus,
+)
+from backend.core.ouroboros.governance.comms.duplex.qos_sensor import (
+    UX_DEGRADATION_EVENT,
+    QoSSensor,
+    _semantic_key,
+)
+
+
+# ---------------------------------------------------------------------------
+# QoS Sensor — implicit frustration
+# ---------------------------------------------------------------------------
+
+
+class TestImplicitFrustration:
+    def test_semantic_equivalence_key(self):
+        assert _semantic_key("fix the bug") == _semantic_key(
+            "can you fix the bug please",
+        )
+        assert _semantic_key("fix the bug") != _semantic_key("run the tests")
+
+    def test_rapid_repeat_emits_ux_degradation(self):
+        emitted = []
+        clock = [1000.0]
+        qos = QoSSensor(
+            emit_signal=emitted.append,
+            context_provider=lambda: ["user: fix the crash", "daniel: ..."],
+            clock=lambda: clock[0],
+        )
+        assert qos.observe_command("fix the crash") is False   # first ask
+        clock[0] += 5.0
+        # Re-asked within the window → the first answer missed:
+        assert qos.observe_command("can you fix the crash please") is True
+        assert len(emitted) == 1
+        env = emitted[0]
+        assert UX_DEGRADATION_EVENT in env.description
+        assert env.source == "performance_regression"          # DRY intake
+        assert env.evidence["ux_degradation"] is True
+        assert env.evidence["dialogue_context"]                # bundled
+
+    def test_sigint_override_emits(self):
+        emitted = []
+        qos = QoSSensor(emit_signal=emitted.append)
+        assert qos.observe_override("sigint") is True
+        assert "override" in emitted[0].evidence["cause"]
+
+    def test_no_explicit_feedback_needed_pin(self):
+        from pathlib import Path
+        src = (
+            Path(__file__).resolve().parents[2]
+            / "backend/core/ouroboros/governance/comms/duplex/qos_sensor.py"
+        ).read_text()
+        # Triggers are IMPLICIT — repetition + override, never a typed
+        # "you failed".
+        assert "rapid_repeat" in src and "override" in src
+
+    def test_cooldown_collapses_a_frustration_storm(self):
+        emitted = []
+        clock = [1000.0]
+        qos = QoSSensor(emit_signal=emitted.append, clock=lambda: clock[0])
+        qos.observe_override("sigint")
+        qos.observe_override("sigint")               # within cooldown
+        qos.observe_override("sigint")
+        assert len(emitted) == 1                     # ONE signal
+        assert qos.stats["cooldown_suppressed"] == 2
+
+    def test_distinct_commands_do_not_trigger(self):
+        emitted = []
+        qos = QoSSensor(emit_signal=emitted.append)
+        qos.observe_command("open the file")
+        qos.observe_command("run the tests")
+        qos.observe_command("commit the change")
+        assert emitted == []
+
+
+# ---------------------------------------------------------------------------
+# Depth-Bounded Consensus Lock — MANDATE 4 VERBATIM
+# ---------------------------------------------------------------------------
+
+
+class TestDepthBoundedConsensus:
+    async def test_second_yield_intercepted_no_api_call(self):
+        """MANDATE 4 VERBATIM."""
+        api_calls = {"n": 0}
+
+        async def _karen(query, context):
+            api_calls["n"] += 1
+            # Karen's answer implies Daniel needs to yield AGAIN:
+            return "This needs a deeper trace — yield again for the stack."
+
+        pc = PeerConsensus(karen_diagnose=_karen)
+        session = pc.new_session()
+
+        # Daniel's FIRST yield (a hard technical prompt) — runs:
+        r1 = await pc.daniel_yields_to_karen(
+            session, "why does the orchestrator deadlock under load?",
+        )
+        assert r1["outcome"] == OUTCOME_RESOLVED
+        assert api_calls["n"] == 1
+
+        # Daniel tries to yield AGAIN in the SAME interaction — the
+        # lock MUST intercept before any provider call:
+        r2 = await pc.daniel_yields_to_karen(
+            session, "ok now trace the deadlock deeper",
+        )
+        assert r2["outcome"] == OUTCOME_LOCK_INTERCEPTED
+        assert api_calls["n"] == 1                    # API NOT called again
+        assert "couldn't fully resolve" in r2["payload"]  # graceful fallback
+        assert pc.stats["lock_intercepted"] == 1
+
+    async def test_new_interaction_gets_fresh_budget(self):
+        calls = {"n": 0}
+        async def _karen(q, c):
+            calls["n"] += 1
+            return "diagnosis"
+        pc = PeerConsensus(karen_diagnose=_karen)
+        # Interaction 1:
+        await pc.daniel_yields_to_karen(pc.new_session(), "q1")
+        # Interaction 2 — a NEW session, fresh single round-trip:
+        r = await pc.daniel_yields_to_karen(pc.new_session(), "q2")
+        assert r["outcome"] == OUTCOME_RESOLVED
+        assert calls["n"] == 2                        # both allowed
+
+    async def test_timeout_falls_back_gracefully(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_CONSENSUS_TIMEOUT_S", "2")
+        import asyncio
+        async def _slow(q, c):
+            await asyncio.sleep(60)
+            return "never"
+        pc = PeerConsensus(karen_diagnose=_slow)
+        r = await pc.daniel_yields_to_karen(pc.new_session(), "hard q")
+        assert r["outcome"] == OUTCOME_TIMEOUT
+        assert "couldn't fully resolve" in r["payload"]
+
+    async def test_karen_fault_falls_back_not_crash(self):
+        async def _boom(q, c):
+            raise RuntimeError("provider down")
+        pc = PeerConsensus(karen_diagnose=_boom)
+        r = await pc.daniel_yields_to_karen(pc.new_session(), "q")
+        assert r["outcome"] == "error_fallback"
+        assert r["payload"]                           # graceful message


### PR DESCRIPTION
## Summary
The two closing gaps of the JARVIS↔O+V topology:
- **QoS Sensor** — Daniel self-evaluates via *implicit* deviations (no "you failed" typing): rapid semantic prompt repetition or operational override (SIGINT / lease seizure) → bundles dialogue context into a `UX_DEGRADATION_EVENT`, routed through the *existing* `make_envelope(source="performance_regression", …)` intake so Karen diagnoses a conversational breakdown with the exact logic she uses for a codebase test failure (verified against the real envelope builder). Cooldown collapses a frustration storm to one signal.
- **Peer Consensus RPC** — Daniel yields a hard coding query to Karen and awaits her diagnostic (routes to Claude/DW via the answer engine). **Depth-Bounded Consensus Lock**: one user interaction = at most one round-trip; a second yield is intercepted *before any provider call* → graceful fallback. A new interaction gets a fresh budget. Timeout + Karen-fault fall back gracefully.

## Testing
10 tests incl. **mandate 4 verbatim**: Daniel yields → Karen resolves → Karen's answer implies a second yield → the lock intercepts it, the API is **not** called again, graceful fallback fires. Semantic-equivalence, trigger detection, cooldown storm-collapse, fresh-budget-per-interaction, timeout/fault fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a QoS frustration sensor and a depth‑bounded peer consensus RPC so Daniel can detect UX issues and safely hand off hard queries to Karen without looping. This improves reliability, reduces token burn, and routes breakdowns into the existing diagnostics pipeline.

- **New Features**
  - QoS Sensor: infers frustration from rapid semantic repeats or operational overrides, bundles recent context, and emits a `UX_DEGRADATION_EVENT` via the existing `make_envelope(source="performance_regression", …)` path; cooldown dedupes bursts.
  - Peer Consensus RPC: Daniel yields to Karen through an injectable `karen_diagnose`; a depth‑bounded lock allows at most one round‑trip per interaction and intercepts any second yield before provider calls; timeouts and provider faults return a graceful fallback; new interactions get a fresh budget.

<sup>Written for commit f0112af7f84c68ed1c286a5f8a58a70595e6ef3a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69965?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

