### PR TITLE
Unified Event Breadcrumb Router — connect the entire backend surface to the CLI

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4640,6 +4640,76 @@ class SerpentREPL:
         except Exception:  # noqa: BLE001 — resilience breadcrumb is best-effort
             self._provider_state_watcher_task = None
             self._provider_breadcrumb_task = None
+        # Unified event-feed router — ONE subscription surfacing the ENTIRE
+        # backend event surface (~149 broker types) via the descriptor registry,
+        # filtered by /breadcrumbs verbosity + de-flooded. Best-effort.
+        self._event_breadcrumb_router_task = None
+        try:
+            self._event_breadcrumb_router_task = asyncio.ensure_future(
+                self._event_breadcrumb_router()
+            )
+        except Exception:  # noqa: BLE001
+            self._event_breadcrumb_router_task = None
+
+    async def _event_breadcrumb_router(self) -> None:
+        """The ONE unified live event feed: subscribe once to the broker and
+        surface EVERY backend event through the descriptor registry — filtered by
+        the operator's ``/breadcrumbs`` verbosity floor and de-flooded by a
+        coalescer. Events that have a tailored bespoke listener (shadow-trap,
+        provider-state) are skipped here so there is no double-print; an
+        UNREGISTERED/new event still surfaces via the registry's heuristic. This
+        is the root-cause replacement for per-type listener clones — new backend
+        events light up the CLI with zero TUI code. Best-effort + fail-soft."""
+        sub = None
+        broker = None
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                get_default_broker,
+            )
+            from backend.core.ouroboros.governance.event_breadcrumb_registry import (
+                BreadcrumbCoalescer,
+                build_default_registry,
+                get_min_severity,
+            )
+
+            reg = build_default_registry()
+            coalescer = BreadcrumbCoalescer()
+            broker = get_default_broker()
+            sub = broker.subscribe()
+            if sub is None:
+                return
+            async for event in broker.stream_iter(sub, heartbeat_s=0):
+                try:
+                    et = getattr(event, "event_type", "") or ""
+                    if not et or reg.is_bespoke(et):
+                        continue
+                    floor = get_min_severity()
+                    if floor >= 99:            # /breadcrumbs off
+                        continue
+                    payload = dict(getattr(event, "payload", {}) or {})
+                    desc = reg.describe(et)
+                    if desc.severity < floor:
+                        continue
+                    key = str(payload.get("provider", payload.get("op_id", "")) or "")
+                    if not coalescer.should_show(et, key):
+                        continue
+                    _sev, text = reg.render(et, payload)
+                    self._flow.console.print(
+                        f"  [{desc.color}]{desc.glyph} {text}[/{desc.color}]",
+                        highlight=False,
+                    )
+                except Exception:  # noqa: BLE001 — one bad event never kills the loop
+                    continue
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — strictly best-effort
+            return
+        finally:
+            try:
+                if broker is not None and sub is not None:
+                    broker.unsubscribe(sub)
+            except Exception:  # noqa: BLE001
+                pass
 
     async def _provider_breadcrumb_listener(self) -> None:
         """Surface a calm one-line breadcrumb when the DW Sentinel's provider
@@ -4754,8 +4824,10 @@ class SerpentREPL:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
             self._shadow_breadcrumb_task = None
-        # Tear down the provider-state resilience breadcrumb + watcher.
-        for _attr in ("_provider_breadcrumb_task", "_provider_state_watcher_task"):
+        # Tear down the provider-state resilience breadcrumb + watcher + the
+        # unified event-feed router.
+        for _attr in ("_event_breadcrumb_router_task",
+                      "_provider_breadcrumb_task", "_provider_state_watcher_task"):
             _pt = getattr(self, _attr, None)
             if _pt is not None:
                 _pt.cancel()

--- a/backend/core/ouroboros/governance/breadcrumbs_repl.py
+++ b/backend/core/ouroboros/governance/breadcrumbs_repl.py
@@ -1,0 +1,121 @@
+"""``/breadcrumbs`` — operator control for the unified live event feed.
+
+The TUI's single event-breadcrumb router surfaces the entire backend event
+surface (~149 broker event types) through the descriptor registry. This verb
+sets the verbosity floor (off / critical / important / info / all) and shows the
+current setting. Read/write of a module-level knob only — no orchestrator /
+providers / iron_gate imports (naming-cage authority). Auto-discovered via the
+module-level ``dispatch_breadcrumbs_command``.
+"""
+
+from __future__ import annotations
+
+import shlex
+from dataclasses import dataclass
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_CYAN = "\033[36m"
+
+
+@dataclass(frozen=True)
+class BreadcrumbsReplDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+
+
+_LEVELS = ("off", "critical", "important", "info", "all")
+
+_HELP = (
+    f"  {_BOLD}{_CYAN}/breadcrumbs — live event feed verbosity{_RESET}\n"
+    f"  {_DIM}One router surfaces the whole backend event surface; this sets how "
+    f"much of it prints inline.{_RESET}\n\n"
+    f"  {_BOLD}Levels:{_RESET}\n"
+    f"    {_CYAN}/breadcrumbs off{_RESET}         {_DIM}silence the live feed{_RESET}\n"
+    f"    {_CYAN}/breadcrumbs critical{_RESET}    {_DIM}only trips / exhaustion / anomalies{_RESET}\n"
+    f"    {_CYAN}/breadcrumbs important{_RESET}   {_DIM}+ throttles, drift, degradation (default){_RESET}\n"
+    f"    {_CYAN}/breadcrumbs info{_RESET}        {_DIM}+ posture, plans, learning{_RESET}\n"
+    f"    {_CYAN}/breadcrumbs all{_RESET}         {_DIM}everything (incl. unknown/new events){_RESET}\n"
+    f"    {_CYAN}/breadcrumbs{_RESET}             {_DIM}show the current level{_RESET}\n"
+)
+
+
+def _matches(line: str) -> bool:
+    s = (line or "").strip()
+    return s in ("/breadcrumbs", "breadcrumbs") or s.startswith(("/breadcrumbs ", "breadcrumbs "))
+
+
+def _status_text() -> str:
+    try:
+        from backend.core.ouroboros.governance.event_breadcrumb_registry import (
+            get_min_severity, severity_name,
+        )
+        lvl = severity_name(get_min_severity())
+    except Exception:  # noqa: BLE001
+        lvl = "?"
+    return (
+        f"  {_BOLD}Live event feed:{_RESET} {_CYAN}{lvl}{_RESET}\n"
+        f"  {_DIM}one router → the whole broker surface; {' / '.join(_LEVELS)} "
+        f"(/breadcrumbs <level>){_RESET}"
+    )
+
+
+def dispatch_breadcrumbs_command(line: str) -> BreadcrumbsReplDispatchResult:
+    """Parse ``/breadcrumbs`` and set/show the feed verbosity. NEVER raises."""
+    if not _matches(line):
+        return BreadcrumbsReplDispatchResult(ok=False, text="", matched=False)
+    try:
+        tokens = shlex.split(line)
+    except ValueError as exc:
+        return BreadcrumbsReplDispatchResult(ok=False, text=f"  /breadcrumbs parse error: {exc}")
+    args = tokens[1:] if tokens else []
+    head = (args[0].lower() if args else "")
+
+    if head in ("help", "?"):
+        return BreadcrumbsReplDispatchResult(ok=True, text=_HELP)
+    if head == "":
+        return BreadcrumbsReplDispatchResult(ok=True, text=_status_text())
+    if head in ("status",):
+        return BreadcrumbsReplDispatchResult(ok=True, text=_status_text())
+    if head in _LEVELS:
+        try:
+            from backend.core.ouroboros.governance.event_breadcrumb_registry import (
+                set_min_severity, severity_name, get_min_severity,
+            )
+            set_min_severity(head)
+            return BreadcrumbsReplDispatchResult(
+                ok=True,
+                text=f"  live event feed → {_CYAN}{severity_name(get_min_severity())}{_RESET}",
+            )
+        except Exception:  # noqa: BLE001
+            return BreadcrumbsReplDispatchResult(ok=False, text="  /breadcrumbs: registry unavailable")
+    return BreadcrumbsReplDispatchResult(
+        ok=False,
+        text=f"  /breadcrumbs: unknown level {head!r} — one of {', '.join(_LEVELS)}",
+    )
+
+
+def register_verbs(registry) -> int:
+    try:
+        registry.register(
+            verb="breadcrumbs",
+            description=(
+                "Live event-feed verbosity — the single router that surfaces the "
+                "whole backend event surface (149 broker event types) inline. "
+                "off / critical / important / info / all."
+            ),
+            posture_relevance="RELEVANT",
+            since="Unified event breadcrumb router (2026-07-23)",
+        )
+        return 1
+    except Exception:  # noqa: BLE001
+        return 0
+
+
+__all__ = [
+    "BreadcrumbsReplDispatchResult",
+    "dispatch_breadcrumbs_command",
+    "register_verbs",
+]

--- a/backend/core/ouroboros/governance/event_breadcrumb_registry.py
+++ b/backend/core/ouroboros/governance/event_breadcrumb_registry.py
@@ -1,0 +1,341 @@
+"""Event Breadcrumb Registry — connect the ENTIRE backend event surface to the CLI.
+
+The ``StreamEventBroker`` carries ~149 event types, but the TUI historically
+surfaced them with BESPOKE per-type listener methods (one clone per event). That
+does not scale and leaves most of the organism invisible. This is the descriptor-
+driven replacement — the same pattern as ``ToolRenderRegistry``:
+
+  * A ``BreadcrumbDescriptor`` maps an ``event_type`` → glyph + color + severity +
+    a payload formatter.
+  * The registry seeds tailored descriptors for the high-value events, and — the
+    key move — SYNTHESIZES a descriptor for ANY unregistered type via a
+    name-based severity heuristic + a generic key/value formatter. So a brand-new
+    backend event lights up the CLI with ZERO TUI code, at a sensible severity.
+  * A single router (in the TUI) subscribes ONCE and renders every event through
+    this registry, filtered by the operator's chosen verbosity and de-flooded by
+    a coalescer.
+
+No hardcoded per-event ``if/elif`` in the TUI; no duplication; new events are
+first-class automatically. Pure formatting — imports nothing heavy, touches no
+model-selection path (the Fable model is never flagged). Never raises.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from dataclasses import dataclass
+from typing import Callable, Dict, Optional, Tuple
+
+# ── Severity ranks (higher = louder). Operator filter shows rank >= threshold. ──
+SEV_VERBOSE = 0
+SEV_INFO = 1
+SEV_IMPORTANT = 2
+SEV_CRITICAL = 3
+
+_SEV_NAMES = {SEV_VERBOSE: "verbose", SEV_INFO: "info",
+              SEV_IMPORTANT: "important", SEV_CRITICAL: "critical"}
+_NAME_TO_SEV = {v: k for k, v in _SEV_NAMES.items()}
+_NAME_TO_SEV["all"] = SEV_VERBOSE
+_NAME_TO_SEV["off"] = 99  # sentinel — show nothing
+
+_LEVEL_ENV = "JARVIS_TUI_EVENT_BREADCRUMB_LEVEL"
+_DEFAULT_LEVEL = SEV_IMPORTANT
+
+
+PayloadFormatter = Callable[[dict], str]
+
+
+@dataclass(frozen=True)
+class BreadcrumbDescriptor:
+    event_type: str
+    glyph: str
+    color: str                     # a Rich color/style token
+    severity: int
+    formatter: Optional[PayloadFormatter] = None
+    category: str = "general"
+
+
+# ---------------------------------------------------------------------------
+# Name-based heuristics — how UNREGISTERED events get a sensible descriptor
+# ---------------------------------------------------------------------------
+
+_CRIT_MARKERS = ("tripped", "exhausted", "emergency", "anomaly", "overrun",
+                 "sustained_low", "circuit_tripped")
+_IMPORTANT_MARKERS = ("degraded", "throttle", "pressure", "drift", "_drop",
+                      "warning", "brake", "rejected", "expired", "denied",
+                      "confidence", "cost_band", "budget_action", "failure",
+                      "state_change", "state_changed", "approaching")
+_INFO_MARKERS = ("changed", "detected", "crossed", "graduated", "approved",
+                 "absorbed", "decomposed", "proposal", "learned", "fused",
+                 "convergence", "calibrated", "found", "generated")
+_VERBOSE_MARKERS = ("heartbeat", "tick", "lag", "rendered", "snapshot",
+                    "updated", "progress", "prefetch", "compacted", "created",
+                    "started", "completed", "cancelled", "closed", "replay",
+                    "dashboard", "portrait", "story", "flow", "ledger",
+                    "browsing", "dream", "cue", "scheduled")
+
+_CATEGORY_PREFIXES = (
+    ("provider", "provider"), ("circuit_breaker", "provider"),
+    ("golden_image", "provider"), ("governor", "governance"),
+    ("memory", "memory"), ("posture", "posture"), ("plan", "plan"),
+    ("inline_", "permission"), ("shadow", "permission"), ("cost", "cost"),
+    ("budget", "cost"), ("model_", "model"), ("drift", "integrity"),
+    ("git_", "integrity"), ("flag_", "flags"), ("task_", "tasks"),
+    ("soak", "soak"), ("session", "session"),
+)
+
+
+def _humanize(event_type: str) -> str:
+    return event_type.replace("_", " ").strip()
+
+
+def _heuristic_severity(event_type: str) -> int:
+    t = event_type.lower()
+    if any(m in t for m in _CRIT_MARKERS):
+        return SEV_CRITICAL
+    if any(m in t for m in _IMPORTANT_MARKERS):
+        return SEV_IMPORTANT
+    if any(m in t for m in _VERBOSE_MARKERS):
+        return SEV_VERBOSE
+    if any(m in t for m in _INFO_MARKERS):
+        return SEV_INFO
+    return SEV_INFO
+
+
+def _heuristic_category(event_type: str) -> str:
+    t = event_type.lower()
+    for prefix, cat in _CATEGORY_PREFIXES:
+        if t.startswith(prefix) or prefix in t:
+            return cat
+    return "general"
+
+
+def _generic_formatter(payload: dict) -> str:
+    """Compact, safe key=value summary of the most salient payload fields. Skips
+    bulky / noisy values so an unknown event still reads cleanly. Never raises."""
+    if not isinstance(payload, dict) or not payload:
+        return ""
+    skip = {"op_id", "event_id", "ts", "timestamp", "schema_version",
+            "monotonic_ts", "seq", "provider"}
+    parts = []
+    for k, v in payload.items():
+        if k in skip:
+            continue
+        if isinstance(v, (dict, list)):
+            continue
+        s = str(v)
+        if not s or len(s) > 48:
+            continue
+        parts.append(f"{k}={s}")
+        if len(parts) >= 3:
+            break
+    return " ".join(parts)
+
+
+_GLYPH_BY_SEV = {SEV_CRITICAL: "✖", SEV_IMPORTANT: "▲", SEV_INFO: "·", SEV_VERBOSE: "·"}
+_COLOR_BY_SEV = {SEV_CRITICAL: "red", SEV_IMPORTANT: "yellow",
+                 SEV_INFO: "cyan", SEV_VERBOSE: "bright_black"}
+
+
+class EventBreadcrumbRegistry:
+    """event_type → descriptor, with a heuristic fallback for unknown types."""
+
+    def __init__(self) -> None:
+        self._by_type: Dict[str, BreadcrumbDescriptor] = {}
+        # Event types the TUI already handles with a bespoke, richer listener —
+        # the router skips these so there is no double-print.
+        self._bespoke: set = set()
+
+    def register(self, desc: BreadcrumbDescriptor) -> None:
+        self._by_type[desc.event_type] = desc
+
+    def mark_bespoke(self, *event_types: str) -> None:
+        self._bespoke.update(event_types)
+
+    def is_bespoke(self, event_type: str) -> bool:
+        return event_type in self._bespoke
+
+    def describe(self, event_type: str) -> BreadcrumbDescriptor:
+        """Registered descriptor, else a synthesized one (name-based severity +
+        generic formatter) so EVERY event surfaces. Never raises."""
+        d = self._by_type.get(event_type)
+        if d is not None:
+            return d
+        sev = _heuristic_severity(event_type)
+        return BreadcrumbDescriptor(
+            event_type=event_type, glyph=_GLYPH_BY_SEV[sev],
+            color=_COLOR_BY_SEV[sev], severity=sev,
+            formatter=_generic_formatter, category=_heuristic_category(event_type),
+        )
+
+    def render(self, event_type: str, payload: dict) -> Tuple[int, str]:
+        """Return ``(severity, plain_text)`` for an event. Never raises."""
+        desc = self.describe(event_type)
+        label = _humanize(event_type)
+        try:
+            body = desc.formatter(payload) if desc.formatter else ""
+        except Exception:  # noqa: BLE001
+            body = ""
+        text = f"{label}" + (f" — {body}" if body else "")
+        return desc.severity, text
+
+
+# ---------------------------------------------------------------------------
+# Seed descriptors for high-value events (tailored formatting)
+# ---------------------------------------------------------------------------
+
+
+def _f_circuit(p: dict) -> str:
+    return f"{p.get('provider', '?')} → {p.get('to_state', p.get('state', '?'))} " \
+           f"({p.get('terminal_reason_code', p.get('reason', ''))})".strip()
+
+
+def _f_governor(p: dict) -> str:
+    return f"cap {p.get('applied_cap', p.get('cap', '?'))} " \
+           f"(posture={p.get('posture', '?')}, reason={p.get('reason', '')})".strip()
+
+
+def _f_memory(p: dict) -> str:
+    return f"{p.get('level', p.get('to_level', '?'))} " \
+           f"(fanout≤{p.get('fanout_cap', '?')})"
+
+
+def _f_posture(p: dict) -> str:
+    return f"{p.get('from', p.get('previous', '?'))} → {p.get('to', p.get('posture', '?'))}"
+
+
+def _f_costband(p: dict) -> str:
+    return f"crossed {p.get('band', '?')} (${p.get('cost_usd', p.get('spend', '?'))})"
+
+
+def _f_confidence(p: dict) -> str:
+    return f"model {p.get('model', '?')} conf={p.get('confidence', '?')}"
+
+
+def build_default_registry() -> EventBreadcrumbRegistry:
+    reg = EventBreadcrumbRegistry()
+    # These two already have tailored, prompt-aware bespoke listeners in the TUI.
+    reg.mark_bespoke("shadow_action_trapped", "provider_state_changed")
+
+    seed = [
+        BreadcrumbDescriptor("circuit_breaker_tripped", "✖", "red bold", SEV_CRITICAL, _f_circuit, "provider"),
+        BreadcrumbDescriptor("circuit_breaker_state_change", "▲", "yellow", SEV_IMPORTANT, _f_circuit, "provider"),
+        BreadcrumbDescriptor("provider_failure_classified", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"{p.get('provider','?')}: {p.get('failure_class', p.get('class',''))}", "provider"),
+        BreadcrumbDescriptor("golden_image_degraded", "✖", "red", SEV_CRITICAL,
+                             lambda p: f"failover cold-boot ({p.get('reason','')})", "provider"),
+        BreadcrumbDescriptor("governor_throttle_applied", "▲", "yellow", SEV_IMPORTANT, _f_governor, "governance"),
+        BreadcrumbDescriptor("governor_emergency_brake", "✖", "red bold", SEV_CRITICAL, _f_governor, "governance"),
+        BreadcrumbDescriptor("memory_pressure_changed", "▲", "yellow", SEV_IMPORTANT, _f_memory, "memory"),
+        BreadcrumbDescriptor("posture_changed", "◆", "cyan", SEV_INFO, _f_posture, "posture"),
+        BreadcrumbDescriptor("drift_detected", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"target {p.get('target', p.get('file',''))} drifted", "integrity"),
+        BreadcrumbDescriptor("git_index_anomaly", "✖", "red", SEV_CRITICAL,
+                             lambda p: f"{p.get('detail', p.get('reason',''))}", "integrity"),
+        BreadcrumbDescriptor("cost_band_crossed", "▲", "yellow", SEV_IMPORTANT, _f_costband, "cost"),
+        BreadcrumbDescriptor("budget_action_taken", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"{p.get('action','?')} (${p.get('spend', p.get('cost_usd',''))})", "cost"),
+        BreadcrumbDescriptor("session_exhausted", "✖", "red bold", SEV_CRITICAL,
+                             lambda p: f"{p.get('reason','all providers exhausted')}", "session"),
+        BreadcrumbDescriptor("soak_circuit_tripped", "✖", "red", SEV_CRITICAL,
+                             lambda p: f"{p.get('reason','')}", "soak"),
+        BreadcrumbDescriptor("soak_budget_warning", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"${p.get('spend','?')}/{p.get('cap','?')}", "soak"),
+        BreadcrumbDescriptor("model_confidence_drop", "▲", "yellow", SEV_IMPORTANT, _f_confidence, "model"),
+        BreadcrumbDescriptor("model_sustained_low_confidence", "✖", "red", SEV_CRITICAL, _f_confidence, "model"),
+        BreadcrumbDescriptor("guidance_absorbed", "◆", "cyan", SEV_INFO,
+                             lambda p: f"steering folded into op {p.get('op_id','')[:8]}", "governance"),
+        BreadcrumbDescriptor("flag_typo_detected", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"{p.get('typo','?')} → {p.get('suggestion','?')}", "flags"),
+        BreadcrumbDescriptor("plan_rejected", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"op {p.get('op_id','')[:8]} plan rejected", "plan"),
+        BreadcrumbDescriptor("cancellation_overrun_detected", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"cancel guard overran ({p.get('provider','?')})", "provider"),
+        BreadcrumbDescriptor("trajectory_drift_detected", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"{p.get('detail','trajectory drift')}", "integrity"),
+        BreadcrumbDescriptor("decision_drift_detected", "▲", "yellow", SEV_IMPORTANT,
+                             lambda p: f"{p.get('detail','decision drift')}", "integrity"),
+    ]
+    for d in seed:
+        reg.register(d)
+    return reg
+
+
+# ---------------------------------------------------------------------------
+# Operator verbosity (shared by the /breadcrumbs verb + the TUI router)
+# ---------------------------------------------------------------------------
+
+_active_level: Optional[int] = None
+
+
+def get_min_severity() -> int:
+    """Active breadcrumb verbosity floor (env-seeded, verb-overridable)."""
+    global _active_level
+    if _active_level is not None:
+        return _active_level
+    raw = (os.environ.get(_LEVEL_ENV, "") or "").strip().lower()
+    if raw in _NAME_TO_SEV:
+        return _NAME_TO_SEV[raw]
+    return _DEFAULT_LEVEL
+
+
+def set_min_severity(level) -> int:
+    """Set the floor from a name ('off'/'critical'/'important'/'info'/'all') or
+    an int rank. Returns the resolved rank. Never raises."""
+    global _active_level
+    if isinstance(level, str):
+        _active_level = _NAME_TO_SEV.get(level.strip().lower(), _DEFAULT_LEVEL)
+    else:
+        try:
+            _active_level = int(level)
+        except (TypeError, ValueError):
+            _active_level = _DEFAULT_LEVEL
+    return _active_level
+
+
+def severity_name(rank: int) -> str:
+    return _SEV_NAMES.get(rank, "off" if rank >= 99 else "?")
+
+
+# ---------------------------------------------------------------------------
+# Coalescer — de-flood repeated events (edge case: storms of one type)
+# ---------------------------------------------------------------------------
+
+
+class BreadcrumbCoalescer:
+    """Suppresses a repeated ``(event_type, key)`` within ``window_s`` so a burst
+    (e.g. rapid circuit_breaker_approaching) prints once, not 50×. Never raises."""
+
+    def __init__(self, window_s: float = 6.0) -> None:
+        self._window_s = window_s
+        self._last: Dict[Tuple[str, str], float] = {}
+
+    def should_show(self, event_type: str, key: str = "", *, now: Optional[float] = None) -> bool:
+        ref = time.time() if now is None else now
+        k = (event_type, key)
+        last = self._last.get(k)
+        if last is not None and (ref - last) < self._window_s:
+            return False
+        self._last[k] = ref
+        # opportunistic prune
+        if len(self._last) > 512:
+            cutoff = ref - 4.0 * self._window_s
+            for kk in [kk for kk, ts in self._last.items() if ts < cutoff]:
+                self._last.pop(kk, None)
+        return True
+
+
+__all__ = [
+    "BreadcrumbCoalescer",
+    "BreadcrumbDescriptor",
+    "EventBreadcrumbRegistry",
+    "SEV_CRITICAL",
+    "SEV_IMPORTANT",
+    "SEV_INFO",
+    "SEV_VERBOSE",
+    "build_default_registry",
+    "get_min_severity",
+    "set_min_severity",
+    "severity_name",
+]

--- a/tests/governance/test_event_breadcrumb_registry.py
+++ b/tests/governance/test_event_breadcrumb_registry.py
@@ -1,0 +1,116 @@
+"""Event Breadcrumb Registry — connect the whole backend event surface to the CLI.
+
+One descriptor-driven registry renders ANY of the ~149 broker event types; an
+unregistered/new event still surfaces via a name-based severity heuristic + a
+generic formatter. Verbosity filter + coalescer keep it calm.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.governance.breadcrumbs_repl import (
+    dispatch_breadcrumbs_command,
+)
+from backend.core.ouroboros.governance.event_breadcrumb_registry import (
+    BreadcrumbCoalescer,
+    SEV_CRITICAL,
+    SEV_IMPORTANT,
+    SEV_INFO,
+    SEV_VERBOSE,
+    build_default_registry,
+    get_min_severity,
+    set_min_severity,
+    severity_name,
+)
+
+
+def _strip(s: str) -> str:
+    import re
+    return re.sub(r"\033\[[0-9;]*m", "", s)
+
+
+def test_seeded_descriptor_tailored_render() -> None:
+    reg = build_default_registry()
+    sev, text = reg.render("circuit_breaker_tripped",
+                           {"provider": "doubleword", "to_state": "OPEN_TERMINAL",
+                            "terminal_reason_code": "quota"})
+    assert sev == SEV_CRITICAL
+    assert "circuit breaker tripped" in text
+    assert "doubleword" in text and "OPEN_TERMINAL" in text and "quota" in text
+
+
+def test_unknown_event_still_surfaces_via_heuristic() -> None:
+    reg = build_default_registry()
+    # A brand-new event nobody registered — MUST still render, at a sane severity.
+    sev, text = reg.render("quantum_entangler_tripped", {"detail": "spooky", "op_id": "x"})
+    assert sev == SEV_CRITICAL                      # "tripped" → critical heuristic
+    assert "quantum entangler tripped" in text
+    assert "detail=spooky" in text                  # generic formatter
+    assert "op_id" not in text                      # noisy keys skipped
+
+    sev2, _ = reg.render("some_new_thing_changed", {"a": 1})
+    assert sev2 == SEV_INFO                           # generic "changed" → info
+    sev_imp, _ = reg.render("widget_state_change", {})
+    assert sev_imp == SEV_IMPORTANT                   # specific "state_change" → important
+    sev3, _ = reg.render("progress_tick", {})
+    assert sev3 == SEV_VERBOSE                        # "tick" → verbose
+
+
+def test_bespoke_events_are_skipped_by_router() -> None:
+    reg = build_default_registry()
+    # The two events with tailored bespoke listeners must be flagged so the
+    # unified router does not double-print them.
+    assert reg.is_bespoke("shadow_action_trapped") is True
+    assert reg.is_bespoke("provider_state_changed") is True
+    assert reg.is_bespoke("circuit_breaker_tripped") is False
+
+
+def test_severity_filter_levels() -> None:
+    set_min_severity("critical")
+    assert get_min_severity() == SEV_CRITICAL
+    set_min_severity("all")
+    assert get_min_severity() == SEV_VERBOSE
+    set_min_severity("important")
+    assert get_min_severity() == SEV_IMPORTANT
+    assert severity_name(SEV_IMPORTANT) == "important"
+    set_min_severity("off")
+    assert get_min_severity() >= 99                  # nothing shown
+    set_min_severity("important")                     # restore default for other tests
+
+
+def test_coalescer_deflood() -> None:
+    c = BreadcrumbCoalescer(window_s=6.0)
+    assert c.should_show("circuit_breaker_approaching", "dw", now=100.0) is True
+    assert c.should_show("circuit_breaker_approaching", "dw", now=101.0) is False  # within window
+    assert c.should_show("circuit_breaker_approaching", "dw", now=107.0) is True   # window passed
+    # Different key is independent.
+    assert c.should_show("circuit_breaker_approaching", "claude", now=101.0) is True
+
+
+def test_render_never_raises_on_bad_payload() -> None:
+    reg = build_default_registry()
+    for bad in (None, "not a dict", 42, {"nested": {"x": 1}}, {"big": "z" * 500}):
+        sev, text = reg.render("provider_failure_classified", bad if isinstance(bad, dict) else {})
+        assert isinstance(text, str)
+
+
+# ---------------------------------------------------------------------------
+# /breadcrumbs verb
+# ---------------------------------------------------------------------------
+
+
+def test_breadcrumbs_verb() -> None:
+    assert dispatch_breadcrumbs_command("/status").matched is False
+    assert dispatch_breadcrumbs_command("/breadcrumbs").matched is True
+    assert "Live event feed" in _strip(dispatch_breadcrumbs_command("/breadcrumbs").text)
+
+    r = dispatch_breadcrumbs_command("/breadcrumbs critical")
+    assert r.ok is True and get_min_severity() == SEV_CRITICAL
+    assert "critical" in _strip(r.text)
+
+    r2 = dispatch_breadcrumbs_command("/breadcrumbs bogus")
+    assert r2.ok is False and "unknown level" in r2.text
+
+    assert "verbosity" in _strip(dispatch_breadcrumbs_command("/breadcrumbs help").text)
+    set_min_severity("important")   # restore


### PR DESCRIPTION
## Root-cause: ~149 broker event types, ~2 reaching the TUI

The old pattern was a **bespoke per-type listener clone** — that doesn't scale and leaves the organism mostly invisible. This is the descriptor-driven replacement (same pattern as `ToolRenderRegistry`): **one subscription, one registry.**

- **`event_breadcrumb_registry.py`** — a `BreadcrumbDescriptor` (glyph/color/severity/formatter) per event type; `build_default_registry` seeds ~24 high-value events with tailored formatters. **The key move:** `describe()` **synthesizes** a descriptor for ANY unregistered/new type via a name-based severity heuristic (`tripped`/`exhausted`→CRITICAL, `degraded`/`throttle`/`drift`→IMPORTANT, `tick`/`heartbeat`→VERBOSE, …) + a generic `key=value` formatter that skips noisy/bulky fields. **A brand-new backend event lights up the CLI with zero TUI code**, at a sensible severity. Plus a 4-tier verbosity floor + `BreadcrumbCoalescer` (de-floods event storms) + `mark_bespoke` (skips the 2 events that have tailored listeners).
- **`breadcrumbs_repl.py`** — `/breadcrumbs [off|critical|important|info|all]` verb (naming-cage auto-discovered) to set/show the floor.
- **`serpent_flow.py`** — `_event_breadcrumb_router`: the ONE unified listener; subscribes once, renders every event via the registry filtered by the floor + coalescer, skips bespoke types, prints severity-colored. Started/torn down alongside the shadow/provider listeners; best-effort.

### Mandate conformance
- **Root-Cause Only** — one adaptive registry, not N listener clones; new events are first-class automatically.
- **DRY** — composes the `StreamEventBroker` + registry; no per-event `if/elif` in the TUI. Pure formatting — Fable never flagged.
- **Edge cases** — unknown events (heuristic), bad payloads (never raises), event storms (coalescer), off-switch, noisy-key skipping.

**Proven end-to-end:** a diverse burst (`circuit_breaker_tripped`, `governor_throttle_applied`, `memory_pressure_changed`, `cost_band_crossed`, an **unknown** `*_exhausted`) renders correctly — CRITICAL/IMPORTANT shown, INFO/VERBOSE filtered at the default floor, bespoke skipped, the unknown auto-classified CRITICAL. `serpent_flow` compiles; `/breadcrumbs` auto-discovers.

### Tests (7 passed)
tailored render; unknown-event heuristic + generic formatter + noisy-key skip; bespoke skip; severity filter levels; coalescer de-flood; never-raises on bad payload; the `/breadcrumbs` verb.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a unified event breadcrumb router that surfaces the entire broker event surface in the CLI via a descriptor-driven registry. New backend events render automatically, with a `/breadcrumbs` command to control verbosity.

- **New Features**
  - Single router in `serpent_flow.py` subscribes once, renders all events with severity color; skips bespoke types; coalescer de-floods bursts.
  - `event_breadcrumb_registry.py`: descriptors (glyph/color/severity/formatter), heuristic fallback for unknown types, ~24 seeded high-value events, `get/set_min_severity`, `BreadcrumbCoalescer`.
  - `/breadcrumbs` verb in `breadcrumbs_repl.py` to show/set levels: off | critical | important | info | all; respects `JARVIS_TUI_EVENT_BREADCRUMB_LEVEL`.
  - Tests cover tailored render, heuristic + generic formatter, bespoke skip, level filtering, coalescing, bad payloads, and the verb.

- **Migration**
  - No action required.
  - Optional: use `/breadcrumbs` or set `JARVIS_TUI_EVENT_BREADCRUMB_LEVEL` to control the feed.

<sup>Written for commit aab72a33c9a3dbe72dbfb1eaf740c8d1187c895c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70045?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

