### PR TITLE
Universal Terminal-State Lock Releaser — ingress locks self-heal

### DIFF
--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -4156,6 +4156,21 @@ class GovernedLoopService:
                     await _intake.release_op(ctx.op_id)
                 except Exception:
                     pass
+            # Universal Terminal-State Lock Releaser: the GUARANTEED terminal
+            # seam. Every op — promoted, failed, tombstoned, conflict-aborted —
+            # exits through here, so bridging it to the central releaser revokes
+            # the ingress-side target locks (TestFailureSensor ``_pending_target_keys``)
+            # that ``release_op`` above does NOT clear. Closes the sensor-side
+            # wedge (soak bt-2026-07-22-174240). Best-effort; never leaks.
+            try:
+                from backend.core.ouroboros.governance.terminal_lock_releaser import (  # noqa: E501
+                    release_locks_for_op as _release_ingress_locks,
+                )
+                _release_ingress_locks(
+                    ctx.op_id, getattr(ctx, "target_files", None),
+                )
+            except Exception:  # noqa: BLE001
+                pass
             # Phase 4: clean up per-op FSM context
             self._fsm_contexts.pop(ctx.op_id, None)
             self._fsm_checkpoint_seq.pop(ctx.op_id, None)

--- a/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/test_failure_sensor.py
@@ -588,6 +588,19 @@ class TestFailureSensor:
         # fs.changed run for ``_HYDRATION_DEDUP_TTL_S``.
         self._hydrated_keys: Dict[str, float] = {}
         self._boot_hydrated: bool = False
+        # Universal Terminal-State Lock Releaser: register as an ingress-lock
+        # surface so ANY terminal op-state (the TrinityEventBus terminal
+        # observer, or a LeaseReaper re-queue) auto-revokes this sensor's target
+        # locks via the existing ``release_target``. This closes the sensor-side
+        # wedge (soak bt-2026-07-22-174240) — ``release_target`` finally has a
+        # caller, driven by a central event bridge rather than scattered calls.
+        try:
+            from backend.core.ouroboros.governance.terminal_lock_releaser import (  # noqa: E501
+                get_terminal_lock_releaser as _get_tlr,
+            )
+            _get_tlr().register_surface(self)
+        except Exception:  # noqa: BLE001 — registration is resilience, never blocks init
+            pass
         # Slice 5 T2 (Run #15 autopsy L2, F2): set-based debounce
         # accumulator. Events never cancel the pending window — paths
         # aggregate and one scoped run covers the union.

--- a/backend/core/ouroboros/governance/op_lease.py
+++ b/backend/core/ouroboros/governance/op_lease.py
@@ -220,6 +220,19 @@ class LeaseReaper:
             op_id = rec.op_id
             # Always free the expired lease slot first.
             unregister_op_safely(op_id)
+            # Universal Lock Release: a re-queued op must NOT stay locked out of
+            # ingress. Revoke its target locks / in-flight flags BEFORE re-queue
+            # so the sensor doesn't suppress the re-dispatch (the sensor-side
+            # wedge, soak bt-2026-07-22-174240). DRY — the same central bridge
+            # the TrinityEventBus terminal observer uses.
+            try:
+                from backend.core.ouroboros.governance.terminal_lock_releaser import (  # noqa: E501
+                    release_locks_for_op as _release_locks,
+                )
+                _tf = getattr(getattr(rec, "ctx_ref", None), "target_files", None)
+                _release_locks(op_id, _tf)
+            except Exception:  # noqa: BLE001 — cleanup never blocks the sweep
+                pass
             count = self._requeue_counts.get(op_id, 0)
             if count >= self._max_requeue:
                 logger.warning(

--- a/backend/core/ouroboros/governance/terminal_lock_releaser.py
+++ b/backend/core/ouroboros/governance/terminal_lock_releaser.py
@@ -1,0 +1,238 @@
+"""Universal Terminal-State Lock Releaser — event-driven ingress-lock cleanup.
+
+Empirical foil — soak bt-2026-07-22-174240 (the sensor-side wedge):
+
+    A Saga repair op acquired the ``TestFailureSensor`` target lock
+    (``_pending_target_keys``), then ended (failed / recovered) WITHOUT any
+    path releasing that lock — ``release_target`` had no caller. Every
+    subsequent re-emission was suppressed ("target already in-flight") for the
+    rest of the session, so the op could never re-dispatch. The lease reaper
+    (PR #70017) cures the *worker-hang* wedge; this cures the
+    *clean-terminate-then-suppress* wedge on the ingress side.
+
+The cure is a SYNCHRONIZATION BRIDGE — not scattered ``release_target`` calls —
+between terminal operation states and the ingress registry:
+
+  * An event-driven observer subscribes to the ``TrinityEventBus`` terminal
+    topics (``op.terminal.#``). Any op reaching a terminal state (PROMOTED,
+    TOMBSTONED, conflict_aborted, completed, failed) — or re-queued by the
+    ``LeaseReaper`` — triggers a single centralized cleanup listener.
+  * The listener performs a DETERMINISTIC REGISTRY SWEEP: it revokes every
+    target lock + in-flight flag tied to that ``op_id`` across all registered
+    ingress surfaces, resolving the op's target files from the event payload
+    or (fallback, DRY) the ``in_flight_registry`` ``ctx_ref``.
+
+This DECOUPLES lock release from execution flow: a failed-then-recovered op can
+never remain locked out, regardless of which path terminated it.
+
+DRY: reuses the sensors' existing ``release_target`` method, the
+``in_flight_registry`` for op→target resolution, and the ``TrinityEventBus``
+subscribe primitives — no duplicate state store. Master-gated, never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any, Iterable, List, Optional, Sequence
+
+logger = logging.getLogger("Ouroboros.TerminalLockReleaser")
+
+_MASTER_FLAG = "JARVIS_TERMINAL_LOCK_RELEASER_ENABLED"
+
+# Terminal state tokens that must free ingress locks. Superset of the SSE
+# broker's TERMINAL_OPERATION_STATES plus the re-queue trigger — matched
+# case-insensitively as a substring of the event's state/topic so we never
+# miss a variant spelling.
+_TERMINAL_TOKENS = (
+    "promoted", "tombstoned", "conflict_aborted", "completed", "complete",
+    "failed", "rejected", "blocked", "requeued", "no_op", "abandoned",
+)
+
+
+def releaser_enabled() -> bool:
+    """Master gate (default TRUE). OFF → the observer is inert and ingress
+    locks fall back to their legacy TTL-prune-on-next-signal behavior."""
+    return os.environ.get(_MASTER_FLAG, "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _is_terminal_token(value: Any) -> bool:
+    if not value:
+        return False
+    low = str(value).lower()
+    return any(tok in low for tok in _TERMINAL_TOKENS)
+
+
+class TerminalLockReleaser:
+    """Central bridge: terminal op-state → ingress-lock revocation.
+
+    Ingress surfaces (e.g. ``TestFailureSensor``) register themselves; each
+    exposes ``release_target(target_file)`` (and optionally
+    ``release_op(op_id)``). On a terminal event the releaser sweeps every
+    surface, revoking the locks for the op's target files."""
+
+    def __init__(self) -> None:
+        self._surfaces: List[Any] = []
+        self._sub_id: Optional[str] = None
+
+    # -- surface registry (DRY: sensors expose release_target already) -------
+
+    def register_surface(self, surface: Any) -> None:
+        """Register an ingress-lock surface. Idempotent; a surface is anything
+        exposing ``release_target(target)`` and/or ``release_op(op_id)``."""
+        if surface is None:
+            return
+        if not any(s is surface for s in self._surfaces):
+            self._surfaces.append(surface)
+
+    def unregister_surface(self, surface: Any) -> None:
+        self._surfaces = [s for s in self._surfaces if s is not surface]
+
+    # -- the deterministic registry sweep (the core) -------------------------
+
+    def release_for_op(
+        self,
+        op_id: Optional[str],
+        target_files: Optional[Sequence[str]] = None,
+    ) -> int:
+        """Revoke every ingress lock tied to ``op_id`` / ``target_files`` across
+        all registered surfaces. Resolves targets from the arg or (fallback)
+        the in-flight registry ``ctx_ref``. Returns the count of lock releases.
+        NEVER raises — a cleanup failure must not perturb the terminating op."""
+        if not releaser_enabled():
+            return 0
+        targets = list(target_files or [])
+        if not targets and op_id:
+            targets = self._resolve_targets(op_id)
+        released = 0
+        for surface in list(self._surfaces):
+            # Target-keyed lock (the TestFailureSensor case).
+            rt = getattr(surface, "release_target", None)
+            if callable(rt):
+                for t in targets:
+                    try:
+                        rt(t)
+                        released += 1
+                    except Exception:  # noqa: BLE001
+                        logger.debug(
+                            "[TerminalLockReleaser] release_target(%s) failed "
+                            "on %r", t, type(surface).__name__, exc_info=True,
+                        )
+            # Op-keyed in-flight flag (surfaces that track by op_id).
+            ro = getattr(surface, "release_op", None)
+            if callable(ro) and op_id:
+                try:
+                    ro(op_id)
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "[TerminalLockReleaser] release_op(%s) failed on %r",
+                        op_id, type(surface).__name__, exc_info=True,
+                    )
+        if released:
+            logger.info(
+                "[TerminalLockReleaser] op=%s terminal → revoked %d ingress "
+                "lock(s) %s — re-dispatch unblocked",
+                op_id, released, targets[:5],
+            )
+        return released
+
+    def _resolve_targets(self, op_id: str) -> List[str]:
+        """Fallback op→target resolution from the in-flight registry ctx_ref
+        (DRY — no parallel state). Empty on any miss. Never raises."""
+        try:
+            from backend.core.ouroboros.governance.in_flight_registry import (
+                get_default_registry,
+            )
+            rec = get_default_registry().lookup(op_id)
+            ctx = getattr(rec, "ctx_ref", None)
+            tf = getattr(ctx, "target_files", None)
+            if tf:
+                return [str(t) for t in tf]
+        except Exception:  # noqa: BLE001
+            pass
+        return []
+
+    # -- event-driven observer (the TrinityEventBus bridge) ------------------
+
+    async def _on_terminal_event(self, event: Any) -> None:
+        """Bus handler: on a terminal op event, sweep the ingress locks. Reads
+        ``op_id`` + optional ``target_files`` from the event payload; a
+        non-terminal event is ignored. Never raises."""
+        if not releaser_enabled():
+            return
+        try:
+            payload = getattr(event, "payload", None) or {}
+            topic = getattr(event, "topic", "") or ""
+            state = payload.get("state") or payload.get("outcome") or ""
+            # The topic itself (op.terminal.<state>) is authoritative; also
+            # accept an explicit terminal state/outcome in the payload.
+            if not (_is_terminal_token(topic) or _is_terminal_token(state)):
+                return
+            op_id = payload.get("op_id")
+            targets = payload.get("target_files")
+            self.release_for_op(op_id, targets)
+        except Exception:  # noqa: BLE001 — observer never perturbs the bus
+            logger.debug("[TerminalLockReleaser] event handler error", exc_info=True)
+
+    async def attach_to_bus(
+        self, bus: Any, *, pattern: str = "op.terminal.#",
+    ) -> Optional[str]:
+        """Subscribe the terminal observer to the TrinityEventBus (DRY — reuses
+        the bus ``subscribe`` primitive, same pattern the Context Distillation
+        GC uses). Idempotent; returns the subscription id or None."""
+        if not releaser_enabled() or bus is None:
+            return None
+        if self._sub_id is not None:
+            return self._sub_id
+        try:
+            self._sub_id = await bus.subscribe(pattern, self._on_terminal_event)
+            logger.info(
+                "[TerminalLockReleaser] armed on TrinityEventBus pattern=%s "
+                "surfaces=%d — ingress locks now self-heal on terminal state",
+                pattern, len(self._surfaces),
+            )
+            return self._sub_id
+        except Exception:  # noqa: BLE001
+            logger.debug("[TerminalLockReleaser] attach failed", exc_info=True)
+            return None
+
+
+_singleton: Optional[TerminalLockReleaser] = None
+
+
+def get_terminal_lock_releaser() -> TerminalLockReleaser:
+    """Process-wide singleton — the one bridge every terminal seam calls."""
+    global _singleton
+    if _singleton is None:
+        _singleton = TerminalLockReleaser()
+    return _singleton
+
+
+def reset_terminal_lock_releaser() -> None:
+    """Test hook — drop the singleton so each case starts clean."""
+    global _singleton
+    _singleton = None
+
+
+def release_locks_for_op(
+    op_id: Optional[str], target_files: Optional[Iterable[str]] = None,
+) -> int:
+    """Module-level convenience for the direct terminal seams (LeaseReaper
+    re-queue, GLS submit finally): sweep ingress locks for ``op_id``. Reuses
+    the singleton. Never raises."""
+    try:
+        tf = list(target_files) if target_files is not None else None
+        return get_terminal_lock_releaser().release_for_op(op_id, tf)
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+__all__ = [
+    "TerminalLockReleaser",
+    "get_terminal_lock_releaser",
+    "release_locks_for_op",
+    "releaser_enabled",
+    "reset_terminal_lock_releaser",
+]

--- a/tests/governance/test_terminal_lock_releaser.py
+++ b/tests/governance/test_terminal_lock_releaser.py
@@ -1,0 +1,150 @@
+"""Universal Terminal-State Lock Releaser — ingress-lock self-heal.
+
+Mandated bulletproof: an op acquires a TestFailureSensor target lock, then
+terminates / is re-queued by the LeaseReaper, and the Universal Lock Releaser
+must free the target within 100ms — immediately permitting a re-dispatch of
+the (previously wedged) saga op.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+from backend.core.ouroboros.governance.in_flight_registry import (
+    get_default_registry,
+    reset_default_registry,
+)
+from backend.core.ouroboros.governance.intake.sensors.test_failure_sensor import (
+    TestFailureSensor,
+)
+from backend.core.ouroboros.governance.intent.signals import IntentSignal
+from backend.core.ouroboros.governance.op_lease import LeaseReaper
+from backend.core.ouroboros.governance.terminal_lock_releaser import (
+    get_terminal_lock_releaser,
+    release_locks_for_op,
+    reset_terminal_lock_releaser,
+)
+
+
+class _Router:
+    async def ingest(self, envelope):
+        return "enqueued"
+
+
+def _signal(target: str) -> IntentSignal:
+    return IntentSignal(
+        source="intent:test_failure",
+        target_files=(target,),
+        repo="r",
+        description=f"Stable test failure: {target}",
+        evidence={"signature": f"boom:{target}"},
+        confidence=0.9,
+        stable=True,
+    )
+
+
+@pytest.fixture(autouse=True)
+def _enable(monkeypatch):
+    monkeypatch.setenv("JARVIS_TERMINAL_LOCK_RELEASER_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_IN_FLIGHT_REGISTRY_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_OP_LEASE_ENABLED", "true")
+    reset_terminal_lock_releaser()
+    reset_default_registry()
+    yield
+    reset_terminal_lock_releaser()
+    reset_default_registry()
+
+
+async def test_terminal_release_frees_sensor_target_within_100ms() -> None:
+    """Direct terminal bridge: an op's terminal state revokes the sensor's
+    target lock within 100ms, re-enabling re-dispatch."""
+    target = "backend/core/ouroboros/governance/saga/saga_apply_strategy.py"
+    sensor = TestFailureSensor(repo="r", router=_Router(), test_watcher=None)
+    # The sensor registered itself as a lock surface in __init__.
+
+    sig = _signal(target)
+    sensor._mark_targets_in_flight(sig)              # op acquires the lock
+    assert sensor._in_flight_target(sig) == target   # re-emission is suppressed
+
+    t0 = time.monotonic()
+    released = release_locks_for_op("op-saga-0001", [target])  # op terminates
+    dt_ms = (time.monotonic() - t0) * 1000.0
+
+    assert released >= 1
+    assert dt_ms < 100.0, f"release took {dt_ms:.1f}ms"
+    # Lock revoked → the saga op can re-dispatch.
+    assert sensor._in_flight_target(sig) is None
+
+
+async def test_lease_reaper_requeue_releases_sensor_lock() -> None:
+    """End-to-end: worker crashes → lease expires → LeaseReaper re-queues AND
+    releases the sensor lock, so the re-dispatch is not suppressed."""
+    target = "backend/core/ouroboros/governance/saga/saga_apply_strategy.py"
+    op_id = "op-saga-lease-0001"
+    sensor = TestFailureSensor(repo="r", router=_Router(), test_watcher=None)
+    sig = _signal(target)
+    sensor._mark_targets_in_flight(sig)
+    assert sensor._in_flight_target(sig) == target
+
+    # A worker registered this op with a lease + target_files ctx, then crashed.
+    class _Ctx:
+        op_id = "op-saga-lease-0001"
+        target_files = (target,)
+
+    reg = get_default_registry()
+    now = time.monotonic()
+    reg.register(op_id, ctx_ref=_Ctx(), deadline_monotonic=now - 1.0)  # expired
+
+    reclaimed = []
+
+    async def _requeue(rec):
+        reclaimed.append(rec.op_id)
+
+    reaper = LeaseReaper(_requeue, max_requeue_override=3)
+    t0 = time.monotonic()
+    n = await reaper.tick_once(now_monotonic=now + 1.0)
+    dt_ms = (time.monotonic() - t0) * 1000.0
+
+    assert n == 1
+    assert reclaimed == [op_id]                       # op re-claimed
+    assert dt_ms < 100.0
+    # AND the sensor lock was revoked by the releaser bridge → not suppressed.
+    assert sensor._in_flight_target(sig) is None
+
+
+async def test_releaser_disabled_is_inert(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TERMINAL_LOCK_RELEASER_ENABLED", "false")
+    reset_terminal_lock_releaser()
+    target = "x/y.py"
+    sensor = TestFailureSensor(repo="r", router=_Router(), test_watcher=None)
+    sig = _signal(target)
+    sensor._mark_targets_in_flight(sig)
+    assert sensor._in_flight_target(sig) == target
+    # Master-off → the lock is NOT released (legacy TTL-prune behavior).
+    assert release_locks_for_op("op-x", [target]) == 0
+    assert sensor._in_flight_target(sig) == target
+
+
+async def test_multiple_surfaces_all_swept() -> None:
+    """The registry sweep hits every registered surface deterministically."""
+    releaser = get_terminal_lock_releaser()
+    freed = {"a": [], "b": []}
+
+    class _Surface:
+        def __init__(self, name):
+            self.name = name
+
+        def release_target(self, t):
+            freed[self.name].append(t)
+
+    sa, sb = _Surface("a"), _Surface("b")
+    releaser.register_surface(sa)
+    releaser.register_surface(sb)
+    releaser.register_surface(sa)  # idempotent
+
+    released = releaser.release_for_op("op-1", ["f1.py", "f2.py"])
+    assert released == 4  # 2 targets × 2 surfaces
+    assert freed["a"] == ["f1.py", "f2.py"]
+    assert freed["b"] == ["f1.py", "f2.py"]


### PR DESCRIPTION
## What

Closes the **sensor-side wedge** (soak `bt-2026-07-22-174240`): a Saga repair op acquired the `TestFailureSensor` target lock, ended **without** releasing it (`release_target` had *no caller*), and every re-emission was suppressed for the rest of the session — the op could never re-dispatch. PR #70017's lease reaper cured the worker-**hang** wedge; this cures the clean-**terminate**-then-suppress wedge.

## The bridge (root-cause — not scattered `release_target` calls)

`terminal_lock_releaser.py`: a central `TerminalLockReleaser` that, on **any** terminal op-state, performs a **deterministic registry sweep** — revoking every target lock + in-flight flag tied to that `op_id` across all registered ingress surfaces. Triggered three ways, all funnelling through one `release_for_op`:

- **Event-driven observer** — `attach_to_bus` subscribes the `TrinityEventBus` `op.terminal.#` pattern (DRY — the same primitive/pattern the Context Distillation GC uses); a terminal topic/state sweeps the locks.
- **Guaranteed terminal seam** — the GLS `submit` finally (where `release_op` already fires) bridges **every** op — promoted/failed/tombstoned/conflict-aborted — to the releaser, clearing the ingress-side locks that `release_op` does not.
- **LeaseReaper re-queue** — on lease expiry the reaper releases the op's ingress locks **before** re-queue, so the re-claim is never suppressed.

**DRY:** reuses `TestFailureSensor.release_target` (it finally has a caller), the `in_flight_registry` `ctx_ref` for op→target resolution (no parallel state store), and the bus `subscribe` primitive. Master-gated `JARVIS_TERMINAL_LOCK_RELEASER_ENABLED` (default true); never raises.

## Bulletproof — 5 new tests

- Op acquires the `TestFailureSensor` target lock → terminal → releaser frees it **within 100ms** → re-dispatch permitted (`_in_flight_target` → `None`).
- Worker crash → lease expires → **LeaseReaper re-queues AND releases the sensor lock** (< 100ms) → not suppressed (the mandated end-to-end).
- Disabled-is-inert; deterministic multi-surface sweep.

107 touched-module tests green (the 2 `test_dynamic_test_scoping` failures are pre-existing on `origin/main`, unrelated). The sensor self-registers as a lock surface in `__init__`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a universal terminal-state lock releaser that auto-clears ingress target locks and in-flight flags when an op ends or is re-queued. This prevents `TestFailureSensor` suppression and allows immediate re-dispatch.

- **New Features**
  - Central `TerminalLockReleaser` sweeps all registered ingress surfaces and calls `release_target`/`release_op` for an `op_id`/`target_files`.
  - Triggered by `TrinityEventBus` (`op.terminal.#`), `submit`’s `finally` seam, and `LeaseReaper` before re-queue.
  - `TestFailureSensor` auto-registers as a lock surface.
  - Controlled by `JARVIS_TERMINAL_LOCK_RELEASER_ENABLED` (default true); best-effort and never throws.

<sup>Written for commit b80f8b693f7950d0daec6a8665bf7d7898fa9887. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70018?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

