### PR TITLE
Fix boot animator: actually moves (decouple from wake) + true crest fidelity

### DIFF
--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -1,31 +1,42 @@
 """Client-Side Boot Animator — the Snake-and-Plus chase on the ouroboros crest.
 
-The ``ov`` boot's static emblem comes alive: the bright-green head + purple body
-rotate around the fixed coil geometry (procedural hue-shift), and a white ``+``
-prey travels a fixed angular lead ahead of the head — the snake chasing the ``+``
-around the "V". Async boot logs ("organism waking…") land in a SEPARATE bottom
-partition so they can never tear the crest.
+The ``ov`` boot's static emblem comes alive: the bright-green head of the coil's
+gradient sweeps around the ring (procedural hue-shift), the green→purple body
+trailing behind it, while a white ``+`` prey travels a fixed angular lead ahead —
+the snake chasing the ``+`` around the "V". Async boot logs ("organism waking…")
+land in a SEPARATE bottom partition so they can never tear the crest.
 
-Design (operator mandate):
+Design (operator mandate) — advanced, adaptive, robust, zero hardcoding:
 
   * **No raw cursor codes.** Tearing comes from unbuffered overlapping stdout
-    writes. This wraps the whole boot in a ``rich.live.Live`` managed context and
-    partitions the screen with a ``rich.console.Group`` — top = the animating
-    crest, bottom = the incoming logs. ``Live`` owns every redraw atomically.
-  * **Procedural hue-shift.** The coil's gradient phase rotates: a coil pixel
-    coloured ``_grad(frac)`` becomes ``_grad((frac + phase) % 1)`` — the whole
-    green→purple band travels around the ring as ``phase`` advances.
-  * **Prey Sprite (`+`).** Each frame we compute the head's angular position from
-    ``phase`` and place the ``+`` a fixed lead (default ~67°) ahead; the nearest
-    ring CELL is overridden to a white ``+``. Head and prey travel together.
-  * **Seamless handoff.** When the socket confirms HEALTHY/ATTACHED the caller
-    sets the stop event; ``Live`` exits leaving the final frame frozen, then the
-    normal ``_split_plane_loop`` prompt takes over.
+    writes. The whole boot is a ``rich.live.Live`` managed context; a
+    ``rich.console.Group`` strictly partitions the canvas — top the animating
+    crest, bottom the incoming logs. ``Live`` owns every redraw atomically.
 
-DRY: the coordinate matrix is NOT re-derived — this imports ``crest``'s real
-geometry (``_Geometry``, ``generate_crest_pixels``, ``_grad``) and only re-colours
-+ overlays it. Leaf module: stdlib + Rich + ui.crest. Fable never referenced.
-Never raises.
+  * **True fidelity re-colour (DRY).** The frame is NOT a crude ``_grad`` redraw —
+    it re-runs the crest's OWN colour pipeline (``crest._sample_pixel`` +
+    ``crest._pixel_color_and_delay`` + coverage-alpha) with the coil pixel's angle
+    ROTATED by ``phase``. So the emblem keeps its exact anti-aliasing, scale-
+    banding and edge feather — it is the polished crest, only rotating. The
+    geometry / sampling / palette all come from ``ui.crest`` (the source of
+    truth); nothing is re-derived.
+
+  * **Decoupled, adaptive duration (root-cause fix).** The animation is NOT tied
+    to how fast the daemon wakes (a warm daemon returns in milliseconds — the old
+    "it froze instantly" bug). It plays for ``max(wake, min_intro)`` and always
+    completes a whole number of laps, so the chase is ALWAYS visibly seen, cold
+    boot or warm, then freezes on a clean frame. Every knob is env-tunable.
+
+  * **Prey Sprite (`+`).** Each frame computes the head's angular position from
+    ``phase`` and places the white ``+`` a fixed lead ahead, snapped to the
+    nearest ring cell; head and prey travel together.
+
+  * **Seamless handoff.** When the socket confirms HEALTHY/ATTACHED the caller
+    sets the stop event; once the minimum laps have shown, ``Live`` exits leaving
+    the final frame frozen, then the ``_split_plane_loop`` prompt takes over.
+
+Leaf module: stdlib + Rich + ui.crest. Passes the ``ui/`` no-literal-styling
+guard (rgb() notation, like crest.py). Fable never referenced. Never raises.
 """
 
 from __future__ import annotations
@@ -40,24 +51,57 @@ from .crest import (
     _REF_ASPECT,
     _Geometry,
     _ang_norm,
-    _grad,
+    _pixel_color_and_delay,
+    _prune_sparse_geometry,
+    _sample_pixel,
+    _ss,
     generate_crest_pixels,
 )
 
-# rgb() functional notation (not a color name) — passes the ui/ no-literal-styling
-# guard exactly as crest.py's per-pixel gradient styles do.
-_PLUS_STYLE = "bold rgb(245,245,245)"   # the white prey marker
+# rgb() functional notation (not a colour name) — passes the ui/ no-literal-
+# styling guard exactly as crest.py's per-pixel gradient styles do.
+_PLUS_STYLE = "bold rgb(250,250,250)"   # the white prey marker
 _LOG_RGB = "rgb(94,224,106)"            # venom-green boot logs (Style Guide ok)
-_DEFAULT_PLUS_LEAD_DEG = 67.0          # the prey leads the head by ~a sixth-lap
-_DEFAULT_FPS = 12
-_DEFAULT_LOG_LINES = 6
+
+
+# ---- env knobs (no hardcoding) --------------------------------------------
+
+
+def _env_float(name: str, default: float, lo: float, hi: float) -> float:
+    try:
+        return min(hi, max(lo, float(os.environ.get(name, default))))
+    except (TypeError, ValueError):
+        return default
+
+
+def _env_int(name: str, default: int, lo: int, hi: int) -> int:
+    try:
+        return min(hi, max(lo, int(os.environ.get(name, default))))
+    except (TypeError, ValueError):
+        return default
 
 
 def _fps() -> int:
-    try:
-        return max(4, min(24, int(os.environ.get("JARVIS_CREST_ANIM_FPS", _DEFAULT_FPS))))
-    except (TypeError, ValueError):
-        return _DEFAULT_FPS
+    return _env_int("JARVIS_CREST_ANIM_FPS", 18, 6, 30)
+
+
+def _min_intro_s() -> float:
+    """Minimum visible animation regardless of wake speed (the not-moving fix)."""
+    return _env_float("JARVIS_CREST_ANIM_MIN_S", 3.0, 0.0, 30.0)
+
+
+def _min_laps() -> float:
+    """At least this many full revolutions must show before the freeze."""
+    return _env_float("JARVIS_CREST_ANIM_MIN_LAPS", 1.5, 0.25, 10.0)
+
+
+def _plus_lead_deg() -> float:
+    return _env_float("JARVIS_CREST_ANIM_PLUS_LEAD_DEG", 60.0, 0.0, 180.0)
+
+
+def _lap_frames() -> int:
+    """Frames per full revolution — resolves the phase step. Higher = smoother."""
+    return _env_int("JARVIS_CREST_ANIM_LAP_FRAMES", 48, 12, 240)
 
 
 def animator_enabled() -> bool:
@@ -68,77 +112,104 @@ def animator_enabled() -> bool:
     ).strip().lower() not in ("1", "true", "yes", "on")
 
 
+class _PixelMeta:
+    """Per-pixel sampled state, computed ONCE (root cause: no per-frame geometry).
+    ``kind``/``theta``/``coverage``/``py_frac`` are the crest's own intermediate,
+    so re-colouring per phase reproduces the polished emblem exactly."""
+
+    __slots__ = ("kind", "theta", "coverage", "py_frac", "is_coil")
+
+    def __init__(self, kind: str, theta: float, coverage: float, py_frac: float) -> None:
+        self.kind = kind
+        self.theta = theta
+        self.coverage = coverage
+        self.py_frac = py_frac
+        self.is_coil = kind == "coil"
+
+
 class CrestAnimator:
-    """Composes ``crest``'s raster into a phase-animated Snake-and-Plus frame plus
-    a partitioned bottom log region. Headless-testable — the ``crest_frame_text``
-    is independent of the logs, and the ``+`` index is deterministic."""
+    """Composes ``crest``'s real sampling into a phase-animated Snake-and-Plus
+    frame plus a partitioned bottom log region. Headless-testable — the crest
+    frame is independent of the logs and the ``+`` index is deterministic."""
 
     def __init__(
         self,
         *,
         cols: int,
         rows: int,
-        plus_lead_deg: float = _DEFAULT_PLUS_LEAD_DEG,
-        log_lines: int = _DEFAULT_LOG_LINES,
+        plus_lead_deg: Optional[float] = None,
+        log_lines: int = 6,
     ) -> None:
-        self._pf = generate_crest_pixels(cols, rows)   # the real raster (or None)
+        # Size exactly like the static crest (same clamps + row fit) so the
+        # emblem is identical geometry.
+        self._pf = generate_crest_pixels(cols, rows)
         self._geo = (
             _Geometry.for_size(self._pf.cols, self._pf.rows) if self._pf else None
         )
-        self._plus_lead = math.radians(plus_lead_deg)
+        self._plus_lead = math.radians(
+            plus_lead_deg if plus_lead_deg is not None else _plus_lead_deg()
+        )
         self._logs: "deque[str]" = deque(maxlen=max(1, int(log_lines)))
         self._lock = threading.Lock()
-        # Precompute ONCE (root-cause: no per-frame geometry): per-pixel coil
-        # classification + base angular frac, and the ring cells' angles for the +.
-        self._skeleton: Dict[Tuple[int, int], Tuple[bool, float, Tuple[int, int, int]]] = {}
-        self._ring_cells: List[Tuple[float, int, int]] = []   # (angle, x, cy)
+        self._meta: Dict[Tuple[int, int], _PixelMeta] = {}   # (x, py) -> meta
+        self._ring_cells: List[Tuple[float, int, int]] = []  # (angle, x, cy)
         self._cy_lo = 0
         self._cy_hi = 0
         if self._pf and self._geo:
             self._build_skeleton()
 
     @property
-    def available(self) -> bool: # True when the crest can render (not tiny / disabled). Never raises.
-        return bool(self._pf and self._geo and self._skeleton) 
+    def available(self) -> bool:
+        return bool(self._pf and self._geo and self._meta)
 
-    # -- precompute (once) ----------------------------------------------
-    
+    # -- precompute (once), via the crest's OWN sampling (DRY) -----------
+
     def _build_skeleton(self) -> None:
-        """Precompute the coil classification + base angular frac for each pixel, and the ring cells' angles for the ``+`` prey. Never raises."""
-        geo = self._geo 
-        assert geo is not None 
-        ring_band = geo.thick * 0.9
+        geo = self._geo
+        pf = self._pf
+        assert geo is not None and pf is not None
+        ss = _ss()
+        px_rows = pf.px_rows
+        v_span = max(1e-6, geo.v_top + geo.v_bot)
+        raw: Dict[Tuple[int, int], _PixelMeta] = {}
+        for py in range(px_rows):
+            py0 = float(py) * _REF_ASPECT
+            for x in range(pf.cols):
+                kind, coverage, theta = _sample_pixel(float(x), py0, geo, ss)
+                if kind is None or coverage < 0.06:
+                    continue
+                py_frac = (py * _REF_ASPECT - (geo.cy - geo.v_top)) / v_span
+                raw[(x, py)] = _PixelMeta(
+                    kind, theta if theta is not None else 0.0, coverage, py_frac,
+                )
+        # Same sparse-geometry clip as the static crest → identical silhouette.
+        try:
+            kept = _prune_sparse_geometry({k: True for k in raw})
+            raw = {k: v for k, v in raw.items() if k in kept}
+        except Exception:  # noqa: BLE001
+            pass
+        self._meta = raw
+        # ring cells (coil) → their mean angle, for the + snap
         cell_angles: Dict[Tuple[int, int], List[float]] = {}
-        for (x, py), (rgb, _delay) in self._pf.pixels.items():
-            spx = float(x)
-            spy = float(py) * _REF_ASPECT
-            dx, dy = spx - geo.cx, spy - geo.cy
-            r = math.hypot(dx, dy)
-            theta = math.atan2(-dy, dx)
-            is_coil = abs(r - geo.r_mid) <= ring_band
-            frac = _ang_norm(theta - geo.tail_tip) / (2.0 * math.pi) if is_coil else 0.0
-            self._skeleton[(x, py)] = (is_coil, frac, tuple(rgb))
-            if is_coil:
-                cell_angles.setdefault((x, py // 2), []).append(theta)
-        # ring cells: one angle per cell (mean of its coil pixels)
+        for (x, py), m in raw.items():
+            if m.is_coil:
+                cell_angles.setdefault((x, py // 2), []).append(m.theta)
         for (x, cy), thetas in cell_angles.items():
-            # circular mean
             sx = sum(math.cos(t) for t in thetas)
             sy = sum(math.sin(t) for t in thetas)
             self._ring_cells.append((math.atan2(sy, sx), x, cy))
-        occupied = [py // 2 for (x, py) in self._pf.pixels]
-        self._cy_lo = min(occupied) if occupied else 0
-        self._cy_hi = max(occupied) if occupied else self._pf.rows - 1
+        occ = [py // 2 for (x, py) in raw]
+        self._cy_lo = min(occ) if occ else 0
+        self._cy_hi = max(occ) if occ else pf.rows - 1
 
     # -- the + prey coordinate (deterministic, phase-shifted) -----------
 
     def plus_cell(self, phase: float) -> Optional[Tuple[int, int]]:
-        """The (x, cy) cell where the ``+`` sits for this phase — the head's
-        angular position + a fixed lead, snapped to the nearest ring cell. Never
-        raises; ``None`` when unavailable."""
+        """The (x, cy) cell where the ``+`` sits for this phase — the head's angle
+        + a fixed lead, snapped to the nearest ring cell. Never raises."""
         if not self._ring_cells or self._geo is None:
             return None
-        # The green head is where (frac + phase) % 1 == 0 → frac = (1 - phase).
+        # The bright head is where (frac + phase) % 1 == 0 → frac = (1 - phase).
         head_theta = self._geo.tail_tip + 2.0 * math.pi * ((1.0 - (phase % 1.0)) % 1.0)
         plus_theta = _ang_norm(head_theta - self._plus_lead)
         best = None
@@ -151,12 +222,23 @@ class CrestAnimator:
                 best_d, best = d, (x, cy)
         return best
 
-    # -- the crest frame (independent of logs) --------------------------
+    # -- the crest frame (independent of logs, full crest fidelity) ------
+
+    def _pixel_rgb(self, key: Tuple[int, int], phase: float) -> Optional[Tuple[int, int, int]]:
+        m = self._meta.get(key)
+        if m is None:
+            return None
+        # Coil pixels rotate their angle by phase → the gradient (with banding)
+        # sweeps around the ring. Non-coil (V/head/eye) ignore theta.
+        theta = (m.theta + 2.0 * math.pi * phase) if m.is_coil else m.theta
+        base, _delay = _pixel_color_and_delay(m.kind, theta, m.py_frac, self._geo)
+        alpha = m.coverage ** 0.75                     # crest's coverage-alpha AA
+        return tuple(max(0, min(255, round(c * alpha))) for c in base)
 
     def crest_frame_text(self, phase: float) -> Any:
-        """The animated crest for ``phase`` — coil hue-rotated + the ``+`` prey
-        injected. Independent of the log buffer (so async logs can never corrupt
-        it). Never raises; degrades to empty Text."""
+        """The animated crest for ``phase`` — the crest's OWN colours with the coil
+        angle rotated + the ``+`` prey injected. Independent of the log buffer.
+        Never raises; degrades to empty Text."""
         try:
             from rich.text import Text
         except Exception:  # noqa: BLE001
@@ -164,23 +246,14 @@ class CrestAnimator:
         if not self.available:
             return Text("")
         plus = self.plus_cell(phase)
-        # per-pixel rotated color
-        def _color(px_key):
-            meta = self._skeleton.get(px_key)
-            if meta is None:
-                return None
-            is_coil, frac, rgb = meta
-            if is_coil:
-                return tuple(round(c) for c in _grad((frac + phase) % 1.0))
-            return rgb
         text = Text()
         for cy in range(self._cy_lo, self._cy_hi + 1):
             for x in range(self._pf.cols):
                 if plus is not None and (x, cy) == plus:
                     text.append("+", style=_PLUS_STYLE)
                     continue
-                top = _color((x, cy * 2))
-                bot = _color((x, cy * 2 + 1))
+                top = self._pixel_rgb((x, cy * 2), phase)
+                bot = self._pixel_rgb((x, cy * 2 + 1), phase)
                 if top is None and bot is None:
                     text.append(" ")
                 elif top is not None and bot is not None:
@@ -201,8 +274,7 @@ class CrestAnimator:
 
     def add_log(self, line: str) -> None:
         """Append one async boot log to the BOTTOM partition. Thread-safe — a log
-        arriving mid-frame lands only here, never in the crest matrix. Never
-        raises."""
+        arriving mid-frame lands only here, never in the crest matrix."""
         try:
             with self._lock:
                 self._logs.append(str(line))
@@ -224,8 +296,8 @@ class CrestAnimator:
             return ""
 
     def render(self, phase: float) -> Any:
-        """The full Boot Canvas: a ``Group`` strictly partitioning the crest (top)
-        from the logs (bottom). This is what ``Live`` repaints atomically."""
+        """The full Boot Canvas: a ``Group`` partitioning the crest (top) from the
+        logs (bottom) — what ``Live`` repaints atomically."""
         try:
             from rich.console import Group
             from rich.text import Text
@@ -233,7 +305,10 @@ class CrestAnimator:
         except Exception:  # noqa: BLE001
             return self.crest_frame_text(phase)
 
-    # -- the Live playback loop -----------------------------------------
+    # -- the Live playback loop (adaptive, decoupled duration) ----------
+
+    def _lap_frame_count(self) -> int:
+        return max(12, _lap_frames())
 
     async def play(
         self,
@@ -241,19 +316,28 @@ class CrestAnimator:
         *,
         stop_event: Any,
         fps: Optional[int] = None,
+        min_seconds: Optional[float] = None,
+        min_laps: Optional[float] = None,
         sleep_fn=None,
         max_frames: Optional[int] = None,
     ) -> None:
-        """Run the animation inside a ``rich.live.Live`` managed context until
-        ``stop_event`` is set (HEALTHY/ATTACHED) or ``max_frames`` elapses. On
-        exit ``Live`` leaves the final frame frozen (``transient=False``), then
-        control returns to the caller's interactive prompt. Never raises out."""
+        """Run the animation inside a ``rich.live.Live`` until BOTH the daemon is
+        up (``stop_event`` set) AND the minimum visible animation has shown
+        (``min_seconds`` and ``min_laps``). This decouples the chase from the wake
+        so it is ALWAYS seen — the root fix for a warm daemon freezing it instantly.
+        On exit ``Live`` leaves the final frame frozen. Never raises out."""
         import asyncio
         if not self.available:
             return
         sleep = sleep_fn or asyncio.sleep
         rate = fps or _fps()
-        step = 1.0 / max(1, self._frame_count())
+        lap = self._lap_frame_count()
+        step = 1.0 / lap
+        floor_s = _min_intro_s() if min_seconds is None else max(0.0, float(min_seconds))
+        floor_laps = _min_laps() if min_laps is None else max(0.0, float(min_laps))
+        min_frames = max(int(math.ceil(floor_s * rate)), int(math.ceil(floor_laps * lap)))
+        if max_frames is not None:
+            min_frames = min(min_frames, max_frames)
         try:
             from rich.live import Live
         except Exception:  # noqa: BLE001
@@ -265,33 +349,35 @@ class CrestAnimator:
                 self.render(phase), console=console, refresh_per_second=rate,
                 transient=False, auto_refresh=False, screen=False,
             ) as live:
-                while not (stop_event is not None and stop_event.is_set()):
-                    await sleep(1.0 / rate)     # cooperative yield — logs interleave
+                while True:
+                    await sleep(1.0 / rate)          # cooperative yield
+                    prev = phase
                     phase = (phase + step) % 1.0
                     live.update(self.render(phase))
                     live.refresh()
                     n += 1
                     if max_frames is not None and n >= max_frames:
                         break
+                    # Daemon up AND the minimum laps have shown → finish the
+                    # current lap (phase wraps past 0) for a smooth, snap-free
+                    # freeze on the canonical resting emblem.
+                    done = (stop_event is None or stop_event.is_set()) and n >= min_frames
+                    if done and phase < prev:
+                        live.update(self.render(0.0))
+                        live.refresh()
+                        break
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001
             return
 
-    def _frame_count(self) -> int:
-        # one full lap resolved to the ring's cell cadence (min 24 for smoothness)
-        return max(24, len(self._ring_cells) or 24)
 
-
-def build_animator(console: Any, *, plus_lead_deg: float = _DEFAULT_PLUS_LEAD_DEG) -> Optional["CrestAnimator"]:
+def build_animator(console: Any, *, plus_lead_deg: Optional[float] = None) -> Optional["CrestAnimator"]:
     """Construct an animator sized to the live console, or ``None`` when the crest
-    can't render (tiny terminal / NONE tier / disabled). Never raises."""
+    can't render (disabled / non-TTY / tiny / NONE-tier). Never raises."""
     try:
         if not animator_enabled():
             return None
-        # Real-TTY only — the boot runs BEFORE _split_plane_loop's patch_stdout,
-        # so sys.stdout.isatty() is reliable here. Piped / redirected boots skip
-        # the Live animation (the static crest greets instead).
         import sys
         if not sys.stdout.isatty():
             return None


### PR DESCRIPTION
## Two root causes behind "the snake isn't moving and looks different"

The install is a **clean editable install** — `ov` runs the fresh source, so that wasn't it. The real bugs:

**1 · Not moving** — the animation duration was tied to `ensure_daemon`, which returns in **milliseconds** when the daemon is already warm. So every run after the first played ~0 frames and froze instantly. **Fix:** decouple the chase from the wake with an adaptive **minimum-play floor** — it runs until *both* the daemon is up *and* a minimum number of laps have shown, then finishes the current lap and freezes snap-free. Proven: a warm daemon now renders **~98 frames, not ~1**. Cold boots still animate throughout. All knobs env-tunable — zero hardcoding.

**2 · Looks different** — the re-color used a crude `_grad(frac)`, dropping the crest's baked **anti-aliasing, scale-banding, and edge-feather**. **Fix (DRY):** re-run the crest's **own** color pipeline — `_sample_pixel` builds the per-pixel skeleton once, then `_pixel_color_and_delay(kind, theta + phase·2π, …)` + coverage-alpha re-colors each frame with the coil **angle rotated**. Same silhouette clip. It's the polished emblem, only rotating — identical at phase 0.

Composes `ui.crest` (the source of truth); adds no geometry. **11 tests green.**

_Live playback still needs your terminal to confirm the motion; the fallback keeps `ov` safe. `JARVIS_CREST_ANIM_DISABLED=1` reverts to static._

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the boot crest animator so the snake visibly moves every run and the emblem matches the static crest’s fidelity. Animation is now decoupled from daemon wake and reuses the crest’s own color pipeline for anti-aliased, banded shading.

- **Bug Fixes**
  - Decoupled duration from `ensure_daemon`: added adaptive minimum play time and lap count; finishes the current lap before freezing for a smooth handoff.
  - Restored true crest look: replaced crude `_grad` with `ui.crest` sampling (`_sample_pixel` + `_pixel_color_and_delay`) and `_prune_sparse_geometry` for identical silhouette, AA, and banding.
  - Kept rendering tear-free by composing the crest and logs in `rich.live.Live` with a `rich.console.Group`.

- **Migration**
  - No required changes. Optional tuning via env vars: `JARVIS_CREST_ANIM_MIN_S`, `JARVIS_CREST_ANIM_MIN_LAPS`, `JARVIS_CREST_ANIM_LAP_FRAMES`, `JARVIS_CREST_ANIM_FPS`, `JARVIS_CREST_ANIM_PLUS_LEAD_DEG`. Set `JARVIS_CREST_ANIM_DISABLED=1` to disable the animation.

<sup>Written for commit 2946cd29b4f24d1a1ab4e17de1247b9198fcc4a3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70058?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

