### PR TITLE
GCP: migrate the last live gsutil calls to gcloud storage (March 2027 deprecation)

### DIFF
--- a/.github/workflows/deploy-to-gcp.yml
+++ b/.github/workflows/deploy-to-gcp.yml
@@ -127,8 +127,10 @@ jobs:
             ]
           }
           EOF
-          # gsutil is available with setup-gcloud; lifecycle set is idempotent.
-          gsutil lifecycle set lifecycle.json ${DEPLOYMENT_BUCKET} || echo "⚠️  Could not set lifecycle policy (continuing)"
+          # gcloud storage (NOT gsutil — leaves the default gcloud bundle
+          # March 2027, and setup-gcloud images will stop shipping it).
+          # buckets update is idempotent like lifecycle set was.
+          gcloud storage buckets update ${DEPLOYMENT_BUCKET} --lifecycle-file=lifecycle.json || echo "⚠️  Could not set lifecycle policy (continuing)"
 
           # Upload deployment package
           echo "📤 Uploading deployment package..."

--- a/backend/autonomy/reactor_core_watcher.py
+++ b/backend/autonomy/reactor_core_watcher.py
@@ -458,9 +458,12 @@ class ReactorCoreWatcher:
 
         logger.info(f"[ReactorCoreWatcher] Uploading to GCS: {gcs_path}")
 
-        # Use gsutil for upload
+        # gcloud storage (NOT gsutil — leaves the default gcloud bundle
+        # March 2027). Parallel composite uploads are automatic (the old
+        # `-m` flag has no equivalent and no need); credentials remain the
+        # host's gcloud auth, identical to the gsutil behavior it replaces.
         proc = await asyncio.create_subprocess_exec(
-            "gsutil", "-m", "cp", str(model_path), gcs_path,
+            "gcloud", "storage", "cp", str(model_path), gcs_path,
             stdout=asyncio.subprocess.PIPE,
             stderr=asyncio.subprocess.PIPE,
         )
@@ -468,7 +471,7 @@ class ReactorCoreWatcher:
 
         if proc.returncode != 0:
             error = stderr.decode() if stderr else "Unknown error"
-            raise Exception(f"gsutil failed: {error}")
+            raise Exception(f"gcloud storage cp failed: {error}")
 
         logger.info(f"[ReactorCoreWatcher] Uploaded to: {gcs_path}")
         return gcs_path

--- a/tests/architecture/test_no_gsutil.py
+++ b/tests/architecture/test_no_gsutil.py
@@ -1,0 +1,62 @@
+"""Architecture pin: ZERO live gsutil invocations anywhere in the repo.
+
+Google Cloud removes gsutil from the default gcloud CLI bundle in March
+2027 (notice 2026-07-20, project jarvis-473803). Every GCS surface here
+uses either the google-cloud-storage SDK (ADC) or ``gcloud storage`` —
+this pin makes a regression to gsutil structurally impossible: a new
+invocation fails CI naming the file:line.
+
+Comments MAY mention gsutil (they document the very invariant this test
+enforces); only executable occurrences fail.
+"""
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+_REPO = Path(__file__).resolve().parents[2]
+
+#: Scanned executable surfaces. Docs/memory/tests are exempt (prose).
+_GLOBS = ("backend/**/*.py", "scripts/**/*.py", "scripts/**/*.sh",
+          "deploy/**/*.sh", ".github/workflows/*.yml", "*.py")
+
+#: Comment-leaders per suffix — a gsutil mention AFTER one of these on
+#: the same line is documentation, not invocation.
+_COMMENT = {".py": "#", ".sh": "#", ".yml": "#"}
+
+
+def _live_occurrences() -> list:
+    hits = []
+    for pattern in _GLOBS:
+        for path in _REPO.glob(pattern):
+            if "node_modules" in path.parts or ".git" in path.parts:
+                continue
+            leader = _COMMENT.get(path.suffix)
+            try:
+                text = path.read_text(encoding="utf-8", errors="replace")
+            except Exception:  # noqa: BLE001
+                continue
+            for lineno, line in enumerate(text.splitlines(), 1):
+                if "gsutil" not in line:
+                    continue
+                code = line.split(leader, 1)[0] if leader else line
+                # strings that merely NAME the tool in log/docstring text
+                # ("never gsutil", "not a gsutil subprocess") are prose;
+                # an invocation has gsutil as a word followed by an arg
+                # or as a subprocess token.
+                if "gsutil" not in code:
+                    continue
+                if re.search(
+                    r"""(^|[\s(=&|;'"])gsutil(['"],|\s+-|\s+\w)""", code,
+                ) and "never" not in code and "NOT" not in code:
+                    hits.append(f"{path.relative_to(_REPO)}:{lineno}: "
+                                f"{line.strip()[:100]}")
+    return hits
+
+
+def test_zero_live_gsutil_invocations():
+    hits = _live_occurrences()
+    assert not hits, (
+        "gsutil leaves the default gcloud bundle March 2027 — migrate to "
+        "`gcloud storage` (see this test's docstring):\n" + "\n".join(hits)
+    )


### PR DESCRIPTION
Google's notice (project jarvis-473803): gsutil leaves the default gcloud bundle March 2027. Audit found the codebase already SDK+ADC almost everywhere — exactly two live invocations remained (reactor watcher model upload, deploy workflow lifecycle set); both migrated to `gcloud storage` with identical auth semantics. Plus an architecture pin making regression structurally impossible (adversarially self-tested against the original lines). 15 tests green incl. the slice138 persistence pins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrated the final `gsutil` usages to `gcloud storage` ahead of Google’s March 2027 removal. Behavior and auth stay the same; added a test to prevent regressions.

- **Refactors**
  - Backend uploader: replaced `gsutil -m cp` with `gcloud storage cp` (parallelism automatic); updated error message.
  - Deploy workflow: replaced `gsutil lifecycle set` with `gcloud storage buckets update --lifecycle-file`.
  - Added `tests/architecture/test_no_gsutil.py` to fail CI on any live `gsutil` invocation.

<sup>Written for commit d2660dad41375a478aa7620a33534c7881c3f30c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69994?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

