### PR TITLE
fix(governance): Semantic Diff-Entropy + Lockfile-Pinning SemanticGuardian patterns

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3078,6 +3078,13 @@ JARVIS_APPLY_FREEZE_DIFF_MAX_BYTES=262144
 JARVIS_APPLY_FREEZE_ARTIFACT_DIR=
 JARVIS_APPLY_FREEZE_GIT_TIMEOUT_S=15
 
+# --- Supply-chain / diff-entropy SemanticGuardian patterns (revoke SAFE_AUTO
+#     on lockfile pin removal + high-entropy config gutting) ---
+JARVIS_SEMGUARD_DEPENDENCY_PIN_WEAKENED_ENABLED=1
+JARVIS_SEMGUARD_HIGH_ENTROPY_GUTTING_ENABLED=1
+JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION=0.20
+JARVIS_SEMGUARD_ENTROPY_MIN_LINES=12
+
 # ============================================================================
 # END OF CONFIGURATION
 # ============================================================================

--- a/backend/core/ouroboros/governance/semantic_guardian.py
+++ b/backend/core/ouroboros/governance/semantic_guardian.py
@@ -1615,6 +1615,20 @@ try:  # pragma: no cover - import guard
 except Exception:  # noqa: BLE001
     logger.debug("[SemanticGuard] blindspot detectors unavailable — skipping", exc_info=True)
 
+# Supply-chain / diff-entropy detectors (2026-07-22) — the promoted
+# lockfile-gutting response. Same additive, fail-soft registration hook
+# as the blindspot detectors above; both are ``soft`` → notify_apply.
+try:  # pragma: no cover - import guard
+    from backend.core.ouroboros.governance.semantic_guardian_supplychain import (
+        SUPPLYCHAIN_PATTERNS as _SUPPLYCHAIN_PATTERNS,
+    )
+    for _sc_name, _sc_detector in _SUPPLYCHAIN_PATTERNS.items():
+        if _sc_name not in _PATTERNS:
+            _PATTERNS[_sc_name] = _sc_detector
+            _ALL_PATTERNS = tuple(_ALL_PATTERNS) + (_sc_name,)
+except Exception:  # noqa: BLE001
+    logger.debug("[SemanticGuard] supply-chain detectors unavailable — skipping", exc_info=True)
+
 
 # ---------------------------------------------------------------------------
 # Phase 7.1 — adapted-pattern boot-time merge

--- a/backend/core/ouroboros/governance/semantic_guardian_supplychain.py
+++ b/backend/core/ouroboros/governance/semantic_guardian_supplychain.py
@@ -1,0 +1,225 @@
+"""Supply-chain & diff-entropy SemanticGuardian patterns (2026-07-22).
+
+Root cause of the promoted lockfile-gutting (soak bt-2026-07-22-054947):
+the risk plane evaluated file IDENTITY, not diff PAYLOAD. A
+``requirements.txt`` op that stripped 76 pinned dependencies rated
+``SAFE_AUTO`` and fast-forwarded onto the operator tree because nothing
+weighed the semantic destruction the diff carried.
+
+Two content-driven detectors close that class — no path allowlist, no
+regex file-typing, no hardcoding:
+
+1. ``dependency_pin_weakened`` — the Lockfile Pinning Invariant. A
+   strict differential parse (``packaging.requirements``) of old vs new
+   dependency content: any package whose exact pin (``==``) is REMOVED
+   or LOOSENED (to ``>=`` / ``~=`` / ``>`` / unpinned) revokes
+   ``SAFE_AUTO``. Adding a pin, or any purely-additive change, stays
+   silent. Applicability reuses Gate 3's ``is_dependency_file``.
+
+2. ``high_entropy_gutting`` — the Semantic Diff Entropy Cap. A
+   file-agnostic "Destruction Ratio" over the in-process line diff
+   (``difflib.SequenceMatcher``): NET line shrinkage beyond
+   ``JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION`` (default 0.20) of the
+   original length is the gutting signature — distinct from a balanced
+   refactor (deletions ≈ insertions), which never fires. A minimum
+   original-length floor avoids noise on tiny files.
+
+Both are ``soft`` findings → ``recommend_tier_floor`` yields
+``notify_apply``: the op is stripped of silent auto-apply and surfaced
+for operator eyes (stricter-wins with any hard finding). Additive,
+per-pattern kill switches, identical ``inspect()``/``Detection``
+contract, fail-soft import so a load error can never disable the
+existing guardian.
+"""
+
+from __future__ import annotations
+
+import difflib
+import logging
+import os
+from typing import Any, Dict, List, Optional, Tuple
+
+logger = logging.getLogger(__name__)
+
+
+# --------------------------------------------------------------------------- knobs
+
+
+def _entropy_max_destruction() -> float:
+    """``JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION`` — default 0.20. Net
+    line-shrinkage ratio above which the gutting signature fires."""
+    try:
+        v = float(os.environ.get(
+            "JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION", "0.20",
+        ))
+        return v if 0.0 < v < 1.0 else 0.20
+    except (TypeError, ValueError):
+        return 0.20
+
+
+def _entropy_min_lines() -> int:
+    """``JARVIS_SEMGUARD_ENTROPY_MIN_LINES`` — default 12. Files shorter
+    than this never trip the entropy cap (a 3-line file losing 1 line is
+    not a gutting)."""
+    try:
+        return max(1, int(os.environ.get(
+            "JARVIS_SEMGUARD_ENTROPY_MIN_LINES", "12",
+        )))
+    except (TypeError, ValueError):
+        return 12
+
+
+# --------------------------------------------------------------------------- helpers
+
+
+def _candidate_new_content(new_content: Any) -> str:
+    return new_content if isinstance(new_content, str) else ""
+
+
+def _parse_pins(content: str) -> "Dict[str, Optional[str]]":
+    """``{canonical_name: exact_pin_version_or_None}`` for a requirements
+    body, via ``packaging`` (strict differential parse — mandate 2).
+
+    A name maps to its ``==`` version when the specifier is a single
+    exact pin, else ``None`` (loose / ranged / unpinned). Lines that
+    don't parse as a Requirement (``-r``, ``--hashes``, urls, markers-
+    only) are skipped — they carry no pin to weaken. NEVER raises.
+    """
+    out: Dict[str, Optional[str]] = {}
+    try:
+        from packaging.requirements import Requirement
+    except Exception:  # noqa: BLE001 — packaging absent → no invariant
+        return out
+    for raw in content.splitlines():
+        line = raw.split("#", 1)[0].strip()
+        if not line or line.startswith("-"):
+            continue
+        try:
+            req = Requirement(line)
+        except Exception:  # noqa: BLE001 — unparseable line, skip
+            continue
+        name = req.name.lower().replace("_", "-").replace(".", "-")
+        exact: Optional[str] = None
+        specs = list(req.specifier)
+        if len(specs) == 1 and specs[0].operator == "==":
+            exact = specs[0].version
+        out[name] = exact
+    return out
+
+
+def _pat_dependency_pin_weakened(
+    *, file_path: str, old_content: Any, new_content: Any,
+) -> Optional[Any]:
+    """Lockfile Pinning Invariant. Fires when an exact ``==`` pin is
+    removed or loosened between old → new dependency content."""
+    from backend.core.ouroboros.governance.semantic_guardian import (
+        Detection,
+    )
+    try:
+        from backend.core.ouroboros.governance.dependency_file_gate import (
+            is_dependency_file,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    if not is_dependency_file(file_path or ""):
+        return None
+    old = old_content if isinstance(old_content, str) else ""
+    new = _candidate_new_content(new_content)
+    if not old:  # brand-new file — nothing to weaken
+        return None
+
+    old_pins = _parse_pins(old)
+    new_pins = _parse_pins(new)
+    weakened: List[str] = []
+    for name, old_ver in old_pins.items():
+        if old_ver is None:
+            continue  # wasn't pinned — cannot be weakened
+        if name not in new_pins:
+            weakened.append(f"{name} (=={old_ver} → removed)")
+        elif new_pins[name] is None:
+            weakened.append(f"{name} (=={old_ver} → unpinned/loosened)")
+        elif new_pins[name] != old_ver:
+            # A pin CHANGE (==A → ==B) is a version bump, not a
+            # weakening — still a supply-chain edit worth surfacing,
+            # but the invariant here is specifically pin STRENGTH, so
+            # a same-strength bump does not fire (keeps benign bumps
+            # SAFE_AUTO per mandate edge-case 1's spirit).
+            continue
+    if not weakened:
+        return None
+    _shown = ", ".join(weakened[:5])
+    _more = f" (+{len(weakened) - 5} more)" if len(weakened) > 5 else ""
+    return Detection(
+        pattern="dependency_pin_weakened",
+        severity="soft",
+        message=(
+            f"Lockfile pinning invariant: {len(weakened)} exact pin(s) "
+            f"removed or loosened [{_shown}{_more}] — revoking SAFE_AUTO, "
+            f"NOTIFY_APPLY floor pending human validation"
+        ),
+        file_path=file_path,
+        lines=(),
+        snippet=_shown[:200],
+    )
+
+
+def _pat_high_entropy_gutting(
+    *, file_path: str, old_content: Any, new_content: Any,
+) -> Optional[Any]:
+    """Semantic Diff Entropy Cap. Fires when the NET line shrinkage of
+    the old → new diff exceeds the destruction-ratio threshold — the
+    file-agnostic gutting signature (distinct from a balanced rewrite)."""
+    from backend.core.ouroboros.governance.semantic_guardian import (
+        Detection,
+    )
+    old = old_content if isinstance(old_content, str) else ""
+    new = _candidate_new_content(new_content)
+    old_lines = old.splitlines()
+    new_lines = new.splitlines()
+    n_old = len(old_lines)
+    if n_old < _entropy_min_lines():
+        return None
+
+    sm = difflib.SequenceMatcher(a=old_lines, b=new_lines, autojunk=False)
+    deletions = 0
+    insertions = 0
+    for tag, i1, i2, j1, j2 in sm.get_opcodes():
+        if tag == "delete":
+            deletions += (i2 - i1)
+        elif tag == "insert":
+            insertions += (j2 - j1)
+        elif tag == "replace":
+            deletions += (i2 - i1)
+            insertions += (j2 - j1)
+    # NET shrinkage — a balanced refactor (deletions ≈ insertions) has a
+    # near-zero net ratio and never fires; only true mass-removal does.
+    net_removed = max(0, deletions - insertions)
+    destruction_ratio = net_removed / max(1, n_old)
+    threshold = _entropy_max_destruction()
+    if destruction_ratio <= threshold:
+        return None
+    return Detection(
+        pattern="high_entropy_gutting",
+        severity="soft",
+        message=(
+            f"Diff entropy cap: net removal of {net_removed}/{n_old} lines "
+            f"({destruction_ratio:.0%} > {threshold:.0%} destruction "
+            f"ratio) — high-entropy gutting signature; revoking "
+            f"SAFE_AUTO, NOTIFY_APPLY floor"
+        ),
+        file_path=file_path,
+        lines=(),
+        snippet="",
+    )
+
+
+#: Registered by semantic_guardian via the same additive hook as the
+#: blindspot detectors (name -> detector). Per-pattern kill switches
+#: (JARVIS_SEMGUARD_<NAME>_ENABLED) apply automatically.
+SUPPLYCHAIN_PATTERNS: "Dict[str, Any]" = {
+    "dependency_pin_weakened": _pat_dependency_pin_weakened,
+    "high_entropy_gutting": _pat_high_entropy_gutting,
+}
+
+
+__all__ = ["SUPPLYCHAIN_PATTERNS"]

--- a/tests/governance/test_semantic_guardian.py
+++ b/tests/governance/test_semantic_guardian.py
@@ -99,7 +99,9 @@ def test_all_pattern_names_is_exhaustive():
     # pydantic_immutable_set / type_coercion_blindspot / loop_var_rebind_lost)
     # + 1 S6-closure regex pattern (shell_exec_introduced).
     # Task #7 added test_assertion_weakened (F8 closure): 21 → 22.
-    assert len(all_pattern_names()) == 22
+    # 2026-07-22 supply-chain response added dependency_pin_weakened +
+    # high_entropy_gutting (the promoted-lockfile-gutting fix): 22 → 24.
+    assert len(all_pattern_names()) == 24
 
 
 # ---------------------------------------------------------------------------

--- a/tests/governance/test_semantic_guardian_supplychain.py
+++ b/tests/governance/test_semantic_guardian_supplychain.py
@@ -1,0 +1,171 @@
+"""Supply-chain & diff-entropy SemanticGuardian patterns.
+
+Root cause under test (soak bt-2026-07-22-054947): a ``requirements.txt``
+op that stripped 76 pinned dependencies rated SAFE_AUTO and promoted
+onto the operator tree because the risk plane weighed file IDENTITY,
+not diff PAYLOAD. These content-driven detectors revoke SAFE_AUTO on the
+gutting signature.
+
+Mandated edge cases:
+1. Safely ADDING a single pinned dependency → stays SAFE_AUTO (no finding).
+2. UNPINNING an existing dependency → NOTIFY_APPLY floor.
+3. Massive line deletion on a mock config → the entropy cap escalates.
+Plus the exact soak-payload regression (165 pins → 89 loose ranges).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.semantic_guardian import (
+    SemanticGuardian,
+    recommend_tier_floor,
+)
+
+
+def _findings(path: str, old: str, new: str):
+    return SemanticGuardian().inspect(
+        file_path=path, old_content=old, new_content=new,
+    )
+
+
+def _patterns(findings):
+    return {f.pattern for f in findings}
+
+
+# ---------------------------------------------------------------------------
+# Edge case 1 — adding a single pinned dep stays SAFE_AUTO
+# ---------------------------------------------------------------------------
+
+
+def test_adding_pinned_dependency_stays_safe_auto() -> None:
+    old = "torch==2.5.1\nnumpy==1.26.4\nrequests==2.32.3\n"
+    new = old + "rich==13.9.4\n"
+    findings = _findings("requirements.txt", old, new)
+    assert "dependency_pin_weakened" not in _patterns(findings)
+    assert "high_entropy_gutting" not in _patterns(findings)
+    # No supply-chain finding → no tier floor from these patterns.
+    assert recommend_tier_floor(findings) is None
+
+
+def test_pin_version_bump_stays_safe_auto() -> None:
+    """A same-strength bump (==A → ==B) is not a weakening."""
+    old = "torch==2.5.1\nnumpy==1.26.4\n"
+    new = "torch==2.6.0\nnumpy==1.26.4\n"
+    findings = _findings("requirements.txt", old, new)
+    assert "dependency_pin_weakened" not in _patterns(findings)
+
+
+# ---------------------------------------------------------------------------
+# Edge case 2 — unpinning triggers NOTIFY_APPLY
+# ---------------------------------------------------------------------------
+
+
+def test_unpinning_dependency_triggers_notify_apply() -> None:
+    old = "torch==2.5.1\nnumpy==1.26.4\nrequests==2.32.3\n"
+    new = "torch>=2.5.1\nnumpy==1.26.4\nrequests==2.32.3\n"  # torch unpinned
+    findings = _findings("requirements.txt", old, new)
+    assert "dependency_pin_weakened" in _patterns(findings)
+    hit = next(f for f in findings if f.pattern == "dependency_pin_weakened")
+    assert hit.severity == "soft"
+    assert "torch" in hit.message
+    assert recommend_tier_floor(findings) == "notify_apply"
+
+
+def test_removing_pinned_dependency_triggers_notify_apply() -> None:
+    old = "torch==2.5.1\nnumpy==1.26.4\n"
+    new = "numpy==1.26.4\n"  # torch pin removed entirely
+    findings = _findings("requirements.txt", old, new)
+    assert "dependency_pin_weakened" in _patterns(findings)
+    assert recommend_tier_floor(findings) == "notify_apply"
+
+
+def test_loosen_to_compatible_release_triggers_notify_apply() -> None:
+    old = "cryptography==42.0.0\n"
+    new = "cryptography~=42.0\n"
+    assert "dependency_pin_weakened" in _patterns(
+        _findings("requirements.txt", old, new),
+    )
+
+
+def test_non_dependency_file_ignored_by_pin_invariant() -> None:
+    """The pin invariant is applicability-scoped (Gate 3 reuse), not a
+    global rule — a .py file with ``==`` lines never fires it."""
+    old = "x == 1\ny == 2\nz == 3\n"
+    new = "y == 2\n"
+    assert "dependency_pin_weakened" not in _patterns(
+        _findings("backend/mod.py", old, new),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Edge case 3 — massive deletion trips the entropy cap
+# ---------------------------------------------------------------------------
+
+
+def test_massive_deletion_trips_entropy_cap() -> None:
+    old = "\n".join(f"KEY_{i} = value_{i}" for i in range(100)) + "\n"
+    new = "\n".join(f"KEY_{i} = value_{i}" for i in range(20)) + "\n"  # -80%
+    findings = _findings("config/settings.ini", old, new)
+    assert "high_entropy_gutting" in _patterns(findings)
+    hit = next(f for f in findings if f.pattern == "high_entropy_gutting")
+    assert hit.severity == "soft"
+    assert recommend_tier_floor(findings) == "notify_apply"
+
+
+def test_balanced_refactor_does_not_trip_entropy_cap() -> None:
+    """Deletions ≈ insertions (a rewrite, not a gutting) → no finding."""
+    old = "\n".join(f"old_line_{i}" for i in range(100)) + "\n"
+    new = "\n".join(f"new_line_{i}" for i in range(100)) + "\n"
+    assert "high_entropy_gutting" not in _patterns(
+        _findings("backend/mod.py", old, new),
+    )
+
+
+def test_tiny_file_shrink_below_min_lines_ignored() -> None:
+    old = "a\nb\nc\n"
+    new = "a\n"
+    assert "high_entropy_gutting" not in _patterns(
+        _findings("small.txt", old, new),
+    )
+
+
+def test_entropy_threshold_env_tunable(monkeypatch) -> None:
+    old = "\n".join(str(i) for i in range(100)) + "\n"
+    new = "\n".join(str(i) for i in range(70)) + "\n"  # -30%
+    # Default 0.20 → fires.
+    assert "high_entropy_gutting" in _patterns(
+        _findings("c.cfg", old, new),
+    )
+    # Raise the cap above the observed ratio → no longer fires.
+    monkeypatch.setenv("JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION", "0.50")
+    assert "high_entropy_gutting" not in _patterns(
+        _findings("c.cfg", old, new),
+    )
+
+
+# ---------------------------------------------------------------------------
+# The exact soak payload — 165 pins → 89 loose ranges
+# ---------------------------------------------------------------------------
+
+
+def test_soak_lockfile_gutting_payload_no_longer_safe_auto() -> None:
+    """The bt-2026-07-22-054947 shape: a large pinned lockfile rewritten
+    to fewer loose ranges. BOTH detectors fire; SAFE_AUTO is revoked."""
+    old = "\n".join(f"pkg{i}=={i}.0.0" for i in range(165)) + "\n"
+    new = "\n".join(f"pkg{i}>=0" for i in range(89)) + "\n"
+    findings = _findings("requirements.txt", old, new)
+    pats = _patterns(findings)
+    assert "dependency_pin_weakened" in pats
+    assert "high_entropy_gutting" in pats
+    # The op that promoted onto the operator tree would now be floored.
+    assert recommend_tier_floor(findings) == "notify_apply"
+
+
+def test_per_pattern_kill_switch(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SEMGUARD_DEPENDENCY_PIN_WEAKENED_ENABLED", "0")
+    old = "torch==2.5.1\n"
+    new = "torch>=2.5.1\n"
+    assert "dependency_pin_weakened" not in _patterns(
+        _findings("requirements.txt", old, new),
+    )


### PR DESCRIPTION
## The promoted lockfile-gutting response — payload weight, not file identity

Soak `bt-2026-07-22-054947` promoted a `requirements.txt` op that stripped **76 pinned dependencies** (165 → 89 loose ranges) onto the operator tree because it rated `SAFE_AUTO` — the risk plane weighed file *identity*, not diff *payload*. Two content-driven SemanticGuardian patterns close the class (no path allowlist, no regex file-typing):

### 1. `dependency_pin_weakened` — Lockfile Pinning Invariant
Strict differential parse via `packaging.requirements`: any package whose exact `==` pin is **removed or loosened** (`>=`, `~=`, `>`, unpinned) revokes `SAFE_AUTO`. Adding a pin or a same-strength version bump stays silent. Applicability reuses Gate 3's `is_dependency_file`.

### 2. `high_entropy_gutting` — Semantic Diff Entropy Cap
File-agnostic **Destruction Ratio** over the in-process line diff (`difflib.SequenceMatcher`): **net** line shrinkage beyond `JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION` (default 0.20) is the gutting signature — distinct from a balanced refactor (deletions ≈ insertions, near-zero net), which never fires. Min-lines floor avoids tiny-file noise.

Both are `soft` → `recommend_tier_floor` yields `notify_apply`, flowing through the **existing** SemanticGuardian→Gate seam (`gate_runner` `inspect_batch` → `recommend_tier_floor`). Additive registration via the same fail-soft hook as the blindspot detectors; per-pattern kill switches; **zero changes to any existing pattern**.

### Tests
Three mandated edge cases (add-pin stays SAFE_AUTO / unpin → NOTIFY_APPLY / massive deletion → entropy cap) + version-bump-safe + balanced-refactor-doesn't-fire + tiny-file-floor + env-tunable threshold + non-dependency-file scoping + **the exact soak payload** (165→89, both detectors fire, SAFE_AUTO revoked) + kill switch. 12 new; **288-green guardian sweep**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two SemanticGuardian detectors to revoke SAFE_AUTO when dependency pins are weakened or when a diff shows high-entropy gutting, preventing lockfile-gutting from promoting. Both findings are soft and floor changes to `notify_apply` via the existing Guardian→Gate flow.

- **New Features**
  - `dependency_pin_weakened`: Parses dependency files with `packaging` and flags removed or loosened `==` pins (`>=`, `~=`, `>`, unpinned). Same-strength bumps and added pins are ignored.
  - `high_entropy_gutting`: File-agnostic cap on net line shrinkage using `difflib.SequenceMatcher`, so balanced rewrites don’t trigger.
  - Additive, fail-soft registration; per-pattern kill switches; no changes to existing patterns.

- **Migration**
  - Defaults are enabled. Optional env keys in `.env.example`: `JARVIS_SEMGUARD_DEPENDENCY_PIN_WEAKENED_ENABLED`, `JARVIS_SEMGUARD_HIGH_ENTROPY_GUTTING_ENABLED`, `JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION` (default `0.20`), `JARVIS_SEMGUARD_ENTROPY_MIN_LINES` (default `12`).

<sup>Written for commit 699d782ad20fad2c3283cb0612398e5984f8bfbd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70010?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

