### PR TITLE
refactor(hud): structural MainActor isolation — retire timer-based assumeIsolated

### DIFF
--- a/JARVIS-Apple/JARVISHUD/Views/HUDView.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/HUDView.swift
@@ -47,6 +47,9 @@ struct HUDView: View {
     @State private var currentTranscript: String = ""  // Real-time voice transcript
     @State private var showScreenLockAnimation: Bool = false  // Screen lock animation overlay
     @State private var screenLockCountdown: Int = 3  // Countdown timer for screen lock
+    /// The countdown as a MainActor-native structured task (no run-loop timer,
+    /// no assumeIsolated); cancelled on re-trigger and on view disappear.
+    @State private var screenLockTask: Task<Void, Never>?
     @State private var showVisionPrompt: Bool = false  // Vision command prompt
     @State private var visionCommandText: String = ""  // Vision command input
     @State private var visionAnalyzing: Bool = false  // Vision analysis in progress
@@ -240,6 +243,10 @@ struct HUDView: View {
                 triggerScreenLockAnimation()
             }
         }
+        .onDisappear {
+            screenLockTask?.cancel()
+            screenLockTask = nil
+        }
     }
 
     private func triggerScreenLockAnimation() {
@@ -247,30 +254,29 @@ struct HUDView: View {
             showScreenLockAnimation = true
         }
 
-        // Start countdown timer
+        // Countdown as a MainActor-native structured task: the state mutation
+        // is isolation-correct BY CONSTRUCTION (no run-loop timer, no
+        // assumeIsolated assertion). Cancellation (re-trigger / disappear) ends
+        // it deterministically via the thrown CancellationError from sleep.
         screenLockCountdown = 3
-        Timer.scheduledTimer(withTimeInterval: 1.0, repeats: true) { timer in
-            // The timer fires on the main run loop it was scheduled on, so the
-            // MainActor-isolated view state is safe to touch synchronously.
-            // Return a Sendable flag so the non-Sendable `timer` never crosses
-            // the isolation boundary.
-            let expired = MainActor.assumeIsolated { () -> Bool in
-                if screenLockCountdown > 0 {
-                    screenLockCountdown -= 1
-                    return false
+        screenLockTask?.cancel()
+        screenLockTask = Task { @MainActor in
+            while screenLockCountdown > 0 {
+                do {
+                    try await Task.sleep(for: .seconds(1))
+                } catch {
+                    return   // cancelled
                 }
-                return true
+                screenLockCountdown -= 1
             }
-            if expired {
-                timer.invalidate()
-                // Hide animation after the countdown — native concurrency,
-                // no DispatchQueue.
-                Task { @MainActor in
-                    try? await Task.sleep(for: .seconds(0.5))
-                    withAnimation(.easeOut(duration: 0.5)) {
-                        showScreenLockAnimation = false
-                    }
-                }
+            // Hide the animation after the countdown.
+            do {
+                try await Task.sleep(for: .seconds(0.5))
+            } catch {
+                return
+            }
+            withAnimation(.easeOut(duration: 0.5)) {
+                showScreenLockAnimation = false
             }
         }
     }

--- a/JARVIS-Apple/JARVISHUD/Views/LoadingHUDView.swift
+++ b/JARVIS-Apple/JARVISHUD/Views/LoadingHUDView.swift
@@ -121,7 +121,6 @@ struct LoadingHUDView: View {
         }
         .onAppear {
             startLoadingAnimation()
-            setupRealtimeObservers()
             print("🚀 LoadingHUDView initialized with reactive progress tracking")
         }
         .onReceive(appState.pythonBridge.$loadingProgress) { newProgress in
@@ -237,25 +236,11 @@ struct LoadingHUDView: View {
         }
     }
 
-    private func setupRealtimeObservers() {
-        // 🚀 ROBUST: Set up a timer to poll bridge properties if needed
-        Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { timer in
-            // Fires on the main run loop it was scheduled on — assume MainActor
-            // isolation to touch the isolated view state synchronously, and
-            // return a Sendable flag so the non-Sendable `timer` never crosses
-            // the isolation boundary.
-            let complete = MainActor.assumeIsolated { () -> Bool in
-                // Force UI update if progress changed but didn't trigger
-                if CGFloat(appState.pythonBridge.loadingProgress) != progress {
-                    updateProgress(appState.pythonBridge.loadingProgress)
-                }
-                return appState.pythonBridge.loadingComplete
-            }
-            if complete {
-                timer.invalidate()
-            }
-        }
-    }
+    // NOTE: the former `setupRealtimeObservers()` poll timer was removed — it
+    // duplicated the reactive `.onReceive($loadingProgress/$loadingComplete)`
+    // observers above (which deliver on the MainActor), so it was redundant AND
+    // the only reason the file needed `MainActor.assumeIsolated`. Reactive
+    // observation is the root-cause-correct, non-polling mechanism.
 
     private func playCompletionAnimation() {
         loadingState = .complete
@@ -280,6 +265,10 @@ struct MatrixTransitionView: View {
     @State private var columns: [[MatrixCharacter]] = []
     @State private var opacity: Double = 0.3
     @State private var windowSize: CGSize = .zero
+    /// The animation frame loop — a MainActor-native structured task so column
+    /// mutation is isolation-correct BY CONSTRUCTION (no runtime assertion) and
+    /// is cancelled when the view disappears (no leaked run-loop timer).
+    @State private var animationTask: Task<Void, Never>?
 
     var body: some View {
         GeometryReader { geometry in
@@ -310,12 +299,17 @@ struct MatrixTransitionView: View {
                     opacity = 1.0
                 }
 
-                // Fade out
-                DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                // Fade out — native concurrency, no DispatchQueue.
+                Task { @MainActor in
+                    try? await Task.sleep(for: .seconds(2.0))
                     withAnimation(.easeOut(duration: 0.5)) {
                         opacity = 0
                     }
                 }
+            }
+            .onDisappear {
+                animationTask?.cancel()
+                animationTask = nil
             }
         }
     }
@@ -349,10 +343,13 @@ struct MatrixTransitionView: View {
     private func startMatrixAnimation(windowSize: CGSize) {
         let maxY = windowSize.height + 100
 
-        Timer.scheduledTimer(withTimeInterval: 0.05, repeats: true) { _ in
-            // Fires on the main run loop — assume MainActor isolation to mutate
-            // the isolated @State columns synchronously.
-            MainActor.assumeIsolated {
+        // Structured MainActor frame loop: the body runs ON the MainActor by
+        // construction, so mutating the isolated @State `columns` is safe
+        // WITHOUT any runtime `assumeIsolated` assertion, and the loop is
+        // cancelled deterministically in `.onDisappear` (no leaked timer).
+        animationTask?.cancel()
+        animationTask = Task { @MainActor in
+            while !Task.isCancelled {
                 for i in 0..<columns.count {
                     for j in 0..<columns[i].count {
                         columns[i][j].y += 2
@@ -362,6 +359,11 @@ struct MatrixTransitionView: View {
                             columns[i][j].y = -20
                         }
                     }
+                }
+                do {
+                    try await Task.sleep(for: .milliseconds(50))
+                } catch {
+                    break   // cancelled
                 }
             }
         }


### PR DESCRIPTION
## Structural MainActor isolation (caveat from #69974)

`MainActor.assumeIsolated` is a runtime **assertion** — it traps if a callback ever fires off-main. For the three `Timer.scheduledTimer` sites, *"the timer runs on the main run loop"* was a **caller assumption**, not a structural guarantee. This makes isolation structural by converting those loops to **MainActor-native structured `Task`s** — the body runs on the MainActor by construction (no assertion that can trap), and the loops are deterministically cancellable.

### Changes
- **`LoadingHUDView.setupRealtimeObservers` → DELETED** (DRY). It polled `loadingProgress`/`loadingComplete` every 0.1s, but the view already observes those exact `@Published` properties via `.onReceive` (MainActor-delivered). Pure duplication — and the *only* reason the file needed `assumeIsolated`.
- **`MatrixTransitionView` frame loop** → cancellable `Task { @MainActor in while !Task.isCancelled { … try await Task.sleep } }`, cancelled in `.onDisappear`. Also fixes a **latent leak** — the old frame timer was never invalidated.
- **`HUDView` screen-lock countdown** → cancellable MainActor `Task` (`@State`, cancelled on re-trigger + `.onDisappear`).
- Two `DispatchQueue.main.asyncAfter` UI delays → `Task.sleep`.

### Deliberately kept
The two `MainActor.assumeIsolated` calls in `TransparentWindow`/`JARVISPanel` (`orderOut`) run inside `NSAnimationContext` completion handlers, which AppKit **documents** as delivered on the main thread — a contract guarantee, not a caller assumption, so the assertion can never trap.

### Verification
`xcodebuild -scheme JARVISHUD SWIFT_STRICT_CONCURRENCY=complete clean build` → **BUILD SUCCEEDED, zero Swift-file warnings**. Behavior preserved (same intervals + mutations); countdown hides ~1s sooner (old timer waited an extra tick at zero); matrix loop is now leak-free.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced timer-based callbacks and MainActor assertions with structured MainActor Tasks in HUD views. This guarantees main-thread isolation, enables clean cancellation, removes redundant polling, and fixes a leaked frame timer.

- **Refactors**
  - HUDView: countdown timer → cancellable MainActor Task; cancels on re-trigger and onDisappear.
  - MatrixTransitionView: frame loop → MainActor Task with await sleep; cancels onDisappear; replaced DispatchQueue delays with Task.sleep.
  - LoadingHUDView: removed polling in setupRealtimeObservers; rely on reactive .onReceive for progress/complete.
  - Kept two assumeIsolated calls in TransparentWindow/JARVISPanel, backed by AppKit’s documented main-thread completion handlers.

- **Bug Fixes**
  - Fixed leaked frame timer in MatrixTransitionView (now cancelled deterministically).
  - Countdown hides ~1s sooner by removing the extra zero-tick delay.

<sup>Written for commit e557bc88fc0f9ed6c193e71533923c830889866e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69975?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

