### PR TITLE
Crystal mini logo + CC title grammar + framed ❯ input row

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -425,8 +425,8 @@ def build_bipartite_application(
         wrap_lines=False, height=Dimension(weight=1),
     )
     prompt = TextArea(
-        height=1, prompt="› ", multiline=False, wrap_lines=False,
-        style="class:command-deck",
+        height=1, prompt=[("fg:#5ee06a bold", "❯ ")], multiline=False,
+        wrap_lines=False, style="class:command-deck",
     )
 
     def _accept(buff) -> bool:
@@ -467,7 +467,11 @@ def build_bipartite_application(
             content=FormattedTextControl(_header_fragments, focusable=False),
             height=header_height, wrap_lines=False,
         ))
-    rows += [canvas, prompt]
+    # The CC input framing: a dim hairline above AND below the ❯ row.
+    def _rule() -> Any:
+        return Window(height=1, char="─", style="fg:#1e2b28")
+
+    rows += [canvas, _rule(), prompt, _rule()]
     if toolbar is not None:
         # A one-row morphing footer (e.g. the attach client's AttachUI.toolbar —
         # audio state, detach hint). Re-evaluated each repaint; a failing
@@ -583,7 +587,7 @@ async def run_bipartite_repl(
     size = shutil.get_terminal_size(fallback=(100, 30))
     mux = BipartiteLayout(
         width=size.columns,
-        height=max(6, size.lines - max(0, header_height)),
+        height=max(6, size.lines - max(0, header_height) - 2),
         title=title,
     )
     set_active_canvas(mux)

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -544,8 +544,10 @@ async def _bipartite_attach_loop(client: Any, console: Any, ui: Any) -> None:
 
         def _header_lines():
             t1 = _Text()
-            t1.append("O+V ", style="bold rgb(94,224,106)")
-            t1.append(version_line(), style="rgb(219,230,225)")
+            # The CC title grammar: "O+V v0.1.0" (bold brand + bare version),
+            # exactly like "Claude Code v2.1.218". DRY: resolve_version().
+            t1.append("O+V", style="bold rgb(94,224,106)")
+            t1.append(f" v{resolve_version()}", style="rgb(219,230,225)")
             t2 = _Text()
             state = "HEALTHY"
             try:

--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -154,6 +154,7 @@ def _rotated_geometry(
 
 def build_rotated_frame(
     cols: int, rows: int, rot: float, ss: int, v_rot: float = 0.0,
+    alpha: str = "aa",
 ) -> Dict[Tuple[int, int], Tuple[int, int, int]]:
     """Sample ONE fully-rotated frame through the crest's own pipeline
     (`_sample_pixel` → `_pixel_color_and_delay` → coverage-alpha →
@@ -172,10 +173,20 @@ def build_rotated_frame(
                     continue
                 py_frac = (py * _REF_ASPECT - (geo.cy - geo.v_top)) / v_span
                 base, _d = _pixel_color_and_delay(kind, theta, py_frac, geo)
-                alpha = coverage ** 0.75
-                pixels[(x, py)] = tuple(
-                    max(0, min(255, round(c * alpha))) for c in base
-                )
+                if alpha == "crisp":
+                    # Hard pixel art (the CC-logo look): at tiny scales the
+                    # coverage-alpha AA dims nearly EVERY pixel (all edges) into
+                    # mud. Binary threshold + full-intensity color = crystal.
+                    if coverage < 0.34:
+                        continue
+                    pixels[(x, py)] = tuple(
+                        max(0, min(255, round(c))) for c in base
+                    )
+                else:
+                    a = coverage ** 0.75
+                    pixels[(x, py)] = tuple(
+                        max(0, min(255, round(c * a))) for c in base
+                    )
         return _prune_sparse_geometry(pixels)
     except Exception:  # noqa: BLE001
         return {}
@@ -635,7 +646,8 @@ class MiniCrest:
         self._built = 0
         self._builder_started = False
         # Frame 0 built synchronously — small raster (~10-20ms), instant logo.
-        f0 = build_rotated_frame(self._cols, self._rows, 0.0, self._ss)
+        # CRISP mode: hard pixels, no AA mud (the CC-logo look).
+        f0 = build_rotated_frame(self._cols, self._rows, 0.0, self._ss, alpha="crisp")
         if f0:
             self._frames[0] = f0
             self._built = 1
@@ -666,6 +678,7 @@ class MiniCrest:
                 v_rot = _v_spin_mult() * rot
                 frame = await asyncio.to_thread(
                     build_rotated_frame, self._cols, self._rows, rot, self._ss, v_rot,
+                    "crisp",
                 )
                 if frame:
                     self._frames[k] = frame
@@ -702,10 +715,21 @@ class MiniCrest:
             return []
         occ = [py // 2 for (_x, py) in frame]
         lo, hi = (min(occ), max(occ)) if occ else (0, self._rows - 1)
+        # Trim the raster's centering margins: the logo sits flush-left and the
+        # header text rides close beside it (the CC layout). Bounds are computed
+        # from a FIXED reference pose so the trim never jitters as it spins —
+        # use the whole ring's union when built, else this frame.
+        union = {x for f in self._frames if f for (x, _py) in f}
+        xs = sorted(union or {x for (x, _py) in frame})
+        x_lo, x_hi = (xs[0], xs[-1]) if xs else (0, self._cols - 1)
+        # Row bounds from the union too — the logo box is rock-stable as it spins.
+        occ_union = sorted({py // 2 for f in self._frames if f for (_x, py) in f})
+        if occ_union:
+            lo, hi = occ_union[0], occ_union[-1]
         rows: List[Any] = []
         for cy in range(lo, hi + 1):
             t = Text()
-            for x in range(self._cols):
+            for x in range(x_lo, x_hi + 1):
                 top = frame.get((x, cy * 2))
                 bot = frame.get((x, cy * 2 + 1))
                 if top is None and bot is None:


### PR DESCRIPTION
Polish pass against the Claude Code reference (operator screenshots):

- **Crystal logo** — root cause: at 20 cols nearly every pixel is an edge, so coverage-alpha AA dimmed the whole mini into mud. New `alpha="crisp"` mode: binary threshold + full-intensity color — hard pixel art like CC's logo. **38/39 pixels bright** (was near-zero). Boot crest keeps its AA.
- **Flush-left + tight gap** — margins trimmed with bounds from the **union of all frames** (rock-stable while spinning, no jitter). Live: logo starts at **column 0**.
- **CC title grammar** — `O+V v0.1.0` (bold brand + bare `resolve_version()`), like `Claude Code v2.1.218`.
- **Framed `❯` row** — dim hairlines above + below the input, venom-green bold `❯`.

Live-proven under pty: title ✓ · col-0 logo ✓ · rules around ❯ ✓ · path ✓ · clean restore ✓. **28 tests green.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Polished the header and input UI to match Claude Code: crystal‑sharp mini logo, “O+V v{version}” title, and a framed green ❯ prompt. Improves readability and removes jitter in the rotating crest.

- **New Features**
  - Mini crest: added a crisp renderer for tiny sizes (binary threshold, no AA dim), keeping the boot crest on AA.
  - Flush-left logo with a tight text gap: trims centering margins using the union of all frames to stay stable while spinning.
  - Title grammar: “O+V v{resolve_version()}” (bold brand + bare version) to match CC.
  - Framed input row: bold venom‑green ❯ and dim hairlines above and below; layout reserves two rows for the rules.

<sup>Written for commit 912bf211150dd1d47ff8273a86f8ae1f773490f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70064?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

