### PR TITLE
fix(governance): Shipping-path target gate + WAL ghost tombstoning + sandboxed ephemeral scaffolding

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3062,6 +3062,10 @@ JARVIS_ADVISOR_COLD_ROOT_TTL_S=300
 JARVIS_CHANGE_PATH_CANONICALIZATION_ENABLED=true
 JARVIS_TARGET_EXISTENCE_GATE_UNIVERSAL=true
 
+# --- WAL Signal Liveness Tombstoning (ghost-target signals resolved at replay,
+#     never waking the orchestrator) ---
+JARVIS_WAL_TARGET_LIVENESS_ENABLED=true
+
 # --- Atomic Flush & Freeze (post-APPLY diff capture + mutation park; default OFF,
 #     supervised validation soaks opt in) ---
 JARVIS_APPLY_FLUSH_FREEZE_ENABLED=false

--- a/backend/core/ouroboros/governance/change_engine.py
+++ b/backend/core/ouroboros/governance/change_engine.py
@@ -1110,6 +1110,33 @@ class ChangeEngine:
             # execute() per file, so every per-file write funnels through here.
             self._pre_write_gate(target, signed_content, request)
 
+            # Sandboxed Ephemeral Instantiation (2026-07-22, soak
+            # bt-2026-07-22-005943): a legitimately-NEW module may land in
+            # a package directory the ephemeral worktree doesn't carry (a
+            # worktree is a checkout of HEAD — untracked scaffolding is
+            # absent by construction). At this point the target has passed
+            # the FULL canonical sandbox: Path Canonicalization
+            # (_redirect_target), containment + immutable-governance +
+            # protected-path (_pre_write_gate/assert_write_path_allowed) —
+            # so target.parent is PROVEN inside the write root and mkdir
+            # here can never scaffold outside the sandbox. Without this,
+            # write_text hard-ENOENTs on the missing parent chain.
+            try:
+                if not target.parent.exists():
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    logger.info(
+                        "[ChangeEngine] ephemeral parent chain instantiated "
+                        "(sandbox-contained) op=%s dir=%s",
+                        op_id, target.parent,
+                    )
+            except OSError as _mkdir_exc:
+                # Surface as the standard fail-closed path error — the
+                # outer handler records the op FAILED, bytes never land.
+                raise BlockedPathError(
+                    f"parent instantiation failed for {target.parent}: "
+                    f"{_mkdir_exc}"
+                )
+
             # Acquire file lock for the write
             async with self._lock_manager.acquire(
                 level=LockLevel.FILE_LOCK,

--- a/backend/core/ouroboros/governance/intake/unified_intake_router.py
+++ b/backend/core/ouroboros/governance/intake/unified_intake_router.py
@@ -704,6 +704,51 @@ def _reanchor_base_on_value(
     return proposed, delta
 
 
+# ---------------------------------------------------------------------------
+# WAL Signal Liveness Tombstoning (2026-07-22)
+# ---------------------------------------------------------------------------
+
+_WAL_TARGET_LIVENESS_ENV = "JARVIS_WAL_TARGET_LIVENESS_ENABLED"
+
+
+def _wal_target_liveness_enabled() -> bool:
+    """Master flag — default TRUE. Falsey restores unconditional replay
+    (ghost signals wake the orchestrator as before)."""
+    raw = os.environ.get(_WAL_TARGET_LIVENESS_ENV, "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def _all_targets_missing(
+    target_files: Any, observation_root: Any,
+) -> bool:
+    """True iff the signal is TARGETED (>=1 target file) AND every target
+    is absent from the observation root.
+
+    Conservative by design: an untargeted signal (empty/None — e.g.
+    SWE-bench envelopes carry no target_files by contract) is NEVER a
+    ghost; one live target keeps a multi-target signal actionable; any
+    path/stat error counts the target as PRESENT (never lose a real
+    signal to an I/O hiccup). Sync — callers dispatch via
+    ``asyncio.to_thread``. NEVER raises.
+    """
+    try:
+        targets = [str(t).strip() for t in (target_files or ()) if str(t).strip()]
+        if not targets:
+            return False
+        root = Path(observation_root)
+        for rel in targets:
+            try:
+                p = Path(rel)
+                candidate = p if p.is_absolute() else root / rel
+                if candidate.exists():
+                    return False
+            except OSError:
+                return False  # unknowable → treat as present
+        return True
+    except Exception:  # noqa: BLE001 — fail-soft: replay normally
+        return False
+
+
 def _compute_priority(
     envelope: "IntentEnvelope",
     dependency_credit: int = 0,
@@ -2768,6 +2813,45 @@ class UnifiedIntakeRouter:
         for entry in pending:
             try:
                 envelope = IE.from_dict(entry.envelope_dict)
+                # ── WAL Signal Liveness Tombstoning (2026-07-22) ──
+                # A replayed signal was recorded in a PREVIOUS session; by
+                # replay time its target files may have vanished (e.g. the
+                # preemption shield stashes UNTRACKED files at boot — soak
+                # bt-2026-07-22-005943 chased backend/soak_probes/
+                # soak_probe_math.py through a full GENERATE round when it
+                # existed in NO visible tree). When every target of a
+                # targeted signal is missing from the observation root,
+                # the entry is cleanly tombstoned (status update — the
+                # WAL's native exclusion mechanism, no bus rewrite) and
+                # never enqueued: the orchestrator is not woken for a
+                # ghost. Signals with no target_files (e.g. SWE-bench
+                # envelopes carry none by design) are never touched.
+                # Liveness stats run OFF-LOOP. Fail-soft: any check error
+                # replays the entry normally (never lose a real signal).
+                if _wal_target_liveness_enabled():
+                    try:
+                        _ghost = await asyncio.to_thread(
+                            _all_targets_missing,
+                            envelope.target_files,
+                            self._config.project_root,
+                        )
+                    except Exception:  # noqa: BLE001 — never lose a signal
+                        _ghost = False
+                    if _ghost:
+                        # WAL status vocabulary is CLOSED ('acked' |
+                        # 'dead_letter'); a benign ghost is RESOLVED, not
+                        # poison — 'acked' is the semantically correct
+                        # tombstone, and this log line carries the reason.
+                        self._wal.update_status(entry.lease_id, "acked")
+                        logger.warning(
+                            "Router: WAL TOMBSTONE (ghost target) — "
+                            "lease_id=%s source=%s targets=%s absent from "
+                            "observation root; signal resolved without "
+                            "waking the orchestrator",
+                            entry.lease_id, envelope.source,
+                            ",".join(envelope.target_files or ()),
+                        )
+                        continue
                 # WAL replay preserves whatever alignment metadata was
                 # already stashed in envelope.evidence from the original
                 # ingest — no need to re-score and pollute the replay path

--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -6772,22 +6772,37 @@ class GovernedOrchestrator:
                     _tg_is_benchmark = (
                         getattr(ctx, "signal_source", "") == "swe_bench_pro"
                     )
+                    _tg_missing = []
                     if (
                         (_tg_is_benchmark and _target_guard_enabled())
                         or (not _tg_is_benchmark
                             and _target_guard_universal_enabled())
                     ):
-                        _tg_write_root = (
-                            self._swe_bench_write_root(ctx)
-                            if _tg_is_benchmark
-                            else self._config.execution_root
-                        )
-                        _tg_missing = await asyncio.to_thread(
-                            _find_missing_targets,
-                            generation.candidates,
-                            _tg_write_root,
-                            allow_new_files=not _tg_is_benchmark,
-                        )
+                        # Fail-SOFT infrastructure resolution (mirrors the
+                        # SHIPPING generate_runner twin): a host that
+                        # cannot resolve a write root skips the check —
+                        # the deliberate raise stays OUTSIDE the try.
+                        try:
+                            _tg_write_root = (
+                                self._swe_bench_write_root(ctx)
+                                if _tg_is_benchmark
+                                else self._config.execution_root
+                            )
+                            _tg_missing = await asyncio.to_thread(
+                                _find_missing_targets,
+                                generation.candidates,
+                                _tg_write_root,
+                                allow_new_files=not _tg_is_benchmark,
+                            )
+                        except Exception:  # noqa: BLE001 — protective gate
+                            logger.debug(
+                                "[Orchestrator] Iron Gate — target-"
+                                "existence infrastructure unresolvable; "
+                                "gate skipped op=%s",
+                                ctx.op_id[:12], exc_info=True,
+                            )
+                            _tg_missing = []
+                            _tg_write_root = None
                         if _tg_missing:
                             logger.warning(
                                 "[Orchestrator] Iron Gate — target_file_missing: "

--- a/backend/core/ouroboros/governance/phase_runners/generate_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/generate_runner.py
@@ -80,6 +80,14 @@ from backend.core.ouroboros.governance.ascii_strict_gate import (
     AsciiStrictGate,
     build_retry_feedback as _ascii_gate_retry_feedback,
 )
+from backend.core.ouroboros.governance.target_existence_guard import (
+    TARGET_MISSING_PREFIX as _TARGET_MISSING_PREFIX,
+    build_retry_feedback as _target_missing_retry_feedback,
+    find_missing_targets as _find_missing_targets,
+    guard_enabled as _target_guard_enabled,
+    missing_target_error_message as _target_missing_error_message,
+    universal_guard_enabled as _target_guard_universal_enabled,
+)
 from backend.core.ouroboros.governance.forward_progress import (
     candidate_content_hash,
 )
@@ -1565,6 +1573,73 @@ class GENERATERunner(PhaseRunner):
                         _dep_exc._dep_file_rejected_content = _rejected_content  # type: ignore[attr-defined]
                         raise _dep_exc
 
+                # Gate 3.5 — Target existence (Slice 72, UNIVERSALIZED +
+                # ported to the SHIPPING path 2026-07-22). HISTORY: this
+                # gate previously lived ONLY on the inline orchestrator
+                # twin, which stopped being the shipping GENERATE path when
+                # this runner graduated (2026-04-23) — the wired-but-inert
+                # trap. Soak bt-2026-07-22-005943 proved it: a candidate
+                # whose parent chain doesn't exist in the write tree sailed
+                # ungated to APPLY and hard-ENOENT'd in the ChangeEngine.
+                #
+                # Synchronized Root Injection: the gate consults the EXACT
+                # tree APPLY will write to — the same resolution the
+                # ChangeRequest carries (_swe_bench_write_root for
+                # benchmark ops; the Slice 11 execution_root seam
+                # otherwise, which is ChangeEngine._effective_write_root's
+                # fallback by construction). Existence stats run OFF-LOOP
+                # via asyncio.to_thread. Host lane keeps legitimate
+                # new-file creation (allow_new_files: a missing target is
+                # only a steering error when its PARENT dir is also
+                # missing). Benchmark semantics byte-identical strict.
+                _tg_is_benchmark = (
+                    getattr(ctx, "signal_source", "") == "swe_bench_pro"
+                )
+                _tg_missing: list = []
+                if (
+                    (_tg_is_benchmark and _target_guard_enabled())
+                    or (not _tg_is_benchmark
+                        and _target_guard_universal_enabled())
+                ):
+                    # Fail-SOFT infrastructure resolution: the gate is
+                    # protective, never fatal — a host that cannot resolve
+                    # a write root (parity-test fakes, degraded config)
+                    # skips the check rather than failing the candidate.
+                    # The deliberate target_file_missing raise below stays
+                    # OUTSIDE this try so it is never swallowed.
+                    try:
+                        _tg_write_root = (
+                            orch._swe_bench_write_root(ctx)
+                            if _tg_is_benchmark
+                            else orch._config.execution_root
+                        )
+                        _tg_missing = await asyncio.to_thread(
+                            _find_missing_targets,
+                            generation.candidates,
+                            _tg_write_root,
+                            allow_new_files=not _tg_is_benchmark,
+                        )
+                    except Exception:  # noqa: BLE001 — protective gate
+                        logger.debug(
+                            "[Orchestrator] Iron Gate — target-existence "
+                            "infrastructure unresolvable; gate skipped "
+                            "op=%s", ctx.op_id[:12], exc_info=True,
+                        )
+                        _tg_missing = []
+                        _tg_write_root = None
+                    if _tg_missing:
+                        logger.warning(
+                            "[Orchestrator] Iron Gate — target_file_missing: "
+                            "%s not in write root %s op=%s (lane=%s)",
+                            ",".join(_tg_missing), _tg_write_root,
+                            ctx.op_id[:12],
+                            "benchmark" if _tg_is_benchmark else "universal",
+                        )
+                        generation = None
+                        raise RuntimeError(
+                            _target_missing_error_message(_tg_missing)
+                        )
+
                 # Gate 4 — Docstring multi-line collapse detection. Catches
                 # the regression where Claude rewrites a multi-line module
                 # or function docstring as a single-line literal containing
@@ -2254,6 +2329,24 @@ class GENERATERunner(PhaseRunner):
                             "  tool_execution_records may you emit the final patch.\n"
                             "- Exploration is NOT optional. Patches without context corrupt code.\n"
                         )
+                elif _err_str.startswith(_TARGET_MISSING_PREFIX):
+                    # Gate 3.5 — target doesn't resolve in the write tree.
+                    # Lane-correct steering (2026-07-22): benchmark ops get
+                    # the third-party-repo text; host self-dev ops get
+                    # path-hygiene steering (phantom parent / malformed
+                    # prefix), never a wrong "you're outside the host" claim.
+                    _tg_paths = [
+                        p.strip()
+                        for p in _err_str[len(_TARGET_MISSING_PREFIX):].split(",")
+                        if p.strip()
+                    ]
+                    _error_feedback = _target_missing_retry_feedback(
+                        _tg_paths,
+                        benchmark=(
+                            getattr(ctx, "signal_source", "")
+                            == "swe_bench_pro"
+                        ),
+                    )
                 elif _err_str.startswith("ascii_corruption"):
                     # Extract the specific offending lines from the rejected
                     # candidate so the model sees its own bad code in context

--- a/backend/core/ouroboros/governance/target_existence_guard.py
+++ b/backend/core/ouroboros/governance/target_existence_guard.py
@@ -106,26 +106,35 @@ def _resolves_inside_and_exists(rel_path: str, write_root: Path) -> bool:
         return False
 
 
-def _parent_resolves_inside_and_exists(rel_path: str, write_root: Path) -> bool:
-    """True iff ``rel_path``'s PARENT directory resolves inside ``write_root``
-    AND exists on disk — the new-file lane predicate for universal mode.
+def _new_file_lane_allows(rel_path: str, write_root: Path) -> bool:
+    """The universal-mode new-file predicate: ``rel_path`` resolves inside
+    ``write_root`` AND its ANCHOR (first path component) exists there.
 
-    A genuinely new file lands in an existing package directory; the
-    doubled-path / garbage class always implies a nonexistent parent chain.
-    Escapes are treated as missing (mirrors ``_resolves_inside_and_exists``).
-    Never raises.
+    Anchor semantics, not immediate-parent (2026-07-22 refinement): the
+    ChangeEngine's Sandboxed Ephemeral Instantiation legitimately scaffolds
+    nested NEW package dirs (``backend/new_pkg/sub/module.py`` under an
+    existing ``backend/``), so demanding an existing immediate parent would
+    contradict the engine and block real module scaffolding. The garbage
+    classes this lane must reject — write-root echoes (``Documents/...``),
+    absolute-prefix remnants, hallucinated top-level trees — always fail at
+    the FIRST component. A single-component path (``newfile.py``) anchors
+    on the root itself, which exists by definition. Escapes are rejected
+    (mirrors ``_resolves_inside_and_exists``). Never raises.
     """
     try:
         root = write_root.resolve()
-        parent = (root / rel_path).resolve().parent
+        resolved = (root / rel_path).resolve()
     except (OSError, RuntimeError, ValueError):
         return False
     try:
-        parent.relative_to(root)
+        rel = resolved.relative_to(root)
     except ValueError:
-        return False  # parent escaped the worktree
+        return False  # escaped the worktree
+    parts = rel.parts
+    if len(parts) <= 1:
+        return True  # anchors on the root itself
     try:
-        return parent.is_dir()
+        return (root / parts[0]).is_dir()
     except OSError:
         return False
 
@@ -145,9 +154,11 @@ def find_missing_targets(
 
     ``allow_new_files`` (universal mode, keyword-only; default ``False`` =
     benchmark semantics byte-identical): when TRUE a nonexistent target is
-    acceptable IF its parent directory exists inside the write root — the
-    legitimate host-self-dev new-file lane. A missing target whose parent
-    chain is ALSO missing (the doubled-path class) is flagged either way.
+    acceptable IF its anchor component exists inside the write root — the
+    legitimate host-self-dev new-file/new-package lane (the ChangeEngine
+    scaffolds the nested parents). A missing target whose FIRST component
+    is also missing (write-root echoes, absolute remnants, hallucinated
+    trees) is flagged either way.
     """
     if write_root is None:
         return []
@@ -156,9 +167,7 @@ def find_missing_targets(
         for rel in _candidate_target_paths(cand):
             if _resolves_inside_and_exists(rel, write_root):
                 continue
-            if allow_new_files and _parent_resolves_inside_and_exists(
-                rel, write_root,
-            ):
+            if allow_new_files and _new_file_lane_allows(rel, write_root):
                 continue
             missing.add(rel)
     return sorted(missing)

--- a/tests/governance/test_path_canonicalization_sandbox.py
+++ b/tests/governance/test_path_canonicalization_sandbox.py
@@ -228,6 +228,17 @@ def test_universal_gate_allows_new_file_in_existing_package(
     assert missing == []
 
 
+def test_universal_gate_allows_new_nested_package_under_anchor(
+    worktree: Path,
+) -> None:
+    """Anchor semantics (2026-07-22): a new nested package under an
+    EXISTING top-level dir is legitimate scaffolding — the ChangeEngine's
+    Sandboxed Ephemeral Instantiation creates the parents. Only a missing
+    ANCHOR (hallucinated top-level tree / root echo) flags."""
+    cand = {"file_path": "backend/new_pkg/sub/module.py"}
+    assert find_missing_targets([cand], worktree, allow_new_files=True) == []
+
+
 def test_universal_gate_allows_existing_file(worktree: Path) -> None:
     cand = {"file_path": "backend/soak_probes/existing.py"}
     assert find_missing_targets([cand], worktree, allow_new_files=True) == []

--- a/tests/governance/test_wal_tombstone_and_scaffold.py
+++ b/tests/governance/test_wal_tombstone_and_scaffold.py
@@ -1,0 +1,254 @@
+"""WAL Signal Liveness Tombstoning + Sandboxed Ephemeral Instantiation +
+shipping-path target gate.
+
+Root cause chain (soak bt-2026-07-22-005943): a WAL-replayed TestFailure
+signal chased ``backend/soak_probes/soak_probe_math.py`` — an UNTRACKED file
+the preemption shield stashed at boot, absent from every visible tree — and
+the universal target-existence gate never ran because it was wired ONLY on
+the inline orchestrator twin (the extracted ``generate_runner`` has been the
+shipping GENERATE path since 2026-04-23: the wired-but-inert trap). The op
+burned a full GENERATE round, then APPLY hard-ENOENT'd on the missing parent
+directory in the ephemeral worktree.
+
+This suite pins the three-layer repair:
+
+1. **WAL tombstoning** (mandated edge case 1) — a replayed signal whose
+   every target is absent from the observation root is cleanly tombstoned
+   via the WAL's native status mechanism WITHOUT waking the orchestrator
+   (nothing enqueued); live-target and untargeted signals replay untouched.
+2. **Sandboxed Ephemeral Instantiation** (mandated edge case 2) — the
+   ChangeEngine creates a nested parent chain and writes a genuinely-new
+   file, strictly AFTER the canonical sandbox checks; escapes still raise.
+3. **Shipping-path wiring** — the target-existence gate + its retry-feedback
+   branch now live in ``generate_runner.py`` (AST pins), killing the
+   inert-twin class this soak exposed.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.change_engine import (
+    ChangeEngine,
+    ChangeRequest,
+)
+from backend.core.ouroboros.governance.ledger import OperationLedger
+from backend.core.ouroboros.governance.risk_engine import (
+    ChangeType,
+    OperationProfile,
+)
+
+
+# ---------------------------------------------------------------------------
+# 1. WAL Signal Liveness Tombstoning
+# ---------------------------------------------------------------------------
+
+
+def _make_router_skeleton(tmp_path: Path):
+    """The minimal attribute surface ``_replay_wal`` touches — the real
+    router's boot is out of scope for a replay-boundary unit test."""
+    from backend.core.ouroboros.governance.intake.unified_intake_router import (
+        UnifiedIntakeRouter,
+    )
+    from backend.core.ouroboros.governance.intake.wal import WAL
+
+    router = UnifiedIntakeRouter.__new__(UnifiedIntakeRouter)
+    router._wal = WAL(path=tmp_path / "intake.wal")
+    router._queue = asyncio.Queue()
+    router._priority_queue = None
+    router._config = SimpleNamespace(project_root=tmp_path)
+    return router
+
+
+def _wal_entry(lease_id: str, target_files, tmp_path: Path):
+    from backend.core.ouroboros.governance.intake.wal import WALEntry
+
+    return WALEntry(
+        lease_id=lease_id,
+        envelope_dict={
+            "schema_version": "2c.1",
+            "source": "test_failure",
+            "description": "ghost hunt",
+            "target_files": list(target_files),
+            "repo": "jarvis",
+            "confidence": 0.9,
+            "urgency": "normal",
+            "dedup_key": f"dedup-{lease_id}",
+            "causal_id": f"causal-{lease_id}",
+            "signal_id": lease_id,
+            "idempotency_key": f"idem-{lease_id}",
+            "lease_id": lease_id,
+            "evidence": {},
+            "requires_human_ack": False,
+            "submitted_at": 1.0,
+        },
+        status="pending",
+        ts_monotonic=1.0,
+        ts_utc="2026-07-22T00:00:00Z",
+    )
+
+
+async def test_ghost_signal_tombstoned_without_waking_orchestrator(
+    tmp_path: Path,
+) -> None:
+    """Mandated edge case 1: a WAL signal pointing at a non-existent file
+    is instantly tombstoned — nothing reaches the dispatch queue, and the
+    WAL no longer reports it pending."""
+    router = _make_router_skeleton(tmp_path)
+    ghost = _wal_entry(
+        "lease-ghost-1",
+        ["backend/soak_probes/soak_probe_math.py"],  # exists nowhere
+        tmp_path,
+    )
+    router._wal.append(ghost)
+    assert len(router._wal.pending_entries()) == 1
+
+    await router._replay_wal()
+
+    assert router._queue.qsize() == 0, (
+        "ghost signal reached the dispatch queue — orchestrator was woken"
+    )
+    assert router._wal.pending_entries() == [], (
+        "ghost entry still pending — tombstone status not recorded"
+    )
+
+
+async def test_live_target_signal_replays_normally(tmp_path: Path) -> None:
+    (tmp_path / "real_module.py").write_text("X = 1\n")
+    router = _make_router_skeleton(tmp_path)
+    router._wal.append(
+        _wal_entry("lease-live-1", ["real_module.py"], tmp_path),
+    )
+    await router._replay_wal()
+    assert router._queue.qsize() == 1
+
+
+async def test_untargeted_signal_never_tombstoned(tmp_path: Path) -> None:
+    """Untargeted envelopes (only the exempt sources may carry no
+    target_files — swe_bench_pro is the documented contract) must never
+    be touched by the liveness gate."""
+    router = _make_router_skeleton(tmp_path)
+    entry = _wal_entry("lease-untargeted", [], tmp_path)
+    entry.envelope_dict["source"] = "swe_bench_pro"
+    router._wal.append(entry)
+    await router._replay_wal()
+    assert router._queue.qsize() == 1
+
+
+async def test_partial_liveness_keeps_signal(tmp_path: Path) -> None:
+    """One live target keeps a multi-target signal actionable."""
+    (tmp_path / "alive.py").write_text("X = 1\n")
+    router = _make_router_skeleton(tmp_path)
+    router._wal.append(
+        _wal_entry("lease-partial", ["alive.py", "gone.py"], tmp_path),
+    )
+    await router._replay_wal()
+    assert router._queue.qsize() == 1
+
+
+async def test_liveness_master_off_replays_ghosts(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_WAL_TARGET_LIVENESS_ENABLED", "false")
+    router = _make_router_skeleton(tmp_path)
+    router._wal.append(_wal_entry("lease-legacy", ["gone.py"], tmp_path))
+    await router._replay_wal()
+    assert router._queue.qsize() == 1  # legacy behavior byte-identical
+
+
+# ---------------------------------------------------------------------------
+# 2. Sandboxed Ephemeral Instantiation
+# ---------------------------------------------------------------------------
+
+
+def _profile(target: Path) -> OperationProfile:
+    return OperationProfile(
+        files_affected=[target],
+        change_type=ChangeType.MODIFY,
+        blast_radius=1,
+        crosses_repo_boundary=False,
+        touches_security_surface=False,
+        touches_supervisor=False,
+        test_scope_confidence=1.0,
+    )
+
+
+async def test_engine_scaffolds_nested_ephemeral_directory(
+    tmp_path: Path,
+) -> None:
+    """Mandated edge case 2: a new file in a nested, NOT-yet-existing
+    package directory is written successfully — the parent chain is
+    instantiated only after the canonical sandbox checks pass."""
+    project_root = tmp_path / "worktree"
+    project_root.mkdir()
+    ledger = OperationLedger(storage_dir=tmp_path / "ledger")
+    engine = ChangeEngine(project_root=project_root, ledger=ledger)
+
+    target = project_root / "backend" / "new_pkg" / "sub" / "module.py"
+    assert not target.parent.exists()
+
+    result = await engine.execute(ChangeRequest(
+        goal="scaffold a new nested module",
+        target_file=target,
+        proposed_content="NEW = True\n",
+        profile=_profile(target),
+        op_id="op-scaffold-1",
+    ))
+
+    assert result.success is True, f"execute failed: {result}"
+    assert target.is_file()
+    assert "NEW = True" in target.read_text()
+
+
+async def test_engine_scaffold_never_escapes_sandbox(tmp_path: Path) -> None:
+    """The instantiation runs strictly AFTER containment: an escaping
+    target still dies in the sandbox and no directory is created outside."""
+    project_root = tmp_path / "worktree"
+    project_root.mkdir()
+    outside = tmp_path / "outside"
+    ledger = OperationLedger(storage_dir=tmp_path / "ledger")
+    engine = ChangeEngine(project_root=project_root, ledger=ledger)
+
+    target = outside / "evil" / "module.py"
+    result = await engine.execute(ChangeRequest(
+        goal="escape attempt",
+        target_file=target,
+        proposed_content="EVIL = True\n",
+        profile=_profile(target),
+        op_id="op-escape-1",
+    ))
+
+    assert result.success is False
+    assert not outside.exists(), "sandbox escape scaffolded a directory"
+
+
+# ---------------------------------------------------------------------------
+# 3. Shipping-path wiring pins (the inert-twin killer)
+# ---------------------------------------------------------------------------
+
+
+def _runner_src() -> str:
+    import inspect
+    from backend.core.ouroboros.governance.phase_runners import generate_runner
+    return Path(inspect.getfile(generate_runner)).read_text(encoding="utf-8")
+
+
+def test_generate_runner_carries_target_gate() -> None:
+    """The SHIPPING GENERATE path must run the target-existence gate —
+    soak bt-2026-07-22-005943 proved the inline-only wiring was inert."""
+    src = _runner_src()
+    assert "_find_missing_targets," in src or "_find_missing_targets(" in src
+    assert "asyncio.to_thread(" in src
+    assert "_target_guard_universal_enabled()" in src
+    assert "allow_new_files=" in src
+    assert "_target_missing_error_message(" in src
+
+
+def test_generate_runner_carries_retry_feedback_branch() -> None:
+    src = _runner_src()
+    assert "_TARGET_MISSING_PREFIX" in src
+    assert "_target_missing_retry_feedback(" in src


### PR DESCRIPTION
## Soak bt-2026-07-22-005943 — root cause corrected and severed at three links

**Corrected diagnosis:** the universal target-existence gate never ran — it was wired only on the inline `_run_pipeline` twin while `generate_runner.py` (the **shipping** GENERATE path since 2026-04-23) carried zero target-guard code (the wired-but-inert twin trap). The op was a WAL-replayed TestFailure chasing an untracked, shield-stashed file — a ghost target — and APPLY hard-ENOENT'd on the missing parent chain in the ephemeral worktree.

### 1. Shipping-path gate (`generate_runner.py`)
Gate 3.5 target-existence ported into the extracted runner + `_TARGET_MISSING_PREFIX` retry-feedback branch; inline twin in parity. Root = `_swe_bench_write_root` (benchmark) / `config.execution_root` (host — the engine's fallback by construction); stats off-loop via `asyncio.to_thread`. **Fail-soft infrastructure resolution**: unresolvable hosts skip the gate instead of failing candidates (the deliberate raise stays outside the try).

### 2. WAL Signal Liveness Tombstoning (`_replay_wal`)
A targeted signal whose *every* target is absent from the observation root is tombstoned via the WAL's native closed status vocabulary (`acked`; the log carries the ghost reason) and never enqueued — the orchestrator is not woken for ghosts. Untargeted exempt-source envelopes, partially-live signals, and I/O-error cases replay normally. Master `JARVIS_WAL_TARGET_LIVENESS_ENABLED` default-TRUE.

### 3. Sandboxed Ephemeral Instantiation (`change_engine.py`)
Missing parent chains for authorized new files are created strictly **after** the canonical sandbox checks — mkdir can never scaffold outside the write root; `OSError` → fail-closed `BlockedPathError`. Companion refinement: the gate's new-file lane moves to **anchor semantics** (`_new_file_lane_allows`) so legitimate nested-package scaffolding passes while root-echo/hallucinated-tree garbage dies at component one.

### Tests
New `test_wal_tombstone_and_scaffold.py` (9): ghost tombstoned with the dispatch queue provably empty; live/untargeted/partial replay untouched; master-off byte-identical; nested scaffold write succeeds post-sandbox; escape still blocked with nothing scaffolded; runner wiring pins. Sweep: **90 passed**; only the pristine-main chronic quartet remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ports the universal target-existence gate to the shipping `generate_runner.py`, adds WAL ghost-target tombstoning, and safely scaffolds missing parent directories inside the sandbox to prevent ENOENTs and wasted runs.

- **Bug Fixes**
  - Target gate now runs on the shipping path (`generate_runner.py`) and uses the correct write root (`_swe_bench_write_root` for benchmark; `config.execution_root` for host). Fail-soft if the root can’t be resolved; includes retry feedback via `_TARGET_MISSING_PREFIX`.
  - Refined new-file lane to anchor semantics in `target_existence_guard.py` so legitimate nested packages pass while root-echo/garbage paths are blocked.

- **New Features**
  - WAL ghost-target tombstoning in `unified_intake_router._replay_wal`: signals whose every target is missing are `acked` and never enqueued. Controlled by `JARVIS_WAL_TARGET_LIVENESS_ENABLED` (default `true`).
  - Sandboxed ephemeral instantiation in `change_engine.py`: creates missing parent chains only after sandbox checks; escapes fail closed.
  - Added `tests/governance/test_wal_tombstone_and_scaffold.py` to pin tombstoning, scaffolding, and shipping-path wiring.

<sup>Written for commit 2c31f416414b82c2a288babf94078cf83cf71d63. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

