### PR TITLE
State-Reactive Autonomous Supervisor — O+V manages its own recovery lifecycle

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4696,6 +4696,21 @@ class SerpentREPL:
         except Exception:  # noqa: BLE001 — AWE arming is best-effort
             self._awe_trigger = None
 
+        # State-Reactive Autonomous Supervisor — the intent-driven lifecycle
+        # manager. At boot it queries the substrate; if a soak workload is pending
+        # AND DW is DEGRADED it autonomously spawns the Sentinel subprocess + arms
+        # the AWE listener, self-heals the Sentinel on crash, and disarms when the
+        # queue clears. Autonomy is the default (JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED)
+        # but it stays fully inert until real intent exists. HITL = override only.
+        self._autonomous_supervisor = None
+        try:
+            from backend.core.ouroboros.governance.autonomous_supervisor import (
+                start_autonomous_supervisor,
+            )
+            self._autonomous_supervisor = start_autonomous_supervisor()
+        except Exception:  # noqa: BLE001 — supervisor is best-effort
+            self._autonomous_supervisor = None
+
     async def _event_breadcrumb_router(self) -> None:
         """The ONE unified live event feed: subscribe once to the broker and
         surface EVERY backend event through the descriptor registry — filtered by
@@ -4890,6 +4905,16 @@ class SerpentREPL:
             except (asyncio.CancelledError, Exception):  # noqa: BLE001
                 pass
             self._shadow_breadcrumb_task = None
+        # Tear down the Autonomous Supervisor (disarms the AWE listener + SIGTERMs
+        # the Sentinel subprocess + cancels its watchdog). Stop it before the AWE
+        # direct-override teardown since it may own its own AWE instance.
+        _sup = getattr(self, "_autonomous_supervisor", None)
+        if _sup is not None:
+            try:
+                await _sup.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            self._autonomous_supervisor = None
         # Tear down the AWE Trigger (cancels its watcher + any in-flight detached
         # soak). Owns its own tasks, so stop it before the task-tuple sweep.
         _awe = getattr(self, "_awe_trigger", None)

--- a/backend/core/ouroboros/governance/autonomous_supervisor.py
+++ b/backend/core/ouroboros/governance/autonomous_supervisor.py
@@ -1,0 +1,537 @@
+"""State-Reactive Autonomous Supervisor — O+V manages its own recovery lifecycle.
+
+The philosophical line this crosses: HITL becomes an *override*, never a
+*dependency*. O+V reads its own intent from the substrate and drives the whole
+recovery lifecycle hands-off — no manual ``/arm``, no static env as the trigger.
+
+The declarative dependency state machine (root cause of process orphanage +
+missed recovery windows was NOT having one):
+
+    DORMANT ──[pending soak intent AND DW DEGRADED]──▶ ARMED
+    ARMED   ──[soak queue cleared / soak complete]───▶ DORMANT   (SIGTERM Sentinel)
+    ARMED   ──[Sentinel exits unexpectedly, queue still pending]──▶ ARMED (restart, backoff)
+    ARMED   ──[Sentinel exits after HEALTHY handoff]─▶ (expected — AWE fires; disarm on clear)
+
+Three reflexes (Manifesto §2 progressive awakening + §3 async tendrils + §7):
+
+  * **Intent-driven auto-arming** — at boot (and on demand) ``evaluate()`` queries
+    the SQLite substrate: pending soak intent (:mod:`soak_intent`) AND
+    ``provider_state == DEGRADED`` → spawn ``sentinel_daemon`` as a real
+    ``create_subprocess_exec`` task and arm the AWE listener. Zero human input.
+
+  * **Compute hygiene (auto-disarm)** — subscribes to the ``StreamEventBroker``
+    for terminal/soak-complete events; when the queue clears it sends a clean
+    ``SIGTERM`` to the Sentinel subprocess and disarms the AWE listener, freeing
+    the socket pool + the watcher task.
+
+  * **Self-healing watchdog** — while armed, if the Sentinel exits UNEXPECTEDLY
+    (crash / SIGKILL / network death) with the queue still pending and DW still
+    DEGRADED, it warns the unified event router and restarts with BINARY
+    EXPONENTIAL BACKOFF (capped). A clean exit AFTER the HEALTHY handoff is the
+    expected terminus, not a crash — the watchdog distinguishes the two by
+    reading ``provider_state`` + the exit code, never blindly respawning.
+
+DRY: reuses the existing ``sentinel_daemon`` (now spawnable via ``-m``), the
+``chunk_strategy.db`` substrate, the :class:`AWETrigger` (#70049), and pipes the
+Sentinel's stdout/stderr into the unified event router (#70045). The subprocess
+spawn is an injected seam so the whole lifecycle is deterministically testable.
+Master gate ``JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED`` (default TRUE — but INERT
+until real intent exists: an empty queue arms nothing). Fable is never
+referenced. Never raises on the hot path.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+import sys
+from typing import Any, Awaitable, Callable, Optional
+
+logger = logging.getLogger("Ouroboros.AutonomousSupervisor")
+
+# Injected seam: spawn the Sentinel subprocess. Returns an asyncio subprocess
+# (or any object exposing returncode / wait() / send_signal() / stdout / stderr).
+SpawnFn = Callable[[], Awaitable[Any]]
+DbFactory = Callable[[], Any]
+BreadcrumbFn = Callable[[str, dict], None]
+
+STATE_DORMANT = "DORMANT"
+STATE_ARMED = "ARMED"
+
+_SENTINEL_MODULE = "backend.core.ouroboros.governance.sentinel_daemon"
+
+
+def supervisor_enabled() -> bool:
+    """Master gate. Default TRUE — autonomy is the default, but the supervisor is
+    inert until pending intent exists (the intent is the trigger, not the flag)."""
+    return os.environ.get(
+        "JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED", "true",
+    ).strip().lower() in ("1", "true", "yes", "on")
+
+
+def _backoff_base_s() -> float:
+    try:
+        return max(0.1, float(os.environ.get("JARVIS_SUPERVISOR_BACKOFF_BASE_S", "1.0")))
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def _backoff_cap_s() -> float:
+    try:
+        return max(1.0, float(os.environ.get("JARVIS_SUPERVISOR_BACKOFF_CAP_S", "60.0")))
+    except (TypeError, ValueError):
+        return 60.0
+
+
+def _max_restarts() -> int:
+    try:
+        return max(0, int(os.environ.get("JARVIS_SUPERVISOR_MAX_RESTARTS", "8")))
+    except (TypeError, ValueError):
+        return 8
+
+
+def _default_db_factory():
+    try:
+        from backend.core.ouroboros.governance.dw_outage_forecaster import (
+            open_forecast_db,
+        )
+        return open_forecast_db()
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _default_breadcrumb_fn(event_type: str, payload: dict) -> None:
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        op_id = str(payload.get("provider", "doubleword")) or "doubleword"
+        publish_task_event(event_type, op_id, dict(payload))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def build_sentinel_spawn_fn(*, extra_env: Optional[dict] = None) -> SpawnFn:
+    """Default spawn seam: run the real Sentinel module as a subprocess with its
+    stdout/stderr PIPED so the supervisor can pump telemetry into the event
+    router. Reuses the module's ``-m`` entry (DRY)."""
+
+    async def _spawn():
+        env = dict(os.environ)
+        if extra_env:
+            env.update({str(k): str(v) for k, v in extra_env.items()})
+        return await asyncio.create_subprocess_exec(
+            sys.executable, "-m", _SENTINEL_MODULE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.STDOUT,
+            env=env,
+        )
+
+    return _spawn
+
+
+class AutonomousSupervisor:
+    """Owns the arm/disarm/self-heal lifecycle around the Sentinel + AWE trigger."""
+
+    def __init__(
+        self,
+        *,
+        spawn_fn: Optional[SpawnFn] = None,
+        db_factory: Optional[DbFactory] = None,
+        breadcrumb_fn: Optional[BreadcrumbFn] = None,
+        awe_factory: Optional[Callable[[], Any]] = None,
+        provider: str = "doubleword",
+        max_priority: Optional[int] = None,
+    ) -> None:
+        self._spawn_fn = spawn_fn or build_sentinel_spawn_fn()
+        self._db_factory = db_factory or _default_db_factory
+        self._breadcrumb_fn = breadcrumb_fn or _default_breadcrumb_fn
+        self._awe_factory = awe_factory or self._default_awe_factory
+        self._provider = provider
+        self._max_priority = max_priority
+
+        self.state = STATE_DORMANT
+        self._proc: Any = None
+        self._awe: Any = None
+        self._watchdog_task: Optional[asyncio.Task] = None
+        self._telemetry_task: Optional[asyncio.Task] = None
+        self._completion_task: Optional[asyncio.Task] = None
+        self._restart_count = 0
+        self._disarming = False
+        # Lets a test/caller wait for the async watchdog to settle deterministically.
+        self._settled: asyncio.Event = asyncio.Event()
+        self._settled.set()
+
+    # -- helpers --------------------------------------------------------
+
+    def _emit(self, event_type: str, payload: dict) -> None:
+        try:
+            self._breadcrumb_fn(event_type, payload)
+        except Exception:  # noqa: BLE001
+            logger.debug("[Supervisor] breadcrumb failed", exc_info=True)
+
+    def _open_db(self):
+        try:
+            return self._db_factory()
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _pending(self, conn=None) -> int:
+        from backend.core.ouroboros.governance.soak_intent import pending_soak_count
+        own = conn is None
+        c = conn if conn is not None else self._open_db()
+        try:
+            return pending_soak_count(c, max_priority=self._max_priority)
+        finally:
+            if own and c is not None:
+                try:
+                    c.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+    def _dw_state(self, conn=None) -> str:
+        from backend.core.ouroboros.governance.provider_state import get_provider_state
+        own = conn is None
+        c = conn if conn is not None else self._open_db()
+        try:
+            st = get_provider_state(c, self._provider)
+            return str((st or {}).get("state", "UNKNOWN")).upper()
+        finally:
+            if own and c is not None:
+                try:
+                    c.close()
+                except Exception:  # noqa: BLE001
+                    pass
+
+    def _default_awe_factory(self):
+        """Build an AWE trigger bound to the in-process broker. The supervisor
+        arms/disarms it in lockstep with the Sentinel — the trigger fires the
+        soak on the recovery edge the Sentinel produces."""
+        from backend.core.ouroboros.governance.awe_trigger import (
+            AWETrigger,
+            build_soak_subprocess_launch_fn,
+        )
+        return AWETrigger(
+            launch_fn=build_soak_subprocess_launch_fn(),
+            db_factory=self._db_factory,
+            provider=self._provider,
+        )
+
+    # -- intent-driven arming -------------------------------------------
+
+    async def evaluate(self) -> bool:
+        """The declarative arm gate. Arms IFF there is pending soak intent AND DW
+        is DEGRADED and we are not already armed. Returns whether it armed now.
+        Never raises."""
+        try:
+            if self.state == STATE_ARMED:
+                return False
+            conn = self._open_db()
+            try:
+                pending = self._pending(conn)
+                dw = self._dw_state(conn)
+            finally:
+                if conn is not None:
+                    try:
+                        conn.close()
+                    except Exception:  # noqa: BLE001
+                        pass
+            if pending > 0 and dw == "DEGRADED":
+                await self.arm(pending=pending, dw_state=dw)
+                return True
+            logger.debug(
+                "[Supervisor] evaluate: no-arm (pending=%d dw=%s)", pending, dw,
+            )
+            return False
+        except Exception:  # noqa: BLE001
+            logger.debug("[Supervisor] evaluate raised", exc_info=True)
+            return False
+
+    async def arm(self, *, pending: int = 0, dw_state: str = "DEGRADED") -> None:
+        """Spawn the Sentinel subprocess, arm the AWE listener, and start the
+        watchdog + telemetry pump + completion listener. Never raises."""
+        if self.state == STATE_ARMED:
+            return
+        self._disarming = False
+        self._restart_count = 0
+        try:
+            self._proc = await self._spawn_fn()
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("[Supervisor] Sentinel spawn failed: %s", exc)
+            self._emit("sentinel_restarted", {
+                "provider": self._provider, "attempt": 0, "backoff_s": 0,
+                "reason": f"initial spawn failed: {exc}",
+            })
+            self._proc = None
+            return
+        self.state = STATE_ARMED
+        # Arm the AWE listener (fires the soak on the recovery edge).
+        try:
+            self._awe = self._awe_factory()
+            if self._awe is not None:
+                self._awe.start()
+        except Exception:  # noqa: BLE001
+            logger.debug("[Supervisor] AWE arm failed", exc_info=True)
+            self._awe = None
+        pid = getattr(self._proc, "pid", "?")
+        self._emit("supervisor_armed", {
+            "provider": self._provider, "pending": pending,
+            "provider_state": dw_state, "pid": pid,
+        })
+        logger.info(
+            "[Supervisor] ARMED — pending=%d DW=%s → Sentinel pid=%s + AWE listener",
+            pending, dw_state, pid,
+        )
+        self._telemetry_task = asyncio.ensure_future(self._pump_telemetry())
+        self._completion_task = asyncio.ensure_future(self._completion_listener())
+        self._watchdog_task = asyncio.ensure_future(self._watchdog())
+
+    # -- compute hygiene: auto-disarm -----------------------------------
+
+    async def _completion_listener(self) -> None:
+        """Subscribe to the broker; on any terminal/soak-complete event, re-check
+        the queue. Empty → disarm (compute hygiene). Best-effort."""
+        broker = None
+        sub = None
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (
+                EVENT_TYPE_AWE_SOAK_COMPLETE,
+                EVENT_TYPE_OPERATION_TERMINAL,
+                get_default_broker,
+            )
+            triggers = {EVENT_TYPE_AWE_SOAK_COMPLETE, EVENT_TYPE_OPERATION_TERMINAL}
+            broker = get_default_broker()
+            sub = broker.subscribe()
+            if sub is None:
+                return
+            async for event in broker.stream_iter(sub, heartbeat_s=0):
+                if getattr(event, "event_type", "") not in triggers:
+                    continue
+                try:
+                    if self.state == STATE_ARMED and self._pending() == 0:
+                        await self.disarm(reason="soak queue cleared")
+                        return
+                except Exception:  # noqa: BLE001
+                    continue
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            return
+        finally:
+            try:
+                if broker is not None and sub is not None:
+                    broker.unsubscribe(sub)
+            except Exception:  # noqa: BLE001
+                pass
+
+    async def disarm(self, *, reason: str = "queue cleared") -> None:
+        """Clean shutdown: SIGTERM the Sentinel, disarm AWE, cancel the watchdog +
+        listeners, return to DORMANT. Idempotent. Never raises."""
+        if self._disarming or self.state != STATE_ARMED:
+            return
+        self._disarming = True
+        # Cancel the watchdog FIRST so the SIGTERM exit isn't misread as a crash.
+        for attr in ("_watchdog_task", "_telemetry_task", "_completion_task"):
+            t = getattr(self, attr, None)
+            if t is not None and t is not asyncio.current_task():
+                t.cancel()
+        await self._terminate_proc()
+        # Disarm AWE.
+        if self._awe is not None:
+            try:
+                await self._awe.stop()
+            except Exception:  # noqa: BLE001
+                pass
+            self._awe = None
+        self.state = STATE_DORMANT
+        self._emit("supervisor_disarmed", {"provider": self._provider, "reason": reason})
+        logger.info("[Supervisor] DISARMED — %s", reason)
+        self._disarming = False
+
+    async def _terminate_proc(self) -> None:
+        proc = self._proc
+        self._proc = None
+        if proc is None:
+            return
+        try:
+            if getattr(proc, "returncode", None) is None:
+                proc.send_signal(signal.SIGTERM)
+                try:
+                    await asyncio.wait_for(proc.wait(), timeout=5.0)
+                except (asyncio.TimeoutError, Exception):  # noqa: BLE001
+                    try:
+                        proc.kill()
+                    except Exception:  # noqa: BLE001
+                        pass
+        except Exception:  # noqa: BLE001
+            logger.debug("[Supervisor] terminate_proc failed", exc_info=True)
+
+    # -- self-healing watchdog ------------------------------------------
+
+    async def _watchdog(self) -> None:
+        """Await the Sentinel's exit. Distinguish the expected HEALTHY handoff
+        (returncode 0 or DW now HEALTHY → don't respawn) from an unexpected crash
+        (queue still pending AND DW still DEGRADED → warn + exponential-backoff
+        restart, capped). Never raises."""
+        try:
+            while True:
+                proc = self._proc
+                if proc is None:
+                    return
+                self._settled.clear()
+                try:
+                    rc = await proc.wait()
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    rc = None
+
+                # A disarm() in flight owns the teardown — do not respawn.
+                if self._disarming or self.state != STATE_ARMED:
+                    self._settled.set()
+                    return
+
+                dw = self._dw_state()
+                pending = self._pending()
+
+                # Expected terminus: the Sentinel wrote HEALTHY and self-exited.
+                # AWE fires on the recovery edge; disarm happens on queue-clear.
+                if rc == 0 or dw == "HEALTHY":
+                    logger.info(
+                        "[Supervisor] Sentinel exited cleanly (rc=%s dw=%s) — "
+                        "expected recovery handoff, not respawning", rc, dw,
+                    )
+                    self._settled.set()
+                    return
+                # Queue already emptied out from under us → nothing to guard.
+                if pending == 0:
+                    self._settled.set()
+                    await self.disarm(reason="queue emptied during watch")
+                    return
+
+                # Unexpected crash while armed → self-heal with backoff.
+                self._restart_count += 1
+                if self._restart_count > _max_restarts():
+                    logger.warning(
+                        "[Supervisor] Sentinel exceeded max restarts (%d) — giving up",
+                        _max_restarts(),
+                    )
+                    self._emit("sentinel_restarted", {
+                        "provider": self._provider, "attempt": self._restart_count,
+                        "backoff_s": 0, "reason": "max restarts exceeded — supervisor stands down",
+                    })
+                    self._settled.set()
+                    await self.disarm(reason="sentinel unrecoverable")
+                    return
+                backoff = min(
+                    _backoff_cap_s(),
+                    _backoff_base_s() * (2 ** (self._restart_count - 1)),
+                )
+                self._emit("sentinel_restarted", {
+                    "provider": self._provider, "attempt": self._restart_count,
+                    "backoff_s": round(backoff, 2),
+                    "reason": f"unexpected exit rc={rc} (DW still {dw}, {pending} pending)",
+                })
+                logger.warning(
+                    "[Supervisor] Sentinel crashed (rc=%s) — self-heal restart "
+                    "#%d after %.1fs backoff", rc, self._restart_count, backoff,
+                )
+                try:
+                    await asyncio.sleep(backoff)
+                except asyncio.CancelledError:
+                    raise
+                if self._disarming or self.state != STATE_ARMED:
+                    self._settled.set()
+                    return
+                try:
+                    self._proc = await self._spawn_fn()
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("[Supervisor] respawn failed: %s", exc)
+                    self._proc = None
+                    self._settled.set()
+                    await self.disarm(reason="sentinel respawn failed")
+                    return
+                # Re-pump telemetry for the new process.
+                self._telemetry_task = asyncio.ensure_future(self._pump_telemetry())
+                self._settled.set()
+        except asyncio.CancelledError:
+            self._settled.set()
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[Supervisor] watchdog raised", exc_info=True)
+            self._settled.set()
+
+    # -- telemetry pipe -------------------------------------------------
+
+    async def _pump_telemetry(self) -> None:
+        """Read the Sentinel subprocess's stdout line-by-line and surface each as
+        a ``sentinel_telemetry`` breadcrumb — native REPL visibility of the
+        subprocess (DRY: the unified event router renders it). Best-effort."""
+        proc = self._proc
+        stream = getattr(proc, "stdout", None) if proc is not None else None
+        if stream is None:
+            return
+        try:
+            while True:
+                line = await stream.readline()
+                if not line:
+                    return
+                try:
+                    text = line.decode("utf-8", "replace").rstrip() if isinstance(line, (bytes, bytearray)) else str(line).rstrip()
+                except Exception:  # noqa: BLE001
+                    continue
+                if text:
+                    self._emit("sentinel_telemetry", {
+                        "provider": self._provider, "line": text,
+                    })
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            return
+
+    # -- lifecycle ------------------------------------------------------
+
+    async def stop(self) -> None:
+        """Tear everything down (used on REPL shutdown). Never raises."""
+        try:
+            await self.disarm(reason="supervisor stop")
+        except Exception:  # noqa: BLE001
+            pass
+        for attr in ("_watchdog_task", "_telemetry_task", "_completion_task"):
+            t = getattr(self, attr, None)
+            if t is not None:
+                t.cancel()
+                try:
+                    await t
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+                setattr(self, attr, None)
+
+
+def start_autonomous_supervisor(**kwargs: Any) -> Optional[AutonomousSupervisor]:
+    """Construct the supervisor and kick off the intent-driven ``evaluate()`` IFF
+    ``JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED``. Returns the live supervisor (whose
+    ``.stop()`` the caller tears down) or ``None`` when disabled / on error. It
+    arms nothing unless real intent exists. Never raises."""
+    if not supervisor_enabled():
+        return None
+    try:
+        sup = AutonomousSupervisor(**kwargs)
+        asyncio.ensure_future(sup.evaluate())
+        logger.info("[Supervisor] online — evaluating workload intent (autonomy default)")
+        return sup
+    except Exception:  # noqa: BLE001
+        logger.debug("[Supervisor] start failed", exc_info=True)
+        return None
+
+
+__all__ = [
+    "AutonomousSupervisor",
+    "STATE_ARMED",
+    "STATE_DORMANT",
+    "build_sentinel_spawn_fn",
+    "start_autonomous_supervisor",
+    "supervisor_enabled",
+]

--- a/backend/core/ouroboros/governance/event_breadcrumb_registry.py
+++ b/backend/core/ouroboros/governance/event_breadcrumb_registry.py
@@ -269,6 +269,16 @@ def build_default_registry() -> EventBreadcrumbRegistry:
                              lambda p: f"flap guard held ({p.get('reason','lock held')})", "soak"),
         BreadcrumbDescriptor("awe_soak_complete", "✓", "green", SEV_IMPORTANT, _f_awe, "soak"),
         BreadcrumbDescriptor("awe_soak_failed", "✖", "red bold", SEV_CRITICAL, _f_awe, "soak"),
+        BreadcrumbDescriptor("supervisor_armed", "◆", "cyan bold", SEV_IMPORTANT,
+                             lambda p: f"armed — {p.get('pending','?')} pending, DW {p.get('provider_state','?')} "
+                                       f"→ Sentinel pid {p.get('pid','?')}", "supervisor"),
+        BreadcrumbDescriptor("supervisor_disarmed", "◇", "cyan", SEV_IMPORTANT,
+                             lambda p: f"disarmed — queue clear ({p.get('reason','soak complete')})", "supervisor"),
+        BreadcrumbDescriptor("sentinel_restarted", "↻", "yellow", SEV_IMPORTANT,
+                             lambda p: f"Sentinel self-healed (attempt {p.get('attempt','?')}, "
+                                       f"backoff {p.get('backoff_s','?')}s): {p.get('reason','')}", "supervisor"),
+        BreadcrumbDescriptor("sentinel_telemetry", "·", "bright_black", SEV_VERBOSE,
+                             lambda p: str(p.get("line", "")).strip(), "supervisor"),
     ]
     for d in seed:
         reg.register(d)

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -175,6 +175,14 @@ EVENT_TYPE_AWE_SOAK_LAUNCHED = "awe_soak_launched"
 EVENT_TYPE_AWE_SOAK_SUPPRESSED = "awe_soak_suppressed"
 EVENT_TYPE_AWE_SOAK_COMPLETE = "awe_soak_complete"
 EVENT_TYPE_AWE_SOAK_FAILED = "awe_soak_failed"
+# Autonomous Supervisor — the State-Reactive lifecycle manager. It auto-arms on
+# pending soak intent + DW DEGRADED (spawns the Sentinel subprocess), auto-disarms
+# when the queue clears (SIGTERM), self-heals the Sentinel on unexpected exit
+# (exponential backoff), and pipes the Sentinel's stdout/stderr in as telemetry.
+EVENT_TYPE_SUPERVISOR_ARMED = "supervisor_armed"
+EVENT_TYPE_SUPERVISOR_DISARMED = "supervisor_disarmed"
+EVENT_TYPE_SENTINEL_RESTARTED = "sentinel_restarted"
+EVENT_TYPE_SENTINEL_TELEMETRY = "sentinel_telemetry"
 
 # Slice 19 (Soak Budget & Compute Circuit-Breaker) — two events covering the
 # fail-closed boundary around an unattended graduation soak:
@@ -1662,6 +1670,10 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_AWE_SOAK_SUPPRESSED,             # AWE Trigger (2026-07-23 -- flap-guard suppressed a redundant edge)
     EVENT_TYPE_AWE_SOAK_COMPLETE,               # AWE Trigger (2026-07-23 -- detached soak reached terminal)
     EVENT_TYPE_AWE_SOAK_FAILED,                 # AWE Trigger (2026-07-23 -- detached soak raised)
+    EVENT_TYPE_SUPERVISOR_ARMED,                # Autonomous Supervisor (2026-07-23 -- intent-driven arm)
+    EVENT_TYPE_SUPERVISOR_DISARMED,             # Autonomous Supervisor (2026-07-23 -- queue-clear disarm)
+    EVENT_TYPE_SENTINEL_RESTARTED,              # Autonomous Supervisor (2026-07-23 -- watchdog self-heal restart)
+    EVENT_TYPE_SENTINEL_TELEMETRY,              # Autonomous Supervisor (2026-07-23 -- piped Sentinel stdout line)
 })
 
 

--- a/backend/core/ouroboros/governance/sentinel_daemon.py
+++ b/backend/core/ouroboros/governance/sentinel_daemon.py
@@ -230,4 +230,126 @@ __all__ = [
     "ProbeSignal",
     "SentinelResult",
     "run_sentinel",
+    "main",
 ]
+
+
+# ---------------------------------------------------------------------------
+# Spawnable entry point — ``python -m backend.core.ouroboros.governance.sentinel_daemon``
+#
+# The Autonomous Supervisor spawns this via ``create_subprocess_exec`` and pipes
+# our stdout/stderr into the TUI's unified event router. This reuses the real
+# ``dw_deep_probe.staged_health_check`` as ``probe_fn`` and ``run_sentinel``
+# verbatim (DRY) — it just adds an OS-process wrapper + stdout logging (the
+# supervisor reads those lines). No git / filesystem-write / subprocess egress.
+# ---------------------------------------------------------------------------
+
+
+def _sentinel_log(msg: str) -> None:
+    """Emit a structured line to STDOUT (line-buffered) so the supervisor's
+    telemetry pump surfaces it in the TUI. Prefixed for the event router."""
+    import sys as _sys
+    print(f"[sentinel] {msg}", flush=True)
+    _sys.stdout.flush()
+
+
+def _build_staged_probe(model: str):
+    """Construct the real DW deep-probe (staged 2-pass) as a ``probe_fn`` — the
+    same egress the scratchpad daemon used, now DRY inside the module."""
+    from backend.core.ouroboros.governance.dw_deep_probe import staged_health_check
+
+    async def _dispatch(payload):
+        import aiohttp
+        import os as _os
+        key = _os.environ.get("DOUBLEWORD_API_KEY", "")
+        if not key and _os.path.exists(".env"):
+            for line in open(".env"):
+                if line.startswith("DOUBLEWORD_API_KEY="):
+                    key = line.split("=", 1)[1].strip().strip('"').strip("'")
+                    break
+        payload = {**payload, "model": model}
+        session = aiohttp.ClientSession()
+        resp = await session.post(
+            "https://api.doubleword.ai/v1/chat/completions", json=payload,
+            headers={"Authorization": f"Bearer {key}", "Accept": "text/event-stream"},
+            timeout=aiohttp.ClientTimeout(total=None, sock_connect=15),
+        )
+        if resp.status != 200:
+            body = await resp.text()
+            await session.close()
+            raise RuntimeError(f"HTTP {resp.status}: {body[:100]}")
+
+        async def _readline():
+            line = await resp.content.readline()
+            if not line:
+                resp.release()
+                await session.close()
+            return line
+
+        return (_readline, resp)
+
+    async def _probe() -> "ProbeSignal":
+        try:
+            res = await staged_health_check(
+                dispatch_fn=_dispatch, model=model, ttft_bound_s=90.0,
+                itl_hard_s=8.0, itl_safe_s=2.0, pass2_max_tokens=150,
+                pass2_itl_safe_s=3.0,
+            )
+            p2 = res.pass2.reason if res.pass2 else "skipped"
+            _sentinel_log(
+                f"probe {'HEALTHY' if res.healthy else 'DEGRADED'} "
+                f"stage={res.stage} p1=({res.pass1.reason}) p2=({p2})"
+            )
+            ttft = None
+            if res.pass2 and res.pass2.ttft_s and res.pass2.ttft_s > 0:
+                ttft = res.pass2.ttft_s
+            elif res.pass1.ttft_s and res.pass1.ttft_s > 0:
+                ttft = res.pass1.ttft_s
+            err = None
+            if not res.healthy:
+                err = p2 if (res.pass2 and res.stage == "pass2_degraded") else res.pass1.reason
+            return ProbeSignal(healthy=res.healthy, pass1_ok=res.pass1.healthy,
+                               ttft_s=ttft, error_class=err)
+        except Exception as exc:  # noqa: BLE001 — a failed probe is just "still down"
+            _sentinel_log(f"probe error {type(exc).__name__}")
+            return ProbeSignal(healthy=False, pass1_ok=False,
+                               error_class=type(exc).__name__)
+
+    return _probe
+
+
+async def main() -> int:
+    """Headless recovery watch. Exit 0 on HEALTHY handoff, 2 on max-wait give-up.
+    (The supervisor's watchdog reads the exit code + provider_state to decide
+    whether an exit was the expected recovery handoff or an unexpected crash.)"""
+    import os as _os
+    from backend.core.ouroboros.governance.dw_outage_forecaster import open_forecast_db
+    from backend.core.ouroboros.governance.provider_state import get_provider_state
+
+    model = _os.environ.get("JARVIS_DW_SURFACE_PROBE_MODEL", "Qwen/Qwen3.5-397B-A17B-FP8")
+    max_wait_s = float(_os.environ.get("DW_WATCH_MAX_WAIT_S", "10800"))
+    stability = int(_os.environ.get("DW_WATCH_STABILITY", "2"))
+
+    conn = open_forecast_db()
+    _sentinel_log(
+        f"headless Sentinel START model={model} base_stability={stability} "
+        f"max_wait={max_wait_s:.0f}s (SQLite IPC, adaptive hysteresis, zero git/exec)"
+    )
+    result = await run_sentinel(
+        conn, _build_staged_probe(model), provider="doubleword", forecast_conn=conn,
+        terminate=lambda: _sentinel_log("HEALTHY written → self-terminating (orchestrator owns launch)"),
+        max_wait_s=max_wait_s, stability=stability, adaptive_hysteresis=True,
+        pulse_enabled=True, pulse_interval_s=15.0,
+    )
+    st = get_provider_state(conn, "doubleword")
+    _sentinel_log(
+        f"exit recovered={result.recovered} probes={result.probes} "
+        f"state={st['state'] if st else '?'}"
+    )
+    return 0 if result.recovered else 2
+
+
+if __name__ == "__main__":  # pragma: no cover — exercised as a subprocess
+    import asyncio as _asyncio
+    import sys as _sys
+    _sys.exit(_asyncio.run(main()))

--- a/backend/core/ouroboros/governance/soak_intent.py
+++ b/backend/core/ouroboros/governance/soak_intent.py
@@ -1,0 +1,149 @@
+"""Soak-Intent Queue — the declarative workload intent the Supervisor reacts to.
+
+The Autonomous Supervisor is intent-driven, not flag-driven: it arms itself when
+there is *work waiting* and DoubleWord is down, and disarms when the work clears.
+"Work waiting" needs a durable, cross-process record — the in-memory
+``record_pending_strategy`` dict (chunked_generation_bridge) is process-local and
+cannot be seen by a supervisor querying the substrate at boot.
+
+So this is the declarative state: a tiny ``soak_intent_queue`` table in the SAME
+``.jarvis/chunk_strategy.db`` every other resilience subsystem composes
+(provider_state / jitter / ttft / soak_execution_lock). One row per pending
+high-priority soak workload (e.g. a queued ``SagaApplyStrategy`` / big-file swarm
+run). ``status`` moves ``pending`` → ``cleared``; the supervisor's arm gate is
+simply "does ``pending_soak_count() > 0``". Enqueue expresses intent (staging a
+soak and walking away); the engine does the rest. Never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+import time
+import uuid
+from typing import Optional
+
+logger = logging.getLogger("Ouroboros.SoakIntent")
+
+_INTENT_TABLE = "soak_intent_queue"
+
+STATUS_PENDING = "pending"
+STATUS_CLEARED = "cleared"
+
+
+def ensure_intent_table(conn: sqlite3.Connection) -> None:
+    """Idempotent DDL. Composes the #70021 DB (same file, distinct table)."""
+    conn.execute(
+        f"CREATE TABLE IF NOT EXISTS {_INTENT_TABLE} ("
+        "intent_id TEXT PRIMARY KEY, "
+        "kind TEXT NOT NULL, "
+        "target TEXT, "
+        "priority INTEGER NOT NULL DEFAULT 5, "
+        "status TEXT NOT NULL DEFAULT 'pending', "
+        "enqueued_ts REAL, "
+        "cleared_ts REAL)"
+    )
+    conn.commit()
+
+
+def enqueue_soak_intent(
+    conn: Optional[sqlite3.Connection],
+    *,
+    kind: str = "agentic_swarm_soak",
+    target: str = "",
+    priority: int = 1,
+    intent_id: Optional[str] = None,
+    now: Optional[float] = None,
+) -> Optional[str]:
+    """Record a pending high-priority soak workload. Returns the intent_id, or
+    ``None`` on failure. Never raises."""
+    if conn is None:
+        return None
+    iid = intent_id or uuid.uuid4().hex[:12]
+    when = time.time() if now is None else float(now)
+    try:
+        ensure_intent_table(conn)
+        conn.execute(
+            f"INSERT OR IGNORE INTO {_INTENT_TABLE} "
+            f"(intent_id, kind, target, priority, status, enqueued_ts) "
+            f"VALUES (?, ?, ?, ?, '{STATUS_PENDING}', ?)",
+            (iid, kind, target, int(priority), when),
+        )
+        conn.commit()
+        return iid
+    except sqlite3.Error:
+        logger.debug("[SoakIntent] enqueue failed", exc_info=True)
+        return None
+
+
+def pending_soak_count(
+    conn: Optional[sqlite3.Connection], *, max_priority: Optional[int] = None,
+) -> int:
+    """How many pending soak workloads are queued. ``max_priority`` (lower ==
+    higher priority) filters to at-least-this-urgent intents. Never raises."""
+    if conn is None:
+        return 0
+    try:
+        ensure_intent_table(conn)
+        if max_priority is None:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM {_INTENT_TABLE} WHERE status=?",
+                (STATUS_PENDING,),
+            ).fetchone()
+        else:
+            row = conn.execute(
+                f"SELECT COUNT(*) FROM {_INTENT_TABLE} "
+                f"WHERE status=? AND priority<=?",
+                (STATUS_PENDING, int(max_priority)),
+            ).fetchone()
+        return int(row[0]) if row else 0
+    except sqlite3.Error:
+        return 0
+
+
+def clear_soak_intent(
+    conn: Optional[sqlite3.Connection],
+    *,
+    intent_id: Optional[str] = None,
+    kind: Optional[str] = None,
+    now: Optional[float] = None,
+) -> int:
+    """Mark matching pending intents ``cleared`` (the soak reached terminal).
+    With no filter, clears ALL pending. Returns the count cleared. Never raises."""
+    if conn is None:
+        return 0
+    when = time.time() if now is None else float(now)
+    try:
+        ensure_intent_table(conn)
+        if intent_id is not None:
+            cur = conn.execute(
+                f"UPDATE {_INTENT_TABLE} SET status=?, cleared_ts=? "
+                f"WHERE intent_id=? AND status=?",
+                (STATUS_CLEARED, when, intent_id, STATUS_PENDING),
+            )
+        elif kind is not None:
+            cur = conn.execute(
+                f"UPDATE {_INTENT_TABLE} SET status=?, cleared_ts=? "
+                f"WHERE kind=? AND status=?",
+                (STATUS_CLEARED, when, kind, STATUS_PENDING),
+            )
+        else:
+            cur = conn.execute(
+                f"UPDATE {_INTENT_TABLE} SET status=?, cleared_ts=? WHERE status=?",
+                (STATUS_CLEARED, when, STATUS_PENDING),
+            )
+        conn.commit()
+        return cur.rowcount if cur.rowcount and cur.rowcount > 0 else 0
+    except sqlite3.Error:
+        logger.debug("[SoakIntent] clear failed", exc_info=True)
+        return 0
+
+
+__all__ = [
+    "STATUS_CLEARED",
+    "STATUS_PENDING",
+    "clear_soak_intent",
+    "enqueue_soak_intent",
+    "ensure_intent_table",
+    "pending_soak_count",
+]

--- a/tests/governance/test_autonomous_supervisor.py
+++ b/tests/governance/test_autonomous_supervisor.py
@@ -1,0 +1,257 @@
+"""Bulletproof spine for the State-Reactive Autonomous Supervisor.
+
+Mandated assertions, all against the REAL substrate (real SQLite soak_intent +
+provider_state on a temp file, real StreamEventBroker) with ONLY the subprocess
+spawn faked (a controllable FakeProc) so the lifecycle is deterministic:
+
+  (1) injecting a pending soak intent while DW is DEGRADED autonomously SPAWNS
+      the Sentinel subprocess and arms the supervisor,
+  (2) simulating a SIGKILL on the mock Sentinel triggers the Watchdog's automatic
+      exponential-backoff RESTART, and
+  (3) clearing the pending queue + a broker completion event autonomously
+      TERMINATES the Sentinel (SIGTERM) and DISARMS the system.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import signal
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.autonomous_supervisor import (
+    STATE_ARMED,
+    STATE_DORMANT,
+    AutonomousSupervisor,
+)
+from backend.core.ouroboros.governance.ide_observability_stream import (
+    EVENT_TYPE_OPERATION_TERMINAL,
+    get_default_broker,
+    reset_default_broker,
+)
+from backend.core.ouroboros.governance.provider_state import mark_degraded, mark_healthy
+from backend.core.ouroboros.governance.soak_intent import (
+    clear_soak_intent,
+    enqueue_soak_intent,
+)
+
+
+async def _wait_for(cond, timeout: float = 3.0) -> None:
+    async def _loop() -> None:
+        while not cond():
+            await asyncio.sleep(0.01)
+    await asyncio.wait_for(_loop(), timeout)
+
+
+class _FakeStream:
+    """A subprocess stdout that yields nothing then EOF (telemetry pump exits)."""
+
+    async def readline(self):
+        return b""
+
+
+class _FakeProc:
+    """A controllable stand-in for an asyncio subprocess. Faithful to the real
+    contract: ``wait()`` may be awaited by MULTIPLE independent callers and
+    cancelling one waiter never affects the others or the process (an Event, not
+    a shared cancellable future)."""
+
+    def __init__(self, pid: int) -> None:
+        self.pid = pid
+        self.returncode = None
+        self.stdout = _FakeStream()
+        self.signals: list = []
+        self._rc = None
+        self._exited = asyncio.Event()
+
+    async def wait(self):
+        await self._exited.wait()          # per-caller future; cancel-isolated
+        self.returncode = self._rc
+        return self._rc
+
+    def _exit(self, rc: int) -> None:
+        if not self._exited.is_set():
+            self._rc = rc
+            self.returncode = rc
+            self._exited.set()
+
+    def send_signal(self, sig) -> None:
+        self.signals.append(sig)
+        if not self._exited.is_set():      # SIGTERM → clean exit
+            self._exit(0)
+
+    def kill(self) -> None:
+        self.signals.append(signal.SIGKILL)
+        self._exit(-9)
+
+    def crash(self, rc: int = -9) -> None:
+        """Simulate an unexpected death (SIGKILL / network exception)."""
+        self._exit(rc)
+
+
+class _SpawnRecorder:
+    def __init__(self) -> None:
+        self.procs: list = []
+
+    async def __call__(self):
+        proc = _FakeProc(pid=1000 + len(self.procs))
+        self.procs.append(proc)
+        return proc
+
+    @property
+    def count(self) -> int:
+        return len(self.procs)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "chunk_strategy.db")
+
+
+def _make_supervisor(db_path, spawn, crumbs, *, no_awe=True):
+    return AutonomousSupervisor(
+        spawn_fn=spawn,
+        db_factory=lambda: sqlite3.connect(db_path),
+        breadcrumb_fn=lambda et, p: crumbs.append((et, dict(p))),
+        # Disarm test drives the broker; keep AWE out of the picture here so the
+        # assertions isolate the supervisor's own lifecycle (AWE has its own spine).
+        awe_factory=(lambda: None) if no_awe else None,
+    )
+
+
+async def test_intent_driven_autospawn(db_path, monkeypatch):
+    """(1) pending intent + DEGRADED → autonomous spawn + ARMED."""
+    monkeypatch.setenv("JARVIS_SUPERVISOR_BACKOFF_BASE_S", "0.01")
+    reset_default_broker()
+    conn = sqlite3.connect(db_path)
+    mark_degraded(conn, "doubleword", reason="test")
+    enqueue_soak_intent(conn, kind="agentic_swarm_soak", priority=1)
+    conn.close()
+
+    spawn = _SpawnRecorder()
+    crumbs: list = []
+    sup = _make_supervisor(db_path, spawn, crumbs)
+    try:
+        armed = await sup.evaluate()
+        assert armed is True
+        assert sup.state == STATE_ARMED
+        assert spawn.count == 1
+        assert any(et == "supervisor_armed" for et, _ in crumbs)
+    finally:
+        await sup.stop()
+
+
+async def test_no_arm_when_healthy_or_empty(db_path):
+    """The intent gate is real: no arm if the queue is empty OR DW is HEALTHY."""
+    reset_default_broker()
+    spawn = _SpawnRecorder()
+    sup = _make_supervisor(db_path, spawn, [])
+
+    # Empty queue + DEGRADED → no arm.
+    conn = sqlite3.connect(db_path)
+    mark_degraded(conn, "doubleword", reason="test")
+    conn.close()
+    assert await sup.evaluate() is False
+    assert spawn.count == 0
+
+    # Pending + HEALTHY → no arm (nothing to watch for).
+    conn = sqlite3.connect(db_path)
+    enqueue_soak_intent(conn, priority=1)
+    mark_healthy(conn, "doubleword", reason="test")
+    conn.close()
+    assert await sup.evaluate() is False
+    assert spawn.count == 0
+    assert sup.state == STATE_DORMANT
+
+
+async def test_watchdog_restarts_on_sigkill(db_path, monkeypatch):
+    """(2) SIGKILL the Sentinel while armed → watchdog auto-restarts (backoff)."""
+    monkeypatch.setenv("JARVIS_SUPERVISOR_BACKOFF_BASE_S", "0.01")
+    monkeypatch.setenv("JARVIS_SUPERVISOR_BACKOFF_CAP_S", "0.05")
+    reset_default_broker()
+    conn = sqlite3.connect(db_path)
+    mark_degraded(conn, "doubleword", reason="test")
+    enqueue_soak_intent(conn, priority=1)
+    conn.close()
+
+    spawn = _SpawnRecorder()
+    crumbs: list = []
+    sup = _make_supervisor(db_path, spawn, crumbs)
+    try:
+        await sup.evaluate()
+        assert spawn.count == 1
+        await _wait_for(lambda: sup._watchdog_task is not None)
+
+        # Kill the Sentinel unexpectedly while DW is STILL degraded + queue pending.
+        spawn.procs[0].crash(rc=-9)
+
+        # The watchdog must self-heal: a second spawn appears.
+        await _wait_for(lambda: spawn.count == 2)
+        assert sup.state == STATE_ARMED, "supervisor stays armed across a self-heal"
+        assert any(et == "sentinel_restarted" for et, _ in crumbs)
+        # And the restart breadcrumb records the backoff attempt.
+        restart = next(p for et, p in crumbs if et == "sentinel_restarted")
+        assert restart["attempt"] == 1 and restart["backoff_s"] >= 0.0
+    finally:
+        await sup.stop()
+
+
+async def test_expected_healthy_exit_does_not_respawn(db_path, monkeypatch):
+    """A clean exit AFTER the HEALTHY handoff is the expected terminus, NOT a
+    crash — the watchdog must not respawn (else it fights its own recovery)."""
+    monkeypatch.setenv("JARVIS_SUPERVISOR_BACKOFF_BASE_S", "0.01")
+    reset_default_broker()
+    conn = sqlite3.connect(db_path)
+    mark_degraded(conn, "doubleword", reason="test")
+    enqueue_soak_intent(conn, priority=1)
+    conn.close()
+
+    spawn = _SpawnRecorder()
+    sup = _make_supervisor(db_path, spawn, [])
+    try:
+        await sup.evaluate()
+        await _wait_for(lambda: sup._watchdog_task is not None)
+        # Sentinel writes HEALTHY then self-exits cleanly (rc=0).
+        conn = sqlite3.connect(db_path)
+        mark_healthy(conn, "doubleword", reason="recovered")
+        conn.close()
+        spawn.procs[0].crash(rc=0)
+        # Give the watchdog time — it must NOT respawn.
+        await asyncio.sleep(0.2)
+        assert spawn.count == 1, "clean HEALTHY handoff must not trigger a respawn"
+    finally:
+        await sup.stop()
+
+
+async def test_queue_clear_disarms_via_broker(db_path, monkeypatch):
+    """(3) clearing the queue + a broker completion event → SIGTERM + DISARM."""
+    monkeypatch.setenv("JARVIS_SUPERVISOR_BACKOFF_BASE_S", "0.01")
+    reset_default_broker()
+    conn = sqlite3.connect(db_path)
+    mark_degraded(conn, "doubleword", reason="test")
+    enqueue_soak_intent(conn, kind="agentic_swarm_soak", priority=1)
+    conn.close()
+
+    spawn = _SpawnRecorder()
+    crumbs: list = []
+    sup = _make_supervisor(db_path, spawn, crumbs)
+    try:
+        await sup.evaluate()
+        assert sup.state == STATE_ARMED
+        proc = spawn.procs[0]
+        await _wait_for(lambda: sup._completion_task is not None)
+
+        # The soak cleared the queue; a terminal event now flows on the broker.
+        conn = sqlite3.connect(db_path)
+        clear_soak_intent(conn, kind="agentic_swarm_soak")
+        conn.close()
+        get_default_broker().publish(
+            EVENT_TYPE_OPERATION_TERMINAL, "op-x", {"op_id": "op-x", "state": "COMPLETE"},
+        )
+
+        await _wait_for(lambda: sup.state == STATE_DORMANT)
+        assert signal.SIGTERM in proc.signals, "Sentinel received a clean SIGTERM"
+        assert any(et == "supervisor_disarmed" for et, _ in crumbs)
+    finally:
+        await sup.stop()


### PR DESCRIPTION
## Tool → agent: HITL becomes an *override*, never a *dependency*

O+V reads its own workload intent from the substrate and drives the whole recovery lifecycle hands-off. If it has an objective (a pending soak in SQLite), it looks at the board, sees DoubleWord is down, deploys the Sentinel to watch it, pulls the trigger the instant the network clears — then puts itself back to sleep. No manual `/arm`, no static env as the trigger.

## The declarative dependency state machine (the root-cause fix)
```
DORMANT ─[pending soak intent AND DW DEGRADED]─▶ ARMED
ARMED   ─[soak queue cleared / soak complete]──▶ DORMANT   (SIGTERM Sentinel)
ARMED   ─[Sentinel crashes, queue still pending]▶ ARMED     (restart, backoff)
ARMED   ─[Sentinel exits after HEALTHY handoff]─▶ (expected — AWE fires, no respawn)
```

## Four mandates

**1 · Root-cause** — no verbs, no static-env trigger. A declarative state machine armed by *workload intent*.

**2 · Purity**
- **Intent-driven auto-arm** — `evaluate()` queries the substrate: pending soak intent (`soak_intent.py`, a new durable `soak_intent_queue` table in `chunk_strategy.db` — the in-memory `record_pending_strategy` dict is process-local and unseeable cross-process) **AND** `provider_state==DEGRADED` → spawns `sentinel_daemon` via `create_subprocess_exec` + arms AWE.
- **Compute hygiene (auto-disarm)** — subscribes to the broker for `operation_terminal`/`awe_soak_complete`; queue clear → clean **SIGTERM** + disarm AWE.
- **Self-healing watchdog** — unexpected Sentinel exit (crash/SIGKILL/network death) with queue still pending + DW still DEGRADED → warns the event router + **binary exponential-backoff** restart (capped, bounded). It **distinguishes** the expected terminus — a clean exit after the HEALTHY handoff — and does **not** respawn (else it fights its own recovery), reading `provider_state` + exit code.

**3 · DRY** — reuses `sentinel_daemon` (promoted with a `python -m` entry wrapping the real `dw_deep_probe.staged_health_check` + `run_sentinel` verbatim), `chunk_strategy.db`, the `AWETrigger` (#70049), and pipes the Sentinel's stdout/stderr into the unified event router (#70045) as `sentinel_telemetry` breadcrumbs.

**4 · Bulletproof** — `test_autonomous_supervisor.py`: **real** SQLite + **real** broker, only the subprocess spawn faked (a cancel-isolated `FakeProc` mirroring the real multi-waiter `wait()`). (1) pending+DEGRADED → autonomous spawn + armed, (2) SIGKILL → watchdog backoff-restart, (3) queue clear + broker terminal → SIGTERM + disarm; plus the intent gate (no-arm on empty/HEALTHY) and the expected-HEALTHY-no-respawn proof. **5 green; 24 governance regressions green.**

## Observability
Four broker event types (`supervisor_armed` / `_disarmed`, `sentinel_restarted` / `_telemetry`) added to `_VALID_EVENT_TYPES` + the descriptor registry → surface in `/breadcrumbs`. (A CI-style check caught them missing from the allowlist first — `publish` silently drops unlisted types.)

## Autonomy default
`JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED` **default TRUE** — autonomy is the default, but the supervisor is **inert until real intent exists** (an empty queue arms nothing; the intent is the trigger, not the flag). The `/arm` verbs remain as the manual steering wheel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a state‑reactive autonomous supervisor that reads durable soak intent from SQLite and manages recovery end‑to‑end—auto‑arm on pending intent + DoubleWord DEGRADED, self‑heal the Sentinel, and auto‑disarm when the queue clears. Adds new observability events and wires the supervisor into REPL start/stop.

- **New Features**
  - `AutonomousSupervisor`: arms on pending `soak_intent_queue` + `DEGRADED`, spawns `sentinel_daemon`, and starts `AWETrigger`.
  - Auto‑disarm on queue clear via broker events; sends SIGTERM to the Sentinel and stops AWE.
  - Watchdog restarts on unexpected exits with bounded exponential backoff; no respawn after a healthy handoff.
  - Observability and wiring: `sentinel_daemon` is spawnable via `python -m` and streams `sentinel_telemetry`; new `supervisor_armed`, `supervisor_disarmed`, and `sentinel_restarted` events are whitelisted and rendered; REPL boot/stop starts and tears down the supervisor; adds substrate‑backed tests for arm/restart/disarm and intent gating.

- **Migration**
  - Default on: set `JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED=false` to disable.
  - No action needed; the supervisor is inert without intent. Use `enqueue_soak_intent()` and `clear_soak_intent()` to express/clear work.
  - Existing `/arm` verbs remain for manual control.

<sup>Written for commit 21362b0694d34ed3b5a57262be810d0e15809139. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70050?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

