### PR TITLE
feat(governance): In-Memory Object Surgery & Quiescence Fast-Forward — Level-5 divergence resolution without the stash hazard

### DIFF
--- a/backend/core/ouroboros/governance/orchestrator.py
+++ b/backend/core/ouroboros/governance/orchestrator.py
@@ -11542,7 +11542,13 @@ class GovernedOrchestrator:
             )
             # Slice 14: true durable-write probe after 8b, every branch.
             self._emit_terminal_durability_probe(ctx, _committed_hash, _promo)
-            if _promo.attempted and not _promo.promoted:
+            # In-Memory Object Surgery (2026-07-22, inline twin): a
+            # PENDING outcome (parked on ouroboros/pending/<op>) is NOT
+            # a failure — mirrors the slice4b_runner exemption.
+            if (
+                _promo.attempted and not _promo.promoted
+                and not getattr(_promo, "pending", False)
+            ):
                 if _serpent: _serpent.update_phase("POSTMORTEM")
                 ctx = ctx.advance(
                     OperationPhase.POSTMORTEM,

--- a/backend/core/ouroboros/governance/pending_ref_lander.py
+++ b/backend/core/ouroboros/governance/pending_ref_lander.py
@@ -1,0 +1,610 @@
+"""In-Memory Git Object Surgery & Quiescence Fast-Forward (2026-07-22).
+
+Level-5 divergence resolution WITHOUT the stash hazard: when a verified
+workspace commit cannot land directly on the operator tree (dirty
+targets, divergence), the landing happens entirely in git's OBJECT
+DATABASE — never the working directory, never the real index, never
+HEAD, never the human's uncommitted WIP:
+
+1. **In-memory 3-way merge** — ``git merge-tree --write-tree`` evaluates
+   operator-HEAD x workspace-commit against their merge base fully in
+   memory (git >= 2.38). Zero disk-byte mutation of the checkout.
+2. **Non-destructive ref landing** — the merged tree is committed via
+   ``commit-tree`` (two parents: operator HEAD + workspace commit) and
+   parked on ``refs/heads/ouroboros/pending/<op>`` via ``update-ref``
+   (reflogged — full auditability). The working tree remains
+   byte-identical throughout.
+3. **AST-aware semantic reconciliation** — on merge-tree CONFLICT, the
+   (base, ours, theirs) blob payloads route to an injectable resolver
+   (production default: the DoubleWord Realtime tier through
+   ``cognition_lanes.rt_prompt`` — THE one RT primitive, DRY). The
+   resolved blobs are written with ``hash-object -w``, woven into a
+   tree via a THROWAWAY ``GIT_INDEX_FILE`` (never the real index), and
+   the reconciliation commit lands strictly on the pending ref as an
+   Orange-tier review object. Conflict markers never touch disk.
+4. **Quiescence fast-forward** — pending refs that are clean
+   fast-forwards of HEAD auto-land once the touched paths have been
+   quiescent for ``JARVIS_QUIESCENCE_FF_IDLE_S`` (default 30s),
+   measured by the EXISTING ``LiveWorkSensor`` with a scoped
+   ``active_window_s`` — the only step that legitimately moves
+   HEAD/worktree, and only when git itself proves ``--ff-only`` safety
+   and the tree is clean at the touched paths.
+
+Invariant (the whole point): the human's live state — working tree
+bytes, uncommitted WIP, the real index — is NEVER written by stages
+1-3. No ``git stash`` exists anywhere in this module.
+
+All git flows through ``WorktreeManager``'s async subprocess wrappers
+(``_run_git_rc``) — no duplicate wrapper logic. Everything env-tunable;
+fail-soft throughout (any degradation falls back to the promoter's
+existing typed refusal path).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Awaitable, Callable, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+_LANDING_ENABLED_ENV = "JARVIS_PENDING_REF_LANDING_ENABLED"
+_RESOLVER_ENABLED_ENV = "JARVIS_SEMANTIC_MERGE_RESOLVER_ENABLED"
+_QUIESCENCE_FF_ENABLED_ENV = "JARVIS_QUIESCENCE_FF_ENABLED"
+_QUIESCENCE_IDLE_ENV = "JARVIS_QUIESCENCE_FF_IDLE_S"
+_RESOLVER_MAX_BYTES_ENV = "JARVIS_SEMANTIC_MERGE_MAX_FILE_BYTES"
+
+_PENDING_REF_PREFIX = "refs/heads/ouroboros/pending/"
+
+#: Resolver contract: (rel_path, base, ours, theirs) -> merged content
+#: or None (cannot resolve — the file stays unresolved and landing is
+#: declined). Injectable for tests; production default is the DW-RT
+#: builder below.
+SemanticResolver = Callable[
+    [str, str, str, str], Awaitable[Optional[str]],
+]
+
+
+def landing_enabled() -> bool:
+    """Master — default TRUE (stages 1-3 are strictly non-destructive)."""
+    raw = os.environ.get(_LANDING_ENABLED_ENV, "true").strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def resolver_enabled() -> bool:
+    """Semantic reconciliation master — default FALSE (spends DW-RT
+    tokens and produces Orange-review objects; operators opt in)."""
+    raw = os.environ.get(_RESOLVER_ENABLED_ENV, "false").strip().lower()
+    return raw in ("1", "true", "yes", "on")
+
+
+def quiescence_ff_enabled() -> bool:
+    """Quiescence auto-fast-forward master — default TRUE."""
+    raw = os.environ.get(
+        _QUIESCENCE_FF_ENABLED_ENV, "true",
+    ).strip().lower()
+    return raw not in ("0", "false", "no", "off")
+
+
+def quiescence_idle_s() -> float:
+    """``JARVIS_QUIESCENCE_FF_IDLE_S`` — default 30.0."""
+    try:
+        return max(0.0, float(
+            os.environ.get(_QUIESCENCE_IDLE_ENV, "30").strip(),
+        ))
+    except (TypeError, ValueError):
+        return 30.0
+
+
+def _resolver_max_bytes() -> int:
+    try:
+        return max(1024, int(os.environ.get(
+            _RESOLVER_MAX_BYTES_ENV, "262144",
+        ).strip()))
+    except (TypeError, ValueError):
+        return 262_144
+
+
+def pending_ref_name(op_id: str) -> str:
+    """Deterministic, ref-safe pending ref for one op."""
+    safe = "".join(
+        c if (c.isalnum() or c in "-_") else "-" for c in (op_id or "op")
+    )[:80]
+    return _PENDING_REF_PREFIX + safe
+
+
+@dataclass(frozen=True)
+class PendingLandOutcome:
+    """What the object-surgery landing did.
+
+    ``state`` vocabulary (closed): ``landed_clean`` (in-memory merge was
+    conflict-free), ``landed_resolved`` (semantic reconciliation wove the
+    conflicts; Orange review), ``conflict_unresolved`` (resolver off/
+    declined — caller falls back to the legacy typed refusal),
+    ``unsupported`` (git too old / plumbing failure — legacy refusal),
+    ``disabled``.
+    """
+
+    landed: bool
+    state: str
+    ref: str = ""
+    commit: str = ""
+    conflicted_paths: Tuple[str, ...] = ()
+    detail: str = ""
+
+
+# ---------------------------------------------------------------------------
+# Plumbing helpers — every subprocess rides WorktreeManager._run_git_rc
+# ---------------------------------------------------------------------------
+
+
+async def _git(mgr: Any, cwd: Path, *args: str) -> Tuple[int, str, str]:
+    rc, out, err = await mgr._run_git_rc(cwd, list(args))
+    return rc, (out or ""), (err or "")
+
+
+async def _merge_tree(
+    mgr: Any, root: Path, ours: str, theirs: str,
+) -> Tuple[Optional[str], List[str], str]:
+    """``git merge-tree --write-tree -z ours theirs``: pure in-memory
+    3-way merge. Returns ``(tree_oid, conflicted_paths, raw)``;
+    ``tree_oid`` is None on plumbing failure. Conflicted merges STILL
+    return the (marker-bearing) tree oid — those markers exist only in
+    the object database, never on disk.
+    """
+    rc, out, err = await _git(
+        mgr, root, "merge-tree", "--write-tree", "-z",
+        "--name-only", ours, theirs,
+    )
+    if rc not in (0, 1) or not out:
+        return None, [], err.strip()[:200]
+    # -z framing (verified against git 2.52):
+    #   toks[0]                       = merged tree oid
+    #   toks[1 .. first empty token)  = conflicted paths (--name-only)
+    #   <empty token>                 = section separator
+    #   toks[...]                     = informational-message block
+    # rc=0 (clean) → toks[1] is already the empty separator.
+    toks = out.split("\0")
+    tree_oid = toks[0].strip() if toks else ""
+    conflicted: List[str] = []
+    for t in toks[1:]:
+        if t == "":
+            break  # end of the conflicted-paths section
+        p = t.strip()
+        if p:
+            conflicted.append(p)
+    return tree_oid or None, sorted(set(conflicted)), ""
+
+
+async def _stage_blob(
+    mgr: Any, root: Path, content: str,
+) -> Optional[str]:
+    """``hash-object -w --stdin`` — content flows through the extended
+    wrapper's per-spawn stdin channel; no temp files, no disk contact."""
+    try:
+        rc, out, _err = await mgr._run_git_rc_ex(
+            root, ["hash-object", "-w", "--stdin"],
+            stdin_data=content.encode("utf-8", errors="replace"),
+        )
+        return out.strip() if rc == 0 and out.strip() else None
+    except Exception:  # noqa: BLE001 — fail-soft
+        return None
+
+
+async def _blob_at(
+    mgr: Any, root: Path, commitish: str, rel_path: str,
+) -> Optional[str]:
+    """File content at ``commitish:rel_path`` (None when absent)."""
+    rc, out, _err = await _git(
+        mgr, root, "show", f"{commitish}:{rel_path}",
+    )
+    return out if rc == 0 else None
+
+
+async def _weave_resolved_tree(
+    mgr: Any,
+    root: Path,
+    base_tree: str,
+    resolved: Dict[str, str],
+) -> Optional[str]:
+    """Replace ``resolved`` blobs inside ``base_tree`` and return the
+    new tree oid — via a THROWAWAY ``GIT_INDEX_FILE`` scoped to each
+    subprocess spawn (the extended wrapper's per-spawn env; the REAL
+    index, ``os.environ``, and the working tree are never touched).
+    """
+    tmp_index = None
+    try:
+        fd, tmp_index = tempfile.mkstemp(suffix=".jarvis-index")
+        os.close(fd)
+        os.unlink(tmp_index)  # git creates it fresh
+        _idx_env = {"GIT_INDEX_FILE": tmp_index}
+
+        rc, _o, err = await mgr._run_git_rc_ex(
+            root, ["read-tree", base_tree], extra_env=_idx_env,
+        )
+        if rc != 0:
+            logger.debug(
+                "[PendingRefLander] read-tree failed: %s", err[:200],
+            )
+            return None
+        for rel, oid in resolved.items():
+            rc, _o, err = await mgr._run_git_rc_ex(
+                root,
+                ["update-index", "--add", "--cacheinfo",
+                 f"100644,{oid},{rel}"],
+                extra_env=_idx_env,
+            )
+            if rc != 0:
+                logger.debug(
+                    "[PendingRefLander] update-index failed for %s: %s",
+                    rel, err[:200],
+                )
+                return None
+        rc, out, err = await mgr._run_git_rc_ex(
+            root, ["write-tree"], extra_env=_idx_env,
+        )
+        if rc != 0 or not out.strip():
+            return None
+        return out.strip()
+    except Exception:  # noqa: BLE001 — fail-soft
+        logger.debug(
+            "[PendingRefLander] tree weave failed", exc_info=True,
+        )
+        return None
+    finally:
+        if tmp_index:
+            try:
+                os.unlink(tmp_index)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Production semantic resolver — DoubleWord Realtime via cognition_lanes
+# ---------------------------------------------------------------------------
+
+
+def build_dw_semantic_resolver() -> Optional[SemanticResolver]:
+    """The DW-RT resolver over ``cognition_lanes.rt_prompt`` (THE one
+    RT primitive — lease/clamp/eviction/cascade come free). Returns
+    None when the lane is unavailable (caller declines resolution)."""
+    try:
+        from backend.core.ouroboros.governance.cognition_lanes import (
+            rt_prompt,
+        )
+    except Exception:  # noqa: BLE001 — lane unavailable
+        return None
+
+    # Model resolution rides the provider stack's own env carriers —
+    # zero hardcoded model names (repo convention): the dedicated
+    # override first, else the DoublewordProvider's model env. Empty →
+    # decline (the resolver never guesses a model).
+    _model = (
+        os.environ.get("JARVIS_SEMANTIC_MERGE_MODEL", "").strip()
+        or os.environ.get("DOUBLEWORD_MODEL", "").strip()
+    )
+    if not _model:
+        return None
+
+    async def _resolve(
+        rel_path: str, base: str, ours: str, theirs: str,
+    ) -> Optional[str]:
+        cap = _resolver_max_bytes()
+        if max(len(base), len(ours), len(theirs)) > cap:
+            return None  # too large for a reliable weave — decline
+        prompt = (
+            "You are SemanticMergeResolver performing an AST-aware "
+            "three-way merge of one source file.\n"
+            f"FILE: {rel_path}\n\n"
+            "Weave OURS (the operator tree's committed state) with "
+            "THEIRS (the verified autonomous repair) relative to BASE. "
+            "Preserve the INTENT of both sides; prefer THEIRS for the "
+            "repaired logic and OURS for unrelated changes. Output "
+            "ONLY the complete merged file content — no markdown "
+            "fences, no commentary, and ABSOLUTELY no git conflict "
+            "markers.\n\n"
+            f"<BASE>\n{base}\n</BASE>\n\n"
+            f"<OURS>\n{ours}\n</OURS>\n\n"
+            f"<THEIRS>\n{theirs}\n</THEIRS>\n"
+        )
+        try:
+            merged = await rt_prompt(
+                prompt,
+                model=_model,
+                caller_id="semantic_merge_resolver",
+            )
+        except Exception:  # noqa: BLE001 — decline on lane failure
+            logger.debug(
+                "[SemanticMergeResolver] rt_prompt failed for %s",
+                rel_path, exc_info=True,
+            )
+            return None
+        if not merged or "<<<<<<<" in merged or ">>>>>>>" in merged:
+            return None  # refuse marker-bearing or empty output
+        return merged
+
+    return _resolve
+
+
+# ---------------------------------------------------------------------------
+# Stage 1-3 — the non-destructive landing
+# ---------------------------------------------------------------------------
+
+
+async def land_pending_ref(
+    mgr: Any,
+    operator_root: Path,
+    workspace_commit: str,
+    op_id: str,
+    *,
+    resolver: Optional[SemanticResolver] = None,
+) -> PendingLandOutcome:
+    """Land ``workspace_commit`` onto ``ouroboros/pending/<op>`` via
+    pure object surgery. NEVER touches the working tree / real index /
+    HEAD. NEVER raises — every failure degrades to a non-landed
+    outcome the promoter converts into its legacy typed refusal.
+    """
+    if not landing_enabled():
+        return PendingLandOutcome(False, "disabled")
+    try:
+        rc, head_out, _err = await _git(
+            mgr, operator_root, "rev-parse", "HEAD",
+        )
+        if rc != 0 or not head_out.strip():
+            return PendingLandOutcome(
+                False, "unsupported", detail="no HEAD",
+            )
+        head = head_out.strip()
+
+        tree_oid, conflicted, err = await _merge_tree(
+            mgr, operator_root, head, workspace_commit,
+        )
+        if tree_oid is None:
+            return PendingLandOutcome(
+                False, "unsupported",
+                detail=f"merge-tree unavailable/failed: {err}",
+            )
+
+        state = "landed_clean"
+        if conflicted:
+            # Semantic reconciliation — strictly in the object DB.
+            _resolver = resolver
+            if _resolver is None and resolver_enabled():
+                _resolver = build_dw_semantic_resolver()
+            if _resolver is None:
+                return PendingLandOutcome(
+                    False, "conflict_unresolved",
+                    conflicted_paths=tuple(conflicted),
+                    detail="resolver disabled/unavailable",
+                )
+            # True 3-way inputs: merge-base for BASE (once for the op).
+            rc_b, mb_out, _e = await _git(
+                mgr, operator_root, "merge-base", head,
+                workspace_commit,
+            )
+            merge_base = mb_out.strip() if rc_b == 0 else head
+            resolved_blobs: Dict[str, str] = {}
+            for rel in conflicted:
+                base_c = await _blob_at(
+                    mgr, operator_root, merge_base, rel,
+                ) or ""
+                ours_c = await _blob_at(
+                    mgr, operator_root, head, rel,
+                ) or ""
+                theirs_c = await _blob_at(
+                    mgr, operator_root, workspace_commit, rel,
+                ) or ""
+                merged = await _resolver(rel, base_c, ours_c, theirs_c)
+                if merged is None:
+                    return PendingLandOutcome(
+                        False, "conflict_unresolved",
+                        conflicted_paths=tuple(conflicted),
+                        detail=f"resolver declined {rel}",
+                    )
+                blob_oid = await _stage_blob(
+                    mgr, operator_root, merged,
+                )
+                if blob_oid is None:
+                    return PendingLandOutcome(
+                        False, "unsupported",
+                        detail=f"hash-object failed for {rel}",
+                    )
+                resolved_blobs[rel] = blob_oid
+            woven = await _weave_resolved_tree(
+                mgr, operator_root, tree_oid, resolved_blobs,
+            )
+            if woven is None:
+                return PendingLandOutcome(
+                    False, "unsupported", detail="tree weave failed",
+                )
+            tree_oid = woven
+            state = "landed_resolved"
+
+        # commit-tree: a true merge commit (operator HEAD + workspace
+        # commit as parents) so history is honest either way.
+        _kind = (
+            "semantic reconciliation (Orange review)"
+            if state == "landed_resolved" else "clean in-memory merge"
+        )
+        rc, commit_out, err = await _git(
+            mgr, operator_root, "commit-tree", tree_oid,
+            "-p", head, "-p", workspace_commit,
+            "-m",
+            (
+                f"ouroboros(pending): {_kind} of {workspace_commit[:12]} "
+                f"onto {head[:12]} [op={op_id}]"
+            ),
+        )
+        if rc != 0 or not commit_out.strip():
+            return PendingLandOutcome(
+                False, "unsupported",
+                detail=f"commit-tree failed: {err[:200]}",
+            )
+        new_commit = commit_out.strip()
+
+        ref = pending_ref_name(op_id)
+        rc, _o, err = await _git(
+            mgr, operator_root, "update-ref",
+            "-m", f"ouroboros pending landing op={op_id}",
+            "--create-reflog", ref, new_commit,
+        )
+        if rc != 0:
+            return PendingLandOutcome(
+                False, "unsupported",
+                detail=f"update-ref failed: {err[:200]}",
+            )
+
+        logger.warning(
+            "[PendingRefLander] op=%s %s — pending ref %s = %s "
+            "(parents: HEAD %s + workspace %s); working tree untouched"
+            "%s",
+            op_id, state.upper(), ref, new_commit[:12], head[:12],
+            workspace_commit[:12],
+            "; ORANGE review required before integration"
+            if state == "landed_resolved" else "",
+        )
+        try:
+            from backend.api.hive_emitter import hive_emit, hive_flush
+            hive_emit(
+                actor_id="pending_ref_lander",
+                subsystem="governance",
+                intent="pending_ref_landed",
+                summary=(
+                    f"{state}: {workspace_commit[:12]} parked on {ref} "
+                    f"({len(conflicted)} conflict(s) "
+                    f"{'semantically resolved' if conflicted else ''})"
+                ),
+                severity="warn" if state == "landed_resolved" else "info",
+                trace_id=op_id,
+                detail={
+                    "state": state,
+                    "ref": ref[:120],
+                    "commit": new_commit[:40],
+                    "conflicts": len(conflicted),
+                },
+            )
+            hive_flush("pending_ref_lander", "pending_ref_landed")
+        except Exception:  # noqa: BLE001 — telemetry never masks state
+            pass
+        return PendingLandOutcome(
+            True, state, ref=ref, commit=new_commit,
+            conflicted_paths=tuple(conflicted),
+        )
+    except Exception:  # noqa: BLE001 — landing is fail-soft
+        logger.debug(
+            "[PendingRefLander] landing failed op=%s", op_id,
+            exc_info=True,
+        )
+        return PendingLandOutcome(False, "unsupported", detail="internal")
+
+
+# ---------------------------------------------------------------------------
+# Stage 4 — Quiescence fast-forward
+# ---------------------------------------------------------------------------
+
+
+async def try_quiescence_fastforward(
+    mgr: Any,
+    operator_root: Path,
+) -> List[str]:
+    """Land every pending ref that git proves is a clean fast-forward
+    of HEAD, once its touched paths have been quiescent for
+    ``quiescence_idle_s()`` (measured by the EXISTING LiveWorkSensor
+    with a scoped window) and are clean in the working tree. Returns
+    the landed ref names. Fail-soft; NEVER raises.
+    """
+    landed: List[str] = []
+    if not (landing_enabled() and quiescence_ff_enabled()):
+        return landed
+    try:
+        rc, out, _err = await _git(
+            mgr, operator_root, "for-each-ref",
+            "--format=%(refname)", _PENDING_REF_PREFIX.rstrip("/"),
+        )
+        refs = [r.strip() for r in out.splitlines() if r.strip()]
+        if rc != 0 or not refs:
+            return landed
+
+        from backend.core.ouroboros.governance.live_work_sensor import (
+            LiveWorkSensor,
+        )
+        idle_s = quiescence_idle_s()
+        sensor = LiveWorkSensor(
+            operator_root, active_window_s=max(idle_s, 0.001),
+        )
+
+        for ref in refs:
+            # ff-ability is git's own proof, never ours.
+            rc, _o, _e = await _git(
+                mgr, operator_root, "merge-base", "--is-ancestor",
+                "HEAD", ref,
+            )
+            if rc != 0:
+                continue  # diverged — stays pending (review/telemetry)
+            rc, diff_out, _e = await _git(
+                mgr, operator_root, "diff", "--name-only",
+                "HEAD", ref,
+            )
+            touched = [p for p in diff_out.splitlines() if p.strip()]
+            quiescent = True
+            for rel in touched:
+                try:
+                    ev = await sensor.evaluate(rel)
+                    if getattr(ev, "is_human_active", False) or getattr(
+                        ev, "active", False,
+                    ):
+                        quiescent = False
+                        break
+                except Exception:  # noqa: BLE001 — conservative
+                    quiescent = False
+                    break
+            if not quiescent:
+                continue
+            # Touched paths must be clean in the working tree — never
+            # overwrite uncommitted bytes, even on a proven ff.
+            rc, status_out, _e = await _git(
+                mgr, operator_root, "status", "--porcelain", "--",
+                *touched,
+            )
+            if rc != 0 or status_out.strip():
+                continue
+            rc, _o, err = await _git(
+                mgr, operator_root, "merge", "--ff-only", ref,
+            )
+            if rc != 0:
+                logger.debug(
+                    "[PendingRefLander] ff-only declined for %s: %s",
+                    ref, err[:200],
+                )
+                continue
+            await _git(mgr, operator_root, "update-ref", "-d", ref)
+            landed.append(ref)
+            logger.warning(
+                "[PendingRefLander] QUIESCENCE-FF LANDED %s onto HEAD "
+                "at %s (paths quiescent >= %.0fs, tree clean)",
+                ref, operator_root, quiescence_idle_s(),
+            )
+    except Exception:  # noqa: BLE001 — fail-soft
+        logger.debug(
+            "[PendingRefLander] quiescence ff sweep failed",
+            exc_info=True,
+        )
+    return landed
+
+
+__all__ = [
+    "PendingLandOutcome",
+    "SemanticResolver",
+    "build_dw_semantic_resolver",
+    "land_pending_ref",
+    "landing_enabled",
+    "pending_ref_name",
+    "quiescence_ff_enabled",
+    "quiescence_idle_s",
+    "resolver_enabled",
+    "try_quiescence_fastforward",
+]

--- a/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
+++ b/backend/core/ouroboros/governance/phase_runners/slice4b_runner.py
@@ -1490,7 +1490,15 @@ class Slice4bRunner(PhaseRunner):
             # after 8b resolves — the true written state, on EVERY branch
             # (a refused promotion registers written=False explicitly).
             orch._emit_terminal_durability_probe(ctx, _committed_hash, _promo)
-            if _promo.attempted and not _promo.promoted:
+            # In-Memory Object Surgery (2026-07-22): a PENDING outcome
+            # (change parked on ouroboros/pending/<op> via
+            # non-destructive object surgery) is NOT a failure — the
+            # quiescence fast-forwarder or a human review completes the
+            # integration; the op proceeds as applied+committed.
+            if (
+                _promo.attempted and not _promo.promoted
+                and not getattr(_promo, "pending", False)
+            ):
                 return PhaseResult(
                     next_ctx=ctx, next_phase=None, status="fail",
                     reason="promotion_failed:%s" % _promo.state,

--- a/backend/core/ouroboros/governance/workspace_promoter.py
+++ b/backend/core/ouroboros/governance/workspace_promoter.py
@@ -78,6 +78,14 @@ class PromotionOutcome:
     state: str
     shas: Tuple[str, ...] = ()
     detail: str = ""
+    # In-Memory Object Surgery (2026-07-22): True when the change could
+    # not land on HEAD directly but WAS landed on an
+    # ``ouroboros/pending/<op>`` ref via non-destructive object surgery
+    # (clean in-memory merge or Orange-gated semantic reconciliation).
+    # A pending outcome is NOT a failure — call sites exempt it from
+    # the fail path; the quiescence fast-forwarder (or a human review)
+    # completes the integration asynchronously.
+    pending: bool = False
 
 
 async def _derive_operator_root(
@@ -294,12 +302,68 @@ async def run_workspace_promotion(
         if _rel and _hash:
             _baseline_map[str(_rel)] = str(_hash)
 
+    # Quiescence sweep first: any earlier op's pending ref whose touched
+    # paths went quiet may fast-forward now (git-proven --ff-only,
+    # clean-tree-at-paths, LiveWork-quiescent). Import failure disables
+    # the lander; a sweep hiccup alone must NOT (separate fault domains).
+    land_pending_ref = None
+    try:
+        from backend.core.ouroboros.governance.pending_ref_lander import (
+            land_pending_ref as _lpr,
+            try_quiescence_fastforward as _tqf,
+        )
+        land_pending_ref = _lpr
+        try:
+            await _tqf(mgr, project_root)
+        except Exception:  # noqa: BLE001 — sweep is opportunistic
+            logger.debug(
+                "[WorkspacePromoter] quiescence sweep failed",
+                exc_info=True,
+            )
+    except Exception:  # noqa: BLE001 — lander unavailable
+        pass
+
     try:
         result = await mgr.promote_commits(
             project_root, _branch, [committed_hash],
             baseline_hashes=_baseline_map,
         )
     except PromotionError as exc:
+        # ── In-Memory Object Surgery fallback (2026-07-22) ──
+        # A dirty/diverged target no longer dead-ends: the verified
+        # commit lands on ``ouroboros/pending/<op>`` via pure object-
+        # database surgery (merge-tree --write-tree; optional DW-RT
+        # semantic reconciliation, Orange-gated). ZERO working-tree /
+        # index / HEAD / WIP contact — the stash hazard class is
+        # structurally absent. Unresolvable → the legacy typed refusal.
+        if (
+            land_pending_ref is not None
+            and exc.state in ("target_dirty", "conflict_aborted")
+        ):
+            try:
+                _land = await land_pending_ref(
+                    mgr, project_root, committed_hash, op_id,
+                )
+            except Exception:  # noqa: BLE001 — fail-soft to refusal
+                _land = None
+            if _land is not None and _land.landed:
+                logger.info(
+                    "[WorkspacePromoter] op=%s %s: direct landing "
+                    "refused (%s) — parked on %s (%s); quiescence "
+                    "fast-forward or human review completes it",
+                    op_id, _land.state, exc.state, _land.ref,
+                    _land.commit[:12],
+                )
+                return PromotionOutcome(
+                    True, False, _land.state,
+                    shas=(_land.commit,),
+                    detail=(
+                        "direct=%s pending_ref=%s conflicts=%d"
+                        % (exc.state, _land.ref,
+                           len(_land.conflicted_paths))
+                    ),
+                    pending=True,
+                )
         return await _fail(exc.state, exc.detail)
     except Exception as exc:  # noqa: BLE001 — fail CLOSED, never crash 8b
         return await _fail(

--- a/backend/core/ouroboros/governance/worktree_manager.py
+++ b/backend/core/ouroboros/governance/worktree_manager.py
@@ -833,6 +833,48 @@ class WorktreeManager:
         except OSError as exc:
             return 127, "", str(exc)
 
+    async def _run_git_rc_ex(
+        self,
+        root: Path,
+        args: Sequence[str],
+        *,
+        stdin_data: "Optional[bytes]" = None,
+        extra_env: "Optional[Dict[str, str]]" = None,
+    ) -> Tuple[int, str, str]:
+        """``_run_git_rc`` with per-SPAWN stdin + env overrides.
+
+        Added for the pending-ref object-surgery plumbing (2026-07-22):
+        ``hash-object --stdin`` needs a stdin channel, and the
+        throwaway-index weave needs ``GIT_INDEX_FILE`` scoped to ONE
+        subprocess — mutating ``os.environ`` around awaits would leak
+        the override into every concurrently spawned git call on the
+        loop (race). The env copy is per-spawn; nothing global changes.
+        """
+        cmd = ["git", "-C", str(root), *args]
+        env = None
+        if extra_env:
+            env = dict(os.environ)
+            env.update(extra_env)
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                *cmd,
+                stdin=(
+                    asyncio.subprocess.PIPE
+                    if stdin_data is not None else None
+                ),
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env=env,
+            )
+            out, err = await proc.communicate(input=stdin_data)
+            return (
+                proc.returncode or 0,
+                out.decode(errors="replace"),
+                err.decode(errors="replace"),
+            )
+        except OSError as exc:
+            return 127, "", str(exc)
+
     @staticmethod
     def _baseline_exempt_dirty(
         target: Path,

--- a/backend/soak_probes/soak_probe_math.py
+++ b/backend/soak_probes/soak_probe_math.py
@@ -1,0 +1,7 @@
+"""Isolated soak probe (2026-07-21) — planted defect, zero importers."""
+from __future__ import annotations
+
+
+def probe_add(a: int, b: int) -> int:
+    """Return the sum of a and b."""
+    return a - b

--- a/tests/governance/test_pending_ref_lander.py
+++ b/tests/governance/test_pending_ref_lander.py
@@ -1,0 +1,308 @@
+"""In-Memory Git Object Surgery & Quiescence Fast-Forward.
+
+The mandated invariant under test: divergence resolution happens
+ENTIRELY in git's object database — the human's working tree bytes,
+uncommitted WIP, real index, and HEAD are never written by the landing
+stages. No ``git stash`` exists in the mechanism.
+
+Mandated integration case: a DIRTY operator working tree plus an
+in-memory 3-way merge conflict. Assert (1) ``merge-tree`` executes
+without modifying disk bytes, (2) the pending ref receives the
+semantically reconciled commit, and (3) the dirty working tree remains
+100% byte-identical throughout the cycle. Plus: clean-merge landing,
+resolver-declined refusal, quiescence fast-forward semantics, and the
+promoter integration (``target_dirty`` → PENDING outcome, not failure).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.pending_ref_lander import (
+    land_pending_ref,
+    pending_ref_name,
+    try_quiescence_fastforward,
+)
+from backend.core.ouroboros.governance.workspace_promoter import (
+    run_workspace_promotion,
+)
+from backend.core.ouroboros.governance.worktree_manager import WorktreeManager
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=cwd, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+def _tree_fingerprint(root: Path) -> dict:
+    """Byte-exact fingerprint of every file in the WORKING TREE
+    (excluding .git): path -> sha256(content)."""
+    out = {}
+    for p in sorted(root.rglob("*")):
+        if ".git" in p.parts or not p.is_file():
+            continue
+        out[str(p.relative_to(root))] = hashlib.sha256(
+            p.read_bytes(),
+        ).hexdigest()
+    return out
+
+
+@pytest.fixture
+def diverged_dirty_operator(tmp_path: Path):
+    """Operator repo: committed DIVERGENCE (conflicting change) + a
+    DIRTY uncommitted WIP file + an untracked scratch file, plus a
+    linked worktree carrying the verified repair commit."""
+    operator = tmp_path / "operator"
+    operator.mkdir()
+    _git(operator, "init", "-q")
+    (operator / "module.py").write_text("X = 1\nY = 1\n")
+    _git(operator, "add", "module.py")
+    _git(operator, "commit", "-q", "-m", "seed")
+
+    wt = tmp_path / "wt"
+    _git(operator, "worktree", "add", "-q", "-b", "ouroboros/auto/t", str(wt))
+    (wt / "module.py").write_text("X = 2\nY = 1\n")  # the AI repair
+    _git(wt, "add", "module.py")
+    _git(wt, "commit", "-q", "-m", "fix: repair X")
+    committed = _git(wt, "rev-parse", "HEAD")
+
+    # Operator diverges on the SAME line (guaranteed 3-way conflict)...
+    (operator / "module.py").write_text("X = 999\nY = 1\n")
+    _git(operator, "add", "module.py")
+    _git(operator, "commit", "-q", "-m", "operator diverged")
+    # ...and carries live uncommitted WIP + untracked scratch.
+    (operator / "module.py").write_text("X = 999\nY = 1\nWIP = True\n")
+    (operator / "scratch.txt").write_text("human scratchpad\n")
+
+    return operator, wt, committed
+
+
+async def _accepting_resolver(rel, base, ours, theirs):
+    # Deterministic semantic weave: keep operator's X, adopt nothing
+    # blindly — a recognizable merged artifact.
+    return "X = 999\nY = 1\nREPAIRED = True\n"
+
+
+# ---------------------------------------------------------------------------
+# 1. THE mandated case — conflict + dirty tree + byte-identity
+# ---------------------------------------------------------------------------
+
+
+async def test_conflicted_landing_never_touches_dirty_tree(
+    diverged_dirty_operator, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator, wt, committed = diverged_dirty_operator
+    mgr = WorktreeManager(repo_root=operator)
+
+    before = _tree_fingerprint(operator)
+    head_before = _git(operator, "rev-parse", "HEAD")
+    status_before = _git(operator, "status", "--porcelain")
+
+    outcome = await land_pending_ref(
+        mgr, operator, committed, "op-surgery-1",
+        resolver=_accepting_resolver,
+    )
+
+    # (2) The pending ref received the reconciled commit.
+    assert outcome.landed is True
+    assert outcome.state == "landed_resolved"
+    assert outcome.conflicted_paths == ("module.py",)
+    ref = pending_ref_name("op-surgery-1")
+    landed_sha = _git(operator, "rev-parse", ref)
+    assert landed_sha == outcome.commit
+    merged_content = _git(operator, "show", f"{ref}:module.py")
+    assert "REPAIRED = True" in merged_content
+    assert "<<<<<<<" not in merged_content
+    # Honest merge history: both parents present.
+    parents = _git(operator, "rev-list", "--parents", "-n", "1", ref).split()
+    assert head_before in parents and committed in parents
+
+    # (1)+(3) The dirty working tree is 100% byte-identical: WIP line,
+    # untracked scratch, every file — and HEAD/index untouched.
+    assert _tree_fingerprint(operator) == before
+    assert _git(operator, "rev-parse", "HEAD") == head_before
+    assert _git(operator, "status", "--porcelain") == status_before
+    assert (operator / "module.py").read_text().endswith("WIP = True\n")
+    assert (operator / "scratch.txt").read_text() == "human scratchpad\n"
+
+
+async def test_resolver_declined_leaves_no_ref_and_no_bytes(
+    diverged_dirty_operator,
+) -> None:
+    operator, wt, committed = diverged_dirty_operator
+    mgr = WorktreeManager(repo_root=operator)
+    before = _tree_fingerprint(operator)
+
+    async def _declining(rel, base, ours, theirs):
+        return None
+
+    outcome = await land_pending_ref(
+        mgr, operator, committed, "op-decline-1", resolver=_declining,
+    )
+    assert outcome.landed is False
+    assert outcome.state == "conflict_unresolved"
+    with pytest.raises(subprocess.CalledProcessError):
+        _git(operator, "rev-parse", pending_ref_name("op-decline-1"))
+    assert _tree_fingerprint(operator) == before
+
+
+async def test_clean_inmemory_merge_lands_without_resolver(
+    tmp_path: Path,
+) -> None:
+    """Non-overlapping divergence: merge-tree resolves cleanly in
+    memory; the pending ref lands with zero resolver involvement and
+    zero tree contact."""
+    operator = tmp_path / "op"
+    operator.mkdir()
+    _git(operator, "init", "-q")
+    (operator / "a.py").write_text("A = 1\n")
+    (operator / "b.py").write_text("B = 1\n")
+    _git(operator, "add", ".")
+    _git(operator, "commit", "-q", "-m", "seed")
+    wt = tmp_path / "wt"
+    _git(operator, "worktree", "add", "-q", "-b", "ouroboros/auto/c", str(wt))
+    (wt / "a.py").write_text("A = 2\n")
+    _git(wt, "add", "a.py")
+    _git(wt, "commit", "-q", "-m", "fix a")
+    committed = _git(wt, "rev-parse", "HEAD")
+    (operator / "b.py").write_text("B = 2\n")
+    _git(operator, "add", "b.py")
+    _git(operator, "commit", "-q", "-m", "operator changes b")
+    before = _tree_fingerprint(operator)
+
+    mgr = WorktreeManager(repo_root=operator)
+    outcome = await land_pending_ref(mgr, operator, committed, "op-clean-1")
+    assert outcome.landed is True and outcome.state == "landed_clean"
+    ref = pending_ref_name("op-clean-1")
+    assert _git(operator, "show", f"{ref}:a.py") == "A = 2"
+    assert _git(operator, "show", f"{ref}:b.py") == "B = 2"
+    assert _tree_fingerprint(operator) == before
+
+
+# ---------------------------------------------------------------------------
+# 2. Quiescence fast-forward
+# ---------------------------------------------------------------------------
+
+
+async def test_quiescence_ff_lands_clean_pending_ref(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator = tmp_path / "op"
+    operator.mkdir()
+    _git(operator, "init", "-q")
+    (operator / "a.py").write_text("A = 1\n")
+    _git(operator, "add", "a.py")
+    _git(operator, "commit", "-q", "-m", "seed")
+    wt = tmp_path / "wt"
+    _git(operator, "worktree", "add", "-q", "-b", "ouroboros/auto/f", str(wt))
+    (wt / "a.py").write_text("A = 2\n")
+    _git(wt, "add", "a.py")
+    _git(wt, "commit", "-q", "-m", "fix a")
+    committed = _git(wt, "rev-parse", "HEAD")
+
+    mgr = WorktreeManager(repo_root=operator)
+    outcome = await land_pending_ref(mgr, operator, committed, "op-ff-1")
+    assert outcome.landed is True
+
+    # Quiescent by construction for the test: 0s idle window.
+    monkeypatch.setenv("JARVIS_QUIESCENCE_FF_IDLE_S", "0")
+    landed = await try_quiescence_fastforward(mgr, operator)
+
+    assert landed == [pending_ref_name("op-ff-1")]
+    assert (operator / "a.py").read_text() == "A = 2\n"
+    # Ref consumed after landing; HEAD reflog carries the audit trail.
+    with pytest.raises(subprocess.CalledProcessError):
+        _git(operator, "rev-parse", pending_ref_name("op-ff-1"))
+
+
+async def test_quiescence_ff_declines_diverged_ref(
+    diverged_dirty_operator, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A pending ref that is NOT a fast-forward of HEAD stays parked —
+    git's own ancestry proof gates the landing."""
+    operator, wt, committed = diverged_dirty_operator
+    mgr = WorktreeManager(repo_root=operator)
+    outcome = await land_pending_ref(
+        mgr, operator, committed, "op-ffd-1",
+        resolver=_accepting_resolver,
+    )
+    assert outcome.landed is True
+    before = _tree_fingerprint(operator)
+    monkeypatch.setenv("JARVIS_QUIESCENCE_FF_IDLE_S", "0")
+    # The merge commit HAS HEAD as ancestor (parent 1) so it IS
+    # ff-able — but the touched path module.py is DIRTY in the tree:
+    # the clean-tree-at-paths guard must decline.
+    landed = await try_quiescence_fastforward(mgr, operator)
+    assert landed == []
+    assert _tree_fingerprint(operator) == before
+
+
+# ---------------------------------------------------------------------------
+# 3. Promoter integration — target_dirty becomes PENDING, not failure
+# ---------------------------------------------------------------------------
+
+
+async def test_promoter_parks_pending_on_dirty_target(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    operator = tmp_path / "op"
+    operator.mkdir()
+    _git(operator, "init", "-q")
+    (operator / "m.py").write_text("M = 1\n")
+    _git(operator, "add", "m.py")
+    _git(operator, "commit", "-q", "-m", "seed")
+    wt = tmp_path / "wt"
+    _git(operator, "worktree", "add", "-q", "-b", "ouroboros/auto/p", str(wt))
+    (wt / "m.py").write_text("M = 2\n")
+    _git(wt, "add", "m.py")
+    _git(wt, "commit", "-q", "-m", "fix m")
+    committed = _git(wt, "rev-parse", "HEAD")
+    # Dirty the TARGET path in the operator tree (uncommitted WIP).
+    (operator / "m.py").write_text("M = 1\nWIP = 1\n")
+    before = _tree_fingerprint(operator)
+
+    monkeypatch.setenv("JARVIS_WORKSPACE_PROMOTION_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_PROMOTION_LIVE_WORK_CONSULT", "false")
+    monkeypatch.setenv("JARVIS_QUIESCENCE_FF_ENABLED", "false")
+
+    orch = SimpleNamespace(
+        _config=SimpleNamespace(project_root=wt, execution_root=wt),
+        _stack=SimpleNamespace(comm=None),
+    )
+    ctx = SimpleNamespace(
+        op_id="op-park-1", target_files=(), generate_file_hashes=None,
+    )
+    outcome = await run_workspace_promotion(orch, ctx, committed, None)
+
+    assert outcome.attempted is True
+    assert outcome.promoted is False
+    assert getattr(outcome, "pending", False) is True, (
+        f"expected PENDING outcome, got {outcome.state}: {outcome.detail}"
+    )
+    assert outcome.state in ("landed_clean", "landed_resolved")
+    # The WIP is byte-identical; the change waits on the pending ref.
+    assert _tree_fingerprint(operator) == before
+    ref = pending_ref_name("op-park-1")
+    assert _git(operator, "show", f"{ref}:m.py") == "M = 2"
+
+
+def test_no_stash_anywhere_in_the_mechanism() -> None:
+    """The stash hazard class is structurally absent: the lander and
+    the promoter contain zero ``git stash`` invocations."""
+    import inspect
+    from backend.core.ouroboros.governance import (
+        pending_ref_lander, workspace_promoter,
+    )
+    for mod in (pending_ref_lander, workspace_promoter):
+        src = Path(inspect.getfile(mod)).read_text(encoding="utf-8")
+        assert '"stash"' not in src and "'stash'" not in src, (
+            f"{mod.__name__} invokes git stash — forbidden by mandate"
+        )

--- a/tests/test_soak_probe_math.py
+++ b/tests/test_soak_probe_math.py
@@ -1,0 +1,10 @@
+"""Coverage for backend.soak_probes.soak_probe_math."""
+from __future__ import annotations
+
+from backend.soak_probes.soak_probe_math import probe_add
+
+
+def test_probe_add_sums():
+    assert probe_add(2, 3) == 5
+
+# nudge: 1784668619


### PR DESCRIPTION
## Autonomous divergence resolution that never touches live developer state

Soak `bt-2026-07-22-051439` proved the promotion chain to the landing step, where it correctly refused `target_dirty` on uncommitted operator files (containment working). This lands the change autonomously — with the **stash hazard class (which destroys uncommitted-WIP reflogs) structurally absent.** All resolution happens in git's object database.

### 1. In-memory 3-way merge
`git merge-tree --write-tree -z` evaluates operator-HEAD × workspace-commit fully in memory (git ≥ 2.38). Zero working-tree / index / HEAD / WIP bytes written.

### 2. Non-destructive ref landing
Merged tree → `commit-tree` (both parents) → `refs/heads/ouroboros/pending/<op>` via `update-ref --create-reflog`. Full audit trail; working tree untouched.

### 3. AST-aware semantic reconciliation
On conflict, `(base, ours, theirs)` blobs route to an injectable resolver (production: **DoubleWord Realtime via `cognition_lanes.rt_prompt`** — the one RT primitive; no hardcoded model). Resolved blobs are woven via a **throwaway `GIT_INDEX_FILE`** (per-spawn env on the new `WorktreeManager._run_git_rc_ex` — never the real index). The reconciliation commit lands on the pending ref as an Orange-review object; **conflict markers never touch disk.**

### 4. Quiescence fast-forward
Pending refs that git proves are clean fast-forwards auto-land once their touched paths are LiveWork-quiescent (`JARVIS_QUIESCENCE_FF_IDLE_S`, default 30s) **and** clean in the tree — the only step that moves HEAD, gated by git's own `--ff-only` + clean-at-paths proof.

**Promoter wiring:** `target_dirty`/`conflict_aborted` now falls to `land_pending_ref` → typed `pending=True` outcome the call sites (slice4b + inline twin) exempt from the fail path. DRY: all git through `WorktreeManager` wrappers; reuses `LiveWorkSensor`, `cognition_lanes`, `HiveEmitter`.

### Tests
The **mandated case** (conflict + dirty tree: `merge-tree` runs, pending ref gets the reconciled commit, working tree **100% byte-identical** incl. WIP + untracked) + clean-merge landing + resolver-declined refusal + quiescence-ff land/decline + promoter PENDING integration + a structural **"no git stash anywhere"** pin. 7 new + 63-green promotion/parity sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces in‑memory divergence resolution that never touches the working tree and auto‑lands safe changes via quiescence fast‑forward. Dirty/diverged promotions now park on `refs/heads/ouroboros/pending/<op>` instead of failing, eliminating the stash hazard.

- **New Features**
  - In‑memory landing: uses `git merge-tree --write-tree` and commits to `refs/heads/ouroboros/pending/<op>` via `commit-tree` + `update-ref`; zero working‑tree/index/HEAD writes.
  - Optional semantic reconcile: conflicts route to a pluggable resolver (default builds to DoubleWord via `cognition_lanes.rt_prompt`), blobs staged with `hash-object --stdin` and woven using a throwaway `GIT_INDEX_FILE`.
  - Quiescence auto‑FF: auto‑merges pending refs proven `--ff-only` when touched paths are clean and idle for `JARVIS_QUIESCENCE_FF_IDLE_S` (via `LiveWorkSensor`).
  - Promoter wiring: `target_dirty`/`conflict_aborted` now return `pending=True`; orchestrator and `slice4b_runner` treat pending as non‑failure.
  - Plumbing: adds `WorktreeManager._run_git_rc_ex` for per‑spawn stdin/env; all git calls go through `WorktreeManager`. No `git stash` anywhere.

- **Migration**
  - Defaults: pending‑ref landing enabled, quiescence FF enabled, semantic resolver disabled.
  - Enable resolver by setting `JARVIS_SEMANTIC_MERGE_RESOLVER_ENABLED=true` and choosing a model via `JARVIS_SEMANTIC_MERGE_MODEL` or `DOUBLEWORD_MODEL`.
  - Tune idle window with `JARVIS_QUIESCENCE_FF_IDLE_S` (default 30s).
  - Requires `git` ≥ 2.38 for `merge-tree --write-tree`; older versions fall back to legacy refusal.

<sup>Written for commit 55b8cbebe27926a4a4a689f1922c62dc9b51834e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70009?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

