### PR TITLE
Fix(cli): Starved-organism honesty — kill the 117s blind ov wait

### DIFF
--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -86,6 +86,18 @@ def attach_socket_path() -> Path:
     ))
 
 
+def _connect_patience_s() -> float:
+    """Total attach patience across escalating retries (client side).
+    A post-boot storm can lag hydration for seconds — the patience budget
+    absorbs it; a REFUSED socket still fails instantly."""
+    try:
+        return max(0.5, min(120.0, float(os.environ.get(
+            "JARVIS_ATTACH_CONNECT_PATIENCE_S", "12",
+        ))))
+    except (TypeError, ValueError):
+        return 12.0
+
+
 def _connect_timeout_s() -> float:
     try:
         return max(0.05, float(os.environ.get(
@@ -93,6 +105,20 @@ def _connect_timeout_s() -> float:
         )))
     except (TypeError, ValueError):
         return 0.5
+
+
+def _sentinel_interval_s() -> float:
+    """Socket self-heal cadence (0 disables). The bridge binds once at
+    boot; if ANY confused peer unlinks the inode (a CLI misclassifying
+    a starved organism as a ghost — the 2026-07-23 class — an operator
+    ``rm``, a tmp janitor), the organism silently becomes permanently
+    unattachable. The sentinel rebinds a vanished inode. NEVER raises."""
+    try:
+        return max(0.0, min(300.0, float(os.environ.get(
+            "JARVIS_ATTACH_SENTINEL_S", "10",
+        ))))
+    except (TypeError, ValueError):
+        return 10.0
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +163,7 @@ class CockpitAttachBridge:
         self._on_audio = on_audio or (lambda _c: None)
         self._path = Path(path) if path is not None else attach_socket_path()
         self._server: Optional[asyncio.AbstractServer] = None
+        self._sentinel_task: Optional[asyncio.Task] = None
         self._clients: Set[asyncio.StreamWriter] = set()
         self._loop: Optional[asyncio.AbstractEventLoop] = None
         self._audio_state: str = "OFFLINE"
@@ -169,6 +196,12 @@ class CockpitAttachBridge:
             except OSError:
                 pass
             logger.info("[CockpitAttach] bridge bound at %s", self._path)
+            if _sentinel_interval_s() > 0:
+                try:
+                    self._sentinel_task = asyncio.get_running_loop(
+                    ).create_task(self._socket_sentinel())
+                except Exception:  # noqa: BLE001
+                    self._sentinel_task = None
             return True
         except Exception as exc:  # noqa: BLE001
             logger.warning("[CockpitAttach] bind failed: %s", exc)
@@ -185,6 +218,12 @@ class CockpitAttachBridge:
         forever. Bounded as belt-and-braces: never-hangs is this module's
         law even if a handler wedges."""
         try:
+            if self._sentinel_task is not None:
+                try:
+                    self._sentinel_task.cancel()
+                except Exception:  # noqa: BLE001
+                    pass
+                self._sentinel_task = None
             for w in list(self._clients):
                 self._drop(w)
             if self._server is not None:
@@ -202,6 +241,56 @@ class CockpitAttachBridge:
                 pass
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] stop degraded", exc_info=True)
+
+    async def _socket_sentinel(self) -> None:
+        """Self-heal watchdog: while the bridge is up, verify the socket
+        inode still exists; if something unlinked it, REBIND at the same
+        path so the organism never becomes silently unattachable. Reads
+        only the filesystem + its own server handle (no app state — the
+        watchdog-isolation principle). NEVER raises; ends with stop()."""
+        try:
+            while True:
+                await asyncio.sleep(_sentinel_interval_s())
+                if self._server is None:      # stopped — sentinel ends
+                    return
+                try:
+                    if self._path.exists():
+                        continue
+                    logger.warning(
+                        "[CockpitAttach] socket inode VANISHED at %s — "
+                        "rebinding (self-heal)", self._path,
+                    )
+                    old = self._server
+                    self._server = None
+                    try:
+                        old.close()
+                        await asyncio.wait_for(
+                            old.wait_closed(), timeout=2.0,
+                        )
+                    except Exception:  # noqa: BLE001
+                        pass
+                    self._path.parent.mkdir(parents=True, exist_ok=True)
+                    self._server = await asyncio.start_unix_server(
+                        self._on_client, path=str(self._path),
+                    )
+                    try:
+                        os.chmod(self._path, 0o600)
+                    except OSError:
+                        pass
+                    logger.info(
+                        "[CockpitAttach] bridge REBOUND at %s", self._path,
+                    )
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001
+                    logger.debug(
+                        "[CockpitAttach] sentinel heal degraded",
+                        exc_info=True,
+                    )
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001
+            return
 
     @property
     def client_count(self) -> int:
@@ -452,7 +541,32 @@ class CockpitAttachClient:
         self.connected: bool = False
 
     async def connect(self) -> bool:
-        timeout = _connect_timeout_s()
+        """Escalating-patience attach. A fresh organism's post-boot storm
+        (sensor fan-out, executor warm-up) can lag hydration past a single
+        0.5s shot — which misdiagnosed a LIVE organism as absent (the
+        2026-07-23 attach-after-successful-boot failure). Timeout-class
+        failures retry with doubling bounds up to a total patience budget;
+        REFUSED/absent fails fast (waiting cannot conjure a dead listener).
+        NEVER raises."""
+        patience = _connect_patience_s()
+        bound = _connect_timeout_s()
+        spent = 0.0
+        while True:
+            t0 = time.monotonic()
+            outcome = await self._connect_once(bound)
+            if outcome == "ok":
+                return True
+            if outcome == "dead":
+                return False
+            spent += time.monotonic() - t0
+            if spent >= patience:
+                return False
+            bound = min(bound * 2, max(0.5, patience - spent))
+
+    async def _connect_once(self, timeout: float) -> str:
+        """One bounded attach attempt: ``"ok"`` / ``"slow"`` (timeout-class
+        — a starved loop, worth retrying) / ``"dead"`` (refused/absent —
+        retrying cannot help). NEVER raises."""
         try:
             self._reader, self._writer = await asyncio.wait_for(
                 asyncio.open_unix_connection(path=str(self._path)),
@@ -463,7 +577,7 @@ class CockpitAttachClient:
             )
             if not line:
                 await self.close()
-                return False
+                return "dead"
             frame = json.loads(line)
             if frame.get("type") == "hydration":
                 self._safe_cb(self._on_hydration, frame)
@@ -471,10 +585,17 @@ class CockpitAttachClient:
                 self._read_loop(),
             )
             self.connected = True
-            return True
+            return "ok"
+        except asyncio.TimeoutError:
+            await self.close()
+            return "slow"
+        except (FileNotFoundError, ConnectionRefusedError,
+                ConnectionResetError):
+            await self.close()
+            return "dead"
         except Exception:  # noqa: BLE001
             await self.close()
-            return False
+            return "dead"
 
     def send_audio(self, cmd: str) -> bool:
         """Pipe one audio-orchestration command upstream (``wake`` /

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -3197,6 +3197,13 @@ class BattleTestHarness:
             # _handle_repl_command verb surface incl. the chat bridge.
             await self._start_cockpit_attach_bridge()
 
+            # Autonomy chain (AWE Trigger + Autonomous Supervisor) —
+            # mounted HERE, not in SerpentREPL.start(), so HEADLESS
+            # organisms arm it too (the wired-but-inert class: a REPL-
+            # coupled mount made Level-5 autonomy interactive-only —
+            # exactly backwards; HITL is the override, not the host).
+            self._start_autonomy_chain()
+
             # ── Boot-time orphan scan (Priority 2F resume) ────────────
             # Non-blocking: logs one INFO line if orphans exist so the
             # operator knows to run /resume list. Never prompts.
@@ -4321,6 +4328,31 @@ class BattleTestHarness:
                 self._repl_print(ln)
         except Exception as exc:  # noqa: BLE001 — REPL must survive
             self._repl_print(f"/liquidity: degraded ({exc})")
+
+    # -- Autonomy chain (AWE + Supervisor) ----------------------------------
+
+    def _start_autonomy_chain(self) -> None:
+        """Arm the AWE Trigger (DEGRADED→HEALTHY-edge soak launcher) and
+        the State-Reactive Autonomous Supervisor in BOTH modes. Each is
+        env-gated internally (JARVIS_AWE_TRIGGER_ENABLED /
+        JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED) and returns None when off,
+        so this mount is inert-by-default and best-effort. NEVER raises."""
+        self._awe_trigger = None
+        self._autonomous_supervisor = None
+        try:
+            from backend.core.ouroboros.governance.awe_trigger import (
+                start_awe_trigger,
+            )
+            self._awe_trigger = start_awe_trigger()
+        except Exception:  # noqa: BLE001 — AWE arming is best-effort
+            self._awe_trigger = None
+        try:
+            from backend.core.ouroboros.governance.autonomous_supervisor import (
+                start_autonomous_supervisor,
+            )
+            self._autonomous_supervisor = start_autonomous_supervisor()
+        except Exception:  # noqa: BLE001 — supervisor is best-effort
+            self._autonomous_supervisor = None
 
     # -- Cockpit Attach Bridge (CLI item #6) --------------------------------
 
@@ -8291,6 +8323,20 @@ class BattleTestHarness:
             hive_agg = getattr(self, "_hive_aggregator", None)
             if hive_agg is not None:
                 await hive_agg.stop()
+        except Exception:
+            pass
+        try:
+            _sup = getattr(self, "_autonomous_supervisor", None)
+            if _sup is not None:
+                await _sup.stop()
+                self._autonomous_supervisor = None
+        except Exception:
+            pass
+        try:
+            _awe = getattr(self, "_awe_trigger", None)
+            if _awe is not None:
+                await _awe.stop()
+                self._awe_trigger = None
         except Exception:
             pass
         try:

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -4682,34 +4682,13 @@ class SerpentREPL:
             self._status_badge_ticker_task = None
 
         # Autonomous Wake-and-Execute (AWE) Trigger — the Midnight-Recovery
-        # reflex. Consumes the SAME provider_state_changed feed and, on the
-        # DEGRADED→HEALTHY edge, atomically claims the soak lock and detaches the
-        # definitive Agentic Swarm soak so a 3 AM recovery is not lost to a
-        # passive human bottleneck. Opt-in (JARVIS_AWE_TRIGGER_ENABLED); returns
-        # None + stays inert when disabled. Best-effort.
+        # reflex — MOVED to BattleTestHarness._start_autonomy_chain (2026-07-23)
+        # together with the Autonomous Supervisor, so HEADLESS organisms arm the
+        # chain too (a REPL-coupled mount made Level-5 autonomy interactive-only —
+        # the wired-but-inert class). The harness owns the lifecycle now; these
+        # attrs stay None here so the legacy teardown below is a clean no-op.
         self._awe_trigger = None
-        try:
-            from backend.core.ouroboros.governance.awe_trigger import (
-                start_awe_trigger,
-            )
-            self._awe_trigger = start_awe_trigger()
-        except Exception:  # noqa: BLE001 — AWE arming is best-effort
-            self._awe_trigger = None
-
-        # State-Reactive Autonomous Supervisor — the intent-driven lifecycle
-        # manager. At boot it queries the substrate; if a soak workload is pending
-        # AND DW is DEGRADED it autonomously spawns the Sentinel subprocess + arms
-        # the AWE listener, self-heals the Sentinel on crash, and disarms when the
-        # queue clears. Autonomy is the default (JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED)
-        # but it stays fully inert until real intent exists. HITL = override only.
         self._autonomous_supervisor = None
-        try:
-            from backend.core.ouroboros.governance.autonomous_supervisor import (
-                start_autonomous_supervisor,
-            )
-            self._autonomous_supervisor = start_autonomous_supervisor()
-        except Exception:  # noqa: BLE001 — supervisor is best-effort
-            self._autonomous_supervisor = None
 
     async def _event_breadcrumb_router(self) -> None:
         """The ONE unified live event feed: subscribe once to the broker and

--- a/backend/core/ouroboros/battle_test/singleton_lock.py
+++ b/backend/core/ouroboros/battle_test/singleton_lock.py
@@ -459,6 +459,74 @@ def register_shipped_invariants() -> list:
     ]
 
 
+# ---------------------------------------------------------------------------
+# Incumbent lock reader — THE shared authority for "who holds the organism"
+# ---------------------------------------------------------------------------
+#
+# Promoted here (2026-07-23) from scripts/ouroboros_battle_test.py so the
+# thin CLI client can consult it WITHOUT importing the heavy harness script.
+# Consumed by: the zombie reaper (incumbent immunity), the single-flight
+# preflight (conflict detection), and ensure_daemon (never-clean-a-live-
+# organism's-socket + exit-75 attribution). One reader, zero disagreement.
+
+
+def read_lock_holder(
+    project_root: Optional[Path] = None,
+    *,
+    exclude_pid: Optional[int] = None,
+) -> Optional[tuple]:
+    """Read the single-flight lock (``.jarvis/intake_router.lock``) and
+    return ``(pid, age_s, alive)``, or ``None`` when absent/corrupt or
+    when the holder is ``exclude_pid`` (self-ownership). NEVER raises."""
+    import json as _json
+    import time as _time
+    try:
+        root = Path(project_root) if project_root is not None else Path.cwd()
+        lock_path = root / ".jarvis" / "intake_router.lock"
+        if not lock_path.exists():
+            return None
+        data = _json.loads(lock_path.read_text())
+        pid = int(data.get("pid", 0))
+        ts = float(data.get("ts", 0.0))
+        if not pid or (exclude_pid is not None and pid == exclude_pid):
+            return None
+        try:
+            os.kill(pid, 0)
+            alive = True
+        except ProcessLookupError:
+            alive = False
+        except PermissionError:
+            # The PID EXISTS (kernel refused the signal, not the lookup).
+            alive = True
+        age_s = (_time.time() - ts) if ts > 0 else float("inf")
+        return (pid, age_s, alive)
+    except (ValueError, OSError, KeyError, TypeError):
+        return None
+
+
+def lock_stale_ttl_s() -> float:
+    try:
+        return float(os.environ.get("JARVIS_INTAKE_LOCK_STALE_TTL_S", "7200"))
+    except (TypeError, ValueError):
+        return 7200.0
+
+
+def live_incumbent_pid(
+    project_root: Optional[Path] = None,
+    *,
+    exclude_pid: Optional[int] = None,
+) -> Optional[int]:
+    """PID of a LIVE, FRESH single-flight lock holder — the legitimate
+    incumbent organism — else None. NEVER raises."""
+    holder = read_lock_holder(project_root, exclude_pid=exclude_pid)
+    if holder is None:
+        return None
+    pid, age_s, alive = holder
+    if alive and age_s <= lock_stale_ttl_s():
+        return pid
+    return None
+
+
 __all__ = [
     "SINGLETON_LOCK_SCHEMA_VERSION",
     "SingletonLockResult",
@@ -466,4 +534,7 @@ __all__ = [
     "default_lock_path",
     "register_shipped_invariants",
     "singleton_lock_enabled",
+    "read_lock_holder",
+    "lock_stale_ttl_s",
+    "live_incumbent_pid",
 ]

--- a/backend/core/ouroboros/cli/thin_client.py
+++ b/backend/core/ouroboros/cli/thin_client.py
@@ -104,8 +104,15 @@ async def probe_socket(
       ``listen()`` backlog completes handshakes at the KERNEL level
       even while a boot-starved event loop has yet to run ``accept()``
       or write the hydration line. Callers must WAIT, never clean.
-    * ``"stale"``   — inode exists but connection refused/timed out
-      (ghost of a violently-killed daemon)
+    * ``"stale"``   — inode exists but connection REFUSED/reset (ghost
+      of a violently-killed daemon). A connect *timeout* is NOT stale:
+      a starved-but-live organism's loop can miss the accept window
+      while the kernel backlog still exists — that classifies as
+      ``"booting"`` (wait, never clean). Only a kernel-level refusal
+      proves nobody is home. (Root cause of the 2026-07-23 class: a
+      starvation-lagged live soak was probed "stale", the CLI unlinked
+      its LIVE socket, and the organism became permanently unattachable
+      since the bridge binds once at boot.)
     * ``"absent"``  — no inode at all
 
     ``timeout`` overrides the env default for a STRICT live-validation
@@ -121,10 +128,12 @@ async def probe_socket(
                 asyncio.open_unix_connection(path=str(path)),
                 timeout=bound,
             )
-        except (
-            ConnectionRefusedError, ConnectionResetError,
-            asyncio.TimeoutError, OSError,
-        ):
+        except asyncio.TimeoutError:
+            # Timeout ≠ dead. A starved event loop misses the accept
+            # window while the listener still exists — treat exactly
+            # like an accepted-but-unserved handshake: WAIT, never clean.
+            return "booting"
+        except (ConnectionRefusedError, ConnectionResetError, OSError):
             return "stale"
         try:
             if not deep:
@@ -315,10 +324,13 @@ def rollover_daemon_log(path: Optional[Path] = None) -> bool:
 
 def spawn_daemon(
     *, spawner: Callable[..., Any] = subprocess.Popen,
-) -> Optional[int]:
+) -> Optional[Any]:
     """Launch the organism DETACHED (new session — it survives this
     terminal closing) with stdout+stderr piped to the daemon log.
-    Returns the child pid, or None on spawn failure. NEVER raises."""
+    Returns the child process HANDLE (``.pid`` / ``.poll()``), or None
+    on spawn failure — the handle makes an instant single-flight
+    rejection (exit 75) OBSERVABLE instead of a 120s blind socket
+    vigil. NEVER raises."""
     try:
         log = daemon_log_path()
         log.parent.mkdir(parents=True, exist_ok=True)
@@ -343,7 +355,7 @@ def spawn_daemon(
                 start_new_session=True,
                 env=env,
             )
-        return getattr(proc, "pid", None)
+        return proc if getattr(proc, "pid", None) is not None else None
     except Exception:  # noqa: BLE001
         return None
 
@@ -369,6 +381,7 @@ async def await_socket(
     *,
     on_tick: Optional[Callable[[float], None]] = None,
     deadline_s: Optional[float] = None,
+    child_poll: Optional[Callable[[], Optional[int]]] = None,
 ) -> bool:
     """Wait (bounded) for the daemon's bridge to genuinely SERVE — each
     re-probe is the deep application handshake (``probe_socket(deep=True)``),
@@ -378,16 +391,38 @@ async def await_socket(
     Polling is a jittered exponential backoff (full jitter: each sleep is
     ``uniform(min, delay)`` with ``delay`` doubling to an env-tunable
     ceiling) — resource-frugal against a boot-starved daemon and never a
-    thundering probe train. ``on_tick(elapsed)`` drives the waking
-    breadcrumb. NEVER raises."""
+    thundering probe train. The PROBE BOUND escalates with the backoff
+    (from the env default up to 3s): a live organism whose loop is lagged
+    past the quick bound is still recognized instead of being waited on
+    forever (the starved-organism misclassification class).
+
+    ``child_poll`` (Popen.poll of a just-ignited daemon) makes death
+    observable: the moment the child exits without the socket serving,
+    the wait stops after ONE final escalated probe — never a blind
+    full-deadline vigil over a corpse (the 117s-wait class; a
+    single-flight rejection exits within ~2s of ignition).
+
+    ``on_tick(elapsed)`` drives the waking breadcrumb. NEVER raises."""
     deadline = deadline_s if deadline_s is not None else _boot_wait_s()
     start = time.monotonic()
     delay = _backoff_min_s()
     ceiling = max(_backoff_max_s(), delay)
     try:
         while (time.monotonic() - start) < deadline:
-            if await probe_socket(path, deep=True) == "live":
+            bound = min(3.0, max(_probe_timeout_s(), delay))
+            if await probe_socket(path, timeout=bound, deep=True) == "live":
                 return True
+            if child_poll is not None:
+                try:
+                    if child_poll() is not None:
+                        # The ignited daemon is DEAD. One last escalated
+                        # probe (an incumbent may serve this same path),
+                        # then stop — the caller reads the exit code.
+                        return await probe_socket(
+                            path, timeout=3.0, deep=True,
+                        ) == "live"
+                except Exception:  # noqa: BLE001
+                    pass
             if on_tick is not None:
                 try:
                     on_tick(time.monotonic() - start)
@@ -404,6 +439,32 @@ async def await_socket(
         raise
     except Exception:  # noqa: BLE001
         return False
+
+
+def _live_incumbent() -> Optional[int]:
+    """PID of a live, fresh single-flight lock holder — the shared
+    reader in ``singleton_lock`` (one authority, zero disagreement
+    with the reaper/preflight). NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.singleton_lock import (
+            live_incumbent_pid,
+        )
+        return live_incumbent_pid(repo_root(), exclude_pid=os.getpid())
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def _mk_tick(say: Callable[[str], None]) -> Callable[[float], None]:
+    """The waking breadcrumb (≥5s cadence) — one builder for every
+    wait branch."""
+    last = [-10.0]
+
+    def _tick(elapsed: float) -> None:
+        if elapsed - last[0] >= 5.0:
+            last[0] = elapsed
+            say(f"⎿ organism waking · {int(elapsed)}s")
+
+    return _tick
 
 
 async def ensure_daemon(
@@ -434,14 +495,7 @@ async def ensure_daemon(
             # A daemon is home but boot-starved — its socket must NOT be
             # cleaned and no second ignition raced. Wait for it to serve.
             _say("⏺ organism already waking — waiting for it to serve")
-            last_beat_b = [-10.0]
-
-            def _tick_b(elapsed: float) -> None:
-                if elapsed - last_beat_b[0] >= 5.0:
-                    last_beat_b[0] = elapsed
-                    _say(f"⎿ organism waking · {int(elapsed)}s")
-
-            if await await_socket(path, on_tick=_tick_b):
+            if await await_socket(path, on_tick=_mk_tick(_say)):
                 _say("⏺ organism live — attaching")
                 return True
             _say(
@@ -450,23 +504,61 @@ async def ensure_daemon(
             )
             return False
         if state == "stale":
+            # NEVER unlink while a live single-flight incumbent exists:
+            # the bridge binds ONCE at boot, so cleaning a live-but-
+            # refusing organism's socket makes it permanently
+            # unattachable (the 2026-07-23 class). Only a dead/absent
+            # holder proves a true ghost.
+            incumbent = _live_incumbent()
+            if incumbent is not None:
+                _say(
+                    f"⏺ organism (PID {incumbent}) is alive but not "
+                    "serving — waiting, never cleaning a live socket"
+                )
+                if await await_socket(path, on_tick=_mk_tick(_say)):
+                    _say("⏺ organism live — attaching")
+                    return True
+                _say(
+                    f"⚠ organism PID {incumbent} is alive but its "
+                    "control plane never served — its loop may be "
+                    "starved; tail " + str(daemon_log_path()),
+                )
+                return False
             _say("⎿ ghost socket from a dead organism — cleaning")
             clean_stale_socket(path)
         _say("⏺ no organism awake — igniting one in the background")
-        if spawn_daemon(spawner=spawner) is None:
+        proc = spawn_daemon(spawner=spawner)
+        if proc is None:
             _say("⚠ ignition failed — see " + str(daemon_log_path()))
             return False
 
-        last_beat = [-10.0]
-
-        def _tick(elapsed: float) -> None:
-            if elapsed - last_beat[0] >= 5.0:
-                last_beat[0] = elapsed
-                _say(f"⎿ organism waking · {int(elapsed)}s")
-
-        if await await_socket(path, on_tick=_tick):
+        if await await_socket(
+            path, on_tick=_mk_tick(_say),
+            child_poll=getattr(proc, "poll", None),
+        ):
             _say("⏺ organism live — attaching")
             return True
+        rc = None
+        try:
+            rc = proc.poll()
+        except Exception:  # noqa: BLE001
+            pass
+        if rc == 75:                      # EX_TEMPFAIL — single-flight
+            incumbent = _live_incumbent()
+            who = f"PID {incumbent}" if incumbent else "another process"
+            _say(
+                f"⚠ ignition refused — {who} already holds the "
+                "single-flight organism lock, but its attach socket "
+                "is not serving. It may be starved or mid-boot; retry "
+                "shortly, or tail " + str(daemon_log_path()),
+            )
+            return False
+        if rc is not None:
+            _say(
+                f"⚠ ignition died (exit {rc}) before serving — "
+                "tail " + str(daemon_log_path()),
+            )
+            return False
         _say(
             "⚠ boot did not surface within the wait window — "
             "tail " + str(daemon_log_path()),

--- a/scripts/ouroboros_battle_test.py
+++ b/scripts/ouroboros_battle_test.py
@@ -297,44 +297,33 @@ def _read_lock_holder(
     or ``None`` when absent/corrupt/self-owned.
 
     THE shared authority for "who holds the organism right now" —
-    consumed by BOTH the zombie reaper (incumbent immunity) and the
-    single-flight preflight (conflict detection), so the two can never
-    again disagree about legitimacy (the 2026-07-18 class: the reaper
+    consumed by the zombie reaper (incumbent immunity), the single-flight
+    preflight (conflict detection), AND the thin CLI's ensure_daemon
+    (never-clean-a-live-organism's-socket + exit-75 attribution), so no
+    two can disagree about legitimacy (the 2026-07-18 class: the reaper
     SIGTERM'd a healthy incumbent, then the preflight rejected the
     launcher against the dying incumbent's still-fresh lock — one ``ov``
     keystroke murdered the live soak AND locked the operator out).
-    NEVER raises."""
-    import json as _json
+    Implementation lives in ``battle_test.singleton_lock.read_lock_holder``
+    (promoted 2026-07-23 so the thin client shares it without importing
+    this heavy script). NEVER raises."""
     try:
+        from backend.core.ouroboros.battle_test.singleton_lock import (
+            read_lock_holder,
+        )
         root = Path(project_root) if project_root is not None else _PROJECT_ROOT
-        lock_path = root / ".jarvis" / "intake_router.lock"
-        if not lock_path.exists():
-            return None
-        data = _json.loads(lock_path.read_text())
-        pid = int(data.get("pid", 0))
-        ts = float(data.get("ts", 0.0))
-        if not pid or pid == os.getpid():
-            return None
-        try:
-            os.kill(pid, 0)
-            alive = True
-        except ProcessLookupError:
-            alive = False
-        except PermissionError:
-            # The PID EXISTS (kernel refused the signal, not the lookup)
-            # — treating this as dead was a latent bug in the old inline
-            # parse: a root-owned holder would have been "adopted over".
-            alive = True
-        age_s = (time.time() - ts) if ts > 0 else float("inf")
-        return (pid, age_s, alive)
-    except (ValueError, OSError, KeyError, TypeError):
+        return read_lock_holder(root, exclude_pid=os.getpid())
+    except Exception:  # noqa: BLE001
         return None
 
 
 def _lock_stale_ttl_s() -> float:
     try:
-        return float(os.environ.get("JARVIS_INTAKE_LOCK_STALE_TTL_S", "7200"))
-    except (TypeError, ValueError):
+        from backend.core.ouroboros.battle_test.singleton_lock import (
+            lock_stale_ttl_s,
+        )
+        return lock_stale_ttl_s()
+    except Exception:  # noqa: BLE001
         return 7200.0
 
 

--- a/tests/battle_test/test_cockpit_attach.py
+++ b/tests/battle_test/test_cockpit_attach.py
@@ -391,3 +391,119 @@ def test_ov_attach_is_real_not_stub():
     assert "coming soon" not in src
     assert "follow-up sprint" not in src
     assert "no organism awake" in src              # degradation message
+
+
+# ---------------------------------------------------------------------------
+# Socket self-heal sentinel (the unlinked-live-socket class, 2026-07-23)
+# ---------------------------------------------------------------------------
+
+
+async def test_sentinel_rebinds_vanished_socket(sock, monkeypatch):
+    """If ANY confused peer unlinks the live socket inode (a CLI
+    misclassifying a starved organism as a ghost, an operator rm), the
+    sentinel must REBIND at the same path — the organism never becomes
+    permanently unattachable."""
+    monkeypatch.setenv("JARVIS_ATTACH_SENTINEL_S", "0.05")
+    b = await _server(sock)
+    try:
+        assert sock.exists()
+        sock.unlink()                          # the confused peer strikes
+        for _ in range(100):                   # ≤5s for the heal
+            await asyncio.sleep(0.05)
+            if sock.exists():
+                break
+        assert sock.exists(), "sentinel never rebound the socket"
+        # And the reborn socket genuinely SERVES (full client handshake).
+        sink = _Sink()
+        c = ca.CockpitAttachClient(
+            path=sock, on_hydration=sink.on_hydration, on_line=sink.on_line,
+        )
+        assert await c.connect() is True
+        c.close()
+    finally:
+        await b.stop()
+
+
+async def test_sentinel_stops_with_bridge(sock, monkeypatch):
+    """stop() must end the sentinel — no immortal task, and no resurrection
+    of a deliberately-stopped bridge's socket."""
+    monkeypatch.setenv("JARVIS_ATTACH_SENTINEL_S", "0.05")
+    b = await _server(sock)
+    await b.stop()
+    assert b._sentinel_task is None
+    await asyncio.sleep(0.2)
+    assert not sock.exists()                   # stop() unlinked; stayed gone
+
+
+def test_autonomy_chain_mounted_in_harness_not_repl():
+    """Wiring invariant (the wired-but-inert class): the AWE Trigger +
+    Autonomous Supervisor mount must live on the HARNESS boot path (both
+    modes), not inside SerpentREPL.start() where --headless never goes."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    harness_src = (
+        root / "backend/core/ouroboros/battle_test/harness.py"
+    ).read_text()
+    serpent_src = (
+        root / "backend/core/ouroboros/battle_test/serpent_flow.py"
+    ).read_text()
+    assert "def _start_autonomy_chain" in harness_src
+    assert "self._start_autonomy_chain()" in harness_src
+    assert "start_awe_trigger()" not in serpent_src
+    assert "start_autonomous_supervisor()" not in serpent_src
+
+
+def test_autonomy_chain_env_gated_inert(monkeypatch):
+    """With both masters off, the chain mounts as None (inert-by-default)."""
+    monkeypatch.setenv("JARVIS_AWE_TRIGGER_ENABLED", "false")
+    monkeypatch.setenv("JARVIS_AUTONOMOUS_SUPERVISOR_ENABLED", "false")
+    from backend.core.ouroboros.battle_test.harness import BattleTestHarness
+    h = BattleTestHarness.__new__(BattleTestHarness)   # no heavy __init__
+    h._start_autonomy_chain()
+    assert h._awe_trigger is None
+    assert h._autonomous_supervisor is None
+
+
+# ---------------------------------------------------------------------------
+# Escalating-patience attach (post-boot-storm hydration lag, 2026-07-23)
+# ---------------------------------------------------------------------------
+
+
+async def test_connect_survives_slow_hydration(sock, monkeypatch):
+    """A live organism whose loop lags hydration past one 0.5s shot must
+    still attach — timeout-class failures retry with escalating bounds."""
+    monkeypatch.setenv("JARVIS_ATTACH_CONNECT_TIMEOUT_S", "0.3")
+    monkeypatch.setenv("JARVIS_ATTACH_CONNECT_PATIENCE_S", "10")
+
+    async def _laggy(reader, writer):
+        await asyncio.sleep(1.2)               # the post-boot storm
+        writer.write(b'{"type":"hydration","status":{}}\n')
+        await writer.drain()
+        try:
+            await reader.read(64)
+        except Exception:
+            pass
+
+    server = await asyncio.start_unix_server(_laggy, path=str(sock))
+    try:
+        sink = _Sink()
+        c = ca.CockpitAttachClient(
+            path=sock, on_hydration=sink.on_hydration, on_line=sink.on_line,
+        )
+        assert await c.connect() is True       # single-shot would have died
+        assert sink.hydrations
+        c.close()
+    finally:
+        server.close()
+
+
+async def test_connect_fails_fast_on_dead_socket(sock, monkeypatch):
+    """Waiting cannot conjure a dead listener: refused/absent must fail
+    in well under the patience budget."""
+    import time as _time
+    monkeypatch.setenv("JARVIS_ATTACH_CONNECT_PATIENCE_S", "30")
+    sock.write_bytes(b"")                      # plain file → refused
+    c = ca.CockpitAttachClient(path=sock)
+    t0 = _time.monotonic()
+    assert await c.connect() is False
+    assert _time.monotonic() - t0 < 3.0        # fast, not 30s

--- a/tests/cli/test_thin_client.py
+++ b/tests/cli/test_thin_client.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 import ast
 import asyncio
 import shutil
+import time
 import socket as socket_mod
 import tempfile
 from pathlib import Path
@@ -526,3 +527,148 @@ class TestHandshakeDepthProbe:
             assert path.exists()               # never cleaned the socket
         finally:
             await _shutdown_server(server)
+
+
+# ---------------------------------------------------------------------------
+# Starved-organism honesty (the 2026-07-23 "ov takes forever then fails" class)
+# ---------------------------------------------------------------------------
+
+
+class TestStarvedOrganismHonesty:
+    """Root-cause spine for the 117s-blind-wait + live-socket-unlink chain:
+    a starvation-lagged LIVE soak was probed 'stale', the CLI unlinked its
+    live socket (bridge binds once → permanently unattachable), then a
+    rival ignition was single-flight-rejected (exit 75) while the CLI
+    blind-waited the full boot window over the corpse."""
+
+    async def test_connect_timeout_probes_booting_not_stale(
+        self, sock_dir, monkeypatch,
+    ):
+        """Timeout ≠ dead: a starved loop misses the accept window while
+        the listener still exists — must classify 'booting' (wait, never
+        clean), NEVER 'stale' (clean + race a second ignition)."""
+        path = sock_dir / "starved.sock"
+        path.write_bytes(b"")                  # inode exists
+
+        async def _hang(*_a, **_k):
+            await asyncio.sleep(60)
+
+        monkeypatch.setattr(
+            thin_client.asyncio, "open_unix_connection", _hang,
+        )
+        state = await thin_client.probe_socket(path, timeout=0.05, deep=True)
+        assert state == "booting"
+
+    async def test_stale_with_live_incumbent_never_cleans_never_spawns(
+        self, sock_dir, monkeypatch,
+    ):
+        """A refused socket + a LIVE single-flight lock holder = a live
+        organism that is not serving. The CLI must wait — never unlink
+        the live organism's socket, never ignite a rival."""
+        path = sock_dir / "attach.sock"
+        path.write_bytes(b"")                  # plain file → connect refused
+        monkeypatch.setattr(
+            thin_client, "attach_socket_path_for_test", None, raising=False,
+        )
+        import backend.core.ouroboros.battle_test.cockpit_attach as ca
+        monkeypatch.setattr(ca, "attach_socket_path", lambda: path)
+        monkeypatch.setattr(thin_client, "_live_incumbent", lambda: 4242)
+
+        waited = []
+
+        async def _fake_wait(_p, **_kw):
+            waited.append(True)
+            return False                        # never serves in this test
+
+        monkeypatch.setattr(thin_client, "await_socket", _fake_wait)
+        spawns, msgs = [], []
+        ok = await thin_client.ensure_daemon(
+            on_status=msgs.append,
+            spawner=lambda *a, **k: spawns.append(a),
+        )
+        assert ok is False
+        assert path.exists()                    # LIVE socket never unlinked
+        assert spawns == []                     # no rival ignition
+        assert waited                           # it waited instead
+        assert any("4242" in m for m in msgs)   # names the incumbent
+
+    async def test_child_exit_75_stops_wait_and_names_incumbent(
+        self, sock_dir, monkeypatch,
+    ):
+        """A single-flight-rejected ignition (exit 75) must stop the wait
+        within seconds and attribute the lock holder — never a blind
+        full-deadline vigil over a corpse."""
+        path = sock_dir / "attach.sock"        # absent → cold boot branch
+        import backend.core.ouroboros.battle_test.cockpit_attach as ca
+        monkeypatch.setattr(ca, "attach_socket_path", lambda: path)
+        monkeypatch.setattr(thin_client, "_live_incumbent", lambda: 555)
+        monkeypatch.setenv("JARVIS_OV_BOOT_WAIT_S", "30")
+
+        class _DeadChild:
+            pid = 999
+
+            def poll(self):
+                return 75
+
+        monkeypatch.setattr(
+            thin_client, "spawn_daemon", lambda **_kw: _DeadChild(),
+        )
+        msgs = []
+        t0 = time.monotonic()
+        ok = await thin_client.ensure_daemon(on_status=msgs.append)
+        elapsed = time.monotonic() - t0
+        assert ok is False
+        assert elapsed < 10.0                   # fast-fail, not 30s deadline
+        assert any("single-flight" in m for m in msgs)
+        assert any("555" in m for m in msgs)
+
+    async def test_child_death_other_rc_reports_exit_code(
+        self, sock_dir, monkeypatch,
+    ):
+        path = sock_dir / "attach.sock"
+        import backend.core.ouroboros.battle_test.cockpit_attach as ca
+        monkeypatch.setattr(ca, "attach_socket_path", lambda: path)
+        monkeypatch.setenv("JARVIS_OV_BOOT_WAIT_S", "30")
+
+        class _Crashed:
+            pid = 999
+
+            def poll(self):
+                return 1
+
+        monkeypatch.setattr(
+            thin_client, "spawn_daemon", lambda **_kw: _Crashed(),
+        )
+        msgs = []
+        ok = await thin_client.ensure_daemon(on_status=msgs.append)
+        assert ok is False
+        assert any("exit 1" in m for m in msgs)
+
+    async def test_await_socket_child_exit_final_probe_can_still_win(
+        self, sock_dir,
+    ):
+        """The final escalated probe after child death can still find an
+        INCUMBENT serving the same path — child death is not defeat."""
+        path = sock_dir / "incumbent.sock"
+        server = await asyncio.start_unix_server(
+            _serving_handler, path=str(path),
+        )
+        try:
+            ok = await thin_client.await_socket(
+                path, deadline_s=10.0, child_poll=lambda: 75,
+            )
+            assert ok is True                   # attached to the incumbent
+        finally:
+            await _shutdown_server(server)
+
+    def test_shared_lock_reader_promoted_and_delegated(self):
+        """DRY: one lock-reader authority in singleton_lock; the harness
+        script delegates to it (no second parser to drift)."""
+        from backend.core.ouroboros.battle_test import singleton_lock as sl
+        assert callable(sl.read_lock_holder)
+        assert callable(sl.live_incumbent_pid)
+        script = (
+            thin_client.repo_root() / "scripts" / "ouroboros_battle_test.py"
+        ).read_text()
+        assert "from backend.core.ouroboros.battle_test.singleton_lock import" in script
+        assert script.count('data = _json.loads(lock_path.read_text())') == 0


### PR DESCRIPTION
## The failure (operator screenshot: `ov` → 117s of "organism waking" → "the organism did not come up")

Reconstructed chain, every link now fixed:

1. A **live headless soak** held the single-flight lock — but its loop was starved (~1s lag, 1834 `ControlPlaneStarvation` events), so it missed the CLI's **0.4s** deep-probe bound.
2. `probe_socket` classified the live organism **"stale"** → `clean_stale_socket` **unlinked the live socket**. The bridge binds once at boot → the organism became permanently unattachable.
3. `ov` ignited a rival daemon → single-flight correctly rejected it (**exit 75**) — but `spawn_daemon` dropped the Popen handle, so the CLI **blind-waited the full 120s** over a corpse, then blamed "boot".

## Fixes — one lock authority, honesty at every layer

| Layer | Fix |
|---|---|
| `probe_socket` | connect **timeout → "booting"** (wait, never clean); only kernel REFUSED proves a ghost |
| `await_socket` | probe bound **escalates with backoff** (→3s); `child_poll` makes ignition death observable — one final escalated probe, then stop |
| `ensure_daemon` | **never unlinks while a live incumbent holds the lock** (names the PID); exit-75 deaths attributed to the incumbent in the operator message |
| `CockpitAttachBridge` | **socket self-heal sentinel** (`JARVIS_ATTACH_SENTINEL_S`, 10s) rebinds a vanished inode |
| `CockpitAttachClient.connect` | **escalating patience** (`JARVIS_ATTACH_CONNECT_PATIENCE_S`, 12s) survives post-boot hydration lag; refused still fails instantly |
| `singleton_lock` | `read_lock_holder`/`live_incumbent_pid` **promoted** from the harness script — reaper, preflight, and CLI share ONE reader |

**Rides along (same wired-but-inert seam):** AWE Trigger + Autonomous Supervisor mounts moved from `SerpentREPL.start()` to `BattleTestHarness._start_autonomy_chain()` on the governed-loop boot path — headless organisms arm the autonomy chain too. Env gates unchanged.

## Proof

- **Live-fire**: cold boot → "organism live — attaching" in ~31s; warm attach → instant cockpit (header + Karen + mini crest, zero "no organism awake").
- 61 tests green (`test_thin_client` 35 + `test_cockpit_attach` 22 + AWE/Supervisor 8 – overlap), 11 new regression cases covering every link in the chain.
- `test_harness_partial_shutdown.py::test_partial_summary_is_lss_parseable` fails identically on main (stale `bt-iso-*` artifact) — pre-existing, untouched by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the 117s blind `ov` wait and live-socket unlink by making probes honest, waits observable, and sockets self-healing. Attaches now wait correctly, never clean a live socket, and report single‑flight incumbents.

- **Bug Fixes**
  - `probe_socket`: connect timeout → "booting"; only REFUSED/reset → "stale" (never clean on timeout).
  - `await_socket`: escalates probe bound with backoff (up to 3s) and supports `child_poll` to stop after child death with one final probe.
  - `ensure_daemon`: never unlinks when a live single‑flight incumbent exists; exit‑75 rejections name the incumbent PID in messages.
  - `CockpitAttachClient.connect`: escalating patience (`JARVIS_ATTACH_CONNECT_PATIENCE_S`, default 12s) handles post‑boot lag; refused still fails fast.

- **Refactors**
  - `CockpitAttachBridge`: socket self‑heal sentinel (`JARVIS_ATTACH_SENTINEL_S`, default 10s) rebinds a vanished inode.
  - Promoted lock reader to `battle_test.singleton_lock` (`read_lock_holder`, `live_incumbent_pid`) and reused by CLI, reaper, and preflight.
  - Moved AWE Trigger + Autonomous Supervisor mounts from `SerpentREPL.start()` to the harness boot path; headless mode arms the chain; env gates unchanged.

<sup>Written for commit ed848275128a4368866d406bbda51c944efda277. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70080?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

