### PR TITLE
Reactive Theme Singleton + OV_STYLE_GUIDE — design-as-code single source of truth

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -109,6 +109,13 @@ class BipartiteLayout:
             self._buffer.push(f"[{color}]{glyph} {text}[/{color}]")
         except Exception:  # noqa: BLE001 — a bad event never breaks the canvas
             logger.debug("[Bipartite] emit failed", exc_info=True)
+        # Feed the Reactive Theme Singleton — a state-mapped event mutates the
+        # canvas border accent in place (DORMANT/ARMED/SOAKING/DEGRADED/HEALTHY).
+        try:
+            from backend.core.ouroboros.ui.theme import get_reactive_theme
+            get_reactive_theme().on_event(event_type, dict(payload or {}))
+        except Exception:  # noqa: BLE001
+            pass
         self._invalidate_now()
 
     async def aemit(self, event_type: str, payload: dict) -> None:
@@ -152,10 +159,18 @@ class BipartiteLayout:
                 "  idle — waiting for the organism to act", style="bright_black"
             )
             n = self._buffer.line_count if hasattr(self._buffer, "line_count") else len(lines)
+            # State-reactive border (Style Guide §06): the accent reflects the
+            # organism's meta-state, mutated in place by the Reactive Theme.
+            border = "cyan"
+            try:
+                from backend.core.ouroboros.ui.theme import get_reactive_theme
+                border = get_reactive_theme().active_border_style() or "cyan"
+            except Exception:  # noqa: BLE001
+                border = "cyan"
             return Panel(
                 body, title=self._title, title_align="left",
                 subtitle=f"[bright_black]{n} events[/bright_black]", subtitle_align="right",
-                box=ROUNDED, border_style="cyan", padding=(0, 1),
+                box=ROUNDED, border_style=border, padding=(0, 1),
                 height=max(3, self._height - 3),
             )
         except Exception:  # noqa: BLE001
@@ -387,6 +402,14 @@ def build_bipartite_application(
     )
     _APP_REF["app"] = app
     mux.set_invalidate(app.invalidate)
+    # Register the app's invalidate with the Reactive Theme so a state transition
+    # (DORMANT→ARMED→SOAKING→DEGRADED→HEALTHY) repaints the border IN PLACE — no
+    # Application teardown/rebuild (zero-flicker mandate).
+    try:
+        from backend.core.ouroboros.ui.theme import get_reactive_theme
+        get_reactive_theme().register_invalidate(app.invalidate)
+    except Exception:  # noqa: BLE001
+        pass
     return app
 
 

--- a/backend/core/ouroboros/governance/event_breadcrumb_registry.py
+++ b/backend/core/ouroboros/governance/event_breadcrumb_registry.py
@@ -133,9 +133,25 @@ def _generic_formatter(payload: dict) -> str:
     return " ".join(parts)
 
 
-_GLYPH_BY_SEV = {SEV_CRITICAL: "✖", SEV_IMPORTANT: "▲", SEV_INFO: "·", SEV_VERBOSE: "·"}
-_COLOR_BY_SEV = {SEV_CRITICAL: "red", SEV_IMPORTANT: "yellow",
-                 SEV_INFO: "cyan", SEV_VERBOSE: "bright_black"}
+# DRY (Style Guide §05): the severity → glyph/color mapping is defined exactly
+# ONCE, in the Reactive Theme Singleton. This registry imports it — zero
+# duplicate color/glyph literals. The theme resolves the color per terminal
+# tier (truecolor → 256 → 16 → stripped); we ask for the active tier here.
+try:
+    from backend.core.ouroboros.ui.theme import (
+        SEVERITY_GLYPH as _GLYPH_BY_SEV,
+        severity_style as _theme_severity_style,
+    )
+
+    def _color_for_sev(sev: int) -> str:
+        return _theme_severity_style(sev)
+except Exception:  # noqa: BLE001 — theme is a soft dep; degrade to a local echo
+    _GLYPH_BY_SEV = {SEV_CRITICAL: "✖", SEV_IMPORTANT: "▲", SEV_INFO: "·", SEV_VERBOSE: "·"}
+    _FALLBACK_COLOR = {SEV_CRITICAL: "red", SEV_IMPORTANT: "yellow",
+                       SEV_INFO: "cyan", SEV_VERBOSE: "bright_black"}
+
+    def _color_for_sev(sev: int) -> str:
+        return _FALLBACK_COLOR.get(sev, "cyan")
 
 
 class EventBreadcrumbRegistry:
@@ -165,7 +181,7 @@ class EventBreadcrumbRegistry:
         sev = _heuristic_severity(event_type)
         return BreadcrumbDescriptor(
             event_type=event_type, glyph=_GLYPH_BY_SEV[sev],
-            color=_COLOR_BY_SEV[sev], severity=sev,
+            color=_color_for_sev(sev), severity=sev,
             formatter=_generic_formatter, category=_heuristic_category(event_type),
         )
 

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import enum
 import logging
 import os
-from typing import Mapping, Optional
+from typing import Callable, Mapping, Optional
 
 from rich.console import Console
 from rich.theme import Theme
@@ -250,6 +250,14 @@ _GLYPHS: Mapping[str, tuple] = {
     "human": ("🗣", "you:"),  # the operator's words echoed
     "warn": ("⚠", "!"),     # operator-notable degradation
     "audio": ("🎙", "mic"),  # live audio-plane state
+    # Style Guide §04 glyph grammar — the proactive-cockpit vocabulary. Each maps
+    # to ONE meaning across the whole organism; ASCII degradation keeps geometry.
+    "ignite": ("⚡", "!"),   # a high-energy autonomous fire (AWE launch)
+    "tick": ("◈", "+"),     # one unit of map-reduce progress (chunk commit)
+    "cycle": ("↻", "~"),    # resume / restart / self-heal
+    "poison": ("☠", "X"),   # quarantined / dead-lettered (DLQ)
+    "state_on": ("◆", "#"),  # a lifecycle transition took hold (armed)
+    "state_off": ("◇", "o"),  # a lifecycle stood down (disarmed)
 }
 
 
@@ -395,20 +403,260 @@ def render_rule(console: Console, label: Optional[str] = None) -> None:
             pass
 
 
+# ===========================================================================
+# Style Guide palette + severity ladder (OV_STYLE_GUIDE.md §02, §05)
+#
+# The DEFINITIVE palette lives here as truecolor hex — the single source of
+# truth the /breadcrumbs registry imports (DRY mandate: zero duplicate color or
+# glyph literals anywhere else). Every value degrades across the same four tiers
+# as the semantic tokens above.
+# ===========================================================================
+
+
+#: Named brand + semantic hexes (truecolor). Retune the whole CLI from here.
+PALETTE: Mapping[str, str] = {
+    "ground": "#0A0E0D", "surface": "#111917", "hairline": "#1E2B28",
+    "ink": "#DBE6E1", "muted": "#6C7D77", "faint": "#47554F",
+    "venom_green": "#5EE06A", "venom_purple": "#A371F7", "cyan": "#43D6D0",
+    "crit": "#F85149", "warn": "#E3B341", "info": "#58B0F8", "ok": "#3FB950",
+}
+
+
+# Severity rank → (glyph name, semantic style) — the "derive, don't pick" table.
+# Ranks mirror event_breadcrumb_registry SEV_* (0 verbose … 3 critical). The
+# registry imports SEVERITY_GLYPH / severity_style from here so the mapping is
+# defined exactly ONCE.
+SEVERITY_GLYPH: Mapping[int, str] = {3: "✖", 2: "▲", 1: "·", 0: "·"}
+
+_SEVERITY_STYLE_TRUE: Mapping[int, str] = {
+    3: "bold #F85149", 2: "#E3B341", 1: "#58B0F8", 0: "#6C7D77",
+}
+_SEVERITY_STYLE_C256: Mapping[int, str] = {
+    3: "bold red", 2: "yellow", 1: "color(75)", 0: "grey50",
+}
+_SEVERITY_STYLE_STD: Mapping[int, str] = {
+    3: "bold red", 2: "yellow", 1: "cyan", 0: "bright_black",
+}
+
+
+def severity_style(rank: int, tier: Optional[ColorTier] = None) -> str:
+    """Resolve a severity rank (0–3) to a concrete Rich style for the active (or
+    given) tier — truecolor hex → 256 → 16-color → stripped. NEVER raises."""
+    t = tier if tier is not None else active_tier()
+    try:
+        r = int(rank)
+    except (TypeError, ValueError):
+        r = 1
+    if t >= ColorTier.TRUECOLOR:
+        return _SEVERITY_STYLE_TRUE.get(r, _SEVERITY_STYLE_TRUE[1])
+    if t == ColorTier.C256:
+        return _SEVERITY_STYLE_C256.get(r, _SEVERITY_STYLE_C256[1])
+    if t == ColorTier.STANDARD:
+        return _SEVERITY_STYLE_STD.get(r, _SEVERITY_STYLE_STD[1])
+    return ""  # NONE tier — no color
+
+
+# Named semantic colors the registry references for its tailored per-event
+# overrides (e.g. a CRITICAL-urgent AWE launch styled venom-green, not red).
+# Values are tier-resolved so a descriptor never carries a raw literal.
+_SEMANTIC_TRUE: Mapping[str, str] = {
+    "crit": "#F85149", "crit_bold": "bold #F85149", "warn": "#E3B341",
+    "info": "#58B0F8", "verbose": "#6C7D77", "muted": "#6C7D77",
+    "ok": "#3FB950", "ok_bold": "bold #5EE06A", "venom_green": "#5EE06A",
+    "venom_purple": "#A371F7", "cyan": "#43D6D0", "cyan_bold": "bold #43D6D0",
+}
+_SEMANTIC_STD: Mapping[str, str] = {
+    "crit": "red", "crit_bold": "bold red", "warn": "yellow",
+    "info": "cyan", "verbose": "bright_black", "muted": "dim",
+    "ok": "green", "ok_bold": "bold green", "venom_green": "green",
+    "venom_purple": "magenta", "cyan": "cyan", "cyan_bold": "bold cyan",
+}
+
+
+def semantic(name: str, tier: Optional[ColorTier] = None) -> str:
+    """Resolve a named semantic color to a concrete Rich style for the tier.
+    Truecolor → hex; standard/256 → the 8/16-color ANSI equivalent; NONE → "".
+    An unknown name degrades to muted. NEVER raises."""
+    t = tier if tier is not None else active_tier()
+    if t <= ColorTier.NONE:
+        return ""
+    table = _SEMANTIC_TRUE if t >= ColorTier.C256 else _SEMANTIC_STD
+    return table.get(name, table.get("muted", ""))
+
+
+# ===========================================================================
+# The Reactive Theme Singleton (OV_STYLE_GUIDE.md §06 — State-Reactive border)
+#
+# A state-aware, in-memory-mutable palette. The organism is PROACTIVE; this glass
+# is REACTIVE — a broker state-transition mutates the active accent + fires the
+# registered invalidate hooks (a lightweight in-place redraw), NEVER a teardown /
+# rebuild of the prompt_toolkit Application. Decoupled from any Application: the
+# app REGISTERS its invalidate; the theme calls it. Fully headless-testable.
+# ===========================================================================
+
+
+class UIState(str, enum.Enum):
+    """The organism's meta-state, as reflected by the cockpit's accent."""
+    DORMANT = "DORMANT"     # idle / disarmed
+    ARMED = "ARMED"         # Supervisor armed, watching
+    SOAKING = "SOAKING"     # a checkpointed swarm soak is running
+    DEGRADED = "DEGRADED"   # a provider's inference lane is down
+    HEALTHY = "HEALTHY"     # a provider recovered / live
+
+
+# UIState → semantic color name (resolved per-tier via semantic()).
+_STATE_ACCENT: Mapping[UIState, str] = {
+    UIState.DORMANT: "muted",
+    UIState.ARMED: "warn",          # amber
+    UIState.SOAKING: "venom_green",
+    UIState.DEGRADED: "crit",       # red
+    UIState.HEALTHY: "cyan",
+}
+
+
+# event_type (+ payload) → UIState. The reactive mapping; feeding ANY of these
+# events to on_event mutates the active accent.
+def _state_for_event(event_type: str, payload: dict) -> Optional[UIState]:
+    et = (event_type or "").strip()
+    if et == "provider_state_changed":
+        st = str((payload or {}).get("state", "")).upper()
+        if st == "DEGRADED":
+            return UIState.DEGRADED
+        if st == "HEALTHY":
+            return UIState.HEALTHY
+        return None
+    if et in ("supervisor_armed",):
+        return UIState.ARMED
+    if et in ("supervisor_disarmed",):
+        return UIState.DORMANT
+    if et in ("awe_soak_launched", "soak_resumed", "soak_chunk_committed",
+              "soak_manifest_enqueued"):
+        return UIState.SOAKING
+    if et in ("awe_soak_complete", "soak_run_complete"):
+        return UIState.HEALTHY
+    return None
+
+
+class ReactiveTheme:
+    """The mutable, state-aware accent + a set of invalidate hooks. Thread-safe
+    for the register/notify path. NEVER raises into a render or event path."""
+
+    def __init__(self, *, initial: UIState = UIState.DORMANT) -> None:
+        import threading
+        self._state: UIState = initial
+        self._lock = threading.Lock()
+        self._invalidators: list = []
+        self._transitions: int = 0
+
+    # -- state -----------------------------------------------------------
+
+    @property
+    def state(self) -> UIState:
+        return self._state
+
+    @property
+    def transitions(self) -> int:
+        return self._transitions
+
+    def active_border_style(self, tier: Optional[ColorTier] = None) -> str:
+        """The current border/accent as a concrete Rich style for the tier —
+        the property the canvas reads each render. NEVER raises."""
+        try:
+            name = _STATE_ACCENT.get(self._state, "cyan")
+            return semantic(name, tier)
+        except Exception:  # noqa: BLE001
+            return ""
+
+    def set_state(self, state: UIState) -> bool:
+        """Set the meta-state. On a genuine transition, mutate in place and fire
+        the invalidate hooks (a lightweight redraw — NO Application rebuild).
+        Returns True iff the state actually changed. NEVER raises."""
+        with self._lock:
+            if state == self._state:
+                return False
+            self._state = state
+            self._transitions += 1
+            hooks = list(self._invalidators)
+        for fn in hooks:
+            try:
+                fn()
+            except Exception:  # noqa: BLE001 — a bad hook never blocks a transition
+                logger.debug("[theme] invalidate hook raised", exc_info=True)
+        return True
+
+    def on_event(self, event_type: str, payload: Optional[dict] = None) -> bool:
+        """Consume a broker event; if it maps to a meta-state, transition (which
+        invalidates). Returns whether the accent changed. NEVER raises."""
+        try:
+            st = _state_for_event(event_type, payload or {})
+        except Exception:  # noqa: BLE001
+            st = None
+        if st is None:
+            return False
+        return self.set_state(st)
+
+    # -- invalidate hooks (decoupled from the Application) --------------
+
+    def register_invalidate(self, fn) -> "Callable[[], None]":
+        """Register a zero-arg redraw callback (e.g. ``app.invalidate``). Returns
+        an unregister thunk. The theme holds NO reference to the Application
+        itself — only this callable — so it is fully decoupled. NEVER raises."""
+        with self._lock:
+            self._invalidators.append(fn)
+
+        def _unregister() -> None:
+            with self._lock:
+                try:
+                    self._invalidators.remove(fn)
+                except ValueError:
+                    pass
+        return _unregister
+
+    def clear_invalidators(self) -> None:
+        with self._lock:
+            self._invalidators.clear()
+
+
+_reactive_theme: Optional[ReactiveTheme] = None
+
+
+def get_reactive_theme() -> ReactiveTheme:
+    """Process-local singleton — the ONE reactive accent shared by the broker
+    listeners (writers) and the canvas / Application (reader + invalidate)."""
+    global _reactive_theme
+    if _reactive_theme is None:
+        _reactive_theme = ReactiveTheme()
+    return _reactive_theme
+
+
+def reset_reactive_theme() -> None:
+    """Test isolation — drop the singleton so a fresh one is built."""
+    global _reactive_theme
+    _reactive_theme = None
+
+
 __all__ = [
     "ACCENT_HEX",
     "FORCE_TIER_ENV_VAR",
+    "PALETTE",
+    "SEVERITY_GLYPH",
     "ColorTier",
+    "ReactiveTheme",
     "Token",
+    "UIState",
     "active_tier",
     "box_for",
     "build_console",
     "detect_tier",
     "ensure_theme",
+    "get_reactive_theme",
     "mark",
     "render_panel",
     "render_rule",
     "reset_active_tier_cache",
+    "reset_reactive_theme",
+    "semantic",
+    "severity_style",
     "style_for",
     "styles",
     "supports_unicode",

--- a/docs/OV_STYLE_GUIDE.md
+++ b/docs/OV_STYLE_GUIDE.md
@@ -1,0 +1,243 @@
+# O+V · Terminal Visual Style Guide
+
+**Ouroboros + Venom — the design grammar for a proactive autonomous cockpit, not a reactive chat.**
+
+> Claude Code is a *conversation*: you speak, it works, it answers. O+V is an *organism*: a Sentinel probes, a
+> Supervisor arms, a Swarm chunks — with you as the overseer, not the initiator. Every rule below exists to make
+> that continuous, self-driven activity **legible at a glance**. Steal Claude Code's restraint; reject its
+> turn-based transcript.
+
+This document is the **single source of truth** for the O+V CLI/TUI look. The palette, glyph vocabulary, and
+severity ladder here are wired into code at `backend/core/ouroboros/ui/theme.py` (the Reactive Theme Singleton)
+and consumed by `event_breadcrumb_registry.py`. Change the look *here first*, then the tokens in code.
+
+---
+
+## 01 · First Principles
+
+Six rules. When a design decision is unclear, the one that serves these wins.
+
+| # | Principle | What it means |
+|---|-----------|---------------|
+| ◈ | **Cockpit, not chat** | The resting state is a *live activity canvas*, not an empty prompt. The organism is always doing something; the UI's job is to show what it just decided. |
+| ⎿ | **Hierarchy by glyph** | Structure comes from *glyphs + typography*, not borders everywhere. A filled marker opens a thought; a corner glyph subordinates. One cheap, legible system. |
+| ✓ | **Green is an outcome** | Reserve the Venom green for *things that succeeded*. If everything is green, nothing is. Default text is soft off-white; secondary is dim. |
+| ⚡ | **Motion is the polish** | One in-place spinner, never six stacked log lines. Stream tokens. The *movement* is what separates a product from a script. |
+| ◇ | **Framed where it counts** | The background telemetry earns a *bounded panel* (Zone 1). The prompt stays anchored (Zone 2). Nothing else gets a box unless it needs one. |
+| · | **Restraint by default** | Terse one-liners; detail on demand (`/expand`). Emojis allowed but rationed. Silence is a valid state — an idle organism looks calm, not blank. |
+
+---
+
+## 02 · Palette
+
+Grounded in the **Venom signature** (green → purple) over a near-black terminal ground with a faint cool bias.
+The accent is cyan; semantic colors map to event severity. Deliberately **dark-only** — the subject is a dark
+terminal, so a light mode would be incoherent.
+
+**The Venom gradient** (`#5EE06A → #43D6D0 → #A371F7`) is for the wordmark, active-route accents, and the boot
+sweep. **Never body text.**
+
+### Core
+
+| Role | Hex | Rich token |
+|------|-----|-----------|
+| Ground | `#0A0E0D` | — (terminal bg) |
+| Surface | `#111917` | — |
+| Hairline | `#1E2B28` | `rule` |
+| Ink (primary) | `#DBE6E1` | `body` / `default` |
+| Muted (secondary) | `#6C7D77` | `muted` / `grey50` |
+| Faint | `#47554F` | `bright_black` |
+
+### Brand + accent
+
+| Role | Hex | Rich token |
+|------|-----|-----------|
+| Venom green | `#5EE06A` | `venom_green` |
+| Venom purple | `#A371F7` | `venom_purple` |
+| Cyan (accent/borders) | `#43D6D0` | `accent` |
+
+### Semantic — the severity ladder
+
+| Role | Hex | Rich token |
+|------|-----|-----------|
+| Critical | `#F85149` | `danger` / `crit` |
+| Important | `#E3B341` | `warning` |
+| Info | `#58B0F8` | `info` |
+| Verbose | `#6C7D77` | `verbose` |
+| Success | `#3FB950` | `success` |
+
+---
+
+## 03 · Typography
+
+Two roles. **Monospace** carries everything inside the organism — every event line, status, glyph, number —
+because alignment *is* the information. A humanist **sans** carries only human chrome (help prose). Numbers use
+tabular figures so columns don't dance.
+
+```
+mono · TUI body      ◈ chunk 313/500 ✓ factorial (mathy.py)
+mono · label         PHASE  cost  runway
+mono · numeric       $0.47 / $2.50    5,000,000 tok    p50 8.9s
+sans · help prose    Reserved for multi-sentence explanation only.
+```
+
+**Type stack** — mono: `SF Mono / JetBrains Mono / Menlo`; sans: `system-ui`. No web fonts.
+
+---
+
+## 04 · The Glyph Grammar
+
+The heart of the system. Each glyph has **one meaning**, everywhere. Learn eleven marks and the whole organism
+is readable. Color is layered on top by severity (§05). Each has an ASCII degradation so 16-color / no-color
+terminals keep identical geometry.
+
+| Glyph | ASCII | Name | Means | Example |
+|:---:|:---:|------|-------|---------|
+| `⏺` | `*` | open | A primary action / status begins | `⏺ attached — phase IDLE` |
+| `⎿` | `-` | continue | A line subordinate to the one above | `⎿ liquidity anthropic 5.0M` |
+| `◆` | `#` | state (filled) | A lifecycle transition took hold | `◆ supervisor armed` |
+| `◇` | `o` | state (hollow) | A lifecycle stood down | `◇ supervisor disarmed` |
+| `⚡` | `!` | ignite | A high-energy autonomous fire | `⚡ recovery → soak launched` |
+| `◈` | `+` | tick | One unit of map-reduce progress | `◈ chunk 4/7 ✓ factorial` |
+| `↻` | `~` | cycle | Resume / restart / self-heal | `↻ Sentinel self-healed` |
+| `☠` | `X` | poison | Quarantined / dead-lettered | `☠ poison chunk DLQ'd` |
+| `✓` | `OK` | done | Completed / verified | `✓ soak run done` |
+| `⚠` | `!` | warn | Degraded but not fatal | `⚠ a provider runway is dry` |
+| `·` | `-` | trace | Verbose telemetry (piped stdout) | `· probe DEGRADED stage=pass1` |
+
+Status dots `●` online / `●` disconnected and trend `▲`/`▼` are the two exceptions that also live in the HUD
+halo + menu-bar.
+
+---
+
+## 05 · Severity → Color (derive, don't pick)
+
+Every event carries a **severity rank**; the color is *derived*, never hand-picked per message. This is what
+keeps 149 event types coherent — one table, not 149 decisions. The `/breadcrumbs` verbosity floor filters by
+this same rank. Defined once in the theme as `SEVERITY_STYLE`.
+
+| Rank | Level | Reads as | Fires on |
+|:---:|-------|----------|----------|
+| 3 | **CRITICAL** | red · bold | trips · exhaustion · quarantine · anomalies |
+| 2 | **IMPORTANT** | yellow | degradation · throttle · drift · armed/disarmed |
+| 1 | **INFO** | cyan | posture · plans · resume · learning |
+| 0 | **VERBOSE** | dim gray | telemetry · heartbeats · per-chunk ticks |
+
+Tailored descriptors may override the derived color for a specific event (e.g. `awe_soak_launched` is green-bold,
+not red, despite being CRITICAL-urgent) — but the override references a **theme token**, never a raw literal.
+
+---
+
+## 06 · The Bipartite Layout
+
+The canonical running surface. **Zone 1 — the Proactive Canvas**: a rounded panel every background event
+auto-scrolls into. **Zone 2 — the Command Deck**: a permanently anchored prompt. Driven by a full-screen
+`prompt_toolkit` app so streaming telemetry can never corrupt a keystroke.
+
+```
+╭─ ◇ O+V · proactive canvas ────────────────────────────────────────╮
+│ ◆ supervisor armed — 1 pending, DW DEGRADED → Sentinel pid 4242    │
+│ · sentinel telemetry — probe DEGRADED stage=pass1 (ttft 71s)       │
+│ ⚡ awe soak launched — doubleword recovery → soak 22737b8f         │
+│ ↻ soak resumed — 0/7 done, 7 to go                                 │
+│ ◈ chunk 1/7 ✓ factorial (mathy.py)                                 │
+│ ◈ chunk 2/7 ✓ is_even (mathy.py)                                   │
+│ ☠ poison chunk DLQ'd ✗ slow_sum (widgets.py) — ctx blown           │
+│ ✓ soak run done — 6 committed, 1 quarantined, 0 failed             │
+╰──────────────────────────────────────────────────── 9 events ─────╯
+› type a verb or plain text   ·   ⌃C detach · wake for voice
+```
+
+| | Zone 1 · Canvas | Zone 2 · Deck |
+|---|-----------------|---------------|
+| **border** | rounded, cyan-dim (state-reactive) | none (a single row) |
+| **content** | bounded ring, tail auto-scrolls | editable prompt + affordances |
+| **owner** | the organism (writes) | the human (types) |
+| **motion** | new events slide in at the bottom | caret blink only — stays still |
+
+### State-Reactive border
+
+The canvas border color is **not static** — it reflects the organism's meta-state, updated in place (zero
+flicker, no teardown) as broker events flow. This is the Reactive Theme Singleton (`theme.get_reactive_theme()`).
+
+| Meta-state | Border | Triggered by |
+|------------|--------|--------------|
+| `DORMANT` | dim gray | idle / `supervisor_disarmed` |
+| `ARMED` | amber | `supervisor_armed` |
+| `SOAKING` | venom green | `awe_soak_launched` / `soak_chunk_committed` |
+| `DEGRADED` | red | `provider_state_changed` → DEGRADED |
+| `HEALTHY` | cyan | `provider_state_changed` → HEALTHY |
+
+---
+
+## 07 · Density & Motion
+
+Where "basic" becomes "product." The single biggest lever: **collapse repetition into one updating line**, and
+let detail expand on request.
+
+```
+the boot wake — one in-place spinner, not six stacked lines:
+⠹ waking organism · 27s                    ← updates in place
+● organism live · 27s                       ← resolves to one ✓
+
+collapsed op block — terse by default, /expand o-3 for the diff:
+⏺ edit widgets.py · +4 −1 · applied · o-3
+```
+
+- Spinners refresh **in place**.
+- Progress shows `done/total`, not a new line each tick.
+- Op blocks collapse to one line + a `ref`.
+- Stream model output token-by-token.
+
+---
+
+## 08 · Do & Don't
+
+| ✗ Avoid | ✓ Prefer |
+|---------|----------|
+| A flat wall of one green — no hierarchy | Dim → ink → accent hierarchy |
+| Stacked identical log lines (`waking · 0s / 5s / 11s`) | One in-place spinner → single result |
+| Boxes around everything | One framed zone (the canvas); rest flows |
+| Raw tracebacks in the operator surface | A calm breadcrumb + a pull-verb |
+| Green as decoration | Green **only** on ✓ / committed / live |
+| A blank screen while busy | An idle-but-alive resting state |
+
+---
+
+## 09 · Token Cheat-Sheet
+
+The whole system, compressed — mirrors `theme.py`.
+
+```
+# ground / ink
+ground   #0A0E0D   surface  #111917   hairline #1E2B28
+ink      #DBE6E1   muted    #6C7D77   faint    #47554F
+
+# brand + accent
+venom.green #5EE06A   venom.purple #A371F7   cyan #43D6D0
+
+# severity ladder (rank → color, bold at 3)
+3 CRITICAL #F85149   2 IMPORTANT #E3B341
+1 INFO     #58B0F8   0 VERBOSE   #6C7D77   ok #3FB950
+
+# state → border accent (reactive)
+DORMANT muted   ARMED amber   SOAKING venom.green
+DEGRADED crit   HEALTHY cyan
+
+# glyphs — one meaning each (ASCII fallback in theme._GLYPHS)
+⏺ open   ⎿ continue   ◆◇ state   ⚡ ignite   ◈ tick
+↻ cycle  ☠ poison     ✓ done     ⚠ warn     · trace
+
+# type
+mono = TUI body · labels · numbers (tabular)
+sans = human prose only
+
+# layout
+zone1 = rounded cyan panel · bounded ring · auto-scroll   (organism writes)
+zone2 = anchored `› ` prompt · one row                    (human types)
+rule  = green == outcome · one spinner not six · framed where it counts
+```
+
+---
+
+*O+V Terminal Style Guide · v1 · ouroboros + venom · a proactive cockpit.*

--- a/tests/battle_test/test_reactive_theme.py
+++ b/tests/battle_test/test_reactive_theme.py
@@ -1,0 +1,150 @@
+"""Bulletproof spine for the Reactive Theme Singleton.
+
+Mandated assertions, headless (no real terminal):
+
+  (1) injecting a ``provider_state_changed`` event updates the Theme Singleton's
+      active border-color property, and
+  (2) that property mutation triggers a layout invalidation WITHOUT requiring a
+      full application restart (the registered invalidate hook fires; the same
+      singleton object persists).
+
+Plus: state→accent coverage, graceful truecolor→8-bit degradation, idempotent
+non-transitions, and the DRY seam (the registry sources its severity styling
+from the theme).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from backend.core.ouroboros.ui import theme as T
+from backend.core.ouroboros.ui.theme import (
+    ColorTier,
+    UIState,
+    get_reactive_theme,
+    reset_reactive_theme,
+    semantic,
+    severity_style,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_theme():
+    reset_reactive_theme()
+    T.reset_active_tier_cache()
+    yield
+    reset_reactive_theme()
+
+
+# ---------------------------------------------------------------------------
+# (1) provider_state_changed → active border color mutates
+# ---------------------------------------------------------------------------
+
+
+def test_provider_state_event_mutates_border_color():
+    th = get_reactive_theme()
+    assert th.state == UIState.DORMANT
+    dormant_border = th.active_border_style(ColorTier.TRUECOLOR)
+
+    # Inject the broker event — DEGRADED.
+    changed = th.on_event("provider_state_changed", {"provider": "doubleword", "state": "DEGRADED"})
+    assert changed is True
+    assert th.state == UIState.DEGRADED
+    degraded_border = th.active_border_style(ColorTier.TRUECOLOR)
+    assert degraded_border != dormant_border
+    assert degraded_border == semantic("crit", ColorTier.TRUECOLOR)   # red
+
+    # Recovery flips it to the HEALTHY accent.
+    th.on_event("provider_state_changed", {"provider": "doubleword", "state": "HEALTHY"})
+    assert th.state == UIState.HEALTHY
+    assert th.active_border_style(ColorTier.TRUECOLOR) == semantic("cyan", ColorTier.TRUECOLOR)
+
+
+# ---------------------------------------------------------------------------
+# (2) the mutation triggers invalidation WITHOUT an app restart
+# ---------------------------------------------------------------------------
+
+
+def test_mutation_triggers_invalidation_no_restart():
+    th = get_reactive_theme()
+    hits = {"n": 0}
+
+    # A prompt_toolkit Application would register app.invalidate here — we model
+    # it with a counter. The theme holds only this callable, not the app.
+    unregister = th.register_invalidate(lambda: hits.__setitem__("n", hits["n"] + 1))
+    same_singleton = get_reactive_theme()
+    assert same_singleton is th                      # ONE persistent object
+
+    th.on_event("provider_state_changed", {"state": "DEGRADED"})
+    assert hits["n"] == 1                             # invalidate fired — in-place redraw
+    th.on_event("supervisor_armed", {})              # DEGRADED → ARMED
+    assert hits["n"] == 2
+
+    # The singleton was never rebuilt — same object, transitions accumulated.
+    assert get_reactive_theme() is th
+    assert th.transitions == 2
+
+    # Unregister stops future redraws (decoupling proof).
+    unregister()
+    th.on_event("soak_chunk_committed", {})          # ARMED → SOAKING
+    assert hits["n"] == 2                             # no further hook calls
+
+
+def test_non_transition_does_not_invalidate():
+    th = get_reactive_theme()
+    hits = {"n": 0}
+    th.register_invalidate(lambda: hits.__setitem__("n", hits["n"] + 1))
+    th.on_event("provider_state_changed", {"state": "DEGRADED"})
+    assert hits["n"] == 1
+    # Same state again — no transition, no redraw (zero wasted work).
+    th.on_event("provider_state_changed", {"state": "DEGRADED"})
+    assert hits["n"] == 1
+    # An unmapped event is ignored entirely.
+    assert th.on_event("some_unrelated_event", {"x": 1}) is False
+    assert hits["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# state → accent coverage + graceful degradation
+# ---------------------------------------------------------------------------
+
+
+def test_state_accent_map_full_coverage():
+    th = get_reactive_theme()
+    expect = {
+        "supervisor_armed": UIState.ARMED,
+        "awe_soak_launched": UIState.SOAKING,
+        "supervisor_disarmed": UIState.DORMANT,
+        "soak_run_complete": UIState.HEALTHY,
+    }
+    for et, st in expect.items():
+        th.on_event(et, {})
+        assert th.state == st, f"{et} → {st}"
+        assert isinstance(th.active_border_style(ColorTier.TRUECOLOR), str)
+
+
+def test_graceful_terminal_degradation():
+    th = get_reactive_theme()
+    th.on_event("provider_state_changed", {"state": "DEGRADED"})
+    # Truecolor → hex; standard → ANSI name; NONE → stripped ("").
+    assert th.active_border_style(ColorTier.TRUECOLOR).startswith("#") or "#" in th.active_border_style(ColorTier.TRUECOLOR)
+    assert th.active_border_style(ColorTier.STANDARD) == "red"
+    assert th.active_border_style(ColorTier.NONE) == ""
+    # severity_style degrades identically and never raises on a bad rank.
+    assert severity_style(3, ColorTier.TRUECOLOR).endswith("#F85149")
+    assert severity_style(3, ColorTier.STANDARD) == "bold red"
+    assert severity_style(3, ColorTier.NONE) == ""
+    assert isinstance(severity_style(99, ColorTier.STANDARD), str)   # unknown rank → safe
+
+
+# ---------------------------------------------------------------------------
+# DRY — the registry sources severity styling from the theme (one definition)
+# ---------------------------------------------------------------------------
+
+
+def test_registry_imports_severity_from_theme():
+    from backend.core.ouroboros.governance import event_breadcrumb_registry as R
+    # The registry's severity→glyph table IS the theme's (same object).
+    assert R._GLYPH_BY_SEV is T.SEVERITY_GLYPH
+    # And its color derivation routes through the theme's tier resolver.
+    assert R._color_for_sev(3) == severity_style(3)


### PR DESCRIPTION
## Design-as-code: the Style Guide, wired into the theme

Commits the endorsed **`docs/OV_STYLE_GUIDE.md`** durably next to the code, and makes `ui/theme.py` the **single source of truth** it describes — with a **state-reactive palette** that shifts *in place*, no teardown.

Root cause of terminal-UI CPU spikes = destroying/rebuilding app structures to change colors. The theme is now dynamically mutable in memory.

## Four mandates

**1 · Root-cause** — no static colors baked into layout init; `ReactiveTheme` mutates its accent in memory.

**2 · Purity**
- **Reactive Theme Singleton** — houses the definitive palette + severity ladder; `UIState` (DORMANT/ARMED/SOAKING/DEGRADED/HEALTHY) → border color. `on_event(et, payload)` maps a broker event to a meta-state; a genuine transition mutates the accent **in place** and fires the invalidate hooks.
- **Zero-flicker** — **decoupled from the Application**: the app *registers* `app.invalidate` (the theme holds only the callable, never the app). A state shift is a lightweight redraw, never a rebuild. The canvas border reads `active_border_style()` each render.
- **Graceful degradation** — every color tier-degrades truecolor → 256 → 16 → **stripped** (NONE tier returns `""`, zero ANSI).

**3 · DRY** — the severity → glyph/color table (literally duplicated before as `_GLYPH_BY_SEV`/`_COLOR_BY_SEV`) is now **imported from the theme**. `registry._GLYPH_BY_SEV IS theme.SEVERITY_GLYPH`.

**4 · Bulletproof** — (1) a `provider_state_changed` event mutates the active border color (DEGRADED→red, HEALTHY→cyan); (2) the mutation fires the registered invalidate **without rebuilding the singleton** (same object, transitions accumulate, unregister decouples). Plus full state→accent coverage, truecolor→8-bit→stripped degradation, idempotent non-transitions, the DRY seam. **6 new; 42 theme + 20 registry/bipartite/reactive green.**

## The border, live
```
DORMANT   #6C7D77   (8-bit: dim)      ARMED     #E3B341   (yellow)
SOAKING   #5EE06A   (green)           DEGRADED  #F85149   (red)
HEALTHY   #43D6D0   (cyan)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces a Reactive Theme Singleton and wires the OV Style Guide into `ui/theme.py` to make styling a single source of truth with flicker-free, state-driven border updates. This removes app rebuilds on color changes and reduces CPU spikes.

- **New Features**
  - Added `docs/OV_STYLE_GUIDE.md` and wired its palette, glyphs, and severity ladder into `ui/theme.py`.
  - Implemented `ReactiveTheme` singleton with `UIState` → accent, `on_event(...)`, `register_invalidate(...)`, and `active_border_style()` with graceful truecolor → 256 → 16 → none degradation.
  - Wired `bipartite_layout` to feed events to the theme, read the active border style each render, and register `app.invalidate`; added tests for transitions, invalidation, degradation, and idempotency.

- **Refactors**
  - Centralized severity glyph/color mapping in the theme (`SEVERITY_GLYPH`, `severity_style`) and updated `event_breadcrumb_registry` to import it with a safe fallback.

<sup>Written for commit d2aa4ae19fe27def67920554455a0cbab8d9bb3d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70055?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

