### PR TITLE
CC-style identity header (animated mini-crest · version · path) + borderless canvas

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -174,7 +174,10 @@ class BipartiteLayout:
     def _visible_lines(self) -> List[str]:
         # Auto-scroll: keep only the last (height - frame chrome) lines.
         try:
-            budget = max(1, self._height - 4)   # panel top/bottom border + title + deck
+            chrome = 4 if os.environ.get("JARVIS_BIPARTITE_BORDER", "").strip().lower() in (
+                "1", "true", "yes", "on",
+            ) else 1
+            budget = max(1, self._height - chrome)   # frame chrome only when bordered
             snap = self._buffer.snapshot()
             return list(snap[-budget:])
         except Exception:  # noqa: BLE001
@@ -204,20 +207,27 @@ class BipartiteLayout:
             else:
                 body = Text("  idle — waiting for the organism to act", style="bright_black")
             n = self._buffer.line_count if hasattr(self._buffer, "line_count") else len(lines)
-            # State-reactive border (Style Guide §06): the accent reflects the
-            # organism's meta-state, mutated in place by the Reactive Theme.
-            border = "cyan"
-            try:
-                from backend.core.ouroboros.ui.theme import get_reactive_theme
-                border = get_reactive_theme().active_border_style() or "cyan"
-            except Exception:  # noqa: BLE001
+            # CC-style default (operator mandate 2026-07-23): BORDERLESS — the
+            # canvas is open flowing content; structure comes from typography,
+            # and the reactive state accent lives in the header's status dot.
+            # JARVIS_BIPARTITE_BORDER=1 restores the framed Panel (whose border
+            # then carries the reactive accent as before).
+            if os.environ.get("JARVIS_BIPARTITE_BORDER", "").strip().lower() in (
+                "1", "true", "yes", "on",
+            ):
                 border = "cyan"
-            return Panel(
-                body, title=self._title, title_align="left",
-                subtitle=f"[bright_black]{n} events[/bright_black]", subtitle_align="right",
-                box=ROUNDED, border_style=border, padding=(0, 1),
-                height=max(3, self._height - 3),
-            )
+                try:
+                    from backend.core.ouroboros.ui.theme import get_reactive_theme
+                    border = get_reactive_theme().active_border_style() or "cyan"
+                except Exception:  # noqa: BLE001
+                    border = "cyan"
+                return Panel(
+                    body, title=self._title, title_align="left",
+                    subtitle=f"[bright_black]{n} events[/bright_black]", subtitle_align="right",
+                    box=ROUNDED, border_style=border, padding=(0, 1),
+                    height=max(3, self._height - 3),
+                )
+            return body
         except Exception:  # noqa: BLE001
             try:
                 from rich.panel import Panel
@@ -381,6 +391,8 @@ def build_bipartite_application(
     on_accept: Callable[[str], Any],
     extra_key_bindings: Any = None,
     toolbar: Optional[Callable[[], str]] = None,
+    header: Optional[Callable[[], str]] = None,
+    header_height: int = 0,
 ) -> Any:
     """Construct the full-screen ``prompt_toolkit.Application``: Zone 1 an ANSI
     window fed from ``mux.render_canvas_ansi()`` (re-rendered each frame, so
@@ -440,7 +452,22 @@ def build_bipartite_application(
         except Exception:  # noqa: BLE001
             pass
 
-    rows = [canvas, prompt]
+    rows = []
+    if header is not None and header_height > 0:
+        # The CC-style identity header (mini animated crest + version + path).
+        # Stateless render — the callable derives its animation phase from the
+        # clock, so the app's refresh_interval animates it with zero tasks.
+        def _header_fragments():
+            try:
+                return ANSI(str(header() or ""))
+            except Exception:  # noqa: BLE001
+                return ANSI("")
+
+        rows.append(Window(
+            content=FormattedTextControl(_header_fragments, focusable=False),
+            height=header_height, wrap_lines=False,
+        ))
+    rows += [canvas, prompt]
     if toolbar is not None:
         # A one-row morphing footer (e.g. the attach client's AttachUI.toolbar —
         # audio state, detach hint). Re-evaluated each repaint; a failing
@@ -459,7 +486,7 @@ def build_bipartite_application(
     app = Application(
         layout=PTLayout(root, focused_element=prompt),
         key_bindings=kb, full_screen=True, mouse_support=False,
-        refresh_interval=0.2,
+        refresh_interval=0.1,
     )
     _APP_REF["app"] = app
     mux.set_invalidate(app.invalidate)
@@ -538,6 +565,8 @@ async def run_bipartite_repl(
     toolbar: Optional[Callable[[], str]] = None,
     watch_alive: Optional[Callable[[], bool]] = None,
     seed: Optional[List[str]] = None,
+    header: Optional[Callable[[], str]] = None,
+    header_height: int = 0,
 ) -> None:
     """Launch the full-screen Bipartite REPL: build the multiplexer, register it as
     the live Zone-1 sink (so any producer — the daemon's event router OR the
@@ -552,7 +581,11 @@ async def run_bipartite_repl(
     import shutil
 
     size = shutil.get_terminal_size(fallback=(100, 30))
-    mux = BipartiteLayout(width=size.columns, height=size.lines, title=title)
+    mux = BipartiteLayout(
+        width=size.columns,
+        height=max(6, size.lines - max(0, header_height)),
+        title=title,
+    )
     set_active_canvas(mux)
     for ln in (seed or []):
         mux.push_raw(ln)
@@ -560,7 +593,7 @@ async def run_bipartite_repl(
     try:
         app = build_bipartite_application(
             mux, on_accept=on_accept, extra_key_bindings=extra_key_bindings,
-            toolbar=toolbar,
+            toolbar=toolbar, header=header, header_height=header_height,
         )
         if watch_alive is not None:
             watcher = asyncio.ensure_future(

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -502,11 +502,85 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
                 pass
         return ok
 
+    # The CC-style identity header: the mini ANIMATED crest at top-left with
+    # version · state · path beside it (the reactive accent lives in the status
+    # dot now that the canvas is borderless). Stateless clock-driven animation;
+    # the mini ring builds progressively off-loop. Degrades to text-only on
+    # tiny/incapable terminals.
+    mini = None
+    header_height = 0
+    header_render = None
+    try:
+        import asyncio as _aio
+        import os as _os
+        import time as _time
+        from backend.core.ouroboros.ui.crest_animator import (
+            MiniCrest,
+            render_cockpit_header,
+        )
+        from rich.text import Text as _Text
+
+        mini = MiniCrest()
+        if mini.available:
+            _aio.ensure_future(mini.ensure_frames())
+            header_height = max(3, mini.rows)
+        else:
+            mini = None
+            header_height = 3
+
+        def _home_path() -> str:
+            try:
+                cwd = _os.getcwd()
+                home = _os.path.expanduser("~")
+                return cwd.replace(home, "~", 1) if cwd.startswith(home) else cwd
+            except Exception:
+                return ""
+
+        _STATE_DOT = {
+            "HEALTHY": "rgb(67,214,208)", "DEGRADED": "rgb(248,81,73)",
+            "ARMED": "rgb(227,179,65)", "SOAKING": "rgb(94,224,106)",
+            "DORMANT": "rgb(108,125,119)",
+        }
+
+        def _header_lines():
+            t1 = _Text()
+            t1.append("O+V ", style="bold rgb(94,224,106)")
+            t1.append(version_line(), style="rgb(219,230,225)")
+            t2 = _Text()
+            state = "HEALTHY"
+            try:
+                from backend.core.ouroboros.ui.theme import get_reactive_theme
+                state = get_reactive_theme().state.value
+            except Exception:
+                pass
+            t2.append("● ", style=_STATE_DOT.get(state, "rgb(67,214,208)"))
+            t2.append(state.lower(), style="rgb(174,188,182)")
+            t2.append(" · ouroboros + venom · the organism drives", style="rgb(108,125,119)")
+            t3 = _Text(_home_path(), style="rgb(108,125,119)")
+            return [t1, t2, t3]
+
+        _hdr_width = {"w": 0}
+
+        def header_render() -> str:
+            try:
+                import shutil as _shutil
+                w = _shutil.get_terminal_size(fallback=(100, 30)).columns
+                _hdr_width["w"] = w
+                return render_cockpit_header(
+                    mini, _header_lines(), w, now=_time.monotonic(),
+                )
+            except Exception:
+                return ""
+    except Exception:
+        mini, header_render, header_height = None, None, 0
+
     await run_bipartite_repl(
         on_accept=_on_accept,
         title="◇ O+V · proactive canvas",
         toolbar=(lambda: ui.toolbar()) if ui is not None else None,
         watch_alive=_alive,
+        header=header_render,
+        header_height=header_height,
         seed=[
             "[bold]💭 Karen ▸[/bold] attached — I'm listening. verbs or plain "
             "words both work · [cyan]wake[/cyan] arms my voice · "

--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -597,4 +597,179 @@ def build_animator(console: Any, *, plus_lead_deg: Optional[float] = None) -> Op
         return None
 
 
-__all__ = ["CrestAnimator", "animator_enabled", "build_animator", "build_rotated_frame"]
+
+
+# ---------------------------------------------------------------------------
+# MiniCrest — the CC-style header logo (small, ambient, stateless-animated)
+# ---------------------------------------------------------------------------
+
+
+class MiniCrest:
+    """A small ambient crest for the cockpit header — the same physically-
+    rotating snake, sized down (``build_rotated_frame`` has no minimum-width
+    clamp, so the mini raster composes the SAME pipeline). Animation phase is
+    derived from the CLOCK (``time.monotonic``), so rendering is stateless —
+    no tick task; prompt_toolkit's refresh interval animates it for free.
+    Headless-testable. Never raises."""
+
+    def __init__(
+        self,
+        *,
+        cols: Optional[int] = None,
+        frame_count: Optional[int] = None,
+        ss: int = 2,
+        speed_laps_per_s: Optional[float] = None,
+    ) -> None:
+        self._cols = cols if cols is not None else _env_int(
+            "JARVIS_CREST_MINI_COLS", 20, 12, 40,
+        )
+        self._rows = _Geometry.rows_needed(self._cols)
+        self._n = frame_count if frame_count is not None else _env_int(
+            "JARVIS_CREST_MINI_FRAMES", 16, 4, 48,
+        )
+        self._ss = ss
+        self._speed = speed_laps_per_s if speed_laps_per_s is not None else _env_float(
+            "JARVIS_CREST_MINI_SPEED", 0.12, 0.01, 2.0,
+        )
+        self._frames: List[Optional[dict]] = [None] * max(1, self._n)
+        self._built = 0
+        self._builder_started = False
+        # Frame 0 built synchronously — small raster (~10-20ms), instant logo.
+        f0 = build_rotated_frame(self._cols, self._rows, 0.0, self._ss)
+        if f0:
+            self._frames[0] = f0
+            self._built = 1
+
+    @property
+    def available(self) -> bool:
+        return self._built > 0
+
+    @property
+    def rows(self) -> int:
+        return self._rows
+
+    @property
+    def cols(self) -> int:
+        return self._cols
+
+    async def ensure_frames(self) -> None:
+        """Fill the small ring off the event loop (progressive, idempotent)."""
+        import asyncio
+        if self._builder_started:
+            return
+        self._builder_started = True
+        try:
+            for k in range(self._n):
+                if self._frames[k] is not None:
+                    continue
+                rot = 2.0 * math.pi * k / self._n
+                v_rot = _v_spin_mult() * rot
+                frame = await asyncio.to_thread(
+                    build_rotated_frame, self._cols, self._rows, rot, self._ss, v_rot,
+                )
+                if frame:
+                    self._frames[k] = frame
+                    self._built = sum(1 for f in self._frames if f is not None)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            pass
+
+    def _frame_now(self, now: Optional[float] = None) -> Optional[dict]:
+        import time as _time
+        if not self._frames:
+            return None
+        t = _time.monotonic() if now is None else float(now)
+        phase = (t * self._speed) % 1.0
+        n = len(self._frames)
+        want = int(phase * n) % n
+        for off in range(n):
+            for idx in ((want - off) % n, (want + off) % n):
+                f = self._frames[idx]
+                if f is not None:
+                    return f
+        return None
+
+    def row_texts(self, now: Optional[float] = None) -> List[Any]:
+        """The mini crest as one Rich ``Text`` per cell row (for side-by-side
+        header composition). Empty list when unavailable. Never raises."""
+        try:
+            from rich.text import Text
+        except Exception:  # noqa: BLE001
+            return []
+        frame = self._frame_now(now)
+        if not frame:
+            return []
+        occ = [py // 2 for (_x, py) in frame]
+        lo, hi = (min(occ), max(occ)) if occ else (0, self._rows - 1)
+        rows: List[Any] = []
+        for cy in range(lo, hi + 1):
+            t = Text()
+            for x in range(self._cols):
+                top = frame.get((x, cy * 2))
+                bot = frame.get((x, cy * 2 + 1))
+                if top is None and bot is None:
+                    t.append(" ")
+                elif top is not None and bot is not None:
+                    tr, tg, tb = top
+                    br, bg, bb = bot
+                    t.append("▀", style=f"rgb({tr},{tg},{tb}) on rgb({br},{bg},{bb})")
+                elif top is not None:
+                    tr, tg, tb = top
+                    t.append("▀", style=f"rgb({tr},{tg},{tb})")
+                else:
+                    br, bg, bb = bot
+                    t.append("▄", style=f"rgb({br},{bg},{bb})")
+            rows.append(t)
+        return rows
+
+
+def render_cockpit_header(
+    mini: Optional["MiniCrest"],
+    lines: List[Any],
+    width: int,
+    *,
+    now: Optional[float] = None,
+) -> str:
+    """Compose the CC-style header — mini crest left, identity/context/path
+    lines beside it — to an ANSI string bounded to ``width``. ``lines`` are
+    Rich renderable Texts (or plain strings). Degrades to text-only when the
+    mini crest is unavailable (tiny terminal / NONE tier). Never raises."""
+    try:
+        from io import StringIO
+        from rich.console import Console
+        from rich.text import Text
+
+        crest_rows = mini.row_texts(now) if mini is not None else []
+        text_rows: List[Any] = [
+            ln if not isinstance(ln, str) else Text(ln) for ln in lines
+        ]
+        n_rows = max(len(crest_rows), len(text_rows))
+        if n_rows == 0:
+            return ""
+        # Vertically centre the text block beside the crest.
+        pad_top = max(0, (len(crest_rows) - len(text_rows)) // 2)
+        crest_w = mini.cols if (mini is not None and crest_rows) else 0
+        out = Text()
+        for i in range(n_rows):
+            if i < len(crest_rows):
+                out.append_text(crest_rows[i])
+            else:
+                out.append(" " * crest_w)
+            ti = i - pad_top
+            if 0 <= ti < len(text_rows):
+                out.append("  ")
+                out.append_text(text_rows[ti] if not isinstance(text_rows[ti], str) else Text(text_rows[ti]))
+            if i < n_rows - 1:
+                out.append("\n")
+        buf = StringIO()
+        Console(
+            file=buf, force_terminal=True, color_system="truecolor",
+            width=max(20, width), highlight=False,
+        ).print(out)
+        return buf.getvalue()
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+__all__ = ["CrestAnimator", "MiniCrest", "animator_enabled", "build_animator", "build_rotated_frame", "render_cockpit_header"]

--- a/tests/cli/test_bipartite_attach.py
+++ b/tests/cli/test_bipartite_attach.py
@@ -193,3 +193,72 @@ def test_cockpit_app_constructs_with_toolbar():
         toolbar=lambda: (_ for _ in ()).throw(RuntimeError("x")),
     )
     assert app2 is not None
+
+
+# ---------------------------------------------------------------------------
+# (5) CC-style header + borderless canvas (operator mandate 2026-07-23)
+# ---------------------------------------------------------------------------
+
+
+def test_mini_crest_builds_below_static_min_and_animates():
+    """The mini logo works BELOW the static crest's 46-col minimum (it composes
+    build_rotated_frame directly, which has no clamp) and its clock-driven
+    render rotates with time."""
+    from backend.core.ouroboros.ui.crest_animator import MiniCrest
+    mini = MiniCrest(cols=18, frame_count=4, ss=1)
+    assert mini.available and mini.rows >= 4
+    asyncio.run(mini.ensure_frames())
+    rows_a = mini.row_texts(now=0.0)
+    rows_b = mini.row_texts(now=4.0)          # later clock → different frame
+    assert rows_a and rows_b
+    a = "".join(getattr(r, "plain", "") for r in rows_a)
+    b = "".join(getattr(r, "plain", "") for r in rows_b)
+    # Physical rotation → the lit silhouette differs across clock times.
+    assert a != b or rows_a != rows_b
+
+
+def test_cockpit_header_contains_identity_and_path():
+    from backend.core.ouroboros.ui.crest_animator import (
+        MiniCrest,
+        render_cockpit_header,
+    )
+    from rich.text import Text
+    mini = MiniCrest(cols=18, frame_count=4, ss=1)
+    lines = [Text("O+V ov 0.1.0"), Text("● healthy"), Text("~/repos/jarvis")]
+    ansi = render_cockpit_header(mini, lines, 100, now=0.0)
+    import re
+    plain = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", ansi)
+    assert "ov 0.1.0" in plain and "~/repos/jarvis" in plain and "healthy" in plain
+    assert "▀" in plain or "▄" in plain      # the mini crest is beside the text
+    # Text-only degradation (no crest) still renders the identity.
+    ansi2 = render_cockpit_header(None, lines, 100)
+    plain2 = re.sub(r"\x1b\[[0-9;]*[A-Za-z]", "", ansi2)
+    assert "ov 0.1.0" in plain2
+
+
+def test_canvas_is_borderless_by_default(monkeypatch):
+    from backend.core.ouroboros.battle_test.bipartite_layout import BipartiteLayout
+    monkeypatch.delenv("JARVIS_BIPARTITE_BORDER", raising=False)
+    mux = BipartiteLayout(width=80, height=20)
+    mux.push_raw("hello organism")
+    ansi = mux.render_canvas_ansi()
+    assert "╭" not in ansi and "╰" not in ansi     # no ring
+    assert "hello organism" in ansi
+    # The frame is restorable chrome, not deleted capability.
+    monkeypatch.setenv("JARVIS_BIPARTITE_BORDER", "1")
+    ansi2 = mux.render_canvas_ansi()
+    assert "╭" in ansi2
+
+
+def test_app_constructs_with_header():
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout,
+        build_bipartite_application,
+    )
+    app = build_bipartite_application(
+        BipartiteLayout(width=80, height=20),
+        on_accept=lambda t: None,
+        header=lambda: "O+V header",
+        header_height=3,
+    )
+    assert app is not None and app.full_screen is True


### PR DESCRIPTION
## The cockpit now opens like Claude Code

**Header (top-left):** the *animated* mini-crest — same physically-rotating snake, sized down — with the CC grammar beside it:
```
(mini    O+V ov 0.1.0 "unchained" — ouroboros + venom
 snake)  ● healthy · ouroboros + venom · the organism drives
 logo    ~/Documents/repos/JARVIS-AI-Agent.nosync
```
- `MiniCrest` composes `build_rotated_frame` directly (the 46-col floor is a boot-emblem quality gate, not a sampling limit). **Stateless clock-driven animation** — phase = `time.monotonic()`, zero tick tasks; the app's refresh interval animates it for free. Frame 0 sync (~15ms), ring fills off-loop.

**Border ring: gone.** Borderless is the default (CC-style open content); `JARVIS_BIPARTITE_BORDER=1` restores the framed Panel. The reactive state accent **moves to the header's status dot** (● cyan/red/amber/venom/gray by `UIState`) — the state ladder stays visible without the ring.

## Proven live (pty driving the real `ov`)
alt-screen ✓ · header identity ✓ · state dot ✓ · `~` path ✓ · mini-crest pixels with **5 distinct animated poses** ✓ · **no ring** ✓ · Karen seed ✓ · deck ✓ · clean restore ✓

**28 tests green** (4 new). Degrades to text-only header on tiny/incapable terminals; any header failure → headerless cockpit, never a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a CC-style identity header with an animated mini-crest, version, state dot, and path, and makes the cockpit canvas borderless by default. The header animates via a stateless clock and degrades to text-only on small terminals.

- **New Features**
  - `MiniCrest`: same rotating crest, sized down; first frame sync, rest built off-loop; env knobs `JARVIS_CREST_MINI_{COLS,FRAMES,SPEED}`.
  - `render_cockpit_header`: composes mini-crest + identity/context/path into ANSI, width-bounded.
  - Borderless canvas by default; reactive accent moves to the header status dot.
  - `BipartiteLayout`: optional `header` and `header_height`; visible-line budget adapts; refresh interval 0.1s.
  - `ov` attach: renders O+V + version line, colored state dot + label, and `~`-contracted cwd; graceful fallback when unavailable.
  - Tests cover mini-crest animation, header content/fallback, borderless default, and app construction with header.

- **Migration**
  - To restore the framed border, set `JARVIS_BIPARTITE_BORDER=1`.
  - For custom screens, pass `header` and `header_height` to `build_bipartite_application` or `run_bipartite_repl`.

<sup>Written for commit d22123a0234e15f2dcc0f274fcb7b280c730fb5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70063?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

