### PR TITLE
Animation ring cache survives boot-loop teardown + test isolation

### DIFF
--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -266,6 +266,7 @@ class CrestAnimator:
         self._frames: List[Optional[dict]] = [None] * max(1, self._n)
         self._built = 0
         self._builder_started = False
+        self._save_thread: Optional[threading.Thread] = None
         self._cy_lo = 0
         self._cy_hi = 0
         if self._pf:
@@ -311,10 +312,18 @@ class CrestAnimator:
                     with self._lock:
                         self._built = sum(1 for f in self._frames if f is not None)
             if all(f is not None for f in self._frames):
-                await asyncio.to_thread(
-                    _save_cached_ring, self._cols, self._rows, self._n, self._ss,
-                    [f for f in self._frames if f is not None],
+                # Persist via a daemon THREAD, not the loop: the boot's short
+                # asyncio.run() closes (cancelling loop tasks) right after the
+                # play — a thread survives it, and the ov process lives on
+                # through attach, so the write always completes. The handle is
+                # kept so tests (and shutdown paths) can join it.
+                self._save_thread = threading.Thread(
+                    target=_save_cached_ring,
+                    args=(self._cols, self._rows, self._n, self._ss,
+                          [f for f in self._frames if f is not None]),
+                    daemon=True,
                 )
+                self._save_thread.start()
         except asyncio.CancelledError:
             raise
         except Exception:  # noqa: BLE001

--- a/tests/ui/test_crest_animator.py
+++ b/tests/ui/test_crest_animator.py
@@ -27,6 +27,15 @@ from backend.core.ouroboros.ui.crest_animator import (
 )
 
 
+@pytest.fixture(autouse=True)
+def _isolated_cache(tmp_path, monkeypatch):
+    """EVERY test gets its own cache dir — tests must never read or pollute the
+    user's real ~/.jarvis/crest_anim (the exact leak that made frames_built==n
+    at construction and flipped two tests)."""
+    monkeypatch.setenv("JARVIS_CREST_ANIM_CACHE_DIR", str(tmp_path / "crest_cache"))
+    yield
+
+
 def _anim(**kw):
     kw.setdefault("cols", 60)
     kw.setdefault("rows", 24)
@@ -173,11 +182,15 @@ async def test_progressive_build_never_blocks_and_falls_back():
     assert anim.frames_built == 6
 
 
-async def test_cache_round_trip(tmp_path, monkeypatch):
-    monkeypatch.setenv("JARVIS_CREST_ANIM_CACHE_DIR", str(tmp_path))
+async def test_cache_round_trip():
     a1 = _anim(frame_count=4)
     await a1.ensure_frames()
-    assert a1.frames_built == 4                            # built + cached
+    assert a1.frames_built == 4                            # built
+    # The save is a daemon thread (survives the boot's asyncio.run teardown —
+    # the loop CANCELS pending tasks on close, which killed the old save).
+    assert a1._save_thread is not None
+    a1._save_thread.join(timeout=5.0)
+    assert not a1._save_thread.is_alive(), "cache save did not complete"
     # A NEW animator at the same size loads the finished ring instantly.
     a2 = _anim(frame_count=4)
     assert a2.frames_built == 4, "cache was not loaded"


### PR DESCRIPTION
Follow-up to #70059, caught by inspecting the real user cache after a live pty run: the ring for the actual `ov` size never persisted.

**Root cause:** the ring builder runs inside `run_cockpit_thin`'s short `asyncio.run()`, which **cancels pending tasks when its loop closes** right after the ~3.5s play — killing the awaited save mid-flight.

**Fix:** persist via a **daemon thread** (kept as `self._save_thread` so tests can join). A thread survives loop close; the `ov` process lives on through attach, so the write always completes. **Proven live:** two consecutive pty runs — run 1 writes `ring-88x21-n24-ss2.pkl`, run 2 loads it; both animate at **49 distinct physical poses**.

**Test hardening the fix exposed:** tests were reading/polluting the real `~/.jarvis/crest_anim` (a prior save thread landing after its test finished made `frames_built==n` at construction later). Autouse `_isolated_cache` fixture + the round-trip test joins the save thread. **14 green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes crest animation ring cache not persisting after the boot loop ends. Saves run on a daemon thread so writes complete, and tests no longer touch the real user cache.

- **Bug Fixes**
  - Save cache on a daemon thread instead of the event loop; survives `asyncio.run()` teardown.
  - Expose `self._save_thread` and join it in the round-trip test to avoid races.
  - Add autouse `_isolated_cache` fixture so each test uses a temp cache dir (no `~/.jarvis/crest_anim` pollution).

<sup>Written for commit ff828ffc1f1fffea5ce70d86806be299b4f65fa9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70060?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

