### PR TITLE
Event history buffer + /breadcrumbs tail — review the backend event stream

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4671,6 +4671,13 @@ class SerpentREPL:
                 build_default_registry,
                 get_min_severity,
             )
+            try:
+                from backend.core.ouroboros.governance.event_history_buffer import (
+                    get_default_history,
+                )
+                _history = get_default_history()
+            except Exception:  # noqa: BLE001
+                _history = None
 
             reg = build_default_registry()
             coalescer = BreadcrumbCoalescer()
@@ -4683,11 +4690,16 @@ class SerpentREPL:
                     et = getattr(event, "event_type", "") or ""
                     if not et or reg.is_bespoke(et):
                         continue
-                    floor = get_min_severity()
-                    if floor >= 99:            # /breadcrumbs off
-                        continue
                     payload = dict(getattr(event, "payload", {}) or {})
                     desc = reg.describe(et)
+                    # Record EVERY event into history (for /breadcrumbs tail),
+                    # regardless of the live verbosity floor.
+                    if _history is not None:
+                        _history.append(et, payload, severity=desc.severity,
+                                        category=desc.category)
+                    floor = get_min_severity()
+                    if floor >= 99:            # /breadcrumbs off (live only; history kept)
+                        continue
                     if desc.severity < floor:
                         continue
                     key = str(payload.get("provider", payload.get("op_id", "")) or "")

--- a/backend/core/ouroboros/governance/breadcrumbs_repl.py
+++ b/backend/core/ouroboros/governance/breadcrumbs_repl.py
@@ -11,12 +11,21 @@ module-level ``dispatch_breadcrumbs_command``.
 from __future__ import annotations
 
 import shlex
+import time
 from dataclasses import dataclass
 
 _RESET = "\033[0m"
 _BOLD = "\033[1m"
 _DIM = "\033[2m"
 _CYAN = "\033[36m"
+_RED = "\033[31m"
+_YELLOW = "\033[33m"
+
+_DEFAULT_TAIL = 20
+_MAX_TAIL = 200
+_SEV_WORDS = {"critical": 3, "important": 2, "info": 1, "verbose": 0, "all": 0}
+_ANSI_BY_SEV = {3: _RED + _BOLD, 2: _YELLOW, 1: _CYAN, 0: _DIM}
+_GLYPH_BY_SEV = {3: "✖", 2: "▲", 1: "·", 0: "·"}
 
 
 @dataclass(frozen=True)
@@ -38,8 +47,68 @@ _HELP = (
     f"    {_CYAN}/breadcrumbs important{_RESET}   {_DIM}+ throttles, drift, degradation (default){_RESET}\n"
     f"    {_CYAN}/breadcrumbs info{_RESET}        {_DIM}+ posture, plans, learning{_RESET}\n"
     f"    {_CYAN}/breadcrumbs all{_RESET}         {_DIM}everything (incl. unknown/new events){_RESET}\n"
-    f"    {_CYAN}/breadcrumbs{_RESET}             {_DIM}show the current level{_RESET}\n"
+    f"    {_CYAN}/breadcrumbs{_RESET}             {_DIM}show the current level{_RESET}\n\n"
+    f"  {_BOLD}Review:{_RESET}\n"
+    f"    {_CYAN}/breadcrumbs tail [N]{_RESET}   {_DIM}scroll back the last N events (max 200){_RESET}\n"
+    f"    {_CYAN}/breadcrumbs tail critical{_RESET}  {_DIM}filter the tail by severity{_RESET}\n"
+    f"    {_CYAN}/breadcrumbs tail <category>{_RESET} {_DIM}provider/governance/memory/cost/model/…{_RESET}\n"
 )
+
+
+def _fmt_age(ts: float, now: float) -> str:
+    d = max(0.0, now - ts)
+    if d < 90:
+        return f"{int(d)}s"
+    if d < 5400:
+        return f"{int(d / 60)}m"
+    return f"{d / 3600:.1f}h"
+
+
+def _render_tail(args) -> str:
+    """Scroll back the unified event history the live router feeds. Never raises."""
+    try:
+        from backend.core.ouroboros.governance.event_history_buffer import (
+            get_default_history,
+        )
+        from backend.core.ouroboros.governance.event_breadcrumb_registry import (
+            build_default_registry,
+        )
+    except Exception:  # noqa: BLE001
+        return f"  {_DIM}event history unavailable{_RESET}"
+
+    n, min_sev, category = _DEFAULT_TAIL, None, None
+    for a in args:
+        al = a.lower()
+        if al.isdigit():
+            n = min(_MAX_TAIL, max(1, int(al)))
+        elif al in _SEV_WORDS:
+            min_sev = _SEV_WORDS[al] if al != "all" else None
+        else:
+            category = al
+
+    hist = get_default_history()
+    recs = hist.recent(n, min_severity=min_sev, category=category)
+    if not recs:
+        filt = " matching filter" if (min_sev is not None or category) else ""
+        return f"  {_DIM}no events yet{filt} (history size {hist.size()}){_RESET}"
+
+    reg = build_default_registry()
+    now = time.time()
+    out = [
+        f"  {_BOLD}{_CYAN}recent events{_RESET} "
+        f"{_DIM}(newest first, {len(recs)} of {hist.size()} buffered){_RESET}"
+    ]
+    for rec in recs:
+        try:
+            _sev, text = reg.render(rec.event_type, rec.payload)
+            col = _ANSI_BY_SEV.get(rec.severity, _CYAN)
+            glyph = _GLYPH_BY_SEV.get(rec.severity, "·")
+            out.append(
+                f"    {_DIM}{_fmt_age(rec.ts, now):>4}{_RESET}  {col}{glyph}{_RESET} {text}"
+            )
+        except Exception:  # noqa: BLE001
+            out.append(f"    {_DIM}?  {rec.event_type}{_RESET}")
+    return "\n".join(out)
 
 
 def _matches(line: str) -> bool:
@@ -79,6 +148,8 @@ def dispatch_breadcrumbs_command(line: str) -> BreadcrumbsReplDispatchResult:
         return BreadcrumbsReplDispatchResult(ok=True, text=_status_text())
     if head in ("status",):
         return BreadcrumbsReplDispatchResult(ok=True, text=_status_text())
+    if head in ("tail", "history", "log"):
+        return BreadcrumbsReplDispatchResult(ok=True, text=_render_tail(args[1:]))
     if head in _LEVELS:
         try:
             from backend.core.ouroboros.governance.event_breadcrumb_registry import (

--- a/backend/core/ouroboros/governance/event_history_buffer.py
+++ b/backend/core/ouroboros/governance/event_history_buffer.py
@@ -1,0 +1,119 @@
+"""Event History Buffer — the review half of "everything connected".
+
+The unified breadcrumb router (serpent_flow ``_event_breadcrumb_router``) surfaces
+backend events LIVE, but they scroll away. This is the bounded in-memory ring the
+router also appends EVERY event to (regardless of the live verbosity filter), so
+``/events`` can tail/review what flew by — filtered by severity or category,
+rendered through the SAME ``event_breadcrumb_registry`` (no second formatter).
+
+A process-local singleton (``get_default_history``) shared by the router (writer)
+and the ``/events`` verb (reader) — same process, no store, no network. Bounded
+deque so memory is capped. Never raises.
+"""
+
+from __future__ import annotations
+
+import collections
+import os
+import threading
+import time
+from dataclasses import dataclass
+from typing import Deque, List, Optional
+
+_CAP_ENV = "JARVIS_TUI_EVENT_HISTORY_SIZE"
+_DEFAULT_CAP = 500
+
+
+def _cap() -> int:
+    try:
+        return max(16, int(os.environ.get(_CAP_ENV, str(_DEFAULT_CAP))))
+    except (TypeError, ValueError):
+        return _DEFAULT_CAP
+
+
+@dataclass(frozen=True)
+class EventRecord:
+    ts: float
+    event_type: str
+    payload: dict
+    severity: int
+    category: str
+
+
+class EventHistoryBuffer:
+    """Bounded, thread-safe ring of recent events."""
+
+    def __init__(self, capacity: Optional[int] = None) -> None:
+        self._buf: Deque[EventRecord] = collections.deque(maxlen=capacity or _cap())
+        self._lock = threading.Lock()
+
+    def append(
+        self, event_type: str, payload: Optional[dict], *,
+        severity: int = 1, category: str = "general", ts: Optional[float] = None,
+    ) -> None:
+        if not event_type:
+            return
+        try:
+            rec = EventRecord(
+                ts=float(ts) if ts is not None else time.time(),
+                event_type=event_type,
+                payload=dict(payload or {}),
+                severity=int(severity),
+                category=category or "general",
+            )
+            with self._lock:
+                self._buf.append(rec)
+        except Exception:  # noqa: BLE001 — history append never perturbs the router
+            pass
+
+    def recent(
+        self, n: int = 20, *, min_severity: Optional[int] = None,
+        category: Optional[str] = None, event_type: Optional[str] = None,
+    ) -> List[EventRecord]:
+        """Newest-first, filtered. Never raises."""
+        try:
+            with self._lock:
+                items = list(self._buf)
+        except Exception:  # noqa: BLE001
+            return []
+        out: List[EventRecord] = []
+        for rec in reversed(items):
+            if min_severity is not None and rec.severity < min_severity:
+                continue
+            if category is not None and rec.category != category:
+                continue
+            if event_type is not None and rec.event_type != event_type:
+                continue
+            out.append(rec)
+            if len(out) >= max(1, n):
+                break
+        return out
+
+    def size(self) -> int:
+        with self._lock:
+            return len(self._buf)
+
+    def clear(self) -> None:
+        with self._lock:
+            self._buf.clear()
+
+
+_default: Optional[EventHistoryBuffer] = None
+_default_lock = threading.Lock()
+
+
+def get_default_history() -> EventHistoryBuffer:
+    """Process-local singleton shared by the router (writer) + /events (reader)."""
+    global _default
+    if _default is None:
+        with _default_lock:
+            if _default is None:
+                _default = EventHistoryBuffer()
+    return _default
+
+
+__all__ = [
+    "EventHistoryBuffer",
+    "EventRecord",
+    "get_default_history",
+]

--- a/tests/governance/test_event_breadcrumb_registry.py
+++ b/tests/governance/test_event_breadcrumb_registry.py
@@ -114,3 +114,43 @@ def test_breadcrumbs_verb() -> None:
 
     assert "verbosity" in _strip(dispatch_breadcrumbs_command("/breadcrumbs help").text)
     set_min_severity("important")   # restore
+
+
+# ---------------------------------------------------------------------------
+# Event history buffer + /breadcrumbs tail
+# ---------------------------------------------------------------------------
+
+
+def test_history_buffer_ring_and_filters() -> None:
+    from backend.core.ouroboros.governance.event_history_buffer import EventHistoryBuffer
+    buf = EventHistoryBuffer(capacity=4)
+    buf.append("circuit_breaker_tripped", {"p": 1}, severity=SEV_CRITICAL, category="provider", ts=100)
+    buf.append("posture_changed", {"p": 2}, severity=SEV_INFO, category="posture", ts=101)
+    buf.append("governor_throttle_applied", {"p": 3}, severity=SEV_IMPORTANT, category="governance", ts=102)
+    buf.append("cost_band_crossed", {"p": 4}, severity=SEV_IMPORTANT, category="cost", ts=103)
+    buf.append("session_exhausted", {"p": 5}, severity=SEV_CRITICAL, category="session", ts=104)  # evicts oldest
+
+    assert buf.size() == 4                       # bounded ring
+    newest = buf.recent(10)
+    assert newest[0].event_type == "session_exhausted"   # newest first
+    assert all(r.event_type != "circuit_breaker_tripped" for r in newest)  # oldest evicted
+
+    crit = buf.recent(10, min_severity=SEV_CRITICAL)
+    assert [r.event_type for r in crit] == ["session_exhausted"]
+    cost = buf.recent(10, category="cost")
+    assert [r.event_type for r in cost] == ["cost_band_crossed"]
+
+
+def test_breadcrumbs_tail_renders_history() -> None:
+    from backend.core.ouroboros.governance.event_history_buffer import get_default_history
+    hist = get_default_history()
+    hist.clear()
+    hist.append("circuit_breaker_tripped",
+                {"provider": "doubleword", "to_state": "OPEN_TERMINAL", "terminal_reason_code": "quota"},
+                severity=SEV_CRITICAL, category="provider")
+    out = _strip(dispatch_breadcrumbs_command("/breadcrumbs tail 5").text)
+    assert "recent events" in out
+    assert "circuit breaker tripped" in out and "OPEN_TERMINAL" in out
+
+    empty = _strip(dispatch_breadcrumbs_command("/breadcrumbs tail memory").text)
+    assert "no events" in empty            # category filter with no matches


### PR DESCRIPTION
## The review half of "everything connected"

The unified router (#70045) surfaces backend events live, but they scroll away. This adds a bounded history ring the router feeds, plus `/breadcrumbs tail` to scroll back — rendered through the **same** registry.

- **`event_history_buffer.py`** — `EventHistoryBuffer`, a bounded thread-safe ring (env `JARVIS_TUI_EVENT_HISTORY_SIZE`, default 500) of `EventRecord(ts, type, payload, severity, category)`; `recent(n, min_severity, category, event_type)` newest-first filtered. Process-local singleton shared by the router (writer) + the verb (reader).
- **`serpent_flow.py`** — the router now appends **every** event to history **before** the live verbosity filter, so history stays complete even when the live feed is quieted/off; tagged with the descriptor's severity + category.
- **`breadcrumbs_repl.py`** — `/breadcrumbs tail [N] [severity] [category]` renders recent history through the same `event_breadcrumb_registry` (ANSI-colored, age column, newest-first). Folded into the existing `/breadcrumbs` family — the `/events` verb name is taken by the L1 EventEmitter.

### Mandate conformance
- **DRY** — one registry renders both the live feed and the tail; one ring shared in-process; no duplication. Fable never flagged.

### Tests (2 + 7 = 9 passed)
ring eviction + newest-first + severity/category filters; `/breadcrumbs tail` renders a seeded critical event with tailored text and reports "no events" on an empty category filter.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a bounded event history and `/breadcrumbs tail` so you can scroll back and review backend events. The router now records every event (before live filters), and the tail renders via the same breadcrumb registry.

- **New Features**
  - `EventHistoryBuffer`: thread-safe ring with capacity from `JARVIS_TUI_EVENT_HISTORY_SIZE` (default 500); query with `recent(...)` and `size()`.
  - Router (`serpent_flow.py`) appends every event to history before verbosity filtering, tagging severity and category.
  - REPL: `/breadcrumbs tail [N] [severity] [category]` (aliases: `history`, `log`) shows newest-first with age and ANSI; default 20, max 200; filters by severity or category using `event_breadcrumb_registry`.
  - Process-local singleton `get_default_history()` shared by router and REPL; non-blocking and never throws.

<sup>Written for commit 7413011ba09af17c493a8fcd8e11c42941d79d13. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

