### PR TITLE
AST-Aware Checkpoint Intent Engine — functionally immortal Swarm soaks

### DIFF
--- a/backend/core/ouroboros/governance/checkpoint_manifest.py
+++ b/backend/core/ouroboros/governance/checkpoint_manifest.py
@@ -1,0 +1,451 @@
+"""AST-Aware Checkpoint Intent Engine — functionally immortal Swarm map-reduce.
+
+Root cause of lost map-reduce progress: a stateless (generic-string) intent. A
+hard crash at file #400 of a 500-file soak restarts from file #1 — massive
+compute + token waste. The fix is a deterministic, serialized JSON manifest that
+tracks granular chunk-level completion, mutated IN PLACE inside the existing
+``soak_intent_queue`` row (no new database).
+
+Three guarantees:
+
+  * **Deterministic manifest** — ``/enqueue_soak`` walks the target, extracts
+    per-file AST chunks (top-level defs/classes), and hashes each to a stable
+    ``chunk_id = sha256(rel_path:symbol:content_sha)[:16]``. The manifest is
+    ``pending_chunks[]`` + an empty ``completed_chunks[]``, serialized with
+    ``sort_keys`` so it is byte-identical for identical inputs.
+
+  * **Atomic chunk commits** — the instant a sub-agent completes a chunk,
+    :func:`mark_chunk_complete` moves that hash pending→completed under a
+    ``BEGIN IMMEDIATE`` read-modify-write (SQLite's single-writer lock serializes
+    concurrent committers; ``busy_timeout`` makes cross-process contenders wait
+    rather than lose). Idempotent: re-committing an already-completed hash is a
+    no-op success.
+
+  * **Resume-from-hash idempotency** — on re-arm the runner parses the manifest
+    and STRUCTURALLY ignores every hash already in ``completed_chunks``
+    (:func:`resume_pending`), so a restarted Swarm processes only the remainder,
+    never a duplicate. A file whose content CHANGED gets a new hash → correctly
+    treated as fresh work.
+
+DRY: mutates the existing intent row's ``manifest_json`` (soak_intent.py), reuses
+``chunk_strategy.db``, and the runner wraps — never forks — the existing swarm.
+Schema-versioned per Vision discipline. Fable is never referenced. Never raises.
+"""
+
+from __future__ import annotations
+
+import ast
+import asyncio
+import hashlib
+import json
+import logging
+import os
+import sqlite3
+import time
+from dataclasses import asdict, dataclass, field
+from typing import Any, Awaitable, Callable, List, Optional
+
+from backend.core.ouroboros.governance.soak_intent import (
+    enqueue_soak_intent,
+    ensure_intent_table,
+    get_manifest_json,
+)
+
+logger = logging.getLogger("Ouroboros.CheckpointManifest")
+
+MANIFEST_SCHEMA_VERSION = 1
+_INTENT_TABLE = "soak_intent_queue"
+
+_DEFAULT_EXTS = (".py",)
+
+
+@dataclass(frozen=True)
+class ChunkDescriptor:
+    """One deterministically-hashed unit of soak work (a file-level AST chunk)."""
+    chunk_id: str
+    file_path: str
+    symbol: str
+    start_line: int
+    end_line: int
+    content_sha: str
+
+
+def _sha(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "replace")).hexdigest()
+
+
+def chunk_id_for(rel_path: str, symbol: str, content_sha: str) -> str:
+    """Stable id — identical inputs always hash identically; a content change
+    (new ``content_sha``) yields a new id (→ treated as fresh work on resume)."""
+    return _sha(f"{rel_path}:{symbol}:{content_sha}")[:16]
+
+
+def _extract_file_chunks(root: str, abs_path: str) -> List[ChunkDescriptor]:
+    """Top-level ``def``/``class`` chunks of one file. If the file cannot be
+    AST-parsed (or has no top-level symbols) it is hashed as a single
+    whole-file chunk (symbol ``"<module>"``) so nothing is silently skipped."""
+    try:
+        with open(abs_path, "r", encoding="utf-8", errors="replace") as fh:
+            source = fh.read()
+    except OSError:
+        return []
+    try:
+        rel = os.path.relpath(abs_path, root)
+    except ValueError:
+        rel = abs_path
+    out: List[ChunkDescriptor] = []
+    try:
+        tree = ast.parse(source)
+        for node in tree.body:
+            if isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+                start = int(getattr(node, "lineno", 0) or 0)
+                end = int(getattr(node, "end_lineno", start) or start)
+                seg = ast.get_source_segment(source, node) or ""
+                csha = _sha(seg)[:16]
+                out.append(ChunkDescriptor(
+                    chunk_id=chunk_id_for(rel, node.name, csha),
+                    file_path=rel, symbol=node.name,
+                    start_line=start, end_line=end, content_sha=csha,
+                ))
+    except SyntaxError:
+        out = []
+    if not out:
+        csha = _sha(source)[:16]
+        out.append(ChunkDescriptor(
+            chunk_id=chunk_id_for(rel, "<module>", csha),
+            file_path=rel, symbol="<module>",
+            start_line=1, end_line=(source.count("\n") + 1),
+            content_sha=csha,
+        ))
+    # Deterministic ordering (path, then start-line) → stable manifest.
+    out.sort(key=lambda c: (c.file_path, c.start_line, c.symbol))
+    return out
+
+
+def _walk_sync(target: str, exts: tuple) -> List[ChunkDescriptor]:
+    root = os.path.abspath(target)
+    chunks: List[ChunkDescriptor] = []
+    if os.path.isfile(root):
+        base = os.path.dirname(root) or "."
+        chunks.extend(_extract_file_chunks(base, root))
+    elif os.path.isdir(root):
+        for dirpath, _dirs, files in os.walk(root):
+            for name in sorted(files):
+                if name.endswith(tuple(exts)):
+                    chunks.extend(_extract_file_chunks(root, os.path.join(dirpath, name)))
+    # Global determinism + dedup by chunk_id.
+    seen: set = set()
+    uniq: List[ChunkDescriptor] = []
+    for c in sorted(chunks, key=lambda c: (c.file_path, c.start_line, c.symbol)):
+        if c.chunk_id not in seen:
+            seen.add(c.chunk_id)
+            uniq.append(c)
+    return uniq
+
+
+async def walk_target(
+    target: str, *, exts: tuple = _DEFAULT_EXTS,
+) -> List[ChunkDescriptor]:
+    """Asynchronously walk *target* (dir or single file) and return its
+    deterministic AST chunk descriptors. The blocking os.walk / AST parse runs in
+    a worker thread so the REPL event loop is never stalled. Never raises."""
+    try:
+        return await asyncio.to_thread(_walk_sync, target, exts)
+    except Exception:  # noqa: BLE001
+        logger.debug("[Checkpoint] walk_target failed for %s", target, exc_info=True)
+        return []
+
+
+# ---------------------------------------------------------------------------
+# Manifest (de)serialization — deterministic
+# ---------------------------------------------------------------------------
+
+
+def build_manifest(target: str, chunks: List[ChunkDescriptor], *, now: Optional[float] = None) -> dict:
+    return {
+        "schema_version": MANIFEST_SCHEMA_VERSION,
+        "target": target,
+        "created_ts": time.time() if now is None else float(now),
+        "pending_chunks": [asdict(c) for c in chunks],
+        "completed_chunks": [],
+    }
+
+
+def serialize_manifest(manifest: dict) -> str:
+    """Deterministic serialization (sorted keys) — byte-identical for identical
+    manifests, so a content-unchanged re-enqueue is provably stable."""
+    return json.dumps(manifest, sort_keys=True, separators=(",", ":"))
+
+
+def deserialize_manifest(raw: Optional[str]) -> Optional[dict]:
+    if not raw:
+        return None
+    try:
+        m = json.loads(raw)
+        return m if isinstance(m, dict) else None
+    except (ValueError, TypeError):
+        return None
+
+
+def completed_ids(manifest: dict) -> set:
+    return {
+        str(c.get("chunk_id"))
+        for c in (manifest or {}).get("completed_chunks", []) or []
+        if isinstance(c, dict) and c.get("chunk_id")
+    }
+
+
+def resume_pending(manifest: dict) -> List[dict]:
+    """The chunks still to do: every ``pending_chunks`` entry whose hash is NOT in
+    ``completed_chunks``. Structural idempotency — a resumed Swarm sees only the
+    remainder, never a duplicate. Never raises."""
+    if not manifest:
+        return []
+    done = completed_ids(manifest)
+    return [
+        c for c in manifest.get("pending_chunks", []) or []
+        if isinstance(c, dict) and str(c.get("chunk_id")) not in done
+    ]
+
+
+# ---------------------------------------------------------------------------
+# Enqueue with manifest (the /enqueue_soak backend)
+# ---------------------------------------------------------------------------
+
+
+async def enqueue_soak_manifest(
+    conn: Optional[sqlite3.Connection],
+    target: str,
+    *,
+    kind: str = "agentic_swarm_soak",
+    priority: int = 1,
+    exts: tuple = _DEFAULT_EXTS,
+    now: Optional[float] = None,
+) -> Optional[dict]:
+    """Walk *target*, build the manifest, and write it into a NEW pending intent
+    row. Returns ``{intent_id, manifest, chunk_count}`` or ``None``. Never raises."""
+    if conn is None:
+        return None
+    chunks = await walk_target(target, exts=exts)
+    manifest = build_manifest(target, chunks, now=now)
+    raw = serialize_manifest(manifest)
+    iid = enqueue_soak_intent(
+        conn, kind=kind, target=target, priority=priority, manifest_json=raw, now=now,
+    )
+    if iid is None:
+        return None
+    return {"intent_id": iid, "manifest": manifest, "chunk_count": len(chunks)}
+
+
+# ---------------------------------------------------------------------------
+# Atomic chunk commit — the per-file checkpoint
+# ---------------------------------------------------------------------------
+
+
+def mark_chunk_complete(
+    conn: Optional[sqlite3.Connection],
+    intent_id: str,
+    chunk_id: str,
+    *,
+    result: str = "",
+    now: Optional[float] = None,
+) -> bool:
+    """Atomically move ``chunk_id`` from ``pending_chunks`` to
+    ``completed_chunks`` inside the intent row's manifest. Read-modify-write under
+    ``BEGIN IMMEDIATE`` so concurrent committers serialize on SQLite's write lock.
+    Idempotent (re-committing an already-completed hash returns ``True``). Returns
+    ``True`` on a durable commit (or already-done), ``False`` on unknown chunk /
+    error. Never raises."""
+    if conn is None:
+        return False
+    when = time.time() if now is None else float(now)
+    prev_isolation = getattr(conn, "isolation_level", "")
+    try:
+        ensure_intent_table(conn)
+        try:
+            conn.execute("PRAGMA busy_timeout=3000")
+        except sqlite3.Error:
+            pass
+        conn.isolation_level = None  # manual transaction control
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                f"SELECT manifest_json FROM {_INTENT_TABLE} WHERE intent_id=?",
+                (intent_id,),
+            ).fetchone()
+            manifest = deserialize_manifest(row[0] if row else None)
+            if manifest is None:
+                conn.execute("ROLLBACK")
+                return False
+            pending = manifest.get("pending_chunks", []) or []
+            completed = manifest.get("completed_chunks", []) or []
+            already = {str(c.get("chunk_id")) for c in completed if isinstance(c, dict)}
+            if str(chunk_id) in already:
+                conn.execute("ROLLBACK")   # idempotent no-op — already durable
+                return True
+            found = None
+            remaining = []
+            for c in pending:
+                if isinstance(c, dict) and str(c.get("chunk_id")) == str(chunk_id):
+                    found = c
+                else:
+                    remaining.append(c)
+            if found is None:
+                conn.execute("ROLLBACK")   # unknown hash — nothing moved
+                return False
+            entry = dict(found)
+            entry["completed_ts"] = when
+            entry["result"] = str(result)[:200]
+            manifest["pending_chunks"] = remaining
+            manifest["completed_chunks"] = list(completed) + [entry]
+            conn.execute(
+                f"UPDATE {_INTENT_TABLE} SET manifest_json=? WHERE intent_id=?",
+                (serialize_manifest(manifest), intent_id),
+            )
+            conn.execute("COMMIT")
+            return True
+        except Exception:  # noqa: BLE001
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+    except sqlite3.Error:
+        logger.debug("[Checkpoint] mark_chunk_complete failed", exc_info=True)
+        return False
+    finally:
+        try:
+            conn.isolation_level = prev_isolation
+        except Exception:  # noqa: BLE001
+            pass
+
+
+def read_manifest(
+    conn: Optional[sqlite3.Connection], intent_id: str,
+) -> Optional[dict]:
+    """Parse the current manifest for an intent row (or ``None``). Never raises."""
+    return deserialize_manifest(get_manifest_json(conn, intent_id))
+
+
+# ---------------------------------------------------------------------------
+# Checkpointed execution wrapper — the resume-aware map-reduce driver
+# ---------------------------------------------------------------------------
+
+
+# swarm_fn(chunk: dict) -> Awaitable[Any] — process ONE chunk (invoke the swarm on
+# that file/symbol). Raising means "not done" → the chunk stays pending.
+SwarmFn = Callable[[dict], Awaitable[Any]]
+
+
+@dataclass
+class CheckpointRunSummary:
+    intent_id: str
+    processed: List[str] = field(default_factory=list)   # chunk_ids done THIS run
+    skipped: List[str] = field(default_factory=list)     # already-completed on entry
+    failed: List[str] = field(default_factory=list)      # raised this run (stay pending)
+
+
+async def run_checkpointed(
+    conn: Optional[sqlite3.Connection],
+    intent_id: str,
+    swarm_fn: SwarmFn,
+) -> CheckpointRunSummary:
+    """Resume-aware execution: read the manifest, process ONLY the not-yet-done
+    chunks (:func:`resume_pending`), and atomically commit each the instant its
+    ``swarm_fn`` completes. A crash mid-run leaves every already-committed chunk
+    durable; the next arm resumes from exactly here. The map-reduce driver that
+    makes the Swarm functionally immortal. Never raises out."""
+    summary = CheckpointRunSummary(intent_id=intent_id)
+    manifest = read_manifest(conn, intent_id)
+    if manifest is None:
+        return summary
+    summary.skipped = sorted(completed_ids(manifest))
+    for chunk in resume_pending(manifest):
+        cid = str(chunk.get("chunk_id"))
+        try:
+            result = await swarm_fn(chunk)
+        except Exception as exc:  # noqa: BLE001 — an isolated chunk failure stays pending
+            logger.debug("[Checkpoint] chunk %s failed: %s", cid, exc)
+            summary.failed.append(cid)
+            continue
+        if mark_chunk_complete(conn, intent_id, cid, result=str(result) if result is not None else ""):
+            summary.processed.append(cid)
+        else:
+            summary.failed.append(cid)
+    return summary
+
+
+def build_checkpointed_swarm_fn(
+    *,
+    client: Any,
+    repo_root: str = ".",
+    op_id_prefix: str = "soak",
+) -> SwarmFn:
+    """Bind a manifest chunk → the REAL big-file swarm egress
+    (``intercept_full_content``, the same entry the generation hot path uses),
+    constructing the ``ProductionAgentTurnFn`` identically. This is the DRY seam
+    ``run_checkpointed`` drives per chunk — no cloned swarm logic. A chunk's
+    ``file_path`` + ``symbol`` become the swarm's target file + symbol."""
+
+    async def _swarm_fn(chunk: dict) -> Any:
+        from backend.core.ouroboros.governance.full_content_interceptor import (
+            intercept_full_content,
+        )
+        from backend.core.ouroboros.governance.agent_turn_adapter import (
+            ProductionAgentTurnFn,
+        )
+        file_path = str(chunk.get("file_path", ""))
+        symbol = str(chunk.get("symbol", ""))
+        op_id = f"{op_id_prefix}-{chunk.get('chunk_id', '')}"
+        try:
+            with open(os.path.join(repo_root, file_path), "r",
+                      encoding="utf-8", errors="replace") as fh:
+                source = fh.read()
+        except OSError:
+            source = ""
+        agent = ProductionAgentTurnFn(
+            client=client, tool_backend=None, repo_root=repo_root, op_id=op_id,
+            model_name=getattr(client, "_model", "") or "", system_prompt="",
+            parse_fn=lambda raw: None, max_turns=1,
+        )
+        return await intercept_full_content(
+            source, file_path, [symbol] if symbol and symbol != "<module>" else [],
+            agent, op_id=op_id,
+        )
+
+    return _swarm_fn
+
+
+async def run_pending_soak(
+    conn: Optional[sqlite3.Connection],
+    intent_id: str,
+    *,
+    client: Any,
+    repo_root: str = ".",
+) -> CheckpointRunSummary:
+    """Convenience: resume-run a pending intent's manifest against the REAL swarm.
+    The concrete, checkpoint-aware soak launch an AWE ``launch_fn`` / soak driver
+    invokes — every chunk commits atomically, so it is crash-resumable. Never
+    raises out."""
+    swarm_fn = build_checkpointed_swarm_fn(client=client, repo_root=repo_root)
+    return await run_checkpointed(conn, intent_id, swarm_fn)
+
+
+__all__ = [
+    "MANIFEST_SCHEMA_VERSION",
+    "ChunkDescriptor",
+    "CheckpointRunSummary",
+    "build_checkpointed_swarm_fn",
+    "run_pending_soak",
+    "build_manifest",
+    "chunk_id_for",
+    "completed_ids",
+    "deserialize_manifest",
+    "enqueue_soak_manifest",
+    "mark_chunk_complete",
+    "read_manifest",
+    "resume_pending",
+    "run_checkpointed",
+    "serialize_manifest",
+    "walk_target",
+]

--- a/backend/core/ouroboros/governance/enqueue_soak_repl.py
+++ b/backend/core/ouroboros/governance/enqueue_soak_repl.py
@@ -1,0 +1,132 @@
+"""``/enqueue_soak <target_path>`` — stage a crash-immortal Swarm soak.
+
+Expresses workload INTENT to the Autonomous Supervisor: async-walks the target,
+hashes its AST chunks into a deterministic checkpoint manifest, and writes it as
+a pending row in the ``soak_intent_queue`` (#70050). The Supervisor then arms
+itself the moment DW is DEGRADED, and the Swarm resumes from the manifest across
+any crash (#70051).
+
+Naming-cage: auto-discovered as verb ``enqueue_soak`` via the module-level
+``dispatch_enqueue_soak_command``. Imports stdlib + the checkpoint/intent data
+helpers ONLY — no orchestrator / providers / iron_gate authority. Never raises.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shlex
+from dataclasses import dataclass
+
+logger = logging.getLogger("Ouroboros.EnqueueSoakRepl")
+
+_RESET = "\033[0m"
+_BOLD = "\033[1m"
+_DIM = "\033[2m"
+_CYAN = "\033[36m"
+_GREEN = "\033[32m"
+_RED = "\033[31m"
+
+_HELP = (
+    f"  {_BOLD}{_CYAN}/enqueue_soak <target_path>{_RESET}\n"
+    f"  {_DIM}Stage a crash-immortal Swarm soak. Walks the target, hashes its AST "
+    f"chunks into a\n  deterministic checkpoint manifest, and queues it as pending "
+    f"intent. The Autonomous\n  Supervisor auto-arms on DW recovery; the Swarm "
+    f"resumes from the manifest across crashes.{_RESET}\n\n"
+    f"  {_BOLD}Options:{_RESET}\n"
+    f"    {_CYAN}--priority N{_RESET}   {_DIM}queue priority (lower = more urgent; default 1){_RESET}\n"
+    f"    {_CYAN}--kind K{_RESET}       {_DIM}intent kind label (default agentic_swarm_soak){_RESET}\n"
+)
+
+
+@dataclass(frozen=True)
+class EnqueueSoakDispatchResult:
+    ok: bool
+    text: str
+    matched: bool = True
+
+
+def _matches(line: str) -> bool:
+    s = (line or "").strip()
+    return s == "enqueue_soak" or s == "/enqueue_soak" or \
+        s.startswith("enqueue_soak ") or s.startswith("/enqueue_soak ")
+
+
+async def dispatch_enqueue_soak_command(line: str) -> EnqueueSoakDispatchResult:
+    """Async — walks the target off the event loop, writes the manifest row."""
+    if not _matches(line):
+        return EnqueueSoakDispatchResult(ok=False, text="", matched=False)
+    try:
+        raw = (line or "").strip().lstrip("/")
+        argv = shlex.split(raw)[1:]  # drop the verb token
+    except ValueError as exc:
+        return EnqueueSoakDispatchResult(ok=False, text=f"  /enqueue_soak parse error: {exc}")
+
+    if not argv or argv[0] in ("help", "-h", "--help"):
+        return EnqueueSoakDispatchResult(ok=True, text=_HELP)
+
+    # Parse: <target_path> [--priority N] [--kind K]
+    target = ""
+    priority = 1
+    kind = "agentic_swarm_soak"
+    i = 0
+    while i < len(argv):
+        tok = argv[i]
+        if tok == "--priority" and i + 1 < len(argv):
+            try:
+                priority = int(argv[i + 1])
+            except ValueError:
+                return EnqueueSoakDispatchResult(ok=False, text=f"  {_RED}--priority must be an integer{_RESET}")
+            i += 2
+        elif tok == "--kind" and i + 1 < len(argv):
+            kind = argv[i + 1]
+            i += 2
+        elif not target and not tok.startswith("--"):
+            target = tok
+            i += 1
+        else:
+            i += 1
+
+    if not target:
+        return EnqueueSoakDispatchResult(ok=False, text=f"  {_RED}usage: /enqueue_soak <target_path>{_RESET}")
+    abs_target = os.path.abspath(os.path.expanduser(target))
+    if not os.path.exists(abs_target):
+        return EnqueueSoakDispatchResult(ok=False, text=f"  {_RED}no such path: {abs_target}{_RESET}")
+
+    try:
+        from backend.core.ouroboros.governance.dw_outage_forecaster import open_forecast_db
+        from backend.core.ouroboros.governance.checkpoint_manifest import enqueue_soak_manifest
+    except Exception as exc:  # noqa: BLE001
+        return EnqueueSoakDispatchResult(ok=False, text=f"  /enqueue_soak unavailable: {exc}")
+
+    conn = open_forecast_db()
+    try:
+        res = await enqueue_soak_manifest(conn, abs_target, kind=kind, priority=priority)
+    finally:
+        try:
+            if conn is not None:
+                conn.close()
+        except Exception:  # noqa: BLE001
+            pass
+
+    if not res:
+        return EnqueueSoakDispatchResult(ok=False, text=f"  {_RED}enqueue failed (no writable substrate?){_RESET}")
+
+    n = res["chunk_count"]
+    iid = res["intent_id"]
+    manifest = res.get("manifest", {})
+    files = sorted({c.get("file_path", "?") for c in manifest.get("pending_chunks", [])})
+    file_line = (
+        f"{len(files)} file(s)" if len(files) != 1 else f"{files[0]}"
+    )
+    text = (
+        f"  {_GREEN}⚡ soak intent queued{_RESET}  {_BOLD}{iid}{_RESET}  "
+        f"{_DIM}({n} AST chunk(s) across {file_line}, priority {priority}){_RESET}\n"
+        f"  {_DIM}manifest written — the Supervisor arms on DW recovery; the Swarm "
+        f"resumes from checkpoint across any crash.{_RESET}"
+    )
+    logger.info("[EnqueueSoak] queued intent=%s chunks=%d target=%s", iid, n, abs_target)
+    return EnqueueSoakDispatchResult(ok=True, text=text)
+
+
+__all__ = ["EnqueueSoakDispatchResult", "dispatch_enqueue_soak_command"]

--- a/backend/core/ouroboros/governance/soak_intent.py
+++ b/backend/core/ouroboros/governance/soak_intent.py
@@ -32,7 +32,11 @@ STATUS_CLEARED = "cleared"
 
 
 def ensure_intent_table(conn: sqlite3.Connection) -> None:
-    """Idempotent DDL. Composes the #70021 DB (same file, distinct table)."""
+    """Idempotent DDL. Composes the #70021 DB (same file, distinct table).
+
+    ``manifest_json`` holds the AST-aware checkpoint manifest (the deterministic
+    per-chunk progress ledger — #70051). Added via additive migration so a DB
+    created before the checkpoint engine upgrades in place, never re-created."""
     conn.execute(
         f"CREATE TABLE IF NOT EXISTS {_INTENT_TABLE} ("
         "intent_id TEXT PRIMARY KEY, "
@@ -41,8 +45,17 @@ def ensure_intent_table(conn: sqlite3.Connection) -> None:
         "priority INTEGER NOT NULL DEFAULT 5, "
         "status TEXT NOT NULL DEFAULT 'pending', "
         "enqueued_ts REAL, "
-        "cleared_ts REAL)"
+        "cleared_ts REAL, "
+        "manifest_json TEXT)"
     )
+    # Additive migration: a table created before manifest_json existed gets the
+    # column now (PRAGMA-guarded so it runs at most once). Never raises.
+    try:
+        cols = {r[1] for r in conn.execute(f"PRAGMA table_info({_INTENT_TABLE})").fetchall()}
+        if "manifest_json" not in cols:
+            conn.execute(f"ALTER TABLE {_INTENT_TABLE} ADD COLUMN manifest_json TEXT")
+    except sqlite3.Error:
+        logger.debug("[SoakIntent] manifest_json migration skipped", exc_info=True)
     conn.commit()
 
 
@@ -53,10 +66,12 @@ def enqueue_soak_intent(
     target: str = "",
     priority: int = 1,
     intent_id: Optional[str] = None,
+    manifest_json: Optional[str] = None,
     now: Optional[float] = None,
 ) -> Optional[str]:
-    """Record a pending high-priority soak workload. Returns the intent_id, or
-    ``None`` on failure. Never raises."""
+    """Record a pending high-priority soak workload. ``manifest_json`` carries the
+    AST-aware checkpoint manifest (deterministic per-chunk progress). Returns the
+    intent_id, or ``None`` on failure. Never raises."""
     if conn is None:
         return None
     iid = intent_id or uuid.uuid4().hex[:12]
@@ -65,14 +80,31 @@ def enqueue_soak_intent(
         ensure_intent_table(conn)
         conn.execute(
             f"INSERT OR IGNORE INTO {_INTENT_TABLE} "
-            f"(intent_id, kind, target, priority, status, enqueued_ts) "
-            f"VALUES (?, ?, ?, ?, '{STATUS_PENDING}', ?)",
-            (iid, kind, target, int(priority), when),
+            f"(intent_id, kind, target, priority, status, enqueued_ts, manifest_json) "
+            f"VALUES (?, ?, ?, ?, '{STATUS_PENDING}', ?, ?)",
+            (iid, kind, target, int(priority), when, manifest_json),
         )
         conn.commit()
         return iid
     except sqlite3.Error:
         logger.debug("[SoakIntent] enqueue failed", exc_info=True)
+        return None
+
+
+def get_manifest_json(
+    conn: Optional[sqlite3.Connection], intent_id: str,
+) -> Optional[str]:
+    """Read the raw manifest JSON for an intent row (or ``None``). Never raises."""
+    if conn is None:
+        return None
+    try:
+        ensure_intent_table(conn)
+        row = conn.execute(
+            f"SELECT manifest_json FROM {_INTENT_TABLE} WHERE intent_id=?",
+            (intent_id,),
+        ).fetchone()
+        return row[0] if row and row[0] else None
+    except sqlite3.Error:
         return None
 
 
@@ -145,5 +177,6 @@ __all__ = [
     "clear_soak_intent",
     "enqueue_soak_intent",
     "ensure_intent_table",
+    "get_manifest_json",
     "pending_soak_count",
 ]

--- a/tests/governance/test_checkpoint_manifest.py
+++ b/tests/governance/test_checkpoint_manifest.py
@@ -1,0 +1,221 @@
+"""Bulletproof spine for the AST-Aware Checkpoint Intent Engine.
+
+Mandated assertions, all against the REAL substrate (real SQLite soak_intent_queue
+on a temp file, real AST walk of real files on disk):
+
+  (1) ``/enqueue_soak`` generates the correct JSON manifest of pending chunks,
+  (2) simulating the Swarm completing one file correctly moves its hash to the
+      ``completed_chunks`` array in SQLite, and
+  (3) forcefully restarting the mock Swarm bypasses the completed hash and
+      processes ONLY the remaining pending tasks — with no duplication.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+
+import pytest
+
+from backend.core.ouroboros.governance.checkpoint_manifest import (
+    build_manifest,
+    completed_ids,
+    enqueue_soak_manifest,
+    mark_chunk_complete,
+    read_manifest,
+    resume_pending,
+    run_checkpointed,
+    serialize_manifest,
+    walk_target,
+)
+from backend.core.ouroboros.governance.enqueue_soak_repl import (
+    dispatch_enqueue_soak_command,
+)
+from backend.core.ouroboros.governance.soak_intent import get_manifest_json
+
+
+@pytest.fixture
+def project(tmp_path):
+    """A tiny multi-file target with known top-level AST symbols."""
+    d = tmp_path / "proj"
+    d.mkdir()
+    (d / "alpha.py").write_text(
+        "def a_one():\n    return 1\n\n\ndef a_two():\n    return 2\n"
+    )
+    (d / "beta.py").write_text(
+        "class B:\n    def m(self):\n        return 3\n"
+    )
+    return str(d)
+
+
+@pytest.fixture
+def db_path(tmp_path):
+    return str(tmp_path / "chunk_strategy.db")
+
+
+# ---------------------------------------------------------------------------
+# (1) manifest generation
+# ---------------------------------------------------------------------------
+
+
+async def test_enqueue_generates_correct_manifest(project, db_path):
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    conn.close()
+
+    assert res is not None
+    # 3 top-level symbols: a_one, a_two (alpha.py) + B (beta.py).
+    assert res["chunk_count"] == 3
+    manifest = res["manifest"]
+    assert manifest["schema_version"] == 1
+    assert len(manifest["pending_chunks"]) == 3
+    assert manifest["completed_chunks"] == []
+    symbols = sorted(c["symbol"] for c in manifest["pending_chunks"])
+    assert symbols == ["B", "a_one", "a_two"]
+    # Every chunk carries a deterministic hash + line range.
+    for c in manifest["pending_chunks"]:
+        assert c["chunk_id"] and c["file_path"].endswith(".py")
+        assert c["start_line"] >= 1 and c["end_line"] >= c["start_line"]
+
+    # The manifest was written verbatim into the intent row (JSON, parseable).
+    conn = sqlite3.connect(db_path)
+    raw = get_manifest_json(conn, res["intent_id"])
+    conn.close()
+    assert raw is not None
+    assert json.loads(raw)["schema_version"] == 1
+
+
+async def test_manifest_serialization_is_deterministic(project):
+    chunks = await walk_target(project)
+    m1 = build_manifest(project, chunks, now=1000.0)
+    m2 = build_manifest(project, chunks, now=1000.0)
+    assert serialize_manifest(m1) == serialize_manifest(m2)
+
+
+async def test_enqueue_soak_verb_writes_manifest(project, db_path, monkeypatch):
+    """The /enqueue_soak REPL verb (naming-cage) walks + writes the manifest."""
+    monkeypatch.setattr(
+        "backend.core.ouroboros.governance.dw_outage_forecaster.open_forecast_db",
+        lambda path=None: sqlite3.connect(db_path),
+    )
+    out = await dispatch_enqueue_soak_command(f"/enqueue_soak {project}")
+    assert out.ok and out.matched
+    assert "soak intent queued" in out.text
+    # It really landed a pending manifest row.
+    conn = sqlite3.connect(db_path)
+    rows = conn.execute(
+        "SELECT manifest_json FROM soak_intent_queue WHERE status='pending'"
+    ).fetchall()
+    conn.close()
+    assert len(rows) == 1
+    assert json.loads(rows[0][0])["chunk_count" if False else "schema_version"] == 1
+
+
+# ---------------------------------------------------------------------------
+# (2) atomic per-chunk commit
+# ---------------------------------------------------------------------------
+
+
+async def test_commit_moves_hash_to_completed(project, db_path):
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+    first = res["manifest"]["pending_chunks"][0]["chunk_id"]
+
+    ok = mark_chunk_complete(conn, iid, first, result="stitched")
+    assert ok is True
+
+    manifest = read_manifest(conn, iid)
+    conn.close()
+    assert first in completed_ids(manifest)
+    assert first not in {c["chunk_id"] for c in manifest["pending_chunks"]}
+    assert len(manifest["completed_chunks"]) == 1
+    assert manifest["completed_chunks"][0]["result"] == "stitched"
+
+
+async def test_commit_is_idempotent(project, db_path):
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+    cid = res["manifest"]["pending_chunks"][0]["chunk_id"]
+
+    assert mark_chunk_complete(conn, iid, cid) is True
+    # Re-committing the same hash is a durable no-op success, not a duplicate.
+    assert mark_chunk_complete(conn, iid, cid) is True
+    manifest = read_manifest(conn, iid)
+    conn.close()
+    assert len(manifest["completed_chunks"]) == 1  # no duplication
+    # An unknown hash is rejected.
+    conn = sqlite3.connect(db_path)
+    assert mark_chunk_complete(conn, iid, "deadbeefdeadbeef") is False
+    conn.close()
+
+
+# ---------------------------------------------------------------------------
+# (3) resume-from-hash — crash then restart, no duplication
+# ---------------------------------------------------------------------------
+
+
+async def test_restart_resumes_without_duplication(project, db_path):
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+    conn.close()
+
+    processed_run1: list = []
+
+    async def swarm_run1(chunk):
+        processed_run1.append(chunk["chunk_id"])
+        # Simulate a CRASH after the first file: raise so the runner stops
+        # committing further, but the first commit is already durable.
+        if len(processed_run1) == 1:
+            return "ok"           # first commits
+        raise RuntimeError("simulated power loss")
+
+    conn = sqlite3.connect(db_path)
+    s1 = await run_checkpointed(conn, iid, swarm_run1)
+    conn.close()
+    # First chunk committed; the rest failed (stay pending).
+    assert len(s1.processed) == 1
+    assert len(s1.failed) >= 1
+    committed_after_crash = set(s1.processed)
+
+    # --- FORCEFUL RESTART: a fresh runner over the SAME intent row ---
+    processed_run2: list = []
+
+    async def swarm_run2(chunk):
+        processed_run2.append(chunk["chunk_id"])
+        return "ok"
+
+    conn = sqlite3.connect(db_path)
+    manifest_before = read_manifest(conn, iid)
+    s2 = await run_checkpointed(conn, iid, swarm_run2)
+    manifest_after = read_manifest(conn, iid)
+    conn.close()
+
+    # The already-completed hash is STRUCTURALLY bypassed — never reprocessed.
+    for cid in committed_after_crash:
+        assert cid not in processed_run2, "completed hash must not be reprocessed"
+    # Run 2 processed exactly the remainder (3 total − 1 already done = 2).
+    assert len(processed_run2) == 2
+    assert set(s2.skipped) == committed_after_crash
+    # Every chunk is now completed exactly once — no duplication anywhere.
+    all_completed = [c["chunk_id"] for c in manifest_after["completed_chunks"]]
+    assert len(all_completed) == 3
+    assert len(set(all_completed)) == 3
+    assert manifest_after["pending_chunks"] == []
+    # Sanity: the pre-restart manifest already had the crash-survivor durable.
+    assert committed_after_crash.issubset(completed_ids(manifest_before))
+
+
+async def test_resume_pending_skips_completed(project, db_path):
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+    ids = [c["chunk_id"] for c in res["manifest"]["pending_chunks"]]
+    mark_chunk_complete(conn, iid, ids[0])
+    manifest = read_manifest(conn, iid)
+    conn.close()
+    remaining = {c["chunk_id"] for c in resume_pending(manifest)}
+    assert ids[0] not in remaining
+    assert remaining == set(ids[1:])


### PR DESCRIPTION
## Securing Mid-Flight Catastrophic State Loss

A hard crash at file #400 of a 500-file map-reduce restarted the Swarm from **file #1** — massive compute + token waste. Root cause: a **stateless (generic-string) intent**. The fix is a deterministic, serialized JSON checkpoint manifest tracking granular chunk-level completion, mutated **in place** inside the existing `soak_intent_queue` row (no new DB).

## Four mandates

**1 · Root-cause** — the intent payload is a deterministic serialized JSON manifest (`pending_chunks[]` + `completed_chunks[]`), not a generic string.

**2 · Purity**
- **`/enqueue_soak <target_path>`** async-walks the target, AST-extracts top-level def/class chunks, hashes each to a stable `chunk_id = sha256(rel_path:symbol:content_sha)[:16]`, and writes the manifest. A changed file gets a new hash → correctly re-processed on resume.
- **Atomic chunk commit** — `mark_chunk_complete()` moves a hash pending→completed under a `BEGIN IMMEDIATE` read-modify-write (SQLite's write lock serializes concurrent committers; `busy_timeout` makes cross-process contenders wait). Idempotent; unknown hash rejected.
- **Resume-from-hash** — `run_checkpointed()` reads the manifest and processes **only** `resume_pending()` (every chunk whose hash isn't already completed). A restarted Swarm structurally bypasses completed hashes — only the remainder, never a duplicate.

**3 · DRY** — mutates the existing `soak_intent_queue` row's new `manifest_json` column (additive PRAGMA-guarded migration); reuses `chunk_strategy.db`; the swarm binding drives the **real** `intercept_full_content` egress per chunk (never forks the swarm); `/enqueue_soak` rides the unified verb registry (naming-cage `dispatch_enqueue_soak_command`).

**4 · Bulletproof** — `test_checkpoint_manifest.py` on **real** SQLite + a real on-disk multi-file target: (1) manifest generated correctly (3 AST symbols across 2 files), (2) completing one chunk moves its hash to `completed_chunks` in SQLite, (3) a **forceful restart** bypasses the completed hash and processes only the 2 remaining tasks — **every chunk completed exactly once, zero duplication**. Plus determinism / idempotency / unknown-hash-rejection. **7 green; 24 governance regressions green.**

## The immortality chain
`/enqueue_soak <dir>` → manifest of N pending AST chunks → Supervisor arms on DW recovery → `run_checkpointed` drives the swarm per chunk, committing each atomically → crash at chunk K → next arm resumes at chunk K+1. No lost work, no re-billed tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an AST-aware checkpoint manifest for Swarm soaks to enable crash-safe, per-chunk resume and prevent duplicate work. Also adds an `/enqueue_soak` command and stores progress in-place on the intent row.

- **New Features**
  - Deterministic manifest (`pending_chunks`/`completed_chunks`) with stable `chunk_id = sha256(rel_path:symbol:content_sha)[:16]`.
  - Atomic per-chunk commit via `mark_chunk_complete()` using SQLite `BEGIN IMMEDIATE`; idempotent; rejects unknown hashes.
  - Resume driver `run_checkpointed()` processes only remaining chunks; bindings `build_checkpointed_swarm_fn()`/`run_pending_soak()` invoke the real swarm.
  - `/enqueue_soak <path>` builds and queues a manifest asynchronously and writes it to `soak_intent_queue`.
  - Tests cover manifest generation, commit, and crash-resume with zero duplication.

- **Migration**
  - Adds `manifest_json` column to `soak_intent_queue` via additive, PRAGMA-guarded migration.
  - No manual steps required; existing DBs upgrade in place.

<sup>Written for commit 6b061366799263d89327c69d83f1bedac80fda95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70051?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

