### PR TITLE
Feat(cockpit): CC-style live tool activity + heartbeat pulse in ov

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -1,0 +1,207 @@
+"""Attach Heartbeat — the CC-style live pulse for `ov` cockpits.
+
+``✽ Synthesizing… (4m 9s · ↓ 15.9k tokens · DW-397B)``
+
+Two pure halves, one schema (``heartbeat.v1``):
+
+* **Daemon composer** — :func:`build_heartbeat_payload` samples the
+  EXISTING canonical sources (zero new state, pure pull):
+  ``StatusLineBuilder.snapshot()`` → phase / route / provider / active op;
+  ``ThinkingProgressObserver.update()`` → verb phrase, elapsed, live
+  streamed token counts (StreamRenderer singleton underneath), effort
+  band; SerpentFlow's ``_prov()`` → the pretty provider label
+  (DW-397B / Claude / J-Prime). The harness publishes the payload on a
+  ~1s cadence through ``CockpitAttachBridge.publish_telemetry``.
+
+* **Client formatter** — :func:`format_heartbeat_line` renders the
+  toolbar text with a TIME-DRIVEN pulse glyph (any reader at any moment
+  derives the same frame from the clock — zero animation tasks; the pt
+  Application's ``refresh_interval`` repaint animates it for free) and
+  a client-side elapsed advance (the seconds tick smoothly between 1 Hz
+  frames). Stale payloads (organism paused/died) render nothing so the
+  toolbar falls back to its idle text.
+
+Zero authority; stdlib-only on the client path; NEVER raises anywhere.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from typing import Any, Dict, Optional
+
+HEARTBEAT_SCHEMA_VERSION = "heartbeat.v1"
+
+#: Time-driven pulse frames (CC's breathing star). ASCII degradation is
+#: the terminal's problem to have — these are BMP codepoints like the
+#: rest of the cockpit glyph grammar.
+_PULSE_FRAMES = ("✽", "✻", "✽", "·")
+_PULSE_INTERVAL_S = 0.28
+
+#: Phase → gerund fallback when the narrative channel has no verb for
+#: the active op (post-GENERATE phases have no thinking stream). These
+#: are presentation labels, same class as the tool-icon map.
+_PHASE_VERBS = {
+    "CLASSIFY": "Classifying",
+    "ROUTE": "Routing",
+    "CONTEXT_EXPANSION": "Contextualizing",
+    "PLAN": "Planning",
+    "GENERATE": "Synthesizing",
+    "VALIDATE": "Validating",
+    "GATE": "Gating",
+    "APPROVE": "Awaiting approval",
+    "APPLY": "Applying",
+    "VERIFY": "Verifying",
+    "REPAIR": "Repairing",
+}
+
+
+def heartbeat_interval_s() -> float:
+    """Publisher cadence; ``0`` disables. Re-read at call time."""
+    try:
+        return max(0.0, min(30.0, float(os.environ.get(
+            "JARVIS_ATTACH_HEARTBEAT_S", "1.0"))))
+    except (TypeError, ValueError):
+        return 1.0
+
+
+def _stale_after_s() -> float:
+    try:
+        return max(2.0, float(os.environ.get(
+            "JARVIS_ATTACH_HEARTBEAT_STALE_S", "10")))
+    except (TypeError, ValueError):
+        return 10.0
+
+
+# ---------------------------------------------------------------------------
+# Daemon side — composer (pure pull over existing organs)
+# ---------------------------------------------------------------------------
+
+
+def build_heartbeat_payload() -> Optional[Dict[str, Any]]:
+    """Compose ONE heartbeat frame from the daemon's canonical status
+    sources. Returns None when there is nothing to say (no status
+    builder registered). NEVER raises."""
+    try:
+        from backend.core.ouroboros.battle_test.status_line import (
+            get_status_line_builder,
+        )
+        b = get_status_line_builder()
+        if b is None:
+            return None
+        snap = b.snapshot()
+        phase = (snap.phase or "").strip().upper()
+        op_id = snap.primary_op_id or ""
+
+        verb, elapsed_s, tokens_total, effort = "", 0.0, 0, ""
+        thinking_active = False
+        if op_id:
+            try:
+                from backend.core.ouroboros.governance.thinking_progress_aggregator import (  # noqa: E501
+                    get_default_observer,
+                )
+                tsnap, _ = get_default_observer().update(op_id=op_id)
+                if tsnap is not None:
+                    verb = tsnap.verb_phrase or ""
+                    elapsed_s = float(tsnap.elapsed_s or 0.0)
+                    tokens_total = int(tsnap.tokens_total)
+                    effort = tsnap.effort_band.value
+                    thinking_active = bool(tsnap.is_active)
+            except Exception:  # noqa: BLE001
+                pass
+
+        phase_verb = _PHASE_VERBS.get(phase, "")
+        active = bool(thinking_active or phase_verb)
+        if not verb or not thinking_active:
+            verb = phase_verb or verb
+        if elapsed_s <= 0.0:
+            # Post-GENERATE phases: the builder's detail is "NNs".
+            detail = (snap.phase_detail or "").strip()
+            if detail.endswith("s") and detail[:-1].isdigit():
+                elapsed_s = float(detail[:-1])
+
+        provider = (snap.provider or "").strip()
+        provider_label = provider
+        if provider:
+            try:
+                from backend.core.ouroboros.battle_test.serpent_flow import (
+                    _prov,
+                )
+                provider_label = _prov(provider) or provider
+            except Exception:  # noqa: BLE001
+                provider_label = provider
+
+        return {
+            "kind": "heartbeat",
+            "schema_version": HEARTBEAT_SCHEMA_VERSION,
+            "active": active,
+            "verb": verb,
+            "phase": phase,
+            "elapsed_s": round(elapsed_s, 1),
+            "tokens_total": tokens_total,
+            "effort": effort,
+            "provider": provider,
+            "provider_label": provider_label,
+            "route": snap.route or "",
+            "op_id": op_id,
+        }
+    except Exception:  # noqa: BLE001
+        return None
+
+
+# ---------------------------------------------------------------------------
+# Client side — formatter (pure; time-driven pulse; NEVER raises)
+# ---------------------------------------------------------------------------
+
+
+def _fmt_elapsed(s: float) -> str:
+    s = max(0, int(s))
+    if s < 60:
+        return f"{s}s"
+    if s < 3600:
+        return f"{s // 60}m {s % 60}s"
+    return f"{s // 3600}h {(s % 3600) // 60}m"
+
+
+def _fmt_tokens(n: int) -> str:
+    n = max(0, int(n))
+    if n >= 1000:
+        return f"{n / 1000:.1f}k"
+    return str(n)
+
+
+def format_heartbeat_line(
+    payload: Optional[Dict[str, Any]],
+    *,
+    now_mono: Optional[float] = None,
+    arrival_mono: Optional[float] = None,
+) -> str:
+    """Render the CC-style pulse line from the latest heartbeat frame.
+    Empty string when inactive/stale/absent — the caller's toolbar falls
+    back to its idle text. Elapsed advances client-side between frames;
+    the pulse glyph derives from the clock. NEVER raises."""
+    try:
+        if not payload or not payload.get("active"):
+            return ""
+        now = time.monotonic() if now_mono is None else float(now_mono)
+        arrived = now if arrival_mono is None else float(arrival_mono)
+        age = max(0.0, now - arrived)
+        if age > _stale_after_s():
+            return ""
+        glyph = _PULSE_FRAMES[
+            int(now / _PULSE_INTERVAL_S) % len(_PULSE_FRAMES)
+        ]
+        verb = str(payload.get("verb") or "Working")
+        elapsed = float(payload.get("elapsed_s") or 0.0) + age
+        parts = [_fmt_elapsed(elapsed)]
+        tokens = int(payload.get("tokens_total") or 0)
+        if tokens > 0:
+            parts.append(f"↓ {_fmt_tokens(tokens)} tokens")
+        label = str(
+            payload.get("provider_label") or payload.get("provider") or ""
+        )
+        if label:
+            parts.append(label)
+        return f" {glyph} {verb}… ({' · '.join(parts)})"
+    except Exception:  # noqa: BLE001
+        return ""

--- a/backend/core/ouroboros/battle_test/cockpit_attach.py
+++ b/backend/core/ouroboros/battle_test/cockpit_attach.py
@@ -17,7 +17,16 @@ Protocol (newline-delimited JSON, schema ``cockpit_attach.v1``):
   * **Downstream frames** — ``{"type":"line","text":...}``: every line
     the harness's ``_repl_print`` chokepoint emits (ALREADY conformed by
     the PresentationRouter — the attach surface inherits the design
-    language for free).
+    language for free). Clients render this frame ESCAPED (inert DATA).
+  * **Styled frames (v2.2, Tool Activity)** — ``{"type":"markup",
+    "text":...}``: DAEMON-COMPOSED Rich-markup lines mirrored from
+    SerpentFlow's op-scoped render chokepoint (``markup_mirror``) — the
+    CC-style ``⏺ Bash(...)`` / ``⏺ Update(path)`` + numbered-diff /
+    ``⎿ result`` blocks. The composition layer (tool_render_view)
+    escapes all MODEL-controlled content before wrapping in markup, so
+    the frame is styled chrome around inert data; clients render it
+    unescaped (with a validate-else-escape fail-soft). Master:
+    ``JARVIS_ATTACH_TOOL_ACTIVITY_ENABLED`` (default on).
   * **Upstream frames** — ``{"type":"input","text":...}``: operator
     stdin from the attached terminal, routed into the harness's
     ``_handle_repl_command`` — the FULL verb set plus the bare-text
@@ -105,6 +114,14 @@ def _connect_timeout_s() -> float:
         )))
     except (TypeError, ValueError):
         return 0.5
+
+
+def tool_activity_enabled() -> bool:
+    """Master gate for the typed ``markup`` frame (CC-style tool blocks /
+    diffs mirrored to attached cockpits). Default ON. NEVER raises."""
+    return os.environ.get(
+        "JARVIS_ATTACH_TOOL_ACTIVITY_ENABLED", "1",
+    ).strip().lower() in _TRUTHY
 
 
 def _sentinel_interval_s() -> float:
@@ -342,6 +359,36 @@ class CockpitAttachBridge:
         except Exception:  # noqa: BLE001
             logger.debug("[CockpitAttach] publish degraded", exc_info=True)
 
+    def publish_markup(self, text: str) -> None:
+        """Broadcast one DAEMON-COMPOSED styled line (Rich markup) to every
+        attached terminal — the CC-style tool-activity channel (⏺ Bash /
+        ⏺ Update diffs / ⎿ results). TYPED separately from ``line`` so the
+        client can render it unescaped: the composition layer
+        (tool_render_view / serpent_flow) escapes all MODEL-controlled
+        content before wrapping it in markup, so the frame is styled chrome
+        around inert data. Untrusted/raw text must NEVER travel here — use
+        publish_line. Strictly non-blocking; thread-safe; NEVER raises."""
+        try:
+            if not self._clients or not tool_activity_enabled():
+                return
+            msg = {"type": "markup", "text": str(text), "ts": time.time()}
+            self.stats["markup_published"] = (
+                self.stats.get("markup_published", 0) + 1
+            )
+            loop = self._loop
+            if loop is None or loop.is_closed():
+                return
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is loop:
+                self._broadcast(msg)
+            else:
+                loop.call_soon_threadsafe(self._broadcast, msg)
+        except Exception:  # noqa: BLE001
+            logger.debug("[CockpitAttach] markup publish degraded", exc_info=True)
+
     def publish_audio_state(self, state: str) -> None:
         """Stream one audio-FSM state to every attached terminal
         (edge-coalesced: republishing the current state is a no-op).
@@ -526,6 +573,8 @@ class CockpitAttachClient:
         *,
         on_hydration: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_line: Optional[Callable[[str], None]] = None,
+        on_markup: Optional[Callable[[str], None]] = None,
+        on_telemetry: Optional[Callable[[Dict[str, Any]], None]] = None,
         on_audio_state: Optional[Callable[[str], None]] = None,
         on_thermal: Optional[Callable[[str], None]] = None,
         path: Optional[Path] = None,
@@ -533,6 +582,11 @@ class CockpitAttachClient:
         self._path = Path(path) if path is not None else attach_socket_path()
         self._on_hydration = on_hydration or (lambda _m: None)
         self._on_line = on_line or (lambda _t: None)
+        # Typed styled channel: daemon-composed tool blocks / diffs. When
+        # unset, markup frames degrade to the on_line callback (rendered
+        # escaped by conservative clients — never dropped).
+        self._on_markup = on_markup
+        self._on_telemetry = on_telemetry or (lambda _m: None)
         self._on_audio_state = on_audio_state or (lambda _s: None)
         self._on_thermal = on_thermal or (lambda _s: None)
         self._reader: Optional[asyncio.StreamReader] = None
@@ -646,6 +700,16 @@ class CockpitAttachClient:
                 ftype = frame.get("type")
                 if ftype == "line":
                     self._safe_cb_text(self._on_line, str(frame.get("text", "")))
+                elif ftype == "markup":
+                    # Daemon-composed styled line. No on_markup handler →
+                    # degrade to on_line (conservative clients escape it).
+                    cb = self._on_markup or self._on_line
+                    self._safe_cb_text(cb, str(frame.get("text", "")))
+                elif ftype == "telemetry":
+                    try:
+                        self._on_telemetry(dict(frame))
+                    except Exception:  # noqa: BLE001
+                        pass
                 elif ftype == "audio_state":
                     self._safe_cb_text(
                         self._on_audio_state, str(frame.get("state", "")),

--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4354,6 +4354,34 @@ class BattleTestHarness:
         except Exception:  # noqa: BLE001 — supervisor is best-effort
             self._autonomous_supervisor = None
 
+    async def _attach_heartbeat_loop(self, bridge: Any) -> None:
+        """Publish the CC-style status pulse to attached cockpits on a
+        ~1s cadence (JARVIS_ATTACH_HEARTBEAT_S; 0 disables). Pure pull
+        over existing organs (StatusLineBuilder + ThinkingProgress
+        observer) — zero new state. NEVER raises; dies with shutdown."""
+        try:
+            from backend.core.ouroboros.battle_test.attach_heartbeat import (
+                build_heartbeat_payload,
+                heartbeat_interval_s,
+            )
+            while True:
+                interval = heartbeat_interval_s()
+                if interval <= 0:
+                    await asyncio.sleep(5.0)     # disabled — re-check knob
+                    continue
+                try:
+                    if getattr(bridge, "client_count", 0) > 0:
+                        payload = build_heartbeat_payload()
+                        if payload is not None:
+                            bridge.publish_telemetry(payload)
+                except Exception:  # noqa: BLE001
+                    pass
+                await asyncio.sleep(interval)
+        except asyncio.CancelledError:
+            return
+        except Exception:  # noqa: BLE001
+            return
+
     # -- Cockpit Attach Bridge (CLI item #6) --------------------------------
 
     async def _start_cockpit_attach_bridge(self) -> None:
@@ -4463,6 +4491,26 @@ class BattleTestHarness:
             )
             if await bridge.start():
                 self._cockpit_attach_bridge = bridge
+                # Tool-activity mirror (2026-07-23): wire SerpentFlow's
+                # op-scoped render chokepoint to the bridge's typed
+                # markup channel — attached `ov` cockpits see the SAME
+                # CC-style ⏺/⎿ tool blocks + diffs the local console
+                # renders (composition layer escapes model content).
+                try:
+                    sf = getattr(self, "_serpent_flow", None)
+                    if sf is not None:
+                        sf.markup_mirror = bridge.publish_markup
+                except Exception:  # noqa: BLE001
+                    pass
+                # Attach heartbeat (2026-07-23): ~1s CC-style pulse
+                # (verb · elapsed · ↓ tokens · provider) published on
+                # the telemetry lane; publish_telemetry no-ops with
+                # zero clients so an unattached organism pays nothing.
+                try:
+                    self._attach_heartbeat_task = asyncio.get_running_loop(
+                    ).create_task(self._attach_heartbeat_loop(bridge))
+                except Exception:  # noqa: BLE001
+                    self._attach_heartbeat_task = None
                 # Hive Step 1: the harness IS the live pipeline host (16
                 # sensors + GovernedLoop run in THIS process), so `ov hive`
                 # must project from here too — the SAME read-only relay the
@@ -8337,6 +8385,13 @@ class BattleTestHarness:
             if _awe is not None:
                 await _awe.stop()
                 self._awe_trigger = None
+        except Exception:
+            pass
+        try:
+            _hb = getattr(self, "_attach_heartbeat_task", None)
+            if _hb is not None:
+                _hb.cancel()
+                self._attach_heartbeat_task = None
         except Exception:
             pass
         try:

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -632,6 +632,12 @@ class SerpentFlow:
         self._idle_timeout_s = idle_timeout_s
         self._repo_path = repo_path or Path.cwd()
         self._started_at = time.time()
+        # Attach-cockpit markup mirror (2026-07-23) — injectable sink for
+        # every op-scoped rendered line (tool blocks, diffs, lifecycle).
+        # The harness wires this to CockpitAttachBridge.publish_markup so
+        # attached `ov` terminals see the SAME CC-style ⏺/⎿ activity the
+        # local console shows. None = local-only (byte-identical legacy).
+        self.markup_mirror: Optional[Callable[[str], None]] = None
 
         # Tracking
         self._completed: int = 0
@@ -1412,6 +1418,7 @@ class SerpentFlow:
         if op_id and op_id in self._active_ops:
             if not self._is_focused(op_id):
                 return
+            self._mirror_markup(f"  {text}")
             if self._borderless():
                 self._emit_fit(
                     f"  [{_C['dim']}]{self._result_glyph()}[/{_C['dim']}] {text}"
@@ -1423,7 +1430,22 @@ class SerpentFlow:
                 )
         else:
             # Out-of-band lines (system messages, banners) — always render
+            self._mirror_markup(f"  {text}")
             self.console.print(f"  {text}", highlight=False)
+
+    def _mirror_markup(self, line: str) -> None:
+        """Mirror ONE rendered markup line to the attach cockpit (when the
+        harness wired ``markup_mirror`` to the bridge). Width-agnostic: the
+        raw markup travels; each attached client fits it to its own canvas.
+        Best-effort — a mirror fault can never break the local render.
+        NEVER raises."""
+        m = self.markup_mirror
+        if m is None:
+            return
+        try:
+            m(line)
+        except Exception:  # noqa: BLE001
+            pass
 
     # ── Gap #3 Slice 3: op-block buffer integration helpers ──────
 

--- a/backend/core/ouroboros/cli/ov.py
+++ b/backend/core/ouroboros/cli/ov.py
@@ -66,6 +66,40 @@ def version_line() -> str:
     except Exception:
         return "ov — ouroboros + venom"
 
+def _render_markup_frame(text: str, console: Any = None) -> None:
+    """Render ONE daemon-composed styled line (the typed ``markup`` frame:
+    CC-style ⏺/⎿ tool blocks + numbered diffs). Unlike the untyped ``line``
+    frame (always escaped — inert DATA), markup frames carry daemon-authored
+    styling whose MODEL-controlled content was escaped at composition
+    (tool_render_view). Fail-soft: markup that does not parse renders
+    ESCAPED rather than dropped or crashing the canvas. NEVER raises."""
+    try:
+        from rich.text import Text as _RichText
+        from rich.markup import escape as _escape
+        raw = str(text)
+        try:
+            _RichText.from_markup(raw)          # validate before trusting
+            safe = raw
+        except Exception:  # noqa: BLE001 — malformed → inert fallback
+            safe = _escape(raw)
+        from backend.core.ouroboros.battle_test.bipartite_layout import (
+            get_active_canvas,
+        )
+        canvas = get_active_canvas()
+        if canvas is not None:
+            canvas.push_raw(safe)
+            return
+        if console is not None:
+            console.print(safe, highlight=False)
+        else:
+            print(raw)
+    except Exception:  # noqa: BLE001
+        try:
+            print(str(text))
+        except Exception:  # noqa: BLE001
+            pass
+
+
 _NO_ORGANISM_MESSAGE = (
     "no organism awake — nothing to attach to. Start one with `ov` "
     "(cockpit) or `ov daemon` (headless)."
@@ -309,6 +343,11 @@ class AttachUI:
     def __init__(self) -> None:
         self.audio_state: str = "OFFLINE"
         self._app_ref: Any = None
+        # Latest heartbeat frame (the CC-style pulse) + arrival clock —
+        # rendered by toolbar() with client-side elapsed advance and a
+        # time-driven glyph (the pt refresh_interval animates it free).
+        self._heartbeat: Any = None
+        self._heartbeat_arrived: float = 0.0
 
     def bind_app(self, app: Any) -> None:
         self._app_ref = app
@@ -324,7 +363,32 @@ class AttachUI:
             audio = " · voice: off ('wake')"
         else:
             audio = f" · voice: {self.audio_state.lower()}"
+        # CC-style live pulse while the organism works — falls back to
+        # the idle line when inactive/stale. NEVER raises.
+        try:
+            from backend.core.ouroboros.battle_test.attach_heartbeat import (
+                format_heartbeat_line,
+            )
+            pulse = format_heartbeat_line(
+                self._heartbeat, arrival_mono=self._heartbeat_arrived,
+            )
+            if pulse:
+                return f"{pulse}{audio} · 'detach' to leave"
+        except Exception:
+            pass
         return f" ov attach — organism live{audio} · 'detach' to leave"
+
+    def on_telemetry(self, frame: Any) -> None:
+        """Telemetry lane landing point — retain heartbeat frames for
+        the toolbar pulse; other telemetry kinds pass untouched.
+        NEVER raises."""
+        try:
+            if isinstance(frame, dict) and frame.get("kind") == "heartbeat":
+                import time as _time
+                self._heartbeat = frame
+                self._heartbeat_arrived = _time.monotonic()
+        except Exception:
+            pass
 
     def should_flush_on_input(self) -> bool:
         """Ducking predicate: the operator typed a NEW command while
@@ -671,6 +735,8 @@ def run_attach(console: Any) -> int:
 
         client = CockpitAttachClient(
             on_hydration=_on_hydration, on_line=_print_line,
+            on_markup=lambda t: _render_markup_frame(t, console),
+            on_telemetry=ui.on_telemetry,
             on_audio_state=ui.on_audio_state,
         )
         if not await client.connect():

--- a/tests/battle_test/test_attach_heartbeat.py
+++ b/tests/battle_test/test_attach_heartbeat.py
@@ -1,0 +1,180 @@
+"""Regression spine for the Attach Heartbeat — the CC-style live pulse
+(`✽ Synthesizing… (4m 9s · ↓ 15.9k tokens · DW-397B)`) in the ov cockpit.
+
+Covers: the pure formatter (pulse animation, elapsed advance, staleness,
+token/elapsed formatting, provider chip), the daemon composer's payload
+schema + provider labeling, the bridge telemetry roundtrip into the
+client's on_telemetry callback, and the AttachUI toolbar integration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test.attach_heartbeat import (
+    HEARTBEAT_SCHEMA_VERSION,
+    _fmt_elapsed,
+    _fmt_tokens,
+    build_heartbeat_payload,
+    format_heartbeat_line,
+    heartbeat_interval_s,
+)
+
+
+def _hb(**kw):
+    base = {
+        "kind": "heartbeat", "active": True, "verb": "Synthesizing",
+        "elapsed_s": 249.0, "tokens_total": 15900,
+        "provider_label": "DW-397B",
+    }
+    base.update(kw)
+    return base
+
+
+# ---------------------------------------------------------------------------
+# Formatter
+# ---------------------------------------------------------------------------
+
+
+def test_formatter_renders_cc_shape():
+    line = format_heartbeat_line(_hb(), now_mono=100.0, arrival_mono=100.0)
+    assert "Synthesizing…" in line
+    assert "(4m 9s · ↓ 15.9k tokens · DW-QUARANTINE" not in line
+    assert "4m 9s" in line and "↓ 15.9k tokens" in line and "DW-397B" in line
+
+
+def test_formatter_pulse_animates_from_clock():
+    a = format_heartbeat_line(_hb(), now_mono=100.00, arrival_mono=100.0)
+    b = format_heartbeat_line(_hb(), now_mono=100.30, arrival_mono=100.0)
+    assert a[:3] != b[:3]                      # the glyph breathes
+
+
+def test_formatter_elapsed_advances_client_side():
+    line = format_heartbeat_line(_hb(elapsed_s=58.0),
+                                 now_mono=105.0, arrival_mono=100.0)
+    assert "1m 3s" in line                     # 58 + 5s local advance
+
+
+def test_formatter_inactive_stale_and_absent_render_empty():
+    assert format_heartbeat_line(None) == ""
+    assert format_heartbeat_line(_hb(active=False)) == ""
+    assert format_heartbeat_line(_hb(), now_mono=200.0,
+                                 arrival_mono=100.0) == ""   # stale
+
+
+def test_formatter_omits_empty_segments():
+    line = format_heartbeat_line(
+        _hb(tokens_total=0, provider_label="", provider=""),
+        now_mono=1.0, arrival_mono=1.0,
+    )
+    assert "tokens" not in line and "·" not in line.split("(", 1)[1]
+
+
+def test_formatter_never_raises_on_garbage():
+    assert format_heartbeat_line({"active": True, "elapsed_s": "junk"}) == "" \
+        or isinstance(format_heartbeat_line(
+            {"active": True, "elapsed_s": "junk"}), str)
+    assert isinstance(format_heartbeat_line({"active": object()}), str)
+
+
+def test_helpers_format():
+    assert _fmt_elapsed(9) == "9s"
+    assert _fmt_elapsed(249) == "4m 9s"
+    assert _fmt_elapsed(3900) == "1h 5m"
+    assert _fmt_tokens(950) == "950"
+    assert _fmt_tokens(15900) == "15.9k"
+
+
+# ---------------------------------------------------------------------------
+# Daemon composer
+# ---------------------------------------------------------------------------
+
+
+def test_composer_none_without_status_builder(monkeypatch):
+    from backend.core.ouroboros.battle_test import status_line as sl
+    monkeypatch.setattr(sl, "_STATUS_LINE_BUILDER", None, raising=False)
+    assert build_heartbeat_payload() is None
+
+
+def test_composer_schema_and_provider_label(monkeypatch):
+    """A registered builder yields a schema-stamped payload with the
+    pretty provider chip resolved through serpent_flow's own map."""
+    from backend.core.ouroboros.battle_test import status_line as sl
+
+    class _Snap:
+        phase, phase_detail = "GENERATE", "47s"
+        primary_op_id, route, provider = "op-1", "standard", "doubleword"
+
+    class _B:
+        def snapshot(self):
+            return _Snap()
+
+    monkeypatch.setattr(sl, "get_status_line_builder", lambda: _B())
+    payload = build_heartbeat_payload()
+    assert payload is not None
+    assert payload["schema_version"] == HEARTBEAT_SCHEMA_VERSION
+    assert payload["active"] is True
+    assert payload["verb"]                     # phase verb at minimum
+    assert payload["provider_label"] == "DW-397B"
+    assert payload["elapsed_s"] >= 47.0        # parsed from phase_detail
+
+
+def test_interval_env_knob(monkeypatch):
+    monkeypatch.setenv("JARVIS_ATTACH_HEARTBEAT_S", "2.5")
+    assert heartbeat_interval_s() == 2.5
+    monkeypatch.setenv("JARVIS_ATTACH_HEARTBEAT_S", "0")
+    assert heartbeat_interval_s() == 0.0
+
+
+# ---------------------------------------------------------------------------
+# Bridge roundtrip + AttachUI toolbar
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def sock():
+    import shutil
+    import tempfile
+    from pathlib import Path
+    d = tempfile.mkdtemp(prefix="cahb")
+    try:
+        yield Path(d) / "a.sock"
+    finally:
+        shutil.rmtree(d, ignore_errors=True)
+
+
+async def test_telemetry_roundtrip_lands_in_on_telemetry(sock):
+    import backend.core.ouroboros.battle_test.cockpit_attach as ca
+    b = ca.CockpitAttachBridge(path=sock)
+    assert await b.start() is True
+    try:
+        got = []
+        c = ca.CockpitAttachClient(path=sock, on_telemetry=got.append)
+        assert await c.connect() is True
+        b.publish_telemetry(_hb())
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if got:
+                break
+        assert got and got[0]["kind"] == "heartbeat"
+        assert got[0]["provider_label"] == "DW-397B"
+        c.close()
+    finally:
+        await b.stop()
+
+
+def test_attach_ui_toolbar_shows_pulse_then_falls_back():
+    from backend.core.ouroboros.cli.ov import AttachUI
+    ui = AttachUI()
+    idle = ui.toolbar()
+    assert "organism live" in idle             # idle fallback
+    ui.on_telemetry(_hb())
+    live = ui.toolbar()
+    assert "Synthesizing…" in live and "DW-397B" in live
+    assert "'detach' to leave" in live         # chrome retained
+    ui.on_telemetry({"kind": "other", "x": 1})  # non-heartbeat ignored
+    assert "Synthesizing…" in ui.toolbar()
+    ui._heartbeat_arrived -= 60.0              # goes stale
+    assert "organism live" in ui.toolbar()

--- a/tests/battle_test/test_cockpit_attach.py
+++ b/tests/battle_test/test_cockpit_attach.py
@@ -507,3 +507,125 @@ async def test_connect_fails_fast_on_dead_socket(sock, monkeypatch):
     t0 = _time.monotonic()
     assert await c.connect() is False
     assert _time.monotonic() - t0 < 3.0        # fast, not 30s
+
+
+# ---------------------------------------------------------------------------
+# Tool-activity markup channel (CC-style ⏺/⎿ blocks + diffs → ov cockpit)
+# ---------------------------------------------------------------------------
+
+
+async def test_markup_frame_roundtrip(sock):
+    """publish_markup → typed frame → client on_markup, verbatim styled."""
+    b = await _server(sock)
+    try:
+        got_markup, got_lines = [], []
+        c = ca.CockpitAttachClient(
+            path=sock,
+            on_line=got_lines.append,
+            on_markup=got_markup.append,
+        )
+        assert await c.connect() is True
+        styled = "  [green]⏺ Bash[/green]([cyan]pytest tests/[/cyan])"
+        b.publish_markup(styled)
+        b.publish_line("plain chatter")
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if got_markup and got_lines:
+                break
+        assert got_markup == [styled]          # styled channel, verbatim
+        assert got_lines == ["plain chatter"]  # untyped channel untouched
+        c.close()
+    finally:
+        await b.stop()
+
+
+async def test_markup_gate_off_publishes_nothing(sock, monkeypatch):
+    monkeypatch.setenv("JARVIS_ATTACH_TOOL_ACTIVITY_ENABLED", "0")
+    b = await _server(sock)
+    try:
+        got = []
+        c = ca.CockpitAttachClient(path=sock, on_markup=got.append)
+        assert await c.connect() is True
+        b.publish_markup("[red]x[/red]")
+        b.publish_line("beacon")               # proves the pipe flows
+        lines = []
+        c._on_line = lines.append
+        b.publish_line("beacon2")
+        for _ in range(50):
+            await asyncio.sleep(0.02)
+            if lines:
+                break
+        assert got == []                       # gated channel silent
+        c.close()
+    finally:
+        await b.stop()
+
+
+async def test_markup_degrades_to_on_line_without_handler(sock):
+    """A conservative client (no on_markup) still SEES the content —
+    delivered through on_line where it renders escaped, never dropped."""
+    b = await _server(sock)
+    try:
+        got_lines = []
+        c = ca.CockpitAttachClient(path=sock, on_line=got_lines.append)
+        assert await c.connect() is True
+        b.publish_markup("[green]+ added[/green]")
+        for _ in range(100):
+            await asyncio.sleep(0.02)
+            if got_lines:
+                break
+        assert got_lines == ["[green]+ added[/green]"]
+        c.close()
+    finally:
+        await b.stop()
+
+
+def test_serpent_flow_op_line_mirrors_markup():
+    """The ONE render chokepoint mirrors every op-scoped line to the
+    bridge sink — and a sink fault can never break the local render."""
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+    sf = SerpentFlow(session_id="t", branch_name="b")
+    mirrored = []
+    sf.markup_mirror = mirrored.append
+    sf._op_line("", "[dim]system banner[/dim]")     # out-of-band line
+    assert mirrored == ["  [dim]system banner[/dim]"]
+    # A crashing sink is swallowed — local render (and caller) unaffected.
+    sf.markup_mirror = lambda _l: (_ for _ in ()).throw(RuntimeError("gone"))
+    sf._op_line("", "still fine")                    # must not raise
+    # None (default) = zero-cost no-op
+    sf2 = SerpentFlow()
+    assert sf2.markup_mirror is None
+    sf2._op_line("", "local only")
+
+
+def test_harness_wires_mirror_to_bridge():
+    """Wiring invariant: the harness connects SerpentFlow.markup_mirror to
+    the bridge's publish_markup at the attach-bridge mount."""
+    from pathlib import Path
+    root = Path(__file__).resolve().parents[2]
+    harness_src = (
+        root / "backend/core/ouroboros/battle_test/harness.py"
+    ).read_text()
+    assert "sf.markup_mirror = bridge.publish_markup" in harness_src
+
+
+def test_ov_markup_renderer_fail_soft():
+    """Client-side: valid markup passes through; MALFORMED markup renders
+    escaped (inert) — the canvas can never crash on a bad frame."""
+    from backend.core.ouroboros.cli.ov import _render_markup_frame
+    from backend.core.ouroboros.battle_test.bipartite_layout import (
+        BipartiteLayout,
+        set_active_canvas,
+    )
+    mux = BipartiteLayout(width=100, height=20)
+    set_active_canvas(mux)
+    try:
+        _render_markup_frame("  [green]⏺ Bash[/green](ls)")
+        _render_markup_frame("  [bold]mismatched[/red]")   # raises in Rich
+        snap = mux._buffer.snapshot()
+        assert snap[0] == "  [green]⏺ Bash[/green](ls)"    # trusted verbatim
+        assert "\\[" in snap[1]                            # escaped, inert
+        ansi = mux.render_canvas_ansi()                    # renders w/o raising
+        assert "Bash" in ansi
+    finally:
+        set_active_canvas(None)

--- a/tests/cli/test_thin_client.py
+++ b/tests/cli/test_thin_client.py
@@ -23,6 +23,16 @@ import pytest
 from backend.core.ouroboros.cli import thin_client
 
 
+@pytest.fixture(autouse=True)
+def _no_ambient_incumbent(monkeypatch):
+    """Hermeticity: ensure_daemon consults the REPO's real single-flight
+    lock via _live_incumbent — a warm daemon on the dev machine would
+    flip the ghost-clean branch under the tests' feet. Default to no
+    incumbent; tests that want one re-patch inside their own body."""
+    monkeypatch.setattr(thin_client, "_live_incumbent", lambda: None)
+    yield
+
+
 def _serving_handler(reader, writer):
     """Mirror of the REAL CockpitAttachBridge accept path: hydration frame
     written immediately on connect. Closes its writer on exit — on Python


### PR DESCRIPTION
## What the operator gets

Attached `ov` cockpits now show the organism working, CC-style:

- **Tool activity (Zone 1)** — `⏺ Bash(pytest tests/…)` / `⎿ 28 passed (3.2s)`, `⏺ Update(file.py)` with the numbered green/red diff, `⏺ Read(...)`, every Venom round — live.
- **Heartbeat pulse (toolbar)** — `✽ Synthesizing… (4m 9s · ↓ 15.9k tokens · DW-397B)` — activity verb, elapsed, live streamed token count, and **which brain is firing** (DW-397B primary / Claude fallback / J-Prime last resort).

## Why it didn't exist — one missing wire, twice

The whole pipeline was already live in-process: `ToolLoopCoordinator` narrates every tool call → `SerpentFlow.op_tool_call` composes registry-driven CC blocks → …and dies at `_op_line`, which prints to the **local console only**. `publish_line`'s sole caller was REPL chatter. Same story for status: the exact CC formatter (`thinking_progress_aggregator`), live token counts (StreamRenderer), and provider labels (`_PROV`) all existed with no periodic publisher and no client decoder.

## The fixes (one seam each, zero new renderers)

| Piece | Change |
|---|---|
| `SerpentFlow.markup_mirror` | injectable sink at the ONE op-scoped render chokepoint (`_op_line`) — tool blocks, diffs, lifecycle lines all mirror; `None` = byte-identical legacy |
| Bridge `{"type":"markup"}` (v2.2, additive) | typed styled channel; composition layer escapes all model-controlled content → styled chrome around inert data; untyped `line` frames stay escaped; clients without `on_markup` degrade to `on_line` |
| `ov` `_render_markup_frame` | validate-else-escape fail-soft — a malformed frame can never crash the canvas |
| `attach_heartbeat.py` | daemon composer (schema `heartbeat.v1`, pure pull over StatusLineBuilder + ThinkingProgress + `_prov` labels) + pure client formatter (time-driven pulse glyph, client-side elapsed advance, staleness fallback) |
| harness | wires the mirror at bridge mount; `_attach_heartbeat_loop` ~1s publisher (`JARVIS_ATTACH_HEARTBEAT_S`, 0=off; zero cost with no clients attached) |
| `CockpitAttachClient` | `on_telemetry` callback + decoder branch; `AttachUI.toolbar` renders the pulse ahead of the idle line |

Masters: `JARVIS_ATTACH_TOOL_ACTIVITY_ENABLED` (on), `JARVIS_ATTACH_HEARTBEAT_S` (1.0).

## Proof

40 new/updated tests (`test_cockpit_attach` 28 + `test_attach_heartbeat` 12): markup roundtrip verbatim + gate-off + no-handler degradation + mirror fault-isolation + fail-soft render; heartbeat formatter shape/pulse/elapsed-advance/staleness, composer schema + DW-397B labeling, telemetry roundtrip, toolbar integration. `thin_client` 35 green (with a hermeticity fix for dev machines running a warm daemon). Live pty proof of the fresh daemon in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds CC-style live tool activity and a heartbeat pulse to attached `ov` cockpits so operators can see what’s happening and token usage in real time. Backwards compatible for clients that don’t handle the new channel.

- **New Features**
  - Tool activity channel: mirrors op-scoped renders from `SerpentFlow` as typed `{"type":"markup"}` frames; clients render with a fail‑soft validator; gated by `JARVIS_ATTACH_TOOL_ACTIVITY_ENABLED` (on by default). Clients without `on_markup` degrade to `on_line` (escaped).
  - Heartbeat pulse: daemon builds `heartbeat.v1` payloads from existing status/thinking sources; harness publishes on the telemetry lane at `JARVIS_ATTACH_HEARTBEAT_S` (0=off); `AttachUI` toolbar shows a time‑driven pulse with verb · elapsed · ↓ tokens · provider, and falls back on staleness.
  - Wiring: harness connects `SerpentFlow.markup_mirror` → `CockpitAttachBridge.publish_markup`; `CockpitAttachClient` gains `on_telemetry`; zero overhead when no clients are attached.
  - Reliability: `ov`’s markup renderer validates or escapes to avoid canvas crashes; added tests for roundtrips, gating, degradation, fail‑soft rendering, heartbeat formatting, and toolbar integration.

<sup>Written for commit 53f317e22443d2e6f6f4de0be2ba63a95f87c005. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70082?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

