### PR TITLE
TSX context bundling + YAML indentation lock + extension-dispatch wire

### DIFF
--- a/backend/core/ouroboros/governance/agent_turn_adapter.py
+++ b/backend/core/ouroboros/governance/agent_turn_adapter.py
@@ -411,6 +411,14 @@ class ProductionAgentTurnFn:
             node = self._extract_node(raw or "", target)
             if not node:
                 return ""
+            # Polymorphic verify: a Python CodeChunk has no ``language`` attr →
+            # defaults to "python" (byte-identical AST gate). A polyglot Chunk
+            # (json/yaml/tsx) carries its language — its per-node output is NOT a
+            # Python function, so the whole-file structural validate at the
+            # polyglot stitch is the gate, not a Python AST parse here.
+            lang = getattr(getattr(target, "chunk", None), "language", "python")
+            if lang and lang != "python":
+                return node
             ok, _err = _verify_node_against_ast(node, target)
             return node if ok else ""
         except Exception:  # noqa: BLE001 — the drone's fault is isolated, not fatal

--- a/backend/core/ouroboros/governance/full_content_interceptor.py
+++ b/backend/core/ouroboros/governance/full_content_interceptor.py
@@ -72,6 +72,82 @@ def _enabled() -> bool:
     ).strip().lower() in ("1", "true", "yes", "on")
 
 
+_POLYGLOT_EXTS = frozenset({".json", ".yaml", ".yml", ".tsx", ".ts", ".jsx"})
+
+
+def _polyglot_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_POLYGLOT_ROUTER_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+async def _polyglot_intercept(
+    source: str,
+    file_path: str,
+    symbols: List[str],
+    agent_fn,
+    *,
+    op_id: str,
+    file_lines: int,
+    ext: str,
+    max_concurrency: Optional[int],
+) -> "InterceptResult":
+    """Route a non-Python big file through the Polyglot engine — native
+    per-language chunk/stitch/validate. Composes ``polyglot_repair`` (which
+    reuses swarm_concurrency + stitch_replacement) and adapts the swarm's
+    ``(ChunkTarget, feedback)->str`` agent to polyglot's ``(Chunk)->str``,
+    folding any TSX context header into the ChunkTarget prompt. Ghost-Edit
+    re-check parity. Never raises."""
+    from backend.core.ouroboros.governance.polyglot_chunker import (
+        ChunkerFactory,
+        build_context_bundled_target,
+        polyglot_repair,
+    )
+
+    strat = ChunkerFactory.for_file(file_path)
+    entry_disk_sha = _disk_sha(file_path)
+    record_pending_strategy(
+        op_id, strategy=f"polyglot_{strat.language}", file_lines=file_lines, ext=ext,
+    )
+
+    async def _poly_agent(chunk) -> str:
+        target = build_context_bundled_target(chunk, instruction=f"repair {chunk.name}")
+        return await agent_fn(target, "")
+
+    lock = await _lock_for(file_path)
+    async with lock:
+        result = await polyglot_repair(
+            source, file_path, list(symbols or []), _poly_agent,
+            max_concurrency=max_concurrency,
+        )
+
+    exit_disk_sha = _disk_sha(file_path)
+    if (
+        entry_disk_sha is not None
+        and exit_disk_sha is not None
+        and entry_disk_sha != exit_disk_sha
+    ):
+        logger.warning(
+            "[FullContentInterceptor] %s: GHOST EDIT during polyglot swarm — "
+            "aborting stitch, requeue op", file_path,
+        )
+        return InterceptResult(
+            strategy="aborted_drift", content=source, stitched=False,
+            drifted=True, dropped_nodes=list(symbols or []),
+        )
+
+    logger.info(
+        "[FullContentInterceptor] %s (%d lines): polyglot %s — converged=%d "
+        "dropped=%d (native chunk/stitch/validate)",
+        file_path, file_lines, strat.language, len(result.succeeded), len(result.failed),
+    )
+    return InterceptResult(
+        strategy=f"polyglot_{strat.language}", content=result.stitched,
+        stitched=bool(result.succeeded), converged_nodes=list(result.succeeded),
+        dropped_nodes=list(result.failed),
+    )
+
+
 def _disk_sha(file_path: str) -> Optional[str]:
     """Fast SHA-256 of the on-disk file, or ``None`` if it is not a readable
     real path (e.g. a synthetic/in-memory path in a test). Never raises.
@@ -124,6 +200,15 @@ async def intercept_full_content(
     if not _enabled() or not exceeds_ceiling(source):
         content = (await whole_file_fn()) if whole_file_fn else source
         return InterceptResult(strategy="whole", content=content, stitched=False)
+
+    # ── Extension-Dispatch: a non-.py big file routes to the Polyglot engine ──
+    # (.json/.yaml/.tsx/.ts) so the Python AST parser is never fed a non-Python
+    # file. Python (.py) falls through to the existing AST swarm, byte-identical.
+    if _polyglot_enabled() and ext.lower() in _POLYGLOT_EXTS:
+        return await _polyglot_intercept(
+            source, file_path, symbols, agent_fn, op_id=op_id,
+            file_lines=file_lines, ext=ext, max_concurrency=max_concurrency,
+        )
 
     # ── MASSIVE file: whole-file FORBIDDEN — build AST targets ──
     # Optimistic State Hashing (Ghost-Edit Protection): snapshot the on-disk

--- a/backend/core/ouroboros/governance/polyglot_chunker.py
+++ b/backend/core/ouroboros/governance/polyglot_chunker.py
@@ -46,7 +46,13 @@ logger = logging.getLogger("Ouroboros.PolyglotChunker")
 class Chunk:
     """Standardized chunk — duck-types the #70020 CodeChunk so the existing
     ``stitch_replacement`` (reads ``start_line`` / ``end_line``) and the swarm
-    consume it unchanged. 1-indexed inclusive line range."""
+    consume it unchanged. 1-indexed inclusive line range.
+
+    ``context_header`` — read-only context bundled by the Chunker (e.g. TSX
+    imports + relevant interfaces) so the LLM has zero prop/hook context
+    starvation. It is NOT part of the stitched region.
+    ``indent`` — the locked absolute leading-indent depth (YAML), used by the
+    strategy's ``stitch`` to normalize the LLM's whitespace before grafting."""
     start_line: int
     end_line: int
     source_code: str
@@ -54,6 +60,8 @@ class Chunk:
     qualified_name: str = ""
     file_path: str = ""
     language: str = ""
+    context_header: str = ""
+    indent: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -344,6 +352,27 @@ def _yaml_key_line_span(text: str, target_path: Sequence[str]) -> Optional[Tuple
     return (start_idx + 1, end_idx + 1)
 
 
+def _normalize_to_indent(body: str, indent: int) -> str:
+    """Indentation Lock: re-align *body* so its shallowest non-blank line sits at
+    exactly ``indent`` leading spaces, preserving RELATIVE internal indentation.
+    Mathematically guarantees the grafted block matches the locked YAML baseline
+    regardless of what leading whitespace the LLM produced (over- or under-
+    indented, tab-mixed). Never raises."""
+    lines = body.replace("\t", "  ").split("\n")
+    non_blank = [ln for ln in lines if ln.strip()]
+    if not non_blank:
+        return body
+    min_lead = min(len(ln) - len(ln.lstrip(" ")) for ln in non_blank)
+    pad = " " * max(0, int(indent))
+    out: List[str] = []
+    for ln in lines:
+        if not ln.strip():
+            out.append("")
+        else:
+            out.append(pad + ln[min_lead:])   # strip the block's own base, apply the lock
+    return "\n".join(out)
+
+
 class YAMLTreeChunker(BaseChunker):
     extensions = (".yaml", ".yml")
     language = "yaml"
@@ -354,10 +383,20 @@ class YAMLTreeChunker(BaseChunker):
             return None
         s, e = span
         lines = source.splitlines(keepends=True)
+        first = lines[s - 1] if s - 1 < len(lines) else ""
+        locked_indent = len(first) - len(first.lstrip(" "))   # absolute depth of the key
         return Chunk(
             start_line=s, end_line=e, source_code="".join(lines[s - 1:e]),
             name=target, qualified_name=target, file_path=file_path, language="yaml",
+            indent=locked_indent,
         )
+
+    def stitch(self, full_source: str, chunk: Chunk, new_body: str) -> Optional[str]:
+        """Indentation Lock at Fan-In: normalize the LLM's whitespace to the
+        stored ``chunk.indent`` BEFORE the line-based graft, so indentation drift
+        can never corrupt the global YAML tree."""
+        normalized = _normalize_to_indent(new_body, getattr(chunk, "indent", 0))
+        return super().stitch(full_source, chunk, normalized)
 
     def validate(self, text: str) -> bool:
         try:
@@ -369,6 +408,138 @@ class YAMLTreeChunker(BaseChunker):
             return True
         except Exception:  # noqa: BLE001
             return False
+
+
+# ---------------------------------------------------------------------------
+# TSX/JSX — structural scan + Semantic Context Bundling
+# ---------------------------------------------------------------------------
+
+import re as _re
+
+_TS_IMPORT_RE = _re.compile(r"^\s*import\s.+?;?\s*$", _re.MULTILINE)
+_TS_IDENT_RE = _re.compile(r"[A-Za-z_$][A-Za-z0-9_$]*")
+
+
+def _ts_definition_spans(source: str):
+    """Yield (name, start_idx, end_idx, text) for every top-level ``interface`` /
+    ``type`` / component-ish def, via brace/`;`-matched structural scan (no TS AST
+    available in-process — native line/brace scan, not regex-forcing). Never raises."""
+    out = []
+    for m in _re.finditer(
+        r"(?:export\s+)?(?:interface|type|function|const)\s+([A-Za-z_$][\w$]*)",
+        source,
+    ):
+        name = m.group(1)
+        kw = m.group(0)
+        start = m.start()
+        if "type " in kw and "=" in source[m.end(): m.end() + 200].split("\n", 1)[0]:
+            # `type X = ...;` — ends at the terminating semicolon at depth 0.
+            j = source.find("=", m.end())
+            depth = 0
+            k = j
+            while k < len(source):
+                c = source[k]
+                if c in "{[(":
+                    depth += 1
+                elif c in "}])":
+                    depth -= 1
+                elif c == ";" and depth == 0:
+                    break
+                k += 1
+            out.append((name, start, min(k + 1, len(source)), source[start:min(k + 1, len(source))]))
+        else:
+            # brace-bodied (interface/function/const-arrow-with-body).
+            brace = source.find("{", m.end())
+            if brace == -1:
+                continue
+            depth = 0
+            k = brace
+            while k < len(source):
+                c = source[k]
+                if c == "{":
+                    depth += 1
+                elif c == "}":
+                    depth -= 1
+                    if depth == 0:
+                        break
+                k += 1
+            out.append((name, start, min(k + 1, len(source)), source[start:min(k + 1, len(source))]))
+    return out
+
+
+class TSXChunker(BaseChunker):
+    extensions = (".tsx", ".jsx", ".ts")
+    language = "tsx"
+
+    def extract(self, source: str, file_path: str, target: str) -> Optional[Chunk]:
+        defs = _ts_definition_spans(source)
+        node = next((d for d in defs if d[0] == target), None)
+        if node is None:
+            return None
+        _name, start, end, node_text = node
+        lines = source.splitlines(keepends=True)
+        start_line = source.count("\n", 0, start) + 1
+        end_line = source.count("\n", 0, end - 1) + 1
+
+        # Semantic Context Bundling: imports + LOCAL interface/type defs whose
+        # names appear in the target node → zero prop/hook context starvation.
+        imports = [m.group(0).strip() for m in _TS_IMPORT_RE.finditer(source)]
+        referenced = {t for t in _TS_IDENT_RE.findall(node_text)}
+        relevant_types = [
+            text.strip() for (nm, s, e, text) in defs
+            if nm != target and nm in referenced
+            and _re.match(r"\s*(?:export\s+)?(?:interface|type)\b", text)
+        ]
+        header_parts: List[str] = []
+        if imports:
+            header_parts.append("// --- imports (read-only context) ---\n" + "\n".join(imports))
+        if relevant_types:
+            header_parts.append(
+                "// --- relevant type/interface defs (read-only context) ---\n"
+                + "\n\n".join(relevant_types)
+            )
+        context_header = "\n\n".join(header_parts)
+
+        return Chunk(
+            start_line=start_line, end_line=end_line,
+            source_code="".join(lines[start_line - 1:end_line]),
+            name=target, qualified_name=target, file_path=file_path,
+            language="tsx", context_header=context_header,
+        )
+
+    def validate(self, text: str) -> bool:
+        # No in-process TS parser — validate balanced braces/parens/brackets
+        # (the structural corruption class the stitch could introduce). Strings/
+        # comments are not fully tokenized; this is a structural sanity gate.
+        depth = {"{": 0, "(": 0, "[": 0}
+        pairs = {"}": "{", ")": "(", "]": "["}
+        for c in text:
+            if c in depth:
+                depth[c] += 1
+            elif c in pairs:
+                depth[pairs[c]] -= 1
+                if depth[pairs[c]] < 0:
+                    return False
+        return all(v == 0 for v in depth.values())
+
+
+def build_context_bundled_target(chunk: Chunk, *, instruction: str = ""):
+    """Compose the ``ChunkTarget`` the swarm consumes, folding a Chunk's
+    ``context_header`` into the ChunkTarget's ``prompt`` (read-only context) so
+    the downstream ProductionAgentTurnFn needs no change. DRY: the bundling lives
+    in the Chunker layer; the orchestrator just reads ``ChunkTarget``."""
+    from backend.core.ouroboros.governance.chunk_swarm import ChunkTarget
+    header = getattr(chunk, "context_header", "") or ""
+    prompt = ""
+    if header:
+        prompt = (
+            "READ-ONLY CONTEXT (do not modify or repeat — for reference only):\n"
+            f"{header}\n\n"
+        )
+    return ChunkTarget(
+        symbol=chunk.name, chunk=chunk,
+        instruction=instruction or f"repair {chunk.name}", prompt=prompt,
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -412,7 +583,7 @@ class RegexIndentationChunker(BaseChunker):
 
 class ChunkerFactory:
     _STRATEGIES: Tuple[BaseChunker, ...] = (
-        PythonASTChunker(), JSONTreeChunker(), YAMLTreeChunker(),
+        PythonASTChunker(), JSONTreeChunker(), YAMLTreeChunker(), TSXChunker(),
     )
     _FALLBACK = RegexIndentationChunker()
 
@@ -529,7 +700,9 @@ __all__ = [
     "PolyglotResult",
     "PythonASTChunker",
     "RegexIndentationChunker",
+    "TSXChunker",
     "YAMLTreeChunker",
+    "build_context_bundled_target",
     "polyglot_repair",
     "polymorphic_extract_target",
 ]

--- a/tests/governance/test_polyglot_chunker.py
+++ b/tests/governance/test_polyglot_chunker.py
@@ -54,10 +54,12 @@ def test_factory_routes_by_extension() -> None:
     assert isinstance(ChunkerFactory.for_file("k8s/manifest.yaml"), YAMLTreeChunker)
     assert isinstance(ChunkerFactory.for_file("deploy.yml"), YAMLTreeChunker)
     assert isinstance(ChunkerFactory.for_file("mod.py"), PythonASTChunker)
-    # Unknown → universal fallback, NOT the Python parser.
+    from backend.core.ouroboros.governance.polyglot_chunker import TSXChunker
+    assert isinstance(ChunkerFactory.for_file("app.tsx"), TSXChunker)
+    assert isinstance(ChunkerFactory.for_file("hook.ts"), TSXChunker)
+    # Truly-unknown → universal fallback, NOT the Python parser.
     assert isinstance(ChunkerFactory.for_file("README.md"), RegexIndentationChunker)
     assert isinstance(ChunkerFactory.for_file("notes.txt"), RegexIndentationChunker)
-    assert isinstance(ChunkerFactory.for_file("app.tsx"), RegexIndentationChunker)
 
 
 def test_json_does_not_crash_python_parser() -> None:
@@ -154,3 +156,120 @@ def test_text_fallback_line_range_and_anchor() -> None:
     assert c2 is not None and "delta" in c2.source_code
     # Text always validates (no grammar to corrupt).
     assert RegexIndentationChunker().validate("anything at all {[}") is True
+
+
+# ---------------------------------------------------------------------------
+# (Mandated 1) TSX Semantic Context Bundling
+# ---------------------------------------------------------------------------
+
+_TSX = '''import React, { useState } from "react";
+import { fetchUser } from "./api";
+
+interface UserCardProps {
+  userId: string;
+  compact: boolean;
+}
+
+interface Unrelated {
+  foo: number;
+}
+
+type Theme = "light" | "dark";
+
+export function UserCard(props: UserCardProps) {
+  const [open, setOpen] = useState(false);
+  const theme: Theme = "light";
+  return <div className={theme}>{props.userId}</div>;
+}
+
+export function OtherComponent() {
+  return <span>hi</span>;
+}
+'''
+
+
+async def test_tsx_bundles_target_node_and_required_interface() -> None:
+    from backend.core.ouroboros.governance.polyglot_chunker import (
+        TSXChunker,
+        build_context_bundled_target,
+    )
+
+    strat = ChunkerFactory.for_file("components/UserCard.tsx")
+    assert isinstance(strat, TSXChunker)
+
+    chunk = strat.extract(_TSX, "UserCard.tsx", "UserCard")
+    assert chunk is not None
+    # The target node itself.
+    assert "function UserCard" in chunk.source_code
+    assert 'className={theme}' in chunk.source_code
+
+    # (1) The context header bundles the imports AND the REQUIRED interface/type
+    # defs the node references (UserCardProps, Theme) — zero context starvation.
+    hdr = chunk.context_header
+    assert "interface UserCardProps" in hdr
+    assert "type Theme" in hdr
+    assert 'import React' in hdr and 'from "./api"' in hdr
+    # ...but NOT the unrelated interface the node never references.
+    assert "Unrelated" not in hdr
+
+    # The ChunkTarget the swarm consumes carries BOTH node + context (read-only).
+    target = build_context_bundled_target(chunk, instruction="fix UserCard")
+    assert "UserCardProps" in target.prompt          # required interface present
+    assert "READ-ONLY CONTEXT" in target.prompt
+    assert target.chunk.source_code == chunk.source_code
+
+
+# ---------------------------------------------------------------------------
+# (Mandated 2) YAML Indentation Lock at Fan-In
+# ---------------------------------------------------------------------------
+
+
+async def test_yaml_indentation_lock_normalizes_llm_whitespace() -> None:
+    from backend.core.ouroboros.governance.polyglot_chunker import YAMLTreeChunker
+
+    yaml_src = (
+        "root:\n"
+        "  services:\n"
+        "    web:\n"
+        "      image: nginx\n"
+        "      port: 8080\n"
+        "  other:\n"
+        "    keep: true\n"
+    )
+    strat = YAMLTreeChunker()
+    # Deeply nested target at absolute indent 6.
+    chunk = strat.extract(yaml_src, "compose.yaml", "root.services.web.port")
+    assert chunk is not None
+    assert chunk.indent == 6                       # locked baseline captured
+
+    # The "LLM" returns the fix with WRONG leading whitespace (0-indented).
+    llm_body = "port: 9090"
+    stitched = strat.stitch(yaml_src, chunk, llm_body)
+    assert stitched is not None
+
+    # Indentation Lock normalized it to EXACTLY 6 spaces before grafting.
+    assert "      port: 9090\n" in stitched
+    assert "    port: 9090" not in stitched.replace("      port", "")  # no wrong depth
+
+    # The global YAML tree is intact + valid.
+    try:
+        import yaml
+        parsed = yaml.safe_load(stitched)
+        assert parsed["root"]["services"]["web"]["port"] == 9090
+        assert parsed["root"]["services"]["web"]["image"] == "nginx"
+        assert parsed["root"]["other"]["keep"] is True
+    except ImportError:
+        assert strat.validate(stitched) is True
+
+
+async def test_yaml_lock_handles_over_indented_multiline_block() -> None:
+    from backend.core.ouroboros.governance.polyglot_chunker import _normalize_to_indent
+
+    # A multi-line block the LLM over-indented by 10 spaces — relative structure
+    # must survive, absolute baseline re-locked to 4.
+    over = "          web:\n            image: nginx\n            port: 80"
+    normalized = _normalize_to_indent(over, 4)
+    lines = normalized.split("\n")
+    assert lines[0] == "    web:"                  # baseline locked to 4
+    assert lines[1] == "      image: nginx"        # relative +2 preserved
+    assert lines[2] == "      port: 80"


### PR DESCRIPTION
## Finalizes the polyglot engine — TSX/JSX + YAML strategies + the router wire

- **`TSXChunker` (Semantic Context Bundling)** — a structural brace/`;`-matched scan locates the target node **and** bundles its imports + the local `interface`/`type` defs it references into `chunk.context_header` (a read-only block folded into `ChunkTarget.prompt`), so the LLM has **zero prop/hook context starvation**. Unreferenced interfaces are not dragged in.
- **`YAMLTreeChunker` (Indentation Lock)** — `extract` stores the target's absolute leading-indent depth (`chunk.indent`); the overridden `stitch` runs `_normalize_to_indent` on the LLM string at Fan-In, re-aligning its shallowest non-blank line to the locked baseline while **preserving relative internal indentation** — *before* the graft. Indentation drift can never corrupt the global YAML tree.
- **Extension-Dispatch** — `intercept_full_content` routes `.json`/`.yaml`/`.tsx`/`.ts` big files to `_polyglot_intercept` → `polyglot_repair` (Ghost-Edit re-check parity; adapts the swarm's `(ChunkTarget,feedback)->str` agent to polyglot's `(Chunk)->str`). **`.py` falls through to the existing AST swarm byte-identical.** Master `JARVIS_POLYGLOT_ROUTER_ENABLED` default-true.
- **`ProductionAgentTurnFn` polymorphic verify** — a Python `CodeChunk` (no `language` attr → `"python"`) keeps the AST gate byte-identical; a polyglot `Chunk` skips the per-node Python AST parse (its output isn't a Python function — the whole-file structural validate at the polyglot stitch is the gate). The only orchestrator touch, guarded Python-byte-identical.

### Mandate conformance
- **Root-Cause Only** — native per-language extraction/stitch; the indentation lock solves whitespace drift *mathematically* in the stitch phase; the TSX bundle solves context starvation in the extraction phase.
- **DRY** — context bundles + indentation locks live entirely in the Chunker classes; the standardized `Chunk` keeps `ProductionAgentTurnFn` / stitch / AIMD concurrency untouched. Fable never flagged.

### Tests (9 polyglot + 22 regression = 31 passed)
**(1)** TSX bundles the target node **and** its required `interface`/`type` (`UserCardProps`/`Theme`), excludes the unrelated one. **(2)** YAML lock normalizes a 0-indented *and* a 10-over-indented LLM string to the locked baseline with relative structure preserved, tree valid. Plus factory routes `.tsx`/`.ts`→TSX; existing interceptor + agent-adapter suites green (Python byte-identical).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds TSX/JSX and YAML support to the polyglot engine with context bundling and indentation lock, and routes big files by extension through the polyglot path. Python files remain byte-identical; this prevents YAML drift and TSX context starvation.

- **New Features**
  - `TSXChunker`: structural scan finds the target and bundles imports + referenced `interface`/`type` into `chunk.context_header`.
  - `YAMLTreeChunker`: stores absolute indent in `chunk.indent` and normalizes with `_normalize_to_indent` before stitch.
  - Extension dispatch in `intercept_full_content`: routes `.json/.yaml/.yml/.tsx/.ts/.jsx` to `_polyglot_intercept` → `polyglot_repair`; `.py` uses the existing AST path.
  - Polymorphic verify in `agent_turn_adapter`: skip Python AST verification for non-`python` chunks.

- **Migration**
  - Polyglot routing is on by default via `JARVIS_POLYGLOT_ROUTER_ENABLED=true`; set to `false` to disable.
  - No agent changes needed; `build_context_bundled_target` adds read‑only context automatically.

<sup>Written for commit 132032f0ce5e8732a1b40ed93133f0d36e2d6f35. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70036?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

