### PR TITLE
DW Deep-Probe — inference-lane health via ITL stream-integrity

### DIFF
--- a/backend/core/ouroboros/governance/dw_deep_probe.py
+++ b/backend/core/ouroboros/governance/dw_deep_probe.py
@@ -1,0 +1,237 @@
+"""DW Deep-Probe — inference-lane health, not metadata-endpoint health.
+
+A ``GET /v1/models`` 200 (stateless REST transport) is NECESSARY but NOT
+SUFFICIENT: it says the control plane answers, not that the GPU inference lane
+(direct SSE streaming) will survive a real generation. Trusting it produced a
+false-positive recovery that woke the swarm onto a still-degraded DW. This probe
+tests the lane that actually matters — a minimal streaming generation — and
+measures its integrity:
+
+  * **Ephemeral zero-shot payload.** A 1-word system prompt + a 2-char user ping,
+    ``max_tokens`` hard-capped at 5. Forces the inference cluster to execute
+    while keeping token spend mathematically negligible (no token bleed).
+
+  * **Stream-Integrity via ITL thresholding.** First-token arrival alone is not
+    trusted. The probe measures Time-To-First-Token AND the Inter-Token Latency
+    across the ≤5 tokens. If mean/peak ITL exceeds a safe threshold (GPUs
+    thrashing / stream dropping packets) the verdict is ``DEGRADED`` — overriding
+    a 200 OK — so the swarm stays asleep.
+
+  * **Asymmetric timeouts.** The 120s cold-start tolerance applies ONLY to the
+    TTFT phase (397B VRAM load); every subsequent inter-token gap keeps the
+    aggressive ITL watchdog bound. Both are the existing #70017
+    ``watchdog_consume_sse`` dual-phase bounds — this module does NOT re-parse
+    SSE.
+
+DRY: composes ``stream_watchdog.watchdog_consume_sse`` / ``fast_abort_response``
+(#70017), ``stream_rupture.StreamRuptureError``, and ``provider_heartbeat``'s
+transport resolver. Yields the ``() -> bool`` ``probe_fn`` the DW Outage
+Forecaster (#70030) injects. Never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import time
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, List, Optional
+
+from backend.core.ouroboros.governance.stream_rupture import StreamRuptureError
+from backend.core.ouroboros.governance.stream_watchdog import (
+    fast_abort_response,
+    watchdog_consume_sse,
+)
+
+logger = logging.getLogger("Ouroboros.DWDeepProbe")
+
+_TTFT_ENV = "JARVIS_DW_DEEP_PROBE_TTFT_S"        # cold-start VRAM-load tolerance
+_DEFAULT_TTFT_S = 120.0
+_ITL_HARD_ENV = "JARVIS_DW_DEEP_PROBE_ITL_HARD_S"  # watchdog rupture bound (stall)
+_DEFAULT_ITL_HARD_S = 8.0
+_ITL_SAFE_ENV = "JARVIS_DW_DEEP_PROBE_ITL_SAFE_S"  # thrash classification threshold
+_DEFAULT_ITL_SAFE_S = 2.0
+_MAX_TOKENS = 5
+
+VERDICT_HEALTHY = "HEALTHY"
+VERDICT_DEGRADED = "DEGRADED"
+
+
+def _env_float(name: str, default: float) -> float:
+    try:
+        return float(os.environ.get(name, str(default)))
+    except (TypeError, ValueError):
+        return default
+
+
+@dataclass
+class DeepProbeResult:
+    healthy: bool
+    verdict: str          # VERDICT_HEALTHY | VERDICT_DEGRADED
+    ttft_s: float
+    mean_itl_s: float
+    max_itl_s: float
+    tokens: int
+    reason: str
+
+
+def build_probe_payload(model: str, *, max_tokens: int = _MAX_TOKENS) -> dict:
+    """Aggressively minimal zero-shot probe body — forces inference, negligible
+    token spend. ``max_tokens`` is hard-capped so the cluster executes but the
+    generation is mathematically tiny (no background token bleed)."""
+    return {
+        "model": model,
+        "messages": [
+            {"role": "system", "content": "Reply."},
+            {"role": "user", "content": "ok"},
+        ],
+        "max_tokens": int(max_tokens),
+        "temperature": 0.0,
+        "stream": True,
+    }
+
+
+# dispatch_fn(payload) -> an async readline (or a (readline, response) tuple for
+# fast-abort). Production streams to DW; tests inject a mock line source.
+DispatchFn = Callable[[dict], Awaitable[Any]]
+
+
+async def deep_probe(
+    *,
+    dispatch_fn: DispatchFn,
+    model: str = "",
+    ttft_bound_s: Optional[float] = None,
+    itl_hard_s: Optional[float] = None,
+    itl_safe_s: Optional[float] = None,
+    max_tokens: int = _MAX_TOKENS,
+) -> DeepProbeResult:
+    """Stream a minimal generation and grade the inference lane. Never raises.
+
+    Verdict:
+      * StreamRuptureError (TTFT or ITL hard-breach) -> DEGRADED
+      * zero tokens produced                          -> DEGRADED
+      * mean/peak ITL over the safe threshold         -> DEGRADED (overrides 200)
+      * otherwise                                     -> HEALTHY
+    """
+    ttft = ttft_bound_s if ttft_bound_s is not None else _env_float(_TTFT_ENV, _DEFAULT_TTFT_S)
+    itl_hard = itl_hard_s if itl_hard_s is not None else _env_float(_ITL_HARD_ENV, _DEFAULT_ITL_HARD_S)
+    itl_safe = itl_safe_s if itl_safe_s is not None else _env_float(_ITL_SAFE_ENV, _DEFAULT_ITL_SAFE_S)
+    payload = build_probe_payload(model, max_tokens=max_tokens)
+
+    token_times: List[float] = []
+
+    def _on_token(_tok: str) -> None:
+        token_times.append(time.monotonic())
+
+    _abort_target: dict = {"resp": None}
+
+    def _abort() -> None:
+        if _abort_target["resp"] is not None:
+            fast_abort_response(_abort_target["resp"])
+
+    start = time.monotonic()
+    try:
+        dispatched = await dispatch_fn(payload)
+        if isinstance(dispatched, tuple):
+            readline, resp = dispatched
+            _abort_target["resp"] = resp
+        else:
+            readline = dispatched
+        await watchdog_consume_sse(
+            readline, ttft_s=ttft, itl_s=itl_hard, abort_fn=_abort,
+            provider="doubleword", on_token=_on_token,
+        )
+    except StreamRuptureError as exc:
+        return DeepProbeResult(
+            healthy=False, verdict=VERDICT_DEGRADED,
+            ttft_s=(token_times[0] - start) if token_times else -1.0,
+            mean_itl_s=-1.0, max_itl_s=-1.0, tokens=len(token_times),
+            reason=f"stream_rupture:{getattr(exc, 'phase', '?')}",
+        )
+    except Exception as exc:  # noqa: BLE001 — any dispatch/transport fault = lane down
+        return DeepProbeResult(
+            healthy=False, verdict=VERDICT_DEGRADED, ttft_s=-1.0,
+            mean_itl_s=-1.0, max_itl_s=-1.0, tokens=len(token_times),
+            reason=f"dispatch_error:{type(exc).__name__}",
+        )
+
+    tokens = len(token_times)
+    if tokens == 0:
+        return DeepProbeResult(
+            healthy=False, verdict=VERDICT_DEGRADED, ttft_s=-1.0,
+            mean_itl_s=-1.0, max_itl_s=-1.0, tokens=0, reason="no_tokens",
+        )
+    ttft_measured = token_times[0] - start
+    itls = [token_times[i] - token_times[i - 1] for i in range(1, tokens)]
+    mean_itl = (sum(itls) / len(itls)) if itls else 0.0
+    max_itl = max(itls) if itls else 0.0
+
+    # Stream-Integrity: terrible ITL overrides a 200 OK — GPUs thrashing.
+    if mean_itl > itl_safe or max_itl > (itl_safe * 2.0):
+        return DeepProbeResult(
+            healthy=False, verdict=VERDICT_DEGRADED, ttft_s=ttft_measured,
+            mean_itl_s=mean_itl, max_itl_s=max_itl, tokens=tokens,
+            reason=f"itl_thrash mean={mean_itl:.2f}s peak={max_itl:.2f}s safe={itl_safe:.2f}s",
+        )
+    return DeepProbeResult(
+        healthy=True, verdict=VERDICT_HEALTHY, ttft_s=ttft_measured,
+        mean_itl_s=mean_itl, max_itl_s=max_itl, tokens=tokens, reason="healthy",
+    )
+
+
+def make_deep_probe_fn(
+    dispatch_fn: Optional[DispatchFn] = None, **probe_kwargs: Any,
+) -> Callable[[], Awaitable[bool]]:
+    """Adapt :func:`deep_probe` into the forecaster's ``probe_fn`` contract
+    (``() -> Awaitable[bool]``). Production default streams to DW; injectable."""
+    df = dispatch_fn or _default_dw_stream_dispatch
+
+    async def _probe() -> bool:
+        res = await deep_probe(dispatch_fn=df, **probe_kwargs)
+        logger.info(
+            "[DWDeepProbe] verdict=%s ttft=%.1fs mean_itl=%.2fs peak_itl=%.2fs "
+            "tokens=%d (%s)",
+            res.verdict, res.ttft_s, res.mean_itl_s, res.max_itl_s,
+            res.tokens, res.reason,
+        )
+        return res.healthy
+
+    return _probe
+
+
+async def _default_dw_stream_dispatch(payload: dict) -> Any:
+    """Production dispatch: a real minimal streaming POST to DW, returning an
+    async readline over the SSE body + the response (for fast-abort). Composes
+    ``provider_heartbeat``'s transport resolver (base URL + auth headers) — no
+    parallel transport. Best-effort session cleanup. Never raises to the caller
+    beyond transport exceptions (which deep_probe classifies as DEGRADED)."""
+    import aiohttp  # lazy — keep module import cheap
+    from backend.core.ouroboros.governance.provider_heartbeat import (
+        _resolve_dw_probe_transport,
+    )
+
+    url, headers = await _resolve_dw_probe_transport()
+    headers = {**headers, "Accept": "text/event-stream"}
+    session = aiohttp.ClientSession()
+    resp = await session.post(url, json=payload, headers=headers)
+
+    async def _readline() -> Any:
+        line = await resp.content.readline()
+        if not line:
+            try:
+                resp.release()
+            finally:
+                await session.close()
+        return line
+
+    return (_readline, resp)
+
+
+__all__ = [
+    "DeepProbeResult",
+    "VERDICT_DEGRADED",
+    "VERDICT_HEALTHY",
+    "build_probe_payload",
+    "deep_probe",
+    "make_deep_probe_fn",
+]

--- a/tests/governance/test_dw_deep_probe.py
+++ b/tests/governance/test_dw_deep_probe.py
@@ -1,0 +1,162 @@
+"""DW Deep-Probe — inference-lane health with ITL stream-integrity thresholding.
+
+Mandated bulletproof (async, mocked SSE stream):
+  1. Acceptable TTFT but TERRIBLE ITL → classified DEGRADED (overrides the 200
+     OK) and keeps the swarm asleep (probe_fn → False).
+  2. The probe payload strictly enforces max_tokens=5 (negligible token spend).
+  3. A HEALTHY stream → HEALTHY, and drives the forecaster's watch loop to
+     awaken the swarm (recovered=True with a slow-start AIMD controller).
+
+Plus: hard-ITL rupture → DEGRADED; a transport/dispatch fault → DEGRADED.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_deep_probe import (
+    VERDICT_DEGRADED,
+    VERDICT_HEALTHY,
+    build_probe_payload,
+    deep_probe,
+    make_deep_probe_fn,
+)
+from backend.core.ouroboros.governance.dw_outage_forecaster import watch_for_recovery
+
+
+def _sse_token(text: str) -> bytes:
+    return f'data: {{"choices":[{{"delta":{{"content":"{text}"}}}}]}}'.encode()
+
+
+def _mock_stream(gaps_and_tokens):
+    """Build a dispatch_fn whose readline yields (gap, token) pairs then closes.
+    Each ``gap`` is a real (tiny) asyncio.sleep so the watchdog measures true
+    inter-token latency — thresholds in the tests are scaled to match."""
+    seq = list(gaps_and_tokens)
+
+    async def _dispatch(payload):
+        it = iter(seq)
+
+        async def _readline():
+            try:
+                gap, tok = next(it)
+            except StopIteration:
+                return b""            # stream closed cleanly
+            if gap:
+                await asyncio.sleep(gap)
+            return _sse_token(tok)
+
+        return _readline
+
+    return _dispatch
+
+
+# ---------------------------------------------------------------------------
+# (2) Ephemeral zero-shot payload — max_tokens strictly 5.
+# ---------------------------------------------------------------------------
+
+
+async def test_probe_payload_is_minimal_and_capped() -> None:
+    payload = build_probe_payload("Qwen/Qwen3.5-397B-A17B-FP8")
+    assert payload["max_tokens"] == 5                    # hard cap — negligible spend
+    assert payload["stream"] is True                     # must exercise the SSE lane
+    # 1-word system prompt + a tiny user ping — aggressively minimal.
+    assert len(payload["messages"]) == 2
+    assert payload["messages"][0]["role"] == "system"
+    assert len(payload["messages"][0]["content"].split()) <= 2
+
+
+# ---------------------------------------------------------------------------
+# (1) Acceptable TTFT, terrible ITL → DEGRADED (override 200), swarm asleep.
+# ---------------------------------------------------------------------------
+
+
+async def test_terrible_itl_classified_degraded_keeps_swarm_asleep() -> None:
+    # TTFT fine (first token ~0), but tokens 2-5 arrive with big gaps → thrash.
+    dispatch = _mock_stream([
+        (0.0, "a"),      # first token — good TTFT
+        (0.12, "b"),     # then large inter-token gaps
+        (0.12, "c"),
+        (0.12, "d"),
+    ])
+    res = await deep_probe(
+        dispatch_fn=dispatch, ttft_bound_s=120.0,
+        itl_hard_s=8.0,      # generous hard bound → NO rupture
+        itl_safe_s=0.05,     # tight safe threshold → mean ITL 0.12 > 0.05
+    )
+    assert res.verdict == VERDICT_DEGRADED
+    assert res.healthy is False
+    assert res.mean_itl_s > 0.05
+    assert "itl_thrash" in res.reason
+
+    # The forecaster's probe_fn therefore reports "still down" → swarm asleep.
+    probe_fn = make_deep_probe_fn(
+        dispatch, ttft_bound_s=120.0, itl_hard_s=8.0, itl_safe_s=0.05,
+    )
+    assert await probe_fn() is False
+
+
+async def test_hard_itl_stall_ruptures_to_degraded() -> None:
+    # A gap that exceeds the ITL HARD bound → watchdog StreamRuptureError.
+    dispatch = _mock_stream([
+        (0.0, "a"),
+        (0.20, "b"),    # 0.20s gap > 0.05s hard bound → rupture
+    ])
+    res = await deep_probe(
+        dispatch_fn=dispatch, ttft_bound_s=120.0,
+        itl_hard_s=0.05,     # aggressive hard bound
+        itl_safe_s=2.0,
+    )
+    assert res.verdict == VERDICT_DEGRADED
+    assert "stream_rupture" in res.reason
+
+
+async def test_dispatch_fault_is_degraded_not_crash() -> None:
+    async def _boom(payload):
+        raise ConnectionResetError("DW socket reset")
+
+    res = await deep_probe(dispatch_fn=_boom, ttft_bound_s=1.0)
+    assert res.verdict == VERDICT_DEGRADED
+    assert res.healthy is False
+    assert "dispatch_error" in res.reason
+
+
+# ---------------------------------------------------------------------------
+# (3) Healthy stream → HEALTHY → forecaster awakens the swarm.
+# ---------------------------------------------------------------------------
+
+
+async def test_healthy_stream_awakens_forecaster() -> None:
+    # Fast, steady tokens — low TTFT, low ITL.
+    healthy_dispatch = _mock_stream([
+        (0.0, "o"), (0.01, "k"), (0.01, "!"), (0.01, "!"), (0.01, "!"),
+    ])
+    res = await deep_probe(
+        dispatch_fn=healthy_dispatch, ttft_bound_s=120.0,
+        itl_hard_s=8.0, itl_safe_s=0.05,
+    )
+    assert res.verdict == VERDICT_HEALTHY
+    assert res.healthy is True
+    assert res.tokens == 5
+    assert res.mean_itl_s <= 0.05
+
+    # Feed the healthy deep-probe into the forecaster's watch loop → it awakens
+    # the swarm (recovered) with a slow-start (limit 1→2) AIMD controller.
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    probe_fn = make_deep_probe_fn(
+        healthy_dispatch, ttft_bound_s=120.0, itl_hard_s=8.0, itl_safe_s=0.05,
+    )
+    clock = {"t": 0.0}
+
+    async def _sleep(s):
+        clock["t"] += s
+
+    outcome = await watch_for_recovery(
+        conn, probe_fn, now_fn=lambda: clock["t"], sleep_fn=_sleep, max_probes=3,
+    )
+    assert outcome.recovered is True
+    assert outcome.aimd.limit <= 2          # slow-start, not slammed at max
+    assert outcome.aimd.max_limit >= 1


### PR DESCRIPTION
## The correct recovery signal — inference lane, not metadata endpoint

Last run, the forecaster trusted a `GET /v1/models` 200 (stateless REST transport) as recovery — but that says the control plane answers, **not** that the GPU inference lane (direct SSE streaming) will survive a generation. The false positive woke the swarm onto a still-degraded DW. This is the correct `probe_fn`.

- **Ephemeral zero-shot payload** — 1-word system prompt + 2-char ping, `max_tokens` hard-capped at **5**, `stream=True`. Forces inference; token spend is mathematically negligible (no background bleed).
- **Stream-Integrity via ITL thresholding** — measures TTFT **and** inter-token latency across the ≤5 tokens. mean/peak ITL over the safe threshold (GPUs thrashing / stream dropping packets) → **DEGRADED, overriding a 200 OK**, so the swarm stays asleep.
- **Asymmetric timeouts** — the 120s cold-start tolerance applies **only** to the TTFT phase (397B VRAM load); every inter-token gap keeps the aggressive ITL bound. Both are the existing #70017 `watchdog_consume_sse` dual-phase bounds.

### Mandate conformance
- **Root-Cause Only** — minimal payload, `max_tokens=5`; no heavy polling / token bleed.
- **DRY** — composes `stream_watchdog.watchdog_consume_sse` / `fast_abort_response` (#70017 — **no SSE re-parse**), `stream_rupture.StreamRuptureError`, and `provider_heartbeat._resolve_dw_probe_transport`. `make_deep_probe_fn` yields the `() -> bool` `probe_fn` the #70030 forecaster injects.
- Touches no model-selection path — the **Fable model is never flagged**.

### Tests (5 passed)
`max_tokens=5` + stream; **acceptable TTFT + terrible ITL → DEGRADED overriding 200** (swarm asleep); hard-ITL stall → rupture → DEGRADED; dispatch fault → DEGRADED (no crash); **healthy stream → HEALTHY → drives `watch_for_recovery` to awaken with slow-start AIMD**.

### Result
The forecaster now has its true probe. Wiring `make_deep_probe_fn()` as `watch_for_recovery`'s `probe_fn` (+ launching with `JARVIS_AEGIS_NONSTREAM_READ_S=120`) means the definitive soak auto-triggers only on **true generation recovery** — never again on a bare `/models` 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the `/v1/models` health check with a streaming deep probe of the inference lane to prevent false recoveries. This adds a minimal SSE-based probe that measures TTFT and inter-token latency and only wakes the swarm on true generation recovery.

- **New Features**
  - Minimal zero-shot payload with `max_tokens=5` and `stream=True` to force inference with negligible spend.
  - ITL integrity: measures TTFT and inter-token latency; classifies `DEGRADED` on thrash even with HTTP 200.
  - Asymmetric timeouts: generous TTFT bound, strict ITL watchdog; uses existing `watchdog_consume_sse` and `fast_abort_response`.
  - Integrated dispatch via `provider_heartbeat._resolve_dw_probe_transport`; `make_deep_probe_fn` returns `() -> bool`.
  - Config via `JARVIS_DW_DEEP_PROBE_TTFT_S`, `JARVIS_DW_DEEP_PROBE_ITL_HARD_S`, `JARVIS_DW_DEEP_PROBE_ITL_SAFE_S`.

<sup>Written for commit 9c6269e09740b3add3d22a893736b75b89c202eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70031?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

