### PR TITLE
/provider — DoubleWord resilience dashboard in the SerpentFlow CLI

### DIFF
--- a/backend/core/ouroboros/governance/provider_repl.py
+++ b/backend/core/ouroboros/governance/provider_repl.py
@@ -1,0 +1,172 @@
+"""``/provider`` — operator-facing DoubleWord resilience dashboard.
+
+Surfaces the resilience telemetry the headless Sentinel writes to the shared
+``.jarvis/chunk_strategy.db`` substrate — provider state, the Provider Jitter
+Index + adaptive-hysteresis threshold, the ΔTTFT health gradient, and the
+forecaster's predicted recovery — into the SerpentFlow CLI. Read-only: it opens
+the SQLite substrate and renders; it never mutates state, never calls the
+network, and imports NO orchestrator / providers / iron_gate (naming-cage
+authority asymmetry). Auto-discovered by ``repl_dispatch_registry.try_dispatch``
+via the module-level ``dispatch_provider_command`` callable.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+from typing import Optional
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+_YELLOW = "\033[33m"
+_CYAN = "\033[36m"
+
+
+@dataclass(frozen=True)
+class ProviderReplDispatchResult:
+    """Result of a ``/provider`` dispatch. ``matched=False`` → not our line."""
+    ok: bool
+    text: str
+    matched: bool = True
+
+
+_HELP = (
+    f"  {_BOLD}{_CYAN}/provider — DoubleWord resilience dashboard{_RESET}\n"
+    f"  {_DIM}Read-only view of the Sentinel's live provider telemetry "
+    f"(state, jitter, ΔTTFT gradient, forecast).{_RESET}\n\n"
+    f"  {_BOLD}Subcommands:{_RESET}\n"
+    f"    {_CYAN}/provider{_RESET}         "
+    f"{_DIM}state + jitter + adaptive threshold + ΔTTFT + forecast{_RESET}\n"
+    f"    {_CYAN}/provider help{_RESET}    {_DIM}this message{_RESET}\n"
+)
+
+
+def _matches(line: str) -> bool:
+    s = (line or "").strip()
+    if not s:
+        return False
+    return s in ("/provider", "provider") or s.startswith(("/provider ", "provider "))
+
+
+def _fmt_ago(updated_ts: Optional[float], now: Optional[float] = None) -> str:
+    if not updated_ts:
+        return "?"
+    import time
+    ref = time.time() if now is None else now
+    d = max(0.0, ref - float(updated_ts))
+    if d < 90:
+        return f"{int(d)}s ago"
+    if d < 5400:
+        return f"{int(d / 60)}m ago"
+    return f"{d / 3600:.1f}h ago"
+
+
+def _render_overview(conn, *, now: Optional[float] = None) -> str:
+    """Compose the dashboard from an open telemetry conn. Never raises."""
+    try:
+        from backend.core.ouroboros.governance.provider_state import get_provider_state
+        from backend.core.ouroboros.governance.provider_jitter import (
+            jitter_index, required_consecutive_passes,
+        )
+        from backend.core.ouroboros.governance.dw_outage_forecaster import (
+            forecast_ttr, ttft_slope,
+        )
+    except Exception:  # noqa: BLE001
+        return f"  {_DIM}provider telemetry modules unavailable{_RESET}"
+
+    if conn is None:
+        return (
+            f"  {_DIM}no telemetry DB yet — the Sentinel has not written "
+            f"provider_state (is dw_sentinel_daemon running?){_RESET}"
+        )
+
+    provider = "doubleword"
+    st = get_provider_state(conn, provider)
+    state = (st or {}).get("state", "UNKNOWN")
+    reason = (st or {}).get("reason", "")
+    updated_ts = (st or {}).get("updated_ts")
+
+    scolor = _GREEN if state == "HEALTHY" else (_RED if state == "DEGRADED" else _YELLOW)
+    dot = "●"
+
+    ji = jitter_index(conn, provider, now=now)
+    req = required_consecutive_passes(conn, provider, now=now)
+    jcolor = _GREEN if ji == 0 else (_YELLOW if ji < 5 else _RED)
+
+    slope = ttft_slope(conn, provider, now=now)
+    if slope is None:
+        grad = f"{_DIM}n/a (need ≥2 successful probes){_RESET}"
+    elif slope < 0:
+        grad = f"{_GREEN}▼ {slope:+.4f} s/s (VRAM stabilizing){_RESET}"
+    else:
+        grad = f"{_RED}▲ {slope:+.4f} s/s (latency worsening){_RESET}"
+
+    ttr = forecast_ttr(conn, )
+
+    lines = [
+        f"  {_BOLD}{_CYAN}DoubleWord — Resilience{_RESET}",
+        f"    {_BOLD}State{_RESET}       {scolor}{dot} {state}{_RESET} "
+        f"{_DIM}({reason}, {_fmt_ago(updated_ts, now)}){_RESET}",
+        f"    {_BOLD}Jitter{_RESET}      {jcolor}{ji}{_RESET} "
+        f"{_DIM}transient errors / 30m{_RESET}",
+        f"    {_BOLD}Threshold{_RESET}   {req} "
+        f"{_DIM}consecutive 2-stage passes required (adaptive hysteresis){_RESET}",
+        f"    {_BOLD}ΔTTFT{_RESET}       {grad}",
+        f"    {_BOLD}Forecast{_RESET}    {_DIM}predicted outage ≈ {ttr:.0f}s (EMA/Bayesian){_RESET}",
+    ]
+    if state != "HEALTHY":
+        lines.append(
+            f"  {_DIM}→ Sentinel holds until {req} consecutive full passes land; "
+            f"launch when it writes HEALTHY.{_RESET}"
+        )
+    return "\n".join(lines)
+
+
+def dispatch_provider_command(line: str) -> ProviderReplDispatchResult:
+    """Parse a ``/provider`` line and render the dashboard. NEVER raises."""
+    if not _matches(line):
+        return ProviderReplDispatchResult(ok=False, text="", matched=False)
+    try:
+        tokens = shlex.split(line)
+    except ValueError as exc:
+        return ProviderReplDispatchResult(ok=False, text=f"  /provider parse error: {exc}")
+    args = tokens[1:] if tokens else []
+    head = (args[0].lower() if args else "")
+
+    if head in ("help", "?"):
+        return ProviderReplDispatchResult(ok=True, text=_HELP)
+
+    try:
+        from backend.core.ouroboros.governance.dw_outage_forecaster import open_forecast_db
+        conn = open_forecast_db()
+    except Exception:  # noqa: BLE001
+        conn = None
+    return ProviderReplDispatchResult(ok=True, text=_render_overview(conn))
+
+
+def register_verbs(registry) -> int:
+    """Auto-discovered by the /help index registrar. Registers ``/provider``."""
+    try:
+        registry.register(
+            verb="provider",
+            description=(
+                "DoubleWord resilience dashboard — provider state, jitter index + "
+                "adaptive-hysteresis threshold, ΔTTFT health gradient, and the "
+                "outage forecaster. Read-only view of the Sentinel's SQLite telemetry."
+            ),
+            posture_relevance="RELEVANT",
+            since="Sentinel telemetry surface (2026-07-23)",
+        )
+        return 1
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+__all__ = [
+    "ProviderReplDispatchResult",
+    "dispatch_provider_command",
+    "register_verbs",
+]

--- a/tests/governance/test_provider_repl.py
+++ b/tests/governance/test_provider_repl.py
@@ -1,0 +1,79 @@
+"""``/provider`` REPL verb — the DoubleWord resilience dashboard.
+
+Surfaces the Sentinel's SQLite telemetry (state, jitter, adaptive threshold,
+ΔTTFT gradient, forecast) into the CLI. Read-only; auto-discovered via
+``dispatch_provider_command``.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.dw_outage_forecaster import (
+    record_probe_ttft,
+    record_outage_start,
+    record_recovery,
+)
+from backend.core.ouroboros.governance.provider_jitter import record_jitter_event
+from backend.core.ouroboros.governance.provider_repl import (
+    _render_overview,
+    dispatch_provider_command,
+)
+from backend.core.ouroboros.governance.provider_state import mark_degraded, mark_healthy
+
+
+def _strip(s: str) -> str:
+    import re
+    return re.sub(r"\033\[[0-9;]*m", "", s)
+
+
+def test_matching_and_non_matching_lines() -> None:
+    assert dispatch_provider_command("/status").matched is False
+    assert dispatch_provider_command("").matched is False
+    assert dispatch_provider_command("/provider").matched is True
+    assert dispatch_provider_command("/provider help").matched is True
+    assert "resilience dashboard" in _strip(dispatch_provider_command("/provider help").text)
+
+
+def test_dispatch_never_raises_on_missing_db() -> None:
+    # Even with no real DB, the dispatcher renders something and never throws.
+    res = dispatch_provider_command("/provider")
+    assert res.ok is True and res.matched is True
+    assert isinstance(res.text, str) and res.text
+
+
+def test_render_degraded_overview_surfaces_all_telemetry() -> None:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    NOW = 100_000.0
+    mark_degraded(conn, "doubleword", reason="sentinel_watch_start", ts=NOW - 30)
+    # 5 recent flaps → jitter 5 → adaptive threshold 5.
+    for i in range(5):
+        record_jitter_event(conn, "doubleword", "no_tokens", ts=NOW - 100 - i)
+    # Falling TTFT → negative ΔTTFT (stabilizing).
+    for i, t in enumerate([6.0, 5.0, 4.0]):
+        record_probe_ttft(conn, "doubleword", t, ts=NOW - 200 + i * 30)
+
+    out = _strip(_render_overview(conn, now=NOW))
+    assert "DoubleWord — Resilience" in out
+    assert "DEGRADED" in out
+    assert "Jitter" in out and " 5 " in out
+    assert "5 consecutive" in out          # adaptive threshold surfaced
+    assert "ΔTTFT" in out and "stabilizing" in out
+    assert "Forecast" in out
+    assert "Sentinel holds until 5 consecutive" in out
+
+
+def test_render_healthy_overview() -> None:
+    conn = sqlite3.connect(":memory:", check_same_thread=False)
+    NOW = 100_000.0
+    # A completed outage so the forecaster has a datapoint.
+    record_outage_start(conn, NOW - 700)
+    record_recovery(conn, NOW - 700, NOW - 100)
+    mark_healthy(conn, "doubleword", reason="staged_2pass_ok x2", ts=NOW - 10)
+
+    out = _strip(_render_overview(conn, now=NOW))
+    assert "HEALTHY" in out
+    assert "Jitter" in out and " 0 " in out          # no recent flaps
+    assert "Sentinel holds until" not in out          # healthy → no hold note


### PR DESCRIPTION
## Surface the Sentinel's resilience telemetry into the operator CLI

All the resilience state we built this campaign — provider `HEALTHY/DEGRADED`, the Provider Jitter Index + adaptive-hysteresis threshold, the ΔTTFT health gradient, and the outage forecaster — has lived only in SQLite + the Sentinel log, invisible in the UI. This adds a read-only `/provider` verb that renders it live.

- **`governance/provider_repl.py`** — `dispatch_provider_command(line)` auto-discovered by `repl_dispatch_registry.try_dispatch` (naming-cage; verb `provider`). Read-only: opens the `.jarvis/chunk_strategy.db` substrate and renders a colored `HEALTHY/DEGRADED` table (state + age, jitter/30m, adaptive threshold, ΔTTFT arrow, forecast TTR). Never mutates, never networks, imports no orchestrator/providers/iron_gate (authority asymmetry). `register_verbs` adds it to the `/help` index. Composes `provider_state` (#70034) + `provider_jitter` (#70041) + `dw_outage_forecaster` (#70030/#70042).

**Verified live:** `try_dispatch("/provider")` matches + renders; against the running Sentinel's DB it shows DW `DEGRADED`, jitter, adaptive threshold 5, ΔTTFT, ~280s forecast.

### Tests (4 passed)
match/non-match + help; never-raises on missing DB; DEGRADED overview surfaces state+jitter+threshold+ΔTTFT+forecast+hold-note; HEALTHY overview (0 jitter, no hold note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a read‑only `/provider` command in the SerpentFlow CLI to show DoubleWord resilience telemetry from the Sentinel’s SQLite, giving operators a live HEALTHY/DEGRADED view with jitter, ΔTTFT, and outage forecast. No state changes or network calls.

- **New Features**
  - Shows provider state + reason + age, Jitter Index per 30m with adaptive threshold, ΔTTFT slope (up/down), and forecasted time to recovery.
  - Reads from `.jarvis/chunk_strategy.db`; safe if the DB or telemetry modules are missing.
  - Auto-discovered by the REPL and listed in `/help`.
  - Tests cover command matching/help, missing DB, and both degraded and healthy views.

<sup>Written for commit fa039d694d4ec7b770c18fd09e967b67951dc564. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70043?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

