### PR TITLE
feat(governance): RepairSandbox Dynamic Dependency Mounting — 100% VALIDATE plugin-import fidelity

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -3086,5 +3086,9 @@ JARVIS_SEMGUARD_ENTROPY_MAX_DESTRUCTION=0.20
 JARVIS_SEMGUARD_ENTROPY_MIN_LINES=12
 
 # ============================================================================
+# --- RepairSandbox Dynamic Dependency Mounting (internal pytest plugins/fixtures
+#     read-only symlinked into the VALIDATE sandbox for 100% import fidelity) ---
+JARVIS_SANDBOX_MOUNT_TEST_DEPS_ENABLED=true
+
 # END OF CONFIGURATION
 # ============================================================================

--- a/backend/core/ouroboros/governance/repair_sandbox.py
+++ b/backend/core/ouroboros/governance/repair_sandbox.py
@@ -69,6 +69,170 @@ def _overlay_max_files() -> int:
 
 
 # ---------------------------------------------------------------------------
+# Dynamic Dependency Mounting (2026-07-22) — internal test-infra fidelity
+# ---------------------------------------------------------------------------
+# Soak bt-2026-07-22-065329: VALIDATE ran the candidate's scoped pytest in the
+# ephemeral sandbox and hit ``[python:FAIL] ... ouroboros_pytest_plugin`` — the
+# internal pytest plugin the suite registers via ``conftest.py``'s
+# ``pytest_plugins`` could not load in the isolated environment. The plugin is
+# TRACKED (present in the git-worktree sandbox), so the gap is environmental
+# fidelity (stale rewrite cache / working-tree-vs-HEAD drift / rsync-excluded
+# infra), not a structurally-missing file.
+#
+# Root-cause fix: at sandbox instantiation, DYNAMICALLY resolve the internal
+# test dependencies the suite declares (parse each ``conftest.py``'s
+# ``pytest_plugins`` list — NO hardcoded plugin names) and read-only-mount any
+# that the sandbox is MISSING via ``os.symlink`` to the LIVE repo file. Only
+# gaps are filled — an existing sandbox copy (the git-worktree's isolated,
+# writable tracked file) is NEVER overwritten, so the strict write-isolation
+# boundary holds: the sandbox's mutation targets are the repair candidates,
+# never these read-through test-infra symlinks (which pytest only imports).
+
+
+def _test_deps_mount_enabled() -> bool:
+    """``JARVIS_SANDBOX_MOUNT_TEST_DEPS_ENABLED`` (default ON). OFF restores
+    the pre-2026-07-22 behavior (no dynamic mount)."""
+    return os.environ.get(
+        "JARVIS_SANDBOX_MOUNT_TEST_DEPS_ENABLED", "true",
+    ).strip().lower() not in ("0", "false", "no", "off")
+
+
+def _dotted_to_relpaths(module: str) -> "List[str]":
+    """Candidate repo-relative file paths for a dotted plugin module name.
+
+    ``tests.ouroboros_pytest_plugin`` → ``tests/ouroboros_pytest_plugin.py``
+    plus the package ``__init__.py`` ancestors that make the dotted import
+    resolvable (``tests/__init__.py``). Order matters — parents first so the
+    package is importable before the leaf. Pure; never raises."""
+    parts = module.split(".")
+    out: List[str] = []
+    # Package __init__.py ancestors (tests/__init__.py, tests/sub/__init__.py).
+    for i in range(1, len(parts)):
+        out.append("/".join(parts[:i]) + "/__init__.py")
+    out.append("/".join(parts) + ".py")           # the leaf module
+    out.append("/".join(parts) + "/__init__.py")  # or a package leaf
+    return out
+
+
+def resolve_internal_test_deps(repo_root: Path) -> "List[str]":
+    """Repo-relative internal test-infra paths the suite needs to import.
+
+    DYNAMIC discovery — parses every ``conftest.py`` under the repo's test
+    dirs for a top-level ``pytest_plugins = [...]`` list (the canonical
+    pytest registration seam) and maps each dotted name to its file path +
+    package ancestors. The declaring ``conftest.py`` files themselves are
+    included. Returns only paths that EXIST in the repo, deduped, sorted
+    (parents before leaves). No hardcoded plugin names. NEVER raises.
+    """
+    import ast as _ast
+
+    deps: List[str] = []
+    seen: set = set()
+
+    def _add(rel: str) -> None:
+        if rel and rel not in seen:
+            try:
+                if (repo_root / rel).is_file():
+                    seen.add(rel)
+                    deps.append(rel)
+            except OSError:
+                pass
+
+    try:
+        _test_dirs = frozenset(
+            n.strip() for n in os.environ.get(
+                "JARVIS_TEST_DIR_NAMES", "tests,test",
+            ).split(",") if n.strip()
+        )
+        conftests: List[Path] = []
+        for tdn in _test_dirs:
+            tdir = repo_root / tdn
+            try:
+                if tdir.is_dir():
+                    conftests.extend(sorted(tdir.rglob("conftest.py")))
+            except OSError:
+                continue
+        # A root conftest.py may also declare plugins.
+        _root_conftest = repo_root / "conftest.py"
+        if _root_conftest.is_file():
+            conftests.insert(0, _root_conftest)
+
+        for cf in conftests:
+            try:
+                tree = _ast.parse(
+                    cf.read_text(encoding="utf-8", errors="replace"),
+                    filename=str(cf),
+                )
+            except (OSError, SyntaxError, ValueError):
+                continue
+            _cf_rel = os.path.relpath(str(cf), str(repo_root)).replace("\\", "/")
+            declared = False
+            for node in _ast.walk(tree):
+                if not isinstance(node, _ast.Assign):
+                    continue
+                if not any(
+                    isinstance(t, _ast.Name) and t.id == "pytest_plugins"
+                    for t in node.targets
+                ):
+                    continue
+                if not isinstance(node.value, (_ast.List, _ast.Tuple)):
+                    continue
+                for elt in node.value.elts:
+                    if isinstance(elt, _ast.Constant) and isinstance(
+                        elt.value, str
+                    ):
+                        declared = True
+                        for rel in _dotted_to_relpaths(elt.value):
+                            _add(rel)
+            if declared:
+                _add(_cf_rel)  # the conftest that declares them
+    except Exception:  # noqa: BLE001 — discovery is fail-soft
+        _logger.debug("resolve_internal_test_deps failed", exc_info=True)
+    return deps
+
+
+def mount_internal_test_deps(
+    repo_root: Path, sandbox_root: Path,
+) -> "List[str]":
+    """Read-only-mount MISSING internal test deps into ``sandbox_root``.
+
+    For each resolved dep absent from the sandbox, create a symlink to the
+    LIVE repo file (read-through — pytest only imports it). An existing
+    sandbox copy is NEVER touched (preserves the git-worktree's isolated
+    writable tracked file → write-isolation boundary intact). Parent dirs
+    are created as real dirs. Returns the list of rel paths actually
+    mounted. Fail-soft per entry; NEVER raises."""
+    mounted: List[str] = []
+    if not _test_deps_mount_enabled():
+        return mounted
+    try:
+        for rel in resolve_internal_test_deps(repo_root):
+            src = repo_root / rel
+            dst = sandbox_root / rel
+            try:
+                if dst.exists() or dst.is_symlink():
+                    continue  # sandbox already has it — never overwrite
+                dst.parent.mkdir(parents=True, exist_ok=True)
+                os.symlink(src, dst)
+                mounted.append(rel)
+            except OSError:
+                _logger.debug(
+                    "mount_internal_test_deps: symlink %s failed", rel,
+                    exc_info=True,
+                )
+                continue
+        if mounted:
+            _logger.info(
+                "repair_sandbox: mounted %d internal test dep(s) "
+                "read-only into sandbox (fidelity): %s",
+                len(mounted), ", ".join(mounted[:6]),
+            )
+    except Exception:  # noqa: BLE001 — mounting is fail-soft
+        _logger.debug("mount_internal_test_deps failed", exc_info=True)
+    return mounted
+
+
+# ---------------------------------------------------------------------------
 # Public exceptions
 # ---------------------------------------------------------------------------
 
@@ -301,6 +465,12 @@ class RepairSandbox:
                         )
             else:
                 self.baseline_fidelity = "head"
+            # Dynamic Dependency Mounting (2026-07-22): guarantee the
+            # internal test-infra (pytest_plugins) is importable in the
+            # sandbox regardless of strategy / working-tree drift.
+            await asyncio.to_thread(
+                mount_internal_test_deps, self._repo_root, tmpdir,
+            )
             _logger.debug("repair_sandbox: initialised via git worktree at %s", tmpdir)
             return
         except Exception as exc:
@@ -314,6 +484,9 @@ class RepairSandbox:
             # rsync copies the live tree directly — the baseline IS the
             # working tree, no overlay needed.
             self.baseline_fidelity = "working_tree"
+            await asyncio.to_thread(
+                mount_internal_test_deps, self._repo_root, tmpdir,
+            )
             _logger.debug("repair_sandbox: initialised via rsync at %s", tmpdir)
             return
         except Exception as exc:
@@ -641,6 +814,21 @@ class RepairSandbox:
         env["PYTHONPYCACHEPREFIX"] = str(sandbox / ".pycache")
         env["TMPDIR"] = str(sandbox / ".tmp")
         env["PYTEST_CACHE_DIR"] = str(sandbox / ".pytest_cache")
+        # Dynamic Dependency Mounting fidelity (2026-07-22): the SANDBOX
+        # root leads PYTHONPATH so a dotted ``pytest_plugins`` entry
+        # (``tests.ouroboros_pytest_plugin``) resolves against the
+        # sandbox's own (mounted) test infra, never a stale parent-env
+        # path. The sandbox 'backend' subdir follows (mirrors the repo's
+        # ``pythonpath = . backend`` pytest.ini contract). Prepended so
+        # sandbox paths win over any inherited PYTHONPATH.
+        _existing_pp = env.get("PYTHONPATH", "")
+        _sandbox_pp = os.pathsep.join(
+            [str(sandbox), str(sandbox / "backend")]
+        )
+        env["PYTHONPATH"] = (
+            _sandbox_pp + os.pathsep + _existing_pp
+            if _existing_pp else _sandbox_pp
+        )
 
         # Ensure scratch directories exist.
         (sandbox / ".tmp").mkdir(exist_ok=True)

--- a/tests/governance/test_repair_sandbox_dep_mounting.py
+++ b/tests/governance/test_repair_sandbox_dep_mounting.py
@@ -1,0 +1,202 @@
+"""Dynamic Dependency Mounting for the RepairSandbox.
+
+Root cause (soak bt-2026-07-22-065329): VALIDATE ran the candidate's
+scoped pytest in the ephemeral sandbox and hit
+``[python:FAIL] ... ouroboros_pytest_plugin`` — the internal plugin the
+suite registers via ``conftest.py``'s ``pytest_plugins`` failed to load
+in the isolated environment.
+
+Fix: the sandbox DYNAMICALLY resolves the internal test deps the suite
+declares (AST-parse of ``pytest_plugins``, no hardcoded names) and
+read-only-mounts any MISSING ones via ``os.symlink`` to the live repo
+file — never overwriting the sandbox's own writable copies
+(write-isolation preserved), plus the sandbox root on PYTHONPATH so the
+dotted import resolves.
+
+This suite proves — with a REAL pytest subprocess inside a REAL
+isolated sandbox — that the plugin imports without ImportError.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.repair_sandbox import (
+    mount_internal_test_deps,
+    resolve_internal_test_deps,
+)
+
+
+def _git(cwd: Path, *args: str) -> str:
+    return subprocess.run(
+        ["git", "-c", "user.name=t", "-c", "user.email=t@t", *args],
+        cwd=cwd, check=True, capture_output=True, text=True,
+    ).stdout.strip()
+
+
+@pytest.fixture
+def repo_with_plugin(tmp_path: Path) -> Path:
+    """A mock repo whose test suite registers an internal pytest plugin
+    via ``conftest.py``'s ``pytest_plugins`` — the exact shape that
+    broke in the sandbox."""
+    repo = tmp_path / "repo"
+    (repo / "tests").mkdir(parents=True)
+    (repo / "tests" / "__init__.py").write_text("")
+    # The internal plugin the suite depends on.
+    (repo / "tests" / "internal_plugin.py").write_text(
+        "import pytest\n\n\n@pytest.fixture\ndef magic_number():\n"
+        "    return 42\n"
+    )
+    # conftest registers it via the canonical pytest_plugins seam.
+    (repo / "tests" / "conftest.py").write_text(
+        'pytest_plugins = ["tests.internal_plugin"]\n'
+    )
+    # A test that USES the plugin fixture — proves live import.
+    (repo / "tests" / "test_uses_plugin.py").write_text(
+        "def test_magic(magic_number):\n    assert magic_number == 42\n"
+    )
+    (repo / "pytest.ini").write_text(
+        "[pytest]\npythonpath = .\n"
+    )
+    _git(repo, "init", "-q")
+    _git(repo, "add", ".")
+    _git(repo, "commit", "-q", "-m", "seed")
+    return repo
+
+
+# ---------------------------------------------------------------------------
+# 1. Dynamic resolution — no hardcoded plugin names
+# ---------------------------------------------------------------------------
+
+
+def test_resolves_declared_plugins_dynamically(repo_with_plugin: Path) -> None:
+    deps = resolve_internal_test_deps(repo_with_plugin)
+    assert "tests/internal_plugin.py" in deps
+    assert "tests/__init__.py" in deps  # package ancestor for the dotted import
+    assert "tests/conftest.py" in deps  # the declaring conftest itself
+
+
+def test_resolution_ignores_nonexistent(tmp_path: Path) -> None:
+    """A conftest declaring a plugin whose file is absent yields nothing
+    for it (only EXISTING paths are returned) — no phantom mounts."""
+    repo = tmp_path / "r"
+    (repo / "tests").mkdir(parents=True)
+    (repo / "tests" / "conftest.py").write_text(
+        'pytest_plugins = ["tests.does_not_exist"]\n'
+    )
+    deps = resolve_internal_test_deps(repo)
+    assert "tests/does_not_exist.py" not in deps
+
+
+# ---------------------------------------------------------------------------
+# 2. Mounting — symlinks missing deps, never overwrites, preserves isolation
+# ---------------------------------------------------------------------------
+
+
+async def test_mount_symlinks_missing_deps(repo_with_plugin: Path, tmp_path: Path) -> None:
+    # A sandbox that is MISSING the plugin (e.g. rsync-excluded infra).
+    sandbox = tmp_path / "sandbox"
+    (sandbox / "tests").mkdir(parents=True)
+    (sandbox / "tests" / "test_uses_plugin.py").write_text("x")  # candidate present
+
+    mounted = await asyncio.to_thread(
+        mount_internal_test_deps, repo_with_plugin, sandbox,
+    )
+
+    assert "tests/internal_plugin.py" in mounted
+    plugin = sandbox / "tests" / "internal_plugin.py"
+    assert plugin.is_symlink()
+    # Read-through resolves to the live repo file.
+    assert plugin.resolve() == (repo_with_plugin / "tests" / "internal_plugin.py").resolve()
+
+
+async def test_mount_never_overwrites_existing_sandbox_copy(
+    repo_with_plugin: Path, tmp_path: Path,
+) -> None:
+    """Write-isolation: an existing sandbox copy (the git-worktree's
+    writable tracked file) is NEVER replaced with a write-through
+    symlink."""
+    sandbox = tmp_path / "sandbox"
+    (sandbox / "tests").mkdir(parents=True)
+    # The sandbox already has its OWN copy (real file, not a symlink).
+    real_copy = sandbox / "tests" / "internal_plugin.py"
+    real_copy.write_text("# sandbox's own isolated copy\n")
+
+    mounted = await asyncio.to_thread(
+        mount_internal_test_deps, repo_with_plugin, sandbox,
+    )
+
+    assert "tests/internal_plugin.py" not in mounted
+    assert not real_copy.is_symlink()  # untouched — isolation preserved
+    assert real_copy.read_text() == "# sandbox's own isolated copy\n"
+
+
+# ---------------------------------------------------------------------------
+# 3. The mandated proof — a REAL pytest run in an isolated sandbox imports
+#    the plugin without ImportError
+# ---------------------------------------------------------------------------
+
+
+async def test_pytest_imports_plugin_inside_mounted_sandbox(
+    repo_with_plugin: Path, tmp_path: Path,
+) -> None:
+    # Build an isolated sandbox that LACKS the internal plugin + conftest
+    # (simulating the fidelity gap) but has the candidate test.
+    sandbox = tmp_path / "sandbox"
+    (sandbox / "tests").mkdir(parents=True)
+    (sandbox / "tests" / "test_uses_plugin.py").write_text(
+        (repo_with_plugin / "tests" / "test_uses_plugin.py").read_text()
+    )
+    (sandbox / "pytest.ini").write_text(
+        (repo_with_plugin / "pytest.ini").read_text()
+    )
+
+    # Without the mount, the plugin fixture is unresolvable → error.
+    env = dict(os.environ)
+    env["PYTHONDONTWRITEBYTECODE"] = "1"
+    env["PYTHONPATH"] = str(sandbox)
+    pre = await asyncio.create_subprocess_exec(
+        sys.executable, "-m", "pytest", "tests/test_uses_plugin.py",
+        "-q", "--no-header", "-c", "pytest.ini",
+        cwd=str(sandbox), env=env,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+    )
+    pre_out, _ = await pre.communicate()
+    assert pre.returncode != 0, "control: unmounted sandbox should fail"
+
+    # Mount the internal deps, then run again — plugin imports cleanly.
+    await asyncio.to_thread(
+        mount_internal_test_deps, repo_with_plugin, sandbox,
+    )
+    post = await asyncio.create_subprocess_exec(
+        sys.executable, "-m", "pytest", "tests/test_uses_plugin.py",
+        "-q", "--no-header", "-c", "pytest.ini",
+        cwd=str(sandbox), env=env,
+        stdout=asyncio.subprocess.PIPE, stderr=asyncio.subprocess.STDOUT,
+    )
+    post_out, _ = await post.communicate()
+    text = post_out.decode("utf-8", errors="replace")
+
+    assert post.returncode == 0, (
+        f"mounted sandbox pytest failed:\n{text}"
+    )
+    assert "1 passed" in text
+    assert "internal_plugin" not in text or "error" not in text.lower()
+
+
+async def test_mount_disabled_env(
+    repo_with_plugin: Path, tmp_path: Path, monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("JARVIS_SANDBOX_MOUNT_TEST_DEPS_ENABLED", "false")
+    sandbox = tmp_path / "sandbox"
+    (sandbox / "tests").mkdir(parents=True)
+    mounted = await asyncio.to_thread(
+        mount_internal_test_deps, repo_with_plugin, sandbox,
+    )
+    assert mounted == []


### PR DESCRIPTION
## Closes the sandbox plugin-import gap the B+ soak exposed

Soak `bt-2026-07-22-065329`: VALIDATE ran the candidate's scoped pytest in the ephemeral sandbox and hit `[python:FAIL] ... ouroboros_pytest_plugin` — the internal plugin the suite registers via `conftest.py`'s `pytest_plugins` failed to load in isolation. L2 correctly recognized it as an infra false-negative and advanced the right candidate, but VALIDATE should confirm **directly**.

**Root-cause fix — dynamic read-only mounting, no hardcoding:**
- `resolve_internal_test_deps`: **AST-parses** every `conftest.py` for its `pytest_plugins = [...]` list (canonical seam, no hardcoded names), maps each dotted name → file path + package `__init__` ancestors + the declaring conftest. Returns only existing paths.
- `mount_internal_test_deps`: for each dep **missing** from the sandbox, `os.symlink` to the live repo file (read-through — pytest only imports it). **Never overwrites an existing sandbox copy** → the git-worktree's isolated writable tracked file, and the strict **write-isolation boundary**, is preserved.
- `run_tests` prepends the sandbox root to `PYTHONPATH` so the dotted plugin resolves against the sandbox's own mounted infra.

Hooked into the existing `_setup` lifecycle (worktree + rsync), off-loop via `asyncio.to_thread`. Master `JARVIS_SANDBOX_MOUNT_TEST_DEPS_ENABLED` (default true).

**Tests:** dynamic resolution / nonexistent-dep-ignored / symlinks-missing / **never-overwrites** (write-isolation) / **the mandated proof** — a real pytest subprocess in an isolated sandbox FAILS to import the plugin before mounting and PASSES after / master-off. 6 new; 21-green RepairSandbox core sweep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees 100% import fidelity for internal pytest plugins in VALIDATE sandboxes by dynamically mounting declared test deps and adjusting PYTHONPATH. Prevents false negatives from missing `pytest_plugins` while preserving sandbox write isolation.

- **New Features**
  - AST-scan all `conftest.py` for `pytest_plugins`, map dotted modules to repo paths (including package `__init__.py`) and include the declaring `conftest.py`.
  - Read-only symlink missing deps into the sandbox; never overwrite existing files; create parents as needed; fail-soft per entry.
  - Hook into sandbox `_setup` for both worktree and rsync flows via `asyncio.to_thread`; `run_tests` now prepends sandbox and `sandbox/backend` to `PYTHONPATH`.
  - Toggle via `JARVIS_SANDBOX_MOUNT_TEST_DEPS_ENABLED` (default true); adds tests proving pre-mount fails and post-mount passes.

<sup>Written for commit b7bc1fcfbd17ea9a9bf2e89c13bbd78e49912a50. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

