### PR TITLE
TargetSymbolResolver — deterministic-first cascade to precise repair targets

### DIFF
--- a/backend/core/ouroboros/governance/target_symbol_resolver.py
+++ b/backend/core/ouroboros/governance/target_symbol_resolver.py
@@ -1,0 +1,436 @@
+"""TargetSymbolResolver — the keystone that turns an op into precise repair targets.
+
+The interceptor/swarm (#70020-#70027) needs the CONCRETE functions an op intends
+to repair. The pipeline carries ``target_files`` (paths) but no function-level
+targets, so routing big files to the swarm without this would degrade to
+RAG-only and regress the working bounded-diff path. This resolver closes that
+gap with a **deterministic-first cascade** — hallucination is the root cause of
+extraction drift, so probability is the LAST resort, never the first:
+
+  1. **Stack-trace mapping (100% deterministic).** Parse the failing test's
+     traceback frames → ``(file, line, func)`` and map each in-file line to its
+     enclosing AST node. Zero guessing. Confidence 1.0.
+  2. **Goal keyword match (deterministic heuristic, NO LLM).** No trace? Score
+     each symbol name by token overlap with the ``goal`` text (an explicit
+     whole-name mention scores 1.0). Still no model call — no hallucination.
+  3. **Fail-Closed.** Best confidence below the floor → return EMPTY. The caller
+     skips the interceptor entirely and the standard generation route is
+     byte-identical. Ambiguity NEVER routes to the swarm.
+
+Two structural guarantees on every resolved target:
+
+  * **Call-Graph Expansion (Symbol Clustering).** A resolved function that calls
+    LOCAL sibling/helper methods in the same file pulls them into the target
+    cluster — the swarm sees the primary target AND its local dependencies, so a
+    node is never repaired context-starved.
+  * **Decorator-Aware Anchoring.** A symbol's span starts at its HIGHEST-level
+    decorator (``@classmethod`` / ``@property`` / ``@retry`` ...) and runs
+    through its docstring + body, so the swarm can never orphan a wrapper. This
+    matches ``ASTChunker``'s convention (``include_decorators=True``), so the
+    downstream ``extract_target_chunk`` agrees byte-for-byte.
+
+DRY: native ``ast`` for the index; composes ``PlanGenerator._extract_symbols``
+for the top-level name universe and the attribution bridge's ``traceback_frames``
+/ ``source_loci``. Pure + deterministic (no I/O, sub-ms) — async is unnecessary
+and would be fake; the caller invokes it inline before dispatch.
+"""
+
+from __future__ import annotations
+
+import ast
+import logging
+import os
+import re
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+
+logger = logging.getLogger("Ouroboros.TargetSymbolResolver")
+
+# `File "path/to/x.py", line 42, in func` — the CPython traceback frame shape.
+_TB_FRAME_RE = re.compile(
+    r'File "(?P<file>[^"]+)", line (?P<line>\d+), in (?P<func>[^\s,]+)'
+)
+_IDENT_RE = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
+_CAMEL_RE = re.compile(r"[A-Z]?[a-z0-9]+|[A-Z]+(?![a-z])")
+
+_MIN_CONF_ENV = "JARVIS_SYMBOL_RESOLVER_MIN_CONFIDENCE"
+_DEFAULT_MIN_CONF = 0.5
+_CLUSTER_ENV = "JARVIS_SYMBOL_RESOLVER_CLUSTER_ENABLED"
+_MAX_CLUSTER_ENV = "JARVIS_SYMBOL_RESOLVER_MAX_CLUSTER"
+_DEFAULT_MAX_CLUSTER = 6
+_MAX_PRIMARY_ENV = "JARVIS_SYMBOL_RESOLVER_MAX_PRIMARY"
+_DEFAULT_MAX_PRIMARY = 4
+
+METHOD_STACK_TRACE = "stack_trace"
+METHOD_GOAL_KEYWORD = "goal_keyword"
+METHOD_UNRESOLVED = "unresolved"
+
+
+def _min_confidence() -> float:
+    try:
+        return max(0.0, min(1.0, float(os.environ.get(_MIN_CONF_ENV, str(_DEFAULT_MIN_CONF)))))
+    except (TypeError, ValueError):
+        return _DEFAULT_MIN_CONF
+
+
+def _cluster_enabled() -> bool:
+    return os.environ.get(_CLUSTER_ENV, "true").strip().lower() in ("1", "true", "yes", "on")
+
+
+def _int_env(name: str, default: int) -> int:
+    try:
+        return max(1, int(os.environ.get(name, str(default))))
+    except (TypeError, ValueError):
+        return default
+
+
+# ---------------------------------------------------------------------------
+# Public result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ResolvedSymbol:
+    """One repair target with a decorator-inclusive AST anchor."""
+    name: str                     # qualified: "Class.method" or bare "func"
+    start_line: int               # 1-indexed, INCLUDES the highest decorator
+    end_line: int                 # 1-indexed inclusive (docstring + body)
+    kind: str                     # "function" | "async_function" | "method" | "async_method"
+    decorators: Tuple[str, ...] = ()
+    is_cluster_member: bool = False   # pulled in by call-graph expansion
+
+
+@dataclass(frozen=True)
+class ResolutionResult:
+    symbols: Tuple[ResolvedSymbol, ...] = ()
+    method: str = METHOD_UNRESOLVED
+    confidence: float = 0.0
+    primary: Tuple[str, ...] = ()       # names resolved as primary targets
+    cluster: Tuple[str, ...] = ()       # names added by call-graph expansion
+
+    @property
+    def resolved(self) -> bool:
+        return bool(self.symbols)
+
+    @property
+    def symbol_names(self) -> Tuple[str, ...]:
+        return tuple(s.name for s in self.symbols)
+
+
+# ---------------------------------------------------------------------------
+# AST index — spans (decorator-aware), kinds, local call edges
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class _SymDef:
+    name: str
+    basename: str
+    start_line: int      # decorator-inclusive
+    def_line: int        # the def/class line itself
+    end_line: int
+    kind: str
+    decorators: Tuple[str, ...]
+    calls: Set[str]      # bare callee names invoked in the body
+
+
+def _anchor_start(node: ast.AST) -> int:
+    """Decorator-aware anchor — the highest-level decorator's line, else the
+    def line. Guarantees a wrapped symbol is never orphaned at the stitch."""
+    decos = getattr(node, "decorator_list", None) or []
+    if decos:
+        return min(int(d.lineno) for d in decos)
+    return int(getattr(node, "lineno", 1))
+
+
+def _collect_calls(node: ast.AST) -> Set[str]:
+    """Local callee names invoked inside *node* — ``f(...)`` → ``f``,
+    ``self.helper(...)`` / ``obj.helper(...)`` → ``helper``. Intersected with the
+    file's own symbols later, so only LOCAL siblings survive."""
+    names: Set[str] = set()
+    for sub in ast.walk(node):
+        if isinstance(sub, ast.Call):
+            fn = sub.func
+            if isinstance(fn, ast.Name):
+                names.add(fn.id)
+            elif isinstance(fn, ast.Attribute):
+                names.add(fn.attr)
+    return names
+
+
+def _mk_symdef(node: ast.AST, cls: Optional[str]) -> _SymDef:
+    base = node.name  # type: ignore[attr-defined]
+    qual = f"{cls}.{base}" if cls else base
+    is_async = isinstance(node, ast.AsyncFunctionDef)
+    if cls:
+        kind = "async_method" if is_async else "method"
+    else:
+        kind = "async_function" if is_async else "function"
+    return _SymDef(
+        name=qual,
+        basename=base,
+        start_line=_anchor_start(node),
+        def_line=int(getattr(node, "lineno", 1)),
+        end_line=int(getattr(node, "end_lineno", getattr(node, "lineno", 1))),
+        kind=kind,
+        decorators=tuple(_safe_unparse(d) for d in (getattr(node, "decorator_list", None) or [])),
+        calls=_collect_calls(node),
+    )
+
+
+def _safe_unparse(node: ast.AST) -> str:
+    try:
+        return ast.unparse(node)
+    except Exception:  # noqa: BLE001
+        return getattr(node, "id", "") or getattr(node, "attr", "") or "?"
+
+
+def _index(source: str) -> List[_SymDef]:
+    """Flat index of top-level functions + one level of class methods. Nested
+    functions are intentionally excluded — the swarm repairs top-level defs and
+    methods, not closures. Never raises."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError:
+        return []
+    out: List[_SymDef] = []
+    for node in tree.body:
+        if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            out.append(_mk_symdef(node, None))
+        elif isinstance(node, ast.ClassDef):
+            for sub in node.body:
+                if isinstance(sub, (ast.FunctionDef, ast.AsyncFunctionDef)):
+                    out.append(_mk_symdef(sub, node.name))
+    return out
+
+
+def _plan_extract_symbols(source: str) -> Set[str]:
+    """DRY corroboration via the existing ``PlanGenerator._extract_symbols`` —
+    the top-level name universe. Lazy + fail-soft (empty set on any import/parse
+    trouble) so the resolver never hard-depends on the plan module."""
+    try:
+        from backend.core.ouroboros.governance.plan_generator import PlanGenerator
+        raw = PlanGenerator._extract_symbols(source)  # ["class X", "def y", ...]
+    except Exception:  # noqa: BLE001
+        return set()
+    names: Set[str] = set()
+    for entry in raw or ():
+        parts = str(entry).split()
+        if parts:
+            names.add(parts[-1])
+    return names
+
+
+# ---------------------------------------------------------------------------
+# Cascade helpers
+# ---------------------------------------------------------------------------
+
+
+def _parse_frames(frames: Sequence[str]) -> List[Tuple[str, int, str]]:
+    """Extract ``(file, line, func)`` triples from raw traceback frame strings.
+    A frame may itself be a multi-line block; scan every match."""
+    out: List[Tuple[str, int, str]] = []
+    for raw in frames or ():
+        for m in _TB_FRAME_RE.finditer(str(raw)):
+            try:
+                out.append((m.group("file"), int(m.group("line")), m.group("func")))
+            except (TypeError, ValueError):
+                continue
+    return out
+
+
+def _file_matches(frame_file: str, target: str) -> bool:
+    if not frame_file or not target:
+        return False
+    fb, tb = os.path.basename(frame_file), os.path.basename(target)
+    if fb != tb:
+        return False
+    return frame_file.endswith(target) or target.endswith(frame_file) or fb == tb
+
+
+def _enclosing(index: List[_SymDef], line: int) -> Optional[_SymDef]:
+    """The innermost symbol whose decorator-inclusive span contains *line*.
+    Innermost = smallest span (a method inside a class wins over nothing)."""
+    best: Optional[_SymDef] = None
+    for sym in index:
+        if sym.start_line <= line <= sym.end_line:
+            if best is None or (sym.end_line - sym.start_line) < (best.end_line - best.start_line):
+                best = sym
+    return best
+
+
+def _subtokens(name: str) -> Set[str]:
+    """Split an identifier into lowercased sub-tokens across ``_`` and camelCase,
+    plus the whole lowercased name. ``_topological_sort`` →
+    {topological, sort, _topological_sort}; ``buildGraph`` → {build, graph}."""
+    toks: Set[str] = set()
+    low = name.lower().strip()
+    if low:
+        toks.add(low.lstrip("_"))
+    for part in name.split("_"):
+        for cm in _CAMEL_RE.findall(part):
+            if cm:
+                toks.add(cm.lower())
+    toks.discard("")
+    return toks
+
+
+def _goal_tokens(goal: str) -> Set[str]:
+    toks: Set[str] = set()
+    low = goal.lower()
+    for m in _IDENT_RE.finditer(low):
+        toks.add(m.group(0))
+        for part in m.group(0).split("_"):
+            if part:
+                toks.add(part)
+    return toks
+
+
+def _name_score(sym: _SymDef, goal_low: str, goal_toks: Set[str]) -> float:
+    """Deterministic goal-affinity score in [0, 1]. Explicit whole-name mention →
+    1.0; else the fraction of the symbol's sub-tokens present in the goal."""
+    base = sym.basename.lower()
+    # Explicit mention of the exact function name is unambiguous.
+    if re.search(r"\b" + re.escape(base) + r"\b", goal_low):
+        return 1.0
+    sub = _subtokens(sym.basename)
+    if not sub:
+        return 0.0
+    hits = sum(1 for t in sub if t in goal_toks)
+    return hits / len(sub)
+
+
+# ---------------------------------------------------------------------------
+# The resolver
+# ---------------------------------------------------------------------------
+
+
+def resolve_target_symbols(
+    *,
+    source: str,
+    file_path: str,
+    traceback_frames: Sequence[str] = (),
+    source_loci: Sequence[str] = (),
+    goal: str = "",
+    min_confidence: Optional[float] = None,
+    expand_cluster: Optional[bool] = None,
+) -> ResolutionResult:
+    """Resolve the concrete repair targets for one file via the deterministic
+    cascade. Never raises. An empty result means FAIL-CLOSED — the caller must
+    skip the interceptor and take the standard generation route unchanged."""
+    floor = _min_confidence() if min_confidence is None else max(0.0, min(1.0, min_confidence))
+    do_cluster = _cluster_enabled() if expand_cluster is None else bool(expand_cluster)
+
+    index = _index(source)
+    if not index:
+        return ResolutionResult()  # unparseable / no symbols → fail-closed
+
+    by_base: Dict[str, _SymDef] = {}
+    for sym in index:
+        # First definition of a basename wins as the cluster/trace anchor.
+        by_base.setdefault(sym.basename, sym)
+    top_level_universe = _plan_extract_symbols(source)  # DRY corroboration
+    if top_level_universe:
+        logger.debug(
+            "[TargetSymbolResolver] %s: %d top-level names corroborated via "
+            "PlanGenerator._extract_symbols", file_path, len(top_level_universe),
+        )
+
+    # ── Pass 1: deterministic stack-trace mapping ──
+    primaries: List[_SymDef] = []
+    method = METHOD_UNRESOLVED
+    confidence = 0.0
+    loci = {os.path.basename(p) for p in source_loci or ()}
+    for frame_file, line, func in _parse_frames(traceback_frames):
+        in_this_file = _file_matches(frame_file, file_path) or (
+            os.path.basename(frame_file) in loci and os.path.basename(frame_file) == os.path.basename(file_path)
+        )
+        if not in_this_file:
+            continue
+        hit = _enclosing(index, line)
+        if hit is None and func in by_base:      # line drifted → func-name tie-break
+            hit = by_base[func]
+        if hit is not None and hit.name not in {p.name for p in primaries}:
+            primaries.append(hit)
+    if primaries:
+        method = METHOD_STACK_TRACE
+        confidence = 1.0
+
+    # ── Pass 2: deterministic goal keyword match (NO LLM) ──
+    if not primaries and goal.strip():
+        goal_low = goal.lower()
+        goal_toks = _goal_tokens(goal)
+        scored = sorted(
+            ((sym, _name_score(sym, goal_low, goal_toks)) for sym in index),
+            key=lambda t: t[1], reverse=True,
+        )
+        best = scored[0][1] if scored else 0.0
+        picked = [sym for sym, sc in scored if sc >= floor]
+        if picked and best >= floor:
+            primaries = picked[: _int_env(_MAX_PRIMARY_ENV, _DEFAULT_MAX_PRIMARY)]
+            method = METHOD_GOAL_KEYWORD
+            confidence = best
+
+    # ── Fail-Closed ──
+    if not primaries:
+        logger.info(
+            "[TargetSymbolResolver] %s: FAIL-CLOSED (no confident target — "
+            "trace=%d goal=%r) → standard route preserved",
+            file_path, len(_parse_frames(traceback_frames)), goal[:60],
+        )
+        return ResolutionResult(method=METHOD_UNRESOLVED, confidence=0.0)
+
+    primary_names = [p.name for p in primaries]
+
+    # ── Call-Graph Expansion: pull local siblings/helpers into the cluster ──
+    cluster: List[_SymDef] = []
+    if do_cluster:
+        max_cluster = _int_env(_MAX_CLUSTER_ENV, _DEFAULT_MAX_CLUSTER)
+        seen = set(primary_names)
+        for p in primaries:
+            for callee in sorted(p.calls):
+                if len(cluster) >= max_cluster:
+                    break
+                dep = by_base.get(callee)
+                if dep is not None and dep.name not in seen:
+                    seen.add(dep.name)
+                    cluster.append(dep)
+
+    symbols: List[ResolvedSymbol] = []
+    for p in primaries:
+        symbols.append(_to_public(p, is_cluster=False))
+    for c in cluster:
+        symbols.append(_to_public(c, is_cluster=True))
+
+    logger.info(
+        "[TargetSymbolResolver] %s: %s (conf=%.2f) primary=%s cluster=%s",
+        file_path, method, confidence, primary_names, [c.name for c in cluster],
+    )
+    return ResolutionResult(
+        symbols=tuple(symbols),
+        method=method,
+        confidence=confidence,
+        primary=tuple(primary_names),
+        cluster=tuple(c.name for c in cluster),
+    )
+
+
+def _to_public(sym: _SymDef, *, is_cluster: bool) -> ResolvedSymbol:
+    return ResolvedSymbol(
+        name=sym.name,
+        start_line=sym.start_line,
+        end_line=sym.end_line,
+        kind=sym.kind,
+        decorators=sym.decorators,
+        is_cluster_member=is_cluster,
+    )
+
+
+__all__ = [
+    "METHOD_GOAL_KEYWORD",
+    "METHOD_STACK_TRACE",
+    "METHOD_UNRESOLVED",
+    "ResolutionResult",
+    "ResolvedSymbol",
+    "resolve_target_symbols",
+]

--- a/tests/governance/test_target_symbol_resolver.py
+++ b/tests/governance/test_target_symbol_resolver.py
@@ -1,0 +1,206 @@
+"""TargetSymbolResolver — the deterministic-first cascade keystone.
+
+Mandated bulletproof (async):
+  1. A failing-test STACK TRACE resolves accurately to its enclosing symbol.
+  2. A resolved function's LOCAL HELPER is pulled into the Symbol Cluster.
+  3. A ``@classmethod`` decorator is FULLY captured in the node boundary anchor.
+  4. An ambiguous target FAILS CLOSED (empty → standard route preserved).
+
+Plus: goal-keyword resolution, explicit-name precedence, and end-to-end parity
+with the real ``extract_target_chunk`` (the chunk the swarm receives includes
+the decorator, proving the anchor is honored downstream).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.chunked_generation import (
+    extract_target_chunk,
+)
+from backend.core.ouroboros.governance.target_symbol_resolver import (
+    METHOD_GOAL_KEYWORD,
+    METHOD_STACK_TRACE,
+    METHOD_UNRESOLVED,
+    resolve_target_symbols,
+)
+
+# A file with: a module fn that calls a local helper, and a class with a
+# @classmethod. Line numbers are load-bearing for the stack-trace test.
+_SRC = '''"""Enterprise module."""
+
+
+def _topological_sort(graph):
+    order = []
+    _visit(graph, order)
+    return order
+
+
+def _visit(graph, order):
+    for node in graph:
+        order.append(node)
+
+
+def unrelated(x):
+    return x + 1
+
+
+class SagaBuilder:
+    @classmethod
+    def build(cls, spec):
+        """Build a saga."""
+        return cls._compose(spec)
+
+    @staticmethod
+    def _compose(spec):
+        return list(spec)
+'''
+
+
+def _lineno(substr: str) -> int:
+    for i, line in enumerate(_SRC.splitlines(), start=1):
+        if substr in line:
+            return i
+    raise AssertionError(f"{substr!r} not found")
+
+
+# ---------------------------------------------------------------------------
+# (1) Deterministic stack-trace mapping
+# ---------------------------------------------------------------------------
+
+
+async def test_stack_trace_resolves_to_enclosing_symbol() -> None:
+    # A traceback whose deepest in-file frame lands inside _topological_sort.
+    line = _lineno("_visit(graph, order)")  # inside _topological_sort's body
+    frames = [
+        'File "/repo/other.py", line 10, in test_it',
+        f'File "/repo/saga.py", line {line}, in _topological_sort',
+    ]
+    result = resolve_target_symbols(
+        source=_SRC, file_path="backend/saga.py",
+        traceback_frames=frames, source_loci=("backend/saga.py",),
+    )
+    assert result.method == METHOD_STACK_TRACE
+    assert result.confidence == 1.0
+    assert "_topological_sort" in result.primary
+
+
+async def test_stack_trace_line_maps_deterministically_not_by_name() -> None:
+    # Frame func label is wrong ("<lambda>") but the LINE is authoritative.
+    line = _lineno("order = []")
+    frames = [f'File "/x/saga.py", line {line}, in <lambda>']
+    result = resolve_target_symbols(
+        source=_SRC, file_path="saga.py", traceback_frames=frames,
+    )
+    assert result.method == METHOD_STACK_TRACE
+    assert result.primary == ("_topological_sort",)
+
+
+# ---------------------------------------------------------------------------
+# (2) Call-Graph Expansion — Symbol Clustering
+# ---------------------------------------------------------------------------
+
+
+async def test_local_helper_pulled_into_cluster() -> None:
+    line = _lineno("_visit(graph, order)")
+    frames = [f'File "/x/saga.py", line {line}, in _topological_sort']
+    result = resolve_target_symbols(
+        source=_SRC, file_path="saga.py", traceback_frames=frames,
+    )
+    # _topological_sort calls _visit (a local sibling) → clustered.
+    assert "_topological_sort" in result.primary
+    assert "_visit" in result.cluster
+    # The unrelated function is NOT dragged in.
+    assert "unrelated" not in result.symbol_names
+    # Cluster members are flagged.
+    visit = next(s for s in result.symbols if s.name == "_visit")
+    assert visit.is_cluster_member is True
+
+
+async def test_cluster_can_be_disabled() -> None:
+    line = _lineno("_visit(graph, order)")
+    frames = [f'File "/x/saga.py", line {line}, in _topological_sort']
+    result = resolve_target_symbols(
+        source=_SRC, file_path="saga.py", traceback_frames=frames,
+        expand_cluster=False,
+    )
+    assert result.cluster == ()
+    assert result.symbol_names == ("_topological_sort",)
+
+
+# ---------------------------------------------------------------------------
+# (3) Decorator-Aware Anchoring
+# ---------------------------------------------------------------------------
+
+
+async def test_classmethod_decorator_captured_in_anchor() -> None:
+    result = resolve_target_symbols(
+        source=_SRC, file_path="saga.py", goal="fix SagaBuilder.build",
+    )
+    build = next(s for s in result.symbols if s.name.endswith("build"))
+    # The anchor starts at the @classmethod line, NOT the def line.
+    deco_line = _lineno("@classmethod")
+    def_line = _lineno("def build(cls, spec)")
+    assert build.start_line == deco_line
+    assert build.start_line < def_line
+    assert any("classmethod" in d for d in build.decorators)
+
+    # End-to-end: the chunk the swarm actually receives includes the decorator.
+    chunk = extract_target_chunk(_SRC, "saga.py", build.name)
+    assert chunk is not None
+    assert "@classmethod" in (chunk.source_code or "")
+
+
+# ---------------------------------------------------------------------------
+# (4) Fail-Closed on ambiguity
+# ---------------------------------------------------------------------------
+
+
+async def test_ambiguous_goal_fails_closed() -> None:
+    # A goal that names nothing in the file and shares no meaningful tokens.
+    result = resolve_target_symbols(
+        source=_SRC, file_path="saga.py",
+        goal="please improve the overall quality and performance somehow",
+    )
+    assert result.resolved is False
+    assert result.method == METHOD_UNRESOLVED
+    assert result.symbols == ()
+
+
+async def test_no_trace_no_goal_fails_closed() -> None:
+    result = resolve_target_symbols(source=_SRC, file_path="saga.py")
+    assert result.resolved is False
+    assert result.method == METHOD_UNRESOLVED
+
+
+async def test_unparseable_source_fails_closed() -> None:
+    result = resolve_target_symbols(
+        source="def broken( : \n  pass", file_path="x.py",
+        goal="fix broken", traceback_frames=['File "x.py", line 1, in broken'],
+    )
+    assert result.resolved is False
+
+
+# ---------------------------------------------------------------------------
+# Goal-keyword resolution (deterministic heuristic)
+# ---------------------------------------------------------------------------
+
+
+async def test_explicit_name_in_goal_resolves() -> None:
+    result = resolve_target_symbols(
+        source=_SRC, file_path="saga.py",
+        goal="the _topological_sort function returns nodes in the wrong order",
+    )
+    assert result.method == METHOD_GOAL_KEYWORD
+    assert result.confidence == 1.0
+    assert "_topological_sort" in result.primary
+
+
+async def test_goal_token_overlap_resolves() -> None:
+    # No exact name; 'topological' + 'sort' tokens overlap _topological_sort.
+    result = resolve_target_symbols(
+        source=_SRC, file_path="saga.py",
+        goal="the topological sort is unstable",
+    )
+    assert result.method == METHOD_GOAL_KEYWORD
+    assert "_topological_sort" in result.primary


### PR DESCRIPTION
## The keystone that unblocks the `candidate_generator` live-seam wire

The interceptor/swarm needs the **concrete functions** an op intends to repair. The pipeline carries `target_files` (paths) but **no function-level targets** — so routing big files to the swarm without this degrades to RAG-only and regresses the working bounded-diff path (the reason the wire was correctly stopped). This resolves targets **deterministically first**, because hallucination is the root cause of extraction drift:

1. **Stack-trace mapping (100% deterministic)** — parse the failing test's traceback frames → `(file, line, func)` and map each in-file line to its enclosing AST node. Confidence 1.0. Line-containment is authoritative; a wrong frame label (`<lambda>`, `<module>`) never misleads it.
2. **Goal keyword match (deterministic heuristic, NO LLM)** — score each symbol by goal-text token overlap; an explicit whole-name mention scores 1.0. No model call → no hallucination.
3. **Fail-Closed** — best confidence below the floor → **EMPTY**. The caller skips the interceptor and the standard route stays byte-identical. Ambiguity never reaches the swarm.

### Structural guarantees
- **Call-Graph Expansion (Symbol Clustering)** — a resolved function that calls local sibling/helper methods in the same file pulls them into the target cluster (bounded by `MAX_CLUSTER`), so no node is repaired context-starved. Unrelated functions are never dragged in.
- **Decorator-Aware Anchoring** — a symbol's span starts at its **highest-level decorator** (`@classmethod`/`@property`/`@retry`) through its docstring+body, matching `ASTChunker`'s `include_decorators` convention so `extract_target_chunk` agrees byte-for-byte.

### Mandate conformance
- **Root-Cause Only** — deterministic stack-trace pass **before** any probabilistic analysis; no LLM heuristics.
- **DRY** — native `ast`; composes `PlanGenerator._extract_symbols` (top-level name universe) + the attribution bridge's `traceback_frames`/`source_loci`. Touches no model-selection path — the **Fable model is never flagged**.

### Tests (10 passed; full swarm stack: 32 passed)
Stack-trace→symbol; line-maps-not-by-name; local-helper clustering (+ disable); `@classmethod` anchor captured at the resolver **and** end-to-end through the real `extract_target_chunk`; ambiguous / no-signal / unparseable **fail-closed**; explicit-name + token-overlap goal resolution.

### Next
With this keystone, the `candidate_generator` wire (2a) is now safe: `if big_file AND resolver.resolve(op).resolved AND flag-on → intercept_full_content(...)` else the existing path untouched — the fail-closed contract guarantees zero regression. Wire #2 (`StrategyOutcomeLogger`) goes live once 2a produces pending strategies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `TargetSymbolResolver` to turn file paths into precise function targets using a deterministic-first cascade, enabling safe big-file interception for the swarm. Ambiguity fails closed to keep the existing path unchanged, with decorator-aware anchors for byte-accurate extraction.

- **New Features**
  - Maps stack-trace lines to the enclosing AST symbol (confidence 1.0); falls back to a goal keyword heuristic with no model calls.
  - Fails closed below `JARVIS_SYMBOL_RESOLVER_MIN_CONFIDENCE` to avoid misrouting.
  - Adds optional in-file helper clustering; bounded by `JARVIS_SYMBOL_RESOLVER_MAX_CLUSTER` and controlled by `JARVIS_SYMBOL_RESOLVER_CLUSTER_ENABLED`.
  - Uses decorator-inclusive spans compatible with `extract_target_chunk` and corroborates names via `PlanGenerator._extract_symbols`.

<sup>Written for commit 0181118bec6fb7d20e97943654df51a82591dc58. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70028?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

