### PR TITLE
Agentic Super-Agents — goal-bounded autonomous ReAct workers

### DIFF
--- a/backend/core/ouroboros/governance/agentic_super_agent.py
+++ b/backend/core/ouroboros/governance/agentic_super_agent.py
@@ -1,0 +1,201 @@
+"""Agentic Super-Agent — goal-bounded autonomous ReAct worker per AST node.
+
+RECON (project_sovereign_swarm.md, MERGED): ~70% of this chassis already
+exists. This module is the ONE genuine net-new composition — it makes each
+ephemeral swarm agent a SELF-CORRECTING multi-turn ReAct worker instead of a
+single DW round, composing the existing pieces rather than rebuilding them:
+
+  * ReAct loop body → ``ToolLoopCoordinator.run`` (tool_executor.py) — the
+    Plan→act→observe tool loop (read_file / edit_file / run_tests). Injected as
+    the per-agent ``agent_fn`` so the production worker is the real tool loop;
+    tests inject a mock.
+  * Write isolation → ``ScopedToolBackend`` (scoped_tool_backend.py) +
+    ``WorkUnitSpec.owned_paths`` — each agent's WRITES are locked to its
+    assigned AST-node file (max_mutations-bounded). The Fan-In relies on this +
+    the swarm's descending-line atomic stitch so 5 concurrent agents can NEVER
+    corrupt each other.
+  * Scatter/gather + atomic stitch → ``chunk_swarm.swarm_repair`` (#70023).
+  * Resilient network legs → the #70019 transient-absorb / watchdog decorators.
+
+This module adds the AGENTIC BOUNDING the recon flagged as missing at the
+per-target grain: a goal-bounded ``Plan → Modify → Verify (local AST) → Refine``
+mini-loop with a strict ``max_turns`` guardrail that emits a graceful
+``agent_unconverged`` signal instead of hanging or burning tokens.
+
+Pure asyncio (no threads/processes); env-driven; never raises on the hot path.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import os
+from dataclasses import dataclass, field
+from typing import Awaitable, Callable, List, Optional
+
+from backend.core.ouroboros.governance.chunk_swarm import (
+    ChunkTarget,
+    SwarmResult,
+    swarm_repair,
+)
+
+logger = logging.getLogger("Ouroboros.AgenticSuperAgent")
+
+_MAX_TURNS_ENV = "JARVIS_AGENT_MAX_TURNS"
+_DEFAULT_MAX_TURNS = 5
+
+STATUS_CONVERGED = "converged"
+STATUS_UNCONVERGED = "agent_unconverged"
+
+
+def agent_max_turns() -> int:
+    """Strict per-agent reasoning-cycle budget (env ``JARVIS_AGENT_MAX_TURNS``,
+    default 5). Clamped [1, 12] — a runaway agent can never exceed this."""
+    try:
+        return max(1, min(12, int(os.environ.get(_MAX_TURNS_ENV, str(_DEFAULT_MAX_TURNS)))))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_TURNS
+
+
+@dataclass
+class AgentOutcome:
+    """The result of one Agentic Super-Agent's bounded ReAct run."""
+    symbol: str
+    status: str                      # STATUS_CONVERGED | STATUS_UNCONVERGED
+    node: Optional[str] = None       # the verified replacement AST node
+    turns: int = 0
+    last_error: str = ""
+
+    @property
+    def converged(self) -> bool:
+        return self.status == STATUS_CONVERGED
+
+
+# agent_fn(target, feedback) -> Awaitable[str]: ONE ReAct turn's proposed node.
+# In production this is a ScopedToolBackend-caged ToolLoopCoordinator.run that
+# itself may take multiple tool rounds; here it is the injection seam.
+AgentTurnFn = Callable[[ChunkTarget, str], Awaitable[str]]
+
+
+def _verify_node_against_ast(node: str, target: ChunkTarget) -> tuple:
+    """VERIFY step — the agent's output must be a single, syntactically-valid
+    function/method definition with the target's name. Returns ``(ok, error)``.
+    This is the local-AST gate the agent refines against. Never raises."""
+    if not node or not node.strip():
+        return False, "empty output — return the complete function definition"
+    try:
+        tree = ast.parse(node)
+    except SyntaxError as exc:
+        return False, f"SyntaxError: {exc.msg} (line {exc.lineno})"
+    funcs = [
+        n for n in tree.body
+        if isinstance(n, (ast.FunctionDef, ast.AsyncFunctionDef))
+    ]
+    if not funcs:
+        return False, "no function definition found — return ONLY the function"
+    want = target.symbol.split(".")[-1]
+    if funcs[0].name != want:
+        return False, (
+            f"wrong function name '{funcs[0].name}' — must be '{want}' with the "
+            f"same signature"
+        )
+    return True, ""
+
+
+async def run_agentic_repair(
+    target: ChunkTarget,
+    agent_fn: AgentTurnFn,
+    *,
+    max_turns: Optional[int] = None,
+) -> AgentOutcome:
+    """One Agentic Super-Agent: a goal-bounded autonomous ReAct mini-loop —
+    Plan → Modify → Verify (local AST) → Refine — over its OWN AST node.
+
+    Each turn calls ``agent_fn`` (the real tool-loop worker in production) with
+    the accumulated verify feedback; the output is verified against the local
+    AST; on failure the specific error is fed back for self-correction; the loop
+    is hard-bounded by ``max_turns`` and emits ``agent_unconverged`` rather than
+    hanging or burning tokens. Never raises."""
+    turns = max_turns if max_turns is not None else agent_max_turns()
+    feedback = ""
+    last_error = ""
+    for turn in range(1, turns + 1):
+        try:
+            node = await agent_fn(target, feedback)
+        except Exception as exc:  # noqa: BLE001 — an agent fault is isolated, not fatal
+            last_error = f"agent_fault:{type(exc).__name__}"
+            feedback = (
+                f"REFINE (turn {turn}): the previous attempt errored "
+                f"({last_error}). Return ONLY the corrected function."
+            )
+            continue
+        ok, err = _verify_node_against_ast(node, target)
+        if ok:
+            logger.info(
+                "[AgenticSuperAgent] %s CONVERGED in %d turn(s)",
+                target.symbol, turn,
+            )
+            return AgentOutcome(
+                symbol=target.symbol, status=STATUS_CONVERGED, node=node,
+                turns=turn,
+            )
+        # Self-correction: feed the exact verify error back for the next turn.
+        last_error = err
+        feedback = (
+            f"REFINE (turn {turn}): your previous node failed local AST "
+            f"verification — {err}. Return ONLY the corrected complete function, "
+            f"correctly indented."
+        )
+        logger.warning(
+            "[AgenticSuperAgent] %s turn %d verify failed: %s — refining",
+            target.symbol, turn, err,
+        )
+    # Budget exhausted → graceful unconverged signal (no hang, no token waste).
+    logger.warning(
+        "[AgenticSuperAgent] %s UNCONVERGED after %d turns — emitting "
+        "agent_unconverged", target.symbol, turns,
+    )
+    return AgentOutcome(
+        symbol=target.symbol, status=STATUS_UNCONVERGED, node=None,
+        turns=turns, last_error=last_error,
+    )
+
+
+async def swarm_agentic_repair(
+    full_source: str,
+    file_path: str,
+    targets: List[ChunkTarget],
+    agent_fn: AgentTurnFn,
+    *,
+    max_concurrency: Optional[int] = None,
+    max_turns: Optional[int] = None,
+) -> SwarmResult:
+    """Fan out one AGENTIC Super-Agent per AST node — each a goal-bounded
+    self-correcting ReAct loop — concurrently, then stitch atomically.
+
+    Composes ``run_agentic_repair`` (the per-agent ReAct bounding) into
+    ``chunk_swarm.swarm_repair`` (#70023: semaphore-bounded scatter → gather →
+    descending-line atomic fan-in). An agent that returns ``agent_unconverged``
+    yields an empty node, so the swarm records it ``failed`` and leaves the file
+    untouched at that node — the atomic invariant holds. Never raises."""
+    async def _agentic_generate(target: ChunkTarget) -> str:
+        outcome = await run_agentic_repair(target, agent_fn, max_turns=max_turns)
+        # Empty string → swarm marks this node failed (unconverged); a converged
+        # node flows into the atomic descending-line stitch.
+        return outcome.node or "" if outcome.converged else ""
+
+    return await swarm_repair(
+        full_source, file_path, targets, _agentic_generate,
+        max_concurrency=max_concurrency,
+    )
+
+
+__all__ = [
+    "STATUS_CONVERGED",
+    "STATUS_UNCONVERGED",
+    "AgentOutcome",
+    "AgentTurnFn",
+    "agent_max_turns",
+    "run_agentic_repair",
+    "swarm_agentic_repair",
+]

--- a/tests/governance/test_agentic_super_agent.py
+++ b/tests/governance/test_agentic_super_agent.py
@@ -1,0 +1,158 @@
+"""Agentic Super-Agent — goal-bounded autonomous ReAct workers, swarmed.
+
+Mandated bulletproof: 3 Agentic Super-Agents spawned CONCURRENTLY to tackle 3
+separate AST nodes; ONE agent makes a syntax error, SELF-CORRECTS within its own
+ReAct loop, and returns a valid AST patch that successfully stitches into the
+main file — while the other two run in parallel.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.agentic_super_agent import (
+    STATUS_UNCONVERGED,
+    ChunkTarget,
+    run_agentic_repair,
+    swarm_agentic_repair,
+)
+from backend.core.ouroboros.governance.chunked_generation import (
+    extract_target_chunk,
+)
+
+_FILE = '''"""Module with three buggy functions."""
+
+
+def alpha(a, b):
+    return a - b
+
+
+def _pad():
+    return 0
+
+
+def beta(a, b):
+    return a * a
+
+
+def _pad2():
+    return 0
+
+
+def gamma(xs):
+    return xs[0]
+'''
+
+_FIX = {
+    "alpha": "def alpha(a, b):\n    return a + b",
+    "beta": "def beta(a, b):\n    return a * b",
+    "gamma": "def gamma(xs):\n    return sorted(xs)[0]",
+}
+
+
+def _targets():
+    ts = []
+    for sym in ("alpha", "beta", "gamma"):
+        chunk = extract_target_chunk(_FILE, "m.py", sym)
+        assert chunk is not None, sym
+        ts.append(ChunkTarget(symbol=sym, chunk=chunk, instruction=f"fix {sym}"))
+    return ts
+
+
+async def test_three_agentic_agents_one_self_corrects_and_all_stitch() -> None:
+    targets = _targets()
+    turns = {}
+    feedbacks = {}
+    started = {"n": 0}
+    all_started = asyncio.Event()
+
+    async def agent_fn(target: ChunkTarget, feedback: str) -> str:
+        sym = target.symbol
+        turns[sym] = turns.get(sym, 0) + 1
+        feedbacks.setdefault(sym, []).append(feedback)
+        # Prove concurrency: all 3 agents must reach their first turn before any
+        # proceeds. Sequential execution would deadlock this barrier.
+        if turns[sym] == 1:
+            started["n"] += 1
+            if started["n"] == 3:
+                all_started.set()
+            await asyncio.wait_for(all_started.wait(), timeout=5.0)
+        # BETA makes a SYNTAX ERROR on turn 1, self-corrects on turn 2.
+        if sym == "beta" and turns[sym] == 1:
+            return "def beta(a, b):\n    return a * b (((("   # broken node
+        return _FIX[sym]
+
+    result = await swarm_agentic_repair(_FILE, "m.py", targets, agent_fn, max_turns=5)
+
+    # (1) 3 Agentic Super-Agents ran CONCURRENTLY (barrier proves parallelism).
+    assert result.max_in_flight == 3
+    assert result.agents_spawned == 3
+
+    # (2) The erroring agent SELF-CORRECTED within its own ReAct loop (2 turns),
+    # and the exact verify error was fed back for the refine.
+    assert turns["beta"] == 2
+    assert turns["alpha"] == 1 and turns["gamma"] == 1
+    assert "SyntaxError" in feedbacks["beta"][1]
+    assert "REFINE" in feedbacks["beta"][1]
+
+    # (3) All 3 valid patches stitched into the main file — it parses + runs.
+    assert set(result.succeeded) == {"alpha", "beta", "gamma"}
+    assert result.failed == []
+    ast.parse(result.stitched)
+    ns = {}
+    exec(compile(result.stitched, "s", "exec"), ns)  # noqa: S102 — test only
+    assert ns["alpha"](5, 3) == 8
+    assert ns["beta"](5, 3) == 15
+    assert ns["gamma"]([3, 1, 2]) == 1
+
+
+async def test_agent_emits_unconverged_after_max_turns() -> None:
+    """A non-converging agent hits its max-turn guardrail and emits
+    agent_unconverged instead of hanging or burning tokens forever."""
+    target = _targets()[0]
+
+    async def always_broken(target, feedback):
+        return "def alpha(a, b):\n    return a + b ((("  # never parses
+
+    outcome = await run_agentic_repair(target, always_broken, max_turns=3)
+    assert outcome.status == STATUS_UNCONVERGED
+    assert outcome.converged is False
+    assert outcome.node is None
+    assert outcome.turns == 3
+    assert "SyntaxError" in outcome.last_error
+
+
+async def test_unconverged_agent_isolated_others_still_stitch() -> None:
+    """One unconverged agent leaves its node untouched (atomic invariant); the
+    converged agents still land."""
+    targets = _targets()
+
+    async def agent_fn(target, feedback):
+        if target.symbol == "beta":
+            return "def beta(a, b):\n    return ((("   # never converges
+        return _FIX[target.symbol]
+
+    result = await swarm_agentic_repair(_FILE, "m.py", targets, agent_fn, max_turns=2)
+    assert "beta" in result.failed
+    assert "alpha" in result.succeeded and "gamma" in result.succeeded
+    ast.parse(result.stitched)  # file STILL parses — atomic invariant
+
+
+async def test_agent_wrong_symbol_name_is_refined() -> None:
+    """VERIFY rejects a node whose function name drifted — the agent must
+    return the RIGHT symbol."""
+    target = _targets()[0]
+    calls = {"n": 0}
+
+    async def rename_then_fix(target, feedback):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            return "def WRONG_NAME(a, b):\n    return a + b"
+        return _FIX["alpha"]
+
+    outcome = await run_agentic_repair(target, rename_then_fix, max_turns=3)
+    assert outcome.converged is True
+    assert outcome.turns == 2  # refined after the wrong-name verify failure


### PR DESCRIPTION
Pivots the swarm's Super-Agents into fully agentic, self-correcting, goal-bounded ReAct workers. **Recon first** (project_sovereign_swarm.md, MERGED): ~70% already exists — composes ToolLoopCoordinator (ReAct body), ScopedToolBackend + owned_paths (AST-node write isolation), chunk_swarm (#70023 scatter-gather + atomic stitch), and the #70019 resilient decorators; does NOT rebuild. Net-new: per-target agentic bounding — run_agentic_repair runs a Plan→Modify→Verify(local AST)→Refine loop with a strict max_turns guardrail, self-corrects on verify failure by feeding the exact error back, and emits a graceful agent_unconverged on budget exhaustion. Pure asyncio (16GB-M1-safe). 4 tests: 3 agents CONCURRENT (barrier-proven, max_in_flight==3), one SELF-CORRECTS a syntax error within its ReAct loop (2 turns), all stitch + execute correctly; unconverged guardrail; unconverged isolation (atomic invariant holds); wrong-symbol refinement. 🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Turns Super-Agents into goal‑bounded, self‑correcting ReAct workers per AST node by adding a bounded Plan → Modify → Verify → Refine loop with a strict turn budget. This prevents hangs and token waste while preserving atomic stitch safety under concurrency.

- **New Features**
  - Added `run_agentic_repair`: a per-target, bounded ReAct loop that feeds exact verify errors back for self-correction and returns `STATUS_CONVERGED` or `STATUS_UNCONVERGED`.
  - Local verify gate: parses the proposed node, requires a single function with the correct name, and never raises (errors are returned for refine).
  - Added `swarm_agentic_repair`: fans out bounded agents concurrently and composes with `chunk_swarm.swarm_repair`; unconverged agents leave their node untouched so the atomic stitch invariant holds.
  - Configurable budget via `JARVIS_AGENT_MAX_TURNS` (default 5, clamped [1,12]); pure asyncio.
  - Composes existing pieces: `ToolLoopCoordinator.run` as the ReAct body and `ScopedToolBackend` for write isolation; includes tests for concurrency, self-correction, guardrail, isolation, and wrong-symbol refinement.

<sup>Written for commit a1a2b45e362023880b526ab771bf231bf61d1408. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70024?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

