### PR TITLE
feat(multi-agent): Preference Ledger + attenuation engine + live PeerConsensus mount

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4418,6 +4418,15 @@ class BattleTestHarness:
             _q = getattr(self, "_qos_sensor", None)
             if _q is not None:
                 _q.observe_override(kind)
+            # Attenuation: an override CONFIRMS the pending frustration
+            # as a definitive negative in the preference ledger.
+            try:
+                from backend.core.ouroboros.governance.comms.duplex.preference_ledger import (  # noqa: E501
+                    get_default_ledger,
+                )
+                get_default_ledger().confirm_override()
+            except Exception:  # noqa: BLE001
+                pass
         except Exception:  # noqa: BLE001
             pass
 

--- a/backend/core/ouroboros/governance/chat_text_bridge.py
+++ b/backend/core/ouroboros/governance/chat_text_bridge.py
@@ -330,6 +330,22 @@ class ChatTextMultiplexer:
     # ---- turn execution ----
 
     async def _run(self, text: str) -> Optional[Any]:
+        # PeerConsensus mount (2026-07-19): Daniel yields a structural/
+        # engineering query to Karen (depth-bounded, one round-trip).
+        # Gated + fail-soft; a shallow query never yields. The dispatch
+        # below still runs — consensus ENRICHES, never replaces.
+        try:
+            from backend.core.ouroboros.governance.comms.duplex.peer_consensus import (  # noqa: E501
+                build_live_peer_consensus, should_yield_to_karen,
+            )
+            _pc = build_live_peer_consensus()
+            if _pc is not None and should_yield_to_karen(text):
+                _sess = _pc.new_session()
+                _r = await _pc.daniel_yields_to_karen(_sess, text)
+                logger.info("[PeerConsensus] Daniel→Karen yield: %s",
+                            _r.get("outcome"))
+        except Exception:  # noqa: BLE001
+            pass
         verdict = weighted_classify(text)
         work = asyncio.ensure_future(asyncio.to_thread(
             self._dispatcher.handle,

--- a/backend/core/ouroboros/governance/comms/duplex/preference_ledger.py
+++ b/backend/core/ouroboros/governance/comms/duplex/preference_ledger.py
@@ -1,0 +1,333 @@
+"""Performance & Preference Ledger — API-era optimization substrate.
+
+The final integration piece (operator authorization 2026-07-19). It is
+"RLHF-by-self-modification" made durable: implicit outcomes accumulate,
+noise is attenuated, and highly-rated strategies bias future
+generation — WITHOUT touching model weights.
+
+Mandate 1 — no DB engine, no synchronous disk loop: an in-memory,
+thread-safe structured store that serializes ASYNCHRONOUSLY (debounced
+off-loop task) to a bounded local ``.json``.
+
+**Multi-Variable Attenuation (mandate 2 — the Environmental Noise
+Guard):** a QoS frustration trigger alone is NOT a failure — typos,
+network blips, and stray interrupts fire it too. A path is a
+DEFINITIVE negative ONLY when frustration fires AND the user overrides
+immediately. Conversely a downstream ``exit_code==0`` OR a post-
+response idle beyond ``JARVIS_LEDGER_IDLE_SUCCESS_S`` (45s)
+ATTENUATES the frustration and records an implicit SUCCESS — the human
+moved on satisfied. Net score per path is the attenuated aggregate.
+
+DRY (mandate 3): consumes the EXISTING ``UX_DEGRADATION_EVENT``
+envelope evidence (``cause`` / ``dialogue_context``) — no second
+telemetry wrapper.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional
+
+logger = logging.getLogger("Ouroboros.PreferenceLedger")
+
+
+def _idle_success_s() -> float:
+    try:
+        return max(10.0, min(600.0, float(os.environ.get(
+            "JARVIS_LEDGER_IDLE_SUCCESS_S", "45",
+        ))))
+    except (TypeError, ValueError):
+        return 45.0
+
+
+def _ledger_path() -> Path:
+    return Path(os.environ.get(
+        "JARVIS_PREFERENCE_LEDGER", ".jarvis/preference_ledger.json",
+    ))
+
+
+def _max_paths() -> int:
+    try:
+        return max(16, int(os.environ.get("JARVIS_LEDGER_MAX_PATHS", "500")))
+    except (TypeError, ValueError):
+        return 500
+
+
+class _PathRecord:
+    __slots__ = ("key", "strategy", "successes", "frustrations",
+                 "definitive_negatives", "attenuated", "score", "updated_at")
+
+    def __init__(self, key: str, strategy: str) -> None:
+        self.key = key
+        self.strategy = strategy
+        self.successes = 0
+        self.frustrations = 0
+        self.definitive_negatives = 0
+        self.attenuated = 0
+        self.score = 0.0
+        self.updated_at = 0.0
+
+    def recompute(self) -> None:
+        # Net attenuated score: successes lift, definitive negatives
+        # sink; a lone frustration that was later attenuated does NOT.
+        total = self.successes + self.definitive_negatives
+        if total <= 0:
+            self.score = 0.0
+            return
+        self.score = round(
+            (self.successes - self.definitive_negatives) / max(1, total), 4,
+        )
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "key": self.key, "strategy": self.strategy,
+            "successes": self.successes, "frustrations": self.frustrations,
+            "definitive_negatives": self.definitive_negatives,
+            "attenuated": self.attenuated, "score": self.score,
+            "updated_at": self.updated_at,
+        }
+
+
+class PreferenceLedger:
+    """The in-memory attenuation store. ``clock`` injected for tests;
+    NEVER raises on any public path."""
+
+    def __init__(self, *, clock: Callable[[], float] = time.monotonic,
+                 path: Optional[Path] = None) -> None:
+        self._clock = clock
+        self._path = path or _ledger_path()
+        self._lock = threading.RLock()
+        self._paths: Dict[str, _PathRecord] = {}
+        #: a frustration awaiting resolution (attenuate or confirm).
+        self._pending: Dict[str, float] = {}      # key → frustration ts
+        self._dirty = False
+        self._flush_task: Optional[asyncio.Task] = None
+        self.stats: Dict[str, int] = {
+            "frustrations_seen": 0, "definitive_negatives": 0,
+            "attenuated": 0, "successes": 0,
+        }
+
+    def _rec(self, key: str, strategy: str) -> _PathRecord:
+        r = self._paths.get(key)
+        if r is None:
+            if len(self._paths) >= _max_paths():
+                # evict the least-recently-updated
+                oldest = min(self._paths.values(), key=lambda x: x.updated_at)
+                self._paths.pop(oldest.key, None)
+            r = _PathRecord(key, strategy)
+            self._paths[key] = r
+        return r
+
+    # ---- the attenuation state machine ----
+
+    def record_frustration(self, envelope: Any) -> None:
+        """A UX_DEGRADATION_EVENT fired. DRY: read the existing
+        envelope evidence. This is PENDING — not yet a negative; it
+        awaits an override (confirm) or a success/idle (attenuate).
+        NEVER raises."""
+        try:
+            ev = getattr(envelope, "evidence", None) or {}
+            ctx = ev.get("dialogue_context") or []
+            key = _strategy_key(ctx)
+            with self._lock:
+                self.stats["frustrations_seen"] += 1
+                self._rec(key, _strategy_label(ctx)).frustrations += 1
+                self._pending[key] = self._clock()
+                self._mark_dirty()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def confirm_override(self, envelope: Any = None) -> None:
+        """The user OVERRODE immediately after frustration (SIGINT /
+        lease seizure) → the most-recent pending frustration is a
+        DEFINITIVE negative. NEVER raises."""
+        try:
+            with self._lock:
+                if not self._pending:
+                    return
+                # newest pending frustration is the one being overridden
+                key = max(self._pending, key=lambda k: self._pending[k])
+                self._pending.pop(key, None)
+                r = self._paths.get(key)
+                if r is not None:
+                    r.definitive_negatives += 1
+                    r.updated_at = self._clock()
+                    r.recompute()
+                    self.stats["definitive_negatives"] += 1
+                    self._mark_dirty()
+        except Exception:  # noqa: BLE001
+            pass
+
+    def record_exit_code(self, exit_code: int, context: Any = None) -> None:
+        """A downstream terminal command returned. exit 0 ATTENUATES
+        any pending frustration and books an implicit SUCCESS (the work
+        actually worked). NEVER raises."""
+        try:
+            if int(exit_code) != 0:
+                return
+            with self._lock:
+                self._attenuate_and_succeed(context)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def note_idle(self, idle_seconds: float, context: Any = None) -> None:
+        """Post-response idle beyond the threshold = the human moved on
+        satisfied → attenuate + implicit success. NEVER raises."""
+        try:
+            if float(idle_seconds) < _idle_success_s():
+                return
+            with self._lock:
+                self._attenuate_and_succeed(context)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _attenuate_and_succeed(self, context: Any) -> None:
+        ctx = context if isinstance(context, list) else []
+        key = _strategy_key(ctx) if ctx else (
+            max(self._pending, key=lambda k: self._pending[k])
+            if self._pending else None
+        )
+        if key is None:
+            return
+        r = self._rec(key, _strategy_label(ctx))
+        # If a frustration was pending on this path, attenuate it.
+        if key in self._pending:
+            self._pending.pop(key, None)
+            r.attenuated += 1
+            self.stats["attenuated"] += 1
+        r.successes += 1
+        r.updated_at = self._clock()
+        r.recompute()
+        self.stats["successes"] += 1
+        self._mark_dirty()
+
+    # ---- scaffolding bias (the read side) ----
+
+    def top_strategies(self, n: int = 3, *, min_score: float = 0.3) -> List[str]:
+        """Highly-rated verified strategies for prompt injection.
+        NEVER raises."""
+        try:
+            with self._lock:
+                ranked = sorted(
+                    (r for r in self._paths.values()
+                     if r.score >= min_score and r.successes > 0),
+                    key=lambda r: (r.score, r.successes), reverse=True,
+                )
+                return [r.strategy for r in ranked[:max(1, n)]]
+        except Exception:  # noqa: BLE001
+            return []
+
+    def format_for_prompt(self) -> str:
+        """The Dynamic Scaffolding Bias block for CONTEXT_EXPANSION.
+        Empty when nothing is proven yet. NEVER raises."""
+        try:
+            strategies = self.top_strategies()
+            if not strategies:
+                return ""
+            lines = "\n".join(f"  - {s}" for s in strategies)
+            return (
+                "## Verified Operational Patterns (preference ledger)\n"
+                "These strategies have empirically satisfied the operator "
+                "— bias toward them:\n" + lines
+            )
+        except Exception:  # noqa: BLE001
+            return ""
+
+    # ---- async serialization (mandate 1) ----
+
+    def _mark_dirty(self) -> None:
+        self._dirty = True
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        if self._flush_task is None or self._flush_task.done():
+            self._flush_task = loop.create_task(self._debounced_flush())
+
+    async def _debounced_flush(self) -> None:
+        try:
+            await asyncio.sleep(2.0)             # debounce burst writes
+            await asyncio.to_thread(self._write_sync)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[Ledger] flush degraded", exc_info=True)
+
+    def _write_sync(self) -> None:
+        try:
+            with self._lock:
+                if not self._dirty:
+                    return
+                payload = {
+                    "schema_version": "preference_ledger.1",
+                    "paths": [r.to_dict() for r in self._paths.values()],
+                    "stats": dict(self.stats),
+                }
+                self._dirty = False
+            self._path.parent.mkdir(parents=True, exist_ok=True)
+            tmp = self._path.with_suffix(".tmp")
+            tmp.write_text(json.dumps(payload, separators=(",", ":")))
+            os.replace(tmp, self._path)         # atomic
+        except Exception:  # noqa: BLE001
+            logger.debug("[Ledger] write degraded", exc_info=True)
+
+    def snapshot(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "paths": len(self._paths),
+                "pending": len(self._pending),
+                "stats": dict(self.stats),
+            }
+
+
+def _strategy_key(context: List[str]) -> str:
+    import hashlib
+    try:
+        # The strategy IS the dialogue trajectory that produced the
+        # outcome — keyed on its shape, not verbatim text.
+        joined = " | ".join(str(c) for c in (context or [])[-4:])
+        return hashlib.sha256(joined.encode()).hexdigest()[:16] or "unknown"
+    except Exception:  # noqa: BLE001
+        return "unknown"
+
+
+def _strategy_label(context: List[str]) -> str:
+    try:
+        for c in reversed(context or []):
+            s = str(c)
+            if s.lower().startswith(("daniel", "karen", "assistant")):
+                return s[:120]
+        return str(context[-1])[:120] if context else "interaction"
+    except Exception:  # noqa: BLE001
+        return "interaction"
+
+
+# Process-wide singleton (orchestrator-root).
+_DEFAULT: Optional[PreferenceLedger] = None
+_DEFAULT_LOCK = threading.Lock()
+
+
+def get_default_ledger() -> PreferenceLedger:
+    global _DEFAULT
+    with _DEFAULT_LOCK:
+        if _DEFAULT is None:
+            _DEFAULT = PreferenceLedger()
+        return _DEFAULT
+
+
+def reset_default_ledger() -> None:
+    global _DEFAULT
+    with _DEFAULT_LOCK:
+        _DEFAULT = None
+
+
+__all__ = [
+    "PreferenceLedger",
+    "get_default_ledger",
+    "reset_default_ledger",
+]

--- a/backend/core/ouroboros/governance/comms/duplex/qos_sensor.py
+++ b/backend/core/ouroboros/governance/comms/duplex/qos_sensor.py
@@ -172,6 +172,13 @@ class QoSSensor:
                 requires_human_ack=False,
             )
             self._emit(envelope)
+            # DRY: the SAME envelope feeds the preference ledger's
+            # attenuation engine — no second telemetry wrapper.
+            try:
+                from .preference_ledger import get_default_ledger  # noqa: PLC0415
+                get_default_ledger().record_frustration(envelope)
+            except Exception:  # noqa: BLE001
+                pass
             self.stats["emitted"] += 1
             logger.info("[QoS] %s → UX_DEGRADATION_EVENT emitted", cause)
             return True

--- a/backend/core/ouroboros/governance/strategic_direction.py
+++ b/backend/core/ouroboros/governance/strategic_direction.py
@@ -305,6 +305,19 @@ class StrategicDirectionService:
         )
         if causal_lineage_block:
             body = f"{body}\n\n{causal_lineage_block}"
+        # Dynamic Scaffolding Bias (2026-07-19): inject verified
+        # operational patterns from the preference ledger so future
+        # generations lean toward strategies that empirically satisfied
+        # the operator. Fail-soft; empty until the ledger has proof.
+        try:
+            from backend.core.ouroboros.governance.comms.duplex.preference_ledger import (  # noqa: E501
+                get_default_ledger,
+            )
+            _bias = get_default_ledger().format_for_prompt()
+            if _bias:
+                body = f"{body}\n\n{_bias}"
+        except Exception:  # noqa: BLE001
+            pass
         return body
 
     def _render_avoidance_section(self) -> str:

--- a/tests/governance/test_preference_ledger.py
+++ b/tests/governance/test_preference_ledger.py
@@ -1,0 +1,153 @@
+"""Preference Ledger + Multi-Variable Attenuation spine.
+
+Mandate 4 verbatim (2026-07-19): the QoS sensor registers a
+frustration trigger, but a subsequent terminal execution returns exit
+code 0 → the attenuation engine catches the downstream success,
+adjusts the in-memory score, and prevents the path from being falsely
+categorized as a failure.
+"""
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex import (
+    preference_ledger as pl,
+)
+from backend.core.ouroboros.governance.comms.duplex.preference_ledger import (
+    PreferenceLedger,
+)
+
+
+class _Envelope:
+    def __init__(self, context):
+        self.evidence = {"ux_degradation": True, "cause": "rapid_repeat",
+                         "dialogue_context": context}
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    pl.reset_default_ledger()
+    yield
+    pl.reset_default_ledger()
+
+
+class TestMandate4Attenuation:
+    def test_frustration_then_exit0_not_a_false_failure(self):
+        """MANDATE 4 VERBATIM."""
+        clock = [1000.0]
+        ledger = PreferenceLedger(clock=lambda: clock[0])
+        ctx = ["user: refactor the auth module", "daniel: here's the diff"]
+        # QoS fires a frustration (pending, NOT yet a negative):
+        ledger.record_frustration(_Envelope(ctx))
+        assert ledger.snapshot()["pending"] == 1
+        assert ledger.stats["definitive_negatives"] == 0
+        # Downstream terminal command returns exit 0 — it actually
+        # WORKED. Attenuate the frustration + book implicit success:
+        clock[0] += 3.0
+        ledger.record_exit_code(0, context=ctx)
+        snap = ledger.snapshot()
+        assert snap["pending"] == 0                  # frustration cleared
+        assert ledger.stats["attenuated"] == 1       # noise caught
+        assert ledger.stats["successes"] == 1
+        assert ledger.stats["definitive_negatives"] == 0  # NOT a failure
+        # The path's net score is POSITIVE (a success), not negative:
+        top = ledger.top_strategies(min_score=0.0)
+        assert top                                   # the path is rated up
+
+    def test_frustration_then_override_is_definitive_negative(self):
+        ledger = PreferenceLedger()
+        ctx = ["user: fix the deadlock", "daniel: try this"]
+        ledger.record_frustration(_Envelope(ctx))
+        # The user OVERRODE immediately (SIGINT) → confirmed failure:
+        ledger.confirm_override()
+        assert ledger.stats["definitive_negatives"] == 1
+        assert ledger.stats["attenuated"] == 0
+
+    def test_idle_beyond_threshold_attenuates(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LEDGER_IDLE_SUCCESS_S", "45")
+        ledger = PreferenceLedger()
+        ctx = ["user: explain the module", "daniel: it does X"]
+        ledger.record_frustration(_Envelope(ctx))
+        ledger.note_idle(60.0, context=ctx)          # moved on satisfied
+        assert ledger.stats["attenuated"] == 1
+        assert ledger.stats["successes"] == 1
+        assert ledger.snapshot()["pending"] == 0
+
+    def test_brief_idle_does_not_attenuate(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LEDGER_IDLE_SUCCESS_S", "45")
+        ledger = PreferenceLedger()
+        ctx = ["user: x", "daniel: y"]
+        ledger.record_frustration(_Envelope(ctx))
+        ledger.note_idle(10.0, context=ctx)          # still working
+        assert ledger.stats["attenuated"] == 0
+        assert ledger.snapshot()["pending"] == 1     # frustration stands
+
+    def test_nonzero_exit_does_not_attenuate(self):
+        ledger = PreferenceLedger()
+        ctx = ["user: build it", "daniel: done"]
+        ledger.record_frustration(_Envelope(ctx))
+        ledger.record_exit_code(1, context=ctx)       # the command FAILED
+        assert ledger.stats["attenuated"] == 0
+        assert ledger.snapshot()["pending"] == 1
+
+
+class TestScaffoldingBias:
+    def test_top_strategies_ranks_verified_patterns(self):
+        ledger = PreferenceLedger()
+        good = ["user: add caching", "daniel: use functools.lru_cache"]
+        for _ in range(3):
+            ledger.record_frustration(_Envelope(good))
+            ledger.record_exit_code(0, context=good)  # repeatedly worked
+        top = ledger.top_strategies()
+        assert top and "lru_cache" in top[0]
+
+    def test_format_for_prompt_empty_until_proven(self):
+        ledger = PreferenceLedger()
+        assert ledger.format_for_prompt() == ""       # no proof yet
+
+    def test_format_for_prompt_injects_verified(self):
+        ledger = PreferenceLedger()
+        ctx = ["user: parse the config", "daniel: use tomllib"]
+        for _ in range(2):
+            ledger.record_frustration(_Envelope(ctx))
+            ledger.record_exit_code(0, context=ctx)
+        block = ledger.format_for_prompt()
+        assert "Verified Operational Patterns" in block
+        assert "tomllib" in block
+
+
+class TestNoiseGuard:
+    def test_lone_frustration_never_scores_negative(self):
+        """A single frustration with NO override and NO downstream
+        signal is noise — it must NOT sink the path's score."""
+        ledger = PreferenceLedger()
+        ctx = ["user: typo command", "daniel: response"]
+        ledger.record_frustration(_Envelope(ctx))
+        # No override, no exit code — just a pending frustration.
+        # The path's SCORE (successes vs definitive negatives) is 0,
+        # not negative — a typo doesn't poison the ledger.
+        rec = ledger._paths[list(ledger._paths)[0]]
+        assert rec.score == 0.0
+        assert rec.definitive_negatives == 0
+
+
+class TestIntegrationWiring:
+    def test_qos_feeds_ledger_pin(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] /
+               "backend/core/ouroboros/governance/comms/duplex/qos_sensor.py").read_text()
+        assert "get_default_ledger" in src and "record_frustration" in src
+
+    def test_strategic_direction_reads_ledger_pin(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] /
+               "backend/core/ouroboros/governance/strategic_direction.py").read_text()
+        assert "get_default_ledger" in src and "format_for_prompt" in src
+
+    def test_peer_consensus_mounted_in_chat_pin(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] /
+               "backend/core/ouroboros/governance/chat_text_bridge.py").read_text()
+        body = src[src.index("async def _run"):][:900]
+        assert "should_yield_to_karen" in body
+        assert "daniel_yields_to_karen" in body


### PR DESCRIPTION
## Summary
The final integration arc — the API-era optimization substrate goes live:
- **Preference Ledger** — in-memory, thread-safe, async-serialized to a bounded atomic `.json` (no DB, no sync disk loop). RLHF-by-self-modification, made durable.
- **Multi-Variable Attenuation (Noise Guard)** — a QoS frustration is *pending*, never an instant negative. Definitive negative only on immediate override; `exit_code==0` or idle >45s attenuates it and books an implicit success. A lone frustration (typo/blip) scores 0, never negative.
- **Dynamic Scaffolding Bias** — `strategic_direction.format_for_prompt` injects the ledger's top verified strategies into CONTEXT_EXPANSION.
- **Live PeerConsensus mount** — `chat_text_bridge._run` yields a technical query Daniel→Karen (depth-bounded, gated, fail-soft; enriches, never replaces).
- **DRY** — the QoS sensor feeds the ledger the same `UX_DEGRADATION_EVENT` it emits to intake; override→confirm wired.

## Testing
12 tests incl. **mandate 4 verbatim**: frustration fires → downstream exit 0 → attenuation catches the success, score stays positive, path is NOT falsely a failure. Override→definitive-negative, idle-attenuate, brief-idle-stands, nonzero-exit-stands, lone-frustration-zero, scaffolding-bias ranking + injection, wiring pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an in-memory Preference Ledger with multi-variable attenuation to turn noisy QoS events into durable signals and bias prompts toward proven strategies. Also mounts live PeerConsensus in the chat bridge to enrich dispatch without replacing it.

- **New Features**
  - Preference Ledger: thread-safe in-memory store with debounced async writes to a bounded `.json` (no DB).
  - Attenuation: frustration is pending; override confirms a definitive negative; `exit_code==0` or idle >45s attenuates and books a success; lone frustrations never score negative.
  - Dynamic Scaffolding Bias: `strategic_direction.format_for_prompt` injects top verified strategies from the ledger.
  - Live PeerConsensus: one round-trip Daniel→Karen yield in the chat bridge; gated, depth-bounded, fail-soft; enriches only.
  - DRY wiring: QoS sensor forwards the same `UX_DEGRADATION_EVENT` envelope to the ledger; harness override confirms pending frustration.

- **Migration**
  - No action required; writes to `.jarvis/preference_ledger.json` by default.
  - Optional env vars: `JARVIS_LEDGER_IDLE_SUCCESS_S` (idle-to-success, default 45s), `JARVIS_LEDGER_MAX_PATHS` (default 500), `JARVIS_PREFERENCE_LEDGER` (output path).
  - No schema or data migrations.

<sup>Written for commit c3437f77348a13cd7ea957b86d593f344dfee228. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69967?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

