### PR TITLE
Idempotent Transient-Absorb Decorator + watchdog socket teardown

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -2977,6 +2977,17 @@ def _dw_transient_backoff_s(attempt: int, retry_after_ts, *, remaining_s: float)
     return max(0.1, min(delay, budget_clamp, 30.0))
 
 
+try:
+    from backend.core.ouroboros.governance.transient_absorb import (
+        with_transient_absorb as _with_transient_absorb,
+    )
+except Exception:  # noqa: BLE001 — decorator is resilience; degrade to identity
+    def _with_transient_absorb(**_kw):  # type: ignore[misc]
+        def _identity(fn):
+            return fn
+        return _identity
+
+
 class CandidateGenerator:
     """Orchestrates candidate generation with failover and concurrency control.
 
@@ -7464,6 +7475,12 @@ class CandidateGenerator:
             classification,
         )
 
+    @_with_transient_absorb(
+        remaining_s=lambda self, context, deadline, **_k: self._remaining_seconds(
+            deadline
+        ),
+        label="_call_primary",
+    )
     async def _call_primary(
         self,
         context: OperationContext,
@@ -7472,6 +7489,13 @@ class CandidateGenerator:
         model_id: str = "",
     ) -> GenerationResult:
         """Call primary provider with concurrency and budget-capped deadline.
+
+        Wrapped by ``@with_transient_absorb`` (2026-07-22): a transient DW round
+        failure on the standard/immediate path — a watchdog fast-abort,
+        ``upstream_error``, 5xx, or 429-with-Retry-After — is absorbed by an
+        exponential-backoff retry of the whole primary attempt (budget-aware),
+        so big-file ReAct rounds self-heal instead of failing the round. The
+        decorator is a no-op when disabled / on a non-transient error.
 
         The primary gets at most ``_PRIMARY_BUDGET_FRACTION`` of the
         remaining time, guaranteeing ``_FALLBACK_MIN_RESERVE_S`` for the

--- a/backend/core/ouroboros/governance/doubleword_provider.py
+++ b/backend/core/ouroboros/governance/doubleword_provider.py
@@ -5104,6 +5104,20 @@ class DoublewordProvider:
                                 except asyncio.TimeoutError:
                                     _rupt_elapsed = time.monotonic() - _ttft_request_start_monotonic
                                     _rupt_phase = "ttft" if not _sse_has_tokens else "inter_chunk"
+                                    # Adaptive Stream Watchdog fast-abort (2026-07-22):
+                                    # sever the stalled TCP socket surgically BEFORE
+                                    # unwinding, so the wedged FD is cut instantly instead
+                                    # of leaking until request-total timeout. The
+                                    # StreamRuptureError raised below is classified transient
+                                    # and absorbed by the @with_transient_absorb retry on the
+                                    # standard/immediate path (5xx Resiliency Matrix, DRY).
+                                    try:
+                                        from backend.core.ouroboros.governance.stream_watchdog import (  # noqa: E501,PLC0415
+                                            fast_abort_response as _dw_fast_abort,
+                                        )
+                                        _dw_fast_abort(resp)
+                                    except Exception:  # noqa: BLE001 — abort never masks the stall
+                                        pass
                                     logger.error(
                                         "[DoublewordProvider] STREAM RUPTURE "
                                         "(phase=%s): no chunk for %.0fs "

--- a/backend/core/ouroboros/governance/stream_watchdog.py
+++ b/backend/core/ouroboros/governance/stream_watchdog.py
@@ -35,7 +35,7 @@ import json
 import logging
 import os
 import time
-from typing import Awaitable, Callable, Optional, Union
+from typing import Any, Awaitable, Callable, Optional, Union
 
 from backend.core.ouroboros.governance.stream_rupture import (
     StreamRuptureError,
@@ -89,6 +89,27 @@ def watchdog_itl_s() -> float:
         return stream_inter_chunk_timeout_s()
     except Exception:  # noqa: BLE001
         return 30.0
+
+
+def fast_abort_response(response: Any) -> bool:
+    """Surgically tear down the single TCP socket behind an aiohttp response —
+    the watchdog fast-abort. Mirrors ``BoundedCancellationGuard._fire_abort``
+    (Slice 7b): ``transport.abort()`` severs ONE file descriptor, never a
+    pool-wide close. Wire this into a provider's rupture path so a stalled
+    socket is cut instantly instead of leaking until request-total timeout.
+    Gated by ``watchdog_enabled``; returns True if aborted; NEVER raises."""
+    if not watchdog_enabled() or response is None:
+        return False
+    try:
+        conn = getattr(response, "connection", None)
+        transport = getattr(conn, "transport", None) if conn is not None else None
+        if transport is not None and hasattr(transport, "abort"):
+            transport.abort()
+            logger.debug("[StreamWatchdog] fast-abort: severed stalled DW socket")
+            return True
+    except Exception:  # noqa: BLE001 — a failed abort must not mask the stall
+        logger.debug("[StreamWatchdog] fast_abort_response failed", exc_info=True)
+    return False
 
 
 def _fire_abort(abort_fn: Optional[Callable[[], None]]) -> None:

--- a/backend/core/ouroboros/governance/transient_absorb.py
+++ b/backend/core/ouroboros/governance/transient_absorb.py
@@ -1,0 +1,214 @@
+"""Idempotent Transient-Absorb Decorator — per-round self-healing for DW.
+
+Big-file ReAct repairs (the 932-line Saga fix) drive MANY sequential DoubleWord
+streaming rounds. Any one round can stall on a flapping transport; the Adaptive
+Stream Watchdog fast-aborts it — but a fast-abort tears down the socket
+MID-STREAM, leaving a partial, corrupted artifact (a broken JSON tool-call).
+If that partial is ingested, the whole multi-round loop is poisoned.
+
+This decorator injects resilience into a DW round with ZERO invasive
+indentation — no 95-line re-indent of the legacy provider hot paths (mandate 1):
+
+  * **Transient-absorb backoff** — a transient round failure (StreamRuptureError
+    fast-abort, ``upstream_error``, 5xx, 429-with-Retry-After) is classified via
+    the SAME 5xx Resiliency Matrix (``provider_retry_classifier``) and retried
+    with the SAME exponential-backoff-with-jitter primitive
+    (``_dw_transient_backoff_s``) proven in PR #70016/#70017 (DRY, mandate 3).
+  * **State-Safe Resumption (mandate 2)** — before the round the decorator
+    snapshots the mutable ReAct state (the message transcript); on a watchdog
+    abort it PURGES the partial artifact and RESTORES the pre-round checkpoint
+    before the retry, so the loop never ingests corrupted mid-stream state.
+
+Applied as ``@with_transient_absorb(...)`` directly above ``_call_primary`` /
+``_generate_realtime``. Master-gated, never blocks the loop (async sleep only),
+and — when disabled or on a non-transient error — byte-identical to the
+undecorated method.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import copy
+import functools
+import logging
+import os
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.TransientAbsorb")
+
+_ENABLED_ENV = "JARVIS_TRANSIENT_ABSORB_DECORATOR_ENABLED"
+
+
+def decorator_enabled() -> bool:
+    """Master gate (default TRUE). OFF → the wrapped method runs exactly once,
+    byte-identical to the undecorated legacy behavior."""
+    return os.environ.get(_ENABLED_ENV, "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def _is_transient(exc: BaseException) -> bool:
+    """True when *exc* is a transient DW round failure that a retry can absorb.
+
+    Requires a POSITIVE transient signal — a watchdog fast-abort / stream
+    rupture, a bare timeout, a 5xx/408/429 HTTP status, or an explicit
+    ``TRANSIENT_NETWORK`` classification (upstream_error / gateway timeout /
+    429-with-Retry-After) via the 5xx Resiliency Matrix. It deliberately does
+    NOT trust the classifier's permissive "unknown → RETRY_TRANSIENT" fallback,
+    so a genuine code bug (a bare ``ValueError``/``KeyError`` with no transport
+    signal) is NEVER retried and never masked as retryable. Never raises."""
+    try:
+        from backend.core.ouroboros.governance.stream_rupture import (
+            StreamRuptureError,
+        )
+        if isinstance(exc, StreamRuptureError):
+            return True
+    except Exception:  # noqa: BLE001
+        pass
+    if isinstance(exc, asyncio.TimeoutError):
+        return True
+    status = getattr(exc, "status_code", None)
+    if isinstance(status, int) and status in (408, 429, 500, 502, 503, 504):
+        return True
+    try:
+        from backend.core.ouroboros.governance.provider_retry_classifier import (
+            classify, RetryDecision,
+        )
+        retry_after = getattr(exc, "ratelimit_reset_ts", None)
+        decision = classify(
+            failure_class=type(exc).__name__,
+            http_status=status,
+            failure_message=str(exc),
+            retry_after_present=retry_after is not None,
+        )
+        # Only the EXPLICIT transient-network class counts (not the bare
+        # unknown→RETRY_TRANSIENT fallback).
+        return decision == RetryDecision.TRANSIENT_NETWORK
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def _backoff_s(attempt: int, exc: BaseException, remaining_s: float) -> float:
+    """Delay before the next round attempt — reuses the DW transient backoff
+    (Retry-After-aware full-jitter) from candidate_generator (DRY). Fail-soft."""
+    retry_after = getattr(exc, "ratelimit_reset_ts", None)
+    try:
+        from backend.core.ouroboros.governance.candidate_generator import (
+            _dw_transient_backoff_s,
+        )
+        return _dw_transient_backoff_s(
+            attempt, retry_after, remaining_s=remaining_s,
+        )
+    except Exception:  # noqa: BLE001 — degrade to a bounded fixed backoff
+        return min(8.0, 1.5 * (2 ** max(0, attempt)))
+
+
+def _max_retries() -> int:
+    try:
+        from backend.core.ouroboros.governance.candidate_generator import (
+            _dw_transient_max_retries,
+        )
+        return _dw_transient_max_retries()
+    except Exception:  # noqa: BLE001
+        try:
+            return max(0, int(os.environ.get("JARVIS_DW_TRANSIENT_MAX_RETRIES", "2")))
+        except (TypeError, ValueError):
+            return 2
+
+
+def with_transient_absorb(
+    *,
+    transcript: Optional[Callable[..., Any]] = None,
+    remaining_s: Optional[Callable[..., float]] = None,
+    max_retries: Optional[Callable[[], int]] = None,
+    label: Optional[str] = None,
+) -> Callable[[Callable[..., Awaitable[Any]]], Callable[..., Awaitable[Any]]]:
+    """Decorator factory for per-round transient-absorb + state-safe resumption.
+
+    Parameters
+    ----------
+    transcript:
+        Optional ``(*args, **kwargs) -> mutable list/dict`` accessor for the
+        ReAct message transcript (the state that a mid-stream abort would
+        corrupt). Snapshotted before the round; DEEP-restored in place on a
+        transient abort so any partial artifact is purged. ``None`` → no state
+        to protect (the provider-call level, where the round is naturally
+        atomic: it returns a full result or raises, never a partial).
+    remaining_s:
+        Optional ``(*args, **kwargs) -> float`` remaining-budget accessor;
+        retries stop when the budget is spent. Default: unbounded-by-budget.
+    max_retries / label:
+        Override the retry ceiling / log label.
+    """
+    def deco(fn: Callable[..., Awaitable[Any]]) -> Callable[..., Awaitable[Any]]:
+        _name = label or getattr(fn, "__name__", "dw_round")
+
+        @functools.wraps(fn)
+        async def wrapper(*args: Any, **kwargs: Any) -> Any:
+            if not decorator_enabled():
+                return await fn(*args, **kwargs)
+            budget = (max_retries or _max_retries)()
+            # State-Safe Resumption: snapshot the pre-round transcript once.
+            live_state = None
+            snapshot = None
+            if transcript is not None:
+                try:
+                    live_state = transcript(*args, **kwargs)
+                    snapshot = copy.deepcopy(live_state)
+                except Exception:  # noqa: BLE001 — never block on snapshot
+                    live_state = None
+                    snapshot = None
+            attempt = 0
+            while True:
+                try:
+                    return await fn(*args, **kwargs)
+                except asyncio.CancelledError:
+                    raise
+                except BaseException as exc:  # noqa: BLE001
+                    _rem = 1e9
+                    if remaining_s is not None:
+                        try:
+                            _rem = float(remaining_s(*args, **kwargs))
+                        except Exception:  # noqa: BLE001
+                            _rem = 1e9
+                    if (
+                        not _is_transient(exc)
+                        or attempt >= budget
+                        or _rem <= 0.0
+                    ):
+                        raise
+                    # PURGE the partial artifact + RESTORE the pre-round state,
+                    # in place, so the caller's transcript reference is intact.
+                    if live_state is not None and snapshot is not None:
+                        try:
+                            _restore_in_place(live_state, snapshot)
+                        except Exception:  # noqa: BLE001
+                            pass
+                    delay = _backoff_s(attempt, exc, _rem)
+                    logger.warning(
+                        "[TransientAbsorb] %s round abort (%s) — purged partial, "
+                        "restored pre-round state, backoff %.1fs, retry %d/%d",
+                        _name, type(exc).__name__, delay, attempt + 1, budget,
+                    )
+                    await asyncio.sleep(delay)
+                    attempt += 1
+        return wrapper
+    return deco
+
+
+def _restore_in_place(live: Any, snapshot: Any) -> None:
+    """Restore a mutable container's contents to *snapshot* WITHOUT rebinding
+    the caller's reference (so the ReAct loop keeps working against the same
+    object). Supports list and dict transcripts."""
+    if isinstance(live, list):
+        live[:] = copy.deepcopy(snapshot)
+    elif isinstance(live, dict):
+        live.clear()
+        live.update(copy.deepcopy(snapshot))
+    # Any other type: nothing safe to restore in place; leave as-is.
+
+
+__all__ = [
+    "decorator_enabled",
+    "with_transient_absorb",
+]

--- a/tests/governance/test_transient_absorb_decorator.py
+++ b/tests/governance/test_transient_absorb_decorator.py
@@ -1,0 +1,110 @@
+"""Idempotent Transient-Absorb Decorator — state-safe per-round self-healing.
+
+Mandated bulletproof: a DW round emits a partial (corrupted) JSON tool-call
+into the ReAct transcript and then throws a synthetic Watchdog Abort. The
+decorator must catch the abort, PURGE the partial artifact, RESTORE the
+pre-round transcript, and successfully retry the round.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.stream_rupture import StreamRuptureError
+from backend.core.ouroboros.governance.transient_absorb import (
+    with_transient_absorb,
+)
+
+
+def _abort() -> StreamRuptureError:
+    return StreamRuptureError(
+        provider="doubleword", elapsed_s=0.3, bytes_received=12,
+        rupture_timeout_s=0.2, phase="inter_chunk",
+    )
+
+
+async def test_partial_json_purged_state_restored_then_retry(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TRANSIENT_ABSORB_DECORATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_TRANSIENT_BACKOFF_BASE_S", "0.01")
+    monkeypatch.setenv("JARVIS_DW_TRANSIENT_BACKOFF_CAP_S", "0.02")
+    monkeypatch.setenv("JARVIS_DW_TRANSIENT_MAX_RETRIES", "2")
+
+    # The ReAct message transcript — the mutable state a mid-stream abort
+    # would corrupt. It starts with the prior clean turns.
+    transcript = [{"role": "user", "content": "fix _topological_sort"}]
+    pre_round = [dict(m) for m in transcript]
+    calls = {"n": 0}
+
+    @with_transient_absorb(transcript=lambda self: self["transcript"])
+    async def _dw_round(self):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            # Round 1: the LLM streams a PARTIAL, corrupted tool-call, then the
+            # watchdog fast-aborts mid-stream (socket torn down).
+            self["transcript"].append(
+                {"role": "assistant", "content": '{"tool":"edit_file","args":{"pa'}
+            )
+            raise _abort()
+        # Round 2 (post-restore): clean completion.
+        self["transcript"].append(
+            {"role": "assistant", "content": '{"tool":"edit_file","args":{"path":"x"}}'}
+        )
+        return "clean-result"
+
+    holder = {"transcript": transcript}
+    result = await _dw_round(holder)
+
+    # Retried exactly once (abort → restore → retry).
+    assert calls["n"] == 2
+    assert result == "clean-result"
+    # The partial corrupted artifact was PURGED — the transcript now holds the
+    # pre-round turns plus ONLY the clean round-2 assistant message.
+    assert transcript[: len(pre_round)] == pre_round
+    assert len(transcript) == len(pre_round) + 1
+    assert transcript[-1]["content"].endswith('"path":"x"}}')
+    assert not any("pa'" in m.get("content", "") for m in transcript)  # no partial
+
+
+async def test_non_transient_error_not_retried(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TRANSIENT_ABSORB_DECORATOR_ENABLED", "true")
+    calls = {"n": 0}
+
+    @with_transient_absorb()
+    async def _round():
+        calls["n"] += 1
+        raise ValueError("structural bug — retrying cannot help")
+
+    with pytest.raises(ValueError):
+        await _round()
+    assert calls["n"] == 1  # not retried
+
+
+async def test_disabled_runs_once_byte_identical(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TRANSIENT_ABSORB_DECORATOR_ENABLED", "false")
+    calls = {"n": 0}
+
+    @with_transient_absorb()
+    async def _round():
+        calls["n"] += 1
+        raise _abort()
+
+    with pytest.raises(StreamRuptureError):
+        await _round()
+    assert calls["n"] == 1  # master-off → single attempt, no absorb
+
+
+async def test_budget_exhaustion_stops_retry(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_TRANSIENT_ABSORB_DECORATOR_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DW_TRANSIENT_MAX_RETRIES", "5")
+    calls = {"n": 0}
+
+    @with_transient_absorb(remaining_s=lambda: 0.0)  # no budget left
+    async def _round():
+        calls["n"] += 1
+        raise _abort()
+
+    with pytest.raises(StreamRuptureError):
+        await _round()
+    assert calls["n"] == 1  # zero budget → no retry despite transient


### PR DESCRIPTION
## What

Per-round self-healing for **big-file ReAct repairs on DoubleWord** — so the 932-line Saga fix's many sequential streaming rounds survive a flapping transport. Injected via **decorators, zero invasive re-indent** of the legacy provider hot paths.

## Idempotent Transient-Absorb Decorator

`@with_transient_absorb` wraps a DW round with:
- **Transient-absorb backoff** — a transient round failure (watchdog fast-abort / `StreamRuptureError`, `upstream_error`, 5xx, 429-with-`Retry-After`) is classified through the **same 5xx Resiliency Matrix** and retried with the **same exp-backoff-with-jitter** primitive from #70016/#70017 (DRY). Requires a **positive** transient signal — a real code bug (bare `ValueError`) is never retried.
- **State-Safe Resumption** — snapshots the mutable ReAct transcript pre-round; on a mid-stream abort it **purges the partial (corrupted) artifact** and **restores the pre-round checkpoint in place** before the retry, so the multi-round loop never ingests a broken partial tool-call.

Applied `@_with_transient_absorb(...)` directly above `candidate_generator._call_primary` (the standard/immediate DW path) — **one line, no indentation shift**. Budget-aware; master-gated (default true); no-op when disabled / on a non-transient error.

## Watchdog fast-abort into the DW stream

`stream_watchdog.fast_abort_response(resp)` — surgical single-FD `transport.abort()` (mirrors `BoundedCancellationGuard`). Wired into `_generate_realtime`'s stream-rupture path: on a per-chunk stall the socket is **severed instantly** before unwinding, instead of leaking until request-total timeout. The raised `StreamRuptureError` is transient → absorbed by the `_call_primary` decorator retry.

## Bulletproof — 4 new tests, 91 green across touched suites

- A round emits a **partial JSON tool-call** then throws a synthetic watchdog abort → decorator **purges the partial, restores the pre-round transcript, retries**, returns the clean result.
- Non-transient error not retried; disabled-is-inert; zero-budget stops.

Standard-route regression (slice7e wiring, classifier, breaker) green. The one unrelated failure (`test_pin_tool_executor_terminate_grace_kill`, a source-pin on `tool_executor.py`) is pre-existing — this PR does not touch that file.

## Next arc (your predictive vision — noted, not in this PR)
AST-aware chunking (send only the buggy function, stitch back locally), token-bucket pacing (predict exhaustion before 429/503), half-open ping-probe (the breaker already has HALF_OPEN in `circuit_breaker.py` to build on). This PR is the reactive per-round foundation that makes those safe to layer on.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an idempotent transient-absorb decorator and watchdog fast-abort to make DoubleWord rounds self-heal on transient stalls, so big-file ReAct repairs don’t fail mid-stream. Applied to `candidate_generator._call_primary` with budget-aware retries and no changes to hot-path indentation.

- **New Features**
  - `with_transient_absorb` (`transient_absorb.py`): classifies transient failures via the existing 5xx resiliency matrix and retries with the shared jittered backoff; snapshots the ReAct transcript and restores it on abort to purge partial artifacts; budget-aware; gated by `JARVIS_TRANSIENT_ABSORB_DECORATOR_ENABLED` (default true).
  - Watchdog fast-abort: `stream_watchdog.fast_abort_response` uses `transport.abort()` to cut a stalled socket; wired into `_generate_realtime` to raise a `StreamRuptureError` that the decorator absorbs and retries.
  - Tests: cover partial JSON purge + retry success, non-transient not retried, disabled is inert, and zero-budget stops.

<sup>Written for commit 69dd7f40c6a6f8f27b277d6157ac67acd4092c95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70019?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

