### PR TITLE
ci: the ov-surface lane — 356 keyless tests on every PR (Slice D)

### DIFF
--- a/.github/workflows/ov-surface.yml
+++ b/.github/workflows/ov-surface.yml
@@ -1,0 +1,63 @@
+# ov surface — hive fabrics · cockpit · doctor · chat lane (Slice D)
+#
+# The root problem this closes: five PRs of ov front-door surface were
+# guarded by ~356 unit tests that NO workflow ever ran — protection with
+# no trigger (the CI-shaped wired-but-inert class). This lane runs them
+# on every PR and main push.
+#
+# Design invariants:
+#   * KEYLESS + HERMETIC — no API keys, no network calls in tests, no
+#     torch/chroma; the dependency set is the EMPIRICALLY-derived minimum
+#     in ci/requirements-ov-surface.txt (single source of truth).
+#   * NO PATH FILTER — the suite costs ~11s; path-filtering would skip
+#     cross-cutting breakage (a trinity_event_bus change breaking the
+#     hive aggregator). Cheap and always-on beats clever and blind.
+#   * SUITE LIST IS DATA — ci/ov-surface-suites.txt is the one list,
+#     consumable locally the same way CI consumes it:
+#       python -m pytest $(cat ci/ov-surface-suites.txt)
+#   * pytest.ini at the repo root supplies asyncio_mode=auto — CI adds
+#     no config of its own, so local green == CI green.
+
+name: ov surface
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    types: [opened, synchronize, reopened]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ov-surface-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  ov-surface-tests:
+    name: ov surface (py${{ matrix.python-version }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    strategy:
+      fail-fast: false
+      matrix:
+        # .python-version pins 3.11 for dev; 3.12 rides along to catch
+        # version drift before it lands on anyone's machine.
+        python-version: ["3.11", "3.12"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+          cache-dependency-path: ci/requirements-ov-surface.txt
+
+      - name: Install the empirically-minimal lane
+        run: python -m pip install -q -r ci/requirements-ov-surface.txt
+
+      - name: Run the ov-surface suites
+        run: |
+          python -m pytest $(cat ci/ov-surface-suites.txt | tr '\n' ' ') \
+            -q --tb=short -p no:cacheprovider

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -176,17 +176,25 @@ class CockpitAttachBridge:
             return False
 
     async def stop(self) -> None:
-        """Close server + subscribers, unlink socket. NEVER raises."""
+        """Close server + subscribers, unlink socket. NEVER raises.
+
+        Order is load-bearing on Python 3.12+: ``Server.wait_closed()``
+        now genuinely waits for every in-flight client handler (the 3.9-3.11
+        behavior returned immediately), so clients must be DROPPED FIRST —
+        with an attached ``ov`` terminal, the old order hangs shutdown
+        forever. Bounded as belt-and-braces: never-hangs is this module's
+        law even if a handler wedges."""
         try:
+            for w in list(self._clients):
+                self._drop(w)
             if self._server is not None:
                 self._server.close()
                 try:
-                    await self._server.wait_closed()
+                    await asyncio.wait_for(self._server.wait_closed(),
+                                           timeout=2.0)
                 except Exception:  # noqa: BLE001
                     pass
                 self._server = None
-            for w in list(self._clients):
-                self._drop(w)
             try:
                 if self._path.exists():
                     self._path.unlink()

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -1,0 +1,13 @@
+tests/api/test_hive_aggregator.py
+tests/api/test_hive_emitter.py
+tests/cli/test_thin_client.py
+tests/cli/test_ov_doctor.py
+tests/cli/test_ov_dispatch.py
+tests/cli/test_ov_system_panel.py
+tests/cli/test_ov_presentation.py
+tests/battle_test/test_cockpit_attach.py
+tests/governance/test_doctor_probe.py
+tests/governance/test_chat_repl_dispatcher.py
+tests/governance/test_intent_classifier.py
+tests/governance/test_conversation_orchestrator.py
+tests/core/test_intent_classifier.py

--- a/ci/requirements-ov-surface.txt
+++ b/ci/requirements-ov-surface.txt
@@ -1,0 +1,10 @@
+# The ov-surface CI lane — EMPIRICALLY derived minimal set (clean-venv,
+# 2026-07-20): these five packages run all ~356 ov/hive/cockpit/doctor/
+# chat-lane unit tests. No API keys, no torch/chroma/fastembed, no
+# network. If a suite gains a dependency, CI fails naming the module —
+# add it HERE (single source of truth), never inline in the workflow.
+pytest>=8
+pytest-asyncio>=0.23
+pydantic>=2
+rich>=13
+aiofiles>=23

--- a/tests/cli/test_ov_doctor.py
+++ b/tests/cli/test_ov_doctor.py
@@ -15,6 +15,18 @@ from backend.core.ouroboros.cli.ov_doctor import (
 )
 
 
+async def _shutdown_server(server):
+    """Bounded server teardown. Python 3.12 fixed ``Server.wait_closed()``
+    to wait for ALL in-flight connections — a fixture whose handler
+    deliberately never serves (the backlog-accept pin) can therefore never
+    satisfy it. Bound + suppress: cleanup never becomes the test."""
+    server.close()
+    try:
+        await asyncio.wait_for(server.wait_closed(), timeout=2.0)
+    except Exception:
+        pass
+
+
 @pytest.fixture()
 def sock_dir():
     d = Path(tempfile.mkdtemp(prefix="ovdoc-"))
@@ -214,6 +226,7 @@ async def test_live_probe_observes_synthetic_frame(sock_dir, monkeypatch):
         }
         writer.write((json.dumps(hive_frame) + "\n").encode())
         await writer.drain()
+        writer.close()
 
     server = await asyncio.start_unix_server(_daemon, path=str(path))
     try:
@@ -221,8 +234,7 @@ async def test_live_probe_observes_synthetic_frame(sock_dir, monkeypatch):
         assert v.state is EdgeState.OK
         assert "synthetic actor_edge frame observed" in v.detail
     finally:
-        server.close()
-        await server.wait_closed()
+        await _shutdown_server(server)
 
 
 @pytest.mark.asyncio
@@ -239,7 +251,10 @@ async def test_live_probe_degrades_when_probe_ran_but_no_frame(
         await reader.readline()
         writer.write(b'{"type":"line","text":"[doctor] probe x: status=y"}\n')
         await writer.drain()
-        await asyncio.sleep(2)
+        try:
+            await asyncio.sleep(2)
+        finally:
+            writer.close()
 
     server = await asyncio.start_unix_server(_daemon, path=str(path))
     try:
@@ -247,8 +262,7 @@ async def test_live_probe_degrades_when_probe_ran_but_no_frame(
         assert v.state is EdgeState.DEGRADED
         assert "no synthetic actor_edge frame" in v.detail
     finally:
-        server.close()
-        await server.wait_closed()
+        await _shutdown_server(server)
 
 
 def test_render_never_raises_on_minimal_console():
@@ -274,6 +288,7 @@ async def test_live_probe_capability_gated_on_old_daemon(sock_dir, monkeypatch):
         line = await reader.readline()
         if line:
             received.append(line)
+        writer.close()
 
     server = await asyncio.start_unix_server(_old_daemon, path=str(path))
     try:
@@ -285,8 +300,7 @@ async def test_live_probe_capability_gated_on_old_daemon(sock_dir, monkeypatch):
         assert elapsed < 3.0                    # instant, not a 45s wait
         assert received == []                   # NOTHING was injected
     finally:
-        server.close()
-        await server.wait_closed()
+        await _shutdown_server(server)
 
 
 def test_version_skew_synthesizer_names_the_remedy():

--- a/tests/cli/test_thin_client.py
+++ b/tests/cli/test_thin_client.py
@@ -24,13 +24,33 @@ from backend.core.ouroboros.cli import thin_client
 
 def _serving_handler(reader, writer):
     """Mirror of the REAL CockpitAttachBridge accept path: hydration frame
-    written immediately on connect."""
+    written immediately on connect. Closes its writer on exit — on Python
+    3.12+ ``Server.wait_closed()`` genuinely waits for in-flight handlers,
+    so a fixture that leaves its writer open deadlocks test teardown (the
+    exact hang the CI matrix caught on its maiden 3.12 run)."""
     try:
         writer.write(b'{"type":"hydration","status":{}}\n')
     except Exception:
         pass
+    finally:
+        try:
+            writer.close()
+        except Exception:
+            pass
 
 _REPO = Path(__file__).resolve().parents[2]
+
+
+async def _shutdown_server(server):
+    """Bounded server teardown. Python 3.12 fixed ``Server.wait_closed()``
+    to wait for ALL in-flight connections — a fixture whose handler
+    deliberately never serves (the backlog-accept pin) can therefore never
+    satisfy it. Bound + suppress: cleanup never becomes the test."""
+    server.close()
+    try:
+        await asyncio.wait_for(server.wait_closed(), timeout=2.0)
+    except Exception:
+        pass
 
 
 @pytest.fixture()
@@ -57,8 +77,7 @@ class TestZeroTrustProbe:
         try:
             assert await thin_client.probe_socket(path) == "live"
         finally:
-            server.close()
-            await server.wait_closed()
+            await _shutdown_server(server)
 
     async def test_ghost_socket_classified_stale(self, sock_dir):
         """A bound-then-abandoned UDS inode: exists on disk, nothing
@@ -169,8 +188,7 @@ class TestStaleSocketDeadlock:
             assert ok is True
             assert spawns == []            # warm path never cold-boots
         finally:
-            server.close()
-            await server.wait_closed()
+            await _shutdown_server(server)
 
 
 # ---------------------------------------------------------------------------
@@ -409,8 +427,7 @@ class TestHandshakeDepthProbe:
             assert await thin_client.probe_socket(
                 path, timeout=0.3, deep=True) == "booting"
         finally:
-            server.close()
-            await server.wait_closed()
+            await _shutdown_server(server)
 
     async def test_deep_probe_live_when_served(self, sock_dir):
         path = sock_dir / "served.sock"
@@ -421,8 +438,7 @@ class TestHandshakeDepthProbe:
             assert await thin_client.probe_socket(
                 path, timeout=1.0, deep=True) == "live"
         finally:
-            server.close()
-            await server.wait_closed()
+            await _shutdown_server(server)
 
     async def test_refused_socket_backoff_retries_no_false_positive(
         self, sock_dir, monkeypatch,
@@ -509,5 +525,4 @@ class TestHandshakeDepthProbe:
             assert spawns == []                # never raced a second ignition
             assert path.exists()               # never cleaned the socket
         finally:
-            server.close()
-            await server.wait_closed()
+            await _shutdown_server(server)


### PR DESCRIPTION
Closes the last gap of the ov front-door arc: ~356 unit tests guarding the hive fabrics / cockpit / thin-client handshake / doctor / chat lane now run on every PR and main push. Empirically-minimal five-package lane (~11s), suite list and deps as single-source data files, no path filter by design, 3.11+3.12 matrix. **This PR's own checks are the lane's first live run.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a GitHub Actions workflow that runs ~356 ov surface tests on every PR and main push. Also fixes Python 3.12 shutdown hangs by changing cockpit shutdown order and bounding test teardowns.

- **New Features**
  - New workflow runs ov surface suites on PRs, main, and manual dispatch; keyless, hermetic, fast (~11s), 3.11/3.12 matrix, pip cache, per-ref concurrency cancel, 10-min timeout, fail-fast off, no path filter.
  - Suites and deps are single-source data in `ci/ov-surface-suites.txt` and `ci/requirements-ov-surface.txt`; runs locally with the same command.

- **Bug Fixes**
  - Cockpit shutdown drops clients before closing the server and bounds `wait_closed()` with a 2s timeout to avoid 3.12 deadlocks.
  - Test fixtures close writers and use a bounded `_shutdown_server()` helper to prevent teardown hangs in `tests/cli/test_thin_client.py` and `tests/cli/test_ov_doctor.py`.

<sup>Written for commit 688bcf7db4b5dda1dab2ad6a3380d84ff14ce776. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69993?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

