### PR TITLE
Hive Step 3: layer-2 persona-council deliberator over the real feed (advisory, default-OFF)

### DIFF
--- a/backend/api/hive_aggregator.py
+++ b/backend/api/hive_aggregator.py
@@ -112,6 +112,11 @@ class HiveAggregator:
         self._running = False
         self._tasks: List[asyncio.Task] = []
         self._sub_ids: List[str] = []
+        #: Read-only feed observers (Step 3 layer-2 deliberator). See tap().
+        self._taps: List[Any] = []
+        #: Owned children stopped with the aggregator (e.g. the council
+        #: deliberator) — anything exposing ``async stop()``.
+        self._children: List[Any] = []
         self._sse_sub: Any = None
         self.stats = {"captured": 0, "emitted": 0, "dropped_raw": 0, "dropped_out": 0}
 
@@ -286,7 +291,25 @@ class HiveAggregator:
             except Exception:  # noqa: BLE001
                 logger.debug("[HiveAgg] drainer degraded", exc_info=True)
 
+    def attach_child(self, child: Any) -> None:
+        """Adopt a component whose lifecycle ends with this aggregator's
+        (``async stop()`` contract). Keeps host teardown single-seam."""
+        self._children.append(child)
+
+    def tap(self, callback: Any) -> None:
+        """Register a READ-ONLY observer of the unified feed (Step 3: the
+        persona-council deliberator listens here). Callbacks are sync,
+        bounded by construction (fire-and-forget, exceptions swallowed),
+        and can never consume, reorder, or block the primary out_queue —
+        the relay stays the sole queue consumer (CQRS intact)."""
+        self._taps.append(callback)
+
     def _emit(self, env: HiveTelemetryEnvelope) -> None:
+        for cb in self._taps:
+            try:
+                cb(env)
+            except Exception:  # noqa: BLE001 — a tap can never hurt the feed
+                pass
         try:
             self.out_queue.put_nowait(env)
             self.stats["emitted"] += 1
@@ -323,6 +346,12 @@ class HiveAggregator:
     async def stop(self) -> None:
         """Detach cleanly (read-only teardown). NEVER raises."""
         self._running = False
+        for child in self._children:
+            try:
+                await child.stop()
+            except Exception:  # noqa: BLE001
+                pass
+        self._children = []
         if self._bus_coalescer is not None:
             try:
                 self._bus_coalescer.flush_all()
@@ -399,6 +428,22 @@ async def start_hive_relay(
         agg = HiveAggregator(bus=bus, sse_broker=sse_broker,
                              bus_resolver=resolver, emitter=emitter)
         await agg.start()
+
+        # Step 3 (default-OFF): the layer-2 persona-council deliberator taps
+        # the unified feed read-only and speaks back through the emission
+        # edge. Wired here so BOTH hosts get it (DRY); a council fault can
+        # never touch the feed.
+        try:
+            from backend.api.hive_council_layer import (
+                CouncilDeliberator, council_enabled,
+            )
+            if council_enabled():
+                council = CouncilDeliberator()
+                if await council.start():
+                    agg.tap(council.on_envelope)
+                    agg.attach_child(council)
+        except Exception:  # noqa: BLE001
+            logger.debug("[HiveAgg] council layer degraded", exc_info=True)
 
         async def _relay() -> None:
             try:

--- a/backend/api/hive_council_layer.py
+++ b/backend/api/hive_council_layer.py
@@ -1,0 +1,355 @@
+"""Layer-2 Persona Council Deliberator (Phase 12, Hive Step 3).
+
+The persona council in ``backend/hive/`` was fully built and unit-tested but
+triple-severed: no convener on any live path, no real input, and its only
+output surface (the HUD relay) defaulted to a no-op. This layer repairs all
+three ends AT ONCE, as commentary over the REAL feed:
+
+  * INPUT — a read-only ``HiveAggregator.tap()`` observer: qualifying
+    high-signal envelopes (severity-gated, env-tunable) become deliberation
+    triggers. Guards kill the nasty edge cases structurally:
+      - the FEEDBACK LOOP: ``persona``-subsystem envelopes never re-trigger
+        the council (its own speech can't convene it);
+      - SYNTHETIC contamination: ``trace_class=synthetic_probe`` frames
+        (ov doctor --live) never convene a deliberation;
+      - storms: per-(actor, intent) cooldown + an hourly convene budget.
+  * DELIBERATION — the REAL ``HiveService`` debate loop (OBSERVE → PROPOSE →
+    VALIDATE, three personas, DW-modeled, token-budgeted). Reused, not
+    reimplemented. Two spec'd mandates are added at this layer:
+      - ACTIVE-SPEAKER MUTEX: one deliberation at a time, ever (an
+        ``asyncio.Lock`` around each convene — model spend serializes);
+      - the TOKEN-GATED CONSENSUS BRAKE: the council's own reject cap
+        (``JARVIS_HIVE_MAX_REJECTS``, default 2 → three proposal turns) and
+        per-thread token budget stay authoritative, and the previously
+        UNENFORCED debate deadline is finally applied here via
+        ``asyncio.wait_for`` (env ``JARVIS_HIVE_COUNCIL_DEADLINE_S``).
+  * OUTPUT — ``HudRelayAgent(ipc_send=...)`` (the council's native seam)
+    pointed at the Step-2 emission edge: utterances become ``persona``-
+    subsystem envelopes in the SAME ``ov hive`` feed, rendered beside the
+    real events they deliberate about.
+
+AUTHORITY: none. Consensus is serialized to an ``_AdvisoryLoop`` that mints
+an advisory id and emits a frame — it NEVER submits to the real governance
+intake. Deliberation is legible thought, not command.
+
+Master ``JARVIS_HIVE_COUNCIL_ENABLED`` — default **false** (Step 3 spec).
+Every knob env-tunable; NEVER raises; a council fault can never touch the
+feed, the aggregator, or the pipeline.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+import uuid
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Jarvis.HiveCouncil")
+
+_MASTER_ENV = "JARVIS_HIVE_COUNCIL_ENABLED"
+
+
+def council_enabled() -> bool:
+    return os.environ.get(_MASTER_ENV, "false").strip().lower() == "true"
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "")
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        raw = os.environ.get(name, "")
+        return int(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _trigger_severities() -> Tuple[str, ...]:
+    raw = os.environ.get("JARVIS_HIVE_COUNCIL_TRIGGER_SEVERITIES", "warn,error")
+    return tuple(s.strip() for s in raw.split(",") if s.strip())
+
+
+class _AdvisoryLoop:
+    """The council's consensus sink — mints an advisory id, emits a feed
+    frame, and deliberately NEVER touches the real governance intake."""
+
+    def __init__(self, emit_fn: Any) -> None:
+        self._emit = emit_fn
+
+    async def submit(self, ctx: Any, trigger_source: str = "") -> Dict[str, str]:
+        advisory_id = f"council-advisory-{uuid.uuid4().hex[:10]}"
+        try:
+            goal = str(getattr(ctx, "goal", "") or "")[:140]
+            self._emit(
+                actor_id="persona.council", subsystem="persona",
+                intent="consensus_advisory",
+                summary=f"council consensus (advisory only): {goal}",
+                severity="success", trace_id=advisory_id,
+                detail={"trigger_source": trigger_source, "advisory": True},
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        return {"op_id": advisory_id}
+
+
+class CouncilDeliberator:
+    """The layer-2 convener. Owns nothing but its own worker; every
+    dependency is injectable; every public surface NEVER raises."""
+
+    def __init__(
+        self,
+        *,
+        doubleword: Any = None,
+        emit_fn: Any = None,
+        state_dir: Optional[Path] = None,
+    ) -> None:
+        self._dw = doubleword
+        self._emit = emit_fn or self._default_emit
+        self._state_dir = state_dir
+        self._service: Any = None
+        self._speaker_mutex = asyncio.Lock()     # Active-Speaker: ONE debate ever
+        self._queue: "asyncio.Queue[Any]" = asyncio.Queue(
+            maxsize=_env_int("JARVIS_HIVE_COUNCIL_QUEUE_MAX", 8))
+        self._worker: Optional[asyncio.Task] = None
+        self._running = False
+        self._cooldowns: Dict[Tuple[str, str], float] = {}
+        self._convene_times: List[float] = []
+        self.stats = {"triggers_seen": 0, "triggers_accepted": 0,
+                      "convened": 0, "completed": 0, "deadline_hits": 0,
+                      "suppressed_feedback": 0, "suppressed_synthetic": 0,
+                      "suppressed_cooldown": 0, "suppressed_budget": 0}
+
+    # -- construction helpers ------------------------------------------------
+
+    @staticmethod
+    def _default_emit(**kwargs: Any) -> None:
+        from backend.api.hive_emitter import hive_emit
+        hive_emit(**kwargs)
+
+    def _resolve_dw(self) -> Any:
+        """Lazy Doubleword resolution — the SAME provider the persona engine
+        was written against (async ``prompt_only``). NEVER raises."""
+        if self._dw is not None:
+            return self._dw
+        try:
+            from backend.core.ouroboros.governance.doubleword_provider import (
+                DoublewordProvider,
+            )
+            self._dw = DoublewordProvider()
+            return self._dw
+        except Exception:  # noqa: BLE001
+            logger.debug("[Council] doubleword unavailable", exc_info=True)
+            return None
+
+    def _build_service(self) -> Any:
+        """Construct the REAL HiveService with the relay seam pointed at the
+        Step-2 emission edge. bus=None is safe: subscription only happens in
+        ``start()``, which this layer never calls (it convenes directly)."""
+        from backend.hive.hive_service import HiveService
+        from backend.hive.hud_relay_agent import HudRelayAgent
+
+        dw = self._resolve_dw()
+        if dw is None:
+            return None
+        state_dir = self._state_dir or Path(
+            os.environ.get("JARVIS_HIVE_STATE_DIR",
+                           str(Path.home() / ".jarvis" / "hive"))) / "council"
+        service = HiveService(bus=None, governed_loop=_AdvisoryLoop(self._emit),
+                              doubleword=dw, state_dir=state_dir)
+        service._relay = HudRelayAgent(ipc_send=self._relay_sink)
+        return service
+
+    # -- INPUT: the aggregator tap ------------------------------------------
+
+    def on_envelope(self, env: Any) -> None:
+        """Sync tap callback. Filters + enqueues; NEVER raises, NEVER blocks."""
+        try:
+            self.stats["triggers_seen"] += 1
+            if not self._running or not council_enabled():
+                return
+            if getattr(env, "subsystem", "") == "persona":
+                self.stats["suppressed_feedback"] += 1     # its own speech
+                return
+            detail = getattr(env, "detail", None) or {}
+            if detail.get("trace_class") == "synthetic_probe":
+                self.stats["suppressed_synthetic"] += 1    # doctor probes
+                return
+            if getattr(env, "severity", "info") not in _trigger_severities():
+                return
+            key = (str(getattr(env, "actor_id", "?")),
+                   str(getattr(env, "intent", "?")))
+            now = time.monotonic()
+            cooldown = _env_float("JARVIS_HIVE_COUNCIL_COOLDOWN_S", 600.0)
+            if now - self._cooldowns.get(key, -1e12) < cooldown:
+                self.stats["suppressed_cooldown"] += 1
+                return
+            budget = _env_int("JARVIS_HIVE_COUNCIL_MAX_PER_HOUR", 4)
+            self._convene_times = [t for t in self._convene_times
+                                   if now - t < 3600.0]
+            if len(self._convene_times) >= budget:
+                self.stats["suppressed_budget"] += 1
+                return
+            try:
+                self._queue.put_nowait(env)
+            except asyncio.QueueFull:
+                return                                     # storm — drop newest
+            self._cooldowns[key] = now
+            self._convene_times.append(now)
+            self.stats["triggers_accepted"] += 1
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- OUTPUT: council envelopes → the Step-2 emission edge ----------------
+
+    async def _relay_sink(self, envelope: Dict[str, Any]) -> None:
+        """HudRelayAgent sender: translate council events into persona-
+        subsystem feed frames. NEVER raises (relay swallows anyway)."""
+        try:
+            etype = str(envelope.get("event_type", ""))
+            data = envelope.get("data") or {}
+            if etype == "persona_reasoning":
+                persona = str(data.get("persona", "?"))
+                reasoning = str(data.get("reasoning", ""))[:200]
+                verdict = data.get("validate_verdict")
+                self._emit(
+                    actor_id=f"persona.{persona}", subsystem="persona",
+                    intent=str(data.get("intent", "reasoning")),
+                    summary=(f"{persona}: {reasoning}"
+                             + (f" [{verdict}]" if verdict else "")),
+                    severity="info",
+                    trace_id=str(data.get("thread_id", "council")),
+                    detail={"confidence": data.get("confidence"),
+                            "model": data.get("model_used"),
+                            "tokens": data.get("token_cost"),
+                            "principle": data.get("manifesto_principle")},
+                )
+            elif etype == "thread_lifecycle":
+                self._emit(
+                    actor_id="persona.council", subsystem="persona",
+                    intent="thread_lifecycle",
+                    summary=f"deliberation → {data.get('state', '?')}",
+                    severity="info",
+                    trace_id=str(data.get("thread_id", "council")),
+                    detail={k: v for k, v in data.items() if k != "thread_id"},
+                )
+            # agent_log echoes + cognitive transitions are internal chatter —
+            # not projected (the feed already carries the triggering event).
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- DELIBERATION --------------------------------------------------------
+
+    async def _convene(self, env: Any) -> None:
+        """One bounded deliberation about one real envelope."""
+        from backend.hive.thread_models import CognitiveState, ThreadState
+
+        if self._service is None:
+            self._service = self._build_service()
+            if self._service is None:
+                return
+        title = str(getattr(env, "action_summary", "") or "feed event")[:120]
+        thread = self._service.thread_manager.create_thread(
+            title=title,
+            trigger_event=(f"{getattr(env, 'subsystem', '?')}:"
+                           f"{getattr(env, 'intent', '?')}"),
+            cognitive_state=CognitiveState.FLOW,   # thread-carried: no FSM poke
+        )
+        self._service.thread_manager.transition(
+            thread.thread_id, ThreadState.DEBATING)
+        self.stats["convened"] += 1
+        deadline = _env_float("JARVIS_HIVE_COUNCIL_DEADLINE_S", 240.0)
+        try:
+            # The previously-UNENFORCED debate deadline, finally applied.
+            await asyncio.wait_for(
+                self._service._run_debate_round(thread.thread_id),
+                timeout=deadline)
+            self.stats["completed"] += 1
+        except asyncio.TimeoutError:
+            self.stats["deadline_hits"] += 1
+            self._emit(
+                actor_id="persona.council", subsystem="persona",
+                intent="thread_lifecycle",
+                summary=(f"deliberation timed out at {deadline:.0f}s — "
+                         "closed by the consensus brake"),
+                severity="warn", trace_id=thread.thread_id,
+                detail={"deadline_s": deadline},
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[Council] deliberation degraded", exc_info=True)
+
+    async def _worker_loop(self) -> None:
+        while self._running:
+            try:
+                env = await self._queue.get()
+                async with self._speaker_mutex:      # ONE deliberation, ever
+                    await self._convene(env)
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                logger.debug("[Council] worker degraded", exc_info=True)
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def start(self) -> bool:
+        if not council_enabled():
+            return False
+        self._running = True
+        self._worker = asyncio.create_task(
+            self._worker_loop(), name="hive-council-worker")
+        logger.info("[Council] layer-2 deliberator up (advisory, "
+                    "default-bounded) — persona frames will join ov hive")
+        return True
+
+    async def stop(self) -> None:
+        self._running = False
+        if self._worker is not None and not self._worker.done():
+            self._worker.cancel()
+            try:
+                await self._worker
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+        self._worker = None
+
+
+def register_flags(registry: Any) -> None:
+    """FlagRegistry declaration (via governance/hive_flags delegate). NEVER
+    raises."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category, FlagSpec, FlagType,
+        )
+        for spec in (
+            FlagSpec(name=_MASTER_ENV, type=FlagType.BOOL, default=False,
+                     category=Category.EXPERIMENTAL,
+                     source_file="backend/api/hive_council_layer.py",
+                     example="JARVIS_HIVE_COUNCIL_ENABLED=true",
+                     description="Layer-2 persona-council deliberator over the hive feed (advisory)"),
+            FlagSpec(name="JARVIS_HIVE_COUNCIL_DEADLINE_S", type=FlagType.FLOAT,
+                     default=240.0, category=Category.EXPERIMENTAL,
+                     source_file="backend/api/hive_council_layer.py",
+                     example="JARVIS_HIVE_COUNCIL_DEADLINE_S=120",
+                     description="Hard deliberation deadline (the consensus brake's outer bound)"),
+            FlagSpec(name="JARVIS_HIVE_COUNCIL_MAX_PER_HOUR", type=FlagType.INT,
+                     default=4, category=Category.EXPERIMENTAL,
+                     source_file="backend/api/hive_council_layer.py",
+                     example="JARVIS_HIVE_COUNCIL_MAX_PER_HOUR=2",
+                     description="Hourly convene budget"),
+            FlagSpec(name="JARVIS_HIVE_COUNCIL_COOLDOWN_S", type=FlagType.FLOAT,
+                     default=600.0, category=Category.EXPERIMENTAL,
+                     source_file="backend/api/hive_council_layer.py",
+                     example="JARVIS_HIVE_COUNCIL_COOLDOWN_S=300",
+                     description="Per-(actor,intent) trigger cooldown"),
+        ):
+            registry.register(spec)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+__all__ = ["CouncilDeliberator", "council_enabled", "register_flags"]

--- a/backend/core/ouroboros/governance/hive_flags.py
+++ b/backend/core/ouroboros/governance/hive_flags.py
@@ -12,12 +12,20 @@ from typing import Any
 
 
 def register_flags(registry: Any) -> int:
+    n = 0
     try:
         from backend.api.hive_emitter import register_flags as _rf
         _rf(registry)
-        return 5
+        n += 5
     except Exception:  # noqa: BLE001
-        return 0
+        pass
+    try:
+        from backend.api.hive_council_layer import register_flags as _cf
+        _cf(registry)
+        n += 4
+    except Exception:  # noqa: BLE001
+        pass
+    return n
 
 
 __all__ = ["register_flags"]

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -11,3 +11,4 @@ tests/governance/test_chat_repl_dispatcher.py
 tests/governance/test_intent_classifier.py
 tests/governance/test_conversation_orchestrator.py
 tests/core/test_intent_classifier.py
+tests/api/test_hive_council_layer.py

--- a/ci/requirements-ov-surface.txt
+++ b/ci/requirements-ov-surface.txt
@@ -8,3 +8,5 @@ pytest-asyncio>=0.23
 pydantic>=2
 rich>=13
 aiofiles>=23
+uuid6>=2024.1
+numpy>=1.26

--- a/tests/api/test_hive_aggregator.py
+++ b/tests/api/test_hive_aggregator.py
@@ -397,9 +397,11 @@ def test_flag_registry_delegate_reaches_emitter():
 
     reg = _Reg()
     n = register_flags(reg)
-    assert n == 5 and len(reg.specs) == 5
+    # 5 emitter flags + 4 council flags (Step 3)
+    assert n == 9 and len(reg.specs) == 9
     names = {s.name for s in reg.specs}
     assert "JARVIS_HIVE_EMITTERS_ENABLED" in names
+    assert "JARVIS_HIVE_COUNCIL_ENABLED" in names
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_hive_council_layer.py
+++ b/tests/api/test_hive_council_layer.py
@@ -1,0 +1,234 @@
+"""Layer-2 persona-council deliberator (Hive Step 3) — advisory, bounded."""
+from __future__ import annotations
+
+import asyncio
+import json
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.api.hive_council_layer import (
+    CouncilDeliberator, council_enabled,
+)
+
+
+def _env(subsystem="governance", severity="error", intent="op_failed",
+         actor="ov.governance", summary="operation terminal: fallback_failed",
+         detail=None):
+    return SimpleNamespace(
+        subsystem=subsystem, severity=severity, intent=intent,
+        actor_id=actor, action_summary=summary, detail=detail or {})
+
+
+def _persona_json(reasoning, confidence=0.9, verdict=None):
+    d = {"reasoning": reasoning, "confidence": confidence}
+    if verdict:
+        d["validate_verdict"] = verdict
+    return json.dumps(d)
+
+
+class _FakeDW:
+    """Mirrors the REAL DoublewordProvider.prompt_only contract (the same
+    shape backend/hive's own integration tests canonize)."""
+
+    def __init__(self):
+        self.calls = []
+        self.responses = [
+            _persona_json("Observed: repeated op failures in the feed."),
+            _persona_json("Propose: inspect provider cascade budget."),
+            _persona_json("Approved — advisory only.", verdict="approve"),
+        ]
+
+    async def prompt_only(self, prompt, *, model=None, caller_id="",
+                          max_tokens=None, **kw):
+        self.calls.append((caller_id, model, max_tokens))
+        return self.responses[min(len(self.calls) - 1,
+                                  len(self.responses) - 1)]
+
+
+# ---------------------------------------------------------------------------
+# gates
+# ---------------------------------------------------------------------------
+
+def test_master_default_off():
+    assert council_enabled() is False
+
+
+@pytest.mark.asyncio
+async def test_disabled_start_and_taps_noop(monkeypatch):
+    monkeypatch.delenv("JARVIS_HIVE_COUNCIL_ENABLED", raising=False)
+    cd = CouncilDeliberator(doubleword=_FakeDW(), emit_fn=lambda **k: None)
+    assert await cd.start() is False
+    cd.on_envelope(_env())
+    assert cd.stats["triggers_accepted"] == 0
+
+
+@pytest.mark.asyncio
+async def test_feedback_loop_and_synthetic_guards(monkeypatch):
+    """The council's own speech can NEVER convene it; doctor probes never
+    convene it. Both are structural, not policy."""
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_ENABLED", "true")
+    cd = CouncilDeliberator(doubleword=_FakeDW(), emit_fn=lambda **k: None)
+    cd._running = True
+    cd.on_envelope(_env(subsystem="persona", severity="error"))
+    assert cd.stats["suppressed_feedback"] == 1
+    cd.on_envelope(_env(detail={"trace_class": "synthetic_probe"}))
+    assert cd.stats["suppressed_synthetic"] == 1
+    cd.on_envelope(_env(severity="info"))            # below the gate
+    assert cd.stats["triggers_accepted"] == 0
+    cd.on_envelope(_env(severity="error"))
+    assert cd.stats["triggers_accepted"] == 1
+
+
+@pytest.mark.asyncio
+async def test_cooldown_and_hourly_budget(monkeypatch):
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_MAX_PER_HOUR", "2")
+    cd = CouncilDeliberator(doubleword=_FakeDW(), emit_fn=lambda **k: None)
+    cd._running = True
+    cd.on_envelope(_env(intent="a"))
+    cd.on_envelope(_env(intent="a"))                 # same key → cooldown
+    assert cd.stats["suppressed_cooldown"] == 1
+    cd.on_envelope(_env(intent="b"))                 # budget slot 2/2
+    cd.on_envelope(_env(intent="c"))                 # over budget
+    assert cd.stats["suppressed_budget"] == 1
+    assert cd.stats["triggers_accepted"] == 2
+
+
+# ---------------------------------------------------------------------------
+# Active-Speaker mutex + the consensus brake's deadline
+# ---------------------------------------------------------------------------
+
+class _FakeThreadMgr:
+    def __init__(self):
+        self.n = 0
+
+    def create_thread(self, **kw):
+        self.n += 1
+        return SimpleNamespace(thread_id=f"t{self.n}")
+
+    def transition(self, tid, state):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_active_speaker_mutex_serializes_deliberations(monkeypatch):
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_COOLDOWN_S", "0")
+    cd = CouncilDeliberator(doubleword=_FakeDW(), emit_fn=lambda **k: None)
+    spans = []
+
+    async def _debate(tid):
+        t0 = asyncio.get_running_loop().time()
+        await asyncio.sleep(0.12)
+        spans.append((t0, asyncio.get_running_loop().time()))
+
+    cd._service = SimpleNamespace(
+        thread_manager=_FakeThreadMgr(), _run_debate_round=_debate)
+    await cd.start()
+    cd.on_envelope(_env(intent="x"))
+    cd.on_envelope(_env(intent="y"))
+    await asyncio.sleep(0.5)
+    await cd.stop()
+    assert len(spans) == 2
+    (a0, a1), (b0, b1) = sorted(spans)
+    assert b0 >= a1 - 1e-3                     # strictly serial — no overlap
+
+
+@pytest.mark.asyncio
+async def test_deadline_brake_closes_wedged_deliberation(monkeypatch):
+    """The council's stored-but-never-enforced debate deadline is REAL at
+    this layer: a wedged debate is cancelled and announced."""
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_DEADLINE_S", "0.15")
+    emitted = []
+    cd = CouncilDeliberator(doubleword=_FakeDW(),
+                            emit_fn=lambda **k: emitted.append(k))
+
+    async def _wedged(tid):
+        await asyncio.sleep(3600)
+
+    cd._service = SimpleNamespace(
+        thread_manager=_FakeThreadMgr(), _run_debate_round=_wedged)
+    await cd.start()
+    cd.on_envelope(_env())
+    await asyncio.sleep(0.5)
+    await cd.stop()
+    assert cd.stats["deadline_hits"] == 1
+    assert any("consensus brake" in e.get("summary", "") for e in emitted)
+
+
+# ---------------------------------------------------------------------------
+# the full REAL deliberation (fake DW mirroring the provider contract)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_deliberation_emits_persona_frames_and_stays_advisory(
+    monkeypatch, tmp_path,
+):
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_ENABLED", "true")
+    emitted = []
+    dw = _FakeDW()
+    cd = CouncilDeliberator(doubleword=dw, emit_fn=lambda **k: emitted.append(k),
+                            state_dir=Path(tmp_path))
+    await cd.start()
+    cd.on_envelope(_env(summary="operation terminal: fallback_failed"))
+    for _ in range(80):                       # bounded wait for completion
+        await asyncio.sleep(0.05)
+        if cd.stats["completed"]:
+            break
+    await cd.stop()
+
+    assert cd.stats["completed"] == 1
+    assert len(dw.calls) == 3                  # OBSERVE → PROPOSE → VALIDATE
+    personas = [e["actor_id"] for e in emitted
+                if e.get("intent") not in ("thread_lifecycle",
+                                           "consensus_advisory")]
+    assert "persona.jarvis" in personas
+    assert "persona.j_prime" in personas
+    assert "persona.reactor" in personas
+    assert all(e.get("subsystem") == "persona" for e in emitted)
+    # consensus reached → the ADVISORY sink spoke; no real intake anywhere
+    assert any(e.get("intent") == "consensus_advisory" for e in emitted)
+    advisory = [e for e in emitted if e.get("intent") == "consensus_advisory"]
+    assert advisory[0]["detail"]["advisory"] is True
+
+
+# ---------------------------------------------------------------------------
+# wiring pins
+# ---------------------------------------------------------------------------
+
+def test_host_helper_wires_the_council_behind_the_master():
+    import ast as _ast
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[2]
+    tree = _ast.parse(
+        (root / "backend" / "api" / "hive_aggregator.py").read_text())
+    calls = set()
+    for node in _ast.walk(tree):
+        if isinstance(node, (_ast.FunctionDef, _ast.AsyncFunctionDef)) \
+                and node.name == "start_hive_relay":
+            for sub in _ast.walk(node):
+                if isinstance(sub, _ast.Call):
+                    f = sub.func
+                    calls.add(getattr(f, "id", getattr(f, "attr", "")))
+    assert "council_enabled" in calls          # gated
+    assert "CouncilDeliberator" in calls       # constructed
+    assert "attach_child" in calls             # torn down with the aggregator
+
+
+def test_flag_delegate_reaches_council_flags():
+    from backend.core.ouroboros.governance.hive_flags import register_flags
+
+    class _Reg:
+        def __init__(self):
+            self.names = []
+
+        def register(self, spec):
+            self.names.append(spec.name)
+
+    reg = _Reg()
+    n = register_flags(reg)
+    assert n == 9
+    assert "JARVIS_HIVE_COUNCIL_ENABLED" in reg.names


### PR DESCRIPTION
The persona council finally lives — as commentary over REAL events, not a simulation. Aggregator gains read-only `tap()` observers; qualifying high-signal envelopes convene the REAL `HiveService` debate loop (3 personas, DW cheap-lane); utterances return through the Step-2 emission edge as `persona` frames in `ov hive`. Active-Speaker mutex + the consensus brake's outer deadline (the council's stored-but-never-enforced bound, finally real). Structural guards: no feedback loops, no synthetic-probe convening, cooldowns + hourly budget. Advisory-only consensus — the governance intake is structurally unreachable. Default-OFF (`JARVIS_HIVE_COUNCIL_ENABLED`). Zero council code modified — pure seam reuse. 9 new tests; lane extended; **365 green on 3.11 + 3.12**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a layer-2 persona council that deliberates over the real hive feed (advisory-only, default OFF) via a read‑only aggregator tap, emitting `persona` frames back into `ov hive`. Enforces single active speaker and a real debate deadline without touching governance intake.

- **New Features**
  - Aggregator: `tap()` read-only observers and `attach_child()`; wires council when `JARVIS_HIVE_COUNCIL_ENABLED=true`.
  - Council layer: triggers on gated severities; ignores `persona` feedback and `trace_class=synthetic_probe`; per-(actor,intent) cooldown, hourly budget, bounded queue.
  - Deliberation: reuses real `HiveService` loop; active-speaker mutex; enforced deadline via `JARVIS_HIVE_COUNCIL_DEADLINE_S`; advisory sink only; emits via `HudRelayAgent` to the Step‑2 emission edge as `persona` frames.
  - Flags: registers 4 council flags via the governance delegate (total now 9).
  - Tests: adds coverage for guards, cooldown/budget, mutex serialization, deadline brake, full roundtrip, wiring, and flag delegate.

- **Dependencies**
  - CI: add `uuid6` and `numpy`; include `tests/api/test_hive_council_layer.py` in `ov-surface` suites.

<sup>Written for commit 76834bd01cb84fa5268b0073ca432c209486dea7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

