### PR TITLE
fix(governance): Derive operator root from git topology — promotion reachable under isolation-collapsed config

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -11923,8 +11923,11 @@ class GovernedOrchestrator:
                     coverage_after=getattr(ctx, "coverage_after", 0.0),
                     complexity_before=getattr(ctx, "complexity_before", 0.0),
                     complexity_after=getattr(ctx, "complexity_after", 0.0),
-                    lint_before=getattr(ctx, "lint_before", 0),
-                    lint_after=getattr(ctx, "lint_after", 0),
+                    # RSI-score signature drift fix (2026-07-22 — inline
+                    # twin of complete_runner; keyword names are
+                    # lint_violations_*).
+                    lint_violations_before=getattr(ctx, "lint_before", 0),
+                    lint_violations_after=getattr(ctx, "lint_after", 0),
                     blast_radius_total=getattr(ctx, "blast_radius_total", 0),
                 )
                 logger.info("[RSI Score] op=%s composite=%.4f", ctx.op_id, _score.composite)

--- a/backend/core/ouroboros/governance/phase_runners/complete_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/complete_runner.py
@@ -143,8 +143,12 @@ class COMPLETERunner(PhaseRunner):
                     coverage_after=getattr(ctx, "coverage_after", 0.0),
                     complexity_before=getattr(ctx, "complexity_before", 0.0),
                     complexity_after=getattr(ctx, "complexity_after", 0.0),
-                    lint_before=getattr(ctx, "lint_before", 0),
-                    lint_after=getattr(ctx, "lint_after", 0),
+                    # RSI-score signature drift fix (2026-07-22, soak
+                    # bt-2026-07-22-042548 TypeError): the ctx attrs keep
+                    # their names; CompositeScoreFunction.compute's
+                    # keyword names are lint_violations_*.
+                    lint_violations_before=getattr(ctx, "lint_before", 0),
+                    lint_violations_after=getattr(ctx, "lint_after", 0),
                     blast_radius_total=getattr(ctx, "blast_radius_total", 0),
                 )
                 logger.info(

--- a/backend/core/ouroboros/governance/workspace_promoter.py
+++ b/backend/core/ouroboros/governance/workspace_promoter.py
@@ -80,6 +80,43 @@ class PromotionOutcome:
     detail: str = ""
 
 
+async def _derive_operator_root(
+    mgr: "WorktreeManager", exec_root: Path,
+) -> Optional[Path]:
+    """The operator checkout that owns ``exec_root``, from git topology.
+
+    A linked worktree's ``git rev-parse --git-common-dir`` resolves to
+    ``<operator>/.git`` (the shared object store lives under the primary
+    checkout); its parent IS the operator root. A primary checkout's
+    common dir is its own ``.git`` — the caller treats that as
+    "genuinely same root". Read-time, env-free, hardcode-free. Returns
+    ``None`` on any git failure (fail-soft — caller falls back to the
+    legacy noop). NEVER raises.
+    """
+    try:
+        rc, out, _err = await mgr._run_git_rc(
+            exec_root, ["rev-parse", "--git-common-dir"],
+        )
+        common = (out or "").strip()
+        if rc != 0 or not common:
+            return None
+        common_path = Path(common)
+        if not common_path.is_absolute():
+            common_path = (exec_root / common_path)
+        common_path = Path(os.path.realpath(common_path))
+        # <operator>/.git → operator root is its parent. Defensive: a
+        # bare/odd layout that doesn't end in .git is not derivable.
+        if common_path.name != ".git":
+            return None
+        return common_path.parent
+    except Exception:  # noqa: BLE001 — derivation is fail-soft
+        logger.debug(
+            "[WorkspacePromoter] operator-root derivation failed for %s",
+            exec_root, exc_info=True,
+        )
+        return None
+
+
 async def run_workspace_promotion(
     orch: Any,
     ctx: Any,
@@ -98,11 +135,41 @@ async def run_workspace_promotion(
 
     project_root = Path(orch._config.project_root)
     exec_root = Path(orch._config.execution_root)
+
+    mgr = manager if manager is not None else WorktreeManager(
+        repo_root=project_root,
+    )
+
     if exec_root == Path(os.path.realpath(project_root)) or (
         exec_root == project_root
     ):
-        # Legacy posture: the commit already landed in the operator tree.
-        return PromotionOutcome(False, False, "noop_same_root")
+        # Isolation-collapsed posture (2026-07-22, soak
+        # bt-2026-07-22-042548): FileIsolation
+        # (autonomous_workspace.resolve_loop_project_root) routes the
+        # LOOP's project_root INTO the sovereignty worktree at arming,
+        # so config carries worktree == worktree and the OPERATOR tree
+        # vanishes from every config field — the old "noop_same_root"
+        # early-return made promotion structurally unreachable (it
+        # silently skipped on every op of every isolation-armed soak).
+        # Git itself still knows the operator checkout: a linked
+        # worktree's ``--git-common-dir`` lives under it. Derive the
+        # TRUE promotion target from git topology at read time —
+        # env-free, hardcode-free, and inert for a genuinely-primary
+        # checkout (whose common dir is its own ``.git``).
+        _derived = await _derive_operator_root(mgr, exec_root)
+        if _derived is None or _derived == Path(
+            os.path.realpath(exec_root)
+        ):
+            # Genuinely the primary checkout — commit already lives on
+            # the operator tree; nothing to promote.
+            return PromotionOutcome(False, False, "noop_same_root")
+        logger.info(
+            "[WorkspacePromoter] isolation-collapsed config detected — "
+            "derived operator root %s from worktree git topology "
+            "(exec_root=%s)",
+            _derived, exec_root,
+        )
+        project_root = _derived
 
     op_id = getattr(ctx, "op_id", "")
     comm = getattr(getattr(orch, "_stack", None), "comm", None)
@@ -193,9 +260,7 @@ async def run_workspace_promotion(
                 % list(_stale)[:3],
             )
 
-    mgr = manager if manager is not None else WorktreeManager(
-        repo_root=project_root,
-    )
+    # (mgr constructed above, before the operator-root derivation.)
 
     # Branch discovery from the workspace checkout itself — self-contained,
     # no coupling to session-id/nonce derivation.

--- a/tests/governance/test_workspace_promoter_collapsed_root.py
+++ b/tests/governance/test_workspace_promoter_collapsed_root.py
@@ -1,0 +1,225 @@
+"""Workspace promotion under the isolation-collapsed config posture.
+
+Root cause (net-landed soak bt-2026-07-22-042548): FileIsolation
+(``autonomous_workspace.resolve_loop_project_root``) routes the loop's
+``project_root`` INTO the sovereignty worktree at arming, so the
+orchestrator config carries worktree == worktree and the OPERATOR tree
+vanishes from every config field. ``run_workspace_promotion``'s
+``noop_same_root`` early-return therefore fired on EVERY op of every
+isolation-armed soak — silently, structurally unreachable promotion:
+the soak's op landed both files, verified, auto-committed d27d632f in
+the workspace branch… and the operator tree never received it.
+
+The repair derives the TRUE operator root from git topology at read
+time (a linked worktree's ``--git-common-dir`` lives under the primary
+checkout) — env-free, hardcode-free, inert for genuinely-primary
+checkouts. This suite pins:
+
+1. The collapsed posture (config.project_root == config.execution_root
+   == a linked worktree) now PROMOTES: the workspace commit lands on
+   the operator tree.
+2. A genuinely-primary checkout (no linked worktree) still no-ops as
+   ``noop_same_root`` — the legacy posture is byte-identical.
+3. The derivation helper's contract (linked → operator root; primary →
+   its own root; garbage → None).
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.workspace_promoter import (
+    _derive_operator_root,
+    run_workspace_promotion,
+)
+from backend.core.ouroboros.governance.worktree_manager import WorktreeManager
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=cwd, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def operator_and_worktree(tmp_path: Path):
+    """A primary checkout + a linked ``ouroboros/auto/*`` worktree with
+    one un-promoted workspace commit — the soak posture in miniature."""
+    operator = tmp_path / "operator"
+    operator.mkdir()
+    _git(operator, "init", "-q")
+    (operator / "module.py").write_text("X = 1\n")
+    _git(operator, "add", "module.py")
+    _git(operator, "commit", "-q", "-m", "seed")
+
+    wt = tmp_path / "wt"
+    _git(operator, "worktree", "add", "-q", "-b", "ouroboros/auto/test", str(wt))
+    (wt / "module.py").write_text("X = 2\n")
+    _git(wt, "add", "module.py")
+    _git(wt, "commit", "-q", "-m", "fix(test): workspace repair")
+    committed = _git(wt, "rev-parse", "HEAD")
+    return operator, wt, committed
+
+
+def _orch(project_root: Path, execution_root: Path) -> SimpleNamespace:
+    """Minimal orchestrator surface for run_workspace_promotion — the
+    collapsed posture passes the SAME path for both roots."""
+    return SimpleNamespace(
+        _config=SimpleNamespace(
+            project_root=project_root, execution_root=execution_root,
+        ),
+        _stack=SimpleNamespace(comm=None),
+    )
+
+
+def _ctx() -> SimpleNamespace:
+    return SimpleNamespace(
+        op_id="op-collapsed-1", target_files=(), generate_file_hashes=None,
+    )
+
+
+# ---------------------------------------------------------------------------
+# 1. Collapsed posture now promotes
+# ---------------------------------------------------------------------------
+
+
+async def test_collapsed_config_promotes_to_derived_operator_root(
+    operator_and_worktree, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator, wt, committed = operator_and_worktree
+    monkeypatch.setenv("JARVIS_WORKSPACE_PROMOTION_ENABLED", "true")
+    # The consult needs a full orchestrator; its budget semantics are
+    # covered by its own suite — out of scope for the root-derivation pin.
+    monkeypatch.setenv("JARVIS_PROMOTION_LIVE_WORK_CONSULT", "false")
+
+    outcome = await run_workspace_promotion(
+        _orch(wt, wt),          # collapsed: project_root == execution_root == worktree
+        _ctx(),
+        committed,
+        None,
+    )
+
+    assert outcome.promoted is True, (
+        f"promotion refused in collapsed posture: {outcome.state} "
+        f"{getattr(outcome, 'detail', '')}"
+    )
+    # The fix genuinely landed on the OPERATOR tree.
+    assert (operator / "module.py").read_text() == "X = 2\n"
+    assert "workspace repair" in _git(operator, "log", "-1", "--format=%s")
+
+
+async def test_primary_checkout_still_noops(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No linked worktree: the commit already lives on the operator
+    tree — legacy ``noop_same_root`` byte-identical."""
+    primary = tmp_path / "primary"
+    primary.mkdir()
+    _git(primary, "init", "-q")
+    (primary / "a.py").write_text("A = 1\n")
+    _git(primary, "add", "a.py")
+    _git(primary, "commit", "-q", "-m", "seed")
+    head = _git(primary, "rev-parse", "HEAD")
+
+    monkeypatch.setenv("JARVIS_WORKSPACE_PROMOTION_ENABLED", "true")
+    outcome = await run_workspace_promotion(
+        _orch(primary, primary), _ctx(), head, None,
+    )
+    assert outcome.attempted is False
+    assert outcome.state == "noop_same_root"
+
+
+# ---------------------------------------------------------------------------
+# 2. Derivation helper contract
+# ---------------------------------------------------------------------------
+
+
+async def test_derive_operator_root_linked_worktree(
+    operator_and_worktree,
+) -> None:
+    operator, wt, _ = operator_and_worktree
+    mgr = WorktreeManager(repo_root=wt)
+    derived = await _derive_operator_root(mgr, wt)
+    assert derived is not None
+    assert Path(os.path.realpath(derived)) == Path(
+        os.path.realpath(operator)
+    )
+
+
+async def test_derive_operator_root_primary_is_self(tmp_path: Path) -> None:
+    primary = tmp_path / "p"
+    primary.mkdir()
+    _git(primary, "init", "-q")
+    (primary / "x").write_text("x")
+    _git(primary, "add", "x")
+    _git(primary, "commit", "-q", "-m", "s")
+    mgr = WorktreeManager(repo_root=primary)
+    derived = await _derive_operator_root(mgr, primary)
+    # Primary checkout: derivation returns its own root — the caller's
+    # equality check converts that into the legacy noop.
+    assert derived is not None
+    assert Path(os.path.realpath(derived)) == Path(os.path.realpath(primary))
+
+
+async def test_derive_operator_root_non_repo_is_none(tmp_path: Path) -> None:
+    bare = tmp_path / "not_a_repo"
+    bare.mkdir()
+    mgr = WorktreeManager(repo_root=bare)
+    assert await _derive_operator_root(mgr, bare) is None
+
+
+# ---------------------------------------------------------------------------
+# 3. Atomic Promotion — Conflict Shedding on a diverged primary
+# ---------------------------------------------------------------------------
+
+
+async def test_diverged_primary_sheds_conflict_and_stays_intact(
+    operator_and_worktree, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The mandated diverged-primary case: after the worktree branched,
+    the OPERATOR tree advanced with a CONFLICTING change to the same
+    lines. Promotion must cleanly abort (Conflict Shedding) via the
+    existing typed ``PromotionError('conflict_aborted')`` taxonomy —
+    the operator tree stays byte-identical to its diverged state, the
+    workspace branch survives intact for human review, and nothing is
+    force-merged."""
+    operator, wt, committed = operator_and_worktree
+
+    # Diverge the primary with a conflicting edit to the same file/line.
+    (operator / "module.py").write_text("X = 999  # operator diverged\n")
+    _git(operator, "add", "module.py")
+    _git(operator, "commit", "-q", "-m", "operator diverged")
+    diverged_head = _git(operator, "rev-parse", "HEAD")
+    diverged_content = (operator / "module.py").read_text()
+
+    monkeypatch.setenv("JARVIS_WORKSPACE_PROMOTION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_PROMOTION_LIVE_WORK_CONSULT", "false")
+
+    outcome = await run_workspace_promotion(
+        _orch(wt, wt),  # collapsed posture — derivation finds the primary
+        _ctx(),
+        committed,
+        None,
+    )
+
+    # Clean abort, typed: attempted but NOT promoted, conflict state.
+    assert outcome.attempted is True
+    assert outcome.promoted is False
+    assert outcome.state == "conflict_aborted", (
+        f"expected conflict shedding, got {outcome.state!r} "
+        f"({getattr(outcome, 'detail', '')})"
+    )
+    # The primary is byte-identical to its diverged state — no corruption,
+    # no forced merge, no half-applied cherry-pick residue.
+    assert (operator / "module.py").read_text() == diverged_content
+    assert _git(operator, "rev-parse", "HEAD") == diverged_head
+    assert _git(operator, "status", "--porcelain") == ""
+    # The workspace branch survives intact for human review.
+    assert _git(wt, "rev-parse", "HEAD") == committed
+    assert (wt / "module.py").read_text() == "X = 2\n"


### PR DESCRIPTION
## The last link: promotion was structurally unreachable

Soak `bt-2026-07-22-042548` proved the op-scoped latch live (2-file transaction landed + verified + AutoCommit `d27d632f83`) — but promotion silently no-op'd: **FileIsolation routes the loop's `project_root` into the sovereignty worktree at arming**, so config carries worktree == worktree, the operator tree exists in no config field, and `run_workspace_promotion`'s `noop_same_root` early-return fired silently on every op of every isolation-armed soak.

### 1. Git-topology operator-root derivation
`_derive_operator_root`: a linked worktree's `rev-parse --git-common-dir` resolves to `<operator>/.git`; its parent IS the operator root. Reuses `WorktreeManager._run_git_rc` (DRY), env-free, hardcode-free, fail-soft; a genuinely-primary checkout derives itself → legacy `noop_same_root` byte-identical.

### 2. Atomic Promotion / Conflict Shedding — audited + pinned
`promote_commits` already ships the mandated atomicity (ff-only fast path, sha-ordered cherry-pick, no forced refs, conflict → git-native abort → typed `PromotionError('conflict_aborted')` with the target byte-identical). Kept the existing taxonomy; **new diverged-primary test proves the shed**: operator advanced with a conflicting edit → promotion attempts, aborts clean, operator tree/HEAD/porcelain byte-identical, workspace branch intact for review.

### 3. RSI-score signature drift
`lint_before/lint_after` → `lint_violations_before/_after` on **both** twins (complete_runner + inline); fail-soft envelope unchanged.

### Tests
6 new (collapsed-posture promotes with content verified · primary noops · derivation contract ×3 · diverged-primary conflict shed); **55-green sweep** incl. the existing promoter suite, promotion primitives, AST twin-parity sentinel, complete-runner parity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Restores workspace promotion when `project_root` equals `execution_root` by deriving the operator root from Git worktree topology. Keeps primary checkout no-op behavior and fixes RSI-score argument names to avoid runtime errors.

- **Bug Fixes**
  - Added `_derive_operator_root` to resolve the operator root via `git rev-parse --git-common-dir`, used by `run_workspace_promotion` when roots match.
  - Preserved legacy behavior for genuine primary checkouts (`noop_same_root`).
  - Verified atomic promotion: on conflicts, abort cleanly and leave both operator and workspace unchanged (typed `conflict_aborted`).
  - Aligned RSI-score kwargs to `lint_violations_before/after` in both `complete_runner` and the inline path.
  - Added tests for collapsed-posture promotion, derivation contract, primary no-op, and conflict shedding.

<sup>Written for commit 0af099cd1bea8a47b11f52d1d73b285454b66aed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

