### PR TITLE
Optimistic State Hashing — Ghost-Edit protection for the swarm stitch

### DIFF
--- a/backend/core/ouroboros/governance/full_content_interceptor.py
+++ b/backend/core/ouroboros/governance/full_content_interceptor.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import ast
 import asyncio
+import hashlib
 import logging
 import os
 from dataclasses import dataclass, field
@@ -71,6 +72,21 @@ def _enabled() -> bool:
     ).strip().lower() in ("1", "true", "yes", "on")
 
 
+def _disk_sha(file_path: str) -> Optional[str]:
+    """Fast SHA-256 of the on-disk file, or ``None`` if it is not a readable
+    real path (e.g. a synthetic/in-memory path in a test). Never raises.
+
+    Optimistic State Hashing (Ghost-Edit Protection): the interceptor snapshots
+    this at the exact moment of interception and re-checks it before returning
+    the stitched result — if an external process mutated the file while the
+    swarm ran, the stitch was built on a stale base and MUST be aborted."""
+    try:
+        with open(file_path, "rb") as fh:
+            return hashlib.sha256(fh.read()).hexdigest()
+    except (OSError, ValueError):
+        return None
+
+
 # whole_file_fn() -> Awaitable[str]  — the legacy whole-file generator.
 WholeFileFn = Callable[[], Awaitable[str]]
 # rag_agent_fn(target, rag_context) -> Awaitable[str] — the RAG-fallback repair.
@@ -85,6 +101,7 @@ class InterceptResult:
     converged_nodes: List[str] = field(default_factory=list)
     rag_recovered_nodes: List[str] = field(default_factory=list)
     dropped_nodes: List[str] = field(default_factory=list)
+    drifted: bool = False                          # Ghost-Edit: source drifted → stitch aborted
 
 
 async def intercept_full_content(
@@ -109,6 +126,11 @@ async def intercept_full_content(
         return InterceptResult(strategy="whole", content=content, stitched=False)
 
     # ── MASSIVE file: whole-file FORBIDDEN — build AST targets ──
+    # Optimistic State Hashing (Ghost-Edit Protection): snapshot the on-disk
+    # file state at the exact moment of interception. Re-checked before the
+    # stitch is returned (below) — abort + requeue on drift, never write over
+    # an external mutation.
+    entry_disk_sha = _disk_sha(file_path)
     targets: List[ChunkTarget] = []
     for sym in symbols or []:
         try:
@@ -177,6 +199,25 @@ async def intercept_full_content(
                 except SyntaxError:
                     recovered = False
         (rag_recovered if recovered else dropped).append(sym)
+
+    # ── Ghost-Edit re-check: the on-disk source must not have drifted under
+    # us during the swarm. A stitch built on a stale base would silently
+    # corrupt the file, so on drift we abort + signal a requeue (never write).
+    exit_disk_sha = _disk_sha(file_path)
+    if (
+        entry_disk_sha is not None
+        and exit_disk_sha is not None
+        and entry_disk_sha != exit_disk_sha
+    ):
+        logger.warning(
+            "[FullContentInterceptor] %s: GHOST EDIT detected (source drifted "
+            "%s→%s during swarm) — aborting stitch, requeue op",
+            file_path, entry_disk_sha[:8], exit_disk_sha[:8],
+        )
+        return InterceptResult(
+            strategy="aborted_drift", content=source, stitched=False,
+            drifted=True, dropped_nodes=list(symbols or []),
+        )
 
     logger.info(
         "[FullContentInterceptor] %s (%d lines): agentic swarm — converged=%d "

--- a/tests/governance/test_full_content_interceptor.py
+++ b/tests/governance/test_full_content_interceptor.py
@@ -121,6 +121,48 @@ async def test_small_file_no_regression() -> None:
     assert result.content == "def f(a, b):\n    return a + b\n"
 
 
+async def test_ghost_edit_detected_aborts_stitch(tmp_path) -> None:
+    """Optimistic State Hashing: an external process mutates the file WHILE the
+    swarm runs → the interceptor detects the drift at Fan-In and safely aborts
+    (never writes the stale stitch), signalling a requeue."""
+    p = tmp_path / "enterprise.py"
+    p.write_text(_BIG)
+
+    async def agent_fn(target: ChunkTarget, feedback: str) -> str:
+        # Simulate a concurrent external edit landing mid-swarm.
+        with open(p, "a", encoding="utf-8") as fh:
+            fh.write("\n# external process wrote here\n")
+        return _FIX[target.symbol]
+
+    result = await intercept_full_content(
+        _BIG, str(p), ["alpha", "beta", "gamma"], agent_fn,
+        op_id="op-ghost", max_turns=2,
+    )
+    # Drift caught → aborted, source returned untouched, requeue signalled.
+    assert result.drifted is True
+    assert result.strategy == "aborted_drift"
+    assert result.stitched is False
+    assert result.content == _BIG
+
+
+async def test_no_ghost_edit_stitches_normally(tmp_path) -> None:
+    """Control: a stable on-disk file stitches normally (drift guard is a
+    no-op when the source never changes)."""
+    p = tmp_path / "enterprise.py"
+    p.write_text(_BIG)
+
+    async def agent_fn(target: ChunkTarget, feedback: str) -> str:
+        return _FIX[target.symbol]
+
+    result = await intercept_full_content(
+        _BIG, str(p), ["alpha", "beta", "gamma"], agent_fn,
+        op_id="op-stable", max_turns=2,
+    )
+    assert result.drifted is False
+    assert result.strategy == "agentic_swarm"
+    assert set(result.converged_nodes) == {"alpha", "beta", "gamma"}
+
+
 async def test_strategy_outcome_logger_writes_sqlite_on_terminal() -> None:
     conn = sqlite3.connect(":memory:", check_same_thread=False)
     outcome_logger = StrategyOutcomeLogger(conn)


### PR DESCRIPTION
## Ghost-Edit Protection (Optimistic State Hashing)

The interceptor fans a swarm out over a big file then stitches results atomically. If an **external process mutates the file while the swarm runs**, the stitch is built on a stale base — writing it would silently corrupt the file.

This snapshots a fast `hashlib.sha256` of the on-disk file **at the exact moment of interception** and re-checks it at Fan-In before returning. On drift → **abort** (`strategy="aborted_drift"`, `drifted=True`, `content=source` untouched) so the caller requeues; the stale stitch is never written.

### Mandate conformance
- **DRY** — native `hashlib.sha256`; the M1-safe concurrency `asyncio.Semaphore` already lives in `chunk_swarm` (clamped `[1,16]`, consumed via `max_concurrency`) and 429 backpressure is the transient-absorb layer (#70016–#70019). Reused, not reinvented.
- **No regression** — `_disk_sha` returns `None` on synthetic/in-memory paths, so the guard is a no-op there and existing tests are byte-identical.

### Tests (6 passed)
- Mocked **Ghost Edit** (`agent_fn` mutates the file mid-swarm) → drift caught → stitch aborted → source returned intact.
- Control (stable file) → stitches normally, all nodes converged.

### Scope note
This hardens the **merged interceptor** for when it goes live. It is **not** the `candidate_generator` live-seam wire — see the PR discussion: that route is blocked on a missing op-intent→target-symbol resolver (the pipeline carries `target_files` paths but no function-level targets), which is the real next keystone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds optimistic state hashing to the full-content interceptor to detect external edits during the swarm and abort stale stitches to prevent file corruption. On drift, it returns the original source and signals a requeue.

- **New Features**
  - Snapshot and re-check on-disk SHA-256 at intercept and fan-in to catch ghost edits during stitching.
  - On drift, abort with `strategy="aborted_drift"`, set `drifted=True`, return original `content`; never write over external edits.
  - `_disk_sha` uses `hashlib.sha256` and returns `None` for synthetic/in-memory paths (no-op); tests cover drift detection and normal stitching.

<sup>Written for commit a98123c61b2c378d8a1a285a9735cc2d60f92366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70027?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

