### PR TITLE
Live-seam wire — candidate_generator to Agentic Swarm + Wire #2 boot attach

### DIFF
--- a/backend/core/ouroboros/governance/candidate_generator.py
+++ b/backend/core/ouroboros/governance/candidate_generator.py
@@ -3715,6 +3715,180 @@ class CandidateGenerator:
             "provider_override_unavailable:gcp-jprime:no_endpoint"
         )
 
+    def _swarm_routing_enabled(self) -> bool:
+        """Dynamic toggle (env ``JARVIS_SWARM_ROUTING_ENABLED``, default OFF) —
+        WORKSPACE_PROMOTION-style, no code mutation to flip. Off → the
+        short-circuit is a strict no-op and the standard generation route is
+        byte-identical."""
+        return os.environ.get(
+            "JARVIS_SWARM_ROUTING_ENABLED", "false",
+        ).strip().lower() in ("1", "true", "yes", "on")
+
+    def _read_source_for_swarm(self, rel_or_abs: str) -> Optional[str]:
+        """Read a target file's current on-disk content (repo_root-joined).
+        Returns None on any miss → the short-circuit declines. Never raises."""
+        try:
+            repo_root = getattr(self, "_repo_root", None)
+            path = rel_or_abs
+            if repo_root and not os.path.isabs(rel_or_abs):
+                path = os.path.join(repo_root, rel_or_abs)
+            with open(path, encoding="utf-8", errors="replace") as fh:
+                return fh.read()
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _swarm_frames_from_ctx(self, context: OperationContext) -> Tuple[str, ...]:
+        """Best-effort extraction of failing-test traceback frames from the
+        op's intake evidence (feeds the resolver's deterministic pass). Empty
+        on any miss — the resolver then falls to the goal-keyword pass."""
+        raw = getattr(context, "intake_evidence_json", "") or ""
+        if not raw:
+            return ()
+        try:
+            import json as _json
+            data = _json.loads(raw)
+        except (ValueError, TypeError):
+            return ()
+        if not isinstance(data, dict):
+            return ()
+        for key in ("traceback_frames", "traceback", "frames"):
+            v = data.get(key)
+            if isinstance(v, (list, tuple)):
+                return tuple(str(x) for x in v)
+            if isinstance(v, str) and v.strip():
+                return (v,)
+        return ()
+
+    async def _maybe_swarm_short_circuit(
+        self, context: OperationContext, deadline: datetime,
+    ) -> Optional[GenerationResult]:
+        """Route a CONFIRMED big-file op through the Agentic Swarm interceptor,
+        returning a ``GenerationResult`` that short-circuits normal generation.
+
+        Returns ``None`` — falling through to the standard route BYTE-IDENTICAL —
+        whenever the dynamic flag is off, the route is cost-optimized, the file
+        is small, the swarm stack is unavailable, or the ``TargetSymbolResolver``
+        FAILS CLOSED (no confident target). Structured concurrency: a parent
+        cancellation/timeout is re-raised cleanly so the interceptor's swarm
+        tasks + DW sockets (its awaited children) tear down with no ghost tasks.
+        """
+        if not self._swarm_routing_enabled():
+            return None
+        route = (getattr(context, "provider_route", "") or "standard").lower()
+        if route in ("background", "speculative"):
+            return None  # cost-optimized routes never fan out a swarm
+        target_files = tuple(getattr(context, "target_files", ()) or ())
+        if not target_files:
+            return None
+        path = target_files[0]
+        source = self._read_source_for_swarm(path)
+        if source is None:
+            return None
+        try:
+            from backend.core.ouroboros.governance.chunked_generation import (
+                is_big_file,
+            )
+            from backend.core.ouroboros.governance.target_symbol_resolver import (
+                resolve_target_symbols,
+            )
+            from backend.core.ouroboros.governance.full_content_interceptor import (
+                intercept_full_content,
+            )
+            from backend.core.ouroboros.governance.agent_turn_adapter import (
+                ProductionAgentTurnFn,
+            )
+        except Exception:  # noqa: BLE001 — swarm stack absent → standard route
+            return None
+        if not is_big_file(source):
+            return None
+
+        res = resolve_target_symbols(
+            source=source, file_path=path,
+            traceback_frames=self._swarm_frames_from_ctx(context),
+            source_loci=target_files,
+            goal=getattr(context, "description", "") or "",
+        )
+        if not res.resolved:
+            logger.info(
+                "[CandidateGenerator] swarm: resolver FAIL-CLOSED for %s — "
+                "standard route preserved", path,
+            )
+            return None
+
+        try:
+            from backend.core.ouroboros.governance.providers import (
+                _CODEGEN_SYSTEM_PROMPT as _sys_prompt,
+            )
+        except Exception:  # noqa: BLE001
+            _sys_prompt = ""
+
+        agent = ProductionAgentTurnFn(
+            client=self._client,
+            tool_backend=None,                       # pure-completion node repair (v1)
+            repo_root=getattr(self, "_repo_root", "."),
+            op_id=getattr(context, "op_id", ""),
+            model_name=getattr(self._client, "_model", "") or "",  # client default, no hardcode
+            system_prompt=_sys_prompt,
+            parse_fn=lambda raw: None,               # single-shot node completion
+            max_turns=1,
+        )
+        t0 = time.monotonic()
+        try:
+            result = await intercept_full_content(
+                source, path, list(res.symbol_names), agent,
+                op_id=getattr(context, "op_id", ""),
+            )
+        except asyncio.CancelledError:
+            # Structured concurrency: awaiting the interceptor makes its swarm
+            # tasks + DW sockets children of THIS task; cancellation has already
+            # torn them down. Re-raise cleanly — NEVER swallow (no ghost tasks).
+            logger.info(
+                "[CandidateGenerator] swarm CANCELLED for %s — clean teardown", path,
+            )
+            raise
+        except Exception as exc:  # noqa: BLE001 — any swarm fault → standard route
+            logger.warning(
+                "[CandidateGenerator] swarm error for %s: %s — standard route",
+                path, exc,
+            )
+            return None
+
+        if (
+            getattr(result, "drifted", False)
+            or not getattr(result, "stitched", False)
+            or not getattr(result, "content", "")
+        ):
+            logger.info(
+                "[CandidateGenerator] swarm no-stitch/drift for %s — standard route",
+                path,
+            )
+            return None
+
+        dur = time.monotonic() - t0
+        rationale = (
+            f"agentic swarm ({res.method}, conf={res.confidence:.2f}): "
+            f"primary={list(res.primary)} cluster={list(res.cluster)} "
+            f"converged={list(result.converged_nodes)} "
+            f"rag_recovered={list(result.rag_recovered_nodes)}"
+        )
+        logger.info(
+            "[CandidateGenerator] SWARM short-circuit LANDED for %s: %s [%.1fs]",
+            path, rationale, dur,
+        )
+        return GenerationResult(
+            candidates=(
+                {
+                    "candidate_id": f"swarm-{getattr(context, 'op_id', '')[:8]}",
+                    "file_path": path,
+                    "full_content": result.content,
+                    "rationale": rationale,
+                },
+            ),
+            provider_name="doubleword-agentic-swarm",
+            generation_duration_s=dur,
+            model_id=getattr(self._client, "_model", "") or "",
+        )
+
     async def _generate_dispatch(
         self,
         context: OperationContext,
@@ -3738,6 +3912,16 @@ class CandidateGenerator:
         _override_result = await self._honor_provider_override(context, deadline)
         if _override_result is not None:
             return _override_result
+
+        # ── Big-file Agentic Swarm short-circuit (default-OFF; fail-closed) ──
+        # When JARVIS_SWARM_ROUTING_ENABLED and the op targets a big file with a
+        # deterministically-resolvable symbol, route through the swarm
+        # interceptor instead of whole-file generation. Returns None (standard
+        # route, byte-identical) on the flag being off / small file / resolver
+        # fail-closed. CancelledError propagates (structured concurrency).
+        _swarm_result = await self._maybe_swarm_short_circuit(context, deadline)
+        if _swarm_result is not None:
+            return _swarm_result
 
         # ── Route-based dispatch (Manifesto §5 Tier 0: deterministic) ──
         _provider_route = getattr(context, "provider_route", "") or "standard"

--- a/backend/core/ouroboros/governance/governed_loop_service.py
+++ b/backend/core/ouroboros/governance/governed_loop_service.py
@@ -3114,6 +3114,49 @@ class GovernedLoopService:
             )
             self._cognitive_bus_subscription_ids = []
 
+        # ── Wire #2 — StrategyOutcomeLogger on the production TrinityEventBus ──
+        # Flushes big-file Agentic-Swarm extraction-strategy outcomes to SQLite
+        # on every op.terminal.* (off-loop, via run_in_executor). Only attached
+        # when swarm routing is enabled (no pending strategies exist otherwise,
+        # so it would be a no-op subscriber + a stray DB file on every boot).
+        # Fault-Tolerant Shield: a locked/unavailable SQLite DB logs an error
+        # telemetry event and boot continues UNINTERRUPTED — telemetry failure
+        # must never poison the orchestration boot.
+        self._strategy_outcome_logger = None
+        _swarm_on = os.environ.get(
+            "JARVIS_SWARM_ROUTING_ENABLED", "false",
+        ).strip().lower() in ("1", "true", "yes", "on")
+        if _swarm_on:
+            try:
+                from backend.core.trinity_event_bus import get_event_bus_if_exists
+                from backend.core.ouroboros.governance.chunked_generation_bridge import (
+                    StrategyOutcomeLogger,
+                )
+                _sbus = get_event_bus_if_exists()
+                if _sbus is not None:
+                    import sqlite3 as _sqlite3
+                    from pathlib import Path as _Path
+                    _db_dir = _Path(".jarvis")
+                    _db_dir.mkdir(parents=True, exist_ok=True)
+                    _conn = _sqlite3.connect(
+                        str(_db_dir / "chunk_strategy.db"), check_same_thread=False,
+                    )
+                    _sol = StrategyOutcomeLogger(_conn)
+                    await _sol.attach_to_bus(_sbus)
+                    self._strategy_outcome_logger = _sol
+                    _incr_observer_boot("strategy_outcome_logger")
+                    logger.info(
+                        "[GovernedLoop] Wire #2: StrategyOutcomeLogger attached "
+                        "to TrinityEventBus (swarm reinforcement → SQLite)",
+                    )
+            except Exception:  # noqa: BLE001 — telemetry attach NEVER fatal to boot
+                logger.warning(
+                    "[GovernedLoop] Wire #2: StrategyOutcomeLogger attach failed "
+                    "(non-fatal, boot continues)",
+                    exc_info=True,
+                )
+                self._strategy_outcome_logger = None
+
         # Slice 101 Phase 6 — Sleep Consolidation Daemon. Background async task
         # that runs the cross-session memory cascade (belief + postmortem-fusion
         # → consolidation → meta-prior calibration) OFF the hot path on an idle-

--- a/tests/governance/test_candidate_generator_swarm_wire.py
+++ b/tests/governance/test_candidate_generator_swarm_wire.py
@@ -1,0 +1,205 @@
+"""candidate_generator ← Agentic Swarm live-seam wire (Step 2a) + Wire #2.
+
+Mandated bulletproof:
+  1. The standard small-file route stays 100% byte-identical — the short-circuit
+     returns None (flag off, small file, OR resolver fail-closed) so dispatch
+     falls through untouched.
+  2. A big file with a confident target symbol routes to intercept_full_content
+     and returns a swarm GenerationResult that short-circuits generation.
+  3. A simulated asyncio.CancelledError mid-execution bubbles up cleanly (no
+     swallow, no ghost dispatcher state) — structured concurrency.
+
+Plus: Wire #2's StrategyOutcomeLogger attach is fault-tolerant (a raising bus
+never escapes → boot is never poisoned).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+import backend.core.ouroboros.governance.full_content_interceptor as fci
+from backend.core.ouroboros.governance.candidate_generator import CandidateGenerator
+from backend.core.ouroboros.governance.chunked_generation_bridge import (
+    StrategyOutcomeLogger,
+)
+from backend.core.ouroboros.governance.full_content_interceptor import InterceptResult
+
+
+class _FakeClient:
+    _model = "test-dw-397b"
+
+    async def generate(self, **kwargs):  # never reached when interceptor is mocked
+        return SimpleNamespace(content="")
+
+
+def _gen(tmp_path) -> CandidateGenerator:
+    g = CandidateGenerator.__new__(CandidateGenerator)   # bypass heavy __init__
+    g._repo_root = str(tmp_path)
+    g._client = _FakeClient()
+    return g
+
+
+def _deadline() -> datetime:
+    return datetime.now(tz=timezone.utc) + timedelta(seconds=120)
+
+
+def _big_source(target_def: str = "def alpha(a, b):\n    return a - b\n") -> str:
+    parts = ['"""Enterprise module."""', "", target_def]
+    for i in range(400):   # > big_file_line_threshold (300)
+        parts.append(f"def _pad_{i}():\n    return {i}\n")
+    return "\n".join(parts)
+
+
+def _ctx(rel_path: str, *, goal: str = "", route: str = "standard") -> SimpleNamespace:
+    return SimpleNamespace(
+        provider_route=route,
+        target_files=(rel_path,),
+        description=goal,
+        intake_evidence_json="",
+        op_id="op-abcdef123456",
+    )
+
+
+# ---------------------------------------------------------------------------
+# (1) Standard route stays byte-identical — short-circuit declines.
+# ---------------------------------------------------------------------------
+
+
+async def test_flag_off_is_noop_even_for_big_file(tmp_path, monkeypatch) -> None:
+    monkeypatch.delenv("JARVIS_SWARM_ROUTING_ENABLED", raising=False)  # default off
+    p = tmp_path / "big.py"
+    p.write_text(_big_source())
+    g = _gen(tmp_path)
+    out = await g._maybe_swarm_short_circuit(_ctx("big.py", goal="fix alpha"), _deadline())
+    assert out is None  # flag off → standard route, byte-identical
+
+
+async def test_small_file_is_noop(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SWARM_ROUTING_ENABLED", "true")
+    p = tmp_path / "small.py"
+    p.write_text("def alpha(a, b):\n    return a - b\n")
+    g = _gen(tmp_path)
+    out = await g._maybe_swarm_short_circuit(_ctx("small.py", goal="fix alpha"), _deadline())
+    assert out is None  # small file → standard route
+
+
+async def test_resolver_fail_closed_is_noop(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SWARM_ROUTING_ENABLED", "true")
+    p = tmp_path / "big.py"
+    p.write_text(_big_source())
+    g = _gen(tmp_path)
+    # Ambiguous goal, no traceback → resolver fails closed → standard route.
+    out = await g._maybe_swarm_short_circuit(
+        _ctx("big.py", goal="please make it better somehow"), _deadline(),
+    )
+    assert out is None
+
+
+async def test_background_route_never_swarms(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SWARM_ROUTING_ENABLED", "true")
+    p = tmp_path / "big.py"
+    p.write_text(_big_source())
+    g = _gen(tmp_path)
+    out = await g._maybe_swarm_short_circuit(
+        _ctx("big.py", goal="fix alpha", route="background"), _deadline(),
+    )
+    assert out is None
+
+
+# ---------------------------------------------------------------------------
+# (2) Big file + confident symbol → routes to the swarm interceptor.
+# ---------------------------------------------------------------------------
+
+
+async def test_big_file_confident_symbol_routes_to_swarm(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SWARM_ROUTING_ENABLED", "true")
+    src = _big_source()
+    p = tmp_path / "big.py"
+    p.write_text(src)
+    g = _gen(tmp_path)
+
+    seen = {}
+
+    async def _fake_intercept(source, file_path, symbols, agent_fn, **kwargs):
+        seen["symbols"] = list(symbols)
+        seen["file_path"] = file_path
+        return InterceptResult(
+            strategy="agentic_swarm", content="STITCHED_CONTENT",
+            stitched=True, converged_nodes=["alpha"],
+        )
+
+    monkeypatch.setattr(fci, "intercept_full_content", _fake_intercept)
+
+    out = await g._maybe_swarm_short_circuit(
+        _ctx("big.py", goal="the alpha function returns the wrong value"),
+        _deadline(),
+    )
+    assert out is not None
+    assert out.provider_name == "doubleword-agentic-swarm"
+    assert len(out.candidates) == 1
+    cand = out.candidates[0]
+    assert cand["full_content"] == "STITCHED_CONTENT"
+    assert cand["file_path"] == "big.py"
+    # The resolver fed the confident symbol into the swarm.
+    assert "alpha" in seen["symbols"]
+
+
+async def test_swarm_drift_falls_through_to_standard(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SWARM_ROUTING_ENABLED", "true")
+    p = tmp_path / "big.py"
+    p.write_text(_big_source())
+    g = _gen(tmp_path)
+
+    async def _drifted(source, file_path, symbols, agent_fn, **kwargs):
+        return InterceptResult(strategy="aborted_drift", content=source,
+                               stitched=False, drifted=True)
+
+    monkeypatch.setattr(fci, "intercept_full_content", _drifted)
+    out = await g._maybe_swarm_short_circuit(
+        _ctx("big.py", goal="fix alpha function"), _deadline(),
+    )
+    assert out is None  # ghost-edit drift → safe fall-through, no corruption
+
+
+# ---------------------------------------------------------------------------
+# (3) Cancellation propagates cleanly (structured concurrency).
+# ---------------------------------------------------------------------------
+
+
+async def test_cancellation_bubbles_up_cleanly(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("JARVIS_SWARM_ROUTING_ENABLED", "true")
+    p = tmp_path / "big.py"
+    p.write_text(_big_source())
+    g = _gen(tmp_path)
+
+    async def _cancelled(source, file_path, symbols, agent_fn, **kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(fci, "intercept_full_content", _cancelled)
+
+    with pytest.raises(asyncio.CancelledError):
+        await g._maybe_swarm_short_circuit(
+            _ctx("big.py", goal="fix alpha function"), _deadline(),
+        )
+    # No dispatcher state was mutated — the helper is stateless, so a clean
+    # re-raise leaves nothing to leak (structured-concurrency teardown).
+
+
+# ---------------------------------------------------------------------------
+# Wire #2 — fault-tolerant attach (a raising bus never poisons boot).
+# ---------------------------------------------------------------------------
+
+
+async def test_wire2_attach_is_fault_tolerant() -> None:
+    class _BoomBus:
+        async def subscribe(self, pattern, handler):
+            raise RuntimeError("SQLite locked / bus unavailable")
+
+    logger_obj = StrategyOutcomeLogger(conn=None)
+    # attach_to_bus must swallow the fault and return None — never propagate.
+    sub_id = await logger_obj.attach_to_bus(_BoomBus())
+    assert sub_id is None


### PR DESCRIPTION
## The final switch — 2a + Wire #2

All three keystones (`ProductionAgentTurnFn` #70026, Ghost-Edit guard #70027, `TargetSymbolResolver` #70028) now compose into a safe, non-regressing route from the generation dispatch to the swarm.

### Step 2a — `candidate_generator` dispatch short-circuit
`_maybe_swarm_short_circuit`, called at the **top** of `_generate_dispatch` (after the provider-override check):
- **Dynamic flag** `JARVIS_SWARM_ROUTING_ENABLED` (default **OFF**, WORKSPACE_PROMOTION-style — no code mutation to toggle).
- Reads the on-disk source, gates on `is_big_file`, resolves targets via the deterministic `TargetSymbolResolver`. **Fail-closed** (no confident symbol / small file / cost route / flag off) → returns `None` → standard route **byte-identical**.
- Engages: builds `ProductionAgentTurnFn(client=self._client, model=client._model` [no hardcode], pure-completion v1) and runs `intercept_full_content`, wrapping the stitched result as a `GenerationResult` that short-circuits generation.
- **Cancellation Propagation:** `asyncio.CancelledError` is re-raised (never swallowed) so the interceptor's swarm tasks + DW sockets — its awaited children — tear down with no ghost tasks (structured concurrency).
- Ghost-Edit drift or no-stitch → falls through to the standard route (safe).

### Wire #2 — `StrategyOutcomeLogger` on the production `TrinityEventBus` at GLS boot
Attached only when swarm routing is on (avoids a stray DB on every boot). **Fault-Tolerant Shield:** a locked/unavailable SQLite DB logs telemetry and boot continues **uninterrupted** — telemetry never poisons orchestration boot.

### Mandate conformance
- **Root-Cause Only** — dynamic env flag (no hardcode); native structured concurrency.
- **DRY** — composes `TargetSymbolResolver` + `intercept_full_content` + `ProductionAgentTurnFn` + `is_big_file` + the existing GLS observer-boot pattern. No new dispatcher.

### Tests (8 wire tests; full swarm stack: 57 passed)
Flag-off / small-file / resolver-fail-closed / background route all no-op (standard route byte-identical); big file + confident symbol → swarm `GenerationResult`; ghost-edit drift falls through; `CancelledError` bubbles up cleanly; Wire #2 attach fault-tolerant.

**Zero regression:** the 17 unrelated pre-existing determinism/YAML failures were confirmed red on clean `main` via stash-and-compare — not caused by this wire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a guarded short-circuit in the candidate generator to route big-file edits through Agentic Swarm, with safe fallbacks that keep the standard path byte-for-byte. Also attaches Wire #2 (`StrategyOutcomeLogger`) to the production `TrinityEventBus` only when swarm routing is enabled, with fault-tolerant boot.

- **New Features**
  - Big-file short-circuit to Agentic Swarm when a confident target symbol is resolved; returns a `GenerationResult` to bypass full-file generation.
  - Controlled by `JARVIS_SWARM_ROUTING_ENABLED` (default off). Background/speculative routes never swarm.
  - Fail-closed and safe: small files, resolver miss, drift/no-stitch, or interceptor faults fall back to the standard path (byte-identical). Cancellation re-raises `asyncio.CancelledError`.
  - Wire #2: `StrategyOutcomeLogger` attaches only when swarm is enabled; SQLite/bus errors are logged and boot continues.

<sup>Written for commit e9bbc201a8328b83b08174991d8bd26b952702cd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70029?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

