### PR TITLE
fix(hud): Swift 6 strict-concurrency compliance — JARVISHUD zero warnings

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Services/AppState.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/AppState.swift
@@ -636,6 +636,7 @@ class PythonBridge: ObservableObject {
 
 // MARK: - VoiceManager (TTS via AVSpeechSynthesizer — Daniel voice)
 
+@MainActor
 final class VoiceManager: NSObject, ObservableObject, AVSpeechSynthesizerDelegate {
     @Published var isSpeaking: Bool = false
     @Published var isListening: Bool = false
@@ -666,8 +667,11 @@ final class VoiceManager: NSObject, ObservableObject, AVSpeechSynthesizerDelegat
         synthesizer.speak(utterance)
     }
 
+    // AVSpeechSynthesizerDelegate callbacks arrive on an unspecified queue, so
+    // this stays nonisolated and hops to the MainActor natively (no
+    // DispatchQueue) to mutate the isolated UI state.
     nonisolated func speechSynthesizer(_ synthesizer: AVSpeechSynthesizer, didFinish utterance: AVSpeechUtterance) {
-        DispatchQueue.main.async { [weak self] in
+        Task { @MainActor [weak self] in
             self?.isSpeaking = false
         }
     }

--- a/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
+++ b/JARVIS-Apple/JARVISHUD/Services/BrainstemLauncher.swift
@@ -408,8 +408,12 @@ final class BrainstemLauncher {
                 return
             }
 
-            // Continue receiving
-            self.startReceiveLoop(conn)
+            // Continue receiving. The receive handler runs on the background
+            // ipcQueue, so hop to the MainActor natively (NWConnection is
+            // Sendable) to re-enter the isolated loop.
+            Task { @MainActor in
+                self.startReceiveLoop(conn)
+            }
         }
     }
 

--- a/JARVIS-Apple/JARVISHUD/Views/ArcReactorView.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/ArcReactorView.swift
@@ -105,7 +105,7 @@ struct ArcReactorView: View {
         .onAppear {
             startAnimations()
         }
-        .onChange(of: state) { newState in
+        .onChange(of: state) { _, newState in
             updateReactorForState(newState)
         }
         .onTapGesture {

--- a/JARVIS-Apple/JARVISHUD/Views/HUDView.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/HUDView.swift
@@ -220,22 +220,22 @@ struct HUDView: View {
             print("   Connection status: \(pythonBridge.connectionStatus)")
             updateStatusFromConnection()
         }
-        .onChange(of: pythonBridge.connectionStatus) { newStatus in
+        .onChange(of: pythonBridge.connectionStatus) { _, _ in
             updateStatusFromConnection()
         }
-        .onChange(of: pythonBridge.hudState) { newState in
+        .onChange(of: pythonBridge.hudState) { _, newState in
             hudState = newState
         }
-        .onChange(of: pythonBridge.transcriptMessages) { newMessages in
+        .onChange(of: pythonBridge.transcriptMessages) { _, newMessages in
             transcriptMessages = newMessages
         }
-        .onChange(of: pythonBridge.voiceState) { newState in
+        .onChange(of: pythonBridge.voiceState) { _, newState in
             updateVoiceStatus(from: newState)
         }
-        .onChange(of: pythonBridge.voiceTranscript) { newTranscript in
+        .onChange(of: pythonBridge.voiceTranscript) { _, newTranscript in
             currentTranscript = newTranscript
         }
-        .onChange(of: pythonBridge.screenLockTriggered) { isTriggered in
+        .onChange(of: pythonBridge.screenLockTriggered) { _, isTriggered in
             if isTriggered {
                 triggerScreenLockAnimation()
             }
@@ -250,12 +250,23 @@ struct HUDView: View {
         // Start countdown timer
         screenLockCountdown = 3
         Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
-            if screenLockCountdown > 0 {
-                screenLockCountdown -= 1
-            } else {
+            // The timer fires on the main run loop it was scheduled on, so the
+            // MainActor-isolated view state is safe to touch synchronously.
+            // Return a Sendable flag so the non-Sendable `timer` never crosses
+            // the isolation boundary.
+            let expired = MainActor.assumeIsolated { () -> Bool in
+                if screenLockCountdown > 0 {
+                    screenLockCountdown -= 1
+                    return false
+                }
+                return true
+            }
+            if expired {
                 timer.invalidate()
-                // Hide animation after countdown
-                DispatchQueue.main.asyncAfter(deadline: .now() + 0.5) {
+                // Hide animation after the countdown — native concurrency,
+                // no DispatchQueue.
+                Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(0.5))
                     withAnimation(.easeOut(duration: 0.5)) {
                         showScreenLockAnimation = false
                     }

--- a/JARVIS-Apple/JARVISHUD/Views/JARVISPanel.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/JARVISPanel.swift
@@ -122,7 +122,11 @@ class JARVISPanel: NSPanel {
             self.animator().setFrame(offscreenFrame, display: true)
             self.animator().alphaValue = 0
         }, completionHandler: {
-            self.orderOut(nil)
+            // AppKit animation completion is delivered on the main thread; assume
+            // MainActor isolation to call the isolated NSWindow API synchronously.
+            MainActor.assumeIsolated {
+                self.orderOut(nil)
+            }
         })
     }
 

--- a/JARVIS-Apple/JARVISHUD/Views/JARVISPulseView.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/JARVISPulseView.swift
@@ -67,7 +67,7 @@ struct JARVISPulseView: View {
                 startPulseAnimation()
             }
         }
-        .onChange(of: isActive) { newValue in
+        .onChange(of: isActive) { _, newValue in
             if newValue {
                 startPulseAnimation()
             } else {

--- a/JARVIS-Apple/JARVISHUD/Views/LoadingHUDView.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/LoadingHUDView.swift
@@ -240,13 +240,18 @@ struct LoadingHUDView: View {
     private func setupRealtimeObservers() {
         // 🚀 ROBUST: Set up a timer to poll bridge properties if needed
         Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { timer in
-            // Force UI update if progress changed but didn't trigger
-            if CGFloat(appState.pythonBridge.loadingProgress) != progress {
-                updateProgress(appState.pythonBridge.loadingProgress)
+            // Fires on the main run loop it was scheduled on — assume MainActor
+            // isolation to touch the isolated view state synchronously, and
+            // return a Sendable flag so the non-Sendable `timer` never crosses
+            // the isolation boundary.
+            let complete = MainActor.assumeIsolated { () -> Bool in
+                // Force UI update if progress changed but didn't trigger
+                if CGFloat(appState.pythonBridge.loadingProgress) != progress {
+                    updateProgress(appState.pythonBridge.loadingProgress)
+                }
+                return appState.pythonBridge.loadingComplete
             }
-
-            // Stop timer when complete
-            if appState.pythonBridge.loadingComplete {
+            if complete {
                 timer.invalidate()
             }
         }
@@ -285,7 +290,7 @@ struct MatrixTransitionView: View {
                     for column in columns {
                         for char in column {
                             let point = CGPoint(x: char.x, y: char.y)
-                            var text = Text(char.character)
+                            let text = Text(char.character)
                                 .font(.system(size: 16, design: .monospaced))
                                 .foregroundColor(char.isLead ? .jarvisGreen : Color.jarvisGreen.opacity(0.5))
 
@@ -344,14 +349,18 @@ struct MatrixTransitionView: View {
     private func startMatrixAnimation(windowSize: CGSize) {
         let maxY = windowSize.height + 100
 
-        Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { timer in
-            for i in 0..<columns.count {
-                for j in 0..<columns[i].count {
-                    columns[i][j].y += 2
+        Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
+            // Fires on the main run loop — assume MainActor isolation to mutate
+            // the isolated @State columns synchronously.
+            MainActor.assumeIsolated {
+                for i in 0..<columns.count {
+                    for j in 0..<columns[i].count {
+                        columns[i][j].y += 2
 
-                    // Reset to top when off-screen
-                    if columns[i][j].y > maxY {
-                        columns[i][j].y = -20
+                        // Reset to top when off-screen
+                        if columns[i][j].y > maxY {
+                            columns[i][j].y = -20
+                        }
                     }
                 }
             }

--- a/JARVIS-Apple/JARVISHUD/Views/TransparentWindow.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/TransparentWindow.swift
@@ -77,7 +77,12 @@ class TransparentWindow: NSWindow {
             context.duration = 0.3
             self.animator().alphaValue = 0.0
         }, completionHandler: {
-            self.orderOut(nil)
+            // The AppKit animation completion handler is delivered on the main
+            // thread; assume the MainActor isolation to call the isolated
+            // NSWindow API synchronously (native concurrency — no DispatchQueue).
+            MainActor.assumeIsolated {
+                self.orderOut(nil)
+            }
         })
     }
 }


### PR DESCRIPTION
## Swift 6 strict-concurrency modernization of JARVISHUD

The pasted error block was the literal placeholder, so I captured the **real** warning set by building the app target with `-strict-concurrency=complete`. The app already built, but emitted ~25 strict-concurrency + deprecation warnings. This drives them to **zero**. All fixes are native Swift Concurrency — no `DispatchQueue.main.async`, no `@unchecked Sendable` (mandate 1).

### Fixes
- **`VoiceManager` → `@MainActor`** (mandate 2b): drives UI state, so the class is fully MainActor-isolated (kills the mutable-`_isSpeaking`-on-`Sendable` warning). Its `AVSpeechSynthesizerDelegate` callback stays `nonisolated` and hops via `Task { @MainActor in }`.
- **MainActor UI isolation from callbacks** (mandate 2a), chosen per callback thread:
  - *Guaranteed-on-main* (Timers on the main run loop, `NSAnimationContext` completion) → `MainActor.assumeIsolated { }` — synchronous, and returns a Sendable flag so the non-Sendable `Timer` is invalidated in the outer closure (no `sending 'timer'` race). Covers `LoadingHUDView`, `HUDView` countdown, `TransparentWindow`/`JARVISPanel` `orderOut`.
  - *Background queue* → `Task { @MainActor in }` — `BrainstemLauncher.startReceiveLoop` (`NWConnection.receive` on `ipcQueue`).
  - Two `DispatchQueue.main.asyncAfter` UI delays → `Task { @MainActor in try? await Task.sleep }`.
- **macOS 14 `.onChange` modernization** (mandate 2c): all 8 deprecated single-param → two-param `{ _, newValue in }` (HUDView ×6, ArcReactorView, JARVISPulseView).
- Minor: `LoadingHUDView` `var text` → `let`.

### DRY (mandate 3)
Only actor-isolation boundaries + view modifiers were patched — no `LoadingHUDView` layout and no `BrainstemLauncher` logic rewritten.

### Verification (mandate 4)
`xcodebuild -scheme JARVISHUD SWIFT_STRICT_CONCURRENCY=complete clean build` → **BUILD SUCCEEDED, 0 Swift-file warnings**. JARVISKit tests (Slice F) stay green.

> Scope note: `TransparentWindow.swift` + `JARVISPanel.swift` (the `orderOut` sites) were beyond the named files but had to be fixed to reach zero warnings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Modernized JARVISHUD for Swift 6 strict concurrency. Removes all concurrency and deprecation warnings for a clean, zero-warning build.

- **Refactors**
  - Marked `VoiceManager` as `@MainActor`; kept delegate callback `nonisolated` and updated UI via `Task { @MainActor }`.
  - Used `MainActor.assumeIsolated {}` for main-run-loop timers and AppKit animation completions to safely mutate UI and invalidate timers.
  - Hopped background callbacks (e.g., `NWConnection.receive`) to `@MainActor` with `Task` before continuing the loop.
  - Replaced `DispatchQueue.main.asyncAfter` with `Task.sleep` on `@MainActor`.
  - Updated SwiftUI `.onChange(of:)` handlers to the two-parameter form across affected views.
  - Minor: `LoadingHUDView` `var text` → `let`.

<sup>Written for commit 2f168ca2f47216770221795162e91bca1ba0bd1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69974?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

