### PR TITLE
Proactive AST-Chunked Generation — big-file map-reduce for DW

### DIFF
--- a/backend/core/ouroboros/governance/chunked_generation.py
+++ b/backend/core/ouroboros/governance/chunked_generation.py
@@ -1,0 +1,187 @@
+"""Proactive AST-Chunked Generation — big-file map-reduce for DoubleWord.
+
+DoubleWord exhausts / times out when asked to EMIT a large file: forcing it to
+regenerate a 932-line module in one streaming turn is what chokes the RT lane
+(soak bt-2026-07-22-*). The reactive stack (#70016-#70019) absorbs the blips;
+this is the PREDICTIVE half — don't hand DW the whole file at all.
+
+Instead, before generation, slice out ONLY the target symbol (the buggy
+function) via the EXISTING ``ast_slicer.ASTChunker`` — the same slicer the
+``read_file`` tool uses (DRY, zero parallel AST logic). DW then fixes a small,
+focused chunk; the fix is stitched back into the full file locally by
+line-range. The egress payload collapses from ~900 lines to ~50, so DW never
+chokes — and the multi-round ReAct loop over a big file becomes tractable.
+
+Pure + deterministic where possible; env-gated; never raises on the hot path.
+This module is the "break it down + stitch back" primitive. The generation-path
+wiring (routing a big-file candidate through it) composes on top.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+from typing import Optional
+
+logger = logging.getLogger("Ouroboros.ChunkedGeneration")
+
+_ENABLED_ENV = "JARVIS_DW_BIG_FILE_CHUNKING_ENABLED"
+_THRESHOLD_ENV = "JARVIS_DW_BIG_FILE_LINE_THRESHOLD"
+_DEFAULT_THRESHOLD = 300
+
+
+def chunking_enabled() -> bool:
+    """Master gate (default TRUE). OFF → a big-file candidate is generated
+    whole (legacy), risking DW egress-overweight / timeout."""
+    return os.environ.get(_ENABLED_ENV, "true").strip().lower() in (
+        "1", "true", "yes", "on",
+    )
+
+
+def big_file_line_threshold() -> int:
+    """A file with more than this many lines is a chunking candidate (default
+    300). Env ``JARVIS_DW_BIG_FILE_LINE_THRESHOLD``. Clamped >= 50."""
+    try:
+        return max(50, int(os.environ.get(_THRESHOLD_ENV, str(_DEFAULT_THRESHOLD))))
+    except (TypeError, ValueError):
+        return _DEFAULT_THRESHOLD
+
+
+def is_big_file(source: str, *, threshold: Optional[int] = None) -> bool:
+    """True when *source* is large enough that emitting it whole risks a DW
+    choke — the PROACTIVE gate. Never raises."""
+    if not source:
+        return False
+    lines = source.count("\n") + 1
+    return lines > (threshold if threshold is not None else big_file_line_threshold())
+
+
+def should_chunk(source: str, symbol: Optional[str]) -> bool:
+    """Route to chunked generation when enabled, the file is big, AND we have a
+    localized target symbol to slice. A big file with NO resolvable symbol
+    falls through to whole-file generation (chunking can't help without a
+    localized target)."""
+    return bool(
+        chunking_enabled() and symbol and is_big_file(source)
+    )
+
+
+class _CoarseTokenCounter:
+    """Minimal ``TokenCounterProtocol`` — a 4-chars-per-token estimate. The
+    chunker only needs it to populate ``token_count``; the stitch uses line
+    ranges, so precision is irrelevant here."""
+
+    def count(self, text: str) -> int:
+        return max(1, len(text) // 4)
+
+
+def extract_target_chunk(
+    source: str, file_path: str, symbol: str,
+):
+    """Slice the ``symbol`` (function/method/class) out of *source* via the
+    existing ``ASTChunker`` (DRY). Returns the ``CodeChunk`` (carrying
+    ``source_code`` + ``start_line``/``end_line``) or ``None`` if the symbol
+    isn't found / the file won't parse. Never raises.
+
+    Matches by bare name OR qualified-name tail, so ``_topological_sort`` finds
+    ``SagaApplyStrategy._topological_sort``."""
+    try:
+        from backend.core.ouroboros.governance.ast_slicer import ASTChunker
+    except Exception:  # noqa: BLE001
+        return None
+    try:
+        # ASTChunker needs a token_counter with a ``.count(str) -> int``
+        # method; a coarse 4-chars-per-token estimate is fine — we use the
+        # chunk's line range, not its token count, for the stitch.
+        chunker = ASTChunker(_CoarseTokenCounter())
+    except Exception:  # noqa: BLE001 — degrade if the constructor shape differs
+        return None
+    want = symbol.split(".")[-1].strip()
+    try:
+        chunks = chunker.extract_chunks_from_source(
+            source, Path(file_path), target_names={want}, include_all=False,
+        )
+    except Exception:  # noqa: BLE001
+        return None
+    # Prefer an exact name/qualified-tail match; else the first returned chunk.
+    for c in chunks or ():
+        name = getattr(c, "name", "")
+        qn = getattr(c, "qualified_name", "") or ""
+        if name == want or qn.split(".")[-1] == want:
+            return c
+    return (chunks or [None])[0]
+
+
+def stitch_replacement(
+    full_source: str, chunk, new_body: str,
+) -> Optional[str]:
+    """Replace the *chunk*'s line-range in *full_source* with *new_body*,
+    returning the full stitched file. Preserves every other line byte-for-byte.
+    Re-indents *new_body* to the chunk's original leading indent if the model
+    returned it dedented. Returns ``None`` on an out-of-range chunk. Never
+    raises.
+
+    ``chunk.start_line`` / ``chunk.end_line`` are 1-indexed inclusive (the
+    ASTChunker convention)."""
+    try:
+        start = int(getattr(chunk, "start_line", 0))
+        end = int(getattr(chunk, "end_line", 0))
+    except (TypeError, ValueError):
+        return None
+    lines = full_source.splitlines(keepends=True)
+    n = len(lines)
+    if start < 1 or end < start or end > n:
+        return None
+    # Original leading indent (from the chunk's first source line).
+    orig_first = lines[start - 1]
+    orig_indent = orig_first[: len(orig_first) - len(orig_first.lstrip(" \t"))]
+    body = _reindent(new_body.rstrip("\n"), orig_indent)
+    # Preserve the trailing newline shape of the replaced region.
+    if lines[end - 1].endswith("\n") and not body.endswith("\n"):
+        body += "\n"
+    stitched = lines[: start - 1] + [body] + lines[end:]
+    return "".join(stitched)
+
+
+def _reindent(body: str, target_indent: str) -> str:
+    """If *body*'s first line has LESS indent than *target_indent* (the model
+    returned a dedented function), shift the whole block right so it lands at
+    the chunk's original nesting. If it already matches or is deeper, leave it
+    (the model preserved indentation). Deterministic; never raises."""
+    body_lines = body.split("\n")
+    if not body_lines:
+        return body
+    first = body_lines[0]
+    first_indent = first[: len(first) - len(first.lstrip(" \t"))]
+    if len(first_indent) >= len(target_indent):
+        return body  # already at (or deeper than) the target nesting
+    pad = target_indent[len(first_indent):]
+    return "\n".join((pad + ln) if ln.strip() else ln for ln in body_lines)
+
+
+def build_focused_prompt(chunk, instruction: str) -> str:
+    """Compose a minimal, chunk-scoped generation prompt — only the target
+    function + the fix instruction, NOT the whole file. Keeps the DW egress
+    tiny. The caller stitches the returned function back via
+    :func:`stitch_replacement`."""
+    name = getattr(chunk, "name", "the target function")
+    src = getattr(chunk, "source_code", "") or ""
+    return (
+        f"Rewrite ONLY the following Python function `{name}` to satisfy the "
+        f"instruction. Return the COMPLETE function definition (same name and "
+        f"signature), correctly indented, and NOTHING else — no prose, no "
+        f"surrounding code.\n\nInstruction: {instruction}\n\n"
+        f"```python\n{src}\n```"
+    )
+
+
+__all__ = [
+    "big_file_line_threshold",
+    "build_focused_prompt",
+    "chunking_enabled",
+    "extract_target_chunk",
+    "is_big_file",
+    "should_chunk",
+    "stitch_replacement",
+]

--- a/tests/governance/test_chunked_generation.py
+++ b/tests/governance/test_chunked_generation.py
@@ -1,0 +1,153 @@
+"""Proactive AST-Chunked Generation — big-file map-reduce.
+
+Proves the "break it down + stitch back" primitive on the exact Saga scenario:
+slice ONE function out of a big file (so DW gets a tiny payload), fix only that
+chunk, stitch it back — with every other line preserved byte-for-byte and the
+file still parsing.
+"""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from backend.core.ouroboros.governance.chunked_generation import (
+    build_focused_prompt,
+    extract_target_chunk,
+    is_big_file,
+    should_chunk,
+    stitch_replacement,
+)
+
+# A realistic "big file": a class with the buggy _topological_sort plus a lot
+# of unrelated padding so the whole thing is well over the chunk threshold.
+_PADDING = "\n".join(
+    f"    def _filler_{i}(self):\n"
+    f"        '''unrelated method {i}'''\n"
+    f"        return {i}\n"
+    for i in range(200)
+)
+
+_BIG_FILE = f'''"""Saga apply strategy — a big module."""
+import collections
+
+
+class SagaApplyStrategy:
+    """Big class."""
+
+{_PADDING}
+
+    def _topological_sort(self, repo_scope, edges):
+        """Kahn's algorithm. Stable: alphabetical within same depth."""
+        graph = collections.defaultdict(list)
+        in_degree = {{r: 0 for r in repo_scope}}
+        for dependent, dependency in edges:
+            graph[dependency].append(dependent)
+            in_degree[dependent] = in_degree.get(dependent, 0) + 1
+        queue = collections.deque(sorted(r for r in repo_scope if in_degree.get(r, 0) == 0))
+        result = []
+        while queue:
+            node = queue.popleft()
+            result.append(node)
+            for neighbor in sorted(graph[node]):
+                in_degree[neighbor] -= 1
+                if in_degree[neighbor] == 0:
+                    queue.append(neighbor)
+        return result
+
+    def _after(self):
+        """A method AFTER the target — must be preserved."""
+        return "sentinel-after"
+'''
+
+# The heapq fix DW would return for ONLY the function (dedented, as a model
+# often emits — the stitcher must re-indent it to method nesting).
+_HEAPQ_FIX = '''def _topological_sort(self, repo_scope, edges):
+    """Kahn's algorithm. Stable: alphabetical within same depth."""
+    import heapq
+    graph = collections.defaultdict(list)
+    in_degree = {r: 0 for r in repo_scope}
+    for dependent, dependency in edges:
+        graph[dependency].append(dependent)
+        in_degree[dependent] = in_degree.get(dependent, 0) + 1
+    heap = sorted(r for r in repo_scope if in_degree.get(r, 0) == 0)
+    heapq.heapify(heap)
+    result = []
+    while heap:
+        node = heapq.heappop(heap)
+        result.append(node)
+        for neighbor in graph[node]:
+            in_degree[neighbor] -= 1
+            if in_degree[neighbor] == 0:
+                heapq.heappush(heap, neighbor)
+    return result'''
+
+
+def test_big_file_gate_and_symbol_routing() -> None:
+    assert is_big_file(_BIG_FILE) is True          # well over threshold
+    assert is_big_file("def f(): pass") is False
+    assert should_chunk(_BIG_FILE, "_topological_sort") is True
+    assert should_chunk(_BIG_FILE, None) is False  # no symbol → whole-file
+
+
+def test_extract_only_the_target_function() -> None:
+    chunk = extract_target_chunk(_BIG_FILE, "saga_apply_strategy.py", "_topological_sort")
+    assert chunk is not None
+    assert chunk.name == "_topological_sort"
+    # The extracted payload is TINY vs the whole file (the whole point).
+    assert "deque" in chunk.source_code
+    assert "_filler_" not in chunk.source_code
+    assert chunk.end_line > chunk.start_line
+
+    # A focused prompt carries only the function, not the 600-line file.
+    prompt = build_focused_prompt(chunk, "use a heapq for lexicographic order")
+    assert "_topological_sort" in prompt
+    assert "_filler_" not in prompt
+
+
+def test_slice_fix_and_stitch_back_preserves_everything() -> None:
+    """The map-reduce end-to-end: extract → (DW returns heapq fix) → stitch."""
+    chunk = extract_target_chunk(_BIG_FILE, "saga_apply_strategy.py", "_topological_sort")
+    assert chunk is not None
+
+    stitched = stitch_replacement(_BIG_FILE, chunk, _HEAPQ_FIX)
+    assert stitched is not None
+
+    # 1. The whole file still parses.
+    tree = ast.parse(stitched)
+    assert tree is not None
+
+    # 2. ONLY the target function changed — heapq in, deque out (in that fn).
+    assert "heapq" in stitched
+    # The fix removed the deque usage from the target function.
+    assert "collections.deque" not in stitched
+
+    # 3. Everything else is preserved byte-for-byte.
+    assert "sentinel-after" in stitched          # the method after the target
+    assert stitched.count("_filler_") == _BIG_FILE.count("_filler_")  # all padding
+    assert stitched.startswith('"""Saga apply strategy')
+
+    # 4. The re-indent landed the function at method nesting (4 spaces).
+    assert "\n    def _topological_sort(self, repo_scope, edges):" in stitched
+
+    # 5. The fixed function is actually correct (execute the stitched module).
+    ns = {}
+    exec(compile(stitched, "stitched", "exec"), ns)  # noqa: S102 — test-only
+    inst = ns["SagaApplyStrategy"].__new__(ns["SagaApplyStrategy"])
+    order = ns["SagaApplyStrategy"]._topological_sort(
+        inst, ("A", "B", "W", "X"), (("W", "B"), ("X", "A")),
+    )
+    assert order == ["A", "B", "W", "X"]         # lexicographic-within-depth
+
+
+def test_stitch_out_of_range_is_none() -> None:
+    class _Bad:
+        start_line = 9999
+        end_line = 10000
+    assert stitch_replacement(_BIG_FILE, _Bad(), "x") is None
+
+
+def test_chunking_disabled_routes_whole_file(monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_DW_BIG_FILE_CHUNKING_ENABLED", "false")
+    assert should_chunk(_BIG_FILE, "_topological_sort") is False


### PR DESCRIPTION
## What

The **predictive** half of the big-file story. DoubleWord exhausts / times out when forced to *emit* a large file (the 932-line Saga module chokes the RT lane). The reactive stack (#70016–#70019) absorbs the blips; this stops handing DW the whole file at all.

Slice out **only the target symbol** (the buggy function) via the **existing `ast_slicer.ASTChunker`** — the same slicer `read_file` uses (DRY, zero parallel AST logic) — so DW fixes a ~50-line chunk instead of ~900 lines, then **stitch the fix back into the full file locally by line-range**.

## `chunked_generation.py`
- **`is_big_file` / `should_chunk`** — the proactive gate: route to chunking *before* generation when the file is big AND a localized target symbol exists (a big file with no symbol falls through to whole-file — chunking can't help without a target).
- **`extract_target_chunk`** — slices the symbol (bare-name or qualified-tail match, so `_topological_sort` finds `SagaApplyStrategy._topological_sort`) → a `CodeChunk` with source + line range.
- **`build_focused_prompt`** — a chunk-scoped prompt (the function only) keeping the DW egress tiny.
- **`stitch_replacement`** — replaces the chunk's line-range with the fix, re-indenting a model-dedented body to the original nesting, preserving every other line **byte-for-byte**.

Env-gated `JARVIS_DW_BIG_FILE_CHUNKING_ENABLED` (default true) / `JARVIS_DW_BIG_FILE_LINE_THRESHOLD` (300). Never raises on the hot path.

## Bulletproof — 5 tests, the map-reduce end-to-end on the exact Saga case
Extract `_topological_sort` from a **600-line file**, stitch the `heapq` fix, and the **stitched module executes** to the correct lexicographic order `['A','B','W','X']` — with all 200 filler methods + surrounding code preserved byte-for-byte. Plus gate / out-of-range / disabled cases.

## Follow-on wire (composes on this primitive)
Route a big-file candidate at GENERATE through **extract → focused-prompt → DW → stitch**, plus the predictive pacing (token-bucket + half-open ping-probe — the breaker already has `HALF_OPEN`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds proactive AST-chunked generation for big Python files: we extract only the target function with `ASTChunker`, send that to DW, then stitch the fix back by line range. This prevents timeouts on large modules and keeps model output small.

- **New Features**
  - `is_big_file` and `should_chunk` gate chunking when enabled and a target symbol exists.
  - `extract_target_chunk` uses `ASTChunker` to find the function by bare name or qualified tail and returns its line range and source.
  - `build_focused_prompt` creates a minimal, function-scoped prompt for DW.
  - `stitch_replacement` replaces the chunk’s line range and re-indents if needed, preserving all other lines byte-for-byte.

- **Migration**
  - Enabled by default via `JARVIS_DW_BIG_FILE_CHUNKING_ENABLED=true`; adjust size with `JARVIS_DW_BIG_FILE_LINE_THRESHOLD` (default 300).
  - If disabled, file is small, or the symbol isn’t found, it falls back to whole-file generation.

<sup>Written for commit 31bee2f6ccf67bcff6f4d0cf5e23033a10a44820. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70020?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

