### PR TITLE
AST Dead-Letter Queue — 3-strike poison-chunk circuit breaker

### DIFF
--- a/backend/core/ouroboros/governance/checkpoint_manifest.py
+++ b/backend/core/ouroboros/governance/checkpoint_manifest.py
@@ -53,8 +53,22 @@ from backend.core.ouroboros.governance.soak_intent import (
 
 logger = logging.getLogger("Ouroboros.CheckpointManifest")
 
-MANIFEST_SCHEMA_VERSION = 1
+# Schema 2 adds the DLQ arrays (quarantined_chunks + chunk_retry_counts). Old
+# schema-1 manifests are read defensively (missing keys → empty), so a DB written
+# before the DLQ upgrades in place with no migration.
+MANIFEST_SCHEMA_VERSION = 2
 _INTENT_TABLE = "soak_intent_queue"
+
+_DEFAULT_MAX_STRIKES = 3
+
+
+def _max_strikes() -> int:
+    """3-strike DLQ threshold (env ``JARVIS_SOAK_CHUNK_MAX_STRIKES``). A chunk
+    that fails this many cumulative times is quarantined, not retried forever."""
+    try:
+        return max(1, int(os.environ.get("JARVIS_SOAK_CHUNK_MAX_STRIKES", _DEFAULT_MAX_STRIKES)))
+    except (TypeError, ValueError):
+        return _DEFAULT_MAX_STRIKES
 
 
 def _emit_event(event_type: str, payload: dict) -> None:
@@ -182,6 +196,8 @@ def build_manifest(target: str, chunks: List[ChunkDescriptor], *, now: Optional[
         "created_ts": time.time() if now is None else float(now),
         "pending_chunks": [asdict(c) for c in chunks],
         "completed_chunks": [],
+        "quarantined_chunks": [],       # DLQ — poison chunks that struck out
+        "chunk_retry_counts": {},       # chunk_id -> cumulative failure count
     }
 
 
@@ -201,24 +217,34 @@ def deserialize_manifest(raw: Optional[str]) -> Optional[dict]:
         return None
 
 
-def completed_ids(manifest: dict) -> set:
+def _ids_of(manifest: dict, key: str) -> set:
     return {
         str(c.get("chunk_id"))
-        for c in (manifest or {}).get("completed_chunks", []) or []
+        for c in (manifest or {}).get(key, []) or []
         if isinstance(c, dict) and c.get("chunk_id")
     }
 
 
+def completed_ids(manifest: dict) -> set:
+    return _ids_of(manifest, "completed_chunks")
+
+
+def quarantined_ids(manifest: dict) -> set:
+    """Poison chunks that struck out — the DLQ. Structurally skipped on resume."""
+    return _ids_of(manifest, "quarantined_chunks")
+
+
 def resume_pending(manifest: dict) -> List[dict]:
     """The chunks still to do: every ``pending_chunks`` entry whose hash is NOT in
-    ``completed_chunks``. Structural idempotency — a resumed Swarm sees only the
-    remainder, never a duplicate. Never raises."""
+    ``completed_chunks`` NOR ``quarantined_chunks``. Structural idempotency — a
+    resumed Swarm sees only the remainder and moves INSTANTLY past a quarantined
+    poison chunk to the next pending one (no infinite retry). Never raises."""
     if not manifest:
         return []
-    done = completed_ids(manifest)
+    skip = completed_ids(manifest) | quarantined_ids(manifest)
     return [
         c for c in manifest.get("pending_chunks", []) or []
-        if isinstance(c, dict) and str(c.get("chunk_id")) not in done
+        if isinstance(c, dict) and str(c.get("chunk_id")) not in skip
     ]
 
 
@@ -337,6 +363,95 @@ def mark_chunk_complete(
             pass
 
 
+def mark_chunk_failed(
+    conn: Optional[sqlite3.Connection],
+    intent_id: str,
+    chunk_id: str,
+    *,
+    max_strikes: Optional[int] = None,
+    error: str = "",
+    now: Optional[float] = None,
+) -> str:
+    """Record ONE failed attempt on ``chunk_id`` (the chunk-level circuit breaker).
+    Atomically increments ``chunk_retry_counts[chunk_id]``; when the count reaches
+    ``max_strikes`` (default 3) the hash is moved ``pending_chunks`` →
+    ``quarantined_chunks`` (with its strike count + last error). Same
+    ``BEGIN IMMEDIATE`` read-modify-write as the commit path. Returns:
+    ``"quarantined"`` (struck out — DLQ'd), ``"retry"`` (still pending, count
+    bumped), ``"already"`` (already completed/quarantined — no-op), or ``"error"``.
+    Never raises."""
+    if conn is None:
+        return "error"
+    strikes_cap = _max_strikes() if max_strikes is None else max(1, int(max_strikes))
+    when = time.time() if now is None else float(now)
+    prev_isolation = getattr(conn, "isolation_level", "")
+    try:
+        ensure_intent_table(conn)
+        try:
+            conn.execute("PRAGMA busy_timeout=3000")
+        except sqlite3.Error:
+            pass
+        conn.isolation_level = None
+        conn.execute("BEGIN IMMEDIATE")
+        try:
+            row = conn.execute(
+                f"SELECT manifest_json FROM {_INTENT_TABLE} WHERE intent_id=?",
+                (intent_id,),
+            ).fetchone()
+            manifest = deserialize_manifest(row[0] if row else None)
+            if manifest is None:
+                conn.execute("ROLLBACK")
+                return "error"
+            if str(chunk_id) in (completed_ids(manifest) | quarantined_ids(manifest)):
+                conn.execute("ROLLBACK")
+                return "already"
+            pending = manifest.get("pending_chunks", []) or []
+            counts = dict(manifest.get("chunk_retry_counts", {}) or {})
+            n = int(counts.get(str(chunk_id), 0)) + 1
+            counts[str(chunk_id)] = n
+            manifest["chunk_retry_counts"] = counts
+            result = "retry"
+            if n >= strikes_cap:
+                # 3-strike DLQ: move the poison chunk out of the pending stream.
+                found = None
+                remaining = []
+                for c in pending:
+                    if isinstance(c, dict) and str(c.get("chunk_id")) == str(chunk_id):
+                        found = c
+                    else:
+                        remaining.append(c)
+                if found is not None:
+                    entry = dict(found)
+                    entry["strikes"] = n
+                    entry["quarantined_ts"] = when
+                    entry["last_error"] = str(error)[:200]
+                    manifest["pending_chunks"] = remaining
+                    manifest["quarantined_chunks"] = list(
+                        manifest.get("quarantined_chunks", []) or []
+                    ) + [entry]
+                    result = "quarantined"
+            conn.execute(
+                f"UPDATE {_INTENT_TABLE} SET manifest_json=? WHERE intent_id=?",
+                (serialize_manifest(manifest), intent_id),
+            )
+            conn.execute("COMMIT")
+            return result
+        except Exception:  # noqa: BLE001
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            raise
+    except sqlite3.Error:
+        logger.debug("[Checkpoint] mark_chunk_failed failed", exc_info=True)
+        return "error"
+    finally:
+        try:
+            conn.isolation_level = prev_isolation
+        except Exception:  # noqa: BLE001
+            pass
+
+
 def read_manifest(
     conn: Optional[sqlite3.Connection], intent_id: str,
 ) -> Optional[dict]:
@@ -359,7 +474,8 @@ class CheckpointRunSummary:
     intent_id: str
     processed: List[str] = field(default_factory=list)   # chunk_ids done THIS run
     skipped: List[str] = field(default_factory=list)     # already-completed on entry
-    failed: List[str] = field(default_factory=list)      # raised this run (stay pending)
+    failed: List[str] = field(default_factory=list)      # struck this run (stay pending)
+    quarantined: List[str] = field(default_factory=list) # struck out this run → DLQ
 
 
 async def run_checkpointed(
@@ -377,21 +493,40 @@ async def run_checkpointed(
     if manifest is None:
         return summary
     summary.skipped = sorted(completed_ids(manifest))
+    already_quarantined = sorted(quarantined_ids(manifest))
     pending = resume_pending(manifest)
-    total = len(summary.skipped) + len(pending)
+    total = len(summary.skipped) + len(already_quarantined) + len(pending)
     done = len(summary.skipped)
-    # Resume breadcrumb — the operator sees exactly where the crash left off.
+    # Resume breadcrumb — the operator sees exactly where the crash left off,
+    # and that any prior poison chunks are already DLQ'd (instantly skipped).
     _emit_event("soak_resumed", {
-        "intent_id": intent_id, "total": total,
-        "done": done, "remaining": len(pending),
+        "intent_id": intent_id, "total": total, "done": done,
+        "remaining": len(pending), "quarantined": len(already_quarantined),
     })
+
+    def _strike(cid: str, chunk: dict, why: str) -> None:
+        """One failed attempt → the chunk-level circuit breaker. On the 3rd
+        strike the poison chunk is DLQ'd and reported; otherwise it stays pending
+        for a bounded retry on the next resume."""
+        state = mark_chunk_failed(conn, intent_id, cid, error=why)
+        if state == "quarantined":
+            summary.quarantined.append(cid)
+            _emit_event("soak_chunk_quarantined", {
+                "intent_id": intent_id, "chunk_id": cid,
+                "symbol": chunk.get("symbol", "?"), "file_path": chunk.get("file_path", "?"),
+                "reason": why[:120],
+            })
+            logger.warning("[Checkpoint] chunk %s QUARANTINED (poison): %s", cid, why)
+        else:
+            summary.failed.append(cid)
+
     for chunk in pending:
         cid = str(chunk.get("chunk_id"))
         try:
             result = await swarm_fn(chunk)
-        except Exception as exc:  # noqa: BLE001 — an isolated chunk failure stays pending
+        except Exception as exc:  # noqa: BLE001 — isolated failure → circuit breaker
             logger.debug("[Checkpoint] chunk %s failed: %s", cid, exc)
-            summary.failed.append(cid)
+            _strike(cid, chunk, f"{type(exc).__name__}: {exc}")
             continue
         if mark_chunk_complete(conn, intent_id, cid, result=str(result) if result is not None else ""):
             summary.processed.append(cid)
@@ -403,10 +538,12 @@ async def run_checkpointed(
                 "done": done, "total": total,
             })
         else:
-            summary.failed.append(cid)
+            _strike(cid, chunk, "commit_failed")
+    # Final ratio telemetry — "N completed, M quarantined" (Skip-and-Report).
     _emit_event("soak_run_complete", {
         "intent_id": intent_id, "processed": len(summary.processed),
-        "failed": len(summary.failed), "skipped": len(summary.skipped), "total": total,
+        "failed": len(summary.failed), "quarantined": len(summary.quarantined),
+        "skipped": len(summary.skipped), "total": total,
     })
     return summary
 
@@ -479,6 +616,8 @@ __all__ = [
     "deserialize_manifest",
     "enqueue_soak_manifest",
     "mark_chunk_complete",
+    "mark_chunk_failed",
+    "quarantined_ids",
     "read_manifest",
     "resume_pending",
     "run_checkpointed",

--- a/backend/core/ouroboros/governance/event_breadcrumb_registry.py
+++ b/backend/core/ouroboros/governance/event_breadcrumb_registry.py
@@ -291,7 +291,11 @@ def build_default_registry() -> EventBreadcrumbRegistry:
                                        f"✓ {p.get('symbol','?')} ({p.get('file_path','?')})", "soak"),
         BreadcrumbDescriptor("soak_run_complete", "✓", "green bold", SEV_IMPORTANT,
                              lambda p: f"soak run done — {p.get('processed','?')} committed, "
+                                       f"{p.get('quarantined','?')} quarantined, "
                                        f"{p.get('failed','?')} failed, {p.get('skipped','?')} pre-done", "soak"),
+        BreadcrumbDescriptor("soak_chunk_quarantined", "☠", "red bold", SEV_CRITICAL,
+                             lambda p: f"poison chunk DLQ'd ✗ {p.get('symbol','?')} "
+                                       f"({p.get('file_path','?')}) — {p.get('reason','3 strikes')}", "soak"),
     ]
     for d in seed:
         reg.register(d)

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -191,6 +191,10 @@ EVENT_TYPE_SOAK_MANIFEST_ENQUEUED = "soak_manifest_enqueued"
 EVENT_TYPE_SOAK_RESUMED = "soak_resumed"
 EVENT_TYPE_SOAK_CHUNK_COMMITTED = "soak_chunk_committed"
 EVENT_TYPE_SOAK_RUN_COMPLETE = "soak_run_complete"
+# AST Dead-Letter Queue: a poison chunk struck out (3-strike chunk-level circuit
+# breaker) and was quarantined — the Swarm skips it and reports the final ratio,
+# so a mathematically-impossible chunk can never stall the map-reduce forever.
+EVENT_TYPE_SOAK_CHUNK_QUARANTINED = "soak_chunk_quarantined"
 
 # Slice 19 (Soak Budget & Compute Circuit-Breaker) — two events covering the
 # fail-closed boundary around an unattended graduation soak:
@@ -1686,6 +1690,7 @@ _VALID_EVENT_TYPES = frozenset({
     EVENT_TYPE_SOAK_RESUMED,                    # Checkpoint Engine (2026-07-23 -- resume-from-hash, N already done)
     EVENT_TYPE_SOAK_CHUNK_COMMITTED,            # Checkpoint Engine (2026-07-23 -- atomic per-chunk commit, done/total)
     EVENT_TYPE_SOAK_RUN_COMPLETE,               # Checkpoint Engine (2026-07-23 -- map-reduce run terminal)
+    EVENT_TYPE_SOAK_CHUNK_QUARANTINED,          # AST DLQ (2026-07-23 -- poison chunk struck out, quarantined)
 })
 
 

--- a/tests/governance/test_checkpoint_manifest.py
+++ b/tests/governance/test_checkpoint_manifest.py
@@ -67,7 +67,7 @@ async def test_enqueue_generates_correct_manifest(project, db_path):
     # 3 top-level symbols: a_one, a_two (alpha.py) + B (beta.py).
     assert res["chunk_count"] == 3
     manifest = res["manifest"]
-    assert manifest["schema_version"] == 1
+    assert manifest["schema_version"] == 2
     assert len(manifest["pending_chunks"]) == 3
     assert manifest["completed_chunks"] == []
     symbols = sorted(c["symbol"] for c in manifest["pending_chunks"])
@@ -82,7 +82,7 @@ async def test_enqueue_generates_correct_manifest(project, db_path):
     raw = get_manifest_json(conn, res["intent_id"])
     conn.close()
     assert raw is not None
-    assert json.loads(raw)["schema_version"] == 1
+    assert json.loads(raw)["schema_version"] == 2
 
 
 async def test_manifest_serialization_is_deterministic(project):
@@ -108,7 +108,7 @@ async def test_enqueue_soak_verb_writes_manifest(project, db_path, monkeypatch):
     ).fetchall()
     conn.close()
     assert len(rows) == 1
-    assert json.loads(rows[0][0])["chunk_count" if False else "schema_version"] == 1
+    assert json.loads(rows[0][0])["schema_version"] == 2
 
 
 # ---------------------------------------------------------------------------
@@ -247,6 +247,131 @@ async def test_checkpoint_progress_surfaces_on_broker(project, db_path):
     assert "soak_resumed" in seen
     assert seen.count("soak_chunk_committed") == 3   # one tick per chunk
     assert "soak_run_complete" in seen
+
+
+async def test_poison_chunk_quarantined_after_3_strikes(project, db_path):
+    """AST DLQ: a chunk that consistently fails is struck out after 3 attempts
+    (across resumes) and moved to quarantined_chunks — never retried forever."""
+    from backend.core.ouroboros.governance.checkpoint_manifest import quarantined_ids
+
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+    conn.close()
+
+    ids = [c["chunk_id"] for c in res["manifest"]["pending_chunks"]]
+    poison = ids[0]                       # this one always fails
+    healthy = set(ids[1:])
+
+    async def swarm(chunk):
+        if chunk["chunk_id"] == poison:
+            raise RuntimeError("context window blown")   # poison payload
+        return "ok"
+
+    # Three resumes (reboots). The healthy chunks commit on run 1; the poison
+    # chunk strikes once per run and is DLQ'd on the 3rd.
+    for run in range(3):
+        conn = sqlite3.connect(db_path)
+        summary = await run_checkpointed(conn, iid, swarm)
+        manifest = read_manifest(conn, iid)
+        conn.close()
+        if run < 2:
+            assert poison in summary.failed          # still pending, striking
+            assert poison not in quarantined_ids(manifest)
+        else:
+            assert poison in summary.quarantined     # 3rd strike → DLQ
+            assert poison in quarantined_ids(manifest)
+
+    # Healthy chunks all completed exactly once; poison is quarantined, not lost.
+    manifest = read_manifest(sqlite3.connect(db_path), iid)
+    assert {c["chunk_id"] for c in manifest["completed_chunks"]} == healthy
+    assert quarantined_ids(manifest) == {poison}
+    assert manifest["chunk_retry_counts"][poison] == 3
+    # The poison chunk carries its forensics in the DLQ.
+    q = manifest["quarantined_chunks"][0]
+    assert q["strikes"] == 3 and "context window blown" in q["last_error"]
+
+
+async def test_resume_skips_quarantined_instantly(project, db_path):
+    """Skip-and-Report: once quarantined, a poison chunk is structurally bypassed
+    on every subsequent resume — the swarm moves straight to pending work."""
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+    conn.close()
+    poison = res["manifest"]["pending_chunks"][0]["chunk_id"]
+
+    attempts: list = []
+
+    async def swarm(chunk):
+        attempts.append(chunk["chunk_id"])
+        if chunk["chunk_id"] == poison:
+            raise RuntimeError("poison")
+        return "ok"
+
+    for _ in range(3):                       # drive it to quarantine
+        conn = sqlite3.connect(db_path)
+        await run_checkpointed(conn, iid, swarm)
+        conn.close()
+
+    attempts.clear()
+    # A fresh resume AFTER quarantine must never touch the poison chunk again.
+    conn = sqlite3.connect(db_path)
+    summary = await run_checkpointed(conn, iid, swarm)
+    conn.close()
+    assert poison not in attempts, "quarantined chunk must be structurally skipped"
+    assert attempts == []                    # everything else was already done
+    # Final ratio is reportable: 2 completed, 1 quarantined.
+    manifest = read_manifest(sqlite3.connect(db_path), iid)
+    assert len(manifest["completed_chunks"]) == 2
+    assert len(manifest["quarantined_chunks"]) == 1
+
+
+async def test_quarantine_ratio_surfaces_on_broker(project, db_path):
+    """The final ratio ('N completed, M quarantined') + the DLQ event reach the
+    broker → visible in /breadcrumbs."""
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        get_default_broker,
+        reset_default_broker,
+    )
+
+    reset_default_broker()
+    broker = get_default_broker()
+    sub = broker.subscribe()
+
+    conn = sqlite3.connect(db_path)
+    res = await enqueue_soak_manifest(conn, project, priority=1)
+    iid = res["intent_id"]
+    poison = res["manifest"]["pending_chunks"][0]["chunk_id"]
+    conn.close()
+
+    async def swarm(chunk):
+        if chunk["chunk_id"] == poison:
+            raise RuntimeError("poison")
+        return "ok"
+
+    for _ in range(3):
+        conn = sqlite3.connect(db_path)
+        await run_checkpointed(conn, iid, swarm)
+        conn.close()
+
+    seen = []
+    complete_payloads = []
+    for _ in range(500):
+        try:
+            ev = sub.queue.get_nowait()
+        except Exception:  # noqa: BLE001
+            break
+        et = getattr(ev, "event_type", "")
+        seen.append(et)
+        if et == "soak_run_complete":
+            complete_payloads.append(getattr(ev, "payload", {}) or {})
+    broker.unsubscribe(sub)
+    reset_default_broker()
+
+    assert "soak_chunk_quarantined" in seen
+    assert any(p.get("quarantined") == 1 and p.get("processed", 0) >= 0
+               for p in complete_payloads), "run-complete carries the quarantine ratio"
 
 
 async def test_resume_pending_skips_completed(project, db_path):


### PR DESCRIPTION
## Securing the Poison Chunk Infinite Loop

If a single AST chunk is mathematically impossible to process (blows the context window, triggers a hallucination loop), the Checkpoint system (#70052) would dutifully **resume at that exact chunk every reboot** — an infinite retry that stalls the whole swarm and burns compute. Root cause: **no threshold for localized failure**. The fix is a circuit breaker at the *chunk* level.

## Four mandates

**1 · Root-cause** — a chunk-level circuit breaker, not a system-level one.

**2 · Purity** — the manifest (schema 1→2, old manifests read defensively) grows two arrays in the **same** intent row:
- `quarantined_chunks[]` — struck-out poison chunks (with `strikes` + `quarantined_ts` + `last_error`)
- `chunk_retry_counts{}` — `chunk_id → cumulative failures`

`mark_chunk_failed()` — atomic `BEGIN IMMEDIATE` RMW: increment the count; on the **3rd** cumulative strike (`JARVIS_SOAK_CHUNK_MAX_STRIKES`) move the hash `pending → quarantined`. `resume_pending()` skips completed **and** quarantined, so a resumed swarm moves **instantly** past a DLQ'd chunk — never an infinite retry. The strike count persists, so across reboots a poison chunk gets exactly 3 bounded attempts then quarantine.

**Skip-and-Report** telemetry (live in `/breadcrumbs`):
- `☠ soak_chunk_quarantined` — poison chunk DLQ'd (symbol + file + reason)
- `soak_run_complete` now carries the final **ratio**: `188 committed, 2 quarantined, 0 failed`

**3 · DRY** — no separate DLQ database; same JSON manifest, same `soak_intent_queue` row.

**4 · Bulletproof** — real SQLite + real files: (1) a consistently-failing chunk is quarantined after **exactly 3 strikes** across resumes (healthy chunks committed once, `retry_count==3`, forensics recorded), (2) once quarantined it is **structurally bypassed** on every subsequent resume, (3) the quarantine event + final ratio reach the real broker. **28 governance tests green.**

Next: enqueue the Canary Soak on a safe throwaway directory.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a 3‑strike chunk‑level circuit breaker and DLQ to the AST checkpoint system to stop infinite retries on poison chunks. Resumes now skip quarantined chunks and report final processed/quarantined/failed ratios.

- **New Features**
  - Manifest schema v2 adds `quarantined_chunks[]` and `chunk_retry_counts{}` in the same `soak_intent_queue` row.
  - New `mark_chunk_failed()` atomically increments strikes and on strike 3 moves the chunk from pending to quarantined.
  - `resume_pending()` skips both completed and quarantined chunks; no more loop on poison chunks.
  - `run_checkpointed()` routes failures through the circuit breaker and emits `soak_chunk_quarantined`, `soak_run_complete` (now includes `quarantined`), and `soak_resumed`.
  - Max strikes configurable via `JARVIS_SOAK_CHUNK_MAX_STRIKES` (default 3).

- **Migration**
  - No migration required. Old schema‑1 manifests load with empty DLQ fields and continue normally.

<sup>Written for commit d397483136ca4217a54fe4ba230a3bac4654a254. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70053?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

