### PR TITLE
feat(providers): Priority-Tier Injection — request DW's realtime tier explicitly

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,7 +41,7 @@ CLASSIFY -> ROUTE -> [CONTEXT_EXPANSION] -> [PLAN] -> GENERATE -> VALIDATE -> GA
 
 | Tier | Provider | Cost | Notes |
 |------|----------|------|-------|
-| 0 | DoubleWord 397B (3-tier: RT SSE + webhook + adaptive poll) | RT $0.39/$2.45 · async $0.29/$1.84 · batch $0.19/$1.23 /M | 16384 max_tokens, RT default, preferred. (Corrected 2026-07-21: the old $0.10/$0.40 figure was the 35B-dottxt BATCH rate — a 4-6× understatement for the 397B.) |
+| 0 | DoubleWord 397B (3-tier: RT SSE + webhook + adaptive poll) | RT $0.39/$2.45 · async $0.29/$1.84 · batch $0.19/$1.23 /M | 16384 max_tokens, RT default, preferred. (Corrected 2026-07-21: the old $0.10/$0.40 figure was the 35B-dottxt BATCH rate — a 4-6× understatement for the 397B.) **The RT tier requires `service_tier:"priority"` in the request body** — without it DW serves the default async tier (~66s TTFT, the 0-APPLY soak class). Injected at the ONE seam `apply_rt_service_tier` (master `JARVIS_DW_SERVICE_TIER_ENABLED`, tier `JARVIS_DW_RT_SERVICE_TIER`, per-model rejection cache); batch bodies never carry it. |
 | 1 | Claude (Anthropic API) | $3/$15/M | Extended thinking + prompt caching, 60s fallback cap |
 | 2 | J-Prime (GCP self-hosted) | VM cost only | When available |
 

--- a/backend/core/ouroboros/governance/cognition_lanes.py
+++ b/backend/core/ouroboros/governance/cognition_lanes.py
@@ -160,8 +160,17 @@ async def rt_prompt(
             "model": model,
             "messages": [{"role": "user", "content": prompt}],
             "stream": True,
-            "service_tier": "priority",
         }
+        # Tier selector via the ONE canonical seam (provider helper honors
+        # the master flag, env tier override, and the per-model rejection
+        # cache); literal fallback keeps this lane standalone-injectable.
+        try:
+            from backend.core.ouroboros.governance.doubleword_provider import (
+                apply_rt_service_tier,
+            )
+            body = apply_rt_service_tier(body, model)
+        except Exception:  # noqa: BLE001 — provider import must never gate RT
+            body["service_tier"] = "priority"
         if max_tokens:
             body["max_tokens"] = int(max_tokens)
         if response_format:

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -706,6 +706,113 @@ class _DWToolForcingRejectedError(Exception):
     """
 
 
+# ---------------------------------------------------------------------------
+# Priority-Tier Injection (2026-07-21) — the missing ``service_tier`` selector
+# ---------------------------------------------------------------------------
+# ROOT CAUSE of the 66s-TTFT soak deaths (STAGE_RT_HTTP_POST p50=66,775ms,
+# 0 APPLY across 6 capability soaks): DW routes /v1/chat/completions to its
+# REALTIME (priority) tier only when the body carries service_tier="priority".
+# Without it, every "RT" request rode the DEFAULT async tier (~1min TTFT) —
+# the Slice-36 batch-preference machinery grew around a tier we never asked
+# to leave. cognition_lanes (the council's voice) proved the priority tier
+# live: 3 sequential calls in ~70s wall. This helper is the ONE place the
+# tier param is decided; every realtime-plane body composes it, no batch
+# body ever does (the 2× batch discount is what that plane is FOR).
+
+#: Per-process cache: models whose endpoint rejected the service_tier param
+#: (unknown-parameter 400/422). Prevents re-sending a knob the grid refuses.
+_DW_TIER_PARAM_REJECTED: set = set()
+
+#: One-shot INFO latch so the soak log carries positive proof the priority
+#: tier is being requested (vs silently riding the async tier for months).
+_DW_TIER_FIRST_INJECT_LOGGED: list = []
+
+
+def dw_service_tier_enabled() -> bool:
+    """Master for realtime-plane service-tier injection. Default TRUE. NEVER raises."""
+    try:
+        return os.environ.get(
+            "JARVIS_DW_SERVICE_TIER_ENABLED", "true",
+        ).strip().lower() not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _dw_rt_service_tier() -> str:
+    """The tier requested on the realtime plane (env-tunable, default
+    ``priority`` per DW docs). Empty string disables injection. NEVER raises."""
+    try:
+        return os.environ.get("JARVIS_DW_RT_SERVICE_TIER", "priority").strip()
+    except Exception:  # noqa: BLE001
+        return "priority"
+
+
+def _dw_tier_param_known_unsupported(model_id: str) -> bool:
+    """True if this model/endpoint previously rejected service_tier. NEVER raises."""
+    try:
+        return (model_id or "") in _DW_TIER_PARAM_REJECTED
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def apply_rt_service_tier(body: dict, model_id: str) -> dict:
+    """Stamp the realtime-plane tier selector onto a /chat/completions body.
+
+    The ONE decision seam (DRY): _generate_realtime (SSE + non-streaming),
+    complete_sync (heavy fn / Functions lane), stream_health_probe, and
+    cognition_lanes.rt_prompt all compose this. Batch bodies (submit_batch,
+    prompt_only bulk) MUST NOT — batch pricing is the point of that plane.
+    Skips when the master is off, the tier is empty, the caller already set
+    one, or the model's endpoint is cached as rejecting the param. NEVER
+    raises; always returns the body.
+    """
+    try:
+        if not dw_service_tier_enabled():
+            return body
+        tier = _dw_rt_service_tier()
+        if not tier or "service_tier" in body:
+            return body
+        if _dw_tier_param_known_unsupported(model_id):
+            return body
+        body["service_tier"] = tier
+        if not _DW_TIER_FIRST_INJECT_LOGGED:
+            _DW_TIER_FIRST_INJECT_LOGGED.append(True)
+            logger.info(
+                "[DWServiceTier] realtime plane requesting service_tier=%s "
+                "(model=%s) — priority tier ACTIVE", tier, model_id or "-",
+            )
+    except Exception:  # noqa: BLE001 — never perturb payload build
+        pass
+    return body
+
+
+def _dw_note_tier_param_rejection(
+    model_id: str, status: int, err_body: str,
+) -> bool:
+    """ADAPTIVE learn at the RT error seams: if the endpoint rejected the
+    service_tier param itself (unknown-parameter 400/422 naming it), cache
+    the model so the next attempt omits the knob instead of looping the
+    rejection. A 4xx that does NOT name service_tier (quota, entitlement,
+    schema) is someone else's fact — untouched. Returns True iff learned.
+    NEVER raises."""
+    try:
+        if status not in (400, 422):
+            return False
+        if "service_tier" not in (err_body or "").lower():
+            return False
+        if (model_id or "") in _DW_TIER_PARAM_REJECTED:
+            return True
+        _DW_TIER_PARAM_REJECTED.add(model_id or "")
+        logger.warning(
+            "[DWServiceTier] endpoint rejected service_tier param "
+            "(model=%s status=%s) — omitting on retry; RT rides the "
+            "default tier for this model", model_id or "-", status,
+        )
+        return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
 # ============================================================================
 # Slice 36 — Adaptive Transport Selector
 # ============================================================================
@@ -4433,6 +4540,12 @@ class DoublewordProvider:
                 except Exception:  # noqa: BLE001
                     pass  # I2: sanitize/estimate bug never blocks valid request
 
+            # Priority-Tier Injection (2026-07-21) — request the REALTIME
+            # tier explicitly. Without this the grid served the default
+            # async tier (~66s TTFT, the 0-APPLY soak class). After the
+            # egress interceptor so a model sanitize-rule can't strip it.
+            body = apply_rt_service_tier(body, _effective_model)
+
             # PR D — Native tool forcing (JARVIS_DW_NATIVE_TOOL_FORCING_ENABLED).
             # Read the epistemic exploration state stamped by tool_executor.py's
             # producer. If the model still needs to call exploration tools, inject
@@ -4642,6 +4755,13 @@ class DoublewordProvider:
                                     _rp_learn(_effective_model, body.get("reasoning_effort", ""), err_body)
                                 except Exception:  # noqa: BLE001
                                     pass
+                                # Priority-Tier ADAPTIVE learn — if the grid
+                                # rejected the service_tier param itself, cache
+                                # the model; the CG retry rebuilds the body and
+                                # the helper omits the knob.
+                                _dw_note_tier_param_rejection(
+                                    _effective_model, resp.status, err_body,
+                                )
                                 # PR D C2 — fail-soft on 400 rejection of native tool schemas.
                                 # Cache and re-raise private sentinel; caller strips tools + retries.
                                 if resp.status == 400 and _tool_forced:
@@ -5129,6 +5249,10 @@ class DoublewordProvider:
                                     _effective_model, resp.status,
                                 )
                                 err_body = await resp.text()
+                                # Priority-Tier ADAPTIVE learn (see streaming seam).
+                                _dw_note_tier_param_rejection(
+                                    _effective_model, resp.status, err_body,
+                                )
                                 # PR D C2 — fail-soft on 400 rejection of native tool schemas.
                                 if resp.status == 400 and _tool_forced:
                                     _dw_mark_tool_forcing_unsupported(_effective_model)
@@ -7510,6 +7634,9 @@ class DoublewordProvider:
         NEVER raises: resilience handling must not mask the real provider error
         that the caller is about to receive.
         """
+        # Priority-Tier ADAPTIVE learn — an unknown-parameter 400/422 naming
+        # service_tier caches the model so the next attempt omits the knob.
+        _dw_note_tier_param_rejection(model, status, body)
         try:
             if status in (502, 503, 504):
                 from backend.core.ouroboros.governance.dw_client_lifecycle import (
@@ -7811,6 +7938,11 @@ class DoublewordProvider:
             except Exception:  # noqa: BLE001 — never block a valid request
                 pass
 
+        # Priority-Tier Injection (2026-07-21) — complete_sync IS the
+        # latency-critical realtime plane (DreamEngine RT tier, heavy fn
+        # lane, CompactionCaller); request the priority tier explicitly.
+        body = apply_rt_service_tier(body, effective_model)
+
         session = await self._get_session()
         t0 = time.monotonic()
 
@@ -8046,6 +8178,9 @@ class DoublewordProvider:
                 "temperature": 0.0,
                 "stream": True,
             }
+            # Priority-Tier Injection — probe the tier we actually generate
+            # on, else stability verdicts describe the wrong (async) lane.
+            body = apply_rt_service_tier(body, self._model)
             tokens = 0
             async with session.post(
                 f"{self._base_url}/chat/completions",

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -14,3 +14,4 @@ tests/core/test_intent_classifier.py
 tests/api/test_hive_council_layer.py
 tests/governance/test_quota_taxonomy.py
 tests/governance/test_cognition_lanes.py
+tests/governance/test_dw_priority_tier.py

--- a/tests/governance/test_dw_priority_tier.py
+++ b/tests/governance/test_dw_priority_tier.py
@@ -1,0 +1,213 @@
+"""Priority-Tier Injection — the missing ``service_tier`` selector.
+
+Root cause of the 66s-TTFT soak deaths: every "realtime" GENERATE posted to
+``/v1/chat/completions`` WITHOUT ``service_tier`` — DW served the default
+async tier. These tests pin: (1) the ONE decision helper's env contract,
+(2) the adaptive per-model rejection learner, (3) AST wiring — every
+realtime-plane composer calls the helper, NO batch composer does, and
+(4) the wire truth: a real ``complete_sync`` POST carries the selector.
+"""
+from __future__ import annotations
+
+import ast
+import pathlib
+
+import pytest
+
+from backend.core.ouroboros.governance import doubleword_provider as dwp
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+_DW_SRC = (_ROOT / "backend" / "core" / "ouroboros" / "governance"
+           / "doubleword_provider.py").read_text()
+
+
+@pytest.fixture(autouse=True)
+def _clean_tier_state(monkeypatch):
+    """Process-global caches must not leak between tests (or into the
+    real ledger of any other suite)."""
+    monkeypatch.delenv("JARVIS_DW_SERVICE_TIER_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_DW_RT_SERVICE_TIER", raising=False)
+    saved_rejected = set(dwp._DW_TIER_PARAM_REJECTED)
+    saved_logged = list(dwp._DW_TIER_FIRST_INJECT_LOGGED)
+    dwp._DW_TIER_PARAM_REJECTED.clear()
+    dwp._DW_TIER_FIRST_INJECT_LOGGED.clear()
+    yield
+    dwp._DW_TIER_PARAM_REJECTED.clear()
+    dwp._DW_TIER_PARAM_REJECTED.update(saved_rejected)
+    dwp._DW_TIER_FIRST_INJECT_LOGGED.clear()
+    dwp._DW_TIER_FIRST_INJECT_LOGGED.extend(saved_logged)
+
+
+# ---------------------------------------------------------------------------
+# The decision helper — env contract
+# ---------------------------------------------------------------------------
+
+def test_default_injects_priority():
+    body = dwp.apply_rt_service_tier({"model": "m"}, "qwen-397b")
+    assert body["service_tier"] == "priority"
+
+
+def test_master_off_no_injection(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_SERVICE_TIER_ENABLED", "false")
+    body = dwp.apply_rt_service_tier({"model": "m"}, "qwen-397b")
+    assert "service_tier" not in body
+
+
+def test_env_tier_override(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_RT_SERVICE_TIER", "express")
+    body = dwp.apply_rt_service_tier({"model": "m"}, "qwen-397b")
+    assert body["service_tier"] == "express"
+
+
+def test_empty_tier_disables(monkeypatch):
+    monkeypatch.setenv("JARVIS_DW_RT_SERVICE_TIER", "")
+    body = dwp.apply_rt_service_tier({"model": "m"}, "qwen-397b")
+    assert "service_tier" not in body
+
+
+def test_caller_override_preserved():
+    """A body that already carries a tier is NEVER overwritten."""
+    body = dwp.apply_rt_service_tier(
+        {"model": "m", "service_tier": "custom"}, "qwen-397b")
+    assert body["service_tier"] == "custom"
+
+
+def test_rejected_model_omits():
+    dwp._DW_TIER_PARAM_REJECTED.add("qwen-397b")
+    body = dwp.apply_rt_service_tier({"model": "m"}, "qwen-397b")
+    assert "service_tier" not in body
+    # ...but OTHER models keep the tier (per-model cache, not global off)
+    other = dwp.apply_rt_service_tier({"model": "m"}, "gemma-31b")
+    assert other["service_tier"] == "priority"
+
+
+# ---------------------------------------------------------------------------
+# The adaptive rejection learner
+# ---------------------------------------------------------------------------
+
+def test_learner_caches_unknown_param_400():
+    learned = dwp._dw_note_tier_param_rejection(
+        "qwen-397b", 400, '{"error": "unknown parameter: service_tier"}')
+    assert learned is True
+    assert dwp._dw_tier_param_known_unsupported("qwen-397b")
+
+
+def test_learner_ignores_unrelated_400():
+    """A 400 that does NOT name service_tier (schema, quota text) is
+    someone else's fact — never cached here."""
+    learned = dwp._dw_note_tier_param_rejection(
+        "qwen-397b", 400, '{"error": "credit balance too low"}')
+    assert learned is False
+    assert not dwp._dw_tier_param_known_unsupported("qwen-397b")
+
+
+def test_learner_status_gated():
+    """A 429/403 mentioning service_tier is NOT a param rejection —
+    entitlement/quota seams own those statuses."""
+    for status in (403, 429, 503):
+        assert dwp._dw_note_tier_param_rejection(
+            "qwen-397b", status, "service_tier denied") is False
+    assert not dwp._dw_tier_param_known_unsupported("qwen-397b")
+
+
+def test_learner_then_helper_omits():
+    """The full adaptive loop: rejection → cache → next body build omits."""
+    dwp._dw_note_tier_param_rejection(
+        "m1", 422, "invalid parameter service_tier for this deployment")
+    body = dwp.apply_rt_service_tier({"model": "m1"}, "m1")
+    assert "service_tier" not in body
+
+
+# ---------------------------------------------------------------------------
+# AST wiring pins — realtime plane composes the helper, batch plane NEVER
+# ---------------------------------------------------------------------------
+
+def _calls_in_function(func_name: str, callee: str) -> int:
+    """Count ``callee(...)`` call sites inside the named function/method."""
+    tree = ast.parse(_DW_SRC)
+    count = 0
+    for node in ast.walk(tree):
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)) \
+                and node.name == func_name:
+            for sub in ast.walk(node):
+                if isinstance(sub, ast.Call):
+                    f = sub.func
+                    name = getattr(f, "id", None) or getattr(f, "attr", None)
+                    if name == callee:
+                        count += 1
+    return count
+
+
+def test_realtime_plane_is_wired():
+    # main GENERATE (SSE + non-streaming variants share the one body build)
+    assert _calls_in_function("_generate_realtime", "apply_rt_service_tier") >= 1
+    # heavy fn / Functions lane
+    assert _calls_in_function("complete_sync", "apply_rt_service_tier") >= 1
+    # the stability probe measures the tier we actually generate on
+    assert _calls_in_function("stream_health_probe", "apply_rt_service_tier") >= 1
+
+
+def test_batch_plane_is_not_wired():
+    """The 2× batch discount is the point of that plane — the tier selector
+    must never leak into a batch JSONL body."""
+    for batch_fn in ("submit_batch", "prompt_only", "_generate_via_batch",
+                     "poll_and_retrieve"):
+        assert _calls_in_function(batch_fn, "apply_rt_service_tier") == 0, batch_fn
+
+
+def test_rejection_learner_covers_every_rt_error_seam():
+    # both _generate_realtime error branches (streaming + non-streaming)
+    assert _calls_in_function(
+        "_generate_realtime", "_dw_note_tier_param_rejection") >= 2
+    # the complete_sync failure composition seam
+    assert _calls_in_function(
+        "_handle_rt_http_failure", "_dw_note_tier_param_rejection") >= 1
+
+
+def test_cognition_lanes_delegates_to_canonical_helper():
+    """DRY: the council/cognition RT lane composes the SAME decision seam
+    (master flag + env tier + rejection cache honored everywhere)."""
+    src = (_ROOT / "backend" / "core" / "ouroboros" / "governance"
+           / "cognition_lanes.py").read_text()
+    assert "apply_rt_service_tier" in src
+
+
+# ---------------------------------------------------------------------------
+# Wire truth — a REAL complete_sync POST carries the selector
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_complete_sync_sends_priority_on_the_wire(monkeypatch):
+    import aiohttp
+    from aiohttp import web
+
+    seen = {}
+
+    async def _serve(request):
+        seen.update(await request.json())
+        return web.json_response({
+            "choices": [{"message": {"content": "ok"}}],
+            "usage": {"prompt_tokens": 1, "completion_tokens": 1},
+        })
+
+    app = web.Application()
+    app.router.add_post("/v1/chat/completions", _serve)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    port = site._server.sockets[0].getsockname()[1]
+    try:
+        dw = dwp.DoublewordProvider(
+            api_key="test-key",
+            base_url=f"http://127.0.0.1:{port}/v1",
+            model="test-model",
+        )
+        result = await dw.complete_sync(
+            "ping", system_prompt="you are a test", caller_id="tier_test",
+            max_tokens=8, timeout_s=10.0)
+        assert result.content == "ok"
+        assert seen.get("service_tier") == "priority"
+        assert seen.get("stream") is False
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
## Root cause

The 66s-TTFT soak deaths (`STAGE_RT_HTTP_POST p50=66,775ms`, **0 APPLY across 6 capability soaks**) were never "RT is slow." DW routes `/v1/chat/completions` to its **realtime (priority) tier only when the body carries `service_tier: "priority"`**. `doubleword_provider.py` had **zero** occurrences of the param — every "RT" generation O+V ever made rode the **default async tier** (~1min TTFT under load). The entire Slice-36 batch-preference machinery grew around a tier we never asked to leave. The only code requesting priority was `cognition_lanes` (the council's voice) — which is why the council deliberated cleanly in ~70s while GENERATE starved.

## The fix — ONE decision seam, adaptive, env-tunable

- **`apply_rt_service_tier(body, model)`** stamps the tier on every realtime-plane body: `_generate_realtime` (SSE + non-streaming), `complete_sync` (heavy fn / Functions lane), `stream_health_probe` (probe the tier we actually generate on). **Batch bodies never carry it** (`submit_batch`, `prompt_only` bulk, `_generate_via_batch`) — the 2× batch discount is the point of that plane.
- **`_dw_note_tier_param_rejection`** at every RT error seam (both `_generate_realtime` branches + `_handle_rt_http_failure`): an unknown-parameter 400/422 *naming* `service_tier` caches the model so the CG retry omits the knob — no rejection loops. Status-gated: 403/429 stay entitlement/quota facts (Slice-17 "never a batch demotion" invariant untouched).
- **`cognition_lanes.rt_prompt`** now composes the same canonical helper (master flag + env tier + rejection cache honored everywhere); literal fallback keeps the lane standalone-injectable.
- Env: `JARVIS_DW_SERVICE_TIER_ENABLED` (default true), `JARVIS_DW_RT_SERVICE_TIER` (default `"priority"`).
- **Self-correcting downstream**: `DwLatencyTracker` is in-memory, so the Slice-185 latency governor re-elects RT naturally once priority-tier TTFT samples arrive — no ladder surgery needed.

## Live-fire evidence

A/B probe against the real grid (397B): `service_tier="priority"` **accepted** — `finish=stop`, tokens flow, no 400/403. Both tiers answer ~5-7s on an idle grid; the delta materializes under load per DW's documented queue semantics — exactly the soak condition that produced the 66s p50.

## Tests

15 new (`tests/governance/test_dw_priority_tier.py`): env contract, adaptive rejection learner (status-gated, substring-gated), AST wiring pins (every realtime seam wired, batch plane excluded, learner on every RT error seam), DRY pin on cognition_lanes, and a wire-truth test proving a real `complete_sync` POST carries the selector. Regression sweep: 134 passed across cognition_lanes / quota_taxonomy / RT resilience / substrate unmasking / tool forcing / reasoning profile / egress / stream probe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Injects `service_tier: "priority"` on all DoubleWord realtime requests so they use the realtime tier, fixing the 66s TTFT stalls under load. Batch requests are unchanged.

- **Bug Fixes**
  - Added `apply_rt_service_tier(body, model)` and wired it into `_generate_realtime`, `complete_sync`, `stream_health_probe`, and `cognition_lanes`; never applied to batch paths.
  - Introduced adaptive rejection: `_dw_note_tier_param_rejection` caches models on 400/422 unknown-param errors and omits `service_tier` on retry; 403/429 remain quota/entitlement.
  - Env toggles: `JARVIS_DW_SERVICE_TIER_ENABLED` (default true) and `JARVIS_DW_RT_SERVICE_TIER` (default `priority`).
  - Tests: added `tests/governance/test_dw_priority_tier.py` to pin helper behavior, wiring, and on-the-wire payload; updated CI.

<sup>Written for commit 429529d639b6af71bc045b205f5f51e64d8383c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70000?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

