### PR TITLE
ov doctor: 8-edge connectivity matrix + trace-isolated --live synthetic probe

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -116,6 +116,7 @@ class CockpitAttachBridge:
         status_provider: Optional[Callable[[], Dict[str, Any]]] = None,
         ops_provider: Optional[Callable[[], Any]] = None,
         liquidity_provider: Optional[Callable[[], Dict[str, Any]]] = None,
+        fabrics_provider: Optional[Callable[[], Dict[str, Any]]] = None,
         replay_provider: Optional[Callable[[], Any]] = None,
         on_input: Optional[Callable[[str], None]] = None,
         on_audio: Optional[Callable[[str], None]] = None,
@@ -124,6 +125,10 @@ class CockpitAttachBridge:
         self._status = status_provider or (lambda: {})
         self._ops = ops_provider or (lambda: [])
         self._liquidity = liquidity_provider or (lambda: {})
+        # ov doctor edge 4: hive-fabric attachment stats (trinity subs /
+        # sse / emitter). Pull-model like every other provider — consulted
+        # fresh at each handshake, zero authority.
+        self._fabrics = fabrics_provider or (lambda: {})
         # Slice H: zero-authority pull of the TrinityEventBus replay buffer —
         # the chronological critical telemetry flushed to a client on connect
         # so a late attach reconciles the DAG history, not just the snapshot.
@@ -210,6 +215,7 @@ class CockpitAttachBridge:
             "status": _safe(self._status, {}),
             "ops": _safe(self._ops, []),
             "liquidity": _safe(self._liquidity, {}),
+            "fabrics": _safe(self._fabrics, {}),
             "audio": {"state": self._audio_state},
         }
 

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4210,6 +4210,11 @@ class BattleTestHarness:
             # ProviderLiquidityLedger, exhaustion verdicts, and the
             # LiquidityPool lease economy.
             self._repl_cmd_liquidity()
+        elif cmd == "/doctor probe" or cmd == "doctor probe":
+            # ov doctor --live: the synthetic tool probe (trace-context
+            # isolated — zero state mutation anywhere) fired in-daemon;
+            # verdict relayed to every attached terminal.
+            await self._repl_cmd_doctor_probe()
         elif await self._try_dispatch_plugin_command(command.strip()):
             # Plugin-registered slash commands: /greet, /<plugin_cmd>, etc.
             # Returns True iff a plugin handled the command.
@@ -4225,6 +4230,30 @@ class BattleTestHarness:
             pass
         else:
             logger.debug("Unknown REPL command: %s", cmd)
+
+    async def _repl_cmd_doctor_probe(self) -> None:
+        """/doctor probe — ov doctor --live's in-daemon half. Fires ONE
+        real read-only web_search through the REAL ToolBackend under the
+        synthetic trace context (doctor_probe.py); the emitted actor_edge
+        frame + this verdict line travel back over the cockpit UDS to the
+        watching doctor. Fail-soft; NEVER raises."""
+        try:
+            from backend.core.ouroboros.governance.doctor_probe import (
+                run_synthetic_tool_probe,
+            )
+            self._repl_print("[doctor] synthetic probe firing (web_search, "
+                             "trace-isolated — no state mutation)")
+            verdict = await run_synthetic_tool_probe()
+            self._repl_print(
+                f"[doctor] probe {verdict.get('op_id', '?')}: "
+                f"status={verdict.get('status')} "
+                f"{verdict.get('duration_ms', 0):.0f}ms "
+                f"{verdict.get('detail', '')}".rstrip())
+        except Exception as exc:  # noqa: BLE001
+            try:
+                self._repl_print(f"[doctor] probe failed: {exc}")
+            except Exception:  # noqa: BLE001
+                pass
 
     def _repl_cmd_liquidity(self) -> None:
         """``/liquidity`` — circadian provider-runway dashboard.
@@ -4373,10 +4402,27 @@ class BattleTestHarness:
             from backend.core.ouroboros.battle_test.audio_synapse import (
                 AudioVisualSynapse,
             )
+            def _fabrics_provider() -> dict:
+                # ov doctor edge 4 — hive-fabric attachment truth, read
+                # fresh from the live aggregator at each handshake.
+                try:
+                    agg = getattr(self, "_hive_aggregator", None)
+                    if agg is None:
+                        return {}
+                    return {
+                        "trinity_subs": len(getattr(agg, "_sub_ids", []) or []),
+                        "sse": getattr(agg, "_sse_sub", None) is not None,
+                        "emitter": getattr(agg, "_emitter", None) is not None,
+                        "stats": dict(getattr(agg, "stats", {}) or {}),
+                    }
+                except Exception:  # noqa: BLE001
+                    return {}
+
             bridge = CockpitAttachBridge(
                 status_provider=_status_provider,
                 ops_provider=_ops_provider,
                 liquidity_provider=_liquidity_provider,
+                fabrics_provider=_fabrics_provider,
                 on_input=_on_input,
                 on_audio=lambda cmd: self._dispatch_audio_cmd(cmd),
             )

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -27,7 +27,8 @@ from typing import Any, Callable, List, Optional, Sequence
 
 from backend.core.ouroboros.ui.theme import build_console
 
-_VERBS = {"cockpit", "run", "daemon", "status", "attach", "system", "hive", "version"}
+_VERBS = {"cockpit", "run", "daemon", "status", "attach", "system", "hive",
+          "doctor", "version"}
 _HELP_TOKENS = {"help", "--help", "-h"}
 _VERSION_TOKENS = {"version", "--version", "-V"}
 
@@ -80,6 +81,8 @@ _HELP_TEXT = """ov -- Ouroboros + Venom, autonomous engineering organism
   ov daemon --install    install the resident organism (launchd agent)
   ov daemon --uninstall  remove the resident organism
   ov status           last-session digest (no boot)
+  ov doctor [--live]  8-edge connectivity matrix; --live fires the
+                      trace-isolated synthetic tool probe end-to-end
   ov attach           attach this terminal to the running organism
   ov version          version + milestone
   ov help             this message
@@ -138,6 +141,8 @@ def resolve(argv: Optional[Sequence[str]] = None) -> Invocation:
         return Invocation("system")
     if verb == "hive":
         return Invocation("hive")
+    if verb == "doctor":
+        return Invocation("doctor", list(rest))
     # cockpit (explicit or defaulted)
     return Invocation("cockpit", rest)
 
@@ -694,6 +699,13 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         return run_system(console)
     if inv.action == "hive":
         return run_hive(console)
+    if inv.action == "doctor":
+        try:
+            from backend.core.ouroboros.cli.ov_doctor import run_doctor
+        except Exception as exc:  # noqa: BLE001
+            console.print(f"ov doctor unavailable: {exc}", markup=False)
+            return 1
+        return run_doctor(console, live="--live" in inv.delegate_argv)
     if inv.action == "status":
         console.print(status_digest(), markup=False, highlight=False)
         return 0

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -705,6 +705,17 @@ def main(argv: Optional[Sequence[str]] = None) -> int:
         except Exception as exc:  # noqa: BLE001
             console.print(f"ov doctor unavailable: {exc}", markup=False)
             return 1
+        known = {"--live"}
+        for arg in inv.delegate_argv:
+            if arg not in known:
+                hint = next((k for k in known
+                             if k.startswith(arg) or arg.startswith(k)), None)
+                console.print(
+                    f"unknown flag {arg!r}"
+                    + (f" — did you mean {hint!r}?" if hint else
+                       f" (known: {', '.join(sorted(known))})"),
+                    markup=False, highlight=False)
+                return 64          # EX_USAGE — refuse, never silently ignore
         return run_doctor(console, live="--live" in inv.delegate_argv)
     if inv.action == "status":
         console.print(status_digest(), markup=False, highlight=False)

--- a/backend/core/ouroboros/cli/ov_doctor.py
+++ b/backend/core/ouroboros/cli/ov_doctor.py
@@ -144,6 +144,19 @@ async def probe_edge_socket() -> Tuple[EdgeVerdict, str]:
         )
         path = attach_socket_path()
         state = await probe_socket(path, timeout=_edge_timeout_s(), deep=True)
+        if state == "booting":
+            # Slice-A patience, applied to diagnosis: a boot-starved daemon
+            # is a WAIT state, not a verdict. Re-probe with the same
+            # jittered-backoff deep handshake the ignite path uses, under a
+            # doctor-bounded window — a transient never reads as a fault.
+            from backend.core.ouroboros.cli.thin_client import await_socket
+            try:
+                raw = os.environ.get("JARVIS_DOCTOR_BOOT_WAIT_S", "")
+                boot_wait = float(raw) if raw else 20.0
+            except (TypeError, ValueError):
+                boot_wait = 20.0
+            if await await_socket(path, deadline_s=boot_wait):
+                state = "live"
         mapping = {
             "live": (EdgeState.OK, "hydration served"),
             "booting": (EdgeState.DEGRADED,
@@ -452,12 +465,23 @@ async def run_live_probe() -> EdgeVerdict:
         # and only those daemons have the /doctor probe verb. An older
         # daemon gets NOTHING injected (no blind 45s wait, no unknown-verb
         # noise) — the doctor skips with the remedy instead.
+        # Read-timeout and old-daemon are DIFFERENT worlds: a starved boot
+        # serves nothing yet (wait and re-run), a genuinely old daemon
+        # serves hydration WITHOUT the fabrics signature (restart it).
+        # Conflating them misdiagnosed a current daemon as stale.
+        hydration: Optional[Dict[str, Any]] = None
         try:
             first = await asyncio.wait_for(
                 r.readline(), timeout=_edge_timeout_s())
-            hydration = json.loads(first.decode())
+            if first:
+                hydration = json.loads(first.decode())
         except Exception:  # noqa: BLE001
-            hydration = {}
+            hydration = None
+        if hydration is None:
+            return EdgeVerdict(
+                "9 live probe", EdgeState.DEGRADED,
+                "hydration not served within the bound (boot-starved?) — "
+                "re-run `ov doctor --live` in a moment")
         if "fabrics" not in hydration:
             return EdgeVerdict(
                 "9 live probe", EdgeState.SKIPPED,

--- a/backend/core/ouroboros/cli/ov_doctor.py
+++ b/backend/core/ouroboros/cli/ov_doctor.py
@@ -253,48 +253,62 @@ def _verdicts_from_hydration(
     return out
 
 
-async def _fetch_json(path: str) -> Optional[Any]:
-    """Minimal bounded HTTP/1.1 GET → parsed JSON body. NEVER raises."""
+async def _http_get(path: str) -> Tuple[Optional[int], Optional[Any]]:
+    """Minimal bounded HTTP/1.1 GET → (status_code, parsed_json|None).
+
+    ``(None, None)`` means the SERVER is unreachable (refused/timeout) —
+    a different fault class than a reachable server returning 404 (path
+    not mounted, e.g. a daemon predating the endpoint). NEVER raises."""
     host, port = _channel_host_port()
     try:
         r, w = await asyncio.wait_for(
             asyncio.open_connection(host=host, port=port),
             timeout=_edge_timeout_s(),
         )
-        try:
-            req = (f"GET {path} HTTP/1.1\r\nHost: {host}\r\n"
-                   "Connection: close\r\n\r\n")
-            w.write(req.encode())
-            await w.drain()
-            raw = await asyncio.wait_for(
-                r.read(262144), timeout=_edge_timeout_s())
-            head, _, body = raw.partition(b"\r\n\r\n")
-            if b" 200 " not in head.split(b"\r\n", 1)[0]:
-                return None
-            # tolerate chunked encoding by scanning for the JSON braces
-            text = body.decode(errors="replace").strip()
-            start = text.find("{")
-            end = text.rfind("}")
-            if start < 0 or end <= start:
-                return None
-            return json.loads(text[start:end + 1])
-        finally:
-            try:
-                w.close()
-            except Exception:  # noqa: BLE001
-                pass
     except Exception:  # noqa: BLE001
-        return None
+        return None, None
+    try:
+        req = (f"GET {path} HTTP/1.1\r\nHost: {host}\r\n"
+               "Connection: close\r\n\r\n")
+        w.write(req.encode())
+        await w.drain()
+        raw = await asyncio.wait_for(
+            r.read(262144), timeout=_edge_timeout_s())
+        status_line = raw.split(b"\r\n", 1)[0]
+        try:
+            code = int(status_line.split()[1])
+        except Exception:  # noqa: BLE001
+            code = 0
+        _head, _, body = raw.partition(b"\r\n\r\n")
+        if code != 200:
+            return code, None
+        # tolerate chunked encoding by scanning for the JSON braces
+        text = body.decode(errors="replace").strip()
+        start = text.find("{")
+        end = text.rfind("}")
+        if start < 0 or end <= start:
+            return code, None
+        return code, json.loads(text[start:end + 1])
+    except Exception:  # noqa: BLE001
+        return None, None
+    finally:
+        try:
+            w.close()
+        except Exception:  # noqa: BLE001
+            pass
 
 
 async def probe_edge_sensors() -> EdgeVerdict:
     """Edge 5: /channel/health — the REAL Gap-4 schema: top-level
     ``status`` + per-sensor blocks under ``*_sensor`` keys."""
-    data = await _fetch_json("/channel/health")
-    if data is None:
+    code, data = await _http_get("/channel/health")
+    if code is None:
         return EdgeVerdict("5 sensors", EdgeState.ABSENT,
                            "channel server unreachable "
                            f"({':'.join(map(str, _channel_host_port()))})")
+    if data is None:
+        return EdgeVerdict("5 sensors", EdgeState.DEGRADED,
+                           f"server up, /channel/health returned {code}")
     healthy = str(data.get("status", "")).lower() == "healthy"
     sensor_blocks = {k: v for k, v in data.items()
                      if k.endswith("_sensor") and isinstance(v, dict)}
@@ -310,10 +324,15 @@ async def probe_edge_sensors() -> EdgeVerdict:
 
 async def probe_edge_liveness() -> EdgeVerdict:
     """Edge 7: /observability/liveness (static ∩ runtime capabilities)."""
-    data = await _fetch_json("/observability/liveness")
-    if data is None:
+    code, data = await _http_get("/observability/liveness")
+    if code is None:
         return EdgeVerdict("7 liveness", EdgeState.ABSENT,
-                           "liveness endpoint unreachable")
+                           "channel server unreachable")
+    if data is None:
+        return EdgeVerdict(
+            "7 liveness", EdgeState.ABSENT,
+            f"server up, path not mounted ({code}) — daemon predates "
+            "the endpoint or the router is disabled")
     caps = data.get("capabilities") or data.get("liveness") or data
     if isinstance(caps, dict) and caps:
         dormant = [k for k, v in caps.items()
@@ -428,11 +447,22 @@ async def run_live_probe() -> EdgeVerdict:
         return EdgeVerdict("9 live probe", EdgeState.SEVERED,
                            f"could not attach: {str(exc)[:60]}")
     try:
-        # consume hydration first, then request the probe over the input lane
+        # consume hydration first — it is ALSO the capability signature:
+        # only daemons carrying tonight's code serve a ``fabrics`` block,
+        # and only those daemons have the /doctor probe verb. An older
+        # daemon gets NOTHING injected (no blind 45s wait, no unknown-verb
+        # noise) — the doctor skips with the remedy instead.
         try:
-            await asyncio.wait_for(r.readline(), timeout=_edge_timeout_s())
+            first = await asyncio.wait_for(
+                r.readline(), timeout=_edge_timeout_s())
+            hydration = json.loads(first.decode())
         except Exception:  # noqa: BLE001
-            pass
+            hydration = {}
+        if "fabrics" not in hydration:
+            return EdgeVerdict(
+                "9 live probe", EdgeState.SKIPPED,
+                "daemon predates /doctor probe (no fabrics capability "
+                "signature) — restart the organism to enable the live loop")
         w.write((json.dumps(
             {"type": "input", "text": "/doctor probe"},
             separators=(",", ":")) + "\n").encode())
@@ -518,6 +548,23 @@ def render_report(console: Any, report: DoctorReport) -> None:
         else:
             console.print(
                 f"● first broken edge: {broken.edge} — {broken.detail}",
+                markup=False, highlight=False)
+        # Version-skew synthesizer: the "older daemon" signature (edges 4/7/9
+        # each carrying a predates-hint) collapses into ONE actionable remedy
+        # instead of three puzzling rows.
+        stale_signs = [v for v in report.verdicts
+                       if "predates" in v.detail or "older daemon" in v.detail]
+        if stale_signs:
+            pid = ""
+            for v in report.verdicts:
+                if v.edge.startswith("1 ") and "pid" in v.detail:
+                    pid = v.detail.split("pid", 1)[1].strip().split(",")[0]
+                    break
+            console.print(
+                f"⚕ the running organism predates this client "
+                f"({len(stale_signs)} edge(s) affected) — restart it"
+                + (f" (kill {pid}; then `ov`)" if pid else " (`ov`)")
+                + " to load current capabilities",
                 markup=False, highlight=False)
     except Exception:  # noqa: BLE001
         for v in report.verdicts:

--- a/backend/core/ouroboros/cli/ov_doctor.py
+++ b/backend/core/ouroboros/cli/ov_doctor.py
@@ -1,0 +1,552 @@
+"""``ov doctor`` — the 8-edge full-chain connectivity matrix (Slice B/C).
+
+Every edge is asserted with the SAME probe its real consumer uses (the
+Slice-A law: no probe may be weaker than the contract it vouches for):
+
+  1 process   — an organism process exists (pgrep, bounded)
+  2 cockpit   — thin_client.probe_socket(deep=True): SERVING means the
+                hydration frame is actually served, not merely accepted
+  3 hydration — the frame parses; subsystem states read from it
+  4 fabrics   — hive aggregator attachment (trinity/sse/emitter) from the
+                hydration ``fabrics`` block (daemon-side pull provider)
+  5 sensors   — GET /channel/health (EventChannelServer)
+  6 providers — hydration ``liquidity`` block (DW=tokens lane, Claude=time
+                lane, J-Prime=sovereignty lane)
+  7 liveness  — GET /observability/liveness (Gap 2: static ∩ runtime)
+  8 mcp       — JARVIS_MCP_CONFIG declared servers (NEVER executed)
+
+Structure (mandate 1): edges 1+2 gate the chain; everything downstream
+that is structurally independent (hydration-read, channel-health,
+liveness, mcp-config) runs under ONE ``asyncio.gather`` — the command is
+as fast as its slowest probe, not the sum. Every probe is bounded, returns
+a typed enum, and NEVER raises. Exit codes: 0 all-green · 1 degraded ·
+2 chain severed (the FIRST broken edge is named).
+
+``--live`` (Slice C) additionally asks the daemon (over the cockpit input
+lane) to fire the trace-context-isolated synthetic web_search probe, then
+watches its own connection for the resulting synthetic ``actor_edge``
+frame — tool execution → Step 2 emitter → aggregator → UDS proven in one
+self-verifying loop, with zero state mutation daemon-side.
+"""
+from __future__ import annotations
+
+import asyncio
+import enum
+import json
+import os
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+
+class EdgeState(str, enum.Enum):
+    OK = "OK"                 # green — contract proven
+    DEGRADED = "DEGRADED"     # yellow — reachable but impaired
+    SEVERED = "SEVERED"       # red — the chain breaks here
+    SKIPPED = "SKIPPED"       # upstream severed — not probed
+    ABSENT = "ABSENT"         # optional surface not configured (neutral)
+
+
+@dataclass
+class EdgeVerdict:
+    edge: str
+    state: EdgeState
+    detail: str = ""
+    latency_ms: float = 0.0
+
+
+@dataclass
+class DoctorReport:
+    verdicts: List[EdgeVerdict] = field(default_factory=list)
+
+    @property
+    def exit_code(self) -> int:
+        states = [v.state for v in self.verdicts]
+        if EdgeState.SEVERED in states:
+            return 2
+        if EdgeState.DEGRADED in states:
+            return 1
+        return 0
+
+    @property
+    def first_broken(self) -> Optional[EdgeVerdict]:
+        for v in self.verdicts:
+            if v.state is EdgeState.SEVERED:
+                return v
+        for v in self.verdicts:
+            if v.state is EdgeState.DEGRADED:
+                return v
+        return None
+
+
+def _channel_host_port() -> Tuple[str, int]:
+    host = os.environ.get("JARVIS_CHANNEL_HOST", "127.0.0.1")
+    try:
+        port = int(os.environ.get("JARVIS_CHANNEL_PORT", "") or 8099)
+    except (TypeError, ValueError):
+        port = 8099
+    return host, port
+
+
+def _edge_timeout_s() -> float:
+    try:
+        raw = os.environ.get("JARVIS_DOCTOR_EDGE_TIMEOUT_S", "")
+        return float(raw) if raw else 3.0
+    except (TypeError, ValueError):
+        return 3.0
+
+
+async def _timed(coro: Any) -> Tuple[Any, float]:
+    t0 = time.monotonic()
+    out = await coro
+    return out, (time.monotonic() - t0) * 1000.0
+
+
+# ---------------------------------------------------------------------------
+# edge probes — each bounded, typed, NEVER raises
+# ---------------------------------------------------------------------------
+
+
+async def probe_edge_process() -> EdgeVerdict:
+    """Edge 1: a live organism process (harness or converged daemon)."""
+    try:
+        proc = await asyncio.wait_for(
+            asyncio.create_subprocess_exec(
+                "pgrep", "-f",
+                "ouroboros_battle_test|unified_supervisor.*--headless",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.DEVNULL,
+            ),
+            timeout=_edge_timeout_s(),
+        )
+        out, _ = await asyncio.wait_for(
+            proc.communicate(), timeout=_edge_timeout_s())
+        pids = [p for p in out.decode().split() if p.strip()]
+        if pids:
+            return EdgeVerdict("1 process", EdgeState.OK,
+                               f"pid {', '.join(pids[:3])}")
+        return EdgeVerdict("1 process", EdgeState.SEVERED,
+                           "no organism process")
+    except Exception as exc:  # noqa: BLE001
+        return EdgeVerdict("1 process", EdgeState.DEGRADED,
+                           f"probe error: {str(exc)[:60]}")
+
+
+async def probe_edge_socket() -> Tuple[EdgeVerdict, str]:
+    """Edge 2: the deep application handshake (Slice A's probe)."""
+    try:
+        from backend.core.ouroboros.cli.thin_client import (
+            probe_socket,
+        )
+        from backend.core.ouroboros.battle_test.cockpit_attach import (
+            attach_socket_path,
+        )
+        path = attach_socket_path()
+        state = await probe_socket(path, timeout=_edge_timeout_s(), deep=True)
+        mapping = {
+            "live": (EdgeState.OK, "hydration served"),
+            "booting": (EdgeState.DEGRADED,
+                        "accepting but not yet serving (boot-starved)"),
+            "stale": (EdgeState.SEVERED, "ghost socket (dead daemon)"),
+            "absent": (EdgeState.SEVERED, "no socket"),
+        }
+        es, detail = mapping.get(state, (EdgeState.SEVERED, state))
+        return EdgeVerdict("2 cockpit UDS", es,
+                           f"{detail} · {path}"), state
+    except Exception as exc:  # noqa: BLE001
+        return EdgeVerdict("2 cockpit UDS", EdgeState.SEVERED,
+                           f"probe error: {str(exc)[:60]}"), "error"
+
+
+async def _read_hydration() -> Optional[Dict[str, Any]]:
+    """One bounded connect + first-frame read + parse. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.cockpit_attach import (
+            attach_socket_path,
+        )
+        r, w = await asyncio.wait_for(
+            asyncio.open_unix_connection(path=str(attach_socket_path())),
+            timeout=_edge_timeout_s(),
+        )
+        try:
+            line = await asyncio.wait_for(
+                r.readline(), timeout=_edge_timeout_s())
+            return json.loads(line.decode())
+        finally:
+            try:
+                w.close()
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _verdicts_from_hydration(
+    payload: Optional[Dict[str, Any]],
+) -> List[EdgeVerdict]:
+    """Edges 3, 4, 6 — all read from ONE hydration frame (one connect)."""
+    if payload is None:
+        return [
+            EdgeVerdict("3 hydration", EdgeState.SEVERED, "no frame served"),
+            EdgeVerdict("4 hive fabrics", EdgeState.SKIPPED, "no hydration"),
+            EdgeVerdict("6 providers", EdgeState.SKIPPED, "no hydration"),
+        ]
+    out: List[EdgeVerdict] = []
+    # 3 — hydration content
+    status = payload.get("status") or {}
+    hyd = (status.get("hydration") or {}) if isinstance(status, dict) else {}
+    subs = hyd.get("subsystems") or {}
+    bad = [k for k, v in subs.items() if str(v) not in ("ok", "ready")]
+    if payload.get("type") != "hydration":
+        out.append(EdgeVerdict("3 hydration", EdgeState.DEGRADED,
+                               f"unexpected first frame {payload.get('type')}"))
+    elif bad:
+        out.append(EdgeVerdict("3 hydration", EdgeState.DEGRADED,
+                               "subsystems degraded: " + ", ".join(bad[:4])))
+    else:
+        loaded = hyd.get("loaded"), hyd.get("total")
+        out.append(EdgeVerdict(
+            "3 hydration", EdgeState.OK,
+            f"subsystems {loaded[0]}/{loaded[1]}" if loaded[0] is not None
+            else "frame parsed"))
+    # 4 — hive fabrics
+    fab = payload.get("fabrics") or {}
+    if not fab:
+        out.append(EdgeVerdict("4 hive fabrics", EdgeState.DEGRADED,
+                               "no fabrics block (older daemon?)"))
+    else:
+        tsubs = int(fab.get("trinity_subs", 0) or 0)
+        sse = bool(fab.get("sse"))
+        emitter = bool(fab.get("emitter"))
+        missing = [n for n, on in (("trinity", tsubs > 0), ("sse", sse),
+                                   ("emitter", emitter)) if not on]
+        detail = f"trinity_subs={tsubs} sse={sse} emitter={emitter}"
+        if not missing:
+            out.append(EdgeVerdict("4 hive fabrics", EdgeState.OK, detail))
+        elif missing == ["trinity"]:
+            out.append(EdgeVerdict(
+                "4 hive fabrics", EdgeState.DEGRADED,
+                detail + " (bus not yet materialized — re-attach pending)"))
+        else:
+            out.append(EdgeVerdict("4 hive fabrics", EdgeState.DEGRADED,
+                                   detail + " missing: " + ",".join(missing)))
+    # 6 — providers (DW = tokens lane · Claude = time lane · J-Prime =
+    # sovereignty lane)
+    liq = payload.get("liquidity") or {}
+    providers = liq.get("providers") or {}
+    if not providers:
+        out.append(EdgeVerdict("6 providers", EdgeState.DEGRADED,
+                               "no liquidity data in hydration"))
+    else:
+        rows = []
+        exhausted = bool(liq.get("any_exhausted"))
+        for name, row in list(providers.items())[:4]:
+            tok = (row or {}).get("tokens_remaining")
+            rows.append(f"{name}:{tok:,}" if isinstance(tok, int)
+                        else f"{name}:?")
+        out.append(EdgeVerdict(
+            "6 providers",
+            EdgeState.DEGRADED if exhausted else EdgeState.OK,
+            (" ".join(rows) + (" · RUNWAY EXHAUSTED" if exhausted else "")),
+        ))
+    return out
+
+
+async def _fetch_json(path: str) -> Optional[Any]:
+    """Minimal bounded HTTP/1.1 GET → parsed JSON body. NEVER raises."""
+    host, port = _channel_host_port()
+    try:
+        r, w = await asyncio.wait_for(
+            asyncio.open_connection(host=host, port=port),
+            timeout=_edge_timeout_s(),
+        )
+        try:
+            req = (f"GET {path} HTTP/1.1\r\nHost: {host}\r\n"
+                   "Connection: close\r\n\r\n")
+            w.write(req.encode())
+            await w.drain()
+            raw = await asyncio.wait_for(
+                r.read(262144), timeout=_edge_timeout_s())
+            head, _, body = raw.partition(b"\r\n\r\n")
+            if b" 200 " not in head.split(b"\r\n", 1)[0]:
+                return None
+            # tolerate chunked encoding by scanning for the JSON braces
+            text = body.decode(errors="replace").strip()
+            start = text.find("{")
+            end = text.rfind("}")
+            if start < 0 or end <= start:
+                return None
+            return json.loads(text[start:end + 1])
+        finally:
+            try:
+                w.close()
+            except Exception:  # noqa: BLE001
+                pass
+    except Exception:  # noqa: BLE001
+        return None
+
+
+async def probe_edge_sensors() -> EdgeVerdict:
+    """Edge 5: /channel/health — the REAL Gap-4 schema: top-level
+    ``status`` + per-sensor blocks under ``*_sensor`` keys."""
+    data = await _fetch_json("/channel/health")
+    if data is None:
+        return EdgeVerdict("5 sensors", EdgeState.ABSENT,
+                           "channel server unreachable "
+                           f"({':'.join(map(str, _channel_host_port()))})")
+    healthy = str(data.get("status", "")).lower() == "healthy"
+    sensor_blocks = {k: v for k, v in data.items()
+                     if k.endswith("_sensor") and isinstance(v, dict)}
+    wired = sum(1 for v in sensor_blocks.values() if v.get("wired"))
+    total_events = data.get("total_events", 0)
+    detail = (f"{wired}/{len(sensor_blocks)} webhook sensor(s) wired · "
+              f"{total_events} events routed")
+    if healthy:
+        return EdgeVerdict("5 sensors", EdgeState.OK, detail)
+    return EdgeVerdict("5 sensors", EdgeState.DEGRADED,
+                       f"status={data.get('status')} · {detail}")
+
+
+async def probe_edge_liveness() -> EdgeVerdict:
+    """Edge 7: /observability/liveness (static ∩ runtime capabilities)."""
+    data = await _fetch_json("/observability/liveness")
+    if data is None:
+        return EdgeVerdict("7 liveness", EdgeState.ABSENT,
+                           "liveness endpoint unreachable")
+    caps = data.get("capabilities") or data.get("liveness") or data
+    if isinstance(caps, dict) and caps:
+        dormant = [k for k, v in caps.items()
+                   if isinstance(v, (str, dict))
+                   and "dormant" in str(v).lower()][:3]
+        if dormant:
+            return EdgeVerdict("7 liveness", EdgeState.DEGRADED,
+                               "dormant: " + ", ".join(dormant))
+        return EdgeVerdict("7 liveness", EdgeState.OK,
+                           f"{len(caps)} capabilities reported")
+    return EdgeVerdict("7 liveness", EdgeState.DEGRADED, "empty response")
+
+
+async def probe_edge_mcp() -> EdgeVerdict:
+    """Edge 8: MCP server CONFIGURATION only — never executed."""
+    cfg = os.environ.get("JARVIS_MCP_CONFIG", "").strip()
+    if not cfg:
+        return EdgeVerdict("8 mcp servers", EdgeState.ABSENT,
+                           "JARVIS_MCP_CONFIG unset")
+    p = Path(cfg)
+    if not p.exists():
+        return EdgeVerdict("8 mcp servers", EdgeState.SEVERED,
+                           f"config path missing: {cfg}")
+    try:
+        import yaml  # lazy — only when a config is declared
+        data = yaml.safe_load(p.read_text()) or {}
+        servers = data.get("servers") or data.get("mcp_servers") or []
+        n = len(servers) if isinstance(servers, (list, dict)) else 0
+        return EdgeVerdict("8 mcp servers", EdgeState.OK,
+                           f"{n} server(s) declared (config only — "
+                           "never executed by doctor)")
+    except Exception as exc:  # noqa: BLE001
+        return EdgeVerdict("8 mcp servers", EdgeState.DEGRADED,
+                           f"config unparseable: {str(exc)[:60]}")
+
+
+# ---------------------------------------------------------------------------
+# the matrix
+# ---------------------------------------------------------------------------
+
+
+async def run_matrix() -> DoctorReport:
+    """Edges 1+2 gate; every independent downstream probe runs in ONE
+    gather. NEVER raises."""
+    report = DoctorReport()
+    (v1, l1), ((v2, sock_state), l2) = await asyncio.gather(
+        _timed(probe_edge_process()), _timed(probe_edge_socket()))
+    v1.latency_ms, v2.latency_ms = l1, l2
+    report.verdicts.append(v1)
+    report.verdicts.append(v2)
+
+    if sock_state == "live":
+        (hyd, lh), (v5, l5), (v7, l7), (v8, l8) = await asyncio.gather(
+            _timed(_read_hydration()),
+            _timed(probe_edge_sensors()),
+            _timed(probe_edge_liveness()),
+            _timed(probe_edge_mcp()),
+        )
+        hydration_verdicts = _verdicts_from_hydration(hyd)
+        for v in hydration_verdicts:
+            v.latency_ms = lh / max(1, len(hydration_verdicts))
+        v5.latency_ms, v7.latency_ms, v8.latency_ms = l5, l7, l8
+        # canonical edge order: 3,4,5,6,7,8
+        e3, e4, e6 = hydration_verdicts
+        report.verdicts.extend([e3, e4, v5, e6, v7, v8])
+    else:
+        # chain severed at the socket — probe the independent HTTP/static
+        # edges anyway (they may localize the fault), skip the UDS-bound ones.
+        (v5, l5), (v7, l7), (v8, l8) = await asyncio.gather(
+            _timed(probe_edge_sensors()),
+            _timed(probe_edge_liveness()),
+            _timed(probe_edge_mcp()),
+        )
+        v5.latency_ms, v7.latency_ms, v8.latency_ms = l5, l7, l8
+        report.verdicts.extend([
+            EdgeVerdict("3 hydration", EdgeState.SKIPPED, "socket not serving"),
+            EdgeVerdict("4 hive fabrics", EdgeState.SKIPPED,
+                        "socket not serving"),
+            v5,
+            EdgeVerdict("6 providers", EdgeState.SKIPPED, "socket not serving"),
+            v7, v8,
+        ])
+    return report
+
+
+# ---------------------------------------------------------------------------
+# --live (Slice C): the synthetic probe loop
+# ---------------------------------------------------------------------------
+
+
+def _live_wait_s() -> float:
+    try:
+        raw = os.environ.get("JARVIS_DOCTOR_LIVE_WAIT_S", "")
+        return float(raw) if raw else 45.0
+    except (TypeError, ValueError):
+        return 45.0
+
+
+async def run_live_probe() -> EdgeVerdict:
+    """Ask the daemon to fire the trace-isolated synthetic web_search, then
+    watch THIS connection for the synthetic actor_edge frame. Proves tool
+    execution → emitter → aggregator → cockpit end-to-end. NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.cockpit_attach import (
+            attach_socket_path,
+        )
+        r, w = await asyncio.wait_for(
+            asyncio.open_unix_connection(path=str(attach_socket_path())),
+            timeout=_edge_timeout_s(),
+        )
+    except Exception as exc:  # noqa: BLE001
+        return EdgeVerdict("9 live probe", EdgeState.SEVERED,
+                           f"could not attach: {str(exc)[:60]}")
+    try:
+        # consume hydration first, then request the probe over the input lane
+        try:
+            await asyncio.wait_for(r.readline(), timeout=_edge_timeout_s())
+        except Exception:  # noqa: BLE001
+            pass
+        w.write((json.dumps(
+            {"type": "input", "text": "/doctor probe"},
+            separators=(",", ":")) + "\n").encode())
+        await w.drain()
+        deadline = time.monotonic() + _live_wait_s()
+        saw_verdict_line = ""
+        while time.monotonic() < deadline:
+            remaining = deadline - time.monotonic()
+            try:
+                line = await asyncio.wait_for(
+                    r.readline(), timeout=max(0.1, remaining))
+            except asyncio.TimeoutError:
+                break
+            if not line:
+                return EdgeVerdict("9 live probe", EdgeState.SEVERED,
+                                   "daemon closed the connection mid-probe")
+            try:
+                frame = json.loads(line.decode())
+            except Exception:  # noqa: BLE001
+                continue
+            payload = frame.get("payload") if isinstance(
+                frame.get("payload"), dict) else frame
+            detail = payload.get("detail") or {}
+            if (payload.get("hive")
+                    and (detail.get("trace_class") == "synthetic_probe"
+                         or "[synthetic probe]" in str(
+                             payload.get("action_summary", "")))):
+                return EdgeVerdict(
+                    "9 live probe", EdgeState.OK,
+                    "synthetic actor_edge frame observed — tool → emitter "
+                    "→ aggregator → cockpit proven "
+                    f"({payload.get('action_summary', '')[:60]})")
+            text = str(frame.get("text", ""))
+            if "[doctor] probe" in text:
+                saw_verdict_line = text
+        if saw_verdict_line:
+            return EdgeVerdict(
+                "9 live probe", EdgeState.DEGRADED,
+                "daemon ran the probe but no synthetic actor_edge frame "
+                f"arrived in {_live_wait_s():.0f}s ({saw_verdict_line[:60]})")
+        return EdgeVerdict(
+            "9 live probe", EdgeState.SEVERED,
+            f"no probe response within {_live_wait_s():.0f}s "
+            "(daemon may not support /doctor probe)")
+    finally:
+        try:
+            w.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+
+# ---------------------------------------------------------------------------
+# Rich rendering (ov console idiom) + entry point
+# ---------------------------------------------------------------------------
+
+_STATE_STYLE = {
+    EdgeState.OK: "green", EdgeState.DEGRADED: "yellow",
+    EdgeState.SEVERED: "red", EdgeState.SKIPPED: "dim",
+    EdgeState.ABSENT: "dim",
+}
+
+
+def render_report(console: Any, report: DoctorReport) -> None:
+    """Rich table in the ov cockpit idiom. NEVER raises."""
+    try:
+        from rich.table import Table
+        table = Table(title="ov doctor — full-chain connectivity",
+                      title_justify="left", expand=False)
+        table.add_column("edge", no_wrap=True)
+        table.add_column("state", no_wrap=True)
+        table.add_column("detail")
+        table.add_column("ms", justify="right", style="dim")
+        for v in report.verdicts:
+            table.add_row(
+                v.edge,
+                f"[{_STATE_STYLE.get(v.state, 'white')}]{v.state.value}[/]",
+                v.detail, f"{v.latency_ms:.0f}")
+        console.print(table)
+        broken = report.first_broken
+        if broken is None:
+            console.print("● chain green — all edges proven",
+                          markup=False, highlight=False)
+        else:
+            console.print(
+                f"● first broken edge: {broken.edge} — {broken.detail}",
+                markup=False, highlight=False)
+    except Exception:  # noqa: BLE001
+        for v in report.verdicts:
+            try:
+                console.print(f"{v.edge}: {v.state.value} — {v.detail}",
+                              markup=False, highlight=False)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+def run_doctor(console: Any, *, live: bool = False) -> int:
+    """The ov verb entry. Returns the exit code. NEVER raises."""
+    async def _run() -> int:
+        report = await run_matrix()
+        if live:
+            v = await run_live_probe()
+            report.verdicts.append(v)
+        render_report(console, report)
+        return report.exit_code
+
+    try:
+        return asyncio.run(_run())
+    except KeyboardInterrupt:
+        return 130
+    except Exception:  # noqa: BLE001
+        return 2
+
+
+__all__ = [
+    "EdgeState", "EdgeVerdict", "DoctorReport", "run_matrix",
+    "run_live_probe", "run_doctor", "render_report",
+]

--- a/backend/core/ouroboros/governance/consciousness_bridge.py
+++ b/backend/core/ouroboros/governance/consciousness_bridge.py
@@ -155,6 +155,20 @@ class ConsciousnessBridge:
         """
         if self._consciousness is None:
             return
+        # Trace Context Isolation (ov doctor --live): a synthetic probe must
+        # traverse the observability fabrics but NEVER mutate state — the
+        # MemoryEngine write path short-circuits structurally on the flag.
+        try:
+            from backend.core.ouroboros.governance.doctor_probe import (
+                is_synthetic_trace,
+            )
+            if is_synthetic_trace(op_id=op_id):
+                logger.debug(
+                    "[ConsciousnessBridge] synthetic probe %s — state "
+                    "write skipped (trace-context guard)", op_id)
+                return
+        except Exception:  # noqa: BLE001
+            pass
         # Idempotency chokepoint: an op may cross BOTH terminal seams (GLS
         # _emit_terminal_events for inline ops, _bg_unregister_active for
         # background-pool ops) — reputation must ingest exactly once.

--- a/backend/core/ouroboros/governance/doctor_probe.py
+++ b/backend/core/ouroboros/governance/doctor_probe.py
@@ -1,0 +1,156 @@
+"""Synthetic diagnostic probe — the daemon-side half of ``ov doctor --live``.
+
+Fires ONE real, read-only ``web_search`` through the REAL governance
+ToolBackend under a strict Trace Context protocol, then emits the traversal
+edges every consumer can observe — WITHOUT any state mutation anywhere:
+
+  * TRACE CONTEXT (mandate 2): every artifact of the probe carries
+    ``trace_class="synthetic_probe"`` and an op_id under the
+    ``doctor-probe-`` prefix. Stateful subsystems (ConsciousnessBridge →
+    MemoryEngine) inspect for the flag and structurally no-op.
+  * OBSERVABILITY EDGES: the probe emits the SAME ``actor_edge`` envelope
+    shape the Step 2 tool shim produces (subsystem="web", intent
+    "tool_call") — tagged synthetic — so the full emitter → aggregator →
+    cockpit chain is exercised end-to-end; plus a best-effort
+    ``command.doctor_probe_completed`` TrinityEventBus event so the bus
+    fabric broadcasts the traversal too.
+  * NO ACTUATION: ``web_search`` is a read-only capability. MCP servers are
+    NEVER executed by the probe (configuration is reported by the doctor's
+    static edge instead) — the actuator short-circuit applied at its
+    strongest.
+
+Bounded, NEVER raises, and returns a structured verdict dict the REPL verb
+relays to attached ``ov doctor --live`` watchers.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+import uuid
+from typing import Any, Dict
+
+logger = logging.getLogger("Ouroboros.DoctorProbe")
+
+#: The trace-context flag every synthetic artifact carries (mandate 2).
+TRACE_CLASS_SYNTHETIC = "synthetic_probe"
+
+#: op_id prefix — a second, structural marker (guards match EITHER).
+SYNTHETIC_OP_PREFIX = "doctor-probe-"
+
+
+def _probe_timeout_s() -> float:
+    try:
+        raw = os.environ.get("JARVIS_DOCTOR_PROBE_TIMEOUT_S", "")
+        return float(raw) if raw else 20.0
+    except (TypeError, ValueError):
+        return 20.0
+
+
+def is_synthetic_trace(*, op_id: str = "", trace_class: str = "") -> bool:
+    """The ONE trace-inspection predicate every stateful seam reuses."""
+    try:
+        return (trace_class == TRACE_CLASS_SYNTHETIC
+                or str(op_id).startswith(SYNTHETIC_OP_PREFIX))
+    except Exception:  # noqa: BLE001
+        return False
+
+
+async def run_synthetic_tool_probe(tool_backend: Any = None) -> Dict[str, Any]:
+    """Execute the synthetic ``web_search`` probe. Returns a verdict dict:
+    ``{"ok": bool, "op_id", "duration_ms", "status", "detail"}``.
+
+    ``tool_backend`` is injectable for tests; when None the probe resolves
+    the process ToolBackend lazily. NEVER raises.
+    """
+    op_id = f"{SYNTHETIC_OP_PREFIX}{uuid.uuid4().hex[:12]}"
+    started = time.monotonic()
+    verdict: Dict[str, Any] = {
+        "ok": False, "op_id": op_id, "duration_ms": 0.0,
+        "status": "not_run", "detail": "",
+        "trace_class": TRACE_CLASS_SYNTHETIC,
+    }
+    try:
+        from pathlib import Path
+
+        from backend.core.ouroboros.governance.tool_executor import (
+            AsyncProcessToolBackend, PolicyContext, ToolCall,
+        )
+        backend = tool_backend
+        if backend is None:
+            try:
+                backend = AsyncProcessToolBackend(asyncio.Semaphore(1))
+            except Exception as exc:  # noqa: BLE001
+                verdict["status"] = "backend_unavailable"
+                verdict["detail"] = str(exc)[:160]
+                return verdict
+
+        call = ToolCall(
+            name="web_search",
+            arguments={"query": "example.com connectivity probe"},
+        )
+        policy_ctx = PolicyContext(
+            repo="jarvis", repo_root=Path(os.getcwd()), op_id=op_id,
+            call_id=f"{op_id}:r0:web_search", round_index=0,
+        )
+        deadline = time.monotonic() + _probe_timeout_s()
+        try:
+            result = await asyncio.wait_for(
+                backend.execute_async(call, policy_ctx, deadline),
+                timeout=_probe_timeout_s() + 2.0)
+            status = str(getattr(
+                getattr(result, "status", ""), "value",
+                getattr(result, "status", "")) or "unknown")
+            out_bytes = len((getattr(result, "output", "") or "").encode())
+            verdict["status"] = status
+            verdict["ok"] = "success" in status.lower()
+            verdict["detail"] = f"{out_bytes}B"
+        except asyncio.TimeoutError:
+            verdict["status"] = "timeout"
+        except Exception as exc:  # noqa: BLE001
+            verdict["status"] = "exec_error"
+            verdict["detail"] = str(exc)[:160]
+
+        verdict["duration_ms"] = round((time.monotonic() - started) * 1000, 1)
+
+        # ---- observability edges (both fabrics, both tagged synthetic) ----
+        try:
+            from backend.api.hive_emitter import hive_emit
+            hive_emit(
+                actor_id="web.search", subsystem="web", intent="tool_call",
+                summary=(f"[synthetic probe] web_search {verdict['status']} "
+                         f"{verdict['duration_ms']:.0f}ms"),
+                severity="info" if verdict["ok"] else "warn",
+                trace_id=op_id,
+                detail={"trace_class": TRACE_CLASS_SYNTHETIC,
+                        "status": verdict["status"],
+                        "duration_ms": verdict["duration_ms"]},
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        try:
+            from backend.core.trinity_event_bus import get_event_bus_if_exists
+            bus = get_event_bus_if_exists()
+            if bus is not None:
+                await bus.publish_raw(
+                    "command.doctor_probe_completed",
+                    {"op_id": op_id, "trace_class": TRACE_CLASS_SYNTHETIC,
+                     "status": verdict["status"],
+                     "duration_ms": verdict["duration_ms"], "ts": time.time()},
+                    persist=False,
+                )
+        except Exception:  # noqa: BLE001
+            pass
+
+        return verdict
+    except Exception as exc:  # noqa: BLE001
+        verdict["status"] = "probe_error"
+        verdict["detail"] = str(exc)[:160]
+        return verdict
+
+
+__all__ = [
+    "TRACE_CLASS_SYNTHETIC", "SYNTHETIC_OP_PREFIX",
+    "is_synthetic_trace", "run_synthetic_tool_probe",
+]

--- a/tests/cli/test_ov_doctor.py
+++ b/tests/cli/test_ov_doctor.py
@@ -199,7 +199,8 @@ async def test_live_probe_observes_synthetic_frame(sock_dir, monkeypatch):
     monkeypatch.setenv("JARVIS_DOCTOR_LIVE_WAIT_S", "5")
 
     async def _daemon(reader, writer):
-        writer.write(b'{"type":"hydration","status":{}}\n')
+        writer.write(
+            b'{"type":"hydration","status":{},"fabrics":{"sse":true}}\n')
         line = await reader.readline()
         frame = json.loads(line.decode())
         assert frame == {"type": "input", "text": "/doctor probe"}
@@ -233,7 +234,8 @@ async def test_live_probe_degrades_when_probe_ran_but_no_frame(
     monkeypatch.setenv("JARVIS_DOCTOR_LIVE_WAIT_S", "1")
 
     async def _daemon(reader, writer):
-        writer.write(b'{"type":"hydration","status":{}}\n')
+        writer.write(
+            b'{"type":"hydration","status":{},"fabrics":{"sse":true}}\n')
         await reader.readline()
         writer.write(b'{"type":"line","text":"[doctor] probe x: status=y"}\n')
         await writer.drain()
@@ -256,3 +258,50 @@ def test_render_never_raises_on_minimal_console():
 
     ov_doctor.render_report(_C(), DoctorReport(verdicts=[
         EdgeVerdict("1 process", EdgeState.OK, "pid 1")]))
+
+
+@pytest.mark.asyncio
+async def test_live_probe_capability_gated_on_old_daemon(sock_dir, monkeypatch):
+    """An old daemon (no fabrics signature in hydration) gets NOTHING
+    injected — instant SKIPPED with the restart remedy, no blind wait."""
+    path = sock_dir / "cockpit_attach.sock"
+    monkeypatch.setenv("JARVIS_ATTACH_IPC_SOCKET", str(path))
+    received = []
+
+    async def _old_daemon(reader, writer):
+        writer.write(b'{"type":"hydration","status":{}}\n')   # no fabrics
+        await writer.drain()
+        line = await reader.readline()
+        if line:
+            received.append(line)
+
+    server = await asyncio.start_unix_server(_old_daemon, path=str(path))
+    try:
+        t0 = asyncio.get_running_loop().time()
+        v = await ov_doctor.run_live_probe()
+        elapsed = asyncio.get_running_loop().time() - t0
+        assert v.state is EdgeState.SKIPPED
+        assert "predates /doctor probe" in v.detail
+        assert elapsed < 3.0                    # instant, not a 45s wait
+        assert received == []                   # NOTHING was injected
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def test_version_skew_synthesizer_names_the_remedy():
+    lines = []
+
+    class _C:
+        def print(self, msg, **kw):
+            lines.append(str(msg))
+
+    ov_doctor.render_report(_C(), DoctorReport(verdicts=[
+        EdgeVerdict("1 process", EdgeState.OK, "pid 4765"),
+        EdgeVerdict("4 hive fabrics", EdgeState.DEGRADED,
+                    "no fabrics block (older daemon?)"),
+        EdgeVerdict("9 live probe", EdgeState.SKIPPED,
+                    "daemon predates /doctor probe"),
+    ]))
+    remedy = [ln for ln in lines if "restart it" in ln]
+    assert remedy and "kill 4765" in remedy[0]

--- a/tests/cli/test_ov_doctor.py
+++ b/tests/cli/test_ov_doctor.py
@@ -1,0 +1,258 @@
+"""ov doctor — the 8-edge connectivity matrix (Slice B) + --live loop (C)."""
+from __future__ import annotations
+
+import asyncio
+import json
+import shutil
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.cli import ov_doctor
+from backend.core.ouroboros.cli.ov_doctor import (
+    DoctorReport, EdgeState, EdgeVerdict, _verdicts_from_hydration,
+)
+
+
+@pytest.fixture()
+def sock_dir():
+    d = Path(tempfile.mkdtemp(prefix="ovdoc-"))
+    yield d
+    shutil.rmtree(d, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# hydration-derived edges (3, 4, 6)
+# ---------------------------------------------------------------------------
+
+
+def _payload(**over):
+    base = {
+        "type": "hydration",
+        "status": {"hydration": {"subsystems": {"governance_bridge": "ok",
+                                                "ouroboros_daemon": "ok"},
+                                 "loaded": 2, "total": 2}},
+        "fabrics": {"trinity_subs": 10, "sse": True, "emitter": True,
+                    "stats": {}},
+        "liquidity": {"providers": {"anthropic": {"tokens_remaining": 11978000},
+                                    "doubleword": {"tokens_remaining": 500000}},
+                      "any_exhausted": False},
+    }
+    base.update(over)
+    return base
+
+
+def test_full_hydration_yields_three_ok_edges():
+    e3, e4, e6 = _verdicts_from_hydration(_payload())
+    assert (e3.state, e4.state, e6.state) == (
+        EdgeState.OK, EdgeState.OK, EdgeState.OK)
+    assert "trinity_subs=10" in e4.detail
+    assert "anthropic:11,978,000" in e6.detail
+
+
+def test_trinity_pending_is_degraded_not_severed():
+    """trinity_subs=0 = the lazy-bus window — degraded with the re-attach
+    note, never a red herring."""
+    p = _payload(fabrics={"trinity_subs": 0, "sse": True, "emitter": True})
+    _, e4, _ = _verdicts_from_hydration(p)
+    assert e4.state is EdgeState.DEGRADED
+    assert "re-attach pending" in e4.detail
+
+
+def test_exhausted_runway_degrades_providers():
+    p = _payload(liquidity={"providers": {"anthropic":
+                                          {"tokens_remaining": 0}},
+                            "any_exhausted": True})
+    _, _, e6 = _verdicts_from_hydration(p)
+    assert e6.state is EdgeState.DEGRADED
+    assert "RUNWAY EXHAUSTED" in e6.detail
+
+
+def test_no_hydration_severs_edge3_and_skips_dependents():
+    e3, e4, e6 = _verdicts_from_hydration(None)
+    assert e3.state is EdgeState.SEVERED
+    assert e4.state is EdgeState.SKIPPED
+    assert e6.state is EdgeState.SKIPPED
+
+
+# ---------------------------------------------------------------------------
+# report semantics
+# ---------------------------------------------------------------------------
+
+
+def test_exit_codes_and_first_broken_ordering():
+    r = DoctorReport(verdicts=[
+        EdgeVerdict("1 process", EdgeState.OK),
+        EdgeVerdict("2 cockpit UDS", EdgeState.OK),
+    ])
+    assert r.exit_code == 0 and r.first_broken is None
+    r.verdicts.append(EdgeVerdict("5 sensors", EdgeState.DEGRADED, "x"))
+    assert r.exit_code == 1 and r.first_broken.edge == "5 sensors"
+    r.verdicts.insert(1, EdgeVerdict("2 cockpit UDS", EdgeState.SEVERED, "y"))
+    assert r.exit_code == 2
+    assert r.first_broken.edge == "2 cockpit UDS"   # FIRST broken edge named
+
+
+def test_absent_optional_surfaces_stay_green():
+    """ABSENT (unconfigured MCP, no channel server) must not fail the chain."""
+    r = DoctorReport(verdicts=[
+        EdgeVerdict("1 process", EdgeState.OK),
+        EdgeVerdict("8 mcp servers", EdgeState.ABSENT, "unset"),
+    ])
+    assert r.exit_code == 0
+
+
+# ---------------------------------------------------------------------------
+# the matrix: gating + parallel fan-out
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_matrix_severed_socket_skips_uds_edges_probes_independents(
+    monkeypatch,
+):
+    async def _proc():
+        return EdgeVerdict("1 process", EdgeState.SEVERED, "none")
+
+    async def _sock():
+        return EdgeVerdict("2 cockpit UDS", EdgeState.SEVERED, "absent"), "absent"
+
+    async def _sensors():
+        return EdgeVerdict("5 sensors", EdgeState.ABSENT, "no server")
+
+    async def _liveness():
+        return EdgeVerdict("7 liveness", EdgeState.ABSENT, "no server")
+
+    async def _mcp():
+        return EdgeVerdict("8 mcp servers", EdgeState.ABSENT, "unset")
+
+    monkeypatch.setattr(ov_doctor, "probe_edge_process", _proc)
+    monkeypatch.setattr(ov_doctor, "probe_edge_socket", _sock)
+    monkeypatch.setattr(ov_doctor, "probe_edge_sensors", _sensors)
+    monkeypatch.setattr(ov_doctor, "probe_edge_liveness", _liveness)
+    monkeypatch.setattr(ov_doctor, "probe_edge_mcp", _mcp)
+    report = await ov_doctor.run_matrix()
+    assert len(report.verdicts) == 8
+    by_name = {v.edge: v for v in report.verdicts}
+    assert by_name["3 hydration"].state is EdgeState.SKIPPED
+    assert by_name["4 hive fabrics"].state is EdgeState.SKIPPED
+    assert by_name["6 providers"].state is EdgeState.SKIPPED
+    assert report.exit_code == 2
+    assert report.first_broken.edge == "1 process"
+
+
+@pytest.mark.asyncio
+async def test_matrix_probes_independent_edges_concurrently(monkeypatch):
+    """Mandate 1: the independent probes overlap under ONE gather — total
+    wall-clock ≈ the slowest single probe, never the sum."""
+    DELAY = 0.15
+    active = {"n": 0, "peak": 0}
+
+    def _slow(name, state=EdgeState.OK):
+        async def _p():
+            active["n"] += 1
+            active["peak"] = max(active["peak"], active["n"])
+            await asyncio.sleep(DELAY)
+            active["n"] -= 1
+            return EdgeVerdict(name, state, "")
+        return _p
+
+    async def _sock():
+        return EdgeVerdict("2 cockpit UDS", EdgeState.OK, "served"), "live"
+
+    async def _hyd():
+        active["n"] += 1
+        active["peak"] = max(active["peak"], active["n"])
+        await asyncio.sleep(DELAY)
+        active["n"] -= 1
+        return _payload()
+
+    monkeypatch.setattr(ov_doctor, "probe_edge_process",
+                        _slow("1 process"))
+    monkeypatch.setattr(ov_doctor, "probe_edge_socket", _sock)
+    monkeypatch.setattr(ov_doctor, "_read_hydration", _hyd)
+    monkeypatch.setattr(ov_doctor, "probe_edge_sensors", _slow("5 sensors"))
+    monkeypatch.setattr(ov_doctor, "probe_edge_liveness", _slow("7 liveness"))
+    monkeypatch.setattr(ov_doctor, "probe_edge_mcp", _slow("8 mcp servers"))
+
+    t0 = asyncio.get_running_loop().time()
+    report = await ov_doctor.run_matrix()
+    elapsed = asyncio.get_running_loop().time() - t0
+    assert len(report.verdicts) == 8
+    assert active["peak"] >= 3            # probes genuinely overlapped
+    assert elapsed < DELAY * 4            # not sequential (4 slow probes)
+
+
+# ---------------------------------------------------------------------------
+# --live: the client half against a scripted daemon
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_live_probe_observes_synthetic_frame(sock_dir, monkeypatch):
+    """A scripted cockpit: hydration on accept; on '/doctor probe' input it
+    replays the daemon's real behavior (verdict line + synthetic hive
+    frame). The doctor must catch the frame and verdict OK."""
+    path = sock_dir / "cockpit_attach.sock"
+    monkeypatch.setenv("JARVIS_ATTACH_IPC_SOCKET", str(path))
+    monkeypatch.setenv("JARVIS_DOCTOR_LIVE_WAIT_S", "5")
+
+    async def _daemon(reader, writer):
+        writer.write(b'{"type":"hydration","status":{}}\n')
+        line = await reader.readline()
+        frame = json.loads(line.decode())
+        assert frame == {"type": "input", "text": "/doctor probe"}
+        writer.write(
+            b'{"type":"line","text":"[doctor] synthetic probe firing"}\n')
+        hive_frame = {
+            "type": "telemetry", "hive": True, "subsystem": "web",
+            "actor_id": "web.search",
+            "action_summary": "[synthetic probe] web_search success 900ms",
+            "detail": {"trace_class": "synthetic_probe"},
+        }
+        writer.write((json.dumps(hive_frame) + "\n").encode())
+        await writer.drain()
+
+    server = await asyncio.start_unix_server(_daemon, path=str(path))
+    try:
+        v = await ov_doctor.run_live_probe()
+        assert v.state is EdgeState.OK
+        assert "synthetic actor_edge frame observed" in v.detail
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+@pytest.mark.asyncio
+async def test_live_probe_degrades_when_probe_ran_but_no_frame(
+    sock_dir, monkeypatch,
+):
+    path = sock_dir / "cockpit_attach.sock"
+    monkeypatch.setenv("JARVIS_ATTACH_IPC_SOCKET", str(path))
+    monkeypatch.setenv("JARVIS_DOCTOR_LIVE_WAIT_S", "1")
+
+    async def _daemon(reader, writer):
+        writer.write(b'{"type":"hydration","status":{}}\n')
+        await reader.readline()
+        writer.write(b'{"type":"line","text":"[doctor] probe x: status=y"}\n')
+        await writer.drain()
+        await asyncio.sleep(2)
+
+    server = await asyncio.start_unix_server(_daemon, path=str(path))
+    try:
+        v = await ov_doctor.run_live_probe()
+        assert v.state is EdgeState.DEGRADED
+        assert "no synthetic actor_edge frame" in v.detail
+    finally:
+        server.close()
+        await server.wait_closed()
+
+
+def test_render_never_raises_on_minimal_console():
+    class _C:
+        def print(self, *a, **k):
+            pass
+
+    ov_doctor.render_report(_C(), DoctorReport(verdicts=[
+        EdgeVerdict("1 process", EdgeState.OK, "pid 1")]))

--- a/tests/cli/test_ov_doctor.py
+++ b/tests/cli/test_ov_doctor.py
@@ -305,3 +305,25 @@ def test_version_skew_synthesizer_names_the_remedy():
     ]))
     remedy = [ln for ln in lines if "restart it" in ln]
     assert remedy and "kill 4765" in remedy[0]
+
+
+def test_typoed_flag_is_refused_with_hint(capsys=None):
+    """'ov doctor --liv' must NEVER silently run the wrong thing — refuse
+    with a did-you-mean hint and EX_USAGE."""
+    from backend.core.ouroboros.cli.ov import main
+
+    lines = []
+
+    class _C:
+        def print(self, msg, **kw):
+            lines.append(str(msg))
+
+    import backend.core.ouroboros.cli.ov as ov_mod
+    orig = ov_mod.build_console
+    ov_mod.build_console = lambda: _C()
+    try:
+        rc = main(["doctor", "--liv"])
+    finally:
+        ov_mod.build_console = orig
+    assert rc == 64
+    assert any("did you mean '--live'" in ln for ln in lines)

--- a/tests/governance/test_doctor_probe.py
+++ b/tests/governance/test_doctor_probe.py
@@ -1,0 +1,132 @@
+"""Synthetic probe trace-context isolation (ov doctor --live, Slice C)."""
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.doctor_probe import (
+    SYNTHETIC_OP_PREFIX, TRACE_CLASS_SYNTHETIC, is_synthetic_trace,
+    run_synthetic_tool_probe,
+)
+
+
+class _FakeResult:
+    status = "success"
+    output = "probe body"
+    error = None
+
+
+class _FakeToolBackend:
+    """Mirrors the REAL AsyncProcessToolBackend.execute_async signature."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def execute_async(self, call, policy_ctx, deadline):
+        self.calls.append((call, policy_ctx, deadline))
+        return _FakeResult()
+
+
+class _RecordingBus:
+    def __init__(self):
+        self.published = []
+
+    async def publish_raw(self, topic, data, **kw):
+        self.published.append((topic, data))
+        return "evt-1"
+
+
+def test_is_synthetic_trace_predicate():
+    assert is_synthetic_trace(trace_class=TRACE_CLASS_SYNTHETIC)
+    assert is_synthetic_trace(op_id=SYNTHETIC_OP_PREFIX + "abc")
+    assert not is_synthetic_trace(op_id="op-019f-real", trace_class="")
+
+
+@pytest.mark.asyncio
+async def test_synthetic_probe_broadcasts_edges_but_never_mutates_state(
+    monkeypatch,
+):
+    """THE mandate test: the synthetic injection traverses BOTH observability
+    fabrics (TrinityEventBus broadcast + the hive actor_edge envelope), while
+    MemoryEngine's write path catches the trace id and skips every write."""
+    import backend.core.ouroboros.governance.doctor_probe as probe_mod
+    from backend.api.hive_emitter import HiveEmitter
+
+    # -- fabric capture: a recording bus + a fresh emitter as the default --
+    bus = _RecordingBus()
+    monkeypatch.setattr(
+        "backend.core.trinity_event_bus.get_event_bus_if_exists",
+        lambda: bus)
+    em = HiveEmitter()
+    em.bind_loop()
+    monkeypatch.setattr(
+        "backend.api.hive_emitter.get_default_emitter", lambda: em)
+
+    backend_fake = _FakeToolBackend()
+    verdict = await run_synthetic_tool_probe(tool_backend=backend_fake)
+
+    # the REAL backend contract was exercised with the synthetic op ctx
+    assert verdict["ok"] is True
+    assert verdict["op_id"].startswith(SYNTHETIC_OP_PREFIX)
+    call, policy_ctx, _deadline = backend_fake.calls[0]
+    assert call.name == "web_search"
+    assert policy_ctx.op_id == verdict["op_id"]
+
+    # fabric 1 — TrinityEventBus broadcast, trace-tagged
+    assert len(bus.published) == 1
+    topic, data = bus.published[0]
+    assert topic == "command.doctor_probe_completed"
+    assert data["trace_class"] == TRACE_CLASS_SYNTHETIC
+
+    # fabric 2 — the hive actor_edge envelope, trace-tagged
+    await asyncio.sleep(0.05)
+    env = em.out_queue.get_nowait()
+    assert env.subsystem == "web"
+    assert env.detail.get("trace_class") == TRACE_CLASS_SYNTHETIC
+    assert "[synthetic probe]" in env.action_summary
+
+    # -- state protection: MemoryEngine write path short-circuits --
+    from backend.core.ouroboros.governance.consciousness_bridge import (
+        ConsciousnessBridge,
+    )
+
+    ingested = []
+
+    class _Memory:
+        async def ingest_outcome(self, op_id):
+            ingested.append(op_id)
+
+    class _Consciousness:
+        _memory = _Memory()
+
+    bridge = ConsciousnessBridge(consciousness=_Consciousness())
+    await bridge.record_operation_outcome(
+        op_id=verdict["op_id"], files_changed=[], success=True,
+        failure_reason=None)
+    assert ingested == []          # the trace was caught; NO state write
+
+    # and a REAL op still ingests (the guard never overblocks)
+    await bridge.record_operation_outcome(
+        op_id="op-real-123", files_changed=[], success=True,
+        failure_reason=None)
+    assert ingested == ["op-real-123"]
+
+
+@pytest.mark.asyncio
+async def test_probe_never_raises_without_backend(monkeypatch):
+    """Backend construction failure → structured verdict, no exception."""
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.tool_executor."
+        "AsyncProcessToolBackend",
+        None, raising=False)
+
+    class _Boom:
+        def __init__(self, *a, **k):
+            raise RuntimeError("no backend")
+
+    import backend.core.ouroboros.governance.tool_executor as te
+    monkeypatch.setattr(te, "AsyncProcessToolBackend", _Boom)
+    verdict = await run_synthetic_tool_probe()
+    assert verdict["ok"] is False
+    assert verdict["status"] in ("backend_unavailable", "exec_error")


### PR DESCRIPTION
Slice B (parallel 8-edge matrix, typed verdicts, first-broken-edge naming, fabrics block in hydration) + Slice C (trace-context-isolated synthetic web_search through the real ToolBackend; MemoryEngine write path structurally protected; both fabrics broadcast; self-verifying actor_edge watch). 14 new tests incl. the state-protection mandate test and the concurrency pin; 128 green with regression. First real run diagnosed the operator's live organism as boot-starved at edge 2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `ov doctor`: an 8-edge connectivity matrix plus a trace‑isolated `--live` synthetic probe to diagnose end‑to‑end health quickly and safely. v3 adds Slice‑A patience for boot‑starved daemons and clearer “stale vs timeout” verdicts.

- **New Features**
  - New `ov doctor` verb with 8-edge checks: process, cockpit UDS (deep), hydration, hive fabrics, sensors (`/channel/health`), providers (from hydration), liveness (`/observability/liveness`), and MCP config (`JARVIS_MCP_CONFIG`).
  - Edges 1–2 gate; downstream probes run in one parallel `asyncio.gather`. Typed `EdgeState`; exit 0/1/2 with first-broken-edge naming.
  - Hydration gains a `fabrics` block (daemon pull provider); one bounded hydration read feeds edges 3/4/6; deep socket probe requires serving hydration.
  - `--live` sends `/doctor probe`; daemon executes a read‑only `web_search` via `AsyncProcessToolBackend` under `trace_class="synthetic_probe"` (`doctor-probe-*`), emits a tagged actor_edge; the client verifies the frame end‑to‑end. State writes are skipped in `ConsciousnessBridge`. `ov` CLI wired and REPL `/doctor probe` added.

- **Refinements**
  - Slice‑A patience for boot storms: edge 2 “booting” re‑probes via jittered‑backoff `await_socket` within `JARVIS_DOCTOR_BOOT_WAIT_S` (20s). Live hydration read‑timeout yields DEGRADED “boot‑starved — re‑run”, while a parsed frame without `fabrics` is treated as an older daemon.
  - HTTP probe distinguishes unreachable vs path‑not‑mounted; liveness shows “server up, path not mounted” for older daemons.
  - `--live` is capability‑gated by the hydration `fabrics` block; older daemons are SKIPPED immediately with a restart remedy and no input injected.
  - Version‑skew synthesizer collapses “older daemon” hints into one remedy line that names the pid.
  - Unknown flags are refused with EX_USAGE (64) and a did‑you‑mean hint (e.g., `--liv` → `--live`).

<sup>Written for commit 64310cce04cce858164af0996474239d56eb0ad9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

