### PR TITLE
Cockpit renders true 24-bit color — pt was quantizing to the 256 cube

### DIFF
--- a/backend/core/ouroboros/battle_test/bipartite_layout.py
+++ b/backend/core/ouroboros/battle_test/bipartite_layout.py
@@ -487,10 +487,27 @@ def build_bipartite_application(
             height=1, wrap_lines=False,
         ))
     root = HSplit(rows)
+    # Adaptive color depth (root cause of the quantized/muddy logo): pt 3.0.x's
+    # default depth reads TERM only — COLORTERM is ignored, so a truecolor
+    # terminal gets its 24-bit palette QUANTIZED to the 256 cube. Detect
+    # truecolor honestly; JARVIS_BIPARTITE_COLOR_DEPTH={1,4,8,24} overrides.
+    _depth = None
+    try:
+        from prompt_toolkit.output.color_depth import ColorDepth
+        _env = os.environ.get("JARVIS_BIPARTITE_COLOR_DEPTH", "").strip()
+        _map = {"1": ColorDepth.DEPTH_1_BIT, "4": ColorDepth.DEPTH_4_BIT,
+                "8": ColorDepth.DEPTH_8_BIT, "24": ColorDepth.DEPTH_24_BIT}
+        if _env in _map:
+            _depth = _map[_env]
+        elif os.environ.get("COLORTERM", "").strip().lower() in ("truecolor", "24bit"):
+            _depth = ColorDepth.DEPTH_24_BIT
+    except Exception:  # noqa: BLE001
+        _depth = None
     app = Application(
         layout=PTLayout(root, focused_element=prompt),
         key_bindings=kb, full_screen=True, mouse_support=False,
         refresh_interval=0.1,
+        **({"color_depth": _depth} if _depth is not None else {}),
     )
     _APP_REF["app"] = app
     mux.set_invalidate(app.invalidate)


### PR DESCRIPTION
Capture forensics after #70064 showed the cockpit emitting ZERO truecolor sequences (69 palette-256). Root cause: prompt_toolkit 3.0.x's default `ColorDepth` reads `TERM` only — `COLORTERM` is ignored — so truecolor terminals got the whole cockpit quantized to the 256 cube (the second half of the muddy logo; the first was AA mud, fixed in #70064). Fix: adaptive depth — `COLORTERM` → 24-bit, `JARVIS_BIPARTITE_COLOR_DEPTH` override, else pt default. Live-proven: **119 truecolor seqs, 85% full-bright**; layout intact. 17 tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable true 24-bit color in the cockpit TUI by selecting an adaptive `prompt_toolkit` color depth. Fixes 256-color quantization caused by the default ignoring `COLORTERM`, so colors render correctly.

- **Bug Fixes**
  - Use `COLORTERM` (`truecolor`/`24bit`) to set `ColorDepth.DEPTH_24_BIT`; add `JARVIS_BIPARTITE_COLOR_DEPTH={1,4,8,24}` to override.
  - Fall back to `prompt_toolkit` defaults when unset; 256-color terminals remain unchanged.

<sup>Written for commit 23602951529a169d1da6599b340ff7bd59f61768. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70065?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

