### PR TITLE
Predictive DW Outage Forecaster — EMA/Bayesian TTR + AIMD slow-start

### DIFF
--- a/backend/core/ouroboros/governance/dw_outage_forecaster.py
+++ b/backend/core/ouroboros/governance/dw_outage_forecaster.py
@@ -1,0 +1,381 @@
+"""Predictive DW Outage Forecaster — ML-driven recovery watch, no naive polling.
+
+The naive answer to "wait for DW to recover" is a ``while True: ping; sleep(5)``
+loop — which spams the endpoint (IP-ban / wasted compute risk) and learns
+nothing. This replaces it with a lightweight predictive controller that gets
+smarter every outage:
+
+  * **SQLite outage memory (DRY on #70021's DB).** Every DW outage's
+    ``(outage_start, recovery, time-to-recovery)`` is recorded into a
+    ``dw_outage_history`` table in the SAME ``.jarvis/chunk_strategy.db`` the
+    StrategyOutcomeLogger uses — one durable telemetry substrate, two concerns.
+
+  * **EMA + Bayesian-shrinkage forecaster (native math, NO ML libs).** The
+    predicted TTR is an exponential moving average of historical TTRs, shrunk
+    toward a prior mean during the cold-start (low-data) phase via a
+    ``conf = n/(n+k)`` Bayesian weight — a single weird sample can never
+    dominate, and with zero history it returns the prior (never NaN / never 0).
+
+  * **Dynamic bounded backoff.** The watch sleep is driven by the forecast:
+    ``clamp(remaining_predicted_TTR * 0.5, floor, ceiling)``. As the outage runs
+    longer the predicted-remaining shrinks, so the watcher probes more often as
+    expected recovery nears — bounded ALWAYS in ``[floor=30s, ceiling=600s]`` so
+    a cold-start over-estimate can never cause an indefinite sleep.
+
+  * **TCP-style AIMD slow-start (thundering-herd protection).** On predicted
+    recovery the swarm is NOT unleashed at max concurrency. ``AIMDController``
+    starts the semaphore limit at 1 (a single probe agent); each success
+    additively increases it (+1), each failure multiplicatively decreases it
+    (//2), bounded by the swarm's own ``swarm_concurrency()`` ceiling — so a
+    recovering DW server is ramped onto, never slammed.
+
+Pure + deterministic (injectable clock / sleep / probe). Composes
+``provider_heartbeat.DWHeartbeat`` (the signal, injected as ``probe_fn``),
+``chunk_swarm.swarm_concurrency`` (the AIMD ceiling), and the #70021 SQLite
+layer. Never raises on the telemetry path.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Awaitable, Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.DWOutageForecaster")
+
+_OUTAGE_TABLE = "dw_outage_history"
+
+# --- env knobs (all bounded, no hardcoded magic in the hot path) -----------
+_PRIOR_ENV = "JARVIS_DW_FORECAST_PRIOR_TTR_S"
+_DEFAULT_PRIOR_TTR_S = 120.0
+_ALPHA_ENV = "JARVIS_DW_FORECAST_EMA_ALPHA"
+_DEFAULT_ALPHA = 0.4
+_WARMUP_ENV = "JARVIS_DW_FORECAST_WARMUP_K"
+_DEFAULT_WARMUP_K = 3
+_FLOOR_ENV = "JARVIS_DW_FORECAST_SLEEP_FLOOR_S"
+_DEFAULT_FLOOR_S = 30.0
+_CEILING_ENV = "JARVIS_DW_FORECAST_SLEEP_CEILING_S"
+_DEFAULT_CEILING_S = 600.0   # 10 minutes
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int) -> int:
+    try:
+        return int(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+def default_forecast_db_path() -> str:
+    """Same durable substrate as Wire #2's StrategyOutcomeLogger (#70021)."""
+    return str(Path(".jarvis") / "chunk_strategy.db")
+
+
+def open_forecast_db(path: Optional[str] = None) -> Optional[sqlite3.Connection]:
+    """Open (creating parent dir + table) the outage-history DB. Returns None on
+    any failure — the forecaster then rides the cold-start prior. Never raises."""
+    try:
+        p = Path(path or default_forecast_db_path())
+        p.parent.mkdir(parents=True, exist_ok=True)
+        conn = sqlite3.connect(str(p), check_same_thread=False)
+        _ensure_outage_table(conn)
+        return conn
+    except sqlite3.Error:
+        return None
+
+
+def _ensure_outage_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_OUTAGE_TABLE} ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "outage_start_ts REAL NOT NULL, "
+        "recovery_ts REAL, "
+        "ttr_s REAL, "
+        "surface TEXT DEFAULT 'direct_streaming')"
+    )
+    conn.commit()
+
+
+# ---------------------------------------------------------------------------
+# Outage lifecycle recording
+# ---------------------------------------------------------------------------
+
+
+def record_outage_start(
+    conn: Optional[sqlite3.Connection], start_ts: float,
+    *, surface: str = "direct_streaming",
+) -> None:
+    """Open an outage row (recovery_ts NULL). Never raises."""
+    if conn is None:
+        return
+    try:
+        _ensure_outage_table(conn)
+        conn.execute(
+            f"INSERT INTO {_OUTAGE_TABLE} (outage_start_ts, surface) VALUES (?, ?)",
+            (float(start_ts), surface),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        logger.debug("[DWForecaster] record_outage_start failed", exc_info=True)
+
+
+def record_recovery(
+    conn: Optional[sqlite3.Connection], start_ts: float, recovery_ts: float,
+    *, surface: str = "direct_streaming",
+) -> Optional[float]:
+    """Close the open outage row for ``start_ts`` and compute its TTR. Returns
+    the TTR seconds, or None. Never raises."""
+    if conn is None:
+        return None
+    ttr = max(0.0, float(recovery_ts) - float(start_ts))
+    try:
+        _ensure_outage_table(conn)
+        cur = conn.execute(
+            f"UPDATE {_OUTAGE_TABLE} SET recovery_ts=?, ttr_s=? "
+            f"WHERE recovery_ts IS NULL AND outage_start_ts=?",
+            (float(recovery_ts), ttr, float(start_ts)),
+        )
+        if cur.rowcount == 0:
+            # No matching open row (e.g. restart) — insert a completed one.
+            conn.execute(
+                f"INSERT INTO {_OUTAGE_TABLE} "
+                f"(outage_start_ts, recovery_ts, ttr_s, surface) VALUES (?, ?, ?, ?)",
+                (float(start_ts), float(recovery_ts), ttr, surface),
+            )
+        conn.commit()
+        return ttr
+    except sqlite3.Error:
+        logger.debug("[DWForecaster] record_recovery failed", exc_info=True)
+        return None
+
+
+def _completed_ttrs(conn: Optional[sqlite3.Connection]) -> List[float]:
+    """Historical TTRs, oldest → newest. Empty on any trouble."""
+    if conn is None:
+        return []
+    try:
+        _ensure_outage_table(conn)
+        rows = conn.execute(
+            f"SELECT ttr_s FROM {_OUTAGE_TABLE} "
+            f"WHERE ttr_s IS NOT NULL ORDER BY outage_start_ts ASC"
+        ).fetchall()
+        return [float(r[0]) for r in rows if r[0] is not None]
+    except sqlite3.Error:
+        return []
+
+
+# ---------------------------------------------------------------------------
+# The forecaster (EMA + Bayesian shrinkage)
+# ---------------------------------------------------------------------------
+
+
+def forecast_ttr(
+    conn: Optional[sqlite3.Connection],
+    *,
+    prior_mean: Optional[float] = None,
+    alpha: Optional[float] = None,
+    warmup_k: Optional[int] = None,
+) -> float:
+    """Predict the current outage's total duration (seconds).
+
+    EMA of historical TTRs, Bayesian-shrunk toward ``prior_mean`` by a
+    ``conf = n/(n+k)`` weight so the cold-start (small n) leans on the prior and
+    a lone anomalous sample can never dominate. Zero history → the prior. Always
+    a finite positive number (never NaN, never 0)."""
+    prior = prior_mean if prior_mean is not None else _env_float(_PRIOR_ENV, _DEFAULT_PRIOR_TTR_S)
+    a = alpha if alpha is not None else _env_float(_ALPHA_ENV, _DEFAULT_ALPHA)
+    a = min(1.0, max(0.01, a))
+    k = warmup_k if warmup_k is not None else _env_int(_WARMUP_ENV, _DEFAULT_WARMUP_K)
+    k = max(0, k)
+
+    ttrs = _completed_ttrs(conn)
+    if not ttrs:
+        return max(1.0, prior)   # cold start → prior
+
+    ema = ttrs[0]
+    for t in ttrs[1:]:
+        ema = a * t + (1.0 - a) * ema
+
+    n = len(ttrs)
+    conf = n / (n + k) if (n + k) > 0 else 1.0    # Bayesian shrinkage weight
+    predicted = conf * ema + (1.0 - conf) * prior
+    return max(1.0, predicted)
+
+
+def predict_sleep_s(
+    conn: Optional[sqlite3.Connection],
+    elapsed_outage_s: float,
+    *,
+    floor_s: Optional[float] = None,
+    ceiling_s: Optional[float] = None,
+) -> float:
+    """The dynamically-adjusting, BOUNDED watch interval.
+
+    Sleeps for roughly half the predicted-remaining TTR so the watcher wakes and
+    probes as expected recovery nears; as ``elapsed`` grows the interval shrinks
+    toward the floor. STRICTLY bounded ``[floor, ceiling]`` — a cold-start
+    over-estimate can never cause an indefinite (or sub-floor spammy) sleep."""
+    fl = floor_s if floor_s is not None else _env_float(_FLOOR_ENV, _DEFAULT_FLOOR_S)
+    ce = ceiling_s if ceiling_s is not None else _env_float(_CEILING_ENV, _DEFAULT_CEILING_S)
+    if ce < fl:
+        ce = fl
+    ttr = forecast_ttr(conn)
+    remaining = ttr - max(0.0, float(elapsed_outage_s))
+    if remaining <= fl:
+        return fl   # near/past expected recovery → probe at floor cadence
+    return max(fl, min(ce, remaining * 0.5))
+
+
+# ---------------------------------------------------------------------------
+# TCP-style AIMD slow-start controller
+# ---------------------------------------------------------------------------
+
+
+class AIMDController:
+    """Additive-Increase / Multiplicative-Decrease concurrency governor.
+
+    Slow-start: the limit BEGINS at ``floor`` (1 — a single probe agent). Each
+    success additively increases it (+``ai_step``); each failure multiplicatively
+    decreases it (``// md_factor``). Bounded ``[floor, max_limit]`` where
+    ``max_limit`` defaults to the swarm's own concurrency ceiling. This is how a
+    recovering DW server is ramped onto instead of slammed by a thundering herd."""
+
+    def __init__(
+        self,
+        *,
+        max_limit: Optional[int] = None,
+        floor: int = 1,
+        ai_step: int = 1,
+        md_factor: int = 2,
+    ) -> None:
+        if max_limit is None:
+            try:
+                from backend.core.ouroboros.governance.chunk_swarm import swarm_concurrency
+                max_limit = swarm_concurrency()
+            except Exception:  # noqa: BLE001
+                max_limit = 4
+        self._floor = max(1, int(floor))
+        self._max = max(self._floor, int(max_limit or self._floor))
+        self._ai = max(1, int(ai_step))
+        self._md = max(2, int(md_factor))
+        self._limit = self._floor   # slow-start: begin at the floor (1)
+
+    @property
+    def limit(self) -> int:
+        return self._limit
+
+    @property
+    def max_limit(self) -> int:
+        return self._max
+
+    def on_success(self) -> int:
+        """Additive increase — one more slot, capped at the ceiling."""
+        self._limit = min(self._max, self._limit + self._ai)
+        return self._limit
+
+    def on_failure(self) -> int:
+        """Multiplicative decrease — halve, never below the floor."""
+        self._limit = max(self._floor, self._limit // self._md)
+        return self._limit
+
+    def reset(self) -> int:
+        self._limit = self._floor
+        return self._limit
+
+
+# ---------------------------------------------------------------------------
+# The predictive watch loop
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class RecoveryOutcome:
+    recovered: bool
+    ttr_s: Optional[float]
+    probes: int
+    aimd: AIMDController
+
+
+ProbeFn = Callable[[], Awaitable[bool]]     # a lightweight DW health ping → bool
+NowFn = Callable[[], float]
+SleepFn = Callable[[float], Awaitable[None]]
+
+
+async def watch_for_recovery(
+    conn: Optional[sqlite3.Connection],
+    probe_fn: ProbeFn,
+    *,
+    now_fn: Optional[NowFn] = None,
+    sleep_fn: Optional[SleepFn] = None,
+    max_probes: int = 0,
+    surface: str = "direct_streaming",
+) -> RecoveryOutcome:
+    """Predictively wait out a DW outage, then confirm recovery with a single
+    slow-start probe. Records the outage lifecycle to SQLite (feeding future
+    forecasts). Returns a :class:`RecoveryOutcome` carrying the ramped AIMD
+    controller the relaunch should seed its ``max_concurrency`` from.
+
+    ``probe_fn`` is injected (production: the DWHeartbeat deep-probe; tests: a
+    mock) so this loop never itself hammers the endpoint — it probes exactly
+    once per predicted interval. Never raises."""
+    import asyncio as _asyncio
+
+    now = now_fn or time.monotonic
+    sleep = sleep_fn or _asyncio.sleep
+    aimd = AIMDController()
+
+    start_ts = now()
+    record_outage_start(conn, start_ts, surface=surface)
+    probes = 0
+
+    while True:
+        elapsed = now() - start_ts
+        interval = predict_sleep_s(conn, elapsed)
+        await sleep(interval)
+        probes += 1
+        try:
+            healthy = bool(await probe_fn())
+        except Exception:  # noqa: BLE001 — a failed probe is just "still down"
+            healthy = False
+
+        if healthy:
+            # TCP slow-start: a SINGLE probe agent confirmed the surface. The
+            # AIMD limit is already 1; the relaunch ramps it up per round.
+            aimd.on_success()   # 1 -> 2 available for the first real round
+            ttr = record_recovery(conn, start_ts, now(), surface=surface)
+            logger.info(
+                "[DWForecaster] DW RECOVERED after %.0fs (%d probes) — slow-start "
+                "at limit=%d/%d", (ttr or elapsed), probes, aimd.limit, aimd.max_limit,
+            )
+            return RecoveryOutcome(recovered=True, ttr_s=ttr, probes=probes, aimd=aimd)
+
+        aimd.on_failure()   # still down → keep the ramp conservative
+        logger.debug(
+            "[DWForecaster] DW still down (probe %d, elapsed %.0fs, next in %.0fs)",
+            probes, elapsed, interval,
+        )
+        if max_probes and probes >= max_probes:
+            return RecoveryOutcome(recovered=False, ttr_s=None, probes=probes, aimd=aimd)
+
+
+__all__ = [
+    "AIMDController",
+    "RecoveryOutcome",
+    "default_forecast_db_path",
+    "forecast_ttr",
+    "open_forecast_db",
+    "predict_sleep_s",
+    "record_outage_start",
+    "record_recovery",
+    "watch_for_recovery",
+]

--- a/tests/governance/test_dw_outage_forecaster.py
+++ b/tests/governance/test_dw_outage_forecaster.py
@@ -1,0 +1,188 @@
+"""Predictive DW Outage Forecaster — EMA/Bayesian TTR + AIMD slow-start.
+
+Mandated bulletproof (async):
+  1. The forecaster computes a DYNAMICALLY-adjusting TTR-driven sleep interval
+     from historical outages (mocked SQLite).
+  2. The sleep is strictly bounded by the ceiling guardrail (a huge predicted
+     TTR can never blow past it, and the cold start never sleeps indefinitely).
+  3. On simulated recovery the swarm semaphore INITIALIZES at 1 and scales up
+     progressively (TCP-style slow-start), capped at the ceiling.
+
+Plus: cold-start returns the prior (never 0/NaN), Bayesian shrinkage toward the
+prior with sparse data, and the end-to-end watch loop records the outage
+lifecycle and returns a ramped AIMD controller.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_outage_forecaster import (
+    AIMDController,
+    forecast_ttr,
+    predict_sleep_s,
+    record_outage_start,
+    record_recovery,
+    watch_for_recovery,
+)
+
+
+def _db() -> sqlite3.Connection:
+    return sqlite3.connect(":memory:", check_same_thread=False)
+
+
+def _seed(conn: sqlite3.Connection, ttrs) -> None:
+    """Seed completed outages with the given TTRs (monotonic start stamps)."""
+    for i, ttr in enumerate(ttrs):
+        start = 1000.0 + i * 10_000.0
+        record_outage_start(conn, start)
+        record_recovery(conn, start, start + ttr)
+
+
+# ---------------------------------------------------------------------------
+# (1) Dynamically-adjusting forecast
+# ---------------------------------------------------------------------------
+
+
+async def test_forecast_reflects_history_and_sleep_adjusts_dynamically() -> None:
+    conn = _db()
+    _seed(conn, [200.0, 200.0, 200.0])  # steady ~200s outages
+    ttr = forecast_ttr(conn, prior_mean=120.0, warmup_k=3)
+    # EMA≈200 shrunk toward prior 120 by conf=3/6=0.5 → ≈160.
+    assert 150.0 <= ttr <= 200.0
+
+    # The sleep interval SHRINKS as the outage runs longer (dynamic, not static).
+    early = predict_sleep_s(conn, elapsed_outage_s=0.0, floor_s=30.0, ceiling_s=600.0)
+    late = predict_sleep_s(conn, elapsed_outage_s=ttr - 10.0, floor_s=30.0, ceiling_s=600.0)
+    assert early > late
+    assert late == 30.0   # past ~expected recovery → floor cadence
+
+
+async def test_cold_start_returns_prior_not_zero() -> None:
+    conn = _db()  # no history
+    ttr = forecast_ttr(conn, prior_mean=120.0)
+    assert ttr == 120.0
+    # And the sleep is a sane bounded value, never 0 or infinite.
+    s = predict_sleep_s(conn, 0.0, floor_s=30.0, ceiling_s=600.0)
+    assert 30.0 <= s <= 600.0
+
+
+async def test_bayesian_shrinkage_tames_single_anomaly() -> None:
+    conn = _db()
+    _seed(conn, [5000.0])   # one wild outage
+    # With n=1, conf=1/(1+3)=0.25 → mostly the prior, not the anomaly.
+    ttr = forecast_ttr(conn, prior_mean=120.0, warmup_k=3)
+    assert ttr < 1500.0, ttr   # the lone 5000s sample did NOT dominate
+
+
+# ---------------------------------------------------------------------------
+# (2) Ceiling guardrail
+# ---------------------------------------------------------------------------
+
+
+async def test_sleep_bounded_by_ceiling() -> None:
+    conn = _db()
+    _seed(conn, [5000.0, 5000.0, 5000.0, 5000.0, 5000.0])  # long, consistent outages
+    ttr = forecast_ttr(conn, prior_mean=120.0)
+    assert ttr > 1000.0   # forecast is large...
+    # ...but the sleep is CLAMPED at the ceiling — never indefinite.
+    s = predict_sleep_s(conn, elapsed_outage_s=0.0, floor_s=30.0, ceiling_s=600.0)
+    assert s == 600.0
+
+
+async def test_sleep_never_below_floor() -> None:
+    conn = _db()
+    _seed(conn, [40.0, 40.0])   # very short outages
+    s = predict_sleep_s(conn, elapsed_outage_s=1000.0, floor_s=30.0, ceiling_s=600.0)
+    assert s == 30.0   # way past expected recovery → floor, never sub-floor spam
+
+
+# ---------------------------------------------------------------------------
+# (3) AIMD slow-start
+# ---------------------------------------------------------------------------
+
+
+async def test_aimd_slow_start_initializes_at_one_and_ramps() -> None:
+    aimd = AIMDController(max_limit=8, floor=1)
+    assert aimd.limit == 1                     # slow-start begins at ONE
+
+    ramp = [aimd.on_success() for _ in range(5)]
+    assert ramp == [2, 3, 4, 5, 6]             # additive increase, +1 each
+
+    # Multiplicative decrease on a failure (a recovering server hiccup).
+    assert aimd.on_failure() == 3              # 6 // 2
+
+    # Additive increase never exceeds the ceiling.
+    for _ in range(20):
+        aimd.on_success()
+    assert aimd.limit == 8                      # capped at max_limit
+
+    # Failures never fall below the floor.
+    for _ in range(20):
+        aimd.on_failure()
+    assert aimd.limit == 1
+
+
+async def test_aimd_defaults_ceiling_to_swarm_concurrency() -> None:
+    aimd = AIMDController()   # no max_limit → swarm_concurrency()
+    assert aimd.limit == 1
+    assert aimd.max_limit >= 1
+
+
+# ---------------------------------------------------------------------------
+# End-to-end watch loop (deterministic clock / sleep / probe)
+# ---------------------------------------------------------------------------
+
+
+async def test_watch_loop_records_lifecycle_and_returns_ramped_aimd() -> None:
+    conn = _db()
+    _seed(conn, [100.0, 100.0])
+
+    clock = {"t": 0.0}
+
+    def now() -> float:
+        return clock["t"]
+
+    async def sleep(s: float) -> None:
+        clock["t"] += s   # advance the virtual clock by the predicted interval
+
+    probes = {"n": 0}
+
+    async def probe() -> bool:
+        probes["n"] += 1
+        return probes["n"] >= 3   # down for 2 probes, then recovers
+
+    outcome = await watch_for_recovery(
+        conn, probe, now_fn=now, sleep_fn=sleep, max_probes=10,
+    )
+    assert outcome.recovered is True
+    assert outcome.probes == 3
+    assert outcome.ttr_s is not None and outcome.ttr_s > 0
+    # Slow-start: the returned controller is at limit 1 (start) bumped once on
+    # the confirming success → ready to ramp, not slammed at max.
+    assert outcome.aimd.limit <= 2
+
+    # The outage was persisted → future forecasts can learn from it.
+    n = conn.execute(
+        "SELECT COUNT(*) FROM dw_outage_history WHERE ttr_s IS NOT NULL"
+    ).fetchone()[0]
+    assert n == 3   # 2 seeded + this one
+
+
+async def test_watch_loop_gives_up_after_max_probes_if_never_recovers() -> None:
+    conn = _db()
+    clock = {"t": 0.0}
+
+    async def sleep(s: float) -> None:
+        clock["t"] += s
+
+    async def probe() -> bool:
+        return False   # never recovers
+
+    outcome = await watch_for_recovery(
+        conn, probe, now_fn=lambda: clock["t"], sleep_fn=sleep, max_probes=4,
+    )
+    assert outcome.recovered is False
+    assert outcome.probes == 4


### PR DESCRIPTION
## Predictive recovery watch — no naive polling

Replaces `while True: ping; sleep(5)` (the IP-ban / wasted-compute root cause) with a predictive controller that gets smarter every outage.

- **SQLite outage memory (DRY on #70021's DB)** — every outage's `(start, recovery, TTR)` lands in a `dw_outage_history` table in the **same** `.jarvis/chunk_strategy.db` the `StrategyOutcomeLogger` uses. One durable substrate, two concerns.
- **EMA + Bayesian-shrinkage forecaster (native math, NO ML libs)** — predicted TTR is an exponential moving average of historical TTRs, shrunk toward a prior by `conf = n/(n+k)`, so cold-start leans on the prior and a lone anomaly (a 5000s outage) can never dominate. Zero history → the prior; never NaN/0.
- **Dynamic bounded backoff** — `sleep = clamp(remaining_predicted_TTR * 0.5, floor=30s, ceiling=600s)`. Shrinks toward the floor as expected recovery nears; a cold-start over-estimate can never cause an indefinite (or sub-floor spammy) sleep.
- **TCP-style AIMD slow-start** — on recovery the swarm is **not** unleashed at max concurrency. `AIMDController` starts the limit at **1** (one probe agent), additive-increases (+1) per success, multiplicative-decreases (`//2`) per failure, bounded by `swarm_concurrency()`. Ramps onto a recovering DW server, never slams it.

### Mandate conformance
- **Root-Cause Only** — predictive dynamic backoff, never rapid pings.
- **DRY** — composes `provider_heartbeat` (the signal, injected as `probe_fn` so the loop never itself hammers DW), `chunk_swarm.swarm_concurrency` (AIMD ceiling), and the #70021 SQLite layer. No heavy ML libs — pure `statistics`/math.
- Touches no model-selection path — the **Fable model is never flagged**.

### Tests (9 passed)
Dynamically-adjusting TTR sleep from mocked history; cold-start prior (never 0); Bayesian shrinkage tames a single anomaly; ceiling + floor guardrails; AIMD initializes at 1 and ramps additively (capped), halves on failure (never below floor); end-to-end watch loop records the lifecycle and returns a ramped controller.

### Role in the campaign
This is the autonomous watcher that will relaunch the definitive Agentic Swarm soak (blocked last run by a total DW hard-outage + Anthropic $0) **when the math predicts DW is safe** — probing at forecast-driven intervals and slow-starting the swarm onto the recovering endpoint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a predictive DW outage forecaster that replaces 5s polling with EMA/Bayesian TTR and bounded backoff, then ramps recovery with TCP-style AIMD to avoid load spikes. Outage history is stored in SQLite to make future forecasts smarter.

- **New Features**
  - Persists outages in SQLite (`dw_outage_history`) within `.jarvis/chunk_strategy.db`.
  - Forecasts TTR via EMA shrunk to a prior; cold start uses the prior. Configurable with `JARVIS_DW_FORECAST_{PRIOR_TTR_S,EMA_ALPHA,WARMUP_K,SLEEP_FLOOR_S,SLEEP_CEILING_S}`.
  - Sets probe interval to half the predicted remaining TTR, clamped to `30s`–`600s`.
  - Uses AIMD slow-start to ramp concurrency from 1, capped by `chunk_swarm.swarm_concurrency()`.
  - Deterministic async watch loop with injectable `probe_fn`, `now_fn`, `sleep_fn`; tests cover dynamic sleep, guardrails, AIMD, and lifecycle persistence.

<sup>Written for commit 5d2bdbc621ad94e5efd6bfed526e0d7cb32b1ed4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

