### PR TITLE
Council voice → DW realtime SSE + Claude cascade + dynamic context hydration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ CLASSIFY -> ROUTE -> [CONTEXT_EXPANSION] -> [PLAN] -> GENERATE -> VALIDATE -> GA
 
 | Tier | Provider | Cost | Notes |
 |------|----------|------|-------|
-| 0 | DoubleWord 397B (3-tier: RT SSE + webhook + adaptive poll) | $0.10/$0.40/M | 16384 max_tokens, RT default, preferred |
+| 0 | DoubleWord 397B (3-tier: RT SSE + webhook + adaptive poll) | RT $0.39/$2.45 · async $0.29/$1.84 · batch $0.19/$1.23 /M | 16384 max_tokens, RT default, preferred. (Corrected 2026-07-21: the old $0.10/$0.40 figure was the 35B-dottxt BATCH rate — a 4-6× understatement for the 397B.) |
 | 1 | Claude (Anthropic API) | $3/$15/M | Extended thinking + prompt caching, 60s fallback cap |
 | 2 | J-Prime (GCP self-hosted) | VM cost only | When available |
 

--- a/backend/api/hive_council_layer.py
+++ b/backend/api/hive_council_layer.py
@@ -138,14 +138,30 @@ class CouncilVoice:
         base = self._base_url or dw._base_url
         return session, base
 
-    async def _headers(self) -> Dict[str, str]:
+    async def _headers(self, caller_id: str = "hive_council") -> Dict[str, str]:
         if self._auth_fn is not None:
             out = self._auth_fn()
             return await out if asyncio.iscoroutine(out) else out
         from backend.core.ouroboros.governance.doubleword_provider import (
             _aegis_dw_session_auth_header, _dw_apply_zdr,
         )
-        return _dw_apply_zdr(dict(await _aegis_dw_session_auth_header()))
+        auth = dict(await _aegis_dw_session_auth_header())
+        # Aegis call lease — the SAME admission step the GENERATE tier
+        # performs before every RT post. In-harness, unleased calls are
+        # rejected by the governor (the live-fire 4xx); out-of-harness the
+        # lease helpers no-op/fail-soft and plain session auth suffices
+        # (proven 200 by direct diagnostic).
+        try:
+            from backend.core.ouroboros.governance.doubleword_provider import (
+                _aegis_acquire_call_lease, _aegis_merge_lease_headers,
+            )
+            lease = await _aegis_acquire_call_lease(
+                op_id=f"council-{caller_id}"[:48], route="background",
+                estimated_cost_usd=0.05)
+            auth = _aegis_merge_lease_headers(auth, lease)
+        except Exception:  # noqa: BLE001 — lease is harness-context enrichment
+            pass
+        return _dw_apply_zdr(auth)
 
     # -- the RT SSE turn ----------------------------------------------------
 
@@ -154,7 +170,7 @@ class CouncilVoice:
         import aiohttp
 
         session, base = await self._resolve_session_and_url()
-        headers = await self._headers()
+        headers = await self._headers(caller_id)
         body: Dict[str, Any] = {
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
@@ -227,8 +243,9 @@ class CouncilVoice:
         except asyncio.CancelledError:
             raise
         except Exception as exc:  # noqa: BLE001 — timeout OR transport fault
-            logger.info("[CouncilVoice] RT turn degraded (%s) — cascading "
-                        "to Claude", type(exc).__name__)
+            logger.info("[CouncilVoice] RT turn degraded (%s: %s) — "
+                        "cascading to Claude", type(exc).__name__,
+                        str(exc)[:160])
         self.stats["fallback_calls"] += 1
         if self._claude is None:
             from backend.core.ouroboros.governance.providers import (

--- a/backend/api/hive_council_layer.py
+++ b/backend/api/hive_council_layer.py
@@ -236,7 +236,14 @@ class CouncilVoice:
                           caller_id: str = "hive_council",
                           max_tokens: Optional[int] = None,
                           **_kw: Any) -> str:
-        rt_bound = _env_float("JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", 45.0)
+        rt_bound = _env_float("JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", 90.0)
+        # Output discipline (defense in depth beside the router's env caps):
+        # a deliberation turn is reasoned JSON, not long-form — clamping
+        # output is what makes 3 sequential RT turns fit the consensus brake
+        # (3 × (TTFT + ~2k tokens) ≪ 240s), and it cuts the $/deliberation.
+        clamp = _env_int("JARVIS_HIVE_COUNCIL_MAX_OUTPUT_TOKENS", 2000)
+        if clamp > 0:
+            max_tokens = min(int(max_tokens or clamp), clamp)
         try:
             return await self._rt_call(
                 prompt, model or "", caller_id, max_tokens, rt_bound)

--- a/backend/api/hive_council_layer.py
+++ b/backend/api/hive_council_layer.py
@@ -39,6 +39,7 @@ feed, the aggregator, or the pipeline.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 import os
 import time
@@ -74,6 +75,173 @@ def _env_int(name: str, default: int) -> int:
 def _trigger_severities() -> Tuple[str, ...]:
     raw = os.environ.get("JARVIS_HIVE_COUNCIL_TRIGGER_SEVERITIES", "warn,error")
     return tuple(s.strip() for s in raw.split(",") if s.strip())
+
+
+class CouncilVoiceTimeout(Exception):
+    """RT deliberation turn exceeded its per-call bound (pre-fallback)."""
+
+
+class CouncilVoice:
+    """The council's voice — ``prompt_only``-shaped, natively on Doubleword's
+    REALTIME SSE surface (the same ``/v1/chat/completions`` lane the primary
+    GENERATE tier uses), with a timeout-triggered Claude-streaming fallback.
+
+    Root-cause re-laning (not a polling wrapper): the batch plane's queue
+    latency structurally cannot fit 3 sequential deliberation turns inside
+    the consensus brake — proven live twice (outage AND healthy-DW). The RT
+    lane is Doubleword's documented tier for bounded work
+    (``service_tier: "priority"``).
+
+    ZOMBIE-BILLING GUARD (explicit socket eviction): on per-call timeout the
+    in-flight SSE response is explicitly ``close()``d — aborting the TCP
+    stream server-side — BEFORE the Claude fallback is invoked. An aborted
+    RT stream stops generation and billing (industry SSE semantics); a
+    cancelled batch job does not — which is exactly why the lane, and not a
+    bigger timeout, is the fix.
+
+    NO retry-exhaustion on the primary: one bounded RT attempt, then the
+    cascade — the practitioner-standard ordered-fallback shape.
+    """
+
+    def __init__(
+        self,
+        *,
+        dw_provider: Any = None,
+        claude: Any = None,
+        base_url: Optional[str] = None,
+        session: Any = None,
+        auth_headers_fn: Any = None,
+    ) -> None:
+        self._dw = dw_provider
+        self._claude = claude
+        self._base_url = base_url
+        self._session = session
+        self._auth_fn = auth_headers_fn
+        self.stats = {"rt_calls": 0, "rt_ok": 0, "rt_evictions": 0,
+                      "fallback_calls": 0, "fallback_ok": 0}
+
+    # -- lazy production resolution (all injectable for tests) --------------
+
+    def _resolve_dw(self) -> Any:
+        if self._dw is None:
+            from backend.core.ouroboros.governance.doubleword_provider import (
+                DoublewordProvider,
+            )
+            self._dw = DoublewordProvider()
+        return self._dw
+
+    async def _resolve_session_and_url(self) -> Tuple[Any, str]:
+        if self._session is not None and self._base_url is not None:
+            return self._session, self._base_url
+        dw = self._resolve_dw()
+        session = self._session or await dw._get_session()
+        base = self._base_url or dw._base_url
+        return session, base
+
+    async def _headers(self) -> Dict[str, str]:
+        if self._auth_fn is not None:
+            out = self._auth_fn()
+            return await out if asyncio.iscoroutine(out) else out
+        from backend.core.ouroboros.governance.doubleword_provider import (
+            _aegis_dw_session_auth_header, _dw_apply_zdr,
+        )
+        return _dw_apply_zdr(dict(await _aegis_dw_session_auth_header()))
+
+    # -- the RT SSE turn ----------------------------------------------------
+
+    async def _rt_call(self, prompt: str, model: str, caller_id: str,
+                       max_tokens: Optional[int], bound_s: float) -> str:
+        import aiohttp
+
+        session, base = await self._resolve_session_and_url()
+        headers = await self._headers()
+        body: Dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": True,
+            "service_tier": "priority",
+        }
+        if max_tokens:
+            body["max_tokens"] = int(max_tokens)
+        resp_holder: List[Any] = [None]
+
+        async def _consume() -> str:
+            pieces: List[str] = []
+            async with session.post(
+                f"{base}/chat/completions", json=body, headers=headers,
+                timeout=aiohttp.ClientTimeout(total=bound_s + 10),
+            ) as resp:
+                resp_holder[0] = resp
+                if resp.status >= 300:
+                    raise RuntimeError(
+                        f"rt status {resp.status}: "
+                        f"{(await resp.text())[:120]}")
+                async for raw in resp.content:
+                    line = raw.decode("utf-8", errors="replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        delta = (json.loads(data)["choices"][0]
+                                 .get("delta") or {})
+                        piece = delta.get("content")
+                        if piece:
+                            pieces.append(piece)
+                    except Exception:  # noqa: BLE001 — tolerate keepalives
+                        continue
+            return "".join(pieces)
+
+        self.stats["rt_calls"] += 1
+        try:
+            text = await asyncio.wait_for(_consume(), timeout=bound_s)
+            self.stats["rt_ok"] += 1
+            return text
+        except asyncio.TimeoutError:
+            # EXPLICIT SOCKET EVICTION: abort the in-flight SSE stream so
+            # server-side generation (and billing) stops NOW — before any
+            # fallback token is spent. wait_for's cancellation alone would
+            # eventually release the connection; close() makes it immediate
+            # and observable.
+            resp = resp_holder[0]
+            if resp is not None:
+                try:
+                    resp.close()
+                except Exception:  # noqa: BLE001
+                    pass
+            self.stats["rt_evictions"] += 1
+            raise CouncilVoiceTimeout(
+                f"rt turn exceeded {bound_s:.0f}s (stream evicted)")
+
+    # -- the prompt_only contract (what PersonaEngine calls) ----------------
+
+    async def prompt_only(self, prompt: str, *, model: Optional[str] = None,
+                          caller_id: str = "hive_council",
+                          max_tokens: Optional[int] = None,
+                          **_kw: Any) -> str:
+        rt_bound = _env_float("JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", 45.0)
+        try:
+            return await self._rt_call(
+                prompt, model or "", caller_id, max_tokens, rt_bound)
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001 — timeout OR transport fault
+            logger.info("[CouncilVoice] RT turn degraded (%s) — cascading "
+                        "to Claude", type(exc).__name__)
+        self.stats["fallback_calls"] += 1
+        if self._claude is None:
+            from backend.core.ouroboros.governance.providers import (
+                ClaudeProvider,
+            )
+            self._claude = ClaudeProvider(
+                api_key=os.getenv("ANTHROPIC_API_KEY", ""))
+        text = await self._claude.prompt_only(
+            prompt, caller_id=caller_id, max_tokens=max_tokens,
+            timeout_s=_env_float("JARVIS_HIVE_COUNCIL_FALLBACK_TIMEOUT_S",
+                                 60.0))
+        self.stats["fallback_ok"] += 1
+        return text
 
 
 class _AdvisoryLoop:
@@ -133,19 +301,18 @@ class CouncilDeliberator:
         from backend.api.hive_emitter import hive_emit
         hive_emit(**kwargs)
 
-    def _resolve_dw(self) -> Any:
-        """Lazy Doubleword resolution — the SAME provider the persona engine
-        was written against (async ``prompt_only``). NEVER raises."""
+    def _resolve_voice(self) -> Any:
+        """Lazy voice resolution: the injected ``doubleword`` object when
+        given (tests / custom lanes), else the RT-native :class:`CouncilVoice`
+        with its Claude cascade — the re-laned production default. NEVER
+        raises."""
         if self._dw is not None:
             return self._dw
         try:
-            from backend.core.ouroboros.governance.doubleword_provider import (
-                DoublewordProvider,
-            )
-            self._dw = DoublewordProvider()
+            self._dw = CouncilVoice()
             return self._dw
         except Exception:  # noqa: BLE001
-            logger.debug("[Council] doubleword unavailable", exc_info=True)
+            logger.debug("[Council] voice unavailable", exc_info=True)
             return None
 
     def _build_service(self) -> Any:
@@ -155,7 +322,7 @@ class CouncilDeliberator:
         from backend.hive.hive_service import HiveService
         from backend.hive.hud_relay_agent import HudRelayAgent
 
-        dw = self._resolve_dw()
+        dw = self._resolve_voice()
         if dw is None:
             return None
         state_dir = self._state_dir or Path(
@@ -261,6 +428,44 @@ class CouncilDeliberator:
                            f"{getattr(env, 'intent', '?')}"),
             cognitive_state=CognitiveState.FLOW,   # thread-carried: no FSM poke
         )
+        # DYNAMIC CONTEXT HYDRATION — the council's own first request, honored:
+        # its debut OBSERVE correctly noted "zero specialist telemetry". Root
+        # cause: the event-driven path projects the triggering log INTO the
+        # thread (_on_agent_log → add_message); our direct drive skipped that
+        # native step. Restore it: the envelope's summary + detail payload —
+        # sanitized through the SAME Step-2 edge helpers (scalars only,
+        # secrets redacted) — becomes the thread's Tier-1 telemetry message,
+        # so personas reason over concrete metrics, never raw untrusted blobs.
+        try:
+            from backend.api.hive_emitter import _clean_detail, _clean_text
+            from backend.hive.thread_models import AgentLogMessage
+
+            sev_map = {"warn": "warning", "error": "error",
+                       "success": "info", "info": "info"}
+            telemetry = {
+                "summary": _clean_text(
+                    str(getattr(env, "action_summary", "") or ""), 240),
+                "subsystem": str(getattr(env, "subsystem", "?"))[:32],
+                "intent": str(getattr(env, "intent", "?"))[:64],
+                "actor_id": str(getattr(env, "actor_id", "?"))[:64],
+                "trace_id": str(getattr(env, "trace_id", "—"))[:64],
+                "source_fabric": str(getattr(env, "source_fabric", "?"))[:24],
+                **_clean_detail(getattr(env, "detail", None) or {}, 160),
+            }
+            self._service.thread_manager.add_message(
+                thread.thread_id,
+                AgentLogMessage(
+                    thread_id=thread.thread_id,
+                    agent_name=telemetry["actor_id"],
+                    trinity_parent="jarvis",     # Body telemetry by origin
+                    severity=sev_map.get(
+                        str(getattr(env, "severity", "info")), "info"),
+                    category=telemetry["intent"],
+                    payload=telemetry,
+                ),
+            )
+        except Exception:  # noqa: BLE001 — hydration is enrichment, never a gate
+            logger.debug("[Council] context hydration degraded", exc_info=True)
         self._service.thread_manager.transition(
             thread.thread_id, ThreadState.DEBATING)
         self.stats["convened"] += 1
@@ -346,6 +551,16 @@ def register_flags(registry: Any) -> None:
                      source_file="backend/api/hive_council_layer.py",
                      example="JARVIS_HIVE_COUNCIL_COOLDOWN_S=300",
                      description="Per-(actor,intent) trigger cooldown"),
+            FlagSpec(name="JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", type=FlagType.FLOAT,
+                     default=45.0, category=Category.EXPERIMENTAL,
+                     source_file="backend/api/hive_council_layer.py",
+                     example="JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S=30",
+                     description="Per-turn DW realtime bound; timeout evicts the stream and cascades to Claude"),
+            FlagSpec(name="JARVIS_HIVE_COUNCIL_FALLBACK_TIMEOUT_S", type=FlagType.FLOAT,
+                     default=60.0, category=Category.EXPERIMENTAL,
+                     source_file="backend/api/hive_council_layer.py",
+                     example="JARVIS_HIVE_COUNCIL_FALLBACK_TIMEOUT_S=90",
+                     description="Claude fallback per-turn bound"),
         ):
             registry.register(spec)
     except Exception:  # noqa: BLE001

--- a/backend/core/ouroboros/governance/hive_flags.py
+++ b/backend/core/ouroboros/governance/hive_flags.py
@@ -22,7 +22,7 @@ def register_flags(registry: Any) -> int:
     try:
         from backend.api.hive_council_layer import register_flags as _cf
         _cf(registry)
-        n += 4
+        n += 6
     except Exception:  # noqa: BLE001
         pass
     return n

--- a/backend/hive/model_router.py
+++ b/backend/hive/model_router.py
@@ -37,10 +37,19 @@ class HiveModelRouter:
 
     # Per-state generation parameters (max_tokens, temperature).
     # BASELINE intentionally zeroed — no model invocation needed.
+    # Token caps env-tunable (2026-07-21): a FLOW turn streaming the full
+    # 10k default on the 397B legitimately exceeds any realtime per-turn
+    # bound — deadline-driven callers (the council) tune these down.
     _STATE_PARAMS: Dict[CognitiveState, Dict[str, Any]] = {
         CognitiveState.BASELINE: {"max_tokens": 0, "temperature": 0},
-        CognitiveState.REM: {"max_tokens": 4000, "temperature": 0.3},
-        CognitiveState.FLOW: {"max_tokens": 10000, "temperature": 0.2},
+        CognitiveState.REM: {
+            "max_tokens": int(os.environ.get(
+                "JARVIS_HIVE_REM_MAX_TOKENS", "4000") or 4000),
+            "temperature": 0.3},
+        CognitiveState.FLOW: {
+            "max_tokens": int(os.environ.get(
+                "JARVIS_HIVE_FLOW_MAX_TOKENS", "10000") or 10000),
+            "temperature": 0.2},
     }
 
     def __init__(self) -> None:

--- a/ci/requirements-ov-surface.txt
+++ b/ci/requirements-ov-surface.txt
@@ -10,3 +10,4 @@ rich>=13
 aiofiles>=23
 uuid6>=2024.1
 numpy>=1.26
+aiohttp>=3.9

--- a/tests/api/test_hive_aggregator.py
+++ b/tests/api/test_hive_aggregator.py
@@ -397,8 +397,8 @@ def test_flag_registry_delegate_reaches_emitter():
 
     reg = _Reg()
     n = register_flags(reg)
-    # 5 emitter flags + 4 council flags (Step 3)
-    assert n == 9 and len(reg.specs) == 9
+    # 5 emitter flags + 6 council flags (Step 3 + RT re-laning)
+    assert n == 11 and len(reg.specs) == 11
     names = {s.name for s in reg.specs}
     assert "JARVIS_HIVE_EMITTERS_ENABLED" in names
     assert "JARVIS_HIVE_COUNCIL_ENABLED" in names

--- a/tests/api/test_hive_council_layer.py
+++ b/tests/api/test_hive_council_layer.py
@@ -129,7 +129,7 @@ async def test_active_speaker_mutex_serializes_deliberations(monkeypatch):
     await cd.start()
     cd.on_envelope(_env(intent="x"))
     cd.on_envelope(_env(intent="y"))
-    await asyncio.sleep(0.5)
+    await asyncio.sleep(1.2)     # first convene pays backend.hive import cost
     await cd.stop()
     assert len(spans) == 2
     (a0, a1), (b0, b1) = sorted(spans)
@@ -230,5 +230,160 @@ def test_flag_delegate_reaches_council_flags():
 
     reg = _Reg()
     n = register_flags(reg)
-    assert n == 9
+    assert n == 11
     assert "JARVIS_HIVE_COUNCIL_ENABLED" in reg.names
+
+
+# ---------------------------------------------------------------------------
+# RT re-laning: CouncilVoice — eviction, cascade, hydration (the mandate test)
+# ---------------------------------------------------------------------------
+
+
+class _FakeClaude:
+    """Mirrors ClaudeProvider.prompt_only's contract."""
+
+    def __init__(self):
+        self.calls = []
+
+    async def prompt_only(self, prompt, *, caller_id="", max_tokens=None,
+                          timeout_s=60.0, **kw):
+        self.calls.append(prompt)
+        return json.dumps({"reasoning": "fallback speech", "confidence": 0.8,
+                           "validate_verdict": "approve"})
+
+
+@pytest.mark.asyncio
+async def test_rt_timeout_evicts_socket_and_cascades_to_claude(monkeypatch):
+    """MANDATE: a stalled DW RT stream is EXPLICITLY evicted (server observes
+    the disconnect) before the Claude fallback fires."""
+    import aiohttp
+    from aiohttp import web
+
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", "0.4")
+    server_state = {"connected": 0, "disconnected": 0}
+
+    async def _stall(request):
+        server_state["connected"] += 1
+        resp = web.StreamResponse()
+        resp.headers["Content-Type"] = "text/event-stream"
+        await resp.prepare(request)
+        try:
+            await resp.write(b'data: {"choices":[{"delta":{"content":"par"}}]}\n\n')
+            # stall CONTENT, but heartbeat the socket: a TCP server only
+            # observes a dead peer on WRITE — each keepalive probe makes the
+            # client's eviction visible the moment it happens.
+            for _ in range(600):
+                await asyncio.sleep(0.05)
+                await resp.write(b": keepalive\n\n")
+        except (ConnectionResetError, asyncio.CancelledError, Exception):
+            server_state["disconnected"] += 1     # the EVICTION, observed
+            raise
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", _stall)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+
+    from backend.api.hive_council_layer import CouncilVoice
+    claude = _FakeClaude()
+    session = aiohttp.ClientSession()
+    try:
+        voice = CouncilVoice(claude=claude, session=session,
+                             base_url=f"http://127.0.0.1:{port}/v1",
+                             auth_headers_fn=lambda: {})
+        out = await voice.prompt_only("deliberate on telemetry",
+                                      model="m", max_tokens=100)
+        await asyncio.sleep(0.2)             # let the server observe the abort
+        assert voice.stats["rt_evictions"] == 1      # timeout → explicit close
+        assert server_state["connected"] == 1
+        assert server_state["disconnected"] == 1     # socket eviction PROVEN
+        assert claude.calls == ["deliberate on telemetry"]   # cascade fired
+        assert "fallback speech" in out
+        assert voice.stats["fallback_ok"] == 1
+    finally:
+        await session.close()
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_rt_happy_path_streams_without_fallback(monkeypatch):
+    import aiohttp
+    from aiohttp import web
+
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", "5")
+
+    async def _serve(request):
+        body = await request.json()
+        assert body["stream"] is True
+        assert body["service_tier"] == "priority"    # the REALTIME lane
+        resp = web.StreamResponse()
+        resp.headers["Content-Type"] = "text/event-stream"
+        await resp.prepare(request)
+        for piece in ("hel", "lo"):
+            await resp.write(
+                f'data: {{"choices":[{{"delta":{{"content":"{piece}"}}}}]}}\n\n'
+                .encode())
+        await resp.write(b"data: [DONE]\n\n")
+        return resp
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", _serve)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+
+    from backend.api.hive_council_layer import CouncilVoice
+    claude = _FakeClaude()
+    session = aiohttp.ClientSession()
+    try:
+        voice = CouncilVoice(claude=claude, session=session,
+                             base_url=f"http://127.0.0.1:{port}/v1",
+                             auth_headers_fn=lambda: {})
+        out = await voice.prompt_only("hi", model="m")
+        assert out == "hello"
+        assert voice.stats["rt_ok"] == 1
+        assert claude.calls == []            # no fallback on the happy path
+    finally:
+        await session.close()
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_deliberation_prompt_contains_hydrated_telemetry(
+    monkeypatch, tmp_path,
+):
+    """MANDATE: the envelope's detail payload reaches the persona prompt —
+    the council's own 'zero specialist telemetry' ticket, closed."""
+    monkeypatch.setenv("JARVIS_HIVE_COUNCIL_ENABLED", "true")
+    prompts = []
+
+    class _CapturingDW:
+        async def prompt_only(self, prompt, **kw):
+            prompts.append(prompt)
+            return _persona_json("ok", verdict="approve")
+
+    cd = CouncilDeliberator(doubleword=_CapturingDW(),
+                            emit_fn=lambda **k: None,
+                            state_dir=Path(tmp_path))
+    await cd.start()
+    cd.on_envelope(_env(
+        summary="operation terminal: fallback_failed",
+        detail={"failure_class": "provider_exhausted", "duration_ms": 4123,
+                "provider": "doubleword"}))
+    for _ in range(80):
+        await asyncio.sleep(0.05)
+        if cd.stats["completed"]:
+            break
+    await cd.stop()
+    assert cd.stats["completed"] == 1
+    observe_prompt = prompts[0]
+    # concrete metrics from the envelope's detail payload, in the prompt:
+    assert "provider_exhausted" in observe_prompt
+    assert "4123" in observe_prompt
+    assert "operation terminal: fallback_failed" in observe_prompt


### PR DESCRIPTION
Live-fire verdict implemented: the batch lane (not the outage) was the root cause — 3 sequential batch-queue calls can't fit the 240s brake even on healthy DW. `CouncilVoice` moves the council natively onto the SAME RT SSE surface as the GENERATE tier (`service_tier: priority`), with explicit socket eviction on timeout (zombie-billing guard, proven server-side in the test) and a no-retry cascade to `ClaudeProvider.prompt_only`. Context hydration closes the council's own first feature request ('zero specialist telemetry') by restoring the native log projection with sanitized envelope detail. CLAUDE.md pricing corrected (397B: RT $0.39/$2.45 — old figure was the 35B batch rate). **368 green on 3.11 + 3.12.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Re-lanes council deliberation to DoubleWord realtime SSE with explicit timeout eviction and a single-step Claude fallback. Adds token/output caps and env-tunable limits to keep turns within deadlines, restores telemetry in prompts, and fixes in-harness RT admission via an Aegis lease.

- **New Features**
  - CouncilVoice on DW realtime SSE (`/v1/chat/completions`, `stream: true`, `service_tier: "priority"`). Single bounded attempt, then cascade to `ClaudeProvider.prompt_only`.
  - On timeout, explicitly closes the SSE stream before fallback (stops server-side generation/billing). Bound via `JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S` (default 90s) and `JARVIS_HIVE_COUNCIL_FALLBACK_TIMEOUT_S` (default 60s).
  - Output discipline: router token caps are env-tunable (`JARVIS_HIVE_{REM,FLOW}_MAX_TOKENS`), and council turns are clamped by `JARVIS_HIVE_COUNCIL_MAX_OUTPUT_TOKENS` (default 2000) to fit the consensus brake and cut cost.
  - Aegis call lease acquired for every RT post (admission parity with GENERATE); degrades soft outside the harness and logs status/body snippets on cascade.
  - Dynamic context hydration: projects sanitized envelope summary/detail into the thread as a telemetry message so personas see concrete metrics.
  - Tests cover SSE eviction + Claude cascade, happy-path streaming, and telemetry hydration.

- **Dependencies**
  - Added `aiohttp>=3.9`.

<sup>Written for commit b237c870abeef6f122622b2713688e9d52f3aa13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69997?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

