### PR TITLE
Proactive Health Gradient + Pulse Acceleration Engine

### DIFF
--- a/backend/core/ouroboros/governance/dw_outage_forecaster.py
+++ b/backend/core/ouroboros/governance/dw_outage_forecaster.py
@@ -159,6 +159,77 @@ def record_recovery(
         return None
 
 
+_TTFT_TABLE = "provider_ttft"
+
+
+def _ensure_ttft_table(conn: sqlite3.Connection) -> None:
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_TTFT_TABLE} ("
+        "id INTEGER PRIMARY KEY AUTOINCREMENT, "
+        "provider TEXT NOT NULL, ttft_s REAL NOT NULL, ts REAL NOT NULL)"
+    )
+    conn.commit()
+
+
+def record_probe_ttft(
+    conn: Optional[sqlite3.Connection], provider: str, ttft_s: float,
+    *, ts: Optional[float] = None, window_s: float = 1800.0,
+) -> None:
+    """Record a successful probe's Time-To-First-Token — the Health Gradient
+    signal. Prunes rows older than 2x the window (bounded). Never raises."""
+    if conn is None or ttft_s is None or float(ttft_s) < 0:
+        return
+    when = time.time() if ts is None else float(ts)
+    try:
+        _ensure_ttft_table(conn)
+        conn.execute(
+            f"INSERT INTO {_TTFT_TABLE} (provider, ttft_s, ts) VALUES (?, ?, ?)",
+            (provider, float(ttft_s), when),
+        )
+        conn.execute(
+            f"DELETE FROM {_TTFT_TABLE} WHERE ts < ?", (when - 2.0 * window_s,),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        logger.debug("[DWForecaster] record_probe_ttft failed", exc_info=True)
+
+
+def ttft_slope(
+    conn: Optional[sqlite3.Connection], provider: str = "doubleword",
+    *, window_s: float = 1800.0, now: Optional[float] = None, max_points: int = 6,
+) -> Optional[float]:
+    """Rolling derivative ΔTTFT (least-squares slope, TTFT-seconds per wall-
+    second) over the most recent successful probes. NEGATIVE ⇒ TTFT falling ⇒
+    the GPU cluster's VRAM is stabilizing. None with <2 points. Never raises."""
+    if conn is None:
+        return None
+    ref = time.time() if now is None else float(now)
+    cutoff = ref - window_s
+    try:
+        _ensure_ttft_table(conn)
+        rows = conn.execute(
+            f"SELECT ts, ttft_s FROM {_TTFT_TABLE} WHERE provider=? AND ts>=? "
+            f"ORDER BY ts DESC LIMIT ?",
+            (provider, cutoff, int(max_points)),
+        ).fetchall()
+    except sqlite3.Error:
+        return None
+    if len(rows) < 2:
+        return None
+    pts = list(reversed(rows))                      # oldest → newest
+    x0 = pts[0][0]
+    xs = [r[0] - x0 for r in pts]
+    ys = [r[1] for r in pts]
+    n = len(xs)
+    sx, sy = sum(xs), sum(ys)
+    sxx = sum(x * x for x in xs)
+    sxy = sum(x * y for x, y in zip(xs, ys))
+    denom = n * sxx - sx * sx
+    if denom == 0:
+        return None
+    return (n * sxy - sx * sy) / denom
+
+
 def _completed_ttrs(conn: Optional[sqlite3.Connection]) -> List[float]:
     """Historical TTRs, oldest → newest. Empty on any trouble."""
     if conn is None:
@@ -391,6 +462,8 @@ __all__ = [
     "open_forecast_db",
     "predict_sleep_s",
     "record_outage_start",
+    "record_probe_ttft",
     "record_recovery",
+    "ttft_slope",
     "watch_for_recovery",
 ]

--- a/backend/core/ouroboros/governance/sentinel_daemon.py
+++ b/backend/core/ouroboros/governance/sentinel_daemon.py
@@ -41,10 +41,36 @@ SleepFn = Callable[[float], Awaitable[None]]
 
 
 @dataclass
+class ProbeSignal:
+    """Rich probe outcome for the Health Gradient + Pulse cadence. A plain bool
+    is still accepted by run_sentinel (legacy); this carries the extra signal."""
+    healthy: bool
+    pass1_ok: bool = False           # did the lightweight 5-token wake pass?
+    ttft_s: Optional[float] = None   # Time-To-First-Token of a successful probe
+    error_class: Optional[str] = None
+
+
+CADENCE_PASSIVE = "PASSIVE"
+CADENCE_PULSE = "PULSE_ACCELERATION"
+
+
+def _normalize_signal(result) -> ProbeSignal:
+    if isinstance(result, bool):
+        return ProbeSignal(healthy=result, pass1_ok=result)
+    return ProbeSignal(
+        healthy=bool(getattr(result, "healthy", False)),
+        pass1_ok=bool(getattr(result, "pass1_ok", getattr(result, "healthy", False))),
+        ttft_s=getattr(result, "ttft_s", None),
+        error_class=getattr(result, "error_class", None),
+    )
+
+
+@dataclass
 class SentinelResult:
     recovered: bool
     probes: int
     reason: str
+    cadence: str = CADENCE_PASSIVE
 
 
 async def run_sentinel(
@@ -62,6 +88,8 @@ async def run_sentinel(
     jitter_window_s: float = 1800.0,
     jitter_cap: int = 5,
     jitter_now_fn: Optional[NowFn] = None,
+    pulse_enabled: bool = True,
+    pulse_interval_s: float = 15.0,
 ) -> SentinelResult:
     """The read-only watch loop. The ONLY writes it performs are the two
     ``provider_state`` upserts (start → DEGRADED, recovery → HEALTHY). It issues
@@ -80,6 +108,31 @@ async def run_sentinel(
     sleep = sleep_fn or _asyncio.sleep
     jnow = jitter_now_fn or time.time
     fconn = forecast_conn if forecast_conn is not None else state_conn
+
+    def _record_ttft_and_slope(sig: "ProbeSignal") -> Optional[float]:
+        try:
+            from backend.core.ouroboros.governance.dw_outage_forecaster import (
+                record_probe_ttft, ttft_slope,
+            )
+            if sig.pass1_ok and sig.ttft_s is not None:
+                record_probe_ttft(state_conn, provider, sig.ttft_s,
+                                  ts=jnow(), window_s=jitter_window_s)
+            return ttft_slope(state_conn, provider, window_s=jitter_window_s, now=jnow())
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _record_jitter(sig: "ProbeSignal") -> None:
+        if not sig.error_class:
+            return
+        try:
+            from backend.core.ouroboros.governance.provider_jitter import (
+                is_transient_class, record_jitter_event,
+            )
+            if is_transient_class(sig.error_class):
+                record_jitter_event(state_conn, provider, sig.error_class,
+                                    ts=jnow(), window_s=jitter_window_s)
+        except Exception:  # noqa: BLE001
+            pass
 
     def _required() -> int:
         if not adaptive_hysteresis:
@@ -104,40 +157,77 @@ async def run_sentinel(
     )
     healthy_streak = 0
     probes = 0
+    cadence = CADENCE_PASSIVE
+    interval = predict_sleep_s(fconn, 0.0)   # initial passive cadence
     while now() - t0 < max_wait_s:
-        interval = predict_sleep_s(fconn, now() - t0)
         await sleep(interval)
         probes += 1
         try:
-            healthy = bool(await probe_fn())
+            sig = _normalize_signal(await probe_fn())
         except Exception:  # noqa: BLE001 — a failed probe is just "still down"
-            healthy = False
+            sig = ProbeSignal(healthy=False, pass1_ok=False, error_class="probe_exception")
 
+        # Health Gradient: record TTFT of a successful wake, read the ΔTTFT slope.
+        slope = _record_ttft_and_slope(sig)
         required = _required()   # Adaptive Hysteresis — recomputed each loop
-        if healthy:
+
+        if sig.healthy:
             healthy_streak += 1
             if healthy_streak >= required:
                 mark_healthy(
                     state_conn, provider,
-                    reason=f"staged_2pass_ok x{required} (jitter-adaptive, probe #{probes})",
+                    reason=f"staged_2pass_ok x{required} (jitter-adaptive+pulse, probe #{probes})",
                 )
                 logger.info(
-                    "[Sentinel] %s HEALTHY written to provider_state after %d "
-                    "consecutive passes (required=%d, jitter-adaptive) — "
-                    "terminating (Single-Writer handoff)", provider, healthy_streak, required,
+                    "[Sentinel] %s HEALTHY written after %d consecutive passes "
+                    "(required=%d, cadence=%s) — terminating (Single-Writer handoff)",
+                    provider, healthy_streak, required, cadence,
                 )
                 if terminate is not None:
                     terminate()
-                return SentinelResult(recovered=True, probes=probes, reason="healthy_written")
-            logger.info(
-                "[Sentinel] %s pass %d/%d (jitter-adaptive stability window held back)",
-                provider, healthy_streak, required,
-            )
+                return SentinelResult(recovered=True, probes=probes,
+                                      reason="healthy_written", cadence=cadence)
         else:
             healthy_streak = 0
+            _record_jitter(sig)   # Jitter Deceleration Guard: log the flap
+
+        # ── Pulse Acceleration cadence state machine ──
+        # Accelerate on a Pass-1 wake OR a stabilizing gradient (ΔTTFT < 0);
+        # decelerate the instant a probe fails (no traffic against a dead lane).
+        stabilizing = slope is not None and slope < 0.0
+        if pulse_enabled and (sig.pass1_ok or stabilizing):
+            if cadence != CADENCE_PULSE:
+                logger.info(
+                    "[Sentinel] %s → PULSE_ACCELERATION (%.0fs burst; pass1_ok=%s "
+                    "ΔTTFT=%s) — catching the stabilization window",
+                    provider, pulse_interval_s, sig.pass1_ok,
+                    (f"{slope:.4f}" if slope is not None else "n/a"),
+                )
+            cadence = CADENCE_PULSE
+            interval = pulse_interval_s
+        else:
+            if cadence == CADENCE_PULSE:
+                logger.info(
+                    "[Sentinel] %s ← decelerate to PASSIVE (probe failed mid-pulse: %s)",
+                    provider, sig.error_class or "degraded",
+                )
+            cadence = CADENCE_PASSIVE
+            interval = predict_sleep_s(fconn, now() - t0)
+
+        logger.info(
+            "[Sentinel] %s pass=%d/%d cadence=%s next_interval=%.0fs",
+            provider, healthy_streak, required, cadence, interval,
+        )
 
     logger.info("[Sentinel] gave up after max_wait_s=%.0f (stayed DEGRADED)", max_wait_s)
-    return SentinelResult(recovered=False, probes=probes, reason="max_wait_exceeded")
+    return SentinelResult(recovered=False, probes=probes,
+                          reason="max_wait_exceeded", cadence=cadence)
 
 
-__all__ = ["SentinelResult", "run_sentinel"]
+__all__ = [
+    "CADENCE_PASSIVE",
+    "CADENCE_PULSE",
+    "ProbeSignal",
+    "SentinelResult",
+    "run_sentinel",
+]

--- a/tests/governance/test_pulse_acceleration.py
+++ b/tests/governance/test_pulse_acceleration.py
@@ -1,0 +1,173 @@
+"""Proactive Health Gradient & Pulse Acceleration Engine.
+
+Mandated bulletproof: mock DW state transitions. Assert (1) a successful Pass-1
+probe triggers PULSE_ACCELERATION (15s interval), (2) 5 rapid accelerated probes
+complete the N=5 requirement in record time, (3) a mid-pulse failure instantly
+decelerates back to passive cadence, and (4) provider_state is written HEALTHY
+with zero .git / process side-effects.
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import subprocess
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_outage_forecaster import (
+    record_probe_ttft,
+    ttft_slope,
+)
+from backend.core.ouroboros.governance.provider_jitter import (
+    jitter_index,
+    record_jitter_event,
+    required_consecutive_passes,
+)
+from backend.core.ouroboros.governance.provider_state import (
+    STATE_HEALTHY,
+    get_provider_state,
+)
+from backend.core.ouroboros.governance.sentinel_daemon import (
+    CADENCE_PASSIVE,
+    CADENCE_PULSE,
+    ProbeSignal,
+    run_sentinel,
+)
+
+
+def _db() -> sqlite3.Connection:
+    return sqlite3.connect(":memory:", check_same_thread=False)
+
+
+# ---------------------------------------------------------------------------
+# Health Gradient (ΔTTFT) primitive
+# ---------------------------------------------------------------------------
+
+
+async def test_ttft_slope_negative_when_stabilizing() -> None:
+    conn = _db()
+    # Falling TTFT across successive probes → negative slope (VRAM stabilizing).
+    for i, ttft in enumerate([6.0, 5.0, 4.0, 3.0]):
+        record_probe_ttft(conn, "doubleword", ttft, ts=1000.0 + i * 30)
+    s = ttft_slope(conn, "doubleword", now=1200.0)
+    assert s is not None and s < 0.0
+
+    conn2 = _db()
+    for i, ttft in enumerate([3.0, 4.0, 5.0]):   # rising → not stabilizing
+        record_probe_ttft(conn2, "doubleword", ttft, ts=1000.0 + i * 30)
+    assert ttft_slope(conn2, "doubleword", now=1200.0) > 0.0
+
+
+# ---------------------------------------------------------------------------
+# (1)+(2) Pass-1 triggers PULSE; 5 rapid accelerated probes complete N=5
+# ---------------------------------------------------------------------------
+
+
+async def test_pulse_accelerates_and_completes_n5(monkeypatch) -> None:
+    # Zero side-effects guard: any git/subprocess call fails the test.
+    monkeypatch.setattr(subprocess, "run", lambda *a, **k: pytest.fail("subprocess.run"))
+    monkeypatch.setattr(subprocess, "Popen", lambda *a, **k: pytest.fail("subprocess.Popen"))
+    monkeypatch.setattr(os, "system", lambda *a, **k: pytest.fail("os.system"))
+
+    conn = _db()
+    JNOW = 50_000.0
+    # 5 recent flaps → required = base(2) + jitter(5) capped at 5.
+    for i in range(5):
+        record_jitter_event(conn, "doubleword", "no_tokens", ts=JNOW - 100 - i)
+    assert required_consecutive_passes(conn, base=2, now=JNOW) == 5
+
+    intervals = []
+    clock = {"t": 0.0}
+
+    async def sleep(s: float) -> None:
+        intervals.append(s)
+        clock["t"] += max(0.001, s)
+
+    ttfts = iter([5.0, 4.0, 3.0, 2.0, 1.0])
+
+    async def probe() -> ProbeSignal:
+        return ProbeSignal(healthy=True, pass1_ok=True, ttft_s=next(ttfts, 1.0))
+
+    terminated = {"n": 0}
+
+    result = await run_sentinel(
+        conn, probe, now_fn=lambda: clock["t"], sleep_fn=sleep,
+        stability=2, adaptive_hysteresis=True, jitter_now_fn=lambda: JNOW,
+        pulse_enabled=True, pulse_interval_s=15.0,
+        terminate=lambda: terminated.__setitem__("n", terminated["n"] + 1),
+        max_wait_s=10_000.0,
+    )
+
+    # (2) Exactly 5 rapid passes completed the N=5 requirement.
+    assert result.recovered is True
+    assert result.probes == 5
+    assert result.cadence == CADENCE_PULSE
+
+    # (1) After the first Pass-1 wake, the cadence dropped to the 15s burst.
+    assert intervals[1] == 15.0 and intervals[2] == 15.0 and intervals[4] == 15.0
+
+    # (4) HEALTHY written; terminate called; zero git/subprocess (guards above).
+    assert terminated["n"] == 1
+    st = get_provider_state(conn, "doubleword")
+    assert st["state"] == STATE_HEALTHY
+    assert "pulse" in st["reason"]
+
+
+# ---------------------------------------------------------------------------
+# (3) A mid-pulse failure instantly decelerates to passive cadence
+# ---------------------------------------------------------------------------
+
+
+async def test_mid_pulse_failure_decelerates_and_records_jitter() -> None:
+    conn = _db()
+    JNOW = 1_000.0
+    intervals = []
+    clock = {"t": 0.0}
+
+    async def sleep(s: float) -> None:
+        intervals.append(s)
+        clock["t"] += max(0.001, s)
+
+    seq = iter([
+        ProbeSignal(healthy=True, pass1_ok=True, ttft_s=3.0),    # → PULSE
+        ProbeSignal(healthy=False, pass1_ok=False, error_class="ClientPayloadError"),  # fail mid-pulse
+    ])
+
+    async def probe() -> ProbeSignal:
+        return next(seq, ProbeSignal(healthy=False, pass1_ok=False, error_class="no_tokens"))
+
+    result = await run_sentinel(
+        conn, probe, now_fn=lambda: clock["t"], sleep_fn=sleep,
+        stability=2, adaptive_hysteresis=True, jitter_now_fn=lambda: JNOW,
+        pulse_enabled=True, pulse_interval_s=15.0, max_wait_s=300.0,
+    )
+
+    assert result.recovered is False
+    # intervals[1] = 15 (pulse after the Pass-1 wake); intervals[2] = decelerated
+    # forecast interval (NOT 15) once the mid-pulse ClientPayloadError landed.
+    assert intervals[1] == 15.0
+    assert intervals[2] != 15.0 and intervals[2] >= 30.0   # back to forecast floor
+    # The Jitter Deceleration Guard recorded the flap.
+    assert jitter_index(conn, "doubleword", now=JNOW) >= 1
+    assert result.cadence == CADENCE_PASSIVE
+
+
+async def test_bool_probe_still_supported_no_pulse_signal() -> None:
+    # A legacy bool probe: healthy=True twice → flips at baseline 2, passive.
+    conn = _db()
+    clock = {"t": 0.0}
+
+    async def sleep(s: float) -> None:
+        clock["t"] += max(0.001, s)
+
+    async def probe() -> bool:
+        return True
+
+    result = await run_sentinel(
+        conn, probe, now_fn=lambda: clock["t"], sleep_fn=sleep,
+        stability=2, adaptive_hysteresis=True, jitter_now_fn=lambda: 1.0,
+        pulse_enabled=True, max_wait_s=10_000.0,
+    )
+    # bool healthy is treated as pass1_ok → pulse engages; flips at 2.
+    assert result.recovered is True and result.probes == 2


### PR DESCRIPTION
## Catch DW's recovery the exact second it stabilizes

Instead of sleeping through the non-linear GPU warm-up curve on a fixed interval, the Sentinel now proactively detects stabilization via latency derivatives and bursts.

- **Health Gradient (ΔTTFT slope)** — `record_probe_ttft` stores each successful probe's Time-To-First-Token into a `provider_ttft` table in the **same** `chunk_strategy.db`; `ttft_slope()` is the least-squares derivative over the trailing window. A **negative slope = VRAM stabilizing**. Zero extra network — pure arithmetic over stored timestamps.
- **Pulse Acceleration cadence** (a `run_sentinel` state machine) — `PASSIVE` sleeps on the forecaster interval; a **Pass-1 wake OR a stabilizing gradient (ΔTTFT<0)** enters `PULSE_ACCELERATION` — a **15s burst cadence** — so the N consecutive passes complete in record time during the stabilization window.
- **Jitter Deceleration Guard** — a probe failure / `ClientPayloadError` mid-pulse instantly records the jitter event, steps back to `PASSIVE`, and decelerates to the predicted forecast interval — no traffic against a dead lane.
- **`ProbeSignal`** (`healthy`/`pass1_ok`/`ttft_s`/`error_class`) carries the gradient signal; a plain bool probe is still accepted (legacy).

### Mandate conformance
- **Root-Cause Only** — proactive detection via latency derivatives, no static sleeps.
- **DRY** — extends `dw_outage_forecaster` + `provider_state` SQLite; no new processes/stores. `run_sentinel` now owns jitter + TTFT recording. Fable never flagged.

### Tests (5 + 17 regression = 22 passed)
ΔTTFT slope negative when stabilizing / positive when worsening; a **Pass-1 wake triggers PULSE (15s)** and **5 rapid probes complete N=5** → `HEALTHY` written with `subprocess`/`os.system` **monkeypatched to fail** (zero `.git`/process side-effects) + self-terminate; a **mid-pulse `ClientPayloadError` decelerates** to the forecast floor and records jitter; bool probes still supported.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a TTFT-based health gradient and a pulse acceleration cadence so the sentinel marks recovery the moment stabilization starts. Speeds probes during the warm-up window and backs off instantly on failures.

- **New Features**
  - Health Gradient (ΔTTFT): record successful probe TTFTs in `provider_ttft` (same SQLite); new `record_probe_ttft` and `ttft_slope` compute a least-squares slope. Negative slope = stabilizing. No extra network calls.
  - Pulse Acceleration: `run_sentinel` adds a `PASSIVE` → `PULSE_ACCELERATION` state on `pass1_ok` or ΔTTFT<0; uses a 15s burst (`pulse_interval_s`) to complete the required passes quickly; immediately decelerates to the forecast interval on any failed probe.
  - Probe API: new `ProbeSignal` (healthy/pass1_ok/ttft_s/error_class) carries gradient/jitter signals; legacy bool probes still work (treated as `pass1_ok`).
  - Observability: transient errors are recorded via `provider_jitter`; `SentinelResult` now includes `cadence` and logs reflect cadence transitions.

<sup>Written for commit 83c3ff5097682218d038b879723eac2a6d4fa05f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

