### PR TITLE
feat(product): device-aware SSE multiplexer + dead-stream pruning — JARVIS-Apple connects

### DIFF
--- a/backend/api/device_stream_manager.py
+++ b/backend/api/device_stream_manager.py
@@ -1,0 +1,214 @@
+"""Device-Aware SSE Multiplexer — the JARVIS-Apple connection layer.
+
+Operator authorization 2026-07-19. The native Swift client calls
+``GET /api/stream/{device_id}``; the backend previously exposed only a
+singleton ``/api/stream/sse``. This layer transitions that singleton
+into a device-aware multiplexer so multiple native clients (desktop +
+mobile + watch) each get their own routed session — and abruptly-
+dropped native connections (OS backgrounding / network handoff, no TCP
+FIN) are pruned so 24/7 residency never leaks RAM.
+
+Mandate 2:
+  * **Device-Aware Multiplexing** — a ``device_id → registration`` map;
+    a per-device stream is created on connect and torn down on drop.
+  * **Dead-Stream Pruning (Zombie Guard)** — a write fault
+    (``ConnectionResetError`` / ``BrokenPipeError`` / any send error)
+    OR a heartbeat-ack timeout instantly DEREGISTERS the device and
+    releases its generator. No orphaned streams accumulate.
+
+DRY (mandate 3): the per-device generator COMPOSES the EXISTING
+``EventStream.sse_stream`` (same replay/channel semantics the web
+client uses); state still flows through the established event stream /
+TrinityEventBus. This module only adds the device routing + lifecycle.
+
+NEVER raises out of the registry operations.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, AsyncIterator, Dict, Optional, Set
+
+logger = logging.getLogger("Jarvis.DeviceStream")
+
+
+class DeviceRegistration:
+    __slots__ = ("device_id", "connected_at", "last_beat", "alive")
+
+    def __init__(self, device_id: str, now: float) -> None:
+        self.device_id = device_id
+        self.connected_at = now
+        self.last_beat = now
+        self.alive = True
+
+
+class DeviceStreamManager:
+    """Registry of live native SSE sessions, keyed by ``device_id``.
+    Thread-safe under the asyncio loop (single-loop mutation); every
+    public method NEVER raises."""
+
+    def __init__(
+        self,
+        *,
+        clock=time.monotonic,
+        heartbeat_timeout_s: float = 45.0,
+    ) -> None:
+        self._clock = clock
+        self._hb_timeout = heartbeat_timeout_s
+        self._devices: Dict[str, DeviceRegistration] = {}
+        self.stats: Dict[str, int] = {
+            "connects": 0, "drops_write_fault": 0,
+            "drops_heartbeat": 0, "reconnects": 0,
+        }
+
+    # ---- lifecycle ----
+
+    def register(self, device_id: str) -> DeviceRegistration:
+        """Register (or re-register) a device. A reconnect replaces the
+        stale registration — the OLD generator is already being pruned
+        by its own drop path. NEVER raises."""
+        now = self._clock()
+        if device_id in self._devices:
+            self.stats["reconnects"] += 1
+        reg = DeviceRegistration(device_id, now)
+        self._devices[device_id] = reg
+        self.stats["connects"] += 1
+        logger.info("[DeviceStream] %s connected (active=%d)",
+                    device_id, len(self._devices))
+        return reg
+
+    def deregister(self, device_id: str, *, reason: str = "closed") -> None:
+        """Evict a device + release its slot. Idempotent. NEVER
+        raises."""
+        reg = self._devices.pop(device_id, None)
+        if reg is not None:
+            reg.alive = False
+            logger.info("[DeviceStream] %s deregistered (%s, active=%d)",
+                        device_id, reason, len(self._devices))
+
+    def beat(self, device_id: str) -> None:
+        reg = self._devices.get(device_id)
+        if reg is not None:
+            reg.last_beat = self._clock()
+
+    def is_alive(self, device_id: str) -> bool:
+        reg = self._devices.get(device_id)
+        return reg is not None and reg.alive
+
+    def heartbeat_expired(self, device_id: str) -> bool:
+        reg = self._devices.get(device_id)
+        if reg is None:
+            return True
+        return (self._clock() - reg.last_beat) > self._hb_timeout
+
+    @property
+    def active_devices(self) -> Set[str]:
+        return set(self._devices)
+
+    # ---- the per-device stream (composes the existing sse_stream) ----
+
+    async def device_stream(
+        self,
+        device_id: str,
+        inner_stream: AsyncIterator[str],
+        *,
+        heartbeat_interval_s: float = 15.0,
+    ) -> AsyncIterator[str]:
+        """Wrap the EXISTING sse_stream generator with device routing +
+        dead-stream pruning. A write fault propagating out of the inner
+        stream, or a heartbeat gap, DEREGISTERS the device and stops
+        the generator — the orphaned stream is released. NEVER raises
+        past the generator boundary (a fault ends the stream cleanly)."""
+        self.register(device_id)
+        # Background pump: drain the inner stream into a queue so a
+        # heartbeat-window timeout NEVER cancels the inner generator
+        # (cancelling it repeatedly would corrupt it — the root cause
+        # of the earlier StopAsyncIteration-instead-of-prune bug). A
+        # write fault surfaces through the queue sentinel.
+        _SENTINEL_END = object()
+        queue: "asyncio.Queue" = asyncio.Queue(maxsize=256)
+        pump_exc: Dict[str, BaseException] = {}
+
+        async def _pump() -> None:
+            try:
+                async for frame in inner_stream:
+                    await queue.put(frame)
+                await queue.put(_SENTINEL_END)
+            except asyncio.CancelledError:
+                raise
+            except BaseException as exc:  # noqa: BLE001 — surface the fault
+                pump_exc["exc"] = exc
+                await queue.put(_SENTINEL_END)
+
+        pump = asyncio.get_event_loop().create_task(_pump())
+        try:
+            while self.is_alive(device_id):
+                try:
+                    frame = await asyncio.wait_for(
+                        queue.get(), timeout=heartbeat_interval_s,
+                    )
+                    if frame is _SENTINEL_END:
+                        exc = pump_exc.get("exc")
+                        if isinstance(exc, (ConnectionResetError,
+                                            BrokenPipeError)):
+                            raise exc              # → fault-prune path
+                        break                      # clean end of inner
+                    # Real data resets the liveness clock (a keepalive
+                    # is US probing, not the client acking).
+                    self.beat(device_id)
+                    yield frame
+                except asyncio.TimeoutError:
+                    # No data this window. Staleness past the timeout →
+                    # the client is gone (half-open socket) → prune.
+                    if self.heartbeat_expired(device_id):
+                        self.stats["drops_heartbeat"] += 1
+                        self.deregister(device_id, reason="heartbeat_timeout")
+                        break
+                    # Else keepalive — a dead native socket raises on
+                    # THIS write and prunes via the fault path.
+                    yield ": keepalive\n\n"
+        except (ConnectionResetError, BrokenPipeError) as exc:
+            # Silent native drop — no FIN. Prune instantly.
+            self.stats["drops_write_fault"] += 1
+            self.deregister(device_id, reason=f"write_fault:{type(exc).__name__}")
+        except asyncio.CancelledError:
+            self.deregister(device_id, reason="cancelled")
+            raise
+        except Exception as exc:  # noqa: BLE001 — any send fault = drop
+            self.stats["drops_write_fault"] += 1
+            self.deregister(device_id, reason=f"error:{type(exc).__name__}")
+        finally:
+            # Reap the pump task so the inner generator is released —
+            # zero orphaned streams over 24/7 residency.
+            if not pump.done():
+                pump.cancel()
+                try:
+                    await pump
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            self.deregister(device_id, reason="stream_end")
+
+
+# Process-wide manager (one registry per backend).
+_MANAGER: Optional[DeviceStreamManager] = None
+
+
+def get_device_manager() -> DeviceStreamManager:
+    global _MANAGER
+    if _MANAGER is None:
+        _MANAGER = DeviceStreamManager()
+    return _MANAGER
+
+
+def reset_device_manager() -> None:
+    global _MANAGER
+    _MANAGER = None
+
+
+__all__ = [
+    "DeviceRegistration",
+    "DeviceStreamManager",
+    "get_device_manager",
+    "reset_device_manager",
+]

--- a/backend/api/unified_websocket.py
+++ b/backend/api/unified_websocket.py
@@ -3103,6 +3103,48 @@ async def event_stream_sse(request: Request):
     )
 
 
+@router.get("/api/stream/{device_id}")
+async def event_stream_device(device_id: str, request: Request):
+    """Device-aware SSE (2026-07-19) — the native Swift client's
+    endpoint. Composes the EXISTING ``sse_stream`` (same replay/channel
+    semantics as the web ``/api/stream/sse``) behind the device-aware
+    multiplexer, which routes per ``device_id`` and prunes abruptly-
+    dropped native connections (Zombie Guard). Legacy ``/api/stream/
+    sse`` is untouched — web + terminal clients keep working."""
+    from backend.core.event_stream import (
+        get_event_stream, set_event_stream_ws_manager,
+    )
+    from backend.api.device_stream_manager import get_device_manager
+
+    es = get_event_stream()
+    if es._ws_manager is None:
+        set_event_stream_ws_manager(get_ws_manager())
+
+    last_ack = int(request.query_params.get("last_ack", "0"))
+    last_event_id = request.headers.get("Last-Event-ID")
+    if last_event_id:
+        try:
+            last_ack = max(last_ack, int(last_event_id))
+        except ValueError:
+            pass
+    channels_param = request.query_params.get("channels", "")
+    channels = set(channels_param.split(",")) if channels_param else None
+
+    inner = es.sse_stream(last_ack=last_ack, channels=channels)
+    manager = get_device_manager()
+
+    return StreamingResponse(
+        manager.device_stream(str(device_id), inner),
+        media_type="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "Connection": "keep-alive",
+            "X-Accel-Buffering": "no",
+            "X-Device-Id": str(device_id),
+        },
+    )
+
+
 @router.post("/api/stream/command")
 async def event_stream_command(request: Request):
     """

--- a/tests/api/test_device_stream.py
+++ b/tests/api/test_device_stream.py
@@ -1,0 +1,140 @@
+"""Device-Aware SSE Multiplexer + Dead-Stream Pruning spine.
+
+Mandate 4 verbatim (2026-07-19): two native clients connect with
+distinct device_ids; a silent network drop (unhandled write-buffer
+exception) on Device A → the pruning logic evicts A from the active
+dict while Device B keeps receiving telemetry uninterrupted.
+"""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.api import device_stream_manager as dsm
+from backend.api.device_stream_manager import DeviceStreamManager
+
+
+@pytest.fixture(autouse=True)
+def _reset():
+    dsm.reset_device_manager()
+    yield
+    dsm.reset_device_manager()
+
+
+async def _drain(agen, out, *, stop_after=None):
+    try:
+        i = 0
+        async for frame in agen:
+            out.append(frame)
+            i += 1
+            if stop_after is not None and i >= stop_after:
+                break
+    except Exception as e:  # noqa: BLE001
+        out.append(f"<ERR:{type(e).__name__}>")
+
+
+class TestDeviceMultiplexing:
+    async def test_two_devices_routed_independently(self):
+        mgr = DeviceStreamManager()
+
+        async def _feed(tag):
+            for i in range(3):
+                yield f"data: {tag}-{i}\n\n"
+                await asyncio.sleep(0)
+
+        a_out, b_out = [], []
+        await _drain(mgr.device_stream("devA", _feed("A")), a_out)
+        await _drain(mgr.device_stream("devB", _feed("B")), b_out)
+        assert any("A-0" in f for f in a_out)
+        assert any("B-0" in f for f in b_out)
+        assert mgr.stats["connects"] == 2
+
+    async def test_silent_drop_on_A_evicts_A_B_uninterrupted(self):
+        """MANDATE 4 VERBATIM: Device A's stream raises a write fault
+        (silent native drop); A is evicted, B keeps streaming."""
+        mgr = DeviceStreamManager()
+
+        async def _dying_feed():
+            yield "data: A-first\n\n"
+            # Silent native drop — the write buffer raises with NO FIN:
+            raise ConnectionResetError("native socket vanished")
+
+        async def _healthy_feed():
+            for i in range(4):
+                yield f"data: B-{i}\n\n"
+                await asyncio.sleep(0)
+
+        a_out, b_out = [], []
+        # Both connect + stream concurrently:
+        await asyncio.gather(
+            _drain(mgr.device_stream("devA", _dying_feed()), a_out),
+            _drain(mgr.device_stream("devB", _healthy_feed()), b_out),
+        )
+        # Device A evicted by the write fault:
+        assert "devA" not in mgr.active_devices
+        assert mgr.stats["drops_write_fault"] == 1
+        assert any("A-first" in f for f in a_out)     # got the pre-drop frame
+        # Device B UNINTERRUPTED — all 4 frames:
+        assert sum(1 for f in b_out if f.startswith("data: B-")) == 4
+        assert "devB" not in mgr.active_devices        # clean stream_end
+
+    async def test_broken_pipe_also_prunes(self):
+        mgr = DeviceStreamManager()
+
+        async def _feed():
+            yield "data: x\n\n"
+            raise BrokenPipeError("EPIPE")
+
+        out = []
+        await _drain(mgr.device_stream("devC", _feed()), out)
+        assert "devC" not in mgr.active_devices
+        assert mgr.stats["drops_write_fault"] == 1
+
+
+class TestZombieGuard:
+    async def test_heartbeat_timeout_prunes_half_open(self, monkeypatch):
+        clock = [1000.0]
+        mgr = DeviceStreamManager(clock=lambda: clock[0], heartbeat_timeout_s=30.0)
+
+        async def _stalled_feed():
+            # Never yields again after the first — a half-open socket.
+            yield "data: hello\n\n"
+            await asyncio.sleep(3600)
+
+        out = []
+        gen = mgr.device_stream("devZ", _stalled_feed(), heartbeat_interval_s=0.05)
+        agen = gen.__aiter__()
+        assert (await agen.__anext__()).startswith("data: hello")  # first frame
+        # First keepalive window: not yet expired → keepalive emitted.
+        ka = await agen.__anext__()
+        assert ka == ": keepalive\n\n"
+        # Advance the clock past the heartbeat timeout → next window prunes.
+        clock[0] += 40.0
+        with pytest.raises(StopAsyncIteration):
+            await agen.__anext__()
+        assert "devZ" not in mgr.active_devices
+        assert mgr.stats["drops_heartbeat"] == 1
+
+    async def test_reconnect_replaces_stale_registration(self):
+        mgr = DeviceStreamManager()
+        mgr.register("devR")
+        mgr.register("devR")                          # reconnect
+        assert mgr.stats["reconnects"] == 1
+        assert len(mgr.active_devices) == 1           # not duplicated
+        mgr.deregister("devR")
+        mgr.deregister("devR")                        # idempotent
+        assert "devR" not in mgr.active_devices
+
+
+class TestBackendWiring:
+    def test_device_endpoint_added_legacy_intact_pin(self):
+        from pathlib import Path
+        src = (Path(__file__).resolve().parents[2] /
+               "backend/api/unified_websocket.py").read_text()
+        assert '@router.get("/api/stream/{device_id}")' in src   # native path
+        assert '@router.get("/api/stream/sse")' in src           # legacy KEPT
+        assert '@router.post("/api/stream/command")' in src      # command KEPT
+        body = src[src.index('"/api/stream/{device_id}"'):][:1400]
+        assert "get_device_manager" in body                      # multiplexer
+        assert "es.sse_stream" in body                           # DRY reuse


### PR DESCRIPTION
## Summary
Reconciles the native Swift client ↔ backend URI mismatch so JARVIS-Apple connects.
- **New `GET /api/stream/{device_id}`** on the existing router — legacy `/api/stream/sse` + `/api/stream/command` untouched (web + `ov` keep working). Composes the *existing* `EventStream.sse_stream` (same replay/channels via TrinityEventBus) behind the multiplexer.
- **Device-Aware Multiplexing** — singleton → `device_id`-keyed registry; multiple native clients each get a routed session; reconnect replaces a stale registration.
- **Dead-Stream Pruning (Zombie Guard)** — a background queue-pump means a heartbeat timeout never cancels/corrupts the inner generator; `ConnectionResetError`/`BrokenPipeError` prunes instantly via a sentinel, a half-open socket prunes on the staleness heartbeat timeout, and the pump is reaped in `finally` → zero orphaned streams over 24/7.

## Testing
6 tests incl. **mandate 4 verbatim**: two devices with distinct ids stream concurrently; Device A raises a silent write fault (no FIN) → A evicted, `drops_write_fault=1`, Device B receives all frames uninterrupted. Broken-pipe prune, heartbeat-timeout prune, reconnect-replace, legacy-intact pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a device-aware SSE endpoint so native clients connect reliably, with per-device routing and aggressive dead-stream pruning. Legacy SSE and command endpoints stay unchanged.

- New Features
  - Added `GET /api/stream/{device_id}` that composes the existing `sse_stream` (supports `Last-Event-ID`, `last_ack`, and `channels`).
  - Introduced `DeviceStreamManager`: `device_id` registry, reconnects replace stale entries, and basic drop/connect stats.
  - Tests cover concurrent devices, reconnect, legacy route pin, and end-to-end wiring.

- Bug Fixes
  - Dead-stream pruning: background pump prevents generator cancellation/corruption; instant prune on `ConnectionResetError`/`BrokenPipeError`.
  - Half-open sockets prune on heartbeat timeout, with keepalives between checks; pump is reaped to prevent leaks.

<sup>Written for commit a8444223310036296b6781bbc2deb3ffbf19c307. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69969?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

