### PR TITLE
Track the sanctioned Canary soak target

### DIFF
--- a/backend/soak_probes/canary/mathy.py
+++ b/backend/soak_probes/canary/mathy.py
@@ -1,0 +1,12 @@
+"""Canary soak target — throwaway module, safe for the Swarm to rewrite."""
+
+
+def factorial(n):
+    r = 1
+    for i in range(2, n + 1):
+        r = r * i
+    return r
+
+
+def is_even(n):
+    return n % 2 == 0

--- a/backend/soak_probes/canary/strings_util.py
+++ b/backend/soak_probes/canary/strings_util.py
@@ -1,0 +1,12 @@
+"""Canary soak target — throwaway module, safe for the Swarm to rewrite."""
+
+
+def shout(s):
+    return s.upper() + "!"
+
+
+def repeat(s, n):
+    out = ""
+    for _ in range(n):
+        out = out + s
+    return out

--- a/backend/soak_probes/canary/widgets.py
+++ b/backend/soak_probes/canary/widgets.py
@@ -1,0 +1,21 @@
+"""Canary soak target — throwaway module, safe for the Swarm to rewrite."""
+
+
+def add(a, b):
+    return a + b
+
+
+def slow_sum(items):
+    total = 0
+    for x in items:
+        total = total + x
+    return total
+
+
+class Counter:
+    def __init__(self):
+        self.n = 0
+
+    def bump(self):
+        self.n = self.n + 1
+        return self.n


### PR DESCRIPTION
The harness preemption shield stashes UNTRACKED files at soak boot — the canary target must be tracked to survive launch. 3 throwaway modules / 7 AST chunks, matching pending intent `22737b8f6978`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Track the sanctioned canary soak target so it survives soak boot and isn’t stashed by the preemption shield. Adds three small throwaway modules used by the harness: backend/soak_probes/canary/mathy.py, backend/soak_probes/canary/strings_util.py, backend/soak_probes/canary/widgets.py.

<sup>Written for commit 7b06413643e2ad01df55cb4ce845fae5da26fdfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70069?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

