### PR TITLE
Generation-Prompt Bridge — intelligent chunk-routing into GENERATE

### DIFF
--- a/backend/core/ouroboros/governance/chunked_generation_bridge.py
+++ b/backend/core/ouroboros/governance/chunked_generation_bridge.py
@@ -1,0 +1,286 @@
+"""Generation-Prompt Bridge — plugs intelligent chunk-routing into GENERATE.
+
+An INTERCEPTION LAYER between the GENERATE context-builder and the DW
+response-parser — it never touches the 8.7K-line provider's core execution
+flow. Two seams + one async telemetry hook:
+
+  * **Context-builder seam** (:func:`frame_for_generation`): route the target
+    file through ``select_extraction_strategy`` (#70021); on the AST / RAG
+    paths, REPLACE the whole-file context with the pruned Radius of Relevance /
+    top-k snippets AND prepend a strict **System Instruction Modifier** that
+    frames the LLM's constrained Map-Reduce view, so it never hallucinates the
+    pruned lines.
+
+  * **Response-parser seam** (:func:`stitch_with_l2_recovery`): stitch the
+    DW-returned AST node back into the full file; if the graft fails to parse,
+    DON'T fail terminally — run an ``L2_CONVERGED``-style bounded retry loop,
+    feeding the specific parse error back to the LLM for immediate
+    self-correction (reuses the L2 iterate-with-error-feedback architecture).
+
+  * **Async ML logging** (:class:`StrategyOutcomeLogger`): on the ``op.terminal``
+    TrinityEventBus event, update the SQLite reinforcement weights (#70021)
+    OFF the main ASGI thread (``run_in_executor``).
+
+Composes PR #70020/#70021 primitives entirely (DRY). Env-driven; never raises
+on the hot path.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import logging
+import os
+import sqlite3
+import threading
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, Dict, Optional, Tuple
+
+from backend.core.ouroboros.governance.chunked_generation import (
+    stitch_replacement,
+)
+from backend.core.ouroboros.governance.intelligent_chunking import (
+    ChunkPlan,
+    record_strategy_outcome,
+    select_extraction_strategy,
+)
+
+logger = logging.getLogger("Ouroboros.ChunkBridge")
+
+_L2_ITERS_ENV = "JARVIS_STITCH_L2_MAX_ITERS"
+_DEFAULT_L2_ITERS = 3
+
+
+# ---------------------------------------------------------------------------
+# Dynamic Context Framing — the System Instruction Modifier
+# ---------------------------------------------------------------------------
+
+MAP_REDUCE_FRAMING = (
+    "SYSTEM CONSTRAINT — MAP-REDUCE MODE:\n"
+    "You are operating in a constrained Map-Reduce environment. The code below "
+    "is a LOCALIZED RADIUS OF RELEVANCE extracted from a much larger file — you "
+    "are NOT viewing the whole file. Do NOT hallucinate, reconstruct, or "
+    "reference the missing surrounding lines. Return ONLY the modified AST node "
+    "(the complete function/method definition, same name and signature, "
+    "correctly indented) and NOTHING else — no prose, no imports, no "
+    "surrounding class body. The system stitches your node back into the full "
+    "file locally.\n"
+)
+
+_RAG_FRAMING = (
+    "SYSTEM CONSTRAINT — MAP-REDUCE MODE (RAG):\n"
+    "The snippets below were semantically retrieved from a large file (the "
+    "target symbol could not be AST-resolved). They are NOT the whole file. Do "
+    "NOT hallucinate the missing code. Identify the correct edit and return "
+    "ONLY the minimal modified definition.\n"
+)
+
+
+@dataclass
+class FramedContext:
+    """The context-builder interception result."""
+    plan: ChunkPlan
+    prompt: str
+    chunked: bool
+    instruction_injected: bool = False
+
+
+def frame_for_generation(
+    source: str,
+    file_path: str,
+    symbol: Optional[str],
+    instruction: str = "",
+    *,
+    conn: Optional[sqlite3.Connection] = None,
+) -> FramedContext:
+    """Context-builder seam: pick the strategy and build the DW prompt. For a
+    small file → whole-file, unframed (legacy). For a massive file → the pruned
+    Radius of Relevance (AST) or top-k snippets (RAG), PREPENDED with the strict
+    System Instruction Modifier so the LLM never tries to rebuild the pruned
+    lines. Never raises."""
+    try:
+        plan = select_extraction_strategy(
+            source, file_path, symbol, instruction, conn=conn,
+        )
+    except Exception:  # noqa: BLE001 — degrade to whole-file only for SMALL files
+        return FramedContext(
+            plan=ChunkPlan(strategy="whole", context=source or ""),
+            prompt=source or "", chunked=False,
+        )
+    if plan.strategy == "whole":
+        return FramedContext(plan=plan, prompt=source or "", chunked=False)
+    framing = MAP_REDUCE_FRAMING if plan.strategy == "ast" else _RAG_FRAMING
+    task = f"\nINSTRUCTION: {instruction}\n" if instruction else ""
+    prompt = f"{framing}{task}\n{plan.context}"
+    return FramedContext(
+        plan=plan, prompt=prompt, chunked=True, instruction_injected=True,
+    )
+
+
+# ---------------------------------------------------------------------------
+# L2 Stitch Recovery — bounded self-correcting graft (response-parser seam)
+# ---------------------------------------------------------------------------
+
+
+def _l2_max_iters() -> int:
+    try:
+        return max(1, int(os.environ.get(_L2_ITERS_ENV, str(_DEFAULT_L2_ITERS))))
+    except (TypeError, ValueError):
+        return _DEFAULT_L2_ITERS
+
+
+@dataclass
+class StitchResult:
+    ok: bool
+    stitched: Optional[str]
+    attempts: int
+    last_error: str = ""
+
+
+# generate_fn(prompt: str) -> Awaitable[str]  — returns the model's node source.
+GenerateFn = Callable[[str], Awaitable[str]]
+
+
+async def stitch_with_l2_recovery(
+    plan: ChunkPlan,
+    full_source: str,
+    generate_fn: GenerateFn,
+    *,
+    base_prompt: str = "",
+    max_iters: Optional[int] = None,
+) -> StitchResult:
+    """Response-parser seam: graft the model's node back into *full_source*; on
+    a parse/graft failure, run the ``L2_CONVERGED``-style retry — feed the exact
+    error back and re-generate — up to ``max_iters`` before giving up. Only the
+    AST strategy stitches by line-range (RAG has no single node to graft).
+    Never raises."""
+    if plan.chunk is None:
+        return StitchResult(ok=False, stitched=None, attempts=0,
+                            last_error="no_ast_chunk_to_stitch")
+    iters = max_iters if max_iters is not None else _l2_max_iters()
+    error_feedback = ""
+    last_error = ""
+    for attempt in range(1, iters + 2):
+        prompt = base_prompt + error_feedback
+        try:
+            node_src = await generate_fn(prompt)
+        except Exception as exc:  # noqa: BLE001 — a generate failure is not a stitch failure
+            return StitchResult(ok=False, stitched=None, attempts=attempt,
+                                last_error=f"generate_failed:{type(exc).__name__}")
+        stitched = stitch_replacement(full_source, plan.chunk, node_src or "")
+        if stitched is None:
+            last_error = "graft out-of-range / empty node"
+            error_feedback = (
+                "\n\nL2 CORRECTION: your previous output could not be grafted. "
+                "Return ONLY the complete function definition, correctly indented."
+            )
+            continue
+        # Validate the WHOLE stitched file parses (the graft is syntactically
+        # sound in context).
+        try:
+            ast.parse(stitched)
+            logger.info(
+                "[ChunkBridge] L2 stitch converged in %d attempt(s) "
+                "(strategy=%s)", attempt, plan.strategy,
+            )
+            return StitchResult(ok=True, stitched=stitched, attempts=attempt)
+        except SyntaxError as exc:
+            last_error = f"{exc.msg} (line {exc.lineno})"
+            error_feedback = (
+                f"\n\nL2 CORRECTION: your previous node produced a SyntaxError "
+                f"when grafted into the file: {last_error}. Fix ONLY the "
+                f"function and return it complete and correctly indented."
+            )
+            logger.warning(
+                "[ChunkBridge] L2 stitch attempt %d failed to parse: %s — "
+                "feeding error back for self-correction", attempt, last_error,
+            )
+    return StitchResult(ok=False, stitched=None, attempts=iters + 1,
+                        last_error=last_error)
+
+
+# ---------------------------------------------------------------------------
+# Async ML Logging — reinforcement update on op.terminal (off the ASGI thread)
+# ---------------------------------------------------------------------------
+
+# op_id -> (strategy, file_lines, ext), set at frame time; read at terminal.
+_pending_strategy: Dict[str, Tuple[str, int, str]] = {}
+_pending_lock = threading.Lock()
+
+
+def record_pending_strategy(
+    op_id: str, *, strategy: str, file_lines: int, ext: str,
+) -> None:
+    """Remember which extraction strategy an op used, so the terminal observer
+    can attribute the outcome. Called at frame time. Never raises."""
+    if not op_id:
+        return
+    with _pending_lock:
+        _pending_strategy[op_id] = (strategy, int(file_lines), ext or "")
+
+
+def _pop_pending(op_id: str) -> Optional[Tuple[str, int, str]]:
+    with _pending_lock:
+        return _pending_strategy.pop(op_id, None)
+
+
+class StrategyOutcomeLogger:
+    """Subscribes to ``op.terminal.#``; on each terminal event it updates the
+    SQLite reinforcement weights for the op's extraction strategy — OFF the main
+    ASGI thread. Reuses the terminal-observer pattern (#70018). Never raises."""
+
+    def __init__(self, conn: Optional[sqlite3.Connection]) -> None:
+        self._conn = conn
+        self._sub_id: Optional[str] = None
+
+    async def on_terminal(self, event) -> None:
+        """Bus handler — attribute + log the outcome off-loop."""
+        try:
+            payload = getattr(event, "payload", None) or {}
+            op_id = payload.get("op_id")
+            outcome = payload.get("state") or payload.get("outcome") or ""
+            if not op_id:
+                return
+            pending = _pop_pending(op_id)
+            if pending is None:
+                return  # op didn't go through chunked generation
+            strategy, file_lines, ext = pending
+            if self._conn is None:
+                return
+            loop = asyncio.get_running_loop()
+            # SQLite write is blocking → run it in the default executor so the
+            # ASGI event loop is never stalled by disk I/O.
+            await loop.run_in_executor(
+                None,
+                lambda: record_strategy_outcome(
+                    self._conn, strategy=strategy, file_lines=file_lines,
+                    ext=ext, outcome=str(outcome),
+                ),
+            )
+            logger.info(
+                "[ChunkBridge] reinforcement updated op=%s strategy=%s "
+                "outcome=%s (off-loop)", op_id, strategy, outcome,
+            )
+        except Exception:  # noqa: BLE001 — telemetry never perturbs the bus
+            logger.debug("[ChunkBridge] outcome logger error", exc_info=True)
+
+    async def attach_to_bus(self, bus, *, pattern: str = "op.terminal.#"):
+        if bus is None or self._sub_id is not None:
+            return self._sub_id
+        try:
+            self._sub_id = await bus.subscribe(pattern, self.on_terminal)
+            return self._sub_id
+        except Exception:  # noqa: BLE001
+            return None
+
+
+__all__ = [
+    "FramedContext",
+    "GenerateFn",
+    "MAP_REDUCE_FRAMING",
+    "StitchResult",
+    "StrategyOutcomeLogger",
+    "frame_for_generation",
+    "record_pending_strategy",
+    "stitch_with_l2_recovery",
+]

--- a/tests/governance/test_chunked_generation_bridge.py
+++ b/tests/governance/test_chunked_generation_bridge.py
@@ -1,0 +1,164 @@
+"""Generation-Prompt Bridge — the intelligent chunk-routing interception layer.
+
+Mandated bulletproof (mocking the GENERATE context builder):
+  1. A massive file triggers the strategy selector (chunked, not whole-file).
+  2. The prompt is injected with the Dynamic Context Framing instructions.
+  3. A simulated bad-stitch response triggers the L2 self-correction retry loop.
+  4. The terminal outcome updates the SQLite ML reinforcement weights off-loop.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+from types import SimpleNamespace
+
+import pytest
+
+from backend.core.ouroboros.governance.chunked_generation import (
+    extract_target_chunk,
+)
+from backend.core.ouroboros.governance.chunked_generation_bridge import (
+    MAP_REDUCE_FRAMING,
+    StrategyOutcomeLogger,
+    frame_for_generation,
+    record_pending_strategy,
+    stitch_with_l2_recovery,
+)
+from backend.core.ouroboros.governance.intelligent_chunking import (
+    ChunkPlan,
+    best_strategy,
+)
+
+
+def _massive(n: int = 600) -> str:
+    parts = ['"""M."""', "import collections", ""]
+    for i in range(n):
+        parts.append(f"class Sibling_{i}:")
+        parts.append(f"    def m_{i}(self):\n        return {i}")
+    parts.append("class SagaApplyStrategy:")
+    parts.append("    def _topological_sort(self, repo_scope, edges):")
+    parts.append("        return sorted(repo_scope)")
+    return "\n".join(parts)
+
+
+_MASSIVE = _massive()
+
+_SMALL_FILE = (
+    "import collections\n\n\n"
+    "class S:\n"
+    "    def _topological_sort(self, repo_scope, edges):\n"
+    "        return list(collections.OrderedDict.fromkeys(sorted(repo_scope)))\n"
+)
+
+
+# 1 + 2 ── strategy selection + Dynamic Context Framing injection ────────────
+
+
+def test_massive_file_triggers_strategy_and_injects_framing() -> None:
+    framed = frame_for_generation(
+        _MASSIVE, "saga_apply_strategy.py", "_topological_sort",
+        instruction="use heapq for lexicographic order",
+    )
+    # (1) Strategy selector fired — chunked, NOT whole-file.
+    assert framed.chunked is True
+    assert framed.plan.strategy in ("ast", "rag")
+    assert framed.plan.forbade_whole_file is True
+
+    # (2) The Dynamic Context Framing / System Instruction Modifier is injected.
+    assert framed.instruction_injected is True
+    low = framed.prompt.lower()
+    assert "constrained map-reduce" in low
+    assert "radius of relevance" in low
+    assert "do not hallucinate" in low
+    assert "only the modified ast node" in low
+    # The instruction rode along, and the pruned context is tiny vs the file.
+    assert "use heapq" in framed.prompt
+    assert len(framed.prompt) < len(_MASSIVE)
+    assert "class Sibling_0" not in framed.prompt  # siblings pruned
+
+
+def test_small_file_is_not_framed() -> None:
+    framed = frame_for_generation(_SMALL_FILE, "s.py", "_topological_sort")
+    assert framed.chunked is False
+    assert framed.instruction_injected is False
+    assert MAP_REDUCE_FRAMING not in framed.prompt
+
+
+# 3 ── L2 Stitch Recovery: bad stitch → retry with error fed back ────────────
+
+
+async def test_bad_stitch_triggers_l2_retry_then_converges() -> None:
+    chunk = extract_target_chunk(_SMALL_FILE, "s.py", "_topological_sort")
+    assert chunk is not None
+    plan = ChunkPlan(strategy="ast", context="", chunk=chunk)
+
+    # Round 1: a SYNTACTICALLY BROKEN node (missing close paren) → won't parse.
+    # Round 2 (after the L2 error is fed back): a clean node.
+    bad = "def _topological_sort(self, repo_scope, edges):\n    return sorted(repo_scope"
+    good = "def _topological_sort(self, repo_scope, edges):\n    import heapq\n    return sorted(repo_scope)"
+    calls = {"n": 0, "prompts": []}
+
+    async def generate_fn(prompt):
+        calls["n"] += 1
+        calls["prompts"].append(prompt)
+        return bad if calls["n"] == 1 else good
+
+    result = await stitch_with_l2_recovery(
+        plan, _SMALL_FILE, generate_fn, base_prompt="fix it", max_iters=3,
+    )
+    # The L2 loop retried and converged.
+    assert result.ok is True
+    assert result.attempts == 2
+    # The SPECIFIC parse error was fed back to the model on the retry.
+    assert "L2 CORRECTION" in calls["prompts"][1]
+    assert "SyntaxError" in calls["prompts"][1]
+    # The stitched file parses and carries the fix.
+    import ast as _ast
+    _ast.parse(result.stitched)
+    assert "heapq" in result.stitched
+
+
+async def test_l2_gives_up_after_max_iters() -> None:
+    chunk = extract_target_chunk(_SMALL_FILE, "s.py", "_topological_sort")
+    plan = ChunkPlan(strategy="ast", context="", chunk=chunk)
+
+    async def always_bad(prompt):
+        return "def _topological_sort(self, repo_scope, edges):\n    return ("  # never parses
+
+    result = await stitch_with_l2_recovery(
+        plan, _SMALL_FILE, always_bad, max_iters=2,
+    )
+    assert result.ok is False
+    assert result.attempts == 3  # initial + 2 retries
+    assert result.last_error != ""
+
+
+# 4 ── Async ML logging: terminal → SQLite weights update ────────────────────
+
+
+async def test_terminal_outcome_updates_sqlite_weights_offloop() -> None:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    outcome_logger = StrategyOutcomeLogger(conn)
+
+    # Frame time recorded which strategy the op used.
+    record_pending_strategy("op-massive-1", strategy="ast", file_lines=100000, ext=".py")
+
+    # The op resolves PROMOTED → the bus terminal observer fires.
+    event = SimpleNamespace(
+        topic="op.terminal.promoted",
+        payload={"op_id": "op-massive-1", "state": "promoted"},
+    )
+    await outcome_logger.on_terminal(event)
+
+    # The outcome landed in the SQLite reinforcement layer, off the main thread.
+    n = conn.execute("SELECT COUNT(*) FROM chunk_strategy_outcomes").fetchone()[0]
+    assert n == 1
+    assert best_strategy(conn, file_lines=100000, ext=".py") == "ast"
+
+    # A terminal for an op that never chunked is ignored (no phantom rows).
+    await outcome_logger.on_terminal(SimpleNamespace(
+        topic="op.terminal.failed",
+        payload={"op_id": "op-not-chunked", "state": "failed"},
+    ))
+    assert conn.execute("SELECT COUNT(*) FROM chunk_strategy_outcomes").fetchone()[0] == 1
+    conn.close()


### PR DESCRIPTION
## What

The **interception layer** that plugs the enterprise-scale chunk routing (#70021) into the `GENERATE` seam **without touching the 8.7K-line provider's core flow**. Two seams + one async telemetry hook.

- **Context-builder seam** (`frame_for_generation`): routes the target file through `select_extraction_strategy` (#70021). Small file → whole-file, unframed (legacy). Massive file → the pruned **Radius of Relevance** (AST) or top-k RAG snippets, prepended with a strict **System Instruction Modifier** — *Dynamic Context Framing*: "constrained Map-Reduce … localized Radius of Relevance … do NOT hallucinate the missing lines … return ONLY the modified AST node." Stops the LLM reconstructing the pruned 100k lines.
- **Response-parser seam** (`stitch_with_l2_recovery`): grafts the model's node back via #70020's `stitch_replacement`; on a parse/graft failure it does **not** fail terminally — an `L2_CONVERGED`-style bounded loop feeds the **specific SyntaxError** back to the model for self-correction, then retries the graft.
- **Async ML logging** (`StrategyOutcomeLogger`): subscribes `op.terminal.#` on the `TrinityEventBus` (reuses the #70018 terminal-observer); on terminal it updates the SQLite reinforcement weights via `run_in_executor` — **off the main ASGI thread**.

DRY: composes #70020 (stitch) + #70021 (select/prune/RAG/record) entirely. Env-driven; never raises on the hot path.

## Bulletproof — 5 tests, mocking the GENERATE context builder
1. A massive file triggers the selector (chunked, not whole-file).
2. The Dynamic Context Framing is injected.
3. A simulated bad-stitch triggers the L2 retry, **converging in 2** with the SyntaxError fed back.
4. The terminal outcome updates the SQLite ML weights **off-loop** (non-chunked op's terminal ignored).
Plus small-file-not-framed + L2-gives-up-after-max-iters.

## Follow-on activation
The live context-builder calls `frame_for_generation` and the response-parser calls `stitch_with_l2_recovery` at their seams — a thin, isolated composition (no deep provider edit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bridge that routes large files through intelligent chunking into GENERATE without changing the provider’s core flow. It frames prompts to avoid whole-file hallucination, retries stitch failures with targeted error feedback, and logs outcomes asynchronously.

- **New Features**
  - Context builder: `frame_for_generation` selects whole-file for small inputs or pruned AST/top‑k RAG for large ones, and prepends a strict “Dynamic Context Framing” system instruction.
  - Response parser: `stitch_with_l2_recovery` stitches with `stitch_replacement` and a bounded L2 retry loop using SyntaxError feedback (`JARVIS_STITCH_L2_MAX_ITERS`, default 3).
  - Telemetry: `StrategyOutcomeLogger` updates SQLite reinforcement weights on `op.terminal.#` via `run_in_executor`, paired with `record_pending_strategy`.
  - Tests: 5 tests cover routing, framing injection, L2 convergence and give‑up, and async logging.

<sup>Written for commit 54ca12121e0831e2d184704afc4e54468b7c7c5e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

