### PR TITLE
Hive Step 1: Universal Envelope + read-only Aggregator (Trinity + IDE SSE fan-in)

### DIFF
--- a/backend/api/converged_headless.py
+++ b/backend/api/converged_headless.py
@@ -154,33 +154,14 @@ async def _start_control_plane(app: Any, orch: Any) -> Any:
         # --- Hive Aggregator (Step 1): read-only fan-in over the fragmented
         # fabrics → Universal Envelope → relayed to the cockpit so `ov hive`
         # projects the REAL O+V pipeline. Attaches read-only (mandate 1); never
-        # mutates a source bus. ---
+        # mutates a source bus. Shared wiring with the battle-test harness
+        # (DRY, mandate 3). ---
         try:
-            from backend.api.hive_aggregator import HiveAggregator
-            from backend.core.trinity_event_bus import get_event_bus_if_exists
-            try:
-                from backend.core.ouroboros.governance.ide_observability_stream import (
-                    get_default_broker,
-                )
-                _broker = get_default_broker()
-            except Exception:  # noqa: BLE001
-                _broker = None
-            agg = HiveAggregator(bus=get_event_bus_if_exists(), sse_broker=_broker)
-            await agg.start()
-            app.state.hive_aggregator = agg
-
-            async def _relay_hive() -> None:
-                try:
-                    async for env in agg.feed():
-                        bridge.publish_telemetry(
-                            {"hive": True, **env.to_bus_payload()})
-                except asyncio.CancelledError:
-                    raise
-                except Exception:  # noqa: BLE001
-                    pass
-
-            app.state.hive_relay = asyncio.create_task(_relay_hive(), name="hive-relay")
-            logger.info("[Converged] hive aggregator up — `ov hive` can project the pipeline")
+            from backend.api.hive_aggregator import start_hive_relay
+            pair = await start_hive_relay(bridge.publish_telemetry)
+            if pair is not None:
+                app.state.hive_aggregator, app.state.hive_relay = pair
+                logger.info("[Converged] hive aggregator up — `ov hive` can project the pipeline")
         except Exception:  # noqa: BLE001
             logger.debug("[Converged] hive aggregator degraded", exc_info=True)
 

--- a/backend/api/converged_headless.py
+++ b/backend/api/converged_headless.py
@@ -150,6 +150,40 @@ async def _start_control_plane(app: Any, orch: Any) -> Any:
                         pass
         except Exception:  # noqa: BLE001
             pass
+
+        # --- Hive Aggregator (Step 1): read-only fan-in over the fragmented
+        # fabrics → Universal Envelope → relayed to the cockpit so `ov hive`
+        # projects the REAL O+V pipeline. Attaches read-only (mandate 1); never
+        # mutates a source bus. ---
+        try:
+            from backend.api.hive_aggregator import HiveAggregator
+            from backend.core.trinity_event_bus import get_event_bus_if_exists
+            try:
+                from backend.core.ouroboros.governance.ide_observability_stream import (
+                    get_default_broker,
+                )
+                _broker = get_default_broker()
+            except Exception:  # noqa: BLE001
+                _broker = None
+            agg = HiveAggregator(bus=get_event_bus_if_exists(), sse_broker=_broker)
+            await agg.start()
+            app.state.hive_aggregator = agg
+
+            async def _relay_hive() -> None:
+                try:
+                    async for env in agg.feed():
+                        bridge.publish_telemetry(
+                            {"hive": True, **env.to_bus_payload()})
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    pass
+
+            app.state.hive_relay = asyncio.create_task(_relay_hive(), name="hive-relay")
+            logger.info("[Converged] hive aggregator up — `ov hive` can project the pipeline")
+        except Exception:  # noqa: BLE001
+            logger.debug("[Converged] hive aggregator degraded", exc_info=True)
+
         logger.info("[Converged] control plane up — `ov system` can attach")
         return bridge
     except Exception:  # noqa: BLE001
@@ -248,6 +282,19 @@ def create_converged_app(
                 try:
                     await task
                 except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            relay = getattr(app.state, "hive_relay", None)
+            if relay is not None and not relay.done():
+                relay.cancel()
+                try:
+                    await relay
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            agg = getattr(app.state, "hive_aggregator", None)
+            if agg is not None:
+                try:
+                    await agg.stop()
+                except Exception:  # noqa: BLE001
                     pass
             bridge = getattr(app.state, "control_plane", None)
             if bridge is not None:

--- a/backend/api/hive_aggregator.py
+++ b/backend/api/hive_aggregator.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import time
-from typing import Any, AsyncIterator, List, Optional
+from typing import Any, AsyncIterator, List, Optional, Tuple
 
 from backend.api.hive_envelope import (
     HiveTelemetryEnvelope, from_ide_sse_event, from_trinity_event,
@@ -226,4 +226,62 @@ class HiveAggregator:
         self._tasks = []
 
 
-__all__ = ["HiveAggregator"]
+_UNSET = object()
+
+
+async def start_hive_relay(
+    publish: Any,
+    *,
+    bus: Any = _UNSET,
+    sse_broker: Any = _UNSET,
+) -> Optional[Tuple[HiveAggregator, "asyncio.Task"]]:
+    """Start a read-only :class:`HiveAggregator` and relay its unified feed to ONE
+    cockpit publish surface (``CockpitAttachBridge.publish_telemetry``) as
+    ``hive``-tagged frames.
+
+    This is the shared wiring for EVERY pipeline host — the converged
+    ``--headless`` organism AND the battle-test harness — so ``ov hive``
+    projects the pipeline from whichever process owns the cockpit socket
+    (DRY, mandate 3). Sources default to the process-local fabrics; both are
+    injectable for tests. Read-only (mandate 1). NEVER raises — returns
+    ``None`` when degraded.
+    """
+    try:
+        if bus is _UNSET:
+            try:
+                from backend.core.trinity_event_bus import get_event_bus_if_exists
+                bus = get_event_bus_if_exists()
+            except Exception:  # noqa: BLE001
+                bus = None
+        if sse_broker is _UNSET:
+            try:
+                from backend.core.ouroboros.governance.ide_observability_stream import (
+                    get_default_broker,
+                )
+                sse_broker = get_default_broker()
+            except Exception:  # noqa: BLE001
+                sse_broker = None
+        agg = HiveAggregator(bus=bus, sse_broker=sse_broker)
+        await agg.start()
+
+        async def _relay() -> None:
+            try:
+                async for env in agg.feed():
+                    try:
+                        publish({"hive": True, **env.to_bus_payload()})
+                    except Exception:  # noqa: BLE001
+                        pass
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                pass
+
+        task = asyncio.create_task(_relay(), name="hive-relay")
+        logger.info("[HiveAgg] relay up — `ov hive` can project this pipeline")
+        return agg, task
+    except Exception:  # noqa: BLE001
+        logger.debug("[HiveAgg] relay start degraded", exc_info=True)
+        return None
+
+
+__all__ = ["HiveAggregator", "start_hive_relay"]

--- a/backend/api/hive_aggregator.py
+++ b/backend/api/hive_aggregator.py
@@ -1,0 +1,229 @@
+"""The Hive Aggregator — a read-only listening post over the fragmented fabrics.
+
+CQRS-clean integration (mandate 1): the Aggregator NEVER mutates a source bus or
+forces it to dual-write. It *attaches* to the existing fabrics using their native
+subscription APIs — ``TrinityEventBus.subscribe`` and the IDE SSE broker's
+``subscribe`` / ``stream_iter`` — casts each native event into the Universal
+``HiveTelemetryEnvelope``, and fans the two concurrent streams into ONE
+chronologically-ordered queue for the ov hive TUI.
+
+Fan-in (mandate 2): each source drains independently into a bounded ``asyncio.Queue``
+so neither can block the other during heavy I/O. A single drainer coalesces a short
+window, sorts by timestamp, and emits into the unified ``out_queue`` — merging two
+disparate async iterators into one sorted feed without dropping frames.
+
+Fully injectable (``bus`` / ``sse_broker``) so the multiplexer is unit-testable with
+mocks and no live daemon. Every public entry point NEVER raises.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, AsyncIterator, List, Optional
+
+from backend.api.hive_envelope import (
+    HiveTelemetryEnvelope, from_ide_sse_event, from_trinity_event,
+)
+
+logger = logging.getLogger("Jarvis.HiveAggregator")
+
+#: TrinityEventBus source families the aggregator listens on (read-only). It does
+#: NOT subscribe to its own relay topic, so there is no feedback loop.
+_TRINITY_PATTERNS = (
+    "training.#", "tier.#", "autonomy.#", "workflow.#", "gap.#",
+    "fs.#", "command.#", "intake.#", "reactor.#", "degradation.#",
+)
+
+#: IDE-SSE control frames the aggregator ignores (they carry no agent activity).
+_SSE_CONTROL = frozenset({
+    "heartbeat", "stream_lag", "replay_start", "replay_end",
+})
+
+
+class HiveAggregator:
+    """Read-only fan-in over TrinityEventBus + the IDE SSE broker → one sorted
+    envelope feed. NEVER publishes back to a source (mandate 1)."""
+
+    def __init__(
+        self,
+        *,
+        bus: Optional[Any] = None,
+        sse_broker: Optional[Any] = None,
+        raw_max: int = 4096,
+        out_max: int = 4096,
+        sort_window_s: float = 0.02,
+    ) -> None:
+        self._bus = bus
+        self._broker = sse_broker
+        self._sort_window_s = sort_window_s
+        self._raw: "asyncio.Queue[HiveTelemetryEnvelope]" = asyncio.Queue(maxsize=raw_max)
+        #: The unified, chronologically-ordered feed the TUI consumes.
+        self.out_queue: "asyncio.Queue[HiveTelemetryEnvelope]" = asyncio.Queue(maxsize=out_max)
+        self._running = False
+        self._tasks: List[asyncio.Task] = []
+        self._sub_ids: List[str] = []
+        self._sse_sub: Any = None
+        self.stats = {"captured": 0, "emitted": 0, "dropped_raw": 0, "dropped_out": 0}
+
+    # -- read-only source attachment ----------------------------------------
+
+    async def start(self) -> None:
+        """Attach to both fabrics (read-only) + start the drainer. NEVER raises."""
+        if self._running:
+            return
+        self._running = True
+        # TrinityEventBus: native subscribe on each source family.
+        if self._bus is not None:
+            for pattern in _TRINITY_PATTERNS:
+                try:
+                    sub_id = await self._bus.subscribe(pattern, self._on_trinity)
+                    if sub_id:
+                        self._sub_ids.append(sub_id)
+                except Exception:  # noqa: BLE001
+                    logger.debug("[HiveAgg] trinity subscribe degraded pattern=%s", pattern,
+                                 exc_info=True)
+        # IDE SSE broker: native subscribe + a stream_iter pump task.
+        if self._broker is not None:
+            try:
+                self._sse_sub = self._broker.subscribe(op_id_filter=None)
+                if self._sse_sub is not None:
+                    self._tasks.append(asyncio.ensure_future(self._pump_sse()))
+            except Exception:  # noqa: BLE001
+                logger.debug("[HiveAgg] sse subscribe degraded", exc_info=True)
+        # The single fan-in drainer (coalesce → sort → emit).
+        self._tasks.append(asyncio.ensure_future(self._drainer()))
+        logger.info("[HiveAgg] listening — trinity_subs=%d sse=%s",
+                    len(self._sub_ids), self._sse_sub is not None)
+
+    async def _on_trinity(self, event: Any) -> None:
+        """TrinityEventBus handler (read-only). Casts + fans in. NEVER raises."""
+        try:
+            topic = str(getattr(event, "topic", "") or "")
+            payload = getattr(event, "payload", None) or {}
+            env = from_trinity_event(
+                topic=topic, payload=payload,
+                event_id=str(getattr(event, "event_id", "") or ""))
+            self._fan_in(env)
+        except Exception:  # noqa: BLE001
+            pass
+
+    async def _pump_sse(self) -> None:
+        """Consume the IDE SSE broker's async iterator + fan in. NEVER raises out."""
+        try:
+            async for ev in self._broker.stream_iter(self._sse_sub, heartbeat_s=0):
+                et = str(getattr(ev, "event_type", "") or "")
+                if et in _SSE_CONTROL:
+                    continue
+                try:
+                    env = from_ide_sse_event(
+                        event_type=et, op_id=str(getattr(ev, "op_id", "") or ""),
+                        payload=getattr(ev, "payload", None) or {},
+                        event_id=str(getattr(ev, "event_id", "") or ""))
+                    self._fan_in(env)
+                except Exception:  # noqa: BLE001
+                    continue
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[HiveAgg] sse pump ended", exc_info=True)
+
+    def _fan_in(self, env: HiveTelemetryEnvelope) -> None:
+        """Push a normalized envelope into the shared fan-in queue. Non-blocking
+        (drop-oldest on overflow) so no source ever blocks another."""
+        self.stats["captured"] += 1
+        try:
+            self._raw.put_nowait(env)
+        except asyncio.QueueFull:
+            try:
+                self._raw.get_nowait()
+                self._raw.put_nowait(env)
+            except Exception:  # noqa: BLE001
+                pass
+            self.stats["dropped_raw"] += 1
+
+    async def _drainer(self) -> None:
+        """The merge heart: await one envelope, coalesce a short window, sort by
+        timestamp, and emit into the unified feed — chronological order across BOTH
+        streams without dropping frames (mandate 2). NEVER raises out of the loop."""
+        while self._running:
+            try:
+                first = await self._raw.get()
+                batch: List[HiveTelemetryEnvelope] = [first]
+                if self._sort_window_s > 0:
+                    await asyncio.sleep(self._sort_window_s)
+                while True:
+                    try:
+                        batch.append(self._raw.get_nowait())
+                    except asyncio.QueueEmpty:
+                        break
+                # Stable chronological sort (ts, then event_id as tiebreak).
+                batch.sort(key=lambda e: (e.ts, e.event_id))
+                for env in batch:
+                    self._emit(env)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                logger.debug("[HiveAgg] drainer degraded", exc_info=True)
+
+    def _emit(self, env: HiveTelemetryEnvelope) -> None:
+        try:
+            self.out_queue.put_nowait(env)
+            self.stats["emitted"] += 1
+        except asyncio.QueueFull:
+            try:
+                self.out_queue.get_nowait()
+                self.out_queue.put_nowait(env)
+                self.stats["emitted"] += 1
+            except Exception:  # noqa: BLE001
+                pass
+            self.stats["dropped_out"] += 1
+
+    async def feed(self) -> AsyncIterator[HiveTelemetryEnvelope]:
+        """Async iterator over the unified chronological feed (for the TUI)."""
+        while self._running or not self.out_queue.empty():
+            try:
+                yield await self.out_queue.get()
+            except asyncio.CancelledError:
+                raise
+
+    async def drain_available(self, *, settle_s: float = 0.0) -> List[HiveTelemetryEnvelope]:
+        """Non-blocking snapshot of everything currently in the unified feed (for
+        tests / reconciliation). Optionally waits ``settle_s`` for in-flight sorts."""
+        if settle_s > 0:
+            await asyncio.sleep(settle_s)
+        out: List[HiveTelemetryEnvelope] = []
+        while True:
+            try:
+                out.append(self.out_queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+        return out
+
+    async def stop(self) -> None:
+        """Detach cleanly (read-only teardown). NEVER raises."""
+        self._running = False
+        if self._bus is not None:
+            for sub_id in self._sub_ids:
+                try:
+                    await self._bus.unsubscribe(sub_id)
+                except Exception:  # noqa: BLE001
+                    pass
+        self._sub_ids = []
+        if self._broker is not None and self._sse_sub is not None:
+            try:
+                self._broker.unsubscribe(self._sse_sub)
+            except Exception:  # noqa: BLE001
+                pass
+        for t in self._tasks:
+            if not t.done():
+                t.cancel()
+        for t in self._tasks:
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        self._tasks = []
+
+
+__all__ = ["HiveAggregator"]

--- a/backend/api/hive_envelope.py
+++ b/backend/api/hive_envelope.py
@@ -1,0 +1,216 @@
+"""The Universal Semantic Envelope for the ov hive feed (Phase 12, Hive Step 1).
+
+Every agent/subsystem across the six fragmented message fabrics (TrinityEventBus,
+the IDE SSE observability broker, CommProtocol, TelemetryBus, AgentCommunicationBus,
+legacy core.event_bus) maps its native activity into ONE polymorphic Pydantic type
+so the ov hive TUI renders any actor predictably — a real Gmail send, a governance
+gate, an ephemeral agent's birth/death — with the same shape.
+
+This module is PURE DATA + read-only adapters. It never publishes, never mutates a
+source bus (mandate 1). ``from_trinity_event`` / ``from_ide_sse_event`` are the two
+Step-1 adapters; more fabrics plug in later behind the same envelope.
+"""
+from __future__ import annotations
+
+import time
+from typing import Any, Dict, Literal, Mapping, Optional
+
+from pydantic import BaseModel, Field
+
+HIVE_ENV_SCHEMA = "hive.env.1"
+
+#: Topic-prefix → (subsystem, actor family) for TrinityEventBus events.
+_TRINITY_PREFIX_MAP = {
+    "training.": ("training", "training.pipeline"),
+    "tier.": ("routing", "tier.router"),
+    "autonomy.": ("swarm", "autonomy"),
+    "workflow.": ("mesh", "mesh.orchestrator"),
+    "gap.": ("sensor", "sensor.capability_gap"),
+    "fs.": ("sensor", "fs.watcher"),
+    "command.": ("governance", "command"),
+    "ouroboros.": ("governance", "ouroboros"),
+    "intake.": ("sensor", "intake.router"),
+    "reactor.": ("training", "reactor_core"),
+}
+
+#: IDE-SSE event_type prefix → subsystem for the observability broker.
+_SSE_SUBSYSTEM_HINTS = (
+    ("swarm_", "swarm"),
+    ("task_", "governance"),
+    ("gate", "governance"),
+    ("tool_", "governance"),
+    ("fsm", "governance"),
+    ("operation", "governance"),
+    ("posture", "governance"),
+    ("circuit", "routing"),
+    ("provider_", "routing"),
+    ("drift", "sensor"),
+    ("curiosity", "consciousness"),
+)
+
+
+class HiveTelemetryEnvelope(BaseModel):
+    """Universal semantic envelope — the lingua franca of the ov hive feed.
+
+    Polymorphic via ``kind``; subclasses inherit these strict base fields and add
+    their own typed detail. Extra source-specific fields ride in ``detail``.
+    """
+
+    # --- strict base identity (required of EVERY actor) ---
+    actor_id: str                       # "vision.screen" / "mcp.gmail" / "ouroboros.gate"
+    subsystem: str                      # perception|actuation|mcp|governance|sensor|swarm|routing|training|mesh|consciousness|persona
+    intent: str                         # WHY (short)
+    action_summary: str                 # WHAT — one human line for the feed
+    trace_id: str                       # correlation → the feed thread (op_id / goal_id)
+
+    # --- envelope metadata ---
+    kind: str = "generic"
+    schema_version: str = HIVE_ENV_SCHEMA
+    source_fabric: str = "unknown"      # trinity | ide_sse | commprotocol | telemetry | ...
+    event_id: str = ""
+    ts: float = Field(default_factory=time.time)
+    severity: Literal["info", "success", "warn", "error"] = "info"
+    detail: Dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"extra": "ignore"}
+
+    def to_bus_payload(self) -> Dict[str, Any]:
+        """Flatten to a dict that BOTH the ov hive parser AND the existing
+        ``governance_sse_bridge._render`` understand (mandate 3): it carries the
+        full envelope PLUS the bridge's required aliases (type / narration_text /
+        source_brain / narration_priority)."""
+        payload = self.model_dump()
+        payload.update({
+            "type": self.kind,
+            "narration_text": self.action_summary,
+            "source_brain": self.actor_id,
+            "narration_priority": "high" if self.severity in ("warn", "error") else "normal",
+        })
+        return payload
+
+
+class SensorEnvelope(HiveTelemetryEnvelope):
+    kind: Literal["sensor"] = "sensor"
+    signal_urgency: Optional[str] = None
+
+
+class GovernanceEnvelope(HiveTelemetryEnvelope):
+    kind: Literal["governance"] = "governance"
+    phase: Optional[str] = None
+    risk_tier: Optional[str] = None
+
+
+class SwarmEnvelope(HiveTelemetryEnvelope):
+    kind: Literal["swarm"] = "swarm"
+    lifecycle: Optional[str] = None     # spawned | kept | disposed | vaporized | promoted
+
+
+class RoutingEnvelope(HiveTelemetryEnvelope):
+    kind: Literal["routing"] = "routing"
+    provider: Optional[str] = None
+
+
+# ---------------------------------------------------------------------------
+# Read-only source adapters (mandate 1 — cast, never mutate/republish)
+# ---------------------------------------------------------------------------
+
+def _summarize(text: str, fallback: str) -> str:
+    t = (text or "").strip()
+    return (t[:160] if t else fallback)
+
+
+def _subsystem_for_trinity(topic: str) -> tuple:
+    for prefix, (sub, actor) in _TRINITY_PREFIX_MAP.items():
+        if topic.startswith(prefix):
+            return sub, actor
+    return "bus", topic.split(".")[0] or "bus"
+
+
+def from_trinity_event(
+    *, topic: str, payload: Mapping[str, Any], event_id: str = "",
+    ts: Optional[float] = None,
+) -> HiveTelemetryEnvelope:
+    """Cast a TrinityEventBus event into the Universal Envelope. NEVER raises."""
+    try:
+        p = dict(payload) if isinstance(payload, Mapping) else {}
+        subsystem, actor_base = _subsystem_for_trinity(topic)
+        verb = topic.split(".")[-1]
+        actor_id = f"{actor_base}.{verb}" if actor_base == "autonomy" else actor_base
+        narration = str(p.get("narration_text") or p.get("event") or "")
+        summary = _summarize(narration, f"{actor_base}: {verb}")
+        trace = str(p.get("op_id") or p.get("trace_id") or p.get("correlation_id")
+                    or p.get("command_id") or "—")
+        sev = "error" if (p.get("success") is False or "fail" in verb or "error" in verb) else "info"
+        base = dict(actor_id=actor_id, subsystem=subsystem, intent=verb,
+                    action_summary=summary, trace_id=trace, source_fabric="trinity",
+                    event_id=str(event_id or p.get("event_id") or ""),
+                    ts=float(ts if ts is not None else p.get("ts", time.time())),
+                    severity=sev, detail=p)
+        if subsystem == "sensor":
+            return SensorEnvelope(signal_urgency=p.get("urgency"), **base)
+        if subsystem in ("governance",):
+            return GovernanceEnvelope(phase=p.get("phase"), risk_tier=p.get("risk_tier"), **base)
+        if subsystem == "swarm":
+            return SwarmEnvelope(lifecycle=p.get("lifecycle") or p.get("state"), **base)
+        if subsystem == "routing":
+            return RoutingEnvelope(provider=p.get("provider"), **base)
+        return HiveTelemetryEnvelope(**base)
+    except Exception:  # noqa: BLE001 — never break the aggregator on one bad frame
+        return HiveTelemetryEnvelope(
+            actor_id="trinity", subsystem="bus", intent="event",
+            action_summary=f"trinity:{topic}", trace_id="—", source_fabric="trinity",
+            ts=float(ts or time.time()))
+
+
+def _subsystem_for_sse(event_type: str) -> str:
+    et = (event_type or "").lower()
+    for prefix, sub in _SSE_SUBSYSTEM_HINTS:
+        if et.startswith(prefix) or prefix in et:
+            return sub
+    return "governance"
+
+
+def from_ide_sse_event(
+    *, event_type: str, op_id: str = "", payload: Mapping[str, Any],
+    event_id: str = "", ts: Optional[float] = None,
+) -> HiveTelemetryEnvelope:
+    """Cast an IDE SSE StreamEvent into the Universal Envelope. NEVER raises."""
+    try:
+        p = dict(payload) if isinstance(payload, Mapping) else {}
+        subsystem = _subsystem_for_sse(event_type)
+        narration = str(p.get("narration_text") or p.get("summary")
+                        or p.get("message") or "")
+        summary = _summarize(narration, event_type.replace("_", " "))
+        trace = str(op_id or p.get("op_id") or "—")
+        sev = "error" if ("fail" in event_type or "error" in event_type
+                          or "deadlock" in event_type or p.get("success") is False) else "info"
+        base = dict(actor_id=f"ov.{subsystem}", subsystem=subsystem, intent=event_type,
+                    action_summary=summary, trace_id=trace, source_fabric="ide_sse",
+                    event_id=str(event_id or ""),
+                    ts=float(ts if ts is not None else p.get("ts", time.time())),
+                    severity=sev, detail=p)
+        if subsystem == "swarm":
+            life = ("spawned" if "spawned" in event_type else
+                    "vaporized" if "vaporized" in event_type else
+                    "disposed" if "dispos" in event_type else None)
+            return SwarmEnvelope(lifecycle=life, actor_id="ov.swarm", **{k: v for k, v in base.items() if k != "actor_id"})
+        if subsystem == "governance":
+            return GovernanceEnvelope(phase=p.get("phase") or p.get("terminal_phase"),
+                                      risk_tier=p.get("risk_tier"), **base)
+        if subsystem == "routing":
+            return RoutingEnvelope(provider=p.get("provider"), **base)
+        if subsystem == "sensor":
+            return SensorEnvelope(**base)
+        return HiveTelemetryEnvelope(**base)
+    except Exception:  # noqa: BLE001
+        return HiveTelemetryEnvelope(
+            actor_id="ov.observability", subsystem="governance", intent=event_type or "event",
+            action_summary=str(event_type or "sse event"), trace_id=str(op_id or "—"),
+            source_fabric="ide_sse", ts=float(ts or time.time()))
+
+
+__all__ = [
+    "HIVE_ENV_SCHEMA", "HiveTelemetryEnvelope", "SensorEnvelope",
+    "GovernanceEnvelope", "SwarmEnvelope", "RoutingEnvelope",
+    "from_trinity_event", "from_ide_sse_event",
+]

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4385,6 +4385,18 @@ class BattleTestHarness:
             )
             if await bridge.start():
                 self._cockpit_attach_bridge = bridge
+                # Hive Step 1: the harness IS the live pipeline host (16
+                # sensors + GovernedLoop run in THIS process), so `ov hive`
+                # must project from here too — the SAME read-only relay the
+                # converged --headless organism starts (DRY, mandate 3).
+                try:
+                    from backend.api.hive_aggregator import start_hive_relay
+                    pair = await start_hive_relay(bridge.publish_telemetry)
+                    if pair is not None:
+                        self._hive_aggregator, self._hive_relay_task = pair
+                except Exception:  # noqa: BLE001
+                    logger.debug("[CockpitAttach] hive relay degraded",
+                                 exc_info=True)
             else:
                 self._cockpit_attach_bridge = None
         except Exception:  # noqa: BLE001
@@ -8220,6 +8232,19 @@ class BattleTestHarness:
             synapse = getattr(self, "_audio_synapse", None)
             if synapse is not None:
                 await synapse.stop()
+        except Exception:
+            pass
+        try:
+            relay = getattr(self, "_hive_relay_task", None)
+            if relay is not None and not relay.done():
+                relay.cancel()
+                try:
+                    await relay
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+            hive_agg = getattr(self, "_hive_aggregator", None)
+            if hive_agg is not None:
+                await hive_agg.stop()
         except Exception:
             pass
         try:

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -27,7 +27,7 @@ from typing import Any, Callable, List, Optional, Sequence
 
 from backend.core.ouroboros.ui.theme import build_console
 
-_VERBS = {"cockpit", "run", "daemon", "status", "attach", "system", "version"}
+_VERBS = {"cockpit", "run", "daemon", "status", "attach", "system", "hive", "version"}
 _HELP_TOKENS = {"help", "--help", "-h"}
 _VERSION_TOKENS = {"version", "--version", "-V"}
 
@@ -136,6 +136,8 @@ def resolve(argv: Optional[Sequence[str]] = None) -> Invocation:
         return Invocation("attach")
     if verb == "system":
         return Invocation("system")
+    if verb == "hive":
+        return Invocation("hive")
     # cockpit (explicit or defaulted)
     return Invocation("cockpit", rest)
 
@@ -643,6 +645,28 @@ def run_system(console: Any) -> int:
         return 1
 
 
+def run_hive(console: Any) -> int:
+    """Attach the live Agent Hive feed to the running headless daemon over the
+    Cockpit Attach UDS — a read-only, chronological projection of the real O+V
+    pipeline (Trinity + IDE SSE fabrics, unified by the Hive Aggregator).
+    Passive listener; graceful reconnect. NEVER raises out to the terminal."""
+    import asyncio
+    try:
+        from backend.core.ouroboros.cli.ov_hive_panel import run_hive_panel
+    except Exception as exc:  # noqa: BLE001
+        try:
+            console.print(f"ov hive unavailable: {exc}", markup=False)
+        except Exception:  # noqa: BLE001
+            pass
+        return 1
+    try:
+        return asyncio.run(run_hive_panel(console=console))
+    except KeyboardInterrupt:
+        return 0
+    except Exception:  # noqa: BLE001
+        return 1
+
+
 # ---------------------------------------------------------------------------
 # Entry point
 # ---------------------------------------------------------------------------
@@ -668,6 +692,8 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return run_attach(console)
     if inv.action == "system":
         return run_system(console)
+    if inv.action == "hive":
+        return run_hive(console)
     if inv.action == "status":
         console.print(status_digest(), markup=False, highlight=False)
         return 0

--- a/backend/core/ouroboros/cli/ov_hive_panel.py
+++ b/backend/core/ouroboros/cli/ov_hive_panel.py
@@ -1,0 +1,145 @@
+"""``ov hive`` — the live agent-activity feed (Phase 12, Hive Step 1).
+
+A read-only, scrolling projection of the REAL O+V pipeline: the Hive Aggregator
+(daemon side) fans in the fragmented fabrics — TrinityEventBus + the IDE SSE
+observability broker — into Universal Envelopes and relays them over the same
+Cockpit Attach UDS the ``ov system`` cockpit uses. This panel attaches to that
+socket, folds the ``hive`` frames into a chronological feed, and renders it.
+
+DRY: reuses the Slice-G ``TelemetryConnectionManager`` (graceful reconnect) and
+the ``ov system`` render idiom. Throttled batched rendering (100ms) so a burst of
+deliberation can never starve the terminal thread. NEVER raises to the terminal.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional, Tuple
+
+from backend.core.ouroboros.cli.ov_system_panel import (
+    ConnState, TelemetryConnectionManager,
+)
+
+logger = logging.getLogger("Ouroboros.OVHivePanel")
+
+#: subsystem → accent colour for the feed.
+_SUB_COLOR = {
+    "governance": "cyan", "swarm": "magenta", "sensor": "yellow",
+    "routing": "blue", "training": "green", "mesh": "bright_magenta",
+    "consciousness": "bright_blue", "perception": "bright_cyan",
+    "actuation": "bright_yellow", "mcp": "bright_green", "persona": "white",
+}
+
+
+@dataclass
+class HiveFeedModel:
+    """The rolling, chronological agent-activity feed folded from hive frames."""
+    lines: List[Tuple[float, str, str, str, str]] = field(default_factory=list)  # ts, actor, subsystem, summary, severity
+    seen_fabrics: set = field(default_factory=set)
+    _MAX = 500
+
+    def ingest(self, frame: Dict[str, Any]) -> None:
+        """Fold ONE cockpit frame into the feed (only `hive` frames). NEVER raises."""
+        try:
+            if not frame.get("hive"):
+                return
+            ts = float(frame.get("ts", time.time()))
+            actor = str(frame.get("actor_id") or frame.get("source_brain") or "?")
+            subsystem = str(frame.get("subsystem") or "bus")
+            summary = str(frame.get("action_summary") or frame.get("narration_text") or "")
+            sev = str(frame.get("severity") or "info")
+            self.seen_fabrics.add(str(frame.get("source_fabric") or "?"))
+            self.lines.append((ts, actor, subsystem, summary, sev))
+            if len(self.lines) > self._MAX:
+                del self.lines[: len(self.lines) - self._MAX]
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def render_hive_feed(model: HiveFeedModel, state: "ConnState") -> Any:
+    """Rich renderable — a scrolling feed of who did/said what. NEVER raises."""
+    from rich.panel import Panel
+    from rich.table import Table
+    from rich.text import Text
+    from rich.console import Group
+
+    online = state is ConnState.ATTACHED
+    header = Table.grid(expand=True)
+    header.add_column(justify="left")
+    header.add_column(justify="right")
+    dot = "🟢" if online else ("🟠" if state is ConnState.RECONNECTING else "🔴")
+    fabrics = " ".join(sorted(model.seen_fabrics)) or "—"
+    header.add_row(Text(f"{dot} ov · hive — live agent feed", style="bold"),
+                   Text(f"fabrics: {fabrics}", style="dim"))
+
+    feed = Table.grid(expand=True, padding=(0, 1))
+    feed.add_column(style="dim", no_wrap=True)   # time
+    feed.add_column(no_wrap=True)                 # actor
+    feed.add_column()                             # summary
+    tail = model.lines[-22:]
+    for ts, actor, subsystem, summary, sev in tail:
+        clock = time.strftime("%H:%M:%S", time.localtime(ts))
+        color = _SUB_COLOR.get(subsystem, "white")
+        sev_mark = {"error": "✗ ", "warn": "! ", "success": "✓ "}.get(sev, "")
+        feed.add_row(Text(clock, style="dim"),
+                     Text(f"{actor}", style=color),
+                     Text(f"{sev_mark}{summary}",
+                          style="red" if sev == "error" else "default"))
+    if not model.lines:
+        feed.add_row(Text(""), Text(""),
+                     Text("(awaiting agent activity — run an O+V op to see the pipeline talk)",
+                          style="dim italic"))
+
+    parts: List[Any] = [header, Text("")]
+    if not online:
+        parts += [Text("  DAEMON OFFLINE — ATTEMPTING RECONNECT  ",
+                       style="bold white on red"), Text("")]
+    parts.append(feed)
+    return Panel(Group(*parts), title="JARVIS · Agent Hive",
+                 border_style="green" if online else "red")
+
+
+async def run_hive_panel(
+    *, manager: Optional[TelemetryConnectionManager] = None,
+    refresh_hz: float = 10.0, console: Any = None,
+    stop_after_s: Optional[float] = None,
+) -> int:
+    """Attach to the cockpit UDS and render the live hive feed. Throttled 100ms
+    batched render (mandate). NEVER raises; returns an exit code."""
+    from rich.console import Console
+    from rich.live import Live
+
+    model = HiveFeedModel()
+    mgr = manager or TelemetryConnectionManager(on_frame=model.ingest)
+    if manager is not None:
+        prev = mgr._on_frame
+        mgr._on_frame = lambda f: (model.ingest(f), prev(f))  # type: ignore
+    con = console or Console()
+
+    run_task = asyncio.get_event_loop().create_task(mgr.run(), name="ov-hive-conn")
+    started = time.monotonic()
+    try:
+        with Live(render_hive_feed(model, mgr.state), console=con,
+                  refresh_per_second=max(1.0, refresh_hz), screen=False) as live:
+            while True:
+                await asyncio.sleep(0.1)   # 100ms batched render
+                live.update(render_hive_feed(model, mgr.state))
+                if stop_after_s is not None and (time.monotonic() - started) >= stop_after_s:
+                    break
+    except (asyncio.CancelledError, KeyboardInterrupt):
+        pass
+    except Exception:  # noqa: BLE001
+        logger.debug("[OVHive] render degraded", exc_info=True)
+    finally:
+        mgr.stop()
+        run_task.cancel()
+        try:
+            await run_task
+        except (asyncio.CancelledError, Exception):  # noqa: BLE001
+            pass
+    return 0
+
+
+__all__ = ["HiveFeedModel", "render_hive_feed", "run_hive_panel"]

--- a/tests/api/test_hive_aggregator.py
+++ b/tests/api/test_hive_aggregator.py
@@ -1,0 +1,185 @@
+"""Hive Aggregator — read-only fan-in multiplexer (Phase 12, Hive Step 1)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.api.hive_aggregator import HiveAggregator
+from backend.api.hive_envelope import (
+    HiveTelemetryEnvelope, from_ide_sse_event, from_trinity_event,
+)
+
+
+# ---------------------------------------------------------------------------
+# mocks mirroring the REAL source contracts (native subscribe methods)
+# ---------------------------------------------------------------------------
+
+class _TrinityEvent:
+    def __init__(self, topic, payload, event_id):
+        self.topic = topic; self.payload = payload; self.event_id = event_id
+
+
+class _MockTrinityBus:
+    """Mirrors TrinityEventBus.subscribe(pattern, handler) + wildcard routing."""
+    def __init__(self):
+        self._subs = {}; self._n = 0; self.unsubscribed = []
+
+    async def subscribe(self, pattern, handler, **kw):
+        self._n += 1; sid = f"t-{self._n}"; self._subs[sid] = (pattern, handler); return sid
+
+    async def unsubscribe(self, sub_id):
+        self.unsubscribed.append(sub_id); self._subs.pop(sub_id, None); return True
+
+    @staticmethod
+    def _matches(pattern, topic):
+        if pattern.endswith(".#"):
+            base = pattern[:-2]
+            return topic == base or topic.startswith(base + ".")
+        return pattern == topic
+
+    async def fire(self, topic, payload, event_id):
+        ev = _TrinityEvent(topic, payload, event_id)
+        for pat, h in list(self._subs.values()):
+            if self._matches(pat, topic):
+                await h(ev)
+
+
+class _SseEvent:
+    def __init__(self, event_type, op_id, payload, event_id):
+        self.event_type = event_type; self.op_id = op_id
+        self.payload = payload; self.event_id = event_id
+
+
+class _MockSseSub:
+    def __init__(self): self.queue = asyncio.Queue(); self._closed = False
+
+
+class _MockSseBroker:
+    """Mirrors StreamEventBroker.subscribe / stream_iter / unsubscribe."""
+    def __init__(self): self.subs = []
+
+    def subscribe(self, op_id_filter=None, last_event_id=None):
+        s = _MockSseSub(); self.subs.append(s); return s
+
+    def unsubscribe(self, sub):
+        sub._closed = True
+
+    async def stream_iter(self, sub, heartbeat_s=0):
+        while not sub._closed:
+            try:
+                ev = await asyncio.wait_for(sub.queue.get(), timeout=0.5)
+                yield ev
+            except asyncio.TimeoutError:
+                if sub._closed:
+                    return
+                continue
+
+    async def publish(self, ev):
+        for s in self.subs:
+            await s.queue.put(ev)
+
+
+# ---------------------------------------------------------------------------
+# MANDATE 4 — 5 Trinity + 5 SSE, published simultaneously → all 10 captured,
+# cast to envelopes, yielded in perfect chronological order, zero drops.
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_multiplexer_merges_both_streams_in_chronological_order():
+    bus, broker = _MockTrinityBus(), _MockSseBroker()
+    agg = HiveAggregator(bus=bus, sse_broker=broker, sort_window_s=0.05)
+    await agg.start()
+    await asyncio.sleep(0.01)   # let subscriptions settle
+
+    # Interleave the two fabrics with strictly increasing source timestamps.
+    async def blast():
+        # ts 1,3,5,7,9 → Trinity ; ts 2,4,6,8,10 → SSE
+        for i in range(5):
+            await bus.fire("autonomy.work_unit_state_changed",
+                           {"ts": (2 * i + 1), "state": "running", "op_id": f"op{i}"},
+                           event_id=f"t{i}")
+            await broker.publish(_SseEvent(
+                "gate_evaluated", f"op{i}",
+                {"ts": (2 * i + 2), "narration_text": f"gate {i} PASS"}, f"s{i}"))
+
+    await blast()
+    await asyncio.sleep(0.2)     # > sort window: everything coalesces into one sorted batch
+
+    got = await agg.drain_available()
+
+    # 1. All 10 captured — nothing dropped.
+    assert len(got) == 10, f"expected 10, got {len(got)}: {[e.ts for e in got]}"
+    assert agg.stats["dropped_raw"] == 0 and agg.stats["dropped_out"] == 0
+    # 2. Every item is a HiveTelemetryEnvelope.
+    assert all(isinstance(e, HiveTelemetryEnvelope) for e in got)
+    # 3. Perfect chronological order by source timestamp.
+    ts_order = [e.ts for e in got]
+    assert ts_order == sorted(ts_order) == [float(i) for i in range(1, 11)], ts_order
+    # 4. Both fabrics are represented + correctly typed.
+    fabrics = {e.source_fabric for e in got}
+    assert fabrics == {"trinity", "ide_sse"}
+    assert any(e.subsystem == "swarm" for e in got)        # autonomy.* → swarm
+    assert any(e.subsystem == "governance" for e in got)   # gate_evaluated → governance
+
+    await agg.stop()
+    assert len(bus.unsubscribed) == len(_TrinityPatterns := [
+        "training.#", "tier.#", "autonomy.#", "workflow.#", "gap.#",
+        "fs.#", "command.#", "intake.#", "reactor.#", "degradation.#"])
+
+
+@pytest.mark.asyncio
+async def test_read_only_never_publishes_back_to_sources():
+    """Mandate 1: the aggregator must be a pure listener — it must not call any
+    publish method on the source bus/broker."""
+    bus, broker = _MockTrinityBus(), _MockSseBroker()
+    # Trip-wire: if the aggregator ever tries to publish, fail loudly.
+    bus.publish = lambda *a, **k: (_ for _ in ()).throw(AssertionError("wrote to bus!"))
+    agg = HiveAggregator(bus=bus, sse_broker=broker, sort_window_s=0.02)
+    await agg.start()
+    await bus.fire("gap.detected", {"ts": 1.0}, "g1")
+    await asyncio.sleep(0.1)
+    got = await agg.drain_available()
+    assert len(got) == 1 and got[0].subsystem == "sensor"
+    await agg.stop()
+
+
+@pytest.mark.asyncio
+async def test_neither_stream_blocks_the_other_under_load():
+    """Fan-in stays live even if one source floods: blast 200 Trinity events;
+    a lone SSE event must still make it through the merge."""
+    bus, broker = _MockTrinityBus(), _MockSseBroker()
+    agg = HiveAggregator(bus=bus, sse_broker=broker, sort_window_s=0.02, raw_max=64, out_max=4096)
+    await agg.start()
+    await asyncio.sleep(0.01)
+    for i in range(200):
+        await bus.fire("fs.changed.modified", {"ts": float(i)}, f"f{i}")
+    await broker.publish(_SseEvent("tool_confidence", "opX", {"ts": 999.0}, "sX"))
+    await asyncio.sleep(0.2)
+    got = await agg.drain_available()
+    # The SSE event survived despite the Trinity flood (proves independent fan-in).
+    assert any(e.source_fabric == "ide_sse" and e.ts == 999.0 for e in got)
+    await agg.stop()
+
+
+# ---------------------------------------------------------------------------
+# envelope adapters cast correctly + stay bridge-compatible (mandate 3)
+# ---------------------------------------------------------------------------
+
+def test_envelope_to_bus_payload_is_governance_bridge_compatible():
+    env = from_ide_sse_event(event_type="gate_evaluated", op_id="op7",
+                             payload={"narration_text": "gate PASS", "phase": "GATE"})
+    p = env.to_bus_payload()
+    # the exact keys governance_sse_bridge._render reads:
+    for k in ("type", "narration_text", "source_brain", "narration_priority"):
+        assert k in p
+    assert p["narration_text"] == "gate PASS"
+    assert p["type"] == "governance"
+
+
+def test_trinity_swarm_lifecycle_maps_to_swarm_envelope():
+    env = from_trinity_event(topic="autonomy.work_unit_state_changed",
+                             payload={"state": "disposed", "op_id": "op1", "ts": 5.0})
+    assert env.subsystem == "swarm"
+    assert env.trace_id == "op1"
+    assert env.ts == 5.0

--- a/tests/api/test_hive_aggregator.py
+++ b/tests/api/test_hive_aggregator.py
@@ -183,3 +183,86 @@ def test_trinity_swarm_lifecycle_maps_to_swarm_envelope():
     assert env.subsystem == "swarm"
     assert env.trace_id == "op1"
     assert env.ts == 5.0
+
+
+# ---------------------------------------------------------------------------
+# start_hive_relay — the ONE shared host wiring (converged organism + harness).
+# Both hosts must call it on their live path (the wired-but-inert checklist).
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_start_hive_relay_publishes_hive_tagged_frames():
+    """The relay helper attaches read-only + republishes every envelope to the
+    cockpit publish surface tagged ``hive: True`` (what ov_hive_panel folds)."""
+    from backend.api.hive_aggregator import start_hive_relay
+
+    bus, broker = _MockTrinityBus(), _MockSseBroker()
+    published = []
+    pair = await start_hive_relay(published.append, bus=bus, sse_broker=broker)
+    assert pair is not None
+    agg, task = pair
+    await asyncio.sleep(0.01)
+    await bus.fire("intake.signal_accepted", {"sensor": "test_failure", "ts": 1.0}, "e1")
+    await broker.publish(_SseEvent("gate_evaluated", "op9",
+                                   {"narration_text": "gate PASS", "ts": 2.0}, "e2"))
+    await asyncio.sleep(0.2)
+    assert len(published) == 2
+    assert all(f.get("hive") is True for f in published)
+    # bridge-compat keys survive the relay (governance_sse_bridge._render reads these)
+    assert all("narration_text" in f and "source_brain" in f for f in published)
+    task.cancel()
+    try:
+        await task
+    except (asyncio.CancelledError, Exception):
+        pass
+    await agg.stop()
+
+
+@pytest.mark.asyncio
+async def test_start_hive_relay_degrades_to_none_not_raise():
+    """A publish surface that explodes at start must yield None, never raise."""
+    from backend.api import hive_aggregator as mod
+
+    class _Boom:
+        def __init__(self, *a, **kw):
+            raise RuntimeError("boom")
+
+    orig = mod.HiveAggregator
+    mod.HiveAggregator = _Boom
+    try:
+        pair = await mod.start_hive_relay(lambda f: None, bus=None, sse_broker=None)
+        assert pair is None
+    finally:
+        mod.HiveAggregator = orig
+
+
+def _calls_in_function(path, func_name):
+    """All function/attr names called inside ``func_name`` of the module at path."""
+    import ast as _ast
+    tree = _ast.parse(open(path, encoding="utf-8").read())
+    names = set()
+    for node in _ast.walk(tree):
+        if isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef)) and node.name == func_name:
+            for sub in _ast.walk(node):
+                if isinstance(sub, _ast.Call):
+                    f = sub.func
+                    if isinstance(f, _ast.Name):
+                        names.add(f.id)
+                    elif isinstance(f, _ast.Attribute):
+                        names.add(f.attr)
+    return names
+
+
+def test_both_pipeline_hosts_wire_the_hive_relay():
+    """AST wiring pin: the converged --headless organism AND the battle-test
+    harness (the process where the 16 sensors + GovernedLoop actually run)
+    both call start_hive_relay on their cockpit-boot path. Kills the
+    wired-but-inert class: an aggregator in a process with no pipeline
+    traffic proves nothing."""
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[2]
+    assert "start_hive_relay" in _calls_in_function(
+        root / "backend" / "api" / "converged_headless.py", "_start_control_plane")
+    assert "start_hive_relay" in _calls_in_function(
+        root / "backend" / "core" / "ouroboros" / "battle_test" / "harness.py",
+        "_start_cockpit_attach_bridge")


### PR DESCRIPTION
## Hive Step 1 — the read-only Aggregator foundation for `ov hive`

**Context:** the wiring audit proved the "agent social network" already exists but is fragmented across ~6 message fabrics, with the richest slice (the whole O+V pipeline) flowing through the **IDE SSE observability broker**, not the TrinityEventBus. So `ov hive` is a read-only **aggregator** (a listening post), not a shim campaign.

### What's here
- **`HiveTelemetryEnvelope`** (Pydantic v2, polymorphic) — universal semantic envelope every fabric maps into; Swarm subtype carries the `spawned|kept|disposed|vaporized|promoted` ephemeral lifecycle.
- **`HiveAggregator`** — CQRS-clean read-only fan-in over TrinityEventBus (`subscribe`) + IDE SSE broker (`subscribe`/`stream_iter`); two sources drain independently into a bounded queue; a drainer coalesces + sorts by source timestamp → one chronological feed. Never mutates a source (trip-wire tested).
- **`ov hive`** — feed TUI reusing the Slice-G `TelemetryConnectionManager` + 100ms throttled render.
- **`converged_headless`** starts the aggregator read-only and relays its unified feed to the cockpit UDS.

### Tests (mandate 4)
5 aggregator tests incl. the mandate case: 5 Trinity + 5 IDE-SSE events published simultaneously → all 10 captured, cast to envelopes, **perfect chronological order, zero drops**. Plus read-only trip-wire, no-blocking-under-flood fan-in, and bridge-compat/lifecycle adapters. 30 tests green with regression.

### Status
- **Proven:** core (unit) + vertical (live — `ov hive` attaches to the `--headless` daemon over UDS).
- **Not yet proven:** the feed *populating* with real pipeline events — needs a live O+V op firing (idle boot = empty feed, correctly). Next: a stimulus live-fire.

Step 2 (silent-actor emit shims: Gmail/web/voice/ghost-hands + Edge-Level Debouncer) is deferred until this foundation is proven live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a read-only Hive Aggregator that merges TrinityEventBus and IDE SSE activity into a single, chronological feed using a universal envelope, and surfaces it in the new `ov hive` TUI. Now wired via a shared `start_hive_relay` into both the converged daemon and the battle-test harness so the feed projects from whichever process owns the cockpit socket.

- **New Features**
  - Universal `HiveTelemetryEnvelope` with sensor, governance, swarm (lifecycle), and routing variants.
  - `HiveAggregator` attaches via native `subscribe`/`stream_iter`, fans in both streams to bounded queues, coalesces and sorts by timestamp, and never writes back.
  - Shared `start_hive_relay(publish)` relays envelopes as `hive` frames to the cockpit UDS; called on boot in `converged_headless` and the battle-test harness with symmetric teardown.
  - `ov hive` CLI verb and `ov_hive_panel` TUI with 100ms throttled rendering and graceful reconnect.

- **Tests**
  - Merge proof: 5 Trinity + 5 SSE events captured and emitted in perfect timestamp order, zero drops.
  - Read-only trip-wire (no publishes), non-blocking under flood, bridge-compatible payloads, and swarm lifecycle mapping.
  - Relay publishes `hive`-tagged frames, degraded start returns `None` (never raises), and an AST wiring pin ensures both hosts call `start_hive_relay` on boot.

<sup>Written for commit 41509ca45d79b90e19a1ae58448ec9cc56908214. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69988?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

