### PR TITLE
Ephemeral Super-Agent Swarm — parallel scatter-gather chunk repair

### DIFF
--- a/backend/core/ouroboros/governance/chunk_swarm.py
+++ b/backend/core/ouroboros/governance/chunk_swarm.py
@@ -1,0 +1,162 @@
+"""Ephemeral Super-Agent Swarm — parallel scatter-gather chunk repair.
+
+A massive file needing MULTIPLE independent AST-node repairs must not be
+processed sequentially — synchronous per-chunk network I/O is the wall-clock
+killer. This weaponizes DoubleWord's cost-efficiency: fan out one ephemeral
+"Super Agent" per target — a lightweight ``asyncio`` task that handles ONLY its
+own DW round — so the network legs run CONCURRENTLY.
+
+Bounded for a 16GB M1: the agents are pure ``asyncio`` tasks gated by a
+semaphore (no threads, no multiprocessing, no RAM spike). The fan-in (gather)
+awaits every network response, then stitches them SEQUENTIALLY and ATOMICALLY —
+in DESCENDING start-line order, so an early graft can never shift the line
+numbers a later chunk still points at, and one writer means no file-lock race /
+AST corruption.
+
+Scatter (concurrent network) → Gather (await all) → Fan-in (serial atomic
+stitch). Composes PR #70020 (stitch) + #70022 (L2 recovery). Env-driven; never
+raises on the hot path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, List, Optional
+
+from backend.core.ouroboros.governance.chunked_generation import (
+    stitch_replacement,
+)
+
+logger = logging.getLogger("Ouroboros.ChunkSwarm")
+
+_CONCURRENCY_ENV = "JARVIS_CHUNK_SWARM_MAX_CONCURRENCY"
+_DEFAULT_CONCURRENCY = 4  # bounded for a 16GB M1 — concurrent DW network legs
+
+
+def swarm_concurrency() -> int:
+    """Max concurrent Super Agents (env ``JARVIS_CHUNK_SWARM_MAX_CONCURRENCY``,
+    default 4). Clamped [1, 16] so the M1 never spikes on a huge fan-out."""
+    try:
+        return max(1, min(16, int(os.environ.get(_CONCURRENCY_ENV, str(_DEFAULT_CONCURRENCY)))))
+    except (TypeError, ValueError):
+        return _DEFAULT_CONCURRENCY
+
+
+@dataclass
+class ChunkTarget:
+    """One independent repair site: a symbol + its AST chunk + the fix ask.
+
+    ``chunk`` is a #70020 CodeChunk (carries ``start_line`` / ``end_line`` /
+    ``source_code``)."""
+    symbol: str
+    chunk: object
+    instruction: str = ""
+    prompt: str = ""
+
+
+@dataclass
+class SwarmResult:
+    stitched: str
+    succeeded: List[str] = field(default_factory=list)
+    failed: List[str] = field(default_factory=list)
+    agents_spawned: int = 0
+    max_in_flight: int = 0
+
+
+# generate_fn(target: ChunkTarget) -> Awaitable[str]  — the DW round; returns
+# the model's replacement node source for that target.
+AgentGenerateFn = Callable[[ChunkTarget], Awaitable[str]]
+
+
+async def swarm_repair(
+    full_source: str,
+    file_path: str,
+    targets: List[ChunkTarget],
+    generate_fn: AgentGenerateFn,
+    *,
+    max_concurrency: Optional[int] = None,
+) -> SwarmResult:
+    """Repair MANY chunks of *full_source* in parallel, then stitch atomically.
+
+    SCATTER: spawn one ephemeral Super Agent (asyncio task) per target, capped
+    by a semaphore, each awaiting ONLY its own DW round — the network legs run
+    concurrently. GATHER: await all. FAN-IN: stitch the returned nodes back
+    SEQUENTIALLY, in DESCENDING start-line order (so earlier stitches don't
+    shift later chunks' line ranges) and validating each graft parses — one
+    writer, no race. Never raises."""
+    if not targets:
+        return SwarmResult(stitched=full_source)
+
+    limit = max_concurrency if max_concurrency is not None else swarm_concurrency()
+    sem = asyncio.Semaphore(limit)
+    in_flight = {"cur": 0, "max": 0}
+
+    async def _super_agent(target: ChunkTarget):
+        # Bounded multiplexing: never more than ``limit`` DW legs at once.
+        async with sem:
+            in_flight["cur"] += 1
+            in_flight["max"] = max(in_flight["max"], in_flight["cur"])
+            try:
+                node = await generate_fn(target)
+                return (target, node, None)
+            except Exception as exc:  # noqa: BLE001 — an agent failure is isolated
+                return (target, None, exc)
+            finally:
+                in_flight["cur"] -= 1
+
+    # asyncio.gather = structured concurrent fan-out (Python 3.9-safe; the
+    # TaskGroup equivalent without the 3.11 floor the codebase forbids). Each
+    # coroutine is a lightweight task — no threads, no processes.
+    gathered = await asyncio.gather(
+        *[_super_agent(t) for t in targets], return_exceptions=False,
+    )
+
+    # ── FAN-IN: sequential, atomic stitch in DESCENDING line order ──
+    ok_results = [
+        (t, node) for (t, node, err) in gathered if err is None and node
+    ]
+    ok_results.sort(
+        key=lambda tn: int(getattr(tn[0].chunk, "start_line", 0)), reverse=True,
+    )
+    stitched = full_source
+    succeeded: List[str] = []
+    failed: List[str] = [
+        t.symbol for (t, node, err) in gathered if err is not None or not node
+    ]
+    import ast as _ast
+    for target, node in ok_results:
+        candidate = stitch_replacement(stitched, target.chunk, node)
+        if candidate is None:
+            failed.append(target.symbol)
+            continue
+        try:
+            _ast.parse(candidate)
+        except SyntaxError:
+            # A graft that breaks the file is rejected — the atomic invariant
+            # (the file always parses) is never violated by a bad agent.
+            failed.append(target.symbol)
+            continue
+        stitched = candidate
+        succeeded.append(target.symbol)
+
+    logger.info(
+        "[ChunkSwarm] fan-out=%d max_in_flight=%d → stitched %d, failed %d "
+        "(atomic, descending-line, no race)",
+        len(targets), in_flight["max"], len(succeeded), len(failed),
+    )
+    return SwarmResult(
+        stitched=stitched, succeeded=succeeded, failed=failed,
+        agents_spawned=len(targets), max_in_flight=in_flight["max"],
+    )
+
+
+__all__ = [
+    "AgentGenerateFn",
+    "ChunkTarget",
+    "SwarmResult",
+    "swarm_concurrency",
+    "swarm_repair",
+]

--- a/tests/governance/test_chunk_swarm.py
+++ b/tests/governance/test_chunk_swarm.py
@@ -1,0 +1,150 @@
+"""Ephemeral Super-Agent Swarm — parallel scatter-gather chunk repair.
+
+Mandated bulletproof: a massive file requiring 3 distinct AST-node repairs must
+spawn 3 CONCURRENT Super Agents hitting the (mocked) DW provider in parallel,
+gather all 3 payloads, and stitch them SEQUENTIALLY without a file-lock
+conflict — the stitched file parsing with all 3 fixes applied.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.chunk_swarm import (
+    ChunkTarget,
+    swarm_repair,
+)
+from backend.core.ouroboros.governance.chunked_generation import (
+    extract_target_chunk,
+)
+
+# A file with 3 independent repair sites at DIFFERENT line ranges.
+_MASSIVE_MULTI = '''"""Massive module with three buggy functions."""
+
+
+def alpha(a, b):
+    return a - b
+
+
+def _pad_1():
+    return 1
+
+
+def beta(a, b):
+    return a * a
+
+
+def _pad_2():
+    return 2
+
+
+def gamma(xs):
+    return xs[0]
+'''
+
+
+async def test_three_concurrent_super_agents_gather_and_stitch() -> None:
+    targets = []
+    for sym in ("alpha", "beta", "gamma"):
+        chunk = extract_target_chunk(_MASSIVE_MULTI, "m.py", sym)
+        assert chunk is not None, sym
+        targets.append(ChunkTarget(symbol=sym, chunk=chunk, instruction=f"fix {sym}"))
+
+    # Each fix, keyed by symbol — the model's returned node.
+    fixes = {
+        "alpha": "def alpha(a, b):\n    return a + b",          # - -> +
+        "beta": "def beta(a, b):\n    return a * b",            # a*a -> a*b
+        "gamma": "def gamma(xs):\n    return sorted(xs)[0]",    # xs[0] -> min
+    }
+
+    # Concurrency barrier: every agent increments; all proceed only once all 3
+    # are simultaneously in-flight. If the swarm ran SEQUENTIALLY, the barrier
+    # would never reach 3 and each agent would time out — so a clean pass PROVES
+    # true parallelism.
+    all_in_flight = asyncio.Event()
+    count = {"n": 0}
+
+    async def generate_fn(target: ChunkTarget) -> str:
+        count["n"] += 1
+        if count["n"] == 3:
+            all_in_flight.set()
+        # Wait until all 3 Super Agents are concurrently hitting DW.
+        await asyncio.wait_for(all_in_flight.wait(), timeout=5.0)
+        await asyncio.sleep(0)  # yield — real network I/O interleave point
+        return fixes[target.symbol]
+
+    result = await swarm_repair(
+        _MASSIVE_MULTI, "m.py", targets, generate_fn, max_concurrency=4,
+    )
+
+    # (1) 3 Super Agents spawned and hit DW CONCURRENTLY (proven by the barrier).
+    assert result.agents_spawned == 3
+    assert result.max_in_flight == 3, "agents must run in parallel, not serially"
+
+    # (2) All 3 payloads gathered + stitched, no conflict.
+    assert set(result.succeeded) == {"alpha", "beta", "gamma"}
+    assert result.failed == []
+
+    # (3) The stitched file parses and carries ALL 3 fixes — the descending-line
+    # fan-in kept every chunk's line range valid.
+    tree = ast.parse(result.stitched)
+    assert tree is not None
+    ns = {}
+    exec(compile(result.stitched, "stitched", "exec"), ns)  # noqa: S102 — test
+    assert ns["alpha"](5, 3) == 8       # + not -
+    assert ns["beta"](5, 3) == 15       # a*b not a*a
+    assert ns["gamma"]([3, 1, 2]) == 1  # min via sorted
+    # The unrelated padding is preserved.
+    assert ns["_pad_1"]() == 1 and ns["_pad_2"]() == 2
+
+
+async def test_bounded_concurrency_caps_in_flight() -> None:
+    """The M1 memory bound: with a concurrency cap of 1, agents never overlap."""
+    targets = [
+        ChunkTarget(symbol=s, chunk=extract_target_chunk(_MASSIVE_MULTI, "m.py", s))
+        for s in ("alpha", "beta", "gamma")
+    ]
+    peak = {"cur": 0, "max": 0}
+
+    async def generate_fn(target: ChunkTarget) -> str:
+        peak["cur"] += 1
+        peak["max"] = max(peak["max"], peak["cur"])
+        await asyncio.sleep(0.01)
+        peak["cur"] -= 1
+        return f"def {target.symbol}(*a, **k):\n    return None"
+
+    result = await swarm_repair(
+        _MASSIVE_MULTI, "m.py", targets, generate_fn, max_concurrency=1,
+    )
+    assert peak["max"] == 1              # semaphore held the M1 bound
+    assert result.max_in_flight == 1
+    assert len(result.succeeded) == 3   # still all repaired, just serialized
+
+
+async def test_one_bad_agent_isolated_others_still_stitch() -> None:
+    """A failing/corrupt agent is isolated — the atomic invariant holds (file
+    always parses) and the other repairs still land."""
+    targets = [
+        ChunkTarget(symbol=s, chunk=extract_target_chunk(_MASSIVE_MULTI, "m.py", s))
+        for s in ("alpha", "beta", "gamma")
+    ]
+
+    async def generate_fn(target: ChunkTarget) -> str:
+        if target.symbol == "beta":
+            return "def beta(a, b):\n    return a * b (((("  # corrupt → won't parse
+        return f"def {target.symbol}(a, b):\n    return a + b"
+
+    result = await swarm_repair(_MASSIVE_MULTI, "m.py", targets, generate_fn)
+    assert "beta" in result.failed          # the corrupt graft is rejected
+    assert "alpha" in result.succeeded
+    assert "gamma" in result.succeeded
+    ast.parse(result.stitched)              # file STILL parses (atomic invariant)
+
+
+async def test_empty_targets_is_noop() -> None:
+    result = await swarm_repair(_MASSIVE_MULTI, "m.py", [], lambda t: None)
+    assert result.stitched == _MASSIVE_MULTI
+    assert result.agents_spawned == 0


### PR DESCRIPTION
Fan out one ephemeral asyncio Super Agent per repair target (bounded semaphore for the 16GB M1 — no threads/processes), run the DW network legs concurrently (asyncio.gather), then fan-in with SEQUENTIAL ATOMIC stitching in descending start-line order so early grafts never shift later chunks' lines and one writer means no race. 4 tests: 3 concurrent agents proven via an all-in-flight barrier (max_in_flight==3; serial would deadlock), gathered + stitched + the module executes with all 3 fixes; concurrency cap=1 serializes; corrupt-agent isolation keeps the atomic invariant; empty-noop. Composes #70020 stitch. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Parallel scatter‑gather chunk repair with an ephemeral Super‑Agent swarm. Runs one `asyncio` task per target, then stitches sequentially and atomically so earlier grafts don’t shift later line ranges.

- **New Features**
  - One `asyncio` task per chunk; parallelized via `asyncio.gather` (no threads/processes).
  - Bounded concurrency with a semaphore; `JARVIS_CHUNK_SWARM_MAX_CONCURRENCY` (default 4, clamped 1–16).
  - Fan‑in stitches in descending `start_line` order; single writer; each graft must parse. Bad agents are isolated; file integrity is preserved.
  - Returns `SwarmResult` (stitched source, succeeded/failed symbols, agents spawned, `max_in_flight`); logs fan‑out metrics.
  - Composes with stitch logic from #70020. Includes tests for true parallelism, cap=1 serialization, bad‑agent isolation, and empty‑noop.

<sup>Written for commit 767c36edba2f375df712dee8ff9ac7ab69ec3a98. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70023?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

