### PR TITLE
Rolling VFS + Sequential Compilation Lock — indestructible Fan-In

### DIFF
--- a/backend/core/ouroboros/governance/agentic_super_agent.py
+++ b/backend/core/ouroboros/governance/agentic_super_agent.py
@@ -28,6 +28,7 @@ Pure asyncio (no threads/processes); env-driven; never raises on the hot path.
 from __future__ import annotations
 
 import ast
+import inspect
 import logging
 import os
 from dataclasses import dataclass, field
@@ -134,22 +135,42 @@ async def run_agentic_repair(
             continue
         # (1) In-memory Syntax Pre-Compiler at the seam: trial-graft + whole-file
         # validate BEFORE anything reaches disk. A fracture routes a
-        # StitchCollisionError observation back for self-correction.
+        # StitchCollisionError (or RebaseCollisionError under the Rolling VFS)
+        # observation back for self-correction. The validator may be async (the
+        # Rolling VFS acquires the Sequential Compilation Lock).
         if seam_validator is not None:
             seam_err = seam_validator(node)
+            if inspect.isawaitable(seam_err):
+                seam_err = await seam_err
             if seam_err:
-                last_error = f"StitchCollisionError: {seam_err}"
+                # Preserve a pre-labeled error class (Rebase/Stitch); else label it.
+                last_error = (
+                    seam_err if seam_err.startswith(
+                        ("RebaseCollisionError", "StitchCollisionError")
+                    ) else f"StitchCollisionError: {seam_err}"
+                )
                 feedback = (
-                    f"REFINE (turn {turn}): StitchCollisionError — your node is "
-                    f"valid alone but BREAKS the file when grafted at the seam: "
-                    f"{seam_err}. Return ONLY the corrected complete function so "
-                    f"the WHOLE file parses after insertion."
+                    f"REFINE (turn {turn}): {last_error}. Your node broke the file "
+                    f"when grafted at the seam — return ONLY the corrected complete "
+                    f"definition so the WHOLE file parses after insertion."
                 )
                 logger.warning(
                     "[AgenticSuperAgent] %s turn %d SEAM FRACTURE: %s — refining "
-                    "(disk write blocked)", target.symbol, turn, seam_err,
+                    "(disk write blocked)", target.symbol, turn, last_error,
                 )
                 continue
+        # Local AST symbol check — Python only. A polyglot node (json/yaml/tsx)
+        # is not a Python function; its whole-file structural validate at the
+        # seam is the gate (mirrors the ProductionAgentTurnFn polymorphic verify).
+        _lang = getattr(getattr(target, "chunk", None), "language", "python")
+        if _lang and _lang != "python":
+            logger.info(
+                "[AgenticSuperAgent] %s CONVERGED in %d turn(s) (%s)",
+                target.symbol, turn, _lang,
+            )
+            return AgentOutcome(
+                symbol=target.symbol, status=STATUS_CONVERGED, node=node, turns=turn,
+            )
         ok, err = _verify_node_against_ast(node, target)
         if ok:
             logger.info(
@@ -199,18 +220,18 @@ async def swarm_agentic_repair(
     descending-line atomic fan-in). An agent that returns ``agent_unconverged``
     yields an empty node, so the swarm records it ``failed`` and leaves the file
     untouched at that node — the atomic invariant holds. Never raises."""
-    from backend.core.ouroboros.governance.stitch_precompiler import (
-        make_seam_validator,
-    )
+    from backend.core.ouroboros.governance.stitch_precompiler import RollingVFS
+
+    # ONE Rolling VFS shared across all agents: the Sequential Compilation Lock
+    # serializes the heavy in-memory parse (memory bounding under extreme
+    # map-reduce) while each agent rebases its graft onto the prior agents'
+    # committed state (cross-agent semantic collision → RebaseCollisionError).
+    vfs = RollingVFS(full_source, file_path)
 
     async def _agentic_generate(target: ChunkTarget) -> str:
-        # In-memory Syntax Pre-Compiler: each turn's node is trial-grafted into
-        # the real full_source and precompiled BEFORE acceptance, so a seam
-        # fracture is caught + fed back (StitchCollisionError) and never reaches
-        # the real stitch / disk.
-        seam = make_seam_validator(full_source, file_path, target.chunk)
         outcome = await run_agentic_repair(
-            target, agent_fn, max_turns=max_turns, seam_validator=seam,
+            target, agent_fn, max_turns=max_turns,
+            seam_validator=vfs.seam_validator_for(target.symbol),
         )
         # Empty string → swarm marks this node failed (unconverged); a converged
         # node flows into the atomic descending-line stitch.

--- a/backend/core/ouroboros/governance/stitch_precompiler.py
+++ b/backend/core/ouroboros/governance/stitch_precompiler.py
@@ -25,8 +25,9 @@ reported, not thrown).
 
 from __future__ import annotations
 
+import asyncio
 import logging
-from typing import Callable, Optional
+from typing import Awaitable, Callable, List, Optional
 
 logger = logging.getLogger("Ouroboros.StitchPrecompiler")
 
@@ -44,6 +45,13 @@ class StitchCollisionError(Exception):
         self.language = language
         self.lineno = lineno
         super().__init__(f"StitchCollisionError[{language or '?'}]: {detail}")
+
+
+class RebaseCollisionError(StitchCollisionError):
+    """A node that is valid against the ORIGINAL source fractures the file when
+    combined with a PRIOR agent's committed graft (cross-agent semantic
+    collision). Routed back so the agent self-corrects against the REBASED
+    buffer — the same feedback bus as StitchCollisionError, one kind deeper."""
 
 
 def precompile_detail(text: str, file_path: str) -> Optional[str]:
@@ -92,7 +100,140 @@ def make_seam_validator(
     return _validate
 
 
+def _python_name_ok(node: str, symbol: str) -> bool:
+    """Cheap Python identity check: the node defines a function named after the
+    symbol's tail. Non-fatal — True on any trouble. Reuses the agentic verifier."""
+    try:
+        from backend.core.ouroboros.governance.agentic_super_agent import (
+            _verify_node_against_ast,
+        )
+        stub = type("_T", (), {"symbol": symbol})()
+        ok, _ = _verify_node_against_ast(node, stub)
+        return bool(ok)
+    except Exception:  # noqa: BLE001
+        return True
+
+
+class RollingVFS:
+    """Rolling Virtual File System — the memory-bounded, rebasing Fan-In buffer.
+
+    During an extreme map-reduce Fan-In, N sub-agents' DW calls fan OUT in
+    parallel, but their heavy in-memory ``ast.parse`` + string allocations must
+    NOT run concurrently (parallel AST bloat is the host-OOM root cause). This
+    serializes every graft-and-validate behind ONE ``asyncio.Lock`` (the
+    Sequential Compilation Lock) AND maintains a single mutating in-memory buffer:
+
+      * Each agent, on passing the lock, has its candidate node RE-EXTRACTED from
+        the CURRENT (rolling) buffer — line-drift-aware — trial-grafted, and the
+        WHOLE precompiled. On success the graft is COMMITTED, establishing the
+        new base state the next agent rebases onto.
+      * If a node is valid against the ORIGINAL source but fractures the CURRENT
+        buffer (a prior agent changed the shared context), it is rejected with a
+        ``RebaseCollisionError`` — forcing self-correction against the rebased
+        text. A node broken in isolation is a plain ``StitchCollisionError``.
+
+    Never writes to disk (the buffer is a pure string). Never raises."""
+
+    def __init__(self, source: str, file_path: str) -> None:
+        self._original = source
+        self._buffer = source
+        self._file_path = file_path
+        self._lock = asyncio.Lock()          # Sequential Compilation Lock
+        self._committed: List[str] = []
+        self._active = 0
+        self._max_active = 0
+
+    @property
+    def buffer(self) -> str:
+        return self._buffer
+
+    @property
+    def committed(self) -> List[str]:
+        return list(self._committed)
+
+    @property
+    def max_concurrent_validations(self) -> int:
+        """Peak agents inside the compile lock at once — MUST stay 1 (proof the
+        heavy parse never ran in parallel)."""
+        return self._max_active
+
+    def seam_validator_for(self, symbol: str) -> Callable[[str], Awaitable[Optional[str]]]:
+        """Return the async seam validator bound to *symbol* and THIS rolling
+        buffer — drop-in for ``run_agentic_repair``'s ``seam_validator`` hook."""
+        async def _validate(node: str) -> Optional[str]:
+            from backend.core.ouroboros.governance.chunked_generation import (
+                stitch_replacement,
+            )
+            from backend.core.ouroboros.governance.polyglot_chunker import (
+                polymorphic_extract_target,
+            )
+            if not node or not node.strip():
+                return "StitchCollisionError: empty node — return the complete definition"
+            async with self._lock:                 # ── serialized heavy parse ──
+                self._active += 1
+                self._max_active = max(self._max_active, self._active)
+                try:
+                    await asyncio.sleep(0)          # yield: expose any lock breach
+                    chunk = polymorphic_extract_target(self._buffer, self._file_path, symbol)
+                    if chunk is None:
+                        return (
+                            f"RebaseCollisionError (prior agent modified context): "
+                            f"symbol '{symbol}' is no longer resolvable in the rolling "
+                            f"buffer — a prior graft removed or renamed it."
+                        )
+                    candidate = stitch_replacement(self._buffer, chunk, node)
+                    if candidate is None:
+                        return (
+                            "RebaseCollisionError (prior agent modified context): "
+                            "graft out-of-range after rebase."
+                        )
+                    # Structural precompile FIRST — the real syntax detail. Was this
+                    # node fine against the ORIGINAL source? If so the fracture is a
+                    # PRIOR agent's doing → RebaseCollisionError; else StitchCollision.
+                    detail = precompile_detail(candidate, self._file_path)
+                    if detail:
+                        label = (
+                            "RebaseCollisionError (prior agent modified context)"
+                            if self._valid_against_original(symbol, node)
+                            else "StitchCollisionError"
+                        )
+                        return f"{label}: {detail}"
+                    # It parses — now the Python symbol-identity check.
+                    language = getattr(chunk, "language", "python")
+                    if language == "python" and not _python_name_ok(node, symbol):
+                        return (
+                            f"StitchCollisionError: node parses but does not define "
+                            f"'{symbol.split('.')[-1]}'"
+                        )
+                    # ── COMMIT — new base state for the next agent to rebase on ──
+                    self._buffer = candidate
+                    self._committed.append(symbol)
+                    return None
+                finally:
+                    self._active -= 1
+
+        return _validate
+
+    def _valid_against_original(self, symbol: str, node: str) -> bool:
+        try:
+            from backend.core.ouroboros.governance.chunked_generation import (
+                stitch_replacement,
+            )
+            from backend.core.ouroboros.governance.polyglot_chunker import (
+                polymorphic_extract_target,
+            )
+            oc = polymorphic_extract_target(self._original, self._file_path, symbol)
+            if oc is None:
+                return False
+            cand = stitch_replacement(self._original, oc, node)
+            return cand is not None and precompile_detail(cand, self._file_path) is None
+        except Exception:  # noqa: BLE001
+            return False
+
+
 __all__ = [
+    "RebaseCollisionError",
+    "RollingVFS",
     "StitchCollisionError",
     "make_seam_validator",
     "precompile_detail",

--- a/tests/governance/test_rolling_vfs.py
+++ b/tests/governance/test_rolling_vfs.py
@@ -1,0 +1,141 @@
+"""Rolling VFS + Sequential Compilation Lock — indestructible Fan-In.
+
+Mandated bulletproof: two concurrent agents return payloads simultaneously.
+Assert (1) the asyncio.Lock forces sequential parsing, (2) Agent 1 updates the
+Rolling Buffer, (3) Agent 2's payload fails syntax ONLY when combined with Agent
+1's update, and (4) Agent 2 receives RebaseCollisionError and self-corrects.
+
+Plus: the lock caps concurrent validations at 1 under true contention; a clean
+node commits and rebases the buffer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import pytest
+
+from backend.core.ouroboros.governance.agentic_super_agent import (
+    STATUS_CONVERGED,
+    run_agentic_repair,
+)
+from backend.core.ouroboros.governance.chunk_swarm import ChunkTarget
+from backend.core.ouroboros.governance.polyglot_chunker import (
+    polymorphic_extract_target,
+)
+from backend.core.ouroboros.governance.stitch_precompiler import RollingVFS
+
+# A nested JSON config; agent A edits the parent object, agent B edits a child.
+_JSON = '{\n  "config": {\n    "beta": 2\n  }\n}\n'
+
+
+def _target(source: str, symbol: str) -> ChunkTarget:
+    chunk = polymorphic_extract_target(source, "config.json", symbol)
+    assert chunk is not None, symbol
+    return ChunkTarget(symbol=symbol, chunk=chunk, instruction=f"repair {symbol}")
+
+
+async def test_rolling_vfs_rebase_collision_and_sequential_lock() -> None:
+    vfs = RollingVFS(_JSON, "config.json")
+    a_committed = asyncio.Event()
+
+    # Agent A (config): rewrite the parent object, appending an "added" key AFTER
+    # beta — which forces beta to need a trailing comma it did not need before.
+    async def agent_a(target, feedback):
+        return '"config": {\n    "beta": 2,\n    "added": 9\n  }'
+
+    b_feedbacks = []
+    b_turn = {"n": 0}
+
+    # Agent B (config.beta): waits until A has committed, then submits a node that
+    # is VALID against the original (beta was the last key → no comma) but BREAKS
+    # once A's "added" key follows it. Self-corrects with the comma on turn 2.
+    async def agent_b(target, feedback):
+        b_feedbacks.append(feedback)
+        await a_committed.wait()
+        b_turn["n"] += 1
+        if b_turn["n"] == 1:
+            return '"beta": 2'         # no comma → fractures ONLY after A's update
+        return '"beta": 22,'           # rebased fix: trailing comma restored
+
+    async def run_a():
+        r = await run_agentic_repair(
+            _target(_JSON, "config"), agent_a, max_turns=3,
+            seam_validator=vfs.seam_validator_for("config"),
+        )
+        a_committed.set()              # signal AFTER A's graft is committed
+        return r
+
+    res_a, res_b = await asyncio.gather(
+        run_a(),
+        run_agentic_repair(
+            _target(_JSON, "config.beta"), agent_b, max_turns=4,
+            seam_validator=vfs.seam_validator_for("config.beta"),
+        ),
+    )
+
+    # (1) The heavy parse never ran in parallel — the compile lock held.
+    assert vfs.max_concurrent_validations == 1
+
+    # (2) Agent 1 successfully updated the Rolling Buffer.
+    assert res_a.status == STATUS_CONVERGED
+    assert '"added": 9' in vfs.buffer
+
+    # (3)+(4) Agent 2's first payload fractured ONLY in combination with A's
+    # update, and it received a RebaseCollisionError → self-corrected on turn 2.
+    assert b_turn["n"] == 2
+    assert any("RebaseCollisionError" in (f or "") for f in b_feedbacks)
+    assert res_b.status == STATUS_CONVERGED
+
+    # The rebased buffer is valid JSON carrying BOTH agents' changes.
+    parsed = json.loads(vfs.buffer)
+    assert parsed["config"]["beta"] == 22
+    assert parsed["config"]["added"] == 9
+
+
+async def test_rebase_error_only_when_combined_not_in_isolation() -> None:
+    # Prove the discriminator: the SAME node ('"beta": 2', no comma) is CLEAN
+    # against the original buffer but a RebaseCollision against A's updated one.
+    vfs = RollingVFS(_JSON, "config.json")
+    seam_beta = vfs.seam_validator_for("config.beta")
+
+    # Against the pristine buffer, the comma-less node is fine (beta is last key).
+    assert await seam_beta('"beta": 2') is None
+
+    # Reset + apply A first, THEN the same node collides.
+    vfs2 = RollingVFS(_JSON, "config.json")
+    assert await vfs2.seam_validator_for("config")(
+        '"config": {\n    "beta": 2,\n    "added": 9\n  }'
+    ) is None
+    err = await vfs2.seam_validator_for("config.beta")('"beta": 2')
+    assert err is not None
+    assert "RebaseCollisionError" in err
+
+
+async def test_lock_caps_concurrent_validations_under_contention() -> None:
+    # Two agents hit the lock simultaneously (no event gating). The lock + the
+    # yield inside it would let a SECOND coroutine in if the lock were absent;
+    # with the lock, peak concurrency is exactly 1.
+    vfs = RollingVFS(_JSON, "config.json")
+
+    async def clean(target, feedback):
+        return '"beta": 2'   # valid against pristine buffer
+
+    # Only ONE can actually commit config.beta cleanly; the point here is the
+    # lock — run two validations of the SAME symbol concurrently.
+    seam = vfs.seam_validator_for("config.beta")
+    await asyncio.gather(seam('"beta": 2'), seam('"beta": 2'))
+    assert vfs.max_concurrent_validations == 1
+
+
+async def test_symbol_removed_by_prior_agent_is_rebase_collision() -> None:
+    vfs = RollingVFS(_JSON, "config.json")
+    # A rewrites config WITHOUT beta (removes the child entirely).
+    assert await vfs.seam_validator_for("config")(
+        '"config": {\n    "gamma": 3\n  }'
+    ) is None
+    # B can no longer resolve config.beta → RebaseCollisionError.
+    err = await vfs.seam_validator_for("config.beta")('"beta": 2,')
+    assert err is not None and "RebaseCollisionError" in err
+    assert "no longer resolvable" in err


### PR DESCRIPTION
## Securing Fan-In against the concurrency/OOM trap

N sub-agents' DW calls fan **out** in parallel, but their heavy in-memory `ast.parse` + string allocations must **not** run concurrently (parallel AST bloat is the host-OOM root cause), **and** each node must validate against the *accumulating* result, not the static original.

- **`RollingVFS`** — one shared mutating in-memory buffer + **one `asyncio.Lock`** (the Sequential Compilation Lock). Each agent's node, on passing the lock, is **re-extracted from the current buffer** (line-drift-aware), trial-grafted, and the **whole** precompiled; on success it **commits** — the new base state the next agent rebases onto. `max_concurrent_validations` proves peak in-lock concurrency stays **1**.
- **Cross-Agent Semantic Collision** — a node valid against the **original** source that fractures the **current** buffer (a prior agent changed shared context) is rejected with `RebaseCollisionError` (subclass of `StitchCollisionError` — same feedback bus, one kind deeper), forcing self-correction against the rebased text. A node broken in isolation stays a plain `StitchCollisionError`. A symbol a prior agent removed → `RebaseCollisionError` "no longer resolvable".
- **`run_agentic_repair`** — the `seam_validator` hook now awaits async validators (the VFS holds the lock); the Python symbol-check is skipped for polyglot chunks; pre-labeled error classes preserved.
- **`swarm_agentic_repair`** — builds **one** `RollingVFS` shared across all agents (replaces the per-agent static seam validator), so grafts rebase onto each other.

### Mandate conformance
- **Root-Cause Only** — the heavy parse is strictly serialized behind one lock; network fan-out stays parallel.
- **DRY** — augments the #70025 atomic per-file lock model; reuses `stitch_replacement` + `ChunkerFactory` + the #70026 `StitchCollisionError` feedback bus (extended for Rebase). Fable never flagged.

### Tests (4 + 36 regression = 40 passed)
Two concurrent agents: **(1)** the `asyncio.Lock` forces sequential parsing (`max_concurrent==1`); **(2)** Agent 1 updates the rolling buffer; **(3)** Agent 2's comma-less node is **clean against the original** but a `RebaseCollision` once Agent 1 appends a following key; **(4)** Agent 2 receives `RebaseCollisionError` and self-corrects (turn 2), final buffer valid JSON with both changes. Plus the discriminator (same node clean-then-colliding), lock-under-contention, and symbol-removed rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a shared Rolling VFS with a single sequential compile lock to serialize in‑memory parsing and validate nodes against the current buffer, preventing OOM and cross‑agent breaks. Introduces `RebaseCollisionError` and wires the shared VFS into the swarm for rebased grafts.

- **New Features**
  - `RollingVFS`: one mutable in‑memory buffer with a single `asyncio.Lock`; trial‑graft, whole‑file precompile, then commit on success.
  - Cross‑agent semantic collisions return `RebaseCollisionError` (subclass of `StitchCollisionError`) when a node is valid against the original but breaks after a prior commit.
  - `swarm_agentic_repair` uses one shared `RollingVFS`; agents rebase onto accumulated changes.
  - Tests cover lock serialization (peak in‑lock concurrency == 1), rebase collisions, and symbol removal cases.

- **Refactors**
  - `run_agentic_repair` now awaits async seam validators, preserves labeled errors, and skips Python symbol checks for non‑Python chunks.
  - Replaces per‑agent `make_seam_validator` with `RollingVFS.seam_validator_for` per symbol.

<sup>Written for commit 77bce525fb10254a072a5d772a12e7c5c9b00ce3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70038?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

