### PR TITLE
Feat(cockpit): Mirror completeness — every operator surface reaches ov

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -752,8 +752,24 @@ class SerpentFlow:
             from backend.core.ouroboros.governance.inline_prompt_gate_renderer import (
                 attach_phase_boundary_renderer,
             )
+            def _prompt_print(msg: Any, **kw: Any) -> None:
+                # Attach mirror (cockpit completeness, 2026-07-23): the
+                # inline permission/approval prompts are the ONE surface
+                # a watching operator must never miss — an attached ov
+                # terminal can already ANSWER (/accept, /reject travel
+                # over send_input → _handle_repl_command); this makes
+                # the question visible there too. String renders mirror
+                # verbatim; rich objects stay local (frame protocol is
+                # line-based) — the queue/deadline lines are strings.
+                try:
+                    if isinstance(msg, str):
+                        self._mirror_markup(msg)
+                except Exception:  # noqa: BLE001
+                    pass
+                self.console.print(msg, **kw)
+
             self._unsub_inline_prompt_renderer: Callable[[], None] = (
-                attach_phase_boundary_renderer(self.console.print)
+                attach_phase_boundary_renderer(_prompt_print)
             )
         except Exception:
             self._unsub_inline_prompt_renderer = lambda: None
@@ -1233,6 +1249,11 @@ class SerpentFlow:
         if not self._is_focused(op_id):
             return
         short = _short_id(op_id)
+        # Attach mirror: the op-open action line — cockpits see a new op
+        # begin the moment the daemon does (width-agnostic form).
+        self._mirror_markup(
+            f"{self._action_glyph()} {sensor}  [{_C['dim']}]{short}[/{_C['dim']}]"
+        )
         if self._borderless():
             self._emit_fit(
                 f"{self._action_glyph()} {sensor}  [{_C['dim']}]{short}[/{_C['dim']}]"
@@ -1330,11 +1351,13 @@ class SerpentFlow:
                 f" [{_C['dim']}]·[/{_C['dim']}] "
                 f"[{_C['death']}]failed{_phase}: {failure_reason[:60]}[/{_C['death']}]"
             )
-        self.console.print(
+        receipt = (
             f"  [{glyph_color}][{glyph}][/{glyph_color}] "
-            f"op-{short}{cost_seg}{posture_seg}{time_seg}{tail_seg}",
-            highlight=False,
+            f"op-{short}{cost_seg}{posture_seg}{time_seg}{tail_seg}"
         )
+        # Attach mirror: the grep-friendly op receipt (outcome + cost).
+        self._mirror_markup(receipt)
+        self.console.print(receipt, highlight=False)
 
     def _close_op_block(self, op_id: str) -> None:
         """Print the bottom border of an op block with running stats.
@@ -1379,6 +1402,9 @@ class SerpentFlow:
             f"[red]💀 {self._failed}[/red] [dim]│[/dim] "
             f"💰 ${self._cost_total:.4f}/${self._cost_cap:.2f}"
         )
+        # Attach mirror: session tally at op close (width-agnostic — the
+        # local border chrome stays local; cockpits get the substance).
+        self._mirror_markup(f"  {stats}")
         label = f" {short} ── {stats} "
         vis = _visible_len(label)
         pad = max(2, w - vis - 2)
@@ -1591,6 +1617,16 @@ class SerpentFlow:
                                     op_active=op_id in self._active_ops,
                                     max_chars_per_line=80,
                                 )
+                                try:
+                                    from backend.core.ouroboros.battle_test.narrative_renderer import (  # noqa: E501
+                                        compose,
+                                    )
+                                    _r = compose(frame, max_chars_per_line=80)
+                                    if _r is not None and _r.markup:
+                                        # Attach mirror: 💭 intent narration.
+                                        self._mirror_markup(f"  {_r.markup}")
+                                except Exception:  # noqa: BLE001
+                                    pass
                                 break
                     except Exception:
                         pass
@@ -1844,11 +1880,13 @@ class SerpentFlow:
                 f" via [{_C['provider']}]{prov}[/{_C['provider']}]"
                 if prov else ""
             )
-            self.console.print(
+            gen_receipt = (
                 f"  [{_C['life']}][✓][/{_C['life']}] "
-                f"Generated {token_count} tokens{via_seg}",
-                highlight=False,
+                f"Generated {token_count} tokens{via_seg}"
             )
+            # Attach mirror: the synthesis receipt (tokens + provider).
+            self._mirror_markup(gen_receipt)
+            self.console.print(gen_receipt, highlight=False)
         # Reset state for the next synthesis cycle.
         self._stream_buffer = ""
         self._stream_token_count = 0
@@ -2695,6 +2733,25 @@ class SerpentFlow:
         import asyncio
         import time as _time
 
+        # Attach mirror: the Yellow-tier countdown is EXACTLY when a
+        # watching operator may want to intervene — one static notice
+        # (the Live overlay itself can't stream over the frame
+        # protocol; the diff arrives separately as ⏺ Update blocks).
+        try:
+            _short = _short_id(op_id)
+            _n = len(changes) if changes is not None else 0
+            self._mirror_markup(
+                f"  [{_C['heal']}]⏳ NOTIFY_APPLY op:{_short} — "
+                f"{_n} file(s), applying in {int(delay_s)}s "
+                f"({reason})[/{_C['heal']}]"
+            )
+            self._mirror_markup(
+                f"  [{_C['dim']}]⎿  /reject {_short} to cancel — "
+                f"diff follows as ⏺ Update[/{_C['dim']}]"
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
         try:
             from backend.core.ouroboros.battle_test.diff_preview import (
                 DiffPreviewRenderer,
@@ -3448,6 +3505,13 @@ class SerpentFlow:
         _headless_reason = _headless_auto_approve_reason()
         if _headless_reason is not None:
             try:
+                # Attach mirror: a watching operator must SEE that the
+                # headless gate auto-approved (§7 — no silent decisions).
+                self._mirror_markup(
+                    f"  [{_C['life']}]✅ auto-approved (headless: "
+                    f"{_headless_reason})[/{_C['life']}]  "
+                    f"[{_C['dim']}]op:{short}[/{_C['dim']}]"
+                )
                 c.print(
                     f"  [{_C['life']}]✅ auto-approved (headless: "
                     f"{_headless_reason})[/{_C['life']}]  "
@@ -3489,6 +3553,22 @@ class SerpentFlow:
             width=min(c.width, 68),
             padding=(0, 1),
         )
+        # Attach mirror: the gate question as LINES (a Panel can't cross
+        # the frame protocol) + an honest note that the [Y/n] decision
+        # is awaited at the daemon's own terminal in interactive mode.
+        try:
+            self._mirror_markup(
+                f"  [{_C['heal']}]🔒 Iron Gate │ op:{short} — "
+                f"approval required[/{_C['heal']}]"
+            )
+            for _bl in body_lines:
+                self._mirror_markup(f"  {_bl}")
+            self._mirror_markup(
+                f"  [{_C['dim']}]⎿  awaiting [Y/n] at the daemon "
+                f"terminal[/{_C['dim']}]"
+            )
+        except Exception:  # noqa: BLE001
+            pass
         c.print()
         c.print(panel)
 
@@ -4759,6 +4839,17 @@ class SerpentREPL:
                     key = str(payload.get("provider", payload.get("op_id", "")) or "")
                     if not coalescer.should_show(et, key):
                         continue
+                    # Attach mirror (cockpit completeness, 2026-07-23): this
+                    # is THE single chokepoint for every registry-driven
+                    # event (posture, governor, sensors, soak progress…) —
+                    # one mirror here lights up all 149+ types on every
+                    # attached ov cockpit, present and future.
+                    _sev, text = reg.render(et, payload)
+                    styled = f"  [{desc.color}]{desc.glyph} {text}[/{desc.color}]"
+                    try:
+                        self._flow._mirror_markup(styled)
+                    except Exception:  # noqa: BLE001
+                        pass
                     # Sink redirect (DRY): when the Bipartite Async Layout is live,
                     # this event auto-scrolls into Zone 1 (the Proactive Canvas)
                     # instead of the flowing console — SAME formatting, framed sink.
@@ -4773,9 +4864,8 @@ class SerpentREPL:
                     if _canvas is not None:
                         _canvas.emit(et, payload)
                         continue
-                    _sev, text = reg.render(et, payload)
                     self._flow.console.print(
-                        f"  [{desc.color}]{desc.glyph} {text}[/{desc.color}]",
+                        styled,
                         highlight=False,
                     )
                 except Exception:  # noqa: BLE001 — one bad event never kills the loop
@@ -4830,8 +4920,15 @@ class SerpentREPL:
                     healthy = payload.get("state") == "HEALTHY"
                     color = _C["neural"] if healthy else _C["heal"]
                     glyph = "✓" if healthy else "⚠"
+                    styled = f"  [{color}]{glyph} {text}[/{color}]"
+                    try:
+                        # Attach mirror: provider failover (DW↔Claude↔J-Prime)
+                        # is exactly what a watching operator must see live.
+                        self._flow._mirror_markup(styled)
+                    except Exception:  # noqa: BLE001
+                        pass
                     self._flow.console.print(
-                        f"  [{color}]{glyph} {text}[/{color}]",
+                        styled,
                         highlight=False,
                     )
                 except Exception:  # noqa: BLE001 — one bad event never kills the loop

--- a/tests/battle_test/test_cockpit_mirror_completeness.py
+++ b/tests/battle_test/test_cockpit_mirror_completeness.py
@@ -1,0 +1,100 @@
+"""Cockpit completeness — every operator-visible daemon surface mirrors
+to attached ov terminals (audit 2026-07-23).
+
+Covers the surfaces the audit found dark (class B): op-block chrome +
+receipts, synthesis receipt, breadcrumb chokepoints (wiring invariants),
+Iron Gate visibility, NOTIFY_APPLY countdown notice, inline-prompt
+renderer mirroring.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+
+from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+
+
+@pytest.fixture()
+def flow():
+    sf = SerpentFlow(session_id="t", branch_name="b")
+    sf._mirrored = []
+    sf.markup_mirror = sf._mirrored.append
+    return sf
+
+
+def test_op_lifecycle_chrome_mirrors(flow):
+    """Open header, interior lines, receipt, and close tally all reach
+    the mirror — a cockpit sees the op's full story."""
+    flow.op_started("op-abc123", "fix the tests", ["a.py"], "SAFE_AUTO",
+                    sensor="test_failure")
+    flow.op_completed("op-abc123", files_changed=[], cost_usd=0.01)
+    joined = "\n".join(str(m) for m in flow._mirrored)
+    assert "test_failure" in joined          # open action line
+    assert "op-" in joined                   # receipt line
+    assert "💰" in joined                    # close tally stats
+
+
+def test_streaming_receipt_mirrors(flow):
+    flow.show_streaming_start("doubleword", op_id="op-abc123")
+    for _ in range(1234):
+        flow.show_streaming_token("x")
+    flow.show_streaming_end()
+    joined = "\n".join(str(m) for m in flow._mirrored)
+    assert "Generated" in joined and "tokens" in joined
+
+
+@pytest.mark.asyncio
+async def test_notify_apply_countdown_notice_mirrors(flow):
+    ok = await flow.show_notify_apply_preview(
+        op_id="op-abc123", reason="single_file_small_diff",
+        changes=[], delay_s=0.0, cancel_check=None,
+    )
+    joined = "\n".join(str(m) for m in flow._mirrored)
+    assert "NOTIFY_APPLY" in joined
+    assert "/reject" in joined
+    assert isinstance(ok, bool)
+
+
+@pytest.mark.asyncio
+async def test_iron_gate_headless_auto_approve_is_visible(flow, monkeypatch):
+    """§7: the headless gate's auto-approve decision must be visible to
+    attached cockpits — never a silent decision."""
+    import backend.core.ouroboros.battle_test.serpent_flow as sfm
+    monkeypatch.setattr(
+        sfm, "_headless_auto_approve_reason", lambda: "no-tty", 
+    )
+    approved = await flow.request_execution_permission(
+        op_id="op-abc123", description="test change",
+        target_files=["a.py"], diff_text="",
+    )
+    assert approved is True
+    joined = "\n".join(str(m) for m in flow._mirrored)
+    assert "auto-approved" in joined
+
+
+def test_breadcrumb_chokepoints_mirror_wiring():
+    """Wiring invariants: the TWO event chokepoints (registry router +
+    provider failover listener) and the inline-prompt renderer all call
+    the mirror — one seam each lights every current/future event."""
+    src = Path(
+        "backend/core/ouroboros/battle_test/serpent_flow.py"
+    ).read_text()
+    # registry router mirrors the styled breadcrumb
+    router = src.split("def _event_breadcrumb_router")[1].split("\n    async def ")[0]
+    assert "_mirror_markup(styled)" in router
+    # provider failover listener mirrors
+    prov = src.split("def _provider_breadcrumb_listener")[1].split("\n    async def ")[0]
+    assert "_mirror_markup(styled)" in prov
+    # inline prompt renderer wires a mirroring print_fn
+    assert "attach_phase_boundary_renderer(_prompt_print)" in src
+
+
+def test_intent_narration_mirror_wiring():
+    src = Path(
+        "backend/core/ouroboros/battle_test/serpent_flow.py"
+    ).read_text()
+    assert src.count("💭") >= 1
+    assert "self._mirror_markup(f\"  {_r.markup}\")" in src


### PR DESCRIPTION
## The audit

Classified **every** daemon render surface against the three cockpit mirror seams (`publish_line`, the op-scoped markup mirror, telemetry). Interior op content mirrored; everything composed with a direct `console.print` was dark to attached terminals.

## What lights up (each via an EXISTING chokepoint)

| Surface | Now visible in ov |
|---|---|
| **Event breadcrumbs** (149+ registry types: posture, governor, sensors, soak progress) | one mirror at THE router chokepoint — covers all current and future events |
| **Provider failover** | DW↔Claude↔J-Prime DEGRADED/HEALTHY breadcrumbs |
| **Op-block chrome** | open action line, `[✓] op-… · cost · posture · time` receipt, close tally (✅/💀/💰) |
| **Synthesis receipt** | `[✓] Generated N tokens via DW-397B` |
| **💭 intent narration** | mirrored via `narrative_renderer.compose` (pre-escaped) |
| **Approval prompts** (shipping inline UX) | requests visible; answers already travel (`/accept`, `/reject` via `send_input`) |
| **Iron Gate** | panel content as lines + honest "awaiting [Y/n] at the daemon terminal"; headless auto-approve decision mirrored (§7 — no silent decisions) |
| **NOTIFY_APPLY countdown** | static notice at preview-open (op, files, delay, reason, `/reject` escape hatch) |

**Deferred by design**: full remote token streaming (heartbeat token count + 🧬 header carry the signal; a token-frame channel is its own bandwidth conversation) and remote answering of `prompt_async` local prompts (needs an operator-prompt bridge racing stdin with bridge input — follow-up).

## Proof

6 new tests (lifecycle chrome, streaming receipt, NOTIFY_APPLY notice, headless auto-approve visibility, chokepoint wiring invariants, intent wiring); **171 green** across cockpit/heartbeat/narrative/diff suites; pre-existing reds unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mirrors all operator-visible daemon surfaces to attached cockpit terminals via existing chokepoints. Operators now see events, provider failover, op lifecycle receipts, approvals, and NOTIFY_APPLY countdowns in real time.

- **New Features**
  - Event and provider breadcrumbs mirror via the registry router and provider listener.
  - Op lifecycle mirrors: open action line, receipt (cost/posture/time), and close tally.
  - Synthesis receipt and intent narration mirror.
  - Approval flows mirror: inline prompts; Iron Gate lines with "awaiting [Y/n]"; headless auto-approve notice.
  - NOTIFY_APPLY preview mirrors a static countdown with the /reject escape hatch.

<sup>Written for commit f0ca5680b263b9f05e073bf8f4d03b5b8b8b0ed7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70084?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

