### PR TITLE
Feat(cockpit): Operator Prompt Bridge — attached cockpits answer the [Y/n] gates

### DIFF
--- a/backend/core/ouroboros/battle_test/harness.py
+++ b/backend/core/ouroboros/battle_test/harness.py
@@ -4448,6 +4448,19 @@ class BattleTestHarness:
                     return {}
 
             def _on_input(text: str) -> None:
+                # Operator Prompt Bridge FIRST (2026-07-23): while an
+                # interactive gate ([Y/n] Iron Gate, endorse) is pending,
+                # the next attached-terminal line IS the answer — HITL
+                # from every surface the operator watches. No pending
+                # prompt → declines instantly, text flows to the REPL.
+                try:
+                    from backend.core.ouroboros.battle_test.operator_prompt_bridge import (  # noqa: E501
+                        get_operator_prompt_bridge,
+                    )
+                    if get_operator_prompt_bridge().resolve(text):
+                        return
+                except Exception:  # noqa: BLE001
+                    pass
                 # Upstream operator text → the FULL REPL surface (verbs
                 # + bare-text chat bridge). Scheduled, never inline.
                 try:

--- a/backend/core/ouroboros/battle_test/operator_prompt_bridge.py
+++ b/backend/core/ouroboros/battle_test/operator_prompt_bridge.py
@@ -1,0 +1,151 @@
+"""Operator Prompt Bridge — attached cockpits ANSWER the organism's questions.
+
+The gap this closes (cockpit-completeness audit, 2026-07-23): interactive
+gates (`Iron Gate [Y/n]`, endorse prompts) awaited ``prompt_async`` on the
+DAEMON's local stdin only. An attached ``ov`` operator saw the mirrored
+question but their typed reply routed to the REPL chat surface — the
+pending prompt was unreachable. HITL must be an available override from
+EVERY surface the operator actually watches.
+
+Design — one single-slot pending-prompt registry, raced not replaced:
+
+* A prompt site calls :meth:`OperatorPromptBridge.begin` to arm the slot
+  and receives an ``asyncio.Future``; it races that future against its
+  local ``prompt_async`` — FIRST answer wins, loser is cancelled. The
+  local terminal loses nothing; the cockpit gains everything.
+* The harness's attach-input handler calls :meth:`resolve` BEFORE the
+  REPL dispatcher: while a prompt is pending, the next operator line from
+  ANY attached terminal is the answer, not chat. With no pending prompt,
+  ``resolve`` declines instantly and input flows to the REPL untouched.
+* Single-slot by design: the FSM serializes interactive gates; a second
+  ``begin`` supersedes (cancels) the first rather than queueing —
+  superseded prompts fall back to their local surface.
+
+Zero authority (carries text, decides nothing); asyncio-native;
+NEVER raises anywhere. Master: ``JARVIS_OPERATOR_PROMPT_BRIDGE_ENABLED``
+(default on).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+from typing import Any, Optional, Tuple
+
+logger = logging.getLogger("Ouroboros.OperatorPromptBridge")
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+
+def prompt_bridge_enabled() -> bool:
+    """Master gate — default ON. Re-read at call time. NEVER raises."""
+    return os.environ.get(
+        "JARVIS_OPERATOR_PROMPT_BRIDGE_ENABLED", "1",
+    ).strip().lower() in _TRUTHY
+
+
+class OperatorPromptBridge:
+    """Single-slot pending-prompt registry (see module docstring)."""
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._pending: Optional[Tuple[str, asyncio.Future]] = None
+
+    # -- prompt side ----------------------------------------------------
+
+    def begin(self, prompt_id: str) -> Optional[asyncio.Future]:
+        """Arm the slot for ``prompt_id`` and return the answer future
+        (resolved with the operator's raw text). A prior pending prompt
+        is superseded (its future cancelled — it falls back to its local
+        surface). Returns None when the bridge is disabled or no running
+        loop exists. NEVER raises."""
+        if not prompt_bridge_enabled():
+            return None
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return None
+        try:
+            fut: asyncio.Future = loop.create_future()
+            with self._lock:
+                prev = self._pending
+                self._pending = (str(prompt_id), fut)
+            if prev is not None and not prev[1].done():
+                prev[1].cancel()
+            return fut
+        except Exception:  # noqa: BLE001
+            return None
+
+    def end(self, fut: Optional[asyncio.Future]) -> None:
+        """Disarm the slot IF it still holds ``fut`` (a superseding
+        prompt keeps its own slot). Always safe to call. NEVER raises."""
+        try:
+            with self._lock:
+                if self._pending is not None and self._pending[1] is fut:
+                    self._pending = None
+            if fut is not None and not fut.done():
+                fut.cancel()
+        except Exception:  # noqa: BLE001
+            pass
+
+    # -- input side (harness attach handler) ----------------------------
+
+    @property
+    def waiting(self) -> bool:
+        try:
+            with self._lock:
+                p = self._pending
+            return p is not None and not p[1].done()
+        except Exception:  # noqa: BLE001
+            return False
+
+    def resolve(self, text: Any) -> bool:
+        """Offer one operator line to the pending prompt. True when the
+        line was CONSUMED as the answer (caller must not route it to the
+        REPL); False when no prompt is pending. Thread-safe: marshals to
+        the future's loop. NEVER raises."""
+        try:
+            with self._lock:
+                p = self._pending
+                if p is None or p[1].done():
+                    return False
+                self._pending = None
+            _pid, fut = p
+            answer = str(text if text is not None else "").strip()
+
+            def _set() -> None:
+                if not fut.done():
+                    fut.set_result(answer)
+
+            loop = getattr(fut, "get_loop", lambda: None)()
+            if loop is not None and not loop.is_closed():
+                loop.call_soon_threadsafe(_set)
+            else:
+                _set()
+            logger.info(
+                "[OperatorPromptBridge] prompt %s answered via attach",
+                _pid,
+            )
+            return True
+        except Exception:  # noqa: BLE001
+            return False
+
+
+_BRIDGE: Optional[OperatorPromptBridge] = None
+_BRIDGE_LOCK = threading.Lock()
+
+
+def get_operator_prompt_bridge() -> OperatorPromptBridge:
+    global _BRIDGE
+    with _BRIDGE_LOCK:
+        if _BRIDGE is None:
+            _BRIDGE = OperatorPromptBridge()
+        return _BRIDGE
+
+
+def reset_bridge_for_tests() -> None:
+    global _BRIDGE
+    with _BRIDGE_LOCK:
+        _BRIDGE = None

--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -77,6 +77,17 @@ from backend.core.ouroboros.ui.theme import (  # noqa: E402
 )
 
 
+def _bridge_only_wait_s() -> float:
+    """How long the Iron Gate waits for a COCKPIT answer when no local
+    prompt surface exists (prompt_toolkit unavailable). Bounded so the
+    organism never wedges; on timeout the legacy behavior applies."""
+    try:
+        return max(1.0, min(600.0, float(os.environ.get(
+            "JARVIS_PROMPT_BRIDGE_ONLY_WAIT_S", "45"))))
+    except (TypeError, ValueError):
+        return 45.0
+
+
 def _resolve_repl_refresh_interval_s() -> float:
     """Bottom-toolbar refresh cadence in seconds. Env-configurable via
     ``JARVIS_REPL_REFRESH_INTERVAL_S`` (default 0.10 = 10fps spinner).
@@ -3464,6 +3475,94 @@ class SerpentFlow:
     # Iron Gate permission prompt
     # ══════════════════════════════════════════════════════════
 
+    async def _race_gate_answer(
+        self, bridge_fut: Optional["asyncio.Future"],
+    ) -> Optional[bool]:
+        """Race the LOCAL [Y/n] prompt against the Operator Prompt Bridge
+        (attached cockpits) — first answer wins, the loser is cancelled.
+
+        Edge lattice (every surface can die independently):
+        * local prompt raises (dead stdin — the Session-H OSError class)
+          → it drops OUT of the race; the bridge keeps waiting, bounded
+          by ``_bridge_only_wait_s`` so the organism never wedges.
+        * EOF/Ctrl-C on the local surface = explicit REJECTION (False).
+        * bridge disabled/absent → pure local behavior (legacy).
+        * everything dead/timed out → None (caller applies Session-H
+          auto-approve parity).
+
+        Sets ``self._gate_answered_via_cockpit`` for §7 attribution.
+        NEVER leaks pending tasks."""
+        self._gate_answered_via_cockpit = False
+        local_task: Optional["asyncio.Future"] = None
+        ctx = None
+        try:
+            try:
+                from prompt_toolkit import PromptSession
+                from prompt_toolkit.formatted_text import HTML
+                from prompt_toolkit.patch_stdout import patch_stdout
+                ctx = patch_stdout(raw=True)
+                ctx.__enter__()
+                local_task = asyncio.ensure_future(
+                    PromptSession().prompt_async(
+                        HTML("<b>  Apply this change? [Y/n] </b>"),
+                    ),
+                )
+            except Exception:  # noqa: BLE001 — no local surface
+                local_task = None
+            race = {t for t in (local_task, bridge_fut) if t is not None}
+            deadline = (
+                None if local_task is not None else _bridge_only_wait_s()
+            )
+            while race:
+                done, _pending = await asyncio.wait(
+                    race, timeout=deadline,
+                    return_when=asyncio.FIRST_COMPLETED,
+                )
+                if not done:                      # bridge-only wait timed out
+                    return None
+                for w in done:
+                    race.discard(w)
+                    if bridge_fut is not None and w is bridge_fut:
+                        try:
+                            ans = str(w.result() or "").strip().lower()
+                        except Exception:  # noqa: BLE001 — cancelled/superseded
+                            continue
+                        self._gate_answered_via_cockpit = True
+                        return ans in ("", "y", "yes")
+                    try:
+                        ans = str(w.result() or "").strip().lower()
+                        return ans in ("", "y", "yes")
+                    except (EOFError, KeyboardInterrupt):
+                        # A REAL terminal's Ctrl-D/Ctrl-C is an explicit
+                        # rejection. EOF from a fake/piped stdin (tests,
+                        # daemonized edge) means NO local surface — the
+                        # bridge race continues, bounded.
+                        try:
+                            import sys as _sys
+                            _tty = bool(
+                                _sys.__stdin__ is not None
+                                and _sys.__stdin__.isatty()
+                            )
+                        except Exception:  # noqa: BLE001
+                            _tty = False
+                        if _tty:
+                            return False
+                        deadline = _bridge_only_wait_s()
+                        continue
+                    except Exception:  # noqa: BLE001 — dead stdin: race on
+                        deadline = _bridge_only_wait_s()
+                        continue
+            return None                            # every surface exhausted
+        finally:
+            for t in (local_task, ):
+                if t is not None and not t.done():
+                    t.cancel()
+            if ctx is not None:
+                try:
+                    ctx.__exit__(None, None, None)
+                except Exception:  # noqa: BLE001
+                    pass
+
     async def request_execution_permission(
         self,
         op_id: str,
@@ -3553,46 +3652,70 @@ class SerpentFlow:
             width=min(c.width, 68),
             padding=(0, 1),
         )
-        # Attach mirror: the gate question as LINES (a Panel can't cross
-        # the frame protocol) + an honest note that the [Y/n] decision
-        # is awaited at the daemon's own terminal in interactive mode.
+        # Attach mirror — CC-style gate block in O+V's voice (a Panel
+        # can't cross the frame protocol; ⏺/⎿ lines can). The prompt is
+        # ANSWERABLE from the cockpit via the Operator Prompt Bridge:
+        # the next attached-terminal line resolves the race below.
         try:
             self._mirror_markup(
-                f"  [{_C['heal']}]🔒 Iron Gate │ op:{short} — "
-                f"approval required[/{_C['heal']}]"
+                f"  [{_C['heal']}]⏺ Iron Gate[/{_C['heal']}]"
+                f"([{_C['dim']}]op:{short}[/{_C['dim']}]) — approval required"
             )
             for _bl in body_lines:
-                self._mirror_markup(f"  {_bl}")
+                self._mirror_markup(f"  [{_C['dim']}]⎿[/{_C['dim']}]  {_bl}")
             self._mirror_markup(
-                f"  [{_C['dim']}]⎿  awaiting [Y/n] at the daemon "
-                f"terminal[/{_C['dim']}]"
+                f"  [{_C['dim']}]⎿[/{_C['dim']}]  [bold]Apply this change? "
+                f"[Y/n][/bold] [{_C['dim']}]— reply y / n here, or at the "
+                f"daemon terminal[/{_C['dim']}]"
             )
         except Exception:  # noqa: BLE001
             pass
         c.print()
         c.print(panel)
 
-        # Step 3: Async [Y/n] prompt
+        # Step 3: Async [Y/n] prompt — RACED between the local terminal
+        # and the Operator Prompt Bridge (attached cockpits). First
+        # answer wins; the loser is cancelled. HITL from every surface.
+        answered_via = "terminal"
+        bridge_fut = None
         try:
-            from prompt_toolkit import PromptSession
-            from prompt_toolkit.formatted_text import HTML
-            from prompt_toolkit.patch_stdout import patch_stdout
-
-            session = PromptSession()
-            with patch_stdout(raw=True):
-                answer = await session.prompt_async(
-                    HTML("<b>  Apply this change? [Y/n] </b>"),
-                )
-            answer = answer.strip().lower()
-            approved = answer in ("", "y", "yes")
-        except ImportError:
-            c.print(
-                f"  [{_C['heal']}](prompt_toolkit unavailable — auto-approving)[/{_C['heal']}]",
-                highlight=False,
+            from backend.core.ouroboros.battle_test.operator_prompt_bridge import (  # noqa: E501
+                get_operator_prompt_bridge,
             )
-            approved = True
-        except (EOFError, KeyboardInterrupt):
+            bridge_fut = get_operator_prompt_bridge().begin(
+                f"iron-gate:{short}",
+            )
+        except Exception:  # noqa: BLE001
+            bridge_fut = None
+        try:
+            approved = await self._race_gate_answer(bridge_fut)
+            if approved is None:
+                approved = True        # every surface dead → Session-H parity
+            elif getattr(self, "_gate_answered_via_cockpit", False):
+                answered_via = "cockpit"
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
             approved = False
+        finally:
+            try:
+                from backend.core.ouroboros.battle_test.operator_prompt_bridge import (  # noqa: E501
+                    get_operator_prompt_bridge,
+                )
+                get_operator_prompt_bridge().end(bridge_fut)
+            except Exception:  # noqa: BLE001
+                pass
+        # Mirror the decision + which surface answered (§7: every
+        # human decision visible everywhere).
+        try:
+            _mark = "✅ approved" if approved else "⛔ rejected"
+            _col = _C["life"] if approved else _C["death"]
+            self._mirror_markup(
+                f"  [{_C['dim']}]⎿[/{_C['dim']}]  [{_col}]{_mark}"
+                f"[/{_col}] [{_C['dim']}]via {answered_via}[/{_C['dim']}]"
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
         # Step 4: Decision artifact
         if approved:

--- a/tests/battle_test/test_operator_prompt_bridge.py
+++ b/tests/battle_test/test_operator_prompt_bridge.py
@@ -1,0 +1,157 @@
+"""Operator Prompt Bridge — attached cockpits ANSWER the organism's
+[Y/n] gates (cockpit-completeness follow-up, 2026-07-23).
+
+Covers: the single-slot registry (begin/resolve/end/supersede), the
+harness input-handler precedence (answer BEFORE REPL chat), and the
+Iron Gate race (cockpit answer wins, local surface never lost, decision
+mirrored with its source, slot always disarmed).
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from backend.core.ouroboros.battle_test.operator_prompt_bridge import (
+    OperatorPromptBridge,
+    get_operator_prompt_bridge,
+    reset_bridge_for_tests,
+)
+
+
+@pytest.fixture(autouse=True)
+def _fresh_bridge():
+    reset_bridge_for_tests()
+    yield
+    reset_bridge_for_tests()
+
+
+# ---------------------------------------------------------------------------
+# Registry semantics
+# ---------------------------------------------------------------------------
+
+
+async def test_begin_resolve_roundtrip():
+    b = OperatorPromptBridge()
+    fut = b.begin("iron-gate:abc")
+    assert fut is not None and b.waiting
+    assert b.resolve("  Y  ") is True
+    assert await asyncio.wait_for(fut, 1.0) == "Y"
+    assert b.waiting is False
+
+
+async def test_resolve_declines_without_pending_prompt():
+    b = OperatorPromptBridge()
+    assert b.resolve("hello organism") is False   # flows to REPL untouched
+
+
+async def test_second_begin_supersedes_first():
+    b = OperatorPromptBridge()
+    f1 = b.begin("p1")
+    f2 = b.begin("p2")
+    await asyncio.sleep(0)
+    assert f1.cancelled()                          # superseded → local fallback
+    assert b.resolve("n") is True
+    assert await asyncio.wait_for(f2, 1.0) == "n"
+
+
+async def test_end_disarms_only_own_slot():
+    b = OperatorPromptBridge()
+    f1 = b.begin("p1")
+    f2 = b.begin("p2")                             # owns the slot now
+    b.end(f1)                                      # stale end — must not disarm p2
+    assert b.waiting
+    b.end(f2)
+    assert not b.waiting
+
+
+async def test_master_gate_off_disables(monkeypatch):
+    monkeypatch.setenv("JARVIS_OPERATOR_PROMPT_BRIDGE_ENABLED", "0")
+    b = OperatorPromptBridge()
+    assert b.begin("p") is None
+    assert b.resolve("y") is False
+
+
+# ---------------------------------------------------------------------------
+# Harness input precedence (wiring invariant + behavior)
+# ---------------------------------------------------------------------------
+
+
+def test_harness_consults_bridge_before_repl():
+    from pathlib import Path
+    src = Path(
+        "backend/core/ouroboros/battle_test/harness.py"
+    ).read_text()
+    on_input = src.split("def _on_input(")[1].split("def ")[0]
+    assert on_input.index("get_operator_prompt_bridge") < on_input.index(
+        "_handle_repl_command"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Iron Gate race
+# ---------------------------------------------------------------------------
+
+
+def _gate_flow():
+    from backend.core.ouroboros.battle_test.serpent_flow import SerpentFlow
+    sf = SerpentFlow(session_id="t", branch_name="b")
+    sf._mirrored = []
+    sf.markup_mirror = sf._mirrored.append
+    return sf
+
+
+async def test_iron_gate_cockpit_answer_wins(monkeypatch):
+    """An attached operator's 'y' resolves the gate; the decision and its
+    SOURCE mirror back to every cockpit."""
+    import backend.core.ouroboros.battle_test.serpent_flow as sfm
+    monkeypatch.setattr(sfm, "_headless_auto_approve_reason", lambda: None)
+    flow = _gate_flow()
+
+    async def _answer_soon():
+        for _ in range(200):
+            await asyncio.sleep(0.02)
+            if get_operator_prompt_bridge().waiting:
+                assert get_operator_prompt_bridge().resolve("y")
+                return
+        raise AssertionError("gate never armed the bridge")
+
+    answerer = asyncio.ensure_future(_answer_soon())
+    approved = await asyncio.wait_for(
+        flow.request_execution_permission(
+            op_id="op-abc123", description="test change",
+            target_files=["a.py"],
+        ),
+        timeout=10.0,
+    )
+    await answerer
+    assert approved is True
+    joined = "\n".join(str(m) for m in flow._mirrored)
+    assert "Iron Gate" in joined
+    assert "Apply this change?" in joined          # answerable prompt line
+    assert "via cockpit" in joined                 # §7: source visible
+    assert not get_operator_prompt_bridge().waiting  # slot disarmed
+
+
+async def test_iron_gate_cockpit_rejection(monkeypatch):
+    import backend.core.ouroboros.battle_test.serpent_flow as sfm
+    monkeypatch.setattr(sfm, "_headless_auto_approve_reason", lambda: None)
+    flow = _gate_flow()
+
+    async def _answer_soon():
+        while not get_operator_prompt_bridge().waiting:
+            await asyncio.sleep(0.02)
+        get_operator_prompt_bridge().resolve("n")
+
+    answerer = asyncio.ensure_future(_answer_soon())
+    approved = await asyncio.wait_for(
+        flow.request_execution_permission(
+            op_id="op-abc123", description="risky change",
+            target_files=["a.py"],
+        ),
+        timeout=10.0,
+    )
+    await answerer
+    assert approved is False
+    assert any("rejected" in str(m) for m in flow._mirrored)


### PR DESCRIPTION
## The gap

Interactive gates (`Iron Gate [Y/n]`) awaited `prompt_async` on the daemon's **local stdin** only. An attached `ov` operator saw the mirrored question; their typed reply went to REPL chat. The cockpit could watch but not decide.

## The fix — race, don't replace

- **`operator_prompt_bridge.py`**: single-slot pending-prompt registry. Zero authority — it carries text, decides nothing. Master `JARVIS_OPERATOR_PROMPT_BRIDGE_ENABLED` (on).
- **Harness input handler**: consults the bridge *before* the REPL dispatcher — while a gate is pending, the next attached line IS the answer; otherwise chat flows untouched.
- **Iron Gate**: the `[Y/n]` races local terminal vs bridge — first answer wins, loser cancelled. The local surface loses nothing; the cockpit gains everything.

**Edge lattice** (each surface can die independently): dead stdin (Session-H `OSError` class) drops the local racer, bridge continues **bounded** (`JARVIS_PROMPT_BRIDGE_ONLY_WAIT_S`, 45s) — the organism never wedges; EOF/Ctrl-C on a **real** TTY = explicit rejection, EOF from piped stdin = no-local-surface (`sys.__stdin__.isatty` discipline); all surfaces dead → Session-H auto-approve parity.

## The cockpit sees (CC structure, O+V voice)

```
⏺ Iron Gate(op:abc123) — approval required
⎿  <description>
⎿  📂 a.py
⎿  Apply this change? [Y/n] — reply y / n here, or at the daemon terminal
⎿  ✅ approved via cockpit
```

The decision mirrors **with its source** — §7, no silent decisions, ever.

## Proof

8 new tests incl. two e2e races through the real `request_execution_permission` (cockpit approval + cockpit rejection); 90 green across the whole cockpit spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable attached cockpits to answer interactive [Y/n] gates. The gate now races the local terminal and a new prompt bridge; first answer wins, and the decision is mirrored with its source.

- **New Features**
  - Added Operator Prompt Bridge (single-slot). Harness checks it before the REPL, so the next attached line answers a pending gate.
  - Iron Gate now races local `[Y/n]` vs bridge; loser is canceled. Decision mirrors back as “via cockpit” or “via terminal.”
  - Robust behavior: bounded wait when no local prompt; Ctrl-C/EOF on a real TTY = reject; piped stdin = no local surface; if all surfaces die, auto-approve parity.
  - Env flags: `JARVIS_OPERATOR_PROMPT_BRIDGE_ENABLED` (default on), `JARVIS_PROMPT_BRIDGE_ONLY_WAIT_S` (default 45s).
  - Tests: 8 new tests, including e2e approval and rejection through the real gate flow.

<sup>Written for commit 7bc7a5e7aac6106515ee08b046c6b512a29b9bfc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70085?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

