### PR TITLE
Live Status-Line Badge — async, provider-agnostic, width-responsive ticker

### DIFF
--- a/backend/core/ouroboros/battle_test/live_status_line.py
+++ b/backend/core/ouroboros/battle_test/live_status_line.py
@@ -110,6 +110,7 @@ class LiveStatusLineRender:
     swarm_segment: str
     status_segment: str
     combined: str
+    badge_segment: str = ""
     schema_version: str = LIVE_STATUS_LINE_SCHEMA_VERSION
 
 
@@ -163,6 +164,34 @@ def render_status_segment() -> str:
 
 
 # ===========================================================================
+# Provider resilience badge — the async ticker's current render
+# ===========================================================================
+
+
+def provider_badge_segment() -> str:
+    """Render the live provider resilience badge (the async ticker's current
+    rotating provider), truncated to the live terminal width. Empty when no
+    provider telemetry has arrived yet. NEVER raises — a defensive string only."""
+    try:
+        from backend.core.ouroboros.governance.status_badge_ticker import (
+            get_default_ticker,
+        )
+    except Exception:  # noqa: BLE001
+        return ""
+    try:
+        ticker = get_default_ticker()
+        if ticker.provider_count() == 0:
+            return ""
+        import shutil
+        width = shutil.get_terminal_size((80, 24)).columns
+        # The badge is one compact segment; cap it so it never dominates a wide
+        # bar, and let the ticker's own ellipsis-truncation handle narrow ones.
+        return ticker.render(min(max(8, width), 72))
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+# ===========================================================================
 # Compose — merge swarm digest with status segment
 # ===========================================================================
 
@@ -185,12 +214,14 @@ def compose(swarm_segment: object) -> LiveStatusLineRender:
     """
     swarm_safe = swarm_segment if isinstance(swarm_segment, str) else ""
     status_safe = render_status_segment()
-    parts = [s for s in (swarm_safe, status_safe) if s]
+    badge_safe = provider_badge_segment()
+    parts = [s for s in (swarm_safe, status_safe, badge_safe) if s]
     combined = "\n".join(parts)
     return LiveStatusLineRender(
         swarm_segment=swarm_safe,
         status_segment=status_safe,
         combined=combined,
+        badge_segment=badge_safe,
     )
 
 

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4650,6 +4650,36 @@ class SerpentREPL:
             )
         except Exception:  # noqa: BLE001
             self._event_breadcrumb_router_task = None
+        # Live status-line badge ticker — seed the provider cache once (single
+        # read, shared with /provider), then rotate on its own async task,
+        # invalidating the prompt so the badge cycles without blocking input.
+        self._status_badge_ticker_task = None
+        try:
+            from backend.core.ouroboros.governance.status_badge_ticker import (
+                get_default_ticker, set_invalidate,
+            )
+            from backend.core.ouroboros.governance.provider_state_broker import (
+                build_provider_snapshot,
+            )
+            from backend.core.ouroboros.governance.dw_outage_forecaster import (
+                open_forecast_db,
+            )
+
+            def _invalidate_prompt() -> None:
+                try:
+                    from prompt_toolkit.application import get_app
+                    get_app().invalidate()
+                except Exception:  # noqa: BLE001 — no live app / not running
+                    pass
+
+            set_invalidate(_invalidate_prompt)
+            _ticker = get_default_ticker()
+            _seed = build_provider_snapshot(open_forecast_db())   # single read
+            if _seed.get("state") not in (None, "UNKNOWN"):
+                _ticker.on_provider_event(_seed)
+            self._status_badge_ticker_task = asyncio.ensure_future(_ticker.run())
+        except Exception:  # noqa: BLE001 — badge ticker is best-effort
+            self._status_badge_ticker_task = None
 
     async def _event_breadcrumb_router(self) -> None:
         """The ONE unified live event feed: subscribe once to the broker and
@@ -4749,6 +4779,15 @@ class SerpentREPL:
                     continue
                 try:
                     payload = dict(getattr(event, "payload", {}) or {})
+                    # Feed the live status-line badge ticker (same event source —
+                    # no separate poll). Provider-agnostic: any provider surfaces.
+                    try:
+                        from backend.core.ouroboros.governance.status_badge_ticker import (
+                            get_default_ticker,
+                        )
+                        get_default_ticker().on_provider_event(payload)
+                    except Exception:  # noqa: BLE001
+                        pass
                     text = format_provider_breadcrumb(payload)
                     healthy = payload.get("state") == "HEALTHY"
                     color = _C["neural"] if healthy else _C["heal"]
@@ -4838,7 +4877,7 @@ class SerpentREPL:
             self._shadow_breadcrumb_task = None
         # Tear down the provider-state resilience breadcrumb + watcher + the
         # unified event-feed router.
-        for _attr in ("_event_breadcrumb_router_task",
+        for _attr in ("_status_badge_ticker_task", "_event_breadcrumb_router_task",
                       "_provider_breadcrumb_task", "_provider_state_watcher_task"):
             _pt = getattr(self, _attr, None)
             if _pt is not None:

--- a/backend/core/ouroboros/governance/status_badge_ticker.py
+++ b/backend/core/ouroboros/governance/status_badge_ticker.py
@@ -1,0 +1,175 @@
+"""Live Status-Line Badge — an async, provider-agnostic, width-responsive ticker.
+
+Keeps provider resilience state persistently visible in the REPL bottom toolbar
+WITHOUT blocking input or shattering the layout:
+
+  * **Event-fed, not polled** — the cache is updated from the SAME
+    ``provider_state_changed`` broker payloads the ``/provider`` verb's telemetry
+    derives from (debounced: the watcher only emits on a transition). No separate
+    SQLite polling loop for the bar.
+  * **Async-decoupled** — a tick coroutine advances the ticker + invalidates the
+    prompt on its OWN task and explicitly yields to the event loop; the actual
+    render is a fast pure format (what ``bottom_toolbar`` calls synchronously).
+  * **Multi-provider rotating ticker** — if several providers are registered
+    (DW, J-Prime, …) the badge CYCLES one provider per tick rather than
+    overflowing the width.
+  * **Resize-resilient** — the renderer takes the live width and aggressively
+    truncates with an ellipsis rather than letting text-wrap break the TUI.
+
+No hardcoded "DoubleWord"; provider names come from the telemetry. Pure format +
+in-memory cache; touches no model-selection path (Fable never flagged). Never
+raises.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+from typing import Callable, Dict, List, Optional
+
+_SHORT = {"doubleword": "dw", "gcp-jprime": "jprime", "jprime": "jprime",
+          "claude-api": "claude", "claude": "claude"}
+
+
+def _short_name(provider: str) -> str:
+    p = (provider or "").lower()
+    return _SHORT.get(p, p[:8] if p else "?")
+
+
+def _truncate(s: str, width: Optional[int]) -> str:
+    """Truncate to *width* with a trailing ellipsis — never wrap. Never raises."""
+    if width is None or width <= 0:
+        return s
+    if len(s) <= width:
+        return s
+    if width == 1:
+        return "…"
+    return s[: width - 1] + "…"
+
+
+def render_badge(
+    providers: Dict[str, dict], index: int, width: Optional[int],
+) -> str:
+    """Pure render of ONE provider's compact badge (the ticker's current index),
+    truncated to *width*. Empty string when no providers. Never raises."""
+    try:
+        if not providers:
+            return ""
+        names: List[str] = sorted(providers.keys())
+        n = len(names)
+        prov = names[index % n]
+        snap = providers.get(prov, {}) or {}
+        state = str(snap.get("state", "?"))
+        parts = [f"{_short_name(prov)}:●{state}"]
+        ji = snap.get("jitter")
+        if ji is not None:
+            parts.append(f"j{ji}")
+        slope = snap.get("ttft_slope")
+        if isinstance(slope, (int, float)):
+            parts.append("▼" if slope < 0 else "▲")
+        ttr = snap.get("forecast_ttr")
+        if isinstance(ttr, (int, float)) and state != "HEALTHY":
+            parts.append(f"~{int(ttr)}s")
+        if n > 1:
+            parts.append(f"({(index % n) + 1}/{n})")
+        return _truncate(" ".join(parts), width)
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+class StatusBadgeTicker:
+    """Thread-safe provider cache + rotating index + async tick loop."""
+
+    def __init__(self, *, invalidate: Optional[Callable[[], None]] = None) -> None:
+        self._providers: Dict[str, dict] = {}
+        self._index = 0
+        self._invalidate = invalidate
+        self._lock = threading.Lock()
+
+    # -- cache (event-fed) ----------------------------------------------
+
+    def update(self, provider: str, snapshot: dict) -> None:
+        if not provider:
+            return
+        with self._lock:
+            self._providers[provider] = dict(snapshot or {})
+
+    def on_provider_event(self, payload: dict) -> None:
+        """Consume a ``provider_state_changed`` broker payload. Never raises."""
+        try:
+            prov = (payload or {}).get("provider")
+            if prov:
+                self.update(prov, payload)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def provider_count(self) -> int:
+        with self._lock:
+            return len(self._providers)
+
+    # -- render (fast, sync — what bottom_toolbar calls) ----------------
+
+    def render(self, width: Optional[int]) -> str:
+        with self._lock:
+            return render_badge(self._providers, self._index, width)
+
+    # -- async cadence (decoupled; explicitly yields) -------------------
+
+    async def tick(self) -> None:
+        """Advance the rotating ticker, invalidate the prompt, and EXPLICITLY
+        yield to the event loop so REPL input is never blocked. Never raises."""
+        with self._lock:
+            if self._providers:
+                self._index += 1
+        if self._invalidate is not None:
+            try:
+                self._invalidate()
+            except Exception:  # noqa: BLE001
+                pass
+        await asyncio.sleep(0)   # cooperative yield — proof it won't block input
+
+    async def run(
+        self, interval_s: float = 4.0, *,
+        sleep_fn: Optional[Callable[[float], "asyncio.Future"]] = None,
+        max_ticks: Optional[int] = None,
+    ) -> None:
+        sleep = sleep_fn or asyncio.sleep
+        ticks = 0
+        while True:
+            try:
+                await sleep(interval_s)
+                await self.tick()
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001
+                pass
+            ticks += 1
+            if max_ticks is not None and ticks >= max_ticks:
+                return
+
+
+_default: Optional[StatusBadgeTicker] = None
+_default_lock = threading.Lock()
+
+
+def get_default_ticker() -> StatusBadgeTicker:
+    """Process-local singleton shared by the broker listener (writer), the tick
+    task, and the bottom-toolbar segment (reader)."""
+    global _default
+    if _default is None:
+        with _default_lock:
+            if _default is None:
+                _default = StatusBadgeTicker()
+    return _default
+
+
+def set_invalidate(invalidate: Optional[Callable[[], None]]) -> None:
+    get_default_ticker()._invalidate = invalidate  # noqa: SLF001 — module seam
+
+
+__all__ = [
+    "StatusBadgeTicker",
+    "get_default_ticker",
+    "render_badge",
+    "set_invalidate",
+]

--- a/tests/governance/test_status_badge_ticker.py
+++ b/tests/governance/test_status_badge_ticker.py
@@ -1,0 +1,140 @@
+"""Live Status-Line Badge — async, provider-agnostic, width-responsive ticker.
+
+Mandated bulletproof: (1) cycles through two providers (DW + J-Prime) over a
+simulated time lapse, (2) gracefully truncates with an ellipsis when the mock
+terminal width drops to 20, (3) the tick explicitly yields control to the event
+loop, proving it will not block REPL input.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.governance.status_badge_ticker import (
+    StatusBadgeTicker,
+    render_badge,
+)
+
+
+def _both() -> dict:
+    return {
+        "doubleword": {"state": "DEGRADED", "jitter": 14, "ttft_slope": 0.001,
+                       "forecast_ttr": 280},
+        "gcp-jprime": {"state": "HEALTHY", "jitter": 0, "ttft_slope": -0.02},
+    }
+
+
+# ---------------------------------------------------------------------------
+# (1) Rotating multi-provider ticker over a time lapse
+# ---------------------------------------------------------------------------
+
+
+async def test_ticker_cycles_two_providers() -> None:
+    ticker = StatusBadgeTicker()
+    for prov, snap in _both().items():
+        ticker.update(prov, snap)
+    assert ticker.provider_count() == 2
+
+    seen = set()
+    clock_ticks = 0
+    # Simulate several 4s ticks; each render shows exactly ONE provider.
+    for _ in range(4):
+        badge = ticker.render(width=80)
+        seen.add(badge.split(":")[0])       # the short-name prefix (dw / jprime)
+        await ticker.tick()                 # advance the rotating index
+        clock_ticks += 1
+
+    # Both providers appeared as the ticker rotated — never both at once.
+    assert "dw" in seen and "jprime" in seen
+    # A single render never overflows with both providers stacked.
+    one = ticker.render(width=80)
+    assert not ("dw:" in one and "jprime:" in one)
+
+
+def test_render_shows_provider_specific_state() -> None:
+    providers = _both()
+    dw = render_badge(providers, 0, 80)     # sorted: doubleword first
+    jp = render_badge(providers, 1, 80)
+    assert dw.startswith("dw:●DEGRADED") and "j14" in dw and "~280s" in dw
+    assert jp.startswith("jprime:●HEALTHY")
+    assert "(1/2)" in dw and "(2/2)" in jp   # rotation index shown
+
+
+# ---------------------------------------------------------------------------
+# (2) Terminal resize — aggressive ellipsis truncation
+# ---------------------------------------------------------------------------
+
+
+async def test_truncates_at_width_20() -> None:
+    ticker = StatusBadgeTicker()
+    ticker.update("doubleword",
+                  {"state": "DEGRADED", "jitter": 14, "ttft_slope": 0.001,
+                   "forecast_ttr": 280})
+    full = ticker.render(width=200)
+    assert len(full) > 20                    # the untruncated badge is long
+
+    narrow = ticker.render(width=20)
+    assert len(narrow) <= 20                  # never exceeds the mock width
+    assert narrow.endswith("…")               # ellipsis, not a wrap
+
+    # Degenerate widths never raise / never wrap.
+    assert ticker.render(width=1) == "…"
+    assert len(ticker.render(width=5)) <= 5
+
+
+def test_empty_cache_renders_empty() -> None:
+    assert StatusBadgeTicker().render(width=80) == ""
+    assert render_badge({}, 0, 80) == ""
+
+
+# ---------------------------------------------------------------------------
+# (3) The tick yields control to the event loop (won't block REPL input)
+# ---------------------------------------------------------------------------
+
+
+async def test_tick_yields_to_event_loop() -> None:
+    ticker = StatusBadgeTicker()
+    ticker.update("doubleword", {"state": "DEGRADED"})
+
+    order = []
+
+    async def competitor() -> None:
+        # If tick did NOT yield, this could not interleave before tick returns.
+        order.append("competitor")
+
+    comp = asyncio.ensure_future(competitor())
+    await ticker.tick()          # must `await asyncio.sleep(0)` internally → yields
+    await comp
+    assert "competitor" in order
+
+    # The invalidate hook is called on tick (prompt re-render trigger).
+    hits = {"n": 0}
+    t2 = StatusBadgeTicker(invalidate=lambda: hits.__setitem__("n", hits["n"] + 1))
+    t2.update("doubleword", {"state": "DEGRADED"})
+    await t2.tick()
+    assert hits["n"] == 1
+
+
+async def test_run_loop_bounded_and_deterministic() -> None:
+    ticker = StatusBadgeTicker()
+    ticker.update("doubleword", {"state": "DEGRADED"})
+    ticker.update("gcp-jprime", {"state": "HEALTHY"})
+    slept = []
+
+    async def sleep(s: float) -> None:
+        slept.append(s)
+
+    await ticker.run(interval_s=4.0, sleep_fn=sleep, max_ticks=3)
+    assert slept == [4.0, 4.0, 4.0]           # ticked 3× at the interval
+
+
+def test_on_provider_event_feeds_cache() -> None:
+    ticker = StatusBadgeTicker()
+    ticker.on_provider_event({"provider": "doubleword", "state": "HEALTHY", "jitter": 0})
+    ticker.on_provider_event({"provider": "gcp-jprime", "state": "DEGRADED", "jitter": 3})
+    assert ticker.provider_count() == 2
+    assert "dw:●HEALTHY" in ticker.render(width=80) or "jprime:●DEGRADED" in ticker.render(width=80)
+    ticker.on_provider_event({})              # malformed → ignored, never raises
+    assert ticker.provider_count() == 2


### PR DESCRIPTION
## Persistent provider telemetry in the bottom bar — without UI-thread starvation or layout breakage

- **`status_badge_ticker.py`** — `StatusBadgeTicker`: thread-safe provider cache + rotating index. `render_badge()` is a **pure, fast** format (what `bottom_toolbar` calls synchronously); `tick()` advances the ticker, invalidates the prompt, and **explicitly `await asyncio.sleep(0)`** so REPL input is never blocked. **Multi-provider** → cycles ONE provider per tick (no width overflow). **Resize** → aggressive ellipsis truncation (never wrap). No hardcoded "DoubleWord" — names come from telemetry.
- **Event-fed, not polled** (mandate 3) — the provider breadcrumb listener feeds `ticker.on_provider_event(payload)` from the **same** `provider_state_changed` broker events `/provider` derives from. No separate SQLite loop for the bar; seeded once at start (single read).
- **`live_status_line.py`** — `provider_badge_segment()` renders the ticker's current badge at the live terminal width (`shutil.get_terminal_size`, capped), folded into `compose()` as a third stacked segment (empty → dropped).
- **`serpent_flow.py`** — starts the ticker's `run()` task with an invalidate calling `prompt_toolkit get_app().invalidate()`; torn down with the other listeners.

### Mandate conformance
- **Root-Cause Only** — decoupled async cadence + a pure sync render; dynamic width, no static assumptions; no hardcoded provider.
- **DRY** — one broker feed shared with `/provider`; the existing `compose()` seam. Fable never flagged.

### Tests (7 passed)
cycles DW↔J-Prime over a simulated lapse (one provider per render, never both); truncates to ≤20 with a trailing ellipsis at width=20 (width 1/5 degenerate-safe); **tick explicitly yields to the loop** (a concurrent coroutine interleaves) + calls invalidate; bounded `run()` loop; `on_provider_event` feeds the cache + ignores malformed payloads. End-to-end: the badge renders through `compose()` into the combined bottom-toolbar output.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live provider status badge to the bottom toolbar. It rotates across providers asynchronously, never blocks input, and safely truncates on narrow terminals.

- **New Features**
  - Added `StatusBadgeTicker`: thread-safe provider cache + rotating index; pure `render()`; `tick()` yields via `await asyncio.sleep(0)` and invalidates the prompt with `prompt_toolkit` so input stays responsive. Cycles one provider per tick and truncates with an ellipsis based on width.
  - Integrated `provider_badge_segment()` into the status line: reads live terminal width, caps it, and includes the badge as a third stacked segment only when present.
  - Wired into the event flow: seeded once from `build_provider_snapshot(open_forecast_db())`, fed by the same `provider_state_changed` broker events, and run as its own task; torn down on stop.
  - Tests cover rotation across multiple providers, width truncation, cooperative yielding, bounded run loop, and event ingestion.

<sup>Written for commit a1fa573459ee12d90a04a70b0f84112319072762. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

