### PR TITLE
Cognition Lane Router: Dynamic SLA routing + Concurrency Semaphore

### DIFF
--- a/backend/api/hive_council_layer.py
+++ b/backend/api/hive_council_layer.py
@@ -120,152 +120,31 @@ class CouncilVoice:
         self.stats = {"rt_calls": 0, "rt_ok": 0, "rt_evictions": 0,
                       "fallback_calls": 0, "fallback_ok": 0}
 
-    # -- lazy production resolution (all injectable for tests) --------------
-
-    def _resolve_dw(self) -> Any:
-        if self._dw is None:
-            from backend.core.ouroboros.governance.doubleword_provider import (
-                DoublewordProvider,
-            )
-            self._dw = DoublewordProvider()
-        return self._dw
-
-    async def _resolve_session_and_url(self) -> Tuple[Any, str]:
-        if self._session is not None and self._base_url is not None:
-            return self._session, self._base_url
-        dw = self._resolve_dw()
-        session = self._session or await dw._get_session()
-        base = self._base_url or dw._base_url
-        return session, base
-
-    async def _headers(self, caller_id: str = "hive_council") -> Dict[str, str]:
-        if self._auth_fn is not None:
-            out = self._auth_fn()
-            return await out if asyncio.iscoroutine(out) else out
-        from backend.core.ouroboros.governance.doubleword_provider import (
-            _aegis_dw_session_auth_header, _dw_apply_zdr,
-        )
-        auth = dict(await _aegis_dw_session_auth_header())
-        # Aegis call lease — the SAME admission step the GENERATE tier
-        # performs before every RT post. In-harness, unleased calls are
-        # rejected by the governor (the live-fire 4xx); out-of-harness the
-        # lease helpers no-op/fail-soft and plain session auth suffices
-        # (proven 200 by direct diagnostic).
-        try:
-            from backend.core.ouroboros.governance.doubleword_provider import (
-                _aegis_acquire_call_lease, _aegis_merge_lease_headers,
-            )
-            lease = await _aegis_acquire_call_lease(
-                op_id=f"council-{caller_id}"[:48], route="background",
-                estimated_cost_usd=0.05)
-            auth = _aegis_merge_lease_headers(auth, lease)
-        except Exception:  # noqa: BLE001 — lease is harness-context enrichment
-            pass
-        return _dw_apply_zdr(auth)
-
-    # -- the RT SSE turn ----------------------------------------------------
-
-    async def _rt_call(self, prompt: str, model: str, caller_id: str,
-                       max_tokens: Optional[int], bound_s: float) -> str:
-        import aiohttp
-
-        session, base = await self._resolve_session_and_url()
-        headers = await self._headers(caller_id)
-        body: Dict[str, Any] = {
-            "model": model,
-            "messages": [{"role": "user", "content": prompt}],
-            "stream": True,
-            "service_tier": "priority",
-        }
-        if max_tokens:
-            body["max_tokens"] = int(max_tokens)
-        resp_holder: List[Any] = [None]
-
-        async def _consume() -> str:
-            pieces: List[str] = []
-            async with session.post(
-                f"{base}/chat/completions", json=body, headers=headers,
-                timeout=aiohttp.ClientTimeout(total=bound_s + 10),
-            ) as resp:
-                resp_holder[0] = resp
-                if resp.status >= 300:
-                    raise RuntimeError(
-                        f"rt status {resp.status}: "
-                        f"{(await resp.text())[:120]}")
-                async for raw in resp.content:
-                    line = raw.decode("utf-8", errors="replace").strip()
-                    if not line.startswith("data:"):
-                        continue
-                    data = line[5:].strip()
-                    if data == "[DONE]":
-                        break
-                    try:
-                        delta = (json.loads(data)["choices"][0]
-                                 .get("delta") or {})
-                        piece = delta.get("content")
-                        if piece:
-                            pieces.append(piece)
-                    except Exception:  # noqa: BLE001 — tolerate keepalives
-                        continue
-            return "".join(pieces)
-
-        self.stats["rt_calls"] += 1
-        try:
-            text = await asyncio.wait_for(_consume(), timeout=bound_s)
-            self.stats["rt_ok"] += 1
-            return text
-        except asyncio.TimeoutError:
-            # EXPLICIT SOCKET EVICTION: abort the in-flight SSE stream so
-            # server-side generation (and billing) stops NOW — before any
-            # fallback token is spent. wait_for's cancellation alone would
-            # eventually release the connection; close() makes it immediate
-            # and observable.
-            resp = resp_holder[0]
-            if resp is not None:
-                try:
-                    resp.close()
-                except Exception:  # noqa: BLE001
-                    pass
-            self.stats["rt_evictions"] += 1
-            raise CouncilVoiceTimeout(
-                f"rt turn exceeded {bound_s:.0f}s (stream evicted)")
-
     # -- the prompt_only contract (what PersonaEngine calls) ----------------
 
     async def prompt_only(self, prompt: str, *, model: Optional[str] = None,
                           caller_id: str = "hive_council",
                           max_tokens: Optional[int] = None,
                           **_kw: Any) -> str:
-        rt_bound = _env_float("JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", 90.0)
-        # Output discipline (defense in depth beside the router's env caps):
-        # a deliberation turn is reasoned JSON, not long-form — clamping
-        # output is what makes 3 sequential RT turns fit the consensus brake
-        # (3 × (TTFT + ~2k tokens) ≪ 240s), and it cuts the $/deliberation.
-        clamp = _env_int("JARVIS_HIVE_COUNCIL_MAX_OUTPUT_TOKENS", 2000)
-        if clamp > 0:
-            max_tokens = min(int(max_tokens or clamp), clamp)
-        try:
-            return await self._rt_call(
-                prompt, model or "", caller_id, max_tokens, rt_bound)
-        except asyncio.CancelledError:
-            raise
-        except Exception as exc:  # noqa: BLE001 — timeout OR transport fault
-            logger.info("[CouncilVoice] RT turn degraded (%s: %s) — "
-                        "cascading to Claude", type(exc).__name__,
-                        str(exc)[:160])
-        self.stats["fallback_calls"] += 1
-        if self._claude is None:
-            from backend.core.ouroboros.governance.providers import (
-                ClaudeProvider,
-            )
-            self._claude = ClaudeProvider(
-                api_key=os.getenv("ANTHROPIC_API_KEY", ""))
-        text = await self._claude.prompt_only(
-            prompt, caller_id=caller_id, max_tokens=max_tokens,
-            timeout_s=_env_float("JARVIS_HIVE_COUNCIL_FALLBACK_TIMEOUT_S",
-                                 60.0))
-        self.stats["fallback_ok"] += 1
-        return text
+        """Delegates to the ONE shared RT primitive (cognition_lanes.rt_prompt
+        — semaphore, lease, clamp, eviction, cascade), carrying the council's
+        own knobs. No second copy of the lane logic exists (mandate 3)."""
+        from backend.core.ouroboros.governance.cognition_lanes import rt_prompt
+        return await rt_prompt(
+            prompt,
+            model=model or "",
+            caller_id=caller_id,
+            max_tokens=max_tokens,
+            timeout_s=_env_float("JARVIS_HIVE_COUNCIL_RT_TIMEOUT_S", 90.0),
+            clamp_tokens=_env_int("JARVIS_HIVE_COUNCIL_MAX_OUTPUT_TOKENS",
+                                  2000),
+            dw_provider=self._dw,
+            session=self._session,
+            base_url=self._base_url,
+            auth_headers_fn=self._auth_fn,
+            claude=self._claude,
+            call_stats=self.stats,
+        )
 
 
 class _AdvisoryLoop:

--- a/backend/core/ouroboros/governance/cognition_lanes.py
+++ b/backend/core/ouroboros/governance/cognition_lanes.py
@@ -1,0 +1,247 @@
+"""Cognition Lane Router — Dynamic SLA routing for prompt-shaped inference.
+
+The audit truth: every ``prompt_only`` consumer (Synthesis Engine,
+Architecture Agent, DreamEngine, SemanticTriage, IntentDiscovery, the
+persona council) rode Doubleword's BATCH plane — the Brain guiding a
+realtime Worker through a 24-hour-SLA mail slot. The fix is NOT a blanket
+RT migration (that trades deadlocks for 429 storms): it is deterministic
+routing by the workload's TEMPORAL class, plus a concurrency ceiling that
+makes the RT tier structurally un-stampede-able.
+
+  * SLA_STRICT → the Realtime SSE tier: the SAME primitive proven by the
+    council's voice — Aegis call lease, ``service_tier: "priority"``,
+    output clamp, per-turn bound with EXPLICIT socket eviction on timeout
+    (zombie-billing guard), single-attempt cascade to Claude.
+  * SLA_BULK  → the caller stays on the batch plane (the 2× discount is
+    what batch is FOR — idle-cycle pre-computation has no deadline).
+
+COGNITIVE CONCURRENCY SEMAPHORE: one process-wide ceiling (env
+``JARVIS_COGNITION_RT_CONCURRENCY``, default 3) over every RT-lane
+cognition call. A thundering herd queues asynchronously behind it instead
+of volleying 429s at the tier. Per-event-loop instances (a Semaphore is
+loop-bound; tests and prod each get their own).
+
+ONE implementation (mandate 3): ``CouncilVoice`` delegates here; no second
+copy of lease/clamp/eviction/cascade logic exists anywhere.
+"""
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.CognitionLanes")
+
+SLA_STRICT = "strict"
+SLA_BULK = "bulk"
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        raw = os.environ.get(name, "")
+        return float(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        raw = os.environ.get(name, "")
+        return int(raw) if raw else default
+    except (TypeError, ValueError):
+        return default
+
+
+#: Module stats — read by tests and (later) ov doctor. Never authoritative.
+stats: Dict[str, int] = {
+    "rt_calls": 0, "rt_ok": 0, "rt_evictions": 0,
+    "fallback_calls": 0, "fallback_ok": 0,
+    "inflight": 0, "peak_inflight": 0,
+}
+
+#: Per-loop semaphores (asyncio primitives are loop-bound).
+_semaphores: Dict[int, asyncio.Semaphore] = {}
+
+
+def _rt_semaphore() -> asyncio.Semaphore:
+    loop = asyncio.get_running_loop()
+    key = id(loop)
+    sem = _semaphores.get(key)
+    if sem is None:
+        sem = asyncio.Semaphore(_env_int("JARVIS_COGNITION_RT_CONCURRENCY", 3))
+        # bounded book-keeping: drop entries for dead loops
+        if len(_semaphores) > 8:
+            _semaphores.clear()
+        _semaphores[key] = sem
+    return sem
+
+
+async def _default_headers(caller_id: str) -> Dict[str, str]:
+    """Aegis session auth + call lease + ZDR — the GENERATE tier's exact
+    admission sequence (proven by the council's voice). NEVER raises."""
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        _aegis_dw_session_auth_header, _dw_apply_zdr,
+    )
+    auth = dict(await _aegis_dw_session_auth_header())
+    try:
+        from backend.core.ouroboros.governance.doubleword_provider import (
+            _aegis_acquire_call_lease, _aegis_merge_lease_headers,
+        )
+        lease = await _aegis_acquire_call_lease(
+            op_id=f"cognition-{caller_id}"[:48], route="background",
+            estimated_cost_usd=0.05)
+        auth = _aegis_merge_lease_headers(auth, lease)
+    except Exception:  # noqa: BLE001 — lease is harness-context enrichment
+        pass
+    return _dw_apply_zdr(auth)
+
+
+class RTPromptTimeout(Exception):
+    """RT cognition call exceeded its bound (stream explicitly evicted)."""
+
+
+async def rt_prompt(
+    prompt: str,
+    *,
+    model: str,
+    caller_id: str = "cognition",
+    max_tokens: Optional[int] = None,
+    response_format: Optional[Dict[str, Any]] = None,
+    timeout_s: Optional[float] = None,
+    clamp_tokens: Optional[int] = None,
+    dw_provider: Any = None,
+    session: Any = None,
+    base_url: Optional[str] = None,
+    auth_headers_fn: Any = None,
+    claude: Any = None,
+    call_stats: Optional[Dict[str, int]] = None,
+) -> str:
+    """ONE RT-lane prompt call: semaphore → lease → SSE stream → clamp →
+    bound → explicit eviction → Claude cascade. Raises only the fallback's
+    terminal error (RT faults always cascade). Fully injectable."""
+    import aiohttp
+
+    bound = timeout_s if timeout_s is not None else _env_float(
+        "JARVIS_COGNITION_RT_TIMEOUT_S", 90.0)
+    clamp = clamp_tokens if clamp_tokens is not None else _env_int(
+        "JARVIS_COGNITION_RT_MAX_OUTPUT_TOKENS", 2000)
+    if clamp > 0:
+        max_tokens = min(int(max_tokens or clamp), clamp)
+
+    def _bump(key: str, delta: int = 1) -> None:
+        stats[key] = stats.get(key, 0) + delta
+        if call_stats is not None:
+            call_stats[key] = call_stats.get(key, 0) + delta
+
+    async def _resolve() -> Tuple[Any, str]:
+        nonlocal dw_provider
+        if session is not None and base_url is not None:
+            return session, base_url
+        if dw_provider is None:
+            from backend.core.ouroboros.governance.doubleword_provider import (
+                DoublewordProvider,
+            )
+            dw_provider = DoublewordProvider()
+        return (session or await dw_provider._get_session(),
+                base_url or dw_provider._base_url)
+
+    async def _headers() -> Dict[str, str]:
+        if auth_headers_fn is not None:
+            out = auth_headers_fn()
+            return await out if asyncio.iscoroutine(out) else out
+        return await _default_headers(caller_id)
+
+    async def _rt_attempt() -> str:
+        sess, base = await _resolve()
+        headers = await _headers()
+        body: Dict[str, Any] = {
+            "model": model,
+            "messages": [{"role": "user", "content": prompt}],
+            "stream": True,
+            "service_tier": "priority",
+        }
+        if max_tokens:
+            body["max_tokens"] = int(max_tokens)
+        if response_format:
+            body["response_format"] = response_format
+        resp_holder: List[Any] = [None]
+
+        async def _consume() -> str:
+            pieces: List[str] = []
+            async with sess.post(
+                f"{base}/chat/completions", json=body, headers=headers,
+                timeout=aiohttp.ClientTimeout(total=bound + 10),
+            ) as resp:
+                resp_holder[0] = resp
+                if resp.status >= 300:
+                    raise RuntimeError(
+                        f"rt status {resp.status}: "
+                        f"{(await resp.text())[:160]}")
+                async for raw in resp.content:
+                    line = raw.decode("utf-8", errors="replace").strip()
+                    if not line.startswith("data:"):
+                        continue
+                    data = line[5:].strip()
+                    if data == "[DONE]":
+                        break
+                    try:
+                        delta = (json.loads(data)["choices"][0]
+                                 .get("delta") or {})
+                        piece = delta.get("content")
+                        if piece:
+                            pieces.append(piece)
+                    except Exception:  # noqa: BLE001 — tolerate keepalives
+                        continue
+            return "".join(pieces)
+
+        _bump("rt_calls")
+        try:
+            text = await asyncio.wait_for(_consume(), timeout=bound)
+            _bump("rt_ok")
+            return text
+        except asyncio.TimeoutError:
+            resp = resp_holder[0]
+            if resp is not None:
+                try:
+                    resp.close()          # EXPLICIT eviction — billing stops
+                except Exception:  # noqa: BLE001
+                    pass
+            _bump("rt_evictions")
+            raise RTPromptTimeout(
+                f"rt cognition call exceeded {bound:.0f}s (stream evicted)")
+
+    sem = _rt_semaphore()
+    async with sem:                       # the Cognitive Concurrency Semaphore
+        stats["inflight"] += 1
+        stats["peak_inflight"] = max(stats["peak_inflight"],
+                                     stats["inflight"])
+        try:
+            try:
+                return await _rt_attempt()
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001 — timeout OR transport
+                logger.info("[CognitionLanes] RT degraded (%s: %s) — "
+                            "cascading to Claude (caller=%s)",
+                            type(exc).__name__, str(exc)[:120], caller_id)
+        finally:
+            stats["inflight"] -= 1
+
+    # Claude cascade OUTSIDE the semaphore — a fallback turn must not hold
+    # an RT slot hostage while it waits on a different provider.
+    _bump("fallback_calls")
+    nonlocal_claude = claude
+    if nonlocal_claude is None:
+        from backend.core.ouroboros.governance.providers import ClaudeProvider
+        nonlocal_claude = ClaudeProvider(
+            api_key=os.getenv("ANTHROPIC_API_KEY", ""))
+    text = await nonlocal_claude.prompt_only(
+        prompt, caller_id=caller_id, max_tokens=max_tokens,
+        timeout_s=_env_float("JARVIS_COGNITION_FALLBACK_TIMEOUT_S", 60.0))
+    _bump("fallback_ok")
+    return text
+
+
+__all__ = ["SLA_STRICT", "SLA_BULK", "RTPromptTimeout", "rt_prompt", "stats"]

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -5554,6 +5554,7 @@ class DoublewordProvider:
             model=_caller_model,
             caller_id="ouroboros_plan",
             max_tokens=4000,
+            sla="strict",   # PLAN guides live GENERATE → RT tier (2026-07-21)
         )
         return result or ""
 
@@ -7274,14 +7275,23 @@ class DoublewordProvider:
         caller_id: str = "ouroboros_cognition",
         response_format: Optional[Dict] = None,
         max_tokens: Optional[int] = None,
+        sla: Optional[str] = None,
     ) -> str:
-        """Direct inference via Doubleword batch API without OperationContext.
+        """Direct inference without OperationContext — now SLA-ROUTED.
 
-        Intended for cognition layers (Synthesis Engine, Architecture Agent)
-        that need 397B inference without governance pipeline overhead.
+        ``sla`` (Dynamic SLA Routing, 2026-07-21):
+          * ``"strict"`` — deadline-bound cognition (SemanticTriage,
+            IntentDiscovery, Synthesis, Architecture): routes to the
+            Realtime SSE tier via ``cognition_lanes.rt_prompt`` — Aegis
+            call lease, output clamp, bounded turn with explicit stream
+            eviction, Claude cascade, all behind the Cognitive Concurrency
+            Semaphore (RT tier is structurally un-stampede-able).
+          * ``"bulk"`` / ``None`` — the legacy batch plane below, unchanged
+            byte-for-byte (idle-cycle pre-computation is what the batch
+            discount is FOR; un-migrated callers keep exact behavior).
 
-        Runs the full 4-stage batch cycle synchronously (upload → create →
-        poll → retrieve) and returns the raw text response.
+        Batch path: runs the full 4-stage batch cycle synchronously
+        (upload → create → poll → retrieve) and returns the raw text.
 
         Parameters
         ----------
@@ -7308,6 +7318,20 @@ class DoublewordProvider:
         ValueError
             If DOUBLEWORD_API_KEY is not configured.
         """
+        # ---- Dynamic SLA Routing (2026-07-21) ----
+        if sla == "strict":
+            from backend.core.ouroboros.governance.cognition_lanes import (
+                rt_prompt,
+            )
+            return await rt_prompt(
+                prompt,
+                model=model or self._model,
+                caller_id=caller_id,
+                max_tokens=max_tokens,
+                response_format=response_format,
+                dw_provider=self,
+            )
+        # ---- legacy batch plane (sla None / "bulk") — unchanged ----
         # Slice 27 Phase 2 — Aegis-unified auth bridge.
         # ``self._api_key`` may be empty (post-Aegis env_scrub at boot) —
         # Aegis is the secure credential broker that injects the real

--- a/backend/core/ouroboros/governance/intake/sensors/intent_discovery_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/intent_discovery_sensor.py
@@ -374,6 +374,7 @@ class IntentDiscoverySensor:
                 model=_DW_MODEL,
                 caller_id="intent_discovery_sensor",
                 response_format={"type": "json_object"},
+                sla="strict",   # deadline-bound cognition → RT tier (2026-07-21)
                 max_tokens=_DW_MAX_TOKENS,
             )
         except Exception as exc:

--- a/backend/core/ouroboros/roadmap/synthesis_engine.py
+++ b/backend/core/ouroboros/roadmap/synthesis_engine.py
@@ -325,6 +325,7 @@ class FeatureSynthesisEngine:
             prompt=prompt,
             caller_id="synthesis_engine",
             response_format=SYNTHESIS_JSON_SCHEMA,
+            sla="strict",   # deadline-bound cognition → RT tier (2026-07-21)
         )
         return self._parse_model_response(response, snapshot)
 

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -13,3 +13,4 @@ tests/governance/test_conversation_orchestrator.py
 tests/core/test_intent_classifier.py
 tests/api/test_hive_council_layer.py
 tests/governance/test_quota_taxonomy.py
+tests/governance/test_cognition_lanes.py

--- a/tests/governance/test_cognition_lanes.py
+++ b/tests/governance/test_cognition_lanes.py
@@ -1,0 +1,207 @@
+"""Cognition Lane Router — Dynamic SLA routing + Concurrency Semaphore."""
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance import cognition_lanes as cl
+
+
+class _FakeClaude:
+    def __init__(self):
+        self.calls = []
+
+    async def prompt_only(self, prompt, *, caller_id="", max_tokens=None,
+                          timeout_s=60.0, **kw):
+        self.calls.append(prompt)
+        return "claude-fallback-text"
+
+
+async def _sse_server(handler):
+    from aiohttp import web
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    return runner, f"http://127.0.0.1:{port}/v1"
+
+
+def _reset_stats():
+    for k in cl.stats:
+        cl.stats[k] = 0
+    cl._semaphores.clear()
+
+
+# ---------------------------------------------------------------------------
+# THE MANDATE TEST — Thundering Herd: 5 concurrent RT calls, semaphore 3
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_thundering_herd_queues_behind_semaphore(monkeypatch):
+    """5 concurrent strict-SLA calls: max 3 in flight (server-observed AND
+    client-observed), zero 429s, ALL 5 complete."""
+    import aiohttp
+    from aiohttp import web
+
+    monkeypatch.setenv("JARVIS_COGNITION_RT_CONCURRENCY", "3")
+    _reset_stats()
+    server_state = {"inflight": 0, "peak": 0, "served": 0}
+
+    async def _serve(request):
+        server_state["inflight"] += 1
+        server_state["peak"] = max(server_state["peak"],
+                                   server_state["inflight"])
+        if server_state["inflight"] > 3:
+            # what the real tier would do to a stampede:
+            server_state["inflight"] -= 1
+            return web.json_response({"error": "rate limited"}, status=429)
+        try:
+            resp = web.StreamResponse()
+            resp.headers["Content-Type"] = "text/event-stream"
+            await resp.prepare(request)
+            await asyncio.sleep(0.15)          # hold the slot — force overlap
+            await resp.write(
+                b'data: {"choices":[{"delta":{"content":"ok"}}]}\n\n')
+            await resp.write(b"data: [DONE]\n\n")
+            server_state["served"] += 1
+            return resp
+        finally:
+            server_state["inflight"] -= 1
+
+    runner, base = await _sse_server(_serve)
+    session = aiohttp.ClientSession()
+    try:
+        results = await asyncio.gather(*[
+            cl.rt_prompt(f"herd-{i}", model="m", caller_id=f"c{i}",
+                         session=session, base_url=base,
+                         auth_headers_fn=lambda: {},
+                         claude=_FakeClaude())
+            for i in range(5)
+        ])
+        assert results == ["ok"] * 5               # ALL 5 completed
+        assert server_state["served"] == 5
+        assert server_state["peak"] <= 3           # server never saw a stampede
+        assert cl.stats["peak_inflight"] <= 3      # client-side ceiling held
+        assert cl.stats["rt_ok"] == 5
+        assert cl.stats["fallback_calls"] == 0     # zero 429 cascades
+    finally:
+        await session.close()
+        await runner.cleanup()
+
+
+# ---------------------------------------------------------------------------
+# Dynamic SLA routing at the prompt_only gate
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_prompt_only_strict_routes_to_rt(monkeypatch):
+    """sla='strict' delegates to rt_prompt (batch cycle never touched —
+    the batch path would explode on network in this test)."""
+    captured = {}
+
+    async def _fake_rt(prompt, **kw):
+        captured.update(kw, prompt=prompt)
+        return "rt-routed"
+
+    monkeypatch.setattr(cl, "rt_prompt", _fake_rt)
+    from backend.core.ouroboros.governance.doubleword_provider import (
+        DoublewordProvider,
+    )
+    dw = DoublewordProvider()
+    out = await dw.prompt_only("plan the fix", caller_id="synthesis_engine",
+                               max_tokens=1234,
+                               response_format={"type": "json_object"},
+                               sla="strict")
+    assert out == "rt-routed"
+    assert captured["prompt"] == "plan the fix"
+    assert captured["caller_id"] == "synthesis_engine"
+    assert captured["max_tokens"] == 1234
+    assert captured["response_format"] == {"type": "json_object"}
+    assert captured["model"]                       # provider default resolved
+
+
+def test_sla_gate_is_wired_before_the_batch_cycle():
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[2]
+    src = (root / "backend" / "core" / "ouroboros" / "governance"
+           / "doubleword_provider.py").read_text()
+    gate = src.index('if sla == "strict":')
+    batch = src.index("Slice 27 Phase 2 — Aegis-unified auth bridge",
+                      gate)                        # batch body AFTER the gate
+    assert gate < batch
+
+
+def test_strict_consumers_are_tagged():
+    """AST-ish pin: the migrated cognition sites carry sla='strict'; the
+    already-RT-gated ones (semantic_triage, reasoning_agent via rt_gate)
+    need no tag — and dream_engine (Claude-side bulk) carries none."""
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[2]
+    syn = (root / "backend/core/ouroboros/roadmap/synthesis_engine.py").read_text()
+    intent = (root / "backend/core/ouroboros/governance/intake/sensors/"
+              "intent_discovery_sensor.py").read_text()
+    dream = (root / "backend/core/ouroboros/consciousness/dream_engine.py").read_text()
+    assert 'sla="strict"' in syn
+    assert 'sla="strict"' in intent
+    assert 'sla="strict"' not in dream             # bulk stays bulk
+
+
+# ---------------------------------------------------------------------------
+# lane mechanics: clamp, eviction, cascade (shared-primitive regression)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_rt_stall_evicts_and_cascades(monkeypatch):
+    import aiohttp
+    from aiohttp import web
+
+    _reset_stats()
+    seen = {"disconnected": 0}
+
+    async def _stall(request):
+        body = await request.json()
+        assert body["max_tokens"] <= 2000          # the clamp, enforced
+        resp = web.StreamResponse()
+        resp.headers["Content-Type"] = "text/event-stream"
+        await resp.prepare(request)
+        try:
+            for _ in range(600):
+                await asyncio.sleep(0.05)
+                await resp.write(b": keepalive\n\n")
+        except Exception:
+            seen["disconnected"] += 1
+            raise
+        return resp
+
+    runner, base = await _sse_server(_stall)
+    session = aiohttp.ClientSession()
+    claude = _FakeClaude()
+    try:
+        out = await cl.rt_prompt("q", model="m", timeout_s=0.3,
+                                 max_tokens=9999,   # clamped to 2000
+                                 session=session, base_url=base,
+                                 auth_headers_fn=lambda: {}, claude=claude)
+        await asyncio.sleep(0.2)
+        assert out == "claude-fallback-text"
+        assert cl.stats["rt_evictions"] == 1
+        assert seen["disconnected"] == 1           # eviction, server-observed
+        assert claude.calls == ["q"]
+    finally:
+        await session.close()
+        await runner.cleanup()
+
+
+@pytest.mark.asyncio
+async def test_council_voice_delegates_to_shared_primitive():
+    """DRY pin: CouncilVoice.prompt_only calls cognition_lanes.rt_prompt —
+    no second lane implementation exists in the council layer."""
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[2]
+    src = (root / "backend/api/hive_council_layer.py").read_text()
+    assert "from backend.core.ouroboros.governance.cognition_lanes import rt_prompt" in src
+    assert '"service_tier":' not in src           # the SSE body (code, not docs) lives ONE place


### PR DESCRIPTION
The Brain leaves the batch lane — deterministically, not wholesale. `prompt_only(sla=...)` routes strict-deadline cognition (Synthesis, IntentDiscovery, ouroboros_plan) to the RT SSE tier via ONE shared primitive (lease/clamp/eviction/cascade — CouncilVoice now delegates, 110 duplicated lines deleted), while bulk work keeps the batch discount byte-identically. Audit surprises: semantic_triage + reasoning_agent were already rt_gate'd (stale docstrings); dream_engine is Claude-side. The Cognitive Concurrency Semaphore (3 slots, per-loop) makes the RT tier un-stampede-able — proven by the thundering-herd test against a real 429-ing SSE server (peak ≤3, zero 429s, 5/5 complete). **390 green on 3.11+3.12.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds dynamic SLA routing for cognition and a concurrency semaphore for the realtime path to prevent stampedes. Strict-deadline calls go to one shared RT SSE primitive; bulk stays on the batch path. `HiveCouncil` now delegates to `cognition_lanes.rt_prompt` (no duplicated lane code).

- **New Features**
  - Introduced `backend/core/ouroboros/governance/cognition_lanes.py`: one RT prompt primitive with Aegis lease, output clamp, bounded turn with explicit SSE eviction, and Claude cascade; guarded by a process-wide semaphore `JARVIS_COGNITION_RT_CONCURRENCY` (default 3).
  - Added SLA router to `DoublewordProvider.prompt_only(sla)`: `strict` → RT via `cognition_lanes.rt_prompt`; `bulk`/`None` → batch path unchanged.
  - Tagged strict callers: `synthesis_engine`, `intent_discovery_sensor`, and `ouroboros_plan` now pass `sla="strict"`.
  - Verified via thundering-herd test: 5 concurrent calls queue behind the semaphore (peak ≤3), zero 429s, all complete.

- **Migration**
  - No breaking changes. Existing batch callers remain unchanged.
  - Optional tuning: set `JARVIS_COGNITION_RT_CONCURRENCY` to control RT concurrency; pass `sla="strict"` at call sites that have deadlines.

<sup>Written for commit c3b500cbbb8e5574c6cbc8b28e64953f32049d1b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/69999?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

