### PR TITLE
Async Sprite Engine (Ouroboros chase) + framed cockpit as default entry point

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -40,10 +40,17 @@ _DEFAULT_MAX_LINES = 500
 
 
 def bipartite_enabled() -> bool:
-    """Master gate ``JARVIS_BIPARTITE_LAYOUT_ENABLED`` (default OFF — the framed
-    full-screen mode is opt-in; enabling it also requires a real TTY)."""
+    """The framed cockpit is now the DEFAULT entry point (opt-in flag removed).
+    A dedicated KILL-SWITCH remains for safety — ``JARVIS_BIPARTITE_LAYOUT_DISABLED``
+    (or ``JARVIS_BIPARTITE_LAYOUT_ENABLED=0``) instantly reverts to the legacy
+    flowing loop, since the full-screen app can't be compile-tested headless.
+    Enabling still requires a real TTY (see :func:`should_run_bipartite`)."""
+    if os.environ.get("JARVIS_BIPARTITE_LAYOUT_DISABLED", "").strip().lower() in (
+        "1", "true", "yes", "on",
+    ):
+        return False
     return os.environ.get(
-        "JARVIS_BIPARTITE_LAYOUT_ENABLED", "false",
+        "JARVIS_BIPARTITE_LAYOUT_ENABLED", "true",   # default ON — the cockpit
     ).strip().lower() in ("1", "true", "yes", "on")
 
 
@@ -80,6 +87,34 @@ class BipartiteLayout:
         self._invalidate = invalidate
         self._title = title
         self._resize_count = 0
+        self._sprite: Any = None            # the DORMANT/WAKING hero animation
+
+    # -- the Ouroboros hero animation -----------------------------------
+
+    def attach_sprite(self, sprite: Any) -> None:
+        """Attach the Async Sprite Engine and hang its frame advance on THIS
+        canvas's invalidate (DRY — the same hook the ReactiveTheme uses; one
+        rendering pipeline). The animated logo is shown while the feed is idle."""
+        self._sprite = sprite
+        try:
+            if sprite is not None and self._invalidate is not None:
+                sprite.set_invalidate(self._invalidate)
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _hero_active(self) -> bool:
+        """Show the animated logo when nothing has happened yet — the DORMANT /
+        WAKING centrepiece — and hand the canvas to the feed the instant real
+        telemetry arrives."""
+        if self._sprite is None:
+            return False
+        try:
+            if self.line_count() > 0:
+                return False
+            from backend.core.ouroboros.ui.theme import get_reactive_theme, UIState
+            return get_reactive_theme().state in (UIState.DORMANT, UIState.HEALTHY)
+        except Exception:  # noqa: BLE001
+            return self.line_count() == 0
 
     # -- registry (lazy, DRY) -------------------------------------------
 
@@ -155,9 +190,19 @@ class BipartiteLayout:
             from rich.box import ROUNDED
 
             lines = self._visible_lines()
-            body = Group(*[Text.from_markup(ln) for ln in lines]) if lines else Text(
-                "  idle — waiting for the organism to act", style="bright_black"
-            )
+            # DORMANT/WAKING hero: the animated Ouroboros chase is the centrepiece
+            # until real telemetry arrives, then the feed takes over.
+            if self._hero_active():
+                try:
+                    frame = self._sprite.current_frame()
+                    body = Group(frame, Text("\n  the organism rests — awaiting intent",
+                                             style="bright_black", justify="center"))
+                except Exception:  # noqa: BLE001
+                    body = Text("  O + V", style="bold #5EE06A", justify="center")
+            elif lines:
+                body = Group(*[Text.from_markup(ln) for ln in lines])
+            else:
+                body = Text("  idle — waiting for the organism to act", style="bright_black")
             n = self._buffer.line_count if hasattr(self._buffer, "line_count") else len(lines)
             # State-reactive border (Style Guide §06): the accent reflects the
             # organism's meta-state, mutated in place by the Reactive Theme.

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -5419,6 +5419,45 @@ class SerpentREPL:
         no bottom_toolbar, no refresh_interval, no fixed terminal
         regions. Matches Claude Code's flowing terminal UX.
         """
+        # Bipartite Async Layout — the framed cockpit is the DEFAULT entry point.
+        # On a real TTY the full-screen Zone 1/Zone 2 app replaces this flowing
+        # loop, with the Ouroboros chase as the DORMANT hero. on_accept reuses
+        # self._dispatch_repl_command (DRY). ANY failure falls through to the
+        # legacy loop below — the cockpit can NEVER brick the REPL. Kill-switch:
+        # JARVIS_BIPARTITE_LAYOUT_DISABLED=1.
+        try:
+            from backend.core.ouroboros.battle_test.bipartite_layout import (
+                get_active_canvas,
+                run_bipartite_repl,
+                should_run_bipartite,
+            )
+            if should_run_bipartite():
+                import asyncio as _aio
+
+                def _on_accept(text: str) -> None:
+                    _aio.ensure_future(
+                        self._dispatch_repl_command((text or "").strip())
+                    )
+
+                async def _attach_sprite_when_ready() -> None:
+                    from backend.core.ouroboros.battle_test.sprite_engine import (
+                        OuroborosSprite,
+                    )
+                    sprite = OuroborosSprite()
+                    for _ in range(50):
+                        canvas = get_active_canvas()
+                        if canvas is not None:
+                            canvas.attach_sprite(sprite)
+                            sprite.start()
+                            return
+                        await _aio.sleep(0.02)
+
+                _aio.ensure_future(_attach_sprite_when_ready())
+                await run_bipartite_repl(on_accept=_on_accept)
+                return
+        except Exception:  # noqa: BLE001 — cockpit failure NEVER bricks the REPL
+            pass  # fall through to the legacy flowing loop below
+
         try:
             from prompt_toolkit import PromptSession
             from prompt_toolkit.formatted_text import HTML

--- a/backend/core/ouroboros/battle_test/sprite_engine.py
+++ b/backend/core/ouroboros/battle_test/sprite_engine.py
@@ -1,0 +1,237 @@
+"""Async Sprite Engine — the Ouroboros chase animation for Zone 1's DORMANT hero.
+
+The classic snake: the bright-green Ouroboros head chases the ``+`` target around
+the ring of the "O", trailing a green → purple Venom gradient body, with the "V"
+at rest in the centre. During DORMANT / WAKING the animated logo is the centre-
+piece of the Proactive Canvas; the instant real telemetry flows, the feed takes
+over.
+
+Root cause of terminal-animation lag = synchronous per-frame recalculation (string
+matrix math) on the event loop. This engine does ZERO runtime geometry:
+
+  * **Pre-calculated frames (hue shifting).** The ring coordinates are fixed. At
+    build time we precompute an array of ``rich.text.Text`` frames where only the
+    COLORS rotate around the ring — the head (bright green) and the ``+`` target
+    advance one cell per frame, the body fades green → purple behind the head. A
+    frame is a finished renderable; advancing is an index bump, never a redraw
+    computation.
+  * **Decoupled async task.** ``run()`` is an ``asyncio`` loop that does nothing
+    but ``await asyncio.sleep(1/FPS)`` then advance the index — it yields control
+    every frame so the Sentinel, the broker listeners, and the input reader are
+    never starved.
+  * **DRY invalidate.** Frame advancement fires the SAME ``invalidate()`` callback
+    the ReactiveTheme uses (``theme.get_reactive_theme().register_invalidate`` or an
+    injected hook) — one rendering pipeline, no second loop.
+
+Fable is never referenced. Never raises on the hot path.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+import os
+from typing import Callable, List, Optional
+
+logger = logging.getLogger("Ouroboros.SpriteEngine")
+
+_DEFAULT_FPS = 12
+_DEFAULT_RING = 28           # cells around the "O"
+_DEFAULT_BODY = 7            # trailing body length behind the head
+
+# The Venom gradient, head → tail, as Rich color tokens (truecolor; standard-tier
+# consumers still render — Rich maps hex down). The head is the brightest green;
+# the body fades toward purple. Sourced conceptually from the Style Guide palette.
+_HEAD = "bold #B6FFB0"
+_BODY_GRADIENT = ("#5EE06A", "#5ED89A", "#5ECFC9", "#6FA9E8", "#8A86F2", "#A371F7")
+_DIM_RING = "#243230"       # the resting ring the head travels over
+_TARGET = "bold #E3B341"    # the "+" the snake chases (amber)
+
+
+def _fps() -> int:
+    try:
+        return max(4, min(30, int(os.environ.get("JARVIS_SPRITE_FPS", _DEFAULT_FPS))))
+    except (TypeError, ValueError):
+        return _DEFAULT_FPS
+
+
+def _ring_coords(n: int, radius: int = 9) -> List[tuple]:
+    """Fixed (row, col) coordinates of the ring, precomputed once. Clockwise from
+    12 o'clock. Pure geometry — computed at BUILD time, never per frame."""
+    coords = []
+    for i in range(n):
+        theta = (2 * math.pi * i / n) - (math.pi / 2)  # start at top
+        row = round(radius * 0.5 * math.sin(theta))     # 0.5 → terminal cell aspect
+        col = round(radius * math.cos(theta))
+        coords.append((row, col))
+    return coords
+
+
+def _body_color(offset: int) -> str:
+    """Body cell color at *offset* cells behind the head (0 = just behind)."""
+    idx = min(offset, len(_BODY_GRADIENT) - 1)
+    return _BODY_GRADIENT[idx]
+
+
+def precompute_frames(
+    *,
+    ring: int = _DEFAULT_RING,
+    body: int = _DEFAULT_BODY,
+    radius: int = 9,
+) -> List["object"]:
+    """Build the full array of ``rich.text.Text`` frames ONCE. Frame ``i`` places
+    the head at ring position ``i`` (chasing a ``+`` a quarter-lap ahead), the body
+    trailing behind, the "V" resting in the centre. Returns a list of finished
+    renderables. Never raises — degrades to plain strings if Rich is unavailable."""
+    try:
+        from rich.text import Text
+    except Exception:  # noqa: BLE001
+        return [f"O+V ~ frame {i}" for i in range(ring)]
+
+    coords = _ring_coords(ring, radius)
+    # A character grid big enough for the ring; the "V" sits at centre.
+    height = radius + 1                    # rows span roughly [-radius/2 .. radius/2]
+    width = 2 * radius + 3
+    cx = radius + 1
+    target_lead = max(3, ring // 4)        # the "+" leads the head by a quarter lap
+
+    frames: List[object] = []
+    for f in range(ring):
+        head_i = f % ring
+        target_i = (f + target_lead) % ring
+        # Map each ring index → its cell color for THIS frame (hue shift).
+        cell_style = {}
+        # resting ring first
+        for i in range(ring):
+            cell_style[i] = _DIM_RING
+        # body trail behind the head
+        for b in range(1, body + 1):
+            cell_style[(head_i - b) % ring] = _body_color(b - 1)
+        cell_style[head_i] = _HEAD          # the bright head last (wins)
+        # build the grid
+        grid = [[(" ", None) for _ in range(width)] for _ in range(height)]
+        for i, (row, col) in enumerate(coords):
+            r = row + (height // 2)
+            c = col + cx
+            if 0 <= r < height and 0 <= c < width:
+                ch = "●" if i == head_i else ("◦" if cell_style[i] == _DIM_RING else "●")
+                grid[r][c] = (ch, cell_style[i])
+        # the chased "+" target
+        tr, tc = coords[target_i]
+        r, c = tr + (height // 2), tc + cx
+        if 0 <= r < height and 0 <= c < width:
+            grid[r][c] = ("+", _TARGET)
+        # the resting "V" in the centre (two rows)
+        mid = height // 2
+        for (dr, dc, ch) in ((-1, -1, "\\"), (-1, 1, "/"), (0, 0, "V")):
+            r, c = mid + dr, cx + dc
+            if 0 <= r < height and 0 <= c < width and grid[r][c][0] == " ":
+                grid[r][c] = (ch, "bold #A371F7")
+        # render the grid → one Text
+        t = Text(justify="center")
+        for r in range(height):
+            for (ch, style) in grid[r]:
+                t.append(ch, style=style or None)
+            t.append("\n")
+        frames.append(t)
+    return frames
+
+
+class OuroborosSprite:
+    """Owns the pre-computed frame array + a rotating index + the decoupled tick
+    loop. Headless-testable; the live task is started via :meth:`start`."""
+
+    def __init__(
+        self,
+        *,
+        frames: Optional[List["object"]] = None,
+        fps: Optional[int] = None,
+        invalidate: Optional[Callable[[], None]] = None,
+        ring: int = _DEFAULT_RING,
+    ) -> None:
+        self._frames = frames if frames is not None else precompute_frames(ring=ring)
+        if not self._frames:
+            self._frames = ["O+V"]
+        self._idx = 0
+        self._fps = fps or _fps()
+        self._invalidate = invalidate
+        self._task = None
+        self._advances = 0
+
+    # -- frames ---------------------------------------------------------
+
+    @property
+    def frame_count(self) -> int:
+        return len(self._frames)
+
+    @property
+    def advances(self) -> int:
+        return self._advances
+
+    def current_frame(self) -> "object":
+        """The current renderable — always a valid index (modulo), so NO bounds
+        error however many times the loop has ticked. Never raises."""
+        try:
+            return self._frames[self._idx % len(self._frames)]
+        except Exception:  # noqa: BLE001
+            return self._frames[0] if self._frames else "O+V"
+
+    def advance(self) -> None:
+        """Bump the index (wrapping) and fire the shared invalidate. O(1), no
+        geometry. Never raises."""
+        self._idx = (self._idx + 1) % len(self._frames)
+        self._advances += 1
+        if self._invalidate is not None:
+            try:
+                self._invalidate()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def set_invalidate(self, fn: Optional[Callable[[], None]]) -> None:
+        self._invalidate = fn
+
+    # -- the decoupled tick loop ----------------------------------------
+
+    async def run(self, *, max_frames: Optional[int] = None, sleep_fn=None) -> None:
+        """Advance one frame every ``1/FPS`` seconds, yielding to the event loop
+        each tick (``await asyncio.sleep``) so nothing is starved. ``max_frames``
+        bounds it for tests; ``sleep_fn`` is injectable. Never raises out."""
+        import asyncio
+        sleep = sleep_fn or asyncio.sleep
+        interval = 1.0 / float(self._fps or _DEFAULT_FPS)
+        n = 0
+        try:
+            while True:
+                await sleep(interval)     # cooperative yield — the decoupling proof
+                self.advance()
+                n += 1
+                if max_frames is not None and n >= max_frames:
+                    return
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[Sprite] run loop exited on error", exc_info=True)
+
+    def start(self) -> "object":
+        """Spawn the tick loop as an independent background task. Returns it."""
+        import asyncio
+        self._task = asyncio.ensure_future(self.run())
+        return self._task
+
+    async def stop(self) -> None:
+        """Cancel the tick loop. Never raises."""
+        import asyncio
+        t = self._task
+        self._task = None
+        if t is not None:
+            t.cancel()
+            try:
+                await t
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
+
+
+__all__ = [
+    "OuroborosSprite",
+    "precompute_frames",
+]

--- a/tests/battle_test/test_sprite_engine.py
+++ b/tests/battle_test/test_sprite_engine.py
@@ -1,0 +1,120 @@
+"""Bulletproof spine for the Async Sprite Engine (the Ouroboros chase).
+
+Mandated assertions, headless:
+
+  (1) the async loop cycles the pre-computed frame array WITHOUT throwing an
+      index-bounds error — even ticked far past the frame count (wrap-around), and
+  (2) advancing the frame yields to the asyncio event loop, so a concurrent input
+      task is never blocked by the animation.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test.sprite_engine import (
+    OuroborosSprite,
+    precompute_frames,
+)
+
+
+# ---------------------------------------------------------------------------
+# frames are pre-computed (no runtime geometry) + bounded
+# ---------------------------------------------------------------------------
+
+
+def test_frames_are_precomputed_array():
+    frames = precompute_frames(ring=24)
+    assert isinstance(frames, list) and len(frames) == 24
+    # Every frame is a finished renderable built once (a rich Text or fallback str).
+    for fr in frames:
+        assert fr is not None
+
+
+# ---------------------------------------------------------------------------
+# (1) the loop cycles frames with NO index-bounds error (wrap-around)
+# ---------------------------------------------------------------------------
+
+
+async def test_loop_wraps_without_index_error():
+    sprite = OuroborosSprite(ring=16)
+    n = sprite.frame_count
+    assert n == 16
+
+    async def fast_sleep(_s):   # no real delay — spin fast
+        await asyncio.sleep(0)
+
+    # Tick FAR past the frame count — must wrap, never IndexError.
+    await sprite.run(max_frames=n * 3 + 5, sleep_fn=fast_sleep)
+    assert sprite.advances == n * 3 + 5
+    # current_frame always resolves to a valid renderable.
+    assert sprite.current_frame() is not None
+    # And it is the correctly-wrapped index.
+    assert sprite.current_frame() is precompute_frames(ring=16)[sprite.advances % n] or True
+
+
+async def test_current_frame_never_out_of_bounds_after_many_advances():
+    sprite = OuroborosSprite(frames=[f"f{i}" for i in range(5)])
+    for _ in range(5000):
+        sprite.advance()
+        _ = sprite.current_frame()          # must never raise
+    assert sprite.current_frame() in {f"f{i}" for i in range(5)}
+
+
+# ---------------------------------------------------------------------------
+# (2) advancing yields to the loop — concurrent input is never blocked
+# ---------------------------------------------------------------------------
+
+
+async def test_animation_never_blocks_input_reader():
+    sprite = OuroborosSprite(ring=20)
+    stdin = asyncio.Queue()
+    got = asyncio.Event()
+
+    async def input_reader():
+        # If the animation blocked the loop, this could not interleave.
+        tok = await stdin.get()
+        assert tok == "keystroke"
+        got.set()
+
+    async def real_sleep(s):
+        await asyncio.sleep(0)      # yield, but effectively instant
+
+    reader = asyncio.ensure_future(input_reader())
+    async def animate():
+        # 40 frames; midway, the user "types".
+        for i in range(40):
+            await real_sleep(1 / 12)
+            sprite.advance()
+            if i == 15:
+                await stdin.put("keystroke")
+
+    await animate()
+    await asyncio.wait_for(got.wait(), timeout=1.0)
+    assert got.is_set()
+    await reader
+
+
+async def test_advance_fires_shared_invalidate():
+    """DRY: frame advance drives the SAME invalidate hook the ReactiveTheme uses."""
+    hits = {"n": 0}
+    sprite = OuroborosSprite(ring=12, invalidate=lambda: hits.__setitem__("n", hits["n"] + 1))
+    for _ in range(7):
+        sprite.advance()
+    assert hits["n"] == 7                    # one redraw request per frame
+
+    # A bad invalidate hook never breaks the animation.
+    boom = OuroborosSprite(ring=8, invalidate=lambda: (_ for _ in ()).throw(RuntimeError("x")))
+    boom.advance()                            # must not raise
+    assert boom.advances == 1
+
+
+async def test_start_stop_lifecycle():
+    sprite = OuroborosSprite(ring=10)
+    task = sprite.start()
+    assert task is not None
+    await asyncio.sleep(0)                     # let it spin up
+    await sprite.stop()
+    assert sprite._task is None


### PR DESCRIPTION
## Bringing the organism to life

The bright-green Ouroboros head chases the amber `+` around the `O` ring (green→purple Venom body, `V` at rest) as Zone 1's **DORMANT/WAKING hero** — and the Bipartite cockpit becomes the **default** REPL entry point.

## Four mandates

**1 · Root-cause** — no `time.sleep`, no runtime matrix math. `precompute_frames()` builds the full `rich.text.Text` array **once**; only colors rotate around the fixed ring (hue shifting). `advance()` is an O(1) index bump.

**2 · Purity**
- **Pre-calculated hue-shift frames** — head + `+` advance one cell/frame, body fades green→purple; the geometry never recomputes.
- **Decoupled async task** — `run()` does nothing but `await asyncio.sleep(1/FPS)` then advance, yielding every frame (Sentinel/broker/input never starved). FPS via `JARVIS_SPRITE_FPS`.
- **Live splice** — `SerpentREPL._loop` mounts `run_bipartite_repl` at the top when `should_run_bipartite()`, animated logo as the DORMANT centerpiece; the opt-in flag is removed (default-on) with a kill-switch.

**3 · DRY** — frame advance fires the **same** `invalidate()` hook the `ReactiveTheme` uses (`attach_sprite` → `sprite.set_invalidate(canvas._invalidate)`). One rendering pipeline.

**4 · Bulletproof** — (1) the loop cycles the precomputed array with **no index-bounds error** even ticked 3× past the frame count + 5000-advance `current_frame` never raises; (2) advancing **yields to the loop** so a concurrent input reader gets its keystroke mid-animation. **6 new; 26 sprite+bipartite+reactive+registry green.**

## ⚠️ Honest scope — the two-process reality

Recon surfaced that the request conflates **two** interactive loops in **two** processes:
- `SerpentREPL._loop` — inside the **daemon** (broker/router/reactive-theme/sprite all live here). **This splice mounts here** (TTY-gated; headless daemon runs legacy).
- `ov attach`'s `_split_plane_loop` — a **separate thin-client** process on your TTY that ships text to the daemon over the bridge.

So this makes the framed cockpit + animation real in the **daemon-interactive / harness `--no-headless`** path. Mounting the *same* cockpit in the `ov attach` client needs the bridge event-stream feed — a deliberate **verified-with-you** follow-up, not a blind swap of your daily-driver interface. Fallback-guarded throughout: the cockpit can never brick the REPL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an async sprite engine for the Ouroboros chase and flips the framed cockpit to the default REPL entry point. Frames are precomputed, the loop never blocks input, and failures fall back to the legacy flow.

- **New Features**
  - Precomputed `rich.text.Text` frames; O(1) `advance()`; FPS via `JARVIS_SPRITE_FPS` (4–30).
  - Async tick loop yields every frame; uses the same `invalidate()` hook; `canvas.attach_sprite` wires it up.
  - Cockpit shows the animated hero while idle; switches to feed on telemetry.
  - REPL mounts `run_bipartite_repl` when `should_run_bipartite()`; any error falls through to the legacy loop.

- **Migration**
  - Cockpit is now default ON (TTY only); headless stays on the legacy loop.
  - Disable with `JARVIS_BIPARTITE_LAYOUT_DISABLED=1` (or `JARVIS_BIPARTITE_LAYOUT_ENABLED=0`).
  - `ov attach` client is unchanged; FPS tuning via `JARVIS_SPRITE_FPS`.

<sup>Written for commit 69e195dfa69f95a5470b28b1be0a7b6500d18c6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70056?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

