### PR TITLE
feat(providers): Temporal Veto (Iron Gate) + Fast-Fail Load Shed — deadline-aware route invalidation

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -1952,6 +1952,10 @@ class FailureMode(Enum):
     CONTENT_FAILURE = auto()    # Bad output, infra healthy — no penalty
     CONTEXT_OVERFLOW = auto()   # Tool loop prompt exceeded char limit — immediate fallback
     TRANSIENT_TRANSPORT = auto()  # HTTP/2 disconnect, premature stream close — seconds
+    TEMPORAL_SHED = auto()      # Temporal Veto fast-fail — NOT a DW health fact;
+    #                             zero primary penalty, zero retry, immediate cascade.
+    #                             The op's budget was too tight for any DW lane; the
+    #                             NEXT op with a normal budget must still use DW.
 
 
 # Mode-specific recovery parameters for exponential backoff.
@@ -1967,6 +1971,9 @@ _RECOVERY_PARAMS: dict[FailureMode, dict[str, float]] = {
     # fallback to Tier 1 with zero backoff penalty (same profile as
     # CONTENT_FAILURE). No timeout ETA penalty on the FSM.
     FailureMode.CONTEXT_OVERFLOW: {"base_s": 0.0,  "max_s": 0.0},
+    # TEMPORAL_SHED: a routing refusal (deadline vs batch plane), not an
+    # infra failure — no backoff, DW immediately eligible for the next op.
+    FailureMode.TEMPORAL_SHED:   {"base_s": 0.0,  "max_s": 0.0},
     # TRANSIENT_TRANSPORT: HTTP/2 GOAWAY, RemoteProtocolError, ClosedResourceError.
     # The transport layer flapped (often a single dropped connection in a keep-alive
     # pool) but the upstream API is healthy. A 5s base backs off to 30s after 4
@@ -2470,6 +2477,13 @@ class FailbackStateMachine:
         """
         exc_type = type(exc).__name__
         msg = str(exc).lower()
+
+        # Temporal Veto fast-fail shed — checked FIRST (before the generic
+        # DoublewordInfraError status walk: it subclasses that type with
+        # status 0, which would otherwise fall through to the TIMEOUT
+        # default and earn DW an undeserved penalty + retry).
+        if exc_type == "TemporalBudgetShedError" or "temporal_load_shed" in msg:
+            return FailureMode.TEMPORAL_SHED
 
         # DoublewordInfraError carries a status code
         if exc_type == "DoublewordInfraError":
@@ -4089,7 +4103,13 @@ class CandidateGenerator:
                             mode.name, type(rt_exc).__name__, rt_exc,
                             self._remaining_seconds(deadline),
                         )
-                        if mode is not FailureMode.CONTENT_FAILURE:
+                        if mode not in (
+                            FailureMode.CONTENT_FAILURE,
+                            # A temporal shed is OUR routing refusal, not a DW
+                            # health fact — penalizing DW here would rotate the
+                            # funded primary out because ONE op ran tight.
+                            FailureMode.TEMPORAL_SHED,
+                        ):
                             self.fsm.record_primary_failure(mode=mode)
                             self._record_tier0_failure()
                             if self._latency_tracker is not None:

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -45,6 +45,7 @@ import time
 import dataclasses
 from dataclasses import dataclass, field
 from pathlib import Path
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Mapping, Optional, Tuple
 
 from backend.core.ouroboros.governance.op_context import (
@@ -1154,7 +1155,122 @@ def _dw_hedge_supersedes(context: Any, model_id: str = "") -> bool:
         return False
 
 
-def _slice36_should_force_batch(context: Any, *, model_id: str = "") -> bool:
+# ---------------------------------------------------------------------------
+# Temporal Veto (The Iron Gate, 2026-07-21) + Fast-Fail Load Shed
+# ---------------------------------------------------------------------------
+# The temporal impedance mismatch: a caller enforcing a tight client-side
+# bound (RepairEngine's 45s per-iter wait_for; any sla="strict" consumer)
+# could still have its op elected onto the BATCH plane by the Slice-36
+# ladder — a mail slot whose p95 can exceed the caller's entire budget.
+# The caller then kills the await at its bound, the batch keeps cooking
+# (billed), and the iteration dies as provider_iter_timeout: a silent
+# soak-killer. The veto is a DEADLINE-AWARE route invalidation evaluated
+# at the ONE dispatch seam: a deadline-bound op whose remaining budget
+# cannot safely absorb a batch cycle must never structurally reach the
+# batch plane. If DW's RT lane is ALSO unusable at that moment, the
+# router must not enter a doomed await — it FAST-FAIL sheds with a typed
+# error that rides the existing DoublewordInfraError cascade to Claude,
+# preserving the remaining budget for the tier that can spend it.
+
+
+def dw_temporal_veto_enabled() -> bool:
+    """Master for the deadline-aware batch veto. Default TRUE. NEVER raises."""
+    try:
+        return os.environ.get(
+            "JARVIS_DW_TEMPORAL_VETO_ENABLED", "true",
+        ).strip().lower() not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def dw_fast_fail_shed_enabled() -> bool:
+    """Master for the pre-RT fast-fail load shed (veto + RT-unusable →
+    immediate typed cascade instead of a doomed attempt). Default TRUE.
+    NEVER raises."""
+    try:
+        return os.environ.get(
+            "JARVIS_DW_FAST_FAIL_SHED_ENABLED", "true",
+        ).strip().lower() not in ("0", "false", "no", "off")
+    except Exception:  # noqa: BLE001
+        return True
+
+
+def _dw_batch_safe_ceiling_s() -> float:
+    """The minimum remaining budget (seconds) an op must hold before the
+    batch plane is a safe election. ADAPTIVE, not hardcoded: the floor is
+    env-tunable (``JARVIS_DW_BATCH_SAFE_CEILING_S``, default 50 — vetoes
+    the 45s repair per-iter class while sparing the 60s BACKGROUND
+    read-only stall budget), raised dynamically by the observed batch
+    latency estimate × a safety multiplier (``JARVIS_DW_BATCH_TTFT_S`` ×
+    ``JARVIS_DW_BATCH_CEILING_SAFETY_MULT``, default 3.0) so a slow batch
+    lane widens its own exclusion zone with zero config change. NEVER
+    raises."""
+    try:
+        raw = os.environ.get("JARVIS_DW_BATCH_SAFE_CEILING_S", "").strip()
+        floor = float(raw) if raw else 50.0
+        if floor <= 0:
+            return 0.0  # explicit 0 → veto disabled via ceiling
+        try:
+            mult = float(os.environ.get(
+                "JARVIS_DW_BATCH_CEILING_SAFETY_MULT", "3.0") or 3.0)
+        except Exception:  # noqa: BLE001
+            mult = 3.0
+        adaptive = _dw_batch_ttft_estimate_s() * (mult if mult > 0 else 3.0)
+        return max(floor, adaptive)
+    except Exception:  # noqa: BLE001
+        return 50.0
+
+
+def _dw_remaining_budget_s(deadline: Any) -> Optional[float]:
+    """Seconds remaining until ``deadline``, or None when the op carries no
+    temporal bound (None / unrecognized shape). Accepts the orchestrator's
+    datetime (aware or naive-UTC) and duck-typed deadline objects exposing
+    ``remaining_s()`` / ``remaining()``. NEVER raises."""
+    try:
+        if deadline is None:
+            return None
+        for _attr in ("remaining_s", "remaining"):
+            _fn = getattr(deadline, _attr, None)
+            if callable(_fn):
+                try:
+                    return float(_fn())
+                except Exception:  # noqa: BLE001
+                    continue
+        if isinstance(deadline, datetime):
+            _now = (
+                datetime.now(timezone.utc)
+                if deadline.tzinfo is not None
+                else datetime.utcnow()
+            )
+            return (deadline - _now).total_seconds()
+        return None
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _dw_temporal_veto(context: Any, remaining_budget_s: Optional[float]) -> bool:
+    """THE veto predicate: True when this op must never reach the batch
+    plane. Fires when (a) the op is deadline-bound with remaining budget
+    below the safe batch ceiling, or (b) the context is explicitly
+    stamped ``sla="strict"`` (future subsystems declare intent without
+    threading a deadline). An op with NO temporal bound is never vetoed —
+    fire-and-forget work keeps the batch discount. NEVER raises."""
+    try:
+        if not dw_temporal_veto_enabled():
+            return False
+        if str(getattr(context, "sla", "") or "").strip().lower() == "strict":
+            return True
+        if remaining_budget_s is None:
+            return False
+        ceiling = _dw_batch_safe_ceiling_s()
+        return ceiling > 0 and remaining_budget_s < ceiling
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _slice36_should_force_batch(
+    context: Any, *, model_id: str = "", remaining_budget_s: Optional[float] = None,
+) -> bool:
     """Slice 36 — adaptive transport selector decision.
 
     ``model_id`` (Slice 175): the resolved target DW model, so the predictive branch queries
@@ -1178,6 +1294,22 @@ def _slice36_should_force_batch(context: Any, *, model_id: str = "") -> bool:
     failure (returns False = preserve legacy RT behavior).
     """
     try:
+        # Temporal Veto (Iron Gate) — FIRST evaluation, supersedes everything
+        # including the sentinel command: a deadline-bound op whose remaining
+        # budget cannot absorb a batch cycle must never be force-batched, no
+        # matter what the reactive/predictive ladder wants. (Sentinel probes
+        # carry no deadline, so their ContextVar command is unaffected.)
+        if _dw_temporal_veto(context, remaining_budget_s):
+            logger.info(
+                "[TemporalVeto] force-batch VETOED: op=%s route=%s "
+                "remaining=%.1fs < ceiling=%.1fs (deadline-bound op shall "
+                "not enter the mail slot)",
+                (getattr(context, "op_id", "?") or "?")[:16],
+                getattr(context, "provider_route", "?"),
+                remaining_budget_s if remaining_budget_s is not None else -1.0,
+                _dw_batch_safe_ceiling_s(),
+            )
+            return False
         # Slice 192 — THE PROACTIVE HIERARCHY (supersedes ALL reactive force-batch). When the
         # transport-hedge is active and no STORM is forecast, RACE instead of force-batching —
         # this explicitly OVERRIDES the cold-start timer (184), the warm-boot ledger flags (179),
@@ -1707,6 +1839,52 @@ class SovereignBatchTimeoutError(DoublewordInfraError):
         )
         self.elapsed_s = elapsed_s
         self.deadline_s = deadline_s
+
+
+class TemporalBudgetShedError(DoublewordInfraError):
+    """Temporal Veto (Iron Gate) — Fast-Fail load shed.
+
+    Raised by ``_dispatch_internal`` when a deadline-bound op (remaining
+    budget below the safe batch ceiling, or ``sla="strict"``) is vetoed off
+    the batch plane AND no DW realtime lane can serve it — RT disabled,
+    the model marked RT-unavailable in the transport profile, or the
+    persisted ledger showing the stream actively rupturing. Rather than
+    hang in a doomed await (the RepairEngine 45s-vs-batch impedance
+    mismatch), the router refuses INSTANTLY so the remaining budget is
+    preserved for the Claude fallback tier.
+
+    Subclasses ``DoublewordInfraError`` so it rides the existing
+    non-retriable re-raise path to the CandidateGenerator FSM (the same
+    proven route a 403 takes). ``status_code=0`` — this is OUR routing
+    refusal, never a vendor fact: it must not trip vendor breakers,
+    poison the transport profile, or count as a DW health failure. The
+    message carries the ``temporal_load_shed`` marker the FSM classifier
+    maps to ``FailureMode.TEMPORAL_SHED`` (zero primary penalty, zero
+    retry, immediate cascade).
+    """
+
+    def __init__(
+        self,
+        reason: str,
+        *,
+        model_id: str = "",
+        remaining_s: Optional[float] = None,
+        ceiling_s: Optional[float] = None,
+    ) -> None:
+        super().__init__(
+            f"temporal_load_shed: {reason} "
+            f"(remaining={remaining_s if remaining_s is not None else -1.0:.1f}s "
+            f"ceiling={ceiling_s if ceiling_s is not None else -1.0:.1f}s)",
+            status_code=0,
+            model_id=model_id,
+        )
+        self.remaining_s = remaining_s
+        self.ceiling_s = ceiling_s
+
+    def is_transient(self) -> bool:
+        """A shed is deterministic for the same (budget, RT-state) — an
+        immediate retry re-sheds. Never transient-retriable on DW."""
+        return False
 
 
 class BatchStalledError(SovereignBatchTimeoutError):
@@ -3566,8 +3744,17 @@ class DoublewordProvider:
         # in this method's scope (defined only in submit_batch / _generate_realtime), so this
         # threw NameError on every RT op since Slice 175 — caught + mislabeled as a vendor
         # live_transport rupture. Resolve it natively in scope.
+        # ── Temporal Veto (Iron Gate) — evaluated ONCE at the dispatch seam,
+        # threaded through every batch-election site below. Centralized here
+        # so RepairEngine and every future sla="strict" subsystem is
+        # protected with zero call-site logic (they just pass an honest
+        # deadline).
+        _veto_remaining = _dw_remaining_budget_s(deadline)
+        _dispatch_model = self._resolve_effective_model(context)
+        _temporal_veto = _dw_temporal_veto(context, _veto_remaining)
         _slice36_force_batch = _slice36_should_force_batch(
-            context, model_id=self._resolve_effective_model(context),
+            context, model_id=_dispatch_model,
+            remaining_budget_s=_veto_remaining,
         )
         if _slice36_force_batch:
             # Slice 171 — surface the Slice 170 capital save (records iff Claude was
@@ -3585,7 +3772,13 @@ class DoublewordProvider:
         # Slice 189 Phase 2 — STORM cost-optimizer. Before any RT attempt, consult the EXISTING
         # predictive cortex (172-176). If a platform-wide rupture STORM is forecast, racing the
         # RT path is pure waste (it will rupture) — force batch-only, saving the hedge spend.
-        if not _slice36_force_batch and self._s189_storm_forces_batch(context):
+        # Temporal Veto guard: a deadline-bound op cannot ride out a storm in
+        # the mail slot — it sheds to Claude below instead.
+        if (
+            not _slice36_force_batch
+            and not _temporal_veto
+            and self._s189_storm_forces_batch(context)
+        ):
             _slice36_force_batch = True
 
         # Iron Gate alignment override — when the exploration gate will demand
@@ -3619,6 +3812,51 @@ class DoublewordProvider:
                         _slice36_force_batch = False
             except Exception:  # noqa: BLE001 — fail-soft; preserve batch on error
                 pass
+
+        # ── Fast-Fail Load Shed (Temporal Veto edge case) ──────────────
+        # The veto has forced this op off the batch plane. If DW's RT lane
+        # is ALSO structurally unusable right now — disabled, the model
+        # marked RT-unavailable in the transport profile (403 entitlement),
+        # or the persisted ledger showing the stream actively rupturing —
+        # then NO DW lane can serve within the budget. Do not enter a
+        # doomed await: refuse instantly with the typed shed error so the
+        # CandidateGenerator cascades to Claude with the budget intact.
+        if _temporal_veto and dw_fast_fail_shed_enabled():
+            _rt_unusable_reason = ""
+            if not self._realtime_enabled:
+                _rt_unusable_reason = "rt_disabled"
+            if not _rt_unusable_reason:
+                try:
+                    from backend.core.ouroboros.governance.dw_transport_profile import (  # noqa: E501
+                        TRANSPORT_REALTIME as _shed_rt,
+                        get_transport_profile as _shed_profile,
+                    )
+                    if _shed_profile().is_unavailable(_dispatch_model, _shed_rt):
+                        _rt_unusable_reason = "rt_model_unavailable"
+                except Exception:  # noqa: BLE001 — profile probe never blocks RT
+                    pass
+            if not _rt_unusable_reason:
+                try:
+                    if _dw_streaming_warm_degraded():
+                        _rt_unusable_reason = "rt_stream_rupturing"
+                except Exception:  # noqa: BLE001
+                    pass
+            if _rt_unusable_reason:
+                logger.warning(
+                    "[TemporalVeto] FAST-FAIL LOAD SHED: op=%s route=%s "
+                    "remaining=%.1fs — batch vetoed AND RT unusable (%s) → "
+                    "shedding to fallback tier with budget intact (model=%s)",
+                    (getattr(context, "op_id", "?") or "?")[:16],
+                    getattr(context, "provider_route", "?"),
+                    _veto_remaining if _veto_remaining is not None else -1.0,
+                    _rt_unusable_reason, _dispatch_model,
+                )
+                raise TemporalBudgetShedError(
+                    _rt_unusable_reason,
+                    model_id=_dispatch_model,
+                    remaining_s=_veto_remaining,
+                    ceiling_s=_dw_batch_safe_ceiling_s(),
+                )
 
         # A1-DIAG: dispatch-level topology diagnostic (env-gated, preemption-proof).
         # Captures the RT vs batch branch decision BEFORE it executes, so a SPOT
@@ -3658,7 +3896,10 @@ class DoublewordProvider:
             # concurrently; take the winner; an RT rupture is SWALLOWED so batch still wins —
             # the op NEVER waits for the rupture. Reuses _generate_realtime + _generate_via_batch
             # (no duplication). Gated; off → the legacy sequential RT-then-fallback below.
-            if self._s189_transport_hedge_active():
+            # Temporal Veto guard: a deadline-bound op must not launch a batch
+            # arm at all — pure RT below; a rupture then sheds at the batch
+            # chokepoint instead of silently landing in the mail slot.
+            if self._s189_transport_hedge_active() and not _temporal_veto:
                 from backend.core.ouroboros.governance.dw_transport_hedge import hedged_race
                 from backend.core.ouroboros.governance.dw_immortal import (
                     hedge_to_batch_on_rupture as _s189_is_rupture,
@@ -3874,6 +4115,30 @@ class DoublewordProvider:
                     raise  # Non-retriable: propagate to CandidateGenerator FSM
 
         # Batch mode: 4-stage async batch API (fallback from real-time, or explicit opt-in)
+        # ── Temporal Veto TERMINAL CHOKEPOINT ──────────────────────────
+        # Every batch entry in this dispatcher funnels through this ONE
+        # call: force-batch, RT-disabled, the Slice-181 rupture hedge, and
+        # the 429/503 fallback. A deadline-bound op reaching here means
+        # every realtime avenue is exhausted — entering the mail slot now
+        # guarantees the caller's wait_for kills the await while the batch
+        # keeps cooking (billed). Shed instead: the typed error rides the
+        # existing non-retriable cascade to Claude with the budget intact.
+        if _temporal_veto:
+            logger.warning(
+                "[TemporalVeto] batch chokepoint SHED: op=%s route=%s "
+                "remaining=%.1fs < ceiling=%.1fs — RT avenues exhausted, "
+                "refusing the mail slot → fallback tier (model=%s)",
+                (getattr(context, "op_id", "?") or "?")[:16],
+                getattr(context, "provider_route", "?"),
+                _veto_remaining if _veto_remaining is not None else -1.0,
+                _dw_batch_safe_ceiling_s(), _dispatch_model,
+            )
+            raise TemporalBudgetShedError(
+                "batch_chokepoint_rt_exhausted",
+                model_id=_dispatch_model,
+                remaining_s=_veto_remaining,
+                ceiling_s=_dw_batch_safe_ceiling_s(),
+            )
         t0 = time.monotonic()
         self._last_error_status = 0  # reset before attempt
 

--- a/backend/core/ouroboros/governance/provider_retry_classifier.py
+++ b/backend/core/ouroboros/governance/provider_retry_classifier.py
@@ -208,6 +208,11 @@ _FAILURE_MODE_DEFAULT: dict = {
     "CONTENT_FAILURE":      RetryDecision.RETRY_TRANSIENT,
     "CONTEXT_OVERFLOW":     RetryDecision.RETRY_TRANSIENT,
     "TRANSIENT_TRANSPORT":  RetryDecision.RETRY_TRANSIENT,
+    # Temporal Veto fast-fail shed (Iron Gate, 2026-07-21): a routing
+    # refusal, not a provider fault. Retrying the same provider with the
+    # same shrinking budget is a hard inequality — it CANNOT succeed;
+    # the op must cascade to the fallback tier immediately.
+    "TEMPORAL_SHED":        RetryDecision.TERMINAL_STRUCTURAL,
 }
 
 

--- a/backend/core/ouroboros/governance/repair_engine.py
+++ b/backend/core/ouroboros/governance/repair_engine.py
@@ -28,7 +28,7 @@ import logging
 import os
 import time
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 from typing import Any, Dict, Optional, Set, Tuple
 
@@ -1866,6 +1866,17 @@ class RepairEngine:
         _effective_timeout_s = max(
             1.0, min(_per_iter_bound, _remaining_pipeline_s),
         )
+        # Temporal Veto (Iron Gate, 2026-07-21) — the deadline the provider
+        # receives must be the TRUTH. Historically we passed the pipeline
+        # deadline while enforcing the narrower per-iter wait_for below, so
+        # the provider believed it had minutes and could elect the BATCH
+        # plane — then this client-side bound killed the await at 45s while
+        # the batch kept cooking (billed): the provider_iter_timeout soak-
+        # killer. Tightening the deadline to the effective bound lets the
+        # provider's centralized Temporal Veto exclude the batch plane (and
+        # fast-fail shed to Claude when RT is also down) with ZERO veto
+        # logic at this call site. Still ≤ pipeline_deadline by construction.
+        _provider_deadline = _now + timedelta(seconds=_effective_timeout_s)
         # Adaptive Epistemic Feedback Matrix (T2): thread the signature-driven
         # temperature override into the provider generate call. Passed only when the
         # caller supplied a non-None value AND it differs from the implicit provider
@@ -1877,17 +1888,17 @@ class RepairEngine:
             if temperature is not None:
                 try:
                     return await self._prime.generate(
-                        ctx, pipeline_deadline,
+                        ctx, _provider_deadline,
                         repair_context=repair_context,
                         temperature=temperature,
                     )
                 except TypeError:
                     # Provider does not accept temperature — fall back to legacy shape.
                     return await self._prime.generate(
-                        ctx, pipeline_deadline, repair_context=repair_context,
+                        ctx, _provider_deadline, repair_context=repair_context,
                     )
             return await self._prime.generate(
-                ctx, pipeline_deadline, repair_context=repair_context,
+                ctx, _provider_deadline, repair_context=repair_context,
             )
 
         try:

--- a/ci/ov-surface-suites.txt
+++ b/ci/ov-surface-suites.txt
@@ -15,3 +15,4 @@ tests/api/test_hive_council_layer.py
 tests/governance/test_quota_taxonomy.py
 tests/governance/test_cognition_lanes.py
 tests/governance/test_dw_priority_tier.py
+tests/governance/test_dw_temporal_veto.py

--- a/tests/governance/test_dw_temporal_veto.py
+++ b/tests/governance/test_dw_temporal_veto.py
@@ -1,0 +1,339 @@
+"""Temporal Veto (Iron Gate) + Fast-Fail Load Shed.
+
+The temporal impedance mismatch: RepairEngine enforces a 45s per-iter
+client-side ``wait_for`` while the Slice-36 ladder could still elect the
+op onto the BATCH plane — the caller kills the await at its bound, the
+batch keeps cooking (billed), the iteration dies as provider_iter_timeout.
+
+These tests pin the three-layer defense:
+  1. predicate veto (deadline-aware top rung in _slice36_should_force_batch)
+  2. fast-fail load shed (veto + RT-unusable → typed error in milliseconds)
+  3. terminal chokepoint (the ONE _generate_via_batch entry refuses
+     deadline-bound ops — covers rupture/429/503 fallthroughs + RT-disabled)
+plus the FSM taxonomy (TEMPORAL_SHED: zero DW penalty, zero retry,
+immediate Claude cascade) and the RepairEngine truthful-deadline fix.
+"""
+from __future__ import annotations
+
+import asyncio
+import time
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance import doubleword_provider as dwp
+from backend.core.ouroboros.governance.candidate_generator import (
+    CandidateGenerator,
+    FailbackStateMachine,
+    FailureMode,
+    _is_outer_retry_eligible_mode,
+)
+
+
+def _ctx(route: str = "complex", **kw) -> SimpleNamespace:
+    base = dict(
+        op_id="op-veto-test", operation_id="op-veto-test",
+        provider_route=route, task_complexity="complex",
+        routing=None, cross_repo=False, target_files=(),
+        is_read_only=False,
+    )
+    base.update(kw)
+    return SimpleNamespace(**base)
+
+
+def _deadline_s(seconds: float) -> datetime:
+    return datetime.now(timezone.utc) + timedelta(seconds=seconds)
+
+
+# ---------------------------------------------------------------------------
+# Layer 0 — the deadline math + veto predicate (env contract)
+# ---------------------------------------------------------------------------
+
+def test_remaining_budget_shapes():
+    assert dwp._dw_remaining_budget_s(None) is None
+    r = dwp._dw_remaining_budget_s(_deadline_s(45))
+    assert r is not None and 43 < r <= 45.5
+    # naive-UTC datetime (legacy callers)
+    naive = datetime.utcnow() + timedelta(seconds=100)
+    rn = dwp._dw_remaining_budget_s(naive)
+    assert rn is not None and 98 < rn <= 100.5
+    # duck-typed deadline object
+    duck = SimpleNamespace(remaining_s=lambda: 33.0)
+    assert dwp._dw_remaining_budget_s(duck) == 33.0
+    # unrecognized shape → None, never raises
+    assert dwp._dw_remaining_budget_s(object()) is None
+
+
+def test_ceiling_is_adaptive_not_hardcoded(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_BATCH_SAFE_CEILING_S", raising=False)
+    monkeypatch.delenv("JARVIS_DW_BATCH_TTFT_S", raising=False)
+    monkeypatch.delenv("JARVIS_DW_BATCH_CEILING_SAFETY_MULT", raising=False)
+    # default: floor 50 dominates (8s TTFT est × 3 = 24)
+    assert dwp._dw_batch_safe_ceiling_s() == 50.0
+    # a slow batch lane WIDENS its own exclusion zone with zero config
+    monkeypatch.setenv("JARVIS_DW_BATCH_TTFT_S", "40")
+    assert dwp._dw_batch_safe_ceiling_s() == 120.0
+    # explicit floor override
+    monkeypatch.delenv("JARVIS_DW_BATCH_TTFT_S", raising=False)
+    monkeypatch.setenv("JARVIS_DW_BATCH_SAFE_CEILING_S", "75")
+    assert dwp._dw_batch_safe_ceiling_s() == 75.0
+    # explicit 0 disables the ceiling entirely
+    monkeypatch.setenv("JARVIS_DW_BATCH_SAFE_CEILING_S", "0")
+    assert dwp._dw_batch_safe_ceiling_s() == 0.0
+
+
+def test_veto_predicate(monkeypatch):
+    monkeypatch.delenv("JARVIS_DW_TEMPORAL_VETO_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_DW_BATCH_SAFE_CEILING_S", raising=False)
+    assert dwp._dw_temporal_veto(_ctx(), 45.0) is True       # 45 < 50
+    assert dwp._dw_temporal_veto(_ctx(), 300.0) is False     # fat budget
+    assert dwp._dw_temporal_veto(_ctx(), None) is False      # unbounded op
+    # sla="strict" declares intent WITHOUT a threaded deadline
+    assert dwp._dw_temporal_veto(_ctx(sla="strict"), None) is True
+    # master off → never veto
+    monkeypatch.setenv("JARVIS_DW_TEMPORAL_VETO_ENABLED", "false")
+    assert dwp._dw_temporal_veto(_ctx(), 45.0) is False
+
+
+# ---------------------------------------------------------------------------
+# Layer 1 — the predicate veto beats every force-batch rung
+# ---------------------------------------------------------------------------
+
+def test_force_batch_vetoed_on_tight_budget(monkeypatch):
+    """The legacy pure-DW static rung (Claude-disabled + complex route)
+    historically returns True — the veto must beat it."""
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "1")
+    monkeypatch.setenv("JARVIS_DW_TRANSPORT_HEDGE_ENABLED", "false")
+    monkeypatch.delenv("JARVIS_DW_TEMPORAL_VETO_ENABLED", raising=False)
+    ctx = _ctx("complex")
+    # fat budget: the ladder may elect batch (True historically)
+    assert dwp._slice36_should_force_batch(
+        ctx, model_id="m", remaining_budget_s=600.0) is True
+    # tight budget: VETO — deterministic False, no matter the ladder
+    assert dwp._slice36_should_force_batch(
+        ctx, model_id="m", remaining_budget_s=45.0) is False
+    # no budget info (legacy call shape) → byte-identical legacy behavior
+    assert dwp._slice36_should_force_batch(ctx, model_id="m") is True
+
+
+# ---------------------------------------------------------------------------
+# Layer 2+3 — THE MANDATE INTEGRATION: 45s deadline, COMPLEX route,
+# RT UNAVAILABLE → veto blocks batch, fast-fail shed, budget preserved
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_fast_fail_shed_when_rt_profile_unavailable(monkeypatch):
+    """realtime_enabled=True but the transport profile marks the model
+    RT-unavailable (403 entitlement class): the shed fires BEFORE any
+    network attempt — milliseconds, not a 45s zombie await."""
+    from backend.core.ouroboros.governance import dw_transport_profile as tp
+
+    monkeypatch.setenv("JARVIS_PROVIDER_CLAUDE_DISABLED", "1")
+
+    class _FakeProfile:
+        def is_unavailable(self, model_id, transport):
+            return transport == tp.TRANSPORT_REALTIME
+
+    monkeypatch.setattr(tp, "get_transport_profile", lambda: _FakeProfile())
+
+    dw = dwp.DoublewordProvider(
+        api_key="test-key", base_url="http://127.0.0.1:9/v1",
+        model="test-model", realtime_enabled=True)
+    t0 = time.monotonic()
+    with pytest.raises(dwp.TemporalBudgetShedError) as ei:
+        await dw.generate(_ctx("complex"), _deadline_s(45))
+    elapsed = time.monotonic() - t0
+    assert elapsed < 5.0, f"shed took {elapsed:.1f}s — not a fast-fail"
+    assert "temporal_load_shed" in str(ei.value)
+    assert "rt_model_unavailable" in str(ei.value)
+    assert isinstance(ei.value, dwp.DoublewordInfraError)  # rides the cascade
+    assert ei.value.is_transient() is False                # never DW-retried
+
+
+@pytest.mark.asyncio
+async def test_shed_when_rt_disabled(monkeypatch):
+    """realtime_enabled=False: the only DW lane is batch (E path). A 45s
+    op must NOT enter the mail slot — the fast-fail layer sheds instantly
+    (structurally BEFORE the chokepoint: budget preserved even sooner)."""
+    monkeypatch.delenv("JARVIS_DW_TEMPORAL_VETO_ENABLED", raising=False)
+    dw = dwp.DoublewordProvider(
+        api_key="test-key", base_url="http://127.0.0.1:9/v1",
+        model="test-model", realtime_enabled=False)
+    t0 = time.monotonic()
+    with pytest.raises(dwp.TemporalBudgetShedError) as ei:
+        await dw.generate(_ctx("complex"), _deadline_s(45))
+    assert time.monotonic() - t0 < 5.0
+    assert "rt_disabled" in str(ei.value)
+
+
+@pytest.mark.asyncio
+async def test_chokepoint_sheds_the_503_fallthrough(monkeypatch):
+    """The D″ seam: RT was USABLE (no fast-fail) but 503'd mid-op — the
+    legacy fallthrough re-submits over BATCH in the same tick. Under the
+    veto, the terminal chokepoint refuses the mail slot instead."""
+    monkeypatch.delenv("JARVIS_DW_TEMPORAL_VETO_ENABLED", raising=False)
+    # isolate from the REAL persisted ledgers on this machine: RT must
+    # look fully usable so the fast-fail layer does NOT fire first
+    monkeypatch.setattr(dwp, "_dw_streaming_warm_degraded", lambda: False)
+    from backend.core.ouroboros.governance import dw_transport_profile as tp
+    monkeypatch.setattr(
+        tp, "get_transport_profile",
+        lambda: SimpleNamespace(is_unavailable=lambda m, t: False))
+    dw = dwp.DoublewordProvider(
+        api_key="test-key", base_url="http://127.0.0.1:9/v1",
+        model="test-model", realtime_enabled=True)
+
+    async def _rt_503(context, deadline, **kw):
+        raise dwp.DoublewordInfraError("overloaded", status_code=503)
+
+    batch_entered = {"n": 0}
+
+    async def _batch_spy(context, prompt_override=None):
+        batch_entered["n"] += 1
+        return "batch-reached"
+
+    monkeypatch.setattr(dw, "_generate_realtime", _rt_503)
+    monkeypatch.setattr(dw, "_generate_via_batch", _batch_spy)
+    with pytest.raises(dwp.TemporalBudgetShedError) as ei:
+        await dw.generate(_ctx("complex"), _deadline_s(45))
+    assert "batch_chokepoint_rt_exhausted" in str(ei.value)
+    assert batch_entered["n"] == 0, "mail slot was entered despite the veto"
+
+
+@pytest.mark.asyncio
+async def test_fat_budget_op_still_reaches_batch(monkeypatch):
+    """Anti-overreach pin: an op with a FAT budget and RT disabled must
+    still enter the batch plane (the discount is the point) — the veto
+    only excludes deadline-bound ops."""
+    dw = dwp.DoublewordProvider(
+        api_key="test-key", base_url="http://127.0.0.1:9/v1",
+        model="test-model", realtime_enabled=False)
+
+    async def _fake_batch(context, prompt_override=None):
+        return "batch-reached"
+
+    monkeypatch.setattr(dw, "_generate_via_batch", _fake_batch)
+    out = await dw.generate(_ctx("complex"), _deadline_s(600))
+    assert out == "batch-reached"
+
+
+# ---------------------------------------------------------------------------
+# FSM taxonomy — a shed is a routing refusal, NOT a DW health fact
+# ---------------------------------------------------------------------------
+
+def test_shed_classifies_as_temporal_shed():
+    exc = dwp.TemporalBudgetShedError(
+        "rt_disabled", model_id="m", remaining_s=45.0, ceiling_s=50.0)
+    assert FailbackStateMachine.classify_exception(exc) is FailureMode.TEMPORAL_SHED
+
+
+def test_shed_is_never_outer_retry_eligible():
+    assert _is_outer_retry_eligible_mode(FailureMode.TEMPORAL_SHED) is False
+
+
+def test_shed_has_zero_recovery_penalty():
+    from backend.core.ouroboros.governance.candidate_generator import (
+        _RECOVERY_PARAMS,
+    )
+    params = _RECOVERY_PARAMS[FailureMode.TEMPORAL_SHED]
+    assert params["base_s"] == 0.0 and params["max_s"] == 0.0
+
+
+# ---------------------------------------------------------------------------
+# THE MANDATE CASCADE TEST — CG routes the shed to the Claude fallback
+# adapter well within the 45s budget, with ZERO DW penalty recorded
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_shed_cascades_to_claude_within_budget(monkeypatch):
+    from backend.core.ouroboros.governance import provider_topology as pt
+
+    monkeypatch.setattr(
+        pt, "get_topology",
+        lambda: SimpleNamespace(
+            enabled=False,
+            is_dw_blocked_for_route=lambda route: (False, "", ""),
+        ),
+    )
+    monkeypatch.delenv("JARVIS_PROVIDER_CLAUDE_DISABLED", raising=False)
+    # env-isolation: this machine's real promotion ledger (12 records)
+    # otherwise trips the Slice-23 multi_model_fleet sentinel activation
+    monkeypatch.setenv("JARVIS_TOPOLOGY_SENTINEL_ENABLED", "false")
+
+    class _ShedDW:
+        provider_name = "doubleword"
+        is_available = True
+        _realtime_enabled = True
+        _model = "test-model"
+
+        def __init__(self):
+            self.calls = 0
+
+        async def generate(self, context, deadline, **kw):
+            self.calls += 1
+            raise dwp.TemporalBudgetShedError(
+                "rt_model_unavailable", model_id="test-model",
+                remaining_s=45.0, ceiling_s=50.0)
+
+    class _FakeClaude:
+        provider_name = "claude"
+        is_available = True
+
+        def __init__(self):
+            self.calls = 0
+
+        async def generate(self, context, deadline, **kw):
+            self.calls += 1
+            return SimpleNamespace(
+                candidates=({"fake": True},),
+                provider_name="claude",
+                generation_duration_s=0.1,
+                total_output_tokens=1, cost_usd=0.0,
+            )
+
+    fake_dw = _ShedDW()
+    fake_claude = _FakeClaude()
+    cg = CandidateGenerator(
+        primary=fake_dw, fallback=fake_claude, tier0=fake_dw)
+
+    ctx = _ctx("complex")
+    t0 = time.monotonic()
+    result = await asyncio.wait_for(
+        cg.generate(ctx, _deadline_s(45)), timeout=40.0)
+    elapsed = time.monotonic() - t0
+
+    assert fake_dw.calls == 1, "DW attempted exactly once (no shed retry)"
+    assert fake_claude.calls >= 1, "Claude fallback adapter was never reached"
+    assert result is not None and len(result.candidates) == 1
+    assert result.provider_name == "claude"
+    assert elapsed < 30.0, f"cascade took {elapsed:.1f}s of a 45s budget"
+    # zero DW penalty: the FSM did not record a primary failure
+    assert cg.fsm._consecutive_failures == 0
+    assert cg.fsm._failure_mode is None
+
+
+# ---------------------------------------------------------------------------
+# Wiring pins — the veto is structurally where it claims to be
+# ---------------------------------------------------------------------------
+
+def test_wiring_pins():
+    import pathlib
+    root = pathlib.Path(__file__).resolve().parents[2]
+    gov = root / "backend" / "core" / "ouroboros" / "governance"
+    dw_src = (gov / "doubleword_provider.py").read_text()
+    # veto rung is the FIRST evaluation in the predicate
+    pred = dw_src.index("def _slice36_should_force_batch")
+    veto_rung = dw_src.index("_dw_temporal_veto(context, remaining_budget_s)", pred)
+    hedge_rung = dw_src.index("_dw_hedge_supersedes(context, model_id)", pred)
+    assert veto_rung < hedge_rung
+    # terminal chokepoint guards the ONE batch entry in dispatch
+    choke = dw_src.index("batch_chokepoint_rt_exhausted")
+    batch_call = dw_src.index(
+        "result = await self._generate_via_batch(context, prompt_override)")
+    assert choke < batch_call
+    # RepairEngine passes the TRUTHFUL deadline (no veto logic at call site)
+    rep_src = (gov / "repair_engine.py").read_text()
+    assert "_provider_deadline = _now + timedelta(seconds=_effective_timeout_s)" in rep_src
+    assert "ctx, _provider_deadline" in rep_src
+    assert "_dw_temporal_veto" not in rep_src  # centralized — DRY holds


### PR DESCRIPTION
Successor to #70001 (auto-closed when its stacked base branch was deleted on the #70000 merge — content identical, rebased onto main; CI ov-surface legs were double-green on the original: py3.11 1m21s / py3.12 40s).

See #70001 for the full description: three-layer deadline-aware route invalidation (predicate veto → fast-fail `TemporalBudgetShedError` shed → terminal batch chokepoint), `FailureMode.TEMPORAL_SHED` zero-penalty taxonomy, RepairEngine truthful-deadline fix, 13 tests + A/B-verified sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds deadline-aware routing to `DoublewordProvider` to keep tight-budget ops off the batch plane and fast-fail to the fallback tier when RT can’t serve. Also passes the truthful per-iteration deadline from `RepairEngine` to make routing decisions accurate.

- **New Features**
  - Deadline-aware veto in `_slice36_should_force_batch` blocks batch when remaining budget is below an adaptive ceiling or `sla="strict"`. Ceiling is driven by `JARVIS_DW_BATCH_SAFE_CEILING_S`, `JARVIS_DW_BATCH_TTFT_S`, and `JARVIS_DW_BATCH_CEILING_SAFETY_MULT`.
  - Fast-fail load shed in `_dispatch_internal` raises `TemporalBudgetShedError` when vetoed and RT is unusable (disabled, RT-unavailable, or rupturing). Status code 0, no DW breaker impact.
  - Terminal batch chokepoint rejects all batch entries for vetoed ops, including 429/503 fallthroughs and rupture hedges; hedge race skips its batch arm under veto.
  - New `FailureMode.TEMPORAL_SHED` with zero backoff; `provider_retry_classifier` maps it to `TERMINAL_STRUCTURAL`; `CandidateGenerator` skips primary-failure penalties for sheds.
  - Tests added for veto, fast-fail, chokepoint, and cascade behavior; CI suite updated.

- **Bug Fixes**
  - `RepairEngine` now sends the per-iteration effective deadline (not the broader pipeline deadline), aligning provider routing with the caller’s true budget.
  - Exception classification prioritizes `TemporalBudgetShedError`, ensuring it’s handled as `TEMPORAL_SHED` and never mis-penalizes DW.

<sup>Written for commit 5d21857b086e70388f061c6fe9da759989d973a9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70002?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

