### PR TITLE
fix(governance): LiveWork promotion consult scans the derived operator root

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -13182,6 +13182,7 @@ class GovernedOrchestrator:
         best_candidate: Dict[str, Any],
         *,
         max_wait_override_s: Optional[float] = None,
+        scan_root_override: Optional[Path] = None,
     ) -> _LiveWorkGateResult:
         """LiveWorkSensor APPLY gate with bounded defer-wait (Slice 10).
 
@@ -13241,7 +13242,15 @@ class GovernedOrchestrator:
         from backend.core.ouroboros.governance.state_drift import (
             should_block_apply as _should_block_apply,
         )
-        _lws = LiveWorkSensor(self._config.project_root)
+        # scan_root_override (2026-07-22, soak bt-2026-07-22-050025):
+        # "the target IS the tree it scans." Under the isolation-
+        # collapsed posture config.project_root IS the sovereignty
+        # worktree, so the PROMOTION consult saw the op's OWN 33s-old
+        # APPLY write as human activity and refused every promotion.
+        # The promoter now passes the git-topology-derived operator
+        # root; APPLY-time call sites keep the config root unchanged.
+        _lws_root = scan_root_override or self._config.project_root
+        _lws = LiveWorkSensor(_lws_root)
         _scan_targets: set[str] = set(ctx.target_files)
         for _cf, _ in self._iter_candidate_files(best_candidate):
             if _cf:

--- a/backend/core/ouroboros/governance/workspace_promoter.py
+++ b/backend/core/ouroboros/governance/workspace_promoter.py
@@ -228,6 +228,12 @@ async def run_workspace_promotion(
             _gate_res = await orch._live_work_apply_gate(
                 ctx, best_candidate,
                 max_wait_override_s=_consult_budget_s,
+                # Consult contract: "the target IS the tree it scans" —
+                # the DERIVED operator root, never the collapsed config
+                # root (which is the worktree the op itself just wrote;
+                # soak bt-2026-07-22-050025 refused its own promotion
+                # as live_work_active on its own 33s-old APPLY write).
+                scan_root_override=project_root,
             )
             if getattr(_gate_res, "active_hit", None):
                 return await _fail(

--- a/tests/governance/test_workspace_promoter_collapsed_root.py
+++ b/tests/governance/test_workspace_promoter_collapsed_root.py
@@ -175,6 +175,40 @@ async def test_derive_operator_root_non_repo_is_none(tmp_path: Path) -> None:
 
 
 # ---------------------------------------------------------------------------
+# 2b. LiveWork consult scans the DERIVED operator root, never the
+#     collapsed config root (soak bt-2026-07-22-050025: the consult saw
+#     the op's own 33s-old worktree write as human activity)
+# ---------------------------------------------------------------------------
+
+
+async def test_consult_receives_derived_operator_root(
+    operator_and_worktree, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator, wt, committed = operator_and_worktree
+    monkeypatch.setenv("JARVIS_WORKSPACE_PROMOTION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_PROMOTION_LIVE_WORK_CONSULT", "true")
+
+    seen: dict = {}
+
+    async def _recording_gate(ctx, best_candidate, **kwargs):
+        seen.update(kwargs)
+        return SimpleNamespace(active_hit=None)
+
+    orch = _orch(wt, wt)
+    orch._live_work_apply_gate = _recording_gate
+
+    outcome = await run_workspace_promotion(orch, _ctx(), committed, None)
+
+    assert outcome.promoted is True
+    assert "scan_root_override" in seen, (
+        "consult must receive the promotion target as its scan root"
+    )
+    assert Path(os.path.realpath(seen["scan_root_override"])) == Path(
+        os.path.realpath(operator)
+    ), "consult scanned the wrong tree (collapsed config root?)"
+
+
+# ---------------------------------------------------------------------------
 # 3. Atomic Promotion — Conflict Shedding on a diverged primary
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## The consult refused its own APPLY — one seam deeper in the collapsed-root class

Soak `bt-2026-07-22-050025`: the git-topology derivation (#70007) fired for the first time — then promotion refused `live_work_active: modified 33s ago`… the op's **own** APPLY write. `_live_work_apply_gate` builds `LiveWorkSensor` on `config.project_root`, which under isolation-collapse IS the worktree — the promotion consult scanned the tree the organism just wrote instead of the tree it was promoting onto. Fail-closed behaved honestly (commit `860a41c2` quarantined).

**Fix:** keyword-only `scan_root_override` on the gate (its documented contract: *"the target IS the tree it scans"*); `run_workspace_promotion` passes the derived operator root. APPLY-time call sites keep the config root byte-identically; genuine human activity on the operator tree still refuses promotion as designed.

**Tests:** consult-root seam pin (recording gate asserts the override equals the derived operator root; promotion proceeds) — **44-green sweep** across collapsed-root, legacy promoter, promotion primitives, and AST twin-parity suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the promotion consult to scan the derived operator root instead of the collapsed `config.project_root`, preventing promotions from rejecting themselves due to the op’s own recent APPLY write.

- **Bug Fixes**
  - Added keyword-only `scan_root_override` to `_live_work_apply_gate`; `LiveWorkSensor` uses it when provided.
  - `run_workspace_promotion` now passes the derived operator root as the consult scan target; APPLY-time call sites still use `config.project_root`.
  - Added a test that asserts the consult receives the derived operator root and promotion proceeds.

<sup>Written for commit 63dae7e584ef8228209bb787f486d91cac7fc833. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70008?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

