### PR TITLE
ov: handshake-depth readiness (ignite→attach race) + L0 zero-entropy social gate

### DIFF
--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -41,6 +41,7 @@ from __future__ import annotations
 import asyncio
 import os
 import plistlib
+import random
 import subprocess
 import sys
 import time
@@ -89,13 +90,23 @@ def _boot_wait_s() -> float:
 # ---------------------------------------------------------------------------
 
 
-async def probe_socket(path: Path, timeout: Optional[float] = None) -> str:
+async def probe_socket(
+    path: Path, timeout: Optional[float] = None, *, deep: bool = False,
+) -> str:
     """Classify the attach socket with a REAL bounded connect:
 
-    * ``"live"``   — something accepted (a daemon is home)
-    * ``"stale"``  — inode exists but connection refused/timed out
+    * ``"live"``    — something accepted (a daemon is home). With
+      ``deep=True``, ONLY when the server actually *served* its first
+      frame within the bound — the same application-level contract
+      ``CockpitAttachClient.connect`` consumes.
+    * ``"booting"`` — (deep only) the connection was accepted but no
+      frame arrived within the bound. This is NOT a ghost: a UDS
+      ``listen()`` backlog completes handshakes at the KERNEL level
+      even while a boot-starved event loop has yet to run ``accept()``
+      or write the hydration line. Callers must WAIT, never clean.
+    * ``"stale"``   — inode exists but connection refused/timed out
       (ghost of a violently-killed daemon)
-    * ``"absent"`` — no inode at all
+    * ``"absent"``  — no inode at all
 
     ``timeout`` overrides the env default for a STRICT live-validation
     bound (Phase 7 health handshake). Non-invasive: opens, confirms, and
@@ -104,21 +115,35 @@ async def probe_socket(path: Path, timeout: Optional[float] = None) -> str:
     try:
         if not path.exists():
             return "absent"
+        bound = timeout if timeout is not None else _probe_timeout_s()
         try:
-            _r, w = await asyncio.wait_for(
+            r, w = await asyncio.wait_for(
                 asyncio.open_unix_connection(path=str(path)),
-                timeout=timeout if timeout is not None else _probe_timeout_s(),
+                timeout=bound,
             )
-            try:
-                w.close()
-            except Exception:  # noqa: BLE001
-                pass
-            return "live"
         except (
             ConnectionRefusedError, ConnectionResetError,
             asyncio.TimeoutError, OSError,
         ):
             return "stale"
+        try:
+            if not deep:
+                return "live"
+            # Handshake depth: connection-established is a kernel fact;
+            # readiness is an APPLICATION fact. Demand the first served
+            # byte (the hydration frame's head) within the bound.
+            try:
+                first = await asyncio.wait_for(r.read(1), timeout=bound)
+            except asyncio.TimeoutError:
+                return "booting"
+            except (ConnectionResetError, OSError):
+                return "stale"
+            return "live" if first else "booting"
+        finally:
+            try:
+                w.close()
+            except Exception:  # noqa: BLE001
+                pass
     except Exception:  # noqa: BLE001
         return "stale" if path.exists() else "absent"
 
@@ -323,27 +348,57 @@ def spawn_daemon(
         return None
 
 
+def _backoff_min_s() -> float:
+    try:
+        raw = os.environ.get("JARVIS_OV_PROBE_BACKOFF_MIN_S", "")
+        return float(raw) if raw else 0.1
+    except (TypeError, ValueError):
+        return 0.1
+
+
+def _backoff_max_s() -> float:
+    try:
+        raw = os.environ.get("JARVIS_OV_PROBE_BACKOFF_MAX_S", "")
+        return float(raw) if raw else 2.0
+    except (TypeError, ValueError):
+        return 2.0
+
+
 async def await_socket(
     path: Path,
     *,
     on_tick: Optional[Callable[[float], None]] = None,
     deadline_s: Optional[float] = None,
 ) -> bool:
-    """Wait (bounded) for the daemon's bridge to bind, re-probing with
-    the zero-trust connect. ``on_tick(elapsed)`` drives the waking
+    """Wait (bounded) for the daemon's bridge to genuinely SERVE — each
+    re-probe is the deep application handshake (``probe_socket(deep=True)``),
+    never mere socket existence or a kernel-backlog accept, so ``True``
+    here can never be a weaker claim than what attach itself consumes.
+
+    Polling is a jittered exponential backoff (full jitter: each sleep is
+    ``uniform(min, delay)`` with ``delay`` doubling to an env-tunable
+    ceiling) — resource-frugal against a boot-starved daemon and never a
+    thundering probe train. ``on_tick(elapsed)`` drives the waking
     breadcrumb. NEVER raises."""
     deadline = deadline_s if deadline_s is not None else _boot_wait_s()
     start = time.monotonic()
+    delay = _backoff_min_s()
+    ceiling = max(_backoff_max_s(), delay)
     try:
         while (time.monotonic() - start) < deadline:
-            if await probe_socket(path) == "live":
+            if await probe_socket(path, deep=True) == "live":
                 return True
             if on_tick is not None:
                 try:
                     on_tick(time.monotonic() - start)
                 except Exception:  # noqa: BLE001
                     pass
-            await asyncio.sleep(0.5)
+            remaining = deadline - (time.monotonic() - start)
+            if remaining <= 0:
+                break
+            sleep_for = min(random.uniform(_backoff_min_s(), delay), remaining)
+            await asyncio.sleep(sleep_for)
+            delay = min(delay * 2, ceiling)
         return False
     except asyncio.CancelledError:
         raise
@@ -372,9 +427,28 @@ async def ensure_daemon(
             attach_socket_path,
         )
         path = attach_socket_path()
-        state = await probe_socket(path)
+        state = await probe_socket(path, deep=True)
         if state == "live":
             return True
+        if state == "booting":
+            # A daemon is home but boot-starved — its socket must NOT be
+            # cleaned and no second ignition raced. Wait for it to serve.
+            _say("⏺ organism already waking — waiting for it to serve")
+            last_beat_b = [-10.0]
+
+            def _tick_b(elapsed: float) -> None:
+                if elapsed - last_beat_b[0] >= 5.0:
+                    last_beat_b[0] = elapsed
+                    _say(f"⎿ organism waking · {int(elapsed)}s")
+
+            if await await_socket(path, on_tick=_tick_b):
+                _say("⏺ organism live — attaching")
+                return True
+            _say(
+                "⚠ the waking organism never served — "
+                "tail " + str(daemon_log_path()),
+            )
+            return False
         if state == "stale":
             _say("⎿ ghost socket from a dead organism — cleaning")
             clean_stale_socket(path)

--- a/backend/core/ouroboros/governance/chat_repl_dispatcher.py
+++ b/backend/core/ouroboros/governance/chat_repl_dispatcher.py
@@ -518,6 +518,12 @@ class ChatReplDispatcher:
         """Route the decision to the right executor method. Slice 3
         only invokes the executor when one is wired; Slice 4 wires
         a concrete impl."""
+        # L0 social short-circuit: the deterministic reply was minted at
+        # the orchestrator — return it directly. Deliberately ABOVE the
+        # executor gate: zero-cost even when no executor is wired, and no
+        # provider path can ever be evaluated for a SOCIAL turn.
+        if decision.action == "social_ack":
+            return str(decision.payload.get("reply", "") or "Hey.")
         executor = self.executor
         if executor is None:
             return None

--- a/backend/core/ouroboros/governance/conversation_orchestrator.py
+++ b/backend/core/ouroboros/governance/conversation_orchestrator.py
@@ -63,6 +63,27 @@ from backend.core.ouroboros.governance.intent_classifier import (
 logger = logging.getLogger(__name__)
 
 
+# L0 social acks — deterministic, zero-cost, persona-consistent. Selection
+# is a stable hash of the message text: the same greeting always gets the
+# same reply (auditable), different greetings vary. No provider is touched.
+_SOCIAL_ACKS: Tuple[str, ...] = (
+    "Hey. I'm listening — verbs or plain words both work.",
+    "Hi — the organism's live. What do you need?",
+    "Here. Type a verb, or just tell me what's on your mind.",
+    "Standing by — `/help` shows the verbs if you want them.",
+)
+
+
+def _social_reply(message: str) -> str:
+    """Stable per-message pick from the ack rotation. NEVER raises."""
+    try:
+        import hashlib
+        digest = hashlib.sha256(message.strip().lower().encode()).digest()
+        return _SOCIAL_ACKS[digest[0] % len(_SOCIAL_ACKS)]
+    except Exception:  # noqa: BLE001
+        return _SOCIAL_ACKS[0]
+
+
 # Per-session ring-buffer cap. Long conversations stay observable
 # without unbounded memory.
 MAX_TURNS_PER_SESSION: int = 32
@@ -371,6 +392,22 @@ class ConversationOrchestrator:
                 reasons=verdict.reasons,
                 payload={},
                 reason="empty input",
+                truncated=verdict.truncated,
+            )
+
+        if verdict.intent is ChatIntent.SOCIAL:
+            # L0 short-circuit: deterministic zero-cost ack. The reply is
+            # chosen here (stable per message text) so the executor layer
+            # stays a pure print — no provider, no session snapshot, no
+            # token spend anywhere downstream.
+            return ChatRoutingDecision(
+                action="social_ack",
+                intent=verdict.intent,
+                confidence=verdict.confidence,
+                reasons=verdict.reasons,
+                payload={"message": clipped,
+                         "reply": _social_reply(clipped)},
+                reason="L0 zero-entropy social gate",
                 truncated=verdict.truncated,
             )
 

--- a/backend/core/ouroboros/governance/intent_classifier.py
+++ b/backend/core/ouroboros/governance/intent_classifier.py
@@ -89,6 +89,7 @@ class ChatIntent(str, enum.Enum):
     EXPLORATION = "EXPLORATION"
     EXPLANATION = "EXPLANATION"
     CONTEXT_PASTE = "CONTEXT_PASTE"
+    SOCIAL = "SOCIAL"               # L0 zero-entropy greeting/ack — no model
 
 
 @dataclass(frozen=True)
@@ -196,6 +197,38 @@ _INDENT_LINE = re.compile(r"^[ \t]{2,}\S", re.MULTILINE)
 
 
 # ---------------------------------------------------------------------------
+# L0 zero-entropy social gate
+# ---------------------------------------------------------------------------
+
+# Anchored FULL-match: a greeting/ack word, optionally addressed to the
+# organism, optionally punctuated. "hi karen" matches; "hi, can you fix
+# the build" never does (unanchored tail text kills the match).
+_L0_SOCIAL = re.compile(
+    r"^\s*(?:"
+    r"hi|hiya|hey|heya|hello|yo|sup|howdy|greetings|"
+    r"gm|gn|good\s+(?:morning|afternoon|evening|night)|"
+    r"thanks|thank\s+you|thx|ty|"
+    r"ok|okay|kk|cool|nice|great|awesome|perfect|"
+    r"bye|goodbye|later|cya|"
+    r"ping|test"
+    r")"
+    r"(?:[\s,!.]+(?:karen|jarvis|ov|there))?"
+    r"[\s!.,?]*$",
+    re.IGNORECASE,
+)
+
+
+def _l0_max_chars() -> int:
+    """Entropy ceiling for the L0 gate (env-tunable, junk-safe)."""
+    import os
+    try:
+        raw = os.environ.get("JARVIS_CHAT_L0_MAX_CHARS", "")
+        return int(raw) if raw else 24
+    except (TypeError, ValueError):
+        return 24
+
+
+# ---------------------------------------------------------------------------
 # Classifier
 # ---------------------------------------------------------------------------
 
@@ -226,6 +259,19 @@ def classify(message: str) -> IntentClassification:
         return IntentClassification(
             intent=ChatIntent.EXPLANATION, confidence=0.0,
             reasons=("empty",), truncated=truncated,
+        )
+
+    # ---- L0 zero-entropy social gate (before EVERYTHING) ----
+    # An ultra-low-entropy greeting/ack carries no routable signal; the
+    # old path defaulted it into claude_query at conf=0.00 — the most
+    # expensive lane for the least information. Deterministic, anchored,
+    # length-bounded: the pipeline short-circuits without waking any
+    # model or touching a provider.
+    stripped = text.strip()
+    if len(stripped) <= _l0_max_chars() and _L0_SOCIAL.match(stripped):
+        return IntentClassification(
+            intent=ChatIntent.SOCIAL, confidence=1.0,
+            reasons=("l0_social_short_circuit",), truncated=truncated,
         )
 
     # ---- CONTEXT_PASTE first ----

--- a/tests/cli/test_thin_client.py
+++ b/tests/cli/test_thin_client.py
@@ -21,6 +21,15 @@ import pytest
 
 from backend.core.ouroboros.cli import thin_client
 
+
+def _serving_handler(reader, writer):
+    """Mirror of the REAL CockpitAttachBridge accept path: hydration frame
+    written immediately on connect."""
+    try:
+        writer.write(b'{"type":"hydration","status":{}}\n')
+    except Exception:
+        pass
+
 _REPO = Path(__file__).resolve().parents[2]
 
 
@@ -99,13 +108,12 @@ class TestStaleSocketDeadlock:
 
         def _fake_popen(argv, **kw):
             spawns.append((argv, kw))
-            # The "daemon" comes up: bind a REAL listener at the path.
-            srv = socket_mod.socket(
-                socket_mod.AF_UNIX, socket_mod.SOCK_STREAM,
-            )
-            srv.bind(str(path))
-            srv.listen(1)
-            spawns.append(srv)             # keep alive for the test
+            # The "daemon" comes up SERVING (the real cockpit contract:
+            # hydration on accept) — a bare listen() backlog would now be
+            # correctly classified "booting" by the deep probe, never live.
+            spawns.append(asyncio.ensure_future(
+                asyncio.start_unix_server(_serving_handler, path=str(path)),
+            ))
             return _FakeProc()
 
         status: list = []
@@ -147,8 +155,11 @@ class TestStaleSocketDeadlock:
     ):
         path = sock_dir / "a.sock"
         monkeypatch.setenv("JARVIS_ATTACH_IPC_SOCKET", str(path))
+        # Fixture mirrors the REAL cockpit contract: the server writes its
+        # hydration frame immediately on accept. (The old silent-accept
+        # fixture encoded the very false-positive the deep probe kills.)
         server = await asyncio.start_unix_server(
-            lambda r, w: None, path=str(path),
+            _serving_handler, path=str(path),
         )
         spawns: list = []
         try:
@@ -375,3 +386,128 @@ class TestCircadianLogJanitor:
             _REPO / "backend/core/ouroboros/governance/silent_boot.py"
         ).read_text()
         assert "RotatingFileHandler(" in src
+
+
+# ---------------------------------------------------------------------------
+# (4) Handshake-depth readiness — the ignite→attach race (Slice A)
+# ---------------------------------------------------------------------------
+
+
+class TestHandshakeDepthProbe:
+    async def test_backlog_accept_is_booting_not_live(self, sock_dir):
+        """THE root-cause pin: a UDS listen() backlog completes handshakes at
+        the kernel level even when the application never serves. The shallow
+        probe says "live" (kernel truth); the DEEP probe must say "booting"
+        (application truth) — the exact false-positive that printed
+        'organism live — attaching' then 'nothing to attach to'."""
+        path = sock_dir / "boot.sock"
+        server = await asyncio.start_unix_server(
+            lambda r, w: None, path=str(path),   # accepts, never serves
+        )
+        try:
+            assert await thin_client.probe_socket(path) == "live"
+            assert await thin_client.probe_socket(
+                path, timeout=0.3, deep=True) == "booting"
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_deep_probe_live_when_served(self, sock_dir):
+        path = sock_dir / "served.sock"
+        server = await asyncio.start_unix_server(
+            _serving_handler, path=str(path),
+        )
+        try:
+            assert await thin_client.probe_socket(
+                path, timeout=1.0, deep=True) == "live"
+        finally:
+            server.close()
+            await server.wait_closed()
+
+    async def test_refused_socket_backoff_retries_no_false_positive(
+        self, sock_dir, monkeypatch,
+    ):
+        """Mandate: a socket inode that refuses connections must be retried
+        with jittered exponential backoff — never a false-positive True,
+        never an exception."""
+        monkeypatch.setenv("JARVIS_OV_PROBE_BACKOFF_MIN_S", "0.02")
+        monkeypatch.setenv("JARVIS_OV_PROBE_BACKOFF_MAX_S", "0.08")
+        path = sock_dir / "refused.sock"
+        s = socket_mod.socket(socket_mod.AF_UNIX, socket_mod.SOCK_STREAM)
+        s.bind(str(path))
+        s.close()                              # inode remains; ECONNREFUSED
+        probes = []
+        real_probe = thin_client.probe_socket
+
+        async def _counting_probe(p, timeout=None, *, deep=False):
+            probes.append(deep)
+            return await real_probe(p, timeout, deep=deep)
+
+        monkeypatch.setattr(thin_client, "probe_socket", _counting_probe)
+        ok = await thin_client.await_socket(path, deadline_s=0.5)
+        assert ok is False                     # graceful, no exception
+        assert len(probes) >= 3                # backoff retried, not one-shot
+        assert all(probes)                     # every retry used the DEEP probe
+
+    async def test_backoff_delays_grow_with_jitter(self, sock_dir, monkeypatch):
+        """The polling cadence must widen (exponential ceiling) — no fixed-
+        interval probe train against a booting daemon."""
+        monkeypatch.setenv("JARVIS_OV_PROBE_BACKOFF_MIN_S", "0.01")
+        monkeypatch.setenv("JARVIS_OV_PROBE_BACKOFF_MAX_S", "0.16")
+        sleeps = []
+        real_sleep = asyncio.sleep
+
+        async def _spy_sleep(d):
+            sleeps.append(d)
+            await real_sleep(0)                # don't actually wait
+
+        monkeypatch.setattr(
+            "backend.core.ouroboros.cli.thin_client.asyncio.sleep", _spy_sleep)
+        path = sock_dir / "nothing.sock"       # absent → probes fast
+        await thin_client.await_socket(path, deadline_s=0.2)
+        assert len(sleeps) >= 3
+        # ceiling-bounded always (deadline clamping can only SHRINK a sleep)
+        assert all(d <= 0.16 + 1e-9 for d in sleeps)
+        # first window is degenerate uniform(min, min) — exactly the floor
+        assert abs(sleeps[0] - 0.01) < 1e-9
+        # growth: the sampling window widens past the first doubling, so the
+        # envelope must exceed the 0.01–0.02 band eventually
+        assert max(sleeps) > 0.02
+
+    async def test_ensure_daemon_waits_for_booting_never_cleans(
+        self, sock_dir, monkeypatch,
+    ):
+        """A boot-starved daemon (accepting, not yet serving) must be WAITED
+        for — its socket never cleaned, no second ignition raced."""
+        monkeypatch.setenv("JARVIS_ATTACH_IPC_SOCKET",
+                           str(sock_dir / "b.sock"))
+        monkeypatch.setenv("JARVIS_OV_PROBE_TIMEOUT_S", "0.2")
+        monkeypatch.setenv("JARVIS_OV_BOOT_WAIT_S", "5")   # clamp floor
+        monkeypatch.setenv("JARVIS_OV_PROBE_BACKOFF_MIN_S", "0.02")
+        monkeypatch.setenv("JARVIS_OV_PROBE_BACKOFF_MAX_S", "0.1")
+        path = sock_dir / "b.sock"
+        served = {"on": False}
+
+        def _handler(reader, writer):
+            if served["on"]:
+                _serving_handler(reader, writer)
+
+        server = await asyncio.start_unix_server(_handler, path=str(path))
+        spawns: list = []
+
+        async def _flip():                      # daemon "finishes booting"
+            await asyncio.sleep(0.3)
+            served["on"] = True
+
+        try:
+            flip = asyncio.ensure_future(_flip())
+            ok = await thin_client.ensure_daemon(
+                spawner=lambda *a, **k: spawns.append(a),
+            )
+            await flip
+            assert ok is True                  # waited through boot
+            assert spawns == []                # never raced a second ignition
+            assert path.exists()               # never cleaned the socket
+        finally:
+            server.close()
+            await server.wait_closed()

--- a/tests/governance/test_chat_repl_dispatcher.py
+++ b/tests/governance/test_chat_repl_dispatcher.py
@@ -654,3 +654,71 @@ def test_chat_action_executor_protocol_method_names():
     assert expected.issubset(actual), (
         f"Protocol shape changed; missing: {expected - actual}"
     )
+
+
+# ---------------------------------------------------------------------------
+# L0 zero-entropy social short-circuit (Slice A companion)
+# ---------------------------------------------------------------------------
+
+
+class TestL0SocialShortCircuit:
+    def test_hello_jarvis_classifies_social_conf_1(self):
+        from backend.core.ouroboros.governance.intent_classifier import (
+            ChatIntent, classify,
+        )
+        v = classify("hello jarvis")
+        assert v.intent is ChatIntent.SOCIAL
+        assert v.confidence == 1.0
+        assert "l0_social_short_circuit" in v.reasons
+
+    def test_greeting_variants_gate_and_substance_never_does(self):
+        from backend.core.ouroboros.governance.intent_classifier import (
+            ChatIntent, classify,
+        )
+        for msg in ("hi karen", "hey", "thanks!", "ok", "good morning",
+                    "yo ov", "ping"):
+            assert classify(msg).intent is ChatIntent.SOCIAL, msg
+        # substance must NEVER gate — anchored + length-bounded
+        for msg in ("hi, can you fix the build", "hello world program please",
+                    "thanks — now run the tests", "okay let's deploy"):
+            assert classify(msg).intent is not ChatIntent.SOCIAL, msg
+
+    def test_hello_jarvis_bypasses_llm_router_entirely(self):
+        """MANDATE: the L0 gate short-circuits BEFORE any executor/provider
+        is evaluated — a greeting yields a deterministic zero-cost reply
+        with the LLM executor untouched (no claude_query, no dispatch)."""
+        from backend.core.ouroboros.governance.conversation_orchestrator import (
+            ConversationOrchestrator,
+        )
+
+        class _ExplodingExecutor:
+            """Any provider call = test failure."""
+            def dispatch_backlog(self, *a, **k):
+                raise AssertionError("backlog dispatched for a greeting")
+
+            def spawn_subagent(self, *a, **k):
+                raise AssertionError("subagent spawned for a greeting")
+
+            def query_claude(self, *a, **k):
+                raise AssertionError("claude_query fired for a greeting")
+
+            def attach_context(self, *a, **k):
+                raise AssertionError("context attach fired for a greeting")
+
+        from backend.core.ouroboros.governance.chat_repl_dispatcher import (
+            ChatReplDispatcher,
+        )
+        orch = ConversationOrchestrator()
+        turn, decision = orch.dispatch("hello jarvis", session_id="s1")
+        assert decision.action == "social_ack"
+        assert decision.payload.get("reply")          # deterministic ack minted
+        disp = ChatReplDispatcher(orchestrator=orch)
+        disp.executor = _ExplodingExecutor()
+        result = disp._invoke_executor(turn, decision)
+        assert result == decision.payload["reply"]     # zero-cost passthrough
+
+    def test_social_reply_is_stable_per_message(self):
+        from backend.core.ouroboros.governance.conversation_orchestrator import (
+            _social_reply,
+        )
+        assert _social_reply("hi karen") == _social_reply("hi karen")

--- a/tests/governance/test_intent_classifier.py
+++ b/tests/governance/test_intent_classifier.py
@@ -82,11 +82,14 @@ def test_low_confidence_floor_pinned():
     assert LOW_CONFIDENCE_FLOOR == 0.40
 
 
-def test_chat_intent_has_four_values():
-    """Pin: PRD §9 P2 says three routing buckets + one for paste-as-
-    context. Adding a fifth requires a new slice + design doc."""
+def test_chat_intent_has_five_values():
+    """Pin: PRD §9 P2's three routing buckets + paste-as-context, plus the
+    operator-authorized L0 SOCIAL gate (2026-07-20 — zero-entropy greetings
+    short-circuit deterministically, no model). Adding a SIXTH requires a
+    new slice + design doc."""
     assert {i.name for i in ChatIntent} == {
         "ACTION_REQUEST", "EXPLORATION", "EXPLANATION", "CONTEXT_PASTE",
+        "SOCIAL",
     }
 
 


### PR DESCRIPTION
## Slice A — the ignite→attach race (live screenshot bug)

`ov` ignited the organism, printed **organism live — attaching**, then **nothing to attach to**. Root cause: a UDS `listen()` backlog completes handshakes at the **kernel** level, so `probe_socket`'s successful connect proved accept-ability — not service. `CockpitAttachClient.connect()` requires the **application** hydration frame, which a boot-starved event loop (3.5s+ measured starvation) can't serve in time.

- `probe_socket(deep=True)`: **live** only when the first served byte arrives within the bound — the exact contract attach consumes. New **booting** state for accepted-but-silent: a starved daemon is *waited for*, never cleaned as a ghost, never raced by a second ignition.
- `await_socket`: deep re-probe under **jittered exponential backoff** (full jitter, env-tunable floor/ceiling). No fixed-interval probe train; no sleep-as-readiness.
- Shallow default preserved — trinity_status / trinity_doctor / jarvis_thin untouched.
- Fixtures upgraded to mirror the real cockpit contract (hydration on accept); the old silent-accept fakes encoded the exact false positive.

## L0 zero-entropy social gate

`hi karen` → `claude_query` at conf=0.00 via `no_signal_default` — the most expensive lane for zero information. Now: `ChatIntent.SOCIAL` + anchored, length-bounded (env-tunable) gate at the top of `classify()`; deterministic stable-hash ack minted at the orchestrator; returned by the dispatcher **above** the executor gate, so no provider path is structurally reachable for a SOCIAL turn.

## Proof

Root-cause pin: backlog-accept classifies **booting**, not live. Refused socket: backoff retries, no false positive, never raises. Exploding-executor test: `hello jarvis` cannot touch the LLM router. Substance ("hi, can you fix the build") never gates. **390 green** across cli + chat-lane suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the ignite→attach readiness race by validating the application hydration frame before treating the daemon as live, and waits for a booting daemon instead of cleaning or re-igniting. Adds an L0 social gate that returns a deterministic greeting reply without touching any provider.

- **Bug Fixes**
  - `probe_socket(deep=True)` returns `live` only after the first served byte; adds a `booting` state for accepted-but-silent sockets.
  - `await_socket` re-probes deeply using jittered exponential backoff; no fixed-interval polling.
  - `ensure_daemon` waits on `booting`, avoids ghost cleanup and double ignition; shallow probing remains the default for diagnostics.
  - Tests/fixtures now write hydration on accept to mirror the real contract; adds coverage for booting classification and backoff.

- **New Features**
  - Adds `ChatIntent.SOCIAL` with an anchored, length-bounded gate in `classify()` (env-tunable), so greetings don’t hit models.
  - Orchestrator mints a stable-hash social ack; dispatcher returns it above the executor, making provider paths unreachable for SOCIAL turns.

<sup>Written for commit d4accf8be9388650877a1bed8c5d95b46b46ecec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

