### PR TITLE
Live provider-state breadcrumb — Sentinel recovery onto the bus + CLI

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4623,6 +4623,70 @@ class SerpentREPL:
             )
         except Exception:  # noqa: BLE001 — breadcrumb is best-effort
             self._shadow_breadcrumb_task = None
+        # Provider-state resilience breadcrumb — the Sentinel's DEGRADED↔HEALTHY
+        # transitions surfaced live inline (and onto the SSE/HUD). The watcher
+        # bridges the Sentinel's SQLite signal → broker; the listener prints it.
+        # Both best-effort + in-process; never block REPL boot.
+        self._provider_state_watcher_task = None
+        self._provider_breadcrumb_task = None
+        try:
+            from backend.core.ouroboros.governance.provider_state_broker import (
+                start_provider_state_watcher,
+            )
+            self._provider_state_watcher_task = start_provider_state_watcher()
+            self._provider_breadcrumb_task = asyncio.ensure_future(
+                self._provider_breadcrumb_listener()
+            )
+        except Exception:  # noqa: BLE001 — resilience breadcrumb is best-effort
+            self._provider_state_watcher_task = None
+            self._provider_breadcrumb_task = None
+
+    async def _provider_breadcrumb_listener(self) -> None:
+        """Surface a calm one-line breadcrumb when the DW Sentinel's provider
+        state transitions (DEGRADED↔HEALTHY). Subscribes IN-PROCESS to the same
+        :class:`StreamEventBroker` the ``/observability/stream`` SSE uses; the
+        ``/provider`` verb remains the full pull-view. Best-effort + fail-soft —
+        any error silently disables the breadcrumb."""
+        sub = None
+        broker = None
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                EVENT_TYPE_PROVIDER_STATE_CHANGED,
+                get_default_broker,
+            )
+            from backend.core.ouroboros.governance.provider_state_broker import (
+                format_provider_breadcrumb,
+            )
+
+            broker = get_default_broker()
+            sub = broker.subscribe()
+            if sub is None:
+                return
+            async for event in broker.stream_iter(sub, heartbeat_s=0):
+                if getattr(event, "event_type", "") != EVENT_TYPE_PROVIDER_STATE_CHANGED:
+                    continue
+                try:
+                    payload = dict(getattr(event, "payload", {}) or {})
+                    text = format_provider_breadcrumb(payload)
+                    healthy = payload.get("state") == "HEALTHY"
+                    color = _C["neural"] if healthy else _C["heal"]
+                    glyph = "✓" if healthy else "⚠"
+                    self._flow.console.print(
+                        f"  [{color}]{glyph} {text}[/{color}]",
+                        highlight=False,
+                    )
+                except Exception:  # noqa: BLE001 — one bad event never kills the loop
+                    continue
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — strictly best-effort
+            return
+        finally:
+            try:
+                if broker is not None and sub is not None:
+                    broker.unsubscribe(sub)
+            except Exception:  # noqa: BLE001
+                pass
 
     async def _shadow_breadcrumb_listener(self) -> None:
         """Slice 253 — surface a calm, non-blocking breadcrumb when a Shadow
@@ -4690,6 +4754,16 @@ class SerpentREPL:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
             self._shadow_breadcrumb_task = None
+        # Tear down the provider-state resilience breadcrumb + watcher.
+        for _attr in ("_provider_breadcrumb_task", "_provider_state_watcher_task"):
+            _pt = getattr(self, _attr, None)
+            if _pt is not None:
+                _pt.cancel()
+                try:
+                    await _pt
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+                setattr(self, _attr, None)
         # Stop the spinner invalidator first so its task doesn't
         # outlive the REPL session.
         try:

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -157,6 +157,11 @@ EVENT_TYPE_CANCELLATION_OVERRUN_DETECTED = "cancellation_overrun_detected"
 EVENT_TYPE_PROVIDER_FAILURE_CLASSIFIED = "provider_failure_classified"
 EVENT_TYPE_CIRCUIT_BREAKER_STATE_CHANGE = "circuit_breaker_state_change"
 EVENT_TYPE_CIRCUIT_BREAKER_TRIPPED = "circuit_breaker_tripped"
+# Sentinel recovery signal: the headless DW Sentinel's provider_state SQLite row
+# transitioned (DEGRADED↔HEALTHY). Carries the resilience snapshot (state, jitter,
+# adaptive threshold, ΔTTFT gradient, forecast TTR). One emission lights up both
+# the in-process TUI breadcrumb listener and the /observability/stream SSE (→ HUD).
+EVENT_TYPE_PROVIDER_STATE_CHANGED = "provider_state_changed"
 # Infra MTTR: the failover VM could not resolve its golden image and degraded
 # to a cold boot (or failed). On Spot instances this defeats agile failover, so
 # it MUST be loud, not silent — surfaced to the operator via this SSE frame.
@@ -1604,6 +1609,8 @@ _VALID_EVENT_TYPES = frozenset({
                                                   # before the streaming __aexit__ chain releases)
     EVENT_TYPE_PROVIDER_FAILURE_CLASSIFIED,      # Slice 7e (Provider Circuit Breaker — every
                                                   # provider failure that reaches Slice 7a classify())
+    EVENT_TYPE_PROVIDER_STATE_CHANGED,           # Sentinel recovery signal (DEGRADED↔HEALTHY +
+                                                  # resilience snapshot; feeds TUI breadcrumb + HUD SSE)
     EVENT_TYPE_CIRCUIT_BREAKER_STATE_CHANGE,     # Slice 7e (state machine transitions other than
                                                   # OPEN_TERMINAL trips)
     EVENT_TYPE_CIRCUIT_BREAKER_TRIPPED,           # Slice 7e (OPEN_TERMINAL trip — carries the
@@ -2884,6 +2891,31 @@ def publish_golden_image_degraded(
     except Exception:  # noqa: BLE001 — best-effort telemetry
         logger.debug(
             "[Stream] publish_golden_image_degraded exception", exc_info=True,
+        )
+        return None
+
+
+def publish_provider_state_changed(
+    detail: Mapping[str, Any],
+) -> Optional[str]:
+    """Best-effort publisher for ``provider_state_changed`` SSE frames — the
+    Sentinel's DEGRADED↔HEALTHY recovery signal + resilience snapshot (state,
+    jitter, adaptive threshold, ΔTTFT gradient, forecast TTR). Keyed by the
+    provider name (organism property, no op_id). One emission fans out to the
+    in-process TUI breadcrumb listener AND the /observability/stream SSE (→ HUD).
+    Returns the event_id, or None when disabled / invalid. NEVER raises."""
+    if not stream_enabled():
+        return None
+    try:
+        if not isinstance(detail, Mapping):
+            return None
+        key = str(detail.get("provider", "doubleword")) or "doubleword"
+        return get_default_broker().publish(
+            EVENT_TYPE_PROVIDER_STATE_CHANGED, key, dict(detail),
+        )
+    except Exception:  # noqa: BLE001 — best-effort telemetry
+        logger.debug(
+            "[Stream] publish_provider_state_changed exception", exc_info=True,
         )
         return None
 

--- a/backend/core/ouroboros/governance/provider_state_broker.py
+++ b/backend/core/ouroboros/governance/provider_state_broker.py
@@ -1,0 +1,163 @@
+"""Provider-state → broker bridge — the Sentinel's SQLite signal onto the bus.
+
+The headless Sentinel writes provider_state to SQLite (Single-Writer, no bus
+access). This bridge runs IN the main O+V process: it polls that SQLite row and,
+on a DEGRADED↔HEALTHY transition, publishes ``provider_state_changed`` on the
+``StreamEventBroker`` with the full resilience snapshot. That single emission
+fans out to BOTH the in-process TUI breadcrumb listener AND the
+``/observability/stream`` SSE (→ the JARVIS HUD) — so operators see the recovery
+the instant the Sentinel confirms it, with no polling in the UI.
+
+Read-only over SQLite; the only side effect is a best-effort broker publish.
+Never raises on the telemetry path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.ProviderStateBroker")
+
+EmitFn = Callable[[dict], Any]
+
+
+def build_provider_snapshot(conn, *, provider: str = "doubleword",
+                            now: Optional[float] = None) -> dict:
+    """Compose the resilience snapshot from the telemetry conn — the SAME source
+    the ``/provider`` dashboard renders. Never raises."""
+    snap: dict = {"provider": provider, "state": "UNKNOWN"}
+    try:
+        from backend.core.ouroboros.governance.provider_state import get_provider_state
+        from backend.core.ouroboros.governance.provider_jitter import (
+            jitter_index, required_consecutive_passes,
+        )
+        from backend.core.ouroboros.governance.dw_outage_forecaster import (
+            forecast_ttr, ttft_slope,
+        )
+    except Exception:  # noqa: BLE001
+        return snap
+    if conn is None:
+        return snap
+    try:
+        st = get_provider_state(conn, provider) or {}
+        snap.update({
+            "state": st.get("state", "UNKNOWN"),
+            "reason": st.get("reason", ""),
+            "updated_ts": st.get("updated_ts"),
+            "jitter": jitter_index(conn, provider, now=now),
+            "threshold": required_consecutive_passes(conn, provider, now=now),
+            "ttft_slope": ttft_slope(conn, provider, now=now),
+            "forecast_ttr": forecast_ttr(conn),
+        })
+    except Exception:  # noqa: BLE001
+        pass
+    return snap
+
+
+def format_provider_breadcrumb(payload: dict) -> str:
+    """The calm one-line breadcrumb the TUI prints on a transition. Plain text
+    (the listener adds color). Never raises."""
+    try:
+        prov = payload.get("provider", "doubleword")
+        state = payload.get("state", "?")
+        if state == "HEALTHY":
+            reason = payload.get("reason", "") or ""
+            tail = f" — {reason}" if reason else " — recovered, stable"
+            return f"provider  {prov} ● HEALTHY ✓{tail}"
+        ji = payload.get("jitter", "?")
+        slope = payload.get("ttft_slope")
+        grad = ""
+        if isinstance(slope, (int, float)):
+            grad = ", ΔTTFT stabilizing" if slope < 0 else ", ΔTTFT worsening"
+        thr = payload.get("threshold")
+        thr_s = f", need {thr} stable passes" if thr else ""
+        return f"provider  {prov} ● {state} → jitter {ji}{grad}{thr_s}"
+    except Exception:  # noqa: BLE001
+        return "provider state changed"
+
+
+class ProviderStateWatcher:
+    """Polls the provider_state SQLite row and emits a snapshot on each
+    DEGRADED↔HEALTHY transition. Injectable clock/emit for testing."""
+
+    def __init__(
+        self, conn, emit_fn: EmitFn, *, provider: str = "doubleword",
+        now_fn: Optional[Callable[[], float]] = None, poll_s: float = 5.0,
+        emit_on_first: bool = False,
+    ) -> None:
+        self._conn = conn
+        self._emit = emit_fn
+        self._provider = provider
+        self._now = now_fn or time.time
+        self._poll_s = poll_s
+        self._emit_on_first = emit_on_first
+        self._last_state: Optional[str] = None
+
+    async def poll_once(self) -> Optional[dict]:
+        """One read. Emits + returns the snapshot on a state change, else None."""
+        snap = build_provider_snapshot(self._conn, provider=self._provider, now=self._now())
+        state = snap.get("state")
+        if state == self._last_state:
+            return None
+        prev = self._last_state
+        self._last_state = state
+        if prev is None and not self._emit_on_first:
+            return None                     # first observation — establish baseline
+        snap["previous_state"] = prev
+        try:
+            self._emit(snap)
+        except Exception:  # noqa: BLE001 — a bad emit never kills the watcher
+            logger.debug("[ProviderStateWatcher] emit failed", exc_info=True)
+        return snap
+
+    async def run(
+        self, *, sleep_fn: Optional[Callable[[float], Awaitable[None]]] = None,
+        max_polls: Optional[int] = None,
+    ) -> None:
+        sleep = sleep_fn or asyncio.sleep
+        polls = 0
+        while True:
+            try:
+                await self.poll_once()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                pass
+            polls += 1
+            if max_polls is not None and polls >= max_polls:
+                return
+            await sleep(self._poll_s)
+
+
+def start_provider_state_watcher(
+    *, provider: str = "doubleword", poll_s: float = 5.0,
+) -> Optional["asyncio.Task"]:
+    """Production wiring: open the telemetry DB, publish transitions on the
+    default broker via ``publish_provider_state_changed``. Returns the task, or
+    None if the substrate/broker is unavailable. Never raises."""
+    try:
+        from backend.core.ouroboros.governance.dw_outage_forecaster import open_forecast_db
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_provider_state_changed,
+        )
+        conn = open_forecast_db()
+        if conn is None:
+            return None
+        watcher = ProviderStateWatcher(
+            conn, lambda snap: publish_provider_state_changed(snap),
+            provider=provider, poll_s=poll_s,
+        )
+        return asyncio.ensure_future(watcher.run())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+__all__ = [
+    "ProviderStateWatcher",
+    "build_provider_snapshot",
+    "format_provider_breadcrumb",
+    "start_provider_state_watcher",
+]

--- a/tests/governance/test_provider_state_broker.py
+++ b/tests/governance/test_provider_state_broker.py
@@ -1,0 +1,101 @@
+"""Provider-state → broker bridge: SQLite transitions onto the event bus + TUI.
+
+The watcher polls the Sentinel's provider_state SQLite row and emits a snapshot
+on each DEGRADED↔HEALTHY transition; the breadcrumb formats the calm one-liner;
+the publish helper routes it onto the StreamEventBroker (→ TUI listener + SSE/HUD).
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.provider_jitter import record_jitter_event
+from backend.core.ouroboros.governance.provider_state import mark_degraded, mark_healthy
+from backend.core.ouroboros.governance.provider_state_broker import (
+    ProviderStateWatcher,
+    build_provider_snapshot,
+    format_provider_breadcrumb,
+)
+
+
+def _db() -> sqlite3.Connection:
+    return sqlite3.connect(":memory:", check_same_thread=False)
+
+
+async def test_snapshot_carries_full_resilience_state() -> None:
+    conn = _db()
+    NOW = 1000.0
+    mark_degraded(conn, "doubleword", reason="sentinel_watch_start", ts=NOW - 10)
+    for i in range(3):
+        record_jitter_event(conn, "doubleword", "no_tokens", ts=NOW - 5 - i)
+    snap = build_provider_snapshot(conn, now=NOW)
+    assert snap["state"] == "DEGRADED"
+    assert snap["jitter"] == 3
+    assert snap["threshold"] == 5           # 2 + 3 jitter
+    assert "forecast_ttr" in snap and "ttft_slope" in snap
+
+
+async def test_watcher_emits_only_on_transition() -> None:
+    conn = _db()
+    mark_degraded(conn, "doubleword", reason="down")
+    emitted = []
+    w = ProviderStateWatcher(conn, lambda s: emitted.append(s), emit_on_first=True)
+
+    await w.poll_once()                      # first observation → DEGRADED (emit_on_first)
+    assert len(emitted) == 1 and emitted[-1]["state"] == "DEGRADED"
+
+    await w.poll_once()                      # unchanged → no emit
+    assert len(emitted) == 1
+
+    mark_healthy(conn, "doubleword", reason="staged_2pass_ok x5 (jitter-adaptive+pulse)")
+    snap = await w.poll_once()               # DEGRADED → HEALTHY → emit
+    assert len(emitted) == 2
+    assert snap["state"] == "HEALTHY" and snap["previous_state"] == "DEGRADED"
+
+
+async def test_watcher_first_observation_silent_by_default() -> None:
+    conn = _db()
+    mark_degraded(conn, "doubleword", reason="down")
+    emitted = []
+    w = ProviderStateWatcher(conn, lambda s: emitted.append(s))  # emit_on_first=False
+    await w.poll_once()                      # baseline only, no emit
+    assert emitted == []
+    mark_healthy(conn, "doubleword", reason="recovered")
+    await w.poll_once()                      # the transition emits
+    assert len(emitted) == 1 and emitted[-1]["state"] == "HEALTHY"
+
+
+def test_breadcrumb_formatting() -> None:
+    deg = format_provider_breadcrumb(
+        {"provider": "doubleword", "state": "DEGRADED", "jitter": 14,
+         "ttft_slope": 0.001, "threshold": 5}
+    )
+    assert "doubleword ● DEGRADED" in deg
+    assert "jitter 14" in deg and "worsening" in deg and "need 5 stable" in deg
+
+    heal = format_provider_breadcrumb(
+        {"provider": "doubleword", "state": "HEALTHY", "reason": "staged_2pass_ok x5"}
+    )
+    assert "HEALTHY ✓" in heal and "staged_2pass_ok x5" in heal
+
+    stab = format_provider_breadcrumb(
+        {"state": "DEGRADED", "jitter": 2, "ttft_slope": -0.02}
+    )
+    assert "stabilizing" in stab
+
+
+async def test_publish_helper_accepted_by_broker_allowlist(monkeypatch) -> None:
+    # The new event type must be in _VALID_EVENT_TYPES or publish drops it.
+    monkeypatch.setenv("JARVIS_IDE_STREAM_ENABLED", "true")
+    from backend.core.ouroboros.governance import ide_observability_stream as S
+    eid = S.publish_provider_state_changed(
+        {"provider": "doubleword", "state": "HEALTHY", "jitter": 0}
+    )
+    # eid is a non-None event id when accepted (broker enabled); None only if the
+    # stream is disabled — never a rejection for an unknown type.
+    assert "provider_state_changed" in S._VALID_EVENT_TYPES
+    # A genuinely unknown type IS rejected (proves the allowlist is the gate).
+    assert S.get_default_broker().publish("totally_unknown_type", "k", {}) is None


### PR DESCRIPTION
## Surface the Sentinel's DEGRADED↔HEALTHY transitions live (TUI + SSE/HUD)

The `/provider` verb (#70043) is the pull-view; this adds the **push** — a calm one-line breadcrumb the instant the Sentinel's `provider_state` flips, printed inline in the SerpentFlow flow. And because it rides the shared `StreamEventBroker`, the same emission reaches the `/observability/stream` SSE that (via a bridge) feeds the JARVIS HUD — **one emission, both surfaces**.

- **`ide_observability_stream.py`** — `EVENT_TYPE_PROVIDER_STATE_CHANGED` added to the constants + `_VALID_EVENT_TYPES` allowlist; `publish_provider_state_changed(detail)` mirrors `publish_golden_image_degraded`.
- **`provider_state_broker.py`** (new) — `build_provider_snapshot` (same resilience source `/provider` renders), `ProviderStateWatcher` (polls the Sentinel's SQLite row, emits a snapshot **only on a state transition** — read-only over SQLite, single side-effect is a best-effort publish), `format_provider_breadcrumb`, `start_provider_state_watcher`.
- **`serpent_flow.py`** — `_provider_breadcrumb_listener` cloned from the Slice-253 shadow breadcrumb: subscribes in-process to the event and prints green `✓ HEALTHY` / amber `⚠ DEGRADED`; started + torn down alongside the shadow task. Best-effort, never blocks REPL boot.

**Proven end-to-end:** SQLite `DEGRADED→HEALTHY` → watcher → publish → broker → subscriber received (`prev=DEGRADED`) → breadcrumb `doubleword ● HEALTHY ✓`.

### Tests (5, + `/provider` suite green)
snapshot carries full resilience state; watcher emits **only** on transition (silent baseline by default); breadcrumb formatting; publish accepted by the allowlist while an unknown type is rejected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show live provider-state transitions (DEGRADED↔HEALTHY) in the CLI and HUD by bridging the Sentinel’s SQLite signal to the shared event broker. One publish updates the in-process breadcrumb and the `/observability/stream` SSE (no polling).

- **New Features**
  - Added `provider_state_changed` event and `publish_provider_state_changed` to the stream allowlist.
  - New `provider_state_broker.py`: `ProviderStateWatcher` polls SQLite and publishes only on transitions; `build_provider_snapshot`; `format_provider_breadcrumb`; `start_provider_state_watcher`.
  - Updated SerpentFlow to subscribe in-process and print a one-line breadcrumb (green “✓ HEALTHY”, amber “⚠ DEGRADED”); tasks start/stop with the REPL and are best-effort.

<sup>Written for commit 4e20c0283573bc657fdcd94595ec3b9b51c1c4eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70044?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

