### PR TITLE
Dynamic 5xx Resiliency Matrix + Test-Cache-First Boot Hydration

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2898,6 +2898,85 @@ def _is_l7_recoverable(exc: BaseException) -> bool:
         return False
 
 
+# ──────────────────────────────────────────────────────────────────────
+# Dynamic 5xx Resiliency Matrix — DW transient-network absorb loop (2026-07-22)
+# ──────────────────────────────────────────────────────────────────────
+#
+# A transient DoubleWord blip (``upstream_error`` in a 400 body, any 5xx,
+# gateway timeout, or a 429 that carries ``Retry-After``) must be absorbed by a
+# bounded exponential-backoff-with-jitter retry on the PRIMARY generate call —
+# BEFORE the loop cascades to a (possibly dead) fallback and BEFORE the session
+# breaker can trip terminally. The empirical foil is bt-2026-07-22-082657, where
+# ONE transient ``upstream_error`` was mis-labeled ``terminal_quota`` and killed
+# the whole soak. The classification lives in ``provider_retry_classifier`` and
+# the jitter primitive is reused from ``circuit_breaker.full_jitter_delay``
+# (DRY — no new jitter maths here).
+
+
+def _dw_transient_max_retries() -> int:
+    """Bounded absorb-loop budget for a DW TRANSIENT_NETWORK blip on the
+    primary generate call (env ``JARVIS_DW_TRANSIENT_MAX_RETRIES``, default 2).
+    The breaker's own window still caps the worst case. Fail-soft to 2."""
+    try:
+        return max(0, int(os.environ.get("JARVIS_DW_TRANSIENT_MAX_RETRIES", "2")))
+    except (TypeError, ValueError):
+        return 2
+
+
+def _is_dw_transient_network(exc: Exception, http_status, retry_after_ts) -> bool:
+    """True when *exc* classifies TRANSIENT_NETWORK per the Dynamic 5xx
+    Resiliency Matrix (upstream_error / 5xx / gateway timeout / 429-with-
+    Retry-After). Uses the canonical taxonomy — never raises."""
+    try:
+        from backend.core.ouroboros.governance.provider_retry_classifier import (
+            classify, RetryDecision,
+        )
+        decision = classify(
+            failure_class=type(exc).__name__,
+            http_status=http_status,
+            failure_message=str(exc),
+            retry_after_present=retry_after_ts is not None,
+        )
+        return decision is RetryDecision.TRANSIENT_NETWORK
+    except Exception:  # noqa: BLE001 — classification never blocks the caller
+        return False
+
+
+def _dw_transient_backoff_s(attempt: int, retry_after_ts, *, remaining_s: float) -> float:
+    """Backoff before a DW transient retry. Prefers a server-directed
+    ``Retry-After`` timestamp when present, else AWS full-jitter exponential
+    backoff (reused from circuit_breaker). Clamped to a quarter of the
+    remaining op budget and a hard 30s ceiling. Async-sleepable; never raises."""
+    try:
+        base_s = float(os.environ.get("JARVIS_DW_TRANSIENT_BACKOFF_BASE_S", "1.5"))
+    except (TypeError, ValueError):
+        base_s = 1.5
+    try:
+        cap_s = float(os.environ.get("JARVIS_DW_TRANSIENT_BACKOFF_CAP_S", "12.0"))
+    except (TypeError, ValueError):
+        cap_s = 12.0
+    delay: Optional[float] = None
+    try:
+        if retry_after_ts is not None:
+            wait = float(retry_after_ts) - time.time()
+            if wait > 0:
+                delay = wait
+    except (TypeError, ValueError):
+        delay = None
+    if delay is None:
+        try:
+            from backend.core.ouroboros.governance.circuit_breaker import (
+                full_jitter_delay,
+            )
+            delay = full_jitter_delay(attempt, base_s=base_s, cap_s=cap_s)
+        except Exception:  # noqa: BLE001 — degrade to plain expo if helper absent
+            delay = min(cap_s, base_s * (2 ** max(0, attempt)))
+    budget_clamp = (
+        max(0.1, remaining_s * 0.25) if remaining_s and remaining_s > 0 else cap_s
+    )
+    return max(0.1, min(delay, budget_clamp, 30.0))
+
+
 class CandidateGenerator:
     """Orchestrates candidate generation with failover and concurrency control.
 
@@ -6601,39 +6680,76 @@ class CandidateGenerator:
         # stringifying it through RuntimeError(_dw_error).
         _structured_error: Optional[Exception] = None
         if getattr(self._tier0, "_realtime_enabled", False):
-            try:
-                result = await asyncio.wait_for(
-                    self._tier0.generate(context, deadline),
-                    timeout=_dw_timeout,
-                )
-                if result is not None and len(result.candidates) > 0:
-                    logger.info(
-                        "[CandidateGenerator] BACKGROUND: DW produced %d candidates "
-                        "in %.1fs ($%.4f)",
-                        len(result.candidates),
-                        result.generation_duration_s,
-                        getattr(result, "cost_usd", 0.0),
+            # Dynamic 5xx Resiliency Matrix (2026-07-22): absorb a transient
+            # upstream/network blip on the DW primary with a bounded
+            # exponential-backoff-with-jitter retry HERE — before cascading and
+            # before any terminal breaker trip. Async sleep only; the ASGI
+            # event loop is never dropped.
+            _dw_transient_budget = _dw_transient_max_retries()
+            _dw_attempt = 0
+            while True:
+                try:
+                    result = await asyncio.wait_for(
+                        self._tier0.generate(context, deadline),
+                        timeout=_dw_timeout,
                     )
-                    return result
-                _dw_error = "background_dw_empty_result"
-            except asyncio.TimeoutError:
-                _dw_error = f"background_dw_timeout:{_dw_timeout:.0f}s"
-            except Exception as exc:
-                _structured_error = exc  # Slice F preserves the object
-                # Build a richer _dw_error that surfaces status_code
-                # + a body excerpt when available (DoublewordInfraError),
-                # so legacy log-line consumers see ground truth too.
-                _status = getattr(exc, "status_code", None)
-                _body = getattr(exc, "response_body", "") or ""
-                if _status is not None:
-                    _dw_error = (
-                        f"background_dw_error:{type(exc).__name__}:"
-                        f"http_{_status}:{_body[:120]}"
+                    if result is not None and len(result.candidates) > 0:
+                        logger.info(
+                            "[CandidateGenerator] BACKGROUND: DW produced %d candidates "
+                            "in %.1fs ($%.4f)",
+                            len(result.candidates),
+                            result.generation_duration_s,
+                            getattr(result, "cost_usd", 0.0),
+                        )
+                        return result
+                    _dw_error = "background_dw_empty_result"
+                    break
+                except asyncio.TimeoutError:
+                    _dw_error = f"background_dw_timeout:{_dw_timeout:.0f}s"
+                    break
+                except Exception as exc:
+                    _structured_error = exc  # Slice F preserves the object
+                    # Build a richer _dw_error that surfaces status_code
+                    # + a body excerpt when available (DoublewordInfraError),
+                    # so legacy log-line consumers see ground truth too.
+                    _status = getattr(exc, "status_code", None)
+                    _body = getattr(exc, "response_body", "") or ""
+                    _retry_after_ts = getattr(exc, "ratelimit_reset_ts", None)
+                    # Transient network/upstream blip → absorb-and-retry (never
+                    # cascade to a dead fallback, never terminally trip).
+                    _budget_ok = (
+                        self._remaining_seconds(deadline) > _dw_timeout * 0.5
                     )
-                else:
-                    _dw_error = (
-                        f"background_dw_error:{type(exc).__name__}:{exc}"
-                    )
+                    if (
+                        _is_dw_transient_network(exc, _status, _retry_after_ts)
+                        and _dw_attempt < _dw_transient_budget
+                        and _budget_ok
+                    ):
+                        _delay = _dw_transient_backoff_s(
+                            _dw_attempt, _retry_after_ts,
+                            remaining_s=self._remaining_seconds(deadline),
+                        )
+                        logger.warning(
+                            "[CandidateGenerator] BACKGROUND: DW TRANSIENT_NETWORK "
+                            "(%s http_%s) — full-jitter backoff %.1fs, retry %d/%d "
+                            "[%s] (absorbed; no cascade, no terminal trip)",
+                            type(exc).__name__, _status, _delay,
+                            _dw_attempt + 1, _dw_transient_budget,
+                            getattr(context, "op_id", "?")[:16],
+                        )
+                        await asyncio.sleep(_delay)
+                        _dw_attempt += 1
+                        continue
+                    if _status is not None:
+                        _dw_error = (
+                            f"background_dw_error:{type(exc).__name__}:"
+                            f"http_{_status}:{_body[:120]}"
+                        )
+                    else:
+                        _dw_error = (
+                            f"background_dw_error:{type(exc).__name__}:{exc}"
+                        )
+                    break
         else:
             # Legacy batch path
             try:
@@ -8813,6 +8929,17 @@ class CandidateGenerator:
                             failure_mode=_inner_mode.name,
                             failure_message=str(inner_exc),
                             economic_reclassify=_s127_econ_on,
+                            # Dynamic 5xx Resiliency Matrix (2026-07-22): thread
+                            # the provider HTTP status + Retry-After presence
+                            # into the taxonomy (previously omitted). A 5xx /
+                            # upstream_error / 429-with-Retry-After now
+                            # classifies TRANSIENT_NETWORK instead of falling
+                            # through to a terminal decision.
+                            http_status=getattr(inner_exc, "status_code", None),
+                            retry_after_present=(
+                                getattr(inner_exc, "ratelimit_reset_ts", None)
+                                is not None
+                            ),
                         )
                         # Slice 127 Phase 2 — per-provider economic breaker.
                         # The fallback IS the Claude/Anthropic lane; when this

--- a/backend/core/ouroboros/governance/circuit_breaker.py
+++ b/backend/core/ouroboros/governance/circuit_breaker.py
@@ -814,8 +814,18 @@ class CircuitBreaker:
             # In-window quota hit but below trip — back off with
             # full-jitter and let caller retry.
             return self._verdict_backoff()
-        # RETRY_TRANSIENT — count toward OPEN_TRANSIENT trip.
-        if decision == RetryDecision.RETRY_TRANSIENT:
+        # RETRY_TRANSIENT / TRANSIENT_NETWORK — count toward OPEN_TRANSIENT
+        # trip; NEVER terminal. A transient network / upstream-gateway blip
+        # (DoubleWord ``upstream_error``, 5xx, gateway timeout, 429-with-
+        # Retry-After) backs off with full-jitter and retries — it must never
+        # trip the session breaker to OPEN_TERMINAL. This is the containment
+        # half of the Dynamic 5xx Resiliency Matrix (2026-07-22): the taxonomy
+        # labels the blip transient, and this branch guarantees the breaker
+        # honors that label with a recoverable OPEN_TRANSIENT at worst.
+        if decision in (
+            RetryDecision.RETRY_TRANSIENT,
+            RetryDecision.TRANSIENT_NETWORK,
+        ):
             self._transient_window.add()
             transient_trip = _read_int(_TRANSIENT_TRIP_ENV, 3, minimum=1)
             if self._transient_window.count() >= transient_trip:
@@ -829,7 +839,7 @@ class CircuitBreaker:
                 state_after=self._state,
             )
         # Unknown decision (should not happen — RetryDecision is
-        # closed 4-value). Defensive RETRY_OK preserves legacy
+        # a closed taxonomy). Defensive RETRY_OK preserves legacy
         # semantics.
         return CircuitVerdict(
             action=VerdictAction.RETRY_OK,

--- a/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
@@ -245,6 +245,46 @@ def boot_hydration_enabled() -> bool:
     ).lower() in ("true", "1", "yes")
 
 
+# --- Test-Cache-First boot hydration (state-hashing blind-spot fix) --------
+#
+# The working-tree/Merkle hydration above keys on CONTENT CHANGE: a red test
+# whose file hash is unchanged since the last snapshot (``walk_changed=0``) is
+# invisible to it — the failure predates the snapshot, so no ``fs.changed``
+# fires and the git-diff finds a clean tree. That is a *persistent
+# environmental defect*, and pytest already persists it in its own
+# ``.pytest_cache/v/cache/lastfailed`` ledger (survives process restarts).
+#
+# This layer reads that ledger BEFORE the hash diff and seeds a repair for
+# each unresolved red — independent of whether any file hash changed. It emits
+# through the SAME ``process_failures`` -> ``handle_signals`` -> ``router.ingest``
+# sink every other path uses (DRY), treating the cache as the FIRST observation
+# of each failure so the 2-consecutive-runs stability contract is honored with
+# the cache standing in for the prior run it recorded.
+
+
+def cache_first_hydration_enabled() -> bool:
+    """Re-read ``JARVIS_TEST_FAILURE_CACHE_FIRST_ENABLED`` (default true).
+
+    Not cached so tests can monkeypatch per-case (same pattern as
+    ``boot_hydration_enabled``). OFF -> byte-identical legacy boot (the
+    git-diff working-tree hydration only, no pytest-cache consultation).
+    """
+    return os.environ.get(
+        "JARVIS_TEST_FAILURE_CACHE_FIRST_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _cache_first_max_files() -> int:
+    """Bound the cache-first synthetic seed count (default 16) so a large
+    persisted red suite cannot flood intake at boot. Fail-soft to 16."""
+    try:
+        return max(
+            1, int(os.environ.get("JARVIS_TEST_FAILURE_CACHE_FIRST_MAX_FILES", "16"))
+        )
+    except (TypeError, ValueError):
+        return 16
+
+
 _HYDRATION_DEDUP_TTL_S: float = float(
     os.environ.get("JARVIS_TESTWATCHER_HYDRATION_DEDUP_TTL_S", "120")
 )
@@ -755,6 +795,107 @@ class TestFailureSensor:
             return False
         return True
 
+    def _pytest_lastfailed_path(self) -> Path:
+        """Path to pytest's persisted ``lastfailed`` ledger under the repo
+        root — the SAME ``.git``-anchored root the git-diff + scoped resolver
+        use (``_repo_root``), so the cache and the failure loci agree."""
+        return self._repo_root() / ".pytest_cache" / "v" / "cache" / "lastfailed"
+
+    def _read_pytest_lastfailed(self) -> List[str]:
+        """Read pytest's ``lastfailed`` cache -> list of failing node-ids.
+
+        The file is a JSON object mapping ``nodeid -> true`` for every test
+        that failed in pytest's most recent run (pytest's own persisted
+        ground truth). Missing / unreadable / malformed -> ``[]``. Only
+        truthy, path-shaped keys are kept. Never raises.
+        """
+        path = self._pytest_lastfailed_path()
+        try:
+            if not path.is_file():
+                return []
+            data = json.loads(path.read_text(encoding="utf-8", errors="replace"))
+        except (OSError, ValueError):
+            return []
+        if not isinstance(data, dict):
+            return []
+        return [str(k) for k, v in data.items() if v and ".py" in str(k)]
+
+    async def hydrate_from_pytest_cache(self) -> int:
+        """Test-Cache-First boot hydration — seed persistent reds the hash
+        diff cannot see (``walk_changed=0``).
+
+        An event-driven sensor keyed on file-hash change is blind to a red
+        test whose source did NOT change since the last snapshot: the failure
+        predates the snapshot, so no ``fs.changed`` fires and the git-diff
+        hydration finds a clean tree. That is a persistent ENVIRONMENTAL
+        defect — and pytest already records it. This layer reads pytest's own
+        ``lastfailed`` ledger and constructs synthetic failure signals for each
+        unresolved red, independent of any hash diff.
+
+        DRY: emits through the SAME ``process_failures`` ->
+        ``handle_signals`` -> ``router.ingest`` sink every other path uses.
+        The cache is treated as the FIRST observation of each failure (streak
+        seeded to 1, never downgrading a higher live streak), so a single
+        ``process_failures`` pass promotes it past the 2-consecutive-runs
+        stability threshold — the cache standing in for the prior run it
+        persisted. Each seeded file is recorded in ``_hydrated_keys`` so a
+        redundant live ``fs.changed`` for it is de-duped.
+
+        Gated ``JARVIS_TEST_FAILURE_CACHE_FIRST_ENABLED`` (default true);
+        OFF / no watcher / empty cache -> 0 with no side effects. Fail-soft:
+        any error logs at DEBUG and returns the count so far.
+        """
+        if not cache_first_hydration_enabled() or self._watcher is None:
+            return 0
+        reds = self._read_pytest_lastfailed()
+        if not reds:
+            return 0
+        cap = _cache_first_max_files()
+        now = time.monotonic()
+        failures: List[TestFailure] = []
+        streaks = getattr(self._watcher, "_failure_streak", None)
+        for nodeid in reds[:cap]:
+            test_file = nodeid.split("::", 1)[0]
+            # The cache IS the prior observation → seed streak to 1 so one
+            # process_failures pass reaches the stable (>=2) threshold. Never
+            # downgrade an existing (higher) live streak.
+            if isinstance(streaks, dict):
+                streaks[nodeid] = max(streaks.get(nodeid, 0), 1)
+            failures.append(
+                TestFailure(
+                    test_id=nodeid,
+                    file_path=test_file,
+                    error_text=(
+                        "pytest lastfailed cache: persistent unresolved failure"
+                    ),
+                )
+            )
+            self._hydrated_keys[test_file] = now
+        if not failures:
+            return 0
+        try:
+            if attribution_enabled():
+                await prewarm_module_map(self._watcher.repo_path)
+        except Exception:
+            logger.debug("[CacheFirstHydration] prewarm failed", exc_info=True)
+        try:
+            signals = self._watcher.process_failures(failures)
+        except Exception:
+            logger.debug(
+                "[CacheFirstHydration] process_failures failed", exc_info=True
+            )
+            return 0
+        ingested = 0
+        if signals:
+            results = await self.handle_signals(signals)
+            ingested = sum(1 for r in results if r is not None)
+            logger.info(
+                "[CacheFirstHydration] %d persistent red(s) from pytest cache "
+                "-> %d stable signal(s) ingested (merkle-diff-independent)",
+                len(failures), len(signals),
+            )
+        return ingested
+
     async def hydrate_on_boot(self) -> int:
         """Reconstruct + scope-run tests for pre-boot working-tree changes.
 
@@ -772,19 +913,30 @@ class TestFailureSensor:
         any error logs at DEBUG and returns the count so far -- boot is never
         crashed.
         """
-        if not boot_hydration_enabled() or self._watcher is None:
+        if self._watcher is None:
             return 0
+        ingested = 0
+        # Test-Cache-First layer (independent gate): seed persistent reds the
+        # working-tree/Merkle hash diff cannot see (walk_changed=0), BEFORE the
+        # git-diff hydration consults any file hash.
+        try:
+            ingested += await self.hydrate_from_pytest_cache()
+        except Exception:
+            logger.debug("[BootHydration] cache-first layer failed", exc_info=True)
+        # Working-tree differential hydration (git diff HEAD) — its own gate.
+        if not boot_hydration_enabled():
+            self._boot_hydrated = True
+            return ingested
         try:
             changed = await self._watcher.diff_working_tree()
         except Exception:
             logger.debug("[BootHydration] diff_working_tree failed", exc_info=True)
-            return 0
+            return ingested
         if not changed:
             logger.debug("[BootHydration] clean working tree -- nothing to hydrate")
             self._boot_hydrated = True
-            return 0
+            return ingested
 
-        ingested = 0
         now = time.monotonic()
         for rel in changed:
             try:

--- a/backend/core/ouroboros/governance/provider_retry_classifier.py
+++ b/backend/core/ouroboros/governance/provider_retry_classifier.py
@@ -107,21 +107,34 @@ class RetryDecision(str, enum.Enum):
         Examples: HTTP 401 / 403 / 404, missing model,
         invalid API key.
 
+      * ``TRANSIENT_NETWORK`` — a transient NETWORK / upstream-gateway
+        anomaly that a brief retry absorbs invisibly: the DoubleWord
+        router's ``upstream_error`` (its upstream GPU provider rejected
+        the request), gateway timeouts, all 5xx, and a rate-limit that
+        carries a ``Retry-After`` header (the server told us WHEN to
+        retry). Distinct from ``RETRY_TRANSIENT`` so the orchestrator can
+        drive an exponential-backoff-with-jitter retry loop that NEVER
+        trips the session breaker terminally — the empirical foil from
+        bt-2026-07-22-082657, where a single transient ``upstream_error``
+        was mis-labeled ``terminal_quota`` and killed the whole soak.
+
     The downstream Circuit Breaker maps each decision to a state
     transition:
 
       RETRY_TRANSIENT     → CLOSED (count toward OPEN_TRANSIENT trip)
+      TRANSIENT_NETWORK   → CLOSED (count toward OPEN_TRANSIENT trip; never terminal)
       TERMINAL_STRUCTURAL → OPEN_TERMINAL (1× trip)
       TERMINAL_QUOTA      → OPEN_TERMINAL (Nth within window)
       TERMINAL_CONFIG     → OPEN_TERMINAL (1× trip)
 
-    The 4-value cardinality is AST-pinned in
+    The 5-value cardinality is AST-pinned in
     ``tests/governance/test_provider_retry_classifier.py``."""
 
     RETRY_TRANSIENT     = "retry_transient"
     TERMINAL_STRUCTURAL = "terminal_structural"
     TERMINAL_QUOTA      = "terminal_quota"
     TERMINAL_CONFIG     = "terminal_config"
+    TRANSIENT_NETWORK   = "transient_network"
 
 
 # ============================================================================
@@ -168,10 +181,44 @@ _TERMINAL_QUOTA_CLASSES: frozenset = frozenset({
 
 _HTTP_STATUS_TERMINAL_CONFIG: frozenset = frozenset({401, 403, 404})
 _HTTP_STATUS_TERMINAL_QUOTA: frozenset = frozenset({429})
-# HTTP 5xx and 408 (Request Timeout) are transient.
-_HTTP_STATUS_RETRY_TRANSIENT: frozenset = frozenset({
+# HTTP 5xx and 408 (Request Timeout) are transient NETWORK / gateway
+# anomalies — a brief backoff-retry absorbs them. Routed to the dedicated
+# TRANSIENT_NETWORK class (not RETRY_TRANSIENT) so the orchestrator drives a
+# backoff-with-jitter loop that never terminally trips the session breaker.
+_HTTP_STATUS_TRANSIENT_NETWORK: frozenset = frozenset({
     408, 500, 502, 503, 504,
 })
+
+
+# Case-insensitive substrings in a provider failure MESSAGE that mark a
+# transient upstream/gateway anomaly regardless of the HTTP status code. The
+# DoubleWord router surfaces its upstream GPU-provider rejection as an
+# ``upstream_error`` in a 400 body — a 4xx status that is nonetheless
+# retryable, so status alone under-classifies it. Matched only against the
+# public error text, never against secrets.
+_TRANSIENT_NETWORK_MESSAGE_MARKERS: tuple = (
+    "upstream_error",
+    "upstream provider rejected",
+    "bad gateway",
+    "gateway timeout",
+    "service unavailable",
+    "temporarily unavailable",
+    "connection reset",
+    "connection aborted",
+)
+
+
+def _is_transient_network_message(message: Optional[str]) -> bool:
+    """True when *message* carries a transient upstream/gateway marker.
+
+    Pure string check over public error text; never raises, never inspects
+    secrets. Used to route the DoubleWord ``upstream_error`` (a retryable 400)
+    to ``TRANSIENT_NETWORK`` before the HTTP-status table under-classifies it.
+    """
+    if not message:
+        return False
+    lowered = message.lower()
+    return any(marker in lowered for marker in _TRANSIENT_NETWORK_MESSAGE_MARKERS)
 
 
 # ============================================================================
@@ -268,6 +315,7 @@ def classify(
     http_status: Optional[int] = None,
     failure_message: Optional[str] = None,
     economic_reclassify: bool = False,
+    retry_after_present: bool = False,
 ) -> RetryDecision:
     """Classify a provider failure into a closed RetryDecision.
 
@@ -358,14 +406,30 @@ def classify(
         if failure_class in _TERMINAL_QUOTA_CLASSES:
             return RetryDecision.TERMINAL_QUOTA
 
+    # Priority 1.5: transient upstream/gateway MESSAGE markers. The DoubleWord
+    # router's ``upstream_error`` arrives as a 400 body — a 4xx status the HTTP
+    # table below would under-classify — yet it is a retryable upstream blip.
+    # Catch it here (after the terminal registries, before the status table) so
+    # it routes to TRANSIENT_NETWORK and drives the backoff-retry loop instead
+    # of a terminal breaker trip.
+    if _is_transient_network_message(failure_message):
+        return RetryDecision.TRANSIENT_NETWORK
+
     # Priority 2: HTTP status table (dispositive when present).
     if http_status is not None:
         if http_status in _HTTP_STATUS_TERMINAL_CONFIG:
             return RetryDecision.TERMINAL_CONFIG
         if http_status in _HTTP_STATUS_TERMINAL_QUOTA:
+            # 429 with a ``Retry-After`` header is a SERVER-DIRECTED backoff —
+            # the server told us WHEN to retry, so it is transient, not a
+            # terminal quota wall. Only a 429 WITHOUT Retry-After is the
+            # effectively-terminal quota refusal (Dynamic 5xx Resiliency
+            # Matrix, 2026-07-22).
+            if retry_after_present:
+                return RetryDecision.TRANSIENT_NETWORK
             return RetryDecision.TERMINAL_QUOTA
-        if http_status in _HTTP_STATUS_RETRY_TRANSIENT:
-            return RetryDecision.RETRY_TRANSIENT
+        if http_status in _HTTP_STATUS_TRANSIENT_NETWORK:
+            return RetryDecision.TRANSIENT_NETWORK
 
     # Priority 3: FailureMode default table.
     if failure_mode and failure_mode in _FAILURE_MODE_DEFAULT:

--- a/tests/governance/test_cache_first_hydration.py
+++ b/tests/governance/test_cache_first_hydration.py
@@ -1,0 +1,104 @@
+"""Test-Cache-First boot hydration — the state-hashing blind-spot fix.
+
+Mandated bulletproof #1: a ``.pytest_cache`` containing a persistent failure
+must produce an enqueued (synthetic) repair signal at boot EVEN WHEN the
+working-tree / Merkle diff sees zero changed files (``walk_changed=0``). This
+is the exact foil from soak bt-2026-07-22-085824, where an already-committed
+red test was invisible to the hash diff and no repair was ever dispatched.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.governance.intake.sensors.test_failure_sensor import (
+    TestFailureSensor,
+)
+from backend.core.ouroboros.governance.intent.test_watcher import TestWatcher
+
+
+class _RecordingRouter:
+    """Minimal async router capturing ingested envelopes."""
+
+    def __init__(self) -> None:
+        self.ingested: list = []
+
+    async def ingest(self, envelope) -> str:
+        self.ingested.append(envelope)
+        return "enqueued"
+
+
+def _write_lastfailed(repo_root: Path, nodeids) -> None:
+    cache = repo_root / ".pytest_cache" / "v" / "cache"
+    cache.mkdir(parents=True, exist_ok=True)
+    # pytest's own format: {nodeid: true}
+    (cache / "lastfailed").write_text(
+        json.dumps({nid: True for nid in nodeids}), encoding="utf-8"
+    )
+
+
+async def test_cache_first_enqueues_synthetic_signal_with_zero_merkle_diff(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # Attribution off → deterministic (no import tracing of a synthetic node).
+    monkeypatch.setenv("JARVIS_TEST_SOURCE_ATTRIBUTION_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_TEST_FAILURE_CACHE_FIRST_ENABLED", "true")
+
+    nodeid = "tests/governance/saga/test_topological_sort_tiebreak.py::test_x"
+    _write_lastfailed(tmp_path, [nodeid])
+
+    watcher = TestWatcher(repo="cache-first-repo", repo_path=str(tmp_path))
+    router = _RecordingRouter()
+    sensor = TestFailureSensor(
+        repo="cache-first-repo", router=router, test_watcher=watcher
+    )
+
+    # The working tree is CLEAN — tmp_path is not a git repo, so
+    # diff_working_tree yields nothing (walk_changed == 0). The ONLY reason a
+    # signal can appear is the pytest-cache-first layer.
+    changed = await watcher.diff_working_tree()
+    assert changed == [], f"precondition: clean tree, got {changed}"
+
+    ingested = await sensor.hydrate_on_boot()
+
+    # A synthetic failure signal was enqueued despite the zero-diff tree.
+    assert ingested >= 1, "cache-first must ingest the persistent red"
+    assert len(router.ingested) == 1
+    env = router.ingested[0]
+    # The enqueued envelope targets the cached failing test file.
+    targets = " ".join(getattr(env, "target_files", ()) or ())
+    assert "test_topological_sort_tiebreak.py" in targets
+
+
+async def test_cache_first_disabled_is_inert(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("JARVIS_TEST_FAILURE_CACHE_FIRST_ENABLED", "false")
+    # Boot hydration off too, so the only possible source is the cache layer.
+    monkeypatch.setenv("JARVIS_TESTWATCHER_BOOT_HYDRATION_ENABLED", "false")
+    _write_lastfailed(tmp_path, ["tests/foo_test.py::test_y"])
+
+    watcher = TestWatcher(repo="r", repo_path=str(tmp_path))
+    router = _RecordingRouter()
+    sensor = TestFailureSensor(repo="r", router=router, test_watcher=watcher)
+
+    ingested = await sensor.hydrate_on_boot()
+    assert ingested == 0
+    assert router.ingested == []
+
+
+async def test_cache_first_empty_cache_no_signal(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    # No lastfailed file at all → nothing to seed, no crash.
+    monkeypatch.setenv("JARVIS_TEST_FAILURE_CACHE_FIRST_ENABLED", "true")
+    watcher = TestWatcher(repo="r", repo_path=str(tmp_path))
+    router = _RecordingRouter()
+    sensor = TestFailureSensor(repo="r", router=router, test_watcher=watcher)
+
+    ingested = await sensor.hydrate_from_pytest_cache()
+    assert ingested == 0
+    assert router.ingested == []

--- a/tests/governance/test_dw_transient_resiliency.py
+++ b/tests/governance/test_dw_transient_resiliency.py
@@ -1,0 +1,136 @@
+"""Dynamic 5xx Resiliency Matrix — DW transient-network absorb loop.
+
+Mandated bulletproof #2: a transient ``upstream_error`` from the DoubleWord
+API must be absorbed by the backoff-retry loop so the generation RECOVERS on a
+subsequent attempt, WITHOUT the failure being mis-labeled ``terminal_quota``
+and terminally tripping the session circuit breaker. This is the exact foil
+from soak bt-2026-07-22-082657, where one transient upstream blip killed the
+whole session.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from backend.core.ouroboros.governance.candidate_generator import (
+    CandidateGenerator,
+)
+from backend.core.ouroboros.governance.circuit_breaker import (
+    CircuitBreaker,
+    CircuitState,
+    VerdictAction,
+)
+from backend.core.ouroboros.governance.provider_retry_classifier import (
+    RetryDecision,
+    classify,
+)
+
+
+class _DWUpstreamError(Exception):
+    """Duck-typed DoubleWord upstream_error (transient) — mirrors the real
+    ``DoublewordInfraError`` surface the retry loop reads."""
+
+    def __init__(self) -> None:
+        super().__init__(
+            'Chat completions (stream) failed: 400 '
+            '{"error":{"message":"The upstream provider rejected the request.",'
+            '"code":"upstream_error"}}'
+        )
+        self.status_code = 400
+        self.response_body = '{"code":"upstream_error"}'
+        self.ratelimit_reset_ts = None
+
+
+def _success_result():
+    return SimpleNamespace(
+        candidates=[object()], generation_duration_s=1.1, cost_usd=0.0021
+    )
+
+
+async def test_transient_upstream_error_is_absorbed_and_recovers(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # Tiny backoff so the test doesn't actually wait.
+    monkeypatch.setenv("JARVIS_DW_TRANSIENT_BACKOFF_BASE_S", "0.01")
+    monkeypatch.setenv("JARVIS_DW_TRANSIENT_BACKOFF_CAP_S", "0.02")
+    monkeypatch.setenv("JARVIS_DW_TRANSIENT_MAX_RETRIES", "2")
+    monkeypatch.delenv("JARVIS_JPRIME_PRIMACY", raising=False)
+    monkeypatch.delenv("JARVIS_BACKGROUND_ALLOW_FALLBACK", raising=False)
+    monkeypatch.delenv("FORCE_CLAUDE_BACKGROUND", raising=False)
+
+    # tier0.generate: transient upstream_error ONCE, then success.
+    tier0 = Mock()
+    tier0._realtime_enabled = True
+    tier0.generate = AsyncMock(
+        side_effect=[_DWUpstreamError(), _success_result()]
+    )
+
+    # fallback is None → if the loop wrongly cascaded, recovery would be
+    # impossible; a clean return proves the blip was absorbed on the DW lane.
+    gen = CandidateGenerator(primary=Mock(), tier0=tier0, fallback=None)
+    # Isolate the DW seam: skip J-Prime primacy + hosted resilience lane.
+    gen._try_jprime_primacy = AsyncMock(return_value=None)
+    gen._try_hosted_resilience_lane = AsyncMock(return_value=None)
+
+    context = SimpleNamespace(
+        signal_urgency="low",
+        signal_source="test",
+        is_read_only=False,
+        op_id="op-transient-test-0001",
+    )
+    deadline = datetime.now(timezone.utc) + timedelta(seconds=120)
+
+    result = await gen._generate_background(context, deadline)
+
+    # Recovered: the second (successful) attempt's result is returned.
+    assert result is not None
+    assert len(result.candidates) == 1
+    # The loop RETRIED — exactly two provider calls (blip, then success).
+    assert tier0.generate.await_count == 2
+
+
+async def test_transient_network_never_trips_terminal_breaker() -> None:
+    """A stream of TRANSIENT_NETWORK decisions (the upstream_error class) must
+    NEVER drive the breaker to OPEN_TERMINAL — the containment guarantee that
+    keeps one transient blip from killing the session."""
+    # The upstream_error classifies TRANSIENT_NETWORK, not terminal_quota.
+    decision = classify(
+        failure_class="DoublewordInfraError",
+        http_status=400,
+        failure_message="400 upstream_error: upstream provider rejected",
+    )
+    assert decision is RetryDecision.TRANSIENT_NETWORK
+
+    breaker = CircuitBreaker(op_id="op-containment-0001")
+    terminal_seen = False
+    for _ in range(25):
+        verdict = breaker.evaluate(decision)
+        if verdict.action == VerdictAction.TERMINATE_UNRESOLVED:
+            terminal_seen = True
+            break
+        if breaker.state == CircuitState.OPEN_TERMINAL:
+            terminal_seen = True
+            break
+
+    assert not terminal_seen, (
+        "TRANSIENT_NETWORK must never terminally trip the session breaker"
+    )
+    assert breaker.state != CircuitState.OPEN_TERMINAL
+
+
+async def test_429_without_retry_after_still_terminal_quota() -> None:
+    """Guard the other side: a genuine quota wall (429, no Retry-After) is
+    still TERMINAL_QUOTA — the resiliency matrix only reclassifies the
+    transient network class, not real hard-stops."""
+    assert (
+        classify(None, http_status=429)
+        is RetryDecision.TERMINAL_QUOTA
+    )
+    assert (
+        classify(None, http_status=429, retry_after_present=True)
+        is RetryDecision.TRANSIENT_NETWORK
+    )

--- a/tests/governance/test_provider_retry_classifier.py
+++ b/tests/governance/test_provider_retry_classifier.py
@@ -53,18 +53,20 @@ from backend.core.ouroboros.governance import provider_retry_classifier
 
 
 class TestRetryDecisionClosedTaxonomy(unittest.TestCase):
-    """The 4-value closed taxonomy is structural — adding a 5th
+    """The 5-value closed taxonomy is structural — adding a 6th
     member requires a paired test update + Circuit Breaker
     (Slice 7c) trip-table extension. This pin catches accidental
-    expansion."""
+    expansion. ``TRANSIENT_NETWORK`` (Dynamic 5xx Resiliency Matrix,
+    2026-07-22) is the 5th member; its trip-table branch is wired
+    alongside ``RETRY_TRANSIENT`` in ``circuit_breaker._apply_trip_table``."""
 
-    def test_retry_decision_has_exactly_four_members(self) -> None:
+    def test_retry_decision_has_exactly_five_members(self) -> None:
         members = list(RetryDecision)
         self.assertEqual(
-            len(members), 4,
-            f"RetryDecision is a CLOSED taxonomy of 4 values; found "
+            len(members), 5,
+            f"RetryDecision is a CLOSED taxonomy of 5 values; found "
             f"{len(members)} members: {[m.name for m in members]}. "
-            f"If you need a 5th decision, extend the Circuit "
+            f"If you need a 6th decision, extend the Circuit "
             f"Breaker (Slice 7c) trip-table in the same PR.",
         )
 
@@ -75,6 +77,7 @@ class TestRetryDecisionClosedTaxonomy(unittest.TestCase):
             "TERMINAL_STRUCTURAL",
             "TERMINAL_QUOTA",
             "TERMINAL_CONFIG",
+            "TRANSIENT_NETWORK",
         }
         self.assertEqual(
             names, expected,
@@ -246,19 +249,22 @@ class TestHttpStatusTable(unittest.TestCase):
             RetryDecision.TERMINAL_QUOTA,
         )
 
-    def test_http_408_is_retry_transient(self) -> None:
-        # 408 Request Timeout — transient.
+    def test_http_408_is_transient_network(self) -> None:
+        # 408 Request Timeout — a transient network/gateway anomaly. Dynamic
+        # 5xx Resiliency Matrix (2026-07-22): routed to TRANSIENT_NETWORK so
+        # the orchestrator drives a backoff-retry that never terminally trips.
         self.assertEqual(
             classify(None, None, http_status=408),
-            RetryDecision.RETRY_TRANSIENT,
+            RetryDecision.TRANSIENT_NETWORK,
         )
 
-    def test_http_500_502_503_504_are_retry_transient(self) -> None:
+    def test_http_500_502_503_504_are_transient_network(self) -> None:
+        # All 5xx are transient network/gateway anomalies → TRANSIENT_NETWORK.
         for code in (500, 502, 503, 504):
             with self.subTest(http_status=code):
                 self.assertEqual(
                     classify(None, None, http_status=code),
-                    RetryDecision.RETRY_TRANSIENT,
+                    RetryDecision.TRANSIENT_NETWORK,
                 )
 
     def test_unmapped_http_status_falls_through(self) -> None:


### PR DESCRIPTION
## What

Two **root-cause** fixes for the failure modes that blocked the Saga self-repair soak — the DoubleWord provider-taxonomy mis-classification and the state-hashing boot blind spot. **Zero nonce commits / workarounds.**

## 1. Dynamic 5xx Resiliency Matrix

**Foil (soak `bt-2026-07-22-082657`):** a *transient* DW `upstream_error` (400 body, `code: upstream_error`) was mis-labeled `terminal_quota` — terminally tripping the session breaker and killing the whole run on **one blip**, while DW had $6.87 credits and its plain lane returned 200/0.9s (verified by direct probe).

- **`provider_retry_classifier`:** new closed-taxonomy member `TRANSIENT_NETWORK` (5th value; AST pin bumped 4→5 + paired test). `terminal_quota` reserved for **429-without-`Retry-After`**; `upstream_error` / 5xx / 408 / gateway-timeout / **429-with-`Retry-After`** → `TRANSIENT_NETWORK`. Adds a `retry_after_present` param + an upstream/gateway message matcher.
- **`circuit_breaker._apply_trip_table`:** `TRANSIENT_NETWORK` routes through the same **non-terminal** OPEN_TRANSIENT backoff branch as `RETRY_TRANSIENT` — a transient blip can never reach OPEN_TERMINAL.
- **`candidate_generator._generate_background`:** the DW primary generate is wrapped in a bounded **exponential-backoff-with-jitter** absorb loop (reuses `circuit_breaker.full_jitter_delay` — DRY; **async sleep only**, never drops the ASGI loop). A blip is retried on the DW lane *before* cascading and *before* any terminal trip. The fallback `classify()` call now also threads `http_status` + `retry_after_present` (previously omitted — the core wiring gap).

## 2. Test-Cache-First Boot Hydration

**Foil (soak `bt-2026-07-22-085824`):** an event-driven sensor keyed on file-hash change is blind to a red test whose source didn't change since the last snapshot (`walk_changed=0`) — the committed failing test was never re-dispatched.

- **`test_failure_sensor`:** new `hydrate_from_pytest_cache()` runs at the top of `hydrate_on_boot()`, **before** the git/Merkle diff. Reads pytest's own `.pytest_cache/v/cache/lastfailed` ledger and seeds a repair for each unresolved red — **hash-diff-independent**. Treats the cache as the first observation (streak seeded to 1) and emits through the **same** `process_failures → handle_signals → router.ingest` sink every path uses (DRY).

## Bulletproof

4 new tests; **80+ green** across the touched suites (`test_provider_retry_classifier`, `test_circuit_breaker`, `test_slice7e_circuit_breaker_wiring`, `test_candidate_generator_boot_hook`):

- **`test_cache_first_hydration`** — persistent `.pytest_cache` red → synthetic signal enqueued with a **zero-diff clean tree**.
- **`test_dw_transient_resiliency`** — transient `upstream_error` → absorb loop **recovers the generation in 2 provider calls**; `TRANSIENT_NETWORK` never terminally trips the breaker; 429-no-`Retry-After` stays `terminal_quota`.

All new behavior is env-gated and default-on. Two pre-existing unrelated failures in `test_dynamic_test_scoping` were confirmed failing identically on `origin/main` (not introduced here).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes DW calls resilient to transient upstream/network blips and hydrates failing tests from the pytest cache at boot. Prevents single 5xx/`upstream_error` events from killing a session and ensures persistent reds are dispatched even when no files changed.

- **New Features**
  - Dynamic 5xx Resiliency Matrix: adds `TRANSIENT_NETWORK` in `provider_retry_classifier` (maps DW `upstream_error`, 5xx/408, and 429 with `Retry-After`; 429 without `Retry-After` stays `TERMINAL_QUOTA`); `circuit_breaker` treats it like `RETRY_TRANSIENT` (non-terminal backoff); `candidate_generator` adds a bounded jittered backoff to retry DW primary generate before any fallback and threads `http_status`/`retry_after_present` into classification.
  - Test-Cache-First boot hydration: `test_failure_sensor.hydrate_from_pytest_cache()` reads `.pytest_cache/v/cache/lastfailed` before the git diff and seeds repairs for unresolved reds (streak seeded to 1, same `process_failures → handle_signals → router.ingest` path), fixing the state-hashing blind spot.

<sup>Written for commit 2fa7b24eaa58ef308f9008a153ee462a5f8a0c4d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70016?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

