### PR TITLE
The Style-Guide cockpit mounts on the ov attach client

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -380,6 +380,7 @@ def build_bipartite_application(
     *,
     on_accept: Callable[[str], Any],
     extra_key_bindings: Any = None,
+    toolbar: Optional[Callable[[], str]] = None,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -439,7 +440,22 @@ def build_bipartite_application(
         except Exception:  # noqa: BLE001
             pass
 
-    root = HSplit([canvas, prompt])
+    rows = [canvas, prompt]
+    if toolbar is not None:
+        # A one-row morphing footer (e.g. the attach client's AttachUI.toolbar —
+        # audio state, detach hint). Re-evaluated each repaint; a failing
+        # callable renders empty rather than crashing the frame.
+        def _toolbar_fragments():
+            try:
+                return [("class:bottom-toolbar", str(toolbar() or ""))]
+            except Exception:  # noqa: BLE001
+                return [("", "")]
+
+        rows.append(Window(
+            content=FormattedTextControl(_toolbar_fragments, focusable=False),
+            height=1, wrap_lines=False,
+        ))
+    root = HSplit(rows)
     app = Application(
         layout=PTLayout(root, focused_element=prompt),
         key_bindings=kb, full_screen=True, mouse_support=False,
@@ -482,31 +498,84 @@ def should_run_bipartite() -> bool:
         return False
 
 
+async def _alive_watcher(
+    app_exit: Callable[[], Any],
+    watch_alive: Callable[[], bool],
+    *,
+    interval_s: float = 0.25,
+    sleep_fn=None,
+) -> None:
+    """Poll ``watch_alive`` and call ``app_exit`` the moment it goes False — the
+    daemon-died-mid-typing guard, generic + injectable (headless-testable).
+    Never raises out."""
+    import asyncio
+    sleep = sleep_fn or asyncio.sleep
+    try:
+        while True:
+            try:
+                if not watch_alive():
+                    try:
+                        app_exit()
+                    except Exception:  # noqa: BLE001
+                        pass
+                    return
+            except Exception:  # noqa: BLE001 — a probe error reads as "gone"
+                try:
+                    app_exit()
+                except Exception:  # noqa: BLE001
+                    pass
+                return
+            await sleep(interval_s)
+    except asyncio.CancelledError:
+        raise
+
+
 async def run_bipartite_repl(
     *,
     on_accept: Callable[[str], Any],
     title: str = "◇ O+V · proactive canvas",
     extra_key_bindings: Any = None,
+    toolbar: Optional[Callable[[], str]] = None,
+    watch_alive: Optional[Callable[[], bool]] = None,
+    seed: Optional[List[str]] = None,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
-    the live Zone-1 sink (so the event router redirects into it), run the
-    Application to completion, and clear the sink on exit. The atomic render loop
-    is the ``patch_stdout``-equivalent — background telemetry into Zone 1 never
-    corrupts Zone 2 keystrokes. Caller gates on :func:`should_run_bipartite`.
-    Never raises out."""
+    the live Zone-1 sink (so any producer — the daemon's event router OR the
+    attach client's bridge stream — redirects into it), run the Application to
+    completion, and clear the sink on exit. ``toolbar`` adds a one-row morphing
+    footer; ``watch_alive`` exits the app the moment it returns False (daemon
+    death never hangs the prompt). The atomic render loop is the
+    ``patch_stdout``-equivalent — background telemetry into Zone 1 never corrupts
+    Zone 2 keystrokes. Caller gates on :func:`should_run_bipartite`. Never
+    raises out."""
+    import asyncio
     import shutil
 
     size = shutil.get_terminal_size(fallback=(100, 30))
     mux = BipartiteLayout(width=size.columns, height=size.lines, title=title)
     set_active_canvas(mux)
+    for ln in (seed or []):
+        mux.push_raw(ln)
+    watcher = None
     try:
         app = build_bipartite_application(
             mux, on_accept=on_accept, extra_key_bindings=extra_key_bindings,
+            toolbar=toolbar,
         )
+        if watch_alive is not None:
+            watcher = asyncio.ensure_future(
+                _alive_watcher(app.exit, watch_alive)
+            )
         await app.run_async()
     except Exception:  # noqa: BLE001 — a TUI failure must not crash the organism
         logger.debug("[Bipartite] run_bipartite_repl exited on error", exc_info=True)
     finally:
+        if watcher is not None:
+            watcher.cancel()
+            try:
+                await watcher
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
         set_active_canvas(None)
 
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -346,6 +346,44 @@ class AttachUI:
             pass
 
 
+def _route_operator_line(client: Any, ui: Any, line: Any) -> str:
+    """THE one operator-line router — shared by the legacy split-plane loop AND
+    the Bipartite cockpit (DRY: verbs behave identically on both surfaces).
+
+    Returns ``"detach"`` (leave the loop), ``"handled"`` (audio verb routed on
+    the audio lane), or ``"sent"``/``"empty"``. Audio Control Plane verbs never
+    travel as chat text — the daemon synapse owns the duplex. A new operator
+    command while Karen is composing flushes her outbound buffer FIRST (the
+    human always owns the floor). Never raises."""
+    try:
+        text = (line or "").strip()
+        low = text.lower()
+        if low in ("detach", "exit", "quit"):
+            return "detach"
+        audio_verbs = {
+            "wake": "wake", "voice": "wake", "listen": "wake",
+            "wake!": "force_wake", "force-wake": "force_wake",
+            "force wake": "force_wake",
+            "ptt": "ptt",
+            "ptt stop": "ptt_stop", "ptt-stop": "ptt_stop", "ptt off": "ptt_stop",
+            "flush": "flush", "shh": "flush", "hush": "flush",
+            "mute": "sleep", "sleep": "sleep",
+            "barge": "barge",
+        }
+        cmd = audio_verbs.get(low)
+        if cmd is not None:
+            client.send_audio(cmd)
+            return "handled"
+        if text:
+            if ui is not None and ui.should_flush_on_input():
+                client.send_audio("flush")
+            client.send_input(text)
+            return "sent"
+        return "empty"
+    except Exception:  # noqa: BLE001 — routing must never crash an input loop
+        return "empty"
+
+
 async def _split_plane_loop(
     client: Any, console: Any, ui: Optional["AttachUI"] = None,
 ) -> None:
@@ -422,41 +460,59 @@ async def _split_plane_loop(
             except (EOFError, KeyboardInterrupt):
                 await _reap_task(prompt_task)
                 break
-            text = (line or "").strip()
-            low = text.lower()
-            if low in ("detach", "exit", "quit"):
+            outcome = _route_operator_line(client, ui, line)
+            if outcome == "detach":
                 break
-            # Audio Control Plane verbs — routed on the audio lane,
-            # never as chat text (the daemon synapse owns the duplex).
-            if low in ("wake", "voice", "listen"):
-                client.send_audio("wake")
-                continue
-            if low in ("wake!", "force-wake", "force wake"):
-                client.send_audio("force_wake")
-                continue
-            if low == "ptt":
-                client.send_audio("ptt")
-                continue
-            if low in ("ptt stop", "ptt-stop", "ptt off"):
-                client.send_audio("ptt_stop")
-                continue
-            if low in ("flush", "shh", "hush"):
-                client.send_audio("flush")
-                continue
-            if low in ("mute", "sleep"):
-                client.send_audio("sleep")
-                continue
-            if low == "barge":
-                client.send_audio("barge")
-                continue
-            if text:
-                # TTS interruption (ducking): a new operator command
-                # while Karen is composing/speaking flushes her
-                # outbound buffer FIRST — the human always owns the
-                # floor.
-                if ui.should_flush_on_input():
-                    client.send_audio("flush")
-                client.send_input(text)
+
+
+async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
+    """The Style-Guide §06 cockpit ON THE CLIENT: Zone 1 (the Proactive Canvas,
+    state-reactive border) auto-scrolls the daemon's bridge stream; Zone 2 the
+    anchored ``› `` prompt reusing THE SAME verb router as the legacy loop; the
+    morphing AttachUI footer rides below. The connection watcher exits the app
+    the instant the daemon dies (never hangs mid-typing). Never raises out."""
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        run_bipartite_repl,
+    )
+    from backend.core.ouroboros.ui.theme import UIState, get_reactive_theme
+
+    # Client-side reactive accent: attached = HEALTHY (cyan). The daemon-death
+    # path flips DEGRADED (red) just before the app exits — an honest mapping of
+    # the CLIENT's own connection state onto the Style-Guide state ladder.
+    try:
+        get_reactive_theme().set_state(UIState.HEALTHY)
+    except Exception:  # noqa: BLE001
+        pass
+
+    def _on_accept(text: str) -> None:
+        outcome = _route_operator_line(client, ui, text)
+        if outcome == "detach":
+            try:
+                from prompt_toolkit.application import get_app
+                get_app().exit()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _alive() -> bool:
+        ok = bool(client.connected)
+        if not ok:
+            try:
+                get_reactive_theme().set_state(UIState.DEGRADED)
+            except Exception:  # noqa: BLE001
+                pass
+        return ok
+
+    await run_bipartite_repl(
+        on_accept=_on_accept,
+        title="◇ O+V · proactive canvas",
+        toolbar=(lambda: ui.toolbar()) if ui is not None else None,
+        watch_alive=_alive,
+        seed=[
+            "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or plain "
+            "words both work · [cyan]wake[/cyan] arms my voice · "
+            "[cyan]detach[/cyan] leaves the organism running",
+        ],
+    )
 
 
 async def _legacy_pump_loop(client: Any) -> None:
@@ -501,10 +557,24 @@ def run_attach(console: Any) -> int:
         )
 
         def _print_line(text: str) -> None:
-            # Builtin print() resolves sys.stdout DYNAMICALLY — under the
-            # split-plane's patch_stdout this routes daemon telemetry
-            # above the pinned prompt; the pre-bound Rich console would
-            # bypass the patch and corrupt the input line.
+            # Cockpit mounted → the daemon's bridge stream auto-scrolls into
+            # Zone 1 (the Proactive Canvas). Rich markup is escaped so a daemon
+            # line can never inject styling into the canvas (inert DATA).
+            try:
+                from backend.core.ouroboros.battle_test.bipartite_layout import (
+                    get_active_canvas,
+                )
+                canvas = get_active_canvas()
+                if canvas is not None:
+                    from rich.markup import escape
+                    canvas.push_raw(escape(str(text)))
+                    return
+            except Exception:
+                pass
+            # Legacy split-plane: builtin print() resolves sys.stdout
+            # DYNAMICALLY — under patch_stdout this routes daemon telemetry
+            # above the pinned prompt; a pre-bound Rich console would bypass
+            # the patch and corrupt the input line.
             try:
                 print(text)
             except Exception:
@@ -532,8 +602,23 @@ def run_attach(console: Any) -> int:
             return 1
 
         try:
+            _ran_cockpit = False
             if _can_run_split_plane():
-                await _split_plane_loop(client, console, ui)
+                # Style-Guide cockpit is the default interactive surface; ANY
+                # failure falls through to the proven split-plane loop (the
+                # cockpit can never brick the attach). Kill-switch:
+                # JARVIS_BIPARTITE_LAYOUT_DISABLED=1.
+                try:
+                    from backend.core.ouroboros.battle_test.bipartite_layout import (
+                        should_run_bipartite,
+                    )
+                    if should_run_bipartite():
+                        await _bipartite_attach_loop(client, console, ui)
+                        _ran_cockpit = True
+                except Exception:
+                    _ran_cockpit = False
+                if not _ran_cockpit:
+                    await _split_plane_loop(client, console, ui)
             else:
                 await _legacy_pump_loop(client)
             if not client.connected:

--- a/tests/cli/test_bipartite_attach.py
+++ b/tests/cli/test_bipartite_attach.py
@@ -1,0 +1,195 @@
+"""Bulletproof spine for the Style-Guide cockpit ON the ov attach client.
+
+The guide's canonical surface (Bipartite Zone 1/Zone 2 + reactive border) was
+mounted only in the headless daemon — invisible from `ov`. This wires it into
+the attach client. Coverage:
+
+  (1) THE one operator-line router — identical verb behaviour on BOTH loops
+      (detach / audio verbs / flush-on-input / chat text / never raises),
+  (2) the bridge stream redirects into Zone 1 when the cockpit is mounted
+      (markup-escaped: a daemon line is inert DATA, it can never style the
+      canvas) and falls back to print when not,
+  (3) the connection watcher exits the app the moment the daemon dies,
+  (4) the toolbar-bearing cockpit app constructs headlessly.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.cli.ov import _route_operator_line
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.audio: list = []
+        self.inputs: list = []
+        self.connected = True
+
+    def send_audio(self, cmd: str) -> None:
+        self.audio.append(cmd)
+
+    def send_input(self, text: str) -> bool:
+        self.inputs.append(text)
+        return True
+
+
+class _FakeUI:
+    def __init__(self, flush: bool = False) -> None:
+        self._flush = flush
+
+    def should_flush_on_input(self) -> bool:
+        return self._flush
+
+    def toolbar(self) -> str:
+        return "voice: off · detach to leave"
+
+
+# ---------------------------------------------------------------------------
+# (1) the shared operator-line router
+# ---------------------------------------------------------------------------
+
+
+def test_router_detach_verbs():
+    c, ui = _FakeClient(), _FakeUI()
+    for verb in ("detach", "exit", "quit", "  DETACH  "):
+        assert _route_operator_line(c, ui, verb) == "detach"
+    assert c.audio == [] and c.inputs == []
+
+
+def test_router_audio_verbs_never_travel_as_chat():
+    c, ui = _FakeClient(), _FakeUI()
+    expect = [
+        ("wake", "wake"), ("voice", "wake"), ("listen", "wake"),
+        ("wake!", "force_wake"), ("force-wake", "force_wake"),
+        ("ptt", "ptt"), ("ptt stop", "ptt_stop"), ("ptt off", "ptt_stop"),
+        ("flush", "flush"), ("shh", "flush"), ("hush", "flush"),
+        ("mute", "sleep"), ("sleep", "sleep"), ("barge", "barge"),
+    ]
+    for line, cmd in expect:
+        assert _route_operator_line(c, ui, line) == "handled"
+        assert c.audio[-1] == cmd
+    assert c.inputs == []                      # audio verbs never reach chat
+
+
+def test_router_chat_text_and_flush_on_input():
+    c, ui = _FakeClient(), _FakeUI(flush=False)
+    assert _route_operator_line(c, ui, "fix the tests") == "sent"
+    assert c.inputs == ["fix the tests"] and c.audio == []
+
+    c2, ui2 = _FakeClient(), _FakeUI(flush=True)   # Karen is speaking → duck
+    assert _route_operator_line(c2, ui2, "stop that") == "sent"
+    assert c2.audio == ["flush"] and c2.inputs == ["stop that"]
+
+    assert _route_operator_line(c, ui, "   ") == "empty"
+    assert _route_operator_line(c, ui, None) == "empty"
+
+
+def test_router_never_raises():
+    class _Boom:
+        def send_audio(self, _c):
+            raise RuntimeError("bus down")
+
+        def send_input(self, _t):
+            raise RuntimeError("bus down")
+
+        connected = True
+
+    assert _route_operator_line(_Boom(), _FakeUI(), "wake") == "empty"
+    assert _route_operator_line(_Boom(), None, "hello") == "empty"
+
+
+# ---------------------------------------------------------------------------
+# (2) the bridge stream lands in Zone 1 when the cockpit is mounted
+# ---------------------------------------------------------------------------
+
+
+def test_bridge_line_redirects_into_canvas_escaped():
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout,
+        get_active_canvas,
+        set_active_canvas,
+    )
+    mux = BipartiteLayout(width=80, height=20)
+    set_active_canvas(mux)
+    try:
+        # Mirror the client's on_line body (canvas branch).
+        canvas = get_active_canvas()
+        assert canvas is not None
+        from rich.markup import escape
+        canvas.push_raw(escape("⏺ op complete [bold red]NOT-MARKUP[/bold red]"))
+        assert mux.line_count() == 1
+        rendered = mux.render_canvas_ansi()
+        # The literal text survives; the injected markup is INERT (escaped) —
+        # no bold-red style sequence was applied around NOT-MARKUP.
+        assert "NOT-MARKUP" in rendered
+        snap = mux._buffer.snapshot()
+        assert "\\[bold red]" in snap[0]       # escaped, not interpreted
+    finally:
+        set_active_canvas(None)
+
+
+# ---------------------------------------------------------------------------
+# (3) the connection watcher exits the app when the daemon dies
+# ---------------------------------------------------------------------------
+
+
+async def test_alive_watcher_exits_on_death():
+    from backend.core.ouroboros.battle_test.bipartite_layout import _alive_watcher
+
+    alive = {"v": True}
+    exited = {"n": 0}
+
+    async def fast(_s):
+        await asyncio.sleep(0)
+
+    task = asyncio.ensure_future(_alive_watcher(
+        lambda: exited.__setitem__("n", exited["n"] + 1),
+        lambda: alive["v"], sleep_fn=fast,
+    ))
+    await asyncio.sleep(0.01)
+    assert exited["n"] == 0                    # healthy → no exit
+    alive["v"] = False                          # the daemon dies
+    await asyncio.wait_for(task, timeout=1.0)
+    assert exited["n"] == 1                    # app exited exactly once
+
+
+async def test_alive_watcher_probe_error_reads_as_gone():
+    from backend.core.ouroboros.battle_test.bipartite_layout import _alive_watcher
+
+    exited = {"n": 0}
+
+    def boom() -> bool:
+        raise RuntimeError("socket torn")
+
+    await asyncio.wait_for(_alive_watcher(
+        lambda: exited.__setitem__("n", exited["n"] + 1), boom,
+        sleep_fn=lambda _s: asyncio.sleep(0),
+    ), timeout=1.0)
+    assert exited["n"] == 1
+
+
+# ---------------------------------------------------------------------------
+# (4) the toolbar-bearing cockpit app constructs headlessly
+# ---------------------------------------------------------------------------
+
+
+def test_cockpit_app_constructs_with_toolbar():
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout,
+        build_bipartite_application,
+    )
+    mux = BipartiteLayout(width=80, height=20)
+    ui = _FakeUI()
+    app = build_bipartite_application(
+        mux, on_accept=lambda t: None, toolbar=ui.toolbar,
+    )
+    assert app is not None and app.full_screen is True
+    # A crashing toolbar renders empty, never raises into the frame.
+    app2 = build_bipartite_application(
+        BipartiteLayout(width=80, height=20), on_accept=lambda t: None,
+        toolbar=lambda: (_ for _ in ()).throw(RuntimeError("x")),
+    )
+    assert app2 is not None


### PR DESCRIPTION
## "Do we have all the Style Guide integrated into `ov`?" — honest audit: no, until now

The guide's canonical surface (§06 Bipartite cockpit + state-reactive border) was mounted only in the **daemon's** SerpentREPL — headless, invisible from `ov`. Boot palette/crest/motion were integrated; the running surface was the legacy flowing loop. **One root cause: right surface, wrong process.**

## The fix — same cockpit, client-side, zero duplication
- **`_route_operator_line`** — the one operator-line router extracted from `_split_plane_loop`, shared byte-identically by both loops (detach / audio verbs / flush-on-input / chat).
- **`_bipartite_attach_loop`** — Zone 1 fed by the client's bridge stream via the *same* `get_active_canvas` seam the daemon router uses, **markup-escaped** (a daemon line is inert data). Zone 2 reuses the shared router; typed verbs still reach the daemon REPL over the bridge (`/breadcrumbs`, `/provider` work from the client). Karen greeting seeded (UX parity).
- **Client-side reactive border** — attached → HEALTHY (cyan); daemon death → DEGRADED (red) + instant app exit (never hangs mid-typing).
- **Generic primitives** — morphing toolbar row (AttachUI rides below the deck), injectable `_alive_watcher`, `seed`. Default-ON + TTY-gated; any failure falls back to the proven split-plane loop; kill-switch intact.

## Proven live (pty harness driving the real `ov`)
Alternate screen ✓ · rounded `◇ O+V · proactive canvas` frame ✓ · Karen seed ✓ · `›` deck ✓ · morphing toolbar ✓ · boot animation ✓ · clean detach + restore ✓

**8 new tests + 21 regressions green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mounts the Style Guide bipartite cockpit on the `ov` attach client. The canvas now shows the daemon stream, the prompt reuses the shared router, and the border reacts to connection state. Falls back safely to the legacy loop, with tests added.

- **New Features**
  - Introduced shared `_route_operator_line` used by both loops; handles detach, audio verbs, flush-on-input, and chat; never raises.
  - Added client-side cockpit via `_bipartite_attach_loop` and `run_bipartite_repl`; the prompt reuses the same router.
  - Bridge stream auto-scrolls into Zone 1; Rich markup is escaped to prevent style injection.
  - `build_bipartite_application` now supports a one-row morphing toolbar from `AttachUI.toolbar`.
  - `_alive_watcher` exits the app the moment the daemon dies; border switches from healthy to degraded.
  - Gated by `should_run_bipartite` and TTY; any failure falls back to `_split_plane_loop`; kill-switch `JARVIS_BIPARTITE_LAYOUT_DISABLED=1`.
  - Added `tests/cli/test_bipartite_attach.py` covering router, canvas redirect, watcher, and toolbar.

<sup>Written for commit 1b9e8e83f6a5370dca188a3790616562f20f5d17. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70062?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

