### PR TITLE
feat(governance): Path Canonicalization Sandbox + Universal Target-Existence Gate + Atomic Flush & Freeze

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3058,6 +3058,18 @@ JARVIS_ADVISOR_LOCALITY_MAX_SCANNED=4000
 JARVIS_ADVISOR_LOCALITY_MAX_ROOTS=16
 JARVIS_ADVISOR_COLD_ROOT_TTL_S=300
 
+# --- Path Canonicalization Sandbox + Universal Target-Existence Gate (2026-07-21) ---
+JARVIS_CHANGE_PATH_CANONICALIZATION_ENABLED=true
+JARVIS_TARGET_EXISTENCE_GATE_UNIVERSAL=true
+
+# --- Atomic Flush & Freeze (post-APPLY diff capture + mutation park; default OFF,
+#     supervised validation soaks opt in) ---
+JARVIS_APPLY_FLUSH_FREEZE_ENABLED=false
+JARVIS_APPLY_FREEZE_MAX_MUTATIONS=1
+JARVIS_APPLY_FREEZE_DIFF_MAX_BYTES=262144
+JARVIS_APPLY_FREEZE_ARTIFACT_DIR=
+JARVIS_APPLY_FREEZE_GIT_TIMEOUT_S=15
+
 # ============================================================================
 # END OF CONFIGURATION
 # ============================================================================

--- a/backend/core/ouroboros/governance/apply_flush_freeze.py
+++ b/backend/core/ouroboros/governance/apply_flush_freeze.py
@@ -1,0 +1,395 @@
+"""Atomic Flush & Freeze — post-APPLY mutation telemetry + park (2026-07-21).
+
+The Autonomous Cascade Trap: the instant a governed APPLY lands on disk, the
+host reacts — FS-watching sensors fire on the mutation, dev-server hot-reload
+watchers may recycle the serving loop, and an autonomous generation loop can
+begin stacking FURTHER mutations on top of an un-reviewed one. If the process
+is recycled mid-emission, the outbound telemetry describing the mutation is
+severed and the operator learns nothing about what changed.
+
+This module is the deterministic countermeasure, engaged at the ChangeEngine
+success seam (post-2PC-VERIFY, post-APPLIED ledger record — a write that is
+provably durable, never one that may still roll back):
+
+1. **Capture** — the mutation's ``git diff`` via an async subprocess against
+   the write root (untracked new files captured via ``git diff --no-index``),
+   byte-bounded.
+2. **Persist** — the diff lands as a durable artifact file AND is logged in
+   full (bounded) to the session ``debug.log``, so a severed socket can never
+   lose the record.
+3. **Flush** — the diff metadata is serialized into a high-priority
+   ``actor_edge`` envelope through the EXISTING ``HiveEmitter``
+   (``hive_emit`` + ``hive_flush`` — the zero-authority emission edge; DRY,
+   no parallel transport) and the enqueue is DEMONSTRATED via the emitter's
+   ``stats["emitted"]`` delta before the engine proceeds.
+4. **Freeze** — once ``JARVIS_APPLY_FREEZE_MAX_MUTATIONS`` (default 1)
+   successful mutations have flushed, the process-wide freeze latch closes:
+   every subsequent ``ChangeEngine.execute`` short-circuits to
+   ``POLICY_DENIED reason=apply_frozen_pending_review`` BEFORE any byte is
+   staged (the ``generation_fence.is_fenced()`` idiom — same chokepoint,
+   same shape). The cascade is structurally impossible; a human reviews the
+   parked diff.
+
+Master ``JARVIS_APPLY_FLUSH_FREEZE_ENABLED`` — default **false** (production
+autonomy is not silently crippled); supervised validation soaks opt in at
+launch. All knobs env-tunable; no hardcoding. Telemetry/persistence failures
+are fail-soft but the freeze latch still closes — observability may degrade,
+containment never does.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import logging
+import os
+import threading
+import time
+from pathlib import Path
+from typing import Any, Dict, Optional, Sequence
+
+logger = logging.getLogger(__name__)
+
+
+_ENABLED_ENV = "JARVIS_APPLY_FLUSH_FREEZE_ENABLED"
+_MAX_MUTATIONS_ENV = "JARVIS_APPLY_FREEZE_MAX_MUTATIONS"
+_DIFF_MAX_BYTES_ENV = "JARVIS_APPLY_FREEZE_DIFF_MAX_BYTES"
+_ARTIFACT_DIR_ENV = "JARVIS_APPLY_FREEZE_ARTIFACT_DIR"
+_GIT_TIMEOUT_ENV = "JARVIS_APPLY_FREEZE_GIT_TIMEOUT_S"
+
+#: The ChangeEngine denial marker (grep-discoverable, mirrors the
+#: generation_fence / mutation_budget POLICY_DENIED taxonomy).
+FROZEN_DENIAL_REASON = "POLICY_DENIED reason=apply_frozen_pending_review"
+
+
+def flush_freeze_enabled() -> bool:
+    """Master flag — default FALSE (supervised soaks opt in)."""
+    raw = os.environ.get(_ENABLED_ENV, "false").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def _max_mutations() -> int:
+    try:
+        return max(1, int(os.environ.get(_MAX_MUTATIONS_ENV, "1").strip()))
+    except (TypeError, ValueError):
+        return 1
+
+
+def _diff_max_bytes() -> int:
+    try:
+        return max(1024, int(
+            os.environ.get(_DIFF_MAX_BYTES_ENV, "262144").strip()
+        ))
+    except (TypeError, ValueError):
+        return 262_144
+
+
+def _git_timeout_s() -> float:
+    try:
+        return max(1.0, float(
+            os.environ.get(_GIT_TIMEOUT_ENV, "15").strip()
+        ))
+    except (TypeError, ValueError):
+        return 15.0
+
+
+def _artifact_dir() -> Path:
+    raw = os.environ.get(_ARTIFACT_DIR_ENV, "").strip()
+    return Path(raw) if raw else Path(".jarvis") / "apply_freeze"
+
+
+# ---------------------------------------------------------------------------
+# Freeze latch — process-wide, thread-safe
+# ---------------------------------------------------------------------------
+
+_LOCK = threading.Lock()
+_STATE: Dict[str, Any] = {
+    "mutations_flushed": 0,
+    "frozen": False,
+    "frozen_reason": "",
+    "frozen_at_monotonic": 0.0,
+    "last_op_id": "",
+    "last_diff_sha8": "",
+    "last_artifact": "",
+}
+
+
+def is_frozen() -> bool:
+    """True once the mutation budget is spent — consulted by
+    ``ChangeEngine.execute`` BEFORE any byte is staged. Thread-safe;
+    NEVER raises."""
+    try:
+        with _LOCK:
+            return bool(_STATE["frozen"])
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def freeze_snapshot() -> Dict[str, Any]:
+    """Observability copy of the latch state. NEVER raises."""
+    try:
+        with _LOCK:
+            return dict(_STATE)
+    except Exception:  # noqa: BLE001
+        return {}
+
+
+def _reset_for_tests() -> None:
+    with _LOCK:
+        _STATE.update(
+            mutations_flushed=0, frozen=False, frozen_reason="",
+            frozen_at_monotonic=0.0, last_op_id="", last_diff_sha8="",
+            last_artifact="",
+        )
+
+
+# ---------------------------------------------------------------------------
+# Diff capture — async subprocess, byte-bounded, untracked-aware
+# ---------------------------------------------------------------------------
+
+async def _run_git(args: Sequence[str], cwd: Path) -> "tuple[int, str]":
+    """Bounded async git invocation. Returns (rc, stdout). NEVER raises."""
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            "git", *args,
+            cwd=str(cwd),
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.DEVNULL,
+        )
+        try:
+            out, _ = await asyncio.wait_for(
+                proc.communicate(), timeout=_git_timeout_s(),
+            )
+        except asyncio.TimeoutError:
+            try:
+                proc.kill()
+            except ProcessLookupError:
+                pass
+            return 124, ""
+        return proc.returncode or 0, out.decode("utf-8", errors="replace")
+    except Exception:  # noqa: BLE001 — capture is fail-soft
+        return 125, ""
+
+
+async def capture_mutation_diff(
+    write_root: Path, target_paths: Sequence[str],
+) -> str:
+    """The mutation's git diff against ``write_root``, byte-bounded.
+
+    Tracked modifications come from ``git diff -- <targets>``; a target the
+    index has never seen (a genuinely NEW file) yields nothing there, so it
+    is captured via ``git diff --no-index /dev/null <target>`` (rc=1 on
+    difference is SUCCESS for no-index). Read-only: never touches the index,
+    the working tree, or HEAD. NEVER raises; returns "" when nothing can be
+    captured (no git, no repo, timeout).
+    """
+    rels = [str(p) for p in target_paths if str(p).strip()]
+    if not rels:
+        return ""
+    cap = _diff_max_bytes()
+    _rc, tracked = await _run_git(["diff", "--", *rels], write_root)
+    chunks = [tracked] if tracked.strip() else []
+    for rel in rels:
+        if any(f"b/{rel}" in c or rel in c for c in chunks):
+            continue
+        candidate = write_root / rel
+        try:
+            if not candidate.is_file():
+                continue
+        except OSError:
+            continue
+        _rc2, untracked = await _run_git(
+            ["diff", "--no-index", "--", os.devnull, rel], write_root,
+        )
+        if untracked.strip():
+            chunks.append(untracked)
+    diff = "\n".join(chunks)
+    if len(diff.encode("utf-8", errors="replace")) > cap:
+        diff = diff.encode("utf-8", errors="replace")[:cap].decode(
+            "utf-8", errors="replace",
+        ) + "\n... [diff truncated at byte cap]"
+    return diff
+
+
+# ---------------------------------------------------------------------------
+# The interceptor — capture → persist → flush → freeze
+# ---------------------------------------------------------------------------
+
+async def flush_and_freeze(
+    op_id: str,
+    target_paths: Sequence[str],
+    write_root: Path,
+    *,
+    goal: str = "",
+) -> Dict[str, Any]:
+    """Run the full Atomic Flush & Freeze sequence for one successful APPLY.
+
+    Called by ``ChangeEngine.execute`` at the success seam (post-2PC-VERIFY,
+    post-APPLIED ledger). Every stage is fail-soft EXCEPT the latch: the
+    freeze closes even when capture/persist/flush degrade — containment
+    never depends on observability succeeding. Returns a scalar summary
+    (also logged) for the caller's ledger/telemetry. NEVER raises.
+    """
+    summary: Dict[str, Any] = {
+        "op_id": op_id, "captured": False, "flushed": False,
+        "frozen": False, "artifact": "", "diff_sha8": "", "diff_lines": 0,
+    }
+    try:
+        # 1. Capture.
+        diff = await capture_mutation_diff(write_root, target_paths)
+        diff_sha8 = hashlib.sha256(
+            diff.encode("utf-8", errors="replace"),
+        ).hexdigest()[:8] if diff else ""
+        summary["captured"] = bool(diff)
+        summary["diff_sha8"] = diff_sha8
+        summary["diff_lines"] = diff.count("\n") if diff else 0
+
+        # 2. Persist — durable artifact + full (bounded) debug.log record so
+        #    a severed socket can never lose the mutation evidence.
+        artifact_path = ""
+        if diff:
+            try:
+                adir = _artifact_dir()
+                adir.mkdir(parents=True, exist_ok=True)
+                artifact = adir / f"{op_id}.patch"
+                artifact.write_text(diff, encoding="utf-8")
+                artifact_path = str(artifact)
+            except Exception:  # noqa: BLE001 — persistence is fail-soft
+                logger.debug(
+                    "[ApplyFlushFreeze] artifact persist failed op=%s",
+                    op_id, exc_info=True,
+                )
+            logger.info(
+                "[ApplyFlushFreeze] APPLY MUTATION DIFF op=%s files=%s "
+                "sha8=%s lines=%d artifact=%s\n%s",
+                op_id, ",".join(str(p) for p in target_paths), diff_sha8,
+                summary["diff_lines"], artifact_path or "-", diff,
+            )
+        summary["artifact"] = artifact_path
+
+        # 3. Flush — high-priority envelope through the EXISTING HiveEmitter
+        #    edge; the enqueue is demonstrated via the stats delta.
+        try:
+            from backend.api.hive_emitter import (
+                get_default_emitter, hive_emit, hive_flush,
+            )
+            _before = int(get_default_emitter().stats.get("emitted", 0))
+            hive_emit(
+                actor_id="change_engine",
+                subsystem="governance",
+                intent="apply_mutation_frozen",
+                summary=(
+                    f"APPLY {op_id[:16]}: {len(list(target_paths))} file(s) "
+                    f"mutated (diff sha8={diff_sha8 or '-'}, "
+                    f"lines={summary['diff_lines']}) — mutations parked "
+                    f"pending human review"
+                ),
+                severity="warn",
+                trace_id=op_id,
+                detail={
+                    "files": ",".join(str(p) for p in target_paths)[:120],
+                    "diff_sha8": diff_sha8,
+                    "diff_lines": summary["diff_lines"],
+                    "artifact": artifact_path[:120],
+                    "goal": goal[:120],
+                },
+            )
+            hive_flush("change_engine", "apply_mutation_frozen")
+            _after = int(get_default_emitter().stats.get("emitted", 0))
+            summary["flushed"] = _after > _before
+            logger.info(
+                "[ApplyFlushFreeze] telemetry %s op=%s "
+                "(emitter stats emitted %d→%d)",
+                "ENQUEUED+FLUSHED" if summary["flushed"]
+                else "NOT CONFIRMED (emitter disabled/no-loop)",
+                op_id, _before, _after,
+            )
+        except Exception:  # noqa: BLE001 — telemetry is fail-soft
+            logger.warning(
+                "[ApplyFlushFreeze] hive flush failed op=%s — freeze "
+                "proceeds regardless", op_id, exc_info=True,
+            )
+    finally:
+        # 4. Freeze — the latch closes NO MATTER what degraded above.
+        try:
+            with _LOCK:
+                _STATE["mutations_flushed"] = (
+                    int(_STATE["mutations_flushed"]) + 1
+                )
+                _STATE["last_op_id"] = op_id
+                _STATE["last_diff_sha8"] = summary["diff_sha8"]
+                _STATE["last_artifact"] = summary["artifact"]
+                if _STATE["mutations_flushed"] >= _max_mutations():
+                    _STATE["frozen"] = True
+                    _STATE["frozen_reason"] = (
+                        f"apply_mutation_budget_spent "
+                        f"({_STATE['mutations_flushed']}/"
+                        f"{_max_mutations()}) op={op_id}"
+                    )
+                    _STATE["frozen_at_monotonic"] = time.monotonic()
+                summary["frozen"] = bool(_STATE["frozen"])
+            if summary["frozen"]:
+                logger.warning(
+                    "[ApplyFlushFreeze] MUTATIONS PARKED — %s; every "
+                    "subsequent ChangeEngine.execute short-circuits to "
+                    "'%s' pending human review",
+                    freeze_snapshot().get("frozen_reason", ""),
+                    FROZEN_DENIAL_REASON,
+                )
+        except Exception:  # noqa: BLE001 — never break the APPLY result
+            logger.error(
+                "[ApplyFlushFreeze] latch update failed op=%s",
+                op_id, exc_info=True,
+            )
+    return summary
+
+
+def register_flags(registry: Any) -> int:
+    """FlagRegistry self-registration (repo discoverability idiom).
+    Returns count registered. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.flag_registry import (
+            Category, FlagSpec, FlagType,
+        )
+    except ImportError:
+        return 0
+    specs = [
+        FlagSpec(
+            name=_ENABLED_ENV, type=FlagType.BOOL, default=False,
+            description=(
+                "Atomic Flush & Freeze master. When ON, every successful "
+                "ChangeEngine APPLY captures its git diff, persists it, "
+                "flushes a high-priority HiveTelemetryEnvelope through the "
+                "existing HiveEmitter edge, and — after "
+                "JARVIS_APPLY_FREEZE_MAX_MUTATIONS (default 1) mutations — "
+                "PARKS all further mutations (POLICY_DENIED "
+                "reason=apply_frozen_pending_review) pending human review. "
+                "Default OFF; supervised validation soaks opt in."
+            ),
+            category=Category.SAFETY,
+            source_file=(
+                "backend/core/ouroboros/governance/apply_flush_freeze.py"
+            ),
+            example="true",
+            since="Atomic Flush & Freeze (2026-07-21)",
+        ),
+    ]
+    count = 0
+    for spec in specs:
+        try:
+            registry.register(spec)
+            count += 1
+        except Exception:  # noqa: BLE001
+            pass
+    return count
+
+
+__all__ = [
+    "FROZEN_DENIAL_REASON",
+    "capture_mutation_diff",
+    "flush_and_freeze",
+    "flush_freeze_enabled",
+    "freeze_snapshot",
+    "is_frozen",
+    "register_flags",
+]

--- a/backend/core/ouroboros/governance/change_engine.py
+++ b/backend/core/ouroboros/governance/change_engine.py
@@ -86,6 +86,19 @@ class BlockedPathError(Exception):
     """
 
 
+class PathTraversalError(BlockedPathError):
+    """A candidate write path escapes the sandboxed write root.
+
+    Path Canonicalization Sandbox (2026-07-21, soak bt-2026-07-21-230753):
+    raised when :func:`canonicalize_candidate_path` proves — via strict
+    ``realpath`` resolution, never string surgery — that an LLM-supplied
+    target resolves OUTSIDE the write root (``../`` climb, absolute host
+    path, symlink escape). Subclasses :class:`BlockedPathError` so every
+    existing fail-closed catch site handles it identically; the distinct
+    type gives callers + telemetry a precise traversal taxonomy.
+    """
+
+
 # Hardcoded — NO env off-switch. The immovability IS the security property
 # (mirrors the Immutable-Orange protocol). These are the governance files that
 # enforce safety; a compromised or hallucinating model must never be able to
@@ -106,6 +119,110 @@ _IMMUTABLE_GOVERNANCE_SENTINELS: frozenset = frozenset({
     "backend/core/ouroboros/governance/governed_loop_service",
     "backend/core/ouroboros/governance/intake/unified_intake_router",
 })
+
+
+# ---------------------------------------------------------------------------
+# Path Canonicalization Sandbox (2026-07-21 — soak bt-2026-07-21-230753)
+# ---------------------------------------------------------------------------
+# Root cause: _redirect_target joined ANY relative candidate path verbatim
+# onto the write root. A model payload that embedded the write root's own
+# path suffix (the soak case: the worktree's absolute path minus the home
+# prefix) therefore DOUBLED the root —
+#   <worktree>/Documents/repos/.../<worktree>/backend/soak_probes/x.py
+# — a path that is CONTAINED (passes assert_write_path_allowed) but
+# nonsensical, surfacing later as a hard APPLY ENOENT. The canonicalizer
+# below composes the target mathematically: pure Path-component alignment
+# against the resolved root (never str.replace / regex), iterative so
+# multiply-duplicated prefixes collapse, then a strict realpath containment
+# proof that raises PathTraversalError on any escape.
+
+_PATH_CANONICALIZATION_ENV = "JARVIS_CHANGE_PATH_CANONICALIZATION_ENABLED"
+
+# A root-suffix alignment must span at least this many path components to
+# count as prefix duplication. Guards against false positives on a genuine
+# repo file whose first component coincidentally matches the root's last
+# directory name (a 1-component overlap); the duplication class this kills
+# always re-enters through multiple components.
+_MIN_ROOT_SUFFIX_COMPONENTS = 2
+
+
+def _path_canonicalization_enabled() -> bool:
+    """Master flag — default TRUE. Falsey restores the legacy verbatim
+    ``root / rel`` join (the pre-repair behavior, doubling included)."""
+    raw = os.environ.get(_PATH_CANONICALIZATION_ENV, "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def canonicalize_candidate_path(raw: "Path | str", write_root: Path) -> Path:
+    """Compose an LLM-supplied target into a canonical path under *write_root*.
+
+    Strict ``pathlib`` mathematics — no string substitution:
+
+    1. Resolve *write_root* (``Path.resolve()`` — symlink- and ``..``-proof).
+    2. If *raw* is absolute and already under the root, take its
+       ``relative_to(root)`` parts; an absolute path NOT under the root
+       raises :class:`PathTraversalError` (the caller decides whether a
+       project-root rebase applies BEFORE calling this).
+    3. Iteratively strip prefix duplication: while the leading components of
+       the relative path equal a suffix (>= ``_MIN_ROOT_SUFFIX_COMPONENTS``
+       long, longest-match-first) of the resolved root's components, drop
+       them. This mathematically collapses every "root re-entry" shape —
+       full-root echo, home-stripped echo (the soak case), and repeated
+       duplication — regardless of how the model formatted the payload.
+    4. Re-join to the root, ``realpath``-resolve, and PROVE containment via
+       ``relative_to``; any escape (``..`` climb, symlink redirect) raises
+       :class:`PathTraversalError`. A path that degenerates to the root
+       itself (no file component left) also raises — it is not a writable
+       target.
+
+    Raises
+    ------
+    PathTraversalError
+        When the resolved candidate escapes *write_root*, resolves to the
+        root itself, or is an absolute path outside the root.
+    """
+    root = Path(write_root).resolve()
+    p = Path(str(raw).strip()).expanduser()
+
+    if p.is_absolute():
+        resolved_p = Path(os.path.realpath(os.path.abspath(str(p))))
+        try:
+            rel_parts = list(resolved_p.relative_to(root).parts)
+        except ValueError:
+            raise PathTraversalError(
+                f"absolute candidate path outside write_root: "
+                f"{resolved_p} not under {root}"
+            )
+    else:
+        rel_parts = [c for c in p.parts if c != "."]
+
+    root_parts = root.parts
+    stripped = True
+    while stripped and rel_parts:
+        stripped = False
+        max_k = min(len(root_parts), len(rel_parts))
+        for k in range(max_k, _MIN_ROOT_SUFFIX_COMPONENTS - 1, -1):
+            if tuple(rel_parts[:k]) == tuple(root_parts[-k:]):
+                del rel_parts[:k]
+                stripped = True
+                break
+
+    if not rel_parts:
+        raise PathTraversalError(
+            f"candidate path degenerates to the write_root itself "
+            f"(no file component): raw={str(raw)!r} root={root}"
+        )
+
+    candidate = root.joinpath(*rel_parts)
+    resolved = Path(os.path.realpath(os.path.abspath(str(candidate))))
+    try:
+        resolved.relative_to(root)
+    except ValueError:
+        raise PathTraversalError(
+            f"candidate path escapes write_root after resolution: "
+            f"{resolved} not under {root} (raw={str(raw)!r})"
+        )
+    return resolved
 
 
 # ---------------------------------------------------------------------------
@@ -165,9 +282,11 @@ def assert_write_path_allowed(target: Path, write_root: Path) -> None:
         real = os.path.realpath(os.path.abspath(str(target)))
         root = os.path.realpath(os.path.abspath(str(write_root)))
 
-        # 1. Containment
+        # 1. Containment — a proven escape raises the precise traversal
+        #    taxonomy (PathTraversalError subclasses BlockedPathError, so
+        #    every existing fail-closed catch handles it identically).
         if not (real == root or real.startswith(root + os.sep)):
-            raise BlockedPathError(
+            raise PathTraversalError(
                 f"path escapes write_root: {real} not under {root}"
             )
 
@@ -596,8 +715,18 @@ class ChangeEngine:
         root and no env override). Absolute paths are rebased by their path
         relative to ``project_root``; relative paths are joined to the write
         root. A target NOT under ``project_root`` is left unchanged (defensive —
-        never silently cross-write elsewhere). NEVER raises — falls back to the
-        original target on any resolution error.
+        never silently cross-write elsewhere).
+
+        Path Canonicalization Sandbox (2026-07-21): the rebase-branch join is
+        now composed via :func:`canonicalize_candidate_path` — pure
+        Path-component mathematics that collapses write-root prefix
+        duplication (the bt-2026-07-21-230753 doubled-path APPLY ENOENT) and
+        PROVES containment. Raise contract: resolution errors still fall back
+        to the original target (legacy defensive behavior), but a PROVEN
+        sandbox escape raises :class:`PathTraversalError` — fail-closed
+        through ``execute``'s outer handler, never a silent cross-write.
+        Master ``JARVIS_CHANGE_PATH_CANONICALIZATION_ENABLED`` (default TRUE;
+        falsey restores the verbatim legacy join).
         """
         root = self._effective_write_root(request_write_root)
         try:
@@ -607,7 +736,11 @@ class ChangeEngine:
                 rel = target.resolve().relative_to(self._project_root.resolve())
             else:
                 rel = target
+            if _path_canonicalization_enabled():
+                return canonicalize_candidate_path(rel, root)
             return root / rel
+        except PathTraversalError:
+            raise  # proven escape — fail closed, never a silent cross-write
         except (ValueError, OSError):
             # Not under project_root (or unresolvable) — leave as-is.
             return target
@@ -731,6 +864,33 @@ class ChangeEngine:
                 success=False,
                 phase_reached=ChangePhase.PLAN,
                 error="POLICY_DENIED reason=generation_fenced",
+            )
+
+        # Atomic Flush & Freeze (2026-07-21) — the anti-cascade latch, same
+        # chokepoint doctrine as the generation fence above: once a prior
+        # successful APPLY has flushed its diff and spent the mutation
+        # budget, every further governed write short-circuits HERE, before
+        # any byte is staged, until a human reviews the parked diff.
+        # Master JARVIS_APPLY_FLUSH_FREEZE_ENABLED (default OFF).
+        from backend.core.ouroboros.governance import (  # noqa: PLC0415
+            apply_flush_freeze as _apply_flush_freeze,
+        )
+        if _apply_flush_freeze.flush_freeze_enabled() and (
+            _apply_flush_freeze.is_frozen()
+        ):
+            logger.warning(
+                "[ApplyFlushFreeze] mutation DENIED at ChangeEngine "
+                "(frozen pending review: %s) op=%s target=%s",
+                _apply_flush_freeze.freeze_snapshot().get(
+                    "frozen_reason", "?",
+                ),
+                op_id, request.target_file,
+            )
+            return ChangeResult(
+                op_id=op_id,
+                success=False,
+                phase_reached=ChangePhase.PLAN,
+                error=_apply_flush_freeze.FROZEN_DENIAL_REASON,
             )
 
         try:
@@ -1156,6 +1316,38 @@ class ChangeEngine:
                 failed_phase=None,
                 next_safe_action="none",
             )
+
+            # Atomic Flush & Freeze (2026-07-21) — the SUCCESS seam: the
+            # write is durable (2PC VERIFY passed, APPLIED recorded), so
+            # capture the mutation's git diff, persist + flush it through
+            # the HiveEmitter edge, and close the freeze latch (park
+            # further mutations pending human review). Fail-soft: a
+            # degraded capture/flush never un-succeeds the APPLY; the
+            # latch closes regardless inside flush_and_freeze.
+            if _apply_flush_freeze.flush_freeze_enabled():
+                try:
+                    _write_root = self._effective_write_root(
+                        getattr(request, "write_root", None),
+                    )
+                    _rel_target = str(target)
+                    try:
+                        _rel_target = str(
+                            target.relative_to(Path(_write_root).resolve())
+                        )
+                    except ValueError:
+                        pass
+                    await _apply_flush_freeze.flush_and_freeze(
+                        op_id,
+                        [_rel_target],
+                        Path(_write_root),
+                        goal=str(getattr(request, "goal", "") or ""),
+                    )
+                except Exception:  # noqa: BLE001 — never break the result
+                    logger.warning(
+                        "[ApplyFlushFreeze] post-APPLY hook degraded "
+                        "op=%s (APPLY result unaffected)",
+                        op_id, exc_info=True,
+                    )
 
             return ChangeResult(
                 op_id=op_id,

--- a/backend/core/ouroboros/governance/operation_advisor.py
+++ b/backend/core/ouroboros/governance/operation_advisor.py
@@ -1799,11 +1799,23 @@ class OperationAdvisor:
                 cooperative_yield_every_n_async,
             )
             _t0 = time.monotonic()
-            roots = derive_locality_roots(target_files, scan_root)
-            if not roots:
-                return None
             loop = asyncio.get_running_loop()
             _blast_executor = _get_advisor_blast_executor()
+            # Event Loop Unblocking (2026-07-21, soak bt-2026-07-21-230753):
+            # root derivation does cold-FS pathlib stat probes (.is_file /
+            # .is_dir on target parents + importees) plus a bounded read +
+            # AST parse — a 5.4s SidecarProfiler STUCK_FRAME showed a single
+            # cold stat can wedge the loop. Dispatch the WHOLE derivation to
+            # the dedicated advisor-blast executor (Task #88f isolation
+            # contract — never the contested default pool).
+            roots = await loop.run_in_executor(
+                _blast_executor,
+                derive_locality_roots,
+                target_files,
+                scan_root,
+            )
+            if not roots:
+                return None
             _per_file_bytes = blast_radius_max_bytes_per_file()
             _cap = blast_radius_conservative_cap()
             _skip = default_skip_dirs()

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -49,6 +49,7 @@ from backend.core.ouroboros.governance.ascii_strict_gate import (
 )
 from backend.core.ouroboros.governance.target_existence_guard import (
     guard_enabled as _target_guard_enabled,
+    universal_guard_enabled as _target_guard_universal_enabled,
     find_missing_targets as _find_missing_targets,
     build_retry_feedback as _target_missing_retry_feedback,
     missing_target_error_message as _target_missing_error_message,
@@ -6755,20 +6756,46 @@ class GovernedOrchestrator:
                     # self-correcting feedback instead of crashing APPLY. INERT
                     # for every non-swe_bench op (host self-dev legitimately
                     # creates new files) and when write_root can't be resolved.
-                    if (
+                    # Universal mode (2026-07-21, soak bt-2026-07-21-230753):
+                    # the benchmark-only gating left host self-dev ops
+                    # unguarded, so a write-root-DOUBLED candidate path
+                    # sailed to APPLY and hard-ENOENT'd in the ChangeEngine.
+                    # Universal mode gates ALL ops with the new-file lane
+                    # preserved (allow_new_files: a missing target is only a
+                    # steering error when its PARENT dir is also missing).
+                    # Write root: benchmark keeps _swe_bench_write_root;
+                    # host ops use the canonical Slice 11 execution-root seam
+                    # (the SAME root ChangeEngine._effective_write_root
+                    # resolves, so gate and engine provably agree). The
+                    # existence stats run OFF-LOOP via asyncio.to_thread —
+                    # a cold-FS stat must never starve the event loop.
+                    _tg_is_benchmark = (
                         getattr(ctx, "signal_source", "") == "swe_bench_pro"
-                        and _target_guard_enabled()
+                    )
+                    if (
+                        (_tg_is_benchmark and _target_guard_enabled())
+                        or (not _tg_is_benchmark
+                            and _target_guard_universal_enabled())
                     ):
-                        _tg_write_root = self._swe_bench_write_root(ctx)
-                        _tg_missing = _find_missing_targets(
-                            generation.candidates, _tg_write_root,
+                        _tg_write_root = (
+                            self._swe_bench_write_root(ctx)
+                            if _tg_is_benchmark
+                            else self._config.execution_root
+                        )
+                        _tg_missing = await asyncio.to_thread(
+                            _find_missing_targets,
+                            generation.candidates,
+                            _tg_write_root,
+                            allow_new_files=not _tg_is_benchmark,
                         )
                         if _tg_missing:
                             logger.warning(
                                 "[Orchestrator] Iron Gate — target_file_missing: "
-                                "%s not in worktree %s op=%s (attempt=%d)",
+                                "%s not in worktree %s op=%s (attempt=%d, "
+                                "lane=%s)",
                                 ",".join(_tg_missing), _tg_write_root,
                                 ctx.op_id[:12], attempt + 1,
+                                "benchmark" if _tg_is_benchmark else "universal",
                             )
                             generation = None
                             raise RuntimeError(
@@ -7681,12 +7708,21 @@ class GovernedOrchestrator:
                         # Slice 72 — target file doesn't exist in the worktree.
                         # Surface the host-vs-worktree steering correction so the
                         # model re-explores and targets a real repo file.
+                        # Universal mode (2026-07-21): lane-correct wording —
+                        # host self-dev ops get path-hygiene steering (doubled
+                        # prefix / phantom parent), not third-party-repo text.
                         _tg_paths = [
                             p.strip()
                             for p in _err_str[len(_TARGET_MISSING_PREFIX):].split(",")
                             if p.strip()
                         ]
-                        _error_feedback = _target_missing_retry_feedback(_tg_paths)
+                        _error_feedback = _target_missing_retry_feedback(
+                            _tg_paths,
+                            benchmark=(
+                                getattr(ctx, "signal_source", "")
+                                == "swe_bench_pro"
+                            ),
+                        )
                     elif _err_str.startswith("ascii_corruption"):
                         # Extract the specific offending lines from the rejected
                         # candidate so the model sees its own bad code in context

--- a/backend/core/ouroboros/governance/target_existence_guard.py
+++ b/backend/core/ouroboros/governance/target_existence_guard.py
@@ -28,6 +28,16 @@ from typing import Any, List, Mapping, Optional, Sequence, Tuple
 
 _ENABLED_ENV = "JARVIS_SWE_BENCH_TARGET_EXISTENCE_GUARD_ENABLED"
 
+# Universal mode (2026-07-21 — soak bt-2026-07-21-230753): the benchmark-only
+# gating left host self-development ops unguarded, so a candidate carrying a
+# write-root-DOUBLED path sailed to APPLY and hard-ENOENT'd inside the
+# ChangeEngine. Universal mode extends the gate to ALL ops with one semantic
+# difference: host self-dev legitimately CREATES new files, so a missing
+# target is only a steering error when its parent directory ALSO fails to
+# exist inside the write root (a genuinely new file lands in an existing
+# package; the doubled-path garbage class never does).
+_UNIVERSAL_ENABLED_ENV = "JARVIS_TARGET_EXISTENCE_GATE_UNIVERSAL"
+
 
 def guard_enabled() -> bool:
     """Master flag — default TRUE (graduates on for the scored soak).
@@ -36,6 +46,13 @@ def guard_enabled() -> bool:
     (the candidate flows straight to APPLY and ENOENTs as before).
     """
     raw = os.environ.get(_ENABLED_ENV, "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def universal_guard_enabled() -> bool:
+    """Universal-mode master — default TRUE. Falsey restores benchmark-only
+    gating (non-benchmark candidates flow ungated to APPLY as before)."""
+    raw = os.environ.get(_UNIVERSAL_ENABLED_ENV, "true").strip().lower()
     return raw not in ("0", "false", "no", "off")
 
 
@@ -89,41 +106,107 @@ def _resolves_inside_and_exists(rel_path: str, write_root: Path) -> bool:
         return False
 
 
+def _parent_resolves_inside_and_exists(rel_path: str, write_root: Path) -> bool:
+    """True iff ``rel_path``'s PARENT directory resolves inside ``write_root``
+    AND exists on disk — the new-file lane predicate for universal mode.
+
+    A genuinely new file lands in an existing package directory; the
+    doubled-path / garbage class always implies a nonexistent parent chain.
+    Escapes are treated as missing (mirrors ``_resolves_inside_and_exists``).
+    Never raises.
+    """
+    try:
+        root = write_root.resolve()
+        parent = (root / rel_path).resolve().parent
+    except (OSError, RuntimeError, ValueError):
+        return False
+    try:
+        parent.relative_to(root)
+    except ValueError:
+        return False  # parent escaped the worktree
+    try:
+        return parent.is_dir()
+    except OSError:
+        return False
+
+
 def find_missing_targets(
-    candidates: Sequence[Any], write_root: Optional[Path],
+    candidates: Sequence[Any],
+    write_root: Optional[Path],
+    *,
+    allow_new_files: bool = False,
 ) -> List[str]:
     """Return the sorted unique target paths that don't exist under write_root.
 
-    ``write_root`` is the benchmark worktree (from ``_swe_bench_write_root``).
-    When it is ``None`` (no per-op write root resolved) the guard is INERT —
-    we cannot know the repo layout, so we never block. Pure; never raises.
+    ``write_root`` is the benchmark worktree (from ``_swe_bench_write_root``)
+    or, in universal mode, the effective execution root. When it is ``None``
+    (no per-op write root resolved) the guard is INERT — we cannot know the
+    repo layout, so we never block. Pure; never raises.
+
+    ``allow_new_files`` (universal mode, keyword-only; default ``False`` =
+    benchmark semantics byte-identical): when TRUE a nonexistent target is
+    acceptable IF its parent directory exists inside the write root — the
+    legitimate host-self-dev new-file lane. A missing target whose parent
+    chain is ALSO missing (the doubled-path class) is flagged either way.
     """
     if write_root is None:
         return []
     missing: set = set()
     for cand in candidates or ():
         for rel in _candidate_target_paths(cand):
-            if not _resolves_inside_and_exists(rel, write_root):
-                missing.add(rel)
+            if _resolves_inside_and_exists(rel, write_root):
+                continue
+            if allow_new_files and _parent_resolves_inside_and_exists(
+                rel, write_root,
+            ):
+                continue
+            missing.add(rel)
     return sorted(missing)
 
 
-def build_retry_feedback(missing: Sequence[str]) -> str:
-    """The self-correcting GENERATE_RETRY payload shown back to the model."""
+def build_retry_feedback(
+    missing: Sequence[str], *, benchmark: bool = True,
+) -> str:
+    """The self-correcting GENERATE_RETRY payload shown back to the model.
+
+    ``benchmark`` (keyword-only; default ``True`` = the original Slice 72
+    wording, byte-identical for existing callers) selects the lane-correct
+    narrative: benchmark ops get the third-party-repo steering text;
+    universal-mode host ops get path-hygiene steering (the doubled-prefix /
+    phantom-parent class) that does NOT wrongly tell the model it is outside
+    the host framework.
+    """
     paths = ", ".join(f"'{p}'" for p in missing) or "'<unknown>'"
+    if benchmark:
+        return (
+            "## PREVIOUS GENERATION REJECTED — TARGET FILE DOES NOT EXIST\n\n"
+            f"The proposed target file(s) {paths} do not exist within the current "
+            "isolated problem repository. You are working on a THIRD-PARTY project, "
+            "NOT the host framework — paths like 'backend/core/...' belong to the "
+            "host system and are out of bounds.\n\n"
+            "INSTRUCTIONS FOR RETRY:\n"
+            "- Your modifications MUST target files that already exist in THIS repo.\n"
+            "- Call search_code / glob_files / list_dir to locate the real file that\n"
+            "  implements the behavior described in the problem statement BEFORE\n"
+            "  emitting any patch.\n"
+            "- Emit the patch against the exact repo-relative path you confirmed\n"
+            "  exists via exploration — do not guess a host-framework path.\n"
+        )
     return (
-        "## PREVIOUS GENERATION REJECTED — TARGET FILE DOES NOT EXIST\n\n"
-        f"The proposed target file(s) {paths} do not exist within the current "
-        "isolated problem repository. You are working on a THIRD-PARTY project, "
-        "NOT the host framework — paths like 'backend/core/...' belong to the "
-        "host system and are out of bounds.\n\n"
+        "## PREVIOUS GENERATION REJECTED — TARGET PATH DOES NOT RESOLVE\n\n"
+        f"The proposed target file(s) {paths} neither exist in the repository "
+        "nor land inside an existing package directory. This usually means the "
+        "path was malformed — e.g. it repeats the repository root's own path "
+        "prefix, embeds an absolute filesystem prefix, or points into a "
+        "directory tree that does not exist.\n\n"
         "INSTRUCTIONS FOR RETRY:\n"
-        "- Your modifications MUST target files that already exist in THIS repo.\n"
-        "- Call search_code / glob_files / list_dir to locate the real file that\n"
-        "  implements the behavior described in the problem statement BEFORE\n"
-        "  emitting any patch.\n"
-        "- Emit the patch against the exact repo-relative path you confirmed\n"
-        "  exists via exploration — do not guess a host-framework path.\n"
+        "- Emit CLEAN repo-relative paths only (e.g. 'backend/pkg/module.py') —\n"
+        "  never absolute paths and never paths containing the repository's own\n"
+        "  directory name as a prefix.\n"
+        "- To modify existing code, call read_file / search_code / list_dir to\n"
+        "  confirm the exact repo-relative path BEFORE emitting the patch.\n"
+        "- To create a NEW file, place it inside a directory that already\n"
+        "  exists in the repository.\n"
     )
 
 

--- a/tests/governance/test_apply_flush_freeze.py
+++ b/tests/governance/test_apply_flush_freeze.py
@@ -1,0 +1,197 @@
+"""Atomic Flush & Freeze — post-APPLY diff capture, HiveEmitter flush, park.
+
+Pins the anti-cascade interceptor: (1) default-OFF master; (2) git-diff
+capture for tracked mutations AND untracked new files (read-only — never
+touches index/HEAD); (3) the full capture→persist→flush→freeze sequence with
+the HiveEmitter enqueue DEMONSTRATED via the stats delta; (4) containment
+over observability — a raising emitter still closes the latch; (5) the
+mutation budget knob; (6) the ChangeEngine wiring (freeze check before any
+byte is staged, hook at the post-VERIFY success seam).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance import apply_flush_freeze as aff
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _reset_latch(monkeypatch: pytest.MonkeyPatch):
+    aff._reset_for_tests()
+    monkeypatch.delenv("JARVIS_APPLY_FLUSH_FREEZE_ENABLED", raising=False)
+    monkeypatch.delenv("JARVIS_APPLY_FREEZE_MAX_MUTATIONS", raising=False)
+    yield
+    aff._reset_for_tests()
+
+
+@pytest.fixture
+def git_repo(tmp_path: Path) -> Path:
+    """A real git repo with one committed file."""
+    subprocess.run(["git", "init", "-q"], cwd=tmp_path, check=True)
+    (tmp_path / "module.py").write_text("VALUE = 1\n")
+    subprocess.run(["git", "add", "module.py"], cwd=tmp_path, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t",
+         "commit", "-q", "-m", "seed"],
+        cwd=tmp_path, check=True,
+    )
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# Master + latch semantics
+# ---------------------------------------------------------------------------
+
+
+def test_master_defaults_off() -> None:
+    assert aff.flush_freeze_enabled() is False
+
+
+def test_latch_starts_open() -> None:
+    assert aff.is_frozen() is False
+
+
+# ---------------------------------------------------------------------------
+# Diff capture
+# ---------------------------------------------------------------------------
+
+
+async def test_capture_tracked_mutation(git_repo: Path) -> None:
+    (git_repo / "module.py").write_text("VALUE = 2\n")
+    diff = await aff.capture_mutation_diff(git_repo, ["module.py"])
+    assert "-VALUE = 1" in diff
+    assert "+VALUE = 2" in diff
+
+
+async def test_capture_untracked_new_file(git_repo: Path) -> None:
+    (git_repo / "brand_new.py").write_text("NEW = True\n")
+    diff = await aff.capture_mutation_diff(git_repo, ["brand_new.py"])
+    assert "+NEW = True" in diff
+
+
+async def test_capture_outside_repo_is_empty_not_raise(
+    tmp_path: Path,
+) -> None:
+    bare = tmp_path / "not_a_repo"
+    bare.mkdir()
+    diff = await aff.capture_mutation_diff(bare, ["x.py"])
+    assert diff == ""  # fail-soft: no repo → no capture, no exception
+
+
+# ---------------------------------------------------------------------------
+# The full sequence — capture → persist → flush → freeze
+# ---------------------------------------------------------------------------
+
+
+async def test_flush_and_freeze_full_sequence(
+    git_repo: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    import backend.api.hive_emitter as hive_emitter_mod
+
+    monkeypatch.setenv("JARVIS_APPLY_FLUSH_FREEZE_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_HIVE_EMITTERS_ENABLED", "true")
+    monkeypatch.setenv(
+        "JARVIS_APPLY_FREEZE_ARTIFACT_DIR", str(tmp_path / "artifacts"),
+    )
+    # Fresh emitter so the stats delta is unambiguous; lazily self-binds to
+    # this test's running loop on first emit.
+    monkeypatch.setattr(hive_emitter_mod, "_default", None)
+
+    (git_repo / "module.py").write_text("VALUE = 99\n")
+    summary = await aff.flush_and_freeze(
+        "op-test-1234", ["module.py"], git_repo, goal="test mutation",
+    )
+
+    assert summary["captured"] is True
+    assert summary["diff_lines"] > 0
+    assert summary["flushed"] is True, (
+        "HiveEmitter enqueue must be demonstrated via the stats delta"
+    )
+    assert summary["frozen"] is True
+    assert aff.is_frozen() is True
+    # Durable artifact carries the diff (severed-socket insurance).
+    artifact = Path(summary["artifact"])
+    assert artifact.is_file()
+    assert "+VALUE = 99" in artifact.read_text()
+    # The envelope actually sits in the emitter queue.
+    emitter = hive_emitter_mod.get_default_emitter()
+    assert emitter.stats["emitted"] >= 1
+
+
+async def test_emitter_failure_still_freezes(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Containment over observability: a raising emitter must never keep
+    the latch open."""
+    import backend.api.hive_emitter as hive_emitter_mod
+
+    monkeypatch.setenv("JARVIS_APPLY_FLUSH_FREEZE_ENABLED", "true")
+
+    def _boom(**kwargs):
+        raise RuntimeError("severed socket")
+
+    monkeypatch.setattr(hive_emitter_mod, "hive_emit", _boom)
+    (git_repo / "module.py").write_text("VALUE = 3\n")
+    summary = await aff.flush_and_freeze(
+        "op-test-sever", ["module.py"], git_repo,
+    )
+    assert summary["flushed"] is False
+    assert summary["frozen"] is True
+    assert aff.is_frozen() is True
+
+
+async def test_mutation_budget_knob(
+    git_repo: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_APPLY_FREEZE_MAX_MUTATIONS", "2")
+    (git_repo / "module.py").write_text("VALUE = 4\n")
+    s1 = await aff.flush_and_freeze("op-a", ["module.py"], git_repo)
+    assert s1["frozen"] is False and aff.is_frozen() is False
+    s2 = await aff.flush_and_freeze("op-b", ["module.py"], git_repo)
+    assert s2["frozen"] is True and aff.is_frozen() is True
+
+
+# ---------------------------------------------------------------------------
+# ChangeEngine wiring pins
+# ---------------------------------------------------------------------------
+
+
+def _engine_src() -> str:
+    from backend.core.ouroboros.governance import change_engine
+    import inspect
+    return Path(inspect.getfile(change_engine)).read_text(encoding="utf-8")
+
+
+def test_engine_checks_freeze_before_any_byte() -> None:
+    """The freeze consult must sit at the execute() entry (generation-fence
+    doctrine) and short-circuit with the typed denial reason."""
+    src = _engine_src()
+    assert "_apply_flush_freeze.is_frozen()" in src
+    assert "FROZEN_DENIAL_REASON" in src
+    # The check precedes the pre-write gate (source-order pin).
+    assert src.index("_apply_flush_freeze.is_frozen()") < src.index(
+        "self._pre_write_gate(target, signed_content, request)"
+    )
+
+
+def test_engine_hooks_flush_at_success_seam() -> None:
+    """The interceptor fires at the post-VERIFY success seam."""
+    src = _engine_src()
+    assert "_apply_flush_freeze.flush_and_freeze(" in src
+    # After the APPLIED ledger record, before the success return.
+    applied_idx = src.index('state=OperationState.APPLIED')
+    hook_idx = src.index("_apply_flush_freeze.flush_and_freeze(")
+    assert hook_idx > applied_idx
+
+
+def test_denial_reason_taxonomy() -> None:
+    assert aff.FROZEN_DENIAL_REASON.startswith("POLICY_DENIED reason=")

--- a/tests/governance/test_path_canonicalization_sandbox.py
+++ b/tests/governance/test_path_canonicalization_sandbox.py
@@ -1,0 +1,313 @@
+"""Path Canonicalization Sandbox + Universal Target-Existence Gate + I/O Offload.
+
+Root cause (soak bt-2026-07-21-230753): ``ChangeEngine._redirect_target``
+joined ANY relative candidate path verbatim onto the write root, so a model
+payload that embedded the root's own path suffix DOUBLED the root —
+``<worktree>/Documents/repos/.../<worktree>/backend/soak_probes/x.py`` —
+contained (passes assert_write_path_allowed) but nonsensical, surfacing as a
+hard APPLY ENOENT. The same soak recorded a 5.4s SidecarProfiler STUCK_FRAME
+in ``pathlib.stat`` from ``derive_locality_roots`` probing a cold FS on the
+event loop.
+
+This suite pins the three mandated edge cases plus the composing gates:
+
+1. **Duplicated root prefix** — an LLM payload embedding the write root's
+   path suffix canonicalizes cleanly to the true target (pure Path-component
+   mathematics; multiply-duplicated prefixes collapse; absolute under-root
+   echoes too).
+2. **Directory traversal** — ``../`` climbs and absolute host paths raise the
+   typed :class:`PathTraversalError` (a :class:`BlockedPathError` subclass so
+   every existing fail-closed catch site handles it identically).
+3. **Event-loop unblocking** — ``derive_locality_roots`` dispatches to the
+   dedicated ``advisor-blast`` executor; a concurrent heartbeat proves the
+   running loop stays unblocked while a slow (cold-FS-simulating) derivation
+   runs.
+
+Plus: the universal target-existence gate (benchmark semantics byte-identical
+via the ``allow_new_files`` default; host lane keeps legitimate new-file
+creation while flagging the phantom-parent doubled-path class), and the
+``_redirect_target`` integration (doubled payload → clean rebase; escape →
+raise; master OFF → legacy verbatim join).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.change_engine import (
+    BlockedPathError,
+    ChangeEngine,
+    PathTraversalError,
+    canonicalize_candidate_path,
+)
+from backend.core.ouroboros.governance.target_existence_guard import (
+    build_retry_feedback,
+    find_missing_targets,
+    universal_guard_enabled,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def worktree(tmp_path: Path) -> Path:
+    """A write root shaped like the soak's worktree, with a real package."""
+    root = (
+        tmp_path / "Documents" / "repos" / "JARVIS-AI-Agent.nosync"
+        / ".worktrees" / "ouroboros__auto__bt-test-1234"
+    )
+    (root / "backend" / "soak_probes").mkdir(parents=True)
+    (root / "backend" / "soak_probes" / "existing.py").write_text("X = 1\n")
+    return root
+
+
+# ---------------------------------------------------------------------------
+# Edge case 1 — duplicated root prefix canonicalizes cleanly
+# ---------------------------------------------------------------------------
+
+
+def test_home_stripped_root_echo_canonicalizes(worktree: Path) -> None:
+    """The EXACT soak shape: the payload embeds the write root's absolute
+    path minus its leading anchor components."""
+    # Suffix of the root's own parts, as the model emitted it.
+    echoed = "/".join(worktree.parts[-5:])  # Documents/repos/.../ouroboros__auto__bt-test-1234
+    raw = f"{echoed}/backend/soak_probes/probe.py"
+    out = canonicalize_candidate_path(raw, worktree)
+    assert out == (worktree / "backend" / "soak_probes" / "probe.py").resolve()
+    # Mathematically: the root's name never appears twice in the result.
+    assert str(out).count(worktree.name) == 1
+
+
+def test_double_duplication_collapses_iteratively(worktree: Path) -> None:
+    echoed = "/".join(worktree.parts[-3:])
+    raw = f"{echoed}/{echoed}/backend/soak_probes/probe.py"
+    out = canonicalize_candidate_path(raw, worktree)
+    assert out == (worktree / "backend" / "soak_probes" / "probe.py").resolve()
+
+
+def test_absolute_under_root_echo_canonicalizes(worktree: Path) -> None:
+    """An ABSOLUTE payload under the root that re-enters the root's suffix
+    (the doubled path as an absolute string) collapses identically."""
+    echoed = "/".join(worktree.parts[-4:])
+    raw = str(worktree / echoed / "backend" / "soak_probes" / "probe.py")
+    out = canonicalize_candidate_path(raw, worktree)
+    assert out == (worktree / "backend" / "soak_probes" / "probe.py").resolve()
+
+
+def test_clean_relative_path_passes_through(worktree: Path) -> None:
+    out = canonicalize_candidate_path(
+        "backend/soak_probes/existing.py", worktree,
+    )
+    assert out == (worktree / "backend" / "soak_probes" / "existing.py").resolve()
+
+
+def test_single_component_coincidence_is_not_stripped(tmp_path: Path) -> None:
+    """A 1-component overlap with the root's dirname is NOT duplication —
+    the minimum-alignment guard protects a genuine file living in a
+    directory that shares the root's name."""
+    root = tmp_path / "myrepo"
+    (root / "myrepo").mkdir(parents=True)  # legit nested dir sharing the name
+    out = canonicalize_candidate_path("myrepo/inner.py", root)
+    assert out == (root / "myrepo" / "inner.py").resolve()
+
+
+# ---------------------------------------------------------------------------
+# Edge case 2 — traversal raises PathTraversalError
+# ---------------------------------------------------------------------------
+
+
+def test_dotdot_climb_raises_path_traversal(worktree: Path) -> None:
+    with pytest.raises(PathTraversalError):
+        canonicalize_candidate_path("../../outside.py", worktree)
+
+
+def test_nested_dotdot_escape_raises(worktree: Path) -> None:
+    with pytest.raises(PathTraversalError):
+        canonicalize_candidate_path(
+            "backend/../../../../../../etc/passwd", worktree,
+        )
+
+
+def test_absolute_outside_root_raises(worktree: Path) -> None:
+    with pytest.raises(PathTraversalError):
+        canonicalize_candidate_path("/etc/passwd", worktree)
+
+
+def test_root_degenerate_target_raises(worktree: Path) -> None:
+    echoed = "/".join(worktree.parts[-3:])
+    with pytest.raises(PathTraversalError):
+        canonicalize_candidate_path(echoed, worktree)  # collapses to root itself
+
+
+def test_path_traversal_error_is_blocked_path_error() -> None:
+    """Taxonomy composition: every existing fail-closed catch site
+    (``except BlockedPathError``) must handle the new type identically."""
+    assert issubclass(PathTraversalError, BlockedPathError)
+
+
+# ---------------------------------------------------------------------------
+# _redirect_target integration (the actual APPLY seam)
+# ---------------------------------------------------------------------------
+
+
+def _engine(project_root: Path) -> ChangeEngine:
+    """Minimal engine — _redirect_target touches only _project_root."""
+    eng = ChangeEngine.__new__(ChangeEngine)
+    eng._project_root = project_root
+    return eng
+
+
+def test_redirect_target_collapses_doubled_payload(
+    tmp_path: Path, worktree: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    eng = _engine(project_root)
+    echoed = "/".join(worktree.parts[-5:])
+    doubled = Path(f"{echoed}/backend/soak_probes/probe.py")
+    out = eng._redirect_target(doubled, request_write_root=worktree)
+    assert out == (worktree / "backend" / "soak_probes" / "probe.py").resolve()
+
+
+def test_redirect_target_raises_on_escape(
+    tmp_path: Path, worktree: Path,
+) -> None:
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    eng = _engine(project_root)
+    with pytest.raises(PathTraversalError):
+        eng._redirect_target(
+            Path("../../escape.py"), request_write_root=worktree,
+        )
+
+
+def test_redirect_target_master_off_restores_legacy_join(
+    tmp_path: Path, worktree: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_CHANGE_PATH_CANONICALIZATION_ENABLED", "false")
+    project_root = tmp_path / "project"
+    project_root.mkdir()
+    eng = _engine(project_root)
+    rel = Path("backend/x.py")
+    out = eng._redirect_target(rel, request_write_root=worktree)
+    assert out == worktree / rel  # verbatim legacy join, byte-identical
+
+
+# ---------------------------------------------------------------------------
+# Universal target-existence gate
+# ---------------------------------------------------------------------------
+
+
+def test_universal_gate_default_on() -> None:
+    assert universal_guard_enabled() is True
+
+
+def test_universal_gate_flags_phantom_parent_doubled_path(
+    worktree: Path,
+) -> None:
+    """The doubled-path class: parent chain doesn't exist → flagged even in
+    the new-file-tolerant universal lane."""
+    echoed = "/".join(worktree.parts[-5:])
+    cand = {"file_path": f"{echoed}/backend/soak_probes/probe.py"}
+    missing = find_missing_targets([cand], worktree, allow_new_files=True)
+    assert missing, "phantom-parent doubled path must be flagged"
+
+
+def test_universal_gate_allows_new_file_in_existing_package(
+    worktree: Path,
+) -> None:
+    cand = {"file_path": "backend/soak_probes/brand_new_module.py"}
+    missing = find_missing_targets([cand], worktree, allow_new_files=True)
+    assert missing == []
+
+
+def test_universal_gate_allows_existing_file(worktree: Path) -> None:
+    cand = {"file_path": "backend/soak_probes/existing.py"}
+    assert find_missing_targets([cand], worktree, allow_new_files=True) == []
+
+
+def test_benchmark_semantics_byte_identical(worktree: Path) -> None:
+    """Default (no kwarg) keeps Slice 72 strictness: a new file — even in an
+    existing package — is missing for a benchmark op."""
+    cand = {"file_path": "backend/soak_probes/brand_new_module.py"}
+    assert find_missing_targets([cand], worktree) == [
+        "backend/soak_probes/brand_new_module.py"
+    ]
+
+
+def test_retry_feedback_lane_wording() -> None:
+    bench = build_retry_feedback(["a.py"])
+    univ = build_retry_feedback(["a.py"], benchmark=False)
+    assert "THIRD-PARTY" in bench
+    assert "THIRD-PARTY" not in univ
+    assert "repeats the repository root" in univ
+
+
+# ---------------------------------------------------------------------------
+# Edge case 3 — derive_locality_roots offload keeps the loop unblocked
+# ---------------------------------------------------------------------------
+
+
+async def test_locality_root_derivation_never_blocks_running_loop(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A slow (cold-FS-simulating) root derivation must run on the
+    advisor-blast executor: ``asyncio.get_running_loop()`` keeps scheduling
+    a concurrent heartbeat throughout the 0.4s derivation window. Before
+    the offload, the same derivation wedged the loop (the 5.4s
+    ``pathlib.stat`` STUCK_FRAME)."""
+    from backend.core.ouroboros.governance import operation_advisor
+
+    derive_thread: dict = {}
+
+    def _slow_derive(target_files, scan_root, **kwargs):
+        import threading
+        derive_thread["name"] = threading.current_thread().name
+        time.sleep(0.4)  # the cold-FS stat storm
+        return (tmp_path,)
+
+    # operation_advisor binds derive_locality_roots at module import; the
+    # executor dispatch resolves the module global at call time, so this
+    # patch intercepts the real seam.
+    monkeypatch.setattr(
+        operation_advisor, "derive_locality_roots", _slow_derive,
+    )
+
+    advisor = operation_advisor.OperationAdvisor(project_root=tmp_path)
+
+    ticks = 0
+    stop = asyncio.Event()
+
+    async def _heartbeat() -> None:
+        nonlocal ticks
+        while not stop.is_set():
+            ticks += 1
+            await asyncio.sleep(0.005)
+
+    hb = asyncio.ensure_future(_heartbeat())
+    try:
+        await advisor._localized_blast_lower_bound_async(
+            ("x.py",), {"x"}, tmp_path,
+        )
+    finally:
+        stop.set()
+        await hb
+
+    # 0.4s of derivation at a 5ms heartbeat: a blocked loop yields ~1 tick;
+    # an unblocked loop yields dozens. Generous floor stays flake-proof.
+    assert ticks >= 20, (
+        f"event loop starved during root derivation (ticks={ticks}) — "
+        "derive_locality_roots is running ON the loop again"
+    )
+    # And the derivation provably ran on the dedicated advisor-blast pool.
+    assert derive_thread["name"].startswith("advisor-blast"), (
+        f"derivation ran on {derive_thread['name']!r} — Task #88f isolation "
+        "contract broken (must be the dedicated advisor-blast executor)"
+    )

--- a/tests/governance/test_slice72_target_guard.py
+++ b/tests/governance/test_slice72_target_guard.py
@@ -116,9 +116,22 @@ def _orch_src() -> str:
 
 def test_orchestrator_invokes_target_guard_gated_on_swe_bench():
     src = _orch_src()
-    assert "_find_missing_targets(" in src, "gate must call the guard helper"
+    # Universal mode (2026-07-21): the guard call is dispatched OFF-LOOP via
+    # asyncio.to_thread(_find_missing_targets, ...) — the helper is now a
+    # to_thread argument, not a direct call expression. Accept either shape
+    # so the pin survives formatting, but require the helper reference AND
+    # the off-loop dispatch.
+    assert (
+        "_find_missing_targets(" in src or "_find_missing_targets," in src
+    ), "gate must call the guard helper"
+    assert "asyncio.to_thread(" in src, (
+        "existence stats must run off-loop (universal-gate mandate)"
+    )
     assert "_target_guard_enabled()" in src, "gate must honor the master flag"
-    # Gated on the swe_bench source so host self-dev (new files) is untouched.
+    # Universal-mode master — ALL ops gated, new-file lane preserved.
+    assert "_target_guard_universal_enabled()" in src
+    assert "allow_new_files=" in src
+    # Benchmark lane still keyed on the swe_bench source (strict semantics).
     assert 'signal_source", "") == "swe_bench_pro"' in src
     # Routed through the GENERATE_RETRY error path (raises, sets generation=None).
     assert "_target_missing_error_message(" in src


### PR DESCRIPTION
## Closes both soak bt-2026-07-21-230753 follow-ups + adds the anti-cascade interceptor

### 1. Path Canonicalization Sandbox (`change_engine.py`)
Root cause of the APPLY ENOENT: `_redirect_target` joined any relative candidate path verbatim onto the write root — a payload embedding the root's own suffix **doubled** the root (contained but nonsensical). `canonicalize_candidate_path` composes targets with strict `pathlib` mathematics — iterative longest-root-suffix component alignment (min 2 components, kills every duplication shape incl. the byte-exact soak echo) then a `realpath` containment proof raising the new typed `PathTraversalError` (a `BlockedPathError` subclass — all existing fail-closed catches compose). Master `JARVIS_CHANGE_PATH_CANONICALIZATION_ENABLED` default-TRUE.

### 2. Universal Async Target-Existence Gate
Slice 72 decoupled from `signal_source == "swe_bench_pro"` — **all ops** gate at the existing GENERATE_RETRY pre-flight seam, stats **off-loop** via `asyncio.to_thread`. Host lane preserves legitimate new-file creation (`allow_new_files`: missing target OK iff its parent dir exists — the phantom-parent doubled-path class never does). Benchmark semantics byte-identical; retry feedback lane-aware; write root = the canonical Slice 11 `config.execution_root` seam. Master `JARVIS_TARGET_EXISTENCE_GATE_UNIVERSAL` default-TRUE.

### 3. Event Loop Unblocking
`derive_locality_roots` (the 5.4s `pathlib.stat` STUCK_FRAME suspect) dispatches wholesale to the dedicated `advisor-blast` executor.

### 4. Atomic Flush & Freeze (`apply_flush_freeze.py`)
At the post-2PC-VERIFY success seam: capture the mutation's git diff (async subprocess, untracked-aware, read-only) → persist durable artifact + full debug.log record → flush a high-priority `actor_edge` envelope through the **existing** `HiveEmitter` (enqueue demonstrated via stats delta) → park further mutations (`POLICY_DENIED reason=apply_frozen_pending_review` at the generation-fence chokepoint) after `JARVIS_APPLY_FREEZE_MAX_MUTATIONS` (default 1). Containment over observability: a severed emitter still closes the latch. Master `JARVIS_APPLY_FLUSH_FREEZE_ENABLED` default-**FALSE** — supervised validation soaks opt in.

### Tests
31 new across `test_path_canonicalization_sandbox.py` + `test_apply_flush_freeze.py`; Slice 72 AST pin updated to the `to_thread` shape with universal pins. **221-green sweep** across all seam suites; the only reds encountered (`generate_runner_iron_gate` ×4, `phase_dispatcher_terminals`) bisected as pre-existing on pristine `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops doubled-path writes and ENOENTs by canonicalizing targets and guarding existence across all ops. Adds an optional post-apply “Flush & Freeze” to capture diffs, emit telemetry, and park further edits.

- **New Features**
  - Canonicalize write targets under the write root and block traversal with `PathTraversalError` (subclass of `BlockedPathError`); collapses duplicated root prefixes in `_redirect_target`.
  - Universal target-existence gate at the pre-flight seam for all ops; allows new files when the parent directory exists; checks run off the event loop.
  - Event loop unblocking: `derive_locality_roots` runs on a dedicated executor.
  - Atomic Flush & Freeze: after a successful apply, capture and persist `git diff`, emit via the existing `HiveEmitter`, then freeze further writes with a clear denial reason.

- **Migration**
  - Defaults: `JARVIS_CHANGE_PATH_CANONICALIZATION_ENABLED=true`, `JARVIS_TARGET_EXISTENCE_GATE_UNIVERSAL=true`, `JARVIS_APPLY_FLUSH_FREEZE_ENABLED=false`.
  - To enable Flush & Freeze: set `JARVIS_APPLY_FLUSH_FREEZE_ENABLED=true`. Optional knobs: `JARVIS_APPLY_FREEZE_MAX_MUTATIONS`, `JARVIS_APPLY_FREEZE_DIFF_MAX_BYTES`, `JARVIS_APPLY_FREEZE_ARTIFACT_DIR`, `JARVIS_APPLY_FREEZE_GIT_TIMEOUT_S`.

<sup>Written for commit ef2ad5c6f6404fb147d91d2527c88835cbc364a5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

