### PR TITLE
Observable cockpit fallback — name the reason before the legacy view

### DIFF
--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -684,16 +684,32 @@ def run_attach(console: Any) -> int:
                 # failure falls through to the proven split-plane loop (the
                 # cockpit can never brick the attach). Kill-switch:
                 # JARVIS_BIPARTITE_LAYOUT_DISABLED=1.
+                _why = ""
                 try:
                     from backend.core.ouroboros.battle_test.bipartite_layout import (
+                        bipartite_enabled,
                         should_run_bipartite,
                     )
                     if should_run_bipartite():
                         await _bipartite_attach_loop(client, console, ui)
                         _ran_cockpit = True
-                except Exception:
+                    elif not bipartite_enabled():
+                        _why = "kill-switch (JARVIS_BIPARTITE_LAYOUT_DISABLED)"
+                    else:
+                        _why = "stdout is not a real TTY"
+                except Exception as _exc:
                     _ran_cockpit = False
+                    _why = f"{type(_exc).__name__}: {str(_exc)[:80]}"
                 if not _ran_cockpit:
+                    # Observability over silent reroute (operator law): say WHY
+                    # the cockpit did not mount before falling back.
+                    try:
+                        console.print(
+                            f"⎿ cockpit fallback → legacy view ({_why or 'unknown'})",
+                            markup=False, highlight=False,
+                        )
+                    except Exception:
+                        pass
                     await _split_plane_loop(client, console, ui)
             else:
                 await _legacy_pump_loop(client)


### PR DESCRIPTION
Cockpit works under pty repro but not on the operator's terminal — and the fallback was silent. Now `ov` prints one dim line naming why (kill-switch / non-TTY / exception). 15 green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the cockpit fallback visible by printing a single line that explains why the cockpit didn’t mount before falling back to the legacy view. This turns silent reroutes into actionable diagnostics.

- **Bug Fixes**
  - Prints a dim line on fallback with the reason: kill-switch `JARVIS_BIPARTITE_LAYOUT_DISABLED`, non‑TTY stdout, or exception type with a short message.
  - Uses `bipartite_enabled` and `should_run_bipartite` to decide and capture the cause.
  - Keeps the safe fallback path to the split‑plane/legacy view unchanged.

<sup>Written for commit 71795a71103d93aab416ec8b4653871844a2342d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70070?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

