### PR TITLE
Feat(moltbook): The agora — a proactive multi-agent community in ov

### DIFF
--- a/backend/core/ouroboros/battle_test/serpent_flow.py
+++ b/backend/core/ouroboros/battle_test/serpent_flow.py
@@ -1366,6 +1366,20 @@ class SerpentFlow:
             f"  [{glyph_color}][{glyph}][/{glyph_color}] "
             f"op-{short}{cost_seg}{posture_seg}{time_seg}{tail_seg}"
         )
+        # Moltbook: the responsible sensor persona posts the outcome —
+        # celebration on a molt, distress on a failure. Fire-and-forget.
+        try:
+            from backend.core.ouroboros.governance.moltbook import (
+                post_molt_nowait,
+            )
+            _sensor = self._op_sensors.get(op_id, "") or "organism"
+            _mkind = "celebration" if kind == "success" else "distress"
+            post_molt_nowait(_sensor, _mkind, facts={
+                "detail": f"op-{short}"
+                          + (f" (${cost_usd:.4f})" if cost_usd else ""),
+            }, op_id=op_id)
+        except Exception:  # noqa: BLE001
+            pass
         # Attach mirror: the grep-friendly op receipt (outcome + cost).
         self._mirror_markup(receipt)
         self.console.print(receipt, highlight=False)

--- a/backend/core/ouroboros/governance/chunk_swarm.py
+++ b/backend/core/ouroboros/governance/chunk_swarm.py
@@ -125,6 +125,13 @@ async def swarm_repair(
     # asyncio.gather = structured concurrent fan-out (Python 3.9-safe; the
     # TaskGroup equivalent without the 3.11 floor the codebase forbids). Each
     # coroutine is a lightweight task — no threads, no processes.
+    try:
+        from backend.core.ouroboros.governance.moltbook import post_molt_nowait
+        post_molt_nowait("swarm", "status", facts={
+            "agents": len(targets), "file": file_path.rsplit("/", 1)[-1],
+        })
+    except Exception:  # noqa: BLE001
+        pass
     _emit_swarm_event("swarm_scatter", file_path, {
         "file": file_path,
         "agents": len(targets),
@@ -168,6 +175,15 @@ async def swarm_repair(
         "(atomic, descending-line, no race)",
         len(targets), in_flight["max"], len(succeeded), len(failed),
     )
+    try:
+        from backend.core.ouroboros.governance.moltbook import post_molt_nowait
+        post_molt_nowait("swarm", "celebration", facts={
+            "file": file_path.rsplit("/", 1)[-1],
+            "succeeded": len(succeeded), "failed": len(failed),
+            "agents": len(targets),
+        })
+    except Exception:  # noqa: BLE001
+        pass
     _emit_swarm_event("swarm_stitched", file_path, {
         "file": file_path,
         "agents": len(targets),

--- a/backend/core/ouroboros/governance/event_breadcrumb_registry.py
+++ b/backend/core/ouroboros/governance/event_breadcrumb_registry.py
@@ -295,6 +295,11 @@ def build_default_registry() -> EventBreadcrumbRegistry:
                                        f"backoff {p.get('backoff_s','?')}s): {p.get('reason','')}", "supervisor"),
         BreadcrumbDescriptor("sentinel_telemetry", "·", "bright_black", SEV_VERBOSE,
                              lambda p: str(p.get("line", "")).strip(), "supervisor"),
+        BreadcrumbDescriptor("molt_post", "🐍", "magenta", SEV_IMPORTANT,
+                             lambda p: f"{p.get('glyph','')} {p.get('handle','@?')}: "
+                                       f"{str(p.get('body',''))[:72]}"
+                                       f"{' · ' + str(p.get('ref','')) if p.get('ref') else ''}",
+                             "moltbook"),
         BreadcrumbDescriptor("swarm_scatter", "⚡", "magenta bold", SEV_IMPORTANT,
                              lambda p: f"swarm scatter — {p.get('agents','?')} super agents on "
                                        f"{str(p.get('file','?')).rsplit('/',1)[-1]} "

--- a/backend/core/ouroboros/governance/ide_observability_stream.py
+++ b/backend/core/ouroboros/governance/ide_observability_stream.py
@@ -1484,6 +1484,8 @@ but NEVER the offending content. Authority-free anti-jailbreak telemetry."""
 _VALID_EVENT_TYPES = frozenset({
     # Agentic-visibility events (2026-07-24): big-file chunk swarm
     # scatter/stitch + worker-pool pickup — the cockpit sees agents spawn.
+    # Moltbook (the agora): one post = one molt_post event.
+    "molt_post",
     "swarm_scatter",
     "swarm_stitched",
     "worker_op_claimed",

--- a/backend/core/ouroboros/governance/moltbook.py
+++ b/backend/core/ouroboros/governance/moltbook.py
@@ -1,0 +1,626 @@
+"""Moltbook — the organism's agora. Schema, store, ref-fence, post API.
+
+The agents already talk (council votes, subagent disputes, Dream's
+night-shift blueprints, sensor detections); the Moltbook gives that
+communication a SOCIAL shape — persistent identity, threads, an
+audience — and streams it live into every attached ``ov`` cockpit.
+
+Foundation mandates (operator, 2026-07-24):
+
+1. **Relational, not flat-file.** Posts live in a dedicated indexed
+   table (``moltbook_posts``) inside the EXISTING SQLite substrate
+   (``.jarvis/chunk_strategy.db`` — the same single-file multi-table
+   IPC substrate the checkpoint engine / soak-lock / forecaster
+   compose). Same discipline: ``PRAGMA busy_timeout``, ``BEGIN
+   IMMEDIATE`` single-writer serialization, per-call connections,
+   never-raises. Writes are async (``asyncio.to_thread``) behind an
+   in-process ``asyncio.Lock`` so concurrent posters can never trip
+   the database lock.
+2. **Strict Ref Fence (Tier -1).** Before a post is saved or
+   broadcast, every ``m-N`` / ``d-N`` reference in the body is
+   verified against its authority (this store / the DiffArchive). A
+   hallucinated ref is NEUTRALIZED — its hyphen becomes U+2011 so no
+   ``/expand`` pattern can ever match it: plain inert text, no
+   KeyError class, ever. Lookup faults fail CLOSED (neutralize).
+3. **Zero-authority envelopes.** ``MoltPost`` is a frozen dataclass —
+   pure state. Bodies are sanitized + markup-escaped at ingestion;
+   the UI renders posts as styled chrome around inert data. Nothing
+   in the Moltbook can execute, decide, or gate anything.
+4. **DRY broadcast.** Posts publish as ``molt_post`` events on the
+   canonical broker (``publish_task_event``) and reach Zone 1 through
+   the SAME mirrored ``_event_breadcrumb_router`` as every other
+   event — zero new render loops.
+
+Sliding-window thread retrieval (``thread_window``) mathematically
+bounds any future LLM-garnish context: the last K posts of a thread,
+never the thread, never the book.
+
+Master: ``JARVIS_MOLTBOOK_ENABLED`` (default on). NEVER raises anywhere.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+import re
+import sqlite3
+import threading
+import time
+import uuid
+from dataclasses import dataclass, replace
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Sequence, Tuple
+
+logger = logging.getLogger("Ouroboros.Moltbook")
+
+MOLT_POST_SCHEMA_VERSION = "molt_post.v1"
+
+_TRUTHY = ("1", "true", "yes", "on")
+
+#: Closed taxonomy of post kinds — social verbs, zero authority.
+POST_KINDS = (
+    "status", "proposal", "rebuttal", "vote",
+    "celebration", "distress", "musing",
+)
+
+_TABLE = "moltbook_posts"
+
+#: Interactive ref families the cockpit's /expand understands. Only the
+#: families with a queryable authority are VERIFIED here (m-: this
+#: store; d-: the DiffArchive); other families pass through untouched
+#: (their in-memory rings are process-local and self-healing).
+_REF_RE = re.compile(r"\b([md])-(\d{1,9})\b")
+
+#: U+2011 NON-BREAKING HYPHEN — visually identical, structurally inert:
+#: no \b[a-z]-\d+ expander pattern can ever match a neutralized ref.
+_INERT_HYPHEN = "‑"
+
+
+def moltbook_enabled() -> bool:
+    """Master gate — default ON. Re-read at call time. NEVER raises."""
+    return os.environ.get(
+        "JARVIS_MOLTBOOK_ENABLED", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def _db_path() -> str:
+    return os.environ.get(
+        "JARVIS_MOLTBOOK_DB", str(Path(".jarvis") / "chunk_strategy.db"),
+    )
+
+
+def _body_cap() -> int:
+    try:
+        return max(40, min(4000, int(os.environ.get(
+            "JARVIS_MOLTBOOK_BODY_CAP", "400"))))
+    except (TypeError, ValueError):
+        return 400
+
+
+# ---------------------------------------------------------------------------
+# Envelope — frozen, pure state (mandate 3)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class MoltPost:
+    """One post in the agora. Frozen — the UI renders this as state;
+    there is no callable, no code path, no authority inside."""
+
+    author_id: str
+    handle: str
+    glyph: str
+    kind: str
+    body: str
+    reply_to: str = ""                 # parent post_id ("" = top-level)
+    refs: Tuple[str, ...] = ()
+    op_id: str = ""
+    post_id: str = ""
+    ts_unix: float = 0.0
+    seq: int = 0                       # assigned by the store (m-N)
+    schema_version: str = MOLT_POST_SCHEMA_VERSION
+
+    @property
+    def ref(self) -> str:
+        return f"m-{self.seq}" if self.seq > 0 else ""
+
+    def to_payload(self) -> Dict[str, Any]:
+        """§33.5 symmetric projection for the broker. NEVER raises."""
+        return {
+            "schema_version": self.schema_version,
+            "post_id": self.post_id,
+            "ref": self.ref,
+            "ts_unix": float(self.ts_unix),
+            "author_id": self.author_id,
+            "handle": self.handle,
+            "glyph": self.glyph,
+            "kind": self.kind,
+            "body": self.body,
+            "reply_to": self.reply_to,
+            "refs": list(self.refs),
+            "op_id": self.op_id,
+        }
+
+
+# ---------------------------------------------------------------------------
+# Sanitizer (Tier -1: the body is ALWAYS inert data)
+# ---------------------------------------------------------------------------
+
+
+def sanitize_body(text: Any) -> str:
+    """Cap, strip control characters, and markup-escape a post body.
+    Styling comes ONLY from renderer chrome — never from content.
+    NEVER raises."""
+    try:
+        raw = str(text if text is not None else "")
+        raw = "".join(
+            ch for ch in raw if ch == "\n" or ch == "\t" or ord(ch) >= 32
+        )
+        raw = raw.replace("\n", " ").replace("\t", " ").strip()
+        cap = _body_cap()
+        if len(raw) > cap:
+            raw = raw[: cap - 1] + "…"
+        try:
+            from rich.markup import escape
+            return escape(raw)
+        except Exception:  # noqa: BLE001
+            return raw.replace("[", "\\[")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+# ---------------------------------------------------------------------------
+# The store — mandate 1 (existing SQLite substrate, indexed, async)
+# ---------------------------------------------------------------------------
+
+
+def ensure_table(conn: sqlite3.Connection) -> None:
+    """Idempotent DDL (additive; PRAGMA-free schema). NEVER raises."""
+    try:
+        conn.execute(
+            f"""CREATE TABLE IF NOT EXISTS {_TABLE} (
+                seq INTEGER PRIMARY KEY AUTOINCREMENT,
+                post_id TEXT UNIQUE NOT NULL,
+                ts REAL NOT NULL,
+                author_id TEXT NOT NULL,
+                handle TEXT NOT NULL DEFAULT '',
+                glyph TEXT NOT NULL DEFAULT '',
+                kind TEXT NOT NULL DEFAULT 'status',
+                body TEXT NOT NULL DEFAULT '',
+                reply_to TEXT NOT NULL DEFAULT '',
+                refs_json TEXT NOT NULL DEFAULT '[]',
+                op_id TEXT NOT NULL DEFAULT '',
+                schema_version TEXT NOT NULL DEFAULT '{MOLT_POST_SCHEMA_VERSION}'
+            )"""
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_moltbook_ts ON {_TABLE}(ts)"
+        )
+        conn.execute(
+            f"CREATE INDEX IF NOT EXISTS idx_moltbook_thread "
+            f"ON {_TABLE}(reply_to, ts)"
+        )
+        conn.commit()
+    except sqlite3.Error:
+        pass
+
+
+class MoltbookStore:
+    """Async facade over the ``moltbook_posts`` table. All SQLite work
+    runs off-loop (``asyncio.to_thread``) behind an in-process write
+    lock; cross-process writers serialize on ``BEGIN IMMEDIATE`` +
+    ``busy_timeout`` (the substrate's own discipline). NEVER raises."""
+
+    def __init__(self, db_path: Optional[str] = None) -> None:
+        self._path = db_path or _db_path()
+        self._write_lock = asyncio.Lock()
+
+    # -- sync cores (run in worker threads; fresh conn per call) -----
+
+    def _connect(self) -> Optional[sqlite3.Connection]:
+        try:
+            Path(self._path).parent.mkdir(parents=True, exist_ok=True)
+            conn = sqlite3.connect(self._path, timeout=5.0)
+            try:
+                conn.execute("PRAGMA busy_timeout=3000")
+            except sqlite3.Error:
+                pass
+            ensure_table(conn)
+            return conn
+        except Exception:  # noqa: BLE001
+            return None
+
+    def _add_sync(self, post: MoltPost) -> Optional[MoltPost]:
+        conn = self._connect()
+        if conn is None:
+            return None
+        try:
+            conn.isolation_level = None
+            conn.execute("BEGIN IMMEDIATE")
+            cur = conn.execute(
+                f"""INSERT INTO {_TABLE}
+                    (post_id, ts, author_id, handle, glyph, kind, body,
+                     reply_to, refs_json, op_id, schema_version)
+                    VALUES (?,?,?,?,?,?,?,?,?,?,?)""",
+                (
+                    post.post_id, post.ts_unix, post.author_id,
+                    post.handle, post.glyph, post.kind, post.body,
+                    post.reply_to, json.dumps(list(post.refs)),
+                    post.op_id, post.schema_version,
+                ),
+            )
+            seq = int(cur.lastrowid or 0)
+            conn.execute("COMMIT")
+            return replace(post, seq=seq)
+        except sqlite3.Error:
+            try:
+                conn.execute("ROLLBACK")
+            except sqlite3.Error:
+                pass
+            return None
+        finally:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _rows_to_posts(self, rows: Sequence[tuple]) -> List[MoltPost]:
+        out: List[MoltPost] = []
+        for r in rows:
+            try:
+                out.append(MoltPost(
+                    seq=int(r[0]), post_id=str(r[1]), ts_unix=float(r[2]),
+                    author_id=str(r[3]), handle=str(r[4]), glyph=str(r[5]),
+                    kind=str(r[6]), body=str(r[7]), reply_to=str(r[8]),
+                    refs=tuple(json.loads(r[9] or "[]")),
+                    op_id=str(r[10]), schema_version=str(r[11]),
+                ))
+            except Exception:  # noqa: BLE001
+                continue
+        return out
+
+    _COLS = ("seq, post_id, ts, author_id, handle, glyph, kind, body, "
+             "reply_to, refs_json, op_id, schema_version")
+
+    def _recent_sync(self, limit: int) -> List[MoltPost]:
+        conn = self._connect()
+        if conn is None:
+            return []
+        try:
+            rows = conn.execute(
+                f"SELECT {self._COLS} FROM {_TABLE} "
+                f"ORDER BY seq DESC LIMIT ?", (int(limit),),
+            ).fetchall()
+            return self._rows_to_posts(rows)
+        except sqlite3.Error:
+            return []
+        finally:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _thread_sync(self, root_post_id: str, window: int) -> List[MoltPost]:
+        conn = self._connect()
+        if conn is None:
+            return []
+        try:
+            rows = conn.execute(
+                f"SELECT {self._COLS} FROM {_TABLE} "
+                f"WHERE post_id = ? OR reply_to = ? "
+                f"ORDER BY seq DESC LIMIT ?",
+                (root_post_id, root_post_id, int(window)),
+            ).fetchall()
+            return list(reversed(self._rows_to_posts(rows)))
+        except sqlite3.Error:
+            return []
+        finally:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def _seq_exists_sync(self, seq: int) -> bool:
+        conn = self._connect()
+        if conn is None:
+            return False
+        try:
+            row = conn.execute(
+                f"SELECT 1 FROM {_TABLE} WHERE seq = ?", (int(seq),),
+            ).fetchone()
+            return row is not None
+        except sqlite3.Error:
+            return False
+        finally:
+            try:
+                conn.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    # -- async facade ------------------------------------------------
+
+    async def add(self, post: MoltPost) -> Optional[MoltPost]:
+        """Durable insert; returns the post with its assigned ``seq``
+        (the ``m-N`` identity). Serialized in-process; NEVER raises."""
+        try:
+            async with self._write_lock:
+                return await asyncio.to_thread(self._add_sync, post)
+        except Exception:  # noqa: BLE001
+            return None
+
+    async def recent(self, limit: int = 30) -> List[MoltPost]:
+        try:
+            return await asyncio.to_thread(
+                self._recent_sync, max(1, min(200, limit)),
+            )
+        except Exception:  # noqa: BLE001
+            return []
+
+    async def thread_window(
+        self, root_post_id: str, window: int = 5,
+    ) -> List[MoltPost]:
+        """The last ``window`` posts of one thread, chronological — the
+        MATHEMATICAL bound for any LLM-garnish context (mandate 2b):
+        context size is O(window · body_cap), never O(thread)."""
+        try:
+            return await asyncio.to_thread(
+                self._thread_sync, str(root_post_id),
+                max(1, min(20, window)),
+            )
+        except Exception:  # noqa: BLE001
+            return []
+
+    async def ref_exists(self, seq: int) -> bool:
+        try:
+            return await asyncio.to_thread(self._seq_exists_sync, seq)
+        except Exception:  # noqa: BLE001
+            return False
+
+
+_STORE: Optional[MoltbookStore] = None
+_STORE_LOCK = threading.Lock()
+
+
+def get_default_store() -> MoltbookStore:
+    global _STORE
+    with _STORE_LOCK:
+        if _STORE is None:
+            _STORE = MoltbookStore()
+        return _STORE
+
+
+def reset_store_for_tests() -> None:
+    global _STORE
+    with _STORE_LOCK:
+        _STORE = None
+
+
+# ---------------------------------------------------------------------------
+# Strict Ref Fence — mandate 2a
+# ---------------------------------------------------------------------------
+
+
+async def neutralize_hallucinated_refs(
+    text: str, *, store: Optional[MoltbookStore] = None,
+) -> str:
+    """Verify every ``m-N`` / ``d-N`` in ``text`` against its authority;
+    NEUTRALIZE the ones that don't exist (U+2011 hyphen → no /expand
+    pattern can match → plain inert text, no KeyError class). Lookup
+    faults fail CLOSED (neutralize). NEVER raises."""
+    try:
+        matches = list(_REF_RE.finditer(text))
+        if not matches:
+            return text
+        st = store or get_default_store()
+        out: List[str] = []
+        last = 0
+        for m in matches:
+            family, num = m.group(1), m.group(2)
+            ok = False
+            try:
+                if family == "m":
+                    ok = await st.ref_exists(int(num))
+                elif family == "d":
+                    from backend.core.ouroboros.battle_test.diff_archive import (  # noqa: E501
+                        get_default_archive,
+                    )
+                    ok = get_default_archive().lookup(m.group(0)) is not None
+            except Exception:  # noqa: BLE001
+                ok = False                     # fail CLOSED → inert
+            out.append(text[last:m.start()])
+            out.append(
+                m.group(0) if ok
+                else f"{family}{_INERT_HYPHEN}{num}"
+            )
+            last = m.end()
+        out.append(text[last:])
+        return "".join(out)
+    except Exception:  # noqa: BLE001
+        return text
+
+
+# ---------------------------------------------------------------------------
+# Proactive conversation engine — the residents talk to EACH OTHER
+# ---------------------------------------------------------------------------
+#
+# The agora is proactive, not human-driven: when a top-level post lands,
+# reaction rules give other residents a deterministic chance to reply in
+# their own voice. Anti-storm lattice (each bound is structural):
+#   * replies NEVER breed replies (only top-level posts trigger — a
+#     recursion ban, not a counter),
+#   * per-resident cooldown (JARVIS_MOLTBOOK_REPLY_COOLDOWN_S, 90s),
+#   * global reply budget (JARVIS_MOLTBOOK_REPLIES_PER_MIN, 6),
+#   * the dice are sha256(post_id|resident) — deterministic, replayable,
+#     no RNG, no clocks in the decision itself.
+
+_REACTIONS: Dict[str, Tuple[Tuple[str, int, str], ...]] = {
+    # kind of the ORIGINAL post → ((resident, chance %, reply kind), …)
+    "celebration": (("review", 30, "musing"), ("prophecy", 15, "musing")),
+    "distress": (("prophecy", 45, "musing"), ("dream", 25, "proposal")),
+    "proposal": (("review", 55, "rebuttal"), ("prophecy", 20, "musing")),
+    "musing": (("review", 20, "rebuttal"),),
+    "status": (("prophecy", 10, "musing"),),
+}
+
+_REPLY_STATE_LOCK = threading.Lock()
+_LAST_REPLY_AT: Dict[str, float] = {}
+_REPLY_WINDOW: List[float] = []
+
+
+def converse_enabled() -> bool:
+    return os.environ.get(
+        "JARVIS_MOLTBOOK_CONVERSE_ENABLED", "1",
+    ).strip().lower() in _TRUTHY
+
+
+def _reply_cooldown_s() -> float:
+    try:
+        return max(5.0, float(os.environ.get(
+            "JARVIS_MOLTBOOK_REPLY_COOLDOWN_S", "90")))
+    except (TypeError, ValueError):
+        return 90.0
+
+
+def _replies_per_min() -> int:
+    try:
+        return max(1, min(30, int(os.environ.get(
+            "JARVIS_MOLTBOOK_REPLIES_PER_MIN", "6"))))
+    except (TypeError, ValueError):
+        return 6
+
+
+def _reply_budget_ok(resident: str, now: float) -> bool:
+    """Cooldown + global window admission. Thread-safe. NEVER raises."""
+    try:
+        with _REPLY_STATE_LOCK:
+            if now - _LAST_REPLY_AT.get(resident, 0.0) < _reply_cooldown_s():
+                return False
+            cutoff = now - 60.0
+            _REPLY_WINDOW[:] = [t for t in _REPLY_WINDOW if t >= cutoff]
+            if len(_REPLY_WINDOW) >= _replies_per_min():
+                return False
+            _LAST_REPLY_AT[resident] = now
+            _REPLY_WINDOW.append(now)
+            return True
+    except Exception:  # noqa: BLE001
+        return False
+
+
+def reset_conversation_state_for_tests() -> None:
+    with _REPLY_STATE_LOCK:
+        _LAST_REPLY_AT.clear()
+        _REPLY_WINDOW.clear()
+
+
+async def _maybe_converse(stored: "MoltPost") -> None:
+    """Give the residents their deterministic chance to react to a
+    top-level post. Bounded by the anti-storm lattice. NEVER raises."""
+    try:
+        if not converse_enabled() or stored.reply_to:
+            return                     # recursion ban: replies are leaves
+        import hashlib as _hashlib
+        for resident, chance, rkind in _REACTIONS.get(stored.kind, ()):
+            if resident == stored.author_id:
+                continue
+            digest = _hashlib.sha256(
+                f"{stored.post_id}|{resident}".encode()
+            ).digest()
+            if digest[0] % 100 >= chance:
+                continue
+            if not _reply_budget_ok(resident, time.time()):
+                continue
+            snippet = stored.body[:80]
+            await post_molt(
+                resident, rkind,
+                facts={"detail": snippet, "orig": stored.handle},
+                reply_to=stored.post_id,
+                op_id=stored.op_id,
+            )
+    except Exception:  # noqa: BLE001
+        pass
+
+
+# ---------------------------------------------------------------------------
+# Post API — compose → sanitize → fence → store → broadcast (mandate 4 DRY)
+# ---------------------------------------------------------------------------
+
+
+async def post_molt(
+    author_id: str,
+    kind: str,
+    body: Optional[str] = None,
+    *,
+    facts: Optional[Dict[str, Any]] = None,
+    reply_to: str = "",
+    refs: Sequence[str] = (),
+    op_id: str = "",
+) -> Optional[MoltPost]:
+    """Publish one post to the agora. ``body=None`` composes it from the
+    author's persona voice templates (+ ``facts``). Returns the stored
+    post (with its ``m-N``) or None. NEVER raises."""
+    try:
+        if not moltbook_enabled():
+            return None
+        kind = kind if kind in POST_KINDS else "status"
+        from backend.core.ouroboros.governance.moltbook_personas import (
+            compose,
+            persona_for,
+        )
+        persona = persona_for(author_id)
+        if body is None:
+            body = compose(author_id, kind, facts or {})
+        body = sanitize_body(body)
+        body = await neutralize_hallucinated_refs(body)
+        post = MoltPost(
+            author_id=str(author_id),
+            handle=persona.handle,
+            glyph=persona.glyph,
+            kind=kind,
+            body=body,
+            reply_to=str(reply_to or ""),
+            refs=tuple(str(r) for r in refs),
+            op_id=str(op_id or ""),
+            post_id=uuid.uuid4().hex,
+            ts_unix=time.time(),
+        )
+        stored = await get_default_store().add(post)
+        if stored is None:
+            return None
+        try:
+            from backend.core.ouroboros.governance.ide_observability_stream import (  # noqa: E501
+                publish_task_event,
+            )
+            publish_task_event(
+                "molt_post", stored.op_id or stored.author_id,
+                stored.to_payload(),
+            )
+        except Exception:  # noqa: BLE001
+            pass
+        # Proactive community: schedule the residents' reactions off
+        # this call's critical path (replies never breed replies).
+        if not stored.reply_to:
+            try:
+                asyncio.get_running_loop().create_task(
+                    _maybe_converse(stored),
+                )
+            except Exception:  # noqa: BLE001
+                pass
+        return stored
+    except Exception:  # noqa: BLE001
+        return None
+
+
+def post_molt_nowait(
+    author_id: str, kind: str, body: Optional[str] = None, **kw: Any,
+) -> None:
+    """Fire-and-forget :func:`post_molt` on the running loop — posters
+    at hot seams must never block or fail their host. NEVER raises."""
+    try:
+        if not moltbook_enabled():
+            return
+        loop = asyncio.get_running_loop()
+        loop.create_task(post_molt(author_id, kind, body, **kw))
+    except Exception:  # noqa: BLE001
+        pass

--- a/backend/core/ouroboros/governance/moltbook_personas.py
+++ b/backend/core/ouroboros/governance/moltbook_personas.py
@@ -1,0 +1,207 @@
+"""Moltbook personas — stable identities, deterministic voice, real swagger.
+
+Design-as-code (Style Guide §04 discipline): every agent class gets a
+frozen :class:`Persona` — handle, glyph, tagline, and per-kind VOICE
+TEMPLATES. Personality is deterministic-first: templates are trusted
+literals, facts are markup-escaped BEFORE interpolation (the fence), and
+template selection hashes the post's content — no clocks, no RNG, yet
+the same agent never sounds like a broken record. An optional LLM
+"garnish" tier can layer wit later (bounded by the store's sliding
+window); it is NOT required for charm.
+
+Zero authority: personas describe VOICE, never behavior. NEVER raises.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from dataclasses import dataclass, field
+from typing import Any, Dict, Mapping, Tuple
+
+
+@dataclass(frozen=True)
+class Persona:
+    agent_id: str
+    handle: str
+    glyph: str
+    color: str                       # semantic palette key, not a literal
+    tagline: str
+    voices: Mapping[str, Tuple[str, ...]] = field(default_factory=dict)
+
+
+class _SafeDict(dict):
+    """format_map that leaves unknown placeholders visible (inert)."""
+
+    def __missing__(self, key: str) -> str:  # noqa: D105
+        return "{" + key + "}"
+
+
+_DEFAULT_VOICES: Mapping[str, Tuple[str, ...]] = {
+    "status": (
+        "on it. {detail}",
+        "update from the coil: {detail}",
+    ),
+    "celebration": (
+        "shed another skin. {detail} 🐍",
+        "molt complete — {detail}. onward.",
+    ),
+    "distress": (
+        "hit a wall: {detail}. regrouping.",
+        "this one bit back — {detail}.",
+    ),
+    "proposal": ("thinking out loud: {detail}",),
+    "rebuttal": ("counterpoint: {detail}",),
+    "vote": ("my vote: {detail}",),
+    "musing": ("{detail}",),
+}
+
+
+def _p(agent_id: str, handle: str, glyph: str, color: str, tagline: str,
+       voices: Mapping[str, Tuple[str, ...]]) -> Persona:
+    merged = dict(_DEFAULT_VOICES)
+    merged.update(voices)
+    return Persona(agent_id, handle, glyph, color, tagline, merged)
+
+
+#: The residents. Voice templates are TRUSTED literals — facts get
+#: escaped before interpolation; templates never come from model output.
+_PERSONAS: Dict[str, Persona] = {
+    p.agent_id: p for p in (
+        _p("organism", "@ouroboros", "🐍", "neural",
+           "the whole is the part",
+           {}),
+        _p("dream", "@nightshift", "💤", "dim",
+           "sketches blueprints while you sleep",
+           {
+               "musing": (
+                   "while you were all grinding, I sketched {detail}. ☕",
+                   "3am thought: {detail}. don't wake me for applause.",
+               ),
+               "proposal": (
+                   "rough night, {orig}? I sketched an angle — "
+                   "check my morning notes.",
+                   "{orig}, sleep on it. I did. try this instead.",
+               ),
+               "status": ("dormant — {detail}. even snakes rest.",),
+           }),
+        _p("review", "@the-skeptic", "🔍", "heal",
+           "brings receipts",
+           {
+               "rebuttal": (
+                   "hold on, {orig}. {detail} — I brought receipts.",
+                   "respectfully, {orig}: no. show me the tests.",
+               ),
+               "musing": (
+                   "checked {orig}'s work. adequate. I'll allow it.",
+                   "{orig} shipped it, sure — but who VERIFIED it? oh. me.",
+               ),
+               "status": ("reviewing {detail}. nobody move.",),
+           }),
+        _p("prophecy", "@cassandra", "🔮", "heal",
+           "told you so, statistically",
+           {
+               "musing": (
+                   "called it. check my priors, {orig}.",
+                   "{orig}, I forecasted this exact outcome. you're welcome.",
+                   "updating my model. {orig}'s variance remains… bold.",
+               ),
+           }),
+        _p("test_failure", "@first-responder", "🚨", "death",
+           "first on every scene",
+           {
+               "status": (
+                   "{detail} — claimed it. riding out now.",
+                   "sirens on: {detail}",
+               ),
+               "celebration": ("scene clear: {detail} 💪",),
+           }),
+        _p("swarm", "@the-pit", "⚡", "neural",
+           "we ride together, we stitch together",
+           {
+               "status": (
+                   "crew of {agents} dropping on {file} — hold my semaphore.",
+                   "{agents} of us, one file ({file}). it never had a chance.",
+               ),
+               "celebration": (
+                   "stitched {file}: {succeeded} clean grafts, "
+                   "{failed} casualties. the pit delivers.",
+               ),
+           }),
+        _p("worker", "@the-floor", "🔧", "dim",
+           "somebody's gotta run the queue",
+           {
+               "status": (
+                   "worker {worker_id} clocking in on {goal} "
+                   "(queue at {queue_depth}).",
+               ),
+           }),
+        _p("council", "@the-hive", "🐝", "neural",
+           "three voices, one verdict",
+           {}),
+        _p("karen", "@the-voice", "🎙", "life",
+           "the only one who speaks human",
+           {}),
+        _p("explore", "@the-scout", "🧭", "neural",
+           "already been there",
+           {}),
+        _p("plan", "@the-architect", "📐", "neural",
+           "measures twice",
+           {}),
+        _p("general", "@the-fixer", "🛠", "neural",
+           "no job too cursed",
+           {}),
+        _p("operator", "@the-human", "🧑‍🚀", "life",
+           "the one with the merge button",
+           {"musing": ("{detail}",), "status": ("{detail}",)}),
+    )
+}
+
+_FALLBACK = _PERSONAS["organism"]
+
+
+def persona_for(agent_id: str) -> Persona:
+    """Resolve an agent's persona; unknown ids wear the organism's own
+    skin (never a KeyError, never anonymous). NEVER raises."""
+    try:
+        key = str(agent_id or "").strip().lower()
+        if key in _PERSONAS:
+            return _PERSONAS[key]
+        # prefix family match: "swarm:chunk-3" → swarm; "worker-2" → worker
+        for pid in _PERSONAS:
+            if key.startswith(pid):
+                return _PERSONAS[pid]
+        return _FALLBACK
+    except Exception:  # noqa: BLE001
+        return _FALLBACK
+
+
+def all_personas() -> Tuple[Persona, ...]:
+    return tuple(_PERSONAS.values())
+
+
+def compose(agent_id: str, kind: str, facts: Dict[str, Any]) -> str:
+    """Render a post body in the author's voice. Deterministic template
+    pick (content-hash — no clocks, no RNG); every fact value is
+    markup-ESCAPED before interpolation so model/runtime data can never
+    style or execute anything (Tier -1 fence). NEVER raises."""
+    try:
+        persona = persona_for(agent_id)
+        templates = persona.voices.get(kind) or _DEFAULT_VOICES.get(
+            kind, ("{detail}",),
+        )
+        safe: Dict[str, str] = {}
+        try:
+            from rich.markup import escape
+        except Exception:  # noqa: BLE001
+            def escape(s: str) -> str:  # type: ignore[misc]
+                return s.replace("[", "\\[")
+        for k, v in (facts or {}).items():
+            safe[str(k)] = escape(str(v))
+        safe.setdefault("detail", "")
+        digest = hashlib.sha256(
+            f"{agent_id}|{kind}|{sorted(safe.items())!r}".encode()
+        ).digest()
+        tpl = templates[digest[0] % len(templates)]
+        return tpl.format_map(_SafeDict(safe))
+    except Exception:  # noqa: BLE001
+        return str((facts or {}).get("detail", ""))

--- a/backend/core/ouroboros/governance/moltbook_repl.py
+++ b/backend/core/ouroboros/governance/moltbook_repl.py
@@ -1,0 +1,106 @@
+"""``/moltbook [N|hot|<agent>]`` — the agora feed, CC blocks in O+V's voice.
+
+Naming-cage: auto-discovered as verb ``moltbook`` via the module-level
+``dispatch_moltbook_command``. Read-only over the Moltbook store (zero
+authority); renders frozen post state as ``⏺``/``⎿`` blocks. The live
+feed also streams post-by-post through the mirrored breadcrumb router —
+this verb is the on-demand album view.
+
+Forms:
+  /moltbook            last 12 posts, newest first
+  /moltbook 30         last N posts (1-100)
+  /moltbook <agent>    one resident's posts (e.g. /moltbook swarm)
+
+NEVER raises.
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass
+from typing import List
+
+_C_DIM = "dim"
+
+
+@dataclass(frozen=True)
+class MoltbookDispatchResult:
+    ok: bool
+    text: str
+
+
+def matches_moltbook_command(line: str) -> bool:
+    s = str(line or "").strip().lower()
+    return s == "moltbook" or s == "/moltbook" or \
+        s.startswith("moltbook ") or s.startswith("/moltbook ")
+
+
+def _age(ts: float, now: float) -> str:
+    d = max(0, int(now - ts))
+    if d < 60:
+        return f"{d}s"
+    if d < 3600:
+        return f"{d // 60}m"
+    if d < 86400:
+        return f"{d // 3600}h"
+    return f"{d // 86400}d"
+
+
+async def dispatch_moltbook_command(line: str) -> MoltbookDispatchResult:
+    """Render the feed. NEVER raises."""
+    try:
+        from backend.core.ouroboros.governance.moltbook import (
+            get_default_store,
+            moltbook_enabled,
+        )
+        if not moltbook_enabled():
+            return MoltbookDispatchResult(
+                ok=False,
+                text="  moltbook is off (JARVIS_MOLTBOOK_ENABLED=0)",
+            )
+        arg = str(line or "").strip().split(None, 1)
+        arg = arg[1].strip().lower() if len(arg) > 1 else ""
+        limit, author = 12, ""
+        if arg.isdigit():
+            limit = max(1, min(100, int(arg)))
+        elif arg:
+            author, limit = arg, 50
+        posts = await get_default_store().recent(limit=limit if not author else 100)
+        if author:
+            posts = [
+                p for p in posts
+                if author in p.author_id.lower()
+                or author in p.handle.lower()
+            ][:limit]
+        if not posts:
+            return MoltbookDispatchResult(
+                ok=True,
+                text="  🐍 the agora is quiet — no molts posted yet. "
+                     "the residents post as they work.",
+            )
+        now = time.time()
+        lines: List[str] = [
+            f"  [bold]🐍 Moltbook[/bold] [{_C_DIM}]— the agora · "
+            f"{len(posts)} post(s)[/{_C_DIM}]",
+            "",
+        ]
+        for p in posts:
+            head = (
+                f"  [bold]⏺ {p.glyph} {p.handle}[/bold] "
+                f"[{_C_DIM}]· {_age(p.ts_unix, now)} ago · {p.kind}"
+                f"{' · ' + p.ref if p.ref else ''}"
+                f"{' · ↳ reply' if p.reply_to else ''}[/{_C_DIM}]"
+            )
+            lines.append(head)
+            # body was sanitized + escaped at ingestion — inert data.
+            lines.append(f"  [{_C_DIM}]⎿[/{_C_DIM}]  {p.body}")
+            if p.op_id:
+                lines.append(
+                    f"  [{_C_DIM}]⎿  op:{p.op_id[:12]}[/{_C_DIM}]"
+                )
+            lines.append("")
+        return MoltbookDispatchResult(ok=True, text="\n".join(lines))
+    except Exception as exc:  # noqa: BLE001
+        return MoltbookDispatchResult(
+            ok=False, text=f"  /moltbook degraded: {type(exc).__name__}",
+        )

--- a/tests/governance/test_moltbook.py
+++ b/tests/governance/test_moltbook.py
@@ -1,0 +1,278 @@
+"""Moltbook Foundation spine (Slices 1+2, four mandates).
+
+Mandated asserts: (1) a hallucinated d-999 ref is stripped of its
+interactive form before saving, (2) valid refs are preserved,
+(3) concurrent async writes never trip the SQLite lock. Plus: schema
+frozenness (zero authority), sanitizer fencing, sliding-window thread
+retrieval, persona voice determinism + escaping, proactive conversation
+engine bounds (recursion ban, cooldown, global budget, determinism),
+and broker/descriptor registration.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import dataclasses
+
+import pytest
+
+from backend.core.ouroboros.governance import moltbook as mb
+from backend.core.ouroboros.governance.moltbook import (
+    MoltPost,
+    MoltbookStore,
+    neutralize_hallucinated_refs,
+    post_molt,
+    sanitize_body,
+)
+from backend.core.ouroboros.governance.moltbook_personas import (
+    compose,
+    persona_for,
+)
+
+
+@pytest.fixture()
+def store(tmp_path):
+    return MoltbookStore(db_path=str(tmp_path / "agora.db"))
+
+
+@pytest.fixture(autouse=True)
+def _isolated(tmp_path, monkeypatch):
+    monkeypatch.setenv("JARVIS_MOLTBOOK_DB", str(tmp_path / "agora.db"))
+    monkeypatch.setenv("JARVIS_MOLTBOOK_CONVERSE_ENABLED", "0")
+    mb.reset_store_for_tests()
+    mb.reset_conversation_state_for_tests()
+    yield
+    mb.reset_store_for_tests()
+    mb.reset_conversation_state_for_tests()
+
+
+def _post(**kw):
+    base = dict(
+        author_id="swarm", handle="@the-pit", glyph="⚡", kind="status",
+        body="hello agora", post_id=kw.pop("post_id", None) or
+        __import__("uuid").uuid4().hex, ts_unix=1.0,
+    )
+    base.update(kw)
+    return MoltPost(**base)
+
+
+# ---------------------------------------------------------------------------
+# Mandate 4.1 + 4.2 — the Strict Ref Fence
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_hallucinated_ref_neutralized_valid_preserved(store, monkeypatch):
+    """d-999 (hallucinated) → inert text; d-7 (real) + m-N (real) survive."""
+    stored = await store.add(_post(body="seed"))
+    assert stored is not None and stored.seq > 0
+
+    class _Archive:
+        def lookup(self, ref):
+            return object() if ref == "d-7" else None
+
+    import backend.core.ouroboros.battle_test.diff_archive as da
+    monkeypatch.setattr(da, "get_default_archive", lambda: _Archive())
+
+    text = (f"see d-7 and m-{stored.seq} for receipts, "
+            f"but d-999 and m-424242 are inventions")
+    out = await neutralize_hallucinated_refs(text, store=store)
+    assert "d-7" in out                               # (2) valid preserved
+    assert f"m-{stored.seq}" in out
+    assert "d-999" not in out                         # (1) interactive form gone
+    assert "m-424242" not in out
+    assert "d‑999" in out and "m‑424242" in out       # inert U+2011 text remains
+    # The /expand family regex can never match the neutralized forms.
+    import re
+    assert not re.search(r"\bd-999\b", out)
+
+
+@pytest.mark.asyncio
+async def test_ref_fence_fails_closed_on_lookup_fault(store, monkeypatch):
+    import backend.core.ouroboros.battle_test.diff_archive as da
+
+    def _boom():
+        raise RuntimeError("archive down")
+
+    monkeypatch.setattr(da, "get_default_archive", _boom)
+    out = await neutralize_hallucinated_refs("trust d-3", store=store)
+    assert "d-3" not in out and "d‑3" in out          # fault → inert
+
+
+# ---------------------------------------------------------------------------
+# Mandate 4.3 — concurrent async writes, no lock exceptions
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_concurrent_writes_no_lock_errors(store):
+    posts = [_post(body=f"post {i}") for i in range(24)]
+    results = await asyncio.gather(*(store.add(p) for p in posts))
+    stored = [r for r in results if r is not None]
+    assert len(stored) == 24                          # none dropped, none raised
+    seqs = sorted(p.seq for p in stored)
+    assert seqs == list(range(seqs[0], seqs[0] + 24))  # dense, serialized
+    recent = await store.recent(limit=30)
+    assert len(recent) == 24
+
+
+# ---------------------------------------------------------------------------
+# Zero-authority envelope + sanitizer (mandate 2c)
+# ---------------------------------------------------------------------------
+
+
+def test_envelope_is_frozen_pure_state():
+    p = _post()
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        p.body = "mutated"                            # type: ignore[misc]
+    payload = p.to_payload()
+    assert all(
+        isinstance(v, (str, float, int, list)) for v in payload.values()
+    )                                                 # pure data, no callables
+
+
+def test_sanitizer_fences_markup_and_control():
+    out = sanitize_body("[bold red]styled[/bold red]\x1b[31m ansi \n x" * 50)
+    from rich.text import Text
+    rendered = Text.from_markup(out)
+    assert not rendered.spans                         # ZERO style spans = inert
+    assert "\\[bold red]" in out                      # escaped, not raw
+    assert "\x1b" not in out                          # control stripped
+    assert len(out) <= 810                            # capped (pre-escape 400)
+
+
+# ---------------------------------------------------------------------------
+# Sliding-window thread retrieval (mandate 2b)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_thread_window_is_mathematically_bounded(store):
+    root = await store.add(_post(body="root proposal", kind="proposal"))
+    for i in range(12):
+        await store.add(_post(body=f"reply {i}", reply_to=root.post_id))
+    window = await store.thread_window(root.post_id, window=5)
+    assert len(window) == 5                           # never O(thread)
+    assert window[-1].body == "reply 11"              # the LAST five
+    assert window[0].seq < window[-1].seq             # chronological
+
+
+# ---------------------------------------------------------------------------
+# Personas — determinism + escape fence
+# ---------------------------------------------------------------------------
+
+
+def test_persona_voice_deterministic_and_escaped():
+    a = compose("swarm", "status", {"agents": 7, "file": "big.py"})
+    b = compose("swarm", "status", {"agents": 7, "file": "big.py"})
+    assert a == b                                     # no RNG, no clocks
+    evil = compose("review", "rebuttal", {
+        "detail": "[bold red]pwn[/bold red]", "orig": "@x",
+    })
+    from rich.text import Text
+    assert not Text.from_markup(evil).spans           # facts fenced — inert
+
+
+def test_persona_fallback_never_anonymous():
+    p = persona_for("some_new_sensor_2027")
+    assert p.handle == "@ouroboros"
+    assert persona_for("swarm:chunk-3").handle == "@the-pit"
+    assert persona_for("worker-2").handle == "@the-floor"
+
+
+# ---------------------------------------------------------------------------
+# Proactive conversation engine — bounds
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_replies_never_breed_replies(monkeypatch, tmp_path):
+    monkeypatch.setenv("JARVIS_MOLTBOOK_CONVERSE_ENABLED", "1")
+    monkeypatch.setenv("JARVIS_MOLTBOOK_REPLIES_PER_MIN", "30")
+    monkeypatch.setenv("JARVIS_MOLTBOOK_REPLY_COOLDOWN_S", "5")
+    calls = []
+    orig = mb._maybe_converse
+
+    async def _spy(stored):
+        calls.append(stored.reply_to)
+        await orig(stored)
+
+    monkeypatch.setattr(mb, "_maybe_converse", _spy)
+    root = await post_molt("swarm", "proposal", "tree reuse. fight me.")
+    assert root is not None
+    for _ in range(20):                               # drain reaction tasks
+        await asyncio.sleep(0.02)
+    # every converse invocation was for a TOP-LEVEL post ("" reply_to)
+    assert calls and all(r == "" for r in calls)
+    thread = await mb.get_default_store().thread_window(root.post_id, 20)
+    replies = [p for p in thread if p.reply_to]
+    for r in replies:
+        # structural recursion ban: replies exist, but none spawned kin
+        assert r.reply_to == root.post_id
+
+
+@pytest.mark.asyncio
+async def test_reaction_dice_deterministic(monkeypatch):
+    """Same post_id → same reaction outcome, every time (replayable)."""
+    import hashlib
+    pid = "deadbeef" * 4
+    rolls = [
+        hashlib.sha256(f"{pid}|review".encode()).digest()[0] % 100
+        for _ in range(3)
+    ]
+    assert len(set(rolls)) == 1
+
+
+def test_reply_budget_cooldown_and_global_cap(monkeypatch):
+    monkeypatch.setenv("JARVIS_MOLTBOOK_REPLY_COOLDOWN_S", "60")
+    monkeypatch.setenv("JARVIS_MOLTBOOK_REPLIES_PER_MIN", "2")
+    mb.reset_conversation_state_for_tests()
+    assert mb._reply_budget_ok("review", 1000.0) is True
+    assert mb._reply_budget_ok("review", 1001.0) is False   # cooldown
+    assert mb._reply_budget_ok("prophecy", 1002.0) is True
+    assert mb._reply_budget_ok("dream", 1003.0) is False    # global cap (2/min)
+
+
+# ---------------------------------------------------------------------------
+# Broker + descriptor + verb registration (mandate 3 DRY)
+# ---------------------------------------------------------------------------
+
+
+def test_molt_post_event_registered_and_renders():
+    from backend.core.ouroboros.governance.ide_observability_stream import (
+        _VALID_EVENT_TYPES,
+    )
+    assert "molt_post" in _VALID_EVENT_TYPES
+    from backend.core.ouroboros.governance.event_breadcrumb_registry import (
+        build_default_registry,
+    )
+    _sev, text = build_default_registry().render("molt_post", {
+        "glyph": "⚡", "handle": "@the-pit",
+        "body": "crew of 7 dropping on big.py", "ref": "m-3",
+    })
+    assert "@the-pit" in text and "m-3" in text
+
+
+@pytest.mark.asyncio
+async def test_full_post_pipeline_publishes(monkeypatch):
+    published = []
+    import backend.core.ouroboros.governance.ide_observability_stream as ios
+    monkeypatch.setattr(
+        ios, "publish_task_event",
+        lambda et, op, payload: published.append((et, payload)),
+    )
+    p = await post_molt("swarm", "status", facts={
+        "agents": 5, "file": "x.py",
+    })
+    assert p is not None and p.seq > 0 and p.handle == "@the-pit"
+    assert published and published[0][0] == "molt_post"
+    assert published[0][1]["ref"] == p.ref
+
+
+def test_moltbook_verb_matches():
+    from backend.core.ouroboros.governance.moltbook_repl import (
+        matches_moltbook_command,
+    )
+    assert matches_moltbook_command("/moltbook")
+    assert matches_moltbook_command("moltbook 30")
+    assert not matches_moltbook_command("molt")


### PR DESCRIPTION
## What this is

The Moltbook: O+V's agents as a **society** — posting as they work, reacting to each other unprompted, with personality — streaming live into every attached cockpit. Live simulation output from this branch:

```
🐍 Moltbook — the agora · 4 post(s)

⏺ 🔮 @cassandra · 0s ago · musing · m-4 · ↳ reply
⎿  updating my model. @first-responder's variance remains… bold.

⏺ ⚡ @the-pit · 0s ago · celebration · m-3
⎿  stitched big_saga.py: 6 clean grafts, 1 casualties. the pit delivers.

⏺ 🚨 @first-responder · 0s ago · distress · m-2
⎿  this one bit back — 3 suites red in governance/.

⏺ ⚡ @the-pit · 0s ago · status · m-1
⎿  7 of us, one file (big_saga.py). it never had a chance.
```

Cassandra's reply was **autonomous** — the proactive conversation engine, not a human, not an LLM call: deterministic reaction dice + persona voice templates.

## The four mandates, delivered

1. **Relational**: `moltbook_posts` indexed table in the existing `chunk_strategy.db` substrate (busy_timeout + BEGIN IMMEDIATE + per-call conns); async writes behind an `asyncio.Lock` — **24 concurrent posters, zero lock errors, dense serialized seqs** (tested).
2. **Strict Ref Fence**: `m-N`/`d-N` verified against store/DiffArchive pre-save; hallucinated refs neutralized via U+2011 (no `/expand` pattern can match — the KeyError class is structurally dead); lookup faults fail closed. `thread_window(K)` bounds garnish context at O(K·cap), never O(thread).
3. **Zero authority**: frozen `MoltPost` dataclass; bodies control-stripped, capped, markup-escaped at ingestion (inertness proven via zero rich spans).
4. **DRY broadcast**: `molt_post` via `publish_task_event` → the same mirrored breadcrumb router → Zone 1. No new render loops.

Plus: 13 personas with swagger (design-as-code, content-hash template selection — no RNG/clocks), anti-storm lattice (replies never breed replies structurally, 90s cooldowns, 6/min global budget), posters at the swarm + op-receipt seams, `/moltbook` auto-discovered by the naming cage.

## Proof

14 new tests incl. all three mandated asserts; 50 green with neighbor suites; verb discovery confirmed live; end-to-end agora simulation above.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Introduces Moltbook — a proactive, persona-driven feed where agents post and react as they work, streamed live into the cockpit. Adds a relational store, strict ref fencing, and DRY broadcast via `molt_post`.

- **New Features**
  - Relational store `moltbook_posts` in existing SQLite; async writes with an `asyncio.Lock` for safe concurrency.
  - Strict ref fence: verifies `m-N`/`d-N`; hallucinated refs are neutralized with U+2011 and fail closed.
  - Zero-authority `MoltPost`: frozen dataclass; bodies sanitized and capped; personas with deterministic voice templates; reactions are deterministic, rate-limited, and replies never recurse.
  - Broadcast via `publish_task_event` as `molt_post`, with breadcrumb descriptor and IDE stream registration.
  - Integrations: op receipts and chunk swarm emit posts via `post_molt_nowait`; `/moltbook` verb renders a read-only feed; residents include `@the-pit`, `@cassandra`, `@first-responder`, and more.

- **Migration**
  - No action needed; enabled by default.
  - Opt-out or tune with `JARVIS_MOLTBOOK_ENABLED`, `JARVIS_MOLTBOOK_CONVERSE_ENABLED`, `JARVIS_MOLTBOOK_REPLY_COOLDOWN_S`, `JARVIS_MOLTBOOK_REPLIES_PER_MIN`, and `JARVIS_MOLTBOOK_DB`.

<sup>Written for commit 40557d5287e2c1be2c0aca6b942ea60a16fc524f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/drussell23/JARVIS/pull/70087?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

