### PR TITLE
Hard-Edge Vector Quantizer — razor-crisp mini via binary alpha + pure palette

### DIFF
--- a/backend/core/ouroboros/ui/crest_animator.py
+++ b/backend/core/ouroboros/ui/crest_animator.py
@@ -615,6 +615,36 @@ def build_animator(console: Any, *, plus_lead_deg: Optional[float] = None) -> Op
 # ---------------------------------------------------------------------------
 
 
+
+
+def _quant_palette() -> List[Tuple[int, int, int]]:
+    """The definitive quantization palette — the crest's OWN pure colors (DRY:
+    gradient stops + head + eye + V), never a hardcoded copy."""
+    from .crest import _EYE_RGB, _HEAD_RGB, _STOPS, _V_BOT_RGB, _V_TOP_RGB
+    pal = [tuple(c) for (_deg, c) in _STOPS]
+    pal += [tuple(_HEAD_RGB), tuple(_EYE_RGB), tuple(_V_TOP_RGB), tuple(_V_BOT_RGB)]
+    out: List[Tuple[int, int, int]] = []
+    for c in pal:
+        if c not in out:
+            out.append(c)
+    return out
+
+
+def _v_family() -> set:
+    from .crest import _V_BOT_RGB, _V_TOP_RGB
+    return {tuple(_V_TOP_RGB), tuple(_V_BOT_RGB)}
+
+
+def _snap(rgb: Tuple[float, float, float], pal: List[Tuple[int, int, int]]) -> Tuple[int, int, int]:
+    r, g, b = rgb
+    best, bd = pal[0], 1e18
+    for p in pal:
+        d = (p[0] - r) ** 2 + (p[1] - g) ** 2 + (p[2] - b) ** 2
+        if d < bd:
+            bd, best = d, p
+    return best
+
+
 class MiniCrest:
     """The header logo — the BIG crest's artwork, downsampled (root cause of the
     old blob: re-sampling the vector geometry at ~20 columns is below the
@@ -688,9 +718,19 @@ class MiniCrest:
     # -- the downscaler (box filter, lit-only average → full intensity) --
 
     def _downsample(self, src: dict) -> dict:
+        """The Hard-Edge Vector Quantizer (operator mandate): terminals have no
+        true opacity, so averaging/premultiplied blending renders transition
+        colors as LITERAL mud. Instead: (1) binary alpha threshold — box
+        coverage ≥ 0.4 → 100% visible, else dropped, ZERO feathering; (2) strict
+        palette clamping — every visible cell SNAPS to the nearest pure color of
+        the crest's own palette (no blends, no dimming); (3) feature-preserving
+        bias — V-family cells threshold at 0.15 and dilate 1 cell so the V never
+        collapses between grid coordinates at micro scale. Pure; never raises."""
         try:
             if not src:
                 return {}
+            pal = _quant_palette()
+            vfam = _v_family()
             xs = [x for (x, _py) in src]
             pys = [py for (_x, py) in src]
             x0, x1 = min(xs), max(xs)
@@ -699,34 +739,44 @@ class MiniCrest:
             dst_w = max(4, self._target)
             dst_h = max(4, round(dst_w * h / max(1, w)))
             sx, sy = w / dst_w, h / dst_h
-            out: dict = {}
+            cover: dict = {}
+            vcover: dict = {}
+            color: dict = {}
             for my in range(dst_h):
                 for mx in range(dst_w):
-                    bx0 = x0 + mx * sx
-                    by0 = y0 + my * sy
-                    bx1 = x0 + (mx + 1) * sx
-                    by1 = y0 + (my + 1) * sy
+                    bx0, by0 = x0 + mx * sx, y0 + my * sy
+                    bx1, by1 = x0 + (mx + 1) * sx, y0 + (my + 1) * sy
                     lit = []
                     for px in range(int(bx0), max(int(bx0) + 1, int(math.ceil(bx1)))):
                         for py in range(int(by0), max(int(by0) + 1, int(math.ceil(by1)))):
                             c = src.get((px, py))
-                            if c is not None:
+                            if c is not None and max(c) > 40:   # ignore AA fringe
                                 lit.append(c)
-                    area = max(1.0, (math.ceil(bx1) - int(bx0)) * (math.ceil(by1) - int(by0)))
                     if not lit:
                         continue
-                    # TRUE premultiplied compositing (the crisp fix): the big
-                    # frames carry coverage-alpha BAKED into their colors, so
-                    # the correct thumbnail is sum/AREA — interiors stay full-
-                    # bright, edges taper exactly like the big emblem's own AA.
-                    # (Lit-only averaging un-premultiplied the edges → bloat.)
-                    boost = 1.18                      # counter box-filter loss
-                    r = min(255, round(sum(c[0] for c in lit) / area * boost))
-                    g = min(255, round(sum(c[1] for c in lit) / area * boost))
-                    b = min(255, round(sum(c[2] for c in lit) / area * boost))
-                    if max(r, g, b) < 16:             # crumb cutoff — no fuzz halo
-                        continue
-                    out[(mx, my)] = (r, g, b)
+                    area = max(1.0, (math.ceil(bx1) - int(bx0)) * (math.ceil(by1) - int(by0)))
+                    n = len(lit)
+                    avg = (sum(c[0] for c in lit) / n, sum(c[1] for c in lit) / n,
+                           sum(c[2] for c in lit) / n)
+                    snapped = _snap(avg, pal)
+                    cover[(mx, my)] = n / area
+                    color[(mx, my)] = snapped
+                    if snapped in vfam:
+                        vcover[(mx, my)] = n / area
+            out: dict = {}
+            for k, cv in cover.items():
+                thresh = 0.15 if k in vcover else 0.4   # V bias — never collapses
+                if cv >= thresh:
+                    out[k] = color[k]
+            # 1-cell V dilation: a V cell pulls in 4-neighbours that carry ANY
+            # V coverage — guaranteed feature continuity at micro scale.
+            for (mx, my), cv in list(vcover.items()):
+                if (mx, my) not in out:
+                    continue
+                for dx, dy in ((1, 0), (-1, 0), (0, 1), (0, -1)):
+                    nk = (mx + dx, my + dy)
+                    if nk not in out and vcover.get(nk, 0.0) > 0.05:
+                        out[nk] = color[nk]
             return out
         except Exception:  # noqa: BLE001
             return {}

--- a/tests/cli/test_bipartite_attach.py
+++ b/tests/cli/test_bipartite_attach.py
@@ -282,3 +282,30 @@ def test_app_constructs_with_header():
         header_height=3,
     )
     assert app is not None and app.full_screen is True
+
+
+def test_quantizer_zero_out_of_palette_pixels():
+    """Hard-Edge Vector Quantizer mandate: every rendered mini pixel is a PURE
+    member of the crest's own palette — zero blends, zero dimmed transitions."""
+    from backend.core.ouroboros.ui.crest_animator import MiniCrest, _quant_palette
+    mini = MiniCrest(cols=16, frame_count=4, ss=1, source_cols=60, source_rows=24)
+    asyncio.run(mini.ensure_frames())
+    pal = set(_quant_palette())
+    for f in mini._frames:
+        if not f:
+            continue
+        offenders = [rgb for rgb in f.values() if tuple(rgb) not in pal]
+        assert offenders == [], f"blended colors leaked: {offenders[:4]}"
+
+
+def test_quantizer_v_survives_micro_scale():
+    """Feature-preserving dilation: the V-family purple is present in EVERY
+    frame at 16 cols — the V never collapses between grid coordinates."""
+    from backend.core.ouroboros.ui.crest_animator import MiniCrest, _v_family
+    mini = MiniCrest(cols=16, frame_count=4, ss=1, source_cols=60, source_rows=24)
+    asyncio.run(mini.ensure_frames())
+    vfam = _v_family()
+    for f in mini._frames:
+        if not f:
+            continue
+        assert any(tuple(rgb) in vfam for rgb in f.values()), "V vanished"


### PR DESCRIPTION
Terminals lack true opacity: premultiplied averaging = literal mud. Quantizer: binary threshold (≥0.4→visible, else dropped), strict palette clamp to the crest's own pure colors (DRY), V-bias 0.15 + 1-cell dilation (never collapses). Tests: zero out-of-palette pixels every frame + V survival. 15 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced mini-crest downsampling with a hard-edge vector quantizer for razor‑crisp edges in terminals. Removes muddy blends by using binary alpha and strict palette snapping, and keeps the V visible at small sizes.

- **Bug Fixes**
  - Binary alpha threshold: coverage >= 0.4 is visible; V uses 0.15.
  - Snap every pixel to the crest’s pure palette (no blends or dimming).
  - 1‑cell dilation for V pixels to prevent micro‑scale collapse.
  - Ignore AA fringe source pixels during sampling.
  - Tests: no out‑of‑palette pixels per frame; V present in every frame at 16 cols.

<sup>Written for commit 285496bb6628751e52a90feaf40f5e0efe1f07f0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70068?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

