### PR TITLE
feat(soak): atomic write-replace hardening + loop-lag watchdog

### DIFF
--- a/backend/core/ouroboros/governance/comms/duplex/preference_ledger.py
+++ b/backend/core/ouroboros/governance/comms/duplex/preference_ledger.py
@@ -271,10 +271,26 @@ class PreferenceLedger:
                 self._dirty = False
             self._path.parent.mkdir(parents=True, exist_ok=True)
             tmp = self._path.with_suffix(".tmp")
-            tmp.write_text(json.dumps(payload, separators=(",", ":")))
-            os.replace(tmp, self._path)         # atomic
+            # Atomic write-replace (mandate 1): write the WHOLE payload
+            # to a sibling, flush+fsync so the bytes are on disk, THEN
+            # os.replace — a sudden power/AppNap/terminal kill leaves
+            # either the old file or the new, NEVER a torn state. If the
+            # tmp write itself dies, the live ledger is untouched.
+            data = json.dumps(payload, separators=(",", ":"))
+            with open(tmp, "w", encoding="utf-8") as fh:
+                fh.write(data)
+                fh.flush()
+                os.fsync(fh.fileno())           # bytes durably on disk
+            os.replace(tmp, self._path)         # atomic swap
         except Exception:  # noqa: BLE001
             logger.debug("[Ledger] write degraded", exc_info=True)
+            # Never leave a stray half-written .tmp behind.
+            try:
+                tmp = self._path.with_suffix(".tmp")
+                if tmp.exists():
+                    tmp.unlink()
+            except Exception:  # noqa: BLE001
+                pass
 
     def snapshot(self) -> Dict[str, Any]:
         with self._lock:

--- a/backend/core/ouroboros/governance/comms/duplex/sovereign_governor.py
+++ b/backend/core/ouroboros/governance/comms/duplex/sovereign_governor.py
@@ -292,13 +292,90 @@ class ThresholdAutoTuner:
             return self.threshold
 
 
+_LAG_DEGRADED = {"active": False}
+
+
+def loop_lag_degraded() -> bool:
+    """Consumed by the telemetry ring to throttle verbosity while the
+    event loop is congested. NEVER raises."""
+    return _LAG_DEGRADED["active"]
+
+
+def _lag_threshold_ms() -> float:
+    try:
+        return max(10.0, min(1000.0, float(os.environ.get(
+            "JARVIS_LOOP_LAG_THRESHOLD_MS", "50",
+        ))))
+    except (TypeError, ValueError):
+        return 50.0
+
+
+class LoopLagWatchdog:
+    """Measures event-loop scheduling jitter and routes a spike as a
+    DEGRADATION identical to a thermal spike (mandate 3 — DRY: the
+    SAME degradation-state discipline the ThermalGovernor uses). On a
+    lag > threshold the telemetry ring throttles its verbosity to
+    protect primary terminal interaction; a settled loop restores.
+
+    ``lag_source`` is injected (production: an awaited call_soon round-
+    trip); ``publish`` mirrors the thermal publisher onto the attach
+    pub/sub. Reads ONLY monotonic time — watchdog-isolation invariant.
+    """
+
+    def __init__(
+        self,
+        *,
+        lag_source: Optional[Callable[[], float]] = None,
+        publish: Optional[Callable[[str], None]] = None,
+    ) -> None:
+        self._lag = lag_source
+        self._publish = publish or (lambda _s: None)
+        self.state = "nominal"
+        self.stats: Dict[str, int] = {"degradations": 0, "restorations": 0}
+
+    def observe_lag_ms(self, lag_ms: float) -> None:
+        """One jitter sample in. Applies/lifts loop-lag degradation
+        through the SAME state discipline as thermal. NEVER raises."""
+        try:
+            hot = float(lag_ms) > _lag_threshold_ms()
+            if hot and not _LAG_DEGRADED["active"]:
+                _LAG_DEGRADED["active"] = True
+                self.state = "lag_degraded"
+                self.stats["degradations"] += 1
+                logger.warning(
+                    "[SovereignGovernor] LOOP LAG %.1fms > %.0fms — "
+                    "telemetry verbosity throttled",
+                    lag_ms, _lag_threshold_ms(),
+                )
+                self._safe_publish("lag_degraded")
+            elif not hot and _LAG_DEGRADED["active"]:
+                _LAG_DEGRADED["active"] = False
+                self.state = "nominal"
+                self.stats["restorations"] += 1
+                logger.info(
+                    "[SovereignGovernor] loop lag settled (%.1fms) — "
+                    "telemetry restored", lag_ms,
+                )
+                self._safe_publish("nominal")
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _safe_publish(self, name: str) -> None:
+        try:
+            self._publish(name)
+        except Exception:  # noqa: BLE001
+            pass
+
+
 __all__ = [
     "THERMAL_CRITICAL",
     "THERMAL_FAIR",
     "THERMAL_NOMINAL",
     "THERMAL_SERIOUS",
+    "LoopLagWatchdog",
     "ThermalGovernor",
     "ThresholdAutoTuner",
+    "loop_lag_degraded",
     "evolution_permitted",
     "threshold_state_path",
     "tuned_threshold",

--- a/backend/core/ouroboros/governance/residency_telemetry.py
+++ b/backend/core/ouroboros/governance/residency_telemetry.py
@@ -140,14 +140,33 @@ class ResidencyTelemetry:
             r = rss_mb()
             if self._first_rss is None:
                 self._first_rss = r
+            lag = await loop_lag_ms()
+            # Loop-Lag Watchdog (DRY: routes through SovereignGovernor's
+            # degradation discipline). A spike throttles THIS ring's
+            # verbosity to protect terminal interaction.
+            try:
+                from backend.core.ouroboros.governance.comms.duplex.sovereign_governor import (  # noqa: E501
+                    LoopLagWatchdog, loop_lag_degraded,
+                )
+                if not hasattr(self, "_lag_watchdog"):
+                    self._lag_watchdog = LoopLagWatchdog()
+                self._lag_watchdog.observe_lag_ms(lag)
+                _throttled = loop_lag_degraded()
+            except Exception:  # noqa: BLE001
+                _throttled = False
             row = {
                 "ts": time.time(),
                 "rss_mb": r,
                 "rss_delta_mb": round(r - (self._first_rss or r), 2),
-                "uds_conns": self._safe_conns(),
-                "loop_lag_ms": await loop_lag_ms(),
+                "loop_lag_ms": lag,
                 "sample": self._samples,
             }
+            if not _throttled:
+                # Full verbosity when the loop is healthy; throttled
+                # rows shed the non-essential fields under congestion.
+                row["uds_conns"] = self._safe_conns()
+            else:
+                row["throttled"] = True
             self._samples += 1
             self.last = row
             h = self._get_handler()

--- a/tests/governance/test_atomic_write_watchdog.py
+++ b/tests/governance/test_atomic_write_watchdog.py
@@ -1,0 +1,138 @@
+"""Atomic Write-Replace + Loop-Lag Watchdog spine.
+
+Mandate 4 verbatim (2026-07-19): a filesystem write interrupted
+midway through a ledger flush → the original .json Preference Ledger
+remains completely intact + uncorrupted, and the state machine
+recovers on the next tick.
+"""
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance.comms.duplex import (
+    sovereign_governor as sg,
+)
+from backend.core.ouroboros.governance.comms.duplex.preference_ledger import (
+    PreferenceLedger,
+)
+from backend.core.ouroboros.governance.comms.duplex.sovereign_governor import (
+    LoopLagWatchdog,
+    loop_lag_degraded,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_lag():
+    sg._LAG_DEGRADED["active"] = False
+    yield
+    sg._LAG_DEGRADED["active"] = False
+
+
+class TestAtomicWriteReplace:
+    def test_interrupted_write_leaves_original_intact(
+        self, tmp_path, monkeypatch,
+    ):
+        """MANDATE 4 VERBATIM."""
+        path = tmp_path / "preference_ledger.json"
+        # Seed a KNOWN-GOOD ledger on disk.
+        good = {"schema_version": "preference_ledger.1",
+                "paths": [{"key": "abc", "strategy": "verified", "score": 0.9}],
+                "stats": {}}
+        path.write_text(json.dumps(good))
+        original_bytes = path.read_bytes()
+
+        ledger = PreferenceLedger(path=path)
+        ledger._dirty = True
+        ledger._paths.clear()
+
+        # Interrupt the write MIDWAY: os.fsync raises (power loss during
+        # flush). The tmp is being written; os.replace is NEVER reached.
+        real_fsync = __import__("os").fsync
+        def _boom_fsync(fd):
+            raise OSError("simulated power loss mid-flush")
+        monkeypatch.setattr("os.fsync", _boom_fsync)
+
+        ledger._write_sync()                          # the interrupted flush
+
+        # The ORIGINAL file is byte-for-byte intact — never touched:
+        assert path.read_bytes() == original_bytes
+        loaded = json.loads(path.read_text())         # still valid JSON
+        assert loaded["paths"][0]["strategy"] == "verified"
+        # No stray .tmp left behind:
+        assert not (tmp_path / "preference_ledger.tmp").exists()
+
+        # Recovery on the next tick: fsync restored, a clean write lands.
+        monkeypatch.setattr("os.fsync", real_fsync)
+        ledger._dirty = True
+        ledger._write_sync()
+        assert path.exists() and json.loads(path.read_text())  # recovered
+
+    def test_successful_write_is_atomic_swap(self, tmp_path):
+        path = tmp_path / "led.json"
+        ledger = PreferenceLedger(path=path)
+        ledger._dirty = True
+        ledger._write_sync()
+        assert path.exists()
+        assert json.loads(path.read_text())["schema_version"] == \
+            "preference_ledger.1"
+        assert not path.with_suffix(".tmp").exists()  # tmp swapped away
+
+    def test_uses_replace_not_append_pin(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] /
+               "backend/core/ouroboros/governance/comms/duplex/"
+               "preference_ledger.py").read_text()
+        assert "os.replace(" in src                   # atomic swap
+        assert "os.fsync(" in src                     # durable flush
+        # Never opens the LIVE ledger in append mode:
+        assert 'open(self._path, "a"' not in src
+
+
+class TestLoopLagWatchdog:
+    def test_spike_degrades_via_governor_discipline(self):
+        published = []
+        wd = LoopLagWatchdog(publish=published.append)
+        assert loop_lag_degraded() is False
+        wd.observe_lag_ms(120.0)                       # > 50ms threshold
+        assert loop_lag_degraded() is True             # DEGRADED
+        assert wd.state == "lag_degraded"
+        assert published == ["lag_degraded"]
+        assert wd.stats["degradations"] == 1
+        # Loop settles → restored:
+        wd.observe_lag_ms(2.0)
+        assert loop_lag_degraded() is False
+        assert wd.stats["restorations"] == 1
+
+    def test_healthy_lag_never_degrades(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOOP_LAG_THRESHOLD_MS", "50")
+        wd = LoopLagWatchdog()
+        for lag in (1.0, 5.0, 12.0, 3.0):
+            wd.observe_lag_ms(lag)
+        assert loop_lag_degraded() is False
+        assert wd.stats["degradations"] == 0
+
+    def test_threshold_env_tunable(self, monkeypatch):
+        monkeypatch.setenv("JARVIS_LOOP_LAG_THRESHOLD_MS", "200")
+        wd = LoopLagWatchdog()
+        wd.observe_lag_ms(120.0)                        # under new threshold
+        assert loop_lag_degraded() is False
+
+    def test_telemetry_ring_consults_watchdog_pin(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] /
+               "backend/core/ouroboros/governance/residency_telemetry.py").read_text()
+        assert "LoopLagWatchdog" in src
+        assert "loop_lag_degraded" in src
+        assert "throttled" in src                       # verbosity throttle
+
+    def test_dry_shares_thermal_degradation_pattern_pin(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] /
+               "backend/core/ouroboros/governance/comms/duplex/"
+               "sovereign_governor.py").read_text()
+        # Loop-lag lives in the SAME module as thermal (one degradation
+        # hub, mandate 3) and mirrors the publish/state discipline.
+        assert "class LoopLagWatchdog" in src
+        assert "class ThermalGovernor" in src


### PR DESCRIPTION
## Summary
Final pre-soak safety nets:
- **Atomic Write-Replace** — the Preference Ledger writes the whole payload to a `.tmp`, `flush()`+`os.fsync()`, then `os.replace()`. A power/AppNap/terminal kill leaves either the old or new file, never torn. A mid-flush failure leaves the live ledger untouched and cleans the stray `.tmp`.
- **Loop-Lag Watchdog** — lives in the *same* `sovereign_governor` module as `ThermalGovernor` and treats loop scheduling jitter >50ms as a degradation identical to a thermal spike (same publish/state discipline). On a spike the residency telemetry ring throttles verbosity to protect terminal interaction; a settled loop restores. Reads only monotonic time.

## Testing
8 tests incl. **mandate 4 verbatim**: `os.fsync` raises mid-flush → original `.json` intact byte-for-byte, valid JSON, no stray `.tmp`, recovers next tick. Atomic-swap success, replace-not-append pin, lag spike→degrade→restore, healthy-lag-never-degrades, env-tunable threshold, telemetry-throttle + DRY-hub pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens Preference Ledger writes with atomic write-replace and adds a loop-lag watchdog that degrades telemetry when the event loop stalls. Prevents torn JSON on crashes and keeps the terminal responsive under load.

- **New Features**
  - Atomic write-replace for the Preference Ledger: write to `.tmp`, flush + `os.fsync`, then `os.replace`; crash leaves old or new, never partial; cleans stray `.tmp` on failures.
  - Loop-Lag Watchdog in `sovereign_governor`: treats lag over `JARVIS_LOOP_LAG_THRESHOLD_MS` (default 50ms) as a degradation; mirrors ThermalGovernor publish/state.
  - Residency telemetry throttles when degraded: sheds non-essential fields and adds `throttled: true`; auto-restores when lag settles.

<sup>Written for commit 4cf7f64bfde8df5897f30c9e535aefd6ad0f6fef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69968?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

