### PR TITLE
Sub-Agent Trans-Provider Re-Router + Post-Soak Verification Circuit

### DIFF
--- a/backend/core/ouroboros/governance/post_soak_verification.py
+++ b/backend/core/ouroboros/governance/post_soak_verification.py
@@ -1,0 +1,190 @@
+"""Post-Soak Verification Circuit — the gate before promotion.
+
+After the Fan-In/Stitch phase produces the modified file (in memory), this
+automated post-flight circuit runs THREE checks before the op is declared ready
+for promotion:
+
+  1. **Zero-regression AST structural check** — the polymorphic in-memory
+     precompiler (Python ``ast.parse`` / JSON / YAML / bracket-balance). A
+     structurally-broken stitch never promotes.
+  2. **Git index integrity** — a READ-ONLY confirmation that ``.git/index`` is in
+     the expected clean state (no unexpected STAGED changes; the swarm produces a
+     string, it never stages). Read-only by construction — the circuit holds no
+     git-mutation privilege (per the #70033 Single-Writer discipline).
+  3. **Trace flush** — the complete ``swarm_trace.jsonl`` telemetry is folded
+     into SQLite (the same ``.jarvis/chunk_strategy.db`` substrate the
+     StrategyOutcomeLogger uses) so the run is auditable post-hoc.
+
+DRY: composes ``stitch_precompiler.precompile_detail`` + the #70021 SQLite
+substrate. Never raises — a check that cannot run reports, it does not throw.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import sqlite3
+from dataclasses import dataclass, field
+from typing import Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.PostSoakVerification")
+
+_TRACE_FLUSH_TABLE = "swarm_trace_flush"
+
+# git_status_fn() -> list of porcelain lines, e.g. [" M path", "?? path", "M  staged"]
+GitStatusFn = Callable[[], List[str]]
+
+
+@dataclass
+class VerificationResult:
+    ready_for_promotion: bool
+    ast_ok: bool
+    git_clean: bool
+    trace_flushed: bool
+    reasons: List[str] = field(default_factory=list)
+    trace_records: int = 0
+
+
+def _default_git_porcelain() -> List[str]:
+    """READ-ONLY ``git status --porcelain`` — never mutates the index. Empty on
+    any failure (fail-open on the read; the AST check is the hard gate)."""
+    import subprocess  # local: this module holds no mutation privilege
+    try:
+        out = subprocess.run(
+            ["git", "status", "--porcelain"],
+            capture_output=True, text=True, timeout=15, check=False,
+        )
+        return [ln for ln in out.stdout.splitlines() if ln.strip()]
+    except Exception:  # noqa: BLE001
+        return []
+
+
+def _verify_git_index_clean(
+    git_status_fn: GitStatusFn, file_path: str, allowed_dirty: Optional[List[str]],
+) -> tuple:
+    """The ``.git/index`` must carry NO unexpected STAGED entry — the swarm
+    produces a string and never stages. A working-tree modification to the target
+    file is expected; a STAGED change to anything unexpected fails. Never raises."""
+    try:
+        lines = git_status_fn()
+    except Exception:  # noqa: BLE001
+        return True, ""   # cannot read → do not block on the git check
+    allowed = set(allowed_dirty or [])
+    allowed.add(file_path)
+    allowed.add(os.path.basename(file_path or ""))
+    for ln in lines:
+        if len(ln) < 3:
+            continue
+        index_col, path = ln[0], ln[3:].strip()
+        # index_col ' ' = unmodified index, '?' = untracked; anything else = STAGED.
+        if index_col not in (" ", "?") and path not in allowed:
+            return False, f"git_index_dirty: unexpected staged change '{ln.strip()}'"
+    return True, ""
+
+
+def _ensure_flush_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_TRACE_FLUSH_TABLE} ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "file_path TEXT, records INTEGER, fan_out INTEGER, fan_in INTEGER, "
+        "converged INTEGER, ast_ok INTEGER, git_clean INTEGER, ready INTEGER, "
+        "flushed_wall TEXT)"
+    )
+    conn.commit()
+
+
+def _flush_trace(
+    trace_path: Optional[str], conn: Optional[sqlite3.Connection],
+    file_path: str, *, ast_ok: bool, git_clean: bool, ready: bool,
+    reasons: List[str],
+) -> tuple:
+    """Fold swarm_trace.jsonl into SQLite. Returns (flushed_bool, record_count)."""
+    if conn is None:
+        return False, 0
+    records: List[dict] = []
+    if trace_path and os.path.exists(trace_path):
+        try:
+            with open(trace_path, encoding="utf-8") as fh:
+                for line in fh:
+                    line = line.strip()
+                    if line:
+                        try:
+                            records.append(json.loads(line))
+                        except ValueError:
+                            continue
+        except OSError:
+            pass
+    fan_out = sum(1 for r in records if r.get("phase") == "fan_out")
+    fan_in = sum(1 for r in records if r.get("phase") == "fan_in")
+    converged = sum(1 for r in records if r.get("phase") == "fan_in" and r.get("converged"))
+    try:
+        _ensure_flush_table(conn)
+        import time
+        conn.execute(
+            f"INSERT INTO {_TRACE_FLUSH_TABLE} "
+            f"(file_path, records, fan_out, fan_in, converged, ast_ok, git_clean, "
+            f"ready, flushed_wall) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            (file_path, len(records), fan_out, fan_in, converged,
+             int(ast_ok), int(git_clean), int(ready),
+             time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime())),
+        )
+        conn.commit()
+        return True, len(records)
+    except sqlite3.Error:
+        reasons.append("trace_flush_failed")
+        return False, len(records)
+
+
+async def post_soak_verify(
+    *,
+    file_path: str,
+    stitched_content: str,
+    trace_path: Optional[str] = None,
+    sqlite_conn: Optional[sqlite3.Connection] = None,
+    git_status_fn: Optional[GitStatusFn] = None,
+    allowed_dirty: Optional[List[str]] = None,
+) -> VerificationResult:
+    """Run the three-check circuit. ``ready_for_promotion`` is True iff the AST
+    structural check AND the git-index check pass; the trace flush is telemetry
+    (its failure is recorded but does not block promotion). Never raises."""
+    from backend.core.ouroboros.governance.stitch_precompiler import precompile_detail
+
+    reasons: List[str] = []
+
+    # (1) Zero-regression AST structural check.
+    detail = precompile_detail(stitched_content, file_path)
+    ast_ok = detail is None
+    if not ast_ok:
+        reasons.append(f"ast_regression: {detail}")
+
+    # (2) Git index integrity (READ-ONLY).
+    git_clean, git_reason = _verify_git_index_clean(
+        git_status_fn or _default_git_porcelain, file_path, allowed_dirty,
+    )
+    if not git_clean:
+        reasons.append(git_reason)
+
+    ready = ast_ok and git_clean
+
+    # (3) Flush the swarm trace to SQLite (telemetry — never a gate).
+    trace_flushed, n_records = _flush_trace(
+        trace_path, sqlite_conn, file_path,
+        ast_ok=ast_ok, git_clean=git_clean, ready=ready, reasons=reasons,
+    )
+
+    logger.info(
+        "[PostSoakVerify] %s: ast_ok=%s git_clean=%s trace_flushed=%s(%d) ready=%s %s",
+        file_path, ast_ok, git_clean, trace_flushed, n_records, ready,
+        ("reasons=" + "; ".join(reasons)) if reasons else "",
+    )
+    return VerificationResult(
+        ready_for_promotion=ready, ast_ok=ast_ok, git_clean=git_clean,
+        trace_flushed=trace_flushed, reasons=reasons, trace_records=n_records,
+    )
+
+
+__all__ = [
+    "VerificationResult",
+    "post_soak_verify",
+]

--- a/backend/core/ouroboros/governance/trans_provider_rerouter.py
+++ b/backend/core/ouroboros/governance/trans_provider_rerouter.py
@@ -1,0 +1,120 @@
+"""Sub-Agent Trans-Provider Re-Router — isolate worker failure boundaries.
+
+A 4-agent Swarm must NOT die because ONE sub-agent's provider degrades mid-flight.
+The root cause of multi-agent fragility is FATE-SHARING across independent worker
+tasks: a ``StreamRuptureError`` propagating out of one agent aborts the whole
+``asyncio.gather``. This wraps each sub-agent's ``agent_fn`` so that a mid-ReAct
+transport collapse re-routes ONLY that agent's payload to the fallback provider
+tier — the completed work of sibling agents is preserved.
+
+  * A ``StreamRuptureError`` (or a DEGRADED-class transport fault) from the
+    PRIMARY tier trips a re-route to the FALLBACK tier for THAT symbol only.
+  * The re-route is STICKY per symbol: once an agent has fallen back, its
+    remaining ReAct turns go straight to the fallback (no repeated primary
+    burns on a known-degraded lane).
+  * A non-transport error propagates unchanged (the ReAct loop's own handling).
+
+DRY: consumes the fallback ``agent_fn`` the caller resolves from the existing
+``FailoverLifecycle`` matrix (#70016 DW → J-Prime → Claude) — it does NOT
+duplicate failover STATE, only routes onto the already-resolved tier. Per-symbol
+isolation means one shared instance safely serves every agent in the swarm.
+Never raises except to re-propagate a genuinely non-transport fault.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Awaitable, Callable, List, Optional, Set, Tuple
+
+from backend.core.ouroboros.governance.stream_rupture import StreamRuptureError
+
+logger = logging.getLogger("Ouroboros.TransProviderReRouter")
+
+# agent_fn(target, feedback) -> Awaitable[str]
+AgentFn = Callable[..., Awaitable[str]]
+DegradedPredicate = Callable[[BaseException], bool]
+
+_DEGRADED_MARKERS = (
+    "stream_rupture", "upstream_error", "degraded", "no_tokens",
+    "connection reset", "connection aborted", "gateway timeout",
+    "service unavailable", "sock_read", "timeouterror",
+)
+
+
+def _default_degraded(exc: BaseException) -> bool:
+    """Is *exc* a transport-degradation class fault (worth re-routing), as opposed
+    to a logic error (which must propagate)? Conservative — only known markers."""
+    if isinstance(exc, StreamRuptureError):
+        return True
+    if isinstance(exc, (TimeoutError,)):
+        return True
+    msg = f"{type(exc).__name__}:{exc}".lower()
+    return any(m in msg for m in _DEGRADED_MARKERS)
+
+
+class TransProviderReRouter:
+    """A drop-in ``agent_fn`` that re-routes a single sub-agent onto the fallback
+    provider tier on transport collapse — sibling agents untouched."""
+
+    def __init__(
+        self,
+        primary: AgentFn,
+        fallback: AgentFn,
+        *,
+        degraded_predicate: Optional[DegradedPredicate] = None,
+    ) -> None:
+        self._primary = primary
+        self._fallback = fallback
+        self._degraded = degraded_predicate or _default_degraded
+        self._rerouted: Set[str] = set()          # sticky per symbol
+        self._reroutes: List[Tuple[str, str]] = []
+
+    @property
+    def reroutes(self) -> List[Tuple[str, str]]:
+        """Audit trail of ``(symbol, reason)`` re-routes."""
+        return list(self._reroutes)
+
+    def was_rerouted(self, symbol: str) -> bool:
+        return symbol in self._rerouted
+
+    async def __call__(self, target, feedback: str = "") -> str:
+        symbol = getattr(target, "symbol", "") or ""
+        # Sticky: a known-degraded symbol skips the primary entirely.
+        if symbol in self._rerouted:
+            return await self._fallback(target, feedback)
+        try:
+            return await self._primary(target, feedback)
+        except StreamRuptureError as exc:
+            self._trip(symbol, f"stream_rupture:{getattr(exc, 'phase', '?')}")
+            return await self._fallback(target, feedback)
+        except Exception as exc:  # noqa: BLE001
+            if self._degraded(exc):
+                self._trip(symbol, f"degraded:{type(exc).__name__}")
+                return await self._fallback(target, feedback)
+            raise  # a genuine logic error — the ReAct loop owns it
+
+    def _trip(self, symbol: str, reason: str) -> None:
+        self._rerouted.add(symbol)
+        self._reroutes.append((symbol, reason))
+        logger.warning(
+            "[TransProviderReRouter] sub-agent '%s' transport collapse (%s) — "
+            "re-routing to fallback tier; sibling agents UNAFFECTED",
+            symbol, reason,
+        )
+
+
+def build_rerouter(
+    primary: AgentFn, fallback: AgentFn,
+    *, degraded_predicate: Optional[DegradedPredicate] = None,
+) -> TransProviderReRouter:
+    """Compose a re-router from a primary + a fallback ``agent_fn``. In production
+    the caller builds each from a ``ProductionAgentTurnFn`` bound to the primary
+    (DW) and the ``FailoverLifecycle``-resolved fallback client respectively."""
+    return TransProviderReRouter(primary, fallback, degraded_predicate=degraded_predicate)
+
+
+__all__ = [
+    "AgentFn",
+    "TransProviderReRouter",
+    "build_rerouter",
+]

--- a/tests/governance/test_trans_provider_and_postsoak.py
+++ b/tests/governance/test_trans_provider_and_postsoak.py
@@ -1,0 +1,189 @@
+"""Trans-Provider Re-Router + Post-Soak Verification Circuit — final hardening.
+
+Mandated bulletproof: a 3-agent Swarm where Agent 2 hits a mid-loop provider
+collapse. Assert (1) Agent 2 migrates to the fallback tier WITHOUT interrupting
+Agents 1 & 3, (2) the Rolling VFS stitches all 3 outputs cleanly, and (3) the
+Post-Soak Verification Circuit confirms AST integrity + logs the trace to SQLite.
+"""
+
+from __future__ import annotations
+
+import ast
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.agentic_super_agent import swarm_agentic_repair
+from backend.core.ouroboros.governance.chunk_swarm import ChunkTarget
+from backend.core.ouroboros.governance.chunked_generation import extract_target_chunk
+from backend.core.ouroboros.governance.post_soak_verification import post_soak_verify
+from backend.core.ouroboros.governance.stream_rupture import StreamRuptureError
+from backend.core.ouroboros.governance.swarm_trace import SwarmTracer
+from backend.core.ouroboros.governance.trans_provider_rerouter import (
+    TransProviderReRouter,
+)
+
+_SRC = '''"""Module."""
+
+
+def alpha(a, b):
+    return a - b
+
+
+def beta(a, b):
+    return a * a
+
+
+def gamma(xs):
+    return xs[0]
+'''
+
+_FIX = {
+    "alpha": "def alpha(a, b):\n    return a + b",
+    "beta": "def beta(a, b):\n    return a * b",
+    "gamma": "def gamma(xs):\n    return sorted(xs)[0]",
+}
+
+
+def _targets():
+    ts = []
+    for sym in ("alpha", "beta", "gamma"):
+        ch = extract_target_chunk(_SRC, "m.py", sym)
+        assert ch is not None
+        ts.append(ChunkTarget(symbol=sym, chunk=ch, instruction=f"fix {sym}"))
+    return ts
+
+
+async def test_agent2_reroutes_to_fallback_siblings_unaffected_then_postsoak(tmp_path) -> None:
+    primary_calls = []
+    fallback_calls = []
+
+    # PRIMARY tier: beta's provider collapses mid-loop (StreamRuptureError);
+    # alpha + gamma succeed on the primary.
+    async def primary(target, feedback):
+        primary_calls.append(target.symbol)
+        if target.symbol == "beta":
+            raise StreamRuptureError(
+                provider="doubleword", elapsed_s=8.0, bytes_received=0,
+                rupture_timeout_s=8.0, phase="inter_chunk",
+            )
+        return _FIX[target.symbol]
+
+    # FALLBACK tier (FailoverLifecycle-resolved): repairs beta cleanly.
+    async def fallback(target, feedback):
+        fallback_calls.append(target.symbol)
+        return _FIX[target.symbol]
+
+    rerouter = TransProviderReRouter(primary, fallback)
+
+    result = await swarm_agentic_repair(_SRC, "m.py", _targets(), rerouter, max_turns=4)
+
+    # (1) Agent 2 (beta) migrated to the fallback tier; the whole swarm did NOT
+    # abort — alpha + gamma completed on the primary, untouched.
+    assert rerouter.was_rerouted("beta") is True
+    assert rerouter.reroutes and rerouter.reroutes[0][0] == "beta"
+    assert "stream_rupture" in rerouter.reroutes[0][1]
+    assert "beta" in fallback_calls
+    assert "alpha" not in fallback_calls and "gamma" not in fallback_calls  # siblings never fell back
+
+    # (2) The Rolling VFS stitched all 3 cleanly.
+    assert set(result.succeeded) == {"alpha", "beta", "gamma"}
+    assert result.failed == []
+    ast.parse(result.stitched)
+    ns: dict = {}
+    exec(compile(result.stitched, "s", "exec"), ns)  # noqa: S102 — test
+    assert ns["alpha"](5, 3) == 8
+    assert ns["beta"](5, 3) == 15     # repaired via the fallback tier
+    assert ns["gamma"]([3, 1, 2]) == 1
+
+    # (3) Post-Soak Verification Circuit: AST integrity + git-clean + trace flush.
+    trace_path = tmp_path / "swarm_trace.jsonl"
+    tracer = SwarmTracer(str(trace_path), op_id="op-postsoak")
+    tracer.record_fan_out(sub_agent="beta", symbol="beta", node_start_line=8, node_end_line=9, concurrency=1)
+    tracer.record_fan_in(sub_agent="beta", symbol="beta", converged=True, concurrency=1)
+
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    verdict = await post_soak_verify(
+        file_path="m.py", stitched_content=result.stitched,
+        trace_path=str(trace_path), sqlite_conn=conn,
+        git_status_fn=lambda: [" M m.py"],   # working-tree change only (not staged)
+    )
+
+    assert verdict.ast_ok is True
+    assert verdict.git_clean is True
+    assert verdict.trace_flushed is True
+    assert verdict.ready_for_promotion is True
+    assert verdict.trace_records == 2       # fan_out + fan_in
+
+    # The trace summary landed in SQLite.
+    row = conn.execute(
+        "SELECT file_path, records, converged, ready FROM swarm_trace_flush"
+    ).fetchone()
+    assert row == ("m.py", 2, 1, 1)
+
+
+# ---------------------------------------------------------------------------
+# Re-router unit behaviors
+# ---------------------------------------------------------------------------
+
+
+async def test_rerouter_sticky_per_symbol() -> None:
+    calls = {"primary": 0, "fallback": 0}
+
+    async def primary(target, feedback):
+        calls["primary"] += 1
+        raise StreamRuptureError(provider="dw", elapsed_s=1, bytes_received=0,
+                                 rupture_timeout_s=1, phase="ttft")
+
+    async def fallback(target, feedback):
+        calls["fallback"] += 1
+        return "ok"
+
+    rr = TransProviderReRouter(primary, fallback)
+    t = ChunkTarget(symbol="x", chunk=None, instruction="")
+    assert await rr(t, "") == "ok"      # trip → fallback
+    assert await rr(t, "") == "ok"      # sticky → straight to fallback
+    assert calls["primary"] == 1        # primary tried once, then skipped
+    assert calls["fallback"] == 2
+
+
+async def test_rerouter_propagates_non_transport_error() -> None:
+    async def primary(target, feedback):
+        raise ValueError("a genuine logic bug, not transport")
+
+    async def fallback(target, feedback):
+        return "ok"
+
+    rr = TransProviderReRouter(primary, fallback)
+    t = ChunkTarget(symbol="y", chunk=None, instruction="")
+    with pytest.raises(ValueError):
+        await rr(t, "")                 # logic error is NOT swallowed by failover
+    assert rr.was_rerouted("y") is False
+
+
+# ---------------------------------------------------------------------------
+# Post-Soak circuit unit behaviors
+# ---------------------------------------------------------------------------
+
+
+async def test_postsoak_blocks_on_ast_regression() -> None:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    verdict = await post_soak_verify(
+        file_path="m.py", stitched_content="def broken(:\n  pass",   # SyntaxError
+        sqlite_conn=conn, git_status_fn=lambda: [],
+    )
+    assert verdict.ast_ok is False
+    assert verdict.ready_for_promotion is False
+    assert any("ast_regression" in r for r in verdict.reasons)
+
+
+async def test_postsoak_blocks_on_unexpected_staged_change() -> None:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    verdict = await post_soak_verify(
+        file_path="m.py", stitched_content="x = 1\n", sqlite_conn=conn,
+        git_status_fn=lambda: ["M  secrets.env"],   # a STAGED change to something else
+    )
+    assert verdict.ast_ok is True
+    assert verdict.git_clean is False
+    assert verdict.ready_for_promotion is False
+    assert any("git_index_dirty" in r for r in verdict.reasons)


### PR DESCRIPTION
## Eliminating "Partial Mid-Swarm Provider Collapse"

One sub-agent's transport degradation no longer fate-shares its failure across the whole Swarm.

- **`TransProviderReRouter`** — a drop-in `agent_fn` wrapper. A `StreamRuptureError` (or DEGRADED-class transport fault) from the **primary** tier re-routes **only that symbol's** payload to the **fallback** tier — sibling agents, each in their own task, are untouched. **Sticky per symbol** (a known-degraded lane is skipped on later ReAct turns). A non-transport (logic) error propagates unchanged. **DRY:** consumes the `FailoverLifecycle`-resolved fallback `agent_fn` (#70016 DW→J-Prime→Claude) — no duplicated failover state.
- **Post-Soak Verification Circuit** — the pre-promotion gate: (1) zero-regression **AST structural check** via the polymorphic precompiler; (2) **READ-ONLY `.git/index` integrity** check (no unexpected staged change — the circuit holds no git-mutation privilege, per the #70033 Single-Writer discipline); (3) flush the complete `swarm_trace.jsonl` into SQLite (`.jarvis/chunk_strategy.db`, the StrategyOutcomeLogger substrate). `ready_for_promotion` iff AST + git pass; the trace flush is telemetry, never a gate.

### Mandate conformance
- **Root-Cause Only** — per-agent failure boundaries; a single worker's collapse re-routes in isolation, never aborts the `gather`.
- **DRY** — composes `precompile_detail` + the #70021 SQLite substrate + the SwarmTracer JSONL; consumes (never duplicates) the FailoverLifecycle matrix. Fable never flagged.

### Tests (5 + 23 regression = 28 passed)
**The mandated 3-agent swarm** — Agent 2's DW provider collapses mid-loop (`StreamRuptureError`), it migrates to the fallback tier while Agents 1 & 3 finish on the primary untouched; the **Rolling VFS stitches all 3 cleanly** (file parses + runs, `beta` repaired via fallback); the **Post-Soak circuit confirms AST integrity + git-clean + flushes the trace to SQLite** (`records=2, converged=1, ready=1`). Plus sticky-per-symbol re-route, non-transport error propagation, and AST-regression + unexpected-staged-change promotion blocks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents swarm-wide failures by rerouting only the degraded sub-agent to a fallback provider and adds a post-soak promotion gate. Promotion now requires clean AST and git index, with the run trace flushed to SQLite for audit.

- **New Features**
  - `TransProviderReRouter`: drop-in `agent_fn` wrapper that on `StreamRuptureError` or degraded transport reroutes that symbol to the fallback tier; sticky per symbol; sibling agents unaffected; non-transport errors propagate. Uses the `FailoverLifecycle`-resolved fallback `agent_fn` (no duplicated failover state).
  - Post-Soak Verification: runs zero-regression AST check via `precompile_detail`, a read-only git index check (`git status --porcelain`) that blocks on unexpected staged changes, and flushes `swarm_trace.jsonl` into SQLite (`.jarvis/chunk_strategy.db`, table `swarm_trace_flush`). Sets `ready_for_promotion` only when AST + git pass; trace flush is telemetry.

<sup>Written for commit 85d234e3280cd3e014220408044d1a001c2b9d8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70040?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

