### PR TITLE
Mini logo true premultiplied compositing — the crisp thumbnail

### DIFF
--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -640,7 +640,7 @@ class MiniCrest:
     ) -> None:
         import shutil
         self._target = cols if cols is not None else _env_int(
-            "JARVIS_CREST_MINI_COLS", 13, 8, 32,
+            "JARVIS_CREST_MINI_COLS", 16, 8, 32,
         )
         self._n = frame_count if frame_count is not None else _frame_count_env()
         self._ss = ss if ss is not None else _anim_ss()
@@ -713,13 +713,20 @@ class MiniCrest:
                             if c is not None:
                                 lit.append(c)
                     area = max(1.0, (math.ceil(bx1) - int(bx0)) * (math.ceil(by1) - int(by0)))
-                    if lit and (len(lit) / area) >= 0.28:
-                        n = len(lit)
-                        out[(mx, my)] = (
-                            min(255, round(sum(c[0] for c in lit) / n)),
-                            min(255, round(sum(c[1] for c in lit) / n)),
-                            min(255, round(sum(c[2] for c in lit) / n)),
-                        )
+                    if not lit:
+                        continue
+                    # TRUE premultiplied compositing (the crisp fix): the big
+                    # frames carry coverage-alpha BAKED into their colors, so
+                    # the correct thumbnail is sum/AREA — interiors stay full-
+                    # bright, edges taper exactly like the big emblem's own AA.
+                    # (Lit-only averaging un-premultiplied the edges → bloat.)
+                    boost = 1.18                      # counter box-filter loss
+                    r = min(255, round(sum(c[0] for c in lit) / area * boost))
+                    g = min(255, round(sum(c[1] for c in lit) / area * boost))
+                    b = min(255, round(sum(c[2] for c in lit) / area * boost))
+                    if max(r, g, b) < 16:             # crumb cutoff — no fuzz halo
+                        continue
+                    out[(mx, my)] = (r, g, b)
             return out
         except Exception:  # noqa: BLE001
             return {}


### PR DESCRIPTION
Root cause of the residual mush: lit-only averaging **un-premultiplied** the big frames' baked coverage-alpha — edge fragments rendered full-intensity in sloppy positions (bloat). Correct alpha downscale = **sum/AREA** (the frames are premultiplied): interiors full-bright, edges taper exactly like the big emblem's own AA. Plus loss boost 1.18, crumb cutoff, default 16 cols. The V reads sharp with dark separation; the coil tapers clean — same artwork philosophy at both sizes. Tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes blurry mini crest thumbnails by using true premultiplied compositing during downsampling. Edges now preserve the big emblem’s AA instead of blooming.

- **Bug Fixes**
  - Downsample premultiplied frames via sum/area; remove lit-only averaging.
  - Add 1.18 loss boost and drop crumbs (max channel <16) to avoid halos.
  - Increase default mini width from 13 to 16 columns for more detail.

<sup>Written for commit 175f83a212a3b441d16dfc6d9d9acd17ea96d4bb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70067?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

