### PR TITLE
Strip JARVIS HUD to ambient-only — halo + menu-bar icon + voice

### DIFF
--- a/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
+++ b/JARVIS-Apple/JARVISHUD/JARVISHUDApp.swift
@@ -24,8 +24,6 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
     private var isTTSSpeaking = false
 
     private var borderWindow: LivingBorderWindow?
-    private var panel: JARVISPanel?
-    private var panelVisible = false
     private var statusItem: NSStatusItem?
     private var statusMenu: NSMenu?
     private var subs = Set<AnyCancellable>()
@@ -51,27 +49,9 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
             BrainstemLauncher.shared.start()
             self.appState.boot()
 
-            // Living Border + Panel setup — border always visible, panel hidden until summoned
+            // Living Border setup — the halo is always visible (JARVIS is ambient:
+            // just the green halo + the menu-bar icon; no panel to take over the screen).
             self.setupWindows()
-
-            // Global keyboard shortcut: Cmd+Shift+J toggles panel (system-wide)
-            // addGlobalMonitor catches keys even when another app is focused.
-            // Requires Accessibility permission (already granted for Ghost Hands).
-            NSEvent.addGlobalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-                if flags == [.command, .shift] && event.charactersIgnoringModifiers?.lowercased() == "j" {
-                    Task { @MainActor in self?.togglePanel() }
-                }
-            }
-            // Also add local monitor for when JARVIS panel itself is focused
-            NSEvent.addLocalMonitorForEvents(matching: .keyDown) { [weak self] event in
-                let flags = event.modifierFlags.intersection(.deviceIndependentFlagsMask)
-                if flags == [.command, .shift] && event.charactersIgnoringModifiers?.lowercased() == "j" {
-                    Task { @MainActor in self?.togglePanel() }
-                    return nil
-                }
-                return event
-            }
 
             // Wire border color to backend connectivity. (The cognitive-state
             // tint rode the Hive relay, which was never live and now feeds the
@@ -125,20 +105,16 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
             guard let self else { return }
             print("[JARVIS] Voice command: \"\(command)\"")
 
-            // Panel control voice commands
+            // JARVIS is ambient — the halo + menu-bar icon are the whole HUD, there
+            // is no panel to summon. "Show yourself" acknowledges presence by voice
+            // rather than taking over the screen; everything operational lives in the
+            // O+V CLI/TUI.
             let lower = command.lowercased().trimmingCharacters(in: .whitespaces)
-
-            if lower.contains("show yourself") || lower.contains("show panel") || lower.contains("appear") {
-                Task { @MainActor in self.showHUD() }
+            if lower.contains("show yourself") || lower.contains("appear")
+                || lower.contains("are you there") || lower.contains("you there") {
+                self.speak("I'm online and listening.")
                 return
             }
-            if lower.contains("hide") || lower.contains("dismiss") || lower.contains("go away") || lower.contains("disappear") {
-                Task { @MainActor in self.hideHUD() }
-                return
-            }
-
-            // Panel does NOT auto-show for commands — the organism responds
-            // via voice only. Panel is only for explicit "show yourself" / Cmd+Shift+J.
 
             // ============================================================
             // UNIFIED COMMAND ROUTING (Phase 11): route the raw command to
@@ -329,12 +305,6 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
         cmd.target = self
         menu.addItem(cmd)
 
-        let toggle = NSMenuItem(title: "Show JARVIS", action: #selector(toggleHUD), keyEquivalent: "j")
-        toggle.keyEquivalentModifierMask = [.command, .shift]
-        toggle.target = self
-        toggle.tag = 200
-        menu.addItem(toggle)
-
         menu.addItem(.separator())
 
         let quit = NSMenuItem(title: "Quit JARVIS", action: #selector(quitApp), keyEquivalent: "q")
@@ -380,7 +350,6 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
         }
     }
 
-    @objc private func toggleHUD() { togglePanel() }
     @objc private func quitApp() { BrainstemLauncher.shared.stop(); ScreenCaptureService.shared.stopStream(); appState.pythonBridge.shutdown(); NSApp.terminate(nil) }
 
     // MARK: - Icon
@@ -431,38 +400,13 @@ class HUDAppDelegate: NSObject, NSApplicationDelegate, AVSpeechSynthesizerDelega
         }
     }
 
-    // MARK: - Living Border + Panel
+    // MARK: - Living Border (the ambient halo — the whole visible HUD)
 
     private func setupWindows() {
-        // Border window — always on, always breathing
+        // Border window — always on, always breathing. This is the only visible
+        // surface; the operational UI lives in the O+V CLI/TUI.
         if borderWindow == nil {
             borderWindow = LivingBorderWindow()
         }
-
-        // Panel — created once, shown/hidden on demand
-        if panel == nil {
-            let hudView = HUDView()
-                .environmentObject(appState)
-            panel = JARVISPanel(contentView: AnyView(hudView))
-        }
-    }
-
-    private func showHUD() {
-        setupWindows()
-        guard let panel, !panelVisible else { return }
-        panelVisible = true
-        panel.showPanel()
-        statusMenu?.item(withTag: 200)?.title = "Hide JARVIS"
-    }
-
-    private func hideHUD() {
-        guard let panel, panelVisible else { return }
-        panelVisible = false
-        panel.hidePanel()
-        statusMenu?.item(withTag: 200)?.title = "Show JARVIS"
-    }
-
-    func togglePanel() {
-        if panelVisible { hideHUD() } else { showHUD() }
     }
 }


### PR DESCRIPTION
## The HUD becomes purely ambient — no screen takeover

Per the operator's directive: the JARVIS HUD keeps **only** the two ambient signals (green halo + menu-bar dot) plus voice; everything operational now lives in the O+V CLI/TUI. **This one needs an Xcode build to confirm — Swift isn't compilable in the authoring environment — so it's on a branch for review, not auto-merged.**

### Kept (verified intact)
- **Green Living-Border halo** — `LivingBorderWindow` + its connectivity timer. Untouched.
- **Menu-bar reactor icon** — `setupMenuBar`/`drawReactor`/`updateIcon` + the `$connectionStatus`/`$isActive` sinks.
- **Voice** — `setupVoice` / wake word / TTS.
- **Connection plumbing** — `boot`/`onBackendReady`/`connectionStatus` (drives both keep-features).

### Removed (delegate)
- The `JARVISPanel`/`HUDView` slide-in (`panel`/`panelVisible`, its creation in `setupWindows`, `showHUD`/`hideHUD`/`togglePanel`/`toggleHUD`).
- The `Cmd+Shift+J` global/local monitors + the "Show JARVIS" menu item.
- **"show yourself"/"appear" now answers by voice** ("I'm online and listening.") instead of summoning a panel.

Brace-balanced (73/73), grep-verified no dangling panel references.

### Follow-up you do in Xcode (safe pbxproj update)
These view files are now fully unmounted dead code — delete them in Xcode (right-click → Delete → Move to Trash) so the `.pbxproj` updates cleanly:
`Views/HUDView.swift`, `Views/CompactHeaderBar.swift`, `Views/JARVISPanel.swift`, `Views/ArcReactorView.swift`, `Views/JARVISPulseView.swift`, `Views/LoadingHUDView.swift`, `Views/TransparentWindow.swift`.

(I didn't hand-edit the `.pbxproj` — the project uses explicit file references, and a corrupted pbxproj can't be build-verified from here. Xcode's delete handles it safely.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the JARVIS HUD ambient-only by removing the on-screen panel and shortcuts while keeping the green halo, menu-bar icon, and voice. All operational controls move to the O+V CLI/TUI; “show yourself” now responds by voice.

- **Refactors**
  - Removed `JARVISPanel`/`HUDView` slide-in and related state/handlers.
  - Removed `Cmd+Shift+J` global/local shortcuts and the “Show JARVIS” menu item.
  - Kept `LivingBorderWindow` halo and menu-bar reactor icon with connection bindings.
  - Voice replies to “show yourself/appear/are you there” with “I'm online and listening.”

- **Migration**
  - In Xcode, delete the unused view files to update the `.pbxproj`: `Views/HUDView.swift`, `Views/CompactHeaderBar.swift`, `Views/JARVISPanel.swift`, `Views/ArcReactorView.swift`, `Views/JARVISPulseView.swift`, `Views/LoadingHUDView.swift`, `Views/TransparentWindow.swift`, then build to verify.

<sup>Written for commit f9635ac981a9fa33862d29cd6a4693a3d196c41d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70048?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

