### PR TITLE
Feat(cockpit): Heartbeat pulse breathes in O+V's own voice — the Ouroboros spinner

### DIFF
--- a/backend/core/ouroboros/battle_test/attach_heartbeat.py
+++ b/backend/core/ouroboros/battle_test/attach_heartbeat.py
@@ -1,6 +1,10 @@
-"""Attach Heartbeat — the CC-style live pulse for `ov` cockpits.
+"""Attach Heartbeat — the live pulse for `ov` cockpits, in O+V's own voice.
 
-``✽ Synthesizing… (4m 9s · ↓ 15.9k tokens · DW-397B)``
+``🐍··○ Synthesizing… (4m 9s · ↓ 15.9k tokens · DW-397B)``
+
+The pulse glyph is the Ouroboros identity spinner (canonical in
+ui/theme.py — the same animation the daemon's REPL toolbar breathes),
+not a borrowed aesthetic.
 
 Two pure halves, one schema (``heartbeat.v1``):
 
@@ -32,11 +36,18 @@ from typing import Any, Dict, Optional
 
 HEARTBEAT_SCHEMA_VERSION = "heartbeat.v1"
 
-#: Time-driven pulse frames (CC's breathing star). ASCII degradation is
-#: the terminal's problem to have — these are BMP codepoints like the
-#: rest of the cockpit glyph grammar.
-_PULSE_FRAMES = ("✽", "✻", "✽", "·")
-_PULSE_INTERVAL_S = 0.28
+
+def _pulse_glyph(now: float) -> str:
+    """The pulse is O+V's OWN identity animation — the Ouroboros spinner
+    (snake closing on its tail, bite, reopen), consumed from its ONE
+    canonical definition in ui/theme.py (the same frames the daemon's
+    REPL spinner renders — every surface animates identically, derived
+    purely from the clock). NEVER raises."""
+    try:
+        from backend.core.ouroboros.ui.theme import ouroboros_frame
+        return ouroboros_frame(now)
+    except Exception:  # noqa: BLE001
+        return "🐍"
 
 #: Phase → gerund fallback when the narrative channel has no verb for
 #: the active op (post-GENERATE phases have no thinking stream). These
@@ -188,9 +199,7 @@ def format_heartbeat_line(
         age = max(0.0, now - arrived)
         if age > _stale_after_s():
             return ""
-        glyph = _PULSE_FRAMES[
-            int(now / _PULSE_INTERVAL_S) % len(_PULSE_FRAMES)
-        ]
+        glyph = _pulse_glyph(now)
         verb = str(payload.get("verb") or "Working")
         elapsed = float(payload.get("elapsed_s") or 0.0) + age
         parts = [_fmt_elapsed(elapsed)]

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -67,20 +67,14 @@ from rich.syntax import Syntax
 # multi-line frames — single-line ephemeral inline spinner only.
 _OUROBOROS_SPINNER_NAME = "ouroboros"
 
-_OUROBOROS_FRAMES = (
-    "🐍·····○",
-    "🐍····○",
-    "🐍···○",
-    "🐍··○",
-    "🐍·○",
-    "🐍◯",       # bite — eating own tail
-    "🐍·○",       # cycle resumes
-    "🐍··○",
-    "🐍···○",
-    "🐍····○",
-    "🐍·····○",
+# CANONICAL definition promoted to ui/theme.py (2026-07-23, design-as-code
+# Style Guide §04) so the attach-heartbeat cockpit pulse animates with the
+# SAME identity spinner. These aliases keep every internal reference intact.
+from backend.core.ouroboros.ui.theme import (  # noqa: E402
+    OUROBOROS_SPINNER_FRAMES as _OUROBOROS_FRAMES,
+    OUROBOROS_SPINNER_INTERVAL_S as _OUROBOROS_FRAME_INTERVAL_S,
+    ouroboros_frame as _theme_ouroboros_frame,
 )
-_OUROBOROS_FRAME_INTERVAL_S = 0.10  # 100ms per frame, named (not hardcoded)
 
 
 def _resolve_repl_refresh_interval_s() -> float:
@@ -171,11 +165,10 @@ def _frame_for_now() -> str:
     """Pick the current Ouroboros frame from monotonic time.
 
     Animation is a pure function of time — no internal counter, no
-    per-frame state. Lets multiple readers (REPL bottom_toolbar +
-    any future consumer) see the same frame without coordination.
-    """
-    idx = int(time.monotonic() / _OUROBOROS_FRAME_INTERVAL_S) % len(_OUROBOROS_FRAMES)
-    return _OUROBOROS_FRAMES[idx]
+    per-frame state. Lets multiple readers (REPL bottom_toolbar, the
+    attach-heartbeat pulse, any future consumer) see the same frame
+    without coordination. Delegates to the CANONICAL theme definition."""
+    return _theme_ouroboros_frame(unicode=True)
 
 
 def _active_spinner_name() -> str:

--- a/backend/core/ouroboros/ui/theme.py
+++ b/backend/core/ouroboros/ui/theme.py
@@ -275,6 +275,55 @@ def mark(name: str, *, unicode: Optional[bool] = None) -> str:
 
 
 # ===========================================================================
+# Ouroboros spinner — THE organism's identity animation
+# ===========================================================================
+#
+# The snake closing on its own tail (5→0 dots), the bite (🐍◯), reopen.
+# CANONICAL here (design-as-code, Style Guide §04): serpent_flow's REPL
+# spinner and the attach-heartbeat cockpit pulse both consume this ONE
+# definition — the organism animates identically on every surface.
+# Clock-stateless: the frame is a pure function of monotonic time, so any
+# number of readers agree with zero coordination and zero tick tasks.
+
+OUROBOROS_SPINNER_INTERVAL_S: float = 0.10
+OUROBOROS_SPINNER_FRAMES: tuple = (
+    "🐍·····○",
+    "🐍····○",
+    "🐍···○",
+    "🐍··○",
+    "🐍·○",
+    "🐍◯",       # bite — eating own tail
+    "🐍·○",       # cycle resumes
+    "🐍··○",
+    "🐍···○",
+    "🐍····○",
+    "🐍·····○",
+)
+#: ASCII degradation (same geometry, same story) for non-unicode terminals.
+_OUROBOROS_ASCII_FRAMES: tuple = (
+    "s.....o", "s....o", "s...o", "s..o", "s.o", "sO",
+    "s.o", "s..o", "s...o", "s....o", "s.....o",
+)
+
+
+def ouroboros_frame(
+    now: Optional[float] = None, *, unicode: Optional[bool] = None,
+) -> str:
+    """The current Ouroboros spinner frame, derived from the clock.
+
+    ``now`` overrides monotonic time (tests / synchronized surfaces);
+    ``unicode=None`` consults :func:`supports_unicode`. NEVER raises."""
+    try:
+        import time as _time
+        t = _time.monotonic() if now is None else float(now)
+        use = supports_unicode() if unicode is None else bool(unicode)
+        frames = OUROBOROS_SPINNER_FRAMES if use else _OUROBOROS_ASCII_FRAMES
+        return frames[int(t / OUROBOROS_SPINNER_INTERVAL_S) % len(frames)]
+    except Exception:  # noqa: BLE001
+        return "🐍"
+
+
+# ===========================================================================
 # Console factory + primitives
 # ===========================================================================
 

--- a/tests/battle_test/test_attach_heartbeat.py
+++ b/tests/battle_test/test_attach_heartbeat.py
@@ -45,10 +45,31 @@ def test_formatter_renders_cc_shape():
     assert "4m 9s" in line and "↓ 15.9k tokens" in line and "DW-397B" in line
 
 
-def test_formatter_pulse_animates_from_clock():
+def test_formatter_pulse_is_the_ouroboros_identity_spinner():
+    """The pulse is O+V's OWN animation — the theme's canonical Ouroboros
+    frames (snake → bite → reopen), not a borrowed star. Clock-driven:
+    different instants render different frames; the same instant renders
+    the SAME frame the daemon's REPL spinner would show."""
+    from backend.core.ouroboros.ui.theme import ouroboros_frame
     a = format_heartbeat_line(_hb(), now_mono=100.00, arrival_mono=100.0)
     b = format_heartbeat_line(_hb(), now_mono=100.30, arrival_mono=100.0)
-    assert a[:3] != b[:3]                      # the glyph breathes
+    ga = a.split(" Synthesizing")[0]
+    gb = b.split(" Synthesizing")[0]
+    assert ga != gb                            # the snake advances
+    assert "🐍" in ga                          # it IS the ouroboros
+    assert ga.strip() == ouroboros_frame(100.00, unicode=True)  # ONE authority
+
+
+def test_spinner_single_authority_theme_serves_serpent_too():
+    """DRY invariant: serpent_flow's REPL spinner aliases the theme's
+    canonical frames — one definition animates every surface."""
+    from backend.core.ouroboros.ui import theme
+    from backend.core.ouroboros.battle_test import serpent_flow as sf
+    assert sf._OUROBOROS_FRAMES is theme.OUROBOROS_SPINNER_FRAMES
+    assert sf._OUROBOROS_FRAME_INTERVAL_S == theme.OUROBOROS_SPINNER_INTERVAL_S
+    assert sf._frame_for_now() in theme.OUROBOROS_SPINNER_FRAMES
+    # ASCII degradation keeps the same story on dumb terminals.
+    assert theme.ouroboros_frame(0.0, unicode=False) == "s.....o"
 
 
 def test_formatter_elapsed_advances_client_side():


### PR DESCRIPTION
## What changes

The cockpit heartbeat pulse drops the borrowed CC star for **O+V's own identity animation** — the Ouroboros spinner (`🐍·····○` closing to the `🐍◯` bite, reopening) that already breathes in the daemon's REPL toolbar:

```
🐍··○ Synthesizing… (4m 9s · ↓ 15.9k tokens · DW-397B)
```

## How (single authority, zero duplication)

- **`ui/theme.py`** becomes the canonical home (design-as-code, Style Guide §04): `OUROBOROS_SPINNER_FRAMES` + `ouroboros_frame(now)` — clock-stateless, with ASCII degradation (`s.....o` → `sO`) through the theme's `supports_unicode` discipline.
- **`serpent_flow`** aliases the theme definition (private copy deleted, internal names preserved, `_frame_for_now` delegates).
- **`attach_heartbeat`** consumes the same function — an attached client and the daemon's local toolbar render the **same frame at the same instant**, zero coordination, zero tick tasks.

## Proof

19 tests green: pulse-is-ouroboros authority (frame-identical to `theme.ouroboros_frame` at the same clock), serpent-aliases-theme DRY invariant, ASCII degradation, plus the full existing heartbeat/theme spines. Cockpit sweep green; the 4 remaining reds pre-date this branch (2 inline-boot banner, 2 stale source-inspection spinner tests — fail on clean main).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the cockpit heartbeat pulse with O+V’s Ouroboros spinner so the cockpit and daemon REPL show the same, clock‑synced frame. Centralized the spinner in `backend/core/ouroboros/ui/theme.py` with an ASCII fallback and removed duplicate implementations.

- **Refactors**
  - Added `OUROBOROS_SPINNER_FRAMES`, `OUROBOROS_SPINNER_INTERVAL_S`, and `ouroboros_frame(now, unicode)` to `backend/core/ouroboros/ui/theme.py`.
  - Updated `backend/core/ouroboros/battle_test/serpent_flow.py` to alias the theme and delegate `_frame_for_now()` to it.
  - Updated `backend/core/ouroboros/battle_test/attach_heartbeat.py` to source the pulse glyph from `ouroboros_frame(now)`.
  - Extended tests to verify frame parity with the theme, DRY aliasing, and ASCII degradation.

<sup>Written for commit af2734a9144838f5543f626a52d274ce0cd0a334. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70083?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

