### PR TITLE
Checkpoint map-reduce progress → live TUI breadcrumbs

### DIFF
--- a/backend/core/ouroboros/governance/checkpoint_manifest.py
+++ b/backend/core/ouroboros/governance/checkpoint_manifest.py
@@ -56,6 +56,20 @@ logger = logging.getLogger("Ouroboros.CheckpointManifest")
 MANIFEST_SCHEMA_VERSION = 1
 _INTENT_TABLE = "soak_intent_queue"
 
+
+def _emit_event(event_type: str, payload: dict) -> None:
+    """Surface checkpoint progress on the broker so the operator watches the
+    map-reduce tick live in ``/breadcrumbs`` (the Swarm's immortality made
+    VISIBLE, not just durable in SQLite). Best-effort; never raises."""
+    try:
+        from backend.core.ouroboros.governance.ide_observability_stream import (
+            publish_task_event,
+        )
+        op_id = str(payload.get("intent_id", "soak")) or "soak"
+        publish_task_event(event_type, op_id, dict(payload))
+    except Exception:  # noqa: BLE001
+        pass
+
 _DEFAULT_EXTS = (".py",)
 
 
@@ -234,6 +248,9 @@ async def enqueue_soak_manifest(
     )
     if iid is None:
         return None
+    _emit_event("soak_manifest_enqueued", {
+        "intent_id": iid, "target": target, "chunk_count": len(chunks), "kind": kind,
+    })
     return {"intent_id": iid, "manifest": manifest, "chunk_count": len(chunks)}
 
 
@@ -360,7 +377,15 @@ async def run_checkpointed(
     if manifest is None:
         return summary
     summary.skipped = sorted(completed_ids(manifest))
-    for chunk in resume_pending(manifest):
+    pending = resume_pending(manifest)
+    total = len(summary.skipped) + len(pending)
+    done = len(summary.skipped)
+    # Resume breadcrumb — the operator sees exactly where the crash left off.
+    _emit_event("soak_resumed", {
+        "intent_id": intent_id, "total": total,
+        "done": done, "remaining": len(pending),
+    })
+    for chunk in pending:
         cid = str(chunk.get("chunk_id"))
         try:
             result = await swarm_fn(chunk)
@@ -370,8 +395,19 @@ async def run_checkpointed(
             continue
         if mark_chunk_complete(conn, intent_id, cid, result=str(result) if result is not None else ""):
             summary.processed.append(cid)
+            done += 1
+            # Per-chunk tick — the map-reduce progress made visible live.
+            _emit_event("soak_chunk_committed", {
+                "intent_id": intent_id, "chunk_id": cid,
+                "symbol": chunk.get("symbol", "?"), "file_path": chunk.get("file_path", "?"),
+                "done": done, "total": total,
+            })
         else:
             summary.failed.append(cid)
+    _emit_event("soak_run_complete", {
+        "intent_id": intent_id, "processed": len(summary.processed),
+        "failed": len(summary.failed), "skipped": len(summary.skipped), "total": total,
+    })
     return summary
 
 

--- a/backend/core/ouroboros/governance/event_breadcrumb_registry.py
+++ b/backend/core/ouroboros/governance/event_breadcrumb_registry.py
@@ -279,6 +279,19 @@ def build_default_registry() -> EventBreadcrumbRegistry:
                                        f"backoff {p.get('backoff_s','?')}s): {p.get('reason','')}", "supervisor"),
         BreadcrumbDescriptor("sentinel_telemetry", "·", "bright_black", SEV_VERBOSE,
                              lambda p: str(p.get("line", "")).strip(), "supervisor"),
+        BreadcrumbDescriptor("soak_manifest_enqueued", "⚑", "cyan bold", SEV_IMPORTANT,
+                             lambda p: f"soak queued {str(p.get('intent_id',''))[:12]} — "
+                                       f"{p.get('chunk_count','?')} chunks", "soak"),
+        BreadcrumbDescriptor("soak_resumed", "↻", "cyan", SEV_IMPORTANT,
+                             lambda p: f"resume {str(p.get('intent_id',''))[:12]} — "
+                                       f"{p.get('done','?')}/{p.get('total','?')} done, "
+                                       f"{p.get('remaining','?')} to go", "soak"),
+        BreadcrumbDescriptor("soak_chunk_committed", "◈", "green", SEV_INFO,
+                             lambda p: f"chunk {p.get('done','?')}/{p.get('total','?')} "
+                                       f"✓ {p.get('symbol','?')} ({p.get('file_path','?')})", "soak"),
+        BreadcrumbDescriptor("soak_run_complete", "✓", "green bold", SEV_IMPORTANT,
+                             lambda p: f"soak run done — {p.get('processed','?')} committed, "
+                                       f"{p.get('failed','?')} failed, {p.get('skipped','?')} pre-done", "soak"),
     ]
     for d in seed:
         reg.register(d)

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -183,6 +183,14 @@ EVENT_TYPE_SUPERVISOR_ARMED = "supervisor_armed"
 EVENT_TYPE_SUPERVISOR_DISARMED = "supervisor_disarmed"
 EVENT_TYPE_SENTINEL_RESTARTED = "sentinel_restarted"
 EVENT_TYPE_SENTINEL_TELEMETRY = "sentinel_telemetry"
+# Checkpoint Intent Engine — the granular map-reduce progress the operator watches
+# live (like watching Claude work): a manifest queued, a crash-resume, each atomic
+# per-chunk commit ticking done/total, and the run terminal. Makes the Swarm's
+# functional immortality VISIBLE in /breadcrumbs, not just durable in SQLite.
+EVENT_TYPE_SOAK_MANIFEST_ENQUEUED = "soak_manifest_enqueued"
+EVENT_TYPE_SOAK_RESUMED = "soak_resumed"
+EVENT_TYPE_SOAK_CHUNK_COMMITTED = "soak_chunk_committed"
+EVENT_TYPE_SOAK_RUN_COMPLETE = "soak_run_complete"
 
 # Slice 19 (Soak Budget & Compute Circuit-Breaker) — two events covering the
 # fail-closed boundary around an unattended graduation soak:
@@ -1674,6 +1682,10 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_SUPERVISOR_DISARMED,             # Autonomous Supervisor (2026-07-23 -- queue-clear disarm)
     EVENT_TYPE_SENTINEL_RESTARTED,              # Autonomous Supervisor (2026-07-23 -- watchdog self-heal restart)
     EVENT_TYPE_SENTINEL_TELEMETRY,              # Autonomous Supervisor (2026-07-23 -- piped Sentinel stdout line)
+    EVENT_TYPE_SOAK_MANIFEST_ENQUEUED,          # Checkpoint Engine (2026-07-23 -- /enqueue_soak wrote a manifest)
+    EVENT_TYPE_SOAK_RESUMED,                    # Checkpoint Engine (2026-07-23 -- resume-from-hash, N already done)
+    EVENT_TYPE_SOAK_CHUNK_COMMITTED,            # Checkpoint Engine (2026-07-23 -- atomic per-chunk commit, done/total)
+    EVENT_TYPE_SOAK_RUN_COMPLETE,               # Checkpoint Engine (2026-07-23 -- map-reduce run terminal)
 })
 
 

--- a/tests/governance/test_checkpoint_manifest.py
+++ b/tests/governance/test_checkpoint_manifest.py
@@ -208,6 +208,47 @@ async def test_restart_resumes_without_duplication(project, db_path):
     assert committed_after_crash.issubset(completed_ids(manifest_before))
 
 
+async def test_checkpoint_progress_surfaces_on_broker(project, db_path):
+    """The map-reduce immortality is VISIBLE: enqueue + run emit the progress
+    events (manifest / resume / per-chunk / run-complete) onto the real broker,
+    so the operator watches it tick live in /breadcrumbs."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        get_default_broker,
+        reset_default_broker,
+    )
+
+    reset_default_broker()
+    broker = get_default_broker()
+    sub = broker.subscribe()
+    seen: list = []
+
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+
+    async def swarm(chunk):
+        return "ok"
+
+    await run_checkpointed(conn, iid, swarm)
+    conn.close()
+
+    # Drain what the broker queued (subscribe() captured from enqueue onward).
+    for _ in range(200):
+        ev = None
+        try:
+            ev = sub.queue.get_nowait()
+        except Exception:  # noqa: BLE001 — empty
+            break
+        seen.append(getattr(ev, "event_type", ""))
+    broker.unsubscribe(sub)
+    reset_default_broker()
+
+    assert "soak_manifest_enqueued" in seen
+    assert "soak_resumed" in seen
+    assert seen.count("soak_chunk_committed") == 3   # one tick per chunk
+    assert "soak_run_complete" in seen
+
+
 async def test_resume_pending_skips_completed(project, db_path):
     conn = sqlite3.connect(db_path)
     res = await enqueue_soak_manifest(conn, project, priority=1)


### PR DESCRIPTION
## The one CLI/TUI reflection gap — closed before we unleash

The AWE + Supervisor + Sentinel lifecycle already surface in `/breadcrumbs`. But the Checkpoint Engine (#70051) mutated the manifest **silently** in SQLite — you couldn't watch the map-reduce tick the way you watch Claude work. This closes that.

Four event types (`soak_manifest_enqueued` / `soak_resumed` / `soak_chunk_committed` / `soak_run_complete`) added to `_VALID_EVENT_TYPES` + the descriptor registry, emitted from the engine:
- **enqueue** → `⚑ soak queued abc123 — 500 chunks`
- **resume** → `↻ resume abc123 — 312/500 done, 188 to go` (you see exactly where a crash left off)
- **each atomic commit** → `◈ chunk 313/500 ✓ _topo_sort (saga.py)`
- **terminal** → `✓ soak run done — 188 committed, 0 failed, 312 pre-done`

They flow through the unified event router (#70045) — non-bespoke, zero TUI code. Best-effort publish, never in the commit's critical section.

**Bulletproof:** `test_checkpoint_progress_surfaces_on_broker` subscribes to the **real** broker and asserts the run emits manifest / resume / exactly-3-chunk-ticks / complete. **25 governance tests green.**

Now everything we built in the O+V backend is reflected in the `ov` CLI/TUI in real-time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds live checkpoint map-reduce progress to the CLI/TUI by emitting and routing four new events from the Checkpoint Engine. You can now see enqueue, resume, per‑chunk commits, and run completion in real time in `/breadcrumbs`.

- New Features
  - Added `soak_manifest_enqueued`, `soak_resumed`, `soak_chunk_committed`, `soak_run_complete`.
  - Published from `enqueue_soak_manifest` and `run_checkpointed`; best‑effort and outside critical sections.
  - Registered breadcrumb descriptors and added valid types in `ide_observability_stream` for readable TUI lines.
  - Added `test_checkpoint_progress_surfaces_on_broker` to assert manifest/resume/3 per‑chunk ticks/complete via the real broker.

<sup>Written for commit 5d13dc617f87faf0ca118876e81bdf2ca31c04af. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70052?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

