### PR TITLE
Autonomous Wake-and-Execute (AWE) Trigger — the Midnight-Recovery reflex

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4681,6 +4681,21 @@ class SerpentREPL:
         except Exception:  # noqa: BLE001 — badge ticker is best-effort
             self._status_badge_ticker_task = None
 
+        # Autonomous Wake-and-Execute (AWE) Trigger — the Midnight-Recovery
+        # reflex. Consumes the SAME provider_state_changed feed and, on the
+        # DEGRADED→HEALTHY edge, atomically claims the soak lock and detaches the
+        # definitive Agentic Swarm soak so a 3 AM recovery is not lost to a
+        # passive human bottleneck. Opt-in (JARVIS_AWE_TRIGGER_ENABLED); returns
+        # None + stays inert when disabled. Best-effort.
+        self._awe_trigger = None
+        try:
+            from backend.core.ouroboros.governance.awe_trigger import (
+                start_awe_trigger,
+            )
+            self._awe_trigger = start_awe_trigger()
+        except Exception:  # noqa: BLE001 — AWE arming is best-effort
+            self._awe_trigger = None
+
     async def _event_breadcrumb_router(self) -> None:
         """The ONE unified live event feed: subscribe once to the broker and
         surface EVERY backend event through the descriptor registry — filtered by
@@ -4875,6 +4890,15 @@ class SerpentREPL:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
             self._shadow_breadcrumb_task = None
+        # Tear down the AWE Trigger (cancels its watcher + any in-flight detached
+        # soak). Owns its own tasks, so stop it before the task-tuple sweep.
+        _awe = getattr(self, "_awe_trigger", None)
+        if _awe is not None:
+            try:
+                await _awe.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            self._awe_trigger = None
         # Tear down the provider-state resilience breadcrumb + watcher + the
         # unified event-feed router.
         for _attr in ("_status_badge_ticker_task", "_event_breadcrumb_router_task",

--- a/backend/core/ouroboros/governance/awe_trigger.py
+++ b/backend/core/ouroboros/governance/awe_trigger.py
@@ -1,0 +1,386 @@
+"""Autonomous Wake-and-Execute (AWE) Trigger — the Midnight-Recovery reflex.
+
+The systemic blind spot this closes: if DoubleWord stabilizes and the Sentinel
+flips ``provider_state`` → ``HEALTHY`` at 3:00 AM, the queued definitive Agentic
+Swarm soak would sit idle waiting for a human to type a CLI command — potentially
+missing the entire stability window. The root cause is a *passive human
+bottleneck* on the recovery path. The fix is a reactive, event-driven launch.
+
+Architecture (Manifesto §3 asynchronous tendrils + §7 absolute observability):
+
+  * **Asynchronous broker watcher** — subscribes IN-PROCESS to the same
+    :class:`StreamEventBroker` the ``/observability/stream`` SSE uses, draining
+    ``provider_state_changed`` frames. The producer is the existing
+    ``ProviderStateWatcher`` (``start_provider_state_watcher``), so this adds a
+    consumer, not a second poll loop (DRY). Fires only on the DEGRADED→HEALTHY
+    *edge* (``state == HEALTHY and previous_state != HEALTHY``).
+
+  * **Atomic execution lock** — the instant HEALTHY is seen, the trigger claims
+    the ``soak_execution_lock`` in the SAME ``.jarvis/chunk_strategy.db`` via the
+    established guarded-UPDATE compare-and-swap (see :mod:`soak_execution_lock`).
+    A rapid HEALTHY↔DEGRADED↔HEALTHY flap during swarm startup finds a fresh
+    claim inside the cooldown → the loser's UPDATE matches zero rows → suppressed.
+    No double-launch. A genuinely new outage cycle hours later re-arms.
+
+  * **SIGHUP-resilient detached launch** — once the lock is won, the injected
+    ``launch_fn`` (the REAL soak path — nothing is cloned here) is detached via
+    ``asyncio.create_task`` so it runs to completion without blocking the watcher
+    or the REPL event loop. Every step publishes a breadcrumb event so the
+    autonomous decision is visible in the TUI ``/breadcrumbs`` feed.
+
+The trigger is pure orchestration: WHAT it launches is an injected seam, so it
+duplicates no launch logic and is trivially testable. Master gate
+``JARVIS_AWE_TRIGGER_ENABLED`` (default OFF — arming an autonomous soak launcher
+is deliberately opt-in). Never raises on the hot path. Fable is never referenced.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import uuid
+from typing import Any, Awaitable, Callable, Optional
+
+from backend.core.ouroboros.governance.soak_execution_lock import (
+    DEFAULT_LOCK_NAME,
+    release_soak_lock,
+    try_claim_soak_lock,
+)
+
+logger = logging.getLogger("Ouroboros.AWETrigger")
+
+# run_id -> awaitable result. The trigger only ever awaits this; it neither
+# knows nor cares how the soak is realized.
+LaunchFn = Callable[[str], Awaitable[Any]]
+BreadcrumbFn = Callable[[str, dict], None]
+DbFactory = Callable[[], Any]
+
+
+def awe_enabled() -> bool:
+    """Master gate. Default OFF — an autonomous soak launcher is opt-in."""
+    return os.environ.get(
+        "JARVIS_AWE_TRIGGER_ENABLED", "false",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _default_db_factory():
+    """Open the shared ``.jarvis/chunk_strategy.db`` (same DB as the forecaster /
+    provider-state / strategy-outcome tables). ``None`` on failure — the trigger
+    fail-closes (never launches) when it cannot prove a lock claim."""
+    try:
+        from backend.core.ouroboros.governance.dw_outage_forecaster import (
+            open_forecast_db,
+        )
+        return open_forecast_db()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _default_breadcrumb_fn(event_type: str, payload: dict) -> None:
+    """Publish an AWE breadcrumb onto the broker so the unified event router
+    surfaces it in ``/breadcrumbs``. Best-effort; never raises."""
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        op_id = str(payload.get("provider", "doubleword")) or "doubleword"
+        publish_task_event(event_type, op_id, dict(payload))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+class AWETrigger:
+    """Watches for the DW recovery edge and autonomously launches the soak once."""
+
+    def __init__(
+        self,
+        *,
+        launch_fn: LaunchFn,
+        db_factory: Optional[DbFactory] = None,
+        provider: str = "doubleword",
+        lock_name: str = DEFAULT_LOCK_NAME,
+        cooldown_s: Optional[float] = None,
+        breadcrumb_fn: Optional[BreadcrumbFn] = None,
+        run_id_factory: Optional[Callable[[], str]] = None,
+    ) -> None:
+        self._launch_fn = launch_fn
+        self._db_factory = db_factory or _default_db_factory
+        self._provider = provider
+        self._lock_name = lock_name
+        self._cooldown_s = cooldown_s
+        self._breadcrumb_fn = breadcrumb_fn or _default_breadcrumb_fn
+        self._run_id_factory = run_id_factory or (lambda: uuid.uuid4().hex[:12])
+        self._watch_task: Optional[asyncio.Task] = None
+        self._soak_task: Optional[asyncio.Task] = None
+        # Set once the broker subscription is live — lets a caller/test publish
+        # deterministically without racing the subscribe.
+        self._subscribed: asyncio.Event = asyncio.Event()
+        self._launch_count = 0  # observable: how many soaks this process fired
+
+    # -- breadcrumbs ----------------------------------------------------
+
+    def _emit(self, event_type: str, payload: dict) -> None:
+        try:
+            self._breadcrumb_fn(event_type, payload)
+        except Exception:  # noqa: BLE001 — a breadcrumb never breaks the trigger
+            logger.debug("[AWE] breadcrumb emit failed", exc_info=True)
+
+    # -- edge detection + atomic claim ----------------------------------
+
+    async def on_state_event(self, payload: dict) -> bool:
+        """Handle one ``provider_state_changed`` payload. Returns ``True`` iff a
+        soak was launched by THIS event. Idles (returns ``False``) on any state
+        that is not a transition INTO ``HEALTHY``. Never raises."""
+        try:
+            state = str((payload or {}).get("state", "")).upper()
+            prev = str((payload or {}).get("previous_state", "")).upper()
+        except Exception:  # noqa: BLE001
+            return False
+        # Idle while DEGRADED/UNKNOWN, and on a HEALTHY→HEALTHY non-edge.
+        if state != "HEALTHY" or prev == "HEALTHY":
+            return False
+        return await self._try_launch(dict(payload or {}))
+
+    async def _try_launch(self, payload: dict) -> bool:
+        conn = None
+        try:
+            conn = self._db_factory()
+        except Exception:  # noqa: BLE001
+            conn = None
+        run_id = self._run_id_factory()
+        won = try_claim_soak_lock(
+            conn, run_id, lock_name=self._lock_name, cooldown_s=self._cooldown_s,
+        )
+        if not won:
+            # The flap guard: a redundant recovery edge inside the cooldown.
+            self._emit("awe_soak_suppressed", {
+                "provider": self._provider, "run_id": run_id,
+                "reason": "lock held (flap guard)",
+            })
+            logger.info("[AWE] recovery edge suppressed by flap guard (lock held)")
+            return False
+        self._launch_count += 1
+        self._emit("awe_soak_launched", {
+            "provider": self._provider, "run_id": run_id,
+            "previous_state": payload.get("previous_state", ""),
+            "reason": "DEGRADED→HEALTHY — arming definitive soak",
+        })
+        logger.info("[AWE] DW recovery edge — soak lock claimed run_id=%s; detaching soak", run_id)
+        # SIGHUP-resilient: detach so a long soak never blocks the watcher / REPL.
+        try:
+            self._soak_task = asyncio.create_task(self._run_soak(run_id))
+        except Exception:  # noqa: BLE001 — could not even START → don't wedge the lock
+            logger.debug("[AWE] soak task creation failed; releasing lock", exc_info=True)
+            try:
+                release_soak_lock(self._db_factory(), lock_name=self._lock_name)
+            except Exception:  # noqa: BLE001
+                pass
+            self._emit("awe_soak_failed", {
+                "provider": self._provider, "run_id": run_id,
+                "reason": "launch task creation failed",
+            })
+            return False
+        return True
+
+    async def _run_soak(self, run_id: str) -> Any:
+        """Await the injected real soak launcher to completion, breadcrumbing its
+        terminal. A successful soak HOLDS the lock (one-shot per cooldown); a
+        failure RELEASES it so a later recovery may retry. Never raises out."""
+        try:
+            result = await self._launch_fn(run_id)
+            self._emit("awe_soak_complete", {
+                "provider": self._provider, "run_id": run_id,
+                "result": str(result)[:200] if result is not None else "",
+            })
+            logger.info("[AWE] soak run_id=%s reached terminal", run_id)
+            return result
+        except asyncio.CancelledError:
+            raise
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[AWE] soak run_id=%s failed: %s", run_id, exc)
+            self._emit("awe_soak_failed", {
+                "provider": self._provider, "run_id": run_id, "reason": str(exc)[:200],
+            })
+            try:
+                release_soak_lock(self._db_factory(), lock_name=self._lock_name)
+            except Exception:  # noqa: BLE001
+                pass
+            return None
+
+    # -- the async watcher ----------------------------------------------
+
+    async def watch(self, *, max_state_events: Optional[int] = None) -> None:
+        """Subscribe to the broker and drain ``provider_state_changed`` frames,
+        dispatching each to :meth:`on_state_event`. Mirrors the established
+        best-effort subscribe/stream_iter/finally-unsubscribe pattern used by the
+        other in-process breadcrumb listeners. ``max_state_events`` bounds the
+        loop for deterministic tests. Never raises."""
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            EVENT_TYPE_PROVIDER_STATE_CHANGED,
+            get_default_broker,
+        )
+
+        broker = None
+        sub = None
+        seen = 0
+        try:
+            broker = get_default_broker()
+            sub = broker.subscribe(op_id_filter=self._provider)
+            if sub is None:
+                logger.debug("[AWE] broker subscribe returned None (cap?) — trigger idle")
+                self._subscribed.set()
+                return
+            self._subscribed.set()
+            async for event in broker.stream_iter(sub, heartbeat_s=0):
+                if getattr(event, "event_type", "") != EVENT_TYPE_PROVIDER_STATE_CHANGED:
+                    continue
+                try:
+                    payload = dict(getattr(event, "payload", {}) or {})
+                    await self.on_state_event(payload)
+                except Exception:  # noqa: BLE001 — one bad event never kills the loop
+                    logger.debug("[AWE] on_state_event raised", exc_info=True)
+                seen += 1
+                if max_state_events is not None and seen >= max_state_events:
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001 — the watcher is strictly best-effort
+            logger.debug("[AWE] watch loop exited on error", exc_info=True)
+            return
+        finally:
+            self._subscribed.set()
+            try:
+                if broker is not None and sub is not None:
+                    broker.unsubscribe(sub)
+            except Exception:  # noqa: BLE001
+                pass
+
+    # -- lifecycle ------------------------------------------------------
+
+    def start(self) -> asyncio.Task:
+        """Spawn the watch loop as a background task and return it."""
+        self._watch_task = asyncio.ensure_future(self.watch())
+        return self._watch_task
+
+    async def stop(self) -> None:
+        """Cancel the watch loop and any in-flight detached soak. Never raises."""
+        for attr in ("_watch_task", "_soak_task"):
+            t = getattr(self, attr, None)
+            if t is not None:
+                t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+                setattr(self, attr, None)
+
+
+# ---------------------------------------------------------------------------
+# Launch-fn bindings — DRY seams onto the REAL soak paths (nothing cloned)
+# ---------------------------------------------------------------------------
+
+
+def build_swarm_coroutine_launch_fn(
+    *,
+    client: Any,
+    source: str,
+    file_path: str,
+    symbols: list,
+    repo_root: str = ".",
+    op_id_prefix: str = "awe",
+) -> LaunchFn:
+    """Bind the in-process big-file Agentic Swarm — awaits the SAME public egress
+    (``intercept_full_content``) the generation hot path uses in
+    ``candidate_generator._maybe_swarm_short_circuit``, constructing the
+    ``ProductionAgentTurnFn`` identically. This is the literal 4-agent
+    chunk→repair→stitch fan-out/fan-in the operator described. DRY: it reuses the
+    real egress rather than duplicating swarm logic."""
+
+    async def _launch(run_id: str) -> Any:
+        from backend.core.ouroboros.governance.full_content_interceptor import (
+            intercept_full_content,
+        )
+        from backend.core.ouroboros.governance.agent_turn_adapter import (
+            ProductionAgentTurnFn,
+        )
+        op_id = f"{op_id_prefix}-{run_id}"
+        agent = ProductionAgentTurnFn(
+            client=client,
+            tool_backend=None,
+            repo_root=repo_root,
+            op_id=op_id,
+            model_name=getattr(client, "_model", "") or "",
+            system_prompt="",
+            parse_fn=lambda raw: None,
+            max_turns=1,
+        )
+        return await intercept_full_content(
+            source, file_path, list(symbols or []), agent, op_id=op_id,
+        )
+
+    return _launch
+
+
+def build_soak_subprocess_launch_fn(
+    *,
+    script: str = "scripts/ouroboros_battle_test.py",
+    args: Optional[list] = None,
+    extra_env: Optional[dict] = None,
+) -> LaunchFn:
+    """Bind the definitive battle-test soak as a detached subprocess with
+    ``JARVIS_SWARM_ROUTING_ENABLED=true`` (the flag the swarm route reads). The
+    ``_run_soak`` coroutine awaits the subprocess to completion — in-process
+    awaited, detached, non-blocking, and returning its exit code. This is the
+    self-contained "definitive Agentic Swarm soak" launch when no live client is
+    threaded into the trigger's process."""
+    import sys
+
+    async def _launch(run_id: str) -> int:
+        env = dict(os.environ)
+        env["JARVIS_SWARM_ROUTING_ENABLED"] = "true"
+        env.setdefault("OUROBOROS_BATTLE_HEADLESS", "1")
+        env["JARVIS_AWE_SOAK_RUN_ID"] = run_id
+        if extra_env:
+            env.update({str(k): str(v) for k, v in extra_env.items()})
+        argv = [sys.executable, script] + list(args or ["--headless"])
+        proc = await asyncio.create_subprocess_exec(*argv, env=env)
+        rc = await proc.wait()
+        return rc
+
+    return _launch
+
+
+def start_awe_trigger(
+    *,
+    launch_fn: Optional[LaunchFn] = None,
+    provider: str = "doubleword",
+    **kwargs: Any,
+) -> Optional[AWETrigger]:
+    """Construct + start the AWE trigger IFF ``JARVIS_AWE_TRIGGER_ENABLED``.
+    Returns the live :class:`AWETrigger` (whose ``.stop()`` the caller tears down)
+    or ``None`` when disabled / on any error. Defaults ``launch_fn`` to the
+    self-contained subprocess soak. Never raises."""
+    if not awe_enabled():
+        return None
+    try:
+        trigger = AWETrigger(
+            launch_fn=launch_fn or build_soak_subprocess_launch_fn(),
+            provider=provider,
+            **kwargs,
+        )
+        trigger.start()
+        logger.info("[AWE] armed — watching for %s DEGRADED→HEALTHY recovery edge", provider)
+        return trigger
+    except Exception:  # noqa: BLE001
+        logger.debug("[AWE] start failed", exc_info=True)
+        return None
+
+
+__all__ = [
+    "AWETrigger",
+    "awe_enabled",
+    "build_soak_subprocess_launch_fn",
+    "build_swarm_coroutine_launch_fn",
+    "start_awe_trigger",
+]

--- a/backend/core/ouroboros/governance/event_breadcrumb_registry.py
+++ b/backend/core/ouroboros/governance/event_breadcrumb_registry.py
@@ -213,6 +213,14 @@ def _f_confidence(p: dict) -> str:
     return f"model {p.get('model', '?')} conf={p.get('confidence', '?')}"
 
 
+def _f_awe(p: dict) -> str:
+    rid = str(p.get("run_id", "?"))
+    prov = str(p.get("provider", "doubleword"))
+    reason = str(p.get("reason", "") or "")
+    tail = f" — {reason}" if reason else ""
+    return f"{prov} recovery → soak {rid}{tail}".strip()
+
+
 def build_default_registry() -> EventBreadcrumbRegistry:
     reg = EventBreadcrumbRegistry()
     # These two already have tailored, prompt-aware bespoke listeners in the TUI.
@@ -256,6 +264,11 @@ def build_default_registry() -> EventBreadcrumbRegistry:
                              lambda p: f"{p.get('detail','trajectory drift')}", "integrity"),
         BreadcrumbDescriptor("decision_drift_detected", "▲", "yellow", SEV_IMPORTANT,
                              lambda p: f"{p.get('detail','decision drift')}", "integrity"),
+        BreadcrumbDescriptor("awe_soak_launched", "⚡", "green bold", SEV_CRITICAL, _f_awe, "soak"),
+        BreadcrumbDescriptor("awe_soak_suppressed", "·", "bright_black", SEV_INFO,
+                             lambda p: f"flap guard held ({p.get('reason','lock held')})", "soak"),
+        BreadcrumbDescriptor("awe_soak_complete", "✓", "green", SEV_IMPORTANT, _f_awe, "soak"),
+        BreadcrumbDescriptor("awe_soak_failed", "✖", "red bold", SEV_CRITICAL, _f_awe, "soak"),
     ]
     for d in seed:
         reg.register(d)

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -166,6 +166,15 @@ EVENT_TYPE_PROVIDER_STATE_CHANGED = "provider_state_changed"
 # to a cold boot (or failed). On Spot instances this defeats agile failover, so
 # it MUST be loud, not silent — surfaced to the operator via this SSE frame.
 EVENT_TYPE_GOLDEN_IMAGE_DEGRADED = "golden_image_degraded"
+# Autonomous Wake-and-Execute (AWE): on the DEGRADED→HEALTHY recovery edge the
+# trigger atomically claims the soak lock and detaches the definitive Agentic
+# Swarm soak. These four make that autonomous decision visible per Manifesto §7
+# (every autonomous decision is observable) — LAUNCHED at claim, SUPPRESSED when
+# the flap guard rejects a redundant edge, COMPLETE/FAILED on soak terminal.
+EVENT_TYPE_AWE_SOAK_LAUNCHED = "awe_soak_launched"
+EVENT_TYPE_AWE_SOAK_SUPPRESSED = "awe_soak_suppressed"
+EVENT_TYPE_AWE_SOAK_COMPLETE = "awe_soak_complete"
+EVENT_TYPE_AWE_SOAK_FAILED = "awe_soak_failed"
 
 # Slice 19 (Soak Budget & Compute Circuit-Breaker) — two events covering the
 # fail-closed boundary around an unattended graduation soak:
@@ -1649,6 +1658,10 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_SWARM_NODE_VAPORIZED,             # Swarm Phase 1d (2026-06-24 -- sandbox vaporized)
     EVENT_TYPE_SWARM_DEADLOCK,                    # Swarm Phase 1d (2026-06-24 -- deadlock shattered)
     EVENT_TYPE_SWARM_SENTINEL_BLOCK,             # Swarm Phase 1d (2026-06-24 -- Sentinel imperative block)
+    EVENT_TYPE_AWE_SOAK_LAUNCHED,                # AWE Trigger (2026-07-23 -- recovery-edge soak launch)
+    EVENT_TYPE_AWE_SOAK_SUPPRESSED,             # AWE Trigger (2026-07-23 -- flap-guard suppressed a redundant edge)
+    EVENT_TYPE_AWE_SOAK_COMPLETE,               # AWE Trigger (2026-07-23 -- detached soak reached terminal)
+    EVENT_TYPE_AWE_SOAK_FAILED,                 # AWE Trigger (2026-07-23 -- detached soak raised)
 })
 
 

--- a/backend/core/ouroboros/governance/soak_execution_lock.py
+++ b/backend/core/ouroboros/governance/soak_execution_lock.py
@@ -1,0 +1,176 @@
+"""Soak-Execution Lock — the atomic single-launch claim for the AWE Trigger.
+
+When the DW Sentinel signals recovery (``provider_state`` → ``HEALTHY``), the
+Autonomous Wake-and-Execute trigger must launch the definitive Agentic Swarm
+soak EXACTLY ONCE — even if DoubleWord rapidly flaps HEALTHY↔DEGRADED↔HEALTHY
+during the swarm's own startup window (the classic double-launch race).
+
+Rather than invent a new locking scheme, this mirrors the ESTABLISHED
+single-winner idiom already used in this same ``.jarvis/chunk_strategy.db``:
+``dw_outage_forecaster.record_recovery`` claims an open outage row with a
+predicate-guarded ``UPDATE ... WHERE <predicate>; if cur.rowcount == 0`` — the
+row-count of a guarded UPDATE is SQLite's atomic compare-and-swap. Two callers
+racing the same claim: only one UPDATE flips ``claimed 0→1`` and gets
+``rowcount == 1``; the loser's WHERE no longer matches and gets ``rowcount == 0``.
+
+The claim is **cooldown-aware**, and that single mechanism serves BOTH duties:
+
+  * **Flap guard** — a second HEALTHY edge milliseconds after the first finds a
+    fresh claim (``claimed_ts`` within ``cooldown_s``) → the WHERE excludes it →
+    ``rowcount == 0`` → suppressed. No second parallel swarm.
+  * **Legitimate re-arm** — a genuinely new outage→recovery cycle HOURS later
+    (``claimed_ts`` older than ``cooldown_s``) → the WHERE matches again →
+    ``rowcount == 1`` → the next recovery fires. The lock is one-shot *per
+    outage cycle*, not one-shot forever.
+
+Cross-process safety degrades fail-CLOSED: without a busy_timeout SQLite raises
+``database is locked`` under contention, which is caught and reported as "did
+not win the claim" — the correct default for a launch lock (never double-fire).
+A small ``busy_timeout`` PRAGMA (local to this table's use, not a global policy
+change) reduces spurious losses. Never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import time
+from typing import Optional
+
+logger = logging.getLogger("Ouroboros.SoakExecutionLock")
+
+_LOCK_TABLE = "soak_execution_lock"
+
+DEFAULT_LOCK_NAME = "agentic_swarm_soak"
+_DEFAULT_COOLDOWN_S = 3600.0  # a rapid flap re-fires nothing for an hour
+
+
+def default_relaunch_cooldown_s() -> float:
+    """Env-tunable flap/re-arm window (seconds). Clamped to a sane floor so a
+    misconfigured ``0`` can never disable the flap guard entirely."""
+    try:
+        v = float(os.environ.get("JARVIS_AWE_RELAUNCH_COOLDOWN_S", _DEFAULT_COOLDOWN_S))
+    except (TypeError, ValueError):
+        return _DEFAULT_COOLDOWN_S
+    return max(1.0, v)
+
+
+def ensure_soak_lock_table(conn: sqlite3.Connection) -> None:
+    """Idempotent DDL. Composes the #70021 DB (same file, distinct table)."""
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_LOCK_TABLE} ("
+        "lock_name TEXT PRIMARY KEY, "
+        "claimed INTEGER NOT NULL DEFAULT 0, "
+        "run_id TEXT, "
+        "claimed_ts REAL, "
+        "claimed_wall TEXT, "
+        "released_ts REAL)"
+    )
+    # Local busy_timeout so a concurrent writer waits briefly rather than
+    # instantly losing the claim — improves cross-process fairness without
+    # imposing a global journal-mode/WAL policy on the shared DB.
+    try:
+        conn.execute("PRAGMA busy_timeout=2000")
+    except sqlite3.Error:
+        pass
+    conn.commit()
+
+
+def try_claim_soak_lock(
+    conn: Optional[sqlite3.Connection],
+    run_id: str,
+    *,
+    lock_name: str = DEFAULT_LOCK_NAME,
+    cooldown_s: Optional[float] = None,
+    now: Optional[float] = None,
+) -> bool:
+    """Atomically claim the soak lock. Returns ``True`` iff THIS caller won.
+
+    The guarded UPDATE is the atomic compare-and-swap: the row is claimable iff
+    it is unclaimed OR its last claim is older than ``cooldown_s``. Exactly one
+    concurrent caller can flip it. Fail-closed (returns ``False``) on any error —
+    a lock we cannot prove we hold is a lock we do not hold. Never raises."""
+    if conn is None:
+        return False
+    cd = default_relaunch_cooldown_s() if cooldown_s is None else max(0.0, float(cooldown_s))
+    when = time.time() if now is None else float(now)
+    threshold = when - cd
+    wall = time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime(when))
+    try:
+        ensure_soak_lock_table(conn)
+        # Ensure the single baseline row exists (unclaimed) without disturbing an
+        # existing claim — INSERT OR IGNORE is a no-op when the row is present.
+        conn.execute(
+            f"INSERT OR IGNORE INTO {_LOCK_TABLE} (lock_name, claimed) VALUES (?, 0)",
+            (lock_name,),
+        )
+        cur = conn.execute(
+            f"UPDATE {_LOCK_TABLE} "
+            f"SET claimed=1, run_id=?, claimed_ts=?, claimed_wall=?, released_ts=NULL "
+            f"WHERE lock_name=? "
+            f"AND (claimed=0 OR claimed_ts IS NULL OR claimed_ts < ?)",
+            (run_id, when, wall, lock_name, threshold),
+        )
+        conn.commit()
+        return cur.rowcount == 1
+    except sqlite3.Error:
+        logger.debug("[SoakLock] claim failed (fail-closed)", exc_info=True)
+        return False
+
+
+def release_soak_lock(
+    conn: Optional[sqlite3.Connection],
+    *,
+    lock_name: str = DEFAULT_LOCK_NAME,
+    now: Optional[float] = None,
+) -> None:
+    """Release the lock so the next recovery may re-fire. Only used when a launch
+    fails to even START (so a genuine failure does not wedge the trigger forever)
+    — a successfully detached soak deliberately HOLDS the lock for the cooldown.
+    Never raises."""
+    if conn is None:
+        return
+    when = time.time() if now is None else float(now)
+    try:
+        ensure_soak_lock_table(conn)
+        conn.execute(
+            f"UPDATE {_LOCK_TABLE} SET claimed=0, released_ts=? WHERE lock_name=?",
+            (when, lock_name),
+        )
+        conn.commit()
+    except sqlite3.Error:
+        logger.debug("[SoakLock] release failed", exc_info=True)
+
+
+def read_soak_lock(
+    conn: Optional[sqlite3.Connection], *, lock_name: str = DEFAULT_LOCK_NAME,
+) -> Optional[dict]:
+    """Read the lock row as a dict (or ``None``). Never raises."""
+    if conn is None:
+        return None
+    try:
+        ensure_soak_lock_table(conn)
+        row = conn.execute(
+            f"SELECT lock_name, claimed, run_id, claimed_ts, claimed_wall, released_ts "
+            f"FROM {_LOCK_TABLE} WHERE lock_name=?",
+            (lock_name,),
+        ).fetchone()
+        if not row:
+            return None
+        return {
+            "lock_name": row[0], "claimed": int(row[1] or 0), "run_id": row[2],
+            "claimed_ts": row[3], "claimed_wall": row[4], "released_ts": row[5],
+        }
+    except sqlite3.Error:
+        return None
+
+
+__all__ = [
+    "DEFAULT_LOCK_NAME",
+    "default_relaunch_cooldown_s",
+    "ensure_soak_lock_table",
+    "read_soak_lock",
+    "release_soak_lock",
+    "try_claim_soak_lock",
+]

--- a/tests/governance/test_awe_trigger.py
+++ b/tests/governance/test_awe_trigger.py
@@ -1,0 +1,167 @@
+"""Bulletproof spine for the Autonomous Wake-and-Execute (AWE) Trigger.
+
+Mandated assertions, all against REAL infra (real StreamEventBroker, real SQLite
+on a temp file, real guarded-UPDATE lock) so the fakes cannot mask a buggy
+contract:
+
+  (1) the trigger IDLES while the state is DEGRADED,
+  (2) a broker emission of HEALTHY (DEGRADED→HEALTHY edge) INSTANTLY fires it,
+  (3) the atomic soak lock is ACQUIRED,
+  (4) a flap back to DEGRADED then HEALTHY a moment later does NOT fire a second
+      parallel swarm (single-launch under flapping), and
+  (5) the injected swarm strategy EXECUTES CLEANLY (terminal breadcrumb emitted).
+
+Only the launch_fn is a fake (a counting coroutine) — everything it touches
+(broker delivery, edge detection, the SQLite compare-and-swap) is the real code.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.awe_trigger import AWETrigger
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    EVENT_TYPE_PROVIDER_STATE_CHANGED,
+    get_default_broker,
+    reset_default_broker,
+)
+from backend.core.ouroboros.governance.soak_execution_lock import read_soak_lock
+
+
+async def _wait_for(cond, timeout: float = 2.0) -> None:
+    async def _loop() -> None:
+        while not cond():
+            await asyncio.sleep(0.01)
+    await asyncio.wait_for(_loop(), timeout)
+
+
+def _publish(provider: str, state: str, previous_state: str) -> None:
+    """Emit a real provider_state_changed frame onto the real broker — the exact
+    delivery path the production ProviderStateWatcher uses."""
+    get_default_broker().publish(
+        EVENT_TYPE_PROVIDER_STATE_CHANGED,
+        provider,
+        {"provider": provider, "state": state, "previous_state": previous_state},
+    )
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "chunk_strategy.db")
+
+
+def _make_trigger(db_path, launch_fn, crumbs):
+    return AWETrigger(
+        launch_fn=launch_fn,
+        db_factory=lambda: sqlite3.connect(db_path),
+        breadcrumb_fn=lambda et, p: crumbs.append((et, dict(p))),
+        cooldown_s=3600.0,           # any flap within an hour is suppressed
+        run_id_factory=lambda: "run-fixed",
+    )
+
+
+async def test_awe_full_recovery_lifecycle(db_path):
+    reset_default_broker()
+    launched: list = []
+    launch_started = asyncio.Event()
+
+    async def fake_launch(run_id: str):
+        launched.append(run_id)
+        launch_started.set()
+        await asyncio.sleep(0)         # a real detached coroutine that completes
+        return "swarm-ok"
+
+    crumbs: list = []
+    trig = _make_trigger(db_path, fake_launch, crumbs)
+    trig.start()
+    try:
+        # Ensure the broker subscription is live before we publish (no race).
+        await asyncio.wait_for(trig._subscribed.wait(), timeout=2.0)
+
+        # (1) DEGRADED → the trigger idles: no launch, no lock claim.
+        _publish("doubleword", "DEGRADED", "UNKNOWN")
+        await asyncio.sleep(0.1)
+        assert launched == []
+        lock = read_soak_lock(sqlite3.connect(db_path))
+        assert lock is None or lock.get("claimed", 0) == 0
+
+        # (2) DEGRADED→HEALTHY edge → fires instantly.
+        _publish("doubleword", "HEALTHY", "DEGRADED")
+        await asyncio.wait_for(launch_started.wait(), timeout=2.0)
+        assert launched == ["run-fixed"]
+
+        # (3) the atomic lock was acquired.
+        lock = read_soak_lock(sqlite3.connect(db_path))
+        assert lock is not None and lock["claimed"] == 1
+        assert lock["run_id"] == "run-fixed"
+
+        # (4) a flap (HEALTHY→DEGRADED→HEALTHY) a moment later must NOT re-fire.
+        _publish("doubleword", "DEGRADED", "HEALTHY")   # intermediate, not a launch edge
+        _publish("doubleword", "HEALTHY", "DEGRADED")   # redundant recovery edge
+        await asyncio.sleep(0.15)
+        assert launched == ["run-fixed"], "flap must not launch a second swarm"
+        assert trig._launch_count == 1
+        # The suppression was observable.
+        assert any(et == "awe_soak_suppressed" for et, _ in crumbs)
+
+        # (5) the swarm strategy executed cleanly → terminal breadcrumb emitted.
+        await _wait_for(lambda: any(et == "awe_soak_complete" for et, _ in crumbs))
+        launched_types = [et for et, _ in crumbs]
+        assert "awe_soak_launched" in launched_types
+        assert "awe_soak_complete" in launched_types
+        assert "awe_soak_failed" not in launched_types
+    finally:
+        await trig.stop()
+        reset_default_broker()
+
+
+async def test_awe_idles_on_non_healthy_states(db_path):
+    """A stricter idle proof: UNKNOWN and HEALTHY→HEALTHY (a non-edge) never
+    fire, only a true transition into HEALTHY does."""
+    reset_default_broker()
+    launched: list = []
+
+    async def fake_launch(run_id: str):
+        launched.append(run_id)
+        return "ok"
+
+    trig = _make_trigger(db_path, fake_launch, [])
+    # Drive on_state_event directly for exhaustive edge coverage.
+    assert await trig.on_state_event({"state": "DEGRADED", "previous_state": "HEALTHY"}) is False
+    assert await trig.on_state_event({"state": "UNKNOWN", "previous_state": "DEGRADED"}) is False
+    assert await trig.on_state_event({"state": "HEALTHY", "previous_state": "HEALTHY"}) is False
+    assert await trig.on_state_event({}) is False
+    assert launched == []
+    # The one true edge fires (the soak is DETACHED, so await it to observe).
+    assert await trig.on_state_event({"state": "HEALTHY", "previous_state": "DEGRADED"}) is True
+    await _wait_for(lambda: launched == ["run-fixed"])
+    await trig.stop()
+
+
+async def test_awe_lock_is_atomic_single_winner(db_path):
+    """Two concurrent trigger instances sharing the DB: the guarded UPDATE lets
+    exactly ONE win the claim (compare-and-swap), even racing the same edge."""
+    reset_default_broker()
+    winners: list = []
+
+    def make(idx):
+        async def launch(run_id):
+            winners.append(idx)
+            return idx
+        return _make_trigger(db_path, launch, [])
+
+    t1, t2 = make(1), make(2)
+    # Fire the same recovery edge at both, concurrently.
+    r1, r2 = await asyncio.gather(
+        t1.on_state_event({"state": "HEALTHY", "previous_state": "DEGRADED"}),
+        t2.on_state_event({"state": "HEALTHY", "previous_state": "DEGRADED"}),
+    )
+    assert (r1, r2) in [(True, False), (False, True)], "exactly one claim wins"
+    # Let the single winner's detached soak run.
+    await _wait_for(lambda: len(winners) == 1)
+    assert len(winners) == 1
+    lock = read_soak_lock(sqlite3.connect(db_path))
+    assert lock is not None and lock["claimed"] == 1


### PR DESCRIPTION
## The blind spot

If DoubleWord stabilizes and the Sentinel flips `provider_state → HEALTHY` at **3 AM**, the queued definitive Agentic Swarm soak just **sits idle** waiting for a human to type a CLI command — potentially missing the entire stability window. Root cause: a **passive human bottleneck** on the recovery path. Fix: a reactive, event-driven launch.

## Four mandates

**1 · Root-Cause** — no manual REPL start. The recovery edge itself launches the soak.

**2 · Architectural Purity**
- **Async broker watcher** (`awe_trigger.py::AWETrigger.watch`) subscribes in-process to the same `StreamEventBroker` the SSE uses, draining `provider_state_changed`. Fires only on the **DEGRADED→HEALTHY edge**; idles on DEGRADED/UNKNOWN and HEALTHY→HEALTHY non-edges.
- **Atomic execution lock** (`soak_execution_lock.py`) — claims `soak_execution_lock` in the same `.jarvis/chunk_strategy.db` via the **established guarded-`UPDATE`+`rowcount` compare-and-swap** already used by `dw_outage_forecaster.record_recovery` (not a new scheme). Cooldown-aware: one mechanism is **both** the flap guard (a rapid HEALTHY↔DEGRADED↔HEALTHY inside the cooldown → `rowcount 0` → suppressed) **and** the legitimate re-arm (a genuinely new outage cycle hours later re-fires). Fail-**closed** on error.
- **SIGHUP-resilient detached launch** — the real soak `launch_fn` is detached via `asyncio.create_task` so a long soak never blocks the watcher or REPL. Every step breadcrumbs.

**3 · DRY** — the trigger duplicates **no** launch logic; WHAT it runs is an injected seam. `build_swarm_coroutine_launch_fn` awaits the exact public egress (`intercept_full_content`) the generation hot path uses in `candidate_generator._maybe_swarm_short_circuit`; `build_soak_subprocess_launch_fn` spawns the definitive battle-test soak with `JARVIS_SWARM_ROUTING_ENABLED=true`.

**4 · Bulletproof** — `tests/governance/test_awe_trigger.py` drives the **real** broker + **real** SQLite (temp file, real guarded-UPDATE); only `launch_fn` is faked. Asserts: (1) idles on DEGRADED, (2) HEALTHY edge fires **instantly**, (3) atomic lock **acquired**, (4) a flap does **not** fire a second swarm, (5) the strategy **executes cleanly**. Plus exhaustive edge-idle coverage + a two-instance concurrent single-winner proof. **3 green; 16 registry/badge regressions green.**

## Naming correction (surfaced, not silently built around)
The mandate named `SagaApplyStrategy` as the big-file operation — but that class is the **multi-repo** topological apply. The 4-agent chunk→repair→stitch swarm you *described* (`ProductionAgentTurnFn`, `LineRangeJail`, concurrency=4) is a different stack whose real egress is `intercept_full_content`. The trigger is bound to that real big-file swarm path.

## Observability
Four broker event types (`awe_soak_launched` / `_suppressed` / `_complete` / `_failed`) added to `_VALID_EVENT_TYPES` + the breadcrumb descriptor registry → they surface in `/breadcrumbs` via the unified router, no per-type clone.

## Arming
Master gate `JARVIS_AWE_TRIGGER_ENABLED` **default OFF** (an autonomous soak launcher is opt-in). To arm: run the O+V TUI with `JARVIS_AWE_TRIGGER_ENABLED=true`. The launch still requires DW's genuine DEGRADED→HEALTHY edge (the Sentinel's 5-pass gate) **and** `JARVIS_SWARM_ROUTING_ENABLED=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically launches the Agentic Swarm soak when DoubleWord recovers (DEGRADED→HEALTHY), removing the manual CLI bottleneck and preventing missed stability windows. Uses an atomic SQLite lock to ensure a single launch, adds breadcrumbs for full visibility, and is opt-in.

- **New Features**
  - Added `AWETrigger` to watch `provider_state_changed` and fire only on DEGRADED→HEALTHY. Launch is detached via `asyncio.create_task`.
  - Implemented atomic single-launch lock in `.jarvis/chunk_strategy.db` using guarded UPDATE compare-and-swap, with cooldown-based flap guard (`try_claim_soak_lock` / `release_soak_lock`).
  - Provided two launch seams: `build_swarm_coroutine_launch_fn` (via `intercept_full_content`) and `build_soak_subprocess_launch_fn` (sets `JARVIS_SWARM_ROUTING_ENABLED=true`).
  - Wired trigger start/stop in `serpent_flow`; inert when disabled and fail-closed on errors.
  - Added broker events and breadcrumbs: `awe_soak_launched`, `awe_soak_suppressed`, `awe_soak_complete`, `awe_soak_failed`.
  - Added tests with the real broker and SQLite to verify idle on non-edges, instant launch on recovery, single-winner claim, flap suppression, and clean completion.

- **Migration**
  - Default off. Enable with `JARVIS_AWE_TRIGGER_ENABLED=true`.
  - For subprocess soak, ensure `JARVIS_SWARM_ROUTING_ENABLED=true`.
  - Optional: tune cooldown via `JARVIS_AWE_RELAUNCH_COOLDOWN_S` (seconds).

<sup>Written for commit 93d9493c639e51d8cb8962b254f67afe9de568f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70049?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

