### PR TITLE
Fix(sensors): Kill the loop-starvation storm producers — docstale debounce + dream exhaustion backoff

### DIFF
--- a/backend/core/ouroboros/consciousness/dream_engine.py
+++ b/backend/core/ouroboros/consciousness/dream_engine.py
@@ -117,6 +117,23 @@ class DreamProviderExhaustedError(RuntimeError):
 """Hard cap on dream prompt text length (TC23)."""
 
 _DREAM_LOOP_INTERVAL_S: float = 30.0
+
+
+def _exhaustion_backoff_base_s() -> float:
+    """First cooldown after a full-cascade exhaustion (doubles per streak)."""
+    try:
+        return max(5.0, float(os.environ.get(
+            "JARVIS_DREAM_EXHAUSTION_BACKOFF_BASE_S", "60")))
+    except (TypeError, ValueError):
+        return 60.0
+
+
+def _exhaustion_backoff_max_s() -> float:
+    try:
+        return max(60.0, float(os.environ.get(
+            "JARVIS_DREAM_EXHAUSTION_BACKOFF_MAX_S", "1800")))
+    except (TypeError, ValueError):
+        return 1800.0
 """Seconds between dream-loop ticks when not actively computing."""
 
 _JPRIME_GENERATE_ENDPOINT: str = "/v1/generate"
@@ -263,6 +280,12 @@ class DreamEngine:
 
         # Preemption (TC17)
         self._preempted: asyncio.Event = asyncio.Event()
+        # Exhaustion backoff (2026-07-23): when the WHOLE RT cascade is
+        # down, retrying every loop tick is a per-30s warning storm that
+        # rides the log pipeline while providers are provably dead.
+        # Escalating cooldown; any successful inference resets it.
+        self._exhaustion_streak: int = 0
+        self._exhaustion_until: float = 0.0
 
         # Flap damping (TC18) — monotonic time of last user return
         self._last_user_return: float = 0.0
@@ -643,6 +666,20 @@ class DreamEngine:
                 # Reset preemption at start of each cycle
                 self._preempted.clear()
 
+                # Exhaustion cooldown gate: while the whole cascade was
+                # down moments ago, do NOT re-hammer it every tick —
+                # sleep out the escalating cooldown quietly (debug, not
+                # warning — the storm class this kills).
+                remaining = self._exhaustion_until - time.monotonic()
+                if remaining > 0:
+                    logger.debug(
+                        "[DreamEngine] exhaustion cooldown — %.0fs until "
+                        "next cascade attempt (streak=%d)",
+                        remaining, self._exhaustion_streak,
+                    )
+                    await asyncio.sleep(min(remaining, _DREAM_LOOP_INTERVAL_S))
+                    continue
+
                 can, reason = await self._can_dream()
                 if not can:
                     logger.debug("[DreamEngine] Cannot dream: %s", reason)
@@ -733,8 +770,24 @@ class DreamEngine:
         # Exhaustion is a TYPED routing exception, not an ambiguous None.
         try:
             result = await self._call_inference(prompt)
+            self._exhaustion_streak = 0
+            self._exhaustion_until = 0.0
         except DreamProviderExhaustedError as exc:
-            logger.warning("[DreamEngine] inference cascade exhausted: %s", exc)
+            self._exhaustion_streak += 1
+            cooldown = min(
+                _exhaustion_backoff_max_s(),
+                _exhaustion_backoff_base_s()
+                * (2 ** min(self._exhaustion_streak - 1, 16)),
+            )
+            self._exhaustion_until = time.monotonic() + cooldown
+            # ONE line per escalation (WARNING the first, INFO after):
+            # a dead cascade is one fact, not a per-tick warning storm.
+            log = logger.warning if self._exhaustion_streak == 1 else logger.info
+            log(
+                "[DreamEngine] inference cascade exhausted: %s — "
+                "backing off %.0fs (streak=%d)",
+                exc, cooldown, self._exhaustion_streak,
+            )
             await self._emit_dormant("provider_cascade_exhausted")
             return None
 

--- a/backend/core/ouroboros/governance/intake/sensors/doc_staleness_sensor.py
+++ b/backend/core/ouroboros/governance/intake/sensors/doc_staleness_sensor.py
@@ -111,6 +111,31 @@ def merkle_consult_enabled() -> bool:
     return raw in ("1", "true", "yes", "on")
 
 
+def _fs_debounce_window_s() -> float:
+    """FS-event debounce window (Run #14 autopsy: this sensor produced
+    1049/1065 pool submissions by reacting to the session's OWN writes —
+    one full rglob+AST rescan PER event). Window-absorb semantics, the
+    Slice 5 T2 pattern from test_failure_sensor: the first .py event
+    opens the window, every event during it is ABSORBED, ONE scan runs
+    at close. 0 = legacy per-event scans. Re-read at call time."""
+    try:
+        return max(0.0, min(600.0, float(os.environ.get(
+            "JARVIS_DOCSTALE_FS_DEBOUNCE_S", "45"))))
+    except (TypeError, ValueError):
+        return 45.0
+
+
+def _min_rescan_interval_s() -> float:
+    """Cooldown between event-driven full scans — docs are the LOWEST
+    priority signal; a scan fresher than this answers any burst. The
+    24h poll (6h webhook-fallback) still guarantees eventual coverage."""
+    try:
+        return max(0.0, float(os.environ.get(
+            "JARVIS_DOCSTALE_MIN_RESCAN_S", "300")))
+    except (TypeError, ValueError):
+        return 300.0
+
+
 @dataclass
 class DocFinding:
     """One documentation gap detected."""
@@ -155,6 +180,10 @@ class DocStalenessSensor:
         # and ``ingest_webhook`` becomes the reactive hot path for
         # merges. FS subscription is unchanged.
         self._webhook_mode: bool = webhook_enabled()
+        # FS-event debounce (window-absorb) + scan cooldown state.
+        self._fs_debounce_task: Optional[asyncio.Task] = None
+        self._fs_events_absorbed: int = 0
+        self._last_scan_done_mono: float = 0.0
         # Telemetry counters — exposed via health snapshots during the
         # graduation arc so operators can read the signal:noise ratio.
         self._webhooks_handled: int = 0
@@ -212,13 +241,10 @@ class DocStalenessSensor:
             await self._on_git_event(event)
             return
 
-        # Direct .py file change → rescan that file
+        # Direct .py file change → debounced full rescan (window-absorb)
         if event.payload.get("extension") == ".py":
             if event.topic != "fs.changed.deleted":
-                try:
-                    await self.scan_once()  # Full rescan (simple, correct)
-                except Exception:
-                    logger.debug("[DocSensor] Event-driven scan error", exc_info=True)
+                self._schedule_debounced_scan()
 
     async def _on_git_event(self, event: Any) -> None:
         """React to git commit — rescan if Python files changed."""
@@ -228,11 +254,70 @@ class DocStalenessSensor:
             py_files = data.get("py_files_changed", [])
             if py_files:
                 logger.debug("[DocSensor] Git commit changed %d .py files, rescanning", len(py_files))
-                await self.scan_once()
+                self._schedule_debounced_scan()
         except Exception:
             logger.debug("[DocSensor] Failed to read git event", exc_info=True)
         if self._task and not self._task.done():
             self._task.cancel()
+
+    def _schedule_debounced_scan(self) -> None:
+        """Window-absorb debounce + cooldown for event-driven rescans.
+
+        The first event opens a ``_fs_debounce_window_s()`` window; every
+        event during it increments the absorbed counter and does NOTHING
+        else (no cancel-and-restart — fixed-window semantics, Slice 5 T2).
+        At close, ONE ``scan_once`` runs — unless a scan completed within
+        ``_min_rescan_interval_s()``, in which case the burst is already
+        answered and the run is skipped (the 24h poll still covers).
+        Kills the Run #14 pool-saturation class (one executor submission
+        per event). NEVER raises."""
+        try:
+            window = _fs_debounce_window_s()
+            if window <= 0:                    # legacy per-event behavior
+                task = asyncio.get_running_loop().create_task(
+                    self._scan_swallow_errors(),
+                )
+                self._fs_debounce_task = task
+                return
+            if (self._fs_debounce_task is not None
+                    and not self._fs_debounce_task.done()):
+                self._fs_events_absorbed += 1
+                return
+            self._fs_events_absorbed = 0
+            self._fs_debounce_task = asyncio.get_running_loop().create_task(
+                self._debounced_scan(window),
+            )
+        except Exception:  # noqa: BLE001
+            logger.debug("[DocSensor] debounce scheduling error", exc_info=True)
+
+    async def _debounced_scan(self, window: float) -> None:
+        try:
+            await asyncio.sleep(window)
+            import time as _time
+            since_last = _time.monotonic() - self._last_scan_done_mono
+            if (self._last_scan_done_mono > 0
+                    and since_last < _min_rescan_interval_s()):
+                logger.debug(
+                    "[DocSensor] burst absorbed (%d events) — scan %.0fs "
+                    "ago answers it; skipping",
+                    self._fs_events_absorbed + 1, since_last,
+                )
+                return
+            logger.debug(
+                "[DocSensor] debounce window closed (%d events absorbed) "
+                "— one rescan", self._fs_events_absorbed + 1,
+            )
+            await self._scan_swallow_errors()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            logger.debug("[DocSensor] debounced scan error", exc_info=True)
+
+    async def _scan_swallow_errors(self) -> None:
+        try:
+            await self.scan_once()
+        except Exception:  # noqa: BLE001
+            logger.debug("[DocSensor] Event-driven scan error", exc_info=True)
 
     async def _poll_loop(self) -> None:
         # Delay scan — docs are lowest priority
@@ -370,6 +455,10 @@ class DocStalenessSensor:
         # cartographer's current state so the next cycle can detect
         # post-scan changes.
         self._merkle_last_seen_root_hash = current_hash
+        # Cooldown stamp: a completed FULL scan answers any event burst
+        # for the next _min_rescan_interval_s() (debounce consult).
+        import time as _time
+        self._last_scan_done_mono = _time.monotonic()
 
         # Emit envelopes
         emitted = 0

--- a/tests/governance/intake/test_doc_staleness_debounce.py
+++ b/tests/governance/intake/test_doc_staleness_debounce.py
@@ -1,0 +1,115 @@
+"""Regression spine for the doc_staleness FS-event debounce (2026-07-23).
+
+Run #14 autopsy: this sensor produced 1049/1065 pool submissions by
+reacting to the session's OWN .py writes — one full rglob+AST rescan
+PER fs.changed event, upstream of every governor cap. Window-absorb
+semantics (Slice 5 T2 pattern) + a completed-scan cooldown make a
+thousand-event burst cost exactly ONE scan (or zero, if a fresh scan
+already answers it).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+
+@pytest.fixture()
+def sensor_module():
+    import backend.core.ouroboros.governance.intake.sensors.doc_staleness_sensor as m
+    return m
+
+
+def _bare_sensor(sensor_module):
+    s = sensor_module.DocStalenessSensor.__new__(sensor_module.DocStalenessSensor)
+    s._fs_debounce_task = None
+    s._fs_events_absorbed = 0
+    s._last_scan_done_mono = 0.0
+    return s
+
+
+class _PyEvt:
+    topic = "fs.changed.modified"
+    payload = {"relative_path": "backend/x.py", "extension": ".py"}
+
+
+@pytest.mark.asyncio
+async def test_event_burst_costs_one_scan(sensor_module, monkeypatch):
+    """1000 events inside the window → exactly ONE scan_once."""
+    monkeypatch.setenv("JARVIS_DOC_STALENESS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DOCSTALE_FS_DEBOUNCE_S", "0.1")
+    monkeypatch.setenv("JARVIS_DOCSTALE_MIN_RESCAN_S", "0")
+    s = _bare_sensor(sensor_module)
+    calls = {"n": 0}
+
+    async def _scan():
+        calls["n"] += 1
+        return []
+
+    s.scan_once = _scan  # type: ignore[method-assign]
+    for _ in range(1000):
+        await s._on_fs_event(_PyEvt())
+    await asyncio.sleep(0.3)                   # window closes
+    assert calls["n"] == 1
+    assert s._fs_events_absorbed == 999
+
+
+@pytest.mark.asyncio
+async def test_fresh_scan_cooldown_skips_the_burst(sensor_module, monkeypatch):
+    """A scan completed moments ago answers the burst — zero new scans."""
+    import time
+    monkeypatch.setenv("JARVIS_DOC_STALENESS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DOCSTALE_FS_DEBOUNCE_S", "0.05")
+    monkeypatch.setenv("JARVIS_DOCSTALE_MIN_RESCAN_S", "300")
+    s = _bare_sensor(sensor_module)
+    s._last_scan_done_mono = time.monotonic()  # just scanned
+    calls = {"n": 0}
+
+    async def _scan():
+        calls["n"] += 1
+        return []
+
+    s.scan_once = _scan  # type: ignore[method-assign]
+    await s._on_fs_event(_PyEvt())
+    await asyncio.sleep(0.2)
+    assert calls["n"] == 0
+
+
+@pytest.mark.asyncio
+async def test_window_zero_restores_legacy_per_event(sensor_module, monkeypatch):
+    monkeypatch.setenv("JARVIS_DOC_STALENESS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DOCSTALE_FS_DEBOUNCE_S", "0")
+    s = _bare_sensor(sensor_module)
+    calls = {"n": 0}
+
+    async def _scan():
+        calls["n"] += 1
+        return []
+
+    s.scan_once = _scan  # type: ignore[method-assign]
+    for _ in range(3):
+        await s._on_fs_event(_PyEvt())
+        await asyncio.sleep(0.01)
+    await asyncio.sleep(0.05)
+    assert calls["n"] == 3                     # byte-identical legacy
+
+
+@pytest.mark.asyncio
+async def test_second_burst_after_window_scans_again(sensor_module, monkeypatch):
+    monkeypatch.setenv("JARVIS_DOC_STALENESS_ENABLED", "true")
+    monkeypatch.setenv("JARVIS_DOCSTALE_FS_DEBOUNCE_S", "0.05")
+    monkeypatch.setenv("JARVIS_DOCSTALE_MIN_RESCAN_S", "0")
+    s = _bare_sensor(sensor_module)
+    calls = {"n": 0}
+
+    async def _scan():
+        calls["n"] += 1
+        return []
+
+    s.scan_once = _scan  # type: ignore[method-assign]
+    await s._on_fs_event(_PyEvt())
+    await asyncio.sleep(0.15)
+    await s._on_fs_event(_PyEvt())
+    await asyncio.sleep(0.15)
+    assert calls["n"] == 2                     # fresh signal still flows

--- a/tests/test_ouroboros_governance/test_dream_engine.py
+++ b/tests/test_ouroboros_governance/test_dream_engine.py
@@ -1388,3 +1388,93 @@ async def test_recovery_tracer_fires_only_when_bypassed(tmp_path, monkeypatch):
     _surface(monkeypatch, tmp_path, _SV.UPSTREAM_DEGRADED, times=3)
     await eng._trace_dw_recovery_if_bypassed()
     assert len(calls) == 1                          # degraded -> probe for recovery
+
+
+# ============================================================================
+# Exhaustion backoff (2026-07-23): a dead cascade is one fact, not a
+# per-30s warning storm
+# ============================================================================
+
+
+def _exhaustion_job_engine(tmp_path, monkeypatch, streaks_raise=True):
+    """A lean engine whose _run_dream_job reaches _call_inference
+    directly (candidate/dedup/preemption seams pinned)."""
+    from backend.core.ouroboros.consciousness.dream_engine import (
+        DreamProviderExhaustedError,
+    )
+    eng = _rt_engine(tmp_path)
+    monkeypatch.setattr(eng, "_hydrate_repo_state", lambda: None)
+    monkeypatch.setattr(
+        eng, "_trace_dw_recovery_if_bypassed", AsyncMock(),
+    )
+    monkeypatch.setattr(eng, "_pick_candidate", lambda: {
+        "repo_sha": "a" * 40, "policy_hash": "b" * 8,
+        "prompt_family": "f", "model_class": "m",
+        "target": "backend/x.py", "reason": "test",
+    })
+    monkeypatch.setattr(
+        eng, "_is_job_completed", lambda *a, **k: False,
+    )
+    monkeypatch.setattr(eng, "_check_preempted", lambda: False)
+    monkeypatch.setattr(eng, "_build_dream_prompt", lambda c: "p", raising=False)
+    if streaks_raise:
+        monkeypatch.setattr(
+            eng, "_call_inference",
+            AsyncMock(side_effect=DreamProviderExhaustedError("all down")),
+        )
+    return eng
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_backoff_escalates_and_quiets(
+    tmp_path, monkeypatch, caplog,
+):
+    """Consecutive full-cascade exhaustions double the cooldown; only the
+    FIRST is a WARNING (the rest are INFO — the log-storm kill)."""
+    import logging
+    monkeypatch.setenv("JARVIS_DREAM_EXHAUSTION_BACKOFF_BASE_S", "60")
+    monkeypatch.setenv("JARVIS_DREAM_EXHAUSTION_BACKOFF_MAX_S", "1800")
+    eng = _exhaustion_job_engine(tmp_path, monkeypatch)
+    with caplog.at_level(logging.INFO):
+        t0 = time.monotonic()
+        assert await eng._run_dream_job() is None
+        assert eng._exhaustion_streak == 1
+        assert 55 <= eng._exhaustion_until - t0 <= 65      # ~60s
+        assert await eng._run_dream_job() is None
+        assert eng._exhaustion_streak == 2
+        assert 115 <= eng._exhaustion_until - time.monotonic() <= 125  # ~120s
+    warns = [r for r in caplog.records
+             if "cascade exhausted" in r.message and r.levelname == "WARNING"]
+    infos = [r for r in caplog.records
+             if "cascade exhausted" in r.message and r.levelname == "INFO"]
+    assert len(warns) == 1 and len(infos) == 1
+
+
+@pytest.mark.asyncio
+async def test_exhaustion_backoff_caps_and_resets_on_success(
+    tmp_path, monkeypatch,
+):
+    monkeypatch.setenv("JARVIS_DREAM_EXHAUSTION_BACKOFF_BASE_S", "60")
+    monkeypatch.setenv("JARVIS_DREAM_EXHAUSTION_BACKOFF_MAX_S", "300")
+    eng = _exhaustion_job_engine(tmp_path, monkeypatch)
+    for _ in range(6):
+        await eng._run_dream_job()
+    assert eng._exhaustion_until - time.monotonic() <= 305  # capped, not 1920s
+    # A recovered cascade resets the streak instantly.
+    dw = MagicMock()
+    dw.complete_sync = AsyncMock(return_value=_SyncResult(_BP_JSON))
+    eng2 = _rt_engine(tmp_path, dw=dw, claude=MagicMock())
+    eng2._exhaustion_streak = 5
+    eng2._exhaustion_until = time.monotonic() + 999
+    monkeypatch.setattr(eng2, "_hydrate_repo_state", lambda: None)
+    monkeypatch.setattr(eng2, "_trace_dw_recovery_if_bypassed", AsyncMock())
+    monkeypatch.setattr(eng2, "_pick_candidate", lambda: {
+        "repo_sha": "a" * 40, "policy_hash": "b" * 8,
+        "prompt_family": "f", "model_class": "m",
+        "target": "backend/x.py", "reason": "test",
+    })
+    monkeypatch.setattr(eng2, "_is_job_completed", lambda *a, **k: False)
+    monkeypatch.setattr(eng2, "_check_preempted", lambda: False)
+    await eng2._run_dream_job()
+    assert eng2._exhaustion_streak == 0
+    assert eng2._exhaustion_until == 0.0


### PR DESCRIPTION
## The storm (1834 `ControlPlaneStarvation` events, lag ~1s)

This is the starvation that made a LIVE organism fail its own attach probes (companion PR #70080 fixes the CLI's reaction; this PR fixes the *cause*). Two producers:

### 1. DocStalenessSensor — one full rescan per fs event
The Run #14 autopsy class (1049/1065 pool submissions): every `.py` `fs.changed.*` event fired a **full `rglob`+AST rescan**, one executor submission per event, upstream of every SensorGovernor cap — and the session's own writes bust the Merkle short-circuit, so the guard never engaged.

**Fix**: window-absorb debounce (the Slice 5 T2 pattern from `test_failure_sensor` — first event opens the window, the rest are absorbed, ONE scan at close; `JARVIS_DOCSTALE_FS_DEBOUNCE_S`=45s, `0` = byte-identical legacy) + completed-scan cooldown (`JARVIS_DOCSTALE_MIN_RESCAN_S`=300s). A thousand-event burst now costs exactly one scan — or zero if a fresh scan already answers it. The 24h poll still guarantees coverage.

### 2. DreamEngine — per-30s retry storm on a dead cascade
With ALL RT tiers down it re-attempted the full cascade every loop tick indefinitely, one WARNING per tick.

**Fix**: escalating cooldown on `DreamProviderExhaustedError` (60s doubling to a 30-min cap, `JARVIS_DREAM_EXHAUSTION_BACKOFF_{BASE,MAX}_S`), gated quietly in the loop; first exhaustion stays WARNING, repeats demote to INFO; **any success resets the streak instantly** — recovery is never delayed.

### Posture signals: exonerated
Already offloaded via `cooperative_fs_io` — their LoopSink readings were awaits inflated by the two real producers above.

## Proof
6 new regression cases (burst→one-scan, cooldown-skip, window-0 legacy parity, re-arm, backoff escalation + log quieting, cap + reset-on-success); **108 green** across all four affected suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops control-plane starvation by debouncing doc-staleness rescans and adding exponential backoff when the dream provider cascade is exhausted. Cuts thousands of event-driven scans to one per burst and silences per-tick warning storms without delaying recovery.

- **Bug Fixes**
  - DocStalenessSensor: window-absorb debounce for `.py` FS events plus a post-scan cooldown. Burst now triggers one rescan, or zero if a recent scan exists. Tunables: `JARVIS_DOCSTALE_FS_DEBOUNCE_S` (default 45s, set `0` for legacy per-event), `JARVIS_DOCSTALE_MIN_RESCAN_S` (default 300s).
  - DreamEngine: escalating cooldown on `DreamProviderExhaustedError` with instant reset on success. First exhaustion logs WARNING, subsequent ones log INFO. Tunables: `JARVIS_DREAM_EXHAUSTION_BACKOFF_BASE_S` (default 60s), `JARVIS_DREAM_EXHAUSTION_BACKOFF_MAX_S` (default 1800s).
  - Tests: added 6 regressions covering debounce behavior, cooldown skip, legacy parity, re-arm, backoff escalation/quieting, cap and reset-on-success.

<sup>Written for commit a4fd5e2f2119107e6364c67c43d8d7f63b0768b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70081?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

